### PR TITLE
fix: report the stateful delta in curie diff (#1352)

### DIFF
--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -4568,6 +4568,14 @@ export const commandManifest = {
           "positional": false,
           "required": false,
           "short": "f"
+        },
+        {
+          "global": false,
+          "help": "Chart reference override, as `cluster up` takes. Diff RENDERS this chart to detect stateful components the apply would delete, so point it at the same chart `curie apply --chart` would use",
+          "id": "chart",
+          "long": "chart",
+          "positional": false,
+          "required": false
         }
       ],
       "hidden": false,

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -4565,6 +4565,14 @@
           "positional": false,
           "required": false,
           "short": "f"
+        },
+        {
+          "global": false,
+          "help": "Chart reference override, as `cluster up` takes. Diff RENDERS this chart to detect stateful components the apply would delete, so point it at the same chart `curie apply --chart` would use",
+          "id": "chart",
+          "long": "chart",
+          "positional": false,
+          "required": false
         }
       ],
       "hidden": false,

--- a/cli/schema/baseline/diff.schema.json
+++ b/cli/schema/baseline/diff.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schemas.curietech.ai/cli/diff/v2.1.json",
+  "$id": "https://schemas.curietech.ai/cli/diff/v2.2.json",
   "title": "curie diff --json",
   "description": "The agent facing payload of `curie diff`: every chart value the effective installation plan and the live release disagree about, plus the values the release carries that the plan does not declare. Read only. Available credentials and provider addresses are resolved to construct the same plan used by apply. Comparisons that depend on an unavailable declared credential are marked unknown. No cluster state is mutated. Secret values are rendered as the literal string `<secret>` and never in the clear.",
   "type": "object",
@@ -19,7 +19,7 @@
     "changes": {
       "type": "integer",
       "minimum": 0,
-      "description": "How many entries are known changes or unresolved comparisons: add, change, reset, and unknown. Unknown counts conservatively so zero still means applying the file is a no op."
+      "description": "How many differences this diff found between the file and the live release: the entries that are known changes or unresolved comparisons (add, change, reset, unknown) PLUS the length of `stateful_removals`. Unknown counts conservatively, and a stateful removal counts even though it is not an entry, so zero still means applying the file is a no op. A NON ZERO COUNT IS NOT PERMISSION TO APPLY, and it is not a count of what apply would do: a non empty `stateful_removals` means `curie apply` REFUSES this file outright rather than making any of these changes."
     },
     "entries": {
       "type": "array",
@@ -78,11 +78,67 @@
     },
     "chart_target": {
       "type": "string",
-      "description": "The chart version this CLI would apply."
+      "description": "The version of the chart this run would apply: this CLI's own by default, or the version declared by the `--chart` override when one was given. Always the chart the comparison actually rendered, so `chart_version_differs` compares like with like."
     },
     "chart_version_differs": {
       "type": "boolean",
-      "description": "True when the deployed chart version differs from the one this CLI would apply. The entry comparison is VALUES-ONLY and cannot see a component added, removed, or renamed between chart versions -- a renamed component's old keys appear as ordinary resets. Treat a true here as 'this diff does not describe a safe apply'."
+      "description": "True when the deployed chart version differs from the one this CLI would apply. The `entries` comparison is VALUES-ONLY: a non stateful component added, removed, or renamed between chart versions is invisible to it, and a renamed one's old keys appear as ordinary resets. STATEFUL components are the exception -- those are reported directly in `stateful_removals`, which is populated from a live read and is independent of this flag. Treat a true here as 'the entry comparison does not describe a safe apply'."
+    },
+    "stateful_removals": {
+      "type": "array",
+      "description": "Live stateful components the target chart would NOT recreate in place, each of which apply would delete along with its persistent data. THIS CLI always emits the key, including as `[]`, and `[]` means the live StatefulSets were read and none are at risk; the property is left out of the top level `required` list only so a consumer pinned to the previous `$id` still validates against this schema (adding it would be a MAJOR bump). A NON EMPTY array means `curie apply` on this exact file WILL REFUSE, so a consumer must not read the exit code alone as permission to apply. The two causes have OPPOSITE remedies: `component_gone` means the target chart does not render the component at all -- `curie apply --migrate-store` carries the data across ONLY when that component is the object store, and the `migration` field is the discriminator, so a component gone for any other reason (a store disabled through the chart BYO gate, e.g. `postgres.deploy: false`) has no automatic carry and apply keeps refusing; `renamed` means the component survives under a different resource name because the release was installed with a `nameOverride` the file does not declare, which is fixed by declaring it in curie.yaml (`--migrate-store` cannot help there).",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The live resource name, which is what an operator recognises in their own cluster."
+          },
+          "component": {
+            "type": "string",
+            "description": "The `app.kubernetes.io/component` label the identity is keyed on. Names embed the chart fullname, so the component, not the name, is what makes two objects the same thing."
+          },
+          "cause": {
+            "enum": [
+              "component_gone",
+              "renamed"
+            ],
+            "description": "`component_gone`: the target chart does not render this component at all. `renamed`: it is rendered, under a different resource name, so helm deletes the old object and creates the new one empty beside the orphaned volume."
+          },
+          "renamed_to": {
+            "type": "string",
+            "description": "The resource name the target chart renders this component as. Present ONLY when `cause` is `renamed`."
+          }
+        },
+        "required": [
+          "name",
+          "component",
+          "cause"
+        ]
+      }
+    },
+    "migration": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": false,
+      "description": "The object store rename this upgrade performs. NON NULL means the target chart renders the object store under a different component than the live release does, which is exactly the case `curie apply --migrate-store` carries the data across. NULL beside a NON EMPTY `stateful_removals` means there is no automatic carry for what would be deleted, and apply will keep refusing until the file is fixed. This CLI always emits the key, as an object or as `null`; the property is left out of the top level `required` list only so a consumer pinned to the previous `$id` still validates.",
+      "properties": {
+        "from": {
+          "type": "string",
+          "description": "The `app.kubernetes.io/component` name of the live object store (`minio`, `rustfs`). A COMPONENT, never a resource name: resource names embed the chart fullname, so a `nameOverride` changes all of them."
+        },
+        "to": {
+          "type": "string",
+          "description": "The `app.kubernetes.io/component` name of the object store the target chart renders (`minio`, `rustfs`). A COMPONENT, never a resource name, for the same reason as `from`."
+        }
+      },
+      "required": [
+        "from",
+        "to"
+      ]
     },
     "unresolved_credentials": {
       "type": "array",

--- a/cli/schema/diff.schema.json
+++ b/cli/schema/diff.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schemas.curietech.ai/cli/diff/v2.1.json",
+  "$id": "https://schemas.curietech.ai/cli/diff/v2.2.json",
   "title": "curie diff --json",
   "description": "The agent facing payload of `curie diff`: every chart value the effective installation plan and the live release disagree about, plus the values the release carries that the plan does not declare. Read only. Available credentials and provider addresses are resolved to construct the same plan used by apply. Comparisons that depend on an unavailable declared credential are marked unknown. No cluster state is mutated. Secret values are rendered as the literal string `<secret>` and never in the clear.",
   "type": "object",
@@ -19,7 +19,7 @@
     "changes": {
       "type": "integer",
       "minimum": 0,
-      "description": "How many entries are known changes or unresolved comparisons: add, change, reset, and unknown. Unknown counts conservatively so zero still means applying the file is a no op."
+      "description": "How many differences this diff found between the file and the live release: the entries that are known changes or unresolved comparisons (add, change, reset, unknown) PLUS the length of `stateful_removals`. Unknown counts conservatively, and a stateful removal counts even though it is not an entry, so zero still means applying the file is a no op. A NON ZERO COUNT IS NOT PERMISSION TO APPLY, and it is not a count of what apply would do: a non empty `stateful_removals` means `curie apply` REFUSES this file outright rather than making any of these changes."
     },
     "entries": {
       "type": "array",
@@ -78,11 +78,67 @@
     },
     "chart_target": {
       "type": "string",
-      "description": "The chart version this CLI would apply."
+      "description": "The version of the chart this run would apply: this CLI's own by default, or the version declared by the `--chart` override when one was given. Always the chart the comparison actually rendered, so `chart_version_differs` compares like with like."
     },
     "chart_version_differs": {
       "type": "boolean",
-      "description": "True when the deployed chart version differs from the one this CLI would apply. The entry comparison is VALUES-ONLY and cannot see a component added, removed, or renamed between chart versions -- a renamed component's old keys appear as ordinary resets. Treat a true here as 'this diff does not describe a safe apply'."
+      "description": "True when the deployed chart version differs from the one this CLI would apply. The `entries` comparison is VALUES-ONLY: a non stateful component added, removed, or renamed between chart versions is invisible to it, and a renamed one's old keys appear as ordinary resets. STATEFUL components are the exception -- those are reported directly in `stateful_removals`, which is populated from a live read and is independent of this flag. Treat a true here as 'the entry comparison does not describe a safe apply'."
+    },
+    "stateful_removals": {
+      "type": "array",
+      "description": "Live stateful components the target chart would NOT recreate in place, each of which apply would delete along with its persistent data. THIS CLI always emits the key, including as `[]`, and `[]` means the live StatefulSets were read and none are at risk; the property is left out of the top level `required` list only so a consumer pinned to the previous `$id` still validates against this schema (adding it would be a MAJOR bump). A NON EMPTY array means `curie apply` on this exact file WILL REFUSE, so a consumer must not read the exit code alone as permission to apply. The two causes have OPPOSITE remedies: `component_gone` means the target chart does not render the component at all -- `curie apply --migrate-store` carries the data across ONLY when that component is the object store, and the `migration` field is the discriminator, so a component gone for any other reason (a store disabled through the chart BYO gate, e.g. `postgres.deploy: false`) has no automatic carry and apply keeps refusing; `renamed` means the component survives under a different resource name because the release was installed with a `nameOverride` the file does not declare, which is fixed by declaring it in curie.yaml (`--migrate-store` cannot help there).",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The live resource name, which is what an operator recognises in their own cluster."
+          },
+          "component": {
+            "type": "string",
+            "description": "The `app.kubernetes.io/component` label the identity is keyed on. Names embed the chart fullname, so the component, not the name, is what makes two objects the same thing."
+          },
+          "cause": {
+            "enum": [
+              "component_gone",
+              "renamed"
+            ],
+            "description": "`component_gone`: the target chart does not render this component at all. `renamed`: it is rendered, under a different resource name, so helm deletes the old object and creates the new one empty beside the orphaned volume."
+          },
+          "renamed_to": {
+            "type": "string",
+            "description": "The resource name the target chart renders this component as. Present ONLY when `cause` is `renamed`."
+          }
+        },
+        "required": [
+          "name",
+          "component",
+          "cause"
+        ]
+      }
+    },
+    "migration": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": false,
+      "description": "The object store rename this upgrade performs. NON NULL means the target chart renders the object store under a different component than the live release does, which is exactly the case `curie apply --migrate-store` carries the data across. NULL beside a NON EMPTY `stateful_removals` means there is no automatic carry for what would be deleted, and apply will keep refusing until the file is fixed. This CLI always emits the key, as an object or as `null`; the property is left out of the top level `required` list only so a consumer pinned to the previous `$id` still validates.",
+      "properties": {
+        "from": {
+          "type": "string",
+          "description": "The `app.kubernetes.io/component` name of the live object store (`minio`, `rustfs`). A COMPONENT, never a resource name: resource names embed the chart fullname, so a `nameOverride` changes all of them."
+        },
+        "to": {
+          "type": "string",
+          "description": "The `app.kubernetes.io/component` name of the object store the target chart renders (`minio`, `rustfs`). A COMPONENT, never a resource name, for the same reason as `from`."
+        }
+      },
+      "required": [
+        "from",
+        "to"
+      ]
     },
     "unresolved_credentials": {
       "type": "array",

--- a/cli/schema/index.json
+++ b/cli/schema/index.json
@@ -91,7 +91,7 @@
       "result": "DiffOutput",
       "kind": "CliOutput",
       "schema": "diff.schema.json",
-      "version": "2.1"
+      "version": "2.2"
     },
     {
       "result": "DoctorOutput",

--- a/cli/src/installation.rs
+++ b/cli/src/installation.rs
@@ -680,6 +680,17 @@ struct EffectiveInstallationPlan {
     live: Option<serde_json::Value>,
     desired: BTreeMap<String, String>,
     preserves_undeclared_github_token: bool,
+    /// What the stateful probe learned about THIS plan, or `None` when the plan
+    /// was completed with [`StatefulProbe::Skip`] and no cluster read happened.
+    ///
+    /// `None` means NOT PROBED -- never "clear". Reading it as clear is the
+    /// silent store destruction the guard exists to prevent, so every consumer
+    /// fails closed on it. The verdict lives HERE, in the plan both `apply` and
+    /// `diff` consume, rather than beside one of them: #1338 bolted the guard
+    /// into `apply` after the shared plan was already built, and the two
+    /// surfaces promptly disagreed about the same file on the same cluster
+    /// (#1352).
+    stateful: Option<StatefulDelta>,
 }
 
 pub fn plan_installation(cfg: Installation, dry_run: bool) -> Result<LocalInstallationPlan> {
@@ -748,8 +759,24 @@ fn plan_installation_inner(
     })
 }
 
