### PR TITLE
Keep the mail-adapter transport cause and back off repeated failed polls

### DIFF
--- a/apps/mail-adapter/README.md
+++ b/apps/mail-adapter/README.md
@@ -125,7 +125,7 @@ stray generic `PORT` or `POLL_INTERVAL` in the pod environment cannot reach one.
 | `CURIE_CHANNEL_TOKEN` | "" | the scoped `chn` token, sent as `X-API-Key` on ingress. Required |
 | `CURIE_EGRESS_SECRET` | "" | shared secret the platform presents on `X-Curie-Adapter-Secret`. Required |
 | `ADAPTER_INGRESS_ENABLED` | `true` | gates the poller only, never the egress server |
-| `CURIE_MAIL_POLL_INTERVAL_SECONDS` | `5.0` | seconds between listings; must be greater than zero |
+| `CURIE_MAIL_POLL_INTERVAL_SECONDS` | `5.0` | seconds between listings; must be greater than zero. A transport failure or 429 arms bounded exponential backoff on top, up to 60s, reset by the next successful listing |
 | `CURIE_MAIL_INGRESS_ATTEMPTS` | `3` | short in-process attempts for transport ambiguity and retryable status; durable retry continues after this budget |
 | `CURIE_MAIL_INGRESS_RETRY_DELAY_SECONDS` | `2.0` | base delay between those attempts; 429 may extend it with `Retry-After` |
 | `CURIE_MAIL_PORT` | `8080` | port the egress server binds |

--- a/apps/mail-adapter/src/curie_mail_adapter/adapter.py
+++ b/apps/mail-adapter/src/curie_mail_adapter/adapter.py
@@ -29,6 +29,11 @@ POLL_LIMIT = 20
 POLL_MAX_PAGES = 5
 BACKOFF_STEP_SECONDS = 5.0
 BACKOFF_MAX_SECONDS = 60.0
+# Status 0 is a transport failure and 429 is provider rate limiting; both mean
+# "slow down", and neither did except 429, so a provider outage re-polled at the
+# normal cadence and burst a warning per pass (373 in 24h in the soak, #2012).
+POLL_BACKOFF_STATUSES = frozenset({0, 429})
+CAUSE_MAX_CHARS = 120
 REJECTED_LABELS = frozenset({"unauthenticated", "spam", "blocked"})
 
 
@@ -137,10 +142,21 @@ class MailAdapter:
             if self.shutdown.is_set():
                 return
             status = self.poll_once()
-            if status == 429:
+            if status in POLL_BACKOFF_STATUSES:
                 backoff = min(backoff * 2 + BACKOFF_STEP_SECONDS, BACKOFF_MAX_SECONDS)
-                logger.warning("poll: 429 rate limited, backing off %ss", backoff)
-            else:
+                logger.warning(
+                    "poll: status=%s, backing off %ss before the next discovery pass",
+                    status,
+                    backoff,
+                )
+            # Only a successful listing proves the provider recovered, so it is the
+            # only thing that clears the delay. A 5xx does not arm the backoff -
+            # that stays deliberately out of this issue's scope - but it must not be
+            # able to un-arm one either: an outage is rarely one failure mode end to
+            # end, and letting a mid-outage 500 reset the delay puts the poller back
+            # on its normal cadence in the middle of the outage, which is the exact
+            # warning burst this backoff exists to stop.
+            elif status == 200:
                 backoff = 0.0
 
     def poll_once(self) -> int:
@@ -152,7 +168,11 @@ class MailAdapter:
         for _ in range(POLL_MAX_PAGES):
             status, page = self.client.list_messages(POLL_LIMIT, page_token)
             if status != 200 or not isinstance(page, dict):
-                logger.warning("poll: list failed with status=%s", status)
+                logger.warning(
+                    "poll: list failed with status=%s cause=%s",
+                    status,
+                    self._transport_cause(status, page),
+                )
                 self.page_cursor = None
                 return status
             messages = [item for item in page.get("messages", []) if isinstance(item, dict)]
@@ -208,6 +228,50 @@ class MailAdapter:
                     _correlation(message_id),
                 )
         return status
