### PR TITLE
Say when a workspace selection is refused, instead of ending the turn silently

### DIFF
--- a/apps/worker/src/curie_worker/kernel.py
+++ b/apps/worker/src/curie_worker/kernel.py
@@ -2166,6 +2166,31 @@ class Kernel:
             return TurnOutcome(terminal_ok=True)
         except WorkspaceSelectionRefused as exc:
             release_order()
+            # LOG it, not only reply (#2004). This was the one turn-ending branch
+            # in this handler that ended a turn silently, and it ends it with no
+            # sandbox: `WorkspaceSelectionRefused` subclasses
+            # `WorkspacePreparationError`, so this narrower `except` runs first
+            # and the turn never reaches the sibling below that logs "turn start
+            # failed".
+            #
+            # The reply covers a person in Slack, who reads the refusal and acts
+            # on it. It covers nobody when the turn came from a hook: there is no
+            # placeholder to edit and no one watching, so an acknowledged entry
+            # with no sandbox and no log is indistinguishable from an idle bot --
+            # and the last change anyone made was a boolean they would not
+            # connect to it.
+            #
+            # info rather than warning: a refusal is this feature working as
+            # designed, and routing routine policy outcomes to warning is how
+            # warnings stop being read. It names the agent because that is the
+            # only thing an operator chasing a silent bot has to search on.
+            logger.info(
+                "workspace selection refused for agent=%s deployment=%s thread=%s: %s",
+                agent_name,
+                workspace_deployment_id,
+                thread_key,
+                exc.public_detail,
+            )
             await self._reply_for(qevent, route, exc.public_detail)
             return TurnOutcome(terminal_ok=True)
         except (

--- a/apps/worker/tests/kernel/test_kernel.py
+++ b/apps/worker/tests/kernel/test_kernel.py
@@ -399,6 +399,75 @@ def test_workspace_selection_precedes_fresh_thread_greeting(make_harness) -> Non
     asyncio.run(go())
 
 
+def test_a_selection_refusal_is_logged_so_an_operator_can_find_it(
+    make_harness, caplog
+) -> None:
+    """The refusal ends the turn; without a log line it ends it invisibly (#2004).
+
+    `WorkspaceSelectionRefused` subclasses `WorkspacePreparationError`, so its
+    narrower `except` runs first and the turn never reaches the sibling branch
+    that logs "turn start failed". Every other turn-ending branch in that handler
+    logs; this one did not.
+
+    The reply covers the Slack case, where the person who asked reads the
+    refusal. It covers nothing when the turn came from a hook: there is no
+    placeholder to edit and no one watching, so an acknowledged entry with no
+    sandbox and no log is indistinguishable from an idle bot -- which is exactly
+    how this was found, and the whole of the reported defect.
+
+    Asserts the agent is named, because "no line naming the agent" is what made
+    the live install unsearchable.
+    """
+
+    class WorkspaceResolved(_FakeResolved):
+        def __init__(self) -> None:
+            super().__init__(uuid.uuid4())
+            self.deployment_id = uuid.uuid4()
+            self.workspace_enabled = True
+
+    class WorkspaceBinding:
+        async def resolve(self, _kind: str, _channel: str) -> WorkspaceResolved:
+            return WorkspaceResolved()
+
+        def boot_env(
+            self,
+            _resolved: object,
+            _thread_key: str,
+            *,
+            kind: str | None = None,
+            address: str | None = None,
+        ) -> dict[str, str]:
+            return {}
+
+        def packs_for(self, _resolved: object) -> BehaviorPacks:
+            return BehaviorPacks.from_config({})
+
+    async def go() -> None:
+        async with make_harness(binding=WorkspaceBinding()) as h:
+            class WorkspaceProbe:
+                def select_repository(self, **kwargs: object) -> str:
+                    raise WorkspaceSelectionRefused(
+                        "Start the thread by naming one allowed root GitHub "
+                        "repository URL."
+                    )
+
+            h.kernel._workspace = WorkspaceProbe()  # type: ignore[assignment]
+            with caplog.at_level(logging.INFO, logger="curie_worker.kernel"):
+                await h.kernel.process_event(_qevent("hi", thread="tRefusalLog"))
+
+            assert h.runner.opened == []
+            logged = "\n".join(record.getMessage() for record in caplog.records)
+            assert "test-agent" in logged, (
+                "the refusal log must name the agent; an operator searching for "
+                f"a silent bot has only that to search on. Got: {logged!r}"
+            )
+            assert "naming one allowed root GitHub repository" in logged, (
+                f"the refusal log must carry the reason. Got: {logged!r}"
+            )
+
+    asyncio.run(go())
+
+
 def test_tool_notes_are_consumed_without_reaching_user_facing_updates(
     make_harness,
 ) -> None:


### PR DESCRIPTION
Setting `workspace_enabled: true` made turns **disappear** (#2004). The queue entry was consumed and acknowledged, no sandbox was created, and the worker logged nothing at all — no error, no warning, no line naming the agent. From every surface an operator looks at, the bot was simply idle.

## Root cause

One missing log line, and *where* it is missing is the interesting part.

`WorkspaceSelectionRefused` subclasses `WorkspacePreparationError`, so its narrower `except` in `_attempt` runs **before** the sibling that logs `"turn start failed for %s"`. Every other turn-ending branch in that handler logs — `CapacityExhaustedError`, two lines up, logs *and* replies exactly like this one does:

| branch | logs? |
|---|---|
| `CapacityExhaustedError` | `logger.warning(...)` |
| **`WorkspaceSelectionRefused`** | **nothing** |
| `RunnerError` / `SandboxError` / `WorkspacePreparationError` | `logger.warning("turn start failed…")` |

Confirmed against the live install: the endpoint the worker calls returns a 409 carrying a refusal code, which becomes `WorkspaceSelectionRefused`, which ends the turn `terminal_ok=True` — acked, no sandbox, no log.

```
POST /v1/internal/workspaces/<id>/selection   (no repo named, as a hook turn sends)
→ 409 {"detail":{"code":"workspace.deployment_disabled", ...}}
```

## Why the existing reply was not enough

The reply was never the problem for a person in Slack: they read *"Start the thread by naming one allowed root GitHub repository URL"* and act on it.

It is the whole problem for a turn that came from a **hook**. There is no placeholder to edit and nobody watching, so an acknowledged entry with no sandbox and no log reads as a bot that stopped answering — with nothing to go on, and the last change anyone made was a boolean they would not connect to it. That is how this was found.

## The choice of level

`info`, not `warning`: a selection refusal is the feature working as designed, and routing routine policy outcomes to warning is how warnings stop being read. It carries the agent, the deployment, the thread and the reason — the agent because that is the only thing an operator chasing a silent bot has to search on.

## Verification

The test asserts the log names the agent and the reason. Without the fix it fails with:

```
AssertionError: the refusal log must name the agent; an operator searching for
a silent bot has only that to search on. Got: ''
```

`apps/worker/tests/kernel/` → 286 passed. One unrelated failure, `test_dead_letter_emits_one_retention_independent_critical_alert`, reproduces identically on the unmodified base and is green in CI on the same commit, so it is a local-environment difference and not from this change.

## Not addressed here

Whether a hook-originated turn should surface a refusal anywhere a person can see it. That is a real gap and a larger question than this one — which is that the operator's own logs did not record the event at all.

Closes #2004