### PR TITLE
Rekey approval cards stranded by a worker roll onto their approval id

### DIFF
--- a/apps/worker/src/curie_worker/approval_cards.py
+++ b/apps/worker/src/curie_worker/approval_cards.py
@@ -12,19 +12,27 @@ kernel remembers the card destination and summary under the approval id, reads
 that ref without consuming it, then removes the exact value only after the card
 edit succeeds.
 
-There is intentionally no dual read for entries keyed by thread before this
-layout was introduced. Those entries remain untouched until their existing 14
-day TTL expires and are not automatically settled by the new worker.
+There is intentionally no dual read at runtime for entries keyed by THREAD
+before this layout was introduced: the settle path stays single-keyed on the
+approval id. Instead ``migrate_legacy_thread_keyed_refs`` runs once at worker
+boot and REKEYS those entries onto their approval id, so the ordinary settle
+path finds them (#1751). Without it, an approval already pending when the
+workers rolled kept its live Approve/Reject buttons forever if it later EXPIRED
+-- an expiry carries no click, so the click path could never heal it.
 """
 
 from __future__ import annotations
 
 import json
+import logging
 from dataclasses import asdict, dataclass
+from typing import Any
 
 from redis.asyncio import Redis
 
 from .config import WorkerConfig
+
+logger = logging.getLogger(__name__)
 
 # Remove a ref only when it is still the exact value read before delivery. This
 # prevents an older settlement pass from deleting a replacement ref written for
@@ -43,6 +51,18 @@ end
 # card whose memory lapsed simply is not auto-disabled (the resolve-click path
 # still heals it on the next interaction).
 DEFAULT_CARD_TTL_S = 14 * 24 * 60 * 60
+
+# One SCAN page. The boot pass walks a single narrow prefix once, so this only
+# bounds how much of the keyspace one round trip inspects -- big enough that a
+# few thousand pending approvals do not cost thousands of round trips, small
+# enough that the cursor never blocks a Valkey serving the kernel's locks.
+_MIGRATION_SCAN_COUNT = 200
+
+# The one negative ``PTTL`` reply that still describes a LIVE key: "the key
+# exists but has no expiry set". Every other negative reply -- -2, "no such
+# key", and anything a future server adds -- means the key is not there, which
+# is a completely different instruction to the migration than "no deadline".
+_PTTL_NO_EXPIRY = -1
 
 
 @dataclass(frozen=True)
@@ -71,6 +91,89 @@ class ApprovalCardRef:
     requested_by: str = ""
     kind: str = ""
     adapter: str | None = None
+
+
+@dataclass(frozen=True)
+class LegacyCardMigration:
+    """What one boot pass of the legacy rekey actually did.
+
+    Returned rather than only logged so the behaviour is directly assertable:
+    "the pass ran" and "the pass moved something" are different facts, and a
+    second run proving ``migrated == 0`` is how idempotence is pinned.
+    """
+
+    scanned: int = 0
+    migrated: int = 0
+    skipped: int = 0
+
+
+def _load(raw: str | bytes) -> dict[str, Any] | None:
+    """The stored value decoded as a payload mapping, or None when it is not one.
+
+    The ONE decode of a stored entry, and the one place that decides what
+    "unparseable" means. Every question the module asks of an entry -- is it
+    legacy, is it a usable ref -- is then asked of this single parsed dict, so
+    two callers can no longer decode the same bytes twice, nor drift on which
+    exceptions count as corrupt (they once did: one caught ``ValueError`` alone
+    while the other also caught ``KeyError``/``TypeError``).
+    """
+
+    try:
+        data = json.loads(raw)
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    return data
+
+
+def _parse_ref(data: dict[str, Any]) -> ApprovalCardRef | None:
+    """A parsed payload as a ref in the CURRENT shape, or None when it is not one.
+
+    Shared by ``read`` and the legacy migration so the two can never drift on
+    what a stored entry means. Unknown fields (notably the ``approval_id`` a
+    pre-rekey entry carried) are dropped by construction: the ref is rebuilt
+    field by field rather than splatted, so re-serialising the result is how the
+    stale discriminator gets stripped.
+
+    The decode already happened in ``_load``; what is caught here is strictly
+    SHAPE drift -- a missing or unusable field in an otherwise valid payload.
+    """
+
+    try:
+        return ApprovalCardRef(
+            channel=str(data["channel"]),
+            ts=str(data["ts"]),
+            summary=str(data["summary"]),
+            endpoint=data.get("endpoint"),
+            requested_by=str(data.get("requested_by") or ""),
+            kind=str(data.get("kind") or ""),
+            adapter=data.get("adapter"),
+        )
+    except (ValueError, KeyError, TypeError):
+        # A shape-drifted entry must not break the resume; treat it as no
+        # remembered card (the click path can still heal the card).
+        return None
+
+
+def _legacy_approval_id(data: dict[str, Any]) -> str | None:
+    """The approval id a PRE-rekey payload carried inside it, if any.
+
+    This field is the whole discriminator between the two layouts (#1751). The
+    thread-keyed layout stored an ``approval_id`` alongside the destination
+    (added by #1199); the current approval-id-keyed layout does not, because the
+    KEY carries that identity. So a payload with a non-empty ``approval_id`` is
+    a legacy entry and a payload without one is either a current entry or a
+    pre-#1199 legacy entry that never recorded which approval it belonged to --
+    and therefore was never pairable in the first place. Both of those are left
+    strictly alone; eating a live entry here would strand the very cards this
+    exists to rescue.
+    """
+
+    approval_id = data.get("approval_id")
+    if not isinstance(approval_id, str) or not approval_id:
+        return None
+    return approval_id
 
 
 class ApprovalCardStore:
@@ -121,30 +224,226 @@ class ApprovalCardStore:
         raw = await self._redis.get(self._config.approval_card_key(approval_id))
         if not raw:
             return None
-        try:
-            data = json.loads(raw)
-            ref = ApprovalCardRef(
-                channel=str(data["channel"]),
-                ts=str(data["ts"]),
-                summary=str(data["summary"]),
-                endpoint=data.get("endpoint"),
-                requested_by=str(data.get("requested_by") or ""),
-                kind=str(data.get("kind") or ""),
-                adapter=data.get("adapter"),
-            )
-            return ref, raw
-        except (ValueError, KeyError, TypeError):
-            # A corrupt or shape-drifted entry must not break the resume; treat
-            # it as no remembered card (the click path can still heal the card).
+        # A corrupt entry (undecodable) and a shape-drifted one (decodable but
+        # not a usable ref) are the same answer here: no remembered card, never
+        # a raised exception that would break the resume.
+        data = _load(raw)
+        if data is None:
             return None
+        ref = _parse_ref(data)
+        if ref is None:
+            return None
+        return ref, raw
 
     async def consume(self, approval_id: str, expected_raw: str | bytes) -> bool:
         """Delete the ref only when its exact stored value still matches."""
 
-        removed = await self._redis.eval(
-            _CONSUME_LUA,
-            1,
-            self._config.approval_card_key(approval_id),
-            expected_raw,
+        return await self._consume_key(
+            self._config.approval_card_key(approval_id), expected_raw
         )
+
+    async def _consume_key(self, key: str, expected_raw: str | bytes) -> bool:
+        """Compare-and-delete one KEY, whatever layout put the value there.
+
+        The primitive under both ``consume`` -- which derives the key from an
+        approval id -- and the legacy migration, which must act on the pre-rekey
+        raw key it scanned and so cannot go through the public verb. Keeping one
+        caller of ``eval`` means the script's argument order (one KEY, the
+        expected value as ``ARGV[1]``) is written down in exactly one place.
+        """
+
+        removed = await self._redis.eval(_CONSUME_LUA, 1, key, expected_raw)
         return bool(removed)
+
+    async def migrate_legacy_thread_keyed_refs(self) -> LegacyCardMigration:
+        """Rekey pre-#1723 THREAD-keyed refs onto their approval id (#1751).
+
+        A ONE-SHOT, best-effort, idempotent boot pass, not a runtime dual read
+        and not a maintenance loop. The distinction matters: the comment on
+        ``WorkerConfig.completions_pending_key`` forbids the REPEATING sweeper
+        from scanning a production keyspace, and that prohibition stands. This
+        runs once per process start, over one narrow prefix, with a bounded
+        ``COUNT``, and becomes a pure no-op the moment no legacy entry remains
+        -- every surviving key under the prefix is then a current-layout entry
+        the discriminator declines to touch.
+
+        Why rekey rather than dual-read: #1723 moved the pointer from the thread
+        to the approval id with no compatibility path, so any approval already
+        pending when the workers rolled is invisible to
+        ``Kernel._finalize_settled_card``. A resolve CLICK still heals its card
+        from the interaction payload; an EXPIRY has no click, so the card keeps
+        live Approve/Reject buttons until its 14 day TTL lapses. Moving the
+        entry lets the ordinary single-keyed settle path find it, which leaves
+        exactly one read path in the hot loop.
+
+        Every step is defensive about a still-running OLD-version replica and
+        about a NEW-version replica that has already posted its own card for the
+        same approval:
+
+        * the write is ``NX``, so an entry the upgraded worker wrote for that
+          approval always wins over the stale legacy pointer;
+        * the delete is the same compare-and-delete Lua ``consume`` uses,
+          against the exact bytes read in this pass, so an old replica that
+          rewrote the thread key mid-pass is not clobbered;
+        * the remaining TTL is carried over, so an approval three days from its
+          SLA does not have its card memory resurrected for another fortnight.
+
+        Per-entry failures are logged and swallowed: a single unparseable or
+        racing key must not abort the rest of the pass, and the pass must never
+        fail worker boot.
+
+        The residual a one-shot pass cannot close: during a ROLLING upgrade an
+        old-version replica is still serving, and it can pause a new approval --
+        writing a fresh thread-keyed entry -- AFTER this replica's pass has
+        already scanned. Nothing revisits that entry, so if it later expires its
+        card keeps live buttons, exactly the #1751 symptom. Closing it would
+        take the runtime dual read #1751 rules out, so it is stated rather than
+        fixed: the window shuts when the roll finishes and every replica is on
+        the new layout, and anything the pass missed lapses on its existing TTL.
+
+        TRANSITIONAL -- MARKED FOR REMOVAL. This exists only to carry the #1723
+        key-layout change across a roll, yet it is roughly half of a module whose
+        real job is the hot settle path. It is safe to delete once no supported
+        upgrade path starts from a worker older than that change: every legacy
+        entry has lapsed on its 14 day TTL by then, so the pass can only ever be
+        a no-op. Deleting it should take ``_legacy_approval_id``, the
+        ``written_targets`` bookkeeping, and the migration constants
+        (``_MIGRATION_SCAN_COUNT``, ``_PTTL_NO_EXPIRY``) with it.
+        """
+
+        scanned = migrated = skipped = 0
+        # Targets THIS pass wrote. The pass writes rekeyed entries back into the
+        # very keyspace it is scanning, and Redis makes no guarantee about keys
+        # created during an in-flight SCAN -- a fresh target may or may not come
+        # back on a later batch. Left unguarded, the returned counts, the GET
+        # count, and the INFO summary an operator reads all depend on that coin
+        # flip. Skipping our own output makes them identical either way. The set
+        # is bounded by the number of entries actually MIGRATED (pending approval
+        # cards only), so it does not reintroduce the unbounded-memory problem
+        # the streaming ``scan_iter`` exists to avoid.
+        written_targets: set[str] = set()
+        # The prefix segment is shared by both layouts -- only the SUFFIX moved
+        # (thread key -> approval id) -- so one match pattern sees every entry of
+        # either generation, and the payload (not the key shape) decides which.
+        pattern = f"{self._config.key_prefix}:approval-card:*"
+        async for key in self._redis.scan_iter(match=pattern, count=_MIGRATION_SCAN_COUNT):
+            # ``scan_iter`` yields ``str`` or ``bytes`` depending on how the
+            # client was built (``decode_responses``), while every key this pass
+            # DERIVES -- the target, the written-targets guard -- is always a
+            # ``str``. Normalise ONCE, here, and use only the normalised form
+            # below: an un-normalised ``bytes`` key compares unequal to its own
+            # ``str`` target under ``decode_responses=False``, and for a legacy
+            # entry whose thread key happens to equal its approval id that turns
+            # the "already where it belongs" guard into a delete of a live
+            # pointer. The GET/PTTL/EVAL all accept the ``str`` form, so there is
+            # no reason to keep the raw one alive past this line.
+            scanned_key = key.decode() if isinstance(key, bytes) else key
+            if scanned_key in written_targets:
+                # This pass's own output, not an entry it was asked to consider:
+                # counted as neither ``scanned`` nor ``skipped``.
+                continue
+            scanned += 1
+            try:
+                if await self._migrate_one(scanned_key, written_targets):
+                    migrated += 1
+                else:
+                    skipped += 1
+            except Exception as exc:  # noqa: BLE001 - one bad key must not end the pass
+                skipped += 1
+                logger.warning(
+                    "legacy approval card migration failed for key %s: %s",
+                    scanned_key,
+                    exc,
+                )
+        counts = LegacyCardMigration(scanned=scanned, migrated=migrated, skipped=skipped)
+        logger.info(
+            "legacy approval card migration: scanned=%d migrated=%d skipped=%d",
+            counts.scanned,
+            counts.migrated,
+            counts.skipped,
+        )
+        return counts
+
+    async def _migrate_one(self, key: str, written_targets: set[str]) -> bool:
+        """Rekey one entry, returning whether this pass moved it.
+
+        False covers every "leave it alone" case as well as a lost NX race, so
+        the caller's ``migrated`` count only ever grows on a real relocation.
+
+        ``key`` is the caller's ALREADY-NORMALISED ``str``, never the raw value
+        ``scan_iter`` yielded, so the ``target == key`` comparison below is a
+        like-for-like one whatever ``decode_responses`` the client was built
+        with.
+
+        ``written_targets`` collects every key THIS pass wrote, so the caller can
+        skip its own output if the in-flight SCAN hands it back.
+        """
+
+        raw = await self._redis.get(key)
+        if not raw:
+            # Expired or consumed between the SCAN and the GET. Nothing to move.
+            return False
+        # Decoded ONCE here; both questions below -- which layout is this, and is
+        # its destination usable -- are asked of this single parsed payload.
+        data = _load(raw)
+        if data is None:
+            # A corrupt value. Left COMPLETELY untouched, like every other entry
+            # this pass cannot positively identify as legacy.
+            return False
+        approval_id = _legacy_approval_id(data)
+        if approval_id is None:
+            # A current-layout entry, or a pre-#1199 legacy entry that never
+            # recorded its approval. Both are left COMPLETELY untouched -- the
+            # first is a live pointer the running worker depends on.
+            return False
+        target = self._config.approval_card_key(approval_id)
+        if target == key:
+            # Already where it belongs (a legacy entry whose "thread key" was the
+            # approval id, or a re-run over a key we cannot improve). Rewriting it
+            # to drop the stale field would buy nothing and risks the TTL.
+            return False
+        ref = _parse_ref(data)
+        if ref is None:
+            # It named an approval but its destination is unusable, so there is
+            # nothing to settle. Leave it to its TTL rather than moving a value
+            # the settle path would reject anyway.
+            return False
+        # Carry the REMAINING life over rather than minting a fresh TTL: this
+        # memory exists to outlive the approval's SLA, not to be renewed by an
+        # upgrade. The two non-positive PTTL replies mean OPPOSITE things and
+        # must not be collapsed: -1 is KEY EXISTS, NO EXPIRY, which deserves the
+        # standard ceiling; -2 is NO SUCH KEY -- the source expired or was
+        # consumed between the GET above and this call -- and writing the target
+        # then would resurrect a ref that had legitimately gone away, with a
+        # fresh 14 days of life on an already-stale payload. Abort the entry
+        # instead: no write, and no compare-and-delete either, since there is
+        # nothing left to delete.
+        pttl = await self._redis.pttl(key)
+        if not isinstance(pttl, int):
+            return False
+        if pttl < 0 and pttl != _PTTL_NO_EXPIRY:
+            return False
+        # The residual this does NOT close: the source can still vanish just
+        # AFTER a positive PTTL, and the NX write then re-creates an entry for
+        # an approval whose pointer had gone. That outcome is bounded and
+        # self-healing -- the settle path consumes it, or its carried-over TTL
+        # (never a renewed one) disposes of it -- which is categorically
+        # different from minting a fresh fortnight for a dead ref.
+        ttl_ms = pttl if pttl > 0 else self._ttl_s * 1000
+        # Re-serialised from the CURRENT ref shape, so the stale ``approval_id``
+        # discriminator does not travel to the new key and make the migrated
+        # entry look legacy to the next pass.
+        payload = json.dumps(asdict(ref))
+        written = await self._redis.set(target, payload, px=ttl_ms, nx=True)
+        if written:
+            # Only a WON NX write is ours to skip. On a lost race the target was
+            # written by the running worker, not by this pass, so it is a genuine
+            # pre-existing entry the scan is entitled to visit -- and being
+            # current-layout it is correctly counted as a skip.
+            written_targets.add(target)
+        # Delete the old key EITHER WAY. If the NX write lost, an entry the
+        # upgraded worker already wrote for this approval supersedes the legacy
+        # pointer, so the legacy key is dead in both branches. The compare is
+        # what protects a still-running old replica that rewrote it mid-pass.
+        await self._consume_key(key, raw)
+        return bool(written)

--- a/apps/worker/src/curie_worker/kernel.py
+++ b/apps/worker/src/curie_worker/kernel.py
@@ -1542,9 +1542,14 @@ class Kernel:
         value. Sequential redelivery finds no ref after successful cleanup. If a
         newer ref replaces the value during delivery, comparison preserves it.
 
-        This remains fully best effort and never fails the resume. There is no
-        dual read for refs keyed by thread before the approval id layout. Those
-        refs are not automatically settled and remain until their TTL expires.
+        This remains fully best effort and never fails the resume. There is
+        still no RUNTIME dual read: this path reads exactly one key, the
+        approval id's. Refs keyed by thread before the approval id layout are
+        instead rekeyed onto their approval id by a one-shot boot migration
+        (``ApprovalCardStore.migrate_legacy_thread_keyed_refs``, #1751), so by
+        the time a resume arrives they are ordinary entries this read finds. A
+        pre-#1199 ref that never recorded its approval id is not migratable and
+        still lapses with its TTL.
         """
 
         if self._card_store is None or not self._is_approval_resume(qevent.event_id):

--- a/apps/worker/src/curie_worker/run.py
+++ b/apps/worker/src/curie_worker/run.py
@@ -68,6 +68,10 @@ class Runtime:
     eval_redis: AsyncRedis
     eval_http: httpx.AsyncClient
     engine: AsyncEngine
+    # The SAME store the kernel settles cards through, exposed so ``_run`` can
+    # drive its one-shot legacy rekey at boot (#1751) without constructing a
+    # second client-and-config pair that could drift from the kernel's.
+    card_store: ApprovalCardStore
     # None unless the connector reconciler is enabled (ADR-0090, #1184). Held
     # here so `_run` supervises it beside the consumers rather than letting it
     # run unsupervised.
@@ -86,6 +90,20 @@ class Runtime:
 # keys off, so a year-long route already means "never reaped by TTL" and
 # anything longer is definitionally a leak.
 _MAX_TUNABLE_SECONDS = 31_536_000
+
+
+# How long the one-shot legacy approval-card rekey (#1751) may hold up boot.
+# Not an operator knob: the number that matters is not "how big is the keyspace"
+# but "how long may readiness stall", and that answer is the same everywhere.
+# WHY a bound exists at all: this pass is awaited BEFORE the asyncio.gather that
+# starts the liveness heartbeat, so nothing is touching the heartbeat file while
+# it runs. Per-entry errors are swallowed and the loop continues, which means a
+# degraded Valkey costs roughly one socket timeout per entry with nothing
+# capping the total -- and the k8s exec probe, finding a stale heartbeat, kills
+# the pod. Unbounded, a best-effort migration becomes a restart loop that never
+# reaches the consumers. Cutting it short only leaves some legacy refs behind,
+# and those lapse with their own TTL.
+_CARD_MIGRATION_BUDGET_S = 30.0
 
 
 def _bounded_seconds(
@@ -270,6 +288,7 @@ def build(config: WorkerConfig, env: Mapping[str, str]) -> Runtime:
         read_timeout_s=2.0,
     )
     sink = build_reply_sink(config)
+    card_store = ApprovalCardStore(async_redis, config)
     kernel = Kernel(
         substrate=substrate,
         runner=runner,
@@ -288,7 +307,7 @@ def build(config: WorkerConfig, env: Mapping[str, str]) -> Runtime:
         # (#1084). Two parameters rather than one so a test can fake the create
         # half without also implementing a read it never exercises.
         approval_reader=approval_client,
-        card_store=ApprovalCardStore(async_redis, config),
+        card_store=card_store,
     )
     killswitch = KillSwitch(async_redis, on_kill=kernel.interrupt_agent)
     kernel.attach_killswitch(killswitch)
@@ -336,6 +355,7 @@ def build(config: WorkerConfig, env: Mapping[str, str]) -> Runtime:
         eval_redis=eval_redis,
         eval_http=eval_http,
         engine=engine,
+        card_store=card_store,
         connector_loop=_build_connector_loop(config, engine),
     )
 
@@ -425,6 +445,28 @@ async def _run(config: WorkerConfig, env: Mapping[str, str]) -> None:
         loop.add_signal_handler(sig, _stop)
 
     logging.getLogger("curie_worker").info("worker starting")
+    # One-shot, before any consumer reads: rekey approval-card refs left under
+    # the pre-#1723 thread key onto their approval id, so an approval that was
+    # already pending when this worker rolled can still have its card settled
+    # (#1751). It is deliberately NOT supervised or repeated -- it is a boot
+    # migration that no-ops once the old key space is empty -- and it is
+    # deliberately swallowed: a Valkey blip here must degrade to "those cards
+    # stay live until TTL", never to a worker that will not start.
+    # It is bounded because the heartbeat has not started yet -- see
+    # _CARD_MIGRATION_BUDGET_S.
+    try:
+        await asyncio.wait_for(
+            rt.card_store.migrate_legacy_thread_keyed_refs(),
+            timeout=_CARD_MIGRATION_BUDGET_S,
+        )
+    except TimeoutError:
+        logger.warning(
+            "legacy approval card migration exceeded its %.0fs boot budget and was "
+            "cut short; any legacy ref it did not reach simply lapses with its TTL",
+            _CARD_MIGRATION_BUDGET_S,
+        )
+    except Exception:
+        logger.exception("legacy approval card migration failed; continuing boot")
     try:
         # return_exceptions=True + per-task restart: a crash in one consumer must
         # not cancel its siblings (#673). Supervisors only return on shutdown.

--- a/apps/worker/tests/kernel/test_approval_card_migration.py
+++ b/apps/worker/tests/kernel/test_approval_card_migration.py
@@ -1,0 +1,392 @@
+"""The one-shot boot rekey of pre-#1723 approval-card refs (#1751).
+
+#1723 moved the card pointer from a THREAD-keyed Valkey entry to an
+APPROVAL-ID-keyed one with no compatibility path, so any approval already
+pending when the workers rolled became invisible to the settle path. A resolve
+CLICK still heals its card; an EXPIRY has no click, so the card kept live
+Approve/Reject buttons for the rest of its 14 day TTL.
+
+These tests drive ``ApprovalCardStore.migrate_legacy_thread_keyed_refs``
+against a REAL Valkey through the ordinary kernel harness, because the whole
+behaviour is Valkey semantics: an NX write, a compare-and-delete, and a carried
+TTL. The negative cases matter at least as much as the positive one -- a
+migration that ate a CURRENT-layout entry would strand exactly the cards this
+exists to rescue.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+from curie_worker.approval_cards import DEFAULT_CARD_TTL_S, ApprovalCardStore
+from redis.asyncio import Redis as AsyncRedis
+
+
+def _legacy_payload(approval_id: str, **overrides: object) -> str:
+    """A pre-#1723 thread-keyed payload: the current fields PLUS ``approval_id``.
+
+    That extra field is the discriminator the migration keys off -- the current
+    layout carries the approval id in the KEY, so a payload that also states it
+    inline can only have come from the thread-keyed generation (#1199).
+    """
+
+    payload: dict[str, object] = {
+        "channel": "C1",
+        "ts": "1723.0001",
+        "summary": "Refund order 42",
+        "endpoint": "https://slack.example/hooks",
+        "requested_by": "U1",
+        "kind": "slack",
+        "adapter": "slack-secondary",
+        "approval_id": approval_id,
+    }
+    payload.update(overrides)
+    return json.dumps(payload)
+
+
+def test_legacy_thread_keyed_ref_is_rekeyed_onto_its_approval_id(make_harness) -> None:
+    """The whole point: after the pass, the ordinary single-keyed read finds it.
+
+    Every field of the destination survives the move (the card is REBUILT from
+    this ref, so a dropped ``kind`` or ``adapter`` would post the settled edit
+    at the wrong place), the stale discriminator is gone from the stored value,
+    the old key is gone, and the remaining TTL is carried rather than reset --
+    an approval three days from its SLA must not have its memory resurrected
+    for another fortnight.
+    """
+
+    async def go() -> None:
+        async with make_harness() as h:
+            legacy_key = f"{h.config.key_prefix}:approval-card:th-rolled"
+            await h.async_redis.set(
+                legacy_key, _legacy_payload("appr-legacy-1"), ex=3600
+            )
+
+            result = await h.card_store.migrate_legacy_thread_keyed_refs()
+            assert (result.scanned, result.migrated, result.skipped) == (1, 1, 0)
+
+            entry = await h.card_store.read("appr-legacy-1")
+            assert entry is not None, "the settle path must now find the ref"
+            ref, _raw = entry
+            assert ref.channel == "C1"
+            assert ref.ts == "1723.0001"
+            assert ref.summary == "Refund order 42"
+            assert ref.endpoint == "https://slack.example/hooks"
+            assert ref.requested_by == "U1"
+            assert ref.kind == "slack"
+            assert ref.adapter == "slack-secondary"
+
+            assert not await h.async_redis.exists(legacy_key)
+
+            new_key = h.config.approval_card_key("appr-legacy-1")
+            stored = json.loads(await h.async_redis.get(new_key))
+            assert "approval_id" not in stored, (
+                "the stale discriminator must not travel to the new key, or the "
+                "next pass would treat the migrated entry as legacy again"
+            )
+
+            # Close to the hour it was seeded with, nowhere near the 14 day
+            # ceiling a fresh remember() would have minted.
+            ttl_ms = await h.async_redis.pttl(new_key)
+            assert 3_000_000 < ttl_ms <= 3_600_000
+
+    asyncio.run(go())
+
+
+def test_current_layout_entry_is_left_byte_identical(make_harness) -> None:
+    """The critical negative: a LIVE entry the running worker depends on.
+
+    A current-layout payload carries no ``approval_id`` field, so the
+    discriminator must decline it outright -- no rewrite, no TTL reset, no
+    delete. Byte identity plus an untouched expiry is the assertion, because a
+    "harmless" re-serialise would still reset the TTL.
+    """
+
+    async def go() -> None:
+        async with make_harness() as h:
+            await h.card_store.remember(
+                "appr-live",
+                channel="C2",
+                ts="9000.1",
+                summary="Ship it",
+                endpoint=None,
+                requested_by="U7",
+                kind="slack",
+                adapter=None,
+            )
+            key = h.config.approval_card_key("appr-live")
+            before = await h.async_redis.get(key)
+            ttl_before = await h.async_redis.pttl(key)
+
+            result = await h.card_store.migrate_legacy_thread_keyed_refs()
+            assert (result.scanned, result.migrated) == (1, 0)
+
+            assert await h.async_redis.get(key) == before
+            ttl_after = await h.async_redis.pttl(key)
+            # Only the elapsed test time may separate them; a reset would jump.
+            assert ttl_after <= ttl_before
+
+    asyncio.run(go())
+
+
+def test_pre_1199_legacy_entry_is_left_untouched(make_harness) -> None:
+    """A thread-keyed entry from BEFORE #1199 never recorded its approval id.
+
+    There is nothing to rekey it onto -- it was never pairable -- so it stays
+    where it is and lapses with its TTL. Both shapes are covered: the field
+    absent, and the field present but empty (which is not an identity either).
+    """
+
+    async def go() -> None:
+        async with make_harness() as h:
+            absent = f"{h.config.key_prefix}:approval-card:th-pre-1199"
+            empty = f"{h.config.key_prefix}:approval-card:th-empty-id"
+            no_id = json.dumps(
+                {"channel": "C3", "ts": "1.1", "summary": "Old card"}
+            )
+            blank_id = _legacy_payload("", channel="C4")
+            await h.async_redis.set(absent, no_id, ex=3600)
+            await h.async_redis.set(empty, blank_id, ex=3600)
+
+            result = await h.card_store.migrate_legacy_thread_keyed_refs()
+            assert (result.scanned, result.migrated, result.skipped) == (2, 0, 2)
+
+            assert await h.async_redis.get(absent) == no_id
+            assert await h.async_redis.get(empty) == blank_id
+
+    asyncio.run(go())
+
+
+def test_an_existing_entry_for_the_same_approval_wins_over_the_legacy_ref(
+    make_harness,
+) -> None:
+    """NX: the upgraded worker's own entry is authoritative.
+
+    Both generations can name the same approval -- a new-version replica may
+    already have re-posted and remembered its card. The legacy pointer is the
+    stale one, so it must not overwrite; and it is dead either way, so the old
+    key is still removed rather than left to be re-examined every boot.
+    """
+
+    async def go() -> None:
+        async with make_harness() as h:
+            await h.card_store.remember(
+                "appr-both",
+                channel="C_NEW",
+                ts="new-ts",
+                summary="The current card",
+                endpoint=None,
+            )
+            legacy_key = f"{h.config.key_prefix}:approval-card:th-both"
+            await h.async_redis.set(
+                legacy_key,
+                _legacy_payload("appr-both", channel="C_OLD", summary="The stale card"),
+                ex=3600,
+            )
+
+            result = await h.card_store.migrate_legacy_thread_keyed_refs()
+            # The current entry is scanned and declined; the legacy one is
+            # scanned, loses the NX race, and is therefore not counted migrated.
+            assert result.scanned == 2
+            assert result.migrated == 0
+
+            entry = await h.card_store.read("appr-both")
+            assert entry is not None
+            ref, _raw = entry
+            assert (ref.channel, ref.summary) == ("C_NEW", "The current card")
+            assert not await h.async_redis.exists(legacy_key)
+
+    asyncio.run(go())
+
+
+def test_a_corrupt_entry_does_not_stop_the_pass(make_harness) -> None:
+    """One unparseable key must not abort the rest of the boot pass.
+
+    Anything could be sitting under this prefix -- a half-written value, a
+    shape from a future layout. The pass counts it as skipped, leaves it alone,
+    and keeps going.
+    """
+
+    async def go() -> None:
+        async with make_harness() as h:
+            garbage = f"{h.config.key_prefix}:approval-card:th-garbage"
+            not_a_dict = f"{h.config.key_prefix}:approval-card:th-list"
+            legacy_key = f"{h.config.key_prefix}:approval-card:th-good"
+            await h.async_redis.set(garbage, "{not json at all", ex=3600)
+            await h.async_redis.set(not_a_dict, json.dumps(["nope"]), ex=3600)
+            await h.async_redis.set(
+                legacy_key, _legacy_payload("appr-after-garbage"), ex=3600
+            )
+
+            result = await h.card_store.migrate_legacy_thread_keyed_refs()
+            assert result.scanned == 3
+            assert result.migrated == 1
+            assert result.skipped == 2
+
+            assert await h.card_store.read("appr-after-garbage") is not None
+            assert await h.async_redis.get(garbage) == "{not json at all"
+            assert await h.async_redis.exists(not_a_dict)
+
+    asyncio.run(go())
+
+
+def test_the_migration_is_idempotent(make_harness) -> None:
+    """A second boot moves nothing: the migrated entry is now current-layout.
+
+    This is what makes an unconditional call at every worker start safe -- once
+    the old key space is drained the pass is a no-op that only pays for one
+    SCAN.
+    """
+
+    async def go() -> None:
+        async with make_harness() as h:
+            legacy_key = f"{h.config.key_prefix}:approval-card:th-twice"
+            await h.async_redis.set(
+                legacy_key, _legacy_payload("appr-twice"), ex=3600
+            )
+
+            first = await h.card_store.migrate_legacy_thread_keyed_refs()
+            assert first.migrated == 1
+            new_key = h.config.approval_card_key("appr-twice")
+            after_first = await h.async_redis.get(new_key)
+
+            second = await h.card_store.migrate_legacy_thread_keyed_refs()
+            assert (second.scanned, second.migrated, second.skipped) == (1, 0, 1)
+            assert await h.async_redis.get(new_key) == after_first
+
+    asyncio.run(go())
+
+
+def test_a_legacy_ref_with_no_expiry_still_migrates_with_the_ceiling(
+    make_harness,
+) -> None:
+    """``PTTL`` -1 is "exists, no expiry", not "gone": it must still move.
+
+    The two negative PTTL replies read alike and mean opposite things. -1 is a
+    live key that simply never had a deadline set, so the standard 14 day
+    ceiling applies -- the same one ``remember`` uses -- and the entry lands on
+    its approval id like any other. Only -2 aborts (below).
+    """
+
+    async def go() -> None:
+        async with make_harness() as h:
+            legacy_key = f"{h.config.key_prefix}:approval-card:th-no-expiry"
+            # No ``ex``/``px``: the key is persistent, so PTTL answers -1.
+            await h.async_redis.set(legacy_key, _legacy_payload("appr-no-expiry"))
+            assert await h.async_redis.pttl(legacy_key) == -1
+
+            result = await h.card_store.migrate_legacy_thread_keyed_refs()
+            assert (result.scanned, result.migrated, result.skipped) == (1, 1, 0)
+
+            assert await h.card_store.read("appr-no-expiry") is not None
+            assert not await h.async_redis.exists(legacy_key)
+
+            new_key = h.config.approval_card_key("appr-no-expiry")
+            ttl_ms = await h.async_redis.pttl(new_key)
+            # The ceiling, not "no expiry": a rekeyed entry must never be the one
+            # key under this prefix that outlives every sweep.
+            assert 13 * 24 * 60 * 60 * 1000 < ttl_ms <= DEFAULT_CARD_TTL_S * 1000
+
+    asyncio.run(go())
+
+
+class _DeletesSourceOnPttl:
+    """The REAL Valkey client, with the GET-then-PTTL window forced open once.
+
+    Everything is delegated to the client the harness built -- the SCAN, the
+    GET, the NX write, the compare-and-delete all run against real Valkey -- and
+    the ONE interposition is that asking for the victim's PTTL deletes it first,
+    so the store observes the -2 ("no such key") reply deterministically instead
+    of waiting on a race no test can schedule.
+    """
+
+    def __init__(self, redis: AsyncRedis, victim: str) -> None:
+        self._redis = redis
+        self._victim = victim
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._redis, name)
+
+    async def pttl(self, key: str | bytes) -> int:
+        name = key.decode() if isinstance(key, bytes) else key
+        if name == self._victim:
+            await self._redis.delete(name)
+        return int(await self._redis.pttl(key))
+
+
+def test_a_source_that_vanishes_before_the_pttl_is_not_resurrected(
+    make_harness,
+) -> None:
+    """``PTTL`` -2 must abort the entry, not mint a fresh fortnight.
+
+    If the legacy key expires or is consumed between the GET and the PTTL, its
+    payload in hand is already stale and the pointer it described has
+    legitimately gone away. Treating that -2 as "no expiry recorded" would write
+    the target with a brand new 14 day life -- resurrecting a card ref the
+    system had finished with. Nothing is written, and nothing is deleted either.
+    """
+
+    async def go() -> None:
+        async with make_harness() as h:
+            legacy_key = f"{h.config.key_prefix}:approval-card:th-vanishes"
+            await h.async_redis.set(
+                legacy_key, _legacy_payload("appr-vanished"), ex=3600
+            )
+            racing = ApprovalCardStore(
+                _DeletesSourceOnPttl(h.async_redis, legacy_key),  # type: ignore[arg-type]
+                h.config,
+            )
+
+            result = await racing.migrate_legacy_thread_keyed_refs()
+            assert (result.scanned, result.migrated, result.skipped) == (1, 0, 1)
+
+            assert not await h.async_redis.exists(
+                h.config.approval_card_key("appr-vanished")
+            ), "a ref that had already gone must not come back with a fresh TTL"
+            assert await h.card_store.read("appr-vanished") is None
+
+    asyncio.run(go())
+
+
+def test_a_self_keyed_legacy_ref_survives_a_bytes_client(make_harness) -> None:
+    """The destructive miss: an un-normalised key compared against a ``str``.
+
+    A store built on a ``decode_responses=False`` client gets ``bytes`` back from
+    the SCAN, while the target it derives is always a ``str``. For a legacy entry
+    whose thread key happens to EQUAL its approval id the two describe the same
+    key, so the "already where it belongs" guard must fire. Compared
+    un-normalised it never does: the NX write loses against the key's own value
+    and the compare-and-delete then removes a live pointer -- the exact stranding
+    this migration exists to end.
+    """
+
+    async def go() -> None:
+        async with make_harness() as h:
+            # Thread key == approval id: the one shape where source and target
+            # are the same key.
+            self_keyed = h.config.approval_card_key("appr-self-keyed")
+            payload = _legacy_payload("appr-self-keyed")
+            await h.async_redis.set(self_keyed, payload, ex=3600)
+
+            raw_redis: AsyncRedis = AsyncRedis(
+                host=h.config.valkey_host,
+                port=h.config.valkey_port,
+                password=h.config.valkey_password or None,
+                db=h.config.valkey_db,
+                decode_responses=False,
+            )
+            try:
+                bytes_store = ApprovalCardStore(raw_redis, h.config)
+                result = await bytes_store.migrate_legacy_thread_keyed_refs()
+                assert (result.scanned, result.migrated, result.skipped) == (1, 0, 1)
+            finally:
+                await raw_redis.aclose()
+
+            assert await h.async_redis.get(self_keyed) == payload, (
+                "the pass must leave the entry exactly where it already was, "
+                "not delete the only pointer to a live card"
+            )
+
+    asyncio.run(go())

--- a/apps/worker/tests/kernel/test_approval_lifecycle.py
+++ b/apps/worker/tests/kernel/test_approval_lifecycle.py
@@ -1633,3 +1633,73 @@ def test_normal_turn_reply_stays_loud_when_endpoint_is_dead(make_harness) -> Non
             assert not await h.async_redis.exists(h.config.done_key(ev.event_id))
 
     asyncio.run(go())
+
+
+def test_a_legacy_thread_keyed_card_is_settled_after_the_boot_migration(
+    make_harness,
+) -> None:
+    """#1751: the stranding a worker roll used to create is gone.
+
+    #1723 rekeyed the card pointer from the thread to the approval id with no
+    dual read, so an approval that was ALREADY PENDING when the workers rolled
+    left its ref under the old thread key where ``_finalize_settled_card``
+    could never see it. A resolve click still healed such a card from its
+    interaction payload; an EXPIRY has no click, so the buttons stayed live for
+    the rest of the 14 day TTL.
+
+    This is the end-to-end shape of the fix: seed the pre-#1723 entry exactly
+    as the old worker wrote it (thread-keyed, ``approval_id`` in the payload),
+    run the one-shot boot migration, then drive the expiry resume turn the #412
+    sweeper enqueues and assert the card is actually settled in place.
+    """
+
+    async def go() -> None:
+        thread = "th-legacy-roll"
+        async with make_harness(approvals=RecordingApprovals()) as h:
+            # Written by the PREVIOUS worker version: keyed by thread, with the
+            # approval id inline (#1199) -- the only reason it is recoverable.
+            legacy_key = f"{h.config.key_prefix}:approval-card:{thread}"
+            await h.async_redis.set(
+                legacy_key,
+                json.dumps(
+                    {
+                        "channel": "C1",
+                        "ts": "posted-legacy",
+                        "summary": "Give ACME a 20% discount",
+                        "endpoint": None,
+                        "requested_by": "U1",
+                        "kind": "slack",
+                        "adapter": None,
+                        "approval_id": "appr-1",
+                    }
+                ),
+                ex=3600,
+            )
+            # Boot: the one-shot pass ``run._run`` makes before any consumer reads.
+            assert (await h.card_store.migrate_legacy_thread_keyed_refs()).migrated == 1
+            assert not await h.async_redis.exists(legacy_key)
+
+            h.runner.default_script = [Final(text="Acknowledged the expiry.", status=DONE)]
+            await h.kernel.process_event(
+                _resume_turn(
+                    "[approval expired] not approved in time",
+                    thread=thread,
+                    approval_id="appr-1",
+                    author="system",
+                )
+            )
+
+            # The buttons are gone: the card was edited in place at the address
+            # the LEGACY entry remembered, with its remembered summary.
+            assert len(h.sink.card_updates) == 1
+            channel, ts, message, endpoint, settled = h.sink.card_updates[0]
+            assert (channel, ts) == ("C1", "posted-legacy")
+            assert endpoint is None
+            assert message.text == "Give ACME a 20% discount"
+            assert settled is not None and settled.decision is None
+            assert settled.requested_by == "U1"
+
+            # And the migrated memory was consumed, so a redelivery no-ops.
+            assert not await h.async_redis.exists(h.config.approval_card_key("appr-1"))
+
+    asyncio.run(go())

--- a/apps/worker/tests/test_run.py
+++ b/apps/worker/tests/test_run.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from curie_worker import run
 from curie_worker.config import WorkerConfig
 from curie_worker.run import (
     _MAX_TUNABLE_SECONDS,
@@ -540,3 +541,193 @@ def test_crashing_supervised_task_does_not_cancel_its_siblings() -> None:
         assert sibling_ran["ok"] is True
 
     asyncio.run(go())
+
+
+# -- #1751: the boot rekey is CALLED by _run, once, before any consumer reads --
+#
+# Every other test of the legacy approval-card migration drives
+# ``ApprovalCardStore.migrate_legacy_thread_keyed_refs`` directly on the store,
+# so all of them would still pass with the boot call deleted from ``_run`` --
+# and the whole #1751 fix would be dead in production behind a green suite.
+# These four pin the call site itself: it happens, it happens BEFORE the
+# consumers start (a legacy ref must be rekeyed before any resume turn is
+# read), and neither a failure nor a budget overrun stops the worker booting.
+
+
+class _FakeCardStore:
+    """Records the boot rekey, and can fail or stall the way Valkey would.
+
+    ``events`` is the one ordering log shared with the fake consumers, so a
+    single list witnesses both that the migration ran and where it ran relative
+    to the reads it must precede.
+    """
+
+    def __init__(
+        self,
+        events: list[str],
+        *,
+        raises: BaseException | None = None,
+        stall_s: float = 0.0,
+    ) -> None:
+        self._events = events
+        self._raises = raises
+        self._stall_s = stall_s
+
+    async def migrate_legacy_thread_keyed_refs(self) -> None:
+        # Recorded before the stall so the ordering assertion still holds on the
+        # budget-overrun path, where the call is cancelled rather than returning.
+        self._events.append("migrate")
+        if self._stall_s:
+            await asyncio.sleep(self._stall_s)
+        if self._raises is not None:
+            raise self._raises
+
+
+class _FakeSupervisedTask:
+    """A consumer whose ``run`` records itself and returns immediately, so each
+    ``_supervise`` settles on a clean completion and the top-level gather
+    finishes without needing a signal to arrive."""
+
+    def __init__(self, events: list[str], name: str) -> None:
+        self._events = events
+        self._name = name
+
+    async def run(self) -> None:
+        self._events.append(self._name)
+
+    def request_stop(self) -> None:
+        # Only reachable through the signal handler, which these tests never fire.
+        pass
+
+
+class _FakeTransport:
+    """Stands in for every long-lived resource ``_run``'s finally block disposes;
+    one class covers all three disposal verbs the runtime's fields use."""
+
+    async def close(self) -> None:
+        pass
+
+    async def aclose(self) -> None:
+        pass
+
+    async def dispose(self) -> None:
+        pass
+
+
+class _FakeRuntime:
+    """Exactly the attributes ``_run`` touches -- deliberately not a real
+    ``Runtime``, so nothing here reaches Valkey, Postgres, or the substrate."""
+
+    def __init__(self, card_store: _FakeCardStore, events: list[str]) -> None:
+        self.card_store = card_store
+        self.consumer = _FakeSupervisedTask(events, "runs")
+        self.killswitch = _FakeSupervisedTask(events, "killswitch")
+        self.eval_consumer = _FakeSupervisedTask(events, "evals")
+        self.connector_loop = None
+        self.runner = _FakeTransport()
+        self.sink = _FakeTransport()
+        self.eval_http = _FakeTransport()
+        self.async_redis = _FakeTransport()
+        self.eval_redis = _FakeTransport()
+        self.engine = _FakeTransport()
+
+
+def _boot(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    raises: BaseException | None = None,
+    stall_s: float = 0.0,
+) -> list[str]:
+    """Drive one full ``_run`` boot against the fakes and return the event log.
+
+    The card store is built here rather than passed in, so it records into the
+    very list the fake consumers append to: one shared log is what makes the
+    ordering assertion meaningful, and a store built by the caller would write
+    its "migrate" marker into a list this function never returns.
+
+    ``build`` and ``run_heartbeat`` are the only two things stubbed: the first
+    because wiring the real runtime would open sockets, the second because the
+    real heartbeat never returns and would hang the gather. The migration call
+    site under test is untouched.
+    """
+    events: list[str] = []
+    card_store = _FakeCardStore(events, raises=raises, stall_s=stall_s)
+
+    def fake_build(config: WorkerConfig, env: Any) -> _FakeRuntime:
+        return _FakeRuntime(card_store, events)
+
+    async def fake_heartbeat(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr(run, "build", fake_build)
+    monkeypatch.setattr(run, "run_heartbeat", fake_heartbeat)
+    # The outer wait_for is a deadlock guard, not the behaviour under test: a
+    # regression that leaves _run blocked must fail this suite, not hang CI.
+    asyncio.run(asyncio.wait_for(run._run(WorkerConfig(), {}), timeout=10))
+    return events
+
+
+def test_run_migrates_legacy_card_refs_once_at_boot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events = _boot(monkeypatch)
+    # Exactly once: it is a boot migration, not something supervised or retried,
+    # and a second pass would re-walk the keyspace on every restart for nothing.
+    assert events.count("migrate") == 1
+
+
+def test_run_migrates_legacy_card_refs_before_the_consumers_start(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The ordering the whole fix rests on. A ref still under the pre-#1723 thread
+    # key must be rekeyed onto its approval id BEFORE the runs consumer can read
+    # a resume turn for it -- otherwise the card the turn settles is the one the
+    # migration has not reached yet, which is the stranding #1751 exists to end.
+    events = _boot(monkeypatch)
+    assert events[0] == "migrate"
+    assert "runs" in events
+
+
+def test_run_boots_the_consumers_when_the_migration_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # A Valkey blip during a best-effort boot migration must degrade to "those
+    # cards stay live until their TTL", never to a worker that will not start.
+    with caplog.at_level(logging.WARNING, logger="curie_worker.run"):
+        events = _boot(monkeypatch, raises=RuntimeError("valkey down"))
+
+    assert events.count("migrate") == 1
+    assert "runs" in events  # boot continued past the failure
+    failures = [
+        r
+        for r in caplog.records
+        if r.name == "curie_worker.run" and "migration failed" in r.getMessage()
+    ]
+    assert len(failures) == 1
+    assert failures[0].levelno == logging.ERROR
+
+
+def test_run_boots_the_consumers_when_the_migration_exceeds_its_budget(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # The bound exists because this pass runs BEFORE the liveness heartbeat
+    # starts: unbounded, a degraded Valkey stalls readiness until the exec probe
+    # kills the pod, and a best-effort migration becomes a restart loop. The
+    # budget is monkeypatched rather than waited out, so the test neither takes
+    # 30 seconds nor hard-codes the production number.
+    monkeypatch.setattr(run, "_CARD_MIGRATION_BUDGET_S", 0.01)
+    with caplog.at_level(logging.WARNING, logger="curie_worker.run"):
+        # Far past the patched budget; wait_for cancels it, so nothing waits 30s.
+        events = _boot(monkeypatch, stall_s=30.0)
+
+    assert events.count("migrate") == 1
+    assert "runs" in events  # boot continued past the cut-short migration
+    cut_short = [
+        r
+        for r in caplog.records
+        if r.name == "curie_worker.run" and "cut short" in r.getMessage()
+    ]
+    assert len(cut_short) == 1
+    assert cut_short[0].levelno == logging.WARNING

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -556,6 +556,39 @@ previous chart. Deleting a StatefulSet does not delete the PVCs its
 `volumeClaimTemplates` created, so the old store's volume survives the upgrade
 and the rollback re-attaches it with the data intact. Keep the export anyway.
 
+### Approvals pending across a worker roll
+
+An upgrade restarts the worker, and an approval can easily be pending for hours
+or days -- so approvals routinely straddle a roll. The worker remembers where it
+posted each Slack approval card so it can settle that card (strip the
+Approve/Reject buttons) when the approval is resolved out of band or EXPIRES.
+That memory used to be keyed by conversation and is now keyed by approval id.
+
+A resolution through the buttons carries its own card location, so it settles
+either way. An **expiry** carries no click: if the worker cannot find the
+remembered card, the expired approval keeps buttons that answer every later
+click with an error.
+
+**No operator action is required.** On startup the worker moves any remaining
+conversation-keyed entries onto their approval id once, so those approvals
+settle normally. The pass is best-effort and cannot fail startup; if Valkey is
+unreachable at that moment the affected cards simply stay live until their
+memory lapses (14 days).
+
+One narrow window stays open while the roll is in progress. The startup pass
+runs once, so it cannot see an entry written after it finished -- and a replica
+still on the old build keeps serving, and keeps recording cards the old way,
+until it is replaced. An approval created by such a replica after the new one
+started can therefore still keep live buttons if it later expires. The window
+closes on its own once the roll completes and every replica is on the new
+build; anything missed lapses with its existing 14 day memory.
+
+One residual case is not recoverable: a card remembered by a build old enough
+that the entry did not record which approval it belonged to cannot be paired
+with anything. If such an approval expires, its message keeps its buttons.
+Edit or delete that Slack message by hand, or ignore it -- the approval itself
+is expired in the API either way, so a click on it cannot approve anything.
+
 ## Known gotchas
 
 Notes from the first installs of the chart on fresh clusters, kept for the


### PR DESCRIPTION
Closes #1751

## What broke

#1723 moved the approval-card pointer from a thread-keyed Valkey entry to an approval-keyed one with no dual read. An approval already pending when the workers roll keeps its Approve and Reject buttons live forever if it later expires: the resolution path edits the card from the click payload, but an expiry has no click, so `Kernel._finalize_settled_card` is the only thing that can disable it, and it looks under a key the old worker never wrote.

## Approach

The issue offers two options -- a one-shot sweep over the old key space, or a release note telling operators to drain approvals before upgrading -- and rules out reinstating a dual read. This takes the sweep, because the pre-#1723 payload already records the approval id (#1199), which makes an exact rekey possible and gives a clean legacy-vs-current discriminator: the current `ApprovalCardRef` does not carry that field, so an entry that has one is legacy by construction. There is still no runtime dual read; `read()` remains single-keyed.

`ApprovalCardStore.migrate_legacy_thread_keyed_refs()` runs once at boot and rekeys legacy entries onto their approval id, so the ordinary settle path finds them. It is marked in-code as transitional and safe to delete once no supported upgrade path starts from a worker older than #1723.

Behaviour worth calling out:

- **Remaining TTL is carried**, not reset, so an approval near its SLA is not resurrected for another fortnight. A `PTTL` of `-2` means the source vanished under the pass and aborts that entry rather than re-creating it; `-1` (no expiry) takes the standard ceiling.
- **`SET NX` on the target**, so a newer ref the upgraded worker already wrote always wins over a stale legacy pointer. The old key is removed with the existing compare-and-delete, so a still-running old replica that rewrote it mid-pass is not clobbered.
- **The pass skips keys it wrote itself.** It writes into the keyspace it scans, and Valkey does not guarantee whether such a key is returned by an in-flight SCAN. Without the guard the counts and the operator-facing summary are nondeterministic -- observed directly: the test passed in isolation and failed in the full suite.
- **The pass is bounded by a timeout at the boot call.** The liveness heartbeat does not start until it returns, so an unbounded pass against a degraded Valkey is a pod restart loop, not a slow migration.
- **It streams via `scan_iter`** rather than materialising the keyspace, and never fails boot.

## Residuals, documented for operators in `docs/operations.md`

- A ref remembered before #1199 records no approval id, is not migratable, and keeps its buttons if it expires.
- A one-shot pass cannot see a thread-keyed entry an old replica writes *after* it has already run. Closing that would need the dual read the issue rules out; the window shuts when the roll completes.

## Verification

Full `apps/worker` suite against a real Valkey, Postgres, RustFS, ClickHouse and Langfuse: **924 passed, 7 skipped, 0 failed**. The 7 skips are the opt-in cluster E2E tests, the same 7 skipped on `origin/main`. `ruff`, `mypy`, `lint-imports`, the docs gate, the wire-tolerance gate and the alembic gate are all clean.

Regression coverage is red-on-revert, verified three ways rather than assumed:

1. Reverting the three production files to `origin/main` fails 10 of the new tests and passes the 35 pre-existing ones.
2. Mutating the rekey to write the wrong target key fails the end-to-end test on its behavioural assertion (`card_updates` 0 vs 1) -- the exact stranding in this issue.
3. Deleting the boot call from `_run` fails all four wiring tests.

The third check exists because the first version of those wiring tests was vacuous: the fake card store recorded into a different list than the one asserted, so they failed against correct code and would have proved nothing.

## Done-check

- [ ] N/A -- failing tests committed first (build-tier item; this ran quick tier)
- [x] All production edits made by delegated sub-agents; no inline driver edits
- [x] No broadened public return types (`read()` and `consume()` keep their exact signatures and behaviour)
- [x] Adversarial Code review completed via agent-router (Codex `gpt-5.6-sol`), findings applied
- [x] Adversarial Scope review completed via agent-router; every hunk mapped, dispositions below
- [x] Sibling-path parity -- N/A: `approval_card_key` has a single owner (`ApprovalCardStore`); the dispatcher and CLI reach approval cards through Slack action ids, not this key
- [x] Guard demonstration -- the legacy discriminator was executed against violating inputs: a current-layout entry, a pre-#1199 entry, a corrupt entry, and a self-keyed entry under a `decode_responses=False` client all survive untouched
- [x] Consolidation pass ran, applied edits, revalidated, and was re-reviewed adversarially (no findings)
- [ ] N/A -- Security reviewer (no security scale-up)
- [x] Observable verification: the settled card edit is asserted end-to-end through the real kernel path against real Valkey
- [ ] N/A -- deployed E2E: no compose, helm, RBAC or env-boundary change; the seam this touches is Valkey, exercised directly by real-Valkey integration tests
- [x] Full affected suite, typecheck and lint clean

## Scope dispositions

Four hunks the scope reviewer flagged, kept deliberately:

- **`_parse_ref` / `_load` extraction touching `read()`** -- a shared helper rather than a second copy of the parse, which the parity rule explicitly allows. Consolidation additionally found the two original helpers caught *different* exception sets; one decode now owns that.
- **`written_targets`** -- not merely accounting. The nondeterminism was observed, not theorised, and the counts appear in the operator-facing summary.
- **`kernel.py` docstring** -- docstring only, zero behaviour change, and the minimum correction of a statement this PR makes false ("those refs are not automatically settled"). Leaving it would be an actively wrong docstring on the sacred module.
- **`docs/operations.md`** -- the issue names the operator note as a deliverable, and the rolling-upgrade residual above is only discoverable there.