+
+    def _transport_cause(self, status: int, body: Any) -> str:
+        """Render a failed list call's cause as a bounded, credential-free string.
+
+        Status is the gate, not the body's shape. Only a status 0 body is one
+        this package synthesized locally: ``agentmail.request`` builds
+        ``{"error": str(exc)}`` for an ``OSError`` and ``{"error": "response
+        body exceeds configured byte limit"}`` for an oversize response, both
+        local strings with a shape the adapter can reason about. Every other
+        status carries a body the PROVIDER authored - arbitrary, unbounded, and
+        able to carry mail content, an upstream stack trace or a page of HTML -
+        including one that happens to hold an ``error`` key. Such a body is
+        never rendered, only counted by its status code, because logging any
+        part of it would breach this package's no-mail-PII rule and push
+        whatever the provider felt like sending into the cluster's log
+        retention. That is a structural refusal at the top of this helper rather
+        than a condition at the call site, so a future caller cannot reintroduce
+        the exposure by passing a provider payload in.
+
+        The budget is a fixed constant rather than a config knob because the
+        size of a log line must not be something a hostile or broken provider
+        can grow, and an operator cannot tune a value they only discover after
+        the disk filled. The redaction pass is defence in depth: ``str(OSError)``
+        from urllib carries no request header today, but the adapter must not
+        depend on a stdlib rendering staying that way.
+        """
+        if status != 0:
+            return "unavailable"
+        if not isinstance(body, dict):
+            return "unavailable"
+        error = body.get("error")
+        if not isinstance(error, str) or not error.strip():
+            return "unavailable"
+        cause = " ".join(error.split())
+        for credential in (
+            self.config.agentmail_api_key,
+            self.config.channel_token,
+            self.config.egress_secret,
+        ):
+            if credential:
+                cause = cause.replace(credential, "[redacted]")
+        if len(cause) > CAUSE_MAX_CHARS:
+            cause = cause[:CAUSE_MAX_CHARS] + "..."
+        return cause
 
     def _retry_pending(self) -> None:
         for pending in self.state.pending():

--- a/apps/mail-adapter/tests/_support.py
+++ b/apps/mail-adapter/tests/_support.py
@@ -77,6 +77,9 @@ class MailState:
         self.threads: dict[str, list[dict[str, Any]]] = {}
         self.replies: list[tuple[str, str]] = []  # (in_reply_to_message_id, text)
         self.list_calls = 0
+        # time.monotonic() per list call, so the retry CADENCE is observable at
+        # the real external seam rather than inferred from the adapter's logs.
+        self.list_times: list[float] = []
         self.list_queries: list[dict[str, str]] = []  # the parsed query of each list call
         self.list_authorization: list[str] = []
         self.thread_calls = 0
@@ -93,6 +96,23 @@ class MailState:
         self.fail_next_list: int | None = None
         self.fail_next_body: int | None = None
         self.fail_next_thread: int | None = None
+        # The body a NON-ZERO injected failure answers with, when a test needs
+        # to choose it. Provider-authored failure bodies are exactly what the
+        # adapter must never render into a log, and putting recognisable content
+        # in one is the only way a test can prove it never does.
+        self.injected_body: dict[str, Any] | None = None
+        # N CONSECUTIVE transport failures on List Messages before answering
+        # normally, mirroring `IngressState.drop_next`. `fail_next_list` is
+        # one-shot and so cannot express a repeated outage, which is the whole
+        # subject of #2012: one dropped call is noise, a sustained one is the
+        # condition the poller has to slow down for.
+        self.drop_next_lists = 0
+        # The index into `list_times` of every list call answered with a dropped
+        # connection, so a test can judge the retry cadence by the gaps it KNOWS
+        # were failures rather than inferring them from elapsed time on a shared
+        # box, where a descheduled normal poll is indistinguishable from a
+        # backed-off one.
+        self.dropped_list_indexes: list[int] = []
         # Provider accepted the reply and exposed it in the thread, but the
         # HTTP response disappeared. Recovery must resolve this from the
         # provider-visible event witness rather than sending again.
@@ -266,7 +286,8 @@ class MailHandler(_JsonHandler):
         if failure == 0:
             self.close_connection = True  # a real transport failure
             return True
-        self._send(failure, {"detail": "injected provider failure"})
+        body = self.state.injected_body
+        self._send(failure, body if body is not None else {"detail": "injected provider failure"})
         return True
 
     def do_GET(self) -> None:
@@ -276,8 +297,15 @@ class MailHandler(_JsonHandler):
         if len(parts) == 4 and parts[3] == "messages":
             query = self._query()
             state.list_calls += 1
