### PR TITLE
Back off a clone that keeps failing instead of retrying every interval

### DIFF
--- a/apps/api/src/curie_api/commitpoller.py
+++ b/apps/api/src/curie_api/commitpoller.py
@@ -22,7 +22,7 @@ deploy paths that could disagree about what a push means would be worse than
 one path that sometimes runs late -- and the webhook remains the fast path
 wherever it can reach.
 
-Three properties worth stating, because each is a way this could go wrong:
+Four properties worth stating, because each is a way this could go wrong:
 
 - **It polls per REPOSITORY, not per agent.** Several agents share one
   repository (ADR-0091), so per-agent polling would make N identical API calls
@@ -34,14 +34,21 @@ Three properties worth stating, because each is a way this could go wrong:
 - **One failing repository does not stop the others.** A repo whose credential
   has been revoked, or that has been deleted, must not silently halt polling
   for every other agent on the cluster.
+- **A clone that keeps failing backs off instead of retrying every interval.**
+  A repository that is unreachable, unauthorized, or too large to clone inside
+  the 120s timeout fails identically on every pass, so retrying at the interval
+  is roughly 1,440 full clones a day for one unchanged sha. Repeated failures
+  of the same class for the same sha wait geometrically longer, to an hourly
+  ceiling, and the stalled lane is reported rather than left silent (#1309).
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
+import math
 import time
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from typing import Any, Protocol
 
@@ -265,8 +272,11 @@ WHERE a.repo_full_name IS NOT NULL AND d.commit_sha IS NOT NULL
 ORDER BY a.repo_full_name, d.environment, d.deployed_at DESC
 """
 
-# These rejections depend on which agents are bound to the repository. They
-# settle against that binding snapshot, then get one new attempt when an
+# A rejection lands in one of three tiers, and the tier is what decides whether
+# the next pass pays for another full mirror clone.
+#
+# Tier one, TOPOLOGY: these depend on which agents are bound to the repository.
+# They settle against that binding snapshot, then get one new attempt when an
 # operator changes it without pushing a new commit (#1307).
 _TOPOLOGY_REJECTIONS = frozenset(
     {
@@ -276,6 +286,65 @@ _TOPOLOGY_REJECTIONS = frozenset(
     }
 )
 _ARCHIVE_FAILURE = "git.archive_failed"
+# Tier two, RETRYABLE: this one says nothing about the commit. The same code
+# covers a subprocess error and both 120s timeouts, so it means anything from a
+# network blip to a repository that is permanently unreachable, unauthorized,
+# missing its clone credential, or too large to clone inside the timeout. It
+# must not be terminal, and it must not be retried every interval either -- it
+# earns another clone on a capped geometric backoff (#1309).
+_RETRYABLE_REJECTIONS = frozenset({_ARCHIVE_FAILURE})
+#
+# Tier three, EVERYTHING ELSE: an ambiguous environment or an invalid bundle is
+# fixed only by pushing a new commit, so those settle for the sha and re-cloning
+# would prove nothing.
+
+# The first wait after a retryable failure. Five minutes turns the worst case --
+# a repository broken all day on a 60s interval -- from ~1,440 clone attempts
+# into 24, while still recovering from a genuine blip inside one pass of an
+# operator's attention (#1309).
+_RETRY_BASE_DELAY_S = 300.0
+# The ceiling on that geometric growth: 5m, 10m, 20m, 40m, then an hour
+# forever. Capping rather than settling is deliberate. A private repository
+# whose clone credential arrives an hour after the binding was made is exactly
+# the shape `docs/operations.md` documents, and a terminal state would strand it
+# until someone pushed a new commit or restarted the API. The bound here is on
+# the RATE of clones; the stalled lane is made findable by the error below
+# instead of by silence.
+_RETRY_MAX_DELAY_S = 3600.0
+# The same ceiling, expressed as a bound on the EXPONENT, because clamping only
+# the product is too late. `2 ** (attempts - 1)` is evaluated in full before
+# `min` ever sees it, and at attempt 1,025 that float multiplication raises
+# OverflowError -- a repository failing every attempt reaches 1,025 in roughly
+# 43 days at the hourly ceiling, well inside the life of an API pod. The
+# exception would escape `poll_once` BEFORE the new record is stored, so the
+# already-expired record survives and every following pass clones again and
+# crashes again: #1309 restored, on exactly the repository this feature exists
+# for. Derived from the two delays rather than written down, so it cannot
+# silently drift if they change (4 for the current constants -- 300s doubled
+# four times is 4,800s, already past the ceiling).
+_RETRY_MAX_DOUBLINGS = math.ceil(math.log2(_RETRY_MAX_DELAY_S / _RETRY_BASE_DELAY_S))
+# How many consecutive failures before this stops reading like a blip -- the
+# same judgement as _SUSTAINED_THROTTLE_ROUNDS above. By the third identical
+# failure the deploy lane has stopped, and an operator needs to find it as that
+# rather than as one more per-pass INFO line (#1309).
+_RETRY_ERROR_ROUNDS = 3
+
+
+@dataclass(frozen=True)
+class ArchiveBackoff:
+    """A retryable rejection that has not yet earned another clone."""
+
+    sha: str
+    # The failure class: the rejection's sorted error codes. A different class
+    # is a different failure, so it restarts the schedule rather than inheriting
+    # the previous one's delay.
+    codes: tuple[str, ...]
+    attempts: int
+    next_attempt_at: float  # monotonic seconds
+    # What the deployments query reported for this branch when the failure was
+    # recorded. A CHANGE in it means a deploy landed since -- from either lane
+    # -- and this record is stale (see the prune in `poll_once`).
+    deployed_sha: str | None
 
 
 # Every repository binding. Grouping these rows produces both the unique poll
@@ -313,6 +382,7 @@ class CommitPoller:
         eval_queue: Any,
         tips: BranchTip,
         interval_seconds: float,
+        clock: Callable[[], float] = time.monotonic,
     ) -> None:
         self._session_factory = session_factory
         self._store = store
@@ -320,13 +390,18 @@ class CommitPoller:
         self._eval_queue = eval_queue
         self._tips = tips
         self._interval = interval_seconds
+        # Monotonic, not wall clock: a backoff window must not be skipped or
+        # extended by an NTP correction. Injectable so the schedule can be
+        # asserted without a test that sleeps for an hour.
+        self._clock = clock
         # The database records successes only. Intrinsic failures settle for
         # the sha, while routing failures settle until the repository binding
         # snapshot changes. In memory only, so restart can retry once.
         self._settled: dict[tuple[str, str], Settled] = {}
-        # Archive failure gets one retry on the next pass, then settles. This
-        # bounds network failure clones without making a single blip terminal.
-        self._archive_retry: dict[tuple[str, str], str] = {}
+        # A retryable rejection is neither forgotten nor terminal: it waits a
+        # geometrically growing, capped delay before earning another clone
+        # (#1309). Keyed the same way as _settled, per (repository, branch).
+        self._archive_backoff: dict[tuple[str, str], ArchiveBackoff] = {}
 
     async def run_forever(self) -> None:
         logger.info("commit poller started interval=%ss", self._interval)
@@ -372,6 +447,23 @@ class CommitPoller:
 
         binding_snapshots = {repo: tuple(names) for repo, names in bindings.items()}
 
+        # A deployment on the branch retires the failure record, whichever lane
+        # produced it. The webhook lane deploys through the same `process_push`
+        # without going near the poller, so the success-clearing branch below
+        # never runs for a commit it handled -- and the stale record would then
+        # survive a rollback to the failed sha and suppress redeploying it, even
+        # though the successful deploy is direct evidence the repository is
+        # clonable again (AC4 of #1309).
+        #
+        # The comparison is against the sha captured AT RECORD TIME, not against
+        # `move.sha`: a branch normally has an older deployed sha than its tip,
+        # so comparing to the tip would prune on the very first failure and
+        # disable the backoff entirely. It is the change in the branch's last
+        # successful deploy that means one landed since.
+        for key, record in list(self._archive_backoff.items()):
+            if deployed.get(key) != record.deployed_sha:
+                del self._archive_backoff[key]
+
         targets: list[PollTarget] = []
         for repo in bindings:
             try:
@@ -398,8 +490,26 @@ class CommitPoller:
         # inside it -- at the recommended 60s interval an unchanged
         # non-deploying branch is roughly 1,440 full clones a day (#1267).
         unsettled: list[Move] = []
+        now = self._clock()
         for move in moves:
-            settled = self._settled.get((move.repo_full_name, move.branch))
+            key = (move.repo_full_name, move.branch)
+            backoff = self._archive_backoff.get(key)
+            if backoff is not None:
+                if backoff.sha != move.sha:
+                    # A record for a different sha suppresses nothing -- a new
+                    # commit is a new chance, and may be the fix -- and it is
+                    # dropped rather than merely ignored, because it is state
+                    # about a commit that is no longer the branch tip (AC4 of
+                    # #1309).
+                    del self._archive_backoff[key]
+                elif now < backoff.next_attempt_at:
+                    # Still inside the window this repository's last failure
+                    # earned. It has to be checked HERE for the same reason the
+                    # settled check is: the mirror clone lives inside
+                    # process_push, so a skip decided any later has already paid
+                    # for it (#1309).
+                    continue
+            settled = self._settled.get(key)
             if settled is None or settled.sha != move.sha:
                 unsettled.append(move)
                 continue
@@ -426,30 +536,24 @@ class CommitPoller:
                 # and this must not keep a second copy that a rollback would
                 # not clear.
                 self._settled.pop(key, None)
-                self._archive_retry.pop(key, None)
+                self._archive_backoff.pop(key, None)
             elif result.status == "rejected":
                 codes = {(error.get("code") or "") for error in (result.errors or [])}
                 if codes & _TOPOLOGY_REJECTIONS:
                     self._settled[key] = Settled(
                         move.sha, binding_snapshots[move.repo_full_name]
                     )
-                    self._archive_retry.pop(key, None)
-                elif _ARCHIVE_FAILURE in codes and self._archive_retry.get(key) != move.sha:
-                    self._archive_retry[key] = move.sha
-                    logger.info(
-                        "commit poll will retry repo=%s branch=%s sha=%s (transient)",
-                        move.repo_full_name,
-                        move.branch,
-                        move.sha[:8],
-                    )
+                    self._archive_backoff.pop(key, None)
+                elif codes & _RETRYABLE_REJECTIONS:
+                    self._record_retryable_failure(move, codes, deployed.get(key))
                 else:
                     self._settled[key] = Settled(move.sha, None)
-                    self._archive_retry.pop(key, None)
+                    self._archive_backoff.pop(key, None)
             else:
                 # An ignored outcome will keep repeating for this commit.
                 # Remember it, or the next pass clones again (#1267).
                 self._settled[key] = Settled(move.sha, None)
-                self._archive_retry.pop(key, None)
+                self._archive_backoff.pop(key, None)
 
             if result.status != "rejected":
                 logger.info(
@@ -460,3 +564,73 @@ class CommitPoller:
                     result.status,
                 )
         return moves
+
+    def _record_retryable_failure(
+        self,
+        move: Move,
+        codes: set[str],
+        deployed_sha: str | None,
+    ) -> None:
+        """Make this repository wait longer before it costs another clone.
+
+        The attempt count continues only while the sha AND the failure class
+        both hold. A new commit may be the fix, and a rejection that changed
+        codes is a different failure -- neither has earned the previous
+        failure's accumulated delay (#1309).
+
+        `deployed_sha` is what the deployments query reported for this branch on
+        this pass, passed in rather than recomputed. It is the baseline the
+        prune in `poll_once` compares against to notice a deploy from the other
+        lane.
+        """
+
+        key = (move.repo_full_name, move.branch)
+        failure = tuple(sorted(codes))
+        previous = self._archive_backoff.get(key)
+        if previous is not None and previous.sha == move.sha and previous.codes == failure:
+            attempts = previous.attempts + 1
+        else:
+            attempts = 1
+        # The exponent is clamped as well as the product: see
+        # `_RETRY_MAX_DOUBLINGS`. The outer `min` still earns its place -- four
+        # doublings gives 4,800s, and the ceiling is 3,600s. `attempts` itself
+        # is deliberately NOT capped: the count is real information, and it is
+        # what the stalled-lane error below reports.
+        delay = min(
+            _RETRY_BASE_DELAY_S * 2 ** min(attempts - 1, _RETRY_MAX_DOUBLINGS),
+            _RETRY_MAX_DELAY_S,
+        )
+        self._archive_backoff[key] = ArchiveBackoff(
+            sha=move.sha,
+            codes=failure,
+            attempts=attempts,
+            next_attempt_at=self._clock() + delay,
+            deployed_sha=deployed_sha,
+        )
+        if attempts >= _RETRY_ERROR_ROUNDS:
+            # Re-emitted on EVERY subsequent attempt, not once at the
+            # threshold: a lane parked at the hourly ceiling would otherwise go
+            # quiet again, which is the silence this was meant to end (#1309).
+            logger.error(
+                "commit poll clone failed %d consecutive times repo=%s branch=%s sha=%s "
+                "codes=%s; deploys from this repository are NOT happening. Retrying in "
+                "%.0fs. The repository may be unreachable, unauthorized, missing a clone "
+                "credential, or too large to clone inside the 120s timeout.",
+                attempts,
+                move.repo_full_name,
+                move.branch,
+                move.sha[:8],
+                ",".join(failure),
+                delay,
+            )
+        else:
+            logger.info(
+                "commit poll will retry repo=%s branch=%s sha=%s codes=%s "
+                "attempt=%d in %.0fs",
+                move.repo_full_name,
+                move.branch,
+                move.sha[:8],
+                ",".join(failure),
+                attempts,
+                delay,
+            )

--- a/apps/api/tests/test_commitpoller.py
+++ b/apps/api/tests/test_commitpoller.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import subprocess
 
 import httpx
 import pytest
@@ -25,6 +26,11 @@ from fastapi.testclient import TestClient
 
 REPO = "octo/agent-bot"
 CLONE = "https://github.com/octo/agent-bot.git"
+# A sha the real `process_push` will accept: it rejects anything that is not
+# 40/64 lowercase hex as "ignored" before it ever reaches the clone (#1309's
+# end-to-end tests drive the real deploy path, so "abc123" would never get
+# there).
+REAL_SHA = "a" * 40
 
 
 class Tips:
@@ -44,6 +50,57 @@ class Tips:
 
 def target(*branches: str, repo: str = REPO) -> PollTarget:
     return PollTarget(repo_full_name=repo, clone_url=CLONE, branches=branches)
+
+
+def _poller_with_clock(
+    *,
+    tips,
+    bindings_for_pass=lambda: [(REPO, "agent")],
+    deployments_for_pass=lambda: [],
+):
+    """The poller plus the mutable clock both harnesses drive it with.
+
+    Returns `(poller, now)`, where `now` is the `{"v": seconds}` dict the
+    injected clock reads: advancing it is how a test crosses a backoff window
+    without sleeping for five minutes.
+
+    The two row sources are callables evaluated per query rather than fixed
+    rows, so the harness that varies its answers between passes (`_run_passes`)
+    and the one that answers identically for forty passes (the end-to-end
+    timeout test, which needs the REAL `process_push` and so cannot use
+    `_run_passes`) share one Session, factory and clock.
+    """
+
+    from contextlib import asynccontextmanager
+
+    from curie_api.commitpoller import CommitPoller
+    from curie_api.config import Settings
+
+    now = {"v": 0.0}
+
+    class Session:
+        async def execute(self, stmt):
+            if "FROM curie.agents" in str(stmt):
+                return bindings_for_pass()
+            # Everything else is the deployments query: its SQL reads
+            # `FROM curie.deployments d JOIN curie.agents a`, so it does not
+            # match the substring above.
+            return deployments_for_pass()
+
+    @asynccontextmanager
+    async def factory():
+        yield Session()
+
+    poller = CommitPoller(
+        session_factory=factory,
+        store=object(),
+        settings=Settings(github_clone_base="https://github.com"),
+        eval_queue=object(),
+        tips=tips,
+        interval_seconds=60,
+        clock=lambda: now["v"],
+    )
+    return poller, now
 
 
 # --------------------------------------------------------------------------- #
@@ -635,56 +692,84 @@ def test_invalid_repo_full_name_is_rejected_before_commit_poll_http(monkeypatch)
 
 # Not re-cloning a commit that already settled (#1267)
 # --------------------------------------------------------------------------- #
-async def _passes(
+async def _run_passes(
     monkeypatch,
-    result,
+    outcomes,
     n: int = 2,
     binding_snapshots: list[tuple[str, ...]] | None = None,
-) -> int:
-    """Run n consecutive poll_once passes; return how many reached the deploy path.
+    seconds_per_pass: float = 0.0,
+    tips=None,
+    after_pass=None,
+    deployments: list[list[tuple[str, str, str]]] | None = None,
+):
+    """Run n consecutive poll_once passes; return (deploy-path calls, poller).
 
     Reaching the deploy path is what costs a full mirror clone -- the clone
-    lives inside process_push -- so this counts exactly the thing #1267 is
-    about.
+    lives inside process_push -- so the count is exactly the thing #1267 and
+    #1309 are about.
+
+    `seconds_per_pass` advances the poller's injected clock between passes, so a
+    backoff window can be crossed (or deliberately not crossed) without a test
+    that sleeps for five minutes. The default of 0.0 keeps every earlier
+    caller's timing semantics: passes back to back, no time elapsing.
+
+    `outcomes` is what the stubbed deploy path returns: one WebhookResult for
+    every call, or a list giving a different outcome per call -- which is what
+    lets a test prove a retry actually reached process_push and what it returned
+    when it did. The last entry of a list repeats once the list runs out.
+
+    `deployments` supplies the rows the deployments query returns on each pass,
+    as `(repo_full_name, environment, commit_sha)`. It defaults to no rows on
+    every pass, which is what every earlier caller already got. Supplying rows is
+    how a test stands in for the OTHER lane -- a webhook deploy the poller never
+    saw -- since that query is the only place its result is visible here.
     """
