### PR TITLE
Report the model curie doctor's install will actually boot

### DIFF
--- a/cli/src/doctor.rs
+++ b/cli/src/doctor.rs
@@ -69,9 +69,36 @@ pub struct Facts {
     pub model_credential: Option<String>,
     /// Where it came from, for the detail line.
     pub model_credential_source: Option<String>,
-    /// The configured model id, verbatim. A value here is not a claim that the
-    /// id is valid, only that something set it.
-    pub model_pin: Option<String>,
+    /// Verbatim `CURIE_MODEL` from the invoking shell. Lowest precedence: the
+    /// shell is not a declared producer of this variable (#1950). A value here
+    /// is not a claim that the id is valid, only that something set it.
+    pub model_shell: Option<String>,
+    /// The model the release's sandboxes boot, read from its COMPUTED helm
+    /// values, so a chart default the operator never supplied is still
+    /// observed. See [`runner_model_from_values`] for which key that is.
+    pub model_release_default: Option<String>,
+    /// WHICH chart key [`Facts::model_release_default`] was read from. The
+    /// chart branches between two of them, and a report that names the wrong
+    /// one hands the operator a `--set` the chart ignores. `None` means the key
+    /// was not observed -- `gather` always sets both together -- and falls back
+    /// to the key a default install boots from.
+    pub model_release_key: Option<ReleaseModelKey>,
+    /// Whether the release currently boots the runner's SCRIPTED FAKE model,
+    /// which makes [`Facts::model_release_default`] configured-but-unused. See
+    /// [`release_fake_model`]: the chart's fake-model flag and the model id are
+    /// independent template arms, so a default install renders BOTH
+    /// `CURIE_FAKE_MODEL=1` and `CURIE_MODEL=claude-sonnet-5` and the id alone
+    /// is not proof the pod boots it -- the same "names a model the pod does
+    /// not boot" defect class as #1950 itself.
+    pub model_release_fake: bool,
+    /// `(agent name, model)` for every agent carrying a per-agent override,
+    /// forwarded as `CURIE_MODEL` at sandbox boot. Highest precedence.
+    pub model_agent_overrides: Vec<(String, String)>,
+    /// The `(namespace, release)` this run was invoked with. An observed fact
+    /// about the run, kept on `Facts` so `evaluate` stays pure and the fix
+    /// string can name the release actually diagnosed rather than `curie/curie`
+    /// (#1358 item 1).
+    pub target: Option<(String, String)>,
     /// Non-secret provider inferred from the bound `CURIE_CREDENTIALS` value.
     /// The credential itself is deliberately discarded during observation.
     pub model_credential_provider: Option<&'static str>,
@@ -141,6 +168,325 @@ fn missing_release_recovery(provider: Option<&str>) -> String {
     command
 }
 
+/// Which chart key the release's model came from.
+///
+/// `charts/curie/templates/agent-sandbox.yaml` renders exactly one
+/// `CURIE_MODEL` entry and picks its value on a branch, so the release default
+/// has two possible homes and only one of them is live on any given install.
+/// Carrying the key is what keeps the report and the fix honest: while the
+/// in-cluster inference service is deployed the chart IGNORES
+/// `agentSandbox.runner.model` entirely, so naming that key on a
+/// `curie cluster up --local-model` install both mislabels the source and
+/// prints a `--set` that cannot change the model in force.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ReleaseModelKey {
+    /// `agentSandbox.runner.model` -- what a default install boots.
+    #[default]
+    Runner,
+    /// `inference.model` -- live only while `inference.deploy` is truthy.
+    Inference,
+}
+
+impl ReleaseModelKey {
+    /// The dotted key exactly as the chart and `--set` spell it.
+    fn chart_key(self) -> &'static str {
+        match self {
+            ReleaseModelKey::Runner => "agentSandbox.runner.model",
+            ReleaseModelKey::Inference => "inference.model",
+        }
+    }
+}
+
+/// Where a model id was observed. Three sources, and they can disagree.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ModelSource {
+    /// A per-agent override, carrying the agent's real name. The worker
+    /// forwards it as `CURIE_MODEL` at sandbox boot, so it wins outright.
+    Agent(String),
+    /// The release's own default, from its computed helm values, carrying the
+    /// chart key it was read from -- the two keys are not interchangeable, see
+    /// [`ReleaseModelKey`].
+    ReleaseDefault(ReleaseModelKey),
+    /// The invoking shell's `CURIE_MODEL`. Lowest, because the shell is not a
+    /// declared producer of that variable.
+    Shell,
+}
+
+impl ModelSource {
+    /// How the source reads in the detail line. An id with no label is not
+    /// something an operator can go and change.
+    fn label(&self) -> String {
+        match self {
+            ModelSource::Agent(name) => format!("agent \"{name}\""),
+            ModelSource::ReleaseDefault(key) => {
+                format!("release default {}", key.chart_key())
+            }
+            ModelSource::Shell => "CURIE_MODEL".to_string(),
+        }
+    }
+}
+
+/// The model this install will actually boot, and what else claimed otherwise.
+#[derive(Debug, Clone)]
+pub struct InForceModel {
+    /// Which source won precedence.
+    pub source: ModelSource,
+    /// The id that source carries, trimmed and non-empty.
+    pub id: String,
+    /// Every other source whose id DIFFERS from the one in force. An identical
+    /// id is not a disagreement.
+    pub disagreeing: Vec<(ModelSource, String)>,
+}
+
+/// Which model the install boots, out of the three places one can be set. Pure.
+///
+/// Precedence is the boot path, not a preference: a per-agent override beats
+/// the release default, which beats the invoking shell. `None` only when no
+/// source yields a model at all.
+///
+/// When several agents set DIFFERENT models there is no single answer, so the
+/// tie-break is chosen to make the check safe rather than pretty: rank the
+/// WEAKEST pin first (`Floating`, then `Unrecognized`, then `Pinned`), so the
+/// check can never report clean while one agent floats, then break the
+/// remaining ties on agent name ascending so the report is stable across runs.
+fn resolve_model(f: &Facts) -> Option<InForceModel> {
+    /// #229's footgun at three sources instead of one: an exported-but-empty
+    /// value is not a configured model, and letting one win precedence would
+    /// resolve to `Unset` and report not-applicable on an install that boots
+    /// something.
+    fn cleaned(id: &str) -> Option<String> {
+        let id = id.trim();
+        (!id.is_empty()).then(|| id.to_string())
+    }
+
+    fn weakness(id: &str) -> u8 {
+        match classify(Some(id)) {
+            PinStatus::Floating { .. } => 0,
+            PinStatus::Unrecognized { .. } => 1,
+            _ => 2,
+        }
+    }
+
+    let mut agents: Vec<(String, String)> = f
+        .model_agent_overrides
+        .iter()
+        .filter_map(|(name, id)| cleaned(id).map(|id| (name.clone(), id)))
+        .collect();
+    agents.sort_by(|a, b| a.0.cmp(&b.0));
+    let release = f.model_release_default.as_deref().and_then(cleaned);
+    let shell = f.model_shell.as_deref().and_then(cleaned);
+
+    // `min_by_key` keeps the first of several equal minima, and the list is
+    // already name-ascending, so this IS the documented tie-break.
+    let (source, id) = match agents.iter().min_by_key(|(_, id)| weakness(id)) {
+        Some((name, id)) => (ModelSource::Agent(name.clone()), id.clone()),
+        None => match &release {
+            Some(id) => (
+                ModelSource::ReleaseDefault(f.model_release_key.unwrap_or_default()),
+                id.clone(),
+            ),
+            None => (ModelSource::Shell, shell.clone()?),
+        },
+    };
+
+    let mut disagreeing: Vec<(ModelSource, String)> = agents
+        .iter()
+        .filter(|(_, other)| *other != id)
+        .map(|(name, other)| (ModelSource::Agent(name.clone()), other.clone()))
+        .collect();
+    for (candidate, other) in [
+        (
+            ModelSource::ReleaseDefault(f.model_release_key.unwrap_or_default()),
+            &release,
+        ),
+        (ModelSource::Shell, &shell),
+    ] {
+        if let Some(other) = other {
+            if *other != id {
+                disagreeing.push((candidate, other.clone()));
+            }
+        }
+    }
+
+    Some(InForceModel {
+        source,
+        id,
+        disagreeing,
+    })
+}
+
+/// The model the release's sandboxes boot, out of its computed helm values.
+///
+/// It is NOT a single path. `charts/curie/templates/agent-sandbox.yaml` renders
+/// exactly one `CURIE_MODEL` env entry and picks its value on a branch:
+/// `.Values.inference.model` when `.Values.inference.deploy` is TRUTHY by Go's
+/// rule (the `curie cluster up --local-model` shape; see [`helm_truthy`], which
+/// is not the same test as "is the boolean true"), otherwise
+/// `.Values.agentSandbox.runner.model`. Reproducing that branch is what keeps
+/// this from naming a model the pod never boots.
+///
+/// It returns the key alongside the id: the label and the fix both have to
+/// name the key that is actually live, or the operator is told to `--set` one
+/// the chart ignores.
+///
+/// An empty or whitespace-only value at either key is not a configured model
+/// (#229) and falls through. The read ends in `as_str`, so a non-string at the
+/// path reads as absent -- safe here because the key is a string in the chart
+/// and in every `--set` form, and deliberately not widened (#1358 item 4).
+fn runner_model_from_values(values: &serde_json::Value) -> Option<(String, ReleaseModelKey)> {
+    fn at(values: &serde_json::Value, path: &[&str]) -> Option<String> {
+        let mut node = values;
+        for key in path {
+            node = node.get(key)?;
+        }
+        let id = node.as_str()?.trim();
+        (!id.is_empty()).then(|| id.to_string())
+    }
+
+    if helm_truthy(values.get("inference").and_then(|i| i.get("deploy"))) {
+        if let Some(model) = at(values, &["inference", "model"]) {
+            return Some((model, ReleaseModelKey::Inference));
+        }
+    }
+    at(values, &["agentSandbox", "runner", "model"]).map(|id| (id, ReleaseModelKey::Runner))
+}
+
+/// Whether the release's sandboxes boot the runner's SCRIPTED FAKE model.
+///
+/// `charts/curie/templates/agent-sandbox.yaml` renders `CURIE_FAKE_MODEL=1` on
+/// `and $runner.fakeModel (not .Values.inference.deploy)`, and picks
+/// `CURIE_MODEL` on a SEPARATE arm. The two are independent, so on the chart's
+/// shipped defaults (`agentSandbox.runner.fakeModel: true`) a release renders
+/// BOTH `CURIE_FAKE_MODEL=1` and `CURIE_MODEL=claude-sonnet-5` -- the id is
+/// configured and the pod boots the scripted fake instead. Reporting that id
+/// as the model in force with no caveat is the very defect #1950 exists to
+/// kill, one level down.
+///
+/// Both legs go through [`helm_truthy`] rather than `as_bool`, for the reason
+/// spelled out there: a value that reaches Helm as a string still takes the
+/// template branch, and disagreeing with Helm is how doctor names a model the
+/// pod does not boot.
+fn release_fake_model(values: &serde_json::Value) -> bool {
+    let fake = values
+        .get("agentSandbox")
+        .and_then(|a| a.get("runner"))
+        .and_then(|r| r.get("fakeModel"));
+    let inference = values.get("inference").and_then(|i| i.get("deploy"));
+    helm_truthy(fake) && !helm_truthy(inference)
+}
+
+/// Go template truthiness, mirrored for the one value the chart branches on.
+///
+/// `agent-sandbox.yaml` gates on `if .Values.inference.deploy`, and Go's
+/// `empty` is false only for `false`, a zero number, an empty string and nil.
+/// Reading it with `as_bool` instead made a value that arrives as a STRING --
+/// a generic `--set-string inference.deploy=true`, say -- send Helm down the
+/// inference branch while doctor went down the runner one, and doctor then
+/// reported a model the pod does not boot.
+///
+/// Yes, this means the string `"false"` is truthy. That is Helm's rule, not a
+/// bug here: a non-empty string is non-empty whatever it spells.
+///
+/// This ladder exists TWICE in the crate: see
+/// `classify_existing_secret_field` in `cli/src/github_app.rs`, which mirrors
+/// the same Go rule for `api.githubAppExistingSecret`. They must agree, so a
+/// change to one belongs in both.
+fn helm_truthy(value: Option<&serde_json::Value>) -> bool {
+    match value {
+        None | Some(serde_json::Value::Null) => false,
+        Some(serde_json::Value::Bool(b)) => *b,
+        Some(serde_json::Value::Number(n)) => n.as_f64() != Some(0.0),
+        Some(serde_json::Value::String(s)) => !s.is_empty(),
+        // Go calls an EMPTY list or map empty exactly as it does `""`, so both
+        // are falsy here and only a populated one is true. A scalar key like
+        // this one should never carry either, but agreeing with Go costs
+        // nothing and disagreeing with the copy in `github_app.rs` does.
+        Some(serde_json::Value::Array(a)) => !a.is_empty(),
+        Some(serde_json::Value::Object(o)) => !o.is_empty(),
+    }
+}
+
+/// The command that pins the model at the source it is actually in force from.
+///
+/// Bare and runnable, with angle-bracket placeholders only: a fix string that
+/// names a flag which does not exist fails for whoever pastes it (#1813). Note
+/// `curie cluster up` has NO `--model` -- that flag belongs to `skill up` -- so
+/// the release default is set through `--set <key>=`, where the key is the one
+/// the release actually reads ([`ReleaseModelKey`]) rather than always
+/// `agentSandbox.runner.model`, which a local-inference install ignores. The
+/// namespace and release come from the run itself rather than defaulting to
+/// `curie/curie` (#1358 item 1).
+fn model_pin_fix(f: &Facts, source: &ModelSource) -> String {
+    match source {
+        ModelSource::Agent(name) => {
+            format!("curie cluster overrides {name} --model <dated-snapshot-id>")
+        }
+        ModelSource::ReleaseDefault(key) => {
+            let (namespace, release) = match &f.target {
+                Some((namespace, release)) => (namespace.as_str(), release.as_str()),
+                None => ("<ns>", "<release>"),
+            };
+            let key = key.chart_key();
+            format!(
+                "curie cluster up --namespace {namespace} --release {release} \
+                 --set {key}=<dated-snapshot-id>"
+            )
+        }
+        ModelSource::Shell => "export CURIE_MODEL=<dated-snapshot-id>".to_string(),
+    }
+}
+
+/// The one not-applicable detail: no source yields a model at all.
+///
+/// It has to say WHICH sources were looked at, or it is indistinguishable from
+/// the check being blind again -- and it must not claim there is no per-agent
+/// override when the platform API was never reached to look.
+fn no_model_determined(f: &Facts) -> String {
+    let overrides = if f.agents.is_some() {
+        "no per-agent override"
+    } else {
+        "per-agent overrides could not be read because the platform API was not reached"
+    };
+    format!(
+        "no model determined: {overrides}, no release default \
+         agentSandbox.runner.model or inference.model, and no CURIE_MODEL"
+    )
+}
+
+/// The caveat for a report that could not see the highest-precedence source.
+///
+/// `Facts::agents` is `None` only when the platform API was not reached at all,
+/// which is NOT the same fact as "reached, and no agent sets a model" -- and a
+/// per-agent override outranks every other source. Reporting a clean pinned
+/// release default while an agent quietly carries a floating one is the exact
+/// failure #1950 exists to kill, so the check says what it could not see. The
+/// state stays as it is (absent is not broken); the honesty is in the detail.
+fn unread_agent_overrides(f: &Facts, in_force: &ModelSource) -> &'static str {
+    if f.agents.is_none() && !matches!(in_force, ModelSource::Agent(_)) {
+        "; per-agent model overrides could not be read because the platform \
+         API was not reached, so an agent may boot a different model"
+    } else {
+        ""
+    }
+}
+
+/// The caveat for an id the release has configured but does NOT currently boot.
+///
+/// See [`release_fake_model`] for why a real id and the fake model coexist. The
+/// id is NOT suppressed and the state does NOT change: it is exactly what
+/// applies the moment fake model is turned off, and the credential story has
+/// its own `model-credential` check. Only the release source can be in this
+/// position -- an agent override or a shell value is forwarded as `CURIE_MODEL`
+/// regardless of what the chart's fake-model arm renders.
+fn release_fake_model_clause(f: &Facts, in_force: &ModelSource) -> &'static str {
+    if f.model_release_fake && matches!(in_force, ModelSource::ReleaseDefault(_)) {
+        "; the sandbox currently boots the runner's scripted fake model, so \
+         this id is configured but not in use"
+    } else {
+        ""
+    }
+}
+
 /// Judge the gathered facts. Pure.
 pub fn evaluate(f: &Facts) -> Vec<Check> {
     let mut out = Vec::new();
@@ -161,32 +507,74 @@ pub fn evaluate(f: &Facts) -> Vec<Check> {
         ),
     });
 
