### PR TITLE
Name every gated write in the permission map, and check that it stays that way

### DIFF
--- a/examples/sre-bot/docs/PERMISSION-MAP.md
+++ b/examples/sre-bot/docs/PERMISSION-MAP.md
@@ -22,7 +22,7 @@ They are not substitutes. A narrow capability surface with no authorization
 decision is an ungated write — that is exactly the incident behind
 `scripts/check-write-path-gated.py`. An authorization decision over a
 capability surface wide enough to do something else is a gate on the wrong
-thing. Both entries below are read on both axes.
+thing. Every entry below is read on both axes.
 
 A connector publishes capabilities against an external system. A skill owns
 deterministic workflow logic and sequencing. Neither may widen the builder's
@@ -88,7 +88,7 @@ Two limits to state rather than imply:
 - Curie's posture today is approval-required plus **allow-by-omission**. A tool
   no gate names is callable. So "which tools are gated" is the whole policy, and
   a forgotten gate is a silent grant rather than a refusal. See the prerequisite
-  in entry 2.
+  in entry 4.
 
 ### Deliberately not granted
 
@@ -98,7 +98,133 @@ Two limits to state rather than imply:
 
 ---
 
-## 2. Upgrading Curie — a workflow, not a tool
+## 2. `scale_deployment` — setting a named Deployment's replica count
+
+| | |
+|---|---|
+| Tool | `mcp__k8s-scale__scale_deployment(namespace, name, replicas)` |
+| Kubernetes verbs | `get`, `patch` on `apps/deployments/scale` |
+| Scoped by | `resourceNames`, one namespace, plus `K8S_SCALE_ALLOWLIST` and `K8S_SCALE_MAX_REPLICAS` |
+| Authorization | `approvalPolicy` gate — a human approves each call |
+| Status | Implemented, ships with its credential absent |
+
+### What that grant actually permits
+
+This is the one entry in this document where **RBAC is the strong constraint and
+the connector is defense in depth**, rather than the other way round. Entry 1
+has to enforce its own narrowness in Python because `patch` on `deployments` is
+the same grant as `set image`, `set env`, and replacing the container command --
+Kubernetes cannot tell those apart. Scaling can be told apart: `scale` is its own
+subresource, so `patch` on `apps/deployments/scale` grants the replica count and
+nothing else. An attempt to change an image with this credential is refused by
+the API server, not by a file in this repository.
+
+What it still permits is `--replicas=0`, which is an outage. The grant does not
+distinguish that from any other number, so the things that do are the connector's
+allowlist, its `K8S_SCALE_MAX_REPLICAS` ceiling, and the gate.
+
+### Capability surface
+
+`replicas` is a caller parameter here, which entry 1 deliberately does not have.
+That is safe for the reason above and only for that reason: the parameter is the
+verb's argument, not a channel into an arbitrary patch body, because the
+subresource cannot carry one.
+
+### Authorization decision
+
+The gate `mcp__k8s-scale__scale_deployment`, on the same route as entry 1.
+
+### Reversible, and it says what to put back
+
+Unlike a restart, a scale can be undone: the replica count in force immediately
+before the patch is enough to restore it. The tool reads that count on the way
+past and returns it, and **refuses to write if it cannot read one** -- an action
+that happened without a recorded prior state leaves the platform holding a record
+it cannot act on (ADR-0117). This is why the reply is JSON rather than prose.
+
+### Deliberately not granted
+
+`patch` on `deployments` itself. Granting it to this identity "for tidiness"
+would throw away the subresource ceiling that is this entry's whole argument.
+
+---
+
+## 3. `upgrade_self` — starting this bot's own version upgrade
+
+| | |
+|---|---|
+| Tool | `mcp__self-upgrade__upgrade_self()` — no arguments |
+| Kubernetes verbs | `get` on `batch/cronjobs`; `create`, `list` on `batch/jobs` |
+| Scoped by | `resourceNames` on the CronJob; **nothing scopes the create** — see below |
+| Authorization | `approvalPolicy` gate — a human approves each call |
+| Status | Implemented, ships with its credential absent. Proven end to end on a live cluster 2026-08-28 |
+
+This upgrades the **bot's own bundle version** -- a new agent version built from
+the repository. It is not entry 4, which upgrades the Curie release underneath
+it. They are different operations with different blast radii, and the shared word
+"upgrade" is the only thing they have in common.
+
+### The grant RBAC cannot narrow
+
+`create` on `jobs` is namespace-wide and cannot be otherwise. `resourceNames`
+matches against the name of an existing object, and a create has no name yet, so
+there is no RBAC expression for "may create only this Job". A credential with
+this Role can in principle create a Job running any image with any command in the
+release's namespace -- the namespace holding the platform's API key.
+
+That is the same shape as entry 1's `patch` on `deployments`, and it gets the
+same answer: the ceiling is enforced in the connector, which exposes one tool
+that **takes no arguments at all** and posts the named CronJob's
+`jobTemplate.spec` verbatim. There is no field a caller can reach, so there is
+nothing to validate and nothing to escape.
+
+Read honestly, what remains is a credential whose blast radius is the release
+namespace if the token escapes the connector pod. It does not leave the pod, for
+the same reason the read connector drops `configuration_view`: the sandbox learns
+a URL and never holds a credential.
+
+### Why this is not the abstraction entry 4 rejects
+
+Entry 4 rejects `upgrade_release(target_version)` -- a connector validating a
+version against a list it holds itself -- because that makes the connector the
+policy holder, in a process the builder cannot edit or inspect per-agent.
+
+This tool holds no policy. It has no version list, no sequencing, and no
+decision: which repository, which branch, which image and which command all come
+from a CronJob an operator wrote and can read. The connector's entire
+contribution is "start that, now, if nothing like it is already running". Move
+any of those choices into the connector and entry 4's objection would apply here
+too.
+
+### Why the bot does not simply do the upgrade
+
+Creating an agent version needs the platform API key, and every `/agents/**`
+route requires it. The sandbox holds a per-turn `state`-scoped token and nothing
+else, deliberately. Handing the sandbox the platform key so that "upgrade
+yourself" could work in one step would trade that property for a convenience, and
+the property is what makes a successful prompt injection unable to walk away with
+a credential. So the key stays in the Job and the bot only presses the button.
+
+### Not reversible, and the reply says so
+
+There is no undo tool. `prior` is null on every path including the successful
+one, so the platform never records a snapshot it cannot act on. Restoring the
+previous version is an operator action with the platform API key, named in the
+reply rather than implied.
+
+Starting the Job is also not finishing it. The reply carries the Job's name and
+says so in as many words, because the agent reports from that text and "started"
+read as "succeeded" is the failure this wording exists to prevent.
+
+### Deliberately not granted
+
+`delete` on `jobs`. Cleaning up finished Jobs is the CronJob's
+`successfulJobsHistoryLimit`, and `delete` would let a prompt-injected agent
+erase the evidence of what it started.
+
+---
+
+## 4. Upgrading Curie's own release — a workflow, not a tool
 
 **PROPOSED. Not implemented.** Superseded as a weekly requirement — issue #1857
 asks for "rollback or recovery behavior", not a named-version upgrade — so this

