### PR TITLE
Make a refused connector call an error on the wire, not a success

### DIFF
--- a/examples/sre-bot/connectors/k8s-write/server.py
+++ b/examples/sre-bot/connectors/k8s-write/server.py
@@ -57,6 +57,7 @@ from typing import Any
 import httpx
 import yaml
 from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp.exceptions import ToolError
 from mcp.types import ToolAnnotations
 
 log = logging.getLogger("k8s-write-mcp")
@@ -99,22 +100,31 @@ WRITE = ToolAnnotations(
 )
 
 
-def _client() -> Any:
-    """Build an httpx client from the mounted kubeconfig, or return a string.
+def _client() -> httpx.Client:
+    """Build an httpx client from the mounted kubeconfig, or raise `ToolError`.
 
     The kubeconfig is a static one built for this identity (the bundle README's
     write-path section has the assembly steps).
     Parsed here rather than pulling in the full Kubernetes client, so the
     failure modes are ones this file can explain.
+
+    Every failure raises `ToolError` so the tool result carries `isError: true`.
+    FastMCP puts the message on the wire behind a fixed `Error executing tool
+    <tool_name>: ` prefix and adds nothing else -- no traceback, no stack frames
+    -- so the sentence the model reads is still the one it read when these were
+    returned, and a caller that only reads the protocol can now tell a refused
+    write from a completed one.
     """
 
     try:
         with open(KUBECONFIG, encoding="utf-8") as fh:
             cfg = yaml.safe_load(fh)
     except FileNotFoundError:
-        return f"no kubeconfig at {KUBECONFIG}: the write credential is not mounted"
+        raise ToolError(
+            f"no kubeconfig at {KUBECONFIG}: the write credential is not mounted"
+        ) from None
     except (OSError, yaml.YAMLError) as exc:
-        return f"could not read the kubeconfig at {KUBECONFIG}: {exc}"
+        raise ToolError(f"could not read the kubeconfig at {KUBECONFIG}: {exc}") from exc
 
     try:
         cluster = cfg["clusters"][0]["cluster"]
@@ -122,7 +132,7 @@ def _client() -> Any:
         server = cluster["server"]
         token = user["token"]
     except (KeyError, IndexError, TypeError):
-        return "kubeconfig is missing a cluster server or a user token"
+        raise ToolError("kubeconfig is missing a cluster server or a user token") from None
 
     # Both CA shapes, because a kubeconfig may carry either and getting this
     # wrong fails as CERTIFICATE_VERIFY_FAILED -- which reads like a cluster
@@ -144,19 +154,23 @@ def _client() -> Any:
         try:
             pem = base64.b64decode(ca_data).decode("ascii")
         except (ValueError, TypeError, UnicodeDecodeError) as exc:
-            return f"kubeconfig certificate-authority-data is not a valid base64 PEM: {exc}"
+            raise ToolError(
+                f"kubeconfig certificate-authority-data is not a valid base64 PEM: {exc}"
+            ) from exc
         ctx = ssl.create_default_context()
         try:
             ctx.load_verify_locations(cadata=pem)
         except ssl.SSLError as exc:
-            return f"kubeconfig certificate-authority-data is not a usable CA certificate: {exc}"
+            raise ToolError(
+                f"kubeconfig certificate-authority-data is not a usable CA certificate: {exc}"
+            ) from exc
         verify = ctx
     elif ca_path:
         verify = ca_path
     elif cluster.get("insecure-skip-tls-verify"):
         # Never silently. A write path that skips verification is a write path
         # that can be pointed at an impostor API server.
-        return (
+        raise ToolError(
             "kubeconfig sets insecure-skip-tls-verify; refusing to write over an "
             "unverified connection"
         )
@@ -185,6 +199,13 @@ def restart_deployment(namespace: str, name: str) -> str:
     do NOT call it again: check the rollout's state with the read-only Kubernetes
     tools first, because the restart may well have started.
 
+    Every failure is a tool error rather than a returned sentence, so a program
+    reading the result -- an eval grader, an audit ledger, a retry policy -- sees
+    `isError: true` and does not count a refusal as a restart. The text it
+    carries is that same sentence a human would have read, behind FastMCP's
+    fixed `Error executing tool restart_deployment: ` prefix and nothing else --
+    never a traceback.
+
     Verify afterwards with the read-only connector (`pods_list`, `events_list`)
     rather than assuming success from this tool's return value.
     """
@@ -192,34 +213,36 @@ def restart_deployment(namespace: str, name: str) -> str:
     namespace = (namespace or "").strip()
     name = (name or "").strip()
     if not namespace or not name:
-        return "both namespace and name are required"
+        raise ToolError("both namespace and name are required")
 
     target = f"{namespace}/{name}"
     if target not in ALLOWLIST:
         permitted = ", ".join(sorted(ALLOWLIST)) or "(none configured)"