+            state.list_times.append(time.monotonic())
             state.list_queries.append(query)
             state.list_authorization.append(self.headers.get("Authorization") or "")
+            if state.drop_next_lists > 0:
+                state.drop_next_lists -= 1
+                # `list_times` was appended above, so this is that call's index.
+                state.dropped_list_indexes.append(len(state.list_times) - 1)
+                self.close_connection = True  # a real transport failure
+                return
             failure, state.fail_next_list = state.fail_next_list, None
             if self._injected(failure):
                 return

--- a/apps/mail-adapter/tests/test_poll_transport.py
+++ b/apps/mail-adapter/tests/test_poll_transport.py
@@ -1,0 +1,341 @@
+"""What the poller does when the provider connection drops on the listing.
+
+Two properties, both observed at the real external seam: the CAUSE the adapter
+records for a failed discovery pass, and the CADENCE at which it retries after
+one. A 24h soak of the deployed adapter produced 373 identical
+`poll: list failed with status=0` warnings (#2012) — the numeric status was the
+whole record, so the outage was undiagnosable from the log, and because status 0
+reset the backoff the poller kept hammering the dead endpoint at its normal
+interval. The fix reads the structured body `agentmail.request` already builds
+and arms the existing bounded backoff for transport failures too; these tests
+pin both halves, plus the reset that must still happen on recovery.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from collections.abc import Callable
+
+import curie_mail_adapter.adapter as adapter_module
+import pytest
+from _support import (
+    AGENTMAIL_API_KEY,
+    CHANNEL_TOKEN,
+    EGRESS_SECRET,
+    IngressState,
+    MailState,
+    wait_until,
+)
+from curie_mail_adapter.adapter import MailAdapter
+
+FAILURE_PREFIX = "poll: list failed"
+
+
+def _failure_record(caplog: pytest.LogCaptureFixture) -> str:
+    """The single discovery-failure warning, as the operator would read it."""
+    messages = [
+        record.getMessage()
+        for record in caplog.records
+        if record.getMessage().startswith(FAILURE_PREFIX)
+    ]
+    assert len(messages) == 1, f"expected exactly one {FAILURE_PREFIX!r} warning: {messages}"
+    return messages[0]
+
+
+def test_a_dropped_list_call_records_a_bounded_safe_cause(
+    mail: MailState,
+    ingress: IngressState,
+    adapter: MailAdapter,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A transport failure is logged with its cause, bounded and credential-free.
+
+    A numeric status alone is what made the soak undiagnosable: DNS failure,
+    refused connection, TLS error and read timeout all arrive as status 0, and
+    the structured body that distinguishes them was being discarded at the one
+    place an operator would look. Reading it back is the fix; the character
+    budget is what keeps a hostile or merely verbose provider string from
+    becoming the log line, and the redaction pass is why a cause can be logged
+    at all without risking the adapter's three credentials.
+    """
+    mail.drop_next_lists = 1
+
+    with caplog.at_level(logging.WARNING, logger="curie_mail_adapter.adapter"):
+        status = adapter.poll_once()
+
+    assert status == 0, f"a dropped connection must surface as a transport failure, got {status}"
+    message = _failure_record(caplog)
+    cause = message.partition("cause=")[2]
+    assert cause, f"the failure warning carries no cause at all: {message!r}"
+    assert cause != "unavailable", (
+        f"the structured provider body was discarded rather than read: {message!r}"
+    )
+    for credential in (AGENTMAIL_API_KEY, CHANNEL_TOKEN, EGRESS_SECRET):
+        assert credential not in message, f"a credential reached the log: {message!r}"
+    assert len(cause) <= adapter_module.CAUSE_MAX_CHARS + 3, (
+        f"the cause is unbounded at {len(cause)} characters: {cause!r}"
+    )
+
+
+def test_a_long_credential_bearing_cause_is_redacted_and_truncated(
+    mail: MailState,
+    ingress: IngressState,
+    adapter: MailAdapter,
+) -> None:
+    """The redaction pass and the character budget, on input the socket cannot produce.
+
+    A dropped connection only ever yields a short, generic ``OSError`` string
+    carrying none of the three credentials, so the end-to-end test above can
+    assert "no credential in the log" and "the cause is bounded" while neither
+    the redaction loop nor the ``CAUSE_MAX_CHARS`` truncation ever runs: both of
+    those assertions hold just as well with the two passes deleted, and an
+    assertion that cannot fail is not protection. Both passes exist for a failure
+    mode the real transport cannot be made to produce on demand - a stdlib
+    rendering that starts carrying the request header, or a provider socket error
+    a kilobyte long - so the hostile body is handed to the helper directly.
+
+    That is not the internal patching `CLAUDE.md` forbids. Nothing is replaced or
+    faked; both fake servers still stand behind the fixtures. The helper is a
+    pure function of its two arguments, and passing them is the only way to hand
+    it an input the real seam refuses to generate.
+    """
+    leaked = (
+        f"<urlopen error [Errno 111] key={AGENTMAIL_API_KEY} "
+        f"chn={CHANNEL_TOKEN} egr={EGRESS_SECRET} " + "padding " * 40 + ">"
+    )
+    # Guard the fixture itself. The credentials must sit before the truncation
+    # point, or truncation rather than redaction is what removes them and the
+    # assertions below go vacuous in the other direction.
+    assert len(leaked) > adapter_module.CAUSE_MAX_CHARS, (
+        f"the hostile cause stopped being long enough to truncate: {len(leaked)} chars"
+    )
+    for credential in (AGENTMAIL_API_KEY, CHANNEL_TOKEN, EGRESS_SECRET):
+        position = leaked.find(credential)
+        assert 0 <= position < adapter_module.CAUSE_MAX_CHARS, (
+            f"{credential!r} sits at {position} rather than before the truncation point, "
+            f"so this test no longer exercises redaction: {leaked!r}"
+        )
+
+    cause = adapter._transport_cause(0, {"error": leaked})
+
+    for credential in (AGENTMAIL_API_KEY, CHANNEL_TOKEN, EGRESS_SECRET):
+        assert credential not in cause, f"a credential survived redaction: {cause!r}"
+    assert "[redacted]" in cause, f"the redaction pass never ran: {cause!r}"
+    assert len(cause) <= adapter_module.CAUSE_MAX_CHARS + 3, (
+        f"the cause is unbounded at {len(cause)} characters: {cause!r}"
+    )
+    assert cause.endswith("..."), f"the character budget never truncated: {cause!r}"
+    assert adapter._transport_cause(500, {"error": leaked}) == "unavailable", (
+        "a status the adapter did not synthesize the body for was rendered anyway"
+    )
+
+
+def test_a_provider_error_body_is_never_rendered_into_the_log(
+    mail: MailState,
+    ingress: IngressState,
+    adapter: MailAdapter,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A non-200 body is provider-authored, so the adapter must not read it at all.
+
+    The failure branch fires for every non-200 status, not only the transport
+    failure, and on a 4xx/5xx the provider's own parsed body is what reaches the
+    cause helper. That body is arbitrary: a provider is free to echo the subject
+    and text of the very mail being listed under an ``error`` key, which is the
+    shape the helper used to render. The character budget is no defence there -
+    a truncated payroll subject is still mail content in the cluster's log
+    retention - so the only sound rule is that a body this package did not write
+    is never read. Only a status 0 body is locally synthesized, so status alone
+    decides, and every other failure is recorded by its status code.
+    """
+    mail.injected_body = {"error": "Subject: payroll spreadsheet; body: SSN 123-45-6789"}
+    mail.fail_next_list = 500
+
+    with caplog.at_level(logging.WARNING, logger="curie_mail_adapter.adapter"):
+        status = adapter.poll_once()
+
+    assert status == 500, f"the injected provider failure did not surface, got {status}"
+    message = _failure_record(caplog)
+    assert "cause=unavailable" in message, (
+        f"a provider-authored failure body was rendered into the log: {message!r}"
+    )
+    assert "SSN" not in message, f"mail content reached the log: {message!r}"
+    assert "payroll" not in message, f"mail content reached the log: {message!r}"
+
+
+def test_repeated_list_transport_failures_back_off_then_reset_on_recovery(
+    mail: MailState,
+    ingress: IngressState,
+    make_adapter: Callable[..., MailAdapter],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A sustained outage slows the poller down, and recovery restores cadence.
+
+    The two backoff bounds are scaled down for this test: production takes a 5s
+    step to a 60s ceiling, so watching three growth steps at production values
+    would cost minutes of suite time for a property that is about ordering, not
+    absolute seconds. Only those two numeric bounds are rebound, for the
+    duration of this test: no function, class or I/O path inside
+    `curie_mail_adapter` is replaced, and every request still crosses the real
+    fake AgentMail server, so the cadence under test is the production one,
+    observed as wall-clock arrival times of real requests at the provider seam.
+
+    The assertions are ordering and bounds rather than exact values, because the
+    suite shares a box with whatever else is running on it. They are keyed to the
+    failure POSITIONS the fake reports rather than to elapsed-time
+    classification: on a loaded runner a normal poll can be descheduled past any
+    "this gap looks slow" threshold, and a test that infers which gaps were
+    backed-off ones from their duration mistakes that deschedule for the very
+    property it is pinning.
+    """
+    monkeypatch.setattr(adapter_module, "BACKOFF_STEP_SECONDS", 0.2)
+    monkeypatch.setattr(adapter_module, "BACKOFF_MAX_SECONDS", 0.6)
+    adapter = make_adapter(poll_interval_seconds=0.01)
+    thread = threading.Thread(target=adapter.poll_loop, daemon=True)
+
+    try:
+        thread.start()
+        assert adapter.ready.wait(10), "prime never completed against an empty inbox"
+        baseline = len(mail.list_times)
+        # Arm the outage BEFORE seeding, so the message cannot be delivered by a
+        # pass that races the arming and the whole outage sits between us and it.
+        mail.drop_next_lists = 4
+        mail.add_inbound("msg-drop", "thr-drop", subject="Held", text="delivered after the outage")
+
+        assert wait_until(lambda: ingress.delivery_ids() == ["msg-drop"], timeout=20), (
+            f"the held message never survived the outage: {ingress.delivery_ids()}"
+        )
+        # Keep polling past the recovered pass, so a post-recovery gap exists to
+        # judge the reset by rather than inferring it from the recovery itself.
+        assert wait_until(lambda: len(mail.list_times) >= baseline + 9, timeout=20), (
+            "the poller never resumed enough passes to expose a post-recovery gap"
+        )
+    finally:
+        adapter.shutdown.set()
+        thread.join(timeout=10)
+
+    times = mail.list_times[baseline:]
+    # The fake records which list calls it dropped, so the waits that followed a
+    # failure are known rather than guessed. Its indexes are absolute; shift them
+    # into this run's window.
+    dropped = [index - baseline for index in mail.dropped_list_indexes if index >= baseline]
+    # `times[k]` is call k's arrival, so the delay the adapter waited before a
+    # dropped call is the interval immediately preceding it.
+    waits_before_failures = [times[index] - times[index - 1] for index in dropped if index >= 1]
+
+    assert len(dropped) == 4, (
+        f"the outage the test armed is not the outage that happened: {dropped}"
+    )
+    assert len(waits_before_failures) >= 3, (
+        f"too few known-failure waits to judge growth: {waits_before_failures}"
+    )
+    assert waits_before_failures[1] > waits_before_failures[0] + 0.15, (
+        f"the delay did not grow across successive failures: {waits_before_failures}"
+    )
+    # 0.61 is the scaled ceiling plus one poll interval, the largest wait a clamped
+    # backoff can produce; the quarter second is scheduler slack. A tolerance wider
+    # than the ceiling itself would still pass with the clamp deleted.
+    assert max(waits_before_failures) <= 0.61 + 0.25, (
+        f"the backoff grew past its ceiling instead of saturating: {waits_before_failures}"
+    )
+    # This is the load-bearing check on the clamp. Once the ceiling is reached the
+    # wait stops changing, so two consecutive equal waits are the clamp's signature;
+    # unclamped, those two differ by roughly a doubling. The drops are consecutive
+    # list calls, so this list is deterministic in shape - the waits preceding drops
+    # 2, 3 and 4 - however many normal passes raced the arming, and the `>= 3` check
+    # above already guarantees both indexes exist. Do not relax it back into a broad
+    # tolerance: a tolerance cannot distinguish saturation from continued growth.
+    assert abs(waits_before_failures[-1] - waits_before_failures[-2]) < 0.15, (
+        "the backoff kept doubling instead of saturating at its ceiling: "
+        f"{waits_before_failures}"
+    )
+    # The recovery pass is the first list call after the last dropped one, so the
+    # final interval of the run is fully post-recovery and needs no guessing.
+    recovery = dropped[-1] + 1
+    assert len(times) >= recovery + 3, (
+        f"too few post-recovery passes to judge the reset: {len(times)} after {recovery}"
+    )
+    assert times[-1] - times[-2] < 0.15, (
+        f"the normal cadence never resumed after recovery: {times[-1] - times[-2]}"
+    )
+    assert ingress.delivery_ids() == ["msg-drop"], (
+        f"the held message was skipped or duplicated across the outage: {ingress.delivery_ids()}"
+    )
+
+
+def test_an_unrelated_failure_does_not_clear_an_armed_backoff(
+    mail: MailState,
+    ingress: IngressState,
+    make_adapter: Callable[..., MailAdapter],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 5xx in the middle of a transport outage must not reset the cadence.
+
+    A provider outage is rarely one failure mode end to end: a dropped
+    connection and a 5xx interleave as the provider's edge fails in different
+    ways, and the poller sees the mixture, not a clean run of one status. If the
+    5xx un-arms the delay the two drops just armed, the poller returns to its
+    normal interval in the MIDDLE of the outage and resumes the warning burst
+    this issue is about — a bug no single-failure-mode test can see, because
+    each status is handled correctly on its own.
+
+    The two fault mechanisms are armed together before the first affected call:
+    the fake handler consumes `drop_next_lists` ahead of the one-shot
+    `fail_next_list`, so setting both is atomic and produces exactly drop, drop,
+    500, normal service. Nothing has to be timed against a live loop, so there
+    is no window in which a racing pass could reorder the outage. The bounds are
+    scaled exactly as the cadence test above scales them, and for the same
+    reason; every request still crosses the real fake AgentMail server.
+    """
+    monkeypatch.setattr(adapter_module, "BACKOFF_STEP_SECONDS", 0.2)
+    monkeypatch.setattr(adapter_module, "BACKOFF_MAX_SECONDS", 0.6)
+    adapter = make_adapter(poll_interval_seconds=0.01)
+    thread = threading.Thread(target=adapter.poll_loop, daemon=True)
+
+    try:
+        thread.start()
+        assert adapter.ready.wait(10), "prime never completed against an empty inbox"
+        baseline = len(mail.list_times)
+        mail.drop_next_lists = 2
+        mail.fail_next_list = 500
+        mail.add_inbound(
+            "msg-mixed", "thr-mixed", subject="Mixed", text="delivered after the outage"
+        )
+
+        assert wait_until(lambda: ingress.delivery_ids() == ["msg-mixed"], timeout=20), (
+            f"the held message never survived the mixed outage: {ingress.delivery_ids()}"
+        )
+        # Keep polling past recovery, so the interval after the 500 is a settled
+        # measurement rather than the tail of the run.
+        assert wait_until(lambda: len(mail.list_times) >= baseline + 8, timeout=20), (
+            "the poller never resumed enough passes to expose the post-500 interval"
+        )
+    finally:
+        adapter.shutdown.set()
+        thread.join(timeout=10)
+
+    times = mail.list_times[baseline:]
+    dropped = [index - baseline for index in mail.dropped_list_indexes if index >= baseline]
+    # The 500 is answered by the call right after the last dropped one, and the
+    # first successful listing is the one after that. The wait the adapter took
+    # BEFORE that successful call is the whole question: the backoff the two
+    # drops armed must still have been in force across the 500.
+    failed_500 = dropped[-1] + 1
+    wait_before_recovery = times[failed_500 + 1] - times[failed_500]
+
+    assert len(dropped) == 2, (
+        f"the outage the test armed is not the outage that happened: {dropped}"
+    )
+    assert len(times) > failed_500 + 1, (
+        f"no listing after the 500 to measure: {len(times)} calls, 500 at {failed_500}"
+    )
+    # Held at its 0.6s ceiling the wait is about 0.61s; if the 500 cleared the
+    # backoff it is the bare 0.01s poll interval. 0.3 sits far from both, so the
+    # check cannot be satisfied by scheduler slack in either direction.
+    assert wait_before_recovery > 0.3, (
+        f"an unrelated 5xx cleared the armed transport backoff: {wait_before_recovery}"
+    )
+    assert ingress.delivery_ids() == ["msg-mixed"], (
+        f"the held message was skipped or duplicated across the outage: {ingress.delivery_ids()}"
+    )


### PR DESCRIPTION
## What

A dropped AgentMail connection surfaced as `poll: list failed with status=0` and nothing else, and `poll_loop` reset its backoff for status 0 — so a sustained outage re-polled at the normal interval and burst one warning per pass (373 in 24h in the soak, 186 in one hour; six more in ~30s on `next@ae5d57b1`).

- `poll_once` logs a bounded, credential-free cause instead of discarding the structured body `agentmail.request` already builds.
- `poll_loop` arms its existing bounded exponential backoff for status 0 as well as 429.
- Only a **successful** listing clears the delay. A 5xx still does not arm the backoff (deliberately out of scope for this issue) but can no longer un-arm one, which would have returned the poller to normal cadence mid-outage.

Delivery remained eventual throughout, and this does not claim a provider root cause.

## Why the cause is safe to log

The cause is gated on the **status**, not on the body's shape. Only a status 0 body is one this package synthesizes (`{"error": str(exc)}` for an `OSError`, `{"error": "response body exceeds configured byte limit"}` for an oversize response). Every other status carries a provider-authored payload that can hold mail content, so it is never rendered — only counted by its status code. The guard sits at the top of the helper rather than at the call site, so a later caller cannot pass a provider payload back in.

What is rendered is whitespace-collapsed, has the three configured credentials replaced with `[redacted]`, and is truncated to a fixed 120-character budget an outside party cannot grow.

Untouched: 429 `Retry-After` handling, durable pending-delivery retry, and the `prime` / `_confirm_restart` paths — those two already backed off on every failure, and `poll_loop` was the only retry loop that did not.

## Verification

All tests drive the real fake AgentMail `ThreadingHTTPServer`; nothing inside `curie_mail_adapter` is faked. Five new tests: consecutive dropped connections for the cadence, a provider-authored `{"error": ...}` body for the payload refusal, a hostile long credential-bearing cause for redaction and truncation, and a drop/drop/500 outage for the reset condition.

Each was confirmed to **fail** against unmodified `origin/next`. Beyond that, the redaction pass, the character budget, the `BACKOFF_MAX_SECONDS` clamp and the reset condition were each individually deleted and the assertion that claims to protect it was confirmed to fire.

- `uv run pytest apps/mail-adapter/tests -q` — 135 passed (130 on base)
- `uv run ruff check .` — clean
- `uv run mypy` — clean, 232 source files
- `bash cli/scripts/verify-fix-pin.sh HEAD <selector>` — `PINNED`
- The cadence tests were run 10x consecutively with no flake

## Done-check

- [x] Failing tests committed before implementation — N/A (quick tier), but every new test was verified to fail against unmodified `origin/next` before the fix was accepted
- [x] All production edits performed by delegated sub-agents; no inline driver edits
- [x] Broadened return types — N/A; `_transport_cause` is new and private, `poll_loop` and `poll_once` signatures are unchanged
- [x] Cross-engine code review completed (Codex, `gpt-5.6-sol`) — three rounds; every finding fixed, final round clean
- [x] Cross-engine scope review completed (Codex) — per-hunk map, verdict PASS, no passengers
- [x] Sibling-path parity — the sibling retry loops `prime` and `_confirm_restart` already back off on every failure; `poll_loop` was the only outlier and now mirrors `_confirm_restart`'s reset condition
- [x] Guard demonstration — the status guard, the credential redaction, the length budget and the backoff clamp were each deleted and executed, and each mutation was caught
- [x] Consolidation pass — N/A (quick tier)
- [x] Security review — N/A as a separate pass; the credential/PII surface was the code reviewer's primary focus and produced the status-gate fix
- [x] Observable verification / deployed E2E — N/A; no user-facing surface and no deployed-behavior dependency
- [x] Full affected suite, typecheck and lint clean

## Out of scope, deliberately

A 5xx does not arm the backoff. The issue's Expected section names only status-zero transport failures, and widening the arming set would change behavior the soak did not implicate. The reset condition **was** changed, because an armed transport backoff being cleared by an unrelated 5xx is a hole in the fix this issue does ask for.

Fix pin: apps/mail-adapter/tests/test_poll_transport.py::test_repeated_list_transport_failures_back_off_then_reset_on_recovery

Closes #2012