+/// Whether completing the plan reads the cluster's StatefulSets.
+///
+/// `Skip` exists SOLELY for `apply --allow-stateful-removal`, which has already
+/// declared the verdict irrelevant and today performs no cluster read at all.
+/// Preserving that is what keeps the override working against an unreadable
+/// cluster: an operator who has decided to discard a store must not be blocked
+/// by a probe whose answer they already overrode (#1352).
+enum StatefulProbe {
+    /// Read the live StatefulSets and reach a verdict. Every surface that has
+    /// not opted out passes this, so `apply` and `diff` read ONE answer.
+    Run,
+    /// Do not read the cluster at all; the plan's `stateful` stays `None`.
+    Skip,
+}
+
 async fn complete_installation_plan(
     local: LocalInstallationPlan,
+    probe: StatefulProbe,
 ) -> Result<EffectiveInstallationPlan> {
     let LocalInstallationPlan {
         cfg,
@@ -782,6 +809,16 @@ async fn complete_installation_plan(
         complete_live_state,
     )?;
     let up_values = crate::ops::up_value_plan(&up);
+    // Deliberately NOT gated on `complete_live_state`. `apply --dry-run` sets
+    // that false, but the guard is documented to run under `--dry-run` anyway:
+    // the plan a dry run prints is exactly the plan that would destroy the
+    // store. Gating the probe on it would silently stop `apply --dry-run`
+    // warning about store deletion, and no existing test would catch it, since
+    // the dry-run fixtures only cover values/conflict parity (#1352).
+    let stateful = match probe {
+        StatefulProbe::Run => Some(guard_stateful_removal(&up, &up_values).await?),
+        StatefulProbe::Skip => None,
+    };
     let mut desired = up_values.effective_values();
     // Declaring a model credential selects the real model independently of the
     // credential value. The lenient diff may not know that value, but it still
@@ -823,6 +860,7 @@ async fn complete_installation_plan(
         live,
         desired,
         preserves_undeclared_github_token,
+        stateful,
     })
 }
 
@@ -844,6 +882,30 @@ enum GuardVerdict {
     WouldRemove(Vec<crate::ops::StatefulRemoval>),
 }
 
+/// Everything one stateful probe learned: the verdict `apply` turns on, plus
+/// the object-store rename `--migrate-store` is the remedy for.
+///
+/// The two travel together because they are read from the SAME live and
+/// rendered component lists, and computing the migration anywhere else would
+/// mean a second cluster read that could disagree with the verdict -- the very
+/// two-surfaces-disagree defect #1352 exists to close.
+///
+/// Only `diff` reads `migration`; `apply` reads `verdict` alone and behaves
+/// exactly as it did before this field existed.
+struct StatefulDelta {
+    verdict: GuardVerdict,
+    /// The object-store component rename this upgrade performs, as
+    /// `(from, to)` COMPONENT names (`minio` -> `rustfs`) -- never resource
+    /// names, which embed the chart fullname and change with `nameOverride`.
+    ///
+    /// `Some` is exactly the case `curie apply --migrate-store` carries the
+    /// data across. `None` means there is no such rename, which is NOT a
+    /// statement that anything is safe: a store disabled through the chart's
+    /// own BYO gate (`postgres.deploy: false`, the #1352 reproduction) is a
+    /// removal with no automatic carry, and `verdict` is what says so.
+    migration: Option<(String, String)>,
+}
+
 /// Decide whether an apply would delete a stateful component the release runs.
 ///
 /// Runs even under `--dry-run`: the plan a dry run prints is exactly the plan
@@ -852,23 +914,65 @@ enum GuardVerdict {
 async fn guard_stateful_removal(
     up: &crate::ops::UpOpts,
     value_plan: &crate::ops::UpValuePlan,
-) -> Result<GuardVerdict> {
+) -> Result<StatefulDelta> {
     let live = crate::ops::live_stateful_components(&up.common)
         .await
-        .context("could not check whether this apply would remove stateful components")?;
+        // Verb-neutral: this verdict is now carried by the shared plan and read
+        // by BOTH `curie apply` and `curie diff` (#1352), so naming "this apply"
+        // here would have `curie diff` report a verb the operator did not run.
+        // `live_stateful_components` already keeps its own wording neutral for
+        // the same reason and leaves the framing to its caller (#1351); this
+        // caller now has two callers of its own.
+        .context("could not check whether this change would remove stateful component(s)")?;
     if live.is_empty() {
         // Genuinely nothing to lose: a namespaced LIST returns an empty items
         // array with exit 0 for a fresh install AND for a namespace that does
         // not exist. A read that FAILED never reaches here; it is an error now
         // rather than a silent empty answer (#1351).
-        return Ok(GuardVerdict::Clear);
+        //
+        // This short-circuits BEFORE the chart is rendered, so `migration` is
+        // `None` here. Correct rather than incomplete: nothing is running, so
+        // there is nothing to carry across.
+        return Ok(StatefulDelta {
+            verdict: GuardVerdict::Clear,
+            migration: None,
+        });
     }
     let rendered = crate::ops::chart_stateful_components(&up.chart, &up.common, value_plan).await?;
+    // The one place both the live and the rendered component lists exist, so
+    // the object-store rename is decided from the SAME read as the verdict
+    // (#1352). Reuses `migrate_store`'s pure decision rather than re-detecting
+    // the store here -- a second copy of "which component is the store" is how
+    // the two surfaces would drift apart again.
+    //
+    // Swallowing the `Err` is correct for this field, and only for this field.
+    // `plan` errors when neither side runs a store it can name, and "there is
+    // no store to migrate" is a legitimate answer to the question this field
+    // asks. It must NEVER be read as "safe": `verdict` below is the sole
+    // statement about whether anything is at risk, and it is computed
+    // independently of this.
+    let migration = match crate::migrate_store::plan(
+        &live.iter().map(|(c, _)| c.clone()).collect::<Vec<_>>(),
+        &rendered.iter().map(|(c, _)| c.clone()).collect::<Vec<_>>(),
+    )
+    .ok()
+    {
+        Some(crate::migrate_store::MigrationPlan::Migrate { from, to }) => {
+            Some((from.suffix().to_string(), to.suffix().to_string()))
+        }
+        Some(crate::migrate_store::MigrationPlan::NotNeeded { .. }) | None => None,
+    };
     let removed = crate::ops::removed_stateful_components(&live, &rendered);
     if removed.is_empty() {
-        return Ok(GuardVerdict::Clear);
+        return Ok(StatefulDelta {
+            verdict: GuardVerdict::Clear,
+            migration,
+        });
     }
-    Ok(GuardVerdict::WouldRemove(removed))
+    Ok(StatefulDelta {
+        verdict: GuardVerdict::WouldRemove(removed),
+        migration,
+    })
 }
 
 /// The one rendering of a component the target chart does not render at all.
@@ -910,6 +1014,25 @@ fn stateful_removal_message(removed: &[crate::ops::StatefulRemoval]) -> String {
         removed.len(),
     );
 
+    msg.push_str(&stateful_removal_remedies(removed));
+
+    msg.push_str("Use --allow-stateful-removal only to proceed WITHOUT the data.");
+    msg
+}
+
+/// The per-cause remedies, factored out of [`stateful_removal_message`] so
+/// `curie diff` can name the SAME two fixes without restating apply's refusal
+/// header (#1352).
+///
+/// Factored rather than restated: the two causes have OPPOSITE remedies, and a
+/// hand-written second copy in `diff` would drift from the refusal an operator
+/// then hits from `apply` on the identical file -- the two surfaces disagreeing
+/// is the whole defect. `stateful_removal_message` composes header + these
+/// remedies + trailer, so its text is unchanged byte for byte.
+fn stateful_removal_remedies(removed: &[crate::ops::StatefulRemoval]) -> String {
+    use crate::ops::RemovalCause;
+
+    let mut msg = String::new();
     let renamed: Vec<&crate::ops::StatefulRemoval> = removed
         .iter()
         .filter(|r| matches!(r.cause, RemovalCause::RenamedTo(_)))
@@ -932,14 +1055,57 @@ fn stateful_removal_message(removed: &[crate::ops::StatefulRemoval]) -> String {
         );
     }
 
-    if removed
+    // #1501 settled what `--migrate-store` can actually carry -- the OBJECT
+    // STORE and nothing else -- and made `apply` REFUSE a migration batch
+    // holding anything else. So the ComponentGone removals split by that same
+    // predicate, rather than all receiving one remedy: telling the operator of
+    // a dropped `postgres` to "re-run with --migrate-store" would name a flag
+    // apply then refuses, which is the diff-vs-apply disagreement #1352 exists
+    // to close, reintroduced from the other side.
+    let (carriable, uncarriable): (
+        Vec<&crate::ops::StatefulRemoval>,
+        Vec<&crate::ops::StatefulRemoval>,
+    ) = removed
         .iter()
-        .any(|r| r.cause == RemovalCause::ComponentGone)
-    {
-        let migration_instruction = if renamed.is_empty() {
-            "Re-run with --migrate-store"
-        } else {
-            "After fixing the renames, re-run with --migrate-store"
+        .filter(|r| r.cause == RemovalCause::ComponentGone)
+        .partition(|r| crate::migrate_store::is_object_store_component(&r.component));
+
+    if !uncarriable.is_empty() {
+        // Deliberately the substance and the voice of `uncarriable_removal_message`
+        // (the refusal `apply --migrate-store` raises just below `apply`), down to
+        // the shared `component_gone_line`: an operator matching what `diff` said
+        // against what `apply` says on the identical file has to read one story,
+        // not two (#1352, #1501). It does NOT offer `--migrate-store`, because for
+        // these components that flag is a dead end.
+        let listed = uncarriable
+            .iter()
+            .map(|r| component_gone_line(r))
+            .collect::<Vec<_>>()
+            .join("\n  ");
+        msg.push_str(&format!(
+            "--migrate-store carries the OBJECT STORE and nothing else, so it cannot \
+             carry {} of these stateful component(s):\n  {listed}\n\n\
+             A component the target chart does not render at all is usually a values \
+             difference -- a `<component>.deploy=false` in the file, or a chart version \
+             that dropped it. Fix the values so these components are still rendered, then \
+             re-run `curie diff` and confirm these entries are gone.\n\n",
+            uncarriable.len(),
+        ));
+    }
+
+    if !carriable.is_empty() {
+        // Conditional on whatever still blocks the migration, in the order the
+        // operator has to clear it: renames live in their own file, and an
+        // uncarriable component has to be rendered again before `--migrate-store`
+        // will be accepted at all (#1501).
+        let migration_instruction = match (renamed.is_empty(), uncarriable.is_empty()) {
+            (true, true) => "Re-run with --migrate-store",
+            (false, true) => "After fixing the renames, re-run with --migrate-store",
+            (true, false) => "After restoring the component(s) above, re-run with --migrate-store",
+            (false, false) => {
+                "After fixing the renames and restoring the component(s) above, re-run with \
+                 --migrate-store"
+            }
         };
         msg.push_str(&format!(
             "Component(s) the chart does not render at all usually mean a chart version \
@@ -948,8 +1114,6 @@ fn stateful_removal_message(removed: &[crate::ops::StatefulRemoval]) -> String {
                  and verifies per object.\n\n"
         ));
     }
-
-    msg.push_str("Use --allow-stateful-removal only to proceed WITHOUT the data.");
     msg
 }
 
@@ -979,9 +1143,23 @@ pub async fn apply(opts: ApplyOpts) -> Result<ApplyOutput> {
              WITHOUT it. Pass exactly one."
         );
     }
+    // Before the plan is completed, because the plan's stateful probe renders
+    // THIS chart: an empty `up.chart` would render nothing and report every
+    // live component as gone.
     local.up.chart = chart;
     let dry_run = local.up.common.dry_run;
