### PR TITLE
Partition a hook's conversation id per delivery, opt-in per hook (Draft ADR-0134)

### DIFF
--- a/apps/api/alembic/versions/0036_agents_hook_partitions.py
+++ b/apps/api/alembic/versions/0036_agents_hook_partitions.py
@@ -1,0 +1,68 @@
+"""agents.hook_partitions: which hooks fan out, and by what (ADR-0134)
+
+ADR-0079's inbound hook ingress gives every firing of one hook a single thread.
+This column is the operator's opt-in to narrowing that to one thread per
+PARTITION: it holds a JSONB map of hook name -> ``{"pointer": <RFC 6901>}``,
+where the pointer names the field of a delivery body that identifies the thing
+the delivery is about (a pull request number, a ticket key).
+
+The map lives on the agent row rather than travelling on the request because a
+partition named by the sender would sit outside the bytes the delivery's HMAC
+covers, and would hand whoever holds the hook secret this agent's sandbox
+cardinality. Nothing here is a credential: a pointer is configuration, and the
+value it reads never lands in this table.
+
+Nullable with no server default, because NULL IS the unpartitioned posture.
+Every existing agent reads as NULL and keeps minting the byte-identical
+three-segment conversation id it minted before, so the column needs no backfill
+and no row is rewritten.
+
+Numbered 0036 rather than 0035: 0035 is claimed by another migration in flight on
+this release train, and a duplicate revision id across the train breaks every
+operator upgrade silently, while a fork in the history is caught loudly by the
+head check.
+
+This revises 0034 for that reason, so whichever of the two merges SECOND must
+re-parent its own migration onto the other's head before it merges. Do not
+rewrite this ``down_revision`` once it has merged: a database already stamped at
+0036 will never retroactively run a 0035 inserted beneath it, and the one-head
+check cannot see that hole.
+
+Revision ID: 0036
+Revises: 0034
+Create Date: 2026-08-29
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0036"
+down_revision: str | None = "0034"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+SCHEMA = "curie"
+
+
+def upgrade() -> None:
+    op.add_column(
+        "agents",
+        sa.Column(
+            "hook_partitions",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+        schema=SCHEMA,
+    )
+
+
+def downgrade() -> None:
+    # Dropping the column silently returns every configured hook to one thread
+    # per hook: the deliveries that were fanning out start serializing again, and
+    # each partition's transcript is orphaned rather than continued. A downgrade
+    # here is a behavior event, not just a schema change, and the configuration
+    # it drops cannot be recovered from anywhere else.
+    op.drop_column("agents", "hook_partitions", schema=SCHEMA)

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -541,6 +541,20 @@
           "channel": {
             "$ref": "#/components/schemas/ChannelBindingWrite"
           },
+          "hook_partitions": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "$ref": "#/components/schemas/HookPartitionConfig"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Hook Partitions"
+          },
           "memory": {
             "default": false,
             "title": "Memory",
@@ -662,6 +676,20 @@
             "title": "Created At",
             "type": "string"
           },
+          "hook_partitions": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "$ref": "#/components/schemas/HookPartitionConfig"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Hook Partitions"
+          },
           "id": {
             "format": "uuid",
             "title": "Id",
@@ -733,6 +761,7 @@
           "thinking",
           "approval_required_tools",
           "approval_routes",
+          "hook_partitions",
           "secrets",
           "memory",
           "created_at"
@@ -770,6 +799,20 @@
               }
             ],
             "title": "Approval Routes"
+          },
+          "hook_partitions": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "$ref": "#/components/schemas/HookPartitionConfig"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Hook Partitions"
           },
           "memory": {
             "anyOf": [
@@ -2663,8 +2706,19 @@
         "type": "object"
       },
       "HookAccepted": {
-        "description": "The hook receipt. ``duplicate`` says whether THIS request enqueued.\n\n``stream_id`` is None only while another request holds the claim and has not\nenqueued yet (the 202 case).",
+        "description": "The hook receipt. ``duplicate`` says whether THIS request enqueued.\n\n``stream_id`` is None only while another request holds the claim and has not\nenqueued yet (the 202 case).\n\n``conversation_id`` is the thread this delivery ACTUALLY landed on. A\npartitioned hook (ADR-0134) mints one id per partition value, and the caller\nhas no other way to learn which of them it got -- it is the last segment of\nthe thread key that ``POST /agents/{agent_id}/threads/{thread_key}/reset``\ntakes, and it is also what the\n``GET /approvals?conversation_id=`` filter takes directly.\n\nOn a DUPLICATE it is read back from the queued turn, never re-derived from\nthis request's body: a retry of the same delivery id may carry a different\npartition value, or the operator may have changed the pointer since, and\neither would name a thread the queued turn never landed on.\n\nIt is None when the landing thread is not knowable from this request: a\npending twin still mid-flight, a stream an operator has trimmed, or the 202\nno-claim case where this request enqueued nothing and nothing is yet known.",
         "properties": {
+          "conversation_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Conversation Id"
+          },
           "duplicate": {
             "title": "Duplicate",
             "type": "boolean"
@@ -2688,9 +2742,25 @@
         "required": [
           "event_id",
           "stream_id",
-          "duplicate"
+          "duplicate",
+          "conversation_id"
         ],
         "title": "HookAccepted",
+        "type": "object"
+      },
+      "HookPartitionConfig": {
+        "additionalProperties": false,
+        "description": "How one hook names the thing each delivery is about (ADR-0134).\n\nOne model serves ``AgentCreate``, ``AgentUpdate`` AND ``AgentOut``, which the\n``_StoredWithoutNulls`` tripwire above would otherwise argue against: that\nsplit only happens for models carrying the wrap serializer, and this one has\nneither it nor an optional field, so the dumped and validated shapes are the\nsame and no ``-Input``/``-Output`` pair is generated. Do not add a separate\n``...Out`` variant.",
+        "properties": {
+          "pointer": {
+            "title": "Pointer",
+            "type": "string"
+          }
+        },
+        "required": [
+          "pointer"
+        ],
+        "title": "HookPartitionConfig",
         "type": "object"
       },
       "KillState": {
@@ -8797,7 +8867,7 @@
     },
     "/hooks/{agent_id}/{hook}": {
       "post": {
-        "description": "Verify one hook delivery and enqueue it as a turn.\n\nOrder, and why each step sits where it does:\n\n1. the hook NAME, validated before anything else, because it is about to be\n   used to build key names;\n2. the size bound, before the signature is computed, so an oversized body is\n   refused without the server ever HMAC-ing it;\n3. the agent row, which unavoidably precedes authentication here (see the\n   module docstring);\n4. the SIGNATURE over the raw body;\n5. the delivery id, checked after authentication so an unsigned caller learns\n   nothing about what this route wants;\n6. routability, then the claim, quota and enqueue.",
+        "description": "Verify one hook delivery and enqueue it as a turn.\n\nOrder, and why each step sits where it does:\n\n1. the hook NAME, validated before anything else, because it is about to be\n   used to build key names -- with ``fullmatch``, since the pattern's ``$``\n   matches before a trailing newline and would let one into those keys;\n2. the size bound, before the signature is computed, so an oversized body is\n   refused without the server ever HMAC-ing it;\n3. the agent row, which unavoidably precedes authentication here (see the\n   module docstring);\n4. the SIGNATURE over the raw body;\n5. the delivery id, checked after authentication so an unsigned caller learns\n   nothing about what this route wants;\n6. the PARTITION this delivery belongs to, if the hook has one (ADR-0134),\n   after both of those and before anything is claimed;\n7. routability, then the claim, quota and enqueue.",
         "operationId": "ingest_hook_hooks__agent_id___hook__post",
         "parameters": [
           {

--- a/apps/api/src/curie_api/crud.py
+++ b/apps/api/src/curie_api/crud.py
@@ -38,6 +38,7 @@ from .schemas import (
     ChannelBindingPatch,
     ChannelBindingWrite,
     DeploymentCreate,
+    HookPartitionConfig,
     PublicationCreate,
     VersionCreate,
 )
@@ -175,6 +176,7 @@ async def create_agent(session: AsyncSession, data: AgentCreate) -> Agent:
             if data.approval_routes is not None
             else None
         ),
+        hook_partitions=_stored_hook_partitions(data.hook_partitions),
         secrets=data.secrets,
         memory=data.memory,
     )
@@ -394,6 +396,35 @@ async def update_agent_approval_routes(
     resolution surface)."""
 
     agent.approval_routes = routes or None
+    await session.commit()
+    await session.refresh(agent)
+    return agent
+
+
+def _stored_hook_partitions(
+    partitions: dict[str, HookPartitionConfig] | None,
+) -> dict[str, Any] | None:
+    """The column value for a hook-partition map (ADR-0134).
+
+    One definition for both write paths, because create and PATCH must not
+    disagree about what "no configuration" looks like in the column: an empty
+    map is stored as NULL, the same "every hook returns to one thread per hook"
+    posture as an omitted map, which is what an operator turning the feature
+    off is asking for.
+    """
+
+    if not partitions:
+        return None
+    return {name: c.model_dump() for name, c in partitions.items()}
+
+
+async def update_agent_hook_partitions(
+    session: AsyncSession, agent: Agent, partitions: dict[str, HookPartitionConfig]
+) -> Agent:
+    """Set which of the agent's hooks fan out (ADR-0134). An empty dict clears
+    them (stored as NULL)."""
+
+    agent.hook_partitions = _stored_hook_partitions(partitions)
     await session.commit()
     await session.refresh(agent)
     return agent

--- a/apps/api/src/curie_api/hook_partition.py
+++ b/apps/api/src/curie_api/hook_partition.py
@@ -1,0 +1,273 @@
+"""How a hook delivery names the thing it is about (ADR-0134, amending ADR-0079).
+
+A hook's firings share ONE thread by default, and that is still the posture an
+agent gets without configuration. What this module adds is the operator's option
+to say that a particular hook's deliveries are about INDEPENDENT things -- one
+pull request each, one ticket each -- and should therefore run as independent
+threads.
+
+**The partition comes from the agent row, not from the request.** A header naming
+the partition would sit outside the bytes the HMAC covers and would hand whoever
+holds the hook secret direct control of this agent's sandbox cardinality. The
+operator instead configures a JSON Pointer per hook (``agents.hook_partitions``);
+the upstream still supplies the VALUE, but only through a field the operator
+named.
+
+**A misconfigured delivery refuses; it never falls back to the unpartitioned
+id.** Falling back would collapse N intended threads into one and would do it
+invisibly -- a working hook that had quietly stopped fanning out. Everything here
+that cannot resolve raises rather than returning a default, which is why there is
+no ``.get(..., fallback)`` anywhere below.
+
+This module is imported by ``schemas.py`` (the write surface) and by
+``routers/hooks.py`` (the ingress). It must not import either of them back.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from collections.abc import Mapping
+from typing import Any
+
+# A hook name is an operator-chosen label that ends up inside Valkey key names
+# and inside the conversation id, so it is constrained rather than trusted: no
+# separators, no unbounded length, nothing that could make two distinct hooks
+# build one key. The same shape now also governs the KEYS of
+# ``agents.hook_partitions``, so a configured hook name and a fired hook name
+# cannot disagree -- a key the ingress would refuse at step 1 could never match a
+# firing, and would configure nothing while looking configured.
+HOOK_NAME = re.compile(r"^[a-z0-9][a-z0-9._-]{0,62}$")
+
+# What a partition VALUE may be. Narrower than the hook name in one direction
+# (uppercase is allowed, because the identities this reads are mixed case --
+# Slack ids, ticket keys) and identical in the ones that matter: no `:`, so a
+# value cannot forge a segment of the conversation id; no `/`, so it cannot
+# escape a URL path segment in the transcript ref; no whitespace, control
+# characters or `=`, so it cannot forge a line in the ingress log or a second
+# entry in the sandbox boot env; and a first character that is alphanumeric, so
+# a bare `..` is unrepresentable. Non-ASCII refuses rather than transliterating.
+#
+# `\A`/`\Z` rather than `^`/`$`: `$` also matches immediately BEFORE a trailing
+# newline, which is exactly the log-forging value this bound exists to exclude.
+PARTITION_VALUE = re.compile(r"\A[A-Za-z0-9][A-Za-z0-9._-]{0,62}\Z")
+
+# An RFC 6901 array index: digits, no leading zero except "0" itself. Without the
+# leading-zero rule one array member is addressable two ways, and two pointers
+# that read one field are two configurations an operator cannot tell apart.
+_ARRAY_INDEX = re.compile(r"\A(0|[1-9][0-9]*)\Z")
+
+
+class PartitionError(ValueError):
+    """A partitioned hook whose delivery cannot name its partition.
+
+    Carries the hook and the pointer in its message because the operator's only
+    other signal is a 422 on a route whose caller they do not control: the hook
+    says which configuration entry is wrong, and the pointer says which field of
+    the document that entry expected to find.
+    """
+
+    def __init__(self, hook: str, pointer: str, reason: str) -> None:
+        self.hook = hook
+        self.pointer = pointer
+        self.detail = (
+            f"hook {hook!r} is partitioned by pointer {pointer!r}, but this "
+            f"delivery {reason}"
+        )
+        super().__init__(self.detail)
+
+
+def validate_pointer_syntax(pointer: str) -> str:
+    """Refuse a pointer that is not a JSON Pointer at all.
+
+    Applied on the WRITE path, so an operator learns about a malformed pointer
+    while they are at the keyboard rather than through a 422 handed to a
+    third-party upstream nobody at this end is watching.
+
+    Args:
+        pointer: The configured pointer.
+
+    Returns:
+        The pointer, unchanged.
+
+    Raises:
+        ValueError: If the pointer is neither empty nor ``/``-prefixed.
+    """
+
+    if pointer != "" and not pointer.startswith("/"):
+        raise ValueError(
+            f"pointer {pointer!r} is not a JSON Pointer: it must be either the "
+            "empty string (the whole document) or start with '/' (e.g. "
+            "'/pull_request/number')"
+        )
+    # RFC 6901 section 3 permits `~` only as the two escapes `~0` and `~1`; any
+    # other `~` -- unfollowed, or followed by anything else -- is not a pointer
+    # at all. Left unchecked, `resolve_pointer` would read a bare `~2` or a
+    # trailing `~` as two literal characters of a key nobody meant, and a
+    # pointer configured before this rule existed must be refused here (and
+    # thus turned into a `PartitionError` by `derive_partition`, which calls
+    # this through `resolve_pointer`) rather than silently misresolving at
+    # delivery time.
+    index = pointer.find("~")
+    while index != -1:
+        if pointer[index : index + 2] not in ("~0", "~1"):
+            raise ValueError(
+                f"pointer {pointer!r} is not a JSON Pointer: ~ must be followed "
+                "by 0 or 1 (RFC 6901 section 3 permits only the escapes ~0 and "
+                "~1)"
+            )
+        index = pointer.find("~", index + 2)
+    return pointer
+
+
+def resolve_pointer(document: Any, pointer: str) -> Any:
+    """Read one value out of a decoded document by RFC 6901 pointer.
+
+    Implemented here rather than taken as a dependency: the rule is a dozen
+    lines, and the one part of it that is easy to get wrong is the unescaping
+    ORDER, which a test pins directly.
+
+    Args:
+        document: The decoded delivery body, or any subtree of it.
+        pointer: An RFC 6901 pointer.
+
+    Returns:
+        The addressed value.
+
+    Raises:
+        ValueError: If the pointer is malformed, or a list segment is not a
+            well-formed index.
+        KeyError: If an object has no such key.
+        IndexError: If a list index is past the end.
+        TypeError: If the pointer descends into a scalar.
+    """
+
+    validate_pointer_syntax(pointer)
+    value = document
+    for token in pointer.split("/")[1:] if pointer else []:
+        # `~1` BEFORE `~0`, and the order is the whole bug: applied the other way
+        # round, `~01` becomes `~1` becomes `/`, and the pointer silently reads a
+        # different key than the one the operator wrote.
+        key = token.replace("~1", "/").replace("~0", "~")
+        if isinstance(value, Mapping):
+            value = value[key]
+        elif isinstance(value, list):
+            if not _ARRAY_INDEX.fullmatch(key):
+                raise ValueError(f"pointer segment {key!r} is not an array index")
+            value = value[int(key)]
+        else:
+            raise TypeError(f"pointer segment {key!r} descends into a non-container")
+    return value
+
+
+def derive_partition(
+    config: Mapping[str, Any] | None, hook: str, body: bytes
+) -> str | None:
+    """The partition this delivery belongs to, or None when the hook has none.
+
+    The None path is the byte-identity path, and it does no work on the payload
+    at all: an agent with no configuration, or with configuration for some OTHER
+    hook, must keep accepting every body it accepts today -- including bodies
+    that are not JSON.
+
+    Args:
+        config: The agent's ``hook_partitions`` map, or None.
+        hook: The validated hook name that fired.
+        body: The raw request body.
+
+    Returns:
+        The partition value, or None when this hook is unpartitioned.
+
+    Raises:
+        PartitionError: When the hook IS partitioned and this delivery cannot
+            name its partition.
+    """
+
+    entry = config.get(hook) if config else None
+    if entry is None:
+        return None
+
+    # `schemas.HookPartitionConfig` is the only writer of this column and makes
+    # `pointer` required, so its absence is a corrupted row rather than a
+    # configuration an operator can reach.
+    pointer: str = entry["pointer"]
+
+    try:
+        document = json.loads(body)
+    except (ValueError, RecursionError) as exc:
+        # The byte bound elsewhere in the ingress path does not bound NESTING
+        # depth: a small, well-under-the-limit body of deeply nested arrays
+        # blows the decoder's recursion limit instead of failing to parse. That
+        # must still land as this same pre-claim 422, never an unhandled 500,
+        # so a pathological body is refused before it can consume a delivery
+        # claim.
+        raise PartitionError(hook, pointer, "carries a body that is not JSON") from exc
+
+    try:
+        value = resolve_pointer(document, pointer)
+    except (ValueError, LookupError, TypeError) as exc:
+        raise PartitionError(
+            hook, pointer, "carries a body the pointer does not resolve against"
+        ) from exc
+
+    # `bool` first: Python's True IS an int, so an int-shaped coercion below
+    # would turn `true` into the partition "True" -- a plausible-looking thread
+    # nobody configured.
+    if isinstance(value, bool) or not isinstance(value, int | str):
+        raise PartitionError(
+            hook,
+            pointer,
+            "resolves to a value that is not a string or an integer, so it "
+            "names no stable identity",
+        )
+
+    # A JSON number is the commonest stable identity there is (a PR number, an
+    # issue number), so it is accepted as its string form: `42` and `"42"` must
+    # not become two threads for one pull request.
+    partition = str(value)
+    if not PARTITION_VALUE.fullmatch(partition):
+        raise PartitionError(
+            hook,
+            pointer,
+            "resolves to a value outside the partition bound of 1-63 characters "
+            "of letters, digits, dot, dash or underscore, beginning with a "
+            "letter or a digit",
+        )
+    return partition
+
+
+def conversation_id(agent_id: uuid.UUID, hook: str, partition: str | None = None) -> str:
+    """The thread a hook delivery lands on.
+
+    Per HOOK by default rather than per delivery, and that choice is load-bearing
+    in two directions. Per delivery would claim a fresh sandbox for every event,
+    and two rapid firings would run concurrently with no ordering at all. Sharing
+    one thread instead means a hook reuses its session and a second firing
+    arriving mid-run defers until the first finishes, which is exactly ADR-0079's
+    "jobs are outputs, not steering inputs" applied to a hook competing with
+    itself.
+
+    ADR-0134 narrows that to per PARTITION where the operator asks for it. A
+    partition is a thread with the lifetime a Slack thread ts has: the deliveries
+    about one pull request still serialize against each other, while deliveries
+    about different pull requests no longer do. Which is why a partition value
+    must be a stable identity of the thing and never a run id or a timestamp.
+
+    The three-segment prefix is preserved verbatim under a partition, so a
+    partitioned id is still disjoint from the agent's Slack thread ids and a hook
+    can never land in the middle of a human conversation.
+
+    Args:
+        agent_id: The agent this hook belongs to.
+        hook: The validated hook name.
+        partition: The derived partition value, or None for the unpartitioned id.
+
+    Returns:
+        The conversation key.
+    """
+
+    unpartitioned = f"hook:{agent_id}:{hook}"
+    if partition is None:
+        return unpartitioned
+    return f"{unpartitioned}:{partition}"

--- a/apps/api/src/curie_api/models.py
+++ b/apps/api/src/curie_api/models.py
@@ -135,6 +135,20 @@ class Agent(Base):
     # sitting in plaintext in the control plane, and rotating it any other way
     # means rotating the platform key for every agent at once.
     hook_generation: Mapped[int] = mapped_column(default=0, server_default="0")
+    # Which of this agent's hooks fan out, and by what (ADR-0134, amending
+    # ADR-0079): hook name -> ``{"pointer": <RFC 6901 pointer>}``, the pointer
+    # naming the field of a delivery body that identifies the thing the delivery
+    # is about. NULL means no hook on this agent partitions, which is the
+    # behavior every hook had before the column existed: one thread per hook.
+    #
+    # The pointer must name a STABLE identity of that thing -- a pull request
+    # number, a ticket key, a thread ts -- and never a run id or a timestamp. A
+    # partition IS a thread and owns a transcript, so an identity that changes
+    # per delivery makes every transcript single-use and grows the state store
+    # without bound. Nothing secret belongs here either (the neighbouring
+    # `hook_generation` comment's discipline): a pointer is configuration, and it
+    # must not be extended into anything carrying a VALUE from the payload.
+    hook_partitions: Mapped[dict[str, Any] | None] = mapped_column(JSONB, default=None)
     # Whether this agent's bindings share one workflow-state namespace or each
     # get their own (#1525 follow-up). Cardinality alone (ADR-0118 decision 2)
     # governs routing and agent-scoped controls (budget, kill state, bundle

--- a/apps/api/src/curie_api/routers/agents.py
+++ b/apps/api/src/curie_api/routers/agents.py
@@ -192,6 +192,12 @@ async def update_agent(agent_id: uuid.UUID, data: AgentUpdate, session: SessionD
     if data.secrets is not None:
         # Omitted leaves the secrets unchanged; an explicit {} clears them (#429).
         agent = await crud.update_agent_secrets(session, agent, data.secrets)
+    if data.hook_partitions is not None:
+        # Omitted leaves the partitions unchanged; an explicit {} clears them
+        # (ADR-0134). Plain `is not None` like the siblings above rather than
+        # `model_fields_set`: there is no platform default a null would clear
+        # back to, which is the distinction `memory` already draws.
+        agent = await crud.update_agent_hook_partitions(session, agent, data.hook_partitions)
     return AgentOut.model_validate(agent)
 
 

--- a/apps/api/src/curie_api/routers/hooks.py
+++ b/apps/api/src/curie_api/routers/hooks.py
@@ -33,14 +33,19 @@ upstream's configuration.
 from __future__ import annotations
 
 import logging
-import re
 import secrets as pysecrets
 import uuid
 from datetime import UTC, datetime
-from typing import Annotated
+from typing import Annotated, Any
 
 import redis.asyncio as redis
-from aci_protocol import STREAM_PAYLOAD_FIELD, QueuedTurn, ReplyHandle, TurnSource
+from aci_protocol import (
+    STREAM_PAYLOAD_FIELD,
+    QueuedTurn,
+    ReplyHandle,
+    TurnSource,
+    parse_queued_turn,
+)
 from fastapi import APIRouter, Header, HTTPException, Request, Response, status
 from pydantic import BaseModel
 from sqlalchemy import select
@@ -58,6 +63,12 @@ from ..delivery import (
 )
 from ..deps import SessionDep
 from ..graveyardwatcher import _text
+from ..hook_partition import (
+    HOOK_NAME,
+    PartitionError,
+    conversation_id,
+    derive_partition,
+)
 from ..models import Agent, AgentChannel
 from ..wirebody import read_bounded_body
 
@@ -76,12 +87,6 @@ _CLAIM_PREFIX = "curie:hook"
 # route to discover which agent ids exist.
 _AUTH_DETAIL = "missing or invalid signature"
 
-# A hook name is an operator-chosen label that ends up inside Valkey key names
-# and inside the conversation id, so it is constrained rather than trusted: no
-# separators, no unbounded length, nothing that could make two distinct hooks
-# build one key.
-_HOOK_NAME = re.compile(r"^[a-z0-9][a-z0-9._-]{0,62}$")
-
 # The header an upstream names its delivery with.
 _DELIVERY_HEADER = "X-Curie-Delivery-Id"
 
@@ -91,35 +96,28 @@ class HookAccepted(BaseModel):
 
     ``stream_id`` is None only while another request holds the claim and has not
     enqueued yet (the 202 case).
+
+    ``conversation_id`` is the thread this delivery ACTUALLY landed on. A
+    partitioned hook (ADR-0134) mints one id per partition value, and the caller
+    has no other way to learn which of them it got -- it is the last segment of
+    the thread key that ``POST /agents/{agent_id}/threads/{thread_key}/reset``
+    takes, and it is also what the
+    ``GET /approvals?conversation_id=`` filter takes directly.
+
+    On a DUPLICATE it is read back from the queued turn, never re-derived from
+    this request's body: a retry of the same delivery id may carry a different
+    partition value, or the operator may have changed the pointer since, and
+    either would name a thread the queued turn never landed on.
+
+    It is None when the landing thread is not knowable from this request: a
+    pending twin still mid-flight, a stream an operator has trimmed, or the 202
+    no-claim case where this request enqueued nothing and nothing is yet known.
     """
 
     event_id: str
     stream_id: str | None
     duplicate: bool
