### PR TITLE
fix(cli): answer bare `skill observability` with exit 4, not clap usage

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1243,8 +1243,11 @@ enum SkillAction {
         commands::OBSERVABILITY_REASON, commands::OBSERVABILITY_ALT,
     ))]
     Observability {
+        /// Optional so the bare form (no leaf) reaches the exit-4 capability
+        /// refusal below instead of dying as a clap usage error (issue
+        /// #1955, ADR-0041).
         #[command(subcommand)]
-        _query: SkillObservabilityQuery,
+        _query: Option<SkillObservabilityQuery>,
     },
     /// Stop and remove the local runner container.
     Down {

--- a/cli/tests/observability_query.rs
+++ b/cli/tests/observability_query.rs
@@ -1233,3 +1233,95 @@ fn skill_observability_queries_are_answered_as_unavailable_with_cross_tier_guida
         );
     }
 }
+
+/// ADR-0041 parity means the **bare** form (no leaf) is answered at every
+/// tier, not just the query leaves covered above: the skill tier answers with
+/// the capability refusal (exit 4, `{error, fix}`), while local and cluster
+/// answer with their surface/plan payloads (exit 0). Before #1955 the skill
+/// tier alone declared its subcommand field non-optional, so clap's
+/// `subcommand_required` kicked in and `curie skill observability` with no
+/// leaf died as a clap usage error -- exit 2, help on stderr, empty stdout --
+/// instead of ever reaching `commands::skill_observability_unavailable()`.
+#[test]
+fn bare_observability_is_answered_at_every_tier_and_refused_at_skill() {
+    // skill: the bare form must reach the exit-4 capability refusal, not
+    // clap's subcommand-required usage error.
+    let output = Command::new(bin())
+        .args(["--json", "skill", "observability"])
+        .stdin(Stdio::null())
+        .env_remove("CURIE_API_URL")
+        .env_remove("CURIE_API_KEY")
+        .output()
+        .unwrap_or_else(|error| panic!("run skill observability: {error}"));
+
+    assert_eq!(
+        output.status.code(),
+        Some(4),
+        "bare skill observability must exit 4, not clap's usage exit 2\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("Usage: curie skill observability"),
+        "bare skill observability must not fall back to clap's subcommand-required usage help \
+         (the #1955 regression): stderr: {stderr}"
+    );
+
+    let value = one_stdout_object(&output);
+    assert_only_error_fix(&value);
+
+    let error = value["error"].as_str().unwrap().to_ascii_lowercase();
+    assert!(
+        error.contains("not available at this tier") && error.contains("skill"),
+        "the error must identify skill-tier capability absence: {value}"
+    );
+
+    let fix = value["fix"].as_str().unwrap().to_ascii_lowercase();
+    assert!(
+        fix.contains("curie local observability") || fix.contains("curie cluster observability"),
+        "the fix must point to a platform query tier: {value}"
+    );
+    assert!(
+        !fix.contains("retry"),
+        "an unsupported skill-tier query must not masquerade as transient: {value}"
+    );
+
+    // local: the parity control -- the sibling tier answers the same bare
+    // verb with its surface report, not a refusal. `commands::observability`
+    // is a pure URL printer, so this needs no running stack.
+    let output = Command::new(bin())
+        .args(["--json", "local", "observability"])
+        .stdin(Stdio::null())
+        .output()
+        .unwrap_or_else(|error| panic!("run local observability: {error}"));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("Usage: curie local observability"),
+        "bare local observability must not fall back to clap usage help: stderr: {stderr}"
+    );
+    let value = assert_success(&output, "bare local observability");
+    assert!(
+        value["surfaces"].as_array().is_some(),
+        "bare local observability must report its surfaces array: {value}"
+    );
+
+    // cluster: same parity control, via --dry-run so no kubectl/helm is
+    // shelled out -- the plan payload is returned before
+    // `require_on_path("kubectl")` runs.
+    let output = Command::new(bin())
+        .args(["--json", "cluster", "observability", "--dry-run"])
+        .stdin(Stdio::null())
+        .output()
+        .unwrap_or_else(|error| panic!("run cluster observability --dry-run: {error}"));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("Usage: curie cluster observability"),
+        "bare cluster observability --dry-run must not fall back to clap usage help: stderr: {stderr}"
+    );
+    let value = assert_success(&output, "bare cluster observability --dry-run");
+    assert!(
+        value.as_object().is_some_and(|object| !object.is_empty()),
+        "bare cluster observability --dry-run must report a non-empty plan payload: {value}"
+    );
+}


### PR DESCRIPTION
`curie skill observability` with no leaf declared its subcommand field non-`Option`, so clap_derive set `subcommand_required(true)` and `Cli::parse()` exited before the `SkillAction::Observability` arm could return the ADR-0041 capability refusal. An agent running `curie --json skill observability` got clap help on stderr, **empty stdout**, and exit **2** — "fix your input and retry" for a form no argv makes work. The same command at `local` exits 0 with a payload.

Declares `Option<SkillObservabilityQuery>`, matching the `local` and `cluster` siblings. The handler arm's `{ .. }` pattern already covered both shapes, so `skill_observability_unavailable()` and its reason/alternative constants are untouched.

## Evidence

| invocation | before | after |
|---|---|---|
| `curie --json skill observability` | exit **2**, empty stdout, clap help on stderr | exit **4**, exactly one `{error, fix}` object on stdout, stderr empty |
| `curie --json skill observability runs\|run\|metrics` | exit 4 | exit 4 (unchanged) |
| `curie --json skill observability bogus` | exit 2 | exit 2 (unchanged — a real typo is still a usage error, not swallowed into a refusal) |
| `curie skill observability --help` | lists the three leaves | unchanged |

**Red-on-revert:** reverting `cli/src/main.rs` alone and re-running the new test fails with `left: Some(2) right: Some(4)`.

**Checks:** `cargo fmt --check` clean · `cargo clippy --all-targets -- -D warnings` clean · `cargo test --test observability_query` 17 passed · full `cli` suite matches base exactly (the two `cluster_connection_transport` failures under parallel load reproduce identically on a clean `origin/next` checkout and are unrelated to this diff) · `curie schema` is byte-identical to the committed `cli/command-manifest.json`, so no manifest regeneration is required.

## Test scope note

The new test drives the **bare** form at all three tiers. Beyond the skill tier's exit class and JSON body, it also asserts that `fix` does not contain "retry" (mirroring the existing per-leaf forcing test verbatim), that bare `local` reports its `surfaces` array, and that bare `cluster --dry-run` returns a non-empty plan. Those three assertions are what make the local/cluster arms a real parity control rather than a bare exit-code check — they encode the contrast the issue itself cites. The cluster arm uses `--dry-run` so it returns before `require_on_path("kubectl")`; the whole test is hermetic (no Docker, kubectl, helm, network, or browser).

No production-code change beyond the one field declaration.

Ref #1955