### PR TITLE
Rank connector reconcile targets before filtering on the bundle

### DIFF
--- a/apps/worker/src/curie_worker/binding.py
+++ b/apps/worker/src/curie_worker/binding.py
@@ -195,6 +195,15 @@ def _parse_resume_event_id(event_id: str) -> uuid.UUID | None:
     except ValueError:
         return None
 
+# The trailing `d.id DESC` carries no meaning of its own -- id order is not a
+# precedence rule and nothing may start reading one into it. It exists only to
+# make the order TOTAL: two active deployments in the same environment with an
+# identical `deployed_at` leave the first two keys tied, and an undefined tie
+# lets this query and connector_loop.py's _TARGETS_SQL -- different joins,
+# different plans -- pick different winners for the same agent. Since #1216 that
+# disagreement costs a DESTRUCTIVE prune (the reconciler removes the connector
+# objects of the version the sandbox is actually booting), not merely a stale
+# apply, so the key is duplicated verbatim in both statements.
 _RESOLVE_SQL = """
 SELECT a.id AS agent_id,
        a.name AS agent_name,
@@ -216,7 +225,7 @@ JOIN {schema}.agent_channels c ON c.agent_id = a.id
 JOIN {schema}.deployments d ON d.agent_id = a.id AND d.status = 'active'
 JOIN {schema}.agent_versions v ON v.id = d.version_id AND v.agent_id = a.id
 WHERE c.kind = :kind AND c.address = :address
-ORDER BY (d.environment = 'prod') DESC, d.deployed_at DESC
+ORDER BY (d.environment = 'prod') DESC, d.deployed_at DESC, d.id DESC
 """
 
 

