### PR TITLE
fix: classify runner stream timeouts explicitly with terminal evidence

### DIFF
--- a/apps/worker/CLAUDE.md
+++ b/apps/worker/CLAUDE.md
@@ -34,7 +34,8 @@ stop -- that is scope creep on the sacred module.
    `side_effect_flag` escalates to a human instead of retrying; the flag is
    persisted to Valkey the instant it is seen so a crash mid-side-effect
    still escalates on reclaim. Flag-clean failures retry by classification
-   (`rate-limit`/`runner-error` transient, everything else escalates).
+   (`rate-limit`/`runner-error`/`runner-timeout` transient, everything else
+   escalates).
 
 ## Delivery is bounded (ADR-0039, #505)
 

--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -179,8 +179,11 @@ Rules (detailed-architecture 2b), each with an integration test that provokes it
   instead of retrying. The flag is persisted to Valkey the instant it is seen, so
   a worker crash mid-side-effect still escalates on reclaim rather than re-running
   a non-idempotent action. Flag-clean failures retry by classification:
-  `rate-limit` and `runner-error` are transient (bounded exponential backoff);
-  `budget-exceeded` and everything else escalate.
+  `rate-limit`, `runner-error` and `runner-timeout` are transient (bounded
+  exponential backoff); `budget-exceeded` and everything else escalate.
+  `runner-timeout` is the runner's streaming budget expiring mid-turn (#2011),
+  told apart from `runner-error` -- the sandbox or the transport dying -- so an
+  operator can see which one happened.
 - **Idempotency + crash recovery.** The Slack event id gates a `done` marker, so
   a redelivered or reclaimed entry that already finished is skipped.
   `XAUTOCLAIM` reclaims entries a dead consumer took but never acked and

--- a/apps/worker/src/curie_worker/kernel.py
+++ b/apps/worker/src/curie_worker/kernel.py
@@ -14,8 +14,8 @@ Rules implemented here (detailed-architecture section 2b):
 5. No auto-retry after side effects. A failed run that emitted ``side_effect_flag``
    escalates to a human instead of retrying; the flag is persisted the instant it
    is seen so a crash mid-side-effect still escalates on reclaim. Flag-clean
-   failures retry by error classification (rate-limit / runner-error are
-   transient; budget-exceeded and everything else escalate).
+   failures retry by error classification (rate-limit / runner-error /
+   runner-timeout are transient; budget-exceeded and everything else escalate).
 
 Idempotency: the Slack event id gates a ``done`` marker so a redelivered or
 reclaimed event that already finished is skipped.
@@ -101,6 +101,7 @@ from .reply_sink import ObservedReplySink, ReplySink, TargetRoute
 from .runner_client import (
     RunnerClient,
     RunnerError,
+    RunnerStreamTimeout,
     RunnerWorkspaceSnapshot,
     TurnStream,
 )
@@ -274,9 +275,30 @@ def _nav_affordance(nav: NavPack | None) -> NavAffordance | None:
     return NavAffordance(label=nav.hub_label, command=nav.hub_command)
 
 
+def _exception_reason(exc: BaseException) -> str:
+    """A never-empty operator-facing reason for a caught exception (#2011).
+
+    ``str(TimeoutError())`` is the empty string, so logging a caught exception
+    directly can print nothing at all where the reason belongs. Prefer the
+    class name plus the message, and fall back to the class name alone when the
+    exception carries no message.
+    """
+    text = str(exc).strip()
+    if text:
+        return f"{type(exc).__name__}: {text}"
+    return type(exc).__name__
+
+
 # Failure classifications that are worth retrying (transient). Everything else
 # (budget-exceeded, model/server errors) escalates rather than looping.
-RETRYABLE_CLASSIFICATIONS = frozenset({"rate-limit", "runner-error"})
+# ``runner-timeout`` (#2011) is the streaming budget expiring mid-turn. It is
+# named separately from ``runner-error`` so an operator can tell "the model ran
+# past the budget" from "the sandbox died", but it stays HERE because retry
+# semantics are unchanged by that naming: a flag-clean timeout was transient
+# before it had a name and still is. The side-effect check in ``_attempt`` runs
+# BEFORE retryability is consulted (ADR-0013), so a timeout that arrives after a
+# side-effect frame still escalates and is never retried.
+RETRYABLE_CLASSIFICATIONS = frozenset({"rate-limit", "runner-error", "runner-timeout"})
 
 # The floor of remaining DELIVERY budget below which a fresh attempt is not
 # started (ADR-0131). The runner cannot claim a sandbox, open a turn and stream a
@@ -3170,12 +3192,40 @@ class Kernel:
                     if isinstance(frame, Final):
                         break
         except (aiohttp.ClientError, TimeoutError) as exc:
-            # Stream dropped mid-run (sandbox killed, network fault). No final.
-            logger.warning("turn stream dropped for %s: %s", qevent.event_id, exc)
+            # Stream dropped mid-run (sandbox killed, network fault, or the
+            # client's streaming budget expiring). No final.
+            #
+            # #2011: both halves of this used to lose information. ``str()`` of a
+            # bare TimeoutError is the EMPTY STRING, so the operator log read
+            # "turn stream dropped for <id>: " with nothing after the colon; and
+            # a timeout collapsed into the same "runner-error" a killed sandbox
+            # produces. ``_exception_reason`` guarantees a non-empty reason for
+            # EVERY exception this clause catches, and a runner timeout gets its
+            # own classification. An ErrorEvent-supplied ``acc.classification``
+            # still wins: the runner's own account of why the turn failed
+            # outranks the transport symptom the worker observed.
+            #
+            # The classification test is the CONCRETE ``RunnerStreamTimeout``,
+            # never the ``TimeoutError`` base class: this clause spans frame
+            # application, and ``_apply_frame`` delivers the reply, whose HTTP
+            # adapter has its own 30s budget. A stalled reply endpoint raises a
+            # plain ``TimeoutError`` while the runner was answering normally, so
+            # it is not a runner timeout and must not borrow the name -- it
+            # falls back to "runner-error". ``TurnStream.__aiter__`` converts
+            # every stream-budget expiry into ``RunnerStreamTimeout``, so a
+            # genuine runner timeout still lands here as "runner-timeout".
+            logger.warning(
+                "turn stream dropped for %s: %s",
+                qevent.event_id,
+                _exception_reason(exc),
+            )
+            classification = acc.classification or (
+                "runner-timeout" if isinstance(exc, RunnerStreamTimeout) else "runner-error"
+            )
             return TurnOutcome(
                 terminal_ok=False,
                 saw_side_effect=acc.saw_side_effect,
-                classification=acc.classification or "runner-error",
+                classification=classification,
                 text=acc.rendered(),
             )
         except ActionBackendError as exc:

--- a/apps/worker/src/curie_worker/runner_client.py
+++ b/apps/worker/src/curie_worker/runner_client.py
@@ -19,6 +19,7 @@ import asyncio
 import base64
 import binascii
 import json
+import logging
 import time
 from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass
@@ -51,6 +52,8 @@ _POST_FINAL_CLEANUP_TIMEOUT_S = 1.0
 _POST_FINAL_DISCARD_CHUNK_BYTES = 64 * 1024
 _T = TypeVar("_T")
 
