### PR TITLE
Require architecture atlas snapshots for releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,7 +32,7 @@ jobs:
   # Gates the ENTIRE tag-triggered publish pipeline (issue #628). A `v*` tag push
   # proves nothing about the tagged commit on its own, so nothing below may run
   # for one until this job says the commit is reviewed, on an allowed release
-  # branch, and green.
+  # branch, green, and covered by its registered architecture-atlas snapshot.
   # See ADR-0058 for the ancestry/checks design and ADR-0065 for the trust
   # boundary this job actually sits behind: it stops an accidentally-tagged
   # commit, not a write actor willing to edit the gate itself, because both
@@ -89,6 +89,11 @@ jobs:
           python3 release/authorize.py "$GITHUB_SHA" --repo "$GITHUB_REPOSITORY" \
             --reviewed-ref origin/${{ env.RELEASE_MAIN_BRANCH }} \
             --reviewed-ref origin/${{ env.RELEASE_NEXT_BRANCH }}
+      - name: Tag must carry its architecture atlas snapshot
+        run: |
+          python3 release/atlas.py \
+            --version "$GITHUB_REF_NAME" \
+            --commit "$GITHUB_SHA"
 
   build:
     name: Build ${{ matrix.name }} image (${{ matrix.platform }})

--- a/docs/architecture-atlas/README.md
+++ b/docs/architecture-atlas/README.md
@@ -23,3 +23,12 @@ required.
 Snapshots under `snapshots/` are immutable historical views. `versions.json`
 selects the default and populates the version picker. Use the project-local
 `update-architecture-atlas` skill to create and research a new snapshot.
+
+Every tagged release must register a snapshot with the same version id before
+the tag is pushed. Generate it from the final architecture-bearing commit, then
+make only the release version edits. The release workflow fails before image or
+binary builds if the snapshot is absent, its manifest and repository metadata
+disagree, its pinned commit is not tag ancestry, or any path other than the
+snapshot registration and release-coupled version files changed after the pin.
+This ordering avoids the impossible requirement for a commit to contain its own
+SHA while still proving the tag has no un-atlased architecture changes.

