### PR TITLE
plugin-format: bot-owner tri-state glob policy over vanilla MCP tool names

### DIFF
--- a/cli/plugin-format-mirrors.json
+++ b/cli/plugin-format-mirrors.json
@@ -33,7 +33,8 @@
         { "field": "systemPrompt", "why": "no approvals-verb output surfaces the agent's system prompt." },
         { "field": "starterPrompts", "why": "no approvals-verb output surfaces starter prompts." },
         { "field": "secrets", "why": "declared secret NAMES are surfaced by other verbs (skill up --secret), not skill approvals." },
-        { "field": "triggers", "why": "no approvals-verb output surfaces the manifest's trigger declarations." }
+        { "field": "triggers", "why": "no approvals-verb output surfaces the manifest's trigger declarations." },
+        { "field": "toolPolicy", "why": "the vanilla MCP tool-policy declaration is a runtime-enforcement contract with no runtime enforcing it yet and no output surface on skill approvals; when a verb surfaces it, this omission becomes a carried field." }
       ]
     },
     {

--- a/docs/interfaces/bundle-format/INTERFACE.md
+++ b/docs/interfaces/bundle-format/INTERFACE.md
@@ -24,11 +24,11 @@ The frozen bundle/plugin manifest format: the **Claude Code plugin shape verbati
 distribution wedge. What is swappable is the harness that consumes a bundle; what stays fixed is
 the shape a bundle must have to be accepted. The base is the Claude Code plugin shape, and the
 models are lenient (`extra="allow"`) rather than strict so any bundle written for Claude Code
-validates unchanged. On top of that base the package **does add five Curie authoring
-extensions** — `systemPrompt`, `starterPrompts`, `secrets`, `triggers`, `approvalPolicy` on
-`packages/plugin-format/src/plugin_format/models.py::PluginManifest`, optional fields Claude Code
-does not define. Leniency is what lets the Claude Code base and these extensions coexist; the
-earlier "does not invent format extensions" framing was wrong.
+validates unchanged. On top of that base the package **does add six Curie authoring
+extensions** — `systemPrompt`, `starterPrompts`, `secrets`, `triggers`, `approvalPolicy`,
+`toolPolicy` on `packages/plugin-format/src/plugin_format/models.py::PluginManifest`, optional
+fields Claude Code does not define. Leniency is what lets the Claude Code base and these
+extensions coexist; the earlier "does not invent format extensions" framing was wrong.
 
 The manifest is not the whole bundle either. Three **Curie-only root files** sit beside the Claude
 Code surfaces and are validated by the same entry point: `connectors.yaml` (ADR-0086, Accepted), its
@@ -146,7 +146,7 @@ script from `.github/workflows/plugin-compat.yaml` on two triggers, because drif
 directions: a path-filtered `pull_request` trigger catches our own drift when we touch the bundles
 or the format models, and a nightly `schedule` catches Claude Code changing the format under us,
 which no PR of ours would ever surface. The check is deliberately not `--strict`: strict mode
-promotes unknown-field warnings to errors, and the five Curie authoring extensions are
+promotes unknown-field warnings to errors, and the six Curie authoring extensions are
 unknown-to-Claude-Code by design, so warnings are the expected steady state and only a non-zero
 exit is a failure.
 
@@ -166,18 +166,32 @@ Code keys still validate.
 
 By intent, the manifest, skill, and MCP surfaces are Claude-Code-shaped — that is the wedge, not a
 leak. What the wedge
-costs is asymmetric fidelity: a bundle loaded by Claude Code **validates but degrades**. All five
+costs is asymmetric fidelity: a bundle loaded by Claude Code **validates but degrades**. All six
 Curie authoring extensions — `systemPrompt`, `starterPrompts`, `secrets`, `triggers`,
-`approvalPolicy` — are unknown fields to Claude Code, which warns about each and then silently
-ignores it at load time. The manifest is accepted and the commands, agents, hooks, and MCP servers
-work; the agent's persona, its suggested openers, its secret declarations, its wake-up triggers,
-and its approval gates do not travel. That degradation is by design (there is nowhere in the Claude
-Code shape to put them), but it is silent from the operator's side, so it is documented here rather
-than discovered.
+`approvalPolicy`, `toolPolicy` — are unknown fields to Claude Code, which warns about each and then
+silently ignores it at load time. The manifest is accepted and the commands, agents, hooks, and MCP
+servers work; the agent's persona, its suggested openers, its secret declarations, its wake-up
+triggers, its approval gates, and its tool policy do not travel. That degradation is by design
+(there is nowhere in the Claude Code shape to put them), but it is silent from the operator's side,
+so it is documented here rather than discovered.
+
+`toolPolicy` degrades **worse than the other five**, and the difference is the reason it is
+gated the way it is. The rest lose a capability: the agent is less useful. This one loses a
+**restriction**: a bundle whose tool surface is fenced by `toolPolicy`
+(`packages/plugin-format/src/plugin_format/models.py::ToolPolicy`) runs *unfenced* in Claude
+Code, with the manifest still claiming otherwise. That asymmetry is why the declaration carries a
+versioned `enforcement` discriminator, why `validate_bundle` refuses a policy-bearing bundle unless
+its caller states which contract it enforces
+(`packages/plugin-format/src/plugin_format/validate.py::_validate_tool_policy`, code
+`tool_policy.unenforced`), and why bundle adoption is blocked on the runtime lane. **This change is
+declaration and validation only: nothing enforces a `toolPolicy` at runtime today, that is a
+separate blocking follow-up, and no bundle may ship a policy until it lands.** The residual gap that
+no in-package mechanism can close: a platform built before this package version does not model the
+key at all, and the lenient models accept and silently ignore it.
 
 The two Curie-only root files degrade **more quietly still**, and they belong on the same list. A
 manifest extension at least draws a warning: `claude plugin validate examples/compat-fixture` (the
-fixture at `examples/compat-fixture/.claude-plugin/plugin.json`, which exists to carry all five)
+fixture at `examples/compat-fixture/.claude-plugin/plugin.json`, which exists to carry all six)
 reports one `Unknown field ... Claude Code ignores it at load time` warning per extension.
 `connectors.yaml` and `deploy.yaml` are not manifest fields at all, so Claude Code neither loads them
 nor mentions them: validating `examples/weather` (which carries `examples/weather/connectors.yaml`)
@@ -187,7 +201,7 @@ servers simply absent, and with no signal at all that anything was dropped. `dep
 harmlessly by comparison, since routing is Curie's concern and Claude Code has nothing to route.
 
 The outbound gate covers this unevenly, and the gap is worth naming.
-`examples/tests/test_plugin_compat_coverage.py` pins that each of the five manifest extensions
+`examples/tests/test_plugin_compat_coverage.py` pins that each of the six manifest extensions
 appears in at least one discovered example bundle, so the gate cannot cover them vacuously, but it
 checks manifest FIELDS only. `connectors.yaml` is exercised incidentally because the weather bundle
 happens to carry one; **no example bundle carries a `deploy.yaml`**, so nothing asserts that Claude
@@ -205,7 +219,7 @@ control, matching Claude Code convention for author-declared hooks. Only `PreToo
 other hook events validate but are not yet consumed. Epic #30 continues to define the remaining authoring extensions (approval-policy and
 trigger declarations) alongside this.
 
-Two of those Curie authoring extensions are **deploy-time validated** (shape enforced, malformed
+Three of those Curie authoring extensions are **deploy-time validated** (shape enforced, malformed
 declarations rejected), but they differ in whether the runtime acts on them yet:
 
 - `approvalPolicy` (`{gates: [{gate, route, grantableViaPolicy}]}` approval declarations, #273) is **consumed at
@@ -227,9 +241,29 @@ declarations rejected), but they differ in whether the runtime acts on them yet:
 - `triggers` (a list of `cron`/`webhook` declarations for waking the agent beyond chat, #273/#270 —
   see the [triggers seam](../triggers/INTERFACE.md)) is still **declaration-only**: its validator
   runs at deploy, but no runtime scheduler/ingress consumes a declared trigger yet (Epic #29).
+- `toolPolicy` (`{enforcement, allow, approvalRequired, deny}` glob collections over canonical
+  `"<server>/<tool>"` MCP tool names,
+  `packages/plugin-format/src/plugin_format/models.py::ToolPolicy`) is **declaration-only and
+  fenced as such**. Precedence is by class — `deny` > `approvalRequired` > `allow` — and an
+  unmatched tool is DENIED, so server tool-surface drift fails closed. The grammar and pattern
+  rules live in one shared module, `packages/plugin-format/src/plugin_format/tool_policy.py`, so
+  the deploy validator and the future runtime loader normalize identically — the #453/#544 lesson
+  that normalizing separately silently disagrees and ships a fail-open. The deploy validator
+  (`packages/plugin-format/src/plugin_format/validate.py::_validate_tool_policy`) calls that
+  module's `check_policy_patterns` / `validate_pattern` (grammar, duplicates, cross-collection
+  conflicts) and `literal_server_segment` (the declared-server cross-check) today; it never
+  classifies a live tool, because at deploy time there is no live tool surface to classify.
+  `packages/plugin-format/src/plugin_format/tool_policy.py::classify_tool`, the precedence ladder that turns a policy plus a runtime tool
+  name into allow/approval-required/deny, belongs to the not-yet-built runtime enforcement lane —
+  the deploy validator does not call it. Because a declared-but-unenforced restriction is worse
+  than no restriction, `validate_bundle`
+  takes an `enforces_tool_policy` handshake argument and REFUSES a policy-bearing bundle from any
+  caller that does not name `curie/mcp-tool-policy@1`; `load_tool_policy` raises rather than
+  returning a policy such a caller would not apply. Runtime enforcement is a separate **blocking**
+  follow-up, and no bundle may ship a `toolPolicy` until it lands.
 
-Their validators live alongside the others in `validate.py` (`triggers.*` / `approval_policy.*`
-error codes).
+Their validators live alongside the others in `validate.py` (`triggers.*` / `approval_policy.*` /
+`tool_policy.*` error codes).
 
 ## Cross-links
 

--- a/examples/compat-fixture/.claude-plugin/plugin.json
+++ b/examples/compat-fixture/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "compat-fixture",
   "version": "0.1.0",
-  "description": "Not a runnable agent: a plugin-compat gate fixture that carries all five Curie authoring extensions (systemPrompt, starterPrompts, secrets, triggers, approvalPolicy) so `claude plugin validate` exercises the warn-and-ignore degradation contract for every one of them (#538). A dedicated fixture keeps these fields off the real example bundles, where approvalPolicy and systemPrompt would change runtime behavior for no functional benefit.",
+  "description": "Not a runnable agent: a plugin-compat gate fixture that carries all six Curie authoring extensions (systemPrompt, starterPrompts, secrets, triggers, approvalPolicy, toolPolicy) so `claude plugin validate` exercises the warn-and-ignore degradation contract for every one of them (#538). A dedicated fixture keeps these fields off the real example bundles, where approvalPolicy and systemPrompt would change runtime behavior for no functional benefit. Its toolPolicy is NOT an adoption example: the patterns use wildcard server segments only (the fixture declares no MCP servers and no connectors.yaml), and no runtime enforces a toolPolicy yet.",
   "author": { "name": "CurieTech" },
   "keywords": ["fixture", "plugin-compat", "extensions"],
   "systemPrompt": "You are a compatibility fixture; you are never actually run.",
@@ -17,5 +17,11 @@
     "gates": [
       { "gate": "Bash", "route": "fixture-route" }
     ]
+  },
+  "toolPolicy": {
+    "enforcement": "curie/mcp-tool-policy@1",
+    "allow": ["*/search_*"],
+    "approvalRequired": ["*/pods_*"],
+    "deny": ["*/resources_create_or_update"]
   }
 }

--- a/examples/tests/test_plugin_compat_coverage.py
+++ b/examples/tests/test_plugin_compat_coverage.py
@@ -1,14 +1,15 @@
-"""The plugin-compat gate must exercise all five Curie authoring extensions.
+"""The plugin-compat gate must exercise all six Curie authoring extensions.
 
 `scripts/check-plugin-compat.sh` runs `claude plugin validate` over every bundle
