### PR TITLE
Claim a thread reset and mark it in-progress atomically

### DIFF
--- a/apps/worker/src/curie_worker/consumer.py
+++ b/apps/worker/src/curie_worker/consumer.py
@@ -64,7 +64,7 @@ _READ_ERROR_BACKOFF_S = 0.5
 _CAP_SCAN_PAGE = 1000
 
 # An operator-requested thread reset (#713): the API SADDs a thread_key here
-# (`apps/api/src/curie_api/threadreset.py`) and the maintenance tick SPOPs
+# (`apps/api/src/curie_api/threadreset.py`) and the maintenance tick claims
 # it to force-release that thread's sandbox. `curie local eval` /
 # `curie cluster eval` SADDs each eval-owned conversation_id onto the same
 # set (#1534) so the next turn's `_handle` (and the tick) release that
@@ -74,17 +74,49 @@ _CAP_SCAN_PAGE = 1000
 # needs, so a plain Valkey SET is enough.
 THREAD_RESET_SET = "curie:thread-reset-requests"
 
-# Claimed-but-not-yet-released thread-reset requests (#812). The drain SPOPs a
-# request off THREAD_RESET_SET (the atomic claim, so no second replica/tick
-# double-releases it) and immediately SADDs it here; it is SREMoved only after
-# `release_thread` actually completes. The API's `is_pending` reads the UNION of
-# both sets, so the observable "reset still outstanding" signal the CLI polls on
-# flips to done only when the sandbox is truly released -- not at claim time, and
-# NOT at all if the release raises or times out (the key is left here, so the CLI
-# reports the reset as unconfirmed rather than a false success). Mirrored verbatim
-# in `apps/api/src/curie_api/threadreset.py`, the same cross-service-constant
+# Claimed-but-not-yet-released thread-reset requests (#812). The drain MOVES a
+# request off THREAD_RESET_SET into this set in one atomic server-side step
+# (`_THREAD_RESET_CLAIM_LUA`, #855) -- the claim and the in-progress mark are the
+# same operation, so no second replica/tick double-releases it AND that claim
+# transition is never observable as a member missing from both sets. It is
+# SREMoved only after `release_thread` actually completes. The API's
+# `is_pending` reads the UNION of both sets, so the observable "reset still
+# outstanding" signal the CLI polls on flips to done only when the sandbox is
+# truly released -- not at claim time, and NOT at all if the release raises or
+# times out (the key is left here, so the CLI reports the reset as unconfirmed
+# rather than a false success). Mirrored verbatim in
+# `apps/api/src/curie_api/threadreset.py`, the same cross-service-constant
 # pattern as THREAD_RESET_SET itself.
+#
+# The marker itself carries no claim identity, though: if a second operator
+# request for the same thread lands while an earlier release is still
+# in-flight, both claims collapse onto this one SADDed key, and the earlier
+# release's unconditional SREM on completion empties it (and the union) while
+# the later release is still running. That duplicate-request gap predates
+# this change and is adjacent to #734 -- not something the atomic claim step
+# closes.
 THREAD_RESET_INFLIGHT_SET = "curie:thread-reset-inflight"
+
+# Claim a thread-reset request and mark it in-progress as ONE atomic unit (#855).
+# Valkey runs a script to completion with nothing interleaved, so the claim
+# transition -- moving the key from the request set to the in-progress set --
+# is never observable as absent from both: there is no window where the API's
+# `is_pending` (the UNION of both) reads False for a live request. A
+# client-side SPOP-then-SADD pair cannot offer that: the RTT between the two
+# commands is a real gap in which the key belongs to neither set, and a poll
+# landing in it reads "released" before `release_thread` has even been
+# invoked (#812's exact user-visible failure). (This says nothing about a
+# repeat request for a thread whose earlier release is still in flight --
+# see the identity-less-marker note above THREAD_RESET_INFLIGHT_SET.)
+# Returns the claimed member, or Lua `false` (Python ``None``) when the request
+# set is empty -- the same bare-member reply shape SPOP itself has.
+_THREAD_RESET_CLAIM_LUA = """
+local claimed = redis.call('SPOP', KEYS[1])
+if claimed then
+  redis.call('SADD', KEYS[2], claimed)
+end
+return claimed
+"""
 
 # Per-tick time budget for draining THREAD_RESET_SET (#743, follow-up to
 # #739). #739 bounded the courtesy interrupt to 5s per *request*, but the