--- a/docs/architecture-atlas/snapshots/v0.7.2.json
+++ b/docs/architecture-atlas/snapshots/v0.7.2.json
@@ -1,0 +1,3221 @@
+{
+  "schemaVersion": "1.4",
+  "asOf": "2026-08-27",
+  "repository": {
+    "name": "curie-eng/curie",
+    "branch": "main",
+    "commit": "771c621cab35df4002414711b43ac4648f3b9f2f",
+    "shortCommit": "771c621c",
+    "release": "v0.7.2"
+  },
+  "title": "Curie architecture atlas",
+  "subtitle": "The production loop, its swappable seams, and the distance between current state and vision.",
+  "architectureGroups": [
+    {
+      "id": "channel-surface",
+      "label": "Channel surface",
+      "subtitle": "1 current \u00b7 2 planned",
+      "kind": "surface",
+      "state": "implemented",
+      "zone": "surfaces",
+      "x": 0.075,
+      "y": 0.25,
+      "description": "One stable channel role in the architecture. Concrete surfaces are implementations of this role and stay inside this expandable node.",
+      "memberIds": [
+        "slack",
+        "email",
+        "teams"
+      ]
+    },
+    {
+      "id": "sandbox-substrate",
+      "label": "Sandbox substrate",
+      "mapLabel": "Substrate",
+      "subtitle": "2 proven implementations",
+      "kind": "substrate",
+      "state": "implemented",
+      "zone": "foundation",
+      "x": 0.92,
+      "y": 0.765,
+      "description": "The stable substrate role beneath sandbox lifecycle. Kubernetes and Docker prove that the same boundary has multiple implementations.",
+      "memberIds": [
+        "kubernetes",
+        "docker"
+      ]
+    }
+  ],
+  "overview": {
+    "title": "The request-to-reply loop",
+    "description": "Read left to right. Every colored connector is a seam: green is proven, yellow is clean but unproven, red is intertwined, and blue is planned.",
+    "stages": [
+      {
+        "id": "surfaces",
+        "eyebrow": "1 \u00b7 Enter",
+        "label": "External surfaces",
+        "description": "A person, repository, or operator starts work.",
+        "nodeIds": [
+          "slack",
+          "cli",
+          "github",
+          "external-hook",
+          "email"
+        ]
+      },
+      {
+        "id": "ingress",
+        "eyebrow": "2 \u00b7 Normalize",
+        "label": "Ingress + API",
+        "description": "Authenticate, bind the agent, and turn the event into work.",
+        "nodeIds": [
+          "dispatcher",
+          "channel-api",
+          "api"
+        ]
+      },
+      {
+        "id": "dispatch",
+        "eyebrow": "3 \u00b7 Route",
+        "label": "Queue + worker",
+        "description": "Claim delivery, lock the conversation, and resolve the run.",
+        "nodeIds": [
+          "queue",
+          "worker"
+        ]
+      },
+      {
+        "id": "runtime",
+        "eyebrow": "4 \u00b7 Isolate",
+        "label": "Sandbox + runner",
+        "description": "Start or resume an isolated, steerable ACI session.",
+        "nodeIds": [
+          "sandbox",
+          "runner"
+        ]
+      },
+      {
+        "id": "execution",
+        "eyebrow": "5 \u00b7 Execute",
+        "label": "Harness + MCP + model",
+        "description": "Run the multi-turn model loop, call hosted MCP tools, and produce side effects.",
+        "nodeIds": [
+          "harness",
+          "model",
+          "connector-host",
+          "oauth-gateway"
+        ]
+      }
+    ],
+    "connections": [
+      {
+        "from": "surfaces",
+        "to": "ingress",
+        "label": "channel ingress",
+        "seamId": "channel-ingress"
+      },
+      {
+        "from": "ingress",
+        "to": "dispatch",
+        "label": "durable work",
+        "seamId": "queue-stream"
+      },
+      {
+        "from": "dispatch",
+        "to": "runtime",
+        "label": "sandbox claim",
+        "seamId": "substrate"
+      },
+      {
+        "from": "runtime",
+        "to": "execution",
+        "label": "model session",
+        "seamId": "harness-modelsession"
+      }
+    ],
+    "return": {
+      "label": "stream result, request approval when needed, then reply to the originating surface",
+      "seamId": "channel-reply"
+    },
+    "rails": [
+      {
+        "id": "approval-loop",
+        "label": "Approval loop",
+        "description": "Pause, authorize, and resume a live turn.",
+        "nodeIds": [
+          "approvals"
+        ],
+        "seamIds": [
+          "approval-authorizer",
+          "approval-principal"
+        ]
+      },
+      {
+        "id": "evidence-plane",
+        "label": "Evidence plane",
+        "description": "Traces, telemetry, eval cases, scores, and results surround every run.",
+        "nodeIds": [
+          "otel",
+          "langfuse",
+          "eval-plane"
+        ],
+        "seamIds": [
+          "telemetry",
+          "eval-scorer"
+        ]
+      },
+      {
+        "id": "substrate",
+        "label": "Substrate",
+        "description": "Kubernetes is the production baseline; Docker proves the same sandbox boundary locally.",
+        "nodeIds": [
+          "kubernetes",
+          "docker"
+        ],
+        "seamIds": [
+          "substrate"
+        ]
+      }
+    ]
+  },
+  "maturityRubric": [
+    {
+      "id": "green",
+      "label": "Proven",
+      "symbol": "\u2713",
+      "definition": "Multiple real implementations have exercised the same boundary."
+    },
+    {
+      "id": "yellow",
+      "label": "Clean, unproven",
+      "symbol": "\u25c7",
+      "definition": "One real implementation sits behind a credible boundary, but a second implementation has not tested the shape."
+    },
+    {
+      "id": "red",
+      "label": "Intertwined",
+      "symbol": "\u00d7",
+      "definition": "A swap still requires coordinated knowledge or changes across implementation owners."
+    },
+    {
+      "id": "planned",
+      "label": "Planned / reserved",
+      "symbol": "\u25cb",
+      "definition": "The intended line is documented, but there is not a real implementation to score."
+    }
+  ],
+  "sources": [
+    {
+      "id": "architecture",
+      "type": "architecture",
+      "title": "Architecture as built",
+      "path": "ARCHITECTURE.md",
+      "href": "https://github.com/curie-eng/curie/blob/771c621cab35df4002414711b43ac4648f3b9f2f/ARCHITECTURE.md"
+    },
+    {
+      "id": "vision",
+      "type": "vision",
+      "title": "Product vision",
+      "path": "docs/vision.md",
+      "href": "https://github.com/curie-eng/curie/blob/771c621cab35df4002414711b43ac4648f3b9f2f/docs/vision.md"
+    },
+    {
+      "id": "architecture-vision",
+      "type": "architecture",
+      "title": "Swappable jobs around an opinionated core",
+      "path": "docs/architecture-vision.md",
+      "href": "https://github.com/curie-eng/curie/blob/771c621cab35df4002414711b43ac4648f3b9f2f/docs/architecture-vision.md"
+    },
+    {
+      "id": "interfaces",
+      "type": "catalog",
+      "title": "Interface catalog",
+      "path": "docs/interfaces.md",
+      "href": "https://github.com/curie-eng/curie/blob/771c621cab35df4002414711b43ac4648f3b9f2f/docs/interfaces.md"
+    },
+    {
+      "id": "message-flow",
+      "type": "diagram",
+      "title": "Message flow",
+      "path": "docs/diagrams/message-flow.md",
+      "href": "https://github.com/curie-eng/curie/blob/771c621cab35df4002414711b43ac4648f3b9f2f/docs/diagrams/message-flow.md"
+    },
+    {
+      "id": "kubernetes",
+      "type": "diagram",
+      "title": "Kubernetes architecture",
+      "path": "docs/diagrams/kubernetes.md",
+      "href": "https://github.com/curie-eng/curie/blob/771c621cab35df4002414711b43ac4648f3b9f2f/docs/diagrams/kubernetes.md"
+    },
+    {
+      "id": "aci-diagram",
+      "type": "diagram",
+      "title": "Agent Container Interface",
+      "path": "docs/diagrams/aci.md",
+      "href": "https://github.com/curie-eng/curie/blob/771c621cab35df4002414711b43ac4648f3b9f2f/docs/diagrams/aci.md"
+    },
+    {
+      "id": "channel-api-code",
+      "type": "code",
+      "title": "Generic channel HTTP ingress",
+      "path": "apps/api/src/curie_api/routers/channels.py",
+      "href": "https://github.com/curie-eng/curie/blob/771c621cab35df4002414711b43ac4648f3b9f2f/apps/api/src/curie_api/routers/channels.py"
+    },
+    {
+      "id": "reply-sink-code",
+      "type": "code",
+      "title": "Neutral reply sink and router",
+      "path": "apps/worker/src/curie_worker/reply_sink.py",
+      "href": "https://github.com/curie-eng/curie/blob/771c621cab35df4002414711b43ac4648f3b9f2f/apps/worker/src/curie_worker/reply_sink.py"
+    },
+    {
+      "id": "binding-code",
+      "type": "code",
+      "title": "Kind/address deployment binding",
+      "path": "apps/worker/src/curie_worker/binding.py",
+      "href": "https://github.com/curie-eng/curie/blob/771c621cab35df4002414711b43ac4648f3b9f2f/apps/worker/src/curie_worker/binding.py"
+    },
+    {
+      "id": "runner-adapter-code",
+      "type": "code",
+      "title": "Claude-shaped ModelSession boundary",
+      "path": "runner/src/curie_runner/adapter.py",
+      "href": "https://github.com/curie-eng/curie/blob/771c621cab35df4002414711b43ac4648f3b9f2f/runner/src/curie_runner/adapter.py"
+    }
+  ],
+  "documentationDrift": [],
+  "zones": [
+    {
+      "id": "surfaces",
+      "label": "External surfaces",
+      "x": 0.01,
+      "y": 0.04,
+      "w": 0.14,
+      "h": 0.91
+    },
+    {
+      "id": "control",
+      "label": "Control & ingress",
+      "x": 0.17,
+      "y": 0.04,
+      "w": 0.22,
+      "h": 0.91
+    },
+    {
+      "id": "core",
+      "label": "Opinionated core",
+      "x": 0.41,
+      "y": 0.04,
+      "w": 0.21,
+      "h": 0.91
+    },
+    {
+      "id": "runtime",
+      "label": "Isolated runtime",
+      "x": 0.64,
+      "y": 0.04,
+      "w": 0.35,
+      "h": 0.55
+    },
+    {
+      "id": "foundation",
+      "label": "Data \u00b7 evidence \u00b7 substrate",
+      "x": 0.64,
+      "y": 0.62,
+      "w": 0.35,
+      "h": 0.33
+    }
+  ],
+  "nodes": [
+    {
+      "id": "slack",
+      "label": "Slack",
+      "subtitle": "Surface today",
+      "kind": "surface",
+      "state": "implemented",
+      "zone": "surfaces",
+      "x": 0.075,
+      "y": 0.18,
+      "description": "The only registered production channel kind today. Bolt Socket Mode handles ingress; Slack Web API renders replies and approval cards.",
+      "technology": [
+        "Slack Bolt",
+        "Socket Mode",
+        "Block Kit"
+      ],
+      "evidence": [
+        "architecture",
+        "message-flow"
+      ],
+      "adrIds": [
+        "ADR-0010",
+        "ADR-0020",
+        "ADR-0096"
+      ]
+    },
+    {
+      "id": "email",
+      "label": "Email",
+      "subtitle": "Next surface",
+      "kind": "surface",
+      "state": "planned",
+      "zone": "surfaces",
+      "x": 0.075,
+      "y": 0.34,
+      "description": "Named in the product vision as a next channel. No first-party adapter is shipped on the current release.",
+      "technology": [
+        "Future adapter"
+      ],
+      "evidence": [
+        "vision",
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0020",
+        "ADR-0096"
+      ]
+    },
+    {
+      "id": "teams",
+      "label": "Teams",
+      "subtitle": "Future surface",
+      "kind": "surface",
+      "state": "planned",
+      "zone": "surfaces",
+      "x": 0.075,
+      "y": 0.47,
+      "description": "Named in the vision, but deliberately deferred until a real second channel teaches the adapter interface.",
+      "technology": [
+        "Future adapter"
+      ],
+      "evidence": [
+        "vision",
+        "architecture-vision"
+      ],
+      "adrIds": [
+        "ADR-0016",
+        "ADR-0020"
+      ]
+    },
+    {
+      "id": "cli",
+      "label": "Curie CLI",
+      "subtitle": "Agent-facing control",
+      "kind": "surface",
+      "state": "implemented",
+      "zone": "surfaces",
+      "x": 0.075,
+      "y": 0.61,
+      "description": "Drives skill, local, and cluster loops. The local/cluster message verbs can replace Slack ingress and reply transport without changing the worker path.",
+      "technology": [
+        "Rust",
+        "structured --json"
+      ],
+      "evidence": [
+        "architecture",
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0021",
+        "ADR-0041",
+        "ADR-0074"
+      ]
+    },
+    {
+      "id": "github",
+      "label": "GitHub",
+      "subtitle": "Push / PR trigger",
+      "kind": "surface",
+      "state": "implemented",
+      "zone": "surfaces",
+      "x": 0.075,
+      "y": 0.76,
+      "description": "Webhook and outbound commit polling converge on the API git-flow engine. Dev pushes build and evaluate; production pushes promote.",
+      "technology": [
+        "HMAC webhook",
+        "commit poller",
+        "commit status"
+      ],
+      "evidence": [
+        "architecture"
+      ],
+      "adrIds": [
+        "ADR-0014",
+        "ADR-0091",
+        "ADR-0092"
+      ]
+    },
+    {
+      "id": "external-hook",
+      "label": "External hook",
+      "subtitle": "HMAC-triggered turn",
+      "kind": "surface",
+      "state": "implemented",
+      "zone": "surfaces",
+      "x": 0.075,
+      "y": 0.53,
+      "description": "A named, HMAC-authenticated API hook creates a bounded webhook-sourced turn. Bundle-declared hook lifecycle and schedules remain planned.",
+      "technology": [
+        "HTTP",
+        "HMAC",
+        "typed QueuedTurn"
+      ],
+      "evidence": [
+        "interfaces",
+        "architecture"
+      ],
+      "adrIds": [
+        "ADR-0079"
+      ]
+    },
+    {
+      "id": "console",
+      "label": "Console UI",
+      "subtitle": "Operations surface",
+      "kind": "surface",
+      "state": "implemented",
+      "zone": "surfaces",
+      "x": 0.075,
+      "y": 0.89,
+      "description": "A real API-backed console for fleet, runs, metrics, cost, logs, versions, evals, approvals, and memory. Usage and Settings remain honest stubs.",
+      "technology": [
+        "React",
+        "Vite",
+        "TypeScript"
+      ],
+      "evidence": [
+        "architecture"
+      ],
+      "adrIds": [
+        "ADR-0024",
+        "ADR-0083"
+      ]
+    },
+    {
+      "id": "dispatcher",
+      "label": "Dispatcher",
+      "subtitle": "Ingress \u00b7 dedupe \u00b7 placeholder",
+      "kind": "service",
+      "state": "implemented",
+      "zone": "control",
+      "x": 0.245,
+      "y": 0.2,
+      "description": "Normalizes Slack events into QueuedTurn, claims event ids for deduplication, posts the placeholder, and appends to the run stream.",
+      "technology": [
+        "Python",
+        "Slack Bolt",
+        "Valkey"
+      ],
+      "evidence": [
+        "message-flow",
+        "architecture"
+      ],
+      "adrIds": [
+        "ADR-0012",
+        "ADR-0013"
+      ]
+    },
+    {
+      "id": "port-adapter",
+      "label": "Port adapter service",
+      "subtitle": "Third-party channel edge",
+      "kind": "service",
+      "state": "planned",
+      "zone": "surfaces",
+      "x": 0.105,
+      "y": 0.39,
+      "description": "The accepted placement for a concrete email, Teams, or third-party adapter: a deployed service, not a bundle-loaded plugin. Generic HTTP ingress and egress already ship, but no supported adapter service, install flow, or conformance kit exists.",
+      "technology": [
+        "Deployed service",
+        "future adapter kit"
+      ],
+      "evidence": [
+        "interfaces",
+        "architecture-vision"
+      ],
+      "adrIds": [
+        "ADR-0096"
+      ]
+    },
+    {
+      "id": "channel-api",
+      "label": "Channel HTTP edge",
+      "mapLabel": "Channel edge",
+      "subtitle": "Generic ingress + egress",
+      "kind": "service",
+      "state": "implemented",
+      "zone": "control",
+      "x": 0.285,
+      "y": 0.41,
+      "description": "The API mints row-scoped channel tokens and platform-owned QueuedTurn records; ReplySinkRouter can send neutral reply events through HttpReplyAdapter. This is shipped infrastructure, not a finished email adapter.",
+      "technology": [
+        "POST /channels/turns",
+        "HttpReplyAdapter",
+        "scoped chn token"
+      ],
+      "evidence": [
+        "channel-api-code",
+        "reply-sink-code",
+        "binding-code",
+        "interfaces",
+        "architecture"
+      ],
+      "adrIds": [
+        "ADR-0096"
+      ]
+    },
+    {
+      "id": "api",
+      "label": "API",
+      "subtitle": "Control plane \u00b7 git flow",
+      "kind": "service",
+      "state": "implemented",
+      "zone": "control",
+      "x": 0.275,
+      "y": 0.67,
+      "description": "Owns agents, versions, deployments, channel bindings, approvals, state, connector rendering, bundle validation, git-flow deploys, and read proxies.",
+      "technology": [
+        "FastAPI",
+        "SQLAlchemy",
+        "Alembic"
+      ],
+      "evidence": [
+        "architecture"
+      ],
+      "adrIds": [
+        "ADR-0014",
+        "ADR-0033",
+        "ADR-0046"
+      ]
+    },
+    {
+      "id": "queue",
+      "label": "Valkey streams",
+      "subtitle": "Runs \u00b7 evals \u00b7 delivery",
+      "kind": "broker",
+      "state": "implemented",
+      "zone": "core",
+      "x": 0.455,
+      "y": 0.31,
+      "description": "At-least-once streams carry run and eval jobs. Shared consumer machinery provides bounded delivery and dead-letter handling.",
+      "technology": [
+        "Valkey",
+        "redis-py",
+        "consumer groups"
+      ],
+      "evidence": [
+        "architecture",
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0013",
+        "ADR-0027",
+        "ADR-0039"
+      ]
+    },
+    {
+      "id": "worker",
+      "label": "Worker kernel",
+      "mapLabel": "Worker",
+      "subtitle": "Route \u00b7 claim \u00b7 steer \u00b7 recover",
+      "kind": "service",
+      "state": "implemented",
+      "zone": "core",
+      "x": 0.575,
+      "y": 0.31,
+      "description": "The concurrency hub: resolves the active deployment, enforces one live session per conversation, selects steer versus fresh turn, protects side effects, and reclaims crashed delivery.",
+      "technology": [
+        "Python",
+        "Valkey",
+        "Postgres"
+      ],
+      "evidence": [
+        "architecture",
+        "message-flow"
+      ],
+      "adrIds": [
+        "ADR-0013",
+        "ADR-0039",
+        "ADR-0059"
+      ]
+    },
+    {
+      "id": "approvals",
+      "label": "Approval plane",
+      "subtitle": "Durable human gate",
+      "kind": "capability",
+      "state": "implemented",
+      "zone": "core",
+      "x": 0.485,
+      "y": 0.58,
+      "description": "A gate terminates the turn as AWAITING_APPROVAL, persists a durable record, suspends the sandbox, and later resumes through a new queued resolution turn.",
+      "technology": [
+        "API record",
+        "authorizer sets",
+        "semantic confirm"
+      ],
+      "evidence": [
+        "architecture",
+        "message-flow"
+      ],
+      "adrIds": [
+        "ADR-0010",
+        "ADR-0034",
+        "ADR-0035",
+        "ADR-0046"
+      ]
+    },
+    {
+      "id": "eval-plane",
+      "label": "Eval plane",
+      "subtitle": "Cases \u00b7 graders \u00b7 report",
+      "kind": "capability",
+      "state": "implemented",
+      "zone": "core",
+      "x": 0.57,
+      "y": 0.72,
+      "description": "The same bundle-carried eval suite runs across skill, local, local-release, and cluster. Worker scores and records cases, then reports a rollup to the API.",
+      "technology": [
+        "frozen case schema",
+        "text graders",
+        "trajectory matcher"
+      ],
+      "evidence": [
+        "architecture",
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0019",
+        "ADR-0022",
+        "ADR-0042",
+        "ADR-0055"
+      ]
+    },
+    {
+      "id": "sandbox",
+      "label": "Sandbox",
+      "subtitle": "One isolated session",
+      "kind": "runtime",
+      "state": "implemented",
+      "zone": "runtime",
+      "x": 0.69,
+      "y": 0.2,
+      "description": "An isolated runtime claimed per conversation. Kubernetes Agent Sandbox is production; Docker runs the same image locally.",
+      "technology": [
+        "Agent Sandbox",
+        "Docker",
+        "network policy"
+      ],
+      "evidence": [
+        "architecture",
+        "kubernetes"
+      ],
+      "adrIds": [
+        "ADR-0002",
+        "ADR-0028",
+        "ADR-0054",
+        "ADR-0059"
+      ]
+    },
+    {
+      "id": "runner",
+      "label": "Runner / ACI server",
+      "mapLabel": "Runner",
+      "subtitle": "Multi-turn session loop",
+      "kind": "runtime",
+      "state": "implemented",
+      "zone": "runtime",
+      "x": 0.79,
+      "y": 0.2,
+      "description": "Serves event, steer, interrupt, and reset; translates harness events into the frozen NDJSON union; injects memory and history; emits telemetry.",
+      "technology": [
+        "Python",
+        "FastAPI",
+        "frozen ACI"
+      ],
+      "evidence": [
+        "architecture",
+        "aci-diagram"
+      ],
+      "adrIds": [
+        "ADR-0005",
+        "ADR-0017",
+        "ADR-0036",
+        "ADR-0049"
+      ]
+    },
+    {
+      "id": "harness",
+      "label": "Claude harness",
+      "mapLabel": "Harness",
+      "subtitle": "Declared package today",
+      "kind": "runtime",
+      "state": "implemented",
+      "zone": "runtime",
+      "x": 0.79,
+      "y": 0.4,
+      "description": "The only production harness contribution. ModelSession exists, but raw SDK messages and the Claude Code plugin format still cross the conceptual boundary.",
+      "technology": [
+        "claude-agent-sdk",
+        "Claude Code plugin format"
+      ],
+      "evidence": [
+        "architecture-vision",
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0005",
+        "ADR-0060",
+        "ADR-0061",
+        "ADR-0062"
+      ]
+    },
+    {
+      "id": "model",
+      "label": "Model endpoint",
+      "mapLabel": "Model",
+      "subtitle": "Provider-selected inference",
+      "kind": "external",
+      "state": "implemented",
+      "zone": "runtime",
+      "x": 0.93,
+      "y": 0.4,
+      "description": "Anthropic is the default; OpenRouter, Zhipu, Moonshot, DeepSeek, and opt-in Ollama routes are also built. Native OpenAI wire format remains absent.",
+      "technology": [
+        "Anthropic",
+        "OpenRouter",
+        "provider-native endpoints",
+        "Ollama"
+      ],
+      "evidence": [
+        "architecture",
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0015",
+        "ADR-0032",
+        "ADR-0048"
+      ]
+    },
+    {
+      "id": "connector-host",
+      "label": "MCP connector hosts",
+      "mapLabel": "MCP hosts",
+      "subtitle": "Collapsed MCP implementations",
+      "kind": "runtime",
+      "state": "implemented",
+      "zone": "runtime",
+      "x": 0.69,
+      "y": 0.48,
+      "description": "The stable MCP role in the architecture. Bundle-declared local and remote MCP servers stay collapsed behind this host boundary, so adding another server does not add another architecture box.",
+      "technology": [
+        "Kubernetes",
+        "MCP",
+        "bundle declaration"
+      ],
+      "evidence": [
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0009",
+        "ADR-0086",
+        "ADR-0087",
+        "ADR-0088",
+        "ADR-0090"
+      ]
+    },
+    {
+      "id": "oauth-gateway",
+      "label": "MCP OAuth gateway",
+      "mapLabel": "OAuth gateway",
+      "subtitle": "Per-person delegated access",
+      "kind": "runtime",
+      "state": "planned",
+      "zone": "runtime",
+      "x": 0.87,
+      "y": 0.52,
+      "description": "The accepted vision boundary for delegated MCP authorization. The control plane owns OAuth discovery, PKCE, encrypted tokens, refresh, revocation, and grants; the gateway applies the active run principal's grant without exposing raw OAuth tokens to the runner.",
+      "technology": [
+        "OAuth 2.1",
+        "PKCE",
+        "MCP authorization",
+        "principal-bound grants"
+      ],
+      "evidence": [
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0088",
+        "ADR-0106"
+      ]
+    },
+    {
+      "id": "agent-proxy",
+      "label": "Agent Proxy",
+      "subtitle": "Credentials + egress boundary",
+      "kind": "runtime",
+      "state": "planned",
+      "zone": "runtime",
+      "x": 0.93,
+      "y": 0.2,
+      "description": "Draft architecture moves provider credentials and enforceable egress policy out of the sandbox. It is a decision candidate, not shipped architecture.",
+      "technology": [
+        "Draft proxy boundary"
+      ],
+      "evidence": [
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0075"
+      ]
+    },
+    {
+      "id": "otel",
+      "label": "OTel collector",
+      "subtitle": "Telemetry write port",
+      "kind": "observability",
+      "state": "implemented",
+      "zone": "foundation",
+      "x": 0.735,
+      "y": 0.69,
+      "description": "Receives OTLP from the runner and exports to Langfuse over HTTP. The write boundary is mostly vendor-neutral.",
+      "technology": [
+        "OpenTelemetry",
+        "OTLP HTTP/gRPC"
+      ],
+      "evidence": [
+        "architecture",
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0004",
+        "ADR-0076"
+      ]
+    },
+    {
+      "id": "langfuse",
+      "label": "Langfuse",
+      "subtitle": "Traces \u00b7 metrics \u00b7 eval scores",
+      "kind": "observability",
+      "state": "implemented",
+      "zone": "foundation",
+      "x": 0.865,
+      "y": 0.69,
+      "description": "The current trace and eval store. The API reconstructs trees and metrics through a vendor-specific read adapter; ClickHouse backs the deployment.",
+      "technology": [
+        "Langfuse v3",
+        "ClickHouse"
+      ],
+      "evidence": [
+        "architecture",
+        "architecture-vision"
+      ],
+      "adrIds": [
+        "ADR-0004"
+      ]
+    },
+    {
+      "id": "postgres",
+      "label": "Postgres",
+      "subtitle": "Control-plane state",
+      "kind": "data",
+      "state": "implemented",
+      "zone": "foundation",
+      "x": 0.735,
+      "y": 0.87,
+      "description": "Stores agents, versions, deployments, channel bindings, approvals, memory, history, and other durable control-plane state.",
+      "technology": [
+        "Postgres",
+        "SQLAlchemy",
+        "JSONB"
+      ],
+      "evidence": [
+        "architecture-vision",
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0008",
+        "ADR-0025",
+        "ADR-0029"
+      ]
+    },
+    {
+      "id": "object-store",
+      "label": "RustFS / S3",
+      "subtitle": "Immutable bundles",
+      "kind": "data",
+      "state": "implemented",
+      "zone": "foundation",
+      "x": 0.865,
+      "y": 0.87,
+      "description": "Stores immutable agent bundles and eval inputs behind an S3-compatible protocol and ObjectStore port.",
+      "technology": [
+        "RustFS",
+        "S3 protocol",
+        "boto3"
+      ],
+      "evidence": [
+        "architecture-vision",
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0014",
+        "ADR-0026"
+      ]
+    },
+    {
+      "id": "kubernetes",
+      "label": "Kubernetes",
+      "subtitle": "Production substrate",
+      "kind": "substrate",
+      "state": "implemented",
+      "zone": "foundation",
+      "x": 0.945,
+      "y": 0.72,
+      "description": "Baseline production substrate: platform services, Agent Sandbox CRDs, security rails, connector workloads, and observability dependencies.",
+      "technology": [
+        "Kubernetes",
+        "Helm",
+        "Agent Sandbox"
+      ],
+      "evidence": [
+        "kubernetes",
+        "architecture"
+      ],
+      "adrIds": [
+        "ADR-0002",
+        "ADR-0006",
+        "ADR-0023"
+      ]
+    },
+    {
+      "id": "docker",
+      "label": "Docker",
+      "subtitle": "Local parity substrate",
+      "kind": "substrate",
+      "state": "implemented",
+      "zone": "foundation",
+      "x": 0.945,
+      "y": 0.87,
+      "description": "Runs the same worker and runner image locally behind the same SandboxClient contract.",
+      "technology": [
+        "Docker Compose",
+        "Docker sandbox"
+      ],
+      "evidence": [
+        "architecture",
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0012",
+        "ADR-0028",
+        "ADR-0054"
+      ]
+    }
+  ],
+  "seams": [
+    {
+      "id": "channel-ingress",
+      "label": "Channel ingress + binding",
+      "maturity": "yellow",
+      "catalogKind": "SOFT",
+      "grade": "B-",
+      "implementations": "1 production channel (Slack) + CLI transport stub",
+      "contract": "QueuedTurn + ReplyHandle; neutral {kind, address} deployment binding",
+      "reason": "The core payload, binding, and per-turn endpoint are channel-neutral, but only Slack is registered as a production kind.",
+      "leakage": "TurnSource.SLACK still names the human-authored channel case generically, and one production adapter does not prove two coexisting channel implementations.",
+      "nextStep": "Ship one real second channel through the existing wire before designing a general registry.",
+      "evidence": [
+        "channel-api-code",
+        "binding-code",
+        "interfaces",
+        "architecture"
+      ],
+      "adrIds": [
+        "ADR-0012",
+        "ADR-0020",
+        "ADR-0096"
+      ],
+      "flowIds": [
+        "slack-turn",
+        "approval-loop",
+        "future-email"
+      ]
+    },
+    {
+      "id": "channel-reply",
+      "label": "Reply delivery semantics",
+      "maturity": "yellow",
+      "catalogKind": "SOFT",
+      "grade": "B-",
+      "implementations": "1 production channel plus SlackReplyAdapter and generic HttpReplyAdapter",
+      "contract": "ReplySink.emit over turn.status, reply.update, reply.post, and turn.completed",
+      "reason": "ReplySink, ReplySinkRouter, four versioned events, and generic HTTP egress are shipped, but no second production channel has proven their semantics.",
+      "leakage": "A second channel without edit-in-place must define how streamed updates, platform-owned posts, acknowledgements, and settled approval state map to its surface.",
+      "nextStep": "Implement email (or another real channel) and let its delivery constraints finalize post/update/stream policy.",
+      "evidence": [
+        "reply-sink-code",
+        "channel-api-code",
+        "interfaces",
+        "message-flow"
+      ],
+      "adrIds": [
+        "ADR-0020",
+        "ADR-0063",
+        "ADR-0078",
+        "ADR-0096"
+      ],
+      "flowIds": [
+        "slack-turn",
+        "approval-loop",
+        "future-email"
+      ]
+    },
+    {
+      "id": "channel-interaction",
+      "label": "Semantic channel interaction",
+      "maturity": "green",
+      "catalogKind": "CLEAN",
+      "grade": "\u2014",
+      "implementations": "2 real renderers (Slack Block Kit, terminal selector)",
+      "contract": "Versioned OutboundMessage with text fallback, Choice, Confirm, and semantic action values",
+      "reason": "Two distinct surfaces render the same semantic message without putting their widgets in the contract.",
+      "leakage": "The terminal mirror is handwritten and capabilities are modeled but not dynamically negotiated.",
+      "nextStep": "Generate or drift-gate the Rust mirror; wire capability negotiation when a second production channel needs it.",
+      "evidence": [
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0020"
+      ],
+      "flowIds": [
+        "approval-loop",
+        "future-email"
+      ]
+    },
+    {
+      "id": "queue-stream",
+      "label": "Queue / stream broker",
+      "maturity": "yellow",
+      "catalogKind": "CLEAN",
+      "grade": "\u2014",
+      "implementations": "1 real broker (Valkey) behind producer and consumer ports",
+      "contract": "StreamPublisher + StreamBroker ports, frozen payload field, and shared bounded consumer",
+      "reason": "The port and consumer invariants are explicit, but a second broker has not exercised them.",
+      "leakage": "Some API producers and graveyard readers still bypass the ports; adjacent set verbs and redis-py exception types also leak Valkey semantics.",
+      "nextStep": "No speculative adapter; promote only if a real broker demand appears.",
+      "evidence": [
+        "interfaces",
+        "architecture"
+      ],
+      "adrIds": [
+        "ADR-0013",
+        "ADR-0027",
+        "ADR-0039"
+      ],
+      "flowIds": [
+        "slack-turn",
+        "approval-loop",
+        "git-deploy",
+        "eval-loop",
+        "future-email"
+      ]
+    },
+    {
+      "id": "substrate",
+      "label": "Sandbox substrate",
+      "maturity": "green",
+      "catalogKind": "CLEAN",
+      "grade": "\u2014",
+      "implementations": "2 real implementations (Kubernetes, Docker)",
+      "contract": "Six-method SandboxClient claim lifecycle plus ClaimView and SandboxView outcome types",
+      "reason": "The same kernel and runner operate through two materially different runtime implementations.",
+      "leakage": "SandboxView.port, model-credential forwarding, connector-secret delivery, warm-pool behavior, and production capacity still differ across Kubernetes and Docker.",
+      "nextStep": "Keep parity tests focused on the shared outcomes; do not turn substrate choice into a product axis.",
+      "evidence": [
+        "interfaces",
+        "architecture",
+        "kubernetes"
+      ],
+      "adrIds": [
+        "ADR-0002",
+        "ADR-0028"
+      ],
+      "flowIds": [
+        "slack-turn",
+        "approval-loop",
+        "eval-loop"
+      ]
+    },
+    {
+      "id": "aci",
+      "label": "Frozen ACI protocol",
+      "maturity": "yellow",
+      "catalogKind": "CLEAN, frozen",
+      "grade": "A-",
+      "implementations": "1 production producer + scripted reference/conformance implementation",
+      "contract": "SessionConfig, boot env, HTTP control verbs, and versioned NDJSON events across Python/TS/Rust",
+      "reason": "This is the strongest documented boundary, but only one production harness stack has proven it end to end.",
+      "leakage": "A non-Claude harness must still consume or translate the Claude Code plugin bundle shape.",
+      "nextStep": "Use the conformance guide against a genuinely different production harness.",
+      "evidence": [
+        "aci-diagram",
+        "architecture-vision",
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0005",
+        "ADR-0017",
+        "ADR-0036",
+        "ADR-0062"
+      ],
+      "flowIds": [
+        "slack-turn",
+        "approval-loop",
+        "eval-loop"
+      ]
+    },
+    {
+      "id": "harness-modelsession",
+      "label": "Runner \u2194 harness / ModelSession",
+      "maturity": "red",
+      "catalogKind": "CLEAN",
+      "grade": "A-",
+      "implementations": "1 production SDK + fake",
+      "contract": "In-process ModelSession protocol and declared harness contribution",
+      "reason": "The named protocol is real, but its message union is still SDK-shaped and the bundle distribution format is Claude Code verbatim.",
+      "leakage": "A foreign harness must emit Claude SDK-shaped objects or replace the runner adapter while also interpreting the Claude plugin format.",
+      "nextStep": "Prove the out-of-process ACI boundary with a second harness; keep provider-native checkpointing an optional capability.",
+      "evidence": [
+        "runner-adapter-code",
+        "architecture-vision",
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0005",
+        "ADR-0060",
+        "ADR-0061",
+        "ADR-0105"
+      ],
+      "flowIds": [
+        "slack-turn",
+        "approval-loop",
+        "eval-loop"
+      ]
+    },
+    {
+      "id": "harness-package",
+      "label": "Declared harness package",
+      "maturity": "yellow",
+      "catalogKind": "CLEAN",
+      "grade": "\u2014",
+      "implementations": "1 declared contribution (Claude)",
+      "contract": "HarnessContribution manifest; built-ins resolve directly and third-party contributions use curie.harness entry points",
+      "reason": "Selection and declared assets are clean, but there is no second real package and third-party conformance remains unproven.",
+      "leakage": "The registry currently wraps the same built-in adapter rather than demonstrating substitution.",
+      "nextStep": "Publish and run contribution conformance against a non-built-in package.",
+      "evidence": [
+        "architecture-vision",
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0060",
+        "ADR-0062"
+      ],
+      "flowIds": [
+        "slack-turn",
+        "eval-loop"
+      ]
+    },
+    {
+      "id": "model-provider",
+      "label": "Model provider + credentials",
+      "maturity": "yellow",
+      "catalogKind": "SOFT",
+      "grade": "\u2014",
+      "implementations": "Multiple live endpoints through one Claude-SDK / Anthropic-wire strategy",
+      "contract": "Declared wire protocol, provider endpoint, canonical credential keys, and boot-env forwarding",
+      "reason": "Several endpoints exercise routing and credential resolution, but they do not represent multiple independent provider or harness implementations of the boundary.",
+      "leakage": "Native OpenAI wire format is absent; several providers share compatibility routing rather than independent harness implementations.",
+      "nextStep": "Add native OpenAI wire only when its semantics are tested through the live-provider parity tier.",
+      "evidence": [
+        "architecture",
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0015",
+        "ADR-0032",
+        "ADR-0048",
+        "ADR-0049"
+      ],
+      "flowIds": [
+        "slack-turn",
+        "eval-loop"
+      ]
+    },
+    {
+      "id": "telemetry",
+      "label": "Telemetry / OTLP",
+      "maturity": "yellow",
+      "catalogKind": "SOFT",
+      "grade": "B+",
+      "implementations": "1 trace backend (Langfuse) behind an OTel collector",
+      "contract": "OTLP write path + Curie API DTO read path",
+      "reason": "The write protocol is standard and the UI sees Curie DTOs, but only Langfuse has exercised both sides.",
+      "leakage": "Vendor attributes and /langfuse URL namespaces leak into the otherwise neutral boundary; the read adapter spans multiple modules.",
+      "nextStep": "Map vendor span attributes in the collector and neutralize read-route naming.",
+      "evidence": [
+        "architecture",
+        "architecture-vision",
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0004",
+        "ADR-0076"
+      ],
+      "flowIds": [
+        "observability",
+        "eval-loop"
+      ]
+    },
+    {
+      "id": "eval-scorer",
+      "label": "Eval case + scorer",
+      "maturity": "green",
+      "catalogKind": "SOFT",
+      "grade": "B",
+      "implementations": "Multiple grader kinds plus a trajectory matcher across Python and Rust",
+      "contract": "Frozen eval-case schema + shared trajectory vectors + tri-state outcomes",
+      "reason": "Distinct scoring implementations and two languages exercise the case boundary, with shared fixtures pinning semantics.",
+      "leakage": "Python and Rust still implement graders separately; cluster answer-quality failure is not yet universally fatal.",
+      "nextStep": "Land semantic provenance verification before making cluster answer-quality promotion fatal.",
+      "evidence": [
+        "architecture",
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0019",
+        "ADR-0022",
+        "ADR-0042",
+        "ADR-0053",
+        "ADR-0055"
+      ],
+      "flowIds": [
+        "git-deploy",
+        "eval-loop"
+      ]
+    },
+    {
+      "id": "eval-store",
+      "label": "Eval result store",
+      "maturity": "yellow",
+      "catalogKind": "SOFT",
+      "grade": "B",
+      "implementations": "1 backend (Langfuse traces + scores)",
+      "contract": "Eval recorder write + EvalMatrix read DTO + version:/suite: tag convention",
+      "reason": "The platform owns the result shape, but only one backend and one unfrozen tag convention have exercised it.",
+      "leakage": "The recorder and matrix reader encode Langfuse tags and API behavior directly.",
+      "nextStep": "Record or freeze the tag convention; wait for a real second store before inventing a generic adapter.",
+      "evidence": [
+        "architecture-vision",
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0004",
+        "ADR-0019"
+      ],
+      "flowIds": [
+        "git-deploy",
+        "eval-loop",
+        "observability"
+      ]
+    },
+    {
+      "id": "blob-storage",
+      "label": "Blob storage",
+      "maturity": "yellow",
+      "catalogKind": "CLEAN",
+      "grade": "B+",
+      "implementations": "1 backend (RustFS) over S3-compatible protocol",
+      "contract": "ObjectStore port + shared S3 client + bundle-fetch init path",
+      "reason": "The port is explicit and S3-compatible services are configuration swaps, but no non-S3 implementation has tested the abstraction.",
+      "leakage": "API and worker use separate async/sync adapters, while bucket bootstrap, init containers, migration, and key-free auth retain S3-specific obligations.",
+      "nextStep": "Leave it alone until a real non-S3 demand appears.",
+      "evidence": [
+        "architecture-vision",
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0026"
+      ],
+      "flowIds": [
+        "git-deploy",
+        "eval-loop"
+      ]
+    },
+    {
+      "id": "relational-db",
+      "label": "Relational database",
+      "maturity": "yellow",
+      "catalogKind": "SOFT",
+      "grade": "A-",
+      "implementations": "1 engine family (Postgres; self-hosted or managed)",
+      "contract": "SQLAlchemy models + Alembic migrations + DSN",
+      "reason": "Managed Postgres is a clean operational swap, but another SQL engine has not exercised the model boundary.",
+      "leakage": "Postgres UUID, JSONB, schema qualification, native enums, DISTINCT ON SQL, and asyncpg-specific JSONB decoding remain in application code.",
+      "nextStep": "Keep Postgres opinionated unless a concrete alternate engine demand emerges.",
+      "evidence": [
+        "architecture-vision",
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0008"
+      ],
+      "flowIds": [
+        "slack-turn",
+        "approval-loop",
+        "git-deploy"
+      ]
+    },
+    {
+      "id": "approval-authorizer",
+      "label": "Approval authorizer",
+      "maturity": "green",
+      "catalogKind": "CLEAN",
+      "grade": "\u2014",
+      "implementations": "3 real approver sets (channel, user group, explicit users)",
+      "contract": "ApproverSet / ApprovalCreator + durable semantic approval record",
+      "reason": "Three distinct membership strategies exercise one API-owned authorization interface.",
+      "leakage": "Authenticated principal semantics and the single-operator dead end remain active draft decisions.",
+      "nextStep": "Land structured authenticated principals before extending approval authority to new channels.",
+      "evidence": [
+        "interfaces",
+        "architecture"
+      ],
+      "adrIds": [
+        "ADR-0010",
+        "ADR-0034",
+        "ADR-0046",
+        "ADR-0106"
+      ],
+      "flowIds": [
+        "approval-loop"
+      ]
+    },
+    {
+      "id": "approval-principal",
+      "label": "Approval principal identity",
+      "maturity": "red",
+      "catalogKind": "SOFT",
+      "grade": "\u2014",
+      "implementations": "Caller-asserted operator identity plus channel-specific actor facts",
+      "contract": "No single authenticated principal contract across chat, console, and operator resolution",
+      "reason": "The authorizer resolves membership cleanly, but the identity presented to resolution is not yet one structured, authenticated principal across entry points.",
+      "leakage": "Caller-asserted resolved_by and actor_channel semantics cross API keys, Slack facts, console sessions, and operator commands.",
+      "nextStep": "Land ADR-0106's canonical principals and negative identity proofs before broadening multi-channel approval authority.",
+      "evidence": [
+        "architecture",
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0033",
+        "ADR-0034",
+        "ADR-0106"
+      ],
+      "flowIds": [
+        "approval-loop"
+      ]
+    },
+    {
+      "id": "workflow-state",
+      "label": "Workflow state store",
+      "maturity": "red",
+      "catalogKind": "SOFT",
+      "grade": "\u2014",
+      "implementations": "1 state API router over Postgres JSONB",
+      "contract": "Scoped namespace/key document API with size limits and CAS behavior",
+      "reason": "The HTTP state router is useful, but not every state consumer stays behind it; operator memory and relational paths can bypass the supposed boundary.",
+      "leakage": "A second state backend would not cover direct model/JSONB access, while memory and transcript loaders still depend on the HTTP shape and capacity limits.",
+      "nextStep": "Inventory and close bypasses before extracting another backend; then treat retention, capacity, and back-pressure as one admission policy.",
+      "evidence": [
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0025",
+        "ADR-0029",
+        "ADR-0109"
+      ],
+      "flowIds": [
+        "slack-turn",
+        "approval-loop"
+      ]
+    },
+    {
+      "id": "memory",
+      "label": "Agent memory",
+      "maturity": "yellow",
+      "catalogKind": "CLEAN",
+      "grade": "\u2014",
+      "implementations": "1 real loader (StateApiMemoryStore)",
+      "contract": "MemoryStore load/append, optional replace, and boot-preamble injection over a scoped state token",
+      "reason": "The loader port and null implementation are clean, but no alternate durable memory backend has exercised them.",
+      "leakage": "The operator inspect/seed/edit/delete plane addresses the Postgres WorkflowStateEntry backing directly instead of going through MemoryStore.",
+      "nextStep": "Keep the operator plane and any future loader consistent before adding another backing; automatic learned-record extraction remains future work.",
+      "evidence": [
+        "interfaces",
+        "architecture"
+      ],
+      "adrIds": [
+        "ADR-0025",
+        "ADR-0030",
+        "ADR-0095",
+        "ADR-0111"
+      ],
+      "flowIds": [
+        "slack-turn"
+      ]
+    },
+    {
+      "id": "conversation-history",
+      "label": "Conversation history",
+      "maturity": "yellow",
+      "catalogKind": "CLEAN",
+      "grade": "\u2014",
+      "implementations": "1 real loader (StateApiTranscriptStore)",
+      "contract": "TranscriptStore load/append + deterministic per-agent/thread reference",
+      "reason": "The harness-neutral replay path is explicit, but only one store and prompt-preamble rehydration have proven it.",
+      "leakage": "Stored append logs remain unbounded under state-store caps; replay is semantic, not token-exact or native-session restoration.",
+      "nextStep": "Keep portable replay mandatory; add native checkpoints only as an optional harness capability.",
+      "evidence": [
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0003",
+        "ADR-0029",
+        "ADR-0105"
+      ],
+      "flowIds": [
+        "slack-turn",
+        "approval-loop"
+      ]
+    },
+    {
+      "id": "triggers",
+      "label": "Trigger ingestion",
+      "maturity": "red",
+      "catalogKind": "SOFT",
+      "grade": "\u2014",
+      "implementations": "4 hardcoded trigger paths (Slack, GitHub webhook, commit poller, generic HMAC hook)",
+      "contract": "No unified runtime trigger port; API hooks mint bounded webhook-sourced turns while bundle declarations and schedules remain planned",
+      "reason": "Several triggers exist, but they do not implement one shared trigger interface or one event lifecycle.",
+      "leakage": "Slack enters through dispatcher while GitHub, polling, and generic hooks enter through API-specific handlers; bundle-declared hooks and schedules are not consumed.",
+      "nextStep": "Connect declarations and schedules to the shipped bounded hook lifecycle before expanding trigger types.",
+      "evidence": [
+        "interfaces",
+        "architecture"
+      ],
+      "adrIds": [
+        "ADR-0079",
+        "ADR-0099"
+      ],
+      "flowIds": [
+        "slack-turn",
+        "git-deploy",
+        "webhook-turn",
+        "future-hooks"
+      ]
+    },
+    {
+      "id": "cli-output",
+      "label": "Agent-facing CLI output",
+      "maturity": "green",
+      "catalogKind": "CLEAN",
+      "grade": "\u2014",
+      "implementations": "40 typed outputs behind one trait across many verbs",
+      "contract": "CliOutput + Ui.emit + versioned JSON result schemas",
+      "reason": "Many independent command results exercise the same human/JSON emission boundary.",
+      "leakage": "A tracked set of legacy/operator verbs still has inline or unstructured success output.",
+      "nextStep": "Finish migrating the tracked exceptions without widening the output contract.",
+      "evidence": [
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0021",
+        "ADR-0041",
+        "ADR-0074"
+      ],
+      "flowIds": [
+        "slack-turn",
+        "git-deploy"
+      ]
+    },
+    {
+      "id": "connector-host",
+      "label": "MCP connector host",
+      "maturity": "red",
+      "catalogKind": "CLEAN",
+      "grade": "\u2014",
+      "implementations": "1 real Kubernetes host + in-memory fake",
+      "contract": "Bundle declaration \u2192 rendered connector workload \u2192 MCP reachability",
+      "reason": "The typed client exposes raw Kubernetes JSON, rendering is Kubernetes-specific outside the port, and CLI and reconciler paths do not share identical apply/prune semantics.",
+      "leakage": "Build inputs, pinned images, delegated OAuth, runtime injection, reconciliation, and Kubernetes objects cross control-plane and cluster ownership.",
+      "nextStep": "Close runtime injection and converge CLI/reconciler lifecycle before calling the host portable.",
+      "evidence": [
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0086",
+        "ADR-0087",
+        "ADR-0088",
+        "ADR-0090",
+        "ADR-0113"
+      ],
+      "flowIds": [
+        "slack-turn",
+        "mcp-service-call",
+        "mcp-delegated-oauth"
+      ]
+    },
+    {
+      "id": "mcp-service-auth",
+      "label": "MCP service-key authentication",
+      "maturity": "yellow",
+      "catalogKind": "SOFT",
+      "grade": "\u2014",
+      "implementations": "1 deployment-owned service identity mode",
+      "contract": "Named connector secret \u2192 platform-hosted MCP environment or authorization header",
+      "reason": "Service credentials already cross a named secret boundary and stay owned by the deployment, but no second production identity mode has proved the abstraction.",
+      "leakage": "Secret rendering and delivery still span bundle declaration, API, Kubernetes, and the incomplete sealed-credential consumer path.",
+      "nextStep": "Keep service authentication explicit and fail closed; prove delegated OAuth as a separate identity mode with no fallback between them.",
+      "evidence": [
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0009",
+        "ADR-0086",
+        "ADR-0094"
+      ],
+      "flowIds": [
+        "mcp-service-call"
+      ]
+    },
+    {
+      "id": "mcp-delegated-oauth",
+      "label": "Per-person MCP OAuth",
+      "maturity": "planned",
+      "catalogKind": "NONE",
+      "grade": "\u2014",
+      "implementations": "0; accepted architecture only",
+      "contract": "Canonical run principal \u2192 principal-scoped grant \u2192 control-plane-owned OAuth gateway \u2192 MCP server",
+      "reason": "ADR-0088 defines the ownership and fail-closed behavior, but the gateway, grant lifecycle, connection action, and resume path are not shipped.",
+      "leakage": "Until implemented, MCP calls cannot safely act with each human's authority; the existing deployment service identity is the only current mode.",
+      "nextStep": "Implement discovery, PKCE, encrypted grant storage, refresh and revocation, then prove missing-auth pause and post-callback resume without giving the runner a raw token.",
+      "evidence": [
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0088",
+        "ADR-0106"
+      ],
+      "flowIds": [
+        "mcp-delegated-oauth"
+      ]
+    },
+    {
+      "id": "sealed-credential",
+      "label": "Sealed connector credential",
+      "maturity": "red",
+      "catalogKind": "SOFT",
+      "grade": "\u2014",
+      "implementations": "1 cross-language wire (Rust sealer, Python opener)",
+      "contract": "Frozen sealed-credential envelope with cluster-side opening",
+      "reason": "The Rust sealer and Python opener interoperate, but the product path is disconnected: validation and delivery do not yet form one working production consumer path.",
+      "leakage": "Security depends on exact agreement between CLI, API rendering, cluster delivery, and the currently uncalled opener.",
+      "nextStep": "Connect and prove the complete sealed-secret path before expanding its wire or consumers.",
+      "evidence": [
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0009",
+        "ADR-0094"
+      ],
+      "flowIds": [
+        "git-deploy"
+      ]
+    },
+    {
+      "id": "bundle-format",
+      "label": "Bundle / plugin format",
+      "maturity": "yellow",
+      "catalogKind": "CLEAN, frozen",
+      "grade": "\u2014",
+      "implementations": "1 deliberately adopted format (Claude Code plugin)",
+      "contract": "Frozen Pydantic models + regenerated committed JSON Schema (no generated Rust/TS) + immutable content-addressed bundle",
+      "reason": "The format is strongly enforced but intentionally has one implementation and one ecosystem shape.",
+      "leakage": "This is the main coupling that a non-Claude harness must interpret or translate.",
+      "nextStep": "Do not invent another format; require alternate harnesses to demonstrate a translation strategy.",
+      "evidence": [
+        "architecture-vision",
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0007",
+        "ADR-0014",
+        "ADR-0017"
+      ],
+      "flowIds": [
+        "git-deploy",
+        "eval-loop"
+      ]
+    },
+    {
+      "id": "port-adapter-service",
+      "label": "Third-party port adapter",
+      "maturity": "planned",
+      "catalogKind": "NONE",
+      "grade": "\u2014",
+      "implementations": "0",
+      "contract": "Intended deployed-service placement; no runtime implementation",
+      "reason": "The decision fixes ownership and placement, but there is nothing real to score.",
+      "leakage": "Adapter discovery, routing, credentials, conformance, and lifecycle are still future work.",
+      "nextStep": "Use the first real second channel as the reference adapter and promotion kit.",
+      "evidence": [
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0096"
+      ],
+      "flowIds": [
+        "future-email"
+      ]
+    },
+    {
+      "id": "agent-proxy",
+      "label": "Agent Proxy boundary",
+      "maturity": "planned",
+      "catalogKind": "NONE",
+      "grade": "\u2014",
+      "implementations": "0",
+      "contract": "Draft credential and egress enforcement boundary outside the sandbox",
+      "reason": "The architecture is drafted but intentionally unimplemented.",
+      "leakage": "Provider credentials and web egress still enter the sandbox under current controls.",
+      "nextStep": "Resolve the draft's open enforcement and deployment decisions before implementation.",
+      "evidence": [
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0075"
+      ],
+      "flowIds": [
+        "slack-turn"
+      ]
+    },
+    {
+      "id": "promotion-gate",
+      "label": "Eval result \u2192 promotion authority",
+      "maturity": "planned",
+      "catalogKind": "NONE",
+      "grade": "\u2014",
+      "implementations": "Commit status exists; internal promotion enforcement does not",
+      "contract": "Reserved policy boundary between graded evidence and production deployment",
+      "reason": "The API reports eval state to GitHub, but process_push does not read that result before creating a production deployment.",
+      "leakage": "Safety depends on external branch protection and release policy rather than a product invariant.",
+      "nextStep": "Land semantic provenance first, then bind promotion to an authoritative graded result without rebuilding the artifact.",
+      "evidence": [
+        "architecture"
+      ],
+      "adrIds": [
+        "ADR-0014",
+        "ADR-0022",
+        "ADR-0042"
+      ],
+      "flowIds": [
+        "git-deploy",
+        "eval-loop"
+      ]
+    }
+  ],
+  "routes": [
+    {
+      "id": "slack-dispatcher",
+      "from": "slack",
+      "to": "dispatcher",
+      "label": "mention / DM",
+      "state": "current",
+      "seamId": "channel-ingress",
+      "bend": 0
+    },
+    {
+      "id": "email-adapter",
+      "from": "email",
+      "to": "port-adapter",
+      "label": "normalized event",
+      "state": "planned",
+      "seamId": "port-adapter-service",
+      "bend": 0
+    },
+    {
+      "id": "teams-adapter",
+      "from": "teams",
+      "to": "port-adapter",
+      "label": "normalized event",
+      "state": "planned",
+      "seamId": "port-adapter-service",
+      "bend": 18
+    },
+    {
+      "id": "adapter-channel-api",
+      "from": "port-adapter",
+      "to": "channel-api",
+      "label": "scoped HTTP",
+      "state": "planned",
+      "seamId": "port-adapter-service",
+      "bend": 0
+    },
+    {
+      "id": "channel-api-adapter",
+      "from": "channel-api",
+      "to": "port-adapter",
+      "label": "reply event callback",
+      "state": "planned",
+      "seamId": "port-adapter-service",
+      "bend": 20
+    },
+    {
+      "id": "adapter-email-reply",
+      "from": "port-adapter",
+      "to": "email",
+      "label": "email reply",
+      "state": "planned",
+      "seamId": "channel-reply",
+      "bend": 18
+    },
+    {
+      "id": "channel-api-queue",
+      "from": "channel-api",
+      "to": "queue",
+      "label": "platform-minted QueuedTurn",
+      "state": "current",
+      "seamId": "channel-ingress",
+      "bend": -12
+    },
+    {
+      "id": "cli-queue",
+      "from": "cli",
+      "to": "queue",
+      "label": "same QueuedTurn",
+      "state": "current",
+      "seamId": "channel-ingress",
+      "bend": -26
+    },
+    {
+      "id": "github-api",
+      "from": "github",
+      "to": "api",
+      "label": "push / poll",
+      "state": "current",
+      "seamId": "triggers",
+      "bend": 0
+    },
+    {
+      "id": "external-hook-api",
+      "from": "external-hook",
+      "to": "api",
+      "label": "named HMAC hook",
+      "state": "current",
+      "seamId": "triggers",
+      "bend": 14
+    },
+    {
+      "id": "console-api",
+      "from": "console",
+      "to": "api",
+      "label": "Curie API DTOs",
+      "state": "current",
+      "seamId": "telemetry",
+      "bend": 16
+    },
+    {
+      "id": "dispatcher-queue",
+      "from": "dispatcher",
+      "to": "queue",
+      "label": "XADD curie:runs",
+      "state": "current",
+      "seamId": "queue-stream",
+      "bend": 0
+    },
+    {
+      "id": "api-queue",
+      "from": "api",
+      "to": "queue",
+      "label": "eval / resume turn",
+      "state": "current",
+      "seamId": "queue-stream",
+      "bend": -18
+    },
+    {
+      "id": "queue-worker",
+      "from": "queue",
+      "to": "worker",
+      "label": "XREADGROUP",
+      "state": "current",
+      "seamId": "queue-stream",
+      "bend": 0
+    },
+    {
+      "id": "worker-sandbox",
+      "from": "worker",
+      "to": "sandbox",
+      "label": "claim / resume",
+      "state": "current",
+      "seamId": "substrate",
+      "bend": 0
+    },
+    {
+      "id": "sandbox-runner",
+      "from": "sandbox",
+      "to": "runner",
+      "label": "start ACI server",
+      "state": "current",
+      "seamId": "aci",
+      "bend": 0
+    },
+    {
+      "id": "worker-runner",
+      "from": "worker",
+      "to": "runner",
+      "label": "event / steer / interrupt",
+      "state": "current",
+      "seamId": "aci",
+      "bend": -12
+    },
+    {
+      "id": "runner-worker",
+      "from": "runner",
+      "to": "worker",
+      "label": "NDJSON events",
+      "state": "current",
+      "seamId": "aci",
+      "bend": 24
+    },
+    {
+      "id": "runner-harness",
+      "from": "runner",
+      "to": "harness",
+      "label": "ModelSession",
+      "state": "current",
+      "seamId": "harness-modelsession",
+      "bend": 0
+    },
+    {
+      "id": "harness-model",
+      "from": "harness",
+      "to": "model",
+      "label": "provider call",
+      "state": "current",
+      "seamId": "model-provider",
+      "bend": 0
+    },
+    {
+      "id": "model-harness",
+      "from": "model",
+      "to": "harness",
+      "label": "streamed result",
+      "state": "current",
+      "seamId": "model-provider",
+      "bend": 19
+    },
+    {
+      "id": "worker-slack",
+      "from": "worker",
+      "to": "slack",
+      "label": "status / post / update",
+      "state": "current",
+      "seamId": "channel-reply",
+      "bend": -92
+    },
+    {
+      "id": "worker-channel-api",
+      "from": "worker",
+      "to": "channel-api",
+      "label": "neutral reply events",
+      "state": "current",
+      "seamId": "channel-reply",
+      "bend": 28
+    },
+    {
+      "id": "worker-approvals",
+      "from": "worker",
+      "to": "approvals",
+      "label": "AWAITING_APPROVAL",
+      "state": "current",
+      "seamId": "approval-authorizer",
+      "bend": 0
+    },
+    {
+      "id": "approvals-api",
+      "from": "approvals",
+      "to": "api",
+      "label": "persist / resolve",
+      "state": "current",
+      "seamId": "approval-authorizer",
+      "bend": 0
+    },
+    {
+      "id": "slack-api-approval",
+      "from": "slack",
+      "to": "api",
+      "label": "approve / reject",
+      "state": "current",
+      "seamId": "approval-principal",
+      "bend": 66
+    },
+    {
+      "id": "worker-api-approval",
+      "from": "worker",
+      "to": "api",
+      "label": "approval create",
+      "state": "current",
+      "seamId": "approval-authorizer",
+      "bend": 18
+    },
+    {
+      "id": "worker-api-eval-report",
+      "from": "worker",
+      "to": "api",
+      "label": "eval report",
+      "state": "current",
+      "seamId": "eval-store",
+      "bend": 30
+    },
+    {
+      "id": "runner-api-state",
+      "from": "runner",
+      "to": "api",
+      "label": "state get / put / list / delete / append",
+      "state": "current",
+      "seamId": "workflow-state",
+      "bend": 34
+    },
+    {
+      "id": "runner-api-memory",
+      "from": "runner",
+      "to": "api",
+      "label": "memory load / append / replace",
+      "state": "current",
+      "seamId": "memory",
+      "bend": 46
+    },
+    {
+      "id": "api-postgres",
+      "from": "api",
+      "to": "postgres",
+      "label": "control-plane state",
+      "state": "current",
+      "seamId": "relational-db",
+      "bend": 0
+    },
+    {
+      "id": "worker-postgres",
+      "from": "worker",
+      "to": "postgres",
+      "label": "binding read",
+      "state": "current",
+      "seamId": "relational-db",
+      "bend": 22
+    },
+    {
+      "id": "api-store",
+      "from": "api",
+      "to": "object-store",
+      "label": "store bundle",
+      "state": "current",
+      "seamId": "blob-storage",
+      "bend": -20
+    },
+    {
+      "id": "worker-store",
+      "from": "worker",
+      "to": "object-store",
+      "label": "load eval bundle",
+      "state": "current",
+      "seamId": "blob-storage",
+      "bend": 18
+    },
+    {
+      "id": "sandbox-store",
+      "from": "object-store",
+      "to": "sandbox",
+      "label": "bundle-fetch init",
+      "state": "current",
+      "seamId": "blob-storage",
+      "bend": -18
+    },
+    {
+      "id": "runner-otel",
+      "from": "runner",
+      "to": "otel",
+      "label": "OTLP spans",
+      "state": "current",
+      "seamId": "telemetry",
+      "bend": 0
+    },
+    {
+      "id": "otel-langfuse",
+      "from": "otel",
+      "to": "langfuse",
+      "label": "OTLP HTTP",
+      "state": "current",
+      "seamId": "telemetry",
+      "bend": 0
+    },
+    {
+      "id": "eval-langfuse",
+      "from": "eval-plane",
+      "to": "langfuse",
+      "label": "traces + scores",
+      "state": "current",
+      "seamId": "eval-store",
+      "bend": 0
+    },
+    {
+      "id": "api-langfuse",
+      "from": "langfuse",
+      "to": "api",
+      "label": "trace / matrix read",
+      "state": "current",
+      "seamId": "telemetry",
+      "bend": 32
+    },
+    {
+      "id": "api-github-status",
+      "from": "api",
+      "to": "github",
+      "label": "commit status; gate external",
+      "state": "current",
+      "seamId": "promotion-gate",
+      "bend": -34
+    },
+    {
+      "id": "worker-evals",
+      "from": "worker",
+      "to": "eval-plane",
+      "label": "run + grade cases",
+      "state": "current",
+      "seamId": "eval-scorer",
+      "bend": 0
+    },
+    {
+      "id": "sandbox-kubernetes",
+      "from": "kubernetes",
+      "to": "sandbox",
+      "label": "production claim",
+      "state": "current",
+      "seamId": "substrate",
+      "bend": -20
+    },
+    {
+      "id": "sandbox-docker",
+      "from": "docker",
+      "to": "sandbox",
+      "label": "local container",
+      "state": "current",
+      "seamId": "substrate",
+      "bend": 25
+    },
+    {
+      "id": "api-mcp-service",
+      "from": "api",
+      "to": "connector-host",
+      "label": "service-key binding",
+      "state": "current",
+      "seamId": "mcp-service-auth",
+      "bend": -26
+    },
+    {
+      "id": "runner-connectors",
+      "from": "runner",
+      "to": "connector-host",
+      "label": "MCP request / result",
+      "state": "current",
+      "seamId": "mcp-service-auth",
+      "bend": 0,
+      "bidirectional": true
+    },
+    {
+      "id": "worker-kubernetes-connectors",
+      "from": "worker",
+      "to": "kubernetes",
+      "label": "list / apply / delete connector workloads",
+      "state": "current",
+      "seamId": "connector-host",
+      "bend": 42
+    },
+    {
+      "id": "api-oauth-gateway",
+      "from": "api",
+      "to": "oauth-gateway",
+      "label": "principal + OAuth grant",
+      "state": "planned",
+      "seamId": "mcp-delegated-oauth",
+      "bend": 34
+    },
+    {
+      "id": "runner-oauth-gateway",
+      "from": "runner",
+      "to": "oauth-gateway",
+      "label": "principal-bound MCP",
+      "state": "planned",
+      "seamId": "mcp-delegated-oauth",
+      "bend": -12,
+      "bidirectional": true
+    },
+    {
+      "id": "oauth-gateway-host",
+      "from": "oauth-gateway",
+      "to": "connector-host",
+      "label": "OAuth-applied MCP",
+      "state": "planned",
+      "seamId": "mcp-delegated-oauth",
+      "bend": 0,
+      "bidirectional": true
+    },
+    {
+      "id": "proxy-model",
+      "from": "harness",
+      "to": "agent-proxy",
+      "label": "credential-free request",
+      "state": "planned",
+      "seamId": "agent-proxy",
+      "bend": 0
+    },
+    {
+      "id": "proxy-provider",
+      "from": "agent-proxy",
+      "to": "model",
+      "label": "authorized egress",
+      "state": "planned",
+      "seamId": "agent-proxy",
+      "bend": -18
+    }
+  ],
+  "flows": [
+    {
+      "id": "whole-system",
+      "label": "Whole system",
+      "state": "current",
+      "summary": "Every currently visible component and route in one architecture map. Choose a specific flow to isolate and walk its path.",
+      "showRouteLabels": false,
+      "steps": []
+    },
+    {
+      "id": "slack-turn",
+      "label": "Slack turn",
+      "state": "current",
+      "summary": "A mention becomes one queued, isolated, multi-turn model session and one edited thread reply.",
+      "steps": [
+        {
+          "routeId": "slack-dispatcher",
+          "title": "Receive and deduplicate",
+          "caption": "Bolt receives the mention; the dispatcher claims the event id and posts the placeholder."
+        },
+        {
+          "routeId": "dispatcher-queue",
+          "title": "Normalize ingress",
+          "caption": "The dispatcher serializes a channel-neutral QueuedTurn onto curie:runs."
+        },
+        {
+          "routeId": "queue-worker",
+          "title": "Claim delivery",
+          "caption": "The worker consumer group claims the event and acquires the conversation lock."
+        },
+        {
+          "routeId": "worker-sandbox",
+          "title": "Resolve and isolate",
+          "caption": "The binding selects agent, version, and bundle; SandboxClient claims or resumes the runtime."
+        },
+        {
+          "routeId": "worker-runner",
+          "title": "Start or steer",
+          "caption": "The worker sends event for a fresh turn or steer for a live one."
+        },
+        {
+          "routeId": "runner-api-memory",
+          "title": "Rehydrate durable memory",
+          "caption": "At boot the runner loads the agent memory log over the scoped state token before composing the effective prompt."
+        },
+        {
+          "routeId": "runner-harness",
+          "title": "Enter the harness",
+          "caption": "The runner translates the ACI request into the active ModelSession."
+        },
+        {
+          "routeId": "harness-model",
+          "title": "Run inference",
+          "caption": "The declared Claude harness calls the selected provider and streams its result."
+        },
+        {
+          "routeId": "runner-worker",
+          "title": "Stream outcomes",
+          "caption": "The runner emits text deltas, tool notes, side-effect markers, and a terminal result as NDJSON."
+        },
+        {
+          "routeId": "worker-slack",
+          "title": "Return to the surface",
+          "caption": "ReplySink updates the original placeholder and the worker acknowledges the stream entry."
+        }
+      ]
+    },
+    {
+      "id": "approval-loop",
+      "label": "Approval + resume",
+      "state": "current",
+      "summary": "A gated tool call ends the turn, persists authority, suspends the sandbox, then resumes through a new queued event.",
+      "steps": [
+        {
+          "routeId": "worker-approvals",
+          "title": "Gate the side effect",
+          "caption": "The runner terminates AWAITING_APPROVAL; the kernel converts it into durable governance work."
+        },
+        {
+          "routeId": "approvals-api",
+          "title": "Persist the decision point",
+          "caption": "The API stores the approval, policy, requester, and allowed approver set."
+        },
+        {
+          "routeId": "worker-slack",
+          "title": "Render a semantic confirm",
+          "caption": "The worker posts a channel-neutral confirm intent; Slack renders the approval card."
+        },
+        {
+          "routeId": "slack-api-approval",
+          "title": "Authorize the human",
+          "caption": "Approve or reject reaches the API, which resolves membership rather than trusting the clicked value."
+        },
+        {
+          "routeId": "api-queue",
+          "title": "Queue a new resolution turn",
+          "caption": "The original event is already acknowledged; resolution enters as its own QueuedTurn."
+        },
+        {
+          "routeId": "queue-worker",
+          "title": "Reclaim the conversation",
+          "caption": "The worker restores the same thread affinity and suspended sandbox."
+        },
+        {
+          "routeId": "worker-runner",
+          "title": "Resume with one-shot allowance",
+          "caption": "The resolution turn tells the runner whether to continue or terminate the rejected action."
+        },
+        {
+          "routeId": "worker-slack",
+          "title": "Settle the surface",
+          "caption": "The card becomes non-interactive and the final reply returns to the same conversation."
+        }
+      ]
+    },
+    {
+      "id": "git-deploy",
+      "label": "PR / git deploy",
+      "state": "current",
+      "summary": "A branch push becomes an immutable bundle, a development deployment, an eval fan-out, and eventually promotion of the same artifact.",
+      "steps": [
+        {
+          "routeId": "github-api",
+          "title": "Ingest a push",
+          "caption": "HMAC webhook or outbound commit poller converges on the same process_push function."
+        },
+        {
+          "routeId": "api-store",
+          "title": "Archive, validate, store",
+          "caption": "The API archives the SHA, validates the frozen plugin shape, and writes an immutable bundle."
+        },
+        {
+          "routeId": "api-postgres",
+          "title": "Create version + deployment",
+          "caption": "Dev branches activate the new version; production branches promote an existing artifact."
+        },
+        {
+          "routeId": "api-queue",
+          "title": "Fan out evals",
+          "caption": "A newly built development bundle appends one deduplicated EvalJob to curie:evals."
+        },
+        {
+          "routeId": "worker-evals",
+          "title": "Grade the exact bundle",
+          "caption": "The eval consumer loads cases from the immutable bundle and drives the runner."
+        },
+        {
+          "routeId": "eval-langfuse",
+          "title": "Record evidence",
+          "caption": "Each case writes a trace and eval score tagged by version and suite."
+        },
+        {
+          "routeId": "worker-api-eval-report",
+          "title": "Report the rollup",
+          "caption": "The worker posts the result to the API."
+        },
+        {
+          "routeId": "api-github-status",
+          "title": "Publish, but do not internally gate",
+          "caption": "GitHub receives a commit status; production promotion still relies on external policy rather than an API invariant."
+        }
+      ]
+    },
+    {
+      "id": "eval-loop",
+      "label": "Eval + parity ladder",
+      "state": "current",
+      "summary": "One bundle and one case file cross skill, local, local-release, and cluster to expose environment drift.",
+      "steps": [
+        {
+          "routeId": "api-store",
+          "title": "Pin the artifact",
+          "caption": "Bundle identity fixes the code, tools, and eval cases under test."
+        },
+        {
+          "routeId": "worker-store",
+          "title": "Load the suite",
+          "caption": "The worker reads evals/cases.json from that exact immutable bundle."
+        },
+        {
+          "routeId": "worker-sandbox",
+          "title": "Choose the required tier",
+          "caption": "Skill, Docker, released Compose, or Kubernetes changes only the substrate rung."
+        },
+        {
+          "routeId": "worker-runner",
+          "title": "Run a fresh case",
+          "caption": "Each case defaults to a fresh conversation and uses the same ACI loop."
+        },
+        {
+          "routeId": "worker-evals",
+          "title": "Score the outcome",
+          "caption": "Text graders and trajectory matching produce pass, fail, or plumbing-only."
+        },
+        {
+          "routeId": "eval-langfuse",
+          "title": "Persist the evidence",
+          "caption": "Traces and scores support the matrix and later diagnosis."
+        }
+      ]
+    },
+    {
+      "id": "observability",
+      "label": "Observability read/write",
+      "state": "current",
+      "summary": "The runner emits standard telemetry downward; the API turns vendor reads back into Curie DTOs for agents and humans.",
+      "steps": [
+        {
+          "routeId": "runner-otel",
+          "title": "Emit the run",
+          "caption": "The runner writes agent, generation, tool, session, and sandbox attributes over OTLP."
+        },
+        {
+          "routeId": "otel-langfuse",
+          "title": "Export once",
+          "caption": "The collector handles Langfuse authentication and HTTP-only OTLP ingest."
+        },
+        {
+          "routeId": "api-langfuse",
+          "title": "Reconstruct the evidence",
+          "caption": "The API reads traces, builds the tool tree, and proxies metrics and cost."
+        },
+        {
+          "routeId": "console-api",
+          "title": "Expose one read surface",
+          "caption": "Console and CLI use Curie API shapes instead of talking to Langfuse directly."
+        }
+      ]
+    },
+    {
+      "id": "mcp-service-call",
+      "label": "MCP with service key",
+      "state": "current",
+      "summary": "Today an MCP connector acts as a deployment-owned bot or service account: the platform binds its named secret and the runner talks through the collapsed MCP host boundary.",
+      "steps": [
+        {
+          "routeId": "worker-kubernetes-connectors",
+          "title": "Reconcile the hosted workload",
+          "caption": "The worker uses ConnectorClient to list, apply, and delete the Kubernetes connector resources derived from the bundle."
+        },
+        {
+          "routeId": "api-mcp-service",
+          "title": "Bind the service identity",
+          "caption": "The bundle names the connector secret; deployment configuration supplies the value and the platform injects it into the hosted MCP connector."
+        },
+        {
+          "routeId": "runner-connectors",
+          "title": "Call the MCP server",
+          "caption": "The runner exchanges MCP requests and results with the hosted connector. Every human currently shares the deployment's service authority."
+        }
+      ]
+    },
+    {
+      "id": "mcp-delegated-oauth",
+      "label": "Future per-person MCP OAuth",
+      "state": "planned",
+      "summary": "The accepted vision binds each run's canonical human principal to that person's OAuth grant. Curie applies the grant at a gateway, and the runner never receives the raw token.",
+      "steps": [
+        {
+          "routeId": "api-oauth-gateway",
+          "title": "Resolve principal and grant",
+          "caption": "The control plane owns OAuth discovery, PKCE, encrypted token storage, refresh, revocation, and the principal-to-grant binding."
+        },
+        {
+          "routeId": "runner-oauth-gateway",
+          "title": "Call as the run principal",
+          "caption": "The runner sends a principal-bound MCP request to the gateway without receiving a provider token."
+        },
+        {
+          "routeId": "oauth-gateway-host",
+          "title": "Apply delegated authority",
+          "caption": "The gateway applies only that principal's active grant and exchanges MCP traffic with the declared server. Missing auth pauses the run for a connection action, then resumes after callback."
+        }
+      ]
+    },
+    {
+      "id": "future-email",
+      "label": "Future email channel",
+      "state": "planned",
+      "summary": "The first real second channel should prove the neutral contracts and reveal which Slack reply assumptions must change.",
+      "steps": [
+        {
+          "routeId": "email-adapter",
+          "title": "Normalize email",
+          "caption": "A deployed adapter owns provider auth, event normalization, identities, and an opaque reply target."
+        },
+        {
+          "routeId": "adapter-channel-api",
+          "title": "Use the shipped HTTP edge",
+          "caption": "The deployed adapter authenticates with a row-scoped token and posts provider-neutral input."
+        },
+        {
+          "routeId": "channel-api-queue",
+          "title": "Enter the same core",
+          "caption": "The API, not the adapter, mints the same QueuedTurn used by Slack and the CLI stub."
+        },
+        {
+          "routeId": "queue-worker",
+          "title": "Reuse the worker invariants",
+          "caption": "Routing, concurrency, sandboxing, approval, and recovery remain unchanged."
+        },
+        {
+          "routeId": "worker-runner",
+          "title": "Reuse the ACI",
+          "caption": "The agent does not learn which channel started the turn."
+        },
+        {
+          "routeId": "worker-channel-api",
+          "title": "Emit neutral reply events",
+          "caption": "ReplySinkRouter sends status, update, post, and completion events through the generic HTTP adapter."
+        },
+        {
+          "routeId": "channel-api-adapter",
+          "title": "Return to the owning adapter",
+          "caption": "The platform calls the adapter endpoint selected from server-controlled binding facts."
+        },
+        {
+          "routeId": "adapter-email-reply",
+          "title": "Teach the real delivery policy",
+          "caption": "Email must decide how streaming, new posts, acknowledgements, and settled approvals map without pretending to be Slack chat.update."
+        }
+      ]
+    },
+    {
+      "id": "webhook-turn",
+      "label": "Generic webhook turn",
+      "state": "current",
+      "summary": "A named HMAC-authenticated hook becomes a bounded webhook-sourced turn on the shared run stream.",
+      "steps": [
+        {
+          "routeId": "external-hook-api",
+          "title": "Authenticate the named hook",
+          "caption": "The API verifies the per-hook HMAC and resolves the target agent."
+        },
+        {
+          "routeId": "api-queue",
+          "title": "Mint the platform turn",
+          "caption": "The API creates the typed webhook-sourced QueuedTurn with bounded delivery metadata."
+        },
+        {
+          "routeId": "queue-worker",
+          "title": "Reuse bounded delivery",
+          "caption": "The shared consumer claims, caps, and dead-letters the hook turn like other run traffic."
+        },
+        {
+          "routeId": "worker-runner",
+          "title": "Run through the same ACI",
+          "caption": "The worker drives the selected bundle without a channel adapter in the path."
+        }
+      ]
+    },
+    {
+      "id": "future-hooks",
+      "label": "Future bundle hooks",
+      "state": "planned",
+      "summary": "Generic webhook consumption ships; bundle-declared hook installation and scheduled turns remain planned.",
+      "steps": [
+        {
+          "routeId": "external-hook-api",
+          "title": "Reuse API-owned ingress",
+          "caption": "A future declaration resolves onto the shipped named-hook endpoint rather than a new dispatcher."
+        },
+        {
+          "routeId": "api-queue",
+          "title": "Create a typed turn",
+          "caption": "A new event kind would carry source, authorization, concurrency, expiry, and delivery policy."
+        },
+        {
+          "routeId": "queue-worker",
+          "title": "Reuse bounded delivery",
+          "caption": "The shared stream consumer must still cap attempts, dead-letter, and expose failure."
+        }
+      ]
+    }
+  ],
+  "adrs": [
+    {
+      "id": "ADR-0002",
+      "number": 2,
+      "title": "Kubernetes Agent Sandbox as the interactive runtime substrate",
+      "status": "accepted",
+      "implementation": "implemented",
+      "summary": "Kubernetes is the production runtime substrate; Docker is the parity implementation behind SandboxClient.",
+      "nodeIds": [
+        "sandbox",
+        "kubernetes",
+        "docker"
+      ],
+      "seamIds": [
+        "substrate"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/771c621cab35df4002414711b43ac4648f3b9f2f/docs/adr/0002-kubernetes-agent-sandbox-as-runtime-substrate.md"
+    },
+    {
+      "id": "ADR-0005",
+      "number": 5,
+      "title": "claude-agent-sdk adapter behind a frozen ACI",
+      "status": "accepted",
+      "implementation": "partial",
+      "summary": "The outer protocol is strong; the in-runner message types and plugin format retain Claude coupling.",
+      "nodeIds": [
+        "runner",
+        "harness"
+      ],
+      "seamIds": [
+        "aci",
+        "harness-modelsession"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/771c621cab35df4002414711b43ac4648f3b9f2f/docs/adr/0005-claude-agent-sdk-adapter-and-frozen-aci.md"
+    },
+    {
+      "id": "ADR-0009",
+      "number": 9,
+      "title": "Per-agent connector auth",
+      "status": "accepted",
+      "implementation": "implemented",
+      "summary": "Connector credentials are named by the bundle and supplied per deployment, giving current MCP servers one service or bot identity rather than a human principal.",
+      "nodeIds": [
+        "api",
+        "connector-host"
+      ],
+      "seamIds": [
+        "mcp-service-auth",
+        "sealed-credential"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/771c621cab35df4002414711b43ac4648f3b9f2f/docs/adr/0009-per-agent-connector-auth.md"
+    },
+    {
+      "id": "ADR-0010",
+      "number": 10,
+      "title": "Approval gates and human-in-the-loop",
+      "status": "accepted",
+      "implementation": "implemented",
+      "summary": "A gated turn persists a durable decision and resumes later through a new event.",
+      "nodeIds": [
+        "approvals",
+        "worker",
+        "slack"
+      ],
+      "seamIds": [
+        "approval-authorizer",
+        "channel-interaction"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/771c621cab35df4002414711b43ac4648f3b9f2f/docs/adr/0010-approval-gates-and-human-in-the-loop.md"
+    },
+    {
+      "id": "ADR-0014",
+      "number": 14,
+      "title": "A git push is the deploy",
+      "status": "accepted",
+      "implementation": "partial",
+      "summary": "Git flow, immutable bundles, and eval fan-out are built; a red eval does not yet universally enforce promotion.",
+      "nodeIds": [
+        "github",
+        "api",
+        "eval-plane",
+        "object-store"
+      ],
+      "seamIds": [
+        "triggers",
+        "bundle-format",
+        "eval-scorer"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/771c621cab35df4002414711b43ac4648f3b9f2f/docs/adr/0014-git-push-is-the-deploy.md"
+    },
+    {
+      "id": "ADR-0016",
+      "number": 16,
+      "title": "Swappable jobs around an opinionated core",
+      "status": "accepted",
+      "implementation": "guiding",
+      "summary": "One curated default per job; a second implementation teaches the interface instead of a speculative registry.",
+      "nodeIds": [
+        "worker",
+        "runner",
+        "api"
+      ],
+      "seamIds": [
+        "aci",
+        "channel-ingress",
+        "telemetry",
+        "blob-storage",
+        "relational-db"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/771c621cab35df4002414711b43ac4648f3b9f2f/docs/adr/0016-swappable-jobs-around-an-opinionated-core.md"
+    },
+    {
+      "id": "ADR-0020",
+      "number": 20,
+      "title": "Rendering-free channel interface",
+      "status": "accepted",
+      "implementation": "partial",
+      "summary": "Semantic Choice and Confirm render in Slack and terminal; capability negotiation and a second production channel remain open.",
+      "nodeIds": [
+        "slack",
+        "cli",
+        "email"
+      ],
+      "seamIds": [
+        "channel-ingress",
+        "channel-reply",
+        "channel-interaction"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/771c621cab35df4002414711b43ac4648f3b9f2f/docs/adr/0020-message-port-rendering-free-channel-interface.md"
+    },
+    {
+      "id": "ADR-0025",
+      "number": 25,
+      "title": "Memory port and first loader",
+      "status": "accepted",
+      "implementation": "implemented",
+      "summary": "Scoped state-backed agent memory reaches the runner as a harness-neutral boot preamble.",
+      "nodeIds": [
+        "runner",
+        "postgres",
+        "api"
+      ],
+      "seamIds": [
+        "memory",
+        "workflow-state"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/771c621cab35df4002414711b43ac4648f3b9f2f/docs/adr/0025-memory-port-and-first-loader.md"
+    },
+    {
+      "id": "ADR-0029",
+      "number": 29,
+      "title": "Conversation-history port and first loader",
+      "status": "accepted",
+      "implementation": "implemented",
+      "summary": "A fresh or restarted sandbox rehydrates the same thread from durable transcript state, without SDK-native resume.",
+      "nodeIds": [
+        "runner",
+        "postgres",
+        "api"
+      ],
+      "seamIds": [
+        "conversation-history",
+        "workflow-state"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/771c621cab35df4002414711b43ac4648f3b9f2f/docs/adr/0029-conversation-history-port-and-first-loader.md"
+    },
+    {
+      "id": "ADR-0030",
+      "number": 30,
+      "title": "Proactive within-episode memory agent",
+      "status": "draft",
+      "implementation": "planned",
+      "summary": "Drafts an injected within-episode memory agent; automatic generation remains absent.",
+      "nodeIds": [
+        "runner"
+      ],
+      "seamIds": [
+        "memory"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/771c621cab35df4002414711b43ac4648f3b9f2f/docs/adr/0030-proactive-within-episode-memory-agent.md"
+    },
+    {
+      "id": "ADR-0042",
+      "number": 42,
+      "title": "LLM-as-a-Verifier grader and progress signal",
+      "status": "accepted",
+      "implementation": "reserved",
+      "summary": "The semantic provenance grader is an accepted slot, but no verifier grader exists in Python or Rust today.",
+      "nodeIds": [
+        "eval-plane"
+      ],
+      "seamIds": [
+        "eval-scorer"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/771c621cab35df4002414711b43ac4648f3b9f2f/docs/adr/0042-llm-as-a-verifier-grader-and-progress-signal.md"
+    },
+    {
+      "id": "ADR-0060",
+      "number": 60,
+      "title": "The harness is a declared package",
+      "status": "accepted",
+      "implementation": "implemented",
+      "summary": "Harness assets and selection are declared; only the built-in Claude contribution exists.",
+      "nodeIds": [
+        "harness",
+        "runner"
+      ],
+      "seamIds": [
+        "harness-package",
+        "harness-modelsession"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/771c621cab35df4002414711b43ac4648f3b9f2f/docs/adr/0060-the-harness-is-a-declared-package.md"
+    },
+    {
+      "id": "ADR-0061",
+      "number": 61,
+      "title": "Out-of-process harness boundary",
+      "status": "draft",
+      "implementation": "planned",
+      "summary": "Would make alternate harness adapters consumable out of process across an Omnigent-compatible wire.",
+      "nodeIds": [
+        "runner",
+        "harness"
+      ],
+      "seamIds": [
+        "aci",
+        "harness-modelsession"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/771c621cab35df4002414711b43ac4648f3b9f2f/docs/adr/0061-out-of-process-harness-boundary.md"
+    },
+    {
+      "id": "ADR-0062",
+      "number": 62,
+      "title": "Harness conformance has teeth",
+      "status": "accepted",
+      "implementation": "partial",
+      "summary": "A reusable conformance suite exists; third-party production contributions have not yet proved it.",
+      "nodeIds": [
+        "runner",
+        "harness"
+      ],
+      "seamIds": [
+        "aci",
+        "harness-package"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/771c621cab35df4002414711b43ac4648f3b9f2f/docs/adr/0062-harness-conformance-has-teeth.md"
+    },
+    {
+      "id": "ADR-0075",
+      "number": 75,
+      "title": "Agent Proxy credential and egress boundary",
+      "status": "draft",
+      "implementation": "planned",
+      "summary": "Moves credentials and enforceable egress outside the sandbox; not current architecture.",
+      "nodeIds": [
+        "agent-proxy",
+        "sandbox",
+        "model"
+      ],
+      "seamIds": [
+        "agent-proxy",
+        "model-provider"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/771c621cab35df4002414711b43ac4648f3b9f2f/docs/adr/0075-the-agent-proxy-credential-and-egress-boundary.md"
+    },
+    {
+      "id": "ADR-0079",
+      "number": 79,
+      "title": "Inbound triggers as a new event kind",
+      "status": "accepted",
+      "implementation": "implemented",
+      "summary": "API-owned, HMAC-authenticated generic hooks mint typed webhook-sourced turns; declaration installation and schedules remain future work.",
+      "nodeIds": [
+        "external-hook",
+        "api",
+        "queue",
+        "worker"
+      ],
+      "seamIds": [
+        "triggers",
+        "queue-stream"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/771c621cab35df4002414711b43ac4648f3b9f2f/docs/adr/0079-inbound-triggers-as-a-new-event-kind.md"
+    },
+    {
+      "id": "ADR-0094",
+      "number": 94,
+      "title": "A bundle carries its own sealed connector keys",
+      "status": "accepted",
+      "implementation": "partial",
+      "summary": "Defines the cross-language sealed-box wire and cluster-owned opening key; end-to-end production delivery is not yet fully connected.",
+      "nodeIds": [
+        "api",
+        "connector-host",
+        "kubernetes"
+      ],
+      "seamIds": [
+        "sealed-credential",
+        "mcp-service-auth"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/771c621cab35df4002414711b43ac4648f3b9f2f/docs/adr/0094-a-bundle-carries-its-own-sealed-connector-keys.md"
+    },
+    {
+      "id": "ADR-0086",
+      "number": 86,
+      "title": "Bundles declare connectors; the platform hosts them",
+      "status": "accepted",
+      "implementation": "partial",
+      "summary": "The bundle declares MCP connectors and Curie derives their hosted runtime, secrets, policy, and MCP configuration; lifecycle portability remains intertwined with Kubernetes.",
+      "nodeIds": [
+        "api",
+        "connector-host"
+      ],
+      "seamIds": [
+        "connector-host",
+        "mcp-service-auth"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/771c621cab35df4002414711b43ac4648f3b9f2f/docs/adr/0086-bundles-declare-connectors-the-platform-hosts-them.md"
+    },
+    {
+      "id": "ADR-0088",
+      "number": 88,
+      "title": "Per-user delegated OAuth for MCP",
+      "status": "accepted",
+      "implementation": "planned",
+      "summary": "Defines principal-scoped OAuth, control-plane-owned grants, a token-hiding MCP gateway, and missing-auth pause and resume semantics. The service-key mode remains separate and cannot silently substitute.",
+      "nodeIds": [
+        "api",
+        "runner",
+        "oauth-gateway",
+        "connector-host",
+        "approvals"
+      ],
+      "seamIds": [
+        "mcp-delegated-oauth",
+        "mcp-service-auth",
+        "approval-authorizer"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/771c621cab35df4002414711b43ac4648f3b9f2f/docs/adr/0088-per-user-delegated-oauth-for-mcp.md"
+    },
+    {
+      "id": "ADR-0095",
+      "number": 95,
+      "title": "Tiered memory lifecycle",
+      "status": "draft",
+      "implementation": "planned",
+      "summary": "Defines agent and channel memory tiers, lifecycle turns, trust, and bootstrap/update obligations.",
+      "nodeIds": [
+        "runner",
+        "api",
+        "postgres"
+      ],
+      "seamIds": [
+        "memory",
+        "workflow-state"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/771c621cab35df4002414711b43ac4648f3b9f2f/docs/adr/0095-tiered-memory-lifecycle.md"
+    },
+    {
+      "id": "ADR-0096",
+      "number": 96,
+      "title": "Port adapters are deployed services",
+      "status": "accepted",
+      "implementation": "reserved",
+      "summary": "Fixes placement and ownership for third-party adapters, while the actual adapter service remains unbuilt.",
+      "nodeIds": [
+        "port-adapter",
+        "slack",
+        "email"
+      ],
+      "seamIds": [
+        "port-adapter-service",
+        "channel-ingress",
+        "channel-reply"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/771c621cab35df4002414711b43ac4648f3b9f2f/docs/adr/0096-port-adapters-are-deployed-services.md"
+    },
+    {
+      "id": "ADR-0099",
+      "number": 99,
+      "title": "Hooks are bundle-declared turns",
+      "status": "draft",
+      "implementation": "planned",
+      "summary": "Drafts scheduled and webhook turns with authorization, silence, concurrency, and test-fire semantics.",
+      "nodeIds": [
+        "api",
+        "queue",
+        "worker"
+      ],
+      "seamIds": [
+        "triggers"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/771c621cab35df4002414711b43ac4648f3b9f2f/docs/adr/0099-hooks-are-bundle-declared-turns-the-system-starts.md"
+    },
+    {
+      "id": "ADR-0100",
+      "number": 100,
+      "title": "Agents search their own surface through the channel port",
+      "status": "draft",
+      "implementation": "planned",
+      "summary": "Proposes a spike before committing channel search verbs; intentionally not current behavior.",
+      "nodeIds": [
+        "slack",
+        "port-adapter"
+      ],
+      "seamIds": [
+        "channel-ingress",
+        "port-adapter-service"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/771c621cab35df4002414711b43ac4648f3b9f2f/docs/adr/0100-agents-search-their-own-surface-through-the-channel-port.md"
+    },
+    {
+      "id": "ADR-0105",
+      "number": 105,
+      "title": "External native session checkpoints",
+      "status": "draft",
+      "implementation": "planned",
+      "summary": "Makes provider-native checkpoints an optional harness capability while retaining portable projection.",
+      "nodeIds": [
+        "harness",
+        "runner",
+        "object-store"
+      ],
+      "seamIds": [
+        "harness-modelsession",
+        "conversation-history"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/771c621cab35df4002414711b43ac4648f3b9f2f/docs/adr/0105-external-native-session-checkpoints.md"
+    },
+    {
+      "id": "ADR-0106",
+      "number": 106,
+      "title": "An approver is an authenticated principal",
+      "status": "draft",
+      "implementation": "planned",
+      "summary": "Replaces caller-asserted approver strings with authenticated principals and makes single-operator dead ends loud.",
+      "nodeIds": [
+        "approvals",
+        "api"
+      ],
+      "seamIds": [
+        "approval-authorizer"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/771c621cab35df4002414711b43ac4648f3b9f2f/docs/adr/0106-an-approver-is-an-authenticated-principal.md"
+    },
+    {
+      "id": "ADR-0107",
+      "number": 107,
+      "title": "An agent reads its own runs",
+      "status": "draft",
+      "implementation": "planned",
+      "summary": "Proposes a first-party scoped runs MCP surface with structured attribution and fail-closed identity.",
+      "nodeIds": [
+        "runner",
+        "api",
+        "langfuse"
+      ],
+      "seamIds": [
+        "telemetry",
+        "connector-host"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/771c621cab35df4002414711b43ac4648f3b9f2f/docs/adr/0107-an-agent-reads-its-own-runs-through-a-first-party-scoped-surface.md"
+    },
+    {
+      "id": "ADR-0108",
+      "number": 108,
+      "title": "Deploy targets carry environment values",
+      "status": "draft",
+      "implementation": "planned",
+      "summary": "Moves environment-specific non-secret values onto deploy targets while preserving connector declaration shape.",
+      "nodeIds": [
+        "api",
+        "github",
+        "connector-host"
+      ],
+      "seamIds": [
+        "bundle-format",
+        "connector-host"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/771c621cab35df4002414711b43ac4648f3b9f2f/docs/adr/0108-a-deploy-target-carries-its-environments-values.md"
+    },
+    {
+      "id": "ADR-0109",
+      "number": 109,
+      "title": "Retention, capacity, and back pressure are one policy",
+      "status": "draft",
+      "implementation": "planned",
+      "summary": "Would admit claims against a coherent capacity policy instead of discovering overload after launch.",
+      "nodeIds": [
+        "worker",
+        "sandbox",
+        "postgres"
+      ],
+      "seamIds": [
+        "substrate",
+        "workflow-state"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/771c621cab35df4002414711b43ac4648f3b9f2f/docs/adr/0109-retention-capacity-and-back-pressure-are-one-policy.md"
+    },
+    {
+      "id": "ADR-0110",
+      "number": 110,
+      "title": "Deterministic security posture classification",
+      "status": "draft",
+      "implementation": "planned",
+      "summary": "Computes posture from shipped layers and operator gates instead of trusting a configured label.",
+      "nodeIds": [
+        "sandbox",
+        "api",
+        "connector-host"
+      ],
+      "seamIds": [
+        "connector-host",
+        "agent-proxy"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/771c621cab35df4002414711b43ac4648f3b9f2f/docs/adr/0110-deterministic-security-posture-classification.md"
+    },
+    {
+      "id": "ADR-0111",
+      "number": 111,
+      "title": "Default memory compaction algorithm",
+      "status": "draft",
+      "implementation": "planned",
+      "summary": "Drafts opt-in, from-source compaction with validation, scope defaults, and an auditable write path.",
+      "nodeIds": [
+        "runner",
+        "api",
+        "postgres"
+      ],
+      "seamIds": [
+        "memory",
+        "conversation-history"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/771c621cab35df4002414711b43ac4648f3b9f2f/docs/adr/0111-the-default-memory-compaction-algorithm.md"
+    }
+  ],
+  "investments": [
+    {
+      "rank": 1,
+      "title": "Prove the channel seam with one real second adapter",
+      "seamIds": [
+        "channel-reply",
+        "channel-ingress",
+        "port-adapter-service",
+        "approval-principal"
+      ],
+      "why": "This is the lowest-graded production job and the only way to turn several good contracts into demonstrated multi-surface architecture.",
+      "unlock": "Email or Teams, true multi-surface binding, per-channel streaming policy, adapter kit and conformance.",
+      "factors": {
+        "flowImpact": 5,
+        "visionUnlock": 5,
+        "couplingRisk": 4,
+        "evidenceGap": 5,
+        "effort": 4
+      }
+    },
+    {
+      "rank": 2,
+      "title": "Run a genuinely different harness through the ACI",
+      "seamIds": [
+        "harness-modelsession",
+        "aci",
+        "harness-package"
+      ],
+      "why": "The outer contract is strong, but the current in-process path and bundle distribution wedge still hide the real replacement cost.",
+      "unlock": "Credible Codex/ADK/Strands support, truthful harness conformance, optional native checkpoints.",
+      "factors": {
+        "flowImpact": 5,
+        "visionUnlock": 5,
+        "couplingRisk": 5,
+        "evidenceGap": 4,
+        "effort": 5
+      }
+    },
+    {
+      "rank": 3,
+      "title": "Close the semantic eval and promotion gap",
+      "seamIds": [
+        "eval-scorer",
+        "eval-store",
+        "promotion-gate"
+      ],
+      "why": "The parity ladder is the product promise, but provenance quality and red-eval promotion still have reserved or validated-only clauses.",
+      "unlock": "Fatal cluster quality gates, meaningful source verification, stronger PR-to-production trust.",
+      "factors": {
+        "flowImpact": 4,
+        "visionUnlock": 5,
+        "couplingRisk": 3,
+        "evidenceGap": 4,
+        "effort": 4
+      }
+    },
+    {
+      "rank": 4,
+      "title": "Unify generic trigger and hook lifecycle",
+      "seamIds": [
+        "triggers",
+        "queue-stream"
+      ],
+      "why": "Three trigger paths exist, but they are hardcoded lanes rather than one typed, bounded event lifecycle.",
+      "unlock": "Bundle-declared schedules/webhooks, explicit delivery destinations, shared concurrency and failure semantics.",
+      "factors": {
+        "flowImpact": 4,
+        "visionUnlock": 4,
+        "couplingRisk": 4,
+        "evidenceGap": 5,
+        "effort": 4
+      }
+    },
+    {
+      "rank": 5,
+      "title": "Move credentials and enforceable egress out of the sandbox",
+      "seamIds": [
+        "agent-proxy",
+        "connector-host",
+        "mcp-service-auth",
+        "mcp-delegated-oauth",
+        "sealed-credential"
+      ],
+      "why": "The current service-key path and accepted delegated-OAuth design expose the same unresolved security boundary: credentials, principal binding, and enforceable egress still span several owners.",
+      "unlock": "Stronger tenant isolation, explicit service versus delegated identity, per-person MCP authority, centralized credential policy, and auditable outbound access.",
+      "factors": {
+        "flowImpact": 4,
+        "visionUnlock": 4,
+        "couplingRisk": 5,
+        "evidenceGap": 5,
+        "effort": 5
+      }
+    },
+    {
+      "rank": 6,
+      "title": "Neutralize the observability read side",
+      "seamIds": [
+        "telemetry",
+        "eval-store"
+      ],
+      "why": "OTLP is already a good write port; vendor attributes, route names, and read modules are the remaining concentrated leakage.",
+      "unlock": "A practical second trace backend without UI or API contract churn.",
+      "factors": {
+        "flowImpact": 3,
+        "visionUnlock": 3,
+        "couplingRisk": 2,
+        "evidenceGap": 3,
+        "effort": 2
+      }
+    }
+  ]
+}

--- a/docs/architecture-atlas/versions.json
+++ b/docs/architecture-atlas/versions.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.0",
-  "defaultVersion": "v0.7.1",
+  "defaultVersion": "v0.7.2",
   "versions": [
     {
       "id": "v0.7.1",
@@ -9,6 +9,14 @@
       "date": "2026-08-22",
       "branch": "main",
       "commit": "1c06d427f253a7204bedeb6aaf61f64f765e91b9"
+    },
+    {
+      "id": "v0.7.2",
+      "label": "v0.7.2",
+      "file": "snapshots/v0.7.2.json",
+      "date": "2026-08-27",
+      "branch": "main",
+      "commit": "771c621cab35df4002414711b43ac4648f3b9f2f"
     }
   ]
 }

--- a/release/atlas.py
+++ b/release/atlas.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Require a tag-pinned architecture-atlas snapshot before release builds start."""
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+class AtlasError(Exception):
+    """The release has no trustworthy architecture-atlas snapshot."""
+
+
+VERSION_ONLY_PATHS = frozenset(
+    {
+        "charts/curie/Chart.yaml",
+        "cli/Cargo.lock",
+        "cli/Cargo.toml",
+        "docs/architecture-atlas/versions.json",
+    }
+)
+
+
+def require_release_snapshot(
+    atlas_dir: Path,
+    version: str,
+    commit: str,
+    *,
+    changed_paths: list[str] | None = None,
+) -> None:
+    """Require `version` to resolve to a snapshot pinned to `commit`."""
+    atlas_dir = atlas_dir.resolve()
+    manifest_path = atlas_dir / "versions.json"
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise AtlasError(f"cannot read architecture atlas manifest {manifest_path}: {exc}") from exc
+
+    matches = [entry for entry in manifest.get("versions", []) if entry.get("id") == version]
+    if len(matches) != 1:
+        raise AtlasError(
+            f"release {version} must have exactly one registered architecture atlas "
+            f"snapshot in {manifest_path}; found {len(matches)}. Generate it from the "
+            "release commit before tagging."
+        )
+
+    entry = matches[0]
+    snapshot_commit = entry.get("commit")
+    if snapshot_commit != commit:
+        if changed_paths is None:
+            raise AtlasError(
+                f"architecture atlas {version} names commit {snapshot_commit!r}, not tag "
+                f"commit {commit}, and no release-delta evidence was supplied"
+            )
+        allowed = VERSION_ONLY_PATHS | {
+            f"docs/architecture-atlas/snapshots/{version}.json"
+        }
+        disallowed = sorted(set(changed_paths) - allowed)
+        if disallowed:
+            raise AtlasError(
+                "architecture changed after the release snapshot pin: "
+                f"{', '.join(disallowed)}. Regenerate {version} from the final "
+                "architecture commit before tagging."
+            )
+
+    relative_snapshot = entry.get("file")
+    if not isinstance(relative_snapshot, str):
+        raise AtlasError(f"architecture atlas {version} has no snapshot file")
+    snapshot_path = (atlas_dir / relative_snapshot).resolve()
+    if atlas_dir not in snapshot_path.parents:
+        raise AtlasError(
+            f"architecture atlas snapshot path escapes its directory: {relative_snapshot}"
+        )
+
+    try:
+        snapshot = json.loads(snapshot_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise AtlasError(f"cannot read architecture atlas snapshot {snapshot_path}: {exc}") from exc
+
+    repository = snapshot.get("repository")
+    if not isinstance(repository, dict):
+        raise AtlasError(f"architecture atlas {version} snapshot has no repository metadata")
+    if repository.get("release") != version:
+        raise AtlasError(
+            f"architecture atlas {version} snapshot repository release is "
+            f"{repository.get('release')!r}"
+        )
+    if repository.get("commit") != snapshot_commit:
+        raise AtlasError(
+            f"architecture atlas {version} snapshot repository commit is "
+            f"{repository.get('commit')!r}, not manifest commit {snapshot_commit}"
+        )
+
+
+def registered_commit(atlas_dir: Path, version: str) -> str:
+    """Return the commit registered for `version`, failing closed on bad input."""
+    manifest_path = atlas_dir.resolve() / "versions.json"
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise AtlasError(f"cannot read architecture atlas manifest {manifest_path}: {exc}") from exc
+    matches = [entry for entry in manifest.get("versions", []) if entry.get("id") == version]
+    if len(matches) != 1 or not isinstance(matches[0].get("commit"), str):
+        raise AtlasError(f"release {version} has no unique registered architecture commit")
+    commit = matches[0]["commit"]
+    assert isinstance(commit, str)
+    return commit
+
+
+def release_delta(repo_root: Path, snapshot_commit: str, tag_commit: str) -> list[str]:
+    """Return the paths after the pin, requiring the pin to be tag ancestry."""
+    ancestor = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", snapshot_commit, tag_commit],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+    if ancestor.returncode != 0:
+        raise AtlasError(
+            f"architecture atlas commit {snapshot_commit} is not an ancestor of tag commit "
+            f"{tag_commit}"
+        )
+    diff = subprocess.run(
+        ["git", "diff", "--name-only", f"{snapshot_commit}..{tag_commit}"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+    if diff.returncode != 0:
+        raise AtlasError(f"cannot inspect release delta: {diff.stderr.strip()}")
+    return [line for line in diff.stdout.splitlines() if line]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--atlas-dir", type=Path, default=Path("docs/architecture-atlas")
+    )
+    parser.add_argument("--version", required=True, help="release tag, including leading v")
+    parser.add_argument("--commit", required=True, help="full commit named by the release tag")
+    args = parser.parse_args(argv)
+
+    try:
+        snapshot_commit = registered_commit(args.atlas_dir, args.version)
+        changed_paths = None
+        if snapshot_commit != args.commit:
+            repo_root = args.atlas_dir.resolve().parents[1]
+            changed_paths = release_delta(repo_root, snapshot_commit, args.commit)
+        require_release_snapshot(
+            args.atlas_dir,
+            args.version,
+            args.commit,
+            changed_paths=changed_paths,
+        )
+    except AtlasError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    print(f"OK: architecture atlas {args.version} is pinned to {args.commit}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/release/tests/test_atlas.py
+++ b/release/tests/test_atlas.py
@@ -1,0 +1,197 @@
+"""Contract tests for the release architecture-atlas gate."""
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "release" / "atlas.py"
+RELEASE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "release.yaml"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("release_atlas", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def write_atlas(tmp_path: Path, *, version: str = "v1.2.3", commit: str = "a" * 40) -> Path:
+    atlas_dir = tmp_path / "docs" / "architecture-atlas"
+    snapshots = atlas_dir / "snapshots"
+    snapshots.mkdir(parents=True)
+    (atlas_dir / "versions.json").write_text(
+        json.dumps(
+            {
+                "schemaVersion": "1.0",
+                "defaultVersion": version,
+                "versions": [
+                    {
+                        "id": version,
+                        "label": version,
+                        "file": f"snapshots/{version}.json",
+                        "date": "2026-08-28",
+                        "branch": "main",
+                        "commit": commit,
+                    }
+                ],
+            }
+        )
+    )
+    (snapshots / f"{version}.json").write_text(
+        json.dumps({"repository": {"release": version, "commit": commit}})
+    )
+    return atlas_dir
+
+
+def test_accepts_a_registered_snapshot_pinned_to_the_release_commit(tmp_path):
+    module = load_module()
+    atlas_dir = write_atlas(tmp_path)
+
+    module.require_release_snapshot(atlas_dir, "v1.2.3", "a" * 40)
+
+
+def test_refuses_a_release_with_no_registered_snapshot(tmp_path):
+    module = load_module()
+    atlas_dir = write_atlas(tmp_path)
+
+    with pytest.raises(module.AtlasError, match="v1.2.4"):
+        module.require_release_snapshot(atlas_dir, "v1.2.4", "a" * 40)
+
+
+def test_accepts_a_snapshot_pinned_before_version_only_release_changes(tmp_path):
+    module = load_module()
+    atlas_dir = write_atlas(tmp_path, commit="b" * 40)
+
+    module.require_release_snapshot(
+        atlas_dir,
+        "v1.2.3",
+        "a" * 40,
+        changed_paths=[
+            "docs/architecture-atlas/versions.json",
+            "docs/architecture-atlas/snapshots/v1.2.3.json",
+            "cli/Cargo.toml",
+        ],
+    )
+
+
+def test_refuses_runtime_changes_after_the_snapshot_pin(tmp_path):
+    module = load_module()
+    atlas_dir = write_atlas(tmp_path, commit="b" * 40)
+
+    with pytest.raises(module.AtlasError, match="apps/api"):
+        module.require_release_snapshot(
+            atlas_dir,
+            "v1.2.3",
+            "a" * 40,
+            changed_paths=["apps/api/src/curie_api/main.py"],
+        )
+
+
+def test_refuses_a_snapshot_whose_metadata_does_not_match_the_manifest(tmp_path):
+    module = load_module()
+    atlas_dir = write_atlas(tmp_path)
+    snapshot = atlas_dir / "snapshots" / "v1.2.3.json"
+    snapshot.write_text(json.dumps({"repository": {"release": "v1.2.3", "commit": "b" * 40}}))
+
+    with pytest.raises(module.AtlasError, match="snapshot repository commit"):
+        module.require_release_snapshot(atlas_dir, "v1.2.3", "a" * 40)
+
+
+def test_refuses_a_snapshot_path_that_escapes_the_atlas(tmp_path):
+    module = load_module()
+    atlas_dir = write_atlas(tmp_path)
+    manifest = json.loads((atlas_dir / "versions.json").read_text())
+    manifest["versions"][0]["file"] = "../../outside.json"
+    (atlas_dir / "versions.json").write_text(json.dumps(manifest))
+
+    with pytest.raises(module.AtlasError, match="escapes"):
+        module.require_release_snapshot(atlas_dir, "v1.2.3", "a" * 40)
+
+
+def test_cli_fails_loud_when_the_release_snapshot_is_missing(tmp_path):
+    atlas_dir = write_atlas(tmp_path)
+
+    done = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--atlas-dir",
+            str(atlas_dir),
+            "--version",
+            "v1.2.4",
+            "--commit",
+            "a" * 40,
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert done.returncode == 1
+    assert "v1.2.4" in done.stderr
+
+
+def run_git(repo: Path, *args: str) -> str:
+    done = subprocess.run(
+        ["git", *args], cwd=repo, capture_output=True, text=True, check=True
+    )
+    return done.stdout.strip()
+
+
+@pytest.mark.parametrize(
+    ("late_path", "expected_code"),
+    [("cli/Cargo.toml", 0), ("apps/api/src/curie_api/main.py", 1)],
+)
+def test_cli_checks_the_real_git_delta_after_the_snapshot_pin(
+    tmp_path, late_path, expected_code
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    run_git(repo, "init", "-q", "-b", "main")
+    run_git(repo, "config", "user.email", "test@example.com")
+    run_git(repo, "config", "user.name", "Test")
+    (repo / "architecture.txt").write_text("final architecture")
+    run_git(repo, "add", "architecture.txt")
+    run_git(repo, "commit", "-qm", "finish architecture")
+    snapshot_commit = run_git(repo, "rev-parse", "HEAD")
+
+    atlas_dir = write_atlas(repo, commit=snapshot_commit)
+    changed = repo / late_path
+    changed.parent.mkdir(parents=True, exist_ok=True)
+    changed.write_text("release change")
+    run_git(repo, "add", ".")
+    run_git(repo, "commit", "-qm", "prepare release")
+    tag_commit = run_git(repo, "rev-parse", "HEAD")
+
+    done = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--atlas-dir",
+            str(atlas_dir),
+            "--version",
+            "v1.2.3",
+            "--commit",
+            tag_commit,
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert done.returncode == expected_code, done.stdout + done.stderr
+    if expected_code == 1:
+        assert late_path in done.stderr
+
+
+def test_authorize_release_runs_the_atlas_gate_before_builds():
+    workflow = yaml.safe_load(RELEASE_WORKFLOW.read_text())
+    steps = workflow["jobs"]["authorize-release"]["steps"]
+    commands = [step.get("run", "") for step in steps]
+
+    assert any("release/atlas.py" in command for command in commands)


### PR DESCRIPTION
## Summary

Backfill an immutable v0.7.2 architecture-atlas snapshot pinned to tag commit `771c621cab35df4002414711b43ac4648f3b9f2f`, including the architecture corrections known by that release, and fail future tag builds before expensive image or binary work when their matching snapshot is absent or stale. The guard supports the non-self-referential release sequence: pin the final architecture commit, then permit only snapshot registration and release-coupled version files before the tag.

## Related issue

No issue; requested directly as a v0.7.2 release follow-up.

## End-to-end verification

This changes release-process behavior, not product runtime behavior on any parity-ladder surface, so the six product E2E tiers are not applicable. The release guard itself is outcome-tested through its real CLI consumer and the checked-in workflow wiring.

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | No plugin packaging, runner loop, ACI event, skill eval, or skill check changes. | n/a | n/a |
| local | n/a | No compose service, API/worker/dispatcher wiring, console, or `curie` output changes. | n/a | n/a |
| local-release | n/a | No released binary, image, chart, compose, install path, or version pin changes; only the tag-publish preflight changes. | n/a | n/a |
| cluster | n/a | No chart template, RBAC, security context, network policy, sandbox, or init-container changes. | n/a | n/a |
| live provider | n/a | No model routing, credentials, provider auth, token, or cost changes. | n/a | n/a |
| external integration | n/a | No third-party API shape or real integration behavior changes; GitHub Actions invokes the repository-local guard. | n/a | n/a |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.
- [x] Or: this change is not behavior-bearing, so no tier applies, and the summary says why.

Release-guard evidence against candidate `200afe26`:

- Positive: `python3 release/atlas.py --version v0.7.2 --commit 771c621cab35df4002414711b43ac4648f3b9f2f` returned `OK: architecture atlas v0.7.2 is pinned to 771c621cab35df4002414711b43ac4648f3b9f2f`.
- Negative: `uv run pytest -q release/tests/test_atlas.py` passed 10 tests, including refusal when `apps/api/src/curie_api/main.py` changes after the snapshot pin and acceptance when only release-coupled files change.
- Independent path: `python3 .claude/skills/update-architecture-atlas/scripts/validate_atlas.py` validated v0.7.2 with 28 nodes, 51 routes, and 11 flows; a served 1440x1000 Chrome preview loaded v0.7.2 as the default and rendered the new external-hook route.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [x] An ADR is added under `docs/adr/` if this is an architectural decision. No new architecture decision is introduced; this enforces the existing versioned-atlas process.