-
-
-def _conversation_id(agent_id: uuid.UUID, hook: str) -> str:
-    """The thread every firing of one hook shares.
-
-    Per HOOK rather than per delivery, and the choice is load-bearing in two
-    directions. Per delivery would claim a fresh sandbox for every event, and two
-    rapid firings would run concurrently with no ordering at all. Sharing one
-    thread instead means a hook reuses its session and a second firing arriving
-    mid-run defers until the first finishes, which is exactly ADR-0079's "jobs
-    are outputs, not steering inputs" applied to a hook competing with itself.
-
-    It is also disjoint from the agent's Slack thread ids, so a hook can never
-    land in the middle of a human conversation.
-
-    Args:
-        agent_id: The agent this hook belongs to.
-        hook: The validated hook name.
-
-    Returns:
-        The conversation key.
-    """
-
-    return f"hook:{agent_id}:{hook}"
+    conversation_id: str | None
 
 
 def _hook_text(hook: str, body: bytes) -> str:
@@ -143,6 +141,47 @@ def _hook_text(hook: str, body: bytes) -> str:
     return f"Inbound hook `{hook}` fired with this payload:\n\n{payload}"
 
 
+async def _landed_conversation_id(
+    client: redis.Redis, stream: str, held: str
+) -> str | None:
+    """The conversation id of the turn a held claim already enqueued.
+
+    Read back from the stream rather than recomputed, and the reason is the very
+    property that makes the claim correct: the claim key is DELIBERATELY
+    partition-independent, so one upstream delivery id runs at most once whatever
+    partition it names (see the key construction below). That is exactly why a
+    duplicate receipt cannot trust the current request -- a retry carrying a
+    different partition value, or one arriving after the operator moved the
+    pointer, derives a thread the single queued turn never landed on. Only the
+    queued turn itself knows.
+
+    Args:
+        client: The Valkey client.
+        stream: The runs stream the turn was appended to.
+        held: The claim key's current value: ``pending:<token>`` while another
+            request is mid-flight, otherwise the stream id of its entry.
+
+    Returns:
+        The queued turn's conversation id, or None when it is not knowable --
+        the claim is still ``pending:``, or the entry is gone because an operator
+        trimmed the stream.
+    """
+
+    if held.startswith("pending:"):
+        return None
+    entries: Any = await client.xrange(stream, min=held, max=held)
+    if not entries:
+        return None
+    _entry_id, fields_raw = entries[0]
+    # Keys decode because the API's client is built without `decode_responses`;
+    # a `decode_responses=True` client (tests) already hands back str.
+    fields = {_text(name): value for name, value in (fields_raw or {}).items()}
+    payload = fields.get(STREAM_PAYLOAD_FIELD)
+    if payload is None:
+        return None
+    return parse_queued_turn(_text(payload)).conversation_id
+
+
 async def _load_agent(session: SessionDep, agent_id: uuid.UUID) -> Agent | None:
     """Load the agent and every surface binding, or None."""
 
@@ -161,6 +200,8 @@ def _mint_turn(
     hook: str,
     event_id: str,
     body: bytes,
+    *,
+    partition: str | None,
 ) -> QueuedTurn:
     """Build the ``QueuedTurn`` a verified hook delivery becomes.
 
@@ -177,6 +218,10 @@ def _mint_turn(
         hook: The validated hook name.
         event_id: This delivery's deterministic event id.
         body: The raw request body.
+        partition: The derived partition value, or None when this hook is
+            unpartitioned. It reaches the conversation id and nothing else: the
+            author stays the hook, since the partition names the thing the
+            delivery is about rather than who sent it.
 
     Returns:
         The queued turn.
@@ -184,7 +229,7 @@ def _mint_turn(
 
     return QueuedTurn(
         event_id=event_id,
-        conversation_id=_conversation_id(agent.id, hook),
+        conversation_id=conversation_id(agent.id, hook, partition),
         # The author is the platform, not a person: no human sent this, and
         # putting an upstream-supplied identity here would let a hook impersonate
         # one to anything downstream that reads the field.
@@ -219,7 +264,8 @@ async def ingest_hook(
     Order, and why each step sits where it does:
 
     1. the hook NAME, validated before anything else, because it is about to be
-       used to build key names;
+       used to build key names -- with ``fullmatch``, since the pattern's ``$``
+       matches before a trailing newline and would let one into those keys;
     2. the size bound, before the signature is computed, so an oversized body is
        refused without the server ever HMAC-ing it;
     3. the agent row, which unavoidably precedes authentication here (see the
@@ -227,10 +273,12 @@ async def ingest_hook(
     4. the SIGNATURE over the raw body;
     5. the delivery id, checked after authentication so an unsigned caller learns
        nothing about what this route wants;
-    6. routability, then the claim, quota and enqueue.
+    6. the PARTITION this delivery belongs to, if the hook has one (ADR-0134),
+       after both of those and before anything is claimed;
+    7. routability, then the claim, quota and enqueue.
     """
 