-    let plan = complete_installation_plan(local).await?;
+    // `Skip` is the only path that reads no cluster state, and it is reserved
+    // for the operator who already overrode the verdict. Everything else --
+    // including `--dry-run` and `--migrate-store` -- probes (#1352).
+    let plan = complete_installation_plan(
+        local,
+        if allow_stateful_removal {
+            StatefulProbe::Skip
+        } else {
+            StatefulProbe::Run
+        },
+    )
+    .await?;
     let EffectiveInstallationPlan {
         cfg,
         up,
@@ -989,6 +1167,7 @@ pub async fn apply(opts: ApplyOpts) -> Result<ApplyOutput> {
         github_token,
         comms,
         live,
+        stateful,
         ..
     } = plan;
 
@@ -1019,12 +1198,24 @@ pub async fn apply(opts: ApplyOpts) -> Result<ApplyOutput> {
     // cluster, a failed `helm template`), never a removal. It propagates on
     // EVERY path including `--migrate-store`: "I could not find out" must not
     // become "start moving data" (#1351).
+    //
+    // The verdict is read from the shared plan rather than computed here, so
+    // `curie diff` cannot reach a different answer on the same file (#1352).
+    // `None` is NOT PROBED and must NEVER be read as `Clear` -- that would
+    // restore exactly the silent destruction this guard exists to prevent -- so
+    // the read is fail-closed through `.context(..)?`.
     let migrating = if allow_stateful_removal {
         false
     } else {
         // Guard the exact upgrade plan, including preserved values carried through
         // the private values file.
-        match guard_stateful_removal(&up, &up_values).await? {
+        // `.verdict` only: the delta's `migration` is a `diff` reporting field.
+        // What apply does is decided by the verdict alone, exactly as before
+        // that field existed (#1352).
+        match stateful
+            .context("the stateful-removal guard did not run")?
+            .verdict
+        {
             GuardVerdict::Clear => false,
             // All-ComponentGone was the whole bypass condition, and it is only
             // HALF the question. `--migrate-store` carries the OBJECT STORE and
@@ -1411,14 +1602,40 @@ pub struct DiffOutput {
     pub release_exists: bool,
     /// The chart the release was installed with (`curie-0.5.1`), if readable.
     pub chart_deployed: Option<String>,
-    /// The chart version this CLI would apply.
+    /// The version of the chart this run would apply: this CLI's own, or the
+    /// `--chart` override's when one was given.
     pub chart_target: String,
     pub entries: Vec<DiffEntry>,
+    /// Live stateful components the target chart would not recreate in place.
+    ///
+    /// Non-empty means `curie apply` on this exact file REFUSES. Carried as the
+    /// full `StatefulRemoval` rather than a name list because the two causes
+    /// have opposite remedies, and a diff that hid the cause would send half the
+    /// operators to a flag that cannot help them (#1352).
+    pub stateful_removals: Vec<crate::ops::StatefulRemoval>,
+    /// The object-store rename this upgrade performs, as `(from, to)` COMPONENT
+    /// names (`minio` -> `rustfs`) -- never resource names, which embed the
+    /// chart fullname and all change together under a `nameOverride`.
+    ///
+    /// The discriminator the removals list alone cannot supply: `Some` is
+    /// exactly the case `curie apply --migrate-store` carries the data across.
+    /// `None` beside a non-empty `stateful_removals` means there is no
+    /// automatic carry -- a store disabled through the chart's own BYO gate
+    /// (`postgres.deploy: false`, #1352's own reproduction) removes a component
+    /// `--migrate-store` has nothing to move, so apply keeps refusing until the
+    /// file is fixed.
+    pub migration: Option<(String, String)>,
 }
 
 impl DiffOutput {
+    /// Every change `apply` would make, values AND components.
+    ///
+    /// The removals are counted, not merely listed: automation reads this
+    /// integer, and the defect this closes was `changes: 3` with exit 0 on the
+    /// file `apply` refuses. A store deletion that did not move the number is
+    /// still invisible to every consumer that only reads it (#1352).
     pub fn changes(&self) -> usize {
-        self.entries.iter().filter(|e| e.kind.is_change()).count()
+        self.entries.iter().filter(|e| e.kind.is_change()).count() + self.stateful_removals.len()
     }
 
     /// The deployed chart's version, stripped of the `curie-` name prefix.
@@ -1430,10 +1647,12 @@ impl DiffOutput {
 
     /// Would `apply` change the chart under these values, not just the values?
     ///
-    /// A value-level diff cannot see a component being added, removed, or
-    /// renamed between chart versions -- and when that happens its output is
-    /// not merely incomplete but misleading, since a renamed component's old
-    /// keys render as ordinary resets.
+    /// The ENTRY comparison is value-level, so it cannot see a non-stateful
+    /// component being added, removed, or renamed between chart versions --
+    /// when that happens its output is not merely incomplete but misleading,
+    /// since a renamed component's old keys render as ordinary resets.
+    /// `stateful_removals` closes the half of that blind spot where the cost is
+    /// irreversible (#1352); the rest of it remains.
     pub fn chart_version_differs(&self) -> bool {
         match self.deployed_version() {
             Some(deployed) => deployed != self.chart_target,
@@ -1471,6 +1690,44 @@ impl crate::ui::CliOutput for DiffOutput {
                 }
                 value
             }).collect::<Vec<_>>(),
+            // ALWAYS emitted, including as `[]`. The key is optional in the
+            // schema (an additive MINOR bump), but omitting it when empty would
+            // re-hide the field from a consumer that looks for it and cannot
+            // tell "no removals" from "a CLI that does not report them" (#1352).
+            "stateful_removals": self.stateful_removals.iter().map(|r| {
+                // `RemovalCause` carries no serde derive, so the wire encoding
+                // is written here by hand and is the contract: `renamed_to` is
+                // present ONLY on `renamed`, so a consumer branching on the
+                // cause cannot read a missing target as an empty one.
+                let mut value = serde_json::json!({
+                    "name": r.name,
+                    "component": r.component,
+                    "cause": match &r.cause {
+                        crate::ops::RemovalCause::ComponentGone => "component_gone",
+                        crate::ops::RemovalCause::RenamedTo(_) => "renamed",
+                    },
+                });
+                if let crate::ops::RemovalCause::RenamedTo(to) = &r.cause {
+                    value
+                        .as_object_mut()
+                        .expect("stateful removal is an object")
+                        .insert(
+                            "renamed_to".to_string(),
+                            serde_json::Value::String(to.clone()),
+                        );
+                }
+                value
+            }).collect::<Vec<_>>(),
+            // ALWAYS emitted too, as an object or as `null`, for the same
+            // reason: a consumer must be able to tell "no store rename" from "a
+            // CLI that does not report one". Component names, never resource
+            // names -- a resource name embeds the chart fullname, so a
+            // `nameOverride` release would report a pair no consumer could
+            // match against `minio`/`rustfs` (#1352).
+            "migration": self.migration.as_ref().map(|(from, to)| serde_json::json!({
+                "from": from,
+                "to": to,
+            })),
         })
     }
 
@@ -1525,6 +1782,25 @@ impl crate::ui::CliOutput for DiffOutput {
             };
             ui.payload_plain(&line);
         }
+        // Beside the entries, not folded into them: a removal is a COMPONENT
+        // going away with its data, and rendering it as another `key: value`
+        // row is what let store destruction read as `+ postgres.deploy: false`
+        // (#1352). The live resource name leads, because that is the string the
+        // operator recognises in their own cluster.
+        for removal in &self.stateful_removals {
+            let cause = match &removal.cause {
+                crate::ops::RemovalCause::ComponentGone => {
+                    "the target chart does not render it".to_string()
+                }
+                crate::ops::RemovalCause::RenamedTo(to) => {
+                    format!("the target renders it as {to}")
+                }
+            };
+            ui.payload_plain(&format!(
+                "STATEFUL: {} ({}) would be DELETED with its data -- {}",
+                removal.name, removal.component, cause,
+            ));
+        }
         let changes = self.changes();
         if changes == 0 {
             ui.payload_plain("no changes: the cluster already matches this file");
@@ -1534,6 +1810,18 @@ impl crate::ui::CliOutput for DiffOutput {
             .any(|entry| entry.kind == DiffKind::Unknown)
         {
             ui.payload_plain(&format!("{changes} change(s) or unresolved comparison(s)"));
+        } else if !self.stateful_removals.is_empty() {
+            // "would be applied" is the ORIGINAL defect's wording, and folding
+            // the removals into `changes()` without touching this line merely
+            // made it a bigger number telling the same lie: `curie apply` on
+            // this file REFUSES, it does not apply anything. The count is still
+            // reported, because automation and humans both read it -- it is the
+            // OUTCOME that must not be misstated (#1352).
+            ui.payload_plain(&format!(
+                "{changes} change(s), including {} stateful removal(s): `curie apply` will \
+                 REFUSE this file rather than apply it",
+                self.stateful_removals.len(),
+            ));
         } else {
             ui.payload_plain(&format!("{changes} change(s) would be applied"));
         }
@@ -1566,12 +1854,42 @@ impl crate::ui::CliOutput for DiffOutput {
         if self.chart_version_differs() {
             ui.note(&format!(
                 "CHART VERSION MISMATCH: the release runs {} but this curie applies {}. \
-                 The comparison above is values-only -- it cannot see a component added, \
-                 removed, or renamed between those versions, and a renamed one shows up \
-                 as an ordinary reset. Do not read this as a safe apply. Reconcile the \
-                 chart version first, or apply with the matching chart.",
+                 The comparison above is values-only, so it cannot see a NON-STATEFUL \
+                 component added, removed, or renamed between those versions, and a \
+                 renamed one shows up as an ordinary reset. Stateful components are the \
+                 exception -- those are reported directly above from a live read (#1352). \
+                 Do not read this as a safe apply. Reconcile the chart version first, or \
+                 apply with the matching chart.",
                 self.chart_deployed.as_deref().unwrap_or("unknown"),
                 self.chart_target,
+            ));
+        }
+        // Truly last, so it is the line left on screen: it is the only note
+        // that says the answer above is not merely incomplete but will be
+        // REFUSED. The remedies come from the same helper apply's refusal uses,
+        // so the two surfaces cannot drift into naming different fixes (#1352).
+        if !self.stateful_removals.is_empty() {
+            // The remedies now say WHICH `component_gone` removals
+            // `--migrate-store` can carry, but not what it would carry them
+            // FROM and TO. Naming the concrete store rename here is what turns
+            // "this flag applies to you" into a fact the operator can check
+            // against their own release -- and its absence, beside a non-empty
+            // removal list, is how a store merely disabled through the chart's
+            // BYO gate reads as the dead end it is (#1352, #1501).
+            let migration = match &self.migration {
+                Some((from, to)) => format!(
+                    "\n\nThis upgrade renames the object store {from} -> {to}, which is \
+                     exactly what `curie apply --migrate-store` carries the data across."
+                ),
+                None => String::new(),
+            };
+            ui.note(&format!(
+                "STATEFUL REMOVAL: `curie apply` will REFUSE this file -- it would DELETE \
+                 {} stateful component(s) the release is running, and the persistent data \
+                 with them.\n\n{}{}",
+                self.stateful_removals.len(),
+                stateful_removal_remedies(&self.stateful_removals).trim_end(),
+                migration,
             ));
         }
     }
@@ -1582,6 +1900,20 @@ pub struct DiffOpts {
     /// Reported, never fatal: diff mutates nothing.
     pub unresolved_credentials: Vec<String>,
     pub local: LocalInstallationPlan,
+    /// The chart `apply` would use, already materialized.
+    ///
+    /// Required, not optional: the stateful probe RENDERS this chart to decide
+    /// what survives, and diff answering that question against a different
+    /// chart than apply would use is the same two-surfaces-disagree defect in a
+    /// new place (#1352).
+    pub chart: String,
+    /// The version of the chart named by `chart`.
+    ///
+    /// Supplied by the caller rather than read from `artifacts::version()`
+    /// here: under `--chart` the rendered chart is not this CLI's own, and a
+    /// diff that renders one chart while reporting another as the target is the
+    /// same two-sources-of-truth defect in a new place (#1352).
+    pub chart_target: String,
 }
 
 /// Compare the file against the live release.
@@ -1594,7 +1926,20 @@ pub struct DiffOpts {
 /// and refusing to answer it there was the behaviour a shared-plan refactor
 /// introduced and a real run against a cluster exposed.
 pub async fn diff(opts: DiffOpts) -> Result<DiffOutput> {
-    let plan = complete_installation_plan(opts.local).await?;
+    let DiffOpts {
+        unresolved_credentials,
+        mut local,
+        chart,
+        chart_target,
+    } = opts;
+    // Before completing the plan, exactly as `apply` does: the probe renders
+    // THIS chart, and an empty ref would render nothing and call every live
+    // component gone.
+    local.up.chart = chart;
+    // `Run` unconditionally. `diff` has no `--allow-stateful-removal` to opt
+    // out with, and skipping the probe on, say, an absent release would
+    // recreate the disagreement: `apply` does not skip it either (#1352).
+    let plan = complete_installation_plan(local, StatefulProbe::Run).await?;
     // A second, independent read: the values plan says nothing about WHICH
     // chart consumes them, and a component renamed between chart versions
     // shows up in the entries below as an ordinary reset.
@@ -1609,15 +1954,31 @@ pub async fn diff(opts: DiffOpts) -> Result<DiffOutput> {
             entry.to = None;
         }
     }
-    disclose_unresolved_credentials(&mut entries, &plan.cfg, &opts.unresolved_credentials);
+    disclose_unresolved_credentials(&mut entries, &plan.cfg, &unresolved_credentials);
+    // Fail closed, exactly as `apply` does. `None` is NOT PROBED, and the
+    // schema defines `[]` as "the live StatefulSets were read and none are at
+    // risk" -- so mapping the unprobed case to `[]` would have `diff` state a
+    // fact it never established. That vacuous pass is the shape #1351 exists to
+    // close, and a `diff` that cannot say whether a store would be deleted must
+    // fail rather than answer `[]` (#1352). A future `Skip` caller therefore
+    // gets an error here, not a quiet diff.
+    let stateful = plan
+        .stateful
+        .context("the stateful-removal check did not run")?;
+    let stateful_removals = match stateful.verdict {
+        GuardVerdict::WouldRemove(removed) => removed,
+        GuardVerdict::Clear => Vec::new(),
+    };
     Ok(DiffOutput {
-        unresolved_credentials: opts.unresolved_credentials,
+        migration: stateful.migration,
+        unresolved_credentials,
         namespace: plan.cfg.install.namespace,
         release: plan.cfg.install.release,
         release_exists: plan.live.is_some(),
         chart_deployed,
-        chart_target: crate::artifacts::version().to_string(),
+        chart_target,
         entries,
+        stateful_removals,
     })
 }
 
@@ -2027,7 +2388,9 @@ mod diff_tests {
         .expect("configuration parses");
         let local = plan_installation(cfg, true).expect("installation plans");
 
-        let plan = complete_installation_plan(local)
+        // `Skip`: this fixture's `up.chart` is empty, so a probe would shell out
+        // to a real `kubectl` and `helm template ""`.
+        let plan = complete_installation_plan(local, StatefulProbe::Skip)
             .await
             .expect("completed plan");
 
@@ -2091,6 +2454,8 @@ mod diff_tests {
             chart_deployed: Some("curie-0.6.0".to_string()),
             chart_target: "0.6.0".to_string(),
             entries,
+            stateful_removals: Vec::new(),
+            migration: None,
         };
 
         let github_entry = out
@@ -2423,6 +2788,8 @@ mod diff_tests {
             chart_deployed: Some("curie-0.5.1".into()),
             chart_target: "0.6.0".into(),
             entries: vec![],
+            stateful_removals: Vec::new(),
+            migration: None,
         };
         assert!(out.chart_version_differs());
         let json = <DiffOutput as crate::ui::CliOutput>::to_json(&out);
@@ -2442,6 +2809,8 @@ mod diff_tests {
             chart_deployed: Some("curie-0.6.0".into()),
             chart_target: "0.6.0".into(),
             entries: vec![],
+            stateful_removals: Vec::new(),
+            migration: None,
         };
         assert!(!out.chart_version_differs());
     }
@@ -2457,6 +2826,8 @@ mod diff_tests {
             chart_deployed: None,
             chart_target: "0.6.0".into(),
             entries: vec![],
+            stateful_removals: Vec::new(),
+            migration: None,
         };
         assert!(!out.chart_version_differs());
     }
@@ -2494,6 +2865,8 @@ mod diff_tests {
                 &BTreeMap::from([("ui.deploy".to_string(), "false".to_string())]),
                 Some(&live(serde_json::json!({"ui": {"deploy": true}}))),
             ),
+            stateful_removals: Vec::new(),
+            migration: None,
         };
         let json = out.to_json();
         assert_eq!(json["changes"], serde_json::json!(1));

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -566,6 +566,11 @@ enum Command {
         /// Path to the installation file.
         #[arg(short = 'f', long = "file", default_value = "curie.yaml")]
         file: std::path::PathBuf,
+        /// Chart reference override, as `cluster up` takes. Diff RENDERS this
+        /// chart to detect stateful components the apply would delete, so point
+        /// it at the same chart `curie apply --chart` would use.
+        #[arg(long)]
+        chart: Option<String>,
     },
 }
 
@@ -3837,16 +3842,47 @@ async fn run(command: Option<Command>) -> Result<()> {
             let api = api_url.as_deref().zip(api_key.as_deref());
             emit(curie::doctor::doctor(&namespace, &release, api).await)
         }
-        Some(Command::Diff { file }) => {
+        Some(Command::Diff { file, chart }) => {
             let cfg = curie::installation::Installation::load(&file)?;
             // Lenient on purpose: `diff` mutates nothing, so a credential it
             // cannot resolve must not withhold the answer. See
             // installation::resolve_credentials_lenient.
             let (local, missing) = curie::installation::plan_installation_lenient(cfg)?;
+            // Resolved exactly as `Apply` does, so both verbs answer about the
+            // same chart. `resolve_chart` errors on the Dev channel with no
+            // `charts/curie` in cwd and its remedy text literally says "pass
+            // --chart", so the flag has to exist on this verb too (#1352).
+            let overridden = chart.is_some();
+            let resolved = artifacts::resolve_chart(
+                chart.as_deref(),
+                artifacts::Channel::current(),
+                artifacts::version(),
+                artifacts::cache_root,
+                std::path::Path::new("charts/curie").is_dir(),
+            )?;
+            // `false`, never `dry_run`-style `true`: `true` returns a
+            // `planned_target()` path that may not exist, and diff must actually
+            // render the chart rather than plan a fetch of it.
+            let chart = materialize_artifact(resolved, false, "chart").await?;
+            // The version REPORTED has to be the version RENDERED. Under
+            // `--chart` those are different charts, and reporting this CLI's
+            // own package version there would compare the deployed release
+            // against a chart the probe never looked at -- raising a false
+            // CHART VERSION MISMATCH, or suppressing a real one. That is the
+            // same two-sources-of-truth defect #1352 is about, in a new place.
+            // The default path keeps `artifacts::version()` exactly as before,
+            // so it makes no extra helm call.
+            let chart_target = if overridden {
+                curie::ops::chart_version(&chart).await?
+            } else {
+                artifacts::version().to_string()
+            };
             emit(
                 curie::installation::diff(curie::installation::DiffOpts {
                     local,
                     unresolved_credentials: missing,
+                    chart,
+                    chart_target,
                 })
                 .await?,
             )

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -2082,6 +2082,30 @@ pub(crate) async fn chart_stateful_components(
     Ok(parse_statefulset_components(&out))
 }
 
+/// The version declared by the chart at `chart`, read from its own `Chart.yaml`.
+///
+/// `helm show chart` accepts every reference form `--chart` does -- a
+/// directory, a `.tgz`, a repo ref -- so this is the version of the chart that
+/// was actually rendered rather than one guessed from the reference's spelling.
+///
+/// A non-zero exit is fatal on purpose: this feeds the CHART VERSION MISMATCH
+/// comparison, and failing open to a guessed version would raise (or suppress)
+/// that warning about a chart nothing looked at (#1352).
+pub async fn chart_version(chart: &str) -> Result<String> {
+    let cmd = OpsCommand::new("helm", vec![plain("show"), plain("chart"), plain(chart)]);
+    let (ok, out, err) = run_capture(&cmd).await?;
+    if !ok {
+        bail!("could not read the chart version of {chart}: {err}");
+    }
+    let chart_yaml: serde_json::Value = serde_norway::from_str(&out)
+        .with_context(|| format!("could not parse the Chart.yaml of {chart}"))?;
+    chart_yaml
+        .get("version")
+        .and_then(|version| version.as_str())
+        .map(str::to_string)
+        .with_context(|| format!("the Chart.yaml of {chart} declares no version"))
+}
+
 /// The component identities of StatefulSets in a multi-document helm render.
 ///
 /// Split-and-parse rather than a regex: a `kind: StatefulSet` line can appear

--- a/cli/tests/installation_plan_parity.rs
+++ b/cli/tests/installation_plan_parity.rs
@@ -139,6 +139,15 @@ if [ "$1" = get ] && [ "$2" = values ]; then
             ;;
     esac
 fi
+if [ "$1" = show ] && [ "$2" = chart ]; then
+    # Only `curie diff --chart` reaches this: the default path reports
+    # `artifacts::version()` and makes no such call at all. Answered from the
+    # real Chart.yaml the flag points at rather than an invented version --
+    # the version REPORTED has to be the version RENDERED, and a stub that made
+    # one up would hide a regression that swapped them (#1352).
+    cat "$3/Chart.yaml"
+    exit 0
+fi
 if [ "$1" = template ]; then
     case " $* " in
         *" --show-only templates/preflight-gvisor.yaml "*)
@@ -658,10 +667,16 @@ exit 0
     }
 
     fn diff(&self, env: &[(&str, &str)]) -> Output {
-        self.run(
-            &["diff", "--file", self.file.to_str().expect("UTF 8 path")],
-            env,
-        )
+        self.diff_with(&[], env)
+    }
+
+    /// The same `--json` diff with extra argv, so a test can exercise a flag
+    /// rather than only the default resolution. `diff` delegates here, so no
+    /// existing call site changes.
+    fn diff_with(&self, extra: &[&str], env: &[(&str, &str)]) -> Output {
+        let mut args = vec!["diff", "--file", self.file.to_str().expect("UTF 8 path")];
+        args.extend_from_slice(extra);
+        self.run(&args, env)
     }
 
     /// `curie diff` without `--json`: the operator-facing render.
@@ -989,6 +1004,29 @@ fn live_rustfs_statefulset() -> String {
             "metadata": {"name": "parity-rustfs"},
             "spec": {"selector": {"matchLabels": {"app.kubernetes.io/component": "rustfs"}}}
         }]
+    })
+    .to_string()
+}
+
+/// A live release running the store the default render ALSO produces, beside a
+/// bundled `postgres` that render drops. The store half is what makes this
+/// distinct from `live_postgres_statefulset`: both sides run `rustfs`, so the
+/// upgrade renames no store and `migration` is `null` while the removal list is
+/// not empty -- the values-gated drop `--migrate-store` cannot carry (#1352).
+fn live_rustfs_and_postgres_statefulsets() -> String {
+    json!({
+        "apiVersion": "v1",
+        "kind": "List",
+        "items": [
+            {
+                "metadata": {"name": "parity-rustfs"},
+                "spec": {"selector": {"matchLabels": {"app.kubernetes.io/component": "rustfs"}}}
+            },
+            {
+                "metadata": {"name": "parity-postgres"},
+                "spec": {"selector": {"matchLabels": {"app.kubernetes.io/component": "postgres"}}}
+            }
+        ]
     })
     .to_string()
 }
