### PR TITLE
Give a delivery one deadline and one renewable fenced owner

### DIFF
--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -352,6 +352,71 @@ worker claims runner containers on the same Docker daemon exactly as the
 compose-managed one would. For an offline round-trip, add `CURIE_FAKE_MODEL=1`
 to the env above and drop the credential.
 
+## Delivery ownership: one deadline, one fenced owner (ADR-0131)
+
+Owning a PEL row is necessary but not sufficient to execute or settle a
+delivery. Every `(stream, group, entry_id)` also carries an absolute Valkey-time
+deadline (created once, never restarted by a retry or a reclaim) and a short
+renewable lease holding an opaque owner token and a monotonically increasing
+fencing generation (`delivery_lease.py`, driven by the shared lifecycle in
+`stream_consumer.py` so the runs and eval lanes share one implementation). A
+heartbeat renews it; a renewal that Valkey cannot confirm fails **closed** —
+the owner is lease-lost, its runner is interrupted through the bounded control
+path, and it may no longer settle anything.
+
+### Capability audit: every owner verb and the fence that gates it
+
+One row per verb a delivery owner can perform that produces a durable or
+user-visible effect.
+
+| Verb | Where | What fences it |
+|---|---|---|
+| Execute or retry a turn | `kernel.py` (the attempt loop; `start_turn` / `steer`) | The lease is checked before every attempt, and attempts consume the one overall deadline. A loss mid-turn fires the base's lease-lost handler, which interrupts the live turn. |
+| Re-execute a *reclaimed* delivery | `kernel.py` reclaim preflight (generation > 1) | A side-effect marker forbids replay and escalates; a runner still reporting an active turn is interrupted and waited out; an unreadable runner fails closed. |
+| ACK (runs lane) | `consumer.py`, immediately before `XACK` | `lease.raise_if_lost()`. A refusal leaves the entry pending for the current owner. |
+| ACK (eval lane) | `eval/stream.py`, immediately before `XACK` | The same pre-ACK `raise_if_lost()`. |
+| ACK **via dead-letter**, handler path | `stream_consumer.py` `_dead_letter` → `_dead_letter_refusal` | Dead-letter is a terminal settlement (it ACKs, then deletes the lease and delivery state). A handler holds a registered lease, so the question is whether that lease is still ours. |
+| ACK **via dead-letter**, over-cap scan | `stream_consumer.py` `_dead_letter_over_cap` | A live-lease check runs *before* cap evaluation, so a healthy long turn cannot be dead-lettered, and `_dead_letter_refusal` re-reads the lease before writing. Both fail closed on an unreadable answer. |
+| Write the done marker + the completion-outbox record | `markers.py` `settle_fenced`, whose only caller is `kernel.py` `_complete` — the only `mark_done` call site | One Lua script verifies the lease token and the fencing generation and then performs the terminal write. A loser writes nothing and returns `None`. |
+| Emit the terminal reply (`turn.completed`) | `kernel.py` `_complete` → `_deliver_completion` | Only reachable past `settle_fenced`; the fenced-out owner returns having emitted nothing. |
+| Clear an outbox record | `markers.py` `clear_completion`, via `_deliver_completion` | The same fence, plus the record-generation compare-and-check, so a stale pass cannot delete a fresh record. |
+| Publish an eval report | `eval/stream.py` `_report` → `POST /evals/report` | The lease is resolved from the entry's stream id (never from a field that is `None` on the failure paths) and checked immediately before the send. A fenced lane whose lease cannot be resolved refuses to publish. |
+
+Stated plainly, as ADR-0131 requires: **a fenced-out owner is refused ACK,
+dead-letter, outbox clearing, and terminal emit** — and is refused starting a
+new attempt.
+
+Two verbs are **deliberately not lease-fenced**, and neither is an oversight:
+
+- **The side-effect marker** (`markers.mark_side_effect`, written from
+  `kernel.py` the instant a `side_effect_flag` is seen). A side effect that
+  happened must be recorded even by an owner that has since lost its fence. The
+  marker is itself a hard no-replay fence, and it is what stops the
+  *replacement* from re-running a non-idempotent action; fencing the write would
+  let a lost lease erase the evidence. This is the one place where fail-closed
+  means "write anyway".
+- **The completion-outbox sweeper** (`kernel.py` `sweep_pending_completions`).
+  The sweeper is not an owner: it drains records for entries that may already be
+  acked off the group, where no lease exists or ever will. Its guard is the
+  record's done flag plus the compare-and-checked `clear_completion`, not a
+  lease. Do not "complete the fence" by adding one here.
+
+### Adapter idempotency: which channel may claim one terminal effect
+
+Terminal transport is at-least-once; the completion outbox retries by stable
+`event_id`. Exactly-once therefore means **one user-visible terminal effect for
+that identifier, never one network send** — ADR-0131 states exactly-once network
+delivery is impossible, and nothing below claims it. An adapter may claim the
+property only when its receiving boundary applies `event_id` idempotently or the
+adapter mutates one stable target.
+
+| Adapter / path | Receiving boundary | Idempotent apply? | Claim |
+|---|---|---|---|
+| `SlackReplyAdapter` (`slack_sink.py`) | One Slack message: `chat.update` on the placeholder's stable `(channel, ts)`. `turn.completed` has no Slack expression and sends nothing, so an outbox retry is a no-op on this channel. | Yes — by **stable target**, not by `event_id`; Slack exposes no idempotency key. | One user-visible terminal effect per `event_id`. |
+| `SlackReplyAdapter`, placeholder-less turn (`reply_ref is None`, the ADR-0079 triggered turn) | `chat.postMessage` — a **create**, not a mutation, until the minted ts is adopted as the turn's ref. | No. | Explicitly at-least-once for that first post; the edits that follow it are covered by the row above. |
+| `HttpReplyAdapter` (`reply_sink.py`) | Whatever the binding's operator-controlled endpoint does with one POST. `turn.completed` carries `event_id` in the body, so the key is on the wire, but this repo cannot verify what the receiver does with it. | Unknown — receiver-owned, unverifiable from here. | **Explicitly at-least-once.** May not advertise exactly-once terminal effect. |
+| Eval report (`eval/stream.py` `_report` → `POST /evals/report`) | The platform API's report endpoint. `EvalReport` carries `repo_full_name`, `sha`, and counts — no idempotency key. | No. | **Explicitly at-least-once.** The pre-send lease check closes most of the window, not the send-then-lose-the-ack window; closing it needs eval-report idempotency at the platform API (follow-up F2). |
+
 ## The sandbox substrate (`curie_worker.sandbox`)
 
 The lifecycle seam between the worker kernel and kubernetes-sigs/agent-sandbox

--- a/apps/worker/src/curie_worker/config.py
+++ b/apps/worker/src/curie_worker/config.py
@@ -337,16 +337,19 @@ class WorkerConfig(BaseSettings):
     # its first reclaim, and values below 3 undermine ADR-0013 crash recovery
     # (which relies on a reclaim actually retrying the entry).
     #
-    # Leave headroom above what a HEALTHY turn can legitimately burn. A single
-    # delivery may span up to ``max_attempts * runner_total_timeout_s`` (~1800s
-    # at defaults, see the retry knobs below), which exceeds
-    # ``reclaim_min_idle_ms`` (900s), so another replica can reclaim a turn that
-    # is still working and bump its delivery count. A healthy long turn can
-    # therefore accrue roughly
-    # ``(max_attempts * runner_total_timeout_s) / reclaim_min_idle_ms`` (~2 at
-    # defaults) deliveries on its own. ``max_delivery`` must stay comfortably
-    # above that: at the ``ge=2`` floor a slow but healthy turn could be
-    # dead-lettered while it is still making progress.
+    # A healthy long turn now accrues NO self-inflicted deliveries (ADR-0131).
+    # The delivery lease's heartbeat resets same-owner PEL idle with
+    # ``XCLAIM ... JUSTID``, which does not increment the delivery counter, and
+    # reclaim consults the lease's liveness before dispatching or dead-lettering
+    # a claim. This is a change from the pre-lease world: a single delivery
+    # could span up to ``max_attempts * runner_total_timeout_s`` (~1800s at
+    # defaults), which exceeded ``reclaim_min_idle_ms`` (900s), so another
+    # replica could reclaim a turn that was still working and bump its delivery
+    # count -- roughly 2 self-inflicted deliveries at defaults. That headroom no
+    # longer needs to exist; do not read the lease's arrival as license to lower
+    # ``max_delivery`` on the strength of it. The cap and its ``ge=2`` floor
+    # DO NOT CHANGE -- ADR-0039 stands, and weakening the cap is the #505 total
+    # stall regression, not a simplification.
     max_delivery: int = Field(default=5, ge=2, validation_alias="CURIE_MAX_DELIVERY")
     # Empty means "derive ``<stream>:dead``" at the use site; a static Field
     # default cannot reference ``self.stream``. An explicit override equal to
@@ -415,6 +418,91 @@ class WorkerConfig(BaseSettings):
             )
         return self
 
+    @model_validator(mode="after")
+    def _lease_spans_three_heartbeats(self) -> WorkerConfig:
+        """Fail at construction if the lease cannot survive two lost heartbeats.
+
+        ADR-0131: "the lease spans at least three heartbeat periods". With a
+        Valkey blip or a slow renewal, one missed heartbeat is routine; the
+        floor of three periods means two consecutive misses still leave a
+        healthy owner's lease live. A tighter ratio would drop a healthy long
+        turn on a single transient hiccup -- the exact flakiness the lease
+        exists to avoid, not introduce.
+        """
+        if self.delivery_lease_ttl_s < 3 * self.delivery_lease_heartbeat_s:
+            raise ValueError(
+                "CURIE_DELIVERY_LEASE_TTL_S "
+                f"({self.delivery_lease_ttl_s!r}) must be at least 3x "
+                "CURIE_DELIVERY_LEASE_HEARTBEAT_S "
+                f"({self.delivery_lease_heartbeat_s!r}): a shorter span drops a "
+                "healthy owner's lease on a single missed heartbeat"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _reclaim_scan_shorter_than_lease(self) -> WorkerConfig:
+        """Fail at construction if the reclaim scan is not faster than the lease.
+
+        ADR-0131: "the reclaim interval is shorter than the lease". A scan
+        cadence at or above the lease TTL leaves an expired lease unrecovered
+        for a whole extra scan pass -- directly widening the stranded-delivery
+        recovery window the lease exists to bound.
+        """
+        if self.reclaim_interval_s >= self.delivery_lease_ttl_s:
+            raise ValueError(
+                "CURIE_RECLAIM_INTERVAL_S "
+                f"({self.reclaim_interval_s!r}) must be strictly shorter than "
+                f"CURIE_DELIVERY_LEASE_TTL_S ({self.delivery_lease_ttl_s!r}): "
+                "a scan slower than the lease leaves an expired lease "
+                "unrecovered for a whole extra scan"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _termination_grace_covers_the_budget(self) -> WorkerConfig:
+        """Fail at construction if platform grace cannot cover budget + reserve.
+
+        ADR-0131: "platform termination grace is at least the execution budget
+        plus shutdown reserve." Below it, a worker draining a maximum-budget
+        turn is SIGKILLed at the exact moment it would settle -- the turn's
+        terminal effect is lost and the entry is left pending. ``None`` means
+        no platform grace was declared (compose, tests) and skips this check
+        entirely rather than guessing a value to compare against.
+        """
+        if self.termination_grace_period_s is None:
+            return self
+        required = self.delivery_budget_s + self.delivery_shutdown_reserve_s
+        if self.termination_grace_period_s < required:
+            raise ValueError(
+                "CURIE_TERMINATION_GRACE_PERIOD_S "
+                f"({self.termination_grace_period_s!r}) must be at least "
+                "CURIE_DELIVERY_BUDGET_S + CURIE_DELIVERY_SHUTDOWN_RESERVE_S "
+                f"({self.delivery_budget_s!r} + "
+                f"{self.delivery_shutdown_reserve_s!r} = {required!r}): a "
+                "shorter grace SIGKILLs a draining worker before it can settle "
+                "a maximum-budget turn"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _runner_request_fits_the_budget(self) -> WorkerConfig:
+        """Fail at construction if the per-request ceiling exceeds the budget.
+
+        ``runner_total_timeout_s`` is now a per-request ceiling INSIDE the
+        overall delivery budget, not an independent clock. A ceiling above the
+        budget is always dead configuration -- the budget expires first on
+        every request -- and reads as if it granted more time than it does.
+        """
+        if self.runner_total_timeout_s > self.delivery_budget_s:
+            raise ValueError(
+                "CURIE_RUNNER_TOTAL_TIMEOUT_S "
+                f"({self.runner_total_timeout_s!r}) must not exceed "
+                f"CURIE_DELIVERY_BUDGET_S ({self.delivery_budget_s!r}): a "
+                "per-request ceiling above the overall budget is dead "
+                "configuration, since the budget always expires first"
+            )
+        return self
+
     # Read loop
     read_count: int = 16
     read_block_ms: int = 5000
@@ -459,20 +547,33 @@ class WorkerConfig(BaseSettings):
     # Crash recovery: reclaim stream entries pending longer than this, and run
     # the orphan-claim reaper, on this cadence.
     #
-    # This window does NOT cover the longest legitimate in-flight time. One
-    # delivery is not one runner call: the kernel may retry a flag-clean failure
-    # up to max_attempts (3) times WITHIN a single delivery, each bounded by
-    # runner_total_timeout_s (600s), so a healthy delivery can legitimately span
-    # up to ~max_attempts * runner_total_timeout_s = ~1800s -- twice this 900s
-    # idle threshold. A long healthy turn can therefore be reclaimed by another
-    # replica and accrue delivery count (see max_delivery's headroom note above).
-    # The consumer skips its OWN in-flight entry ids, so this only bites across
-    # replicas; that cross-replica dup-dispatch is pre-existing and tracked
-    # separately. Raising this threshold past
-    # max_attempts * runner_total_timeout_s would close it at the cost of slower
-    # crash recovery.
+    # This window is now a COMPATIBILITY BACKSTOP behind the delivery lease
+    # (ADR-0131), not the primary guard. Before the lease, this was the only
+    # signal available: one delivery is not one runner call -- the kernel may
+    # retry a flag-clean failure up to max_attempts (3) times WITHIN a single
+    # delivery, each bounded by runner_total_timeout_s (600s), so a healthy
+    # delivery could legitimately span up to ~max_attempts *
+    # runner_total_timeout_s = ~1800s, twice this 900s idle threshold -- and a
+    # long healthy turn could therefore be reclaimed by another replica and
+    # accrue delivery count. That cross-replica dup-dispatch is the defect this
+    # ticket fixes: the lease is checked for liveness before any reclaim path
+    # dispatches or dead-letters, so a live-leased entry is skipped regardless
+    # of this idle window. This value stays unchanged at 900000 as the backstop
+    # for the case a lease itself is somehow absent or already expired (e.g. a
+    # crashed owner past its lease TTL, where this threshold provides an
+    # independent, coarser second opinion). Raising it past
+    # max_attempts * runner_total_timeout_s would close the pre-lease gap
+    # entirely, but is not needed now that the lease is the primary guard, and
+    # would slow crash recovery for entries the lease mechanism cannot cover.
     reclaim_min_idle_ms: int = 900000
-    reclaim_interval_s: float = 30.0
+    # Unchanged at 30.0; now bound by ``_reclaim_scan_shorter_than_lease``,
+    # which enforces the ADR's actual requirement (scan strictly shorter than
+    # the lease TTL) rather than a specific number. See the delivery-lease
+    # block above for why 30.0 (not the ADR's stated initial 10.0) is kept: it
+    # is the whole maintenance-tick cadence, not a dedicated lease-scan loop.
+    reclaim_interval_s: float = Field(
+        default=30.0, gt=0, validation_alias="CURIE_RECLAIM_INTERVAL_S"
+    )
     # Prompt reclaim for a consumer that has stopped interacting with the
     # group (#1532). Entry idle is the wrong signal: a live replica's
     # in-flight turn is pending for the whole runner timeout, so a short
@@ -484,6 +585,41 @@ class WorkerConfig(BaseSettings):
 
     # Slack placeholder edits are throttled to avoid rate limits while streaming.
     slack_edit_min_interval_s: float = 0.7
+
+    # Delivery budget and ownership lease (ADR-0131, #1971).
+    #
+    # One deadline and one renewable fenced owner per ``(stream, group,
+    # entry_id)``. ``delivery_budget_s`` is the OVERALL wall-clock deadline for
+    # the whole delivery -- claim, every runner request, every retry backoff,
+    # reclaim, and terminal cleanup -- not just one runner call.
+    # ``runner_total_timeout_s`` (above) is now a per-request ceiling INSIDE
+    # this budget, not an independent clock: a stalled request is cut short by
+    # whichever of the two is smaller, but the budget is what actually bounds
+    # the delivery. The lease is the renewable proof of ownership that makes a
+    # healthy long turn un-reclaimable and a dead owner's turn recoverable
+    # after a bounded expiry, replacing the old dead pair of a flat HTTP
+    # timeout and a 900s idle-based steal window.
+    delivery_budget_s: float = Field(
+        default=600.0, ge=60.0, le=1800.0, validation_alias="CURIE_DELIVERY_BUDGET_S"
+    )
+    delivery_lease_ttl_s: float = Field(
+        default=45.0, gt=0, validation_alias="CURIE_DELIVERY_LEASE_TTL_S"
+    )
+    delivery_lease_heartbeat_s: float = Field(
+        default=10.0, gt=0, validation_alias="CURIE_DELIVERY_LEASE_HEARTBEAT_S"
+    )
+    delivery_shutdown_reserve_s: float = Field(
+        default=60.0, ge=0, validation_alias="CURIE_DELIVERY_SHUTDOWN_RESERVE_S"
+    )
+    # The platform's voluntary termination grace, injected by the chart from
+    # the SAME value it renders onto the Pod's ``terminationGracePeriodSeconds``
+    # so the app's validator and the platform can never drift apart. ``None``
+    # means "no platform grace declared" (compose, tests, a bare
+    # ``WorkerConfig()`` in a unit test) and SKIPS the grace validator below
+    # rather than guessing a value for an environment that has none.
+    termination_grace_period_s: float | None = Field(
+        default=None, validation_alias="CURIE_TERMINATION_GRACE_PERIOD_S"
+    )
 
     # Runner HTTP timeouts
     runner_connect_timeout_s: float = 10.0
@@ -791,6 +927,28 @@ class WorkerConfig(BaseSettings):
 
     def side_effect_key(self, event_id: str) -> str:
         return f"{self.key_prefix}:sidefx:{event_id}"
+
+    def delivery_lease_key(self, stream: str, group: str, entry_id: str) -> str:
+        """The lease STRING key: the opaque owner token, TTL'd at
+        ``delivery_lease_ttl_s``. Keyed by the delivery triple
+        ``(stream, group, entry_id)``, NOT the event id -- the same event id
+        can legitimately be redelivered under a new entry id after a
+        dead-letter, and keying by event id would fence the wrong thing. Absent
+        means no live owner; expiry IS how ownership becomes transferable.
+        """
+        return f"{self.key_prefix}:lease:{stream}:{group}:{entry_id}"
+
+    def delivery_state_key(self, stream: str, group: str, entry_id: str) -> str:
+        """The delivery state HASH key: ``deadline_ms`` (absolute, Valkey server
+        time, create-if-absent) and ``gen`` (the fencing generation,
+        HINCRBY'd on each acquisition). Retained for ``idempotency_ttl_s``
+        (86400s) -- deliberately longer than the lease so the generation
+        survives lease expiry and a fresh acquisition's deadline is never
+        re-minted from an entry that merely lost its short-lived lease.
+        Explicitly deleted on terminal ACK and dead-letter settlement; the TTL
+        is only the backstop for a crash between the two.
+        """
+        return f"{self.key_prefix}:delivery:{stream}:{group}:{entry_id}"
 
     def completion_key(self, event_id: str) -> str:
         # The durable outbox record for this event's ``turn.completed``. NO TTL:

--- a/apps/worker/src/curie_worker/consumer.py
+++ b/apps/worker/src/curie_worker/consumer.py
@@ -53,7 +53,8 @@ from opentelemetry.trace import SpanKind, StatusCode
 from redis.asyncio import Redis
 
 from .config import WorkerConfig
-from .kernel import Kernel
+from .delivery_lease import DeliveryLeaseStore, LeaseLostError
+from .kernel import Kernel, _thread_key_for
 from .stream_consumer import DeliverySpec, ReadLoopSpec, StreamConsumer
 
 logger = logging.getLogger(__name__)
@@ -117,8 +118,17 @@ class Consumer(StreamConsumer):
         kernel: Kernel,
         config: WorkerConfig,
         max_concurrency: int = 16,
+        leases: DeliveryLeaseStore | None = None,
     ) -> None:
-        super().__init__(redis)
+        # The delivery-ownership fence (ADR-0131) lives entirely in the shared
+        # base: acquisition, the background heartbeat, release, and the reclaim
+        # liveness guards. This lane supplies only the store and the lane-specific
+        # way to stop a runner when the fence moves, so runs and evals share one
+        # implementation by construction. ``leases=None`` keeps every pre-ADR-0131
+        # construction (and the tests that use it) behaving exactly as before.
+        super().__init__(
+            redis, leases=leases, on_lease_lost=self._interrupt_on_lease_lost
+        )
         # The base class narrows self._redis to the StreamBroker port (stream
         # verbs only, by design -- a second broker implementation need not
         # support anything else). The thread-reset drain (#713) needs a plain
@@ -251,92 +261,148 @@ class Consumer(StreamConsumer):
                     span.add_event("trace.context.malformed", {"outcome": "failure"})
                 elif TRACEPARENT_STREAM_FIELD not in fields:
                     span.add_event("trace.context.missing", {"outcome": "success"})
-                try:
-                    qevent = from_stream_fields(fields)
-                except Exception as exc:
-                    if hasattr(span, "set_status"):
-                        span.set_status(StatusCode.ERROR)
-                    span.add_event(
-                        "queue.message.unparseable",
-                        {"outcome": "failure", "error.class": type(exc).__name__},
-                    )
-                    record_metric(
-                        "curie.queue.process",
-                        attributes={**metric_attributes, "outcome": "failure"},
-                    )
-                    logger.exception("unparseable stream entry %s; dead-lettering", entry_id)
-                    await self._dead_letter(
-                        entry_id,
-                        fields,
-                        reason="unparseable",
-                        delivery_count=await self._pending_delivery_count(entry_id),
-                    )
-                    return
 
-                age = self._message_age_seconds(qevent.received_at)
-                for name in (
-                    "curie.queue.wait.duration",
-                    "curie.queue.message.age",
-                ):
+                # ADR-0131: hold delivery AUTHORITY for the whole body. Owning
+                # the PEL row is necessary but not sufficient -- a peer replica
+                # that took the row (a reclaim, an XAUTOCLAIM) is refused here
+                # rather than allowed to run the same turn a second time. The
+                # lifecycle (acquire, background heartbeat, release) lives in the
+                # shared base so this lane and the eval lane cannot diverge.
+                async with self._delivery_lease(entry_id, fields) as lease:
+                    if lease is None:
+                        # Another owner holds it. Return WITHOUT acking: the
+                        # entry stays pending for whoever legitimately owns it.
+                        # A refusal is a normal early return, never an exception
+                        # -- an exception here would be caught by ``_consume``'s
+                        # isolation guard and logged as a failure, which is a
+                        # stack trace per entry for the routine case of losing a
+                        # race.
+                        return
+                    try:
+                        qevent = from_stream_fields(fields)
+                    except Exception as exc:
+                        if hasattr(span, "set_status"):
+                            span.set_status(StatusCode.ERROR)
+                        span.add_event(
+                            "queue.message.unparseable",
+                            {"outcome": "failure", "error.class": type(exc).__name__},
+                        )
+                        record_metric(
+                            "curie.queue.process",
+                            attributes={**metric_attributes, "outcome": "failure"},
+                        )
+                        logger.exception("unparseable stream entry %s; dead-lettering", entry_id)
+                        await self._dead_letter(
+                            entry_id,
+                            fields,
+                            reason="unparseable",
+                            delivery_count=await self._pending_delivery_count(entry_id),
+                        )
+                        return
+
+                    age = self._message_age_seconds(qevent.received_at)
+                    for name in (
+                        "curie.queue.wait.duration",
+                        "curie.queue.message.age",
+                    ):
+                        record_metric(
+                            name,
+                            age,
+                            attributes={**metric_attributes, "outcome": "success"},
+                        )
                     record_metric(
-                        name,
-                        age,
-                        attributes={**metric_attributes, "outcome": "success"},
+                        "curie.turn.accepted",
+                        attributes={
+                            "service.name": "curie-worker",
+                            "source": "worker",
+                            "outcome": "accepted",
+                        },
                     )
-                record_metric(
-                    "curie.turn.accepted",
-                    attributes={
-                        "service.name": "curie-worker",
-                        "source": "worker",
-                        "outcome": "accepted",
-                    },
-                )
-                # Eval (and operator reset-thread) SADDs onto THREAD_RESET_SET
-                # when a sandbox should be released. Drain those before this
-                # turn claims so a following eval case or cluster message does
-                # not wait for the maintenance tick with quota already full.
-                # A failed drain must not fail the turn; the next handle or
-                # maintenance tick retries the remaining requests (#1534).
-                try:
-                    if await self._valkey.scard(THREAD_RESET_SET):
-                        await self._drain_thread_reset_requests()
-                except Exception:
-                    logger.exception(
-                        "thread-reset drain before turn %s failed; continuing",
-                        entry_id,
-                    )
-                try:
-                    await self._kernel.process_event(qevent)
-                except Exception as exc:
-                    # Leave the entry pending: XAUTOCLAIM will reclaim and retry.
-                    if hasattr(span, "set_status"):
-                        span.set_status(StatusCode.ERROR)
-                    span.add_event(
-                        "queue.processing.failed",
-                        {"outcome": "failure", "error.class": type(exc).__name__},
-                    )
+                    # Eval (and operator reset-thread) SADDs onto THREAD_RESET_SET
+                    # when a sandbox should be released. Drain those before this
+                    # turn claims so a following eval case or cluster message does
+                    # not wait for the maintenance tick with quota already full.
+                    # A failed drain must not fail the turn; the next handle or
+                    # maintenance tick retries the remaining requests (#1534).
+                    try:
+                        if await self._valkey.scard(THREAD_RESET_SET):
+                            await self._drain_thread_reset_requests()
+                    except Exception:
+                        logger.exception(
+                            "thread-reset drain before turn %s failed; continuing",
+                            entry_id,
+                        )
+                    try:
+                        if self._leases is None:
+                            # No fence configured: call the kernel EXACTLY as it
+                            # was called before ADR-0131. The base yields a
+                            # permissive sentinel so this handler body stays
+                            # uniform, but forwarding that sentinel would claim
+                            # an authority nobody holds -- and ``process_event``
+                            # keeps its lease optional for precisely this caller.
+                            await self._kernel.process_event(qevent)
+                        else:
+                            await self._kernel.process_event(qevent, lease=lease)
+                    except Exception as exc:
+                        # Leave the entry pending: XAUTOCLAIM will reclaim and retry.
+                        if hasattr(span, "set_status"):
+                            span.set_status(StatusCode.ERROR)
+                        span.add_event(
+                            "queue.processing.failed",
+                            {"outcome": "failure", "error.class": type(exc).__name__},
+                        )
+                        record_metric(
+                            "curie.queue.process",
+                            attributes={**metric_attributes, "outcome": "failure"},
+                        )
+                        record_metric(
+                            "curie.queue.settle",
+                            attributes={**metric_attributes, "outcome": "pending"},
+                        )
+                        logger.exception("processing failed for entry %s; left pending", entry_id)
+                        return
+                    try:
+                        # A stale owner may not ACK. Checked immediately before
+                        # the ack, because the fence can move at any point during
+                        # a long turn and the ack is the irreversible one: it
+                        # takes the entry off the group, out from under the
+                        # replacement that now owns it.
+                        lease.raise_if_lost()
+                    except LeaseLostError:
+                        logger.warning(
+                            "refusing to ack entry %s: this owner lost the delivery "
+                            "lease mid-turn; leaving it pending for the current owner",
+                            entry_id,
+                        )
+                        record_metric(
+                            "curie.queue.process",
+                            attributes={**metric_attributes, "outcome": "failure"},
+                        )
+                        record_metric(
+                            "curie.queue.settle",
+                            attributes={**metric_attributes, "outcome": "pending"},
+                        )
+                        return
+                    await self._ack(entry_id)
+                    # Terminal acknowledgement: remove the delivery state as well
+                    # as the lease (the base's release drops only the lease). The
+                    # state's one-day retention is the backstop for a crash
+                    # between the ack and here, not the normal way it goes away --
+                    # without this a dead-lettered-and-redelivered event id
+                    # accumulates state keys until that TTL. Best-effort: the ack
+                    # above already happened.
+                    await self._settle_delivery_best_effort(entry_id)
+                    process_outcome = "success"
+                    span.add_event("queue.message.acked", {"outcome": "ack"})
                     record_metric(
                         "curie.queue.process",
-                        attributes={**metric_attributes, "outcome": "failure"},
+                        attributes={**metric_attributes, "outcome": "success"},
                     )
                     record_metric(
                         "curie.queue.settle",
-                        attributes={**metric_attributes, "outcome": "pending"},
+                        attributes={**metric_attributes, "outcome": "ack"},
                     )
-                    logger.exception("processing failed for entry %s; left pending", entry_id)
                     return
-                await self._ack(entry_id)
-                process_outcome = "success"
-                span.add_event("queue.message.acked", {"outcome": "ack"})
-                record_metric(
-                    "curie.queue.process",
-                    attributes={**metric_attributes, "outcome": "success"},
-                )
-                record_metric(
-                    "curie.queue.settle",
-                    attributes={**metric_attributes, "outcome": "ack"},
-                )
-                return
         finally:
             record_metric(
                 "curie.queue.process.duration",
@@ -345,6 +411,33 @@ class Consumer(StreamConsumer):
             )
             self._inflight_ids.discard(entry_id)
             self._sem.release()
+
+    async def _interrupt_on_lease_lost(self, entry_id: str, fields: dict[str, str]) -> None:
+        """Stop the live runner for a delivery whose fence has moved (ADR-0131).
+
+        Wired as the base's ``on_lease_lost``. It uses ``interrupt_thread`` --
+        the EXISTING bounded control path -- and nothing else. Cancelling the
+        handler task instead would look tidier and be wrong: a bare cancel skips
+        the runner-side stop and leaves a turn producing effects on a sandbox
+        this process no longer owns, which is exactly what the replacement's
+        reclaim preflight then has to clean up.
+
+        Every failure is logged and swallowed. Failing to interrupt must not mask
+        the lease loss itself, which ``lease.lost`` has already recorded and which
+        the pre-ack fence enforces on its own; and the replacement's preflight is
+        the second, independent guard against a turn that keeps running here.
+        """
+        try:
+            qevent = from_stream_fields(fields)
+            await self._kernel.interrupt_thread(
+                _thread_key_for(qevent), "delivery lease lost"
+            )
+        except Exception:
+            logger.exception(
+                "could not interrupt the runner for entry %s after its delivery "
+                "lease was lost; the fence still refuses every terminal write",
+                entry_id,
+            )
 
     @staticmethod
     def _message_age_seconds(received_at: str) -> float:

--- a/apps/worker/src/curie_worker/delivery_lease.py
+++ b/apps/worker/src/curie_worker/delivery_lease.py
@@ -1,0 +1,473 @@
+"""The renewable, fenced ownership lease for one stream delivery (ADR-0131, #1971).
+
+A delivery is a ``(stream, group, entry_id)``. Owning its PEL row is *necessary
+but not sufficient* to execute or settle it: the delivery also has a short Valkey
+lease carrying an opaque owner token and a monotonically increasing fencing
+generation, and only the holder of a live lease may run the handler, ACK,
+dead-letter, clear an outbox record, or emit a terminal result.
+
+Three design decisions are load-bearing enough to state here rather than in a
+plan nobody reads at the call site.
+
+**1. This store takes ``redis.asyncio.Redis`` directly, not the ``StreamBroker``
+port.** The fence *is* Valkey semantics -- atomic ``EVAL``, server ``TIME``, key
+expiry with ``PX``, entry-targeted ``XPENDING`` ownership, and ``XCLAIM ...
+JUSTID``. Widening ``StreamBroker`` would force a hypothetical second broker to
+implement Lua scripting and string-key verbs it has no reason to have, and would
+churn ``docs/interfaces/queue-stream/INTERFACE.md`` -- a published interface
+document -- for a worker-internal feature. The precedent already exists twice:
+``markers.py`` takes a concrete ``Redis``, and ``Consumer.__init__`` keeps its own
+``self._valkey: Redis`` for the thread-reset drain "rather than widening
+StreamBroker for one unrelated feature".
+
+**2. One script serves both acquisition and transfer.** ``acquire`` refuses if
+and only if a *live* lease exists; when the previous owner's lease has expired,
+that same call **is** the transfer. A separate ``transfer`` in the reclaim loop
+followed by an ``acquire`` in the handler would open a window in which authority
+is held by a process that is not yet executing. One script closes it by
+construction, and the reclaim paths degrade to a cheap ``EXISTS`` filter
+(:meth:`DeliveryLeaseStore.is_live`) rather than a second authority point.
+
+**3. The fencing generation outlives the lease.** There are TWO keys per
+delivery, and the split is not incidental:
+
+- ``{prefix}:lease:{stream}:{group}:{entry_id}`` -- a STRING holding the opaque
+  owner token, expiring at ``delivery_lease_ttl_s``. Short-lived by design: its
+  expiry is exactly how a dead owner's delivery becomes recoverable.
+- ``{prefix}:delivery:{stream}:{group}:{entry_id}`` -- a HASH holding
+  ``deadline_ms`` (absolute, from Valkey server ``TIME``, written
+  **create-if-absent**) and ``gen`` (the fencing generation, ``HINCRBY``'d on
+  every change of authority), retained for ``idempotency_ttl_s``.
+
+If the generation lived in the lease key, expiry would erase it and the next
+acquisition would restart at 1 -- monotonicity broken, and a stale owner holding
+generation 1 would validate against a fresh generation 1. The long retention also
+makes "the state key is absent" unambiguously mean *first delivery*: minting a
+fresh deadline for a delivery that already burned its budget is precisely the
+budget multiplication ``HSETNX`` on ``deadline_ms`` exists to prevent.
+
+Every fallible path here **fails closed**. A heartbeat that cannot confirm
+renewal is lease-lost, not "probably fine": loss of the ownership store is never
+permission to keep producing user-visible effects.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+import uuid
+from dataclasses import dataclass
+
+from redis.asyncio import Redis
+
+from .config import WorkerConfig
+
+# The permissive budget handed to a consumer built with NO lease store (the
+# base-only degradation in ``StreamConsumer._delivery_lease``). It is finite,
+# positive, and far beyond the configurable maximum budget (1800s) purely so the
+# leaseless path behaves exactly as it did before ADR-0131: every
+# ``min(per_request_ceiling, remaining)`` resolves to the ceiling, and no budget
+# check ever trips. It is never compared against a real deadline.
+_UNFENCED_BUDGET_S = 86_400.0
+
+# Acquire, and transfer, in one authority point. KEYS: lease, delivery state.
+# ARGV: 1 owner token, 2 consumer, 3 lease TTL ms, 4 budget ms, 5 state
+# retention ms, 6 stream, 7 group, 8 entry id.
+#
+# The PEL check is ENTRY-TARGETED (``XPENDING ... IDLE 0 <entry> <entry> 1``) and
+# compares the consumer name the range form returns. The summary form
+# (``IDLE 0 - + 1 <consumer>``) looks equivalent and is not: it pages the
+# consumer's whole pending list and ``COUNT 1`` answers about its OLDEST entry,
+# not the one being fenced. The runs lane holds up to ``max_concurrency`` (16)
+# entries per consumer, so that form would grant a lease whenever the consumer
+# owned ANY pending entry -- silently defeating the fence it exists to enforce.
+#
+# ``EXISTS`` on the lease key is the single refusal condition, and it is both
+# "refuse a concurrent acquisition" and "refuse a premature transfer": a
+# replacement may take a delivery only once the previous owner's lease expired.
+#
+# ``HSETNX`` on the deadline is create-if-absent so a replacement inherits the
+# SAME deadline. A plain ``HSET`` here multiplies the configured budget by the
+# number of transfers -- three reclaims would turn 1,800 seconds into 5,400.
+_ACQUIRE_LUA = """
+local lease_key = KEYS[1]
+local state_key = KEYS[2]
+local owner = ARGV[1]
+local consumer = ARGV[2]
+local stream = ARGV[6]
+local group = ARGV[7]
+local entry = ARGV[8]
+
+local pending = redis.call('XPENDING', stream, group, 'IDLE', 0, entry, entry, 1)
+if #pending == 0 then return {0, 'not-pending'} end
+if pending[1][2] ~= consumer then return {0, 'not-owner'} end
+
+if redis.call('EXISTS', lease_key) == 1 then return {0, 'held'} end
+
+local t = redis.call('TIME')
+local now = t[1] * 1000 + math.floor(t[2] / 1000)
+redis.call('HSETNX', state_key, 'deadline_ms', string.format('%d', now + tonumber(ARGV[4])))
+local gen = redis.call('HINCRBY', state_key, 'gen', 1)
+local deadline = redis.call('HGET', state_key, 'deadline_ms')
+redis.call('SET', lease_key, owner, 'PX', tonumber(ARGV[3]))
+redis.call('PEXPIRE', state_key, tonumber(ARGV[5]))
+return {1, gen, deadline, string.format('%d', now)}
+"""
+
+# Renew, with three independent fail-closed guards. KEYS: lease, delivery state.
+# ARGV: 1 owner token, 2 expected generation, 3 lease TTL ms, 4 state retention
+# ms, 5 stream, 6 group, 7 entry id, 8 consumer.
+#
+# All three guards run BEFORE anything is written, and each catches a distinct
+# way a stale process believes it is still the owner:
+#   - the PEL row moved to another consumer (an XCLAIM/XAUTOCLAIM took it);
+#   - the lease key holds a different token (our lease expired and was retaken);
+#   - the generation moved (the slow-heartbeat case: Valkey answers after our
+#     lease already expired AND was retaken by a process that happens to be us).
+#
+# ``XCLAIM ... JUSTID`` is what keeps a healthy long turn un-reclaimable: it
+# resets the same-owner PEL idle clock WITHOUT incrementing ``times_delivered``.
+# Dropping ``JUSTID`` burns one delivery of the ADR-0039 budget on every
+# heartbeat and dead-letters a perfectly healthy turn in under a minute.
+#
+# A fresh ``TIME`` is read and returned so the caller re-anchors its monotonic
+# clock on every successful renewal: the deadline never moves, but the anchor
+# does, which is what makes elapsed-time enforcement immune to a wall-clock step.
+_HEARTBEAT_LUA = """
+local lease_key = KEYS[1]
+local state_key = KEYS[2]
+local owner = ARGV[1]
+local stream = ARGV[5]
+local group = ARGV[6]
+local entry = ARGV[7]
+local consumer = ARGV[8]
+
+local pending = redis.call('XPENDING', stream, group, 'IDLE', 0, entry, entry, 1)
+if #pending == 0 then return {0, 'not-pending'} end
+if pending[1][2] ~= consumer then return {0, 'not-owner'} end
+if redis.call('GET', lease_key) ~= owner then return {0, 'not-owner-token'} end
+if redis.call('HGET', state_key, 'gen') ~= ARGV[2] then return {0, 'stale-generation'} end
+
+redis.call('PEXPIRE', lease_key, tonumber(ARGV[3]))
+redis.call('PEXPIRE', state_key, tonumber(ARGV[4]))
+redis.call('XCLAIM', stream, group, consumer, 0, entry, 'JUSTID')
+
+local t = redis.call('TIME')
+local now = t[1] * 1000 + math.floor(t[2] / 1000)
+return {1, string.format('%d', now), redis.call('HGET', state_key, 'deadline_ms')}
+"""
+
+# Compare-and-delete, the same idiom ``markers.py``'s ``_CLEAR_COMPLETION_LUA``
+# uses. A late ``__aexit__`` from an owner that already lost the fence must not
+# free the CURRENT owner's lease -- that would hand the delivery to a third
+# process while the real owner is still executing. There is no unconditional arm.
+_RELEASE_LUA = """
+if redis.call('GET', KEYS[1]) == ARGV[1] then
+  return redis.call('DEL', KEYS[1])
+end
+return 0
+"""
+
+
+class LeaseRefused(Exception):
+    """Acquisition was refused. ``reason`` says which guard refused it.
+
+    The distinction is operational, not cosmetic, and callers log the two
+    differently:
+
+    - ``held`` -- another owner's lease is live. Normal and expected under
+      contention and on every reclaim scan that races a healthy turn; the
+      correct response is to return without acking and leave the entry pending.
+    - ``not-owner`` / ``not-pending`` -- the PEL and our belief have diverged:
+      the entry is owned by another consumer, or is not pending at all. Neither
+      is routine, and both mean this process was about to fence a delivery it
+      was never given, so they are worth a WARNING.
+    """
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(f"delivery lease refused: {reason}")
+        self.reason = reason
+
+
+class LeaseLostError(RuntimeError):
+    """This owner's lease could not be confirmed, so it has no authority left.
+
+    Raised by :meth:`DeliveryLease.raise_if_lost` at the settle boundaries. A
+    process that sees this may not ACK, dead-letter, clear an outbox record, or
+    emit a terminal result: whoever now holds the fence owns those.
+    """
+
+
+@dataclass(frozen=True)
+class DeliveryBudget:
+    """The delivery's one deadline, measured with a monotonic clock.
+
+    ADR-0131: *"Within one process, elapsed-time enforcement uses a monotonic
+    clock anchored to the last Valkey-time observation so wall-clock adjustment
+    cannot extend the budget."*
+
+    ``deadline_ms`` and ``anchor_server_ms`` are both Valkey **server** time, so
+    their difference is the budget remaining as of the anchor. Everything since
+    is measured with ``time.monotonic()``, which no NTP step or manual clock
+    correction can move. ``time.time()`` must never appear in this module: an
+    absolute in-process clock read against these server-time milliseconds would
+    silently extend or destroy a live budget the moment the two disagree.
+    """
+
+    deadline_ms: int
+    anchor_server_ms: int
+    anchor_monotonic: float
+
+    def remaining_s(self) -> float:
+        """Seconds left, negative once the budget is spent (never wrapped)."""
+        at_anchor_s = (self.deadline_ms - self.anchor_server_ms) / 1000.0
+        return at_anchor_s - (time.monotonic() - self.anchor_monotonic)
+
+    def reanchor(self, server_ms: int) -> DeliveryBudget:
+        """The same deadline, re-based on a fresh server observation.
+
+        Not on the production heartbeat path -- ``DeliveryLeaseStore.heartbeat``
+        constructs a fresh ``DeliveryBudget`` directly. Retained as test-only API,
+        exercised by
+        ``test_remaining_s_is_driven_by_the_monotonic_anchor_not_the_wall_clock``
+        to demonstrate the ADR-0131 invariant that remaining time is driven by
+        the monotonic anchor rather than the wall clock. The deadline is
+        deliberately NOT recomputed: re-deriving it from ``now + budget`` is how
+        a renewal would turn into a budget extension.
+        """
+        return DeliveryBudget(
+            deadline_ms=self.deadline_ms,
+            anchor_server_ms=server_ms,
+            anchor_monotonic=time.monotonic(),
+        )
+
+
+class DeliveryLease:
+    """One process's authority over one delivery, for as long as it is renewed.
+
+    It carries the delivery it is a lease ON -- the ``(stream, group, entry_id)``
+    triple ADR-0131 keys a delivery by -- alongside the owner token and the
+    fencing generation. That is what lets a holder name its OWN lease and state
+    keys at the terminal settle: the fence is checked against keys derived from
+    the triple the lease was granted for, never against keys rediscovered by a
+    search. On the leaseless sentinel (:func:`unfenced_lease`) the triple is
+    empty, exactly as ``owner`` is, and nothing fenced ever reads it.
+
+    ``budget`` is replaced in place by the heartbeat loop -- a fresh
+    ``DeliveryBudget`` built from the Lua script's returned deadline and server
+    time, not a call to :meth:`DeliveryBudget.reanchor` -- so a holder always
+    reads the freshest anchor; ``lost`` is set the instant a renewal cannot be
+    confirmed, and never cleared -- authority is not recoverable once fenced out.
+    """
+
+    def __init__(
+        self,
+        *,
+        stream: str,
+        group: str,
+        entry_id: str,
+        owner: str,
+        generation: int,
+        budget: DeliveryBudget,
+    ) -> None:
+        self.stream = stream
+        self.group = group
+        self.entry_id = entry_id
+        self.owner = owner
+        self.generation = generation
+        self.budget = budget
+        self.lost = asyncio.Event()
+
+    def remaining_s(self) -> float:
+        return self.budget.remaining_s()
+
+    def raise_if_lost(self) -> None:
+        """Refuse to settle when the fence has already moved on.
+
+        Called immediately before an ACK or any other terminal write. Fail
+        closed: a lost lease is not a warning to log past, it is a hard stop.
+        """
+        if self.lost.is_set():
+            raise LeaseLostError(
+                f"delivery lease lost (owner={self.owner}, generation={self.generation}); "
+                "this owner may not ack, dead-letter, or emit a terminal result"
+            )
+
+
+def unfenced_lease() -> DeliveryLease:
+    """The permissive sentinel for a consumer built with NO lease store.
+
+    This is the ONE place a missing lease is read as permission, and it exists
+    only so a base-only ``StreamConsumer`` (the second-broker port, the
+    ``_FakeBroker`` unit tests) behaves exactly as it did before ADR-0131.
+    Nowhere else may absence be treated as authority.
+
+    Its budget is finite and positive on purpose. A sentinel reading as
+    exhausted would make every budget check skip every attempt -- a total stall
+    reached from the other side of the same mistake.
+    """
+    return DeliveryLease(
+        stream="",
+        group="",
+        entry_id="",
+        owner="",
+        generation=0,
+        budget=DeliveryBudget(
+            deadline_ms=int(_UNFENCED_BUDGET_S * 1000),
+            anchor_server_ms=0,
+            anchor_monotonic=time.monotonic(),
+        ),
+    )
+
+
+class DeliveryLeaseStore:
+    """Scripted delivery-ownership leases over Valkey.
+
+    Mirrors ``Markers.__init__``: a concrete async client plus the worker config
+    that owns the key namespace and every clock in it.
+    """
+
+    def __init__(self, redis: Redis, config: WorkerConfig) -> None:
+        self._redis = redis
+        self._config = config
+
+    @property
+    def heartbeat_interval_s(self) -> float:
+        """How often a holder must renew. The config validator guarantees the
+        lease spans at least three of these, so two consecutive missed renewals
+        still leave a healthy owner's lease live."""
+        return self._config.delivery_lease_heartbeat_s
+
+    def _keys(self, stream: str, group: str, entry_id: str) -> tuple[str, str]:
+        return (
+            self._config.delivery_lease_key(stream, group, entry_id),
+            self._config.delivery_state_key(stream, group, entry_id),
+        )
+
+    async def acquire(
+        self, stream: str, group: str, entry_id: str, *, consumer: str
+    ) -> DeliveryLease:
+        """Take authority over this delivery, or refuse.
+
+        This is also the transfer path (see decision #2 in the module docstring):
+        once the previous owner's lease has expired the very same call grants,
+        inheriting the original deadline and incrementing the fencing generation.
+
+        Raises :class:`LeaseRefused`; never returns a lease it did not win.
+        """
+        lease_key, state_key = self._keys(stream, group, entry_id)
+        owner = uuid.uuid4().hex
+        # Anchored BEFORE the round trip, so the round trip itself counts
+        # against the budget rather than being silently gifted back.
+        anchor_monotonic = time.monotonic()
+        raw = await self._redis.eval(
+            _ACQUIRE_LUA,
+            2,
+            lease_key,
+            state_key,
+            owner,
+            consumer,
+            str(int(self._config.delivery_lease_ttl_s * 1000)),
+            str(int(self._config.delivery_budget_s * 1000)),
+            str(int(self._config.idempotency_ttl_s * 1000)),
+            stream,
+            group,
+            entry_id,
+        )
+        if int(raw[0]) != 1:
+            raise LeaseRefused(str(raw[1]))
+        return DeliveryLease(
+            stream=stream,
+            group=group,
+            entry_id=entry_id,
+            owner=owner,
+            generation=int(raw[1]),
+            budget=DeliveryBudget(
+                deadline_ms=int(raw[2]),
+                anchor_server_ms=int(raw[3]),
+                anchor_monotonic=anchor_monotonic,
+            ),
+        )
+
+    async def heartbeat(
+        self,
+        stream: str,
+        group: str,
+        entry_id: str,
+        *,
+        consumer: str,
+        owner: str,
+        generation: int,
+    ) -> DeliveryBudget | None:
+        """Renew the lease and reset same-owner PEL idle, or refuse.
+
+        Returns the re-anchored budget on success and ``None`` on ANY refusal --
+        the caller treats ``None`` as lease-lost and fails closed. There is no
+        third answer, deliberately: a renewal that cannot be confirmed is
+        indistinguishable from one that was refused, and both must fence this
+        owner out.
+        """
+        lease_key, state_key = self._keys(stream, group, entry_id)
+        anchor_monotonic = time.monotonic()
+        raw = await self._redis.eval(
+            _HEARTBEAT_LUA,
+            2,
+            lease_key,
+            state_key,
+            owner,
+            str(generation),
+            str(int(self._config.delivery_lease_ttl_s * 1000)),
+            str(int(self._config.idempotency_ttl_s * 1000)),
+            stream,
+            group,
+            entry_id,
+            consumer,
+        )
+        if int(raw[0]) != 1:
+            return None
+        return DeliveryBudget(
+            deadline_ms=int(raw[2]),
+            anchor_server_ms=int(raw[1]),
+            anchor_monotonic=anchor_monotonic,
+        )
+
+    async def release(
+        self, stream: str, group: str, entry_id: str, *, owner: str
+    ) -> bool:
+        """Give up the lease, but only if it is still ours (compare-and-delete).
+
+        The delivery STATE survives a release. Its absence must keep meaning
+        "first delivery": a released-then-reacquired entry that minted a fresh
+        deadline would multiply the budget exactly as a reverted ``HSETNX`` does.
+        Only :meth:`settle` removes it.
+        """
+        lease_key, _state_key = self._keys(stream, group, entry_id)
+        deleted = await self._redis.eval(_RELEASE_LUA, 1, lease_key, owner)
+        return int(deleted) == 1
+
+    async def settle(self, stream: str, group: str, entry_id: str) -> None:
+        """Terminal cleanup: remove the lease AND the delivery state.
+
+        ADR-0131: internal delivery state is *"removed after terminal
+        acknowledgement or dead-letter settlement"*. Called only from those two
+        places -- the long retention on the state key is the backstop for a crash
+        between the ACK and this call, not the normal way it goes away.
+        """
+        lease_key, state_key = self._keys(stream, group, entry_id)
+        await self._redis.delete(lease_key, state_key)
+
+    async def is_live(self, stream: str, group: str, entry_id: str) -> bool:
+        """Is some owner currently holding this delivery?
+
+        A bare ``EXISTS``: the cheap read every reclaim path makes before it
+        cap-evaluates or dispatches. It deliberately does not say WHO holds the
+        lease -- the reclaim paths only need to know that somebody does.
+        """
+        lease_key, _state_key = self._keys(stream, group, entry_id)
+        return bool(await self._redis.exists(lease_key))
+
+    async def peek(self, stream: str, group: str, entry_id: str) -> dict[str, str]:
+        """The delivery state hash for diagnostics, ``{}`` when absent."""
+        _lease_key, state_key = self._keys(stream, group, entry_id)
+        state = await self._redis.hgetall(state_key)
+        return {str(k): str(v) for k, v in (state or {}).items()}

--- a/apps/worker/src/curie_worker/eval/stream.py
+++ b/apps/worker/src/curie_worker/eval/stream.py
@@ -22,7 +22,10 @@ crash before that attempt leaves the entry pending, so the next redelivery re-ru
 it -- an eval is never lost to a mid-run crash. A malformed payload cannot be
 processed on any redelivery, so it is logged and acked (a poison-pill drop). A
 missing/corrupt bundle or a provisioning failure is a failed run reported and
-acked, not a crash; a failing eval case is a failed count in the report.
+acked, not a crash; a failing eval case is a failed count in the report. A suite
+that outruns its ADR-0131 delivery deadline is the same shape: abandoned,
+reported as a failure, and acked -- a replacement inherits the SAME deadline, so
+re-running would only spend a budget that is already gone.
 """
 
 from __future__ import annotations
@@ -67,6 +70,7 @@ from ..binding import (
 )
 from ..bundle_store import BundleReader
 from ..config import WorkerConfig
+from ..delivery_lease import DeliveryLeaseStore, LeaseLostError
 from ..sandbox import SandboxSubstrate
 from ..sandbox.types import SandboxError
 from ..stream_consumer import DeliverySpec, ReadLoopSpec, StreamConsumer
@@ -257,8 +261,18 @@ class EvalStreamConsumer(StreamConsumer):
         reporter: EvalReporter,
         recorder: LangfuseEvalRecorder,
         repo_lookup: Any,
+        leases: DeliveryLeaseStore | None = None,
     ) -> None:
-        super().__init__(redis)
+        # ADR-0131: "runs and evals must share the lease implementation by
+        # construction. A fix on only one consumer lane is incomplete." The whole
+        # lifecycle is the shared base's; this lane only hands it the store.
+        #
+        # It deliberately wires NO ``on_lease_lost``: an eval suite has no single
+        # runner turn to interrupt through the kernel's bounded control path, so
+        # there is nothing for the callback to stop. Active cancellation on lease
+        # loss is the named follow-up (F2), and the residual is documented at
+        # ``_report`` below -- not papered over with a second interrupt mechanism.
+        super().__init__(redis, leases=leases)
         self._config = config
         self._bundles = bundle_store
         self._substrate = substrate
@@ -378,61 +392,90 @@ class EvalStreamConsumer(StreamConsumer):
     async def _handle_entry(self, entry_id: str, fields: dict[str, str]) -> None:
         self._inflight_ids.add(entry_id)
         try:
-            try:
-                # The sanctioned tolerant decode: a newer API adding an optional
-                # field must not land in the poison-pill branch below, which
-                # would ack and DROP the job with no dead letter.
-                item = parse_eval_job(fields[STREAM_PAYLOAD_FIELD])
-            except Exception:
-                # Poison pill: unprocessable on any redelivery. Dead-letter it
-                # (not a bare ack) so the malformed entry is observable in the
-                # eval graveyard, matching the runs lane's unparseable path (#535).
-                logger.exception("malformed eval work item %s; dead-lettering as poison", entry_id)
+            # ADR-0131: the same fence the runs lane holds, in the same shared
+            # context manager. Placed inside the outer ``try`` and outside the
+            # inner one so the ``finally`` below still discards the in-flight id
+            # last, after the lease has been released.
+            async with self._delivery_lease(entry_id, fields) as lease:
+                if lease is None:
+                    # Leased elsewhere: return WITHOUT acking so the entry stays
+                    # pending for its true owner. A refusal is a normal early
+                    # return, never an exception.
+                    return
+                try:
+                    # The sanctioned tolerant decode: a newer API adding an optional
+                    # field must not land in the poison-pill branch below, which
+                    # would ack and DROP the job with no dead letter.
+                    item = parse_eval_job(fields[STREAM_PAYLOAD_FIELD])
+                except Exception:
+                    # Poison pill: unprocessable on any redelivery. Dead-letter it
+                    # (not a bare ack) so the malformed entry is observable in the
+                    # eval graveyard, matching the runs lane's unparseable path (#535).
+                    logger.exception(
+                        "malformed eval work item %s; dead-lettering as poison", entry_id
+                    )
+                    record_metric(
+                        "curie.eval.process",
+                        attributes={
+                            "service.name": "curie-worker",
+                            "source": "eval",
+                            "outcome": "failure",
+                        },
+                    )
+                    await self._dead_letter(
+                        entry_id, fields, reason="unparseable", delivery_count=1
+                    )
+                    return
+                try:
+                    result = await self._run_and_report(item, entry_id)
+                    logger.info("eval %s @ %s: %s", item.suite, item.sha, result.summary())
+                except Exception:
+                    # An unexpected error before the report attempt: leave pending so
+                    # the reclaim loop re-runs it (an eval must not be lost to a crash).
+                    logger.exception("eval processing failed for %s; left pending", entry_id)
+                    record_metric(
+                        "curie.eval.process",
+                        attributes={
+                            "service.name": "curie-worker",
+                            "source": "eval",
+                            "outcome": "failure",
+                        },
+                    )
+                    return
+                metric_outcome = (
+                    "plumbing"
+                    if result.results
+                    and all(row.outcome is EvalOutcome.PLUMBING_OK for row in result.results)
+                    else (
+                        "failure"
+                        if any(row.outcome is EvalOutcome.FAIL for row in result.results)
+                        else "success"
+                    )
+                )
                 record_metric(
                     "curie.eval.process",
                     attributes={
                         "service.name": "curie-worker",
                         "source": "eval",
-                        "outcome": "failure",
+                        "outcome": metric_outcome,
                     },
                 )
-                await self._dead_letter(entry_id, fields, reason="unparseable", delivery_count=1)
-                return
-            try:
-                result = await self._run_and_report(item, entry_id)
-                logger.info("eval %s @ %s: %s", item.suite, item.sha, result.summary())
-            except Exception:
-                # An unexpected error before the report attempt: leave pending so
-                # the reclaim loop re-runs it (an eval must not be lost to a crash).
-                logger.exception("eval processing failed for %s; left pending", entry_id)
-                record_metric(
-                    "curie.eval.process",
-                    attributes={
-                        "service.name": "curie-worker",
-                        "source": "eval",
-                        "outcome": "failure",
-                    },
-                )
-                return
-            metric_outcome = (
-                "plumbing"
-                if result.results
-                and all(row.outcome is EvalOutcome.PLUMBING_OK for row in result.results)
-                else (
-                    "failure"
-                    if any(row.outcome is EvalOutcome.FAIL for row in result.results)
-                    else "success"
-                )
-            )
-            record_metric(
-                "curie.eval.process",
-                attributes={
-                    "service.name": "curie-worker",
-                    "source": "eval",
-                    "outcome": metric_outcome,
-                },
-            )
-            await self._ack(entry_id)
+                try:
+                    # A stale owner may not ACK: the entry belongs to whoever
+                    # holds the fence now.
+                    lease.raise_if_lost()
+                except LeaseLostError:
+                    logger.warning(
+                        "refusing to ack eval entry %s: this owner lost the "
+                        "delivery lease mid-suite; leaving it pending",
+                        entry_id,
+                    )
+                    return
+                await self._ack(entry_id)
+                # Terminal acknowledgement removes the delivery STATE as well as
+                # the lease; the base's release drops only the lease. Best-effort:
+                # the ack above already happened.
+                await self._settle_delivery_best_effort(entry_id)
         finally:
             self._inflight_ids.discard(entry_id)
 
@@ -440,7 +483,9 @@ class EvalStreamConsumer(StreamConsumer):
         repo = await self._repo_lookup.repo_full_name(item.agent_id)
         loaded = await self._load_suite(item)
         if loaded is None:
-            return await self._report_failed(item, repo, "unresolvable suite/bundle")
+            return await self._report_failed(
+                item, repo, "unresolvable suite/bundle", stream_id=stream_id
+            )
 
         suite = loaded.suite
         model = self._eval_model(item)
@@ -464,45 +509,97 @@ class EvalStreamConsumer(StreamConsumer):
             )
             if self._recorder is not None:
                 await self._recorder.record(result)
-            await self._report(item, repo, result)
+            await self._report(item, repo, result, stream_id=stream_id)
             return result
 
         base_url, release_key, token = await self._acquire_target(item)
         if base_url is None:
-            return await self._report_failed(item, repo, "runner provisioning failed")
+            return await self._report_failed(
+                item, repo, "runner provisioning failed", stream_id=stream_id
+            )
         samples = sample_config_from_env(os.environ)
+        # ADR-0131 gives a delivery ONE overall deadline, and it covers the whole
+        # delivery -- not just the runs lane. Without this bound the eval lane
+        # acquires a lease, lets the shared heartbeat renew it indefinitely, and
+        # runs a suite that can outlive its own budget: the deadline would exist
+        # in Valkey and be enforced nowhere. Read AFTER provisioning on purpose,
+        # so the claim/bind wait is charged against the budget rather than gifted
+        # back. ``asyncio.timeout`` is used instead of plumbing a deadline through
+        # ``run_eval_suite``'s signature because cancellation genuinely STOPS the
+        # in-flight case (a parameter would only be advisory), and widening that
+        # frozen-ish run-layer API is a separate change.
+        deadline_s = self._remaining_budget_s(stream_id)
+        run_result: EvalRunResult | None = None
         try:
-            if loaded.scorer is None:
-                result = await run_eval_suite(
-                    suite,
-                    base_url=base_url,
-                    version=item.sha,
-                    recorder=self._recorder,
-                    token=token,
-                    model=model,
-                    fake=self._config.fake_model,
-                    samples=samples,
-                    stream_id=stream_id,
-                )
-            else:
-                result = await run_eval_suite(
-                    suite,
-                    base_url=base_url,
-                    version=item.sha,
-                    recorder=self._recorder,
-                    token=token,
-                    model=model,
-                    fake=self._config.fake_model,
-                    scorer=loaded.scorer,
-                    samples=samples,
-                    stream_id=stream_id,
-                )
+            async with asyncio.timeout(deadline_s):
+                if loaded.scorer is None:
+                    run_result = await run_eval_suite(
+                        suite,
+                        base_url=base_url,
+                        version=item.sha,
+                        recorder=self._recorder,
+                        token=token,
+                        model=model,
+                        fake=self._config.fake_model,
+                        samples=samples,
+                        stream_id=stream_id,
+                    )
+                else:
+                    run_result = await run_eval_suite(
+                        suite,
+                        base_url=base_url,
+                        version=item.sha,
+                        recorder=self._recorder,
+                        token=token,
+                        model=model,
+                        fake=self._config.fake_model,
+                        scorer=loaded.scorer,
+                        samples=samples,
+                        stream_id=stream_id,
+                    )
+        except TimeoutError:
+            # Terminal for THIS delivery, not a crash to be reclaimed: the
+            # deadline is inherited by a replacement (``HSETNX`` on
+            # ``deadline_ms``), so re-running would only exhaust it again. Report
+            # the failure -- through the fenced path below -- and let the caller
+            # ack. Logged before the release so the deadline is named even if
+            # teardown is slow.
+            logger.error(
+                "eval %s @ %s exceeded its delivery deadline (%.1fs of budget "
+                "remained when the suite started); abandoning the suite",
+                item.suite,
+                item.sha,
+                deadline_s if deadline_s is not None else -1.0,
+            )
         finally:
             if release_key is not None:
                 await asyncio.to_thread(self._substrate.release, release_key)
 
-        await self._report(item, repo, result)
-        return result
+        if run_result is None:
+            return await self._report_failed(
+                item, repo, "delivery deadline exceeded", stream_id=stream_id
+            )
+        await self._report(item, repo, run_result, stream_id=stream_id)
+        return run_result
+
+    def _remaining_budget_s(self, stream_id: str) -> float | None:
+        """Seconds left of this delivery's one deadline, or ``None`` when this
+        lane is unfenced.
+
+        Never negative: an already-spent budget must bound the run at zero rather
+        than wrap into "no deadline", which is how a budget check turns into the
+        opposite of itself. ``None`` (no recorded lease) maps to
+        ``asyncio.timeout(None)`` -- unbounded, exactly the pre-ADR-0131
+        behaviour a base-only consumer had. That is the UNFENCED lane: the shared
+        base registers a lease in ``_held_leases`` only when there is a real one
+        to register, never the permissive sentinel, so a consumer built with no
+        lease store records nothing here and its suite is bounded by nothing --
+        as it was before the ADR.
+        """
+        lease = self._held_leases.get(stream_id)
+        if lease is None:
+            return None
+        return max(0.0, lease.remaining_s())
 
     async def _load_suite(self, item: EvalJob) -> _LoadedEvalSuite | None:
         if item.bundle_ref is None:
@@ -617,13 +714,65 @@ class EvalStreamConsumer(StreamConsumer):
         )
         return env
 
-    async def _report_failed(self, item: EvalJob, repo: str | None, reason: str) -> EvalRunResult:
+    async def _report_failed(
+        self, item: EvalJob, repo: str | None, reason: str, *, stream_id: str
+    ) -> EvalRunResult:
+        # ``stream_id`` is threaded in rather than carried on the result: the
+        # failure DTO below has no run to attach one to, and the fence is
+        # resolved from this argument (see ``_report``).
         logger.error("eval %s @ %s failed: %s", item.suite, item.sha, reason)
         result = EvalRunResult(version=item.sha, suite=item.suite, results=[])
-        await self._report(item, repo, result)
+        await self._report(item, repo, result, stream_id=stream_id)
         return result
 
-    async def _report(self, item: EvalJob, repo: str | None, result: EvalRunResult) -> None:
+    async def _report(
+        self, item: EvalJob, repo: str | None, result: EvalRunResult, *, stream_id: str
+    ) -> None:
+        # ADR-0131, the eval lane's one user-visible terminal effect. A suite
+        # whose fence has already moved must not publish a second report for a
+        # job a replacement now owns, so the loss is checked immediately before
+        # the send rather than only at the ack.
+        #
+        # The fence is resolved from the ``stream_id`` ARGUMENT, never from
+        # ``result.stream_id``. The failure paths above build an
+        # ``EvalRunResult`` with no run behind it, so that field is ``None`` on
+        # exactly the "unresolvable bundle" / "provisioning failed" / "deadline
+        # exceeded" cases -- the Valkey/K8s-adjacent failures most likely to
+        # coincide with a lease loss. Looking the lease up by an absent field
+        # would miss, and a missing lease read as "no fence" is a fence that
+        # FAILS OPEN. Resolution is therefore explicit and total.
+        #
+        # This closes MOST of the window, not all of it: a lease lost between
+        # this check and the platform's apply still produces a report that the
+        # replacement will duplicate. Eval reports are therefore an explicitly
+        # AT-LEAST-ONCE boundary -- the kind ADR-0131 requires be named rather
+        # than papered over -- and closing it needs eval-report idempotency at
+        # the platform API, tracked as follow-up F2.
+        lease = self._held_leases.get(stream_id)
+        if lease is None and self._leases is not None:
+            # A fenced lane whose lease cannot be resolved for this entry: this
+            # owner cannot prove it still holds authority, so it does not
+            # publish. Fail closed, the same posture the lease store itself
+            # takes. The ``self._leases is not None`` half is what keeps an
+            # UNFENCED lane publishing: the base records no lease at all for it
+            # (it registers only real ones, never the permissive sentinel), and
+            # with no lease store there is no fence to fail closed on.
+            logger.warning(
+                "not reporting eval %s @ %s: no delivery lease is recorded for "
+                "entry %s, so this owner cannot prove it still holds the fence",
+                item.suite,
+                item.sha,
+                stream_id,
+            )
+            return
+        if lease is not None and lease.lost.is_set():
+            logger.warning(
+                "not reporting eval %s @ %s: this owner lost the delivery lease "
+                "mid-suite and a replacement owns the job",
+                item.suite,
+                item.sha,
+            )
+            return
         # The frozen EvalReport carries passed_count/total only, and the API turns
         # it into a GitHub commit status. That shape cannot express "ran but was
         # never graded": 0/N posts a red that did not happen and N/N posts the

--- a/apps/worker/src/curie_worker/kernel.py
+++ b/apps/worker/src/curie_worker/kernel.py
@@ -92,6 +92,7 @@ from .behaviorpacks import (
 )
 from .binding import DECISION_ENV, GRANT_TOOL_ENV, RESUMED_KIND_ENV, BindingResolver
 from .config import WorkerConfig
+from .delivery_lease import DeliveryLease
 from .killswitch import KillSwitch
 from .markers import CompletionRecord, MalformedCompletionError, Markers
 from .publication_validation import validate_snapshot_against_base
@@ -168,6 +169,15 @@ _ERROR_LIFECYCLE_OUTCOMES = frozenset(
         "classified_failure",
         "side_effect_halted",
         "interrupted",
+        # ADR-0131. Deliberately DISTINCT from ``budget_halted``, which means the
+        # model spend budget was exhausted: this one means the delivery's
+        # wall-clock deadline was. Folding the two together would make both
+        # unreadable in telemetry -- an operator seeing a spike could no longer
+        # tell "agents are burning money" from "turns are running long".
+        "deadline_halted",
+        # The turn finished but a replacement already held the fence, so nothing
+        # was written and nothing was emitted.
+        "fenced_out",
     }
 )
 
@@ -267,6 +277,57 @@ def _nav_affordance(nav: NavPack | None) -> NavAffordance | None:
 # Failure classifications that are worth retrying (transient). Everything else
 # (budget-exceeded, model/server errors) escalates rather than looping.
 RETRYABLE_CLASSIFICATIONS = frozenset({"rate-limit", "runner-error"})
+
+# The floor of remaining DELIVERY budget below which a fresh attempt is not
+# started (ADR-0131). The runner cannot claim a sandbox, open a turn and stream a
+# final in a couple of seconds, so an attempt started under this floor is
+# guaranteed to be cut off mid-flight -- it buys nothing and spends the last of
+# the deadline that the escalation and the terminal settle still need.
+_MIN_ATTEMPT_BUDGET_S = 5.0
+
+# How long the reclaim preflight waits for a previous owner's runner to go idle
+# after the interrupt, and how often it re-reads. Bounded (and further clamped to
+# the delivery's own remaining budget) so recovering one transferred delivery can
+# never consume the whole deadline; an interrupt that has not landed inside this
+# window is treated as an unreadable runner, which fails closed.
+_RECLAIM_PREFLIGHT_IDLE_TIMEOUT_S = 5.0
+_RECLAIM_PREFLIGHT_POLL_S = 0.05
+
+
+class ReclaimPreflightUnsafe(RuntimeError):
+    """A transferred delivery could not be proven safe to re-execute.
+
+    Raised by the reclaim preflight when the previous owner's runner still
+    reports (or cannot deny) a live turn after the bounded interrupt-and-wait.
+    Raising leaves the stream entry PENDING, which is the fail-closed answer
+    ADR-0131 requires: "a replacement does not run beside a possibly active
+    turn." It is deliberately NOT a retryable classification -- there is no
+    attempt to classify, because no attempt was started.
+    """
+
+
+def _is_fenced(lease: DeliveryLease | None) -> bool:
+    """Does this lease carry real distributed authority (ADR-0131)?
+
+    Three shapes reach the kernel and only one of them is a fence. A ``None``
+    lease is a direct caller (the sweeper's re-emit path, every pre-ADR-0131
+    test). ``unfenced_lease()`` -- the permissive sentinel a consumer built with
+    NO lease store yields -- has an empty owner and generation 0, and must take
+    the leaseless path or a base-only consumer could never settle anything. Only
+    a lease acquired from the store, with a real owner token and a generation of
+    at least 1, is authority.
+    """
+    return lease is not None and lease.generation > 0 and bool(lease.owner)
+
+
+def _remaining_budget(lease: DeliveryLease | None) -> float | None:
+    """Seconds of delivery budget left, or ``None`` for a caller with no budget.
+
+    ``None`` is what keeps every leaseless caller byte-identical: it reaches
+    ``RunnerClient`` as "no per-request override", so the session default
+    applies exactly as it did before ADR-0131.
+    """
+    return None if lease is None else lease.remaining_s()
 
 # The platform-authored prefix that marks an approval resume turn as an EXPIRY
 # (vs a resolve). Set by ``resumequeue.build_expiry_resume_turn`` on both expiry
@@ -811,8 +872,17 @@ class Kernel:
         self._adopt_ref(qevent, ack)
         return ack
 
-    async def process_event(self, qevent: QueuedTurn) -> None:
-        """Observe one kernel lifecycle while preserving its ``None`` result."""
+    async def process_event(
+        self, qevent: QueuedTurn, *, lease: DeliveryLease | None = None
+    ) -> None:
+        """Observe one kernel lifecycle while preserving its ``None`` result.
+
+        ``lease`` is this delivery's ownership fence and overall deadline
+        (ADR-0131). Keyword-only and OPTIONAL: the sweeper's re-emit path and
+        every direct caller run without one and keep their pre-ADR-0131
+        behavior exactly. It is never required, and its absence is never checked
+        for -- the leaseless path is a supported caller, not a degraded one.
+        """
 
         error: BaseException | None = None
         with operation_span(
@@ -823,7 +893,14 @@ class Kernel:
             token = _LIFECYCLE_SPAN.set(span)
             outcome_token = _LIFECYCLE_OUTCOME.set(None)
             try:
-                await self._process_event(qevent)
+                if lease is None:
+                    # A caller with no lease reaches the body exactly as it did
+                    # before ADR-0131 -- one positional argument, no keyword.
+                    # The lease is genuinely optional here, not defaulted-away,
+                    # and the leaseless call shape is part of that contract.
+                    await self._process_event(qevent)
+                else:
+                    await self._process_event(qevent, lease=lease)
             except asyncio.CancelledError as exc:
                 error = exc
                 _LIFECYCLE_OUTCOME.set("interrupted")
@@ -858,7 +935,9 @@ class Kernel:
         if error is not None:
             raise error
 
-    async def _process_event(self, qevent: QueuedTurn) -> None:
+    async def _process_event(
+        self, qevent: QueuedTurn, *, lease: DeliveryLease | None = None
+    ) -> None:
         """Handle one queued turn to a terminal state (success or escalate).
 
         Returns normally once the event is terminally handled; the consumer then
@@ -970,6 +1049,7 @@ class Kernel:
                     route,
                     "escalated",
                     telemetry_outcome="classified_failure",
+                    lease=lease,
                 )
                 return
 
@@ -1002,6 +1082,7 @@ class Kernel:
                         "No agent is configured for this "
                         f"{qevent.reply_handle.kind} address "
                         f"{qevent.reply_handle.channel} yet.",
+                        lease=lease,
                     )
                     return
                 # The FIRST sanctioned route source, and the normal path: once a
@@ -1020,6 +1101,7 @@ class Kernel:
                         qevent,
                         route,
                         "This agent is paused by an operator. Try again once it resumes.",
+                        lease=lease,
                     )
                     return
                 agent_id = resolved.agent_id
@@ -1116,9 +1198,58 @@ class Kernel:
                 if self._config.shimmer:
                     await self._set_shimmer(qevent, route, packs)
 
+            # ADR-0131 reclaim preflight. A delivery that has CHANGED HANDS --
+            # generation > 1, a distributed-state fact and never a sniff of the
+            # message text, so kernel rule 3 stands -- may not simply route: the
+            # ordinary path would STEER into a retained live turn, which is right
+            # for a follow-up and wrong for a retry of the same event. Placed
+            # deliberately AFTER the side-effect check above (rule 1 of the
+            # preflight is that check, and a marker must forbid replay before any
+            # interrupt-and-rehydrate is contemplated) and BEFORE the first
+            # attempt.
+            if _is_fenced(lease) and lease is not None and lease.generation > 1:
+                await self._preflight_reclaimed_delivery(thread_key, lease)
+
             attempt = 0
             while True:
                 attempt += 1
+                # The delivery's overall deadline gates every attempt, and the
+                # attempts CONSUME it: a retry never restarts it.
+                if lease is not None:
+                    if lease.lost.is_set():
+                        # Fenced out between attempts. Start nothing: a
+                        # replacement holds this delivery and is entitled to run
+                        # it. Returning without completing leaves the entry
+                        # pending, and the consumer's pre-ACK check keeps this
+                        # owner from acking it away.
+                        logger.warning(
+                            "delivery lease lost before attempt %d for event %s; "
+                            "starting no attempt and settling nothing",
+                            attempt,
+                            event_id,
+                        )
+                        return
+                    remaining = lease.remaining_s()
+                    if remaining <= _MIN_ATTEMPT_BUDGET_S:
+                        # DISTINCT from the model-spend ``budget-exceeded``
+                        # classification: this is the wall-clock delivery
+                        # deadline, and conflating the two would make both
+                        # unreadable in telemetry.
+                        await self._escalate(
+                            qevent,
+                            route,
+                            "The run exceeded its delivery deadline after "
+                            f"{attempt - 1} attempt(s) and was not restarted. "
+                            "Flagging for a human.",
+                        )
+                        await self._complete(
+                            qevent,
+                            route,
+                            "escalated",
+                            telemetry_outcome="deadline_halted",
+                            lease=lease,
+                        )
+                        return
                 outcome = await self._attempt(
                     qevent,
                     route,
@@ -1129,6 +1260,7 @@ class Kernel:
                     packs,
                     workspace_deployment_id,
                     agent_name,
+                    remaining_s=_remaining_budget(lease),
                 )
 
                 if outcome.status is SessionStatus.AWAITING_APPROVAL:
@@ -1148,6 +1280,7 @@ class Kernel:
                         route,
                         "awaiting-approval",
                         telemetry_outcome="awaiting_approval",
+                        lease=lease,
                     )
                     return
 
@@ -1161,6 +1294,7 @@ class Kernel:
                             if outcome.status is SessionStatus.IDLE_AWAITING_INPUT
                             else "done"
                         ),
+                        lease=lease,
                     )
                     return
 
@@ -1176,6 +1310,7 @@ class Kernel:
                         route,
                         "escalated",
                         telemetry_outcome="side_effect_halted",
+                        lease=lease,
                     )
                     return
 
@@ -1196,6 +1331,7 @@ class Kernel:
                             if outcome.classification == "budget-exceeded"
                             else "classified_failure"
                         ),
+                        lease=lease,
                     )
                     return
 
@@ -1207,7 +1343,14 @@ class Kernel:
                         "retry_class": cast("str", outcome.classification),
                     },
                 )
-                await asyncio.sleep(self._backoff(attempt))
+                backoff_s = self._backoff(attempt)
+                if lease is not None:
+                    # The backoff CONSUMES the delivery budget; it never extends
+                    # it. Clamped, because an unclamped backoff longer than the
+                    # remaining deadline burns the whole thing asleep and then
+                    # escalates without ever having retried -- the worst of both.
+                    backoff_s = min(backoff_s, max(0.0, lease.remaining_s()))
+                await asyncio.sleep(backoff_s)
         finally:
             release_order()
             # Lower the assistant-thread "shimmer" raised above, on every exit
@@ -1276,6 +1419,90 @@ class Kernel:
                             candidate,
                         )
         return reaped
+
+    async def _preflight_reclaimed_delivery(
+        self, thread_key: str, lease: DeliveryLease
+    ) -> None:
+        """Prove a TRANSFERRED delivery is safe to re-execute, or refuse it.
+
+        ADR-0131's reclaim rules 2, 3 and 4, in that order. Rule 1 -- "a
+        side-effect marker forbids replay and settles to human escalation" -- is
+        the existing ``saw_side_effect`` check in ``_process_event``, which runs
+        BEFORE this and needs no code here; that ordering is load-bearing and is
+        pinned by a test rather than duplicated as a second check, because a
+        preflight that interrupted, waited and then rehydrated could otherwise
+        re-execute a half-done non-idempotent action.
+
+        Rule 2: a runner that still reports an active turn is interrupted and
+        must become idle (or disappear) before the retry. The interrupt goes
+        through ``interrupt_thread``, the EXISTING bounded control path -- no
+        second mechanism, and never a bare task cancel, which would skip the
+        runner-side stop.
+
+        Rule 3: an unreadable runner FAILS CLOSED. ``_turn_active`` already
+        reports busy when liveness cannot be read, so an unreadable runner
+        exhausts the bounded poll and this raises, leaving the stream entry
+        pending. A replacement never runs beside a possibly-active turn -- the
+        "just retry it" simplification is precisely the failure mode this
+        refuses.
+
+        Rule 4 is what falling off the end of this method means: old authority is
+        fenced (the lease generation moved), the old runner is inactive, and no
+        side-effect marker exists.
+
+        This deliberately diverges from the ordinary route, which STEERS into a
+        retained live turn: this is the same event being retried, not a follow-up.
+        The choice is driven by the lease generation, an explicit distributed
+        state fact, so kernel rule 3 ("never keyword-guess intent") is untouched.
+        """
+        # ONE deadline for the WHOLE preflight, established before the first
+        # probe -- not merely the gap between polls. Every liveness probe below
+        # derives its per-request HTTP bound from what is left of it, so a wedged
+        # runner (accepts the connect, then answers nothing) cannot ride
+        # ``RunnerClient``'s 600s streaming budget inside a single iteration. It
+        # could otherwise burn the delivery's entire deadline here and the next
+        # pass would escalate ``deadline_halted`` having made ZERO attempts,
+        # which is the opposite of "delivery is bounded". Clamped to the
+        # delivery's own remaining budget as well as the constant, so recovering
+        # one transferred delivery can never eat the whole deadline.
+        #
+        # Exhausting the window is not a silent pass: a probe cut short by it
+        # fails closed (``_turn_active`` reports busy on any unreadable answer)
+        # and the loop falls through to the raise below, which is exactly rule
+        # 3's refusal.
+        deadline = time.monotonic() + min(
+            _RECLAIM_PREFLIGHT_IDLE_TIMEOUT_S, max(0.0, lease.remaining_s())
+        )
+
+        def _left() -> float:
+            return max(0.0, deadline - time.monotonic())
+
+        handle = await asyncio.to_thread(self._substrate.lookup, thread_key)
+        if handle is None:
+            # No retained sandbox: the previous owner's runner is gone, which is
+            # the "or disappear" half of rule 2.
+            return
+        if not await self._turn_active(handle, remaining_s=_left()):
+            return
+        logger.warning(
+            "reclaimed delivery for thread %s (generation %d) found a live turn "
+            "from a previous owner; interrupting before retry",
+            thread_key,
+            lease.generation,
+        )
+        # The interrupt is deliberately NOT given this window: it keeps its own
+        # independent control-plane timeout, because a fence derived from a
+        # budget that may already be spent could not stop the runner it fenced.
+        await self.interrupt_thread(thread_key, "fenced transfer of a reclaimed delivery")
+        while time.monotonic() < deadline:
+            await asyncio.sleep(min(_RECLAIM_PREFLIGHT_POLL_S, _left()))
+            handle = await asyncio.to_thread(self._substrate.lookup, thread_key)
+            if handle is None or not await self._turn_active(handle, remaining_s=_left()):
+                return
+        raise ReclaimPreflightUnsafe(
+            f"thread {thread_key} still reports (or cannot deny) a live turn after "
+            "the reclaim interrupt; refusing to run a replacement beside it"
+        )
 
     async def interrupt_thread(self, thread_key: str, reason: str) -> bool:
         """Hard-stop the thread's live turn. True if a live runner was signalled."""
@@ -1464,11 +1691,15 @@ class Kernel:
         qevent: QueuedTurn,
         route: TargetRoute,
         message: str,
+        *,
+        lease: DeliveryLease | None = None,
     ) -> None:
         """Edit the placeholder with a reason and complete the turn (a polite
         drop for an unmapped channel or a paused agent, never a crash)."""
         await self._reply_for(qevent, route, message)
-        await self._complete(qevent, route, "dropped", telemetry_outcome="interrupted")
+        await self._complete(
+            qevent, route, "dropped", telemetry_outcome="interrupted", lease=lease
+        )
 
     async def _reply(
         self,
@@ -1497,6 +1728,7 @@ class Kernel:
         outcome: str,
         *,
         telemetry_outcome: str,
+        lease: DeliveryLease | None = None,
     ) -> None:
         """The terminal ordering, at every durable ``mark_done`` call site.
 
@@ -1516,9 +1748,23 @@ class Kernel:
         second sanctioned source -- no adapter can write to the stream, so the
         handle is trustworthy). A terminal path that marked done without a record
         would be a completion nothing could ever recover.
+
+        Since ADR-0131 this is also the FENCE. When the caller holds a delivery
+        lease, steps 1 and 2 fuse into ``Markers.settle_fenced``, one script that
+        verifies the lease token and the fencing generation and then performs the
+        same two writes. That adds a PRECONDITION; it reorders nothing -- the
+        record is still durable before/with the done marker, and it is still
+        cleared only after a confirmed emit.
+
+        A caller that fails the fence returns HERE, before ``_deliver_completion``
+        is ever reached: ADR-0131 says a stale owner "may not ACK, dead-letter,
+        clear an outbox record, or emit a terminal result", and all three of the
+        latter live downstream of this point. It also marks the lease lost, so the
+        consumer's pre-ACK ``raise_if_lost`` refuses the fourth verb too and the
+        entry stays pending for whoever now holds the fence. Without that, a turn
+        whose settle was refused would be acked with no completion written at all.
         """
         event_id = qevent.event_id
-        _LIFECYCLE_OUTCOME.set(telemetry_outcome)
         record = CompletionRecord(
             event_id=event_id,
             event=TurnCompleted(
@@ -1532,8 +1778,48 @@ class Kernel:
             created_at=time.time(),
             done=False,
         )
-        generation = await self._markers.mark_completion_pending(event_id, record)
-        await self._markers.mark_done(event_id)
+        if _is_fenced(lease):
+            assert lease is not None  # narrowed by _is_fenced
+            fenced = await self._markers.settle_fenced(
+                event_id,
+                record,
+                # The delivery this lease was GRANTED for, carried on the lease
+                # itself. Not `self._config.stream`: the fence must be checked
+                # against the exact keys the lease was acquired on, and the
+                # lease is the only thing that knows which entry that was.
+                stream=lease.stream,
+                group=lease.group,
+                entry_id=lease.entry_id,
+                owner=lease.owner,
+                generation=lease.generation,
+            )
+            if fenced is None:
+                # The single most diagnostic line in this feature: it is the
+                # only record that a turn ran to a terminal outcome and then
+                # discovered it no longer owned the delivery. Name what we held,
+                # so an operator can line it up against the replacement's
+                # acquisition rather than guessing which side was stale.
+                logger.warning(
+                    "fenced out of terminal settlement for event %s "
+                    "(owner=%s generation=%d outcome=%s): another owner holds "
+                    "this delivery; writing no marker, clearing nothing and "
+                    "emitting nothing",
+                    event_id,
+                    lease.owner,
+                    lease.generation,
+                    outcome,
+                )
+                _LIFECYCLE_OUTCOME.set("fenced_out")
+                # Authority is not recoverable, so record the loss locally too:
+                # the consumer's pre-ACK check is what keeps this owner from
+                # acking a delivery it just failed to settle.
+                lease.lost.set()
+                return
+            generation = fenced
+        else:
+            generation = await self._markers.mark_completion_pending(event_id, record)
+            await self._markers.mark_done(event_id)
+        _LIFECYCLE_OUTCOME.set(telemetry_outcome)
         await self._deliver_completion(record, generation=generation)
         attributes = {
             "service.name": "curie-worker",
@@ -1774,6 +2060,8 @@ class Kernel:
         packs: BehaviorPacks | None = None,
         workspace_deployment_id: uuid.UUID | None = None,
         agent_name: str | None = None,
+        *,
+        remaining_s: float | None = None,
     ) -> TurnOutcome:
         thread_key = _thread_key_for(qevent)
 
@@ -1818,6 +2106,7 @@ class Kernel:
                         workspace_deployment_id=workspace_deployment_id,
                         agent_name=agent_name,
                         source=qevent.source,
+                        remaining_s=remaining_s,
                     )
             except BaseException:
                 # start_turn owns a live response as soon as it returns, which
@@ -1986,6 +2275,7 @@ class Kernel:
         workspace_deployment_id: uuid.UUID | None = None,
         agent_name: str | None = None,
         source: TurnSource = TurnSource.SLACK,
+        remaining_s: float | None = None,
     ) -> _RouteResult:
         # A workspace-enabled thread must establish (or confirm) its repository
         # before any platform response path. This deliberately precedes the
@@ -2064,7 +2354,7 @@ class Kernel:
             # guarding: the per-thread lock held across this critical section is
             # what stops another turn on this thread from opening between the read
             # and the start.
-            if await self._turn_active(handle):
+            if await self._turn_active(handle, remaining_s=remaining_s):
                 raise ThreadBusyError(
                     f"thread {thread_key} has a live session; deferring the {source} turn"
                 )
@@ -2072,6 +2362,12 @@ class Kernel:
             active_before_steer = False
             if retained_live_route:
                 try:
+                    # NOT given ``remaining_s``: see the note above _turn_active.
+                    # This read runs UNDER the per-thread lock, so its bound has
+                    # to be a short control-plane one, not the delivery budget
+                    # (min(600, a 30-minute budget) is still 600). Routed
+                    # separately; a committed test also doubles ``status`` with a
+                    # base_url-only stub here.
                     status = await self._runner.status(handle.base_url)
                 except Exception as exc:  # noqa: BLE001 -- steering still decides the route
                     logger.warning(
@@ -2088,7 +2384,9 @@ class Kernel:
                             "runner pre-steer status carried no usable turn_active: %r",
                             status,
                         )
-            steered = await self._runner.steer(handle.base_url, event, token=handle.token or None)
+            steered = await self._runner.steer(
+                handle.base_url, event, token=handle.token or None, remaining_s=remaining_s
+            )
             if steered:
                 _record_route("steer")
                 _lifecycle_event("runner.turn.steered", "steer")
@@ -2101,12 +2399,19 @@ class Kernel:
             if retained_live_route and active_before_steer:
                 _record_route("finish-race")
                 _lifecycle_event("runner.finish_race", "finish-race")
-        turn = await self._runner.start_turn(handle.base_url, event, token=handle.token or None)
+        # The per-request timeout is min(runner_total_timeout_s, remaining
+        # delivery budget): the budget can only ever SHORTEN a request, never
+        # grant one more time than the delivery has left (ADR-0131).
+        turn = await self._runner.start_turn(
+            handle.base_url, event, token=handle.token or None, remaining_s=remaining_s
+        )
         _record_route("start")
         _lifecycle_event("runner.turn.started", "start")
         return _RouteResult(steered=False, handle=handle, turn=turn)
 
-    async def _turn_active(self, handle: SandboxHandle) -> bool:
+    async def _turn_active(
+        self, handle: SandboxHandle, *, remaining_s: float | None = None
+    ) -> bool:
         """Is a turn live in this sandbox right now?
 
         The read a job uses to decide whether to run or defer. It is a plain GET
@@ -2123,12 +2428,17 @@ class Kernel:
 
         Args:
             handle: The claimed sandbox for this thread.
+            remaining_s: Wall-clock budget the caller has left, or None for a
+                caller that holds no budget. It only ever SHORTENS the probe's
+                HTTP bound (``min`` with the client's ceiling): without it this
+                GET inherits the 600s streaming session total, so one wedged
+                runner costs the caller that whole window inside a single call.
 
         Returns:
             True when a turn is live, or when liveness could not be determined.
         """
         try:
-            status = await self._runner.status(handle.base_url)
+            status = await self._runner.status(handle.base_url, remaining_s=remaining_s)
         except Exception as exc:  # noqa: BLE001 -- any unreadable answer means "assume busy"
             logger.warning("could not read turn liveness at %s: %r", handle.base_url, exc)
             return True

--- a/apps/worker/src/curie_worker/markers.py
+++ b/apps/worker/src/curie_worker/markers.py
@@ -33,6 +33,15 @@ answers: a record proves its turn finished, so a turn that owns one must not be
 rerun for as long as that record can exist. Completion emit is at-least-once;
 turn SIDE EFFECTS are at-most-once for the whole outbox retention window, and
 that is why ``mark_done`` widens the marker's own TTL to match.
+
+Since ADR-0131 the terminal write has TWO forms, and they differ only by a
+precondition. ``settle_fenced`` is the form a delivery OWNER uses: it verifies
+the ownership lease and its fencing generation in the same script that writes
+the record and the marker, so a fenced-out owner writes nothing at all.
+``mark_completion_pending`` + ``mark_done`` remain the leaseless form, used by a
+kernel called without a lease and by the sweeper -- neither of which is an owner
+and neither of which has a fence to check. The ordering, the TTLs, and the
+resulting state are identical in both; only the precondition is new.
 """
 
 from __future__ import annotations
@@ -70,6 +79,46 @@ redis.call('SET', KEYS[1], '1', 'EX', ARGV[1])
 if redis.call('EXISTS', KEYS[2]) == 1 then
   redis.call('HSET', KEYS[2], ARGV[2], '1')
 end
+return 1
+"""
+
+# The fencing generation field inside the DELIVERY STATE hash. Owned by
+# ``delivery_lease.py`` (which HINCRBYs it on every change of authority); named
+# here because ``_SETTLE_FENCED_LUA`` below reads it, and a literal buried in Lua
+# is exactly the kind of cross-module constant that drifts silently.
+_DELIVERY_GENERATION_FIELD = "gen"
+
+# The FENCED terminal settlement (ADR-0131): the ownership check and the whole
+# terminal write, indivisibly.
+#
+# This is the ADR's "one atomic operation verifies the current lease, writes the
+# done marker and completion outbox, and identifies the winning owner". It fuses
+# what ``mark_completion_pending`` + ``mark_done`` do in two calls, and the
+# fusion is the point: two calls cannot be atomic with a fence check, so a slow
+# owner could pass the check and then write after a replacement had already
+# taken authority.
+#
+# It does NOT reorder anything. The record is still written BEFORE/WITH the done
+# marker, for the reason the module docstring gives, and is still cleared only
+# after a CONFIRMED emit (by ``clear_completion``, which is untouched). The fence
+# adds a PRECONDITION in front of the same ordering.
+#
+# Two guards, both before any write, both fail-closed:
+#   - the lease key must still hold OUR owner token; and
+#   - the delivery state's fencing generation must still be the one we hold.
+# ``_ACQUIRE_LUA`` installs the token and increments the generation in one
+# script, so the two move together; checking both means a hand-rolled or
+# partially-applied change of authority cannot slip between them.
+#
+# ``_MARK_DONE_LUA`` above is deliberately NOT modified: it still serves the
+# leaseless path (a kernel called without a lease) and the completion sweeper,
+# neither of which is a delivery owner.
+_SETTLE_FENCED_LUA = """
+if redis.call('GET', KEYS[4]) ~= ARGV[7] then return 0 end
+if redis.call('HGET', KEYS[5], ARGV[8]) ~= ARGV[9] then return 0 end
+redis.call('HSET', KEYS[2], ARGV[3], ARGV[5], ARGV[2], '1', ARGV[4], ARGV[6])
+redis.call('SADD', KEYS[3], ARGV[10])
+redis.call('SET', KEYS[1], '1', 'EX', ARGV[1])
 return 1
 """
 
@@ -228,6 +277,66 @@ class Markers:
             pipe.sadd(self._config.completions_pending_key(), event_id)
             await pipe.execute()
         return generation
+
+    async def settle_fenced(
+        self,
+        event_id: str,
+        record: CompletionRecord,
+        *,
+        stream: str,
+        group: str,
+        entry_id: str,
+        owner: str,
+        generation: int,
+    ) -> str | None:
+        """Settle this turn terminally, but only if this owner still holds the fence.
+
+        The fenced sibling of ``mark_completion_pending`` + ``mark_done``, fused
+        into one script so the ownership check and the terminal write cannot be
+        separated (see ``_SETTLE_FENCED_LUA``). On success the outbox record is
+        stored, indexed, and flagged done, and the done marker is set -- the same
+        state, in the same order, the two-call path produces.
+
+        The delivery triple is the caller's, taken straight off the
+        ``DeliveryLease`` it was granted for, so the lease and state keys named
+        here are EXACTLY the ones the fence was acquired on. There is no lookup:
+        ADR-0131 keys a delivery by ``(stream, group, entry_id)``, the lease
+        carries that triple, and the two key helpers on ``WorkerConfig`` are the
+        single definition of how it becomes a key. A settle therefore costs one
+        round trip and touches nothing but this delivery.
+
+        Returns the record's GENERATION on success, so the caller can
+        compare-and-clear the record it wrote, exactly as the leaseless path
+        does. Returns ``None`` when the fence refused: this owner's lease has
+        moved on, and per ADR-0131 it "may not ACK, dead-letter, clear an outbox
+        record, or emit a terminal result". Nothing was written.
+        """
+        lease_key = self._config.delivery_lease_key(stream, group, entry_id)
+        state_key = self._config.delivery_state_key(stream, group, entry_id)
+        record_generation = uuid.uuid4().hex
+        ttl_s = max(
+            self._config.idempotency_ttl_s, int(self._config.completion_max_retention_s)
+        )
+        settled = await self._redis.eval(
+            _SETTLE_FENCED_LUA,
+            5,
+            self._config.done_key(event_id),
+            self._config.completion_key(event_id),
+            self._config.completions_pending_key(),
+            lease_key,
+            state_key,
+            str(ttl_s),
+            _DONE_FIELD,
+            _RECORD_FIELD,
+            _GENERATION_FIELD,
+            record.model_dump_json(),
+            record_generation,
+            owner,
+            _DELIVERY_GENERATION_FIELD,
+            str(generation),
+            event_id,
+        )
+        return record_generation if int(settled) == 1 else None
 
     async def read_completion(self, event_id: str) -> StoredCompletion | None:
         """The stored record AS STORED, or None when some emitter cleared it.

--- a/apps/worker/src/curie_worker/run.py
+++ b/apps/worker/src/curie_worker/run.py
@@ -35,6 +35,7 @@ from .config import WorkerConfig
 from .connector_loop import ConnectorReconcileLoop, HttpManifestSource
 from .consumer import Consumer
 from .dead_letter_alert import install_dead_letter_alerting
+from .delivery_lease import DeliveryLeaseStore
 from .eval import EvalReporter, EvalStreamConsumer, LangfuseEvalRecorder
 from .heartbeat import run_heartbeat
 from .kernel import Kernel
@@ -387,7 +388,17 @@ def build(config: WorkerConfig, env: Mapping[str, str]) -> Runtime:
     )
     killswitch = KillSwitch(async_redis, on_kill=kernel.interrupt_agent)
     kernel.attach_killswitch(killswitch)
-    consumer = Consumer(redis=async_redis, kernel=kernel, config=config)
+    # Delivery ownership leases (ADR-0131), built from the CONCRETE async client
+    # for the same reason ``Markers`` above is: the fence needs Lua scripting and
+    # server ``TIME``, which the ``StreamBroker`` port deliberately does not
+    # carry. Each lane gets its own store bound to its own connection, so the
+    # eval lane's blocking read can never stall a runs-lane heartbeat.
+    consumer = Consumer(
+        redis=async_redis,
+        kernel=kernel,
+        config=config,
+        leases=DeliveryLeaseStore(async_redis, config),
+    )
 
     # The eval lane (F3): a second consumer group on curie:evals, on its own
     # Valkey connection so its blocking read never stalls the runs consumer. It
@@ -404,6 +415,7 @@ def build(config: WorkerConfig, env: Mapping[str, str]) -> Runtime:
     eval_consumer = EvalStreamConsumer(
         redis=eval_redis,
         config=config,
+        leases=DeliveryLeaseStore(eval_redis, config),
         bundle_store=BundleStore(config),
         substrate=substrate,
         reporter=EvalReporter(

--- a/apps/worker/src/curie_worker/runner_client.py
+++ b/apps/worker/src/curie_worker/runner_client.py
@@ -23,10 +23,11 @@ import time
 from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass
 from types import TracebackType
-from typing import TypeVar
+from typing import Any, TypeVar
 
 import aiohttp
 from aci_protocol import Event, Final, Interrupt, OutboundEvent, parse_ndjson_line
+from aiohttp.helpers import sentinel
 from curie_telemetry import inject_trace_context, operation_span, record_metric
 from opentelemetry.trace import SpanKind, StatusCode
 
@@ -43,6 +44,9 @@ from opentelemetry.trace import SpanKind, StatusCode
 # going) instead of re-deriving the bound -- or a coupling to this client's
 # other timeouts -- at each call site.
 _DEFAULT_INTERRUPT_TIMEOUT_S = 5.0
+# The smallest per-request bound a spent budget may derive. See
+# ``_request_timeout``: aiohttp treats a total of 0.0 as "no timeout".
+_MIN_REQUEST_TIMEOUT_S = 0.05
 _POST_FINAL_CLEANUP_TIMEOUT_S = 1.0
 _POST_FINAL_DISCARD_CHUNK_BYTES = 64 * 1024
 _T = TypeVar("_T")
@@ -160,6 +164,12 @@ class RunnerClient:
         if snapshot_patch_max_bytes <= 0:
             raise ValueError("snapshot patch byte limit must be positive")
         self._own_session = session is None
+        self._connect_timeout_s = connect_timeout_s
+        # Since ADR-0131 this is a per-request CEILING inside the delivery's one
+        # overall deadline, not an independent clock. It stays the session
+        # default (so every caller without a budget is behaviourally unchanged)
+        # and is the upper half of the ``min`` in ``_request_timeout``.
+        self._total_timeout_s = total_timeout_s
         self._session = session or aiohttp.ClientSession(
             timeout=aiohttp.ClientTimeout(
                 total=total_timeout_s, connect=connect_timeout_s, sock_read=total_timeout_s
@@ -168,11 +178,48 @@ class RunnerClient:
         # A per-request override, not folded into the session default above: it
         # replaces (not merges with) the session timeout for this one call, so
         # ``/v1/interrupt`` gets its own short control-plane budget regardless of
-        # how the streaming timeouts above are tuned.
+        # how the streaming timeouts above are tuned. The budget-derived
+        # overrides below rely on exactly that mechanic.
+        #
+        # ``/v1/interrupt`` is DELIBERATELY excluded from the budget path and a
+        # test guards it structurally: the interrupt is the fail-closed stop a
+        # lost lease fires, and deriving its timeout from a budget that may
+        # already be exhausted would make the fence unable to stop the runner it
+        # just fenced.
         self._interrupt_timeout = aiohttp.ClientTimeout(total=interrupt_timeout_s)
         self._snapshot_patch_max_bytes = snapshot_patch_max_bytes
         self._snapshot_body_max_bytes = (
             4 * ((snapshot_patch_max_bytes + 2) // 3) + 131_072
+        )
+
+    def _request_timeout(self, remaining_s: float | None) -> aiohttp.ClientTimeout | Any:
+        """The per-request timeout for a delivery with ``remaining_s`` of budget.
+
+        Returns aiohttp's own ``sentinel`` when there is no budget in hand, so
+        the session default applies and every leaseless caller is
+        byte-identical in behavior. An explicit ``timeout=None`` would not do
+        that: aiohttp reads it as ``ClientTimeout(total=None)``, i.e. no
+        timeout at all -- the one shape this method must never produce. The
+        sentinel is aiohttp's own "use the session default" value (it is what
+        ``timeout`` defaults to internally); its type is private to aiohttp,
+        hence the ``Any`` half of the return annotation.
+
+        The effective bound is ``min(total_timeout_s, remaining_s)``: the budget
+        can only ever SHORTEN a request. A 30-minute delivery must not hand one
+        runner request a 30-minute HTTP deadline.
+
+        A spent budget is floored to ``_MIN_REQUEST_TIMEOUT_S`` rather than
+        passed through. aiohttp starts a timeout handle only ``if timeout > 0``,
+        so a bounded value of exactly 0.0 disables the timeout entirely -- the
+        "no timeout at all" shape this method must never produce, and it would
+        arrive precisely when the delivery has the least time to spare. The
+        floor is small enough that an exhausted budget still fails fast.
+        """
+        if remaining_s is None:
+            return sentinel
+        bounded = max(_MIN_REQUEST_TIMEOUT_S, min(self._total_timeout_s, remaining_s))
+        return aiohttp.ClientTimeout(
+            total=bounded, connect=self._connect_timeout_s, sock_read=bounded
         )
 
     async def _rpc(
@@ -224,12 +271,22 @@ class RunnerClient:
             raise error
         return result  # type: ignore[return-value]
 
-    async def start_turn(self, base_url: str, event: Event, token: str | None = None) -> TurnStream:
+    async def start_turn(
+        self,
+        base_url: str,
+        event: Event,
+        token: str | None = None,
+        *,
+        remaining_s: float | None = None,
+    ) -> TurnStream:
         """Open a turn. Returns once the runner has accepted it (turn active)."""
 
         async def request(headers: dict[str, str] | None) -> tuple[TurnStream, str]:
             resp = await self._session.post(
-                f"{base_url}/v1/event", json=event.model_dump(), headers=headers
+                f"{base_url}/v1/event",
+                json=event.model_dump(),
+                headers=headers,
+                timeout=self._request_timeout(remaining_s),
             )
             if resp.status != 200:
                 body = await resp.text()
@@ -239,12 +296,22 @@ class RunnerClient:
 
         return await self._rpc("event", token, request)
 
-    async def steer(self, base_url: str, event: Event, token: str | None = None) -> bool:
+    async def steer(
+        self,
+        base_url: str,
+        event: Event,
+        token: str | None = None,
+        *,
+        remaining_s: float | None = None,
+    ) -> bool:
         """Inject a follow-up into the live turn. False on 409 (no active turn)."""
 
         async def request(headers: dict[str, str] | None) -> tuple[bool, str]:
             async with self._session.post(
-                f"{base_url}/v1/steer", json=event.model_dump(), headers=headers
+                f"{base_url}/v1/steer",
+                json=event.model_dump(),
+                headers=headers,
+                timeout=self._request_timeout(remaining_s),
             ) as resp:
                 if resp.status == 409:
                     return False, "conflict"
@@ -281,7 +348,13 @@ class RunnerClient:
 
         await self._rpc("interrupt", token, request)
 
-    async def reset(self, base_url: str, token: str | None = None) -> None:
+    async def reset(
+        self,
+        base_url: str,
+        token: str | None = None,
+        *,
+        remaining_s: float | None = None,
+    ) -> None:
         """Discard the runner's conversation so the next turn starts fresh (#550).
 
         The eval driver calls this between cases to enforce per-case isolation.
@@ -291,7 +364,11 @@ class RunnerClient:
         condition to swallow.
         """
         async def request(headers: dict[str, str] | None) -> tuple[None, str]:
-            async with self._session.post(f"{base_url}/v1/reset", headers=headers) as resp:
+            async with self._session.post(
+                f"{base_url}/v1/reset",
+                headers=headers,
+                timeout=self._request_timeout(remaining_s),
+            ) as resp:
                 if resp.status != 200:
                     body = await resp.text()
                     raise RunnerError(f"/v1/reset -> {resp.status}: {body}")
@@ -299,7 +376,13 @@ class RunnerClient:
 
         await self._rpc("reset", token, request)
 
-    async def snapshot(self, base_url: str, token: str | None = None) -> RunnerWorkspaceSnapshot:
+    async def snapshot(
+        self,
+        base_url: str,
+        token: str | None = None,
+        *,
+        remaining_s: float | None = None,
+    ) -> RunnerWorkspaceSnapshot:
         """Capture a bounded patch before a publication approval suspends.
 
         This call is always runner-token authenticated. A missing token is a
@@ -311,7 +394,9 @@ class RunnerClient:
         if not token:
             raise RunnerError("publication snapshot requires a runner token")
         async with self._session.post(
-            f"{base_url}/v1/snapshot", headers=_auth_headers(token)
+            f"{base_url}/v1/snapshot",
+            headers=_auth_headers(token),
+            timeout=self._request_timeout(remaining_s),
         ) as resp:
             if resp.status != 200:
                 body = await resp.text()
@@ -359,9 +444,15 @@ class RunnerClient:
             except (KeyError, TypeError, ValueError, binascii.Error, json.JSONDecodeError) as exc:
                 raise RunnerError("/v1/snapshot returned an invalid bounded payload") from exc
 
-    async def status(self, base_url: str) -> dict[str, object]:
+    async def status(
+        self, base_url: str, *, remaining_s: float | None = None
+    ) -> dict[str, object]:
         async def request(headers: dict[str, str] | None) -> tuple[dict[str, object], str]:
-            async with self._session.get(f"{base_url}/status", headers=headers) as resp:
+            async with self._session.get(
+                f"{base_url}/status",
+                headers=headers,
+                timeout=self._request_timeout(remaining_s),
+            ) as resp:
                 if resp.status != 200:
                     body = await resp.text()
                     raise RunnerError(f"/status -> {resp.status}: {body}")

--- a/apps/worker/src/curie_worker/stream_consumer.py
+++ b/apps/worker/src/curie_worker/stream_consumer.py
@@ -13,8 +13,10 @@ per-message business logic and passes them in.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import cast
@@ -32,12 +34,21 @@ from redis.exceptions import (
 )
 
 from .broker import StreamBroker
+from .delivery_lease import (
+    DeliveryLease,
+    DeliveryLeaseStore,
+    LeaseRefused,
+    unfenced_lease,
+)
 
 # One stream entry as redis returns it with decode_responses=True.
 StreamEntry = tuple[str, dict[str, str]]
 
 # An async per-message handler: (entry_id, fields) -> None.
 EntryHandler = Callable[[str, dict[str, str]], Awaitable[None]]
+
+# Called once when a delivery's lease is lost mid-flight: (entry_id, fields).
+LeaseLostHandler = Callable[[str, dict[str, str]], Awaitable[None]]
 
 
 @dataclass(frozen=True)
@@ -93,7 +104,14 @@ class StreamConsumer:
     business logic.
     """
 
-    def __init__(self, redis: StreamBroker, delivery: DeliverySpec | None = None) -> None:
+    def __init__(
+        self,
+        redis: StreamBroker,
+        delivery: DeliverySpec | None = None,
+        *,
+        leases: DeliveryLeaseStore | None = None,
+        on_lease_lost: LeaseLostHandler | None = None,
+    ) -> None:
         # The stream broker behind the port (#284). ``redis.asyncio.Redis`` is the
         # one backing today and structurally satisfies ``StreamBroker``; a second
         # broker is a drop-in. Named ``_redis`` still so the sacred consumer.py
@@ -108,6 +126,38 @@ class StreamConsumer:
         # The reclaim/dead-letter knobs, or None for a base-only reader that
         # exercises just ``_consume`` (no reclaim machinery).
         self._delivery = delivery
+        # Delivery ownership leases (ADR-0131). Like ``consumer.py``'s
+        # ``self._valkey``, this collaborator is built from the CONCRETE
+        # ``redis.asyncio.Redis`` rather than the ``StreamBroker`` port above:
+        # the fence needs Lua scripting, server ``TIME``, and string-key verbs
+        # the port deliberately does not carry (see delivery_lease.py's module
+        # docstring). Optional, and None for a base-only consumer or a second
+        # broker implementation -- that construction must keep working exactly
+        # as it did before the lease existed.
+        self._leases: DeliveryLeaseStore | None = leases
+        # Leases this process is holding RIGHT NOW, keyed by entry id, populated
+        # and cleared by ``_delivery_lease``. It is the ONE registry of in-flight
+        # leases -- a lane that kept its own second copy would have to stay in
+        # lockstep with this one by hand, and the two fences reading different
+        # dicts is exactly how a fence silently stops seeing its lease.
+        #
+        # It exists so a caller that did not receive the lease can still find it
+        # without threading one through a shared signature. ``_dead_letter`` uses
+        # it to tell which of its two callers it is serving: a handler path is
+        # registered here, the maintenance scan is not (see
+        # ``_dead_letter_refusal`` for what the fence asks in each case). The
+        # eval lane reads it the same way at its report fence and its budget.
+        #
+        # Only a REAL lease is registered; the permissive ``unfenced_lease()``
+        # sentinel is not, so absence here means either "not in a handler" or
+        # "this consumer has no lease store at all", and every reader must
+        # disambiguate on ``self._leases`` rather than on absence alone.
+        self._held_leases: dict[str, DeliveryLease] = {}
+        # Fired once when a lease is lost mid-flight, so the owning lane can
+        # stop its runner through its own bounded control path. The base never
+        # cancels a handler task itself: a bare cancel skips the runner-side
+        # stop and leaves a turn producing effects on a sandbox we no longer own.
+        self._on_lease_lost: LeaseLostHandler | None = on_lease_lost
 
     @property
     def _spec(self) -> DeliverySpec:
@@ -199,11 +249,280 @@ class StreamConsumer:
     async def _ack(self, entry_id: str) -> None:
         await self._redis.xack(self._spec.stream, self._spec.group, entry_id)
 
+    async def _settle_delivery(self, entry_id: str) -> None:
+        """Remove this delivery's lease AND its state after a terminal settlement.
+
+        ADR-0131: delivery state is "removed after terminal acknowledgement or
+        dead-letter settlement". The base's lease release drops only the lease,
+        so without this a dead-lettered-and-redelivered entry id accumulates
+        state keys until their retention TTL expires them.
+
+        RAISES THROUGH on failure. It is the caller that knows whether a settle
+        failure is recoverable, and the two shapes genuinely differ: a caller
+        that is already inside its own error handling (``_dead_letter``, which
+        must mark the span and the metric and re-raise) needs the exception, and
+        a caller that has already acked wants
+        :meth:`_settle_delivery_best_effort` instead. Both lanes read the
+        delivery off ``self._spec``, which is exactly the runs/eval difference
+        (``stream`` vs ``eval_stream``) each lane used to spell out itself.
+        """
+        if self._leases is None:
+            return
+        await self._leases.settle(self._spec.stream, self._spec.group, entry_id)
+
+    async def _settle_delivery_best_effort(self, entry_id: str) -> None:
+        """:meth:`_settle_delivery` for a caller that has ALREADY acked.
+
+        Best-effort by construction: the entry is already off the group by the
+        time this runs, so raising here would only turn a settled turn or suite
+        into a logged failure. The state key's own retention is the backstop for
+        a crash between the ack and here, not the normal way it goes away.
+        """
+        if self._delivery is None or self._leases is None:
+            # Nothing to settle without both a bound DeliverySpec and a lease
+            # store -- ``_settle_delivery`` would no-op on a missing lease
+            # store anyway, and a missing DeliverySpec must be handled here,
+            # before the try, because the except below reads ``self._spec``
+            # for its logger and that property raises on a None delivery too.
+            # Swallowing is this method's whole contract, so bail out early
+            # rather than let that second read escape uncaught.
+            return
+        try:
+            await self._settle_delivery(entry_id)
+        except Exception:
+            self._spec.logger.warning(
+                "settling the delivery state for entry %s on stream %s failed; "
+                "leaving it to its retention TTL",
+                entry_id,
+                self._spec.stream,
+                exc_info=True,
+            )
+
     async def _entry_fields(self, entry_id: str) -> dict[str, str] | None:
         """The original entry's fields, or None if it was already trimmed off the
         stream (then a metadata-only graveyard row is written)."""
         rows = await self._redis.xrange(self._spec.stream, min=entry_id, max=entry_id)
         return dict(rows[0][1]) if rows else None
+
+    async def _lease_is_live(self, entry_id: str) -> bool:
+        """Does some owner hold this delivery right now?
+
+        FAIL CLOSED on an unreadable answer. Every caller uses this to decide
+        whether it may dead-letter or dispatch a delivery, and ADR-0131 is
+        explicit that "loss of the ownership store cannot be treated as
+        permission to continue producing effects" -- so a Valkey blip reads as
+        "somebody owns it", which costs one skipped maintenance pass, rather
+        than as "nobody owns it", which costs a duplicate turn or a healthy
+        turn's dead-letter.
+
+        With no lease store configured at all there is no fence to consult and
+        the answer is False, leaving the pre-ADR-0131 behavior intact.
+        """
+        if self._leases is None:
+            return False
+        try:
+            return await self._leases.is_live(
+                self._spec.stream, self._spec.group, entry_id
+            )
+        except Exception:
+            self._spec.logger.warning(
+                "lease liveness unreadable for entry %s on stream %s; "
+                "treating it as OWNED and skipping this pass",
+                entry_id,
+                self._spec.stream,
+                exc_info=True,
+            )
+            return True
+
+    @asynccontextmanager
+    async def _delivery_lease(
+        self, entry_id: str, fields: dict[str, str]
+    ) -> AsyncIterator[DeliveryLease | None]:
+        """Hold delivery authority for the body of a handler (ADR-0131).
+
+        Lives HERE, once, rather than in each lane, because the ADR requires the
+        runs and eval consumers to share the lease implementation by
+        construction: "a fix on only one consumer lane is incomplete."
+
+        Yields the lease on success and ``None`` when acquisition was refused --
+        a refusal is a normal early return from the handler, never an exception.
+        An exception would be caught by ``_consume``'s isolation guard and
+        logged as a failure, which is correct but noisy for the routine case of
+        losing a race to a peer that is already working the entry.
+
+        With no lease store, yields the permissive sentinel so a base-only
+        consumer is unchanged. That is the one place a missing lease is read as
+        permission; nowhere else may it be.
+        """
+        if self._leases is None:
+            yield unfenced_lease()
+            return
+
+        spec = self._spec
+        try:
+            lease = await self._leases.acquire(
+                spec.stream, spec.group, entry_id, consumer=spec.consumer
+            )
+        except LeaseRefused as refused:
+            if refused.reason == "held":
+                # Routine under contention: a peer holds a live lease and is
+                # working this entry. Return without acking; it stays pending
+                # for its true owner.
+                spec.logger.debug(
+                    "entry %s on stream %s is leased elsewhere; not dispatching",
+                    entry_id,
+                    spec.stream,
+                )
+            else:
+                # The PEL and our belief have diverged -- we were about to fence
+                # a delivery Valkey never gave us. Not routine.
+                spec.logger.warning(
+                    "refused the delivery lease for entry %s on stream %s (%s); "
+                    "this consumer does not hold the pending entry",
+                    entry_id,
+                    spec.stream,
+                    refused.reason,
+                )
+            yield None
+            return
+
+        heartbeat = asyncio.create_task(self._heartbeat_lease(lease, entry_id, fields))
+        # Registered BEFORE the body runs, so the dead-letter fence can find this
+        # lease from anywhere inside the handler -- including the unparseable
+        # path, which reaches the graveyard without ever naming its lease.
+        self._held_leases[entry_id] = lease
+        try:
+            yield lease
+        finally:
+            # Deregistered FIRST: once the body is done this process is no longer
+            # a holder, and a later maintenance-scan dead-letter of the same id
+            # must fall through to the "does anybody else own it" question rather
+            # than consulting a lease we have already finished with.
+            self._held_leases.pop(entry_id, None)
+            heartbeat.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await heartbeat
+            try:
+                await self._leases.release(
+                    spec.stream, spec.group, entry_id, owner=lease.owner
+                )
+            except Exception:
+                # Releasing is an optimization: the lease expires on its own at
+                # ``delivery_lease_ttl_s``. Raising out of this ``finally`` would
+                # mask whatever the handler was already failing with.
+                spec.logger.warning(
+                    "releasing the delivery lease for entry %s failed; "
+                    "leaving it to expire",
+                    entry_id,
+                    exc_info=True,
+                )
+
+    async def _heartbeat_lease(
+        self, lease: DeliveryLease, entry_id: str, fields: dict[str, str]
+    ) -> None:
+        """Renew the lease until it is lost or the handler finishes.
+
+        Sleeps with a PLAIN ``asyncio.sleep``, never ``_sleep_or_stop``. A
+        SIGTERM sets ``_stop`` while the worker is deliberately draining its
+        in-flight turns, and a stop-aware sleep here would drop every in-flight
+        lease the instant the signal landed -- turning a graceful rollout into a
+        fleet-wide fence-out, the exact opposite of draining. The platform
+        termination grace is sized to cover the budget plus the shutdown
+        reserve precisely so this loop may keep running through shutdown.
+
+        Any refusal OR any exception is lease-lost. ADR-0131: "if Valkey cannot
+        confirm renewal, the owner fails closed as lease-lost."
+        """
+        assert self._leases is not None
+        spec = self._spec
+        while True:
+            await asyncio.sleep(self._leases.heartbeat_interval_s)
+            try:
+                budget = await self._leases.heartbeat(
+                    spec.stream,
+                    spec.group,
+                    entry_id,
+                    consumer=spec.consumer,
+                    owner=lease.owner,
+                    generation=lease.generation,
+                )
+            except Exception as exc:  # noqa: BLE001 - any failure is lease-lost
+                budget = None
+                reason = f"renewal raised {type(exc).__name__}: {exc}"
+            else:
+                reason = "renewal refused by Valkey"
+            if budget is None:
+                lease.lost.set()
+                spec.logger.warning(
+                    "delivery lease LOST for entry %s on stream %s "
+                    "(owner=%s generation=%d): %s; this owner may no longer ack, "
+                    "dead-letter, or emit a terminal result",
+                    entry_id,
+                    spec.stream,
+                    lease.owner,
+                    lease.generation,
+                    reason,
+                )
+                if self._on_lease_lost is not None:
+                    try:
+                        await self._on_lease_lost(entry_id, fields)
+                    except Exception:
+                        # A failure to stop the runner must not mask the loss
+                        # itself, which ``lease.lost`` has already recorded and
+                        # which the settle boundaries enforce on their own.
+                        spec.logger.exception(
+                            "lease-lost handler failed for entry %s on stream %s",
+                            entry_id,
+                            spec.stream,
+                        )
+                return
+            # Re-anchor in place so the holder always reads the freshest
+            # observation. The DEADLINE never moves: only the anchor does.
+            lease.budget = budget
+
+    async def _dead_letter_refusal(self, entry_id: str) -> str | None:
+        """Why this process may NOT dead-letter ``entry_id``, or None if it may.
+
+        ADR-0131 names dead-letter as one of the four verbs a fenced-out owner
+        loses: *"A stale owner that fails a renewal immediately loses authority
+        ... and may not ACK, dead-letter, clear an outbox record, or emit a
+        terminal result."* Dead-letter is a terminal settlement -- it ACKs the
+        delivery off the group and then deletes the lease and delivery state --
+        so an unfenced one lets a stale process settle a delivery that now
+        belongs to somebody else, and delete the CURRENT owner's keys on the way
+        out.
+
+        The two callers arrive from opposite sides of the fence, so the question
+        asked is different at each:
+
+        - **A handler path** (the unparseable/poison entry) is INSIDE
+          ``_delivery_lease`` and is registered in ``_held_leases``. The question
+          is whether our own lease is still ours: a heartbeat that failed while
+          the graveyard row was being prepared has already set ``lost``, and a
+          lost lease is authority we no longer have.
+        - **``_dead_letter_over_cap``** holds no lease -- it got here precisely
+          because ``_lease_is_live`` said nobody did. The question is whether
+          that is STILL true: a new owner may have acquired in the window since
+          that read, and its delivery must not be settled underneath it. The
+          re-read fails closed on an unreadable answer, like every other use.
+
+        With no lease store there is no fence to consult and nothing is ever
+        refused, so a consumer built without leases dead-letters exactly as it
+        did before ADR-0131.
+        """
+        if self._leases is None:
+            return None
+        held = self._held_leases.get(entry_id)
+        if held is not None:
+            if held.lost.is_set():
+                return (
+                    "this owner's delivery lease was lost mid-flight "
+                    f"(owner={held.owner}, generation={held.generation})"
+                )
+            return None
+        if await self._lease_is_live(entry_id):
+            return "another owner now holds the delivery lease"
+        return None
 
     async def _dead_letter(
         self,
@@ -230,6 +549,12 @@ class StreamConsumer:
         ``dl_`` -- so the metadata always wins AND the original is fully
         recoverable.
 
+        Fenced (ADR-0131): dead-letter is a terminal settlement, so it is gated on
+        this process still holding delivery authority. ``_dead_letter_refusal``
+        explains what that means for each caller; a refusal returns having
+        written nothing and acked nothing, leaving the entry pending for whoever
+        now owns it.
+
         XADD before XACK, deliberately: a crash between the two leaves the entry
         pending, so it is re-reclaimed and re-dead-lettered -- a duplicate
         graveyard row, which is strictly safer than the XACK-first ordering's
@@ -246,6 +571,33 @@ class StreamConsumer:
         node boundaries, so the stream is bounded at *at least* the configured
         length, not exactly it.
         """
+        attributes = {
+            "service.name": "curie-worker",
+            "source": self._spec.telemetry_source,
+        }
+        # The fence, asked as a PRECONDITION (ADR-0131; see
+        # ``_dead_letter_refusal``). Asked here rather than further down so a
+        # refusal costs nothing: no graveyard row is written for a delivery we
+        # are not going to settle, and the XADD-before-XACK ordering below is
+        # untouched -- this is a new gate in front of the sequence, not a
+        # reordering of it. Refusal returns rather than raising: losing the fence
+        # is the routine outcome of a peer taking over, and an exception would
+        # reach ``_consume``'s isolation guard as a per-entry stack trace.
+        refusal = await self._dead_letter_refusal(entry_id)
+        if refusal is not None:
+            self._spec.logger.warning(
+                "refusing to dead-letter entry %s on stream %s (%s); leaving it "
+                "pending for its current owner and touching no lease or state key",
+                entry_id,
+                self._spec.stream,
+                refusal,
+            )
+            record_metric(
+                "curie.queue.settle",
+                attributes={**attributes, "outcome": "pending"},
+            )
+            return
+
         target = self._spec.dead_letter_target
         # Escape the original's own ``dl_*`` keys (see above) so the metadata
         # written last always wins and the original stays recoverable.
@@ -260,10 +612,6 @@ class StreamConsumer:
                 "dl_dead_lettered_at": datetime.now(UTC).isoformat(),
             }
         )
-        attributes = {
-            "service.name": "curie-worker",
-            "source": self._spec.telemetry_source,
-        }
         error: Exception | None = None
         with operation_span(
             "curie.queue.dead-letter",
@@ -284,7 +632,27 @@ class StreamConsumer:
                     reason,
                     target,
                 )
+                # The XADD above is a round trip, so a heartbeat can fail while
+                # it is in flight. Re-read the fence immediately before the ACK
+                # to close that window -- but only the FREE in-process flag a
+                # held lease already carries, never a second Valkey read, so the
+                # ordering is unchanged and the maintenance path (which holds no
+                # lease) pays nothing. Fails closed by raising: the graveyard row
+                # is already written, so unlike the precondition above there is
+                # no clean early return left, and a duplicate row on the true
+                # owner's later dead-letter is the ordering's accepted cost.
+                held = self._held_leases.get(entry_id)
+                if held is not None:
+                    held.raise_if_lost()
                 await self._ack(entry_id)
+                # ADR-0131: delivery state is "removed after terminal
+                # acknowledgement or dead-letter settlement". After the ACK and
+                # inside the same try, and deliberately the RAISING settle rather
+                # than the best-effort one the post-ack handler paths use: here a
+                # settle failure must be caught by the handler below and reported
+                # as a failed dead-letter, not swallowed into a half-settled
+                # entry. The XADD-before-XACK ordering above is untouched.
+                await self._settle_delivery(entry_id)
             except Exception as exc:
                 error = exc
                 if hasattr(span, "set_status"):
@@ -361,6 +729,15 @@ class StreamConsumer:
                 # guard stays ahead of the cap check.
                 if entry_id in self._inflight_ids:
                     continue
+                # ADR-0131: "a live lease is checked before cap evaluation so a
+                # healthy long turn cannot be dead-lettered." This is the
+                # cross-replica sibling of the guard above -- that one protects
+                # our OWN in-flight entry, this one protects a peer's. It sits
+                # ahead of the cap check for the same reason: an entry somebody
+                # is actively working has not spent its budget on failures, and
+                # its count must not be judged.
+                if await self._lease_is_live(entry_id):
+                    continue
                 delivered = int(row["times_delivered"])
                 if delivered < self._spec.max_delivery:
                     continue
@@ -394,6 +771,13 @@ class StreamConsumer:
         group interaction is older than ``dead_consumer_idle_ms`` is gone, and
         its PEL can be taken without waiting the 15-minute entry window
         (#1532).
+
+        Since ADR-0131 this discovery is CANDIDATE DISCOVERY ONLY and is not
+        authority to steal a delivery. The ADR rejected process discovery as the
+        sole authority "because process discovery and retained runner lifetime
+        can diverge. Dead-consumer state remains a useful candidate signal
+        behind the lease fence." The fence itself is applied one level down, in
+        ``_claim_consumer_pending``.
         """
         try:
             consumers = await self._redis.xinfo_consumers(self._spec.stream, self._spec.group)
@@ -436,12 +820,18 @@ class StreamConsumer:
             )
             if not rows:
                 break
-            ids = [
-                str(row["message_id"])
-                for row in rows
-                if str(row["message_id"]) not in self._inflight_ids
-                and str(row["message_id"]) not in over_cap
-            ]
+            ids: list[str] = []
+            for row in rows:
+                candidate = str(row["message_id"])
+                if candidate in self._inflight_ids or candidate in over_cap:
+                    continue
+                # The dead peer's process may be gone while its delivery's lease
+                # is still live -- a replacement that already took it, or the
+                # peer's own last renewal not yet expired. A dead consumer is a
+                # candidate, never authority (see the docstring above).
+                if await self._lease_is_live(candidate):
+                    continue
+                ids.append(candidate)
             if ids:
                 claimed = await self._redis.xclaim(
                     self._spec.stream,
@@ -452,6 +842,11 @@ class StreamConsumer:
                 )
                 for entry_id, fields in cast("list[StreamEntry]", claimed or []):
                     if entry_id in self._inflight_ids or entry_id in over_cap:
+                        continue
+                    # Re-checked after the XCLAIM: the window between the filter
+                    # above and the claim is exactly long enough for a
+                    # replacement to acquire the lease.
+                    if await self._lease_is_live(entry_id):
                         continue
                     reclaimed += 1
                     await self._spec.handler(entry_id, dict(fields))
@@ -491,6 +886,30 @@ class StreamConsumer:
                     continue  # still being processed here; not an orphan
                 if entry_id in over_cap:
                     continue  # budget spent; never dispatch it again
+                # A live lease elsewhere: another owner is working it (ADR-0131).
+                # Note the ordering consequence -- XAUTOCLAIM has ALREADY claimed
+                # the entry to us by the time we see it here, which bumps the
+                # healthy peer's PEL delivery count. That is why the pre-cap
+                # check in ``_dead_letter_over_cap`` matters more than this one:
+                # this guard prevents the DISPATCH, that one prevents the
+                # DEAD-LETTER.
+                #
+                # The owner does NOT get the PEL row back. ``_HEARTBEAT_LUA``
+                # fails CLOSED: its guards run before any write, and a row that
+                # has moved to another consumer returns ``not-owner``, which the
+                # heartbeat loop reads as lease-lost. Its ``XCLAIM ... JUSTID``
+                # sits BEHIND that guard and only resets idle on a row the owner
+                # still holds; it is not a re-claim arm, and there must not be
+                # one -- an owner that stole its row back
+                # would be un-fencing itself against a replacement Valkey has
+                # legitimately handed the delivery to, which is the exact split
+                # brain ADR-0131 exists to prevent. So the cost of this
+                # XAUTOCLAIM is a bumped delivery count and, if the reclaimer is
+                # a different process, the healthy owner discovering on its next
+                # renewal that it has been fenced out. That is why the count is
+                # cap-checked BEFORE the claim rather than after.
+                if await self._lease_is_live(entry_id):
+                    continue
                 reclaimed += 1
                 record_metric(
                     "curie.queue.retry",

--- a/apps/worker/tests/binding/test_boot_env_single_declaration.py
+++ b/apps/worker/tests/binding/test_boot_env_single_declaration.py
@@ -256,6 +256,33 @@ _NON_BOOT_ALLOWLIST: frozenset[str] = frozenset(
         # its own env to pick the active harness, unset selects the built-in
         # Claude. Not a boot contract key.
         "CURIE_HARNESS",
+        # Delivery budget and ownership lease (ADR-0131, #1971), read from the
+        # WORKER's env by WorkerConfig. Never a sandbox boot key: they govern
+        # how the worker paces and reclaims its own delivery loop, not
+        # anything injected into a runner claim.
+        # - CURIE_DELIVERY_BUDGET_S: the overall wall-clock deadline for one
+        #   delivery (claim, every runner request, retries, reclaim, cleanup).
+        # - CURIE_DELIVERY_LEASE_TTL_S: how long the fenced ownership lease on
+        #   an in-flight delivery is valid before it is reclaimable.
+        # - CURIE_DELIVERY_LEASE_HEARTBEAT_S: how often the owner renews that
+        #   lease while the delivery is still healthy.
+        # - CURIE_DELIVERY_SHUTDOWN_RESERVE_S: time reserved near the budget's
+        #   end for terminal cleanup instead of another runner attempt.
+        # - CURIE_RECLAIM_INTERVAL_S: the maintenance-tick cadence that scans
+        #   for expired leases to reclaim; same reclaim family as
+        #   CURIE_RECLAIM_MIN_IDLE_MS in the code above, worker-side policy
+        #   decided before any sandbox exists.
+        "CURIE_DELIVERY_BUDGET_S",
+        "CURIE_DELIVERY_LEASE_TTL_S",
+        "CURIE_DELIVERY_LEASE_HEARTBEAT_S",
+        "CURIE_DELIVERY_SHUTDOWN_RESERVE_S",
+        "CURIE_RECLAIM_INTERVAL_S",
+        # The platform's voluntary termination grace (ADR-0131, #1971),
+        # injected by the chart from the SAME value it renders onto the Pod's
+        # ``terminationGracePeriodSeconds`` so the worker's own shutdown
+        # validator and the platform can never drift apart. Read from the
+        # WORKER's env by WorkerConfig; the sandbox never sees it.
+        "CURIE_TERMINATION_GRACE_PERIOD_S",
     }
 )
 

--- a/apps/worker/tests/conftest.py
+++ b/apps/worker/tests/conftest.py
@@ -1,0 +1,51 @@
+"""Shared per-test Valkey fixtures for the worker test suite.
+
+``sync_redis`` and ``names`` are used by ``tests/kernel`` (via
+``kernel/conftest.py``'s ``make_harness``) and by ``tests/test_delivery_lease.py``,
+which drives the lease store directly against the same real Valkey without a
+full kernel harness. Living here at the package root makes pytest resolve ONE
+definition for both -- and for anything else under ``tests/`` that wants a
+throwaway, collision-free Valkey namespace -- rather than two copies that can
+quietly diverge, which is exactly what had already happened between them.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+
+import pytest
+import redis
+from curie_test_support.valkey import connect_or_skip
+
+
+@pytest.fixture
+def sync_redis() -> Iterator[redis.Redis]:
+    client = connect_or_skip(decode_responses=True)
+    yield client
+    client.close()
+
+
+@pytest.fixture
+def names(sync_redis: redis.Redis) -> Iterator[dict[str, str]]:
+    """Per-test-unique stream / group / key prefixes on the shared Valkey.
+
+    ``sandbox_prefix`` is written to by the kernel harness's sandbox substrate
+    (its affinity store); ``test_delivery_lease.py`` never creates keys under
+    it, so cleaning that pattern there is simply a no-op scan rather than a
+    narrower override. The glob list below is the union of the two formerly
+    separate copies, not a pick between them -- a dropped glob here silently
+    leaks Valkey keys between tests.
+    """
+    token = uuid.uuid4().hex
+    ns = {
+        "stream": f"test:curie:runs:{token}",
+        "group": f"g-{token}",
+        "prefix": f"test:curie:worker:{token}",
+        "sandbox_prefix": f"test:curie:sandbox:{token}",
+    }
+    yield ns
+    for pat in (f"{ns['prefix']}*", f"{ns['sandbox_prefix']}*", ns["stream"]):
+        keys = list(sync_redis.scan_iter(match=pat))
+        if keys:
+            sync_redis.delete(*keys)

--- a/apps/worker/tests/eval/test_stream.py
+++ b/apps/worker/tests/eval/test_stream.py
@@ -62,7 +62,7 @@ from curie_worker.eval import (
 from curie_worker.eval import stream as eval_stream_module
 from curie_worker.eval.models import EvalCaseResult, EvalOutcome, EvalRunResult
 from curie_worker.sandbox import AffinityStore, SandboxSubstrate, SubstrateConfig
-from curie_worker.sandbox.types import ClaimView, SandboxView
+from curie_worker.sandbox.types import ClaimView, SandboxError, SandboxView
 from opentelemetry import trace
 from redis.asyncio import Redis as AsyncRedis
 
@@ -2301,5 +2301,964 @@ def test_stream_records_the_trigger_identity_and_selected_trajectory_scorer(
 
             await client.delete(cfg.eval_stream)
             await client.aclose()
+
+    asyncio.run(go())
+
+
+# --- ADR-0131 (#1971): the eval lane's own delivery-ownership coverage --------
+#
+# "Runs and evals must share the lease implementation by construction. A fix on
+# only one consumer lane is incomplete." These are the eval-lane twins of R1-R5
+# in ``tests/kernel/test_delivery_ownership.py``, and they are deliberately NOT
+# a shared parametrized body with the runs lane: the two lanes have genuinely
+# different handler shapes -- the runs lane spawns ``_handle`` as a task behind a
+# semaphore, the eval lane awaits ``_handle_entry`` INLINE inside ``_consume`` --
+# and one shared body would hide exactly the difference that matters. Each twin
+# carries its own negative control.
+#
+# Valkey is real, as everywhere in this file. What IS substituted is
+# ``_run_and_report``: these twins are about the lease lifecycle the shared base
+# owns (acquire, refuse, renew, fence the ACK, skip the cap), not about suite
+# execution, which the rest of this file already drives end-to-end against real
+# RustFS and real Langfuse. Substituting the suite run keeps the in-flight window
+# under the test's control and leaves the whole of ``_handle_entry`` -- the body
+# the lease wraps -- under test.
+#
+# Time is compressed by CONFIGURING short lease clocks, never by patching a
+# clock: TTL (1.0) >= 3 * heartbeat (0.3), reclaim interval (0.05) < TTL, runner
+# ceiling (30) <= budget (60, its configurable floor). The Valkey server ``TIME``
+# read behind the deadline is never stubbed.
+
+_EVAL_TTL_S = 1.0
+
+
+def _lease_cfg(token: str, **overrides: object) -> WorkerConfig:
+    base: dict[str, object] = {
+        "key_prefix": f"test:curie:worker:{token}",
+        "delivery_budget_s": 60.0,
+        "delivery_lease_ttl_s": _EVAL_TTL_S,
+        "delivery_lease_heartbeat_s": 0.3,
+        "reclaim_interval_s": 0.05,
+        "runner_total_timeout_s": 30.0,
+    }
+    base.update(overrides)
+    return _cfg(f"test:evals:{token}", f"g-{token}", **base)
+
+
+def _lease_result(entry_id: str) -> EvalRunResult:
+    return EvalRunResult(
+        version="v1",
+        suite="lease",
+        stream_id=entry_id,
+        results=[
+            EvalCaseResult(
+                case_id="1", outcome=EvalOutcome.PASS, output="ok", latency_ms=1.0
+            )
+        ],
+    )
+
+
+class _HeldSuiteRun:
+    """A suite run the test starts, holds open, and releases on demand."""
+
+    def __init__(self) -> None:
+        self.started = asyncio.Event()
+        self.hold = asyncio.Event()
+        self.runs: list[str] = []
+
+    async def __call__(self, _item: EvalJob, stream_id: str) -> EvalRunResult:
+        self.runs.append(stream_id)
+        self.started.set()
+        await self.hold.wait()
+        return _lease_result(stream_id)
+
+
+async def _instant_suite_run(_item: EvalJob, stream_id: str) -> EvalRunResult:
+    return _lease_result(stream_id)
+
+
+def _lease_consumer(
+    *, redis_client: AsyncRedis, cfg: WorkerConfig, leases: Any, suite_run: Any
+) -> EvalStreamConsumer:
+    consumer = EvalStreamConsumer(
+        redis=redis_client,
+        config=cfg,
+        bundle_store=cast("Any", None),
+        substrate=_UnusedSubstrate(),
+        reporter=cast("Any", None),
+        recorder=cast("Any", None),
+        repo_lookup=_StubRepo(),
+        leases=leases,
+    )
+    consumer._run_and_report = suite_run  # type: ignore[method-assign,assignment]
+    return consumer
+
+
+async def _eval_payload(client: AsyncRedis, cfg: WorkerConfig, *, sha: str) -> str:
+    item = _item(suite="lease", sha=sha, bundle_ref="unused", target_url="http://unused")
+    return await client.xadd(cfg.eval_stream, {STREAM_PAYLOAD_FIELD: item.model_dump_json()})
+
+
+async def _eval_read_one(
+    client: AsyncRedis, cfg: WorkerConfig, consumer_name: str
+) -> tuple[str, dict[str, str]]:
+    rows = await client.xreadgroup(
+        cfg.eval_consumer_group, consumer_name, {cfg.eval_stream: ">"}, count=1
+    )
+    assert rows, "expected an eval entry to read"
+    entry_id, fields = rows[0][1][0]
+    return entry_id, dict(fields)
+
+
+async def _eval_pending(client: AsyncRedis, cfg: WorkerConfig) -> dict[str, int]:
+    rows = await client.xpending_range(
+        cfg.eval_stream, cfg.eval_consumer_group, min="-", max="+", count=50
+    )
+    return {row["message_id"]: int(row["times_delivered"]) for row in rows}
+
+
+async def _eval_cleanup(client: AsyncRedis, cfg: WorkerConfig) -> None:
+    await client.delete(cfg.eval_stream, cfg.eval_dead_letter_stream_name())
+    keys = [key async for key in client.scan_iter(match=f"{cfg.key_prefix}*")]
+    if keys:
+        await client.delete(*keys)
+    await client.aclose()
+
+
+def test_eval_a_second_replica_is_refused_while_the_first_holds_a_live_lease() -> None:
+    """R1's eval twin. Two eval consumers, one entry, one suite run.
+
+    Red on revert of the ``async with self._delivery_lease(...)`` wrapper in
+    ``EvalStreamConsumer._handle_entry``: both replicas run the suite and the
+    platform receives two reports for one job. The refused replica returns
+    WITHOUT acking, so the entry stays pending for the true owner.
+
+    The positive control is the second entry, delivered to the very same refused
+    consumer and carried to an ACK.
+    """
+    from curie_worker.delivery_lease import DeliveryLeaseStore
+
+    async def go() -> None:
+        token = uuid.uuid4().hex[:8]
+        cfg = _lease_cfg(token)
+        cfg_a = cfg.model_copy(update={"eval_consumer_name": "eval-a"})
+        cfg_b = cfg.model_copy(update={"eval_consumer_name": "eval-b"})
+        client = AsyncRedis(host=_VH, port=_VP, password=_VPW, decode_responses=True)
+        store = DeliveryLeaseStore(client, cfg)
+        held = _HeldSuiteRun()
+        consumer_a = _lease_consumer(
+            redis_client=client, cfg=cfg_a, leases=store, suite_run=held
+        )
+        consumer_b = _lease_consumer(
+            redis_client=client, cfg=cfg_b, leases=store, suite_run=_instant_suite_run
+        )
+        await consumer_a.ensure_group()
+
+        await _eval_payload(client, cfg, sha=f"sha-{token}")
+        entry_id, fields = await _eval_read_one(client, cfg, "eval-a")
+        task = asyncio.create_task(consumer_a._handle(entry_id, fields))
+        await _wait_until(held.started.is_set)
+        assert await store.is_live(cfg.eval_stream, cfg.eval_consumer_group, entry_id)
+
+        # B takes the PEL row exactly as XAUTOCLAIM does on the reclaim path.
+        await client.xclaim(cfg.eval_stream, cfg.eval_consumer_group, "eval-b", 0, [entry_id])
+        await consumer_b._handle(entry_id, dict(fields))
+
+        assert held.runs == [entry_id], "the refused replica ran the suite a second time"
+        assert entry_id in await _eval_pending(client, cfg), "the refused replica acked"
+
+        # POSITIVE CONTROL: an entry B legitimately owns runs and acks.
+        second_id = await _eval_payload(client, cfg, sha=f"sha2-{token}")
+        entry_b, fields_b = await _eval_read_one(client, cfg, "eval-b")
+        assert entry_b == second_id
+        await consumer_b._handle(entry_b, fields_b)
+        assert entry_b not in await _eval_pending(client, cfg)
+
+        held.hold.set()
+        await task
+        await _eval_cleanup(client, cfg)
+
+    asyncio.run(go())
+
+
+def test_eval_a_running_suite_holds_its_lease_without_burning_a_delivery() -> None:
+    """R2's eval twin: the heartbeat renews across several TTLs, and the
+    same-owner ``XCLAIM ... JUSTID`` does not bump ``times_delivered``.
+
+    Red on dropping the background heartbeat (a long suite's lease expires
+    mid-run and a peer takes it) and, independently, on dropping ``JUSTID`` (each
+    beat burns one of the ADR-0039 delivery budget's five, dead-lettering a
+    healthy suite in under a minute).
+
+    The negative control is the sibling entry leased directly and never renewed:
+    it expires inside the same window.
+    """
+    from curie_worker.delivery_lease import DeliveryLeaseStore
+
+    async def go() -> None:
+        token = uuid.uuid4().hex[:8]
+        cfg = _lease_cfg(token)
+        client = AsyncRedis(host=_VH, port=_VP, password=_VPW, decode_responses=True)
+        store = DeliveryLeaseStore(client, cfg)
+        held = _HeldSuiteRun()
+        consumer = _lease_consumer(
+            redis_client=client, cfg=cfg, leases=store, suite_run=held
+        )
+        await consumer.ensure_group()
+
+        await _eval_payload(client, cfg, sha=f"sha-{token}")
+        await _eval_payload(client, cfg, sha=f"sib-{token}")
+        renewed_id, renewed_fields = await _eval_read_one(client, cfg, cfg.eval_consumer_name)
+        abandoned_id, _fields = await _eval_read_one(client, cfg, cfg.eval_consumer_name)
+        await store.acquire(
+            cfg.eval_stream,
+            cfg.eval_consumer_group,
+            abandoned_id,
+            consumer=cfg.eval_consumer_name,
+        )
+
+        before = (await _eval_pending(client, cfg))[renewed_id]
+        task = asyncio.create_task(consumer._handle(renewed_id, renewed_fields))
+        await _wait_until(held.started.is_set)
+
+        deadline = time.monotonic() + 3.0
+        while time.monotonic() < deadline:
+            assert await store.is_live(
+                cfg.eval_stream, cfg.eval_consumer_group, renewed_id
+            ), "a running eval lost its lease: the heartbeat is not renewing"
+            await asyncio.sleep(0.1)
+
+        assert (
+            await store.is_live(cfg.eval_stream, cfg.eval_consumer_group, abandoned_id) is False
+        ), "the un-renewed sibling never expired, so the survival above is vacuous"
+        after = (await _eval_pending(client, cfg))[renewed_id]
+        assert after == before, (
+            "the same-owner XCLAIM must use JUSTID: it reset PEL idle but "
+            f"burned {after - before} deliveries of the ADR-0039 budget"
+        )
+
+        held.hold.set()
+        await task
+        assert renewed_id not in await _eval_pending(client, cfg)
+        await _eval_cleanup(client, cfg)
+
+    asyncio.run(go())
+
+
+def test_eval_a_dead_owners_entry_transfers_only_after_expiry() -> None:
+    """R3's eval twin: force-kill recovery on the eval lane.
+
+    The dead owner's lease is taken through the store and abandoned, because a
+    SIGKILLed process runs no ``finally`` -- cancelling a task would exercise the
+    graceful release instead and prove nothing about expiry.
+
+    Red on removing the expiry gate (the replacement runs the suite immediately,
+    beside one the killed pod may still have live) and on turning the
+    ``HSETNX`` on ``deadline_ms`` into an ``HSET`` (the replacement gets a fresh
+    budget). Refused before expiry, granted after it: both halves asserted.
+    """
+    from curie_worker.delivery_lease import DeliveryLeaseStore
+
+    async def go() -> None:
+        token = uuid.uuid4().hex[:8]
+        cfg = _lease_cfg(token)
+        client = AsyncRedis(host=_VH, port=_VP, password=_VPW, decode_responses=True)
+        store = DeliveryLeaseStore(client, cfg)
+        held = _HeldSuiteRun()
+        consumer = _lease_consumer(
+            redis_client=client, cfg=cfg, leases=store, suite_run=held
+        )
+        await consumer.ensure_group()
+
+        await _eval_payload(client, cfg, sha=f"sha-{token}")
+        entry_id, fields = await _eval_read_one(client, cfg, "dead-eval-worker")
+        dead = await store.acquire(
+            cfg.eval_stream, cfg.eval_consumer_group, entry_id, consumer="dead-eval-worker"
+        )
+        assert dead.generation == 1
+        await client.xclaim(
+            cfg.eval_stream, cfg.eval_consumer_group, cfg.eval_consumer_name, 0, [entry_id]
+        )
+
+        await consumer._handle(entry_id, dict(fields))
+        assert held.runs == [], "a replacement ran an eval whose lease was still live"
+        assert entry_id in await _eval_pending(client, cfg)
+
+        await asyncio.sleep(_EVAL_TTL_S + 0.4)
+        assert await store.is_live(cfg.eval_stream, cfg.eval_consumer_group, entry_id) is False
+
+        task = asyncio.create_task(consumer._handle(entry_id, dict(fields)))
+        await _wait_until(held.started.is_set)
+        state = await store.peek(cfg.eval_stream, cfg.eval_consumer_group, entry_id)
+        assert state["gen"] == "2", "the fencing generation did not increment on transfer"
+        assert int(state["deadline_ms"]) == dead.budget.deadline_ms, (
+            "the replacement minted a FRESH deadline: reclaim multiplied the budget"
+        )
+
+        held.hold.set()
+        await task
+        assert held.runs == [entry_id]
+        assert entry_id not in await _eval_pending(client, cfg)
+        await _eval_cleanup(client, cfg)
+
+    asyncio.run(go())
+
+
+def test_eval_a_live_lease_holds_off_the_delivery_cap() -> None:
+    """R4's eval twin: "a live lease is checked before cap evaluation".
+
+    The eval lane runs its own delivery cap into its own graveyard, so the guard
+    has to be proven here too and not inferred from the runs lane. The entry is
+    driven to the cap while a peer holds a LIVE lease; ``_inflight_ids`` is
+    asserted empty so only the new cross-replica check can explain the skip.
+
+    Red on reverting the ``is_live`` guard in ``_dead_letter_over_cap``: a
+    healthy long eval is dead-lettered mid-run and reported as poison. The
+    positive control is the second pass, after the lease is released.
+    """
+    from curie_worker.delivery_lease import DeliveryLeaseStore
+
+    async def go() -> None:
+        token = uuid.uuid4().hex[:8]
+        cfg = _lease_cfg(token, max_delivery=2, reclaim_min_idle_ms=0)
+        client = AsyncRedis(host=_VH, port=_VP, password=_VPW, decode_responses=True)
+        store = DeliveryLeaseStore(client, cfg)
+        consumer = _lease_consumer(
+            redis_client=client, cfg=cfg, leases=store, suite_run=_instant_suite_run
+        )
+        await consumer.ensure_group()
+
+        await _eval_payload(client, cfg, sha=f"sha-{token}")
+        entry_id, _fields = await _eval_read_one(client, cfg, "peer-eval")
+        await client.xclaim(
+            cfg.eval_stream, cfg.eval_consumer_group, "peer-eval", 0, [entry_id]
+        )
+        assert (await _eval_pending(client, cfg))[entry_id] >= cfg.max_delivery
+
+        lease = await store.acquire(
+            cfg.eval_stream, cfg.eval_consumer_group, entry_id, consumer="peer-eval"
+        )
+        assert consumer._inflight_ids == set(), (
+            "the in-flight guard would mask the lease guard under test"
+        )
+
+        assert await consumer._dead_letter_over_cap() == set()
+        assert await client.xrange(cfg.eval_dead_letter_stream_name()) == [], (
+            "a healthy long eval was dead-lettered"
+        )
+        assert entry_id in await _eval_pending(client, cfg)
+
+        # POSITIVE CONTROL: released, the same entry at the same count is
+        # dead-lettered on the next pass.
+        assert (
+            await store.release(
+                cfg.eval_stream, cfg.eval_consumer_group, entry_id, owner=lease.owner
+            )
+            is True
+        )
+        assert await consumer._dead_letter_over_cap() == {entry_id}
+        rows = await client.xrange(cfg.eval_dead_letter_stream_name())
+        assert len(rows) == 1
+        assert rows[0][1]["dl_original_id"] == entry_id
+        assert entry_id not in await _eval_pending(client, cfg)
+        await _eval_cleanup(client, cfg)
+
+    asyncio.run(go())
+
+
+def test_eval_request_stop_stops_the_read_loop_but_never_the_heartbeat() -> None:
+    """R5's eval twin: the voluntary-rollout drain.
+
+    ``request_stop()`` must stop the read loop taking NEW entries while the
+    in-flight suite keeps renewing its lease and runs to completion. Red on
+    reverting the "the heartbeat sleeps with a plain ``asyncio.sleep``, never
+    ``self._sleep_or_stop``" decision, which would drop every in-flight lease the
+    instant SIGTERM landed.
+
+    The eval lane drains by construction rather than through a post-gather
+    ``_inflight`` wait (its handler is awaited INLINE inside ``_consume``), which
+    is exactly why this twin exists instead of a shared body with the runs lane.
+
+    The negative control is the sibling lease that is never renewed: it expires
+    across the same post-stop window.
+    """
+    from curie_worker.delivery_lease import DeliveryLeaseStore
+
+    async def go() -> None:
+        token = uuid.uuid4().hex[:8]
+        cfg = _lease_cfg(token)
+        client = AsyncRedis(host=_VH, port=_VP, password=_VPW, decode_responses=True)
+        store = DeliveryLeaseStore(client, cfg)
+        held = _HeldSuiteRun()
+        consumer = _lease_consumer(
+            redis_client=client, cfg=cfg, leases=store, suite_run=held
+        )
+        await consumer.ensure_group()
+
+        await _eval_payload(client, cfg, sha=f"sha-{token}")
+        task = asyncio.create_task(consumer.run())
+        await _wait_until(held.started.is_set)
+        entry_id = held.runs[0]
+
+        await _eval_payload(client, cfg, sha=f"sib-{token}")
+        sibling_id, _fields = await _eval_read_one(client, cfg, cfg.eval_consumer_name)
+        await store.acquire(
+            cfg.eval_stream,
+            cfg.eval_consumer_group,
+            sibling_id,
+            consumer=cfg.eval_consumer_name,
+        )
+
+        consumer.request_stop()
+        late_id = await _eval_payload(client, cfg, sha=f"late-{token}")
+
+        deadline = time.monotonic() + 3.0
+        while time.monotonic() < deadline:
+            assert await store.is_live(
+                cfg.eval_stream, cfg.eval_consumer_group, entry_id
+            ), "request_stop() dropped the in-flight lease: the drain cannot finish"
+            await asyncio.sleep(0.1)
+
+        assert (
+            await store.is_live(cfg.eval_stream, cfg.eval_consumer_group, sibling_id) is False
+        ), "the un-renewed sibling never expired, so the survival above is vacuous"
+        assert held.runs == [entry_id], "the read loop took a new entry after request_stop()"
+        assert late_id not in await _eval_pending(client, cfg)
+
+        held.hold.set()
+        await asyncio.wait_for(task, timeout=10.0)
+        assert entry_id not in await _eval_pending(client, cfg), (
+            "the drained eval never acked"
+        )
+        await _eval_cleanup(client, cfg)
+
+    asyncio.run(go())
+
+
+# --- ADR-0131 (#1971): the two defects review found on THIS lane ---------------
+#
+# Both were found after the twins above were written, and neither is pinned by
+# them, because both live below the lease LIFECYCLE the twins cover:
+#
+#   1. ``_report`` resolved the fence from ``result.stream_id``. The two
+#      failure DTOs built by ``_report_failed`` carry no run, so that field is
+#      ``None`` on exactly the Valkey/K8s-adjacent failures most likely to
+#      coincide with a lease loss -- the lookup missed, and a missing lease read
+#      as "no fence" is a fence that FAILS OPEN.
+#   2. The lane acquired a lease and never read its remaining budget, so a suite
+#      outran the delivery's one deadline while the heartbeat renewed forever.
+#
+# Valkey stays real. What is substituted is the RustFS bundle fetch, the
+# substrate, and (for the deadline tests) ``run_eval_suite`` at the module seam
+# -- the same seams ``_canned_run`` and ``_fake_job_consumer`` already hold still
+# so the report gate itself is what is under test.
+
+
+class _ProvisioningFailureSubstrate:
+    """A substrate whose ``claim`` fails the way a cluster out of capacity does.
+
+    ``_acquire_target`` catches ``SandboxError`` and answers ``(None, None,
+    None)``, which is the "runner provisioning failed" path. ``release`` records
+    so a test can prove the un-provisioned path frees nothing.
+    """
+
+    def __init__(self) -> None:
+        self.released: list[str] = []
+
+    def claim(self, _key: str, **_kwargs: object) -> Any:
+        raise SandboxError("no capacity for an eval sandbox")
+
+    def release(self, key: str) -> None:  # pragma: no cover - must not be reached
+        self.released.append(key)
+
+
+def _fence_suite() -> EvalSuite:
+    return EvalSuite(
+        name="fence",
+        cases=[EvalCase(id="1", input="q", grader=Grader(kind=CONTAINS, expected="ok"))],
+    )
+
+
+# The two ``_run_and_report`` failure paths whose ``EvalRunResult`` has no run
+# behind it, so ``result.stream_id`` is None and the reverted fence missed.
+_FENCED_FAILURE_PATHS = ("unresolvable-bundle", "provisioning-failed")
+
+
+def _failure_path_wiring(path: str) -> tuple[Any, Any, EvalJob]:
+    """Bundle store, substrate, and job that drive ``_run_and_report`` down one
+    of the two failure paths for real (no monkeypatching of the lane itself)."""
+    if path == "unresolvable-bundle":
+        # Not a readable archive: ``_extract_eval_files`` raises, ``_load_suite``
+        # answers None, and the lane reports "unresolvable suite/bundle".
+        return (
+            _FakeBundleStore(b"this is not a tar.gz"),
+            _UnusedSubstrate(),
+            _item(
+                suite="fence",
+                sha="sha-unresolvable",
+                bundle_ref="bundles/corrupt.tgz",
+                target_url="http://unused",
+            ),
+        )
+    # A loadable suite, but no ``target_url``: the lane provisions, the substrate
+    # refuses, and it reports "runner provisioning failed".
+    return (
+        _FakeBundleStore(_suite_bundle(_fence_suite())),
+        _ProvisioningFailureSubstrate(),
+        _item(
+            suite="fence",
+            sha="sha-provisioning",
+            bundle_ref="bundles/ok.tgz",
+            target_url=None,
+        ),
+    )
+
+
+def _fence_consumer(
+    *,
+    redis_client: AsyncRedis | None,
+    cfg: WorkerConfig,
+    leases: Any,
+    bundle_store: Any,
+    substrate: Any,
+    reporter: Any,
+) -> EvalStreamConsumer:
+    return _consumer(
+        cfg,
+        redis=redis_client,
+        leases=leases,
+        bundle_store=bundle_store,
+        substrate=substrate,
+        reporter=reporter,
+        repo_lookup=_StubRepo(),
+    )
+
+
+@pytest.mark.parametrize("failure_path", _FENCED_FAILURE_PATHS)
+def test_eval_a_fenced_out_owner_publishes_no_report_on_a_failure_path(
+    failure_path: str,
+) -> None:
+    """Defect 1. A lost lease must suppress the report on the FAILURE paths too.
+
+    Red on the exact pre-fix shape: ``_report`` resolving its lease from
+    ``result.stream_id`` instead of the ``stream_id`` ARGUMENT, with no
+    fail-closed branch behind it. ``_report_failed`` builds an ``EvalRunResult``
+    that never populates that field, so the lookup misses, absence reads as "no
+    fence", and a fenced-out owner publishes a report for a job a replacement now
+    owns. Reverting ONLY the lookup is caught as well, by the positive control:
+    the healthy owner's lease misses the same way and the failure paths stop
+    reporting at all. Also red on deleting the ``lease.lost.is_set()`` guard.
+
+    The lease is a REAL one from the real store, fenced out by setting ``lost``
+    exactly as ``_heartbeat_lease`` does when Valkey refuses a renewal.
+
+    The positive control is the second delivery, driven down the SAME failure
+    path with a healthy lease: without it this test would pass even if reporting
+    were broken entirely.
+    """
+    from curie_worker.delivery_lease import DeliveryLeaseStore
+
+    async def go() -> None:
+        token = uuid.uuid4().hex[:8]
+        cfg = _lease_cfg(token)
+        client = AsyncRedis(host=_VH, port=_VP, password=_VPW, decode_responses=True)
+        store = DeliveryLeaseStore(client, cfg)
+        bundle_store, substrate, item = _failure_path_wiring(failure_path)
+        reporter = _FakeReporter()
+        consumer = _fence_consumer(
+            redis_client=client,
+            cfg=cfg,
+            leases=store,
+            bundle_store=bundle_store,
+            substrate=substrate,
+            reporter=reporter,
+        )
+        await consumer.ensure_group()
+
+        # Two real pending deliveries, so the store grants two real leases. The
+        # EvalJob is handed to ``_run_and_report`` directly -- the stream entries
+        # exist to make the lease real, not to carry the payload.
+        await _eval_payload(client, cfg, sha=f"lost-{token}")
+        await _eval_payload(client, cfg, sha=f"live-{token}")
+        lost_id, _lost_fields = await _eval_read_one(client, cfg, cfg.eval_consumer_name)
+        live_id, _live_fields = await _eval_read_one(client, cfg, cfg.eval_consumer_name)
+
+        lost_lease = await store.acquire(
+            cfg.eval_stream, cfg.eval_consumer_group, lost_id, consumer=cfg.eval_consumer_name
+        )
+        lost_lease.lost.set()
+        consumer._held_leases[lost_id] = lost_lease
+
+        fenced = await consumer._run_and_report(item, lost_id)
+
+        assert fenced.stream_id is None, (
+            "the failure DTO must still carry NO stream_id: if it ever gained one "
+            "the reverted lookup would resolve by luck and this test would stop "
+            "pinning the fail-open"
+        )
+        assert reporter.reports == [], (
+            f"a fenced-out owner published a report on the {failure_path} path: "
+            "the fence failed open on exactly the failure most likely to coincide "
+            "with a lease loss"
+        )
+        if isinstance(substrate, _ProvisioningFailureSubstrate):
+            assert substrate.released == [], "nothing was provisioned, so nothing frees"
+
+        # POSITIVE CONTROL: the same failure path, same consumer, same job -- with
+        # a lease this owner still holds -- publishes exactly one report.
+        live_lease = await store.acquire(
+            cfg.eval_stream, cfg.eval_consumer_group, live_id, consumer=cfg.eval_consumer_name
+        )
+        assert not live_lease.lost.is_set()
+        consumer._held_leases[live_id] = live_lease
+
+        await consumer._run_and_report(item, live_id)
+
+        assert len(reporter.reports) == 1, (
+            "the healthy owner published no report, so the suppression above is "
+            "vacuous -- reporting is broken on this path regardless of the fence"
+        )
+        published = reporter.reports[0]
+        assert published.sha == item.sha
+        assert published.repo_full_name == "owner/repo"
+        # The failure DTO reports 0/0: a real red, not a skipped all-plumbing run.
+        assert (published.passed_count, published.total) == (0, 0)
+
+        await _eval_cleanup(client, cfg)
+
+    asyncio.run(go())
+
+
+@pytest.mark.parametrize("failure_path", _FENCED_FAILURE_PATHS)
+def test_eval_report_fails_closed_when_a_fenced_lane_records_no_lease(
+    failure_path: str,
+) -> None:
+    """Defect 1's other half: absence of a lease is NOT permission.
+
+    On a lane wired with a lease store, an entry with no recorded lease means
+    this owner cannot prove it still holds authority, so it must not publish.
+    Red on deleting the ``if lease is None and self._leases is not None: return``
+    branch in ``_report`` -- the branch that turns the reverted lookup's miss
+    from a fail-open into a refusal.
+
+    The positive control is the leaseless lane (no lease store at all, the
+    base-only degradation ``unfenced_lease`` exists for), which must still
+    publish: without it, "return early always" would pass this test.
+    """
+    from curie_worker.delivery_lease import DeliveryLeaseStore
+
+    async def go() -> None:
+        token = uuid.uuid4().hex[:8]
+        cfg = _lease_cfg(token)
+        client = AsyncRedis(host=_VH, port=_VP, password=_VPW, decode_responses=True)
+        store = DeliveryLeaseStore(client, cfg)
+
+        bundle_store, substrate, item = _failure_path_wiring(failure_path)
+        fenced_reporter = _FakeReporter()
+        fenced = _fence_consumer(
+            redis_client=client,
+            cfg=cfg,
+            leases=store,
+            bundle_store=bundle_store,
+            substrate=substrate,
+            reporter=fenced_reporter,
+        )
+        assert fenced._held_leases == {}, "the entry must have NO recorded lease"
+
+        await fenced._run_and_report(item, "9999-0")
+
+        assert fenced_reporter.reports == [], (
+            "a fenced lane published without being able to name its lease; "
+            "absence was read as authority"
+        )
+
+        # POSITIVE CONTROL: the same job on a lane built with NO lease store still
+        # publishes -- the pre-ADR-0131 degradation must be preserved, not broken
+        # by the fail-closed branch above.
+        base_bundle, base_substrate, base_item = _failure_path_wiring(failure_path)
+        base_reporter = _FakeReporter()
+        unfenced = _fence_consumer(
+            redis_client=client,
+            cfg=cfg,
+            leases=None,
+            bundle_store=base_bundle,
+            substrate=base_substrate,
+            reporter=base_reporter,
+        )
+        assert unfenced._leases is None
+
+        await unfenced._run_and_report(base_item, "9999-0")
+
+        assert len(base_reporter.reports) == 1, (
+            "the leaseless lane stopped reporting: the fail-closed branch caught "
+            "the base-only degradation it was never meant to touch"
+        )
+        assert base_reporter.reports[0].sha == base_item.sha
+
+        await _eval_cleanup(client, cfg)
+
+    asyncio.run(go())
+
+
+class _TimedSuiteRun:
+    """A ``run_eval_suite`` stand-in that takes a known amount of wall time.
+
+    Substituted at the module seam exactly as ``_canned_run`` does: the deadline
+    the lease carries is what is under test here, not suite execution, which the
+    rest of this file drives end-to-end against a real runner.
+    """
+
+    def __init__(self, duration_s: float) -> None:
+        self._duration_s = duration_s
+        self.started = asyncio.Event()
+        self.completed = asyncio.Event()
+
+    async def __call__(
+        self,
+        suite: EvalSuite,
+        *,
+        version: str,
+        stream_id: str | None = None,
+        **_kwargs: Any,
+    ) -> EvalRunResult:
+        self.started.set()
+        await asyncio.sleep(self._duration_s)
+        self.completed.set()
+        return EvalRunResult(
+            version=version,
+            suite=suite.name,
+            stream_id=stream_id,
+            results=[
+                EvalCaseResult(case_id="1", outcome=EvalOutcome.PASS, output="ok", latency_ms=1.0)
+            ],
+        )
+
+
+def test_eval_a_suite_is_cut_short_at_the_deliverys_remaining_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Defect 2: ADR-0131's ONE deadline must bound an eval suite.
+
+    Red on reverting ``_run_and_report``'s ``deadline_s =
+    self._remaining_budget_s(stream_id)`` / ``async with
+    asyncio.timeout(deadline_s)`` wrapper: the lane acquires a lease, the shared
+    heartbeat renews it indefinitely, and the suite runs to completion long past
+    the budget -- a deadline that exists in Valkey and is enforced nowhere.
+
+    Time is NOT compressed by patching a clock. ``delivery_budget_s`` has a
+    configurable floor of 60s and ``runner_total_timeout_s`` may not exceed it,
+    so a config-only harness could only build a 60-second test. Instead the store
+    grants a REAL lease -- real Valkey server ``TIME`` anchor, real monotonic
+    arithmetic -- and only its ``deadline_ms`` is moved in, which is precisely
+    the "construct a lease with a short remaining budget" lever. No validator is
+    weakened and ``time.monotonic``/``TIME`` are untouched.
+
+    Three legs: cut short and reported; cut short while FENCED OUT and therefore
+    silent (the two defects overlapping, since "delivery deadline exceeded" is
+    the third stream_id-less failure DTO); and the positive control, an ample
+    budget under which the very same suite completes and is reported -- without
+    which this would pass if the suite never ran at all.
+    """
+    from curie_worker.delivery_lease import DeliveryBudget, DeliveryLeaseStore
+
+    async def go() -> None:
+        token = uuid.uuid4().hex[:8]
+        cfg = _lease_cfg(token)
+        client = AsyncRedis(host=_VH, port=_VP, password=_VPW, decode_responses=True)
+        store = DeliveryLeaseStore(client, cfg)
+        substrate = _TokenSubstrate("tok")
+        reporter = _FakeReporter()
+        consumer = _fence_consumer(
+            redis_client=client,
+            cfg=cfg,
+            leases=store,
+            bundle_store=_FakeBundleStore(_suite_bundle(_fence_suite())),
+            substrate=substrate,
+            reporter=reporter,
+        )
+        await consumer.ensure_group()
+
+        item = _item(
+            suite="fence", sha=f"sha-{token}", bundle_ref="bundles/ok.tgz", target_url=None
+        )
+
+        async def lease_with_remaining(entry_id: str, remaining_ms: int | None) -> Any:
+            lease = await store.acquire(
+                cfg.eval_stream,
+                cfg.eval_consumer_group,
+                entry_id,
+                consumer=cfg.eval_consumer_name,
+            )
+            if remaining_ms is not None:
+                lease.budget = DeliveryBudget(
+                    deadline_ms=lease.budget.anchor_server_ms + remaining_ms,
+                    anchor_server_ms=lease.budget.anchor_server_ms,
+                    anchor_monotonic=time.monotonic(),
+                )
+            consumer._held_leases[entry_id] = lease
+            return lease
+
+        for label in ("short", "fenced", "ample"):
+            await _eval_payload(client, cfg, sha=f"{label}-{token}")
+        short_id, _f1 = await _eval_read_one(client, cfg, cfg.eval_consumer_name)
+        fenced_id, _f2 = await _eval_read_one(client, cfg, cfg.eval_consumer_name)
+        ample_id, _f3 = await _eval_read_one(client, cfg, cfg.eval_consumer_name)
+
+        # LEG 1: 0.5s of budget left, a 10s suite.
+        slow = _TimedSuiteRun(duration_s=10.0)
+        monkeypatch.setattr(eval_stream_module, "run_eval_suite", slow)
+        await lease_with_remaining(short_id, 500)
+
+        started = time.monotonic()
+        cut = await consumer._run_and_report(item, short_id)
+        elapsed = time.monotonic() - started
+
+        assert slow.started.is_set(), (
+            "the suite never started, so 'it did not complete' proves nothing"
+        )
+        assert not slow.completed.is_set(), (
+            "the suite ran to completion past its delivery deadline"
+        )
+        assert elapsed < 4.0, (
+            f"the suite ran {elapsed:.1f}s on 0.5s of remaining budget; it was not "
+            "bounded at roughly the budget"
+        )
+        assert cut.total == 0, "a suite that outran its deadline must not report rows"
+        assert len(substrate.released) == 1, (
+            "the sandbox was not released on the deadline path; the finally leaks a claim"
+        )
+        assert len(reporter.reports) == 1
+        assert (reporter.reports[0].passed_count, reporter.reports[0].total) == (0, 0)
+
+        # LEG 2: the same abandonment while fenced out. "delivery deadline
+        # exceeded" is the third failure DTO with no ``stream_id``, so it rides
+        # the same fail-open the tests above pin -- asserted here, on the path
+        # that only exists because of defect 2.
+        slow2 = _TimedSuiteRun(duration_s=10.0)
+        monkeypatch.setattr(eval_stream_module, "run_eval_suite", slow2)
+        fenced_lease = await lease_with_remaining(fenced_id, 500)
+        fenced_lease.lost.set()
+
+        await consumer._run_and_report(item, fenced_id)
+
+        assert slow2.started.is_set() and not slow2.completed.is_set()
+        assert len(substrate.released) == 2, (
+            "the sandbox must be released even when this owner may not report"
+        )
+        assert len(reporter.reports) == 1, (
+            "a fenced-out owner published its deadline-exceeded report"
+        )
+
+        # POSITIVE CONTROL: an ample budget (the real 60s the store granted) and a
+        # fast suite -- the same code path completes and reports real rows.
+        fast = _TimedSuiteRun(duration_s=0.05)
+        monkeypatch.setattr(eval_stream_module, "run_eval_suite", fast)
+        ample = await lease_with_remaining(ample_id, None)
+        assert ample.remaining_s() > 30.0, (
+            "the control's budget must comfortably exceed the suite, or it proves "
+            "nothing about completion"
+        )
+
+        control = await consumer._run_and_report(item, ample_id)
+
+        assert fast.completed.is_set(), "the control suite did not run to completion"
+        assert (control.passed_count, control.total) == (1, 1)
+        assert len(substrate.released) == 3
+        assert len(reporter.reports) == 2
+        assert (reporter.reports[1].passed_count, reporter.reports[1].total) == (1, 1)
+
+        await _eval_cleanup(client, cfg)
+
+    asyncio.run(go())
+
+
+def test_an_unfenced_eval_lane_has_no_deadline_at_all_while_a_fenced_one_does() -> None:
+    """``leases=None`` means NO budget -- ``None``, never the sentinel's 86400s.
+
+    Retiring the eval lane's own lease registry in favour of the shared base's
+    made a documented path reachable: the base registers a REAL lease in
+    ``_held_leases`` and never the permissive sentinel, so a consumer built with
+    no lease store records nothing, ``_remaining_budget_s`` answers ``None``, and
+    ``asyncio.timeout(None)`` leaves the suite bounded by nothing -- exactly the
+    pre-ADR-0131 behaviour a base-only consumer had. The retired shape resolved
+    the same miss with ``... or unfenced_lease()`` and so bounded that suite at
+    the sentinel's 86400s instead. The change is deliberate; this test is what
+    makes it a decision rather than an accident.
+
+    Both directions are pinned, because both fail silently. Restoring the ``or
+    unfenced_lease()`` fallback turns the unfenced lane's ``None`` into roughly
+    86400.0 (red on leg 1). A lookup that stopped finding the real lease turns
+    the fenced lane's float into ``None`` (red on leg 2) -- an eval suite running
+    unbounded past a delivery deadline that exists in Valkey and is enforced
+    nowhere, which is precisely what ``_remaining_budget_s`` exists to prevent.
+    """
+    from curie_worker.delivery_lease import DeliveryLeaseStore, unfenced_lease
+
+    async def go() -> None:
+        token = uuid.uuid4().hex[:8]
+        cfg = _lease_cfg(token)
+        client = AsyncRedis(host=_VH, port=_VP, password=_VPW, decode_responses=True)
+
+        # LEG 1: the UNFENCED lane. No store, so no lease is ever registered and
+        # there is no budget to read -- before, during and after a handler body.
+        unfenced = _fence_consumer(
+            redis_client=client,
+            cfg=cfg,
+            leases=None,
+            bundle_store=_FakeBundleStore(_suite_bundle(_fence_suite())),
+            substrate=_UnusedSubstrate(),
+            reporter=_FakeReporter(),
+        )
+        assert unfenced._leases is None
+        assert unfenced._remaining_budget_s("1-0") is None
+
+        async with unfenced._delivery_lease("1-0", {}) as sentinel:
+            # The one place absence reads as permission: the body still runs.
+            assert sentinel is not None
+            assert unfenced._held_leases == {}, (
+                "an unfenced lane registered the permissive sentinel; its suite is "
+                "now bounded by the sentinel's budget instead of by nothing"
+            )
+            assert unfenced._remaining_budget_s("1-0") is None
+
+        # The value that must NOT show up above. A fallback that resolves the
+        # miss to the sentinel would hand the eval lane this number as a real
+        # deadline, which is the pre-consolidation semantics.
+        assert unfenced_lease().remaining_s() > 86_000.0
+
+        # LEG 2: the FENCED counterpart, same call, on a real lease from the real
+        # store -- so leg 1's ``None`` is the absence of a lease and not a
+        # ``_remaining_budget_s`` that answers ``None`` for everything.
+        store = DeliveryLeaseStore(client, cfg)
+        fenced = _fence_consumer(
+            redis_client=client,
+            cfg=cfg,
+            leases=store,
+            bundle_store=_FakeBundleStore(_suite_bundle(_fence_suite())),
+            substrate=_UnusedSubstrate(),
+            reporter=_FakeReporter(),
+        )
+        await fenced.ensure_group()
+        await _eval_payload(client, cfg, sha=f"budget-{token}")
+        entry_id, fields = await _eval_read_one(client, cfg, cfg.eval_consumer_name)
+
+        async with fenced._delivery_lease(entry_id, fields) as lease:
+            assert lease is not None
+            assert fenced._held_leases.get(entry_id) is lease
+            remaining = fenced._remaining_budget_s(entry_id)
+            assert isinstance(remaining, float), (
+                f"a fenced lane read no deadline from a lease it holds: {remaining!r}"
+            )
+            assert 0.0 < remaining <= cfg.delivery_budget_s
+            assert remaining > 30.0, (
+                f"the granted budget was {remaining:.1f}s of a {cfg.delivery_budget_s:.0f}s "
+                "delivery budget; it is not the real one"
+            )
+
+        # Deregistered on the way out, so a finished delivery reads as unfenced
+        # again rather than keeping a budget nobody holds.
+        assert fenced._remaining_budget_s(entry_id) is None
+
+        await _eval_cleanup(client, cfg)
 
     asyncio.run(go())

--- a/apps/worker/tests/kernel/conftest.py
+++ b/apps/worker/tests/kernel/conftest.py
@@ -13,15 +13,15 @@ sync fixtures.
 from __future__ import annotations
 
 import contextlib
-import uuid
-from collections.abc import AsyncIterator, Callable, Iterator
+from collections.abc import AsyncIterator, Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+from typing import Any
 
 import aiohttp
 import pytest
 import redis
-from aci_protocol import Final, OutboundEvent, SessionStatus
+from aci_protocol import Final, OutboundEvent, QueuedTurn, SessionStatus
 from aiohttp import web
 from aiohttp.test_utils import TestServer
 from channel_protocol import OutboundMessage
@@ -44,9 +44,6 @@ from curie_test_support.valkey import (
 from curie_test_support.valkey import (
     VALKEY_PW as _VALKEY_PW,
 )
-from curie_test_support.valkey import (
-    connect_or_skip,
-)
 from curie_worker.approval_cards import ApprovalCardStore
 from curie_worker.config import WorkerConfig
 from curie_worker.kernel import Kernel
@@ -63,29 +60,10 @@ from curie_worker.sandbox.types import ClaimView, SandboxView
 from curie_worker.threadlock import ThreadLock
 from redis.asyncio import Redis as AsyncRedis
 
-
-@pytest.fixture
-def sync_redis() -> Iterator[redis.Redis]:
-    client = connect_or_skip(decode_responses=True)
-    yield client
-    client.close()
-
-
-@pytest.fixture
-def names(sync_redis: redis.Redis) -> Iterator[dict[str, str]]:
-    """Per-test-unique stream / group / key prefixes on the shared Valkey."""
-    token = uuid.uuid4().hex
-    ns = {
-        "stream": f"test:curie:runs:{token}",
-        "group": f"g-{token}",
-        "prefix": f"test:curie:worker:{token}",
-        "sandbox_prefix": f"test:curie:sandbox:{token}",
-    }
-    yield ns
-    for pat in (f"{ns['prefix']}*", f"{ns['sandbox_prefix']}*", ns["stream"]):
-        keys = list(sync_redis.scan_iter(match=pat))
-        if keys:
-            sync_redis.delete(*keys)
+# ``sync_redis`` and ``names`` (the per-test-unique stream / group / key
+# prefixes on the shared Valkey) live in ``tests/conftest.py``: they are used
+# here AND by ``tests/test_delivery_lease.py``, which drives the lease store
+# directly against the same real Valkey without a full kernel harness.
 
 
 def make_config(names: dict[str, str], **overrides: object) -> WorkerConfig:
@@ -490,6 +468,54 @@ class FakeRunner:
         if self.hold is not None:
             self.hold.set()  # type: ignore[attr-defined]
         return web.json_response({"ok": True})
+
+
+# --- Delivery-lease test helpers (ADR-0131, #1971) -----------------------------
+#
+# Shared by ``test_delivery_ownership.py`` and ``test_long_turn_evidence.py``,
+# which both drive real ``Consumer``/``Kernel`` pairs against the delivery
+# lease. Living here rather than duplicated in each file keeps them from
+# quietly diverging on the ``lease is None`` forwarding branch, which encodes
+# the kernel's optional-lease call contract: a signature change to
+# ``Kernel.process_event`` breaks both call sites identically.
+
+
+class _ProcessEventSpy:
+    """Wraps ``kernel.process_event``, recording each call and its lease.
+
+    The lease is what the whole feature threads through the sacred handler, so
+    recording it (rather than only counting calls) is what lets a test assert on
+    the generation and the inherited deadline the kernel actually received. The
+    ``lease is None`` branch forwards the ORIGINAL one-argument call so that,
+    before the feature lands, these tests fail on a missing lease rather than on
+    a ``TypeError`` from a keyword the signature does not have yet.
+    """
+
+    def __init__(self, kernel: Any) -> None:
+        self._inner = kernel.process_event
+        self.calls: list[tuple[str, Any]] = []
+        kernel.process_event = self
+
+    async def __call__(self, qevent: QueuedTurn, *, lease: Any = None) -> None:
+        self.calls.append((qevent.event_id, lease))
+        if lease is None:
+            await self._inner(qevent)
+        else:
+            await self._inner(qevent, lease=lease)
+
+    def leases_for(self, event_id: str) -> list[Any]:
+        return [lease for eid, lease in self.calls if eid == event_id]
+
+    def entries_for(self, event_id: str) -> int:
+        return sum(1 for eid, _ in self.calls if eid == event_id)
+
+
+async def _pending_rows(h: Any) -> dict[str, int]:
+    """Every pending entry id -> its current ``times_delivered``."""
+    rows = await h.async_redis.xpending_range(
+        h.config.stream, h.config.consumer_group, min="-", max="+", count=50
+    )
+    return {row["message_id"]: int(row["times_delivered"]) for row in rows}
 
 
 @dataclass

--- a/apps/worker/tests/kernel/test_completion_outbox.py
+++ b/apps/worker/tests/kernel/test_completion_outbox.py
@@ -509,3 +509,212 @@ def test_an_escalated_turn_reports_the_escalated_outcome(make_harness) -> None:
             assert [c.outcome for c in h.sink.completions] == ["escalated"]
 
     asyncio.run(go())
+
+
+# --- R6 (ADR-0131): ONE user-visible terminal effect, and the fence that keeps
+# --- a stale owner from producing a second one -------------------------------
+#
+# The named idempotent receiving boundary, per ADR-0131's requirement that tests
+# and documentation NAME it before claiming exactly-once terminal effect: the
+# ``turn.completed`` event carries this turn's ``event_id``, and the recording
+# sink below is the stand-in for a receiving adapter that applies that id
+# idempotently (one message per event_id, edited in place). The ADR is explicit
+# that exactly-once TRANSPORT is impossible, so everything here asserts one
+# user-visible EFFECT at that boundary -- never one network send.
+
+_R6_LEASE_KNOBS: dict[str, object] = {
+    "delivery_budget_s": 60.0,
+    "delivery_lease_ttl_s": 1.0,
+    "delivery_lease_heartbeat_s": 0.3,
+    "runner_total_timeout_s": 30.0,
+}
+
+
+async def _dispatch_and_settle(consumer: Consumer, entry_id: str, fields: dict) -> None:
+    await consumer._dispatch(entry_id, fields)
+    await asyncio.gather(*list(consumer._inflight), return_exceptions=True)
+
+
+async def _read_one(h, consumer_name: str) -> tuple[str, dict]:
+    rows = await h.async_redis.xreadgroup(
+        h.config.consumer_group, consumer_name, {h.config.stream: ">"}, count=1
+    )
+    assert rows, "expected an entry to read"
+    entry_id, fields = rows[0][1][0]
+    return entry_id, dict(fields)
+
+
+def test_a_failed_terminal_send_recovers_to_exactly_one_user_visible_effect(
+    make_harness,
+) -> None:
+    """R6, the recovery half, driven through the fenced consumer.
+
+    Three deliveries of the SAME event id: the first turn's terminal send fails,
+    the second recovers it from the stored record, and the third adds nothing.
+    Exactly ONE ``turn.completed`` reaches the idempotent receiving boundary
+    across all three.
+
+    This also pins the settlement of the delivery state on BOTH terminal paths --
+    the successful ACK (C2) and the already-done skip (C11). Red on reverting
+    either ``settle`` call: a dead-lettered-and-redelivered event id then
+    accumulates delivery-state keys until their one-day retention TTL.
+
+    The negative control is the fourth delivery, of a DIFFERENT event id: it
+    still produces its own effect, so "no further effect" above is the
+    idempotency key doing its job and not a sink that stopped recording.
+    """
+    # Imported inside the test on purpose: ``delivery_lease`` does not exist
+    # until this ticket lands, and a module-level import would fail COLLECTION
+    # for this whole file, turning every unrelated test in it red.
+    from curie_worker.delivery_lease import DeliveryLeaseStore
+
+    async def go() -> None:
+        async with make_harness(
+            shimmer=False, completion_sweep_grace_s=0.0, **_R6_LEASE_KNOBS
+        ) as h:
+            store = DeliveryLeaseStore(h.async_redis, h.config)
+            consumer = Consumer(
+                redis=h.async_redis, kernel=h.kernel, config=h.config, leases=store
+            )
+            await consumer.ensure_group()
+            h.runner.default_script = [Final(text="answer", status=DONE)]
+
+            # Delivery 1: the terminal send fails. The turn IS complete; the
+            # completion is owed and durably recorded.
+            h.sink.fail_events = {"turn.completed"}
+            await h.async_redis.xadd(
+                h.config.stream, to_stream_fields(_qevent(thread="tR6", event_id="r6-1"))
+            )
+            entry_1, fields_1 = await _read_one(h, h.config.consumer_name)
+            await _dispatch_and_settle(consumer, entry_1, fields_1)
+
+            assert h.sink.completions == []
+            assert await h.async_redis.exists(h.config.completion_key("r6-1"))
+            assert await store.peek(h.config.stream, h.config.consumer_group, entry_1) == {}, (
+                "the delivery state outlived a terminal ACK"
+            )
+
+            # Delivery 2: the same event id under a new stream entry (a genuine
+            # redelivery). The already-done skip re-emits from the STORED record.
+            h.sink.fail_events = set()
+            await h.async_redis.xadd(
+                h.config.stream, to_stream_fields(_qevent(thread="tR6", event_id="r6-1"))
+            )
+            entry_2, fields_2 = await _read_one(h, h.config.consumer_name)
+            await _dispatch_and_settle(consumer, entry_2, fields_2)
+
+            assert [c.event_id for c in h.sink.completions] == ["r6-1"]
+            assert await store.peek(h.config.stream, h.config.consumer_group, entry_2) == {}, (
+                "the already-done skip left its delivery state behind"
+            )
+
+            # Delivery 3 adds nothing at the boundary, and neither does a sweep.
+            await h.async_redis.xadd(
+                h.config.stream, to_stream_fields(_qevent(thread="tR6", event_id="r6-1"))
+            )
+            entry_3, fields_3 = await _read_one(h, h.config.consumer_name)
+            await _dispatch_and_settle(consumer, entry_3, fields_3)
+            await h.kernel.sweep_pending_completions()
+            assert [c.event_id for c in h.sink.completions] == ["r6-1"]
+
+            # NEGATIVE CONTROL: a different event id still lands its own effect.
+            await h.async_redis.xadd(
+                h.config.stream, to_stream_fields(_qevent(thread="tR6", event_id="r6-2"))
+            )
+            entry_4, fields_4 = await _read_one(h, h.config.consumer_name)
+            await _dispatch_and_settle(consumer, entry_4, fields_4)
+            assert [c.event_id for c in h.sink.completions] == ["r6-1", "r6-2"]
+
+    asyncio.run(go())
+
+
+def test_a_stale_generation_owner_writes_no_marker_clears_nothing_and_emits_nothing(
+    make_harness,
+) -> None:
+    """R6, the stale-owner half, and AC4's four refused verbs at the settle point.
+
+    An owner holding generation N runs to a terminal outcome while the delivery
+    state already holds N+1 -- the "slow owner whose lease expired and was taken"
+    case. ``settle_fenced`` must refuse atomically: no done marker, no write to
+    (and no clear of) the outbox record another writer owns, and no terminal
+    emit. The refusal to ACK is pinned separately, in
+    ``tests/kernel/test_delivery_ownership.py``.
+
+    Red on reverting ``_complete``'s fenced settlement to the two-call
+    ``mark_completion_pending`` + ``mark_done`` pair: the loser then writes the
+    marker and emits, and the user sees the turn finish twice.
+
+    The positive control is the CURRENT owner running the identical path
+    immediately afterwards. Without it this test passes just as well if
+    ``settle_fenced`` refuses everybody.
+    """
+    # Imported inside the test on purpose: ``delivery_lease`` does not exist
+    # until this ticket lands, and a module-level import would fail COLLECTION
+    # for this whole file, turning every unrelated test in it red.
+    from curie_worker.delivery_lease import DeliveryLeaseStore
+
+    async def go() -> None:
+        async with make_harness(shimmer=False, **_R6_LEASE_KNOBS) as h:
+            store = DeliveryLeaseStore(h.async_redis, h.config)
+            consumer = Consumer(
+                redis=h.async_redis, kernel=h.kernel, config=h.config, leases=store
+            )
+            await consumer.ensure_group()
+            h.runner.default_script = [Final(text="answer", status=DONE)]
+
+            qe = _qevent(thread="tR6s", event_id="r6-stale")
+            await h.async_redis.xadd(h.config.stream, to_stream_fields(qe))
+            entry_id, _fields = await _read_one(h, h.config.consumer_name)
+
+            stale = await store.acquire(
+                h.config.stream,
+                h.config.consumer_group,
+                entry_id,
+                consumer=h.config.consumer_name,
+            )
+            assert (
+                await store.release(
+                    h.config.stream, h.config.consumer_group, entry_id, owner=stale.owner
+                )
+                is True
+            )
+            current = await store.acquire(
+                h.config.stream,
+                h.config.consumer_group,
+                entry_id,
+                consumer=h.config.consumer_name,
+            )
+            assert (stale.generation, current.generation) == (1, 2)
+
+            # An outbox record owned by another writer, deliberately NOT done so
+            # the already-done skip does not short-circuit the run under test.
+            await Markers(h.async_redis, h.config).mark_completion_pending(
+                "r6-stale", _record("r6-stale", thread="tR6s", done=False)
+            )
+            assert await h.async_redis.smembers(h.config.completions_pending_key()) == {
+                "r6-stale"
+            }
+
+            await h.kernel.process_event(qe, lease=stale)
+
+            assert h.sink.completions == [], "a fenced-out owner emitted a terminal result"
+            assert await h.async_redis.exists(h.config.done_key("r6-stale")) == 0, (
+                "a fenced-out owner wrote the done marker"
+            )
+            assert await h.async_redis.exists(h.config.completion_key("r6-stale")), (
+                "a fenced-out owner cleared an outbox record it does not own"
+            )
+            assert (
+                await h.async_redis.hget(h.config.completion_key("r6-stale"), "done") == "0"
+            ), "a fenced-out owner flagged another writer's record done"
+
+            # POSITIVE CONTROL: the current owner settles and emits, so the
+            # refusal above is the generation check and not a dead settle path.
+            await h.kernel.process_event(
+                _qevent(thread="tR6s", event_id="r6-stale"), lease=current
+            )
+            assert [c.event_id for c in h.sink.completions] == ["r6-stale"]
+            assert await h.async_redis.exists(h.config.done_key("r6-stale"))
+            assert await h.async_redis.exists(h.config.completion_key("r6-stale")) == 0
+
+    asyncio.run(go())

--- a/apps/worker/tests/kernel/test_consumer_dead_letter.py
+++ b/apps/worker/tests/kernel/test_consumer_dead_letter.py
@@ -34,6 +34,7 @@ instead of re-dispatching.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
 import uuid
@@ -47,6 +48,8 @@ from curie_worker.config import WorkerConfig
 from curie_worker.consumer import Consumer
 from curie_worker.dead_letter_alert import install_dead_letter_alerting
 from pydantic import ValidationError
+
+from .conftest import _pending_rows
 
 DONE = SessionStatus.DONE
 
@@ -102,18 +105,6 @@ async def _deliver_new(consumer: Consumer, h) -> int:
 async def _reclaim_and_settle(consumer: Consumer) -> None:
     await consumer._reclaim_once()
     await asyncio.gather(*list(consumer._inflight))
-
-
-async def _pending_rows(h) -> dict[str, int]:
-    """Every pending entry id -> its current ``times_delivered``."""
-    rows = await h.async_redis.xpending_range(
-        h.config.stream,
-        h.config.consumer_group,
-        min="-",
-        max="+",
-        count=50,
-    )
-    return {row["message_id"]: int(row["times_delivered"]) for row in rows}
 
 
 async def _pending_ids(h) -> set[str]:
@@ -951,3 +942,871 @@ def test_dead_letter_stream_equal_to_source_stream_is_rejected() -> None:
         ).dead_letter_stream
         == "curie:runs:dead"
     )
+
+
+# --- ADR-0131: a live lease is checked BEFORE cap evaluation ------------------
+
+
+def test_a_live_lease_holds_off_the_cap_and_releasing_it_dead_letters_normally(
+    make_harness,
+) -> None:
+    """R4. "A live lease is checked before cap evaluation so a healthy long turn
+    cannot be dead-lettered" (ADR-0131), directly.
+
+    The entry is driven to ``times_delivered >= max_delivery`` -- the exact state
+    that dead-letters today -- while a peer replica holds a LIVE lease on it. The
+    cap scan must skip it. ``_inflight_ids`` is asserted empty throughout, so the
+    pre-existing same-process guard cannot be what saved it: only the new
+    cross-replica lease check can.
+
+    Red on reverting the ``is_live`` guard inserted between the ``_inflight_ids``
+    skip and the ``delivered = int(row["times_delivered"])`` read in
+    ``_dead_letter_over_cap``: a healthy long turn on a peer is dead-lettered
+    mid-run, its reply is lost, and the graveyard reports it as poison.
+
+    The positive control is the second pass: once the lease is released the very
+    same entry dead-letters normally, so the skip above is the fence and not a
+    cap that stopped working. The cap itself, its ``>=`` boundary and its
+    PEL-backed count are untouched -- weakening ``max_delivery`` is the #505
+    total-stall regression, not a simplification.
+    """
+    # Imported inside the test on purpose: ``delivery_lease`` does not exist
+    # until this ticket lands, and a module-level import would fail COLLECTION
+    # for this whole file, turning every unrelated test in it red.
+    from curie_worker.delivery_lease import DeliveryLeaseStore
+
+    async def go() -> None:
+        async with make_harness(
+            max_delivery=2,
+            reclaim_min_idle_ms=0,
+            delivery_budget_s=60.0,
+            delivery_lease_ttl_s=1.0,
+            delivery_lease_heartbeat_s=0.3,
+            runner_total_timeout_s=30.0,
+        ) as h:
+            store = DeliveryLeaseStore(h.async_redis, h.config)
+            consumer = Consumer(
+                redis=h.async_redis, kernel=h.kernel, config=h.config, leases=store
+            )
+            await consumer.ensure_group()
+
+            qe = _qevent("healthy long turn", thread="tcap", event_id="cap-live")
+            await h.async_redis.xadd(h.config.stream, to_stream_fields(qe))
+
+            # Delivery #1 (XREADGROUP) then #2 (XCLAIM) -> at the cap of 2, and
+            # pending under a PEER, so this consumer's own in-flight guard is not
+            # in play.
+            rows = await h.async_redis.xreadgroup(
+                h.config.consumer_group, "peer-worker", {h.config.stream: ">"}, count=1
+            )
+            entry_id = rows[0][1][0][0]
+            await h.async_redis.xclaim(
+                h.config.stream, h.config.consumer_group, "peer-worker", 0, [entry_id]
+            )
+            assert (await _pending_rows(h))[entry_id] >= h.config.max_delivery
+
+            lease = await store.acquire(
+                h.config.stream, h.config.consumer_group, entry_id, consumer="peer-worker"
+            )
+            assert await store.is_live(h.config.stream, h.config.consumer_group, entry_id)
+            assert consumer._inflight_ids == set(), (
+                "the in-flight guard would mask the lease guard under test"
+            )
+
+            over_cap = await consumer._dead_letter_over_cap()
+            assert over_cap == set(), "a healthy long turn was judged against the cap"
+            assert await _dead_rows(h) == [], "a healthy long turn was dead-lettered"
+            assert entry_id in await _pending_ids(h)
+
+            # POSITIVE CONTROL: with the lease gone the same entry, at the same
+            # count, dead-letters on the next pass.
+            assert (
+                await store.release(
+                    h.config.stream, h.config.consumer_group, entry_id, owner=lease.owner
+                )
+                is True
+            )
+            over_cap = await consumer._dead_letter_over_cap()
+            assert over_cap == {entry_id}
+            rows = await _dead_rows(h)
+            assert len(rows) == 1
+            assert rows[0][1]["dl_original_id"] == entry_id
+            assert entry_id not in await _pending_ids(h)
+
+    asyncio.run(go())
+
+
+# --- ADR-0131: dead-letter is FENCED (the four terminal verbs) ----------------
+#
+# ADR-0131: a fenced-out owner "may not ACK, dead-letter, clear an outbox
+# record, or emit a terminal result." ``_dead_letter`` settles a delivery three
+# ways at once -- it XADDs the graveyard row, XACKs the entry off the group, and
+# then deletes the lease and delivery-state keys -- so an unfenced one lets a
+# stale process ack somebody else's delivery AND delete the current owner's
+# keys. ``_dead_letter_refusal`` is the precondition that stops it, and it asks
+# a DIFFERENT question of each of its two callers; the tests below pin both
+# branches with a positive control each, so a fence that refused everything
+# (equally broken: a graveyard that never fills is #505's stall) fails too.
+
+
+async def _park_over_cap(h, consumer_name: str) -> str:
+    """One entry, pending under ``consumer_name`` at ``times_delivered >= cap``.
+
+    The exact state ``_dead_letter_over_cap`` hands to ``_dead_letter``: read
+    once by XREADGROUP (delivery #1) then claimed once (delivery #2).
+    """
+    qe = _qevent("long turn", thread="tfence", event_id=f"fence-{uuid.uuid4().hex[:8]}")
+    await h.async_redis.xadd(h.config.stream, to_stream_fields(qe))
+    rows = await h.async_redis.xreadgroup(
+        h.config.consumer_group, consumer_name, {h.config.stream: ">"}, count=1
+    )
+    entry_id = rows[0][1][0][0]
+    await h.async_redis.xclaim(
+        h.config.stream, h.config.consumer_group, consumer_name, 0, [entry_id]
+    )
+    assert (await _pending_rows(h))[entry_id] >= h.config.max_delivery
+    return entry_id
+
+
+def _lease_keys(h, entry_id: str) -> tuple[str, str]:
+    return (
+        h.config.delivery_lease_key(h.config.stream, h.config.consumer_group, entry_id),
+        h.config.delivery_state_key(h.config.stream, h.config.consumer_group, entry_id),
+    )
+
+
+# Short lease clocks so a real fence loss is observed in-test without touching a
+# clock. ``delivery_budget_s`` floors at 60.0 and a validator rejects
+# ``runner_total_timeout_s`` above it, so the runner ceiling comes down too --
+# that is the whole compression lever here. ``max_delivery`` is NOT touched:
+# weakening the ADR-0039 cap is the #505 regression, not a test convenience.
+_FENCE_CONFIG: dict[str, object] = {
+    "max_delivery": 2,
+    "reclaim_min_idle_ms": 0,
+    "delivery_budget_s": 60.0,
+    "runner_total_timeout_s": 30.0,
+    "delivery_lease_ttl_s": 1.0,
+    "delivery_lease_heartbeat_s": 0.3,
+}
+
+
+def test_a_consumer_with_no_lease_store_dead_letters_exactly_as_before(
+    make_harness,
+) -> None:
+    """The leaseless regression guard: no lease store means no fence at all.
+
+    ``_dead_letter_refusal`` returns None immediately when ``self._leases is
+    None``, so a base-only consumer (the second-broker port, the ``_FakeBroker``
+    units, every pre-ADR-0131 deployment) dead-letters an over-cap entry exactly
+    as it did before the fence existed.
+
+    Red if the fence is ever made unconditional -- e.g. dropping the
+    ``if self._leases is None: return None`` early return from
+    ``_dead_letter_refusal``, or having a missing store read as "somebody owns
+    it". Either turns the graveyard off for every leaseless consumer, which is
+    #505's permanent stall reached from the new code.
+    """
+
+    async def go() -> None:
+        async with make_harness(max_delivery=2, reclaim_min_idle_ms=0) as h:
+            consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
+            await consumer.ensure_group()
+            assert consumer._leases is None
+
+            try:
+                entry_id = await _park_over_cap(h, "peer-worker")
+
+                over_cap = await consumer._dead_letter_over_cap()
+
+                assert over_cap == {entry_id}
+                rows = await _dead_rows(h)
+                assert len(rows) == 1, f"a leaseless consumer stopped dead-lettering: {rows}"
+                assert rows[0][1]["dl_original_id"] == entry_id
+                assert entry_id not in await _pending_ids(h)
+            finally:
+                await h.async_redis.delete(_dead_stream(h.config))
+
+    asyncio.run(go())
+
+
+def test_the_maintenance_scan_refuses_to_dead_letter_once_another_owner_acquires(
+    make_harness,
+) -> None:
+    """A lease taken in the window between the cap read and the settle wins.
+
+    ``_dead_letter_over_cap``'s own pre-cap ``_lease_is_live`` check cannot cover
+    this: it is a READ, and a new owner may acquire in the window between it and
+    the terminal writes. So ``_dead_letter`` is called directly here, exactly as
+    the scan calls it, with a live peer lease in place -- the only way to reach
+    the second line of defense the review asked for.
+
+    All three settle effects must be absent: nothing on ``<stream>:dead``, the
+    entry NOT acked (still pending, delivery count untouched), and neither the
+    lease key nor the delivery-state key deleted out from under the live owner.
+
+    Red on removing the ``_dead_letter_refusal`` precondition from
+    ``_dead_letter``: a stale scan acks the new owner's delivery off the group,
+    writes it to the graveyard as poison, and deletes the keys the owner is
+    heartbeating -- ADR-0131's split brain, from the maintenance side.
+    """
+    from curie_worker.delivery_lease import DeliveryLeaseStore
+
+    async def go() -> None:
+        async with make_harness(**_FENCE_CONFIG) as h:
+            store = DeliveryLeaseStore(h.async_redis, h.config)
+            consumer = Consumer(
+                redis=h.async_redis, kernel=h.kernel, config=h.config, leases=store
+            )
+            await consumer.ensure_group()
+
+            try:
+                entry_id = await _park_over_cap(h, "peer-worker")
+                lease_key, state_key = _lease_keys(h, entry_id)
+
+                await store.acquire(
+                    h.config.stream, h.config.consumer_group, entry_id, consumer="peer-worker"
+                )
+                # The maintenance branch, not the handler branch: this process
+                # holds no lease of its own, so the refusal must come from the
+                # re-read of somebody ELSE's liveness.
+                assert consumer._held_leases == {}
+
+                before = (await _pending_rows(h))[entry_id]
+                await consumer._dead_letter(
+                    entry_id,
+                    await consumer._entry_fields(entry_id),
+                    reason="max-delivery-exceeded",
+                    delivery_count=before,
+                )
+
+                assert await _dead_rows(h) == [], "settled a delivery another owner holds"
+                assert entry_id in await _pending_ids(h), "acked another owner's delivery"
+                assert (await _pending_rows(h))[entry_id] == before
+                assert await h.async_redis.exists(lease_key) == 1, "deleted the owner's lease"
+                assert await h.async_redis.exists(state_key) == 1, "deleted the owner's state"
+            finally:
+                await h.async_redis.delete(_dead_stream(h.config))
+
+    asyncio.run(go())
+
+
+def test_the_maintenance_scan_dead_letters_normally_when_nobody_owns_the_entry(
+    make_harness,
+) -> None:
+    """POSITIVE CONTROL for the two maintenance refusals above and below.
+
+    Byte-for-byte the same setup and the same direct ``_dead_letter`` call, with
+    the single difference that no live lease exists and the store is readable.
+    Without this test a fence that refused unconditionally -- or a
+    ``_dead_letter`` broken outright -- would leave the refusal tests green
+    while the graveyard silently stopped filling, which is #505's stall wearing
+    the fence's clothes.
+
+    All three settle effects must happen: the graveyard row, the ACK, and the
+    ``settle`` that removes BOTH the lease and delivery-state keys (ADR-0131:
+    delivery state is "removed after terminal acknowledgement or dead-letter
+    settlement").
+
+    Red on a fence that refuses when ``_lease_is_live`` says False, or on
+    dropping the ``self._leases.settle(...)`` call after the ACK.
+    """
+    from curie_worker.delivery_lease import DeliveryLeaseStore
+
+    async def go() -> None:
+        async with make_harness(**_FENCE_CONFIG) as h:
+            store = DeliveryLeaseStore(h.async_redis, h.config)
+            consumer = Consumer(
+                redis=h.async_redis, kernel=h.kernel, config=h.config, leases=store
+            )
+            await consumer.ensure_group()
+
+            try:
+                entry_id = await _park_over_cap(h, "peer-worker")
+                lease_key, state_key = _lease_keys(h, entry_id)
+
+                # Acquired and RELEASED, so the delivery-state key exists (release
+                # deliberately preserves it) and only ``settle`` can remove it.
+                lease = await store.acquire(
+                    h.config.stream, h.config.consumer_group, entry_id, consumer="peer-worker"
+                )
+                assert (
+                    await store.release(
+                        h.config.stream, h.config.consumer_group, entry_id, owner=lease.owner
+                    )
+                    is True
+                )
+                live = await store.is_live(h.config.stream, h.config.consumer_group, entry_id)
+                assert live is False
+                assert await h.async_redis.exists(state_key) == 1
+                assert consumer._held_leases == {}
+
+                delivered = (await _pending_rows(h))[entry_id]
+                await consumer._dead_letter(
+                    entry_id,
+                    await consumer._entry_fields(entry_id),
+                    reason="max-delivery-exceeded",
+                    delivery_count=delivered,
+                )
+
+                rows = await _dead_rows(h)
+                assert len(rows) == 1, f"an unowned over-cap entry was not dead-lettered: {rows}"
+                assert rows[0][1]["dl_original_id"] == entry_id
+                assert rows[0][1]["dl_delivery_count"] == str(delivered)
+                assert entry_id not in await _pending_ids(h), "dead-lettered but never acked"
+                assert await h.async_redis.exists(lease_key) == 0
+                assert await h.async_redis.exists(state_key) == 0, "delivery state outlived settle"
+            finally:
+                await h.async_redis.delete(_dead_stream(h.config))
+
+    asyncio.run(go())
+
+
+# --- The settle asymmetry: RAISE at the dead-letter, SWALLOW after the ACK ----
+#
+# ``_settle_delivery`` (raises through) and ``_settle_delivery_best_effort``
+# (catches and logs a WARNING) are deliberately two methods on the shared base,
+# and WHICH ONE a call site picks is the entire point of the split. The two
+# tests below drive a real ``DeliveryLeaseStore`` whose ``settle`` cannot
+# complete and assert OPPOSITE outcomes at the two call sites, so swapping
+# either one for the other variant turns exactly one of them red.
+
+
+def test_a_failed_settle_makes_the_dead_letter_report_failure_not_a_clean_row(
+    make_harness,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The dead-letter settle RAISES THROUGH: a half-settled entry says so.
+
+    ``_dead_letter`` finishes with ``_settle_delivery`` -- the raising variant --
+    from inside the try that marks the span, records ``curie.queue.dead_letter``
+    and re-raises. A settle that fails there leaves the entry HALF settled: the
+    graveyard row is written and the entry is acked off the group, but its
+    delivery state is still on the box. That must be reported as a failed
+    dead-letter; swallowing it would hand the caller, the alerting and the
+    metric a dead-letter that looks clean while the state key silently outlives
+    it to its retention TTL.
+
+    Red on flipping that call to ``_settle_delivery_best_effort``, and equally
+    red on re-introducing a subclass override of ``_settle_delivery`` that
+    swallows -- the shape both lanes carried before the base consolidated them,
+    and the reason the raising variant is the overridable base method rather
+    than a private one.
+
+    The store is real and so is the failure: ONLY ``settle`` is replaced, so the
+    acquire/release that created the delivery-state key ran for real, and that
+    key surviving is the observable proof the settle genuinely did not happen
+    (an injection that silently no-opped would leave this test green on nothing).
+
+    ``record_metric`` is wrapped rather than replaced so the real declaration
+    check still runs on every point this path emits.
+    """
+    from curie_worker import stream_consumer as stream_consumer_module
+    from curie_worker.delivery_lease import DeliveryLeaseStore
+
+    points: list[tuple[str, dict[str, str]]] = []
+    real_record_metric = stream_consumer_module.record_metric
+
+    def recording_metric(
+        name: str, value: float = 1, *, attributes: dict[str, str] | None = None
+    ) -> None:
+        points.append((name, dict(attributes or {})))
+        real_record_metric(name, value, attributes=attributes)
+
+    def outcomes(name: str) -> list[str]:
+        return [attrs.get("outcome", "") for point, attrs in points if point == name]
+
+    async def go() -> None:
+        async with make_harness(**_FENCE_CONFIG) as h:
+            store = DeliveryLeaseStore(h.async_redis, h.config)
+            consumer = Consumer(
+                redis=h.async_redis, kernel=h.kernel, config=h.config, leases=store
+            )
+            await consumer.ensure_group()
+
+            try:
+                entry_id = await _park_over_cap(h, "peer-worker")
+                lease_key, state_key = _lease_keys(h, entry_id)
+
+                # Acquired and RELEASED, exactly as the positive control above:
+                # the fence permits, the state key exists, and only ``settle``
+                # can remove it.
+                lease = await store.acquire(
+                    h.config.stream, h.config.consumer_group, entry_id, consumer="peer-worker"
+                )
+                await store.release(
+                    h.config.stream, h.config.consumer_group, entry_id, owner=lease.owner
+                )
+                assert await h.async_redis.exists(state_key) == 1
+                assert consumer._held_leases == {}
+
+                boom = RuntimeError("valkey refused the terminal settle")
+
+                async def exploding_settle(*_args: object, **_kwargs: object) -> None:
+                    raise boom
+
+                monkeypatch.setattr(store, "settle", exploding_settle)
+                monkeypatch.setattr(
+                    stream_consumer_module, "record_metric", recording_metric
+                )
+
+                delivered = (await _pending_rows(h))[entry_id]
+                with pytest.raises(RuntimeError) as raised:
+                    await consumer._dead_letter(
+                        entry_id,
+                        await consumer._entry_fields(entry_id),
+                        reason="max-delivery-exceeded",
+                        delivery_count=delivered,
+                    )
+                assert raised.value is boom, (
+                    "the settle failure was swallowed and something else raised"
+                )
+
+                # Reported as a FAILED dead-letter, not a successful one.
+                assert outcomes("curie.queue.dead_letter") == ["failure"], (
+                    "a dead-letter whose settle failed was recorded as clean: "
+                    f"{points}"
+                )
+                assert outcomes("curie.queue.settle") == ["pending"]
+
+                # ...and the two writes that precede the settle DID happen, in
+                # that order: the graveyard row first (the neighbouring ordering
+                # test pins XADD-before-XACK against a graveyard that cannot be
+                # written), then the ACK. A failed settle must not be mistaken
+                # for a refused dead-letter, which writes neither.
+                rows = await _dead_rows(h)
+                assert len(rows) == 1, f"the graveyard row was rolled back: {rows}"
+                assert rows[0][1]["dl_original_id"] == entry_id
+                assert entry_id not in await _pending_ids(h), "the entry was never acked"
+                assert await h.async_redis.exists(lease_key) == 0, (
+                    "the lease key vanished, so the injected settle did not fire"
+                )
+                assert await h.async_redis.exists(state_key) == 1, (
+                    "the delivery state was removed, so the settle under test ran"
+                )
+            finally:
+                await h.async_redis.delete(_dead_stream(h.config))
+
+    asyncio.run(go())
+
+
+def test_a_failed_settle_after_the_ack_is_warned_about_and_the_turn_still_succeeds(
+    make_harness,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The MIRROR of the test above, at the post-ack call site: it SWALLOWS.
+
+    ``Consumer._handle`` settles after its terminal ACK, and by then the entry
+    is already off the group: raising there would turn a turn that ran, replied
+    and acked into a logged handler failure, and there is nothing left to retry
+    -- the state key's own retention is the backstop. So this site calls
+    ``_settle_delivery_best_effort``, which catches and logs one WARNING.
+
+    Same real store, same injected ``settle`` failure, opposite assertion: the
+    handler task completes normally, the turn is acked and answered, and the
+    only trace is a WARNING carrying the entry id and the exception. Red on
+    flipping this call site to the raising ``_settle_delivery`` (the handler
+    task ends in an exception and the success metric is never recorded), and red
+    on downgrading the log to silence.
+    """
+    from curie_worker.delivery_lease import DeliveryLeaseStore
+
+    async def go() -> None:
+        async with make_harness(**_FENCE_CONFIG) as h:
+            h.runner.default_script = [Final(text="answered", status=DONE)]
+            store = DeliveryLeaseStore(h.async_redis, h.config)
+            consumer = Consumer(
+                redis=h.async_redis, kernel=h.kernel, config=h.config, leases=store
+            )
+            await consumer.ensure_group()
+
+            async def exploding_settle(*_args: object, **_kwargs: object) -> None:
+                raise RuntimeError("valkey refused the terminal settle")
+
+            monkeypatch.setattr(store, "settle", exploding_settle)
+
+            try:
+                qe = _qevent(
+                    "post-ack settle",
+                    thread="tdl-postack",
+                    event_id=f"postack-{uuid.uuid4().hex[:8]}",
+                )
+                await h.async_redis.xadd(h.config.stream, to_stream_fields(qe))
+                rows = await h.async_redis.xreadgroup(
+                    h.config.consumer_group,
+                    h.config.consumer_name,
+                    {h.config.stream: ">"},
+                    count=1,
+                )
+                entry_id, fields = rows[0][1][0]
+
+                with caplog.at_level(logging.DEBUG, logger="curie_worker.consumer"):
+                    await consumer._dispatch(entry_id, dict(fields))
+                    handlers = list(consumer._inflight)
+                    results = await asyncio.gather(*handlers, return_exceptions=True)
+
+                assert [r for r in results if isinstance(r, BaseException)] == [], (
+                    "a settle failure AFTER the ack escaped the handler and "
+                    "failed a turn that had already succeeded"
+                )
+                assert h.runner.opened == ["post-ack settle"]
+                assert h.sink.last_text == "answered"
+                assert entry_id not in await _pending_ids(h), "the turn never acked"
+                assert await _dead_rows(h) == [], "a settled turn reached the graveyard"
+
+                settle_logs = [
+                    r for r in caplog.records if "settling the delivery state" in r.getMessage()
+                ]
+                assert len(settle_logs) == 1, (
+                    f"expected exactly one settle-failure log, got: "
+                    f"{[r.getMessage() for r in settle_logs]}"
+                )
+                record = settle_logs[0]
+                assert record.levelno == logging.WARNING, (
+                    f"the post-ack settle failure was logged at {record.levelname}, not WARNING"
+                )
+                assert entry_id in record.getMessage()
+                assert record.exc_info is not None, (
+                    "the swallowed exception was not attached, so an operator "
+                    "cannot tell WHY the state key was left behind"
+                )
+            finally:
+                await h.async_redis.delete(_dead_stream(h.config))
+
+    asyncio.run(go())
+
+
+def test_the_settle_split_survives_on_the_consumer_subclass_itself(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The same asymmetry asserted where the REGRESSION would land: on ``Consumer``.
+
+    The two tests above drive the two call sites. This one drives the two
+    METHODS, on a real ``Consumer``, because the likeliest regression is not a
+    changed call site at all: the method deleted from ``consumer.py`` when the
+    base consolidated the three copies had exactly the name ``_settle_delivery``
+    and exactly the SWALLOWING shape. ``Consumer`` now inherits three coupled
+    things -- ``_settle_delivery`` (raises), ``_settle_delivery_best_effort``
+    (swallows) and ``_dead_letter``, which deliberately calls the raising one --
+    so a future "make settle best-effort everywhere" cleanup that re-adds
+    ``Consumer._settle_delivery`` would not only change the post-ack site: it
+    would silently convert the INHERITED dead-letter's settle into a swallow.
+    A half-settled dead-letter then reports as a clean one -- the CRITICAL alert
+    fires as normal, no failure metric is recorded, and the lease and
+    delivery-state keys leak to their retention TTL with no signal anywhere.
+
+    Deliberately Valkey-free: a fake store is enough to make ``settle`` fail, and
+    an override anywhere must be caught on every box, not only where the compose
+    stack happens to be up.
+    """
+
+    class _RefusingLeaseStore:
+        """A lease store whose terminal settle cannot complete.
+
+        Records its calls so a variant that never reached the store at all --
+        the other way this test could go quietly vacuous -- is visible.
+        """
+
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, str, str]] = []
+
+        async def settle(self, stream: str, group: str, entry_id: str) -> None:
+            self.calls.append((stream, group, entry_id))
+            raise RuntimeError("valkey refused the terminal settle")
+
+    config = WorkerConfig(
+        stream="curie:runs", consumer_group="curie-workers", consumer_name="worker-1"
+    )
+    store = _RefusingLeaseStore()
+    consumer = Consumer(
+        redis=None,  # type: ignore[arg-type]
+        kernel=None,  # type: ignore[arg-type]
+        config=config,
+        leases=store,  # type: ignore[arg-type]
+    )
+    entry_id = "1700000000000-0"
+
+    # The dead-letter's variant: raises through, so ``_dead_letter``'s own
+    # handler can mark the span, record the failure metric and re-raise.
+    with pytest.raises(RuntimeError, match="refused the terminal settle"):
+        asyncio.run(consumer._settle_delivery(entry_id))
+
+    # The post-ack variant: same failure, same store, returns normally.
+    with caplog.at_level(logging.DEBUG, logger="curie_worker.consumer"):
+        asyncio.run(consumer._settle_delivery_best_effort(entry_id))
+
+    assert store.calls == [
+        (config.stream, config.consumer_group, entry_id),
+        (config.stream, config.consumer_group, entry_id),
+    ], f"a variant never reached the lease store at all: {store.calls}"
+
+    settle_logs = [r for r in caplog.records if "settling the delivery state" in r.getMessage()]
+    assert len(settle_logs) == 1, (
+        "the swallowed settle failure must leave exactly one trace; got "
+        f"{[r.getMessage() for r in settle_logs]}"
+    )
+    record = settle_logs[0]
+    assert record.name == "curie_worker.consumer", (
+        f"the settle warning came from {record.name}; the dead-letter alerting and "
+        "the operator's log filters both key off this logger"
+    )
+    assert record.levelno == logging.WARNING, (
+        f"the swallowed settle failure was logged at {record.levelname}, not WARNING"
+    )
+    assert entry_id in record.getMessage()
+    assert record.exc_info is not None, (
+        "the swallowed exception was not attached, so an operator cannot tell WHY "
+        "the delivery state was left behind"
+    )
+
+
+def test_the_maintenance_scan_fails_closed_when_lease_liveness_is_unreadable(
+    make_harness,
+) -> None:
+    """An unreadable ownership store reads as OWNED, never as permission.
+
+    ADR-0131: "loss of the ownership store cannot be treated as permission to
+    continue producing effects." The store here is a REAL ``DeliveryLeaseStore``
+    over a real client pointed at a dead port -- no mock -- so ``is_live``
+    raises for real and ``_lease_is_live``'s ``except`` arm is what answers.
+
+    The cost of failing closed is one skipped maintenance pass: the entry stays
+    pending and is dead-lettered on a later tick once Valkey answers again. The
+    cost of failing OPEN is a healthy turn's delivery settled underneath its
+    owner during a blip -- unrecoverable.
+
+    Red on removing the ``_dead_letter_refusal`` precondition, and equally red
+    on flipping ``_lease_is_live``'s exception handler to ``return False``. The
+    positive control is the test above: a READABLE store with no live lease
+    proceeds, so this is fail-closed and not a fence that refuses everything.
+    """
+    from curie_worker.delivery_lease import DeliveryLeaseStore
+    from redis.asyncio import Redis as AsyncRedis
+    from redis.exceptions import ConnectionError as RedisConnectionError
+
+    async def go() -> None:
+        async with make_harness(**_FENCE_CONFIG) as h:
+            # A real client that cannot reach anything: port 1 is never a Valkey.
+            unreachable = AsyncRedis(
+                host="127.0.0.1", port=1, socket_connect_timeout=0.5, decode_responses=True
+            )
+            store = DeliveryLeaseStore(unreachable, h.config)
+            consumer = Consumer(
+                redis=h.async_redis, kernel=h.kernel, config=h.config, leases=store
+            )
+            await consumer.ensure_group()
+
+            try:
+                entry_id = await _park_over_cap(h, "peer-worker")
+                with pytest.raises(RedisConnectionError):
+                    await store.is_live(h.config.stream, h.config.consumer_group, entry_id)
+
+                before = (await _pending_rows(h))[entry_id]
+                await consumer._dead_letter(
+                    entry_id,
+                    await consumer._entry_fields(entry_id),
+                    reason="max-delivery-exceeded",
+                    delivery_count=before,
+                )
+
+                assert await _dead_rows(h) == [], "settled a delivery it could not vouch for"
+                assert entry_id in await _pending_ids(h)
+                assert (await _pending_rows(h))[entry_id] == before
+            finally:
+                with contextlib.suppress(Exception):
+                    await unreachable.aclose()
+                await h.async_redis.delete(_dead_stream(h.config))
+
+    asyncio.run(go())
+
+
+def test_a_handler_that_lost_its_lease_mid_flight_may_not_dead_letter(
+    make_harness,
+) -> None:
+    """The handler branch: our OWN lease going lost is authority we no longer have.
+
+    The unparseable path reaches the graveyard from INSIDE ``_delivery_lease``,
+    so its lease is registered in ``_held_leases`` and the fence asks
+    ``held.lost`` rather than re-reading liveness. The loss here is genuine: a
+    peer XCLAIMs the PEL row, the real heartbeat's next renewal comes back
+    ``not-owner``, and ``lost`` is set by production code -- no clock is patched
+    and nothing is mocked.
+
+    A lost lease means the entry now belongs to whoever holds the fence, so the
+    refusal must leave it PENDING for them and write nothing.
+
+    Red on removing the ``_dead_letter_refusal`` precondition from
+    ``_dead_letter``: the graveyard row is written (the later
+    ``held.raise_if_lost()`` guard fires only AFTER the XADD, by design), so a
+    fenced-out owner poisons a delivery the new owner is still working.
+    """
+    from curie_worker.delivery_lease import DeliveryLeaseStore
+
+    async def go() -> None:
+        async with make_harness(**_FENCE_CONFIG) as h:
+            store = DeliveryLeaseStore(h.async_redis, h.config)
+            consumer = Consumer(
+                redis=h.async_redis, kernel=h.kernel, config=h.config, leases=store
+            )
+            await consumer.ensure_group()
+
+            try:
+                fields = {"garbage": "x", "trace": uuid.uuid4().hex[:8]}
+                await h.async_redis.xadd(h.config.stream, fields)
+                rows = await h.async_redis.xreadgroup(
+                    h.config.consumer_group,
+                    h.config.consumer_name,
+                    {h.config.stream: ">"},
+                    count=1,
+                )
+                entry_id = rows[0][1][0][0]
+
+                async with consumer._delivery_lease(entry_id, fields) as lease:
+                    assert lease is not None
+                    assert consumer._held_leases.get(entry_id) is lease, (
+                        "the handler branch of the fence is not the one under test"
+                    )
+
+                    # The real fence move: a peer takes the PEL row, so our next
+                    # renewal is refused and the heartbeat marks us lost.
+                    await h.async_redis.xclaim(
+                        h.config.stream, h.config.consumer_group, "peer-worker", 0, [entry_id]
+                    )
+                    await asyncio.wait_for(lease.lost.wait(), timeout=10.0)
+
+                    await consumer._dead_letter(
+                        entry_id, fields, reason="unparseable", delivery_count=1
+                    )
+
+                    assert await _dead_rows(h) == [], "a fenced-out owner wrote a graveyard row"
+                    assert entry_id in await _pending_ids(h), (
+                        "a fenced-out owner acked the current owner's delivery"
+                    )
+            finally:
+                await h.async_redis.delete(_dead_stream(h.config))
+
+    asyncio.run(go())
+
+
+def test_a_handler_holding_a_healthy_lease_dead_letters_normally(
+    make_harness,
+) -> None:
+    """POSITIVE CONTROL for the handler-branch refusal above.
+
+    Same path, same registered lease, same ``_dead_letter`` call -- the only
+    difference is that nothing fenced us out, so the unparseable entry must
+    reach the graveyard and be acked exactly as it always has. Without this,
+    a ``_dead_letter_refusal`` that returned a reason for every held lease
+    would leave the refusal test green while silently disabling the unparseable
+    path, and poison would go back to being reclaimed forever.
+
+    Red on a handler-branch fence that refuses a lease whose ``lost`` is clear.
+    """
+    from curie_worker.delivery_lease import DeliveryLeaseStore
+
+    async def go() -> None:
+        async with make_harness(**_FENCE_CONFIG) as h:
+            store = DeliveryLeaseStore(h.async_redis, h.config)
+            consumer = Consumer(
+                redis=h.async_redis, kernel=h.kernel, config=h.config, leases=store
+            )
+            await consumer.ensure_group()
+
+            try:
+                token = uuid.uuid4().hex[:8]
+                fields = {"garbage": "x", "trace": token}
+                await h.async_redis.xadd(h.config.stream, fields)
+                rows = await h.async_redis.xreadgroup(
+                    h.config.consumer_group,
+                    h.config.consumer_name,
+                    {h.config.stream: ">"},
+                    count=1,
+                )
+                entry_id = rows[0][1][0][0]
+                lease_key, state_key = _lease_keys(h, entry_id)
+
+                async with consumer._delivery_lease(entry_id, fields) as lease:
+                    assert lease is not None
+                    assert not lease.lost.is_set()
+                    assert consumer._held_leases.get(entry_id) is lease
+
+                    await consumer._dead_letter(
+                        entry_id, fields, reason="unparseable", delivery_count=1
+                    )
+
+                    dead = await _dead_rows(h)
+                    assert len(dead) == 1, f"a healthy owner could not dead-letter: {dead}"
+                    assert dead[0][1]["dl_original_id"] == entry_id
+                    assert dead[0][1]["dl_reason"] == "unparseable"
+                    assert dead[0][1]["trace"] == token
+                    assert entry_id not in await _pending_ids(h)
+                    assert await h.async_redis.exists(lease_key) == 0
+                    assert await h.async_redis.exists(state_key) == 0
+            finally:
+                await h.async_redis.delete(_dead_stream(h.config))
+
+    asyncio.run(go())
+
+
+def test_the_graveyard_write_precedes_the_ack_so_a_failed_write_leaves_it_pending(
+    make_harness,
+) -> None:
+    """XADD before XACK, observed through a graveyard that cannot be written.
+
+    The fence added above is a gate in FRONT of this sequence, not a reordering
+    of it, so the ordering rationale still has to hold: a crash (or a failing
+    write) between the two must cost a DUPLICATE graveyard row on the retry,
+    never a lost entry. The target is turned into a plain string key, so the
+    real XADD raises WRONGTYPE against real Valkey -- no patched client.
+
+    With XADD first, the failure happens before the ACK: the entry is still
+    pending and will be re-reclaimed and re-dead-lettered. Reverse the two and
+    this test goes red the interesting way -- the entry is acked off the group
+    with no graveyard row anywhere, which is the silent-loss failure mode the
+    ordering exists to avoid. The delivery-state key surviving is the same
+    proof from the settle side: nothing terminal ran.
+    """
+    from curie_worker.delivery_lease import DeliveryLeaseStore
+    from redis.exceptions import ResponseError
+
+    async def go() -> None:
+        async with make_harness(**_FENCE_CONFIG) as h:
+            store = DeliveryLeaseStore(h.async_redis, h.config)
+            consumer = Consumer(
+                redis=h.async_redis, kernel=h.kernel, config=h.config, leases=store
+            )
+            await consumer.ensure_group()
+            dead = _dead_stream(h.config)
+
+            try:
+                entry_id = await _park_over_cap(h, "peer-worker")
+                _lease_key, state_key = _lease_keys(h, entry_id)
+                # Give the delivery a state key to watch, then leave it unowned so
+                # the fence permits: what stops this dead-letter is the write.
+                lease = await store.acquire(
+                    h.config.stream, h.config.consumer_group, entry_id, consumer="peer-worker"
+                )
+                await store.release(
+                    h.config.stream, h.config.consumer_group, entry_id, owner=lease.owner
+                )
+
+                await h.async_redis.set(dead, "not-a-stream")
+                before = (await _pending_rows(h))[entry_id]
+
+                with pytest.raises(ResponseError):
+                    await consumer._dead_letter(
+                        entry_id,
+                        await consumer._entry_fields(entry_id),
+                        reason="max-delivery-exceeded",
+                        delivery_count=before,
+                    )
+
+                assert entry_id in await _pending_ids(h), (
+                    "the entry was acked without a graveyard row: XACK ran before XADD"
+                )
+                assert (await _pending_rows(h))[entry_id] == before
+                assert await h.async_redis.exists(state_key) == 1
+            finally:
+                await h.async_redis.delete(dead)
+
+    asyncio.run(go())

--- a/apps/worker/tests/kernel/test_delivery_ownership.py
+++ b/apps/worker/tests/kernel/test_delivery_ownership.py
@@ -1,0 +1,675 @@
+"""Fenced delivery ownership in the RUNS lane (ADR-0131, #1971).
+
+The regressions R1, R2, R3, R5, R8 from the plan's test strategy, plus the
+terminal-ACK fence, driven through the real ``Consumer`` against **real
+Valkey**. Valkey is never mocked here and that is load-bearing rather than
+stylistic: the fence *is* Valkey semantics -- atomic ``EVAL``, server ``TIME``,
+key expiry, ``XPENDING`` ownership and ``XCLAIM ... JUSTID``'s refusal to bump
+the delivery counter. A mocked store would assert only that we wrote the Lua we
+wrote.
+
+**Time is compressed by CONFIGURING short lease clocks, never by patching a
+clock.** ``_LEASE_KNOBS`` below keeps every ratio the ``WorkerConfig``
+validators enforce (TTL >= 3x heartbeat, reclaim interval < TTL, runner ceiling
+<= budget) while running in seconds. The budget stays at its configurable floor
+of 60s because nothing in this file waits the budget out -- only the lease
+clocks need to be small. The one thing deliberately NOT compressed or stubbed
+is the Valkey server ``TIME`` read: that the deadline comes from the server is
+the property under test.
+
+Every test here carries a negative control. Where a guard is asserted to
+refuse, the same path is also asserted to succeed once the guard should let it
+through -- otherwise the test passes just as happily when the whole path is
+dead.
+
+The eval-lane twins of R1-R5 live in ``tests/eval/test_stream.py`` and are
+deliberately NOT a shared parametrized body: the two lanes have genuinely
+different handler shapes (task-spawned here, inline there) and one body would
+hide exactly the difference that matters.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+import uuid
+from collections.abc import Callable
+from typing import Any
+
+from aci_protocol import Final, QueuedTurn, ReplyHandle, SessionStatus, TextDelta
+from curie_dispatcher.queue import to_stream_fields
+from curie_worker.consumer import Consumer
+from curie_worker.delivery_lease import DeliveryLeaseStore
+
+from .conftest import _pending_rows, _ProcessEventSpy
+
+DONE = SessionStatus.DONE
+
+# The compressed lease clocks. Every ratio the config validators enforce is
+# preserved: TTL (1.0) >= 3 * heartbeat (0.3); the harness's reclaim interval
+# (0.05) < TTL; the runner ceiling (30) <= the budget (60, its configurable
+# floor).
+_TTL_S = 1.0
+_HEARTBEAT_S = 0.3
+_BUDGET_S = 60.0
+
+_LEASE_KNOBS: dict[str, object] = {
+    "delivery_budget_s": _BUDGET_S,
+    "delivery_lease_ttl_s": _TTL_S,
+    "delivery_lease_heartbeat_s": _HEARTBEAT_S,
+    "runner_total_timeout_s": 30.0,
+}
+
+
+def _qevent(text: str, *, thread: str = "th-1", event_id: str | None = None) -> QueuedTurn:
+    return QueuedTurn(
+        event_id=event_id or uuid.uuid4().hex,
+        conversation_id=thread,
+        author="U1",
+        text=text,
+        reply_handle=ReplyHandle(kind="slack", channel="C1", placeholder="p-1"),
+        received_at="2026-07-05T00:00:00+00:00",
+    )
+
+
+async def _wait_until(pred: Callable[[], bool], timeout: float = 10.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if pred():
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError("condition not met within timeout")
+
+
+async def _read_one(h: Any, consumer_name: str) -> tuple[str, dict[str, str]]:
+    """Take the next new entry into ``consumer_name``'s PEL, as the read loop does."""
+    rows = await h.async_redis.xreadgroup(
+        h.config.consumer_group, consumer_name, {h.config.stream: ">"}, count=1
+    )
+    assert rows, "expected an entry to read"
+    entry_id, fields = rows[0][1][0]
+    return entry_id, dict(fields)
+
+
+async def _settle(consumer: Consumer) -> None:
+    await asyncio.gather(*list(consumer._inflight), return_exceptions=True)
+
+
+# --- R1: ownership ------------------------------------------------------------
+
+
+def test_a_second_replica_is_refused_while_the_first_holds_a_live_lease(
+    make_harness,
+) -> None:
+    """R1, the observed defect directly: two replicas, one entry.
+
+    Red on revert of the live-lease refusal in ``_ACQUIRE_LUA`` (or of the
+    ``async with self._delivery_lease(...)`` wrapper in ``Consumer._handle``):
+    without the fence BOTH handlers enter and the same turn runs twice on two
+    replicas. The refused replica must return WITHOUT acking, so the entry stays
+    pending for whoever legitimately holds it.
+
+    The negative control is the refusal; the positive control is the SECOND
+    entry, delivered to the very same refused consumer and carried all the way
+    to an ACK. Without it this test would pass just as well against a consumer
+    whose whole handler was dead.
+    """
+
+    async def go() -> None:
+        async with make_harness(**_LEASE_KNOBS) as h:
+            store = DeliveryLeaseStore(h.async_redis, h.config)
+            cfg_a = h.config.model_copy(update={"consumer_name": "worker-a"})
+            cfg_b = h.config.model_copy(update={"consumer_name": "worker-b"})
+            consumer_a = Consumer(
+                redis=h.async_redis, kernel=h.kernel, config=cfg_a, leases=store
+            )
+            consumer_b = Consumer(
+                redis=h.async_redis, kernel=h.kernel, config=cfg_b, leases=store
+            )
+            await consumer_a.ensure_group()
+            spy = _ProcessEventSpy(h.kernel)
+
+            hold = asyncio.Event()
+            h.runner.hold = hold
+            h.runner.default_script = [TextDelta(text="working")]
+            h.runner.tail = [Final(text="done", status=DONE)]
+
+            await h.async_redis.xadd(
+                h.config.stream,
+                to_stream_fields(_qevent("first", thread="own-a", event_id="own-1")),
+            )
+            entry_id, fields = await _read_one(h, "worker-a")
+            await consumer_a._dispatch(entry_id, fields)
+            await _wait_until(lambda: h.runner.turn_active)
+            assert await store.is_live(h.config.stream, h.config.consumer_group, entry_id)
+
+            # B takes the PEL row exactly as XAUTOCLAIM does on the reclaim path,
+            # so the ONLY thing standing between B and the handler is the lease.
+            await h.async_redis.xclaim(
+                h.config.stream, h.config.consumer_group, "worker-b", 0, [entry_id]
+            )
+            await consumer_b._dispatch(entry_id, dict(fields))
+            await _settle(consumer_b)
+
+            assert len(spy.leases_for("own-1")) == 1, (
+                "the refused replica entered the kernel: both owners ran the same turn"
+            )
+            assert h.runner.opened == ["first"], "the refused replica opened a second turn"
+            # Refused means "return without acking": the entry stays pending.
+            assert entry_id in await _pending_rows(h)
+
+            # POSITIVE CONTROL: the same consumer B, an entry it legitimately
+            # owns, all the way to the ACK. The refusal above was the fence and
+            # not a dead handler.
+            h.runner.hold = None
+            h.runner.default_script = [Final(text="second answer", status=DONE)]
+            await h.async_redis.xadd(
+                h.config.stream,
+                to_stream_fields(_qevent("second", thread="own-b", event_id="own-2")),
+            )
+            entry_b, fields_b = await _read_one(h, "worker-b")
+            await consumer_b._dispatch(entry_b, fields_b)
+            await _settle(consumer_b)
+
+            assert len(spy.leases_for("own-2")) == 1
+            assert spy.leases_for("own-2")[0] is not None, "the kernel was handed no lease"
+            assert entry_b not in await _pending_rows(h), "the granted delivery never acked"
+
+            hold.set()
+            await _settle(consumer_a)
+
+    asyncio.run(go())
+
+
+# --- R2: heartbeat renewal ----------------------------------------------------
+
+
+def test_a_heartbeating_handler_holds_its_lease_without_burning_a_delivery(
+    make_harness,
+) -> None:
+    """R2. Two independent reverts, both red here.
+
+    Dropping the background heartbeat expires a healthy long turn's lease
+    mid-run; dropping ``JUSTID`` from the same-owner ``XCLAIM`` burns one
+    delivery of the ADR-0039 budget per heartbeat and dead-letters a healthy turn
+    in under a minute. The delivery count stays PEL-backed and is never reset.
+
+    The negative control is the sibling entry leased directly and never
+    renewed: it expires inside the SAME window, so "the lease was still live"
+    is about the heartbeat and not about a TTL that silently never expires.
+    """
+
+    async def go() -> None:
+        async with make_harness(**_LEASE_KNOBS) as h:
+            store = DeliveryLeaseStore(h.async_redis, h.config)
+            consumer = Consumer(
+                redis=h.async_redis, kernel=h.kernel, config=h.config, leases=store
+            )
+            await consumer.ensure_group()
+
+            hold = asyncio.Event()
+            h.runner.hold = hold
+            h.runner.default_script = [TextDelta(text="working")]
+            h.runner.tail = [Final(text="done", status=DONE)]
+
+            await h.async_redis.xadd(
+                h.config.stream,
+                to_stream_fields(_qevent("long turn", thread="hb-1", event_id="hb-1")),
+            )
+            await h.async_redis.xadd(
+                h.config.stream,
+                to_stream_fields(_qevent("abandoned", thread="hb-2", event_id="hb-2")),
+            )
+            renewed_id, renewed_fields = await _read_one(h, h.config.consumer_name)
+            abandoned_id, _abandoned_fields = await _read_one(h, h.config.consumer_name)
+
+            # The negative control: same consumer, same window, NO heartbeats.
+            await store.acquire(
+                h.config.stream,
+                h.config.consumer_group,
+                abandoned_id,
+                consumer=h.config.consumer_name,
+            )
+
+            before = (await _pending_rows(h))[renewed_id]
+            await consumer._dispatch(renewed_id, renewed_fields)
+            await _wait_until(lambda: h.runner.turn_active)
+
+            # ~3x the lease TTL and ~10 heartbeat periods.
+            deadline = time.monotonic() + 3.0
+            while time.monotonic() < deadline:
+                assert await store.is_live(
+                    h.config.stream, h.config.consumer_group, renewed_id
+                ), "a healthy in-flight turn lost its lease: the heartbeat is not renewing"
+                await asyncio.sleep(0.1)
+
+            assert (
+                await store.is_live(h.config.stream, h.config.consumer_group, abandoned_id)
+                is False
+            ), "the un-renewed sibling never expired, so the lease TTL is not real"
+
+            after = (await _pending_rows(h))[renewed_id]
+            assert after == before, (
+                "the same-owner XCLAIM must use JUSTID: it reset PEL idle but "
+                f"burned {after - before} deliveries of the ADR-0039 budget"
+            )
+
+            hold.set()
+            await _settle(consumer)
+            assert renewed_id not in await _pending_rows(h)
+
+    asyncio.run(go())
+
+
+# --- R3: dead-owner reclaim ---------------------------------------------------
+
+
+def test_a_dead_owners_delivery_transfers_only_after_expiry_and_keeps_its_deadline(
+    make_harness,
+) -> None:
+    """R3, force-kill recovery.
+
+    Owner A acquires and dies without releasing (a SIGKILLed process runs no
+    ``finally``, which is why the lease is taken through the store directly here
+    rather than by cancelling a task -- cancelling would run the graceful
+    release path and prove nothing about expiry).
+
+    Red on two reverts: dropping the ``EXISTS`` gate in ``_ACQUIRE_LUA`` lets the
+    replacement steal the delivery immediately; turning the ``HSETNX`` on
+    ``deadline_ms`` into an ``HSET`` hands the replacement a fresh budget.
+
+    Negative control: refused before expiry. Positive control: granted after it,
+    with the generation incremented and the deadline inherited.
+    """
+
+    async def go() -> None:
+        async with make_harness(**_LEASE_KNOBS) as h:
+            store = DeliveryLeaseStore(h.async_redis, h.config)
+            consumer = Consumer(
+                redis=h.async_redis, kernel=h.kernel, config=h.config, leases=store
+            )
+            await consumer.ensure_group()
+            spy = _ProcessEventSpy(h.kernel)
+            h.runner.default_script = [Final(text="recovered", status=DONE)]
+
+            await h.async_redis.xadd(
+                h.config.stream,
+                to_stream_fields(_qevent("crashed turn", thread="dead-1", event_id="dead-1")),
+            )
+            entry_id, fields = await _read_one(h, "dead-owner")
+            lease_a = await store.acquire(
+                h.config.stream, h.config.consumer_group, entry_id, consumer="dead-owner"
+            )
+            assert lease_a.generation == 1
+
+            # The replacement takes the PEL row (what XAUTOCLAIM does) but the
+            # lease has not expired yet.
+            await h.async_redis.xclaim(
+                h.config.stream, h.config.consumer_group, h.config.consumer_name, 0, [entry_id]
+            )
+            await consumer._dispatch(entry_id, dict(fields))
+            await _settle(consumer)
+
+            assert spy.leases_for("dead-1") == [], (
+                "a replacement ran a delivery whose lease was still live"
+            )
+            assert h.runner.opened == []
+            assert entry_id in await _pending_rows(h)
+
+            await asyncio.sleep(_TTL_S + 0.4)
+            assert (
+                await store.is_live(h.config.stream, h.config.consumer_group, entry_id) is False
+            )
+
+            await consumer._dispatch(entry_id, dict(fields))
+            await _settle(consumer)
+
+            leases = spy.leases_for("dead-1")
+            assert len(leases) == 1, "the replacement never ran after the lease expired"
+            replacement = leases[0]
+            assert replacement is not None, "the kernel was handed no lease"
+            assert replacement.generation == 2, (
+                "the fencing generation did not increment on the change of authority"
+            )
+            assert replacement.budget.deadline_ms == lease_a.budget.deadline_ms, (
+                "the replacement minted a FRESH deadline: reclaim multiplied the budget"
+            )
+            assert h.runner.opened == ["crashed turn"]
+
+    asyncio.run(go())
+
+
+# --- R5: rollout / termination ------------------------------------------------
+
+
+def test_request_stop_stops_the_read_loop_but_never_the_heartbeat(make_harness) -> None:
+    """R5, the voluntary-rollout half.
+
+    ``request_stop()`` (what SIGTERM triggers via ``run.py:_stop``) must stop the
+    read loop taking NEW entries while the in-flight handler keeps renewing its
+    lease and runs to completion.
+
+    Red on reverting the "the heartbeat sleeps with a plain ``asyncio.sleep``,
+    never ``self._sleep_or_stop``" decision: a drain would then drop every
+    in-flight lease the instant SIGTERM landed -- a silent, high-frequency
+    regression no other test in this suite would catch.
+
+    ``reclaim_min_idle_ms`` is parked at its production value so the maintenance
+    tick cannot reclaim anything underneath the assertions; this test is about
+    the drain, not about reclaim.
+    """
+
+    async def go() -> None:
+        async with make_harness(**_LEASE_KNOBS, reclaim_min_idle_ms=900000) as h:
+            store = DeliveryLeaseStore(h.async_redis, h.config)
+            consumer = Consumer(
+                redis=h.async_redis, kernel=h.kernel, config=h.config, leases=store
+            )
+            await consumer.ensure_group()
+            spy = _ProcessEventSpy(h.kernel)
+
+            hold = asyncio.Event()
+            h.runner.hold = hold
+            h.runner.default_script = [TextDelta(text="working")]
+            h.runner.tail = [Final(text="drained", status=DONE)]
+
+            await h.async_redis.xadd(
+                h.config.stream,
+                to_stream_fields(_qevent("in flight", thread="drain-1", event_id="drain-1")),
+            )
+            task = asyncio.create_task(consumer.run())
+            await _wait_until(lambda: h.runner.turn_active)
+            inflight_ids = set(consumer._inflight_ids)
+            assert len(inflight_ids) == 1
+            entry_id = inflight_ids.pop()
+
+            # The negative control: the SAME entry pending under a second
+            # consumer group, leased directly and never renewed. A second group
+            # (rather than a second entry on this one) keeps it entirely out of
+            # the live read loop's ">" -- otherwise the loop and this test would
+            # race for it -- while still being a real PEL row, which ``acquire``
+            # requires. It must expire across the very same post-stop window, so
+            # "the in-flight lease survived" is about the heartbeat.
+            sibling_group = f"{h.config.consumer_group}-sib"
+            await h.async_redis.xgroup_create(
+                h.config.stream, sibling_group, id="0", mkstream=True
+            )
+            sibling_rows = await h.async_redis.xreadgroup(
+                sibling_group, "sib-owner", {h.config.stream: ">"}, count=1
+            )
+            sibling_id = sibling_rows[0][1][0][0]
+            await store.acquire(
+                h.config.stream, sibling_group, sibling_id, consumer="sib-owner"
+            )
+
+            consumer.request_stop()
+            # The read loop can still be parked inside a blocking XREADGROUP when
+            # the stop is set, so give it more than ``read_block_ms`` to unblock
+            # and re-check. Without this the entry below would be a coin flip
+            # rather than a test.
+            await asyncio.sleep(3 * h.config.read_block_ms / 1000)
+
+            # Nothing new is taken after the stop...
+            await h.async_redis.xadd(
+                h.config.stream,
+                to_stream_fields(_qevent("too late", thread="drain-3", event_id="drain-3")),
+            )
+            # ...while the in-flight lease is renewed across ~3 TTLs.
+            deadline = time.monotonic() + 3.0
+            while time.monotonic() < deadline:
+                assert await store.is_live(
+                    h.config.stream, h.config.consumer_group, entry_id
+                ), "request_stop() dropped the in-flight lease: the drain cannot finish"
+                await asyncio.sleep(0.1)
+
+            assert await store.is_live(h.config.stream, sibling_group, sibling_id) is False, (
+                "the un-renewed sibling never expired, so the survival above is vacuous"
+            )
+            assert "drain-3" not in [eid for eid, _ in spy.calls], (
+                "the read loop took a new entry after request_stop()"
+            )
+            lease = spy.leases_for("drain-1")[0]
+            assert lease is not None
+            assert not lease.lost.is_set(), "a draining owner was declared lease-lost"
+
+            hold.set()
+            await asyncio.wait_for(task, timeout=10.0)
+
+            # The in-flight handler ran to completion and acked.
+            assert h.sink.last_text == "drained"
+            assert entry_id not in await _pending_rows(h)
+
+    asyncio.run(go())
+
+
+def test_a_hard_killed_owner_leaves_its_lease_to_expire_before_a_replacement_runs(
+    make_harness,
+) -> None:
+    """R5, the force-kill half.
+
+    A SIGKILL runs no ``finally``, so the lease is neither released nor renewed
+    and ownership becomes transferable only by EXPIRY. Modelled by taking the
+    lease through the store and abandoning it: cancelling a task would instead
+    run the context manager's graceful release, which is the other half of R5
+    and proves nothing about expiry.
+
+    Red on revert of the expiry gate: the replacement would run immediately,
+    beside a runner the killed pod may still have live.
+    """
+
+    async def go() -> None:
+        async with make_harness(**_LEASE_KNOBS) as h:
+            store = DeliveryLeaseStore(h.async_redis, h.config)
+            consumer = Consumer(
+                redis=h.async_redis, kernel=h.kernel, config=h.config, leases=store
+            )
+            await consumer.ensure_group()
+            spy = _ProcessEventSpy(h.kernel)
+            h.runner.default_script = [Final(text="after the kill", status=DONE)]
+
+            await h.async_redis.xadd(
+                h.config.stream,
+                to_stream_fields(_qevent("killed", thread="kill-1", event_id="kill-1")),
+            )
+            entry_id, fields = await _read_one(h, "killed-worker")
+            await store.acquire(
+                h.config.stream, h.config.consumer_group, entry_id, consumer="killed-worker"
+            )
+            await h.async_redis.xclaim(
+                h.config.stream, h.config.consumer_group, h.config.consumer_name, 0, [entry_id]
+            )
+
+            # Half a TTL in, the replacement is still refused.
+            await asyncio.sleep(_TTL_S / 2)
+            await consumer._dispatch(entry_id, dict(fields))
+            await _settle(consumer)
+            assert spy.leases_for("kill-1") == []
+            assert h.runner.opened == []
+
+            # Past expiry it is granted -- the positive control that keeps the
+            # refusal above from being a dead path.
+            await asyncio.sleep(_TTL_S + 0.4)
+            await consumer._dispatch(entry_id, dict(fields))
+            await _settle(consumer)
+            assert len(spy.leases_for("kill-1")) == 1
+            assert h.runner.opened == ["killed"]
+            assert entry_id not in await _pending_rows(h)
+
+    asyncio.run(go())
+
+
+# --- R6, the ACK half: a fenced-out owner may not settle ----------------------
+
+
+def test_an_owner_that_loses_its_lease_refuses_the_terminal_ack(make_harness) -> None:
+    """AC4: lease loss prevents a stale owner ACKing.
+
+    The ownership store is made to disagree with the owner mid-turn (the lease
+    key is dropped, which is what a peer's post-expiry acquisition looks like
+    from this owner's side). The heartbeat then fails CLOSED, the lost lease
+    drives the existing bounded interrupt path, and the handler must NOT ack --
+    the entry stays pending for whoever now holds the fence.
+
+    Red on reverting ``lease.raise_if_lost()`` before ``self._ack(entry_id)`` in
+    ``Consumer._handle``: the fenced-out owner acks the delivery out from under
+    its replacement.
+
+    The sibling entry is the positive control: an unmolested delivery on the
+    same consumer acks normally, so the refusal above is the fence and not a
+    consumer that stopped acking altogether.
+    """
+
+    async def go() -> None:
+        async with make_harness(**_LEASE_KNOBS, reclaim_min_idle_ms=900000) as h:
+            store = DeliveryLeaseStore(h.async_redis, h.config)
+            consumer = Consumer(
+                redis=h.async_redis, kernel=h.kernel, config=h.config, leases=store
+            )
+            await consumer.ensure_group()
+            spy = _ProcessEventSpy(h.kernel)
+
+            hold = asyncio.Event()
+            h.runner.hold = hold
+            h.runner.default_script = [TextDelta(text="working")]
+            h.runner.tail = [Final(text="done", status=DONE)]
+
+            await h.async_redis.xadd(
+                h.config.stream,
+                to_stream_fields(_qevent("fenced out", thread="fence-1", event_id="fence-1")),
+            )
+            entry_id, fields = await _read_one(h, h.config.consumer_name)
+            await consumer._dispatch(entry_id, fields)
+            await _wait_until(lambda: h.runner.turn_active)
+
+            lease = spy.leases_for("fence-1")[0]
+            assert lease is not None, "the kernel was handed no lease"
+
+            # The ownership store no longer agrees this process is the owner.
+            await h.async_redis.delete(
+                h.config.delivery_lease_key(h.config.stream, h.config.consumer_group, entry_id)
+            )
+            await _wait_until(lease.lost.is_set, timeout=10.0)
+            # Lease loss goes through the EXISTING bounded control path, never a
+            # bare task cancel (a cancel skips the runner-side stop and leaves a
+            # turn producing effects on a sandbox we no longer own).
+            await _wait_until(lambda: h.runner.interrupts >= 1, timeout=10.0)
+
+            hold.set()
+            await _settle(consumer)
+            assert entry_id in await _pending_rows(h), (
+                "a fenced-out owner acked the delivery"
+            )
+
+            # POSITIVE CONTROL: an untouched delivery on the same consumer acks.
+            h.runner.hold = None
+            h.runner.default_script = [Final(text="clean", status=DONE)]
+            await h.async_redis.xadd(
+                h.config.stream,
+                to_stream_fields(_qevent("clean", thread="fence-2", event_id="fence-2")),
+            )
+            clean_id, clean_fields = await _read_one(h, h.config.consumer_name)
+            await consumer._dispatch(clean_id, clean_fields)
+            await _settle(consumer)
+            assert clean_id not in await _pending_rows(h)
+
+    asyncio.run(go())
+
+
+# --- R8: the budget survives reclaim ------------------------------------------
+
+
+def test_a_transferred_delivery_inherits_the_remaining_budget_not_a_fresh_one(
+    make_harness,
+) -> None:
+    """R8, scaled statement of AC2: "multiple attempts cannot multiply a
+    1,800-second budget into 5,400 seconds."
+
+    Red on reverting the ``HSETNX 'deadline_ms'`` create-if-absent semantics to a
+    plain ``HSET``: each transfer would then mint a fresh deadline and three
+    attempts would triple the configured budget.
+
+    The negative control is the SECOND entry: a genuinely first delivery does get
+    a fresh, strictly later deadline, so the deadline equality asserted for the
+    transfers is not the trivial "every deadline is the same" case.
+    """
+
+    async def go() -> None:
+        async with make_harness(**_LEASE_KNOBS) as h:
+            store = DeliveryLeaseStore(h.async_redis, h.config)
+            consumer = Consumer(
+                redis=h.async_redis, kernel=h.kernel, config=h.config, leases=store
+            )
+            await consumer.ensure_group()
+            spy = _ProcessEventSpy(h.kernel)
+            h.runner.default_script = [Final(text="ok", status=DONE)]
+
+            await h.async_redis.xadd(
+                h.config.stream,
+                to_stream_fields(_qevent("budgeted", thread="bud-1", event_id="bud-1")),
+            )
+            entry_id, fields = await _read_one(h, "first-owner")
+            lease_1 = await store.acquire(
+                h.config.stream, h.config.consumer_group, entry_id, consumer="first-owner"
+            )
+            first_remaining = lease_1.remaining_s()
+            assert 0.0 < first_remaining <= _BUDGET_S
+
+            # Two more changes of authority, each only after expiry.
+            await asyncio.sleep(_TTL_S + 0.4)
+            lease_2 = await store.acquire(
+                h.config.stream, h.config.consumer_group, entry_id, consumer="first-owner"
+            )
+            await asyncio.sleep(_TTL_S + 0.4)
+            lease_3 = await store.acquire(
+                h.config.stream, h.config.consumer_group, entry_id, consumer="first-owner"
+            )
+
+            assert [lease_1.generation, lease_2.generation, lease_3.generation] == [1, 2, 3]
+            assert lease_2.budget.deadline_ms == lease_1.budget.deadline_ms
+            assert lease_3.budget.deadline_ms == lease_1.budget.deadline_ms
+            # Not ordered against each other: ``remaining_s()`` is "budget left as
+            # of right now", and both of these are read on the same line, at the
+            # same instant, against the SAME inherited deadline -- so they are two
+            # readings of one quantity and agree to within clock noise. Ordering
+            # them would be a coin flip. What proves the budget is CONSUMED is the
+            # margin against ``first_remaining``, captured two lease TTLs earlier,
+            # which the assertions below quantify.
+            assert abs(lease_3.remaining_s() - lease_2.remaining_s()) < 0.05
+            assert lease_2.remaining_s() < first_remaining
+            assert lease_3.remaining_s() < first_remaining
+            # Three attempts never exceeded the configured budget.
+            assert first_remaining - lease_3.remaining_s() >= 2 * _TTL_S
+            assert lease_3.remaining_s() <= _BUDGET_S - 2 * _TTL_S
+
+            # And the kernel receives the inherited budget, not a fresh one: the
+            # replacement's delivery is what actually runs the turn.
+            await store.release(
+                h.config.stream, h.config.consumer_group, entry_id, owner=lease_3.owner
+            )
+            await h.async_redis.xclaim(
+                h.config.stream, h.config.consumer_group, h.config.consumer_name, 0, [entry_id]
+            )
+            await consumer._dispatch(entry_id, dict(fields))
+            await _settle(consumer)
+
+            handed = spy.leases_for("bud-1")
+            assert len(handed) == 1
+            assert handed[0] is not None, "the kernel was handed no lease"
+            assert handed[0].generation == 4
+            assert handed[0].budget.deadline_ms == lease_1.budget.deadline_ms
+            assert handed[0].remaining_s() < first_remaining - 2 * _TTL_S
+
+            # NEGATIVE CONTROL: a first delivery of a DIFFERENT entry mints its
+            # own, strictly later deadline.
+            await h.async_redis.xadd(
+                h.config.stream,
+                to_stream_fields(_qevent("fresh", thread="bud-2", event_id="bud-2")),
+            )
+            other_id, _other_fields = await _read_one(h, "first-owner")
+            fresh = await store.acquire(
+                h.config.stream, h.config.consumer_group, other_id, consumer="first-owner"
+            )
+            assert fresh.generation == 1
+            assert fresh.budget.deadline_ms > lease_1.budget.deadline_ms
+
+    asyncio.run(go())

--- a/apps/worker/tests/kernel/test_kernel.py
+++ b/apps/worker/tests/kernel/test_kernel.py
@@ -1802,3 +1802,365 @@ def test_lock_acquire_timeout_retries_in_process(make_harness) -> None:
             assert await h.async_redis.exists(h.config.done_key(ev.event_id))
 
     asyncio.run(go())
+
+
+# --- ADR-0131 (#1971): steering across a long turn, and the reclaim preflight --
+#
+# Time is compressed by CONFIGURING short lease clocks, never by patching a
+# clock. Every ratio the WorkerConfig validators enforce is preserved: TTL (1.0)
+# >= 3 * heartbeat (0.3), the harness's reclaim interval (0.05) < TTL, and the
+# runner ceiling (30) <= the budget (60, its configurable floor). The Valkey
+# server TIME read behind the deadline is deliberately never stubbed.
+
+_LEASE_TTL_S = 1.0
+
+_LEASE_KNOBS: dict[str, object] = {
+    "delivery_budget_s": 60.0,
+    "delivery_lease_ttl_s": _LEASE_TTL_S,
+    "delivery_lease_heartbeat_s": 0.3,
+    "runner_total_timeout_s": 30.0,
+}
+
+
+async def _leased_entry(h: Any, store: Any, *, event_id: str, generation: int) -> Any:
+    """A lease on a real PEL row, advanced to ``generation`` by re-acquisition.
+
+    Acquire/release/acquire is what a change of authority looks like to the
+    state hash, so this produces a genuine ``generation > 1`` lease -- the exact
+    and only signal the reclaim preflight keys on (a distributed-state fact, not
+    a sniff of the message text: kernel rule 3 stands).
+    """
+    from curie_dispatcher.queue import to_stream_fields
+
+    await h.async_redis.xadd(
+        h.config.stream, to_stream_fields(_qevent("reclaimed", event_id=event_id))
+    )
+    rows = await h.async_redis.xreadgroup(
+        h.config.consumer_group, h.config.consumer_name, {h.config.stream: ">"}, count=1
+    )
+    entry_id = rows[0][1][0][0]
+    lease = None
+    for _ in range(generation):
+        if lease is not None:
+            await store.release(
+                h.config.stream, h.config.consumer_group, entry_id, owner=lease.owner
+            )
+        lease = await store.acquire(
+            h.config.stream,
+            h.config.consumer_group,
+            entry_id,
+            consumer=h.config.consumer_name,
+        )
+    assert lease is not None and lease.generation == generation
+    return lease
+
+
+def test_a_long_turn_keeps_accepting_steers_and_a_finished_one_opens_a_new_turn(
+    make_harness,
+) -> None:
+    """R7: continued steering, before and after the old 600s boundary.
+
+    The boundary is compressed by CONFIGURING short lease clocks: the second
+    steer lands after ~3 lease TTLs and ~10 heartbeat periods, which is the same
+    place on the lease timeline that a real 600s+ turn occupies at production
+    knobs. The old flat 600s HTTP deadline is what used to cut a turn like this
+    off mid-flight; the point of the assertion is that a turn living well past
+    its lease TTL still accepts steers, has burned no deliveries, and holds a
+    live lease throughout.
+
+    Red on revert of C8's remaining-budget plumbing if it breaks steering (a
+    zero or negative per-request budget derived for ``steer``), and on any
+    regression of kernel rules 1 and 2: a follow-up on a live thread is a STEER,
+    a follow-up after the turn ends opens a NEW turn via the 409 finish-race
+    fallback, never a retried steer.
+
+    ``h.runner.opened`` is the negative control on the steering half: a steer
+    that silently became a second turn shows up there.
+    """
+    from curie_dispatcher.queue import to_stream_fields
+    from curie_worker.consumer import Consumer
+
+    # Imported inside the test on purpose: ``delivery_lease`` does not exist
+    # until this ticket lands, and a module-level import would fail COLLECTION
+    # for this whole file, turning every unrelated test in it red.
+    from curie_worker.delivery_lease import DeliveryLeaseStore
+
+    async def go() -> None:
+        async with make_harness(**_LEASE_KNOBS, reclaim_min_idle_ms=900000) as h:
+            store = DeliveryLeaseStore(h.async_redis, h.config)
+            consumer = Consumer(
+                redis=h.async_redis, kernel=h.kernel, config=h.config, leases=store
+            )
+            await consumer.ensure_group()
+
+            hold = asyncio.Event()
+            h.runner.hold = hold
+            h.runner.default_script = [TextDelta(text="working")]
+            h.runner.tail = [Final(text="done", status=DONE)]
+
+            await h.async_redis.xadd(
+                h.config.stream,
+                to_stream_fields(_qevent("first", thread="steer-1", event_id="steer-1")),
+            )
+            rows = await h.async_redis.xreadgroup(
+                h.config.consumer_group, h.config.consumer_name, {h.config.stream: ">"}, count=1
+            )
+            entry_id, fields = rows[0][1][0]
+            before = (
+                await h.async_redis.xpending_range(
+                    h.config.stream,
+                    h.config.consumer_group,
+                    min=entry_id,
+                    max=entry_id,
+                    count=1,
+                )
+            )[0]["times_delivered"]
+            await consumer._dispatch(entry_id, dict(fields))
+            await _wait_until(lambda: h.runner.turn_active)
+
+            # Early in the turn: a same-thread follow-up steers.
+            await h.kernel.process_event(_qevent("second", thread="steer-1"))
+            assert h.runner.steers == ["second"]
+            assert h.runner.opened == ["first"]
+
+            # ...and well past the compressed boundary it still steers, on a
+            # lease that is still live and has burned no deliveries.
+            await asyncio.sleep(3 * _LEASE_TTL_S)
+            assert await store.is_live(h.config.stream, h.config.consumer_group, entry_id)
+            await h.kernel.process_event(_qevent("third", thread="steer-1"))
+            assert h.runner.steers == ["second", "third"]
+            assert h.runner.opened == ["first"], "a steer opened a second turn"
+            after = (
+                await h.async_redis.xpending_range(
+                    h.config.stream,
+                    h.config.consumer_group,
+                    min=entry_id,
+                    max=entry_id,
+                    count=1,
+                )
+            )[0]["times_delivered"]
+            assert int(after) == int(before)
+
+            hold.set()
+            await asyncio.gather(*list(consumer._inflight), return_exceptions=True)
+
+            # After completion the same thread's follow-up opens a NEW turn: the
+            # steer hits 409 (no active turn) and the kernel falls back rather
+            # than retrying the steer (kernel rule 2).
+            h.runner.hold = None
+            h.runner.default_script = [Final(text="fresh", status=DONE)]
+            await h.kernel.process_event(_qevent("fourth", thread="steer-1"))
+            assert h.runner.steers == ["second", "third"], "the 409 steer was retried"
+            assert h.runner.opened == ["first", "fourth"]
+            assert h.sink.last_text == "fresh"
+
+    asyncio.run(go())
+
+
+def test_a_reclaimed_delivery_with_a_side_effect_marker_never_runs_the_runner_again(
+    make_harness,
+) -> None:
+    """Reclaim preflight rule 1 (ADR-0131, plan C10): a side-effect marker
+    forbids replay and settles to human escalation, with ZERO second runner
+    execution.
+
+    The check already exists (kernel rule 4) and needs no new code; what this
+    test pins is the ORDERING -- it must run BEFORE the transferred-delivery
+    preflight, so a preflight that interrupted, waited and then rehydrated could
+    never re-execute a half-done non-idempotent action.
+
+    Red if the preflight is inserted ahead of the side-effect check, or if the
+    marker check is made conditional on the lease being absent.
+
+    The negative control is the second event: a marker-free delivery at the same
+    generation DOES run, so "zero executions" above is the marker and not a
+    preflight that refuses everything.
+    """
+    # Imported inside the test on purpose: ``delivery_lease`` does not exist
+    # until this ticket lands, and a module-level import would fail COLLECTION
+    # for this whole file, turning every unrelated test in it red.
+    from curie_worker.delivery_lease import DeliveryLeaseStore
+
+    async def go() -> None:
+        async with make_harness(**_LEASE_KNOBS) as h:
+            store = DeliveryLeaseStore(h.async_redis, h.config)
+            await h.async_redis.xgroup_create(
+                h.config.stream, h.config.consumer_group, id="0", mkstream=True
+            )
+            h.runner.default_script = [Final(text="ok", status=DONE)]
+
+            lease = await _leased_entry(h, store, event_id="pre-se", generation=2)
+            ev = _qevent("retry me", thread="pre-se", event_id="pre-se")
+            await h.async_redis.set(h.config.side_effect_key(ev.event_id), "1")
+
+            await h.kernel.process_event(ev, lease=lease)
+
+            assert h.runner.opened == [], "a reclaimed delivery re-ran a side-effecting turn"
+            assert h.runner.interrupts == 0
+            assert h.sink.last_text is not None and "human" in h.sink.last_text.lower()
+            assert await h.async_redis.exists(h.config.done_key(ev.event_id))
+
+            # NEGATIVE CONTROL: same generation, no marker -> the turn runs.
+            clean_lease = await _leased_entry(h, store, event_id="pre-clean", generation=2)
+            clean = _qevent("run me", thread="pre-clean", event_id="pre-clean")
+            await h.kernel.process_event(clean, lease=clean_lease)
+            assert h.runner.opened == ["run me"]
+
+    asyncio.run(go())
+
+
+def test_a_reclaimed_delivery_interrupts_a_still_active_retained_runner(
+    make_harness,
+) -> None:
+    """Reclaim preflight rule 2: a runner that still reports an active turn is
+    interrupted and must become idle (or disappear) before the retry.
+
+    A replacement must not run beside a possibly-live turn on a sandbox the
+    previous owner was working. The interrupt goes through the EXISTING bounded
+    control path (``Kernel.interrupt_thread``); no second mechanism is added.
+    Note the deliberate divergence from the ordinary route: ``_route_and_start``
+    would STEER into a retained live turn, which is wrong for a redelivery of the
+    same event -- it is a retry, not a follow-up.
+
+    Red on removing the preflight: the delivery would be steered into (or opened
+    beside) the previous owner's turn with no interrupt at all.
+
+    The negative control is the second half: an IDLE retained runner at the same
+    generation is not interrupted, so the interrupt above is the liveness read
+    and not an unconditional one on every reclaim.
+    """
+    # Imported inside the test on purpose: ``delivery_lease`` does not exist
+    # until this ticket lands, and a module-level import would fail COLLECTION
+    # for this whole file, turning every unrelated test in it red.
+    from curie_worker.delivery_lease import DeliveryLeaseStore
+
+    async def go() -> None:
+        async with make_harness(**_LEASE_KNOBS) as h:
+            store = DeliveryLeaseStore(h.async_redis, h.config)
+            await h.async_redis.xgroup_create(
+                h.config.stream, h.config.consumer_group, id="0", mkstream=True
+            )
+
+            # A first, ordinary turn so the thread has a retained sandbox.
+            h.runner.default_script = [Final(text="one", status=DONE)]
+            await h.kernel.process_event(_qevent("first", thread="pre-live"))
+            assert h.runner.opened == ["first"]
+
+            # The retained runner reports a live turn (the previous owner's).
+            h.runner.turn_active = True
+
+            async def idle_on_interrupt() -> None:
+                await _wait_until(lambda: h.runner.interrupts >= 1, timeout=10.0)
+                h.runner.turn_active = False
+
+            watcher = asyncio.create_task(idle_on_interrupt())
+            lease = await _leased_entry(h, store, event_id="pre-live-2", generation=2)
+            h.runner.default_script = [Final(text="two", status=DONE)]
+            await h.kernel.process_event(
+                _qevent("second", thread="pre-live", event_id="pre-live-2"), lease=lease
+            )
+            await watcher
+
+            assert h.runner.interrupts >= 1, "the preflight never interrupted the live turn"
+            assert h.runner.opened == ["first", "second"], (
+                "the reclaimed delivery did not retry once the runner went idle"
+            )
+
+            # NEGATIVE CONTROL: an idle retained runner is not interrupted.
+            interrupts_before = h.runner.interrupts
+            idle_lease = await _leased_entry(h, store, event_id="pre-idle", generation=2)
+            h.runner.default_script = [Final(text="three", status=DONE)]
+            await h.kernel.process_event(
+                _qevent("third", thread="pre-live", event_id="pre-idle"), lease=idle_lease
+            )
+            assert h.runner.interrupts == interrupts_before, (
+                "an idle runner was interrupted: the preflight is unconditional"
+            )
+            assert h.runner.opened == ["first", "second", "third"]
+
+    asyncio.run(go())
+
+
+def test_an_unreadable_runner_fails_closed_and_leaves_a_reclaimed_delivery_pending(
+    make_harness,
+) -> None:
+    """Reclaim preflight rule 3: an unreadable runner FAILS CLOSED.
+
+    ``_turn_active`` already reports busy on an unreadable answer, so the bounded
+    poll can never clear and the preflight must raise -- leaving the stream entry
+    PENDING rather than running a replacement beside a turn whose liveness nobody
+    can read. Asserted at the consumer, because "left pending" is the observable
+    contract and does not depend on which exception type the preflight raises.
+
+    Red on making the preflight fail OPEN (proceeding when liveness is
+    unreadable), which is the failure mode a "just retry it" simplification
+    reaches for.
+
+    The negative control is the second delivery, with the status endpoint
+    healthy again: the same reclaimed entry then runs and acks.
+    """
+    from curie_dispatcher.queue import to_stream_fields
+    from curie_worker.consumer import Consumer
+
+    # Imported inside the test on purpose: ``delivery_lease`` does not exist
+    # until this ticket lands, and a module-level import would fail COLLECTION
+    # for this whole file, turning every unrelated test in it red.
+    from curie_worker.delivery_lease import DeliveryLeaseStore
+
+    async def go() -> None:
+        async with make_harness(**_LEASE_KNOBS, reclaim_min_idle_ms=900000) as h:
+            store = DeliveryLeaseStore(h.async_redis, h.config)
+            consumer = Consumer(
+                redis=h.async_redis, kernel=h.kernel, config=h.config, leases=store
+            )
+            await consumer.ensure_group()
+
+            # A first turn so the thread retains a sandbox to be read.
+            h.runner.default_script = [Final(text="one", status=DONE)]
+            await h.kernel.process_event(_qevent("first", thread="pre-blind"))
+
+            await h.async_redis.xadd(
+                h.config.stream,
+                to_stream_fields(
+                    _qevent("second", thread="pre-blind", event_id="pre-blind-2")
+                ),
+            )
+            rows = await h.async_redis.xreadgroup(
+                h.config.consumer_group, h.config.consumer_name, {h.config.stream: ">"}, count=1
+            )
+            entry_id, fields = rows[0][1][0]
+            # Take and drop a lease so the consumer's own acquisition is a
+            # TRANSFER (generation 2) and the preflight applies.
+            first = await store.acquire(
+                h.config.stream,
+                h.config.consumer_group,
+                entry_id,
+                consumer=h.config.consumer_name,
+            )
+            await store.release(
+                h.config.stream, h.config.consumer_group, entry_id, owner=first.owner
+            )
+
+            h.runner.status_fails = True
+            await consumer._dispatch(entry_id, dict(fields))
+            await asyncio.gather(*list(consumer._inflight), return_exceptions=True)
+
+            assert h.runner.opened == ["first"], (
+                "a replacement ran beside a runner whose liveness could not be read"
+            )
+            summary = await h.async_redis.xpending(h.config.stream, h.config.consumer_group)
+            assert summary["pending"] == 1, "an unreadable runner did not leave the entry pending"
+
+            # NEGATIVE CONTROL: the status endpoint recovers and the same
+            # reclaimed entry runs to an ACK.
+            h.runner.status_fails = False
+            h.runner.turn_active = False
+            h.runner.default_script = [Final(text="two", status=DONE)]
+            await consumer._dispatch(entry_id, dict(fields))
+            await asyncio.gather(*list(consumer._inflight), return_exceptions=True)
+
+            assert h.runner.opened == ["first", "second"]
+            summary = await h.async_redis.xpending(h.config.stream, h.config.consumer_group)
+            assert summary["pending"] == 0
+
+    asyncio.run(go())

--- a/apps/worker/tests/kernel/test_long_turn_evidence.py
+++ b/apps/worker/tests/kernel/test_long_turn_evidence.py
@@ -1,0 +1,762 @@
+"""The controlled long-run EVIDENCE harness for ADR-0131's Phase-4 exit gate.
+
+The gate: *"A controlled 12-15 minute test and a configured 30-minute budget
+produce regular progress, accept steering, survive the tested recovery event,
+and create exactly one terminal result."*
+
+This module is **opt-in** and skipped by the normal suite, following the same
+convention ``apps/worker/CLAUDE.md`` documents for ``CURIE_SANDBOX_E2E=1``: a
+13-minute wall-clock run has no business in the per-commit gate, and a gate that
+takes 13 minutes stops being run. Set ``CURIE_LONG_TURN_EVIDENCE=1`` to collect
+the evidence.
+
+Env knobs (all optional):
+
+- ``CURIE_LONG_TURN_SECONDS`` -- how long the turn is held open. Default 780
+  (13 minutes), the gate's window. Set ~1700 for the configured-30-minute-budget
+  run; set 45-90 to smoke the harness itself without burning the wall clock.
+- ``CURIE_LONG_TURN_SAMPLE_S`` -- sampling cadence. Default 15.
+- ``CURIE_LONG_TURN_EVIDENCE_LOG`` -- JSONL destination. Defaults to a tmp path,
+  which is printed.
+- ``CURIE_LONG_TURN_STEER_AT_S`` -- when the mid-run steer is issued. Default is
+  620 (just past the old runner deadline) when the run is long enough to reach
+  it, otherwise 60% of the hold.
+- ``CURIE_LONG_TURN_RUNNER_CEILING_S`` -- the runner client's per-request
+  ceiling. Defaults to the larger of the production ``runner_total_timeout_s``
+  (600) and ``CURIE_LONG_TURN_SECONDS + 60`` -- i.e. it tracks whatever hold
+  you configure, so the harness passes at its own defaults AND stays correct
+  for a short smoke run. Override it explicitly to rehearse the
+  request-recycle boundary (a ceiling BELOW the hold) instead.
+
+**A continuous long turn needs two knobs raised together, not one.** The
+delivery budget (``delivery_budget_s``, ADR-0039) bounds the WHOLE delivery,
+retries included; the runner ceiling (``runner_total_timeout_s``) bounds a
+SINGLE request within it. Raising only the budget does not buy one continuous
+turn past the ceiling -- it buys retries: the request is cut at the ceiling,
+the kernel retries, the retry steers the still-live turn, and the delivery
+settles there instead of running continuously. A genuinely continuous hold
+therefore requires raising the per-request ceiling to at least the hold
+length, in addition to the delivery budget. Assertion 0 below is what
+originally taught us this relationship, and its message names both knobs.
+
+**Why the assertions are conditional on the elapsed time.** The 600s and 900s
+boundaries are the two clocks ADR-0131 replaced (the runner's flat HTTP deadline
+and the PEL-idle steal window). A run configured shorter than a boundary never
+reaches it, and asserting a crossing that did not happen would be a green test
+about nothing. Each boundary assertion therefore fires only when the run
+actually got there, and the summary block reports which ones were exercised.
+
+**The per-request ceiling is a real boundary this run can hit.** A runner
+request is bounded by ``min(runner_total_timeout_s, remaining budget)`` and that
+bound is aiohttp's ``total``, which streamed progress does not reset. A hold
+longer than the ceiling therefore does NOT produce one continuous 13-minute
+runner request: the request is cut, the kernel retries, the retry steers the
+retained live turn, and the delivery settles there. Assertion 0 below refuses to
+let that pass as evidence, and its message names the knob.
+
+**Nothing here is mocked.** Real Valkey, the real ``DeliveryLeaseStore`` Lua,
+two real ``Consumer`` replicas with distinct names on one group running their own
+read and maintenance loops, and the in-process fake runner from ``conftest``.
+The negative control below is driven through the same real machinery: the whole
+point of a falsifiable control is that it would be worthless if the failure it
+demonstrates were produced by a stub.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import json
+import os
+import resource
+import subprocess
+import time
+import uuid
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import aiohttp
+import pytest
+from aci_protocol import Final, QueuedTurn, ReplyHandle, SessionStatus, TextDelta
+from curie_dispatcher.queue import to_stream_fields
+from curie_worker.consumer import Consumer
+from curie_worker.delivery_lease import DeliveryLeaseStore
+
+from .conftest import _ProcessEventSpy
+
+pytestmark = pytest.mark.skipif(
+    "CURIE_LONG_TURN_EVIDENCE" not in os.environ,
+    reason=(
+        "long-run ADR-0131 evidence harness; opt in with CURIE_LONG_TURN_EVIDENCE=1 "
+        "(a 13-minute wall-clock run does not belong in the per-commit suite)"
+    ),
+)
+
+DONE = SessionStatus.DONE
+
+# The two clocks ADR-0131 replaced. Named here rather than inlined because every
+# conditional assertion below is about one of them.
+OLD_RUNNER_DEADLINE_S = 600.0
+OLD_PEL_IDLE_RECLAIM_S = 900.0
+
+# Production-shaped knobs, exactly as the exit gate specifies them. Nothing is
+# compressed: this run is about real-time behavior at real settings, which is
+# what separates it from the compressed regressions in
+# ``test_delivery_ownership.py``.
+#
+# ``reclaim_min_idle_ms`` is pinned to its PRODUCTION default (900000) rather
+# than the harness's 50ms. That is load-bearing: ``_reclaim_once`` runs
+# ``XAUTOCLAIM`` BEFORE its liveness check, so a compressed idle window would
+# bump ``times_delivered`` on a healthy peer's entry every maintenance tick and
+# make the JUSTID assertion below unprovable. At the production window the
+# heartbeat's ``XCLAIM ... JUSTID`` keeps PEL idle near the heartbeat interval
+# and the entry never becomes a reclaim candidate at all -- which is the
+# property under test.
+_PROD_KNOBS: dict[str, object] = {
+    "delivery_budget_s": 1800.0,
+    "delivery_lease_ttl_s": 45.0,
+    "delivery_lease_heartbeat_s": 10.0,
+    "reclaim_interval_s": 30.0,
+    "runner_total_timeout_s": 600.0,
+    "reclaim_min_idle_ms": 900000,
+}
+
+# The negative control's compressed clocks. Every ratio the WorkerConfig
+# validators enforce is preserved (TTL >= 3x heartbeat, reclaim interval < TTL,
+# runner ceiling <= budget); the budget sits at its configurable floor because
+# nothing in the control waits a budget out. ``reclaim_min_idle_ms`` IS
+# compressed here on purpose -- the control needs the reclaim path to fire, and
+# it costs seconds rather than the 15 minutes of PEL idle production would need.
+_CONTROL_TTL_S = 1.0
+_CONTROL_KNOBS: dict[str, object] = {
+    "delivery_budget_s": 60.0,
+    "delivery_lease_ttl_s": _CONTROL_TTL_S,
+    "delivery_lease_heartbeat_s": 0.3,
+    "reclaim_interval_s": 0.25,
+    "runner_total_timeout_s": 30.0,
+    "reclaim_min_idle_ms": 300,
+    "dead_consumer_idle_ms": 300,
+}
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.environ.get(name)
+    return default if raw in (None, "") else float(str(raw))
+
+
+def _qevent(text: str, *, thread: str, event_id: str | None = None) -> QueuedTurn:
+    return QueuedTurn(
+        event_id=event_id or uuid.uuid4().hex,
+        conversation_id=thread,
+        author="U1",
+        text=text,
+        reply_handle=ReplyHandle(kind="slack", channel="C1", placeholder="p-1"),
+        received_at="2026-08-28T00:00:00+00:00",
+    )
+
+
+async def _wait_until(pred: Callable[[], bool], timeout: float = 30.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if pred():
+            return
+        await asyncio.sleep(0.05)
+    raise AssertionError("condition not met within timeout")
+
+
+class _DispatchSpy:
+    """Counts the entries one replica's OWN loops handed to its handler.
+
+    Both entry points have to be wrapped. ``_read_loop`` resolves
+    ``self._dispatch`` at call time, but ``DeliverySpec.handler`` was bound to
+    the original method in ``Consumer.__init__``, so the reclaim path -- the
+    one that actually matters here, because cross-replica takeover arrives
+    through reclaim and never through a read -- would otherwise slip past the
+    spy and make this recorder silently blind to the single case it exists to
+    observe. ``DeliverySpec`` is frozen, hence ``dataclasses.replace``.
+    """
+
+    def __init__(self, consumer: Consumer) -> None:
+        self._inner = consumer._dispatch
+        self.ids: list[str] = []
+        consumer._dispatch = self  # type: ignore[method-assign]
+        consumer._delivery = dataclasses.replace(consumer._delivery, handler=self)
+
+    async def __call__(self, entry_id: str, fields: dict[str, str]) -> None:
+        self.ids.append(entry_id)
+        await self._inner(entry_id, fields)
+
+
+def _proc_usage() -> dict[str, float]:
+    """Process CPU seconds, RSS, and swap, with no new dependency.
+
+    ``ru_maxrss`` is a high-water mark, so it can only grow; ``VmRSS`` from
+    ``/proc/self/status`` is the instantaneous value and is what makes a leak
+    across a 13-minute hold visible. Both are recorded because a run whose peak
+    and current diverge tells a different story from one where they track.
+    ``VmSwap`` is read from the same file for free: a long hold that starts
+    swapping is a distinct failure shape from one that just grows RSS.
+    """
+    ru = resource.getrusage(resource.RUSAGE_SELF)
+    rss_kb = 0.0
+    swap_kb = 0.0
+    try:
+        for line in Path("/proc/self/status").read_text().splitlines():
+            if line.startswith("VmRSS:"):
+                rss_kb = float(line.split()[1])
+            elif line.startswith("VmSwap:"):
+                swap_kb = float(line.split()[1])
+    except OSError:  # pragma: no cover - /proc absent
+        pass
+    return {
+        "cpu_s": round(ru.ru_utime + ru.ru_stime, 3),
+        "rss_kb": rss_kb,
+        "peak_rss_kb": float(ru.ru_maxrss),
+        "swap_kb": swap_kb,
+    }
+
+
+def _container_count() -> int | None:
+    """Running container count via ``docker ps``, read defensively.
+
+    This harness must not become dependent on Docker being present: a missing
+    binary, no daemon, or no permissions all record ``None`` instead of
+    failing the run.
+    """
+    try:
+        result = subprocess.run(
+            ["docker", "ps", "-q"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=True,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return len([line for line in result.stdout.splitlines() if line.strip()])
+
+
+async def _pel_row(h: Any, entry_id: str) -> dict[str, Any] | None:
+    rows = await h.async_redis.xpending_range(
+        h.config.stream, h.config.consumer_group, min=entry_id, max=entry_id, count=1
+    )
+    return dict(rows[0]) if rows else None
+
+
+def _evidence_log_path(tmp_path: Path) -> Path:
+    configured = os.environ.get("CURIE_LONG_TURN_EVIDENCE_LOG")
+    if configured:
+        path = Path(configured)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        return path
+    return tmp_path / "long-turn-evidence.jsonl"
+
+
+# --- Test 1: the positive run -------------------------------------------------
+
+
+def test_a_long_delivery_survives_both_old_clocks_and_settles_exactly_once(
+    make_harness, tmp_path: Path
+) -> None:
+    """The Phase-4 exit-gate evidence run (ADR-0131).
+
+    Two real replicas on one group, production knobs, one turn held open for
+    ``CURIE_LONG_TURN_SECONDS`` (default 780s). Samples every 15s to JSONL, then
+    asserts the ADR's five delivery-level claims.
+
+    Reverts that turn this red, each named against the property it breaks:
+
+    - Remove the background heartbeat task in
+      ``StreamConsumer._delivery_lease`` -> the lease expires mid-turn, the peer
+      becomes eligible, and both the second-replica and the terminal-result
+      assertions fail.
+    - Drop ``JUSTID`` from the same-owner ``XCLAIM`` in ``_HEARTBEAT_LUA`` ->
+      ``times_delivered`` climbs one per heartbeat and the ADR-0039 budget is
+      dead-lettered out from under a healthy turn.
+    - Remove the ``EXISTS`` refusal from ``_ACQUIRE_LUA``, or the
+      ``_lease_is_live`` guards in ``_reclaim_once`` /
+      ``_dead_letter_over_cap`` -> the peer replica enters the handler.
+    - Revert the ``HSETNX`` on ``deadline_ms`` to ``HSET`` -> the remaining
+      budget stops declining monotonically across the run.
+    - Revert C8's ``remaining_s`` plumbing into ``RunnerClient.steer`` in a way
+      that derives a non-positive per-request budget -> the mid-run steer is
+      refused, breaking kernel rule 1 ("steering is never blocked").
+
+    The negative control for the whole run lives in the companion test below:
+    without it, "nothing bad happened in 13 minutes" would be indistinguishable
+    from a harness that cannot observe anything bad at all.
+    """
+    hold_s = _env_float("CURIE_LONG_TURN_SECONDS", 780.0)
+    sample_s = _env_float("CURIE_LONG_TURN_SAMPLE_S", 15.0)
+    # Self-consistent default: assertion 0 requires the ceiling to accommodate
+    # the hold (a request cut short of the hold makes the delivery settle
+    # early), so the default tracks whatever hold is configured rather than
+    # pinning to the production value alone.
+    ceiling_s = _env_float(
+        "CURIE_LONG_TURN_RUNNER_CEILING_S",
+        max(float(_PROD_KNOBS["runner_total_timeout_s"]), hold_s + 60.0),  # type: ignore[arg-type]
+    )
+    default_steer_at = (
+        OLD_RUNNER_DEADLINE_S + 20.0 if hold_s > OLD_RUNNER_DEADLINE_S + 60.0 else hold_s * 0.6
+    )
+    steer_at_s = _env_float("CURIE_LONG_TURN_STEER_AT_S", default_steer_at)
+    log_path = _evidence_log_path(tmp_path)
+    thread = "evidence-long-1"
+    long_event_id = "evidence-long-1"
+
+    async def go() -> None:
+        async with make_harness(**_PROD_KNOBS) as h:
+            store = DeliveryLeaseStore(h.async_redis, h.config)
+            cfg_a = h.config.model_copy(update={"consumer_name": "replica-a"})
+            cfg_b = h.config.model_copy(update={"consumer_name": "replica-b"})
+            consumer_a = Consumer(redis=h.async_redis, kernel=h.kernel, config=cfg_a, leases=store)
+            consumer_b = Consumer(redis=h.async_redis, kernel=h.kernel, config=cfg_b, leases=store)
+            dispatch_a = _DispatchSpy(consumer_a)
+            dispatch_b = _DispatchSpy(consumer_b)
+            spy = _ProcessEventSpy(h.kernel)
+
+            # The harness's RunnerClient is built with a 30s ceiling, which no
+            # existing test outgrows and this one does within half a minute.
+            # Raised to the CONFIGURED per-request ceiling so the run measures
+            # ADR-0131's real shape -- a long delivery made of bounded requests
+            # -- rather than a harness artifact. Both the session default and the
+            # budget-derived override are set: the override is what a leased
+            # delivery uses, the default is the fallback, and leaving them
+            # inconsistent would make a plumbing regression look like a timeout.
+            runner_client = h.kernel._runner
+            runner_client._total_timeout_s = ceiling_s
+            runner_client._session._timeout = aiohttp.ClientTimeout(
+                total=ceiling_s, connect=runner_client._connect_timeout_s, sock_read=ceiling_s
+            )
+
+            hold = asyncio.Event()
+            h.runner.hold = hold
+            h.runner.default_script = [TextDelta(text="working on the long run")]
+            h.runner.tail = [Final(text="long run complete", status=DONE)]
+
+            # The group is created at ``$`` (see ``Consumer.ensure_group``), so it
+            # MUST exist before the turn is enqueued. Leaving it to the replicas'
+            # own startup is a race that loses the entry outright whenever the
+            # XADD wins -- a silently empty run, not a failure.
+            await consumer_a.ensure_group()
+            task_a = asyncio.create_task(consumer_a.run())
+            task_b = asyncio.create_task(consumer_b.run())
+            samples: list[dict[str, Any]] = []
+            started = time.monotonic()
+            try:
+                await h.async_redis.xadd(
+                    h.config.stream,
+                    to_stream_fields(
+                        _qevent("start the long run", thread=thread, event_id=long_event_id)
+                    ),
+                )
+                await _wait_until(lambda: h.runner.turn_active, timeout=60.0)
+                started = time.monotonic()
+
+                # Whichever replica won the read is "the owner"; the other is the
+                # peer whose intrusion the fence must prevent. Deriving it rather
+                # than assigning it keeps the race real: two replicas on one
+                # group genuinely compete for the read.
+                inflight = set(consumer_a._inflight_ids) | set(consumer_b._inflight_ids)
+                assert len(inflight) == 1, f"expected one in-flight entry, saw {inflight!r}"
+                entry_id = inflight.pop()
+                owner = "replica-a" if entry_id in consumer_a._inflight_ids else "replica-b"
+                peer_dispatch = dispatch_b if owner == "replica-a" else dispatch_a
+
+                lease = spy.leases_for(long_event_id)[0]
+                assert lease is not None, "the kernel was handed no lease"
+                first_remaining = lease.remaining_s()
+
+                steered_at: float | None = None
+                steer_accepted: str | None = None
+                with log_path.open("w", encoding="utf-8") as log:
+
+                    async def emit(note: str) -> dict[str, Any]:
+                        elapsed = time.monotonic() - started
+                        row = await _pel_row(h, entry_id)
+                        state = await store.peek(h.config.stream, h.config.consumer_group, entry_id)
+                        sample: dict[str, Any] = {
+                            "note": note,
+                            "elapsed_s": round(elapsed, 2),
+                            "owner": owner,
+                            "entry_id": entry_id,
+                            "pel_present": row is not None,
+                            "times_delivered": int(row["times_delivered"]) if row else None,
+                            "pel_idle_ms": int(row["time_since_delivered"]) if row else None,
+                            "pel_consumer": str(row["consumer"]) if row else None,
+                            "lease_live": await store.is_live(
+                                h.config.stream, h.config.consumer_group, entry_id
+                            ),
+                            "lease_lost": lease.lost.is_set(),
+                            "generation": int(state["gen"]) if "gen" in state else None,
+                            "remaining_budget_s": round(lease.remaining_s(), 2),
+                            "handler_entries": spy.entries_for(long_event_id),
+                            "peer_dispatches": len(peer_dispatch.ids),
+                            "peer_entered_handler": spy.entries_for(long_event_id) > 1,
+                            "runner_turns_opened": len(h.runner.opened),
+                            "runner_steers": len(h.runner.steers),
+                            "runner_turn_active": h.runner.turn_active,
+                            "sink_completions": len(h.sink.completions),
+                            "container_count": _container_count(),
+                            **_proc_usage(),
+                        }
+                        samples.append(sample)
+                        log.write(json.dumps(sample) + "\n")
+                        log.flush()
+                        return sample
+
+                    await emit("start")
+                    while True:
+                        elapsed = time.monotonic() - started
+                        if elapsed >= hold_s:
+                            break
+                        if steered_at is None and elapsed >= steer_at_s:
+                            # Kernel rule 1: a follow-up on a live thread is a
+                            # STEER and is NEVER blocked. Rule 2: if the turn
+                            # finished underneath us the steer gets a 409 and the
+                            # kernel opens a fresh turn instead of retrying it.
+                            # Either outcome is "accepted"; a raise or a hang is
+                            # not, which is why it is bounded here.
+                            steers_before = len(h.runner.steers)
+                            opened_before = len(h.runner.opened)
+                            steer_started = time.monotonic()
+                            await asyncio.wait_for(
+                                h.kernel.process_event(
+                                    _qevent("also check the disk usage", thread=thread)
+                                ),
+                                timeout=120.0,
+                            )
+                            steered_at = time.monotonic() - started
+                            if len(h.runner.steers) > steers_before:
+                                steer_accepted = "steered"
+                            elif len(h.runner.opened) > opened_before:
+                                steer_accepted = "409-fallback-new-turn"
+                            await emit(
+                                f"steer:{steer_accepted or 'rejected'}"
+                                f":{round(time.monotonic() - steer_started, 2)}s"
+                            )
+                            continue
+                        await asyncio.sleep(min(sample_s, max(0.1, hold_s - elapsed)))
+                        if time.monotonic() - started >= hold_s:
+                            break
+                        await emit("sample")
+
+                    final_sample = await emit("hold-release")
+                    ran_for = final_sample["elapsed_s"]
+
+                    hold.set()
+                    await asyncio.gather(
+                        *list(consumer_a._inflight),
+                        *list(consumer_b._inflight),
+                        return_exceptions=True,
+                    )
+                    await emit("settled")
+
+                # -- the ADR's claims -------------------------------------------
+                delivered = [s["times_delivered"] for s in samples if s["times_delivered"]]
+                idles = [s["pel_idle_ms"] for s in samples if s["pel_idle_ms"] is not None]
+                remaining = [s["remaining_budget_s"] for s in samples]
+
+                pre_release = [s for s in samples if s["note"] != "settled"]
+                settled_at = next(
+                    (s["elapsed_s"] for s in pre_release if not s["pel_present"]), None
+                )
+
+                summary = {
+                    "log": str(log_path),
+                    "delivery_settled_at_s": settled_at,
+                    "samples": len(samples),
+                    "ran_for_s": ran_for,
+                    "configured_hold_s": hold_s,
+                    "runner_request_ceiling_s": ceiling_s,
+                    "owner": owner,
+                    "crossed_600s": ran_for > OLD_RUNNER_DEADLINE_S,
+                    "crossed_900s": ran_for > OLD_PEL_IDLE_RECLAIM_S,
+                    "times_delivered": sorted(set(delivered)),
+                    "max_pel_idle_ms": max(idles) if idles else None,
+                    "handler_entries": spy.entries_for(long_event_id),
+                    "peer_dispatches": len(peer_dispatch.ids),
+                    "runner_turns_opened": h.runner.opened,
+                    "runner_steers": h.runner.steers,
+                    "steered_at_s": steered_at,
+                    "steer_outcome": steer_accepted,
+                    "budget_first_remaining_s": round(first_remaining, 2),
+                    "budget_last_remaining_s": remaining[-1],
+                    "completions": [(c.event_id, c.outcome) for c in h.sink.completions],
+                    "container_count": _container_count(),
+                    **_proc_usage(),
+                }
+                print("\n=== ADR-0131 LONG-TURN EVIDENCE ===")
+                print(json.dumps(summary, indent=2, sort_keys=True))
+                print("=== END EVIDENCE ===\n")
+
+                # 0. The delivery was STILL IN FLIGHT when the hold was released.
+                #    Without this the whole run is unfalsifiable: every assertion
+                #    below is also satisfied by a delivery that quietly settled
+                #    at the per-request ceiling and left the harness measuring an
+                #    idle system for the remaining minutes.
+                assert final_sample["pel_present"] and final_sample["lease_live"], (
+                    f"the delivery settled at ~{settled_at}s, well before the hold was "
+                    f"released at {ran_for}s, so this run measured an idle system for the "
+                    "rest of its window. One runner request is hard-capped at "
+                    "min(runner_total_timeout_s, remaining budget) = "
+                    f"{ceiling_s}s -- aiohttp's ``total``, which model progress does NOT "
+                    "reset. Past it the kernel retries, the retry finds the retained turn "
+                    "still live and STEERS it (kernel rule 1), and the steer's attempt "
+                    "returns terminal_ok, so the delivery settles 'delivered' there. The "
+                    "1800s budget therefore does not extend one CONTINUOUS turn beyond "
+                    "that ceiling. Raise CURIE_LONG_TURN_RUNNER_CEILING_S above "
+                    "CURIE_LONG_TURN_SECONDS to evidence the single-request shape, or "
+                    "report this as the gate's finding."
+                )
+
+                # 1. The delivery outlived the clocks ADR-0131 replaced. Both are
+                #    conditional: a run configured shorter than a boundary never
+                #    reached it, and asserting a crossing that did not happen
+                #    would be a green assertion about nothing.
+                if ran_for > OLD_RUNNER_DEADLINE_S:
+                    assert h.sink.completions, (
+                        "the delivery produced no terminal result after living past the "
+                        f"old {OLD_RUNNER_DEADLINE_S}s runner deadline"
+                    )
+                if ran_for > OLD_PEL_IDLE_RECLAIM_S:
+                    assert spy.entries_for(long_event_id) == 1, (
+                        "a second handler entry appeared after the old "
+                        f"{OLD_PEL_IDLE_RECLAIM_S}s PEL-idle reclaim threshold: the "
+                        "lease did not keep the healthy turn un-reclaimable"
+                    )
+                # The always-available form of the same property: the heartbeat's
+                # XCLAIM ... JUSTID keeps PEL idle pinned near the heartbeat
+                # interval, so the entry never even approaches the reclaim
+                # window, whatever the run's length.
+                if idles:
+                    assert max(idles) < float(_PROD_KNOBS["delivery_lease_ttl_s"]) * 1000, (  # type: ignore[arg-type]
+                        f"PEL idle reached {max(idles)}ms, past the lease TTL: the "
+                        "heartbeat is not resetting same-owner idle with JUSTID"
+                    )
+
+                # 2. XCLAIM ... JUSTID: not one delivery of the ADR-0039 budget
+                #    was burned across the whole run.
+                assert len(set(delivered)) <= 1, (
+                    f"times_delivered moved across the run ({sorted(set(delivered))}): the "
+                    "heartbeat's same-owner XCLAIM is burning the ADR-0039 delivery budget"
+                )
+
+                # 3. One delivery, one execution. The peer replica ran its own
+                #    read and maintenance loops for the entire hold and never
+                #    entered the handler.
+                assert spy.entries_for(long_event_id) == 1, (
+                    f"the handler was entered {spy.entries_for(long_event_id)} times for one "
+                    "delivery: the fence let a second replica run the same turn"
+                )
+                assert entry_id not in peer_dispatch.ids, (
+                    f"the peer replica dispatched entry {entry_id}: reclaim did not "
+                    "check the live lease before dispatching"
+                )
+
+                # 4. Steering was accepted mid-run (kernel rule 1, with rule 2's
+                #    409 fallback as the other legal outcome).
+                assert steered_at is not None, "the mid-run steer was never issued"
+                assert steer_accepted is not None, (
+                    "the mid-run steer was neither delivered to the live turn nor "
+                    "converted into a fresh turn by the 409 finish-race fallback: "
+                    "steering was blocked, which kernel rule 1 forbids"
+                )
+                if ran_for > OLD_RUNNER_DEADLINE_S:
+                    assert steered_at > OLD_RUNNER_DEADLINE_S, (
+                        f"the steer landed at {steered_at}s, before the old "
+                        f"{OLD_RUNNER_DEADLINE_S}s boundary this run exists to cross"
+                    )
+
+                # 5. Exactly ONE user-visible terminal effect, and the delivery
+                #    is settled off the group.
+                terminal = [c for c in h.sink.completions if c.event_id == long_event_id]
+                assert len(terminal) == 1, (
+                    f"expected exactly one terminal result for {long_event_id}, got "
+                    f"{[(c.event_id, c.outcome) for c in h.sink.completions]}"
+                )
+                assert terminal[0].outcome == "delivered", (
+                    f"the long delivery settled as {terminal[0].outcome!r}, not delivered"
+                )
+                assert await _pel_row(h, entry_id) is None, (
+                    "the delivery was never acked: it is still pending after settling"
+                )
+                assert not await store.is_live(
+                    h.config.stream, h.config.consumer_group, entry_id
+                ), "the lease outlived the settled delivery"
+
+                # 6. The budget was CONSUMED, never restarted. A reverted HSETNX
+                #    shows up here as a remaining budget that stopped declining.
+                assert remaining[-1] < first_remaining, (
+                    "the remaining delivery budget did not decline across the run: "
+                    "something re-minted the deadline instead of inheriting it"
+                )
+            finally:
+                consumer_a.request_stop()
+                consumer_b.request_stop()
+                hold.set()
+                for task in (task_a, task_b):
+                    task.cancel()
+                await asyncio.gather(task_a, task_b, return_exceptions=True)
+
+    asyncio.run(go())
+
+
+# --- Test 2: the falsifiable negative control ---------------------------------
+
+
+def test_control_without_heartbeat_renewal_a_second_replica_does_take_the_turn(
+    make_harness, tmp_path: Path
+) -> None:
+    """THE CONTROL. The pre-fix failure, reproduced and asserted POSITIVELY.
+
+    The positive run above proves nothing on its own: "no duplicate execution in
+    13 minutes" is exactly what a harness that cannot see a duplicate execution
+    also reports. So the same machinery -- real Valkey, the real Lua, two real
+    ``Consumer`` replicas, the real reclaim loop -- is run with the owner's
+    heartbeat effectively disabled (its store is handed a heartbeat interval far
+    longer than the lease TTL, which is precisely what deleting the renewal does
+    to a live turn). The owner's lease then expires UNDER a still-running turn,
+    and the test passes only when the bad thing is observed: the peer replica
+    enters the handler for the same delivery and ``times_delivered`` increases.
+
+    Clocks are compressed so this costs seconds, not minutes. Real-time scale is
+    what the positive run is for; falsification does not need it.
+
+    Nothing is stubbed. The heartbeat is disabled by CONFIGURATION, so every
+    Valkey round trip, every Lua guard, and the reclaim path itself are the
+    production ones. A mocked store here would assert only that the mock did
+    what the mock was told, which is the failure mode this control exists to
+    rule out for the run above.
+
+    What turns THIS test red is over-fencing: if lease expiry stopped working,
+    or a reclaim path grew an unconditional skip, an abandoned delivery would
+    never be recovered by anyone and the fence would have traded duplicate
+    execution for permanent stranding. That is the opposite regression, and it
+    is exactly as bad.
+    """
+    log_path = tmp_path / "long-turn-control.jsonl"
+    thread = "evidence-control-1"
+    control_event_id = "evidence-control-1"
+
+    async def go() -> None:
+        async with make_harness(**_CONTROL_KNOBS) as h:
+            cfg_a = h.config.model_copy(update={"consumer_name": "control-a"})
+            cfg_b = h.config.model_copy(update={"consumer_name": "control-b"})
+            # The whole mutation, in one line: the OWNER's store believes it must
+            # renew once an hour, so the 1s lease expires under a live turn. The
+            # peer's store is untouched, so recovery runs at production fidelity.
+            # ``model_copy`` deliberately bypasses the config validator that
+            # forbids this ratio -- a config this broken is not reachable through
+            # the constructor, which is the point of the validator and the reason
+            # the mutation has to be applied here.
+            store_a = DeliveryLeaseStore(
+                h.async_redis, cfg_a.model_copy(update={"delivery_lease_heartbeat_s": 3600.0})
+            )
+            store_b = DeliveryLeaseStore(h.async_redis, cfg_b)
+            consumer_a = Consumer(
+                redis=h.async_redis, kernel=h.kernel, config=cfg_a, leases=store_a
+            )
+            consumer_b = Consumer(
+                redis=h.async_redis, kernel=h.kernel, config=cfg_b, leases=store_b
+            )
+            dispatch_b = _DispatchSpy(consumer_b)
+            spy = _ProcessEventSpy(h.kernel)
+            await consumer_a.ensure_group()
+
+            hold = asyncio.Event()
+            h.runner.hold = hold
+            h.runner.default_script = [TextDelta(text="working")]
+            h.runner.tail = [Final(text="control done", status=DONE)]
+
+            task_b: asyncio.Task[None] | None = None
+            try:
+                await h.async_redis.xadd(
+                    h.config.stream,
+                    to_stream_fields(
+                        _qevent("control run", thread=thread, event_id=control_event_id)
+                    ),
+                )
+                rows = await h.async_redis.xreadgroup(
+                    h.config.consumer_group, "control-a", {h.config.stream: ">"}, count=1
+                )
+                entry_id, fields = rows[0][1][0]
+                before = int((await _pel_row(h, entry_id))["times_delivered"])  # type: ignore[index]
+
+                await consumer_a._dispatch(entry_id, dict(fields))
+                await _wait_until(lambda: h.runner.turn_active, timeout=30.0)
+                assert spy.entries_for(control_event_id) == 1
+                assert await store_b.is_live(h.config.stream, h.config.consumer_group, entry_id), (
+                    "the owner never took a lease at all; the control would be vacuous"
+                )
+
+                # The lease expires under the still-running turn.
+                await asyncio.sleep(_CONTROL_TTL_S + 0.5)
+                assert h.runner.turn_active, (
+                    "the turn ended before the lease expired; the control never "
+                    "reached the state it exists to demonstrate"
+                )
+                expired = not await store_b.is_live(
+                    h.config.stream, h.config.consumer_group, entry_id
+                )
+                assert expired, (
+                    "the un-renewed lease never expired, so the fence was never "
+                    "actually open and anything observed below proves nothing"
+                )
+
+                # Now the peer's real reclaim loop is the only actor.
+                task_b = asyncio.create_task(consumer_b.run())
+                await _wait_until(lambda: spy.entries_for(control_event_id) >= 2, timeout=30.0)
+
+                after_row = await _pel_row(h, entry_id)
+                after = int(after_row["times_delivered"]) if after_row else before
+                record = {
+                    "entry_id": entry_id,
+                    "handler_entries": spy.entries_for(control_event_id),
+                    "peer_dispatches": dispatch_b.ids,
+                    "times_delivered_before": before,
+                    "times_delivered_after": after,
+                    "pel_consumer": str(after_row["consumer"]) if after_row else None,
+                    "runner_turn_active_after_takeover": h.runner.turn_active,
+                    "generations": (
+                        await DeliveryLeaseStore(h.async_redis, cfg_b).peek(
+                            h.config.stream, h.config.consumer_group, entry_id
+                        )
+                    ),
+                }
+                log_path.write_text(json.dumps(record) + "\n", encoding="utf-8")
+                print("\n=== ADR-0131 NEGATIVE CONTROL (pre-fix failure) ===")
+                print(json.dumps(record, indent=2, sort_keys=True))
+                print("=== END CONTROL ===\n")
+
+                # Asserted POSITIVELY: this test passes because the bad thing
+                # happened. Both halves of the observed defect are named.
+                assert record["handler_entries"] >= 2, (
+                    "the peer replica never entered the handler even with the owner's "
+                    "lease expired under a live turn -- this control cannot falsify "
+                    "the positive run, so the positive run proves nothing"
+                )
+                assert entry_id in dispatch_b.ids, (
+                    "the second handler entry did not come from the peer replica's "
+                    "own reclaim loop, so it is not the cross-replica defect"
+                )
+                assert after > before, (
+                    "times_delivered did not increase on takeover: without the "
+                    "heartbeat's XCLAIM ... JUSTID the ADR-0039 budget must be burned "
+                    "by the reclaim, and it was not"
+                )
+            finally:
+                hold.set()
+                consumer_a.request_stop()
+                consumer_b.request_stop()
+                await asyncio.gather(
+                    *list(consumer_a._inflight),
+                    *list(consumer_b._inflight),
+                    return_exceptions=True,
+                )
+                if task_b is not None:
+                    task_b.cancel()
+                    await asyncio.gather(task_b, return_exceptions=True)
+
+    asyncio.run(go())

--- a/apps/worker/tests/kernel/test_runner_client.py
+++ b/apps/worker/tests/kernel/test_runner_client.py
@@ -7,6 +7,7 @@ is what TurnStream.close (called from __aexit__) invokes."""
 from __future__ import annotations
 
 import asyncio
+import inspect
 import tracemalloc
 from typing import Any
 
@@ -485,6 +486,176 @@ def test_large_post_final_tail_is_discarded_without_aggregation() -> None:
             assert runner.handler_errors == []
         finally:
             tracemalloc.stop()
+            await client.close()
+            await server.close()
+
+    asyncio.run(go())
+
+
+# --- Per-request timeout from the remaining delivery budget (ADR-0131, #1971) -
+#
+# ``runner_total_timeout_s`` stops being an independent clock and becomes a
+# per-request CEILING inside the delivery's one overall deadline. Each
+# budget-consuming RPC takes an optional ``remaining_s``; the effective timeout
+# is ``min(runner_total_timeout_s, remaining_s)``, and ``remaining_s=None`` keeps
+# the session default so every pre-existing caller is behaviourally unchanged.
+#
+# Asserted against a REAL local server that accepts the connection and then never
+# answers -- the shape a budget must actually bound -- so these measure client
+# behavior rather than a mock of it.
+
+
+class _HangingEventRunner:
+    """A runner whose ``/v1/event`` and ``/v1/interrupt`` accept the connection
+    and never answer."""
+
+    def __init__(self) -> None:
+        self.app = web.Application()
+        self.app.add_routes(
+            [
+                web.post("/v1/event", self._hang),
+                web.post("/v1/interrupt", self._hang),
+            ]
+        )
+        self.hang = asyncio.Event()  # set only in teardown
+
+    async def _hang(self, _request: web.Request) -> web.Response:
+        await self.hang.wait()
+        return web.json_response({"ok": True})
+
+
+def test_start_turn_uses_the_remaining_budget_when_it_is_shorter() -> None:
+    """A delivery with 0.3s of budget left must not hand the runner the full 30s
+    session budget. Reverting the per-request override makes this call wait the
+    whole streaming timeout, so the elapsed assertion is what goes red."""
+
+    async def go() -> None:
+        runner = _HangingEventRunner()
+        server = TestServer(runner.app)
+        await server.start_server()
+        base_url = f"http://127.0.0.1:{server.port}"
+        # 30s session default, deliberately huge relative to the budget below.
+        client = RunnerClient(total_timeout_s=30.0)
+        try:
+            loop = asyncio.get_event_loop()
+            started = loop.time()
+            with pytest.raises(TimeoutError):
+                await client.start_turn(base_url, _event(), remaining_s=0.3)
+            assert loop.time() - started < 5.0
+        finally:
+            runner.hang.set()
+            await client.close()
+            await server.close()
+
+    asyncio.run(go())
+
+
+def test_start_turn_without_a_remaining_budget_uses_the_session_default() -> None:
+    """``remaining_s=None`` must leave the session timeout in charge: that is the
+    path every leaseless caller and every existing test takes, and it must stay
+    byte-identical in behavior."""
+
+    async def go() -> None:
+        runner = _HangingEventRunner()
+        server = TestServer(runner.app)
+        await server.start_server()
+        base_url = f"http://127.0.0.1:{server.port}"
+        client = RunnerClient(total_timeout_s=0.3)
+        try:
+            loop = asyncio.get_event_loop()
+            started = loop.time()
+            with pytest.raises(TimeoutError):
+                await client.start_turn(base_url, _event(), remaining_s=None)
+            assert loop.time() - started < 5.0
+        finally:
+            runner.hang.set()
+            await client.close()
+            await server.close()
+
+    asyncio.run(go())
+
+
+def test_the_effective_timeout_is_the_min_of_the_budget_and_the_session_ceiling() -> None:
+    """A remaining budget LARGER than the per-request ceiling must not raise the
+    ceiling. Reverting ``min(...)`` to "the budget wins" would let a 30-minute
+    delivery hand one runner request a 30-minute HTTP deadline."""
+
+    async def go() -> None:
+        runner = _HangingEventRunner()
+        server = TestServer(runner.app)
+        await server.start_server()
+        base_url = f"http://127.0.0.1:{server.port}"
+        client = RunnerClient(total_timeout_s=0.3)
+        try:
+            loop = asyncio.get_event_loop()
+            started = loop.time()
+            with pytest.raises(TimeoutError):
+                await client.start_turn(base_url, _event(), remaining_s=30.0)
+            assert loop.time() - started < 5.0
+        finally:
+            runner.hang.set()
+            await client.close()
+            await server.close()
+
+    asyncio.run(go())
+
+
+def test_a_remaining_budget_does_not_break_a_responsive_turn() -> None:
+    """The positive control for the three timeout tests above: with a budget in
+    hand and a runner that answers, the turn still opens and streams. Without it
+    they would all pass against a client whose every request now fails."""
+
+    async def go() -> None:
+        runner = _HeaderRecordingRunner()
+        server = TestServer(runner.app)
+        await server.start_server()
+        base_url = f"http://127.0.0.1:{server.port}"
+        client = RunnerClient(total_timeout_s=30.0)
+        try:
+            turn = await client.start_turn(base_url, _event(), remaining_s=5.0)
+            await _drain(turn)
+            assert "event" in runner.headers
+            assert await client.steer(base_url, _event(), remaining_s=5.0) is True
+        finally:
+            await client.close()
+            await server.close()
+
+    asyncio.run(go())
+
+
+def test_interrupt_takes_no_remaining_budget_while_the_other_rpcs_do() -> None:
+    """A structural guard against a future "simplification" that folds interrupt
+    into the budget path. ``/v1/interrupt`` is the fail-closed path a lost lease
+    fires: deriving its timeout from a budget that may already be exhausted would
+    make the fence unable to stop the runner it just fenced."""
+    for name in ("start_turn", "steer", "status", "snapshot", "reset"):
+        parameters = inspect.signature(getattr(RunnerClient, name)).parameters
+        assert "remaining_s" in parameters, f"{name} must accept a remaining budget"
+
+    assert "remaining_s" not in inspect.signature(RunnerClient.interrupt).parameters, (
+        "interrupt must never take a remaining budget: it is the fail-closed "
+        "control path and keeps its own independent timeout"
+    )
+
+
+def test_interrupt_keeps_its_own_timeout_under_a_huge_streaming_budget() -> None:
+    """The behavioral half of the guard above. With a 30s session budget and a
+    wedged runner, the interrupt must still return at its own 0.2s bound."""
+
+    async def go() -> None:
+        runner = _HangingEventRunner()
+        server = TestServer(runner.app)
+        await server.start_server()
+        base_url = f"http://127.0.0.1:{server.port}"
+        client = RunnerClient(total_timeout_s=30.0, interrupt_timeout_s=0.2)
+        try:
+            loop = asyncio.get_event_loop()
+            started = loop.time()
+            with pytest.raises(TimeoutError):
+                await client.interrupt(base_url, "delivery lease lost")
+            assert loop.time() - started < 5.0
+        finally:
+            runner.hang.set()
             await client.close()
             await server.close()
 

--- a/apps/worker/tests/test_config.py
+++ b/apps/worker/tests/test_config.py
@@ -699,3 +699,263 @@ def test_recorder_health_precondition_fails_when_service_is_unavailable(
         assert unavailable_host in message
     else:
         pytest.fail("health precondition returned successfully while its service was absent")
+
+
+# --- Delivery budget and ownership lease (ADR-0131, #1971) --------------------
+#
+# One deadline and one renewable fenced owner per delivery. The four cross-field
+# validators below exist because each relationship is invisible until an
+# incident: a lease that cannot span three heartbeat periods drops a healthy turn
+# on a single Valkey blip; a reclaim scan slower than the lease leaves an expired
+# lease unrecovered for a whole extra scan; a termination grace below
+# budget + reserve SIGKILLs a draining worker at the exact moment it would
+# settle; and a per-request runner ceiling above the overall budget is dead
+# configuration that reads as if it granted more time than it does. The operator
+# must learn at boot, not at 2am -- so each rejection NAMES the env vars.
+
+_LEASE_BASELINE: dict[str, object] = {
+    "delivery_budget_s": 600.0,
+    "delivery_lease_ttl_s": 45.0,
+    "delivery_lease_heartbeat_s": 10.0,
+    "delivery_shutdown_reserve_s": 60.0,
+    "reclaim_interval_s": 30.0,
+    "runner_total_timeout_s": 600.0,
+    "termination_grace_period_s": None,
+}
+
+
+def _lease_config(**overrides: object) -> WorkerConfig:
+    """A self-consistent delivery config with exactly ONE relationship perturbed.
+
+    Validators run in declaration order and the first raise wins, so a test that
+    perturbed two relationships at once could assert on the wrong message. Every
+    test below moves one knob off this baseline and leaves the rest satisfied.
+    """
+    values = dict(_LEASE_BASELINE)
+    values.update(overrides)
+    return WorkerConfig(**values)
+
+
+def test_delivery_lease_fields_carry_the_adr_initial_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ADR-0131's stated initial values. Drifting a default here silently changes
+    the fence's timing on every deployment that does not override it."""
+    _clear_all_config_env(monkeypatch)
+
+    config = WorkerConfig()
+
+    assert config.delivery_budget_s == 600.0
+    assert config.delivery_lease_ttl_s == 45.0
+    assert config.delivery_lease_heartbeat_s == 10.0
+    assert config.delivery_shutdown_reserve_s == 60.0
+    # None means "no platform grace declared" (compose, tests) and SKIPS the
+    # grace validator rather than guessing a value for it.
+    assert config.termination_grace_period_s is None
+    # Unchanged by this train, but now bound by a validator: 30 < 45 satisfies
+    # the ADR's "the reclaim interval is shorter than the lease".
+    assert config.reclaim_interval_s == 30.0
+
+
+def test_delivery_knobs_read_their_curie_aliases(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The chart templates these five as first-class env; a name drift here means
+    an operator's --set silently does nothing."""
+    _clear_all_config_env(monkeypatch)
+    monkeypatch.setenv("CURIE_DELIVERY_BUDGET_S", "1800")
+    monkeypatch.setenv("CURIE_DELIVERY_LEASE_TTL_S", "90")
+    monkeypatch.setenv("CURIE_DELIVERY_LEASE_HEARTBEAT_S", "20")
+    monkeypatch.setenv("CURIE_DELIVERY_SHUTDOWN_RESERVE_S", "45")
+    monkeypatch.setenv("CURIE_TERMINATION_GRACE_PERIOD_S", "1860")
+    monkeypatch.setenv("CURIE_RECLAIM_INTERVAL_S", "10")
+
+    config = WorkerConfig()
+
+    assert config.delivery_budget_s == 1800.0
+    assert config.delivery_lease_ttl_s == 90.0
+    assert config.delivery_lease_heartbeat_s == 20.0
+    assert config.delivery_shutdown_reserve_s == 45.0
+    assert config.termination_grace_period_s == 1860.0
+    assert config.reclaim_interval_s == 10.0
+
+
+def test_delivery_knobs_ignore_bare_field_name_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Aliased like every other CURIE_* knob: a stray bare-name env var in the
+    pod env must not leak into the fence's timing."""
+    _clear_all_config_env(monkeypatch)
+    monkeypatch.setenv("DELIVERY_BUDGET_S", "1800")
+    monkeypatch.setenv("DELIVERY_LEASE_TTL_S", "1")
+    monkeypatch.setenv("DELIVERY_LEASE_HEARTBEAT_S", "1")
+    monkeypatch.setenv("DELIVERY_SHUTDOWN_RESERVE_S", "0")
+    monkeypatch.setenv("TERMINATION_GRACE_PERIOD_S", "5")
+
+    config = WorkerConfig()
+
+    assert config.delivery_budget_s == 600.0
+    assert config.delivery_lease_ttl_s == 45.0
+    assert config.delivery_lease_heartbeat_s == 10.0
+    assert config.delivery_shutdown_reserve_s == 60.0
+    assert config.termination_grace_period_s is None
+
+
+def test_delivery_budget_accepts_the_adr_maximum_and_rejects_above_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """1800s is the ADR's stated maximum ("Operators may configure 1,800
+    seconds"). A higher value would silently require a termination grace the
+    chart schema will not accept, so it is refused here instead."""
+    _clear_all_config_env(monkeypatch)
+
+    assert _lease_config(delivery_budget_s=1800.0).delivery_budget_s == 1800.0
+
+    with pytest.raises(ValueError):
+        _lease_config(delivery_budget_s=1800.5)
+
+
+def test_delivery_budget_accepts_its_floor_and_rejects_below_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A budget under a minute cannot cover claim + one runner request + settle,
+    so it is a misconfiguration rather than an aggressive tuning choice."""
+    _clear_all_config_env(monkeypatch)
+
+    # runner_total_timeout_s must come down with it -- see the fourth validator.
+    assert (
+        _lease_config(delivery_budget_s=60.0, runner_total_timeout_s=60.0).delivery_budget_s
+        == 60.0
+    )
+
+    with pytest.raises(ValueError):
+        _lease_config(delivery_budget_s=59.9, runner_total_timeout_s=59.9)
+
+
+def test_lease_ttl_must_span_three_heartbeat_periods(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ADR-0131: "the lease spans at least three heartbeat periods". Two lost
+    heartbeats must not lose a healthy turn's lease -- reverting this validator
+    lets an operator configure a fence that a single Valkey blip breaks."""
+    _clear_all_config_env(monkeypatch)
+
+    # The boundary itself PASSES: exactly three periods is the ADR's floor.
+    at_the_boundary = _lease_config(delivery_lease_ttl_s=45.0, delivery_lease_heartbeat_s=15.0)
+    assert at_the_boundary.delivery_lease_ttl_s == 45.0
+
+    # One tick below the boundary fails.
+    with pytest.raises(ValueError) as exc_info:
+        _lease_config(delivery_lease_ttl_s=44.9, delivery_lease_heartbeat_s=15.0)
+
+    message = str(exc_info.value)
+    assert "CURIE_DELIVERY_LEASE_TTL_S" in message
+    assert "CURIE_DELIVERY_LEASE_HEARTBEAT_S" in message
+
+
+def test_reclaim_interval_must_be_strictly_shorter_than_the_lease_ttl(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ADR-0131: "the reclaim interval is shorter than the lease". A scan slower
+    than the lease leaves an expired lease unrecovered for a whole extra scan,
+    which is exactly the stranded-delivery latency the fence exists to bound."""
+    _clear_all_config_env(monkeypatch)
+
+    just_under = _lease_config(delivery_lease_ttl_s=45.0, reclaim_interval_s=44.9)
+    assert just_under.reclaim_interval_s == 44.9
+
+    # Equal is NOT shorter: the relationship is strict.
+    with pytest.raises(ValueError) as exc_info:
+        _lease_config(delivery_lease_ttl_s=45.0, reclaim_interval_s=45.0)
+
+    message = str(exc_info.value)
+    assert "CURIE_RECLAIM_INTERVAL_S" in message
+    assert "CURIE_DELIVERY_LEASE_TTL_S" in message
+
+
+def test_termination_grace_must_cover_the_budget_plus_the_shutdown_reserve(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ADR-0131: "platform termination grace is at least the execution budget
+    plus shutdown reserve". Below it, a worker draining a maximum-budget turn is
+    SIGKILLed at the exact moment it would settle -- the turn's terminal effect
+    is lost and the entry is left pending."""
+    _clear_all_config_env(monkeypatch)
+
+    exactly_enough = _lease_config(
+        delivery_budget_s=600.0,
+        delivery_shutdown_reserve_s=60.0,
+        termination_grace_period_s=660.0,
+    )
+    assert exactly_enough.termination_grace_period_s == 660.0
+
+    with pytest.raises(ValueError) as exc_info:
+        _lease_config(
+            delivery_budget_s=600.0,
+            delivery_shutdown_reserve_s=60.0,
+            termination_grace_period_s=659.9,
+        )
+
+    message = str(exc_info.value)
+    assert "CURIE_TERMINATION_GRACE_PERIOD_S" in message
+    assert "CURIE_DELIVERY_BUDGET_S" in message
+    assert "CURIE_DELIVERY_SHUTDOWN_RESERVE_S" in message
+
+
+def test_termination_grace_of_none_skips_the_grace_validator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """None means "no platform grace declared", which is the compose and test
+    case. Reverting the None guard into a comparison makes every leaseless local
+    stack -- and this whole test suite -- fail to construct a config at all."""
+    _clear_all_config_env(monkeypatch)
+
+    config = _lease_config(
+        delivery_budget_s=1800.0,
+        delivery_shutdown_reserve_s=60.0,
+        termination_grace_period_s=None,
+        runner_total_timeout_s=600.0,
+    )
+
+    assert config.termination_grace_period_s is None
+    assert config.delivery_budget_s == 1800.0
+
+
+def test_runner_total_timeout_must_not_exceed_the_delivery_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``runner_total_timeout_s`` is now a per-request ceiling INSIDE the overall
+    deadline, not an independent clock. A ceiling above the budget is always dead
+    configuration and reads as if it granted more time than it does."""
+    _clear_all_config_env(monkeypatch)
+
+    equal = _lease_config(delivery_budget_s=600.0, runner_total_timeout_s=600.0)
+    assert equal.runner_total_timeout_s == 600.0
+
+    with pytest.raises(ValueError) as exc_info:
+        _lease_config(delivery_budget_s=600.0, runner_total_timeout_s=600.1)
+
+    message = str(exc_info.value)
+    assert "RUNNER_TOTAL_TIMEOUT_S" in message
+    assert "CURIE_DELIVERY_BUDGET_S" in message
+
+
+def test_delivery_key_helpers_are_keyed_by_the_delivery_triple(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A delivery is a ``(stream, group, entry_id)``, NOT an event id: the same
+    event id can legitimately be redelivered under a new entry id after a
+    dead-letter, and keying the lease by event id would fence the wrong thing.
+    The two keys are separate because the generation must outlive the lease --
+    a generation stored in the short-lived lease key would restart at 1 on
+    expiry, and a stale owner holding generation 1 would then validate."""
+    _clear_all_config_env(monkeypatch)
+
+    config = WorkerConfig(key_prefix="curie:worker")
+
+    lease_key = config.delivery_lease_key("curie:runs", "curie-workers", "1-0")
+    state_key = config.delivery_state_key("curie:runs", "curie-workers", "1-0")
+
+    assert lease_key == "curie:worker:lease:curie:runs:curie-workers:1-0"
+    assert state_key == "curie:worker:delivery:curie:runs:curie-workers:1-0"
+    assert lease_key != state_key

--- a/apps/worker/tests/test_delivery_lease.py
+++ b/apps/worker/tests/test_delivery_lease.py
@@ -1,0 +1,655 @@
+"""Per-script contract tests for the delivery ownership lease (ADR-0131, #1971).
+
+Against **real Valkey**, never a mock. The repo rule is "Valkey is never mocked"
+and here it is load-bearing rather than stylistic: the fence *is* Valkey
+semantics -- atomic ``EVAL``, server ``TIME``, key expiry, ``XPENDING``
+ownership, and ``XCLAIM ... JUSTID``'s refusal to bump the delivery counter. A
+mocked ``EVAL`` would assert only that we wrote the Lua we wrote.
+
+Time is compressed by CONFIGURING short lease clocks (TTL 1.0s, heartbeat 0.3s),
+never by patching a clock. The one thing deliberately NOT compressed or stubbed
+is the Valkey server ``TIME`` read: the whole point of the deadline is that it
+comes from the server, so a test that faked it would prove nothing about the
+property under test. The *budget* is left at its 60s floor because nothing in
+this file waits on the budget -- only the lease clocks need to be small.
+
+The API this file pins, for the implementer of ``delivery_lease.py``:
+
+    DeliveryLeaseStore(redis: Redis, config: WorkerConfig)
+      .acquire(stream, group, entry_id, *, consumer)  -> DeliveryLease
+          raises LeaseRefused, whose ``.reason`` is "held" (a live lease exists)
+          or "not-owner" (we do not hold the PEL row)
+      .heartbeat(stream, group, entry_id, *, consumer, owner, generation)
+          -> DeliveryBudget | None   (None == fail-closed refusal, lease lost)
+      .release(stream, group, entry_id, *, owner) -> bool   (compare-and-delete)
+      .settle(stream, group, entry_id) -> None    (lease AND state key removed)
+      .is_live(stream, group, entry_id) -> bool   (the cheap reclaim-path read)
+      .peek(stream, group, entry_id) -> dict[str, str]   ({} when absent)
+
+    DeliveryLease: .owner .generation .budget .lost .remaining_s() .raise_if_lost()
+    DeliveryBudget: .deadline_ms .anchor_server_ms .anchor_monotonic
+                    .remaining_s() .reanchor(server_ms)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import time
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+from curie_test_support.valkey import (
+    VALKEY_HOST as _VALKEY_HOST,
+)
+from curie_test_support.valkey import (
+    VALKEY_PORT as _VALKEY_PORT,
+)
+from curie_test_support.valkey import (
+    VALKEY_PW as _VALKEY_PW,
+)
+from curie_worker.config import WorkerConfig
+from curie_worker.delivery_lease import (
+    DeliveryBudget,
+    DeliveryLeaseStore,
+    LeaseRefused,
+)
+from redis.asyncio import Redis as AsyncRedis
+
+# The compressed lease clocks. Every ratio the config validators enforce is
+# preserved: TTL (1.0) >= 3 * heartbeat (0.3), reclaim (0.5) < TTL (1.0), and
+# the runner ceiling (30) <= the budget (60, its configurable floor).
+_TTL_S = 1.0
+_HEARTBEAT_S = 0.3
+_BUDGET_S = 60.0
+
+
+# ``sync_redis`` and ``names`` (the per-test-unique stream / group / key
+# prefix on the shared Valkey) live in ``tests/conftest.py``, shared with
+# ``tests/kernel``'s ``make_harness``.
+
+
+def _config(names: dict[str, str], **overrides: object) -> WorkerConfig:
+    base: dict[str, object] = {
+        "valkey_host": _VALKEY_HOST,
+        "valkey_port": _VALKEY_PORT,
+        "valkey_password": _VALKEY_PW,
+        "stream": names["stream"],
+        "consumer_group": names["group"],
+        "key_prefix": names["prefix"],
+        "delivery_budget_s": _BUDGET_S,
+        "delivery_lease_ttl_s": _TTL_S,
+        "delivery_lease_heartbeat_s": _HEARTBEAT_S,
+        "reclaim_interval_s": 0.5,
+        "runner_total_timeout_s": 30.0,
+    }
+    base.update(overrides)
+    return WorkerConfig(**base)
+
+
+@contextlib.asynccontextmanager
+async def _store(names: dict[str, str], **overrides: object) -> AsyncIterator[
+    tuple[DeliveryLeaseStore, WorkerConfig, AsyncRedis]
+]:
+    """A lease store on a live async client, torn down on every exit path."""
+    config = _config(names, **overrides)
+    client: AsyncRedis = AsyncRedis(
+        host=_VALKEY_HOST,
+        port=_VALKEY_PORT,
+        password=_VALKEY_PW or None,
+        decode_responses=True,
+    )
+    try:
+        yield DeliveryLeaseStore(client, config), config, client
+    finally:
+        with contextlib.suppress(Exception):
+            await client.aclose()
+
+
+async def _pending(
+    client: AsyncRedis, config: WorkerConfig, consumer: str, *, count: int = 1
+) -> list[str]:
+    """Add ``count`` entries and read them into ``consumer``'s PEL.
+
+    The PEL row is what ``acquire`` verifies: the lease is authority, but a
+    consumer that does not hold the pending entry has no standing to take it.
+    """
+    with contextlib.suppress(Exception):
+        await client.xgroup_create(config.stream, config.consumer_group, id="0", mkstream=True)
+    ids = [await client.xadd(config.stream, {"payload": f"p{i}"}) for i in range(count)]
+    read = await client.xreadgroup(
+        config.consumer_group, consumer, {config.stream: ">"}, count=count
+    )
+    delivered = [entry_id for _stream, entries in read for entry_id, _fields in entries]
+    assert delivered == ids, f"expected {ids} in {consumer}'s PEL, got {delivered}"
+    return ids
+
+
+async def _times_delivered(
+    client: AsyncRedis, config: WorkerConfig, entry_id: str
+) -> int:
+    rows: Any = await client.xpending_range(
+        config.stream, config.consumer_group, min=entry_id, max=entry_id, count=1
+    )
+    assert rows, f"entry {entry_id} is not pending"
+    return int(rows[0]["times_delivered"])
+
+
+# --- acquire: the single authority point -------------------------------------
+
+
+def test_acquire_refuses_a_replacement_while_the_lease_is_live(names) -> None:  # noqa: ANN001
+    """The observed defect, directly: without the live-lease refusal BOTH owners
+    enter the handler and the same turn runs twice on two replicas."""
+
+    async def go() -> None:
+        async with _store(names) as (store, config, client):
+            (entry,) = await _pending(client, config, "worker-a")
+            lease_a = await store.acquire(
+                config.stream, config.consumer_group, entry, consumer="worker-a"
+            )
+            assert lease_a.generation == 1
+            assert await store.is_live(config.stream, config.consumer_group, entry) is True
+
+            # B takes the PEL row, exactly as XAUTOCLAIM does on the reclaim path,
+            # so the ONLY thing standing between B and the handler is the lease.
+            await client.xclaim(
+                config.stream, config.consumer_group, "worker-b", 0, [entry]
+            )
+            with pytest.raises(LeaseRefused) as exc_info:
+                await store.acquire(
+                    config.stream, config.consumer_group, entry, consumer="worker-b"
+                )
+            assert exc_info.value.reason == "held"
+
+            # Positive control: the refusal above was the fence, not a dead path.
+            # Once A's lease is gone, the very same call is granted.
+            assert (
+                await store.release(
+                    config.stream, config.consumer_group, entry, owner=lease_a.owner
+                )
+                is True
+            )
+            lease_b = await store.acquire(
+                config.stream, config.consumer_group, entry, consumer="worker-b"
+            )
+            assert lease_b.generation == 2
+            assert lease_b.owner != lease_a.owner
+
+    asyncio.run(go())
+
+
+def test_acquire_refuses_a_consumer_that_does_not_hold_the_pel_row(names) -> None:  # noqa: ANN001
+    """The lease is authority AND the PEL row is a precondition. A consumer that
+    never read the entry has no standing to fence it; reverting the ownership
+    check lets any replica mint authority over a delivery it was never given."""
+
+    async def go() -> None:
+        async with _store(names) as (store, config, client):
+            (entry,) = await _pending(client, config, "worker-a")
+
+            with pytest.raises(LeaseRefused) as exc_info:
+                await store.acquire(
+                    config.stream, config.consumer_group, entry, consumer="worker-c"
+                )
+            assert exc_info.value.reason == "not-owner"
+            # Nothing was minted on the refused path.
+            assert await store.is_live(config.stream, config.consumer_group, entry) is False
+            assert await store.peek(config.stream, config.consumer_group, entry) == {}
+
+            # Positive control: the true PEL owner is granted.
+            lease = await store.acquire(
+                config.stream, config.consumer_group, entry, consumer="worker-a"
+            )
+            assert lease.generation == 1
+
+    asyncio.run(go())
+
+
+def test_acquire_after_expiry_transfers_and_increments_the_generation(names) -> None:  # noqa: ANN001
+    """Force-kill recovery. A replacement may take a delivery ONLY after the
+    lease expires, and the generation increments monotonically on every change of
+    authority -- which is what makes the old owner's late heartbeat refusable."""
+
+    async def go() -> None:
+        async with _store(names) as (store, config, client):
+            (entry,) = await _pending(client, config, "worker-a")
+            lease_a = await store.acquire(
+                config.stream, config.consumer_group, entry, consumer="worker-a"
+            )
+            # A dies without releasing: the lease is left to expire.
+            await client.xclaim(
+                config.stream, config.consumer_group, "worker-b", 0, [entry]
+            )
+
+            # Before expiry the replacement is refused.
+            with pytest.raises(LeaseRefused) as exc_info:
+                await store.acquire(
+                    config.stream, config.consumer_group, entry, consumer="worker-b"
+                )
+            assert exc_info.value.reason == "held"
+
+            await asyncio.sleep(_TTL_S + 0.4)
+            assert await store.is_live(config.stream, config.consumer_group, entry) is False
+
+            lease_b = await store.acquire(
+                config.stream, config.consumer_group, entry, consumer="worker-b"
+            )
+            assert lease_b.generation == lease_a.generation + 1
+            assert lease_b.generation == 2
+
+    asyncio.run(go())
+
+
+def test_a_replacement_inherits_the_original_deadline_not_a_fresh_budget(names) -> None:  # noqa: ANN001
+    """The anti-budget-multiplication property (create-if-absent on
+    ``deadline_ms``). Reverting HSETNX to HSET lets three transfers turn a
+    configured 1,800-second budget into 5,400 seconds of execution."""
+
+    async def go() -> None:
+        async with _store(names) as (store, config, client):
+            (entry,) = await _pending(client, config, "worker-a")
+            lease_a = await store.acquire(
+                config.stream, config.consumer_group, entry, consumer="worker-a"
+            )
+            first_deadline = int(
+                (await store.peek(config.stream, config.consumer_group, entry))["deadline_ms"]
+            )
+            assert lease_a.budget.deadline_ms == first_deadline
+
+            await client.xclaim(
+                config.stream, config.consumer_group, "worker-b", 0, [entry]
+            )
+            await asyncio.sleep(_TTL_S + 0.4)
+            lease_b = await store.acquire(
+                config.stream, config.consumer_group, entry, consumer="worker-b"
+            )
+
+            # The generation moved, so a real re-acquisition happened -- the
+            # deadline equality below is not the trivial "nothing changed" case.
+            assert lease_b.generation == 2
+            assert lease_b.budget.deadline_ms == first_deadline
+            assert (
+                int((await store.peek(config.stream, config.consumer_group, entry))["deadline_ms"])
+                == first_deadline
+            )
+            # The replacement's remaining budget is what is LEFT, not the whole
+            # budget: at least the lease TTL has burned since the first owner.
+            assert lease_b.remaining_s() < _BUDGET_S - _TTL_S
+
+    asyncio.run(go())
+
+
+# --- heartbeat: three independent fail-closed guards --------------------------
+
+
+def test_heartbeat_refuses_a_wrong_owner_token(names) -> None:  # noqa: ANN001
+    """Fail closed on an owner token that is not the one in the lease key.
+    Reverting the compare lets any process renew any lease."""
+
+    async def go() -> None:
+        async with _store(names) as (store, config, client):
+            (entry,) = await _pending(client, config, "worker-a")
+            lease = await store.acquire(
+                config.stream, config.consumer_group, entry, consumer="worker-a"
+            )
+
+            refused = await store.heartbeat(
+                config.stream,
+                config.consumer_group,
+                entry,
+                consumer="worker-a",
+                owner="not-the-owner-token",
+                generation=lease.generation,
+            )
+            assert refused is None
+
+            # Positive control: the true owner renews, so the refusal above was
+            # the owner compare and not a heartbeat path that never works.
+            renewed = await store.heartbeat(
+                config.stream,
+                config.consumer_group,
+                entry,
+                consumer="worker-a",
+                owner=lease.owner,
+                generation=lease.generation,
+            )
+            assert renewed is not None
+
+    asyncio.run(go())
+
+
+def test_heartbeat_refuses_a_stale_fencing_generation(names) -> None:  # noqa: ANN001
+    """The slow-heartbeat case: Valkey answers after the lease already expired and
+    was taken. The owner token alone cannot catch it, which is precisely why the
+    generation is checked in the heartbeat and not only at acquisition."""
+
+    async def go() -> None:
+        async with _store(names) as (store, config, client):
+            (entry,) = await _pending(client, config, "worker-a")
+            lease_a = await store.acquire(
+                config.stream, config.consumer_group, entry, consumer="worker-a"
+            )
+            await client.xclaim(
+                config.stream, config.consumer_group, "worker-b", 0, [entry]
+            )
+            await asyncio.sleep(_TTL_S + 0.4)
+            lease_b = await store.acquire(
+                config.stream, config.consumer_group, entry, consumer="worker-b"
+            )
+            assert lease_b.generation == 2
+
+            # CORRECT owner token, STALE generation: only the generation check can
+            # refuse this, so the assertion isolates that guard alone.
+            refused = await store.heartbeat(
+                config.stream,
+                config.consumer_group,
+                entry,
+                consumer="worker-b",
+                owner=lease_b.owner,
+                generation=lease_a.generation,
+            )
+            assert refused is None
+
+            # Positive control: the current generation renews.
+            renewed = await store.heartbeat(
+                config.stream,
+                config.consumer_group,
+                entry,
+                consumer="worker-b",
+                owner=lease_b.owner,
+                generation=lease_b.generation,
+            )
+            assert renewed is not None
+
+    asyncio.run(go())
+
+
+def test_heartbeat_refuses_once_the_pel_row_is_owned_by_someone_else(names) -> None:  # noqa: ANN001
+    """A renewal must verify PEL ownership as well as the lease. Without it an
+    owner whose entry has been claimed away keeps renewing authority over a
+    delivery Valkey has already handed to another consumer."""
+
+    async def go() -> None:
+        async with _store(names) as (store, config, client):
+            (entry,) = await _pending(client, config, "worker-a")
+            lease = await store.acquire(
+                config.stream, config.consumer_group, entry, consumer="worker-a"
+            )
+
+            # Positive control FIRST, while the PEL row is still ours.
+            assert (
+                await store.heartbeat(
+                    config.stream,
+                    config.consumer_group,
+                    entry,
+                    consumer="worker-a",
+                    owner=lease.owner,
+                    generation=lease.generation,
+                )
+                is not None
+            )
+
+            await client.xclaim(
+                config.stream, config.consumer_group, "worker-b", 0, [entry]
+            )
+
+            refused = await store.heartbeat(
+                config.stream,
+                config.consumer_group,
+                entry,
+                consumer="worker-a",
+                owner=lease.owner,
+                generation=lease.generation,
+            )
+            assert refused is None
+
+    asyncio.run(go())
+
+
+def test_heartbeat_extends_the_lease_without_bumping_times_delivered(names) -> None:  # noqa: ANN001
+    """Two independent reverts, both caught here. Dropping the renewal expires a
+    healthy long turn's lease; dropping ``JUSTID`` from the same-owner ``XCLAIM``
+    burns one delivery per heartbeat and dead-letters a healthy turn in under a
+    minute. The delivery count stays PEL-backed and is never reset."""
+
+    async def go() -> None:
+        async with _store(names) as (store, config, client):
+            renewed_entry, abandoned_entry = await _pending(client, config, "worker-a", count=2)
+            renewed = await store.acquire(
+                config.stream, config.consumer_group, renewed_entry, consumer="worker-a"
+            )
+            # The negative control: same consumer, same window, NO heartbeats.
+            await store.acquire(
+                config.stream, config.consumer_group, abandoned_entry, consumer="worker-a"
+            )
+
+            before = await _times_delivered(client, config, renewed_entry)
+
+            # Six beats spans ~1.8s, comfortably past the 1.0s lease TTL.
+            for _ in range(6):
+                await asyncio.sleep(_HEARTBEAT_S)
+                anchor = await store.heartbeat(
+                    config.stream,
+                    config.consumer_group,
+                    renewed_entry,
+                    consumer="worker-a",
+                    owner=renewed.owner,
+                    generation=renewed.generation,
+                )
+                assert anchor is not None
+                # Every successful renewal re-anchors on a fresh server TIME, so
+                # a worker with a skewed clock still measures elapsed correctly.
+                assert anchor.deadline_ms == renewed.budget.deadline_ms
+                assert anchor.anchor_server_ms >= renewed.budget.anchor_server_ms
+
+            assert (
+                await store.is_live(config.stream, config.consumer_group, renewed_entry) is True
+            )
+            # ...and the un-renewed sibling expired over the SAME window, so the
+            # assertion above is about the heartbeat and not about a lease TTL
+            # that silently never expires.
+            assert (
+                await store.is_live(config.stream, config.consumer_group, abandoned_entry)
+                is False
+            )
+
+            after = await _times_delivered(client, config, renewed_entry)
+            assert after == before, (
+                "the same-owner XCLAIM must use JUSTID: it reset PEL idle but "
+                f"burned {after - before} deliveries of the ADR-0039 budget"
+            )
+
+    asyncio.run(go())
+
+
+# --- release and settle -------------------------------------------------------
+
+
+def test_release_is_compare_and_delete_so_a_stale_token_frees_nothing(names) -> None:  # noqa: ANN001
+    """A late ``__aexit__`` from an owner that already lost the fence must not
+    free the CURRENT owner's lease -- that would hand the delivery to a third
+    process while the real owner is still executing."""
+
+    async def go() -> None:
+        async with _store(names) as (store, config, client):
+            (entry,) = await _pending(client, config, "worker-a")
+            lease = await store.acquire(
+                config.stream, config.consumer_group, entry, consumer="worker-a"
+            )
+
+            assert (
+                await store.release(
+                    config.stream, config.consumer_group, entry, owner="stale-owner-token"
+                )
+                is False
+            )
+            assert await store.is_live(config.stream, config.consumer_group, entry) is True
+
+            assert (
+                await store.release(
+                    config.stream, config.consumer_group, entry, owner=lease.owner
+                )
+                is True
+            )
+            assert await store.is_live(config.stream, config.consumer_group, entry) is False
+
+            # Release drops the LEASE only. The delivery state survives, because
+            # its absence must keep meaning "first delivery" -- a released-then-
+            # reacquired entry that minted a fresh deadline would multiply the
+            # budget exactly as a reverted HSETNX does.
+            state = await store.peek(config.stream, config.consumer_group, entry)
+            assert state.get("deadline_ms")
+            assert state.get("gen") == "1"
+
+    asyncio.run(go())
+
+
+def test_settle_removes_both_the_lease_and_the_delivery_state(names) -> None:  # noqa: ANN001
+    """Terminal ACK and dead-letter settlement remove the delivery state. Without
+    it, a dead-lettered-and-redelivered event id accumulates state keys until
+    their one-day retention TTL."""
+
+    async def go() -> None:
+        async with _store(names) as (store, config, client):
+            (entry,) = await _pending(client, config, "worker-a")
+            await store.acquire(
+                config.stream, config.consumer_group, entry, consumer="worker-a"
+            )
+            lease_key = config.delivery_lease_key(config.stream, config.consumer_group, entry)
+            state_key = config.delivery_state_key(config.stream, config.consumer_group, entry)
+            assert await client.exists(lease_key) == 1
+            assert await client.exists(state_key) == 1
+
+            await store.settle(config.stream, config.consumer_group, entry)
+
+            assert await client.exists(lease_key) == 0
+            assert await client.exists(state_key) == 0
+            assert await store.is_live(config.stream, config.consumer_group, entry) is False
+            assert await store.peek(config.stream, config.consumer_group, entry) == {}
+
+    asyncio.run(go())
+
+
+# --- the substrate property the whole deadline rests on -----------------------
+
+
+def test_server_time_inside_eval_is_a_plausible_epoch(names) -> None:  # noqa: ANN001
+    """``redis.call('TIME')`` inside ``EVAL`` must return real epoch time, not
+    zero and not process uptime. Every deadline in this feature is computed from
+    it inside the acquire script, so if this property does not hold the budget is
+    meaningless -- and it would fail silently as an instantly-expired deadline."""
+
+    async def go() -> None:
+        async with _store(names) as (store, config, client):
+            raw = await client.eval(
+                "local t = redis.call('TIME') "
+                "return tostring(t[1] * 1000 + math.floor(t[2] / 1000))",
+                0,
+            )
+            server_ms = int(raw)
+            wall_ms = time.time() * 1000
+            # After 2023-11-14: rules out 0, a small uptime counter, and seconds
+            # mistakenly returned as milliseconds.
+            assert server_ms > 1_700_000_000_000
+            assert abs(server_ms - wall_ms) < 5 * 60 * 1000
+
+            # And the deadline the acquire script actually writes is anchored on
+            # it: roughly "now plus the configured budget".
+            (entry,) = await _pending(client, config, "worker-a")
+            lease = await store.acquire(
+                config.stream, config.consumer_group, entry, consumer="worker-a"
+            )
+            expected_ms = wall_ms + _BUDGET_S * 1000
+            assert abs(lease.budget.deadline_ms - expected_ms) < 60_000
+            assert 0.0 < lease.remaining_s() <= _BUDGET_S
+
+    asyncio.run(go())
+
+
+# --- DeliveryBudget: monotonic anchoring (pure unit, no Valkey) ---------------
+
+
+def test_remaining_s_is_driven_by_the_monotonic_anchor_not_the_wall_clock() -> None:
+    """ADR-0131: "elapsed-time enforcement uses a monotonic clock anchored to the
+    last Valkey-time observation so wall-clock adjustment cannot extend the
+    budget."
+
+    The server anchor here is deliberately ANCIENT (2001-09-09). A ``remaining_s``
+    that consulted the wall clock -- ``time.time()`` against these absolute
+    milliseconds -- would read this budget as having expired about 25 years ago,
+    so every assertion below is red on that revert. Faking the monotonic source
+    is done by choosing ``anchor_monotonic``, which is the whole reason it is a
+    field rather than an implicit "now".
+    """
+    ancient_server_ms = 1_000_000_000_000  # 2001-09-09, ~25 years before now
+    monotonic_now = time.monotonic()
+
+    fresh = DeliveryBudget(
+        deadline_ms=ancient_server_ms + 10_000,
+        anchor_server_ms=ancient_server_ms,
+        anchor_monotonic=monotonic_now,
+    )
+    assert 9.5 < fresh.remaining_s() <= 10.0
+
+    # The SAME server-time facts, anchored four monotonic seconds ago: the only
+    # thing that moved is the monotonic anchor, and remaining moves with it.
+    aged = DeliveryBudget(
+        deadline_ms=ancient_server_ms + 10_000,
+        anchor_server_ms=ancient_server_ms,
+        anchor_monotonic=monotonic_now - 4.0,
+    )
+    assert 5.5 < aged.remaining_s() <= 6.0
+
+    # Re-anchoring on a later server observation (the shape a renewal preserves;
+    # the production heartbeat builds an equivalent budget directly) keeps the
+    # deadline and re-bases elapsed on "now".
+    reanchored = aged.reanchor(ancient_server_ms + 4_000)
+    assert reanchored.deadline_ms == aged.deadline_ms
+    assert 5.5 < reanchored.remaining_s() <= 6.0
+    assert reanchored.anchor_server_ms == ancient_server_ms + 4_000
+
+    # An exhausted budget reads as non-positive rather than wrapping around.
+    spent = DeliveryBudget(
+        deadline_ms=ancient_server_ms + 1_000,
+        anchor_server_ms=ancient_server_ms,
+        anchor_monotonic=monotonic_now - 30.0,
+    )
+    assert spent.remaining_s() < 0.0
+
+
+def test_delivery_lease_module_never_reads_the_wall_clock() -> None:
+    """``time.time()`` anywhere in this module is the defect: an NTP step or a
+    manual clock correction would then extend or destroy a live budget. The
+    monotonic anchor is the only in-process clock, and Valkey server ``TIME`` is
+    the only absolute one.
+
+    This inspects actual ``time.X(...)`` call expressions via ``ast`` rather
+    than scanning raw text, so mentioning ``time.time()`` in a comment or
+    docstring (e.g. to document this very rule) cannot trip the assertion --
+    only a real call would."""
+    import ast
+
+    source = (
+        Path(__file__).resolve().parents[1]
+        / "src/curie_worker/delivery_lease.py"
+    ).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    def time_attr_calls(attr: str) -> list[ast.Call]:
+        return [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == attr
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "time"
+        ]
+
+    assert time_attr_calls("time") == []
+    # Proves the scan actually sees this module's clock reads, rather than
+    # passing vacuously against an empty or unparsed source.
+    assert len(time_attr_calls("monotonic")) > 0

--- a/apps/worker/tests/test_stream_consumer.py
+++ b/apps/worker/tests/test_stream_consumer.py
@@ -85,3 +85,84 @@ def test_handler_exception_does_not_tear_down_the_consume_loop(caplog) -> None: 
         assert errors[0].exc_info is not None
 
     asyncio.run(go())
+
+
+# --- Base-only degradation with no lease store (ADR-0131, #1971) --------------
+#
+# ``StreamConsumer`` gains an optional ``DeliveryLeaseStore`` and an
+# ``on_lease_lost`` callback. Both default to None so a base-only consumer -- the
+# ``_FakeBroker`` shape above, and any future second broker -- is unchanged. The
+# lease context manager degrading to "always grant" is allowed in exactly this
+# one place; nowhere else may a missing lease be read as permission.
+
+
+def test_base_consumer_takes_the_lease_kwargs_and_leaves_them_unset() -> None:
+    """The new parameters are optional. If either becomes required, every
+    base-only construction in this file and in the second-broker port breaks."""
+
+    async def go() -> None:
+        broker = _FakeBroker([], lambda: None)
+        consumer = StreamConsumer(broker, leases=None, on_lease_lost=None)  # type: ignore[arg-type]
+
+        assert consumer._leases is None
+        assert consumer._on_lease_lost is None
+
+    asyncio.run(go())
+
+
+def test_lease_context_manager_grants_permissively_without_a_lease_store() -> None:
+    """With no lease store the CM must yield a permissive sentinel, never None
+    and never a refusal: reverting that degradation makes every base-only
+    consumer return early from its handler and stop consuming entirely.
+
+    The sentinel must also report a POSITIVE remaining budget. A sentinel that
+    read as exhausted would make the kernel's budget check skip every attempt --
+    the same total stall, arrived at from the other side.
+    """
+
+    async def go() -> None:
+        broker = _FakeBroker([], lambda: None)
+        consumer = StreamConsumer(broker)  # type: ignore[arg-type]
+
+        async with consumer._delivery_lease("1-0", {"event_id": "e1"}) as lease:
+            assert lease is not None
+            assert not lease.lost.is_set()
+            lease.raise_if_lost()  # must not raise: nothing can be lost here
+            assert lease.remaining_s() > 0.0
+
+        # Exiting with no store to release against must not raise either.
+
+    asyncio.run(go())
+
+
+def test_no_lease_store_still_consumes_every_entry_and_isolates_a_handler_error(
+    caplog,  # noqa: ANN001
+) -> None:
+    """The #673 contract, re-asserted through the lease-aware constructor: adding
+    the lease lifecycle must not make a leaseless consumer drop entries or let a
+    handler exception escape ``_consume`` and tear down its sibling loops."""
+
+    async def go() -> None:
+        handled: list[str] = []
+
+        async def handler(entry_id: str, _fields: dict[str, str]) -> None:
+            handled.append(entry_id)
+            if entry_id == "2-0":
+                raise ConnectionError("dead-letter XADD hit a Valkey blip")
+
+        batch = [("1-0", {}), ("2-0", {}), ("3-0", {})]
+        holder: dict[str, StreamConsumer] = {}
+        broker = _FakeBroker(batch, lambda: holder["c"].request_stop())
+        consumer = StreamConsumer(broker, leases=None, on_lease_lost=None)  # type: ignore[arg-type]
+        holder["c"] = consumer
+
+        logger = logging.getLogger("curie_worker.test_consume_leaseless")
+        with caplog.at_level(logging.ERROR, logger=logger.name):
+            await asyncio.wait_for(consumer._consume(_spec(logger), handler), timeout=2)
+
+        assert handled == ["1-0", "2-0", "3-0"]
+        errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert len(errors) == 1
+        assert "2-0" in errors[0].getMessage()
+
+    asyncio.run(go())

--- a/charts/curie/ci/worker-ttl-bounds-assertions.sh
+++ b/charts/curie/ci/worker-ttl-bounds-assertions.sh
@@ -8,7 +8,7 @@
 # command`. That exception is not classified by the kernel, so the turn hangs,
 # the entry is re-delivered to dead-letter, and every attempt leaks a sandbox.
 # `values.schema.json` makes helm refuse the value at install/template time so it
-# never reaches worker env at all. Nine assertions:
+# never reaches worker env at all. Ten assertions:
 #
 #   (a) POSITIVE, defaults: the render SUCCEEDS and the worker Deployment
 #       carries the three env vars at their shipped defaults.
@@ -50,12 +50,28 @@
 #       test_substrate_config_refuses_an_unparseable_ttl_naming_the_env_var. (i)
 #       and that case are one seam read from two ends; deleting either removes
 #       half of the only gate on the null path.
+#   (j) ADR-0131 RELATIONSHIP, positive and negative: the rendered
+#       terminationGracePeriodSeconds must cover the rendered
+#       CURIE_DELIVERY_BUDGET_S + CURIE_DELIVERY_SHUTDOWN_RESERVE_S. The
+#       positive raises budget and grace together and must still render+pass;
+#       the negative raises the budget while leaving grace at its pre-ADR-0131
+#       value of 1800 and must be REFUSED BY THE RENDER ITSELF, by the
+#       `curie.worker.validateDrainBudget` guard in _helpers.tpl.
+#       That guard is the only fence an operator actually hits: JSON Schema
+#       cannot express cross-field arithmetic, so values.schema.json accepts
+#       grace=1800, `helm upgrade` used to succeed, and the worker then
+#       CrashLoopBackOffed because its `WorkerConfig` check raises before
+#       `asyncio.run` and no supervisor can catch it -- a silent breaking
+#       upgrade for any install that overrides grace. The fixed-value
+#       assertion in (a) only ever sees 1860 at the default; this is the half
+#       that actually exercises the inequality the ADR mandates, and the only
+#       assertion that demonstrates the guard REJECTING something.
 #
-# WORDING IS NOT ASSERTED, AND MUST NOT BECOME ASSERTED. Every negative below
-# checks only (1) that helm exited non-zero and (2) that the captured output
-# contains the bare knob name. The failure text comes from helm's own bundled
-# JSON-Schema validator, whose wording changed between the CI-pinned helm and
-# current helm while the pass/fail outcomes stayed identical:
+# SCHEMA WORDING IS NOT ASSERTED, AND MUST NOT BECOME ASSERTED. Every negative
+# below EXCEPT (j) checks only (1) that helm exited non-zero and (2) that the
+# captured output contains the bare knob name. The failure text comes from
+# helm's own bundled JSON-Schema validator, whose wording changed between the
+# CI-pinned helm and current helm while the pass/fail outcomes stayed identical:
 #
 #   helm 3.16.4 (the CI pin, .github/workflows/helm-ci.yaml:40):
 #     - worker.routeTtlSeconds: Must be greater than 0
@@ -69,6 +85,12 @@
 # `want integer`, or the `- <path>: ` prefix shape: a wording-locked assertion
 # passes on the author's machine and fails in CI, or the reverse, for a reason
 # that has nothing to do with the chart.
+#
+# (j) is the deliberate exception: its message is CHART-OWNED text from
+# `fail` in _helpers.tpl, not helm's validator, so it cannot drift with the
+# helm version and asserting it is what proves the guard -- rather than some
+# unrelated template error -- is what refused the render. It checks the three
+# key names and the arithmetic, not the full sentence.
 #
 # Runnable locally (from anywhere) and from CI. Fails loudly.
 set -euo pipefail
@@ -125,10 +147,42 @@ deploys = [
 if len(deploys) != 1:
     raise SystemExit(f"expected exactly one worker Deployment, rendered {len(deploys)}")
 got = deploys[0]["spec"]["template"]["spec"].get("terminationGracePeriodSeconds")
-if type(got) is not int or got != 1800:
+if type(got) is not int or got != 1860:
     raise SystemExit(
         "worker terminationGracePeriodSeconds rendered "
-        f"{got!r}, expected integer 1800"
+        f"{got!r}, expected integer 1860"
+    )
+PY
+)"
+
+# ADR-0131 relationship: rendered grace must be >= rendered delivery budget +
+# rendered shutdown reserve. The fixed-value check above catches a values-file
+# drift; THIS catches an operator who raises the budget (or leaves an old grace
+# override in place) without raising the grace to match -- the actual
+# ADR-0131 misconfiguration, and the one the fixed check cannot see.
+WORKER_GRACE_COVERS_BUDGET_PY="$(
+  cat <<'PY'
+import sys, yaml
+docs = [d for d in yaml.safe_load_all(open(sys.argv[1])) if d]
+deploys = [
+    d for d in docs
+    if d.get("kind") == "Deployment"
+    and (d["metadata"].get("labels") or {}).get("app.kubernetes.io/component") == "worker"
+]
+if len(deploys) != 1:
+    raise SystemExit(f"expected exactly one worker Deployment, rendered {len(deploys)}")
+spec = deploys[0]["spec"]["template"]["spec"]
+grace = spec.get("terminationGracePeriodSeconds")
+env = {e["name"]: e.get("value") for c in spec["containers"] for e in c.get("env", [])}
+budget = int(env["CURIE_DELIVERY_BUDGET_S"])
+reserve = int(env["CURIE_DELIVERY_SHUTDOWN_RESERVE_S"])
+required = budget + reserve
+if type(grace) is not int or grace < required:
+    raise SystemExit(
+        f"terminationGracePeriodSeconds ({grace!r}) does not cover "
+        f"CURIE_DELIVERY_BUDGET_S + CURIE_DELIVERY_SHUTDOWN_RESERVE_S "
+        f"({budget} + {reserve} = {required}): a draining worker would be "
+        "SIGKILLed before it could settle"
     )
 PY
 )"
@@ -189,10 +243,18 @@ fi
 if ! msg="$(python3 -c "$WORKER_TERMINATION_GRACE_PY" "$DEFAULT_RENDER" 2>&1)"; then
   fail a "$msg"
 fi
+if ! msg="$(python3 -c "$WORKER_GRACE_COVERS_BUDGET_PY" "$DEFAULT_RENDER" 2>&1)"; then
+  fail a "$msg"
+fi
 assert_env a -- \
   CURIE_CLAIM_TIMEOUT_SECONDS=90 \
   CURIE_ROUTE_TTL_SECONDS=3600 \
-  CURIE_SUSPENDED_ROUTE_TTL_SECONDS=86400
+  CURIE_SUSPENDED_ROUTE_TTL_SECONDS=86400 \
+  CURIE_DELIVERY_BUDGET_S=600 \
+  CURIE_DELIVERY_LEASE_TTL_S=45 \
+  CURIE_DELIVERY_LEASE_HEARTBEAT_S=10 \
+  CURIE_DELIVERY_SHUTDOWN_RESERVE_S=60 \
+  CURIE_TERMINATION_GRACE_PERIOD_S=1860
 
 # (b)
 assert_env b \
@@ -262,4 +324,50 @@ done
 # (i)
 assert_env i --set worker.routeTtlSeconds=null -- CURIE_ROUTE_TTL_SECONDS=
 
-echo "worker-ttl-bounds-assertions: all nine assertions passed"
+# (j) ADR-0131 grace/budget relationship, POSITIVE and NEGATIVE. This is the
+# important half of the assertion, not a formality -- a render assertion that
+# only ever sees the default values is vacuous. The negative reproduces the
+# actual ADR-0131 misconfiguration: an operator raises the delivery budget to
+# 1800 but leaves an old terminationGracePeriodSeconds override (1800, the
+# pre-ADR-0131 value) in place, so grace no longer covers budget + reserve
+# (1800 + 60 = 1860 > 1800). That combination used to render clean and kill the
+# worker at boot; it is now refused at render time by
+# `curie.worker.validateDrainBudget`, so the negative asserts the REFUSAL and
+# its message rather than inspecting a rendered manifest.
+J_POSITIVE="$TMP/j-positive.yaml"
+if ! helm template curie "$CHART" \
+  --set worker.deliveryBudgetSeconds=1800 \
+  --set worker.terminationGracePeriodSeconds=1860 \
+  >"$J_POSITIVE" 2>&1; then
+  fail j "the render FAILED on a raised budget with a matching grace; it must succeed
+  $(head -5 "$J_POSITIVE")"
+fi
+if ! msg="$(python3 -c "$WORKER_GRACE_COVERS_BUDGET_PY" "$J_POSITIVE" 2>&1)"; then
+  fail j "$msg"
+fi
+
+# The NEGATIVE control. Captured, not piped: helm exits non-zero by design here
+# and `set -o pipefail` would abort the script on the very outcome being
+# asserted.
+J_NEGATIVE_OUT=""
+if J_NEGATIVE_OUT="$(helm template curie "$CHART" \
+  --set worker.deliveryBudgetSeconds=1800 \
+  --set worker.terminationGracePeriodSeconds=1800 2>&1)"; then
+  fail j "helm ACCEPTED deliveryBudgetSeconds=1800 with terminationGracePeriodSeconds=1800 (grace 1800 < required 1860). That render must be refused: it upgrades clean and then CrashLoopBackOffs the worker on the boot validator"
+fi
+# The three key names and the arithmetic, checked one token at a time so the
+# assertion says WHICH part of the message went missing. Chart-owned wording,
+# not helm's -- see the header note above.
+for token in \
+  "worker.terminationGracePeriodSeconds" \
+  "worker.deliveryBudgetSeconds" \
+  "worker.deliveryShutdownReserveSeconds" \
+  "(1800) + " \
+  "(60) = 1860" \
+  "ADR-0131"; do
+  grep -qF "$token" <<<"$J_NEGATIVE_OUT" \
+    || fail j "the refusal does not mention $token; an operator reading it during an upgrade cannot tell which value to raise
+  $(head -3 <<<"$J_NEGATIVE_OUT")"
+done
+
+echo "worker-ttl-bounds-assertions: all ten assertions passed"

--- a/charts/curie/templates/_helpers.tpl
+++ b/charts/curie/templates/_helpers.tpl
@@ -1073,3 +1073,33 @@ securityContext:
 securityContext:
 {{- toYaml . | nindent 2 }}
 {{- end -}}
+
+{{/* ---- ADR-0131 drain-budget relationship (worker) ----
+     `worker.terminationGracePeriodSeconds` must cover
+     `worker.deliveryBudgetSeconds` + `worker.deliveryShutdownReserveSeconds`.
+     The chart renders that same grace value BOTH onto the Pod's
+     `spec.terminationGracePeriodSeconds` and into the worker's
+     `CURIE_TERMINATION_GRACE_PERIOD_S`, where `WorkerConfig` re-checks the
+     inequality at boot -- and that check raises before `asyncio.run`, so the
+     supervisor cannot catch it and the pod CrashLoopBackOffs.
+
+     Without this render-time guard, an existing install that overrides
+     `worker.terminationGracePeriodSeconds` to any value the schema accepts but
+     the inequality rejects `helm upgrade`s CLEANLY and then takes the entire
+     turn plane down: a silent breaking upgrade. `values.schema.json` cannot
+     close it -- JSON Schema has no cross-field arithmetic -- and the CI
+     render-assertion never sees operator values. So the fence has to be here,
+     where `helm template`/`install`/`upgrade` all pass through it.
+
+     This does NOT replace the worker's boot validator, which remains the
+     backstop for the non-Helm substrates (Compose, bare env). It only moves the
+     Helm-shaped failure from pod boot to render time, where it is actionable. */}}
+{{- define "curie.worker.validateDrainBudget" -}}
+{{- $grace := int64 .Values.worker.terminationGracePeriodSeconds -}}
+{{- $budget := int64 .Values.worker.deliveryBudgetSeconds -}}
+{{- $reserve := int64 .Values.worker.deliveryShutdownReserveSeconds -}}
+{{- $required := add $budget $reserve -}}
+{{- if lt $grace $required -}}
+{{- fail (printf "worker.terminationGracePeriodSeconds (%d) must be at least worker.deliveryBudgetSeconds (%d) + worker.deliveryShutdownReserveSeconds (%d) = %d (ADR-0131). At %d a worker draining a full-budget delivery is SIGKILLed before it can settle, and the worker refuses this configuration at boot, so the Pod CrashLoopBackOffs instead of starting. Fix: raise worker.terminationGracePeriodSeconds to %d or more, or lower worker.deliveryBudgetSeconds and/or worker.deliveryShutdownReserveSeconds so their sum is at most %d." $grace $budget $reserve $required $grace $required $grace) -}}
+{{- end -}}
+{{- end -}}

--- a/charts/curie/templates/worker.yaml
+++ b/charts/curie/templates/worker.yaml
@@ -8,6 +8,12 @@
 {{- if gt (float64 $workspaceStageBudget) (float64 .Values.worker.workspace.totalTimeoutSeconds) }}
 {{- fail "worker.workspace stage timeouts must sum to no more than totalTimeoutSeconds" }}
 {{- end }}
+{{/* ADR-0131: grace must cover deliveryBudget + deliveryShutdownReserve. Render
+     time is the ONLY place this can fail usefully -- values.schema.json cannot
+     express cross-field arithmetic, and the worker's own boot check raises
+     before its supervisor exists, so a bad value that reaches a Pod is a
+     CrashLoopBackOff after a green `helm upgrade`. */}}
+{{- include "curie.worker.validateDrainBudget" . }}
 {{- if .Values.worker.serviceAccount.create }}
 {{/*
 The worker drives the Kubernetes API to claim and manage agent-sandbox custom
@@ -336,6 +342,30 @@ spec:
               value: {{ .Values.worker.routeTtlSeconds | quote }}
             - name: CURIE_SUSPENDED_ROUTE_TTL_SECONDS
               value: {{ .Values.worker.suspendedRouteTtlSeconds | quote }}
+            # Delivery budget and ownership lease (ADR-0131, #1971). The
+            # overall wall-clock deadline for one delivery -- claim, every
+            # runner request, every retry backoff, reclaim, and terminal
+            # cleanup.
+            - name: CURIE_DELIVERY_BUDGET_S
+              value: {{ .Values.worker.deliveryBudgetSeconds | quote }}
+            # How long the renewable ownership lease lives before it is
+            # considered expired and transferable to a new owner.
+            - name: CURIE_DELIVERY_LEASE_TTL_S
+              value: {{ .Values.worker.deliveryLeaseTtlSeconds | quote }}
+            # How often the owner renews its lease and resets its PEL idle.
+            - name: CURIE_DELIVERY_LEASE_HEARTBEAT_S
+              value: {{ .Values.worker.deliveryLeaseHeartbeatSeconds | quote }}
+            # Budget reserved for terminal settlement after the runner work is
+            # done; terminationGracePeriodSeconds below must be at least the
+            # delivery budget plus this reserve.
+            - name: CURIE_DELIVERY_SHUTDOWN_RESERVE_S
+              value: {{ .Values.worker.deliveryShutdownReserveSeconds | quote }}
+            # The platform's own voluntary termination grace, injected from the
+            # SAME value that renders onto this Pod's spec.terminationGracePeriodSeconds
+            # (line ~145) so the worker's boot validator and the platform can
+            # never disagree about how long a drain is allowed to take.
+            - name: CURIE_TERMINATION_GRACE_PERIOD_S
+              value: {{ .Values.worker.terminationGracePeriodSeconds | quote }}
             # Slack assistant-thread "shimmer" (#1182). Rendered on the WORKER
             # only: it both raises the caption and lowers it, so one value
             # governs the feature release-wide and the two halves cannot be

--- a/charts/curie/values.schema.json
+++ b/charts/curie/values.schema.json
@@ -36,6 +36,36 @@
           "maximum": 31536000,
           "description": "Seconds a route suspended awaiting an approval pins its sandbox. Must be greater than 0 and at most 31536000 (one year). Integer rather than number for the same reason as routeTtlSeconds: a YAML float renders through `| quote` as scientific notation for larger values (ci/github-app-credential-assertions.sh:11)."
         },
+        "deliveryBudgetSeconds": {
+          "type": "integer",
+          "minimum": 60,
+          "maximum": 1800,
+          "description": "Overall wall-clock deadline for one delivery (ADR-0131). Below 60s a budget cannot cover claim + one runner request + settle; above 1800s (the ADR's stated maximum) silently requires a termination grace the schema will not accept."
+        },
+        "deliveryLeaseTtlSeconds": {
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 3600,
+          "description": "How long the renewable ownership lease lives before it is considered expired and transferable (ADR-0131). Must be at least 3x deliveryLeaseHeartbeatSeconds; the worker's own validator enforces the relationship, not this schema."
+        },
+        "deliveryLeaseHeartbeatSeconds": {
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 3600,
+          "description": "How often the delivery lease owner renews its lease and resets its PEL idle (ADR-0131). Too large relative to deliveryLeaseTtlSeconds drops a healthy owner's lease on a single missed heartbeat; the worker's own validator enforces that relationship."
+        },
+        "deliveryShutdownReserveSeconds": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 3600,
+          "description": "Budget reserved for fenced terminal settlement after runner work completes (ADR-0131). terminationGracePeriodSeconds must be at least deliveryBudgetSeconds plus this value, or a draining worker is SIGKILLed before it can settle."
+        },
+        "terminationGracePeriodSeconds": {
+          "type": "integer",
+          "minimum": 60,
+          "maximum": 86400,
+          "description": "Voluntary Pod termination grace before SIGKILL. Must be at least deliveryBudgetSeconds + deliveryShutdownReserveSeconds (ADR-0131, #1971), or a worker draining a maximum-budget turn is killed at the exact moment it would settle; below 60s not even a fast drain reliably completes."
+        },
         "workspace": {
           "type": "object",
           "properties": {

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -1097,7 +1097,16 @@ mailAdapter:
 worker:
   deploy: true
   replicas: 1
-  terminationGracePeriodSeconds: 1800
+  # Must be >= deliveryBudgetSeconds + deliveryShutdownReserveSeconds
+  # (ADR-0131): 1800 + 60 = 1860 covers the ADR's maximum configurable budget.
+  # The prior 1800 (#1570, "Give worker turns time to drain") was sized
+  # against max_attempts * runner_total_timeout_s with zero headroom for
+  # settlement -- a worker draining a maximum-budget turn was SIGKILLed at
+  # exactly the moment it would have settled. Voluntary termination may now
+  # take up to the configured budget plus reserve, so a rollout can take up
+  # to ~31 minutes per pod at the maximum budget; operators choose that cost
+  # when they choose a long execution budget.
+  terminationGracePeriodSeconds: 1860
   image:
     repository: ghcr.io/curie-eng/curie-worker
     # Empty -> chart appVersion (immutable). Set to pin an explicit version tag.
@@ -1276,6 +1285,32 @@ worker:
   # is accepted by YAML, renders fine, and used to boot healthy and then hang
   # every turn while leaking a sandbox per attempt (#1388).
   suspendedRouteTtlSeconds: 86400
+  # Delivery budget and ownership lease (ADR-0131, #1971). One overall
+  # wall-clock deadline and one renewable fenced owner per delivery, replacing
+  # the old dead pair of a flat per-request HTTP timeout and a 900s idle-based
+  # steal window. Integers, not floats -- as with routeTtlSeconds, a YAML
+  # float renders through the template's `| quote` as scientific notation for
+  # larger values, which the worker then cannot parse.
+  #
+  # The OVERALL deadline for one delivery: claim, every runner request, every
+  # retry backoff, reclaim, and terminal cleanup. Must be between 60 and 1800
+  # (the ADR's stated maximum); values.schema.json enforces this at
+  # install/template time and the worker's own validator enforces it again at
+  # boot.
+  deliveryBudgetSeconds: 600
+  # How long the renewable ownership lease lives before it is considered
+  # expired and transferable. Must span at least 3 heartbeat periods
+  # (deliveryLeaseHeartbeatSeconds) so a single missed heartbeat never drops a
+  # healthy owner's lease -- enforced by the worker's own validator.
+  deliveryLeaseTtlSeconds: 45
+  # How often the owner renews its lease and resets its PEL idle via
+  # `XCLAIM ... JUSTID`, which does NOT increase the stream entry's delivery
+  # count.
+  deliveryLeaseHeartbeatSeconds: 10
+  # Budget reserved for terminal settlement (fenced ACK/dead-letter/outbox
+  # clear) after the runner work is done. `terminationGracePeriodSeconds`
+  # above must be at least deliveryBudgetSeconds + this value.
+  deliveryShutdownReserveSeconds: 60
   # The Slack assistant-thread "shimmer" (#1182): the animated caption Slack
   # shows next to the app's name while a turn runs. On by default -- the
   # placeholder message only changes when the model emits text, so a model that


### PR DESCRIPTION
Implements [ADR-0131](docs/adr/0131-a-delivery-has-one-deadline-and-one-renewable-fenced-owner.md) (Accepted 2026-08-27). Tracking issue: #1971.

## The defect

The worker had two unrelated clocks: a 600s total HTTP deadline per runner request, and a 900s PEL-idle reclaim. Nothing renewed PEL ownership across replicas while a handler was live. The spike observed all three boundaries on a real candidate — a runner still emitting progress was cancelled at 600s, and at the 900s boundary a second replica entered the handler while the first was still running. Raising the runner timeout alone would have made the overlap larger, not made a 30-minute delivery safe.

## The change

A delivery carries a per-`(stream, group, entry_id)` lease in Valkey holding an opaque owner token and a monotonically increasing fencing generation. The owner renews it on a heartbeat; a replacement may take it only after the lease has **demonstrably expired**, never on suspicion of death. Execution and settlement are fenced on the generation, so an owner that lost its lease cannot produce the terminal effect.

Three details are load-bearing, each with a red-on-revert regression:

- **`XCLAIM … JUSTID`** renews PEL ownership without incrementing `times_delivered`. A plain `XCLAIM` would burn the ADR-0039 delivery budget once per heartbeat.
- **`HSETNX` on the deadline**, so a replacement inherits the original budget. `HSET` here would let a delivery live forever by changing hands.
- **Monotonic anchoring** to the last observed Valkey server `TIME`, so a wall-clock change cannot extend a budget. The module never reads the wall clock, asserted by AST rather than text match.

The fencing generation lives in the long-retention state key, not the lease key — on the lease key it would reset when the lease expired and silently break fencing at exactly the moment it matters.

Ownership checks are **entry-targeted** (`XPENDING … IDLE 0 <entry> <entry> 1`). The consumer-scoped form pages the whole pending list and answers about the *oldest* entry, which with `max_concurrency=16` would pass whenever the consumer held any entry at all — defeating the fence.

## Config and rollout

An operator-wide delivery budget (default 600s, bounded 60–1800s) plus lease TTL, heartbeat interval and shutdown reserve, each with a boot-time validator. The chart raises `terminationGracePeriodSeconds` to 1860 and renders a guard that **fails the render** when a raised budget would outrun the drain grace.

## Evidence

Two controlled runs held a single delivery open for **13:01** and **28:23** wall — crossing the old 600s timeout and, in the second, the old 900s reclaim threshold. Each: one handler entry, zero peer dispatches, `times_delivered` pinned at 1, steering accepted mid-turn at 630s, exactly one terminal effect. The same harness with the heartbeat disabled reproduces the original defect (two handler entries, `times_delivered` 1→2), so the runs can fail.

Local: 1163 passed / 0 failed, ruff clean, mypy clean across 232 source files, chart assertions 10/10.

## Relationship to #1532

Complementary, not overlapping. #1532's `consumer_liveness` is a per-consumer-*process* lease; this is a per-*delivery* lease keyed by entry id. Dead-consumer discovery finds candidates; the delivery lease is the authority. Consumer disappearance alone is not authority to steal a delivery whose lease is still live.

## Scope note

The originating goal asked for a per-agent or per-turn budget. ADR-0131 Alternatives #5 explicitly rejects that for the first implementation and pins an operator-wide setting. The ADR governs.

## Known follow-ups (not in this PR)

- The `XAUTOCLAIM` reclaim path checks the lease *after* claiming. The fence still prevents any user-visible effect, so this is bounded thrash rather than a safety violation; closing it means replacing `XAUTOCLAIM` with `XPENDING`+`XCLAIM`, a crash-recovery behavior change.
- Pre-steer `status` and `_turn_active` run under the per-thread lock with a 600s bound. Pre-existing on `next`, not introduced here.
- `remaining_s` on the eval runner's `reset`/`snapshot` has no caller; either wire the budget into the eval driver or drop the dead params.