### PR TITLE
Slack adapter: derive text from Block Kit, and name every drop it makes

### DIFF
--- a/apps/dispatcher/README.md
+++ b/apps/dispatcher/README.md
@@ -14,7 +14,14 @@ run orchestration are the worker's job, not the dispatcher's.
 Ingest admits more than it used to (#2006). A message whose body lives in Block Kit
 `blocks` or legacy `attachments` — an alert app's post, typically — is normalized by
 `inbound_text.derive_text` instead of being read off an empty top-level `text`, so it
-reaches the model with its content instead of minting an empty turn. Message subtypes are
+reaches the model with its content instead of minting an empty turn. What that walker
+leaves out is a closed denylist of keys, not a judgement about which strings are prose: it
+refuses to descend into an `accessory`, `confirm`, `options`, `option_groups`, `placeholder`
+or `hint` subtree, and into an `actions` block's `elements`, so button labels,
+confirmation-dialog copy, select placeholders and option lists stay out of the turn. It is
+not a complete exclusion of interface chrome, and should not be read as one — an input
+block's `label` is not on that denylist, so its text does reach the derived turn. Message
+subtypes are
 now an open world: only the closed `relevance.NON_CONTENT_SUBTYPES` denylist (edits,
 deletes, tombstones, EKM-redacted bodies, assistant thread-start markers) is refused, so
 `file_share`, `thread_broadcast` and any subtype Slack ships in future are ingested. And a
@@ -26,14 +33,19 @@ Still refused: a bot-authored `app_mention` that carries a `thread_ts`, as a loo
 between two Curie installations in one workspace — the cost is that an alert bot replying
 *inside* a thread is not ingested; a `message` event outside the DM lane, which the app
 never subscribed to; a redelivery whose dedupe key is already claimed; and a button click
-that names no command or has nowhere to reply.
+with nowhere to reply — an App Home or modal click, which carries no channel and no
+message.
 
-Every one of those is logged at INFO with its enumerated reason and rationale (the full
-list is `relevance.DROP_RATIONALES`), so an operator chasing a message that produced no
-turn can grep the dispatcher log for `dropped inbound slack delivery` and read why. If the
-grep finds nothing, the refusal was Bolt's, above these handlers — see
-`docs/interfaces/channel-ingress/INTERFACE.md`, which is the system of record for this
-contract.
+Every refusal these handlers make on the message lanes is logged at INFO with its
+enumerated reason and rationale (the full list is `relevance.DROP_RATIONALES`), so an
+operator chasing a message that produced no turn can grep the dispatcher log for
+`dropped inbound slack delivery` and read why. The click lane logs the same way for the
+refusal it can make; two further reasons in that list, `no_action_in_payload` and
+`empty_action_command`, are defensive guards Bolt's catch-all action matcher does not
+currently deliver, so they are not dispositions to expect in production logs — they are
+kept on purpose, and `docs/interfaces/channel-ingress/INTERFACE.md` says why. If the grep
+finds nothing, the refusal was Bolt's, above these handlers — that same document is the
+system of record for this contract.
 
 ## The queue seam (what the worker consumes)
 

--- a/apps/dispatcher/README.md
+++ b/apps/dispatcher/README.md
@@ -9,6 +9,32 @@ All of this runs under reconnect supervision with graceful shutdown.
 It does exactly that and no more: routing, the finish-race, steer/interrupt, and
 run orchestration are the worker's job, not the dispatcher's.
 
+## What is ingested, and what is refused
+
+Ingest admits more than it used to (#2006). A message whose body lives in Block Kit
+`blocks` or legacy `attachments` — an alert app's post, typically — is normalized by
+`inbound_text.derive_text` instead of being read off an empty top-level `text`, so it
+reaches the model with its content instead of minting an empty turn. Message subtypes are
+now an open world: only the closed `relevance.NON_CONTENT_SUBTYPES` denylist (edits,
+deletes, tombstones, EKM-redacted bodies, assistant thread-start markers) is refused, so
+`file_share`, `thread_broadcast` and any subtype Slack ships in future are ingested. And a
+bot-authored `app_mention` posted at the root of a channel is ingested, so an alert bot can
+@-mention the agent; the DM lane does not inspect bot authorship at all (Bolt's own
+`IgnoringSelfEvents` middleware drops the bot's own posts before any listener runs).
+
+Still refused: a bot-authored `app_mention` that carries a `thread_ts`, as a loop guard
+between two Curie installations in one workspace — the cost is that an alert bot replying
+*inside* a thread is not ingested; a `message` event outside the DM lane, which the app
+never subscribed to; a redelivery whose dedupe key is already claimed; and a button click
+that names no command or has nowhere to reply.
+
+Every one of those is logged at INFO with its enumerated reason and rationale (the full
+list is `relevance.DROP_RATIONALES`), so an operator chasing a message that produced no
+turn can grep the dispatcher log for `dropped inbound slack delivery` and read why. If the
+grep finds nothing, the refusal was Bolt's, above these handlers — see
+`docs/interfaces/channel-ingress/INTERFACE.md`, which is the system of record for this
+contract.
+
 ## The queue seam (what the worker consumes)
 
 The dispatcher `XADD`s onto a Valkey Stream (`CURIE_STREAM`, default

--- a/apps/dispatcher/src/curie_dispatcher/__init__.py
+++ b/apps/dispatcher/src/curie_dispatcher/__init__.py
@@ -4,9 +4,7 @@ Acks Slack events fast, posts an in-thread placeholder, and enqueues a normalize
 job onto a Valkey Stream keyed by the delivery's event id (idempotent), under
 reconnect supervision. The queue payload is ``aci_protocol.QueuedTurn`` (issue
 #7); this package owns its Valkey Stream transport (the ``payload`` encoding and
-dedupe) plus the Slack ingress. Refusals on the ingest path are enumerated by
-``relevance.DropReason`` and logged, so no inbound message is dropped in silence
-(#2006).
+dedupe) plus the Slack ingress.
 """
 
 from aci_protocol import STREAM_PAYLOAD_FIELD as STREAM_PAYLOAD_FIELD
@@ -25,7 +23,6 @@ from .queue import (
     from_stream_fields,
     to_stream_fields,
 )
-from .relevance import DropReason, classify
 from .supervisor import BackoffPolicy, Connection, Supervisor
 
 __version__ = "0.0.0"
@@ -35,7 +32,6 @@ __all__ = [
     "BackoffPolicy",
     "Connection",
     "DispatcherConfig",
-    "DropReason",
     "SocketModeConnection",
     "Supervisor",
     "__version__",
@@ -43,7 +39,6 @@ __all__ = [
     "build_redis",
     "build_web_client",
     "claim_event",
-    "classify",
     "enqueue",
     "from_stream_fields",
     "process_event",

--- a/apps/dispatcher/src/curie_dispatcher/__init__.py
+++ b/apps/dispatcher/src/curie_dispatcher/__init__.py
@@ -4,7 +4,9 @@ Acks Slack events fast, posts an in-thread placeholder, and enqueues a normalize
 job onto a Valkey Stream keyed by the delivery's event id (idempotent), under
 reconnect supervision. The queue payload is ``aci_protocol.QueuedTurn`` (issue
 #7); this package owns its Valkey Stream transport (the ``payload`` encoding and
-dedupe) plus the Slack ingress.
+dedupe) plus the Slack ingress. Refusals on the ingest path are enumerated by
+``relevance.DropReason`` and logged, so no inbound message is dropped in silence
+(#2006).
 """
 
 from aci_protocol import STREAM_PAYLOAD_FIELD as STREAM_PAYLOAD_FIELD
@@ -16,13 +18,14 @@ from .app import (
     build_web_client,
 )
 from .config import DispatcherConfig
-from .handlers import is_actionable, process_event, register_handlers
+from .handlers import process_event, register_handlers
 from .queue import (
     claim_event,
     enqueue,
     from_stream_fields,
     to_stream_fields,
 )
+from .relevance import DropReason, classify
 from .supervisor import BackoffPolicy, Connection, Supervisor
 
 __version__ = "0.0.0"
@@ -32,6 +35,7 @@ __all__ = [
     "BackoffPolicy",
     "Connection",
     "DispatcherConfig",
+    "DropReason",
     "SocketModeConnection",
     "Supervisor",
     "__version__",
@@ -39,9 +43,9 @@ __all__ = [
     "build_redis",
     "build_web_client",
     "claim_event",
+    "classify",
     "enqueue",
     "from_stream_fields",
-    "is_actionable",
     "process_event",
     "register_handlers",
     "to_stream_fields",

--- a/apps/dispatcher/src/curie_dispatcher/handlers.py
+++ b/apps/dispatcher/src/curie_dispatcher/handlers.py
@@ -5,10 +5,33 @@ The Socket Mode transport acks the envelope in under three seconds on its own
 own the rest of the lifecycle step: dedupe the delivery, post an in-thread
 placeholder reply, and enqueue the normalized job for the worker.
 
-Two event types feed the same processing path:
-  - ``app_mention``: the bot was @-mentioned in a channel; always process.
-  - ``message``: only direct messages to the bot (``channel_type == "im"``) are
-    processed, so ordinary channel chatter is not enqueued.
+Two event types feed the same processing path, with lane-specific admission
+(#2006). Every refusal these listeners make is an enumerated
+``relevance.DropReason`` emitted through ``relevance.drop`` -- no drop of ours is
+silent, which is the defect that ticket closes.
+
+  - ``app_mention``: the bot was @-mentioned. A human mention is always
+    processed, at root or in a thread. A *bot*-authored mention is processed
+    only as a ROOT post: one carrying ``thread_ts`` is refused as
+    ``BOT_AUTHORED_THREAD_REPLY``, because Curie's own replies are always
+    threaded and two installations in one workspace could otherwise mention-loop
+    each other -- a case Bolt's self filter cannot see, since the two bot
+    identities differ.
+  - ``message``: only the direct-message lane (``channel_type == "im"``) is
+    processed. That is envelope validation, not a relevance judgement:
+    ``apps/dispatcher/slack-app-manifest.yaml`` subscribes to ``app_mention``
+    and ``message.im`` only, so any other channel type is outside the declared
+    subscription surface and is refused as ``UNSUBSCRIBED_LANE``. Bot authorship
+    is NOT consulted on this lane -- incoming webhooks, Workflow Builder posts
+    and other apps all reach us as bot-authored ``message.im`` events, and our
+    own posts are already gone: Bolt's ``IgnoringSelfEvents`` middleware drops
+    self-authored events before any listener here runs.
+
+On both lanes the only content filter is the closed ``NON_CONTENT_SUBTYPES``
+denylist; unknown and future subtypes are actionable. Refusals made *above*
+these listeners by Bolt's own middleware (self events, authorization, listener
+matching) are documented in ``docs/interfaces/channel-ingress/INTERFACE.md``
+rather than re-implemented here.
 
 We use the dispatcher's own ``WebClient`` (built from the bot token) rather than
 Bolt's per-request injected client so the Web API surface is a single, mockable
@@ -41,7 +64,9 @@ from .approval_actions import (
     resolve_note_submission,
 )
 from .config import DispatcherConfig
-from .queue import claim_event, enqueue
+from .inbound_text import derive_text
+from .queue import claim_event, enqueue, release_event
+from .relevance import DropReason, Lane, classify, drop
 
 if TYPE_CHECKING:
     from redis import Redis
@@ -53,23 +78,55 @@ def _utc_now_iso() -> str:
     return datetime.now(UTC).isoformat()
 
 
-def is_actionable(event: dict[str, Any]) -> bool:
-    """False for events the dispatcher must ignore to avoid loops and noise.
+def _post_placeholder(
+    *,
+    web_client: WebClient,
+    redis_client: "Redis",
+    config: DispatcherConfig,
+    slack_event_id: str,
+    channel: str,
+    thread_ts: str,
+) -> Any:
+    """Post the in-thread placeholder, releasing the dedupe claim if it fails (#2006).
 
-    Bot-authored messages (including the dispatcher's own placeholder) and
-    subtyped messages (edits, joins, deletions) are not user requests.
+    ``claim_event`` runs before this call, and Bolt acks an Events API envelope
+    before running the listener body and then catches the body's exception in its
+    executor. So a raising ``chat_postMessage`` used to leave the key claimed with
+    no work done: any later delivery of that event id hit the claim and was
+    refused, and the message was lost for good with only a framework log line --
+    exactly the silent-loss class this ticket closes.
+
+    HONEST BOUND on what this buys. Because Bolt already acked, a Slack
+    redelivery of the failed event is rare; it is not the normal consequence of
+    the body raising. Releasing restores idempotency *correctness* -- the adapter
+    stops holding a claim for work it never did, so a retry, a replay or an
+    operator re-send can still be processed. It does not guarantee that every
+    failed placeholder is recovered.
+
+    THE ASYMMETRY IS DELIBERATE, do not "fix" it for consistency: only a failure
+    *before* the placeholder releases. Once the placeholder is in the channel
+    something user-visible has happened, so a failing ``enqueue`` after it keeps
+    the claim -- releasing there would let a redelivery post a SECOND placeholder
+    into the same thread, trading an invisible failure for a visible, confusing
+    one. Before the placeholder nothing user-visible has occurred, so releasing
+    is free.
     """
-    if event.get("bot_id"):
-        return False
-    if event.get("subtype"):
-        return False
-    return True
+    try:
+        return web_client.chat_postMessage(
+            channel=channel,
+            thread_ts=thread_ts,
+            text=config.placeholder_text,
+        )
+    except BaseException:
+        release_event(redis_client, config, slack_event_id)
+        raise
 
 
 def process_event(
     *,
     body: dict[str, Any],
     event: dict[str, Any],
+    lane: Lane,
     web_client: WebClient,
     redis_client: "Redis",
     config: DispatcherConfig,
@@ -78,28 +135,39 @@ def process_event(
 ) -> str | None:
     """Dedupe, post the placeholder, and enqueue one Slack event.
 
+    ``lane`` says which subscribed lane the delivery arrived on; the
+    bot-authorship rule is lane-specific (see ``relevance.classify``) and cannot
+    be inferred from the event body alone.
+
     Returns the Valkey Stream id when a job was enqueued, or None when the event
-    was skipped (non-actionable, or a duplicate delivery already claimed).
+    was refused. Every refusal is logged with its enumerated ``DropReason``.
     """
     log = logger or logging.getLogger(__name__)
 
-    if not is_actionable(event):
+    # `body.get`, not `body["event_id"]`: this drop runs before the claim and a
+    # malformed envelope with no event_id must be refused, not crash the listener.
+    reason = classify(event, lane=lane)
+    if reason is not None:
+        drop(log, reason, event_id=str(body.get("event_id", "")), lane=lane)
         return None
 
     slack_event_id = body["event_id"]
 
     if not claim_event(redis_client, config, slack_event_id):
-        log.info("duplicate slack event %s, skipping", slack_event_id)
+        drop(log, DropReason.DUPLICATE_DELIVERY, event_id=slack_event_id)
         return None
 
     # Reply in-thread: for a root message the thread key is its own ts.
     thread_ts = event.get("thread_ts") or event["ts"]
     channel = event["channel"]
 
-    placeholder = web_client.chat_postMessage(
+    placeholder = _post_placeholder(
+        web_client=web_client,
+        redis_client=redis_client,
+        config=config,
+        slack_event_id=slack_event_id,
         channel=channel,
         thread_ts=thread_ts,
-        text=config.placeholder_text,
     )
     placeholder_ts = placeholder["ts"]
 
@@ -116,7 +184,12 @@ def process_event(
         event_id=slack_event_id,
         conversation_id=thread_ts,
         author=event.get("user", ""),
-        text=event.get("text", ""),
+        # NOT `event.get("text", "")`: a Block Kit or attachment-shaped post
+        # carries an empty or fallback-only top-level `text` and its real body in
+        # `blocks`/`attachments`, so that read emptied the turn while still
+        # burning a placeholder (#2006). `derive_text` returns a non-empty
+        # top-level text byte-identically, so existing enqueues are unchanged.
+        text=derive_text(event),
         # A person spoke, so this turn MAY steer a live one. Stated rather than
         # left to the model default for the same reason `kind` is: a producer
         # that does not say what it is produces turns nobody can audit.
@@ -162,8 +235,14 @@ def process_action(
     """
     log = logger or logging.getLogger(__name__)
 
+    # A click carries no Slack event_id; the trigger_id is the interaction's own
+    # identity and is what the synthesized dedupe key below is built from, so it
+    # is the useful thing to name in a pre-claim drop.
+    interaction_id = str(body.get("trigger_id") or "")
+
     actions = body.get("actions") or []
     if not actions:
+        drop(log, DropReason.NO_ACTION_IN_PAYLOAD, event_id=interaction_id)
         return None
     # Approval-card buttons (#246) resolve through the API, never become a
     # turn. Bolt runs every matching listener, so this catch-all sees the
@@ -172,6 +251,7 @@ def process_action(
         return None
     command = action_command(actions[0])
     if not command:
+        drop(log, DropReason.EMPTY_ACTION_COMMAND, event_id=interaction_id)
         return None
 
     # The catch-all matcher fires on *every* block action, including ones from an
@@ -186,26 +266,32 @@ def process_action(
     # Reply in the clicked message's thread (its thread_ts, or its own ts if root).
     thread_ts = message.get("thread_ts") or message.get("ts")
     if not channel or not thread_ts:
-        log.info("block action without channel/message, skipping")
+        drop(log, DropReason.UNADDRESSABLE_ACTION, event_id=interaction_id)
         return None
 
     # A click carries no Slack event_id, so synthesize a stable idempotency key
     # from the interaction; a re-delivered click cannot enqueue (or post a second
     # placeholder) twice, same as the event dedupe.
-    interaction = body.get("trigger_id") or (
+    interaction = interaction_id or (
         f"{actions[0].get('action_ts', '')}-{actions[0].get('action_id', '')}"
     )
     slack_event_id = f"action-{interaction}"
     if not claim_event(redis_client, config, slack_event_id):
-        log.info("duplicate block action %s, skipping", slack_event_id)
+        drop(log, DropReason.DUPLICATE_DELIVERY, event_id=slack_event_id)
         return None
 
     user = (body.get("user") or {}).get("id", "")
 
-    placeholder = web_client.chat_postMessage(
+    # Same claim -> placeholder ordering as `process_event`, so the same release
+    # rule applies on this lane; fixing one mint site and not its twin is this
+    # repo's dominant drift shape.
+    placeholder = _post_placeholder(
+        web_client=web_client,
+        redis_client=redis_client,
+        config=config,
+        slack_event_id=slack_event_id,
         channel=channel,
         thread_ts=thread_ts,
-        text=config.placeholder_text,
     )
     queued = QueuedTurn(
         event_id=slack_event_id,
@@ -240,12 +326,17 @@ def register_handlers(
     injectable for tests; None builds the production client from config."""
 
     approval_resolver = resolver if resolver is not None else build_resolver(config)
+    # Resolved once here rather than per listener: the lane filter below drops
+    # outside `process_event`, so it needs a logger of its own, and the injected
+    # one is the single logger every drop must land on.
+    log = logger or logging.getLogger(__name__)
 
     @app.event("app_mention")
     def _on_app_mention(body: dict[str, Any], event: dict[str, Any]) -> None:
         process_event(
             body=body,
             event=event,
+            lane="mention",
             web_client=web_client,
             redis_client=redis_client,
             config=config,
@@ -255,11 +346,27 @@ def register_handlers(
 
     @app.event("message")
     def _on_message(body: dict[str, Any], event: dict[str, Any]) -> None:
-        if event.get("channel_type") != "im":
+        # ENVELOPE VALIDATION, not a relevance decision (#2006). The manifest at
+        # `apps/dispatcher/slack-app-manifest.yaml` subscribes bot_events to
+        # exactly `app_mention` and `message.im`, so a message on any other
+        # channel type cannot legitimately arrive in production -- a burst on
+        # this reason means the installed app is subscribed to something the
+        # manifest does not declare. It also cannot move to the routing seam even
+        # in principle: `QueuedTurn` carries no lane and no subtype, and
+        # `BindingResolver.resolve` sees only (kind, channel).
+        channel_type = event.get("channel_type")
+        if channel_type != "im":
+            drop(
+                log,
+                DropReason.UNSUBSCRIBED_LANE,
+                event_id=str(body.get("event_id", "")),
+                channel_type=channel_type,
+            )
             return
         process_event(
             body=body,
             event=event,
+            lane="im",
             web_client=web_client,
             redis_client=redis_client,
             config=config,

--- a/apps/dispatcher/src/curie_dispatcher/handlers.py
+++ b/apps/dispatcher/src/curie_dispatcher/handlers.py
@@ -47,6 +47,7 @@ from typing import TYPE_CHECKING, Any
 
 from aci_protocol import QueuedTurn, ReplyHandle, TurnSource
 from slack_bolt import App
+from slack_sdk.errors import SlackApiError
 from slack_sdk.web import WebClient
 
 from .approval_actions import (
@@ -66,7 +67,7 @@ from .approval_actions import (
 from .config import DispatcherConfig
 from .inbound_text import derive_text
 from .queue import claim_event, enqueue, release_event
-from .relevance import DropReason, Lane, classify, drop
+from .relevance import DropReason, Lane, classify, drop, missing_envelope_fields
 
 if TYPE_CHECKING:
     from redis import Redis
@@ -78,11 +79,31 @@ def _utc_now_iso() -> str:
     return datetime.now(UTC).isoformat()
 
 
+def _is_unambiguous_rejection(error: SlackApiError) -> bool:
+    """True when Slack itself answered this call with an error code.
+
+    That answer is the only evidence we get that NOTHING was posted: Slack
+    received the request, refused it by name (``ratelimited``,
+    ``channel_not_found``, ``invalid_auth``, ...) and did not deliver a message.
+    A transport failure carries no such answer -- the request may well have been
+    accepted before the connection died.
+
+    ``fatal_error`` is excluded on Slack's own word: ``chat.postMessage``
+    documents that when it is returned "some aspect of the operation succeeded
+    before the error was raised", so it is an ambiguous outcome wearing an error
+    code, not a refusal.
+    """
+    response = getattr(error, "response", None)
+    code = getattr(response, "get", lambda _key: None)("error") if response is not None else None
+    return isinstance(code, str) and bool(code) and code != "fatal_error"
+
+
 def _post_placeholder(
     *,
     web_client: WebClient,
     redis_client: "Redis",
     config: DispatcherConfig,
+    log: logging.Logger,
     slack_event_id: str,
     channel: str,
     thread_ts: str,
@@ -110,6 +131,19 @@ def _post_placeholder(
     into the same thread, trading an invisible failure for a visible, confusing
     one. Before the placeholder nothing user-visible has occurred, so releasing
     is free.
+
+    ONLY AN UNAMBIGUOUS REFUSAL RELEASES. "The call raised" is not the same
+    claim as "nothing was posted". A ``SlackApiError`` carrying Slack's own
+    error code means Slack answered and refused, so no placeholder exists and a
+    later retry is clean -- release. Everything else (a timeout, a dropped
+    connection, ``SlackRequestError``, ``fatal_error``, an exception type we do
+    not recognise) may have failed *after* Slack accepted the post, so a
+    placeholder may already be sitting in the thread; releasing there would let
+    a replay post a SECOND one, which is precisely the duplicate the
+    claim-before-placeholder ordering exists to prevent. Both outcomes are
+    imperfect and we pick the quieter one: keep the claim, and log at ERROR that
+    it is being kept deliberately so the retained key is never mistaken for the
+    silent-loss bug this function fixes. Either way the exception is re-raised.
     """
     try:
         return web_client.chat_postMessage(
@@ -117,8 +151,17 @@ def _post_placeholder(
             thread_ts=thread_ts,
             text=config.placeholder_text,
         )
-    except BaseException:
-        release_event(redis_client, config, slack_event_id)
+    except BaseException as error:
+        if isinstance(error, SlackApiError) and _is_unambiguous_rejection(error):
+            release_event(redis_client, config, slack_event_id)
+            raise
+        log.error(
+            "placeholder for slack delivery %r failed with an ambiguous outcome (%s); "
+            "keeping the idempotency claim because a placeholder may already be in the "
+            "thread and a retry could post a second one",
+            slack_event_id,
+            type(error).__name__,
+        )
         raise
 
 
@@ -144,27 +187,46 @@ def process_event(
     """
     log = logger or logging.getLogger(__name__)
 
-    # `body.get`, not `body["event_id"]`: this drop runs before the claim and a
-    # malformed envelope with no event_id must be refused, not crash the listener.
-    reason = classify(event, lane=lane)
-    if reason is not None:
-        drop(log, reason, event_id=str(body.get("event_id", "")), lane=lane)
+    # ENVELOPE VALIDATION FIRST, AND BEFORE THE CLAIM (#2006). Everything the
+    # mint site needs is read with `.get` and checked here, because indexing it
+    # later is the silent-loss shape this ticket closes: `body["event_id"]`
+    # raised before any claim (Bolt acked, swallowed the exception, message
+    # gone), and `event["ts"]`/`event["channel"]` raised *after* `claim_event`
+    # succeeded -- so the claim outlived a turn that never existed and Slack's
+    # redelivery was refused as an already-seen delivery. Refusing through the
+    # normal `drop` path leaves the key free and the refusal visible.
+    #
+    # Reply in-thread: for a root message the thread key is its own ts.
+    slack_event_id = str(body.get("event_id") or "")
+    channel = str(event.get("channel") or "")
+    thread_ts = str(event.get("thread_ts") or event.get("ts") or "")
+    missing = missing_envelope_fields(
+        {"event_id": slack_event_id, "channel": channel, "thread_ts_or_ts": thread_ts}
+    )
+    if missing:
+        drop(
+            log,
+            DropReason.MALFORMED_ENVELOPE,
+            event_id=slack_event_id,
+            lane=lane,
+            missing=missing,
+        )
         return None
 
-    slack_event_id = body["event_id"]
+    reason = classify(event, lane=lane)
+    if reason is not None:
+        drop(log, reason, event_id=slack_event_id, lane=lane)
+        return None
 
     if not claim_event(redis_client, config, slack_event_id):
         drop(log, DropReason.DUPLICATE_DELIVERY, event_id=slack_event_id)
         return None
 
-    # Reply in-thread: for a root message the thread key is its own ts.
-    thread_ts = event.get("thread_ts") or event["ts"]
-    channel = event["channel"]
-
     placeholder = _post_placeholder(
         web_client=web_client,
         redis_client=redis_client,
         config=config,
+        log=log,
         slack_event_id=slack_event_id,
         channel=channel,
         thread_ts=thread_ts,
@@ -275,6 +337,16 @@ def process_action(
     interaction = interaction_id or (
         f"{actions[0].get('action_ts', '')}-{actions[0].get('action_id', '')}"
     )
+    # The same pre-claim envelope validation `process_event` does, for the one
+    # field this mint site requires and has not already checked: the identity
+    # the dedupe key is built from. `strip("-")` collapses the synthesized
+    # "<action_ts>-<action_id>" to "" when the payload carried neither, and
+    # claiming `action--` would burn ONE key shared by every such click --
+    # refusing the first and every later one as an already-seen delivery.
+    missing = missing_envelope_fields({"trigger_id_or_action_ts": interaction.strip("-")})
+    if missing:
+        drop(log, DropReason.MALFORMED_ENVELOPE, event_id=interaction_id, missing=missing)
+        return None
     slack_event_id = f"action-{interaction}"
     if not claim_event(redis_client, config, slack_event_id):
         drop(log, DropReason.DUPLICATE_DELIVERY, event_id=slack_event_id)
@@ -289,6 +361,7 @@ def process_action(
         web_client=web_client,
         redis_client=redis_client,
         config=config,
+        log=log,
         slack_event_id=slack_event_id,
         channel=channel,
         thread_ts=thread_ts,

--- a/apps/dispatcher/src/curie_dispatcher/handlers.py
+++ b/apps/dispatcher/src/curie_dispatcher/handlers.py
@@ -165,6 +165,85 @@ def _post_placeholder(
         raise
 
 
+def _mint_turn(
+    *,
+    web_client: WebClient,
+    redis_client: "Redis",
+    config: DispatcherConfig,
+    log: logging.Logger,
+    clock: Clock,
+    slack_event_id: str,
+    delivery_kind: str,
+    author: str,
+    text: str,
+    channel: str,
+    thread_ts: str,
+) -> str:
+    """Post the placeholder, enqueue the turn, and return its Stream id.
+
+    THE SHARED TAIL OF BOTH MINT SITES, held in one place so they cannot drift.
+    ``process_event`` and ``process_action`` differ in how they validate an
+    envelope, judge relevance, take the dedupe claim and derive their text; from
+    the placeholder onward they owe the queue an identical ``QueuedTurn``.
+    Fixing one mint site and not its twin is this repo's dominant drift shape,
+    so the invariants below (#1312's ordering rule, ADR-0096 D4.4's literal
+    ``kind`` and explicit ``adapter``) are asserted here once rather than once
+    per lane, and a field added at the next protocol bump has one site to touch.
+
+    The caller MUST have taken the dedupe claim already: ``_post_placeholder``
+    owns the release-only-on-an-unambiguous-refusal rule (#2006) and is called
+    from here, so the claim -> placeholder -> ``XADD`` ordering and the release
+    asymmetry are the same on both lanes by construction.
+
+    ``delivery_kind`` names what arrived ("slack event", "block action") for the
+    enqueue log line -- the one thing that still differs downstream of here.
+    """
+    placeholder = _post_placeholder(
+        web_client=web_client,
+        redis_client=redis_client,
+        config=config,
+        log=log,
+        slack_event_id=slack_event_id,
+        channel=channel,
+        thread_ts=thread_ts,
+    )
+    placeholder_ts = placeholder["ts"]
+
+    # Nothing else goes between the placeholder and the XADD below. The Slack
+    # assistant-thread status ("shimmer") used to sit right here, and it was the
+    # wrong side of the durable write (#1312): a best-effort cosmetic call, whose
+    # own failures are swallowed at debug, gating the only moment this turn
+    # becomes recoverable. slack_sdk's retry handler puts the worst case near
+    # 4.5s (see app.py's timeout constant), and Bolt has five shared listener
+    # workers, so a handful of slow status calls could stall ingestion with no
+    # visible explanation. The worker raises and lowers the shimmer now, which
+    # also puts set and clear in one process instead of racing across two.
+    queued = QueuedTurn(
+        event_id=slack_event_id,
+        conversation_id=thread_ts,
+        author=author,
+        text=text,
+        # A person spoke, or a person clicked a button -- still a person, still
+        # steerable -- so this turn MAY steer a live one. Stated rather than
+        # left to the model default for the same reason `kind` is: a producer
+        # that does not say what it is produces turns nobody can audit.
+        source=TurnSource.SLACK,
+        # The literal "slack" is this dispatcher stating what it is; it never
+        # comes from config, because a Slack Socket Mode dispatcher that could
+        # claim another kind is a misrouting vector. `adapter=None` is explicit
+        # rather than defaulted so a reader sees that Slack's route is the
+        # worker's configured origin, not an oversight (ADR-0096 D4.4). Same
+        # literal, same reason, on both lanes.
+        reply_handle=ReplyHandle(
+            kind="slack", channel=channel, placeholder=placeholder_ts, adapter=None
+        ),
+        received_at=clock(),
+    )
+    stream_id = enqueue(redis_client, config, queued)
+    log.info("enqueued %s %s as stream entry %s", delivery_kind, slack_event_id, stream_id)
+    return stream_id
+
+
 def process_event(
     *,
     body: dict[str, Any],
@@ -222,29 +301,14 @@ def process_event(
         drop(log, DropReason.DUPLICATE_DELIVERY, event_id=slack_event_id)
         return None
 
-    placeholder = _post_placeholder(
+    return _mint_turn(
         web_client=web_client,
         redis_client=redis_client,
         config=config,
         log=log,
+        clock=clock,
         slack_event_id=slack_event_id,
-        channel=channel,
-        thread_ts=thread_ts,
-    )
-    placeholder_ts = placeholder["ts"]
-
-    # Nothing else goes between the placeholder and the XADD below. The Slack
-    # assistant-thread status ("shimmer") used to sit right here, and it was the
-    # wrong side of the durable write (#1312): a best-effort cosmetic call, whose
-    # own failures are swallowed at debug, gating the only moment this turn
-    # becomes recoverable. slack_sdk's retry handler puts the worst case near
-    # 4.5s (see app.py's timeout constant), and Bolt has five shared listener
-    # workers, so a handful of slow status calls could stall ingestion with no
-    # visible explanation. The worker raises and lowers the shimmer now, which
-    # also puts set and clear in one process instead of racing across two.
-    queued = QueuedTurn(
-        event_id=slack_event_id,
-        conversation_id=thread_ts,
+        delivery_kind="slack event",
         author=event.get("user", ""),
         # NOT `event.get("text", "")`: a Block Kit or attachment-shaped post
         # carries an empty or fallback-only top-level `text` and its real body in
@@ -252,23 +316,9 @@ def process_event(
         # burning a placeholder (#2006). `derive_text` returns a non-empty
         # top-level text byte-identically, so existing enqueues are unchanged.
         text=derive_text(event),
-        # A person spoke, so this turn MAY steer a live one. Stated rather than
-        # left to the model default for the same reason `kind` is: a producer
-        # that does not say what it is produces turns nobody can audit.
-        source=TurnSource.SLACK,
-        # The literal "slack" is this dispatcher stating what it is; it never
-        # comes from config, because a Slack Socket Mode dispatcher that could
-        # claim another kind is a misrouting vector. `adapter=None` is explicit
-        # rather than defaulted so a reader sees that Slack's route is the
-        # worker's configured origin, not an oversight (ADR-0096 D4.4).
-        reply_handle=ReplyHandle(
-            kind="slack", channel=channel, placeholder=placeholder_ts, adapter=None
-        ),
-        received_at=clock(),
+        channel=channel,
+        thread_ts=thread_ts,
     )
-    stream_id = enqueue(redis_client, config, queued)
-    log.info("enqueued slack event %s as stream entry %s", slack_event_id, stream_id)
-    return stream_id
 
 
 def action_command(action: dict[str, Any]) -> str:
@@ -354,34 +404,22 @@ def process_action(
 
     user = (body.get("user") or {}).get("id", "")
 
-    # Same claim -> placeholder ordering as `process_event`, so the same release
-    # rule applies on this lane; fixing one mint site and not its twin is this
-    # repo's dominant drift shape.
-    placeholder = _post_placeholder(
+    # The shared tail: same claim -> placeholder -> XADD ordering as
+    # `process_event`, because it IS `process_event`'s, so the same release rule
+    # and the same `QueuedTurn` shape apply on this lane by construction.
+    return _mint_turn(
         web_client=web_client,
         redis_client=redis_client,
         config=config,
         log=log,
+        clock=clock,
         slack_event_id=slack_event_id,
+        delivery_kind="block action",
+        author=user,
+        text=command,
         channel=channel,
         thread_ts=thread_ts,
     )
-    queued = QueuedTurn(
-        event_id=slack_event_id,
-        conversation_id=thread_ts,
-        author=user,
-        text=command,
-        # A person clicked a button. Still a person, still steerable.
-        source=TurnSource.SLACK,
-        # Same literal, same reason, on the sibling lane (ADR-0096 D4.4).
-        reply_handle=ReplyHandle(
-            kind="slack", channel=channel, placeholder=placeholder["ts"], adapter=None
-        ),
-        received_at=clock(),
-    )
-    stream_id = enqueue(redis_client, config, queued)
-    log.info("enqueued block action %s as stream entry %s", slack_event_id, stream_id)
-    return stream_id
 
 
 def register_handlers(

--- a/apps/dispatcher/src/curie_dispatcher/inbound_text.py
+++ b/apps/dispatcher/src/curie_dispatcher/inbound_text.py
@@ -1,0 +1,303 @@
+"""Derive a turn's prompt text from a Slack event, not just its top-level ``text`` (D1).
+
+A Slack message delivered as Block Kit, as a legacy attachment, or as a bare
+file share carries an empty (or whitespace-only) top-level ``text``. Reading
+``event["text"]`` alone therefore mints a turn with no prompt in it: the message
+is not dropped, it is *emptied*, which is the silent-loss defect class issue
+#2006 closes. This module is the one place that answers "what did the human
+actually say", so the ingest path in ``handlers.py`` stays a straight line.
+
+**Design influence, no code copied.** The shape of this fix was informed by the
+Vercel ``eve`` commit ``4464e4d`` (Apache-2.0) and Cloudflare's ``agents`` PR
+#2129, both of which hit the same emptied-message failure in their own Slack
+adapters. Neither the code nor any derivative of it is present here -- the
+walker below was written against Slack's own Block Kit reference, and the
+borrowing is conceptual (walk the payload, denylist the chrome, bound the
+traversal). That is why the repository ``NOTICE`` is unchanged: nothing in this
+file is a redistribution of third-party work.
+
+**Passthrough is byte-identical.** When top-level ``text`` is non-empty after
+``.strip()`` it is returned *unchanged*, including surrounding whitespace and
+the ``<@U…>`` mention markup the worker relies on for addressing. Every enqueue
+that works today is therefore bit-for-bit unaffected; derivation is strictly a
+new path for payloads that would otherwise have produced nothing.
+
+**Coverage is partial, and stated as such.** The walker is generic: it finds
+recognized text-bearing nodes at any depth, *including inside block types it
+does not know*, because Slack ships new block types faster than any adapter can
+special-case them. It does not individually render the rich-text element types
+absent from the table below -- ``date``, ``file``, ``citation``, message
+mention, canvas reference, workflow mention, and work object. Those contribute
+whatever recognized text they nest (plus a plain-string ``text`` value where
+they happen to carry one, which is how ``date`` surfaces) and nothing more.
+This is accepted partial coverage, not completeness.
+
+**UI chrome is not message content.** Button labels, confirmation-dialog copy,
+select placeholders, option lists and input hints are interface strings the
+sender never wrote as prose. Feeding them to the model is both noise and a
+prompt-injection surface, so the walker refuses to descend into those keys at
+all. That refusal is also what makes the attachment ``fallback`` rule correct:
+chrome can no longer be the thing that "yielded", so an attachment whose only
+content is a button still emits its fallback string.
+
+**The bounds bound traversal, not just the output.** A hostile or merely
+enormous payload is bounded three ways -- recursion depth, visited-node count,
+and accumulated characters -- and each stops the *walk*. Truncating only the
+final joined string would still pay the CPU and memory cost of visiting a
+200k-element flat list, so every budget is checked before descending.
+"""
+
+from typing import Any
+
+#: Maximum recursion depth. Slack's own nesting (block -> elements ->
+#: rich_text_section -> elements) is three or four levels; 12 leaves generous
+#: headroom while keeping the walk far below Python's recursion limit.
+_MAX_DEPTH = 12
+
+#: Maximum characters charged against the walk. Reaching it stops traversal,
+#: and the returned string is truncated to this length.
+_MAX_CHARS = 40000
+
+#: Maximum container/leaf nodes visited. Depth does not bound breadth: a flat
+#: list of a million elements is depth 2 and would otherwise be walked whole.
+_MAX_NODES = 5000
+
+#: Keys whose subtrees are UI chrome, never message content. The walker does
+#: not descend into them at any depth (an ``actions`` block's ``elements``
+#: list is denied too, see ``_denied_keys``).
+_CHROME_KEYS = frozenset(
+    {"accessory", "confirm", "options", "option_groups", "placeholder", "hint"}
+)
+
+#: Composition-object and rich-text node types whose ``text`` is the content.
+_TEXT_OBJECT_TYPES = frozenset({"plain_text", "mrkdwn", "text"})
+
+#: Attachment keys emitted, in order, by the explicit attachment branch before
+#: its ``fields``/``footer``/nested ``blocks`` are handled.
+_ATTACHMENT_LEAD_KEYS = ("pretext", "title", "text")
+
+
+class _Collector:
+    """Ordered segment accumulator that owns the traversal budgets.
+
+    Characters are charged for every candidate segment, including one that is
+    then collapsed as a repeat of its immediate predecessor. The budget
+    measures work done walking the payload, not the size of the result, which
+    is what makes it a real bound on a bulky repetitive payload.
+    """
+
+    def __init__(self) -> None:
+        self.segments: list[str] = []
+        self.chars = 0
+        self.nodes = 0
+
+    @property
+    def exhausted(self) -> bool:
+        """True once either the character or the node budget is spent."""
+        return self.chars >= _MAX_CHARS or self.nodes >= _MAX_NODES
+
+    def charge_node(self) -> None:
+        """Count one visited container node against the node budget."""
+        self.nodes += 1
+
+    def emit(self, value: object) -> None:
+        """Append ``value`` as a segment when it is a non-blank string.
+
+        Blank and non-string values are ignored. A segment identical to the
+        one immediately before it is collapsed -- deliberately a trivial
+        adjacent check and not a global dedupe index, which would drop
+        legitimate repetition elsewhere in a long message.
+        """
+        if not isinstance(value, str) or not value.strip():
+            return
+        # Charged before the adjacency check: the walk did the work either way.
+        self.chars += len(value) + 1
+        if self.segments and self.segments[-1] == value:
+            return
+        self.segments.append(value)
+
+    def render(self) -> str:
+        """Join the collected segments and enforce the character cap."""
+        return "\n".join(self.segments)[:_MAX_CHARS]
+
+
+def _denied_keys(node_type: object) -> frozenset[str]:
+    """Keys the walker must not descend into for a node of this type."""
+    if node_type == "actions":
+        # An actions block's elements are buttons; their labels are chrome.
+        return _CHROME_KEYS | {"elements"}
+    return _CHROME_KEYS
+
+
+def _emit_recognized(node: dict[Any, Any], node_type: str, out: _Collector) -> bool:
+    """Emit ``node`` per D1's type table; return True when it is consumed.
+
+    A False return means the node is not a recognized leaf and the caller
+    should keep recursing into it.
+    """
+    if node_type in _TEXT_OBJECT_TYPES:
+        text = node.get("text")
+        if isinstance(text, str):
+            out.emit(text)
+            return True
+        return False
+    if node_type == "link":
+        text = node.get("text")
+        out.emit(text if isinstance(text, str) and text.strip() else node.get("url"))
+        return True
+    if node_type == "emoji":
+        name = node.get("name")
+        if isinstance(name, str) and name.strip():
+            out.emit(f":{name}:")
+        return True
+    if node_type == "user":
+        user_id = node.get("user_id")
+        if isinstance(user_id, str) and user_id.strip():
+            out.emit(f"<@{user_id}>")
+        return True
+    if node_type == "channel":
+        channel_id = node.get("channel_id")
+        if isinstance(channel_id, str) and channel_id.strip():
+            out.emit(f"<#{channel_id}>")
+        return True
+    if node_type == "usergroup":
+        group_id = node.get("usergroup_id")
+        if isinstance(group_id, str) and group_id.strip():
+            out.emit(f"<!subteam^{group_id}>")
+        return True
+    if node_type == "broadcast":
+        broadcast_range = node.get("range")
+        if isinstance(broadcast_range, str) and broadcast_range.strip():
+            out.emit(f"<!{broadcast_range}>")
+        return True
+    if node_type == "image":
+        out.emit(node.get("alt_text"))
+        return True
+    return False
+
+
+def _walk(node: object, depth: int, out: _Collector) -> None:
+    """Recursively collect text-bearing content from ``node``.
+
+    Scalars other than a recognized node's own text value are never emitted:
+    ``block_id``, ``action_id``, urls of non-link nodes and the like are
+    structure, not prose. Anything that is not a dict or a list is a dead end.
+    """
+    if out.exhausted or depth > _MAX_DEPTH:
+        return
+    if isinstance(node, list):
+        out.charge_node()
+        for item in node:
+            if out.exhausted:
+                return
+            _walk(item, depth + 1, out)
+        return
+    if not isinstance(node, dict):
+        return
+    out.charge_node()
+
+    node_type = node.get("type")
+    if isinstance(node_type, str) and _emit_recognized(node, node_type, out):
+        return
+
+    skip = set(_denied_keys(node_type))
+    if isinstance(node_type, str):
+        # Accepted partial coverage: an unrecognized typed node whose own
+        # ``text`` is a plain string still yields it (Slack's ``date`` element
+        # is exactly this shape). A dict ``text`` is a composition object and
+        # is left to the recursion below.
+        own_text = node.get("text")
+        if isinstance(own_text, str):
+            out.emit(own_text)
+            skip.add("text")
+
+    for key, value in node.items():
+        if key in skip:
+            continue
+        if out.exhausted:
+            return
+        _walk(value, depth + 1, out)
+
+
+def _walk_attachment(attachment: object, out: _Collector) -> None:
+    """Consume one legacy message attachment.
+
+    The attachment dict is handled here **or** by the generic walker, never
+    both: handing it to both paths would emit ``text``, ``title`` and every
+    field twice. ``fallback`` is Slack's own plain-text summary of the rest of
+    the attachment, so it is emitted only when nothing else in this attachment
+    yielded anything.
+    """
+    if not isinstance(attachment, dict):
+        return
+    out.charge_node()
+    before = len(out.segments)
+
+    for key in _ATTACHMENT_LEAD_KEYS:
+        out.emit(attachment.get(key))
+    fields = attachment.get("fields")
+    if isinstance(fields, list):
+        for field in fields:
+            if out.exhausted:
+                break
+            if isinstance(field, dict):
+                out.emit(field.get("title"))
+                out.emit(field.get("value"))
+    out.emit(attachment.get("footer"))
+    _walk(attachment.get("blocks"), 1, out)
+
+    if len(out.segments) == before:
+        out.emit(attachment.get("fallback"))
+
+
+def _emit_file(file_entry: object, out: _Collector) -> None:
+    """Emit a shared file's human-readable label.
+
+    ``file_share`` is admitted as actionable (D3), so a file dropped into a DM
+    with no accompanying message must still derive *something* -- otherwise
+    admitting it would open a brand-new silent-empty path, the exact defect
+    this module exists to close.
+    """
+    if not isinstance(file_entry, dict):
+        return
+    out.charge_node()
+    title = file_entry.get("title")
+    out.emit(title if isinstance(title, str) and title.strip() else file_entry.get("name"))
+
+
+def derive_text(event: dict[str, Any]) -> str:
+    """Return the prompt text for a Slack message event.
+
+    A non-empty top-level ``text`` (after ``.strip()``) is returned unchanged
+    and nothing else is consulted. Otherwise the text is derived from
+    ``blocks``, then ``attachments``, then ``files``, with non-empty segments
+    joined by newlines in Slack's own serialization order.
+
+    Never raises on a malformed payload: a missing, ``None``, or wrongly typed
+    value at any position yields "" or the partial text collected so far.
+    Callers get a plain string of at most ``_MAX_CHARS`` characters -- with the
+    deliberate exception of the byte-identical passthrough above, which is
+    returned exactly as Slack sent it.
+    """
+    raw_text = event.get("text")
+    if isinstance(raw_text, str) and raw_text.strip():
+        return raw_text
+
+    out = _Collector()
+    _walk(event.get("blocks"), 1, out)
+
+    attachments = event.get("attachments")
+    if isinstance(attachments, list):
+        for attachment in attachments:
+            if out.exhausted:
+                break
+            _walk_attachment(attachment, out)
+
+    files = event.get("files")
+    if isinstance(files, list):
+        for file_entry in files:
+            if out.exhausted:
+                break
+            _emit_file(file_entry, out)
+
+    return out.render()

--- a/apps/dispatcher/src/curie_dispatcher/inbound_text.py
+++ b/apps/dispatcher/src/curie_dispatcher/inbound_text.py
@@ -80,6 +80,11 @@ _CHROME_KEYS = frozenset(
     {"accessory", "confirm", "options", "option_groups", "placeholder", "hint"}
 )
 
+#: ``_CHROME_KEYS`` plus ``elements``, for an ``actions`` block whose elements
+#: are buttons. Hoisted to module scope so it is computed once, not on every
+#: ``actions`` node the walker visits.
+_ACTIONS_DENIED_KEYS = _CHROME_KEYS | {"elements"}
+
 #: Composition-object and rich-text node types whose ``text`` is the content.
 _TEXT_OBJECT_TYPES = frozenset({"plain_text", "mrkdwn", "text"})
 
@@ -163,7 +168,7 @@ def _denied_keys(node_type: object) -> frozenset[str]:
     """Keys the walker must not descend into for a node of this type."""
     if node_type == "actions":
         # An actions block's elements are buttons; their labels are chrome.
-        return _CHROME_KEYS | {"elements"}
+        return _ACTIONS_DENIED_KEYS
     return _CHROME_KEYS
 
 
@@ -239,7 +244,7 @@ def _walk(node: object, depth: int, out: _Collector) -> None:
     if isinstance(node_type, str) and _emit_recognized(node, node_type, out):
         return
 
-    skip = set(_denied_keys(node_type))
+    skip: frozenset[str] = _denied_keys(node_type)
     if isinstance(node_type, str):
         # Accepted partial coverage: an unrecognized typed node whose own
         # ``text`` is a plain string still yields it (Slack's ``date`` element
@@ -248,7 +253,7 @@ def _walk(node: object, depth: int, out: _Collector) -> None:
         own_text = node.get("text")
         if isinstance(own_text, str):
             out.emit(own_text)
-            skip.add("text")
+            skip = skip | {"text"}
 
     for key, value in node.items():
         if key in skip:

--- a/apps/dispatcher/src/curie_dispatcher/inbound_text.py
+++ b/apps/dispatcher/src/curie_dispatcher/inbound_text.py
@@ -32,19 +32,30 @@ whatever recognized text they nest (plus a plain-string ``text`` value where
 they happen to carry one, which is how ``date`` surfaces) and nothing more.
 This is accepted partial coverage, not completeness.
 
-**UI chrome is not message content.** Button labels, confirmation-dialog copy,
-select placeholders, option lists and input hints are interface strings the
-sender never wrote as prose. Feeding them to the model is both noise and a
-prompt-injection surface, so the walker refuses to descend into those keys at
-all. That refusal is also what makes the attachment ``fallback`` rule correct:
-chrome can no longer be the thing that "yielded", so an attachment whose only
-content is a button still emits its fallback string.
+**The denied keys are not message content.** ``accessory``, ``confirm``,
+``options``, ``option_groups``, ``placeholder``, ``hint``, and an ``actions``
+block's ``elements`` carry button labels, confirmation-dialog copy, select
+placeholders and input hints -- interface strings the sender never wrote as
+prose, and both noise and a prompt-injection surface -- so the walker refuses to
+descend into them at any depth. That denylist is the whole of what is excluded;
+it is not a claim that every interface string is filtered out. An ``input``
+block's ``label`` is the standing counter-example: it is *not* denied and does
+reach the output, because input blocks do not appear in ordinary channel
+messages and the label is authored copy rather than a canned control string.
+The denylist is also what makes the attachment ``fallback`` rule correct: a
+denied key can no longer be the thing that "yielded", so an attachment whose
+only content is a button still emits its fallback string.
 
 **The bounds bound traversal, not just the output.** A hostile or merely
 enormous payload is bounded three ways -- recursion depth, visited-node count,
 and accumulated characters -- and each stops the *walk*. Truncating only the
 final joined string would still pay the CPU and memory cost of visiting a
-200k-element flat list, so every budget is checked before descending.
+200k-element flat list, so every budget is checked before descending. Two
+consequences are load-bearing rather than incidental: **every** visited node is
+charged, scalars and non-dict list entries included, so breadth cannot be spent
+for free down a container path; and each segment is trimmed to the *remaining*
+character budget at emit time, so a single 10MB ``mrkdwn`` string is never
+stored -- let alone joined -- whole on the way to a 40k-character result.
 """
 
 from typing import Any
@@ -84,12 +95,23 @@ class _Collector:
     then collapsed as a repeat of its immediate predecessor. The budget
     measures work done walking the payload, not the size of the result, which
     is what makes it a real bound on a bulky repetitive payload.
+
+    Storage is bounded at the same instant as the charge: a segment is trimmed
+    to whatever is left of the character budget *before* it is kept, so the
+    accumulator never holds, and ``render`` never joins, a string larger than
+    the cap.
     """
 
     def __init__(self) -> None:
         self.segments: list[str] = []
         self.chars = 0
         self.nodes = 0
+        #: Emit attempts that carried real (non-blank, ``str``) text, counted
+        #: even when the segment is then collapsed as an adjacent duplicate or
+        #: trimmed away by the budget. "Did this subtree have content?" is a
+        #: question about the payload, so it must not be inferred from a change
+        #: in ``len(segments)``, which those two cases leave untouched.
+        self.text_emits = 0
 
     @property
     def exhausted(self) -> bool:
@@ -97,7 +119,13 @@ class _Collector:
         return self.chars >= _MAX_CHARS or self.nodes >= _MAX_NODES
 
     def charge_node(self) -> None:
-        """Count one visited container node against the node budget."""
+        """Count one visited node against the node budget.
+
+        *Every* node the walk touches is charged -- scalars and non-dict list
+        entries as much as dicts and lists. Charging only containers would
+        leave a list of a million bare strings, or an attachment with a million
+        empty ``{}`` fields, bounded by input size rather than by ``_MAX_NODES``.
+        """
         self.nodes += 1
 
     def emit(self, value: object) -> None:
@@ -110,14 +138,24 @@ class _Collector:
         """
         if not isinstance(value, str) or not value.strip():
             return
+        self.text_emits += 1
+        remaining = _MAX_CHARS - self.chars
         # Charged before the adjacency check: the walk did the work either way.
         self.chars += len(value) + 1
-        if self.segments and self.segments[-1] == value:
+        if remaining <= 0:
             return
-        self.segments.append(value)
+        segment = value[:remaining]
+        if self.segments and self.segments[-1] == segment:
+            return
+        self.segments.append(segment)
 
     def render(self) -> str:
-        """Join the collected segments and enforce the character cap."""
+        """Join the collected segments and enforce the character cap.
+
+        Every segment was already trimmed to the budget remaining when it
+        arrived, so the join is bounded by construction; the slice here is the
+        belt to that pair of braces, not the thing doing the bounding.
+        """
         return "\n".join(self.segments)[:_MAX_CHARS]
 
 
@@ -185,8 +223,10 @@ def _walk(node: object, depth: int, out: _Collector) -> None:
     """
     if out.exhausted or depth > _MAX_DEPTH:
         return
+    # Charged for every node, container or not: a scalar list element costs a
+    # visit even though it is a dead end, and that is what bounds breadth.
+    out.charge_node()
     if isinstance(node, list):
-        out.charge_node()
         for item in node:
             if out.exhausted:
                 return
@@ -194,7 +234,6 @@ def _walk(node: object, depth: int, out: _Collector) -> None:
         return
     if not isinstance(node, dict):
         return
-    out.charge_node()
 
     node_type = node.get("type")
     if isinstance(node_type, str) and _emit_recognized(node, node_type, out):
@@ -227,26 +266,43 @@ def _walk_attachment(attachment: object, out: _Collector) -> None:
     field twice. ``fallback`` is Slack's own plain-text summary of the rest of
     the attachment, so it is emitted only when nothing else in this attachment
     yielded anything.
+
+    "Yielded anything" is read off ``text_emits``, never off a change in
+    ``len(out.segments)``: an attachment whose text repeats the segment
+    immediately before it is collapsed by ``emit``, leaving the segment count
+    unmoved, and inferring from the count would then emit the ``fallback`` of an
+    attachment that plainly did have content.
+
+    Every budget is re-checked between this attachment's own keys, exactly as
+    the generic walker checks between a dict's values -- otherwise an
+    attachment that exhausted the budget on its ``pretext`` would go on to walk
+    its fields, footer and nested blocks anyway.
     """
+    out.charge_node()
     if not isinstance(attachment, dict):
         return
-    out.charge_node()
-    before = len(out.segments)
+    before = out.text_emits
 
     for key in _ATTACHMENT_LEAD_KEYS:
+        if out.exhausted:
+            return
         out.emit(attachment.get(key))
     fields = attachment.get("fields")
     if isinstance(fields, list):
+        out.charge_node()
         for field in fields:
             if out.exhausted:
                 break
+            out.charge_node()
             if isinstance(field, dict):
                 out.emit(field.get("title"))
                 out.emit(field.get("value"))
+    if out.exhausted:
+        return
     out.emit(attachment.get("footer"))
     _walk(attachment.get("blocks"), 1, out)
 
-    if len(out.segments) == before:
+    if out.text_emits == before:
         out.emit(attachment.get("fallback"))
 
 
@@ -258,9 +314,9 @@ def _emit_file(file_entry: object, out: _Collector) -> None:
     admitting it would open a brand-new silent-empty path, the exact defect
     this module exists to close.
     """
+    out.charge_node()
     if not isinstance(file_entry, dict):
         return
-    out.charge_node()
     title = file_entry.get("title")
     out.emit(title if isinstance(title, str) and title.strip() else file_entry.get("name"))
 

--- a/apps/dispatcher/src/curie_dispatcher/queue.py
+++ b/apps/dispatcher/src/curie_dispatcher/queue.py
@@ -20,6 +20,15 @@ EX <ttl>`` before enqueuing: the first delivery claims the key and enqueues; a
 retry finds the key present and is dropped. This is chosen over stream-side
 dedupe because it is O(1), TTL-bounded (no unbounded dedupe set to prune), and
 does not require scanning the Stream.
+
+The claim also has a release path, ``release_event`` (``DEL <dedupe_key>``,
+#2006), and it is deliberately asymmetric. A failure between claiming and
+posting the placeholder has produced no user-visible side effect yet, so
+releasing is safe and lets a genuine Slack redelivery retry cleanly. A failure
+between a *successful* placeholder post and the ``XADD``, by contrast, must
+NOT release: the placeholder is already visible in the channel, and a
+redelivery that re-claims would post a second one. The asymmetry is the point,
+not an inconsistency to "clean up" later.
 """
 
 from typing import Any, Protocol, cast, runtime_checkable
@@ -33,13 +42,15 @@ from .config import DispatcherConfig
 class StreamPublisher(Protocol):
     """The stream-broker port (producer side): append an entry + dedupe-claim.
 
-    Issue #284 / ADR-0027. The producer's whole coupling to the broker is these
-    two verbs: ``xadd`` (append the one-``payload`` entry to the stream) and a
-    ``SET NX EX`` dedupe-claim (``set``). Typing the producer against this
-    Protocol makes a future non-redis broker a drop-in on the write side. The
-    consumer side has its own port (``StreamBroker`` in the worker). ``redis.Redis``
-    structurally satisfies this, so it is the one backing today with no adapter.
-    The verbs are typed permissively to match redis-py's signatures.
+    Issue #284 / ADR-0027, widened by #2006. The producer's whole coupling to
+    the broker is these three verbs: ``xadd`` (append the one-``payload`` entry
+    to the stream), a ``SET NX EX`` dedupe-claim (``set``), and its release
+    (``delete``). Typing the producer against this Protocol makes a future
+    non-redis broker a drop-in on the write side. The consumer side has its own
+    port (``StreamBroker`` in the worker). ``redis.Redis`` already has
+    ``delete``, so it structurally satisfies this widened port too, same as
+    before -- the one backing today with no adapter. The verbs are typed
+    permissively to match redis-py's signatures.
     """
 
     def xadd(self, name: Any, fields: Any) -> Any:
@@ -48,6 +59,10 @@ class StreamPublisher(Protocol):
 
     def set(self, name: Any, value: Any, *, nx: bool = ..., ex: Any = ...) -> Any:
         """``SET`` with ``NX``/``EX`` — the dedupe-claim beside the stream."""
+        ...
+
+    def delete(self, *names: Any) -> Any:
+        """``DEL`` — releases a dedupe claim (see ``release_event``)."""
         ...
 
 
@@ -75,6 +90,26 @@ def claim_event(redis_client: "StreamPublisher", config: "DispatcherConfig", eve
         ex=config.dedupe_ttl_seconds,
     )
     return bool(claimed)
+
+
+def release_event(
+    redis_client: "StreamPublisher", config: "DispatcherConfig", event_id: str
+) -> None:
+    """Release the dedupe claim on ``event_id`` so a Slack redelivery can retry.
+
+    Legitimate to call only when nothing user-visible has happened yet -- i.e.
+    before the placeholder post has succeeded. Once a placeholder has been
+    posted, do NOT call this: a redelivery would re-claim and post a second
+    placeholder (see the module docstring's Dedupe paragraph and #2006).
+
+    Caveat: under Socket Mode, Bolt acks the envelope before running the
+    listener body, so a Slack redelivery triggered by a failure inside the
+    listener is rare -- there is often no retry for the release to enable.
+    Calling this restores idempotency *correctness* (the claim no longer lies
+    about an event having gone through) rather than guaranteeing recovery of
+    every failure.
+    """
+    redis_client.delete(config.dedupe_key(event_id))
 
 
 def enqueue(redis_client: "StreamPublisher", config: "DispatcherConfig", turn: QueuedTurn) -> str:

--- a/apps/dispatcher/src/curie_dispatcher/relevance.py
+++ b/apps/dispatcher/src/curie_dispatcher/relevance.py
@@ -1,0 +1,189 @@
+"""The dispatcher's enumerated drop contract: which inbound Slack deliveries are
+refused before they ever become a turn, and the documented reason for each.
+
+Two rules govern this module, and both exist because #2006 found the adapter
+losing real user messages in silence:
+
+1. **Every refusal the adapter itself makes is enumerated and logged.** A
+   ``DropReason`` member with a one-sentence entry in :data:`DROP_RATIONALES`,
+   emitted through :func:`drop`. A bare ``return None`` on the ingest path is
+   the defect this module closes, not a style preference.
+2. **Denylists are closed, allowlists are open.** The filter this replaced
+   dropped on *any* message ``subtype`` -- a blanket denial over a set Slack
+   keeps growing, so ``file_share`` (a person uploading a file with a comment)
+   and ``thread_broadcast`` (a person's thread reply) were swallowed with no log
+   line at all. :data:`NON_CONTENT_SUBTYPES` names the small, closed set that is
+   structurally not new user content; everything else, including subtypes Slack
+   has not shipped yet, is actionable.
+
+**What this module deliberately does not do.** It does not re-implement the
+self-authored-event guard. ``slack_bolt``'s built-in ``IgnoringSelfEvents``
+middleware compares the incoming identity against the authorized bot identity
+and acks the envelope *before any listener runs*, so an event Curie itself
+posted never reaches these lanes. That middleware is the real loop guard;
+duplicating it here would add an adapter-level relevance decision that buys
+nothing and would (as it did before #2006) also discard legitimate posts from
+*other* apps. Bolt's admission boundary is documented in
+``docs/interfaces/channel-ingress/INTERFACE.md`` rather than reproduced here.
+
+Relevance that can be decided from the routed payload belongs at the routing
+seam (``Kernel.process_event`` in the worker), not in this adapter. What stays
+here is what the seam structurally cannot see: ``QueuedTurn`` carries no Slack
+lane and no subtype, and ``BindingResolver.resolve`` receives only
+``(kind, channel)``.
+"""
+
+import logging
+from collections.abc import Mapping
+from enum import StrEnum
+from types import MappingProxyType
+from typing import Any, Literal
+
+#: Which subscribed lane a delivery arrived on. The manifest
+#: (``apps/dispatcher/slack-app-manifest.yaml``) subscribes to exactly two bot
+#: events, so this is the complete set of lanes -- not an open string.
+Lane = Literal["mention", "im"]
+
+
+class DropReason(StrEnum):
+    """Why the adapter refused an inbound delivery, as a stable log token.
+
+    Every member is exercised end to end by ``tests/test_inbound_relevance.py``
+    and carries a rationale in :data:`DROP_RATIONALES`; adding a member without
+    both is a test failure, so a new adapter-level refusal cannot ship without
+    a demonstration of what it refuses and why.
+    """
+
+    UNSUBSCRIBED_LANE = "unsubscribed_lane"
+    BOT_AUTHORED_THREAD_REPLY = "bot_authored_thread_reply"
+    NON_CONTENT_SUBTYPE = "non_content_subtype"
+    DUPLICATE_DELIVERY = "duplicate_delivery"
+    NO_ACTION_IN_PAYLOAD = "no_action_in_payload"
+    EMPTY_ACTION_COMMAND = "empty_action_command"
+    UNADDRESSABLE_ACTION = "unaddressable_action"
+
+
+#: One documented sentence per reason. Asserted total in both directions -- a
+#: reason with no rationale is exactly the undocumented drop #2006 closes, and
+#: an orphan rationale means a reason was deleted without its explanation.
+DROP_RATIONALES: Mapping[DropReason, str] = MappingProxyType(
+    {
+        DropReason.UNSUBSCRIBED_LANE: (
+            "The delivered envelope is outside the adapter's declared subscription "
+            "surface -- apps/dispatcher/slack-app-manifest.yaml subscribes to "
+            "app_mention and message.im only, so a message event on any other "
+            "channel type cannot legitimately arrive and refusing it is envelope "
+            "validation rather than a relevance judgement."
+        ),
+        DropReason.BOT_AUTHORED_THREAD_REPLY: (
+            "Loop guard across installations: Curie's own replies and placeholders "
+            "are always threaded, so admitting a bot-authored mention that carries "
+            "a thread timestamp would let two Curie installations in one workspace "
+            "mention-loop each other indefinitely, which Bolt's self filter cannot "
+            "stop because the two bot identities differ."
+        ),
+        DropReason.NON_CONTENT_SUBTYPE: (
+            "The subtype marks something other than new user content: an edit, a "
+            "delete, a tombstone, a body redacted by Enterprise Key Management, or "
+            "an assistant thread-start marker."
+        ),
+        DropReason.DUPLICATE_DELIVERY: (
+            "Slack redelivered a delivery whose idempotency key was already claimed, "
+            "so processing it again would post a second placeholder and mint a "
+            "second turn for one message."
+        ),
+        DropReason.NO_ACTION_IN_PAYLOAD: (
+            "A block-action payload carrying no actions names no command and "
+            "addresses nothing, so there is no turn to mint from it."
+        ),
+        DropReason.EMPTY_ACTION_COMMAND: (
+            "A clicked button carrying neither a value nor a usable action id names "
+            "no command, so the turn text would be empty."
+        ),
+        DropReason.UNADDRESSABLE_ACTION: (
+            "An App Home or modal click carries no channel and no message, so there "
+            "is no thread in which a reply could be delivered."
+        ),
+    }
+)
+
+
+#: The closed set of message subtypes that are structurally not new user
+#: content. Kept deliberately small: the manifest subscribes only to
+#: ``app_mention`` and ``message.im``, so channel-lane noise (joins, leaves,
+#: topic/purpose/name changes, pins) cannot reach these lanes in production and
+#: does not need naming here. Everything not in this set -- including subtypes
+#: Slack ships after this was written -- is admitted and left to routing.
+NON_CONTENT_SUBTYPES: frozenset[str] = frozenset(
+    {
+        "message_changed",
+        "message_deleted",
+        "message_replied",
+        "tombstone",
+        "ekm_access_denied",
+        "assistant_app_thread",
+    }
+)
+
+
+def drop(
+    log: logging.Logger,
+    reason: DropReason,
+    *,
+    event_id: str,
+    **extra: object,
+) -> None:
+    """Record one refusal: exactly one INFO record naming the reason and its rationale.
+
+    Exactly one record per drop is the property the anti-silent-swallow suite
+    rests on, so this must not grow a second emit. Values are rendered with
+    ``%r`` so a newline or control character inside a Slack-supplied id cannot
+    forge an extra log line; message bodies are never logged at all.
+
+    Args:
+        log: The dispatcher's injected logger -- the one the drop must land on.
+        reason: The enumerated reason, whose value is the stable log token.
+        event_id: The delivery's idempotency key, or "" when none exists yet.
+        **extra: Additional non-body context (a channel type, a subtype).
+    """
+    details = "".join(f" {key}={value!r}" for key, value in sorted(extra.items()))
+    log.info(
+        "dropped inbound slack delivery %r: %s -- %s%s",
+        event_id,
+        reason.value,
+        DROP_RATIONALES[reason],
+        details,
+    )
+
+
+def classify(event: dict[str, Any], *, lane: Lane) -> DropReason | None:
+    """The reason this event must not become a turn, or None to admit it.
+
+    Args:
+        event: The Slack event body as delivered.
+        lane: Which subscribed lane it arrived on. The bot-authorship rule is
+            lane-specific, so this cannot be inferred from the event alone.
+
+    Returns:
+        A :class:`DropReason` when the event is refused, else None.
+    """
+    subtype = event.get("subtype")
+    if isinstance(subtype, str) and subtype in NON_CONTENT_SUBTYPES:
+        return DropReason.NON_CONTENT_SUBTYPE
+
+    # Bot authorship is a refusal on the mention lane ONLY, and only in a
+    # thread. A bot-authored mention at root is the case #2006 is about (an
+    # alert app @-mentioning Curie) and must reach routing. On the DM lane bot
+    # authorship is not consulted at all: incoming webhooks, Workflow Builder
+    # posts and other apps all arrive as bot-authored message.im events, and our
+    # own posts are already gone -- Bolt's IgnoringSelfEvents dropped them
+    # before this listener ran.
+    #
+    # Accepted cost, stated rather than discovered later: an alert bot that
+    # replies INSIDE a thread with a mention is not ingested. Root-only
+    # admission is what separates the ticket's case from the cross-installation
+    # loop without a new schema field or a bot allowlist.
+    if lane == "mention" and event.get("bot_id") and event.get("thread_ts"):
+        return DropReason.BOT_AUTHORED_THREAD_REPLY
+
+    return None

--- a/apps/dispatcher/src/curie_dispatcher/relevance.py
+++ b/apps/dispatcher/src/curie_dispatcher/relevance.py
@@ -54,6 +54,7 @@ class DropReason(StrEnum):
     a demonstration of what it refuses and why.
     """
 
+    MALFORMED_ENVELOPE = "malformed_envelope"
     UNSUBSCRIBED_LANE = "unsubscribed_lane"
     BOT_AUTHORED_THREAD_REPLY = "bot_authored_thread_reply"
     NON_CONTENT_SUBTYPE = "non_content_subtype"
@@ -68,6 +69,13 @@ class DropReason(StrEnum):
 #: an orphan rationale means a reason was deleted without its explanation.
 DROP_RATIONALES: Mapping[DropReason, str] = MappingProxyType(
     {
+        DropReason.MALFORMED_ENVELOPE: (
+            "The delivery omits a field the turn is minted from -- the event id on an "
+            "event, the channel, the thread key, or the interaction identity on a "
+            "click -- and refusing it before the idempotency claim beats raising after "
+            "it, because Bolt has already acked and would swallow the exception while "
+            "the claim survived for work that never happened."
+        ),
         DropReason.UNSUBSCRIBED_LANE: (
             "The delivered envelope is outside the adapter's declared subscription "
             "surface -- apps/dispatcher/slack-app-manifest.yaml subscribes to "
@@ -153,6 +161,33 @@ def drop(
         reason.value,
         DROP_RATIONALES[reason],
         details,
+    )
+
+
+def missing_envelope_fields(required: Mapping[str, object]) -> tuple[str, ...]:
+    """The names of the mint-site fields this delivery did not usably supply.
+
+    Envelope validation, deliberately separate from :func:`classify`: it reads
+    the *envelope* (``body``) as well as the event, and it must run before the
+    idempotency claim, whereas ``classify`` answers "is this event content we
+    should answer" from the event alone.
+
+    A field counts as present only when it is a non-blank string. Slack's ids
+    and timestamps are strings, and a blank one is no more usable than an absent
+    one -- an empty event id yields a dedupe key shared by every delivery that
+    omits it, and an empty thread key is a single lock across unrelated threads.
+
+    Args:
+        required: Field name -> the value the delivery supplied (or None).
+
+    Returns:
+        The unusable field names in the order given, or ``()`` when all are
+        present -- an empty tuple is falsy, so callers read as ``if missing:``.
+    """
+    return tuple(
+        name
+        for name, value in required.items()
+        if not isinstance(value, str) or not value.strip()
     )
 
 

--- a/apps/dispatcher/tests/test_broker_port.py
+++ b/apps/dispatcher/tests/test_broker_port.py
@@ -24,4 +24,7 @@ def test_minimal_second_broker_satisfies_port() -> None:
         def set(self, name: object, value: object, *, nx: bool = False, ex: object = None) -> bool:
             return True
 
+        def delete(self, *names: object) -> int:
+            return 1
+
     assert isinstance(FakeBroker(), StreamPublisher)

--- a/apps/dispatcher/tests/test_inbound_relevance.py
+++ b/apps/dispatcher/tests/test_inbound_relevance.py
@@ -47,7 +47,7 @@ from curie_dispatcher.queue import from_stream_fields
 from curie_dispatcher.relevance import DROP_RATIONALES, DropReason
 from slack_bolt import App
 from slack_bolt.adapter.socket_mode import SocketModeHandler
-from slack_sdk.errors import SlackApiError
+from slack_sdk.errors import SlackApiError, SlackRequestError
 from slack_sdk.socket_mode.request import SocketModeRequest
 from slack_sdk.web import WebClient
 
@@ -277,6 +277,21 @@ def _mention(
     return event
 
 
+def _mention_missing(field: str, **kwargs: Any) -> dict[str, Any]:
+    """An ``app_mention`` Slack always stamps ``field`` on, delivered without it.
+
+    Slack documents ``channel`` and ``ts`` as present on every delivered
+    ``app_mention`` (docs.slack.dev/reference/events/app_mention), so these are
+    shapes production should never see -- which is exactly why the adapter must
+    refuse them by name instead of indexing them and raising after the claim.
+    Built by removing the key from the well-formed builder above, so the two
+    cannot drift apart.
+    """
+    event = _mention(**kwargs)
+    del event[field]
+    return event
+
+
 def _dm(
     *,
     text: str = "hello bot",
@@ -335,6 +350,24 @@ def _block_action_body(
         # neither ``channel`` nor ``message``, so there is no thread to answer in.
         body["container"] = {"type": "view", "view_id": "V1"}
         body["view"] = {"id": "V1", "type": "home"}
+    return body
+
+
+def _anonymous_action_body() -> dict[str, Any]:
+    """A click carrying no identity to build an idempotency key from.
+
+    Slack stamps ``trigger_id`` on the ``block_actions`` payload and
+    ``action_ts`` / ``action_id`` on each entry of ``actions`` (Slack:
+    docs.slack.dev/reference/interaction-payloads/block-actions-payload). A
+    payload carrying none of the three still addresses a real thread and still
+    names a command through the button's ``value`` -- it just has no interaction
+    identity, so the synthesized key collapses to ``action--``.
+    """
+    body = _block_action_body(
+        actions=[{"type": "button", "value": "restart the deploy"}],
+        trigger_id="unused",
+    )
+    del body["trigger_id"]
     return body
 
 
@@ -559,6 +592,91 @@ MATRIX: tuple[Row, ...] = (
             ),
         ),
     ),
+    Row(
+        name="dm_message_deleted_is_not_content",
+        expected=DropReason.NON_CONTENT_SUBTYPE,
+        why=(
+            "A deletion notice: Slack names the removed `deleted_ts` and nests the "
+            "`previous_message`, and there is no new user request anywhere in it "
+            "(Slack: docs.slack.dev/reference/events/message, subtype message_deleted). "
+            "NON_CONTENT_SUBTYPES is a closed denylist, so every member needs its own "
+            "row -- without one, deleting this member from the set is a mutation the "
+            "suite cannot see."
+        ),
+        request=_events_api_request(
+            "env-deleted",
+            "Ev-deleted",
+            {
+                "type": "message",
+                "subtype": "message_deleted",
+                "channel": "D1",
+                "channel_type": "im",
+                "hidden": True,
+                "ts": "1808.0002",
+                "deleted_ts": "1808.0001",
+                "previous_message": {
+                    "type": "message",
+                    "user": "U9",
+                    "text": "never mind",
+                    "ts": "1808.0001",
+                },
+            },
+        ),
+    ),
+    Row(
+        name="dm_message_replied_is_not_content",
+        expected=DropReason.NON_CONTENT_SUBTYPE,
+        why=(
+            "Parent-message bookkeeping: Slack re-sends the PARENT, with its `message` "
+            "nested and `reply_count` bumped, when someone replies in its thread "
+            "(Slack: message subtype message_replied). The reply itself arrives as its "
+            "own event, so admitting this one would mint a second turn for text the "
+            "user sent once."
+        ),
+        request=_events_api_request(
+            "env-replied",
+            "Ev-replied",
+            {
+                "type": "message",
+                "subtype": "message_replied",
+                "channel": "D1",
+                "channel_type": "im",
+                "hidden": True,
+                "ts": "1809.0002",
+                "message": {
+                    "type": "message",
+                    "user": "U9",
+                    "text": "the parent message",
+                    "ts": "1809.0001",
+                    "thread_ts": "1809.0001",
+                    "reply_count": 1,
+                },
+            },
+        ),
+    ),
+    Row(
+        name="dm_tombstone_is_not_content",
+        expected=DropReason.NON_CONTENT_SUBTYPE,
+        why=(
+            "The marker Slack leaves where a threaded parent was removed (Slack: "
+            "message subtype tombstone). Its `text` is Slack's own chrome, not "
+            "something a person wrote, so admitting it would enqueue a turn whose "
+            "prompt Slack authored."
+        ),
+        request=_events_api_request(
+            "env-tombstone",
+            "Ev-tombstone",
+            {
+                "type": "message",
+                "subtype": "tombstone",
+                "channel": "D1",
+                "channel_type": "im",
+                "hidden": True,
+                "ts": "1810.0001",
+                "text": "This message was deleted.",
+            },
+        ),
+    ),
     # -- AC 3: bot identity. TWO DISTINCT IDS -- see the comments on each row --
     Row(
         name="mention_from_self_b1_is_dropped_by_bolt",
@@ -617,6 +735,27 @@ MATRIX: tuple[Row, ...] = (
             ),
         ),
     ),
+    Row(
+        name="mention_from_a_human_in_a_thread",
+        expected=Disposition.ENQUEUED,
+        why=(
+            "THE negative control for the loop guard above, and the mutation it exists "
+            "to kill. BOT_AUTHORED_THREAD_REPLY is bot-authored AND threaded; widening "
+            "it to every threaded mention would swallow the single most ordinary "
+            "inbound Curie has -- a person answering in the thread Curie is already "
+            "replying in. Without this row that mutation passes the whole file."
+        ),
+        request=_events_api_request(
+            "env-human-thread",
+            "Ev-human-thread",
+            _mention(
+                text="<@U0BOT> and what about staging",
+                thread_ts="1903.0001",
+                ts="1903.0002",
+            ),
+        ),
+        text_contains=("and what about staging",),
+    ),
     # -- AC 3: the DM lane ----------------------------------------------------
     Row(
         name="dm_from_a_human",
@@ -644,7 +783,78 @@ MATRIX: tuple[Row, ...] = (
         ),
         text_contains=("deploy finished, 3 warnings",),
     ),
+    Row(
+        name="dm_from_a_foreign_bot_in_a_thread",
+        expected=Disposition.ENQUEUED,
+        why=(
+            "The lane half of the same mutation. `relevance.classify` consults bot "
+            "authorship only when `lane == 'mention'`, because the cross-installation "
+            "mention loop is a mention-lane phenomenon. A bot-authored DM that happens "
+            "to be threaded -- an incoming webhook or Workflow Builder post answering "
+            "in an existing DM thread -- carries no such loop, so extending the guard "
+            "to this lane would be a brand-new silent drop that today's rows miss."
+        ),
+        request=_events_api_request(
+            "env-dm-bot-thread",
+            "Ev-dm-bot-thread",
+            _dm(
+                text="deploy rolled back",
+                bot_id="B2",
+                ts="1806.0003",
+                extra={"thread_ts": "1806.0002"},
+            ),
+        ),
+        text_contains=("deploy rolled back",),
+    ),
     # -- AC 3: envelope validation, dedupe, and the action lane ---------------
+    Row(
+        name="mention_without_a_channel_is_malformed",
+        expected=DropReason.MALFORMED_ENVELOPE,
+        why=(
+            "Slack stamps `channel` on every delivered app_mention (Slack: "
+            "docs.slack.dev/reference/events/app_mention), so a delivery without one "
+            "cannot be answered -- there is nowhere to post the placeholder. Reading it "
+            "as `event['channel']` used to raise AFTER `claim_event` succeeded: Bolt "
+            "had already acked and swallowed the exception, so the claim outlived a "
+            "turn that never existed and Slack's redelivery was then refused as an "
+            "already-seen delivery. The dedupe assertion below is the half that pins "
+            "validation ahead of the claim -- move the check back after `claim_event` "
+            "and this row fails on the burned key even though the log line is "
+            "unchanged."
+        ),
+        request=_events_api_request(
+            "env-no-channel", "Ev-no-channel", _mention_missing("channel", text="are we up")
+        ),
+        dedupe_id="Ev-no-channel",
+    ),
+    Row(
+        name="mention_without_a_thread_key_is_malformed",
+        expected=DropReason.MALFORMED_ENVELOPE,
+        why=(
+            "`ts` is the message's own timestamp and doubles as the thread key for a "
+            "root post (Slack: docs.slack.dev/reference/events/app_mention); a reply is "
+            "posted with `thread_ts` set to one or the other. With neither there is no "
+            "thread to answer in, and the blank key would become ONE conversation id "
+            "shared by every such delivery. Same ordering pin as the row above."
+        ),
+        request=_events_api_request(
+            "env-no-ts", "Ev-no-ts", _mention_missing("ts", text="are we up")
+        ),
+        dedupe_id="Ev-no-ts",
+    ),
+    Row(
+        name="event_without_an_event_id_is_malformed",
+        expected=DropReason.MALFORMED_ENVELOPE,
+        why=(
+            "`event_id` is the Events API wrapper's own identifier (Slack: "
+            "docs.slack.dev/apis/events-api, the event_callback envelope) and is the "
+            "idempotency key this adapter claims. A blank one would claim a single key "
+            "shared by every delivery that omits it, refusing all but the first as "
+            "duplicates -- so it is refused before the claim, leaving that key free."
+        ),
+        request=_events_api_request("env-no-id", "", _mention(text="are we up")),
+        dedupe_id="",
+    ),
     Row(
         name="message_outside_the_subscribed_lane",
         expected=DropReason.UNSUBSCRIBED_LANE,
@@ -724,6 +934,26 @@ MATRIX: tuple[Row, ...] = (
             trigger_id="trig-no-command",
         ),
         dedupe_id="action-trig-no-command",
+    ),
+    Row(
+        name="block_action_with_no_interaction_identity",
+        expected=DropReason.MALFORMED_ENVELOPE,
+        why=(
+            "The action lane's own malformed shape. Slack stamps `trigger_id` on the "
+            "payload and `action_ts` / `action_id` on each `actions` entry (Slack: "
+            "docs.slack.dev/reference/interaction-payloads/block-actions-payload). With "
+            "none of the three the synthesized key collapses to `action--`: ONE key "
+            "shared by every such click, so the first would burn it and every later "
+            "click -- from any user, on any card -- would be refused as an already-seen "
+            "delivery. This click names a command and addresses a real thread, so it "
+            "reaches the identity check rather than the two guards above it. Driven "
+            "directly -- see _DIRECT_DRIVER_NOTE: with no `action_id` key at all, "
+            "Bolt's catch-all matcher indexes `action['action_id']` and raises "
+            "KeyError, so no listener ever runs."
+        ),
+        driver=Driver.DIRECT_ACTION,
+        action_body=_anonymous_action_body(),
+        dedupe_id="action--",
     ),
 )
 
@@ -983,6 +1213,147 @@ def test_a_failed_enqueue_after_a_successful_placeholder_keeps_the_claim(
     assert redis_client.exists(config.dedupe_key("Ev-xadd")) == 1, (
         "the claim must be HELD after a successful placeholder: releasing it would "
         "let Slack's redelivery post a second placeholder in the same thread"
+    )
+
+
+# ---------------------------------------------------------------------------
+# The other half of the release rule: ONLY an unambiguous refusal releases
+# ---------------------------------------------------------------------------
+#
+# The three tests above all fail the placeholder with a `SlackApiError` carrying
+# a real Slack error code, which is the one case where the claim is released.
+# That is a narrow evidence claim, not "the call raised": Slack answered, named
+# its refusal, and delivered nothing, so a later retry is clean.
+#
+# Everything else is ambiguous and KEEPS the claim. Two shapes are pinned below.
+#
+#   * A transport failure (`SlackRequestError`, a timeout, a dropped connection)
+#     carries no answer from Slack at all -- the request may well have been
+#     accepted before the connection died.
+#   * `fatal_error` wears an error code but is not a refusal. Slack documents it
+#     on chat.postMessage as "The server could not complete your operation(s)
+#     without encountering a catastrophic error. It's possible some aspect of
+#     the operation succeeded before the error was raised."
+#     (Slack: docs.slack.dev/reference/methods/chat.postMessage, errors table.)
+#
+# In both cases a placeholder may already be sitting in the thread, so releasing
+# would let a replay post a SECOND one -- exactly the duplicate the
+# claim-before-placeholder ordering exists to prevent. Keeping the claim is the
+# quieter of two imperfect outcomes, and it is a deliberate choice rather than
+# the #2006 bug reappearing, which is why it is pinned here.
+
+
+def test_an_ambiguous_transport_failure_keeps_the_claim_on_the_event_lane(
+    redis_client: redis.Redis, config: DispatcherConfig
+) -> None:
+    """A failure with no answer from Slack must NOT release: the post may have
+    landed, and a released claim would let a replay post a second placeholder."""
+    boom = SlackRequestError("the connection died mid-request")
+    failing = _build_harness(config, redis_client, chat_post_message=_raising_post_message(boom))
+
+    failing.handler.handle(
+        failing.sock,
+        _events_api_request("env-transport", "Ev-transport", _mention(text="please answer")),
+    )
+    _drain(failing.app)
+
+    assert failing.sock.acked_envelope_ids == ["env-transport"]
+    assert len(failing.errors) == 1, failing.errors
+    assert _stream_entries(redis_client, config) == []
+    assert redis_client.exists(config.dedupe_key("Ev-transport")) == 1, (
+        "a transport failure released the dedupe claim: Slack never answered, so the "
+        "placeholder may already be in the thread and a replay would post a second one"
+    )
+
+    # The user-visible consequence of holding the claim, asserted rather than
+    # inferred from the key: a redelivery of the same event id is refused with an
+    # enumerated reason instead of posting into the thread a second time.
+    retry = _build_harness(config, redis_client)
+    retry.handler.handle(
+        retry.sock,
+        _events_api_request("env-transport-2", "Ev-transport", _mention(text="please answer")),
+    )
+    _drain(retry.app)
+
+    assert retry.errors == []
+    assert _stream_entries(redis_client, config) == []
+    assert _drop_reasons_logged(retry.records) == [DropReason.DUPLICATE_DELIVERY]
+
+
+def test_a_fatal_error_response_keeps_the_claim_on_the_event_lane(
+    redis_client: redis.Redis, config: DispatcherConfig
+) -> None:
+    """`fatal_error` is an error code, but Slack's own chat.postMessage docs say
+    "some aspect of the operation succeeded before the error was raised" -- so it
+    is an ambiguous outcome, and treating it as a refusal would release a claim
+    whose placeholder may already be visible."""
+    boom = SlackApiError("fatal_error", {"ok": False, "error": "fatal_error"})
+    failing = _build_harness(config, redis_client, chat_post_message=_raising_post_message(boom))
+
+    failing.handler.handle(
+        failing.sock,
+        _events_api_request("env-fatal", "Ev-fatal", _mention(text="please answer")),
+    )
+    _drain(failing.app)
+
+    assert len(failing.errors) == 1, failing.errors
+    assert _stream_entries(redis_client, config) == []
+    assert redis_client.exists(config.dedupe_key("Ev-fatal")) == 1, (
+        "`fatal_error` released the dedupe claim, but Slack documents it as possibly "
+        "having succeeded in part -- a replay could post a second placeholder"
+    )
+
+
+def test_an_ambiguous_transport_failure_keeps_the_claim_on_the_action_lane(
+    redis_client: redis.Redis, config: DispatcherConfig
+) -> None:
+    """The identical rule on the sibling mint site: `process_action` shares
+    `_post_placeholder`, and a lane-specific divergence here is this repo's
+    dominant drift shape."""
+    boom = SlackRequestError("the connection died mid-request")
+    failing = _build_harness(config, redis_client, chat_post_message=_raising_post_message(boom))
+
+    click = _block_action_body(
+        actions=[{"type": "button", "action_id": "reports", "action_ts": "1.5"}],
+        trigger_id="trig-transport",
+    )
+    failing.handler.handle(failing.sock, _interactive_request("env-click-transport", click))
+    _drain(failing.app)
+
+    assert len(failing.errors) == 1, failing.errors
+    assert _stream_entries(redis_client, config) == []
+    assert redis_client.exists(config.dedupe_key("action-trig-transport")) == 1, (
+        "a transport failure released the dedupe claim on the action lane"
+    )
+
+    retry = _build_harness(config, redis_client)
+    retry.handler.handle(retry.sock, _interactive_request("env-click-transport-2", click))
+    _drain(retry.app)
+
+    assert retry.errors == []
+    assert _stream_entries(redis_client, config) == []
+    assert _drop_reasons_logged(retry.records) == [DropReason.DUPLICATE_DELIVERY]
+
+
+def test_a_fatal_error_response_keeps_the_claim_on_the_action_lane(
+    redis_client: redis.Redis, config: DispatcherConfig
+) -> None:
+    """`fatal_error`'s ambiguity is a property of Slack's Web API, not of a lane,
+    so the action lane must hold its claim for exactly the same reason."""
+    boom = SlackApiError("fatal_error", {"ok": False, "error": "fatal_error"})
+    failing = _build_harness(config, redis_client, chat_post_message=_raising_post_message(boom))
+
+    click = _block_action_body(
+        actions=[{"type": "button", "action_id": "reports", "action_ts": "1.5"}],
+        trigger_id="trig-fatal",
+    )
+    failing.handler.handle(failing.sock, _interactive_request("env-click-fatal", click))
+    _drain(failing.app)
+
+    assert len(failing.errors) == 1, failing.errors
+    assert _stream_entries(redis_client, config) == []
+    assert redis_client.exists(config.dedupe_key("action-trig-fatal")) == 1, (
+        "`fatal_error` released the dedupe claim on the action lane"
     )
 
 

--- a/apps/dispatcher/tests/test_inbound_relevance.py
+++ b/apps/dispatcher/tests/test_inbound_relevance.py
@@ -1,0 +1,1011 @@
+"""The anti-silent-swallow matrix (#2006, AC 3) and the drop-reason contract (AC 2).
+
+Every row below is a realistic inbound Slack payload driven end to end through
+Bolt's real ``SocketModeHandler.handle``, exactly as ``test_dispatch.py`` does:
+real Valkey, real Bolt middleware chain, real listener thread pool. Only the
+Slack Web API client and the socket transport are faked.
+
+**What makes this an oracle rather than a smoke test** -- three properties, and
+losing any one of them turns the whole file into a test that passes while the
+adapter eats messages:
+
+1. Each row must end in exactly one of two visible dispositions: a new entry on
+   the Valkey stream, or exactly one log record from the *injected* dispatcher
+   logger naming a specific ``DropReason``. A row that produces **neither**
+   fails, and that failure is the whole point of the file -- "neither" is what
+   silent loss looks like from the outside.
+2. A ``@app.error`` collector records every listener/middleware exception, and
+   every matrix row asserts it saw **zero**. Bolt acks an Events API envelope
+   *before* it runs the listener body and then routes the body's exception to
+   this handler (``slack_bolt/listener/thread_runner.py``,
+   ``ThreadListenerRunner.run``; ``slack_bolt/app/app.py``, ``App.dispatch``'s
+   outer ``except``). Without this collector, an exception after the ack is
+   indistinguishable from a silent drop -- neither enqueue nor drop log.
+3. The logger is **injected** (``register_handlers``'s existing ``logger``
+   parameter, forwarded by ``build_app``) and asserted on directly. ``caplog``
+   would depend on propagation out of Bolt's listener executor threads, which is
+   not a property this suite should rest on.
+
+Slack payload shapes below are cited to Slack's API reference, never to what the
+implementation happens to assume; framework claims are cited to the installed
+``slack_bolt`` source path.
+"""
+
+import logging
+import uuid
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+import redis
+from curie_dispatcher.app import build_app
+from curie_dispatcher.config import DispatcherConfig
+from curie_dispatcher.handlers import process_action
+from curie_dispatcher.queue import from_stream_fields
+from curie_dispatcher.relevance import DROP_RATIONALES, DropReason
+from slack_bolt import App
+from slack_bolt.adapter.socket_mode import SocketModeHandler
+from slack_sdk.errors import SlackApiError
+from slack_sdk.socket_mode.request import SocketModeRequest
+from slack_sdk.web import WebClient
+
+from .conftest import FakeSocketClient, _authorize
+from .test_dispatch import BOT_TS, _drain, _events_api_request
+
+# ---------------------------------------------------------------------------
+# Harness
+# ---------------------------------------------------------------------------
+
+
+class _RecordCollector(logging.Handler):
+    """Captures records off the injected logger, including from Bolt's executor
+    threads. ``list.append`` is atomic, and every assertion runs after
+    ``_drain``, so no extra locking is needed."""
+
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+
+@dataclass
+class Harness:
+    """One Bolt app plus the two collectors the oracle rests on."""
+
+    app: App
+    web_client: WebClient
+    sock: FakeSocketClient
+    handler: SocketModeHandler
+    #: The logger injected into ``register_handlers`` -- the one every drop the
+    #: adapter logs must land on. Held here so the direct-driver rows can pass
+    #: the same logger the Bolt-driven rows assert against.
+    logger: logging.Logger
+    records: list[logging.LogRecord]
+    errors: list[BaseException]
+
+
+def _build_harness(
+    config: DispatcherConfig,
+    redis_client: redis.Redis,
+    *,
+    chat_post_message: Any | None = None,
+) -> Harness:
+    """A dispatcher app wired for observation: injected logger + error collector.
+
+    ``build_app`` forwards ``logger`` straight into ``register_handlers``, which
+    hands it to ``process_event`` / ``process_action``, so every drop the adapter
+    logs lands in this harness's ``records`` and nowhere else (``propagate`` is
+    off, and the logger name is unique per harness so rows cannot cross-talk).
+    """
+    web_client = WebClient(token="xoxb-test")
+    post_message: Any = chat_post_message or MagicMock(return_value={"ts": BOT_TS})
+    web_client.chat_postMessage = post_message  # type: ignore[method-assign]
+
+    collector = _RecordCollector()
+    logger = logging.getLogger(f"curie_dispatcher.test.{uuid.uuid4().hex}")
+    logger.setLevel(logging.DEBUG)
+    logger.propagate = False
+    logger.addHandler(collector)
+
+    app = build_app(
+        config,
+        web_client=web_client,
+        redis_client=redis_client,
+        authorize=_authorize,
+        logger=logger,
+    )
+
+    errors: list[BaseException] = []
+
+    # Bolt routes both listener-body exceptions (ThreadListenerRunner.run) and
+    # dispatch-level exceptions (App.dispatch's outer except -> the middleware
+    # error handler) to the function registered here. `App.error` installs it as
+    # BOTH handlers, so this list sees every framework-swallowed failure.
+    @app.error
+    def _collect_error(error: Exception) -> None:
+        errors.append(error)
+
+    return Harness(
+        app=app,
+        web_client=web_client,
+        sock=FakeSocketClient(),
+        handler=SocketModeHandler(app, app_token="xapp-test"),
+        logger=logger,
+        records=collector.records,
+        errors=errors,
+    )
+
+
+def _drop_reasons_logged(records: list[logging.LogRecord]) -> list[DropReason]:
+    """Every ``DropReason`` named by a record on the injected logger.
+
+    Tolerant of the exact log format on purpose: the contract is "the reason is
+    named", not "the reason is formatted this way". Matches on the member's
+    value or its name so a ``StrEnum`` declared with either explicit values or
+    ``auto()`` satisfies it.
+    """
+    found: list[DropReason] = []
+    for record in records:
+        text = record.getMessage().lower()
+        for reason in DropReason:
+            if str(reason.value).lower() in text or reason.name.lower() in text:
+                found.append(reason)
+                break
+    return found
+
+
+def _stream_entries(redis_client: redis.Redis, config: DispatcherConfig) -> list[Any]:
+    return list(redis_client.xrange(config.stream))
+
+
+# ---------------------------------------------------------------------------
+# Payload builders -- shapes cited to Slack's API reference
+# ---------------------------------------------------------------------------
+
+
+def _alert_blocks() -> list[dict[str, Any]]:
+    """An alert-shaped Block Kit body: the #2006 case.
+
+    A post built from blocks carries an empty or near-empty top-level ``text``;
+    Slack documents ``text`` as a fallback for notifications, not as the body
+    (Slack: "Blocks" reference, docs.slack.dev/reference/block-kit/blocks, and
+    "Creating rich message layouts"). Block shapes below:
+    ``header`` (plain_text), ``section`` with ``fields`` (mrkdwn text objects),
+    ``rich_text`` with ``rich_text_section`` elements of type ``text`` /
+    ``link`` / ``emoji`` / ``user``, and ``context`` with a mrkdwn element.
+    """
+    return [
+        {"type": "header", "text": {"type": "plain_text", "text": "Disk usage critical"}},
+        {
+            "type": "section",
+            "fields": [
+                {"type": "mrkdwn", "text": "*Host*\nweb-01"},
+                {"type": "mrkdwn", "text": "*Usage*\n97 percent"},
+            ],
+        },
+        {
+            "type": "rich_text",
+            "elements": [
+                {
+                    "type": "rich_text_section",
+                    "elements": [
+                        {"type": "text", "text": "runbook at "},
+                        {"type": "link", "url": "https://example.invalid/runbook"},
+                        {"type": "emoji", "name": "rotating_light"},
+                        {"type": "user", "user_id": "U123"},
+                    ],
+                }
+            ],
+        },
+        {
+            "type": "context",
+            "elements": [{"type": "mrkdwn", "text": "fired by prometheus"}],
+        },
+    ]
+
+
+BLOCK_CONTENT = (
+    "Disk usage critical",
+    "web-01",
+    "97 percent",
+    "runbook at",
+    "https://example.invalid/runbook",
+    ":rotating_light:",
+    "<@U123>",
+    "fired by prometheus",
+)
+
+
+def _alert_attachments() -> list[dict[str, Any]]:
+    """Legacy secondary-content attachments (Slack: "Secondary message
+    attachments", docs.slack.dev/messaging/formatting-message-text). The fields
+    exercised are the documented ones an alert integration populates: ``pretext``,
+    ``title``, ``text``, ``fields[].title`` / ``fields[].value``, ``footer`` --
+    plus ``fallback``, which Slack defines as the plain-text summary shown where
+    the attachment cannot render.
+    """
+    return [
+        {
+            "color": "#d00000",
+            "pretext": "Alert from Grafana",
+            "title": "Latency SLO burn",
+            "text": "p99 is 3.2s over the last 5m",
+            "fields": [{"title": "Service", "value": "checkout-api", "short": True}],
+            "footer": "grafana",
+            "fallback": "SUMMARY-ONLY-FALLBACK",
+        }
+    ]
+
+
+ATTACHMENT_CONTENT = (
+    "Alert from Grafana",
+    "Latency SLO burn",
+    "p99 is 3.2s over the last 5m",
+    "Service",
+    "checkout-api",
+    "grafana",
+)
+
+
+def _mention(
+    *,
+    text: str = "",
+    blocks: list[dict[str, Any]] | None = None,
+    attachments: list[dict[str, Any]] | None = None,
+    bot_id: str | None = None,
+    thread_ts: str | None = None,
+    ts: str = "1700.0001",
+) -> dict[str, Any]:
+    """An ``app_mention`` event (Slack: docs.slack.dev/reference/events/app_mention)."""
+    event: dict[str, Any] = {"type": "app_mention", "channel": "C123", "text": text, "ts": ts}
+    if bot_id is None:
+        event["user"] = "U123"
+    else:
+        # A bot-authored post carries ``bot_id`` and no ``user``; Slack documents
+        # ``bot_id`` on messages posted by apps/incoming webhooks.
+        event["bot_id"] = bot_id
+    if blocks is not None:
+        event["blocks"] = blocks
+    if attachments is not None:
+        event["attachments"] = attachments
+    if thread_ts is not None:
+        event["thread_ts"] = thread_ts
+    return event
+
+
+def _dm(
+    *,
+    text: str = "hello bot",
+    subtype: str | None = None,
+    bot_id: str | None = None,
+    channel_type: str = "im",
+    ts: str = "1800.0001",
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """A ``message`` event on the DM lane (Slack: docs.slack.dev/reference/events/message.im).
+
+    ``channel_type`` is the field Slack stamps on the delivered ``message``
+    envelope; ``im`` is the direct-message lane the app manifest subscribes to.
+    """
+    event: dict[str, Any] = {
+        "type": "message",
+        "channel_type": channel_type,
+        "channel": "D1",
+        "text": text,
+        "ts": ts,
+    }
+    if bot_id is None:
+        event["user"] = "U9"
+    else:
+        event["bot_id"] = bot_id
+    if subtype is not None:
+        event["subtype"] = subtype
+    if extra:
+        event.update(extra)
+    return event
+
+
+def _block_action_body(
+    *,
+    actions: list[dict[str, Any]],
+    trigger_id: str,
+    with_channel: bool = True,
+) -> dict[str, Any]:
+    """A ``block_actions`` interaction payload (Slack: docs.slack.dev/reference/
+    interaction-payloads/block-actions-payload)."""
+    body: dict[str, Any] = {
+        "type": "block_actions",
+        "trigger_id": trigger_id,
+        "team": {"id": "T1"},
+        "user": {"id": "U123"},
+        "api_app_id": "A1",
+        "token": "verif",
+        "actions": actions,
+    }
+    if with_channel:
+        body["container"] = {"type": "message", "message_ts": "1700.0001"}
+        body["channel"] = {"id": "C123"}
+        body["message"] = {"ts": "1700.0001", "thread_ts": "1700.0001"}
+    else:
+        # An App Home / modal click: container is a view, and the payload carries
+        # neither ``channel`` nor ``message``, so there is no thread to answer in.
+        body["container"] = {"type": "view", "view_id": "V1"}
+        body["view"] = {"id": "V1", "type": "home"}
+    return body
+
+
+def _interactive_request(envelope_id: str, payload: dict[str, Any]) -> SocketModeRequest:
+    return SocketModeRequest(type="interactive", envelope_id=envelope_id, payload=payload)
+
+
+# ---------------------------------------------------------------------------
+# The matrix
+# ---------------------------------------------------------------------------
+
+
+class Disposition(Enum):
+    """The two non-``DropReason`` outcomes a row may declare."""
+
+    ENQUEUED = "enqueued"
+    #: Refused by Bolt ABOVE our listeners. Not our code's drop -- see the B1 row.
+    DROPPED_BY_BOLT = "dropped_by_bolt"
+
+
+class Driver(Enum):
+    BOLT = "bolt"
+    #: Driven by calling ``process_action`` directly. Used ONLY where Bolt's own
+    #: catch-all matcher provably cannot deliver the payload to a listener; see
+    #: ``_DIRECT_DRIVER_NOTE``.
+    DIRECT_ACTION = "direct_action"
+
+
+_DIRECT_DRIVER_NOTE = """
+Two rows cannot be driven through Bolt, and the reason is in Bolt's matcher, not
+in our code. ``register_handlers`` registers the catch-all as
+``@app.action(re.compile(r".+"))``. Bolt resolves that against the first action
+in the payload (``slack_bolt/listener_matcher/builtins.py``, ``_block_action``:
+``action = to_action(body)`` then ``_matches(pattern, action["action_id"])``,
+with ``to_action`` returning ``body["actions"][0]``). Therefore:
+
+  * ``actions: []`` -> ``to_action`` raises ``IndexError`` inside the matcher,
+    which ``App.dispatch``'s outer ``except`` turns into a framework error. No
+    listener ever runs, so ``NO_ACTION_IN_PAYLOAD`` is unreachable end to end.
+  * an action whose ``action_id`` is ``""`` (and which carries no ``value``) ->
+    ``re.compile(r".+").search("")`` is ``None``, so the matcher returns False
+    and no listener runs. ``EMPTY_ACTION_COMMAND`` is likewise unreachable.
+
+Both guards are still live defence inside ``process_action`` (a second listener,
+a matcher change, or a direct caller reaches them), and the ticket's contract
+requires every ``DropReason`` to be exercised -- so these two rows call
+``process_action`` directly. They still assert only user-visible outcomes: no
+stream entry, exactly one logged reason, and no dedupe key burned.
+"""
+
+
+@dataclass(frozen=True)
+class Row:
+    """One inbound payload plus the disposition the adapter owes it."""
+
+    name: str
+    expected: Disposition | DropReason
+    #: Why this row expects what it expects -- printed in every failure message.
+    why: str
+    request: SocketModeRequest | None = None
+    action_body: dict[str, Any] | None = None
+    driver: Driver = Driver.BOLT
+    #: Delivered first, on a SEPARATE app, so the asserted delivery is measured
+    #: in isolation (``_drain`` shuts an executor down permanently).
+    prime: SocketModeRequest | None = None
+    text_contains: tuple[str, ...] = ()
+    text_not_contains: tuple[str, ...] = ()
+    dedupe_id: str | None = None
+
+
+MATRIX: tuple[Row, ...] = (
+    # -- AC 1: bodies that are empty at the top level but carry real content ---
+    Row(
+        name="mention_block_kit_body_only",
+        expected=Disposition.ENQUEUED,
+        why=(
+            "AC 1, the ticket's headline defect: an alert-shaped Block Kit post has "
+            "text='' and its content in `blocks`. On the current code this enqueues a "
+            "turn with empty text -- the message is emptied, not dropped."
+        ),
+        request=_events_api_request(
+            "env-blocks", "Ev-blocks", _mention(text="", blocks=_alert_blocks())
+        ),
+        text_contains=BLOCK_CONTENT,
+    ),
+    Row(
+        name="mention_attachments_body_only",
+        expected=Disposition.ENQUEUED,
+        why=(
+            "AC 1 on the attachment-shaped variant. `fallback` must NOT appear: Slack "
+            "defines it as the summary used where the attachment cannot render, so it "
+            "duplicates content that was already emitted."
+        ),
+        request=_events_api_request(
+            "env-attach", "Ev-attach", _mention(text="", attachments=_alert_attachments())
+        ),
+        text_contains=ATTACHMENT_CONTENT,
+        text_not_contains=("SUMMARY-ONLY-FALLBACK",),
+    ),
+    Row(
+        name="mention_whitespace_text_with_blocks",
+        expected=Disposition.ENQUEUED,
+        why=(
+            "'   ' is truthy in Python, so a whitespace-only `text` must not be mistaken "
+            "for a real body; the block content is what reaches the model."
+        ),
+        request=_events_api_request(
+            "env-ws", "Ev-ws", _mention(text="   ", blocks=_alert_blocks())
+        ),
+        text_contains=("Disk usage critical",),
+    ),
+    # -- AC 3: the open-world subtype inversion (D3) --------------------------
+    Row(
+        name="dm_file_share_with_comment",
+        expected=Disposition.ENQUEUED,
+        why=(
+            "`file_share` is a real user message: a person uploaded a file WITH a "
+            "comment (Slack: docs.slack.dev/reference/events/message, subtypes). The "
+            "current blanket 'any subtype drops' filter swallows it unlogged."
+        ),
+        request=_events_api_request(
+            "env-file",
+            "Ev-file",
+            _dm(
+                text="here is the incident report",
+                subtype="file_share",
+                extra={"files": [{"id": "F1", "title": "incident.pdf", "name": "incident.pdf"}]},
+            ),
+        ),
+        text_contains=("here is the incident report",),
+    ),
+    Row(
+        name="dm_thread_broadcast",
+        expected=Disposition.ENQUEUED,
+        why=(
+            "`thread_broadcast` is a human thread reply also sent to the conversation "
+            "(Slack: message subtypes). It is content, not lifecycle."
+        ),
+        request=_events_api_request(
+            "env-broadcast",
+            "Ev-broadcast",
+            _dm(
+                text="also sending this to the channel",
+                subtype="thread_broadcast",
+                ts="1801.0002",
+                extra={"thread_ts": "1801.0001"},
+            ),
+        ),
+        text_contains=("also sending this to the channel",),
+    ),
+    Row(
+        name="dm_unknown_future_subtype",
+        expected=Disposition.ENQUEUED,
+        why=(
+            "THE row that proves the open-world inversion (D3). Slack keeps adding "
+            "subtypes; an unknown one must reach routing rather than be denied by a "
+            "filter that denies an open set. Bolt's message matcher is type-only and "
+            "subtype-blind (slack_bolt/listener_matcher/builtins.py, event matching), "
+            "so every message.im subtype does reach our listener."
+        ),
+        request=_events_api_request(
+            "env-future",
+            "Ev-future",
+            _dm(text="a subtype nobody has shipped yet", subtype="some_future_subtype"),
+        ),
+        text_contains=("a subtype nobody has shipped yet",),
+    ),
+    Row(
+        name="dm_message_changed_is_not_content",
+        expected=DropReason.NON_CONTENT_SUBTYPE,
+        why=(
+            "An edit of an existing message: the payload nests the edited `message` and "
+            "`previous_message` and carries no new user request (Slack: message_changed)."
+        ),
+        request=_events_api_request(
+            "env-changed",
+            "Ev-changed",
+            {
+                "type": "message",
+                "subtype": "message_changed",
+                "channel": "D1",
+                "channel_type": "im",
+                "ts": "1802.0002",
+                "message": {"type": "message", "user": "U9", "text": "edited", "ts": "1802.0001"},
+                "previous_message": {
+                    "type": "message",
+                    "user": "U9",
+                    "text": "original",
+                    "ts": "1802.0001",
+                },
+            },
+        ),
+    ),
+    Row(
+        name="dm_ekm_access_denied_is_not_content",
+        expected=DropReason.NON_CONTENT_SUBTYPE,
+        why=(
+            "Enterprise Key Management redacted the body, so there is no request to "
+            "answer; admitting it would mint an empty turn (Slack: ekm_access_denied)."
+        ),
+        request=_events_api_request(
+            "env-ekm", "Ev-ekm", _dm(text="", subtype="ekm_access_denied", ts="1803.0001")
+        ),
+    ),
+    Row(
+        name="dm_assistant_app_thread_is_not_content",
+        expected=DropReason.NON_CONTENT_SUBTYPE,
+        why=(
+            "A thread-start marker carrying assistant metadata rather than user content "
+            "(Slack: message subtype assistant_app_thread). Curie enables assistant "
+            "functionality, so this needs an explicit disposition rather than riding the "
+            "unknown/future rule."
+        ),
+        request=_events_api_request(
+            "env-assist",
+            "Ev-assist",
+            _dm(
+                text="",
+                subtype="assistant_app_thread",
+                ts="1804.0001",
+                extra={"assistant_app_thread": {"title": "New chat"}},
+            ),
+        ),
+    ),
+    # -- AC 3: bot identity. TWO DISTINCT IDS -- see the comments on each row --
+    Row(
+        name="mention_from_self_b1_is_dropped_by_bolt",
+        expected=Disposition.DROPPED_BY_BOLT,
+        why=(
+            "UPSTREAM FRAMEWORK BEHAVIOR -- THIS ROW DOES NOT EXERCISE OUR CODE. "
+            "`bot_id: 'B1'` is the SAME identity conftest._authorize returns "
+            "(AuthorizeResult(bot_id='B1', bot_user_id='U0BOT')), so this is a "
+            "self-authored event. slack_bolt's IgnoringSelfEvents middleware "
+            "(slack_bolt/middleware/ignoring_self_events/ignoring_self_events.py: "
+            "`bot_id == auth_result.bot_id` -> `req.context.ack()` with no `next()`) "
+            "acks the envelope and returns BEFORE any listener runs, logging its reason "
+            "at DEBUG only. That middleware is the real self-loop guard, and it is why "
+            "the adapter's blanket DM bot filter is deleted. The assertion here is "
+            "therefore 'no enqueue, no listener invoked, no error' -- attributed to "
+            "slack_bolt, not claimed as a drop of ours."
+        ),
+        request=_events_api_request(
+            "env-self", "Ev-self", _mention(text="Working on it.", bot_id="B1", ts="1900.0001")
+        ),
+    ),
+    Row(
+        name="mention_from_foreign_bot_b2_at_root",
+        expected=Disposition.ENQUEUED,
+        why=(
+            "`B2` is a FOREIGN alert bot -- a different identity from the authorized "
+            "`B1`, so IgnoringSelfEvents passes it through and our code decides. D4: a "
+            "bot-authored mention at ROOT (no thread_ts) is the ticket's case (an alert "
+            "bot @-mentioning Curie) and must reach routing."
+        ),
+        request=_events_api_request(
+            "env-b2-root",
+            "Ev-b2-root",
+            _mention(text="<@U0BOT> disk is full on web-01", bot_id="B2", ts="1901.0001"),
+        ),
+        text_contains=("disk is full on web-01",),
+    ),
+    Row(
+        name="mention_from_foreign_bot_b2_in_thread",
+        expected=DropReason.BOT_AUTHORED_THREAD_REPLY,
+        why=(
+            "D4's cross-installation loop guard. Curie's own replies and placeholders "
+            "are ALWAYS threaded, so two Curie installations in one workspace could "
+            "mention-loop each other indefinitely; Bolt's self filter cannot stop that "
+            "because the two bot identities differ. Root-only admission separates the "
+            "ticket's case from the loop with no schema change."
+        ),
+        request=_events_api_request(
+            "env-b2-thread",
+            "Ev-b2-thread",
+            _mention(
+                text="<@U0BOT> replying in your thread",
+                bot_id="B2",
+                thread_ts="1902.0001",
+                ts="1902.0002",
+            ),
+        ),
+    ),
+    # -- AC 3: the DM lane ----------------------------------------------------
+    Row(
+        name="dm_from_a_human",
+        expected=Disposition.ENQUEUED,
+        why="The baseline DM lane: a person messaging the bot directly (message.im).",
+        request=_events_api_request(
+            "env-dm", "Ev-dm", _dm(text="what is our error rate", ts="1805.0001")
+        ),
+        text_contains=("what is our error rate",),
+    ),
+    Row(
+        name="dm_from_a_foreign_bot",
+        expected=Disposition.ENQUEUED,
+        why=(
+            "D4/R2: the blanket DM bot filter is DELETED. Incoming webhooks, Workflow "
+            "Builder posts and other apps all reach Curie as bot-authored `message.im` "
+            "events, and discarding them was a real silent loss. Self-authored DMs are "
+            "still dropped upstream by IgnoringSelfEvents -- which is exactly why the "
+            "id here is `B2` and not `B1`."
+        ),
+        request=_events_api_request(
+            "env-dm-bot",
+            "Ev-dm-bot",
+            _dm(text="deploy finished, 3 warnings", bot_id="B2", ts="1806.0001"),
+        ),
+        text_contains=("deploy finished, 3 warnings",),
+    ),
+    # -- AC 3: envelope validation, dedupe, and the action lane ---------------
+    Row(
+        name="message_outside_the_subscribed_lane",
+        expected=DropReason.UNSUBSCRIBED_LANE,
+        why=(
+            "ENVELOPE VALIDATION, NOT A RELEVANCE DECISION. "
+            "`apps/dispatcher/slack-app-manifest.yaml` subscribes "
+            "`settings.event_subscriptions.bot_events` to exactly `app_mention` and "
+            "`message.im`, so a `message` whose channel_type is not `im` cannot "
+            "legitimately arrive in production; refusing it asserts the delivered "
+            "envelope matches the declared subscription surface. It also cannot move to "
+            "the routing seam even in principle: QueuedTurn carries no lane and no "
+            "subtype, and BindingResolver.resolve sees only (kind, channel). A burst on "
+            "this reason means the installed app is subscribed to something the manifest "
+            "does not declare -- not 'a chatty channel'."
+        ),
+        request=_events_api_request(
+            "env-chan",
+            "Ev-chan",
+            _dm(text="just chatting", channel_type="channel", ts="1807.0001"),
+        ),
+    ),
+    Row(
+        name="duplicate_redelivery_of_a_claimed_event",
+        expected=DropReason.DUPLICATE_DELIVERY,
+        why=(
+            "Slack redelivers an event when it does not see a timely ack. The first "
+            "delivery (driven on a SEPARATE app below, so this row's app sees only the "
+            "redelivery) claimed the dedupe key; the redelivery must be refused with an "
+            "enumerated reason rather than a bare log line."
+        ),
+        prime=_events_api_request("env-dup-1", "Ev-dup", _mention(text="first delivery")),
+        request=_events_api_request("env-dup-2", "Ev-dup", _mention(text="first delivery")),
+    ),
+    Row(
+        name="app_home_click_has_nowhere_to_reply",
+        expected=DropReason.UNADDRESSABLE_ACTION,
+        why=(
+            "An App Home / modal click arrives with `container.type == 'view'` and no "
+            "`channel` and no `message`, so no in-thread reply is possible. This drop "
+            "must stay AHEAD of the dedupe claim -- burning the key here would drop "
+            "Slack's redelivery too (test_dispatch.py pins that separately)."
+        ),
+        request=_interactive_request(
+            "env-home",
+            _block_action_body(
+                actions=[{"type": "button", "action_id": "reports", "action_ts": "1.5"}],
+                trigger_id="trig-home",
+                with_channel=False,
+            ),
+        ),
+        dedupe_id="action-trig-home",
+    ),
+    Row(
+        name="block_action_with_no_actions",
+        expected=DropReason.NO_ACTION_IN_PAYLOAD,
+        why=(
+            "A block-action payload carrying no actions names no command and addresses "
+            "nothing. Driven directly -- see _DIRECT_DRIVER_NOTE: Bolt's catch-all "
+            "matcher raises IndexError on `actions: []` before any listener runs."
+        ),
+        driver=Driver.DIRECT_ACTION,
+        action_body=_block_action_body(actions=[], trigger_id="trig-empty-actions"),
+        dedupe_id="action-trig-empty-actions",
+    ),
+    Row(
+        name="block_action_naming_no_command",
+        expected=DropReason.EMPTY_ACTION_COMMAND,
+        why=(
+            "A button carrying neither `value` nor a usable `action_id` names no command, "
+            "so there is nothing to enqueue as turn text. Driven directly -- see "
+            "_DIRECT_DRIVER_NOTE: `re.compile(r'.+').search('')` is None, so Bolt's "
+            "catch-all never matches this payload."
+        ),
+        driver=Driver.DIRECT_ACTION,
+        action_body=_block_action_body(
+            actions=[{"type": "button", "action_id": "", "value": "", "action_ts": "1.5"}],
+            trigger_id="trig-no-command",
+        ),
+        dedupe_id="action-trig-no-command",
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# The oracle
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("row", MATRIX, ids=[row.name for row in MATRIX])
+def test_every_inbound_payload_is_enqueued_or_refused_with_a_named_reason(
+    row: Row, redis_client: redis.Redis, config: DispatcherConfig
+) -> None:
+    """AC 3. Every row ends visibly: on the stream, or in the log naming a reason.
+
+    THIS ASSERTION CANNOT PASS VACUOUSLY, and that is the entire point of the
+    file. The "produced neither" branch fires first and names the row, so a
+    payload the adapter swallows in silence -- no stream entry, no drop log, no
+    exception -- fails here rather than looking like a clean pass. Deleting the
+    `enqueued or logged` check, or widening any expectation to "anything", is the
+    mutation this test exists to make impossible.
+    """
+    if row.prime is not None:
+        # The prime runs on its own app: `_drain` shuts an executor down for
+        # good, so the same app cannot handle a second delivery, and a shared one
+        # would blend the two deliveries' log records.
+        primer = _build_harness(config, redis_client)
+        primer.handler.handle(primer.sock, row.prime)
+        _drain(primer.app)
+        assert primer.errors == [], f"the priming delivery for {row.name!r} itself failed"
+        assert len(_stream_entries(redis_client, config)) == 1, "the prime must have enqueued"
+
+    before = len(_stream_entries(redis_client, config))
+    harness = _build_harness(config, redis_client)
+
+    if row.driver is Driver.BOLT:
+        assert row.request is not None
+        harness.handler.handle(harness.sock, row.request)
+        _drain(harness.app)
+        # Slack is told "received" either way; a drop is never a failed delivery.
+        assert harness.sock.acked_envelope_ids == [row.request.envelope_id], row.why
+    else:
+        assert row.action_body is not None
+        process_action(
+            body=row.action_body,
+            web_client=harness.web_client,
+            redis_client=redis_client,
+            config=config,
+            logger=harness.logger,
+        )
+        _drain(harness.app)
+
+    entries = _stream_entries(redis_client, config)
+    enqueued = len(entries) - before
+    logged = _drop_reasons_logged(harness.records)
+
+    # --- the anti-silent-swallow property -----------------------------------
+    if row.expected is not Disposition.DROPPED_BY_BOLT:
+        assert enqueued or logged, (
+            f"row {row.name!r} produced NEITHER a stream entry NOR a logged DropReason. "
+            f"That is a silent swallow -- the exact defect #2006 closes. Expected "
+            f"{row.expected}. Why this row exists: {row.why}"
+        )
+
+    # --- an exception after Bolt's ack looks identical to a silent drop ------
+    assert harness.errors == [], (
+        f"row {row.name!r} raised inside the listener: {harness.errors!r}. Bolt acks "
+        f"the envelope before running the body and swallows the exception into its own "
+        f"error handler, so this failure is invisible to the two checks above."
+    )
+
+    if row.expected is Disposition.ENQUEUED:
+        assert enqueued == 1, f"row {row.name!r} must enqueue exactly one turn. {row.why}"
+        assert logged == [], f"row {row.name!r} enqueued AND logged a drop: {logged}"
+        queued = from_stream_fields(entries[-1][1])
+        for fragment in row.text_contains:
+            assert fragment in queued.text, (
+                f"row {row.name!r}: enqueued turn text is missing {fragment!r}. "
+                f"Text was {queued.text!r}. {row.why}"
+            )
+        for fragment in row.text_not_contains:
+            assert fragment not in queued.text, (
+                f"row {row.name!r}: enqueued turn text must not contain {fragment!r}. "
+                f"Text was {queued.text!r}. {row.why}"
+            )
+    elif row.expected is Disposition.DROPPED_BY_BOLT:
+        assert enqueued == 0, f"row {row.name!r} must not enqueue. {row.why}"
+        assert harness.records == [], (
+            f"row {row.name!r} must be refused by slack_bolt BEFORE any listener runs, "
+            f"so the dispatcher's own logger must have recorded nothing at all. "
+            f"Records: {[r.getMessage() for r in harness.records]}. {row.why}"
+        )
+    else:
+        assert enqueued == 0, f"row {row.name!r} must not enqueue. {row.why}"
+        assert logged == [row.expected], (
+            f"row {row.name!r} must log exactly one drop naming {row.expected}; "
+            f"logged {logged}. Messages: {[r.getMessage() for r in harness.records]}. "
+            f"{row.why}"
+        )
+
+    if row.dedupe_id is not None:
+        # These rows refuse BEFORE the idempotency claim, so no key may be burned:
+        # a burned key would linger for the TTL and drop Slack's redelivery too.
+        assert redis_client.exists(config.dedupe_key(row.dedupe_id)) == 0, row.why
+
+
+def test_a_non_empty_top_level_text_is_enqueued_byte_identically(
+    redis_client: redis.Redis, config: DispatcherConfig
+) -> None:
+    """The negative control for AC 1: derivation must not fire when it must not.
+
+    Slack sends the `<@U0BOT>` mention markup inside `text`, and the worker's own
+    mention handling depends on it surviving. If the derivation rewrote, joined,
+    stripped or re-ordered a message that already had a body, every existing
+    enqueue would silently change meaning -- so this asserts byte identity,
+    including the surrounding whitespace, rather than "contains".
+    """
+    original = "  <@U0BOT> deploy prod  "
+    harness = _build_harness(config, redis_client)
+    harness.handler.handle(
+        harness.sock,
+        _events_api_request(
+            "env-identity", "Ev-identity", _mention(text=original, blocks=_alert_blocks())
+        ),
+    )
+    _drain(harness.app)
+
+    assert harness.errors == []
+    entries = _stream_entries(redis_client, config)
+    assert len(entries) == 1
+    assert from_stream_fields(entries[0][1]).text == original
+
+
+# ---------------------------------------------------------------------------
+# The claim-release regression (EB-20 / EB-21 / EB-22)
+# ---------------------------------------------------------------------------
+#
+# HONEST CAVEAT, recorded so nobody reads more into these three tests than they
+# prove. In Socket Mode, Bolt acks the envelope BEFORE running the listener body
+# (slack_bolt/listener/thread_runner.py, ThreadListenerRunner.run: `ack()` is
+# called for auto-acknowledged Events API listeners, then the body is submitted
+# to the executor). Slack has therefore already been told "received", so a Slack
+# redelivery of the failed event is RARE -- it is not the normal consequence of
+# the listener raising. Releasing the claim restores idempotency *correctness*:
+# the adapter no longer holds a dedupe claim for work it never did, so any later
+# delivery of that event id -- a Slack retry, a replay, an operator-driven
+# re-send -- can still be processed. It is not a guarantee that every failed
+# placeholder is recovered.
+
+
+def _raising_post_message(exc: BaseException) -> Any:
+    def _raise(**_kwargs: object) -> None:
+        raise exc
+
+    return _raise
+
+
+def test_a_failed_placeholder_releases_the_claim_on_the_event_lane(
+    redis_client: redis.Redis, config: DispatcherConfig
+) -> None:
+    """`claim_event` runs before `chat_postMessage`; if the post raises, the key
+    must not stay claimed, or the event is terminally lost -- #2006's own class."""
+    boom = SlackApiError("ratelimited", {"ok": False, "error": "ratelimited"})
+    failing = _build_harness(config, redis_client, chat_post_message=_raising_post_message(boom))
+
+    failing.handler.handle(
+        failing.sock, _events_api_request("env-boom", "Ev-boom", _mention(text="please answer"))
+    )
+    _drain(failing.app)
+
+    # Bolt acked first and then swallowed the exception into its error handler:
+    # without this collector the failure is invisible from the outside.
+    assert failing.sock.acked_envelope_ids == ["env-boom"]
+    assert len(failing.errors) == 1, failing.errors
+    assert _stream_entries(redis_client, config) == []
+
+    # (a) The claim was released.
+    assert redis_client.exists(config.dedupe_key("Ev-boom")) == 0, (
+        "the dedupe claim survived a failed placeholder, so any later delivery of "
+        "Ev-boom is refused as a duplicate and the message is lost for good"
+    )
+
+    # (b) A redelivery of the SAME event id now succeeds.
+    retry = _build_harness(config, redis_client)
+    retry.handler.handle(
+        retry.sock, _events_api_request("env-boom-2", "Ev-boom", _mention(text="please answer"))
+    )
+    _drain(retry.app)
+
+    assert retry.errors == []
+    entries = _stream_entries(redis_client, config)
+    assert len(entries) == 1
+    assert from_stream_fields(entries[0][1]).text == "please answer"
+
+
+def test_a_failed_placeholder_releases_the_claim_on_the_action_lane(
+    redis_client: redis.Redis, config: DispatcherConfig
+) -> None:
+    """The identical defect on the sibling mint site. `process_action` claims and
+    posts in the same order, so fixing one lane and not its twin would leave
+    button clicks silently lost -- this repo's dominant drift shape."""
+    boom = SlackApiError("ratelimited", {"ok": False, "error": "ratelimited"})
+    failing = _build_harness(config, redis_client, chat_post_message=_raising_post_message(boom))
+
+    click = _block_action_body(
+        actions=[{"type": "button", "action_id": "reports", "action_ts": "1.5"}],
+        trigger_id="trig-boom",
+    )
+    failing.handler.handle(failing.sock, _interactive_request("env-click-boom", click))
+    _drain(failing.app)
+
+    assert len(failing.errors) == 1, failing.errors
+    assert _stream_entries(redis_client, config) == []
+    assert redis_client.exists(config.dedupe_key("action-trig-boom")) == 0, (
+        "the dedupe claim survived a failed placeholder on the action lane"
+    )
+
+    retry = _build_harness(config, redis_client)
+    retry.handler.handle(retry.sock, _interactive_request("env-click-retry", click))
+    _drain(retry.app)
+
+    assert retry.errors == []
+    entries = _stream_entries(redis_client, config)
+    assert len(entries) == 1
+    assert from_stream_fields(entries[0][1]).text == "reports"
+
+
+def test_a_failed_enqueue_after_a_successful_placeholder_keeps_the_claim(
+    redis_client: redis.Redis, config: DispatcherConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The deliberate asymmetry, pinned so a later 'consistency' refactor fails.
+
+    Once the placeholder is posted, something user-visible has happened. Releasing
+    the claim at that point would let a redelivery post a SECOND placeholder into
+    the same thread -- trading an invisible failure for a visible, confusing one.
+    So the release is legitimate only before any user-visible side effect.
+
+    The broker failure is forced on the real Valkey client rather than faked:
+    nothing about Valkey's behavior is mocked, one call is made to raise.
+    """
+    post_message = MagicMock(return_value={"ts": BOT_TS})
+    harness = _build_harness(config, redis_client, chat_post_message=post_message)
+
+    def _xadd_fails(*_args: object, **_kwargs: object) -> str:
+        raise redis.RedisError("stream unavailable")
+
+    monkeypatch.setattr(redis_client, "xadd", _xadd_fails)
+
+    harness.handler.handle(
+        harness.sock, _events_api_request("env-xadd", "Ev-xadd", _mention(text="hello"))
+    )
+    _drain(harness.app)
+
+    assert len(harness.errors) == 1, harness.errors
+    # The placeholder DID reach the channel; the user has already seen it.
+    assert post_message.call_count == 1
+    assert redis_client.exists(config.dedupe_key("Ev-xadd")) == 1, (
+        "the claim must be HELD after a successful placeholder: releasing it would "
+        "let Slack's redelivery post a second placeholder in the same thread"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC 2 -- the drop contract
+# ---------------------------------------------------------------------------
+
+
+def test_every_drop_reason_carries_a_documented_rationale() -> None:
+    """A reason with no documented rationale is exactly the undocumented drop
+    AC 2 forbids, so the mapping is asserted total in both directions."""
+    assert set(DROP_RATIONALES) == set(DropReason), (
+        "DROP_RATIONALES must have one entry per DropReason and no orphans"
+    )
+    for reason in DropReason:
+        assert DROP_RATIONALES[reason].strip(), f"{reason} has an empty rationale"
+
+
+def test_every_drop_reason_is_exercised_by_a_matrix_row() -> None:
+    """The mechanical half of AC 2: adding a DropReason without adding a matrix
+    row for it fails the suite, so a new adapter-level refusal cannot ship
+    without an end-to-end demonstration of what it refuses and why."""
+    exercised = {row.expected for row in MATRIX if isinstance(row.expected, DropReason)}
+    missing = set(DropReason) - exercised
+    assert not missing, f"DropReason members with no matrix row: {sorted(missing)}"
+    assert exercised == set(DropReason)

--- a/apps/dispatcher/tests/test_inbound_text.py
+++ b/apps/dispatcher/tests/test_inbound_text.py
@@ -1,0 +1,568 @@
+"""Pure unit tests for the Slack inbound-text walker (`inbound_text.derive_text`, D1).
+
+No Bolt, no Valkey, no network -- ``inbound_text`` is stdlib-only and these
+tests exercise it directly with plain dict fixtures. The end-to-end Block Kit
+regression driven through Bolt lives in ``test_inbound_relevance.py`` (Stream
+B); this file is the walker's own behavior table: byte-identical top-level
+passthrough, block/attachment/file derivation, the UI-chrome key denylist,
+the three traversal bounds, and every degenerate input D1 specifies.
+
+Every assertion about a Slack event, block, or attachment shape is grounded in
+a comment citing Slack's own reference docs -- never in an assumption about
+what the walker will do.
+"""
+
+from typing import Any
+
+import pytest
+from curie_dispatcher.inbound_text import _MAX_CHARS, _MAX_DEPTH, _MAX_NODES, derive_text
+
+
+def _wrap_in_depth(inner: Any, levels: int) -> Any:
+    """Nest ``inner`` inside ``levels`` single-item lists.
+
+    A list is one of the two generic recursion containers D1 names ("recurse
+    into dict values and list items"), so this is a container-agnostic way to
+    push a leaf node past ``_MAX_DEPTH`` without depending on which block type
+    the implementation happens to nest through.
+    """
+    node = inner
+    for _ in range(levels):
+        node = [node]
+    return node
+
+
+# ---------------------------------------------------------------------------
+# Top-level text: byte-identical passthrough, whitespace-only falls through
+# ---------------------------------------------------------------------------
+
+
+def test_nonempty_top_level_text_is_returned_byte_identical() -> None:
+    # https://docs.slack.dev/reference/events/app_mention -- the event's
+    # top-level ``text`` carries the message body verbatim, including
+    # ``<@U…>`` mention markup the worker relies on for addressing, and any
+    # leading/trailing whitespace the user actually sent.
+    event: dict[str, Any] = {
+        "type": "app_mention",
+        "text": "  <@U123> please look at this  ",
+        "blocks": [
+            {"type": "section", "text": {"type": "mrkdwn", "text": "SHOULD_NOT_APPEAR"}},
+        ],
+        "attachments": [{"text": "SHOULD_NOT_APPEAR_EITHER"}],
+    }
+    assert derive_text(event) == "  <@U123> please look at this  "
+
+
+def test_whitespace_only_top_level_text_falls_through_to_blocks() -> None:
+    # https://docs.slack.dev/reference/events/app_mention -- an alert-style
+    # app_mention with an all-whitespace ``text`` and a Block Kit body: the
+    # exact "emptied, not dropped" shape this ticket fixes (D1).
+    event: dict[str, Any] = {
+        "type": "app_mention",
+        "text": "   ",
+        "blocks": [
+            {"type": "section", "text": {"type": "mrkdwn", "text": "Derived from blocks"}},
+        ],
+    }
+    assert derive_text(event) == "Derived from blocks"
+
+
+# ---------------------------------------------------------------------------
+# The alert-shaped Block Kit body (AC 1's shape)
+# ---------------------------------------------------------------------------
+
+
+def test_alert_shaped_blocks_payload_derives_every_element_in_order() -> None:
+    """A realistic app_mention alert body: header, section text, section
+    fields, a rich_text block with nested rich_text_section elements, and a
+    context block. Every block shape below matches Slack's own reference.
+    """
+    event: dict[str, Any] = {
+        "type": "app_mention",
+        "text": "",
+        "blocks": [
+            # https://docs.slack.dev/reference/block-kit/blocks/header-block/
+            {
+                "type": "header",
+                "block_id": "hdr1",
+                "text": {"type": "plain_text", "text": "Deploy Alert"},
+            },
+            # https://docs.slack.dev/reference/block-kit/blocks/section-block/
+            {
+                "type": "section",
+                "block_id": "sec1",
+                "text": {"type": "mrkdwn", "text": "*Service* is unhealthy"},
+            },
+            {
+                "type": "section",
+                "block_id": "sec2",
+                "fields": [
+                    {"type": "mrkdwn", "text": "*Region:*\nus-east-1"},
+                    {"type": "mrkdwn", "text": "*Status:*\nCritical"},
+                ],
+            },
+            # https://docs.slack.dev/reference/block-kit/blocks/rich-text-block/
+            {
+                "type": "rich_text",
+                "block_id": "rt1",
+                "elements": [
+                    {
+                        "type": "rich_text_section",
+                        "elements": [
+                            {"type": "text", "text": "See "},
+                            {
+                                "type": "link",
+                                "url": "https://example.com/runbook",
+                                "text": "the runbook",
+                            },
+                            {"type": "link", "url": "https://example.com/bare"},
+                            {"type": "emoji", "name": "fire"},
+                            {"type": "user", "user_id": "U456"},
+                            {"type": "broadcast", "range": "here"},
+                        ],
+                    }
+                ],
+            },
+            # https://docs.slack.dev/reference/block-kit/blocks/context-block/
+            {
+                "type": "context",
+                "block_id": "ctx1",
+                "elements": [
+                    {"type": "mrkdwn", "text": "Reported by the monitor"},
+                ],
+            },
+        ],
+    }
+
+    derived = derive_text(event)
+
+    for expected in (
+        "Deploy Alert",
+        "Service* is unhealthy",
+        "Region:",
+        "us-east-1",
+        "Status:",
+        "See ",
+        "the runbook",
+        "https://example.com/bare",
+        ":fire:",
+        "<@U456>",
+        "<!here>",
+        "Reported by the monitor",
+    ):
+        assert expected in derived, f"missing {expected!r} in {derived!r}"
+
+    # Slack's own serialization order: header, section text, section fields,
+    # the rich_text run, then the context note (D1: "adequate", not a claim
+    # of Slack "document order").
+    positions = [
+        derived.index(s)
+        for s in (
+            "Deploy Alert",
+            "Service* is unhealthy",
+            "Region:",
+            "See ",
+            "the runbook",
+            "https://example.com/bare",
+            ":fire:",
+            "<@U456>",
+            "<!here>",
+            "Reported by the monitor",
+        )
+    ]
+    assert positions == sorted(positions)
+
+
+def test_rich_text_element_types_render_per_type() -> None:
+    # https://docs.slack.dev/reference/block-kit/blocks/rich-text-block/
+    # -- every documented rich_text_section element type this ticket's table
+    # names, each asserted on its exact rendered form (D1).
+    event: dict[str, Any] = {
+        "blocks": [
+            {
+                "type": "rich_text",
+                "elements": [
+                    {
+                        "type": "rich_text_section",
+                        "elements": [
+                            {"type": "text", "text": "plain run"},
+                            {
+                                "type": "link",
+                                "url": "https://x.example/a",
+                                "text": "labeled link",
+                            },
+                            {"type": "link", "url": "https://x.example/b"},
+                            {"type": "emoji", "name": "tada"},
+                            {"type": "user", "user_id": "U789"},
+                            {"type": "channel", "channel_id": "C456"},
+                            {"type": "usergroup", "usergroup_id": "S123"},
+                            {"type": "broadcast", "range": "here"},
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+    derived = derive_text(event)
+    assert "plain run" in derived
+    assert "labeled link" in derived
+    assert "https://x.example/b" in derived
+    assert ":tada:" in derived
+    assert "<@U789>" in derived
+    assert "<#C456>" in derived
+    assert "<!subteam^S123>" in derived
+    assert "<!here>" in derived
+
+
+# ---------------------------------------------------------------------------
+# Attachments: explicit-branch keys, nested blocks, fallback, double-counting
+# ---------------------------------------------------------------------------
+
+
+def test_attachments_only_payload_derives_pretext_title_text_fields_footer() -> None:
+    # https://docs.slack.dev/messaging/legacy-secondary-message-attachments/
+    # -- the message-attachment shape (pretext, title, text, fields, footer),
+    # still delivered by legacy integrations and alerting bots.
+    event: dict[str, Any] = {
+        "type": "app_mention",
+        "text": "",
+        "attachments": [
+            {
+                "pretext": "Incoming alert",
+                "title": "Disk usage critical",
+                "text": "Volume /data is at 97% capacity.",
+                "fields": [
+                    {"title": "Host", "value": "db-7", "short": True},
+                    {"title": "Threshold", "value": "90%", "short": True},
+                ],
+                "footer": "monitoring-bot",
+            }
+        ],
+    }
+
+    derived = derive_text(event)
+
+    for expected in (
+        "Incoming alert",
+        "Disk usage critical",
+        "Volume /data is at 97% capacity.",
+        "Host",
+        "db-7",
+        "Threshold",
+        "90%",
+        "monitoring-bot",
+    ):
+        assert expected in derived
+
+
+def test_attachment_nested_blocks_are_included_and_not_double_counted() -> None:
+    """An attachment's own ``text``/``title`` are emitted by the explicit
+    attachment branch; its nested ``blocks`` are walked too, but the
+    attachment dict itself must not additionally be handed to the generic
+    walker -- each piece appears exactly once (D1).
+    """
+    event: dict[str, Any] = {
+        "attachments": [
+            {
+                "title": "Build failed",
+                "text": "pytest exited non-zero",
+                "blocks": [
+                    {
+                        "type": "section",
+                        "text": {"type": "mrkdwn", "text": "See the CI log for details"},
+                    }
+                ],
+            }
+        ],
+    }
+
+    derived = derive_text(event)
+
+    assert derived.count("Build failed") == 1
+    assert derived.count("pytest exited non-zero") == 1
+    assert derived.count("See the CI log for details") == 1
+
+
+def test_attachment_with_real_content_does_not_emit_fallback() -> None:
+    # D1: "fallback is used only when the attachment yielded nothing else."
+    event: dict[str, Any] = {
+        "attachments": [
+            {
+                "text": "Real content here",
+                "fallback": "SHOULD_NOT_APPEAR_fallback_text",
+            }
+        ],
+    }
+    derived = derive_text(event)
+    assert "Real content here" in derived
+    assert "SHOULD_NOT_APPEAR_fallback_text" not in derived
+
+
+def test_attachment_with_only_fallback_emits_it() -> None:
+    event: dict[str, Any] = {
+        "attachments": [{"fallback": "Plain text summary of this attachment"}],
+    }
+    assert derive_text(event) == "Plain text summary of this attachment"
+
+
+def test_attachment_whose_only_content_is_chrome_still_emits_fallback() -> None:
+    """The key denylist is what makes "fallback only when nothing else
+    yielded" correct: chrome (a button label) must not count as "something
+    else", or this attachment would silently lose its fallback (D1).
+    """
+    event: dict[str, Any] = {
+        "attachments": [
+            {
+                "fallback": "Please upgrade your Slack client to see this",
+                "blocks": [
+                    {
+                        "type": "actions",
+                        "elements": [
+                            {
+                                "type": "button",
+                                "text": {"type": "plain_text", "text": "Approve"},
+                                "action_id": "approve1",
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+    derived = derive_text(event)
+    assert derived == "Please upgrade your Slack client to see this"
+    assert "Approve" not in derived
+
+
+# ---------------------------------------------------------------------------
+# UI-chrome key denylist
+# ---------------------------------------------------------------------------
+
+
+def test_ui_chrome_keys_are_denylisted() -> None:
+    # https://docs.slack.dev/reference/block-kit/composition-objects/confirmation-dialog-object/
+    # https://docs.slack.dev/reference/block-kit/block-elements/button-element/
+    # https://docs.slack.dev/reference/block-kit/block-elements/static-select-element/
+    # -- accessory, confirm, options, option_groups, placeholder, and hint
+    # carry UI-only strings (button labels, dropdown choices, dialog copy)
+    # that must never become model input; an actions block's own button
+    # labels are denylisted the same way (D1).
+    event: dict[str, Any] = {
+        "blocks": [
+            {
+                "type": "section",
+                "text": {"type": "mrkdwn", "text": "Approve this request?"},
+                "accessory": {
+                    "type": "button",
+                    "text": {"type": "plain_text", "text": "CHROME_ACCESSORY"},
+                    "action_id": "btn1",
+                    "confirm": {
+                        "title": {"type": "plain_text", "text": "CHROME_CONFIRM_TITLE"},
+                        "text": {"type": "mrkdwn", "text": "CHROME_CONFIRM_TEXT"},
+                        "confirm": {"type": "plain_text", "text": "CHROME_CONFIRM_YES"},
+                        "deny": {"type": "plain_text", "text": "CHROME_CONFIRM_NO"},
+                    },
+                },
+            },
+            {
+                "type": "input",
+                "block_id": "in1",
+                "label": {"type": "plain_text", "text": "Real label text"},
+                "hint": {"type": "plain_text", "text": "CHROME_HINT"},
+                "element": {
+                    "type": "static_select",
+                    "placeholder": {"type": "plain_text", "text": "CHROME_PLACEHOLDER"},
+                    "options": [
+                        {
+                            "text": {"type": "plain_text", "text": "CHROME_OPTION"},
+                            "value": "v1",
+                        }
+                    ],
+                    "option_groups": [
+                        {
+                            "label": {"type": "plain_text", "text": "unreachable group label"},
+                            "options": [
+                                {
+                                    "text": {
+                                        "type": "plain_text",
+                                        "text": "CHROME_OPTION_GROUP",
+                                    },
+                                    "value": "v2",
+                                }
+                            ],
+                        }
+                    ],
+                },
+            },
+            {
+                "type": "actions",
+                "block_id": "act1",
+                "elements": [
+                    {
+                        "type": "button",
+                        "text": {"type": "plain_text", "text": "CHROME_ACTION_BUTTON"},
+                        "action_id": "approve1",
+                    }
+                ],
+            },
+        ],
+    }
+
+    derived = derive_text(event)
+
+    for chrome in (
+        "CHROME_ACCESSORY",
+        "CHROME_CONFIRM_TITLE",
+        "CHROME_CONFIRM_TEXT",
+        "CHROME_CONFIRM_YES",
+        "CHROME_CONFIRM_NO",
+        "CHROME_HINT",
+        "CHROME_PLACEHOLDER",
+        "CHROME_OPTION",
+        "CHROME_OPTION_GROUP",
+        "CHROME_ACTION_BUTTON",
+        "unreachable group label",
+    ):
+        assert chrome not in derived, f"chrome leaked: {chrome!r} in {derived!r}"
+
+    # Positive control: real, non-chrome content in the same payload still
+    # surfaces, so the assertions above are not vacuous.
+    assert "Approve this request?" in derived
+    assert "Real label text" in derived
+
+
+# ---------------------------------------------------------------------------
+# Unknown / future shapes -- accepted partial coverage (D1)
+# ---------------------------------------------------------------------------
+
+
+def test_unrecognized_block_type_still_yields_known_text_objects_at_depth() -> None:
+    # The walker is generic and recursive: it finds mrkdwn/plain_text text
+    # objects (https://docs.slack.dev/reference/block-kit/composition-objects/text-object/)
+    # at any depth, including inside a block ``type`` it does not recognize
+    # (D1) -- Slack ships new block types faster than any adapter can
+    # special-case them.
+    event: dict[str, Any] = {
+        "blocks": [
+            {
+                "type": "workflow_step",  # not in D1's table
+                "block_id": "ws1",
+                "inputs": {
+                    "note": {"type": "mrkdwn", "text": "buried inside an unknown block type"},
+                },
+            },
+        ],
+    }
+    assert derive_text(event) == "buried inside an unknown block type"
+
+
+def test_unrecognized_typed_node_with_str_text_yields_it() -> None:
+    # Accepted partial coverage (D1): a node whose ``type`` is not in the
+    # recognized table but whose own ``text`` value is a plain ``str`` (not a
+    # nested text-object dict) still yields that string. D1 names Slack's
+    # ``date`` rich-text element as exactly this case.
+    event: dict[str, Any] = {
+        "blocks": [
+            {"type": "date", "text": "Jan 5", "timestamp": 1234567890},
+        ],
+    }
+    assert derive_text(event) == "Jan 5"
+
+
+def test_unrecognized_node_with_non_text_scalar_key_yields_nothing() -> None:
+    # Accepted partial coverage, pinned rather than discovered later (D1): a
+    # node carrying a *different* new scalar key (not ``text``) contributes
+    # nothing, even though it is the only content in the payload.
+    event: dict[str, Any] = {
+        "blocks": [
+            {"type": "future_block", "caption": "This should not surface"},
+        ],
+    }
+    assert derive_text(event) == ""
+
+
+# ---------------------------------------------------------------------------
+# Bounds: traversal must stop, not just the output (D1)
+# ---------------------------------------------------------------------------
+
+
+def test_depth_cap_stops_traversal_but_keeps_shallower_content() -> None:
+    # D1: max recursion depth _MAX_DEPTH; traversal must stop without
+    # raising RecursionError, and must still return the segments found above
+    # the cap.
+    shallow = {"type": "mrkdwn", "text": "shallow content within the cap"}
+    deep_leaf = {"type": "mrkdwn", "text": "buried past the depth cap"}
+    event: dict[str, Any] = {
+        "blocks": [shallow, _wrap_in_depth([deep_leaf], _MAX_DEPTH + 5)],
+    }
+    derived = derive_text(event)  # must not raise RecursionError
+    assert "shallow content within the cap" in derived
+    assert "buried past the depth cap" not in derived
+
+
+def test_character_cap_truncates_and_traversal_stops() -> None:
+    # D1: total character cap _MAX_CHARS. Truncating only the final joined
+    # string would not bound a broad shallow payload -- traversal itself must
+    # stop as soon as the cap is reached, so a sentinel placed after enough
+    # bulk to exceed the cap must never appear in the output.
+    bulk = [{"type": "mrkdwn", "text": "x" * 1000} for _ in range((_MAX_CHARS // 1000) + 5)]
+    sentinel_block = {"type": "mrkdwn", "text": "SENTINEL_PAST_CHAR_CAP"}
+    event: dict[str, Any] = {"blocks": [*bulk, sentinel_block]}
+    derived = derive_text(event)
+    assert len(derived) <= _MAX_CHARS
+    assert "SENTINEL_PAST_CHAR_CAP" not in derived
+
+
+def test_node_count_cap_bounds_a_broad_shallow_payload() -> None:
+    # D1: max visited-node count _MAX_NODES. Depth 12 does not bound
+    # breadth -- a flat, shallow list far past the node cap must still
+    # return promptly and bounded, not visit (and join) every node.
+    wide = [{"type": "mrkdwn", "text": f"seg{i}"} for i in range(_MAX_NODES * 4)]
+    event: dict[str, Any] = {"blocks": wide}
+    derived = derive_text(event)
+    assert "seg0" in derived
+    assert f"seg{_MAX_NODES * 4 - 1}" not in derived
+
+
+# ---------------------------------------------------------------------------
+# files -- newly admitted via file_share (D3)
+# ---------------------------------------------------------------------------
+
+
+def test_files_contribute_title_or_name_per_file() -> None:
+    # https://docs.slack.dev/reference/events/message.file_share -- D1: files
+    # exist because D3 newly admits file_share; an admitted file share with
+    # no derived text would be a brand-new silent-empty path, the exact
+    # defect class this ticket closes.
+    event: dict[str, Any] = {
+        "subtype": "file_share",
+        "text": "",
+        "files": [
+            {"id": "F1", "title": "quarterly-report.pdf", "name": "quarterly-report.pdf"},
+            {"id": "F2", "name": "screenshot.png"},
+        ],
+    }
+    derived = derive_text(event)
+    assert "quarterly-report.pdf" in derived
+    assert "screenshot.png" in derived
+
+
+# ---------------------------------------------------------------------------
+# Degenerate inputs -- must return "" without raising
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "event",
+    [
+        pytest.param({}, id="empty-event"),
+        pytest.param({"text": ""}, id="empty-text"),
+        pytest.param({"blocks": []}, id="empty-blocks-list"),
+        pytest.param({"blocks": None}, id="blocks-none"),
+        pytest.param({"attachments": [{}]}, id="attachment-empty-dict"),
+        pytest.param({"blocks": ["not a dict"]}, id="block-is-bare-string"),
+        pytest.param({"blocks": [None]}, id="none-inside-list"),
+    ],
+)
+def test_degenerate_inputs_return_empty_string_without_raising(event: dict[str, Any]) -> None:
+    assert derive_text(event) == ""

--- a/apps/dispatcher/tests/test_inbound_text.py
+++ b/apps/dispatcher/tests/test_inbound_text.py
@@ -12,6 +12,7 @@ a comment citing Slack's own reference docs -- never in an assumption about
 what the walker will do.
 """
 
+import time
 from typing import Any
 
 import pytest
@@ -334,6 +335,40 @@ def test_attachment_whose_only_content_is_chrome_still_emits_fallback() -> None:
     assert "Approve" not in derived
 
 
+def test_an_attachment_repeating_the_previous_segment_does_not_leak_its_fallback() -> None:
+    """A duplicate is not an absence.
+
+    https://docs.slack.dev/messaging/legacy-secondary-message-attachments/ --
+    ``fallback`` is the plain-text summary Slack shows where the attachment
+    cannot render, so it belongs in the derived prompt only when the attachment
+    contributed nothing else. An alerting integration that posts the same line
+    twice (a repeated status attached to two cards) is a payload where the second
+    attachment plainly DID have content and its fallback must stay out.
+
+    This is the interaction the two rules have with each other: the second
+    attachment's ``text`` is identical to the segment immediately before it, so
+    the adjacent-duplicate collapse leaves the emitted-segment list unchanged.
+    Inferring "this attachment yielded nothing" from that unchanged list is what
+    leaks the fallback, and it is the only shape in which the two rules can
+    disagree.
+    """
+    event: dict[str, Any] = {
+        "attachments": [
+            {"text": "Checkout latency is back to normal"},
+            {
+                "text": "Checkout latency is back to normal",
+                "fallback": "SHOULD_NOT_APPEAR_second_fallback",
+            },
+        ],
+    }
+
+    derived = derive_text(event)
+
+    assert "SHOULD_NOT_APPEAR_second_fallback" not in derived
+    # The repeated line is collapsed, so the whole derivation is that one line.
+    assert derived == "Checkout latency is back to normal"
+
+
 # ---------------------------------------------------------------------------
 # UI-chrome key denylist
 # ---------------------------------------------------------------------------
@@ -522,6 +557,84 @@ def test_node_count_cap_bounds_a_broad_shallow_payload() -> None:
     derived = derive_text(event)
     assert "seg0" in derived
     assert f"seg{_MAX_NODES * 4 - 1}" not in derived
+
+
+def test_a_flat_list_of_bare_scalars_is_charged_against_the_node_budget() -> None:
+    """Breadth spent on scalars must cost the same as breadth spent on dicts.
+
+    https://docs.slack.dev/reference/block-kit/blocks/ -- ``blocks`` is a JSON
+    array whose entries Slack defines as objects, so an array of bare strings and
+    numbers is a payload only a hostile or broken sender produces. It must still
+    be bounded: charging only dicts and lists lets a sender buy an unlimited
+    number of visits for free and then place real content past the point the walk
+    should have stopped.
+
+    The sentinel is the oracle here, not the clock. It sits AFTER more scalars
+    than the node budget allows, so a walk that charges every visited node can
+    never reach it; a walk that charges only containers reaches it immediately.
+    The elapsed-time assertion is the secondary guard against the same defect
+    showing up as a stall rather than as leaked content.
+    """
+    scalars: list[Any] = ["filler", 12345] * 150_000
+    sentinel = {"type": "mrkdwn", "text": "SENTINEL_PAST_THE_SCALAR_RUN"}
+    event: dict[str, Any] = {"blocks": [*scalars, sentinel]}
+
+    started = time.perf_counter()
+    derived = derive_text(event)
+    elapsed = time.perf_counter() - started
+
+    assert "SENTINEL_PAST_THE_SCALAR_RUN" not in derived
+    # Bare scalars are structure, not prose, so nothing at all is derived.
+    assert derived == ""
+    assert elapsed < 1.0, f"walking 300k bare scalars took {elapsed:.2f}s"
+
+
+def test_an_attachment_with_an_enormous_fields_list_is_charged_per_field() -> None:
+    """The container path must be charged too, not just ``blocks``.
+
+    https://docs.slack.dev/messaging/legacy-secondary-message-attachments/ --
+    ``fields`` is an array of ``{title, value}`` objects. An attachment carrying
+    hundreds of thousands of empty ``{}`` fields is bounded only if the list AND
+    each field are charged; otherwise the whole array is walked for free and the
+    real field placed at its end is still reached.
+    """
+    fields: list[Any] = [{} for _ in range(200_000)]
+    fields.append({"title": "SENTINEL_FIELD_TITLE", "value": "SENTINEL_FIELD_VALUE"})
+    event: dict[str, Any] = {"attachments": [{"fields": fields}]}
+
+    started = time.perf_counter()
+    derived = derive_text(event)
+    elapsed = time.perf_counter() - started
+
+    assert "SENTINEL_FIELD_TITLE" not in derived
+    assert "SENTINEL_FIELD_VALUE" not in derived
+    assert derived == ""
+    assert elapsed < 1.0, f"walking 200k empty attachment fields took {elapsed:.2f}s"
+
+
+def test_a_single_enormous_text_value_is_trimmed_rather_than_kept_whole() -> None:
+    """One huge string must not be stored, joined, or returned in full.
+
+    https://docs.slack.dev/reference/block-kit/composition-objects/text-object/
+    -- a ``mrkdwn`` text object's ``text`` is a single string, so a sender can
+    put megabytes in ONE node. A cap applied only to the final joined result
+    would still hold that whole string in memory on the way there; the visible
+    consequence asserted here is that the derived prompt is exactly the cap and
+    that the walk stopped, so nothing after the huge value is derived either.
+    """
+    huge = "z" * (5 * 1024 * 1024)
+    event: dict[str, Any] = {
+        "blocks": [
+            {"type": "section", "text": {"type": "mrkdwn", "text": huge}},
+            {"type": "section", "text": {"type": "mrkdwn", "text": "SENTINEL_PAST_HUGE_VALUE"}},
+        ],
+    }
+
+    derived = derive_text(event)
+
+    assert len(derived) == _MAX_CHARS
+    assert derived == "z" * _MAX_CHARS
+    assert "SENTINEL_PAST_HUGE_VALUE" not in derived
 
 
 # ---------------------------------------------------------------------------

--- a/docs/interfaces/channel-ingress/INTERFACE.md
+++ b/docs/interfaces/channel-ingress/INTERFACE.md
@@ -109,6 +109,90 @@ the Rust CLI mints the exact
 (`cli/src/queue.rs`) and drives the whole deployed system with zero Slack contact
 via `curie local message` / `cluster message` (`cli/src/chat.rs`, `cli/src/message.rs`).
 
+## Adapter admission and the drop contract (Slack)
+
+This clarifies *this* seam's ingress contract for the one adapter that exists (#2006). It
+is a Slack-adapter statement, not a vocabulary other adapters are asked to adopt.
+
+**The rule.** The adapter normalizes what it receives; routing decides what is relevant.
+Anything decidable from the routed payload belongs at the routing seam
+(`BindingResolver.resolve` above), so what stays in `apps/dispatcher` is normalization plus
+the few refusals that seam structurally cannot make. Every drop the adapter's own code
+makes is an enumerated member of
+`apps/dispatcher/src/curie_dispatcher/relevance.py::DropReason`, carries a documented
+rationale in `apps/dispatcher/src/curie_dispatcher/relevance.py::DROP_RATIONALES`, and is
+emitted as exactly one INFO record by
+`apps/dispatcher/src/curie_dispatcher/relevance.py::drop`. There are no silent drops inside
+the adapter: a bare `return None` on the ingest path is the defect #2006 closed, not a
+style preference. The module is the system of record for this table, and the dispatcher's
+tests assert the two sets equal in both directions.
+
+| `DropReason` | Documented rationale |
+|---|---|
+| `UNSUBSCRIBED_LANE` | The delivered envelope is outside the adapter's declared subscription surface — `apps/dispatcher/slack-app-manifest.yaml` subscribes to `app_mention` and `message.im` only, so a message event on any other channel type cannot legitimately arrive, and refusing it is envelope validation rather than a relevance judgement. |
+| `BOT_AUTHORED_THREAD_REPLY` | Loop guard across installations: Curie's own replies and placeholders are always threaded, so admitting a bot-authored mention that carries a thread timestamp would let two Curie installations in one workspace mention-loop each other indefinitely, which Bolt's self filter cannot stop because the two bot identities differ. |
+| `NON_CONTENT_SUBTYPE` | The subtype marks something other than new user content: an edit, a delete, a tombstone, a body redacted by Enterprise Key Management, or an assistant thread-start marker. |
+| `DUPLICATE_DELIVERY` | Slack redelivered a delivery whose idempotency key was already claimed, so processing it again would post a second placeholder and mint a second turn for one message. |
+| `NO_ACTION_IN_PAYLOAD` | A block-action payload carrying no actions names no command and addresses nothing, so there is no turn to mint from it. |
+| `EMPTY_ACTION_COMMAND` | A clicked button carrying neither a value nor a usable action id names no command, so the turn text would be empty. |
+| `UNADDRESSABLE_ACTION` | An App Home or modal click carries no channel and no message, so there is no thread in which a reply could be delivered. |
+
+The last three sit on the Block Kit click lane, which is a real ingest lane:
+`apps/dispatcher/src/curie_dispatcher/handlers.py::process_action` mints a `QueuedTurn`
+exactly as `apps/dispatcher/src/curie_dispatcher/handlers.py::process_event` does, so a
+dropped click is inbound loss of the same class. An approval-card click is deliberately
+absent — it is *handled* by the dedicated approval listener, not dropped.
+
+- **The framework's admission boundary sits above the adapter, and is documented rather
+  than re-implemented.** Three of Bolt's own mechanisms admit or refuse an event before any
+  listener in `apps/dispatcher/src/curie_dispatcher/handlers.py` runs, so none of them can
+  be a `DropReason`. `slack_bolt`'s built-in `IgnoringSelfEvents` middleware compares the
+  incoming identity against the authorized bot identity and acks a self-authored event
+  without invoking a listener, logging only at DEBUG — so at production log levels that
+  drop is invisible. Bolt's authorization middleware refuses an event whose token or team
+  does not authorize. Bolt's listener matchers match on event *type* only and are
+  subtype-blind, so an unregistered type is acked and dropped, and every `message.im`
+  subtype does reach the adapter's listener. These are Bolt's decisions on Bolt's terms and
+  the dispatcher deliberately does not duplicate them. `IgnoringSelfEvents` is the real
+  self-event loop guard, which is why the adapter no longer carries a blanket
+  bot-authorship filter of its own: that filter was redundant with the middleware *and*
+  harmful, discarding legitimate incoming-webhook, Workflow Builder and other-app posts.
+- **`UNSUBSCRIBED_LANE` is envelope validation, not a relevance decision.** The Slack app
+  subscribes to exactly `app_mention` and `message.im`
+  (`apps/dispatcher/slack-app-manifest.yaml`), so refusing another lane is the adapter
+  asserting that the delivered envelope matches its declared subscription — the same family
+  as refusing a payload with no event id, not a judgement that channel chatter is
+  uninteresting. It also could not move downstream even if we wanted it to: `QueuedTurn`
+  carries no Slack lane and no subtype, and `BindingResolver.resolve` receives only the
+  `(kind, channel)` pair, so the routing seam has no field on which to tell a mention from
+  ordinary chatter and would simply mint a turn.
+- **Subtype handling is open-world.**
+  `apps/dispatcher/src/curie_dispatcher/relevance.py::NON_CONTENT_SUBTYPES` is a small
+  closed denylist of things that are structurally not new user content; everything else,
+  including subtypes Slack ships after this was written, is admitted and left to routing.
+  The inverse rule this replaced — refuse *any* subtype — swallowed `file_share` (a person
+  uploading a file with a comment) and `thread_broadcast` (a person's thread reply), both
+  real user content. The open default is bounded by the manifest: with only `app_mention`
+  and `message.im` subscribed, channel-lane noise (joins, leaves, topic and purpose
+  changes, pins) cannot reach these lanes in production, so the denylist stays small rather
+  than becoming a speculative catalogue of every subtype Slack documents.
+- **Bot authorship is a mention-lane rule, and its cost is accepted.** A foreign bot's
+  *root* `@`-mention is admitted — the alert-app case this work exists for, whose body
+  typically arrives as Block Kit and is normalized by
+  `apps/dispatcher/src/curie_dispatcher/inbound_text.py::derive_text` rather than read off
+  an empty top-level `text`. A bot-authored mention carrying `thread_ts` is refused as
+  `BOT_AUTHORED_THREAD_REPLY` for the cross-installation loop above; on the DM lane bot
+  authorship is not consulted at all. The accepted cost, stated rather than discovered
+  later: an alert bot that replies *inside* a thread with a mention is not ingested.
+  Root-only admission is what separates the ticket's case from the loop without a new
+  `QueuedTurn` field or a bot allowlist.
+- **Sibling ingress paths — audited, unchanged.** The first-party HTTP ingress paths
+  (`apps/api/src/curie_api/routers/hooks.py`,
+  `apps/api/src/curie_api/routers/channels.py`) already refuse explicitly: every refusal is
+  an HTTP status returned to the caller and every duplicate is a flagged response, so they
+  need no equivalent vocabulary today, and extending the enumerated reasons to them if they
+  ever grow relevance logic is deliberately deferred.
+
 ## Known leakage
 
 Two ends and the binding surface were cleaned; what remains is egress semantics and

--- a/docs/interfaces/channel-ingress/INTERFACE.md
+++ b/docs/interfaces/channel-ingress/INTERFACE.md
@@ -140,7 +140,21 @@ tests assert the two sets equal in both directions.
 The last three sit on the Block Kit click lane, which is a real ingest lane:
 `apps/dispatcher/src/curie_dispatcher/handlers.py::process_action` mints a `QueuedTurn`
 exactly as `apps/dispatcher/src/curie_dispatcher/handlers.py::process_event` does, so a
-dropped click is inbound loss of the same class. An approval-card click is deliberately
+dropped click is inbound loss of the same class. Of the three, only `UNADDRESSABLE_ACTION`
+is a disposition Bolt actually delivers today: an App Home or modal click really does
+arrive with no channel and no message. `NO_ACTION_IN_PAYLOAD` and `EMPTY_ACTION_COMMAND`
+are **defensive guards on that lane that the current matcher does not reach**. The
+catch-all registration in
+`apps/dispatcher/src/curie_dispatcher/handlers.py::register_handlers` is
+`@app.action(re.compile(r".+"))`, and `slack_bolt` resolves the clicked action inside its
+own matcher before invoking the listener: a payload with an empty `actions` list raises
+there rather than arriving at `process_action`, and an empty `action_id` never matches
+`.+` at all. The dispatcher's tests therefore exercise those two rows directly instead of
+through Bolt. They are kept, not deleted, for three reasons: they are one comparison each;
+the matcher's payload handling is a `slack_bolt` implementation detail rather than a
+contract this seam holds, so a release that starts delivering either shape must meet a
+logged refusal; and a silent `return None` on that path is the defect #2006 removes, which
+is exactly what a deleted guard would restore. An approval-card click is deliberately
 absent — it is *handled* by the dedicated approval listener, not dropped.
 
 - **The framework's admission boundary sits above the adapter, and is documented rather
@@ -186,6 +200,21 @@ absent — it is *handled* by the dedicated approval listener, not dropped.
   later: an alert bot that replies *inside* a thread with a mention is not ingested.
   Root-only admission is what separates the ticket's case from the loop without a new
   `QueuedTurn` field or a bot allowlist.
+
+  Its known consequence, stated here rather than left to be found: a bot-authored event
+  normally carries no human `user`, so the turn is queued with an empty `author` while its
+  text becomes a model turn like any other. That is not a new prompt-injection primitive —
+  the same text was already reachable from any member of the workspace — but it does widen
+  the set of *automated* principals that can drive the model, a compromised third-party app
+  or the holder of an incoming-webhook URL among them, and routing cannot tell one from a
+  person afterwards because the adapter carries neither `bot_id` nor the message subtype
+  onto the queue. Carrying machine provenance onto the turn is deliberately deferred, not
+  overlooked: `QueuedTurn`
+  (`packages/aci-protocol/src/aci_protocol/turn.py::QueuedTurn`) cannot gain a field
+  without a protocol-version bump
+  (`packages/aci-protocol/src/aci_protocol/version.py::PROTOCOL_VERSION`) and the matching
+  `packages/aci-protocol/schema/wire.lock` regeneration, which is a change to the frozen
+  package rather than to this adapter.
 - **Sibling ingress paths — audited, unchanged.** The first-party HTTP ingress paths
   (`apps/api/src/curie_api/routers/hooks.py`,
   `apps/api/src/curie_api/routers/channels.py`) already refuse explicitly: every refusal is


### PR DESCRIPTION
Closes #2006.

Two silent failures in the Slack adapter, one root cause: it decided things below the routing seam, and decided them without saying so.

## What was broken

**Bodies arrived empty.** `process_event` took the turn text from `event["text"]` alone. An alert-shaped post whose content lives in `blocks` or `attachments` — the common shape for a bot posting into a channel — reached the model blank. Not dropped: *emptied*, which is worse, because it still burned a placeholder and a turn.

**Refusals were invisible.** `is_actionable` dropped on **any** `subtype`. That is a blanket denylist over a set Slack keeps adding to, so `file_share` (a user uploading a file *with a comment*), `thread_broadcast` (a real user message), and every subtype Slack ships next year were swallowed with no log line at all. Every other refusal on the ingest path was a bare `return None`.

## What changed

- **`inbound_text.derive_text`** builds the turn text from `blocks`, then `attachments`, then `files`, when top-level `text` is empty. The walk is generic rather than a per-block-type switch, so a block type we do not know still yields its text; it is bounded in depth, characters and visited nodes, because the payload is third-party input on the hot ingest path.
- **`relevance.DropReason`** enumerates every refusal the adapter's own code makes, each with a documented rationale and exactly one INFO record. No ingest path returns `None` silently any more.
- **The subtype filter is inverted.** A small named non-content set is refused; everything else, unknown future subtypes included, now reaches the model.
- **The blanket bot filter is gone.** Bolt's built-in `IgnoringSelfEvents` already drops our own events before any listener runs, so the adapter no longer duplicates it. A foreign bot's **root** mention is admitted — that is the case this ticket exists for. A bot-authored mention carrying `thread_ts` is refused as `BOT_AUTHORED_THREAD_REPLY`, because two Curie installations in one workspace could otherwise mention-loop each other in a thread, and Bolt's self filter cannot stop that across two bot identities.
- **`channel_type` is envelope validation, not relevance.** `slack-app-manifest.yaml` subscribes to `app_mention` and `message.im` only, so refusing another lane asserts the delivered envelope matches the declared subscription. It could not move downstream even in principle: `QueuedTurn` carries no lane or subtype and the binding resolver sees only `(kind, channel)`.
- **Two paths that lost a message after the ack are closed.** A malformed envelope crashed *after* Bolt acked — and for a missing `ts`/`channel`, after taking the dedupe claim, so the redelivery was then refused as a duplicate of a turn that never existed. Validation now runs before the claim. Separately, a failed placeholder left the claim held; it is released now, but **only on an unambiguous Slack refusal** — a timeout or `fatal_error` can happen after Slack accepted the post, so those keep the claim and log the ambiguity.

## Verification

Beyond the suite, driven end to end through the real Bolt Socket Mode handler and real Valkey:

```
[blocks-only mention]        ENQUEUED
    QueuedTurn.text (newline-separated):
        PagerDuty: API latency
        p99 is *2.4s* on checkout
        *Severity:*
        SEV-2
        *Service:*
        checkout-api

[attachments-only mention]   ENQUEUED
    QueuedTurn.text (newline-separated):
        Build failed
        3 tests failed on main

[non-im message lane]        REFUSED   unsubscribed_lane -- ...
[edited message]             REFUSED   non_content_subtype -- ...
[bot mention in a thread]    REFUSED   bot_authored_thread_reply -- ...
[file_share with a comment]  ENQUEUED  "look at this trace"
[unknown future subtype]     ENQUEUED  "still a message"
```

The `Acknowledge` button label in that first payload is correctly absent — interface chrome is not message content.

## Reviewing this

The four commits are kept unsquashed on purpose; each is separately reviewable. `d1e71aa` is the failing-test contract and its position **before** the implementation is the evidence for it. `eba6133` is exactly what three adversarial cross-engine reviews changed. `2cb61be` is behaviour-neutral consolidation.

## Done-check

- [x] **Failing tests committed before implementation** — `d1e71aa` (tests, red) precedes `9576d84` (implementation).
- [x] **All production edits by delegated sub-agents** — no inline driver edits.
- [x] **Broadened signatures checked at every caller** — `process_event` gained a required keyword-only `lane`; the only two callers are the listeners in `register_handlers` (the many `kernel.process_event` hits under `apps/worker` are an unrelated function). `is_actionable` was deleted and has zero remaining references repo-wide.
- [x] **Code review** — cross-engine (Codex), file:line evidence. Five blocking findings, all fixed. See note on the router below.
- [x] **Scope review** — cross-engine. Every hunk mapped; two passenger findings conceded, two kept with reasons recorded below.
- [x] **Security review** — cross-engine. One blocking finding (traversal caps bypassable on container paths) fixed; advisories recorded in `INTERFACE.md`.
- [x] **Sibling-path parity** — both `QueuedTurn` mint sites (`process_event`, `process_action`) carry the fix, and `_mint_turn` now makes drifting apart structurally harder. The sibling HTTP ingress paths were audited and documented, not refactored.
- [x] **Guard demonstration** — each new refusal was executed and observed, not read (output above).
- [x] **Consolidation pass** — ran, applied two findings, re-validated, and the applied diff was re-reviewed cross-engine: no blocking findings.
- [x] **Observable verification** — the run above.
- [x] **Full affected suite, typecheck, lint** — `ruff` clean; `mypy` clean (195 files); `check-docs.sh` OK; `pytest apps/dispatcher packages/aci-protocol` 335 passed, 0 skipped (Valkey-backed, so the matrix genuinely ran).
- [ ] **Live-Slack tier: NOT RUN.** No Slack workspace was reachable. Everything above proves the dispatcher normalizes and enqueues the derived text; it does not prove delivery through a real workspace. Captured payloads were used as unit-test inputs only and are **not** offered as external-integration evidence.

## Judgement calls, so you can overrule them

- **Two reviewers called the claim-release fix a separate bug.** It is kept here: it is the same defect class the ticket is about, and splitting it would leave a known silent-loss path on `main` with nothing filed. The `StreamPublisher` port gained a `delete` verb for it, which forced the one edit to an existing passing test — `FakeBroker` gained a `delete` method so the `isinstance` port-shape check still holds. **No assertion anywhere was weakened, deleted, or retitled**; widening a port necessarily widens its minimal implementation.
- **Package exports were conceded.** Only the now-deleted `is_actionable` is removed; `classify`/`DropReason` are not exported.
- **Block-action refusals are kept in the vocabulary** — a click mints a `QueuedTurn`, so it is a real ingest lane — but the docs now say honestly that Bolt's matcher does not deliver two of them today.
- **No ADR.** This is a bug fix plus a clarification of the existing channel-ingress interface for the one adapter that exists, deliberately *not* framed as a cross-adapter pattern. If you want the rule elevated to an ADR, that is your call and it should precede any broader adoption.

## Known follow-ups, not done here

Carrying machine provenance onto a turn (a bot-authored event queues with an empty `author`, and routing cannot tell an automated principal apart afterwards) needs a `QueuedTurn` field, which needs a protocol-version and `wire.lock` bump. Richer `files` normalization, and extending the enumerated vocabulary to the HTTP ingress adapters if they ever grow relevance logic, are also deferred.

*Note on tooling: `agent-router adversarial-review` exited 1 — it selected the grok reviewer, which is broken on this machine (`openat2` requirement). All four reviews were run instead as direct read-only `codex exec` sessions, which is still cross-engine against the Claude driver. That substitution is recorded rather than reported as a clean router pass.*

*The `PR body (real newlines)` gate failed on this PR's first body, which quoted derived text containing literal escape sequences; the body was corrected and the gate passes on the current text. A re-run of that first job replays the original payload, so that one historical run stays red by construction.*