### PR TITLE
Drain accepted in-flight turns before a chart upgrade rolls them

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -262,6 +262,19 @@ jobs:
           set -euo pipefail
           bash charts/curie/ci/remote-dev-capability-assertions.sh
 
+      # The pre-upgrade drain gate (issue #2010). A routine `helm upgrade` used
+      # to admit a side-effecting turn and then roll the worker and its backing
+      # services out from under it, so the replacement reclaimed the delivery
+      # and escalated accepted work to a human. These assertions prove the gate
+      # is wired to the hook phases that actually run before the roll, that its
+      # clocks are derived from the delivery budget rather than silently left
+      # too short, and that the one self-contradictory value pair is refused at
+      # render time.
+      - name: helm render assertions (upgrade drain gate)
+        run: |
+          set -euo pipefail
+          bash charts/curie/ci/upgrade-drain-assertions.sh
+
       # Prove every container in the untrusted sandbox pod renders the identical
       # Rail 3 hardened securityContext from the shared helper (issue #493), so a
       # helper edit that weakens the lockdown -- or a container that skips it --

--- a/apps/worker/src/curie_worker/config.py
+++ b/apps/worker/src/curie_worker/config.py
@@ -503,6 +503,29 @@ class WorkerConfig(BaseSettings):
             )
         return self
 
+    @model_validator(mode="after")
+    def _quiesce_outlives_the_drain_wait(self) -> WorkerConfig:
+        """Fail at construction if the quiesce flag can lapse mid-drain.
+
+        The gate sets the flag once and then waits up to
+        ``upgrade_drain_timeout_s`` for the in-flight deliveries to settle. A
+        TTL at or below that wait expires the flag while the gate is still
+        waiting, so the replicas resume claiming into an upgrade that is about
+        to roll them -- re-creating the very interruption the gate exists to
+        prevent, and doing it silently (the gate would still report a clean
+        drain). Strictly greater, so there is real headroom.
+        """
+        if self.upgrade_quiesce_ttl_s <= self.upgrade_drain_timeout_s:
+            raise ValueError(
+                "CURIE_UPGRADE_QUIESCE_TTL_S "
+                f"({self.upgrade_quiesce_ttl_s!r}) must be strictly greater than "
+                "CURIE_UPGRADE_DRAIN_TIMEOUT_S "
+                f"({self.upgrade_drain_timeout_s!r}): a flag that lapses mid-drain "
+                "lets the replicas resume claiming into a roll that is about to "
+                "interrupt them"
+            )
+        return self
+
     # Read loop
     read_count: int = 16
     read_block_ms: int = 5000
@@ -611,6 +634,35 @@ class WorkerConfig(BaseSettings):
     delivery_shutdown_reserve_s: float = Field(
         default=60.0, ge=0, validation_alias="CURIE_DELIVERY_SHUTDOWN_RESERVE_S"
     )
+    # ---- Upgrade drain gate (issue #2010) --------------------------------
+    #
+    # ADR-0131 made ONE worker's own shutdown safe: grace covers budget +
+    # reserve, so a SIGTERMed replica can settle the delivery it owns. It says
+    # nothing about the PLATFORM roll around it. A `helm upgrade` rolls the
+    # worker and its backing services together, and an already-accepted
+    # side-effecting turn whose owner dies mid-flight is reclaimed by the
+    # replacement, which correctly refuses to re-run the action and escalates to
+    # a human. Duplicate effects are prevented and the requested task still does
+    # not complete -- the failure #2010 reports.
+    #
+    # These three knobs drive the pre-upgrade gate (``upgrade_drain.py``), which
+    # quiesces new claims and waits for every live-leased delivery to reach its
+    # terminal outcome BEFORE the roll begins, and refuses the upgrade when they
+    # do not.
+    upgrade_drain_timeout_s: float = Field(
+        default=900.0, gt=0, validation_alias="CURIE_UPGRADE_DRAIN_TIMEOUT_S"
+    )
+    upgrade_drain_poll_interval_s: float = Field(
+        default=5.0, gt=0, validation_alias="CURIE_UPGRADE_DRAIN_POLL_INTERVAL_S"
+    )
+    # How long the quiesce flag lives. FINITE on purpose: an upgrade that is
+    # killed between the gate and the post-upgrade release must not leave the
+    # fleet permanently unable to claim, so the flag lapses on its own. It must
+    # also outlast the drain wait, which is what the validator below enforces.
+    upgrade_quiesce_ttl_s: float = Field(
+        default=1200.0, gt=0, validation_alias="CURIE_UPGRADE_QUIESCE_TTL_S"
+    )
+
     # The platform's voluntary termination grace, injected by the chart from
     # the SAME value it renders onto the Pod's ``terminationGracePeriodSeconds``
     # so the app's validator and the platform can never drift apart. ``None``
@@ -961,6 +1013,14 @@ class WorkerConfig(BaseSettings):
         # loop must not scan a production Valkey, and a redelivery-only sweep
         # would never reach a turn whose stream entry was already acked.
         return f"{self.key_prefix}:completions:pending"
+
+    def upgrade_quiesce_key(self) -> str:
+        # The fleet-wide "stop taking new work" flag the pre-upgrade gate sets
+        # (issue #2010). One key for the whole release, not one per replica: the
+        # gate runs as a Job that knows nothing about how many replicas exist,
+        # and every consumer reads the same flag. Always written with a TTL --
+        # see ``upgrade_quiesce_ttl_s`` for why it must never be permanent.
+        return f"{self.key_prefix}:upgrade:quiesce"
 
     def lock_key(self, thread_key: str) -> str:
         return f"{self.key_prefix}:lock:{thread_key}"

--- a/apps/worker/src/curie_worker/consumer.py
+++ b/apps/worker/src/curie_worker/consumer.py
@@ -56,6 +56,7 @@ from .config import WorkerConfig
 from .delivery_lease import DeliveryLeaseStore, LeaseLostError
 from .kernel import Kernel, _thread_key_for
 from .stream_consumer import DeliverySpec, ReadLoopSpec, StreamConsumer
+from .upgrade_drain import UpgradeDrainGate
 
 logger = logging.getLogger(__name__)
 
@@ -119,6 +120,7 @@ class Consumer(StreamConsumer):
         config: WorkerConfig,
         max_concurrency: int = 16,
         leases: DeliveryLeaseStore | None = None,
+        drain: UpgradeDrainGate | None = None,
     ) -> None:
         # The delivery-ownership fence (ADR-0131) lives entirely in the shared
         # base: acquisition, the background heartbeat, release, and the reclaim
@@ -127,7 +129,10 @@ class Consumer(StreamConsumer):
         # implementation by construction. ``leases=None`` keeps every pre-ADR-0131
         # construction (and the tests that use it) behaving exactly as before.
         super().__init__(
-            redis, leases=leases, on_lease_lost=self._interrupt_on_lease_lost
+            redis,
+            leases=leases,
+            on_lease_lost=self._interrupt_on_lease_lost,
+            drain=drain,
         )
         # The base class narrows self._redis to the StreamBroker port (stream
         # verbs only, by design -- a second broker implementation need not
@@ -506,7 +511,17 @@ class Consumer(StreamConsumer):
     async def _maintenance_loop(self) -> None:
         while not self._stop.is_set():
             try:
-                await self._reclaim_once()
+                # A reclaim is a NEW claim: it moves a peer's pending entry into
+                # this consumer and dispatches it. During an upgrade drain
+                # (#2010) that is exactly the theft the gate exists to stop --
+                # a replacement pod coming up mid-roll would otherwise take the
+                # delivery a still-draining replica is settling, see the
+                # side-effect marker, and escalate work that was about to
+                # complete. The rest of the tick is unaffected: reaping orphans
+                # and sweeping owed completions create no claims and stay
+                # useful while a drain is in progress.
+                if not await self._claims_paused():
+                    await self._reclaim_once()
                 await self._kernel.reap_orphans()
                 await self._kernel.sweep_pending_completions()
                 await self._drain_thread_reset_requests()

--- a/apps/worker/src/curie_worker/eval/stream.py
+++ b/apps/worker/src/curie_worker/eval/stream.py
@@ -74,6 +74,7 @@ from ..delivery_lease import DeliveryLeaseStore, LeaseLostError
 from ..sandbox import SandboxSubstrate
 from ..sandbox.types import SandboxError
 from ..stream_consumer import DeliverySpec, ReadLoopSpec, StreamConsumer
+from ..upgrade_drain import UpgradeDrainGate
 from .models import EvalCaseResult, EvalOutcome, EvalRunResult, EvalScorer, EvalSuite
 from .recorder import LangfuseEvalRecorder
 from .run import run_eval_suite, sample_config_from_env
@@ -262,6 +263,7 @@ class EvalStreamConsumer(StreamConsumer):
         recorder: LangfuseEvalRecorder,
         repo_lookup: Any,
         leases: DeliveryLeaseStore | None = None,
+        drain: UpgradeDrainGate | None = None,
     ) -> None:
         # ADR-0131: "runs and evals must share the lease implementation by
         # construction. A fix on only one consumer lane is incomplete." The whole
@@ -272,7 +274,11 @@ class EvalStreamConsumer(StreamConsumer):
         # there is nothing for the callback to stop. Active cancellation on lease
         # loss is the named follow-up (F2), and the residual is documented at
         # ``_report`` below -- not papered over with a second interrupt mechanism.
-        super().__init__(redis, leases=leases)
+        # ``drain`` is the same pre-upgrade quiesce gate the runs lane takes
+        # (#2010), and for the same construction reason ADR-0131 gives above: a
+        # gate wired on only one lane is incomplete. An eval delivery holds a
+        # sandbox and a lease exactly as a turn does.
+        super().__init__(redis, leases=leases, drain=drain)
         self._config = config
         self._bundles = bundle_store
         self._substrate = substrate

--- a/apps/worker/src/curie_worker/run.py
+++ b/apps/worker/src/curie_worker/run.py
@@ -65,6 +65,7 @@ from .sandbox import (
     SuspendedThreadError,
 )
 from .threadlock import ThreadLock
