### PR TITLE
Make an approval gate unshadowable and end a denied turn

### DIFF
--- a/docs/interfaces/harness-modelsession/INTERFACE.md
+++ b/docs/interfaces/harness-modelsession/INTERFACE.md
@@ -23,10 +23,12 @@ epic_note: folds into
 Inside the runner the model harness is reached through one in-process port: the
 `ModelSession` Protocol. Everything above it (ACI translation, budget, side-effect
 flagging, NDJSON, the HTTP layer) is written against the Protocol. The port itself is
-CLEAN, but the SDK is not yet confined to one module: nine runner modules still import
+CLEAN, but the SDK is not yet confined to one module: ten runner modules still import
 `claude_agent_sdk` today (`check.py`, `session.py`, `hooks.py`, `adapter.py`, `fake.py`,
-`approval.py`, `translate.py`, `plugin.py`, `state.py`), and the value that crosses the port is
-currently the raw SDK message union rather than a runner-owned neutral type. The
+`approval.py`, `translate.py`, `plugin.py`, `state.py`, `__main__.py`, whose boot path
+assembles the approval gate's `PreToolUse` hook matcher alongside the bundle's), and the
+value that crosses the port is currently the raw SDK message union rather than a
+runner-owned neutral type. The
 runner-owned `TurnEvent` model that was once going to draw that line is withdrawn, not
 pending: issue #307 is closed as superseded and its PR #315 was closed unmerged (the
 withdrawal of OpenCode-as-second-harness, recorded in ADR-0060/0061), and no `TurnEvent`
@@ -109,7 +111,7 @@ The port is CLEAN as a code interface but leaks harness shape where the SDK is n
 walled off, called out in vision-doc Job 1:
 
 - **SDK-shaped message payload.** The value crossing the port is the concrete
-  `claude_agent_sdk` message union, and `claude_agent_sdk` is imported across nine
+  `claude_agent_sdk` message union, and `claude_agent_sdk` is imported across ten
   runner modules rather than one harness package. The runner-owned `TurnEvent` model that
   was to draw the neutral line is withdrawn (issue #307 closed as superseded, its PR #315
   closed unmerged and kept only as mining material for the package-shaped redesign);

--- a/runner/src/curie_runner/__main__.py
+++ b/runner/src/curie_runner/__main__.py
@@ -15,6 +15,7 @@ import sys
 import anyio
 from aci_protocol import BootEnv
 from aiohttp import web