@@ -3548,5 +3586,354 @@ fn an_unreadable_cluster_fails_the_diff_rather_than_reporting_no_removals() {
     assert!(
         !forbidden_message.to_ascii_lowercase().contains("apply"),
         "the shared guard's context must stay verb neutral: {forbidden_error}"
+    );
+}
+
+/// The `migration` field `diff --json` must ALWAYS carry, as an object or as
+/// `null`.
+///
+/// A missing key panics rather than reading as `null`: "this CLI does not
+/// report store renames" and "this upgrade renames no store" are the two
+/// answers the field exists to separate, and letting an absent key stand in for
+/// the second would make every assertion below pass against a payload that
+/// never grew the field.
+fn migration(diff: &Value) -> &Value {
+    diff.get("migration")
+        .unwrap_or_else(|| panic!("diff must always emit a migration key: {diff}"))
+}
+
+#[test]
+fn diff_reports_the_store_rename_migrate_store_carries_the_data_across() {
+    // The discriminator the removals list alone cannot supply, and the reason
+    // the `component_gone` remedy is not universal. Here the live release runs
+    // `minio` while the target render produces `rustfs`: a store SWAP, which is
+    // exactly the case `curie apply --migrate-store` carries the objects
+    // across. It reports the same `component_gone` cause as the values-gated
+    // drop below, and only `migration` tells the two apart.
+    //
+    // Red on revert through the `expect` in `migration`: without the field the
+    // payload carries the removal and nothing else, so a consumer -- human or
+    // agent -- reading `component_gone` has to guess whether the flag the
+    // remedy names can help, and half of them guess wrong (#1352).
+    let fixture = HelmFixture::new(
+        installation_for_the_stateful_guard(),
+        HelmValuesResponse::Absent,
+    );
+    let live = live_minio_statefulset();
+
+    let diff = json_output(
+        fixture.diff(&[("CURIE_TEST_KUBECTL_STS", live.as_str())]),
+        "diff",
+    );
+
+    // COMPONENT names on both sides, never resource names: the live object is
+    // `parity-minio`, and a `migration` reporting that could not be matched
+    // against `minio` by any consumer, since the fullname moves under a
+    // `nameOverride` while the component does not.
+    assert_eq!(
+        migration(&diff),
+        &json!({"from": "minio", "to": "rustfs"}),
+        "the store swap must be reported as the component pair `--migrate-store` moves between: {diff}"
+    );
+
+    let removal = stateful_removal(&diff, "parity-minio");
+    assert_eq!(
+        removal["component"], "minio",
+        "the removal must carry the component identity the migration is keyed on: {removal}"
+    );
+    assert_eq!(
+        removal["cause"], "component_gone",
+        "the target chart renders rustfs, so the live minio component is gone entirely: {removal}"
+    );
+    assert!(
+        removal.get("renamed_to").is_none(),
+        "a component that is gone has no rename target: {removal}"
+    );
+}
+
+#[test]
+fn diff_reports_no_migration_for_a_values_gated_stateful_drop() {
+    // The issue's own reproduction, and the half `--migrate-store` cannot
+    // reach. The live release runs `rustfs` -- the SAME store the target render
+    // produces, so no store is renamed -- beside a bundled `postgres` the
+    // render drops, which is what a curie.yaml that stops deploying postgres
+    // (the chart's BYO gate) does to a running database.
+    //
+    // `migration: null` beside a NON EMPTY `stateful_removals` is the payload
+    // that says there is no automatic carry: `curie apply --migrate-store`
+    // copies OBJECT STORE buckets only, so it has nothing to move here and
+    // apply keeps refusing until the file is fixed. Pre-fix a consumer could
+    // not tell this from the store swap above at all -- both reported the same
+    // `component_gone`, and only one of them has a flag that helps (#1352).
+    //
+    // Red on revert through the `expect` in `migration`, and red on a fix that
+    // reported a migration unconditionally: `null` here is a fact about this
+    // upgrade, not a missing value.
+    let fixture = HelmFixture::new(
+        installation_for_the_stateful_guard(),
+        HelmValuesResponse::Absent,
+    );
+    let live = live_rustfs_and_postgres_statefulsets();
+
+    let diff = json_output(
+        fixture.diff(&[("CURIE_TEST_KUBECTL_STS", live.as_str())]),
+        "diff",
+    );
+
+    assert_eq!(
+        migration(&diff),
+        &Value::Null,
+        "both sides run rustfs, so this upgrade renames no store: {diff}"
+    );
+    let removals = stateful_removals(&diff);
+    assert_eq!(
+        removals.len(),
+        1,
+        "the live postgres is dropped while the store survives in place: {diff}"
+    );
+    let removal = stateful_removal(&diff, "parity-postgres");
+    assert_eq!(
+        removal["component"], "postgres",
+        "the dropped component is the database, not the store: {removal}"
+    );
+    assert_eq!(
+        removal["cause"], "component_gone",
+        "the target chart does not render postgres at all: {removal}"
+    );
+    // The control that keeps `migration: null` meaningful: a run that reported
+    // the store as removed too would make the null merely wrong rather than
+    // informative.
+    assert!(
+        !removals
+            .iter()
+            .any(|reported| reported["name"] == "parity-rustfs"),
+        "the store the render also produces is not at risk: {diff}"
+    );
+}
+
+#[test]
+fn diff_does_not_offer_a_flag_apply_would_refuse_for_an_uncarriable_removal() {
+    // The #1352 / #1501 interaction. #1352 made `diff` reuse
+    // `stateful_removal_remedies` -- the helper apply's refusal composes -- so
+    // the two surfaces cannot name different fixes. #1501 then established that
+    // `--migrate-store` carries the OBJECT STORE and nothing else, and made
+    // `apply --migrate-store` REFUSE any batch holding anything else. Between
+    // them, a remedy that offered `--migrate-store` for EVERY `component_gone`
+    // told the operator of a dropped `postgres` to re-run with a flag apply
+    // then refuses: a brand new diff-vs-apply disagreement, which is the exact
+    // defect class #1352 exists to close.
+    //
+    // The fixture is the issue's own reproduction: live `rustfs` (the store the
+    // target render also produces, so nothing is being migrated between) beside
+    // a bundled `postgres` the render drops. Red on revert on the first
+    // assertion -- the pre-fix remedy names `--migrate-store` unconditionally.
+    let fixture = HelmFixture::new(
+        installation_for_the_stateful_guard(),
+        HelmValuesResponse::Absent,
+    );
+    let live = live_rustfs_and_postgres_statefulsets();
+    let env = [("CURIE_TEST_KUBECTL_STS", live.as_str())];
+
+    let human = fixture.diff_human(&env);
+    let rendered = format!(
+        "{}{}",
+        String::from_utf8_lossy(&human.stdout),
+        String::from_utf8_lossy(&human.stderr)
+    );
+
+    assert!(
+        !rendered.contains("re-run with --migrate-store"),
+        "diff must not send the operator to the flag apply refuses for this batch:\n{rendered}"
+    );
+    assert!(
+        !rendered.contains("apply will carry the data across itself"),
+        "there is nothing --migrate-store can carry here, so it must not be promised:\n{rendered}"
+    );
+    // The remedy that replaces it has to be actionable, not merely absent: the
+    // component's identity, and where the drop actually comes from.
+    assert!(
+        rendered.contains("parity-postgres") && rendered.contains("postgres"),
+        "the render must name the component whose data is at risk:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("carries the OBJECT STORE and nothing else"),
+        "the render must say why --migrate-store is not the fix here:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("`<component>.deploy=false`"),
+        "the render must point at the values that drop the component:\n{rendered}"
+    );
+
+    // The other half of the parity claim: the SAME file and the SAME cluster,
+    // through the flag diff no longer recommends. A second fixture because the
+    // first one's call log has already recorded the diff run.
+    let apply_fixture = HelmFixture::new(
+        installation_for_the_stateful_guard(),
+        HelmValuesResponse::Absent,
+    );
+    let apply = apply_fixture.apply(&["--migrate-store"], &env);
+    assert!(
+        !apply.status.success(),
+        "apply --migrate-store must refuse the batch diff declined to recommend it for; stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&apply.stdout),
+        String::from_utf8_lossy(&apply.stderr)
+    );
+    let error = json_error(apply, "apply");
+    let message = error["error"].as_str().expect("apply error message string");
+    assert!(
+        message.contains("parity-postgres"),
+        "apply's refusal must name the same component diff reported: {error}"
+    );
+    assert!(
+        message.contains("cannot carry"),
+        "apply's refusal must be the uncarriable one, not the generic guard: {error}"
+    );
+    assert!(
+        !apply_fixture.calls().contains("HELM_CALL: upgrade"),
+        "the refusal must precede the irreversible upgrade:\n{}",
+        apply_fixture.calls()
+    );
+}
+
+#[test]
+fn the_diff_summary_does_not_claim_a_refused_file_would_be_applied() {
+    // `N change(s) would be applied` on a file `curie apply` REFUSES is the
+    // original defect's wording, and folding the removals into `changes()`
+    // without touching this line merely made it a bigger number telling the
+    // same lie. The operator reads the last summary line and approves; the
+    // apply then exits 1 having applied nothing.
+    //
+    // Red on revert on the `would be applied` half specifically: the REFUSE
+    // note below the summary already existed in the first pass, so a run that
+    // kept the old summary line would still satisfy an assertion that only
+    // looked for `REFUSE` anywhere in the output. The count must SURVIVE --
+    // automation and humans both read it -- so this pins the outcome, not the
+    // number (#1352).
+    let fixture = HelmFixture::new(
+        installation_for_the_stateful_guard(),
+        HelmValuesResponse::Absent,
+    );
+    let live = live_postgres_statefulset();
+
+    let human = fixture.diff_human(&[("CURIE_TEST_KUBECTL_STS", live.as_str())]);
+    let rendered = format!(
+        "{}{}",
+        String::from_utf8_lossy(&human.stdout),
+        String::from_utf8_lossy(&human.stderr)
+    );
+
+    assert!(
+        !rendered.contains("would be applied"),
+        "nothing about a file apply refuses would be applied:\n{rendered}"
+    );
+    let summary = rendered
+        .lines()
+        .find(|line| line.contains("change(s)"))
+        .unwrap_or_else(|| panic!("the render must still summarise the change count:\n{rendered}"));
+    // The expected count comes from the payload the SAME input produces rather
+    // than a literal, so an unrelated chart default gaining or losing a value
+    // cannot make this test lie in either direction -- and so the human and
+    // JSON projections are pinned to the same number, which is the parity claim
+    // #1352 rests on. A second fixture because the first one's call log has
+    // already recorded the human run.
+    let json_fixture = HelmFixture::new(
+        installation_for_the_stateful_guard(),
+        HelmValuesResponse::Absent,
+    );
+    let diff = json_output(
+        json_fixture.diff(&[("CURIE_TEST_KUBECTL_STS", live.as_str())]),
+        "diff",
+    );
+    let changes = diff["changes"].as_u64().expect("changes is an integer");
+    assert!(
+        summary.starts_with(&format!("{changes} change(s)")),
+        "the count must still be reported, and must be the count the payload carries: {summary}"
+    );
+    assert!(
+        summary.contains(&format!(
+            "including {} stateful removal(s)",
+            stateful_removals(&diff).len()
+        )),
+        "the summary must say how much of that count is destruction: {summary}"
+    );
+    assert!(
+        summary.contains("REFUSE"),
+        "the summary line itself must state the outcome, not leave it to a note further down: {summary}"
+    );
+}
+
+#[test]
+fn diff_answers_the_same_against_an_explicitly_passed_chart() {
+    // `--chart` exists on this verb because diff RENDERS the chart to decide
+    // what survives, and `resolve_chart`'s own remedy text on a dev build with
+    // no `charts/curie` in cwd literally says "pass --chart" (#1352). The
+    // fixture runs from the repository root, so the DEFAULT path already
+    // resolves `charts/curie` implicitly -- which is exactly why the flag needs
+    // its own coverage: every other diff test would stay green with the
+    // argument unwired.
+    //
+    // Red on revert two ways: a `--chart` clap surface that does not exist
+    // fails argument parsing, and one that parses but is dropped before the
+    // render would answer from the implicitly resolved chart, which this test
+    // cannot distinguish -- so the assertion is that the OVERRIDDEN path
+    // produces the same removal, i.e. the flag reaches a chart that renders.
+    let default_fixture = HelmFixture::new(
+        installation_for_the_stateful_guard(),
+        HelmValuesResponse::Absent,
+    );
+    let live = live_postgres_statefulset();
+    let env = [("CURIE_TEST_KUBECTL_STS", live.as_str())];
+    let expected = json_output(default_fixture.diff(&env), "diff");
+
+    let chart = repo_root().join("charts/curie");
+    let overridden_fixture = HelmFixture::new(
+        installation_for_the_stateful_guard(),
+        HelmValuesResponse::Absent,
+    );
+    let overridden = json_output(
+        overridden_fixture.diff_with(
+            &["--chart", chart.to_str().expect("UTF 8 chart path")],
+            &env,
+        ),
+        "diff",
+    );
+
+    assert_eq!(
+        stateful_removals(&overridden),
+        stateful_removals(&expected),
+        "an explicit chart must answer the stateful question exactly as the resolved default does: {overridden}"
+    );
+    assert_eq!(
+        migration(&overridden),
+        migration(&expected),
+        "the store rename is read from the same render, so it cannot differ either: {overridden}"
+    );
+    // The flag has to reach the RESOLUTION, not merely parse. `helm show chart`
+    // fires on the overridden path ONLY -- the default reports
+    // `artifacts::version()` and never asks -- so this is the one call that
+    // distinguishes "the argument was honoured" from "the argument was accepted
+    // and dropped", which the identical answers above cannot.
+    let calls = overridden_fixture.calls();
+    assert!(
+        calls.contains(&format!(
+            "HELM_CALL: show chart {}",
+            chart.to_str().expect("UTF 8 chart path")
+        )),
+        "the version REPORTED must be read from the chart the flag named:\n{calls}"
+    );
+    assert!(
+        !default_fixture.calls().contains("HELM_CALL: show chart"),
+        "the default path must stay exactly as it was, with no extra helm call:\n{}",
+        default_fixture.calls()
+    );
+    // And it has to reach the RENDER too: the chart the probe renders is the
+    // chart apply would use, and a diff rendering one chart while reporting
+    // another is the two-sources-of-truth defect in a new place.
+    assert!(
+        calls.contains(&format!(
+            "HELM_CALL: template parity {}",
+            chart.to_str().expect("UTF 8 chart path")
+        )),
+        "the overridden chart must actually be the one rendered:\n{calls}"
     );
 }

