### PR TITLE
Resolve placement classes through a nil-tolerant helper so legacy releases upgrade

### DIFF
--- a/charts/curie/CLAUDE.md
+++ b/charts/curie/CLAUDE.md
@@ -50,6 +50,19 @@ component and rail detail in `charts/curie/README.md`.
 - **Values keys are camelCase, not hyphenated.** Go templates cannot
   dot-index a hyphenated key. Keep this consistent across any new values
   additions.
+- **Placement-class lookups go through `curie.placement.class`; never
+  index `.Values.placement.<class>` directly in a template.** Helm's
+  values coalescing deletes a key whose replayed value is YAML null, so
+  `helm upgrade --reuse-values` on a release created before placement
+  classes existed -- which stored `placement: null` -- leaves
+  `.Values.placement` nil, and a direct dereference crashes the render
+  before any cluster mutation (#2008). A nil or missing tree/class
+  degrades to the chart's empty defaults; a tree or class that is present
+  but not a map is refused with `fail`, deliberately -- `fromYaml` returns
+  an error map rather than an error for a non-map document, so softening
+  that refusal into a default would silently drop every scheduling
+  constraint the operator asked for. A new pod surface added to the chart
+  uses the helper with its class name rather than a fresh direct index.
 - **Fail-closed egress, always.** `security.networkPolicy.allowedEgress` is
   empty by default; an unset allowlist must never mean allow-all. If you add
   a new egress destination the runner needs, it goes into this allowlist
@@ -130,7 +143,12 @@ component and rail detail in `charts/curie/README.md`.
     instead by the worker's own boot-time refusal. Both checks are
     load-bearing -- the schema catches a bad value early for the common
     cases, the worker's refusal is the backstop for the coalescing gap the
-    schema cannot see.
+    schema cannot see. `placement` is the second instance of this exact
+    coalescing gap -- a release created before placement classes existed
+    can store `placement: null`, and `--reuse-values` on upgrade replays
+    it, deleting the key -- and the `curie.placement.class` helper (see
+    the values-keys invariant above) is its template-level backstop
+    (#2008).
 
 ## Verify
 

--- a/charts/curie/ci/render-assertions.sh
+++ b/charts/curie/ci/render-assertions.sh
@@ -1096,6 +1096,104 @@ helm template placement-render "$CHART" --output-dir "$PLACEMENT_PLATFORM_ONLY_O
 python3 "$PLACEMENT_CHECK" "$PLACEMENT_PLATFORM_ONLY_OUT" platform-only \
   || fail "the platform-only marker was absent from a platform pod or leaked into another placement class."
 
+echo "=== Placement assertion 4: a legacy release's retained placement: null still renders (#2008) ==="
+# `helm upgrade --reuse-values` replays the STORED release config as this
+# upgrade's user-supplied values -- it is not a merge over the chart's current
+# defaults. Helm's values coalescing then deletes any top-level key whose
+# replayed value is YAML null outright, so a release created before placement
+# classes existed, which stored `placement: null`, hands that null straight
+# back in on every future upgrade. `.Values.placement` is then nil and every
+# `.Values.placement.<class>` lookup in the templates panics with a nil
+# pointer template error (issue #2008). A live `helm upgrade --dry-run
+# --reuse-values` reproduction needs an actual prior Helm release, which this
+# chart-only CI has no cluster or release history to provide -- rendering a
+# fixture that reproduces the exact coalesced shape (`placement: null`
+# alongside an ordinary retained setting, so this reads as a real retained
+# values file and not a one-key probe) is the faithful, cluster-free stand-in
+# for the same upgrade path.
+PLACEMENT_LEGACY_NULL="$TMP/placement-legacy-null.yaml"
+cat > "$PLACEMENT_LEGACY_NULL" <<'YAMLEOF'
+placement: null
+global:
+  storageClass: gp3-legacy
+YAMLEOF
+
+PLACEMENT_LEGACY_NULL_OUT="$(mktemp -d -p "$TMP")"
+PLACEMENT_LEGACY_NULL_ERR="$TMP/placement-legacy-null.err"
+# set -euo pipefail would otherwise kill the script silently at this line on
+# the very failure we are testing for; capture stderr and check the exit
+# status explicitly so a broken render reports a useful message instead.
+if ! helm template placement-render "$CHART" --output-dir "$PLACEMENT_LEGACY_NULL_OUT" \
+  -f "$PLACEMENT_LEGACY_NULL" "${PLACEMENT_HELM_ARGS[@]}" \
+  > /dev/null 2>"$PLACEMENT_LEGACY_NULL_ERR"; then
+  fail "a legacy release's retained 'placement: null' failed to render (#2008): $(cat "$PLACEMENT_LEGACY_NULL_ERR")"
+fi
+python3 "$PLACEMENT_CHECK" "$PLACEMENT_LEGACY_NULL_OUT" default \
+  || fail "a legacy release's retained 'placement: null' rendered but did not degrade to the chart's empty placement defaults (#2008): every expected pod surface must still be present and none may carry a placement marker or scheduling field."
+
+echo "=== Placement assertion 4 negative control: reverting the nil-safe placement accessor FAILS ==="
+# Mandatory, per Assertion 7's convention: an assert that has never been shown
+# failing is not a pin. Mutate a TEMP COPY of the chart's _helpers.tpl and
+# require the legacy-null render to fail again.
+#
+# The #2008 fix has not landed on this branch yet, so this mutation cannot
+# target known-existing text the way Assertion 7's and 12b's negative
+# controls do. It instead locates its mutation target -- the nil-safe
+# placement accessor in _helpers.tpl -- by NAME: the `curie.placement.class`
+# define the fix is expected to introduce. It mutates that define's body back
+# into a raw, nil-UNSAFE `.Values.placement.<class>`-style dereference by
+# stripping this chart's own established `| default dict` nil-guard idiom
+# (see _helpers.tpl:766) from inside it. If the define cannot be found, or is
+# found but does not use that idiom, the mutation script fails loudly naming
+# what it could not find rather than silently no-op'ing, so a renamed or
+# differently-shaped fix does not leave this negative control quietly
+# pinning nothing.
+PLACEMENT_MUTANT="$TMP/mutant-placement"
+cp -a "$CHART" "$PLACEMENT_MUTANT"
+python3 - "$PLACEMENT_MUTANT/templates/_helpers.tpl" <<'PYEOF'
+import pathlib
+import re
+import sys
+
+p = pathlib.Path(sys.argv[1])
+text = p.read_text()
+
+block_re = re.compile(
+    r'{{-?\s*define "curie\.placement\.class"\s*-?}}.*?{{-?\s*end\s*-?}}',
+    re.DOTALL,
+)
+m = block_re.search(text)
+if not m:
+    sys.stderr.write(
+        "negative control could not find a 'curie.placement.class' define in "
+        "_helpers.tpl to mutate. That is the nil-safe placement accessor "
+        "Assertion 4 (#2008) expects the fix to introduce; if the fix named "
+        "it something else, update this negative control's anchor to match.\n"
+    )
+    sys.exit(1)
+
+block = m.group(0)
+if "| default dict" not in block:
+    sys.stderr.write(
+        "negative control found 'curie.placement.class' but no '| default "
+        "dict' nil-guard idiom (this chart's established pattern, see "
+        "_helpers.tpl:766) inside it to strip. Update this negative control "
+        "to match however the #2008 fix actually guards against nil "
+        ".Values.placement.\n"
+    )
+    sys.exit(1)
+
+mutated_block = block.replace("| default dict", "", 1)
+p.write_text(text.replace(block, mutated_block, 1))
+PYEOF
+
+PLACEMENT_MUTANT_OUT="$(mktemp -d -p "$TMP")"
+if helm template placement-render "$PLACEMENT_MUTANT" --output-dir "$PLACEMENT_MUTANT_OUT" \
+  -f "$PLACEMENT_LEGACY_NULL" "${PLACEMENT_HELM_ARGS[@]}" > /dev/null 2>&1; then
+  fail "negative control did not fire: a legacy release's retained 'placement: null' still rendered after stripping the nil-guard from curie.placement.class, so Placement assertion 4 (#2008) is not actually pinning anything."
+fi
+echo "  ok: stripping the nil-guard from curie.placement.class makes the legacy-null render fail again (the assert can fail)"
+
 echo "=== Assertion 12c: worker API URL and key wiring (#1529, #1578) ==="
 WORKER_API_CHECK="$TMP/check_worker_api.py"
 cat > "$WORKER_API_CHECK" <<'PYEOF'

--- a/charts/curie/ci/render-assertions.sh
+++ b/charts/curie/ci/render-assertions.sh
@@ -1194,6 +1194,61 @@ if helm template placement-render "$PLACEMENT_MUTANT" --output-dir "$PLACEMENT_M
 fi
 echo "  ok: stripping the nil-guard from curie.placement.class makes the legacy-null render fail again (the assert can fail)"
 
+echo "=== Placement assertion 5: a malformed placement class is refused, not silently dropped (#2008) ==="
+# The #2008 nil tolerance routes every class lookup through
+# `curie.placement.class`, which hands its result to the three consumers as
+# YAML. Helm's `fromYaml` returns an ERROR MAP rather than raising on a non-map
+# document, so without a kind refusal in that helper a malformed class renders
+# clean with `.podLabels`/`.annotations`/`.nodeSelector` all resolving to
+# nothing -- every scheduling constraint the operator asked for silently
+# dropped, and workloads free to land on unintended nodes. The pre-#2008
+# templates aborted on this shape; these asserts pin that the fix stayed
+# fail-CLOSED on it while only the nil case became tolerant.
+PLACEMENT_MALFORMED_CLASS="$TMP/placement-malformed-class.yaml"
+cat > "$PLACEMENT_MALFORMED_CLASS" <<'YAMLEOF'
+placement:
+  platform: spot
+YAMLEOF
+
+PLACEMENT_MALFORMED_CLASS_OUT="$(mktemp -d -p "$TMP")"
+PLACEMENT_MALFORMED_CLASS_ERR="$TMP/placement-malformed-class.err"
+# Same `set -euo pipefail` care as assertion 4: the expected outcome here is a
+# FAILING render, so check the exit status explicitly instead of letting the
+# non-zero status kill the script.
+if helm template placement-render "$CHART" --output-dir "$PLACEMENT_MALFORMED_CLASS_OUT" \
+  -f "$PLACEMENT_MALFORMED_CLASS" "${PLACEMENT_HELM_ARGS[@]}" \
+  > /dev/null 2>"$PLACEMENT_MALFORMED_CLASS_ERR"; then
+  fail "a malformed placement class ('placement.platform: spot', a scalar where a map of placement fields belongs) rendered successfully and silently dropped its scheduling constraints -- that is the #2008 fail-open regression: the chart must refuse the shape, not quietly schedule the workload anywhere."
+fi
+grep -q 'placement\.platform' "$PLACEMENT_MALFORMED_CLASS_ERR" \
+  || fail "a malformed placement class was refused, but the error never names the offending class ('placement.platform'), so the refusal is an incidental crash rather than an actionable message: $(cat "$PLACEMENT_MALFORMED_CLASS_ERR")"
+
+PLACEMENT_MALFORMED_TOP="$TMP/placement-malformed-top.yaml"
+cat > "$PLACEMENT_MALFORMED_TOP" <<'YAMLEOF'
+placement: spot
+YAMLEOF
+
+PLACEMENT_MALFORMED_TOP_OUT="$(mktemp -d -p "$TMP")"
+PLACEMENT_MALFORMED_TOP_ERR="$TMP/placement-malformed-top.err"
+if helm template placement-render "$CHART" --output-dir "$PLACEMENT_MALFORMED_TOP_OUT" \
+  -f "$PLACEMENT_MALFORMED_TOP" "${PLACEMENT_HELM_ARGS[@]}" \
+  > /dev/null 2>"$PLACEMENT_MALFORMED_TOP_ERR"; then
+  fail "a malformed top-level 'placement: spot' rendered successfully and silently dropped every placement class -- the chart must refuse a non-map placement, not quietly schedule every workload anywhere (#2008 fail-open regression)."
+fi
+grep -q 'placement' "$PLACEMENT_MALFORMED_TOP_ERR" \
+  || fail "a malformed top-level placement was refused, but the error never mentions 'placement', so the refusal is an incidental crash rather than an actionable message: $(cat "$PLACEMENT_MALFORMED_TOP_ERR")"
+
+# Positive control: the refusal must be narrow. The legacy nil path from
+# assertion 4 -- the whole point of #2008 -- must still render.
+PLACEMENT_REFUSAL_CONTROL_OUT="$(mktemp -d -p "$TMP")"
+PLACEMENT_REFUSAL_CONTROL_ERR="$TMP/placement-refusal-control.err"
+if ! helm template placement-render "$CHART" --output-dir "$PLACEMENT_REFUSAL_CONTROL_OUT" \
+  -f "$PLACEMENT_LEGACY_NULL" "${PLACEMENT_HELM_ARGS[@]}" \
+  > /dev/null 2>"$PLACEMENT_REFUSAL_CONTROL_ERR"; then
+  fail "the malformed-placement refusal is too broad: a legacy release's retained 'placement: null' no longer renders, so the fail-closed guard swallowed the #2008 nil tolerance it was supposed to preserve: $(cat "$PLACEMENT_REFUSAL_CONTROL_ERR")"
+fi
+echo "  ok: malformed placement values are refused by name, and legacy 'placement: null' still renders"
+
 echo "=== Assertion 12c: worker API URL and key wiring (#1529, #1578) ==="
 WORKER_API_CHECK="$TMP/check_worker_api.py"
 cat > "$WORKER_API_CHECK" <<'PYEOF'

--- a/charts/curie/templates/_helpers.tpl
+++ b/charts/curie/templates/_helpers.tpl
@@ -43,28 +43,46 @@ app.kubernetes.io/instance: {{ .root.Release.Name }}
 app.kubernetes.io/component: {{ .component }}
 {{- end -}}
 
+{{/* Resolve one named placement class. Pass a dict with "root" (the top
+     context) and "class" (the placement class name). Every class lookup in the
+     chart goes through this helper rather than indexing the placement values
+     directly, so that a legacy release whose retained values carry
+     `placement: null` (issue #2008) degrades to the chart's empty defaults
+     instead of crashing the render. Helm's coalescing deletes a null-valued key
+     outright, so when `helm upgrade --reuse-values` replays the stored config of
+     a release created before placement classes existed, the placement map is nil
+     -- even though values.yaml defines all five classes -- and every direct
+     per-class dereference in a template would panic on that nil. The
+     `| default dict` on the class lookup itself likewise covers a placement map
+     that is present but missing this class. */}}
+{{- define "curie.placement.class" -}}
+{{- $classes := .root.Values.placement | default dict -}}
+{{- toYaml (index $classes .class | default dict) -}}
+{{- end -}}
+
 {{- define "curie.placement.labels" -}}
-{{- with .podLabels }}
+{{- with (fromYaml (include "curie.placement.class" .)).podLabels }}
 {{- toYaml . }}
 {{- end }}
 {{- end -}}
 
 {{- define "curie.placement.annotations" -}}
-{{- with .annotations }}
+{{- with (fromYaml (include "curie.placement.class" .)).annotations }}
 {{- toYaml . }}
 {{- end }}
 {{- end -}}
 
 {{- define "curie.placement.spec" -}}
-{{- with .nodeSelector }}
+{{- $class := fromYaml (include "curie.placement.class" .) -}}
+{{- with $class.nodeSelector }}
 nodeSelector:
 {{- toYaml . | nindent 2 }}
 {{- end }}
-{{- with .tolerations }}
+{{- with $class.tolerations }}
 tolerations:
 {{- toYaml . | nindent 2 }}
 {{- end }}
-{{- with .affinity }}
+{{- with $class.affinity }}
 affinity:
 {{- toYaml . | nindent 2 }}
 {{- end }}

--- a/charts/curie/templates/_helpers.tpl
+++ b/charts/curie/templates/_helpers.tpl
@@ -53,11 +53,37 @@ app.kubernetes.io/component: {{ .component }}
      a release created before placement classes existed, the placement map is nil
      -- even though values.yaml defines all five classes -- and every direct
      per-class dereference in a template would panic on that nil. The
-     `| default dict` on the class lookup itself likewise covers a placement map
-     that is present but missing this class. */}}
+     empty-dict substitution on the class lookup itself likewise covers a
+     placement map that is present but missing this class.
+
+     The kind checks are the fail-CLOSED half of that tolerance, and they are
+     not optional: this helper hands its result to consumers as YAML, and
+     Helm's `fromYaml` on a non-map document returns an error map rather than
+     raising, so a malformed class (say `placement.platform: spot`) would
+     resolve `.podLabels`, `.annotations`, and `.nodeSelector` to nothing and
+     render clean -- silently dropping every scheduling constraint the operator
+     meant to apply and letting workloads land on unintended nodes. The
+     pre-#2008 templates dereferenced the class directly and aborted on that
+     shape; refusing here keeps that behavior while still degrading a *nil*
+     placement to the chart's empty defaults. The refusal lives in the template
+     rather than in `values.schema.json` because that schema is deliberately
+     permissive and does not type `placement` at all (see charts/curie/CLAUDE.md),
+     so a template-level refusal is this chart's established backstop for the
+     gap. Note the kind tests use `kindIs`/`kindOf` and not truthiness: an
+     `and $class (...)` guard would read a `false` or `0` class as absent and
+     default it away, which is the same fail-open bug in a different costume. */}}
 {{- define "curie.placement.class" -}}
 {{- $classes := .root.Values.placement | default dict -}}