-        return (
+        raise ToolError(
             f"refusing: {target} is not in this connector's allowlist. "
             f"Permitted: {permitted}. This is a deliberate ceiling -- widening it "
             "is an operator change, not something to work around."
         )
 
     client = _client()
-    if isinstance(client, str):
-        return client
 
     path = f"/apis/apps/v1/namespaces/{namespace}/deployments/{name}"
     try:
         with client:
             existing = client.get(path)
             if existing.status_code == 404:
-                return f"no Deployment {target}. Check the name with the read-only tools."
+                raise ToolError(
+                    f"no Deployment {target}. Check the name with the read-only tools."
+                )
             if existing.status_code in (401, 403):
-                return (
+                raise ToolError(
                     f"the API server refused the read ({existing.status_code}). The write "
                     "credential lacks access to this Deployment. This will not fix itself on retry."
                 )
             if existing.status_code >= 400:
-                return f"could not read {target}: {existing.status_code} {existing.text[:200]}"
+                raise ToolError(
+                    f"could not read {target}: {existing.status_code} {existing.text[:200]}"
+                )
 
             # The patch body is constant apart from the timestamp. Nothing a
             # caller supplied reaches it.
@@ -238,22 +261,24 @@ def restart_deployment(namespace: str, name: str) -> str:
                 content=json.dumps(patch),
                 headers={"Content-Type": "application/strategic-merge-patch+json"},
             )
-    except httpx.TimeoutException:
-        return (
+    except httpx.TimeoutException as exc:
+        raise ToolError(
             f"the API server did not respond within {TIMEOUT:g}s. The restart MAY have "
             "started -- check the rollout with the read-only tools before doing anything else. "
             "Do not call this again."
-        )
+        ) from exc
     except httpx.HTTPError as exc:
-        return f"could not reach the API server: {exc}"
+        raise ToolError(f"could not reach the API server: {exc}") from exc
 
     if applied.status_code in (401, 403):
-        return (
+        raise ToolError(
             f"the API server refused the patch ({applied.status_code}). The write credential "
             "can read this Deployment but not patch it. This will not fix itself on retry."
         )
     if applied.status_code >= 400:
-        return f"the restart was rejected: {applied.status_code} {applied.text[:200]}"
+        raise ToolError(
+            f"the restart was rejected: {applied.status_code} {applied.text[:200]}"
+        )
 
     return (
         f"restart triggered for {target} at {stamp}. New pods are rolling out under the "

--- a/examples/sre-bot/connectors/k8s-write/test_server.py
+++ b/examples/sre-bot/connectors/k8s-write/test_server.py
@@ -19,9 +19,12 @@ import os
 import sys
 from pathlib import Path
 
+import anyio
 import httpx
 import pytest
 import yaml
+from mcp.server.fastmcp.exceptions import ToolError
+from mcp.shared.memory import create_connected_server_and_client_session as _connect
 
 _REAL_CA_PEM = (
     b"-----BEGIN CERTIFICATE-----\n"
@@ -139,8 +142,9 @@ def test_target_outside_the_allowlist_never_reaches_the_api(tmp_path, monkeypatc
         raise AssertionError("built a client for a target outside the allowlist")
 
     monkeypatch.setattr(srv, "_client", explode)
-    out = srv.restart_deployment(ns, name)
-    assert "refusing" in out and "allowlist" in out
+    with pytest.raises(ToolError) as excinfo:
+        srv.restart_deployment(ns, name)
+    assert "refusing" in str(excinfo.value) and "allowlist" in str(excinfo.value)
 
 
 def test_empty_allowlist_refuses_to_start(tmp_path):
@@ -193,21 +197,29 @@ def test_insecure_skip_tls_verify_is_refused(tmp_path):
             "users": [{"user": {"token": "t"}}],
         },
     )
-    out = srv._client()
-    assert isinstance(out, str) and "insecure-skip-tls-verify" in out
+    with pytest.raises(ToolError) as excinfo:
+        srv._client()
+    assert "insecure-skip-tls-verify" in str(excinfo.value)
 
 
-def test_missing_kubeconfig_is_a_sentence_not_a_traceback(tmp_path):
+def test_missing_kubeconfig_raises_a_sentence_not_a_traceback(tmp_path):
+    # A ToolError still reaches the model as its message behind FastMCP's fixed
+    # `Error executing tool ...: ` prefix and nothing else -- never a traceback
+    # -- so naming the missing mount survives the change from returning to
+    # raising. (The wire test below pins that prefix exactly.)
     srv = _load(tmp_path, kubeconfig=None)
-    out = srv.restart_deployment("public", "api")
-    assert isinstance(out, str) and "not mounted" in out
+    with pytest.raises(ToolError) as excinfo:
+        srv.restart_deployment("public", "api")
+    assert "not mounted" in str(excinfo.value)
 
 
 @pytest.mark.parametrize("failure", ["transport", "http-error"])
-def test_token_never_appears_in_a_returned_message(tmp_path, monkeypatch, failure):
+def test_token_never_appears_in_an_error_message(tmp_path, monkeypatch, failure):
     # str(exc) on an httpx error carries the URL, and the URL is built from the
     # kubeconfig -- so a message that interpolates the exception is one edit away
-    # from carrying the bearer token into a Slack channel.
+    # from carrying the bearer token into a Slack channel. Raising rather than
+    # returning does not change that: the ToolError's text is what the model
+    # sees, so it is the text that must not carry the credential.
     srv = _load(tmp_path)
 
     class Failing(_FakeClient):
@@ -220,15 +232,16 @@ def test_token_never_appears_in_a_returned_message(tmp_path, monkeypatch, failur
             return httpx.Response(500, text="internal error")
 
     monkeypatch.setattr(srv, "_client", lambda: Failing())
-    out = srv.restart_deployment("public", "api")
-    assert isinstance(out, str)
-    assert "write-token" not in out
+    with pytest.raises(ToolError) as excinfo:
+        srv.restart_deployment("public", "api")
+    message = str(excinfo.value)
+    assert "write-token" not in message
     if failure == "transport":
         # str(exc) on a transport error carries the URL, which is built from the
         # kubeconfig. It must not carry the credential with it.
-        assert "could not reach the API server" in out
+        assert "could not reach the API server" in message
     else:
-        assert "the restart was rejected: 500" in out
+        assert "the restart was rejected: 500" in message
 
 
 # --------------------------------------------------------------------------- #
@@ -242,24 +255,28 @@ def test_timeout_says_do_not_retry(tmp_path, monkeypatch):
             raise httpx.TimeoutException("slow")
 
     monkeypatch.setattr(srv, "_client", lambda: Timeouts())
-    out = srv.restart_deployment("public", "api")
-    assert "Do not call this again" in out
-    assert "MAY have" in out
+    with pytest.raises(ToolError) as excinfo:
+        srv.restart_deployment("public", "api")
+    message = str(excinfo.value)
+    assert "Do not call this again" in message
+    assert "MAY have" in message
 
 
 @pytest.mark.parametrize("status", [401, 403])
 def test_permission_errors_say_they_will_not_fix_themselves(tmp_path, monkeypatch, status):
     srv = _load(tmp_path)
     monkeypatch.setattr(srv, "_client", lambda: _FakeClient(get_status=status))
-    out = srv.restart_deployment("public", "api")
-    assert "not fix itself" in out
+    with pytest.raises(ToolError) as excinfo:
+        srv.restart_deployment("public", "api")
+    assert "not fix itself" in str(excinfo.value)
 
 
 def test_missing_deployment_is_reported_plainly(tmp_path, monkeypatch):
     srv = _load(tmp_path)
     monkeypatch.setattr(srv, "_client", lambda: _FakeClient(get_status=404))
-    out = srv.restart_deployment("public", "api")
-    assert "no Deployment public/api" in out
+    with pytest.raises(ToolError) as excinfo:
+        srv.restart_deployment("public", "api")
+    assert "no Deployment public/api" in str(excinfo.value)
 
 
 def test_success_message_does_not_claim_the_rollout_finished(tmp_path, monkeypatch):
@@ -269,6 +286,75 @@ def test_success_message_does_not_claim_the_rollout_finished(tmp_path, monkeypat
     monkeypatch.setattr(srv, "_client", lambda: _FakeClient())
     out = srv.restart_deployment("public", "api")
     assert "not that the rollout completed" in out
+
+
+# --------------------------------------------------------------------------- #
+# The wire. Everything above calls the tool function directly, and no assertion
+# at that level can see the field this connector is actually judged by. FastMCP
+# marks a result `isError: true` only when the call RAISED; a refusal that is
+# `return`ed is a string like any other, so it goes out as `isError: false` and
+# is indistinguishable from a completed restart to anything reading the protocol
+# rather than the prose -- an eval grader, an audit ledger, a retry policy.
+#
+# So this one goes through the real MCP request path, in process, and asserts
+# the flag on the CallToolResult.
+# --------------------------------------------------------------------------- #
+def _call_tool(srv, name, args):
+    """Call one tool through the real MCP request path and return the CallToolResult."""
+
+    async def go():
+        async with _connect(srv.mcp._mcp_server) as client:
+            return await client.call_tool(name, args)
+
+    return anyio.run(go)
+
+
+def test_a_refusal_and_a_restart_carry_different_is_error_flags(tmp_path, monkeypatch):
+    srv = _load(tmp_path)
+    # A client that would succeed, so the only thing separating the two calls is
+    # the allowlist -- not a broken fake.
+    monkeypatch.setattr(srv, "_client", lambda: _FakeClient())
+
+    refused = _call_tool(srv, "restart_deployment", {"namespace": "platform", "name": "api"})
+    assert refused.isError is True
+    # The prose survives the trip, minus a fixed SDK prefix: FastMCP puts our
+    # message text on the wire and adds no traceback, so raising costs nothing
+    # the sentence was doing.
+    refusal_text = refused.content[0].text
+    assert "refusing" in refusal_text
+    assert "allowlist" in refusal_text
+    assert "deliberate ceiling" in refusal_text
+
+    # The SDK prefixes the message; OBSERVED against the pinned mcp==1.28.1,
+    # which builds it at mcp/server/fastmcp/tools/base.py:117
+    # (`raise ToolError(f"Error executing tool {self.name}: {e}") from e`) and
+    # puts str(e) in as the only text content. Pinned rather than
+    # substring-matched so a version bump that reshapes or drops the prefix
+    # fails here instead of quietly changing what an operator reads in Slack.
+    prefix = "Error executing tool restart_deployment: "
+    assert refusal_text.startswith(prefix)
+    # ...and what follows it is our sentence verbatim, with the permitted list
+    # built from the module's own allowlist. Rewording the refusal fails here
+    # too, not just changing the prefix.
+    permitted = ", ".join(sorted(srv.ALLOWLIST))
+    assert refusal_text[len(prefix):] == (
+        "refusing: platform/api is not in this connector's allowlist. "
+        f"Permitted: {permitted}. This is a deliberate ceiling -- widening it "
+        "is an operator change, not something to work around."
+    )
+
+    done = _call_tool(srv, "restart_deployment", {"namespace": "public", "name": "api"})
+    assert done.isError is False
+    assert "restart triggered" in done.content[0].text
+    # The contrast in the OTHER direction: the success path carries no prefix at
+    # all, so the two results differ in text shape as well as in the flag.
+    assert not done.content[0].text.startswith("Error executing tool")
+    assert done.content[0].text.startswith("restart triggered for public/api at ")
+
+    # THE contrast, stated outright: this is the whole property. When both of
+    # these were returned strings the two results were the same shape, and a
+    # program counting successful restarts counted the refusal as one.
+    assert refused.isError != done.isError
 
 
 # --------------------------------------------------------------------------- #

--- a/examples/sre-bot/connectors/tempo/server.py
+++ b/examples/sre-bot/connectors/tempo/server.py
@@ -56,6 +56,7 @@ from urllib.parse import quote
 
 import httpx
 from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp.exceptions import ToolError
 from mcp.types import ToolAnnotations
 
 log = logging.getLogger("tempo-mcp")
@@ -113,14 +114,24 @@ READ_ONLY = ToolAnnotations(readOnlyHint=True, destructiveHint=False, openWorldH
 def _proxy(path: str, params: dict[str, Any] | None = None) -> Any:
     """GET one Tempo path through Grafana's datasource proxy.
 
-    Every error is returned as a STRING rather than raised. A raised exception
-    reaches the model as a stack trace, which it will either paste into Slack or
-    treat as a transient failure and retry. A sentence it can read out loud is
-    more useful and stops the retry loop.
+    Every error is raised as a `ToolError` rather than returned. A returned
+    string is `isError: false` on the wire, so a refused read and an empty one
+    are the same result to anything reading the protocol -- an eval grader, a
+    ledger, a retry policy -- and a refusal gets counted as an answer.
+
+    The concern that first argued for returning strings does not apply to
+    `ToolError`: FastMCP puts the message on the wire behind a fixed
+    `Error executing tool <tool_name>: ` prefix and adds nothing else -- no
+    traceback, no stack frames -- so there is nothing for the model to paste
+    into Slack, and the sentence after the prefix is the same sentence it read
+    before: still one it can read out loud, and still one that says whether
+    retrying is worth anything.
     """
 
     if not GRAFANA_URL or not TOKEN:
-        return "not configured: GRAFANA_URL and GRAFANA_SERVICE_ACCOUNT_TOKEN must both be set"
+        raise ToolError(
+            "not configured: GRAFANA_URL and GRAFANA_SERVICE_ACCOUNT_TOKEN must both be set"
+        )
     url = f"{GRAFANA_URL}/api/datasources/proxy/uid/{quote(DS_UID)}{path}"
     try:
         r = httpx.get(
@@ -129,24 +140,26 @@ def _proxy(path: str, params: dict[str, Any] | None = None) -> Any:
             headers={"Authorization": f"Bearer {TOKEN}", "Accept": "application/json"},
             timeout=TIMEOUT,
         )
-    except httpx.TimeoutException:
-        return f"Tempo did not respond within {TIMEOUT:g}s. Narrow the time range and try again."
+    except httpx.TimeoutException as exc:
+        raise ToolError(
+            f"Tempo did not respond within {TIMEOUT:g}s. Narrow the time range and try again."
+        ) from exc
     except httpx.HTTPError as exc:
         # str(exc) carries the URL, never the Authorization header.
-        return f"could not reach Grafana: {exc}"
+        raise ToolError(f"could not reach Grafana: {exc}") from exc
 
     if r.status_code == 401 or r.status_code == 403:
-        return (
+        raise ToolError(
             f"Grafana refused the request ({r.status_code}). The service account token is "
             "missing or lacks access to the Tempo datasource. This will not fix itself on retry."
         )
     if r.status_code == 404:
-        return (
+        raise ToolError(
             f"no such Tempo endpoint or datasource uid {DS_UID!r} ({r.status_code}). "
             "Check TEMPO_DATASOURCE_UID."
         )
     if r.status_code >= 400:
-        return f"Tempo returned {r.status_code}: {r.text[:300]}"
+        raise ToolError(f"Tempo returned {r.status_code}: {r.text[:300]}")
 
     # Check the advertised size first so an oversized body can be refused
     # without parsing it, then fall back to what actually arrived -- Content-
@@ -154,16 +167,20 @@ def _proxy(path: str, params: dict[str, Any] | None = None) -> Any:
     # trace tends to come back.
     too_big = _oversized(r)
     if too_big is not None:
-        return too_big
+        raise ToolError(too_big)
 
     try:
         return r.json()
-    except ValueError:
-        return f"Tempo returned non-JSON: {r.text[:300]}"
+    except ValueError as exc:
+        raise ToolError(f"Tempo returned non-JSON: {r.text[:300]}") from exc
 
 
 def _oversized(r: httpx.Response) -> str | None:
-    """The refusal message if this body exceeds the cap, else None."""
+    """The refusal message if this body exceeds the cap, else None.
+
+    A pure helper, so it reports rather than raises; `_proxy` is the one that
+    turns the message into a `ToolError`.
+    """
 
     declared = r.headers.get("content-length")
     size = None
@@ -227,13 +244,14 @@ def get_trace(trace_id: str) -> Any:
     searching and reading the summary unless the span detail is the question.
 
     Responses over 1 MiB are REFUSED rather than returned, so a trace from a
-    very busy request will not come back at all. That is a ceiling, not a
+    very busy request will not come back at all. The refusal arrives as a tool
+    error carrying that sentence, not as a result. That is a ceiling, not a
     transient failure -- narrow the search instead of retrying.
     """
 
     trace_id = trace_id.strip()
     if not trace_id:
-        return "trace_id is required -- get one from search_traces"
+        raise ToolError("trace_id is required -- get one from search_traces")
     return _proxy(f"/api/traces/{quote(trace_id)}")
 
 
@@ -257,7 +275,7 @@ def list_trace_tag_values(tag: str) -> Any:
 
     tag = tag.strip()
     if not tag:
-        return "tag is required, e.g. resource.service.name"
+        raise ToolError("tag is required, e.g. resource.service.name")
     return _proxy(f"/api/v2/search/tag/{quote(tag)}/values")
 
 

--- a/examples/sre-bot/connectors/tempo/test_server.py
+++ b/examples/sre-bot/connectors/tempo/test_server.py
@@ -12,8 +12,11 @@ import os
 import sys
 from pathlib import Path
 
+import anyio
 import httpx
 import pytest
+from mcp.server.fastmcp.exceptions import ToolError
+from mcp.shared.memory import create_connected_server_and_client_session as _connect
 
 # Load server.py BY PATH under a unique module name, rather than putting this
 # directory on sys.path and importing `server`.
@@ -114,8 +117,13 @@ def test_limit_is_clamped(monkeypatch, asked, expected):
 
 
 # --------------------------------------------------------------------------- #
-# Errors. Every one is returned as a SENTENCE, because a raised exception
-# reaches the model as a stack trace -- which it pastes into Slack or retries.
+# Errors. Every one is a ToolError carrying a SENTENCE. The sentence is what
+# stops the model pasting a traceback into Slack or retrying something that will
+# refuse again -- FastMCP puts the message on the wire behind a fixed
+# `Error executing tool <tool_name>: ` prefix and adds nothing else, no
+# traceback (the wire test below pins that shape exactly).
+# Raising rather than returning is what makes the result `isError: true`, so a
+# refusal is not the same wire value as an answer (see the wire test below).
 # --------------------------------------------------------------------------- #
 @pytest.mark.parametrize(
     "status,must_contain",
@@ -126,14 +134,14 @@ def test_limit_is_clamped(monkeypatch, asked, expected):
         (500, "500"),
     ],
 )
-def test_http_errors_become_readable_strings(monkeypatch, status, must_contain):
+def test_http_errors_become_readable_tool_errors(monkeypatch, status, must_contain):
     srv = _load()
     monkeypatch.setattr(
         srv.httpx, "get", lambda *a, **kw: httpx.Response(status, text="boom")
     )
-    out = srv.search_traces("{}")
-    assert isinstance(out, str)
-    assert must_contain in out
+    with pytest.raises(ToolError) as excinfo:
+        srv.search_traces("{}")
+    assert must_contain in str(excinfo.value)
 
 
 # --------------------------------------------------------------------------- #
@@ -158,13 +166,14 @@ def test_oversized_body_is_refused_by_content_length(monkeypatch):
             200, json={"ok": True}, headers={"content-length": oversized}
         ),
     )
-    out = srv.get_trace("abc123")
-    assert isinstance(out, str)
-    assert "cap" in out
+    with pytest.raises(ToolError) as excinfo:
+        srv.get_trace("abc123")
+    message = str(excinfo.value)
+    assert "cap" in message
     # Actionable, and explicitly not retryable -- otherwise the agent tries
     # three times and reports a timeout.
-    assert "Narrow the query" in out
-    assert "refused again" in out
+    assert "Narrow the query" in message
+    assert "refused again" in message
 
 
 def test_oversized_body_is_refused_when_content_length_is_absent(monkeypatch):
@@ -175,9 +184,9 @@ def test_oversized_body_is_refused_when_content_length_is_absent(monkeypatch):
     resp = httpx.Response(200, json=big)
     del resp.headers["content-length"]
     monkeypatch.setattr(srv.httpx, "get", lambda *a, **kw: resp)
-    out = srv.get_trace("abc123")
-    assert isinstance(out, str)
-    assert "cap" in out
+    with pytest.raises(ToolError) as excinfo:
+        srv.get_trace("abc123")
+    assert "cap" in str(excinfo.value)
 
 
 def test_a_normal_sized_trace_is_still_returned(monkeypatch):
@@ -201,25 +210,36 @@ def test_search_results_are_capped_too(monkeypatch):
             200, json={"traces": []}, headers={"content-length": oversized}
         ),
     )
-    assert "cap" in srv.search_traces("{}")
+    with pytest.raises(ToolError) as excinfo:
+        srv.search_traces("{}")
+    assert "cap" in str(excinfo.value)
 
 
 def test_auth_failure_says_it_will_not_fix_itself(monkeypatch):
     # Without this the agent retries a 403 three times and reports a timeout.
     srv = _load()
     monkeypatch.setattr(srv.httpx, "get", lambda *a, **kw: httpx.Response(403))
-    assert "not fix itself" in srv.search_traces("{}")
+    with pytest.raises(ToolError) as excinfo:
+        srv.search_traces("{}")
+    assert "not fix itself" in str(excinfo.value)
 
 
-def test_timeout_is_not_an_exception(monkeypatch):
+def test_timeout_is_a_sentence_not_a_traceback(monkeypatch):
+    # It IS an exception now -- a ToolError -- but that is not the property that
+    # matters here. What matters is that the httpx traceback never reaches the
+    # model: it gets one sentence naming the timeout and what to narrow, which
+    # is what stops the retry loop.
     srv = _load()
 
     def boom(*a, **kw):
         raise httpx.TimeoutException("too slow")
 
     monkeypatch.setattr(srv.httpx, "get", boom)
-    out = srv.search_traces("{}")
-    assert isinstance(out, str) and "did not respond" in out
+    with pytest.raises(ToolError) as excinfo:
+        srv.search_traces("{}")
+    message = str(excinfo.value)
+    assert "did not respond" in message
+    assert "too slow" not in message
 
 
 def test_transport_error_does_not_leak_the_token(monkeypatch):
@@ -229,8 +249,9 @@ def test_transport_error_does_not_leak_the_token(monkeypatch):
         raise httpx.ConnectError("connection refused")
 
     monkeypatch.setattr(srv.httpx, "get", boom)
-    out = srv.search_traces("{}")
-    assert "glsa_test" not in out
+    with pytest.raises(ToolError) as excinfo:
+        srv.search_traces("{}")
+    assert "glsa_test" not in str(excinfo.value)
 
 
 # --------------------------------------------------------------------------- #
@@ -243,8 +264,77 @@ def test_empty_trace_id_is_rejected_before_a_request(monkeypatch):
         raise AssertionError("should not have called Grafana")
 
     monkeypatch.setattr(srv.httpx, "get", explode)
-    assert "required" in srv.get_trace("   ")
-    assert "required" in srv.list_trace_tag_values("")
+    with pytest.raises(ToolError) as excinfo:
+        srv.get_trace("   ")
+    assert "required" in str(excinfo.value)
+    with pytest.raises(ToolError) as excinfo:
+        srv.list_trace_tag_values("")
+    assert "required" in str(excinfo.value)
+
+
+# --------------------------------------------------------------------------- #
+# The wire. Every case above calls the tool function directly, and none of them
+# can see the field the connector is actually judged by. FastMCP marks a result
+# `isError: true` only when the call RAISED; a refusal that is `return`ed is a
+# string like any other, so it goes out as `isError: false` and reads as an
+# answer to anything consuming the protocol rather than the prose -- an eval
+# grader, a ledger, a retry policy. "Grafana refused the request" and "no traces
+# matched" were the same wire result, and the difference between them is the
+# whole reason to ask Tempo anything.
+#
+# So this one goes through the real MCP request path, in process.
+# --------------------------------------------------------------------------- #
+def _call_tool(srv, name, args):
+    """Call one tool through the real MCP request path and return the CallToolResult."""
+
+    async def go():
+        async with _connect(srv.mcp._mcp_server) as client:
+            return await client.call_tool(name, args)
+
+    return anyio.run(go)
+
+
+def test_a_refused_read_and_an_answered_one_carry_different_is_error_flags(monkeypatch):
+    srv = _load()
+
+    monkeypatch.setattr(srv.httpx, "get", lambda *a, **kw: httpx.Response(403))
+    refused = _call_tool(srv, "get_trace", {"trace_id": "abc123"})
+    assert refused.isError is True
+    # The sentence survives the trip behind a fixed SDK prefix: FastMCP puts our
+    # message text on the wire, never a traceback, so raising costs nothing the
+    # prose was doing.
+    assert "not fix itself" in refused.content[0].text
+
+    # The prefix, pinned. OBSERVED against the pinned mcp==1.28.1, which builds
+    # it at mcp/server/fastmcp/tools/base.py:117
+    # (`raise ToolError(f"Error executing tool {self.name}: {e}") from e`) and
+    # puts str(e) in as the only text content. Pinned rather than
+    # substring-matched so a version bump that reshapes or drops the prefix
+    # fails here instead of quietly changing what an operator reads in Slack.
+    prefix = "Error executing tool get_trace: "
+    refusal_text = refused.content[0].text
+    assert refusal_text.startswith(prefix)
+    # ...and what follows it is _proxy's sentence verbatim, so rewording the
+    # refusal fails here too, not just changing the prefix.
+    assert refusal_text[len(prefix):] == (
+        "Grafana refused the request (403). The service account token is "
+        "missing or lacks access to the Tempo datasource. This will not fix "
+        "itself on retry."
+    )
+
+    payload = {"batches": [{"spans": [{"name": "GET /health"}]}]}
+    monkeypatch.setattr(srv.httpx, "get", lambda *a, **kw: httpx.Response(200, json=payload))
+    answered = _call_tool(srv, "get_trace", {"trace_id": "abc123"})
+    assert answered.isError is False
+    assert "GET /health" in answered.content[0].text
+    # The contrast in the OTHER direction: an answered read carries no prefix at
+    # all, so the two results differ in text shape as well as in the flag.
+    assert not answered.content[0].text.startswith("Error executing tool")
+
+    # THE contrast, stated outright: this is the whole property. While both were
+    # returned strings these two results had the same shape, and a program
+    # reading them could not tell a refusal from a trace.
+    assert refused.isError != answered.isError
 
 
 def test_every_tool_is_annotated_read_only():


### PR DESCRIPTION
## Summary

Both bundled SRE-bot connectors returned every failure as a plain string from the tool
function, so FastMCP wrapped it as ordinary content and the tool result carried
`isError: false`. A refusal and a completed write were the same shape at the protocol
level, so anything branching on `isError` — an eval grader, a future ledger entry, a retry
policy — counted a refused restart as a restart. Every failure path in
`connectors/k8s-write/server.py` and `connectors/tempo/server.py` now raises `ToolError`.
The message strings are byte-identical: the wording was the good part and none of it
changed. What changes is that a refusal is now an error to a program while staying the
same sentence to a reader.

`_client()` is narrowed from `Any` to `httpx.Client` and its caller's
`isinstance(client, str)` branch is gone, so a stray `return` there now fails type
checking rather than reaching the wire as a success.

## Related issue

Ref #1941

Deliberately `Ref`, not `Closes` — see "Known residual" below. Both connectors that exist
on `main` are fixed; two more on `next` still carry the pattern, and closing this on merge
would drop that.

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | The change is inside a bundled example connector under `examples/sre-bot/connectors/`. These are standalone MCP server processes with their own Dockerfiles; no Curie tier builds, deploys, or exercises them. | — | — |
| local | n/a | As above — no Curie lane runs these processes. | — | — |
| local-release | n/a | As above. | — | — |
| cluster | n/a | As above. Running them would need a live Grafana/Tempo and a real write kubeconfig, neither of which the ceiling under test depends on. | — | — |
| live provider | n/a | The behaviour under test is the MCP tool-result shape, which is produced by the FastMCP server in-process and does not involve a model provider. | — | — |
| external integration | n/a | The refusal paths under test are the ones that fire *before* or *instead of* reaching Kubernetes or Grafana. | — | — |

The behaviour-bearing surface here is the MCP tool result, and its real entry point is an
MCP client calling the tool. That is what is proved, in process, against the pinned
`mcp==1.28.1` the connectors ship in their `requirements.txt`.

**Positive and negative, at the real entry point.** Each suite gains one test that goes
through the real MCP request path via `create_connected_server_and_client_session` and
asserts the flag itself — no function-level assertion can see `isError`, which is the
field this issue is about:

- `test_a_refusal_and_a_restart_carry_different_is_error_flags` — an out-of-allowlist
  `restart_deployment` returns `isError is True`; an allowlisted one returns
  `isError is False`; the test asserts `refused.isError != done.isError` outright.
- `test_a_refused_read_and_an_answered_one_carry_different_is_error_flags` — the same
  contrast for `get_trace` on a 403 versus a normal payload.

Each pins the refusal's exact wire text — FastMCP's `Error executing tool <name>: `
prefix, then our sentence verbatim after it — with the observed SDK behaviour cited in
the comment (`mcp/server/fastmcp/tools/base.py:117`) per the AGENTS.md rule that SDK-shape
assertions be grounded in observed behaviour. Pinned rather than substring-matched, so a
version bump that reshapes or drops the prefix fails there rather than quietly changing
what an operator reads in Slack.

**Guard demonstrated by execution, not by reading.** Measured directly against the pinned
SDK before writing the fix:

```
returning the string  -> isError=False, text == the string
raise ToolError(m)    -> isError=True,  text == "Error executing tool <name>: " + m
```

**Red on revert.** Reverting only the two `server.py` files and keeping the tests:

```
24 failed, 17 passed
... test_a_refusal_and_a_restart_carry_different_is_error_flags - assert False is True
... test_a_refused_read_and_an_answered_one_carry_different_is_error_flags - assert False is True
```

Both wire tests fail on exactly the assertion this issue is about. Restored: `41 passed`.

**Checks run**

| Check | Result |
| --- | --- |
| `pytest examples/sre-bot/connectors` (mcp==1.28.1, the connectors' pin) | `41 passed` (39 pre-existing + 2 new) |
| Same, on `origin/main` before the change | `39 passed` (baseline) |
| `ruff check .` (0.16.2, repo-wide) | `All checks passed!` |
| `pytest examples/tests` | `32 passed` |
| `mypy` | does not cover `examples/`; unchanged |

## Known residual

- **Two more connectors carry this pattern, on `next` only.**
  `examples/sre-bot/connectors/k8s-scale/server.py` and
  `.../self-upgrade/server.py` return their kubeconfig and API errors as strings the same
  way. They do not exist on `main`, so they are out of scope for a `main`-targeted bug fix
  and are not touched here. They need the same change on the `next` train.
- **No structural guard against a future regression.** `_proxy` must keep returning `Any`
  because a success payload is arbitrary JSON, so nothing at the type level stops a new
  branch added inside it later from `return`ing a message instead of raising. The two wire
  tests pin the paths that exist, not future ones.
- **These suites do not run in CI.** `examples/sre-bot/connectors/*/test_server.py` is not
  in the root `testpaths`, so nothing runs it automatically; it was run by hand here.
  Adding it would work today (`mcp` resolves in the workspace venv) but only as a
  transitive dependency, which is fragile — worth doing deliberately rather than as a
  passenger on this fix.

## Review gates

Adversarial review routed to an alternative provider (codex / gpt-5.6-sol) via
agent-router on every pass:

- **Scope** — clean; every hunk traces to the AC or is a mechanical consequence.
- **Code** — raised one P1: the new prose claimed FastMCP renders a `ToolError` as its
  message "and nothing else", which is false because the SDK prefixes it. Confirmed by
  direct measurement, then fixed: the prose at five sites was corrected and both wire
  tests now pin the exact text.
- **Consolidation** — `/simplify`'s four passes returned clean on reuse, efficiency and
  altitude; one nit applied (bind `str(excinfo.value)` once in two tests, matching the
  pattern already used in the same files). A second finding — inconsistent
  `from exc` / `from None` — was checked and rejected as a false positive: the rule is
  "exception bound with `as exc` → `from exc`, unbound → `from None`", and it holds at all
  ten sites.
- **Spec-vs-impl, final committed state** — clean; every AC met, no remaining string
  return, no message changed, no weakened assertion.

## Done-check

- [x] **Failing tests committed before implementation** — n/a, quick tier (single-stream,
      clear AC). Red-on-revert evidence is recorded above instead.
- [x] **All production edits delegated** — driver ran only git, tests and bookkeeping.
- [x] **Broadened return types** — none broadened; `_client()` was *narrowed*
      (`Any` → `httpx.Client`) and its only caller's string branch was removed.
- [x] **Code review** — completed, one P1 found and fixed.
- [x] **Scope review** — completed, no passengers.
- [x] **Sibling-path parity** — sibling sites enumerated: `k8s-scale` and `self-upgrade`
      on `next`. Not covered here because they do not exist on this base; named under
      "Known residual" rather than filed as an issue.
- [x] **Guard demonstration** — the refusal guard was executed and its wire result
      observed, not read from source.
- [x] **Consolidation pass** — ran, one nit applied, re-reviewed clean.
- [ ] **Security review** — not flagged. The change alters an error *signal*; the
      enforcement itself (the allowlist, the constant patch body) is untouched and its
      tests are unchanged.
- [x] **Observable verification** — n/a, no user-facing surface; the protocol-level tests
      are the observable check for this surface.
- [x] **E2E** — no tier applies, per the table above.
- [x] **Full affected suite, lint** — green, see Checks run.

## Checklist

- [x] Tests pass for the area I touched.
- [x] Docs updated if behavior changed — the load-bearing docs here are the module and
      test docstrings that argued *for* returning strings; those were rewritten rather
      than deleted. No README, `connectors.yaml`, SKILL.md or eval case asserts the old
      shape (grepped).
- [x] An ADR is added if this is an architectural decision — not one; this is a bug fix
      inside an example bundle.