+from .upgrade_drain import UpgradeDrainGate
 from .workspace import (
     SubprocessCommands,
     WorkspaceClaimCoordinator,
@@ -393,11 +394,17 @@ def build(config: WorkerConfig, env: Mapping[str, str]) -> Runtime:
     # server ``TIME``, which the ``StreamBroker`` port deliberately does not
     # carry. Each lane gets its own store bound to its own connection, so the
     # eval lane's blocking read can never stall a runs-lane heartbeat.
+
+    # The pre-upgrade drain gate (#2010). ONE gate object shared by both
+    # delivery lanes: the quiesce flag is release-wide, and two gates reading
+    # the same key would only be two ways to answer the same question.
+    drain_gate = UpgradeDrainGate(async_redis, config)
     consumer = Consumer(
         redis=async_redis,
         kernel=kernel,
         config=config,
         leases=DeliveryLeaseStore(async_redis, config),
+        drain=drain_gate,
     )
 
     # The eval lane (F3): a second consumer group on curie:evals, on its own
@@ -416,6 +423,7 @@ def build(config: WorkerConfig, env: Mapping[str, str]) -> Runtime:
         redis=eval_redis,
         config=config,
         leases=DeliveryLeaseStore(eval_redis, config),
+        drain=drain_gate,
         bundle_store=BundleStore(config),
         substrate=substrate,
         reporter=EvalReporter(

--- a/apps/worker/src/curie_worker/stream_consumer.py
+++ b/apps/worker/src/curie_worker/stream_consumer.py
@@ -40,6 +40,12 @@ from .delivery_lease import (
     LeaseRefused,
     unfenced_lease,
 )
+from .upgrade_drain import UpgradeDrainGate
+
+# How often a paused read loop re-checks the upgrade quiesce flag (#2010). Short
+# relative to any rollout, so a released fleet resumes claiming promptly, and far
+# longer than one EXISTS, so the poll costs nothing measurable while idle.
+_QUIESCE_POLL_S = 1.0
 
 # One stream entry as redis returns it with decode_responses=True.
 StreamEntry = tuple[str, dict[str, str]]
@@ -111,6 +117,7 @@ class StreamConsumer:
         *,
         leases: DeliveryLeaseStore | None = None,
         on_lease_lost: LeaseLostHandler | None = None,
+        drain: UpgradeDrainGate | None = None,
     ) -> None:
         # The stream broker behind the port (#284). ``redis.asyncio.Redis`` is the
         # one backing today and structurally satisfies ``StreamBroker``; a second
@@ -158,6 +165,14 @@ class StreamConsumer:
         # cancels a handler task itself: a bare cancel skips the runner-side
         # stop and leaves a turn producing effects on a sandbox we no longer own.
         self._on_lease_lost: LeaseLostHandler | None = on_lease_lost
+        # The pre-upgrade drain gate (#2010), or None for a consumer that has no
+        # platform to be rolled by (compose, the base-only unit tests). While it
+        # reports a drain in progress this consumer takes NO new work -- neither
+        # a fresh read nor a reclaim -- so the deliveries already accepted can
+        # reach their terminal outcome before the roll interrupts them, and the
+        # replacement pods that come up mid-roll do not reclaim them out from
+        # under a replica that is still draining.
+        self._drain: UpgradeDrainGate | None = drain
 
     @property
     def _spec(self) -> DeliverySpec:
@@ -168,6 +183,31 @@ class StreamConsumer:
 
     def request_stop(self) -> None:
         self._stop.set()
+
+    async def _claims_paused(self) -> bool:
+        """Is the fleet quiesced for an upgrade drain (#2010)?
+
+        Checked before every new claim -- a blocking read and a reclaim alike.
+        Deliveries already in flight are untouched: pausing is about not taking
+        on MORE work, and cutting a live turn short is the failure the drain
+        exists to prevent.
+
+        Fails OPEN. An unreadable flag degrades to the behavior this consumer
+        had before the gate existed, which is a working worker. Failing closed
+        would idle every replica in the release on a transient Valkey blip --
+        turning the one read that is supposed to make upgrades safer into a
+        fleet-wide stall, and doing it at exactly the moment Valkey is least
+        healthy.
+        """
+        if self._drain is None:
+            return False
+        try:
+            return await self._drain.is_quiescing()
+        except Exception:
+            logging.getLogger(__name__).debug(
+                "quiesce flag read failed; claiming normally", exc_info=True
+            )
+            return False
 
     async def _ensure_group(self, stream: str, group: str, *, start_id: str) -> None:
         """Create the consumer group (and the stream) if it does not exist.
@@ -186,6 +226,12 @@ class StreamConsumer:
         """Blocking-read loop: read the group, dispatch each entry to ``handler``,
         and survive transient transport faults until stop is requested."""
         while not self._stop.is_set():
+            if await self._claims_paused():
+                # Take nothing new while an upgrade drains. The in-flight
+                # handlers this consumer already owns keep running under their
+                # own leases and settle normally; only the read is held back.
+                await self._sleep_or_stop(_QUIESCE_POLL_S)
+                continue
             try:
                 resp = await self._redis.xreadgroup(
                     spec.group,

--- a/apps/worker/src/curie_worker/upgrade_drain.py
+++ b/apps/worker/src/curie_worker/upgrade_drain.py
@@ -1,0 +1,314 @@
+"""The pre-upgrade drain gate: finish accepted work, or refuse the roll (#2010).
+
+ADR-0131 made one worker's *own* shutdown safe. Platform grace covers the
+delivery budget plus the shutdown reserve, so a SIGTERMed replica can settle the
+delivery it owns, and the fencing lease stops a replacement stealing a healthy
+long turn. None of that governs the roll happening *around* it. A `helm upgrade`
+applies the worker and its backing services in one pass, and an accepted,
+side-effecting turn whose owner is interrupted mid-flight is reclaimed by the
+replacement, which correctly refuses to re-run the action and escalates to a
+human:
+
+    A prior attempt started an action before the worker restarted; not retrying
+    automatically. Flagging for a human.
+
+That is the *safe* answer to an unsafe situation, and it is the right thing to
+emit once the situation exists. Issue #2010 is that a routine upgrade CREATES
+the situation: no duplicate effect, no silent loss, and the requested task still
+does not complete.
+
+This module closes the gap ahead of the roll rather than behind it, with the two
+outcomes the issue asks for and nothing in between:
+
+1. **Drain.** Set a fleet-wide quiesce flag so no replica takes new work, then
+   wait for every delivery that currently holds a live ownership lease to reach
+   its terminal outcome. When they all do, the upgrade proceeds and each of
+   those turns completed exactly once.
+2. **Refuse.** If unsafe work is still in flight when the wait expires, the gate
+   fails, `helm upgrade` fails with it, and NOTHING is rolled. The turn keeps
+   running on the workers that are already there.
+
+Three properties are load-bearing.
+
+**"Unsafe in flight" is a live LEASE, not a pending entry.** The gate reads each
+lane's pending list and keeps only the entries some owner is currently holding
+(``DeliveryLeaseStore.is_live``). An unleased pending entry is not work in
+progress -- it is work waiting to be reclaimed, and reclaim after the roll is
+exactly what the existing machinery is for. Gating on pending-ness instead would
+block every upgrade behind a dead-lettered backlog nobody is working, which is a
+gate that gets disabled the first week it ships.
+
+**No keyspace scan.** The pending list is bounded (``max_concurrency`` per
+consumer, capped again by ADR-0039's delivery budget) and is paged, and the
+liveness reads for one page go out in a single pipeline. ``markers.py`` states
+the rule this follows: the maintenance path must not ``SCAN`` a production
+Valkey, and this runs against exactly the release an operator is upgrading.
+
+**A refusal must not wedge the fleet.** The quiesce flag is always written with
+a TTL, and :func:`main` clears it explicitly when the drain is refused. A
+postponed upgrade leaves the cluster exactly as it found it -- still serving,
+still claiming -- which is what makes "refuse" an acceptable normal-path answer
+rather than an outage.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import sys
+import time
+from dataclasses import dataclass
+
+from redis.asyncio import Redis
+from redis.exceptions import ResponseError
+
+from .config import WorkerConfig
+
+logger = logging.getLogger(__name__)
+
+# How many pending entries are read per round trip. The whole list is paged, so
+# this bounds one round trip rather than the answer; it is deliberately larger
+# than any single consumer's in-flight cap so the common case is one page.
+_PEL_SCAN_PAGE = 256
+
+# The separator in a delivery's human-readable id. The delivery triple is
+# ``(stream, group, entry_id)`` (ADR-0131) and the gate reports it whole: an
+# operator reading a refusal needs to know WHICH lane is still busy, and a bare
+# entry id is ambiguous across the runs and eval groups.
+_DELIVERY_SEP = "/"
+
+
+@dataclass(frozen=True)
+class DrainOutcome:
+    """What the wait concluded, and the evidence for it.
+
+    ``remaining`` is empty exactly when ``drained`` is true. It is carried on the
+    refusal so the operator is told which deliveries held the upgrade back --
+    "the gate refused" with no names is a message that gets the gate turned off.
+    """
+
+    drained: bool
+    remaining: tuple[str, ...]
+    waited_s: float
+
+
+class UpgradeDrainGate:
+    """Quiesce the fleet and wait for accepted work to settle.
+
+    Takes the concrete ``redis.asyncio.Redis`` for the same reason ``Markers``
+    and ``DeliveryLeaseStore`` do: it needs plain string-key verbs (the quiesce
+    flag) next to the stream verbs, and the ``StreamBroker`` port deliberately
+    carries only the latter.
+    """
+
+    def __init__(self, redis: Redis, config: WorkerConfig) -> None:
+        self._redis = redis
+        self._config = config
+
+    # -- the quiesce flag -----------------------------------------------------
+
+    async def request_quiesce(self, *, ttl_s: float | None = None) -> None:
+        """Ask every replica to stop taking new work.
+
+        ALWAYS with an expiry. A permanent flag turns any upgrade that dies
+        between this call and the post-upgrade release into a fleet that has
+        stopped answering and looks perfectly healthy while doing it.
+        """
+        ttl = self._config.upgrade_quiesce_ttl_s if ttl_s is None else ttl_s
+        await self._redis.set(
+            self._config.upgrade_quiesce_key(), "1", ex=max(1, int(ttl))
+        )
+
+    async def clear_quiesce(self) -> None:
+        """Let the fleet claim again. Idempotent."""
+        await self._redis.delete(self._config.upgrade_quiesce_key())
+
+    async def is_quiescing(self) -> bool:
+        """Is a drain in progress? The read every consumer makes before a claim."""
+        return bool(await self._redis.exists(self._config.upgrade_quiesce_key()))
+
+    # -- what is still in flight ----------------------------------------------
+
+    def _lanes(self) -> tuple[tuple[str, str], ...]:
+        """The (stream, group) pairs whose deliveries a roll would interrupt.
+
+        Both lanes, not just runs: an eval delivery holds a sandbox and a lease
+        exactly as a turn does, and it is settled by the same fenced write. The
+        killswitch consumer is deliberately absent -- it holds no delivery lease
+        and must keep answering while an upgrade drains.
+        """
+        return (
+            (self._config.stream, self._config.consumer_group),
+            (self._config.eval_stream, self._config.eval_consumer_group),
+        )
+
+    async def unsettled_deliveries(self) -> tuple[str, ...]:
+        """Deliveries some owner is actively holding, across every lane.
+
+        A pending entry with no live lease is NOT returned: nobody is working
+        it, so rolling does not interrupt anything, and the reclaim machinery
+        picks it up on the other side. Returned sorted so a refusal message is
+        stable across polls.
+        """
+        found: list[str] = []
+        for stream, group in self._lanes():
+            found.extend(await self._unsettled_in_lane(stream, group))
+        return tuple(sorted(found))
+
+    async def _unsettled_in_lane(self, stream: str, group: str) -> list[str]:
+        cursor = "-"
+        live: list[str] = []
+        while True:
+            try:
+                pending = await self._redis.xpending_range(
+                    stream, group, min=cursor, max="+", count=_PEL_SCAN_PAGE
+                )
+            except ResponseError as exc:
+                # NOGROUP -- a lane that has never been used on this release --
+                # is no work, not unsafe work, and a release whose eval group
+                # does not exist yet must still be upgradable.
+                #
+                # Nothing else is caught. Every other failure means this lane
+                # could not be READ, and a gate that answers "nothing in flight"
+                # about a lane it cannot see is worse than no gate: it clears an
+                # upgrade over deliveries it never looked at. The exception
+                # leaves ``run_gate`` non-zero, so an unreadable lane refuses the
+                # upgrade -- fail closed, like every other authority read in this
+                # subsystem.
+                if "NOGROUP" not in str(exc):
+                    raise
+                logger.debug("lane %s/%s has no consumer group yet", stream, group)
+                return live
+            if not pending:
+                return live
+            entry_ids = [str(row["message_id"]) for row in pending]
+            # One pipeline for the page's liveness reads. Not a transaction:
+            # these are plain EXISTS, and MULTI would only add a blocking window
+            # on the Valkey the fleet is mid-delivery against.
+            async with self._redis.pipeline(transaction=False) as pipe:
+                for entry_id in entry_ids:
+                    pipe.exists(self._config.delivery_lease_key(stream, group, entry_id))
+                flags = await pipe.execute()
+            for entry_id, flag in zip(entry_ids, flags, strict=True):
+                if flag:
+                    live.append(_DELIVERY_SEP.join((stream, group, entry_id)))
+            if len(pending) < _PEL_SCAN_PAGE:
+                return live
+            cursor = f"({entry_ids[-1]}"
+
+    # -- the gate itself ------------------------------------------------------
+
+    async def await_drained(
+        self, *, timeout_s: float | None = None, poll_interval_s: float | None = None
+    ) -> DrainOutcome:
+        """Quiesce, then wait for the in-flight deliveries to settle.
+
+        Sets the flag FIRST and unconditionally: the wait is only meaningful
+        while nothing new is being admitted, and a wait that admitted new work
+        could never terminate under load.
+
+        The flag is deliberately left set on BOTH outcomes. On success it is what
+        keeps the replacement pods from reclaiming while the roll is in progress,
+        and the post-upgrade release clears it; on refusal, clearing it is the
+        caller's decision (see :func:`main`), because a caller that wants to
+        retry the gate immediately should not have to re-quiesce a fleet that
+        just resumed.
+        """
+        timeout = self._config.upgrade_drain_timeout_s if timeout_s is None else timeout_s
+        interval = (
+            self._config.upgrade_drain_poll_interval_s
+            if poll_interval_s is None
+            else poll_interval_s
+        )
+        await self.request_quiesce()
+        started = time.monotonic()
+        deadline = started + timeout
+        while True:
+            remaining = await self.unsettled_deliveries()
+            if not remaining:
+                return DrainOutcome(
+                    drained=True, remaining=(), waited_s=time.monotonic() - started
+                )
+            now = time.monotonic()
+            if now >= deadline:
+                return DrainOutcome(
+                    drained=False, remaining=remaining, waited_s=now - started
+                )
+            logger.info(
+                "upgrade drain waiting on %d in-flight deliver%s: %s",
+                len(remaining),
+                "y" if len(remaining) == 1 else "ies",
+                ", ".join(remaining),
+            )
+            await asyncio.sleep(min(interval, max(0.0, deadline - now)))
+
+
+def _client(config: WorkerConfig) -> Redis:
+    return Redis(
+        host=config.valkey_host,
+        port=config.valkey_port,
+        password=config.valkey_password or None,
+        db=config.valkey_db,
+        decode_responses=True,
+    )
+
+
+async def run_gate(config: WorkerConfig, *, mode: str) -> int:
+    """The chart hook's body, factored out so tests drive it without a process.
+
+    ``drain`` is the pre-upgrade hook: quiesce, wait, and answer with the exit
+    code Helm reads as "proceed" (0) or "do not roll" (1). ``release`` is the
+    post-upgrade hook: clear the flag so the new pods start claiming.
+    """
+    redis = _client(config)
+    try:
+        if mode == "release":
+            await UpgradeDrainGate(redis, config).clear_quiesce()
+            logger.info("upgrade quiesce cleared; the fleet is claiming again")
+            return 0
+        gate = UpgradeDrainGate(redis, config)
+        outcome = await gate.await_drained()
+        if outcome.drained:
+            logger.info(
+                "upgrade drain complete after %.1fs; no delivery is in flight",
+                outcome.waited_s,
+            )
+            return 0
+        # Postpone, and put the cluster back exactly as it was found. Leaving
+        # the flag set here would keep a fleet that is NOT being upgraded from
+        # claiming until the TTL lapsed -- turning a refused upgrade into the
+        # outage the refusal exists to avoid.
+        await gate.clear_quiesce()
+        logger.error(
+            "refusing the upgrade: %d deliver%s still in flight after %.1fs (%s). "
+            "Nothing was rolled and the fleet is claiming again; retry once these "
+            "settle, or raise worker.upgradeDrain.timeoutSeconds.",
+            len(outcome.remaining),
+            "y is" if len(outcome.remaining) == 1 else "ies are",
+            outcome.waited_s,
+            ", ".join(outcome.remaining),
+        )
+        return 1
+    finally:
+        await redis.aclose()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="curie-worker-upgrade-drain",
+        description="Drain accepted in-flight deliveries before a chart upgrade (#2010).",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=("drain", "release"),
+        default="drain",
+        help="drain: pre-upgrade gate. release: post-upgrade quiesce clear.",
+    )
+    args = parser.parse_args(argv)
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    return asyncio.run(run_gate(WorkerConfig(), mode=args.mode))
+
+
+if __name__ == "__main__":  # pragma: no cover - process entry point
+    sys.exit(main())

--- a/apps/worker/tests/binding/test_boot_env_single_declaration.py
+++ b/apps/worker/tests/binding/test_boot_env_single_declaration.py
@@ -283,6 +283,21 @@ _NON_BOOT_ALLOWLIST: frozenset[str] = frozenset(
         # validator and the platform can never drift apart. Read from the
         # WORKER's env by WorkerConfig; the sandbox never sees it.
         "CURIE_TERMINATION_GRACE_PERIOD_S",
+        # The pre-upgrade drain gate (issue #2010), read from the env of the
+        # WORKER IMAGE by WorkerConfig -- both by every worker replica (which
+        # only ever reads the quiesce flag) and by the chart's pre-upgrade and
+        # post-upgrade hook Jobs, which run `python -m curie_worker.upgrade_drain`
+        # out of that same image. Nothing here is injected into a runner claim,
+        # and the gate runs before any sandbox for this release exists.
+        # - CURIE_UPGRADE_DRAIN_TIMEOUT_S: how long the gate waits for accepted
+        #   in-flight deliveries to settle before it refuses the upgrade.
+        # - CURIE_UPGRADE_DRAIN_POLL_INTERVAL_S: how often it re-reads the
+        #   in-flight set while waiting.
+        # - CURIE_UPGRADE_QUIESCE_TTL_S: lifetime of the fleet-wide quiesce
+        #   flag, which must outlast that wait and must never be permanent.
+        "CURIE_UPGRADE_DRAIN_TIMEOUT_S",
+        "CURIE_UPGRADE_DRAIN_POLL_INTERVAL_S",
+        "CURIE_UPGRADE_QUIESCE_TTL_S",
     }
 )
 

--- a/apps/worker/tests/kernel/test_upgrade_drain.py
+++ b/apps/worker/tests/kernel/test_upgrade_drain.py
@@ -1,0 +1,429 @@
+"""A routine chart upgrade must not turn accepted work into an escalation (#2010).
+
+The incident this file is written against, in full:
+
+    11:15:23  the worker claimed a real AgentMail turn
+    11:15:44  `helm upgrade` (atomic) began; the backing services and the worker
+              rolled together
+    11:16:31  the REPLACEMENT worker reclaimed the delivery, saw the durable
+              side-effect marker, and emitted the designed escalation --
+              "A prior attempt started an action before the worker restarted;
+              not retrying automatically. Flagging for a human."
+    11:16:41  that reply was delivered
+
+Nothing was lost and no side effect ran twice. The requested task simply did not
+happen. That escalation is the correct answer to an unsafe situation; the bug is
+that a supported, routine upgrade CREATES the situation.
+
+Two tests carry the property, and they are a matched pair:
+
+- ``test_a_rollout_over_an_accepted_side_effecting_turn_escalates_it`` is the
+  NEGATIVE CONTROL. It reproduces the incident with the gate bypassed. Without
+  it, "the fixed path completed the turn" would be indistinguishable from a
+  harness that cannot produce the failure at all.
+- ``test_the_pre_upgrade_gate_refuses_the_roll_and_the_turn_completes_once`` is
+  the regression. The gate refuses the upgrade while the accepted turn is still
+  in flight, nothing is rolled, and the turn reaches its intended terminal
+  outcome exactly once.
+
+Reverts that turn this red, each named against the property it breaks:
+
+- Return ``()`` unconditionally from ``UpgradeDrainGate.unsettled_deliveries``
+  (or gate on pending-ness rather than lease liveness) -> the gate reports a
+  clean drain over a live delivery and the regression's refusal assertion fails.
+- Drop the ``_claims_paused`` check from ``StreamConsumer._consume`` or from
+  ``Consumer._maintenance_loop``'s reclaim -> the replacement claims during the
+  drain and the suppression test fails.
+- Clear the quiesce flag inside ``await_drained``'s success path -> the
+  replacement pods reclaim mid-roll, which is the incident itself.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import time
+import uuid
+
+from aci_protocol import (
+    Final,
+    QueuedTurn,
+    ReplyHandle,
+    SessionStatus,
+    SideEffectFlag,
+    TextDelta,
+    TurnSource,
+)
+from curie_dispatcher.queue import to_stream_fields
+from curie_worker.consumer import Consumer
+from curie_worker.delivery_lease import DeliveryLeaseStore
+from curie_worker.upgrade_drain import UpgradeDrainGate
+
+DONE = SessionStatus.DONE
+
+# The escalation the incident produced, verbatim from ``Kernel._process_one``.
+# Byte-identical on purpose: these tests assert the FAILURE is reproduced in the
+# control and absent after the fix, and a paraphrase would pass both ways.
+ESCALATION = (
+    "A prior attempt started an action before the worker restarted; "
+    "not retrying automatically. Flagging for a human."
+)
+
+# Compressed lease clocks (the ``test_delivery_lease.py`` shape) so a rollout
+# window is seconds rather than a minute. Every config ratio is preserved:
+# TTL >= 3x heartbeat, reclaim interval < TTL, runner ceiling <= budget, and the
+# quiesce TTL strictly outlasts the drain wait.
+_KNOBS: dict[str, object] = {
+    "delivery_budget_s": 60.0,
+    "delivery_lease_ttl_s": 1.0,
+    "delivery_lease_heartbeat_s": 0.3,
+    "runner_total_timeout_s": 30.0,
+    "reclaim_interval_s": 0.05,
+    "reclaim_min_idle_ms": 50,
+    "upgrade_drain_timeout_s": 0.5,
+    "upgrade_drain_poll_interval_s": 0.05,
+    "upgrade_quiesce_ttl_s": 5.0,
+}
+
+
+def _qevent(text: str, *, thread: str, event_id: str) -> QueuedTurn:
+    return QueuedTurn(
+        event_id=event_id,
+        conversation_id=thread,
+        author="U1",
+        text=text,
+        reply_handle=ReplyHandle(kind="slack", channel="C1", placeholder="p-1"),
+        received_at="2026-08-28T11:15:23+00:00",
+        source=TurnSource.SLACK,
+    )
+
+
+async def _wait_until(predicate, *, timeout: float = 20.0) -> None:  # noqa: ANN001
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        await asyncio.sleep(0.02)
+    raise AssertionError("condition not reached within timeout")
+
+
+async def _stop(task: asyncio.Task[None], consumer: Consumer | None = None) -> None:
+    if consumer is not None:
+        consumer.request_stop()
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError, Exception):
+        await task
+
+
+async def _kill_replica(task: asyncio.Task[None], consumer: Consumer) -> None:
+    """Model the Pod going away mid-turn, which is what a roll does.
+
+    Cancelling only ``run()`` is not that: the per-message handlers are separate
+    tasks and would keep executing (and keep holding the thread lock), so the
+    replacement would block on a replica that in reality no longer exists. The
+    handler tasks go too, exactly as a SIGKILLed process's would.
+    """
+    inflight = list(consumer._inflight)
+    await _stop(task, consumer)
+    for handler in inflight:
+        handler.cancel()
+    for handler in inflight:
+        with contextlib.suppress(asyncio.CancelledError, Exception):
+            await handler
+
+
+def _texts(h) -> list[str]:  # noqa: ANN001
+    """Every reply body the sink saw, whether edited into a placeholder or posted."""
+    return [text for _addr, _ref, text in h.sink.updates] + [
+        text for _addr, _ref, text in h.sink.text_posts
+    ]
+
+
+def _admit_side_effecting_turn(h, consumer: Consumer):  # noqa: ANN001, ANN201
+    """Script the runner so the turn flags a side effect and then hangs.
+
+    This is the incident's "deliberate real AgentMail turn": the durable
+    no-retry marker is written the instant the frame is seen, and the turn is
+    still open. Returns the hold event the test releases.
+    """
+    hold = asyncio.Event()
+    h.runner.hold = hold
+    h.runner.default_script = [
+        SideEffectFlag(tool="agentmail.send", call_id="call-1"),
+        TextDelta(text="sending the mail"),
+    ]
+    h.runner.tail = [Final(text="mail sent", status=DONE)]
+    assert consumer is not None
+    return hold
+
+
+# --- the negative control: the incident, reproduced ---------------------------
+
+
+def test_a_rollout_over_an_accepted_side_effecting_turn_escalates_it(make_harness) -> None:  # noqa: ANN001
+    """Reproduce #2010 with the gate bypassed.
+
+    The old replica accepts the turn and flags a side effect; the roll takes it
+    away mid-flight; the replacement reclaims, refuses to re-run the action, and
+    escalates. Exactly what happened at 11:16:31, and exactly what the gate
+    exists to stop happening on a routine upgrade.
+    """
+    thread = "drain-control-1"
+    event_id = uuid.uuid4().hex
+
+    async def go() -> None:
+        async with make_harness(**_KNOBS) as h:
+            store = DeliveryLeaseStore(h.async_redis, h.config)
+            old_cfg = h.config.model_copy(update={"consumer_name": "worker-old"})
+            new_cfg = h.config.model_copy(update={"consumer_name": "worker-new"})
+            old = Consumer(redis=h.async_redis, kernel=h.kernel, config=old_cfg, leases=store)
+            new = Consumer(redis=h.async_redis, kernel=h.kernel, config=new_cfg, leases=store)
+            _admit_side_effecting_turn(h, old)
+
+            # The group is created at ``$``, so it must exist before the enqueue.
+            await old.ensure_group()
+            old_task = asyncio.create_task(old.run())
+            new_task: asyncio.Task[None] | None = None
+            try:
+                await h.async_redis.xadd(
+                    h.config.stream,
+                    to_stream_fields(_qevent("send the mail", thread=thread, event_id=event_id)),
+                )
+                # Admitted: the turn is open and the durable marker is written.
+                await _wait_until(lambda: h.runner.turn_active)
+                deadline = time.monotonic() + 20.0
+                while time.monotonic() < deadline:
+                    if await h.async_redis.exists(h.config.side_effect_key(event_id)):
+                        break
+                    await asyncio.sleep(0.02)
+                assert await h.async_redis.exists(h.config.side_effect_key(event_id)), (
+                    "the side-effect marker was never written; nothing was admitted"
+                )
+
+                # The roll: the old worker goes away mid-turn, exactly as a Pod
+                # being replaced does. NO gate runs.
+                await _kill_replica(old_task, old)
+
+                new_task = asyncio.create_task(new.run())
+                await _wait_until(lambda: any(ESCALATION in t for t in _texts(h)), timeout=30.0)
+
+                # The incident's shape, asserted: escalated, delivered, and the
+                # requested task never happened.
+                assert any(ESCALATION in t for t in _texts(h))
+                assert not any("mail sent" in t for t in _texts(h)), (
+                    "the control did not actually reproduce the failure"
+                )
+            finally:
+                if new_task is not None:
+                    await _stop(new_task, new)
+                if not old_task.done():
+                    await _stop(old_task, old)
+
+    asyncio.run(go())
+
+
+# --- the regression: refuse the roll, finish the work -------------------------
+
+
+def test_the_pre_upgrade_gate_refuses_the_roll_and_the_turn_completes_once(make_harness) -> None:  # noqa: ANN001
+    """The same accepted turn, with the pre-upgrade gate in front of the roll.
+
+    The gate finds a live-leased delivery, refuses, and `helm upgrade` fails
+    with it -- so nothing is rolled, the turn keeps running on the workers that
+    are already there, and it reaches its intended terminal outcome exactly
+    once. The no-duplicate-side-effect invariant is asserted on the far side: a
+    redelivery of the same event after the turn is done runs no second action.
+    """
+    thread = "drain-fixed-1"
+    event_id = uuid.uuid4().hex
+
+    async def go() -> None:
+        async with make_harness(**_KNOBS) as h:
+            store = DeliveryLeaseStore(h.async_redis, h.config)
+            gate = UpgradeDrainGate(h.async_redis, h.config)
+            old_cfg = h.config.model_copy(update={"consumer_name": "worker-old"})
+            old = Consumer(
+                redis=h.async_redis,
+                kernel=h.kernel,
+                config=old_cfg,
+                leases=store,
+                drain=gate,
+            )
+            hold = _admit_side_effecting_turn(h, old)
+
+            await old.ensure_group()
+            old_task = asyncio.create_task(old.run())
+            try:
+                await h.async_redis.xadd(
+                    h.config.stream,
+                    to_stream_fields(_qevent("send the mail", thread=thread, event_id=event_id)),
+                )
+                await _wait_until(lambda: h.runner.turn_active)
+                deadline = time.monotonic() + 20.0
+                while time.monotonic() < deadline:
+                    if await h.async_redis.exists(h.config.side_effect_key(event_id)):
+                        break
+                    await asyncio.sleep(0.02)
+                assert await h.async_redis.exists(h.config.side_effect_key(event_id))
+
+                # The chart's pre-upgrade hook, before a single manifest is
+                # applied. It must refuse: an accepted, side-effecting delivery
+                # is live.
+                outcome = await gate.await_drained()
+                assert outcome.drained is False, (
+                    "the gate cleared an upgrade over a live side-effecting delivery"
+                )
+                assert outcome.remaining, "a refusal must name what held it back"
+                assert all(
+                    r.startswith(f"{h.config.stream}/{h.config.consumer_group}/")
+                    for r in outcome.remaining
+                )
+
+                # `helm upgrade` fails on that exit code, so NOTHING rolls. The
+                # postponed upgrade puts the fleet back the way it found it.
+                await gate.clear_quiesce()
+
+                # The turn finishes on the workers that were already there.
+                hold.set()
+                await _wait_until(lambda: any("mail sent" in t for t in _texts(h)), timeout=30.0)
+                await _wait_until(lambda: len(h.sink.completions) >= 1, timeout=30.0)
+
+                assert not any(ESCALATION in t for t in _texts(h)), (
+                    "accepted work was still converted into a human escalation"
+                )
+                assert len(h.runner.opened) == 1, (
+                    f"the turn ran more than once: {h.runner.opened!r}"
+                )
+                assert len(h.sink.completions) == 1, (
+                    f"expected exactly one terminal completion, saw {h.sink.completions!r}"
+                )
+
+                # The invariant this fix may not trade away: a redelivery of the
+                # same event after it is terminally done executes no second
+                # action. The kernel's ``is_terminal`` short-circuit is what
+                # holds it, and it must still hold with the gate in the path.
+                await h.async_redis.xadd(
+                    h.config.stream,
+                    to_stream_fields(_qevent("send the mail", thread=thread, event_id=event_id)),
+                )
+                await asyncio.sleep(1.0)
+                assert len(h.runner.opened) == 1, (
+                    "a redelivery re-ran the side-effecting turn"
+                )
+            finally:
+                hold.set()
+                await _stop(old_task, old)
+
+    asyncio.run(go())
+
+
+# --- new claims are suppressed for the whole drain ----------------------------
+
+
+def test_a_quiesced_consumer_claims_nothing_and_resumes_when_released(make_harness) -> None:  # noqa: ANN001
+    """"...while preventing new claims during the drain."
+
+    A wait that kept admitting work could never terminate under load, and a
+    replacement Pod that comes up mid-roll must not reclaim the delivery a
+    still-draining replica is settling. Both are the same suppression, so both
+    are asserted here: nothing is claimed while the flag is set, and the very
+    same entry is claimed once it clears.
+    """
+    thread = "drain-quiesce-1"
+    event_id = uuid.uuid4().hex
+
+    async def go() -> None:
+        async with make_harness(**_KNOBS) as h:
+            store = DeliveryLeaseStore(h.async_redis, h.config)
+            gate = UpgradeDrainGate(h.async_redis, h.config)
+            consumer = Consumer(
+                redis=h.async_redis,
+                kernel=h.kernel,
+                config=h.config,
+                leases=store,
+                drain=gate,
+            )
+            h.runner.default_script = [Final(text="handled", status=DONE)]
+
+            await consumer.ensure_group()
+            await gate.request_quiesce()
+            task = asyncio.create_task(consumer.run())
+            try:
+                await h.async_redis.xadd(
+                    h.config.stream,
+                    to_stream_fields(_qevent("do the thing", thread=thread, event_id=event_id)),
+                )
+                # Long enough for several read-loop cycles (read_block_ms is
+                # 100ms in the harness) and several maintenance ticks.
+                await asyncio.sleep(1.5)
+                assert h.runner.opened == [], (
+                    "a quiesced consumer claimed new work during the drain"
+                )
+
+                await gate.clear_quiesce()
+                await _wait_until(lambda: len(h.runner.opened) == 1, timeout=30.0)
+                assert h.runner.opened == ["do the thing"]
+            finally:
+                await _stop(task, consumer)
+
+    asyncio.run(go())
+
+
+def test_a_quiesced_consumer_does_not_reclaim_a_departed_replicas_entry(make_harness) -> None:  # noqa: ANN001
+    """The incident's own mechanism, blocked.
+
+    A reclaim IS a new claim: it moves a peer's pending entry into this consumer
+    and dispatches it. That is precisely how the replacement Pod took the
+    delivery at 11:16:31 and escalated it. The read-loop suppression above
+    cannot cover this -- a reclaimed entry never goes through ``XREADGROUP`` --
+    so it is asserted separately, against an entry left pending by a replica
+    that is already gone (no live lease, idle past the reclaim threshold).
+
+    Red on removing the ``_claims_paused`` guard in ``Consumer._maintenance_loop``.
+    """
+    thread = "drain-reclaim-1"
+    event_id = uuid.uuid4().hex
+
+    async def go() -> None:
+        async with make_harness(**_KNOBS) as h:
+            store = DeliveryLeaseStore(h.async_redis, h.config)
+            gate = UpgradeDrainGate(h.async_redis, h.config)
+            consumer = Consumer(
+                redis=h.async_redis,
+                kernel=h.kernel,
+                config=h.config,
+                leases=store,
+                drain=gate,
+            )
+            h.runner.default_script = [Final(text="handled", status=DONE)]
+
+            await consumer.ensure_group()
+            await h.async_redis.xadd(
+                h.config.stream,
+                to_stream_fields(_qevent("finish the thing", thread=thread, event_id=event_id)),
+            )
+            # Read it into a consumer name that no longer exists: the departed
+            # replica's PEL row, holding no lease.
+            await h.async_redis.xreadgroup(
+                h.config.consumer_group,
+                "worker-departed",
+                {h.config.stream: ">"},
+                count=1,
+            )
+            await asyncio.sleep(h.config.reclaim_min_idle_ms / 1000 + 0.1)
+
+            await gate.request_quiesce()
+            task = asyncio.create_task(consumer.run())
+            try:
+                await asyncio.sleep(1.5)
+                assert h.runner.opened == [], (
+                    "a quiesced consumer reclaimed a departed replica's delivery"
+                )
+
+                await gate.clear_quiesce()
+                await _wait_until(lambda: len(h.runner.opened) == 1, timeout=30.0)
+                assert h.runner.opened == ["finish the thing"]
+            finally:
+                await _stop(task, consumer)
+
+    asyncio.run(go())

--- a/apps/worker/tests/test_upgrade_drain.py
+++ b/apps/worker/tests/test_upgrade_drain.py
@@ -1,0 +1,499 @@
+"""Per-behavior contract tests for the pre-upgrade drain gate (issue #2010).
+
+Against **real Valkey**, never a mock, for the same reason
+``test_delivery_lease.py`` states: what the gate reads IS Valkey semantics --
+``XPENDING`` ownership, key expiry, and the presence of a lease key another
+process wrote. A mocked client would assert only that we called the verbs we
+called.
+
+Clocks are compressed by CONFIGURING short values, never by patching time. Every
+ratio the ``WorkerConfig`` validators enforce is preserved, including the new
+one: the quiesce TTL must strictly outlast the drain wait.
+
+The API this file pins:
+
+    UpgradeDrainGate(redis: Redis, config: WorkerConfig)
+      .request_quiesce(*, ttl_s=None)     -> None   (always with an expiry)
+      .clear_quiesce()                    -> None
+      .is_quiescing()                     -> bool
+      .unsettled_deliveries()             -> tuple[str, ...]  ("stream/group/entry")
+      .await_drained(*, timeout_s=None, poll_interval_s=None) -> DrainOutcome
+
+    DrainOutcome: .drained .remaining .waited_s
+    run_gate(config, *, mode="drain"|"release") -> int   (the hook's exit code)
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import contextlib
+import importlib
+import re
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+from curie_test_support.valkey import (
+    VALKEY_HOST as _VALKEY_HOST,
+)
+from curie_test_support.valkey import (
+    VALKEY_PORT as _VALKEY_PORT,
+)
+from curie_test_support.valkey import (
+    VALKEY_PW as _VALKEY_PW,
+)
+from curie_worker.config import WorkerConfig
+from curie_worker.delivery_lease import DeliveryLeaseStore
+from curie_worker.upgrade_drain import UpgradeDrainGate, main, run_gate
+from redis.asyncio import Redis as AsyncRedis
+from redis.exceptions import ResponseError
+
+# Compressed lease clocks, same shape as test_delivery_lease.py.
+_TTL_S = 1.0
+_HEARTBEAT_S = 0.3
+_BUDGET_S = 60.0
+# The drain wait, and a quiesce TTL that strictly outlasts it (the validator).
+_DRAIN_TIMEOUT_S = 0.5
+_QUIESCE_TTL_S = 2.0
+
+
+def _config(names: dict[str, str], **overrides: object) -> WorkerConfig:
+    base: dict[str, object] = {
+        "valkey_host": _VALKEY_HOST,
+        "valkey_port": _VALKEY_PORT,
+        "valkey_password": _VALKEY_PW,
+        "stream": names["stream"],
+        "consumer_group": names["group"],
+        "key_prefix": names["prefix"],
+        # Per-test eval lane names too. The gate reads BOTH lanes, and leaving
+        # the eval defaults in place would point it at a shared production-named
+        # group on the shared test Valkey -- a cross-test coupling that reads as
+        # a flake rather than as the wiring mistake it is.
+        "eval_stream": f"{names['stream']}:evals",
+        "eval_consumer_group": f"{names['group']}-evals",
+        "delivery_budget_s": _BUDGET_S,
+        "delivery_lease_ttl_s": _TTL_S,
+        "delivery_lease_heartbeat_s": _HEARTBEAT_S,
+        "reclaim_interval_s": 0.5,
+        "runner_total_timeout_s": 30.0,
+        "upgrade_drain_timeout_s": _DRAIN_TIMEOUT_S,
+        "upgrade_drain_poll_interval_s": 0.05,
+        "upgrade_quiesce_ttl_s": _QUIESCE_TTL_S,
+    }
+    base.update(overrides)
+    return WorkerConfig(**base)
+
+
+@contextlib.asynccontextmanager
+async def _gate(
+    names: dict[str, str], **overrides: object
+) -> AsyncIterator[tuple[UpgradeDrainGate, WorkerConfig, AsyncRedis]]:
+    config = _config(names, **overrides)
+    client: AsyncRedis = AsyncRedis(
+        host=_VALKEY_HOST,
+        port=_VALKEY_PORT,
+        password=_VALKEY_PW or None,
+        decode_responses=True,
+    )
+    try:
+        yield UpgradeDrainGate(client, config), config, client
+    finally:
+        with contextlib.suppress(Exception):
+            await client.delete(config.upgrade_quiesce_key())
+        with contextlib.suppress(Exception):
+            await client.aclose()
+
+
+async def _pending(client: AsyncRedis, config: WorkerConfig, consumer: str) -> str:
+    """One entry, read into ``consumer``'s PEL. The lease's own precondition."""
+    with contextlib.suppress(Exception):
+        await client.xgroup_create(
+            config.stream, config.consumer_group, id="0", mkstream=True
+        )
+    entry_id = await client.xadd(config.stream, {"payload": "p"})
+    read: Any = await client.xreadgroup(
+        config.consumer_group, consumer, {config.stream: ">"}, count=1
+    )
+    delivered = [eid for _s, entries in read for eid, _f in entries]
+    assert delivered == [entry_id], f"expected {entry_id} pending, got {delivered}"
+    return str(entry_id)
+
+
+# --- the quiesce flag ---------------------------------------------------------
+
+
+def test_quiesce_is_always_written_with_an_expiry(names) -> None:  # noqa: ANN001
+    """A permanent flag turns a killed upgrade into a fleet that has silently
+    stopped answering. Red if ``request_quiesce`` ever writes without a TTL."""
+
+    async def go() -> None:
+        async with _gate(names) as (gate, config, client):
+            await gate.request_quiesce()
+            assert await gate.is_quiescing() is True
+            ttl = await client.ttl(config.upgrade_quiesce_key())
+            assert ttl > 0, "the quiesce flag has no expiry; a dead upgrade wedges the fleet"
+            assert ttl <= int(_QUIESCE_TTL_S)
+
+    asyncio.run(go())
+
+
+def test_quiesce_lapses_on_its_own_so_an_abandoned_upgrade_self_heals(names) -> None:  # noqa: ANN001
+    """The TTL is the fail-safe for a hook that is killed between the gate and
+    the post-upgrade release: nobody clears the flag, and the fleet recovers."""
+
+    async def go() -> None:
+        async with _gate(names, upgrade_quiesce_ttl_s=1.0, upgrade_drain_timeout_s=0.5) as (
+            gate,
+            _config,
+            _client,
+        ):
+            await gate.request_quiesce()
+            assert await gate.is_quiescing() is True
+            await asyncio.sleep(1.4)
+            assert await gate.is_quiescing() is False
+
+    asyncio.run(go())
+
+
+def test_clear_quiesce_is_idempotent(names) -> None:  # noqa: ANN001
+    """The post-upgrade release runs on a fleet that may already be claiming
+    (the TTL lapsed first); clearing twice must not be an error."""
+
+    async def go() -> None:
+        async with _gate(names) as (gate, _config, _client):
+            await gate.clear_quiesce()
+            await gate.request_quiesce()
+            await gate.clear_quiesce()
+            await gate.clear_quiesce()
+            assert await gate.is_quiescing() is False
+
+    asyncio.run(go())
+
+
+# --- what counts as unsafe in-flight work ------------------------------------
+
+
+def test_a_live_leased_delivery_is_reported_as_unsettled(names) -> None:  # noqa: ANN001
+    """The whole delivery triple, not a bare entry id: an operator reading a
+    refusal has to know which lane is still busy."""
+
+    async def go() -> None:
+        async with _gate(names) as (gate, config, client):
+            entry_id = await _pending(client, config, "replica-a")
+            store = DeliveryLeaseStore(client, config)
+            await store.acquire(
+                config.stream, config.consumer_group, entry_id, consumer="replica-a"
+            )
+            assert await gate.unsettled_deliveries() == (
+                f"{config.stream}/{config.consumer_group}/{entry_id}",
+            )
+
+    asyncio.run(go())
+
+
+def test_a_pending_entry_with_no_live_lease_is_not_unsettled(names) -> None:  # noqa: ANN001
+    """Nobody is working it, so rolling interrupts nothing and the existing
+    reclaim machinery picks it up afterwards.
+
+    Red on a gate that reads pending-ness instead of liveness: every upgrade
+    would then block behind whatever backlog happened to be un-acked, which is a
+    gate that gets switched off in its first week.
+    """
+
+    async def go() -> None:
+        async with _gate(names) as (gate, config, client):
+            await _pending(client, config, "replica-a")
+            assert await gate.unsettled_deliveries() == ()
+
+    asyncio.run(go())
+
+
+def test_a_lapsed_lease_stops_counting_as_unsettled(names) -> None:  # noqa: ANN001
+    """The owner died. Its lease expires, the delivery becomes recoverable, and
+    the gate must stop holding the upgrade for a process that is gone."""
+
+    async def go() -> None:
+        async with _gate(names) as (gate, config, client):
+            entry_id = await _pending(client, config, "replica-a")
+            store = DeliveryLeaseStore(client, config)
+            await store.acquire(
+                config.stream, config.consumer_group, entry_id, consumer="replica-a"
+            )
+            assert len(await gate.unsettled_deliveries()) == 1
+            await asyncio.sleep(_TTL_S + 0.3)
+            assert await gate.unsettled_deliveries() == ()
+
+    asyncio.run(go())
+
+
+def test_the_eval_lane_is_gated_too(names) -> None:  # noqa: ANN001
+    """ADR-0131: "runs and evals must share the lease implementation by
+    construction. A fix on only one consumer lane is incomplete." The same holds
+    for the gate -- an eval delivery holds a sandbox and a lease exactly as a
+    turn does."""
+
+    async def go() -> None:
+        async with _gate(names) as (gate, config, client):
+            with contextlib.suppress(Exception):
+                await client.xgroup_create(
+                    config.eval_stream, config.eval_consumer_group, id="0", mkstream=True
+                )
+            entry_id = await client.xadd(config.eval_stream, {"payload": "suite"})
+            await client.xreadgroup(
+                config.eval_consumer_group,
+                "eval-replica-a",
+                {config.eval_stream: ">"},
+                count=1,
+            )
+            store = DeliveryLeaseStore(client, config)
+            await store.acquire(
+                config.eval_stream,
+                config.eval_consumer_group,
+                str(entry_id),
+                consumer="eval-replica-a",
+            )
+            assert await gate.unsettled_deliveries() == (
+                f"{config.eval_stream}/{config.eval_consumer_group}/{entry_id}",
+            )
+
+    asyncio.run(go())
+
+
+def test_a_lane_that_has_never_been_used_is_not_unsafe_work(names) -> None:  # noqa: ANN001
+    """A release whose eval group does not exist yet must not be unable to
+    upgrade. No group is no work, not an unreadable lane to refuse over."""
+
+    async def go() -> None:
+        async with _gate(names) as (gate, _config, _client):
+            assert await gate.unsettled_deliveries() == ()
+
+    asyncio.run(go())
+
+
+def test_a_lane_that_cannot_be_read_refuses_the_upgrade(names) -> None:  # noqa: ANN001
+    """Fail closed on an unreadable lane.
+
+    Red on widening the NOGROUP guard back to a bare ``except``: a gate that
+    answers "nothing in flight" about a lane it could not look at is worse than
+    no gate, because it clears an upgrade over deliveries it never saw. Driven
+    with a real WRONGTYPE (a plain string sitting where the stream should be),
+    so the refusal is proven against Valkey's own error rather than a patched
+    client.
+    """
+
+    async def go() -> None:
+        async with _gate(names) as (gate, config, client):
+            await client.set(config.stream, "not-a-stream")
+            try:
+                with pytest.raises(ResponseError):
+                    await gate.unsettled_deliveries()
+            finally:
+                await client.delete(config.stream)
+
+    asyncio.run(go())
+
+
+# --- the gate itself ----------------------------------------------------------
+
+
+def test_await_drained_quiesces_before_it_waits(names) -> None:  # noqa: ANN001
+    """A wait that kept admitting new work could never terminate under load, so
+    the flag goes up first and unconditionally."""
+
+    async def go() -> None:
+        async with _gate(names) as (gate, config, client):
+            entry_id = await _pending(client, config, "replica-a")
+            store = DeliveryLeaseStore(client, config)
+            await store.acquire(
+                config.stream, config.consumer_group, entry_id, consumer="replica-a"
+            )
+            outcome = await gate.await_drained()
+            assert outcome.drained is False
+            assert await gate.is_quiescing() is True, (
+                "await_drained waited without quiescing first"
+            )
+
+    asyncio.run(go())
+
+
+def test_await_drained_refuses_and_names_the_deliveries_holding_it_back(names) -> None:  # noqa: ANN001
+    """"The gate refused" with no names is a message that gets the gate turned
+    off. The refusal carries the delivery ids."""
+
+    async def go() -> None:
+        async with _gate(names) as (gate, config, client):
+            entry_id = await _pending(client, config, "replica-a")
+            store = DeliveryLeaseStore(client, config)
+            await store.acquire(
+                config.stream, config.consumer_group, entry_id, consumer="replica-a"
+            )
+            outcome = await gate.await_drained()
+            assert outcome.drained is False
+            assert outcome.remaining == (
+                f"{config.stream}/{config.consumer_group}/{entry_id}",
+            )
+            assert outcome.waited_s >= _DRAIN_TIMEOUT_S
+
+    asyncio.run(go())
+
+
+def test_await_drained_returns_as_soon_as_the_owner_settles(names) -> None:  # noqa: ANN001
+    """The success path, and it must not sit out the whole timeout: the gate
+    polls, so a delivery that settles early lets the upgrade proceed early."""
+
+    async def go() -> None:
+        async with _gate(names, upgrade_drain_timeout_s=5.0, upgrade_quiesce_ttl_s=10.0) as (
+            gate,
+            config,
+            client,
+        ):
+            entry_id = await _pending(client, config, "replica-a")
+            store = DeliveryLeaseStore(client, config)
+            lease = await store.acquire(
+                config.stream, config.consumer_group, entry_id, consumer="replica-a"
+            )
+
+            async def settle_soon() -> None:
+                await asyncio.sleep(0.2)
+                await store.settle(config.stream, config.consumer_group, entry_id)
+
+            settler = asyncio.create_task(settle_soon())
+            outcome = await gate.await_drained(poll_interval_s=0.05)
+            await settler
+            assert lease.owner
+            assert outcome.drained is True
+            assert outcome.remaining == ()
+            assert outcome.waited_s < 5.0, "the gate sat out the whole timeout"
+
+    asyncio.run(go())
+
+
+def test_an_empty_release_drains_immediately(names) -> None:  # noqa: ANN001
+    """The overwhelmingly common upgrade: nothing in flight, no waiting."""
+
+    async def go() -> None:
+        async with _gate(names) as (gate, _config, _client):
+            outcome = await gate.await_drained()
+            assert outcome.drained is True
+            assert outcome.waited_s < _DRAIN_TIMEOUT_S
+
+    asyncio.run(go())
+
+
+# --- the hook's exit contract -------------------------------------------------
+
+
+def test_the_hook_exits_zero_and_leaves_the_fleet_quiesced_on_a_clean_drain(names) -> None:  # noqa: ANN001
+    """Helm reads 0 as "roll". The flag STAYS set across the roll so the
+    replacement pods that come up mid-upgrade do not reclaim the deliveries a
+    still-draining replica is settling; the post-upgrade release clears it."""
+
+    async def go() -> None:
+        config = _config(names)
+        code = await run_gate(config, mode="drain")
+        assert code == 0
+        client: AsyncRedis = AsyncRedis(
+            host=_VALKEY_HOST,
+            port=_VALKEY_PORT,
+            password=_VALKEY_PW or None,
+            decode_responses=True,
+        )
+        try:
+            assert await client.exists(config.upgrade_quiesce_key())
+            assert await run_gate(config, mode="release") == 0
+            assert not await client.exists(config.upgrade_quiesce_key())
+        finally:
+            await client.delete(config.upgrade_quiesce_key())
+            await client.aclose()
+
+    asyncio.run(go())
+
+
+def test_a_refused_upgrade_leaves_the_fleet_claiming_again(names) -> None:  # noqa: ANN001
+    """Postponing must put the cluster back exactly as it was found.
+
+    Red on a refusal path that leaves the flag set: a refused upgrade -- one
+    where nothing was rolled and nothing changed -- would stop every replica in
+    the release from claiming until the TTL lapsed, turning the refusal into the
+    outage the refusal exists to avoid.
+    """
+
+    async def go() -> None:
+        config = _config(names)
+        client: AsyncRedis = AsyncRedis(
+            host=_VALKEY_HOST,
+            port=_VALKEY_PORT,
+            password=_VALKEY_PW or None,
+            decode_responses=True,
+        )
+        try:
+            entry_id = await _pending(client, config, "replica-a")
+            store = DeliveryLeaseStore(client, config)
+            await store.acquire(
+                config.stream, config.consumer_group, entry_id, consumer="replica-a"
+            )
+            assert await run_gate(config, mode="drain") == 1
+            assert not await client.exists(config.upgrade_quiesce_key()), (
+                "a refused upgrade left the fleet quiesced"
+            )
+        finally:
+            await client.delete(config.upgrade_quiesce_key())
+            await client.aclose()
+
+    asyncio.run(go())
+
+
+# --- the chart's cross-artifact coupling --------------------------------------
+
+_CHART_HOOK = (
+    Path(__file__).resolve().parents[3]
+    / "charts"
+    / "curie"
+    / "templates"
+    / "worker-upgrade-drain.yaml"
+)
+
+
+def test_the_chart_hooks_invoke_a_module_and_modes_this_package_actually_has() -> None:
+    """The Jobs run `python -m curie_worker.upgrade_drain --mode ...` out of the
+    worker image, and nothing else checks that string.
+
+    The chart CI assertions render the command but cannot import it, and the
+    helm-ci path filter does not include ``apps/worker/**`` -- so a rename or a
+    dropped ``--mode`` value here would leave a chart that templates perfectly
+    and fails at the one moment it runs, in the middle of an operator's upgrade.
+    This assertion lives on the worker side deliberately: it is the side where
+    that rename happens.
+    """
+    if not _CHART_HOOK.exists():  # a released wheel has no chart checkout
+        return
+    commands = [
+        ast.literal_eval(match)
+        for match in re.findall(r"command: (\[[^\]]*\])", _CHART_HOOK.read_text())
+    ]
+    assert commands, f"no container command found in {_CHART_HOOK}"
+    for command in commands:
+        interpreter, dash_m, module, mode_flag, mode = command
+        assert (interpreter, dash_m, mode_flag) == ("python", "-m", "--mode"), command
+        importlib.import_module(module)
+        # The mode reaches argparse, whose `choices` is the real contract; an
+        # unknown one exits 2 before the gate does anything.
+        assert mode in ("drain", "release"), f"the chart asks for --mode {mode}"
+    modes = {command[4] for command in commands}
+    assert modes == {"drain", "release"}, (
+        f"the chart wires {sorted(modes)}; both hooks are required -- without the "
+        "release the fleet waits out the whole quiesce TTL after every upgrade"
+    )
+
+
+def test_an_unknown_mode_is_refused_rather_than_silently_draining() -> None:
+    """``main`` is the process entry point the chart calls. A typo in the hook
+    must fail loudly, not fall through to a default that quiesces the fleet."""
+    try:
+        main(["--mode", "quiesce-forever"])
+    except SystemExit as exit_code:
+        assert exit_code.code == 2
+    else:
+        raise AssertionError("an unknown --mode was accepted")

--- a/charts/curie/ci/render-assertions.sh
+++ b/charts/curie/ci/render-assertions.sh
@@ -929,6 +929,9 @@ expected = {
     ("Job", f"{prefix}-netpol-probe"): "hooks",
     ("Job", f"{prefix}-security-probe"): "hooks",
     ("Job", f"{prefix}-langfuse-model-pricing"): "hooks",
+    # The pre-upgrade drain gate and its post-upgrade release (issue #2010).
+    ("Job", f"{prefix}-upgrade-drain"): "hooks",
+    ("Job", f"{prefix}-upgrade-drain-release"): "hooks",
     ("Pod", f"{prefix}-security-probe-hardening"): "hooks",
     ("Deployment", "agent-sandbox-controller"): "controller",
 }

--- a/charts/curie/ci/upgrade-drain-assertions.sh
+++ b/charts/curie/ci/upgrade-drain-assertions.sh
@@ -1,0 +1,280 @@
+#!/usr/bin/env bash
+#
+# The pre-upgrade drain gate must be wired the way issue #2010 needs it, and
+# must refuse the two configurations that would make it silently useless.
+#
+# Every assertion here corresponds to a way the gate stops protecting anything
+# while still rendering perfectly valid YAML:
+#
+#   * a `pre-install` hook would fail every fresh install against a Valkey that
+#     does not exist yet;
+#   * a non-zero backoffLimit would re-quiesce the fleet and re-wait the whole
+#     timeout on a refusal, turning one postponed upgrade into minutes of a
+#     cluster that is not claiming;
+#   * `hook-failed` in the delete policy would destroy the only log naming which
+#     deliveries held the upgrade back;
+#   * a quiesce TTL that does not outlast the wait lapses mid-drain, so the
+#     replicas resume claiming into the roll AND the gate still reports success;
+#   * a wait shorter than the delivery budget refuses upgrades over turns that
+#     are still inside the budget ADR-0131 already promised them, which is a
+#     gate that gets switched off in its first week.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+helm template t "$CHART" > "$TMP/default.yaml"
+helm template t "$CHART" --set worker.upgradeDrain.enabled=false > "$TMP/disabled.yaml"
+helm template t "$CHART" --set worker.deploy=false > "$TMP/no-worker.yaml"
+
+# --- the two render-time refusals -------------------------------------------
+#
+# Asserted by EXECUTING the rejected configuration, not by reading the helper:
+# a guard that has never been seen refusing is a guard nobody has tested.
+
+assert_render_fails() {
+  local label="$1" expected="$2"
+  shift 2
+  local out
+  if out="$(helm template t "$CHART" "$@" 2>&1)"; then
+    echo "FAIL: $label rendered successfully; expected a render-time refusal" >&2
+    exit 1
+  fi
+  if ! printf '%s' "$out" | grep -qF "$expected"; then
+    echo "FAIL: $label was refused, but not for the expected reason." >&2
+    echo "  expected to find: $expected" >&2
+    echo "  actual output:" >&2
+    printf '%s\n' "$out" | sed 's/^/    /' >&2
+    exit 1
+  fi
+  echo "OK: $label is refused at render time"
+}
+
+assert_render_fails \
+  "a quiesce TTL that does not outlast the drain wait" \
+  "must be strictly greater than worker.upgradeDrain.timeoutSeconds" \
+  --set worker.upgradeDrain.timeoutSeconds=900 \
+  --set worker.upgradeDrain.quiesceTtlSeconds=900
+
+# The cross-family relationship is DERIVED, not refused: raising the delivery
+# budget is a decision made for unrelated reasons, and failing the render for a
+# value the operator never touched would break configurations valid today. Both
+# ends of the derivation are rendered so the assertion checks the relationship
+# rather than a constant.
+helm template t "$CHART" \
+  --set worker.deliveryBudgetSeconds=1800 \
+  --set worker.terminationGracePeriodSeconds=1860 > "$TMP/raised.yaml"
+helm template t "$CHART" \
+  --set worker.deliveryBudgetSeconds=60 \
+  --set worker.deliveryShutdownReserveSeconds=0 \
+  --set worker.upgradeDrain.timeoutSeconds=120 \
+  --set worker.upgradeDrain.quiesceTtlSeconds=300 > "$TMP/small.yaml"
+
+python3 - "$TMP/default.yaml" "$TMP/disabled.yaml" "$TMP/no-worker.yaml" "$TMP/small.yaml" "$TMP/raised.yaml" <<'PY'
+import sys
+
+import yaml
+
+default_path, disabled_path, no_worker_path, small_path, raised_path = sys.argv[1:6]
+
+DRAIN = "upgrade-drain"
+RELEASE = "upgrade-drain-release"
+
+
+def load(path):
+    with open(path) as handle:
+        return [doc for doc in yaml.safe_load_all(handle) if doc]
+
+
+def jobs_by_component(docs):
+    out = {}
+    for doc in docs:
+        if doc.get("kind") != "Job":
+            continue
+        component = (doc.get("metadata") or {}).get("labels", {}).get(
+            "app.kubernetes.io/component"
+        )
+        if component in (DRAIN, RELEASE):
+            out.setdefault(component, []).append(doc)
+    return out
+
+
+failures = []
+
+
+def check(condition, message):
+    if not condition:
+        failures.append(message)
+
+
+# --- the gate is absent unless it is asked for -------------------------------
+for path, label in ((disabled_path, "upgradeDrain.enabled=false"), (no_worker_path, "worker.deploy=false")):
+    present = jobs_by_component(load(path))
+    check(not present, f"{label} still rendered {sorted(present)}")
+
+# --- the default render ------------------------------------------------------
+jobs = jobs_by_component(load(default_path))
+for component in (DRAIN, RELEASE):
+    check(
+        len(jobs.get(component, [])) == 1,
+        f"expected exactly one {component} Job, found {len(jobs.get(component, []))}",
+    )
+
+if not failures:
+    drain = jobs[DRAIN][0]
+    release = jobs[RELEASE][0]
+
+    drain_ann = (drain.get("metadata") or {}).get("annotations", {})
+    release_ann = (release.get("metadata") or {}).get("annotations", {})
+
+    # The hook phases. `pre-upgrade` ONLY: a fresh install has nothing in flight
+    # and no Valkey to ask, so `pre-install` would fail every first install.
+    check(
+        drain_ann.get("helm.sh/hook") == "pre-upgrade",
+        f"drain hook is {drain_ann.get('helm.sh/hook')!r}, expected exactly 'pre-upgrade'",
+    )
+    check(
+        release_ann.get("helm.sh/hook") == "post-upgrade",
+        f"release hook is {release_ann.get('helm.sh/hook')!r}, expected exactly 'post-upgrade'",
+    )
+    # The failed gate Job must survive: its log is the only place an operator
+    # can read WHICH deliveries held the upgrade back.
+    check(
+        "hook-failed" not in drain_ann.get("helm.sh/hook-delete-policy", ""),
+        "the drain Job is auto-deleted on failure, destroying the refusal's evidence",
+    )
+    check(
+        "before-hook-creation" in drain_ann.get("helm.sh/hook-delete-policy", ""),
+        "the drain Job is not cleared before the next attempt",
+    )
+
+    drain_spec = drain.get("spec") or {}
+    release_spec = release.get("spec") or {}
+    # A refusal is a decision, not a transient error.
+    check(
+        drain_spec.get("backoffLimit") == 0,
+        f"drain backoffLimit is {drain_spec.get('backoffLimit')!r}, expected 0: "
+        "retrying a refusal re-quiesces the fleet and re-waits the whole timeout",
+    )
+    # Clearing the flag IS idempotent and worth retrying.
+    check(
+        (release_spec.get("backoffLimit") or 0) > 0,
+        f"release backoffLimit is {release_spec.get('backoffLimit')!r}, expected > 0",
+    )
+    # The Job-level ceiling must sit ABOVE the gate's own wait, or Kubernetes
+    # kills the gate before it can answer and every upgrade fails.
+    check(
+        (drain_spec.get("activeDeadlineSeconds") or 0) > 900,
+        f"drain activeDeadlineSeconds is {drain_spec.get('activeDeadlineSeconds')!r}, "
+        "expected greater than the 900s default drain wait",
+    )
+
+    for component, doc, mode in ((DRAIN, drain, "drain"), (RELEASE, release, "release")):
+        pod = (doc.get("spec") or {}).get("template", {}).get("spec", {})
+        check(
+            pod.get("restartPolicy") == "Never",
+            f"{component} restartPolicy is {pod.get('restartPolicy')!r}, expected 'Never'",
+        )
+        containers = pod.get("containers") or []
+        check(len(containers) == 1, f"{component} has {len(containers)} containers, expected 1")
+        if not containers:
+            continue
+        container = containers[0]
+        # The WORKER image: the gate reads the worker's own key namespace and
+        # lease keys through WorkerConfig, so a different image would be a
+        # second copy of that layout free to drift.
+        check(
+            "curie-worker" in (container.get("image") or ""),
+            f"{component} image is {container.get('image')!r}, expected the worker image",
+        )
+        check(
+            container.get("command")
+            == ["python", "-m", "curie_worker.upgrade_drain", "--mode", mode],
+            f"{component} command is {container.get('command')!r}",
+        )
+        env = {e["name"]: e for e in container.get("env", []) if isinstance(e, dict)}
+        for required in ("VALKEY_HOST", "VALKEY_PORT", "VALKEY_PASSWORD"):
+            check(required in env, f"{component} is missing {required}")
+        # Both Jobs build the same WorkerConfig, whose validator refuses a
+        # quiesce TTL that does not outlast the wait. A release Job missing
+        # these would construct a config the gate could not.
+        check(
+            env.get("CURIE_UPGRADE_DRAIN_TIMEOUT_S", {}).get("value") == "900",
+            f"{component} CURIE_UPGRADE_DRAIN_TIMEOUT_S is "
+            f"{env.get('CURIE_UPGRADE_DRAIN_TIMEOUT_S', {}).get('value')!r}, expected '900'",
+        )
+        check(
+            env.get("CURIE_UPGRADE_QUIESCE_TTL_S", {}).get("value") == "1800",
+            f"{component} CURIE_UPGRADE_QUIESCE_TTL_S is "
+            f"{env.get('CURIE_UPGRADE_QUIESCE_TTL_S', {}).get('value')!r}, expected '1800'",
+        )
+
+    drain_env = {
+        e["name"]: e
+        for e in (drain["spec"]["template"]["spec"]["containers"][0].get("env") or [])
+        if isinstance(e, dict)
+    }
+    check(
+        drain_env.get("CURIE_UPGRADE_DRAIN_POLL_INTERVAL_S", {}).get("value") == "5",
+        "the drain Job does not carry the configured poll interval",
+    )
+
+# --- the derived clocks ------------------------------------------------------
+
+
+def drain_env(path, label):
+    jobs = jobs_by_component(load(path))
+    if len(jobs.get(DRAIN, [])) != 1:
+        failures.append(f"the {label} render produced no drain Job")
+        return None
+    return {
+        e["name"]: e
+        for e in (jobs[DRAIN][0]["spec"]["template"]["spec"]["containers"][0].get("env") or [])
+        if isinstance(e, dict)
+    }
+
+
+# A wait already above the budget is left alone: the floor is a floor, not an
+# override, so an operator who asks for longer keeps it.
+env = drain_env(small_path, "smaller-budget")
+if env is not None:
+    check(
+        env.get("CURIE_UPGRADE_DRAIN_TIMEOUT_S", {}).get("value") == "120",
+        "a drain wait already above the budget was not left at the configured value: "
+        f"{env.get('CURIE_UPGRADE_DRAIN_TIMEOUT_S', {}).get('value')!r}",
+    )
+    check(
+        env.get("CURIE_UPGRADE_QUIESCE_TTL_S", {}).get("value") == "300",
+        "a quiesce TTL already above the wait was not left at the configured value: "
+        f"{env.get('CURIE_UPGRADE_QUIESCE_TTL_S', {}).get('value')!r}",
+    )
+
+# Raising deliveryBudgetSeconds to its 1800s maximum, with the grace ADR-0131
+# requires, must still render -- and must carry the gate up with it rather than
+# leaving a 900s wait that would refuse every upgrade during ordinary traffic.
+# 1800 + 60 reserve = 1860, and the quiesce TTL is derived above that.
+env = drain_env(raised_path, "raised-budget")
+if env is not None:
+    check(
+        env.get("CURIE_UPGRADE_DRAIN_TIMEOUT_S", {}).get("value") == "1860",
+        "raising the delivery budget did not raise the effective drain wait: "
+        f"{env.get('CURIE_UPGRADE_DRAIN_TIMEOUT_S', {}).get('value')!r}, expected '1860'",
+    )
+    check(
+        env.get("CURIE_UPGRADE_QUIESCE_TTL_S", {}).get("value") == "1920",
+        "the quiesce TTL was not derived above the raised wait, so the worker "
+        "would refuse it at boot: "
+        f"{env.get('CURIE_UPGRADE_QUIESCE_TTL_S', {}).get('value')!r}, expected '1920'",
+    )
+
+if failures:
+    print("FAIL: upgrade drain gate render assertions failed", file=sys.stderr)
+    for failure in failures:
+        print("  " + failure, file=sys.stderr)
+    raise SystemExit(1)
+
+print("OK: upgrade drain gate render assertions passed")
+PY

--- a/charts/curie/templates/_helpers.tpl
+++ b/charts/curie/templates/_helpers.tpl
@@ -1148,6 +1148,48 @@ securityContext:
 {{- end -}}
 {{- end -}}
 
+{{/* ---- Upgrade drain gate arithmetic (issue #2010) ----
+     The gate's two clocks are DERIVED, with the values as floors, and only a
+     self-contradictory pair is refused outright. The split is deliberate.
+
+     `timeoutSeconds` vs the delivery budget is a CROSS-FAMILY relationship an
+     operator does not author together: raising `deliveryBudgetSeconds` is a
+     decision about how long a turn may run, made for reasons that have nothing
+     to do with upgrades. Refusing that render would break configurations that
+     are valid today, on a chart upgrade, for a value the operator never touched
+     -- so the effective wait is raised to cover the budget instead. The gate
+     must never give up on a delivery that is still inside the budget ADR-0131
+     already promised it; a gate that refuses upgrades during ordinary traffic
+     is a gate that gets switched off in its first week.
+
+     The quiesce TTL is then derived above that, because the worker's OWN boot
+     validator refuses a TTL that does not outlast the wait -- so a rendered
+     pair the app would reject is a green `helm upgrade` followed by a
+     CrashLoopBackOff, the same failure `validateDrainBudget` above exists to
+     prevent.
+
+     What IS refused is the one pair an operator writes together and can only
+     get wrong by contradicting themselves: a `quiesceTtlSeconds` at or below
+     the `timeoutSeconds` they set beside it. Silently raising that one would
+     hide a stated intent rather than an unrelated default. */}}
+{{- define "curie.worker.upgradeDrain.timeout" -}}
+{{- max (int64 .Values.worker.upgradeDrain.timeoutSeconds) (add (int64 .Values.worker.deliveryBudgetSeconds) (int64 .Values.worker.deliveryShutdownReserveSeconds)) -}}
+{{- end -}}
+
+{{/* Headroom over the effective wait, so the flag cannot lapse in the moments
+     between the gate's last poll and the roll it clears the way for. */}}
+{{- define "curie.worker.upgradeDrain.quiesceTtl" -}}
+{{- max (int64 .Values.worker.upgradeDrain.quiesceTtlSeconds) (add (int64 (include "curie.worker.upgradeDrain.timeout" .)) 60) -}}
+{{- end -}}
+
+{{- define "curie.worker.validateUpgradeDrain" -}}
+{{- $timeout := int64 .Values.worker.upgradeDrain.timeoutSeconds -}}
+{{- $quiesce := int64 .Values.worker.upgradeDrain.quiesceTtlSeconds -}}
+{{- if le $quiesce $timeout -}}
+{{- fail (printf "worker.upgradeDrain.quiesceTtlSeconds (%d) must be strictly greater than worker.upgradeDrain.timeoutSeconds (%d) (issue #2010). As set, the fleet-wide quiesce flag lapses while the gate is still waiting, so the replicas resume claiming into a roll that is about to interrupt them -- and the gate would still report a clean drain. Fix: raise worker.upgradeDrain.quiesceTtlSeconds above %d, or lower worker.upgradeDrain.timeoutSeconds below %d." $quiesce $timeout $timeout $quiesce) -}}
+{{- end -}}
+{{- end -}}
+
 {{/* ---- Langfuse ClickHouse startup gate (issue #2009) ----
      Both Langfuse deployments run their ClickHouse migrations during boot, so a
      Helm upgrade that recreates the ClickHouse Service can start them before the

--- a/charts/curie/templates/worker-upgrade-drain.yaml
+++ b/charts/curie/templates/worker-upgrade-drain.yaml
@@ -1,0 +1,183 @@
+{{- if and .Values.worker.deploy .Values.worker.upgradeDrain.enabled }}
+{{/*
+Pre-upgrade drain gate, and its post-upgrade release (issue #2010).
+
+ADR-0131 made one worker's OWN shutdown safe: `terminationGracePeriodSeconds`
+covers the delivery budget plus the shutdown reserve, so a SIGTERMed replica can
+settle the delivery it owns, and the fencing lease stops a replacement stealing
+a healthy long turn. None of that governs the roll happening around it. A
+`helm upgrade` applies the worker AND its backing services in one pass, and an
+already-accepted, side-effecting turn whose owner is interrupted mid-flight is
+reclaimed by the replacement, which correctly refuses to re-run the action and
+escalates to a human. No duplicate effect, no silent loss -- and the requested
+task does not complete. That is the failure #2010 reports, and it happened on a
+release whose grace was already 1800s.
+
+The gate closes it AHEAD of the roll rather than behind it:
+
+  pre-upgrade  -> quiesce new claims across the release, wait for every delivery
+                  holding a live ownership lease to settle. Exit 0 and the roll
+                  proceeds with each of those turns completed exactly once; exit
+                  1 and `helm upgrade` fails with the hook, so NOTHING is
+                  applied and the turn keeps running where it already is.
+  post-upgrade -> clear the flag so the new Pods start claiming.
+
+Three details are load-bearing.
+
+`pre-upgrade` and not `pre-upgrade,pre-install`: on a first install there is
+nothing in flight and no Valkey to ask, and a gate that has to reach a
+not-yet-existing dependency would fail every fresh install.
+
+`backoffLimit: 0` with `restartPolicy: Never`: a refusal is a DECISION, not a
+transient error. Retrying it would silently re-quiesce the fleet and wait the
+whole timeout again, turning one postponed upgrade into several minutes of a
+cluster that is not claiming.
+
+The failed Job is NOT auto-deleted (`hook-delete-policy` omits `hook-failed`):
+its log names the deliveries that held the upgrade back, which is the only place
+an operator can read why the upgrade was refused. `before-hook-creation` still
+clears it on the next attempt.
+*/}}
+{{- include "curie.worker.validateUpgradeDrain" . }}
+{{/* The EFFECTIVE clocks, not the raw values: `timeoutSeconds` is a floor and
+     the gate is raised to cover the delivery budget, with the quiesce TTL
+     derived above that. See `curie.worker.upgradeDrain.timeout` for why this is
+     derived rather than refused. */}}
+{{- $drainTimeout := include "curie.worker.upgradeDrain.timeout" . }}
+{{- $quiesceTtl := include "curie.worker.upgradeDrain.quiesceTtl" . }}
+{{- $image := include "curie.image" (dict "repository" .Values.worker.image.repository "tag" .Values.worker.image.tag "digest" .Values.worker.image.digest "defaultTag" .Chart.AppVersion) }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "curie.fullname" . }}-upgrade-drain
+  labels:
+    {{- include "curie.labels" . | nindent 4 }}
+    app.kubernetes.io/component: upgrade-drain
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 0
+  # A hard ceiling above the gate's own wait, so a Job wedged on an unreachable
+  # Valkey cannot hold `helm upgrade` open indefinitely. The gate returns on its
+  # own timeout well before this; reaching it means the container never got as
+  # far as waiting.
+  activeDeadlineSeconds: {{ add (int64 $drainTimeout) 120 }}
+  template:
+    metadata:
+      labels:
+        {{- with (include "curie.placement.labels" (dict "root" $ "class" "hooks")) }}
+        {{- . | nindent 8 }}
+        {{- end }}
+        {{- include "curie.selectorLabels" (dict "root" . "component" "upgrade-drain") | nindent 8 }}
+      {{- with (include "curie.placement.annotations" (dict "root" $ "class" "hooks")) }}
+      annotations:
+        {{- . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with (include "curie.placement.spec" (dict "root" $ "class" "hooks")) }}
+      {{- . | nindent 6 }}
+      {{- end }}
+      restartPolicy: Never
+      {{- with .Values.worker.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.worker.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: upgrade-drain
+          # The WORKER image, deliberately: the gate reads the worker's own key
+          # namespace, its lease keys, and its two delivery lanes, all through
+          # `curie_worker.config.WorkerConfig`. A separate image would be a
+          # second copy of that key layout, free to drift from the one the
+          # workers actually use.
+          image: {{ $image | quote }}
+          imagePullPolicy: {{ .Values.worker.image.pullPolicy }}
+          {{- with .Values.worker.containerSecurityContext }}
+          {{- include "curie.containerSecurityContext" . | nindent 10 }}
+          {{- end }}
+          command: ["python", "-m", "curie_worker.upgrade_drain", "--mode", "drain"]
+          env:
+            {{- include "curie.env.valkey" . | nindent 12 }}
+            # Valkey is the ONLY wiring the gate needs. Stream, group and key
+            # prefix are chart-invariant -- templates/worker.yaml overrides none
+            # of them -- so the gate reads the same namespace the workers write
+            # by using the very same WorkerConfig defaults they do. Rendering an
+            # override here would be a second, drift-prone declaration of a
+            # namespace this chart does not actually configure.
+            - name: CURIE_UPGRADE_DRAIN_TIMEOUT_S
+              value: {{ $drainTimeout | quote }}
+            - name: CURIE_UPGRADE_DRAIN_POLL_INTERVAL_S
+              value: {{ .Values.worker.upgradeDrain.pollIntervalSeconds | quote }}
+            - name: CURIE_UPGRADE_QUIESCE_TTL_S
+              value: {{ $quiesceTtl | quote }}
+          resources:
+            {{- toYaml .Values.worker.upgradeDrain.resources | nindent 12 }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "curie.fullname" . }}-upgrade-drain-release
+  labels:
+    {{- include "curie.labels" . | nindent 4 }}
+    app.kubernetes.io/component: upgrade-drain-release
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  # Unlike the gate, this one SHOULD retry: clearing the flag is idempotent, and
+  # a release that never lands leaves the fleet waiting out `quiesceTtlSeconds`
+  # before it claims again. The TTL is the fail-safe behind these attempts, not
+  # a substitute for them.
+  backoffLimit: 3
+  activeDeadlineSeconds: 300
+  template:
+    metadata:
+      labels:
+        {{- with (include "curie.placement.labels" (dict "root" $ "class" "hooks")) }}
+        {{- . | nindent 8 }}
+        {{- end }}
+        {{- include "curie.selectorLabels" (dict "root" . "component" "upgrade-drain-release") | nindent 8 }}
+      {{- with (include "curie.placement.annotations" (dict "root" $ "class" "hooks")) }}
+      annotations:
+        {{- . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with (include "curie.placement.spec" (dict "root" $ "class" "hooks")) }}
+      {{- . | nindent 6 }}
+      {{- end }}
+      restartPolicy: Never
+      {{- with .Values.worker.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.worker.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: upgrade-drain-release
+          image: {{ $image | quote }}
+          imagePullPolicy: {{ .Values.worker.image.pullPolicy }}
+          {{- with .Values.worker.containerSecurityContext }}
+          {{- include "curie.containerSecurityContext" . | nindent 10 }}
+          {{- end }}
+          command: ["python", "-m", "curie_worker.upgrade_drain", "--mode", "release"]
+          env:
+            {{- include "curie.env.valkey" . | nindent 12 }}
+            # Present so the release Job builds the SAME WorkerConfig the gate
+            # does; the config's own validator refuses a quiesce TTL that does
+            # not outlast the drain wait, and a Job that omitted these would
+            # construct a config the gate could not.
+            - name: CURIE_UPGRADE_DRAIN_TIMEOUT_S
+              value: {{ $drainTimeout | quote }}
+            - name: CURIE_UPGRADE_QUIESCE_TTL_S
+              value: {{ $quiesceTtl | quote }}
+          resources:
+            {{- toYaml .Values.worker.upgradeDrain.resources | nindent 12 }}
+{{- end }}

--- a/charts/curie/values.schema.json
+++ b/charts/curie/values.schema.json
@@ -66,6 +66,27 @@
           "maximum": 86400,
           "description": "Voluntary Pod termination grace before SIGKILL. Must be at least deliveryBudgetSeconds + deliveryShutdownReserveSeconds (ADR-0131, #1971), or a worker draining a maximum-budget turn is killed at the exact moment it would settle; below 60s not even a fast drain reliably completes."
         },
+        "upgradeDrain": {
+          "type": "object",
+          "description": "Pre-upgrade drain gate (issue #2010): quiesce new claims and drain already-accepted deliveries to their terminal outcome before the roll, or refuse the upgrade while unsafe in-flight work exists.",
+          "properties": {
+            "enabled": {"type": "boolean"},
+            "timeoutSeconds": {
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "maximum": 7200,
+              "description": "Floor for how long the gate waits for in-flight deliveries before refusing the upgrade. The effective wait is raised to at least deliveryBudgetSeconds + deliveryShutdownReserveSeconds so the gate never gives up on a delivery still inside the budget ADR-0131 promised it."
+            },
+            "pollIntervalSeconds": {"type": "integer", "exclusiveMinimum": 0, "maximum": 3600},
+            "quiesceTtlSeconds": {
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "maximum": 86400,
+              "description": "Floor for the lifetime of the fleet-wide quiesce flag, derived above the effective drain wait so it cannot lapse mid-drain. Setting it at or below timeoutSeconds is refused at render time. Finite by construction, so an upgrade killed between the two hooks cannot leave the fleet permanently unable to claim."
+            },
+            "resources": {"type": "object"}
+          }
+        },
         "workspace": {
           "type": "object",
           "properties": {

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -1336,6 +1336,56 @@ worker:
   # clear) after the runner work is done. `terminationGracePeriodSeconds`
   # above must be at least deliveryBudgetSeconds + this value.
   deliveryShutdownReserveSeconds: 60
+  # Pre-upgrade drain gate (issue #2010). ADR-0131 made one worker's own
+  # shutdown safe; it says nothing about the roll happening around it. A
+  # `helm upgrade` applies the worker AND its backing services in one pass, so
+  # an already-accepted, side-effecting turn whose owner is interrupted is
+  # reclaimed by the replacement, which correctly refuses to re-run the action
+  # and escalates to a human. No duplicate effect, no silent loss -- and the
+  # requested task does not complete.
+  #
+  # When enabled, a `pre-upgrade` hook Job quiesces new claims across the
+  # release and waits for every delivery that currently holds a live ownership
+  # lease to reach its terminal outcome. If they all settle, the roll proceeds
+  # and each of those turns completed exactly once. If they do not, the hook
+  # fails, `helm upgrade` fails with it, and NOTHING is rolled -- the upgrade is
+  # postponed rather than converting accepted work into an escalation. A
+  # `post-upgrade` hook clears the flag once the roll is done.
+  #
+  # Disable it for a release where an interrupted turn is acceptable (a dev
+  # cluster, a fake-model install). The chart's behavior without it is exactly
+  # what it was before the gate existed.
+  upgradeDrain:
+    enabled: true
+    # How long to wait for the in-flight deliveries before refusing. A FLOOR,
+    # not a ceiling: the effective wait is raised to at least
+    # deliveryBudgetSeconds + deliveryShutdownReserveSeconds, because a gate
+    # that gives up while a turn is still inside the budget ADR-0131 already
+    # promised it would postpone upgrades during ordinary traffic. Raising the
+    # delivery budget therefore raises this automatically rather than breaking
+    # the render for a value you never touched.
+    timeoutSeconds: 900
+    # How often the gate re-reads the in-flight set while waiting.
+    pollIntervalSeconds: 5
+    # How long the quiesce flag lives. Also a floor: it is derived above the
+    # EFFECTIVE wait above, because the worker refuses a TTL that does not
+    # outlast the drain at boot, and a render the app rejects is a green
+    # `helm upgrade` followed by a CrashLoopBackOff. Finite by construction, so
+    # an upgrade killed between the two hooks cannot leave the fleet
+    # permanently unable to claim. Size it to span the expected rollout: the
+    # flag is what keeps replacement Pods from reclaiming mid-roll.
+    #
+    # Setting it at or below timeoutSeconds IS refused at render time -- that
+    # pair is written together, so contradicting yourself there is a stated
+    # intent worth surfacing rather than silently raising.
+    quiesceTtlSeconds: 1800
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
+      limits:
+        cpu: 200m
+        memory: 128Mi
   # The Slack assistant-thread "shimmer" (#1182): the animated caption Slack
   # shows next to the app's name while a turn runs. On by default -- the
   # placeholder message only changes when the model emits text, so a model that


### PR DESCRIPTION
A routine `helm upgrade` admitted a real side-effecting AgentMail turn and then rolled the worker and its backing services out from under it. The replacement worker reclaimed the delivery, saw the durable side-effect marker, correctly refused to re-run the action, and escalated to a human. No duplicate effect, no silent loss — and the requested task did not complete.

That escalation is the right answer to an unsafe situation. The bug is that a supported, routine upgrade **creates** the situation on the normal path. ADR-0131 already made one worker's own shutdown safe (grace covers budget + reserve; the fencing lease stops a replacement stealing a healthy turn) — which is why the deployed 1800s grace did not help. Nothing governed the roll happening *around* it.

## What this adds

A pre-upgrade drain gate, with the two outcomes #2010 asks for and nothing between them:

- **Drain.** A `pre-upgrade` hook Job quiesces new claims release-wide, then waits for every delivery holding a live ownership lease to reach its terminal outcome. Exit 0 → the roll proceeds, and each of those turns completed exactly once.
- **Refuse.** If unsafe work remains at the deadline, the hook exits 1, `helm upgrade` fails with it, and **nothing is applied**. The refusal names the deliveries that held it back and clears the flag, so a postponed upgrade leaves the cluster exactly as it found it.

A `post-upgrade` hook clears the flag; its TTL is the fail-safe, so an upgrade killed between the two hooks cannot leave the fleet unable to claim. Both delivery lanes honour the flag on their read loop **and** their reclaim — a reclaim is a new claim, and it is how the replacement took the delivery in the incident.

### Design notes

- **"Unsafe in flight" is a live lease, not a pending entry.** An unleased pending entry is work nobody is doing; gating on pending-ness would block every upgrade behind a dead-lettered backlog, which is a gate that gets switched off in its first week.
- **No keyspace scan.** Pending lists are paged and each page's liveness reads go out in one pipeline — the rule `markers.py` already states for the maintenance path.
- **Fail closed on an unreadable lane.** Only `NOGROUP` (a lane never used on this release) is treated as "no work"; anything else refuses the upgrade rather than clearing it over deliveries it never saw.
- **The gate's clocks are derived, with the values as floors.** Raising `deliveryBudgetSeconds` raises the effective wait instead of breaking a render for a value the operator never touched, and the quiesce TTL is derived above that so the chart can never render a pair the worker's own boot validator rejects. Only a self-contradictory `quiesceTtlSeconds <= timeoutSeconds` is refused outright.

The no-duplicate-side-effect invariant is untouched and asserted on the far side of the drain.

## Verification

`apps/worker/tests/kernel/test_upgrade_drain.py` carries a matched pair: a **negative control** that reproduces the incident with the gate bypassed (old replica accepts and flags a side effect, the roll kills it, the replacement reclaims and escalates), and the **regression** where the gate refuses, nothing rolls, and the turn completes exactly once. Every guard was demonstrated rejecting a violating input by executing it, and each assertion was mutation-checked.

Scope note: treated as an issue-tracked fix rather than a new ADR, per `AGENTS.md` ("when in doubt, write the issue") — it realizes ADR-0131's drain intent at the platform layer and closes off no new architectural alternative. No frozen schema, contract, protocol, or ADR was touched.

## Done-check

- [x] **Failing tests committed before implementation code** — N/A as separate commits (squashed to one clean commit per the repo's commit convention); every assertion was mutation-verified red against the implementation instead. See below.
- [x] **Broadened return types** — none; no public signature widened. New params are keyword-only with `None` defaults, so every existing construction is unchanged.
- [x] **Sibling-path parity** — both delivery lanes (runs and evals) take the gate, per ADR-0131's "a fix on only one consumer lane is incomplete"; asserted by `test_the_eval_lane_is_gated_too`. The killswitch consumer is deliberately excluded (holds no delivery lease, must keep answering during a drain).
- [x] **Guard demonstration** — every guard executed against a violating input: both render-time refusals run real `helm template` invocations in `charts/curie/ci/upgrade-drain-assertions.sh`; the fail-closed unreadable-lane guard is driven with a real Valkey `WRONGTYPE`; the chart↔module coupling guard was proven red by renaming the module in the template.
- [x] **Mutation-verified** — `unsettled_deliveries → ()` fails 7 tests incl. the regression; removing `_claims_paused` from `_consume` fails the read-loop suppression test; removing it from `_maintenance_loop` fails the reclaim-suppression test; swallowing every lane read error fails the fail-closed test.
- [x] **Full affected test suite, typecheck, lint** — `pytest apps/worker` (excluding `tests/eval`): **1043 passed, 9 skipped**. `ruff` clean, `mypy` clean (233 files), `lint-imports` 4/4 contracts kept.
- [x] **Chart checks** — `curie dev chart-check`: **all 30 assertion scripts pass**, including the new `upgrade-drain-assertions.sh` (wired into `helm-ci.yaml`, which enumerates each script as its own step). `helm lint` clean. `scripts/check-docs.sh` and `scripts/check-wire-tolerance.sh` clean.
- [ ] **Deployed E2E** — not run. The change is chart-hook + worker wiring; no cluster was mutated, per the task's constraints.
- [x] **Adversarial reviewer passes** — not run: this session was explicitly instructed not to use the Agent tool. Flagging rather than claiming.

`apps/worker/tests/eval/test_stream.py` (10 tests) and `test_recorder.py` (1) fail in this environment on `httpx.ReadTimeout` against a Langfuse that is not running. Verified identical on a pristine `origin/next` worktree — pre-existing, not from this change.

Closes #2010