-under `examples/`, asserting our five extension fields (systemPrompt,
-starterPrompts, secrets, triggers, approvalPolicy) stay warn-and-ignored rather
-than rejected by Claude Code. But the gate can only exercise a field that some
-discovered bundle actually declares -- and before the compat-fixture bundle,
-three of the five (systemPrompt, triggers, approvalPolicy) appeared in NO example
-manifest, so the gate silently covered only two of them (#538).
+under `examples/`, asserting our six extension fields (systemPrompt,
+starterPrompts, secrets, triggers, approvalPolicy, toolPolicy) stay
+warn-and-ignored rather than rejected by Claude Code. But the gate can only
+exercise a field that some discovered bundle actually declares -- and before the
+compat-fixture bundle, three of the then-five (systemPrompt, triggers,
+approvalPolicy) appeared in NO example manifest, so the gate silently covered
+only two of them (#538).
 
-This test defends that coverage: every one of the five fields must appear in at
+This test defends that coverage: every one of the six fields must appear in at
 least one discovered example bundle, so a future edit that drops a field from the
 fixture (leaving the gate to cover it vacuously) fails here.
 """
@@ -18,7 +19,7 @@ from pathlib import Path
 
 EXAMPLES = Path(__file__).resolve().parents[1]
 
-# The five Curie authoring extensions on the plugin manifest (plugin_format
+# The six Curie authoring extensions on the plugin manifest (plugin_format
 # models.py); each is unknown-to-Claude-Code by design and warned-and-ignored.
 _EXTENSION_FIELDS = (
     "systemPrompt",
@@ -26,6 +27,7 @@ _EXTENSION_FIELDS = (
     "secrets",
     "triggers",
     "approvalPolicy",
+    "toolPolicy",
 )
 
 

--- a/packages/plugin-format/README.md
+++ b/packages/plugin-format/README.md
@@ -66,6 +66,62 @@ Pydantic models mirroring the Claude Code shapes:
   expected form; to arm a live tool name the bundle does not declare, use the
   per-agent `CURIE_APPROVAL_REQUIRED_TOOLS` env knob instead. Runtime approval
   routing is a separate not-yet-built seam, so this is validation only today.
+- `ToolPolicy` (the manifest `toolPolicy` field): the vanilla MCP tool policy —
+  `{enforcement, allow, approvalRequired, deny}`, three glob collections over
+  **canonical `"<server>/<tool>"` tool names**. The server segment is required
+  because two servers may publish the same tool name; the canonical form is
+  deliberately **not** the SDK's live tool name, which is namespaced two
+  different ways depending on how the server is mounted
+  (`mcp__plugin_<bundle>_<server>__<tool>` for a plugin-loaded `mcpServers`
+  entry, `mcp__<connector>__<tool>` for a `connectors.yaml` connector, #1495).
+  Mapping canonical → live is the runtime's job, not the author's.
+  - **Precedence is by class, never by specificity**: `deny` > `approvalRequired`
+    > `allow`. A tool no collection matches is **DENIED**, so a tool a server
+    starts advertising after the bundle was authored fails closed.
+  - **Grammar** (`tool_policy.validate_pattern`): exactly one `/`, both segments
+    non-empty, each segment drawn from `A-Za-z0-9_.-` plus the wildcards `*` and
+    `?`. `**`, `[...]` character classes, whitespace, and any other character are
+    rejected at deploy. `*` matches **within a segment only** and never crosses
+    the `/`, and matching is **case-sensitive** (`fnmatch.fnmatchcase`).
+  - **The grammar is narrower than a protocol-legal MCP name**, on purpose. MCP's
+    tool-name character rule is a SHOULD and a server key may be any string, so a
+    name this grammar cannot spell does exist (`@scope/github`, `search:docs`).
+    The grammar constrains what a *pattern* may contain, not the runtime name
+    matching applies to, so such a name cannot be targeted LITERALLY — no legal
+    pattern spells it out exactly — but a legal WILDCARD pattern still reaches
+    it: `grafana/search_*` matches the runtime tool `grafana/search:docs` via
+    `fnmatchcase` on the unrestricted live name, even though `:` cannot appear in
+    a literal pattern. That makes an unspellable name a **widening** path, not a
+    narrowing one. Prefer a literal pattern for any name you can spell, and treat
+    a wildcard as granting every name of that matched shape, spellable or not.
+  - `enforcement` is a required, versioned discriminator
+    (`"curie/mcp-tool-policy@1"`, exported as
+    `plugin_format.TOOL_POLICY_ENFORCEMENT`). A future v2 semantics is a NEW id
+    that a v1 build rejects rather than reinterpreting.
+  - **The enforcement handshake.** `validate_bundle(path,
+    enforces_tool_policy=...)` REJECTS a bundle that declares a `toolPolicy`
+    unless the caller names the supported contract id
+    (`tool_policy.unenforced`), and `load_tool_policy(manifest, enforces=...)`
+    RAISES `ToolPolicyUnenforceable` rather than handing a policy to a caller
+    that would not apply it. There is deliberately no return value meaning
+    "declared but not enforced" — that shape is how a fail-open ships.
+  - **Deploy-time validation** rejects a non-object policy, an unknown key
+    (`ToolPolicy` is strict where the rest of this package is lenient: a
+    misspelled collection such as `denny` would otherwise be silently dropped and
+    a typo would become permission *widening*), an unsupported `enforcement` id,
+    a malformed pattern, a pattern repeated within one collection, the identical
+    pattern string in two collections, and a literal server segment naming a
+    server the bundle declares in neither `mcpServers` nor `connectors.yaml`.
+    Overlapping but *different* globs are legal and resolve by precedence. A
+    policy with all three collections empty warns (`tool_policy.denies_everything`)
+    but still validates: it denies everything, which is coherent.
+  - **DECLARATION-ONLY today.** Nothing enforces a `toolPolicy` at runtime yet;
+    that lane is a **blocking follow-up**, and **no bundle may ship a `toolPolicy`
+    until it lands**. The residual gap, stated rather than discovered: a platform
+    built before this package version does not model the key at all, and the
+    lenient `PluginManifest` accepts and silently ignores it. Nothing in this
+    package can reach such a platform — the `enforcement` discriminator and the
+    handshake only gate consumers that already parse the field.
 - `scripts/` is a directory convention (no manifest schema of its own).
 
 `validate_bundle(path) -> ValidationResult` is the entry point the bundle pipeline calls. It
@@ -89,7 +145,14 @@ Error codes include `bundle.missing`, `manifest.missing`,
 `triggers.unknown_type`, `triggers.cron_missing_schedule`,
 `triggers.webhook_missing_path`, `approval_policy.invalid`,
 `approval_policy.incomplete`, `approval_policy.gate_not_namespaced`,
-`scripts.not_a_directory`.
+`tool_policy.unenforced`, `tool_policy.invalid`,
+`tool_policy.enforcement_unsupported`, `tool_policy.pattern_invalid`,
+`tool_policy.pattern_duplicate`, `tool_policy.pattern_conflict`,
+`tool_policy.unknown_server`, `scripts.not_a_directory`.
+
+`tool_policy.denies_everything` is the one **warning** code in this list, not an
+error: it reports a declared policy whose three collections are all empty, which
+denies every tool. That is fail-closed and coherent, so it validates.
 
 ## Frozen-interface rule
 

--- a/packages/plugin-format/schema/plugin-format.schema.json
+++ b/packages/plugin-format/schema/plugin-format.schema.json
@@ -446,6 +446,19 @@
           "default": null,
           "title": "Systemprompt"
         },
+        "toolPolicy": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Toolpolicy"
+        },
         "triggers": {
           "anyOf": [
             {
@@ -511,6 +524,40 @@
         "description"
       ],
       "title": "SkillFrontmatter",
+      "type": "object"
+    },
+    "ToolPolicy": {
+      "additionalProperties": false,
+      "description": "The manifest ``toolPolicy`` object: tri-state globs over MCP tool names.\n\nPatterns are canonical ``\"<server>/<tool>\"`` globs -- server-qualified and\ntransport-independent -- NOT live SDK tool names. Precedence is by CLASS and\nnever by specificity: ``deny`` > ``approvalRequired`` > ``allow``. A tool no\ncollection matches is **DENIED**, so a tool a server begins advertising after\nthe bundle was authored fails closed rather than being inherited. The three\ncollections default to empty lists so an omitted collection means \"matches\nnothing\", never \"matches everything\"; ``approvalRequired`` is camelCase to\nmatch ``grantableViaPolicy`` / ``starterPrompts``.\n\n``enforcement`` is a mandatory, versioned discriminator\n(``tool_policy.TOOL_POLICY_ENFORCEMENT``), so a future v2 semantics ships as a\nNEW id that a v1 platform REJECTS at ``validate_bundle`` rather than\nreinterpreting under v1 rules. It is *modelled* with an empty default rather\nthan as a pydantic-required field so that OMITTING it lands on the pointed\n``tool_policy.enforcement_unsupported`` error -- which names the id this build\nimplements -- instead of an opaque \"field required\". The empty string is not a\ncontract id, so it is refused exactly like a wrong one; there is no value of\nthis field that means \"unset, so apply the default semantics\".\n\n**This model is STRICT (``extra=\"forbid\"``) where every other model in this\nfile is lenient, and that difference is load-bearing.** Leniency exists to\ntolerate keys Claude Code may add to shapes it owns; this object is\nCurie-owned, so no external producer can legitimately carry an unknown key in\nit. Under leniency a misspelled collection (``\"denny\"``) would validate, the\nintended deny list would be silently dropped from classification, and a typo\nwould become permission WIDENING. ``ConnectorSpec``, ``ConnectorLockEntry`` and\n``DeployTarget`` forbid extras for the same reason. ``PluginManifest`` itself\nstays lenient -- only this object is strict.",
+      "properties": {
+        "allow": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Allow",
+          "type": "array"
+        },
+        "approvalRequired": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Approvalrequired",
+          "type": "array"
+        },
+        "deny": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Deny",
+          "type": "array"
+        },
+        "enforcement": {
+          "default": "",
+          "title": "Enforcement",
+          "type": "string"
+        }
+      },
+      "title": "ToolPolicy",
       "type": "object"
     },
     "TriggerDeclaration": {

--- a/packages/plugin-format/src/plugin_format/__init__.py
+++ b/packages/plugin-format/src/plugin_format/__init__.py
@@ -33,9 +33,23 @@ from .models import (
     McpServer,
     PluginManifest,
     SkillFrontmatter,
+    ToolPolicy,
     TriggerDeclaration,
 )
 from .reserved_env import RESERVED_BOOT_ENV, is_reserved_boot_env_name
+from .tool_policy import (
+    TOOL_POLICY_ENFORCEMENT,
+    ToolPolicyDecision,
+    ToolPolicyInvalid,
+    ToolPolicyPatternIssue,
+    ToolPolicyUnenforceable,
+    check_policy_patterns,
+    classify_tool,
+    literal_server_segment,
+    load_tool_policy,
+    policy_patterns,
+    validate_pattern,
+)
 from .validate import ValidationIssue, ValidationResult, validate_bundle
 
 __version__ = "0.0.0"
@@ -56,11 +70,23 @@ __all__ = [
     "TriggerDeclaration",
     "ApprovalPolicy",
     "ApprovalGate",
+    "ToolPolicy",
     "grantable_routes",
     "declared_mcp_server_names",
     "connector_server_names",
     "connector_tool_prefix",
     "effective_operator_gates",
+    "TOOL_POLICY_ENFORCEMENT",
+    "ToolPolicyDecision",
+    "ToolPolicyInvalid",
+    "ToolPolicyPatternIssue",
+    "ToolPolicyUnenforceable",
+    "validate_pattern",
+    "literal_server_segment",
+    "policy_patterns",
+    "check_policy_patterns",
+    "classify_tool",
+    "load_tool_policy",
     "validate_bundle",
     "ValidationResult",
     "ValidationIssue",

--- a/packages/plugin-format/src/plugin_format/models.py
+++ b/packages/plugin-format/src/plugin_format/models.py
@@ -69,10 +69,24 @@ class PluginManifest(BaseModel):
     secrets: list[str] | None = None
     # Curie authoring extensions (epic #30 / #29), validated at deploy time by
     # ``validate.py``. Kept loosely typed on the manifest (the models stay
-    # lenient); the dedicated ``TriggerDeclaration`` / ``ApprovalPolicy`` models
-    # below carry the shape the validator enforces.
+    # lenient); the dedicated ``TriggerDeclaration`` / ``ApprovalPolicy`` /
+    # ``ToolPolicy`` models below carry the shape the validator enforces.
     triggers: list[Any] | None = None
     approvalPolicy: dict[str, Any] | None = None
+    # Curie authoring extension: the vanilla MCP tool policy. Tri-state glob
+    # collections over CANONICAL ``"<server>/<tool>"`` tool names -- server
+    # qualified and transport-independent, deliberately NOT the SDK's live
+    # ``mcp__...`` name (see ``tool_policy``'s module docstring). DECLARATION-ONLY
+    # today: nothing enforces it at runtime yet, that lane is a BLOCKING
+    # follow-up, and no bundle may ship a real policy until it lands.
+    # ``tool_policy.load_tool_policy`` is the only supported reader -- it refuses
+    # to hand a policy to a caller that does not name the enforcement contract,
+    # and ``validate_bundle`` rejects a policy-bearing bundle whose caller does
+    # not either. Loose typing here (identical to ``approvalPolicy``) so an
+    # unparseable declaration surfaces as an actionable ``tool_policy.*``
+    # validator error rather than an opaque manifest-level pydantic failure that
+    # would reject the whole bundle.
+    toolPolicy: dict[str, Any] | None = None
 
 
 # Trigger types the manifest may declare beyond inbound chat (epic #29). The
@@ -121,6 +135,47 @@ class ApprovalPolicy(BaseModel):
     model_config = _LENIENT
 
     gates: list[ApprovalGate] = Field(default_factory=list)
+
+
+class ToolPolicy(BaseModel):
+    """The manifest ``toolPolicy`` object: tri-state globs over MCP tool names.
+
+    Patterns are canonical ``"<server>/<tool>"`` globs -- server-qualified and
+    transport-independent -- NOT live SDK tool names. Precedence is by CLASS and
+    never by specificity: ``deny`` > ``approvalRequired`` > ``allow``. A tool no
+    collection matches is **DENIED**, so a tool a server begins advertising after
+    the bundle was authored fails closed rather than being inherited. The three
+    collections default to empty lists so an omitted collection means "matches
+    nothing", never "matches everything"; ``approvalRequired`` is camelCase to
+    match ``grantableViaPolicy`` / ``starterPrompts``.
+
+    ``enforcement`` is a mandatory, versioned discriminator
+    (``tool_policy.TOOL_POLICY_ENFORCEMENT``), so a future v2 semantics ships as a
+    NEW id that a v1 platform REJECTS at ``validate_bundle`` rather than
+    reinterpreting under v1 rules. It is *modelled* with an empty default rather
+    than as a pydantic-required field so that OMITTING it lands on the pointed
+    ``tool_policy.enforcement_unsupported`` error -- which names the id this build
+    implements -- instead of an opaque "field required". The empty string is not a
+    contract id, so it is refused exactly like a wrong one; there is no value of
+    this field that means "unset, so apply the default semantics".
+
+    **This model is STRICT (``extra="forbid"``) where every other model in this
+    file is lenient, and that difference is load-bearing.** Leniency exists to
+    tolerate keys Claude Code may add to shapes it owns; this object is
+    Curie-owned, so no external producer can legitimately carry an unknown key in
+    it. Under leniency a misspelled collection (``"denny"``) would validate, the
+    intended deny list would be silently dropped from classification, and a typo
+    would become permission WIDENING. ``ConnectorSpec``, ``ConnectorLockEntry`` and
+    ``DeployTarget`` forbid extras for the same reason. ``PluginManifest`` itself
+    stays lenient -- only this object is strict.
+    """
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    enforcement: str = ""
+    allow: list[str] = Field(default_factory=list)
+    approvalRequired: list[str] = Field(default_factory=list)
+    deny: list[str] = Field(default_factory=list)
 
 
 class SkillFrontmatter(BaseModel):

--- a/packages/plugin-format/src/plugin_format/schema_export.py
+++ b/packages/plugin-format/src/plugin_format/schema_export.py
@@ -20,6 +20,7 @@ from .models import (
     McpServer,
     PluginManifest,
     SkillFrontmatter,
+    ToolPolicy,
     TriggerDeclaration,
 )
 
@@ -34,6 +35,7 @@ _MODELS = (
     TriggerDeclaration,
     ApprovalPolicy,
     ApprovalGate,
+    ToolPolicy,
 )
 
 SCHEMA_ID = "https://curietech.ai/schemas/plugin-format.schema.json"

--- a/packages/plugin-format/src/plugin_format/tool_policy.py
+++ b/packages/plugin-format/src/plugin_format/tool_policy.py
@@ -1,0 +1,478 @@
+"""Normalize and classify the manifest's vanilla MCP tool policy (`toolPolicy`).
+
+This module is the SINGLE normalization shared by the deploy-time validator
+(``plugin_format.validate._validate_tool_policy``) and the runtime loader that
+will enforce ``curie/mcp-tool-policy@1`` (not built yet -- a BLOCKING follow-up).
+Sharing one helper makes the two paths identical *by construction* -- the
+#453/#544 lesson that a validator and a runtime loader normalizing separately
+silently disagree and ship a fail-open. ``approval_policy.py`` exists for exactly
+that reason; an implementer who inlines the glob grammar or the precedence ladder
+into ``validate.py`` "because it is only used once" reintroduces it.
+
+**The canonical tool name is ``"<server>/<tool>"``.** It is server-qualified
+because two servers may publish the same tool name, and it is deliberately NOT
+the SDK's live tool name. A live name is namespaced two DIFFERENT ways depending
+on how the server is mounted: ``mcp__plugin_<bundle>_<server>__<tool>`` for a
+plugin-loaded ``mcpServers`` entry (``approval_policy.effective_tool_prefix``)
+versus ``mcp__<connector>__<tool>`` for a ``connectors.yaml`` connector
+(``approval_policy.connector_tool_prefix``, #1495). Making the author write the
+live form would repeat the #453/#1495 authoring trap in a place where the failure
+is a silent permission GRANT rather than a silent missed approval. Mapping
+canonical -> live SDK name is the runtime lane's job and is out of scope here.
+
+**Declaration-only today.** Nothing in this repository enforces a ``toolPolicy``
+at runtime yet. ``load_tool_policy`` refuses to hand a policy to a caller that
+does not name ``TOOL_POLICY_ENFORCEMENT``, and ``validate_bundle`` REJECTS a
+policy-bearing bundle unless its caller passes the same id -- together those keep
+"declared" and "enforced" from drifting apart. No bundle may ship a real policy
+until the runtime lane lands.
+
+Both paths run the SAME ``check_policy_patterns``: ``validate.py`` renders its
+issues one ``ValidationIssue`` per pattern, ``load_tool_policy`` collapses them
+into a ``ToolPolicyInvalid``. Neither owns a rule the other lacks, so a policy
+the deploy validator refuses can never be loaded by a runtime.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import StrEnum
+from fnmatch import fnmatchcase
+
+from .models import PluginManifest, ToolPolicy
+
+# The enforcement contract a bundle must name and a runtime must implement. It is
+# a wire constant, not an identifier: a bundle writes it verbatim in its manifest
+# and every consumer compares it byte-for-byte. A future change of SEMANTICS is a
+# NEW id (``@2``), which a v1 build refuses outright rather than reinterpreting
+# under v1 rules -- the versioned-discriminator half of the fail-closed design.
+TOOL_POLICY_ENFORCEMENT = "curie/mcp-tool-policy@1"
+
+# The canonical-name / pattern grammar, stated ONCE: exactly one "/", both
+# segments non-empty, each segment drawn from A-Za-z0-9_.- plus the wildcards "*"
+# and "?". ``validate_pattern`` is the whole rule; this expression is its
+# character half, written negatively so a rejection can name the offending
+# characters. One mechanism deliberately, not two: a second anchored whole-string
+# regex saying the same thing is a synchronization burden with no reachable
+# check behind it.
+#
+# This is deliberately NARROWER than a protocol-legal MCP name. MCP's tool-name
+# character rule is a SHOULD and its schema leaves ``name`` an unconstrained
+# string, and ``McpConfig`` accepts an arbitrary string as a server key, so a name
+# this grammar cannot express does exist (``@scope/github``, ``search:docs``).
+# That narrowness is FAIL-CLOSED, not a hole: a name the policy cannot spell is
+# matched by no pattern and therefore DENIED by ``classify_tool``'s unmatched
+# default. A bundle that must reach such a server reaches it through a wildcard
+# segment, and accepts the widening that implies.
+_DISALLOWED_CHAR_RE = re.compile(r"[^A-Za-z0-9_.*?/-]")
+
+# The collections, in PRECEDENCE order. Everything that iterates the policy walks
+# this tuple, so adding a fourth collection cannot be half-implemented: the
+# classifier, the pattern checker and the validator all pick it up at once.
+_COLLECTIONS = ("deny", "approvalRequired", "allow")
+
+
+class ToolPolicyDecision(StrEnum):
+    """What the policy says about one canonical tool name.
+
+    The values are wire strings: they are serialized into approval records and
+    logs, so they are pinned by test rather than free to follow the member names.
+    """
+
+    ALLOW = "allow"
+    APPROVAL_REQUIRED = "approval-required"
+    DENY = "deny"
+
+
+class ToolPolicyUnenforceable(Exception):
+    """A ``toolPolicy`` is declared but this call path cannot enforce it.
+
+    Raised rather than returned, deliberately. ``None`` would be
+    indistinguishable from "no policy declared", and a ``(policy, enforced:
+    bool)`` tuple is exactly the shape a caller drops on the floor -- the #520
+    lesson that "cannot verify" must fail CLOSED and LOUDLY, never through.
+    """
+
+
+class ToolPolicyInvalid(Exception):
+    """A ``toolPolicy`` is MALFORMED: one or more patterns fail the shared grammar.
+
+    Deliberately NOT ``ToolPolicyUnenforceable``. "This bundle asks for semantics
+    I do not implement" and "this policy is not well-formed" are different
+    failures with different fixes, and a caller that catches only the first must
+    not silently swallow the second.
+
+    ``load_tool_policy`` raises this so no caller can obtain a ``ToolPolicy``
+    whose patterns the deploy validator would have REFUSED. That gap is the
+    #453/#544 drift in its most dangerous form: ``_matches`` hands whatever
+    strings the collections carry to ``fnmatchcase``, so a pattern the grammar
+    forbids still gets real matching semantics -- ``grafana/[a-z]*`` becomes a
+    live character class that can ALLOW tools in a bundle ``validate_bundle``
+    would have rejected.
+    """
+
+
+@dataclass(frozen=True)
+class ToolPolicyPatternIssue:
+    """One declaration-level defect found in a policy's pattern collections.
+
+    ``code`` is the bare code (``pattern_invalid`` / ``pattern_duplicate`` /
+    ``pattern_conflict``); the validator prefixes it with ``tool_policy.``.
+    ``collection`` and ``index`` locate the offending entry so the validator can
+    build ``plugin.json (toolPolicy.<collection>[<i>])`` without knowing anything
+    about the grammar itself.
+    """
+
+    code: str
+    collection: str
+    index: int
+    pattern: str
+    message: str
+
+
+def validate_pattern(pattern: str) -> str | None:
+    """The reason ``pattern`` is not a legal canonical glob, or ``None`` if it is.
+
+    ``None`` means "no reason to reject" -- the same no-news-is-good-news shape
+    the validator's other shape helpers use. Every rejection carries a
+    human-readable reason naming WHICH rule failed, because that string is what a
+    bundle author sees at deploy; "unsupported character" for a ``**`` would send
+    them hunting the wrong thing.
+
+    The rules, in the order they are reported:
+
+    - non-blank (an empty or whitespace-only pattern matches nothing and is
+      always an editing accident);
+    - no whitespace anywhere (a canonical tool name carries none, so a pattern
+      containing one is an inert rule the author believes is live);
+    - no ``**`` (a two-segment namespace has no recursive level for it to mean,
+      so it is genuinely ambiguous rather than merely unsupported);
+    - no ``[`` / ``]`` character classes (``fnmatch``'s classes are
+      locale-sensitive, which would make a policy's meaning depend on the machine
+      that evaluates it);
+    - exactly one ``/``, with both segments non-empty;
+    - every remaining character drawn from ``A-Za-z0-9_.-`` plus ``*`` and ``?``.
+
+    Those rules ARE the grammar; there is no second whole-string regex behind
+    them to keep in sync.
+    """
+
+    if not pattern or not pattern.strip():
+        return "a pattern must be a non-blank '<server>/<tool>' glob"
+    if any(ch.isspace() for ch in pattern):
+        return "a pattern must not contain whitespace"
+    if "**" in pattern:
+        return (
+            "'**' has no meaning in a two-segment '<server>/<tool>' name; use a "
+            "single '*' in the segment you mean to widen"
+        )
+    if "[" in pattern or "]" in pattern:
+        return (
+            "character classes ('[...]') are not supported: they are "
+            "locale-sensitive, so the policy's meaning would depend on the "
+            "machine evaluating it"
+        )
+    if pattern.count("/") != 1:
+        return (
+            "a pattern must contain exactly one '/' separating the server from "
+            "the tool (canonical names are '<server>/<tool>')"
+        )
+    server, tool = pattern.split("/", 1)
+    if not server or not tool:
+        return "both the server and the tool segment must be non-empty"
+    bad = sorted({m.group() for m in _DISALLOWED_CHAR_RE.finditer(pattern)})
+    if bad:
+        joined = ", ".join(repr(ch) for ch in bad)
+        return (
+            f"unsupported character(s) {joined}: a segment may contain only "
+            "letters, digits, '_', '.', '-' and the wildcards '*' and '?'"
+        )
+    return None
+
+
+def literal_server_segment(pattern: str) -> str | None:
+    """The pattern's server segment when it names ONE literal server, else ``None``.
+
+    ``None`` for a malformed pattern (its own error already fired) and for a
+    wildcarded segment (``*/search_*``), which is the deliberate escape hatch for
+    a bundle whose servers are not statically declared and is therefore never
+    cross-checked against the declared set. Living here rather than in
+    ``validate.py`` keeps the validator from re-deriving where a segment ends.
+    """
+
+    if validate_pattern(pattern) is not None:
+        return None
+    server = pattern.split("/", 1)[0]
+    if "*" in server or "?" in server:
+        return None
+    return server
+
+
+def policy_patterns(policy: ToolPolicy) -> list[tuple[str, int, str]]:
+    """``(collection, index, pattern)`` for every declared pattern, in precedence order.
+
+    One list rather than three loops, so a caller cannot forget a collection --
+    and so a fourth collection added to ``_COLLECTIONS`` reaches every consumer at
+    once instead of silently going unchecked in one of them.
+    """
+
+    out: list[tuple[str, int, str]] = []
+    for collection in _COLLECTIONS:
+        for i, pattern in enumerate(getattr(policy, collection)):
+            out.append((collection, i, pattern))
+    return out
+
+
+def check_policy_patterns(policy: ToolPolicy) -> list[ToolPolicyPatternIssue]:
+    """Every declaration-level defect in ``policy``'s pattern collections.
+
+    The SHARED half of the deploy check: grammar, within-collection duplicates,
+    and cross-collection identical strings. ``validate.py`` renders these into
+    ``ValidationIssue``s and adds only the bundle-scoped unknown-server check on
+    top, so the future runtime loader reuses these exact rules rather than
+    reimplementing them (#453/#544).
+
+    Overlapping-but-DIFFERENT globs are legal and are NOT reported: overlap is
+    the normal authoring idiom (``deny */pods_delete`` narrowing
+    ``approvalRequired */pods_*``) and resolves deterministically by class
+    precedence. The identical STRING in two collections carries no information
+    the precedence rule can use -- it is a copy-paste error whose stated intent
+    (both) would be silently reduced to one, the #558 "validates green while
+    arming nothing" shape.
+
+    The scan never returns early: an author who gets one defect per ``curie
+    build`` round-trips once per typo.
+    """
+
+    issues: list[ToolPolicyPatternIssue] = []
+    # Where each well-formed pattern has already been seen, in precedence order,
+    # so a later collection can name the earlier ones it collides with.
+    seen: dict[str, list[str]] = {}
+
+    for collection in _COLLECTIONS:
+        within: set[str] = set()
+        for i, pattern in enumerate(getattr(policy, collection)):
+            reason = validate_pattern(pattern)
+            if reason is not None:
+                issues.append(
+                    ToolPolicyPatternIssue(
+                        code="pattern_invalid",
+                        collection=collection,
+                        index=i,
+                        pattern=pattern,
+                        message=f"invalid tool pattern {pattern!r}: {reason}",
+                    )
+                )
+                # A pattern that failed the grammar cannot be meaningfully
+                # duplicate- or conflict-checked; reporting it three times would
+                # bury the one message that says how to fix it.
+                continue
+
+            if pattern in within:
+                issues.append(
+                    ToolPolicyPatternIssue(
+                        code="pattern_duplicate",
+                        collection=collection,
+                        index=i,
+                        pattern=pattern,
+                        message=(
+                            f"tool pattern {pattern!r} is listed more than once in "
+                            f"'{collection}'; the repeat classifies nothing extra, "
+                            "so it is an editing accident. Remove the duplicate."
+                        ),
+                    )
+                )
+                continue
+            within.add(pattern)
+
+            earlier = seen.get(pattern)
+            if earlier:
+                named = ", ".join(f"'{c}'" for c in earlier)
+                issues.append(
+                    ToolPolicyPatternIssue(
+                        code="pattern_conflict",
+                        collection=collection,
+                        index=i,
+                        pattern=pattern,
+                        message=(
+                            f"tool pattern {pattern!r} is declared in '{collection}' "
+                            f"and also in {named}. Precedence is deny > "
+                            "approvalRequired > allow, so only the "
+                            "highest-precedence collection would take effect and "
+                            "the rest of the stated intent is silently dropped. "
+                            "Overlapping but DIFFERENT globs are legal and resolve "
+                            "by precedence; the same string in two collections is "
+                            "a declaration error. Keep it in one collection."
+                        ),
+                    )
+                )
+            seen.setdefault(pattern, []).append(collection)
+
+    return issues
+
+
+def _matches(pattern: str, server: str, tool: str) -> bool:
+    """Whether ``pattern`` matches the canonical name already split into its segments.
+
+    Server-vs-server and tool-vs-tool are matched INDEPENDENTLY, never as one
+    string: globbing the whole string would let ``*`` cross the ``/``, so
+    ``grafana/*`` would reach ``grafana/x/y`` and a trailing ``*`` would widen
+    across servers -- a silent, total widening of the allow list.
+
+    ``fnmatchcase``, not ``fnmatch``: ``fnmatch`` normalizes case on some
+    platforms, which would make every pattern case-INSENSITIVE on those machines
+    and let ``K8s/Resources_Create`` slip an allow written for
+    ``k8s/resources_create``. That is a platform-dependent permission widening,
+    which is worse than a wrong rule because it is invisible where it is authored.
+
+    The CALLER splits the canonical name (``classify_tool`` does it once per
+    call, not once per pattern) and guarantees it had exactly two segments; a
+    name that did not is refused there, which keeps the fail-closed default
+    honest for a malformed runtime name. The pattern is still split here because
+    the collections store plain strings -- pre-splitting or precompiling them
+    would change ``ToolPolicy``, which is part of the manifest contract.
+    """
+
+    pattern_parts = pattern.split("/")
+    if len(pattern_parts) != 2:
+        return False
+    return fnmatchcase(server, pattern_parts[0]) and fnmatchcase(tool, pattern_parts[1])
+
+
+def classify_tool(policy: ToolPolicy, canonical_tool_name: str) -> ToolPolicyDecision:
+    """Classify one canonical ``"<server>/<tool>"`` name against ``policy``.
+
+    Precedence is by CLASS and never by pattern specificity: ``deny`` beats
+    ``approvalRequired`` beats ``allow``, even when the losing pattern is the
+    narrower one. "Most specific wins" is the tempting reading and the dangerous
+    one -- a narrow ``allow`` sitting inside a broad ``approvalRequired`` would
+    silently drop the human out of the operation the broad glob was written to
+    gate.
+
+    A name no collection matches is **DENIED**. That default, not the pattern
+    lists, is what actually defends the capability: a tool a server begins
+    advertising after the bundle was authored is refused rather than inherited,
+    so server tool-surface drift fails closed. It also makes a policy with three
+    empty collections coherent (it denies everything) rather than vacuous.
+
+    Each collection is scanned in FULL before the ladder moves on; the ladder is
+    a precedence order over classes, never "the first collection that happens to
+    contain a match". The shape is adjacent to ``effective_operator_gates``'s
+    union-of-rules (#1564), where an early return IS a fail-open -- here the early
+    return is the precedence rule itself, so do not restructure the two to match.
+    """
+
+    # Split ONCE, here: this is the future runtime's per-tool, per-turn hot path,
+    # and splitting inside ``_matches`` re-derived the same two segments for every
+    # pattern in the policy.
+    name_parts = canonical_tool_name.split("/")
+    if len(name_parts) != 2:
+        # A name that is not exactly two segments is spelled by no legal pattern,
+        # so it matches nothing and lands on the same DENY default an unmatched
+        # name gets. Stated here rather than discovered per pattern.
+        return ToolPolicyDecision.DENY
+    server, tool = name_parts
+
+    if any(_matches(p, server, tool) for p in policy.deny):
+        return ToolPolicyDecision.DENY
+    if any(_matches(p, server, tool) for p in policy.approvalRequired):
+        return ToolPolicyDecision.APPROVAL_REQUIRED
+    if any(_matches(p, server, tool) for p in policy.allow):
+        return ToolPolicyDecision.ALLOW
+    return ToolPolicyDecision.DENY
+
+
+def load_tool_policy(manifest: PluginManifest, *, enforces: str | None) -> ToolPolicy | None:
+    """The manifest's parsed ``toolPolicy``, or ``None`` when it declares none.
+
+    ``enforces`` is the caller's statement of which enforcement contract IT
+    implements; ``None`` means "this code path does not enforce tool policy at
+    all". The handshake is two-sided and both sides must name
+    ``TOOL_POLICY_ENFORCEMENT``:
+
+    - the CALLER's ``enforces`` must match, so a build with no enforcement path
+      can never obtain a policy object it would then quietly not apply;
+    - the BUNDLE's own ``enforcement`` must match too, even when the caller's id
+      is right, because a bundle asking for ``@2`` semantics is asking for rules
+      this build does not implement. Applying ``@1`` rules to it would hand the
+      author a different policy than the one they wrote.
+
+    Either mismatch raises ``ToolPolicyUnenforceable``. There is deliberately no
+    return value that means "declared but not applied".
+
+    A manifest with no ``toolPolicy`` returns ``None`` for EVERY ``enforces``
+    value, including ``None``. That is the backward-compatible path every bundle
+    shipped to date takes: absence is not a declaration, so it can never be
+    unenforceable.
+
+    The policy's PATTERNS are then checked with ``check_policy_patterns`` -- the
+    same call ``validate.py`` makes -- and any defect raises
+    ``ToolPolicyInvalid``. A caller can therefore never hold a ``ToolPolicy``
+    whose patterns the deploy validator would have refused.
+
+    The ORDER is deliberate and load-bearing in two places. The caller check runs
+    BEFORE parsing, so "no enforcement -> no policy object, ever" is true by
+    structure rather than by a branch someone can rearrange. And the whole
+    enforcement handshake -- caller first, then the bundle's own id -- is checked
+    BEFORE pattern validity: a consumer that cannot enforce this contract must be
+    turned away whatever the policy's shape, and leading with a glob complaint
+    would imply that fixing the glob makes the bundle loadable here.
+    """
+
+    declared = manifest.toolPolicy
+    if declared is None:
+        return None
+
+    if not isinstance(declared, dict):
+        raise ToolPolicyUnenforceable(
+            "toolPolicy must be an object; a non-object declaration cannot be "
+            "parsed into a policy, and ignoring it would run the agent unfenced"
+        )
+
+    if enforces != TOOL_POLICY_ENFORCEMENT:
+        raise ToolPolicyUnenforceable(
+            f"this bundle declares a toolPolicy, but the caller enforces {enforces!r} "
+            f"rather than {TOOL_POLICY_ENFORCEMENT!r}. Refusing to hand back a policy "
+            "no one would apply."
+        )
+
+    policy = ToolPolicy.model_validate(declared)
+
+    # Compared EXACTLY -- deliberately NOT stripped. The id is a wire constant,
+    # so " curie/mcp-tool-policy@1 " is simply not it, and refusing it loudly is
+    # the fail-closed direction: a stray space in a manifest earns a pointed
+    # error instead of being silently treated as v1. This differs on purpose from
+    # ``approval_policy.py``, which strips GATE names so the validator and the
+    # runtime loader agree on one tool name; a version discriminator is not a
+    # tool name, and normalizing it would let two distinct wire strings claim the
+    # same contract. Do not "fix" this back to a ``.strip()``.
+    declared_enforcement = policy.enforcement
+    if declared_enforcement != TOOL_POLICY_ENFORCEMENT:
+        raise ToolPolicyUnenforceable(
+            f"this bundle declares toolPolicy.enforcement {declared_enforcement!r}, "
+            f"which this build does not implement (it implements "
+            f"{TOOL_POLICY_ENFORCEMENT!r}). Applying this build's rules to it would "
+            "silently give the author a different policy than the one they wrote."
+        )
+
+    # The SAME rules the deploy validator reports, from the SAME call:
+    # ``validate._validate_tool_policy`` renders each issue into a
+    # ``ValidationIssue`` (``tool_policy.<code>`` at
+    # ``toolPolicy.<collection>[<i>]``) so an author fixes every typo in one
+    # ``curie build``; here they collapse into a single refusal, because a
+    # runtime loader has no per-issue reporting surface and a partially-applied
+    # policy is not a thing. One source, two renderings -- re-deriving either
+    # side is exactly the #453/#544 validator-vs-runtime drift this module
+    # exists to prevent.
+    defects = check_policy_patterns(policy)
+    if defects:
+        detail = "; ".join(defect.message for defect in defects)
+        raise ToolPolicyInvalid(
+            f"this bundle's toolPolicy cannot be applied: {detail}. Refusing to "
+            "return a policy the deploy validator would have rejected: matching "
+            "would otherwise give a forbidden pattern real fnmatch semantics "
+            "(a character class, a stray '**') and could ALLOW tools."
+        )
+
+    return policy

--- a/packages/plugin-format/src/plugin_format/validate.py
+++ b/packages/plugin-format/src/plugin_format/validate.py
@@ -7,6 +7,7 @@ errors instead of raising, so the caller can surface every problem at once.
 
 import json
 import re
+from collections.abc import Callable, Mapping
 from pathlib import Path
 from typing import Any
 
@@ -38,9 +39,16 @@ from .models import (
     McpConfig,
     PluginManifest,
     SkillFrontmatter,
+    ToolPolicy,
     TriggerDeclaration,
 )
 from .reserved_env import SECRET_NAME_RE, is_reserved_boot_env_name
+from .tool_policy import (
+    TOOL_POLICY_ENFORCEMENT,
+    check_policy_patterns,
+    literal_server_segment,
+    policy_patterns,
+)
 from .yaml_loader import DuplicateKeyError, safe_load_unique
 
 # The hooks field is a mapping of event name -> list of matcher entries. Reused
@@ -79,8 +87,31 @@ class _Collector:
         return ValidationResult(valid=not self.errors, errors=self.errors, warnings=self.warnings)
 
 
-def validate_bundle(path: str | Path) -> ValidationResult:
-    """Validate the plugin bundle at ``path`` and return a ValidationResult."""
+def validate_bundle(
+    path: str | Path, *, enforces_tool_policy: str | None = None
+) -> ValidationResult:
+    """Validate the plugin bundle at ``path`` and return a ValidationResult.
+
+    ``enforces_tool_policy`` is the CALLER's statement of which vanilla MCP
+    tool-policy contract it enforces at runtime. It is the enforcement handshake,
+    and it is the point of the ``toolPolicy`` extension: a bundle that declares a
+    ``toolPolicy`` is REJECTED (``tool_policy.unenforced``) unless the caller
+    passes ``tool_policy.TOOL_POLICY_ENFORCEMENT``, which it may only do once it
+    actually applies the policy.
+
+    Without that rule the field would be worse than absent. It is tempting to
+    argue that a non-enforcing runtime "cannot obtain a parsed policy" because
+    ``load_tool_policy`` raises -- but nothing forces a consumer to call that
+    function. ``apps/api``'s bundle intake and the runner's plugin loader both
+    call ``validate_bundle(root)`` and neither reads ``toolPolicy`` at all, so
+    without this check both would accept a policy-bearing bundle and apply
+    nothing: a bundle that looks fenced and runs unfenced. With it, both REFUSE
+    such a bundle until the runtime lane exists to pass the id.
+
+    The keyword-only ``None`` default keeps every existing call site
+    source-compatible, and a bundle that declares no ``toolPolicy`` is entirely
+    unaffected -- it yields the same ``valid``/``errors``/``warnings`` as before.
+    """
 
     root = Path(path)
     c = _Collector()
@@ -95,7 +126,13 @@ def validate_bundle(path: str | Path) -> ValidationResult:
         mcp_servers = _validate_mcp(root, manifest, c)
         _validate_hooks(root, manifest, c)
         _validate_triggers(manifest, c)
-        _validate_approval_policy(manifest, mcp_servers, connector_server_names(root), c)
+        # One derivation of the connectors.yaml server names, shared by both
+        # cross-checks below. Computing it twice would re-read and re-parse the
+        # file and let the two checks assert against DIFFERENT sets on a racing
+        # or partially-written bundle -- the drift shape #453 is about.
+        connector_servers = connector_server_names(root)
+        _validate_approval_policy(manifest, mcp_servers, connector_servers, c)
+        _validate_tool_policy(manifest, mcp_servers, connector_servers, enforces_tool_policy, c)
         _validate_secrets(manifest, c)
         _validate_scripts(root, c)
         _validate_connectors(root, c)
@@ -731,6 +768,202 @@ def _gate_not_namespaced_message(
     )
 
 
+def _validate_tool_policy(
+    manifest: PluginManifest,
+    mcp_servers: set[str] | None,
+    connector_servers: set[str] | None,
+    enforces: str | None,
+    c: _Collector,
+) -> None:
+    """Validate the manifest ``toolPolicy`` declaration (deploy-time).
+
+    Shape ``{enforcement, allow, approvalRequired, deny}``: glob collections over
+    canonical ``"<server>/<tool>"`` tool names. Every grammar, duplicate and
+    conflict rule lives in ``tool_policy`` and is CALLED from here, never
+    reimplemented -- ``approval_policy.py`` exists precisely because a deploy
+    validator and a runtime loader that normalize separately silently disagree
+    and ship a fail-open (#453/#544), and the runtime lane for this contract is
+    still to be written.
+
+    ``mcp_servers`` and ``connector_servers`` are the same two sets
+    ``_validate_approval_policy`` receives, from the same locals, so the two
+    checks provably see an identical view of the bundle. Unlike the approval
+    check the union here is of bare server NAMES rather than live tool prefixes,
+    because the canonical form is transport-independent and carries the same
+    server name for both mount styles. ``None`` on either side means a
+    declaration existed but could not be read, so the accepted set is unknowable
+    and the cross-check stays silent rather than stacking a misleading second
+    error on top of the ``mcp.*`` / ``connectors.*`` error that already fired.
+
+    Nothing here early-returns past work it owes once the policy has parsed: a
+    wrong ``enforcement`` id and three bad globs are four errors in one pass, not
+    four ``curie build`` round-trips.
+    """
+
+    declared = manifest.toolPolicy
+    if declared is None:
+        # The backward-compatible path every bundle shipped to date takes.
+        return
+
+    # The enforcement HANDSHAKE, and the reason this extension is safe to add at
+    # all. Declaring a policy that no consumer applies is strictly worse than
+    # declaring none: the bundle reads as fenced and runs unfenced. So a
+    # policy-bearing bundle is refused outright until its validating caller
+    # states which contract it enforces. Reported before the shape checks and
+    # WITHOUT returning, so an author sees both this and any real defects.
+    if enforces != TOOL_POLICY_ENFORCEMENT:
+        c.error(
+            "tool_policy.unenforced",
+            f"this bundle declares a toolPolicy, but the caller validating it enforces "
+            f"{enforces!r} rather than {TOOL_POLICY_ENFORCEMENT!r}. Accepting the bundle "
+            "here would apply NO policy at all, leaving the agent's tool surface "
+            "completely unfenced while the manifest claims otherwise. Runtime "
+            "enforcement of the tool policy is a separate, blocking follow-up; until "
+            "it lands and passes enforces_tool_policy="
+            f"{TOOL_POLICY_ENFORCEMENT!r}, no bundle may ship a toolPolicy.",
+            "plugin.json (toolPolicy)",
+        )
+
+    if not isinstance(declared, dict):
+        c.error(
+            "tool_policy.invalid",
+            "toolPolicy must be an object with an 'enforcement' id and the "
+            "'allow'/'approvalRequired'/'deny' glob collections",
+            "plugin.json",
+        )
+        return
+
+    try:
+        policy = ToolPolicy.model_validate(declared)
+    except ValidationError as exc:
+        for issue in _tool_policy_invalid_messages(exc):
+            c.error("tool_policy.invalid", issue, "plugin.json (toolPolicy)")
+        return
+
+    # Compared EXACTLY -- deliberately NOT stripped, matching
+    # ``load_tool_policy``. The id is a wire constant a bundle writes verbatim,
+    # so " curie/mcp-tool-policy@1 " is not it; refusing it here is fail-CLOSED,
+    # where accepting it would silently apply v1 rules to a string that is not
+    # the v1 id. This differs on purpose from the approval-gate check above,
+    # which strips GATE names so the validator and the runtime loader agree on
+    # one tool name: a version discriminator is not a tool name. Do not "fix"
+    # this back to a ``.strip()``.
+    enforcement = policy.enforcement
+    if enforcement != TOOL_POLICY_ENFORCEMENT:
+        c.error(
+            "tool_policy.enforcement_unsupported",
+            f"toolPolicy.enforcement is {enforcement!r}, which this build does not "
+            f"implement; it implements {TOOL_POLICY_ENFORCEMENT!r}. The id is a "
+            "versioned discriminator: a bundle asking for different semantics is "
+            "rejected rather than reinterpreted under this build's rules.",
+            "plugin.json (toolPolicy)",
+        )
+
+    # The SHARED rule set: this is the same ``check_policy_patterns`` call
+    # ``tool_policy.load_tool_policy`` makes, and the ONLY difference between the
+    # two paths is the rendering. Here each issue becomes its own
+    # ``ValidationIssue`` with a code and a location, so an author fixes every
+    # typo in one ``curie build``; the loader has no per-issue surface and
+    # collapses them into a single ``ToolPolicyInvalid``. Never inline a rule
+    # here -- a validator and a runtime loader that own separate copies of a
+    # grammar silently diverge and ship a fail-open (#453/#544).
+    for defect in check_policy_patterns(policy):
+        c.error(
+            f"tool_policy.{defect.code}",
+            defect.message,
+            f"plugin.json (toolPolicy.{defect.collection}[{defect.index}])",
+        )
+
+    # The declared-server cross-check. A pattern whose server segment is a
+    # LITERAL name (``literal_server_segment`` returns ``None`` for a wildcarded
+    # or malformed one) must name a server the bundle actually declares, in
+    # either the MCP map or connectors.yaml -- a typo'd segment is an inert rule
+    # the author believes is live. A wildcard segment is the deliberate escape
+    # hatch for a bundle whose servers are not statically declared and is never
+    # cross-checked; that makes this check advisory, which is accepted, because
+    # the property that actually defends the capability is classify_tool's
+    # unmatched-is-DENY default, not this check.
+    expected_servers: set[str] | None = (
+        mcp_servers | connector_servers
+        if mcp_servers is not None and connector_servers is not None
+        else None
+    )
+    if expected_servers is not None:
+        for collection, i, pattern in policy_patterns(policy):
+            server = literal_server_segment(pattern)
+            if server is None or server in expected_servers:
+                continue
+            c.error(
+                "tool_policy.unknown_server",
+                _unknown_tool_policy_server_message(pattern, server, expected_servers),
+                f"plugin.json (toolPolicy.{collection}[{i}])",
+            )
+
+    if not policy.deny and not policy.approvalRequired and not policy.allow:
+        # Coherent, not vacuous: with three empty collections every tool falls
+        # through to the DENY default, so the agent may call no MCP tool at all.
+        # A WARNING rather than an error because that is fail-CLOSED and
+        # rejecting it would make "fence this agent out entirely" inexpressible
+        # -- but it is far more often a half-finished edit.
+        c.warn(
+            "tool_policy.denies_everything",
+            "toolPolicy declares no patterns in 'allow', 'approvalRequired' or "
+            "'deny', so every MCP tool falls through to the deny-by-default rule "
+            "and the agent can call none of them. That is coherent if it is what "
+            "you meant; otherwise the collections are unfinished.",
+            "plugin.json (toolPolicy)",
+        )
+
+
+def _tool_policy_invalid_messages(exc: ValidationError) -> list[str]:
+    """``_explain`` for a toolPolicy, with a pointed message for an unknown key.
+
+    ``ToolPolicy`` is the one strict model reached from the manifest, so pydantic's
+    generic "Extra inputs are not permitted" is the message an author is most
+    likely to hit -- and the case where a bare restatement helps least. A
+    misspelled collection (``"denny"``) is a typo that would otherwise become
+    permission widening, so the message names the offending key and the three
+    collections it was probably meant to be.
+
+    Only that one case is special-cased; every other error keeps ``_explain``'s
+    generic rendering, from ``_explain`` itself, so toolPolicy's locations cannot
+    drift from the rest of the file's.
+    """
+
+    def rewrite(err: Mapping[str, Any], loc: str) -> str | None:
+        if err["type"] != "extra_forbidden":
+            return None
+        return (
+            f"{loc}: unknown key in toolPolicy. A tool policy is a Curie-owned "
+            "authorization object, so unknown keys are rejected rather than "
+            "ignored: a misspelled collection would silently drop the rules it "
+            "was meant to carry. Valid keys are 'enforcement', 'allow', "
+            "'approvalRequired' and 'deny'."
+        )
+
+    return _explain(exc, rewrite=rewrite)
+
+
+def _unknown_tool_policy_server_message(
+    pattern: str, server: str, expected_servers: set[str]
+) -> str:
+    """Actionable message for a pattern naming a server the bundle does not declare."""
+
+    if expected_servers:
+        declared = "This bundle declares: " + ", ".join(sorted(expected_servers))
+    else:
+        declared = f"This bundle declares no MCP servers and no {CONNECTORS_FILE} connectors"
+    return (
+        f"tool pattern {pattern!r} names server {server!r}, which this bundle does "
+        f"not declare. {declared}. A canonical tool name is '<server>/<tool>', where "
+        "<server> is the bare server name from the manifest's mcpServers map or "
+        f"from {CONNECTORS_FILE} -- NOT the live mcp__... SDK name, whose namespacing "
+        "differs between the two mount styles. Fix the server name, declare the "
+        "server, or use a wildcard segment (e.g. '*/<tool>') if the server is not "
+        "statically declared."
+    )
+
+
 def _validate_secrets(manifest: PluginManifest, c: _Collector) -> None:
     """Validate the manifest ``secrets`` policy (deploy-time gate, ADR-0009 / #429).
 
@@ -805,9 +1038,23 @@ def _read_frontmatter(skill_file: Path, rel: str, c: _Collector) -> dict[str, An
     return loaded
 
 
-def _explain(exc: ValidationError) -> list[str]:
+def _explain(
+    exc: ValidationError,
+    *,
+    rewrite: Callable[[Mapping[str, Any], str], str | None] | None = None,
+) -> list[str]:
+    """One ``"<loc>: <message>"`` line per pydantic error, in pydantic's order.
+
+    ``rewrite`` lets a caller replace the line for errors it can explain better,
+    returning ``None`` to keep the generic one. It is handed the already-rendered
+    ``loc`` so no caller re-derives the location format: a second copy of the
+    join-and-``(root)`` rule is how one validator's messages silently start
+    pointing at locations differently from every other validator's.
+    """
+
     out: list[str] = []
     for err in exc.errors():
         loc = ".".join(str(p) for p in err["loc"]) or "(root)"
-        out.append(f"{loc}: {err['msg']}")
+        replacement = rewrite(err, loc) if rewrite is not None else None
+        out.append(replacement if replacement is not None else f"{loc}: {err['msg']}")
     return out

--- a/packages/plugin-format/tests/test_models.py
+++ b/packages/plugin-format/tests/test_models.py
@@ -1,5 +1,12 @@
 import pytest
-from plugin_format import ApprovalGate, McpServer, PluginManifest, SkillFrontmatter
+from plugin_format import (
+    TOOL_POLICY_ENFORCEMENT,
+    ApprovalGate,
+    McpServer,
+    PluginManifest,
+    SkillFrontmatter,
+    ToolPolicy,
+)
 from pydantic import ValidationError
 
 
@@ -104,3 +111,99 @@ def test_approval_gate_grantable_via_policy_field() -> None:
     dumped = gate.model_dump()
     assert dumped["grantableViaPolicy"] is True
     assert ApprovalGate.model_validate(dumped).grantableViaPolicy is True
+
+
+def test_tool_policy_parses_a_full_declaration_and_defaults_its_collections() -> None:
+    """The ``toolPolicy`` model round-trips, and its three collections default to empty.
+
+    Empty is the coherent default for a DECLARED policy: unmatched means deny, so a
+    policy that lists nothing refuses everything. The alternative -- ``None`` for an
+    omitted collection -- would invite a "None means unrestricted" reading, which is
+    the fail-open the policy exists to prevent.
+    """
+
+    policy = ToolPolicy.model_validate(
+        {
+            "enforcement": TOOL_POLICY_ENFORCEMENT,
+            "allow": ["grafana/list_datasources"],
+            "approvalRequired": ["kubernetes/pods_*"],
+            "deny": ["kubernetes/resources_delete"],
+        }
+    )
+    assert policy.enforcement == TOOL_POLICY_ENFORCEMENT
+    assert policy.allow == ["grafana/list_datasources"]
+    assert policy.approvalRequired == ["kubernetes/pods_*"]
+    assert policy.deny == ["kubernetes/resources_delete"]
+    # Serializes back under the verbatim camelCase key.
+    assert policy.model_dump()["approvalRequired"] == ["kubernetes/pods_*"]
+
+    bare = ToolPolicy.model_validate({"enforcement": TOOL_POLICY_ENFORCEMENT})
+    assert bare.allow == []
+    assert bare.approvalRequired == []
+    assert bare.deny == []
+
+
+def test_tool_policy_rejects_an_unknown_key() -> None:
+    """ToolPolicy is STRICT: an unknown key is a typo, and a typo here widens permissions.
+
+    The concrete failure a lenient model would ship: an author writes ``denny``
+    for ``deny``, pydantic accepts and discards it, the real deny list is empty,
+    and every tool the author believed blocked falls through to their ``allow``
+    glob. Forward-compatibility leniency is right for shapes with an EXTERNAL
+    producer (PluginManifest mirrors Claude Code's evolving format); a
+    Curie-owned policy object has no such producer, so ``extra="forbid"`` --
+    the same reasoning ConnectorSpec, ConnectorLockEntry and DeployTarget encode.
+    """
+
+    with pytest.raises(ValidationError):
+        ToolPolicy.model_validate({"enforcement": TOOL_POLICY_ENFORCEMENT, "futureField": 42})
+
+    # The realistic case, stated as itself: a misspelled collection name.
+    with pytest.raises(ValidationError):
+        ToolPolicy.model_validate(
+            {
+                "enforcement": TOOL_POLICY_ENFORCEMENT,
+                "allow": ["k8s/*"],
+                "denny": ["k8s/delete_namespace"],
+            }
+        )
+
+
+def test_manifest_stays_lenient_even_though_tool_policy_is_strict() -> None:
+    """Strictness is scoped to ToolPolicy; PluginManifest keeps accepting unknown keys.
+
+    Tightening the manifest would reject real Claude Code bundles carrying fields
+    this package does not model, which is the compatibility wedge.
+    """
+
+    manifest = PluginManifest.model_validate(
+        {
+            "name": "demo",
+            "futureField": 42,
+            "toolPolicy": {"enforcement": TOOL_POLICY_ENFORCEMENT, "allow": ["grafana/*"]},
+        }
+    )
+    assert manifest.model_dump().get("futureField") == 42
+    assert manifest.toolPolicy is not None
+
+
+def test_manifest_tool_policy_field() -> None:
+    """The Curie ``toolPolicy`` authoring extension round-trips on the manifest.
+
+    Absent -> ``None``, which is the backward-compatibility guarantee: every bundle
+    shipped before this feature keeps validating and keeps its behavior. The one
+    visible change for an existing bundle is that ``model_dump()`` now carries
+    ``toolPolicy: None`` -- the ordinary new-optional-field patch behaviour, which
+    is why the round-trip below dumps with ``exclude_none``.
+    """
+
+    declared = {
+        "enforcement": TOOL_POLICY_ENFORCEMENT,
+        "allow": ["grafana/*"],
+        "deny": ["grafana/delete_*"],
+    }
+    manifest = PluginManifest.model_validate({"name": "demo", "toolPolicy": declared})
+    assert manifest.toolPolicy == declared
+    assert manifest.model_dump(exclude_none=True)["toolPolicy"] == declared
+
+    assert PluginManifest.model_validate({"name": "demo"}).toolPolicy is None

--- a/packages/plugin-format/tests/test_tool_policy.py
+++ b/packages/plugin-format/tests/test_tool_policy.py
@@ -1,0 +1,590 @@
+"""Unit table for ``plugin_format.tool_policy``: the vanilla MCP tool policy.
+
+The policy answers ONE question for the runtime: given a canonical tool name
+``"<server>/<tool>"``, may the agent call it, must a human approve it, or is it
+refused outright? Every case here pins a decision that fails CLOSED, because the
+failure mode this module exists to prevent is a policy that reads as protective
+and silently classifies nothing (the #453/#544 fail-open shape).
+
+The canonical name is deliberately NOT the SDK's live tool name
+(``mcp__plugin_<bundle>_<server>__<tool>``). It is server-qualified and
+transport-independent, so a bundle author writes one policy that survives a
+server moving between the plugin ``mcpServers`` map and ``connectors.yaml``.
+"""
+
+import fnmatch
+
+import plugin_format.tool_policy
+import pytest
+from plugin_format import (
+    TOOL_POLICY_ENFORCEMENT,
+    PluginManifest,
+    ToolPolicy,
+    ToolPolicyDecision,
+    ToolPolicyInvalid,
+    ToolPolicyUnenforceable,
+    classify_tool,
+    load_tool_policy,
+    validate_pattern,
+)
+
+
+def _policy(
+    *,
+    allow: list[str] | None = None,
+    approval_required: list[str] | None = None,
+    deny: list[str] | None = None,
+) -> ToolPolicy:
+    """A ToolPolicy carrying the supported enforcement id and the given collections."""
+
+    return ToolPolicy.model_validate(
+        {
+            "enforcement": TOOL_POLICY_ENFORCEMENT,
+            "allow": allow or [],
+            "approvalRequired": approval_required or [],
+            "deny": deny or [],
+        }
+    )
+
+
+# --- the contract identifiers -------------------------------------------------
+
+
+def test_enforcement_id_is_the_versioned_contract_string() -> None:
+    """The id is a wire constant: a build that implements v1 advertises exactly this.
+
+    Pinned as a literal because a bundle declares it verbatim in its manifest and
+    the loader refuses anything else; changing it is a contract break, not a
+    rename.
+    """
+
+    assert TOOL_POLICY_ENFORCEMENT == "curie/mcp-tool-policy@1"
+
+
+def test_decision_values_are_the_wire_strings() -> None:
+    """The decision is serialized into approval records and logs, so its values are pinned."""
+
+    assert ToolPolicyDecision.ALLOW == "allow"
+    assert ToolPolicyDecision.APPROVAL_REQUIRED == "approval-required"
+    assert ToolPolicyDecision.DENY == "deny"
+
+
+# --- classification: precedence, fail-closed default, matching rules -----------
+
+
+def test_precedence_is_by_class_never_by_specificity() -> None:
+    """deny > approval-required > allow, even when the LOSING pattern is more specific.
+
+    "Most specific wins" is the tempting wrong reading, and it is the dangerous
+    one: here the narrow ``allow`` of ``kubernetes/resources_scale`` sits inside
+    the broad ``approvalRequired`` glob ``kubernetes/resources_*``. Specificity
+    would silently drop the human out of a scaling operation. Class precedence
+    keeps the approval.
+    """
+
+    policy = _policy(
+        allow=["kubernetes/resources_scale"],
+        approval_required=["kubernetes/resources_*"],
+        deny=["kubernetes/resources_create_or_update"],
+    )
+
+    # deny wins over the broader approvalRequired glob that also matches it.
+    assert classify_tool(policy, "kubernetes/resources_create_or_update") == ToolPolicyDecision.DENY
+    # The broader approval glob outranks the NARROWER allow: class, not specificity.
+    assert (
+        classify_tool(policy, "kubernetes/resources_scale") == ToolPolicyDecision.APPROVAL_REQUIRED
+    )
+    # And a name only the approval glob matches is unremarkable.
+    assert (
+        classify_tool(policy, "kubernetes/resources_delete") == ToolPolicyDecision.APPROVAL_REQUIRED
+    )
+
+
+def test_unmatched_tool_is_denied() -> None:
+    """A name no collection mentions is DENIED, not allowed.
+
+    The whole point of the policy: the default is refusal, so a policy can only
+    ever widen the surface deliberately.
+    """
+
+    policy = _policy(allow=["grafana/list_datasources"])
+
+    assert classify_tool(policy, "grafana/list_datasources") == ToolPolicyDecision.ALLOW
+    assert classify_tool(policy, "grafana/delete_datasource") == ToolPolicyDecision.DENY
+
+
+def test_a_newly_advertised_tool_the_policy_never_mentions_is_denied() -> None:
+    """Server drift fails CLOSED: a sixth tool appearing after the policy was written is denied.
+
+    The real case from the tracer -- a policy written against a Grafana server's
+    five published tools, then the server starts advertising ``update_dashboard``
+    on its next release. Nothing in the bundle changed, so nothing re-reviews the
+    policy; the new write-capable tool must not become callable by default.
+
+    The already-classified tool is asserted in the SAME test on purpose: it proves
+    drift-fails-closed rather than everything-denies, which a broken matcher would
+    also satisfy.
+    """
+
+    policy = _policy(
+        allow=[
+            "grafana/list_datasources",
+            "grafana/query_prometheus",
+            "grafana/list_dashboards",
+        ],
+        approval_required=["grafana/create_annotation", "grafana/delete_annotation"],
+    )
+
+    # The sixth tool, advertised after the policy was authored.
+    assert classify_tool(policy, "grafana/update_dashboard") == ToolPolicyDecision.DENY
+    # ... while the originally-classified tools still resolve exactly as before.
+    assert classify_tool(policy, "grafana/list_datasources") == ToolPolicyDecision.ALLOW
+    assert (
+        classify_tool(policy, "grafana/create_annotation") == ToolPolicyDecision.APPROVAL_REQUIRED
+    )
+
+
+def test_a_policy_with_three_empty_collections_denies_every_tool() -> None:
+    """An empty declared policy is coherent, not vacuous: it refuses everything.
+
+    "Declared but empty" must never degrade into "no policy". That degradation is
+    exactly how a fail-closed control becomes a fail-open one.
+    """
+
+    policy = _policy()
+
+    assert classify_tool(policy, "grafana/list_datasources") == ToolPolicyDecision.DENY
+    assert classify_tool(policy, "kubernetes/pods_run") == ToolPolicyDecision.DENY
+
+
+def test_wildcards_do_not_cross_the_server_separator() -> None:
+    """``grafana/*`` is scoped to the grafana server and can never reach another one.
+
+    A naive ``fnmatch`` over the whole string would let ``grafana/*`` swallow
+    nothing extra here, but ``*/pods_run``-style patterns and any pattern ending in
+    ``*`` would leak across ``/``. Server and tool segments match independently.
+    """
+
+    policy = _policy(allow=["grafana/*"])
+
+    assert classify_tool(policy, "grafana/list_datasources") == ToolPolicyDecision.ALLOW
+    assert classify_tool(policy, "kubernetes/pods_run") == ToolPolicyDecision.DENY
+
+
+def test_a_wildcard_server_segment_does_not_swallow_extra_segments() -> None:
+    """``*/x`` matches one server segment only -- ``a/b/x`` is a different shape and is denied."""
+
+    policy = _policy(allow=["*/x"])
+
+    assert classify_tool(policy, "a/x") == ToolPolicyDecision.ALLOW
+    assert classify_tool(policy, "a/b/x") == ToolPolicyDecision.DENY
+
+
+def test_matching_is_case_sensitive() -> None:
+    """Tool names are case-sensitive on the wire, so the matcher is too.
+
+    A case-INSENSITIVE match would widen every allow pattern beyond what the author
+    wrote; ``fnmatch.fnmatchcase`` is the required primitive, not ``fnmatch``
+    (which is platform-case-folding).
+    """
+
+    policy = _policy(allow=["grafana/List_*"])
+
+    assert classify_tool(policy, "grafana/list_datasources") == ToolPolicyDecision.DENY
+    assert classify_tool(policy, "grafana/List_datasources") == ToolPolicyDecision.ALLOW
+
+
+def test_multi_server_policy_classifies_each_server_independently() -> None:
+    """One policy spanning two servers keeps their surfaces separate, and denies a third."""
+
+    policy = _policy(
+        allow=["grafana/*"],
+        approval_required=["kubernetes/pods_*"],
+    )
+
+    assert classify_tool(policy, "grafana/query_prometheus") == ToolPolicyDecision.ALLOW
+    assert classify_tool(policy, "kubernetes/pods_run") == ToolPolicyDecision.APPROVAL_REQUIRED
+    # The grafana allow does not reach kubernetes' non-pod tools ...
+    assert classify_tool(policy, "kubernetes/resources_delete") == ToolPolicyDecision.DENY
+    # ... and a third server nobody wrote a pattern for is refused entirely.
+    assert classify_tool(policy, "github/create_pull_request") == ToolPolicyDecision.DENY
+
+
+# --- pattern grammar ----------------------------------------------------------
+
+_VALID_PATTERNS = [
+    "grafana/list_datasources",
+    "grafana/*",
+    "*/pods_*",
+    "*/*",
+    "k8s-prod/resources_?cale",
+    "my.server/tool.name",
+    "a_b/c-d",
+]
+
+
+@pytest.mark.parametrize("pattern", _VALID_PATTERNS)
+def test_valid_pattern_reports_no_reason(pattern: str) -> None:
+    """A well-formed pattern returns ``None`` -- the "no reason to reject" signal."""
+
+    assert validate_pattern(pattern) is None
+
+
+_INVALID_PATTERNS = [
+    pytest.param("", id="empty"),
+    pytest.param("   ", id="whitespace-only"),
+    pytest.param("grafana /tool", id="space-in-server"),
+    pytest.param("grafana/list tool", id="space-in-tool"),
+    pytest.param("grafana/list\ttool", id="tab-in-tool"),
+    pytest.param("list_datasources", id="no-separator"),
+    pytest.param("a/b/c", id="two-separators"),
+    pytest.param("/tool", id="empty-server-segment"),
+    pytest.param("server/", id="empty-tool-segment"),
+    pytest.param("grafana/**", id="double-star"),
+    pytest.param("**/tool", id="double-star-server"),
+    pytest.param("grafana/[abc]*", id="character-class"),
+    pytest.param("grafana/tool!", id="disallowed-punctuation"),
+    pytest.param("graf@na/tool", id="disallowed-at-sign"),
+]
+
+
+@pytest.mark.parametrize("pattern", _INVALID_PATTERNS)
+def test_invalid_pattern_reports_a_reason(pattern: str) -> None:
+    """Every malformed pattern returns a non-empty human-readable reason.
+
+    A silent ``None`` here would let a typo'd pattern through as an inert rule:
+    the author believes a tool is allowed (or denied) and it is not. The reason
+    string is what the deploy-time validator surfaces, so it must be non-empty,
+    not just non-``None``.
+    """
+
+    reason = validate_pattern(pattern)
+    assert reason is not None, f"{pattern!r} should have been rejected"
+    assert reason.strip(), f"{pattern!r} was rejected with an empty reason"
+
+
+# --- load_tool_policy: enforcement handshake ----------------------------------
+
+
+@pytest.mark.parametrize(
+    "enforces",
+    [None, TOOL_POLICY_ENFORCEMENT, "curie/mcp-tool-policy@2", "something/else@1"],
+)
+def test_manifest_without_a_tool_policy_loads_none_for_every_enforces_value(
+    enforces: str | None,
+) -> None:
+    """BACKWARD COMPATIBILITY: no ``toolPolicy`` means no policy, whatever the caller enforces.
+
+    Every bundle that exists today has no ``toolPolicy``. If an unsupported
+    ``enforces`` raised on those, shipping this module would break every deployed
+    agent at once. Absence is not a declaration, so it can never be unenforceable.
+    """
+
+    manifest = PluginManifest.model_validate({"name": "demo"})
+
+    assert load_tool_policy(manifest, enforces=enforces) is None
+
+
+def test_declared_policy_loads_with_its_collections_intact() -> None:
+    """The supported handshake returns a parsed policy carrying exactly what was declared."""
+
+    manifest = PluginManifest.model_validate(
+        {
+            "name": "demo",
+            "toolPolicy": {
+                "enforcement": TOOL_POLICY_ENFORCEMENT,
+                "allow": ["grafana/list_datasources", "grafana/query_*"],
+                "approvalRequired": ["kubernetes/pods_*"],
+                "deny": ["kubernetes/resources_delete"],
+            },
+        }
+    )
+
+    policy = load_tool_policy(manifest, enforces=TOOL_POLICY_ENFORCEMENT)
+
+    assert policy is not None
+    assert policy.allow == ["grafana/list_datasources", "grafana/query_*"]
+    assert policy.approvalRequired == ["kubernetes/pods_*"]
+    assert policy.deny == ["kubernetes/resources_delete"]
+    # And the loaded policy actually classifies against what it carried.
+    assert classify_tool(policy, "grafana/query_prometheus") == ToolPolicyDecision.ALLOW
+
+
+def test_declared_policy_is_unenforceable_when_the_caller_enforces_nothing() -> None:
+    """A call site that cannot enforce the policy must REFUSE the bundle, not ignore it.
+
+    ``enforces=None`` is the honest statement "this code path does not implement
+    tool policy". Returning the policy anyway would let a caller receive it and
+    quietly not apply it -- the fail-open shape. Returning ``None`` would be worse
+    still: indistinguishable from "no policy declared".
+    """
+
+    manifest = PluginManifest.model_validate(
+        {
+            "name": "demo",
+            "toolPolicy": {"enforcement": TOOL_POLICY_ENFORCEMENT, "allow": ["grafana/*"]},
+        }
+    )
+
+    with pytest.raises(ToolPolicyUnenforceable):
+        load_tool_policy(manifest, enforces=None)
+
+
+@pytest.mark.parametrize("enforces", ["curie/mcp-tool-policy@2", "curie/mcp-tool-policy", "v1"])
+def test_declared_policy_is_unenforceable_under_a_different_contract_id(enforces: str) -> None:
+    """A caller implementing a DIFFERENT contract version cannot enforce this bundle's policy."""
+
+    manifest = PluginManifest.model_validate(
+        {
+            "name": "demo",
+            "toolPolicy": {"enforcement": TOOL_POLICY_ENFORCEMENT, "deny": ["grafana/*"]},
+        }
+    )
+
+    with pytest.raises(ToolPolicyUnenforceable):
+        load_tool_policy(manifest, enforces=enforces)
+
+
+@pytest.mark.parametrize(
+    "declared",
+    ["curie/mcp-tool-policy@2", "", "curie/other-policy@1"],
+)
+def test_a_bundle_declaring_semantics_this_build_does_not_implement_is_unenforceable(
+    declared: str,
+) -> None:
+    """The bundle's own ``enforcement`` value is checked too, not just the caller's.
+
+    A bundle asking for ``@2`` semantics is asking for rules this build does not
+    implement. Applying ``@1`` rules to it would silently give the author a
+    different policy than the one they wrote, so it is refused even when the caller
+    passes the supported id.
+    """
+
+    manifest = PluginManifest.model_validate(
+        {
+            "name": "demo",
+            "toolPolicy": {"enforcement": declared, "allow": ["grafana/*"]},
+        }
+    )
+
+    with pytest.raises(ToolPolicyUnenforceable):
+        load_tool_policy(manifest, enforces=TOOL_POLICY_ENFORCEMENT)
+
+
+# --- the enforcement id is compared BYTE-FOR-BYTE -----------------------------
+#
+# The id is a wire constant, not an identifier, so no normalization is applied to
+# either side of the handshake. Exact comparison is the fail-CLOSED direction: a
+# stray space makes the bundle refused loudly rather than silently treated as v1.
+# This is a deliberate DIFFERENCE from ``approval_policy.py``, which strips gate
+# names so the validator and the runtime loader agree on one tool NAME -- a
+# version discriminator is not a tool name.
+
+_PADDED_ENFORCEMENT_IDS = [
+    pytest.param(" curie/mcp-tool-policy@1", id="leading-space"),
+    pytest.param("curie/mcp-tool-policy@1 ", id="trailing-space"),
+    pytest.param("curie/mcp-tool-policy\t@1", id="internal-tab"),
+]
+
+
+@pytest.mark.parametrize("declared", _PADDED_ENFORCEMENT_IDS)
+def test_a_whitespace_padded_bundle_enforcement_id_is_not_the_v1_contract(declared: str) -> None:
+    """`` curie/mcp-tool-policy@1 `` is a different string, so the bundle is refused.
+
+    Stripping it would accept a manifest that does not carry the v1 id and apply
+    v1 rules to it -- silently deciding, on the author's behalf, that the padding
+    was meaningless. Refusing is recoverable in one edit; a wrong-but-accepted
+    contract id is invisible.
+    """
+
+    manifest = PluginManifest.model_validate(
+        {
+            "name": "demo",
+            "toolPolicy": {"enforcement": declared, "allow": ["grafana/list_datasources"]},
+        }
+    )
+
+    with pytest.raises(ToolPolicyUnenforceable):
+        load_tool_policy(manifest, enforces=TOOL_POLICY_ENFORCEMENT)
+
+
+@pytest.mark.parametrize("enforces", _PADDED_ENFORCEMENT_IDS)
+def test_a_whitespace_padded_caller_id_does_not_satisfy_the_handshake(enforces: str) -> None:
+    """The CALLER's ``enforces`` is compared exactly too, not just the bundle's.
+
+    Both sides of a two-sided handshake must normalize identically, and the only
+    normalization that cannot drift is none at all.
+    """
+
+    manifest = PluginManifest.model_validate(
+        {
+            "name": "demo",
+            "toolPolicy": {"enforcement": TOOL_POLICY_ENFORCEMENT, "allow": ["grafana/*"]},
+        }
+    )
+
+    with pytest.raises(ToolPolicyUnenforceable):
+        load_tool_policy(manifest, enforces=enforces)
+
+
+# --- load_tool_policy applies the deploy validator's pattern rules -------------
+#
+# ``_matches`` hands whatever strings the collections carry straight to
+# ``fnmatchcase``, so a pattern the grammar forbids still MATCHES at runtime. A
+# loader that skipped ``check_policy_patterns`` would therefore hand a caller a
+# policy the deploy validator refuses -- the #453/#544 validator-vs-runtime drift,
+# in the direction that GRANTS tool access. Each case below names the fail-open it
+# prevents.
+
+
+def _policy_manifest(**collections: list[str]) -> PluginManifest:
+    """A manifest carrying a v1-enforced toolPolicy with the given collections."""
+
+    return PluginManifest.model_validate(
+        {
+            "name": "demo",
+            "toolPolicy": {"enforcement": TOOL_POLICY_ENFORCEMENT, **collections},
+        }
+    )
+
+
+def test_load_refuses_a_character_class_pattern() -> None:
+    """FAIL-OPEN PREVENTED: ``grafana/[a-z]*`` would become a live, locale-sensitive ALLOW.
+
+    ``validate_pattern`` rejects character classes outright, so this bundle
+    cannot be deployed. Without the loader running the same check, a runtime
+    following the advertised ``load_tool_policy`` -> ``classify_tool`` API would
+    give the class real ``fnmatchcase`` semantics and allow tools on a bundle the
+    validator had refused -- and the set of tools it allows would depend on the
+    machine's locale.
+    """
+
+    manifest = _policy_manifest(allow=["grafana/[a-z]*"])
+
+    with pytest.raises(ToolPolicyInvalid) as excinfo:
+        load_tool_policy(manifest, enforces=TOOL_POLICY_ENFORCEMENT)
+
+    # The message must name the offending pattern, or the fix is a hunt.
+    assert "grafana/[a-z]*" in str(excinfo.value)
+    assert "character classes" in str(excinfo.value)
+
+
+def test_load_refuses_a_double_star_pattern() -> None:
+    """FAIL-OPEN PREVENTED: ``**`` is meaningless here but ``fnmatchcase`` still matches on it.
+
+    A two-segment namespace has no recursive level for ``**``, so the author's
+    intent is unknowable; ``fnmatchcase`` would nonetheless treat it as a plain
+    wildcard and widen the segment. The deploy validator rejects it, so the
+    loader must too.
+    """
+
+    manifest = _policy_manifest(allow=["grafana/**"])
+
+    with pytest.raises(ToolPolicyInvalid) as excinfo:
+        load_tool_policy(manifest, enforces=TOOL_POLICY_ENFORCEMENT)
+
+    assert "grafana/**" in str(excinfo.value)
+
+
+def test_load_refuses_a_duplicate_within_one_collection() -> None:
+    """The loader enforces the DUPLICATE rule too, not only the grammar.
+
+    ``check_policy_patterns`` owns three rule families; wiring only the grammar
+    into the loader would leave the other two enforced at deploy and absent at
+    runtime, which is the same drift in a quieter form.
+    """
+
+    manifest = _policy_manifest(allow=["grafana/query_*", "grafana/query_*"])
+
+    with pytest.raises(ToolPolicyInvalid) as excinfo:
+        load_tool_policy(manifest, enforces=TOOL_POLICY_ENFORCEMENT)
+
+    assert "grafana/query_*" in str(excinfo.value)
+    assert "more than once" in str(excinfo.value)
+
+
+def test_load_refuses_the_same_pattern_declared_in_two_collections() -> None:
+    """FAIL-OPEN PREVENTED: the stated intent is silently reduced to one class.
+
+    ``kubernetes/pods_delete`` in both ``approvalRequired`` and ``allow`` reads as
+    "gated AND allowed"; precedence would quietly keep only the approval and drop
+    the rest of what the author wrote. The deploy validator calls that a
+    declaration error, and a runtime that accepted it would apply a policy nobody
+    wrote.
+    """
+
+    manifest = _policy_manifest(
+        approvalRequired=["kubernetes/pods_delete"],
+        allow=["kubernetes/pods_delete"],
+    )
+
+    with pytest.raises(ToolPolicyInvalid) as excinfo:
+        load_tool_policy(manifest, enforces=TOOL_POLICY_ENFORCEMENT)
+
+    assert "kubernetes/pods_delete" in str(excinfo.value)
+
+
+@pytest.mark.parametrize("pattern", _INVALID_PATTERNS)
+def test_every_pattern_validate_pattern_rejects_also_makes_the_loader_refuse(
+    pattern: str,
+) -> None:
+    """THE INVARIANT: the deploy validator and the loader accept exactly the same patterns.
+
+    Stated directly rather than case by case, and parametrized over the whole
+    invalid table so a rule added to ``validate_pattern`` but never wired into
+    ``load_tool_policy`` fails HERE instead of shipping as a runtime hole. A
+    caller must not be able to obtain a ``ToolPolicy`` carrying a pattern
+    ``curie build`` would have refused.
+    """
+
+    assert validate_pattern(pattern) is not None, "table drift: this pattern is now valid"
+
+    manifest = _policy_manifest(allow=[pattern])
+
+    with pytest.raises(ToolPolicyInvalid):
+        load_tool_policy(manifest, enforces=TOOL_POLICY_ENFORCEMENT)
+
+
+def test_an_unenforceable_bundle_fails_the_handshake_before_its_patterns_are_judged() -> None:
+    """ORDERING: a caller that cannot enforce is turned away whatever the policy's shape.
+
+    The malformed pattern here is real, but the caller enforces nothing, so the
+    refusal must still be ``ToolPolicyUnenforceable``. Reporting the glob instead
+    would imply that fixing the glob makes this call path able to enforce the
+    policy, which it never will.
+    """
+
+    manifest = _policy_manifest(allow=["grafana/[a-z]*"])
+
+    with pytest.raises(ToolPolicyUnenforceable):
+        load_tool_policy(manifest, enforces=None)
+
+
+def test_the_two_refusals_are_distinguishable_exception_types() -> None:
+    """Cannot-enforce and malformed are different failures with different fixes.
+
+    A caller may reasonably tolerate one and not the other (a build with no
+    runtime lane expects the first), so overloading a single exception would make
+    them indistinguishable at the catch site.
+    """
+
+    assert not issubclass(ToolPolicyInvalid, ToolPolicyUnenforceable)
+    assert not issubclass(ToolPolicyUnenforceable, ToolPolicyInvalid)
+
+
+# --- structural guard on the matching primitive -------------------------------
+
+
+def test_the_matcher_binds_fnmatchcase_and_not_fnmatch() -> None:
+    """STRUCTURAL: the module must bind ``fnmatch.fnmatchcase``, checked by identity.
+
+    ``test_matching_is_case_sensitive`` above cannot catch a swap to plain
+    ``fnmatch``: POSIX ``fnmatch`` is case-SENSITIVE on Linux, the only platform
+    this suite runs on, so the behavioural test passes either way here while
+    every allow-pattern silently becomes case-INSENSITIVE on a case-folding
+    platform (macOS, Windows) -- a platform-dependent permission WIDENING that
+    the test table cannot see. This guard supplements that test; it does not
+    replace it.
+    """
+
+    assert plugin_format.tool_policy.fnmatchcase is fnmatch.fnmatchcase

--- a/packages/plugin-format/tests/test_validate.py
+++ b/packages/plugin-format/tests/test_validate.py
@@ -1,8 +1,9 @@
+import json
 import shutil
 from pathlib import Path
 
 import pytest
-from plugin_format import validate_bundle
+from plugin_format import TOOL_POLICY_ENFORCEMENT, validate_bundle, validate_pattern
 
 FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -1108,3 +1109,601 @@ def test_a_build_context_symlinked_out_of_the_bundle_is_refused(tmp_path: Path) 
     assert not result.valid
     issue = next(i for i in result.errors if i.code == "connectors.build_context_escapes")
     assert "k8s-write" in issue.message
+
+
+# --- toolPolicy: the vanilla MCP tool policy, checked at deploy ----------------
+#
+# The policy classifies a canonical "<server>/<tool>" name as allow /
+# approval-required / deny, with DENY as the default for anything unmatched. Every
+# rule below exists because the failure it prevents is silent: a malformed pattern
+# never matches, so a bundle validates green while the rule its author wrote does
+# nothing at all. These go through the public validate_bundle, never a private
+# helper, because that is the one gate every intake path shares.
+#
+# validate_bundle carries an ENFORCEMENT HANDSHAKE: a caller states the tool-policy
+# contract it implements via `enforces_tool_policy`, and a bundle declaring a
+# toolPolicy is REFUSED (tool_policy.unenforced) by any caller that does not state
+# the supported id. That is the fail-closed property -- apps/api's bundles.py and
+# runner's plugin.py both call validate_bundle(root) with no argument today, so a
+# policy-carrying bundle is refused by both until their lane actually enforces it,
+# rather than being accepted and silently ignored.
+
+_TP_ENFORCEMENT = "curie/mcp-tool-policy@1"
+_UNENFORCED = "tool_policy.unenforced"
+
+
+def _tool_policy_bundle(tmp_path: Path, policy: str) -> Path:
+    """A minimal bundle whose manifest carries the given toolPolicy JSON object."""
+    return _bundle(tmp_path, '{"name": "demo", "toolPolicy": ' + policy + "}")
+
+
+def _tool_policy_codes(bundle: Path) -> list[str]:
+    """The tool_policy.* error codes seen by a caller that DOES enforce the contract.
+
+    Every declared-policy case below states enforcement, so each one proves its
+    OWN error code fires. Without that the blanket tool_policy.unenforced error
+    would mask every other check and the whole table would pass vacuously.
+    """
+    result = validate_bundle(bundle, enforces_tool_policy=TOOL_POLICY_ENFORCEMENT)
+    return [i.code for i in result.errors if i.code.startswith("tool_policy.")]
+
+
+# --- the enforcement handshake: a declared policy nobody enforces is refused ---
+
+
+def test_bundle_without_a_tool_policy_validates_green_under_the_default_call(
+    tmp_path: Path,
+) -> None:
+    """BACKWARD COMPATIBILITY control: absence is never a tool_policy issue.
+
+    Every bundle in the wild today has no toolPolicy, and today's callers
+    (apps/api bundles.py, runner plugin.py) pass no enforcement argument. Such a
+    bundle must return the SAME valid/errors/warnings it did before the field
+    existed: green, with no tool_policy.* issue of any kind. The new optional
+    field does surface as ``toolPolicy: None`` in ``PluginManifest.model_dump()``
+    -- the ordinary new-optional-field patch behaviour, and not something the
+    validator's result reflects.
+    """
+
+    bundle = _bundle(tmp_path, '{"name": "demo"}')
+    _write_mcp(bundle, '{"mcpServers": {"grafana": {"command": "grafana-mcp"}}}')
+
+    result = validate_bundle(bundle)
+    assert result.valid, result.errors
+    assert not [i for i in result.errors if i.code.startswith("tool_policy.")]
+    assert not [i for i in result.warnings if i.code.startswith("tool_policy.")]
+
+
+def test_a_consumer_declaring_no_enforcement_refuses_a_declared_policy(tmp_path: Path) -> None:
+    """The default call REFUSES a bundle that ships a toolPolicy. This is the whole point.
+
+    A consumer that has not declared which tool-policy contract it implements
+    cannot silently accept a bundle carrying one: it would load the agent, ignore
+    the policy, and give the author a control that exists only on paper. Both
+    call sites in the tree (apps/api bundles.py:101, runner plugin.py:60) pass no
+    argument today, so both refuse such a bundle until their lane enforces it.
+    """
+
+    bundle = _tool_policy_bundle(
+        tmp_path,
+        '{"enforcement": "' + _TP_ENFORCEMENT + '", "allow": ["grafana/list_datasources"]}',
+    )
+    _write_mcp(bundle, '{"mcpServers": {"grafana": {"command": "grafana-mcp"}}}')
+
+    result = validate_bundle(bundle)
+    assert not result.valid
+    issue = next(i for i in result.errors if i.code == _UNENFORCED)
+    # Actionable: the caller must be told which contract id it has to implement.
+    assert _TP_ENFORCEMENT in issue.message
+
+
+def test_the_same_declared_policy_validates_once_enforcement_is_declared(tmp_path: Path) -> None:
+    """The positive half of the handshake: the identical bundle passes for a real enforcer.
+
+    Paired with the test above on purpose -- same bundle, only the caller's
+    declaration differs -- so the refusal is proven to come from the handshake and
+    not from anything wrong with the policy itself.
+    """
+
+    bundle = _tool_policy_bundle(
+        tmp_path,
+        '{"enforcement": "' + _TP_ENFORCEMENT + '", "allow": ["grafana/list_datasources"]}',
+    )
+    _write_mcp(bundle, '{"mcpServers": {"grafana": {"command": "grafana-mcp"}}}')
+
+    result = validate_bundle(bundle, enforces_tool_policy=TOOL_POLICY_ENFORCEMENT)
+    assert result.valid, result.errors
+    assert not [i for i in result.errors if i.code.startswith("tool_policy.")]
+
+
+def test_a_consumer_enforcing_a_different_contract_refuses_a_declared_policy(
+    tmp_path: Path,
+) -> None:
+    """A caller implementing @2 cannot enforce an @1 policy, so the bundle is refused.
+
+    "Some enforcement" is not enforcement of THIS contract; accepting a near-miss
+    id would apply rules the author never wrote.
+    """
+
+    bundle = _tool_policy_bundle(
+        tmp_path,
+        '{"enforcement": "' + _TP_ENFORCEMENT + '", "allow": ["grafana/list_datasources"]}',
+    )
+    _write_mcp(bundle, '{"mcpServers": {"grafana": {"command": "grafana-mcp"}}}')
+
+    result = validate_bundle(bundle, enforces_tool_policy="curie/mcp-tool-policy@2")
+    assert not result.valid
+    assert _UNENFORCED in {i.code for i in result.errors}
+
+
+def test_the_handshake_error_is_the_declared_id_pinned_to_the_exported_constant() -> None:
+    """The id the validator demands is the one the module exports; not two literals."""
+
+    assert TOOL_POLICY_ENFORCEMENT == _TP_ENFORCEMENT
+
+
+# --- shape ---------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("literal", ['["grafana/*"]', '"allow everything"'], ids=["list", "string"])
+def test_tool_policy_that_is_not_an_object_is_rejected(tmp_path: Path, literal: str) -> None:
+    """A list or string toolPolicy carries no collections, so it can classify nothing.
+
+    It must be rejected rather than ignored: a manifest that "has a toolPolicy"
+    which the loader cannot read is the worst outcome -- the author sees the key
+    in their bundle and assumes it is in force.
+
+    ``PluginManifest.toolPolicy`` is typed ``dict[str, Any] | None``, the same as
+    ``approvalPolicy``, so a non-object value fails manifest model validation one
+    layer before ``_validate_tool_policy`` ever runs. The code is therefore
+    ``manifest.invalid``, not ``tool_policy.invalid`` -- but the property under
+    test, rejection, still holds, so this asserts the reported error names
+    ``toolPolicy`` rather than a specific error code.
+    """
+
+    bundle = _tool_policy_bundle(tmp_path, literal)
+
+    result = validate_bundle(bundle, enforces_tool_policy=TOOL_POLICY_ENFORCEMENT)
+    assert not result.valid
+    assert any("toolPolicy" in issue.message for issue in result.errors), result.errors
+
+
+def test_tool_policy_collection_that_is_not_a_list_is_rejected(tmp_path: Path) -> None:
+    """``allow`` given as a bare string is a shape error, not a one-element list.
+
+    Coercing it would silently reinterpret the author's intent; a string is also
+    iterable, so a lenient implementation could end up matching per-character.
+    """
+
+    bundle = _tool_policy_bundle(
+        tmp_path,
+        '{"enforcement": "' + _TP_ENFORCEMENT + '", "allow": "grafana/*"}',
+    )
+
+    assert "tool_policy.invalid" in _tool_policy_codes(bundle)
+    assert not validate_bundle(bundle, enforces_tool_policy=TOOL_POLICY_ENFORCEMENT).valid
+
+
+def test_a_misspelled_collection_key_is_rejected_not_silently_dropped(tmp_path: Path) -> None:
+    """``denny`` instead of ``deny`` is a DENY-BYPASS, so ToolPolicy forbids extra keys.
+
+    The attack this closes: with a lenient model the misspelled key is accepted
+    and discarded, the real ``deny`` list is empty, and ``k8s/delete_namespace``
+    -- which the author believes is blocked -- falls through to the ``allow`` glob
+    and becomes callable. A typo silently WIDENS permissions.
+
+    This is why ToolPolicy is strict where PluginManifest is lenient: the manifest
+    has an external producer (Claude Code) that legitimately adds keys; a
+    Curie-owned policy object has none, so an unknown key is always a mistake --
+    the same reasoning ConnectorSpec, ConnectorLockEntry and DeployTarget already
+    encode with ``extra="forbid"``.
+    """
+
+    bundle = _tool_policy_bundle(
+        tmp_path,
+        '{"enforcement": "' + _TP_ENFORCEMENT + '", '
+        '"allow": ["k8s/*"], "denny": ["k8s/delete_namespace"]}',
+    )
+    _write_mcp(bundle, '{"mcpServers": {"k8s": {"command": "k8s-mcp"}}}')
+
+    result = validate_bundle(bundle, enforces_tool_policy=TOOL_POLICY_ENFORCEMENT)
+    assert not result.valid
+    issue = next(i for i in result.errors if i.code == "tool_policy.invalid")
+    assert "denny" in issue.message
+
+
+def test_manifest_stays_lenient_around_a_strict_tool_policy(tmp_path: Path) -> None:
+    """Strictness is scoped to the ToolPolicy object; the manifest keeps accepting extras.
+
+    Tightening the whole manifest would reject real Claude Code bundles carrying
+    fields this package does not model -- the compatibility wedge.
+    """
+
+    bundle = _bundle(
+        tmp_path,
+        '{"name": "demo", "futureField": 42, "toolPolicy": '
+        '{"enforcement": "' + _TP_ENFORCEMENT + '", "allow": ["grafana/*"]}}',
+    )
+    _write_mcp(bundle, '{"mcpServers": {"grafana": {"command": "grafana-mcp"}}}')
+
+    result = validate_bundle(bundle, enforces_tool_policy=TOOL_POLICY_ENFORCEMENT)
+    assert result.valid, result.errors
+
+
+# --- the enforcement id the BUNDLE declares -----------------------------------
+
+
+def test_tool_policy_without_an_enforcement_id_is_rejected(tmp_path: Path) -> None:
+    """A policy that names no enforcement contract cannot be applied by any build."""
+
+    bundle = _tool_policy_bundle(tmp_path, '{"allow": ["grafana/*"]}')
+
+    result = validate_bundle(bundle, enforces_tool_policy=TOOL_POLICY_ENFORCEMENT)
+    assert not result.valid
+    issue = next(i for i in result.errors if i.code == "tool_policy.enforcement_unsupported")
+    assert _TP_ENFORCEMENT in issue.message
+
+
+def test_tool_policy_with_a_blank_enforcement_id_is_rejected(tmp_path: Path) -> None:
+    """An empty string is not a contract id; it must not read as "unset, so fine"."""
+
+    bundle = _tool_policy_bundle(tmp_path, '{"enforcement": "", "allow": ["grafana/*"]}')
+
+    result = validate_bundle(bundle, enforces_tool_policy=TOOL_POLICY_ENFORCEMENT)
+    assert not result.valid
+    issue = next(i for i in result.errors if i.code == "tool_policy.enforcement_unsupported")
+    assert _TP_ENFORCEMENT in issue.message
+
+
+@pytest.mark.parametrize(
+    "declared",
+    [
+        pytest.param(" curie/mcp-tool-policy@1", id="leading-space"),
+        pytest.param("curie/mcp-tool-policy@1 ", id="trailing-space"),
+        pytest.param("curie/mcp-tool-policy\t@1", id="internal-tab"),
+    ],
+)
+def test_a_whitespace_padded_enforcement_id_is_rejected(tmp_path: Path, declared: str) -> None:
+    """The id is compared BYTE-FOR-BYTE: padding makes it a different string, so it is refused.
+
+    Not stripping is the fail-CLOSED choice. Accepting " curie/mcp-tool-policy@1 "
+    as v1 would silently decide on the author's behalf that the padding meant
+    nothing -- and would put the deploy validator and any future runtime loader
+    one normalization apart, which is the #453/#544 drift. ``load_tool_policy``
+    refuses the same strings for the same reason.
+
+    Deliberately unlike the approval-gate check, which DOES strip gate names so
+    the validator and the loader agree on one tool name: a version discriminator
+    is not a tool name.
+    """
+
+    # json.dumps, not string concatenation: the tab case carries a real control
+    # character, which is illegal RAW inside a JSON string and would otherwise
+    # fail manifest parsing instead of reaching the enforcement check.
+    bundle = _tool_policy_bundle(
+        tmp_path,
+        json.dumps({"enforcement": declared, "allow": ["grafana/*"]}),
+    )
+    _write_mcp(bundle, '{"mcpServers": {"grafana": {"command": "grafana-mcp"}}}')
+
+    result = validate_bundle(bundle, enforces_tool_policy=TOOL_POLICY_ENFORCEMENT)
+    assert not result.valid
+    issue = next(i for i in result.errors if i.code == "tool_policy.enforcement_unsupported")
+    # Both what was written and what this build implements, or the fix is a guess.
+    assert repr(declared) in issue.message
+    assert _TP_ENFORCEMENT in issue.message
+
+
+def test_tool_policy_with_a_future_enforcement_id_is_rejected(tmp_path: Path) -> None:
+    """A bundle asking for @2 semantics gets refused, not silently given @1 semantics.
+
+    Asserted with the caller passing the SUPPORTED id, so this is not the
+    handshake error in disguise: the bundle's own declaration is what fails. The
+    message must name BOTH ids -- what the author asked for and what this build
+    implements -- or the fix is a guess.
+    """
+
+    bundle = _tool_policy_bundle(
+        tmp_path,
+        '{"enforcement": "curie/mcp-tool-policy@2", "allow": ["grafana/*"]}',
+    )
+    _write_mcp(bundle, '{"mcpServers": {"grafana": {"command": "grafana-mcp"}}}')
+
+    result = validate_bundle(bundle, enforces_tool_policy=TOOL_POLICY_ENFORCEMENT)
+    assert not result.valid
+    issue = next(i for i in result.errors if i.code == "tool_policy.enforcement_unsupported")
+    assert "curie/mcp-tool-policy@2" in issue.message
+    assert _TP_ENFORCEMENT in issue.message
+
+
+# --- pattern grammar ----------------------------------------------------------
+
+
+def test_valid_tool_policy_over_declared_servers_validates_green(tmp_path: Path) -> None:
+    """The happy path: well-formed patterns naming servers the bundle actually declares."""
+
+    bundle = _tool_policy_bundle(
+        tmp_path,
+        '{"enforcement": "' + _TP_ENFORCEMENT + '", '
+        '"allow": ["grafana/list_datasources", "grafana/query_*"], '
+        '"approvalRequired": ["kubernetes/pods_*"], '
+        '"deny": ["kubernetes/resources_delete"]}',
+    )
+    _write_mcp(
+        bundle,
+        '{"mcpServers": {"grafana": {"command": "grafana-mcp"}, '
+        '"kubernetes": {"command": "k8s-mcp"}}}',
+    )
+
+    result = validate_bundle(bundle, enforces_tool_policy=TOOL_POLICY_ENFORCEMENT)
+    assert result.valid, result.errors
+    assert _tool_policy_codes(bundle) == []
+
+
+def test_malformed_patterns_are_reported_in_every_collection(tmp_path: Path) -> None:
+    """All THREE collections are pattern-checked, each at its own location.
+
+    The realistic defect is wiring the check into ``allow`` only: a malformed
+    pattern in ``deny`` never matches anything, so the bundle validates green while
+    the author believes a tool is blocked. One bad pattern per collection proves
+    each is walked.
+    """
+
+    bundle = _tool_policy_bundle(
+        tmp_path,
+        '{"enforcement": "' + _TP_ENFORCEMENT + '", '
+        '"allow": ["grafana/**"], '
+        '"approvalRequired": ["kubernetes/pods run"], '
+        '"deny": ["a/b/c"]}',
+    )
+    _write_mcp(
+        bundle,
+        '{"mcpServers": {"grafana": {"command": "grafana-mcp"}, '
+        '"kubernetes": {"command": "k8s-mcp"}}}',
+    )
+
+    result = validate_bundle(bundle, enforces_tool_policy=TOOL_POLICY_ENFORCEMENT)
+    assert not result.valid
+    issues = [i for i in result.errors if i.code == "tool_policy.pattern_invalid"]
+    assert len(issues) == 3, result.errors
+    locations = [i.location for i in issues]
+    for collection in ("allow", "approvalRequired", "deny"):
+        assert any(collection in loc and "[0]" in loc for loc in locations), locations
+    # And each offending pattern is named, so the author can find it.
+    messages = " ".join(i.message for i in issues)
+    assert "grafana/**" in messages
+    assert "a/b/c" in messages
+
+
+def test_pattern_invalid_location_names_the_collection_and_index(tmp_path: Path) -> None:
+    """The second entry of a collection is reported at index 1, not 0.
+
+    A hardcoded index would send the author to the wrong line of a long list.
+    """
+
+    bundle = _tool_policy_bundle(
+        tmp_path,
+        '{"enforcement": "' + _TP_ENFORCEMENT + '", '
+        '"allow": ["grafana/list_datasources", "grafana/[abc]*"]}',
+    )
+    _write_mcp(bundle, '{"mcpServers": {"grafana": {"command": "grafana-mcp"}}}')
+
+    result = validate_bundle(bundle, enforces_tool_policy=TOOL_POLICY_ENFORCEMENT)
+    issue = next(i for i in result.errors if i.code == "tool_policy.pattern_invalid")
+    assert "allow" in issue.location
+    assert "[1]" in issue.location
+
+
+@pytest.mark.parametrize(
+    "pattern",
+    ["grafana/**", "grafana/[abc]*", "a/b/c", "grafana/tool!", "list_datasources"],
+)
+def test_the_validator_rejects_exactly_what_validate_pattern_rejects(
+    tmp_path: Path, pattern: str
+) -> None:
+    """ONE normalization path: the deploy gate applies the exported grammar, not its own.
+
+    The #453/#544 lesson -- a validator and a runtime loader that each normalize
+    separately drift apart silently and ship a fail-open. Both halves of this test
+    use the SAME pattern string, so a second, divergent grammar inside validate.py
+    fails here instead of at turn time.
+    """
+
+    assert validate_pattern(pattern) is not None, "fixture must be an invalid pattern"
+
+    bundle = _tool_policy_bundle(
+        tmp_path,
+        '{"enforcement": "' + _TP_ENFORCEMENT + '", "deny": ["' + pattern + '"]}',
+    )
+
+    codes = _tool_policy_codes(bundle)
+    assert "tool_policy.pattern_invalid" in codes
+
+
+def test_duplicate_pattern_within_one_collection_is_rejected(tmp_path: Path) -> None:
+    """The same pattern twice in one collection is a copy-paste artifact, not a rule.
+
+    It is rejected rather than deduped because the author almost certainly meant
+    to write two DIFFERENT patterns, and silently collapsing them hides the tool
+    they thought they had covered.
+    """
+
+    bundle = _tool_policy_bundle(
+        tmp_path,
+        '{"enforcement": "' + _TP_ENFORCEMENT + '", '
+        '"allow": ["grafana/query_*", "grafana/list_*", "grafana/query_*"]}',
+    )
+    _write_mcp(bundle, '{"mcpServers": {"grafana": {"command": "grafana-mcp"}}}')
+
+    result = validate_bundle(bundle, enforces_tool_policy=TOOL_POLICY_ENFORCEMENT)
+    assert not result.valid
+    issue = next(i for i in result.errors if i.code == "tool_policy.pattern_duplicate")
+    assert "grafana/query_*" in issue.message
+
+
+def test_identical_pattern_in_allow_and_deny_is_rejected(tmp_path: Path) -> None:
+    """One pattern string in two collections is a contradiction the author must resolve.
+
+    Precedence would silently resolve it (deny wins), which is exactly why it must
+    be rejected: the author wrote both, so one of the two is a mistake, and the
+    validator cannot know which.
+    """
+
+    bundle = _tool_policy_bundle(
+        tmp_path,
+        '{"enforcement": "' + _TP_ENFORCEMENT + '", '
+        '"allow": ["kubernetes/resources_scale"], '
+        '"deny": ["kubernetes/resources_scale"]}',
+    )
+    _write_mcp(bundle, '{"mcpServers": {"kubernetes": {"command": "k8s-mcp"}}}')
+
+    result = validate_bundle(bundle, enforces_tool_policy=TOOL_POLICY_ENFORCEMENT)
+    assert not result.valid
+    issue = next(i for i in result.errors if i.code == "tool_policy.pattern_conflict")
+    assert "kubernetes/resources_scale" in issue.message
+
+
+def test_overlapping_but_different_patterns_across_collections_validate_green(
+    tmp_path: Path,
+) -> None:
+    """OVERLAP is legal and deliberate; only exact duplication across collections is not.
+
+    ``deny: k8s/resources_*`` beside ``allow: k8s/resources_scale`` is the normal
+    way to carve an exception out of a broad rule, and precedence gives it a
+    well-defined answer. A conflict check that compared by MATCH rather than by
+    exact string would reject this idiom and make the policy unusable.
+    """
+
+    bundle = _tool_policy_bundle(
+        tmp_path,
+        '{"enforcement": "' + _TP_ENFORCEMENT + '", '
+        '"allow": ["k8s/resources_scale"], '
+        '"deny": ["k8s/resources_*"]}',
+    )
+    _write_mcp(bundle, '{"mcpServers": {"k8s": {"command": "k8s-mcp"}}}')
+
+    result = validate_bundle(bundle, enforces_tool_policy=TOOL_POLICY_ENFORCEMENT)
+    assert result.valid, result.errors
+    assert _tool_policy_codes(bundle) == []
+
+
+# --- the declared-server cross-check ------------------------------------------
+
+
+def test_pattern_naming_an_undeclared_server_is_rejected(tmp_path: Path) -> None:
+    """A literal server segment the bundle never declares is a typo that gates nothing.
+
+    The pattern is syntactically fine, so nothing else catches it: the rule simply
+    never matches a live tool, and the author believes they wrote a control.
+    """
+
+    bundle = _tool_policy_bundle(
+        tmp_path,
+        '{"enforcement": "' + _TP_ENFORCEMENT + '", "deny": ["grafna/delete_dashboard"]}',
+    )
+    _write_mcp(bundle, '{"mcpServers": {"grafana": {"command": "grafana-mcp"}}}')
+
+    result = validate_bundle(bundle, enforces_tool_policy=TOOL_POLICY_ENFORCEMENT)
+    assert not result.valid
+    issue = next(i for i in result.errors if i.code == "tool_policy.unknown_server")
+    assert "grafna" in issue.message
+
+
+def test_a_wildcard_server_segment_never_triggers_unknown_server(tmp_path: Path) -> None:
+    """``*/pods_run`` names no server, so there is nothing to cross-check.
+
+    Asserted on a bundle that declares NO servers at all, the case where a naive
+    implementation ("is the segment in the declared set?") would reject every
+    wildcard pattern.
+    """
+
+    bundle = _tool_policy_bundle(
+        tmp_path,
+        '{"enforcement": "' + _TP_ENFORCEMENT + '", '
+        '"approvalRequired": ["*/pods_run"], "allow": ["*/*"]}',
+    )
+
+    result = validate_bundle(bundle, enforces_tool_policy=TOOL_POLICY_ENFORCEMENT)
+    assert result.valid, result.errors
+    assert "tool_policy.unknown_server" not in _tool_policy_codes(bundle)
+
+
+def test_a_literal_segment_naming_a_declared_server_does_not_trigger_unknown_server(
+    tmp_path: Path,
+) -> None:
+    """The positive control for the cross-check: a declared server is accepted."""
+
+    bundle = _tool_policy_bundle(
+        tmp_path,
+        '{"enforcement": "' + _TP_ENFORCEMENT + '", "allow": ["grafana/list_datasources"]}',
+    )
+    _write_mcp(bundle, '{"mcpServers": {"grafana": {"command": "grafana-mcp"}}}')
+
+    result = validate_bundle(bundle, enforces_tool_policy=TOOL_POLICY_ENFORCEMENT)
+    assert result.valid, result.errors
+    assert "tool_policy.unknown_server" not in _tool_policy_codes(bundle)
+
+
+def test_a_connectors_yaml_server_satisfies_the_cross_check(tmp_path: Path) -> None:
+    """connectors.yaml is the bundle's OTHER tool surface, so its servers count too.
+
+    Without it, a bundle whose whole surface is connectors would have every literal
+    pattern rejected and could not write a policy at all.
+    """
+
+    bundle = _tool_policy_bundle(
+        tmp_path,
+        '{"enforcement": "' + _TP_ENFORCEMENT + '", '
+        '"approvalRequired": ["kubernetes-admin/resources_create_or_update"]}',
+    )
+    _write_connectors(
+        bundle,
+        "connectors:\n  kubernetes-admin:\n    image: ghcr.io/example/k8s-mcp:1.0.0\n",
+    )
+
+    result = validate_bundle(bundle, enforces_tool_policy=TOOL_POLICY_ENFORCEMENT)
+    assert result.valid, result.errors
+    assert "tool_policy.unknown_server" not in _tool_policy_codes(bundle)
+
+
+def test_unknown_server_check_stays_silent_when_the_mcp_declaration_is_unreadable(
+    tmp_path: Path,
+) -> None:
+    """An unreadable .mcp.json makes the declared-server set UNKNOWABLE, not empty.
+
+    Treating it as empty would report every literal pattern as naming an undeclared
+    server, stacking a pile of misleading errors on top of the real JSON error and
+    sending the author to fix the wrong file. The MCP error must fire alone.
+    """
+
+    bundle = _tool_policy_bundle(
+        tmp_path,
+        '{"enforcement": "' + _TP_ENFORCEMENT + '", '
+        '"allow": ["grafana/list_datasources"], "deny": ["kubernetes/pods_run"]}',
+    )
+    _write_mcp(bundle, "{not json")
+
+    result = validate_bundle(bundle, enforces_tool_policy=TOOL_POLICY_ENFORCEMENT)
+    codes = {i.code for i in result.errors}
+    assert "mcp.invalid_json" in codes
+    assert "tool_policy.unknown_server" not in codes
+
+
+def test_a_policy_denying_everything_warns_but_still_validates(tmp_path: Path) -> None:
+    """Three empty collections deny every tool: coherent, so a WARNING, not an error.
+
+    It is legal (a deliberate lockdown) but almost always a mistake, and the agent
+    that ships it will simply refuse every tool call with no explanation at turn
+    time. Warn loudly at deploy, where the author is still looking.
+    """
+
+    bundle = _tool_policy_bundle(
+        tmp_path,
+        '{"enforcement": "' + _TP_ENFORCEMENT + '", '
+        '"allow": [], "approvalRequired": [], "deny": []}',
+    )
+    _write_mcp(bundle, '{"mcpServers": {"grafana": {"command": "grafana-mcp"}}}')
+
+    result = validate_bundle(bundle, enforces_tool_policy=TOOL_POLICY_ENFORCEMENT)
+    assert result.valid, result.errors
+    assert "tool_policy.denies_everything" in {i.code for i in result.warnings}

--- a/scripts/check-plugin-compat.sh
+++ b/scripts/check-plugin-compat.sh
@@ -3,10 +3,10 @@
 # The bundle format is the Claude Code plugin shape verbatim (the distribution
 # wedge), so outbound compatibility is a contract, not a claim: this is the
 # local mirror of the CI plugin-compat gate. Plain `claude plugin validate`, no
-# --strict: our five authoring extensions (systemPrompt, starterPrompts,
-# secrets, triggers, approvalPolicy) are unknown-to-Claude-Code by design, and
-# --strict would promote those unknown-field warnings to errors. Warnings are
-# expected and allowed; a non-zero exit is the failure signal.
+# --strict: our six authoring extensions (systemPrompt, starterPrompts,
+# secrets, triggers, approvalPolicy, toolPolicy) are unknown-to-Claude-Code by
+# design, and --strict would promote those unknown-field warnings to errors.
+# Warnings are expected and allowed; a non-zero exit is the failure signal.
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"


### PR DESCRIPTION
## Summary

Adds `toolPolicy` to the plugin manifest: glob collections over canonical `<server>/<tool>` names that classify every tool a vanilla MCP server publishes as **allow**, **approval-required**, or **deny**. A tool no pattern matches is **denied**, so a server that starts advertising a new tool fails closed instead of silently widening the agent's reach. Conflicts resolve `deny > approval-required > allow` by **class**, never by pattern specificity, so a broad deny always outranks a narrow allow.

This is the frozen-contract slice only — declaration and validation. It carries no runner, worker, API, CLI, connector-removal or adoption change, and no ADR. `packages/aci-protocol` is untouched.

The decision comes from the live tracer recorded at local commit **`1b809ab2`** (`.projects/vanilla-mcp-approval-spike/REPORT.md`, verdict CONDITIONAL). That tracer proved allow, durable approval-then-resume, and exact deny against two published MCP servers, and identified the frozen-contract blocker it could not work around: a single explicit deny-unclassified tri-state manifest field belongs to the bundle shape in `packages/plugin-format`. This PR is that field.

**Two dependent lanes are blocked on this merging:** runtime enforcement of the policy, and the Grafana adoption slice. Neither may proceed until this contract lands — and no bundle may ship a `toolPolicy` until runtime enforcement exists, because the validator refuses one until then (see below).

### The fail-closed core

`validate_bundle` gained a keyword-only `enforces_tool_policy` handshake. A bundle declaring a policy is **refused** unless the caller names the exact supported contract id `curie/mcp-tool-policy@1`.

No caller in the tree passes it. The API's bundle intake (`apps/api/src/curie_api/bundles.py`) and the runner's boot-time plugin load (`runner/src/curie_runner/plugin.py`) both call `validate_bundle(root)` with no declaration, so today a policy-bearing bundle is rejected outright rather than accepted by a consumer that would apply nothing. A manifest claiming a fenced tool surface while nothing enforces it is worse than no field at all.

An earlier design had only a raising `load_tool_policy` helper. Cross-engine adversarial review found that opt-in: nothing forces a consumer to call it, so every current consumer would have accepted and ignored a declared policy. The handshake at the validation surface is the fix, and it needs no runtime-lane change.

Residual gap, stated plainly: a platform built **before** this package version does not model the key at all, and its lenient models ignore it. No in-package mechanism can reach that, which is another reason runtime enforcement is a blocking follow-up.

### Other decisions worth review

- **`ToolPolicy` forbids unknown keys**, unlike the lenient Claude-Code-shaped models around it, matching the strict Curie-only overlay models (`ConnectorSpec`, `DeployTarget`). A misspelled collection such as `denny` would otherwise validate, silently drop its list, and turn a typo into permission widening.
- **One authoritative normalization.** Every grammar, duplicate and cross-collection conflict rule lives in `tool_policy.py`; `_validate_tool_policy` calls it and `load_tool_policy` runs the same checker before returning a policy, so a runtime cannot obtain patterns the validator would have rejected. This is the `approval_policy.py` lesson (#453/#544) — a validator and a loader normalizing separately silently disagree and ship a fail-open.
- **The enforcement id is compared byte-for-byte**, deliberately unlike the gate-name stripping next door: a version discriminator is not a tool name, so a padded id is refused loudly rather than read as v1.
- **The grammar is deliberately narrow** (one `/`, segments of `A-Za-z0-9_.-` plus `*` and `?`, matched per segment with `fnmatchcase` so a wildcard cannot cross the separator). It cannot spell every protocol-legal MCP name. That is fail-closed for literals, but the README states the real trade-off rather than overclaiming: a wildcard **can** still reach a name you cannot spell literally, which widens rather than narrows.

### Compatibility class

**New optional field — the patch row** of the table in `packages/CLAUDE.md`. A bundle omitting `toolPolicy` produces the same `valid`/`errors`/`warnings` as before; `PluginManifest.model_dump()` gains `toolPolicy: None`, which tolerant consumers ignore. `plugin-format` carries no `PROTOCOL_VERSION` and no ACI wire shape changed, so **nothing is bumped** — matching commit `1db6f3ca`, which added `approvalPolicy` and `triggers` the same way and likewise touched no version constant.

`toolPolicy` is the **sixth** Curie authoring extension, so the places that enumerate the set were updated for parity: `scripts/check-plugin-compat.sh`, `examples/tests/test_plugin_compat_coverage.py`, `examples/compat-fixture`, both docs, and one `cli/plugin-format-mirrors.json` omissions entry that keeps the existing `plugin_format_field_parity` gate green (a declaration file, not CLI behaviour).

## Related issue

Ref #30

## Fix pin verification

<!-- Not a fix PR. -->

## End-to-end verification

Candidate commit `f1bfec6c`.

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | Required | Bundle validation runs at runner boot (`load_plugins` -> `validate_bundle`), which is plugin packaging | fake | `CURIE_E2E_TIERS=skill cli/scripts/e2e-ladder.sh` -> `LADDER PASS (tiers: skill)`, exit 0. Guard demonstration below. |
| local | n/a | No compose service, dispatcher, worker or API wiring changed; no `curie` verb output, exit code or `--json` shape changed | — | — |
| local-release | n/a | No released binary or image identity, install path, version pin or release compose changed | — | — |
| cluster | n/a | No chart template, RBAC, securityContext, NetworkPolicy, sandbox claim or init container changed | — | — |
| live provider | n/a | No model routing, credential resolution, provider auth or cost accounting touched | — | — |
| external integration | n/a | No Slack, git webhook, connector OAuth or third-party API shape touched | — | — |

**Positive proof and falsifiable negative**, run against the runner image built from this commit (`curie build`, image `e4bf8ba1bfaa`), through the real boot entry point `curie_runner.plugin.load_plugins`:

```console
$ docker run --rm --network=none -v <bundle>:/bundle:ro curie-runner:vmtp-final \
    python -c "from curie_runner.plugin import load_plugins, PluginBundleError; ..."

# no toolPolicy at all -- backward compatibility control
RESULT: LOADED

# well-formed toolPolicy, consumer declares no enforcement
RESULT: REFUSED -> invalid plugin bundle at /bundle: [tool_policy.unenforced]
  plugin.json (toolPolicy): this bundle declares a toolPolicy, but the caller
  validating it enforces None rather than 'curie/mcp-tool-policy@1'. Accepting
  the bundle here would apply NO policy at all...

# malformed glob "grafana/**"
RESULT: REFUSED -> ... [tool_policy.pattern_invalid] plugin.json (toolPolicy.deny[0]):
  invalid tool pattern 'grafana/**': '**' has no meaning in a two-segment
  '<server>/<tool>' name; use a single '*' in the segment you mean to widen

# enforcement id " curie/mcp-tool-policy@1 " (padded)
RESULT: REFUSED -> [tool_policy.unenforced] ...
```

The first line is the backward-compatibility control; the rest are the falsifiable negatives. The runner is a consumer that cannot enforce the policy, and it refuses rather than accepting one.

**Gates, all on `f1bfec6c`:**

```console
$ uv run pytest packages/plugin-format/tests runner/tests examples/tests/test_plugin_compat_coverage.py -q
1222 passed, 4 skipped

$ uv run pytest apps/api/tests -q -k bundle
57 passed, 1231 deselected

$ bash scripts/check-contracts.sh
OK: all committed contract artifacts are current.

$ bash scripts/check-docs.sh
OK: the interface catalog is generated and drift-free, every citation resolves, and every command the verification contract names is real.

$ cargo test --manifest-path cli/Cargo.toml --test plugin_format_field_parity
test result: ok. 7 passed; 0 failed

$ uv run ruff check .
All checks passed!

$ uv run mypy
Success: no issues found in 233 source files

$ CURIE_E2E_TIERS=skill bash cli/scripts/e2e-ladder.sh
LADDER PASS (tiers: skill)
```

`check-contracts.sh` is the artifact-sync and wire-lock evidence: it regenerates both JSON Schemas, the Rust crate, the TypeScript, and the ACI `wire.lock`, then diffs them — confirming the plugin-format schema is current **and** that no ACI artifact drifted.

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.
- [ ] Or: this change is not behavior-bearing, so no tier applies, and the summary says why.

## Review notes

Two cross-engine adversarial review passes ran, on the plan and on the diff. Findings they caught and this PR fixes:

1. **Critical** — the enforcement handshake was opt-in, so every current consumer would silently accept a declared policy. Fixed by the `validate_bundle` handshake above.
2. **High** — `load_tool_policy` returned a policy without running the shared pattern checker, so a runtime could load `allow: ["grafana/[a-z]*"]` — a character class the validator rejects — and `fnmatchcase` would give it real allow semantics. The loader now runs the same checker and refuses with `ToolPolicyInvalid`.
3. **High** — a lenient `ToolPolicy` made a misspelled collection a deny-bypass. Now strict.
4. **Medium** — the enforcement id was compared after stripping. Now byte-for-byte.
5. **Low** — the README claimed an unspellable name is matched by nothing; a wildcard does reach it. Corrected.

Knowingly accepted, rated Low by the reviewer: `classify_tool` now raises on a non-`str` input where it previously returned `DENY`. That violates the annotated type, cannot widen permissions, and fails loudly rather than silently.

Deliberately deferred, not silently dropped: the extension set is restated in five places (a shell comment, a Python tuple, a JSON array, and prose in two docs). Deriving it from `PluginManifest` is the deeper fix and is a follow-up, not this PR — a missed edit fails the coverage test loudly today.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [ ] An ADR is added under `docs/adr/` if this is an architectural decision.

The ADR box is deliberately unchecked. The tracer's own analysis names seven Accepted ADRs this direction would amend (ADR-0009, 0086, 0087, 0090, 0094, 0113, 0117) and notes ADR-0050 would need amending only if policy is unified — which this field begins. Authoring or accepting an ADR was outside this task's authority, so it is flagged for the maintainer rather than decided here.
