### PR TITLE
Gate Curie's own skills against the Agent Skills spec

### DIFF
--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -1,7 +1,12 @@
 ---
 name: implement
-disable-model-invocation: true
 description: Implement a ticket or feature with proportional planning, test first behavior changes, independent review when available, and verification through the real affected surface.
+# disable-model-invocation sits under metadata because the Agent Skills spec
+# only allows a fixed set of top-level fields; Claude Code reads this key only
+# at top level, so it no longer takes effect here. Full rationale:
+# docs/interfaces/bundle-format/INTERFACE.md
+metadata:
+  disable-model-invocation: "true"
 ---
 
 # Implement

--- a/.github/workflows/agent-skills.yaml
+++ b/.github/workflows/agent-skills.yaml
@@ -1,0 +1,50 @@
+name: Agent Skills
+
+# Curie's own skills must satisfy the published Agent Skills spec directly, not
+# merely load through our deliberately lenient plugin-format loader. This gate
+# is the inbound spec-conformance twin of plugin-compat, which defends the
+# outbound direction (a Curie bundle validates as a Claude Code plugin).
+#
+# Unlike plugin-compat, there is NO `schedule` trigger, and that difference is
+# deliberate. plugin-compat validates against a floating external CLI, so a
+# nightly run catches Claude Code changing the format under us with no PR of
+# ours involved. This gate pins the reference validator (skills-ref==0.1.1 in
+# scripts/check-agent-skills.sh) precisely so it is deterministic, so a nightly
+# run could never surface anything a path-filtered PR run did not. Adopting a
+# newer spec revision is a reviewed edit to that pin, not a surprise from cron.
+on:
+  pull_request:
+    branches: [main, next]
+    paths:
+      - ".claude/skills/**"
+      - "examples/**"
+      - "packages/plugin-format/tests/fixtures/**"
+      - "runner/tests/fixtures/**"
+      - "scripts/check-agent-skills.sh"
+      - ".github/workflows/agent-skills.yaml"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  agent-skills:
+    name: Skills conform to the Agent Skills spec
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      # Pinning the setup-uv action alone still leaves the resolver floating:
+      # uv's own version decides which transitive deps of the pinned validator
+      # get resolved, so pin the uv version too to keep this gate deterministic.
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          version: "0.10.7"
+      - name: Validate every Curie-owned skill
+        run: bash scripts/check-agent-skills.sh

