### PR TITLE
Make the durable-state namespace-count cap atomic under concurrency

### DIFF
--- a/apps/api/src/curie_api/routers/state.py
+++ b/apps/api/src/curie_api/routers/state.py
@@ -14,12 +14,13 @@ platform key.
 """
 
 import enum
+import hashlib
 import json
 import uuid
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Response, status
-from sqlalchemy import func, select
+from sqlalchemy import func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import crud, sandbox_token
@@ -119,6 +120,56 @@ def _json_size(value: Any) -> int:
     return len(json.dumps(value, separators=(",", ":")).encode("utf-8"))
 
 
+# Advisory-lock class for the per-agent namespace-count cap (#933). The
+# TWO-argument ``pg_advisory_xact_lock(int4, int4)`` form is used deliberately:
+# Postgres keeps the two-int4 lock space entirely separate from the
+# one-argument bigint space, so this can never collide with a
+# ``pg_advisory_lock(<bigint>)`` taken anywhere else -- including the test-only
+# write gates in apps/api/tests/, which use the one-arg form. The number is the
+# issue.
+_NAMESPACE_LOCK_CLASS = 933
+
+
+def _namespace_lock_key(agent_id: uuid.UUID) -> int:
+    """A stable int4 advisory-lock key for one agent (#933).
+
+    Deterministic in every process and across restarts, which is the whole
+    point: Python's builtin ``hash()`` is PER-PROCESS randomized (PYTHONHASHSEED),
+    so two API workers would derive different keys for the same agent and the
+    lock would silently stop serializing anything. Hence hashlib. blake2b over
+    the UUID's 16 raw bytes, truncated to a signed int4 because
+    ``pg_advisory_xact_lock(int4, int4)`` takes int4s.
+
+    A collision between two DIFFERENT agents is SAFE: it only makes those two
+    agents serialize their new-namespace creations against each other for the
+    few statements the lock is held. It can never produce a wrong verdict,
+    because every query in the critical section -- the existence probe, the
+    re-check, and the ``count(distinct namespace)`` -- is still filtered by
+    ``agent_id``.
+    """
+    digest = hashlib.blake2b(agent_id.bytes, digest_size=4).digest()
+    return int.from_bytes(digest, "big", signed=True)
+
+
+async def _namespace_exists(
+    session: AsyncSession, agent_id: uuid.UUID, namespace: str
+) -> bool:
+    """Does this agent already have any row in ``namespace``? (#933)
+
+    Extracted so the unlocked pre-check and the re-check under the advisory lock
+    are provably the same query; a future edit cannot let them drift apart.
+    """
+    found = await session.scalar(
+        select(WorkflowStateEntry.namespace)
+        .where(
+            WorkflowStateEntry.agent_id == agent_id,
+            WorkflowStateEntry.namespace == namespace,
+        )
+        .limit(1)
+    )
+    return found is not None
+
+
 async def _enforce_caps(
     session: AsyncSession,
     agent_id: uuid.UUID,
@@ -159,27 +210,70 @@ async def _enforce_caps(
     # once the agent is at its limit -- writes to an existing namespace never hit
     # this. Without it a sandbox could loop creating unbounded namespaces, each
     # under the byte caps, after #840 made the namespace agent-chosen.
-    namespace_exists = await session.scalar(
-        select(WorkflowStateEntry.namespace)
-        .where(
-            WorkflowStateEntry.agent_id == agent_id,
-            WorkflowStateEntry.namespace == namespace,
-        )
-        .limit(1)
+    #
+    # #933: the check and the caller's INSERT are separate statements, so the
+    # bare check was a TOCTOU a concurrent burst could walk straight past (N
+    # requests to N brand-new namespaces all read cap-1 and all pass). The guard
+    # below is DOUBLE-CHECKED LOCKING: an unlocked pre-check keeps the hot path
+    # free, and only a would-be namespace CREATION serializes on a per-agent
+    # advisory lock held to COMMIT/ROLLBACK.
+
+    # 1. Hot path. Every write into an already-existing namespace returns here,
+    #    at exactly the cost of the single probe this code ran before #933 --
+    #    no lock, no extra round trip. dadf93e2's "writes to an existing
+    #    namespace are unaffected" is load-bearing and is preserved literally.
+    if await _namespace_exists(session, agent_id, namespace):
+        return
+
+    # 2. Serialize the creation. Transaction-level, so it is released by the
+    #    COMMIT or the ROLLBACK with no explicit unlock and no leak path when
+    #    the 403 below propagates. This REQUIRES a transaction to already be
+    #    open -- outside one the lock would be released immediately and this
+    #    guard would be vacuous. The byte-cap ``others`` SELECT above runs
+    #    unconditionally and autobegins it; moving this block above those
+    #    queries would silently make the lock meaningless.
+    #
+    #    LOCK ORDERING (no deadlock cycle exists, and this is what a future
+    #    change would break): the advisory lock is only ever requested when the
+    #    namespace has no rows for this agent, so no ``SELECT ... FOR UPDATE``
+    #    row lock is held at that moment -- in ``append_state`` and in
+    #    ``routers/memory.py`` a FOR UPDATE that matches zero rows takes no
+    #    lock, and any caller that DOES hold a row lock is by definition writing
+    #    an already-existing namespace and returned at step 1. The order is
+    #    strictly one-way, advisory lock -> row locks. Moving a FOR UPDATE above
+    #    the existence check, or making this lock unconditional, reopens that
+    #    analysis from scratch.
+    await session.execute(
+        text("SELECT pg_advisory_xact_lock(:cls, :key)"),
+        {"cls": _NAMESPACE_LOCK_CLASS, "key": _namespace_lock_key(agent_id)},
     )
-    if namespace_exists is None:
-        namespace_count = await session.scalar(
-            select(func.count(func.distinct(WorkflowStateEntry.namespace))).where(
-                WorkflowStateEntry.agent_id == agent_id
-            )
+
+    # 3. Re-check under the lock. A sibling request may have created this exact
+    #    namespace while we waited; refusing it then would be a FALSE POSITIVE
+    #    -- two concurrent writes to the same brand-new namespace must both
+    #    succeed when the agent has room. Not optional.
+    #
+    #    READ COMMITTED DEPENDENCY: this re-check and the count below only see
+    #    the sibling's commit because READ COMMITTED gives each statement a
+    #    fresh snapshot. Under REPEATABLE READ or SERIALIZABLE the snapshot
+    #    predates that commit and this guard degrades SILENTLY -- no error, just
+    #    the old overshoot plus a spurious 403 here. Nothing sets an isolation
+    #    level today; changing that breaks this.
+    if await _namespace_exists(session, agent_id, namespace):
+        return
+
+    namespace_count = await session.scalar(
+        select(func.count(func.distinct(WorkflowStateEntry.namespace))).where(
+            WorkflowStateEntry.agent_id == agent_id
         )
-        if (namespace_count or 0) >= settings.state_max_namespaces:
-            raise HTTPException(
-                status.HTTP_403_FORBIDDEN,
-                f"agent is at its {settings.state_max_namespaces}-namespace cap; "
-                f"delete a namespace or reuse an existing one before creating "
-                f"{namespace!r}",
-            )
+    )
+    if (namespace_count or 0) >= settings.state_max_namespaces:
+        raise HTTPException(
+            status.HTTP_403_FORBIDDEN,
+            f"agent is at its {settings.state_max_namespaces}-namespace cap; "
+            f"delete a namespace or reuse an existing one before creating "
+            f"{namespace!r}",
+        )
 
 
 async def _get_entry(

--- a/apps/api/tests/test_state.py
+++ b/apps/api/tests/test_state.py
@@ -4,11 +4,19 @@ Nothing mocked -- exercises the API against the compose Postgres (the
 disposable-DB conftest provisions and migrates a throwaway database per run).
 """
 
+import asyncio
+import threading
+import time
 import uuid
+from collections.abc import Callable
+from concurrent.futures import Future, ThreadPoolExecutor
 from typing import Any
 
+import asyncpg
 from curie_api.config import get_settings
+from curie_api.routers.state import _NAMESPACE_LOCK_CLASS, _namespace_lock_key
 from curie_api.sandbox_token import mint
+from sqlalchemy import make_url
 
 # Scoped-sandbox-token auth matrix constants (#410).
 _FAR_FUTURE = 4102444800  # 2100-01-01, valid at test time
@@ -424,6 +432,362 @@ def test_namespace_count_over_the_per_agent_cap_is_rejected(
         assert "cap" in over.text.lower() and "namespace" in over.text.lower()
         # More keys in an EXISTING namespace still succeed (not a new namespace).
         assert put("ns1", "k2").status_code == 200
+    finally:
+        get_settings.cache_clear()
+
+
+def _asyncpg_dsn() -> str:
+    url = make_url(get_settings().database_url).set(drivername="postgresql")
+    return url.render_as_string(hide_password=False)
+
+
+async def _install_state_insert_gate() -> None:
+    """Hold every INSERT into the state store at an advisory lock (#933).
+
+    The state variant of test_memory.py's BEFORE UPDATE gate: the write that can
+    create a new namespace is an INSERT, not an UPDATE. Lock id 933933 is
+    distinct from test_memory's 391391 so the two gates can never alias, and both
+    live in the ONE-argument advisory space, which Postgres keeps entirely
+    separate from the two-int4 space the production namespace lock uses.
+    """
+    connection = await asyncpg.connect(_asyncpg_dsn())
+    try:
+        await connection.execute(
+            """
+            CREATE OR REPLACE FUNCTION curie.test_state_insert_gate()
+            RETURNS trigger
+            LANGUAGE plpgsql
+            AS $$
+            BEGIN
+                PERFORM pg_advisory_xact_lock(933933);
+                RETURN NEW;
+            END;
+            $$
+            """
+        )
+        await connection.execute(
+            """
+            CREATE TRIGGER test_state_insert_gate
+            BEFORE INSERT ON curie.workflow_state_entries
+            FOR EACH ROW
+            EXECUTE FUNCTION curie.test_state_insert_gate()
+            """
+        )
+    finally:
+        await connection.close()
+
+
+async def _remove_state_insert_gate() -> None:
+    connection = await asyncpg.connect(_asyncpg_dsn())
+    try:
+        await connection.execute(
+            """
+            DROP TRIGGER IF EXISTS test_state_insert_gate
+            ON curie.workflow_state_entries
+            """
+        )
+        await connection.execute("DROP FUNCTION IF EXISTS curie.test_state_insert_gate()")
+    finally:
+        await connection.close()
+
+
+async def _wait_for_blocked_state_requests(minimum: int, requests: list[Future[Any]]) -> None:
+    """Block until `minimum` sessions are waiting on a lock, or fail loudly.
+
+    Deliberately NOT filtered by `query LIKE '%workflow_state_entries%'` the way
+    test_memory's twin is: once the cap is atomic, the second writer waits on
+    `SELECT pg_advisory_xact_lock($1, $2)` inside the cap check and never reaches
+    an INSERT, so its query text names no table and that filter would never see
+    it. Leaving the predicate on `wait_event_type` alone is safe because the
+    disposable-DB conftest gives the run its own database (so `current_database()`
+    already scopes the count to this test's traffic) and the gate holder *holds*
+    its advisory lock rather than waiting on one.
+    """
+    connection = await asyncpg.connect(_asyncpg_dsn())
+    try:
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            count = await connection.fetchval(
+                """
+                SELECT count(*)
+                FROM pg_stat_activity
+                WHERE datname = current_database()
+                  AND wait_event_type = 'Lock'
+                """
+            )
+            if int(count) >= minimum:
+                return
+            # A request that finished instead of blocking means the interleaving
+            # under test never happened -- fail loudly rather than hang to the
+            # deadline and report a timeout.
+            completed = [request.result() for request in requests if request.done()]
+            assert not completed, f"request completed before blocking: {completed}"
+            await asyncio.sleep(0.01)
+        raise AssertionError(f"only some of {minimum} state requests blocked")
+    finally:
+        await connection.close()
+
+
+def _hold_advisory_lock(
+    args: tuple[int, ...],
+    acquired: threading.Event,
+    release: threading.Event,
+    errors: list[Exception],
+) -> None:
+    """Hold a Postgres session-level advisory lock from an outside session (#933).
+
+    Shared by both #933 gates: the one-argument INSERT gate (`(933933,)`) and
+    the two-argument PRODUCTION namespace lock (`_NAMESPACE_LOCK_CLASS`,
+    `_namespace_lock_key(...)`). Postgres keeps the one-argument and
+    two-argument advisory-lock spaces entirely separate, so 933933 as a
+    single arg can never collide with the two-arg production key.
+
+    Session-level (`pg_advisory_lock`), not transaction-level, because it has
+    to outlive the statement that takes it and be released on a signal from
+    the test.
+    """
+    placeholders = ", ".join(f"${i}" for i in range(1, len(args) + 1))
+
+    async def hold() -> None:
+        connection = await asyncpg.connect(_asyncpg_dsn())
+        try:
+            await connection.execute(f"SELECT pg_advisory_lock({placeholders})", *args)
+            acquired.set()
+            release.wait()
+            await connection.execute(f"SELECT pg_advisory_unlock({placeholders})", *args)
+        finally:
+            # Closing the connection releases the session lock too, so no
+            # failure path can leave the key held and wedge every later test.
+            await connection.close()
+
+    try:
+        asyncio.run(hold())
+    except Exception as error:
+        errors.append(error)
+        acquired.set()
+
+
+def _run_ordered_state_requests(
+    first: Callable[[], Any], second: Callable[[], Any]
+) -> tuple[Any, Any]:
+    """Run two real requests concurrently, both parked at the INSERT gate.
+
+    Ordering is established by the database, not by a timer: `first` is submitted
+    and confirmed blocked before `second` is submitted, and both are confirmed
+    blocked before the gate is released. "Confirmed blocked" means observed --
+    polling `pg_stat_activity` until the expected number of waiters is seen --
+    not timed; the poll loop's sleep is pacing between observations, not a
+    handoff window, so the interleaving is identical on a loaded box regardless
+    of that sleep's duration.
+    """
+    asyncio.run(_install_state_insert_gate())
+    acquired = threading.Event()
+    release = threading.Event()
+    lock_errors: list[Exception] = []
+    lock_thread = threading.Thread(
+        target=_hold_advisory_lock,
+        args=((933933,), acquired, release, lock_errors),
+        daemon=True,
+    )
+    lock_thread.start()
+    try:
+        assert acquired.wait(timeout=10), "database gate was not acquired"
+        assert not lock_errors, lock_errors
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            first_request = executor.submit(first)
+            try:
+                asyncio.run(_wait_for_blocked_state_requests(1, [first_request]))
+                second_request = executor.submit(second)
+                asyncio.run(_wait_for_blocked_state_requests(2, [first_request, second_request]))
+            finally:
+                release.set()
+            first_response = first_request.result(timeout=10)
+            second_response = second_request.result(timeout=10)
+    finally:
+        # An INSERT gate left installed would block essentially every later test
+        # in the session, so it comes down even if the orchestration failed.
+        release.set()
+        lock_thread.join(timeout=10)
+        asyncio.run(_remove_state_insert_gate())
+
+    assert not lock_thread.is_alive(), "database gate did not release"
+    assert not lock_errors, lock_errors
+    return first_response, second_response
+
+
+def _state_writer(
+    client: Any, headers: dict[str, str], aid: str, namespace: str, key: str
+) -> Callable[[], Any]:
+    def request() -> Any:
+        return client.put(
+            f"/agents/{aid}/state/{namespace}/{key}", json={"value": 1}, headers=headers
+        )
+
+    return request
+
+
+def test_existing_namespace_write_does_not_take_the_namespace_lock(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    """#933 AC4: an existing-namespace write never touches the advisory lock.
+
+    The mutation this catches is deleting the hot-path early `return` in
+    `_enforce_caps` (routers/state.py) -- i.e. making the advisory lock
+    unconditional. Every other test in this file still passes under that
+    mutation, because they all create ABSENT namespaces and so take the lock
+    either way. dadf93e2's stated contract is that "writes to an existing
+    namespace are unaffected": no lock, no added latency. Without this test that
+    sentence is pinned by nothing.
+
+    Both directions are proved under ONE held lock, which is what makes a pass
+    meaningful rather than vacuous:
+
+    * the brand-NEW namespace write is confirmed blocked on the key (via
+      `pg_stat_activity`, not a sleep), so the key really is the production one
+      and the lock really is being contended; then
+    * the EXISTING-namespace write must return 200 inside a bounded timeout.
+
+    Failure is a `TimeoutError` from `.result()`, never a hang: the holder is
+    released in a `finally` on every path.
+    """
+    aid = _agent(client, auth_headers)
+    # Seed the namespace so the second write into it is an EXISTING-namespace
+    # write. Seeded before the lock is taken; seeding afterwards would itself
+    # block on the very key under test.
+    seed = client.put(f"/agents/{aid}/state/existing/k1", json={"value": 1}, headers=auth_headers)
+    assert seed.status_code == 200, seed.text
+
+    acquired = threading.Event()
+    release = threading.Event()
+    lock_errors: list[Exception] = []
+    lock_thread = threading.Thread(
+        target=_hold_advisory_lock,
+        args=(
+            (_NAMESPACE_LOCK_CLASS, _namespace_lock_key(uuid.UUID(aid))),
+            acquired,
+            release,
+            lock_errors,
+        ),
+        daemon=True,
+    )
+    lock_thread.start()
+    try:
+        assert acquired.wait(timeout=10), "production namespace lock was not acquired"
+        assert not lock_errors, lock_errors
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            # Control arm: a NEW namespace must serialize on the held key.
+            blocked = executor.submit(_state_writer(client, auth_headers, aid, "brand-new", "k1"))
+            try:
+                asyncio.run(_wait_for_blocked_state_requests(1, [blocked]))
+                # The arm under test. Post-fix it returns before the lock is ever
+                # requested; with the hot-path `return` deleted it joins the
+                # queue behind the holder and this `.result` raises TimeoutError.
+                unblocked = executor.submit(
+                    _state_writer(client, auth_headers, aid, "existing", "k2")
+                )
+                existing_response = unblocked.result(timeout=5)
+            finally:
+                # Released INSIDE the executor context: exiting the `with` joins
+                # its workers with no timeout, so a still-blocked request would
+                # hang there instead of failing.
+                release.set()
+            blocked_response = blocked.result(timeout=10)
+    finally:
+        release.set()
+        lock_thread.join(timeout=10)
+
+    assert not lock_thread.is_alive(), "namespace lock holder did not release"
+    assert not lock_errors, lock_errors
+    assert existing_response.status_code == 200, existing_response.text
+    # The control arm proves the block was real contention, not a dead key: it
+    # only completes once the holder lets go.
+    assert blocked_response.status_code == 200, blocked_response.text
+
+    listing = client.get(f"/agents/{aid}/state", headers=auth_headers)
+    assert listing.status_code == 200, listing.text
+    by_ns = {row["namespace"]: row for row in listing.json()}
+    assert by_ns["existing"]["key_count"] == 2, listing.text
+    assert by_ns["brand-new"]["key_count"] == 1, listing.text
+
+
+def test_concurrent_new_namespaces_cannot_exceed_the_cap(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    """#933: a concurrent burst must not walk past the per-agent namespace cap.
+
+    Pre-fix this is RED. The cap is a check-then-write TOCTOU: writer 2's
+    unlocked `count(distinct namespace)` sees only the seed, because writer 1's
+    `race-a` row is still uncommitted behind the gate, so it reads 1 < 2 and
+    passes its check too. Both insert -- two 200s, zero 403s, three namespaces
+    for a cap of 2.
+    """
+    aid = _agent(client, auth_headers)
+    # Seed BEFORE the gate is installed; a seed written afterwards would itself
+    # block on the gate.
+    seed = client.put(f"/agents/{aid}/state/seed/k", json={"value": 1}, headers=auth_headers)
+    assert seed.status_code == 200, seed.text
+
+    get_settings().state_max_namespaces = 2
+    try:
+        # The distinct-namespace count reaches 2 either way, so the same wait
+        # predicate holds pre-fix and post-fix. Post-fix writer 1 blocks at the
+        # gate while holding the namespace advisory lock and writer 2 blocks on
+        # that lock inside the cap check; pre-fix writer 2 sails through its
+        # check and blocks at the gate on its own INSERT. Two waiters either way.
+        first, second = _run_ordered_state_requests(
+            _state_writer(client, auth_headers, aid, "race-a", "k"),
+            _state_writer(client, auth_headers, aid, "race-b", "k"),
+        )
+
+        # Which writer wins is not under test, so assert the multiset.
+        statuses = sorted([first.status_code, second.status_code])
+        assert statuses == [200, 403], (first.text, second.text)
+        refused = first if first.status_code == 403 else second
+        assert "cap" in refused.text.lower() and "namespace" in refused.text.lower()
+
+        listing = client.get(f"/agents/{aid}/state", headers=auth_headers)
+        assert listing.status_code == 200, listing.text
+        assert len(listing.json()) == 2, listing.text
+    finally:
+        get_settings.cache_clear()
+
+
+def test_concurrent_writes_to_the_same_new_namespace_both_succeed(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    """The false-positive guard for #933's own fix, not regression coverage.
+
+    Stated honestly: this test also passes PRE-fix, because today both writers
+    sail through the unlocked check and insert. Its value is in the other
+    direction -- it goes RED against a fix that takes the namespace lock WITHOUT
+    re-checking existence under it. Such a fix would make writer 2 run the count,
+    see 2 (`seed` + `shared-new`) >= 2, and 403 a write that must be allowed. The
+    cap and seed numbers are chosen so it discriminates; do not raise the cap.
+
+    The two writers use DIFFERENT keys so the `uq_state_agent_ns_key` unique
+    constraint is not involved: this is about the cap, not about insert
+    conflicts.
+    """
+    aid = _agent(client, auth_headers)
+    seed = client.put(f"/agents/{aid}/state/seed/k", json={"value": 1}, headers=auth_headers)
+    assert seed.status_code == 200, seed.text
+
+    get_settings().state_max_namespaces = 2
+    try:
+        first, second = _run_ordered_state_requests(
+            _state_writer(client, auth_headers, aid, "shared-new", "k1"),
+            _state_writer(client, auth_headers, aid, "shared-new", "k2"),
+        )
+
+        assert first.status_code == 200, first.text
+        assert second.status_code == 200, second.text
+
+        listing = client.get(f"/agents/{aid}/state", headers=auth_headers)
+        assert listing.status_code == 200, listing.text
+        body = listing.json()
+        assert len(body) == 2, body
+        by_ns = {row["namespace"]: row for row in body}
+        assert by_ns["shared-new"]["key_count"] == 2, body
     finally:
         get_settings.cache_clear()
 


### PR DESCRIPTION
The per-agent namespace-count cap added in #925 was a check-then-write TOCTOU: `_enforce_caps` ran `SELECT count(distinct namespace)` and the caller's INSERT committed later, in a per-request session at READ COMMITTED. An agent at `cap-1` firing N concurrent PUTs to N distinct brand-new namespaces had every request read `cap-1`, pass, and insert.

Only the namespace-**creating** path is now serialized, on a per-agent transaction-level advisory lock, via double-checked locking:

1. An unlocked existence pre-check returns early, so every write into an already-existing namespace costs exactly the single indexed probe it cost before and takes **no lock** — `dadf93e2`'s "writes to an existing namespace are unaffected" is preserved literally.
2. `pg_advisory_xact_lock(class, key)`, released by COMMIT or ROLLBACK, so the 403 path has no leak.
3. The existence check is repeated **under the lock** — a sibling may have created the same namespace while we waited, and refusing it then would be a false positive.
4. The original count and 403 follow, byte-identical.

The lock key is `blake2b` over the agent UUID rather than builtin `hash()`, which is per-process randomized and would give two API workers different keys for the same agent. A cross-agent collision only serializes those agents; every query in the critical section is still filtered by `agent_id`.

## Verification

Regression coverage drives genuinely concurrent requests through the real HTTP route, held at a database-level INSERT gate and sequenced by **observed blocking** (polling `pg_stat_activity`) rather than a timed handoff, so it is deterministic in both directions.

Each guard was demonstrated by executing a mutation, not by reading the code:

| Mutation | Result |
|---|---|
| unfixed base | burst test fails: `assert [200, 200] == [200, 403]`, 3 namespaces |
| delete the re-check under the lock | same-namespace test fails with a spurious `403 agent is at its 2-namespace cap` |
| delete the hot-path early return | existing-namespace test fails with `TimeoutError` |

`apps/api` suite: **1079 passed, 10 skipped**. One failure, `test_control_integration.py::test_cost_composes_metrics_for_the_agent`, is environmental — it fails identically with `state.py` reverted to base because no Langfuse endpoint was running locally. `ruff` clean, `mypy` clean (191 files), `lint-imports` 4 kept / 0 broken, no OpenAPI drift.

## Scope

No ADR, schema, migration, `packages/aci-protocol`, or `packages/plugin-format` change. No new settings key, feature flag, `lock_timeout`, or retry. The 403 status and message are unchanged, and no existing test was modified.

## Deferred — two follow-ups a maintainer should file

Neither is a regression from this PR; both are pre-existing and were deliberately left out of scope. Recorded here rather than filed as issues.

1. **The per-namespace and per-value byte caps have the identical check-then-write shape.** Fixing them inside this lock would move the byte-cap queries under it and make the lock fire on the hot existing-namespace path, contradicting AC4 and `dadf93e2`'s intent. Needs its own design.
2. **Deleting a namespace's last row races an existing-namespace write and can overshoot the count cap.** Agent at cap with namespaces A,B: a PUT of a new key into existing A passes the unlocked pre-check; a concurrent delete removes A's last row; a third request creates C in the freed slot; the first PUT then recreates A, leaving A,B,C over a cap of 2. Verified **identical in the pre-change code** — today's `_enforce_caps` gates the count behind the same unlocked probe — so this change neither introduces nor widens it. Closing it requires putting the hot path under a lock, which is precisely what AC4 forbids.

Because of (2), "a concurrent burst cannot exceed the cap" holds for the burst scenario the issue describes; the delete-race path remains as the named residual.

## Review

Plan and diff were reviewed adversarially on a different engine (Codex `gpt-5.6-sol` via agent-router) across four passes — plan, code, scope, and a re-review of the consolidation diff — plus a spec-vs-impl pass on the closing commit.

The plan review refuted three claims, all applied: the original test design used a fixed-sleep handoff that was **not** deterministic and would have passed green against unfixed code. The code review surfaced that AC4 was unpinned — deleting the hot-path return left every test green — which is why the third test exists. The safety of the memory path and the absence of a deadlock cycle rest on code reading, not execution.

Closes #933
