### PR TITLE
Gate Langfuse startup on ClickHouse being reachable

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -181,6 +181,17 @@ jobs:
           set -euo pipefail
           bash charts/curie/ci/otel-collector-langfuse-secret-assertions.sh
 
+      # Prove Langfuse startup is gated on ClickHouse being up (issue #2009). A
+      # Helm upgrade that recreates the ClickHouse Service otherwise lets the new
+      # Langfuse pods start their migrations against an unresolvable name, so the
+      # rollout converges only through CrashLoopBackOff. This one EXECUTES the
+      # rendered init-container script against a stub ClickHouse that is down and
+      # then comes up, so it fails on a gate that merely renders without waiting.
+      - name: helm render assertions (langfuse clickhouse readiness gate)
+        run: |
+          set -euo pipefail
+          bash charts/curie/ci/langfuse-clickhouse-readiness-assertions.sh
+
       # Prove the Langfuse web+worker containers carry a numeric runAsUser
       # alongside runAsNonRoot (issue #351) so the kubelet can verify non-root
       # and the pods actually start on an enforcing cluster.

--- a/charts/curie/ci/langfuse-clickhouse-readiness-assertions.sh
+++ b/charts/curie/ci/langfuse-clickhouse-readiness-assertions.sh
@@ -1,0 +1,295 @@
+#!/usr/bin/env bash
+#
+# Regression test for issue #2009 (Langfuse web restarts during a Helm upgrade
+# while the ClickHouse Service is unavailable).
+#
+# Observed on a live in-place `next` upgrade: the Helm revision completed, but
+# the new Langfuse web pod restarted three times because it began its ClickHouse
+# migrations before the recreated chart-owned ClickHouse Service was resolvable:
+#
+#   failed to open database: dial tcp: lookup curie-clickhouse on 10.43.0.10:53: no such host
+#
+# Kubernetes reported BackOff and the release converged only through
+# CrashLoopBackOff retries. The fix is the `wait-for-clickhouse` init container
+# both Langfuse deployments now render (helper `curie.langfuse.clickhouseGate`),
+# which polls ClickHouse's HTTP `/ping` until it answers 200 -- so the
+# application container is not started at all until the dependency is up.
+#
+# This is deliberately NOT a render-shape-only test. A rendered init container
+# proves nothing about whether the gate actually waits, so the behavioural
+# assertions EXTRACT the rendered shell script and RUN it against a stub that
+# reproduces the delayed dependency:
+#
+#   1. Delayed ClickHouse: the endpoint is closed when the gate starts and only
+#      opens several seconds later. The gate must WAIT and then exit 0 in a
+#      single invocation -- the zero-restart property the issue asks for.
+#   2. Never-ready ClickHouse: the endpoint never opens. The gate must exit
+#      NON-ZERO after its bounded attempts. Without this, assertion 1 would pass
+#      for a gate that returns success unconditionally.
+#   3. Reachable but refusing: the endpoint answers 503. The gate must still not
+#      pass, proving it checks that ClickHouse is *accepting* queries rather
+#      than only that the name resolves.
+#   4. Slow but healthy: the endpoint takes 3s to answer 200. The gate must pass
+#      once `clickhouseReadiness.timeoutSeconds` allows for it and fail while it
+#      does not -- the per-request timeout is a probe setting, so it lives in
+#      values rather than the template (charts/curie/CLAUDE.md's probe-settings
+#      invariant) and this proves the value is actually honoured.
+#
+# Plus render assertions that the gate is wired into BOTH Langfuse deployments
+# (web and worker are the same boot path -- the sibling of the reported one),
+# probes the same endpoint the application is configured with, carries the same
+# securityContext as its application container (the #351 named-image-user class
+# applies to init containers too), and is operator-disableable.
+#
+# Runnable locally (from anywhere) and from CI. Fails loudly.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+TMP="$(mktemp -d)"
+cleanup() {
+  [[ -n "${STUB_PID:-}" ]] && kill "$STUB_PID" 2>/dev/null || true
+  rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+command -v node >/dev/null 2>&1 || fail "node is required: the rendered gate probes ClickHouse with the Langfuse images' own node runtime, and these assertions execute that rendered script"
+
+DEFAULT="$TMP/default.yaml"
+PATIENT="$TMP/patient.yaml"
+FAST="$TMP/fast.yaml"
+TOLERANT="$TMP/tolerant.yaml"
+DISABLED="$TMP/disabled.yaml"
+
+echo "=== Rendering templates/langfuse.yaml (defaults) ==="
+helm template rel "$CHART" --show-only templates/langfuse.yaml > "$DEFAULT"
+
+echo "=== Rendering templates/langfuse.yaml (1s polls, room to wait) ==="
+helm template rel "$CHART" --show-only templates/langfuse.yaml \
+  --set langfuse.clickhouseReadiness.maxAttempts=30 \
+  --set langfuse.clickhouseReadiness.intervalSeconds=1 > "$PATIENT"
+
+echo "=== Rendering templates/langfuse.yaml (short readiness bounds) ==="
+helm template rel "$CHART" --show-only templates/langfuse.yaml \
+  --set langfuse.clickhouseReadiness.maxAttempts=3 \
+  --set langfuse.clickhouseReadiness.intervalSeconds=1 > "$FAST"
+
+echo "=== Rendering templates/langfuse.yaml (short bounds, generous probe timeout) ==="
+helm template rel "$CHART" --show-only templates/langfuse.yaml \
+  --set langfuse.clickhouseReadiness.maxAttempts=3 \
+  --set langfuse.clickhouseReadiness.intervalSeconds=1 \
+  --set langfuse.clickhouseReadiness.timeoutSeconds=10 > "$TOLERANT"
+
+echo "=== Rendering templates/langfuse.yaml (gate disabled) ==="
+helm template rel "$CHART" --show-only templates/langfuse.yaml \
+  --set langfuse.clickhouseReadiness.enabled=false > "$DISABLED"
+
+# ---------------------------------------------------------------- render shape
+
+cat > "$TMP/shape.py" <<'PY'
+import sys, yaml
+
+path, disabled_path = sys.argv[1], sys.argv[2]
+
+
+def deployments(path):
+    out = {}
+    for doc in yaml.safe_load_all(open(path)):
+        if doc and doc.get("kind") == "Deployment":
+            out[doc["metadata"]["name"]] = doc
+    return out
+
+
+def podspec(dep):
+    return dep["spec"]["template"]["spec"]
+
+
+def env_of(container, name):
+    for entry in container.get("env") or []:
+        if entry.get("name") == name:
+            return entry.get("value")
+    return None
+
+
+rendered = deployments(path)
+for suffix, app_name in (("-langfuse-web", "langfuse-web"), ("-langfuse-worker", "langfuse-worker")):
+    dep = next((d for n, d in rendered.items() if n.endswith(suffix)), None)
+    if dep is None:
+        raise SystemExit(f"no Deployment ending in {suffix!r} rendered")
+    spec = podspec(dep)
+    inits = spec.get("initContainers") or []
+    gate = next((c for c in inits if c.get("name") == "wait-for-clickhouse"), None)
+    if gate is None:
+        raise SystemExit(
+            f"{suffix}: no 'wait-for-clickhouse' init container -- the application "
+            f"container can start before ClickHouse resolves, which is the #2009 regression "
+            f"(got initContainers {[c.get('name') for c in inits]})"
+        )
+
+    app = next((c for c in spec["containers"] if c.get("name") == app_name), None)
+    if app is None:
+        raise SystemExit(f"{suffix}: no {app_name!r} application container rendered")
+    if app_name in {c.get("name") for c in inits}:
+        raise SystemExit(f"{suffix}: the application container must not be an init container")
+
+    # The gate must probe exactly the endpoint the application is configured to
+    # use, or it gates on the wrong host and the bug survives.
+    gate_url = env_of(gate, "CLICKHOUSE_URL")
+    app_url = env_of(app, "CLICKHOUSE_URL")
+    if not gate_url:
+        raise SystemExit(f"{suffix}: gate has no CLICKHOUSE_URL env")
+    if gate_url != app_url:
+        raise SystemExit(
+            f"{suffix}: gate probes {gate_url!r} but the application connects to {app_url!r}"
+        )
+
+    # #351 class: a named image user plus runAsNonRoot is CreateContainerConfigError.
+    if (gate.get("securityContext") or {}) != (app.get("securityContext") or {}):
+        raise SystemExit(
+            f"{suffix}: gate securityContext {gate.get('securityContext')!r} does not match the "
+            f"application container's {app.get('securityContext')!r}; the init container is subject "
+            f"to the same numeric-runAsUser requirement (#351)"
+        )
+
+    print(f"  ok: {suffix.lstrip('-')} gates on wait-for-clickhouse probing {gate_url}")
+
+for name, dep in deployments(disabled_path).items():
+    for container in podspec(dep).get("initContainers") or []:
+        if container.get("name") == "wait-for-clickhouse":
+            raise SystemExit(f"{name}: gate still rendered with clickhouseReadiness.enabled=false")
+print("  ok: clickhouseReadiness.enabled=false removes the gate from both deployments")
+PY
+
+echo "=== Assertion 1: both Langfuse deployments render the ClickHouse gate ==="
+if ! out="$(python3 "$TMP/shape.py" "$DEFAULT" "$DISABLED" 2>&1)"; then
+  fail "$out"
+fi
+echo "$out"
+
+# ------------------------------------------------------------------ behaviour
+
+# Extract the rendered gate script so the assertions below execute exactly what
+# the chart ships, not a paraphrase of it.
+cat > "$TMP/extract.py" <<'PY'
+import sys, yaml
+
+for doc in yaml.safe_load_all(open(sys.argv[1])):
+    if doc and doc.get("kind") == "Deployment" and doc["metadata"]["name"].endswith("-langfuse-web"):
+        for container in doc["spec"]["template"]["spec"].get("initContainers") or []:
+            if container["name"] == "wait-for-clickhouse":
+                sys.stdout.write(container["args"][0])
+                raise SystemExit(0)
+raise SystemExit("could not extract the wait-for-clickhouse script from the rendered web Deployment")
+PY
+
+python3 "$TMP/extract.py" "$PATIENT" > "$TMP/gate-patient.sh"
+python3 "$TMP/extract.py" "$FAST" > "$TMP/gate-fast.sh"
+python3 "$TMP/extract.py" "$TOLERANT" > "$TMP/gate-tolerant.sh"
+[[ -s "$TMP/gate-patient.sh" && -s "$TMP/gate-fast.sh" && -s "$TMP/gate-tolerant.sh" ]] || fail "an extracted gate script is empty"
+
+# A free port that nothing is listening on: the delayed/absent ClickHouse.
+PORT="$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')"
+
+# Stub ClickHouse. $1 = seconds to stay down before binding, $2 = /ping status,
+# $3 = port, $4 = seconds each /ping response is held back (slow but healthy).
+cat > "$TMP/stub.py" <<'PY'
+import sys, time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+delay, status, port = float(sys.argv[1]), int(sys.argv[2]), int(sys.argv[3])
+response_delay = float(sys.argv[4]) if len(sys.argv) > 4 else 0.0
+
+
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.0"
+
+    def do_GET(self):
+        time.sleep(response_delay)
+        self.send_response(status)
+        self.send_header("Content-Length", "4")
+        self.end_headers()
+        self.wfile.write(b"Ok.\n")
+
+    def log_message(self, *args):
+        pass
+
+    # A probe that times out hangs up mid-response; that is the behaviour under
+    # test, not a stub failure, so it must not print a traceback.
+    def handle_one_request(self):
+        try:
+            super().handle_one_request()
+        except (BrokenPipeError, ConnectionResetError):
+            self.close_connection = True
+
+
+time.sleep(delay)
+HTTPServer(("127.0.0.1", port), Handler).serve_forever()
+PY
+
+run_gate() {  # run_gate <gate-script> <outfile>; returns the gate's exit status
+  set +e
+  CLICKHOUSE_URL="http://127.0.0.1:$PORT" sh "$1" > "$2" 2>&1
+  local status=$?
+  set -e
+  return $status
+}
+
+echo
+echo "=== Assertion 2: a DELAYED ClickHouse is waited for, not crash-looped ==="
+python3 "$TMP/stub.py" 4 200 "$PORT" & STUB_PID=$!
+started="$(date +%s)"
+if ! run_gate "$TMP/gate-patient.sh" "$TMP/delayed.log"; then
+  echo "--- gate output ---"; cat "$TMP/delayed.log"
+  fail "the gate exited non-zero against a ClickHouse that came up after 4s; a routine upgrade would still CrashLoopBackOff (#2009)"
+fi
+elapsed=$(( $(date +%s) - started ))
+kill "$STUB_PID" 2>/dev/null || true; wait "$STUB_PID" 2>/dev/null || true; STUB_PID=""
+grep -q "Waiting for ClickHouse readiness" "$TMP/delayed.log" \
+  || fail "the gate did not report waiting; it cannot have observed the dependency being down (output: $(cat "$TMP/delayed.log"))"
+grep -q "exiting for init container restart" "$TMP/delayed.log" \
+  && fail "the gate gave up and asked for a restart instead of waiting out a 4s ClickHouse delay"
+(( elapsed >= 3 )) \
+  || fail "the gate returned after ${elapsed}s against a ClickHouse that was down for 4s -- it cannot have probed the real endpoint"
+echo "  ok: gate waited ${elapsed}s for the delayed dependency, then exited 0 in a single run (zero restarts)"
+
+echo
+echo "=== Assertion 3: a ClickHouse that never comes up fails the gate (bounded) ==="
+if run_gate "$TMP/gate-fast.sh" "$TMP/absent.log"; then
+  echo "--- gate output ---"; cat "$TMP/absent.log"
+  fail "the gate exited 0 with NOTHING listening -- it passes vacuously, so assertion 2 proves nothing"
+fi
+grep -q "ClickHouse unreachable at" "$TMP/absent.log" \
+  || fail "the gate failed without naming the unreachable endpoint (output: $(cat "$TMP/absent.log"))"
+echo "  ok: gate exits non-zero after its bounded attempts and names the endpoint"
+
+echo
+echo "=== Assertion 4: reachable but not serving (HTTP 503) does not open the gate ==="
+python3 "$TMP/stub.py" 0 503 "$PORT" & STUB_PID=$!
+sleep 1
+if run_gate "$TMP/gate-fast.sh" "$TMP/refusing.log"; then
+  echo "--- gate output ---"; cat "$TMP/refusing.log"
+  fail "the gate passed against a ClickHouse answering 503; it gates on name resolution only, not on ClickHouse accepting queries"
+fi
+kill "$STUB_PID" 2>/dev/null || true; wait "$STUB_PID" 2>/dev/null || true; STUB_PID=""
+echo "  ok: a non-200 /ping keeps the gate closed"
+
+echo
+echo "=== Assertion 5: the probe timeout is a values knob, and it is honoured ==="
+python3 "$TMP/stub.py" 0 200 "$PORT" 3 & STUB_PID=$!
+sleep 1
+if run_gate "$TMP/gate-fast.sh" "$TMP/slow-strict.log"; then
+  echo "--- gate output ---"; cat "$TMP/slow-strict.log"
+  fail "the gate passed against a /ping taking 3s while timeoutSeconds was 2 -- the rendered per-request timeout is not being applied"
+fi
+if ! run_gate "$TMP/gate-tolerant.sh" "$TMP/slow-tolerant.log"; then
+  echo "--- gate output ---"; cat "$TMP/slow-tolerant.log"
+  fail "the gate still failed against a healthy 3s /ping with timeoutSeconds=10; the operator knob does not widen the probe, so a slow BYO ClickHouse can never open the gate"
+fi
+kill "$STUB_PID" 2>/dev/null || true; wait "$STUB_PID" 2>/dev/null || true; STUB_PID=""
+echo "  ok: a 3s /ping fails at timeoutSeconds=2 and passes at timeoutSeconds=10"
+
+echo
+echo "PASS: both Langfuse deployments gate startup on ClickHouse's HTTP /ping; the rendered gate waits out a delayed dependency and exits 0 once, fails bounded when ClickHouse never appears, and stays closed while ClickHouse answers non-200, and honours the operator's probe timeout (issue #2009)."

--- a/charts/curie/templates/_helpers.tpl
+++ b/charts/curie/templates/_helpers.tpl
@@ -1103,3 +1103,72 @@ securityContext:
 {{- fail (printf "worker.terminationGracePeriodSeconds (%d) must be at least worker.deliveryBudgetSeconds (%d) + worker.deliveryShutdownReserveSeconds (%d) = %d (ADR-0131). At %d a worker draining a full-budget delivery is SIGKILLed before it can settle, and the worker refuses this configuration at boot, so the Pod CrashLoopBackOffs instead of starting. Fix: raise worker.terminationGracePeriodSeconds to %d or more, or lower worker.deliveryBudgetSeconds and/or worker.deliveryShutdownReserveSeconds so their sum is at most %d." $grace $budget $reserve $required $grace $required $grace) -}}
 {{- end -}}
 {{- end -}}
+
+{{/* ---- Langfuse ClickHouse startup gate (issue #2009) ----
+     Both Langfuse deployments run their ClickHouse migrations during boot, so a
+     Helm upgrade that recreates the ClickHouse Service can start them before the
+     name resolves; Langfuse then exits with `failed to open database: dial tcp:
+     lookup <release>-clickhouse ... no such host` and the rollout converges only
+     through CrashLoopBackOff. This init container polls ClickHouse's HTTP
+     `/ping` until it answers 200, so the application container is not started
+     until the dependency is actually accepting connections -- the same
+     wait-then-hand-over shape `templates/api.yaml` uses for Postgres.
+
+     `node` is the Langfuse images' own runtime, so the probe needs no extra
+     tooling in the image. Bounded like the Postgres gate: after `maxAttempts`
+     polls the container exits non-zero and the kubelet restarts it, which keeps
+     a genuinely-down ClickHouse visible instead of hanging forever. Every probe
+     setting (attempts, interval, per-request timeout) comes from values rather
+     than the template, per the chart's probe-settings invariant -- a BYO
+     ClickHouse that answers slowly needs a longer timeout, not a patched chart.
+
+     Call with a dict: `root` (the chart context), `image` (the component's
+     image repository), `containerSecurityContext` and `resources` (the
+     component's, so the gate inherits the same posture and the pod's effective
+     request is unchanged -- init and app container requests are maxed, not
+     summed). */}}
+{{- define "curie.langfuse.clickhouseGate" -}}
+{{- $root := .root -}}
+- name: wait-for-clickhouse
+  image: "{{ .image }}:{{ $root.Values.langfuse.image.tag }}"
+  imagePullPolicy: {{ $root.Values.global.imagePullPolicy }}
+  {{- with .containerSecurityContext }}
+  securityContext:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  command: ["/bin/sh", "-c"]
+  args:
+    - |
+      attempt=1
+      max_attempts={{ $root.Values.langfuse.clickhouseReadiness.maxAttempts }}
+      interval={{ $root.Values.langfuse.clickhouseReadiness.intervalSeconds }}
+      probe_timeout_ms={{ mulf $root.Values.langfuse.clickhouseReadiness.timeoutSeconds 1000 | int }}
+      while [ "$attempt" -le "$max_attempts" ]; do
+        if PROBE_TIMEOUT_MS="$probe_timeout_ms" node -e '
+      const http = require("http");
+      const request = http.get(process.env.CLICKHOUSE_URL + "/ping", { timeout: Number(process.env.PROBE_TIMEOUT_MS) }, (response) => {
+        response.resume();
+        process.exit(response.statusCode === 200 ? 0 : 1);
+      });
+      request.on("timeout", () => { request.destroy(); process.exit(1); });
+      request.on("error", () => { process.exit(1); });
+      ' 2>/dev/null; then
+          echo "ClickHouse ready after $attempt attempt(s); starting Langfuse"
+          exit 0
+        fi
+        if [ "$attempt" -eq 1 ]; then
+          echo "Waiting for ClickHouse readiness at $CLICKHOUSE_URL"
+        fi
+        if [ "$attempt" -lt "$max_attempts" ]; then
+          sleep "$interval"
+        fi
+        attempt=$((attempt + 1))
+      done
+      echo "ClickHouse unreachable at $CLICKHOUSE_URL after $max_attempts readiness attempts; exiting for init container restart" >&2
+      exit 1
+  env:
+    - name: CLICKHOUSE_URL
+      value: http://{{ include "curie.clickhouse.host" $root }}:{{ $root.Values.clickhouse.httpPort }}
+  resources:
+    {{- toYaml .resources | nindent 4 }}
+{{- end -}}

--- a/charts/curie/templates/langfuse.yaml
+++ b/charts/curie/templates/langfuse.yaml
@@ -44,6 +44,14 @@ spec:
       {{- with (include "curie.placement.spec" .Values.placement.platform) }}
       {{- . | nindent 6 }}
       {{- end }}
+      {{- if .Values.langfuse.clickhouseReadiness.enabled }}
+      initContainers:
+        {{- include "curie.langfuse.clickhouseGate" (dict
+             "root" .
+             "image" .Values.langfuse.image.web
+             "containerSecurityContext" .Values.langfuse.web.containerSecurityContext
+             "resources" .Values.langfuse.web.resources) | nindent 8 }}
+      {{- end }}
       containers:
         - name: langfuse-web
           image: "{{ .Values.langfuse.image.web }}:{{ .Values.langfuse.image.tag }}"
@@ -138,6 +146,14 @@ spec:
     spec:
       {{- with (include "curie.placement.spec" .Values.placement.platform) }}
       {{- . | nindent 6 }}
+      {{- end }}
+      {{- if .Values.langfuse.clickhouseReadiness.enabled }}
+      initContainers:
+        {{- include "curie.langfuse.clickhouseGate" (dict
+             "root" .
+             "image" .Values.langfuse.image.worker
+             "containerSecurityContext" .Values.langfuse.worker.containerSecurityContext
+             "resources" .Values.langfuse.worker.resources) | nindent 8 }}
       {{- end }}
       containers:
         - name: langfuse-worker

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -103,6 +103,25 @@ langfuse:
     tag: "3"
   telemetryEnabled: false
   enableExperimentalFeatures: true
+  # Startup gate on the ClickHouse endpoint Langfuse boots against (issue
+  # #2009). Both Langfuse deployments run their schema migrations at boot; when
+  # a Helm upgrade recreates the chart-owned ClickHouse Service, the new pods
+  # can start before that Service is resolvable and die with
+  # `failed to open database: dial tcp: lookup curie-clickhouse ... no such
+  # host`, converging only via CrashLoopBackOff retries. An init container polls
+  # ClickHouse's HTTP `/ping` until it answers, so the application container is
+  # not started at all until the dependency is up. Bounded on purpose: after
+  # `maxAttempts` polls the init container exits non-zero and Kubernetes
+  # restarts it, which is the same backstop `api.migrate` uses for Postgres.
+  # Attempt budget matches that gate (60 attempts, 2s apart); `timeoutSeconds`
+  # caps how long one `/ping` may hang, so the worst-case wait before a restart
+  # is maxAttempts x (timeoutSeconds + intervalSeconds). Raise it for a BYO
+  # ClickHouse that answers slowly rather than letting every attempt time out.
+  clickhouseReadiness:
+    enabled: true
+    maxAttempts: 60
+    intervalSeconds: 2
+    timeoutSeconds: 2
   # NEXTAUTH_URL the browser reaches the web UI at. Override for a real ingress.
   nextauthUrl: http://localhost:23000
   # Dev-only secret material. Override in prod or set `existingSecret` to a


### PR DESCRIPTION
A routine in-place `helm upgrade` recreates the chart-owned ClickHouse Service, and the new Langfuse pods start their boot-time ClickHouse migrations before that name resolves. On the live soak upgrade to `next@ae5d57b1` the Langfuse web pod restarted three times with `failed to open database: dial tcp: lookup curie-clickhouse on 10.43.0.10:53: no such host`, and the release converged only through CrashLoopBackOff retries.

## The change

Both Langfuse deployments render a `wait-for-clickhouse` init container that polls ClickHouse's HTTP `/ping` until it answers 200, so the application container is not started until the dependency is accepting queries. It reuses the wait-then-hand-over shape `templates/api.yaml` already uses for Postgres, including the bounded attempt budget whose exhaustion hands the decision back to the kubelet rather than hanging forever.

- The probe runs on `node`, the Langfuse images' own runtime, so it needs nothing extra in the image.
- The gate inherits its component's `securityContext` (the #351 numeric-`runAsUser` class applies to init containers too) and `resources` (init and app requests are maxed, not summed, so the pod's effective request is unchanged).
- Every probe setting -- `maxAttempts`, `intervalSeconds`, `timeoutSeconds` -- lives in `langfuse.clickhouseReadiness` rather than the template, per the chart's probe-settings invariant. Worst-case wait before a restart is `maxAttempts x (timeoutSeconds + intervalSeconds)`; `enabled: false` turns the gate off.
- The new keys stay out of `values.schema.json`, per that file's deliberately-permissive policy in `charts/curie/CLAUDE.md`.