-    out.push(match classify(f.model_pin.as_deref()) {
-        PinStatus::Unset => skipped(
-            "model-pin",
-            "Model pin",
-            "no CURIE_MODEL set, so the platform default applies",
-        ),
-        PinStatus::Pinned { id, date } => {
-            ok("model-pin", "Model pin", format!("{id} (snapshot {date})"))
+    // The model the install actually BOOTS, not the one the invoking shell
+    // happens to name (#1950). `not_applicable` is reserved for the single case
+    // where no source yields a model at all, and says which three were looked
+    // at -- otherwise it is indistinguishable from the check being blind again.
+    out.push(match resolve_model(f) {
+        None => skipped("model-pin", "Model pin", no_model_determined(f)),
+        Some(m) => {
+            let source = m.source.label();
+            // Nothing appended when nothing disagrees: a detail ending on a
+            // dangling "other sources disagree:" reads as a truncated report.
+            let disagreement = if m.disagreeing.is_empty() {
+                String::new()
+            } else {
+                let named: Vec<String> = m
+                    .disagreeing
+                    .iter()
+                    .map(|(source, id)| format!("{} = {id}", source.label()))
+                    .collect();
+                format!("; other sources disagree: {}", named.join(", "))
+            };
+            // What the report could NOT see, appended to every state: a
+            // silently-unread override outranks whatever is named above.
+            let unread = unread_agent_overrides(f, &m.source);
+            // The id is configured but not what the pod boots. Placed after
+            // the source label and before the disagreement/unread clauses, so
+            // it qualifies the id it is about and nothing else.
+            let fake = release_fake_model_clause(f, &m.source);
+            match classify(Some(m.id.as_str())) {
+                PinStatus::Pinned { id, date } => ok(
+                    "model-pin",
+                    "Model pin",
+                    format!(
+                        "{id} (snapshot {date}), in force from \
+                         {source}{fake}{disagreement}{unread}"
+                    ),
+                ),
+                // Ok rather than Missing, deliberately: a floating name works,
+                // and a working install must not report as unready. What is at
+                // risk is reproducibility, so this carries a fix without
+                // failing the check.
+                PinStatus::Floating { id } => Check {
+                    id: "model-pin",
+                    title: "Model pin",
+                    state: State::Ok,
+                    detail: format!(
+                        "{id} is a floating name, in force from {source}; the \
+                         provider can repoint it at new weights with no change \
+                         here, and no gate would see it{fake}{disagreement}{unread}"
+                    ),
+                    fix: Some(model_pin_fix(f, &m.source)),
+                },
+                // No fix, and no claim about whether the id moves: the shape
+                // rule cannot read this one, and a wrong fix string is worse
+                // than none (#1813).
+                PinStatus::Unrecognized { id } => ok(
+                    "model-pin",
+                    "Model pin",
+                    format!(
+                        "{id}, in force from {source}; this check reads a model \
+                         id by shape alone and does not recognise this one, so \
+                         it cannot say whether the id moves{fake}{disagreement}{unread}"
+                    ),
+                ),
+                // Unreachable: `resolve_model` yields only trimmed, non-empty
+                // ids. Report it as no model rather than assert it away.
+                PinStatus::Unset => skipped("model-pin", "Model pin", no_model_determined(f)),
+            }
         }
-        // Ok rather than Missing, deliberately: a floating name works, and a
-        // working install must not report as unready. What is at risk is
-        // reproducibility, so this carries a fix without failing the check.
-        PinStatus::Floating { id } => Check {
-            id: "model-pin",
-            title: "Model pin",
-            state: State::Ok,
-            detail: format!(
-                "{id} is a floating name; the provider can repoint it at new \
-                 weights with no change here, and no gate would see it"
-            ),
-            fix: Some(
-                "export CURIE_MODEL=<id>-YYYYMMDD   (pin the dated snapshot, so a \
-                 graded bundle keeps the weights it was graded on)"
-                    .into(),
-            ),
-        },
     });
 
     out.push(if f.docker_ok {
@@ -492,6 +880,11 @@ mod tests {
         checks.iter().find(|c| c.id == id).expect(id)
     }
 
+    /// The one check this issue is about, pulled out of a full `evaluate`.
+    fn model_pin(f: &Facts) -> Check {
+        find(&evaluate(f), "model-pin").clone()
+    }
+
     /// The laptop rung is a complete way to use Curie. Reporting five failures
     /// at someone who has not asked for a cluster is how a doctor command
     /// becomes noise people stop reading.
@@ -611,7 +1004,7 @@ mod tests {
     #[test]
     fn a_floating_model_reports_ok_with_a_fix() {
         let f = Facts {
-            model_pin: Some("gpt-4o".into()),
+            model_shell: Some("gpt-4o".into()),
             ..Default::default()
         };
         let c = evaluate(&f)
@@ -630,7 +1023,7 @@ mod tests {
     #[test]
     fn a_pinned_snapshot_carries_no_fix() {
         let f = Facts {
-            model_pin: Some("claude-haiku-4-5-20251001".into()),
+            model_shell: Some("claude-haiku-4-5-20251001".into()),
             ..Default::default()
         };
         let c = evaluate(&f)
@@ -642,8 +1035,12 @@ mod tests {
         assert!(c.detail.contains("20251001"), "{}", c.detail);
     }
 
-    /// No model configured is not a gap: the platform default is a valid way to
-    /// run, so this must not count against readiness.
+    /// No model configured anywhere is not a gap: the platform default is a
+    /// valid way to run, so this must not count against readiness. What #1950
+    /// narrowed is what "unset" MEANS -- it is no longer "the invoking shell
+    /// did not export CURIE_MODEL", it is "no source yields a model at all",
+    /// and the detail has to say which three sources were looked at or the
+    /// operator cannot tell this apart from the check being blind again.
     #[test]
     fn an_unset_model_is_not_applicable() {
         let c = evaluate(&Facts::default())
@@ -651,6 +1048,965 @@ mod tests {
             .find(|c| c.id == "model-pin")
             .expect("model-pin check");
         assert_eq!(c.state, State::NotApplicable);
+        let detail = &c.detail;
+        assert!(
+            detail.contains("override"),
+            "must name the per-agent override as one of the sources looked at: {detail}"
+        );
+        assert!(
+            detail.contains("agentSandbox.runner.model"),
+            "must name the release default by its real key: {detail}"
+        );
+        assert!(
+            detail.contains("CURIE_MODEL"),
+            "must name the shell variable: {detail}"
+        );
+    }
+
+    /// The exact scenario #1950 reports, and the single most important
+    /// assertion in this change. An operator runs `curie cluster up`, never
+    /// exports CURIE_MODEL, and the chart's own default `claude-sonnet-5` --
+    /// which this repo's own `an_undated_name_floats` calls a floating alias --
+    /// is what every sandbox boots. Before this, the shell was the only source
+    /// read, so the check reported `not_applicable` with no fix: the
+    /// diagnostic built to catch a floating alias reported clean on the
+    /// shipped default.
+    #[test]
+    fn a_floating_release_default_on_a_live_release_reports_floating() {
+        let f = Facts {
+            model_release_default: Some("claude-sonnet-5".into()),
+            target: Some(("curie".into(), "curie".into())),
+            ..wired()
+        };
+        let c = model_pin(&f);
+        assert_ne!(
+            c.state,
+            State::NotApplicable,
+            "a floating model on a live release is not 'not applicable': {}",
+            c.detail
+        );
+        assert_eq!(c.state, State::Ok, "{}", c.detail);
+        assert!(
+            c.detail.contains("claude-sonnet-5"),
+            "must name the id actually in force: {}",
+            c.detail
+        );
+        assert!(
+            c.detail.contains("release default"),
+            "must say WHERE it is in force from, or the operator cannot act on \
+             it: {}",
+            c.detail
+        );
+        assert!(
+            c.fix.is_some(),
+            "a floating name in force is exactly the case that carries advice"
+        );
+    }
+
+    /// AC1's precedence, exercised as a ladder: the per-agent override is what
+    /// the worker forwards as CURIE_MODEL at sandbox boot, so it beats the
+    /// release default, which in turn beats the invoking shell -- a value the
+    /// boot-env contract does not even declare the CLI as a producer of. Each
+    /// rung is asserted by removing the one above it, so a precedence order
+    /// written backwards fails here rather than in production.
+    #[test]
+    fn an_agent_override_beats_the_release_default_beats_the_shell() {
+        let all = Facts {
+            model_shell: Some("shell-model-20250101".into()),
+            model_release_default: Some("claude-sonnet-5".into()),
+            model_agent_overrides: vec![("bot".into(), "gpt-4o-mini".into())],
+            target: Some(("curie".into(), "curie".into())),
+            ..wired()
+        };
+
+        let r = resolve_model(&all).expect("a model is in force");
+        assert_eq!(r.id, "gpt-4o-mini");
+        assert!(
+            matches!(&r.source, ModelSource::Agent(name) if name == "bot"),
+            "the agent override must win, and must carry the agent's real name"
+        );
+        let c = model_pin(&all);
+        assert!(c.detail.contains("gpt-4o-mini"), "{}", c.detail);
+        assert!(
+            c.detail.contains("bot"),
+            "the operator has to know WHICH agent is in force: {}",
+            c.detail
+        );
+
+        let no_agent = Facts {
+            model_agent_overrides: vec![],
+            ..all.clone()
+        };
+        let r = resolve_model(&no_agent).expect("a model is in force");
+        assert_eq!(r.id, "claude-sonnet-5");
+        assert!(matches!(
+            r.source,
+            ModelSource::ReleaseDefault(ReleaseModelKey::Runner)
+        ));
+
+        let shell_only = Facts {
+            model_agent_overrides: vec![],
+            model_release_default: None,
+            ..all
+        };
+        let r = resolve_model(&shell_only).expect("a model is in force");
+        assert_eq!(r.id, "shell-model-20250101");
+        assert!(matches!(r.source, ModelSource::Shell));
+    }
+
+    /// The inverse failure the issue names: a shell that happens to export a
+    /// dated snapshot while the release still floats. Reporting only the
+    /// winner would hide the disagreement entirely, so the detail has to carry
+    /// both ids AND both source labels -- an id with no label is not something
+    /// an operator can go and change.
+    #[test]
+    fn disagreement_is_named() {
+        let f = Facts {
+            model_shell: Some("claude-haiku-4-5-20251001".into()),
+            model_release_default: Some("claude-sonnet-5".into()),
+            target: Some(("curie".into(), "curie".into())),
+            ..wired()
+        };
+        let c = model_pin(&f);
+        assert_eq!(c.state, State::Ok, "{}", c.detail);
+        assert!(
+            c.detail.contains("claude-sonnet-5"),
+            "the in-force id: {}",
+            c.detail
+        );
+        assert!(
+            c.detail.contains("release default"),
+            "the in-force source: {}",
+            c.detail
+        );
+        assert!(
+            c.detail.contains("claude-haiku-4-5-20251001"),
+            "the disagreeing id: {}",
+            c.detail
+        );
+        assert!(
+            c.detail.contains("CURIE_MODEL"),
+            "the disagreeing source: {}",
+            c.detail
+        );
+    }
+
+    /// Several agents, several models. The check must never read clean because
+    /// it happened to pick the pinned one: the weakest pin is the risk the
+    /// install actually carries, so `Floating` outranks `Unrecognized`
+    /// outranks `Pinned`, and ties break on agent name so the report is
+    /// deterministic across runs.
+    #[test]
+    fn the_weakest_agent_pin_is_the_one_reported() {
+        let f = Facts {
+            model_agent_overrides: vec![
+                ("alpha".into(), "claude-haiku-4-5-20251001".into()),
+                ("beta".into(), "claude-sonnet-5".into()),
+            ],
+            target: Some(("curie".into(), "curie".into())),
+            ..wired()
+        };
+        let r = resolve_model(&f).expect("a model is in force");
+        assert_eq!(r.id, "claude-sonnet-5");
+        assert!(
+            matches!(&r.source, ModelSource::Agent(name) if name == "beta"),
+            "the floating agent must be the one reported in force"
+        );
+        let c = model_pin(&f);
+        assert_eq!(c.state, State::Ok, "{}", c.detail);
+        assert!(c.fix.is_some(), "a floating name in force carries advice");
+        assert!(c.detail.contains("beta"), "must name it: {}", c.detail);
+        assert!(
+            c.detail.contains("alpha") && c.detail.contains("claude-haiku-4-5-20251001"),
+            "the other agent still disagrees and must be listed: {}",
+            c.detail
+        );
+    }
+
+    /// AC2's other half. `not_applicable` used to mean "the invoking shell did
+    /// not export CURIE_MODEL", which is why the shipped default reported
+    /// clean. It now means exactly one thing -- no source yields a model at
+    /// all -- so any single source present must move the check off it.
+    #[test]
+    fn only_a_total_absence_is_not_applicable() {
+        let one_source_each = [
+            Facts {
+                model_shell: Some("claude-sonnet-5".into()),
+                ..Default::default()
+            },
+            Facts {
+                model_release_default: Some("claude-sonnet-5".into()),
+                ..Default::default()
+            },
+            Facts {
+                model_agent_overrides: vec![("bot".into(), "claude-sonnet-5".into())],
+                ..Default::default()
+            },
+        ];
+        for f in one_source_each {
+            let c = model_pin(&f);
+            assert_ne!(
+                c.state,
+                State::NotApplicable,
+                "a model IS determinable here, so this is not 'not applicable': {}",
+                c.detail
+            );
+        }
+
+        let c = model_pin(&Facts::default());
+        assert_eq!(c.state, State::NotApplicable);
+        for source in ["override", "agentSandbox.runner.model", "CURIE_MODEL"] {
+            assert!(
+                c.detail.contains(source),
+                "the one not-applicable branch must say which sources were \
+                 looked at, and name {source}: {}",
+                c.detail
+            );
+        }
+    }
+
+    /// AC3. `glm-4-0520` is a fully pinned zhipu snapshot; the old catch-all
+    /// asserted it floats and offered `export CURIE_MODEL=<id>-YYYYMMDD`, which
+    /// produces an id that provider will reject. The honest report makes no
+    /// claim about whether the id moves and carries no fix at all -- a wrong
+    /// fix string is worse than none (#1813).
+    #[test]
+    fn an_unrecognized_id_carries_no_fix() {
+        let f = Facts {
+            model_release_default: Some("glm-4-0520".into()),
+            target: Some(("curie".into(), "curie".into())),
+            ..wired()
+        };
+        let c = model_pin(&f);
+        assert_eq!(c.state, State::Ok, "{}", c.detail);
+        assert!(
+            c.fix.is_none(),
+            "an unrecognised shape must not be told to pin a date it may not \
+             accept: {:?}",
+            c.fix
+        );
+        assert!(c.detail.contains("glm-4-0520"), "{}", c.detail);
+        assert!(
+            c.detail.contains("does not recognise"),
+            "must say plainly that the rule cannot read this shape: {}",
+            c.detail
+        );
+        assert!(
+            !c.detail.contains("is a floating name"),
+            "must not assert the claim it is declining to make: {}",
+            c.detail
+        );
+    }
+
+    /// AC4, and the guard against re-inventing a flag. `curie cluster up` has
+    /// no `--model` (that flag belongs to `skill up`); the release default is
+    /// set with `--set agentSandbox.runner.model=`. A fix string naming a flag
+    /// that does not exist fails for whoever pastes it, which is the exact
+    /// defect #1813 was filed for. Every shape that can emit a fix is swept,
+    /// so a new branch cannot slip past this.
+    #[test]
+    fn every_model_pin_fix_is_a_bare_runnable_command() {
+        // Flags `ClusterAction` really declares for each verb. Anything else in
+        // an emitted fix is invented.
+        let declared = |verb: &str| -> &'static [&'static str] {
+            match verb {
+                "up" => &["--namespace", "--release", "--set"],
+                "overrides" => &["--model"],
+                other => panic!("fix names an unknown `curie cluster` verb: {other}"),
+            }
+        };
+
+        let mut shapes: Vec<Facts> = Vec::new();
+        for id in [
+            "claude-sonnet-5",           // floating -- emits a fix
+            "claude-haiku-4-5-20251001", // pinned -- must not
+            "glm-4-0520",                // unrecognised -- must not
+        ] {
+            for target in [None, Some(("acme".to_string(), "acme-bot".to_string()))] {
+                shapes.push(Facts {
+                    model_agent_overrides: vec![("bot".into(), id.into())],
+                    target: target.clone(),
+                    ..wired()
+                });
+                shapes.push(Facts {
+                    model_release_default: Some(id.into()),
+                    target: target.clone(),
+                    ..wired()
+                });
+                // The same source on the branch a --local-model install takes.
+                // Its fix names a different key and must still be runnable.
+                shapes.push(Facts {
+                    model_release_default: Some(id.into()),
+                    model_release_key: Some(ReleaseModelKey::Inference),
+                    target: target.clone(),
+                    ..wired()
+                });
+                shapes.push(Facts {
+                    model_shell: Some(id.into()),
+                    target,
+                    ..wired()
+                });
+            }
+        }
+
+        let mut saw_a_fix = false;
+        for f in shapes {
+            let c = model_pin(&f);
+            let Some(fix) = c.fix.as_deref() else {
+                continue;
+            };
+            saw_a_fix = true;
+            assert!(
+                fix.starts_with("curie ") || fix.starts_with("export "),
+                "a fix must be a command someone can paste, got {fix:?}"
+            );
+            assert!(
+                !fix.contains('('),
+                "prose in a fix string makes it unrunnable -- move it to the \
+                 detail: {fix:?}"
+            );
+            if let Some(rest) = fix.strip_prefix("curie cluster ") {
+                let verb = rest.split_whitespace().next().unwrap_or_default();
+                let allowed = declared(verb);
+                for flag in fix.split_whitespace().filter(|t| t.starts_with("--")) {
+                    assert!(
+                        allowed.contains(&flag),
+                        "`curie cluster {verb}` does not declare {flag}: {fix:?}"
+                    );
+                }
+            }
+        }
+        assert!(
+            saw_a_fix,
+            "the sweep exercised no fix-emitting shape at all"
+        );
+    }
+
+    /// #1358 item 1: every other doctor fix omits the --namespace/--release the
+    /// run was invoked with, so pasting one operates on curie/curie instead of
+    /// the release just diagnosed. This check's fix must not repeat that.
+    #[test]
+    fn the_release_fix_names_the_real_namespace_and_release() {
+        let f = Facts {
+            model_release_default: Some("claude-sonnet-5".into()),
+            target: Some(("acme".into(), "acme".into())),
+            ..wired()
+        };
+        let fix = model_pin(&f).fix.expect("a floating default carries a fix");
+        assert!(
+            fix.contains("--namespace acme --release acme"),
+            "the fix must target the release doctor actually looked at: {fix}"
+        );
+        assert!(
+            fix.contains("agentSandbox.runner.model="),
+            "must name the key that actually sets the release default: {fix}"
+        );
+    }
+
+    /// A `curie cluster up --local-model` install. The chart IGNORES
+    /// `agentSandbox.runner.model` while the in-cluster inference service is
+    /// deployed -- `helm template --set inference.deploy=true --set
+    /// inference.model=qwen3:4b` renders exactly one `CURIE_MODEL`, and its
+    /// value is `qwen3:4b`. So the label naming the runner key would name a key
+    /// that is not in force, and the fix would print a `--set` that CANNOT
+    /// change the model the sandboxes boot: a command that does nothing is not
+    /// a fix (AC1, AC4).
+    #[test]
+    fn a_local_inference_release_names_the_key_that_is_in_force() {
+        let f = Facts {
+            model_release_default: Some("qwen3:4b".into()),
+            model_release_key: Some(ReleaseModelKey::Inference),
+            target: Some(("curie".into(), "curie".into())),
+            ..wired()
+        };
+        let c = model_pin(&f);
+        assert_eq!(c.state, State::Ok, "{}", c.detail);
+        assert!(c.detail.contains("qwen3:4b"), "{}", c.detail);
+        assert!(
+            c.detail.contains("release default inference.model"),
+            "the label must name the key the chart actually reads: {}",
+            c.detail
+        );
+        assert!(
+            !c.detail.contains("agentSandbox.runner.model"),
+            "the runner key is not in force on this install and naming it \
+             sends the operator to a value the chart ignores: {}",
+            c.detail
+        );
+        let fix = c
+            .fix
+            .expect("qwen3:4b is a floating name and carries a fix");
+        assert!(
+            fix.contains("--set inference.model=<dated-snapshot-id>"),
+            "the fix has to set the key in force: {fix}"
+        );
+        assert!(
+            !fix.contains("agentSandbox.runner.model"),
+            "this --set changes nothing while inference is deployed: {fix}"
+        );
+    }
+
+    /// The other side of the same branch, so the fix for the ordinary install
+    /// cannot regress into naming the inference key.
+    #[test]
+    fn a_default_release_still_names_the_runner_key() {
+        let f = Facts {
+            model_release_default: Some("claude-sonnet-5".into()),
+            model_release_key: Some(ReleaseModelKey::Runner),
+            target: Some(("curie".into(), "curie".into())),
+            ..wired()
+        };
+        let c = model_pin(&f);
+        assert!(
+            c.detail
+                .contains("release default agentSandbox.runner.model"),
+            "{}",
+            c.detail
+        );
+        assert!(!c.detail.contains("inference.model"), "{}", c.detail);
+        let fix = c.fix.expect("a floating default carries a fix");
+        assert!(
+            fix.contains("--set agentSandbox.runner.model=<dated-snapshot-id>"),
+            "{fix}"
+        );
+        assert!(!fix.contains("--set inference.model"), "{fix}");
+    }
+
+    /// Helm decides which key is live by Go template truthiness, not by
+    /// `as_bool`. A value that arrives as a string -- a generic
+    /// `--set-string inference.deploy=true`, or anything that round-trips
+    /// through a values file as one -- sends Helm down the inference branch,
+    /// and a doctor that demanded a real boolean went down the other one and
+    /// reported a model the pod does not boot.
+    ///
+    /// The string `"false"` being truthy looks like a bug and is not: Go calls
+    /// a non-empty string non-empty whatever it spells, so the chart takes the
+    /// inference branch there too. Mirroring the wrong-looking half is the
+    /// whole point -- doctor has to agree with Helm, not with intuition.
+    #[test]
+    fn inference_deploy_follows_helm_truthiness() {
+        let with_deploy = |deploy: serde_json::Value| {
+            runner_model_from_values(&serde_json::json!({
+                "inference": { "deploy": deploy, "model": "qwen3:4b" },
+                "agentSandbox": { "runner": { "model": "claude-sonnet-5" } }
+            }))
+        };
+
+        for truthy in [
+            serde_json::json!(true),
+            serde_json::json!("true"),
+            serde_json::json!("false"),
+            serde_json::json!("0"),
+            serde_json::json!(1),
+        ] {
+            assert_eq!(
+                with_deploy(truthy.clone()),
+                Some(("qwen3:4b".to_string(), ReleaseModelKey::Inference)),
+                "helm renders the inference branch for {truthy}, so this must too"
+            );
+        }
+
+        for falsey in [
+            serde_json::json!(false),
+            serde_json::json!(0),
+            serde_json::json!(""),
+            serde_json::json!(null),
+            // Go's `empty` calls an empty list and an empty map empty too, and
+            // `classify_existing_secret_field` in `github_app.rs` already
+            // reads them that way. The two copies of this ladder must agree.
+            serde_json::json!([]),
+            serde_json::json!({}),
+        ] {
+            assert_eq!(
+                with_deploy(falsey.clone()),
+                Some(("claude-sonnet-5".to_string(), ReleaseModelKey::Runner)),
+                "helm skips the inference branch for {falsey}, so this must too"
+            );
+        }
+
+        // Absent entirely -- the shape of every install that never asked for
+        // local inference.
+        assert_eq!(
+            runner_model_from_values(&serde_json::json!({
+                "agentSandbox": { "runner": { "model": "claude-sonnet-5" } }
+            })),
+            Some(("claude-sonnet-5".to_string(), ReleaseModelKey::Runner))
+        );
+    }
+
+    /// The chart's SHIPPED DEFAULTS render `CURIE_FAKE_MODEL=1` and
+    /// `CURIE_MODEL=claude-sonnet-5` at once, off two independent template
+    /// arms (`charts/curie/templates/agent-sandbox.yaml`, verified with `helm
+    /// template`). Before this, doctor read the id and announced it as the
+    /// model in force from the release default, on an install whose sandboxes
+    /// never send it anywhere -- the same "names a model the pod does not
+    /// boot" defect #1950 exists to kill.
+    ///
+    /// The id stays in the detail and the state stays `Ok`: the id IS what
+    /// applies the moment fake model is turned off, and the credential story
+    /// belongs to the separate `model-credential` check.
+    #[test]
+    fn a_fake_model_release_says_the_configured_id_is_not_in_use() {
+        let f = Facts {
+            model_release_default: Some("claude-sonnet-5".into()),
+            model_release_key: Some(ReleaseModelKey::Runner),
+            model_release_fake: true,
+            target: Some(("curie".into(), "curie".into())),
+            ..wired()
+        };
+        let c = model_pin(&f);
+        assert_eq!(
+            c.state,
+            State::Ok,
+            "a fake-model install is not broken: {}",
+            c.detail
+        );
+        assert!(
+            c.detail.contains("scripted fake model") && c.detail.contains("not in use"),
+            "the detail must say the pod boots the fake model instead: {}",
+            c.detail
+        );
+        assert!(
+            c.detail.contains("claude-sonnet-5"),
+            "the id is not suppressed -- it applies the moment fake model is \
+             turned off: {}",
+            c.detail
+        );
+        assert_eq!(
+            c.fix.as_deref(),
+            Some(
+                "curie cluster up --namespace curie --release curie \
+                 --set agentSandbox.runner.model=<dated-snapshot-id>"
+            ),
+            "the fix is unchanged by the fake-model caveat"
+        );
+    }
+
+    /// The negative control for the test above: the ordinary release, boots
+    /// what it names. A caveat that shows up here would tell every real
+    /// install its model is not in use.
+    #[test]
+    fn a_real_model_release_carries_no_fake_model_clause() {
+        let f = Facts {
+            model_release_default: Some("claude-sonnet-5".into()),
+            model_release_key: Some(ReleaseModelKey::Runner),
+            model_release_fake: false,
+            target: Some(("curie".into(), "curie".into())),
+            ..wired()
+        };
+        assert!(
+            !model_pin(&f).detail.contains("scripted fake model"),
+            "{}",
+            model_pin(&f).detail
+        );
+    }
+
+    /// `agent-sandbox.yaml:482` gates `CURIE_FAKE_MODEL` on
+    /// `and $runner.fakeModel (not .Values.inference.deploy)`, so a release
+    /// deploying in-cluster inference boots the real local model even with
+    /// `fakeModel: true` still sitting in its values. Reading the flag alone
+    /// would caveat an install that has nothing to caveat.
+    ///
+    /// Asserted at the values level, because that is where the two-legged
+    /// branch lives; `gather` does nothing but hand this its computed values.
+    #[test]
+    fn local_inference_beats_the_fake_model_flag() {
+        let with = |fake: serde_json::Value, deploy: serde_json::Value| {
+            release_fake_model(&serde_json::json!({
+                "inference": { "deploy": deploy, "model": "qwen3:4b" },
+                "agentSandbox": { "runner": { "fakeModel": fake } }
+            }))
+        };
+        assert!(
+            with(serde_json::json!(true), serde_json::json!(false)),
+            "fakeModel with no inference deployed IS the fake-model shape"
+        );
+        assert!(
+            !with(serde_json::json!(true), serde_json::json!(true)),
+            "the chart omits CURIE_FAKE_MODEL when inference is deployed"
+        );
+        assert!(
+            !with(serde_json::json!(false), serde_json::json!(false)),
+            "no fakeModel, no caveat"
+        );
+        // Both legs are Go-truthy, not `as_bool`: a `--set-string` round trip
+        // stores either as a string and Helm still takes the branch.
+        assert!(
+            with(serde_json::json!("true"), serde_json::json!("")),
+            "a string fakeModel is truthy to Helm, so it must be here too"
+        );
+        // Neither key present at all -- an older release, or a values file
+        // that never mentioned the runner.
+        assert!(!release_fake_model(&serde_json::json!({})));
+    }
+
+    /// The caveat is about the RELEASE source only. A shell `CURIE_MODEL` is
+    /// forwarded at sandbox boot whatever the chart's fake-model arm renders,
+    /// so attaching the caveat to it would be a claim about a value the chart
+    /// never produced.
+    #[test]
+    fn a_shell_model_carries_no_fake_model_clause() {
+        let f = Facts {
+            model_shell: Some("claude-sonnet-5".into()),
+            model_release_default: None,
+            model_release_key: None,
+            model_release_fake: true,
+            target: Some(("curie".into(), "curie".into())),
+            ..wired()
+        };
+        let c = model_pin(&f);
+        assert!(
+            !c.detail.contains("scripted fake model"),
+            "the release's fake-model flag says nothing about a shell value: {}",
+            c.detail
+        );
+    }
+
+    /// The per-agent override outranks every other source, and `doctor` run
+    /// without --api-url/--api-key cannot see it. Before this, an install with
+    /// a pinned release default and an agent quietly carrying a floating
+    /// override reported clean with no fix -- the exact failure this check
+    /// exists to catch. `Facts::agents` already distinguishes "not reached"
+    /// from "reached, none set", so the report says which one it is instead of
+    /// claiming an absence it never looked for.
+    #[test]
+    fn an_unreadable_platform_api_is_said_out_loud() {
+        let unreachable = Facts {
+            model_release_default: Some("claude-haiku-4-5-20251001".into()),
+            model_release_key: Some(ReleaseModelKey::Runner),
+            target: Some(("curie".into(), "curie".into())),
+            agents: None,
+            ..wired()
+        };
+        let c = model_pin(&unreachable);
+        assert_eq!(
+            c.state,
+            State::Ok,
+            "absent is not broken -- the honesty belongs in the detail: {}",
+            c.detail
+        );
+        assert!(
+            c.detail.contains("could not be read"),
+            "a pinned report that never looked at the highest-precedence \
+             source has to say so: {}",
+            c.detail
+        );
+        assert!(
+            c.detail.contains("platform API"),
+            "and say WHY it could not look: {}",
+            c.detail
+        );
+
+        // Reached, and genuinely nothing set. Repeating the caveat here would
+        // train the operator to ignore it on the runs where it is true.
+        let reached = Facts {
+            agents: Some(vec![]),
+            ..unreachable.clone()
+        };
+        assert!(
+            !model_pin(&reached).detail.contains("could not be read"),
+            "the API WAS reached: {}",
+            model_pin(&reached).detail
+        );
+
+        // An override in force IS the highest-precedence source, so there is
+        // nothing unread to warn about.
+        let from_an_agent = Facts {
+            model_agent_overrides: vec![("bot".into(), "claude-sonnet-5".into())],
+            ..unreachable
+        };
+        assert!(
+            !model_pin(&from_an_agent)
+                .detail
+                .contains("could not be read"),
+            "{}",
+            model_pin(&from_an_agent).detail
+        );
+    }
+
+    /// The same blindness on the not-applicable branch. "no per-agent
+    /// override" is a claim, and it is false whenever the API was never
+    /// reached to look.
+    #[test]
+    fn a_total_absence_does_not_claim_there_are_no_overrides() {
+        let c = model_pin(&Facts::default());
+        assert_eq!(c.state, State::NotApplicable);
+        assert!(
+            c.detail.contains("could not be read"),
+            "must not assert an absence it never looked for: {}",
+            c.detail
+        );
+
+        let reached = Facts {
+            agents: Some(vec![]),
+            ..Default::default()
+        };
+        let c = model_pin(&reached);
+        assert_eq!(c.state, State::NotApplicable);
+        assert!(
+            c.detail.contains("no per-agent override"),
+            "the API was reached, so the absence is a real observation: {}",
+            c.detail
+        );
+    }
+
+    /// #229's footgun, now at three sources instead of one. An agent row with
+    /// `model: ""` would otherwise win precedence and resolve to Unset,
+    /// producing exactly the `not_applicable` AC2 forbids -- on an install
+    /// whose release default is a floating alias.
+    #[test]
+    fn an_empty_value_at_any_source_never_wins_precedence() {
+        let f = Facts {
+            model_agent_overrides: vec![("bot".into(), "   ".into())],
+            model_release_default: Some(String::new()),
+            model_shell: Some("claude-sonnet-5".into()),
+            target: Some(("curie".into(), "curie".into())),
+            ..wired()
+        };
+        let r = resolve_model(&f).expect("the shell value is a real model");
+        assert_eq!(r.id, "claude-sonnet-5");
+        assert!(matches!(r.source, ModelSource::Shell));
+        let c = model_pin(&f);
+        assert_eq!(c.state, State::Ok, "{}", c.detail);
+        assert!(
+            !c.detail.contains("bot"),
+            "an empty override is not an override and must not be reported as \
+             one: {}",
+            c.detail
+        );
+
+        let all_blank = Facts {
+            model_agent_overrides: vec![("bot".into(), String::new())],
+            model_release_default: Some("  ".into()),
+            model_shell: Some("".into()),
+            ..Default::default()
+        };
+        assert_eq!(model_pin(&all_blank).state, State::NotApplicable);
+    }
+
+    /// Two agents on the same model is the ordinary shape of a multi-agent
+    /// install, not a disagreement. Listing the second one would train the
+    /// operator to ignore the disagreement clause on the runs where it matters.
+    #[test]
+    fn several_agents_on_the_same_model_are_not_a_disagreement() {
+        let f = Facts {
+            model_agent_overrides: vec![
+                ("beta".into(), "claude-sonnet-5".into()),
+                ("alpha".into(), "claude-sonnet-5".into()),
+            ],
+            target: Some(("curie".into(), "curie".into())),
+            ..wired()
+        };
+        let r = resolve_model(&f).expect("a model is in force");
+        assert_eq!(r.id, "claude-sonnet-5");
+        assert!(
+            matches!(&r.source, ModelSource::Agent(name) if name == "alpha"),
+            "ties break on name ascending so the report is stable across runs"
+        );
+        assert!(
+            r.disagreeing.is_empty(),
+            "an identical id is not a disagreement: {:?}",
+            r.disagreeing
+        );
+        assert!(
+            !model_pin(&f).detail.contains("disagree"),
+            "{}",
+            model_pin(&f).detail
+        );
+    }
+
+    /// When the override, the release default and the shell all agree there is
+    /// nothing to append -- and a detail ending in a dangling
+    /// "other sources disagree:" with nothing after it reads as a truncated
+    /// report and sends someone looking for a problem that is not there.
+    #[test]
+    fn agreement_across_sources_leaves_no_dangling_disagreement_clause() {
+        let f = Facts {
+            model_agent_overrides: vec![("bot".into(), "claude-sonnet-5".into())],
+            model_release_default: Some("claude-sonnet-5".into()),
+            model_shell: Some("claude-sonnet-5".into()),
+            target: Some(("curie".into(), "curie".into())),
+            ..wired()
+        };
+        let r = resolve_model(&f).expect("a model is in force");
+        assert!(
+            r.disagreeing.is_empty(),
+            "nothing disagrees: {:?}",
+            r.disagreeing
+        );
+        let detail = model_pin(&f).detail;
+        assert!(
+            !detail.contains("disagree"),
+            "no disagreement clause at all when nothing disagrees: {detail}"
+        );
+        assert!(
+            !detail.trim_end().ends_with(':'),
+            "a detail must never end on a dangling clause: {detail}"
+        );
+    }
+
+    /// The direction this check must NOT fail in. A correctly pinned snapshot
+    /// in force is not a problem, even while a floating alias sits at a source
+    /// that loses precedence: the alias is worth surfacing in the disagreement
+    /// list, and emitting a fix for an install that is already pinned is how a
+    /// doctor teaches people to ignore it.
+    #[test]
+    fn a_pinned_id_in_force_emits_no_fix_even_beside_a_floating_alias() {
+        let f = Facts {
+            model_agent_overrides: vec![("bot".into(), "claude-haiku-4-5-20251001".into())],
+            model_release_default: Some("claude-sonnet-5".into()),
+            target: Some(("curie".into(), "curie".into())),
+            ..wired()
+        };
+        let c = model_pin(&f);
+        assert_eq!(c.state, State::Ok, "{}", c.detail);
+        assert!(
+            c.fix.is_none(),
+            "the model in force is already a dated snapshot: {:?}",
+            c.fix
+        );
+        assert!(
+            c.detail.contains("snapshot 20251001"),
+            "the pinned spelling is load-bearing: {}",
+            c.detail
+        );
+        assert!(
+            c.detail.contains("claude-sonnet-5"),
+            "the floating alias still has to be visible: {}",
+            c.detail
+        );
+    }
+
+    /// The pure half of the release-default probe: `gather()` cannot reach it
+    /// without a live cluster, so the path walk is unit-tested against a
+    /// hand-built computed-values document instead. Empty and absent both read
+    /// as "no default observed" -- see the blank-value case above for why.
+    ///
+    /// It is NOT a single path. `charts/curie/templates/agent-sandbox.yaml`
+    /// renders exactly one `CURIE_MODEL` env entry and picks its value on a
+    /// branch: `inference.model` when `inference.deploy` is true, otherwise
+    /// `agentSandbox.runner.model`. This function has to reproduce that branch
+    /// or it names a model the pod never boots.
+    #[test]
+    fn runner_model_from_values_reads_the_chart_path() {
+        let values = serde_json::json!({
+            "agentSandbox": { "runner": { "model": "claude-sonnet-5" } }
+        });
+        assert_eq!(
+            runner_model_from_values(&values),
+            Some(("claude-sonnet-5".to_string(), ReleaseModelKey::Runner))
+        );
+
+        // `curie cluster up --local-model` produces exactly this shape, and the
+        // sandbox then boots `qwen3:4b` against the in-cluster inference
+        // service -- `agentSandbox.runner.model` is not used for the boot env
+        // on this branch at all. Reporting `claude-sonnet-5` here would name a
+        // model the install never runs, which is the AC1 failure.
+        assert_eq!(
+            runner_model_from_values(&serde_json::json!({
+                "inference": { "deploy": true, "model": "qwen3:4b" },
+                "agentSandbox": { "runner": { "model": "claude-sonnet-5" } }
+            })),
+            Some(("qwen3:4b".to_string(), ReleaseModelKey::Inference)),
+            "the in-cluster inference model wins when inference.deploy is true"
+        );
+
+        // The chart's own default. `inference.model` is populated in
+        // values.yaml whether or not inference is deployed, so a read that
+        // ignored `deploy` would report `qwen3:4b` on every ordinary install.
+        assert_eq!(
+            runner_model_from_values(&serde_json::json!({
+                "inference": { "deploy": false, "model": "qwen3:4b" },
+                "agentSandbox": { "runner": { "model": "claude-sonnet-5" } }
+            })),
+            Some(("claude-sonnet-5".to_string(), ReleaseModelKey::Runner)),
+            "deploy:false must not let inference.model win"
+        );
+
+        // #229's empty-value footgun on the inference branch: an empty string
+        // is not a configured model anywhere else in this code, so it falls
+        // through rather than resolving to Unset and reporting not-applicable
+        // on an install that boots something.
+        assert_eq!(
+            runner_model_from_values(&serde_json::json!({
+                "inference": { "deploy": true, "model": "" },
+                "agentSandbox": { "runner": { "model": "claude-sonnet-5" } }
+            })),
+            Some(("claude-sonnet-5".to_string(), ReleaseModelKey::Runner)),
+            "an empty inference.model is not a configured model"
+        );
+
+        // A local-model install need not carry an agentSandbox block at all in
+        // the computed values; the inference branch stands on its own.
+        assert_eq!(
+            runner_model_from_values(&serde_json::json!({
+                "inference": { "deploy": true, "model": "qwen3:4b" }
+            })),
+            Some(("qwen3:4b".to_string(), ReleaseModelKey::Inference)),
+            "the inference branch must not require agentSandbox to be present"
+        );
+
+        assert_eq!(runner_model_from_values(&serde_json::json!({})), None);
+        assert_eq!(
+            runner_model_from_values(&serde_json::json!({
+                "agentSandbox": { "runner": { "model": "" } }
+            })),
+            None
+        );
+        assert_eq!(
+            runner_model_from_values(&serde_json::json!({
+                "agentSandbox": { "runner": {} }
+            })),
+            None
+        );
+    }
+
+    /// The coupling this check depends on and cannot see: doctor reads the
+    /// model out of the release's computed values, and if the chart ever
+    /// renames that path the check goes quietly blind again -- reporting "no
+    /// model determined" on an install that boots one. Reading the shipped
+    /// values.yaml means a rename breaks this test instead.
+    ///
+    /// The `inference.deploy` assertion is the other half: it is what makes
+    /// `agentSandbox.runner.model` the live source on a default install today.
+    /// If the chart ever flips that default, this branch of
+    /// `runner_model_from_values` changes which key is authoritative, and the
+    /// test should say so rather than the check silently reporting the wrong
+    /// source.
+    #[test]
+    fn the_chart_still_ships_a_model_at_the_path_doctor_reads() {
+        let path =
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../charts/curie/values.yaml");
+        let raw = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("the shipped chart values must be readable: {e}"));
+        let values: serde_json::Value =
+            serde_norway::from_str(&raw).expect("the shipped chart values must parse");
+
+        assert_eq!(
+            values
+                .get("inference")
+                .and_then(|i| i.get("deploy"))
+                .and_then(serde_json::Value::as_bool),
+            Some(false),
+            "the chart must still default inference.deploy to false -- that is \
+             what makes agentSandbox.runner.model the model a default install \
+             actually boots"
+        );
+
+        let (model, key) = runner_model_from_values(&values).unwrap_or_else(|| {
+            panic!(
+                "the chart no longer ships a model at either path curie doctor \
+                 reads: inference.model when inference.deploy, else \
+                 agentSandbox.runner.model"
+            )
+        });
+        assert!(!model.trim().is_empty(), "{model:?}");
+        assert_eq!(
+            key,
+            ReleaseModelKey::Runner,
+            "with inference.deploy false the shipped default must come from \
+             agentSandbox.runner.model, which is the key the fix names"
+        );
     }
 
     /// Every failing check must be actionable. A report that says "missing"
@@ -833,6 +2189,278 @@ mod tests {
             find(&checks, "webhook").detail
         );
     }
+
+    // -- gather(), driven ------------------------------------------------
+    //
+    // Env mutation is process-global, so this reuses the save/clear/restore
+    // idiom already in this crate (`cli/src/installation.rs`'s `diff_tests`)
+    // rather than inventing a second one. `CURIE_MODEL` is read by
+    // `installation.rs`'s planner as well as by `gather()`, so a test that
+    // sets it must serialise against every other env-mutating test in the
+    // crate, not just its own file's -- hence the crate-wide
+    // `crate::PROCESS_ENV_LOCK` rather than a lock private to this file. The
+    // lock is held for the whole test so a parallel test cannot observe the
+    // mutated variable.
+
+    struct ModelEnvRestore(Vec<(&'static str, Option<std::ffi::OsString>)>);
+
+    impl ModelEnvRestore {
+        fn clear(names: &[&'static str]) -> Self {
+            let saved = names
+                .iter()
+                .map(|name| (*name, std::env::var_os(*name)))
+                .collect();
+            for name in names {
+                std::env::remove_var(*name);
+            }
+            Self(saved)
+        }
+
+        fn set(&self, name: &str, value: &str) {
+            std::env::set_var(name, value);
+        }
+    }
+
+    impl Drop for ModelEnvRestore {
+        fn drop(&mut self) {
+            for (name, value) in &self.0 {
+                match value {
+                    Some(value) => std::env::set_var(*name, value),
+                    None => std::env::remove_var(*name),
+                }
+            }
+        }
+    }
+
+    /// AC5. Before this, deleting the entire model wiring from `gather()` left
+    /// 20 doctor tests, 7 modelpin tests and both contract tests green --
+    /// `gather()` had no coverage anywhere in the repo, so the check was
+    /// judged only on facts a test handed it. This drives the real function.
+    ///
+    /// No cluster is needed: `gather()` returns early when
+    /// `kubectl config current-context` is unavailable or empty, and both the
+    /// shell read and the target record happen before that point. Setting
+    /// `f.model_shell = None` or dropping the `f.target` assignment at the
+    /// probe site must fail this test.
+    #[tokio::test]
+    async fn gather_reads_the_shell_model_and_records_the_target() {
+        let _lock = crate::PROCESS_ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let names = [curie_aci_protocol::env_keys::CURIE_MODEL];
+        let env = ModelEnvRestore::clear(&names);
+        env.set(
+            curie_aci_protocol::env_keys::CURIE_MODEL,
+            "some-model-20250101",
+        );
+
+        let f = gather("ns", "rel", None).await;
+
+        assert_eq!(
+            f.model_shell.as_deref(),
+            Some("some-model-20250101"),
+            "gather() must actually read CURIE_MODEL from the environment"
+        );
+        assert_eq!(
+            f.target,
+            Some(("ns".to_string(), "rel".to_string())),
+            "the namespace and release doctor was invoked with are facts about \
+             the run, and the model-pin fix string is built from them"
+        );
+    }
+
+    // -- gather(), driven against a stubbed cluster ----------------------
+    //
+    // The test above returns early at `kubectl config current-context`, so it
+    // cannot see a single helm read. The release default is read from the
+    // COMPUTED values (`helm get values --all`), which is the source #1950 was
+    // blind to, so it needs a cluster that answers. Rather than a real one,
+    // fake `kubectl`/`helm`/`docker` executables go on `PATH` -- the same
+    // harness shape `cli/src/ops.rs`'s cluster-diagnosis tests already use.
+
+    /// `kubectl` for a reachable cluster: a context name, and nothing else.
+    /// The NodePort probe is deliberately left failing -- `gather()` reads an
+    /// unavailable Service as "not exposed that way", which keeps this harness
+    /// about the model reads.
+    const KUBECTL_STUB: &str = r#"#!/bin/sh
+case "$*" in
+  "config current-context") printf '%s\n' 'doctor-stub-context' ;;
+  *) printf 'unexpected kubectl invocation: %s\n' "$*" >&2; exit 64 ;;
+esac
+"#;
+
+    /// `helm` for an installed release. The `--all` arm is the load-bearing
+    /// one: those are the COMPUTED values, the only read in which a chart
+    /// default the operator never supplied is visible at all.
+    const HELM_STUB: &str = r#"#!/bin/sh
+case "$*" in
+  list*) printf '%s\n' "$CURIE_TEST_DOCTOR_HELM_LIST" ;;
+  *"--all"*) printf '%s\n' "$CURIE_TEST_DOCTOR_HELM_COMPUTED" ;;
+  "get values"*) printf '%s\n' "$CURIE_TEST_DOCTOR_HELM_VALUES" ;;
+  *) printf 'unexpected helm invocation: %s\n' "$*" >&2; exit 64 ;;
+esac
+"#;
+
+    fn write_executable(path: &std::path::Path, body: &str) {
+        std::fs::write(path, body).expect("write fake cluster executable");
+        use std::os::unix::fs::PermissionsExt;
+        let mut permissions = std::fs::metadata(path)
+            .expect("read fake cluster executable metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(path, permissions).expect("make fake cluster executable runnable");
+    }
+
+    /// Fake `kubectl`, `helm` and `docker` on `PATH`, plus the variables their
+    /// bodies read, so `gather()` can be driven all the way through its
+    /// cluster reads without a cluster.
+    ///
+    /// `PATH` and those variables are process-global, so a caller must hold
+    /// `crate::PROCESS_ENV_LOCK` for as long as this guard lives. Every
+    /// variable is saved and restored in `Drop`, which runs on the unwind of a
+    /// failed assertion exactly as it does on a clean return -- a panicking
+    /// test therefore cannot leak a fake `helm` into the rest of the suite.
+    /// Each variable is overwritten in place rather than cleared first, so
+    /// `PATH` is never momentarily absent.
+    struct StubbedCluster {
+        restore: Vec<(&'static str, Option<std::ffi::OsString>)>,
+        // Declared last so the stub directory is removed only after `Drop`
+        // above has already taken the stubs back off `PATH`.
+        _tools: tempfile::TempDir,
+    }
+
+    impl StubbedCluster {
+        /// `computed` is what `helm get values --all` returns: the chart's own
+        /// defaults merged with the operator's overrides, which is the read
+        /// `Facts::model_release_default` is fed from.
+        fn install(computed: &str) -> Self {
+            let tools = tempfile::tempdir().expect("create fake cluster tool directory");
+            write_executable(&tools.path().join("docker"), "#!/bin/sh\nexit 0\n");
+            write_executable(&tools.path().join("kubectl"), KUBECTL_STUB);
+            write_executable(&tools.path().join("helm"), HELM_STUB);
+
+            let mut entries = vec![tools.path().to_path_buf()];
+            entries.extend(std::env::split_paths(
+                &std::env::var_os("PATH").unwrap_or_default(),
+            ));
+            let path = std::env::join_paths(entries).expect("join the stub directory onto PATH");
+
+            let assignments: [(&'static str, std::ffi::OsString); 4] = [
+                ("PATH", path),
+                (
+                    "CURIE_TEST_DOCTOR_HELM_LIST",
+                    r#"[{"name":"rel","chart":"curie-0.6.0"}]"#.into(),
+                ),
+                ("CURIE_TEST_DOCTOR_HELM_COMPUTED", computed.into()),
+                // What the OPERATOR supplied. Empty on purpose: the whole
+                // point of the computed read is that a release whose operator
+                // supplied nothing still boots a model.
+                ("CURIE_TEST_DOCTOR_HELM_VALUES", "{}".into()),
+            ];
+            let restore = assignments
+                .iter()
+                .map(|(name, _)| (*name, std::env::var_os(*name)))
+                .collect();
+            for (name, value) in &assignments {
+                std::env::set_var(name, value);
+            }
+            Self {
+                restore,
+                _tools: tools,
+            }
+        }
+    }
+
+    impl Drop for StubbedCluster {
+        fn drop(&mut self) {
+            for (name, value) in &self.restore {
+                match value {
+                    Some(value) => std::env::set_var(name, value),
+                    None => std::env::remove_var(name),
+                }
+            }
+        }
+    }
+
+    /// AC5, the release leg. Pins the paired
+    /// `f.model_release_default` / `f.model_release_key` assignment in
+    /// `gather()` that `crate::ops::fetch_release_computed_values` feeds.
+    /// Deleting either half of that assignment, or switching the read back to
+    /// `fetch_release_values` (the operator-supplied values, where a chart
+    /// default nobody set is invisible -- the #1950 defect), must fail this
+    /// test. The shell-model test above cannot catch any of that: it returns
+    /// early at the kubectl context probe, before a single helm read.
+    #[tokio::test]
+    async fn gather_reads_the_release_default_model_from_computed_helm_values() {
+        let _lock = crate::PROCESS_ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _cluster = StubbedCluster::install(
+            r#"{"agentSandbox":{"runner":{"model":"chart-default-model-20250101"}}}"#,
+        );
+
+        let f = gather("ns", "rel", None).await;
+
+        assert_eq!(
+            f.release,
+            Some(("rel".to_string(), "curie-0.6.0".to_string())),
+            "the stubbed release was never read, so gather() bailed out before \
+             the model reads and the assertions below are judging nothing"
+        );
+        assert_eq!(
+            f.model_release_default.as_deref(),
+            Some("chart-default-model-20250101"),
+            "gather() must record the model from the release's COMPUTED helm \
+             values -- an operator who ran `curie cluster up` and never set a \
+             model supplied nothing, and that default is what the sandboxes boot"
+        );
+        assert_eq!(
+            f.model_release_key,
+            Some(ReleaseModelKey::Runner),
+            "the key must travel with the id: the chart reads one of two, and \
+             a fix naming the other one is a command that changes nothing"
+        );
+    }
+
+    /// AC5, the branch a `curie cluster up --local-model` install actually
+    /// renders. `agent-sandbox.yaml` ignores `agentSandbox.runner.model` while
+    /// `inference.deploy` is truthy, so both values are present in these
+    /// computed values and only the inference one is in force. Pins the same
+    /// `gather()` assignment as the test above, on the branch where a
+    /// hard-coded `ReleaseModelKey::Runner`, a dropped key assignment, or a
+    /// read that ignored `runner_model_from_values`'s precedence would all
+    /// report a model the pods do not boot.
+    #[tokio::test]
+    async fn gather_records_the_inference_model_and_key_on_a_local_model_install() {
+        let _lock = crate::PROCESS_ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _cluster = StubbedCluster::install(
+            r#"{"inference":{"deploy":true,"model":"local-inference-model"},"agentSandbox":{"runner":{"model":"chart-default-model-20250101"}}}"#,
+        );
+
+        let f = gather("ns", "rel", None).await;
+
+        assert_eq!(
+            f.release,
+            Some(("rel".to_string(), "curie-0.6.0".to_string())),
+            "the stubbed release was never read, so gather() bailed out before \
+             the model reads and the assertions below are judging nothing"
+        );
+        assert_eq!(
+            f.model_release_default.as_deref(),
+            Some("local-inference-model"),
+            "while inference.deploy is truthy the chart renders inference.model \
+             and ignores the runner key, so reporting the runner value would \
+             name a model no sandbox boots"
+        );
+        assert_eq!(
+            f.model_release_key,
+            Some(ReleaseModelKey::Inference),
+            "the fix string is built from this key, and `--set \
+             agentSandbox.runner.model=` on a --local-model install changes nothing"
+        );
+    }
 }
 
 // -- observation --------------------------------------------------------------
@@ -843,11 +2471,19 @@ pub async fn gather(namespace: &str, release: &str, api: Option<(&str, &str)>) -
     let mut f = Facts {
         docker_ok: probe_ok("docker", &["info"]).await,
         bundle_name: bundle_name(),
+        // What this run was pointed at, so the model-pin fix names the release
+        // just diagnosed rather than curie/curie (#1358 item 1).
+        target: Some((namespace.to_string(), release.to_string())),
         ..Default::default()
     };
 
-    // Names, never values: the id is the configuration, not a secret.
-    f.model_pin = std::env::var(curie_aci_protocol::env_keys::CURIE_MODEL).ok();
+    // Names, never values: the id is the configuration, not a secret. Blank is
+    // not a configured model (#229), and the filter is applied at every one of
+    // the three sources so an empty value cannot win precedence.
+    f.model_shell = std::env::var(curie_aci_protocol::env_keys::CURIE_MODEL)
+        .ok()
+        .map(|id| id.trim().to_string())
+        .filter(|id| !id.is_empty());
 
     for name in crate::commands::MODEL_CREDENTIAL_ENV_NAMES {
         if let Ok(value) = std::env::var(name) {
@@ -876,12 +2512,24 @@ pub async fn gather(namespace: &str, release: &str, api: Option<(&str, &str)>) -
     if let Some((url, key)) = api {
         if let Ok(client) = crate::api::ApiClient::new(url, key) {
             if let Ok(agents) = client.list_agents().await {
-                f.agents = Some(
-                    agents
-                        .into_iter()
-                        .map(|a| (a.name, a.repo_full_name))
-                        .collect(),
-                );
+                // One pass, two facts. The `(name, repo_full_name)` collection
+                // is the repo-binding check's input and stays exactly as it
+                // was; the per-agent model was previously discarded here, which
+                // is why the highest-precedence source was invisible (#1950).
+                let mut bindings = Vec::with_capacity(agents.len());
+                for a in agents {
+                    if let Some(model) = a
+                        .model
+                        .as_deref()
+                        .map(str::trim)
+                        .filter(|model| !model.is_empty())
+                    {
+                        f.model_agent_overrides
+                            .push((a.name.clone(), model.to_string()));
+                    }
+                    bindings.push((a.name, a.repo_full_name));
+                }
+                f.agents = Some(bindings);
             }
         }
     }
@@ -902,7 +2550,37 @@ pub async fn gather(namespace: &str, release: &str, api: Option<(&str, &str)>) -
     };
     f.release = Some((release.to_string(), chart));
 
-    if let Ok(Some(values)) = crate::ops::fetch_release_values(&common).await {
+    // Two SEPARATE reads, deliberately, issued CONCURRENTLY.
+    //
+    // Separate: `fetch_release_values` reports only what the operator supplied,
+    // so an operator who never set a model has nothing to read there and the
+    // chart default the sandboxes boot is invisible -- the #1950 defect.
+    // `--all` returns the computed values. The two stay apart because switching
+    // slack_configured, api.ingress.* or clone_credential onto computed values
+    // would silently change three unrelated checks.
+    //
+    // Concurrent: neither consumes the other's output and both depend only on
+    // `common`, so awaiting them in turn made every cluster run pay two helm
+    // spawns and two API-server round trips back to back for nothing. Each
+    // result keeps its own failure-tolerant handling below.
+    let (computed, values) = tokio::join!(
+        crate::ops::fetch_release_computed_values(&common),
+        crate::ops::fetch_release_values(&common),
+    );
+
+    if let Ok(Some(computed)) = computed {
+        // The key travels with the id: the chart reads one of two, and a fix
+        // naming the other one is a command that changes nothing.
+        if let Some((model, key)) = runner_model_from_values(&computed) {
+            f.model_release_default = Some(model);
+            f.model_release_key = Some(key);
+        }
+        // Off the SAME read, never a third helm call: whether that id is the
+        // one the pod actually boots.
+        f.model_release_fake = release_fake_model(&computed);
+    }
+
+    if let Ok(Some(values)) = values {
         let at = |path: &[&str]| -> Option<String> {
             let mut node = &values;
             for k in path {

--- a/cli/src/installation.rs
+++ b/cli/src/installation.rs
@@ -2072,8 +2072,11 @@ mod stateful_guard_message_tests {
 #[cfg(test)]
 mod diff_tests {
     use super::*;
-
-    static CREDENTIAL_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    // Env mutation is process-global: there must be exactly one lock domain
+    // guarding it, so this reuses the crate-wide lock (also taken by
+    // `doctor.rs`'s model-env test) instead of a lock private to this file.
+    // Named at every use site rather than aliased, so the single domain stays
+    // visible to whoever next reaches for a second one.
 
     struct CredentialEnvRestore(Vec<(&'static str, Option<std::ffi::OsString>)>);
 
@@ -2107,7 +2110,7 @@ mod diff_tests {
 
     #[test]
     fn shipped_curie_yaml_example_plans_for_apply() {
-        let _lock = CREDENTIAL_ENV_LOCK
+        let _lock = crate::PROCESS_ENV_LOCK
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         let names = ["ANTHROPIC_API_KEY", "SLACK_APP_TOKEN", "SLACK_BOT_TOKEN"];
@@ -2271,7 +2274,7 @@ mod diff_tests {
 
     #[test]
     fn every_lenient_desired_map_difference_is_disclosed_as_unknown() {
-        let _lock = CREDENTIAL_ENV_LOCK
+        let _lock = crate::PROCESS_ENV_LOCK
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         let names = [
@@ -2367,7 +2370,7 @@ mod diff_tests {
 
     #[tokio::test]
     async fn explicit_model_credential_set_survives_the_environment() {
-        let _lock = CREDENTIAL_ENV_LOCK
+        let _lock = crate::PROCESS_ENV_LOCK
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         let env = CredentialEnvRestore::clear(&["CURIE_MODEL_CREDENTIALS"]);
@@ -2405,7 +2408,7 @@ mod diff_tests {
 
     #[test]
     fn an_unresolved_declared_github_change_never_reports_zero_changes() {
-        let _lock = CREDENTIAL_ENV_LOCK
+        let _lock = crate::PROCESS_ENV_LOCK
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         let env = CredentialEnvRestore::clear(&["CURIE_1426_GITHUB_CREDENTIAL"]);

--- a/cli/src/modelpin.rs
+++ b/cli/src/modelpin.rs
@@ -22,6 +22,19 @@
 //! model id nobody fetched would be inventing data, and a stale hand-written
 //! catalog is worse than no catalog.
 //!
+//! **The rule is three-way, not two** (#1950). Pinned, floating, and
+//! *unrecognised*. The third arm exists because the second used to be a
+//! catch-all: any id whose shape [`dated_suffix`] could not parse was
+//! *asserted* to float. That mislabelled a whole class of ids that are fully
+//! pinned snapshots -- `glm-4-0520`, `kimi-k2-0711-preview`,
+//! `gemini-1.5-pro-002`, `mistral-large-2411`,
+//! `anthropic.claude-3-5-sonnet-20240620-v1:0`, `amazon.nova-pro-v1:0` -- in a
+//! spelling this rule has never seen. Calling those floating invents a fact, and the fix the check
+//! emitted for a floating name (`export CURIE_MODEL=<id>-YYYYMMDD`) produces an
+//! id every one of those providers rejects. Refusing to assert is the honest
+//! answer: `Unrecognized` carries no claim about whether the id moves and no
+//! advice about pinning it.
+//!
 //! Classification is a pure function of the id, so every case below is a unit
 //! test rather than a fixture.
 
@@ -95,6 +108,74 @@ pub enum PinStatus {
         /// The full model id.
         id: String,
     },
+    /// A shape this rule does not recognise. It carries a number, or an
+    /// explicit `v<digits>` version marker, that the rule cannot read as a
+    /// calendar date, so it is very likely a provider revision this rule has
+    /// never seen. Deliberately asserts nothing about whether the id moves.
+    Unrecognized {
+        /// The full model id.
+        id: String,
+    },
+}
+
+/// Whether the id carries a component this rule cannot interpret.
+///
+/// Split on every separator the providers in use here spell an id with -- `-`,
+/// `.`, `:`, `_`, `/` (the last covers the OpenRouter `vendor/model` form) --
+/// and look for a token in **either** of two shapes. Both mean the same thing:
+/// "a version lives in this id, and this rule cannot read which one".
+///
+/// - **A run of three or more ASCII digits and nothing else** (`002`, `0520`,
+///   `0711`, `2411`, `20240620`). Three is the threshold because a family or
+///   version digit is one or two (`claude-sonnet-5`, `qwen3`, `gpt-4o`,
+///   `llama-3.1`), while every observed provider revision suffix is three or
+///   more. A number that long, sitting where [`dated_suffix`] could not read it
+///   as a calendar date, is a revision spelling this rule has not seen.
+/// - **An explicit version marker: `v` followed by one or more ASCII digits and
+///   nothing else** (`v1`, `v2`, `v10`). This is the Bedrock scheme.
+///   `amazon.nova-pro-v1:0` is a concrete versioned id that AWS publishes
+///   alongside separately versioned siblings such as `v1:1`, and it is not
+///   silently repointed -- lifecycle migration is the caller's move, not the
+///   provider's. Its digit run is a single character, so the first shape misses
+///   it entirely and the id would be *asserted* to float; the `v` marker is the
+///   signal that says otherwise (#1950).
+///
+/// A token carrying any other character matches neither shape (`405b` is a
+/// parameter count, and `v20251001x` is a build tag rather than a marker,
+/// because the digits do not run to the end of the token). Both tests are
+/// deliberately exact rather than "contains digits".
+///
+/// The question this answers is "could this shape be carrying a revision or a
+/// date I cannot read?", not "is this id one of the five in #1950". It has two
+/// known limits, and neither is fail-safe -- each is a case the rule gets
+/// wrong, in a bounded and deliberate way:
+///
+/// - a hypothetical two-digit revision (`model-52`) still reads as floating, so
+///   the check still *asserts* something it cannot know for that shape. That is
+///   the pre-existing behaviour and a real limit, not a safe fallback;
+///   separating it from a family digit needs a signal shape alone does not have.
+/// - a genuinely floating alias carrying an unrelated three-digit token reads as
+///   unrecognised, so the check declines to advise where it could have. That one
+///   costs advice rather than asserting a falsehood, which is why the threshold
+///   sits where it does.
+fn carries_unreadable_revision(id: &str) -> bool {
+    // Purely numeric, three characters or more: a provider revision or a date
+    // this rule could not parse.
+    fn long_digit_run(token: &str) -> bool {
+        token.len() >= 3 && token.bytes().all(|b| b.is_ascii_digit())
+    }
+    // `v` followed by at least one ASCII digit and nothing else: an explicit
+    // version marker. The digits must run to the end of the token, which is what
+    // keeps the build tag `v20251001x` out.
+    fn version_marker(token: &str) -> bool {
+        match token.strip_prefix('v') {
+            Some(digits) => !digits.is_empty() && digits.bytes().all(|b| b.is_ascii_digit()),
+            None => false,
+        }
+    }
+
+    id.split(['-', '.', ':', '_', '/'])
+        .any(|token| long_digit_run(token) || version_marker(token))
 }
 
 /// Classify the configured model id by its shape.
@@ -102,6 +183,10 @@ pub enum PinStatus {
 /// `None` and an all-whitespace value are both `Unset`: an exported-but-empty
 /// variable is the #229 footgun, and reading it as a configured model would
 /// report a pin that does not exist.
+///
+/// A readable calendar date is a pin. Otherwise the id is only *asserted* to
+/// float when it carries nothing that could be an unreadable revision -- see
+/// [`carries_unreadable_revision`].
 pub fn classify(model: Option<&str>) -> PinStatus {
     let Some(id) = model.map(str::trim).filter(|id| !id.is_empty()) else {
         return PinStatus::Unset;
@@ -111,6 +196,7 @@ pub fn classify(model: Option<&str>) -> PinStatus {
             id: id.to_string(),
             date,
         },
+        None if carries_unreadable_revision(id) => PinStatus::Unrecognized { id: id.to_string() },
         None => PinStatus::Floating { id: id.to_string() },
     }
 }
@@ -140,11 +226,35 @@ mod tests {
         );
     }
 
+    /// The case that motivated this check: the name stayed and the weights
+    /// behind it changed. This list is half the contract of the three-way rule
+    /// -- every id here carries no token that could be read as a revision or a
+    /// date, so the rule is entitled to assert that it moves. The list is
+    /// deliberately only ever extended: shrinking it would silently move an id
+    /// into `Unrecognized`, where the check declines to advise at all.
     #[test]
     fn an_undated_name_floats() {
-        // The case that motivated this check: the name stayed and the weights
-        // behind it changed.
-        for id in ["gpt-4o", "claude-sonnet-5", "claude-opus-5", "qwen3:4b"] {
+        for id in [
+            "gpt-4o",
+            "claude-sonnet-5",
+            "claude-opus-5",
+            "qwen3:4b",
+            // `405b` is a parameter count, not a revision -- it is not purely
+            // numeric, so the 3+-digit rule must not claim it as one (#1950
+            // edge case 11b).
+            "llama-3.1-405b",
+            "gpt-4o-mini",
+            "deepseek-chat",
+            "model-latest",
+            // A build tag, not a version marker. The `v<digits>` rule added for
+            // the Bedrock ids must NOT swallow this: its digits do not run to
+            // the end of the token (`v20251001x`), so the marker test fails and
+            // the id keeps the floating verdict it has always had. If this ever
+            // flips to `Unrecognized`, the marker predicate has been loosened
+            // into "starts with v and has digits somewhere", which would take a
+            // whole class of aliases with it.
+            "model-v20251001x",
+        ] {
             assert_eq!(
                 classify(Some(id)),
                 PinStatus::Floating { id: id.into() },
@@ -172,9 +282,17 @@ mod tests {
     }
 
     /// The eight-digit range check is what keeps an ordinary build or version
-    /// suffix from being reported as a pinned date.
+    /// suffix from being reported as a pinned date. That property is the whole
+    /// reason this test exists and it is asserted directly below, id by id.
+    ///
+    /// What changed with the three-way rule (#1950): these ids all carry a
+    /// 3+-digit numeric token, so instead of being *asserted* to float they now
+    /// route to `Unrecognized` -- the rule cannot read the number as a calendar
+    /// date, and it will not guess that it is therefore an alias. Every id from
+    /// the original list is retained deliberately: this list is the record of
+    /// what the range check rejects.
     #[test]
-    fn an_eight_digit_suffix_that_is_not_a_date_still_floats() {
+    fn an_eight_digit_suffix_that_is_not_a_date_is_not_a_pin() {
         for id in [
             "some-model-99999999",   // month 99
             "some-model-20251301",   // month 13
@@ -184,33 +302,104 @@ mod tests {
             "some-model-2025-01-32", // hyphenated, day 32
             "2024-08-06",            // a bare date is not a model id
         ] {
+            assert!(
+                !matches!(classify(Some(id)), PinStatus::Pinned { .. }),
+                "{id} must never be reported as a pin -- a number that is not a \
+                 calendar date is not a snapshot"
+            );
             assert_eq!(
                 classify(Some(id)),
-                PinStatus::Floating { id: id.into() },
+                PinStatus::Unrecognized { id: id.into() },
                 "{id} should not read as a date"
             );
         }
     }
 
+    /// The loop is split because the three-way rule parts these four ids: a
+    /// purely numeric 3+-digit token is a revision this rule cannot read, while
+    /// a token carrying any non-digit (or shorter than three) is not. All four
+    /// original ids are retained -- they are the boundary cases of the
+    /// discriminator, and dropping one would leave that boundary untested.
     #[test]
-    fn a_short_or_non_numeric_suffix_floats() {
-        for id in ["model-2025", "model-latest", "model-v20251001x", "model-"] {
+    fn a_short_or_non_numeric_suffix_is_not_a_pin() {
+        // `2025` is four pure digits, so the rule declines to call it an alias.
+        assert_eq!(
+            classify(Some("model-2025")),
+            PinStatus::Unrecognized {
+                id: "model-2025".into()
+            }
+        );
+        for id in [
+            "model-latest", // no numeric token at all
+            // Numeric-looking, but neither shape: not purely numeric, and not a
+            // `v<digits>` marker either, since the trailing `x` means the digits
+            // do not run to the end of the token.
+            "model-v20251001x",
+            "model-", // trailing empty token, shorter than three
+        ] {
             assert_eq!(
                 classify(Some(id)),
                 PinStatus::Floating { id: id.into() },
                 "{id} should read as floating"
             );
         }
+        for id in ["model-2025", "model-latest", "model-v20251001x", "model-"] {
+            assert!(
+                !matches!(classify(Some(id)), PinStatus::Pinned { .. }),
+                "{id} must never be reported as a pin"
+            );
+        }
     }
 
-    /// An id with no separator at all must not panic on the `rsplit_once`.
+    /// An id with no separator at all must not panic on the split. That is the
+    /// property this test exists for and it survives the three-way rule
+    /// verbatim; only the verdict moved, because eight pure digits is exactly
+    /// the shape the new arm refuses to interpret.
     #[test]
-    fn an_id_with_no_dash_floats() {
+    fn an_id_with_no_separator_does_not_panic() {
         assert_eq!(
             classify(Some("20251001")),
-            PinStatus::Floating {
+            PinStatus::Unrecognized {
                 id: "20251001".into()
             }
         );
+    }
+
+    /// The defect #1950 names: every one of these is a fully pinned snapshot
+    /// from a provider whose spelling this rule has never seen, and every one
+    /// was reported `ok | ... is a floating name` with a fix
+    /// (`export CURIE_MODEL=<id>-YYYYMMDD`) that produces an INVALID id for it.
+    /// Refusing to assert is the honest answer; a wrong fix string is worse
+    /// than none.
+    ///
+    /// The two `amazon.nova-*` ids are AWS's versioned-id scheme and the reason
+    /// the discriminator grew its second shape. Bedrock spells a concrete model
+    /// version as a `v<major>:<minor>` suffix (`amazon.nova-pro-v1:0`, with
+    /// separately published siblings such as `v1:1`), and AWS documents that
+    /// moving between them is the caller's migration, never an automatic
+    /// repoint. Under the 3+-digit rule alone these tokenise to
+    /// `amazon`/`nova`/`pro`/`v1`/`0` with no numeric run long enough to catch,
+    /// so they were *asserted* to float and handed an
+    /// `export CURIE_MODEL=<id>-YYYYMMDD` fix Bedrock rejects -- a pinned id
+    /// reported as floating, which is exactly the false assertion this arm
+    /// exists to stop.
+    #[test]
+    fn a_provider_revision_suffix_is_not_asserted_to_float() {
+        for id in [
+            "anthropic.claude-3-5-sonnet-20240620-v1:0", // Bedrock, fully pinned
+            "amazon.nova-pro-v1:0",                      // Bedrock versioned id
+            "amazon.nova-lite-v1:0",                     // ditto, sibling family
+            "glm-4-0520",                                // zhipu
+            "kimi-k2-0711-preview",                      // moonshot
+            "gemini-1.5-pro-002",
+            "mistral-large-2411",
+        ] {
+            assert_eq!(
+                classify(Some(id)),
+                PinStatus::Unrecognized { id: id.into() },
+                "{id} carries a revision this rule cannot read, so it must not \
+                 be asserted to float"
+            );
+        }
     }
 }

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -2998,6 +2998,21 @@ pub async fn fetch_release_values(o: &CommonOpts) -> Result<Option<serde_json::V
     fetch_existing_values(o).await
 }
 
+/// The **computed** values of an existing release: the chart's own defaults
+/// merged with whatever the operator overrode.
+///
+/// That merge is the whole difference from [`fetch_release_values`], which
+/// reports only what the operator supplied. An operator who ran `curie cluster
+/// up` and never set a model supplied nothing, so helm recorded nothing, and
+/// the user-supplied read cannot see the chart default the sandboxes actually
+/// boot. `--all` is the only way to observe a default nobody supplied (#1950).
+///
+/// `None` only when Helm positively reports the release does not exist; read
+/// failures, malformed JSON, and non-object/non-null shapes fail closed.
+pub async fn fetch_release_computed_values(o: &CommonOpts) -> Result<Option<serde_json::Value>> {
+    fetch_helm_values(o, helm_get_all_values_cmd(o), "computed Helm values").await
+}
+
 /// Resolve [`GITHUB_TOKEN_KEY`] for this run.
 ///
 /// - `flag` is the `--github-token` value: `None` when the flag and
@@ -3143,22 +3158,38 @@ fn resolve_generated_secrets(
     Ok(resolved)
 }
 
+/// `helm get values <release> -n <ns> [--all] -o json`. `all` is the only
+/// difference between the two wrappers below, and it is load bearing rather
+/// than stylistic: without it helm reports only what the operator supplied.
+fn helm_get_values_cmd_with(o: &CommonOpts, all: bool) -> OpsCommand {
+    let mut args = vec![
+        plain("get"),
+        plain("values"),
+        plain(&o.release),
+        plain("-n"),
+        plain(&o.namespace),
+    ];
+    if all {
+        args.push(plain("--all"));
+    }
+    args.push(plain("-o"));
+    args.push(plain("json"));
+    OpsCommand::new("helm", args)
+}
+
 /// `helm get values <release> -n <ns> -o json`: helm's record of the values a
 /// prior install supplied. `cluster up` reads it back so an upgrade re-supplies
 /// the same generated secrets instead of rotating them.
 fn helm_get_values_cmd(o: &CommonOpts) -> OpsCommand {
-    OpsCommand::new(
-        "helm",
-        vec![
-            plain("get"),
-            plain("values"),
-            plain(&o.release),
-            plain("-n"),
-            plain(&o.namespace),
-            plain("-o"),
-            plain("json"),
-        ],
-    )
+    helm_get_values_cmd_with(o, false)
+}
+
+/// `helm get values <release> -n <ns> --all -o json`: the COMPUTED values --
+/// chart defaults merged with the operator's overrides. The sibling above
+/// reports only what the operator supplied, which is why `--all` is load
+/// bearing here and not a stylistic difference.
+fn helm_get_all_values_cmd(o: &CommonOpts) -> OpsCommand {
+    helm_get_values_cmd_with(o, true)
 }
 
 /// Whether Helm positively reported that the requested release does not exist.
@@ -3173,7 +3204,20 @@ fn helm_release_is_absent(stderr: &str) -> bool {
 /// shapes fail closed. Helm prints `null` for an existing release with no user
 /// supplied values.
 async fn fetch_existing_values(o: &CommonOpts) -> Result<Option<serde_json::Value>> {
-    let (ok, out, err) = run_capture(&helm_get_values_cmd(o)).await?;
+    fetch_helm_values(o, helm_get_values_cmd(o), "Helm values").await
+}
+
+/// The shared read for both `helm get values` shapes. `what` names the read in
+/// the operator facing message ("Helm values" or "computed Helm values") and is
+/// the only thing that varies between callers; the absent-release, connectivity
+/// vs failure, malformed-JSON and non-object ladders are deliberately single
+/// sourced so the fail-closed contract cannot drift between them.
+async fn fetch_helm_values(
+    o: &CommonOpts,
+    cmd: OpsCommand,
+    what: &str,
+) -> Result<Option<serde_json::Value>> {
+    let (ok, out, err) = run_capture(&cmd).await?;
     let fix = format!(
         "verify the release and cluster access with `helm status {} -n {}`, then retry",
         o.release, o.namespace
@@ -3184,7 +3228,7 @@ async fn fetch_existing_values(o: &CommonOpts) -> Result<Option<serde_json::Valu
         }
         let reason = failure_reason(&err);
         let message = format!(
-            "could not read Helm values for release {} in namespace {}: {reason}",
+            "could not read {what} for release {} in namespace {}: {reason}",
             o.release, o.namespace
         );
         let error = if is_connectivity_failure(&err) {
@@ -3197,14 +3241,14 @@ async fn fetch_existing_values(o: &CommonOpts) -> Result<Option<serde_json::Valu
 
     let values: serde_json::Value = serde_json::from_str(out.trim()).map_err(|error| {
         crate::exit::CliError::failure(format!(
-            "could not read Helm values for release {} in namespace {}: malformed Helm values JSON ({error})",
+            "could not read {what} for release {} in namespace {}: malformed Helm values JSON ({error})",
             o.release, o.namespace
         ))
         .with_fix(fix.clone())
     })?;
     if !values.is_object() && !values.is_null() {
         return Err(crate::exit::CliError::failure(format!(
-            "could not read Helm values for release {} in namespace {}: malformed Helm values JSON, expected an object or null",
+            "could not read {what} for release {} in namespace {}: malformed Helm values JSON, expected an object or null",
             o.release, o.namespace
         ))
         .with_fix(fix)
@@ -10365,6 +10409,22 @@ mod tests {
     fn helm_get_values_reads_user_supplied_values_as_json() {
         let cmd = helm_get_values_cmd(&common());
         assert_eq!(cmd.display(), "helm get values curie -n curie -o json");
+    }
+
+    /// `--all` is the entire point of this helper, and its absence is invisible
+    /// at runtime: helm answers happily either way, just without the chart
+    /// defaults. That is exactly the bug #1950 reports -- an operator who never
+    /// supplied a model has no user-supplied value to read, so the sibling
+    /// command above returns nothing and `doctor` reports the floating chart
+    /// default as "not applicable". A test that does not pin `--all` lets a
+    /// refactor reintroduce that silently.
+    #[test]
+    fn helm_get_all_values_reads_computed_values_as_json() {
+        let cmd = helm_get_all_values_cmd(&common());
+        assert_eq!(
+            cmd.display(),
+            "helm get values curie -n curie --all -o json"
+        );
     }
 
     #[test]

--- a/cli/tests/json_contract.rs
+++ b/cli/tests/json_contract.rs
@@ -1584,8 +1584,17 @@ fn doctor_output_validates() {
         model_credential: Some("CURIE_CREDENTIALS".to_string()),
         model_credential_source: Some("environment".to_string()),
         // A dated snapshot, so the schema is validated against the pinned
-        // branch of the model-pin check rather than its advisory branch.
-        model_pin: Some("claude-haiku-4-5-20251001".to_string()),
+        // branch of the model-pin check rather than its advisory branch. It
+        // arrives from the RELEASE DEFAULT rather than the invoking shell,
+        // which is the state #1950 is about: the release is what the sandboxes
+        // actually boot, and the shell is not a declared producer of the value
+        // at all.
+        model_shell: None,
+        model_release_default: Some("claude-haiku-4-5-20251001".to_string()),
+        model_release_key: Some(curie::doctor::ReleaseModelKey::Runner),
+        model_release_fake: false,
+        model_agent_overrides: vec![],
+        target: Some(("curie".to_string(), "curie".to_string())),
         model_credential_provider: None,
         docker_ok: true,
         bundle_name: Some("my-agent".to_string()),


### PR DESCRIPTION
Closes #1950

`curie doctor`'s `model-pin` check read only the invoking shell's `CURIE_MODEL`
— a variable whose boot-env contract names `worker` and `substrate` as its
producers, not the CLI. On the install this repo ships it reported
`not_applicable` while the sandbox template baked `claude-sonnet-5`, a floating
alias. The diagnostic built to catch a repointed alias reported clean on the one
case it exists for.

## What changed

`model-pin` now resolves the model in force from the sources that decide it — a
per-agent override, else the release default, else the shell — names which is in
force, and names the others when they disagree.

Three things surfaced while building it that the issue did not anticipate:

1. **The chart default was not reachable at all.** The issue says the release
   default is "already in hand" via `fetch_release_values()`. That call runs
   `helm get values` **without** `--all`, so it returns only operator-supplied
   values. On a default install it returns `null`. This is a second, independent
   cause of the `not_applicable` report, and it needs the new computed-values
   read to fix.
2. **`curie cluster up` has no `--model` flag.** The release fix uses
   `--set agentSandbox.runner.model=`, which is the documented path.
3. **`inference.deploy` overrides `runner.model`.** `agent-sandbox.yaml` renders
   exactly one `CURIE_MODEL`, taking `inference.model` when inference is
   deployed. Reading only `agentSandbox.runner.model` would name a model a
   `--local-model` install never boots, and emit a fix setting a key the chart
   ignores.

Also, from review: a release with fake model active now says so (the chart
renders `CURIE_FAKE_MODEL` and `CURIE_MODEL` off independent arms, so the id is
configured but not in use), and a run without API credentials says the per-agent
overrides could not be read rather than presenting an unread source as clean.

`PinStatus::Unrecognized` stops the check asserting that an id it cannot parse
floats. Driven live, `anthropic.claude-3-5-sonnet-20240620-v1:0`, `glm-4-0520`,
`kimi-k2-0711-preview`, `gemini-1.5-pro-002` and `amazon.nova-pro-v1:0` all
reported `floating`; every one is a pinned snapshot, and the emitted
`-YYYYMMDD` fix produced an invalid id for every BYO provider this repo
documents. The classifier stays shape-only — no catalog, no credential, no
network call.

## Verified on a live release

A `kind` cluster with the chart installed and **zero** operator-supplied values:

```
BEFORE (binary built from the merge base)
  state : not_applicable
  detail: no CURIE_MODEL set, so the platform default applies

AFTER
  state : ok
  detail: claude-sonnet-5 is a floating name, in force from release default
          agentSandbox.runner.model; ...; the sandbox currently boots the runner's
          scripted fake model, so this id is configured but not in use; per-agent
          model overrides could not be read because the platform API was not reached
  fix   : curie cluster up --namespace curie --release curie \
          --set agentSandbox.runner.model=<dated-snapshot-id>
```

and after `--set inference.deploy=true --set inference.model=qwen3:4b`, with
`helm get manifest` confirming the pod carries `CURIE_MODEL: "qwen3:4b"`:

```
  detail: qwen3:4b is a floating name, in force from release default inference.model; ...
  fix   : curie cluster up --namespace curie --release curie \
          --set inference.model=<dated-snapshot-id>
```

## Coverage

`gather()` had no test anywhere in the repo. It now has three, and they are
mutation-proven: reverting the computed-values read to `fetch_release_values`
(the change that reintroduces the original bug) turns two of them red, and
deleting the shell read turns the third red.

## Scope note

`Facts::target` partially addresses #1358 item 1 — **for the model-pin fix string
only**. The other doctor fix strings still omit the invoked
`--namespace`/`--release` and are deliberately unchanged here; #1358 stays open.

## Follow-ups, not done here

- doctor has no local-tier (compose) or skill-tier probe for the runner model.
- `runner_model_from_values` mirrors the chart's branch in Rust, so a new arm in
  `agent-sandbox.yaml` drifts silently. Reading the rendered SandboxTemplate
  instead would be drift-proof; that is a redesign, not a patch fix.