-{{- toYaml (index $classes .class | default dict) -}}
+{{- if not (kindIs "map" $classes) -}}
+{{- fail (printf "placement must be a map of placement classes, got %s" (kindOf $classes)) -}}
+{{- end -}}
+{{- $class := index $classes .class -}}
+{{- if kindIs "invalid" $class -}}
+{{- $class = dict -}}
+{{- else if not (kindIs "map" $class) -}}
+{{- fail (printf "placement.%s must be a map of placement fields (podLabels, annotations, nodeSelector, tolerations, affinity), got %s" .class (kindOf $class)) -}}
+{{- end -}}
+{{- toYaml $class -}}
 {{- end -}}
 
 {{- define "curie.placement.labels" -}}

--- a/charts/curie/templates/agent-sandbox.yaml
+++ b/charts/curie/templates/agent-sandbox.yaml
@@ -41,11 +41,11 @@ patch lives in the template layer alongside the #66 RBAC patch below.
 {{- $controllerManifest := .Files.Get "files/agent-sandbox/controller.yaml" }}
 {{- $controllerMetadataAnchor := "    metadata:\n      labels:\n        app: agent-sandbox-controller" }}
 {{- $controllerMetadata := "    metadata:\n      labels:" }}
-{{- with (include "curie.placement.labels" .Values.placement.controller) }}
+{{- with (include "curie.placement.labels" (dict "root" $ "class" "controller")) }}
 {{- $controllerMetadata = printf "%s\n%s" $controllerMetadata (indent 8 .) }}
 {{- end }}
 {{- $controllerMetadata = printf "%s\n        app: agent-sandbox-controller" $controllerMetadata }}