+logger = logging.getLogger(__name__)
+
 
 def _auth_headers(token: str | None) -> dict[str, str] | None:
     """Per-call Authorization header for the per-sandbox runner token (issue #63).
@@ -64,8 +67,31 @@ def _auth_headers(token: str | None) -> dict[str, str] | None:
     return None
 
 
+def _mark_rpc_failed(span: Any, outcome: str, cause: BaseException) -> None:
+    """Stamp one runner-RPC span as failed, in the one shared vocabulary."""
+    if hasattr(span, "set_status"):
+        span.set_status(StatusCode.ERROR)
+    span.add_event(
+        "runner.rpc.failed",
+        {"outcome": outcome, "error.class": type(cause).__name__},
+    )
+
+
 class RunnerError(Exception):
     """The runner returned an unexpected HTTP status or an unreadable stream."""
+
+
+class RunnerStreamTimeout(TimeoutError):
+    """The streamed turn body exceeded the client's total/sock-read budget.
+
+    A ``TimeoutError`` subclass on purpose (#2011): every existing
+    ``except TimeoutError`` / ``except (aiohttp.ClientError, TimeoutError)``
+    handler in the worker keeps catching this unchanged. What it adds is a
+    non-empty ``str()`` -- ``str(TimeoutError())`` is the EMPTY STRING, which is
+    how a real 600s cluster timeout reached the operator log as "turn stream
+    dropped for <id>: " with nothing after the colon -- naming both the
+    normalized underlying exception class and the budget that expired.
+    """
 
 
 @dataclass(frozen=True)
@@ -84,25 +110,77 @@ class RunnerWorkspaceSnapshot:
 class TurnStream:
     """An open ``/v1/event`` response: the turn is active; iterate for frames."""
 
-    def __init__(self, response: aiohttp.ClientResponse) -> None:
+    def __init__(
+        self, response: aiohttp.ClientResponse, budget_s: float | None = None
+    ) -> None:
         self._response = response
         self._saw_final = False
+        # The streaming budget this stream is running under, carried from the
+        # client so the stream can NAME the budget it blew (#2011). Optional so
+        # a directly-constructed TurnStream (tests, evals) still works.
+        self._budget_s = budget_s
 
     async def __aiter__(self) -> AsyncIterator[OutboundEvent]:
-        async for raw in self._response.content:
-            line = raw.decode("utf-8").strip()
-            if not line:
-                continue
-            frame = parse_ndjson_line(line)
-            if isinstance(frame, Final):
-                self._saw_final = True
-            yield frame
-            if isinstance(frame, Final):
-                # Final is terminal for every consumer, including evals that
-                # naturally iterate to stream end. Bytes after it belong only
-                # to the bounded transport cleanup in __aexit__; they must not
-                # be parsed, applied, or allowed to occupy the 600s turn budget.
-                return
+        try:
+            async for raw in self._response.content:
+                line = raw.decode("utf-8").strip()
+                if not line:
+                    continue
+                frame = parse_ndjson_line(line)
+                if isinstance(frame, Final):
+                    self._saw_final = True
+                yield frame
+                if isinstance(frame, Final):
+                    # Final is terminal for every consumer, including evals that
+                    # naturally iterate to stream end. Bytes after it belong only
+                    # to the bounded transport cleanup in __aexit__; they must not
+                    # be parsed, applied, or allowed to occupy the 600s turn budget.
+                    return
+        except TimeoutError as cause:
+            # ONLY TimeoutError (which covers asyncio.TimeoutError,
+            # aiohttp.ServerTimeoutError and aiohttp.SocketTimeoutError). A
+            # genuine connection reset is an aiohttp.ClientError and is NOT a
+            # timeout: it must keep flowing to the kernel as the generic
+            # runner-error it has always been. asyncio.CancelledError does not
+            # subclass TimeoutError, so cooperative cancellation still passes
+            # straight through -- do not broaden this clause.
+            self._record_stream_timeout(cause)
+            raise RunnerStreamTimeout(self._timeout_reason(cause)) from cause
+
+    def _timeout_reason(self, cause: BaseException) -> str:
+        budget = "unbounded" if self._budget_s is None else f"{self._budget_s}s"
+        return (
+            f"runner turn stream exceeded its {budget} total/sock-read budget "
+            f"({type(cause).__name__})"
+        )
+
+    def _record_stream_timeout(self, cause: BaseException) -> None:
+        """Emit the terminal record this boundary previously never produced.
+
+        ``RunnerClient._rpc``'s span for ``start_turn`` closes as soon as the
+        response HEADERS arrive, so a budget expiring while the NDJSON BODY is
+        read left no evidence at the RPC boundary at all -- the only
+        ``curie.runner.rpc.result`` point for the turn said ``success`` (#2011).
+        The attribute values here are already in the shared allowlist, and the
+        span/event keys are the same closed vocabulary ``_rpc`` uses.
+        """
+        reason = self._timeout_reason(cause)
+        logger.warning("%s", reason)
+        attributes = {
+            "service.name": "curie-worker",
+            "operation": "event",
+            "role": "client",
+        }
+        record_metric(
+            "curie.runner.rpc.result",
+            attributes={**attributes, "outcome": "timeout"},
+        )
+        with operation_span(
+            "curie.runner.rpc",
+            kind=SpanKind.CLIENT,
+            attributes=attributes,
+        ) as span:
+            _mark_rpc_failed(span, "timeout", cause)
 
     async def _discard_post_final(self) -> None:
         """Briefly keep the transport open while discarding bytes through EOF.
@@ -163,6 +241,7 @@ class RunnerClient:
     ) -> None:
         if snapshot_patch_max_bytes <= 0:
             raise ValueError("snapshot patch byte limit must be positive")
+        self._total_timeout_s = total_timeout_s
         self._own_session = session is None
         self._connect_timeout_s = connect_timeout_s
         # Since ADR-0131 this is a per-request CEILING inside the delivery's one
@@ -251,12 +330,7 @@ class RunnerClient:
             except Exception as exc:
                 error = exc
                 outcome = "timeout" if isinstance(exc, TimeoutError) else "failure"
-                if hasattr(span, "set_status"):
-                    span.set_status(StatusCode.ERROR)
-                span.add_event(
-                    "runner.rpc.failed",
-                    {"outcome": outcome, "error.class": type(exc).__name__},
-                )
+                _mark_rpc_failed(span, outcome, exc)
             else:
                 span.add_event("runner.rpc.completed", {"outcome": outcome})
 
@@ -292,7 +366,7 @@ class RunnerClient:
                 body = await resp.text()
                 resp.release()
                 raise RunnerError(f"/v1/event -> {resp.status}: {body}")
-            return TurnStream(resp), "success"
+            return TurnStream(resp, self._total_timeout_s), "success"
 
         return await self._rpc("event", token, request)
 

--- a/apps/worker/tests/kernel/conftest.py
+++ b/apps/worker/tests/kernel/conftest.py
@@ -444,13 +444,26 @@ class FakeRunner:
         resp = web.StreamResponse(status=200, headers={"Content-Type": "application/x-ndjson"})
         await resp.prepare(request)
         self.turn_active = True
-        for frame in script:
-            await resp.write((frame.model_dump_json() + "\n").encode("utf-8"))
-        if self.hold is not None:
-            await self.hold.wait()  # type: ignore[attr-defined]
-            for frame in self.tail:
+        # Cleared on EVERY exit path, not just the normal one. A client that
+        # gives up mid-stream (its total/sock-read budget expiring, #2011)
+        # releases the response, and aiohttp then CANCELS this handler while it
+        # is parked on ``hold`` -- so a fake that only cleared the flag on its
+        # way out would stay "busy" forever, and every later turn on the thread
+        # would be answered by a 200 from /v1/steer and folded into the dead
+        # turn instead of opening a fresh one. The real runner's session ends
+        # with the process/turn that died, so idle-after-a-drop is the faithful
+        # model, and it is what makes the timeout retry path testable at all.
+        try:
+            for frame in script:
                 await resp.write((frame.model_dump_json() + "\n").encode("utf-8"))
-        self.turn_active = False
+            if self.hold is not None:
+                await self.hold.wait()  # type: ignore[attr-defined]
+                for frame in self.tail:
+                    await resp.write((frame.model_dump_json() + "\n").encode("utf-8"))
+        finally:
+            self.turn_active = False
+        # Normal path only: on a dead transport this raises, and there is no
+        # eof to send to a client that already went away.
         await resp.write_eof()
         return resp
 
@@ -543,7 +556,12 @@ def make_harness(
     ledger recorder), ``with_killswitch``
     (build a real KillSwitch wired to the kernel) and ``sink`` (any ``ReplySink``
     -- a real ``ReplySinkRouter`` for the adapter-selection tests, T-B3/T-B4);
-    the rest are config overrides."""
+    the rest are config overrides. ``runner_total_timeout_s`` is an ordinary
+    config override: it drives BOTH the ``WorkerConfig`` and the
+    ``RunnerClient``'s streaming budget (mirroring ``run.py``), so a test that
+    expires the stream mid-flight (#2011) passes a fractional value and the
+    config's own ``runner_total_timeout_s <= delivery_budget_s`` validator still
+    judges what the client actually does."""
 
     def factory(**overrides: object) -> contextlib.AbstractAsyncContextManager[Harness]:
         return kernel_harness(names, sync_redis, **overrides)
@@ -592,7 +610,14 @@ async def kernel_harness(
         host=_VALKEY_HOST, port=_VALKEY_PORT, password=_VALKEY_PW or None, decode_responses=True
     )
     reply_sink = FakeSink() if sink is None else sink
-    runner_client = RunnerClient(total_timeout_s=30.0)
+    # One source of truth, exactly as production does it (``run.py`` builds the
+    # real client with ``total_timeout_s=config.runner_total_timeout_s``):
+    # ``runner_total_timeout_s`` flows through ``**config_overrides`` into the
+    # ``WorkerConfig`` and the client is built from the resulting config. A
+    # harness whose client budget could silently disagree with its own config
+    # would slip past the config's ``runner_total_timeout_s <=
+    # delivery_budget_s`` validator, which now couples the two.
+    runner_client = RunnerClient(total_timeout_s=config.runner_total_timeout_s)
     card_store = ApprovalCardStore(async_redis, config)
     kernel = Kernel(
         substrate=substrate,

--- a/apps/worker/tests/kernel/test_kernel.py
+++ b/apps/worker/tests/kernel/test_kernel.py
@@ -2164,3 +2164,211 @@ def test_an_unreadable_runner_fails_closed_and_leaves_a_reclaimed_delivery_pendi
             assert summary["pending"] == 0
 
     asyncio.run(go())
+
+
+# --- The streaming budget expiring is its OWN failure, not a generic one (#2011)
+# When aiohttp's total/sock_read budget expires mid-stream the kernel used to
+# see a BARE ``TimeoutError`` whose ``str()`` is the empty string: the operator
+# log read "turn stream dropped for <id>: " with nothing after the colon, and
+# the outcome collapsed into the same "runner-error" a killed sandbox or a
+# broken socket produces. A timeout is a distinct, actionable condition (the
+# model ran past the budget) and must classify and log as one.
+
+
+def test_stream_timeout_classifies_as_runner_timeout_with_a_named_reason(
+    make_harness, caplog
+) -> None:
+    """#2011: a mid-stream timeout is classified ``runner-timeout`` and logged
+    with a NON-EMPTY reason.
+
+    The runner streams a side-effect frame and then hangs without a ``Final``,
+    so the client's short total budget expires while the kernel is iterating.
+    Today the outcome comes back as the generic ``runner-error`` and the warning
+    ends at a bare colon, which is exactly the pair this pins."""
+
+    async def go() -> None:
+        async with make_harness(runner_total_timeout_s=0.5) as h:
+            hold = asyncio.Event()  # never set: the response hangs open
+            h.runner.hold = hold
+            h.runner.default_script = [SideEffectFlag(tool="deploy")]
+            released: list[bool] = []
+
+            def release_order() -> None:
+                released.append(True)
+
+            qe = _qevent("go", thread="tStreamTimeout")
+            try:
+                with caplog.at_level(logging.WARNING, logger="curie_worker.kernel"):
+                    outcome = await h.kernel._attempt(qe, TargetRoute(), release_order)
+            finally:
+                hold.set()  # let the fake runner's handler unwind
+
+            assert outcome.terminal_ok is False
+            assert outcome.classification == "runner-timeout"
+            assert outcome.saw_side_effect is True
+            assert released, "the order lock was not released on the timed-out turn"
+
+            dropped = [
+                r.getMessage()
+                for r in caplog.records
+                if "turn stream dropped" in r.getMessage()
+            ]
+            assert dropped, caplog.text
+            message = dropped[-1]
+            # "turn stream dropped for <event_id>: <reason>" -- the reason is what
+            # #2011 lost. A bare TimeoutError stringifies to "", so today this is
+            # the empty tail the operator sees.
+            reason = message.rsplit(":", 1)[1].strip()
+            assert reason, f"the drop reason is empty: {message!r}"
+            assert "Timeout" in message, message
+
+    asyncio.run(go())
+
+
+def test_stream_timeout_after_a_side_effect_escalates_without_retry(make_harness) -> None:
+    """#2011 x rule 4: a timeout that arrives after a side-effect frame is
+    escalated to a human, never retried, and the escalation names the new
+    ``runner-timeout`` classification rather than the generic runner-error.
+
+    Same shape as test_side_effect_failure_escalates_without_retry, but the
+    failure is the streaming budget expiring instead of an ErrorEvent."""
+
+    async def go() -> None:
+        async with make_harness(runner_total_timeout_s=0.5, max_attempts=3) as h:
+            hold = asyncio.Event()
+            h.runner.hold = hold
+            h.runner.default_script = [SideEffectFlag(tool="deploy")]
+            ev = _qevent("do it", thread="tTimeoutSideEffect")
+            try:
+                await h.kernel.process_event(ev)
+            finally:
+                hold.set()
+
+            assert h.runner.opened == ["do it"]  # exactly one attempt, no retry
+            assert h.sink.last_text is not None
+            assert "human" in h.sink.last_text.lower()
+            assert "runner-timeout" in h.sink.last_text
+            assert await h.async_redis.exists(h.config.side_effect_key(ev.event_id))
+            assert await h.async_redis.exists(h.config.done_key(ev.event_id))
+
+    asyncio.run(go())
+
+
+def test_stream_timeout_without_a_side_effect_still_retries(make_harness, monkeypatch) -> None:
+    """#2011, the negative path: naming the timeout must not change retry
+    semantics. A flag-clean timeout is still transient, so ``runner-timeout``
+    belongs in RETRYABLE_CLASSIFICATIONS and in the ``retry_class`` metric
+    allowlist -- ``record_metric`` RAISES on an out-of-domain attribute value,
+    so the real (un-probed) telemetry here is what catches a missing entry.
+
+    Attempt 1 streams a delta and then hangs until the client's budget expires;
+    the hold is released while the kernel backs off, so attempt 2 finds an idle
+    runner (a 409 on the steer probe) and opens a fresh turn that completes.
+
+    Two independent things make the runner idle again before attempt 2 probes
+    it -- the client's disconnect cancels the hanging handler, and the releaser
+    below sets ``hold`` just past the budget -- and ``FakeRunner._event`` now
+    clears ``turn_active`` on both paths. That matters because /v1/steer answers
+    200 while a turn is still marked live: a runner left wrongly busy would have
+    the retry folded into the dead turn as a STEER instead of opening a second
+    one, which is what ``steers == []`` below guards."""
+
+    real_record_metric = kernel_module.record_metric
+    recorded: list[tuple[str, dict[str, str]]] = []
+
+    def spy(name: str, value: float = 1, *, attributes: dict[str, str] | None = None) -> None:
+        recorded.append((name, dict(attributes or {})))
+        # Delegate to the real recorder so the metric allowlist still validates.
+        real_record_metric(name, value, attributes=attributes)
+
+    monkeypatch.setattr(kernel_module, "record_metric", spy)
+
+    async def go() -> None:
+        async with make_harness(
+            runner_total_timeout_s=0.5,
+            max_attempts=3,
+            retry_backoff_base_s=0.5,
+            retry_backoff_max_s=0.6,
+        ) as h:
+            hold = asyncio.Event()
+            h.runner.hold = hold
+            h.runner.turn_scripts = [
+                [TextDelta(text="partial")],
+                [Final(text="recovered", status=DONE)],
+            ]
+
+            async def release_after_the_budget_expires() -> None:
+                # The turn is open; the client gives up 0.5s later and the kernel
+                # then backs off 0.5s before attempt 2 probes the runner. Release
+                # just past the client's budget so a handler that was not already
+                # cancelled by the disconnect unwinds inside that window; either
+                # way the probe finds an idle session (409 on the steer) and a
+                # NEW turn is opened.
+                await _wait_until(lambda: len(h.runner.opened) >= 1)
+                await asyncio.sleep(0.6)
+                hold.set()
+
+            releasing = asyncio.create_task(release_after_the_budget_expires())
+            ev = _qevent("go", thread="tTimeoutRetry")
+            try:
+                await h.kernel.process_event(ev)
+            finally:
+                hold.set()
+                await releasing
+
+            # Asserted FIRST: this is the #2011 property. Leaving it behind the
+            # shape assertions would let a harness-timing slip surface instead of
+            # the classification the test exists to pin.
+            retries = [attrs for name, attrs in recorded if name == "curie.queue.retry"]
+            assert retries, recorded
+            assert retries[-1]["retry_class"] == "runner-timeout"
+
+            assert h.runner.opened == ["go", "go"]  # timed out, then retried
+            assert h.runner.steers == []  # the retry opened a turn, it did not steer
+            assert h.sink.last_text == "recovered"
+            assert not await h.async_redis.exists(h.config.side_effect_key(ev.event_id))
+
+    asyncio.run(go())
+
+
+def test_reply_delivery_timeout_is_not_a_runner_timeout(make_harness, caplog, monkeypatch) -> None:
+    """#2011, the boundary: only a RUNNER timeout may claim ``runner-timeout``.
+
+    The `except (aiohttp.ClientError, TimeoutError)` clause in `_consume` spans
+    frame application, and delivering a reply has its own HTTP budget
+    (`HttpReplyAdapter` builds a 30s `ClientTimeout`). So a stalled reply
+    endpoint raises a bare `TimeoutError` while the runner was answering
+    perfectly well -- classifying that as ``runner-timeout`` would point an
+    operator at the model budget for a delivery fault. It must stay
+    ``runner-error``, while still logging a NON-EMPTY reason like every other
+    exception this clause catches."""
+
+    async def go() -> None:
+        async with make_harness() as h:
+            h.runner.default_script = [TextDelta(text="partial")]
+
+            async def stalled_delivery(*_args: object, **_kwargs: object) -> None:
+                # Not a RunnerStreamTimeout: this is what aiohttp raises when the
+                # reply endpoint stops answering mid-turn.
+                raise TimeoutError()
+
+            monkeypatch.setattr(h.kernel, "_apply_frame", stalled_delivery)
+
+            qe = _qevent("go", thread="tReplyTimeout")
+            with caplog.at_level(logging.WARNING, logger="curie_worker.kernel"):
+                outcome = await h.kernel._attempt(qe, TargetRoute(), lambda: None)
+
+            assert outcome.terminal_ok is False
+            assert outcome.classification == "runner-error"
+
+            dropped = [
+                r.getMessage()
+                for r in caplog.records
+                if "turn stream dropped" in r.getMessage()
+            ]
+            assert dropped, caplog.text
+            message = dropped[-1]
+            reason = message.rsplit(":", 1)[1].strip()
+            assert reason, f"the drop reason is empty: {message!r}"
+
+    asyncio.run(go())

--- a/apps/worker/tests/kernel/test_otel_runtime.py
+++ b/apps/worker/tests/kernel/test_otel_runtime.py
@@ -14,6 +14,7 @@ from typing import Any
 import pytest
 from aci_protocol import (
     ErrorEvent,
+    Event,
     Final,
     QueuedTurn,
     ReplyHandle,
@@ -813,3 +814,58 @@ def test_planned_shared_telemetry_api_is_the_runtime_dependency() -> None:
     assert callable(extract_trace_context)
     assert callable(operation_span)
     assert callable(record_metric)
+
+
+def test_stream_timeout_emits_a_timeout_rpc_result_and_a_failed_span(
+    make_harness,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#2011: the runner RPC boundary must produce terminal evidence when the
+    streaming budget expires.
+
+    ``start_turn``'s span closes as soon as the response headers arrive, so a
+    budget that expires while the NDJSON body is being read currently emits
+    nothing here at all: the only ``curie.runner.rpc.result`` point for the turn
+    says ``outcome="success"``. The stream boundary must record its own
+    ``outcome="timeout"`` point and mark its span ERROR, or a timed-out turn is
+    invisible in the RPC telemetry."""
+
+    async def go() -> None:
+        probe = _install(monkeypatch)
+        async with make_harness() as h:
+            hold = asyncio.Event()  # never set: the response hangs after a prefix
+            h.runner.hold = hold
+            h.runner.default_script = [TextDelta(text="x")]
+            handle = await asyncio.to_thread(h.substrate.claim, "thread-stream-timeout")
+            client = runner_client_module.RunnerClient(total_timeout_s=0.5)
+            try:
+                turn = await client.start_turn(
+                    handle.base_url, Event(type="message", text="hi", user="U", ts="1")
+                )
+                with pytest.raises(TimeoutError):
+                    async with turn:
+                        async for _frame in turn:
+                            pass
+
+                results = _metrics(probe, "curie.runner.rpc.result")
+                timeouts = [
+                    point for point in results if point.attributes.get("outcome") == "timeout"
+                ]
+                assert timeouts, [point.attributes for point in results]
+                attributes = timeouts[-1].attributes
+                assert attributes["service.name"] == "curie-worker"
+                assert attributes["operation"] == "event"
+                assert attributes["role"] == "client"
+                assert set(attributes) <= _BOUNDED_KEYS
+
+                failed = [
+                    span
+                    for span in _spans(probe, "curie.runner.rpc")
+                    if span.status is StatusCode.ERROR
+                ]
+                assert failed, "the stream boundary must mark its span failed"
+            finally:
+                hold.set()
+                await client.close()
+
+    asyncio.run(go())

--- a/apps/worker/tests/kernel/test_runner_client.py
+++ b/apps/worker/tests/kernel/test_runner_client.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import logging
 import tracemalloc
 from typing import Any
 
@@ -19,7 +20,7 @@ from curie_runner import RunTracer, SideEffectClassifier, create_app
 from curie_runner import server as runner_server
 from curie_runner.fake import FakeModelSession
 from curie_runner.session import SessionRunner
-from curie_worker.runner_client import RunnerClient, RunnerError
+from curie_worker.runner_client import RunnerClient, RunnerError, RunnerStreamTimeout
 
 DONE = SessionStatus.DONE
 
@@ -658,5 +659,61 @@ def test_interrupt_keeps_its_own_timeout_under_a_huge_streaming_budget() -> None
             runner.hang.set()
             await client.close()
             await server.close()
+
+    asyncio.run(go())
+
+
+# --- The streaming boundary owns its own timeout terminal record (#2011) ------
+# ``start_turn``'s ``_rpc`` span has already closed by the time the NDJSON body
+# is streamed, so an expiring total/sock_read budget used to leave NO record at
+# this boundary at all, and handed the kernel a bare ``TimeoutError`` whose
+# ``str()`` is the empty string.
+
+
+def test_stream_timeout_raises_a_named_timeout_and_logs_the_expired_budget(
+    make_harness, caplog
+) -> None:
+    """#2011: iterating a turn whose runner hangs past the client's budget must
+    raise a ``RunnerStreamTimeout`` -- still a ``TimeoutError``, so every
+    existing ``except TimeoutError`` keeps catching it -- whose message names the
+    normalized exception class and the budget that expired, and must emit a
+    correlated WARNING on the client's own logger. Today the raised exception is
+    a bare ``TimeoutError`` that stringifies to "" and nothing is logged here."""
+
+    async def go() -> None:
+        async with make_harness() as h:
+            hold = asyncio.Event()  # never set: the response hangs after a prefix
+            h.runner.hold = hold
+            h.runner.default_script = [TextDelta(text="x")]
+            handle = await asyncio.to_thread(h.substrate.claim, "tStreamTimeout")
+            client = RunnerClient(total_timeout_s=0.5)
+            try:
+                with caplog.at_level(logging.WARNING, logger="curie_worker.runner_client"):
+                    turn = await client.start_turn(handle.base_url, _event())
+                    with pytest.raises(TimeoutError) as excinfo:
+                        async with turn:
+                            async for _frame in turn:
+                                pass
+
+                exc = excinfo.value
+                assert isinstance(exc, RunnerStreamTimeout)
+                assert isinstance(exc, TimeoutError)  # existing handlers still catch it
+                assert str(exc).strip(), "a stream timeout must not stringify to nothing"
+                assert "Timeout" in str(exc)  # the normalized underlying class
+                assert "0.5" in str(exc)  # the budget that expired, in seconds
+
+                warnings = [
+                    record.getMessage()
+                    for record in caplog.records
+                    if record.name == "curie_worker.runner_client"
+                    and record.levelno >= logging.WARNING
+                ]
+                assert warnings, caplog.text
+                assert any("Timeout" in message and "0.5" in message for message in warnings), (
+                    warnings
+                )
+            finally:
+                hold.set()
+                await client.close()
 
     asyncio.run(go())

--- a/packages/telemetry/schema/metrics.json
+++ b/packages/telemetry/schema/metrics.json
@@ -194,10 +194,11 @@
         "retry_class": [
           "redelivery",
           "rate-limit",
-          "runner-error"
+          "runner-error",
+          "runner-timeout"
         ]
       },
-      "cardinality_bound": 6
+      "cardinality_bound": 8
     },
     "curie.queue.dead_letter": {
       "type": "counter",

--- a/packages/telemetry/src/curie_telemetry/metrics.py
+++ b/packages/telemetry/src/curie_telemetry/metrics.py
@@ -66,7 +66,12 @@ _QUEUE_ATTRIBUTES = {
 _QUEUE_RETRY_ATTRIBUTES = {
     "service.name": ["curie-worker"],
     "source": ["worker", "eval"],
-    "retry_class": ["redelivery", "rate-limit", "runner-error"],
+    # "runner-timeout" (#2011): the runner streaming budget expiring is its own
+    # retry cause, distinct from the generic "runner-error". It MUST be declared
+    # here -- ``record_metric`` raises on an out-of-domain attribute value, so a
+    # retryable classification missing from this allowlist crashes the worker on
+    # the retry emission rather than silently dropping a point.
+    "retry_class": ["redelivery", "rate-limit", "runner-error", "runner-timeout"],
 }
 _THREAD_ATTRIBUTES = {
     "service.name": ["curie-worker"],

--- a/packages/telemetry/tests/test_metrics.py
+++ b/packages/telemetry/tests/test_metrics.py
@@ -135,9 +135,9 @@ def test_retry_metrics_separate_bounded_retry_causes() -> None:
     assert queue["attributes"] == {
         "service.name": ["curie-worker"],
         "source": ["worker", "eval"],
-        "retry_class": ["redelivery", "rate-limit", "runner-error"],
+        "retry_class": ["redelivery", "rate-limit", "runner-error", "runner-timeout"],
     }
-    assert queue["cardinality_bound"] == 6
+    assert queue["cardinality_bound"] == 8
     reply = manifest["curie.reply.retry"]
     assert reply["attributes"] == {
         "service.name": ["curie-worker"],


### PR DESCRIPTION
Fixes #2011.

A real post-upgrade turn on `next@ae5d57b1` streamed tool work, then failed exactly 600s after worker claim when aiohttp's `total`/`sock_read` budget expired mid-stream. `str(TimeoutError())` is the empty string, so the worker logged `turn stream dropped for <id>: ` with nothing after the colon, collapsed the outcome into the generic `runner-error`, and the runner RPC boundary emitted no terminal record — `RunnerClient._rpc`'s span closes when the response *headers* arrive, while the NDJSON body streams afterwards.

## What changed

- **`RunnerStreamTimeout`** (`runner_client.py`) — a `TimeoutError` subclass, so every existing `except TimeoutError` keeps catching it unchanged. Its `str()` is guaranteed non-empty and names both the normalized exception class and the budget that expired.
- **`TurnStream.__aiter__`** emits the correlated terminal record the boundary never produced: a warning on `curie_worker.runner_client`, a `curie.runner.rpc.result` point with `outcome="timeout"`, and a failed (ERROR-status) span.
- **`Kernel._consume`** logs a never-empty reason via `_exception_reason`, and classifies the **concrete** `RunnerStreamTimeout` as `runner-timeout`. Deliberately *not* `TimeoutError`: that clause also spans frame application, and a stalled reply adapter (`HttpReplyAdapter`, its own 30s budget) raises a bare `TimeoutError` while the runner is answering fine — that stays `runner-error`.
- **`runner-timeout` joins `RETRYABLE_CLASSIFICATIONS`**, so retry semantics are *unchanged* — a flag-clean timeout was transient before it had a name and still is — and joins the `retry_class` metric allowlist, which `record_metric` enforces by raising on an out-of-domain value.

**The no-automatic-retry-after-a-side-effect rule (ADR-0013) is untouched.** The `saw_side_effect` check in `_attempt` still runs before retryability is consulted.

## Done-check

- [x] **Failing tests committed before implementation** — `2c21b291` (test) preceded `cde30ad2` (fix), squashed here.
- [x] **All production edits delegated** to native sub-agents; driver ran only git/test/validation commands.
- [x] **Broadened return types** — none. No signature's return type changed; `__aiter__` raises a `TimeoutError` *subclass*, so all existing handlers are unaffected.
- [x] **Adversarial code review** (agent-router → codex/gpt-5.6-sol) — 2 P2 findings, both fixed: `runner-timeout` was too broad (caught reply-delivery timeouts), and `apps/worker/README.md` retry-classification drift.
- [x] **Adversarial scope review** (codex/gpt-5.6-sol) — no unjustified passengers. Telemetry allowlist + schema regen are mechanically required (closed metric domain); the test-harness changes enable the required tests.
- [x] **Sibling-path parity** — `aiohttp.ClientError` at the same boundary still emits no terminal record. Out of this issue's stated scope (runner *timeout* boundary); recorded as a follow-up, its `runner-error` classification is correct and unchanged.
- [x] **Guard demonstration** — mutation-tested: reverting the `isinstance` narrowing back to `TimeoutError` makes `test_reply_delivery_timeout_is_not_a_runner_timeout` fail with `assert 'runner-timeout' == 'runner-error'`; restoring it goes green.
- [x] **Consolidation pass** — 4 cleanup reviewers; applied a shared `_mark_rpc_failed` helper (dedups the span-failure vocabulary across `_rpc` and the stream boundary) and lifted the classification conditional into a named local. Re-reviewed by agent-router: no regressions. 4 findings deferred with reasons.
- [ ] Security scale-up — N/A (not flagged).
- [ ] Observable verification / E2E — N/A: no user-facing surface and no deployed-behavior dependency; the change is covered by integration tests against a live aiohttp runner.
- [x] **Full affected suite + lint + typecheck clean** — see below.

## Verification

`apps/worker/tests/kernel/` + `packages/telemetry/tests/`: **363 passed**. `ruff` clean, `mypy` clean (231 files), `lint-imports` 4/4 contracts kept, `check-docs.sh` and `check-wire-tolerance.sh` OK.

Full `apps/worker/tests`: 1212 passed, 17 failed — all 17 are `binding/test_resolver.py` hitting a shared local Postgres whose schema belongs to another branch (`column d.workspace_enabled does not exist`). Verified identical: **the same 17 fail on pristine `origin/next`**, so they are pre-existing environment, not this change.

Five new regression tests: the headline timeout classification with a non-empty correlated reason, no-retry-after-side-effect escalation, retry-still-works when flag-clean (asserting the real `curie.queue.retry` `retry_class`), the runner-RPC-boundary terminal record, and the failed-trace/timeout-metric assertion.