@@ -331,6 +363,11 @@ class Consumer(StreamConsumer):
         into ``THREAD_RESET_INFLIGHT_SET`` (which ``is_pending`` also reads) for
         the duration of the release, and cleared from it only on SUCCESS.
 
+        The claim and that in-progress mark are ONE server-side step
+        (``_THREAD_RESET_CLAIM_LUA``, #855), not an ``SPOP`` followed by a
+        separate ``SADD`` -- see that constant's comment for why the two-round-trip
+        version would reopen #812's failure at RTT scale.
+
         A release that raises or times out is logged and LEFT in the in-progress
         set: ``is_pending`` therefore stays True and the CLI reports the reset as
         unconfirmed rather than a false success (scenario B). It is deliberately
@@ -345,23 +382,30 @@ class Consumer(StreamConsumer):
         the budget is spent, rather than serially paying every request's
         release bound inline in this tick. Members not yet popped simply stay
         in ``THREAD_RESET_SET`` and are drained on a later tick -- safe
-        because ``SPOP`` never removes a member without this loop taking
-        ownership of it in the same step."""
+        because the atomic claim never removes a member from the request set
+        without this loop taking ownership of it, and marking it in-progress,
+        in the same step."""
         start = time.monotonic()
         while True:
-            raw = await self._valkey.spop(THREAD_RESET_SET)
+            # Claim the request AND mark it in-progress in one atomic step, so
+            # `is_pending` (the union of the request and in-progress sets) stays
+            # True across the whole claim rather than briefly reading False in
+            # the gap between two round trips (#812, #855).
+            raw = await self._valkey.eval(
+                _THREAD_RESET_CLAIM_LUA,
+                2,
+                THREAD_RESET_SET,
+                THREAD_RESET_INFLIGHT_SET,
+            )
             if raw is None:
                 return
-            # SPOP with no count (as called here) always returns a single
-            # bare member, never the set-of-members shape its overload
-            # allows with an explicit count -- narrow away that shape for
-            # the type checker rather than the client's imprecise overload.
-            assert isinstance(raw, (str, bytes)), f"unexpected SPOP shape: {raw!r}"
+            # The script returns the SPOP reply verbatim, and SPOP with no count
+            # always returns a single bare member, never the set-of-members shape
+            # its overload allows with an explicit count -- narrow away that
+            # shape for the type checker rather than the client's imprecise
+            # overload.
+            assert isinstance(raw, (str, bytes)), f"unexpected claim shape: {raw!r}"
             thread_key = raw.decode("utf-8") if isinstance(raw, bytes) else raw
-            # Mark the claim in-progress BEFORE releasing, so `is_pending` (the
-            # union of the request and in-progress sets) stays True for the whole
-            # release rather than flipping at claim time (#812).
-            await self._valkey.sadd(THREAD_RESET_INFLIGHT_SET, thread_key)
             try:
                 released = await self._kernel.release_thread(thread_key)
             except Exception:

--- a/apps/worker/tests/kernel/test_consumer.py
+++ b/apps/worker/tests/kernel/test_consumer.py
@@ -16,6 +16,7 @@ import pytest
 import redis.exceptions
 from aci_protocol import Final, QueuedTurn, ReplyHandle, SessionStatus, TextDelta
 from curie_dispatcher.queue import to_stream_fields
+from curie_test_support.valkey import VALKEY_HOST, VALKEY_PORT, VALKEY_PW
 from curie_worker import consumer as consumer_module
 from curie_worker import kernel as kernel_module
 from curie_worker.consumer import (
@@ -1604,5 +1605,205 @@ def test_maintenance_tick_thread_reset_is_not_stalled_by_a_hanging_substrate_rel
 
             # The request was popped either way; a fresh reset is needed to retry.
             assert await h.async_redis.scard(THREAD_RESET_SET) == 0
+
+    asyncio.run(go())
+
+
+def test_maintenance_tick_thread_reset_claim_and_mark_is_atomic(make_harness) -> None:
+    """#855: claiming a reset request and marking it in-progress must be ONE
+    server-side step. As an SPOP followed by a separate SADD they are two round
+    trips, and between them the thread_key is in NEITHER set -- so the API's
+    ``is_pending`` (the UNION of the two) reads False for a request whose
+    sandbox has not been touched yet, and the CLI's ``reset-thread`` poll takes
+    that single ``requested: false`` as proof and prints "reset complete,
+    sandbox released" before ``release_thread`` has even been invoked. That is
+    #812's user-visible failure narrowed to one network hop.
+
+    Both halves matter. (a) The gap must never be observable, and the observer
+    that proves it sits at the CENTRAL COMMAND BOUNDARY -- ``execute_command``,
+    the single funnel every redis-py call (``spop``, ``sadd``, ``eval``,
+    ``srem``, a pipeline's writes) is issued through -- rather than on any one
+    named method. After every command the drain issues, it reads the union on a
+    SECOND, INDEPENDENT connection (so the observation never recurses through
+    the client under test, and never perturbs what it measures) and records a
+    violation if the live request is in neither set. That is what makes this
+    mutation-resistant rather than shape-recognising: the old ``.spop()`` +
+    ``.sadd()`` pair, two separate ``EVAL``s (one SPOP-ing, one SADD-ing), and a
+    raw ``execute_command("SPOP", ...)`` + ``execute_command("SADD", ...)`` pair
+    ALL go red, because all three are two commands with an observable gap
+    between them -- the observer never has to know which method name was used.
+    (b) The mark must still land, and land from the atomic claim itself:
+    mid-release the key IS in the in-progress set, yet no separate marking
+    command (an ``SADD``/``SMOVE`` against ``THREAD_RESET_INFLIGHT_SET``) was
+    ever issued through that same boundary. (a) alone would pass vacuously if
+    the drain simply stopped claiming anything; (b) is what proves it did not.
+    """
+
+    async def go() -> None:
+        async with make_harness() as h:
+            h.runner.default_script = [Final(text="hi", status=DONE)]
+            await h.kernel.process_event(_qevent("hi", thread="tAtomicClaim"))
+            assert h.substrate.lookup("tAtomicClaim") is not None
+
+            violations: list[str] = []
+            observed: list[str] = []
+            observer_errors: list[str] = []
+            inflight_marks: list[tuple[Any, ...]] = []
+            original_execute = h.async_redis.execute_command
+            original_sadd = h.async_redis.sadd
+            original_srem = h.async_redis.srem
+
+            # The observer reads on its own connection: issuing its reads through
+            # the spied client would recurse into the spy and would interleave
+            # extra commands into the very sequence under observation.
+            observer_redis: AsyncRedis = AsyncRedis(
+                host=VALKEY_HOST,
+                port=VALKEY_PORT,
+                password=VALKEY_PW or None,
+                decode_responses=True,
+            )
+
+            started = asyncio.Event()
+            proceed = asyncio.Event()
+            original_release = h.kernel.release_thread
+
+            async def blocking_release(thread_key: str) -> bool:
+                started.set()
+                await proceed.wait()
+                return await original_release(thread_key)
+
+            async def spy_execute_command(*args: Any, **options: Any) -> Any:
+                name = args[0]
+                name = (name.decode() if isinstance(name, bytes) else name).upper()
+                # A separate marking round trip is itself the defect: record any
+                # command that writes the in-progress set from the client side.
+                if (
+                    not started.is_set()
+                    and name in {"SADD", "SMOVE"}
+                    and THREAD_RESET_INFLIGHT_SET in args[1:]
+                ):
+                    inflight_marks.append(args)
+                result = await original_execute(*args, **options)
+                # The observation window runs from "a live request exists in the
+                # request set" up to the instant the release begins. Before the
+                # release starts the key MUST be somewhere in the union; once the
+                # release is running the mid-release assertion below covers it,
+                # and after a successful release both sets are legitimately empty
+                # -- observing past that point would manufacture false
+                # violations.
+                if not started.is_set():
+                    observed.append(name)
+                    try:
+                        in_requests = await observer_redis.sismember(
+                            THREAD_RESET_SET, "tAtomicClaim"
+                        )
+                        in_flight = await observer_redis.sismember(
+                            THREAD_RESET_INFLIGHT_SET, "tAtomicClaim"
+                        )
+                        if not in_requests and not in_flight:
+                            violations.append(name)
+                    except Exception as exc:  # never raise inside the spy
+                        observer_errors.append(f"{name}: {exc!r}")
+                return result
+
+            h.kernel.release_thread = blocking_release  # type: ignore[method-assign]
+            task: asyncio.Task[None] | None = None
+            try:
+                # THREAD_RESET_SET / THREAD_RESET_INFLIGHT_SET are FIXED
+                # cross-service constants -- unlike this harness's stream and
+                # sandbox keys they are not namespaced per run, so their contents
+                # outlive the test, the process, and the run on a shared Valkey.
+                # Residue matters asymmetrically: a leftover "tAtomicClaim" in
+                # the in-progress set makes the observer read `in_flight` True at
+                # every boundary, so arm (a) can never record a violation and
+                # goes SILENTLY VACUOUS rather than red. This test also *creates*
+                # that residue -- an assertion firing mid-release leaves the drain
+                # blocked before its SREM -- so both the pre-clean here and the
+                # unconditional post-clean below are load-bearing.
+                # These writes happen before the spy is installed (and, in the
+                # `finally`, after it is restored), so they can never be counted
+                # as violations or as inflight_marks.
+                await original_srem(THREAD_RESET_SET, "tAtomicClaim")
+                await original_srem(THREAD_RESET_INFLIGHT_SET, "tAtomicClaim")
+                assert not await observer_redis.sismember(
+                    THREAD_RESET_SET, "tAtomicClaim"
+                )
+                assert not await observer_redis.sismember(
+                    THREAD_RESET_INFLIGHT_SET, "tAtomicClaim"
+                ), "stale in-progress residue would make arm (a) vacuous"
+
+                await original_sadd(THREAD_RESET_SET, "tAtomicClaim")
+                # The live request now exists; install the spy before the drain
+                # can issue its first command. The spy is only ever installed
+                # between here and the `finally` below, so its own presence is
+                # the observation window -- `not started.is_set()` alone closes
+                # it at the release.
+                h.async_redis.execute_command = (  # type: ignore[method-assign,assignment]
+                    spy_execute_command
+                )
+                consumer = Consumer(
+                    redis=h.async_redis, kernel=h.kernel, config=h.config
+                )
+                task = asyncio.create_task(consumer._drain_thread_reset_requests())
+                await asyncio.wait_for(started.wait(), timeout=5.0)
+
+                # (b) The mark landed -- the pending signal is still True while
+                # the release runs...
+                assert await observer_redis.sismember(
+                    THREAD_RESET_INFLIGHT_SET, "tAtomicClaim"
+                )
+                # ...and it came from the atomic claim, not a second round trip
+                # through the command boundary.
+                assert inflight_marks == []
+
+                proceed.set()
+                await asyncio.wait_for(task, timeout=10.0)
+            finally:
+                h.async_redis.execute_command = (  # type: ignore[method-assign,assignment]
+                    original_execute
+                )
+                proceed.set()
+                # Unblock and settle the drain first: while it is still parked in
+                # the release it has not reached its own SREM, and a cleanup that
+                # raced it could be undone by a late claim write.
+                if task is not None and not task.done():
+                    with contextlib.suppress(Exception):
+                        await asyncio.wait_for(asyncio.shield(task), timeout=10.0)
+                    if not task.done():
+                        task.cancel()
+                        with contextlib.suppress(BaseException):
+                            await task
+                # Exception-safe so a cleanup failure cannot mask the assertion
+                # that brought us here.
+                for _set in (THREAD_RESET_SET, THREAD_RESET_INFLIGHT_SET):
+                    with contextlib.suppress(Exception):
+                        await original_srem(_set, "tAtomicClaim")
+                with contextlib.suppress(Exception):
+                    await observer_redis.aclose()
+
+            assert observer_errors == [], f"observer failed to read: {observer_errors}"
+            # The observer must actually have run. An empty `violations` list is
+            # only evidence if commands reached the boundary at all -- if a future
+            # change stops routing the claim through ``execute_command``, arm (a)
+            # fails loudly here instead of passing on zero observations.
+            assert observed, (
+                "no command was observed at the command boundary while the "
+                "window was open; arm (a) proved nothing"
+            )
+            # (a) Every command the drain issued left the live request visible in
+            # the union. A non-empty list names the command after which
+            # `is_pending` would have read False for a request whose sandbox had
+            # not been released yet.
+            assert violations == [], (
+                "thread_key was in NEITHER THREAD_RESET_SET nor "
+                f"THREAD_RESET_INFLIGHT_SET after: {violations}"
+            )
+
+            # End state is clean: released, and nothing left pending.
+            assert h.substrate.lookup("tAtomicClaim") is None
+            assert not await h.async_redis.sismember(THREAD_RESET_SET, "tAtomicClaim")
+            assert not await h.async_redis.sismember(
+                THREAD_RESET_INFLIGHT_SET, "tAtomicClaim"
+            )
 
     asyncio.run(go())


### PR DESCRIPTION
## Summary

The worker's maintenance-tick drain claimed a thread-reset request with `SPOP THREAD_RESET_SET` and then marked it in-progress with a separate `SADD THREAD_RESET_INFLIGHT_SET`. Between the two replies the thread key was in **neither** set, and the API's `is_pending` reads the union of both — so a poll landing in that RTT-wide window read `requested: false` for a request whose sandbox had not been touched yet. The CLI treats a single `requested: false` as terminal proof of release (`cli/src/commands.rs:3199`) and prints "reset complete, sandbox released", so the operator's confirming message adopts the still-live pre-reset sandbox and reads stale conversation state — #812's exact outcome, narrowed to one network hop. Both steps are now a single Lua `EVAL`, which Valkey runs to completion with nothing interleaved.

## Related issue

Closes #855

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | No plugin/skill packaging, runner turn loop, ACI event, or skill eval/check is touched; the diff is confined to the worker's Valkey command shape. | — | — |
| local | **Required** | The change alters worker runtime behavior on the maintenance tick against a live Valkey. | fake | `CURIE_BIN=… CURIE_BASE_TAG=ci-local CURIE_E2E_TIERS=local bash cli/scripts/e2e-ladder.sh` → `LADDER PASS (tiers: local)`, bundle identity `dc8312cdde104687211d22abe2040e64eab6187091d4b350f0f5a10837ab7886`. Plus a targeted live run of the actual reset path against the compose stack (below). |
| local-release | n/a | No released binary or image identity, install path, version pin, or release compose file is touched. | — | — |
| cluster | n/a | No chart template, RBAC, securityContext, NetworkPolicy, sandbox claim, or init container is touched. | — | — |
| live provider | n/a | No model routing, credential resolution, provider auth, or token/cost accounting is touched; the drain is model-agnostic. | — | — |
| external integration | n/a | No Slack, git webhook, connector OAuth, or third-party API shape is touched. | — | — |

**Targeted `local`-tier run of the changed path** (candidate `1c0d3e89`, images `ghcr.io/curie-eng/curie-{api,worker}:ci-local` built from this tree; running worker confirmed to carry `_THREAD_RESET_CLAIM_LUA`):

- `curie local up --minimal` → `curie local deploy --plugin-dir examples/weather` → `curie local message "what is the weather" --thread t855live` → `{"finalized":true,"reply":"all done","thread":"t855live"}`, sandbox container `curie-thread-7603c5e11d-8854a5` live.
- **Falsifiable negative** — worker stopped, so nothing can drain: `POST /agents/{id}/threads/t855live/reset` → `{"requested":true}`, then 10 consecutive polls all `{"requested":true}`, sandbox still present. The signal does not falsely flip when no release can happen.
- **Positive** — worker restarted, then polled tightly through the whole claim-and-release transition: 204 polls, first `{"requested":false}` at poll #204, with `0` live sandbox containers at that instant. No poll ever reported released before the sandbox was gone.

## Acceptance criteria

- **AC1 — claim-and-mark is atomic.** `apps/worker/src/curie_worker/consumer.py`: `_THREAD_RESET_CLAIM_LUA` does `SPOP` + `SADD` in one script, invoked as a single `EVAL` over both keys; the client-side `SADD` is gone.
- **AC2 — a test asserts the union is never simultaneously empty for a live request across the claim transition.** `test_maintenance_tick_thread_reset_claim_and_mark_is_atomic` observes at redis-py's central command boundary (`execute_command`) and reads the union on a **second, independent** connection after every command the drain issues, so it pins the invariant rather than the implementation shape.
- **AC3 — deferred.** Whether the CLI should require a positive released signal rather than inferring from `!requested` is untouched here; that is the #734-adjacent design question the issue explicitly defers.

**Red-on-revert, proven from both a clean and a deliberately dirty Valkey.** Three mutations all fail:

| Mutation | Result |
| --- | --- |
| original `.spop()` + `.sadd()` pair | RED |
| two separate `EVAL`s (one SPOP-ing, one SADD-ing) | RED — `AssertionError: thread_key was in NEITHER THREAD_RESET_SET nor THREAD_RESET_INFLIGHT_SET after: ['EVAL']` |
| `execute_command("SPOP")` + `execute_command("SADD")` | RED |

The test also scrubs both sets before and after: `THREAD_RESET_SET` / `THREAD_RESET_INFLIGHT_SET` are un-namespaced cross-service constants, so residue from a failed run makes the check **silently vacuous** rather than red. That was not hypothetical — an earlier draft of the test passed the two-EVAL mutation on a dirty Valkey and failed it once the sets were clean.

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved.
- [ ] Or: this change is not behavior-bearing.

## Checklist

- [x] Tests pass for the area I touched — `uv run pytest apps/worker/tests -q` → `886 passed, 30 skipped`; `uv run ruff check .`, `uv run mypy` (193 files), `uv run lint-imports`, `bash scripts/check-docs.sh`, `bash scripts/check-contracts.sh` all clean.
- [x] Docs updated if behavior changed — the in-file comments that described the two-step claim were corrected, and the guarantee is scoped honestly (see below).
- [x] An ADR is not needed; this is a bug fix within an existing decision.

## Noted, not fixed here

- **The in-progress marker carries no claim identity.** If a second operator request for the same thread lands while an earlier release is still in flight, both claims collapse onto one key and the earlier release's unconditional `SREM` empties the union while the later release is still running. That gap predates this change and is adjacent to #734; the comments now say so rather than overclaiming an unconditional invariant.
- **`apps/api/src/curie_api/threadreset.py`'s mirrored prose still describes the old two-step writer.** The API package was out of scope for this fix; worth a follow-up so the duplicated-constant pattern's two halves stay in sync.
- **`is_pending`'s two sequential `SISMEMBER`s are left as-is.** With the writer atomic the key's lifecycle is monotone (requests → in-progress → gone), so a requests-then-in-progress read pair cannot observe an empty union for a live request; the reader's non-atomicity is a round-trip count question, not a correctness one.
- **RESP3.** Lua `false` is a Boolean reply under RESP3, where a client could return `False` rather than `None`. The shipped stack uses redis-py's default RESP2, so no current configuration reaches it.
