### PR TITLE
Refuse a connector object name that forges the `-mcp-` join (#1446)

### DIFF
--- a/apps/api/src/curie_api/routers/agents.py
+++ b/apps/api/src/curie_api/routers/agents.py
@@ -6,6 +6,7 @@ import uuid
 from pathlib import Path
 
 from fastapi import APIRouter, Depends, HTTPException, status
+from plugin_format.connector_render import AmbiguousObjectName
 from sqlalchemy.exc import IntegrityError
 from starlette.concurrency import run_in_threadpool
 
@@ -313,7 +314,36 @@ async def read_version_connectors(
                 owned_secret_keys=bundles.owned_secret_keys(declared),
             )
 
-    return await run_in_threadpool(_render)
+    # `object_name` fails closed on an agent name that forges its `-mcp-` join
+    # (#1446), and that raise surfaces HERE: every derivation the renderer
+    # touches goes through it. The create path refuses such a name now, so the
+    # only rows still holding one predate that validator -- which is exactly the
+    # case this read-only endpoint has to survive.
+    #
+    # 422 rather than letting it fall through as a 500. The request is
+    # well-formed -- real ids, a stored bundle, valid install-time params -- and
+    # nothing about it can be corrected; what cannot be satisfied is the STORED
+    # agent name. A 500 tells an operator running `cluster deploy` only that the
+    # server broke, with no name in the body and nothing to act on, and the name
+    # is not necessarily one they are holding: the bundle's deploy.yaml chose
+    # which agent this renders for.
+    #
+    # "Recreate", not "rename": `AgentUpdate` carries no `name` field, so there
+    # is no in-place rename to point them at. Saying "rename" would send them
+    # looking for an API that does not exist.
+    try:
+        return await run_in_threadpool(_render)
+    except AmbiguousObjectName as exc:
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            f"the stored name of agent {agent_name!r} cannot produce an "
+            f"unambiguous connector object name ({exc}). Connector objects are named "
+            "'{release}-{agent}-mcp-{connector}', so this name makes two "
+            "different agents render the same Kubernetes objects and share one "
+            "connector's credential (#1446). Recreate the agent under a name "
+            "that neither contains '-mcp-' nor ends in '-mcp'; an agent's name "
+            "cannot be changed in place.",
+        ) from exc
 
 
 @router.get("/{agent_id}/versions/{version_id}/files", response_model=BundleFiles)

--- a/apps/api/src/curie_api/schemas.py
+++ b/apps/api/src/curie_api/schemas.py
@@ -17,6 +17,7 @@ from aci_protocol import ApprovalRequest as ApprovalRequest
 from aci_protocol import EvalReport as EvalReport
 from fastapi import HTTPException
 from plugin_format import is_reserved_boot_env_name
