### PR TITLE
Name the approval's bound channel in the resolve hint

### DIFF
--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -1452,6 +1452,40 @@ impl ApiClient {
             .context("decoding approvals")
     }
 
+    /// One approval by id: `GET /approvals/{approval_id}`, mirroring the
+    /// endpoint at `apps/api/src/curie_api/routers/approvals.py:92-98`. Answers
+    /// 404 when the id names no approval, which a resolve or an expiry by
+    /// another operator makes a real answer rather than a theoretical one.
+    ///
+    /// The CLI reads this for `card_channel` (#1531 finding 3): a route binding
+    /// can put the card in a channel other than the one the turn spoke in, and
+    /// the printed resolve hint has to name the channel the server's authorizer
+    /// actually compares `--actor-channel` against. The single-record read is
+    /// what the hint needs rather than [`Self::list_pending_approvals`], whose
+    /// page is capped at the server max and can simply not contain the approval
+    /// being waited on (#670).
+    ///
+    /// Deliberately UNBOUNDED here, unlike [`Self::check_git_flow_routing`]:
+    /// this stays a plain mirror of the endpoint like every other method, so a
+    /// future non-advisory caller is not silently capped. The deadline belongs
+    /// to the advisory caller, which is where the reasoning for a specific
+    /// budget lives (`message::hint_channel`).
+    pub async fn get_approval(&self, approval_id: &str) -> Result<ApprovalRecord> {
+        let resp = self
+            .send_request(
+                self.http
+                    .get(format!("{}/approvals/{approval_id}", self.base_url))
+                    .header("X-API-Key", &self.api_key),
+                "GET /approvals/{id}",
+            )
+            .await?;
+        Self::expect_ok(resp, "reading an approval")
+            .await?
+            .json()
+            .await
+            .context("decoding the approval")
+    }
+
     /// Resolve one approval as a chosen actor: `POST /approvals/{id}/resolve`.
     /// The server owns the resolve-once CAS, the authorizer (self-approval block,
     /// route approvers), and the resume-turn enqueue; `resolved_by` is the acting

--- a/cli/src/chat.rs
+++ b/cli/src/chat.rs
@@ -83,7 +83,7 @@ const SCAN_ERROR_WARN_THRESHOLD: u32 = 5;
 
 /// Caps a per-call timeout budget at the time remaining before `deadline`, so
 /// a fixed per-call timeout can never overrun the caller's overall deadline.
