### PR TITLE
Warn when a repo binding leaves git-flow unroutable

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -2468,6 +2468,93 @@
         "title": "ResolvedTarget",
         "type": "object"
       },
+      "RoutingCheck": {
+        "description": "Whether pushes to a repository still resolve to an agent (#1221).\n\n``resolvable`` is false only when the real resolver raised: a branch with no\nmatching target resolves to \"ignore\", which is intended behaviour, not a\nproblem. An unbound repository (``agent_count`` 0) stays resolvable too --\nthis reports ROUTING, not whether anything is bound.",
+        "properties": {
+          "agent_count": {
+            "default": 0,
+            "title": "Agent Count",
+            "type": "integer"
+          },
+          "agents": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Agents",
+            "type": "array"
+          },
+          "repo_full_name": {
+            "title": "Repo Full Name",
+            "type": "string"
+          },
+          "resolvable": {
+            "default": true,
+            "title": "Resolvable",
+            "type": "boolean"
+          },
+          "unresolvable": {
+            "items": {
+              "$ref": "#/components/schemas/RoutingCheckProblem"
+            },
+            "title": "Unresolvable",
+            "type": "array"
+          }
+        },
+        "required": [
+          "repo_full_name"
+        ],
+        "title": "RoutingCheck",
+        "type": "object"
+      },
+      "RoutingCheckProblem": {
+        "description": "One environment whose pushes this repository can no longer route.\n\n``message`` is the resolver's OWN text, carried verbatim so the CLI can\nprint it without paraphrasing the rule.",
+        "properties": {
+          "code": {
+            "title": "Code",
+            "type": "string"
+          },
+          "environment": {
+            "title": "Environment",
+            "type": "string"
+          },
+          "message": {
+            "title": "Message",
+            "type": "string"
+          }
+        },
+        "required": [
+          "environment",
+          "code",
+          "message"
+        ],
+        "title": "RoutingCheckProblem",
+        "type": "object"
+      },
+      "RoutingCheckRequest": {
+        "description": "Ask whether a repository's pushes can still be routed to an agent (#1221).\n\nMigration 0018 (ADR-0091) dropped the unique index on ``repo_full_name``, so\nbinding a SECOND agent to a repository is legal -- and silently flips every\nfuture push for the agent that was already bound from \"deploys\" to\n\"rejected\", because nothing says which of the two a branch belongs to. The\ncaller sends the bundle's ``deploy.yaml`` TEXT for the same reason\n``ResolveTargetRequest`` does: the API owns the resolver rule, so a client\nrestating it here would drift from the rule actually enforced on a push.",
+        "properties": {
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Content"
+          },
+          "repo_full_name": {
+            "title": "Repo Full Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "repo_full_name"
+        ],
+        "title": "RoutingCheckRequest",
+        "type": "object"
+      },
       "RunnerPods": {
         "description": "The runner sandbox pods in a namespace (populates the Logs pod dropdown).",
         "properties": {
@@ -6295,6 +6382,66 @@
         "summary": "Trigger Eval",
         "tags": [
           "evals"
+        ]
+      }
+    },
+    "/git-flow/routing-check": {
+      "post": {
+        "description": "Report whether pushes to this repository still resolve to an agent.\n\nThe arguments handed to the resolver are built exactly the way\n``gitflow.process_push`` builds them, so the routing rule applied here is\nidentical to a real push's and cannot drift. It is not an unconditional\nprophecy of the next push's outcome, though: this endpoint resolves\nagainst the caller's local ``deploy.yaml``, while a real push resolves\nagainst the pushed commit's -- a dirty working tree or a HEAD that has\nsince moved can make the two disagree.\n\nA repository with several agents AND declared targets is the intended\nADR-0091 configuration and reports resolvable; warning on it would be noise\non exactly the shape the ADR asks operators to adopt.",
+        "operationId": "check_git_flow_routing_git_flow_routing_check_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RoutingCheckRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RoutingCheck"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Check Git Flow Routing",
+        "tags": [
+          "git-flow"
         ]
       }
     },

--- a/apps/api/src/curie_api/deploy_target_parsing.py
+++ b/apps/api/src/curie_api/deploy_target_parsing.py
@@ -1,0 +1,43 @@
+"""The ONE parser for a bundle's ``deploy.yaml`` text (ADR-0089).
+
+Extracted from ``routers/deploy_targets.py`` so a second consumer -- the
+git-flow routing check of #1221 -- cannot end up with a private copy. Two
+parsers for this file is the exact failure ADR-0089 put parsing in the API to
+prevent: the file's whole job is to be unambiguous about where a deploy lands,
+and a disagreement routes a deploy somewhere the author did not intend while
+reporting success. A copy inside a router is that second parser by the back
+door, so it lives here, imported by both.
+"""
+
+import yaml
+from fastapi import HTTPException, status
+from plugin_format.deploy_targets import DeployTargetsFile, validate_deploy_targets
+from plugin_format.yaml_loader import DuplicateKeyError, safe_load_unique
+
+
+def parse_deploy_targets(content: str) -> DeployTargetsFile:
+    """Parse and validate ``deploy.yaml``, or raise the operator-facing 400.
+
+    Shared by every endpoint that reads this format so they cannot disagree
+    about whether a file is valid -- which would be a second parser by the back
+    door, the exact thing ADR-0089 put this in the API to prevent.
+    """
+
+    try:
+        data = safe_load_unique(content)
+    except DuplicateKeyError as exc:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            f"deploy.duplicate_target: deploy.yaml contains duplicate key {exc.key!r}",
+        ) from exc
+    except yaml.YAMLError as exc:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST, f"deploy.yaml is unparseable: {exc}"
+        ) from exc
+
+    parsed, errors = validate_deploy_targets(data)
+    if errors:
+        detail = "; ".join(f"{code}: {message}" for code, message in errors)
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, detail)
+    assert parsed is not None
+    return parsed