+from plugin_format.connector_render import agent_forges_join
 from pydantic import (
     BaseModel,
     ConfigDict,
@@ -433,6 +434,59 @@ def _validate_secret_map(value: dict[str, str] | None) -> dict[str, str] | None:
     return value
 
 
+def _validate_agent_name(value: str) -> str:
+    """Reject an agent name that would forge the connector object-name join.
+
+    A connector's Kubernetes objects are named
+    ``{release}-{agent}-mcp-{connector}``
+    (``plugin_format.connector_render.object_name``). The ``-mcp-`` is a bare
+    substring inside one DNS label rather than a structural separator, so the
+    join point is not recoverable from the rendered string: agent ``a-mcp-b``
+    with connector ``c`` and agent ``a`` with connector ``b-mcp-c`` render
+    byte-identical objects AND the identical ``app.kubernetes.io/name`` pod
+    selector. The connector is deliberately unauthenticated (ADR-0086 -- the
+    sandbox holds no credential to authenticate WITH, so the network is the
+    whole of the access control), which makes that name the only thing binding
+    a sandbox to a credential: one agent's sandbox reaches another agent's
+    connector holding another agent's production token, and nothing errors
+    anywhere (#1446).
+
+    ``connectors.yaml`` names and ``deploy.yaml``'s ``target.agent`` are both
+    gated by bundle validation. ``POST /agents`` is the hole -- the stored
+    ``Agent.name`` reaches the renderer with no field validator in between --
+    and it is the path the CLI's ``resolve_agent`` and the UI's create modal
+    both take. Refusing on write keeps the forging name out of the database
+    entirely; the render-time 422 in ``routers/agents.py`` only covers rows
+    created before this validator existed.
+
+    Deliberately ONLY the delimiter-forging shape. ``AgentCreate.name`` accepts
+    spaces, uppercase, and 200-character names today; that is a real but
+    SEPARATE pre-existing gap, and tightening it here would refuse names live
+    installs already hold. Do not "helpfully" widen this into general
+    name-shape validation -- that is its own change, with its own migration
+    story.
+
+    The rule itself is imported, never restated: ``agent_forges_join`` asks
+    whether ``-mcp-`` appears in ``f"{name}-"``, which catches a TRAILING
+    ``-mcp`` (the join supplies the dash that completes it) as surely as an
+    outright ``-mcp-``, while leaving a LEADING ``mcp-`` alone -- its only
+    alternative split leaves an empty agent, so nothing is ambiguous. A second
+    copy of that asymmetry here would be free to drift from the renderer it
+    exists to protect.
+    """
+
+    if agent_forges_join(value):
+        raise ValueError(
+            f"agent name {value!r} collides with the connector object-name "
+            "delimiter '-mcp-': a connector's Kubernetes objects are named "
+            "'{release}-{agent}-mcp-{connector}', so a name that contains "
+            "'-mcp-' or ends in '-mcp' makes two different agents render the "
+            "same objects and share one connector's credential (#1446). Pick a "
+            "name that neither contains '-mcp-' nor ends in '-mcp'."
+        )
+    return value
+
+
 class _StoredWithoutNulls(BaseModel):
     """Serializes to the stored-JSONB shape: unset keys are absent, not null.
 
@@ -750,6 +804,7 @@ class AgentCreate(BaseModel):
     # sandbox by the worker binding. None means no connector secrets.
     secrets: dict[str, str] | None = None
 
+    _check_name = field_validator("name")(_validate_agent_name)
     _check_model = field_validator("model")(_validate_model_override)
     _check_thinking = field_validator("thinking")(_validate_thinking_override)
     _check_approval_tools = field_validator("approval_required_tools")(_validate_tool_names)

--- a/apps/api/tests/test_agents.py
+++ b/apps/api/tests/test_agents.py
@@ -1183,3 +1183,80 @@ def test_agent_legitimate_secret_name_still_creates(
     )
     assert ok.status_code == 201, ok.text
     assert ok.json()["secrets"] == ["GITHUB_PERSONAL_ACCESS_TOKEN"]
+
+
+# --- an agent name that forges the connector object-name join -- #1446 -------
+#
+# A connector's Kubernetes objects are named `{release}-{agent}-mcp-{connector}`
+# (`plugin_format.connector_render.object_name`). The `-mcp-` is a bare
+# substring inside one DNS label, not a structural separator, so the join point
+# is not recoverable from the rendered string: `agent='a-mcp-b'/connector='c'`
+# and `agent='a'/connector='b-mcp-c'` render the SAME Service, Deployment, both
+# NetworkPolicies, and -- worse -- the same `app.kubernetes.io/name` pod
+# selector. The connector is deliberately unauthenticated (ADR-0086: "the
+# network is not one layer of the access control here, it is the whole of it"),
+# so the object name is the ONLY thing binding a sandbox to a credential. One
+# agent's sandbox then reaches another agent's connector holding another
+# agent's production token, and nothing errors anywhere.
+#
+# `connectors.yaml` names and `deploy.yaml`'s `target.agent` are both gated by
+# bundle validation. `POST /agents` is the hole: `AgentCreate.name` reaches
+# `render_connector_manifests` (routers/agents.py, via the stored `Agent.name`)
+# with no field validator between, and this is the path the CLI's
+# `resolve_agent` and the UI's create modal both take. These tests close it at
+# the write seam, so the forging name can never enter the database at all.
+#
+# Deliberately NOT asserted here: general name shape (spaces, uppercase, length).
+# `AgentCreate.name` accepts those today and that is a separate, pre-existing
+# gap -- pinning it here would make this fence look like something it is not.
+_FORGING_AGENT_NAMES = [
+    # The pair from the issue: contains the join outright.
+    "a-mcp-b",
+    # The one a naive `'-mcp-' in name` ban MISSES: `'-mcp-' in 'x-mcp'` is
+    # False, yet `x-mcp` + connector `c` and `x` + connector `mcp-c` both render
+    # `<release>-x-mcp-mcp-c`. The trailing dash of the join is supplied by the
+    # join itself, so ending in `-mcp` forges it just as surely.
+    "x-mcp",
+    # The realistic one an operator actually types, and the reason the error
+    # message has to be actionable: `grafana-mcp` is a natural agent name.
+    "grafana-mcp",
+]
+
+
+@pytest.mark.parametrize("name", _FORGING_AGENT_NAMES)
+def test_agent_name_forging_the_connector_join_is_422(
+    client: Any, auth_headers: dict[str, str], clean_db: None, name: str
+) -> None:
+    bad = _create(client, auth_headers, name=name, channel=_slack("C0EXAMPLE1"))
+    assert bad.status_code == 422, bad.text
+    # The body must name the FIELD, or an operator staring at a 422 from a
+    # create call carrying a channel, a repo and a secrets map has no way to
+    # know which of them was refused.
+    assert any("name" in err["loc"] for err in bad.json()["detail"]), bad.text
+    # ...and the REASON, in the operator's own vocabulary. A bare "invalid
+    # name" sends them hunting for a character they typed wrong; the mechanism
+    # is that the name collides with the connector object-name delimiter, and
+    # the only fix is to rename the agent.
+    assert "-mcp-" in bad.text, bad.text
+
+
+_SAFE_AGENT_NAMES = [
+    # The shipped fixture names, which must keep working.
+    "acme-dev",
+    # LEADING `mcp-` on the agent side is fine and must stay fine: the only
+    # alternative split of `<release>-mcp-x-mcp-<connector>` leaves an empty
+    # agent, so nothing is ambiguous. A rule that over-rejects here would break
+    # live installs for no security gain, which is why the negative corpus is
+    # asserted and not assumed.
+    "mcp-x",
+    "mcp",
+]
+
+
+@pytest.mark.parametrize("name", _SAFE_AGENT_NAMES)
+def test_an_agent_name_that_only_looks_like_the_join_still_creates(
+    client: Any, auth_headers: dict[str, str], clean_db: None, name: str
+) -> None:
+    ok = _create(client, auth_headers, name=name, channel=_slack("C0EXAMPLE2"))
+    assert ok.status_code == 201, ok.text
+    assert ok.json()["name"] == name

--- a/apps/api/tests/test_bundle_connectors.py
+++ b/apps/api/tests/test_bundle_connectors.py
@@ -9,11 +9,18 @@ CLI, under the operator's own kubectl credentials.
 
 from __future__ import annotations
 
+import asyncio
+import io
 import json
+import tarfile
 from pathlib import Path
+from typing import Any
 
 import pytest
 from curie_api import bundles
+from curie_api.config import get_settings
+from curie_api.models import Agent, AgentChannel
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 
 def _bundle(root: Path, connectors_yaml: str | None = None) -> Path:
@@ -270,3 +277,154 @@ def test_a_referenced_secret_points_outside_curies_own_secret(tmp_path: Path) ->
     ref = next(e for e in env if e["name"] == "GRAFANA_TOKEN")["valueFrom"]["secretKeyRef"]
     assert ref["name"] == "grafana-mcp"
     assert "value" not in next(e for e in env if e["name"] == "GRAFANA_TOKEN")
+
+
+# --------------------------------------------------------------------------- #
+# A stored agent name that forges the object-name join -- #1446
+#
+# `object_name` builds `{release}-{agent}-mcp-{connector}`, and the `-mcp-` is a
+# bare substring of one DNS label rather than a structural separator. So
+# `agent='a-mcp-b'/connector='c'` and `agent='a'/connector='b-mcp-c'` render
+# byte-identical objects AND the identical `app.kubernetes.io/name` pod
+# selector. Because the connector is deliberately unauthenticated (ADR-0086 --
+# the sandbox holds no credential to authenticate WITH, so the network is the
+# whole of the access control), that name is the only thing binding a sandbox
+# to a credential: one agent's sandbox reaches another agent's connector
+# holding another agent's production token, silently.
+#
+# Once the renderer fails closed on such a name, THIS endpoint is where the
+# refusal surfaces, because `read_version_connectors` reads the stored
+# `Agent.name` straight into `render_connector_manifests` inside a
+# `run_in_threadpool` with no `except` around it. Unhandled, that is a 500: an
+# opaque server error on a read-only endpoint the CLI calls during every
+# `cluster deploy`, with nothing in the response saying which name is at fault
+# or that renaming the agent is the fix. A 422 naming the agent is what makes
+# it diagnosable without reading source or pulling API logs.
+#
+# The row is written straight through the ORM rather than through `POST
+# /agents`, deliberately: the create path now refuses this name, so the only
+# way an install still has one is a row created before that validator existed.
+# That is the case this endpoint has to survive, and it is not reachable
+# through the API by construction.
+# --------------------------------------------------------------------------- #
+
+ENDPOINT_RELEASE = "curie"
+ENDPOINT_NAMESPACE = "curie-prod"
+ENDPOINT_APP_NAME = "curie"
+
+
+def _archive(connectors_yaml: str) -> bytes:
+    """The smallest bundle that validates AND declares a hosted connector.
+
+    A bundle declaring no connector renders an empty list without ever reaching
+    `object_name`, so the connector is what makes this test bite at all.
+    """
+
+    files = {
+        ".claude-plugin/plugin.json": json.dumps(
+            {"name": "acme-bot", "version": "0.1.0", "description": "t"}
+        ),
+        "skills/acme-bot/SKILL.md": "---\nname: acme-bot\ndescription: t\n---\nhi\n",
+        "connectors.yaml": connectors_yaml,
+    }
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        for rel, content in files.items():
+            data = content.encode("utf-8")
+            info = tarfile.TarInfo(f"acme-bot/{rel}")
+            info.size = len(data)
+            tf.addfile(info, io.BytesIO(data))
+    return buf.getvalue()
+
+
+def _agent_row(name: str) -> str:
+    """Insert the agent row directly, the way a pre-validator install holds one.
+
+    Mirrors `crud.create_agent`'s shape (the agent and its binding in one
+    transaction) but goes around `AgentCreate`, because the write-seam validator
+    is precisely what this row is meant to predate. Fresh engine per call, the
+    pattern `test_crud.py` and `test_evals_trigger_integration.py` use to keep
+    the query off the TestClient's portal loop.
+    """
+
+    async def run() -> str:
+        engine = create_async_engine(get_settings().database_url)
+        sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
+        try:
+            async with sessionmaker() as session:
+                agent = Agent(
+                    name=name,
+                    channel=AgentChannel(kind="slack", address="C0EXAMPLE4"),
+                )
+                session.add(agent)
+                await session.commit()
+                return str(agent.id)
+        finally:
+            await engine.dispose()
+
+    return asyncio.run(run())
+
+
+def _version_with_bundle(client: Any, headers: dict[str, str], agent_id: str) -> str:
+    version = client.post(
+        f"/agents/{agent_id}/versions",
+        json={"version_label": "v1", "created_by": "test"},
+        headers=headers,
+    )
+    assert version.status_code == 201, version.text
+    version_id = version.json()["id"]
+    stored = client.put(
+        f"/agents/{agent_id}/versions/{version_id}/bundle",
+        files={"file": ("b.tar.gz", _archive(HOSTED))},
+        headers=headers,
+    )
+    assert stored.status_code == 201, stored.text
+    return str(version_id)
+
+
+def _read_connectors(client: Any, headers: dict[str, str], agent_id: str, version_id: str) -> Any:
+    return client.get(
+        f"/agents/{agent_id}/versions/{version_id}/connectors",
+        params={
+            "release": ENDPOINT_RELEASE,
+            "namespace": ENDPOINT_NAMESPACE,
+            "app_name": ENDPOINT_APP_NAME,
+        },
+        headers=headers,
+    )
+
+
+def test_a_stored_forging_agent_name_is_a_422_not_a_500(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    agent_id = _agent_row("a-mcp-b")
+    version_id = _version_with_bundle(client, auth_headers, agent_id)
+
+    resp = _read_connectors(client, auth_headers, agent_id, version_id)
+    assert resp.status_code == 422, resp.text
+    # Naming the agent is the whole point: `cluster deploy` renders manifests
+    # for whichever agent the bundle's deploy.yaml selected, so an operator
+    # reading this response is not necessarily holding the name that caused it.
+    assert "a-mcp-b" in resp.text, resp.text
+
+
+def test_the_same_bundle_still_renders_for_an_unambiguous_agent(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    # The control, and it is not optional: without it the 422 test above passes
+    # just as happily if the endpoint, the bundle fixture, or the upload broke
+    # for some reason having nothing to do with #1446. Same bundle, same
+    # release, same namespace -- only the agent name differs.
+    agent_id = _agent_row("acme-dev")
+    version_id = _version_with_bundle(client, auth_headers, agent_id)
+
+    resp = _read_connectors(client, auth_headers, agent_id, version_id)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    name = f"{ENDPOINT_RELEASE}-acme-dev-mcp-grafana"
+    assert {o["metadata"]["name"] for o in body["manifests"]} == {
+        name,
+        f"{name}-allow",
+        f"{name}-allow-ingress",
+    }
+    assert name in body["mcp_entries"]["grafana"]["url"]

--- a/docs/interfaces/bundle-format/INTERFACE.md
+++ b/docs/interfaces/bundle-format/INTERFACE.md
@@ -66,7 +66,9 @@ files**, both optional, both invisible to Claude Code:
   value. Validated by `packages/plugin-format/src/plugin_format/validate.py::_validate_connectors`,
   which emits `connectors.*` codes (`connectors.not_object`, `connectors.ambiguous`,
   `connectors.underspecified`, `connectors.reserved_name`, `connectors.duplicate_connector`,
-  `connectors.duplicate_server`, and others). Authored mapping keys are checked for
+  `connectors.duplicate_server`, `connectors.ambiguous_name` (a connector name that forges the
+  `-mcp-` join used to render the connector's object name, so two different (agent, connector)
+  pairs would render byte-identical objects), and others). Authored mapping keys are checked for
   duplicates before validation, so a repeated connector name is rejected rather than
   silently replaced by the last YAML value.
 - `deploy.yaml` (ADR-0089, `packages/plugin-format/src/plugin_format/deploy_targets.py::DeployTargetsFile`)
@@ -76,7 +78,10 @@ files**, both optional, both invisible to Claude Code:
   `packages/plugin-format/src/plugin_format/validate.py::_validate_deploy_targets`, which emits
   `deploy.*` codes (`deploy.not_object`, `deploy.duplicate_target`, `deploy.bad_target_name`,
   `deploy.bad_env`, `deploy.missing_agent` (a declared target must name its agent; the error names
-  the target key), `deploy.bad_agent_name`, `deploy.bad_slack_channel`). Authored mapping keys are
+  the target key), `deploy.bad_agent_name`, `deploy.ambiguous_agent_name` (the agent, not the
+  connector, must not END in `-mcp`, since the agent sits immediately left of the `-mcp-` join —
+  same collision as `connectors.ambiguous_name`, viewed from the other side of the join),
+  `deploy.bad_slack_channel`). Authored mapping keys are
   checked for duplicates before validation, so a repeated target name fails closed instead of
   silently selecting the last YAML value.
 

--- a/docs/interfaces/bundle-format/INTERFACE.md
+++ b/docs/interfaces/bundle-format/INTERFACE.md
@@ -66,9 +66,12 @@ files**, both optional, both invisible to Claude Code:
   value. Validated by `packages/plugin-format/src/plugin_format/validate.py::_validate_connectors`,
   which emits `connectors.*` codes (`connectors.not_object`, `connectors.ambiguous`,
   `connectors.underspecified`, `connectors.reserved_name`, `connectors.duplicate_connector`,
-  `connectors.duplicate_server`, `connectors.ambiguous_name` (a connector name that forges the
-  `-mcp-` join used to render the connector's object name, so two different (agent, connector)
-  pairs would render byte-identical objects), and others). Authored mapping keys are checked for
+  `connectors.duplicate_server`, `connectors.ambiguous_name` (a connector name that contains
+  `-mcp-` or STARTS with `mcp-`, forging the `-mcp-` join used to render the connector's object
+  name, so two different (agent, connector) pairs would render byte-identical objects — checked
+  only for a hosted connector, one declaring `image:`; a remote connector, declaring `url:`,
+  derives no Kubernetes object name, since `render()` emits no objects for it and its `.mcp.json`
+  entry is the authored URL, so its name is not checked), and others). Authored mapping keys are checked for
   duplicates before validation, so a repeated connector name is rejected rather than
   silently replaced by the last YAML value.
 - `deploy.yaml` (ADR-0089, `packages/plugin-format/src/plugin_format/deploy_targets.py::DeployTargetsFile`)
@@ -79,8 +82,9 @@ files**, both optional, both invisible to Claude Code:
   `deploy.*` codes (`deploy.not_object`, `deploy.duplicate_target`, `deploy.bad_target_name`,
   `deploy.bad_env`, `deploy.missing_agent` (a declared target must name its agent; the error names
   the target key), `deploy.bad_agent_name`, `deploy.ambiguous_agent_name` (the agent, not the
-  connector, must not END in `-mcp`, since the agent sits immediately left of the `-mcp-` join —
-  same collision as `connectors.ambiguous_name`, viewed from the other side of the join),
+  connector, must not contain `-mcp-` or END in `-mcp`, since the agent sits immediately left of
+  the `-mcp-` join — same collision as `connectors.ambiguous_name`, viewed from the other side of
+  the join),
   `deploy.bad_slack_channel`). Authored mapping keys are
   checked for duplicates before validation, so a repeated target name fails closed instead of
   silently selecting the last YAML value.

--- a/packages/plugin-format/src/plugin_format/connector_render.py
+++ b/packages/plugin-format/src/plugin_format/connector_render.py
@@ -44,6 +44,86 @@ from .connectors import ConnectorSpec
 _DNS_LABEL_MAX = 63
 _DIGEST_LEN = 8
 
+# The literal that joins the agent to the connector in `object_name` (#1116).
+# It is a bare substring INSIDE one DNS label, not a structural separator: the
+# rendered name has no field boundary, so the join point cannot be recovered
+# from the result. `curie-a-mcp-b-mcp-c` reads equally well as
+# (agent=`a-mcp-b`, connector=`c`) and (agent=`a`, connector=`b-mcp-c`), and
+# both render byte-identical objects. Defined once so the rule below and the
+# concatenation it guards cannot drift apart -- a second copy of this literal
+# is how the guard silently stops matching what is actually rendered (#1446).
+_JOIN = "-mcp-"
+
+
+class AmbiguousObjectName(ValueError):
+    """A name would make the rendered object name ambiguous (#1446).
+
+    A named subclass rather than a bare ``ValueError`` on purpose. The two
+    consumers that contain this failure -- the API's connector-manifest render
+    and the runner's ``.mcp.json`` derivation -- have to catch exactly this
+    condition and nothing else. Catching bare ``ValueError`` there would also
+    swallow ordinary programming errors and degrade them into "mounted no
+    connectors", which is the same silent, unlogged wrong-credential outcome
+    this exception exists to prevent.
+    """
+
+
+def agent_forges_join(agent: str) -> bool:
+    """Whether this agent name would forge a second ``-mcp-`` in the object name.
+
+    The rule is NOT "the name contains ``-mcp-``", which is the fix the issue
+    itself proposed and which does not close the hole: agent ``x-mcp`` with
+    connector ``c`` and agent ``x`` with connector ``mcp-c`` both render
+    ``curie-x-mcp-mcp-c``, while neither ``x-mcp`` nor ``mcp-c`` contains the
+    delimiter as a substring at all. The property that matters is whether
+    the name FORGES a second occurrence of the delimiter once the concatenation
+    happens, so each side is tested against the half of the delimiter it abuts.
+
+    The agent is immediately FOLLOWED by the join, so appending the join's
+    leading dash is exactly what it will sit against. A trailing ``-mcp`` is
+    therefore fatal here (``grafana-mcp`` + ``-mcp-c...`` completes a second
+    join) while a LEADING ``mcp-`` is harmless (an alternative split of
+    ``curie-mcp-x-mcp-c`` would leave an EMPTY agent, which no bundle can
+    declare). That is the mirror image of ``connector_forges_join`` below, and
+    the asymmetry reads like a bug until the derivation is done -- a symmetric
+    rule would be wrong in both directions, over-refusing agent ``mcp-x`` and
+    connector ``c-mcp`` and breaking working installs for no security gain.
+
+    The RELEASE is deliberately not guarded by any equivalent predicate. A
+    ``-mcp-`` on the release side cannot create an (agent, connector)
+    ambiguity: every alternative split of ``grafana-mcp-acme-mcp-grafana``
+    either leaves an empty agent or stops preserving the release prefix. The
+    obvious-looking whole-string guard, ``base.count(_JOIN) == 1``, would refuse
+    every deploy of a release literally named ``grafana-mcp``.
+
+    The rule is SOUND, not exact. It never MISSES a collision -- that is the
+    security property -- but under the validators' 40-character name cap it can
+    refuse a name whose only alternative split would need a partner longer than
+    the cap, i.e. a name for which no valid colliding partner exists. Refusing
+    loudly at validation time is the correct direction of error for a name that
+    is the sole binding between a sandbox and a credential.
+    """
+
+    return _JOIN in f"{agent}-"
+
+
+def connector_forges_join(connector: str) -> bool:
+    """Whether this connector name would forge a second ``-mcp-`` in the object name.
+
+    The mirror of ``agent_forges_join``: the connector is PRECEDED by the join,
+    so prepending the join's trailing dash is what it will sit against. A
+    LEADING ``mcp-`` is fatal here, while a trailing ``-mcp`` is harmless --
+    nothing follows the connector, so ``c-mcp`` has nothing to complete a second
+    join with. ``kubernetes``, ``netpol-probe`` and ``grafana-mcp`` therefore
+    stay renderable, which matters because the first two are the connector names
+    this repo's own example bundles ship.
+
+    See ``agent_forges_join`` for why the release is not guarded and why the
+    rule is sound rather than exact.
+    """
+
+    return _JOIN in f"-{connector}"
+
 
 def sandbox_selector(release: str, app_name: str) -> dict[str, str]:
     """The pods Rail 1's default-deny egress selects, exactly.
@@ -82,9 +162,51 @@ def object_name(release: str, agent: str, connector: str) -> str:
     It also makes pruning safe. Objects are pruned by an owner label; with
     colliding names, ownership silently transfers to whoever deployed last, and
     one agent removing a connector deletes another agent's running server.
+
+    Fails closed on a name that forges a second ``-mcp-`` (#1446). #1116 made
+    names distinct per (release, agent, connector) but the join it introduced is
+    a bare substring, so two DIFFERENT tuples could still render one Service,
+    one Deployment, both NetworkPolicies and -- worst -- one
+    ``app.kubernetes.io/name``, which IS the pod selector. The connector is
+    deliberately unauthenticated (ADR-0086: the network is not one layer of the
+    access control, it is the whole of it), so this name is the only thing
+    binding a sandbox to a credential and a collision hands one agent another
+    agent's production token with nothing logged.
+
+    Raising, rather than quietly deriving some other unique name, is what keeps
+    the other half of this function's contract intact. "Stable and derivable"
+    means every name that renders today renders byte-identically tomorrow; a
+    disambiguating rename would orphan every live Service, Deployment and
+    NetworkPolicy under a name nothing reconciles any more -- still running,
+    still holding its credential -- while a fresh set came up beside it.
     """
 
-    base = f"{release}-{agent}-mcp-{connector}"
+    # BEFORE `base` is built, and before the length check below, deliberately.
+    # The truncate-with-digest branch looks like it would disambiguate these and
+    # cannot: the digest is taken over `base`, and a forging pair produces the
+    # SAME `base` from both tuples, hence the same sha256 and the same
+    # truncation. It reproduces the collision byte for byte rather than breaking
+    # it. The agent is checked FIRST so a name offending on both sides reports
+    # the agent deterministically, instead of an incidentally ordered message.
+    if agent_forges_join(agent):
+        raise AmbiguousObjectName(
+            f"agent `{agent}` would forge a second `{_JOIN}` in the connector object "
+            f"name `<release>-<agent>{_JOIN}<connector>`, so a different "
+            "agent/connector pair would render the same Service, Deployment, both "
+            "NetworkPolicies and the same `app.kubernetes.io/name` pod selector -- "
+            "one agent's sandbox would reach the other's connector and the credential "
+            "bound to it (ADR-0086). Rename the agent."
+        )
+    if connector_forges_join(connector):
+        raise AmbiguousObjectName(
+            f"connector `{connector}` would forge a second `{_JOIN}` in the connector "
+            f"object name `<release>-<agent>{_JOIN}<connector>`, so a different "
+            "agent/connector pair would render the same Service, Deployment, both "
+            "NetworkPolicies and the same `app.kubernetes.io/name` pod selector -- "
+            "one agent's sandbox would reach the other's connector and the credential "
+            "bound to it (ADR-0086). Rename the connector."
+        )
+    base = f"{release}-{agent}{_JOIN}{connector}"
     if len(base) <= _DNS_LABEL_MAX:
         return base
     # Truncate WITH a digest of the full name: clipping alone would map two long

--- a/packages/plugin-format/src/plugin_format/connectors.py
+++ b/packages/plugin-format/src/plugin_format/connectors.py
@@ -256,6 +256,26 @@ def _known_placeholders() -> frozenset[str]:
     return frozenset(PLACEHOLDERS)
 
 
+def _forges_the_render_join(name: str) -> bool:
+    """Whether this connector name would forge a second ``-mcp-`` in the object name.
+
+    Imported lazily for exactly the reason ``_known_placeholders`` above is:
+    ``connector_render`` imports THIS module at top level, so importing it back
+    at top level is a circular import.
+
+    The rule is deliberately not restated here. The renderer owns it, so the
+    name this validator refuses and the name the renderer refuses cannot drift
+    -- and the drift would be silent in both directions: a name the validator
+    accepts but the renderer refuses turns a friendly bundle error into a crash
+    at deploy time, and a name the validator refuses but the renderer accepts
+    blocks a bundle that was fine (#1446).
+    """
+
+    from .connector_render import connector_forges_join
+
+    return connector_forges_join(name)
+
+
 def _is_valid_name(name: str) -> bool:
     """RFC 1123 label, capped: the name becomes a k8s object and a DNS label."""
 
@@ -302,6 +322,25 @@ def validate_connectors(data: Any) -> tuple[ConnectorsFile | None, list[tuple[st
                     "(the approval server / the durable state server), so a connector "
                     "declaring it would replace that server in the agent's session and "
                     f"the agent would lose {lost} -- rename the connector",
+                )
+            )
+        # A separate `if`, never an `elif` on the shape check above: a name can
+        # be both badly shaped and forging, and this validator's convention is
+        # to report every applicable code so the author fixes the whole file in
+        # one pass instead of discovering the next problem after each rename.
+        if _forges_the_render_join(name):
+            errors.append(
+                (
+                    "connectors.ambiguous_name",
+                    f"{where}: `{name}` would forge a second `-mcp-` in the object name "
+                    "Curie derives for this connector (`<release>-<agent>-mcp-"
+                    "<connector>`), so it is no longer recoverable where the agent ends "
+                    "and the connector begins -- a DIFFERENT agent/connector pair would "
+                    "render the same Service, Deployment, both NetworkPolicies and the "
+                    "same `app.kubernetes.io/name` pod selector, handing one agent's "
+                    "sandbox the other's connector and the credential bound to it "
+                    "(the connector is deliberately unauthenticated, ADR-0086) -- rename "
+                    "the connector so it does not start with `mcp-` or contain `-mcp-`",
                 )
             )
         if spec.image and spec.url:

--- a/packages/plugin-format/src/plugin_format/connectors.py
+++ b/packages/plugin-format/src/plugin_format/connectors.py
@@ -328,7 +328,26 @@ def validate_connectors(data: Any) -> tuple[ConnectorsFile | None, list[tuple[st
         # be both badly shaped and forging, and this validator's convention is
         # to report every applicable code so the author fixes the whole file in
         # one pass instead of discovering the next problem after each rename.
-        if _forges_the_render_join(name):
+        #
+        # Gated on `spec.is_hosted`: this guard exists because the name reaches
+        # `object_name` and could collide with another agent/connector pair
+        # there. A remote connector's name never reaches `object_name` at all
+        # -- `render()` emits zero objects for it, and `mcp_entry()` returns the
+        # authored `url` verbatim -- so there is no object name for it to make
+        # ambiguous. Refusing it would reject a previously valid bundle for a
+        # collision it cannot cause (#1446). A hosted connector that also sets
+        # `unhosted_url` still has `image` set (`is_hosted` True) and stays
+        # guarded, correctly: it renders real objects on the cluster tier.
+        #
+        # This is a deliberate ASYMMETRY with `deploy.ambiguous_agent_name`,
+        # which stays unconditional. An agent name is durable platform identity
+        # that outlives any one bundle version (ADR-0089 -- a typo there mints a
+        # new agent), it feeds `object_name` for every hosted connector the
+        # agent will EVER declare, and `deploy.yaml` validation does not read
+        # `connectors.yaml`, so it cannot know whether a hosted connector even
+        # exists yet. Refusing the agent name up front is the conservative
+        # choice; refusing a remote connector name here is not.
+        if spec.is_hosted and _forges_the_render_join(name):
             errors.append(
                 (
                     "connectors.ambiguous_name",

--- a/packages/plugin-format/src/plugin_format/deploy_targets.py
+++ b/packages/plugin-format/src/plugin_format/deploy_targets.py
@@ -37,6 +37,12 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
+# The renderer owns the join rule, and it is imported rather than restated so
+# the name this validator refuses and the name the renderer refuses cannot
+# drift. A plain module-level import is fine here: unlike `connectors`, this
+# module is not imported by `connector_render`, so there is no cycle (#1446).
+from .connector_render import agent_forges_join
+
 # Curie's two deployment environments. Not open-ended: the worker's binding
 # query ranks prod over dev explicitly, so a third value would silently never
 # be selected.
@@ -124,15 +130,42 @@ def validate_deploy_targets(data: Any) -> tuple[DeployTargetsFile | None, list[t
                     f"{where}: agent is required for every declared target",
                 )
             )
-        elif not _is_valid_name(target.agent):
-            errors.append(
-                (
-                    "deploy.bad_agent_name",
-                    f"{where}: `{target.agent}` is not a valid agent name. A typo here does "
-                    "not fail -- it MINTS A NEW AGENT and the deploy reports success, so the "
-                    "name is checked before anything is created (ADR-0089).",
+        else:
+            # Two independent `if`s inside the `else`, not an `elif` chain. A
+            # name can be both malformed and forging (`Acme-mcp-bot`), and this
+            # file accumulates every applicable code. The `else` is what keeps
+            # the forging check off a `None` agent: called on `None` the
+            # predicate raises TypeError out of a validator whose whole contract
+            # is to RETURN errors, turning "agent is required" into a crash.
+            if not _is_valid_name(target.agent):
+                errors.append(
+                    (
+                        "deploy.bad_agent_name",
+                        f"{where}: `{target.agent}` is not a valid agent name. A typo here does "
+                        "not fail -- it MINTS A NEW AGENT and the deploy reports success, so the "
+                        "name is checked before anything is created (ADR-0089).",
+                    )
                 )
-            )
+            # The same class of silent failure one level deeper: a typo MINTS a
+            # new agent, a forged join MERGES two. Every connector Curie renders
+            # for this agent is named `<release>-<agent>-mcp-<connector>`, and
+            # `-mcp-` is a bare substring inside one DNS label rather than a
+            # structural separator (#1446).
+            if agent_forges_join(target.agent):
+                errors.append(
+                    (
+                        "deploy.ambiguous_agent_name",
+                        f"{where}: `{target.agent}` would forge a second `-mcp-` in every "
+                        "connector object name Curie renders for this agent "
+                        "(`<release>-<agent>-mcp-<connector>`), so a DIFFERENT "
+                        "agent/connector pair would render the same Service, Deployment, "
+                        "both NetworkPolicies and the same `app.kubernetes.io/name` -- which "
+                        "IS the pod selector, so one agent's sandbox would reach the other's "
+                        "connector and the credential bound to it (the connector is "
+                        "deliberately unauthenticated, ADR-0086) -- rename the agent so it "
+                        "does not end in `-mcp` or contain `-mcp-`",
+                    )
+                )
         if target.slack_channel is not None and not _SLACK_RE.fullmatch(target.slack_channel):
             errors.append(
                 (

--- a/packages/plugin-format/tests/test_connector_render.py
+++ b/packages/plugin-format/tests/test_connector_render.py
@@ -341,6 +341,27 @@ def test_over_long_names_that_share_a_prefix_still_differ() -> None:
 # --------------------------------------------------------------------------- #
 
 
+def _render_connector(agent: str, connector: str, release: str = "curie") -> list[dict]:
+    """Render one connector's objects, holding everything but the names fixed.
+
+    The one render call both the refusal tests and their controls go through.
+    The namespace, app name, spec and secret name are incidental to #1446, and
+    pinning them in a single place is what lets a refusal and the control it is
+    paired with differ in nothing but the agent and connector names -- which is
+    the entire claim those pairs make.
+    """
+
+    return r.render(
+        release=release,
+        agent=agent,
+        namespace="ns",
+        app_name="curie",
+        connector=connector,
+        spec=DEV,
+        secret_name="s",
+    )
+
+
 def _rendered_names(release: str, agent: str, connector: str) -> dict[str, str]:
     """The four object names one connector renders, keyed by what they are.
 
@@ -351,15 +372,7 @@ def _rendered_names(release: str, agent: str, connector: str) -> dict[str, str]:
     all four take their name from `object_name`, which is where the guard lives.
     """
 
-    objs = r.render(
-        release=release,
-        agent=agent,
-        namespace="ns",
-        app_name="curie",
-        connector=connector,
-        spec=DEV,
-        secret_name="s",
-    )
+    objs = _render_connector(agent, connector, release)
     # Select the policies by direction, never by kind: two NetworkPolicies ship
     # per connector, so `kind == "NetworkPolicy"` silently picks whichever is
     # first and tests the wrong object.
@@ -369,18 +382,6 @@ def _rendered_names(release: str, agent: str, connector: str) -> dict[str, str]:
         "egress": _egress_np(objs)["metadata"]["name"],
         "ingress": _ingress_np(objs)["metadata"]["name"],
     }
-
-
-def _render_forging(agent: str, connector: str, release: str = "curie") -> list[dict]:
-    return r.render(
-        release=release,
-        agent=agent,
-        namespace="ns",
-        app_name="curie",
-        connector=connector,
-        spec=DEV,
-        secret_name="s",
-    )
 
 
 def test_the_issue_pair_cannot_render_the_same_objects() -> None:
@@ -398,9 +399,9 @@ def test_the_issue_pair_cannot_render_the_same_objects() -> None:
     )
 
     with pytest.raises(r.AmbiguousObjectName) as first:
-        _render_forging(agent="a-mcp-b", connector="c")
+        _render_connector(agent="a-mcp-b", connector="c")
     with pytest.raises(r.AmbiguousObjectName) as second:
-        _render_forging(agent="a", connector="b-mcp-c")
+        _render_connector(agent="a", connector="b-mcp-c")
 
     assert "a-mcp-b" in str(first.value), "the error must name the offending agent"
     assert "b-mcp-c" in str(second.value), "the error must name the offending connector"
@@ -413,7 +414,7 @@ def test_every_rendered_object_kind_is_refused() -> None:
     # stopped emitting the ingress policy #1443 added. The control below pins
     # the full set and its names, so dropping an object fails here too.
     with pytest.raises(r.AmbiguousObjectName):
-        _render_forging(agent="a-mcp-b", connector="c")
+        _render_connector(agent="a-mcp-b", connector="c")
 
     control = _rendered_names("curie", "acme-dev", "grafana")
     assert control == {
@@ -442,9 +443,9 @@ def test_a_substring_ban_would_miss_this_pair() -> None:
     assert f"curie-{'x-mcp'}-mcp-{'c'}" == f"curie-{'x'}-mcp-{'mcp-c'}"
 
     with pytest.raises(r.AmbiguousObjectName):
-        _render_forging(agent="x-mcp", connector="c")
+        _render_connector(agent="x-mcp", connector="c")
     with pytest.raises(r.AmbiguousObjectName):
-        _render_forging(agent="x", connector="mcp-c")
+        _render_connector(agent="x", connector="mcp-c")
 
 
 def test_a_forging_pair_is_refused_even_past_the_digest_boundary() -> None:
@@ -467,9 +468,9 @@ def test_a_forging_pair_is_refused_even_past_the_digest_boundary() -> None:
     assert len(left) > 63, "this pair must reach the truncate-with-digest branch"
 
     with pytest.raises(r.AmbiguousObjectName):
-        _render_forging(agent=long_agent, connector=short_connector)
+        _render_connector(agent=long_agent, connector=short_connector)
     with pytest.raises(r.AmbiguousObjectName):
-        _render_forging(agent=short_agent, connector=long_connector)
+        _render_connector(agent=short_agent, connector=long_connector)
 
 
 _FORGING_AGENT = "a-mcp-b"
@@ -502,7 +503,7 @@ _DERIVATIONS: list[tuple[str, Callable[[], object]]] = [
         "render_ingress_networkpolicy",
         lambda: r.render_ingress_networkpolicy("curie", _FORGING_AGENT, "curie", "c", DEV),
     ),
-    ("render", lambda: _render_forging(agent=_FORGING_AGENT, connector="c")),
+    ("render", lambda: _render_connector(agent=_FORGING_AGENT, connector="c")),
 ]
 
 

--- a/packages/plugin-format/tests/test_connector_render.py
+++ b/packages/plugin-format/tests/test_connector_render.py
@@ -7,8 +7,10 @@ refactor cannot quietly reintroduce them.
 
 from __future__ import annotations
 
+import hashlib
 import shutil
 import subprocess
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
@@ -318,6 +320,380 @@ def test_over_long_names_that_share_a_prefix_still_differ() -> None:
     b = r.object_name("release", "agent-with-a-very-long-name-number-two", "grafana")
     assert len(a) <= 63 and len(b) <= 63
     assert a != b
+
+
+# --------------------------------------------------------------------------- #
+# Forged join -- #1446
+#
+# #1116 made the object name agent-scoped by joining the two names with the
+# literal `-mcp-`. That literal is a bare substring INSIDE a single DNS label,
+# not a structural separator, so the join point is not recoverable from the
+# rendered string: `curie-a-mcp-b-mcp-c` reads equally well as
+# (agent=`a-mcp-b`, connector=`c`) and (agent=`a`, connector=`b-mcp-c`). Two
+# different agents therefore render byte-identical Services, Deployments,
+# NetworkPolicies AND `app.kubernetes.io/name` pod selectors.
+#
+# The connector is deliberately unauthenticated (ADR-0086: "the network is not
+# one layer of the access control here, it is the whole of it"), so the object
+# name is the ONLY thing binding a sandbox to a credential. A collision hands
+# one agent another agent's production token with nothing logged and nothing
+# failing. These tests pin the refusal.
+# --------------------------------------------------------------------------- #
+
+
+def _rendered_names(release: str, agent: str, connector: str) -> dict[str, str]:
+    """The four object names one connector renders, keyed by what they are.
+
+    Used as the CONTROL for the refusal tests below. A test that only asserts
+    `render()` raises passes vacuously if a future change stops rendering an
+    object at all, so every refusal test is paired with a render of a
+    non-forging name that proves all four kinds are still produced -- and that
+    all four take their name from `object_name`, which is where the guard lives.
+    """
+
+    objs = r.render(
+        release=release,
+        agent=agent,
+        namespace="ns",
+        app_name="curie",
+        connector=connector,
+        spec=DEV,
+        secret_name="s",
+    )
+    # Select the policies by direction, never by kind: two NetworkPolicies ship
+    # per connector, so `kind == "NetworkPolicy"` silently picks whichever is
+    # first and tests the wrong object.
+    return {
+        "Service": next(o for o in objs if o["kind"] == "Service")["metadata"]["name"],
+        "Deployment": next(o for o in objs if o["kind"] == "Deployment")["metadata"]["name"],
+        "egress": _egress_np(objs)["metadata"]["name"],
+        "ingress": _ingress_np(objs)["metadata"]["name"],
+    }
+
+
+def _render_forging(agent: str, connector: str, release: str = "curie") -> list[dict]:
+    return r.render(
+        release=release,
+        agent=agent,
+        namespace="ns",
+        app_name="curie",
+        connector=connector,
+        spec=DEV,
+        secret_name="s",
+    )
+
+
+def test_the_issue_pair_cannot_render_the_same_objects() -> None:
+    # The exact pair from #1446. Both tuples build the identical base string
+    # `curie-a-mcp-b-mcp-c`, so before this guard the DEV agent `a` declaring a
+    # connector `b-mcp-c` and the PROD agent `a-mcp-b` declaring a connector `c`
+    # rendered the same Service, the same Deployment, both the same
+    # NetworkPolicies and the same pod selector. Whichever deployed last owned
+    # every object, and the other agent's sandbox reached a connector holding a
+    # credential that was never issued to it. Nothing errored -- that silence is
+    # the whole defect, and it is why the refusal is fail-closed rather than a
+    # warning.
+    assert f"curie-{'a-mcp-b'}-mcp-{'c'}" == f"curie-{'a'}-mcp-{'b-mcp-c'}", (
+        "if this ever stops holding the pair below is no longer the issue's pair"
+    )
+
+    with pytest.raises(r.AmbiguousObjectName) as first:
+        _render_forging(agent="a-mcp-b", connector="c")
+    with pytest.raises(r.AmbiguousObjectName) as second:
+        _render_forging(agent="a", connector="b-mcp-c")
+
+    assert "a-mcp-b" in str(first.value), "the error must name the offending agent"
+    assert "b-mcp-c" in str(second.value), "the error must name the offending connector"
+
+
+def test_every_rendered_object_kind_is_refused() -> None:
+    # AC3: the check covers all FOUR rendered objects, not just the Deployment.
+    # The guard sits in `object_name`, so `render()` refuses before it produces
+    # any of them -- but "raises" alone would still pass if `render` quietly
+    # stopped emitting the ingress policy #1443 added. The control below pins
+    # the full set and its names, so dropping an object fails here too.
+    with pytest.raises(r.AmbiguousObjectName):
+        _render_forging(agent="a-mcp-b", connector="c")
+
+    control = _rendered_names("curie", "acme-dev", "grafana")
+    assert control == {
+        "Service": "curie-acme-dev-mcp-grafana",
+        "Deployment": "curie-acme-dev-mcp-grafana",
+        "egress": "curie-acme-dev-mcp-grafana-allow",
+        "ingress": "curie-acme-dev-mcp-grafana-allow-ingress",
+    }
+
+
+def test_a_substring_ban_would_miss_this_pair() -> None:
+    # This is the test that separates the shipped rule from the fix the issue
+    # itself suggested. `-mcp-` is NOT a substring of either offending name:
+    #
+    #     "-mcp-" in "x-mcp"  ->  False
+    #     "-mcp-" in "mcp-c"  ->  False
+    #
+    # yet agent `x-mcp` + connector `c` and agent `x` + connector `mcp-c` both
+    # render `curie-x-mcp-mcp-c`. A ban on the literal substring therefore
+    # leaves this collision fully live while looking like a fix. The rule has to
+    # be "would this name FORGE a second join once the concatenation happens",
+    # which is `-mcp-` in f"{agent}-" on the left and in f"-{connector}" on the
+    # right -- each side tested against the half of the delimiter it abuts.
+    assert "-mcp-" not in "x-mcp"
+    assert "-mcp-" not in "mcp-c"
+    assert f"curie-{'x-mcp'}-mcp-{'c'}" == f"curie-{'x'}-mcp-{'mcp-c'}"
+
+    with pytest.raises(r.AmbiguousObjectName):
+        _render_forging(agent="x-mcp", connector="c")
+    with pytest.raises(r.AmbiguousObjectName):
+        _render_forging(agent="x", connector="mcp-c")
+
+
+def test_a_forging_pair_is_refused_even_past_the_digest_boundary() -> None:
+    # The truncate-with-digest branch does NOT close this hole on its own, and
+    # believing it does is the easy wrong conclusion: it looks like a
+    # disambiguator because it exists to stop two long names clipping together.
+    # It cannot help here. The digest is taken over `base`, and a forging pair
+    # produces the SAME `base` from both tuples -- so it produces the same
+    # sha256, the same truncation, and reproduces the collision byte for byte.
+    # The guard has to run BEFORE the length check; this test fails if someone
+    # moves it after.
+    long_agent = "a" * 25 + "-mcp-" + "b" * 25
+    short_connector = "c" * 10
+    short_agent = "a" * 25
+    long_connector = "b" * 25 + "-mcp-" + "c" * 10
+
+    left = f"curie-{long_agent}-mcp-{short_connector}"
+    right = f"curie-{short_agent}-mcp-{long_connector}"
+    assert left == right, "the two tuples must build one base for this test to mean anything"
+    assert len(left) > 63, "this pair must reach the truncate-with-digest branch"
+
+    with pytest.raises(r.AmbiguousObjectName):
+        _render_forging(agent=long_agent, connector=short_connector)
+    with pytest.raises(r.AmbiguousObjectName):
+        _render_forging(agent=short_agent, connector=long_connector)
+
+
+_FORGING_AGENT = "a-mcp-b"
+
+# Every accessor that derives anything from the object name. They all funnel
+# through `object_name` today, which is why one guard is enough -- but that is a
+# property of the current code, not a guarantee. If a refactor gives any of
+# these its own copy of the `-mcp-` concatenation, the guard stops covering it
+# and the collision comes back through that one path alone, silently. This list
+# is the pin, and it includes `_labels` deliberately: those labels ARE the
+# Service selector, the Deployment matchLabels and both policies' podSelectors,
+# so a collision there cross-wires traffic even when the object names differ.
+_DERIVATIONS: list[tuple[str, Callable[[], object]]] = [
+    ("object_name", lambda: r.object_name("curie", _FORGING_AGENT, "c")),
+    ("service_dns", lambda: r.service_dns("curie", _FORGING_AGENT, "c", "ns")),
+    ("host_aliases", lambda: r.host_aliases("curie", _FORGING_AGENT, "c", "ns", 8000)),
+    ("substitutions", lambda: r.substitutions("curie", _FORGING_AGENT, "c", "ns", 8000)),
+    ("mcp_entry", lambda: r.mcp_entry("curie", _FORGING_AGENT, "ns", "c", DEV)),
+    ("_labels", lambda: r._labels("curie", _FORGING_AGENT, "c")),
+    ("render_service", lambda: r.render_service("curie", _FORGING_AGENT, "c", DEV)),
+    (
+        "render_deployment",
+        lambda: r.render_deployment("curie", _FORGING_AGENT, "ns", "c", DEV, "s"),
+    ),
+    (
+        "render_networkpolicy",
+        lambda: r.render_networkpolicy("curie", _FORGING_AGENT, "curie", "c", DEV),
+    ),
+    (
+        "render_ingress_networkpolicy",
+        lambda: r.render_ingress_networkpolicy("curie", _FORGING_AGENT, "curie", "c", DEV),
+    ),
+    ("render", lambda: _render_forging(agent=_FORGING_AGENT, connector="c")),
+]
+
+
+@pytest.mark.parametrize("call", [pytest.param(fn, id=name) for name, fn in _DERIVATIONS])
+def test_the_refusal_reaches_every_derivation(call: Callable[[], object]) -> None:
+    # A guard that only covers `render()` leaves `mcp_entry` handing the sandbox
+    # a URL for the OTHER agent's connector, and `substitutions` baking that
+    # same host into CURIE_ALLOWED_HOSTS -- both without rendering a single
+    # object. Every derivation has to refuse, or the credential still leaks
+    # through the path that skipped the renderer.
+    with pytest.raises(r.AmbiguousObjectName):
+        call()
+
+
+def test_the_error_names_the_offending_side() -> None:
+    # An operator hits this on an install that worked yesterday (an agent named
+    # `grafana-mcp` was legal before this fix). "invalid name" would send them
+    # into the source; the message has to say WHICH of the two names offends and
+    # WHAT ITS VALUE IS, because the agent comes from deploy.yaml and the
+    # connector from connectors.yaml -- two different files to go edit.
+    with pytest.raises(r.AmbiguousObjectName) as agent_side:
+        r.object_name("curie", "aa-mcp-bb", "grafana")
+    assert "aa-mcp-bb" in str(agent_side.value)
+
+    with pytest.raises(r.AmbiguousObjectName) as connector_side:
+        r.object_name("curie", "acme", "mcp-zzqq")
+    assert "mcp-zzqq" in str(connector_side.value)
+
+    # Both sides offending reports the AGENT, deterministically -- the guard
+    # checks the agent first. Pinned so the message is reproducible rather than
+    # incidentally ordered.
+    with pytest.raises(r.AmbiguousObjectName) as both:
+        r.object_name("curie", "aa-mcp-bb", "mcp-zzqq")
+    assert "aa-mcp-bb" in str(both.value)
+    assert "mcp-zzqq" not in str(both.value)
+
+
+# The asymmetry below looks like a bug until the derivation is done, so it is
+# stated here once rather than in each case:
+#
+#   agent     is followed by the join  ->  refused iff `-mcp-` in f"{agent}-"
+#   connector is preceded by the join  ->  refused iff `-mcp-` in f"-{connector}"
+#
+# So a TRAILING `-mcp` is fatal on the agent side (`grafana-mcp` + `-mcp-c...`
+# completes a second join) but harmless on the connector side (nothing follows
+# the connector, so `c-mcp` cannot complete anything). A LEADING `mcp-` is the
+# mirror: fatal on the connector side, harmless on the agent side (an
+# alternative split of `curie-mcp-x-mcp-c` would leave an EMPTY agent, which is
+# not a name any bundle can declare). Each side sits against a different half of
+# the delimiter, so a symmetric rule would be wrong in both directions -- it
+# would over-reject `c-mcp` and `mcp-x`, breaking installs for no security gain.
+_REFUSED_AGENTS = ["a-mcp-b", "grafana-mcp", "x-mcp"]
+_ALLOWED_AGENTS = ["mcp-x", "mcp", "acme-dev", "kubernetes"]
+_REFUSED_CONNECTORS = ["b-mcp-c", "mcp-c"]
+_ALLOWED_CONNECTORS = ["c-mcp", "grafana-mcp", "mcp", "grafana", "kubernetes", "netpol-probe"]
+
+
+@pytest.mark.parametrize("agent", _REFUSED_AGENTS)
+def test_agent_forges_join_is_true_for_a_name_that_completes_the_delimiter(agent: str) -> None:
+    assert r.agent_forges_join(agent) is True
+
+
+@pytest.mark.parametrize("agent", _ALLOWED_AGENTS)
+def test_agent_forges_join_is_false_for_a_name_that_only_looks_like_it(agent: str) -> None:
+    # Over-rejection is not the safe direction here. Every name refused is an
+    # install that must be renamed before its next deploy, so a rule that is
+    # merely conservative breaks working agents for nothing.
+    assert r.agent_forges_join(agent) is False
+
+
+@pytest.mark.parametrize("connector", _REFUSED_CONNECTORS)
+def test_connector_forges_join_is_true_for_a_name_that_completes_the_delimiter(
+    connector: str,
+) -> None:
+    assert r.connector_forges_join(connector) is True
+
+
+@pytest.mark.parametrize("connector", _ALLOWED_CONNECTORS)
+def test_connector_forges_join_is_false_for_a_name_that_only_looks_like_it(
+    connector: str,
+) -> None:
+    # `kubernetes` and `netpol-probe` are the connector names actually shipped
+    # in examples/, and `grafana-mcp` is the shape an author reaches for first.
+    # If any of these start being refused, this fix has broken the repo's own
+    # bundles.
+    assert r.connector_forges_join(connector) is False
+
+
+@pytest.mark.parametrize(
+    ("release", "agent", "connector", "expected"),
+    [
+        ("curie", "acme-dev", "grafana-mcp", "curie-acme-dev-mcp-grafana-mcp"),
+        ("curie", "acme-dev", "c-mcp", "curie-acme-dev-mcp-c-mcp"),
+        ("curie", "acme-dev", "mcp", "curie-acme-dev-mcp-mcp"),
+        ("curie", "mcp-x", "grafana", "curie-mcp-x-mcp-grafana"),
+        ("curie", "mcp", "grafana", "curie-mcp-mcp-grafana"),
+        ("grafana-mcp", "acme", "grafana", "grafana-mcp-acme-mcp-grafana"),
+    ],
+    ids=[
+        "connector_grafana_mcp",
+        "connector_c_mcp",
+        "connector_mcp",
+        "agent_mcp_x",
+        "agent_mcp",
+        "release_grafana_mcp",
+    ],
+)
+def test_names_that_only_look_like_the_join_still_render(
+    release: str, agent: str, connector: str, expected: str
+) -> None:
+    # The over-rejection guard, and the test that fails if someone "simplifies"
+    # the rule to a substring ban or to `base.count("-mcp-") == 1`. Each of
+    # these renders an UNAMBIGUOUS name: no other valid (agent, connector) split
+    # of the result exists, because the alternative split either leaves one side
+    # empty or fails to preserve the release prefix.
+    assert r.object_name(release, agent, connector) == expected
+    names = _rendered_names(release, agent, connector)
+    assert names == {
+        "Service": expected,
+        "Deployment": expected,
+        "egress": f"{expected}-allow",
+        "ingress": f"{expected}-allow-ingress",
+    }
+
+
+def test_the_release_is_deliberately_not_guarded() -> None:
+    # The release side is NOT checked, and that is a decision rather than an
+    # oversight. A `-mcp-` inside the release cannot create an
+    # (agent, connector) ambiguity: any alternative split of
+    # `grafana-mcp-acme-mcp-grafana` either leaves an empty agent or stops
+    # preserving the release prefix. Guarding the whole rendered base -- the
+    # obvious-looking `base.count("-mcp-") == 1` -- would refuse every deploy of
+    # a release literally named `grafana-mcp`, which is a real break of working
+    # installs in exchange for no security gain at all.
+    assert r.object_name("grafana-mcp", "acme", "grafana") == "grafana-mcp-acme-mcp-grafana"
+    assert r.agent_forges_join("acme") is False
+    assert r.connector_forges_join("grafana") is False
+
+
+def _name_as_it_rendered_before_1446(release: str, agent: str, connector: str) -> str:
+    """The pre-#1446 derivation, restated so the pin is independent of the code.
+
+    Deliberately a second copy of the formula: a pin that called `object_name`
+    to compute its own expectation could not detect a rename at all.
+    """
+
+    base = f"{release}-{agent}-mcp-{connector}"
+    if len(base) <= 63:
+        return base
+    digest = hashlib.sha256(base.encode()).hexdigest()[:8]
+    return f"{base[: 63 - 8 - 1].rstrip('-')}-{digest}"
+
+
+@pytest.mark.parametrize(
+    ("release", "agent", "connector"),
+    [
+        ("curie", "acme-dev", "grafana"),
+        ("curie", "acme-bot", "kubernetes"),
+        ("curie", "sre-prod", "netpol-probe"),
+        ("acme-bot", "driftcheck", "grafana"),
+        # Over the 63-character ceiling, so this one pins the
+        # truncate-with-digest branch as well as the plain concatenation.
+        ("release-with-a-long-name", "agent-with-a-very-long-name-number-one", "grafana"),
+    ],
+)
+def test_allowed_names_render_exactly_the_name_they_render_today(
+    release: str, agent: str, connector: str
+) -> None:
+    # #1116's contract has two halves and this fix may only touch one. Names
+    # must be DISTINCT per (release, agent, connector) -- that is what the guard
+    # above buys -- and they must stay "stable and derivable", which means every
+    # name that deploys today must render byte-identically tomorrow. A rename
+    # would not fail loudly: it would leave every live Service, Deployment and
+    # NetworkPolicy orphaned under a name nothing reconciles any more, still
+    # running, still holding its credential, while a fresh set comes up beside
+    # it. This test is the churn pin.
+    assert r.object_name(release, agent, connector) == _name_as_it_rendered_before_1446(
+        release, agent, connector
+    )
+
+
+def test_an_unhosted_connector_still_derives_nothing() -> None:
+    # `unhosted_mcp_entry` calls `mcp_entry("", "", "", "", spec)` with four
+    # empty strings for a remote connector. Empty names must not trip the new
+    # guard -- for two independent reasons: the spec is not hosted so
+    # `service_dns` is never reached, and `-mcp-` is not in `"-"` on either side
+    # anyway. If this starts raising, every remote connector in every bundle
+    # stops resolving.
+    entry = r.unhosted_mcp_entry(REMOTE)
+    assert entry is not None
+    assert entry["url"] == "https://mcp.internal/mcp"
 
 
 # --------------------------------------------------------------------------- #

--- a/packages/plugin-format/tests/test_connectors.py
+++ b/packages/plugin-format/tests/test_connectors.py
@@ -383,3 +383,92 @@ def test_a_reserved_name_and_a_bad_shape_report_both() -> None:
     codes = _codes({"connectors": {"curie": {"secrets": ["T"]}}})
     assert "connectors.reserved_name" in codes
     assert "connectors.underspecified" in codes
+
+
+# --------------------------------------------------------------------------- #
+# Names that forge the renderer's `-mcp-` join -- #1446
+#
+# The renderer joins the agent and the connector with the literal `-mcp-`
+# (`{release}-{agent}-mcp-{connector}`). That literal is a bare substring inside
+# one DNS label, not a structural separator, so a connector whose name starts
+# with `mcp-` or contains `-mcp-` makes the rendered name ambiguous about where
+# the agent ends and the connector begins: a DIFFERENT agent/connector pair then
+# renders the same Service, the same Deployment, both the same NetworkPolicies
+# and the same `app.kubernetes.io/name` pod selector. The connector is
+# deliberately unauthenticated (ADR-0086), so the object name is the only thing
+# binding a sandbox to a credential -- a collision quietly hands one agent
+# another agent's production token.
+#
+# The renderer refuses too, as a backstop. This validator is the primary gate,
+# because it is the one that reaches the author with a name and a fix instead of
+# a 500 at deploy time.
+# --------------------------------------------------------------------------- #
+FORGING_CONNECTOR_NAMES = ["mcp-c", "b-mcp-c", "mcp-grafana"]
+SAFE_CONNECTOR_NAMES = ["grafana-mcp", "c-mcp", "mcp", "grafana", "kubernetes", "netpol-probe"]
+
+
+@pytest.mark.parametrize("name", FORGING_CONNECTOR_NAMES)
+def test_a_connector_name_that_forges_the_render_join_is_rejected(name: str) -> None:
+    # The spec here is otherwise perfectly valid -- a plain hosted image, a
+    # well-formed RFC 1123 name, nothing reserved. So this can only pass if the
+    # new check fires on its own; it cannot be masked by `connectors.bad_name`
+    # or `connectors.underspecified` standing in for it.
+    assert _codes({"connectors": {name: {"image": "x:1"}}}) == ["connectors.ambiguous_name"]
+
+
+@pytest.mark.parametrize("name", SAFE_CONNECTOR_NAMES)
+def test_a_connector_name_that_merely_ends_in_mcp_is_accepted(name: str) -> None:
+    # The asymmetry that looks like a bug: a TRAILING `-mcp` is fine on the
+    # connector, because nothing follows the connector to complete a second
+    # join, while it is fatal on the agent, which the join follows directly.
+    # Refusing these would be an over-rejection with a real cost -- `kubernetes`
+    # and `netpol-probe` are the connector names shipped in examples/, and every
+    # install declaring one would stop deploying for no security gain.
+    assert "connectors.ambiguous_name" not in _codes({"connectors": {name: {"image": "x:1"}}})
+
+
+def test_the_ambiguous_name_error_says_what_to_do() -> None:
+    # An author reads this message and has to fix it without opening the
+    # renderer's source: it must name the connector, say that the name forges a
+    # second `-mcp-` in the object name Curie derives, and say to rename.
+    _, errors = validate_connectors({"connectors": {"mcp-grafana": {"image": "x:1"}}})
+    message = next(m for c, m in errors if c == "connectors.ambiguous_name")
+    assert "mcp-grafana" in message
+    assert "-mcp-" in message
+    assert "rename" in message.lower()
+
+
+def test_the_validator_and_the_renderer_share_one_join_rule() -> None:
+    # Two copies of the rule would drift, and the drift is silent in the worst
+    # direction: a name the validator accepts and the renderer refuses turns a
+    # friendly bundle error into a 500 at deploy time, and a name the validator
+    # refuses but the renderer accepts blocks a bundle that would have been
+    # fine. Modelled on the placeholder-list pin above -- the renderer owns the
+    # rule, the validator only asks.
+    from plugin_format.connector_render import connector_forges_join
+
+    for name in FORGING_CONNECTOR_NAMES + SAFE_CONNECTOR_NAMES:
+        rejected = "connectors.ambiguous_name" in _codes({"connectors": {name: {"image": "x:1"}}})
+        assert rejected is connector_forges_join(name), name
+
+
+def test_a_forging_name_and_a_bad_shape_report_both() -> None:
+    # Same accumulation convention as the reserved-name check above: the author
+    # sees every problem in the file in one pass, rather than discovering the
+    # next one only after renaming to fix the first. This fails if the new check
+    # lands as an `elif` on the shape check.
+    codes = _codes({"connectors": {"mcp-c": {"secrets": ["T"]}}})
+    assert "connectors.ambiguous_name" in codes
+    assert "connectors.underspecified" in codes
+
+
+def test_bundle_surfaces_an_ambiguous_connector_name(tmp_path: Path) -> None:
+    # Through the real entry point. `validate.py` forwards validator codes
+    # verbatim with no allowlist, and this is what proves it -- a new code that
+    # never reaches `validate_bundle` never reaches an author either.
+    root = _bundle(tmp_path, "connectors:\n  mcp-grafana:\n    image: x:1\n")
+    result = validate_bundle(str(root))
+    assert not result.valid
+    offending = [e for e in result.errors if e.code == "connectors.ambiguous_name"]
+    assert offending, [e.code for e in result.errors]
+    assert "mcp-grafana" in offending[0].message

--- a/packages/plugin-format/tests/test_connectors.py
+++ b/packages/plugin-format/tests/test_connectors.py
@@ -456,10 +456,64 @@ def test_a_forging_name_and_a_bad_shape_report_both() -> None:
     # Same accumulation convention as the reserved-name check above: the author
     # sees every problem in the file in one pass, rather than discovering the
     # next one only after renaming to fix the first. This fails if the new check
-    # lands as an `elif` on the shape check.
-    codes = _codes({"connectors": {"mcp-c": {"secrets": ["T"]}}})
+    # lands as an `elif` on the shape check. Paired against `image` + `url`
+    # rather than the underspecified shape below -- that shape is hosted
+    # (`image` is set), so the ambiguous-name guard is live for it too.
+    codes = _codes({"connectors": {"mcp-c": {"image": "x:1", "url": "https://y/mcp"}}})
     assert "connectors.ambiguous_name" in codes
-    assert "connectors.underspecified" in codes
+    assert "connectors.ambiguous" in codes
+
+
+def test_a_forging_name_on_an_underspecified_connector_is_not_yet_judged() -> None:
+    # Neither `image:` nor `url:` is set, so `is_hosted` is False and the
+    # ambiguous-name guard does not fire -- not because the name is safe, but
+    # because we do not yet know it will ever reach `object_name`. If the
+    # author resolves `connectors.underspecified` by adding `url:`, this exact
+    # name is perfectly legal. Reporting `connectors.ambiguous_name` here would
+    # be a spurious error chasing a shape the author hasn't chosen yet.
+    assert _codes({"connectors": {"mcp-c": {"secrets": ["T"]}}}) == ["connectors.underspecified"]
+
+
+def test_a_forging_remote_connector_name_is_accepted() -> None:
+    # `render()` emits zero objects for a `url` connector and `mcp_entry()`
+    # returns the authored URL verbatim, so `object_name` is never called on
+    # this name -- it cannot collide with anything. Refusing it anyway would
+    # break a previously valid bundle for a collision it cannot cause.
+    assert "connectors.ambiguous_name" not in _codes(
+        {"connectors": {"mcp-internal": {"url": "https://mcp.internal/mcp"}}}
+    )
+    assert "connectors.ambiguous_name" not in _codes(
+        {"connectors": {"x-mcp-y": {"url": "https://mcp.internal/mcp"}}}
+    )
+
+
+@pytest.mark.parametrize("name", ["mcp-internal", "x-mcp-y"])
+def test_the_same_forging_name_is_refused_only_when_hosted(name: str) -> None:
+    # The important half of the boundary: the exact same name that is safe as
+    # `url` (above) is still refused once it is `image` -- a hosted connector
+    # renders real Kubernetes objects through `object_name`, so the collision
+    # this check exists to prevent is live again. Pinning both outcomes side
+    # by side is what stops a future widening of the remote exemption from
+    # quietly disabling the hosted guard too.
+    remote_codes = _codes({"connectors": {name: {"url": "https://mcp.internal/mcp"}}})
+    hosted_codes = _codes({"connectors": {name: {"image": "x:1"}}})
+    assert "connectors.ambiguous_name" not in remote_codes
+    assert hosted_codes == ["connectors.ambiguous_name"]
+
+
+def test_a_forging_hosted_connector_with_an_unhosted_url_stays_refused() -> None:
+    # `unhosted_url` is the tier-3 fallback address, not a substitute for
+    # `image` -- the connector is still hosted (`is_hosted` reads `image`) and
+    # still renders real objects on any tier that can host it. This is the
+    # shape most likely to be mis-gated by a later edit that broadens the
+    # `url`-only exemption to "anything with a URL on it."
+    assert _codes(
+        {
+            "connectors": {
+                "mcp-grafana": {"image": "x:1", "unhosted_url": "${GRAFANA_MCP_URL}"}
+            }
+        }
+    ) == ["connectors.ambiguous_name"]
 
 
 def test_bundle_surfaces_an_ambiguous_connector_name(tmp_path: Path) -> None:

--- a/packages/plugin-format/tests/test_deploy_targets.py
+++ b/packages/plugin-format/tests/test_deploy_targets.py
@@ -201,3 +201,88 @@ def test_bundle_allows_chained_merge_anchors(tmp_path: Path) -> None:
 
 def test_the_real_acme_bot_routing_validates(tmp_path: Path) -> None:
     assert validate_bundle(str(_bundle(tmp_path, REAL))).valid
+
+
+# --------------------------------------------------------------------------- #
+# Agent names that forge the renderer's `-mcp-` join -- #1446
+#
+# Every connector Curie renders for an agent is named
+# `{release}-{agent}-mcp-{connector}`. `-mcp-` is a bare substring inside one
+# DNS label, not a structural separator, so an agent name that ends in `-mcp` or
+# contains `-mcp-` makes that name ambiguous about where the agent ends: a
+# DIFFERENT agent/connector pair renders the same Service, the same Deployment,
+# both the same NetworkPolicies, and -- worst of all -- the same
+# `app.kubernetes.io/name`, which IS the pod selector. One agent's sandbox then
+# reaches the other agent's connector and the credential bound to it (ADR-0086
+# leaves the connector deliberately unauthenticated, so the network is the whole
+# of the access control).
+#
+# This is the same class of silent failure the shape check already guards: a
+# typo does not fail, it MINTS A NEW AGENT. A forged join is one level deeper --
+# it does not mint a new agent, it MERGES two.
+# --------------------------------------------------------------------------- #
+FORGING_AGENT_NAMES = ["a-mcp-b", "x-mcp", "grafana-mcp"]
+SAFE_AGENT_NAMES = ["mcp-x", "mcp", "acme-dev", "acme-bot"]
+
+
+@pytest.mark.parametrize("agent", FORGING_AGENT_NAMES)
+def test_an_agent_name_that_forges_the_render_join_is_rejected(agent: str) -> None:
+    # Each of these is a well-formed RFC 1123 label, so the existing shape check
+    # passes it and always has. Only the new code can catch it, which is what
+    # the exact-list assertion pins -- a passing test here cannot be a
+    # `deploy.bad_agent_name` standing in.
+    assert _codes({"targets": {"p": {"agent": agent}}}) == ["deploy.ambiguous_agent_name"]
+
+
+@pytest.mark.parametrize("agent", SAFE_AGENT_NAMES)
+def test_an_agent_name_that_merely_starts_with_mcp_is_accepted(agent: str) -> None:
+    # The asymmetry that reads like a bug: a LEADING `mcp-` is fine on the agent
+    # and fatal on the connector, because the alternative split of
+    # `curie-mcp-x-mcp-c` would leave an EMPTY agent, which no bundle can
+    # declare. Each side abuts a different half of the delimiter. Over-rejecting
+    # here is not the safe direction -- every name refused is a working install
+    # that must be renamed before its next deploy.
+    assert "deploy.ambiguous_agent_name" not in _codes({"targets": {"p": {"agent": agent}}})
+
+
+def test_a_malformed_and_forging_agent_name_reports_both() -> None:
+    # `Acme-mcp-bot` is both badly shaped (uppercase is not an RFC 1123 label)
+    # and forging. The file's convention is to accumulate every applicable code
+    # so the author fixes the whole file in one pass; this fails if the new
+    # check lands as an `elif` and swallows one of the two.
+    codes = _codes({"targets": {"p": {"agent": "Acme-mcp-bot"}}})
+    assert "deploy.bad_agent_name" in codes
+    assert "deploy.ambiguous_agent_name" in codes
+
+
+def test_a_malformed_name_that_does_not_forge_reports_only_the_shape_error() -> None:
+    # Regression pin on the existing behaviour: adding the new code must not
+    # start attaching it to every malformed name. `Acme_Bot` is a shape problem
+    # and nothing else.
+    codes = _codes({"targets": {"p": {"agent": "Acme_Bot"}}})
+    assert "deploy.bad_agent_name" in codes
+    assert "deploy.ambiguous_agent_name" not in codes
+
+
+def test_a_missing_agent_still_reports_only_missing_agent() -> None:
+    # The new check has to be guarded on the agent being present. The obvious
+    # placement -- a sibling `if` beside the existing `elif not _is_valid_name`
+    # chain -- calls the predicate on `None` and raises TypeError out of a
+    # validator whose entire contract is to RETURN errors, turning a friendly
+    # "targets.p: agent is required" into a crash during bundle validation.
+    codes = _codes({"targets": {"p": {"agent": None, "env": "prod"}}})
+    assert codes == ["deploy.missing_agent"]
+
+
+def test_the_ambiguous_agent_name_error_says_what_to_do() -> None:
+    # The operator hitting this is hitting it on an install that deployed
+    # yesterday -- `grafana-mcp` was a legal agent name before this fix. The
+    # message has to name the target key (which of several targets to edit), the
+    # agent, and say to rename, or the only way to resolve it is to read the
+    # renderer's source.
+    _, errors = validate_deploy_targets({"targets": {"p": {"agent": "grafana-mcp"}}})
+    message = next(m for c, m in errors if c == "deploy.ambiguous_agent_name")
+    assert "targets.p" in message
+    assert "grafana-mcp" in message
+    assert "-mcp-" in message
+    assert "rename" in message.lower()

--- a/runner/src/curie_runner/connectors.py
+++ b/runner/src/curie_runner/connectors.py
@@ -40,7 +40,11 @@ from pathlib import Path
 from typing import Any
 
 import yaml
-from plugin_format.connector_render import mcp_entry, unhosted_mcp_entry
+from plugin_format.connector_render import (
+    AmbiguousObjectName,
+    mcp_entry,
+    unhosted_mcp_entry,
+)
 from plugin_format.connectors import CONNECTORS_FILE, ConnectorsFile, validate_connectors
 from plugin_format.yaml_loader import safe_load_unique
 
@@ -118,10 +122,34 @@ def derive_mcp_servers(
                 entries[name] = entry
         return entries
 
-    return {
-        name: mcp_entry(release, agent, namespace, name, spec)
-        for name, spec in sorted(declared.connectors.items())
-    }
+    try:
+        return {
+            name: mcp_entry(release, agent, namespace, name, spec)
+            for name, spec in sorted(declared.connectors.items())
+        }
+    except AmbiguousObjectName as exc:
+        # The same trade `_read` makes above, for the same reason. The CONNECTOR
+        # half of this rule is already fail-soft here, because `_read` runs
+        # `validate_connectors` and returns None on any error. The AGENT half
+        # has no such path: the name arrives on the boot env, is never validated
+        # in this module, and goes straight into the comprehension above, where
+        # `object_name` fails closed on a name that forges its `-mcp-` join
+        # (#1446). Uncaught, that crashes the boot -- and a crashed boot loses
+        # the whole session, for every turn, until someone reads a stack trace
+        # out of a sandbox pod's logs. Mounting nothing costs the agent this
+        # connector's tools, which is visible in its tool list and fixed by
+        # recreating the agent under a non-forging name.
+        #
+        # Narrow on purpose: `AmbiguousObjectName`, never a bare `ValueError`.
+        # Widening it would turn an unrelated programming error into a silent
+        # "mounted no connectors", which is the exact class of silent failure
+        # #1446 is about.
+        logger.warning(
+            "agent name %r forges the connector object-name join, mounting no connectors: %s",
+            agent,
+            exc,
+        )
+        return {}
 
 
 def build_mcp_servers(platform: dict[str, Any], derived: dict[str, Any]) -> dict[str, Any]:

--- a/runner/tests/test_connectors.py
+++ b/runner/tests/test_connectors.py
@@ -7,6 +7,7 @@ URL the agent dials is the one the Service actually has.
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 
 from aci_protocol import BootEnv, Budget
@@ -360,3 +361,73 @@ def test_the_reserved_list_matches_the_runner_constants() -> None:
     # never the reverse. This is the pin that keeps the copy honest: rename
     # either constant here and the deploy-time guard stops fencing it.
     assert RESERVED_CONNECTOR_NAMES == {APPROVAL_SERVER_NAME, STATE_SERVER_NAME}
+
+
+# --------------------------------------------------------------------------- #
+# An agent name that forges the object-name join -- #1446
+#
+# `mcp_entry` derives the URL through `object_name`, which builds
+# `{release}-{agent}-mcp-{connector}`. Since #1446 that function fails closed on
+# an agent name that would forge a SECOND `-mcp-` (it contains the delimiter, or
+# it ends in `-mcp`), because two different `(agent, connector)` pairs would
+# otherwise render one Service, one Deployment, both NetworkPolicies and one
+# `app.kubernetes.io/name` pod selector -- and the connector is unauthenticated
+# by design (ADR-0086), so that name is the only thing binding a sandbox to a
+# credential.
+#
+# The connector-name half of that rule is already fail-soft here: `_read` runs
+# `validate_connectors` and returns None on any error, so a forging CONNECTOR
+# name logs and mounts nothing. The AGENT name has no such path -- it arrives on
+# the boot env, is never validated in this module, and goes straight into the
+# `mcp_entry` comprehension in `derive_mcp_servers`. An uncaught raise there
+# contradicts this module's own documented contract (see `_read`): "Log and
+# mount nothing rather than fail the turn ... a crashed boot loses the whole
+# session." Losing the connector's tools is visible in the agent's tool list and
+# recoverable by renaming the agent; losing the boot is the entire session, for
+# every turn, until someone reads a stack trace out of a sandbox pod's logs.
+# --------------------------------------------------------------------------- #
+FORGING_AGENT = "a-mcp-b"
+
+
+def test_a_forging_agent_name_mounts_nothing_rather_than_crashing_the_boot(
+    tmp_path: Path, caplog
+) -> None:
+    root = _bundle(tmp_path, HOSTED)
+
+    with caplog.at_level(logging.WARNING, logger="curie_runner.connectors"):
+        servers = derive_mcp_servers(
+            root, release="curie", agent=FORGING_AGENT, namespace="curie"
+        )
+
+    assert servers == {}, f"a forging agent name must mount nothing, got {servers}"
+    # Silence would be worse than the crash it replaces: the agent boots, its
+    # tool list is quietly short one connector, and every tool call fails as
+    # "no such tool" with nothing anywhere naming the cause. The warning must
+    # carry the AGENT NAME, because that is the single thing an operator has to
+    # change and it is assigned at deploy time, not written in the bundle.
+    assert any(
+        FORGING_AGENT in record.getMessage() for record in caplog.records
+    ), caplog.text
+
+    # The control, in the same test on purpose: if `_bundle`, `HOSTED`, or
+    # `derive_mcp_servers` broke for any reason unrelated to #1446, the
+    # assertion above would pass vacuously on an empty dict. Same bundle, same
+    # release, same namespace -- only the agent name differs.
+    assert derive_mcp_servers(root, **SCOPE)["grafana"]["url"] == (
+        "http://curie-acme-dev-mcp-grafana.curie.svc.cluster.local:8000/mcp"
+    )
+
+
+def test_an_agent_name_that_only_looks_like_the_join_still_mounts(tmp_path: Path) -> None:
+    # A LEADING `mcp-` on the agent side is unambiguous -- the only alternative
+    # split of `curie-mcp-x-mcp-grafana` leaves an empty agent -- so it must
+    # keep working. This is the test that reddens if someone "simplifies" the
+    # rule to a bare `'-mcp-' in name` substring ban or a
+    # `base.count('-mcp-') == 1` guard: both over-reject, and an over-rejecting
+    # rule silently strips a live agent of its connectors for no security gain.
+    servers = derive_mcp_servers(
+        _bundle(tmp_path, HOSTED), release="curie", agent="mcp-x", namespace="curie"
+    )
+    assert servers["grafana"]["url"] == (
+        "http://curie-mcp-x-mcp-grafana.curie.svc.cluster.local:8000/mcp"
+    )


### PR DESCRIPTION
## Summary

`object_name()` joined the agent and the connector with a literal `-mcp-`, which is a bare substring
inside one DNS label rather than a structural separator, so the join point was not recoverable from
the rendered name. Two different `(agent, connector)` tuples rendered byte-identical objects — and
because the same string feeds `app.kubernetes.io/name`, it was a **pod-selector** collision too, not
just a name clash at apply time. The connector is deliberately unauthenticated (ADR-0086), so the
object name is the only thing binding a sandbox to a credential: the loser of the collision had its
Service, Deployment and both NetworkPolicies overwritten, and its sandbox then resolved the winner's
Service holding the wrong credential, with nothing logged.

**The issue's own suggested fix does not close it.** Banning the substring `-mcp-` in both name
validators misses this pair, verified by execution:

```
agent='x-mcp' connector='c'      ->  curie-x-mcp-mcp-c
agent='x'     connector='mcp-c'  ->  curie-x-mcp-mcp-c
'-mcp-' in 'x-mcp' == False ;  '-mcp-' in 'mcp-c' == False
```

The real property is that a name *forges a second occurrence of the join* once the join is
performed. That rule is per-side and asymmetric, because each side abuts a different half of the
delimiter:

```python
agent forges      iff  "-mcp-" in f"{agent}-"      # contains it, or ends "-mcp"
connector forges  iff  "-mcp-" in f"-{connector}"  # contains it, or starts "mcp-"
```

The rule is **sound, not exact**: under the 40-character name cap it can refuse a name whose only
alternative split would need a partner longer than the cap. It never *misses* a collision — that is
the security property — but it may over-refuse, and it says why when it does.

`object_name` now fails closed with `AmbiguousObjectName`, stated once and imported everywhere;
`validate_connectors` and `validate_deploy_targets` refuse at bundle-validation time with an
actionable message. The two live consumers **contain** the new exception rather than inherit a new
crash: the connectors endpoint answers 422 naming the agent instead of an opaque 500, and the runner
degrades to "log and mount nothing" exactly as it already does for an unreadable `connectors.yaml`
(a crashed boot loses the whole session). `AgentCreate.name` gains a validator for the same shape,
because `POST /agents` is the one path into the collision that bundle validation never sees.

The connector guard applies only to **hosted** connectors: a remote (`url:`) connector derives no
Kubernetes object name at all, so refusing its name would break a valid bundle for a collision it
cannot cause. `deploy.ambiguous_agent_name` stays unconditional — an agent name is durable platform
identity (ADR-0089) that feeds `object_name` for every hosted connector the agent will ever declare.

Every name that renders today still renders **byte-identically**, so no live object is renamed on
upgrade (#1116's "stable and derivable" contract), pinned by a test.

## Related issue

Closes #1446

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | **Required** | Reaches bundle packaging/validation (`connectors.yaml`, `deploy.yaml`) and the runner turn loop (`derive_mcp_servers`). | fake | `CURIE_E2E_IMAGE=curie-runner:1446 CURIE_BIN=<built from this tree> bash cli/scripts/e2e.sh` against `6f05b343` → **`E2E PASS`, exit 0**. Real runner container built from this tree booted, took a turn, ran `skill eval` (`plumbing_ok=1`, `bundle_digest 0cbe8fa7…`), re-upped on a mutated source with a new digest, and tore down clean. **Falsifiable negative, same CLI surface:** `curie skill check` on a bundle whose hosted connector is named `mcp-grafana` → `verdict: invalid_bundle`, `[connectors.ambiguous_name] … rename the connector so it does not start with 'mcp-' or contain '-mcp-'`; the *same* connector renamed `grafana` → `verdict: green`. |
| local | **Required — PROVED IN CI** | Reaches API wiring (new 422 on `GET /agents/{id}/versions/{vid}/connectors`, new `AgentCreate.name` validator). | fake | **CI ran the rung against this branch: `E2E parity ladder (skill + local, fake model)` — SUCCESS** ([job](https://github.com/curie-eng/curie/actions/runs/33252759764/job/99101302384)), i.e. `CURIE_E2E_TIERS=skill,local curie dev e2e-ladder` end to end: `local up` → `local deploy` → `local message` → `local down`. **The hands-on local pass AGENTS.md asks for on top of CI was not run on this box** — `cli/src/local.rs` pins `COMPOSE_PROJECT_NAME=curie` globally, so `curie local up/down` owns one shared stack, and 7 other bonus jobs were active against that same Postgres; the rung would have migrated and torn it down under them (the documented `Can't locate revision identified by '0024'` failure). Not run rather than corrupt concurrent work. **Second independent path meanwhile:** HTTP-level tests through the real FastAPI app against the real Postgres — `test_agents.py::test_agent_name_forging_the_connector_join_is_422` (422, `loc` names `name`) and `test_bundle_connectors.py::test_a_stored_forging_agent_name_is_a_422_not_a_500`. **To repeat by hand on a quiet box:** `CURIE_E2E_TIERS=local curie dev e2e-ladder`. |
| local-release | n/a | No released binary or image identity, install path, version pin, or release compose is touched. | — | — |
| cluster | n/a (CI ran it anyway, SUCCESS) | No chart template, RBAC, securityContext, NetworkPolicy shape, sandbox claim or init container changes. For every **accepted** `(agent, connector)` the rendered objects are byte-identical to before (pinned by `test_allowed_names_render_exactly_the_name_they_render_today`); the diff only adds a refusal, and a refused bundle never reaches a cluster. | — | CI's `E2E parity ladder (cluster rung on kind, fake model)` and `(local-release, fake model)` both passed on this branch, which is corroboration rather than a required tier. |
| live provider | n/a | No model routing, credential resolution, provider auth, or token/cost accounting. Connector secrets are still referenced by name only; nothing in the credential chain changed. | — | — |
| external integration | n/a | No Slack, git webhook, connector OAuth, or third-party API shape. | — | — |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved: `skill` was run here and `local` was proved by CI's ladder on this branch. The **hands-on** local pass is the one thing outstanding, and the table names its blocker.
- [ ] Or: this change is not behavior-bearing — does not apply.

### Acceptance criteria

- **AC1** — `render()` refuses both halves of the issue's exact pair, and validation refuses each bundle naming the reason. Positive: `test_the_issue_pair_cannot_render_the_same_objects`. Negative: the substring-ban blind spot is pinned separately by `test_a_substring_ban_would_miss_this_pair`.
- **AC2** — negative mutation: neutering both predicates to `return False` (the effective revert) turns **32 tests red**; restored byte-identical afterwards. The "allowed names still render" tests correctly stay green under that mutation, so they are not vacuous.
- **AC3** — covered across all four kinds by `test_every_rendered_object_kind_is_refused`, which also asserts the exact `{Service, Deployment, NetworkPolicy -allow, NetworkPolicy -allow-ingress}` set so a future change that drops an object is caught here too.

### Checks

`packages/plugin-format` + `runner`: 976 passed, 4 skipped. `apps/api`: 1152 passed, 10 skipped, 1
failed — `test_control_integration.py::test_cost_composes_metrics_for_the_agent`, an
`httpx.ConnectError` that **reproduces identically on pristine `origin/main`** (the shared Langfuse
stack was taken down by another job mid-run). `ruff check` clean; `mypy` clean (98 files);
`curie dev docs-lint` exit 0. No schema regeneration and no `PROTOCOL_VERSION` bump: the name rules
live only in Python validator code, not in the committed JSON Schema (`tests/test_schema_compat.py`
is the gate that proves it), and `packages/aci-protocol` is untouched.

## Operator note

An **existing** agent whose stored name forges the join (for example `grafana-mcp`) will now get a
422 from the connectors endpoint and mount no connectors — deliberately, since it was previously at
risk of being handed another agent's credential. There is no rename remedy: `AgentUpdate` carries no
`name` field, so the agent must be recreated under a non-forging name. Detect before upgrading:

```sql
SELECT id, name FROM agents WHERE name LIKE '%-mcp-%' OR name LIKE '%-mcp';
```

## Follow-ups (deliberately out of scope)

1. **`object_name`'s digest truncation still collides** — separate, pre-existing mechanism from
   #1116, untouched by this PR. Above 63 characters the name truncates with 8 hex chars of sha256
   (32 bits), so accepted distinct tuples collide by birthday search. Reproduced: release `r`×40,
   connector `c`, agents `aaaaaaaaaaaaa000000000000000000000001ghl` and
   `aaaaaaaaaaaaa000000000000000000000002313` both render
   `rrrr…rrrr-aaaaaaaaaaaaa-348ed9e3`. Widening `_DIGEST_LEN` **renames every currently-truncated
   live object**, which is exactly the churn this PR avoids — a maintainer decision, not a patch-release change.
2. **`AgentCreate.name` has no general shape validation** — it still accepts spaces, uppercase and
   200-character names. This PR adds only the delimiter-forging check; the broader gap predates it.
3. **The CLI does not validate `--agent <name>` locally.** The rule lives once in `plugin-format`
   and the API imports it, and the CLI derives no object names itself (`cli/src/connectors.rs::object_names`
   only reads what the API rendered), so there is no sibling copy to drift — but the CLI/API
   validation seam named in AGENTS.md is one-sided here.
4. **No supported agent rename**, per the operator note above.

## Checklist

- [x] Tests pass for the area I touched.
- [x] Docs updated: `docs/interfaces/bundle-format/INTERFACE.md` gains both new error codes with their exact rules and the hosted-only scope.
- [x] No ADR needed — this implements an existing decision (ADR-0086) rather than making a new one.
