### PR TITLE
fix: name the agent and the fault when a workspace cannot be prepared

### DIFF
--- a/apps/worker/CLAUDE.md
+++ b/apps/worker/CLAUDE.md
@@ -34,8 +34,13 @@ stop -- that is scope creep on the sacred module.
    `side_effect_flag` escalates to a human instead of retrying; the flag is
    persisted to Valkey the instant it is seen so a crash mid-side-effect
    still escalates on reclaim. Flag-clean failures retry by classification
-   (`rate-limit`/`runner-error`/`runner-timeout` transient, everything else
-   escalates).
+   (`rate-limit`/`runner-error`/`runner-timeout`/`workspace-error` transient,
+   everything else escalates). `workspace-error` (#2004) is a workspace
+   preparation FAULT before the turn was accepted; it must log a WARNING naming
+   the agent, deployment, repository and stage, because a silent one acks the
+   turn and creates no sandbox with nothing in the log to find it by. A
+   deliberate selection refusal is the other half of that split: a decision, not
+   a fault, so it stays terminal, answers the user, and logs at INFO.
 
 ## Delivery is bounded (ADR-0039, #505)
 

--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -179,11 +179,21 @@ Rules (detailed-architecture 2b), each with an integration test that provokes it
   instead of retrying. The flag is persisted to Valkey the instant it is seen, so
   a worker crash mid-side-effect still escalates on reclaim rather than re-running
   a non-idempotent action. Flag-clean failures retry by classification:
-  `rate-limit`, `runner-error` and `runner-timeout` are transient (bounded
-  exponential backoff); `budget-exceeded` and everything else escalate.
+  `rate-limit`, `runner-error`, `runner-timeout` and `workspace-error` are
+  transient (bounded exponential backoff); `budget-exceeded` and everything else
+  escalate.
   `runner-timeout` is the runner's streaming budget expiring mid-turn (#2011),
   told apart from `runner-error` -- the sandbox or the transport dying -- so an
   operator can see which one happened.
+  `workspace-error` is a managed-workspace preparation FAULT before the turn was
+  ever accepted (#2004): the clone, the archive, the upload, or a missing
+  workspace coordinator. It is told apart from `runner-error` for the same
+  reason, and it always carries a `workspace start failed` WARNING naming the
+  agent, the deployment, the repository the turn asked for and the stage that
+  failed -- such a turn used to ack, create no sandbox and log nothing at all.
+  A deliberate repository-selection refusal is the other half of that split and
+  is NOT this: it is a decision rather than a fault, so it stays terminal,
+  answers the user, and logs at INFO instead.
 - **Idempotency + crash recovery.** The Slack event id gates a `done` marker, so
   a redelivered or reclaimed entry that already finished is skipped.
   `XAUTOCLAIM` reclaims entries a dead consumer took but never acked and

--- a/apps/worker/src/curie_worker/kernel.py
+++ b/apps/worker/src/curie_worker/kernel.py
@@ -15,7 +15,8 @@ Rules implemented here (detailed-architecture section 2b):
    escalates to a human instead of retrying; the flag is persisted the instant it
    is seen so a crash mid-side-effect still escalates on reclaim. Flag-clean
    failures retry by error classification (rate-limit / runner-error /
-   runner-timeout are transient; budget-exceeded and everything else escalate).
+   runner-timeout / workspace-error are transient; budget-exceeded and
+   everything else escalate).
 
 Idempotency: the Slack event id gates a ``done`` marker so a redelivered or
 reclaimed event that already finished is skipped.
@@ -298,7 +299,19 @@ def _exception_reason(exc: BaseException) -> str:
 # before it had a name and still is. The side-effect check in ``_attempt`` runs
 # BEFORE retryability is consulted (ADR-0013), so a timeout that arrives after a
 # side-effect frame still escalates and is never retried.
-RETRYABLE_CLASSIFICATIONS = frozenset({"rate-limit", "runner-error", "runner-timeout"})
+# ``workspace-error`` (#2004) is a managed-workspace preparation failure -- a
+# clone, an archive, an upload, or a missing coordinator -- raised before the
+# turn was ever accepted. It is named separately from ``runner-error`` for the
+# same reason ``runner-timeout`` is: an operator reading the escalation must be
+# able to tell "this thread's repository could not be prepared" from "the
+# sandbox died", and previously the two were indistinguishable. It stays HERE
+# because naming it changes nothing about retryability: a clone or internal-API
+# blip was transient before it had a name and still is, and the side-effect
+# check above still runs first, so a workspace failure that somehow arrives
+# after a side-effect frame escalates rather than replaying it.
+RETRYABLE_CLASSIFICATIONS = frozenset(
+    {"rate-limit", "runner-error", "runner-timeout", "workspace-error"}
+)
 
 # The floor of remaining DELIVERY budget below which a fresh attempt is not
 # started (ADR-0131). The runner cannot claim a sandbox, open a turn and stream a
@@ -1149,9 +1162,27 @@ class Kernel:
                 if getattr(resolved, "workspace_enabled", False):
                     workspace_deployment_id = getattr(resolved, "deployment_id", None)
                     if workspace_deployment_id is None:
-                        raise WorkspacePreparationError(
+                        # Outside _attempt's handlers, so this one has to name
+                        # itself: deployment_id is legitimately optional on a
+                        # resolved binding, making this a reachable
+                        # misconfiguration that would otherwise reach the
+                        # consumer as an anonymous processing exception (#2004).
+                        # Log first so the failure names the agent, then let the
+                        # raise stand unchanged: it leaves the stream entry
+                        # pending for reclaim rather than settling it -- only
+                        # the visibility changed here.
+                        binding_failure = WorkspacePreparationError(
                             "binding", "workspace-enabled deployment has no deployment id"
                         )
+                        self._log_workspace_start_failure(
+                            qevent,
+                            qevent.text,
+                            binding_failure,
+                            agent_id=agent_id,
+                            agent_name=agent_name,
+                            workspace_deployment_id=None,
+                        )
+                        raise binding_failure
                 # One-shot post-approval allowance (#430, ADR-0035): when THIS turn is the
                 # resume of a genuinely-approved permission-gate approval, deliver a single
                 # gated-tool grant so the approved action completes once; the gate re-arms
@@ -2071,6 +2102,70 @@ class Kernel:
 
     # -- internals ------------------------------------------------------------
 
+    def _log_workspace_start_failure(
+        self,
+        qevent: QueuedTurn,
+        turn_text: str,
+        exc: WorkspacePreparationError,
+        *,
+        agent_id: uuid.UUID | None,
+        agent_name: str | None,
+        workspace_deployment_id: uuid.UUID | None,
+    ) -> None:
+        """Name the deployment behind a workspace PREPARATION failure (#2004).
+
+        The refusal branch below already covers its own half: it answers the
+        requester with ``exc.public_detail`` and tells the operator over its own
+        INFO line. This complements that rather than replacing it. Every OTHER
+        workspace start failure -- a clone, an archive, an upload, a missing
+        coordinator -- falls into ``_attempt``'s broad start-failure clause,
+        which used to log an event id and an anonymous ``repr``: naming neither
+        the agent, nor the deployment, nor the repository. A binding carrying no
+        deployment id is different again: it never reaches that clause at all,
+        because it is raised earlier, in ``_process_event``, before ``_attempt``
+        runs -- and had no log of its own before this ticket. The reported
+        symptom is what both cost -- the turn acks, creates no sandbox, and an
+        operator has nothing to search on.
+
+        So this emits one WARNING carrying everything needed to find the
+        deployment from the outside: the event, the agent, the deployment, the
+        repository the turn asked for (``<none named>`` when the message named
+        none -- that absence is itself the usual cause), the preparation stage
+        that failed, and a never-empty reason. WARNING rather than the refusal's
+        INFO because the two are different kinds of event: a refusal is a
+        decision the feature made on purpose, a preparation failure is a fault
+        nobody chose.
+
+        It takes the turn TEXT rather than an ``Event`` because the earliest
+        workspace failure -- a workspace-enabled deployment carrying no
+        deployment id -- is raised before ``_attempt`` has built one, and a
+        failure this helper cannot be called from is exactly the silence #2004
+        is about.
+        """
+        # Total by construction: parse_github_repo_fact RAISES
+        # WorkspaceSelectionRefused on a multi-repository message. That refusal
+        # is incidental here -- a second failure raised by the reparse, not the
+        # one being reported -- and letting it escape would replace the caller's
+        # fault with it, losing the outcome the caller is about to return and
+        # leaving the entry pending until dead-letter. Naming one of the two
+        # repositories instead would be a lie, so the ambiguity is reported as
+        # itself. Narrow on purpose -- a genuine bug here should still surface.
+        try:
+            repository = parse_github_repo_fact(turn_text) or "<none named>"
+        except WorkspacePreparationError:
+            repository = "<ambiguous>"
+        logger.warning(
+            "workspace start failed for %s: agent=%s agent_id=%s deployment=%s "
+            "repo=%s stage=%s reason=%s",
+            qevent.event_id,
+            agent_name or "<unknown>",
+            agent_id if agent_id is not None else "<unknown>",
+            workspace_deployment_id if workspace_deployment_id is not None else "<unknown>",
+            repository,
+            exc.stage,
+            _exception_reason(exc),
+        )
+
     async def _attempt(
         self,
         qevent: QueuedTurn,
@@ -2193,13 +2288,32 @@ class Kernel:
             )
             await self._reply_for(qevent, route, exc.public_detail)
             return TurnOutcome(terminal_ok=True)
+        except WorkspacePreparationError as exc:
+            # AFTER the refusal branch above, and it has to stay after it:
+            # `WorkspaceSelectionRefused` subclasses this, so ordering these two
+            # the other way round would swallow a deliberate policy answer and
+            # retry it. What reaches HERE is infrastructure, not policy -- the
+            # clone, the archive, the upload, the coordinator wiring. It used to
+            # fall into the clause below and answer to the name "runner-error",
+            # pointing an operator at a runner that never saw the fault. Retry
+            # behavior is deliberately identical (`workspace-error` is
+            # retryable); only the name and the log line change.
+            release_order()
+            self._log_workspace_start_failure(
+                qevent,
+                event.text,
+                exc,
+                agent_id=agent_id,
+                agent_name=agent_name,
+                workspace_deployment_id=workspace_deployment_id,
+            )
+            return TurnOutcome(terminal_ok=False, classification="workspace-error")
         except (
             RunnerError,
             aiohttp.ClientError,
             TimeoutError,
             OSError,
             SandboxError,
-            WorkspacePreparationError,
         ) as exc:
             # The turn was never accepted (transient runner 5xx, runner not ready,
             # claim timeout, route-lock acquire timeout). Convert to a retryable

--- a/apps/worker/tests/kernel/test_consumer.py
+++ b/apps/worker/tests/kernel/test_consumer.py
@@ -15,12 +15,14 @@ from aci_protocol import Final, QueuedTurn, ReplyHandle, SessionStatus, TextDelt
 from curie_dispatcher.queue import to_stream_fields
 from curie_worker import consumer as consumer_module
 from curie_worker import kernel as kernel_module
+from curie_worker.behaviorpacks import BehaviorPacks
 from curie_worker.consumer import (
     THREAD_RESET_INFLIGHT_SET,
     THREAD_RESET_SET,
     Consumer,
 )
 from curie_worker.sandbox import QuotaRejection
+from curie_worker.workspace import WorkspacePreparationError
 
 DONE = SessionStatus.DONE
 
@@ -673,5 +675,163 @@ def test_maintenance_tick_thread_reset_is_not_stalled_by_a_hanging_substrate_rel
 
             # The request was popped either way; a fresh reset is needed to retry.
             assert await h.async_redis.scard(THREAD_RESET_SET) == 0
+
+    asyncio.run(go())
+
+
+# --- An acked entry must never be a silent one (#2004) -----------------------
+# The kernel-level regressions call ``process_event`` directly, so they can only
+# see the silence. The ack is a CONSUMER fact -- a normal return from
+# ``process_event`` is what makes ``Consumer`` XACK -- so the pairing the ticket
+# actually reports is only observable here, against the real stream and group.
+
+
+def _workspace_binding(deployment_id: uuid.UUID) -> object:
+    """A workspace-enabled binding carrying a FIXED deployment id.
+
+    Fixed on purpose: the id is what an operator greps the worker log for, so
+    the assertion below checks the real value rather than that some uuid landed.
+    Defined locally rather than imported from ``test_kernel``; importlib mode
+    makes cross-test-module imports fragile.
+    """
+
+    class WorkspaceResolved:
+        def __init__(self) -> None:
+            self.agent_id = uuid.uuid4()
+            self.agent_name = "test-agent"
+            self.endpoint: str | None = None
+            self.adapter: str | None = None
+            self.deployment_id = deployment_id
+            self.workspace_enabled = True
+
+    class WorkspaceBinding:
+        async def resolve(self, _kind: str, _channel: str) -> WorkspaceResolved:
+            return WorkspaceResolved()
+
+        def boot_env(
+            self,
+            _resolved: object,
+            _thread_key: str,
+            *,
+            kind: str | None = None,
+            address: str | None = None,
+        ) -> dict[str, str]:
+            return {}
+
+        def packs_for(self, _resolved: object) -> BehaviorPacks:
+            return BehaviorPacks()
+
+    return WorkspaceBinding()
+
+
+def test_failed_workspace_preparation_acks_the_entry_and_is_not_silent(
+    make_harness, caplog
+) -> None:
+    """#2004 end to end: the reported evidence was a group at ``pending 0`` with
+    ``last-delivered-id`` equal to the turn's stream id -- yet no sandbox and an
+    empty worker log.
+
+    The refusal half of that symptom is already covered on ``next`` by the INFO
+    line the refusal branch emits; this pins the PREPARATION half, which is the
+    one still silent here. Selection succeeds and the clone fails, so the turn
+    retries to its escalation and the entry is acked -- and only the ack makes
+    the silence undiagnosable. An entry left pending is at least visible in
+    XPENDING; an acked entry with nothing in the log is indistinguishable from a
+    bot that was never mentioned. Driven through the real ``Consumer`` and the
+    real stream so the ack is the production one, not an assertion about
+    ``process_event``'s return value.
+    """
+
+    caplog.set_level(logging.WARNING, logger="curie_worker.kernel")
+    deployment_id = uuid.uuid4()
+
+    async def go() -> None:
+        async with make_harness(binding=_workspace_binding(deployment_id)) as h:
+            # Selection SUCCEEDS -- this is a fault, not a policy refusal -- and
+            # the workspace then fails to materialize, which is the path that
+            # still ends the turn without naming anything.
+            class WorkspaceProbe:
+                def select_repository(
+                    self,
+                    *,
+                    thread_key: str,
+                    deployment_id: uuid.UUID,
+                    author: str,
+                    repo_full_name: str | None,
+                ) -> str:
+                    assert repo_full_name is not None
+                    return repo_full_name
+
+                def claim_or_resume_with_handle(self, **kwargs: object) -> object:
+                    raise WorkspacePreparationError(
+                        "clone", "git clone exited 128: repository not found"
+                    )
+
+                def touch(self, thread_key: str, *, ttl_seconds: int) -> bool:
+                    return True
+
+                def enumerate_expired(self) -> list[object]:
+                    # The consumer's maintenance loop polls this every tick;
+                    # without it the loop logs a repeated AttributeError
+                    # traceback that pollutes this test's caplog capture.
+                    return []
+
+            h.kernel._workspace = WorkspaceProbe()  # type: ignore[assignment]
+
+            consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
+            await consumer.ensure_group()
+
+            qe = _qevent(
+                "Fix https://github.com/acme-corp/acme-bot",
+                thread="tAckSilent",
+                event_id="ws-ack-1",
+            )
+            await h.async_redis.xadd(h.config.stream, to_stream_fields(qe))
+
+            task = asyncio.create_task(consumer.run())
+            # Wait for the escalation itself, not its classification string --
+            # the turn exhausts its retries and escalates on both the pre-fix
+            # and post-fix source, and only the classification name
+            # ("runner-error" vs "workspace-error") differs between them.
+            # Gating on the new name would time out pre-fix and never reach
+            # the assertions below, which is the thing this test exists to
+            # pin.
+            await _wait_until(
+                lambda: h.sink.last_text is not None
+                and "Flagging for a human" in h.sink.last_text
+            )
+            consumer.request_stop()
+            await task
+
+            # Half one of the ticket's evidence: the entry really was consumed
+            # and acked off the group -- nothing is left for an operator to find.
+            summary = await h.async_redis.xpending(h.config.stream, h.config.consumer_group)
+            assert summary["pending"] == 0
+            assert h.fake_k8s.claim_envs == []  # ...and no sandbox was ever created
+            assert h.runner.opened == []  # ...and the runner never saw a turn
+
+            # Half two, asserted second so the pairing is explicit: an acked,
+            # sandbox-less turn is only a bug because the worker said nothing
+            # about it. This is the assertion that fails on the current base.
+            failures = [
+                r
+                for r in caplog.records
+                if r.name == "curie_worker.kernel" and "workspace start failed" in r.getMessage()
+            ]
+            assert failures, (
+                "the entry was acked with no sandbox and no line naming the agent -- "
+                f"exactly what #2004 reports: {caplog.text!r}"
+            )
+            assert all(r.levelno == logging.WARNING for r in failures)
+            message = failures[-1].getMessage()
+            assert "agent=test-agent" in message, message
+            assert f"deployment={deployment_id}" in message, message
+            assert "stage=clone" in message, message
+
+            # Last: the escalation is correctly classified post-fix. Placed
+            # after the silence assertion above so a pre-fix failure reports
+            # the meaningful thing (no warning line) rather than this one.
+            assert h.sink.last_text is not None
+            assert "workspace-error" in h.sink.last_text
 
     asyncio.run(go())

--- a/apps/worker/tests/kernel/test_kernel.py
+++ b/apps/worker/tests/kernel/test_kernel.py
@@ -35,7 +35,10 @@ from curie_worker.kernel import ThreadBusyError
 from curie_worker.reply_sink import TargetRoute
 from curie_worker.runner_client import RunnerError, TurnStream
 from curie_worker.sandbox import QuotaRejection
-from curie_worker.workspace import WorkspaceSelectionRefused
+from curie_worker.workspace import (
+    WorkspacePreparationError,
+    WorkspaceSelectionRefused,
+)
 
 DONE = SessionStatus.DONE
 IDLE = SessionStatus.IDLE_AWAITING_INPUT
@@ -466,6 +469,215 @@ def test_a_selection_refusal_is_logged_so_an_operator_can_find_it(
             )
 
     asyncio.run(go())
+
+
+# --- A workspace PREPARATION failure must never be anonymous (#2004) ----------
+# The refusal half of this ticket is already covered above, by the INFO line the
+# refusal branch emits. These pin the other half: a clone, an upload, or a
+# binding carrying no deployment id used to be swallowed by the broad
+# start-failure clause, which names an event id and an anonymous repr -- so a
+# workspace-enabled turn acked, created no sandbox, and left the operator with
+# nothing to search on. They assert the log line, not the reply; the reply was
+# never the missing half.
+
+
+def _workspace_binding(deployment_id: uuid.UUID | None) -> object:
+    """A binding for a workspace-enabled deployment with a FIXED deployment id.
+
+    Fixed on purpose: the id is what an operator greps for, so the tests assert
+    the exact value reaches the log rather than that some uuid did. ``None`` is
+    admitted because it is a real resolved shape -- deployment_id is optional on
+    the binding row -- and the misconfiguration it produces is its own test."""
+
+    class WorkspaceResolved(_FakeResolved):
+        def __init__(self) -> None:
+            super().__init__(uuid.uuid4())
+            self.deployment_id = deployment_id
+            self.workspace_enabled = True
+
+    class WorkspaceBinding:
+        async def resolve(self, _kind: str, _channel: str) -> WorkspaceResolved:
+            return WorkspaceResolved()
+
+        def boot_env(
+            self,
+            _resolved: object,
+            _thread_key: str,
+            *,
+            kind: str | None = None,
+            address: str | None = None,
+        ) -> dict[str, str]:
+            return {}
+
+        def packs_for(self, _resolved: object) -> BehaviorPacks:
+            return BehaviorPacks()
+
+    return WorkspaceBinding()
+
+
+def _workspace_start_failures(caplog: Any) -> list[str]:
+    return [r.getMessage() for r in caplog.records if "workspace start failed" in r.getMessage()]
+
+
+def _workspace_start_failure_records(caplog: Any) -> list[logging.LogRecord]:
+    # Companion to _workspace_start_failures: keeps the record itself so a
+    # test can assert on level, not just message text.
+    return [r for r in caplog.records if "workspace start failed" in r.getMessage()]
+
+
+def test_workspace_preparation_failure_escalates_by_its_own_name(make_harness, caplog) -> None:
+    """#2004: a workspace that cannot be prepared fails LOUDLY and by name.
+
+    Selection succeeds, then the clone fails -- so this is a fault, not the
+    deliberate refusal the branch above handles. Pre-fix it fell into the broad
+    start-failure clause: the only trace was ``turn start failed for <event id>``
+    with an anonymous repr -- naming neither the agent, the deployment, the
+    repository, nor the stage -- and it escalated as the generic
+    ``runner-error``, indistinguishable from a runner 5xx. This pins both halves:
+    the operator line, and the classification the user-visible escalation
+    carries. Retry behavior is unchanged, which the escalation-after-3-attempts
+    shape (and the real, unprobed ``retry_class`` metric this path emits) still
+    proves."""
+
+    caplog.set_level(logging.WARNING, logger="curie_worker.kernel")
+    deployment_id = uuid.uuid4()
+
+    async def go() -> None:
+        async with make_harness(binding=_workspace_binding(deployment_id), max_attempts=3) as h:
+            class WorkspaceProbe:
+                def select_repository(
+                    self,
+                    *,
+                    thread_key: str,
+                    deployment_id: uuid.UUID,
+                    author: str,
+                    repo_full_name: str | None,
+                ) -> str:
+                    assert repo_full_name is not None
+                    return repo_full_name
+
+                def claim_or_resume_with_handle(self, **kwargs: object) -> object:
+                    raise WorkspacePreparationError(
+                        "clone", "git clone exited 128: repository not found"
+                    )
+
+                def touch(self, thread_key: str, *, ttl_seconds: int) -> bool:
+                    return True
+
+            h.kernel._workspace = WorkspaceProbe()  # type: ignore[assignment]
+            await h.kernel.process_event(
+                _qevent("Fix https://github.com/acme-corp/acme-bot", thread="tWorkspaceClone")
+            )
+
+            # The turn was never accepted: nothing was claimed and no turn opened.
+            assert h.fake_k8s.claim_envs == []
+            assert h.runner.opened == []
+
+            # Visible terminal failure, under the workspace's own name. Pre-fix
+            # this said "runner-error" and pointed operators at the runner.
+            assert h.sink.last_text is not None
+            assert "workspace-error" in h.sink.last_text, h.sink.last_text
+            assert "human" in h.sink.last_text.lower()
+
+            failures = _workspace_start_failures(caplog)
+            assert failures, f"the preparation failure was unnamed: {caplog.text!r}"
+            message = failures[-1]
+            assert "agent=test-agent" in message, message
+            assert f"deployment={deployment_id}" in message, message
+            assert "acme-corp/acme-bot" in message, message
+            assert "stage=clone" in message, message
+            assert "repository not found" in message, message
+
+    asyncio.run(go())
+
+
+def test_workspace_enabled_binding_without_deployment_id_is_named(make_harness, caplog) -> None:
+    """#2004: the binding-stage misconfiguration logs before it raises.
+
+    ``deployment_id`` is optional on a resolved binding, so a workspace-enabled
+    deployment carrying none is reachable config drift. It is raised outside
+    ``_attempt``'s handlers, so it never reached the visibility helper and the
+    consumer saw only an anonymous processing exception. The raise is deliberate
+    and unchanged -- leaving the entry pending is the right terminal answer for a
+    config error -- so it is asserted here, not softened."""
+
+    caplog.set_level(logging.WARNING, logger="curie_worker.kernel")
+
+    async def go() -> None:
+        async with make_harness(binding=_workspace_binding(None)) as h:
+            with pytest.raises(WorkspacePreparationError):
+                await h.kernel.process_event(_qevent("do the thing", thread="tNoDeploymentId"))
+
+            assert h.fake_k8s.claim_envs == []
+            assert h.runner.opened == []
+
+            failures = _workspace_start_failures(caplog)
+            assert failures, f"the binding misconfiguration was unnamed: {caplog.text!r}"
+            message = failures[-1]
+            assert "agent=test-agent" in message, message
+            assert "stage=binding" in message, message
+            assert "has no deployment id" in message, message
+            # The whole point of this failure: no deployment id ever reached
+            # the log call, and no repository was selected either.
+            assert "deployment=<unknown>" in message, message
+            assert "repo=<none named>" in message, message
+            record = _workspace_start_failure_records(caplog)[-1]
+            assert record.levelno == logging.WARNING, record
+
+    asyncio.run(go())
+
+
+def test_binding_failure_on_an_ambiguous_message_logs_without_re_raising(
+    make_harness, caplog
+) -> None:
+    """#2004: the visibility helper must not raise the refusal it trips over.
+
+    The helper reparses the turn text to name the repository, and
+    ``parse_github_repo_fact`` itself RAISES ``WorkspaceSelectionRefused`` on a
+    message naming two repositories. That refusal is incidental -- the failure
+    being reported is the binding one -- so a naive helper would replace the
+    caller's fault with it, and the missing-deployment-id raise below would reach
+    the consumer as a refusal instead.
+
+    This is the one reachable path where the guard still bites: the
+    ``deployment_id is None`` raise in ``_process_event`` calls the helper with
+    the raw turn text, before any selection is attempted. It pins that the
+    ambiguity is reported as itself (neither repository can be named without
+    lying about which one won) and that the binding failure is still what
+    escapes."""
+
+    caplog.set_level(logging.WARNING, logger="curie_worker.kernel")
+
+    async def go() -> None:
+        async with make_harness(binding=_workspace_binding(None)) as h:
+            with pytest.raises(WorkspacePreparationError) as raised:
+                await h.kernel.process_event(
+                    _qevent(
+                        "Port https://github.com/acme-corp/acme-bot to "
+                        "https://github.com/acme-corp/acme-api",
+                        thread="tAmbiguousRepo",
+                    )
+                )
+
+            # The helper swallowed the reparse's refusal instead of letting it
+            # stand in for the fault the caller is reporting.
+            assert not isinstance(raised.value, WorkspaceSelectionRefused), raised.value
+            assert raised.value.stage == "binding", raised.value
+
+            assert h.fake_k8s.claim_envs == []
+            assert h.runner.opened == []
+
+            failures = _workspace_start_failures(caplog)
+            assert failures, f"the binding misconfiguration was unnamed: {caplog.text!r}"
+            message = failures[-1]
+            assert "agent=test-agent" in message, message
+            assert "repo=<ambiguous>" in message, message
+            assert "stage=binding" in message, message
+            record = _workspace_start_failure_records(caplog)[-1]
+            assert record.levelno == logging.WARNING, record
+
+    asyncio.run(go())
+
 
 
 def test_tool_notes_are_consumed_without_reaching_user_facing_updates(

--- a/packages/telemetry/schema/metrics.json
+++ b/packages/telemetry/schema/metrics.json
@@ -195,10 +195,11 @@
           "redelivery",
           "rate-limit",
           "runner-error",
-          "runner-timeout"
+          "runner-timeout",
+          "workspace-error"
         ]
       },
-      "cardinality_bound": 8
+      "cardinality_bound": 10
     },
     "curie.queue.dead_letter": {
       "type": "counter",

--- a/packages/telemetry/src/curie_telemetry/metrics.py
+++ b/packages/telemetry/src/curie_telemetry/metrics.py
@@ -71,7 +71,16 @@ _QUEUE_RETRY_ATTRIBUTES = {
     # here -- ``record_metric`` raises on an out-of-domain attribute value, so a
     # retryable classification missing from this allowlist crashes the worker on
     # the retry emission rather than silently dropping a point.
-    "retry_class": ["redelivery", "rate-limit", "runner-error", "runner-timeout"],
+    # "workspace-error" (#2004): a managed-workspace preparation failure before
+    # the turn was ever accepted, named apart from "runner-error" for the same
+    # reason -- and, being retryable, subject to the same crash-on-omission.
+    "retry_class": [
+        "redelivery",
+        "rate-limit",
+        "runner-error",
+        "runner-timeout",
+        "workspace-error",
+    ],
 }
 _THREAD_ATTRIBUTES = {
     "service.name": ["curie-worker"],

--- a/packages/telemetry/tests/test_metrics.py
+++ b/packages/telemetry/tests/test_metrics.py
@@ -135,9 +135,15 @@ def test_retry_metrics_separate_bounded_retry_causes() -> None:
     assert queue["attributes"] == {
         "service.name": ["curie-worker"],
         "source": ["worker", "eval"],
-        "retry_class": ["redelivery", "rate-limit", "runner-error", "runner-timeout"],
+        "retry_class": [
+            "redelivery",
+            "rate-limit",
+            "runner-error",
+            "runner-timeout",
+            "workspace-error",
+        ],
     }
-    assert queue["cardinality_bound"] == 8
+    assert queue["cardinality_bound"] == 10
     reply = manifest["curie.reply.retry"]
     assert reply["attributes"] == {
         "service.name": ["curie-worker"],


### PR DESCRIPTION
## Summary

This builds on #2040 (`49476919`), which landed while this was in flight and made the *other* half of #2004 visible: a deliberate repository-selection refusal now logs at `info`. **That decision stands untouched here** — a refusal is the feature working as designed, and this PR neither changes that log, its level, its wording, nor its test. This branch was rebased onto it and everything it already covers was dropped.

What remains invisible on `next` is the other kind of workspace start failure: the clone that fails, the archive that will not validate, the upload that times out, the coordinator that is not wired. Those still fall into the broad start-failure clause in `_attempt`, which logs an event id and an anonymous `repr` — naming neither the agent, the deployment, nor the repository — and then escalates to the user under the name `runner-error`, pointing whoever reads it at a runner that never saw the fault. The issue asks for exactly this: *"A failed clone should fail the turn loudly and say so in the reply, or at minimum log the agent, the repository and the reason."*

Preparation failures now get their own handler (placed after the refusal's, which must keep running first — it is a subclass) emitting one WARNING naming the event, agent, deployment, requested repository, failing stage and a never-empty reason. WARNING rather than the refusal's INFO because the two are different kinds of thing: a refusal is a decision, a failed clone is a fault. They also gain a `workspace-error` classification following #2011's `runner-timeout` precedent — retry semantics deliberately unchanged, only the name and the log.

## Related issue

Ref #2004

<!-- Deliberately `Ref`, not `Closes`: #2040 already addressed the refusal path.
     Whether the issue closes with this one is the maintainer's call. -->

## Fix pin verification

Fix pin: apps/worker/tests/kernel/test_consumer.py::test_failed_workspace_preparation_acks_the_entry_and_is_not_silent

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | Worker-internal: one log line and one retry classification. No skill, bundle, or agent surface is touched. | — | — |
| local | n/a | No compose service, profile, image, or env plumbing changes. The observable behavior is exercised against a real Valkey stream and the real `Consumer` below. | — | — |
| local-release | n/a | No released artifact, install path, or version pin changes. | — | — |
| cluster | n/a | No chart, RBAC, securityContext, or controller change. | — | — |
| live provider | n/a | No provider auth, model routing, or external API shape involved. | — | — |
| external integration | n/a | No adapter, connector, or third-party contract changes. | — | — |

Behavior-bearing, but every deployed tier is genuinely n/a: the change adds an operator log line and names one retry classification inside the worker kernel. The seam where the reported symptom manifests — an entry acked with an empty log — is proved directly against a real Valkey stream and the real consumer.

```
TEST_VALKEY_PORT=<port> CI_REQUIRE_VALKEY_TESTS=1 uv run pytest -q apps/worker/tests/kernel packages/telemetry/tests
398 passed, 2 skipped in 50.95s
uv run ruff check .        -> All checks passed!
uv run mypy                -> Success: no issues found in 232 source files
bash scripts/check-docs.sh -> OK
uv run lint-imports        -> Contracts: 4 kept, 0 broken.
```

Four regressions, each verified to FAIL on this base (`812d86c9`) by reverting only `kernel.py` and the telemetry source and re-running them:

| Regression | Failure on the base |
| --- | --- |
| `test_consumer.py::test_failed_workspace_preparation_acks_the_entry_and_is_not_silent` | `the entry was acked with no sandbox and no line naming the agent` — `pending == 0` passed, the log assertion failed |
| `test_kernel.py::test_workspace_preparation_failure_escalates_by_its_own_name` | `The run failed (runner-error) after 3 attempt(s)` — the escalation did not name the workspace |
| `test_kernel.py::test_workspace_enabled_binding_without_deployment_id_is_named` | `the binding misconfiguration was unnamed: ''` |
| `test_kernel.py::test_binding_failure_on_an_ambiguous_message_logs_without_re_raising` | `the binding misconfiguration was unnamed: ''` |

Negative / independent path: the ambiguous-message regression drives the **real** `parse_github_repo_fact`, which itself refuses a two-repository message. Guard demonstration by execution rather than by reading — deleting the `try/except` that makes the repository lookup total made that test fail with `WorkspaceSelectionRefused` escaping and replacing the fault being reported, which is the exact regression the guard exists to prevent.

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.
- [x] Or: this change is not behavior-bearing at any deployed tier, and the summary says why.

## Checklist

- [x] Tests pass for the area I touched.
- [x] Docs updated (`apps/worker/README.md`, `apps/worker/CLAUDE.md`) — rewritten to describe both halves honestly: the refusal is terminal, answers the user and logs at INFO; every other workspace start failure is a fault that retries under `workspace-error` and logs a WARNING naming agent, deployment, repository and stage.
- [ ] An ADR is added under `docs/adr/` — not an architectural decision; it follows the classification pattern established for `runner-timeout` (#2011).

## Review record

Adversarial review ran cross-engine and read-only on Codex. `agent-router adversarial-review` selected grok and returned `status: failed` on an infrastructure error (`secure Grok storage requires openat2 on Linux kernel 5.6 or newer`) — a reviewer-infrastructure failure, not a quota skip — so the review used the Codex path this repo's conventions name. Three blocking findings were raised against the pre-rebase diff and all three were fixed; a re-review of the fix delta returned no blocking findings.

1. **A regression the first draft introduced.** The new log helper called `parse_github_repo_fact`, which itself raises on a multi-repository message, from inside a handler for that same exception — it would have re-raised before the log, swallowed the reply, and left the entry pending until dead-letter. Fixed by making the lookup total, and pinned by the regression above.
2. **One workspace start failure bypassed the helper**: a workspace-enabled deployment carrying no `deployment_id`, raised in `_process_event` before `_attempt` exists. It now logs through the same helper; the raise, and the entry staying pending, are deliberately unchanged.
3. **No regression asserted the ACK half of the symptom.** Added the consumer-seam test.

Scope review mapped every non-trivial hunk to an acceptance criterion. The telemetry allowlist / schema enum / `cardinality_bound` 8→10 changes are mechanical consequences of naming a new retryable class — `record_metric` raises on an out-of-domain value, so omitting them would crash the worker on the retry emission. No drive-by changes, no frozen-contract or ADR changes.

Out of scope by design: the underlying reason the reporter's own workspace could not start. This makes that reason visible; it does not diagnose it. Also unchanged, per #2040's author: whether a hook-originated turn should surface a refusal anywhere a person can see it.