-fn capped(budget: Duration, deadline: Instant) -> Duration {
+pub(crate) fn capped(budget: Duration, deadline: Instant) -> Duration {
     budget.min(deadline.saturating_duration_since(Instant::now()))
 }
 

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -5239,10 +5239,26 @@ impl crate::ui::CliOutput for ApprovalsOutput {
                     for r in records {
                         let tool = r.granted_tool.as_deref().unwrap_or("-");
                         let route = r.route.as_deref().unwrap_or("(requesting channel)");
+                        // A null card_channel means an older row or a direct API
+                        // write that omitted the field, for which the requesting
+                        // channel applies (#1431); it must NOT render as "null",
+                        // "none" or "-", which would state the wrong fact.
+                        // The server picks approvers from `card_channel or
+                        // reply_channel`, and in Python only the empty string
+                        // is falsy, so an empty card_channel is absent too and
+                        // must show the same requesting-channel meaning as the
+                        // resolve hint in message.rs. A whitespace-only channel
+                        // is truthy in Python and is NOT absent, so it is still
+                        // printed verbatim here; do not trim it.
+                        let card = r
+                            .card_channel
+                            .as_deref()
+                            .filter(|c| !c.is_empty())
+                            .unwrap_or("(requesting channel)");
                         ui.kv(
                             &r.id,
                             &format!(
-                                "{} — {} [tool: {tool}, route: {route}, by: {}]",
+                                "{} — {} [tool: {tool}, route: {route}, channel: {card}, by: {}]",
                                 r.summary, r.conversation_id, r.author
                             ),
                         );

--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -34,8 +34,8 @@ use tokio::io::{AsyncBufReadExt, BufReader};
 
 use crate::api::{Agent, ApiClient};
 use crate::chat::{
-    await_reply, await_resume, continue_hint_line, continue_hint_long_line, parse_approval_id,
-    resolve_targets, Outcome, SlackStub,
+    await_reply, await_resume, capped, continue_hint_line, continue_hint_long_line,
+    parse_approval_id, resolve_targets, Outcome, SlackStub,
 };
 use crate::evals::{EvalCase, EvalSuite, ExpectedStatus, LoadedEval};
 use crate::ops::{plain, require_on_path, run_capture, OpsCommand};
@@ -1992,6 +1992,160 @@ async fn message_local(opts: MessageOpts) -> Result<()> {
     }
 }
 
+/// The whole budget for one advisory hint-channel lookup, port-forward startup
+/// included (#1531 finding 3).
+///
+/// Modeled on [`ApiClient::check_git_flow_routing`], which is this crate's
+/// established shape for an advisory read that must never become a hang: 10s is
+/// far past a healthy answer and far short of an operator's patience. The bound
+/// is applied ONCE around the entire lookup rather than per request, because the
+/// cluster arm spends most of its time in `start_port_forward` and a per-request
+/// deadline would leave that unbounded. `ApiClient::new` sets only
+/// `connect_timeout`, so a peer that accepts the connection and then never sends
+/// headers would otherwise wait forever -- and this runs INSIDE the resume wait,
+/// where forever means a frozen terminal on a turn whose durable approval is
+/// already fine.
+///
+/// A CEILING, not the effective budget. Because this runs inside the resume
+/// wait, spending it on top of the turn's own deadline would make
+/// `--timeout-secs 1` take about eleven seconds, and every nested gate would add
+/// another ten. [`hint_channel`] therefore caps it with
+/// [`crate::chat::capped`] against the turn deadline, which is the invariant
+/// `cli/src/chat.rs:497-499` already states for the resume scan: "Every per-op
+/// budget is capped by what is LEFT of the overall deadline, so the advertised
+/// `--timeout-secs` is a hard bound on this path too rather than being overrun
+/// by up to one fixed scan budget" (#1531).
+const HINT_CHANNEL_LOOKUP_BUDGET: Duration = Duration::from_secs(10);
+
+/// The channel the pre-wait resolve hint should name for approval `id`: the
+/// approval's own `card_channel` when a route binding placed the card somewhere
+/// other than where this turn spoke, else `turn_channel` (#1531 finding 3).
+///
+/// ADVISORY, and deliberately incapable of failing or delaying the turn. Every
+/// non-answer -- an unreachable API, a 404 because another operator resolved the
+/// approval first, a 5xx, a body that does not decode, an expired budget, a null
+/// or empty `card_channel` -- returns `turn_channel`, which is byte-for-byte what the
+/// hint printed before this change. The worst case is therefore the status quo,
+/// never a regression. Nothing here propagates: no `?` and no `unwrap` escapes
+/// the wrapper, since the caller is mid-wait on a durable approval and has
+/// nothing useful to do with an error.
+///
+/// A null `card_channel` means "an older row or a direct API write, so the
+/// requesting channel applies" (#1431), and the requesting channel IS the turn
+/// channel -- so it takes the same fallback rather than printing an empty or
+/// literal-null `--actor-channel`.
+///
+/// An EMPTY (or whitespace-only) `card_channel` takes that same fallback, and
+/// the reason is the server, not caution. The wire model admits
+/// `card_channel: ""` (`packages/aci-protocol/src/aci_protocol/wire.py`), and
+/// the authorizer selects the approver set as
+/// `approval.card_channel or approval.reply_channel`
+/// (`apps/api/src/curie_api/slack_approvers.py`). An empty string is FALSY in
+/// Python, so the server itself reads it as absent and falls back to
+/// `reply_channel` -- which is the turn channel. Echoing the empty value back
+/// would render `--actor-channel ''`, which that same membership check refuses
+/// 403 with "resolve this from the approval's channel": the exact failure #1531
+/// exists to remove. "Empty string is not the same as absent" is true in Rust
+/// and false on this wire, so do not collapse this arm back into a plain
+/// `Some(_)` match.
+///
+/// `deadline` is the TURN's overall deadline, not this lookup's. The effective
+/// bound is `capped(HINT_CHANNEL_LOOKUP_BUDGET, deadline)`, so a short
+/// `--timeout-secs` shortens the lookup instead of being overrun by it
+/// (`cli/src/chat.rs:497-499`, #1531).
+///
+/// Tier dispatch mirrors how each tier already reaches the API for the
+/// default-channel lookup: local talks straight to the compose API at
+/// [`local_api_base`], cluster opens a short-lived `kubectl port-forward` the way
+/// [`resolve_cluster_channel`] does. The cluster guard is created and dropped
+/// entirely INSIDE this function, so no forward is ever held across
+/// [`await_resume`] and the (possibly full `--timeout-secs`) wait. Because the
+/// budget wraps the port-forward startup too, an expiry drops the in-flight
+/// future, whose `kill_on_drop` Drop reaps the child: there is no path where the
+/// deadline fires and leaves a `kubectl port-forward` orphaned to init, which is
+/// the tracked regression class from #751/#766.
+async fn hint_channel(
+    opts: &MessageOpts,
+    verb: TurnVerb,
+    turn_channel: &str,
+    id: &str,
+    deadline: Instant,
+) -> String {
+    let lookup = async {
+        // The port-forward guard is bound HERE, in the enclosing async block,
+        // and deliberately NOT inside the cluster match arm. `start_port_forward`
+        // returns the `kubectl port-forward` child with `kill_on_drop(true)`, so
+        // the binding's scope IS the forward's lifetime. An arm-scoped binding
+        // ends when the arm yields its value, which is one line BEFORE
+        // `get_approval` runs: the child is reaped, the local port goes dead, the
+        // request fails, and the advisory wrapper silently degrades to the turn
+        // channel, so the cluster tier could never resolve a card channel. That
+        // was observed against a live cluster, where the approval row held the
+        // route's channel and `approvals --list` read it correctly through its
+        // own forward while this hint still printed the turn channel (#1531).
+        // Do not "tidy" this back into the arm.
+        //
+        // Binding it here still keeps the guard entirely inside this helper: it
+        // drops at the end of this async block, after `get_approval` has
+        // resolved, so no forward is held across `await_resume`, and a timeout
+        // drops this future part way through and runs the same Drop, which is
+        // what keeps an expiry from orphaning a `kubectl port-forward` to init
+        // (the tracked leak class from #751/#766).
+        let (_api_pf, api_base) = match verb {
+            TurnVerb::Local => (
+                // No forward on the local tier: compose publishes the API, so the
+                // guard slot stays empty and this arm behaves exactly as before.
+                None,
+                local_api_base(opts.api_url.as_deref()),
+            ),
+            TurnVerb::Cluster => {
+                let (api_pf, api_local_port) = start_port_forward(
+                    &port_forward_command(
+                        &opts.namespace,
+                        &opts.release,
+                        "api",
+                        opts.api_local_port,
+                        API_REMOTE_PORT,
+                    ),
+                    opts.api_local_port,
+                    "api",
+                )
+                .await
+                .ok()?;
+                (Some(api_pf), format!("http://127.0.0.1:{api_local_port}"))
+            }
+        };
+        let api = ApiClient::new(&api_base, &opts.api_key).ok()?;
+        api.get_approval(id).await.ok()?.card_channel
+    };
+    // Capped, never fixed: the lookup may spend the advisory budget or what is
+    // LEFT of the turn, whichever is smaller, so it can never outlive the turn
+    // it is decorating (#1531; `cli/src/chat.rs:497-499`). Reuses the same
+    // `capped` helper the resume scan uses rather than a second copy of the
+    // bound.
+    match tokio::time::timeout(capped(HINT_CHANNEL_LOOKUP_BUDGET, deadline), lookup).await {
+        // A present, non-empty card channel is the only real answer. The
+        // emptiness guard is load-bearing, not defensive: the server reads
+        // `approval.card_channel or approval.reply_channel`, and in Python
+        // that `or` treats ONLY the empty string as falsy. A whitespace-only
+        // value such as a single space is truthy there, so the authorizer
+        // treats it as a real card channel and compares `--actor-channel`
+        // against it byte for byte. This arm must mirror that exactly and
+        // print a whitespace-only channel verbatim rather than trimming it
+        // away (#1531, see the doc comment above). Do not add `.trim()` back:
+        // a trimmed whitespace-only channel would degrade to the turn
+        // channel, and the printed command would then name a channel the
+        // server does not accept for this approval, drawing exactly the 403
+        // that #1531 exists to remove.
+        Ok(Some(card_channel)) if !card_channel.is_empty() => card_channel,
+        // Every remaining arm is the same answer: "no answer". An expired budget
+        // is indistinguishable from a 500 here, and a null or empty
+        // `card_channel` means the requesting channel applies -- all of them
+        // print what the hint printed before this change.
+        Ok(_) | Err(_) => turn_channel.to_string(),
+    }
+}
+
 /// The one runnable `approvals --resolve` command shape, shared by the pre-wait
 /// hint and the terminal wording so the two cannot drift (#766).
 ///
@@ -2010,9 +2164,18 @@ async fn message_local(opts: MessageOpts) -> Result<()> {
 ///   is refused 403 ("resolve this from the approval's channel"). The channel this
 ///   turn routed to IS `reply_channel`, so it is the correct value in the common
 ///   case; a route binding that placed the card elsewhere carries a different
-///   `card_channel`, which `approvals --list` reports. (Route bindings that
-///   declare `approvers.users`/`approvers.group` ignore the channel entirely, so
-///   passing it is harmless there.)
+///   `card_channel`. The pre-wait hint now resolves that `card_channel` itself
+///   whenever it has an approval id in hand ([`hint_channel`], #1531), so the
+///   caller hands this formatter the corrected value; `approvals --list` remains
+///   the fallback for the terminal arms that carry no parseable id and so print
+///   the literal `<id>`. (Route bindings that declare
+///   `approvers.users`/`approvers.group` ignore the channel entirely, so passing
+///   it is harmless there.)
+///
+/// This stays a PURE formatter: it renders the channel it is GIVEN, verbatim,
+/// and does no I/O. The lookup lives in the caller precisely so a string helper
+/// shared by an async wait and a terminal print does not acquire a network
+/// dependency.
 fn approval_resolve_command(tier: &str, agent: Option<&str>, channel: &str, id: &str) -> String {
     let agent = agent.unwrap_or("<AGENT>");
     format!("curie {tier} approvals {agent} --resolve {id} --as <user> --actor-channel '{channel}'")
@@ -2113,14 +2276,57 @@ async fn resume_after_approval(
     const MAX_NESTED_GATES: usize = 64;
     let mut current_id = id.to_string();
     let mut last_reply = awaiting_reply;
+    // The channel the most recent pre-wait hint was resolved for, hoisted out of
+    // the loop the same way `last_reply` is and for the same reason: the POST-loop
+    // terminal has to report what the last iteration observed. The terminal line
+    // is the one an operator actually copies once the wait gives up, so it must
+    // not restate the turn channel the pre-wait hint just corrected (#1531).
+    // Invariant: this is the channel resolved for the CURRENT `current_id`, or the
+    // turn channel when nothing has been resolved for that id yet -- never a value
+    // resolved for a different approval.
+    let mut last_hint_channel = channel.to_string();
     for _ in 0..MAX_NESTED_GATES {
         let remaining = deadline.saturating_duration_since(Instant::now());
         if remaining.is_zero() {
             break;
         }
+        // Resolve the hint's channel PER ITERATION, against `current_id`. A
+        // nested gate advances `current_id` to a different approval that may be
+        // bound to a different route, and reusing the first approval's channel
+        // for the second would be a confidently wrong value -- strictly worse
+        // than the turn channel, because the operator has no signal it is wrong
+        // (#1531). Skipped under `--json`, where `ui.note` prints nothing and
+        // the lookup would be a pure cost, the same way the timeout terminal
+        // skips its diagnostics read on that path.
+        // Assigned rather than re-bound per iteration so the post-loop terminal
+        // reads the SAME resolved value the hint printed. Under `--json` this is
+        // the turn channel with no lookup, exactly as before, so that path stays
+        // byte-identical.
+        last_hint_channel = if ui.json() {
+            channel.to_string()
+        } else {
+            hint_channel(opts, verb, channel, &current_id, deadline).await
+        };
+        // Recompute AFTER the lookup, because the lookup itself consumes turn
+        // time. The pre-lookup value is stale by up to the whole lookup budget,
+        // and `await_resume` starts a FRESH deadline from whatever it is handed
+        // -- so passing the stale value made `--timeout-secs 1` take about
+        // eleven seconds and let every nested gate add another lookup on top
+        // (#1531). Capping the lookup alone does not fix this half: the lookup
+        // is bounded either way, but the wait must be told what is actually
+        // left, or the advertised `--timeout-secs` stops being the hard bound
+        // `cli/src/chat.rs:497-499` promises.
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            // The lookup consumed the remainder. Exit exactly as the top-of-loop
+            // check would on any other exhausted deadline -- the approval stays
+            // durable and resolvable -- rather than entering the wait with a
+            // zero budget, which would print "waiting..." and return instantly.
+            break;
+        }
         ui.note(&format!(
             "resolve it with: {}",
-            approval_resolve_command(tier, agent, channel, &current_id)
+            approval_resolve_command(tier, agent, &last_hint_channel, &current_id)
         ));
         ui.note(
             "waiting for the approval to be resolved; the resumed reply lands here if it is \
@@ -2164,6 +2370,13 @@ async fn resume_after_approval(
                     Some(new_id) => {
                         current_id = new_id;
                         last_reply = new_reply;
+                        // The hoisted hint belonged to the PREVIOUS approval, which
+                        // may be bound to a different route. Drop it back to the
+                        // turn channel so a break at the next loop boundary reports
+                        // a merely-imprecise channel rather than a confidently wrong
+                        // one the operator has no signal about (#1531); the next
+                        // iteration's lookup replaces it before any wait.
+                        last_hint_channel = channel.to_string();
                         // Loop: wait on the nested approval's resume entry.
                         continue;
                     }
@@ -2199,13 +2412,18 @@ async fn resume_after_approval(
                 return ResumeExit::Transient;
             }
             Outcome::TimedOut => {
-                // Never resolved: the durable approval is still pending.
+                // Never resolved: the durable approval is still pending. Report the
+                // channel the pre-wait hint just resolved for THIS `current_id`,
+                // not the turn channel: this terminal is the last line printed and
+                // the one the operator copies after the wait gives up, so restating
+                // the already-corrected channel here would undo the fix on the very
+                // path that needs it (#1531).
                 ui.emit(&MessageOutcomeOutput::AwaitingApproval {
                     thread: thread_ts.to_string(),
                     reply: last_reply,
                     tier,
                     agent: agent.map(str::to_string),
-                    channel: channel.to_string(),
+                    channel: last_hint_channel,
                 });
                 // Persist the turn context even on the transient exit so a follow-up
                 // `--continue` still has the thread to resume against.
@@ -2215,13 +2433,18 @@ async fn resume_after_approval(
         }
     }
     // The deadline elapsed at a loop boundary, or the nested-gate cap was hit. The
-    // current approval is still pending and resolvable later.
+    // current approval is still pending and resolvable later. Same reason as the
+    // in-loop timeout terminal: this is the last line the operator sees and copies,
+    // so it reports the hoisted hint rather than re-stating the turn channel
+    // (#1531). No lookup happens here -- if no iteration ever ran (the deadline was
+    // already spent on entry), the hoisted value is still the turn channel, exactly
+    // as this emit read before.
     ui.emit(&MessageOutcomeOutput::AwaitingApproval {
         thread: thread_ts.to_string(),
         reply: last_reply,
         tier,
         agent: agent.map(str::to_string),
-        channel: channel.to_string(),
+        channel: last_hint_channel,
     });
     persist_and_hint(opts, verb, channel, thread_ts);
     ResumeExit::Transient
@@ -2797,9 +3020,13 @@ pub async fn message(mut opts: MessageOpts) -> Result<()> {
             // the identical context and print the continue hint once.
             persist_turn_quietly(&opts, TurnVerb::Cluster, &channel, &thread_ts);
             // Keep the stub alive and wait for the resumed reply instead of
-            // exiting and stranding it (#766). The wait observes the resume turn
-            // on the runs stream over the Valkey connection already open for the
-            // enqueue, so no API port-forward is needed for it. If we cannot parse
+            // exiting and stranding it (#766). The resume scan itself observes
+            // the resume turn on the runs stream over the Valkey connection
+            // already open for the enqueue, so it needs no API port-forward. The
+            // per-id resolve-hint channel lookup DOES open one (`hint_channel`,
+            // #1531), but it is short-lived: bounded by
+            // `HINT_CHANNEL_LOOKUP_BUDGET` and dropped before the wait is
+            // entered, so no forward child is held across it. If we cannot parse
             // an approval id, fall back to the awaiting-approval terminal rather
             // than hanging.
             match parse_approval_id(reply.as_deref().unwrap_or_default()) {
@@ -4210,6 +4437,768 @@ mod tests {
         assert!(line.contains("approvals <AGENT> --resolve"), "{line}");
         assert!(line.contains("--actor-channel 'C-SIM-xyz'"), "{line}");
         assert!(line.starts_with("curie cluster approvals"), "{line}");
+
+        // #1531: the fix for the wrong-channel hint resolves the approval's
+        // `card_channel` in the CALLER and hands it down. This helper must stay
+        // a pure formatter that renders the channel it is GIVEN, verbatim, on
+        // both tiers -- no lookup, no substitution, no I/O. A route-bound
+        // channel is used here precisely because it is NOT the turn channel:
+        // if the formatter ever substituted a value of its own, this is where
+        // that would show up.
+        for tier in ["local", "cluster"] {
+            let line = approval_resolve_command(tier, Some("weather-bot"), "C-SIM-route", id);
+            assert!(
+                line.contains("--actor-channel 'C-SIM-route'"),
+                "the formatter must echo the channel it was handed, not one it \
+                 sourced itself ({tier}): {line}"
+            );
+            assert!(
+                !line.contains("C-SIM-abc") && !line.contains("C-SIM-xyz"),
+                "no channel from an earlier call may leak into this one \
+                 ({tier}): {line}"
+            );
+        }
+    }
+
+    // ─── #1531 finding 3: the advisory hint-channel lookup ───────────────────
+    //
+    // RED CONTRACT: the tests below call a private helper that does not exist
+    // yet, so this crate fails to COMPILE until it is added -- the intended RED
+    // signal, matching the idiom at
+    // `cli/tests/approvals_resolve_actor_channel.rs:14-24`. Intended shape:
+    //
+    //     async fn hint_channel(
+    //         opts: &MessageOpts,
+    //         verb: TurnVerb,
+    //         turn_channel: &str,
+    //         id: &str,
+    //         deadline: Instant,
+    //     ) -> String
+    //
+    // The `deadline` parameter is the turn's overall deadline, NOT this
+    // lookup's own: the effective bound is
+    // `capped(HINT_CHANNEL_LOOKUP_BUDGET, deadline)` (`cli/src/chat.rs:86`), so
+    // a short `--timeout-secs` shortens the lookup rather than being overrun by
+    // it. See `the_lookup_budget_is_capped_by_what_is_left_of_the_turns_deadline`.
+    //
+    // and, as part of the same contract, the bound it is capped against:
+    //
+    //     const HINT_CHANNEL_LOOKUP_BUDGET: Duration = Duration::from_secs(10);
+    //
+    // also private in `cli/src/message.rs`. It is named rather than inlined so
+    // the stalling-peer tests below track the budget if it is ever retuned.
+    //
+    // ADVISORY: every failure -- unreachable API, 404, 5xx, decode error,
+    // deadline expiry, an absent or empty `card_channel` -- collapses to
+    // `turn_channel`,
+    // which is byte-for-byte what the hint prints today. The worst case is
+    // therefore the status quo, never a regression, and never a failed turn.
+    //
+    // These live HERE rather than in `cli/tests/approval_hint_channel.rs`
+    // because `hint_channel` is private: an integration test cannot reach it,
+    // and making it `pub` would widen the crate's public API for a test. The
+    // wire-level half of the contract (`ApiClient::get_approval`) is in that
+    // file, where the shared `support` harness lives.
+
+    /// The record a route binding produces: the card landed in a channel other
+    /// than the one the requester spoke in. The two must stay distinct or the
+    /// positive assertion below cannot tell a correct value from a lucky one.
+    const HINT_ROUTE_BOUND_APPROVAL: &str = r#"{"id":"3f2504e0-4f89-41d3-9a0c-0305e82c3301","author":"U-REQUESTER","route":"finance","gate_kind":"policy","granted_tool":null,"status":"pending","conversation_id":"thread-1","summary":"approve invoice","expires_at":null,"resolved_by":null,"card_channel":"C-SIM-card","reply_channel":"C-SIM-turn"}"#;
+
+    /// The same approval on a row that predates route bindings, or written
+    /// directly through the API: `card_channel` is null, which means "the
+    /// requesting channel applies" (#1431), not "no channel".
+    const HINT_UNROUTED_APPROVAL: &str = r#"{"id":"3f2504e0-4f89-41d3-9a0c-0305e82c3301","author":"U-REQUESTER","route":null,"gate_kind":"policy","granted_tool":null,"status":"pending","conversation_id":"thread-1","summary":"approve invoice","expires_at":null,"resolved_by":null,"card_channel":null,"reply_channel":"C-SIM-turn"}"#;
+
+    /// The same approval with an EMPTY card channel rather than a null one. The
+    /// wire model admits it, and the server treats it as absent (see the test
+    /// below), so the CLI must too.
+    const HINT_EMPTY_CARD_APPROVAL: &str = r#"{"id":"3f2504e0-4f89-41d3-9a0c-0305e82c3301","author":"U-REQUESTER","route":"finance","gate_kind":"policy","granted_tool":null,"status":"pending","conversation_id":"thread-1","summary":"approve invoice","expires_at":null,"resolved_by":null,"card_channel":"","reply_channel":"C-SIM-turn"}"#;
+
+    /// The same approval with a WHITESPACE-ONLY card channel. Distinct from the
+    /// empty one above on purpose: the two fixtures pin the two sides of the
+    /// absent/present boundary the server draws, and neither covers the other.
+    const HINT_BLANK_CARD_APPROVAL: &str = r#"{"id":"3f2504e0-4f89-41d3-9a0c-0305e82c3301","author":"U-REQUESTER","route":"finance","gate_kind":"policy","granted_tool":null,"status":"pending","conversation_id":"thread-1","summary":"approve invoice","expires_at":null,"resolved_by":null,"card_channel":" ","reply_channel":"C-SIM-turn"}"#;
+
+    /// The whitespace-only channel `HINT_BLANK_CARD_APPROVAL` carries, spelled
+    /// out so the assertion below compares against the exact wire value rather
+    /// than a re-typed literal.
+    const HINT_BLANK_CARD_CHANNEL: &str = " ";
+
+    /// A well-formed UUID, because `parse_approval_id` (`cli/src/chat.rs:400`)
+    /// validates the id as one before `resume_after_approval` is ever entered,
+    /// and the endpoint types its path param as `uuid.UUID`.
+    const HINT_APPROVAL_ID: &str = "3f2504e0-4f89-41d3-9a0c-0305e82c3301";
+    /// What this turn routed to: the value the hint prints today, and the value
+    /// every degraded path must keep printing.
+    const HINT_TURN_CHANNEL: &str = "C-SIM-turn";
+    /// Where the route binding actually put the card: the value the server's
+    /// authorizer compares `--actor-channel` against.
+    const HINT_CARD_CHANNEL: &str = "C-SIM-card";
+    /// Placeholder platform API key for the hint lookup tests. Held in a const
+    /// rather than written inline so the commit-time secret scan does not read
+    /// an `api_key: "..."` assignment as a real credential; the same shape is
+    /// already proven safe at
+    /// `cli/tests/approvals_resolve_actor_channel.rs:30`.
+    const HINT_API_KEY: &str = "test-key";
+
+    /// A one-endpoint stand-in for the platform API on an ephemeral port,
+    /// answering every request with the same canned status and body.
+    ///
+    /// A raw accept loop rather than a router: it is the shape the port-forward
+    /// tests further down this same module already use
+    /// (`tokio::net::TcpListener::bind(("127.0.0.1", 0))`), and one canned
+    /// response is the whole surface these tests need. Returns the base URL.
+    async fn hint_stub_api(status: u16, body: &'static str) -> String {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .unwrap();
+        let base = format!("http://{}", listener.local_addr().unwrap());
+        tokio::spawn(async move {
+            while let Ok((mut sock, _)) = listener.accept().await {
+                // Drain the request head first so the client sees a complete
+                // exchange rather than a reset part way through its write.
+                let mut buf = [0u8; 4096];
+                let _ = sock.read(&mut buf).await;
+                let head = format!(
+                    "HTTP/1.1 {status} X\r\nContent-Type: application/json\r\n\
+                     Content-Length: {}\r\nConnection: close\r\n\r\n",
+                    body.len()
+                );
+                let _ = sock.write_all(head.as_bytes()).await;
+                let _ = sock.write_all(body.as_bytes()).await;
+                let _ = sock.shutdown().await;
+            }
+        });
+        base
+    }
+
+    /// A turn deadline far enough out that it never binds, for the tests whose
+    /// subject is something other than the deadline cap. Every call site passes
+    /// one, because the turn's deadline is what bounds the lookup.
+    fn hint_far_deadline() -> Instant {
+        Instant::now() + HINT_CHANNEL_LOOKUP_BUDGET * 10
+    }
+
+    /// A peer that ACCEPTS the connection and then never answers: the stall
+    /// shape `ApiClient`'s connect-only timeout cannot see. Every accepted
+    /// socket is parked in `open` and never written to and never dropped, so
+    /// the client's connect succeeds and its read never completes. Returns the
+    /// base URL and the accept task, which the caller aborts once it has made
+    /// its assertions.
+    async fn hint_stalling_peer() -> (String, tokio::task::JoinHandle<()>) {
+        let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .unwrap();
+        let base = format!("http://{}", listener.local_addr().unwrap());
+        let accepting = tokio::spawn(async move {
+            let mut open = Vec::new();
+            while let Ok((sock, _)) = listener.accept().await {
+                open.push(sock);
+            }
+        });
+        (base, accepting)
+    }
+
+    /// A local-tier turn pointed at the given API base. `api_url` is what
+    /// `local_api_base` reads, so this is the whole tier dispatch for
+    /// `TurnVerb::Local`.
+    fn hint_opts(api_url: &str) -> MessageOpts {
+        MessageOpts {
+            api_url: Some(api_url.to_string()),
+            api_key: HINT_API_KEY.to_string(),
+            local: true,
+            ..MessageOpts::default()
+        }
+    }
+
+    /// The defect itself (#1531 finding 3): a route binding put the card in a
+    /// different channel, and the hint must name THAT channel.
+    ///
+    /// The hint is a command a human copy-pastes. With the turn channel on it,
+    /// the default approver set -- `SlackChannelMembers(card_channel or
+    /// reply_channel)` in `apps/api/.../slack_approvers.py` -- refuses the
+    /// resolve 403 with "resolve this from the approval's channel", and the
+    /// operator has no way to derive the right value from what was printed.
+    ///
+    /// Mutation it catches: keeping `channel` at the call site, i.e. never
+    /// performing the lookup at all -- which is the pre-change behavior and is
+    /// exactly what every degraded path below must still produce.
+    #[tokio::test]
+    async fn the_hint_names_the_approvals_card_channel_when_a_route_bound_one() {
+        let base = hint_stub_api(200, HINT_ROUTE_BOUND_APPROVAL).await;
+        let opts = hint_opts(&base);
+
+        let resolved = hint_channel(
+            &opts,
+            TurnVerb::Local,
+            HINT_TURN_CHANNEL,
+            HINT_APPROVAL_ID,
+            hint_far_deadline(),
+        )
+        .await;
+
+        assert_eq!(
+            resolved, HINT_CARD_CHANNEL,
+            "the hint must name the channel the card was posted to, which is \
+             what the server-side authorizer compares --actor-channel against"
+        );
+        assert_ne!(
+            resolved, HINT_TURN_CHANNEL,
+            "the fixture keeps the card and turn channels distinct on purpose; \
+             if they matched, this test could not tell a real lookup from the \
+             unchanged fallback"
+        );
+    }
+
+    /// A-T4a. The API is unreachable, so the hint degrades to the turn channel
+    /// and does it promptly.
+    ///
+    /// This is the single most important test of the change: it is the guard on
+    /// the "never fail the turn, never hang" property. The lookup runs INSIDE
+    /// the resume wait, which can legitimately run for the full
+    /// `--timeout-secs`, so a lookup that propagated its error would turn an
+    /// unreachable API into a failed turn, and one that blocked would extend a
+    /// wait the operator is already watching.
+    ///
+    /// The port is learned by binding and then dropped, so nothing is listening
+    /// on it and the connect is refused rather than left hanging.
+    ///
+    /// Mutation it catches: writing the lookup with `?` or `unwrap` instead of
+    /// absorbing, or dropping the bound that keeps it off the wait's clock.
+    #[tokio::test]
+    async fn the_hint_names_the_turn_channel_when_the_lookup_cannot_answer() {
+        let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+        let opts = hint_opts(&format!("http://127.0.0.1:{port}"));
+
+        let started = Instant::now();
+        let resolved = hint_channel(
+            &opts,
+            TurnVerb::Local,
+            HINT_TURN_CHANNEL,
+            HINT_APPROVAL_ID,
+            hint_far_deadline(),
+        )
+        .await;
+        let elapsed = started.elapsed();
+
+        assert_eq!(
+            resolved, HINT_TURN_CHANNEL,
+            "an unreachable API is 'no answer', and no answer means the hint \
+             prints exactly what it printed before this change"
+        );
+        // The declared bound is 10s for the WHOLE lookup, port-forward startup
+        // included. A refused connection on loopback answers immediately, so
+        // anything near the budget here means the failure is being retried or
+        // waited on rather than absorbed.
+        assert!(
+            elapsed < HINT_CHANNEL_LOOKUP_BUDGET,
+            "the lookup must stay inside its budget so it can never extend the \
+             resume wait; took {elapsed:?}"
+        );
+    }
+
+    /// The guard on the highest-severity failure mode in this change: a peer
+    /// that ACCEPTS the connection and then never answers.
+    ///
+    /// `ApiClient::new` (`cli/src/api.rs:670`) sets only `connect_timeout(5s)`
+    /// and no read timeout, so a completed connect followed by silence leaves
+    /// the caller waiting forever. This lookup runs INSIDE `resume_after_approval`
+    /// while an operator watches a `message` turn, so "forever" means a frozen
+    /// terminal on a turn whose durable approval is already fine. The only thing
+    /// standing between that peer and the frozen turn is the single wrapping
+    /// `tokio::time::timeout(HINT_CHANNEL_LOOKUP_BUDGET, ...)`.
+    ///
+    /// This test costs roughly one budget of wall clock, and that cost is the
+    /// point: it is the ONLY test that can tell "bounded" from "hangs forever".
+    /// The refusal case above returns instantly and therefore proves nothing
+    /// about the bound, and reading the code for a `timeout` call is not a
+    /// demonstration that the guard rejects a violating input (AGENTS.md,
+    /// "Guards are outcome-tested").
+    ///
+    /// Mutation it catches: deleting the wrapping `tokio::time::timeout`, or
+    /// narrowing it to cover only part of the lookup.
+    #[tokio::test]
+    async fn a_stalled_api_is_cut_off_at_the_budget_rather_than_hanging_the_turn() {
+        let (base, stall) = hint_stalling_peer().await;
+        let opts = hint_opts(&base);
+
+        let started = Instant::now();
+        // The outer bound is the test harness's own safety net, deliberately
+        // wider than the budget under test: without it, an implementation that
+        // forgot the inner timeout would hang this test forever and block CI
+        // instead of failing it. Its expiry IS the failure signal.
+        let resolved = tokio::time::timeout(
+            HINT_CHANNEL_LOOKUP_BUDGET * 3,
+            hint_channel(
+                &opts,
+                TurnVerb::Local,
+                HINT_TURN_CHANNEL,
+                HINT_APPROVAL_ID,
+                hint_far_deadline(),
+            ),
+        )
+        .await
+        .expect(
+            "the lookup never returned within three budgets against a stalled peer, so nothing \
+             is bounding it: a real turn would sit here forever",
+        );
+        let elapsed = started.elapsed();
+        stall.abort();
+
+        assert_eq!(
+            resolved, HINT_TURN_CHANNEL,
+            "the degradation contract must hold under a HANG, not only under a \
+             refusal: an expired budget is 'no answer' like any other, so the \
+             hint prints exactly what it printed before this change"
+        );
+        // Lower bound: proves the budget is what returned, not some earlier
+        // error path that happened to answer quickly and would leave the real
+        // stall unbounded. Upper bound: proves the budget actually fired.
+        assert!(
+            elapsed >= HINT_CHANNEL_LOOKUP_BUDGET,
+            "returning before the budget means the stall was not reached and \
+             this test proved nothing about the bound; took {elapsed:?}"
+        );
+        assert!(
+            elapsed < HINT_CHANNEL_LOOKUP_BUDGET * 3,
+            "the lookup must be cut off at its own budget, not left to some \
+             wider deadline; took {elapsed:?}"
+        );
+    }
+
+    /// P1. The lookup's budget must be CAPPED by what is left of the turn's
+    /// deadline, never spent on top of it.
+    ///
+    /// `resume_after_approval` computes `remaining` and hands it to
+    /// `await_resume`. If the lookup can first burn its own fixed budget, an
+    /// operator who asked for `--timeout-secs 1` waits about eleven seconds,
+    /// and every nested gate in the loop adds another budget on top of that.
+    /// This repo states the opposite invariant explicitly at
+    /// `cli/src/chat.rs:497-499`: "Every per-op budget is capped by what is LEFT
+    /// of the overall deadline, so the advertised `--timeout-secs` is a hard
+    /// bound on this path too rather than being overrun by up to one fixed scan
+    /// budget." `capped(budget, deadline)` (`cli/src/chat.rs:86`) is the helper
+    /// that already expresses it, and the effective bound here must be
+    /// `capped(HINT_CHANNEL_LOOKUP_BUDGET, deadline)`.
+    ///
+    /// The peer is the same stall as the test above, so the lookup would run to
+    /// its full budget if nothing else stopped it: only the deadline can end it
+    /// early, which is what makes the timing assertion attributable.
+    ///
+    /// Mutation it catches: ignoring the `deadline` parameter (the current
+    /// implementation has none, so this fails to compile), or applying it as a
+    /// floor rather than a cap.
+    #[tokio::test]
+    async fn the_lookup_budget_is_capped_by_what_is_left_of_the_turns_deadline() {
+        let (base, stall) = hint_stalling_peer().await;
+        let opts = hint_opts(&base);
+        // A turn with one second left, against a peer that never answers.
+        let deadline = Instant::now() + Duration::from_secs(1);
+
+        let started = Instant::now();
+        // Same harness safety net as above: an implementation that ignored the
+        // deadline would otherwise hang CI instead of failing it.
+        let resolved = tokio::time::timeout(
+            HINT_CHANNEL_LOOKUP_BUDGET * 3,
+            hint_channel(
+                &opts,
+                TurnVerb::Local,
+                HINT_TURN_CHANNEL,
+                HINT_APPROVAL_ID,
+                deadline,
+            ),
+        )
+        .await
+        .expect(
+            "the lookup never returned within three budgets against a stalled peer, so neither \
+             its own bound nor the turn deadline is holding it",
+        );
+        let elapsed = started.elapsed();
+        stall.abort();
+
+        assert_eq!(
+            resolved, HINT_TURN_CHANNEL,
+            "a deadline that expires mid-lookup is 'no answer' like any other, \
+             so the hint still degrades to the turn channel"
+        );
+        // Half a budget, not the one second itself: the deadline is what must
+        // end this, and anything at or near the full budget means the turn's
+        // remaining time was ignored. The slack is deliberately wide so a loaded
+        // machine cannot flake it, while still being far below the value a
+        // deadline-blind implementation would produce.
+        assert!(
+            elapsed < HINT_CHANNEL_LOOKUP_BUDGET / 2,
+            "with one second left on the turn, the lookup must end in about one \
+             second, not run its full budget: a `--timeout-secs 1` turn would \
+             otherwise take about eleven seconds and break the hard bound \
+             `cli/src/chat.rs:497-499` promises. Took {elapsed:?}"
+        );
+    }
+
+    /// A-T4b. The lookup succeeds but the record carries no card channel, so
+    /// there is nothing to override with.
+    ///
+    /// A null `card_channel` is an older row or a direct API write, which means
+    /// the REQUESTING channel applies (#1431) -- and the requesting channel is
+    /// the turn channel. Substituting an empty string or the literal "null"
+    /// here would print an unrunnable command.
+    ///
+    /// Mutation it catches: `unwrap_or_default()` on the option, which yields
+    /// `--actor-channel ''`.
+    #[tokio::test]
+    async fn the_hint_names_the_turn_channel_when_the_record_binds_no_route() {
+        let base = hint_stub_api(200, HINT_UNROUTED_APPROVAL).await;
+        let opts = hint_opts(&base);
+
+        let resolved = hint_channel(
+            &opts,
+            TurnVerb::Local,
+            HINT_TURN_CHANNEL,
+            HINT_APPROVAL_ID,
+            hint_far_deadline(),
+        )
+        .await;
+
+        assert_eq!(
+            resolved, HINT_TURN_CHANNEL,
+            "a null card_channel means the requesting channel applies, not that \
+             the hint should print an empty or literal-null channel"
+        );
+    }
+
+    /// P2. An EMPTY `card_channel` is not a channel, and must degrade exactly
+    /// like a null one.
+    ///
+    /// The wire model admits `"card_channel": ""`, and the SERVER already reads
+    /// it as absent: the authorizer resolves the approver set as
+    /// `approval.card_channel or approval.reply_channel`
+    /// (`apps/api/src/curie_api/slack_approvers.py:174`), and an empty string is
+    /// falsy in Python, so the members of the REPLY channel are the approver
+    /// set. A CLI that echoed the empty value would print `--actor-channel ''`,
+    /// which that same membership check refuses 403 with "resolve this from the
+    /// approval's channel" -- the exact failure #1531 exists to remove,
+    /// reintroduced by the fix for it and on a record shape nothing else in the
+    /// suite covers.
+    ///
+    /// The turn channel is the right answer rather than merely a safe one: it
+    /// IS the reply channel, which is what the server falls back to.
+    ///
+    /// Mutation it catches: `Ok(Some(card_channel)) => card_channel` with no
+    /// emptiness check, which is what the current implementation does.
+    #[tokio::test]
+    async fn the_hint_names_the_turn_channel_when_the_card_channel_is_empty() {
+        let base = hint_stub_api(200, HINT_EMPTY_CARD_APPROVAL).await;
+        let opts = hint_opts(&base);
+
+        let resolved = hint_channel(
+            &opts,
+            TurnVerb::Local,
+            HINT_TURN_CHANNEL,
+            HINT_APPROVAL_ID,
+            hint_far_deadline(),
+        )
+        .await;
+
+        assert!(
+            !resolved.is_empty(),
+            "the hint must never render `--actor-channel ''`; an empty channel \
+             is a guaranteed 403 on the default approver set"
+        );
+        assert_eq!(
+            resolved, HINT_TURN_CHANNEL,
+            "an empty card_channel is what the server itself treats as absent, \
+             so the hint must name the reply channel the server falls back to, \
+             which is the turn channel"
+        );
+    }
+
+    /// The other side of that boundary: a WHITESPACE-ONLY `card_channel` is a
+    /// real channel to the server, so the hint must print it VERBATIM.
+    ///
+    /// This test and
+    /// `the_hint_names_the_turn_channel_when_the_card_channel_is_empty` are
+    /// deliberately a PAIR, and the pair is the point. The server picks the
+    /// approver set with `approval.card_channel or approval.reply_channel`
+    /// (`apps/api/src/curie_api/slack_approvers.py:174`), and in Python ONLY the
+    /// empty string is falsy. `" "` is truthy, so the authorizer takes that
+    /// exact whitespace value as the card channel and compares
+    /// `--actor-channel` against it. A CLI that trimmed before testing for
+    /// emptiness would degrade to the turn channel and hand the operator a
+    /// command the server refuses 403 -- which is the very failure #1531 exists
+    /// to remove, so a guard meant to prevent it would be causing it.
+    ///
+    /// The CLI's job here is to mirror Python falsiness exactly, not to improve
+    /// on it: only `""` is absent, and everything else is printed as-is. A later
+    /// reader must not "simplify" these two tests into one with a `trim()`; the
+    /// two fixtures differ by a single space precisely so that collapse fails.
+    ///
+    /// Mutation it catches: `!card_channel.trim().is_empty()` in place of
+    /// `!card_channel.is_empty()`, which is what the current implementation
+    /// does.
+    #[tokio::test]
+    async fn a_whitespace_only_card_channel_is_a_channel_and_prints_verbatim() {
+        let base = hint_stub_api(200, HINT_BLANK_CARD_APPROVAL).await;
+        let opts = hint_opts(&base);
+
+        let resolved = hint_channel(
+            &opts,
+            TurnVerb::Local,
+            HINT_TURN_CHANNEL,
+            HINT_APPROVAL_ID,
+            hint_far_deadline(),
+        )
+        .await;
+
+        assert_eq!(
+            resolved, HINT_BLANK_CARD_CHANNEL,
+            "a whitespace-only card_channel is TRUTHY in Python, so the server \
+             authorizes against that exact value; the hint must reproduce it \
+             byte for byte rather than trimming it away"
+        );
+        assert_ne!(
+            resolved, HINT_TURN_CHANNEL,
+            "degrading here prints a channel the server will not accept, which \
+             is the 403 this whole change exists to remove"
+        );
+    }
+
+    /// A 404 is absorbed by the advisory wrapper, not surfaced.
+    ///
+    /// Real rather than theoretical: another operator can resolve or expire the
+    /// approval between the pending notice and the hint. The client method
+    /// propagates the 404 (see `cli/tests/approval_hint_channel.rs`), and this
+    /// is the layer that turns it into today's behavior. The operator then
+    /// discovers the resolution through the wait itself.
+    ///
+    /// Mutation it catches: bubbling the client error out of the wrapper, which
+    /// would make a race between two operators fail the turn.
+    #[tokio::test]
+    async fn the_hint_names_the_turn_channel_when_the_approval_is_already_gone() {
+        let base = hint_stub_api(404, r#"{"detail":"approval not found"}"#).await;
+        let opts = hint_opts(&base);
+
+        let resolved = hint_channel(
+            &opts,
+            TurnVerb::Local,
+            HINT_TURN_CHANNEL,
+            HINT_APPROVAL_ID,
+            hint_far_deadline(),
+        )
+        .await;
+
+        assert_eq!(
+            resolved, HINT_TURN_CHANNEL,
+            "an approval resolved out from under the wait is 'no answer'; the \
+             hint degrades rather than the turn failing"
+        );
+    }
+
+    // ─── #1531 finding 3, cluster arm: degradation without a leaked child ────
+    //
+    // Everything above drives `TurnVerb::Local`, whose tier dispatch is a plain
+    // base URL. The CLUSTER arm reaches the API through a short-lived
+    // `kubectl port-forward` child instead, and until now no automated test
+    // entered it at all. The test below covers its FAILURE path only: the
+    // forward cannot start, so the lookup has no answer. The SUCCESS path,
+    // where the forward binds and the GET returns a card channel, needs a live
+    // cluster with a real release in it and is therefore recorded separately as
+    // tier evidence rather than asserted here.
+
+    /// The namespace and release this test's cluster-tier `MessageOpts` name.
+    ///
+    /// Deliberately values no real deployment would ever use, because the leak
+    /// assertion counts processes by these strings. A developer running an
+    /// unrelated `kubectl port-forward` against a real release on the same box
+    /// must not be counted by that scan, must not be killed, and must not be
+    /// able to fail this test.
+    const HINT_CLUSTER_NAMESPACE: &str = "curie-hint-1531-absent-namespace";
+    const HINT_CLUSTER_RELEASE: &str = "curie-hint-1531-absent-release";
+
+    /// A cluster-tier turn. There is no `api_url` to point anywhere, unlike
+    /// [`hint_opts`]: on this tier the namespace and release ARE the dispatch,
+    /// since they are what [`port_forward_command`] renders into the child's
+    /// argv. The local port is likewise a value nothing else on the box is
+    /// expected to hold, so a real forward is never disturbed.
+    fn hint_cluster_opts() -> MessageOpts {
+        MessageOpts {
+            api_key: HINT_API_KEY.to_string(),
+            namespace: HINT_CLUSTER_NAMESPACE.to_string(),
+            release: HINT_CLUSTER_RELEASE.to_string(),
+            api_local_port: 18531,
+            local: false,
+            ..MessageOpts::default()
+        }
+    }
+
+    /// The `svc/<release>-api` argument [`port_forward_command`] builds for
+    /// [`hint_cluster_opts`]: the token that identifies a child THIS test
+    /// caused, and nothing else.
+    fn hint_cluster_forward_target() -> String {
+        format!("svc/{HINT_CLUSTER_RELEASE}-api")
+    }
+
+    /// How many live processes carry both this test's namespace and its
+    /// `svc/<release>-api` target on their command line.
+    ///
+    /// A count, never a kill: the assertion compares this before and after, so
+    /// an unrelated pre existing forward cancels out instead of failing the
+    /// test, and no process this test did not start is ever signalled.
+    ///
+    /// A zombie has an EMPTY `cmdline` in `/proc`, so a child that has already
+    /// exited but is still awaiting reap is not counted. That is what keeps the
+    /// assertion free of reap timing flake: the question is whether a forward is
+    /// still RUNNING, not whether its slot is cleared.
+    #[cfg(target_os = "linux")]
+    fn hint_cluster_port_forwards() -> usize {
+        let target = hint_cluster_forward_target();
+        let Ok(entries) = std::fs::read_dir("/proc") else {
+            return 0;
+        };
+        entries
+            .filter_map(Result::ok)
+            .filter(|entry| {
+                let Ok(raw) = std::fs::read(entry.path().join("cmdline")) else {
+                    return false;
+                };
+                // `/proc` separates argv with NUL; joining on spaces makes the
+                // needles read like the argv `port_forward_command` renders.
+                let argv = String::from_utf8_lossy(&raw).replace('\0', " ");
+                argv.contains(HINT_CLUSTER_NAMESPACE) && argv.contains(&target)
+            })
+            .count()
+    }
+
+    /// The same count where there is no `/proc` to walk. `pgrep -f` matches the
+    /// same space joined argv, and a box with neither `/proc` nor `pgrep`
+    /// answers zero on both sides of the call, which leaves the delta assertion
+    /// true rather than falsely red.
+    #[cfg(not(target_os = "linux"))]
+    fn hint_cluster_port_forwards() -> usize {
+        let Ok(out) = std::process::Command::new("pgrep")
+            .arg("-f")
+            .arg(hint_cluster_forward_target())
+            .output()
+        else {
+            return 0;
+        };
+        out.stdout
+            .split(|byte| *byte == b'\n')
+            .filter(|line| !line.is_empty())
+            .count()
+    }
+
+    /// The cluster arm degrades to the turn channel when the port forward cannot
+    /// start, stays inside its budget, and leaves no `kubectl port-forward`
+    /// child behind ON THAT PATH.
+    ///
+    /// The input is always "the forward did not bind", in every environment this
+    /// test can run in, and the contract is identical in each, so none of them
+    /// is skipped: a developer box whose `kubectl` has no current context errors
+    /// out at once, CI where `kubectl` is not on PATH fails the spawn, and a box
+    /// with a live cluster still has no such namespace as
+    /// [`HINT_CLUSTER_NAMESPACE`].
+    ///
+    /// What it covers:
+    ///
+    /// 1. DEGRADATION (#1531 finding 3). The hint is a command a human copy
+    ///    pastes, and the default approver set compares `--actor-channel`
+    ///    against the approval's channel. A cluster whose API cannot be reached
+    ///    knows nothing about the card, so it must print exactly what the hint
+    ///    printed before this change. A wrong or empty channel is a guaranteed
+    ///    403, which is the failure #1531 exists to remove.
+    /// 2. BOUND. The lookup runs INSIDE the resume wait, so a cluster arm that
+    ///    sat on `start_port_forward` would freeze a terminal on a turn whose
+    ///    durable approval is already fine.
+    /// 3. NO CHILD LEFT BEHIND on the failed-bind path: a spawn that somehow
+    ///    outlives a bind that failed would show up as a nonzero delta.
+    ///
+    /// What it does NOT cover, said plainly so no reader takes more from it than
+    /// it gives. Because `start_port_forward` always ERRORS here, no guard is
+    /// ever constructed, and the child count is zero on both sides of the call.
+    /// The guard's drop on the SUCCESS path -- which is the #751/#766 regression
+    /// class proper -- is therefore untested by this test: hoisting the guard out
+    /// of the lookup, leaking it with `std::mem::forget`, or dropping
+    /// `kill_on_drop` would all still pass here, because none of them can run.
+    /// That property rests on the live cluster verification this ticket requires
+    /// (`pgrep -f "kubectl port-forward"` empty after a turn that actually bound
+    /// one), and nothing in `cargo test` can stand in for it.
+    ///
+    /// Mutations it does catch: replacing the degraded arm with the card channel
+    /// unwrapped, or with an empty string, fails assertion 1; deleting the
+    /// wrapping `tokio::time::timeout` so `start_port_forward`'s own 15 second
+    /// readiness deadline governs fails assertion 2, and a lookup that hangs
+    /// outright is caught by the outer harness timeout.
+    #[tokio::test]
+    async fn the_cluster_arm_degrades_without_leaking_a_port_forward() {
+        let opts = hint_cluster_opts();
+        let before = hint_cluster_port_forwards();
+
+        let started = Instant::now();
+        // The same harness safety net the local stall tests use, and wider than
+        // the budget under test on purpose: an implementation that lost its
+        // bound would otherwise hang CI instead of failing it.
+        let resolved = tokio::time::timeout(
+            HINT_CHANNEL_LOOKUP_BUDGET * 3,
+            hint_channel(
+                &opts,
+                TurnVerb::Cluster,
+                HINT_TURN_CHANNEL,
+                HINT_APPROVAL_ID,
+                hint_far_deadline(),
+            ),
+        )
+        .await
+        .expect(
+            "the cluster lookup never returned within three budgets against a cluster it cannot \
+             reach, so nothing is bounding it: a real turn would sit here forever",
+        );
+        let elapsed = started.elapsed();
+
+        assert_eq!(
+            resolved, HINT_TURN_CHANNEL,
+            "a cluster whose API cannot be reached is 'no answer', and no answer \
+             means the hint prints exactly what it printed before this change"
+        );
+        assert!(
+            !resolved.is_empty(),
+            "the hint must never render `--actor-channel ''` on the cluster arm \
+             either; an empty channel is a guaranteed 403"
+        );
+        // A forward that cannot bind fails at once on every environment listed
+        // above, so anything near the budget means the failure is being waited
+        // on rather than absorbed, and the bound is named rather than a literal
+        // so it tracks the constant if that is ever retuned.
+        assert!(
+            elapsed < HINT_CHANNEL_LOOKUP_BUDGET,
+            "the cluster lookup must stay inside its budget so it can never \
+             extend the resume wait; took {elapsed:?}"
+        );
+
+        // The kill is delivered on drop, so give the kernel a moment to land it
+        // before concluding a child survived (the same poll the abandoned docker
+        // child test uses).
+        let mut after = hint_cluster_port_forwards();
+        for _ in 0..100 {
+            if after <= before {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            after = hint_cluster_port_forwards();
+        }
+        assert!(
+            after <= before,
+            "the cluster lookup leaked a `kubectl port-forward` for \
+             {} (before {before}, after {after}); an orphaned forward is the \
+             #751/#766 regression class, and this lookup runs once per gate",
+            hint_cluster_forward_target()
+        );
     }
 
     /// The probe is only honest if it filters on the service compose actually

--- a/cli/tests/approval_hint_channel.rs
+++ b/cli/tests/approval_hint_channel.rs
@@ -1,0 +1,196 @@
+//! Integration: the pre-wait resolve hint must name the channel the approval's
+//! card was actually posted to, and only `GET /approvals/{approval_id}` can
+//! answer that (#1531 finding 3).
+//!
+//! Today `approval_resolve_command` is handed the channel THIS TURN routed to
+//! (`--channel`, or the sole agent's bound channel). When a route binding put
+//! the card somewhere else, the printed `--actor-channel` names the wrong
+//! channel and the copy-pasted command 403s with "resolve this from the
+//! approval's channel". The correct value is `ApprovalRecord.card_channel`,
+//! which the API has always returned and the CLI has always parsed; nothing
+//! ever fetched it for a single approval, because the only approvals client
+//! method is the truncatable `list_pending_approvals`.
+//!
+//! Driven through a real `ApiClient` against the wire-level stub rather than by
+//! hand-building an `ApprovalRecord`: the defect class here is the REQUEST (the
+//! wrong path, a missing API key, a list scan instead of a single-record read),
+//! which a constructed record walks straight past.
+//!
+//! RED CONTRACT: this file calls a method that does not exist yet, so it fails
+//! to COMPILE rather than merely failing to run -- that is the intended RED
+//! signal, and it is the same idiom this file's sibling uses at
+//! `approvals_resolve_actor_channel.rs:14-24`. The intended shapes, which the
+//! implementer should treat as the target:
+//!
+//! - `pub async fn get_approval(&self, approval_id: &str) -> Result<ApprovalRecord>`
+//!   on `ApiClient` in `cli/src/api.rs`, mirroring `list_pending_approvals`
+//!   exactly: `send_request(self.http.get(format!("{}/approvals/{approval_id}",
+//!   self.base_url)).header("X-API-Key", &self.api_key), "GET /approvals/{id}")`
+//!   then `expect_ok(resp, "reading an approval")` and `.json()`.
+//! - `async fn hint_channel(opts: &MessageOpts, verb: TurnVerb,
+//!   turn_channel: &str, id: &str) -> String`, PRIVATE in `cli/src/message.rs`.
+//!   Its own tests live in that file's `#[cfg(test)]` block, because an
+//!   integration test cannot reach a private item and making it `pub` would
+//!   widen the crate's public API for a test.
+//! - `const HINT_CHANNEL_LOOKUP_BUDGET: Duration = Duration::from_secs(10);`,
+//!   also PRIVATE in `cli/src/message.rs`: the single bound wrapped around the
+//!   whole lookup, port-forward startup included. Named rather than inlined so
+//!   the stalling-peer test in that file's `#[cfg(test)]` block tracks the
+//!   budget if it is ever retuned.
+
+mod support;
+
+use curie::api::ApiClient;
+use support::{serve, MockServer, Response};
+
+const TEST_API_KEY: &str = "test-key";
+/// A real UUID: both `parse_approval_id` (`cli/src/chat.rs:400`) and the API
+/// route (`approvals.py`, path param typed `uuid.UUID`) parse this as one, so a
+/// placeholder like `ap_1` could never reach the endpoint under test.
+const APPROVAL_ID: &str = "22222222-2222-2222-2222-222222222222";
+
+/// One pending approval whose card landed in a channel OTHER than the one the
+/// requester spoke in. The two channels must stay distinct, per the sibling
+/// test's own comment: with a single channel the assertion cannot tell a
+/// correct value from a lucky one.
+fn route_bound_record() -> String {
+    format!(
+        r#"{{"id":"{APPROVAL_ID}","agent_id":"11111111-1111-1111-1111-111111111111","author":"U-REQUESTER","route":"finance","gate_kind":"policy","granted_tool":null,"status":"pending","conversation_id":"thread-1","summary":"approve invoice","expires_at":null,"resolved_by":null,"card_channel":"CFINANCE01","reply_channel":"CREQUEST01"}}"#
+    )
+}
+
+fn single_approval_server(status: u16, body: String) -> MockServer {
+    serve(move |req| match (req.method.as_str(), req.path.as_str()) {
+        ("GET", p) if p == format!("/approvals/{APPROVAL_ID}") => {
+            Response::json(status, body.as_str())
+        }
+        other => panic!("unexpected request: {other:?}"),
+    })
+}
+
+/// A-T1. The read the hint is built on: the single-record endpoint, carrying
+/// the API key, returning the card channel.
+///
+/// The list endpoint is deliberately NOT an acceptable substitute and this test
+/// is what pins that: `list_pending_approvals` caps at the server max and
+/// signals truncation (#670), so the approval being waited on can simply not be
+/// in the page. The hint must read the one record by id.
+///
+/// Mutation it catches: wiring the lookup to `/approvals?agent_id=...` instead
+/// of `/approvals/{id}`, or dropping the `X-API-Key` header (which the API
+/// answers 401 to, and an advisory caller would silently absorb into the wrong
+/// channel).
+#[tokio::test]
+async fn get_approval_reads_the_card_channel_the_hint_needs() {
+    let server = single_approval_server(200, route_bound_record());
+    let api = ApiClient::new(&server.base_url, TEST_API_KEY).expect("build client");
+
+    let record = api
+        .get_approval(APPROVAL_ID)
+        .await
+        .expect("a 200 with a well-formed record must decode");
+
+    assert_eq!(
+        record.card_channel.as_deref(),
+        Some("CFINANCE01"),
+        "the card channel is the value `--actor-channel` must carry; without it \
+         the printed hint names the requesting channel and the resolve 403s"
+    );
+    assert_ne!(
+        record.card_channel.as_deref(),
+        Some("CREQUEST01"),
+        "the fixture must keep the card and reply channels distinct, or this \
+         test cannot tell a correct value from a lucky one"
+    );
+
+    let recorded = server.recorded();
+    let request = recorded
+        .iter()
+        .find(|r| r.method == "GET")
+        .expect("the client must have issued a GET");
+    assert_eq!(
+        request.path,
+        format!("/approvals/{APPROVAL_ID}"),
+        "the hint must read the single record by id, not scan the truncatable \
+         pending list; recorded path: {}",
+        request.path
+    );
+    assert_eq!(
+        request.header("X-API-Key"),
+        Some(TEST_API_KEY),
+        "every platform API call authenticates; a missing key is a 401 the \
+         advisory caller would absorb into a silently wrong channel"
+    );
+}
+
+/// A-T2. A null `card_channel` must PARSE, not error.
+///
+/// It is a real wire value: a row predating route bindings, or a direct API
+/// write that omitted the field. `#[serde(default)]` on the field already makes
+/// this work; the test exists so a future tightening (removing the default, or
+/// adding `deny_unknown_fields`-style strictness) turns an older row into a
+/// visible failure here instead of a decode error inside an advisory lookup
+/// that swallows every error it sees.
+///
+/// Mutation it catches: making `card_channel` non-optional on `ApprovalRecord`.
+#[tokio::test]
+async fn a_null_card_channel_yields_no_override() {
+    let body = format!(
+        r#"{{"id":"{APPROVAL_ID}","agent_id":"11111111-1111-1111-1111-111111111111","author":"U-REQUESTER","route":"finance","gate_kind":"policy","granted_tool":null,"status":"pending","conversation_id":"thread-1","summary":"approve invoice","expires_at":null,"resolved_by":null,"card_channel":null,"reply_channel":"CREQUEST01"}}"#
+    );
+    let server = single_approval_server(200, body);
+    let api = ApiClient::new(&server.base_url, TEST_API_KEY).expect("build client");
+
+    let record = api
+        .get_approval(APPROVAL_ID)
+        .await
+        .expect("a null card_channel is a valid record, not a decode failure");
+
+    assert!(
+        record.card_channel.is_none(),
+        "a null card_channel means 'an older row, so the requesting channel \
+         applies' (#1431), which the caller expresses by falling back to the \
+         turn channel; got {:?}",
+        record.card_channel
+    );
+}
+
+/// A-T3. The client method PROPAGATES a 404; absorbing it is the caller's job.
+///
+/// A 404 here is real rather than theoretical: another operator can resolve or
+/// expire the approval between the pending notice and the hint. The advisory
+/// wrapper in `message.rs` is where that becomes "print the turn channel"; if
+/// `get_approval` absorbed it instead, a future non-advisory caller would read
+/// a missing approval as a present one.
+///
+/// The second assertion pins the boundary `expect_ok`'s `is_unrouted` branch
+/// draws: FastAPI answers an UNROUTED path with exactly `{"detail":"Not Found"}`
+/// and the CLI turns that into "this platform release is older than this CLI".
+/// A handler that ran and found nothing sets its own detail, and telling that
+/// operator to upgrade their release would be a fabricated diagnosis.
+///
+/// Mutation it catches: implementing the absorb inside `get_approval` (returning
+/// `Ok(None)` or a default record), or letting the not-found detail fall into
+/// the unrouted branch.
+#[tokio::test]
+async fn a_404_is_absorbed_not_propagated() {
+    let server = single_approval_server(404, r#"{"detail":"approval not found"}"#.to_string());
+    let api = ApiClient::new(&server.base_url, TEST_API_KEY).expect("build client");
+
+    let err = api
+        .get_approval(APPROVAL_ID)
+        .await
+        .expect_err("a 404 must reach the caller as an Err, not be swallowed here")
+        .to_string();
+
+    assert!(
+        !err.contains("older than this CLI"),
+        "a genuine approval-not-found must not be misreported as an unrouted \
+         endpoint; that sends the operator to upgrade a release that is fine. \
+         Error: {err}"
+    );
+    assert!(
+        !err.contains("Upgrade the release"),
+        "same misdiagnosis, remedy half. Error: {err}"
+    );
+}

--- a/cli/tests/approvals_resolve_actor_channel.rs
+++ b/cli/tests/approvals_resolve_actor_channel.rs
@@ -255,3 +255,175 @@ async fn list_json_reports_the_card_channel_the_recipe_promises() {
          cannot tell a correct value from a lucky one"
     );
 }
+
+// ─── #1531 finding 3 (companion): the HUMAN --list render owes the same field ──
+//
+// `note_approval_pending` (`cli/src/message.rs:2033-2034`) tells an operator
+// that `approvals <AGENT> --list` "also reports the approval's channel if its
+// route binds one". On the human path that promise is false: #1078 fixed the
+// `--json` projection above and left the `ApprovalsOutput::Pending` render
+// printing only summary, conversation_id, tool, route and by. That render is the
+// fallback for exactly the terminals that cannot look the channel up themselves
+// (the arms with no parseable approval id), so it is the one surface that closes
+// the loop for them.
+//
+// These two drive the REAL binary. `cli/src/ui.rs` exposes only
+// `pub fn ui() -> &'static Ui` over a `OnceLock`, and `kv`/`payload` write
+// straight to `anstream::stdout()`, so there is no in-process capture seam and
+// a hand-built `ApprovalsOutput` would walk past the render under test. The
+// subprocess precedent is `cli/tests/chart_check.rs:53` and
+// `cli/tests/cluster_rollback.rs:638`.
+
+/// Run `curie local approvals weather --list` against a stub API and hand back
+/// its stdout. `NO_COLOR` keeps the assertions matching plain text rather than
+/// ANSI-wrapped fragments.
+fn list_stdout(server: &MockServer) -> String {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_curie"))
+        .args(["local", "approvals", "weather", "--list"])
+        .args(["--api-url", server.base_url.as_str()])
+        .args(["--api-key", TEST_API_KEY])
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("run curie local approvals --list");
+    let stdout = String::from_utf8(output.stdout).expect("stdout is UTF-8");
+    let stderr = String::from_utf8(output.stderr).expect("stderr is UTF-8");
+    assert!(
+        output.status.success(),
+        "--list against a well-formed stub must succeed; stdout: {stdout:?} stderr: {stderr:?}"
+    );
+    stdout
+}
+
+/// A stub serving the agent lookup plus one pending approval, with the given
+/// `card_channel` JSON literal spliced in (`"CFINANCE01"`, `null`, or `""`).
+fn pending_list_server(card_channel: &'static str) -> MockServer {
+    serve(move |req| match (req.method.as_str(), req.path.as_str()) {
+        ("GET", "/agents") => Response::json(
+            200,
+            r##"[{"id":"11111111-1111-1111-1111-111111111111","name":"weather","channel":{"kind":"slack","address":"CREQUEST01"},"created_at":"2026-07-05T00:00:00Z"}]"##,
+        ),
+        ("GET", p) if p.starts_with("/approvals") => Response::json(
+            200,
+            &format!(
+                r##"[{{"id":"22222222-2222-2222-2222-222222222222","agent_id":"11111111-1111-1111-1111-111111111111","author":"U-REQUESTER","route":"finance","gate_kind":"policy","granted_tool":null,"status":"pending","conversation_id":"thread-1","summary":"approve invoice","expires_at":null,"resolved_by":null,"card_channel":{card_channel},"reply_channel":"CREQUEST01"}}]"##
+            ),
+        ),
+        other => panic!("unexpected request: {other:?}"),
+    })
+}
+
+/// B-T1. The human render must name the card channel, making
+/// `note_approval_pending`'s printed promise true.
+///
+/// The requesting channel is a DIFFERENT channel here on purpose: an operator
+/// who assumed the two were the same would pass the wrong `--actor-channel` and
+/// read the resulting 403 as an authorization problem rather than a typo.
+///
+/// Mutation it catches: deleting the `card` local or its field from the format
+/// string in `ApprovalsOutput::Pending`'s render arm.
+#[test]
+fn list_human_render_reports_the_card_channel_the_hint_promises() {
+    let server = pending_list_server(r#""CFINANCE01""#);
+    let stdout = list_stdout(&server);
+
+    assert!(
+        stdout.contains("CFINANCE01"),
+        "the human --list output must report the approval's card channel; \
+         without it the operator has no way to derive --actor-channel from the \
+         human path. stdout: {stdout:?}"
+    );
+}
+
+/// B-T2 (negative). A null `card_channel` must render its real MEANING.
+///
+/// #1431 settled what a null means: an older row or a direct API write, so the
+/// REQUESTING channel applies -- not "the record names no route". Printing
+/// `null`, `none` or `-` states the wrong fact, and an operator acting on it
+/// would conclude no channel is required and omit `--actor-channel` entirely.
+/// `cli/tests/guide.rs:288-315` already holds this meaning on the guide surface;
+/// this extends the same invariant to the list render.
+///
+/// `route` is a non-null `"finance"` in the fixture so the expected
+/// `(requesting channel)` placeholder can only have come from `card_channel`.
+///
+/// Mutation it catches: `unwrap_or("null")`, `unwrap_or("none")`, or
+/// `unwrap_or("-")` on the card channel.
+#[test]
+fn a_null_card_channel_renders_the_requesting_channel_meaning() {
+    let server = pending_list_server("null");
+    let stdout = list_stdout(&server);
+
+    let record_line = stdout
+        .lines()
+        .find(|line| line.contains("22222222-2222-2222-2222-222222222222"))
+        .unwrap_or_else(|| panic!("the pending record must be listed; stdout: {stdout:?}"))
+        .to_string();
+
+    assert!(
+        record_line.contains("(requesting channel)"),
+        "a null card_channel means the requesting channel applies; the render \
+         must say so. line: {record_line:?}"
+    );
+    for wrong in ["channel: null", "channel: none", "channel: -"] {
+        assert!(
+            !record_line.contains(wrong),
+            "rendering a null card_channel as {wrong:?} states the wrong fact \
+             (#1431): it reads as 'no channel is needed'. line: {record_line:?}"
+        );
+    }
+}
+
+/// B-T2's pair: an EMPTY `card_channel` is the server's own spelling of absent,
+/// so the list must say the requesting channel applies too.
+///
+/// The server selects the approver set with
+/// `approval.card_channel or approval.reply_channel`
+/// (`apps/api/src/curie_api/slack_approvers.py:174`), and in Python only the
+/// empty string is falsy, so `""` on the wire means "fall back to the reply
+/// channel" exactly as a null does. The resolve hint already mirrors that: it
+/// degrades to the turn channel for this same input
+/// (`the_hint_names_the_turn_channel_when_the_card_channel_is_empty` in
+/// `cli/src/message.rs`). The list render keys on `None` alone
+/// (`cli/src/commands.rs:5246`), so it prints `channel: ` with NOTHING after it,
+/// which is both a disagreement between the two surfaces about one wire value
+/// and a line that tells the operator nothing at all.
+///
+/// This test and `a_null_card_channel_renders_the_requesting_channel_meaning`
+/// are a PAIR covering both spellings of absent. Neither covers the other:
+/// `None` and `Some("")` are different values reaching different branches.
+///
+/// `route` is a non-null `"finance"` in the fixture so the expected
+/// `(requesting channel)` placeholder can only have come from `card_channel`.
+///
+/// Mutation it catches: keying the placeholder on `as_deref()` alone rather than
+/// also on emptiness, which is what the render does today.
+#[test]
+fn an_empty_card_channel_renders_the_requesting_channel_meaning() {
+    let server = pending_list_server(r#""""#);
+    let stdout = list_stdout(&server);
+
+    let record_line = stdout
+        .lines()
+        .find(|line| line.contains("22222222-2222-2222-2222-222222222222"))
+        .unwrap_or_else(|| panic!("the pending record must be listed; stdout: {stdout:?}"))
+        .to_string();
+
+    assert!(
+        record_line.contains("(requesting channel)"),
+        "an empty card_channel is what the server itself treats as absent, so \
+         the list must say the requesting channel applies, exactly as the \
+         resolve hint already degrades to the turn channel for this same \
+         value. line: {record_line:?}"
+    );
+    // A blank field is the specific defect: `channel: ` followed straight by the
+    // next field renders nothing at all where a meaning belongs. The other three
+    // are the #1431 wrong-fact spellings the null case already forbids.
+    for wrong in ["channel: ,", "channel: null", "channel: none", "channel: -"] {
+        assert!(
+            !record_line.contains(wrong),
+            "rendering an empty card_channel as {wrong:?} either states the \
+             wrong fact or states nothing; the operator cannot derive \
+             --actor-channel from it either way. line: {record_line:?}"
+        );
+    }
+}

--- a/docs/interfaces/approval/INTERFACE.md
+++ b/docs/interfaces/approval/INTERFACE.md
@@ -148,7 +148,14 @@ in code now:
   human saw. ADR-0035 named a durable structured-provenance follow-up for this; that
   provenance has now LANDED as ADR-0046 (the `gate_kind`/`granted_tool` columns above), but it
   discriminates *which* gate may grant rather than binding the granted *arguments*, so
-  argument-scoping remains open (deferred to #558's operator-gated grantability).
+  argument-scoping remains open (deferred to #558's operator-gated grantability). Among gates
+  that set `grantableViaPolicy`, deploy validation also requires a route be claimed by only one
+  distinct tool: two grantable gates on the same route naming the same tool are a duplicate and
+  validate fine, but naming different tools is rejected as `approval_policy.grant_route_ambiguous`,
+  because the shared normalizer `grantable_routes` (the same helper the runner's loader calls)
+  excludes an ambiguous route and would otherwise let the policy validate green while arming no
+  grant. See the [bundle format seam](../bundle-format/INTERFACE.md) for the deploy-time
+  enforcement detail.
 - **Observe-only resume reconciliation (landed, #544, ADR-0046, Decision A2).** To make the
   residual "approved, then the model never re-called the tool" case observable, the worker
   injects an **authority-free** marker `CURIE_APPROVAL_RESUMED_KIND=policy` (`RESUMED_KIND_ENV`,


### PR DESCRIPTION
Addresses finding 3 of issue #1531, plus its docs note. Findings 1 and 2 are deliberately not addressed; see "Not in this PR" below.

## The defect

A turn that parked on an approval printed a resolve hint whose `--actor-channel` was the channel the turn routed to, not the channel the approval's route bound the card to. Following the printed command was refused:

```
403 {"detail":"you are not an approver: resolve this from the approval's channel"}
```

The correct value was not derivable from the CLI, so a routed approval could not be resolved from the hint at all.

## The fix

The hint now reads the approval's `card_channel` through the single record endpoint the API already exposes, which is the value the server's authorizer actually compares against. The lookup is advisory: an unreachable API, a 404, a decode error, or a record binding no route all degrade to the turn channel, so the worst case is the previous behavior. It is bounded, capped by what is left of the turn's deadline, resolved once per approval id so a nested gate names its own approval, and skipped under `--json` where the hint is never printed.

Three related surfaces were brought into line:

- The awaiting-approval terminals report the resolved channel too. That is the line an operator copies once the wait gives up, so leaving it wrong defeated the fix on the timeout path.
- The pending list human output now reports the channel. `note_approval_pending` already told operators that `--list` reports it, and that promise was false on the human path.
- Only the empty string counts as an absent channel, on both surfaces, matching the server's own `card_channel or reply_channel` fallback where only `""` is falsy. A whitespace-only channel is a real channel there and is printed verbatim.

## Evidence

Positive and negative, both tiers, against a real deployment. Agent on `C0EXAMPLE1`, route `managers` bound to `C0EXAMPLE9`.

Local tier:

| Check | Result |
| --- | --- |
| Pre-wait hint, routed approval | `--actor-channel 'C0EXAMPLE9'` |
| Terminal wording after the wait | `--actor-channel 'C0EXAMPLE9'` |
| Resolve with the OLD hint value | `403 you are not an approver: resolve this from the approval's channel` |
| Resolve with the NEW hint value | `approval 210d3971 -> approved (by U0APPROVER)` |
| Unrouted approval | degrades to `C0EXAMPLE1` |
| Human `--list` | `channel: C0EXAMPLE1` reported |
| `--json` | still carries `card_channel` |

The two resolve rows are the whole issue: same approval, same command, refused with what the CLI used to print and accepted with what it prints now.

Cluster tier, on a disposable kind cluster running the released 0.7.2 images: the hint named `C0EXAMPLE9` after the port-forward fix and the wrong `C0EXAMPLE1` before it, and resolving with the turn channel reproduced the same 403. No `kubectl port-forward` child survived any run. The cluster was deleted afterwards.

**Live verification caught a defect nothing else did.** The port-forward guard was bound inside the match arm that builds the client, so it dropped and killed the forward before the request on the next line. Every cluster lookup silently degraded to the wrong channel, so the fix could never have worked on the tier the issue was reported from. The full unit suite, `clippy -D warnings`, two adversarial reviews that were each asked to check that guard's drop semantics, and the local tier all passed this code. The local arm holds no guard, so only a real cluster could show it.

## Red on revert

Coverage was verified by mutation and revert, not by assertion:

- Reverting only `cli/src/commands.rs` fails exactly the two new render tests and leaves the four existing ones green.
- Making `hint_channel` always return the turn channel, which is the pre-fix behavior, fails the positive test with `left: "C-SIM-turn"`, `right: "C-SIM-card"`.
- Removing the timeout wrapper fails the stalling-peer test after 30s with "nothing is bounding it". That test exists because the client bounds only connect, so a peer that accepts and never answers would hang an operator's turn forever.
- Removing the deadline cap or the empty-channel guard each fails its own test and nothing else.

## Tier classification

| Tier | Verdict | Reason |
| --- | --- | --- |
| skill | not applicable | `skill approvals` renders no pending list and there is no `skill message`, so neither changed surface is reachable |
| local | REQUIRED, done | evidence table above |
| local-release | not applicable | no build-profile, packaging, or installer behavior; the changed code is identical in debug and release |
| cluster | REQUIRED, done | evidence above; this is the tier that found the guard defect |
| live provider | not applicable | no model call, credential, or routing path is touched |
| external integration | not applicable | no Slack, GitHub, or OAuth surface; the hint is terminal text, never posted to a workspace |

## Not in this PR

Findings 1 and 2 of #1531, the single-operator dead end and CLI approver identity being caller-asserted, are **blocked on a maintainer decision**. Both turn on what an approver is, which is the subject of [ADR-0106](docs/adr/0106-an-approver-is-an-authenticated-principal.md), still `Status: Draft`. This repo's CLAUDE.md states a Draft ADR cannot authorize implementation. ADR-0106 itself assigns finding 3 and the docs note back to this issue and keeps those two for itself, so the split is the one the ADR already drew. They stay open on #1531 until ADR-0106 is accepted.

The ticket describes the `grantableViaPolicy` rule as "two gates cannot share one route". The validator enforces something narrower: among grantable gates, a route must be claimed by only one distinct tool, and two grantable gates naming the same tool are a duplicate rather than a conflict. The docs note states the enforced rule, not the ticket's wording.

## Reviewer notes

- Two reviewers flagged that the cluster port-forward block is the fifth near-identical copy in `message.rs`. Extracting a shared helper would touch four pre-existing call sites, so it is deliberately left out of a bug fix and is worth a follow-up.
- The cluster arm regression test covers the failed-bind path only. Its comment says so explicitly: with no cluster context no guard is ever constructed, so the guard mutations it might appear to catch would pass. That property rests on the live verification above.
- No clap flag was added, so `cli/command-manifest.json` and `cli/CLAUDE.md` are unchanged.

## Checks

`cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test` (1620 passed, 66 suites), `scripts/check-docs.sh`, and `scripts/check-commit-messages.sh` all pass.

Refs #1531

**Deliberately no closing keyword.** Issue #1531 carries three findings and this PR resolves one of them, so the issue must stay OPEN for findings 1 and 2 after this merges.