-    if not _HOOK_NAME.match(hook):
+    if not HOOK_NAME.fullmatch(hook):
         raise HTTPException(
             status.HTTP_400_BAD_REQUEST,
             "hook name must be 1-63 characters of lowercase letters, digits, dot, "
@@ -260,6 +308,19 @@ async def ingest_hook(
             "stable upstream id is what keeps a retried delivery from running the "
             "agent twice",
         )
+
+    # Derived here and nowhere else in the order. After the signature and the
+    # delivery id, so an unsigned caller is never told which field of its payload
+    # the operator reads -- nor that this hook is partitioned at all. Before the
+    # claim, so a refusal leaves no claim key behind and the upstream's retry of a
+    # CORRECTED payload is not deduplicated away as a duplicate. And before the
+    # reply surface is selected, so a partition misconfiguration is attributed to
+    # the hook's configuration rather than surfacing as a 404 or 409 about a
+    # binding the operator would then go and inspect for nothing.
+    try:
+        partition = derive_partition(agent.hook_partitions, hook, raw)
+    except PartitionError as exc:
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, str(exc)) from exc
 
     if (kind is None) != (address is None):
         raise HTTPException(
@@ -299,6 +360,11 @@ async def ingest_hook(
     digest = sha16(x_curie_delivery_id)
     # Namespaced by agent AND hook, so two hooks on one agent cannot swallow each
     # other's deliveries when an upstream reuses its id space across them.
+    #
+    # Neither of these carries the partition, and that is deliberate rather than
+    # an oversight: one upstream delivery id must run at most once, whatever
+    # partition it names. Folding the partition in would let a retry that derived
+    # a different value run the agent a second time for the same delivery.
     event_id = f"hook-{agent.id}-{hook}-{digest}"
     key = f"{_CLAIM_PREFIX}:delivery:{agent.id}:{hook}:{digest}"
     owner = f"pending:{pysecrets.token_hex(16)}"
@@ -331,7 +397,7 @@ async def ingest_hook(
                     "too many new hook deliveries for this agent; retry later",
                     headers={"Retry-After": str(settings.hook_backlog_window_s)},
                 )
-            turn = _mint_turn(agent, binding, hook, event_id, raw)
+            turn = _mint_turn(agent, binding, hook, event_id, raw, partition=partition)
             enqueued, current = await enqueue_owned(
                 client,
                 key=key,
@@ -342,29 +408,56 @@ async def ingest_hook(
                 lease_s=settings.channel_delivery_lease_s,
             )
             if enqueued:
+                # The conversation id is here because it is the operator's only
+                # server-side record of which thread a delivery landed on. There
+                # is no verb that resets every partition of one hook, so a
+                # partition is reset by its full id, and this line plus the
+                # receipt are the two places that id is shown.
                 logger.info(
-                    "hook ingress enqueued event_id=%s stream_id=%s hook=%s",
+                    "hook ingress enqueued event_id=%s stream_id=%s hook=%s "
+                    "conversation_id=%s",
                     event_id,
                     current,
                     hook,
+                    turn.conversation_id,
                 )
                 return HookAccepted(
-                    event_id=event_id, stream_id=current, duplicate=False
+                    event_id=event_id,
+                    stream_id=current,
+                    duplicate=False,
+                    conversation_id=turn.conversation_id,
                 )
+            # Not `turn.conversation_id`: this request enqueued nothing, so the thread
+            # the delivery landed on is the one the WINNING turn named, whatever
+            # partition this body derives.
             return HookAccepted(
                 event_id=event_id,
                 stream_id=duplicate_stream_id(current, response),
                 duplicate=True,
+                conversation_id=await _landed_conversation_id(
+                    client, settings.runs_stream, current
+                ),
             )
         held = await client.get(key)
         if held is not None:
+            current = _text(held)
             return HookAccepted(
                 event_id=event_id,
-                stream_id=duplicate_stream_id(_text(held), response),
+                stream_id=duplicate_stream_id(current, response),
                 duplicate=True,
+                conversation_id=await _landed_conversation_id(
+                    client, settings.runs_stream, current
+                ),
             )
 
     # Both attempts found the key absent after failing to claim it. Someone is
-    # mid-flight; answering "come back" is honest and never a second XADD.
+    # mid-flight; answering "come back" is honest and never a second XADD. The
+    # conversation id is None for the same reason the stream id is: nothing has
+    # been enqueued that this request can name.
     response.status_code = status.HTTP_202_ACCEPTED
-    return HookAccepted(event_id=event_id, stream_id=None, duplicate=True)
+    return HookAccepted(
+        event_id=event_id,
+        stream_id=None,
+        duplicate=True,
+        conversation_id=None,
+    )

--- a/apps/api/src/curie_api/schemas.py
+++ b/apps/api/src/curie_api/schemas.py
@@ -30,6 +30,7 @@ from pydantic import (
 )
 
 from .config import get_settings
+from .hook_partition import HOOK_NAME, validate_pointer_syntax
 from .models import GIT_FLOW_CREATED_BY, Environment
 from .repo_full_name import RepoFullName
 from .workspace_policy import REPOSITORY_FULL_NAME_PATTERN, valid_repository_name
@@ -514,6 +515,56 @@ class ApprovalApprovers(_StoredWithoutNulls):
         return self
 
 
+class HookPartitionConfig(BaseModel):
+    """How one hook names the thing each delivery is about (ADR-0134).
+
+    One model serves ``AgentCreate``, ``AgentUpdate`` AND ``AgentOut``, which the
+    ``_StoredWithoutNulls`` tripwire above would otherwise argue against: that
+    split only happens for models carrying the wrap serializer, and this one has
+    neither it nor an optional field, so the dumped and validated shapes are the
+    same and no ``-Input``/``-Output`` pair is generated. Do not add a separate
+    ``...Out`` variant.
+    """
+
+    # A typo'd key must not be silently dropped: here the dropped key would be
+    # the whole partition, and the hook would run unpartitioned while its config
+    # still looked right in a GET. Same reason as `ApprovalApprovers`.
+    model_config = ConfigDict(extra="forbid")
+
+    # An RFC 6901 pointer into the delivery body.
+    pointer: str
+
+    @field_validator("pointer")
+    @classmethod
+    def _check_pointer(cls, value: str) -> str:
+        # The ingress's own syntax rule, imported rather than restated, so a
+        # pointer the write surface accepts is exactly one the resolver can read.
+        return validate_pointer_syntax(value)
+
+
+def _validate_hook_partitions(
+    value: "dict[str, HookPartitionConfig] | None",
+) -> "dict[str, HookPartitionConfig] | None":
+    """Partition keys are hook NAMES, checked against the shape the ingress
+    enforces.
+
+    A key outside that shape can never match a firing, so it configures nothing
+    while looking configured -- the operator sees a partition map and gets
+    unpartitioned threads.
+    """
+
+    if value is None:
+        return value
+    for name in value:
+        if not HOOK_NAME.fullmatch(name):
+            raise ValueError(
+                f"hook_partitions key {name!r} is not a hook name: 1-63 "
+                "characters of lowercase letters, digits, dot, dash or "
+                "underscore, beginning with a letter or a digit"
+            )
+    return value
+
+
 def _validate_route_names(
     value: "dict[str, ApprovalRouteBinding] | None",
 ) -> "dict[str, ApprovalRouteBinding] | None":
@@ -888,6 +939,10 @@ class AgentCreate(BaseModel):
     # secret. Stored on the agent row for the local tier and forwarded into the
     # sandbox by the worker binding. None means no connector secrets.
     secrets: dict[str, str] | None = None
+    # Per-hook delivery partitioning (ADR-0134): hook name -> the JSON Pointer
+    # into the delivery body that names the thing each delivery is about. None
+    # (the default) is the unpartitioned behavior: one thread per hook.
+    hook_partitions: dict[str, HookPartitionConfig] | None = None
     # Whether this agent's bindings share one workflow-state namespace (#1525
     # follow-up). False (the default) matches a single-binding agent's existing
     # behavior exactly, since there is nothing yet to share with.
@@ -898,6 +953,7 @@ class AgentCreate(BaseModel):
     _check_approval_tools = field_validator("approval_required_tools")(_validate_tool_names)
     _check_approval_routes = field_validator("approval_routes")(_validate_route_names)
     _check_secrets = field_validator("secrets")(_validate_secret_map)
+    _check_hook_partitions = field_validator("hook_partitions")(_validate_hook_partitions)
     _reject_retired_channel_keys = model_validator(mode="before")(_reject_retired_binding_keys)
 
 
@@ -936,6 +992,13 @@ class AgentUpdate(BaseModel):
     # New connector secrets (#429). Omitted (None) leaves current secrets
     # unchanged; an explicit empty dict clears them.
     secrets: dict[str, str] | None = None
+    # New per-hook delivery partitioning (ADR-0134). Omitted (None) leaves the
+    # partitions unchanged; an explicit empty dict clears them, returning every
+    # hook on this agent to one thread per hook. Deliberately `approval_routes`'
+    # semantics and NOT the `model`/`thinking` `model_fields_set` three-way:
+    # there is no platform default for this field to be cleared back TO, so
+    # reading None as "omitted" conflates nothing.
+    hook_partitions: dict[str, HookPartitionConfig] | None = None
     # Which repository's pushes deploy this agent (ADR-0091). PATCHable because
     # an agent created before its repo existed -- or, until migration 0018, the
     # SECOND agent of a repo, which the unique index forbade from carrying it --
@@ -950,6 +1013,7 @@ class AgentUpdate(BaseModel):
     _check_approval_tools = field_validator("approval_required_tools")(_validate_tool_names)
     _check_approval_routes = field_validator("approval_routes")(_validate_route_names)
     _check_secrets = field_validator("secrets")(_validate_secret_map)
+    _check_hook_partitions = field_validator("hook_partitions")(_validate_hook_partitions)
     _reject_retired_channel_keys = model_validator(mode="before")(_reject_retired_binding_keys)
     # The update-only half: a withdrawn `channel` here is refused, while the
     # same key stays required on `AgentCreate`.
@@ -976,6 +1040,9 @@ class AgentOut(BaseModel):
     thinking: str | None
     approval_required_tools: list[str] | None
     approval_routes: dict[str, ApprovalRouteBindingOut] | None
+    # Which hooks fan out, and by what (ADR-0134). Null is the unpartitioned
+    # posture and the value every pre-existing agent row carries.
+    hook_partitions: dict[str, HookPartitionConfig] | None
     # Connector secret NAMES only (#429) -- values are never returned. The stored
     # column is a name->value map; expose just the sorted names so an operator can
     # see which secrets an agent has bound without the material leaving the API.

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -11,6 +11,7 @@ real Postgres (and real Valkey/Langfuse); nothing here mocks them.
 import asyncio
 import os
 import secrets
+import uuid
 from collections.abc import Iterator
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -18,10 +19,12 @@ from typing import Any
 
 import asyncpg
 import pytest
+import redis
 from alembic import command
 from alembic.config import Config
 from curie_api.config import get_settings
 from curie_api.main import create_app
+from curie_test_support.valkey import connect_or_skip
 from fastapi.testclient import TestClient
 from sqlalchemy import make_url
 from sqlalchemy.engine import URL
@@ -161,6 +164,41 @@ def clean_db(migrated: None) -> None:
 def client(_disposable_db: Any) -> Any:
     # Depends on _disposable_db so the app engine is built against the disposable
     # DB (the app lifespan already requires the compose stack: RustFS, Valkey).
+    with TestClient(create_app()) as test_client:
+        yield test_client
+
+
+# --- hook ingress fixtures (test_hooks.py, test_hook_partition.py) -------------
+#
+# Shared here rather than imported across test modules: the suite runs under
+# ``--import-mode=importlib`` with no ``__init__.py``, so one test module
+# cannot reliably import another by name, but pytest discovers conftest
+# fixtures regardless of import mode.
+
+
+@pytest.fixture
+def runs_stream() -> Iterator[str]:
+    """A per-test runs stream, so enqueued turns never leak between tests."""
+
+    name = f"test:curie:runs:{uuid.uuid4().hex}"
+    os.environ["RUNS_STREAM"] = name
+    get_settings.cache_clear()
+    yield name
+    os.environ.pop("RUNS_STREAM", None)
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+def valkey(runs_stream: str) -> Iterator[redis.Redis]:
+    client = connect_or_skip(decode_responses=True)
+    yield client
+    client.delete(runs_stream)
+    client.close()
+
+
+@pytest.fixture
+def hooks_client(_disposable_db: Any, runs_stream: str) -> Iterator[TestClient]:
+    # Built AFTER runs_stream so the app reads the per-test stream name.
     with TestClient(create_app()) as test_client:
         yield test_client
 

--- a/apps/api/tests/test_hook_partition.py
+++ b/apps/api/tests/test_hook_partition.py
@@ -1,0 +1,1539 @@
+"""One thread per PARTITION of a hook, and a refusal when a delivery cannot name one.
+
+Written before ``curie_api.hook_partition`` exists, so every import below is a
+claim about the surface that module must expose. The sections map to the
+acceptance criteria one to one:
+
+* **A** -- a hook that does not opt in mints the id it minted before, byte- and
+  SHA-256-identically, and its body is never parsed (AC1);
+* **B** -- a partitioned hook mints one conversation per partition VALUE (AC2);
+* **C** -- a misconfigured partitioned delivery refuses; it never falls back to
+  the unpartitioned id (AC3);
+* **D** -- the receipt (and the ingress log) names the thread the delivery landed
+  on, which is the only way a caller learns the id it needs for a thread reset or
+  the ``GET /approvals?conversation_id=`` filter (AC4);
+* **E** -- the opt-in is operator-owned, round-trips, and clears (AC5).
+
+**Posture, inherited from ``test_hooks.py``.** This route lets an outside system
+make an agent act, so the refusals in section C deliberately outnumber the happy
+paths. Each of them asserts THREE things rather than one -- the 422, that nothing
+was enqueued, and that no delivery claim key was written -- because a refusal
+that still took the claim would deduplicate away the upstream's retry of a
+corrected payload, and a test asserting only the status code cannot tell a
+refusal-before-the-claim from a refusal-after-it.
+
+**Fall-back is the failure mode this file exists to forbid.** If a pointer does
+not resolve, collapsing N intended threads into one would leave the operator
+looking at a working hook that had quietly stopped fanning out. That is why the
+negative assertions here (`no enqueue`, `no claim key`, `not the three-segment
+id`) carry more of the contract than the positive ones.
+
+The pure-function tests in the first section import nothing but
+``curie_api.hook_partition`` and take no fixtures, so they run with the dev stack
+down. Everything from the second section on needs the disposable database and
+Valkey, exactly as ``test_hooks.py`` does.
+
+The ``runs_stream`` / ``valkey`` / ``hooks_client`` fixtures are shared with
+``test_hooks.py`` through ``conftest.py``. The plain helpers below are copied in
+SHAPE from ``test_hooks.py`` rather than imported from it: the suite runs under
+``--import-mode=importlib`` with no ``__init__.py`` in this directory, so one
+test module cannot reliably import another by name.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import logging
+import uuid
+from typing import Any
+
+import pytest
+import redis
+from aci_protocol import QueuedTurn
+from curie_api.config import get_settings
+from curie_api.delivery import sha16
+from curie_api.hook_partition import (
+    HOOK_NAME,
+    PARTITION_VALUE,
+    PartitionError,
+    conversation_id,
+    derive_partition,
+    resolve_pointer,
+    validate_pointer_syntax,
+)
+from curie_api.hook_signing import derive
+from fastapi.testclient import TestClient
+
+EMAIL_ENDPOINT = "http://curie-mail-adapter:8080/"
+EMAIL_ADAPTER = "agentmail-sandbox"
+
+# A fixed example UUID for the pure-function tests. This repo is public: example
+# agent ids are example UUIDs and never a real one.
+EXAMPLE_AGENT = uuid.UUID("00000000-0000-4000-8000-000000000001")
+
+# The hook-name corpus the byte-identity claim is made over: the 1-character
+# boundary, the 63-character boundary, and one name per allowed character class.
+HOOK_CORPUS = ("a", "a" * 63, "a.b-c_d", "0deploy", "x9._-", "sweep")
+
+
+# =============================================================================
+# Pure functions -- no database, no Valkey (sections A, B and edge case E5)
+# =============================================================================
+
+
+def test_the_hook_name_corpus_is_itself_inside_the_allowed_shape() -> None:
+    """Guards the corpus, not the code.
+
+    Every byte-identity assertion below is worthless if it is made over names the
+    ingress would have refused at step 1, so the corpus is checked against the
+    same pattern the route uses before it is used as evidence of anything.
+    """
+
+    for hook in HOOK_CORPUS:
+        assert HOOK_NAME.fullmatch(hook), hook
+
+
+def test_the_hook_name_shape_refuses_a_trailing_newline() -> None:
+    """A regression guard for the ingress bug the end-to-end test in Section A
+    also exercises.
+
+    Python's `$` matches immediately BEFORE a trailing newline (not only at the
+    true end of string), so a hook-name check written as `HOOK_NAME.match(hook)`
+    against this `$`-anchored pattern would accept `"prs\\n"` -- and the name goes
+    straight into the claim key, the event id, and the ingress log line Section D
+    depends on. `fullmatch` closes it, because it requires the match to consume
+    the whole string, trailing newline included; this pins the pattern side of
+    that fix the way the corpus test above pins the accept side.
+    """
+
+    assert HOOK_NAME.fullmatch("prs\n") is None
+
+
+def test_an_unpartitioned_hook_mints_the_id_it_minted_before() -> None:
+    """AC1, and the highest-value assertion in this file.
+
+    Compared against a literal f-string built HERE, never against a second
+    production copy of the mint: a test that calls the same helper twice would
+    stay green through a change that altered the string for every existing agent.
+    The SHA-256 equality is the same claim stated at the artifact level -- every
+    downstream key, label and hash derived from this id is untouched.
+    """
+
+    for hook in HOOK_CORPUS:
+        expected = f"hook:{EXAMPLE_AGENT}:{hook}"
+
+        assert conversation_id(EXAMPLE_AGENT, hook) == expected
+        # The default and an explicit None must not diverge; the router passes a
+        # derived `partition` that is None on the unpartitioned path.
+        assert conversation_id(EXAMPLE_AGENT, hook, None) == expected
+        assert (
+            hashlib.sha256(conversation_id(EXAMPLE_AGENT, hook).encode()).hexdigest()
+            == hashlib.sha256(expected.encode()).hexdigest()
+        )
+        assert expected.count(":") == 2, "an unpartitioned id has exactly three segments"
+
+
+def test_a_partition_is_appended_as_a_fourth_segment_and_nothing_else() -> None:
+    """AC2 at the unit level: the partition never rewrites the first three parts."""
+
+    partitioned = conversation_id(EXAMPLE_AGENT, "prs", "42")
+
+    assert partitioned == f"hook:{EXAMPLE_AGENT}:prs:42"
+    assert partitioned.count(":") == 3
+    # The prefix is preserved verbatim, which is what keeps a partitioned id
+    # disjoint from the agent's Slack thread ids exactly as before.
+    assert partitioned.startswith(f"{conversation_id(EXAMPLE_AGENT, 'prs')}:")
+
+
+def test_an_unconfigured_hook_never_parses_the_body() -> None:
+    """AC1's second half: the byte-identity path does no work on the payload.
+
+    A body that is not JSON at all is the counterfactual. If `derive_partition`
+    parsed first and consulted the map second, this raises instead of returning
+    None, and every existing unconfigured hook would start refusing bodies it has
+    always accepted.
+    """
+
+    not_json = b"not json at all"
+
+    assert derive_partition(None, "issues", not_json) is None
+    assert derive_partition({}, "issues", not_json) is None
+    # A POPULATED map with no entry for THIS hook is the same path (edge case E8).
+    assert derive_partition({"deploys": {"pointer": "/id"}}, "issues", not_json) is None
+
+
+@pytest.mark.parametrize(
+    ("pointer", "document", "expected"),
+    [
+        pytest.param("", {"a": 1}, {"a": 1}, id="empty-pointer-is-the-whole-document"),
+        pytest.param("/a", {"a": 1}, 1, id="top-level-key"),
+        pytest.param("/a/b", {"a": {"b": 2}}, 2, id="nested-key"),
+        pytest.param("/items/0", {"items": ["x", "y"]}, "x", id="array-index-zero"),
+        pytest.param("/items/10", {"items": list(range(11))}, 10, id="multi-digit-index"),
+        pytest.param("/a~1b", {"a/b": "v"}, "v", id="tilde-one-decodes-to-slash"),
+        pytest.param("/m~0n", {"m~n": "v"}, "v", id="tilde-zero-decodes-to-tilde"),
+        # Edge case E11, the classic RFC 6901 bug: `~1` must be applied BEFORE
+        # `~0`. Applied the other way round, `~01` becomes `~1` becomes `/`, and
+        # this pointer silently reads the WRONG key -- which is a partition
+        # derived from the wrong field, not an error anyone would see.
+        pytest.param("/a~01b", {"a~1b": "right", "a/1b": "wrong"}, "right", id="escape-order"),
+    ],
+)
+def test_resolve_pointer_follows_rfc_6901(pointer: str, document: Any, expected: Any) -> None:
+    assert resolve_pointer(document, pointer) == expected
+
+
+@pytest.mark.parametrize(
+    ("pointer", "document"),
+    [
+        pytest.param("/missing", {"a": 1}, id="absent-key"),
+        pytest.param("/items/5", {"items": [1, 2]}, id="index-past-the-end"),
+        pytest.param("/a/b", {"a": 1}, id="descend-into-a-scalar"),
+        pytest.param("/x", 42, id="scalar-document-root"),
+        # A list index is digits with no leading zero (except "0" itself), so a
+        # pointer cannot address one member two ways.
+        pytest.param("/items/01", {"items": [1, 2]}, id="leading-zero-index"),
+        pytest.param("/items/x", {"items": [1, 2]}, id="non-numeric-index"),
+        pytest.param("/items/-1", {"items": [1, 2]}, id="negative-index"),
+    ],
+)
+def test_resolve_pointer_refuses_rather_than_guessing(pointer: str, document: Any) -> None:
+    """No `.get(..., default)` anywhere in here. A pointer that does not resolve
+    is a configuration error, and returning a default would be the fall-back this
+    whole feature refuses to do."""
+
+    with pytest.raises((PartitionError, ValueError, KeyError, IndexError, TypeError)):
+        resolve_pointer(document, pointer)
+
+
+@pytest.mark.parametrize("pointer", ["", "/", "/n", "/a~1b", "/pull_request/number"])
+def test_validate_pointer_syntax_accepts_a_well_formed_pointer(pointer: str) -> None:
+    assert validate_pointer_syntax(pointer) == pointer
+
+
+@pytest.mark.parametrize("pointer", ["number", "n/umber", "~0", " /n", "a"])
+def test_validate_pointer_syntax_refuses_a_pointer_with_no_leading_slash(pointer: str) -> None:
+    """The write surface rejects a malformed pointer at CONFIGURATION time, so an
+    operator learns about it on the PATCH rather than on the first delivery that
+    was supposed to run."""
+
+    with pytest.raises(ValueError):
+        validate_pointer_syntax(pointer)
+
+
+@pytest.mark.parametrize("pointer", ["/a~0b", "/a~1b", "/a~01b", "", "/"])
+def test_validate_pointer_syntax_accepts_every_well_formed_escape(pointer: str) -> None:
+    """RFC 6901 defines exactly two escapes, `~0` and `~1`, and any digit may
+    follow a literal `~1` or `~0` pair once escaped (`~01` is `~1` followed by a
+    literal `1`, not a third escape) -- so a well-formed pointer built from them
+    must still round-trip through syntax validation."""
+
+    assert validate_pointer_syntax(pointer) == pointer
+
+
+@pytest.mark.parametrize(
+    "pointer",
+    [
+        pytest.param("/a~2b", id="tilde-followed-by-neither-0-nor-1"),
+        pytest.param("/a~", id="trailing-bare-tilde"),
+        pytest.param("/~", id="bare-tilde-segment"),
+        pytest.param("/x/~", id="bare-tilde-in-a-later-segment"),
+    ],
+)
+def test_validate_pointer_syntax_refuses_an_invalid_escape(pointer: str) -> None:
+    """RFC 6901 permits only `~0` and `~1`. A bare or dangling `~` is a malformed
+    pointer that can never resolve as the operator intended -- `resolve_pointer`'s
+    `.replace("~1", ...).replace("~0", ...)` would leave the stray `~` (and
+    whatever follows it) untouched in the lookup key, so this must be refused at
+    CONFIGURATION time rather than surfacing as a confusing absent-key refusal on
+    the first delivery."""
+
+    with pytest.raises(ValueError):
+        validate_pointer_syntax(pointer)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "a",
+        "9",
+        "A",
+        "a" * 63,
+        "PR-42",
+        "C0EXAMPLE1",
+        "OPS.1_2",
+        # A timestamp passes the bound. Deliberate, and NOT an endorsement: edge
+        # case E3 records that the charset cannot detect an unstable identity, and
+        # that the stability requirement is a documentation-and-review control.
+        # A runtime heuristic here would refuse legitimate numeric ids.
+        "1756425600",
+    ],
+)
+def test_the_partition_bound_admits_a_stable_identity(value: str) -> None:
+    assert PARTITION_VALUE.fullmatch(value), value
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param("", id="empty"),
+        pytest.param("a" * 64, id="one-past-the-63-char-bound"),
+        pytest.param(".lead", id="leading-dot-could-build-a-dot-segment"),
+        pytest.param("-lead", id="leading-dash"),
+        pytest.param("_lead", id="leading-underscore"),
+        pytest.param("a:b", id="colon-would-forge-a-segment"),
+        pytest.param("a/b", id="slash-would-escape-a-url-path-segment"),
+        pytest.param("a b", id="space"),
+        pytest.param("a\nb", id="embedded-newline-would-forge-a-log-line"),
+        pytest.param("ab\n", id="trailing-newline"),
+        pytest.param("..", id="dot-dot"),
+        pytest.param("a%2Fb", id="percent"),
+        pytest.param("café", id="non-ascii-refuses-rather-than-transliterating"),
+    ],
+)
+def test_the_partition_bound_refuses_everything_that_could_forge_a_key(value: str) -> None:
+    """Checked with `fullmatch`, on purpose. `re.match` with a `$`-anchored
+    pattern still admits a TRAILING newline, which would let a partition value
+    forge a second line in the ingress log (edge case E1's log-forging row). The
+    behavioural version of that claim is asserted through `derive_partition`
+    below, so the module is free to spell it `fullmatch` or `\\Z`."""
+
+    assert PARTITION_VALUE.fullmatch(value) is None, value
+
+
+@pytest.mark.parametrize(
+    ("body", "why"),
+    [
+        pytest.param(b'{"n": "ab\\n"}', "a trailing newline", id="trailing-newline"),
+        pytest.param(b'{"n": true}', "a bool is an int in Python", id="bool-true"),
+        pytest.param(b'{"n": false}', "a bool is an int in Python", id="bool-false"),
+        pytest.param(b'{"n": -5}', "a negative int leads with a dash", id="negative-int"),
+        pytest.param(b'{"n": 1.5}', "a float is not an identity", id="float"),
+        pytest.param(b'{"n": null}', "null names nothing", id="null"),
+    ],
+)
+def test_derive_partition_refuses_a_value_the_bound_excludes(body: bytes, why: str) -> None:
+    """The behavioural form of the bound, kept separate from the pattern test.
+
+    `True` is the one worth stating out loud: Python's bool IS an int, so a
+    `str(value)` coercion written against the int case turns `true` into the
+    partition `"True"` -- a plausible-looking string that silently becomes a
+    thread. It must refuse.
+    """
+
+    config = {"prs": {"pointer": "/n"}}
+
+    with pytest.raises(PartitionError) as raised:
+        derive_partition(config, "prs", body)
+
+    detail = str(raised.value)
+    assert "prs" in detail and "/n" in detail, f"{why}: {detail}"
+
+
+def test_derive_partition_coerces_an_int_but_returns_a_string() -> None:
+    """AC2's coercion rule. A JSON number is the commonest stable identity there
+    is (a PR number, an issue number), so it is accepted -- as `str(value)`, since
+    the conversation id is a string and `42` and `"42"` must not become two
+    threads for one pull request."""
+
+    config = {"prs": {"pointer": "/number"}}
+
+    assert derive_partition(config, "prs", b'{"number": 42}') == "42"
+    assert derive_partition(config, "prs", b'{"number": "42"}') == "42"
+
+
+def test_the_longest_representable_session_id_is_arithmetic_someone_re_checked() -> None:
+    """Edge case E5: the length composition, pinned so the bound cannot drift.
+
+    `binding.py` builds `CURIE_SESSION_ID` as `agent-<uuid>-thread-<thread key>`,
+    and the conversation id is the last component of that thread key. Its own
+    arithmetic at the bound:
+
+        "hook:" 5 + uuid 36 + ":" 1 + hook 63 + ":" 1 + partition 63 = 169
+
+    and the session id built directly from it:
+
+        "agent-" 6 + uuid 36 + "-thread-" 8 + 169 = 219
+
+    Stated as an equality rather than an inequality, because a `<=` against a
+    round number invites someone to widen the round number instead of re-doing
+    the arithmetic. NOTE for the reviewer: the plan's E5 estimated ~161 for this
+    string; the arithmetic above says 219, and the worker's real thread key adds a
+    percent-encoded `kind:address` prefix on top of that. Nothing here overflows a
+    bound (the K8s claim name and `THREAD_HASH_LABEL` are fixed-length SHA
+    prefixes), but the estimate is the number to correct, not this test.
+    """
+
+    longest = conversation_id(EXAMPLE_AGENT, "a" * 63, "b" * 63)
+    session_id = f"agent-{EXAMPLE_AGENT}-thread-{longest}"
+
+    assert len(longest) == 5 + 36 + 1 + 63 + 1 + 63
+    assert len(longest) == 169
+    assert len(session_id) == 6 + 36 + 8 + 169
+    assert len(session_id) == 219
+
+
+# =============================================================================
+# Helpers (shape copied from test_hooks.py -- see the module docstring for why
+# this file does not import them; the `runs_stream` / `valkey` / `hooks_client`
+# fixtures are shared through conftest.py instead)
+# =============================================================================
+
+
+def _bind(
+    client: TestClient,
+    headers: dict[str, str],
+    *,
+    name: str,
+    hook_partitions: dict[str, Any] | None = None,
+) -> str:
+    """Create an agent bound to an email channel and return its id.
+
+    The `hook_partitions` keyword is the only difference from `test_hooks._bind`:
+    the create surface is one of the two write paths AC5 covers, so a partitioned
+    agent is built through it rather than through a direct column write.
+    """
+
+    payload: dict[str, Any] = {
+        "name": name,
+        "channel": {
+            "kind": "email",
+            "address": f"{name}@example.test",
+            "endpoint": EMAIL_ENDPOINT,
+            "adapter": EMAIL_ADAPTER,
+        },
+    }
+    if hook_partitions is not None:
+        payload["hook_partitions"] = hook_partitions
+    created = client.post("/agents", json=payload, headers=headers)
+    assert created.status_code == 201, created.text
+    return str(created.json()["id"])
+
+
+def _sign(secret: str, body: bytes) -> str:
+    return "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+
+def _secret_for(agent_id: str, generation: int = 0) -> str:
+    return derive(get_settings().api_key, agent_id=agent_id, generation=generation)
+
+
+def _post(
+    client: TestClient,
+    agent_id: str,
+    hook: str,
+    body: bytes,
+    *,
+    secret: str | None = None,
+    signature: str | None = None,
+    delivery_id: str | None = "dlv-1",
+) -> Any:
+    """POST one delivery, signing with `secret` unless a signature is forced."""
+
+    headers = {"Content-Type": "application/json"}
+    if signature is not None:
+        headers["X-Curie-Signature-256"] = signature
+    elif secret is not None:
+        headers["X-Curie-Signature-256"] = _sign(secret, body)
+    if delivery_id is not None:
+        headers["X-Curie-Delivery-Id"] = delivery_id
+    return client.post(f"/hooks/{agent_id}/{hook}", content=body, headers=headers)
+
+
+def _queued(valkey: redis.Redis, stream: str) -> list[QueuedTurn]:
+    entries = valkey.xrange(stream)
+    return [QueuedTurn.model_validate_json(fields["payload"]) for _, fields in entries]
+
+
+def _claim_key(agent_id: str, hook: str, delivery_id: str) -> str:
+    """The delivery claim key `hooks.py` writes, rebuilt independently here.
+
+    Edge case E9 pins that this key carries the agent, the hook and the delivery
+    digest and deliberately NOT the partition: one upstream delivery id must run
+    at most once, whatever partition it names. Rebuilt from `sha16` rather than
+    read back from the route so a change to the key's shape shows up as a failing
+    refusal test rather than as an assertion that quietly checks nothing.
+    """
+
+    return f"curie:hook:delivery:{agent_id}:{hook}:{sha16(delivery_id)}"
+
+
+# =============================================================================
+# Section A -- byte identity through the ingress (AC1)
+# =============================================================================
+
+
+def test_an_unconfigured_hook_enqueues_the_three_segment_id(
+    hooks_client: TestClient,
+    auth_headers: dict[str, str],
+    valkey: redis.Redis,
+    runs_stream: str,
+    clean_db: None,
+) -> None:
+    """The unit claim, restated end to end. An agent that never opted in must
+    reach the stream carrying the exact string it carried before this feature."""
+
+    agent_id = _bind(hooks_client, auth_headers, name="unconfiguredagent")
+
+    answer = _post(
+        hooks_client,
+        agent_id,
+        "issues",
+        b'{"number": 41}',
+        secret=_secret_for(agent_id),
+        delivery_id="a-1",
+    )
+
+    assert answer.status_code == 200, answer.text
+    (turn,) = _queued(valkey, runs_stream)
+    assert turn.conversation_id == f"hook:{agent_id}:issues"
+    assert turn.conversation_id.count(":") == 2
+    # The body carried a value a pointer COULD have read. Nothing read it.
+    assert "41" not in turn.conversation_id
+
+
+def test_a_hook_with_no_entry_in_a_populated_map_is_unpartitioned(
+    hooks_client: TestClient,
+    auth_headers: dict[str, str],
+    valkey: redis.Redis,
+    runs_stream: str,
+    clean_db: None,
+) -> None:
+    """Configuring ONE hook must not change any other hook on the same agent.
+
+    The body is deliberately not JSON at all: if the route parsed the body before
+    consulting the map, this delivery would refuse, and every unconfigured hook on
+    a partitioned agent would start rejecting payloads it used to accept.
+    """
+
+    agent_id = _bind(
+        hooks_client,
+        auth_headers,
+        name="populatedmapagent",
+        hook_partitions={"deploys": {"pointer": "/number"}},
+    )
+
+    answer = _post(
+        hooks_client,
+        agent_id,
+        "issues",
+        b"not json at all",
+        secret=_secret_for(agent_id),
+        delivery_id="a-2",
+    )
+
+    assert 200 <= answer.status_code < 300, answer.text
+    (turn,) = _queued(valkey, runs_stream)
+    assert turn.conversation_id == f"hook:{agent_id}:issues"
+
+
+def test_a_hook_name_with_a_trailing_newline_is_refused_at_ingress(
+    hooks_client: TestClient,
+    auth_headers: dict[str, str],
+    valkey: redis.Redis,
+    runs_stream: str,
+    clean_db: None,
+) -> None:
+    """The end-to-end form of the `HOOK_NAME` regression pinned at the unit level
+    above. The hook name is checked FIRST, before the agent row, the signature or
+    the delivery id (the module docstring's step 1), because it is about to be
+    used to build key names -- a name with a trailing newline could forge a
+    second line in the claim key, the event id, or the ingress log line Section D
+    depends on. The newline arrives percent-encoded in the path (`%0A`), the way
+    an upstream URL-building library would send it.
+    """
+
+    agent_id = _bind(hooks_client, auth_headers, name="newlinehookagent")
+
+    refused = _post(
+        hooks_client,
+        agent_id,
+        "prs%0A",
+        b'{"number": 41}',
+        secret=_secret_for(agent_id),
+        delivery_id="f-newline",
+    )
+
+    assert refused.status_code == 400, refused.text
+    assert "hook name" in refused.json()["detail"], refused.json()["detail"]
+    assert _queued(valkey, runs_stream) == []
+
+
+# =============================================================================
+# Section B -- partitioned id shape (AC2)
+# =============================================================================
+
+
+def test_a_partitioned_hook_mints_a_distinct_thread_per_value(
+    hooks_client: TestClient,
+    auth_headers: dict[str, str],
+    valkey: redis.Redis,
+    runs_stream: str,
+    clean_db: None,
+) -> None:
+    """The whole point of the feature: one sweep finding three pull requests
+    produces three threads, not three deliveries serialized into one sandbox."""
+
+    agent_id = _bind(
+        hooks_client,
+        auth_headers,
+        name="fanoutagent",
+        hook_partitions={"prs": {"pointer": "/number"}},
+    )
+    secret = _secret_for(agent_id)
+
+    for number in (41, 42, 43):
+        answer = _post(
+            hooks_client,
+            agent_id,
+            "prs",
+            b'{"number": %d}' % number,
+            secret=secret,
+            delivery_id=f"b-{number}",
+        )
+        assert answer.status_code == 200, answer.text
+
+    ids = [turn.conversation_id for turn in _queued(valkey, runs_stream)]
+    assert ids == [f"hook:{agent_id}:prs:{n}" for n in (41, 42, 43)]
+    assert len(set(ids)) == 3
+    assert all(one.count(":") == 3 for one in ids)
+
+
+def test_two_deliveries_naming_one_partition_share_a_thread(
+    hooks_client: TestClient,
+    auth_headers: dict[str, str],
+    valkey: redis.Redis,
+    runs_stream: str,
+    clean_db: None,
+) -> None:
+    """The other half of AC2, and the half a fan-out-only test would miss.
+
+    Two DIFFERENT deliveries about the SAME thing must land on one thread, or the
+    partition is just a per-delivery id wearing a pointer, and intra-partition
+    serialization -- the property ADR-0079 bought -- is gone.
+    """
+
+    agent_id = _bind(
+        hooks_client,
+        auth_headers,
+        name="sameparttagent",
+        hook_partitions={"prs": {"pointer": "/number"}},
+    )
+    secret = _secret_for(agent_id)
+
+    first = _post(
+        hooks_client, agent_id, "prs", b'{"number": 42}', secret=secret, delivery_id="b-same-1"
+    )
+    second = _post(
+        hooks_client, agent_id, "prs", b'{"number": 42}', secret=secret, delivery_id="b-same-2"
+    )
+
+    assert first.status_code == 200 and second.status_code == 200
+    one, two = _queued(valkey, runs_stream)
+    # Two distinct events -- this is NOT the duplicate path.
+    assert one.event_id != two.event_id
+    assert one.conversation_id == two.conversation_id == f"hook:{agent_id}:prs:42"
+
+
+@pytest.mark.parametrize(
+    ("pointer", "body", "expected"),
+    [
+        pytest.param("/number", b'{"number": 42}', "42", id="int-coerced-to-str"),
+        pytest.param("/number", b'{"number": "42"}', "42", id="string-value"),
+        pytest.param(
+            "/pull_request/number",
+            b'{"pull_request": {"number": 42}, "number": 99}',
+            "42",
+            id="nested-and-not-the-decoy-at-the-root",
+        ),
+        pytest.param(
+            "/items/0/key",
+            b'{"items": [{"key": "OPS-7"}, {"key": "OPS-8"}]}',
+            "OPS-7",
+            id="array-index",
+        ),
+        pytest.param("/a~1b", b'{"a/b": "slashkey"}', "slashkey", id="tilde-one-is-a-slash"),
+        pytest.param("/m~0n", b'{"m~n": "tildekey"}', "tildekey", id="tilde-zero-is-a-tilde"),
+        pytest.param(
+            "/a~01b",
+            b'{"a~1b": "rightkey", "a/1b": "wrongkey"}',
+            "rightkey",
+            id="escape-order-e11",
+        ),
+    ],
+)
+def test_the_pointer_forms_an_operator_can_configure(
+    hooks_client: TestClient,
+    auth_headers: dict[str, str],
+    valkey: redis.Redis,
+    runs_stream: str,
+    clean_db: None,
+    pointer: str,
+    body: bytes,
+    expected: str,
+) -> None:
+    """Each case carries a decoy where one exists, so a resolver that reached the
+    right value by the wrong route (reading the root, taking the first array
+    member unconditionally, decoding `~0` before `~1`) fails here."""
+
+    agent_id = _bind(
+        hooks_client,
+        auth_headers,
+        name="pointeragent",
+        hook_partitions={"prs": {"pointer": pointer}},
+    )
+
+    answer = _post(
+        hooks_client, agent_id, "prs", body, secret=_secret_for(agent_id), delivery_id="b-ptr"
+    )
+
+    assert answer.status_code == 200, answer.text
+    (turn,) = _queued(valkey, runs_stream)
+    assert turn.conversation_id == f"hook:{agent_id}:prs:{expected}"
+
+
+def test_two_hooks_on_one_agent_partition_independently(
+    hooks_client: TestClient,
+    auth_headers: dict[str, str],
+    valkey: redis.Redis,
+    runs_stream: str,
+    clean_db: None,
+) -> None:
+    """Edge case E8. The map is keyed by hook name, and a firing reads only its
+    own entry -- so two hooks with different pointers cannot read each other's
+    field, and a body shaped for one cannot refuse for the other."""
+
+    agent_id = _bind(
+        hooks_client,
+        auth_headers,
+        name="twopointeragent",
+        hook_partitions={
+            "prs": {"pointer": "/number"},
+            "issues": {"pointer": "/issue/key"},
+        },
+    )
+    secret = _secret_for(agent_id)
+
+    _post(hooks_client, agent_id, "prs", b'{"number": 42}', secret=secret, delivery_id="b-h1")
+    _post(
+        hooks_client,
+        agent_id,
+        "issues",
+        b'{"issue": {"key": "OPS-3"}}',
+        secret=secret,
+        delivery_id="b-h2",
+    )
+
+    ids = [turn.conversation_id for turn in _queued(valkey, runs_stream)]
+    assert ids == [f"hook:{agent_id}:prs:42", f"hook:{agent_id}:issues:OPS-3"]
+
+
+# =============================================================================
+# Section C -- refusals (AC3): 422, no enqueue, no claim
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    ("pointer", "body"),
+    [
+        pytest.param("/number", b"not json at all", id="body-is-not-json"),
+        pytest.param("/number", b"", id="body-is-empty"),
+        pytest.param("/x", b"42", id="json-scalar-at-the-document-root"),
+        pytest.param("/x", b'["a", "b"]', id="json-array-at-the-document-root"),
+        pytest.param("/number", b'{"other": 1}', id="pointer-names-an-absent-key"),
+        pytest.param("/items/5", b'{"items": [1, 2]}', id="index-past-the-end"),
+        pytest.param("/number", b'{"number": null}', id="value-is-null"),
+        pytest.param("/number", b'{"number": {"a": 1}}', id="value-is-a-nested-object"),
+        pytest.param("/number", b'{"number": [1]}', id="value-is-a-list"),
+        pytest.param("/number", b'{"number": 1.5}', id="value-is-a-float"),
+        # Python's `True` IS an int. A `str(value)` coercion written for the int
+        # case turns this into the partition "True" -- a real-looking thread that
+        # no operator configured. It must refuse, not coerce.
+        pytest.param("/number", b'{"number": true}', id="value-is-a-bool"),
+        pytest.param("/number", b'{"number": -5}', id="value-is-a-negative-int"),
+        pytest.param("/number", b'{"number": "a:b"}', id="value-contains-a-colon"),
+        pytest.param("/number", b'{"number": "a/b"}', id="value-contains-a-slash"),
+        pytest.param("/number", b'{"number": "ab\\n"}', id="value-ends-in-a-newline"),
+        pytest.param("/number", b'{"number": ""}', id="value-is-the-empty-string"),
+        pytest.param(
+            "/number",
+            b'{"number": "' + b"a" * 64 + b'"}',
+            id="value-is-64-chars-one-past-the-bound",
+        ),
+        pytest.param("/number", b'{"number": ".lead"}', id="value-starts-with-a-dot"),
+        pytest.param("/number", b'{"number": "-lead"}', id="value-starts-with-a-dash"),
+        pytest.param("/number", b'{"number": "_lead"}', id="value-starts-with-an-underscore"),
+    ],
+)
+def test_a_delivery_that_cannot_name_its_partition_is_refused(
+    hooks_client: TestClient,
+    auth_headers: dict[str, str],
+    valkey: redis.Redis,
+    runs_stream: str,
+    clean_db: None,
+    pointer: str,
+    body: bytes,
+) -> None:
+    """AC3, one case per failure mode, and three assertions per case.
+
+    The status code alone proves almost nothing here. What must hold is that the
+    refusal happened BEFORE the claim: a refused delivery that took its claim key
+    would make the upstream's retry of a CORRECTED payload look like a duplicate
+    and drop it silently, which is the same silent-degradation failure the 422
+    exists to avoid in the first place.
+
+    The detail names both the hook and the pointer because the operator's only
+    other signal is a 422 on a route they do not control the caller of.
+    """
+
+    delivery_id = "c-refused"
+    agent_id = _bind(
+        hooks_client,
+        auth_headers,
+        name="refusalagent",
+        hook_partitions={"prs": {"pointer": pointer}},
+    )
+
+    refused = _post(
+        hooks_client,
+        agent_id,
+        "prs",
+        body,
+        secret=_secret_for(agent_id),
+        delivery_id=delivery_id,
+    )
+
+    assert refused.status_code == 422, refused.text
+    detail = refused.json()["detail"]
+    assert isinstance(detail, str), detail
+    assert "prs" in detail, detail
+    assert pointer in detail, detail
+    assert _queued(valkey, runs_stream) == []
+    assert not valkey.exists(_claim_key(agent_id, "prs", delivery_id)), (
+        "the refusal took the delivery claim, so a corrected retry of this same "
+        "delivery id would be deduplicated away and never run"
+    )
+
+
+def test_a_corrected_retry_of_a_refused_delivery_still_runs(
+    hooks_client: TestClient,
+    auth_headers: dict[str, str],
+    valkey: redis.Redis,
+    runs_stream: str,
+    clean_db: None,
+) -> None:
+    """The counterfactual for the no-claim assertion above, stated as behaviour.
+
+    Same delivery id, same hook, same agent: only the body is fixed. If the
+    refusal had claimed, this second request answers `duplicate: true` and
+    enqueues nothing, and the operator's fix never takes effect.
+    """
+
+    agent_id = _bind(
+        hooks_client,
+        auth_headers,
+        name="correctedagent",
+        hook_partitions={"prs": {"pointer": "/number"}},
+    )
+    secret = _secret_for(agent_id)
+
+    refused = _post(
+        hooks_client, agent_id, "prs", b'{"wrong": 1}', secret=secret, delivery_id="c-retry"
+    )
+    assert refused.status_code == 422, refused.text
+    assert _queued(valkey, runs_stream) == []
+
+    corrected = _post(
+        hooks_client, agent_id, "prs", b'{"number": 42}', secret=secret, delivery_id="c-retry"
+    )
+
+    assert corrected.status_code == 200, corrected.text
+    assert corrected.json()["duplicate"] is False
+    (turn,) = _queued(valkey, runs_stream)
+    assert turn.conversation_id == f"hook:{agent_id}:prs:42"
+
+
+def test_an_unsigned_delivery_to_a_partitioned_hook_answers_401_not_422(
+    hooks_client: TestClient,
+    auth_headers: dict[str, str],
+    valkey: redis.Redis,
+    runs_stream: str,
+    clean_db: None,
+) -> None:
+    """The partition check runs AFTER signature verification, so an unsigned
+    caller learns nothing about the hook's configuration.
+
+    A 422 naming the pointer here would tell an unauthenticated caller which
+    field of its payload the operator reads -- and would confirm that this hook is
+    partitioned at all. The detail must be the shared auth string, byte for byte.
+    """
+
+    agent_id = _bind(
+        hooks_client,
+        auth_headers,
+        name="unsignedpartagent",
+        hook_partitions={"prs": {"pointer": "/number"}},
+    )
+
+    refused = _post(hooks_client, agent_id, "prs", b"not json at all", signature=None)
+
+    assert refused.status_code == 401, refused.text
+    assert refused.json()["detail"] == "missing or invalid signature"
+    assert _queued(valkey, runs_stream) == []
+
+
+def test_a_delivery_with_no_id_to_a_partitioned_hook_answers_400_not_422(
+    hooks_client: TestClient,
+    auth_headers: dict[str, str],
+    valkey: redis.Redis,
+    runs_stream: str,
+    clean_db: None,
+) -> None:
+    """The other half of the ordering claim: the partition check also runs after
+    the delivery-id check, so a caller with no `X-Curie-Delivery-Id` is told about
+    the header it is missing rather than about a pointer it cannot fix."""
+
+    agent_id = _bind(
+        hooks_client,
+        auth_headers,
+        name="noidpartagent",
+        hook_partitions={"prs": {"pointer": "/number"}},
+    )
+
+    refused = _post(
+        hooks_client,
+        agent_id,
+        "prs",
+        b"not json at all",
+        secret=_secret_for(agent_id),
+        delivery_id=None,
+    )
+
+    assert refused.status_code == 400, refused.text
+    assert "X-Curie-Delivery-Id" in refused.json()["detail"]
+    assert _queued(valkey, runs_stream) == []
+
+
+def test_a_refused_partition_never_falls_back_to_the_unpartitioned_thread(
+    hooks_client: TestClient,
+    auth_headers: dict[str, str],
+    valkey: redis.Redis,
+    runs_stream: str,
+    clean_db: None,
+) -> None:
+    """The negative-space assertion the whole 422 decision rests on.
+
+    A fall-back would look like success: a 200, a turn on the stream, the agent
+    running. The only visible symptom would be that N intended threads had
+    quietly collapsed into one. This asserts the ABSENCE of the three-segment id,
+    which no status-code assertion anywhere else in this file covers.
+    """
+
+    agent_id = _bind(
+        hooks_client,
+        auth_headers,
+        name="nofallbackagent",
+        hook_partitions={"prs": {"pointer": "/number"}},
+    )
+
+    refused = _post(
+        hooks_client,
+        agent_id,
+        "prs",
+        b'{"wrong_field": 1}',
+        secret=_secret_for(agent_id),
+        delivery_id="c-fallback",
+    )
+
+    assert refused.status_code == 422, refused.text
+    threads = [turn.conversation_id for turn in _queued(valkey, runs_stream)]
+    assert threads == []
+    assert f"hook:{agent_id}:prs" not in threads
+
+
+def test_deeply_nested_json_is_refused_as_422_not_500(
+    hooks_client: TestClient,
+    auth_headers: dict[str, str],
+    valkey: redis.Redis,
+    runs_stream: str,
+    clean_db: None,
+) -> None:
+    """A pathological body must refuse cleanly, not crash the ingress.
+
+    `json.loads` raises `RecursionError` on JSON nested past Python's recursion
+    limit, and `RecursionError` is a `RuntimeError`, not a `ValueError` -- so the
+    `except ValueError` in `derive_partition`'s parse step does not catch it. Left
+    uncaught, this reaches the ASGI server as an unhandled 500, which is strictly
+    worse than every other malformed body in this section: it also skips the
+    no-enqueue, no-claim guarantee this file otherwise proves for every refusal.
+    The body is 200 KB, comfortably under `hook_max_body_bytes` (1 MiB), so the
+    size bound cannot be the thing doing the refusing here.
+    """
+
+    delivery_id = "c-deepnest"
+    agent_id = _bind(
+        hooks_client,
+        auth_headers,
+        name="deepnestagent",
+        hook_partitions={"prs": {"pointer": "/number"}},
+    )
+
+    body = b"[" * 100_000 + b"]" * 100_000
+
+    refused = _post(
+        hooks_client,
+        agent_id,
+        "prs",
+        body,
+        secret=_secret_for(agent_id),
+        delivery_id=delivery_id,
+    )
+
+    assert refused.status_code == 422, refused.text
+    detail = refused.json()["detail"]
+    assert isinstance(detail, str), detail
+    assert "prs" in detail, detail
+    assert "/number" in detail, detail
+    assert _queued(valkey, runs_stream) == []
+    assert not valkey.exists(_claim_key(agent_id, "prs", delivery_id)), (
+        "the refusal took the delivery claim, so a corrected retry of this same "
+        "delivery id would be deduplicated away and never run"
+    )
+
+
+# =============================================================================
+# Section D -- the receipt and the ingress log (AC4)
+# =============================================================================
+
+
+def test_the_receipt_names_the_thread_the_delivery_landed_on(
+    hooks_client: TestClient,
+    auth_headers: dict[str, str],
+    valkey: redis.Redis,
+    runs_stream: str,
+    clean_db: None,
+) -> None:
+    """The caller of a partitioned hook has no other way to learn its four-segment
+    id, and it needs one for `POST /control/threads/{key}/reset` and for the
+    `GET /approvals?conversation_id=` filter. Asserted against the ENQUEUED turn,
+    not against a second f-string, so a receipt built from a different mint fails.
+    """
+
+    partitioned = _bind(
+        hooks_client,
+        auth_headers,
+        name="receiptpartagent",
+        hook_partitions={"prs": {"pointer": "/number"}},
+    )
+    plain = _bind(hooks_client, auth_headers, name="receiptplainagent")
+
+    one = _post(
+        hooks_client,
+        partitioned,
+        "prs",
+        b'{"number": 42}',
+        secret=_secret_for(partitioned),
+        delivery_id="d-1",
+    )
+    two = _post(
+        hooks_client, plain, "issues", b"{}", secret=_secret_for(plain), delivery_id="d-2"
+    )
+
+    assert one.status_code == 200 and two.status_code == 200, (one.text, two.text)
+    first, second = _queued(valkey, runs_stream)
+    assert one.json()["conversation_id"] == first.conversation_id
+    assert one.json()["conversation_id"] == f"hook:{partitioned}:prs:42"
+    assert two.json()["conversation_id"] == second.conversation_id
+    assert two.json()["conversation_id"] == f"hook:{plain}:issues"
+
+
+def test_a_retried_delivery_reports_the_same_conversation_id(
+    hooks_client: TestClient,
+    auth_headers: dict[str, str],
+    valkey: redis.Redis,
+    runs_stream: str,
+    clean_db: None,
+) -> None:
+    """The duplicate path carries the id too.
+
+    An upstream that only ever sees the retry -- because its first attempt timed
+    out on the wire -- would otherwise never learn the thread its delivery is on.
+    Only one turn is enqueued, so the second receipt cannot be reading it off a
+    turn it just minted; it has to derive the id the same way the first did.
+    """
+
+    agent_id = _bind(
+        hooks_client,
+        auth_headers,
+        name="dupreceiptagent",
+        hook_partitions={"prs": {"pointer": "/number"}},
+    )
+    secret = _secret_for(agent_id)
+    body = b'{"number": 42}'
+
+    first = _post(hooks_client, agent_id, "prs", body, secret=secret, delivery_id="d-dup")
+    second = _post(hooks_client, agent_id, "prs", body, secret=secret, delivery_id="d-dup")
+
+    assert first.json()["duplicate"] is False
+    assert second.json()["duplicate"] is True
+    assert second.json()["conversation_id"] == first.json()["conversation_id"]
+    assert second.json()["conversation_id"] == f"hook:{agent_id}:prs:42"
+    assert len(_queued(valkey, runs_stream)) == 1
+
+
+def test_a_duplicate_receipt_names_the_thread_the_delivery_landed_on(
+    hooks_client: TestClient,
+    auth_headers: dict[str, str],
+    valkey: redis.Redis,
+    runs_stream: str,
+    clean_db: None,
+) -> None:
+    """The duplicate path must report where the delivery ACTUALLY landed, not a
+    thread recomputed from whatever body the retry happens to carry.
+
+    An upstream retry of the SAME delivery id can legitimately carry a DIFFERENT
+    body -- a webhook re-signed after the PR moved on, a payload the sender
+    regenerated -- but the delivery already ran once and landed on a thread.
+    Recomputing the partition from the retry's body would answer with a thread
+    this delivery never touched, and the operator would reset or filter the wrong
+    one.
+    """
+
+    agent_id = _bind(
+        hooks_client,
+        auth_headers,
+        name="dupthreadagent",
+        hook_partitions={"prs": {"pointer": "/number"}},
+    )
+    secret = _secret_for(agent_id)
+
+    first = _post(
+        hooks_client, agent_id, "prs", b'{"number": 41}', secret=secret, delivery_id="d-retry"
+    )
+    assert first.status_code == 200, first.text
+    assert first.json()["duplicate"] is False
+    assert first.json()["conversation_id"] == f"hook:{agent_id}:prs:41"
+
+    second = _post(
+        hooks_client, agent_id, "prs", b'{"number": 42}', secret=secret, delivery_id="d-retry"
+    )
+
+    assert second.status_code == 200, second.text
+    assert second.json()["duplicate"] is True
+    assert second.json()["conversation_id"] == f"hook:{agent_id}:prs:41", (
+        "the retry's body named partition 42, but this delivery already landed "
+        "on 41 -- the receipt must name the thread it landed on, not the one its "
+        "retry's body would derive"
+    )
+    (turn,) = _queued(valkey, runs_stream)
+    assert turn.conversation_id == f"hook:{agent_id}:prs:41"
+
+
+def test_a_duplicate_receipt_ignores_a_partition_config_change_after_it_landed(
+    hooks_client: TestClient,
+    auth_headers: dict[str, str],
+    valkey: redis.Redis,
+    runs_stream: str,
+    clean_db: None,
+) -> None:
+    """Same claim, a sharper angle: the operator can repoint the hook entirely
+    between the two deliveries. The retry must still answer with the thread the
+    FIRST delivery landed on, derived under the OLD config -- not one recomputed
+    under the new pointer, which would read a different field of the SAME retry
+    body and could name a different partition entirely.
+    """
+
+    agent_id = _bind(
+        hooks_client,
+        auth_headers,
+        name="dupconfigagent",
+        hook_partitions={"prs": {"pointer": "/number"}},
+    )
+    secret = _secret_for(agent_id)
+
+    first = _post(
+        hooks_client, agent_id, "prs", b'{"number": 41}', secret=secret, delivery_id="d-cfg"
+    )
+    assert first.status_code == 200, first.text
+    assert first.json()["conversation_id"] == f"hook:{agent_id}:prs:41"
+
+    patched = hooks_client.patch(
+        f"/agents/{agent_id}",
+        json={"hook_partitions": {"prs": {"pointer": "/other"}}},
+        headers=auth_headers,
+    )
+    assert patched.status_code == 200, patched.text
+
+    second = _post(
+        hooks_client,
+        agent_id,
+        "prs",
+        b'{"number": 41, "other": "zz"}',
+        secret=secret,
+        delivery_id="d-cfg",
+    )
+
+    assert second.status_code == 200, second.text
+    assert second.json()["duplicate"] is True
+    assert second.json()["conversation_id"] == f"hook:{agent_id}:prs:41"
+    (turn,) = _queued(valkey, runs_stream)
+    assert turn.conversation_id == f"hook:{agent_id}:prs:41"
+
+
+def test_the_ingress_log_names_the_conversation_id(
+    hooks_client: TestClient,
+    auth_headers: dict[str, str],
+    valkey: redis.Redis,
+    runs_stream: str,
+    clean_db: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The operator's only server-side record of which thread a delivery landed on.
+
+    There is no fan-out reset verb, so an operator resets a partition by its full
+    four-segment id -- and this log line plus the receipt are the two places that
+    id is ever shown. A log line that named only the hook would leave an operator
+    with N live threads and no way to enumerate them.
+
+    `caplog.handler` is attached to the service logger BY HAND. `configure_logging`
+    sets `propagate = False` on `curie_api` (deliberately, so records are not
+    double-emitted through whatever uvicorn and the OTel wiring put on root), and
+    pytest installs its capture handler on the ROOT logger only -- so the obvious
+    `with caplog.at_level(...)` form captures nothing here and the assertion below
+    would fail for a reason that has nothing to do with the log line.
+    """
+
+    agent_id = _bind(
+        hooks_client,
+        auth_headers,
+        name="logagent",
+        hook_partitions={"prs": {"pointer": "/number"}},
+    )
+    service_logger = logging.getLogger("curie_api")
+    service_logger.addHandler(caplog.handler)
+    try:
+        with caplog.at_level(logging.INFO, logger="curie_api"):
+            answer = _post(
+                hooks_client,
+                agent_id,
+                "prs",
+                b'{"number": 42}',
+                secret=_secret_for(agent_id),
+                delivery_id="d-log",
+            )
+    finally:
+        service_logger.removeHandler(caplog.handler)
+
+    assert answer.status_code == 200, answer.text
+    expected = f"hook:{agent_id}:prs:42"
+    lines = [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == "curie_api.routers.hooks"
+    ]
+    assert any(f"conversation_id={expected}" in line for line in lines), lines
+
+
+# =============================================================================
+# Section E -- the write surface round-trip (AC5)
+# =============================================================================
+
+
+def test_the_partition_map_round_trips_through_create_and_get(
+    hooks_client: TestClient, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    """Create is one of the two write paths, and GET is the only read path."""
+
+    configured = {"prs": {"pointer": "/number"}, "issues": {"pointer": "/issue/key"}}
+    agent_id = _bind(
+        hooks_client, auth_headers, name="roundtripagent", hook_partitions=configured
+    )
+
+    fetched = hooks_client.get(f"/agents/{agent_id}", headers=auth_headers)
+
+    assert fetched.status_code == 200, fetched.text
+    assert fetched.json()["hook_partitions"] == configured
+
+
+def test_an_agent_created_without_the_map_reads_back_null(
+    hooks_client: TestClient, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    """The default is NULL, not an empty object: NULL is the unpartitioned
+    posture, and every pre-existing agent row has it."""
+
+    agent_id = _bind(hooks_client, auth_headers, name="defaultnullagent")
+
+    fetched = hooks_client.get(f"/agents/{agent_id}", headers=auth_headers)
+
+    assert fetched.json()["hook_partitions"] is None
+
+
+def test_a_post_with_an_empty_map_persists_null(
+    hooks_client: TestClient,
+    auth_headers: dict[str, str],
+    valkey: redis.Redis,
+    runs_stream: str,
+    clean_db: None,
+) -> None:
+    """CREATE's version of edge case E10. `test_clearing_the_map_returns_the_hook_to_one_thread`
+    proves the rule on PATCH; this proves the SAME rule on the other write path,
+    so an operator who passes an explicit `{}` on `POST /agents` -- rather than
+    omitting the key entirely -- gets the identical unpartitioned posture, both in
+    the stored column and in what the very next firing mints.
+    """
+
+    agent_id = _bind(hooks_client, auth_headers, name="createemptymapagent", hook_partitions={})
+
+    fetched = hooks_client.get(f"/agents/{agent_id}", headers=auth_headers)
+    assert fetched.status_code == 200, fetched.text
+    assert fetched.json()["hook_partitions"] is None, "an empty map on create must persist as NULL"
+
+    answer = _post(
+        hooks_client,
+        agent_id,
+        "issues",
+        b'{"number": 41}',
+        secret=_secret_for(agent_id),
+        delivery_id="e-createempty",
+    )
+
+    assert answer.status_code == 200, answer.text
+    assert answer.json()["conversation_id"] == f"hook:{agent_id}:issues"
+    (turn,) = _queued(valkey, runs_stream)
+    assert turn.conversation_id == f"hook:{agent_id}:issues"
+
+
+def test_a_patch_that_omits_the_map_leaves_it_unchanged(
+    hooks_client: TestClient, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    """Omitted is not cleared. A PATCH that renames an agent must not silently
+    return every one of its hooks to a single thread."""
+
+    configured = {"prs": {"pointer": "/number"}}
+    agent_id = _bind(
+        hooks_client, auth_headers, name="omitpatchagent", hook_partitions=configured
+    )
+
+    patched = hooks_client.patch(
+        f"/agents/{agent_id}", json={"model": "example-model"}, headers=auth_headers
+    )
+
+    assert patched.status_code == 200, patched.text
+    assert patched.json()["hook_partitions"] == configured
+    fetched = hooks_client.get(f"/agents/{agent_id}", headers=auth_headers)
+    assert fetched.json()["hook_partitions"] == configured
+
+
+def test_a_patch_replaces_the_map_wholesale(
+    hooks_client: TestClient, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    """Replacement, not a merge. A PATCH naming only `issues` must drop `prs`, or
+    an operator could never remove a partition without clearing everything."""
+
+    agent_id = _bind(
+        hooks_client,
+        auth_headers,
+        name="replacepatchagent",
+        hook_partitions={"prs": {"pointer": "/number"}},
+    )
+
+    patched = hooks_client.patch(
+        f"/agents/{agent_id}",
+        json={"hook_partitions": {"issues": {"pointer": "/issue/key"}}},
+        headers=auth_headers,
+    )
+
+    assert patched.status_code == 200, patched.text
+    assert patched.json()["hook_partitions"] == {"issues": {"pointer": "/issue/key"}}
+    assert "prs" not in (patched.json()["hook_partitions"] or {})
+
+
+def test_clearing_the_map_returns_the_hook_to_one_thread(
+    hooks_client: TestClient,
+    auth_headers: dict[str, str],
+    valkey: redis.Redis,
+    runs_stream: str,
+    clean_db: None,
+) -> None:
+    """Edge case E10, and the BEHAVIOUR is the assertion, not the column.
+
+    An explicit `{}` clears; it is stored as NULL, so the GET answers `null`
+    rather than `{}`. Asserting only the column would leave the clear path
+    untested where it matters -- what the operator is buying is that the very next
+    firing goes back to the three-segment id.
+    """
+
+    agent_id = _bind(
+        hooks_client,
+        auth_headers,
+        name="clearagent",
+        hook_partitions={"prs": {"pointer": "/number"}},
+    )
+    secret = _secret_for(agent_id)
+
+    before = _post(
+        hooks_client, agent_id, "prs", b'{"number": 42}', secret=secret, delivery_id="e-1"
+    )
+    assert before.json()["conversation_id"] == f"hook:{agent_id}:prs:42"
+
+    cleared = hooks_client.patch(
+        f"/agents/{agent_id}", json={"hook_partitions": {}}, headers=auth_headers
+    )
+
+    assert cleared.status_code == 200, cleared.text
+    assert cleared.json()["hook_partitions"] is None, "an empty map must persist as NULL"
+    fetched = hooks_client.get(f"/agents/{agent_id}", headers=auth_headers)
+    assert fetched.json()["hook_partitions"] is None
+
+    after = _post(
+        hooks_client, agent_id, "prs", b'{"number": 42}', secret=secret, delivery_id="e-2"
+    )
+
+    assert after.status_code == 200, after.text
+    assert after.json()["conversation_id"] == f"hook:{agent_id}:prs"
+    threads = [turn.conversation_id for turn in _queued(valkey, runs_stream)]
+    assert threads == [f"hook:{agent_id}:prs:42", f"hook:{agent_id}:prs"]
+
+
+@pytest.mark.parametrize(
+    ("key", "token"),
+    [
+        pytest.param("Issues", "Issues", id="uppercase"),
+        pytest.param("has:colon", "has:colon", id="colon-would-forge-a-segment"),
+        pytest.param("has/slash", "has/slash", id="slash"),
+        pytest.param("has space", "has space", id="space"),
+        pytest.param(".leading", ".leading", id="leading-dot"),
+        pytest.param("", "hook_partitions", id="empty-key"),
+        pytest.param("x" * 64, "x" * 64, id="64-chars-one-past-the-bound"),
+    ],
+)
+def test_a_key_outside_the_hook_name_shape_is_refused_on_both_write_paths(
+    hooks_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    key: str,
+    token: str,
+) -> None:
+    """A configured hook name and a fired hook name cannot be allowed to disagree.
+
+    A key the ingress would refuse at step 1 can never match a firing, so it
+    configures nothing while looking configured -- the operator sees a partition
+    map and gets unpartitioned threads. Both write paths are checked: a rule
+    enforced only on create leaks in through PATCH.
+    """
+
+    created = hooks_client.post(
+        "/agents",
+        json={
+            "name": "badkeyagent",
+            "channel": {
+                "kind": "email",
+                "address": "badkeyagent@example.test",
+                "endpoint": EMAIL_ENDPOINT,
+                "adapter": EMAIL_ADAPTER,
+            },
+            "hook_partitions": {key: {"pointer": "/number"}},
+        },
+        headers=auth_headers,
+    )
+    assert created.status_code == 422, created.text
+    assert token in created.text, created.text
+
+    agent_id = _bind(hooks_client, auth_headers, name="badkeypatchagent")
+    patched = hooks_client.patch(
+        f"/agents/{agent_id}",
+        json={"hook_partitions": {key: {"pointer": "/number"}}},
+        headers=auth_headers,
+    )
+    assert patched.status_code == 422, patched.text
+    assert token in patched.text, patched.text
+
+
+@pytest.mark.parametrize(
+    "pointer",
+    [
+        pytest.param("number", id="no-leading-slash"),
+        pytest.param("pull_request/number", id="path-with-no-leading-slash"),
+        pytest.param("~0", id="escape-with-no-leading-slash"),
+    ],
+)
+def test_a_malformed_pointer_is_refused_at_configuration_time(
+    hooks_client: TestClient, auth_headers: dict[str, str], clean_db: None, pointer: str
+) -> None:
+    """Refused on the write, not on the first delivery.
+
+    A pointer that can never resolve is an operator error, and the operator is at
+    the keyboard during the PATCH. Deferring it to ingress means the failure
+    surfaces as a 422 to a third-party upstream nobody at this end is watching.
+    """
+
+    agent_id = _bind(hooks_client, auth_headers, name="badpointeragent")
+
+    patched = hooks_client.patch(
+        f"/agents/{agent_id}",
+        json={"hook_partitions": {"prs": {"pointer": pointer}}},
+        headers=auth_headers,
+    )
+
+    assert patched.status_code == 422, patched.text
+    assert pointer in patched.text, patched.text
+
+
+def test_an_invalid_escape_pointer_is_refused_on_both_write_paths(
+    hooks_client: TestClient, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    """RFC 6901 permits only the two escapes `~0` and `~1`. A bare or dangling `~`
+    can never resolve as the operator intended, so it must be refused at
+    CONFIGURATION time on both write paths, the same as any other malformed
+    pointer shape in this section.
+    """
+
+    created = hooks_client.post(
+        "/agents",
+        json={
+            "name": "badescapeagent",
+            "channel": {
+                "kind": "email",
+                "address": "badescapeagent@example.test",
+                "endpoint": EMAIL_ENDPOINT,
+                "adapter": EMAIL_ADAPTER,
+            },
+            "hook_partitions": {"prs": {"pointer": "/a~2b"}},
+        },
+        headers=auth_headers,
+    )
+    assert created.status_code == 422, created.text
+
+    agent_id = _bind(hooks_client, auth_headers, name="badescapepatchagent")
+    patched = hooks_client.patch(
+        f"/agents/{agent_id}",
+        json={"hook_partitions": {"prs": {"pointer": "/a~"}}},
+        headers=auth_headers,
+    )
+
+    assert patched.status_code == 422, patched.text
+    assert "/a~" in patched.text, patched.text
+
+
+def test_an_unknown_key_inside_the_config_object_is_refused(
+    hooks_client: TestClient, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    """Pins `extra="forbid"` on the config model.
+
+    A typo'd key that is silently dropped leaves the operator believing a
+    configuration is active that is not -- the same reason `ApprovalApprovers`
+    forbids extras. Here the dropped key would be the whole partition, and the
+    hook would run unpartitioned while its config looked right in a GET.
+    """
+
+    agent_id = _bind(hooks_client, auth_headers, name="extrakeyagent")
+
+    patched = hooks_client.patch(
+        f"/agents/{agent_id}",
+        json={"hook_partitions": {"prs": {"pointer": "/n", "poitner": "/m"}}},
+        headers=auth_headers,
+    )
+
+    assert patched.status_code == 422, patched.text
+    assert "poitner" in patched.text, patched.text

--- a/apps/api/tests/test_hooks.py
+++ b/apps/api/tests/test_hooks.py
@@ -15,9 +15,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import hmac
-import os
 import uuid
-from collections.abc import Iterator
 from typing import Any
 
 import pytest
@@ -25,8 +23,6 @@ import redis
 from aci_protocol import QueuedTurn, TurnSource
 from curie_api.config import get_settings
 from curie_api.hook_signing import derive
-from curie_api.main import create_app
-from curie_test_support.valkey import connect_or_skip
 from fastapi.testclient import TestClient
 from sqlalchemy import text as sql_text
 from sqlalchemy.ext.asyncio import create_async_engine
@@ -36,30 +32,9 @@ EMAIL_ADAPTER = "agentmail-sandbox"
 
 
 # --- fixtures -----------------------------------------------------------------
-
-
-@pytest.fixture
-def runs_stream() -> Iterator[str]:
-    name = f"test:curie:runs:{uuid.uuid4().hex}"
-    os.environ["RUNS_STREAM"] = name
-    get_settings.cache_clear()
-    yield name
-    os.environ.pop("RUNS_STREAM", None)
-    get_settings.cache_clear()
-
-
-@pytest.fixture
-def valkey(runs_stream: str) -> Iterator[redis.Redis]:
-    client = connect_or_skip(decode_responses=True)
-    yield client
-    client.delete(runs_stream)
-    client.close()
-
-
-@pytest.fixture
-def hooks_client(_disposable_db: Any, runs_stream: str) -> Iterator[TestClient]:
-    with TestClient(create_app()) as test_client:
-        yield test_client
+#
+# `runs_stream`, `valkey` and `hooks_client` live in conftest.py, shared with
+# test_hook_partition.py.
 
 
 @pytest.fixture
@@ -200,6 +175,11 @@ def test_every_firing_of_one_hook_shares_a_thread(
     A fresh thread per delivery would claim a sandbox per event and let two
     firings run concurrently with no ordering; sharing one means the second
     defers behind the first. Two hooks on one agent stay separate.
+
+    This is also the explicit UNPARTITIONED control for the opt-in delivery
+    partitioning in `test_hook_partition.py`: an agent that never configured
+    `hook_partitions` mints a THREE-segment id, so a change that made every hook
+    fan out by default fails here rather than only there.
     """
 
     agent_id = _bind(hooks_client, auth_headers, name="threadagent")
@@ -212,6 +192,7 @@ def test_every_firing_of_one_hook_shares_a_thread(
     threads = [t.conversation_id for t in _queued(valkey, runs_stream)]
     assert threads[0] == threads[1], threads
     assert threads[2] != threads[0], threads
+    assert all(t.count(":") == 2 for t in threads), threads
 
 
 # --- refusals -----------------------------------------------------------------

--- a/apps/worker/tests/kernel/conftest.py
+++ b/apps/worker/tests/kernel/conftest.py
@@ -13,6 +13,8 @@ sync fixtures.
 from __future__ import annotations
 
 import contextlib
+import socket
+import threading
 from collections.abc import AsyncIterator, Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -295,6 +297,11 @@ class _FakeClaim:
 class _FakeSandbox:
     name: str
     operating_mode: str = "Running"
+    # The sandbox-specific dial port, or None for the fleet-wide fallback.
+    # ``None`` is what every existing test gets, and it makes the substrate use
+    # ``SubstrateConfig.runner_port`` exactly as before (``substrate.py``:
+    # ``port=bound.port if bound.port is not None else config.runner_port``).
+    port: int | None = None
 
 
 @dataclass
@@ -309,6 +316,40 @@ class FakeK8s:
     quota_rejection: QuotaRejection | None = None
     ready_reason: str | None = None
     ready_message: str | None = None
+    # OPT-IN per-sandbox runner ports, pre-started by the harness fixture (see
+    # ``per_sandbox_runners``). Empty (the default) is the shared-runner world
+    # every existing test lives in: every sandbox gets ``port=None`` and dials
+    # the one fleet-wide runner.
+    #
+    # The pool cannot be created here: ``create_claim`` is sync -- the substrate
+    # calls it through ``asyncio.to_thread`` -- so it can neither start an
+    # aiohttp ``TestServer`` nor await one.
+    runner_ports: list[int] = field(default_factory=list)
+    # sandbox name -> the port it was handed, so a fan-out test can assert the
+    # partitions resolved to DISTINCT runners rather than to one shared fake.
+    assigned_ports: dict[str, int] = field(default_factory=dict)
+    _next_port: int = 0
+    # ``create_claim`` runs on a worker thread, and a fan-out test creates
+    # several claims concurrently, so handing out the next port is a real race.
+    _port_lock: threading.Lock = field(default_factory=threading.Lock)
+
+    def _take_port(self, sandbox_name: str) -> int | None:
+        """The next pooled port for a new sandbox, or None when unpooled."""
+        with self._port_lock:
+            if not self.runner_ports:
+                return None
+            if self._next_port >= len(self.runner_ports):
+                # Refuse rather than wrap. Recycling a port would hand two
+                # sandboxes ONE fake runner with ONE ``turn_active`` flag, which
+                # is the exact false-pass this pool exists to eliminate.
+                raise AssertionError(
+                    f"per-sandbox runner pool exhausted after "
+                    f"{len(self.runner_ports)} sandboxes; raise per_sandbox_runners"
+                )
+            port = self.runner_ports[self._next_port]
+            self._next_port += 1
+            self.assigned_ports[sandbox_name] = port
+            return port
 
     def create_claim(
         self,
@@ -329,7 +370,9 @@ class FakeK8s:
             ready_reason=self.ready_reason,
             ready_message=self.ready_message,
         )
-        self.sandboxes[sandbox_name] = _FakeSandbox(name=sandbox_name)
+        self.sandboxes[sandbox_name] = _FakeSandbox(
+            name=sandbox_name, port=self._take_port(sandbox_name)
+        )
 
     def get_claim(self, name: str) -> ClaimView | None:
         claim = self.claims.get(name)
@@ -366,11 +409,18 @@ class FakeK8s:
         if sandbox is None:
             return None
         # 127.0.0.1 so RunnerClient reaches the in-process fake runner.
+        #
+        # ``port=None`` keeps the fleet-wide fallback (every existing test: one
+        # shared fake runner on ``SubstrateConfig.runner_port``). A per-sandbox
+        # port is how a fan-out test gives each partition its OWN runner, so
+        # each has its own ``turn_active`` flag and the kernel's liveness read
+        # answers per thread instead of fleet-wide.
         return SandboxView(
             name=sandbox.name,
             ready=True,
             service_fqdn="127.0.0.1",
             operating_mode=sandbox.operating_mode,
+            port=sandbox.port,
         )
 
     def set_sandbox_mode(self, name: str, mode: str) -> None:
@@ -531,6 +581,19 @@ async def _pending_rows(h: Any) -> dict[str, int]:
     return {row["message_id"]: int(row["times_delivered"]) for row in rows}
 
 
+def _closed_port() -> int:
+    """A loopback port nothing is listening on.
+
+    Bind to port 0, read what the OS handed out, close it again. Used as the
+    fleet-wide ``runner_port`` trap described in ``kernel_harness``: dialling it
+    must fail, so a lost per-sandbox port is a loud test failure rather than a
+    silent fall-back onto the one shared fake runner.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
 @dataclass
 class Harness:
     substrate: SandboxSubstrate
@@ -542,6 +605,12 @@ class Harness:
     fake_k8s: FakeK8s
     card_store: ApprovalCardStore
     killswitch: object | None = None
+    # The opt-in per-sandbox fake runners, keyed by the port each is serving on,
+    # so a test can map an asserted ``fake_k8s.assigned_ports`` value back to the
+    # runner that answered for that sandbox. Empty unless ``per_sandbox_runners``
+    # was passed; ``runner`` above stays the shared one either way. Appended LAST
+    # and defaulted so the existing 9-positional construction below stays valid.
+    runners: dict[int, FakeRunner] = field(default_factory=dict)
 
 
 @pytest.fixture
@@ -561,7 +630,14 @@ def make_harness(
     ``RunnerClient``'s streaming budget (mirroring ``run.py``), so a test that
     expires the stream mid-flight (#2011) passes a fractional value and the
     config's own ``runner_total_timeout_s <= delivery_budget_s`` validator still
-    judges what the client actually does."""
+    judges what the client actually does.
+
+    ``per_sandbox_runners`` (default 0, meaning "unchanged") starts N ADDITIONAL
+    fake runners, one per sandbox, and exposes them as ``Harness.runners``. Pass
+    it when the test is about several threads running AT ONCE: with the shared
+    single runner, every sandbox dials one fake with one ``turn_active`` flag, so
+    the kernel reads every thread as busy and a fan-out test would "prove" that
+    independent threads serialize."""
 
     def factory(**overrides: object) -> contextlib.AbstractAsyncContextManager[Harness]:
         return kernel_harness(names, sync_redis, **overrides)
@@ -582,6 +658,7 @@ async def kernel_harness(
     publication_creator: object | None = None,
     sink: object | None = None,
     claim_timeout_seconds: float = 3.0,
+    per_sandbox_runners: int = 0,
     **config_overrides: object,
 ) -> AsyncIterator[Harness]:
     """Assemble a live kernel wired to a fake runner and real Valkey."""
@@ -592,14 +669,37 @@ async def kernel_harness(
     port = server.port
     assert port is not None
 
-    fake_k8s = FakeK8s()
+    # Opt-in per-sandbox runners. Started HERE, before any claim: the substrate
+    # calls ``FakeK8s.create_claim`` synchronously on a worker thread, which can
+    # neither start an aiohttp server nor await one.
+    extra_servers: list[TestServer] = []
+    runners: dict[int, FakeRunner] = {}
+    for _ in range(per_sandbox_runners):
+        extra_runner = FakeRunner()
+        extra_server = TestServer(extra_runner.app)
+        await extra_server.start_server()
+        assert extra_server.port is not None
+        extra_servers.append(extra_server)
+        runners[extra_server.port] = extra_runner
+
+    # The fleet-wide fallback port. With per-sandbox runners in play it is set to
+    # a deliberately CLOSED port, and that is the negative control that keeps
+    # this harness honest: if a future change stops honouring ``SandboxView.port``
+    # (``substrate.py``'s ``port=bound.port if bound.port is not None else
+    # config.runner_port``), every sandbox falls back to a dead port,
+    # ``Kernel._turn_active`` fails CLOSED and reports every thread busy, and the
+    # fan-out test fails LOUDLY -- instead of silently sharing one runner, one
+    # ``turn_active`` flag, and passing for the wrong reason.
+    fleet_port = _closed_port() if per_sandbox_runners else port
+
+    fake_k8s = FakeK8s(runner_ports=list(runners))
     substrate = SandboxSubstrate(
         fake_k8s,  # type: ignore[arg-type]
         AffinityStore(sync_redis, key_prefix=names["sandbox_prefix"]),
         SubstrateConfig(
             namespace="test-ns",
             warm_pool="test-pool",
-            runner_port=port,
+            runner_port=fleet_port,
             route_ttl_seconds=60,
             claim_timeout_seconds=claim_timeout_seconds,
             poll_interval_seconds=0.005,
@@ -655,6 +755,7 @@ async def kernel_harness(
             fake_k8s,
             card_store,
             killswitch,
+            runners,
         )
     finally:
         with contextlib.suppress(Exception):
@@ -663,3 +764,8 @@ async def kernel_harness(
             await async_redis.aclose()
         with contextlib.suppress(Exception):
             await server.close()
+        # Every per-sandbox server too: a missed close leaks an aiohttp site for
+        # the rest of the pytest session and surfaces as unrelated flakes.
+        for extra_server in extra_servers:
+            with contextlib.suppress(Exception):
+                await extra_server.close()

--- a/apps/worker/tests/kernel/test_hook_partition.py
+++ b/apps/worker/tests/kernel/test_hook_partition.py
@@ -1,0 +1,322 @@
+"""A hook fans out per partition, and each partition still serializes.
+
+A hook's conversation id may carry a fourth, operator-configured segment --
+``hook:<agent-id>:<name>:<partition>`` -- so one firing of a hook that finds N
+independent things runs N threads instead of deferring N-1 of them behind the
+first. These tests pin both halves of that: partitions of one hook run
+CONCURRENTLY, and two deliveries naming the SAME partition still serialize
+exactly as an unpartitioned hook does today.
+
+**The harness trap these tests exist to defend against.** The kernel suite's
+shared ``FakeK8s`` resolves every sandbox to ``127.0.0.1`` on ONE fleet-wide
+runner port, so every claim dials ONE ``FakeRunner`` holding ONE global
+``turn_active`` flag. ``Kernel._turn_active`` then reports EVERY thread busy the
+moment any thread is live, and a fan-out test written on that fake concludes
+that independent partitions serialize against each other -- a passing test of
+the wrong thing, and the opposite of the behavior under test.
+
+The fix is ``per_sandbox_runners``: one ``FakeRunner`` behind its own aiohttp
+server per sandbox, handed to the substrate through ``SandboxView.port``. So the
+positive control below asserts the three handles resolved to three **DISTINCT**
+runner ports. That assertion is not decoration -- without it the test cannot
+tell real fan-out from the shared-runner trap, because the trap's symptom
+(every partition talking to one runner) is invisible in claim counts, steer logs
+and turn text alike. The harness's second guard is the fleet-wide fallback port,
+which is deliberately CLOSED whenever ``per_sandbox_runners`` is set: if the
+per-sandbox port is ever dropped on the floor, every partition falls back to a
+dead port, ``_turn_active`` fails closed, and these tests fail loudly instead of
+quietly sharing one runner.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+import uuid
+from collections.abc import Callable
+
+import pytest
+from aci_protocol import (
+    Final,
+    QueuedTurn,
+    ReplyHandle,
+    SessionStatus,
+    TextDelta,
+    TurnSource,
+)
+from curie_worker.kernel import ThreadBusyError
+
+DONE = SessionStatus.DONE
+
+# An example agent id and an example Slack channel: this repo is public, so no
+# identifier here is real.
+AGENT_ID = "00000000-0000-4000-8000-00000000a1b2"
+CHANNEL = "C0EXAMPLE1"
+HOOK = "prs"
+
+
+def _conversation_id(hook: str = HOOK, partition: str | None = None) -> str:
+    """The id the hook ingress mints, with or without its partition segment.
+
+    Built here rather than imported so these tests state the wire shape they
+    depend on instead of inheriting whatever the API happens to produce.
+    """
+    base = f"hook:{AGENT_ID}:{hook}"
+    return base if partition is None else f"{base}:{partition}"
+
+
+def _hook_event(
+    text: str,
+    *,
+    partition: str | None = None,
+    hook: str = HOOK,
+    event_id: str | None = None,
+) -> QueuedTurn:
+    """One webhook delivery, as the hook ingress enqueues it.
+
+    ``source=TurnSource.WEBHOOK`` is load-bearing: ADR-0079 makes a job an
+    OUTPUT, so the kernel defers it with ``ThreadBusyError`` on a live thread
+    rather than steering into it. A ``TurnSource.SLACK`` turn would steer and
+    these tests would assert nothing about deferral. ``placeholder=None`` mirrors
+    the ingress, which has no pre-posted message to edit.
+
+    Its own helper rather than ``test_kernel.py``'s ``_qevent``: that one hard
+    codes a Slack conversation id and source, and importing across test modules
+    is fragile under importlib mode.
+    """
+    return QueuedTurn(
+        event_id=event_id or uuid.uuid4().hex,
+        conversation_id=_conversation_id(hook, partition),
+        author=f"hook:{hook}",
+        text=text,
+        reply_handle=ReplyHandle(
+            kind="slack", channel=CHANNEL, placeholder=None, endpoint=None
+        ),
+        received_at="2026-08-29T00:00:00+00:00",
+        source=TurnSource.WEBHOOK,
+    )
+
+
+async def _wait_until(pred: Callable[[], bool], timeout: float = 5.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if pred():
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError("condition not met within timeout")
+
+
+def _park_every_runner(h, hold: asyncio.Event) -> None:
+    """Make every per-sandbox runner hang mid-turn until ``hold`` is set.
+
+    A turn that hangs is the only way to observe concurrency at all: without it
+    each turn finishes before the next starts and three serialized turns look
+    identical to three concurrent ones.
+    """
+    for runner in h.runners.values():
+        runner.hold = hold
+        runner.default_script = [TextDelta(text="working")]
+        runner.tail = [Final(text="done", status=DONE)]
+
+
+def _live_ports(h) -> set[int]:
+    """Ports whose runner has a turn live RIGHT NOW."""
+    return {port for port, runner in h.runners.items() if runner.turn_active}
+
+
+def _opened_total(h) -> int:
+    return sum(len(runner.opened) for runner in h.runners.values())
+
+
+def test_three_partitions_of_one_hook_run_concurrently(make_harness) -> None:
+    """The positive control: fan-out, and the proof the harness can see it.
+
+    Three ids differing ONLY in their partition segment, driven concurrently.
+    They must reach three sandboxes, three DISTINCT runner ports, and three
+    simultaneously live turns, with no steer and no deferral anywhere.
+    """
+
+    async def go() -> None:
+        async with make_harness(per_sandbox_runners=3) as h:
+            hold = asyncio.Event()
+            _park_every_runner(h, hold)
+
+            events = [_hook_event(f"pr {n}", partition=str(n)) for n in (41, 42, 43)]
+            # Differing only in the partition segment is the whole premise: if
+            # the ids agreed, one thread key would serialize them.
+            assert len({e.conversation_id for e in events}) == 3
+            assert {e.conversation_id.rsplit(":", 1)[0] for e in events} == {
+                _conversation_id()
+            }
+
+            tasks = [asyncio.create_task(h.kernel.process_event(e)) for e in events]
+            try:
+                # All three live AT THE SAME MOMENT, not merely all three
+                # eventually having run.
+                await _wait_until(lambda: len(_live_ports(h)) == 3)
+                live = _live_ports(h)
+                claims = set(h.fake_k8s.claims)
+                assigned = dict(h.fake_k8s.assigned_ports)
+                opened = {port: list(r.opened) for port, r in h.runners.items()}
+                steers = {port: list(r.steers) for port, r in h.runners.items()}
+                shared_opened = list(h.runner.opened)
+            finally:
+                hold.set()
+                outcomes = await asyncio.gather(*tasks, return_exceptions=True)
+
+            assert [o for o in outcomes if isinstance(o, BaseException)] == [], (
+                "a partition was deferred or failed; fan-out did not happen"
+            )
+            assert len(claims) == 3, f"expected one sandbox per partition, got {claims}"
+            # THE load-bearing assertion. Three distinct ports is the only
+            # observable difference between real fan-out and the shared-runner
+            # trap described in the module docstring.
+            assert len(set(assigned.values())) == 3, (
+                f"partitions shared a runner port: {assigned}"
+            )
+            assert live == set(assigned.values()), (
+                f"live turns {live} did not match the assigned ports {assigned}"
+            )
+            assert sum(len(v) for v in opened.values()) == 3
+            assert all(len(v) == 1 for v in opened.values()), (
+                f"a runner served more than one partition: {opened}"
+            )
+            assert all(v == [] for v in steers.values()), (
+                f"a job steered a live session: {steers}"
+            )
+            # The fleet-wide runner is on a port no sandbox was given, and with
+            # per-sandbox runners the fallback port is closed: anything reaching
+            # it would mean the per-sandbox port was ignored.
+            assert shared_opened == []
+
+    asyncio.run(go())
+
+
+def test_two_deliveries_on_one_partition_serialize(make_harness) -> None:
+    """Sequential intra-partition serialization survives the fan-out change.
+
+    The second delivery names the SAME partition, so it is the same thread: it
+    must defer with ``ThreadBusyError``, never steer into the live turn and
+    never open a second one beside it.
+    """
+
+    async def go() -> None:
+        async with make_harness(per_sandbox_runners=3) as h:
+            hold = asyncio.Event()
+            _park_every_runner(h, hold)
+
+            first = asyncio.create_task(
+                h.kernel.process_event(_hook_event("pr 41 first", partition="41"))
+            )
+            try:
+                await _wait_until(lambda: len(_live_ports(h)) == 1)
+                with pytest.raises(ThreadBusyError):
+                    await h.kernel.process_event(
+                        _hook_event("pr 41 second", partition="41")
+                    )
+                claims = set(h.fake_k8s.claims)
+                opened = _opened_total(h)
+                steers = {port: list(r.steers) for port, r in h.runners.items()}
+            finally:
+                hold.set()
+                await asyncio.gather(first, return_exceptions=True)
+
+            assert len(claims) == 1, f"one partition claimed more than one sandbox: {claims}"
+            assert opened == 1, "the deferred delivery opened a turn beside the live one"
+            assert all(v == [] for v in steers.values()), (
+                f"a job steered a live session: {steers}"
+            )
+
+    asyncio.run(go())
+
+
+def test_concurrent_deliveries_on_one_partition_serialize(make_harness) -> None:
+    """The same rule with no pre-sequencing: exactly one of the two runs.
+
+    Both deliveries are dispatched as concurrent tasks, so which one opens the
+    turn is decided by the kernel's per-thread FIFO lock rather than by the
+    test. Whichever loses must defer, not steer, and not fork a second turn.
+    """
+
+    async def go() -> None:
+        async with make_harness(per_sandbox_runners=3) as h:
+            hold = asyncio.Event()
+            _park_every_runner(h, hold)
+
+            tasks = [
+                asyncio.create_task(
+                    h.kernel.process_event(_hook_event(text, partition="41"))
+                )
+                for text in ("pr 41 a", "pr 41 b")
+            ]
+            try:
+                await _wait_until(
+                    lambda: len(_live_ports(h)) == 1
+                    and sum(t.done() for t in tasks) == 1
+                )
+                claims = set(h.fake_k8s.claims)
+                opened = _opened_total(h)
+                steers = {port: list(r.steers) for port, r in h.runners.items()}
+            finally:
+                hold.set()
+                outcomes = await asyncio.gather(*tasks, return_exceptions=True)
+
+            busy = [o for o in outcomes if isinstance(o, ThreadBusyError)]
+            other = [
+                o
+                for o in outcomes
+                if isinstance(o, BaseException) and not isinstance(o, ThreadBusyError)
+            ]
+            assert other == [], f"unexpected failure on a serialized partition: {other}"
+            assert len(busy) == 1, f"expected exactly one deferral, got {outcomes}"
+            assert len(claims) == 1, f"one partition claimed more than one sandbox: {claims}"
+            assert opened == 1
+            assert all(v == [] for v in steers.values()), (
+                f"a job steered a live session: {steers}"
+            )
+
+    asyncio.run(go())
+
+
+def test_an_unpartitioned_hook_still_shares_one_thread(make_harness) -> None:
+    """The negative control: no partition segment means no fan-out.
+
+    Three deliveries on one three-segment id behave exactly as they do today --
+    one sandbox, one turn, two deferrals. This is the test that catches a change
+    which makes an UNPARTITIONED hook start fanning out, which would silently
+    multiply every existing agent's sandbox count.
+    """
+
+    async def go() -> None:
+        async with make_harness(per_sandbox_runners=3) as h:
+            hold = asyncio.Event()
+            _park_every_runner(h, hold)
+
+            unpartitioned = _conversation_id()
+            assert unpartitioned.count(":") == 2, "the control id gained a partition"
+
+            first = asyncio.create_task(h.kernel.process_event(_hook_event("sweep 1")))
+            try:
+                await _wait_until(lambda: len(_live_ports(h)) == 1)
+                deferrals = 0
+                for text in ("sweep 2", "sweep 3"):
+                    with pytest.raises(ThreadBusyError):
+                        await h.kernel.process_event(_hook_event(text))
+                    deferrals += 1
+                claims = set(h.fake_k8s.claims)
+                opened = _opened_total(h)
+                assigned = dict(h.fake_k8s.assigned_ports)
+                steers = {port: list(r.steers) for port, r in h.runners.items()}
+            finally:
+                hold.set()
+                await asyncio.gather(first, return_exceptions=True)
+
+            assert deferrals == 2
+            assert len(claims) == 1, f"an unpartitioned hook fanned out: {claims}"
+            assert len(assigned) == 1, f"an unpartitioned hook fanned out: {assigned}"
+            assert opened == 1
+            assert all(v == [] for v in steers.values()), (
+                f"a job steered a live session: {steers}"
+            )
+
+    asyncio.run(go())

--- a/cli/api-mirrors.json
+++ b/cli/api-mirrors.json
@@ -23,6 +23,10 @@
         {
           "field": "created_at",
           "why": "No CLI verb prints an agent's creation timestamp; the deploy summary and lifecycle verbs render id/name/channel only."
+        },
+        {
+          "field": "hook_partitions",
+          "why": "No CLI verb reads or prints an agent's hook partition map; it is configured through the API write surface and surfaced back on the hook receipt, which the CLI never calls."
         }
       ]
     },

--- a/docs/adr/0115-agents-call-each-other-with-no-third-party.md
+++ b/docs/adr/0115-agents-call-each-other-with-no-third-party.md
@@ -49,11 +49,19 @@ bearing where they sit:
   `author=f"hook:{hook}"`, and the code says why: an upstream-supplied identity
   there "would let a hook impersonate one to anything downstream that reads the
   field". The reply route comes wholly from the target's binding row, so the
-  answer goes to the target's channel and a caller never sees it. And
-  `_conversation_id` is per hook, so two calls would share one thread and the
-  second would defer behind the first. A caller, a private answer, and
-  concurrency are the three things a call needs, and this surface refuses all
-  three on purpose.
+  answer goes to the target's channel and a caller never sees it. And by
+  default `_conversation_id` is per hook, so two calls would share one thread
+  and the second would defer behind the first. That is the unpartitioned
+  default: an operator can instead enable per-value partitioning for a hook
+  ([ADR-0134](0134-a-hook-shares-one-thread-per-partition.md), Draft), picking
+  which signed-body field names the partition. The operator only chooses that
+  pointer; the *values* come from whoever can sign a delivery, so a configured
+  hook gives a sender-driven number of concurrent threads. That does not
+  change the conclusion here, because concurrency was never the missing piece
+  -- a caller and a private reply route are, and this surface still has
+  neither: the author stays pinned to the hook regardless of partition, and
+  the reply still goes wherever the target's binding row says, never back to
+  whoever signed the delivery.
 - **The channel ingress is for adapters, not agents.** A `chn` token is scoped
   to a binding row so an ingress adapter can enqueue for that binding. It says
   nothing about who asked, and the same reply-routing property applies: the

--- a/docs/adr/0134-a-hook-shares-one-thread-per-partition.md
+++ b/docs/adr/0134-a-hook-shares-one-thread-per-partition.md
@@ -1,0 +1,352 @@
+# 134. A hook shares one thread per partition
+
+Date: 2026-08-29
+
+Status: Draft
+
+**Amends [ADR-0079](0079-inbound-triggers-as-a-new-event-kind.md)** by narrowing
+the thread identity of the ingress its Decision 1 authorized: one thread per
+hook becomes one thread per *partition* of a hook, opt-in per hook and off by
+default. ADR-0079's own decisions stand unchanged — the API still accepts
+inbound triggers, a trigger is still a placeholder-less event kind whose output
+the kernel posts, and a job still waits for idle rather than steering a live
+interactive session. Only the granularity of "the thread" moves. The per-hook
+reasoning actually being narrowed was never written in 0079's text; when
+ADR-0079 was implemented it lived in the `_conversation_id` docstring of
+`apps/api/src/curie_api/routers/hooks.py`, and it now lives in
+`curie_api.hook_partition.conversation_id`, which this ADR restates and
+amends.
+
+## Context
+
+A hook fires once and finds N independent things: a sweep over open pull
+requests finds three PRs, a triage sweep finds five issues, a reconciler finds
+seven drifted resources. Each is separate work with its own history and its own
+conclusion, and nothing orders them against each other.
+
+Today all N collapse into one thread. The ingress mints
+`hook:<agent_id>:<hook>` once per hook, the worker keys a sandbox claim on it,
+and the second and third deliveries defer behind the first with
+`ThreadBusyError`. That was the right default and remains the right default: per
+*delivery* would claim a fresh sandbox for every event and let two firings of
+the same hook race with no ordering at all, which is exactly what ADR-0079's
+"jobs are outputs, not steering inputs" rules out. The defect is not that the
+hook shares a thread. The defect is that "the hook" is the only granularity
+available, so a hook whose deliveries genuinely are about different things has
+no way to say so.
+
+The maintainer settled the shape on 2026-08-27 as **partition now, delegation
+later**. A hook that finds N things could instead delegate N sub-turns to other
+agents; that is [ADR-0115](0115-agents-call-each-other-with-no-third-party.md)'s
+question, it is Draft, it needs a credential no sandbox holds, and it is
+explicitly **not** this decision.
+
+A 2026-08-28 mechanism spike against the real kernel, `SandboxSubstrate`,
+`RunnerClient` and a real Valkey observed three partitioned deliveries claiming
+three sandboxes and running three turns concurrently with intra-partition
+serialization intact, and an unpartitioned hook still serializing into one. The
+mechanism is not in question here; the granularity policy is.
+
+## Decision
+
+**A hook's conversation id gains an optional fourth segment.** The id becomes
+`hook:<agent_id>:<hook>:<partition>` for a hook that opts in, and stays
+`hook:<agent_id>:<hook>` for every hook that does not. An unpartitioned hook
+mints a byte-identical and SHA-256-identical string to the one it mints today,
+which is what keeps every artifact keyed on that id — Valkey key namespaces,
+claim names, transcripts, boot env — unchanged for every agent that does not
+configure this.
+
+**The partition source is an operator-owned column on the agent row**, an
+`agents.hook_partitions` JSONB map of hook name to
+`{"pointer": "<RFC 6901 pointer>"}`. The operator decides both *that* a hook
+fans out and *which* field of the delivery document identifies the thing each
+delivery is about. The upstream supplies the value, but only through a field the
+operator named.
+
+An `X-Curie-Partition` request header was rejected. It would sit outside the
+bytes the HMAC covers, so the value that decides sandbox cardinality would be
+unauthenticated even on a correctly signed delivery; and it would hand any
+holder of the derived hook secret direct control of this agent's concurrent
+sandbox count, which is a resource-amplification surface the operator never
+opted into.
+
+Be precise about what the column does and does not buy. It does **not** stop a
+holder of the derived hook secret from choosing the partition values: whoever
+can sign a delivery still picks what goes in the field the pointer names, and
+therefore still drives the resulting cardinality. What the column changes is who
+enables that at all. The operator selects an authenticated field — one inside
+the bytes the HMAC covers — and by configuring it makes a deliberate, per-hook
+decision to let the sender drive cardinality for that hook. The header
+alternative gave the sender that power *without* the operator enabling anything,
+on every hook, by default. That is the distinction the column exists for.
+
+Draft [ADR-0099](0099-hooks-are-bundle-declared-turns-the-system-starts.md)'s
+bundle-declared triggers are the long-term home for this declaration. That is
+unbuilt. The agent row is the smallest thing that works under the write surface
+that exists, and moving the declaration into the bundle manifest later is a
+follow-up (FU-2), not a different decision.
+
+**A misconfigured partitioned delivery refuses with 422 and never falls back.**
+If the body is not JSON, the pointer does not resolve, or the resolved value is
+not a bounded scalar, the delivery is refused naming both the hook and the
+pointer. Falling back to the unpartitioned id would collapse N intended threads
+into one *silently*: the operator would see a hook returning 2xx, producing
+turns, and quietly no longer fanning out. A configuration error must not resolve
+into a plausible-looking degraded state, so this one resolves into a loud one.
+The derivation runs after signature verification and after the delivery-id
+check, so an unsigned caller learns nothing about a hook's configuration, and
+before the delivery claim, so a refused delivery holds no claim and a corrected
+retry is not deduplicated away.
+
+**422 is terminal for an unchanged delivery.** A retry is meaningful only after
+the payload or the operator's pointer has been corrected; resending identical
+bytes against unchanged configuration will refuse identically, forever. An
+upstream that retries every non-2xx unchanged therefore pays, per attempt, one
+signature verification, one lookup of the agent and its channel bindings, and
+one bounded parse of the body — the same exposure any authenticated 4xx already
+carries on this route — and touches no delivery claim, so it neither consumes
+the backlog window nor blocks a corrected delivery behind it. The cost of that loop is that
+it produces no run record at all: a hook stuck in it is visible only in the
+ingress log, not in anything an operator lists as a failed turn.
+
+**A partition value matches `^[A-Za-z0-9][A-Za-z0-9._-]{0,62}$`** — one to 63
+characters. Uppercase is permitted because the identifiers this exists to carry
+are mixed case (Slack ids, ticket keys, branch names). `:` is forbidden so a
+four-segment id can never be read as three. `/` is forbidden as a
+canonical-identity policy and as defense in depth, **not** because an encoding
+is missing: the worker percent-encodes the whole thread key before it becomes a
+`CURIE_HISTORY_REF` path segment, so a slash would already be safe on the wire.
+It is excluded so that the id an operator reads in a receipt, a log line, or a
+dashboard is the same string everywhere and never has a second readable form. A
+leading `.`, `-` or `_` is excluded, which
+also makes a bare `..` unrepresentable. Unicode is excluded entirely: a
+partition derived from a non-ASCII identifier refuses rather than being
+transliterated into something that no longer names the thing.
+
+The bound is defense in depth, not the only control. The worker already
+percent-encodes each component of its thread key, so a longer or stranger
+conversation id becomes one encoded segment and cannot forge another thread's
+key. On length, the partition adds at most 64 characters (the value plus its
+separator) to the conversation id and therefore to `CURIE_SESSION_ID`, which
+stays in the low hundreds of characters; the Kubernetes claim name is
+`curie-thread-<sha256(thread_key)[:10]>-<nonce>`, a fixed length whatever the id
+does, and so cannot overflow. A pure-function test pins the arithmetic so the
+bound cannot drift without someone re-checking it.
+
+**No wire change and no worker production change are needed, and that is
+structural rather than lucky.** `QueuedTurn.conversation_id` is a plain `str`,
+so a four-segment id round-trips the queued-event contract untouched; and the
+kernel's `_thread_key_for` builds its key as
+`quote(kind):quote(address):quote(conversation_id)`, comparing the result and
+never parsing it. The conversation id is one opaque encoded segment to every
+consumer downstream of the ingress.
+
+**The caller learns the id it landed on.** The hook receipt carries
+`conversation_id` on every path — the enqueue, both duplicate paths, and the
+202 no-claim path — and the ingress info log names it server-side. Without that,
+a partitioned hook's operator would have no way to name the thread for the
+`GET /approvals?conversation_id=` filter or to compose the key the reset verb
+wants, because the id now depends on payload content the operator never sees.
+
+**The receipt's id is an input to the reset verb, not its argument.** The reset
+surface is `POST /agents/{agent_id}/threads/{thread_key}/reset`, driven by
+`curie … reset-thread <agent> --thread-key <key>`, which passes `--thread-key`
+through verbatim. What it consumes is the *worker's* composed thread key, not a
+conversation id: `_thread_key_for` joins `quote(kind)`, `quote(address)` and
+`quote(conversation_id)` with `:`, percent-encoding each segment with no safe
+characters. So the `:` separators inside a hook conversation id are themselves
+encoded. A hook delivery replying on Slack channel `C0EXAMPLE1` whose receipt
+reads `hook:0f2b7c1e-4a9d-4f2c-9d31-5b6e8a7c0d12:pr-sweep:1481` resets under the
+thread key
+`slack:C0EXAMPLE1:hook%3A0f2b7c1e-4a9d-4f2c-9d31-5b6e8a7c0d12%3Apr-sweep%3A1481`.
+None of this is new to partitioning: it is equally true of an unpartitioned
+hook's three-segment id today. What partitioning changes is how often an
+operator needs to do it, since a value they never chose now decides which
+thread they are naming.
+
+## What the conversation id keys
+
+Fifteen artifacts derive from the conversation id and therefore change shape for
+a partitioned hook. Each row records the decision, not just the effect.
+
+| # | Artifact | Call site | What changes | Decision |
+|---|---|---|---|---|
+| 1 | Sandbox affinity route | `sandbox/affinity.py`, `<prefix>:route:<thread_key>` | one route per partition | **Intended.** This is the partition key itself; everything else follows from it |
+| 2 | Claim name + `curietech.ai/thread-hash` label | `sandbox/types.py`, `curie-thread-<sha256[:10]>-<nonce>` | one hook now emits N thread hashes | **Accepted.** Fixed-length SHA, length-safe at any partition; dashboards filtered on a single hash under-report (FU-3) |
+| 3 | Valkey thread lock | `worker/config.py`, `curie:worker:lock:<thread_key>` | one lock per partition | **Intended.** This is what makes fan-out work *and* what keeps two deliveries on one partition serialized |
+| 4 | In-process order lock | `kernel.py` `_order_locks` | one lock per partition | **Intended.** Already keyed per thread key; two partitions were never serialized against each other |
+| 5 | Kill-switch fan-out set | `kernel.py` `interrupt_agent` / `_active_by_agent` | one hook contributes N thread keys | **Accepted.** Kill cost is proportional to fan-out; each interrupt is individually bounded, so correctness is unchanged and only latency scales |
+| 6 | `CURIE_HISTORY_REF` | `binding.py`, `.../state/transcript/<encoded thread_key>` | the transcript **splits** per partition | **Intended**, and the reason for the stability requirement below: each partition owns a transcript |
+| 7 | `CURIE_SESSION_ID` | `binding.py`, `agent-<id>-thread-<thread_key>` | longer value only | **Accepted**, bounded by the charset cap |
+| 8 | `SandboxHandle.session_id` fallback | `sandbox/substrate.py`, `session_id or thread-<hash>` | follows the claim hash | **Accepted**, fixed length by construction |
+| 9 | Thread-reset chain | `apps/api` `threadreset.py` + `POST /agents/{agent_id}/threads/{thread_key}/reset`, worker consumer, `Kernel.release_thread` / `interrupt_thread`, CLI `reset-thread --thread-key` | takes the **composed thread key** verbatim and never parses it | **Accepted.** The verb's argument is `<kind>:<address>:<url-encoded conversation id>`, not the receipt's id, so an operator resets one partition by composing that key themselves — true of an unpartitioned hook today, and now needed per partition. No verb resets every partition of a hook (FU-1) |
+| 10 | `Approval.conversation_id`, the approvals filter, resume | `apps/api` approvals router | approvals bind to the partition, not the hook | **Correct by construction** for resume; the filter needs the full id, which the receipt now supplies |
+| 11 | Behavior-pack shimmer seed | worker behavior pack | a different seed per partition | **Accepted**, cosmetic |
+| 12 | `ReplyTarget.conversation_id` on emitted replies | worker reply events | carries the four-segment id | **Harmless today** (the Slack sink ignores it, see below); a future adapter that threads replies on it would fan replies per partition |
+| 13 | `ThreadWorkspace` repository selection | `models.py` `ThreadWorkspace`, unique on `(agent_id, conversation_id)`; `crud.get_thread_workspace` / `select_thread_workspace` | one immutable repository selection per partition instead of per hook | **Intended.** A partition *is* a thread, and "one immutable, independent repository selection per conversation" applies to it exactly as to any other thread. The selection is normally made from an opening thread message, and a hook partition has no human to make it, but the kernel's `_route_and_start` extracts a single repository URL from the hook-rendered event text and submits it for selection, so a payload naming one repository can establish a partition's selection on its own. A workspace-enabled partition with neither an existing selection nor a URL in the event text is refused with `workspace.repository_required` (`POST /workspaces/{deployment_id}/selection`) until one is made -- there is no deployment-default fallback |
+| 14 | Worker workspace ownership ledger and retained base objects | `workspace.py`, `_WorkspaceOwnership` keyed by `thread_key`, plus the sanitized `PreparedWorkspace` base object it names | durable per-partition retained state, so retained bytes scale with partition count rather than with hook count | **Accepted, but on a shorter lease than the transcript it sits beside.** `_WorkspaceOwnership` rows carry `expires_at_epoch` and are reaped by the existing TTL reaper (`enumerate_expired` → `begin_expired_reap` → `finish_expired_reap`) with no new mechanism, so a partition's workspace base is bounded and eventually released. The transcript is not: it lives in `workflow_state_entries` (`apps/api/src/curie_api/models.py`), which has no expiry column and no reaper, so it persists indefinitely. Both still depend on the partition value being a stable identity, since a per-delivery value retains a fresh workspace base for every delivery until its lease expires, and grows the transcript store without bound in the meantime |
+| 15 | `agent_actions.conversation_id` audit/undo records | `models.py` `AgentAction` (indexed `conversation_id`), `crud.list_actions` | actions record the partition, not the hook | **Correct by construction.** The action belongs to the thread that took it, and an undo must not reach across partitions. The consequence is on the query side: an operator listing a hook's actions by conversation needs the full four-segment id, exactly as the approvals filter does |
+
+Eight artifacts are load-bearing and deliberately **unchanged**, several of them
+in ways that will look like oversights to a later reader.
+
+| Artifact | Why it does not take the partition |
+|---|---|
+| Completion outbox and pending set | Keyed per **event id**, and the event id is unchanged |
+| Done and side-effect markers | Same: per event id, so a partitioned delivery is still applied at most once |
+| Delivery claim key `curie:hook:delivery:<agent>:<hook>:<sha16>` | **Must not** gain the partition. One upstream delivery id must run at most once whatever partition it names; folding the partition in would let a redelivery run a second time under a different partition |
+| Backlog key `curie:hook:backlog:<agent>` | Metered per agent, by construction (see the quota below) |
+| `CURIE_MEMORY_REF` | Agent-scoped, not thread-scoped. Memory does **not** fragment when threads do — that is the point of the split between the two |
+| The reply handle in `_mint_turn` | Built wholly from the channel binding row; where a reply goes has nothing to do with which partition produced it |
+| The turn author, `hook:<hook>` | The author is the hook. A partition is a thread, not an identity |
+| Slack sink `_thread_ts` | Matches a Slack timestamp against the whole id; a `hook:`-prefixed id has never matched and a four-segment one still does not, so hook replies stay channel-level posts |
+
+## The quota, as a fact and not a gate
+
+The agent backlog quota admits `hook_backlog_limit` (64) deliveries per agent
+per `hook_backlog_window_s` (60) seconds, configured in
+`apps/api/src/curie_api/config.py` and enforced on the ingress claim. It is
+counted per agent and **never reads the conversation id**, so admission is
+exactly what it was before this ADR.
+
+What changes is what that same number now bounds. Before, 64 admitted
+deliveries produced at most one concurrent sandbox for a hook; now they can
+produce up to 64. The window is an admission counter, not a concurrency
+semaphore, so sustained fan-out is not bounded by any fixed ceiling at all — it
+is bounded by admission rate multiplied by turn duration. The real backstop is
+the substrate `ResourceQuota`, whose rejection is terminal without retry, which
+means an over-fanned sweep fails loudly and terminally rather than queueing up
+behind itself.
+
+**No platform-side fan-out cap is added, and neither setting changes.** The
+maintainer rejected both on 2026-08-27: a platform cap would refuse work for a
+reason the sweep author cannot see or reason about, and lowering the admission
+limit would penalise every unpartitioned hook for a capability it never used.
+The sweep owns its own bound.
+
+## A partition value must be a stable identity
+
+A partition **is** a thread. It owns a transcript, an affinity route, a lock,
+and a claim, with exactly the lifetime and retention a Slack thread ts has
+today. So the value a pointer resolves to must be a stable identity of the thing
+the delivery is about — a pull request number, a ticket key, a Slack thread ts —
+and never a run id, a delivery id, or a timestamp. A value that changes per
+delivery makes every transcript single-use and grows the state store without
+bound while delivering none of the continuity the split is for.
+
+This is a documentation and review control, not a runtime one. The bound cannot
+tell `1481` from `1756425600`, and a heuristic that tried would refuse
+legitimate numeric identifiers. It is stated in the column's own comment, in the
+config schema, and here.
+
+No new retention story is invented for partitions, and none is needed: none
+exists for Slack threads either, and a partition is the same kind of object.
+
+## Consequences
+
+An agent-wide kill now signals N runners for a hook that used to have one.
+Correctness is unchanged — the fan-out kill already iterated a set of thread
+keys — but the cost is proportional to the fan-out. A saved dashboard filtered
+on a single `curietech.ai/thread-hash` under-reports for the same reason: one
+hook now emits a hash per partition (FU-3).
+
+There is no fan-out reset verb, and the single-partition path is not as direct
+as a receipt makes it look. The receipt and the ingress log name the minted
+conversation id, but the reset verb takes the worker's composed thread key, so
+an operator resetting one partition must build
+`<kind>:<address>:<url-encoded conversation id>` themselves. FU-1 is therefore
+not merely "a verb that resets every partition": it is a reset surface that
+accepts a hook's conversation id — or a hook name, fanning out over every live
+partition of it — and composes the thread key on the operator's behalf.
+
+Nothing in the platform bounds or displays how many partitions a hook has
+created. That is an **accepted risk**, not an oversight: the maintainer declined
+a platform-side cap on 2026-08-27 for the reasons recorded under the quota
+above, and no gate is added here. The gap that remains is observability rather
+than control — an operator cannot currently answer "how many live partitions
+does this hook have," which is the number they would need to notice a pointer
+aimed at a delivery id before the retained per-partition state grows. An
+operator-observable count of live partitions per hook is **FU-5**.
+
+The transcript splits per partition, which is the intended benefit and the
+reason for the stability requirement above.
+
+A future channel adapter that threads its replies on
+`ReplyTarget.conversation_id` would fan replies per partition. Slack does not,
+so nothing is broken today, but that adapter's author needs to decide it rather
+than discover it.
+
+A delivery retried after the operator edits `hook_partitions` derives a
+different partition than the original request did. That does not matter to
+enqueue: the owner-checked enqueue script turns a pending lease into a
+permanent stream-id receipt and permits exactly one `XADD` per delivery id, so
+one delivery id enqueues at most once, on whichever partition the winning
+request derived — a late former owner either re-claims before any successor or
+observes the successor and does not `XADD`. A retry carrying a different
+partition value, or arriving after the operator changed the pointer, is a
+duplicate that mints nothing. Because the receipt cannot be re-derived from the
+retry's own body, `HookAccepted.conversation_id` on a duplicate is read back
+from the queued turn instead, and is null whenever the landing thread is not
+knowable from that request — a pending twin still mid-flight, a stream an
+operator has trimmed, or the 202 case.
+
+A partition derived from a non-ASCII identifier refuses rather than being
+transliterated, and the 422 names the pointer so the operator can see why.
+
+Configuring a pointer enables sender-driven partition cardinality for that hook.
+A holder of the derived hook secret chooses the values, and therefore how many
+partitions exist; what the operator holds is the decision to enable that at all,
+on this hook, through a field the HMAC covers. The header alternative would have
+given the sender the same power without the operator enabling anything.
+
+Follow-ups: **FU-1** a reset surface that takes a hook's conversation id (or
+fans out over a hook's partitions) and composes the thread key itself; **FU-2**
+moving the declaration into a bundle manifest under ADR-0099; **FU-3**
+dashboards keyed on `curietech.ai/thread-hash`; **FU-4**
+`docs/interfaces/triggers/INTERFACE.md` still states the per-agent webhook
+ingress runtime is not built, which has been false since the ingress landed;
+**FU-5** an operator-observable count of live partitions per hook.
+
+## Alternatives considered
+
+**An `X-Curie-Partition` request header.** Rejected by the maintainer on
+2026-08-27. It sits outside the HMAC's covered bytes and hands the upstream this
+agent's sandbox cardinality directly, turning an authenticated sender into an
+unauthenticated capacity dial.
+
+**A bundle trigger declaration under Draft ADR-0099.** Rejected for now on
+2026-08-27 as the right long-term home for the wrong moment: 0099 is Draft and
+its runtime is unbuilt, so building the declaration there first would block a
+working slice on an unstarted decision. Recorded as FU-2.
+
+**A platform-side fan-out cap.** Rejected by the maintainer on 2026-08-27. A
+ceiling the sweep author cannot see would refuse work for an invisible reason,
+and the substrate `ResourceQuota` already provides a terminal backstop.
+
+**Silent fallback to the unpartitioned id on a misconfigured pointer.** Rejected
+in design. It would collapse N threads into one while returning 2xx, which is
+the ambiguous-signal failure the loud refusal exists to prevent.
+
+## Realizing code path
+
+`apps/api/src/curie_api/hook_partition.py` derives the partition and mints the
+id, migration `apps/api/alembic/versions/0036_agents_hook_partitions.py` adds
+the operator-owned column (revision `0036` skips `0035`, already claimed by
+another in-flight migration on this release train), and
+`apps/worker/tests/kernel/test_hook_partition.py` is the durable regression
+guard for fan-out and intra-partition serialization.
+
+`0036` currently revises `0034` because `0035` is claimed by that in-flight
+migration, so whichever of the two merges **second** must re-parent its own
+migration onto the other's head before merging. A merged migration's
+`down_revision` is never rewritten afterwards: a database already stamped at
+`0036` would not retroactively run a `0035` inserted beneath it, and the static
+one-head check cannot see that hole.
+
+This ADR is **Draft** and authorizes nothing by itself. Under
+[ADR-0085](0085-acceptance-not-implementation-authorizes-an-adr.md) as amended
+by [ADR-0102](0102-accepted-alongside-implementation-with-explicit-approval.md),
+acceptance is a maintainer act: either this ADR is published Accepted, or the
+coordinated exception is recorded with explicit maintainer approval naming the
+realizing code path above.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -163,4 +163,5 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0131 | [A delivery has one deadline and one renewable fenced owner](0131-a-delivery-has-one-deadline-and-one-renewable-fenced-owner.md) | Accepted |
 | 0132 | [Gate evals on the worst cohort and require cross-family verifiers](0132-worst-cohort-eval-gates-and-cross-family-verifiers.md) | Draft |
 | 0133 | [The control agent renders screens; a human presses the buttons](0133-the-control-agent-renders-screens-a-human-presses.md) | Draft |
+| 0134 | [A hook shares one thread per partition](0134-a-hook-shares-one-thread-per-partition.md) | Draft |
 <!-- END GENERATED: adr-index -->

--- a/docs/interfaces/relational-db/INTERFACE.md
+++ b/docs/interfaces/relational-db/INTERFACE.md
@@ -66,16 +66,19 @@ is a judgement call, not something derivable from the tree.
    column is a native Postgres `Enum(Environment, name="environment", schema=SCHEMA)`
    (`apps/api/src/curie_api/models.py::Deployment`), which materializes as a `CREATE TYPE` in the `curie` schema.
 3. **`JSONB` column type** — `apps/api/src/curie_api/models.py::JSONB` is imported from
-   `sqlalchemy.dialects.postgresql` on the same line as `UUID` and used on **thirteen** columns:
+   `sqlalchemy.dialects.postgresql` on the same line as `UUID` and used on **fourteen** columns:
    `behavior_packs`, `approval_required_tools`, `approval_routes`, `secrets`,
-   `changed_paths`, `evidence`, `arguments`, `result`, `prior_state`, `target`,
-   `post_state`, and `value`. The last one is
+   `hook_partitions`, `changed_paths`, `evidence`, `arguments`, `result`, `prior_state`,
+   `target`, `post_state`, and `value`. The last one is
    `apps/api/src/curie_api/models.py::WorkflowStateEntry.value`; `evidence` is used
-   by both approval and action audit rows. Two of them are
+   by both approval and action audit rows. Three of them are
    load-bearing rather than incidental: the workflow-state store exists precisely because
-   Postgres JSONB meant no new datastore was needed (see that class's docstring), and the
+   Postgres JSONB meant no new datastore was needed (see that class's docstring), the
    action ledger's `prior_state` holds a snapshot whose shape belongs to whatever resource
-   a connector wrote to, which no column type can know in advance (ADR-0117).
+   a connector wrote to, which no column type can know in advance (ADR-0117), and
+   `hook_partitions` holds per-hook delivery partitioning — hook name to the JSON Pointer
+   into a delivery body naming the thing each delivery is about; NULL means one thread
+   per hook (ADR-0134, Draft).
 4. **Raw dialect-specific SQL outside the ORM** — `DISTINCT ON`, which is Postgres-only,
    is written by hand in `apps/api/src/curie_api/commitpoller.py::_DEPLOYED_SQL` (executed
    through `text(...)` in `apps/api/src/curie_api/commitpoller.py::CommitPoller.poll_once`)


### PR DESCRIPTION
Optional per-delivery partition on the hook conversation id, opt-in per hook. A hook with no `hook_partitions` entry mints the byte- and SHA-256-identical `hook:<agent>:<hook>` id it mints today; a configured hook mints `hook:<agent>:<hook>:<partition>`, so a sweep that finds three things gets three conversations and therefore three sandboxes, while two firings on one partition still serialize (one turn, zero steers, `ThreadBusyError` on the second).

Settled 2026-08-27: partition now, ADR-0115 delegation later. Draft [ADR-0134](docs/adr/0134-a-hook-shares-one-thread-per-partition.md) amends ADR-0079 and records the narrowing, the fifteen conversation-keyed artifacts and their dispositions, the eight that must not change, and the backlog quota as a fact rather than a gate.

## What changed

- `agents.hook_partitions` (JSONB, migration `0036`): hook name -> `{"pointer": "<RFC 6901 JSON Pointer>"}` into the delivery body. NULL / `{}` is the unpartitioned posture. Exposed on `POST`/`PATCH`/`GET /agents`.
- `curie_api.hook_partition`: the hook-name shape (moved, unchanged), the partition bound `^[A-Za-z0-9][A-Za-z0-9._-]{0,62}` applied with `fullmatch`, an RFC 6901 resolver (`~0`/`~1` only), `derive_partition`, and the single `conversation_id` mint.
- `POST /hooks/{agent}/{hook}`: derivation runs after signature verification and the delivery-id check, before the claim and the reply-surface selection. A partitioned delivery that cannot name its partition (non-JSON, deep nesting, unresolvable pointer, non-scalar or out-of-bound value) is refused with 422 naming hook and pointer, enqueues nothing and holds no claim; it never falls back to the shared thread.
- `HookAccepted.conversation_id` (`string | null`) names the thread the delivery landed on; on a duplicate it is read back from the queued turn, never re-derived from the retry body; null when not knowable (pending twin, trimmed stream, the 202 path). The ingress info log carries it too.
- Unchanged by design: the delivery claim key and event id (one upstream delivery id runs at most once, whatever partition it names), the per-agent backlog quota, `CURIE_MEMORY_REF`, the reply handle, `author=hook:<hook>`, Slack thread derivation. No wire change; `packages/aci-protocol` and `packages/plugin-format` untouched. No `apps/worker/src` change.
- Worker test harness: `FakeK8s` can hand each sandbox its own fake runner port (`per_sandbox_runners`), because the shared single-port fake makes every partition look busy and a fan-out test on it passes for the wrong reason. `test_hook_partition.py` proves 3 partitions -> 3 claims on 3 distinct ports with 3 concurrent turns, intra-partition serialization sequential and concurrent, and the unpartitioned control.
- `cli/api-mirrors.json` records the `hook_partitions` omission for the CLI `Agent` mirror; `openapi.json` regenerated; `docs/interfaces/relational-db/INTERFACE.md` names the new JSONB column; ADR-0115 qualifies per-hook serialization as the unpartitioned default.

## Facts recorded, not gates

`hook_backlog_limit` (64) per `hook_backlog_window_s` (60 s) per agent is unchanged and never reads the conversation id, so admission is unchanged; after this change the same number bounds concurrent sandboxes per agent rather than queued deliveries. The window is an admission counter, not a concurrency semaphore, so sustained fan-out is bounded by admission rate × turn duration, and the real backstop is the substrate ResourceQuota, whose rejection is terminal without retry. No platform-side fan-out cap is added (declined by the maintainer on 2026-08-27; the sweep owns its own bound).

## Before merge (maintainer)

- **ADR-0134 is `Status: Draft`.** Under `docs/adr/AGENTS.md` a Draft does not authorize implementation. Merging this needs either acceptance of ADR-0134 or the ADR-0102 coordinated exception recorded with explicit approval; the realizing code path is `apps/api/src/curie_api/hook_partition.py`, migration `0036`, and `apps/worker/tests/kernel/test_hook_partition.py`.
- **Migration ordering with #1935.** That PR carries `0035_control_proposals.py` on this train; this branch takes `0036` (parent `0034`) so the two never share a revision id. Whichever merges second must re-parent its migration onto the other's head before merging; a merged migration's `down_revision` is never rewritten afterwards.

## Follow-ups (named in ADR-0134)

- FU-1: a reset verb that accepts a hook's conversation id (or fans out over a hook's partitions) and composes the worker thread key itself. Today reset takes `<kind>:<address>:<url-encoded conversation_id>`.
- FU-2: move the declaration into the bundle trigger (Draft ADR-0099).
- FU-3: dashboards filtered on one `curietech.ai/thread-hash` now under-report a partitioned hook.
- FU-4: `docs/interfaces/triggers/INTERFACE.md` predates the generic hook ingress (pre-existing drift, left alone here).
- FU-5: an operator-observable count of live partitions per hook.

## Done-check

- [x] Failing tests committed before implementation — contract commit landed first (API tests failed with `ModuleNotFoundError: curie_api.hook_partition`; worker proof passed immediately because it needs no production change).
- [x] All production edits by delegated executors; the driver's only direct edits were the consolidation pass.
- [x] Broadened return type: `HookAccepted.conversation_id` became `str | None`; no CLI mirror or other caller consumes it (verified `cli/src`, `apps/ui`).
- [x] Code review: `agent-router adversarial-review` exit 1 (grok reviewer infrastructure failure, not a skip); fallback Codex `exec --sandbox read-only` reviews ran for Code, Scope, Security, an architecture review of the ADR, and a re-review of the fix delta. Eight code-review findings: seven fixed, one declined (pre-existing triggers-catalog drift, FU-4).
- [x] Scope review: no passengers; two findings fixed.
- [x] Security review: duplicate-receipt defect fixed (receipt read back from the queued turn); invalid RFC 6901 escapes and `RecursionError` fixed.
- [x] Sibling-path parity: create vs PATCH vs GET, ingress enqueue/duplicate/202 paths, CLI mirror, OpenAPI — all covered; migration id collision with #1935 handled by taking `0036`.
- [x] Guard demonstration: the 20-case refusal matrix, the trailing-newline hook name, deep-nesting JSON and the invalid-escape config all executed as 422/400; the regression tests were run without the fixes and 10 of 11 failed.
- [x] Consolidation: `/simplify` applied three cleanups; full `apps/api` suite re-run green afterwards; Codex re-review of the delta found only doc corrections, applied.
- [x] Observable verification / E2E: N/A (no user-facing surface, no deployed-surface flag; the worker proof runs against the real kernel, substrate, runner client and a real Valkey).
- [x] Full affected suites: `apps/api` 1379 passed / 10 skipped / 1 failed (`test_control_integration.py::test_cost_composes_metrics_for_the_agent`, needs Langfuse, absent from the disposable stack); `apps/worker/tests/kernel` 291 passed / 2 skipped; `cargo test --test api_field_parity` 18 passed; alembic revision gate head `0036`; migration up/down/up on a throwaway database; ruff + mypy clean; `scripts/check-docs.sh` clean.