--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -4316,6 +4316,11 @@ export const commandManifest = {
           "name": "plugin-compat"
         },
         {
+          "about": "Validate every Curie-owned skill against the Agent Skills reference validator, pinned to `skills-ref==0.1.1` so the gate is deterministic (`bash scripts/check-agent-skills.sh`). The inbound spec-conformance twin of `plugin-compat`: that one proves our bundles are accepted by Claude Code, this one proves our skills satisfy the published spec",
+          "hidden": false,
+          "name": "agent-skills"
+        },
+        {
           "about": "Run the committed eval suites through the fake model and assert every case goes RED -- the falsifiability gate's real-path negative control (#619, `bash cli/scripts/eval-falsifiability.sh`). Offline, no credential",
           "hidden": false,
           "name": "eval-falsifiability"

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -4313,6 +4313,11 @@
           "name": "plugin-compat"
         },
         {
+          "about": "Validate every Curie-owned skill against the Agent Skills reference validator, pinned to `skills-ref==0.1.1` so the gate is deterministic (`bash scripts/check-agent-skills.sh`). The inbound spec-conformance twin of `plugin-compat`: that one proves our bundles are accepted by Claude Code, this one proves our skills satisfy the published spec",
+          "hidden": false,
+          "name": "agent-skills"
+        },
+        {
           "about": "Run the committed eval suites through the fake model and assert every case goes RED -- the falsifiability gate's real-path negative control (#619, `bash cli/scripts/eval-falsifiability.sh`). Offline, no credential",
           "hidden": false,
           "name": "eval-falsifiability"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -633,6 +633,12 @@ enum DevAction {
     DocsLint,
     /// Validate every `examples/` bundle against Claude Code (`bash scripts/check-plugin-compat.sh`).
     PluginCompat,
+    /// Validate every Curie-owned skill against the Agent Skills reference
+    /// validator, pinned to `skills-ref==0.1.1` so the gate is deterministic
+    /// (`bash scripts/check-agent-skills.sh`). The inbound spec-conformance twin
+    /// of `plugin-compat`: that one proves our bundles are accepted by Claude
+    /// Code, this one proves our skills satisfy the published spec.
+    AgentSkills,
     /// Run the committed eval suites through the fake model and assert every case
     /// goes RED -- the falsifiability gate's real-path negative control (#619,
     /// `bash cli/scripts/eval-falsifiability.sh`). Offline, no credential.
@@ -2281,6 +2287,9 @@ async fn run(command: Option<Command>) -> Result<()> {
             DevAction::DocsLint => commands::dev_script("scripts/check-docs.sh", &[]).await,
             DevAction::PluginCompat => {
                 commands::dev_script("scripts/check-plugin-compat.sh", &[]).await
+            }
+            DevAction::AgentSkills => {
+                commands::dev_script("scripts/check-agent-skills.sh", &[]).await
             }
             DevAction::EvalFalsifiability => {
                 commands::dev_script("cli/scripts/eval-falsifiability.sh", &[]).await
@@ -4355,6 +4364,14 @@ mod tests {
             cli.command,
             Some(Command::Dev {
                 action: DevAction::DocsLint
+            })
+        ));
+        let cli = Cli::try_parse_from(["curie", "dev", "agent-skills"])
+            .expect("dev agent-skills should parse");
+        assert!(matches!(
+            cli.command,
+            Some(Command::Dev {
+                action: DevAction::AgentSkills
             })
         ));
         let cli = Cli::try_parse_from(["curie", "dev", "eval-falsifiability"])

--- a/docs/interfaces/bundle-format/INTERFACE.md
+++ b/docs/interfaces/bundle-format/INTERFACE.md
@@ -106,6 +106,40 @@ promotes unknown-field warnings to errors, and the five Curie authoring extensio
 unknown-to-Claude-Code by design, so warnings are the expected steady state and only a non-zero
 exit is a failure.
 
+Outbound compatibility and **spec conformance** are different contracts, and the second needs its
+own gate: Claude Code accepting our bundles does not establish that the skills inside them satisfy
+the published Agent Skills spec, which is stricter about what a `SKILL.md` frontmatter may contain.
+`scripts/check-agent-skills.sh` (run it as `curie dev agent-skills`) defends that direction, and CI
+runs the same script from `.github/workflows/agent-skills.yaml`. Determinism here takes three pins
+working together, not one: `SKILLS_REF_VERSION` fixes the reference validator at
+`skills-ref==0.1.1`, `SKILLS_REF_EXCLUDE_NEWER` is threaded through every `uvx` invocation as a
+resolution cutoff that freezes the transitive dependency set, and the workflow pins the uv version
+on its `setup-uv` step because uv's resolver is what picks those transitive deps. The transitive
+set matters because it decides verdicts — `skills-ref` declares floating dependencies, and
+strictyaml's refusal of JSON-style flow collections is precisely what makes `allowed-tools: []`
+fail, so a strictyaml release could flip the gate with no change of ours. Given those three pins
+and a reachable PyPI the gate is deterministic, which is why this workflow has no nightly
+`schedule` trigger while plugin-compat does, since a pinned validator cannot drift between runs and
+adopting a newer spec revision is a reviewed edit. The check runs over an explicit allowlist rather
+than pure discovery, and a discovery drift check asserts that allowlist covers exactly the skills
+found under the Curie-owned roots, so a newly added skill cannot silently escape the gate by being
+unlisted. The script also preflights the validator and refuses to emit any verdict when it cannot
+be resolved or launched, so a network failure reds the gate rather than being mistaken for a skill
+being invalid — which is what lets the next claim be trusted. The fixture
+`packages/plugin-format/tests/fixtures/bad_skill/skills/broken` is carried as an **asserted
+negative**: the gate requires the reference validator to keep rejecting it, which makes
+the deliberately malformed fixture proof that the gate is not vacuous rather than an unexplained
+exclusion. Note that this constrains Curie's OWN skills only — the `plugin_format` loader stays
+deliberately lenient and keeps accepting Claude-Code-shaped bundles carrying keys the spec does not
+know about, and the two bars are intentionally different.
+
+Conforming had one real cost, paid once. `.claude/skills/implement` is the single skill the gate
+forced a migration on: its top-level `disable-model-invocation: true` is not one of the fixed
+fields the spec allows, so it moved under `metadata`, the spec's designated slot for vendor
+extensions. That keeps the declaration but drops its effect — Claude Code reads the key only at the
+top level, so it no longer enforces slash-command-only invocation for that skill. Nothing in this
+repo reads the key, and the trade is accepted deliberately.
+
 ## Implementations today
 
 One: the `plugin_format` package. **Unlike `aci-protocol`, it is NOT tri-language with generated

--- a/runner/tests/fixtures/mcp_green/skills/green/SKILL.md
+++ b/runner/tests/fixtures/mcp_green/skills/green/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: green
 description: Placeholder skill so the bundle passes plugin-format validation.
-allowed-tools: []
 ---
 
 # Green
 
-Placeholder skill body; the bundle exists to exercise MCP tool loading.
+Placeholder skill body; the bundle exists to exercise MCP tool loading, so it
+declares no `allowed-tools` and the loader's `None` default stands.

--- a/runner/tests/fixtures/mcp_red_broken/skills/broken/SKILL.md
+++ b/runner/tests/fixtures/mcp_red_broken/skills/broken/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: broken
 description: Placeholder skill so the bundle passes plugin-format validation.
-allowed-tools: []
 ---
 
 # Broken
 
 Placeholder skill body; the inline MCP server exits immediately and reaches status failed.
+No `allowed-tools` is declared, so the loader's `None` default stands.

--- a/runner/tests/fixtures/mcp_red_pointer/skills/red/SKILL.md
+++ b/runner/tests/fixtures/mcp_red_pointer/skills/red/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: red
 description: Placeholder skill so the bundle passes plugin-format validation.
-allowed-tools: []
 ---
 
 # Red
 
 Placeholder skill body; the bundle's MCP declaration is the broken string-pointer form.
+No `allowed-tools` is declared, so the loader's `None` default stands.

--- a/scripts/check-agent-skills.sh
+++ b/scripts/check-agent-skills.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# Assert every Curie-owned skill still validates against the official Agent
+# Skills reference validator. This is the INBOUND spec-conformance twin of
+# scripts/check-plugin-compat.sh: that script proves a Curie bundle validates
+# unmodified as a Claude Code plugin (outbound compatibility), this one proves
+# our own SKILL.md files satisfy the Agent Skills spec directly. They are
+# different contracts -- the plugin-format loader stays deliberately lenient so
+# Claude-Code-shaped bundles keep loading, while this gate holds Curie's own
+# skills to the stricter published spec.
+set -euo pipefail
+
+# The pin is deliberate. A gate that floats to whatever the newest spec revision
+# happens to be is not deterministic: the same commit could pass today and fail
+# tomorrow with no change of ours. Bumping this version is a reviewed edit, and
+# the migration it forces is the point.
+SKILLS_REF_VERSION="0.1.1"
+# Pinning the version alone does NOT make the gate deterministic. skills-ref
+# declares floating dependencies (`click>=8.0`, `strictyaml>=1.7.3`) and uvx
+# resolves the newest compatible transitive versions at run time -- and it is the
+# transitive set, strictyaml in particular, that decides verdicts here:
+# strictyaml's refusal of JSON-style flow collections is precisely what makes
+# `allowed-tools: []` fail. A strictyaml release could therefore flip this gate
+# with no change of ours. The resolution cutoff freezes the whole dependency set,
+# so moving it is a reviewed edit exactly like the version bump.
+SKILLS_REF_EXCLUDE_NEWER="2026-08-29T00:00:00Z"
+# The distribution is `skills-ref`, but its console script is named
+# `agentskills`, not `skills-ref`.
+SKILLS_REF_BIN="agentskills"
+# Every uvx invocation in this file shares one flag array. Spelling the pins out
+# per call site invites a future bump that lands on some invocations and misses
+# others, which is the same silently-inconsistent state the pin exists to prevent.
+uvx_args=(--from "skills-ref==$SKILLS_REF_VERSION" --exclude-newer "$SKILLS_REF_EXCLUDE_NEWER")
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+if ! command -v uvx >/dev/null 2>&1; then
+  echo "ERROR: 'uvx' is not on PATH, so the Agent Skills reference validator cannot be run." >&2
+  echo "Install uv (curl -LsSf https://astral.sh/uv/install.sh | sh) and re-run." >&2
+  exit 1
+fi
+
+# uvx exits 1 when it cannot resolve or launch the tool -- the same status the
+# validator uses to REJECT a skill. Exit status alone therefore cannot separate
+# "the malformed fixture was correctly rejected" from "the network was down", so
+# the validator has to be proven runnable BEFORE any status is interpreted below.
+echo "== resolving the Agent Skills reference validator =="
+if ! skills_ref_version_line="$(uvx "${uvx_args[@]}" "$SKILLS_REF_BIN" --version 2>&1)"; then
+  echo "ERROR: the Agent Skills reference validator could not be resolved or launched." >&2
+  echo "This is NOT 'a skill is invalid': no verdict from this gate can be trusted," >&2
+  echo "positive or negative, because a resolution failure is indistinguishable from a" >&2
+  echo "validation rejection by exit status alone. uvx said:" >&2
+  printf '%s\n' "$skills_ref_version_line" >&2
+  echo "Check network access to PyPI, and that skills-ref==$SKILLS_REF_VERSION still" >&2
+  echo "resolves under --exclude-newer $SKILLS_REF_EXCLUDE_NEWER." >&2
+  exit 1
+fi
+# Record which validator actually ran, so the CI log says what produced the verdict.
+printf 'using %s\n' "$skills_ref_version_line"
+
+# Skills that MUST validate clean against the reference validator. Every path is
+# relative to the repo root.
+VALID_SKILLS=(
+  ".claude/skills/implement"
+  ".claude/skills/update-architecture-atlas"
+  "examples/github-issues/skills/github-issues"
+  "examples/sre-bot/skills/sre-bot"
+  "examples/text-stats-engine/skills/text-stats"
+  "examples/weather/skills/weather"
+  "packages/plugin-format/tests/fixtures/valid_bundle/skills/greeter"
+  "runner/tests/fixtures/mcp_green/skills/green"
+  "runner/tests/fixtures/mcp_red_broken/skills/broken"
+  "runner/tests/fixtures/mcp_red_pointer/skills/red"
+)
+
+# Skills that MUST be REJECTED, asserted as negatives rather than quietly
+# excluded. bad_skill/skills/broken omits the required `description` field by
+# construction -- that malformation is the fixture's whole reason to exist, and
+# requiring the reference validator to keep rejecting it is what proves this
+# gate is not vacuous.
+INVALID_SKILLS=(
+  "packages/plugin-format/tests/fixtures/bad_skill/skills/broken"
+)
+
+if [ "${#VALID_SKILLS[@]}" -eq 0 ]; then
+  echo "ERROR: VALID_SKILLS is empty, so this gate would pass vacuously." >&2
+  echo "An empty positive set defeats the purpose of the check." >&2
+  exit 1
+fi
+
+# Curie-owned roots that may contain a SKILL.md. An allowlist alone silently
+# stops covering anything added later, so discovery drift is checked explicitly
+# below: a new skill must be classified, never merely unlisted.
+SKILL_ROOTS=(
+  ".claude/skills"
+  "examples"
+  "packages/plugin-format/tests/fixtures"
+  "runner/tests/fixtures"
+)
+
+# find(1) runs inside a process substitution below, so its exit status never
+# reaches this shell -- `set -euo pipefail` cannot see it. A vanished root would
+# just shrink the discovered set, and if the matching list entries were dropped in
+# the same change the drift check would reconcile and PASS while checking nothing.
+# Requiring each root to exist keeps that failure legible.
+missing_roots=()
+for root in "${SKILL_ROOTS[@]}"; do
+  if [ ! -d "$root" ]; then
+    missing_roots+=("$root")
+  fi
+done
+if [ "${#missing_roots[@]}" -gt 0 ]; then
+  echo "ERROR: ${#missing_roots[@]} SKILL_ROOTS entry/entries do not exist: ${missing_roots[*]}" >&2
+  echo "The roots list is stale, so discovery cannot be trusted: skills under a moved or" >&2
+  echo "renamed root are invisible here and this gate would pass without checking them." >&2
+  echo "Update SKILL_ROOTS in scripts/check-agent-skills.sh." >&2
+  exit 1
+fi
+
+echo "== discovering skills under ${SKILL_ROOTS[*]} =="
+discovered=()
+# The validator's own find_skill_md accepts both SKILL.md and lowercase
+# skill.md. Discovery has to match both spellings too, or a skill.md-only
+# directory is invisible here while still validating -- the exact escape this
+# drift check exists to catch.
+while IFS= read -r skill_md; do
+  discovered+=("$(dirname "$skill_md")")
+done < <(find "${SKILL_ROOTS[@]}" \( -name SKILL.md -o -name skill.md \) | sort)
+echo "found ${#discovered[@]} skill(s)"
+
+listed=()
+listed+=("${VALID_SKILLS[@]}")
+listed+=("${INVALID_SKILLS[@]}")
+
+echo "== checking the allowlist covers exactly the discovered skills =="
+# Associative-array lookups turn both set differences into O(n+m): `[[ -v ...
+# ]]` tests membership without expanding the value, so it is safe under
+# `set -u` even for keys that were never assigned.
+declare -A listed_map=()
+for known in "${listed[@]}"; do
+  listed_map["$known"]=1
+done
+unlisted=()
+for skill in "${discovered[@]}"; do
+  [[ -v listed_map[$skill] ]] || unlisted+=("$skill")
+done
+
+declare -A discovered_map=()
+for skill in "${discovered[@]}"; do
+  discovered_map["$skill"]=1
+done
+stale=()
+for known in "${listed[@]}"; do
+  [[ -v discovered_map[$known] ]] || stale+=("$known")
+done
+
+drifted=0
+if [ "${#unlisted[@]}" -gt 0 ]; then
+  echo "ERROR: ${#unlisted[@]} skill(s) escaped the gate: ${unlisted[*]}" >&2
+  echo "A new skill exists that neither list names, so nothing checks it. Add it to" >&2
+  echo "VALID_SKILLS in scripts/check-agent-skills.sh (or to INVALID_SKILLS with a" >&2
+  echo "comment naming why it must fail)." >&2
+  drifted=1
+fi
+if [ "${#stale[@]}" -gt 0 ]; then
+  echo "ERROR: ${#stale[@]} listed skill(s) no longer exist: ${stale[*]}" >&2
+  echo "The list in scripts/check-agent-skills.sh is stale. Drop the entries for" >&2
+  echo "skills that were moved or deleted." >&2
+  drifted=1
+fi
+if [ "$drifted" -ne 0 ]; then
+  exit 1
+fi
+echo "allowlist covers exactly the ${#discovered[@]} discovered skill(s)"
+
+echo "== validating each skill against Agent Skills $SKILLS_REF_VERSION =="
+failed=()
+for skill in "${VALID_SKILLS[@]}"; do
+  echo "-- $skill --"
+  if ! uvx "${uvx_args[@]}" "$SKILLS_REF_BIN" validate "$skill"; then
+    failed+=("$skill")
+  fi
+done
+
+if [ "${#failed[@]}" -gt 0 ]; then
+  echo "ERROR: the Agent Skills reference validator rejected ${#failed[@]} skill(s): ${failed[*]}" >&2
+  echo "Curie's own skills are held to the published spec: frontmatter must be" >&2
+  echo "strictyaml-parseable and may only carry name, description, license," >&2
+  echo "allowed-tools, metadata, and compatibility. Vendor extensions belong under" >&2
+  echo "the free-form 'metadata' map. Fix the skill, or update" >&2
+  echo "docs/interfaces/bundle-format/INTERFACE.md to record a new contract." >&2
+  exit 1
+fi
+
+echo "== asserting the deliberately malformed fixture(s) are still rejected =="
+passed=()
+unverdicted=()
+for skill in "${INVALID_SKILLS[@]}"; do
+  echo "-- $skill (must be rejected) --"
+  # "Nonzero" is not evidence of a rejection: a missing path exits 2 and a uvx
+  # resolution failure exits 1, the same as a real rejection. Only status 1
+  # carrying the validator's own marker is a verdict; anything else is a broken
+  # harness and must not be counted as this gate biting.
+  set +e
+  reject_output="$(uvx "${uvx_args[@]}" "$SKILLS_REF_BIN" validate "$skill" 2>&1)"
+  reject_status=$?
+  set -e
+  # The rejection reason is printed, not swallowed: the evidence that this gate
+  # bites belongs in the CI log.
+  printf '%s\n' "$reject_output"
+  if [ "$reject_status" -eq 0 ]; then
+    passed+=("$skill")
+  elif [ "$reject_status" -ne 1 ] || ! printf '%s' "$reject_output" | grep -q 'Validation failed for'; then
+    unverdicted+=("$skill")
+  fi
+done
+
+if [ "${#unverdicted[@]}" -gt 0 ]; then
+  echo "ERROR: could not obtain a validation verdict for ${#unverdicted[@]} skill(s): ${unverdicted[*]}" >&2
+  echo "The validator neither accepted nor rejected them: it exited with a status that" >&2
+  echo "is not a verdict, or exited 1 without printing 'Validation failed for'. That is a" >&2
+  echo "HARNESS failure (bad fixture path, resolution or launch problem), not a rejection," >&2
+  echo "and treating it as one is exactly how this gate would pass for the wrong reason." >&2
+  echo "Fix the environment or the listed path; the output above is the evidence." >&2
+  exit 1
+fi
+
+if [ "${#passed[@]}" -gt 0 ]; then
+  echo "ERROR: ${#passed[@]} asserted-invalid skill(s) now VALIDATE CLEAN: ${passed[*]}" >&2
+  echo "These fixtures are malformed on purpose and are what proves this gate is not" >&2
+  echo "vacuous. Either the fixture stopped being malformed (restore the defect, or" >&2
+  echo "the tests that depend on it are already broken) or the spec now accepts it" >&2
+  echo "and the entry belongs in VALID_SKILLS instead." >&2
+  exit 1
+fi
+
+echo "OK: ${#VALID_SKILLS[@]} skill(s) conform to Agent Skills $SKILLS_REF_VERSION; ${#INVALID_SKILLS[@]} asserted-invalid fixture(s) still rejected."


### PR DESCRIPTION
## Summary

Outbound plugin compatibility and inbound spec conformance are different contracts. `scripts/check-plugin-compat.sh` proves a Curie bundle validates as a Claude Code plugin; nothing proved the skills *inside* those bundles satisfy the published Agent Skills spec, which is stricter about `SKILL.md` frontmatter. Two of ours did not. This adds `scripts/check-agent-skills.sh` (`curie dev agent-skills`, CI via `.github/workflows/agent-skills.yaml`), which runs the official reference validator over an explicit allowlist of Curie-owned skills, migrates the two nonconforming cases, and carries the deliberately malformed fixture as an asserted negative. The `plugin_format` loader is untouched and stays lenient — this constrains Curie's own skills only, and the two bars are intentionally different.

**Determinism is three pins, not one.** The validator version (`skills-ref==0.1.1`), an `--exclude-newer` cutoff that freezes its transitive dependency set, and the uv version on the workflow step. The cutoff is load-bearing rather than belt-and-braces: strictyaml's refusal of JSON-style flow collections is what makes `allowed-tools: []` fail, and strictyaml floats in the validator's own dependency spec, so a strictyaml release could otherwise have flipped this gate's verdict with no change of ours. That determinism is also why this workflow has no nightly `schedule` while plugin-compat does — a pinned validator cannot drift between runs.

**Two ways the gate refuses to pass for the wrong reason.** An allowlist silently stops covering what is added later, so a discovery drift check asserts it names exactly the skills found under the four Curie-owned roots, reporting an escaped skill and a stale entry as distinct failures. And because a `uvx` resolution failure exits 1 — indistinguishable from a validation rejection by status alone — a preflight refuses to emit any verdict when the validator cannot be resolved, and the negative pass requires exit 1 **and** the validator's own `Validation failed for` marker.

**Migrations the gate forced.** `.claude/skills/implement` moves the nonstandard `disable-model-invocation` under the spec's free-form `metadata` map; three runner MCP fixtures drop `allowed-tools: []`. One trade-off is worth a reviewer's attention: re-homing that key keeps the declaration but drops its effect, because Claude Code reads it only at top level, so the repo-local `/implement` skill becomes model-invocable. Nothing in this repo reads the key (it appeared exactly once repo-wide), the alternative was leaving the skill nonconforming, and the cost is recorded in `docs/interfaces/bundle-format/INTERFACE.md` and in a frontmatter comment at the site. Reversing it is a one-line call if you would rather keep the Claude Code behavior than conform.

## Related issue

Ref: no tracked issue — opportunistic conformance work.

## End-to-end verification

This change is not behavior-bearing for the product: it adds a CI gate and migrates skill frontmatter. No deployment tier exercises it, so the tiers below are n/a. The gate itself is a guard, and a guard is only proved by watching it reject — every violation class below was executed, not read.

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | No runtime path changes; the diff is a CI gate plus SKILL.md frontmatter | — | — |
| local | n/a | No compose service or runtime behavior touched | — | — |
| local-release | n/a | No release artifact behavior touched | — | — |
| cluster | n/a | No chart, RBAC, or cluster path touched | — | — |
| live provider | n/a | No provider or credential path touched | — | — |
| external integration | n/a | No external integration touched | — | — |

**Guard demonstration — every violation class executed against commit `462bd66`:**

| Violation injected | Observed |
| --- | --- |
| Curie skill regains a nonstandard top-level field | exit 1, names the field and the allowed set |
| The asserted-negative fixture stops being malformed | exit 1, "now VALIDATE CLEAN" |
| A new skill is added but not listed | exit 1, "escaped the gate" |
| A listed skill is deleted | exit 1, "no longer exist" |
| A skill spelled `skill.md` (lowercase) escapes discovery | exit 1, "escaped the gate" |
| The validator cannot be resolved (preflight) | exit 1, states explicitly this is NOT "a skill is invalid" |
| A harness failure lands only in the negative pass | exit 1, "could not obtain a validation verdict" — the false-success path is closed |

Clean run: `OK: 10 skill(s) conform to Agent Skills 0.1.1; 1 asserted-invalid fixture(s) still rejected.`

Positive proof plus a falsifiable negative for each criterion: the 10 allowlisted skills validate clean (positive), the malformed fixture must still be rejected (negative), and the drift check is proved in both directions. Independently confirmed that the four `SKILL_ROOTS` cover every tracked skill in the repo — `git ls-files` finds 11 `SKILL.md`, and the gate discovers exactly those 11.

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.
- [x] Or: this change is not behavior-bearing, so no tier applies, and the summary says why.

## Checklist

- [x] Tests pass for the area I touched. `uv run --python 3.13 pytest packages/plugin-format/tests runner/tests/test_gate_shadowing.py tools/ci-workflow-paths/tests tools/ci-retry-gate/tests examples/tests/test_plugin_compat_coverage.py tools/doclint/tests -q` → 514 passed. `cargo test` → 1605 passed. `bash scripts/check-docs.sh` → OK. `ruff check .` → clean. `shellcheck scripts/check-agent-skills.sh` → clean.
- [x] Docs updated if behavior changed — `docs/interfaces/bundle-format/INTERFACE.md`.
- [x] An ADR is added under `docs/adr/` if this is an architectural decision — n/a, this implements conformance to an external published spec rather than deciding a Curie architecture question.

### Reviewer notes

- `cli/command-manifest.json` and `apps/ui/src/generated/commandManifest.ts` are regenerated artifacts (`curie schema`, then `node apps/ui/scripts/gen-command-manifest.mjs`), required in the same commit as a command-surface edit per `cli/CLAUDE.md`. Both diffs are additive-only.
- Deliberately **not** included: wrapping the `Install uv` step in this repo's retry trio. `tools/ci-retry-gate` is allowlist-based and passes as-is, so adding the retry would mean editing that gate's `RETRY_ALLOWLIST` — scope beyond this change. Transient PyPI flake reds this gate loudly rather than producing a wrong verdict, which is the property the preflight was built for. Worth a follow-up if the gate proves flaky.