--- a/apps/api/src/curie_api/main.py
+++ b/apps/api/src/curie_api/main.py
@@ -37,6 +37,7 @@ from .routers import (
     deploy_targets,
     deployments,
     evals,
+    gitflow_routing,
     github,
     hooks,
     memory,
@@ -266,6 +267,7 @@ def create_app() -> FastAPI:
     app.include_router(bundles.router)
     app.include_router(deploy_targets.router)
     app.include_router(github.router)
+    app.include_router(gitflow_routing.router)
     app.include_router(observability.router)
     app.include_router(control.router)
     app.include_router(evals.router)

--- a/apps/api/src/curie_api/routers/deploy_targets.py
+++ b/apps/api/src/curie_api/routers/deploy_targets.py
@@ -8,43 +8,17 @@ backwards -- the caller uses this BEFORE an agent exists, to find out which
 agent to create.
 """
 
-import yaml
 from fastapi import APIRouter, Depends, HTTPException, status
-from plugin_format.deploy_targets import DeployTargetsFile, validate_deploy_targets
-from plugin_format.yaml_loader import DuplicateKeyError, safe_load_unique
 
 from ..auth import require_api_key
+from ..deploy_target_parsing import parse_deploy_targets as _parse
 from ..schemas import ListedTargets, NamedTarget, ResolvedTarget, ResolveTargetRequest
 
 router = APIRouter(tags=["deploy-targets"], dependencies=[Depends(require_api_key)])
 
-
-def _parse(content: str) -> DeployTargetsFile:
-    """Parse and validate ``deploy.yaml``, or raise the operator-facing 400.
-
-    Shared by both endpoints so `list` and `resolve` cannot disagree about
-    whether a file is valid -- which would be a second parser by the back door,
-    the exact thing ADR-0089 put this in the API to prevent.
-    """
-
-    try:
-        data = safe_load_unique(content)
-    except DuplicateKeyError as exc:
-        raise HTTPException(
-            status.HTTP_400_BAD_REQUEST,
-            f"deploy.duplicate_target: deploy.yaml contains duplicate key {exc.key!r}",
-        ) from exc
-    except yaml.YAMLError as exc:
-        raise HTTPException(
-            status.HTTP_400_BAD_REQUEST, f"deploy.yaml is unparseable: {exc}"
-        ) from exc
-
-    parsed, errors = validate_deploy_targets(data)
-    if errors:
-        detail = "; ".join(f"{code}: {message}" for code, message in errors)
-        raise HTTPException(status.HTTP_400_BAD_REQUEST, detail)
-    assert parsed is not None
-    return parsed
+# `_parse` is imported rather than defined here: the git-flow routing check
+# (#1221) needs the same parser, and a second copy of it would be the second
+# parser ADR-0089 exists to prevent. See `deploy_target_parsing`.
 
 
 @router.post("/deploy-targets/resolve", response_model=ResolvedTarget)

--- a/apps/api/src/curie_api/routers/gitflow_routing.py
+++ b/apps/api/src/curie_api/routers/gitflow_routing.py
@@ -1,0 +1,137 @@
+"""Is a repository's git-flow routing still resolvable? (#1221, ADR-0091)
+
+Migration 0018 dropped the unique index on ``agents.repo_full_name`` so one
+repository can build several agents -- a dev bot and a prod bot are the same
+bundle on two channels. The cost is that binding a SECOND agent to a repository
+silently changes the OUTCOME of every future push for the agent that was
+already bound: with no declared targets, ``resolve_target_agent`` has nothing to
+say which of the two a branch deploys to, so it rejects. Nothing warned, and the
+break showed up as pushes that quietly stopped deploying.
+
+This endpoint is where a client asks the question instead of guessing at it. It
+answers by CALLING the real resolver, never by restating its rule: a rule
+restated in the CLI is a rule that drifts from the one a push actually enforces,
+which is the same client/server drift #1212 exists to correct. It is read-only
+-- it decides nothing and writes nothing.
+"""
+
+from fastapi import APIRouter, Depends
+
+from .. import crud
+from ..auth import require_api_key
+from ..config import get_settings
+from ..deploy_target_parsing import parse_deploy_targets
+from ..deps import SessionDep
+from ..gitflow import (
+    TargetUnresolved,
+    _target_agent_name,
+    environment_for_ref,
+    resolve_target_agent,
+)
+from ..models import Environment
+from ..schemas import RoutingCheck, RoutingCheckProblem, RoutingCheckRequest
+
+router = APIRouter(tags=["git-flow"], dependencies=[Depends(require_api_key)])
+
+
+def _reachable_environments() -> list[Environment]:
+    """The environments a real push to this installation can actually reach.
+
+    Derived by ASKING ``environment_for_ref``, never by restating its rule --
+    the same reason this endpoint calls the resolver instead of reimplementing
+    it. ``environment_for_ref`` owns the ref-to-environment precedence and
+    compares against ``dev_branch`` FIRST, so an installation that configures
+    ``dev_branch`` and ``prod_branch`` to the SAME branch has a prod resolver no
+    push can ever reach: the dev comparison always wins. A hardcoded
+    (dev, prod) list evaluates prod anyway, and a prod-only target problem then
+    reports the repository unresolvable over a push that CANNOT HAPPEN -- a
+    warning an operator cannot act on, and the client/server divergence #1221
+    exists to remove, merely relocated into this endpoint.
+
+    Asking per configured deploy branch collapses that case to ``[dev]`` on its
+    own, with no same-branch special case to keep in sync. Order is
+    deterministic and dev-before-prod for the same reason `/deploy-targets/list`
+    orders that way: a caller reading the list reads the earlier one first.
+    """
+
+    settings = get_settings()
+    environments: list[Environment] = []
+    for branch in (settings.dev_branch, settings.prod_branch):
+        environment = environment_for_ref(f"refs/heads/{branch}", settings)
+        if environment is not None and environment not in environments:
+            environments.append(environment)
+    return environments
+
+
+@router.post("/git-flow/routing-check", response_model=RoutingCheck)
+async def check_git_flow_routing(body: RoutingCheckRequest, session: SessionDep) -> RoutingCheck:
+    """Report whether pushes to this repository still resolve to an agent.
+
+    The arguments handed to the resolver are built exactly the way
+    ``gitflow.process_push`` builds them, so the routing rule applied here is
+    identical to a real push's and cannot drift. It is not an unconditional
+    prophecy of the next push's outcome, though: this endpoint resolves
+    against the caller's local ``deploy.yaml``, while a real push resolves
+    against the pushed commit's -- a dirty working tree or a HEAD that has
+    since moved can make the two disagree.
+
+    A repository with several agents AND declared targets is the intended
+    ADR-0091 configuration and reports resolvable; warning on it would be noise
+    on exactly the shape the ADR asks operators to adopt.
+    """
+
+    repo_agents = await crud.get_agents_by_repo(session, body.repo_full_name)
+
+    # Parsing happens before the empty-repo_agents short-circuit below,
+    # deliberately: whether the body is well-formed is request validation, and
+    # request validation must not depend on database state. A malformed body
+    # is a 400 whether or not anything happens to be bound to this repository.
+    targets = parse_deploy_targets(body.content) if body.content is not None else None
+
+    # Mirror process_push's own ignore guard (gitflow.py): with no agent bound
+    # to this repository yet, a real push returns WebhookResult(status="ignored")
+    # BEFORE the resolver is ever reached -- there is no routing decision to make.
+    # Reproducing that short-circuit here, rather than letting an empty
+    # repo_agents fall into resolve_target_agent's "0 agents" TargetUnresolved,
+    # is what keeps this endpoint from being a second, disagreeing copy of the
+    # routing rule (#1221, ADR-0091): an unbound repository is the state before
+    # the first deploy, not a routing fault.
+    if not repo_agents:
+        return RoutingCheck(
+            repo_full_name=body.repo_full_name,
+            agent_count=0,
+            agents=[],
+            resolvable=True,
+            unresolvable=[],
+        )
+
+    unresolvable: list[RoutingCheckProblem] = []
+    for environment in _reachable_environments():
+        named = _target_agent_name(targets, environment)
+        named_elsewhere = (
+            await crud.get_agent_by_name(session, named)
+            if named and not any(a.name == named for a in repo_agents)
+            else None
+        )
+        try:
+            # A None return is NOT a problem: it means this branch declares no
+            # target, which is deliberately ignored rather than rejected.
+            resolve_target_agent(targets, environment, repo_agents, named_elsewhere)
+        except TargetUnresolved as exc:
+            unresolvable.append(
+                RoutingCheckProblem(
+                    environment=environment.value,
+                    code=exc.code,
+                    # Verbatim: the caller prints the resolver's own words rather
+                    # than paraphrasing a rule it does not own.
+                    message=str(exc),
+                )
+            )
+
+    return RoutingCheck(
+        repo_full_name=body.repo_full_name,
+        agent_count=len(repo_agents),
+        agents=[a.name for a in repo_agents],
+        resolvable=not unresolvable,
+        unresolvable=unresolvable,
+    )

--- a/apps/api/src/curie_api/schemas.py
+++ b/apps/api/src/curie_api/schemas.py
@@ -978,6 +978,53 @@ class ListedTargets(BaseModel):
     targets: list[NamedTarget] = []
 
 
+class RoutingCheckRequest(BaseModel):
+    """Ask whether a repository's pushes can still be routed to an agent (#1221).
+
+    Migration 0018 (ADR-0091) dropped the unique index on ``repo_full_name``, so
+    binding a SECOND agent to a repository is legal -- and silently flips every
+    future push for the agent that was already bound from "deploys" to
+    "rejected", because nothing says which of the two a branch belongs to. The
+    caller sends the bundle's ``deploy.yaml`` TEXT for the same reason
+    ``ResolveTargetRequest`` does: the API owns the resolver rule, so a client
+    restating it here would drift from the rule actually enforced on a push.
+    """
+
+    repo_full_name: str
+    # The bundle's deploy.yaml TEXT, or None when the bundle has no such file.
+    # None and an empty `targets:` map say the same thing about routing (#1210),
+    # and the resolver already treats them identically.
+    content: str | None = None
+
+
+class RoutingCheckProblem(BaseModel):
+    """One environment whose pushes this repository can no longer route.
+
+    ``message`` is the resolver's OWN text, carried verbatim so the CLI can
+    print it without paraphrasing the rule.
+    """
+
+    environment: str
+    code: str
+    message: str
+
+
+class RoutingCheck(BaseModel):
+    """Whether pushes to a repository still resolve to an agent (#1221).
+
+    ``resolvable`` is false only when the real resolver raised: a branch with no
+    matching target resolves to "ignore", which is intended behaviour, not a
+    problem. An unbound repository (``agent_count`` 0) stays resolvable too --
+    this reports ROUTING, not whether anything is bound.
+    """
+
+    repo_full_name: str
+    agent_count: int = 0
+    agents: list[str] = Field(default_factory=list)
+    resolvable: bool = True
+    unresolvable: list[RoutingCheckProblem] = Field(default_factory=list)
+
+
 class ConnectorManifests(BaseModel):
     """Kubernetes objects derived from a version's ``connectors.yaml``.
 

--- a/apps/api/tests/test_gitflow_routing_check.py
+++ b/apps/api/tests/test_gitflow_routing_check.py
@@ -1,0 +1,212 @@
+"""`POST /git-flow/routing-check`: can this repository's pushes still route? (#1221)
+
+Migration 0018 (ADR-0091) dropped the unique index on `agents.repo_full_name`,
+so binding a SECOND agent to a repository is legal -- and, with no declared
+targets, silently flips every future push for the agent that was ALREADY bound
+from "deploys" to "rejected". The regression test below is the two-agent case;
+the rest fence it so the warning cannot become noise on the configuration
+ADR-0091 actually asks operators to adopt.
+
+Real Postgres round-trip (the disposable-DB conftest), because the answer is a
+function of the rows: a pure-function test could not catch a lookup that stopped
+seeing a sibling agent.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from curie_api.config import get_settings
+
+REPO = "octo/routing-check"
+
+# The ADR-0091 intended configuration: two agents, one target each. Nothing here
+# is ambiguous, so nothing should warn.
+DECLARED = """
+targets:
+  dev:
+    agent: routing-dev
+    env: dev
+    slack_channel: C0EXAMPLE1
+  prod:
+    agent: routing-prod
+    env: prod
+    slack_channel: C0EXAMPLE2
+"""
+
+
+def _bind(client: Any, headers: dict[str, str], name: str, address: str, repo: str = REPO) -> None:
+    created = client.post(
+        "/agents",
+        json={
+            "name": name,
+            "channel": {"kind": "slack", "address": address},
+            "repo_full_name": repo,
+        },
+        headers=headers,
+    )
+    assert created.status_code == 201, created.text
+
+
+def _check(client: Any, headers: dict[str, str], content: str | None = None) -> Any:
+    body: dict[str, Any] = {"repo_full_name": REPO}
+    if content is not None:
+        body["content"] = content
+    return client.post("/git-flow/routing-check", json=body, headers=headers)
+
+
+def test_one_bound_agent_with_no_deploy_yaml_still_routes(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    # The pre-#1221 status quo, and the state every single-agent repository is
+    # in: one agent, no deploy.yaml, and pushes that deploy.
+    _bind(client, auth_headers, "routing-solo", "C0EXAMPLE3")
+
+    r = _check(client, auth_headers)
+    assert r.status_code == 200, r.text
+    payload = r.json()
+    assert payload["resolvable"] is True
+    assert payload["agent_count"] == 1
+    assert payload["agents"] == ["routing-solo"]
+    assert payload["unresolvable"] == []
+
+
+def test_binding_a_second_agent_makes_every_push_unroutable(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    """THE regression test for #1221.
+
+    Binding the second agent does not break only the new one: with nothing to
+    say which agent a branch deploys to, the resolver rejects, so the agent that
+    was already working stops deploying too. That is the silence this endpoint
+    exists to end.
+    """
+
+    _bind(client, auth_headers, "routing-dev", "C0EXAMPLE3")
+    _bind(client, auth_headers, "routing-prod", "C0EXAMPLE4")
+
+    r = _check(client, auth_headers)
+    assert r.status_code == 200, r.text
+    payload = r.json()
+    assert payload["resolvable"] is False
+    assert payload["agent_count"] == 2
+    assert sorted(payload["agents"]) == ["routing-dev", "routing-prod"]
+
+    problems = {p["environment"]: p for p in payload["unresolvable"]}
+    assert sorted(problems) == ["dev", "prod"], payload
+    for problem in problems.values():
+        assert problem["code"] == "deploy.no_targets"
+        # The resolver's own words, so the caller never restates the rule.
+        assert "2 agents are built from this repository" in problem["message"]
+
+
+def test_two_agents_with_declared_targets_do_not_warn(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    # The negative case, and the reason this reports the RESOLVER's answer
+    # rather than an agent count: several agents per repository is what ADR-0091
+    # made possible, and a warning on the supported shape is pure noise.
+    _bind(client, auth_headers, "routing-dev", "C0EXAMPLE3")
+    _bind(client, auth_headers, "routing-prod", "C0EXAMPLE4")
+
+    r = _check(client, auth_headers, DECLARED)
+    assert r.status_code == 200, r.text
+    payload = r.json()
+    assert payload["resolvable"] is True, payload
+    assert payload["unresolvable"] == []
+    assert payload["agent_count"] == 2
+
+
+def test_an_empty_targets_map_is_the_same_as_no_deploy_yaml(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    # #1210: what decides the fallback is whether a target is DECLARED, not
+    # whether the file exists. `curie init` scaffolds an empty map, so this is
+    # the ordinary case rather than a corner one.
+    _bind(client, auth_headers, "routing-dev", "C0EXAMPLE3")
+    _bind(client, auth_headers, "routing-prod", "C0EXAMPLE4")
+
+    r = _check(client, auth_headers, "targets: {}\n")
+    assert r.status_code == 200, r.text
+    payload = r.json()
+    assert payload["resolvable"] is False
+    codes = {p["code"] for p in payload["unresolvable"]}
+    assert codes == {"deploy.no_targets"}
+    assert all("empty `targets:` map" in p["message"] for p in payload["unresolvable"])
+
+
+def test_an_unbound_repository_is_reported_resolvable(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    # Nothing bound is not a routing FAULT -- it is the state before the first
+    # deploy. This endpoint reports routing, not binding existence.
+    r = _check(client, auth_headers)
+    assert r.status_code == 200, r.text
+    payload = r.json()
+    assert payload["agent_count"] == 0
+    assert payload["agents"] == []
+    assert payload["resolvable"] is True
+
+
+def test_the_endpoint_requires_the_platform_api_key(client: Any, clean_db: None) -> None:
+    # Same auth as every other router (apps/api/CLAUDE.md): one shared key.
+    assert client.post("/git-flow/routing-check", json={"repo_full_name": REPO}).status_code == 401
+    wrong = client.post(
+        "/git-flow/routing-check",
+        json={"repo_full_name": REPO},
+        headers={"X-API-Key": "wrong"},
+    )
+    assert wrong.status_code == 401
+
+
+def test_malformed_deploy_yaml_is_the_same_400_as_the_resolver(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    # Proof that this endpoint shares `/deploy-targets/resolve`'s parser rather
+    # than carrying a second one: an identical file must fail identically. A
+    # divergence here is ADR-0089's forbidden second parser reappearing.
+    bad = "targets:\n  p:\n   env: [unclosed\n"
+    mine = _check(client, auth_headers, bad)
+    theirs = client.post(
+        "/deploy-targets/resolve", json={"content": bad, "target": "p"}, headers=auth_headers
+    )
+    assert mine.status_code == theirs.status_code == 400, mine.text
+    assert mine.json()["detail"] == theirs.json()["detail"]
+    assert "unparseable" in mine.json()["detail"]
+
+
+def test_a_same_branch_configuration_only_reports_the_reachable_environment(
+    client: Any,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unreachable environment must not be warned about (#1221).
+
+    ``gitflow.environment_for_ref`` compares a ref against ``dev_branch``
+    FIRST, so when both deploy branches are the same branch every push to it
+    becomes `dev` and NO push can ever reach the prod resolver. Reporting a
+    prod problem here would warn an operator about a push their configuration
+    makes impossible -- the client/server divergence this endpoint exists to
+    remove. `get_settings` is `lru_cache`-d, so the cache must be cleared after
+    the env change (and on teardown) or the override silently does nothing.
+    """
+
+    monkeypatch.setenv("DEV_BRANCH", "main")
+    monkeypatch.setenv("PROD_BRANCH", "main")
+    get_settings.cache_clear()
+    try:
+        # Two agents and no declared targets: the resolver rejects for BOTH
+        # environments, so prod would appear here if it were still evaluated.
+        _bind(client, auth_headers, "routing-dev", "C0EXAMPLE5")
+        _bind(client, auth_headers, "routing-prod", "C0EXAMPLE6")
+
+        r = _check(client, auth_headers)
+        assert r.status_code == 200, r.text
+        payload = r.json()
+        assert payload["resolvable"] is False, payload
+        assert [p["environment"] for p in payload["unresolvable"]] == ["dev"], payload
+        assert payload["unresolvable"][0]["code"] == "deploy.no_targets"
+    finally:
+        get_settings.cache_clear()

--- a/cli/api-mirrors.json
+++ b/cli/api-mirrors.json
@@ -218,6 +218,16 @@
       "struct": "ListedTargets",
       "schema": "ListedTargets",
       "omissions": []
+    },
+    {
+      "struct": "RoutingCheckProblem",
+      "schema": "RoutingCheckProblem",
+      "omissions": []
+    },
+    {
+      "struct": "RoutingCheck",
+      "schema": "RoutingCheck",
+      "omissions": []
     }
   ],
   "non_mirrors": [],

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -34,6 +34,46 @@ pub struct ResolvedTarget {
     pub slack_channel: Option<String>,
 }
 