-{{- with (include "curie.placement.annotations" .Values.placement.controller) }}
+{{- with (include "curie.placement.annotations" (dict "root" $ "class" "controller")) }}
 {{- $controllerMetadata = printf "%s\n      annotations:\n%s" $controllerMetadata (indent 8 .) }}
 {{- end }}
 {{- $controllerManifest = $controllerManifest | replace $controllerMetadataAnchor $controllerMetadata }}
@@ -54,7 +54,7 @@ patch lives in the template layer alongside the #66 RBAC patch below.
 {{- with .Values.priorityClasses.platform.name }}
 {{- $controllerPodFields = printf "%s\n      priorityClassName: %s" $controllerPodFields . }}
 {{- end }}
-{{- with (include "curie.placement.spec" .Values.placement.controller) }}
+{{- with (include "curie.placement.spec" (dict "root" $ "class" "controller")) }}
 {{- $controllerPodFields = printf "%s\n%s" $controllerPodFields (indent 6 .) }}
 {{- end }}
 {{- $controllerManifest = $controllerManifest | replace $controllerServiceAccount $controllerPodFields }}
@@ -189,19 +189,19 @@ spec:
   podTemplate:
     metadata:
       labels:
-        {{- with (include "curie.placement.labels" .Values.placement.sandbox) }}
+        {{- with (include "curie.placement.labels" (dict "root" . "class" "sandbox")) }}
         {{- . | nindent 8 }}
         {{- end }}
         {{- include "curie.selectorLabels" (dict "root" . "component" "runner-sandbox") | nindent 8 }}
         {{- if $agent }}
         curietech.ai/agent: {{ $agent | quote }}
         {{- end }}