## The regression

`ci/langfuse-clickhouse-readiness-assertions.sh` is not a render-shape check. It extracts the rendered init-container script and **runs** it against a stub ClickHouse that is down and then comes up, asserting the gate waits and exits 0 in a single invocation -- the zero-restart property the issue asks for. Three negative controls stop it passing vacuously:

| Scenario | Required behaviour |
|---|---|
| ClickHouse comes up after 4s | gate waits, exits 0 once |
| ClickHouse never comes up | gate exits non-zero, bounded, naming the endpoint |
| ClickHouse answers 503 | gate stays closed (resolution alone is not readiness) |
| Healthy `/ping` takes 3s | fails at `timeoutSeconds: 2`, passes at 10 |

Reverting only the template wiring makes the script fail on assertion 1, so it is a live regression rather than a restatement of the diff.

## Verification

- All 29 `charts/curie/ci/*-assertions.sh` scripts pass, including the new one.
- `helm lint` (default + `values-dev`) and `helm template` + `kubeconform -strict` across the default, `values-dev`, and e2e-nogvisor overlays: clean.
- Executed the rendered gate inside the real `langfuse/langfuse:3` and `langfuse/langfuse-worker:3` images as uid 1001 (`/bin/sh` and `node` both present, bounded failure observed).
- End-to-end against a real `clickhouse-server:24.8` on a Docker network, started 8s **after** the gate so the name genuinely did not resolve: the gate waited through the lookup failure and handed over after 12s in one run, zero restarts.

No cluster or external state was changed.

Closes #2009