+/// One environment whose pushes a repository can no longer route (#1221).
+///
+/// `message` is the platform resolver's OWN text. The CLI prints it verbatim
+/// and never paraphrases it: the routing rule lives in `gitflow.py`, and a
+/// restatement here would be free to drift from the rule a push enforces.
+#[derive(Debug, Clone, Deserialize)]
+pub struct RoutingCheckProblem {
+    #[serde(default)]
+    pub environment: String,
+    #[serde(default)]
+    pub code: String,
+    #[serde(default)]
+    pub message: String,
+}
+
+/// Whether git-flow pushes to a repository still resolve to an agent (#1221).
+///
+/// Every field carries `serde(default)`: this decode is advisory, and a
+/// platform that answers with a narrower shape must degrade to "nothing to
+/// warn about" rather than panic a deploy that otherwise succeeded.
+#[derive(Debug, Clone, Deserialize)]
+pub struct RoutingCheck {
+    #[serde(default)]
+    pub repo_full_name: String,
+    #[serde(default)]
+    pub agent_count: u32,
+    #[serde(default)]
+    pub agents: Vec<String>,
+    #[serde(default = "yes")]
+    pub resolvable: bool,
+    #[serde(default)]
+    pub unresolvable: Vec<RoutingCheckProblem>,
+}
+
+/// `resolvable` defaults to TRUE when absent: silence must mean "no problem
+/// reported", never a warning invented from a field the platform never sent.
+fn yes() -> bool {
+    true
+}
+
 /// One target plus the name it is declared under (ADR-0089).
 #[derive(Debug, Clone, Deserialize)]
 pub struct NamedTarget {
@@ -1236,6 +1276,70 @@ impl ApiClient {
             anyhow::bail!("listing the deploy targets failed ({status}): {body}");
         }
         serde_json::from_str(&body).context("decoding the deploy target list")
+    }
+
+    /// Ask the API whether this repository's pushes still route (#1221).
+    ///
+    /// ADVISORY, and deliberately incapable of failing a deploy: binding an
+    /// agent to a repository already succeeded by the time this is called, so
+    /// an error here would report failure for work that landed. Every
+    /// non-success -- an older platform with no such route, a 500, a body that
+    /// does not decode -- returns `Ok(None)`, meaning "no answer", which the
+    /// caller renders as no output at all.
+    ///
+    /// The `deploy.yaml` text goes over the wire unparsed for the same reason
+    /// `resolve_deploy_target` sends it: ADR-0089 keeps exactly one parser for
+    /// this format, and the resolver rule the answer depends on is the
+    /// platform's, not a copy of it living here.
+    ///
+    /// This is the ONE call with a per-request deadline, and it is set here
+    /// rather than on the shared client on purpose. `ApiClient::new` bounds
+    /// only `connect_timeout`, so a peer that accepts the TCP connection and
+    /// then stalls before sending headers leaves the caller waiting forever --
+    /// and because this runs AFTER the deploy has already landed, that
+    /// unbounded wait turns a successful deploy into an apparent hang, which is
+    /// exactly the failure this check promises never to cause. A GLOBAL timeout
+    /// is the wrong fix: bundle upload, deploy activation, and the streaming
+    /// reads legitimately run longer than any bound this call wants, and
+    /// capping them would break work that must not be interrupted. 10s is far
+    /// past a healthy answer and far short of an operator's patience; expiry
+    /// lands in the non-success path below as `Ok(None)` -- a timeout is "no
+    /// answer", indistinguishable from a 500, and prints nothing.
+    pub async fn check_git_flow_routing(
+        &self,
+        repo_full_name: &str,
+        content: Option<&str>,
+    ) -> Result<Option<RoutingCheck>> {
+        let sent = self
+            .send_request(
+                self.http
+                    .post(format!("{}/git-flow/routing-check", self.base_url))
+                    .header("X-API-Key", &self.api_key)
+                    .json(&serde_json::json!({
+                        "repo_full_name": repo_full_name,
+                        "content": content,
+                    }))
+                    .timeout(std::time::Duration::from_secs(10)),
+                "checking git-flow routing",
+            )
+            .await;
+        // A send that never completed -- the 10s deadline above, or an
+        // unreachable API -- is "no answer" like any other, so it is absorbed
+        // here rather than bubbled with `?`. Propagating would make the
+        // function's advisory contract depend on every caller remembering to
+        // discard the error.
+        let Ok(resp) = sent else {
+            return Ok(None);
+        };
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        // A platform predating this endpoint answers FastAPI's bare 404. That is
+        // skew, not a fault: an operator on an older release is not doing
+        // anything wrong and must not be told to upgrade by an advisory check.
+        if is_unrouted(status, &body) || !status.is_success() {
+            return Ok(None);
+        }
+        Ok(serde_json::from_str(&body).ok())
     }
 
     pub async fn version_connectors(

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -13,7 +13,7 @@ use clap::ValueEnum;
 use curie_aci_protocol::{Budget, EventType, OutboundEvent, SessionStatus};
 use serde::{Deserialize, Serialize};
 
-use crate::api::{ApiClient, BudgetConfig, ChannelOutcome};
+use crate::api::{ApiClient, BudgetConfig, ChannelOutcome, RoutingCheck};
 use crate::bundle::pack_tar_gz;
 use crate::docker::{self, CheckSpec, StartSpec};
 use crate::evals::{
@@ -3668,6 +3668,11 @@ pub struct PreparedDeploy {
     label: String,
     env: String,
     requested_repo: Option<String>,
+    /// The bundle's `deploy.yaml` TEXT, or None when the bundle has no such
+    /// file. Carried rather than re-read so the routing check (#1221) asks
+    /// about the file that was actually packed, and unparsed because ADR-0089
+    /// keeps exactly one parser for this format and it is not in this binary.
+    deploy_targets_yaml: Option<String>,
     connect_hint: String,
     step: crate::ui::Step,
 }
@@ -3732,17 +3737,23 @@ pub async fn prepare_deploy(opts: DeployOpts) -> Result<PreparedDeploy> {
     // Resolve a declared target, if one was named (ADR-0089). The file is sent
     // as TEXT and parsed server-side: one parser means the CLI and the
     // validator cannot disagree about where this deploy lands.
+    // Read ONCE, for two consumers: `--target` resolution below and the
+    // post-deploy routing check (#1221). Absence is the ordinary case, not an
+    // error -- most bundles declare no targets -- so the read is kept as a
+    // Result only so `--target` can still name the io failure precisely.
+    let deploy_targets_path = plugin_dir.join("deploy.yaml");
+    let deploy_targets_read = std::fs::read_to_string(&deploy_targets_path);
+    let deploy_targets_yaml = deploy_targets_read.as_ref().ok().cloned();
     let resolved = match &opts.target {
         Some(name) => {
-            let path = plugin_dir.join("deploy.yaml");
-            let content = std::fs::read_to_string(&path).map_err(|err| {
+            let content = deploy_targets_read.as_ref().map_err(|err| {
                 crate::exit::usage(format!(
                     "--target {name} needs a deploy.yaml in the bundle, but {} could not be \
                      read: {err}",
-                    path.display()
+                    deploy_targets_path.display()
                 ))
             })?;
-            Some(client.resolve_deploy_target(&content, name).await?)
+            Some(client.resolve_deploy_target(content, name).await?)
         }
         None => None,
     };
@@ -3829,9 +3840,77 @@ pub async fn prepare_deploy(opts: DeployOpts) -> Result<PreparedDeploy> {
         label,
         env: env.to_string(),
         requested_repo: opts.repo,
+        deploy_targets_yaml,
         connect_hint: opts.connect_hint,
         step,
     })
+}
+
+/// The operator-facing text for a repository whose pushes no longer route (#1221).
+///
+/// Pure, so the wording is unit-testable without a platform. Three things it
+/// must do and one it must not:
+///
+/// - name the repository and every agent now bound to it, because the operator
+///   who just deployed one of them cannot otherwise tell who else is affected;
+/// - carry the resolver's own `message` VERBATIM -- paraphrasing it would put a
+///   second statement of the routing rule in the client, free to drift from the
+///   one `gitflow.py` enforces on a push (the drift #1212 exists to correct);
+/// - say plainly that the affected pushes break for EVERY agent bound to the
+///   repository, including ones this deploy never touched, since the surprise
+///   is that a working agent breaks without being deployed to.
+///
+/// What it must NOT do is widen the damage past what the resolver reported. A
+/// bundle can declare a valid `dev` target and a `prod` target naming an agent
+/// that does not exist: the answer comes back unresolvable carrying ONLY the
+/// prod problem, while dev pushes still deploy exactly as before. Claiming
+/// every push is rejected would be false there, and appending a fixed "declare
+/// a target" remedy would be worse than false -- targets already exist, and the
+/// real remedy is the one the resolver named in its own `message`. So the
+/// affected environments are read off `unresolvable`, and no generic remedy is
+/// appended at all: each problem's own text carries the fix for its own code
+/// (`deploy.no_targets` already ends with "Declare a target (ADR-0089)."), and
+/// a hardcoded second remedy could only contradict it.
+fn routing_warning(check: &RoutingCheck) -> String {
+    let agents = if check.agents.is_empty() {
+        "(none)".to_string()
+    } else {
+        check.agents.join(", ")
+    };
+    // Environments as the resolver named them, deduplicated in the order it
+    // sent them. A problem with a blank `environment` (the field is
+    // `serde(default)`) contributes no name rather than an empty one.
+    let mut envs: Vec<&str> = Vec::new();
+    for problem in &check.unresolvable {
+        let env = problem.environment.trim();
+        if !env.is_empty() && !envs.contains(&env) {
+            envs.push(env);
+        }
+    }
+    // With no environment named, the response says routing is broken without
+    // saying where. Staying vague is the honest rendering: inventing a list
+    // would be the same overstatement this function exists to avoid.
+    let scope = if envs.is_empty() {
+        "some pushes to this repository no longer deploy anything".to_string()
+    } else {
+        format!(
+            "pushes that deploy the {} environment{} no longer deploy anything",
+            envs.join(", "),
+            if envs.len() == 1 { "" } else { "s" }
+        )
+    };
+    let mut lines = vec![format!(
+        "git-flow routing for {} is broken: {} agents are bound to it ({agents}), and {scope} \
+         -- for every one of those agents, including agents this deploy did not touch.",
+        check.repo_full_name, check.agent_count
+    )];
+    for problem in &check.unresolvable {
+        lines.push(format!(
+            "  {} ({}): {}",
+            problem.environment, problem.code, problem.message
+        ));
+    }
+    lines.join("\n")
 }
 
 pub async fn deploy_prepared(prepared: PreparedDeploy) -> Result<DeployOutput> {
@@ -3843,6 +3922,7 @@ pub async fn deploy_prepared(prepared: PreparedDeploy) -> Result<DeployOutput> {
         label,
         env,
         requested_repo,
+        deploy_targets_yaml,
         connect_hint,
         step,
     } = prepared;
@@ -3877,6 +3957,28 @@ pub async fn deploy_prepared(prepared: PreparedDeploy) -> Result<DeployOutput> {
         ui.note(&format!(
             "repo binding: git-flow pushes to {repo} deploy this agent"
         ));
+        // ...unless they no longer route anywhere (#1221). Migration 0018
+        // (ADR-0091) dropped the unique index on `repo_full_name`, so a SECOND
+        // agent may bind the same repository -- and with no declared targets
+        // that silently flips every future push for the agent that was ALREADY
+        // bound from "deploys" to "rejected". This is the one point BOTH
+        // binding paths converge on: an agent bound at creation and one bound
+        // by a later PATCH (#1212) both arrive here.
+        //
+        // The API answers, because the API owns the resolver. Asking it is what
+        // keeps this warning from becoming a second copy of the routing rule,
+        // free to drift from the one a push actually enforces. It is advisory
+        // in every direction: an older platform, an unreachable one, or an
+        // undecodable answer all print nothing rather than souring a deploy
+        // that already succeeded.
+        if let Ok(Some(check)) = client
+            .check_git_flow_routing(repo, deploy_targets_yaml.as_deref())
+            .await
+        {
+            if !check.resolvable {
+                ui.warn(&routing_warning(&check));
+            }
+        }
     }
 
     let channel = match &outcome.channel {
@@ -6181,13 +6283,126 @@ mod tests {
         absent_container_note, merge_secret_env, model_credential_summary,
         parse_credential_env_file, parse_manifest_gates, plan_recorded_state,
         plan_recorded_teardown, plan_skill_down, recorded_ids_match, replace_first_line,
-        report_sweep, resolve_cases_path, resolve_env_file_credentials, seed_env_if_missing,
-        select_in_force_deployment, select_passthrough_env, sweep_json_row, sweep_table_row,
-        validate_channel_binding, ApprovalGateDecl, DownPlan, EnvSeed, RecordedStatePlan,
-        RecordedStateQuery, RecordedTeardown, SweepRow,
+        report_sweep, resolve_cases_path, resolve_env_file_credentials, routing_warning,
+        seed_env_if_missing, select_in_force_deployment, select_passthrough_env, sweep_json_row,
+        sweep_table_row, validate_channel_binding, ApprovalGateDecl, DownPlan, EnvSeed,
+        RecordedStatePlan, RecordedStateQuery, RecordedTeardown, SweepRow,
     };
     use serde::Deserialize;
     use std::path::{Path, PathBuf};
+
+    /// The platform's answer for a repository two agents bind with no declared
+    /// targets -- built by deserializing the WIRE shape, so the test cannot
+    /// drift from what the endpoint actually sends (#1221).
+    fn unroutable_check() -> crate::api::RoutingCheck {
+        serde_json::from_str(
+            r#"{
+                "repo_full_name": "octo/shared-repo",
+                "agent_count": 2,
+                "agents": ["acme-bot", "acme-dev"],
+                "resolvable": false,
+                "unresolvable": [
+                    {
+                        "environment": "dev",
+                        "code": "deploy.no_targets",
+                        "message": "2 agents are built from this repository but the bundle has no deploy.yaml, so there is nothing to say which one this branch deploys to. Declare a target (ADR-0089)."
+                    }
+                ]
+            }"#,
+        )
+        .expect("the routing-check wire shape should decode")
+    }
+
+    #[test]
+    fn the_routing_warning_names_the_repository_and_every_bound_agent() {
+        // The operator just deployed ONE of these agents. Naming only that one
+        // would hide the actual damage: the sibling that was working stops
+        // deploying without anyone touching it.
+        let warning = routing_warning(&unroutable_check());
+        assert!(warning.contains("octo/shared-repo"), "was {warning}");
+        assert!(warning.contains("acme-bot"), "was {warning}");
+        assert!(warning.contains("acme-dev"), "was {warning}");
+    }
+
+    #[test]
+    fn the_routing_warning_carries_the_resolvers_own_words_verbatim() {
+        // Paraphrasing here would put a second statement of the routing rule in
+        // the client, free to drift from the one a push enforces (#1212).
+        let check = unroutable_check();
+        let warning = routing_warning(&check);
+        assert!(
+            warning.contains(&check.unresolvable[0].message),
+            "was {warning}"
+        );
+        assert!(warning.contains("deploy.no_targets"), "was {warning}");
+        assert!(warning.contains("dev"), "was {warning}");
+    }
+
+    #[test]
+    fn the_routing_warning_states_the_blast_radius_it_was_told_about() {
+        let warning = routing_warning(&unroutable_check());
+        // The damage is real and must read as such, but scoped to the
+        // environment the resolver actually named.
+        assert!(warning.contains("dev"), "was {warning}");
+        assert!(
+            warning.contains("no longer deploy anything"),
+            "was {warning}"
+        );
+        assert!(
+            warning.contains("did not touch"),
+            "the warning must say untouched agents are affected too: {warning}"
+        );
+        // The remedy is the resolver's, carried in its own message. A second,
+        // hardcoded one is what made this warning misleading for a bundle that
+        // already declares targets.
+        assert!(
+            !warning.contains("Fix: declare a target"),
+            "the client must not append its own remedy: {warning}"
+        );
+    }
+
+    /// One environment broken and one fine -- a bundle with a good `dev` target
+    /// and a `prod` target naming an agent that does not exist. Dev pushes
+    /// still deploy, so the warning must not say otherwise (#1221).
+    fn prod_only_unroutable_check() -> crate::api::RoutingCheck {
+        serde_json::from_str(
+            r#"{
+                "repo_full_name": "octo/shared-repo",
+                "agent_count": 2,
+                "agents": ["acme-bot", "acme-dev"],
+                "resolvable": false,
+                "unresolvable": [
+                    {
+                        "environment": "prod",
+                        "code": "deploy.unknown_agent",
+                        "message": "The prod target names agent 'acme-prod', which does not exist."
+                    }
+                ]
+            }"#,
+        )
+        .expect("the routing-check wire shape should decode")
+    }
+
+    #[test]
+    fn the_routing_warning_does_not_widen_one_broken_environment_to_all() {
+        let check = prod_only_unroutable_check();
+        let warning = routing_warning(&check);
+        assert!(warning.contains("prod"), "was {warning}");
+        assert!(
+            warning.contains(&check.unresolvable[0].message),
+            "was {warning}"
+        );
+        // Nothing may suggest the dev lane broke: it did not, and telling the
+        // operator it did sends them to fix working configuration.
+        assert!(
+            !warning.contains("dev environment"),
+            "dev still routes and must not be named as broken: {warning}"
+        );
+        assert!(
+            !warning.contains("every push"),
+            "only the reported environments are affected: {warning}"
+        );
+    }
 
     #[test]
     fn env_file_resolver_respects_shell_and_vault_precedence() {

--- a/cli/tests/api_deploy.rs
+++ b/cli/tests/api_deploy.rs
@@ -696,3 +696,95 @@ async fn surfaces_api_errors_with_status_and_body() {
     assert!(text.contains("401"), "unexpected error: {text}");
     assert!(text.contains("invalid API key"), "unexpected error: {text}");
 }
+
+// --------------------------------------------------------------------------- #
+// The advisory git-flow routing check (#1221)
+//
+// Binding a SECOND agent to a repository is legal since migration 0018
+// (ADR-0091) and silently stops every push for the agent that was already
+// bound. The CLI asks the API about it AFTER the deploy has landed, so the
+// check must be incapable of turning a successful deploy into a failure: every
+// answer that is not a decodable success is `Ok(None)`, which prints nothing.
+// --------------------------------------------------------------------------- #
+
+const UNROUTABLE: &str = r#"{
+  "repo_full_name": "octo/shared-repo",
+  "agent_count": 2,
+  "agents": ["acme-bot", "acme-dev"],
+  "resolvable": false,
+  "unresolvable": [
+    {"environment": "dev", "code": "deploy.no_targets", "message": "2 agents are built from this repository but the bundle has no deploy.yaml, so there is nothing to say which one this branch deploys to. Declare a target (ADR-0089)."},
+    {"environment": "prod", "code": "deploy.no_targets", "message": "2 agents are built from this repository but the bundle has no deploy.yaml, so there is nothing to say which one this branch deploys to. Declare a target (ADR-0089)."}
+  ]
+}"#;
+
+#[tokio::test]
+async fn routing_check_decodes_an_unresolvable_repository() {
+    let server = serve(|req| match (req.method.as_str(), req.path.as_str()) {
+        ("POST", "/git-flow/routing-check") => Response::json(200, UNROUTABLE),
+        other => panic!("unexpected request: {other:?}"),
+    });
+    let client = ApiClient::new(&server.base_url, "k").unwrap();
+
+    let check = client
+        .check_git_flow_routing("octo/shared-repo", None)
+        .await
+        .unwrap()
+        .expect("a successful body must decode");
+
+    assert!(!check.resolvable);
+    assert_eq!(check.agent_count, 2);
+    assert_eq!(check.agents, vec!["acme-bot", "acme-dev"]);
+    // The resolver's problems survive the hop intact: the CLI prints its
+    // `message` verbatim rather than restating the rule (#1212).
+    assert_eq!(check.unresolvable.len(), 2);
+    assert_eq!(check.unresolvable[0].environment, "dev");
+    assert_eq!(check.unresolvable[0].code, "deploy.no_targets");
+    assert!(check.unresolvable[0].message.contains("Declare a target"));
+
+    // The repository and the bundle's deploy.yaml text both travel to the API,
+    // which owns the parser and the resolver (ADR-0089).
+    let body: serde_json::Value = serde_json::from_slice(&server.recorded()[0].body).unwrap();
+    assert_eq!(body["repo_full_name"], "octo/shared-repo");
+    assert!(body["content"].is_null());
+}
+
+#[tokio::test]
+async fn routing_check_is_silent_against_a_platform_that_predates_it() {
+    // FastAPI's bare not-found body: the CLI is newer than the platform. That
+    // operator is not doing anything wrong, and an advisory check must not tell
+    // them their deploy failed.
+    let server = serve(|_req| Response::json(404, r#"{"detail":"Not Found"}"#));
+    let client = ApiClient::new(&server.base_url, "k").unwrap();
+    assert!(client
+        .check_git_flow_routing("octo/shared-repo", Some("targets: {}\n"))
+        .await
+        .unwrap()
+        .is_none());
+}
+
+#[tokio::test]
+async fn routing_check_never_fails_a_deploy_on_a_server_error() {
+    // The deploy already succeeded by the time this runs; a 500 here says
+    // nothing about it, so it degrades to "no answer" rather than an error.
+    let server = serve(|_req| Response::json(500, r#"{"detail":"boom"}"#));
+    let client = ApiClient::new(&server.base_url, "k").unwrap();
+    assert!(client
+        .check_git_flow_routing("octo/shared-repo", None)
+        .await
+        .unwrap()
+        .is_none());
+}
+
+#[tokio::test]
+async fn routing_check_swallows_a_body_it_cannot_decode() {
+    // Platform skew can answer 200 with a shape this CLI does not model. A
+    // decode failure is still "no answer", never a failed deploy.
+    let server = serve(|_req| Response::json(200, r#"["not", "an", "object"]"#));
+    let client = ApiClient::new(&server.base_url, "k").unwrap();
+    assert!(client
+        .check_git_flow_routing("octo/shared-repo", None)
+        .await
+        .unwrap()
+        .is_none());
+}


### PR DESCRIPTION
Migration 0018 (ADR-0091) dropped the unique index on `agents.repo_full_name`,
so a repository may build several agents. But `resolve_target_agent` only routes
a push when the bundle declares no targets AND exactly one agent is bound.
Binding a SECOND agent therefore flipped every future push for the agent that
was ALREADY bound from "deploys" to "rejected", silently, for an operator who
never touched it.

## What this does

- Adds `POST /git-flow/routing-check`, which answers whether a repository's
  pushes still resolve by CALLING the real resolver and building its arguments
  exactly as `process_push` does, including the empty-`repo_agents` ignore
  guard. The rule is never restated, so it cannot drift from the one a push
  enforces. The environments it evaluates are derived by asking
  `environment_for_ref` itself, so an install whose dev and prod branches are
  the same ref never gets warned about a prod push that cannot happen.
- Lifts `deploy.yaml` parsing into `deploy_target_parsing` so the new endpoint
  and `/deploy-targets/*` share ADR-0089's single parser rather than growing a
  second one. Parsing runs before the bound-agent short circuit, so a malformed
  body is a 400 regardless of database state.
- Has `<tier> deploy` consult it after a repo binding lands and print the
  resolver's own message verbatim. The call sits at the one point BOTH binding
  paths reach, so an agent bound at creation and one bound by a later PATCH are
  covered alike. The warning names only the environments the resolver actually
  reported, and appends no remedy of its own.
- Keeps it strictly advisory. It carries its own 10s deadline (the shared client
  bounds only `connect_timeout`), and an older platform, an unreachable one, a
  timeout, or an undecodable answer all print nothing rather than souring a
  deploy that already succeeded.

A bundle that declares targets stays silent, because several agents per
repository is then the intended ADR-0091 configuration.

## Verification

Red-on-revert was proven by mutation: forcing `resolvable` true, ignoring the
bundle's declared targets, and dropping the verbatim resolver message each turn
the new tests red.

Fixes #1221