-      {{- with (include "curie.placement.annotations" .Values.placement.sandbox) }}
+      {{- with (include "curie.placement.annotations" (dict "root" . "class" "sandbox")) }}
       annotations:
         {{- . | nindent 8 }}
       {{- end }}
     spec:
-      {{- with (include "curie.placement.spec" .Values.placement.sandbox) }}
+      {{- with (include "curie.placement.spec" (dict "root" . "class" "sandbox")) }}
       {{- . | nindent 6 }}
       {{- end }}
       {{- if $runner.serviceAccount.create }}

--- a/charts/curie/templates/api.yaml
+++ b/charts/curie/templates/api.yaml
@@ -33,17 +33,17 @@ spec:
   template:
     metadata:
       labels:
-        {{- with (include "curie.placement.labels" .Values.placement.platform) }}
+        {{- with (include "curie.placement.labels" (dict "root" $ "class" "platform")) }}
         {{- . | nindent 8 }}
         {{- end }}
         {{- include "curie.labels" . | nindent 8 }}
         {{- include "curie.selectorLabels" (dict "root" . "component" "api") | nindent 8 }}
-      {{- with (include "curie.placement.annotations" .Values.placement.platform) }}
+      {{- with (include "curie.placement.annotations" (dict "root" $ "class" "platform")) }}
       annotations:
         {{- . | nindent 8 }}
       {{- end }}
     spec:
-      {{- with (include "curie.placement.spec" .Values.placement.platform) }}
+      {{- with (include "curie.placement.spec" (dict "root" $ "class" "platform")) }}
       {{- . | nindent 6 }}
       {{- end }}
       # The runner-logs proxy lists pods and reads pod logs via the K8s API, so

--- a/charts/curie/templates/clickhouse.yaml
+++ b/charts/curie/templates/clickhouse.yaml
@@ -52,7 +52,7 @@ spec:
   template:
     metadata:
       annotations:
-        {{- with (include "curie.placement.annotations" .Values.placement.data) }}
+        {{- with (include "curie.placement.annotations" (dict "root" $ "class" "data")) }}
         {{- . | nindent 8 }}
         {{- end }}
         # Roll the pod when the rendered logging overlay changes. Without this a
@@ -61,13 +61,13 @@ spec:
         # -- i.e. the fix would appear applied while the node kept starving.
         checksum/config: {{ include "curie.clickhouse.loggingConfig" . | sha256sum }}
       labels:
-        {{- with (include "curie.placement.labels" .Values.placement.data) }}
+        {{- with (include "curie.placement.labels" (dict "root" $ "class" "data")) }}
         {{- . | nindent 8 }}
         {{- end }}
         {{- include "curie.labels" . | nindent 8 }}
         {{- include "curie.selectorLabels" (dict "root" . "component" "clickhouse") | nindent 8 }}
     spec:
-      {{- with (include "curie.placement.spec" .Values.placement.data) }}
+      {{- with (include "curie.placement.spec" (dict "root" $ "class" "data")) }}
       {{- . | nindent 6 }}
       {{- end }}
       {{- with .Values.priorityClasses.platform.name }}

--- a/charts/curie/templates/dispatcher.yaml
+++ b/charts/curie/templates/dispatcher.yaml
@@ -22,17 +22,17 @@ spec:
   template:
     metadata:
       labels:
-        {{- with (include "curie.placement.labels" .Values.placement.platform) }}
+        {{- with (include "curie.placement.labels" (dict "root" $ "class" "platform")) }}
         {{- . | nindent 8 }}
         {{- end }}
         {{- include "curie.labels" . | nindent 8 }}
         {{- include "curie.selectorLabels" (dict "root" . "component" "dispatcher") | nindent 8 }}
-      {{- with (include "curie.placement.annotations" .Values.placement.platform) }}
+      {{- with (include "curie.placement.annotations" (dict "root" $ "class" "platform")) }}
       annotations:
         {{- . | nindent 8 }}
       {{- end }}
     spec:
-      {{- with (include "curie.placement.spec" .Values.placement.platform) }}
+      {{- with (include "curie.placement.spec" (dict "root" $ "class" "platform")) }}
       {{- . | nindent 6 }}
       {{- end }}
       {{- with .Values.priorityClasses.platform.name }}

--- a/charts/curie/templates/inference.yaml
+++ b/charts/curie/templates/inference.yaml
@@ -47,17 +47,17 @@ spec:
   template:
     metadata:
       labels:
-        {{- with (include "curie.placement.labels" .Values.placement.platform) }}
+        {{- with (include "curie.placement.labels" (dict "root" $ "class" "platform")) }}
         {{- . | nindent 8 }}
         {{- end }}
         {{- include "curie.labels" . | nindent 8 }}
         {{- include "curie.selectorLabels" (dict "root" . "component" "inference") | nindent 8 }}
-      {{- with (include "curie.placement.annotations" .Values.placement.platform) }}
+      {{- with (include "curie.placement.annotations" (dict "root" $ "class" "platform")) }}
       annotations:
         {{- . | nindent 8 }}
       {{- end }}
     spec:
-      {{- with (include "curie.placement.spec" .Values.placement.platform) }}
+      {{- with (include "curie.placement.spec" (dict "root" $ "class" "platform")) }}
       {{- . | nindent 6 }}
       {{- end }}
       volumes:

--- a/charts/curie/templates/langfuse-model-pricing.yaml
+++ b/charts/curie/templates/langfuse-model-pricing.yaml
@@ -27,16 +27,16 @@ spec:
   template:
     metadata:
       labels:
-        {{- with (include "curie.placement.labels" .Values.placement.hooks) }}
+        {{- with (include "curie.placement.labels" (dict "root" $ "class" "hooks")) }}
         {{- . | nindent 8 }}
         {{- end }}
         {{- include "curie.selectorLabels" (dict "root" . "component" "langfuse-model-pricing") | nindent 8 }}
-      {{- with (include "curie.placement.annotations" .Values.placement.hooks) }}
+      {{- with (include "curie.placement.annotations" (dict "root" $ "class" "hooks")) }}
       annotations:
         {{- . | nindent 8 }}
       {{- end }}
     spec:
-      {{- with (include "curie.placement.spec" .Values.placement.hooks) }}
+      {{- with (include "curie.placement.spec" (dict "root" $ "class" "hooks")) }}
       {{- . | nindent 6 }}
       {{- end }}
       restartPolicy: Never

--- a/charts/curie/templates/langfuse.yaml
+++ b/charts/curie/templates/langfuse.yaml
@@ -31,17 +31,17 @@ spec:
   template:
     metadata:
       labels:
-        {{- with (include "curie.placement.labels" .Values.placement.platform) }}
+        {{- with (include "curie.placement.labels" (dict "root" $ "class" "platform")) }}
         {{- . | nindent 8 }}
         {{- end }}
         {{- include "curie.labels" . | nindent 8 }}
         {{- include "curie.selectorLabels" (dict "root" . "component" "langfuse-web") | nindent 8 }}
-      {{- with (include "curie.placement.annotations" .Values.placement.platform) }}
+      {{- with (include "curie.placement.annotations" (dict "root" $ "class" "platform")) }}
       annotations:
         {{- . | nindent 8 }}
       {{- end }}
     spec:
-      {{- with (include "curie.placement.spec" .Values.placement.platform) }}
+      {{- with (include "curie.placement.spec" (dict "root" $ "class" "platform")) }}
       {{- . | nindent 6 }}
       {{- end }}
       containers:
@@ -126,17 +126,17 @@ spec:
   template:
     metadata:
       labels:
-        {{- with (include "curie.placement.labels" .Values.placement.platform) }}
+        {{- with (include "curie.placement.labels" (dict "root" $ "class" "platform")) }}
         {{- . | nindent 8 }}
         {{- end }}
         {{- include "curie.labels" . | nindent 8 }}
         {{- include "curie.selectorLabels" (dict "root" . "component" "langfuse-worker") | nindent 8 }}
-      {{- with (include "curie.placement.annotations" .Values.placement.platform) }}
+      {{- with (include "curie.placement.annotations" (dict "root" $ "class" "platform")) }}
       annotations:
         {{- . | nindent 8 }}
       {{- end }}
     spec:
-      {{- with (include "curie.placement.spec" .Values.placement.platform) }}
+      {{- with (include "curie.placement.spec" (dict "root" $ "class" "platform")) }}
       {{- . | nindent 6 }}
       {{- end }}
       containers:

--- a/charts/curie/templates/otel-collector.yaml
+++ b/charts/curie/templates/otel-collector.yaml
@@ -66,18 +66,18 @@ spec:
   template:
     metadata:
       annotations:
-        {{- with (include "curie.placement.annotations" .Values.placement.platform) }}
+        {{- with (include "curie.placement.annotations" (dict "root" $ "class" "platform")) }}
         {{- . | nindent 8 }}
         {{- end }}
         checksum/config: {{ printf "%s|%s" (include "curie.otelCollector.config" .) (include "curie.otlpAuthHeader" .) | sha256sum }}
       labels:
-        {{- with (include "curie.placement.labels" .Values.placement.platform) }}
+        {{- with (include "curie.placement.labels" (dict "root" $ "class" "platform")) }}
         {{- . | nindent 8 }}
         {{- end }}
         {{- include "curie.labels" . | nindent 8 }}
         {{- include "curie.selectorLabels" (dict "root" . "component" "otel-collector") | nindent 8 }}
     spec:
-      {{- with (include "curie.placement.spec" .Values.placement.platform) }}
+      {{- with (include "curie.placement.spec" (dict "root" $ "class" "platform")) }}
       {{- . | nindent 6 }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.otelCollector.terminationGracePeriodSeconds }}

--- a/charts/curie/templates/postgres.yaml
+++ b/charts/curie/templates/postgres.yaml
@@ -29,17 +29,17 @@ spec:
   template:
     metadata:
       labels:
-        {{- with (include "curie.placement.labels" .Values.placement.data) }}
+        {{- with (include "curie.placement.labels" (dict "root" $ "class" "data")) }}
         {{- . | nindent 8 }}
         {{- end }}
         {{- include "curie.labels" . | nindent 8 }}
         {{- include "curie.selectorLabels" (dict "root" . "component" "postgres") | nindent 8 }}
-      {{- with (include "curie.placement.annotations" .Values.placement.data) }}
+      {{- with (include "curie.placement.annotations" (dict "root" $ "class" "data")) }}
       annotations:
         {{- . | nindent 8 }}
       {{- end }}
     spec:
-      {{- with (include "curie.placement.spec" .Values.placement.data) }}
+      {{- with (include "curie.placement.spec" (dict "root" $ "class" "data")) }}
       {{- . | nindent 6 }}
       {{- end }}
       {{- with .Values.priorityClasses.platform.name }}

--- a/charts/curie/templates/preflight-avx.yaml
+++ b/charts/curie/templates/preflight-avx.yaml
@@ -28,16 +28,16 @@ spec:
   template:
     metadata:
       labels:
-        {{- with (include "curie.placement.labels" .Values.placement.hooks) }}
+        {{- with (include "curie.placement.labels" (dict "root" $ "class" "hooks")) }}
         {{- . | nindent 8 }}
         {{- end }}
         {{- include "curie.selectorLabels" (dict "root" . "component" "preflight-avx") | nindent 8 }}
-      {{- with (include "curie.placement.annotations" .Values.placement.hooks) }}
+      {{- with (include "curie.placement.annotations" (dict "root" $ "class" "hooks")) }}
       annotations:
         {{- . | nindent 8 }}
       {{- end }}
     spec:
-      {{- with (include "curie.placement.spec" .Values.placement.hooks) }}
+      {{- with (include "curie.placement.spec" (dict "root" $ "class" "hooks")) }}
       {{- . | nindent 6 }}
       {{- end }}
       restartPolicy: Never

--- a/charts/curie/templates/preflight-controller.yaml
+++ b/charts/curie/templates/preflight-controller.yaml
@@ -85,17 +85,17 @@ spec:
   template:
     metadata:
       labels:
-        {{- with (include "curie.placement.labels" .Values.placement.hooks) }}
+        {{- with (include "curie.placement.labels" (dict "root" $ "class" "hooks")) }}
         {{- . | nindent 8 }}
         {{- end }}
         {{- include "curie.labels" . | nindent 8 }}
         {{- include "curie.selectorLabels" (dict "root" . "component" "preflight-controller") | nindent 8 }}
-      {{- with (include "curie.placement.annotations" .Values.placement.hooks) }}
+      {{- with (include "curie.placement.annotations" (dict "root" $ "class" "hooks")) }}
       annotations:
         {{- . | nindent 8 }}
       {{- end }}
     spec:
-      {{- with (include "curie.placement.spec" .Values.placement.hooks) }}
+      {{- with (include "curie.placement.spec" (dict "root" $ "class" "hooks")) }}
       {{- . | nindent 6 }}
       {{- end }}
       serviceAccountName: {{ include "curie.fullname" . }}-preflight-controller

--- a/charts/curie/templates/preflight-gvisor.yaml
+++ b/charts/curie/templates/preflight-gvisor.yaml
@@ -45,16 +45,16 @@ spec:
   template:
     metadata:
       labels:
-        {{- with (include "curie.placement.labels" .Values.placement.hooks) }}
+        {{- with (include "curie.placement.labels" (dict "root" $ "class" "hooks")) }}
         {{- . | nindent 8 }}
         {{- end }}
         {{- include "curie.selectorLabels" (dict "root" . "component" "preflight-gvisor") | nindent 8 }}
-      {{- with (include "curie.placement.annotations" .Values.placement.hooks) }}
+      {{- with (include "curie.placement.annotations" (dict "root" $ "class" "hooks")) }}
       annotations:
         {{- . | nindent 8 }}
       {{- end }}
     spec:
-      {{- with (include "curie.placement.spec" .Values.placement.hooks) }}
+      {{- with (include "curie.placement.spec" (dict "root" $ "class" "hooks")) }}
       {{- . | nindent 6 }}
       {{- end }}
       restartPolicy: Never

--- a/charts/curie/templates/preflight-networkpolicy.yaml
+++ b/charts/curie/templates/preflight-networkpolicy.yaml
@@ -81,17 +81,17 @@ spec:
   template:
     metadata:
       labels:
-        {{- with (include "curie.placement.labels" .Values.placement.hooks) }}
+        {{- with (include "curie.placement.labels" (dict "root" $ "class" "hooks")) }}
         {{- . | nindent 8 }}
         {{- end }}
         {{- include "curie.labels" . | nindent 8 }}
         {{- include "curie.selectorLabels" (dict "root" . "component" "netpol-probe") | nindent 8 }}
-      {{- with (include "curie.placement.annotations" .Values.placement.hooks) }}
+      {{- with (include "curie.placement.annotations" (dict "root" $ "class" "hooks")) }}
       annotations:
         {{- . | nindent 8 }}
       {{- end }}
     spec:
-      {{- with (include "curie.placement.spec" .Values.placement.hooks) }}
+      {{- with (include "curie.placement.spec" (dict "root" $ "class" "hooks")) }}
       {{- . | nindent 6 }}
       {{- end }}
       serviceAccountName: {{ include "curie.fullname" . }}-netpol-probe

--- a/charts/curie/templates/runner-prewarm.yaml
+++ b/charts/curie/templates/runner-prewarm.yaml
@@ -37,13 +37,13 @@ spec:
   template:
     metadata:
       labels:
-        {{- with (include "curie.placement.labels" .Values.placement.sandbox) }}
+        {{- with (include "curie.placement.labels" (dict "root" $ "class" "sandbox")) }}
         {{- . | nindent 8 }}
         {{- end }}
         {{- include "curie.labels" . | nindent 8 }}
         {{- include "curie.selectorLabels" (dict "root" . "component" "runner-prewarm") | nindent 8 }}
       annotations:
-        {{- with (include "curie.placement.annotations" .Values.placement.sandbox) }}
+        {{- with (include "curie.placement.annotations" (dict "root" $ "class" "sandbox")) }}
         {{- . | nindent 8 }}
         {{- end }}
         # Rolls the prewarm pods on every `helm upgrade` so imagePullPolicy Always
@@ -51,7 +51,7 @@ spec:
         # alter the pod spec). See the file header.
         curietech.ai/prewarm-revision: {{ .Release.Revision | quote }}
     spec:
-      {{- with (include "curie.placement.spec" .Values.placement.sandbox) }}
+      {{- with (include "curie.placement.spec" (dict "root" $ "class" "sandbox")) }}
       {{- . | nindent 6 }}
       {{- end }}
       {{- with $runner.imagePullSecrets }}

--- a/charts/curie/templates/rustfs.yaml
+++ b/charts/curie/templates/rustfs.yaml
@@ -31,17 +31,17 @@ spec:
   template:
     metadata:
       labels:
-        {{- with (include "curie.placement.labels" .Values.placement.data) }}
+        {{- with (include "curie.placement.labels" (dict "root" $ "class" "data")) }}
         {{- . | nindent 8 }}
         {{- end }}
         {{- include "curie.labels" . | nindent 8 }}
         {{- include "curie.selectorLabels" (dict "root" . "component" "rustfs") | nindent 8 }}
-      {{- with (include "curie.placement.annotations" .Values.placement.data) }}
+      {{- with (include "curie.placement.annotations" (dict "root" $ "class" "data")) }}
       annotations:
         {{- . | nindent 8 }}
       {{- end }}
     spec:
-      {{- with (include "curie.placement.spec" .Values.placement.data) }}
+      {{- with (include "curie.placement.spec" (dict "root" $ "class" "data")) }}
       {{- . | nindent 6 }}
       {{- end }}
       {{- with .Values.priorityClasses.platform.name }}
@@ -133,16 +133,16 @@ spec:
   template:
     metadata:
       labels:
-        {{- with (include "curie.placement.labels" .Values.placement.hooks) }}
+        {{- with (include "curie.placement.labels" (dict "root" $ "class" "hooks")) }}
         {{- . | nindent 8 }}
         {{- end }}
         {{- include "curie.selectorLabels" (dict "root" . "component" "rustfs-init") | nindent 8 }}
-      {{- with (include "curie.placement.annotations" .Values.placement.hooks) }}
+      {{- with (include "curie.placement.annotations" (dict "root" $ "class" "hooks")) }}
       annotations:
         {{- . | nindent 8 }}
       {{- end }}
     spec:
-      {{- with (include "curie.placement.spec" .Values.placement.hooks) }}
+      {{- with (include "curie.placement.spec" (dict "root" $ "class" "hooks")) }}
       {{- . | nindent 6 }}
       {{- end }}
       restartPolicy: OnFailure

--- a/charts/curie/templates/security-probe.yaml
+++ b/charts/curie/templates/security-probe.yaml
@@ -103,19 +103,19 @@ kind: Pod
 metadata:
   name: {{ include "curie.fullname" . }}-security-probe-hardening
   labels:
-    {{- with (include "curie.placement.labels" .Values.placement.hooks) }}
+    {{- with (include "curie.placement.labels" (dict "root" $ "class" "hooks")) }}
     {{- . | nindent 4 }}
     {{- end }}
     {{- include "curie.labels" . | nindent 4 }}
   annotations:
-    {{- with (include "curie.placement.annotations" .Values.placement.hooks) }}
+    {{- with (include "curie.placement.annotations" (dict "root" $ "class" "hooks")) }}
     {{- . | nindent 4 }}
     {{- end }}
     "helm.sh/hook": test
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": before-hook-creation
 spec:
-  {{- with (include "curie.placement.spec" .Values.placement.hooks) }}
+  {{- with (include "curie.placement.spec" (dict "root" $ "class" "hooks")) }}
   {{- . | nindent 2 }}
   {{- end }}
   restartPolicy: Never
@@ -190,16 +190,16 @@ spec:
   template:
     metadata:
       labels:
-        {{- with (include "curie.placement.labels" .Values.placement.hooks) }}
+        {{- with (include "curie.placement.labels" (dict "root" $ "class" "hooks")) }}
         {{- . | nindent 8 }}
         {{- end }}
         {{- include "curie.selectorLabels" (dict "root" . "component" "security-probe") | nindent 8 }}
-      {{- with (include "curie.placement.annotations" .Values.placement.hooks) }}
+      {{- with (include "curie.placement.annotations" (dict "root" $ "class" "hooks")) }}
       annotations:
         {{- . | nindent 8 }}
       {{- end }}
     spec:
-      {{- with (include "curie.placement.spec" .Values.placement.hooks) }}
+      {{- with (include "curie.placement.spec" (dict "root" $ "class" "hooks")) }}
       {{- . | nindent 6 }}
       {{- end }}
       serviceAccountName: {{ include "curie.fullname" . }}-security-probe

--- a/charts/curie/templates/ui.yaml
+++ b/charts/curie/templates/ui.yaml
@@ -35,17 +35,17 @@ spec:
   template:
     metadata:
       labels:
-        {{- with (include "curie.placement.labels" .Values.placement.platform) }}
+        {{- with (include "curie.placement.labels" (dict "root" $ "class" "platform")) }}
         {{- . | nindent 8 }}
         {{- end }}
         {{- include "curie.labels" . | nindent 8 }}
         {{- include "curie.selectorLabels" (dict "root" . "component" "ui") | nindent 8 }}
-      {{- with (include "curie.placement.annotations" .Values.placement.platform) }}
+      {{- with (include "curie.placement.annotations" (dict "root" $ "class" "platform")) }}
       annotations:
         {{- . | nindent 8 }}
       {{- end }}
     spec:
-      {{- with (include "curie.placement.spec" .Values.placement.platform) }}
+      {{- with (include "curie.placement.spec" (dict "root" $ "class" "platform")) }}
       {{- . | nindent 6 }}
       {{- end }}
       {{- with .Values.ui.imagePullSecrets }}

--- a/charts/curie/templates/valkey.yaml
+++ b/charts/curie/templates/valkey.yaml
@@ -29,17 +29,17 @@ spec:
   template:
     metadata:
       labels:
-        {{- with (include "curie.placement.labels" .Values.placement.data) }}
+        {{- with (include "curie.placement.labels" (dict "root" $ "class" "data")) }}
         {{- . | nindent 8 }}
         {{- end }}
         {{- include "curie.labels" . | nindent 8 }}
         {{- include "curie.selectorLabels" (dict "root" . "component" "valkey") | nindent 8 }}
-      {{- with (include "curie.placement.annotations" .Values.placement.data) }}
+      {{- with (include "curie.placement.annotations" (dict "root" $ "class" "data")) }}
       annotations:
         {{- . | nindent 8 }}
       {{- end }}
     spec:
-      {{- with (include "curie.placement.spec" .Values.placement.data) }}
+      {{- with (include "curie.placement.spec" (dict "root" $ "class" "data")) }}
       {{- . | nindent 6 }}
       {{- end }}
       {{- with .Values.priorityClasses.platform.name }}

--- a/charts/curie/templates/worker.yaml
+++ b/charts/curie/templates/worker.yaml
@@ -109,7 +109,7 @@ spec:
   template:
     metadata:
       annotations:
-        {{- with (include "curie.placement.annotations" .Values.placement.platform) }}
+        {{- with (include "curie.placement.annotations" (dict "root" $ "class" "platform")) }}
         {{- . | nindent 8 }}
         {{- end }}
         # Roll the workers when the per-adapter egress credentials change
@@ -133,13 +133,13 @@ spec:
         # secretKeyRef env resolves once at pod start).
         checksum/adapter-credentials: {{ include "curie.adapterCredentialsChecksumSource" . | sha256sum }}
       labels:
-        {{- with (include "curie.placement.labels" .Values.placement.platform) }}
+        {{- with (include "curie.placement.labels" (dict "root" $ "class" "platform")) }}
         {{- . | nindent 8 }}
         {{- end }}
         {{- include "curie.labels" . | nindent 8 }}
         {{- include "curie.selectorLabels" (dict "root" . "component" "worker") | nindent 8 }}
     spec:
-      {{- with (include "curie.placement.spec" .Values.placement.platform) }}
+      {{- with (include "curie.placement.spec" (dict "root" $ "class" "platform")) }}
       {{- . | nindent 6 }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.worker.terminationGracePeriodSeconds }}

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -28,6 +28,12 @@ global:
 # and prewarm, Helm hooks, and the sandbox controller, respectively.
 # podLabels can drive platform selectors. nodeSelector, tolerations, and
 # affinity remain generic Kubernetes placement fields for any substrate.
+# A release upgraded from a pre-placement chart can replay `placement: null`
+# back in through `helm upgrade --reuse-values`, because Helm's coalescing
+# deletes a null-valued key outright rather than falling back to this file. The
+# templates therefore resolve every class through the `curie.placement.class`
+# helper, so that case degrades to the empty defaults below instead of failing
+# the render (#2008).
 placement:
   platform:
     podLabels: {}


### PR DESCRIPTION
## Summary