--- a/apps/worker/src/curie_worker/connector_agent.py
+++ b/apps/worker/src/curie_worker/connector_agent.py
@@ -43,6 +43,13 @@ Connectors using the reference form (`secrets: [{from_secret: ...}]`, #1163)
 have no owned keys at all, so they reconcile with no exception. That is the
 path ADR-0090 calls the prerequisite, and it is why this restriction shrinks as
 bundles adopt it rather than being permanent.
+
+`prune_agent` is the same reasoning reached from the other direction (#1216).
+When the in-force version has no stored bundle there is no render at all -- not
+an empty one, an absent one -- so nothing this agent owns can be declared, and
+the same no-Secret-of-any-name exclusion applies for the same reason: without a
+render we do not know which Secret name is ours, and the one live there is the
+operator's real, unrecoverable credential.
 """
 
 from __future__ import annotations
@@ -113,6 +120,35 @@ def own(obj: dict[str, Any], agent: str) -> dict[str, Any]:
     metadata["labels"] = {**(metadata.get("labels") or {}), OWNER_LABEL: agent}
     stamped["metadata"] = metadata
     return stamped
+
+
+def _execute_and_report(
+    client: ConnectorClient,
+    carried: ReconcilePlan,
+    *,
+    agent: str,
+    namespace: str,
+    skipped: str | None = None,
+) -> AgentOutcome:
+    """Run a decided plan and turn it into an outcome.
+
+    Exists so the failure-log format lives in exactly one place: every caller
+    here deletes, so every caller can fail deletes, and a finalizer or an RBAC
+    gap recurs every pass. Returning straight off `execute()` left the object
+    name and the error in no log stream at all -- `connector_apply` does not log
+    delete failures either. It deliberately does NOT own the `is_noop` fast
+    path: the two callers disagree on what a no-op returns (see each).
+    """
+
+    report = execute(client, carried, namespace=namespace, agent=agent)
+    if not report.ok:
+        logger.warning(
+            "connector reconcile agent=%s had %d failure(s): %s",
+            agent,
+            len(report.failures),
+            "; ".join(f"{kind}/{name}: {err}" for kind, name, err in report.failures),
+        )
+    return AgentOutcome(agent=agent, skipped=skipped, plan=carried, report=report)
 
 
 def reconcile_agent(
@@ -197,16 +233,59 @@ def reconcile_agent(
     else:
         carried = computed
 
-    report = execute(client, carried, namespace=namespace, agent=agent)
-    # Shared with the skip branch on purpose: that branch deletes, so it can fail
-    # deletes, and a finalizer or an RBAC gap there recurs every pass. Returning
-    # straight off `execute()` left the object name and the error in no log
-    # stream at all -- `connector_apply` does not log delete failures either.
-    if not report.ok:
-        logger.warning(
-            "connector reconcile agent=%s had %d failure(s): %s",
-            agent,
-            len(report.failures),
-            "; ".join(f"{kind}/{name}: {err}" for kind, name, err in report.failures),
-        )
-    return AgentOutcome(agent=agent, skipped=skipped, plan=carried, report=report)
+    return _execute_and_report(
+        client, carried, agent=agent, namespace=namespace, skipped=skipped
+    )
+
+
+def prune_agent(
+    client: ConnectorClient,
+    *,
+    agent: str,
+    namespace: str,
+) -> AgentOutcome:
+    """Converge an agent whose in-force version declares nothing we can read.
+
+    Reached when the version the deployment points at has no stored bundle
+    (#1216). There is no render to ask for -- the API answers "no bundle stored
+    for this version" -- so the desired set is empty, and every object this
+    agent owns is by definition undeclared. Pruning them is the correct
+    convergence, not a fallback: the alternative the loop used to take was to
+    quietly reconcile a LOWER-precedence bundled version instead, which left the
+    cluster serving connectors from a version no sandbox boots.
+
+    **No Secret of any name is manageable here**, exactly as on the
+    `unprovisioned` branch above and for the same reason. The owned Secret is
+    minted by `curie cluster deploy` from values the cluster deliberately does
+    not hold (ADR-0086); only a render names it, and there is no render on this
+    path. So an owner-labelled Secret alive here cannot be told apart from the
+    operator's live credential, and deleting it is unrecoverable and breaks
+    every connector pod on its next restart. Kind is the safe discriminator
+    here, and only here.
+
+    The outcome is `skipped` rather than a plain reconcile: the applies were not
+    merely unnecessary, they were suppressed by a condition an operator can fix
+    (push the bundle, or deploy a version that has one), so the pass summary
+    must say so instead of reporting a quiet prune.
+    """
+
+    live = client.list_owned(namespace, agent)
+    manageable = [obj for obj in live if identity(obj)[0] != "Secret"]
+    computed = plan([], manageable, agent=agent)
+
+    # Named without the version id: the operator's action is the same either
+    # way, and `curie agent deploy` is what reports the version it stored.
+    reason = (
+        "the in-force version has no stored bundle, so no connectors can be "
+        "rendered for it; objects this agent still owns were pruned"
+    )
+    if computed.is_noop:
+        # Converged: nothing owned, nothing to remove. Returning an empty report
+        # rather than calling execute() keeps the steady state free of a
+        # cluster round-trip, matching reconcile_agent's no-op early return.
+        return AgentOutcome(agent=agent, skipped=reason, plan=computed, report=ApplyReport())
+
+    logger.warning("connector reconcile skipped agent=%s: %s", agent, reason)
+    return _execute_and_report(
+        client, computed, agent=agent, namespace=namespace, skipped=reason
+    )

--- a/apps/worker/src/curie_worker/connector_loop.py
+++ b/apps/worker/src/curie_worker/connector_loop.py
@@ -47,6 +47,7 @@ from .connector_agent import (
     AgentOutcome,
     ManifestSource,
     RenderedConnectors,
+    prune_agent,
     reconcile_agent,
 )
 from .connector_apply import ConnectorClient
@@ -57,21 +58,41 @@ _PLATFORM_5XX_GRACE_PASSES = 3
 
 
 # Every agent with an in-force deployment, and the version that deployment
-# points at. Mirrors binding.py's precedence so the connectors a thread gets
-# belong to the same version its sandbox boots: prod outranks dev, then most
-# recent. DISTINCT ON collapses an agent with both active to that one winner --
-# without it an agent would be reconciled twice per pass, the second undoing
-# the first.
+# points at. RANK FIRST, DECIDE SECOND: this must select the SAME winner
+# binding.py's _RESOLVE_SQL does -- prod outranks dev, then most recent
+# deployed_at -- because the connectors a thread gets have to belong to the
+# version its sandbox actually boots. DISTINCT ON collapses an agent with both
+# active to that one winner; without it an agent would be reconciled twice per
+# pass, the second undoing the first.
+#
+# The bundle is REPORTED (has_bundle), never filtered on (#1216). The predicate
+# used to read `WHERE v.bundle_ref IS NOT NULL`, which filtered before ranking:
+# when the true winner was a bundleless version, the row vanished and the
+# NEXT-ranked version -- a lower-precedence one the sandbox is not booting --
+# was silently promoted and its connector objects applied, with nothing to
+# converge them away. Filtering here can only ever disagree with binding; a
+# version we cannot render for is a fact about what this pass may DO, not about
+# which version is in force, so it is decided in _reconcile_one instead.
+#
+# The trailing `d.id DESC` carries no meaning of its own -- id order is not a
+# precedence rule and nothing may start reading one into it. It exists only to
+# make the order TOTAL: two active deployments in the same environment with an
+# identical `deployed_at` leave the first two keys tied, and an undefined tie
+# lets this query and binding.py's _RESOLVE_SQL -- different joins, different
+# plans -- pick different winners for the same agent. Since the prune path
+# above, that disagreement costs a DESTRUCTIVE prune (this loop deletes the
+# connector objects of the version the sandbox is actually booting), not merely
+# a stale apply, so the key is duplicated verbatim in both statements.
 _TARGETS_SQL = """
 SELECT DISTINCT ON (a.id)
        a.id AS agent_id,
        a.name AS agent_name,
-       v.id AS version_id
+       v.id AS version_id,
+       v.bundle_ref IS NOT NULL AS has_bundle
 FROM {schema}.agents a
 JOIN {schema}.deployments d ON d.agent_id = a.id AND d.status = 'active'
 JOIN {schema}.agent_versions v ON v.id = d.version_id AND v.agent_id = a.id
-WHERE v.bundle_ref IS NOT NULL
-ORDER BY a.id, (d.environment = 'prod') DESC, d.deployed_at DESC
+ORDER BY a.id, (d.environment = 'prod') DESC, d.deployed_at DESC, d.id DESC
 """
 
 
@@ -80,6 +101,12 @@ class AgentTarget:
     agent_id: uuid.UUID
     agent_name: str
     version_id: uuid.UUID
+    # Whether the in-force version has a stored bundle. False means the render
+    # endpoint has nothing to serve, so this agent gets the prune-only path
+    # rather than a reconcile (#1216). Defaults True so a caller constructing a
+    # target for the ordinary case says nothing about a condition that is the
+    # exception.
+    has_bundle: bool = True
 
 
 class HttpManifestSource:
@@ -170,11 +197,26 @@ class ConnectorReconcileLoop:
                 agent_id=row["agent_id"],
                 agent_name=row["agent_name"],
                 version_id=row["version_id"],
+                has_bundle=bool(row["has_bundle"]),
             )
             for row in rows
         ]
 
     def _reconcile_one(self, target: AgentTarget) -> AgentOutcome:
+        if not target.has_bundle:
+            # The in-force version has no stored bundle, so the render endpoint
+            # 404s for it and `raise_for_status()` would mark this agent failed
+            # every pass, forever, with no pass ever able to clear it. Falling
+            # back to a bundled runner-up is the #1216 bug itself. What is left
+            # is the honest reading: this version declares no connectors we can
+            # reach, so everything we own for the agent is undeclared and the
+            # prune-only path converges it -- minus the Secret, which we must
+            # not touch without a render to name it.
+            return prune_agent(
+                self._client,
+                agent=target.agent_name,
+                namespace=self._namespace,
+            )
         return reconcile_agent(
             self._source,
             self._client,

--- a/apps/worker/tests/reconcile/test_connector_loop.py
+++ b/apps/worker/tests/reconcile/test_connector_loop.py
@@ -459,3 +459,109 @@ def test_the_http_source_defaults_are_safe_when_the_api_omits_fields() -> None:
     rendered = RenderedConnectors()
     assert rendered.manifests == []
     assert not rendered.needs_operator_credentials
+
+
+# --------------------------------------------------------------------------- #
+# The in-force version has no bundle (#1216)
+# --------------------------------------------------------------------------- #
+# These exercise the REAL `_reconcile_one`, so only `targets()` is replaced.
+# The fake client and its manifest helper are the ones
+# `tests/reconcile/test_connector_agent.py` already established -- imported
+# rather than re-declared, so a second, subtly different notion of "what the
+# cluster returns" cannot drift away from the first.
+from .test_connector_agent import FakeClient, live_copy, manifest  # noqa: E402
+
+
+class ExplodingSource:
+    """A ManifestSource that must never be asked for anything.
+
+    The #1216 bug is invisible to a source that answers: the loop happily
+    rendered SOMETHING, just from the wrong version. Making the render itself
+    the failure is what turns "did not render" into an assertion.
+    """
+
+    def rendered(self, *, agent_id: str, version_id: str) -> Any:
+        raise AssertionError(
+            f"rendered a bundleless version: agent={agent_id} version={version_id}"
+        )
+
+
+class StubTargetsLoop(ConnectorReconcileLoop):
+    """The loop with only the database swapped out.
+
+    Unlike `Loop` above, `_reconcile_one` is the real one -- the branch under
+    test lives there, so faking it would test nothing.
+    """
+
+    def __init__(self, targets: list[AgentTarget], **kw: Any) -> None:
+        super().__init__(namespace="curie", db_schema="curie", **kw)
+        self._targets = targets
+
+    async def targets(self) -> list[AgentTarget]:  # type: ignore[override]
+        return list(self._targets)
+
+
+def bundleless(name: str) -> AgentTarget:
+    import uuid
+
+    return AgentTarget(
+        agent_id=uuid.uuid4(), agent_name=name, version_id=uuid.uuid4(), has_bundle=False
+    )
+
+
+async def test_a_bundleless_target_never_renders_and_prunes_what_it_owns() -> None:
+    # The render endpoint 404s for a version with no stored bundle, so asking
+    # would fail this agent every pass forever. The objects it owns belong to a
+    # declaration nothing can produce, so they are pruned instead.
+    agent = bundleless("a")
+    client = FakeClient(
+        [
+            live_copy(manifest("Service", "grafana"), agent="a"),
+            live_copy(manifest("Deployment", "grafana"), agent="a"),
+        ]
+    )
+    loop = StubTargetsLoop([agent], engine=None, source=ExplodingSource(), client=client)
+
+    summary = await loop.one_pass()
+
+    assert client.applied == [], "a bundleless version must not apply anything"
+    assert sorted(client.deleted) == [("Deployment", "grafana"), ("Service", "grafana")]
+    assert summary.skipped == 1
+    assert summary.deleted == 2
+    assert summary.failed == 0
+
+
+async def test_a_bundleless_target_never_deletes_an_owned_secret() -> None:
+    # Without a render we do not know which Secret name is ours, and the one
+    # live here is the operator's credential (ADR-0086) -- unrecoverable, and
+    # its removal breaks every connector pod on its next restart. So no Secret
+    # of any name is manageable on this path, exactly as on the unprovisioned
+    # branch.
+    agent = bundleless("a")
+    client = FakeClient(
+        [
+            live_copy(manifest("Service", "grafana"), agent="a"),
+            live_copy(manifest("Secret", "curie-a-connector-secrets"), agent="a"),
+        ]
+    )
+    loop = StubTargetsLoop([agent], engine=None, source=ExplodingSource(), client=client)
+
+    await loop.one_pass()
+
+    assert client.deleted == [("Service", "grafana")]
+    assert all(kind != "Secret" for kind, _ in client.deleted)
+
+
+async def test_a_converged_bundleless_target_touches_the_cluster_only_to_look() -> None:
+    # Nothing owned means nothing to remove. The steady state of an agent parked
+    # on a bundleless version must not re-issue deletes every minute.
+    agent = bundleless("a")
+    client = FakeClient([])
+    loop = StubTargetsLoop([agent], engine=None, source=ExplodingSource(), client=client)
+
+    summary = await loop.one_pass()
+
+    assert client.applied == []
+    assert client.deleted == []
+    assert summary.skipped == 1
+    assert summary.deleted == 0

--- a/apps/worker/tests/reconcile/test_connector_target_ranking.py
+++ b/apps/worker/tests/reconcile/test_connector_target_ranking.py
@@ -1,0 +1,458 @@
+"""Which version the connector reconciler picks, against the REAL Postgres (#1216).
+
+`connector_loop._TARGETS_SQL` and `binding._RESOLVE_SQL` must choose the SAME
+version for an agent: the connectors a thread gets have to belong to the version
+its sandbox actually boots. That agreement is a property of two SQL statements,
+so it is asserted against a real database rather than a fake -- a mock cannot
+disagree about `DISTINCT ON`, an enum comparison, or a NULL.
+
+The bug this file exists to pin: `_TARGETS_SQL` used to filter
+`WHERE v.bundle_ref IS NOT NULL` BEFORE ranking. When the true winner was a
+bundleless version its row vanished and the runner-up -- a version the sandbox
+never boots -- was silently promoted, its connector objects applied, and nothing
+ever converged them away. Rank first, decide second.
+
+Seeding follows `apps/worker/tests/binding/test_resolver.py`'s idiom (its
+`_seed_agent` / `_seed_deployment`, the per-test uuid token, the explicit
+cleanup). The helpers are local copies rather than an import: this file needs a
+NULL `bundle_ref` and an explicit `deployed_at`, neither of which the resolver
+test has any use for, and widening a shared helper for a second caller's edge
+case is how a fixture stops describing either.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+from curie_worker import binding, connector_loop
+from curie_worker.connector_agent import RenderedConnectors
+from curie_worker.connector_loop import ConnectorReconcileLoop
+from curie_worker.connector_reconcile import OWNER_LABEL
+from sqlalchemy import text
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+
+from .test_connector_agent import FakeClient, live_copy, manifest
+
+_DB_URL = os.environ.get(
+    "TEST_DATABASE_URL", "postgresql+asyncpg://postgres:postgres@localhost:25432/postgres"
+)
+_SCHEMA = os.environ.get("TEST_DB_SCHEMA", "curie")
+
+NS = "curie"
+
+
+async def _seed_agent(engine: AsyncEngine, *, name: str, address: str) -> uuid.UUID:
+    """One agent and its single channel binding (ADR-0096, #1459).
+
+    The binding is seeded even though `_TARGETS_SQL` does not join
+    `agent_channels`, because the pinning test drives `_RESOLVE_SQL` -- which
+    does -- over the same rows. Two agents seeded differently would not be
+    comparing the two queries at all.
+    """
+    agent_id = uuid.uuid4()
+    async with engine.begin() as conn:
+        await conn.execute(
+            text(f"INSERT INTO {_SCHEMA}.agents (id, name) VALUES (:id, :name)"),
+            {"id": agent_id, "name": name},
+        )
+        await conn.execute(
+            text(
+                f"INSERT INTO {_SCHEMA}.agent_channels (id, agent_id, kind, address) "
+                "VALUES (:id, :agent_id, 'slack', :address)"
+            ),
+            {"id": uuid.uuid4(), "agent_id": agent_id, "address": address},
+        )
+    return agent_id
+
+
+async def _seed_deployment(
+    engine: AsyncEngine,
+    *,
+    agent_id: uuid.UUID,
+    environment: str,
+    bundle_ref: str | None,
+    deployed_seconds_ago: int,
+) -> uuid.UUID:
+    """One version plus the active deployment pointing at it; returns the version id.
+
+    `bundle_ref` is nullable on purpose: a version created before its bundle is
+    stored is a state the real endpoints produce, and
+    `apps/api/tests/test_bundle_ingestion_bounds.py` pins that deploying it is
+    allowed. `deployed_seconds_ago` is explicit because the whole precedence
+    question is prod-versus-newer, which a `now()` default cannot express.
+    """
+    version_id = uuid.uuid4()
+    async with engine.begin() as conn:
+        await conn.execute(
+            text(
+                f"INSERT INTO {_SCHEMA}.agent_versions "
+                "(id, agent_id, version_label, bundle_ref, created_by) "
+                "VALUES (:id, :agent_id, :label, :ref, 'test')"
+            ),
+            {
+                "id": version_id,
+                "agent_id": agent_id,
+                "label": f"v-{environment}",
+                "ref": bundle_ref,
+            },
+        )
+        await conn.execute(
+            text(
+                f"INSERT INTO {_SCHEMA}.deployments "
+                "(id, agent_id, version_id, environment, status, deployed_at) "
+                f"VALUES (:id, :agent_id, :version_id, CAST(:env AS {_SCHEMA}.environment), "
+                # The timestamp is computed in Python: `now() - :param` leaves
+                # the parameter's type indeterminate, so Postgres infers
+                # timestamptz and the subtraction yields an interval.
+                "'active', :deployed_at)"
+            ),
+            {
+                "id": uuid.uuid4(),
+                "agent_id": agent_id,
+                "version_id": version_id,
+                "env": environment,
+                "deployed_at": datetime.now(UTC) - timedelta(seconds=deployed_seconds_ago),
+            },
+        )
+    return version_id
+
+
+async def _cleanup(engine: AsyncEngine, agent_ids: list[uuid.UUID]) -> None:
+    async with engine.begin() as conn:
+        for agent_id in agent_ids:
+            await conn.execute(
+                text(f"DELETE FROM {_SCHEMA}.agent_channels WHERE agent_id = :id"),
+                {"id": agent_id},
+            )
+            await conn.execute(
+                text(f"DELETE FROM {_SCHEMA}.agents WHERE id = :id"), {"id": agent_id}
+            )
+
+
+async def _engine_or_skip() -> AsyncEngine:
+    engine = create_async_engine(_DB_URL)
+    try:
+        async with engine.connect():
+            pass
+    except SQLAlchemyError as exc:
+        await engine.dispose()
+        pytest.skip(f"Postgres not reachable at {_DB_URL}: {exc}")
+    return engine
+
+
+class RefusesForAgent:
+    """A ManifestSource that refuses to render ANY version of one agent.
+
+    Keyed on the agent, not on the bundleless version: refusing only that one
+    version would let the #1216 bug through, because the bug does not render the
+    in-force version -- it renders the RUNNER-UP. A pass sweeps every agent in
+    the shared database, so the rest are answered with an empty render rather
+    than a raise.
+    """
+
+    def __init__(self, agent_id: uuid.UUID) -> None:
+        self._forbidden = str(agent_id)
+        self.rendered_versions: list[str] = []
+
+    def rendered(self, *, agent_id: str, version_id: str) -> RenderedConnectors:
+        self.rendered_versions.append(version_id)
+        if agent_id == self._forbidden:
+            raise AssertionError(
+                f"rendered version {version_id} for an agent whose in-force "
+                "version has no bundle; the render endpoint 404s and the "
+                "reconciler must not ask"
+            )
+        return RenderedConnectors()
+
+
+def test_the_prod_winner_is_reported_even_when_it_has_no_bundle() -> None:
+    """Rank first, decide second.
+
+    Prod is bundleless, dev is bundled and deployed LATER, so the two orderings
+    disagree and the seeding cannot accidentally pass. Reinstating
+    filter-then-rank returns the DEV version here and this goes red.
+    """
+
+    async def go() -> None:
+        engine = await _engine_or_skip()
+        try:
+            token = uuid.uuid4().hex[:8]
+            agent_id = await _seed_agent(
+                engine, name=f"rank-{token}", address=f"C-rank-{token}"
+            )
+            prod_version = await _seed_deployment(
+                engine,
+                agent_id=agent_id,
+                environment="prod",
+                bundle_ref=None,
+                deployed_seconds_ago=600,
+            )
+            dev_version = await _seed_deployment(
+                engine,
+                agent_id=agent_id,
+                environment="dev",
+                bundle_ref=f"bundles/{token}.zip",
+                deployed_seconds_ago=60,
+            )
+            try:
+                loop = ConnectorReconcileLoop(
+                    engine=engine,
+                    source=RefusesForAgent(agent_id),
+                    client=FakeClient(),
+                    namespace=NS,
+                    db_schema=_SCHEMA,
+                )
+                mine = [t for t in await loop.targets() if t.agent_id == agent_id]
+
+                assert len(mine) == 1, "DISTINCT ON must collapse dev+prod to one winner"
+                assert mine[0].version_id == prod_version, (
+                    "the reconciler picked a version the sandbox will not boot; "
+                    f"expected the prod winner {prod_version}, got {mine[0].version_id} "
+                    f"(the dev version is {dev_version})"
+                )
+                assert mine[0].has_bundle is False
+            finally:
+                await _cleanup(engine, [agent_id])
+        finally:
+            await engine.dispose()
+
+    asyncio.run(go())
+
+
+def test_a_pass_prunes_rather_than_reconciling_a_lower_precedence_version() -> None:
+    """The behavioural AC, end to end through `one_pass`.
+
+    Same seeded state, a real database, a source that fails the test if asked to
+    render the in-force version, and a cluster already holding two objects this
+    agent owns. The pass must render nothing for this agent and remove what it
+    owns, because the version in force declares no connectors we can reach.
+    """
+
+    async def go() -> None:
+        engine = await _engine_or_skip()
+        try:
+            token = uuid.uuid4().hex[:8]
+            agent_name = f"prune-{token}"
+            agent_id = await _seed_agent(
+                engine, name=agent_name, address=f"C-prune-{token}"
+            )
+            prod_version = await _seed_deployment(
+                engine,
+                agent_id=agent_id,
+                environment="prod",
+                bundle_ref=None,
+                deployed_seconds_ago=600,
+            )
+            dev_version = await _seed_deployment(
+                engine,
+                agent_id=agent_id,
+                environment="dev",
+                bundle_ref=f"bundles/{token}.zip",
+                deployed_seconds_ago=60,
+            )
+            try:
+                client = FakeClient(
+                    [
+                        live_copy(manifest("Service", f"svc-{token}"), agent=agent_name),
+                        live_copy(
+                            manifest("Deployment", f"dep-{token}"), agent=agent_name
+                        ),
+                    ]
+                )
+                source = RefusesForAgent(agent_id)
+                loop = ConnectorReconcileLoop(
+                    engine=engine,
+                    source=source,
+                    client=client,
+                    namespace=NS,
+                    db_schema=_SCHEMA,
+                )
+
+                await loop.one_pass()
+
+                assert str(prod_version) not in source.rendered_versions
+                assert str(dev_version) not in source.rendered_versions, (
+                    "the runner-up was rendered: the pass is reconciling a "
+                    "version this agent's sandbox does not boot"
+                )
+                assert client.applied == [], (
+                    "objects were applied from a version no sandbox boots"
+                )
+                assert sorted(client.deleted) == [
+                    ("Deployment", f"dep-{token}"),
+                    ("Service", f"svc-{token}"),
+                ]
+            finally:
+                await _cleanup(engine, [agent_id])
+        finally:
+            await engine.dispose()
+
+    asyncio.run(go())
+
+
+def test_the_two_queries_agree_on_the_winner() -> None:
+    """Pinning test (#1216 part 2), the shape `binding.py` already uses for
+    `_PERMISSION_GATE_SUMMARY_PREFIX` and `_RESUME_EVENT_ID_RE`: a duplicated
+    literal that two modules must keep in agreement gets a test whose only job
+    is to fail when they diverge.
+
+    Here the duplicated literal is the ORDER BY. Both deployments are bundled,
+    so nothing but precedence can separate them, and dev is the newer one so
+    prod-first and most-recent-first disagree.
+
+    Inverting EITHER query's ORDER BY must turn this red. That is the whole
+    point: `_TARGETS_SQL` has no other test that can see its ordering, which is
+    how it drifted away from `_RESOLVE_SQL` unnoticed in the first place.
+
+    This test pins only the ENVIRONMENT key -- the environment expression
+    decides the winner here before `deployed_at` is ever consulted, so flipping
+    the recency key alone leaves it green;
+    `test_the_two_queries_agree_on_the_more_recent_of_two_prod_deployments` is
+    the other half of the clause.
+    """
+
+    async def go() -> None:
+        engine = await _engine_or_skip()
+        try:
+            token = uuid.uuid4().hex[:8]
+            address = f"C-pin-{token}"
+            agent_id = await _seed_agent(engine, name=f"pin-{token}", address=address)
+            await _seed_deployment(
+                engine,
+                agent_id=agent_id,
+                environment="prod",
+                bundle_ref=f"bundles/{token}-prod.zip",
+                deployed_seconds_ago=600,
+            )
+            await _seed_deployment(
+                engine,
+                agent_id=agent_id,
+                environment="dev",
+                bundle_ref=f"bundles/{token}-dev.zip",
+                deployed_seconds_ago=60,
+            )
+            try:
+                resolve_sql = text(binding._RESOLVE_SQL.format(schema=_SCHEMA))
+                targets_sql = text(connector_loop._TARGETS_SQL.format(schema=_SCHEMA))
+                async with engine.connect() as conn:
+                    bound: Any = (
+                        (
+                            await conn.execute(
+                                resolve_sql, {"kind": "slack", "address": address}
+                            )
+                        )
+                        .mappings()
+                        .first()
+                    )
+                    targets = (await conn.execute(targets_sql)).mappings().all()
+
+                assert bound is not None
+                mine = [row for row in targets if row["agent_id"] == agent_id]
+                assert len(mine) == 1
+                assert mine[0]["version_id"] == bound["version_id"], (
+                    "the reconciler and the binding resolver disagree about which "
+                    "version is in force; the connectors an agent gets would come "
+                    "from a version its sandbox does not boot"
+                )
+            finally:
+                await _cleanup(engine, [agent_id])
+        finally:
+            await engine.dispose()
+
+    asyncio.run(go())
+
+
+def test_the_two_queries_agree_on_the_more_recent_of_two_prod_deployments() -> None:
+    """The RECENCY half of AC 2, and the reason it needs its own test.
+
+    Its sibling `test_the_two_queries_agree_on_the_winner` seeds prod against
+    dev, so `(d.environment = 'prod') DESC` settles the winner before
+    `d.deployed_at DESC` is read at all: flip the recency key there and both
+    queries still answer prod, and the test stays green. Here BOTH deployments
+    are prod and both are bundled, so the environment key ties and recency is
+    the only thing left that can separate them -- flipping `d.deployed_at DESC`
+    to `ASC` in either query turns this red. Neither ORDER BY key is defended
+    without both tests.
+
+    The two deployments also exercise the tie-break's reason for existing: with
+    the environment expression tied, only `deployed_at` (and behind it the
+    total-order key `d.id DESC`) keeps the two statements from disagreeing, and
+    a disagreement now costs a destructive prune.
+    """
+
+    async def go() -> None:
+        engine = await _engine_or_skip()
+        try:
+            token = uuid.uuid4().hex[:8]
+            address = f"C-recency-{token}"
+            agent_id = await _seed_agent(
+                engine, name=f"recency-{token}", address=address
+            )
+            older_version = await _seed_deployment(
+                engine,
+                agent_id=agent_id,
+                environment="prod",
+                bundle_ref=f"bundles/{token}-older.zip",
+                deployed_seconds_ago=600,
+            )
+            newer_version = await _seed_deployment(
+                engine,
+                agent_id=agent_id,
+                environment="prod",
+                bundle_ref=f"bundles/{token}-newer.zip",
+                deployed_seconds_ago=60,
+            )
+            try:
+                resolve_sql = text(binding._RESOLVE_SQL.format(schema=_SCHEMA))
+                targets_sql = text(connector_loop._TARGETS_SQL.format(schema=_SCHEMA))
+                async with engine.connect() as conn:
+                    bound: Any = (
+                        (
+                            await conn.execute(
+                                resolve_sql, {"kind": "slack", "address": address}
+                            )
+                        )
+                        .mappings()
+                        .first()
+                    )
+                    targets = (await conn.execute(targets_sql)).mappings().all()
+
+                assert bound is not None
+                mine = [row for row in targets if row["agent_id"] == agent_id]
+                assert len(mine) == 1, "DISTINCT ON must collapse two prod rows to one"
+                assert bound["version_id"] == newer_version, (
+                    "the binding resolver picked the OLDER of two prod deployments; "
+                    f"expected {newer_version}, got {bound['version_id']} "
+                    f"(the older version is {older_version})"
+                )
+                assert mine[0]["version_id"] == newer_version, (
+                    "the reconciler picked the OLDER of two prod deployments; its "
+                    "connector objects would come from a version no sandbox boots; "
+                    f"expected {newer_version}, got {mine[0]['version_id']}"
+                )
+                assert mine[0]["version_id"] == bound["version_id"]
+            finally:
+                await _cleanup(engine, [agent_id])
+        finally:
+            await engine.dispose()
+
+    asyncio.run(go())
+
+
+def test_the_seeded_objects_are_owned_by_the_agent_under_test() -> None:
+    """Guard on the guard: the prune assertions above are only meaningful if the
+    fake cluster reports those objects as this agent's. An owner label that did
+    not match would make `list_owned` return nothing and the delete assertions
+    would pass for the wrong reason.
+    """
+
+    agent = "guard-agent"
+    obj = live_copy(manifest("Service", "svc"), agent=agent)
+    assert obj["metadata"]["labels"][OWNER_LABEL] == agent
+    assert FakeClient([obj]).list_owned(NS, agent) == [obj]


### PR DESCRIPTION
Closes #1216

## What was wrong

`connector_loop.py::_TARGETS_SQL` documented that it mirrors `binding.py::_RESOLVE_SQL`'s precedence, so the connectors a thread gets belong to the version its sandbox boots. It did not. It filtered `WHERE v.bundle_ref IS NOT NULL` **before** ranking, so when the true binding winner was a bundleless version its row vanished and the next-ranked version was silently promoted. The reconciler then applied connector objects rendered from a version no sandbox runs, and, because the in-force deployment stayed permanently invisible to it, never converged them away.

The filter itself was not gratuitous: the render endpoint 404s for a bundleless version (`routers/agents.py`), so simply deleting the `WHERE` would make the loop `raise_for_status()` on that agent every pass forever.

Separately, `_TARGETS_SQL` executed under **zero** tests — `test_connector_loop.py` subclasses the loop and overrides `targets()`. So inverting its `ORDER BY` was silent while inverting `binding.py`'s turned `test_prod_deployment_wins_over_dev` red. That asymmetry is how the two drifted apart unnoticed.

## What changed

- **Rank first, decide second.** `_TARGETS_SQL` reports the bundle as `has_bundle` instead of filtering on it, so `DISTINCT ON` picks exactly the winner `_RESOLVE_SQL` picks.
- **A bundleless winner takes a new prune-only path** (`connector_agent.py::prune_agent`) rather than falling through to a runner-up. It declares no connectors we can reach, so everything the agent owns is undeclared and gets pruned. **No Secret of any name is pruned there**, for the reason the existing `unprovisioned` branch already gives: without a render nothing names the operator-supplied Secret (ADR-0086), and deleting it is unrecoverable.
- **Both queries gain `d.id DESC` as a final key.** Two active deployments in one environment with an identical `deployed_at` left the order undefined, so the two statements could pick different winners under different plans — and since the prune path exists, that disagreement costs a delete rather than a stale apply. The key carries no precedence meaning of its own, only totality. (Raised by review, not in the original issue.)
- **The ordering is now pinned against the real Postgres**, one test per `ORDER BY` key on each side.

## Deliberately not done

The issue also proposed making `POST /deployments` reject an active deployment on a bundleless version. That is **out of scope here and needs a maintainer call**: it contradicts the issue's own behavioural AC (which requires that state to be creatable through the real endpoints) and would break `apps/api/tests/test_bundle_ingestion_bounds.py::test_version_with_no_bundle_yet_deploys_without_revalidation`, which pins that behaviour deliberately as "the pre-B2 residue case". This PR makes the reconciler correct in the presence of that state rather than outlawing the state.

## Red-on-revert evidence

Every mutation below was applied to the merged tree and reverted; each turned a **named** test red, and the unmutated tree is green (`103 passed, 6 skipped`).

| Mutation | Named test that went red |
|---|---|
| Reinstate `WHERE v.bundle_ref IS NOT NULL` | `test_the_prod_winner_is_reported_even_when_it_has_no_bundle`, `test_a_pass_prunes_rather_than_reconciling_a_lower_precedence_version` |
| `_TARGETS_SQL` `(environment='prod') DESC` -> `ASC` | those two, plus `test_the_two_queries_agree_on_the_winner` |
| `_TARGETS_SQL` `deployed_at DESC` -> `ASC` | `test_the_two_queries_agree_on_the_more_recent_of_two_prod_deployments` |
| `_RESOLVE_SQL` `(environment='prod') DESC` -> `ASC` | `test_the_two_queries_agree_on_the_winner`, `test_prod_deployment_wins_over_dev` |
| `_RESOLVE_SQL` `deployed_at DESC` -> `ASC` | `test_the_two_queries_agree_on_the_more_recent_of_two_prod_deployments` |
| Drop the Secret exclusion in `prune_agent` | `test_a_bundleless_target_never_deletes_an_owned_secret` |

Both `ORDER BY` keys on both sides are independently pinned, so AC 2 holds for either query and either key.

## Verification

Full Python suite green: worker (reconcile/binding/sandbox 378, eval 155, kernel 191, top-level 281), api 1087, dispatcher+packages 625, runner 578, remainder 3597/11 skipped. `ruff` clean, `mypy` clean (191 files), `lint-imports` 4/4, `uv lock --check`, alembic revision gate (head 0027), doclint, wire-tolerance gate, commit-message gate all pass.

Two pre-existing environment conditions, neither caused by this diff:
- `scripts/check-released-upgrade.py` fails with "no stable vX.Y.Z release tag is reachable from origin/main" — `git tag --merged origin/main` is empty locally even with all 22 tags fetched. It reads only git refs, so no working-tree change can affect it. Its self-test additionally needs the compose Postgres on the fixed port 25432, occupied by a concurrent job.
- `apps/worker/tests/eval/test_stream.py` flaked once on a timeout under machine load; it passes alone and the whole `eval` directory then passes 155/155.

No Rust or UI files are touched, so `cargo`/`pnpm` were not run locally; CI covers them.

## Done-check

- [x] **Failing tests committed before implementation** — N/A for tier. This ran as a quick-tier single stream; tests and implementation were authored together and squashed into one commit. Red-on-revert is demonstrated above instead.
- [x] **All production edits by a delegated executor** — driver ran only git, tests and bookkeeping; every source edit came from a spawned sub-agent.
- [x] **Broadened return types** — none. `AgentTarget` gained a defaulted field; `prune_agent` returns the existing `AgentOutcome`.
- [x] **Adversarial Code review** — agent-router exit 0, routed to codex/gpt-5.6-sol. Two findings, both blocking, both fixed: the non-total `ORDER BY`, and a pinning test that left the `deployed_at` key undefended.
- [x] **Scope** — every hunk traces to an AC, except the `d.id DESC` tiebreaker, which is a reviewer finding recorded above.
- [x] **Sibling-path parity** — the sibling is `binding.py::_RESOLVE_SQL`; it is covered by this diff and by the new pinning tests rather than left to drift.
- [x] **Guard demonstration** — the Secret-exclusion guard was demonstrated by executing the mutation that removes it and observing the named failure (table above).
- [x] **Consolidation** — `/simplify` ran; three of four angles independently flagged the duplicated execute-and-log tail, extracted to `_execute_and_report`. Revalidated, and the full mutation battery re-run afterwards to confirm the extraction unpinned nothing. Adversarial re-review of the consolidation diff: clean.
- [x] **Security reviewer** — not flagged; no auth, PII or secrets surface added. The one credential-adjacent behaviour (never pruning a Secret) is guarded and demonstrated.
- [x] **Observable verification / E2E** — N/A. No user-facing or deployed surface changes; the behaviour is exercised against a real Postgres rather than mocks.
- [x] **Full affected suite, typecheck, lint** — see Verification.
