### PR TITLE
fix(api): refuse a pending approval whose route binding is gone

### DIFF
--- a/apps/api/src/curie_api/approvers.py
+++ b/apps/api/src/curie_api/approvers.py
@@ -142,6 +142,58 @@ class InvalidApprovers:
         )
 
 
+class UnboundRoute:
+    """The approval named a route whose binding is gone: a set admitting nobody.
+
+    A pending approval that named a route is resolvable only through that
+    route's binding (ADR-0123). Once the binding is gone there is no set left to
+    resolve and no fallback applies: falling through to the card channel would
+    swap a server-enforced approver set for a caller-asserted ``actor_channel``
+    check on an approval that is ALREADY pending, which is exactly the
+    escalation ADR-0123 closes. An absent binding is therefore NOT the same fact
+    as a binding present with no ``approvers`` block -- that one is still ADR-0034
+    AC4's zero-setup default and still resolves through channel membership.
+
+    Like ``InvalidApprovers``, this is modelled as a set rather than a special
+    path: it reports ``undetermined`` and the authorizer's existing fail-closed
+    rule denies it, so nothing in ``authorizer.py`` needs to know this set
+    exists. ``undetermined`` and not ``member=False`` because the clicker is not
+    outside a set that was evaluated -- the configuration stopped them, and
+    telling them otherwise sends them arguing with a policy that is not there.
+    """
+
+    # NEW vocabulary added by ADR-0123, not a rename: see the audit-vocabulary
+    # note above. The four strings that ship in rows already on main stay
+    # byte-identical; an operator reading the append-only trail must be able to
+    # tell "the route you named is gone" from "the approvers block does not
+    # parse", so this refusal gets its own name rather than borrowing one.
+    audit_name = "UnboundRouteBinding"
+
+    def __init__(self, route: str) -> None:
+        self._route = route
+
+    async def contains(
+        self, actor: str, actor_channel: str | None
+    ) -> MembershipVerdict:
+        # The reason names the CLASS of failure and the evidence carries the
+        # route, following ``SlackUserGroupMembers._undetermined``: the reason is
+        # echoed to whoever clicked, while the evidence lands on the audit row
+        # where ADR-0123 requires the missing binding to be named.
+        return MembershipVerdict(
+            member=False,
+            undetermined=True,
+            reason=(
+                "could not verify approvers: this approval's route is no longer "
+                "bound, so the approvers it named cannot be resolved"
+            ),
+            evidence={
+                "kind": "route_binding",
+                "route": self._route,
+                "binding_present": False,
+            },
+        )
+
+
 class ApproverSetSelector(Protocol):
     """Pick the approver set an approval's route binding calls for.
 

--- a/apps/api/src/curie_api/crud.py
+++ b/apps/api/src/curie_api/crud.py
@@ -446,11 +446,21 @@ async def get_approval_route_binding(session: AsyncSession, approval: Approval) 
     approver group revokes them immediately instead of leaving them able to
     resolve yesterday's stale request.
 
-    None covers every legitimate miss -- a generic approval with no agent
+    None still covers every legitimate miss -- a generic approval with no agent
     (``agent_id`` is nullable by design), an approval with no route, an agent
-    with no bindings, a route the map does not bind -- and each of them means
-    "no approvers declared", which is channel membership by design (AC4), not a
-    failure.
+    with no bindings, a route the map does not bind -- but it no longer means
+    one thing. ADR-0123 makes the selector split a None on whether the approval
+    NAMED a route: a routeless approval keeps the AC4 zero-setup channel
+    membership, while a routed approval with no binding is refused outright,
+    because a route the operator narrowed must not be readable as one they never
+    narrowed.
+
+    This function deliberately still returns a bare None and does not say which
+    of the four misses happened. The selector needs only ``approval.route`` to
+    make that split, and a richer return type is not something ADR-0123 asks
+    for. Note the guard below is ``not approval.route``, so a ``route=""``
+    approval is routeless here; the selector keys on the same truthiness so the
+    two files cannot disagree about what "named a route" means.
 
     A present-but-non-dict value is NOT one of those misses, so it is returned
     raw (the JSONB value can be anything) rather than coerced to None: the

--- a/apps/api/src/curie_api/slack_approvers.py
+++ b/apps/api/src/curie_api/slack_approvers.py
@@ -13,6 +13,12 @@ usergroup IDs and ``C...`` channel IDs: the binding format is Slack's shape, so
 the code that reads it is Slack-aware and belongs on this side of the port. That
 is what lets ``authorizer.py`` be pure policy with no Slack in it at all.
 
+Selection also decides the ABSENT-binding case (ADR-0123), and the set it
+returns for it lives in ``approvers.py`` rather than here: "this route is not
+bound" is a fact about ``agents.approval_routes``, not about Slack, so
+``approvers.UnboundRoute`` is provider-neutral even though only a Slack-aware
+selector can tell that case apart from a binding that declares no approvers.
+
 The evidence asymmetry is deliberate and worth stating plainly. ``SlackChannelMembers``
 performs no lookup: the click's channel IS the proof, because Slack only renders
 a card (and only accepts clicks on it) for members of the channel it posted in,
@@ -28,7 +34,13 @@ from typing import Any
 
 from pydantic import ValidationError
 
-from .approvers import ApproverSet, ExplicitUsers, InvalidApprovers, MembershipVerdict
+from .approvers import (
+    ApproverSet,
+    ExplicitUsers,
+    InvalidApprovers,
+    MembershipVerdict,
+    UnboundRoute,
+)
 from .models import Approval
 from .schemas import ApprovalApprovers
 from .usergroups import GroupMembershipSource, UserGroupLookupError
@@ -152,6 +164,11 @@ class SlackApproverSetSelector:
     Holds the ``GroupMembershipSource`` so it can hand it to a user-group set;
     None when no bot token is configured, which is a normal Slack-free deployment
     (a route bound to a group then fails closed at resolve time).
+
+    The no-approvers case is a three-way split, not a single fallback
+    (ADR-0123): a binding present with no ``approvers`` block and a routeless
+    approval both keep channel membership, while an approval that NAMED a route
+    with no binding to read is refused outright.
     """
 
     def __init__(self, group_client: GroupMembershipSource | None) -> None:
@@ -159,7 +176,15 @@ class SlackApproverSetSelector:
 
     def __call__(self, approval: Approval, binding: Any) -> ApproverSet:
         """Precedence, exactly as issue #420 states it: ``users`` wins over
-        ``group``, which wins over channel membership. No I/O happens here."""
+        ``group``, which wins over channel membership. No I/O happens here.
+
+        Channel membership is not the universal fallback it once was: an
+        approval that named a route whose binding is absent is refused outright
+        rather than falling through to it (ADR-0123). That split keys on
+        ``binding is None``, NOT on the parsed approvers block -- ``_parse_approvers``
+        returns ``(None, None)`` for both "no binding at all" and "binding
+        present, no approvers declared", and conflating those two is the defect.
+        """
 
         approvers, spec_error = _parse_approvers(binding)
         if spec_error is not None:
@@ -169,8 +194,25 @@ class SlackApproverSetSelector:
             # what the binding was trying to say.
             return InvalidApprovers(spec_error)
         if approvers is None:
-            # No approvers declared: the card channel's members are the approvers,
-            # exactly as before #420 (AC4).
+            if approval.route and binding is None:
+                # The approval NAMED a route and there is no binding left to
+                # read (ADR-0123). Not the same fact as a binding that declares
+                # no approvers: falling through would let whoever rewrote the
+                # route map swap a server-enforced approver set for a
+                # caller-asserted ``actor_channel`` check on an approval that is
+                # ALREADY pending, which is the whole escalation.
+                #
+                # ``binding is None`` and not ``not binding``: a route bound to
+                # ``{}`` is BOUND, the operator just declared nothing, and only
+                # ``None`` is absence. The truthiness test on ``approval.route``
+                # is deliberate too -- ``crud.get_approval_route_binding``
+                # returns early on ``not approval.route``, so keying on
+                # ``is not None`` here would refuse a ``route=""`` approval that
+                # crud has already classified as routeless.
+                return UnboundRoute(approval.route)
+            # A binding that is present and declares no approvers, or an approval
+            # that named no route at all: the card channel's members are the
+            # approvers, exactly as before #420 (AC4).
             return SlackChannelMembers(approval.card_channel or approval.reply_channel)
         if approvers.users:
             return ExplicitUsers(approvers.users)

--- a/apps/api/tests/test_approvals.py
+++ b/apps/api/tests/test_approvals.py
@@ -955,15 +955,33 @@ def test_gate_kind_check_constraint_rejects_unknown_values(
         asyncio.run(_insert("bogus"))
 
 
-def test_route_bound_approval_authorizes_against_card_channel(
+def test_route_bound_approval_with_no_agent_resolves_through_neither_channel(
     approvals_client: TestClient,
     auth_headers: dict[str, str],
     clean_db: None,
     valkey: redis.Redis,
     runs_stream: str,
 ) -> None:
-    """#247: when a route binding placed the card in another channel, THAT
-    channel's members are the approvers; the requesting channel no longer is."""
+    """#247 narrowed by ADR-0123 (#1081). Retargeted from
+    ``..._authorizes_against_card_channel``, whose second half asserted a 200.
+
+    #247's intent was that when a route binding placed the card in another
+    channel, THAT channel's members are the approvers and the requesting channel
+    no longer is. This record names a route but ``_payload`` sets no
+    ``agent_id``, so there is no agent, no route map, and nothing to read: the
+    binding comes back absent. Under ADR-0123 a routed approval with
+    ``agent_id: null`` therefore fails closed -- the split is on
+    ``approval.route`` alone, with no ``agent_id`` carve-out, because
+    ``crud.get_approval_route_binding`` returns the same bare ``None`` for an
+    agentless approval as for a route somebody deleted while it pended.
+
+    So BOTH channels are refused here, and both for the same unbound-route
+    reason -- asserted below precisely so the two 403s are not mistaken for the
+    channel discrimination they used to prove. That discrimination is not lost:
+    it is pinned by ``test_binding_without_approvers_keeps_channel_membership``,
+    where a binding actually exists and the card channel really does hold the
+    authority.
+    """
 
     created = approvals_client.post(
         "/approvals",
@@ -972,24 +990,32 @@ def test_route_bound_approval_authorizes_against_card_channel(
     ).json()
     assert created["route"] == "managers"
     assert created["card_channel"] == "C_MGRS"
+    assert created["agent_id"] is None
     resolve_url = f"/approvals/{created['id']}/resolve"
 
-    # The requesting channel (C1) is NOT the approvers' channel anymore.
+    # The requesting channel (C1) is still not the approvers' channel.
     from_requesting = approvals_client.post(
         resolve_url,
         json={"decision": "approved", "resolved_by": "U9", "actor_channel": "C1"},
         headers=auth_headers,
     )
     assert from_requesting.status_code == 403
+    assert "no longer bound" in from_requesting.json()["detail"]
 
-    # A member of the route-bound channel resolves it.
-    ok = approvals_client.post(
+    # And the card channel is no longer enough either: this was the 200.
+    from_card = approvals_client.post(
         resolve_url,
         json={"decision": "approved", "resolved_by": "U9", "actor_channel": "C_MGRS"},
         headers=auth_headers,
     )
-    assert ok.status_code == 200
-    assert len(valkey.xrange(runs_stream)) == 1
+    assert from_card.status_code == 403, from_card.text
+    assert "no longer bound" in from_card.json()["detail"]
+
+    _assert_unbound_route_denial(approvals_client, auth_headers, created["id"])
+
+    record = approvals_client.get(f"/approvals/{created['id']}", headers=auth_headers)
+    assert record.json()["status"] == "pending"
+    assert valkey.xrange(runs_stream) == []
 
 
 def test_audit_log_records_attempts_with_authorizer_snapshots(
@@ -1695,6 +1721,32 @@ def _resolve(
     )
 
 
+def _assert_unbound_route_denial(
+    client: TestClient,
+    headers: dict[str, str],
+    approval_id: str,
+    *,
+    route: str = "managers",
+) -> Any:
+    """The ADR-0123 refusal as the audit trail records it, asserted in one place.
+
+    Four tests read this same row back, and the row is the ONLY place the ADR's
+    "names the missing binding as its reason" clause is observable -- the reason
+    string echoed to the clicker deliberately carries the class of failure, not
+    the route. Kept as a helper so a change to the evidence shape breaks one
+    assertion rather than silently passing three of four call sites. Returns the
+    row so a caller can add the assertions specific to it.
+    """
+
+    row = client.get(f"/approvals/{approval_id}/audit", headers=headers).json()[-1]
+    assert row["authorized"] is False
+    assert row["authorizer"] == "UnboundRouteBinding"
+    assert row["evidence"]["kind"] == "route_binding"
+    assert row["evidence"]["route"] == route
+    assert row["evidence"]["binding_present"] is False
+    return row
+
+
 # --- AC1: a group binding narrows authority inside a broad channel -------------
 
 
@@ -2195,7 +2247,13 @@ def test_group_lookup_failure_denies_and_audits_the_failure(
     assert valkey.xrange(runs_stream) == []
 
 
-# --- AC4: no approvers declared keeps today's behavior exactly -----------------
+# --- AC4: no approvers DECLARED keeps today's behavior; no BINDING does not ----
+#
+# ADR-0123 (#1081) splits these two. A binding that is present and declares no
+# approvers is still the zero-setup channel default (the first test below, which
+# is the negative control and must stay untouched). A routed approval with NO
+# binding is refused outright -- the two tests after it were retargeted from
+# asserting the old channel fallback.
 
 
 def test_binding_without_approvers_keeps_channel_membership(
@@ -2225,16 +2283,26 @@ def test_binding_without_approvers_keeps_channel_membership(
     assert len(valkey.xrange(runs_stream)) == 1
 
 
-def test_agentless_approval_keeps_channel_membership(
+def test_agentless_routed_approval_fails_closed_without_a_binding(
     approvals_client: TestClient,
     auth_headers: dict[str, str],
     clean_db: None,
     valkey: redis.Redis,
     runs_stream: str,
 ) -> None:
-    """AC4 / edge case 7: ``agent_id`` is nullable by design (the generic/dev
-    path). With no agent there is no binding to read, so the record falls back to
-    channel membership on its card_channel -- today's behavior, unchanged."""
+    """ADR-0123 (#1081) applied literally, and the announced consequence of
+    doing so. This test previously asserted the 200 below; it is retargeted, not
+    dropped, so the reversal stays visible in one place.
+
+    ``agent_id`` is nullable by design (the generic/dev path), so this record
+    has no agent and therefore no binding -- but it NAMES a route, and the
+    Decision splits on that alone. ``crud.get_approval_route_binding`` returns a
+    bare ``None`` for all four misses (agentless, routeless, agent deleted,
+    route unbound), so the selector cannot carve out the agentless case without
+    a richer return type ADR-0123 does not authorize. Inferring an exemption
+    from that ``None`` would reintroduce the very substitution the ADR rejects,
+    so a routed agentless approval fails closed too.
+    """
 
     created = approvals_client.post(
         "/approvals", json=_routed_payload(None, author=_APPROVER), headers=auth_headers
@@ -2245,28 +2313,44 @@ def test_agentless_approval_keeps_channel_membership(
     outside = _resolve(approvals_client, auth_headers, created["id"], _OTHER, _ELSEWHERE)
     assert outside.status_code == 403, outside.text
 
-    # AC2 survives the no-binding path: the author is refused from the card
-    # channel, where anyone else would be allowed.
+    # AC2 survives the new path: self-approval is still refused BEFORE the set
+    # is asked, so the author is told about the self-approval, not the route.
     author = _resolve(approvals_client, auth_headers, created["id"], _APPROVER)
     assert author.status_code == 403, author.text
     assert "self-approval" in author.json()["detail"]
 
+    # The card channel used to be enough here. It is not any more.
     inside = _resolve(approvals_client, auth_headers, created["id"], _OTHER)
-    assert inside.status_code == 200, inside.text
-    assert len(valkey.xrange(runs_stream)) == 1
+    assert inside.status_code == 403, inside.text
+    assert "no longer bound" in inside.json()["detail"]
+
+    _assert_unbound_route_denial(approvals_client, auth_headers, created["id"])
+
+    record = approvals_client.get(f"/approvals/{created['id']}", headers=auth_headers)
+    assert record.json()["status"] == "pending"
+    assert valkey.xrange(runs_stream) == []
 
 
-def test_unbound_route_name_keeps_channel_membership(
+def test_a_route_absent_from_the_map_is_unresolvable_and_borrows_no_other_route(
     approvals_client: TestClient,
     auth_headers: dict[str, str],
     clean_db: None,
     valkey: redis.Redis,
     runs_stream: str,
 ) -> None:
-    """AC4 / edge case 8: the approval names a route the agent's map does not
-    bind (renamed or removed while pending). Fresh-read semantics say current
-    config wins, and current config declares no approvers for this route, so it
-    is channel membership -- mirroring the worker's unbound-route card fallback.
+    """ADR-0123 (#1081), retargeted from ``..._keeps_channel_membership``.
+
+    The approval names a route the agent's map does not bind (renamed or
+    removed while pending). Fresh-read semantics still hold -- current config
+    wins -- but current config no longer says "no approvers declared" for this
+    route, it says the route is not bound, and that is refused outright rather
+    than degraded to card-channel membership.
+
+    Two separate 403s live here and must not be conflated: the sibling route's
+    allowlist must not leak onto this route (it never could), AND the actor
+    standing in the card channel is now refused for the unbound-route reason
+    rather than allowed. Both are asserted on their reason, not merely on "not
+    200".
     """
 
     agent_id = _agent_with_routes(
@@ -2280,17 +2364,116 @@ def test_unbound_route_name_keeps_channel_membership(
         headers=auth_headers,
     ).json()
 
-    # The OTHER route's allowlist must not leak onto this one.
+    # The OTHER route's allowlist must not leak onto this one -- and the reason
+    # proves the legal binding was never consulted in the first place.
     listed_elsewhere = _resolve(
         approvals_client, auth_headers, created["id"], _LISTED, _ELSEWHERE
     )
     assert listed_elsewhere.status_code == 403, listed_elsewhere.text
+    assert "no longer bound" in listed_elsewhere.json()["detail"]
 
-    # AC2 survives the unbound-route path too.
+    # AC2 survives the unbound-route path too: self-approval is refused before
+    # the set is asked, so this one keeps the self-approval reason.
     author = _resolve(approvals_client, auth_headers, created["id"], _APPROVER)
     assert author.status_code == 403, author.text
     assert "self-approval" in author.json()["detail"]
 
+    # This was a 200 before ADR-0123: right room, vanished authority.
     inside = _resolve(approvals_client, auth_headers, created["id"], _OTHER)
-    assert inside.status_code == 200, inside.text
+    assert inside.status_code == 403, inside.text
+    assert "no longer bound" in inside.json()["detail"]
+
+    _assert_unbound_route_denial(approvals_client, auth_headers, created["id"])
+
+    record = approvals_client.get(f"/approvals/{created['id']}", headers=auth_headers)
+    assert record.json()["status"] == "pending"
+    assert valkey.xrange(runs_stream) == []
+
+
+# --- #1081 / ADR-0123: rewriting a route map while an approval pends -----------
+
+
+def test_clearing_a_bound_route_makes_a_pending_approval_unresolvable_not_wider(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    valkey: redis.Redis,
+    runs_stream: str,
+) -> None:
+    """The #1081 escalation, end to end, in ADR-0123's own three steps. This is
+    the regression test: it must be RED if the selector split is reverted.
+
+    A route bound to a user group narrows authority to a server-enforced set.
+    Rewriting the agent's route map without that route used to convert the
+    already-pending approval to ``SlackChannelMembers``, which is CALLER-asserted
+    on the axis that matters -- the resolver supplies ``actor_channel``. So the
+    same person who cleared the route could then resolve an approval they were
+    never in the approver set for. That is a change of KIND, not of width, and
+    the audit row recorded only ``ChannelMembershipAuthorizer``.
+
+    A route write is a full replacement, so patching to a map containing only
+    ``legal`` is the same operator action as ``--clear-routes`` or a
+    ``--routes-from`` file that omits the route.
+    """
+
+    calls: list[httpx.Request] = []
+    _fake_slack(approvals_client, [_APPROVER], calls=calls)
+    agent_id = _agent_with_routes(
+        approvals_client,
+        auth_headers,
+        {"managers": {"channel": _BROAD, "approvers": {"group": _GROUP}}},
+    )
+    created = approvals_client.post(
+        "/approvals", json=_routed_payload(agent_id), headers=auth_headers
+    ).json()
+
+    # Step 1: while the binding stands, a non-member of the group is refused
+    # even standing in the card channel. This is the authority being protected.
+    blocked = _resolve(approvals_client, auth_headers, created["id"], _OTHER)
+    assert blocked.status_code == 403, blocked.text
+    assert "not an approver" in blocked.json()["detail"]
+
+    # Step 2: the route map is rewritten without `managers`.
+    rewritten = approvals_client.patch(
+        f"/agents/{agent_id}",
+        json={"approval_routes": {"legal": {"channel": _ELSEWHERE}}},
+        headers=auth_headers,
+    )
+    assert rewritten.status_code == 200, rewritten.text
+    assert "managers" not in rewritten.json()["approval_routes"]
+
+    # Step 3: the SAME refused actor asserts the card channel. Before ADR-0123
+    # this returned 200 and the escalation was complete.
+    escalated = _resolve(approvals_client, auth_headers, created["id"], _OTHER)
+    assert escalated.status_code == 403, escalated.text
+    assert "no longer bound" in escalated.json()["detail"]
+
+    # The audit row names the missing binding, which is the ADR's fourth clause
+    # and the only place it is observable.
+    row = _assert_unbound_route_denial(approvals_client, auth_headers, created["id"])
+    assert row["action"] == "denied"
+    assert row["actor"] == _OTHER
+    assert row["reason"]
+
+    # The refusal is total: nothing claimed, nothing woken.
+    record = approvals_client.get(f"/approvals/{created['id']}", headers=auth_headers)
+    assert record.json()["status"] == "pending"
+    assert valkey.xrange(runs_stream) == []
+
+    # ADR-0123's stated recovery: restore the binding and the approval resolves
+    # normally. The operator has a stuck approval, not a lost one.
+    restored = approvals_client.patch(
+        f"/agents/{agent_id}",
+        json={
+            "approval_routes": {
+                "managers": {"channel": _BROAD, "approvers": {"group": _GROUP}}
+            }
+        },
+        headers=auth_headers,
+    )
+    assert restored.status_code == 200, restored.text
+
+    ok = _resolve(approvals_client, auth_headers, created["id"], _APPROVER)
+    assert ok.status_code == 200, ok.text
+    assert ok.json()["status"] == "approved"
     assert len(valkey.xrange(runs_stream)) == 1

--- a/apps/api/tests/test_authorizer.py
+++ b/apps/api/tests/test_authorizer.py
@@ -11,6 +11,12 @@ reached exclusively through a MockTransport-backed real client.
 Self-approval is deliberately NOT tested at the set level: a set is never asked
 about it (ADR-0034), so a set-level self-approval test would assert an invariant
 that does not live there. It is pinned on the authorizer, once per set, below.
+
+The ADR-0123 (#1081) section pins the last piece: an ABSENT binding is not the
+same fact as a binding that declares no approvers. These go through the same
+``_authorize`` helper, so they stay binding-to-decision tests of the real
+selector rather than assertions about a class in isolation -- which is also why
+the new set is never imported here by name.
 """
 
 import asyncio
@@ -95,7 +101,12 @@ _CARD_CHANNEL = "C0BROAD01"
 _REQUEST_CHANNEL = "C0REQ0001"
 
 
-def _bound_approval(*, author: str = _AUTHOR, card_channel: str = _CARD_CHANNEL) -> Approval:
+def _bound_approval(
+    *,
+    author: str = _AUTHOR,
+    card_channel: str = _CARD_CHANNEL,
+    route: str = "managers",
+) -> Approval:
     """An approval whose card a route binding placed in ``card_channel`` (#247).
 
     Distinct from ``_approval`` above: the #420 story is about a card sitting in
@@ -110,7 +121,7 @@ def _bound_approval(*, author: str = _AUTHOR, card_channel: str = _CARD_CHANNEL)
         reply_channel=_REQUEST_CHANNEL,
         reply_placeholder="p-1",
         dedupe_key="ev-420",
-        route="managers",
+        route=route,
         card_channel=card_channel,
     )
 
@@ -446,21 +457,144 @@ def test_authorizer_falls_back_to_channel_membership_without_approvers() -> None
     assert elsewhere.evidence["actor_channel"] == "C0WRONG01"
 
 
-def test_authorizer_falls_back_to_channel_membership_without_a_binding() -> None:
-    """AC4: no binding at all (an agentless or unbound-route approval) is the
-    zero-setup path and must keep resolving against the card channel."""
+# --- ADR-0123 (#1081): an absent binding is not "no approvers declared" -------
+#
+# The axis under test is `_bound_approval()` (route="managers") against
+# `_approval()` (no route), each with `binding=None`. Same missing binding, two
+# different answers, because the Decision splits on whether the approval NAMED
+# a route. Everything below the divider that the #420 tests already cover
+# (users-beats-group precedence, the group lookup, the malformed-block and
+# malformed-binding fail-closed cases) must stay green untouched.
+
+
+def test_authorizer_refuses_a_routed_approval_whose_binding_is_gone() -> None:
+    """ADR-0123 (#1081): a pending approval that NAMED a route is resolvable
+    only through that route's binding. With the binding absent there is no set
+    to resolve and no channel fallback applies.
+
+    This retargets the old ``..._without_a_binding`` test, whose "an agentless
+    or unbound-route approval is the zero-setup path" claim ADR-0123 supersedes.
+    Falling through to the card channel swaps a server-enforced approver set for
+    a caller-asserted ``actor_channel`` check on an approval that is ALREADY
+    pending, which is the whole escalation. The actor below stands IN the card
+    channel, so the old behavior ALLOWED them: reverting the selector split
+    flips this test to allowed and fails it, which is what makes it
+    red-on-revert rather than vacuously green.
+
+    A route bound to JSON ``null`` reaches the selector as ``binding=None`` too
+    (crud returns a bare ``None`` for it), so that edge case is this case.
+    """
 
     name, in_channel = _authorize(
         _bound_approval(), _OUTSIDER, _CARD_CHANNEL, binding=None
     )
-    assert name == "ChannelMembershipAuthorizer"
-    assert in_channel.allowed
+    assert name == "UnboundRouteBinding"
+    assert not in_channel.allowed
+    assert "no longer bound" in in_channel.reason
+    assert in_channel.evidence is not None
+    assert in_channel.evidence["kind"] == "route_binding"
+    assert in_channel.evidence["route"] == "managers"
+    assert in_channel.evidence["binding_present"] is False
 
-    _name, elsewhere = _authorize(
+    # The set admits nobody, so the wrong channel is refused for the same
+    # reason rather than the channel-membership one.
+    elsewhere_name, elsewhere = _authorize(
         _bound_approval(), _OUTSIDER, "C0WRONG01", binding=None
     )
+    assert elsewhere_name == "UnboundRouteBinding"
     assert not elsewhere.allowed
-    assert "not an approver" in elsewhere.reason
+    assert "no longer bound" in elsewhere.reason
+
+
+def test_authorizer_keeps_channel_membership_for_a_routeless_approval() -> None:
+    """ADR-0123's third bullet: an approval that named NO route never had a
+    narrower set to lose, so an absent binding is still the #420 AC4 zero-setup
+    default. ``_decide`` at the top of this file already walks the decision;
+    what is pinned here is the audit NAME, which is the half that moves
+    silently if the selector splits on the binding alone instead of on
+    ``approval.route and binding is None``."""
+
+    name, decision = _authorize(_approval(), "U_MANAGER", "C_MGRS", binding=None)
+    assert name == "ChannelMembershipAuthorizer"
+    assert decision.allowed
+
+
+def test_authorizer_treats_an_empty_binding_as_present_not_absent() -> None:
+    """ADR-0123 edge case: a route bound to ``{}`` is BOUND. The operator
+    declared no approvers; they did not remove the route. Only ``None`` is
+    absence, so this keeps channel membership and the routed actor standing in
+    the card channel is allowed.
+
+    An implementation written as ``if approval.route and not binding`` instead
+    of ``binding is None`` refuses here. This is the exact off-by-one, and this
+    test is the only thing that catches it."""
+
+    name, decision = _authorize(
+        _bound_approval(), _OUTSIDER, _CARD_CHANNEL, binding={}
+    )
+    assert name == "ChannelMembershipAuthorizer"
+    assert decision.allowed
+
+
+def test_an_empty_route_string_is_routeless_and_keeps_channel_membership() -> None:
+    """Two files must agree on what "named a route" means, and they agree by
+    TRUTHINESS, not by ``is not None``.
+
+    ``crud.get_approval_route_binding`` returns early on ``not approval.route``,
+    so an approval carrying ``route=""`` is already routeless there and yields a
+    ``None`` binding. The selector's fail-closed branch must key on the same
+    truthiness (``approval.route and binding is None``). An implementer writing
+    ``approval.route is not None`` instead would refuse this approval in the
+    selector while crud had already classified it as routeless -- a silent
+    divergence between two files, in the fail-closed direction, that nothing
+    else pins.
+    """
+
+    name, decision = _authorize(
+        _bound_approval(route=""), _OUTSIDER, _CARD_CHANNEL, binding=None
+    )
+    assert name == "ChannelMembershipAuthorizer"
+    assert decision.allowed
+
+
+def test_an_unbound_route_and_an_unreadable_block_stay_distinct_in_the_audit() -> None:
+    """Audit vocabulary (approvers.py's frozen ``audit_name`` strings): both
+    undetermined sets refuse everyone, but an operator reading the append-only
+    trail must be able to tell "the route you named is gone" from "the
+    approvers block does not parse". ADR-0123 adds a NEW string and renames
+    nothing, so the malformed case must NOT drift onto the new name."""
+
+    gone, _gone_decision = _authorize(
+        _bound_approval(), _OUTSIDER, _CARD_CHANNEL, binding=None
+    )
+    unreadable, decision = _authorize(
+        _bound_approval(),
+        _OUTSIDER,
+        _CARD_CHANNEL,
+        binding={"channel": _CARD_CHANNEL, "approvers": {"group": 123}},
+    )
+    assert gone == "UnboundRouteBinding"
+    assert unreadable == "InvalidApproversSpec"
+    assert not decision.allowed
+    assert decision.evidence is not None
+    assert decision.evidence["kind"] == "approvers_config"
+
+
+def test_self_approval_wins_over_a_missing_binding_but_the_audit_still_names_it() -> None:
+    """Ordering (ADR-0034, unchanged by ADR-0123): self-approval is refused
+    BEFORE the set is asked, so an author clicking their own request on a route
+    whose binding is gone is told about the self-approval, not about the route.
+    The audit name still comes from the set that WOULD have decided and carries
+    no evidence -- the same contract the malformed-block case pins, now for the
+    new set. Both branches deny, so nothing is widened either way."""
+
+    name, decision = _authorize(
+        _bound_approval(author=_AUTHOR), _AUTHOR, _CARD_CHANNEL, binding=None
+    )
+    assert name == "UnboundRouteBinding"
+    assert not decision.allowed
+    assert "self-approval" in decision.reason
+    assert decision.evidence is None
 
 
 def test_authorizer_denies_a_malformed_approvers_block_without_channel_fallback() -> None:

--- a/docs/approvals.md
+++ b/docs/approvals.md
@@ -126,7 +126,8 @@ precedence is fixed: `users` beats `group` beats channel membership.
 
 | Declared | Set | Lookup | Does the click channel matter? |
 |---|---|---|---|
-| nothing | `SlackChannelMembers` | none, the click's channel is the proof | yes, it is the only test |
+| nothing, and the route is bound (or the approval has no route at all) | `SlackChannelMembers` | none, the click's channel is the proof | yes, it is the only test |
+| nothing, and the approval names a route that is **not** bound | `UnboundRoute` — refuses everyone | none, there is no set to resolve | no, nobody is admitted |
 | `approvers.group: S...` | `SlackUserGroupMembers` | Slack `usergroups.users.list` | no |
 | `approvers.users: [U...]` | `ExplicitUsers` | none, pure config | no |
 
@@ -246,6 +247,7 @@ or `approvers.group` ignores the channel entirely, so passing it there is harmle
 | `403 self-approval is blocked` | You are the author of the turn that raised it. Resolve as a different actor. |
 | `403 you are not an approver` | The route's set does not admit that actor from that channel. Pass the record's `card_channel` as `--actor-channel` (`--list --json` reports it since #1078), or check the `approvers` block. A null `card_channel` is from an older row or a direct API write that omitted the field, so use the requesting channel. |
 | `403 could not verify approvers` | The declared `approvers` block is malformed and cannot be evaluated. Correct its `users` or `group` value, then replace the complete route map. |
+| `403 could not verify approvers: ... route is no longer bound` | The approval named a route whose binding was cleared or rewritten while it was pending — `--clear-routes`, a `--routes-from` file that omits the route, or any `--route` write, since a write is a full replacement. A pending approval is resolvable only through its own route's binding (ADR-0123), so it fails closed rather than widening to card-channel membership. Restore the binding and the approval resolves normally; it is not lost. |
 | `403 could not verify approver group membership` | Slack group membership could not be verified. This fails closed and does not name its cause. Check the API `SLACK_BOT_TOKEN`, its `usergroups:read` scope and reinstallation, and Slack availability. It never falls back to channel membership. |
 | `409 already resolved by ...` | Someone else won the claim. The decision stands. |
 | `410 expired` | The record passed its deadline. The session was already woken down its timeout branch. |

--- a/docs/interfaces/approval/INTERFACE.md
+++ b/docs/interfaces/approval/INTERFACE.md
@@ -206,9 +206,11 @@ in code now:
   channel (`card_channel` on the record), whose members the authorizer then counts as the
   approvers. **A named-but-unbound route now escalates loudly and creates no approval**
   (#544, ADR-0046, AC2), reversing #247's earlier warn-and-route-to-requesting-channel
-  fallback — authority must never silently widen. This is distinct from the API's
-  `get_approval_route_binding` channel fallback (`apps/api/src/curie_api/crud.py`), which is
-  for genuinely agent-less generic approvals (ADR-0034) and is UNCHANGED. The
+  fallback — authority must never silently widen. ADR-0123 brings resolve time into line
+  with that creation-time rule: the API's `get_approval_route_binding` channel fallback
+  (`apps/api/src/curie_api/crud.py`) now applies only to a **routeless** approval, so a
+  routed approval with no binding is refused at BOTH ends of the lifecycle — no approval is
+  created for it, and one already pending stops being resolvable. The
   card's transport follows the same split (#451): a bound channel that differs from the
   requesting channel is deployment policy, not part of the triggering conversation, so the
   card posts top-level over the worker's default Slack transport rather than the trigger's
@@ -366,15 +368,21 @@ non-approver.
 approval's `agent_id` and `route`; nothing is snapshotted onto the record at creation. That
 is the correct TOCTOU direction for authorization: revocation takes effect at the decision
 point, and a user removed from the approver group yesterday cannot resolve a stale pending
-approval today. The accepted consequence: deleting or renaming a binding that carried
-`approvers` while an approval pends WIDENS authority from the declared group or list to
-card-channel membership, because the resolver cannot distinguish "never bound" from "was
-bound, now unbound" without the rejected snapshot. It is accepted because mutating
-`approval_routes` requires the agent PATCH endpoint (the same platform key that can already
-resolve any approval directly, so no new escalation path), because fail-closing unbound
-routes would reject approvals that resolve fine today, and because the audit row records
-the widened basis actually used. An approval with a NULL `agent_id`, or one naming a route
-absent from the map, likewise has no binding to read and keeps channel membership.
+approval today. That direction is unchanged, and revocation still takes effect on the next
+click. What ADR-0123 changes is the ABSENT binding: deleting or renaming a binding while an
+approval pends no longer WIDENS that approval to card-channel membership — it makes the
+approval **unresolvable**. A pending approval that named a route is resolvable only through
+that route's binding, so with the binding gone the selector returns `UnboundRoute`, which
+admits nobody and reports `undetermined`; the resolve attempt is a 403 and the audit row
+records `UnboundRouteBinding` with the missing route in its evidence. ADR-0123 supersedes
+exactly this one consequence of ADR-0034; ADR-0034's AC4 zero-setup default stands, so a
+binding that is PRESENT and declares no `approvers` still means card-channel membership.
+An approval with a NULL `agent_id` that nonetheless names a route falls under the same
+rule and is refused too — `get_approval_route_binding` returns a bare None for every miss,
+and the split is on whether the approval named a route, not on why the binding is missing.
+An approval that names NO route never had a narrower set to lose and keeps channel
+membership. The recovery from a stuck approval is to restore the binding, after which it
+resolves normally; nothing is lost.
 
 ### The three ports
 


### PR DESCRIPTION
Implements the Decision in Accepted **ADR-0123**, which supersedes the one consequence ADR-0034 accepted on a rationale that does not hold for group-bound or list-bound routes.

## The defect

`SlackApproverSetSelector.__call__` fell back to `SlackChannelMembers` whenever the route binding declared no approvers — **including when there was no binding at all**. `crud.get_approval_route_binding` collapses every miss to a bare `None`, so clearing or rewriting an agent's route map downgraded an **already-pending** approval from a server-enforced approver set to a caller-asserted `actor_channel` check. A platform-key holder outside `S0FINANCE` could drop the route and then resolve the approval that group was gating. Self-approval blocking does not help — it compares only against `approval.author`, and this is a second identity.

## The change

The no-approvers case now splits three ways, exactly as ADR-0123 specifies:

| approval | binding | approver set |
|---|---|---|
| names a route | present, no `approvers` block | `SlackChannelMembers` — **unchanged** (ADR-0034 AC4) |
| names a route | **absent** | **`UnboundRoute`** — admits nobody, fails closed |
| names no route | — | `SlackChannelMembers` — **unchanged** (#420 AC4) |

`UnboundRoute` is a new provider-neutral `ApproverSet` shaped after `InvalidApprovers`. It reports `undetermined=True`, so `authorizer.py`'s existing fail-closed rule denies it with **no authorizer change**. Its audit evidence names the missing binding (`{"kind": "route_binding", "route": ..., "binding_present": false}`), so an operator reading the append-only trail sees *why* the approval stopped being resolvable.

The condition is `if approval.route and binding is None:` — both halves are load-bearing and pinned by tests. `binding is None` (not `not binding`) because a route bound to `{}` is **bound**; truthiness on `approval.route` because `crud.get_approval_route_binding` returns early on `not approval.route`, so `is not None` would refuse a `route=""` approval crud has already classified as routeless.

## ⚠️ Announced behavior change — please confirm this is what you intended

**The split keys on `approval.route` alone, with no `agent_id` carve-out.** A routed approval created with `agent_id: null` (the generic/dev path) therefore **also fails closed now**.

This follows ADR-0123 literally: its rule is worded purely in terms of whether the approval named a route, and the selector cannot distinguish "no agent" from "route removed while pending" without widening `get_approval_route_binding`'s return type, which the ADR does not authorize. It is also consistent with #544 Decision B, which already refuses to *create* an approval for a named-but-unbound route. But it is the one place this PR makes a judgment call, so it is called out here rather than buried.

**Four pre-existing tests pinned the old behavior and were retargeted — none deleted, none weakened:**

- `test_authorizer_falls_back_to_channel_membership_without_a_binding` → `test_authorizer_refuses_a_routed_approval_whose_binding_is_gone`
- `test_agentless_approval_keeps_channel_membership` → `test_agentless_routed_approval_fails_closed_without_a_binding`
- `test_unbound_route_name_keeps_channel_membership` → `test_a_route_absent_from_the_map_is_unresolvable_and_borrows_no_other_route`
- `test_route_bound_approval_authorizes_against_card_channel` → `test_route_bound_approval_with_no_agent_resolves_through_neither_channel`

Each keeps the AC2 self-approval coverage and the allowlist-no-leak coverage it originally protected, and now asserts the *specific* refusal reason so two different 403s cannot be conflated.

## Out of scope (deliberately)

- **A permission model for who may rewrite a route map** — ADR-0123 defers this to ADR-0106's canonical principals.
- **The `expires_at`-is-optional gap** — ADR-0123 says it is pre-existing and "worth its own issue rather than a rule smuggled in here."
- **Expiry is unreachable behind the authz gate.** The security reviewer raised this (P2): `resolve_approval` authorizes *before* it checks expiry, so any refuse-all set means a past-SLA resolve attempt returns 403 and never flips the record to expired. I verified this is **pre-existing and not introduced here** — on the untouched `ExplicitUsers` path a refused actor past `expires_at` already gets 403, not 410, and this PR does not touch `routers/approvals.py` or `authorizer.py` at all. It affects `InvalidApprovers` and the group-lookup-failure set today. **Worth its own issue**; fixing it here would be a scope passenger with its own security implications.

## Verification

- **Red-on-revert proven**: reverting only the branch condition to `if False:` fails 4 tests, including the end-to-end escalation test.
- **End-to-end regression test** performs the real escalation: group binding → outsider refused → `PATCH /agents/{id}` route map without `managers` → same outsider asserting `actor_channel` is **403, not 200** → audit row records `UnboundRouteBinding` → approval still `pending`, no resume enqueued → restore the binding → resolves 200.
- **Negative controls kept green**: routeless approval, binding present with no `approvers` block, binding `{}`, `route=""`, malformed binding → `InvalidApprovers`, and `users` > `group` precedence.
- Frozen `audit_name` vocabulary is byte-identical; `UnboundRouteBinding` is purely additive.
- `apps/api` suite **1160 passed, 1 skipped**; `ruff`, `mypy` (195 files), `lint-imports` (4 contracts), and `scripts/check-docs.sh` all clean.
- Adversarial review (agent-router → codex/gpt-5.6-sol): **Code** and **Scope** clean; **Security** raised only the pre-existing expiry ordering above; **consolidation** re-review confirmed no coverage lost.

Ref #1081