--- a/examples/tests/test_permission_map_names_every_gate.py
+++ b/examples/tests/test_permission_map_names_every_gate.py
@@ -1,0 +1,90 @@
+"""Every gated write in a bundle has an entry in that bundle's permission map.
+
+The failure this exists to stop has now happened twice, the same way both times.
+
+``examples/sre-bot/docs/PERMISSION-MAP.md`` opens with "Every write this bot can
+perform". `scale_deployment` shipped and the document did not mention it
+(curie#1952). Then `upgrade_self` shipped and the document did not mention that
+either -- and `upgrade_self` is the verb that replaces the bot's own running
+version, carrying the one grant in the bundle that RBAC cannot narrow.
+
+Nothing reported either omission, because nothing could: a gate validates against
+the connector that publishes it, never against prose. The document stays true by
+someone remembering, and the thing being documented is exactly the thing a
+reviewer reads the document instead of deriving. So a permission map that has
+silently stopped being complete is worse than no permission map: it answers
+"which writes can this bot do" with a confident, short, wrong list.
+
+Scoped to CONNECTOR tools (``mcp__*``), which is what this document is about: a
+verb reached through a connector carries a credential and an RBAC surface, and
+those are the two things an entry has to state. A gate on a built-in like
+``Bash`` is a different question with a different answer, and demanding a
+permission-map entry for one would have this check failing on
+``examples/compat-fixture`` -- a test fixture with no write path at all.
+
+The check is deliberately shallow -- the gate's tool name must appear somewhere
+in the document. It cannot tell you the entry is accurate, or current, or honest
+about what the grant permits. It tells you someone was made to write one, which
+is the step that was skipped both times.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+EXAMPLES = REPO / "examples"
+
+
+def _gated_bundles() -> list[tuple[str, str, Path]]:
+    """``(bundle, gate, permission_map)`` for every gate in every bundle.
+
+    A bundle with gates but no permission map is reported by
+    ``test_a_bundle_with_gated_writes_has_a_permission_map`` rather than skipped
+    here, so adding the first gated verb to a bundle cannot pass vacuously.
+    """
+
+    found: list[tuple[str, str, Path]] = []
+    for manifest in sorted(EXAMPLES.glob("*/.claude-plugin/plugin.json")):
+        bundle = manifest.parent.parent.name
+        parsed = json.loads(manifest.read_text(encoding="utf-8"))
+        gates = ((parsed.get("approvalPolicy") or {}).get("gates")) or []
+        doc = manifest.parent.parent / "docs" / "PERMISSION-MAP.md"
+        for gate in gates:
+            name = gate.get("gate") if isinstance(gate, dict) else None
+            # Connector tools only: see the module docstring.
+            if name and str(name).startswith("mcp__"):
+                found.append((bundle, str(name), doc))
+    return found
+
+
+def test_the_bundles_and_their_gates_are_readable() -> None:
+    # A guard that silently finds nothing passes vacuously, which is the failure
+    # mode of every check that reads files by glob.
+    assert _gated_bundles(), "no gated writes found: check the glob"
+
+
+@pytest.mark.parametrize(
+    "bundle,gate,doc",
+    _gated_bundles(),
+    ids=[f"{b}:{g}" for b, g, _ in _gated_bundles()],
+)
+def test_a_gated_write_is_named_in_the_permission_map(
+    bundle: str, gate: str, doc: Path
+) -> None:
+    assert doc.is_file(), (
+        f"{bundle} declares the gated write '{gate}' but has no "
+        f"docs/PERMISSION-MAP.md. A bundle that can write needs the document "
+        f"that says which writes, permitted by whom, bounded by what."
+    )
+    # The tool name, not the gate string, because the document writes the tool
+    # with its signature -- `mcp__k8s-scale__scale_deployment(namespace, name,
+    # replicas)` -- and a substring check on the name matches that.
+    assert gate in doc.read_text(encoding="utf-8"), (
+        f"{bundle}'s permission map does not mention '{gate}'. That document "
+        f"claims to list every write this bot can perform, so an unlisted gated "
+        f"verb makes it confidently wrong rather than merely incomplete. Add an "
+        f"entry saying what the grant actually permits, what scopes it, and what "
+        f"is deliberately not granted -- or drop the gate and its connector."
+    )


### PR DESCRIPTION
`examples/sre-bot/docs/PERMISSION-MAP.md` opens with "Every write this bot can perform". It listed one.

`scale_deployment` shipped and the document did not mention it (#1952). Then `upgrade_self` shipped two days ago and it did not mention that either — the verb that replaces the bot's own running version, carrying the one grant in the bundle RBAC cannot narrow. A reviewer asking "what can this thing write?" got a confident, short, wrong answer, which is worse than no document.

## What changed

Adds entries 2 (`scale_deployment`) and 3 (`upgrade_self`), and renumbers the Helm-upgrade proposal to 4 so the implemented verbs come first.

Two of the new sections are load-bearing rather than descriptive:

- **`scale_deployment`** is the one entry where RBAC is the strong constraint and the connector is defense in depth, because `deployments/scale` is a subresource. Entry 1 has to enforce its narrowness in Python; this one does not, and a reader who does not know that will copy the wrong pattern.
- **`upgrade_self`** has to answer the objection entry 4 raises against `upgrade_release(target_version)` — that a connector validating its own version list makes the connector the policy holder. It does not apply here, and the reason is worth stating: this tool holds no list, no sequencing and no decision, and takes no arguments at all. Move any of those into the connector and the objection lands.

## The guard

This is the part that closes #1952 rather than patching today's instance.

Nothing reported either omission because nothing could: a gate validates against the connector that publishes it, never against prose. So `examples/tests/test_permission_map_names_every_gate.py` asserts every `mcp__*` gate in a bundle's `approvalPolicy` appears somewhere in that bundle's permission map.

Deliberately shallow — it cannot tell you an entry is accurate, current, or honest about what the grant permits. It tells you someone was made to write one, which is the step that was skipped both times.

Scoped to connector tools because that is what the document is about. Its first version failed on `examples/compat-fixture`, a test fixture whose `Bash` gate has no credential and no RBAC surface to describe.

## Verification

- `uv run pytest examples/tests/ -q` → 66 passed
- Falsifiability checked directly: removing `mcp__self-upgrade__upgrade_self` from the document fails the guard naming that exact gate; restoring it passes.

Closes #1952