### PR TITLE
Route Langfuse S3 endpoints through the scheme-aware helper

### DIFF
--- a/charts/curie/ci/worker-object-store-assertions.sh
+++ b/charts/curie/ci/worker-object-store-assertions.sh
@@ -104,20 +104,31 @@ def container_env(docs, kind, component, container_name, init=False):
     """Select by the component LABEL and the container NAME.
 
     `endswith("-worker")` also matches `<release>-curie-langfuse-worker`, which
-    renders earlier and legitimately has no object-store env -- so a suffix
-    match silently inspected Langfuse and reported the curie worker as
-    misconfigured while the chart was correct. The label is unambiguous, and the
-    container name keeps a sidecar rendered first from being inspected instead
-    of the application container.
+    renders earlier -- so a suffix match silently inspected Langfuse and reported
+    the curie worker as misconfigured while the chart was correct. The label is
+    unambiguous, and the container name keeps a sidecar rendered first from being
+    inspected instead of the application container.
+
+    The component label is read off the object, falling back to the pod template:
+    the Langfuse Deployments label only their pod template (they mirror the
+    compose stack's service shape), so reading object metadata alone matched no
+    Langfuse workload at all -- indistinguishable from a Langfuse workload that is
+    configured correctly. Object metadata still wins where the two differ, which is
+    how the SandboxTemplate (`agent-sandbox` on the object, `runner-sandbox` on the
+    pod) keeps being selected by the name its caller uses.
     """
 
     for d in docs:
         if d.get("kind") != kind:
             continue
-        if d["metadata"].get("labels", {}).get("app.kubernetes.io/component") != component:
-            continue
         pod_template = "template" if kind == "Deployment" else "podTemplate"
-        pod_spec = d["spec"][pod_template]["spec"]
+        pod = d["spec"][pod_template]
+        labelled = d["metadata"].get("labels", {}).get(
+            "app.kubernetes.io/component"
+        ) or pod.get("metadata", {}).get("labels", {}).get("app.kubernetes.io/component")
+        if labelled != component:
+            continue
+        pod_spec = pod["spec"]
         containers = pod_spec.get("initContainers" if init else "containers", [])
         matches = [c for c in containers if c.get("name") == container_name]
         assert len(matches) == 1, (
@@ -149,9 +160,18 @@ def assert_contract(docs, label, expected_endpoint):
     bundle_fetch = env_of(
         docs, "SandboxTemplate", "agent-sandbox", "bundle-fetch", init=True
     )
+    # Langfuse is a fourth and fifth reader of the same store, on both of its
+    # workloads. It is inspected here because it was NOT: its endpoints were built
+    # from a literal http:// while api/worker/sandbox used the chart's scheme-aware
+    # helper, so a BYO store on port 443 got https:// everywhere except Langfuse
+    # and trace ingestion died at the TLS handshake (#1500).
+    langfuse_web = env_of(docs, "Deployment", "langfuse-web", "langfuse-web")
+    langfuse_worker = env_of(docs, "Deployment", "langfuse-worker", "langfuse-worker")
     assert api is not None, "api Deployment not rendered"
     assert worker is not None, "worker Deployment not rendered"
     assert bundle_fetch is not None, "SandboxTemplate bundle-fetch not rendered"
+    assert langfuse_web is not None, "langfuse-web Deployment not rendered"
+    assert langfuse_worker is not None, "langfuse-worker Deployment not rendered"
 
     failures = []
 
@@ -248,14 +268,22 @@ def assert_contract(docs, label, expected_endpoint):
                     f"      {source} = {value_source(env[api_key])}"
                 )
 
-    for source, env, key in (
+    # The full value, not merely the scheme: a scheme-only check would still pass
+    # the day one of these is pointed at a different-but-same-scheme host, which is
+    # the same agreement bug the rest of this file exists to catch.
+    endpoint_sites = (
         ("api", api, "S3_ENDPOINT_URL"),
         ("worker", worker, "S3_ENDPOINT_URL"),
         ("bundle fetch", bundle_fetch, "S3_ENDPOINT"),
-    ):
+        ("langfuse-web", langfuse_web, "LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT"),
+        ("langfuse-web", langfuse_web, "LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT"),
+        ("langfuse-worker", langfuse_worker, "LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT"),
+        ("langfuse-worker", langfuse_worker, "LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT"),
+    )
+    for source, env, key in endpoint_sites:
         if env.get(key, {}).get("value") != expected_endpoint:
             failures.append(
-                f"{label} {source} endpoint must be {expected_endpoint}, got {env.get(key)}"
+                f"{label} {source} {key} must be {expected_endpoint}, got {env.get(key)}"
             )
 
     # The compose default must never be what a Kubernetes pod receives.
@@ -290,15 +318,19 @@ def assert_contract(docs, label, expected_endpoint):
     print(f"ok: {label}: api and worker agree on {', '.join(sorted(keys))}")
     for k in sorted(keys):
         print(f"      {k:18} = {shown(api[k])}")