-    from contextlib import asynccontextmanager
-
     from curie_api import gitflow
-    from curie_api.commitpoller import CommitPoller
-    from curie_api.config import Settings
 
+    per_call = list(outcomes) if isinstance(outcomes, list) else [outcomes]
     calls = {"n": 0}
 
     async def counting(session, store, settings, eval_queue, payload):
+        outcome = per_call[min(calls["n"], len(per_call) - 1)]
         calls["n"] += 1
-        return result
+        return outcome
 
     snapshots = binding_snapshots or [("agent",)] * n
+    deployment_rows = deployments if deployments is not None else [[]] * n
     pass_index = {"value": 0}
 
-    class Session:
-        async def execute(self, stmt):
-            if "FROM curie.agents" in str(stmt):
-                return [(REPO, name) for name in snapshots[pass_index["value"]]]
-            return []
-
-    @asynccontextmanager
-    async def factory():
-        yield Session()
-
     monkeypatch.setattr(gitflow, "process_push", counting)
-    poller = CommitPoller(
-        session_factory=factory,
-        store=object(),
-        settings=Settings(github_clone_base="https://github.com"),
-        eval_queue=object(),
-        tips=Tips({(REPO, "dev"): "abc123", (REPO, "main"): None}),
-        interval_seconds=60,
+    poller, now = _poller_with_clock(
+        tips=tips or Tips({(REPO, "dev"): "abc123", (REPO, "main"): None}),
+        bindings_for_pass=lambda: [(REPO, name) for name in snapshots[pass_index["value"]]],
+        deployments_for_pass=lambda: deployment_rows[pass_index["value"]],
     )
     for _ in range(n):
         await poller.poll_once()
+        if after_pass is not None:
+            after_pass(poller, now["v"])
         pass_index["value"] += 1
-    return calls["n"]
+        now["v"] += seconds_per_pass
+    return calls["n"], poller
+
+
+async def _passes(
+    monkeypatch,
+    outcomes,
+    n: int = 2,
+    binding_snapshots: list[tuple[str, ...]] | None = None,
+    seconds_per_pass: float = 0.0,
+) -> int:
+    """How many of n passes reached the deploy path. See `_run_passes`."""
+
+    calls, _ = await _run_passes(
+        monkeypatch,
+        outcomes,
+        n=n,
+        binding_snapshots=binding_snapshots,
+        seconds_per_pass=seconds_per_pass,
+    )
+    return calls
 
 
 @pytest.mark.anyio
@@ -742,19 +827,483 @@ async def test_a_topology_rejection_waits_for_a_binding_change(monkeypatch, code
     ) == 2
 
 
+def _archive_failure(*extra_codes: str):
+    """A rejection carrying `git.archive_failed` plus any extra codes."""
+    from curie_api.schemas import WebhookResult
+
+    codes = ["git.archive_failed", *extra_codes]
+    return WebhookResult(status="rejected", errors=[{"code": code} for code in codes])
+
+
 @pytest.mark.anyio
 async def test_a_transient_clone_failure_IS_retried(monkeypatch) -> None:
     """The other side: remembering must not make a network blip permanent.
 
     An unreachable remote is the one rejection that says nothing about the
     commit, so suppressing its retry would strand a repository until the API
-    restarted.
+    restarted. #1309 bounds the RATE of those retries; it must not quietly turn
+    them into the terminal state #1267 gives every other rejection. With enough
+    time elapsing to clear even the hourly ceiling, every pass tries again.
+    """
+
+    assert await _passes(monkeypatch, _archive_failure(), n=4, seconds_per_pass=3600.0) == 4
+
+
+@pytest.mark.anyio
+async def test_a_repeatedly_failing_clone_is_not_recloned_every_pass(monkeypatch) -> None:
+    """AC2 of #1309. The regression: ~1,440 full clones a day for one sha.
+
+    Before this, `git.archive_failed` was retried on the very next pass and then
+    settled -- two clones, then silence. The suppression half of the fix is that
+    a second pass arriving before the backoff window has elapsed must not reach
+    process_push at all, because the mirror clone lives inside it.
+    """
+
+    assert await _passes(monkeypatch, _archive_failure(), n=4, seconds_per_pass=0.0) == 1
+
+
+@pytest.mark.anyio
+async def test_an_archive_failure_recovers_once_the_backoff_has_elapsed(monkeypatch) -> None:
+    """AC1 of #1309: one real timeout must stay recoverable.
+
+    The second pass runs exactly at `next_attempt_at`, reaches process_push, and
+    deploys. `_archive_backoff` being empty afterwards is the assertion that
+    matters: only the deployed branch pops the record, so a run that never got
+    past the filter -- or that got a second rejection -- would leave one behind.
     """
 
     from curie_api.schemas import WebhookResult
 
-    transient = WebhookResult(status="rejected", errors=[{"code": "git.archive_failed"}])
-    assert await _passes(monkeypatch, transient, n=4) == 2
+    calls, poller = await _run_passes(
+        monkeypatch,
+        [_archive_failure(), WebhookResult(status="deployed")],
+        n=2,
+        # Exactly _RETRY_BASE_DELAY_S: the window is "not before", so landing on
+        # the boundary is a retry, not a skip.
+        seconds_per_pass=300.0,
+    )
+    assert calls == 2, "the repaired repository never got its second clone"
+    assert poller._archive_backoff == {}, "a successful deploy left failure state behind"
+    assert poller._settled == {}, "a successful deploy must leave the database in charge"
+
+
+@pytest.mark.anyio
+async def test_the_backoff_window_holds_until_it_elapses(monkeypatch) -> None:
+    """AC1 of #1309, negative control: 299s is still inside the window.
+
+    299 and 300 seconds are the two sides of the same window, and asserting
+    both -- through the real filter, with no private state read -- is what pins
+    the boundary rather than merely the record's contents.
+    """
+
+    assert await _passes(monkeypatch, _archive_failure(), n=2, seconds_per_pass=299.0) == 1
+
+
+@pytest.mark.anyio
+async def test_the_retry_delay_grows_geometrically_and_is_capped(monkeypatch) -> None:
+    """AC2 of #1309: increasing, capped delay -- asserted in seconds.
+
+    The numbers are the point, so they are literals rather than recomputed from
+    the module's constants: 5m, 10m, 20m, 40m, then an hour that does NOT keep
+    doubling. The cap is what keeps a repository repaired later self-healing --
+    an uncapped schedule reaches days and is terminal in all but name.
+    """
+
+    delays: list[float] = []
+
+    def record(poller, now: float) -> None:
+        delays.append(poller._archive_backoff[(REPO, "dev")].next_attempt_at - now)
+
+    calls, _ = await _run_passes(
+        monkeypatch,
+        _archive_failure(),
+        n=6,
+        # Two hours clears every window, so all six passes really attempt.
+        seconds_per_pass=7200.0,
+        after_pass=record,
+    )
+    assert calls == 6
+    assert delays == [300.0, 600.0, 1200.0, 2400.0, 3600.0, 3600.0]
+
+
+@pytest.mark.anyio
+async def test_a_changed_failure_class_restarts_the_backoff(monkeypatch) -> None:
+    """AC2 of #1309: the count continues only for the SAME failure.
+
+    A rejection whose codes changed is a different failure -- the repository
+    moved from one problem to another -- and has not earned the accumulated
+    delay of the previous one. Without the codes in the record, the second
+    failure below would wait 600s on the strength of an unrelated first.
+    """
+
+    delays: list[float] = []
+
+    def record(poller, now: float) -> None:
+        delays.append(poller._archive_backoff[(REPO, "dev")].next_attempt_at - now)
+
+    await _run_passes(
+        monkeypatch,
+        [_archive_failure(), _archive_failure("deploy.ambiguous_env")],
+        n=2,
+        seconds_per_pass=7200.0,
+        after_pass=record,
+    )
+    assert delays == [300.0, 300.0], f"a different failure class inherited a delay: {delays}"
+
+
+@pytest.mark.anyio
+async def test_a_sustained_clone_failure_reports_the_lane_as_stalled(
+    monkeypatch, caplog
+) -> None:
+    """AC3 of #1309: an Error record after a defined consecutive threshold.
+
+    Two properties, and the second is the one that gets lost: nothing at ERROR
+    for the first two attempts (a blip must not page anyone), and the error
+    REPEATS on every attempt after the threshold. A lane parked at the hourly
+    ceiling that reported itself once, hours ago, is back to being silent --
+    which is the #1309 failure, not the fix for it.
+    """
+
+    seen: list[int] = []
+
+    def count_errors(poller, now: float) -> None:
+        seen.append(len([r for r in caplog.records if r.levelno >= logging.ERROR]))
+
+    with caplog.at_level(logging.ERROR, logger="curie_api.commitpoller"):
+        await _run_passes(
+            monkeypatch,
+            _archive_failure(),
+            n=4,
+            seconds_per_pass=7200.0,
+            after_pass=count_errors,
+        )
+
+    assert seen == [0, 0, 1, 2], f"errors after each attempt: {seen}"
+    errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    text = errors[0].getMessage()
+    assert REPO in text, f"the stalled repository must be named: {text}"
+    assert "NOT happening" in text, f"the record must say deploys have stopped: {text}"
+    assert "credential" in text, f"the record must point at the likely causes: {text}"
+
+
+@pytest.mark.anyio
+async def test_a_new_commit_is_attempted_while_the_old_backoff_is_open(monkeypatch) -> None:
+    """AC4 of #1309: failure state is per sha, and a new sha clears it.
+
+    The backoff is a statement about one commit, not about the repository
+    forever. Suppressing a NEW commit -- which may be the very push that fixes
+    the repository -- would be a worse outage than the one #1309 is about. The
+    negative control is `..._is_not_recloned_every_pass` above: same sha, same
+    zero elapsed time, one clone.
+    """
+
+    class MovingTip:
+        """A dev branch whose tip the test moves between passes."""
+
+        def __init__(self, sha: str) -> None:
+            self.sha = sha
+
+        def sha_for(self, repo_full_name: str, branch: str) -> str | None:
+            return self.sha if branch == "dev" else None
+
+    tips = MovingTip("abc123")
+
+    def push_a_new_commit(poller, now: float) -> None:
+        tips.sha = "def456"
+
+    calls, _ = await _run_passes(
+        monkeypatch,
+        _archive_failure(),
+        n=2,
+        # No time passes at all: the first sha's window is still wide open.
+        seconds_per_pass=0.0,
+        tips=tips,
+        after_pass=push_a_new_commit,
+    )
+    assert calls == 2, "a new commit was suppressed by the previous commit's backoff"
+
+
+@pytest.mark.anyio
+async def test_a_successful_deploy_resets_the_attempt_count(monkeypatch) -> None:
+    """AC4 of #1309: a deploy clears the record, it does not just pause it.
+
+    If the record survived a success, the next unrelated failure would inherit
+    the old attempt count -- backing off for 10 minutes on a first blip and
+    reporting a stalled lane one failure early.
+    """
+
+    from curie_api.schemas import WebhookResult
+
+    calls, poller = await _run_passes(
+        monkeypatch,
+        [_archive_failure(), WebhookResult(status="deployed"), _archive_failure()],
+        n=3,
+        seconds_per_pass=7200.0,
+    )
+    assert calls == 3
+    assert poller._archive_backoff[(REPO, "dev")].attempts == 1, (
+        "the failure after a successful deploy continued the old count"
+    )
+
+
+@pytest.mark.anyio
+async def test_a_lane_failing_for_weeks_keeps_retrying_instead_of_crashing(
+    monkeypatch,
+) -> None:
+    """AC2 of #1309: the hourly ceiling must be a ceiling, not a crash loop.
+
+    `_RETRY_BASE_DELAY_S * 2 ** (attempts - 1)` evaluates the exponent in full
+    before `min` clamps anything, and at attempt 1,025 that float multiplication
+    raises OverflowError. A repository that fails every attempt reaches 1,025 in
+    roughly 43 days at the hourly ceiling -- well inside the life of an API pod.
+    The exception escapes poll_once before the new record is stored, so the
+    already-expired record survives and the lane clones again on every single
+    interval: exactly the ~1,440-clones-a-day regression #1309 exists to end,
+    now permanent instead of transient.
+
+    Driven through the real poll_once with no private state seeded, so on the
+    unfixed code pass 1,025 raises out of poll_once and this errors -- there is
+    no run_forever here to swallow it.
+    """
+
+    calls, _ = await _run_passes(
+        monkeypatch,
+        _archive_failure(),
+        n=1026,
+        # Two hours clears even the hourly ceiling, so every pass really
+        # attempts and the attempt count really reaches 1,026.
+        seconds_per_pass=7200.0,
+    )
+    assert calls == 1026, f"the poll pass stopped attempting after {calls}"
+
+
+@pytest.mark.anyio
+async def test_a_deploy_from_the_webhook_lane_clears_the_backoff(monkeypatch) -> None:
+    """AC4 of #1309: a successful deploy is a successful deploy, either lane.
+
+    The backoff record was cleared only when the POLLER itself saw a deploy. The
+    webhook lane runs the same process_push without going near the poller, so:
+    the poller fails on sha A and writes a 5-minute record; the webhook deploys
+    sha B on that branch; the branch is rolled back to A. A is a move again, the
+    stale record still matches it, its window is still open -- and the rollback
+    is suppressed, even though the deploy of B is direct evidence the repository
+    is clonable again. The poller must not sit on a stale failure for a branch
+    the platform has since deployed.
+
+    The negative control is `..._is_not_recloned_every_pass` above: same sha, no
+    time elapsed, NO deployment change, one clone.
+    """
+
+    # Two more shas of the same shape as REAL_SHA, because this scenario needs
+    # three distinct commits at once -- reusing REAL_SHA for both sides of a
+    # rollback would prove nothing.
+    polled_sha = "b" * 40
+    webhook_sha = "c" * 40
+
+    calls, _ = await _run_passes(
+        monkeypatch,
+        _archive_failure(),
+        n=2,
+        # No time passes at all: A's window is still wide open on pass 2, so the
+        # only thing that can let it through is the deployment of B.
+        seconds_per_pass=0.0,
+        tips=Tips({(REPO, "dev"): polled_sha, (REPO, "main"): None}),
+        deployments=[[], [(REPO, "dev", webhook_sha)]],
+    )
+    assert calls == 2, "a rollback was suppressed by a failure the other lane already fixed"
+
+
+@pytest.mark.anyio
+async def test_each_deploy_branch_backs_off_on_its_own_schedule(monkeypatch) -> None:
+    """AC2 of #1309: "the same failure" includes the BRANCH, not just the repo.
+
+    Every other test here exercises one branch, because the shared fixture
+    gives `main` no tip and so only `dev` ever moves. That leaves the branch
+    dimension of the key unpinned: a record keyed on the repository alone would
+    have both deploy branches sharing one backoff, and each branch's failure
+    would evict the other's record on every single pass -- so neither window
+    would ever suppress anything and the repository would be back to a full
+    mirror clone per branch per interval, which is the #1309 regression itself.
+
+    Both branches are given a real, distinct tip so both move on every pass,
+    and both fail the same way. What proves the isolation is that the third
+    pass clones NOTHING: two independent windows, each opened by that branch's
+    own second failure, are both still shut.
+    """
+
+    dev_sha = "d" * 40
+    main_sha = "e" * 40
+
+    attempts: dict[tuple[str, str], list[int]] = {}
+
+    def record(poller, now: float) -> None:
+        for key, backoff in poller._archive_backoff.items():
+            attempts.setdefault(key, []).append(backoff.attempts)
+
+    calls, poller = await _run_passes(
+        monkeypatch,
+        _archive_failure(),
+        n=3,
+        # One base window per pass: pass 2 lands exactly on `next_attempt_at`
+        # and retries, and pass 3 lands inside the 600s that second failure
+        # earned -- for BOTH branches, if each really has its own record.
+        seconds_per_pass=300.0,
+        tips=Tips({(REPO, "dev"): dev_sha, (REPO, "main"): main_sha}),
+        after_pass=record,
+    )
+
+    assert calls == 4, (
+        "two branches over three passes should clone twice each and then be "
+        f"suppressed together, not {calls} times"
+    )
+    assert set(poller._archive_backoff) == {(REPO, "dev"), (REPO, "main")}, (
+        f"the two deploy branches did not get their own records: {poller._archive_backoff}"
+    )
+    assert poller._archive_backoff[(REPO, "dev")].sha == dev_sha
+    assert poller._archive_backoff[(REPO, "main")].sha == main_sha
+    # Each branch failed twice, at t=0 and t=300, so each has earned 600s from
+    # its own second failure -- a shared counter would read 1 or 4, never 2 on
+    # both.
+    assert attempts == {
+        (REPO, "dev"): [1, 2, 2],
+        (REPO, "main"): [1, 2, 2],
+    }, f"the two branches did not count their failures separately: {attempts}"
+    assert poller._archive_backoff[(REPO, "dev")].next_attempt_at == 900.0
+    assert poller._archive_backoff[(REPO, "main")].next_attempt_at == 900.0
+
+
+# --------------------------------------------------------------------------- #
+# Driving a real subprocess timeout through the whole lane (#1309, AC5)
+# --------------------------------------------------------------------------- #
+def _timing_out_git(calls: list[list[str]]):
+    """A `subprocess.run` that always times out, recording each invocation.
+
+    120s is the timeout `clone_and_archive` actually passes, and both the clone
+    and the archive use it. A repository too large to clone inside it fails this
+    way on every attempt, forever -- which is the case #1309 exists for, and the
+    one PR #1289 classified as transient.
+
+    The received `timeout` keyword is recorded too, on the returned callable's
+    `.timeouts` attribute, so a caller that wants to pin the bound (rather than
+    just observe argv) can without changing the `calls` list every existing
+    caller already asserts on.
+    """
+    timeouts: list[object] = []
+
+    def run(*args, **kwargs):
+        calls.append(list(args[0]) if args else [])
+        timeouts.append(kwargs.get("timeout"))
+        raise subprocess.TimeoutExpired(cmd=args[0] if args else ["git"], timeout=120)
+
+    run.timeouts = timeouts
+    return run
+
+
+def test_a_clone_timeout_becomes_a_gitflow_error(monkeypatch) -> None:
+    """AC5 of #1309, layer one: TimeoutExpired through `clone_and_archive`.
+
+    `clone_and_archive` catches TimeoutExpired alongside CalledProcessError and
+    re-raises GitFlowError. That conversion is the reason a timeout arrives at
+    the poller as a rejection rather than as a crashed poll pass. The 120s bound
+    itself is pinned here too: an unbounded git clone is a poll pass that never
+    returns, and the bound is what makes the failure a rejection the backoff can
+    classify rather than a hang.
+    """
+
+    from curie_api import gitflow
+    from curie_api.config import Settings
+
+    calls: list[list[str]] = []
+    fake_run = _timing_out_git(calls)
+    monkeypatch.setattr("curie_api.gitflow.subprocess.run", fake_run)
+
+    with pytest.raises(gitflow.GitFlowError):
+        gitflow.clone_and_archive(
+            CLONE,
+            REAL_SHA,
+            Settings(github_clone_base="https://github.com"),
+            repo_full_name=REPO,
+            ref="refs/heads/dev",
+        )
+    assert calls and calls[0][:1] == ["git"], "the timeout must come from the git clone"
+    assert fake_run.timeouts[0] == 120, "clone_and_archive must bound the clone at 120s"
+
+
+@pytest.mark.anyio
+async def test_process_push_reports_a_clone_timeout_as_archive_failed(monkeypatch) -> None:
+    """AC5 of #1309, layer two: TimeoutExpired through `process_push`.
+
+    This pins the code the poller classifies on. If a timeout ever stopped
+    mapping to `git.archive_failed`, the backoff would never engage and the
+    rejection would settle terminally instead -- silently, on the lane with no
+    GitHub delivery UI. No database: `process_push` reaches the clone after only
+    `crud.get_agents_by_repo`.
+    """
+
+    from curie_api import crud, gitflow
+    from curie_api.config import Settings
+
+    class StubAgent:
+        repo_full_name = REPO
+        name = "agent"
+
+    async def one_agent(session, full_name):
+        return [StubAgent()]
+
+    monkeypatch.setattr(crud, "get_agents_by_repo", one_agent)
+    monkeypatch.setattr("curie_api.gitflow.subprocess.run", _timing_out_git([]))
+
+    result = await gitflow.process_push(
+        object(),
+        object(),
+        Settings(github_clone_base="https://github.com"),
+        object(),
+        Move(REPO, CLONE, "dev", REAL_SHA).as_push_payload(),
+    )
+    assert result.status == "rejected"
+    assert [e.get("code") for e in (result.errors or [])] == ["git.archive_failed"]
+
+
+@pytest.mark.anyio
+async def test_a_permanently_timing_out_repository_stops_being_recloned(
+    monkeypatch, caplog
+) -> None:
+    """AC5 of #1309, layer three: repeated poll_once over the REAL deploy path.
+
+    The end-to-end proof, and the only test here that counts actual git
+    invocations rather than a fake's calls. Forty passes at the recommended 60s
+    interval is forty full mirror clones today; under the backoff the same forty
+    passes clone at t=0, 300, 900 and 2100 seconds -- four attempts -- and the
+    lane reports itself stalled instead of going quiet.
+    """
+
+    from curie_api import crud
+
+    class StubAgent:
+        repo_full_name = REPO
+        name = "agent"
+
+    async def one_agent(session, full_name):
+        return [StubAgent()]
+
+    clones: list[list[str]] = []
+    monkeypatch.setattr(crud, "get_agents_by_repo", one_agent)
+    monkeypatch.setattr("curie_api.gitflow.subprocess.run", _timing_out_git(clones))
+
+    # The same plumbing `_run_passes` builds, minus its counting stub: this test
+    # drives the REAL `process_push`, so the clones it counts are real git
+    # invocations. The default row sources are exactly what it needs -- one
+    # binding, no deployments, on every pass.
+    poller, now = _poller_with_clock(tips=Tips({(REPO, "dev"): REAL_SHA, (REPO, "main"): None}))
+    with caplog.at_level(logging.ERROR, logger="curie_api.commitpoller"):
+        for _ in range(40):
+            await poller.poll_once()
+            now["v"] += 60.0
+
+    assert len(clones) == 4, f"40 polls produced {len(clones)} clone attempts"
+    errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert errors, "a repository failing every attempt must report the lane as stalled"
+    assert "NOT happening" in errors[0].getMessage()
 
 
 @pytest.mark.anyio

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -334,6 +334,12 @@ clearing it (`--clear-github-token`) does not restart the API pod
 automatically; `cluster up` prints the exact restart command to run, and
 until you run it the API keeps using the old value.
 
+On the commit-polling lane, a repeated `git.archive_failed` for the same
+commit now backs off geometrically -- five minutes, then ten, twenty,
+forty, to a one-hour ceiling -- instead of re-cloning every poll interval,
+and after three consecutive failures the API logs an error saying deploys
+from that repository are NOT happening (#1309).
+
 Once wired, a push to the agent's dev branch builds and deploys under its
 dev bot identity; a push or merge to its prod branch promotes that same
 built artifact without rebuilding.


### PR DESCRIPTION
Closes #1309

## The defect

`git.archive_failed` says nothing about the commit — one code covers a subprocess error, a clone timeout and an archive timeout — so #1289 made it the one rejection the commit poller retried. It retried once, on the very next pass, then settled that sha forever with nothing logged.

Neither half is right. A repository that is unreachable, unauthorized, missing its clone credential, or too large to clone inside the 120s timeout fails identically on every attempt, so the "retry" was two full mirror clones inside two minutes followed by silence: no adaptive backoff, and nothing an operator could find when a deploy lane had stopped.

## What changed

Repeated failures of the **same class for the same sha** now wait geometrically longer before earning another clone — 5m, 10m, 20m, 40m, then an hourly ceiling — turning the worst case on the recommended 60s interval from ~1,440 clone attempts a day into 24. The check sits **before** `process_push`, because the mirror clone lives inside it and a skip decided any later has already paid for it.

The delay is **capped rather than terminal** on purpose. A private repository whose clone credential arrives an hour after the binding is exactly the shape `docs/operations.md` documents, and a terminal state would strand it until someone pushed a new commit or restarted the API. The bound is on the *rate*; from the third consecutive failure the lane reports itself at ERROR and keeps doing so, so a lane parked at the ceiling is findable rather than quiet.

The exponent is clamped, not just the product: `2 ** (attempts - 1)` is evaluated in full before `min` sees it, and at attempt 1,025 — about 43 days at the ceiling — that multiplication raises `OverflowError`, which would escape before the new record was stored and leave the expired one in place, putting the lane back to a clone every interval.

Failure state clears on both conditions the issue names. The attempt count continues only while the sha **and** the failure codes hold, so a new commit is never suppressed by the previous one's window; and a deployment on the branch retires the record **whichever lane produced it**, so a webhook deploy followed by a rollback is not blocked by a failure the platform has already disproved.

## Acceptance criteria

| AC | Evidence |
|---|---|
| 1. Recoverable after one transient failure | `_RETRYABLE_REJECTIONS` never settles; the record expires. `test_an_archive_failure_recovers_once_the_backoff_has_elapsed` deploys on pass 2 and asserts the record is cleared; `test_the_backoff_window_holds_until_it_elapses` is the 299s negative control. |
| 2. Increasing capped delay, per repo + branch + sha + failure class | All four gate the count continuation (key is `(repo, branch)`; `previous.sha`; `previous.codes`). `test_the_retry_delay_grows_geometrically_and_is_capped` asserts `[300, 600, 1200, 2400, 3600, 3600]`; `test_a_changed_failure_class_restarts_the_backoff` asserts `[300, 300]`; `test_each_deploy_branch_backs_off_on_its_own_schedule` pins the branch dimension. |
| 3. Error record after a defined threshold | `logger.error` at `_RETRY_ERROR_ROUNDS = 3` — the same construct the file already uses for sustained GitHub throttling (#1269). `test_a_sustained_clone_failure_reports_the_lane_as_stalled` asserts `[0, 0, 1, 2]`: silent below the threshold, re-emitted after. |
| 4. State clears on sha change or successful deploy | Sha change deletes the record; a poller deploy pops it; a **webhook-lane** deploy prunes it via the branch's last-deployed sha. `test_a_deploy_from_the_webhook_lane_clears_the_backoff` drives fail-A → webhook-deploys-B → rollback-to-A. |
| 5. TimeoutExpired through all three call sites | A real `subprocess.TimeoutExpired`, not a hand-built rejection: through `clone_and_archive` (asserts `GitFlowError` and the 120s bound), through `process_push` (asserts `git.archive_failed`), and through 40 repeated `poll_once` passes on the **real** deploy path — 40 polls, 4 clones, and the stalled-lane error. |

## Verification

Red-on-revert, each mutation executed and its failure recorded:

| Mutation | Result |
|---|---|
| Backoff window never suppresses | `assert 4 == 1`, `assert 2 == 1`, `40 polls produced 40 clone attempts` |
| Exponent left unclamped | `OverflowError: int too large to convert to float` |
| Cross-lane prune removed | `a rollback was suppressed by a failure the other lane already fixed` |
| ERROR threshold moved 3 → 99 | `errors after each attempt: [0, 0, 0, 0]` |
| Branch dropped from the key | `two branches over three passes should clone twice each` |

Checks: `pytest apps/api` 1111 passed / 7 failed, `ruff check .` clean, `mypy` clean (193 files), `lint-imports` 4 contracts kept, `scripts/check-docs.sh` OK. The 7 failures are `httpx.ReadTimeout` against Langfuse in the local compose stack and reproduce **identically on pristine `origin/main`** in the same environment (control run: same 7 tests, same error) — environmental, not this diff.

Reviewed cross-engine by Codex (read-only), which raised the `OverflowError` and the cross-lane-deploy findings above; both are fixed and covered. A consolidation pass followed, re-reviewed with no findings.

## Deliberate calls worth a maintainer's eye

- **The first retry now waits 300s rather than one poll interval.** AC 1 constrains terminality, not latency, and AC 2 mandates a delay on repeated failure — but this is a real behaviour change from #1289's next-pass retry.
- **Capped, not terminal.** A permanently broken repository keeps costing 24 clones a day forever rather than stopping. The trade buys self-healing without an API restart; a bounded attempt policy would be the other reading of AC 2.
- **Backoff lives in process memory**, matching the existing `_settled`: a pod restart re-clones once.

## Follow-ups (not filed)

- Retryable/terminal classification lives in the poller, mirroring the existing `_TOPOLOGY_REJECTIONS` pattern. It arguably belongs with the producer (`gitflow.process_push`) so every lane inherits it.
- `git.archive_failed` conflates permanent and transient causes; distinguishing them at the source would let truly permanent errors settle terminally.
- `_archive_backoff` and `_settled` both retain entries for bindings that later disappear — pre-existing shape, now on two dicts.