+from claude_agent_sdk import HookMatcher
 
 from .adapter import ClaudeAgentSession, ModelSession, build_options
 from .approval import (
@@ -22,6 +23,7 @@ from .approval import (
     ApprovalPolicyError,
     assert_gates_not_shadowed,
     build_approval_gate,
+    build_approval_hook,
     build_approval_server,
     build_can_use_tool,
     resolve_approval_policy,
@@ -104,6 +106,35 @@ def _compose_system_prompt(
     model_preamble = f"Configured model: {model}" if model else None
     parts = [p for p in (memory_preamble, conversation_preamble, base, model_preamble) if p]
     return "\n\n".join(parts) if parts else None
+
+
+def _merge_pre_tool_use_hooks(
+    approval_hooks: dict[str, list[HookMatcher]] | None,
+    bundle_hooks: dict[str, list[HookMatcher]] | None,
+) -> dict[str, list[HookMatcher]] | None:
+    """Merge the approval gate's PreToolUse matcher with the bundle's own (#1852).
+
+    Merge, never replace: dropping the bundle's declared PreToolUse guardrails
+    (#272) would silently disarm them, and dropping the approval matcher leaves
+    the gate bypassable by any permission rule -- the #1852 defect itself. The
+    approval matcher is placed first for determinism of our own construction;
+    the CLI dispatches matchers on one event CONCURRENTLY
+    (claude_agent_sdk/types.py:1956-1961), so list position is not a runtime
+    precedence guarantee and nothing here relies on it.
+
+    Returns None when neither side contributes anything: ``ClaudeAgentOptions``
+    takes ``hooks=None`` to mean "no hooks declared", which is not the same as
+    an empty matcher list, and ``load_bundle_hooks`` returning None for a bundle
+    with no hooks is the common case rather than an error.
+    """
+
+    merged: dict[str, list[HookMatcher]] = {}
+    for source in (approval_hooks, bundle_hooks):
+        if not source:
+            continue
+        for event, matchers in source.items():
+            merged.setdefault(event, []).extend(matchers)
+    return merged or None
 
 
 def build_runner(
@@ -198,6 +229,16 @@ def build_runner(
         logger.error("approval policy unusable error_class=%s: %s", type(exc).__name__, exc)
         raise
 
+    # The gate's own PreToolUse matcher (#1852), MERGED with the bundle's rather
+    # than replacing it. Built here, after the boot refusal above has passed, so
+    # a bundle Curie is about to refuse never gets a hook registered against it.
+    # No gate -> no hook, which is what keeps an unconfigured agent's wiring
+    # byte-identical to before.
+    session_hooks = _merge_pre_tool_use_hooks(
+        build_approval_hook(approval_gate) if approval_gate is not None else None,
+        bundle_hooks,
+    )
+
     # The durable state store exposed to bundle code (#249): when the worker
     # forwarded CURIE_STATE_URL, mount the platform ``curie-state`` MCP
     # server so a skill can read/write suspend/resume-surviving state without the
@@ -238,7 +279,12 @@ def build_runner(
             thinking=config.thinking,
             task_budget_hint=config.session.budget.task_budget_hint,
             env=sdk_env or {},
-            hooks=bundle_hooks,
+            # The approval gate's PreToolUse matcher rides here alongside the
+            # bundle's own (#1852): can_use_tool is skipped by any permission
+            # rule that already allows the call (claude_agent_sdk/types.py:
+            # 1932-1948), and a skill's allowed-tools frontmatter is exactly
+            # such a rule, so the hook is the only layer that sees every call.
+            hooks=session_hooks,
             # Every session carries the in-process approval-request tool, so a
             # skill can raise a policy gate (ADR-0010) without the bundle
             # shipping its own MCP server for it. The ``curie-state`` server

--- a/runner/src/curie_runner/approval.py
+++ b/runner/src/curie_runner/approval.py
@@ -32,13 +32,13 @@ from __future__ import annotations
 
 import json
 import logging
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, NamedTuple
 
 import yaml
-from claude_agent_sdk import create_sdk_mcp_server, tool
+from claude_agent_sdk import HookMatcher, create_sdk_mcp_server, tool
 from claude_agent_sdk.types import (
     CanUseTool,
     McpSdkServerConfig,
@@ -458,7 +458,11 @@ class ApprovalGate:
     ``pending_summary``/``pending_route`` are set by the callback when it
     blocks a call and consumed by the session at turn end to flip the final
     to awaiting-approval; ``reset()`` clears them at each turn start so one
-    turn's block never leaks into the next.
+    turn's block never leaks into the next. ``pending_halt`` records that the
+    runner's own gate asked the CLI to stop the turn (#1852) -- it is
+    runner-internal state, never a wire field, and the session reads it to tell
+    "the turn ended badly because we stopped it for approval" apart from "the
+    turn ended badly".
 
     The first blocked call of a turn wins: a model that retries the denied
     tool (against the deny message's instruction) does not overwrite the
@@ -505,6 +509,12 @@ class ApprovalGate:
     policy_route: str | None = None
     grant_tool: str | None = None
     grantable_by_route: dict[str, str] = field(default_factory=dict)
+    # Set by ``block()`` whenever the gate refuses a call (#1852). Since the
+    # refusal now carries the SDK's turn-stopping flags, the CLI aborts the turn
+    # and its terminal result arrives shaped like a failure; this marker is how
+    # ``SessionRunner`` knows the runner itself requested that stop. It is
+    # runner-internal and is NEVER serialized onto the wire.
+    pending_halt: bool = False
     _boot_turn_seen: bool = False
 
     def grantable_tool_for_route(self, route: str | None) -> str | None:
@@ -527,6 +537,10 @@ class ApprovalGate:
         self.policy_requested = False
         self.policy_rejected = False
         self.policy_route = None
+        # Strictly per-turn, and cleared with the other pending state rather
+        # than with the boot-turn grant below: a halt that leaked forward would
+        # make every later errored turn finalize as awaiting-approval (#1852).
+        self.pending_halt = False
         # Boot-turn-only grant: keep it on the first reset (the boot turn),
         # expire any unspent grant on the second and later resets so it never
         # leaks into a subsequent turn.
@@ -543,6 +557,11 @@ class ApprovalGate:
         return False
 
     def block(self, tool_name: str, tool_input: dict[str, Any]) -> None:
+        # Outside the first-block guard on purpose (#1852): the FIRST blocked
+        # call still wins the summary the human resolves against, but a second
+        # blocked call in the same turn must still assert that the runner asked
+        # for a stop. Do not tidy this back inside the guard below.
+        self.pending_halt = True
         if self.pending_summary is None:
             self.pending_summary = summarize_tool_call(tool_name, tool_input)
             self.pending_route = self.route_by_tool.get(tool_name)
@@ -553,6 +572,48 @@ class ApprovalGate:
             self.pending_granted_tool = tool_name
 
 
+class _GateDecision(NamedTuple):
+    """The three-way approval-gate outcome shared by both interception points.
+
+    ``build_can_use_tool`` (the SDK permission callback, backstop) and
+    ``build_approval_hook`` (the PreToolUse hook, #1852, first line of
+    defense) each apply the identical ungated/granted/blocked rule to a
+    candidate tool call before rendering it into their own callback's return
+    shape (an SDK ``PermissionResult`` vs a hook-output dict). ``_decide_gate``
+    below is that one rule, so a future change to it lands in both call sites
+    at once instead of risking the two drifting apart -- exactly the defect
+    class #1852 closed for the two independent invocation contexts, applied
+    here to the decision they share.
+
+    ``blocked`` is the only field a caller branches on today; ``ungated`` is
+    carried so a caller that wants to distinguish "nothing to do" from
+    "allowed via grant" can, without re-deriving it from ``gate.required``.
+    """
+
+    blocked: bool
+    ungated: bool
+
+
+def _decide_gate(gate: ApprovalGate, tool_name: str, tool_input: dict[str, Any]) -> _GateDecision:
+    """Apply the gate rule to one candidate call, mutating ``gate`` as needed.
+
+    Mirrors the pre-extraction ``can_use_tool`` logic verbatim: a tool outside
+    ``gate.required`` is ungated (no state change, allow); a gated tool with an
+    unspent one-shot grant is granted (the grant is spent here, allow); anything
+    else is blocked (``gate.block`` records it, deny). The caller still owns
+    rendering the outcome into its own return shape and any outcome-specific
+    side effects (the hook's grant-spend log line, the SDK deny's ``interrupt``
+    flag) -- this function decides, it does not render.
+    """
+
+    if tool_name not in gate.required:
+        return _GateDecision(blocked=False, ungated=True)
+    if gate.consume_grant(tool_name):
+        return _GateDecision(blocked=False, ungated=False)
+    gate.block(tool_name, tool_input)
+    return _GateDecision(blocked=True, ungated=False)
+
+
 def build_can_use_tool(gate: ApprovalGate) -> CanUseTool:
     """The SDK permission callback replacing the hardcoded bypass (#245).
 
@@ -561,6 +622,18 @@ def build_can_use_tool(gate: ApprovalGate) -> CanUseTool:
     for unconfigured tools. The decision is proactive -- the call is blocked
     before execution -- unlike the reactive ``side_effect_flag`` classifier,
     which only reports after the fact.
+
+    Since #1852 this is the **second** line of defense, not the first.
+    ``build_approval_hook`` decides first on the real path, because the SDK
+    documents on ``ClaudeAgentOptions.can_use_tool``
+    (``claude_agent_sdk/types.py:1932-1948``) that this callback is *not*
+    invoked for a call already permitted by ``allowed_tools``, ``permission_mode``
+    or a settings ``permissions.allow`` rule -- and a skill's ``allowed-tools``
+    frontmatter is exactly such a rule. Confirmed live (2026-08-29,
+    claude-agent-sdk 0.2.135 + OpenRouter anthropic/claude-sonnet-4.5): with
+    ``allowed_tools=["Bash"]`` and no PreToolUse hook, this callback was never
+    invoked and Bash executed. It remains the decision on the fake tier, and the
+    backstop for every tool the hook abstains on or if no hook is registered.
     """
 
     async def can_use_tool(
@@ -568,17 +641,175 @@ def build_can_use_tool(gate: ApprovalGate) -> CanUseTool:
         tool_input: dict[str, Any],
         _context: ToolPermissionContext,
     ) -> PermissionResultAllow | PermissionResultDeny:
-        if tool_name in gate.required:
-            # The one-shot post-approval allowance (#430): a resume-boot grant
-            # for exactly this tool lets one call through (no block recorded, the
-            # approved action completes) and re-arms the gate.
-            if gate.consume_grant(tool_name):
-                return PermissionResultAllow()
-            gate.block(tool_name, tool_input)
-            return PermissionResultDeny(message=_DENY_MESSAGE)
+        # The one-shot post-approval allowance (#430): a resume-boot grant for
+        # exactly this tool lets one call through (no block recorded, the
+        # approved action completes) and re-arms the gate. ``_decide_gate``
+        # applies this rule (shared with the hook below).
+        decision = _decide_gate(gate, tool_name, tool_input)
+        if decision.blocked:
+            # ``interrupt`` is the SDK-native "deny AND stop the turn" flag
+            # (``PermissionResultDeny.interrupt``, claude_agent_sdk/types.py:247-252),
+            # forwarded to the CLI as ``response_data["interrupt"]`` in
+            # claude_agent_sdk/_internal/query.py:474-477. Before #1852 only
+            # ``_DENY_MESSAGE``'s prose asked the model to end its turn, and
+            # against a real OpenRouter-backed model it simply spun until the
+            # caller timed out -- with the stream entry pending and no approval
+            # record. Prose is not a halt mechanism; this flag is. It rides the
+            # DENY only: an allow that carried it would kill every ungated call.
+            return PermissionResultDeny(message=_DENY_MESSAGE, interrupt=True)
         return PermissionResultAllow()
 
     return can_use_tool
+
+
+# What the operator sees when the hook stops the turn. Short by design: it is
+# surfaced as the CLI's stop reason, not as the approval summary (which is
+# ``pending_summary``, built by ``summarize_tool_call``).
+_HOOK_STOP_REASON = "Paused for human approval: an approval-required tool call was denied."
+
+# Why the hook allows a call outright. Only ever emitted after the one-shot
+# post-approval grant (#430) has actually been spent, so it can state that.
+_HOOK_GRANT_REASON = (
+    "Approved by a human: the one-shot post-approval grant for this tool was spent"
+    " on this call, and the gate is re-armed for any further call."
+)
+
+
+def _hook_field(hook_input: Any, key: str) -> Any:
+    """Read one field from a hook input that may be a mapping or a dataclass.
+
+    The SDK types the callback's first argument as ``HookInput`` (a union of
+    TypedDicts, so a dict at runtime), but the CLI is the thing that actually
+    constructs it and a future shape change must not turn the gate into a
+    raising hook. Missing/odd shapes resolve to None and the caller abstains.
+    """
+
+    if isinstance(hook_input, Mapping):
+        return hook_input.get(key)
+    return getattr(hook_input, key, None)
+
+
+def build_approval_hook(gate: ApprovalGate) -> dict[str, list[HookMatcher]]:
+    """The ``PreToolUse`` hook that no permission rule can shadow (#1852).
+
+    ``can_use_tool`` (#245) arms the gate but is skipped whenever some other
+    permission rule already allows the call, and a skill's ``allowed-tools``
+    frontmatter is such a rule -- so a bundle could arm a gate and then walk
+    straight through it. The SDK names the fix on that very field: "To observe
+    or gate *every* tool call regardless of permission rules, use a
+    ``PreToolUse`` hook via ``hooks`` instead"
+    (``claude_agent_sdk/types.py:1945-1947``). ``matcher=None`` matches every
+    tool call, which is the whole claim.
+
+    Returns the ``{"PreToolUse": [HookMatcher]}`` mapping ``__main__`` MERGES
+    into the bundle's own hooks (#272). Note that the CLI dispatches every
+    matcher on one event **concurrently** (``types.py:1956-1961``), so this hook
+    must not assume it runs before a bundle's hook, and its position in the
+    merged list is construction order, not precedence.
+
+    Three outcomes, keyed on gate membership:
+
+    - **Ungated tool** -> ``{}``. No decision, so the call falls through the
+      CLI's normal precedence and on to ``can_use_tool``, preserving today's
+      posture exactly. An ``allow`` here would silently widen authority for
+      every non-gated tool AND skip the callback the policy lane (#544/#558)
+      still relies on.
+    - **Gated, with the one-shot grant available** -> an EXPLICIT ``allow``,
+      after spending the grant here. This is load-bearing, not stylistic: the
+      SDK documents (and it was observed live on 2026-08-29 against OpenRouter
+      anthropic/claude-sonnet-4.5) that a hook ``allow`` also skips
+      ``can_use_tool``. So the hook must be the thing that spends the grant --
+      if it returned ``{}`` instead, ``can_use_tool`` would run, find the grant
+      unspent, and either block the approved call or (if the hook had spent it
+      and still returned ``{}``) let one approval buy unlimited executions.
+      Either way #430's one-shot allowance breaks. Do not "simplify" this to a
+      bare ``{}``.
+    - **Gated, no grant** -> record the block and ``deny``, plus the
+      turn-stopping control fields, so the run pauses rather than spinning.
+
+    A bundle's own PreToolUse guardrail can still veto an approved call
+    (#1852, accepted rather than fixed). The grant above is spent AT DECISION
+    TIME -- before this hook returns -- but every matcher on one ``PreToolUse``
+    event is dispatched CONCURRENTLY by the CLI (``claude_agent_sdk/types.py``,
+    the ``ClaudeAgentOptions.hooks`` docstring), so a bundle's own hook for the
+    same tool (see ``hooks.py``) resolves independently and can return
+    ``deny`` even though this hook already returned ``allow`` and spent the
+    grant. When that happens the approved call does not execute, but the
+    one-shot grant is already gone, so recovery is a fresh approval -- there is
+    no way to detect a concurrently-dispatched hook's outcome from inside this
+    callback, so this cannot be fixed from here. This is deliberate defense in
+    depth, not a bug: a bundle's own guardrail vetoing an approved call is a
+    legitimate second opinion, and failing toward "did not run, needs
+    re-approval" is the safe direction -- the alternative (letting a
+    bundle-denied call through because it was separately approved) would be a
+    real hole. ``consume_grant`` is called here anyway (see the WARNING log at
+    the call site) precisely because NOT spending it would let ``can_use_tool``
+    re-block the approved call, which is the #430 regression this explicit
+    ``allow`` exists to prevent.
+    """
+
+    async def approval_hook(
+        hook_input: Any,
+        _tool_use_id: str | None,
+        _context: Any,
+    ) -> dict[str, Any]:
+        tool_name = _hook_field(hook_input, "tool_name")
+        if not isinstance(tool_name, str) or not tool_name:
+            # Abstain rather than raise. A hook that raises is reported by the
+            # CLI as a hook error and the call then PROCEEDS -- a crash in the
+            # gate would become a fail-open. Abstaining leaves ``can_use_tool``
+            # as the backstop, which is strictly the pre-#1852 posture.
+            return {}
+        if tool_name not in gate.required:
+            return {}
+
+        raw_input = _hook_field(hook_input, "tool_input")
+        tool_input: dict[str, Any] = raw_input if isinstance(raw_input, dict) else {}
+
+        # ``_decide_gate`` applies the shared ungated/granted/blocked rule (also
+        # used by ``build_can_use_tool`` above); the grant, if any, is spent as
+        # a side effect of this call.
+        decision = _decide_gate(gate, tool_name, tool_input)
+        if not decision.blocked:
+            # Observability for #1852 (accepted, not fixed): the grant is spent
+            # HERE, before the concurrently-dispatched bundle PreToolUse hook's
+            # own outcome is known (see the docstring above). If a bundle hook
+            # independently denies this same call, the call never executes but
+            # the grant is already gone -- silently, from an operator's view.
+            # This WARNING is the only way to correlate "approval granted" with
+            # "the call may not have actually run" from pod logs.
+            logger.warning("approval one-shot grant spent tool=%s", tool_name)
+            return {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "allow",
+                    "permissionDecisionReason": _HOOK_GRANT_REASON,
+                }
+            }
+
+        # ``continue_`` and ``stopReason`` are ``SyncHookJSONOutput`` common
+        # control fields (claude_agent_sdk/types.py:520-561): "Whether Claude
+        # should proceed after hook execution" and "Message shown when continue
+        # is False". Emit the Python spelling ``continue_`` -- the SDK rewrites
+        # it to the wire's "continue" in
+        # claude_agent_sdk/_internal/query.py::_convert_hook_output_for_cli, so
+        # emitting the wire name directly would be passed through untouched and
+        # silently ignored, and the turn would keep running after the deny.
+        return {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "deny",
+                "permissionDecisionReason": _DENY_MESSAGE,
+            },
+            "continue_": False,
+            "stopReason": _HOOK_STOP_REASON,
+        }
+
+    # ``Any`` for the same reason ``hooks.py::_make_callback`` uses it: the SDK's
+    # ``HookCallback`` alias is typed against its TypedDict union, and a plain
+    # ``dict[str, Any]`` return is not assignable to it.
+    callback: Any = approval_hook
+    return {"PreToolUse": [HookMatcher(matcher=None, hooks=[callback])]}
 
 
 # --- The manifest approval policy (#247): gates shipped in the bundle -----------

--- a/runner/src/curie_runner/fake.py
+++ b/runner/src/curie_runner/fake.py
@@ -19,7 +19,7 @@ from claude_agent_sdk import (
     TextBlock,
     ToolUseBlock,
 )
-from claude_agent_sdk.types import CanUseTool, ToolPermissionContext
+from claude_agent_sdk.types import CanUseTool, PermissionResultDeny, ToolPermissionContext
 
 from .approval import APPROVAL_TOOL_NAME, ApprovalGate, process_approval_request
 
@@ -101,13 +101,16 @@ class FakeModelSession:
 
     ``can_use_tool`` (the #245 permission gate) lets the offline path exercise the
     same intercept the SDK applies: before each scripted ``ToolUseBlock`` is
-    yielded, the permission callback runs for its side effect (a gated tool's deny
-    records the block on the shared gate, flipping the turn to awaiting-approval).
-    The block itself is delivered unchanged -- matching the real SDK, which emits
-    the ``tool_use`` even for a denied call -- so a gated turn still surfaces the
-    tool note it would in production. Defaults None, so a fake constructed without
-    it behaves exactly as before. Bundle PreToolUse command hooks (#272) are NOT
-    run here: they shell out and would break the fake's offline no-op guarantee.
+    yielded, the permission callback runs and its DECISION is honored -- a gated
+    tool's deny records the block on the shared gate (flipping the turn to
+    awaiting-approval), and a deny carrying ``interrupt=True`` additionally ends
+    the replay, the same way the real CLI aborts the turn (#1852; see
+    ``_apply_gate``). The block itself is delivered unchanged -- matching the
+    real SDK, which emits the ``tool_use`` even for a denied call -- so a gated
+    turn still surfaces the tool note it would in production. Defaults None, so
+    a fake constructed without it behaves exactly as before. Bundle PreToolUse
+    command hooks (#272) are NOT run here: they shell out and would break the
+    fake's offline no-op guarantee.
     """
 
     def __init__(
@@ -130,6 +133,12 @@ class FakeModelSession:
         self.queries: list[str] = []
         self.interrupts = 0
         self._interrupted = False
+        # Set when the permission callback denies WITH interrupt=True (#1852):
+        # the real CLI aborts the turn on that flag, so the replay must stop too
+        # or the offline tier silently models a gate weaker than production's.
+        # Strictly per-turn -- reset in ``query`` beside ``_interrupted``, so a
+        # halt can never truncate an unrelated later replay.
+        self._halted = False
 
     def _default_script(self) -> list[Any]:
         """The default per-turn script, branching on the approval marker.
@@ -152,6 +161,7 @@ class FakeModelSession:
     async def query(self, text: str) -> None:
         self.queries.append(text)
         self._interrupted = False
+        self._halted = False
 
     async def interrupt(self) -> None:
         self.interrupts += 1
@@ -163,9 +173,17 @@ class FakeModelSession:
                 return
             await self._apply_gate(message)
             yield message
+            if self._halted:
+                # The denied ToolUseBlock above IS delivered (the real SDK emits
+                # the tool_use even for a denied call), and nothing after it is:
+                # an interrupting deny aborts the turn, so any scripted text or
+                # terminal result that followed never happens (#1852). This is a
+                # separate mechanism from the ``_interrupted`` truncation above,
+                # which models an OPERATOR stop and must keep working on its own.
+                return
 
     async def _apply_gate(self, message: Any) -> None:
-        """Run the permission gate over each ToolUseBlock for its side effect.
+        """Run the permission gate over each ToolUseBlock and honor its decision.
 
         Mirrors the SDK: the gate decides a call before it executes, and a gated
         deny records the block on the shared ``ApprovalGate`` (flipping the turn to
@@ -173,6 +191,15 @@ class FakeModelSession:
         SDK emits the ``tool_use`` before the permission decision, so a denied call
         still surfaces as a tool note. A no-op unless a gate is configured, keeping
         the un-gated fake unchanged.
+
+        The callback's return value is READ, not discarded (#1852): a
+        ``PermissionResultDeny`` with ``interrupt=True`` is forwarded by the SDK
+        to the CLI as ``response_data["interrupt"]``
+        (``claude_agent_sdk/_internal/query.py:474-477``), which aborts the turn.
+        Recording it here is what lets the offline tier prove the halt rather
+        than replay past a call production would have stopped on. A deny WITHOUT
+        the flag is unchanged: the replay continues and the scripted terminal
+        result still arrives.
         """
 
         if not isinstance(message, AssistantMessage):
@@ -189,7 +216,11 @@ class FakeModelSession:
                 payload = block.input if isinstance(block.input, dict) else {}
                 process_approval_request(self._approval_gate, payload)
             if self._can_use_tool is not None:
-                await self._can_use_tool(block.name, block.input, ToolPermissionContext())
+                decision = await self._can_use_tool(
+                    block.name, block.input, ToolPermissionContext()
+                )
+                if isinstance(decision, PermissionResultDeny) and decision.interrupt:
+                    self._halted = True
 
     async def close(self) -> None:
         self.connected = False

--- a/runner/src/curie_runner/session.py
+++ b/runner/src/curie_runner/session.py
@@ -97,16 +97,63 @@ def _is_auth_rejection(message: object) -> bool:
 
 
 def _apply_approval_override(final: Final, state: TurnState) -> Final:
-    """Flip a successful final to awaiting-approval when a gate fired (ADR-0010).
+    """Flip a final to awaiting-approval when a gate fired (ADR-0010, #1852).
 
-    Only a DONE final is overridden: a failure, budget halt, or intentional
-    interrupt outranks a pending approval (the turn did not complete cleanly,
-    so suspending on it would strand a broken run behind a human decision).
+    A DONE final is overridden, as it always was. A NON-DONE final is overridden
+    only when the runner's own gate requested the halt
+    (``approval_halt_requested``) AND nothing else reported a real failure:
+    since #1852 a gated deny carries the SDK's turn-stopping flags
+    (``PermissionResultDeny.interrupt`` / the hook's ``continue_: False``), so
+    the CLI aborts the turn and its terminal ``ResultMessage`` arrives
+    ``is_error``-shaped, which ``translate.py::_translate_result`` maps to
+    CLASSIFIED_FAILURE. Without honoring the flag, the fix for the hang would
+    turn it into a failure carrying no approval record -- a worse outcome than
+    the hang, because there would be nothing for a human to approve.
+
+    **Precedence: a failure the runner did not cause outranks the halt.** The
+    halt marker is set by ``ApprovalGate.block`` at deny time, BEFORE the turn's
+    terminal cause is known, so on its own it cannot tell "the CLI aborted
+    because we asked it to" from "the provider fell over a moment later". The
+    tiebreaker is ``TurnState.error_classification``, which ``translate.py``
+    sets ONLY where the model or transport reported a classified error of its
+    own (an ``AssistantMessage.error``, or a rejected ``RateLimitEvent``) and
+    deliberately NOT on the bare error-shaped result an abort produces. So:
+
+    - halt marker, no classified error  -> the abort is ours; pause for approval
+      (the #1852 case, where the alternative is losing the approval record);
+    - halt marker AND a classified error -> the model/transport failed on its
+      own; report the failure. Relabelling a provider outage as
+      awaiting-approval would hide it behind a human decision that cannot fix
+      it, and approving it would resume straight back into the same failure.
+
+    Both branches require ``state.approval_summary``, so a halt recorded with
+    no summary cannot flip a final on its own.
+
+    What still outranks a pending approval, unchanged:
+
+    - the **budget halt**, checked before this call in ``_drive_turn`` (a run
+      that blew its ceiling has not completed cleanly, and approving it would
+      resume straight back into the same halt);
+    - a **genuine operator interrupt**, excluded upstream at the
+      ``_merge_gate_block`` guard (the operator asked for the turn to stop and
+      must get idle-awaiting-input, not a pause behind a decision they did not
+      request);
+    - an **auth rejection**, which returns before any final exists.
+
+    A DONE final is untouched by the new guard: a turn the model finished
+    cleanly is an approval pause regardless of any non-terminal error frame it
+    streamed along the way (a recovered rate limit, say).
+
     The captured summary rides the final so the platform can persist it on the
     durable Approval record.
     """
 
-    if state.approval_summary and final.status is SessionStatus.DONE:
+    runner_halted_the_turn = (
+        state.approval_halt_requested and state.error_classification is None
+    )
+    if state.approval_summary and (
+        final.status is SessionStatus.DONE or runner_halted_the_turn
+    ):
         return Final(
             text=final.text,
             status=SessionStatus.AWAITING_APPROVAL,
@@ -635,6 +682,12 @@ class SessionRunner:
           summary already stands) lets ``_apply_approval_override`` treat both
           trigger types identically, along with the durable provenance
           (#544, Decision C) the worker branches on.
+        - **Approval halt (#1852):** a gated deny now asks the CLI to stop the
+          turn, so the gate's ``pending_halt`` marker is carried onto the turn
+          state for ``_apply_approval_override`` -- but only when the operator
+          did not also interrupt. A human pressing stop is an intentional stop,
+          not an approval request; reporting it as awaiting-approval would
+          suspend the thread behind a decision nobody asked for.
         """
 
         gate = self._approval_gate
@@ -661,6 +714,11 @@ class SessionRunner:
             state.approval_route = gate.pending_route
             state.approval_gate_kind = gate.pending_gate_kind
             state.approval_granted_tool = gate.pending_granted_tool
+
+        # See the "Approval halt" bullet above: an operator interrupt outranks a
+        # runner-requested one, so the marker is copied only in its absence.
+        if gate.pending_halt and not self._interrupt_requested:
+            state.approval_halt_requested = True
 
     def _budget_halt_lines(self) -> list[str]:
         """The error+final pair emitted whenever the output-token ceiling trips.

--- a/runner/src/curie_runner/translate.py
+++ b/runner/src/curie_runner/translate.py
@@ -80,6 +80,15 @@ class TurnState:
     # reply recorded into the conversation transcript (#20); left None on a
     # failure/budget/auth final so those turns are not persisted as history.
     final_text: str | None = None
+    # Runner-internal, NOT a wire field (#1852): set by
+    # ``SessionRunner._merge_gate_block`` when the runner's OWN approval gate
+    # asked the CLI to stop the turn. A gated deny now carries the SDK's
+    # turn-stopping flags, so the CLI aborts and its terminal result arrives
+    # is_error-shaped -- which ``_translate_result`` classifies as a failure.
+    # This flag is what lets ``_apply_approval_override`` flip a turn the CLI
+    # reported as errored *because we interrupted it*, instead of reporting a
+    # failure with nothing to approve.
+    approval_halt_requested: bool = False
 
 
 def translate_message(

--- a/runner/tests/test_approval_gate_enforcement.py
+++ b/runner/tests/test_approval_gate_enforcement.py
@@ -1,0 +1,917 @@
+"""The approval gate is ENFORCED, not merely armed (#1852).
+
+PR #1875 landed only the boot-time refusal (``assert_gates_not_shadowed``, tested
+in ``test_gate_shadowing.py``). That closes the case where the bundle itself
+preauthorizes a gated tool, but it cannot close the two halves this file covers:
+
+1. **The gate has to run at a layer permission rules cannot skip.** The SDK
+   documents on ``ClaudeAgentOptions.can_use_tool`` (see
+   ``.venv/lib/python3.14/site-packages/claude_agent_sdk/types.py``, the
+   ``can_use_tool`` field docstring) that the callback is "*not* invoked for tool
+   calls already permitted by ``allowed_tools`` ... or ``permissions.allow`` rules
+   in settings", and that "To observe or gate *every* tool call regardless of
+   permission rules, use a ``PreToolUse`` hook via ``hooks`` instead -- but note
+   that a ``PreToolUse`` hook returning an *allow* decision also skips this
+   callback." So the gate's DECIDING layer must be the PreToolUse hook.
+
+   Observed live (2026-08-29, claude-agent-sdk 0.2.135 + OpenRouter
+   anthropic/claude-sonnet-4.5) with
+   ``ClaudeAgentOptions(allowed_tools=["Bash"], permission_mode="default",
+   can_use_tool=<cb>)``:
+     - no PreToolUse hook              -> ``can_use_tool`` NEVER invoked, Bash EXECUTED;
+     - hook returns deny + continue False -> hook invoked, ``can_use_tool`` never
+       invoked, Bash NOT executed, and the turn ended promptly with a terminal
+       ``ResultMessage``;
+     - hook returns allow              -> hook invoked, ``can_use_tool`` NOT invoked,
+       Bash executed.
+   That third line is why the hook -- not ``can_use_tool`` -- has to be what spends
+   the one-shot post-approval grant: a hook allow means the callback never runs.
+
+2. **Stopping the turn must still produce an approval record.** A hook deny that
+   stops the turn, and a ``PermissionResultDeny(interrupt=True)``, both end the
+   turn in a shape the session previously read as a plain failure, so the run
+   ended ``classified-failure`` with no ``approval_summary`` and nothing to
+   approve -- the "denied live tool call left the turn hanging" half of the issue.
+   ``_apply_approval_override`` only flipped a DONE final, so a runner-requested
+   halt has to be carried on its own flag.
+
+Everything here runs offline: no network, no credential, no mocked
+Postgres/Valkey/Langfuse. The model session is replaced at the ``ModelSession``
+adapter seam (``FakeModelSession``), which is the repo's sanctioned mock point.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import typing
+from pathlib import Path
+from typing import Any
+
+import anyio
+import pytest
+from aci_protocol import Event, SessionStatus, parse_ndjson
+from claude_agent_sdk import (
+    AssistantMessage,
+    HookMatcher,
+    ResultMessage,
+    TextBlock,
+    ToolUseBlock,
+)
+from claude_agent_sdk.types import (
+    PermissionResultAllow,
+    PermissionResultDeny,
+    PreToolUseHookSpecificOutput,
+    SyncHookJSONOutput,
+    ToolPermissionContext,
+)
+from curie_runner import __main__ as boot
+from curie_runner.__main__ import build_runner
+from curie_runner.approval import (
+    _DENY_MESSAGE,
+    APPROVAL_SUMMARY_PREFIX,
+    ApprovalGate,
+    ApprovalPolicyError,
+    build_approval_hook,
+    build_can_use_tool,
+)
+from curie_runner.config import RunnerConfig
+from curie_runner.fake import FakeModelSession
+from curie_runner.otel import RunTracer
+from curie_runner.session import SessionRunner
+from curie_runner.side_effects import SideEffectClassifier
+
+_BUDGET = '{"max_output_tokens_per_run": 10000, "max_usd_per_day": 1.0}'
+
+
+# --- fixtures: a realistic plugin bundle, not a stub ----------------------------
+
+
+def _bundle(
+    root: Path,
+    *,
+    gates: list[str] | None = None,
+    skill_allowed_tools: list[str] | None = None,
+    manifest_hooks: dict[str, Any] | None = None,
+) -> str:
+    """Write a real bundle dir: manifest + (optionally) a skill with frontmatter.
+
+    Mirrors the ``_bundle`` idiom in ``test_gate_shadowing.py`` but adds the
+    manifest ``hooks`` field, because the merge under test (#1852) is between the
+    bundle's own PreToolUse matchers and the approval matcher.
+    """
+
+    (root / ".claude-plugin").mkdir(parents=True, exist_ok=True)
+    manifest: dict[str, Any] = {
+        "name": "approval-demo",
+        "version": "0.1.0",
+        "description": "A bundle for the gate-enforcement tests.",
+    }
+    if gates:
+        manifest["approvalPolicy"] = {"gates": [{"gate": g, "route": "ops"} for g in gates]}
+    if manifest_hooks is not None:
+        manifest["hooks"] = manifest_hooks
+    (root / ".claude-plugin" / "plugin.json").write_text(json.dumps(manifest), encoding="utf-8")
+    if skill_allowed_tools is not None:
+        skill_dir = root / "skills" / "approval-demo"
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        lines = [
+            "---",
+            "name: approval-demo",
+            "description: Demonstrates the approval gate.",
+            "allowed-tools:",
+            *(f"  - {entry}" for entry in skill_allowed_tools),
+            "---",
+            "",
+            "# approval-demo",
+            "",
+        ]
+        (skill_dir / "SKILL.md").write_text("\n".join(lines), encoding="utf-8")
+    return str(root)
+
+
+def _config(plugin_dir: str, **extra: str) -> RunnerConfig:
+    return RunnerConfig.from_env(
+        {
+            "CURIE_PLUGIN_DIR": plugin_dir,
+            "CURIE_SESSION_ID": "s-1852",
+            "CURIE_SANDBOX_ID": "b-1852",
+            "CURIE_BUDGET": _BUDGET,
+            **extra,
+        }
+    )
+
+
+def _hook_callback(gate: ApprovalGate):
+    """The single PreToolUse callback ``build_approval_hook`` contributes."""
+
+    hooks = build_approval_hook(gate)
+    assert set(hooks) == {"PreToolUse"}, "the approval hook registers PreToolUse only"
+    matchers = hooks["PreToolUse"]
+    assert len(matchers) == 1
+    matcher = matchers[0]
+    assert isinstance(matcher, HookMatcher)
+    # matcher=None means "every tool call". A tool-name matcher string would let
+    # the CLI's own matching decide which calls reach us, and the gate's whole
+    # claim is that it sees every one.
+    assert matcher.matcher is None
+    assert len(matcher.hooks) == 1
+    return matcher.hooks[0]
+
+
+def _run_hook(gate: ApprovalGate, tool: str, tool_input: dict[str, Any]) -> dict[str, Any]:
+    callback = _hook_callback(gate)
+
+    async def go() -> dict[str, Any]:
+        return await callback(
+            {"tool_name": tool, "tool_input": tool_input}, "tuid-1", {"signal": None}
+        )
+
+    return anyio.run(go)
+
+
+def _decision(output: dict[str, Any]) -> dict[str, Any]:
+    assert "hookSpecificOutput" in output, f"no hook decision in {output!r}"
+    return output["hookSpecificOutput"]
+
+
+def _runner_over(script: list[Any], *, gate: ApprovalGate, ceiling: int = 10_000, **kw):
+    session = FakeModelSession(lambda: script, **kw)
+    runner = SessionRunner(
+        session_factory=lambda: session,
+        ceiling=ceiling,
+        tracer=RunTracer(None),
+        classifier=SideEffectClassifier(),
+        trace_name="t",
+        approval_gate=gate,
+    )
+    return runner, session
+
+
+def _recording_deny(gate: ApprovalGate, *, interrupt: bool):
+    """A permission callback that records the block exactly as the hook does.
+
+    The fake tier deliberately does not run PreToolUse hooks (they shell out and
+    would break its offline no-op guarantee -- see ``FakeModelSession``), so a
+    session-level test drives the same state transition through the permission
+    callback seam the fake DOES honor. ``interrupt`` is a parameter because the
+    two turn-ending shapes under test differ: ``True`` is the SDK aborting the
+    turn immediately, ``False`` lets the scripted terminal result be delivered so
+    the error-result shape itself can be asserted on.
+    """
+
+    async def callback(
+        tool_name: str, tool_input: dict[str, Any], _ctx: ToolPermissionContext
+    ) -> PermissionResultAllow | PermissionResultDeny:
+        if tool_name in gate.required:
+            gate.block(tool_name, tool_input)
+            return PermissionResultDeny(message=_DENY_MESSAGE, interrupt=interrupt)
+        return PermissionResultAllow()
+
+    return callback
+
+
+def _gated_bash_then_error_result() -> list[Any]:
+    """A gated Bash call followed by an interrupt-shaped terminal ERROR result.
+
+    This is the shape a CLI-side stop produces: the model's tool call is emitted,
+    the call never executes, and the turn terminates on an error-subtype
+    ``ResultMessage`` rather than a clean success.
+    """
+
+    return [
+        AssistantMessage(content=[TextBlock(text="I'll run that")], model="m"),
+        AssistantMessage(
+            content=[ToolUseBlock(id="t1", name="Bash", input={"command": "rm -rf /tmp/x"})],
+            model="m",
+        ),
+        ResultMessage(
+            subtype="error_during_execution",
+            duration_ms=1,
+            duration_api_ms=1,
+            is_error=True,
+            num_turns=1,
+            session_id="s",
+            result="aborted",
+        ),
+    ]
+
+
+# --- A. the exact issue repro, through the real boot path (AC1/AC2) -------------
+
+
+def test_boot_refuses_the_issue_repro_bundle(tmp_path: Path) -> None:
+    # revert: drop the assert_gates_not_shadowed call from build_runner -> this fails.
+    # The verbatim #1852 repro: a manifest that gates Bash shipped alongside a
+    # skill whose frontmatter declares `allowed-tools: [Bash]`. Driven through
+    # build_runner (not the validator in isolation) because boot is the only
+    # scope that holds both the assembled gate and the bundle directory.
+    plugin_dir = _bundle(tmp_path, gates=["Bash"], skill_allowed_tools=["Bash"])
+
+    with pytest.raises(ApprovalPolicyError) as exc:
+        build_runner(_config(plugin_dir), fake_model=True)
+
+    message = str(exc.value)
+    assert "skills/approval-demo/SKILL.md" in message  # the file to edit
+    assert "'Bash'" in message  # the entry, and the gated tool
+    assert "before the approval callback runs" in message  # why it is fatal
+
+
+def test_boot_accepts_the_same_bundle_once_the_entry_is_removed(tmp_path: Path) -> None:
+    # revert/negative control: if assert_gates_not_shadowed over-matched, a
+    # legitimately gated bundle would refuse to boot and operators would remove
+    # the gate to get running again.
+    plugin_dir = _bundle(tmp_path, gates=["Bash"], skill_allowed_tools=["Read"])
+    runner = build_runner(_config(plugin_dir), fake_model=True)
+    assert runner is not None
+
+
+# --- B. an operator gate armed AFTER deployment (AC6) ---------------------------
+
+
+def test_hook_denies_a_gate_the_operator_armed_after_the_bundle_shipped() -> None:
+    # revert: hook returns {} (or an "ask") for a gated tool -> this fails, and the
+    # tool runs unapproved.
+    # The bundle ships no approvalPolicy and no allowed-tools entry, so nothing at
+    # deploy time has anything to check; the gate exists only because an operator
+    # set CURIE_APPROVAL_REQUIRED_TOOLS=Bash afterwards. The hook must still deny.
+    gate = ApprovalGate(required=frozenset({"Bash"}))
+
+    output = _run_hook(gate, "Bash", {"command": "rm -rf /tmp/x"})
+
+    decision = _decision(output)
+    assert decision["hookEventName"] == "PreToolUse"
+    assert decision["permissionDecision"] == "deny"
+    assert decision["permissionDecisionReason"] == _DENY_MESSAGE
+
+    # The turn-stopping half. `continue_` is the Python-side spelling; the SDK
+    # rewrites it to the wire's "continue" in
+    # claude_agent_sdk/_internal/query.py::_convert_hook_output_for_cli, so a
+    # callback that emitted the wire name would be silently ignored and the turn
+    # would keep running after the deny.
+    assert output["continue_"] is False
+    assert "continue" not in output, "emit continue_, not the wire name; the SDK converts"
+    assert isinstance(output.get("stopReason"), str) and output["stopReason"]
+
+    # And the approval record the platform suspends on.
+    assert gate.pending_summary is not None
+    assert gate.pending_summary.startswith(APPROVAL_SUMMARY_PREFIX)
+    assert "rm -rf /tmp/x" in gate.pending_summary
+    assert gate.pending_gate_kind == "permission"
+    assert gate.pending_granted_tool == "Bash"
+    # The runner asked for the stop, so an interrupt-shaped turn end is still an
+    # approval pause rather than a failure (see test F).
+    assert gate.pending_halt is True
+
+
+def test_reset_clears_the_halt_marker() -> None:
+    # revert: reset() leaves pending_halt set -> the NEXT turn's unrelated failure
+    # is reported as awaiting-approval on a stale flag.
+    gate = ApprovalGate(required=frozenset({"Bash"}))
+    gate.block("Bash", {"command": "x"})
+    assert gate.pending_halt is True
+    gate.reset()
+    assert gate.pending_halt is False
+
+
+# --- C. a non-gated tool falls through to the existing callback -----------------
+
+
+def test_hook_returns_no_decision_for_an_ungated_tool() -> None:
+    # revert: hook returns an explicit "allow" for every tool -> this fails.
+    # An explicit allow would be a behavior change well beyond the gate: the SDK
+    # documents that a PreToolUse allow SKIPS can_use_tool entirely, so allowing
+    # Read here would silently disable the approval callback for every other tool.
+    gate = ApprovalGate(required=frozenset({"Bash"}))
+
+    output = _run_hook(gate, "Read", {"file_path": "/etc/hosts"})
+
+    assert output == {}
+    assert gate.pending_summary is None
+    assert gate.pending_halt is False
+
+
+@pytest.mark.parametrize(
+    "hook_input",
+    [None, {}, {"tool_name": None}, {"tool_input": {"command": "x"}}, "not-a-mapping", []],
+)
+def test_hook_tolerates_a_missing_or_odd_shaped_input(hook_input: object) -> None:
+    # revert: index hook_input["tool_name"] directly -> a KeyError/TypeError inside
+    # a permission hook, which the CLI reports as a hook error and then lets the
+    # call PROCEED. A crash in the gate must never become a fail-open.
+    gate = ApprovalGate(required=frozenset({"Bash"}))
+    callback = _hook_callback(gate)
+
+    async def go() -> Any:
+        return await callback(hook_input, None, {"signal": None})
+
+    assert anyio.run(go) == {}
+    assert gate.pending_summary is None
+
+
+# --- D. the one-shot grant is spent by the HOOK, not by can_use_tool (AC4) ------
+
+
+def test_hook_spends_the_one_shot_grant_and_re_arms() -> None:
+    # revert: hook returns {} when a grant is available (leaving the allow to
+    # can_use_tool) -> the SDK never reaches can_use_tool for a hook-gated call, so
+    # the approved action is denied a second time and the resume deadlocks.
+    gate = ApprovalGate(required=frozenset({"Bash"}), grant_tool="Bash")
+
+    first = _run_hook(gate, "Bash", {"command": "the approved action"})
+    assert _decision(first)["permissionDecision"] == "allow"
+    assert "continue_" not in first, "an allow must not stop the turn"
+    assert gate.pending_summary is None  # the approved call records no block
+    assert gate.pending_halt is False
+
+    second = _run_hook(gate, "Bash", {"command": "sneak a retry"})
+    assert _decision(second)["permissionDecision"] == "deny"
+    assert gate.pending_summary is not None
+    assert "sneak a retry" in gate.pending_summary
+
+
+def test_can_use_tool_is_not_what_consumed_the_grant() -> None:
+    # revert: leave consume_grant in build_can_use_tool only -> this fails.
+    # Observed live: a PreToolUse hook returning "allow" SKIPS can_use_tool, so if
+    # the hook allowed while can_use_tool still owned the grant, the grant would
+    # never be spent and the very next gated call would be allowed too -- one
+    # approval buying unlimited executions.
+    gate = ApprovalGate(required=frozenset({"Bash"}), grant_tool="Bash")
+    callback = build_can_use_tool(gate)
+
+    allowed = _run_hook(gate, "Bash", {"command": "the approved action"})
+    assert _decision(allowed)["permissionDecision"] == "allow"
+
+    async def go() -> None:
+        # The hook spent it: the callback now denies.
+        result = await callback("Bash", {"command": "again"}, ToolPermissionContext())
+        assert isinstance(result, PermissionResultDeny)
+
+    anyio.run(go)
+
+
+# --- E. the callback's deny interrupts the turn ---------------------------------
+
+
+def test_can_use_tool_deny_carries_interrupt_true() -> None:
+    # revert: PermissionResultDeny(message=...) without interrupt=True -> the SDK
+    # default is interrupt=False (see PermissionResultDeny in
+    # claude_agent_sdk/types.py), so the model keeps its turn open after the deny
+    # and the run hangs instead of pausing for approval -- the live-OpenRouter half
+    # of the issue.
+    async def go() -> None:
+        gate = ApprovalGate(required=frozenset({"Bash"}))
+        callback = build_can_use_tool(gate)
+        result = await callback("Bash", {"command": "x"}, ToolPermissionContext())
+        assert isinstance(result, PermissionResultDeny)
+        assert result.message == _DENY_MESSAGE
+        assert result.interrupt is True
+
+    anyio.run(go)
+
+
+def test_can_use_tool_allow_is_unchanged_for_ungated_tools() -> None:
+    # negative control: interrupt=True must ride the DENY only. An allow that
+    # somehow carried a stop would kill every ungated tool call.
+    async def go() -> None:
+        gate = ApprovalGate(required=frozenset({"Bash"}))
+        callback = build_can_use_tool(gate)
+        result = await callback("Read", {"file_path": "/x"}, ToolPermissionContext())
+        assert isinstance(result, PermissionResultAllow)
+
+    anyio.run(go)
+
+
+# --- F. the headline regression: a stopped turn still finalizes as an approval ---
+
+
+def test_gated_turn_ending_in_an_error_result_finalizes_awaiting_approval() -> None:
+    # revert: _apply_approval_override flips only a DONE final -> this fails with
+    # status == classified-failure and no approval_summary, which is exactly the
+    # "denied tool call left the turn hanging with no approval record" defect.
+    # Stopping the turn is what the gate ASKED for, so the interrupt-shaped
+    # terminal result it produces must not be read as the run failing.
+    gate = ApprovalGate(required=frozenset({"Bash"}), route_by_tool={"Bash": "ops"})
+    runner, _session = _runner_over(
+        _gated_bash_then_error_result(),
+        gate=gate,
+        # interrupt=False so the scripted terminal ERROR result is actually
+        # delivered; that result is the shape under test.
+        can_use_tool=_recording_deny(gate, interrupt=False),
+        truncate_on_interrupt=False,
+    )
+
+    lines: list[str] = []
+
+    async def go() -> None:
+        await runner.start()
+        async for line in runner.run_turn(Event(type="message", text="go", user="U", ts="1")):
+            lines.append(line)
+
+    anyio.run(go)
+    events = parse_ndjson("".join(lines))
+
+    final = events[-1]
+    assert final.type == "final"
+    assert final.status == SessionStatus.AWAITING_APPROVAL
+    assert final.status != SessionStatus.CLASSIFIED_FAILURE
+    assert final.approval_summary
+    assert final.approval_summary.startswith(APPROVAL_SUMMARY_PREFIX)
+    assert final.approval_gate_kind == "permission"
+    assert final.approval_granted_tool == "Bash"
+    assert final.approval_route == "ops"
+    assert runner.status == SessionStatus.AWAITING_APPROVAL
+
+
+def test_ungated_error_result_still_ends_classified_failure() -> None:
+    # negative control for F: the halt flag must be the ONLY thing that rescues an
+    # error result. revert: flip any error final to awaiting-approval -> this fails,
+    # and every genuine crash would be parked behind a human decision forever.
+    gate = ApprovalGate(required=frozenset({"Bash"}))
+    runner, _session = _runner_over(
+        [
+            AssistantMessage(content=[TextBlock(text="working")], model="m"),
+            ResultMessage(
+                subtype="error_during_execution",
+                duration_ms=1,
+                duration_api_ms=1,
+                is_error=True,
+                num_turns=1,
+                session_id="s",
+                result="boom",
+            ),
+        ],
+        gate=gate,
+    )
+
+    lines: list[str] = []
+
+    async def go() -> None:
+        await runner.start()
+        async for line in runner.run_turn(Event(type="message", text="go", user="U", ts="1")):
+            lines.append(line)
+
+    anyio.run(go)
+    events = parse_ndjson("".join(lines))
+    assert events[-1].status == SessionStatus.CLASSIFIED_FAILURE
+    assert not events[-1].approval_summary
+
+
+
+def _gated_bash_then_model_error_result() -> list[Any]:
+    """A gated Bash call, then a REAL model failure, then the error result.
+
+    Same shape as ``_gated_bash_then_error_result`` except the provider reported
+    a failure of its own (``AssistantMessage.error``) before the turn ended --
+    which is what ``translate.py`` records on ``TurnState.error_classification``.
+    ``server_error`` is deliberately not ``authentication_failed``: the auth code
+    fast-fails earlier in ``_drive_turn`` and would never reach the override.
+    """
+
+    return [
+        AssistantMessage(content=[TextBlock(text="I'll run that")], model="m"),
+        AssistantMessage(
+            content=[ToolUseBlock(id="t1", name="Bash", input={"command": "rm -rf /tmp/x"})],
+            model="m",
+        ),
+        AssistantMessage(content=[], model="m", error="server_error"),
+        ResultMessage(
+            subtype="error_during_execution",
+            duration_ms=1,
+            duration_api_ms=1,
+            is_error=True,
+            num_turns=1,
+            session_id="s",
+            result="provider unavailable",
+        ),
+    ]
+
+
+def test_gated_turn_that_also_hit_a_model_error_ends_classified_failure() -> None:
+    # revert (the mutation this kills): drop `state.error_classification is None`
+    # from the halt branch of _apply_approval_override, i.e. flip ANY non-DONE
+    # final whenever the halt marker is set -> this fails with
+    # status == awaiting-approval.
+    #
+    # The halt marker is written by ApprovalGate.block at DENY time, before the
+    # turn's terminal cause is known, so it alone cannot distinguish "the CLI
+    # aborted because we asked it to" (test F) from "the provider fell over".
+    # Relabelling a provider outage as awaiting-approval hides a real failure
+    # behind a human decision that cannot fix it, and an approver resuming it
+    # lands straight back in the same failure.
+    gate = ApprovalGate(required=frozenset({"Bash"}), route_by_tool={"Bash": "ops"})
+    runner, _session = _runner_over(
+        _gated_bash_then_model_error_result(),
+        gate=gate,
+        can_use_tool=_recording_deny(gate, interrupt=False),
+        truncate_on_interrupt=False,
+    )
+
+    lines: list[str] = []
+
+    async def go() -> None:
+        await runner.start()
+        async for line in runner.run_turn(Event(type="message", text="go", user="U", ts="1")):
+            lines.append(line)
+
+    anyio.run(go)
+    events = parse_ndjson("".join(lines))
+
+    # Not vacuous: the gate really did fire and really did ask for the halt, so
+    # the ONLY thing keeping this out of awaiting-approval is the model error.
+    assert gate.pending_summary is not None
+    assert gate.pending_halt is True
+
+    final = events[-1]
+    assert final.type == "final"
+    assert final.status == SessionStatus.CLASSIFIED_FAILURE
+    assert final.status != SessionStatus.AWAITING_APPROVAL
+    assert not final.approval_summary
+    # And the failure is still reported as itself, not swallowed.
+    assert any(
+        e.type == "error" and e.classification == "server_error" for e in events
+    ), "the model's own error frame must survive"
+
+
+def test_a_done_gated_turn_still_flips_even_after_a_model_error_frame() -> None:
+    # negative control for the guard above: the new error_classification check
+    # must ride the HALT branch only. revert: apply it to the DONE branch too ->
+    # this fails, and a turn the model finished cleanly after a recovered
+    # (non-terminal) error would lose its approval record entirely.
+    gate = ApprovalGate(required=frozenset({"Bash"}), route_by_tool={"Bash": "ops"})
+    script = [
+        AssistantMessage(content=[], model="m", error="server_error"),
+        AssistantMessage(
+            content=[ToolUseBlock(id="t1", name="Bash", input={"command": "rm -rf /tmp/x"})],
+            model="m",
+        ),
+        ResultMessage(
+            subtype="success",
+            duration_ms=1,
+            duration_api_ms=1,
+            is_error=False,
+            num_turns=1,
+            session_id="s",
+            result="recovered and finished",
+        ),
+    ]
+    runner, _session = _runner_over(
+        script,
+        gate=gate,
+        can_use_tool=_recording_deny(gate, interrupt=False),
+        truncate_on_interrupt=False,
+    )
+
+    lines: list[str] = []
+
+    async def go() -> None:
+        await runner.start()
+        async for line in runner.run_turn(Event(type="message", text="go", user="U", ts="1")):
+            lines.append(line)
+
+    anyio.run(go)
+    events = parse_ndjson("".join(lines))
+
+    final = events[-1]
+    assert final.type == "final"
+    assert final.status == SessionStatus.AWAITING_APPROVAL
+    assert final.approval_summary
+    assert final.approval_gate_kind == "permission"
+
+
+# --- G. negative control: an operator interrupt outranks the gate ---------------
+
+
+def test_operator_interrupt_on_a_gated_turn_still_ends_idle() -> None:
+    # revert: copy the gate's halt marker onto the turn state unconditionally ->
+    # this fails. A human pressing stop is an intentional stop, not an approval
+    # request; reporting it as awaiting-approval would suspend the thread behind a
+    # decision nobody asked for and no approver would recognize.
+    gate = ApprovalGate(required=frozenset({"Bash"}))
+    runner, session = _runner_over(
+        _gated_bash_then_error_result(),
+        gate=gate,
+        can_use_tool=_recording_deny(gate, interrupt=False),
+        truncate_on_interrupt=False,
+    )
+
+    lines: list[str] = []
+
+    async def go() -> None:
+        await runner.start()
+        gen = runner.run_turn(Event(type="message", text="go", user="U", ts="1"))
+        lines.append(await gen.__anext__())  # first frame; the turn is live
+        await runner.interrupt("user stop")  # the operator's own stop
+        async for line in gen:
+            lines.append(line)
+
+    anyio.run(go)
+    events = parse_ndjson("".join(lines))
+
+    # The gate really did block this turn -- otherwise the control is vacuous.
+    assert gate.pending_summary is not None
+    assert session.interrupts >= 1
+    assert events[-1].type == "final"
+    assert events[-1].status == SessionStatus.IDLE_AWAITING_INPUT
+
+
+# --- H. negative control: a budget halt still outranks a pending approval --------
+
+
+def test_budget_halt_still_outranks_a_pending_approval() -> None:
+    # revert: evaluate the approval override before the budget halt -> this fails.
+    # A run that blew its token ceiling has not completed cleanly; suspending it
+    # behind a human decision strands a broken run, and approving it would resume
+    # straight back into the same halt.
+    gate = ApprovalGate(required=frozenset({"Bash"}))
+    script = [
+        AssistantMessage(
+            content=[ToolUseBlock(id="t1", name="Bash", input={"command": "x"})],
+            model="m",
+            usage={"output_tokens": 500},
+        ),
+        ResultMessage(
+            subtype="success",
+            duration_ms=1,
+            duration_api_ms=1,
+            is_error=False,
+            num_turns=1,
+            session_id="s",
+            result="done",
+            usage={"output_tokens": 500},
+        ),
+    ]
+    runner, _session = _runner_over(
+        script,
+        gate=gate,
+        ceiling=10,
+        can_use_tool=_recording_deny(gate, interrupt=False),
+        truncate_on_interrupt=False,
+    )
+
+    lines: list[str] = []
+
+    async def go() -> None:
+        await runner.start()
+        async for line in runner.run_turn(Event(type="message", text="go", user="U", ts="1")):
+            lines.append(line)
+
+    anyio.run(go)
+    events = parse_ndjson("".join(lines))
+
+    assert gate.pending_summary is not None  # the gate did fire this turn
+    assert events[-1].type == "final"
+    assert events[-1].status == SessionStatus.CLASSIFIED_FAILURE
+    assert "budget" in events[-1].text
+
+
+# --- I. boot merges the approval matcher WITH the bundle's own hooks -------------
+
+
+class _CapturedSession:
+    """Stands in for ClaudeAgentSession so the built options can be inspected.
+
+    The real class constructs a ClaudeSDKClient; the assertion here is about what
+    ``build_runner`` PUT in the options, so the transport is not needed.
+    """
+
+    def __init__(self, options: Any) -> None:
+        self.options = options
+
+
+def _options_from_boot(monkeypatch: pytest.MonkeyPatch, config: RunnerConfig) -> Any:
+    monkeypatch.setattr(boot, "ClaudeAgentSession", _CapturedSession)
+    runner = build_runner(config)
+    session = runner._factory()
+    assert isinstance(session, _CapturedSession)
+    return session.options
+
+
+_BUNDLE_HOOKS = {
+    "PreToolUse": [{"matcher": "Bash", "hooks": [{"type": "command", "command": "true"}]}]
+}
+
+
+def test_boot_merges_the_approval_matcher_ahead_of_bundle_hooks(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # revert: pass hooks=bundle_hooks unchanged -> the gate never runs as a hook and
+    # a skill/settings permission rule silently bypasses it (the #1852 defect).
+    # revert: pass hooks=approval_hook only -> the bundle's declared PreToolUse
+    # guardrails (#272) are silently dropped.
+    plugin_dir = _bundle(tmp_path, manifest_hooks=_BUNDLE_HOOKS)
+    config = _config(plugin_dir, CURIE_APPROVAL_REQUIRED_TOOLS="Bash")
+
+    options = _options_from_boot(monkeypatch, config)
+
+    matchers = options.hooks["PreToolUse"]
+    assert len(matchers) == 2
+    # The approval matcher is first and unscoped; the bundle's keeps its own
+    # matcher string, proving it was preserved rather than rebuilt.
+    assert matchers[0].matcher is None
+    assert matchers[1].matcher == "Bash"
+    # Defense in depth: the callback stays wired too, so an ungated tool that
+    # falls through the hook is still decided by the approval callback.
+    assert options.can_use_tool is not None
+
+
+def test_boot_wires_the_approval_matcher_when_the_bundle_declares_no_hooks(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # revert: only merge when bundle hooks exist -> the common case (a gated bundle
+    # with no hooks of its own) boots with no hook at all and stays bypassable.
+    plugin_dir = _bundle(tmp_path)
+    config = _config(plugin_dir, CURIE_APPROVAL_REQUIRED_TOOLS="Bash")
+
+    options = _options_from_boot(monkeypatch, config)
+
+    assert options.hooks is not None
+    assert [m.matcher for m in options.hooks["PreToolUse"]] == [None]
+
+
+def test_boot_adds_no_approval_matcher_when_nothing_is_gated(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # negative control: an unconfigured agent must see zero behavior change --
+    # no gate, no approval hook, and the bundle's own hooks untouched.
+    plugin_dir = _bundle(tmp_path, manifest_hooks=_BUNDLE_HOOKS)
+    config = _config(plugin_dir)
+
+    options = _options_from_boot(monkeypatch, config)
+
+    assert [m.matcher for m in options.hooks["PreToolUse"]] == ["Bash"]
+    assert options.can_use_tool is None
+
+
+# --- J. fake-tier parity: a deny with interrupt=True stops the replay ------------
+
+
+def _collect(session: FakeModelSession) -> list[Any]:
+    async def go() -> list[Any]:
+        await session.connect()
+        await session.query("go")
+        return [message async for message in session.receive_turn()]
+
+    return anyio.run(go)
+
+
+def test_fake_session_stops_replaying_after_an_interrupting_deny() -> None:
+    # revert: FakeModelSession._apply_gate ignores the PermissionResultDeny result
+    # -> the offline tier keeps replaying past a call the real SDK would have
+    # aborted, so the fake/CI/chart-default path stops modelling the gate it is
+    # supposed to prove (the tier-parity rule).
+    sentinel = "MUST-NOT-REPLAY-AFTER-INTERRUPTING-DENY"
+    gate = ApprovalGate(required=frozenset({"Bash"}))
+    script = [
+        AssistantMessage(
+            content=[ToolUseBlock(id="t1", name="Bash", input={"command": "x"})], model="m"
+        ),
+        AssistantMessage(content=[TextBlock(text=sentinel)], model="m"),
+        ResultMessage(
+            subtype="success",
+            duration_ms=1,
+            duration_api_ms=1,
+            is_error=False,
+            num_turns=1,
+            session_id="s",
+            result=sentinel,
+        ),
+    ]
+
+    session = FakeModelSession(lambda: script, can_use_tool=_recording_deny(gate, interrupt=True))
+    messages = _collect(session)
+
+    texts = [
+        block.text
+        for message in messages
+        if isinstance(message, AssistantMessage)
+        for block in message.content
+        if isinstance(block, TextBlock)
+    ]
+    assert sentinel not in texts
+    assert not any(isinstance(m, ResultMessage) for m in messages)
+    assert gate.pending_summary is not None
+
+
+def test_fake_session_keeps_replaying_after_a_non_interrupting_deny() -> None:
+    # negative control for J: only interrupt=True truncates. Without this, an
+    # implementation that truncates on ANY deny would pass J while breaking every
+    # existing gated-turn test that expects the terminal result to arrive.
+    gate = ApprovalGate(required=frozenset({"Bash"}))
+    script = [
+        AssistantMessage(
+            content=[ToolUseBlock(id="t1", name="Bash", input={"command": "x"})], model="m"
+        ),
+        ResultMessage(
+            subtype="success",
+            duration_ms=1,
+            duration_api_ms=1,
+            is_error=False,
+            num_turns=1,
+            session_id="s",
+            result="done",
+        ),
+    ]
+
+    session = FakeModelSession(lambda: script, can_use_tool=_recording_deny(gate, interrupt=False))
+    messages = _collect(session)
+
+    assert any(isinstance(m, ResultMessage) for m in messages)
+
+
+# --- K. pin the SDK's decision-key names ----------------------------------------
+#
+# Source of truth: .venv/lib/python3.14/site-packages/claude_agent_sdk/types.py
+# (SyncHookJSONOutput, PreToolUseHookSpecificOutput, PermissionResultDeny) and
+# claude_agent_sdk/_internal/query.py::_convert_hook_output_for_cli. These are
+# TypedDicts, so a rename upstream is invisible at runtime -- the hook would keep
+# returning keys the CLI ignores and the gate would silently stop gating, which is
+# the exact failure mode #1852 is about. Assert against the pinned SDK's own
+# declarations rather than a hand-copied table.
+
+
+def test_hook_output_keys_are_declared_by_the_pinned_sdk() -> None:
+    # revert: rename any emitted key (continue_ -> continue, permissionDecision ->
+    # decision, hookSpecificOutput -> hookOutput) -> this fails instead of the gate
+    # silently ceasing to enforce.
+    gate = ApprovalGate(required=frozenset({"Bash"}))
+    output = _run_hook(gate, "Bash", {"command": "x"})
+
+    top_level = set(SyncHookJSONOutput.__annotations__)
+    assert set(output) <= top_level, f"undeclared top-level key(s): {set(output) - top_level}"
+    assert {"continue_", "stopReason", "hookSpecificOutput"} <= set(output)
+
+    specific = set(PreToolUseHookSpecificOutput.__annotations__)
+    decision = _decision(output)
+    assert set(decision) <= specific, f"undeclared decision key(s): {set(decision) - specific}"
+    assert {"hookEventName", "permissionDecision", "permissionDecisionReason"} <= set(decision)
+
+
+def test_the_decision_values_are_declared_by_the_pinned_sdk() -> None:
+    # revert: emit "block"/"reject" instead of "deny", or "PreToolUseHook" as the
+    # event name -> the CLI silently ignores an unrecognized value and the call
+    # proceeds.
+    annotation = PreToolUseHookSpecificOutput.__annotations__["permissionDecision"]
+    literal = typing.get_args(annotation)[0]  # unwrap NotRequired[...]
+    allowed = set(typing.get_args(literal))
+    assert {"allow", "deny"} <= allowed
+
+    gate = ApprovalGate(required=frozenset({"Bash"}))
+    denied = _decision(_run_hook(gate, "Bash", {"command": "x"}))
+    assert denied["permissionDecision"] in allowed
+
+    granted = ApprovalGate(required=frozenset({"Bash"}), grant_tool="Bash")
+    allowed_out = _decision(_run_hook(granted, "Bash", {"command": "x"}))
+    assert allowed_out["permissionDecision"] in allowed
+
+    event_literal = typing.get_args(PreToolUseHookSpecificOutput.__annotations__["hookEventName"])
+    assert denied["hookEventName"] in set(event_literal)
+
+
+def test_permission_result_deny_still_carries_an_interrupt_field() -> None:
+    # revert / upstream drift: if the SDK drops or renames `interrupt`, the deny in
+    # build_can_use_tool stops stopping the turn and the run hangs again. Fail here
+    # rather than in production.
+    fields = {f.name for f in dataclasses.fields(PermissionResultDeny)}
+    assert {"message", "interrupt"} <= fields
+    assert PermissionResultDeny().interrupt is False  # the default we must override


### PR DESCRIPTION
Closes #1852.

## What was broken

Both halves of the issue are one root cause. Curie enforced approval-required tools through `ClaudeAgentOptions.can_use_tool`. The pinned `claude-agent-sdk` documents on that very field that the callback is *not* invoked for a tool already permitted by `allowed_tools`, `permission_mode`, or a `permissions.allow` rule in settings — and names the remedy: "To observe or gate *every* tool call regardless of permission rules, use a `PreToolUse` hook via `hooks` instead." A skill's `allowed-tools: [Bash]` frontmatter becomes exactly such a rule.

#1875 made that *configuration* fail closed at boot. It did not make the *mechanism* unshadowable, and it did not touch the hang.

I probed the pinned SDK against a real OpenRouter model before writing any code:

| Options | `can_use_tool` invoked | Bash executed |
|---|---|---|
| `allowed_tools=["Bash"]`, no hook | **no** | **yes** |
| `allowed_tools=["Bash"]`, PreToolUse hook denies | no | **no** |
| `allowed_tools=["Bash"]`, PreToolUse hook allows | no | yes |
| `allowed_tools=[]`, `setting_sources=[]`, no hook | **no** | **yes** |

The last row is the one that matters: on this path the callback was never consulted *at all*, which is why removing `allowed-tools` produced no usable workaround and why prose in the deny message could never be the stopping mechanism.

## The change

- **Enforcement moves into a `PreToolUse` hook** (`matcher=None`, every tool), merged alongside any the bundle declares (#272) rather than replacing them. An ungated tool returns no decision and falls through to the existing callback, so an unconfigured agent sees zero behaviour change.
- **A one-shot post-approval grant returns an explicit `allow`.** This is the subtle one: an empty return would let `can_use_tool` run and re-block the very call a human just approved — the #430 regression. The SDK's "an allow decision also skips this callback" is what makes the grant work exactly once.
- **A gated call is denied with the SDK's turn-stopping fields**, and `can_use_tool`'s deny now carries `PermissionResultDeny(interrupt=True)`. Both paths go through one shared decision helper, so the gate rule cannot change on one path and not the other.
- **The approval halt outranks an abort-shaped result**, so the record is not lost — but a classified model or transport error still wins, so a provider outage is never relabelled as something a human can approve away.

`setting_sources` is deliberately **not** changed: the hook closes that surface too, without stopping CLAUDE.md and legitimate project settings from loading. Nothing under `packages/aci-protocol` or `packages/plugin-format` is touched — no wire or plugin-format change was needed.

## Runtime evidence

A disposable release on a scratch cluster, real OpenRouter model, gate armed through **both** the bundle manifest `approvalPolicy` *and* an operator `--gate` added after deployment. Only the runner image differs between the two columns.

**Negative control — runner built from `main`:**

```
waiting for worker reply: ok (9.0s)
approval-clean: no pending approvals
```
```
runner log: tool call ... tool=Bash
runner log: turn end ... status=done
```
The gate reported itself armed, the tool ran, no record was created.

The shadow bundle (`allowed-tools: Bash` present) instead hit #1875's boot refusal and produced the issue's other symptom — `waiting for worker reply: failed (timed out after 120s)`, no record. Actionable in the pod log, invisible at the operator surface; see follow-ups.

**Positive — same bundle, same gates, fixed runner:**

```
waiting for worker reply: ok (14.6s)
resolve it with: curie cluster approvals <AGENT> --resolve <id> --as <user> ...
```
```
<id>  Tool call awaiting approval: Bash {"command": "printf 'CURIE_APPROVAL_OK<newline>'", ...} [tool: Bash, route: ops]
```
The turn finalised awaiting-approval, the durable record names the exact blocked command and the manifest route, and the command did not run.

**One-shot grant and re-arm** — a fresh thread *after* a completed approval cycle was gated again, then approved:

```
approval <id> -> approved (by U-operator)
3. *Execution*: The approved command ran successfully and output `CURIE_APPROVAL_OK`
```

One execution, then the gate re-armed. The cluster release and its namespace were uninstalled and deleted afterwards; `helm list` and `kubectl get namespace` both confirm absence.

## Tests

22 new tests in `runner/tests/test_approval_gate_enforcement.py`, written and committed red before the implementation, covering the realistic plugin-bundle path (a real bundle with `approvalPolicy` plus a `SKILL.md`), the operator-gate-after-deployment case, the hook decision for gated/ungated/granted, the halt precedence, and the fake-tier parity. Each names the mutation it kills, and the set was validated against a mutation matrix — every mutation killed exactly its intended tests and nothing else. The hook's decision keys are pinned against the SDK's own `SyncHookJSONOutput` / `HookSpecificOutput` types so an upstream rename fails a test rather than silently ceasing to gate.

`runner` 607 passed / 4 skipped; `ruff`, `mypy`, `lint-imports`, `check-docs`, and the commit-message gate all clean.

## Review

Cross-engine adversarial review raised three findings:

1. **A bundle `PreToolUse` deny can consume the grant without the call executing.** Accepted, not fixed — a bundle's own guardrail vetoing an approved call is deliberate defence in depth, and failing toward "did not run, needs re-approval" is the safe direction. The SDK gives a callback no way to see a concurrently-dispatched hook's outcome. Made observable with a WARNING and documented in place.
2. **The halt marker could relabel an unrelated failure as awaiting-approval.** Fixed, with tests.
3. **A preceding policy request can outrank the permission block's provenance.** Pre-existing on `main` (`_merge_gate_block`'s precedence is unchanged by this PR); filed below rather than fixed here.

## Follow-ups worth filing

- A runner that refuses to boot is only actionable in pod logs; `cluster message` just times out. The fail-closed behaviour is right, the operator surface is not.
- Finding 3 above: policy-gate provenance outranking a later permission block.
- The chart's `runner-prewarm` pod hardcodes `imagePullPolicy: Always`, so it `ImagePullBackOff`s against a locally-imported image even when the sandbox template correctly uses `Never`. Harmless here (warm-pool replicas default to 0) but it makes every offline cluster e2e show a red pod.

<!-- evidence captured on a disposable scratch release; the release and its namespace were removed afterwards -->