### PR TITLE
Reuse the stored bundle on prod promote instead of re-cloning

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -299,10 +299,17 @@ Three properties keep an approval from becoming a standing permission:
 ## Pushing agent versions with git (deploy flow)
 
 A push is verified with an HMAC (Hash-based Message Authentication Code)
-signature, archived, validated, and stored as an immutable versioned bundle.
-A **dev-branch** push builds the artifact and fans out its eval suite as a CI
-check. A **prod-branch** push promotes that same artifact without rebuilding.
-One diagram, both branches:
+signature. The delivery that **builds** the bundle -- archiving, validating,
+and storing it as an immutable versioned bundle -- is a **dev-branch** push,
+which then fans out its eval suite as a CI check. A **prod-branch** push
+promotes that same artifact without rebuilding: if the pushed sha already has
+a stored bundle for this repository, the promote fetches its bytes straight
+from the object store and skips both the clone and the re-validation, which is
+why a prod promote does not need access to the git remote (#1211). Either way
+the deployed artifact is still the exact object that was validated when it was
+first built; the promote only re-checks its bounds against current caps
+(`deploy.revalidate_stored_bundle`, ADR-0059 decision 3). One diagram, both
+branches:
 
 There are **two ways a push reaches this flow**, and they converge immediately.
 The webhook below is the fast path. The second is a timer: `CommitPoller` in the

--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -54,11 +54,19 @@ worker, Postgres, RustFS/S3, Langfuse, and GitHub.
   required keyword-only parameter for this reason and must not get a default.
   The clone also pins `http.followRedirects=false`, since git's default
   follows a redirect on the very request carrying the auth header.
-- **Prod push reuses the dev-built bundle; it does not rebuild.** A push to
-  the prod branch looks up the `Version` already created for that sha (from
-  the dev push) and only creates a new `Deployment` row. If you find yourself
-  rebuilding on promote, that is a bug, not a feature -- promotion is meant to
-  be "the exact artifact that passed on dev," not a fresh build.
+- **Prod push reuses the dev-built bundle; it does not rebuild.** Before any
+  clone, a **prod-branch** push looks up a stored bundle for that sha across
+  every agent bound to the repository (ADR-0091), fetches its bytes from the
+  object store, and reads `deploy.yaml` out of them to route the push; it
+  still only creates a new `Deployment` row. A prod promote of an
+  already-bundled sha therefore needs no access to the git remote -- which
+  matters because the platform's GitHub credential can expire or be revoked
+  without stopping webhook delivery (#1211). A **dev-branch** push is not
+  affected by this: it always clones and always validates, redeliveries
+  included, because the clone is also where the ancestry check (#1139) runs.
+  If you find yourself rebuilding on promote, that is a bug, not a feature --
+  promotion is meant to be "the exact artifact that passed on dev," not a
+  fresh build.
 - **The plugin bundle validator (`plugin_format.validate_bundle`) is the only
   gate a bundle passes through**, whether it arrives via the CLI's
   `curie local deploy` / `curie cluster deploy`, the UI's create-agent

--- a/apps/api/src/curie_api/bundles.py
+++ b/apps/api/src/curie_api/bundles.py
@@ -39,6 +39,7 @@ __all__ = [
     "bundle_root",
     "detect_format",
     "extract_and_validate",
+    "extract_stored_bundle",
     "read_bundle_text_files",
 ]
 
@@ -86,7 +87,7 @@ def extract_and_validate(
     """
 
     extension, content_type = detect_format(data)
-    safe_extract(
+    extract_stored_bundle(
         data,
         dest,
         max_uncompressed_bytes=max_uncompressed_bytes,
@@ -95,6 +96,47 @@ def extract_and_validate(
     )
     result = validate_bundle(bundle_root(dest))
     return extension, content_type, result
+
+
+def extract_stored_bundle(
+    data: bytes,
+    dest: Path,
+    *,
+    max_uncompressed_bytes: int = DEFAULT_MAX_UNCOMPRESSED_BYTES,
+    max_compression_ratio: float = DEFAULT_MAX_COMPRESSION_RATIO,
+    max_members: int = DEFAULT_MAX_MEMBERS,
+) -> None:
+    """Extract bytes that already passed ``validate_bundle`` at store time.
+
+    Bounded extraction under the caller's caps, and nothing else: no
+    ``detect_format``, no ``validate_bundle``. Re-validation is not so much
+    skipped here as already done -- the storage key is immutable and write-once
+    (see ``storage.ObjectStore``), so the object cannot have changed since it
+    was validated on the delivery that stored it. The part that CAN have moved
+    since is the operator's caps, and ``safe_extract`` re-applies them here:
+    the same backward-compatibility commitment ``deploy.revalidate_stored_bundle``
+    makes (ADR-0059 decision 3).
+
+    Raises ``UnsupportedArchive`` when a cap is exceeded. Mapping that onto the
+    caller's own error contract is the caller's job -- ``gitflow.process_push``
+    re-raises it as ``deploy.BundleTooLarge`` so an over-cap legacy bundle keeps
+    reporting ``bundle.too_large`` rather than the vaguer ``bundle.unsupported``.
+
+    Named sibling of ``read_bundle_text_files``, which does the same
+    bounded-extract-without-validate for the bundle-files read endpoint, and the
+    shared bounded-extract primitive ``extract_and_validate`` itself calls, so
+    the caps argument list has one home rather than two copies. The "stored" in
+    the name describes the caller whose contract this docstring records, not a
+    property this function re-checks.
+    """
+
+    safe_extract(
+        data,
+        dest,
+        max_uncompressed_bytes=max_uncompressed_bytes,
+        max_compression_ratio=max_compression_ratio,
+        max_members=max_members,
+    )
 
 
 def read_connectors(root: Path) -> ConnectorsFile:

--- a/apps/api/src/curie_api/gitflow.py
+++ b/apps/api/src/curie_api/gitflow.py
@@ -2,10 +2,12 @@
 
 A push to the dev branch builds the plugin bundle at that commit and deploys it
 under the dev bot identity; a push to the prod branch promotes the same commit
-(reusing the already-built bundle when present) under the prod bot identity. The
-bundle is produced by archiving the pushed sha from the repo, so the flow needs
-only git-protocol access to the remote (local bare repos in tests) and never the
-GitHub API.
+under the prod bot identity, reusing the already-built bundle when present --
+the lookup runs BEFORE any clone, so a promote of a sha this repository has
+already bundled needs no access to the remote at all (#1211). When the bundle
+does have to be built, it is produced by archiving the pushed sha from the repo,
+so that path needs only git-protocol access to the remote (local bare repos in
+tests) and never the GitHub API.
 """
 
 import base64
@@ -20,7 +22,7 @@ import tempfile
 import uuid
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol
 from urllib.parse import urlsplit
 
 from aci_protocol import EvalJob
@@ -214,25 +216,26 @@ def _git_failure_detail(
     return str(exc)[:200]
 
 
-def clone_and_archive(
-    clone_url: str,
-    sha: str,
-    settings: Settings,
-    *,
-    repo_full_name: str,
-    ref: str,
-    credentials: Any = None,
-) -> bytes:
-    """Mirror-clone the repo and return a tar of the tree at ``sha``.
+def verify_push_origin(
+    clone_url: str, sha: str, settings: Settings, *, repo_full_name: str
+) -> str:
+    """Authorize a push against its repository binding, and return the derived URL.
 
-    Refuses clone URLs outside the configured scheme allowlist and restricts git
-    to safe transports, so a webhook cannot coerce an arbitrary git command.
+    This is the network-free half of the clone's authorization: the payload
+    scheme allowlist, the ``_is_valid_sha`` option-injection gate (#65), the
+    ``repo_full_name`` derivation (``InvalidRepoFullName``, #1140), the derived
+    URL's own scheme allowlist, and whole-key origin equality (#1122). None of
+    it needs the remote.
 
-    ``clone_url`` is the untrusted webhook payload value: it is compared against
-    the origin derived from ``repo_full_name`` (which the caller must have read
-    from the agent row) and then discarded. Git is handed the derived origin,
-    for both the clone argv and the credential header, so a signed-but-forged
-    payload cannot choose where the platform GitHub token travels (#1122).
+    It is its own function so the path that reuses a stored bundle and the path
+    that clones run THE SAME CODE rather than two copies (#1211).
+    ``clone_and_archive`` still calls it, so its contract is unchanged; a
+    promote that never clones calls it directly.
+
+    Returns the trusted origin derived from ``repo_full_name`` -- the only URL
+    that may ever reach git. Raises ``GitFlowError`` for a refused scheme or a
+    malformed sha, ``InvalidRepoFullName`` for an unencodable binding, and
+    ``CloneOriginMismatch`` when the payload names a different origin.
     """
 
     if not clone_url.startswith(settings.git_allowed_schemes):
@@ -259,6 +262,33 @@ def clone_and_archive(
             f"clone url does not match the registered repository "
             f"{repo_full_name!r}: {clone_url[:200]!r}"
         )
+    return trusted_url
+
+
+def clone_and_archive(
+    clone_url: str,
+    sha: str,
+    settings: Settings,
+    *,
+    repo_full_name: str,
+    ref: str,
+    credentials: Any = None,
+) -> bytes:
+    """Mirror-clone the repo and return a tar of the tree at ``sha``.
+
+    Refuses clone URLs outside the configured scheme allowlist and restricts git
+    to safe transports, so a webhook cannot coerce an arbitrary git command.
+
+    ``clone_url`` is the untrusted webhook payload value: it is compared against
+    the origin derived from ``repo_full_name`` (which the caller must have read
+    from the agent row) and then discarded. Git is handed the derived origin,
+    for both the clone argv and the credential header, so a signed-but-forged
+    payload cannot choose where the platform GitHub token travels (#1122).
+    """
+
+    trusted_url = verify_push_origin(
+        clone_url, sha, settings, repo_full_name=repo_full_name
+    )
 
     tmp = tempfile.mkdtemp(prefix="gitflow-")
     env = {
@@ -413,16 +443,124 @@ async def process_push(
     # decides which agent receives the resulting Version.
     trusted_repo_full_name = str(repo_agents[0].repo_full_name)
 
+    # Set only on the clone path; `detect_format` is the only producer and
+    # `store_bundle` the only consumer, and neither is reachable when the bytes
+    # came from the store (see the `assert` in the bundle_built block below).
+    extension: str | None = None
+    content_type: str | None = None
+
     try:
-        archive = await run_in_threadpool(
-            clone_and_archive,
-            clone_url,
-            after,
-            settings,
-            repo_full_name=trusted_repo_full_name,
-            ref=ref,
+        # Unconditionally, before any database or object-store work: a forged
+        # push is refused and logged before this handler does anything else.
+        # Hoisting it out of the clone is what keeps #1122's origin pin, #1140's
+        # repo_full_name derivation and #65's sha gate on BOTH paths -- none of
+        # them ever needed the network, so none of them was really something the
+        # clone was providing.
+        verify_push_origin(
+            clone_url, after, settings, repo_full_name=trusted_repo_full_name
         )
-        extension, content_type = deploy.validate_archive(archive, settings)
+
+        # Has anything in this repository already built and stored this exact
+        # commit? If so, reuse those bytes and do not clone at all (#1211).
+        # The reuse fast path is PROD ONLY; the named gate below is
+        # load-bearing, so read WHY PROD ONLY before the reuse argument.
+        #
+        # WHY PROD ONLY. `CommitNotOnBranch` (#1139) is
+        # `git merge-base --is-ancestor` run against the remote, and there is no
+        # offline form of it. #1211's acceptance criterion is that the prod
+        # promote still succeeds when the remote has been deleted. Those two
+        # cannot both hold on one code path, so exactly one lane pays: prod
+        # trades the ancestry check for the offline promote, and dev -- which
+        # was never asked to work offline -- clones on every delivery exactly as
+        # it does on `main` today and keeps #1139 fully enforced.
+        #
+        # WHAT IS REUSED, AND WHY IT IS SAFE. The stored object passed
+        # `validate_bundle` when it was stored and its key is immutable and
+        # write-once, so it cannot have changed since. The promote deploys THAT
+        # object either way -- before this branch existed the freshly cloned
+        # bytes were validated and then discarded -- so cloning to re-validate
+        # bytes nobody deploys bought nothing but a network dependency. The
+        # bounded read of `deploy.yaml` off the stored bytes is
+        # `_read_stored_targets`; its docstring carries the
+        # extract-without-revalidate argument in full.
+        #
+        # WHAT IS PRESERVED. `verify_push_origin` above runs unconditionally, on
+        # both paths and in both environments, so #1122's origin pin, both
+        # scheme allowlists, #65's sha format gate and #1140's repo_full_name
+        # derivation are untouched by this change.
+        #
+        # WHAT IS NOT PRESERVED, plainly, and only on prod. A holder of the
+        # webhook signing secret can POST a signed push with
+        # `ref: refs/heads/main` and an `after` sha that has a stored bundle for
+        # THIS repository but is not an ancestor of the prod branch -- a sha
+        # pushed to dev, bundled, then abandoned rather than merged -- and it
+        # will be promoted. Five facts bound that:
+        #
+        #   1. It is exactly the pre-#1194 posture. Before c655ab9e the promote
+        #      performed zero clones and there was no ancestry check at all;
+        #      this restores that, it does not open something new.
+        #   2. The sha must ALREADY have a stored bundle for this repository, so
+        #      it already passed `validate_bundle` on a prior delivery here.
+        #      #1139's actual attack -- promoting a hostile fork's
+        #      `refs/pull/N/head` sha out of the `--mirror` clone -- is NOT
+        #      reachable, because such a sha has no stored bundle. The escape is
+        #      "promote a commit of ours that is not on main", not "promote a
+        #      stranger's code".
+        #   3. Because the dev lane always clones, the only way a sha acquires a
+        #      stored bundle in the first place is by passing #1139's ancestry
+        #      check on a dev delivery. That is what bounds the prod escape to
+        #      "a commit of ours that was on dev and is not on main" rather than
+        #      to arbitrary code: the dev gate does the containment work.
+        #   4. The clone path is unaffected: any sha without a stored bundle
+        #      still clones and still gets the full ancestry check, so #1139's
+        #      coverage is intact for every first-time delivery.
+        #   5. The attacker is the one `apps/api/CLAUDE.md` already assumes --
+        #      "the HMAC signature authenticates the sender, not the payload".
+        #
+        # This deliberately leaves the dev-redelivery row of #1211's measured
+        # table (0 clones before #1194, 1 clone after) unfixed: a re-delivered
+        # dev sha still pays a clone. Closing that row means an
+        # offline-checkable replacement for #1139, which needs a new invariant
+        # and a schema change -- a separate ticket with an ADR, not something to
+        # improvise here.
+        may_reuse_without_remote_verification = environment is Environment.prod
+        prebuilt = (
+            await _bundled_version_for_commit(session, repo_agents, after)
+            if may_reuse_without_remote_verification
+            else None
+        )
+        if prebuilt is not None:
+            archive = await store.get(str(prebuilt.bundle_ref))
+            try:
+                targets = await run_in_threadpool(_read_stored_targets, archive, settings)
+            except bundles.UnsupportedArchive as exc:
+                # Exact, not a catch-all. `safe_extract` raises
+                # `UnsupportedArchive` for unsafe entries OR for a cap
+                # violation, and on already-stored bytes the unsafe-entry causes
+                # are unreachable: they were refused before the object could be
+                # stored, and the key is immutable. A cap violation is all that
+                # is left, and it is what `deploy.revalidate_stored_bundle`
+                # -- which this extract now runs in FRONT of -- reports as
+                # `bundle.too_large` (ADR-0059 decision 3). Letting it surface
+                # as `bundle.unsupported` instead would regress an
+                # operator-facing error contract as a side effect of a
+                # performance fix.
+                raise deploy.BundleTooLarge(
+                    f"stored bundle for version {prebuilt.id} fails the current "
+                    f"bundle size/ratio limits and must be rebuilt and "
+                    f"re-uploaded: {exc}"
+                ) from exc
+        else:
+            archive = await run_in_threadpool(
+                clone_and_archive,
+                clone_url,
+                after,
+                settings,
+                repo_full_name=trusted_repo_full_name,
+                ref=ref,
+            )
+            extension, content_type = deploy.validate_archive(archive, settings)
+            targets = await run_in_threadpool(_read_targets, archive, settings)
     except InvalidRepoFullName as exc:
         return WebhookResult(
             status="rejected", errors=[{"code": "git.invalid_repository", "message": str(exc)}]
@@ -444,10 +582,16 @@ async def process_push(
         return WebhookResult(
             status="rejected", errors=[{"code": "bundle.unsupported", "message": str(exc)}]
         )
+    except deploy.BundleTooLarge as exc:
+        # The same code the `revalidate_stored_bundle` block below returns, so a
+        # legacy over-cap bundle reports identically whichever of the two
+        # bounds checks reaches it first.
+        return WebhookResult(
+            status="rejected", errors=[{"code": "bundle.too_large", "message": str(exc)}]
+        )
     except deploy.BundleInvalid as exc:
         return WebhookResult(status="rejected", errors=exc.errors)
 
-    targets = await run_in_threadpool(_read_targets, archive, settings)
     named = _target_agent_name(targets, environment)
     named_elsewhere = (
         await crud.get_agent_by_name(session, named)
@@ -486,12 +630,21 @@ async def process_push(
         # again: prod then promotes not merely an identical artifact but the
         # SAME one, which is what makes "promote what you validated" a property
         # of the schema rather than of discipline.
-        sibling = await _sibling_bundle(session, repo_agents, agent.id, after)
+        sibling = await _bundled_version_for_commit(
+            session, repo_agents, after, exclude_agent_id=agent.id
+        )
         if sibling is not None:
             version = await crud.attach_bundle(
                 session, version, str(sibling.bundle_ref), str(sibling.bundle_sha256)
             )
         else:
+            # Unreachable when the archive came from the store: the pre-clone
+            # lookup only returns a bundled version belonging to one of
+            # `repo_agents`, so either that version IS this agent's (bundle_built
+            # is False and this block does not run) or it is a sibling's and the
+            # branch above attaches it. So `archive` here is always freshly
+            # cloned, and `validate_archive` has always supplied the pair.
+            assert extension is not None and content_type is not None
             await deploy.store_bundle(
                 store, session, agent.id, version, archive, extension, content_type
             )
@@ -503,9 +656,18 @@ async def process_push(
     # A prod promote (bundle_built is False) reuses a bundle that may have been
     # stored before the current size/ratio caps existed, or under looser ones --
     # revalidate it here (ADR-0059 decision 3's backward-compat commitment). The
-    # bundle_built branch above already ran these bytes through
+    # bundle_built branch above ran freshly CLONED bytes through
     # `deploy.validate_archive` under the current caps moments ago, so re-fetching
     # and rechecking the identical bytes here would be redundant.
+    #
+    # On the reuse path (#1211) `extract_stored_bundle` has already re-applied
+    # the same caps to these bytes minutes earlier in this handler, so this call
+    # repeats work. It is kept deliberately: this is the single documented home
+    # of ADR-0059 decision 3's commitment, it also covers deliveries where the
+    # earlier extract did not happen (a sibling attach, where the object the
+    # version now points at is not the object `deploy.yaml` was read from), and
+    # deleting it would make the commitment depend on the shape of an
+    # optimization. Both routes report `bundle.too_large`.
     if not bundle_built:
         try:
             await deploy.revalidate_stored_bundle(store, version, settings)
@@ -644,15 +806,38 @@ def resolve_target_agent(
     )
 
 
-def _read_targets(archive: bytes, settings: Settings) -> DeployTargetsFile | None:
-    """Read ``deploy.yaml`` out of an already-validated archive.
+class _BundleExtract(Protocol):
+    """The bounded-extract call shape the two ``deploy.yaml`` readers share."""
 
-    Extracted to a temp dir because that is the only way to read one file out
-    of the bundle, and run in a threadpool by the caller since it is blocking.
+    def __call__(
+        self,
+        data: bytes,
+        dest: Path,
+        *,
+        max_uncompressed_bytes: int,
+        max_compression_ratio: float,
+        max_members: int,
+    ) -> object: ...
+
+
+def _read_deploy_targets(
+    extract: _BundleExtract, archive: bytes, settings: Settings
+) -> DeployTargetsFile | None:
+    """Extract ``archive`` under the operator's caps and read its ``deploy.yaml``.
+
+    The three caps are security-relevant (ADR-0059 decision 3), so the argument
+    list lives HERE, once: the two wrappers below differ only in which extract
+    they hand in, and a change to the caps cannot reach one reader and miss the
+    other. Extraction to a temp dir is the only way to read one file out of a
+    bundle, and it is blocking, so callers run the wrappers in a threadpool.
+
+    Read the wrapper you were sent from, not this helper, for what the choice of
+    ``extract`` means: ``_read_stored_targets``'s docstring carries the
+    extract-without-revalidate argument in full.
     """
 
     with tempfile.TemporaryDirectory() as tmp:
-        bundles.extract_and_validate(
+        extract(
             archive,
             Path(tmp),
             max_uncompressed_bytes=settings.bundle_max_uncompressed_bytes,
@@ -660,6 +845,47 @@ def _read_targets(archive: bytes, settings: Settings) -> DeployTargetsFile | Non
             max_members=settings.bundle_max_members,
         )
         return bundles.read_deploy_targets(Path(tmp))
+
+
+def _read_targets(archive: bytes, settings: Settings) -> DeployTargetsFile | None:
+    """Read ``deploy.yaml`` out of an already-validated archive.
+
+    Extracted to a temp dir because that is the only way to read one file out
+    of the bundle, and run in a threadpool by the caller since it is blocking.
+    """
+
+    return _read_deploy_targets(bundles.extract_and_validate, archive, settings)
+
+
+def _read_stored_targets(archive: bytes, settings: Settings) -> DeployTargetsFile | None:
+    """Read ``deploy.yaml`` out of a bundle fetched from the object store.
+
+    THIS PATH STILL EXTRACTS. It extracts the whole archive to a temp dir, under
+    exactly the same configured uncompressed-size, compression-ratio and
+    member-count caps `_read_targets` uses -- that is the only way to read one
+    file out of a bundle, and it is blocking, so the caller runs it in a
+    threadpool. What it does NOT do is re-run ``detect_format`` and
+    ``validate_bundle``: these bytes came from the immutable, write-once
+    storage key, where they passed ``validate_bundle`` on the delivery that
+    stored them, and they are the object this delivery deploys either way.
+
+    #1211's acceptance criterion asks for "zero extractions" on a promote. That
+    is, precisely, a zero of ``bundles.extract_and_validate`` calls -- which is
+    the honest measure here, because ``extract_and_validate`` is the composite
+    (detect + extract + validate) whose second and third parts are the redundant
+    work, and because it is the function the issue's own instrumentation
+    counted. A reader who sees "zero extractions" in a test name and then finds
+    a ``safe_extract`` call underneath this function has found the right thing,
+    not a lie: the extraction is bounded and unavoidable, the re-validation is
+    what went away.
+
+    Raises ``bundles.UnsupportedArchive`` when the current caps refuse bytes
+    stored under looser ones; ``process_push`` maps that to
+    ``deploy.BundleTooLarge`` so ADR-0059 decision 3's operator-facing code
+    survives the reorder.
+    """
+
+    return _read_deploy_targets(bundles.extract_stored_bundle, archive, settings)
 
 
 def _target_agent_name(targets: DeployTargetsFile | None, environment: Environment) -> str | None:
@@ -671,18 +897,40 @@ def _target_agent_name(targets: DeployTargetsFile | None, environment: Environme
     return matching[0].agent if len(matching) == 1 else None
 
 
-async def _sibling_bundle(
+async def _bundled_version_for_commit(
     session: AsyncSession,
     repo_agents: "Sequence[Agent]",
-    agent_id: uuid.UUID,
     commit_sha: str,
+    *,
+    exclude_agent_id: uuid.UUID | None = None,
 ) -> "AgentVersion | None":
-    """A version another agent of this repo already stored for this commit."""
+    """A version of this repository that already has this commit's bundle stored.
 
-    for sibling in repo_agents:
-        if sibling.id == agent_id:
+    Two questions, one predicate, on purpose. With ``exclude_agent_id`` it is
+    the ADR-0091 bundle-once/bind-many sibling reuse (#1194): has ANOTHER agent
+    of this repository already stored this commit, so the target agent can bind
+    the same object instead of uploading the bytes again? Without it, it is the
+    pre-clone check (#1211): has ANYTHING in this repository already built and
+    stored this exact commit, so this delivery needs no remote at all?
+
+    They are the same question with a different exclusion, and #1211 is exactly
+    what happens when they drift -- the lookup already existed, it just ran
+    after the clone it could have avoided. Keeping one function means the two
+    can never disagree about what "already bundled" means.
+
+    ``repo_agents`` arrives in ``Agent.name`` order (``crud.get_agents_by_repo``
+    orders it), so the version returned for a repository is deterministic.
+
+    Note the truthiness test on ``bundle_ref``, not ``is not None``: a row whose
+    bundle_ref is NULL is the residue of a prior attempt that failed after the
+    row committed (d3a0f4b8) and must be rebuilt, and an empty-string ref would
+    otherwise sail into ``store.get("")``.
+    """
+
+    for candidate in repo_agents:
+        if exclude_agent_id is not None and candidate.id == exclude_agent_id:
             continue
-        existing = await crud.get_version_by_commit(session, sibling.id, commit_sha)
+        existing = await crud.get_version_by_commit(session, candidate.id, commit_sha)
         if existing is not None and existing.bundle_ref:
             return existing
     return None

--- a/apps/api/tests/test_gitflow_integration.py
+++ b/apps/api/tests/test_gitflow_integration.py
@@ -16,6 +16,7 @@ import hashlib
 import hmac
 import json
 import os
+import shutil
 import subprocess
 import uuid
 from collections.abc import Iterator
@@ -25,6 +26,7 @@ from typing import Any
 import pytest
 from curie_api import bundles, crud
 from curie_api.config import get_settings
+from curie_api.deps import get_eval_queue
 from curie_test_support.scaffold import scaffolded_deploy_yaml
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
@@ -198,6 +200,83 @@ def _register_agent(client: Any, headers: dict[str, str]) -> str:
         headers=headers,
     ).json()
     return str(agent["id"])
+
+
+class _ExtractSpy:
+    """Counts `bundles.extract_and_validate` calls while still doing the real work.
+
+    Patched onto the MODULE object (`monkeypatch.setattr(bundles, ...)`), never
+    onto an import alias: both production call sites -- `gitflow._read_targets`
+    and `deploy.validate_archive` -- resolve the name as
+    `bundles.extract_and_validate` at call time, so this one patch counts both.
+
+    It delegates to the captured original rather than returning canned values,
+    so the delivery under test stays a real delivery. A stub would make "zero
+    extractions" true by making the push meaningless, which is the failure mode
+    a call-count assertion is most prone to.
+    """
+
+    def __init__(self) -> None:
+        self.calls = 0
+        # Captured BEFORE the patch is installed, so the spy wraps the real
+        # function and never itself.
+        self._real = bundles.extract_and_validate
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        self.calls += 1
+        return self._real(*args, **kwargs)
+
+
+class _RecordingEvalQueue:
+    """Stands in for the Valkey eval producer and remembers what was enqueued.
+
+    Installed through `app.dependency_overrides[get_eval_queue]`, the same
+    public seam `test_webhook_body_bound.py` uses, rather than by reaching into
+    the queue's internals or reading the stream back out of Valkey.
+    """
+
+    def __init__(self) -> None:
+        self.jobs: list[Any] = []
+
+    async def enqueue(self, job: Any) -> str:
+        self.jobs.append(job)
+        return f"0-{len(self.jobs)}"
+
+
+def _delete_bare_repo(base_dir: Path, repo_full_name: str = REPO) -> None:
+    """Make the remote unreachable, the way a dead PAT or a deleted repo does.
+
+    #1110 records the operational expectation this rests on: `github_token` is a
+    static PAT that "dies when they leave". A dead credential does not stop
+    GitHub delivering webhooks -- it stops only the clone -- so "the push
+    arrives but the remote cannot be read" is a state the platform is expected
+    to meet, not a contrived one. Removing the bare repository under the derived
+    origin reproduces exactly that split.
+
+    The `_work` tree is deliberately left in place: the derived origin is
+    `<base>/<owner>/<name>.git` and nothing else, so nothing can resolve through
+    it. The assertion below is what keeps this helper honest -- a silent no-op
+    here would turn every test that calls it into a test of nothing.
+    """
+
+    bare = base_dir / f"{repo_full_name}.git"
+    shutil.rmtree(bare)
+    assert not bare.exists(), "the remote must really be gone, or these tests prove nothing"
+
+
+def _tighten_uncompressed_cap(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    """Shrink `bundle_max_uncompressed_bytes` for the rest of the test.
+
+    Same two moves as `trusted_clone_base`: set the env, then clear the settings
+    cache so the next per-request `get_settings()` picks the new value up. It
+    needs no teardown of its own precisely because it writes through the SAME
+    `monkeypatch` instance that fixture holds, so that fixture's clear-AFTER-undo
+    ordering covers this variable too -- undo first, THEN clear, or the still-set
+    value is simply re-cached and leaks into the next test.
+    """
+
+    monkeypatch.setenv("BUNDLE_MAX_UNCOMPRESSED_BYTES", value)
+    get_settings.cache_clear()
 
 
 def test_dev_push_deploys_dev_bot(
@@ -617,6 +696,398 @@ def test_signed_push_with_a_foreign_url_fallback_is_rejected(
 
 
 # --------------------------------------------------------------------------- #
+# A promote reuses the stored bundle instead of re-cloning (#1211)
+# --------------------------------------------------------------------------- #
+# #1194 hoisted `clone_and_archive` + `deploy.validate_archive` above the
+# `if bundle_built:` guard, because deploy.yaml -- which decides the target
+# agent -- lives inside the bundle. The hoist is right; what it cost is that a
+# prod promote now pays a full mirror clone plus two extractions for bytes it
+# then discards, and FAILS outright when the remote is unreachable. These tests
+# pin the promote's reuse of the already-stored, already-validated object, and
+# they pin the guards that must survive the reordering.
+#
+# The measure is calls to `bundles.extract_and_validate` -- the composite
+# (detect + extract + validate_bundle) whose second and third parts are the
+# redundant work on this path, and the one the issue's own instrumentation
+# counted. A promote may still bounded-extract the stored bytes to read one
+# YAML file; what it must not do is re-run whole-bundle validation on an
+# artifact that passed it at store time under an immutable, write-once key.
+
+
+def test_prod_promote_reuses_the_stored_bundle_with_the_remote_deleted(
+    client: Any,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    trusted_clone_base: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1211's acceptance criterion, driven through the real webhook.
+
+    Dev builds and stores the bundle; the remote then disappears; prod promotes
+    the same sha anyway, reusing the same version and touching no network.
+
+    Two mutations this must catch, and they are caught by DIFFERENT assertions:
+
+    * Reverting the branch so the clone runs unconditionally reddens step 5 --
+      the promote comes back `rejected` with `git.archive_failed`, because the
+      bare repository is gone.
+    * Keeping the reuse but feeding the stored bytes to `_read_targets` (the
+      issue's literal Fix wording) instead of `_read_stored_targets` reddens the
+      final assertion with `spy.calls == 1`.
+
+    Neither mutation is caught by the other's assertion, which is why both are
+    here.
+    """
+
+    agent_id = _register_agent(client, auth_headers)
+    clone_url, sha = _build_bare_repo(trusted_clone_base, REPO, VALID_FILES)
+
+    dev = _post(client, "push", _push_payload("refs/heads/dev", sha, clone_url)).json()
+    assert dev["status"] == "deployed", dev
+    assert dev["version_id"] is not None
+
+    _delete_bare_repo(trusted_clone_base)
+
+    # Installed only NOW. Counting the dev delivery too would leave the test
+    # unable to say WHICH delivery did the work, and the dev push must run the
+    # real validation or there is nothing trustworthy to promote.
+    spy = _ExtractSpy()
+    monkeypatch.setattr(bundles, "extract_and_validate", spy)
+
+    prod = _post(client, "push", _push_payload("refs/heads/main", sha, clone_url)).json()
+
+    assert prod["status"] == "promoted", prod
+    assert prod["environment"] == "prod"
+    assert prod["version_id"] == dev["version_id"], (
+        "prod must promote the artifact dev validated, not a rebuild of it"
+    )
+    assert spy.calls == 0, (
+        f"a promote of an already-stored bundle must re-validate nothing; got {spy.calls}"
+    )
+
+    # "promoted" is a string; a Deployment row is the product. Read it back
+    # through the API rather than trusting the response body's own report.
+    deployments = client.get(
+        "/deployments", params={"agent_id": agent_id}, headers=auth_headers
+    ).json()
+    prod_rows = [d for d in deployments if d["environment"] == "prod"]
+    assert len(prod_rows) == 1, deployments
+    assert prod_rows[0]["commit_sha"] == sha
+    assert prod_rows[0]["version_id"] == dev["version_id"]
+
+
+def test_a_redelivered_dev_push_reuses_the_version_without_rebuilding(
+    client: Any,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    trusted_clone_base: Path,
+) -> None:
+    """A redelivered dev push is idempotent: one version, one eval job.
+
+    GitHub redelivers a webhook whenever the first attempt looks unhealthy, and
+    an operator can redeliver by hand from the deliveries UI. The version is
+    already built and stored, so the second delivery must reuse that row rather
+    than build a second one or fan out a second eval.
+
+    What it must NOT claim is that the dev lane skips the clone. The dev lane
+    deliberately still clones on every delivery, because the clone is where
+    `git merge-base --is-ancestor` (#1139) runs -- see
+    `test_a_dev_push_for_a_sha_no_longer_on_the_branch_is_still_rejected`.
+    #1211's stored-bundle fast path is therefore prod-only, and the
+    dev-redelivery row of that issue's table is left unfixed on purpose: a dev
+    redelivery still pays for its clone, and that is the price of keeping the
+    ancestry check on the lane an attacker can reach with a signed replay. So
+    the remote stays up here, and what is pinned is idempotence, not
+    offline-ness.
+
+    The eval queue is recorded across BOTH deliveries on purpose: asserting only
+    "zero on the second" would also pass if the fan-out had stopped working
+    entirely. One job after the first delivery and still one after the second is
+    what pins `environment is dev and bundle_built`'s dedupe (6c3698e1).
+    """
+
+    agent_id = _register_agent(client, auth_headers)
+    clone_url, sha = _build_bare_repo(trusted_clone_base, REPO, VALID_FILES)
+
+    eval_queue = _RecordingEvalQueue()
+    client.app.dependency_overrides[get_eval_queue] = lambda: eval_queue
+    try:
+        first = _post(client, "push", _push_payload("refs/heads/dev", sha, clone_url)).json()
+        assert first["status"] == "deployed", first
+        assert len(eval_queue.jobs) == 1, "the first dev delivery fans out one eval job"
+
+        second = _post(client, "push", _push_payload("refs/heads/dev", sha, clone_url)).json()
+    finally:
+        client.app.dependency_overrides.pop(get_eval_queue, None)
+
+    assert second["status"] == "deployed", second
+    assert second["version_id"] == first["version_id"], (
+        "a redelivery must reuse the version dev already built, not build a second one"
+    )
+    assert len(eval_queue.jobs) == 1, (
+        "a redelivered push must not enqueue a second eval job for the same version"
+    )
+
+    versions = client.get(f"/agents/{agent_id}/versions", headers=auth_headers).json()
+    assert len(versions) == 1, versions
+    assert versions[0]["id"] == first["version_id"]
+
+    # Each delivery records its own Deployment row -- that is the audit trail --
+    # but both point at the one version, which is the property that matters.
+    deployments = client.get(
+        "/deployments", params={"agent_id": agent_id}, headers=auth_headers
+    ).json()
+    assert [d["environment"] for d in deployments] == ["dev", "dev"], deployments
+    assert {d["version_id"] for d in deployments} == {first["version_id"]}
+
+
+def test_a_dev_push_for_a_sha_no_longer_on_the_branch_is_still_rejected(
+    client: Any,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    trusted_clone_base: Path,
+) -> None:
+    """#1211's reuse must never reach the dev lane, or #1139 stops guarding it.
+
+    The exploit this prevents: a holder of the webhook signing secret replays a
+    dev push naming a sha that was deployed to dev once and has since been
+    force-pushed off the branch. A bundle for that sha is already stored, so a
+    reuse lookup that ran for dev would hand those bytes straight back to the
+    dev bot without ever asking git whether the commit is still on the branch --
+    a signed rollback of the dev agent onto abandoned code. Keeping the
+    stored-bundle fast path prod-only is what keeps `git merge-base
+    --is-ancestor` on every dev delivery.
+
+    Mutation this catches: widening the reuse lookup back to dev flips this
+    red-to-green in the wrong direction -- the push would come back `deployed`,
+    served from the stored bundle, with the clone and its ancestry check never
+    run. The test fails exactly when the bypass is widened.
+    """
+
+    agent_id = _register_agent(client, auth_headers)
+    clone_url, sha = _build_bare_repo(trusted_clone_base, REPO, VALID_FILES)
+
+    # A real dev deploy first, so a stored bundle for this sha exists. Without
+    # one the reuse path could not fire even if it were wired to dev, and the
+    # rejection below would prove nothing about the bypass.
+    dev = _post(client, "push", _push_payload("refs/heads/dev", sha, clone_url)).json()
+    assert dev["status"] == "deployed", dev
+
+    # Roll the branch off that sha the way a force-push does. The replacement is
+    # an ORPHAN commit: a descendant would leave `sha` an ancestor of the branch
+    # and the ancestry check would pass. `sha` itself must stay a live object --
+    # `refs/heads/main` still holds it -- so `merge-base` answers "not an
+    # ancestor" instead of failing on a missing object, which is a different
+    # rejection and would not prove the check ran.
+    work = trusted_clone_base / "_work" / REPO
+    bare = trusted_clone_base / f"{REPO}.git"
+    _git("checkout", "-q", "--orphan", "rewritten", cwd=work)
+    (work / "REWRITTEN.txt").write_text("history rewritten over the deployed sha\n")
+    _git("add", "-A", cwd=work)
+    _git("commit", "-q", "-m", "force-push over dev", cwd=work)
+    rewritten_sha = _git("rev-parse", "HEAD", cwd=work)
+    # Push under a non-branch ref first so the object exists in the bare repo,
+    # then move the branch itself: `refs/heads/dev` is a non-fast-forward here,
+    # which is exactly what a force-push is.
+    _git("push", "--quiet", str(bare), f"{rewritten_sha}:refs/rewritten/head", cwd=work)
+    _git("update-ref", "refs/heads/dev", rewritten_sha, cwd=bare)
+    assert _git("rev-parse", "refs/heads/dev", cwd=bare) == rewritten_sha, (
+        "the branch must really have moved, or this test proves nothing"
+    )
+
+    body = _post(client, "push", _push_payload("refs/heads/dev", sha, clone_url)).json()
+
+    assert body["status"] == "rejected", body
+    assert {error["code"] for error in body["errors"]} == {"git.commit_not_on_branch"}, body
+
+    # The first dev deployment stands; the replay recorded nothing of its own.
+    deployments = client.get(
+        "/deployments", params={"agent_id": agent_id}, headers=auth_headers
+    ).json()
+    assert [d["environment"] for d in deployments] == ["dev"], deployments
+
+
+@pytest.mark.parametrize(
+    "repository",
+    [
+        {"full_name": REPO, "clone_url": f"https://evil.example/{REPO}.git"},
+        # GitHub sets `clone_url` with the .git suffix and `url` without it; the
+        # fallback field must not be an unguarded back door on this path either
+        # (the parity-seam precedent is the existing clone_url/url pair above).
+        {"full_name": REPO, "url": f"https://evil.example/{REPO}"},
+    ],
+    ids=["clone_url", "url_fallback"],
+)
+def test_a_foreign_clone_url_is_rejected_even_when_the_bundle_is_already_stored(
+    repository: dict[str, str],
+    client: Any,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    trusted_clone_base: Path,
+) -> None:
+    """#1122's origin pin must still fire on the path that no longer clones.
+
+    A dev push has already stored a bundle for this sha, so the promote takes
+    the reuse path. If the origin check lived inside `clone_and_archive`, the
+    branch that skips the clone would skip the check with it, and a correctly
+    signed payload naming somebody else's repository would be promoted. Hoisting
+    the check out is what keeps this rejection identical on both paths.
+
+    Mutation this must catch: moving `verify_push_origin` into the clone-only
+    branch turns this green-to-red -- the push would come back `promoted`.
+
+    Note for the TDD run: unlike the reuse tests above, this one is GREEN before
+    the fix as well (today the clone runs unconditionally and its own pre-flight
+    rejects). That is the point of it. It is a guard against the fix dropping a
+    control, so it cannot be red first without asserting something false.
+    """
+
+    agent_id = _register_agent(client, auth_headers)
+    clone_url, sha = _build_bare_repo(trusted_clone_base, REPO, VALID_FILES)
+
+    dev = _post(client, "push", _push_payload("refs/heads/dev", sha, clone_url)).json()
+    assert dev["status"] == "deployed", dev
+
+    body = _post(
+        client,
+        "push",
+        {"ref": "refs/heads/main", "after": sha, "repository": repository},
+    ).json()
+
+    assert body["status"] == "rejected", body
+    assert "git.origin_mismatch" in {e["code"] for e in body["errors"]}
+
+    # The dev deployment is untouched and nothing was promoted.
+    deployments = client.get(
+        "/deployments", params={"agent_id": agent_id}, headers=auth_headers
+    ).json()
+    assert [d["environment"] for d in deployments] == ["dev"], deployments
+
+
+def test_a_version_without_a_stored_bundle_does_not_take_the_reuse_path(
+    client: Any,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    trusted_clone_base: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A row with `bundle_ref` NULL is residue, not a promotable artifact.
+
+    d3a0f4b8 introduced `bundle_built = version is None or version.bundle_ref is
+    None` for exactly this: a row that committed and then failed before its
+    bundle was stored must be REBUILT, never deployed. The reuse lookup is the
+    one place that could quietly undo it.
+
+    Mutation this must catch: writing the lookup as "any version for this sha"
+    -- dropping the `bundle_ref` truthiness test, or using `is not None` so an
+    empty-string ref sails into `store.get("")` -- turns this red, because the
+    delivery would reuse nothing and extract nothing.
+
+    Green before the fix as well, deliberately: it pins behaviour the fix must
+    preserve rather than behaviour the fix adds.
+    """
+
+    agent_id = _register_agent(client, auth_headers)
+    clone_url, sha = _build_bare_repo(trusted_clone_base, REPO, VALID_FILES)
+    _insert_partial_version(agent_id, sha)
+
+    # The remote is deliberately still present: this half asserts the delivery
+    # genuinely goes and rebuilds.
+    spy = _ExtractSpy()
+    monkeypatch.setattr(bundles, "extract_and_validate", spy)
+
+    body = _post(client, "push", _push_payload("refs/heads/dev", sha, clone_url)).json()
+    assert body["status"] == "deployed", body
+    assert spy.calls >= 1, "a bundleless row must send the delivery back to the remote"
+
+    versions = client.get(f"/agents/{agent_id}/versions", headers=auth_headers).json()
+    assert len(versions) == 1, "the partial row is repaired in place, not duplicated"
+    assert versions[0]["commit_sha"] == sha
+    assert versions[0]["bundle_ref"] is not None
+
+
+def test_a_bundleless_version_is_not_promotable_when_the_remote_is_gone(
+    client: Any,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    trusted_clone_base: Path,
+) -> None:
+    """The negative half: a row alone must not buy the offline path.
+
+    The reuse path is earned by a STORED bundle, not by the existence of a
+    version row for the sha. With nothing stored there is nothing to deploy, so
+    the only correct answer is the rejection the clone failure produces -- a
+    bundleless row must never become promotable just because a row exists.
+    """
+
+    agent_id = _register_agent(client, auth_headers)
+    _clone_url, sha = _build_bare_repo(trusted_clone_base, REPO, VALID_FILES)
+    _insert_partial_version(agent_id, sha)
+    _delete_bare_repo(trusted_clone_base)
+
+    body = _post(
+        client,
+        "push",
+        _push_payload("refs/heads/main", sha, f"file://{trusted_clone_base}/{REPO}.git"),
+    ).json()
+
+    assert body["status"] == "rejected", body
+    assert {e["code"] for e in body["errors"]} == {"git.archive_failed"}, body
+    assert (
+        client.get("/deployments", params={"agent_id": agent_id}, headers=auth_headers).json()
+        == []
+    )
+
+
+def test_a_stored_bundle_over_the_current_caps_is_still_rejected_as_too_large(
+    client: Any,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    trusted_clone_base: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A performance reorder must not silently downgrade an error contract.
+
+    ADR-0059 decision 3 commits to a specific operator-facing outcome: a bundle
+    stored before the current caps existed (or under looser ones) is refused at
+    deploy time as `bundle.too_large`, with a message saying it must be rebuilt
+    and re-uploaded. `deploy.revalidate_stored_bundle` is what produces that.
+
+    Reading deploy.yaml off the stored bytes puts a bounded extract IN FRONT of
+    that revalidation, so a bundle over the caps now blows up there first -- and
+    a bounded extract's natural failure is `bundle.unsupported`, a different,
+    vaguer code that tells the operator nothing about size. The reordering must
+    map that one failure back, because on already-stored bytes the caps are the
+    only reachable cause: unsafe entries were refused before the object could be
+    stored, and the storage key is immutable and write-once.
+
+    This is the only test on the git-flow path pinning that code, so asserting
+    the exact set rather than `in` is the point -- `bundle.unsupported` passing
+    for `bundle.too_large` is precisely the regression.
+    """
+
+    agent_id = _register_agent(client, auth_headers)
+    clone_url, sha = _build_bare_repo(trusted_clone_base, REPO, VALID_FILES)
+
+    # Stored under the default caps, exactly as a legacy bundle was.
+    dev = _post(client, "push", _push_payload("refs/heads/dev", sha, clone_url)).json()
+    assert dev["status"] == "deployed", dev
+
+    # Now the operator tightens the caps under it.
+    _tighten_uncompressed_cap(monkeypatch, "1")
+
+    body = _post(client, "push", _push_payload("refs/heads/main", sha, clone_url)).json()
+
+    assert body["status"] == "rejected", body
+    assert {e["code"] for e in body["errors"]} == {"bundle.too_large"}, body
+
+    deployments = client.get(
+        "/deployments", params={"agent_id": agent_id}, headers=auth_headers
+    ).json()
+    assert [d["environment"] for d in deployments] == ["dev"], deployments
+
+
+# --------------------------------------------------------------------------- #
 # One repository, two agents (ADR-0091, #1070)
 # --------------------------------------------------------------------------- #
 DEPLOY_YAML = """
@@ -715,6 +1186,68 @@ def test_prod_promotes_the_exact_artifact_dev_validated(
         "prod must promote the artifact dev validated, not a re-upload of it"
     )
     assert dev_version["commit_sha"] == prod_version["commit_sha"] == sha
+
+
+def test_prod_promote_to_a_sibling_agent_skips_the_clone(
+    client: Any,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    trusted_clone_base: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The two-agent shape (#1211 on top of ADR-0091) also needs no remote.
+
+    This is the harder half of the reuse. On the legacy single-agent shape the
+    promote finds the agent's OWN version and `bundle_built` is False. Here the
+    main push resolves to a DIFFERENT agent, which has no version for this sha,
+    so `bundle_built` is True and the delivery takes the bundle-once/bind-many
+    branch: it creates a row for the prod agent and attaches the dev agent's
+    stored object to it rather than uploading the bytes again.
+
+    Both halves therefore have to work offline -- the deploy.yaml read that
+    decides the target, and the sibling lookup that supplies the object -- and
+    `store_bundle` must never be reached, because there are no fresh bytes to
+    store. `test_prod_promotes_the_exact_artifact_dev_validated` asserts the
+    shared `bundle_ref` with the remote up; this asserts it survives with the
+    remote gone, which is the assertion the clone could previously satisfy by
+    accident.
+    """
+
+    dev_id = _register(client, auth_headers, "two-agent-dev", "C000000D01")
+    prod_id = _register(client, auth_headers, "two-agent-prod", "C000000E01")
+    clone_url, sha = _build_bare_repo(trusted_clone_base, REPO, TWO_TARGET_FILES)
+
+    dev = _post(client, "push", _push_payload("refs/heads/dev", sha, clone_url)).json()
+    assert dev["status"] == "deployed", dev
+    assert dev["agent_id"] == dev_id
+
+    _delete_bare_repo(trusted_clone_base)
+
+    spy = _ExtractSpy()
+    monkeypatch.setattr(bundles, "extract_and_validate", spy)
+
+    prod = _post(client, "push", _push_payload("refs/heads/main", sha, clone_url)).json()
+
+    assert prod["status"] == "promoted", prod
+    assert prod["agent_id"] == prod_id, "deploy.yaml still routes main to the prod agent"
+    assert spy.calls == 0, f"the sibling path must re-validate nothing; got {spy.calls}"
+
+    def only_version(agent_id: str) -> dict[str, Any]:
+        versions = client.get(f"/agents/{agent_id}/versions", headers=auth_headers).json()
+        assert len(versions) == 1, versions
+        return dict(versions[0])
+
+    dev_version, prod_version = only_version(dev_id), only_version(prod_id)
+    assert dev_version["id"] != prod_version["id"], "each agent still owns its own row"
+    assert dev_version["bundle_ref"] == prod_version["bundle_ref"], (
+        "with no remote to clone from, the prod row must point at the object dev stored"
+    )
+    assert prod_version["bundle_ref"] is not None
+
+    deployments = client.get(
+        "/deployments", params={"agent_id": prod_id}, headers=auth_headers
+    ).json()
+    assert [d["environment"] for d in deployments] == ["prod"], deployments
 
 
 def test_a_target_naming_another_repos_agent_is_rejected_end_to_end(
@@ -829,6 +1362,87 @@ def test_commit_poller_retries_after_routing_topology_is_repaired(
     assert len(deployments) == 1, deployments
     assert deployments[0]["commit_sha"] == sha
     assert deployments[0]["environment"] == "dev"
+
+
+def test_the_commit_poller_promotes_a_stored_bundle_with_the_remote_deleted(
+    client: Any,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    trusted_clone_base: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The polling lane inherits the reuse; it is not special-cased (#1211).
+
+    The poller does not clone to notice a move -- it reads the branch tip from
+    the GitHub API and then hands `process_push` the same payload the webhook
+    would have delivered. So the two lanes must agree here, and the way to show
+    that is to drive the real `CommitPoller` rather than to argue from shared
+    code.
+
+    Placement note: this lives here, beside the other real-poller test, and not
+    in `test_commitpoller.py`. That file is deliberately pure-unit -- stubbed
+    sessions, a stubbed `process_push`, no database, no object store and no bare
+    repositories -- and this test needs all four. Adding them there would
+    duplicate this module's fixtures into a file whose stated design is to not
+    need them.
+
+    The dev branch is already deployed at this sha, so the only move the pass
+    finds is main: one promote, with no remote to promote from.
+    """
+
+    from curie_api.commitpoller import CommitPoller
+
+    agent_id = _register_agent(client, auth_headers)
+    clone_url, sha = _build_bare_repo(trusted_clone_base, REPO, VALID_FILES)
+    dev = _post(client, "push", _push_payload("refs/heads/dev", sha, clone_url)).json()
+    assert dev["status"] == "deployed", dev
+
+    _delete_bare_repo(trusted_clone_base)
+    settings = get_settings()
+
+    class Tips:
+        """Both deploy branches sit on the pushed sha, as they do after a merge."""
+
+        def sha_for(self, repo_full_name: str, branch: str) -> str | None:
+            assert repo_full_name == REPO
+            return sha
+
+    class NoopEvalQueue:
+        async def enqueue(self, _job: Any) -> None:
+            pass
+
+    spy = _ExtractSpy()
+    monkeypatch.setattr(bundles, "extract_and_validate", spy)
+
+    async def exercise() -> list[str]:
+        engine = create_async_engine(settings.database_url)
+        maker = async_sessionmaker(engine, expire_on_commit=False)
+        poller = CommitPoller(
+            session_factory=maker,
+            store=client.app.state.bundle_store,
+            settings=settings,
+            eval_queue=NoopEvalQueue(),
+            tips=Tips(),
+            interval_seconds=60,
+        )
+        try:
+            return [move.branch for move in await poller.poll_once()]
+        finally:
+            await engine.dispose()
+
+    moved = asyncio.run(exercise())
+    assert moved == [settings.prod_branch], (
+        f"only main has moved since the dev deploy; got {moved}"
+    )
+    assert spy.calls == 0, f"a polled promote must re-validate nothing; got {spy.calls}"
+
+    deployments = client.get(
+        "/deployments", params={"agent_id": agent_id}, headers=auth_headers
+    ).json()
+    prod_rows = [d for d in deployments if d["environment"] == "prod"]
+    assert len(prod_rows) == 1, deployments
+    assert prod_rows[0]["version_id"] == dev["version_id"]
+    assert prod_rows[0]["commit_sha"] == sha
 
 
 # --------------------------------------------------------------------------- #

--- a/apps/api/tests/test_gitflow_unit.py
+++ b/apps/api/tests/test_gitflow_unit.py
@@ -674,6 +674,165 @@ def test_clone_failure_reports_git_stderr_not_the_exit_code() -> None:
     assert "Repository not found" in str(err.value)
 
 
+# --------------------------------------------------------------------------- #
+# The network-free half of the clone's authorization, on its own (#1211)
+# --------------------------------------------------------------------------- #
+# A promote of an already-stored bundle no longer clones, so every check that
+# used to live inside `clone_and_archive` and cost nothing -- the payload scheme
+# allowlist, the sha format gate, the `repo_full_name` derivation, the derived
+# URL's own scheme allowlist, and whole-key origin equality -- has to run
+# somewhere both paths reach. `verify_push_origin` is that somewhere, and the
+# tests below call it DIRECTLY: exercising it only through `clone_and_archive`
+# would test it exclusively on the path that no longer always runs.
+#
+# The exhaustive fourteen-case mismatch battery stays where it is, still driven
+# through `clone_and_archive`; what is repeated here is a representative subset,
+# because two copies of fourteen cases rot into two different fourteen cases.
+#
+# Note what is absent: no `subprocess.run` patch anywhere below. That is not an
+# omission, it is the property -- this function starts no process at all, which
+# is what lets it be hoisted in front of the branch and run on a delivery that
+# will never touch the network. A version of it that needed a mock would have
+# smuggled the clone back in.
+_MISMATCH_SUBSET = [
+    # Userinfo of any kind: a credential in the payload URL is never honored.
+    f"https://x-access-token:t@github.com/{_REPO}.git",
+    # Hostname is evil.example; the "github.com" is the username.
+    f"https://github.com@evil.example/{_REPO}.git",
+    # A non-default port reaches a different service on the same host.
+    f"https://github.com:8443/{_REPO}.git",
+    # Scheme downgrade.
+    f"http://github.com/{_REPO}.git",
+    # Path prefix. Whole-key equality, never startswith.
+    "https://github.com/octo/demo-agent-evil.git",
+    # Unparseable port: urlsplit().port raises ValueError, which must read as a
+    # mismatch rather than escaping as a 500.
+    f"https://github.com:notaport/{_REPO}.git",
+    # Malformed IPv6 literal: urlsplit itself raises ValueError.
+    f"https://[::1/{_REPO}.git",
+]
+
+
+@pytest.mark.parametrize("payload_url", _MISMATCH_SUBSET)
+def test_verify_push_origin_rejects_a_mismatched_origin(payload_url: str) -> None:
+    from curie_api.gitflow import verify_push_origin
+
+    settings = Settings(github_token="ghs-secret-token")
+    with pytest.raises(CloneOriginMismatch):
+        verify_push_origin(payload_url, _VALID_SHA1, settings, repo_full_name=_REPO)
+
+
+@pytest.mark.parametrize(
+    "payload_url",
+    [
+        # GitHub sets clone_url with .git and url without it.
+        f"https://github.com/{_REPO}.git",
+        f"https://github.com/{_REPO}",
+        # Trailing slash, with and without .git before it.
+        f"https://github.com/{_REPO}.git/",
+        f"https://github.com/{_REPO}/",
+        # An explicit default port is the same origin.
+        f"https://github.com:443/{_REPO}.git",
+        # urlsplit().hostname lowercases ASCII hosts.
+        f"https://GitHub.com/{_REPO}.git",
+    ],
+)
+def test_verify_push_origin_returns_the_derived_url_for_every_accepted_form(
+    payload_url: str,
+) -> None:
+    # Asserting the RETURN VALUE, not merely "it did not raise". The derived URL
+    # is the only string that may ever reach git, and a function that accepted
+    # the payload and handed its caller the payload back would satisfy a
+    # does-not-raise assertion while re-opening #1122 for whoever uses it next.
+    from curie_api.gitflow import verify_push_origin
+
+    assert (
+        verify_push_origin(payload_url, _VALID_SHA1, Settings(), repo_full_name=_REPO)
+        == _GITHUB_URL
+    )
+
+
+def test_verify_push_origin_refuses_a_mixed_case_scheme_as_a_config_error() -> None:
+    # `HTTPS://` is refused by the case-sensitive PAYLOAD scheme allowlist, which
+    # runs BEFORE the origin comparator. The error TYPE is the assertion: a
+    # scheme refusal is not a forged-push report, and the two produce different
+    # operator-facing codes (`git.archive_failed` vs `git.origin_mismatch`).
+    # Case-folding that allowlist to turn this into an accept would be widening a
+    # security gate to pass a test. Nobody may do that.
+    from curie_api.gitflow import verify_push_origin
+
+    with pytest.raises(GitFlowError) as err:
+        verify_push_origin(
+            f"HTTPS://github.com/{_REPO}.git", _VALID_SHA1, Settings(), repo_full_name=_REPO
+        )
+    assert not isinstance(err.value, CloneOriginMismatch)
+
+
+@pytest.mark.parametrize("clone_base", ["github.com", "ssh://git@github.com"])
+def test_verify_push_origin_refuses_a_configured_base_outside_the_allowlist(
+    clone_base: str,
+) -> None:
+    # The DERIVED url gets its own scheme check, because it -- not the payload --
+    # is what git would be handed. A misconfigured `github_clone_base` must fail
+    # as a deployment configuration error, never be reported as a forged push,
+    # so again the assertion that carries the meaning is the error type.
+    from curie_api.gitflow import verify_push_origin
+
+    settings = Settings(github_token="ghs-secret-token", github_clone_base=clone_base)
+    with pytest.raises(GitFlowError) as err:
+        verify_push_origin(_GITHUB_URL, _VALID_SHA1, settings, repo_full_name=_REPO)
+    assert not isinstance(err.value, CloneOriginMismatch)
+
+
+def test_verify_push_origin_propagates_an_invalid_repo_full_name() -> None:
+    # #1140. `InvalidRepoFullName` is a distinct exception rather than a
+    # GitFlowError precisely so `process_push` can map it to
+    # `git.invalid_repository`, and it must escape this function unwrapped or the
+    # code changes shape depending on whether the delivery cloned. This is why
+    # `git.invalid_repository` needs no duplicate integration test per path: one
+    # function raises it for both.
+    from curie_api.gitflow import verify_push_origin
+    from curie_api.repo_full_name import InvalidRepoFullName
+
+    with pytest.raises(InvalidRepoFullName):
+        verify_push_origin(_ALLOWED_URL, _VALID_SHA1, _local_settings(), repo_full_name="octo/..")
+
+
+@pytest.mark.parametrize(
+    "bad_sha",
+    [
+        "--upload-pack=touch /tmp/pwned",  # a real option-injection payload
+        "deadbeef",  # too short
+        "A" * 40,  # uppercase hex is rejected
+        "a" * 40 + "\n--foo",  # embedded newline smuggling a git option
+        "",  # empty
+    ],
+)
+def test_verify_push_origin_rejects_a_malformed_sha(bad_sha: str) -> None:
+    # #65's option-injection gate. It travels with the origin check rather than
+    # staying behind in the clone, so a delivery that never runs `git archive`
+    # still refuses a sha that is not a full lowercase-hex object id -- and the
+    # refusal is a plain GitFlowError, not a mismatch report.
+    from curie_api.gitflow import verify_push_origin
+
+    with pytest.raises(GitFlowError) as err:
+        verify_push_origin(_ALLOWED_URL, bad_sha, _local_settings(), repo_full_name=_REPO)
+    assert not isinstance(err.value, CloneOriginMismatch)
+
+
+def test_verify_push_origin_accepts_a_local_file_origin() -> None:
+    # The control on every rejection above: a function that refused everything
+    # would satisfy them all and break every real deploy. `file://` is the shape
+    # the integration suite's bare repositories use, so this is also the form the
+    # end-to-end tests depend on.
+    from curie_api.gitflow import verify_push_origin
+
+    assert (
+        verify_push_origin(_ALLOWED_URL, _VALID_SHA1, _local_settings(), repo_full_name=_REPO)
+        == _ALLOWED_URL
+    )
+
+
 def test_rejected_push_is_logged_loudly() -> None:
     # A rejected push still returns 200 -- GitHub would retry a non-2xx and the
     # push will not succeed on a retry. The cost is that every dashboard reports


### PR DESCRIPTION
Closes #1211

## What was wrong

#1194 hoisted `clone_and_archive` and `deploy.validate_archive` out of the `if bundle_built:` guard so `deploy.yaml` could route a push before the target agent is known (ADR-0091). The reordering is necessary. What it cost is the promote path: `bundle_built` is `False` there, `store_bundle` is never called, so the freshly cloned bytes are extracted twice and then thrown away while the already-stored object is what actually gets deployed. It also made a promote fail outright whenever the git remote is unreachable, which #1110 documents as an expected operational state for a static PAT.

## What changed

A prod promote now looks for an already-stored bundle for the pushed sha across every agent bound to the repository **before** cloning. On a hit it feeds `store.get(bundle_ref)` bytes to the routing read and skips both the clone and `validate_archive`.

Three things make that safe rather than merely shorter:

1. **The origin check was hoisted out of the clone, not lost with it.** `verify_push_origin` is extracted from `clone_and_archive` and called unconditionally in `process_push`, so the origin pin (#1122), both scheme allowlists, the sha format gate (#65) and the `repo_full_name` derivation (#1140) now run on both paths. `clone_and_archive` still calls it too, so its contract and its existing tests are untouched.
2. **The fast path is prod-only.** A dev delivery still clones, so #1139's `merge-base --is-ancestor` check keeps guarding the lane a signed replay can reach.
3. **`bundle.too_large` survives the reordering.** The stored-path extract runs in front of `revalidate_stored_bundle`, so its `UnsupportedArchive` is mapped back to `BundleTooLarge` rather than silently downgrading ADR-0059 decision 3's operator-facing code to `bundle.unsupported`.

## Reviewer notes, called out rather than buried

**Accepted residual risk, mandated by the acceptance criterion.** #1211's AC requires the promote to succeed with the remote deleted, so no network check is possible on that path and `CommitNotOnBranch` cannot run there. A holder of the webhook signing secret can therefore promote to prod a sha that has a stored bundle for this repository but is not an ancestor of the prod branch. Four things bound it: it restores exactly the pre-#1194 posture; the sha must already have a stored bundle for this repo, and since dev still clones, it can only have got one by passing the ancestry check on a dev delivery, so #1139's hostile-fork `refs/pull/N/head` attack is not reachable; every first-time delivery still clones and still gets the full check; and the attacker is the one `apps/api/CLAUDE.md` already assumes. The trade-off is written into a comment at the branch point. If it is judged unacceptable, the fix is a new ticket with an ADR, not a widening of this one.

**Deliberately not fixed:** the dev-redelivery row of the issue's measured table. Closing it would mean putting the reuse on the dev lane, which is exactly the widening above. Left as-is on purpose.

**Interpreting "zero extractions".** The issue's Fix paragraph says to feed the stored bytes to `_read_targets`, but its AC asks for zero `bundles.extract_and_validate` calls, and `_read_targets` is such a call. The stored path therefore reads `deploy.yaml` with a bounded extract that does not re-run `detect_format` or `validate_bundle`. It still extracts, under the same caps; what it skips is the re-validation of bytes that came from the immutable, write-once storage key and already passed `validate_bundle` when they were stored. `_read_stored_targets`'s docstring says this in full so no reader mistakes the test name for "nothing is extracted".

**Test additions beyond the issue's own AC.** The eval fan-out dedupe assertion, the direct `verify_push_origin` cases beyond the forged-origin one, and the commit-poller scenario are all coverage the issue did not name. They are kept on purpose: each pins an invariant this reordering could plausibly break, and the poller reaches the same `process_push`.

## Verification

Every mutation the AC names was executed, not reasoned about:

- clone unconditionally -> the promote test goes red with `assert 'rejected' == 'promoted'`
- feed the stored bytes to `_read_targets` (the issue's literal Fix wording) -> red with `assert 1 == 0`
- widen the reuse back to the dev lane -> the ancestry regression test goes red with `assert 'deployed' == 'rejected'`

294 focused tests pass. `ruff`, `mypy`, `lint-imports` and `scripts/check-docs.sh` are clean. The wider `apps/api` suite was compared commit-for-commit against `origin/main` on the same stack: the failures that remain are identical on both sides and are environmental, so this branch adds no regression.