--- a/cli/tests/installation_plan_parity.rs
+++ b/cli/tests/installation_plan_parity.rs
@@ -558,6 +558,19 @@ exit 0
     }
 
     fn run(&self, args: &[&str], env: &[(&str, &str)]) -> Output {
+        self.run_with_globals(&["--json"], args, env)
+    }
+
+    /// The same stubbed run with NO global flags, so a test can assert on the
+    /// HUMAN render rather than the `--json` payload. `render` and `to_json`
+    /// are two independent projections of the same output object, and a
+    /// removal reported in one but not the other is exactly the surface
+    /// disagreement #1352 is about.
+    fn run_human(&self, args: &[&str], env: &[(&str, &str)]) -> Output {
+        self.run_with_globals(&[], args, env)
+    }
+
+    fn run_with_globals(&self, globals: &[&str], args: &[&str], env: &[(&str, &str)]) -> Output {
         let mut paths = vec![self.temp.path().join("bin")];
         if let Some(current) = std::env::var_os("PATH") {
             paths.extend(std::env::split_paths(&current));
@@ -567,7 +580,7 @@ exit 0
         let mut command = Command::new(bin());
         command
             .current_dir(repo_root())
-            .arg("--json")
+            .args(globals)
             .args(args)
             .env("PATH", path)
             .env("CURIE_TEST_CALL_LOG", &self.log)
@@ -646,6 +659,14 @@ exit 0
 
     fn diff(&self, env: &[(&str, &str)]) -> Output {
         self.run(
+            &["diff", "--file", self.file.to_str().expect("UTF 8 path")],
+            env,
+        )
+    }
+
+    /// `curie diff` without `--json`: the operator-facing render.
+    fn diff_human(&self, env: &[(&str, &str)]) -> Output {
+        self.run_human(
             &["diff", "--file", self.file.to_str().expect("UTF 8 path")],
             env,
         )
@@ -881,6 +902,23 @@ fn live_minio_statefulset() -> String {
     .to_string()
 }
 
+/// A live release running the bundled `postgres`, in the shape
+/// `kubectl get statefulset -o json` returns it. The default helm stub renders
+/// `rustfs` and nothing else, so against that render this component is
+/// `ComponentGone` -- the issue's reproduction, where a curie.yaml that stops
+/// deploying postgres reads as an ordinary values add.
+fn live_postgres_statefulset() -> String {
+    json!({
+        "apiVersion": "v1",
+        "kind": "List",
+        "items": [{
+            "metadata": {"name": "parity-postgres"},
+            "spec": {"selector": {"matchLabels": {"app.kubernetes.io/component": "postgres"}}}
+        }]
+    })
+    .to_string()
+}
+
 fn live_mixed_store_statefulsets() -> String {
     json!({
         "apiVersion": "v1",
@@ -1054,9 +1092,19 @@ fn existing_values_absent_is_fresh_for_all_consumers() {
     );
     let diff = json_output(fixture.diff(&[]), "diff");
     assert_eq!(diff["release_exists"], false, "{diff}");
+    // #1352 grew this list by exactly ONE call. `diff` now runs the same
+    // stateful-removal probe `apply` does, from the shared plan, so it reads the
+    // live StatefulSets between the values read and the deployed-chart read.
+    // The fixture's default kubectl answer is the empty List, and the guard
+    // short-circuits on an empty live list, so an absent release never reaches
+    // `helm template` -- asserting a render here would fail a correct
+    // implementation and pressure removal of the short circuit that saves a
+    // render on every fresh apply.
     assert_eq!(
         fixture.calls().trim(),
-        "HELM_CALL: get values parity -n parity -o json\nHELM_CALL: list -n parity -o json"
+        "HELM_CALL: get values parity -n parity -o json\n\
+         KUBECTL_CALL: get statefulset -n parity -o json\n\
+         HELM_CALL: list -n parity -o json"
     );
 }
 
@@ -3199,5 +3247,306 @@ fn a_namespace_with_no_statefulsets_still_passes_the_guard() {
     assert!(
         calls.contains("HELM_CALL: upgrade"),
         "the upgrade must run:\n{calls}"
+    );
+}
+
+/// The `stateful_removals` array `diff --json` must ALWAYS carry, even empty.
+///
+/// `expect` rather than `unwrap_or(&[])` on purpose: an omitted key is the
+/// pre-#1352 shape, and defaulting it to an empty slice would let every
+/// assertion below pass against a payload that never grew the field.
+fn stateful_removals(diff: &Value) -> &Vec<Value> {
+    diff["stateful_removals"]
+        .as_array()
+        .unwrap_or_else(|| panic!("diff must always emit a stateful_removals array: {diff}"))
+}
+
+/// The one removal naming `name`, or a panic naming what was reported instead.
+fn stateful_removal<'a>(diff: &'a Value, name: &str) -> &'a Value {
+    stateful_removals(diff)
+        .iter()
+        .find(|removal| removal["name"] == name)
+        .unwrap_or_else(|| panic!("no stateful removal reported for {name}: {diff}"))
+}
+
+/// How many entries `changes` counts on its own, derived from the payload the
+/// run actually emitted rather than a hardcoded total, so the arithmetic
+/// relationship is what is pinned and an unrelated chart-default gaining or
+/// losing a value cannot make this test lie in either direction.
+fn change_kind_entries(diff: &Value) -> usize {
+    diff["entries"]
+        .as_array()
+        .expect("diff entries array")
+        .iter()
+        .filter(|entry| {
+            matches!(
+                entry["kind"].as_str().expect("diff entry kind"),
+                "add" | "change" | "reset to chart default" | "unknown"
+            )
+        })
+        .count()
+}
+
+#[test]
+fn diff_reports_the_stateful_removal_apply_refuses_on() {
+    // AC1, the issue's reproduction and the core of #1352. `diff()` called
+    // `complete_installation_plan` + `fetch_release_chart` and nothing else, so
+    // it never read a StatefulSet: a file that would DELETE a live stateful
+    // component rendered as an ordinary values change, exit 0, while `apply` on
+    // the SAME file and the SAME cluster exited 1 refusing. Two surfaces, one
+    // input, opposite answers.
+    //
+    // Red on revert: without the fix `stateful_removals` is absent entirely, so
+    // the `expect` in `stateful_removals` panics. Note that a bare
+    // `changes > 0` assertion would pass TODAY -- the values delta already
+    // counts -- which is why the count is pinned as arithmetic over the
+    // payload's own entries plus the removals, not as a threshold.
+    let fixture = HelmFixture::new(
+        installation_for_the_stateful_guard(),
+        HelmValuesResponse::Absent,
+    );
+    let live = live_postgres_statefulset();
+    let env = [("CURIE_TEST_KUBECTL_STS", live.as_str())];
+
+    let diff = json_output(fixture.diff(&env), "diff");
+
+    let removals = stateful_removals(&diff);
+    assert_eq!(
+        removals.len(),
+        1,
+        "the live postgres StatefulSet is the only removal in this render: {diff}"
+    );
+    let removal = stateful_removal(&diff, "parity-postgres");
+    assert_eq!(
+        removal["component"], "postgres",
+        "the removal must carry the component identity the guard matched on: {removal}"
+    );
+    assert_eq!(
+        removal["cause"], "component_gone",
+        "the target chart does not render postgres at all: {removal}"
+    );
+    assert!(
+        removal.get("renamed_to").is_none(),
+        "a component that is gone has no rename target: {removal}"
+    );
+    assert_eq!(
+        diff["changes"].as_u64().expect("changes is an integer") as usize,
+        change_kind_entries(&diff) + removals.len(),
+        "a removal that is not counted is a removal an agent consumer gating on `changes` never sees: {diff}"
+    );
+
+    // The human render is an independent projection of the same output object;
+    // a removal reported only in the JSON leaves the operator reading `diff`
+    // in a terminal with the exact pre-fix experience.
+    let human = fixture.diff_human(&env);
+    let rendered = format!(
+        "{}{}",
+        String::from_utf8_lossy(&human.stdout),
+        String::from_utf8_lossy(&human.stderr)
+    );
+    assert!(
+        rendered.contains("parity-postgres"),
+        "the render must name the live resource an operator recognises:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("DELETED"),
+        "the render must say the component would be DELETED, not merely changed:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("curie apply") && rendered.contains("REFUSE"),
+        "the render must say `curie apply` will refuse, so the operator is not surprised by exit 1:\n{rendered}"
+    );
+
+    // The other half of the parity claim: the same file and the same cluster,
+    // through `apply`. A second fixture because the first one's call log has
+    // already recorded the diff run.
+    let apply_fixture = HelmFixture::new(
+        installation_for_the_stateful_guard(),
+        HelmValuesResponse::Absent,
+    );
+    let apply = apply_fixture.apply(&[], &env);
+    assert_eq!(
+        apply.status.code(),
+        Some(1),
+        "apply must still refuse the same input; stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&apply.stdout),
+        String::from_utf8_lossy(&apply.stderr)
+    );
+    let error = json_error(apply, "apply");
+    let message = error["error"].as_str().expect("apply error message string");
+    assert!(
+        message.contains("refusing to apply") && message.contains("parity-postgres"),
+        "apply's refusal must name the same resource diff reported: {error}"
+    );
+    assert!(
+        !apply_fixture.calls().contains("HELM_CALL: upgrade"),
+        "the refusal must stop before the upgrade:\n{}",
+        apply_fixture.calls()
+    );
+}
+
+#[test]
+fn diff_reports_a_renamed_stateful_component_with_its_rename_target() {
+    // AC2, the #1323 shape. Here the chart DOES render postgres -- under
+    // `parity-curie-postgres` rather than the live `parity-postgres`, which is
+    // what a curie.yaml that does not reproduce the release's `nameOverride`
+    // produces. Helm deletes the old object and creates the new one empty
+    // beside the orphaned volumes, so it is exactly as destructive as a drop,
+    // and the two causes have OPPOSITE remedies (`--migrate-store` vs.
+    // declaring `nameOverride`).
+    //
+    // Red on revert twice over: `stateful_removals` does not exist pre-fix, and
+    // a fix that collapsed the removals to bare names would lose the cause the
+    // remedy is chosen from. The mixed render stub is load-bearing -- against
+    // the default rustfs-only render a live postgres is `ComponentGone`, so an
+    // AC2 written without it is a mislabelled AC1 and a rename regression still
+    // ships.
+    let fixture = HelmFixture::new(
+        installation_for_the_stateful_guard(),
+        HelmValuesResponse::Absent,
+    );
+    let live = live_mixed_store_statefulsets();
+
+    let diff = json_output(
+        fixture.diff(&[
+            ("CURIE_TEST_HELM_MIXED_STATEFULSETS", "1"),
+            ("CURIE_TEST_KUBECTL_STS", live.as_str()),
+        ]),
+        "diff",
+    );
+
+    let renamed = stateful_removal(&diff, "parity-postgres");
+    assert_eq!(
+        renamed["component"], "postgres",
+        "the rename is same-component, different-name: {renamed}"
+    );
+    assert_eq!(
+        renamed["cause"], "renamed",
+        "a component the render keeps under another name is a rename, not a drop: {renamed}"
+    );
+    assert_eq!(
+        renamed["renamed_to"], "parity-curie-postgres",
+        "without the rename target the operator cannot tell which name to declare: {renamed}"
+    );
+
+    // The same payload must still distinguish the other cause, or the two
+    // remedies collapse into one.
+    let gone = stateful_removal(&diff, "parity-minio");
+    assert_eq!(gone["cause"], "component_gone", "{gone}");
+    assert!(
+        gone.get("renamed_to").is_none(),
+        "`renamed_to` belongs only to the rename cause: {gone}"
+    );
+
+    assert_eq!(
+        diff["changes"].as_u64().expect("changes is an integer") as usize,
+        change_kind_entries(&diff) + stateful_removals(&diff).len(),
+        "every removal must be counted, renames included: {diff}"
+    );
+}
+
+#[test]
+fn diff_reports_no_stateful_removal_when_live_and_rendered_agree() {
+    // AC3, the no-false-alarm control. A guard that cries wolf teaches
+    // operators to pass the override flag by reflex, which is worse than no
+    // guard at all for the one case that is real. The live release runs
+    // `rustfs` under exactly the name the default render produces, so there is
+    // nothing to report.
+    //
+    // Red on revert through the `expect` in `stateful_removals`: the key must
+    // be PRESENT as `[]`. An omitted optional key would re-hide the field from
+    // every consumer that looks for it, and would make this test's emptiness
+    // assertion vacuously true.
+    let fixture = HelmFixture::new(
+        installation_for_the_stateful_guard(),
+        HelmValuesResponse::Absent,
+    );
+    let live = live_rustfs_statefulset();
+
+    let diff = json_output(
+        fixture.diff(&[("CURIE_TEST_KUBECTL_STS", live.as_str())]),
+        "diff",
+    );
+
+    assert!(
+        stateful_removals(&diff).is_empty(),
+        "a release whose live components match the render loses nothing: {diff}"
+    );
+    assert_eq!(
+        diff["changes"].as_u64().expect("changes is an integer") as usize,
+        change_kind_entries(&diff),
+        "with no removals `changes` must stay exactly the entry count it always was: {diff}"
+    );
+}
+
+#[test]
+fn an_unreadable_cluster_fails_the_diff_rather_than_reporting_no_removals() {
+    // AC5, the strongest red-on-revert available: pre-fix `diff` never calls
+    // kubectl at all, so both of these runs currently produce a SUCCESSFUL
+    // diff reporting no removals -- the #1351 vacuous-pass shape, pointed at
+    // the read-only surface. "I could not find out" must never render as
+    // "nothing would be deleted", because that is the answer an operator
+    // approves an apply on.
+    //
+    // The values response is an EXISTING release: an unreadable cluster is
+    // interesting precisely when there is a live release with data to lose.
+    let live_values = || {
+        HelmValuesResponse::Object(json!({
+            "api": {"githubToken": "ghp-live-token"}
+        }))
+    };
+
+    // ADR-0021's exit-code contract: an unreachable apiserver is exit 3
+    // Transient (retry the same argv), because an apiserver rolling restart
+    // clears on its own.
+    let fixture = HelmFixture::new(installation_for_the_stateful_guard(), live_values());
+    let output = fixture.diff(&[("CURIE_TEST_KUBECTL_FAIL", "1")]);
+    assert_eq!(
+        output.status.code(),
+        Some(3),
+        "an unreachable apiserver is transient, not a clean diff; stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let error = json_error(output, "diff");
+    let message = error["error"].as_str().expect("error message string");
+    assert!(
+        message.contains("parity"),
+        "the failure must name the namespace it could not read: {error}"
+    );
+    assert!(
+        message.contains("The connection to the server localhost:8080 was refused"),
+        "the failure must carry kubectl's own words: {error}"
+    );
+    // R4: the guard's framing is now SHARED by apply and diff, so wording that
+    // names one verb reports a check the other caller was not performing. A
+    // `curie diff` that says "this apply" is the seam leaking.
+    assert!(
+        !message.to_ascii_lowercase().contains("apply"),
+        "the shared guard's context must stay verb neutral: {error}"
+    );
+
+    // Exit 1 Failure, not 3: a permission denial will not clear on its own, so
+    // telling an automation loop to retry the same argv is wrong advice.
+    let forbidden_fixture = HelmFixture::new(installation_for_the_stateful_guard(), live_values());
+    let forbidden = forbidden_fixture.diff(&[("CURIE_TEST_KUBECTL_FORBIDDEN", "1")]);
+    assert_eq!(
+        forbidden.status.code(),
+        Some(1),
+        "a Forbidden cluster read is permanent, not transient or a silent success; stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&forbidden.stdout),
+        String::from_utf8_lossy(&forbidden.stderr)
+    );
+    let forbidden_error = json_error(forbidden, "diff");
+    let forbidden_message = forbidden_error["error"]
+        .as_str()
+        .expect("error message string");
+    assert!(
+        forbidden_message.contains("cannot list resource \"statefulsets\""),
+        "the failure must carry kubectl's own Forbidden wording, so an RBAC problem reads differently from an unreachable cluster: {forbidden_error}"
+    );
+    assert!(
+        !forbidden_message.to_ascii_lowercase().contains("apply"),
+        "the shared guard's context must stay verb neutral: {forbidden_error}"
     );
 }

--- a/cli/tests/json_contract.rs
+++ b/cli/tests/json_contract.rs
@@ -1111,9 +1111,18 @@ fn diff_output_validates() {
         chart_deployed: Some("curie-0.5.1".to_string()),
         chart_target: "0.6.0".to_string(),
         entries,
+        // #1352: the common case is nothing to lose, and the payload must still
+        // carry the key so a consumer that reads it cannot mistake "not
+        // reported" for "no removals".
+        stateful_removals: Vec::new(),
     };
     let json = out.to_json();
     assert_valid("diff.schema.json", &json);
+    assert_eq!(
+        json["stateful_removals"],
+        serde_json::json!([]),
+        "an empty removal list must still be emitted as an array: {json}"
+    );
 
     // Every classification the schema enumerates must be reachable from a real
     // plan, or the enum is documenting states the code cannot produce.
@@ -1157,6 +1166,84 @@ fn diff_output_validates() {
     assert_eq!(
         unknown["unresolved_credential"],
         "CURIE_1426_GITHUB_CREDENTIAL"
+    );
+}
+
+/// #1352: the schema addition has to be EXERCISED, not merely accepted. A
+/// removal-carrying payload is the shape an agent consumer gates a destructive
+/// apply on, and `RemovalCause` has no serde derive -- `to_json` writes the
+/// encoding by hand, so nothing but this test holds the two cause spellings and
+/// the conditional `renamed_to` in place.
+#[test]
+fn diff_output_with_stateful_removals_validates() {
+    let out = curie::installation::DiffOutput {
+        unresolved_credentials: Vec::new(),
+        namespace: "acme-bot".to_string(),
+        release: "acme-bot".to_string(),
+        release_exists: true,
+        chart_deployed: Some("curie-0.6.0".to_string()),
+        chart_target: "0.6.0".to_string(),
+        entries: vec![curie::installation::DiffEntry {
+            key: "worker.replicas".to_string(),
+            kind: curie::installation::DiffKind::Change,
+            from: Some("1".to_string()),
+            to: Some("2".to_string()),
+            unresolved_credential: None,
+        }],
+        stateful_removals: vec![
+            // The chart does not render this component at all: a chart version
+            // renamed or dropped it, and `--migrate-store` is the remedy.
+            curie::ops::StatefulRemoval {
+                name: "acme-bot-minio".to_string(),
+                component: "minio".to_string(),
+                cause: curie::ops::RemovalCause::ComponentGone,
+            },
+            // The component survives under another resource name: a values
+            // difference, whose remedy is declaring `nameOverride` instead.
+            curie::ops::StatefulRemoval {
+                name: "acme-bot-postgres".to_string(),
+                component: "postgres".to_string(),
+                cause: curie::ops::RemovalCause::RenamedTo("acme-bot-curie-postgres".to_string()),
+            },
+        ],
+    };
+
+    let json = out.to_json();
+    assert_valid("diff.schema.json", &json);
+
+    let removals = json["stateful_removals"]
+        .as_array()
+        .expect("stateful_removals is an array");
+    assert_eq!(
+        removals.len(),
+        2,
+        "both removals must survive to_json: {json}"
+    );
+
+    let gone = &removals[0];
+    assert_eq!(gone["name"], "acme-bot-minio");
+    assert_eq!(gone["component"], "minio");
+    assert_eq!(gone["cause"], "component_gone");
+    assert!(
+        gone.get("renamed_to").is_none(),
+        "a component that is gone has no rename target: {gone}"
+    );
+
+    let renamed = &removals[1];
+    assert_eq!(renamed["name"], "acme-bot-postgres");
+    assert_eq!(renamed["component"], "postgres");
+    assert_eq!(renamed["cause"], "renamed");
+    assert_eq!(
+        renamed["renamed_to"], "acme-bot-curie-postgres",
+        "the rename target is the half the operator needs to fix their file: {renamed}"
+    );
+
+    // The count an agent gates on has to include the removals, or a payload
+    // whose only change is store destruction reads as `changes: 1`.
+    assert_eq!(
+        json["changes"],
+        serde_json::json!(3),
+        "one changed entry plus two removals: {json}"
     );
 }
 

--- a/cli/tests/json_contract.rs
+++ b/cli/tests/json_contract.rs
@@ -1115,6 +1115,11 @@ fn diff_output_validates() {
         // carry the key so a consumer that reads it cannot mistake "not
         // reported" for "no removals".
         stateful_removals: Vec::new(),
+        // #1352: and the same reasoning for the rename discriminator -- an
+        // upgrade that renames no object store must say so as `null`, not by
+        // omitting the key, or a consumer cannot tell it from a CLI that does
+        // not report renames at all.
+        migration: None,
     };
     let json = out.to_json();
     assert_valid("diff.schema.json", &json);
@@ -1122,6 +1127,15 @@ fn diff_output_validates() {
         json["stateful_removals"],
         serde_json::json!([]),
         "an empty removal list must still be emitted as an array: {json}"
+    );
+    assert_eq!(
+        json["migration"],
+        serde_json::Value::Null,
+        "no store rename must still be emitted, as an explicit null: {json}"
+    );
+    assert!(
+        json.get("migration").is_some(),
+        "the migration key must be PRESENT, not merely absent-and-read-as-null: {json}"
     );
 
     // Every classification the schema enumerates must be reachable from a real
@@ -1206,6 +1220,13 @@ fn diff_output_with_stateful_removals_validates() {
                 cause: curie::ops::RemovalCause::RenamedTo("acme-bot-curie-postgres".to_string()),
             },
         ],
+        // The discriminator that makes the `component_gone` remedy actionable:
+        // the store IS renamed here, so `--migrate-store` is the operator's
+        // path for the minio removal above -- and would still be a dead end for
+        // the postgres rename beside it. COMPONENT names, never resource names:
+        // `acme-bot-minio` embeds the chart fullname, which a `nameOverride`
+        // moves, while `minio` is what every consumer can match on (#1352).
+        migration: Some(("minio".to_string(), "rustfs".to_string())),
     };
 
     let json = out.to_json();
@@ -1245,6 +1266,17 @@ fn diff_output_with_stateful_removals_validates() {
         serde_json::json!(3),
         "one changed entry plus two removals: {json}"
     );
+
+    // `to_json` writes this object by hand too, so nothing but this holds the
+    // `from`/`to` spelling in place. Both removals above report the SAME
+    // `component_gone`/`renamed` pair whether or not a store moves, so without
+    // this object the payload cannot say which of them `--migrate-store` can
+    // actually carry -- the ambiguity #1352 exists to close.
+    assert_eq!(
+        json["migration"],
+        serde_json::json!({"from": "minio", "to": "rustfs"}),
+        "the store rename must survive to_json as a component pair: {json}"
+    );
 }
 
 #[test]
@@ -1276,9 +1308,61 @@ fn diff_schema_keeps_unresolved_credential_marker_optional() {
     );
 }
 
