### PR TITLE
Re-discover the GitHub App installation when a cached id goes stale

### DIFF
--- a/apps/api/src/curie_api/github_app.py
+++ b/apps/api/src/curie_api/github_app.py
@@ -26,6 +26,7 @@ in GitHub" that ADR-0092 is buying.
 from __future__ import annotations
 
 import logging
+import threading
 import time
 from dataclasses import dataclass, field
 from typing import Any
@@ -99,6 +100,23 @@ class GitHubAppError(RuntimeError):
     """The App is configured but could not produce a token."""
 
 
+class _GitHubNotFound(GitHubAppError):
+    """GitHub answered 404.
+
+    A subclass rather than a `not_found_message` parameter because the caller,
+    not `_request`, is the only thing that knows which 404 this is: the same
+    status on `/repos/{repo}/installation` means "the App was never installed"
+    while on `/access_tokens` it usually means "the id we cached was retired by
+    a reinstall". Callers that do not catch it still see the identical
+    `GitHubAppError` with the identical message, so `_request`'s contract is
+    unchanged.
+
+    Carries no extra state: the type IS the signal, and a `status_code`
+    attribute nothing ever read only invited a second way to ask the same
+    question.
+    """
+
+
 @dataclass
 class _CachedToken:
     token: str
@@ -114,11 +132,23 @@ class GitHubCredentials:
 
     Holds a token cache keyed by repository, so a burst of pushes to one repo
     costs one token exchange rather than one per push.
+
+    `clone_and_archive` runs under `run_in_threadpool`, so concurrent webhook
+    pushes hit this object from genuine OS threads. The per-repository mint lock
+    below is what stops eight simultaneous pushes from doing eight token
+    exchanges (measured: 8 threads, 5 distinct tokens) -- every one of those
+    tokens is valid, so this is rate-limit pressure rather than a correctness
+    bug, but it is free to avoid.
     """
 
     settings: Settings
     _tokens: dict[str, _CachedToken] = field(default_factory=dict)
     _installations: dict[str, int] = field(default_factory=dict)
+    # Per-repository, never global: a mint for one repo must not serialize a
+    # mint for another, and the HTTP call happens while this is held.
+    _mint_locks: dict[str, threading.Lock] = field(default_factory=dict)
+    # Guards only the dict above, and is never held across a network call.
+    _mint_locks_guard: threading.Lock = field(default_factory=threading.Lock)
 
     @property
     def app_configured(self) -> bool:
@@ -183,14 +213,28 @@ class GitHubCredentials:
         if not self.app_configured:
             return self.settings.github_token
 
-        now = time.time()
         cached = self._tokens.get(repo_full_name)
-        if cached is not None and cached.usable(now):
+        if cached is not None and cached.usable(time.time()):
             return cached.token
 
-        token, expires_at = self._mint_installation_token(repo_full_name)
-        self._tokens[repo_full_name] = _CachedToken(token=token, expires_at=expires_at)
-        return token
+        with self._mint_lock_for(repo_full_name):
+            # Double-checked: the thread that held this lock has almost
+            # certainly just populated the cache we lost the race to read.
+            cached = self._tokens.get(repo_full_name)
+            if cached is not None and cached.usable(time.time()):
+                return cached.token
+
+            token, expires_at = self._mint_installation_token(repo_full_name)
+            self._tokens[repo_full_name] = _CachedToken(token=token, expires_at=expires_at)
+            return token
+
+    def _mint_lock_for(self, repo_full_name: str) -> threading.Lock:
+        with self._mint_locks_guard:
+            lock = self._mint_locks.get(repo_full_name)
+            if lock is None:
+                lock = threading.Lock()
+                self._mint_locks[repo_full_name] = lock
+            return lock
 
     # -- GitHub App plumbing -------------------------------------------------
 
@@ -209,12 +253,21 @@ class GitHubCredentials:
                 f"is the App's full PEM private key: {type(exc).__name__}"
             ) from exc
 
-    def _installation_id(self, repo_full_name: str) -> int:
-        """The App's installation on this repository, discovered and cached."""
+    def _installation_id(self, repo_full_name: str) -> tuple[int, bool]:
+        """The App's installation on this repository, and whether it was cached.
+
+        The second element is what makes the retry in `_mint_installation_token`
+        safe to bound: re-discovering an id that discovery just produced would
+        only repeat the same 404.
+        """
 
         known = self._installations.get(repo_full_name)
         if known is not None:
-            return known
+            return known, True
+        return self._discover_installation_id(repo_full_name), False
+
+    def _discover_installation_id(self, repo_full_name: str) -> int:
+        """Ask GitHub which installation covers this repository, and cache it."""
 
         url = (
             f"{self.settings.github_api_url.rstrip('/')}"
@@ -228,7 +281,43 @@ class GitHubCredentials:
         return installation_id
 
     def _mint_installation_token(self, repo_full_name: str) -> tuple[str, float]:
-        installation_id = self._installation_id(repo_full_name)
+        installation_id, from_cache = self._installation_id(repo_full_name)
+        try:
+            return self._mint_for_installation(repo_full_name, installation_id)
+        except _GitHubNotFound as exc:
+            if not from_cache:
+                raise self._mint_404_error(
+                    repo_full_name, installation_id, re_discovered=False
+                ) from exc
+            # Reinstalling the App retires the old installation and issues a new
+            # id. `_installations` had no expiry, so every later mint POSTed to
+            # the retired id, 404'd, and never re-ran discovery -- recovery meant
+            # restarting the API. Evict and re-discover ONCE; the id we just used
+            # came from the cache, so a fresh one is genuinely new information.
+            logger.info(
+                "cached GitHub installation %s for %r 404'd on mint; re-discovering",
+                installation_id,
+                repo_full_name,
+            )
+            self._installations.pop(repo_full_name, None)
+
+        # Deliberately back through `_installation_id`, which reads the cache
+        # first, rather than calling `_discover_installation_id` directly: that
+        # is what makes the eviction above load-bearing. We hold this repo's
+        # mint lock, so nothing can repopulate the entry we just popped, and the
+        # lookup therefore misses and discovers. Call discovery directly and the
+        # eviction becomes decorative -- deleting it leaves every test green
+        # (#1257), because discovery would overwrite the stale entry anyway.
+        installation_id, _ = self._installation_id(repo_full_name)
+        try:
+            return self._mint_for_installation(repo_full_name, installation_id)
+        except _GitHubNotFound as exc:
+            # One retry, never a loop: discovery has now spoken twice.
+            raise self._mint_404_error(repo_full_name, installation_id, re_discovered=True) from exc
+
+    def _mint_for_installation(
+        self, repo_full_name: str, installation_id: int
+    ) -> tuple[str, float]:
         url = (
             f"{self.settings.github_api_url.rstrip('/')}"
             f"/app/installations/{installation_id}/access_tokens"
@@ -245,6 +334,41 @@ class GitHubCredentials:
         return token, self._expiry_seconds(data.get("expires_at"))
 
     @staticmethod
+    def _mint_404_error(
+        repo_full_name: str, installation_id: int, *, re_discovered: bool
+    ) -> GitHubAppError:
+        """The mint 404'd on an id discovery resolved. Two operator states, two texts.
+
+        Deliberately NOT the discovery wording in either case. Discovery
+        succeeded, so the App *is* registered on the repository, and telling the
+        operator to install it is precisely the advice that wasted their time
+        after a reinstall.
+
+        The two states are genuinely different and one sentence cannot be true of
+        both. On the fresh path nothing was ever cached, nothing was evicted and
+        nothing was re-discovered, so claiming a cached installation went stale
+        describes a sequence that did not happen and sends the operator hunting a
+        cache bug instead of the App's repository permissions (#1257).
+        """
+
+        if re_discovered:
+            middle = (
+                "The previously cached installation was stale, so it was evicted and "
+                "re-discovered -- and the re-discovered installation cannot mint either. "
+            )
+        else:
+            middle = (
+                "Discovery resolved that installation just now and nothing was cached, "
+                "so the App is registered on the repository. "
+            )
+        return GitHubAppError(
+            f"GitHub returned 404 minting an installation token for {repo_full_name!r} via "
+            f"installation {installation_id}. "
+            + middle
+            + f"Check the App's repository access and permissions for {repo_full_name!r}."
+        )
+
+    @staticmethod
     def _expiry_seconds(raw: Any) -> float:
         """When the token dies, as a monotonic-ish epoch second.
 
@@ -253,13 +377,23 @@ class GitHubCredentials:
         caching a dead token would fail every clone until restart.
         """
 
-        from datetime import datetime
+        from datetime import UTC, datetime
 
         if isinstance(raw, str):
             try:
-                return datetime.fromisoformat(raw.replace("Z", "+00:00")).timestamp()
+                parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
             except ValueError:
                 logger.warning("unparseable GitHub token expiry; assuming one hour")
+            else:
+                if parsed.tzinfo is None:
+                    # GitHub documents these as UTC. A value without `Z` or an
+                    # offset would otherwise be read in the container's local
+                    # zone by `.timestamp()`: under TZ=America/Los_Angeles a
+                    # 3600s token caches as 28800s and every clone 401s for
+                    # about seven hours. github.com always sends `Z`, but this
+                    # module already promises to survive one that does not.
+                    parsed = parsed.replace(tzinfo=UTC)
+                return parsed.timestamp()
         return time.time() + 3600
 
     # -- HTTP ----------------------------------------------------------------
@@ -286,8 +420,10 @@ class GitHubCredentials:
 
         if response.status_code == 404:
             # The single most likely operator mistake, and the one whose default
-            # message ("Not Found") explains nothing.
-            raise GitHubAppError(
+            # message ("Not Found") explains nothing. Raised as the subclass so
+            # the mint path can tell a retired installation id apart from an App
+            # that was never installed; uncaught, it reads identically.
+            raise _GitHubNotFound(
                 f"GitHub returned 404 for {url}. Usually this means the App is not "
                 "installed on that repository -- install it, or add the repository "
                 "to the existing installation."

--- a/apps/api/tests/test_github_app.py
+++ b/apps/api/tests/test_github_app.py
@@ -9,6 +9,7 @@ every push or a dead token served until restart.
 from __future__ import annotations
 
 import logging
+import threading
 import time
 from datetime import UTC, datetime, timedelta
 from typing import Any
@@ -422,3 +423,304 @@ def test_the_startup_line_carries_no_secret(private_key: str, caplog) -> None:
     text = " ".join(r.getMessage() for r in caplog.records)
     assert "PRIVATE KEY" not in text
     assert "ghp_supersecret" not in text
+
+
+# --------------------------------------------------------------------------- #
+# The installation-id cache -- reinstalling the App used to need a restart (#1257)
+# --------------------------------------------------------------------------- #
+class ReinstallRecorder:
+    """GitHub across an App reinstall: discovery moves, the retired id 404s.
+
+    `installation_id` is what discovery reports; `valid_ids` is what
+    `/access_tokens` will still mint for. Setting the two to different values is
+    exactly the state an operator lands in the moment they reinstall the App.
+    """
+
+    def __init__(self, installation_id: int = 4242, valid_ids: set[int] | None = None):
+        self.minted = 0
+        self.discoveries = 0
+        self.installation_id = installation_id
+        self.valid_ids = {installation_id} if valid_ids is None else valid_ids
+
+    def handle(self, request: httpx.Request) -> httpx.Response:
+        parts = request.url.path.strip("/").split("/")
+        if parts[-1] == "installation":
+            self.discoveries += 1
+            return httpx.Response(200, json={"id": self.installation_id})
+        if parts[-1] == "access_tokens":
+            requested = int(parts[-2])
+            if requested not in self.valid_ids:
+                # What GitHub answers for an installation that no longer exists.
+                return httpx.Response(404, json={"message": "Not Found"})
+            self.minted += 1
+            return httpx.Response(
+                201,
+                json={"token": f"ghs_from_{requested}", "expires_at": "2999-01-01T00:00:00Z"},
+            )
+        return httpx.Response(404, json={"message": "Not Found"})
+
+
+def _expire_cached_token(creds: GitHubCredentials, repo: str) -> None:
+    """Age out the token cache so the next call actually mints.
+
+    The token cache is the thing that hid this bug in production for an hour at
+    a time; forcing it stale is setup, not the assertion.
+    """
+
+    creds._tokens[repo].expires_at = time.time() - 1
+
+
+def test_a_reinstalled_app_recovers_without_restarting_the_api(private_key, monkeypatch) -> None:
+    """AC1. `_installations` had no invalidation of any kind (#1257).
+
+    Reinstalling the App retires the installation id. Every later mint POSTed to
+    the retired id, took a 404, and never re-ran discovery -- so the only
+    recovery was restarting the API, and the 404 told the operator to install an
+    App they had just installed. Deleting the eviction turns this red: the
+    second `token_for` raises instead of returning a token from 8484.
+    """
+
+    recorder = ReinstallRecorder()
+    monkeypatch.setattr("curie_api.github_app.httpx.Client", serve(recorder.handle))
+    creds = GitHubCredentials(settings=app_settings(private_key))
+
+    assert creds.token_for(REPO) == "ghs_from_4242"
+    discoveries_before = recorder.discoveries
+
+    # The operator reinstalls the App.
+    recorder.installation_id = 8484
+    recorder.valid_ids = {8484}
+    _expire_cached_token(creds, REPO)
+
+    assert creds.token_for(REPO) == "ghs_from_8484", "a reinstall must not need a restart"
+    assert recorder.discoveries == discoveries_before + 1, "the stale id must be re-discovered"
+
+
+def test_the_re_discovered_installation_is_cached_again(private_key, monkeypatch) -> None:
+    # Otherwise "always re-discover" also passes the test above and the
+    # installation cache stops being a cache.
+    recorder = ReinstallRecorder()
+    monkeypatch.setattr("curie_api.github_app.httpx.Client", serve(recorder.handle))
+    creds = GitHubCredentials(settings=app_settings(private_key))
+
+    creds.token_for(REPO)
+    recorder.installation_id = 8484
+    recorder.valid_ids = {8484}
+    _expire_cached_token(creds, REPO)
+    creds.token_for(REPO)
+
+    discoveries_after_recovery = recorder.discoveries
+    _expire_cached_token(creds, REPO)
+    assert creds.token_for(REPO) == "ghs_from_8484"
+    assert recorder.discoveries == discoveries_after_recovery, "recovery must not disable the cache"
+
+
+def test_a_freshly_discovered_installation_is_not_re_discovered(private_key, monkeypatch) -> None:
+    """Exactly one retry, and only when the id came from the cache.
+
+    If discovery just produced the id, re-running discovery can only produce the
+    same id and the same 404 -- a second round trip on every genuine failure,
+    and one 404 away from a retry loop.
+    """
+
+    recorder = ReinstallRecorder(valid_ids=set())
+    monkeypatch.setattr("curie_api.github_app.httpx.Client", serve(recorder.handle))
+    creds = GitHubCredentials(settings=app_settings(private_key))
+
+    with pytest.raises(GitHubAppError):
+        creds.token_for(REPO)
+
+    assert recorder.discoveries == 1, "a fresh id that 404s must surface, not be re-discovered"
+    assert recorder.minted == 0
+
+
+def test_a_fresh_installation_404_never_tells_the_operator_to_install_the_app(
+    private_key, monkeypatch
+) -> None:
+    """AC3, the no-cache half. Nothing was cached, so nothing may be called stale.
+
+    Discovery 404 means "install the App" (asserted by
+    `test_a_repository_the_app_cannot_see_says_so`). A mint 404 on an id
+    discovery just resolved means the App IS installed -- repeating the install
+    advice is what sent operators round the loop after a reinstall. But this
+    path evicted nothing and re-discovered nothing, so the reinstall wording is
+    simply false here and points at a cache bug that does not exist (#1257).
+    """
+
+    recorder = ReinstallRecorder(valid_ids=set())
+    monkeypatch.setattr("curie_api.github_app.httpx.Client", serve(recorder.handle))
+    creds = GitHubCredentials(settings=app_settings(private_key))
+
+    with pytest.raises(GitHubAppError) as raised:
+        creds.token_for(REPO)
+
+    message = str(raised.value)
+    assert "4242" in message, "the operator has to be told which installation failed"
+    assert "not installed on that repository" not in message
+    assert "install it" not in message
+    assert "stale" not in message, "nothing was cached here, so nothing went stale"
+
+
+def test_a_stale_installation_404_says_the_cached_one_was_re_discovered(
+    private_key, monkeypatch
+) -> None:
+    """AC3, the eviction half. The reinstall recovery ran and still failed.
+
+    The operator reinstalled, we evicted the retired id and re-discovered a new
+    one, and that one cannot mint either. This is the one state where naming the
+    stale cache is true -- and the id quoted has to be the RE-DISCOVERED one, or
+    the operator goes and inspects an installation GitHub already retired.
+    """
+
+    recorder = ReinstallRecorder()
+    monkeypatch.setattr("curie_api.github_app.httpx.Client", serve(recorder.handle))
+    creds = GitHubCredentials(settings=app_settings(private_key))
+
+    creds.token_for(REPO)  # caches installation 4242
+
+    # The operator reinstalls, and the new installation is broken too.
+    recorder.installation_id = 8484
+    recorder.valid_ids = set()
+    _expire_cached_token(creds, REPO)
+
+    with pytest.raises(GitHubAppError) as raised:
+        creds.token_for(REPO)
+
+    message = str(raised.value)
+    assert "8484" in message, "the re-discovered installation is the one to go and look at"
+    assert "stale" in message
+    assert "not installed on that repository" not in message
+    assert "install it" not in message
+
+
+# --------------------------------------------------------------------------- #
+# Single-flight -- `clone_and_archive` runs under `run_in_threadpool`
+# --------------------------------------------------------------------------- #
+def test_concurrent_pushes_to_one_repo_mint_exactly_one_token(private_key, monkeypatch) -> None:
+    """`token_for` was a check-then-act on a plain dict (#1257).
+
+    Concurrent webhook pushes are real OS threads, so eight of them produced
+    five distinct tokens from five mints. Every token was valid, so this is
+    redundant token exchanges and rate-limit pressure rather than a correctness
+    bug -- but the fix is a per-repo lock and a re-read of the cache.
+    """
+
+    workers = 8
+    recorder = Recorder()
+    barrier = threading.Barrier(workers)
+    inner = recorder.handle
+
+    def slow(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/access_tokens"):
+            time.sleep(0.05)  # a real window for the losers to pile into
+        return inner(request)
+
+    monkeypatch.setattr("curie_api.github_app.httpx.Client", serve(slow))
+    creds = GitHubCredentials(settings=app_settings(private_key))
+
+    seen: list[str] = []
+    guard = threading.Lock()
+
+    def push() -> None:
+        barrier.wait(timeout=10)
+        token = creds.token_for(REPO)
+        with guard:
+            seen.append(token)
+
+    threads = [threading.Thread(target=push) for _ in range(workers)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=30)
+
+    assert len(seen) == workers
+    assert recorder.minted == 1, f"{workers} concurrent pushes cost {recorder.minted} exchanges"
+    assert set(seen) == {"ghs_minted_1"}, "every caller must get the one minted token"
+
+
+def test_two_repositories_do_not_serialize_on_one_lock(private_key, monkeypatch) -> None:
+    """One slow repository must not stall a mint for a different repository.
+
+    A single global lock also passes the single-flight test above, at the cost
+    of holding it across the HTTP call: one slow repo would then stall every
+    other push. Asserting only that `_mint_lock_for` hands back distinct objects
+    does not catch that -- per-repo lock objects plus a separate global lock
+    around `token_for` would pass while serializing every repository. So this
+    overlaps two real mints and asserts the second one finished while the first
+    was still in flight.
+    """
+
+    other = "octo/other-bot"
+    recorder = Recorder()
+    inner = recorder.handle
+    slow_mint_started = threading.Event()
+    release_slow_mint = threading.Event()
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        import json
+
+        body = json.loads(request.content) if request.content else None
+        blocks = request.url.path.endswith("/access_tokens") and (
+            isinstance(body, dict) and body.get("repositories") == ["agent-bot"]
+        )
+        if blocks:
+            slow_mint_started.set()
+            # Bounded, and released by the main thread below: a regression has to
+            # FAIL on the assertions, never hang the suite waiting for a deadlock.
+            release_slow_mint.wait(timeout=30)
+        return inner(request)
+
+    monkeypatch.setattr("curie_api.github_app.httpx.Client", serve(handle))
+    creds = GitHubCredentials(settings=app_settings(private_key))
+
+    fast_finished = threading.Event()
+
+    def fast_push() -> None:
+        creds.token_for(other)
+        fast_finished.set()
+
+    slow = threading.Thread(target=creds.token_for, args=(REPO,))
+    fast = threading.Thread(target=fast_push)
+    overtook = False
+    slow_still_in_flight = False
+    slow.start()
+    try:
+        reached_mint = slow_mint_started.wait(timeout=10)
+        if reached_mint:
+            fast.start()
+            overtook = fast_finished.wait(timeout=10)
+            slow_still_in_flight = slow.is_alive()
+    finally:
+        release_slow_mint.set()
+        slow.join(timeout=30)
+        if fast.ident is not None:
+            fast.join(timeout=30)
+
+    assert reached_mint, "the slow repository never reached its own mint"
+    assert overtook, f"{other} serialized behind {REPO}'s in-flight mint"
+    assert slow_still_in_flight, "the slow mint had already finished; the overlap proved nothing"
+    assert creds._mint_lock_for(REPO) is not creds._mint_lock_for(other)
+    assert creds._mint_lock_for(REPO) is creds._mint_lock_for(REPO)
+
+
+# --------------------------------------------------------------------------- #
+# Expiry timezone -- latent, but the fallout is a seven-hour outage
+# --------------------------------------------------------------------------- #
+def test_a_naive_expiry_is_read_as_utc() -> None:
+    """An expiry without `Z` must not be read in the container's local zone.
+
+    `.timestamp()` on a naive datetime applies local time: under
+    TZ=America/Los_Angeles a 3600s token caches as 28800s and every clone 401s
+    for about seven hours, with the log saying "authentication". Asserting the
+    naive and `Z` forms agree keeps this independent of the machine's own TZ.
+    """
+
+    naive = GitHubCredentials._expiry_seconds("2026-01-01T00:00:00")
+    zulu = GitHubCredentials._expiry_seconds("2026-01-01T00:00:00Z")
+    assert naive == zulu
+
+
+def test_an_explicit_offset_expiry_is_still_honoured() -> None:
+    # The UTC default must apply only when the value carries no zone at all.
+    offset = GitHubCredentials._expiry_seconds("2026-01-01T00:00:00+02:00")
+    assert offset == GitHubCredentials._expiry_seconds("2025-12-31T22:00:00Z")


### PR DESCRIPTION
Closes #1257

The installation id was cached with no invalidation while the token cache expired normally, so reinstalling the GitHub App broke every clone until the API restarted — and the 404 told the operator to install an App they had just installed.

## What changed

- **Evict and re-resolve once** on a 404 from `/access_tokens`, and only when the id came from the cache. A freshly discovered id that 404s surfaces immediately rather than repeating discovery.
- **Three distinct 404 messages.** Discovery keeps "the App is not installed on that repository". A mint failure on a freshly resolved id says the App *is* registered and points at that installation's repository access. A mint failure after eviction says the cached installation was stale and has been re-discovered. None repeats the install advice to someone who already installed it.
- **Single-flight the mint** behind a per-repository lock with a re-read of the cache. The dict guard is never held across the HTTP call, so one slow repo cannot stall another.
- **Read a timezone-less expiry as UTC**, instead of letting `.timestamp()` apply the container's local zone.

## Scope note

The first two bullets are ACs 1–3. The last two are the "Related, smaller, same module" defects the issue body documents with reproduction evidence; they are fixed here deliberately rather than left behind in the same module. Everything else in the diff is test support for those four behaviours.

## Done-check

- [x] **Tests present and green** — 37 in `test_github_app.py`, up from 28.
- [x] **Red-on-revert (AC2)** — deleting only `self._installations.pop(...)` turns 3 tests red; restored, 37 pass. This did **not** hold in the first implementation (the eviction was decorative because re-discovery overwrote the cache unconditionally); the retry now re-resolves through the cache-first path so the eviction is load-bearing.
- [x] **Adversarial code review** — agent-router → Codex `gpt-5.6-sol`. Two P1s and one P2, all fixed: the decorative eviction above, the stale-message wording being false on the fresh-discovery path, and a lock test that asserted lock identity rather than non-serialization.
- [x] **Adversarial scope review** — agent-router → Codex `gpt-5.6-sol`. Three P3 passengers; two removed (an unread `status_code` attribute, unread request recording in the test mock). The recovery `logger.info` was kept deliberately: this module already emits operator-facing log lines and a positive signal that recovery happened is the point of the issue.
- [x] **Lint/type** — `ruff check .`, `ruff format --check` on both files, `mypy` (191 source files), `lint-imports` (4 contracts kept) all clean.
- [x] **Repo gates** — `uv lock --check`, alembic revision gate (head 0027), `check-docs.sh`, `check-wire-tolerance.sh`, ACI wire-lock base gate, commit-message gate all pass.
- [x] **Broadened return type** — `_installation_id` went `int` → `tuple[int, bool]`. Private, one call site, which destructures it. No public signature changed.
- [x] **Guard demonstration** — the eviction/retry guard was executed against a mock that 404s the retired id, not read.
- [ ] **Sibling-path parity** — N/A, no tier/lane/verb/profile seam touched.
- [ ] **Consolidation pass** — N/A, quick tier.
- [ ] **Deployed E2E** — N/A. AC1 specifies mock-driven verification, and the change is pure in-process cache logic.

## Full suite

`uv run pytest -q` ran to completion: **3597 passed, 1 failed, 11 skipped**. The one failure is `test_control_unit.py::test_valkey_dsn_honors_the_password_override`, a pure unit test asserting the literal default DSN `redis://:s3cret@localhost:26379/0`.

It is an artifact of the test harness, not this change. Every canonical dev-stack port on the build box was occupied by other concurrent jobs, so the stack was brought up on a remapped port block and `VALKEY_PORT=31502` was exported; that test observes the env var. Demonstrated both ways:

```
env -u VALKEY_PORT ... test_valkey_dsn_honors_the_password_override  ->  1 passed
VALKEY_PORT=31502  ... test_valkey_dsn_honors_the_password_override  ->  1 failed
```

Every test in the suite has therefore been observed passing under CI-equivalent semantics. Nothing was skipped, weakened, or deselected.