-    print(f"ok: {label}: all S3 endpoints are {expected_endpoint}")
+    print(f"ok: {label}: all {len(endpoint_sites)} S3 endpoints are {expected_endpoint}")
+    for source, _env, key in endpoint_sites:
+        print(f"      {source:15} {key}")
     print(f"ok: {label}: S3_SECRET_KEY is a ref -> {ref['name']}/{ref['key']}")
 
 
-def expect_failure(docs, messages):
+def expect_failure(
+    docs, messages, label="default probe", expected_endpoint="http://curie-rustfs:9000"
+):
     captured = io.StringIO()
     try:
         with redirect_stdout(captured):
-            assert_contract(docs, "default probe", "http://curie-rustfs:9000")
+            assert_contract(docs, label, expected_endpoint)
     except SystemExit as error:
         assert error.code == 1
     else:
@@ -372,5 +404,30 @@ expect_failure(
     ("worker is missing S3_ACCESS_KEY",),
 )
 
-assert_contract(render(EXTERNAL_VALUES), "external", "https://s3.example.com:443")
+external_docs = render(EXTERNAL_VALUES)
+assert_contract(external_docs, "external", "https://s3.example.com:443")
+
+# Rebuilding either Langfuse endpoint from a literal http:// is exactly the
+# regression this gate exists for, and it is invisible on the in-cluster default
+# (which is http:// anyway), so the probe runs against the external render. Both
+# workloads are probed: a probe on langfuse-web alone would stay green while
+# langfuse-worker regressed.
+for component in ("langfuse-web", "langfuse-worker"):
+    for key in ("LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT", "LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT"):
+        hardcoded_scheme = copy.deepcopy(external_docs)
+        langfuse_env = container_env(hardcoded_scheme, "Deployment", component, component)
+        assert langfuse_env is not None, f"{component} Deployment was not rendered"
+        endpoint = next(entry for entry in langfuse_env if entry.get("name") == key)
+        endpoint["value"] = "http://s3.example.com:443"
+        expect_failure(
+            hardcoded_scheme,
+            (f"external probe {component} {key} must be https://s3.example.com:443",),
+            label="external probe",
+            expected_endpoint="https://s3.example.com:443",
+        )
+
+print(
+    "ok: a literal http:// on either Langfuse endpoint, on either Langfuse "
+    "workload, fails the external-store contract"
+)
 PY

--- a/charts/curie/templates/_helpers.tpl
+++ b/charts/curie/templates/_helpers.tpl
@@ -634,8 +634,13 @@ livenessProbe:
     secretKeyRef:
       name: {{ .Values.rustfs.existingSecret | default (include "curie.secretName" .) }}
       key: rustfsSecretKey
+{{- /* Both endpoints go through curie.rustfs.endpoint, never a literal
+       scheme. They were hardcoded http:// while api/worker/sandbox used the
+       helper, so a BYO store on rustfs.port 443 got https:// everywhere except
+       Langfuse, and trace ingestion died at the TLS handshake -- with the rest
+       of the release healthy, which is why nothing pointed at the cause. */}}
 - name: LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT
-  value: http://{{ include "curie.rustfs.host" . }}:{{ .Values.rustfs.port }}
+  value: {{ include "curie.rustfs.endpoint" . }}
 - name: LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE
   value: "true"
 - name: LANGFUSE_S3_EVENT_UPLOAD_PREFIX
@@ -652,7 +657,7 @@ livenessProbe:
       name: {{ .Values.rustfs.existingSecret | default (include "curie.secretName" .) }}
       key: rustfsSecretKey
 - name: LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT
-  value: http://{{ include "curie.rustfs.host" . }}:{{ .Values.rustfs.port }}
+  value: {{ include "curie.rustfs.endpoint" . }}
 - name: LANGFUSE_S3_MEDIA_UPLOAD_FORCE_PATH_STYLE
   value: "true"
 - name: LANGFUSE_S3_MEDIA_UPLOAD_PREFIX

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -456,7 +456,8 @@ rustfs:
   deploy: true
   image: rustfs/rustfs:1.0.0-beta.12
   awsCliImage: amazon/aws-cli:2.32.6
-  # For the API, worker, and sandbox bundle fetch endpoints, an external RustFS on port 443 uses HTTPS. All other configurations use HTTP.
+  # Applies to every object-store endpoint the chart renders (API, worker, sandbox bundle fetch,
+  # and Langfuse's event/media upload endpoints): an external RustFS on port 443 uses HTTPS. All other configurations use HTTP.
   host: ""
   port: 9000
   # Signing region for sandbox bundle fetches. Keep it aligned with the regional S3 endpoint.


### PR DESCRIPTION
Closes #1500

## What broke