+// #1352: `curie diff --chart` reports the version of the chart it actually
+// RENDERS, so it reads that chart's own Chart.yaml rather than this CLI's
+// package version. Answered from the real file the flag points at: a stub
+// inventing a version here would make the CHART VERSION MISMATCH note this
+// run emits a fiction. Shell builtins only -- PATH here holds these two
+// stubs and nothing else, so `cat` would silently produce an empty chart.
+// This is shell text spliced verbatim into a generated `helm` stub script
+// (not a Rust comment), so the explanation travels with the branch into
+// every stub that embeds it.
+const HELM_SHOW_CHART_STUB_BRANCH: &str = r#"if [ "$1" = show ] && [ "$2" = chart ]; then
+    # #1352: `curie diff --chart` reports the version of the chart it actually
+    # RENDERS, so it reads that chart's own Chart.yaml rather than this CLI's
+    # package version. Answered from the real file the flag points at: a stub
+    # inventing a version here would make the CHART VERSION MISMATCH note this
+    # run emits a fiction. Shell builtins only -- PATH here holds these two
+    # stubs and nothing else, so `cat` would silently produce an empty chart.
+    while IFS= read -r chart_line; do
+        printf '%s\n' "$chart_line"
+    done < "$3/Chart.yaml"
+    exit 0
+fi
+"#;
+
+// #1352: `curie diff` now reads the live StatefulSets before it will render
+// the target chart, the same stateful-removal guard `curie apply` runs. An
+// empty live list is the "fresh install, nothing at stake" answer, so the
+// guard short-circuits before it would ever need the chart's rendered
+// StatefulSet specs -- which is why this stub needs no `template` branch,
+// unlike the helm stub's `show chart` branch above.
+fn write_stateful_probe_stubs(bin_dir: &std::path::Path) {
+    use std::os::unix::fs::PermissionsExt;
+
+    let kubectl = bin_dir.join("kubectl");
+    std::fs::write(
+        &kubectl,
+        r#"#!/bin/sh
+if [ "$1" = get ] && [ "$2" = statefulset ]; then
+    printf '%s\n' '{"apiVersion":"v1","items":[],"kind":"List","metadata":{"resourceVersion":""}}'
+    exit 0
+fi
+exit 64
+"#,
+    )
+    .expect("write kubectl stub");
+    let mut permissions = std::fs::metadata(&kubectl)
+        .expect("kubectl stub metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&kubectl, permissions).expect("make kubectl stub executable");
+}
+
 #[test]
 fn credentialless_diff_human_output_names_export_and_never_claims_a_reset() {
     use std::os::unix::fs::PermissionsExt;
+    use std::path::PathBuf;
     use std::process::Command;
 
     let temp = tempfile::tempdir().expect("temporary directory");
@@ -1300,8 +1384,10 @@ fn credentialless_diff_human_output_names_export_and_never_claims_a_reset() {
     let helm = bin_dir.join("helm");
     std::fs::write(
         &helm,
-        r#"#!/bin/sh
-if [ "$1" = get ] && [ "$2" = values ]; then
+        format!(
+            "#!/bin/sh\n{}{}",
+            HELM_SHOW_CHART_STUB_BRANCH,
+            r#"if [ "$1" = get ] && [ "$2" = values ]; then
     printf '%s\n' '{"agentSandbox":{"runner":{"credentials":"model live","fakeModel":false}},"ui":{"service":{"type":"NodePort"}},"langfuse":{"web":{"service":{"type":"NodePort"}}}}'
     exit 0
 fi
@@ -1310,7 +1396,8 @@ if [ "$1" = list ]; then
     exit 0
 fi
 exit 64
-"#,
+"#
+        ),
     )
     .expect("write helm stub");
     let mut permissions = std::fs::metadata(&helm)
@@ -1319,10 +1406,20 @@ exit 64
     permissions.set_mode(0o755);
     std::fs::set_permissions(&helm, permissions).expect("make helm stub executable");
 
+    write_stateful_probe_stubs(&bin_dir);
+
     let output = Command::new(env!("CARGO_BIN_EXE_curie"))
         .arg("diff")
         .arg("--file")
         .arg(&config)
+        // #1352: diff now resolves a chart exactly as apply does, so a dev
+        // build with no `charts/curie` under the process cwd errors before
+        // ever reaching the credential-leniency behaviour under test. The
+        // test binary's cwd is the `cli` crate dir, which has no
+        // `charts/curie`, so point at the repository's own chart the same
+        // way an operator would with `--chart`.
+        .arg("--chart")
+        .arg(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../charts/curie"))
         .env("PATH", &bin_dir)
         .env("CURIE_CONFIG_DIR", temp.path().join("config"))
         .env_remove("CURIE_MODEL")
@@ -1373,6 +1470,7 @@ exit 64
 #[test]
 fn credentialless_diff_without_a_release_does_not_claim_every_declared_value_is_created() {
     use std::os::unix::fs::PermissionsExt;
+    use std::path::PathBuf;
     use std::process::Command;
 
     let temp = tempfile::tempdir().expect("temporary directory");
@@ -1394,8 +1492,10 @@ fn credentialless_diff_without_a_release_does_not_claim_every_declared_value_is_
     let helm = bin_dir.join("helm");
     std::fs::write(
         &helm,
-        r##"#!/bin/sh
-if [ "$1" = get ] && [ "$2" = values ]; then
+        format!(
+            "#!/bin/sh\n{}{}",
+            HELM_SHOW_CHART_STUB_BRANCH,
+            r##"if [ "$1" = get ] && [ "$2" = values ]; then
     printf '%s\n' 'Error: release: not found' >&2
     exit 1
 fi
@@ -1404,7 +1504,8 @@ if [ "$1" = list ]; then
     exit 0
 fi
 exit 64
-"##,
+"##
+        ),
     )
     .expect("write helm stub");
     let mut permissions = std::fs::metadata(&helm)
@@ -1413,10 +1514,20 @@ exit 64
     permissions.set_mode(0o755);
     std::fs::set_permissions(&helm, permissions).expect("make helm stub executable");
 
+    write_stateful_probe_stubs(&bin_dir);
+
     let output = Command::new(env!("CARGO_BIN_EXE_curie"))
         .arg("diff")
         .arg("--file")
         .arg(&config)
+        // #1352: diff now resolves a chart exactly as apply does, so a dev
+        // build with no `charts/curie` under the process cwd errors before
+        // ever reaching the credential-leniency behaviour under test. The
+        // test binary's cwd is the `cli` crate dir, which has no
+        // `charts/curie`, so point at the repository's own chart the same
+        // way an operator would with `--chart`.
+        .arg("--chart")
+        .arg(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../charts/curie"))
         .env("PATH", &bin_dir)
         .env("CURIE_CONFIG_DIR", temp.path().join("config"))
         .env_remove("CURIE_MODEL")

--- a/docs/interfaces/cli-output/INTERFACE.md
+++ b/docs/interfaces/cli-output/INTERFACE.md
@@ -119,7 +119,7 @@ That set is not hand-maintained prose: `cli/schema/index.json` carries one
   longer schema-free: there are 41 committed schemas under `cli/schema/` with an
   index (`cli/schema/index.json`), a `syn`-based inventory gate over every `impl
   CliOutput`, and per-family output validation — all 41 are validated against real
-  `to_json()` output across 67 tests in `cli/tests/json_contract.rs`. Those tests
+  `to_json()` output across 68 tests in `cli/tests/json_contract.rs`. Those tests
   drive each output type's `to_json()` once per output variant rather than calling
   the pure builder functions behind it, so a variant whose `to_json()` arm drifts
   from the schema is caught even when the builder it delegates to still validates.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -407,10 +407,28 @@ data too.
 curie diff -f curie.yaml
 ```
 
-`chart_version_differs: true` means the comparison above it is values-only and
-cannot see a component added, removed, or renamed between versions. A renamed
+`diff` reads the release's live StatefulSets and renders the target chart, so a
+stateful component that chart would DELETE is reported directly as
+`stateful_removals` and counted in `changes`, instead of surfacing as an
+ordinary value add. A non-empty list is not a routine change count: `curie
+apply` on that same file will REFUSE.
+
+`migration` names the object-store rename (`minio` → `rustfs`) that `curie
+apply --migrate-store` carries the data across. Its absence beside a non-empty
+`stateful_removals` means there is no automatic carry -- a store disabled
+through the chart's own BYO gate (`postgres.deploy: false`) removes a component
+`--migrate-store` has nothing to move.
+
+`chart_version_differs: true` means the value-level entry comparison cannot see
+a NON-STATEFUL component added, removed, or renamed between versions. A renamed
 component's old keys appear as ordinary resets, which reads far milder than the
-swap it would be.
+swap it would be. Stateful components are the exception: those come from the
+live read above, whatever the chart versions say.
+
+`curie diff --chart <ref>` points the comparison at the same chart `curie apply
+--chart <ref>` would use, and reports that chart's version as the target. A dev
+build run outside a source checkout needs it, since resolving and rendering a
+chart is now part of `diff`.
 
 `curie apply` refuses outright when the upgrade would delete a StatefulSet the
 release is running, and names it. `--migrate-store` is the option to reach
@@ -432,6 +450,11 @@ unreachable cluster classifies as transient (exit code 3), so an automation
 loop can retry the same command. This also applies to `--dry-run`: a dry run
 that could not read the cluster cannot honestly claim the store is safe, so it
 now errors instead of printing a plan.
+
+`curie diff` fails closed the same way, and classifies the same: it mutates
+nothing and resolves no credential (an unresolvable one is reported, never
+fatal), but answering "no removals" when the cluster read failed is the false
+assurance this check exists to prevent.
 
 Without the CLI, the same check by hand:
 


### PR DESCRIPTION
Closes #1352

`curie diff` exited 0 with a routine change count on the exact file and cluster where `curie apply` exits 1 refusing to delete a stateful component. Store destruction rendered as an ordinary `+ postgres.deploy: false` value add, and automation reading `--json` saw `changes: N` and success.

#1319 built `EffectiveInstallationPlan` as the plan `apply` and `diff` share; #1338 then bolted `guard_stateful_removal` onto `apply` **after** that plan was consumed, so the two surfaces could disagree about the same file. The probe now lives **in** the shared plan and both read one verdict.

### What changed

- `EffectiveInstallationPlan.stateful` carries the verdict plus the object-store rename. `None` means NOT PROBED and is never read as clear — both callers fail closed on it (#1351).
- `StatefulProbe::Skip` keeps `apply --allow-stateful-removal` making no cluster read at all, so an operator who already overrode the verdict still proceeds against an unreadable cluster. `apply`'s refusal text, exit codes and `--migrate-store` gate are unchanged.
- `DiffOutput` gains `stateful_removals` (carrying the **cause**, since `component_gone` and `renamed` have opposite remedies) and `migration`, which names the object-store rename `--migrate-store` actually carries data across. A null `migration` beside a non-empty removal list means there is no automatic carry — the issue's own `postgres.deploy: false` case.
- Removals count in `changes()` and render in both surfaces, and the summary no longer claims a refused file "would be applied".
- `curie diff --chart <ref>` points the comparison at the chart `apply --chart` would use, and `chart_target` now reports the chart actually rendered rather than the CLI's own version.
- diff schema v2.1 → v2.2 (additive, optional properties) per ADR-0101, baseline refreshed; the `changes` and `chart_version_differs` descriptions were corrected in the same bump.

### Behavior change, called out

`curie diff` now reads `kubectl get statefulset` and resolves a chart, and **fails closed** on an unreadable cluster the way `apply` does. That is deliberate: reporting "no removals" when the read failed is the defect. It is consistent with `diff` already hard-failing on an unreadable `helm get values`; the credential-leniency contract is unaffected. `docs/operations.md` is updated.

### Done-check

- [x] **Failing tests committed first** — `eb2e80b0` is 5 behaviourally red tests; `curie dev verify-fix-pin` on the fix commit reports **PINNED** for `diff_reports_the_stateful_removal_apply_refuses_on`.
- [x] **All production edits delegated** to sub-agents; driver ran only git/tests/bookkeeping.
- [x] **Broadened return types** — none. `DiffOpts` gained required fields `chart`/`chart_target` and `DiffOutput` gained `stateful_removals`/`migration`; all literal constructions in-tree updated.
- [x] **Code review** — agent-router → grok. Findings fixed: missing `migration`, `chart_target` ignoring `--chart`, stale `docs/operations.md`. The run timed out before a clean completion; findings were consumed from its partial output.
- [x] **Scope review** — agent-router → grok. Every hunk mapped to the issue or to a mandatory regeneration; **zero** unjustified hunks. Findings fixed: `diff()` fail-open on an unprobed plan, "would be applied" on a refused file, over-promised `--migrate-store` remedy, `migration` absent.
- [x] **Sibling-path parity** — `apply` (plain / `--dry-run` / `--migrate-store` / `--allow-stateful-removal`) and `diff` all covered. `cluster up` performs the same destructive upgrade with no guard; it does not use this plan and is **filed as a follow-up below**, not silently skipped.
- [x] **Guard demonstration** — the fail-closed reads were executed, not read: `CURIE_TEST_KUBECTL_FAIL` → exit 3, `CURIE_TEST_KUBECTL_FORBIDDEN` → exit 1, both asserted verb-neutral.
- [x] **Consolidation** — `/simplify` (4 angles). One finding applied (duplicated probe stubs factored). Skipped with reason: `try_join!`ing `helm list` with the plan would make a deterministic call-ORDER assertion nondeterministic.
- [x] **Full affected suite + lint** — `cargo fmt --check`, `cargo clippy --locked -- -D warnings`, `cargo test --locked`, `refresh-schema-baseline.sh --check`, `check-version-consistency.sh`, `scripts/check-docs.sh` all exit 0.
- [ ] N/A — Security reviewer (not flagged), deployed E2E (no deployed surface; the guard is decision logic verified against recorded real `kubectl`/`helm` output, this repo's established practice for it).

### Rebased onto #1501

`main` landed #1501 ("Refuse `--migrate-store` removals the migration cannot carry") mid-run — which is exactly the follow-up this PR was going to file. Rebased onto it. Git merged both refactors of `stateful_removal_message` with **no** textual conflict but left a semantic one: the shared remedy helper still offered `--migrate-store` for any `ComponentGone`, so `curie diff` would have recommended a flag `curie apply` now refuses — a fresh diff-vs-apply disagreement, the very defect class this issue closes.

Fixed at the shared helper: `stateful_removal_remedies` now partitions `ComponentGone` through `migrate_store::is_object_store_component`, offering the flag only for the object store and mirroring `uncarriable_removal_message` for the rest, so both surfaces stay in lockstep by construction. New test `diff_does_not_offer_a_flag_apply_would_refuse_for_an_uncarriable_removal` pins it from both sides. No existing message assertion needed changing.

### Follow-ups (not this PR)

1. `cluster up` does the same destructive upgrade with no guard. `ops::run_prepared_up` already holds `(&UpOpts, &UpValuePlan)` — `guard_stateful_removal`'s exact signature — and is the natural choke point.
2. `resolve_chart`/`materialize_artifact` should return `(path, version)` so no caller has to infer which chart it resolved.