A Helm release created before placement classes existed stores `placement: null`. `helm upgrade --reuse-values` replays that stored config as the new user values, and Helm's coalescing deletes a key whose replayed value is YAML null — so `.Values.placement` came back nil and every `.Values.placement.<class>` dereference in the templates crashed the render with `nil pointer evaluating interface {}.platform`, before any cluster mutation. The only workaround was for the operator to hand-synthesize all five internal default class maps. Every placement lookup now goes through one nil-tolerant `curie.placement.class` helper, so a legacy release upgrades cleanly with no compatibility map.

## Related issue

Closes #2008

## Fix pin verification

Fix pin: charts/curie/ci/render-assertions.sh

## What changed

- **`charts/curie/templates/_helpers.tpl`** — new `curie.placement.class` define resolves one named class nil-safely. `curie.placement.labels` / `.annotations` / `.spec` changed signature from a bare class dict to `(dict "root" <root> "class" "<name>")`, matching the file's existing `curie.selectorLabels` idiom.
- **19 templates, 69 call sites** — mechanically rewritten to the new signature. Three sites in `agent-sandbox.yaml` sit inside `{{- define "curie.sandboxTemplate" -}}` within a `{{- with .root }}` block and pass `.`; the other 66 pass `$`. Zero `.Values.placement.` dereferences remain.
- **Fail-closed on a malformed shape.** A nil or missing tree/class degrades to the chart's empty defaults, but a tree or class that is *present and not a map* is refused with `fail` naming the key and its actual kind. `fromYaml` returns an error map rather than an error for a non-map document, so without this the previously-fatal `placement: {platform: spot}` would render successfully with every scheduling constraint silently dropped. This was caught by adversarial review, not by the original fix.
- **`charts/curie/ci/render-assertions.sh`** — Placement assertions 4 and 5 plus a negative control.
- **Docs** — `charts/curie/CLAUDE.md` gains the lookup invariant; the existing `values.schema.json` sub-bullet now names `placement` as the second instance of that same coalescing gap. `values.yaml` comment only.

## End-to-end verification

`helm template` on a fixture reproducing the coalesced shape is the faithful reproduction of this bug: the failure is a *render* failure that happens before any cluster contact, and the issue's own reproduction is `helm upgrade --dry-run`. A live `--reuse-values` run needs an existing release, which chart CI has no cluster or release history to provide; that limitation is stated in the assertion's own comment rather than papered over.

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | Chart-only change; no bundle, runner, or agent surface touched. | — | — |
| local | n/a | No compose service, image, or env plumbing changed. | — | — |
| local-release | n/a | Same. | — | — |
| cluster | n/a | The defect is a template render failure that aborts before any cluster mutation; render-level checks reach it fully. No cluster was mutated (task constraint). | — | — |
| live provider | n/a | No provider, credential, or model path touched. | — | — |
| external integration | n/a | No external integration touched. | — | — |

**Regression fails before the fix, passes after** — against `origin/next` @ `7dfa4008`:

```
$ bash charts/curie/ci/render-assertions.sh            # at 7dfa4008 + the test commit only
=== Placement assertion 4: a legacy release's retained placement: null still renders (#2008) ===
FAIL: a legacy release's retained 'placement: null' failed to render (#2008): Error: template:
curie/templates/worker.yaml:112:63: executing "curie/templates/worker.yaml" at
<.Values.placement.platform>: nil pointer evaluating interface {}.platform
exit=1
```

```
$ bash charts/curie/ci/render-assertions.sh            # with the fix
=== Placement assertion 4: a legacy release's retained placement: null still renders (#2008) ===
  ok: all 23 pod surfaces omit placement markers and scheduling fields by default
=== Placement assertion 4 negative control: reverting the nil-safe placement accessor FAILS ===
  ok: stripping the nil-guard from curie.placement.class makes the legacy-null render fail again (the assert can fail)
=== Placement assertion 5: a malformed placement class is refused, not silently dropped (#2008) ===
  ok: malformed placement values are refused by name, and legacy 'placement: null' still renders
exit=0
```

**Falsifiable negative controls, both executed, not read:**

- Stripping the first `| default dict` from `curie.placement.class` makes the legacy-null render fail again — so assertion 4 is pinning something.
- `placement: {platform: spot}` → exit 1, `placement.platform must be a map of placement fields (podLabels, annotations, nodeSelector, tolerations, affinity), got string`. On the base chart this shape also failed (`can't evaluate field annotations in type string`); on the first draft of this fix it rendered exit 0 with zero `nodeSelector` keys. The refusal restores the pre-existing fail-closed behavior.
- `placement: spot` → exit 1, `placement must be a map of placement classes, got string`.

**Nothing else moved.** Rendered output is byte-identical to the base chart (chart-generated random credentials masked) for default values, `values-dev.yaml`, `values-dev.yaml + values-e2e-nogvisor.yaml`, and the CI populated-placement fixture — 5220 / 3235 / 3235 / 5675 lines each. All 23 pod surfaces still receive their exact populated placement class (assertion 1), still omit it by default (assertion 2), and the platform marker still does not leak across classes (assertion 3).

**Gates run to completion locally, all green:** `helm lint` on all three shipped overlays; all 28 `charts/curie/ci/*.sh` assertion scripts; `kubeconform -strict -ignore-missing-schemas -kubernetes-version 1.29.0` on default / dev / nogvisor **and** on the `placement: null` path (88 resources, identical to default); `scripts/check-docs.sh`; `scripts/check-version-consistency.sh`; `scripts/check-commit-messages.sh`.

## Reviewer notes

- **`main` is affected too.** `origin/main` fails identically (`worker.yaml:104:63`, same nil dereference). AGENTS.md routes a bug shared by both lines to `main` first; this PR targets `next` because that is where the issue was filed and reproduced (`next@ae5d57b1`, chart 0.7.2). Worth a follow-up cherry-pick or letting the next forward merge carry it — flagging rather than deciding.
- **The 69-site rewrite is the cost of the chosen fix.** Guarding only inside the three helpers cannot work: the nil dereference happens while evaluating the *argument*, before the helper is entered. Guarding at each call site inline would touch the same 69 lines while leaving the nil-safety scattered and re-introducible by the next template author. Centralizing it in one accessor was the smaller long-term change; every call-site edit is a pure mechanical substitution and the byte-identity check above is the proof.
- Adversarial review ran cross-engine (Codex `gpt-5.6-sol`) and raised exactly one blocking finding, the fail-open regression, which is fixed in `21776c3c` and pinned by assertion 5.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [ ] An ADR is added under `docs/adr/` if this is an architectural decision. — n/a, this restores the intended behavior of an existing decision rather than making a new one.