`curie.langfuse.env` built both Langfuse S3 endpoints from a literal `http://` while the API, worker, and sandbox bundle-fetch used `curie.rustfs.endpoint`. On the documented BYO shape (`rustfs.deploy=false`, `rustfs.host=s3.example.com`, `rustfs.port=443`) three sites rendered `https://` and the four Langfuse ones rendered `http://`, so every Langfuse upload died at the TLS handshake. Langfuse v3 writes each raw event to S3 before queueing a reference and the OTel collector exports to Langfuse, so trace ingestion stopped — loud in the pod logs, invisible in the product, while bundle fetch kept working.

It is the same store, not a separate one: that helper already reads `rustfs.bucket`, `rustfs.auth.accessKey`, `rustfs.existingSecret`, and `rustfs.port`. `curie.rustfs.endpoint` is `scheme://host:port` over the same host helper and the same port, so the substitution is scheme-only.

## Why the gate passed over it

`assert_contract` opened only the `-api` and `-worker` Deployments plus the one `bundle-fetch` init container, then printed `ok: external: all S3 endpoints are https://s3.example.com:443` over four `http://` values in the same rendered document — an ok line that overstated its own coverage.

It now checks all seven sites against the **full** expected endpoint (not just the scheme, which would still pass a different-but-same-scheme host), on both the default and external renders, and prints the count and the sites it actually checked. Four probes rebuild each Langfuse endpoint on each Langfuse workload from a literal `http://` against the external render and require the contract to go red; probing one workload would stay green while the other regressed.

Selecting the Langfuse workloads needed the component label to fall back to the pod template, the only place those Deployments carry it. Object metadata still wins where both exist, so the SandboxTemplate (`agent-sandbox` on the object, `runner-sandbox` on the pod) resolves exactly as before; no two workloads share an effective component.

## Acceptance criteria

**AC1 — all seven use the same scheme, proven by a render assertion.** The issue's own repro now yields the inverse of its report:

```
$ helm template curie charts/curie --namespace dev \
    --set rustfs.deploy=false --set rustfs.host=s3.example.com --set rustfs.port=443 --output-dir <scratch>
$ grep -rho "https\?://s3.example.com:443" <scratch>/curie/templates | sort | uniq -c
      7 https://s3.example.com:443
```

The gate states its own coverage:

```
ok: external: all 7 S3 endpoints are https://s3.example.com:443
      api             S3_ENDPOINT_URL
      worker          S3_ENDPOINT_URL
      bundle fetch    S3_ENDPOINT
      langfuse-web    LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT
      langfuse-web    LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT
      langfuse-worker LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT
      langfuse-worker LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT
```

**AC2 — reverting the helper makes the assertion exit 1.** Executed, not reasoned about: reverting both sites to the literal form gives `REVERTED_EXIT=1` with

```
FAIL: external: api/worker object-store configuration diverges
  - external langfuse-web    LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT must be https://s3.example.com:443, got http://s3.example.com:443
  - external langfuse-web    LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT must be https://s3.example.com:443, got http://s3.example.com:443
  - external langfuse-worker LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT must be https://s3.example.com:443, got http://s3.example.com:443
  - external langfuse-worker LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT must be https://s3.example.com:443, got http://s3.example.com:443
```

Restoring gives exit 0.

**AC3 — the in-cluster default render is unchanged.** `security.allowDevDefaults=true` makes the managed secrets deterministic, so this is byte-exact rather than eyeballed past credential noise:

```
sha base (origin/main) = 616edc1a2d1e8170bacbe22693da75c8e5feda36810a256f6146221391809f4c
sha fixed              = 616edc1a2d1e8170bacbe22693da75c8e5feda36810a256f6146221391809f4c
```

Negative control: the same base-vs-fixed comparison on the **external** shape differs on exactly 8 lines — the four `http://` → `https://` pairs and nothing else.

## Validation

- `worker-object-store-assertions.sh` green; the other 24 `charts/curie/ci/*.sh` gates green.
- `helm lint charts/curie`: 0 failed.
- `cargo test --test chart_check`: 7 passed (the 1:1 CI-directory mapping holds — no new script was added).
- Selector-broadening safety proven by enumeration: no two workloads of the same kind share an effective component label.

## Scope

`values.yaml:459` is included because this change falsifies it — it enumerated the three old consumers. The hunk is comment-only; the byte-identical default render above is the proof no value moved. `compose.dev.yaml` legitimately stays on plaintext `http://rustfs:9000` (in-cluster, no external-store shape) and is untouched.

The scope reviewer flagged five P2 items — three why-comments, the `{key}` added to the failure message, and the enumerated success listing. Kept deliberately: every existing check in that script carries a why-comment naming the real failure it caught, and with seven sites the old wording produced two identical failure lines per Langfuse workload. None affect rendered output.

## Review

Cross-engine adversarial review via agent-router (Codex, gpt-5.6-sol) — code, scope, and spec-vs-impl passes, all exit 0. Spec-vs-impl judged AC1/AC2/AC3 all MET.