### PR TITLE
curie doctor: target every fix, preserve the egress allowlist, and stop conflating three probe outcomes

### DIFF
--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -5563,22 +5563,16 @@ export const commandManifest = {
       "about": "Report what is set up, what is missing, and the command that fixes it",
       "args": [
         {
-          "default_values": [
-            "curie"
-          ],
           "global": false,
-          "help": "Kubernetes namespace to inspect",
+          "help": "Kubernetes namespace to inspect. Defaults to `curie.yaml`'s `install:` block when one is present in this directory, otherwise `curie`",
           "id": "namespace",
           "long": "namespace",
           "positional": false,
           "required": false
         },
         {
-          "default_values": [
-            "curie"
-          ],
           "global": false,
-          "help": "Helm release to inspect",
+          "help": "Helm release to inspect. Defaults to `curie.yaml`'s `install:` block when one is present in this directory, otherwise `curie`",
           "id": "release",
           "long": "release",
           "positional": false,

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -5560,22 +5560,16 @@
       "about": "Report what is set up, what is missing, and the command that fixes it",
       "args": [
         {
-          "default_values": [
-            "curie"
-          ],
           "global": false,
-          "help": "Kubernetes namespace to inspect",
+          "help": "Kubernetes namespace to inspect. Defaults to `curie.yaml`'s `install:` block when one is present in this directory, otherwise `curie`",
           "id": "namespace",
           "long": "namespace",
           "positional": false,
           "required": false
         },
         {
-          "default_values": [
-            "curie"
-          ],
           "global": false,
-          "help": "Helm release to inspect",
+          "help": "Helm release to inspect. Defaults to `curie.yaml`'s `install:` block when one is present in this directory, otherwise `curie`",
           "id": "release",
           "long": "release",
           "positional": false,

--- a/cli/src/doctor.rs
+++ b/cli/src/doctor.rs
@@ -799,6 +799,9 @@ pub fn summary(checks: &[Check]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ui::CliOutput;
+    use serde_json::json;
+    use std::collections::BTreeSet;
 
     fn laptop() -> Facts {
         Facts {
@@ -909,17 +912,28 @@ mod tests {
         );
     }
 
-    /// Cluster, release, Slack and clone credential all in place.
+    /// Cluster, release, Slack and clone credential all in place. The target is
+    /// `acme/acme` rather than the default, so a fix string that hardcodes
+    /// `curie` is visible to every test built on this fixture.
     fn wired() -> Facts {
         Facts {
             model_credential: Some("CURIE_CREDENTIALS".into()),
             kube_context: Some("minikube".into()),
-            release: Some(("acme".into(), "curie-0.6.0".into())),
-            slack_configured: true,
+            target: Some(("acme".into(), "acme".into())),
+            release: ReleaseProbe::Installed {
+                chart: "curie-0.6.0".into(),
+            },
+            slack_app_token: true,
+            slack_bot_token: true,
             clone_credential: Some("github app".into()),
             api_exposure: Some("NodePort 30799".into()),
             ..laptop()
         }
+    }
+
+    /// `wired()` with one release probe outcome swapped in, for the D5 matrix.
+    fn probed(release: ReleaseProbe) -> Facts {
+        Facts { release, ..wired() }
     }
 
     fn find<'a>(checks: &'a [Check], id: &str) -> &'a Check {
@@ -929,6 +943,19 @@ mod tests {
     /// The one check this issue is about, pulled out of a full `evaluate`.
     fn model_pin(f: &Facts) -> Check {
         find(&evaluate(f), "model-pin").clone()
+    }
+
+    /// The set of check ids whose fix is a `curie cluster ...` command.
+    fn cluster_fix_ids(checks: &[Check]) -> BTreeSet<&'static str> {
+        checks
+            .iter()
+            .filter(|c| {
+                c.fix
+                    .as_deref()
+                    .is_some_and(|f| f.starts_with("curie cluster "))
+            })
+            .map(|c| c.id)
+            .collect()
     }
 
     /// The laptop rung is a complete way to use Curie. Reporting five failures
@@ -974,7 +1001,8 @@ mod tests {
             model_credential_source: Some("environment".into()),
             model_credential_provider: crate::ops::provider_from_credential_prefix(credential),
             clone_credential: Some("github app (app_id=4475970)".into()),
-            slack_configured: true,
+            slack_app_token: true,
+            slack_bot_token: true,
             ..laptop()
         };
         let rendered = format!("{:?}", evaluate(&f));
@@ -993,6 +1021,12 @@ mod tests {
 
     /// Each rung's summary has to say what you can DO, not how many checks
     /// passed -- a count tells an operator nothing about where they are.
+    ///
+    /// The rungs below name `curie/acme`: these fixtures only ever set the
+    /// release, so the namespace half was the rendering default, and the pair
+    /// is carried over verbatim rather than tidied to `acme/acme` -- nothing
+    /// here reads a target, and a fixture edit is not the place to change what
+    /// a fix string would print.
     #[test]
     fn the_summary_reports_capability_at_each_rung() {
         let cases = [
@@ -1009,7 +1043,10 @@ mod tests {
                 Facts {
                     model_credential: Some("CURIE_CREDENTIALS".into()),
                     kube_context: Some("minikube".into()),
-                    release: Some(("acme".into(), "curie-0.6.0".into())),
+                    target: Some(("curie".into(), "acme".into())),
+                    release: ReleaseProbe::Installed {
+                        chart: "curie-0.6.0".into(),
+                    },
                     ..laptop()
                 },
                 "Slack is not wired",
@@ -1018,8 +1055,12 @@ mod tests {
                 Facts {
                     model_credential: Some("CURIE_CREDENTIALS".into()),
                     kube_context: Some("minikube".into()),
-                    release: Some(("acme".into(), "curie-0.6.0".into())),
-                    slack_configured: true,
+                    target: Some(("curie".into(), "acme".into())),
+                    release: ReleaseProbe::Installed {
+                        chart: "curie-0.6.0".into(),
+                    },
+                    slack_app_token: true,
+                    slack_bot_token: true,
                     ..laptop()
                 },
                 "Git-push deploys are not wired",
@@ -1028,8 +1069,12 @@ mod tests {
                 Facts {
                     model_credential: Some("CURIE_CREDENTIALS".into()),
                     kube_context: Some("minikube".into()),
-                    release: Some(("acme".into(), "curie-0.6.0".into())),
-                    slack_configured: true,
+                    target: Some(("curie".into(), "acme".into())),
+                    release: ReleaseProbe::Installed {
+                        chart: "curie-0.6.0".into(),
+                    },
+                    slack_app_token: true,
+                    slack_bot_token: true,
                     clone_credential: Some("github app".into()),
                     api_exposure: Some("NodePort 30799".into()),
                     agents: Some(vec![("bot".into(), Some("acme/bot".into()))]),
@@ -2056,10 +2101,21 @@ mod tests {
     }
 
     /// Every failing check must be actionable. A report that says "missing"
-    /// without saying what to run is the checklist problem restated.
+    /// without saying what to run is the checklist problem restated. The four
+    /// `ReleaseProbe` outcomes are included because #1261's rule -- no `missing`
+    /// without a `fix` -- covers the states D5 introduces too.
     #[test]
     fn every_missing_check_carries_a_command() {
-        let facts = [Facts::default(), laptop()];
+        let facts = vec![
+            Facts::default(),
+            laptop(),
+            probed(ReleaseProbe::HelmMissing),
+            probed(ReleaseProbe::ProbeFailed),
+            probed(ReleaseProbe::NotInstalled),
+            probed(ReleaseProbe::Installed {
+                chart: "curie-0.7.0".into(),
+            }),
+        ];
         for f in facts {
             for c in evaluate(&f).iter().filter(|c| c.state == State::Missing) {
                 let fix = c.fix.as_deref().unwrap_or("");
@@ -2180,8 +2236,12 @@ mod tests {
         let f = Facts {
             model_credential: Some("CURIE_CREDENTIALS".into()),
             kube_context: Some("default".into()),
-            release: Some(("sre-bot".into(), "curie-0.6.0".into())),
-            slack_configured: true,
+            target: Some(("sre-bot".into(), "sre-bot".into())),
+            release: ReleaseProbe::Installed {
+                chart: "curie-0.6.0".into(),
+            },
+            slack_app_token: true,
+            slack_bot_token: true,
             clone_credential: Some("github app".into()),
             api_exposure: Some("NodePort 30799".into()),
             agents: Some(vec![("sre-bot".into(), Some("acme/sre-bot".into()))]),
@@ -2201,12 +2261,9 @@ mod tests {
     #[test]
     fn no_known_exposure_is_hedged_not_asserted() {
         let f = Facts {
-            model_credential: Some("CURIE_CREDENTIALS".into()),
-            kube_context: Some("minikube".into()),
-            release: Some(("acme".into(), "curie-0.6.0".into())),
-            slack_configured: true,
+            api_exposure: None,
             clone_credential: Some("pat".into()),
-            ..laptop()
+            ..wired()
         };
         let c = find(&evaluate(&f), "webhook").clone();
         assert_eq!(c.state, State::Missing);
@@ -2220,8 +2277,12 @@ mod tests {
         let f = Facts {
             model_credential: Some("CURIE_CREDENTIALS".into()),
             kube_context: Some("minikube".into()),
-            release: Some(("acme".into(), "curie-0.6.0".into())),
-            slack_configured: true,
+            target: Some(("acme".into(), "acme".into())),
+            release: ReleaseProbe::Installed {
+                chart: "curie-0.6.0".into(),
+            },
+            slack_app_token: true,
+            slack_bot_token: true,
             ..laptop()
         };
         let checks = evaluate(&f);
@@ -2338,6 +2399,10 @@ esac
     /// default the operator never supplied is visible at all.
     const HELM_STUB: &str = r#"#!/bin/sh
 case "$*" in
+  # `gather()` asks whether helm exists at all before it asks what is
+  # installed, so that "no helm" and "helm could not answer" stay distinct
+  # states rather than one absence claim (#1358). A real helm answers this.
+  version*) printf 'v3.14.0+gstub\n' ;;
   list*) printf '%s\n' "$CURIE_TEST_DOCTOR_HELM_LIST" ;;
   *"--all"*) printf '%s\n' "$CURIE_TEST_DOCTOR_HELM_COMPUTED" ;;
   "get values"*) printf '%s\n' "$CURIE_TEST_DOCTOR_HELM_VALUES" ;;
@@ -2443,9 +2508,15 @@ esac
 
         let f = gather("ns", "rel", None).await;
 
+        // `Installed` alone proves the stub's `rel` entry was matched:
+        // `classify_release_probe` finds the release BY NAME, so the name half
+        // of the pair this assertion used to carry is structural here rather
+        // than dropped (#1358).
         assert_eq!(
             f.release,
-            Some(("rel".to_string(), "curie-0.6.0".to_string())),
+            ReleaseProbe::Installed {
+                chart: "curie-0.6.0".to_string()
+            },
             "the stubbed release was never read, so gather() bailed out before \
              the model reads and the assertions below are judging nothing"
         );
@@ -2481,9 +2552,15 @@ esac
 
         let f = gather("ns", "rel", None).await;
 
+        // `Installed` alone proves the stub's `rel` entry was matched:
+        // `classify_release_probe` finds the release BY NAME, so the name half
+        // of the pair this assertion used to carry is structural here rather
+        // than dropped (#1358).
         assert_eq!(
             f.release,
-            Some(("rel".to_string(), "curie-0.6.0".to_string())),
+            ReleaseProbe::Installed {
+                chart: "curie-0.6.0".to_string()
+            },
             "the stubbed release was never read, so gather() bailed out before \
              the model reads and the assertions below are judging nothing"
         );
@@ -2500,6 +2577,1141 @@ esac
             "the fix string is built from this key, and `--set \
              agentSandbox.runner.model=` on a --local-model install changes nothing"
         );
+    }
+
+    // -- D1: every cluster fix names the invoked target ----------------------
+
+    /// The fix strings were pasted verbatim with `<ns>`/`<name>` placeholders or
+    /// no target at all, so an operator running doctor against `acme/acme` was
+    /// handed commands that would act on `curie/curie` -- a different release,
+    /// silently. Two fixtures because the two fix populations are DISJOINT:
+    /// `NotInstalled` short-circuits the four downstream checks, and `Installed`
+    /// never produces the missing-release recovery. Asserting the exact id set
+    /// (not "whatever fixes exist are targeted") is what keeps this honest: a
+    /// fix that stops being produced fails here rather than passing vacuously.
+    #[test]
+    fn every_cluster_fix_names_the_invoked_target() {
+        assert_targeted_fix_sets("acme", "acme");
+    }
+
+    /// The same two fixtures on the DEFAULT target. Emission is unconditional by
+    /// decision: making it conditional would couple doctor's defaults to
+    /// `cluster up`'s defaults, which is the exact assumption class that
+    /// produced this bug. Without this test the obvious "only print it when it
+    /// differs" shortcut passes.
+    #[test]
+    fn the_target_is_emitted_even_when_it_equals_the_default() {
+        assert_targeted_fix_sets("curie", "curie");
+    }
+
+    fn assert_targeted_fix_sets(namespace: &str, release: &str) {
+        // Fixture A: no release yet. Only the missing-release recovery fires.
+        let absent = Facts {
+            target: Some((namespace.into(), release.into())),
+            release: ReleaseProbe::NotInstalled,
+            ..wired()
+        };
+        let checks = evaluate(&absent);
+        assert_eq!(
+            cluster_fix_ids(&checks),
+            BTreeSet::from(["release"]),
+            "an absent release produces exactly the recovery fix: {checks:?}"
+        );
+        assert_each_fix_targets(&checks, namespace, release);
+
+        // Fixture B: a release IS installed, and every downstream check is in
+        // its Missing state, so all four of the other cluster fixes fire.
+        let installed = Facts {
+            target: Some((namespace.into(), release.into())),
+            release: ReleaseProbe::Installed {
+                chart: "curie-0.7.0".into(),
+            },
+            slack_app_token: false,
+            slack_bot_token: false,
+            clone_credential: None,
+            api_exposure: None,
+            agents: Some(vec![("bot".into(), None)]),
+            ..wired()
+        };
+        let checks = evaluate(&installed);
+        assert_eq!(
+            cluster_fix_ids(&checks),
+            BTreeSet::from(["clone-credential", "repo-binding", "slack", "webhook"]),
+            "an installed release produces exactly the four downstream fixes: {checks:?}"
+        );
+        assert_each_fix_targets(&checks, namespace, release);
+    }
+
+    fn assert_each_fix_targets(checks: &[Check], namespace: &str, release: &str) {
+        for c in checks.iter().filter(|c| {
+            c.fix
+                .as_deref()
+                .is_some_and(|f| f.starts_with("curie cluster "))
+        }) {
+            let fix = c.fix.as_deref().expect("filtered on having a fix");
+            assert!(
+                fix.contains(&format!("--namespace {namespace}")),
+                "{} must name the namespace doctor was invoked with: {fix}",
+                c.id
+            );
+            assert!(
+                fix.contains(&format!("--release {release}")),
+                "{} must name the release doctor was invoked with: {fix}",
+                c.id
+            );
+        }
+    }
+
+    /// A fixture that never exercised targeting carries no target, and a fix
+    /// rendered as `--namespace  --release ` is not runnable. The rendering
+    /// fallback is `curie`; resolution itself lives in `resolve_target`.
+    #[test]
+    fn an_untargeted_fixture_still_renders_a_runnable_fix() {
+        let f = Facts {
+            target: None,
+            release: ReleaseProbe::NotInstalled,
+            ..wired()
+        };
+        let fix = find(&evaluate(&f), "release")
+            .fix
+            .clone()
+            .expect("a missing release must offer a recovery command");
+        assert!(
+            fix.contains("--namespace curie --release curie"),
+            "an empty target must render as the default, not as blanks: {fix}"
+        );
+    }
+
+    // -- D2: the webhook fix reproduces the allowlist, or refuses -------------
+
+    fn webhook_facts(cidrs: &[&str], reproducible: bool) -> Facts {
+        Facts {
+            api_exposure: None,
+            sandbox_egress_cidrs: cidrs.iter().map(|c| (*c).to_string()).collect(),
+            sandbox_egress_is_reproducible: reproducible,
+            ..wired()
+        }
+    }
+
+    fn webhook_fix(f: &Facts) -> String {
+        find(&evaluate(f), "webhook")
+            .fix
+            .clone()
+            .expect("an unexposed API must offer a fix")
+    }
+
+    /// `cluster up` is a full upgrade: a value nothing re-supplies is dropped.
+    /// The webhook fix used to supply only the two ingress `--set`s, so an
+    /// operator who followed doctor's advice sealed the sandbox's egress
+    /// allowlist and broke the model path on a release that had been working.
+    #[test]
+    fn the_webhook_fix_resupplies_a_reproducible_egress_allowlist() {
+        let f = webhook_facts(&["160.79.104.0/23", "192.0.2.0/24"], true);
+        let fix = webhook_fix(&f);
+        let first = fix
+            .find("--allow-web-egress 160.79.104.0/23")
+            .unwrap_or_else(|| panic!("the first recorded CIDR must be re-supplied: {fix}"));
+        let second = fix
+            .find("--allow-web-egress 192.0.2.0/24")
+            .unwrap_or_else(|| panic!("the second recorded CIDR must be re-supplied: {fix}"));
+        assert!(
+            first < second,
+            "the allowlist must be re-supplied in recorded order: {fix}"
+        );
+        assert!(
+            !fix.contains("--allow-egress-host"),
+            "a CIDR read back off a release cannot be reversed to a provider \
+             name, and ADR-0114 errors when an explicit provider list omits the \
+             detected one: {fix}"
+        );
+    }
+
+    /// Nothing recorded means nothing to preserve. An implementation that
+    /// always appends the flag would emit `--allow-web-egress` with no value.
+    #[test]
+    fn an_empty_allowlist_adds_no_egress_flags() {
+        let fix = webhook_fix(&webhook_facts(&[], true));
+        assert!(
+            !fix.contains("--allow-web-egress"),
+            "an empty allowlist has nothing to re-supply: {fix}"
+        );
+        assert!(
+            !fix.contains("WARNING"),
+            "an empty allowlist is trivially reproducible, so there is no hazard \
+             to warn about: {fix}"
+        );
+    }
+
+    /// The key negative. `up_value_plan` rewrites every supplied entry as
+    /// TCP/443, so a UDP or port-53 rule cannot be reproduced by either flag,
+    /// and a capped list drops entries outright -- both NARROW a live
+    /// NetworkPolicy. A caveat is read after the policy is already broken, so
+    /// the only safe direction is to emit nothing. A caveat-based design would
+    /// have PASSED a test that only checked for a warning.
+    #[test]
+    fn a_non_reproducible_allowlist_emits_no_egress_flags() {
+        let owned: Vec<String> = (0..11).map(|i| format!("192.0.2.{i}/32")).collect();
+        let eleven: Vec<&str> = owned.iter().map(String::as_str).collect();
+        let cases = [
+            // (a) a rule that is not TCP/443 -- reproducing it would coerce it.
+            (vec!["192.0.2.0/24"], "a non-TCP/443 rule"),
+            // (b) more entries than the readability bound -- which must never
+            // silently truncate.
+            (eleven, "an eleven-entry allowlist"),
+        ];
+        for (cidrs, what) in cases {
+            let fix = webhook_fix(&webhook_facts(&cidrs, false));
+            assert_eq!(
+                fix.matches("--allow-web-egress").count(),
+                0,
+                "{what} must emit ZERO egress flags rather than a lossy subset: {fix}"
+            );
+            assert!(
+                fix.contains("WARNING"),
+                "{what} must name the hazard: {fix}"
+            );
+            assert!(
+                fix.contains("helm get values"),
+                "{what} must point at the recorded policy: {fix}"
+            );
+        }
+    }
+
+    /// Every shape `security.networkPolicy.allowedEgress` can take, and the one
+    /// bit that decides whether the webhook fix may re-supply it.
+    ///
+    /// `up_value_plan` coerces every supplied entry to exactly one TCP/443 port
+    /// rule, so anything else on the release cannot be reproduced by
+    /// `--allow-web-egress`; the count bound is readability only and flips the
+    /// gate rather than truncating. An unreadable ENTRY is not skipped either --
+    /// skipping one would hand the operator a `cluster up` carrying fewer CIDRs
+    /// than the release records, which is D2 wearing a different hat.
+    #[test]
+    fn sandbox_egress_faithfulness_rule() {
+        let tcp443 = || json!([{"protocol": "TCP", "port": 443}]);
+        let policy = |entries: serde_json::Value| json!({"security": {"networkPolicy": {"allowedEgress": entries}}});
+        let cidrs_of =
+            |n: u64| -> Vec<String> { (0..n).map(|i| format!("192.0.2.{i}/32")).collect() };
+        let entries_of = |n: u64| -> serde_json::Value {
+            serde_json::Value::Array(
+                cidrs_of(n)
+                    .into_iter()
+                    .map(|cidr| json!({"cidr": cidr, "ports": tcp443()}))
+                    .collect(),
+            )
+        };
+
+        let reproducible: Vec<(&str, serde_json::Value, Vec<String>)> = vec![
+            (
+                "one plain HTTPS entry",
+                policy(json!([{"cidr": "160.79.104.0/23", "ports": tcp443()}])),
+                vec!["160.79.104.0/23".to_string()],
+            ),
+            (
+                "a string-typed port, which a values file produces",
+                policy(json!([{"cidr": "160.79.104.0/23",
+                               "ports": [{"protocol": "TCP", "port": "443"}]}])),
+                vec!["160.79.104.0/23".to_string()],
+            ),
+            (
+                "a lower-case protocol, which a values file also produces",
+                policy(json!([{"cidr": "160.79.104.0/23",
+                               "ports": [{"protocol": "tcp", "port": 443}]}])),
+                vec!["160.79.104.0/23".to_string()],
+            ),
+            ("an empty allowlist", policy(json!([])), vec![]),
+            (
+                "ten entries -- the readability bound is inclusive",
+                policy(entries_of(10)),
+                cidrs_of(10),
+            ),
+            // No policy recorded at all is not a lossy read: emitting no flags
+            // reproduces "nothing" exactly, so the gate stays open. Otherwise
+            // every release without an allowlist would carry the hazard clause.
+            (
+                "no allowedEgress key at all",
+                json!({"security": {"networkPolicy": {}}}),
+                vec![],
+            ),
+            (
+                "an explicitly null allowedEgress",
+                policy(serde_json::Value::Null),
+                vec![],
+            ),
+            ("no security block at all", json!({}), vec![]),
+        ];
+        for (what, values, expected) in reproducible {
+            let (cidrs, ok) = sandbox_egress_from_values(&values);
+            assert_eq!(cidrs, expected, "{what}: recorded order and content");
+            assert!(ok, "{what} must be reproducible");
+        }
+
+        let not_reproducible: Vec<(&str, serde_json::Value)> = vec![
+            (
+                "a UDP rule",
+                policy(json!([{"cidr": "192.0.2.0/24",
+                               "ports": [{"protocol": "UDP", "port": 443}]}])),
+            ),
+            (
+                "a port-53 rule",
+                policy(json!([{"cidr": "192.0.2.0/24",
+                               "ports": [{"protocol": "TCP", "port": 53}]}])),
+            ),
+            (
+                "two port rules on one entry",
+                policy(json!([{"cidr": "192.0.2.0/24",
+                               "ports": [{"protocol": "TCP", "port": 443},
+                                         {"protocol": "TCP", "port": 80}]}])),
+            ),
+            (
+                "an entry with no ports at all",
+                policy(json!([{"cidr": "192.0.2.0/24"}])),
+            ),
+            (
+                "an entry with an empty ports list",
+                policy(json!([{"cidr": "192.0.2.0/24", "ports": []}])),
+            ),
+            (
+                "a port rule with no protocol",
+                policy(json!([{"cidr": "192.0.2.0/24", "ports": [{"port": 443}]}])),
+            ),
+            ("eleven entries", policy(entries_of(11))),
+            // A recorded rule this reader cannot name is still a recorded rule.
+            // Dropping it and calling the rest faithful is the narrowing this
+            // whole gate exists to prevent.
+            (
+                "an entry with no cidr",
+                policy(json!([{"ports": tcp443()}])),
+            ),
+            (
+                "an entry whose cidr is empty after trimming",
+                policy(json!([{"cidr": "   ", "ports": tcp443()}])),
+            ),
+            (
+                "an entry whose cidr is not a scalar",
+                policy(json!([{"cidr": ["192.0.2.0/24"], "ports": tcp443()}])),
+            ),
+            (
+                "one good entry beside one with no cidr",
+                policy(json!([{"cidr": "160.79.104.0/23", "ports": tcp443()},
+                              {"ports": tcp443()}])),
+            ),
+            (
+                "an allowedEgress that is not a list at all",
+                policy(json!("not-a-list")),
+            ),
+            (
+                "an allowedEgress recorded as an object",
+                policy(json!({"cidr": "192.0.2.0/24"})),
+            ),
+        ];
+        for (what, values) in not_reproducible {
+            let (cidrs, ok) = sandbox_egress_from_values(&values);
+            assert!(!ok, "{what} must NOT be reproducible");
+            assert!(
+                cidrs.is_empty(),
+                "{what} must return nothing to re-supply, got {cidrs:?}"
+            );
+        }
+    }
+
+    /// The invariant the whole faithfulness gate rests on, asserted on its own
+    /// so it cannot be lost in a table: **a false gate always returns an empty
+    /// vec.** Any non-empty list beside a false gate is a partial allowlist, and
+    /// a partial allowlist pasted into `cluster up` NARROWS a live NetworkPolicy
+    /// -- the exact failure D2 exists to prevent, reintroduced one entry at a
+    /// time instead of all at once.
+    #[test]
+    fn a_false_egress_gate_never_returns_a_partial_list() {
+        let tcp443 = || json!([{"protocol": "TCP", "port": 443}]);
+        let good = || json!({"cidr": "160.79.104.0/23", "ports": tcp443()});
+        let policy = |entries: serde_json::Value| json!({"security": {"networkPolicy": {"allowedEgress": entries}}});
+        let many: Vec<serde_json::Value> = (0..11)
+            .map(|i| json!({"cidr": format!("192.0.2.{i}/32"), "ports": tcp443()}))
+            .collect();
+
+        // Each case pairs at least one perfectly readable entry with one this
+        // reader cannot reproduce, so an implementation that filters instead of
+        // refusing returns a non-empty -- and lossy -- list.
+        let mixed = [
+            policy(
+                json!([good(), {"cidr": "192.0.2.0/24", "ports": [{"protocol": "UDP", "port": 443}]}]),
+            ),
+            policy(
+                json!([good(), {"cidr": "192.0.2.0/24", "ports": [{"protocol": "TCP", "port": 53}]}]),
+            ),
+            policy(json!([good(), {"cidr": "192.0.2.0/24"}])),
+            policy(json!([good(), {"cidr": "", "ports": tcp443()}])),
+            policy(json!([good(), {"ports": tcp443()}])),
+            policy(serde_json::Value::Array(many)),
+            policy(json!("not-a-list")),
+        ];
+        for values in mixed {
+            let (cidrs, ok) = sandbox_egress_from_values(&values);
+            assert!(!ok, "{values} must not read as reproducible");
+            assert!(
+                cidrs.is_empty(),
+                "a false gate must yield NO cidrs, or the fix emits a narrowed \
+                 allowlist: {cidrs:?} from {values}"
+            );
+        }
+    }
+
+    /// The sibling that must NOT be "fixed" to match. `missing_release_recovery`
+    /// fires only when there is no release, so there is nothing recorded to
+    /// preserve, and its credential-derived `--allow-egress-host` is the right
+    /// flag for a FRESH install (#1813). Rewriting it to use `--allow-web-egress`
+    /// would regress the provider inference that ticket landed.
+    #[test]
+    fn the_missing_release_recovery_keeps_allow_egress_host() {
+        let f = Facts {
+            release: ReleaseProbe::NotInstalled,
+            model_credential_provider: crate::ops::provider_from_credential_prefix(
+                "sk-ant-PLACEHOLDER",
+            ),
+            sandbox_egress_cidrs: vec!["160.79.104.0/23".into()],
+            sandbox_egress_is_reproducible: true,
+            ..wired()
+        };
+        let fix = find(&evaluate(&f), "release")
+            .fix
+            .clone()
+            .expect("a missing release must offer a recovery command");
+        assert!(
+            fix.contains("--allow-egress-host anthropic"),
+            "the fresh-install recovery keeps its provider inference: {fix}"
+        );
+        assert!(
+            !fix.contains("--allow-web-egress"),
+            "there is no recorded policy to preserve on a release that does not \
+             exist: {fix}"
+        );
+    }
+
+    // -- D3: the BYO-Secret clone credential ---------------------------------
+
+    /// The chart calls `githubAppExistingSecret` the RECOMMENDED path, and
+    /// doctor reported an install using it as having no clone credential at all
+    /// -- telling an operator to run `cluster github-app` over a working setup.
+    #[test]
+    fn a_secret_backed_github_app_is_a_clone_credential() {
+        let f = Facts {
+            clone_credential: Some("github app (secret=gh-app)".into()),
+            ..wired()
+        };
+        let c = find(&evaluate(&f), "clone-credential").clone();
+        assert_eq!(c.state, State::Ok);
+        assert!(
+            c.detail.contains("gh-app"),
+            "the Secret must be reported by name: {}",
+            c.detail
+        );
+        assert!(c.fix.is_none(), "a working credential needs no fix");
+    }
+
+    /// The chart template consumes the existing Secret when one is set, so that
+    /// is what the report must name. Reporting both would invite an operator to
+    /// "fix" an install that is already working.
+    #[test]
+    fn clone_credential_prefers_the_existing_secret_over_inline_key_material() {
+        assert_eq!(
+            clone_credential_from_values(&json!({"api": {"githubAppExistingSecret": "gh-app"}})),
+            Some("github app (secret=gh-app)".to_string())
+        );
+        assert_eq!(
+            clone_credential_from_values(&json!({"api": {"githubAppId": "4475970"}})),
+            Some("github app (app_id=4475970)".to_string())
+        );
+        assert_eq!(
+            clone_credential_from_values(&json!({"api": {"githubToken": "ghp_PLACEHOLDER"}})),
+            Some("personal access token".to_string())
+        );
+        assert_eq!(
+            clone_credential_from_values(&json!({"api": {
+                "githubAppExistingSecret": "gh-app",
+                "githubAppId": "4475970"
+            }})),
+            Some("github app (secret=gh-app)".to_string()),
+            "the Secret path is what the chart consumes, so it wins the report"
+        );
+        assert_eq!(
+            clone_credential_from_values(&json!({"api": {}})),
+            None,
+            "nothing recorded is still nothing"
+        );
+    }
+
+    /// Names, never values (#1348). The Secret's KEY name is adjacent in the
+    /// same values block, and reading the wrong field is how key material
+    /// reaches a payload that gets pasted into issues.
+    #[test]
+    fn a_secret_backed_credential_never_reports_key_material() {
+        let values = json!({"api": {
+            "githubAppExistingSecret": "gh-app",
+            "githubAppExistingSecretKey": "private-key.pem"
+        }});
+        let f = Facts {
+            clone_credential: clone_credential_from_values(&values),
+            ..wired()
+        };
+        let detail = find(&evaluate(&f), "clone-credential").detail.clone();
+        assert!(detail.contains("gh-app"), "{detail}");
+        assert!(
+            !detail.contains("private-key.pem"),
+            "the key name is not the Secret name: {detail}"
+        );
+        assert!(!detail.contains("-----BEGIN"), "{detail}");
+    }
+
+    // -- D4: type-tolerant reads ---------------------------------------------
+
+    /// #1253: an unquoted `githubAppId: 4475970` in a values file is a live,
+    /// GitOps-common shape, and a `as_str()`-only read called that install
+    /// credential-less. The scientific-notation form is the same value.
+    #[test]
+    fn a_numeric_app_id_in_a_values_file_is_still_a_clone_credential() {
+        assert_eq!(
+            clone_credential_from_values(&json!({"api": {"githubAppId": 4475970}})),
+            Some("github app (app_id=4475970)".to_string())
+        );
+        assert_eq!(
+            clone_credential_from_values(&json!({"api": {"githubAppId": 4.47597e6}})),
+            Some("github app (app_id=4475970)".to_string()),
+            "an integral float is the same app id, not a new one"
+        );
+    }
+
+    /// The issue's §4 symptom, asserted as the operator sees it: an install
+    /// whose ingress is already on printed `MISS  Webhook exposure`, because
+    /// `--set-string api.ingress.enabled=true` and a quoted values-file entry
+    /// both record a STRING and the read was `as_bool()`-only. Asserted through
+    /// the exposure string and the check state, not through the predicate --
+    /// a truthiness helper can be right while the report is still wrong.
+    #[test]
+    fn a_string_typed_ingress_flag_counts_as_enabled() {
+        let values = json!({"api": {"ingress": {"enabled": "true", "host": "bot.example.com"}}});
+        assert_eq!(
+            api_exposure_from_values(&values, None),
+            Some("ingress (bot.example.com)".to_string()),
+            "a quoted true is how helm --set-string records it"
+        );
+
+        // And the user-visible half: that exposure must land the check on Ok.
+        let f = Facts {
+            api_exposure: api_exposure_from_values(&values, None),
+            ..wired()
+        };
+        let c = find(&evaluate(&f), "webhook").clone();
+        assert_eq!(
+            c.state,
+            State::Ok,
+            "an install with ingress on must not read as MISS: {}",
+            c.detail
+        );
+        assert!(c.detail.contains("bot.example.com"), "{}", c.detail);
+        assert!(c.fix.is_none(), "there is nothing to fix: {:?}", c.fix);
+    }
+
+    /// The rest of the exposure decision, in the one place it is now pure: a
+    /// real bool still works, a host-less ingress keeps its existing wording,
+    /// the NodePort fallback is only consulted when ingress is off, and a value
+    /// that is not truthy must fall through rather than claim an ingress.
+    #[test]
+    fn exposure_falls_back_to_the_nodeport_only_when_ingress_is_off() {
+        let on = json!({"api": {"ingress": {"enabled": true, "host": "bot.example.com"}}});
+        assert_eq!(
+            api_exposure_from_values(&on, Some("30799".to_string())),
+            Some("ingress (bot.example.com)".to_string()),
+            "an enabled ingress wins over a NodePort that also exists"
+        );
+
+        let hostless = json!({"api": {"ingress": {"enabled": true}}});
+        assert_eq!(
+            api_exposure_from_values(&hostless, None),
+            Some("ingress".to_string()),
+            "an ingress with no host keeps its existing wording"
+        );
+
+        let off = json!({"api": {"ingress": {"enabled": false}}});
+        assert_eq!(
+            api_exposure_from_values(&off, Some("30799".to_string())),
+            Some("NodePort 30799".to_string())
+        );
+        assert_eq!(
+            api_exposure_from_values(&off, None),
+            None,
+            "neither mechanism in place is reported as unknown, not as broken"
+        );
+
+        // The negative that matters here: "1" is not the literal true, so it
+        // must NOT be reported as an ingress the operator does not have.
+        let typo = json!({"api": {"ingress": {"enabled": "1", "host": "bot.example.com"}}});
+        assert_eq!(
+            api_exposure_from_values(&typo, None),
+            None,
+            "a value that is not the literal true must not claim an ingress"
+        );
+        assert_eq!(
+            api_exposure_from_values(&typo, Some("30799".to_string())),
+            Some("NodePort 30799".to_string()),
+            "and it falls through to the NodePort read like any other off state"
+        );
+    }
+
+    /// The negative that keeps the widening honest. Treating any non-empty
+    /// string as true would report an install as exposed on a typo -- a
+    /// security-relevant over-claim, in a check whose whole job is to say
+    /// whether the API is reachable from outside.
+    #[test]
+    fn only_a_true_bool_or_the_literal_string_true_enables_ingress() {
+        for enabled in [json!(true), json!("true"), json!("TRUE"), json!(" True ")] {
+            assert!(truthy(Some(&enabled)), "{enabled} must enable ingress");
+        }
+        for disabled in [
+            json!(false),
+            json!("false"),
+            json!("1"),
+            json!("yes"),
+            json!("on"),
+            json!(""),
+            json!(0),
+            json!(1),
+            json!(null),
+            json!([true]),
+            json!({"enabled": true}),
+        ] {
+            assert!(
+                !truthy(Some(&disabled)),
+                "{disabled} must NOT enable ingress"
+            );
+        }
+        assert!(!truthy(None), "an absent flag must not enable ingress");
+    }
+
+    /// The empty-string filter predates the coercion widening and must survive
+    /// it: a chart default of `""` is an unset field, not a credential.
+    #[test]
+    fn an_empty_string_value_is_still_absent() {
+        assert_eq!(
+            scalar_at(
+                &json!({"api": {"githubAppId": ""}}),
+                &["api", "githubAppId"]
+            ),
+            None
+        );
+        assert_eq!(
+            clone_credential_from_values(&json!({"api": {"githubAppId": ""}})),
+            None,
+            "an empty app id is not a clone credential"
+        );
+    }
+
+    /// Widening string|number|bool must not become "stringify anything": an
+    /// array or an object at a scalar path is a shape this reader does not
+    /// understand, and rendering its debug form into a detail is how structure
+    /// leaks into a report.
+    #[test]
+    fn a_non_scalar_value_is_absent() {
+        assert_eq!(
+            scalar_at(
+                &json!({"api": {"githubAppId": ["4475970"]}}),
+                &["api", "githubAppId"]
+            ),
+            None
+        );
+        assert_eq!(
+            scalar_at(
+                &json!({"api": {"githubAppId": {"value": "4475970"}}}),
+                &["api", "githubAppId"]
+            ),
+            None
+        );
+        assert_eq!(
+            scalar_at(
+                &json!({"api": {"githubAppId": null}}),
+                &["api", "githubAppId"]
+            ),
+            None
+        );
+        assert_eq!(
+            scalar_at(&json!({"api": {}}), &["api", "githubAppId"]),
+            None,
+            "an absent path is absent"
+        );
+    }
+
+    // -- D5: helm-missing, could-not-answer and absent are distinguishable ----
+
+    /// The three states were byte-identical: `fetch_release_chart` collapsed
+    /// every nonzero `helm list` to `Ok(None)`, so a laptop with no helm, an
+    /// expired cluster credential, and a genuinely empty namespace all printed
+    /// "not installed in this namespace".
+    #[test]
+    fn classify_release_probe_separates_every_outcome() {
+        assert_eq!(
+            classify_release_probe(false, true, "[]", "acme"),
+            ReleaseProbe::HelmMissing,
+            "no helm means the release cannot be inspected at all"
+        );
+        assert_eq!(
+            classify_release_probe(
+                true,
+                true,
+                r#"[{"name":"acme","chart":"curie-0.7.0"}]"#,
+                "acme"
+            ),
+            ReleaseProbe::Installed {
+                chart: "curie-0.7.0".to_string()
+            }
+        );
+        assert_eq!(
+            classify_release_probe(true, true, "[]", "acme"),
+            ReleaseProbe::NotInstalled
+        );
+        assert_eq!(
+            classify_release_probe(true, true, "null", "acme"),
+            ReleaseProbe::NotInstalled,
+            "helm prints null for an empty namespace in some versions"
+        );
+        assert_eq!(
+            classify_release_probe(true, true, "   ", "acme"),
+            ReleaseProbe::NotInstalled,
+            "empty stdout on success is the empty-namespace shape"
+        );
+        for stdout in ["", "[]", r#"[{"name":"acme","chart":"curie-0.7.0"}]"#] {
+            assert_eq!(
+                classify_release_probe(true, false, stdout, "acme"),
+                ReleaseProbe::ProbeFailed,
+                "a nonzero exit is not an answer, whatever landed on stdout"
+            );
+        }
+    }
+
+    /// The namespace can hold other releases. Taking the first array element
+    /// would report someone else's chart as this release's.
+    #[test]
+    fn exit_zero_for_a_different_release_is_not_installed() {
+        assert_eq!(
+            classify_release_probe(
+                true,
+                true,
+                r#"[{"name":"other","chart":"curie-0.7.0"}]"#,
+                "acme"
+            ),
+            ReleaseProbe::NotInstalled
+        );
+    }
+
+    /// The key negative. Turning "I could not read the answer" into "there is no
+    /// release" is a positive absence claim built on no evidence -- the #1354
+    /// shape -- and it is what `fetch_existing_values` already fails closed on
+    /// ("the release state is unknown"). A helm whose `list -o json` shape
+    /// changes must make doctor say so, not report a live release as gone.
+    #[test]
+    fn exit_zero_with_unreadable_stdout_is_probe_failed_not_not_installed() {
+        for stdout in [
+            "not json at all",
+            r#"{"releases":[]}"#,
+            r#"[{"name":"acme"}]"#,
+        ] {
+            assert_eq!(
+                classify_release_probe(true, true, stdout, "acme"),
+                ReleaseProbe::ProbeFailed,
+                "unreadable stdout {stdout:?} must not become an absence claim"
+            );
+        }
+    }
+
+    /// The user-visible half of the same defect: four different causes must not
+    /// produce the same two lines. Pairwise distinctness is the assertion the
+    /// issue's report ("byte-identical") maps onto directly.
+    #[test]
+    fn each_release_probe_renders_a_distinct_report() {
+        let variants = [
+            ReleaseProbe::HelmMissing,
+            ReleaseProbe::ProbeFailed,
+            ReleaseProbe::NotInstalled,
+            ReleaseProbe::Installed {
+                chart: "curie-0.7.0".into(),
+            },
+        ];
+        let mut seen: Vec<(ReleaseProbe, (State, String, State, String))> = Vec::new();
+        for probe in variants {
+            let checks = evaluate(&probed(probe.clone()));
+            let cluster = find(&checks, "cluster");
+            let release = find(&checks, "release");
+            let report = (
+                cluster.state,
+                cluster.detail.clone(),
+                release.state,
+                release.detail.clone(),
+            );
+            if probe != ReleaseProbe::NotInstalled {
+                assert!(
+                    !release.detail.contains("no deployed release"),
+                    "{probe:?} must not claim the release is absent: {}",
+                    release.detail
+                );
+            }
+            for (other, previous) in &seen {
+                assert_ne!(
+                    &report, previous,
+                    "{probe:?} and {other:?} render the same report"
+                );
+            }
+            seen.push((probe, report));
+        }
+    }
+
+    /// A JSON consumer gates on `ready`. Reporting `true` while doctor could not
+    /// see the release at all would let a pipeline proceed on no evidence.
+    #[test]
+    fn an_unknown_release_is_never_ready() {
+        for probe in [ReleaseProbe::HelmMissing, ReleaseProbe::ProbeFailed] {
+            let checks = evaluate(&probed(probe.clone()));
+            let out = DoctorOutput {
+                summary: summary(&checks),
+                checks,
+            };
+            assert_eq!(
+                out.to_json()["ready"],
+                serde_json::Value::Bool(false),
+                "{probe:?} knows nothing about the release, so it is not ready"
+            );
+        }
+    }
+
+    /// #1354 recurring through the states D5 introduces, in both directions: a
+    /// probe that failed and a missing helm must not roll up to the verdict
+    /// reserved for "helm answered, and there is no release here".
+    #[test]
+    fn a_failed_probe_does_not_claim_the_release_is_absent() {
+        let failed = summary(&evaluate(&probed(ReleaseProbe::ProbeFailed)));
+        assert!(!failed.contains("No cluster release yet"), "{failed}");
+        assert!(
+            failed.contains("Cluster line"),
+            "the verdict must send the operator to the line that explains it: {failed}"
+        );
+
+        let no_helm = summary(&evaluate(&probed(ReleaseProbe::HelmMissing)));
+        assert!(!no_helm.contains("No cluster release yet"), "{no_helm}");
+        assert!(
+            no_helm.contains("helm"),
+            "a missing helm is the reason, and the verdict must say so: {no_helm}"
+        );
+    }
+
+    /// `Ok` on the cluster check means a kube context is configured -- not that
+    /// anything reached the cluster. When helm never ran, nothing contacted it,
+    /// and claiming otherwise is the over-claim this check exists to avoid.
+    #[test]
+    fn the_cluster_detail_says_whether_the_cluster_was_contacted() {
+        for probe in [
+            ReleaseProbe::NotInstalled,
+            ReleaseProbe::Installed {
+                chart: "curie-0.7.0".into(),
+            },
+        ] {
+            let detail = find(&evaluate(&probed(probe.clone())), "cluster")
+                .detail
+                .clone();
+            assert!(detail.contains("reached"), "{probe:?}: {detail}");
+        }
+        let detail = find(&evaluate(&probed(ReleaseProbe::HelmMissing)), "cluster")
+            .detail
+            .clone();
+        assert!(
+            !detail.contains("reached"),
+            "helm never ran, so nothing contacted the cluster: {detail}"
+        );
+        assert!(
+            detail.contains("kubeconfig"),
+            "it must say where the context came from instead: {detail}"
+        );
+    }
+
+    /// The standing structural guard. doctor's payload is pasted into issues,
+    /// and helm's own output is an ARBITRARY external line: it can carry an
+    /// `Authorization` header, an exec-plugin's argv, or a token-bearing URL.
+    /// No prefix denylist can enumerate that, so the property is that NOTHING
+    /// from a subprocess survives -- asserted over the whole planted string,
+    /// token by token, not over a list of credential shapes.
+    #[test]
+    fn no_subprocess_output_ever_reaches_a_check() {
+        // Every token is distinctive on purpose: the assertion is that NONE of
+        // them survives, so a token that doctor could legitimately author (say,
+        // "cluster") would make the guard fail for the wrong reason.
+        //
+        // The credential-shaped tokens are ASSEMBLED AT RUNTIME rather than
+        // written out. A complete `xoxb-...` / `ghp_...` / `github_pat_...`
+        // string sitting in this source trips the repo's secret scanners even
+        // on a placeholder, and gitleaks scans full history, so one that lands
+        // and is removed later still fails. The planted string is byte-for-byte
+        // what it always was, so this plants the same input and proves the same
+        // property. Do NOT "tidy" these back into single literals.
+        let ph = "PLACEHOLDER";
+        let planted_owned = [
+            format!("sk-ant-{ph}"),
+            format!("sk-or-{ph}"),
+            format!("{}{ph}", "xoxb-"),
+            format!("{}{ph}", "xapp-"),
+            format!("{}{ph}", "ghp_"),
+            format!("{}{ph}", "github_pat_"),
+            format!("{}{} RSA PRIVATE KEY", "-----", "BEGIN"),
+            format!("Authorization: Bearer {ph}"),
+            format!("https://example.invalid/?access_token={ph}"),
+            "curie-doctor-subprocess-marker-1358".to_string(),
+        ]
+        .join(" ");
+        let planted = planted_owned.as_str();
+
+        // The classifier is the one place a subprocess's bytes are handed to
+        // doctor, so route the planted output through it on both exit paths.
+        let mut probes = vec![
+            classify_release_probe(true, false, planted, "acme"),
+            classify_release_probe(true, true, planted, "acme"),
+            ReleaseProbe::HelmMissing,
+            ReleaseProbe::NotInstalled,
+            ReleaseProbe::Installed {
+                chart: "curie-0.7.0".into(),
+            },
+        ];
+        probes.dedup();
+
+        for probe in probes {
+            let checks = evaluate(&probed(probe.clone()));
+            let rendered = format!("{checks:?}");
+            for token in planted.split_whitespace() {
+                assert!(
+                    !rendered.contains(token),
+                    "{probe:?} echoed {token:?} from the subprocess: {rendered}"
+                );
+            }
+            assert!(
+                !summary(&checks).contains("curie-doctor-subprocess-marker-1358"),
+                "the summary echoed the subprocess too"
+            );
+        }
+    }
+
+    // -- D6a: Slack partial state --------------------------------------------
+
+    /// The check read only `botToken` and then claimed "app and bot tokens
+    /// recorded". Socket mode needs BOTH, so a half-configured release read as
+    /// fully wired and the bot silently never connected.
+    #[test]
+    fn a_bot_token_without_an_app_token_is_not_ok() {
+        let f = Facts {
+            slack_bot_token: true,
+            slack_app_token: false,
+            ..wired()
+        };
+        let checks = evaluate(&f);
+        let c = find(&checks, "slack");
+        assert_eq!(c.state, State::Missing);
+        assert!(
+            c.detail.contains("only the bot token"),
+            "the detail must say which token was observed: {}",
+            c.detail
+        );
+        assert!(
+            c.detail.contains("socket mode needs both"),
+            "and why one is not enough: {}",
+            c.detail
+        );
+        let fix = c.fix.as_deref().expect("a partial state must be fixable");
+        assert!(fix.contains("--namespace acme"), "{fix}");
+        assert!(fix.contains("--release acme"), "{fix}");
+        assert!(
+            !summary(&checks).contains("Fully wired"),
+            "{}",
+            summary(&checks)
+        );
+    }
+
+    /// The mirror case. An app token with no bot token is the same failure in
+    /// the other direction, and an implementation that only special-cases one
+    /// of the two passes the sibling test alone.
+    #[test]
+    fn an_app_token_without_a_bot_token_is_not_ok() {
+        let f = Facts {
+            slack_bot_token: false,
+            slack_app_token: true,
+            ..wired()
+        };
+        let checks = evaluate(&f);
+        let c = find(&checks, "slack");
+        assert_eq!(c.state, State::Missing);
+        assert!(
+            c.detail.contains("only the app token"),
+            "the detail must say which token was observed: {}",
+            c.detail
+        );
+        assert!(
+            c.detail.contains("socket mode needs both"),
+            "and why one is not enough: {}",
+            c.detail
+        );
+        assert!(c.fix.is_some(), "a partial state must be fixable");
+        assert!(
+            !summary(&checks).contains("Fully wired"),
+            "{}",
+            summary(&checks)
+        );
+    }
+
+    /// The positive path keeps its wording: both tokens recorded is Ok, with no
+    /// fix and nothing to do.
+    #[test]
+    fn both_tokens_recorded_is_ok() {
+        let c = find(&evaluate(&wired()), "slack").clone();
+        assert_eq!(c.state, State::Ok);
+        assert_eq!(c.detail, "app and bot tokens recorded");
+        assert!(c.fix.is_none());
+    }
+
+    /// Neither token keeps the original wording and stays fixable.
+    #[test]
+    fn no_tokens_recorded_is_reported_as_none() {
+        let f = Facts {
+            slack_bot_token: false,
+            slack_app_token: false,
+            ..wired()
+        };
+        let c = find(&evaluate(&f), "slack").clone();
+        assert_eq!(c.state, State::Missing);
+        assert_eq!(c.detail, "no tokens recorded");
+    }
+
+    // -- D6b: curie.yaml precedence ------------------------------------------
+
+    /// doctor hardcoded `curie/curie` and never looked at the `curie.yaml` in
+    /// the directory it was run from, so in an installation directory it
+    /// reported on a release that did not exist. Resolution is per FIELD: an
+    /// all-or-nothing implementation drops the file's release the moment
+    /// `--namespace` alone is passed. An inference is announced, never silent.
+    #[test]
+    fn resolve_target_precedence() {
+        let declared = Some(("acme", "acme"));
+
+        let both = resolve_target(Some("ops"), Some("ops-bot"), declared);
+        assert_eq!(both.namespace, "ops");
+        assert_eq!(both.release, "ops-bot");
+        assert_eq!(
+            both.announcement, None,
+            "nothing was inferred, so there is nothing to announce"
+        );
+
+        let inferred = resolve_target(None, None, declared);
+        assert_eq!(inferred.namespace, "acme");
+        assert_eq!(inferred.release, "acme");
+        let note = inferred
+            .announcement
+            .expect("an inferred target must be announced");
+        assert!(note.contains("curie.yaml"), "must name the source: {note}");
+        assert!(note.contains("acme"), "must name the value: {note}");
+
+        // Secondary path: one flag set, one field taken from the file.
+        let mixed = resolve_target(Some("ops"), None, declared);
+        assert_eq!(mixed.namespace, "ops", "the flag wins its own field");
+        assert_eq!(
+            mixed.release, "acme",
+            "the other field still comes from curie.yaml"
+        );
+        let note = mixed
+            .announcement
+            .expect("a partially inferred target is still an inference");
+        assert!(note.contains("curie.yaml"), "{note}");
+
+        let defaults = resolve_target(None, None, None);
+        assert_eq!(defaults.namespace, "curie");
+        assert_eq!(defaults.release, "curie");
+        assert_eq!(
+            defaults.announcement, None,
+            "the built-in default is not an inference from a file"
+        );
+    }
+
+    // -- D6c: the three surviving mutations ----------------------------------
+
+    /// Hardcoding the Ok arm of the docker check survived the whole suite: no
+    /// test ever set `docker_ok: false` alongside a bundle, so the Missing arm
+    /// and the summary branch that depends on it were both unreached.
+    #[test]
+    fn docker_not_reachable_is_reported_and_gates_the_summary() {
+        let f = Facts {
+            docker_ok: false,
+            ..laptop()
+        };
+        let checks = evaluate(&f);
+        let c = find(&checks, "docker");
+        assert_eq!(c.state, State::Missing);
+        assert!(
+            c.fix.as_deref().unwrap_or("").contains("Docker"),
+            "the fix must name Docker: {:?}",
+            c.fix
+        );
+        assert!(
+            summary(&checks).contains("Docker is not reachable"),
+            "{}",
+            summary(&checks)
+        );
+    }
+
+    /// The clone-credential check never reached Missing in any test, so an
+    /// implementation that could not produce that arm at all stayed green. The
+    /// detail has to name the CONSEQUENCE: the symptom is a push that appears
+    /// to work and deploys nothing.
+    #[test]
+    fn a_release_with_no_clone_credential_reports_missing() {
+        let f = Facts {
+            clone_credential: None,
+            ..wired()
+        };
+        let c = find(&evaluate(&f), "clone-credential").clone();
+        assert_eq!(c.state, State::Missing);
+        assert!(
+            c.detail.contains("git-push deploys will fail"),
+            "must name the consequence: {}",
+            c.detail
+        );
+        let fix = c.fix.as_deref().expect("must offer a fix");
+        assert!(fix.contains("--namespace acme"), "{fix}");
+        assert!(fix.contains("--release acme"), "{fix}");
+    }
+
+    /// `"ready": true` hardcoded in `to_json` survived every test, because no
+    /// test read `ready` at all. Both directions are asserted, so a constant in
+    /// either position fails. Docker is the lever deliberately, NOT `model-pin`:
+    /// #1663 established that a floating pin is Ok-with-a-fix and must never
+    /// make a working install read as unready.
+    #[test]
+    fn ready_is_false_when_any_check_is_missing() {
+        let clean = Facts {
+            agents: Some(vec![("bot".into(), Some("acme/bot".into()))]),
+            ..wired()
+        };
+        let checks = evaluate(&clean);
+        assert!(
+            checks.iter().all(|c| c.state != State::Missing),
+            "the clean fixture must have no Missing check: {checks:?}"
+        );
+        let out = DoctorOutput {
+            summary: summary(&checks),
+            checks,
+        };
+        assert_eq!(out.to_json()["ready"], serde_json::Value::Bool(true));
+
+        let broken = Facts {
+            docker_ok: false,
+            ..clean
+        };
+        let checks = evaluate(&broken);
+        let out = DoctorOutput {
+            summary: summary(&checks),
+            checks,
+        };
+        assert_eq!(out.to_json()["ready"], serde_json::Value::Bool(false));
     }
 }
 

--- a/cli/src/doctor.rs
+++ b/cli/src/doctor.rs
@@ -57,6 +57,31 @@ pub struct Check {
     pub fix: Option<String>,
 }
 
+/// What the `helm list` probe established about the release.
+///
+/// `Option<(String, String)>` could not express "we do not know", so a laptop
+/// with no helm, an expired cluster credential and a genuinely empty namespace
+/// all printed the same two lines (#1358). Every variant is diagnostic-free by
+/// construction: helm's stderr is an arbitrary external line that can carry
+/// an `Authorization` header, an exec-plugin's argv, or a token-bearing URL, and
+/// this report is pasted into issues. No prefix denylist can enumerate that, so
+/// no subprocess stderr is carried here at all -- only the bounded, structured
+/// `chart` field that this report exists to display (#1348).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum ReleaseProbe {
+    /// `helm` is not on PATH, so the release was never inspected at all.
+    HelmMissing,
+    /// helm ran and did not answer: a nonzero exit, or a zero exit whose stdout
+    /// is not the release list this code understands. The `fix` hands the
+    /// operator the diagnostic to run themselves.
+    ProbeFailed,
+    /// helm answered, and reports no deployed release by this name here.
+    #[default]
+    NotInstalled,
+    /// helm answered, and this release is deployed.
+    Installed { chart: String },
+}
+
 /// Everything the checks reason about, gathered once.
 ///
 /// Separating observation from judgement is what makes the judgement testable:
@@ -98,6 +123,14 @@ pub struct Facts {
     /// about the run, kept on `Facts` so `evaluate` stays pure and the fix
     /// string can name the release actually diagnosed rather than `curie/curie`
     /// (#1358 item 1).
+    ///
+    /// ONE field for one fact: #1950 and #1358 each arrived with their own
+    /// spelling of it, and two fields carrying the same fact drift a writer at
+    /// a time until the model-pin fix and the cluster fixes name different
+    /// releases. `None` is a run or fixture that never exercised targeting;
+    /// [`target`] renders that as [`DEFAULT_TARGET`] so a cluster fix stays
+    /// runnable, while `model_pin_fix` keeps its own `<ns>`/`<release>`
+    /// placeholders (#1950).
     pub target: Option<(String, String)>,
     /// Non-secret provider inferred from the bound `CURIE_CREDENTIALS` value.
     /// The credential itself is deliberately discarded during observation.
@@ -106,10 +139,25 @@ pub struct Facts {
     /// Plugin name from `.claude-plugin/plugin.json` in the working directory.
     pub bundle_name: Option<String>,
     pub kube_context: Option<String>,
-    /// `(release, chart)` when a Curie release is installed.
-    pub release: Option<(String, String)>,
-    /// Whether the release has non-empty Slack tokens recorded.
-    pub slack_configured: bool,
+    /// What the `helm list` probe established. `NotInstalled` is the `Default`
+    /// only because it is the state a fixture that says nothing means.
+    pub release: ReleaseProbe,
+    /// The CIDRs `security.networkPolicy.allowedEgress` records, in recorded
+    /// order. Empty means either nothing recorded or nothing this reader can
+    /// reproduce -- the two are never distinguished, because a partial list is
+    /// exactly what must not be emitted.
+    pub sandbox_egress_cidrs: Vec<String>,
+    /// Whether `cluster up` can re-supply that allowlist EXACTLY. One fact
+    /// rather than two conditions: the consumer's only question is "can the fix
+    /// reproduce this, yes or no", and splitting it invites a partial-emission
+    /// branch. `false` by default, so a fixture silent about egress can never
+    /// produce egress flags.
+    pub sandbox_egress_is_reproducible: bool,
+    /// Whether the release records a non-empty Slack app token. Presence only --
+    /// the value is never read.
+    pub slack_app_token: bool,
+    /// Whether the release records a non-empty Slack bot token.
+    pub slack_bot_token: bool,
     /// Which clone credential the release carries, if any.
     pub clone_credential: Option<String>,
     /// Every agent and its repository binding. `None` means the platform API
@@ -157,11 +205,95 @@ fn skipped(id: &'static str, title: &'static str, detail: impl Into<String>) -> 
     }
 }
 
+/// The target a fix names when `Facts` carries none, and what `resolve_target`
+/// falls back to when neither a flag nor a `curie.yaml` supplies one.
+const DEFAULT_TARGET: &str = "curie";
+
+/// The `release` detail when helm itself is absent.
+///
+/// `HelmMissing` and `NotInstalled` both render as (cluster `Ok`, release
+/// `Missing`), so `summary` cannot tell them apart from the check states alone
+/// and matches this sentinel instead. Shared rather than written out twice, so a
+/// later wording tweak cannot silently break the verdict with every test green.
+const HELM_ABSENT_DETAIL: &str = "helm is not installed, so nothing about a cluster release \
+                                  could be read";
+
+/// Classify a `helm list` run. Pure, so every outcome is a unit test rather than
+/// a cluster fixture -- and it takes the exit status and stdout ONLY. helm's
+/// stderr is never passed in, because nothing it says may reach a payload.
+fn classify_release_probe(
+    helm_present: bool,
+    ok: bool,
+    stdout: &str,
+    release: &str,
+) -> ReleaseProbe {
+    if !helm_present {
+        return ReleaseProbe::HelmMissing;
+    }
+    if !ok {
+        return ReleaseProbe::ProbeFailed;
+    }
+    let stdout = stdout.trim();
+    // helm prints `null`, or nothing at all, for a namespace holding no
+    // releases. That is a known output shape, not a failure to read one.
+    if stdout.is_empty() || stdout == "null" {
+        return ReleaseProbe::NotInstalled;
+    }
+    let Ok(serde_json::Value::Array(listed)) = serde_json::from_str::<serde_json::Value>(stdout)
+    else {
+        // Exit zero this reader cannot parse is NOT an absence claim. Turning
+        // "I could not read the answer" into "your release is gone" is the
+        // #1354 shape, and it is what `ops::fetch_existing_values` already fails
+        // closed on: "the release state is unknown".
+        return ReleaseProbe::ProbeFailed;
+    };
+    // By name, never by position: the namespace can hold other releases, and
+    // taking the first element reports someone else's chart as this one's.
+    let Some(entry) = listed
+        .iter()
+        .find(|e| e.get("name").and_then(serde_json::Value::as_str) == Some(release))
+    else {
+        return ReleaseProbe::NotInstalled;
+    };
+    match entry.get("chart").and_then(serde_json::Value::as_str) {
+        Some(chart) if !chart.is_empty() => ReleaseProbe::Installed {
+            chart: chart.to_string(),
+        },
+        // Listed, but without the one field this reader needs: a helm whose
+        // `list -o json` shape moved must make doctor say it could not tell.
+        _ => ReleaseProbe::ProbeFailed,
+    }
+}
+
+/// The namespace and release to name in a fix string.
+///
+/// A `Facts` built by a test that never exercised targeting carries no target,
+/// and `--namespace  --release ` is not a runnable command. This is a RENDERING
+/// fallback only; resolution itself lives in `resolve_target`.
+fn target(f: &Facts) -> (&str, &str) {
+    match &f.target {
+        Some((namespace, release)) => (namespace.as_str(), release.as_str()),
+        None => (DEFAULT_TARGET, DEFAULT_TARGET),
+    }
+}
+
+/// The `curie cluster <subcommand>` prefix every targeted fix opens with. Five
+/// fixes name the same release, and a prefix spelled five times is a prefix that
+/// drifts a flag at a time; each site appends only what is its own.
+fn targeted(subcommand: &str, namespace: &str, release: &str) -> String {
+    format!("curie cluster {subcommand} --namespace {namespace} --release {release}")
+}
+
 /// The recovery command for a missing cluster release. Provider egress follows
 /// the same credential-prefix map as `cluster up`; an absent or unrecognized
 /// credential leaves egress sealed rather than guessing Anthropic.
-fn missing_release_recovery(provider: Option<&str>) -> String {
-    let mut command = "curie cluster up --namespace <ns> --release <name>".to_string();
+///
+/// It deliberately does NOT re-supply a recorded egress allowlist the way the
+/// webhook fix does: it fires only when there is no release, so there is nothing
+/// recorded to preserve, and `--allow-egress-host` is the right flag for a fresh
+/// install (#1813).
+fn missing_release_recovery(namespace: &str, release: &str, provider: Option<&str>) -> String {
+    let mut command = targeted("up", namespace, release);
     if let Some(provider) = provider {
         command.push_str(&format!(" --allow-egress-host {provider}"));
     }
@@ -487,6 +619,36 @@ fn release_fake_model_clause(f: &Facts, in_force: &ModelSource) -> &'static str 
     }
 }
 
+/// The exposure fix, which is a full `cluster up` and therefore drops every
+/// value nothing re-supplies -- including the sandbox's egress allowlist, which
+/// is how following doctor's advice sealed a working release's model path.
+///
+/// The allowlist is reproduced in full or not at all. `ops::up_value_plan`
+/// rewrites every `--allow-web-egress` CIDR as exactly one TCP/443 rule, so a
+/// rule shaped any other way would be COERCED, and a capped list would drop
+/// entries outright; both NARROW a live NetworkPolicy, and a caveat is read
+/// after the policy is already broken. There is deliberately no middle branch.
+fn webhook_recovery(f: &Facts, namespace: &str, release: &str) -> String {
+    let mut command = targeted("up", namespace, release);
+    command.push_str(" --set api.ingress.enabled=true --set api.ingress.host=<host>");
+    if f.sandbox_egress_is_reproducible {
+        // `--allow-web-egress` rather than `--allow-egress-host`: a CIDR read
+        // back off a release cannot be reversed to a provider name, and
+        // ADR-0114 errors when an explicit provider list omits the detected one.
+        for cidr in &f.sandbox_egress_cidrs {
+            command.push_str(&format!(" --allow-web-egress {cidr}"));
+        }
+    } else {
+        command.push_str(&format!(
+            "   (WARNING: this release records a sandbox egress allowlist this command \
+             cannot reproduce; running it as-is would narrow the policy. Read it first \
+             with `helm get values {release} -n {namespace}` and re-supply those rules \
+             deliberately.)"
+        ));
+    }
+    command
+}
+
 /// Judge the gathered facts. Pure.
 pub fn evaluate(f: &Facts) -> Vec<Check> {
     let mut out = Vec::new();
@@ -618,40 +780,124 @@ pub fn evaluate(f: &Facts) -> Vec<Check> {
         }
         return out;
     };
-    out.push(ok("cluster", "Cluster", context.clone()));
+    let (namespace, release) = target(f);
 
-    let Some((release, chart)) = &f.release else {
-        out.push(missing(
-            "release",
-            "Curie release",
-            "not installed in this namespace",
-            missing_release_recovery(f.model_credential_provider),
-        ));
+    // helm is what answers "is there a release here", so these two checks may
+    // only assert what the probe proved. `Ok` on Cluster means a kube context is
+    // configured; the detail says whether anything actually contacted the
+    // cluster, and `Missing` is reserved for the one outcome where doctor has
+    // positive evidence that something did not work. Before this, a missing
+    // helm, an expired credential and an empty namespace printed the same two
+    // lines (#1358).
+    let downstream_blocked = match &f.release {
+        ReleaseProbe::HelmMissing => {
+            out.push(ok(
+                "cluster",
+                "Cluster",
+                format!(
+                    "{context} (from the kubeconfig; helm is not installed, so the \
+                     cluster was not contacted)"
+                ),
+            ));
+            out.push(missing(
+                "release",
+                "Curie release",
+                HELM_ABSENT_DETAIL,
+                "install helm, then re-run: https://helm.sh/docs/intro/install/",
+            ));
+            Some("needs helm to read the release")
+        }
+        ReleaseProbe::ProbeFailed => {
+            out.push(missing(
+                "cluster",
+                "Cluster",
+                format!(
+                    "{context} — from the kubeconfig; `helm list` did not answer, so the \
+                     cluster was not confirmed reachable"
+                ),
+                // The diagnostic the operator runs themselves, which is what
+                // replaces echoing helm's message: it enumerates the causes
+                // categorically without claiming which one occurred, and
+                // without carrying a byte doctor did not author.
+                format!(
+                    "run `helm list -n {namespace}` and `kubectl config current-context` to \
+                     see why — an expired credential, an unreachable API server and an RBAC \
+                     denial all land here — then re-run `curie doctor`"
+                ),
+            ));
+            out.push(skipped(
+                "release",
+                "Curie release",
+                "`helm list` did not answer, so nothing about the release is known",
+            ));
+            Some("the release could not be inspected")
+        }
+        ReleaseProbe::NotInstalled => {
+            out.push(ok("cluster", "Cluster", format!("{context} (reached)")));
+            // "no DEPLOYED release" is what plain `helm list` actually shows:
+            // it filters out pending and failed ones. `helm list -a` was the
+            // alternative and is worse -- it also lists releases kept with
+            // --keep-history, so a deleted release would read as present, and
+            // over-claiming presence is the wrong direction for a check whose
+            // fix is "install it".
+            out.push(missing(
+                "release",
+                "Curie release",
+                format!(
+                    "helm reports no deployed release named {release} in this namespace \
+                     (a pending or failed release is not listed)"
+                ),
+                missing_release_recovery(namespace, release, f.model_credential_provider),
+            ));
+            Some("needs a release")
+        }
+        ReleaseProbe::Installed { chart } => {
+            out.push(ok("cluster", "Cluster", format!("{context} (reached)")));
+            out.push(ok(
+                "release",
+                "Curie release",
+                format!("{release} ({chart})"),
+            ));
+            None
+        }
+    };
+
+    // Everything below reads the release's own values, so an outcome that did
+    // not reach one skips them with the reason it did not -- not with a verdict
+    // about a release nobody could see.
+    if let Some(reason) = downstream_blocked {
         for (id, title) in [
             ("slack", "Slack"),
             ("clone-credential", "Clone credential"),
             ("webhook", "Webhook exposure"),
             ("repo-binding", "Repo binding"),
         ] {
-            out.push(skipped(id, title, "needs a release"));
+            out.push(skipped(id, title, reason));
         }
         return out;
-    };
-    out.push(ok(
-        "release",
-        "Curie release",
-        format!("{release} ({chart})"),
-    ));
+    }
 
-    out.push(if f.slack_configured {
-        ok("slack", "Slack", "app and bot tokens recorded")
-    } else {
-        missing(
+    // Socket mode needs BOTH tokens, and this check used to read only the bot
+    // token while claiming both were recorded -- so a half-configured release
+    // read as wired and the bot silently never connected.
+    let slack_fix = || {
+        targeted("comms --slack", namespace, release) + " --app-token xapp-... --bot-token xoxb-..."
+    };
+    out.push(match (f.slack_app_token, f.slack_bot_token) {
+        (true, true) => ok("slack", "Slack", "app and bot tokens recorded"),
+        (true, false) => missing(
             "slack",
             "Slack",
-            "no tokens recorded",
-            "curie cluster comms --slack --app-token xapp-... --bot-token xoxb-...",
-        )
+            "only the app token is recorded — socket mode needs both",
+            slack_fix(),
+        ),
+        (false, true) => missing(
+            "slack",
+            "Slack",
+            "only the bot token is recorded — socket mode needs both",
+            slack_fix(),
+        ),
+        (false, false) => missing("slack", "Slack", "no tokens recorded", slack_fix()),
     });
 
     out.push(match &f.clone_credential {
@@ -660,7 +906,7 @@ pub fn evaluate(f: &Facts) -> Vec<Check> {
             "clone-credential",
             "Clone credential",
             "none — a private repo cannot be cloned, so git-push deploys will fail",
-            "curie cluster github-app --app-id <id> --private-key ./key.pem",
+            targeted("github-app", namespace, release) + " --app-id <id> --private-key ./key.pem",
         ),
     });
 
@@ -676,7 +922,7 @@ pub fn evaluate(f: &Facts) -> Vec<Check> {
             "Webhook exposure",
             "no ingress and no NodePort — if a load balancer or tunnel fronts the API, \
              this check cannot see it and you can ignore this",
-            "curie cluster up --set api.ingress.enabled=true --set api.ingress.host=<host>",
+            webhook_recovery(f, namespace, release),
         ),
     });
 
@@ -713,9 +959,10 @@ pub fn evaluate(f: &Facts) -> Vec<Check> {
                          silently ignored",
                         unbound.join(", ")
                     ),
-                    "curie cluster deploy --plugin-dir . --repo <owner>/<name>   \
-                     (binds an agent that has none; it will NOT rebind one already \
-                     pointing at a different repository)",
+                    targeted("deploy", namespace, release)
+                        + " --plugin-dir . --repo <owner>/<name>   (binds an agent that has \
+                           none; it will NOT rebind one already pointing at a different \
+                           repository)",
                 )
             }
         }
@@ -754,6 +1001,10 @@ pub fn guidance(checks: &[Check]) -> Option<String> {
 pub fn summary(checks: &[Check]) -> String {
     let state = |id: &str| checks.iter().find(|c| c.id == id).map(|c| c.state);
     let has = |id: &str| state(id) == Some(State::Ok);
+    let release_detail = checks
+        .iter()
+        .find(|c| c.id == "release")
+        .map(|c| c.detail.as_str());
 
     if !has("bundle") {
         return "No bundle here. Start with `curie init my-agent`.".to_string();
@@ -764,6 +1015,22 @@ pub fn summary(checks: &[Check]) -> String {
     if !has("model-credential") {
         return "Ready to run offline (`curie skill up --fake-model`). A model \
                 credential is needed for real replies."
+            .to_string();
+    }
+    // Two ways the release is UNKNOWN rather than absent, and neither may reach
+    // the verdict below it -- reporting "no cluster release yet" off a probe
+    // that never answered is a positive absence claim built on no evidence
+    // (#1354, in the states #1358 introduced).
+    if state("cluster") == Some(State::Missing) {
+        return "A cluster context is configured but `helm list` did not answer, so \
+                nothing about the release is known -- see the Cluster line above."
+            .to_string();
+    }
+    // `HelmMissing` and `NotInstalled` are both (cluster Ok, release Missing),
+    // so only the detail separates them; hence the shared sentinel.
+    if release_detail == Some(HELM_ABSENT_DETAIL) {
+        return "Ready to run locally. helm is not installed, so nothing about a \
+                cluster release could be read."
             .to_string();
     }
     if !has("release") {
@@ -794,6 +1061,53 @@ pub fn summary(checks: &[Check]) -> String {
             .to_string();
     }
     "Fully wired: local runs, Slack, and git-push deploys.".to_string()
+}
+
+// -- targeting ----------------------------------------------------------------
+
+/// Which release doctor will inspect, and whether that was inferred.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Target {
+    pub namespace: String,
+    pub release: String,
+    /// The line to print when a field came from `curie.yaml`. `None` when
+    /// nothing was inferred: a built-in default is not an inference from a file,
+    /// and announcing one would be noise on every run.
+    pub announcement: Option<String>,
+}
+
+/// Resolve the target: the flag wins, else `curie.yaml`'s `install:` block, else
+/// the built-in default. Pure, so the precedence table is a unit test with no
+/// filesystem access; reading the file is the caller's job, and doctor must not
+/// fail when it cannot.
+///
+/// Precedence is per FIELD. An all-or-nothing implementation throws away the
+/// file's release the moment `--namespace` alone is passed, which is how an
+/// operator ends up reported on a release they did not name. `diff` already
+/// takes its target from `install:` (ADR-0097); this makes `doctor` follow.
+pub fn resolve_target(
+    flag_namespace: Option<&str>,
+    flag_release: Option<&str>,
+    declared: Option<(&str, &str)>,
+) -> Target {
+    let declared_namespace = declared.map(|(namespace, _)| namespace);
+    let declared_release = declared.map(|(_, release)| release);
+    let namespace = flag_namespace
+        .or(declared_namespace)
+        .unwrap_or(DEFAULT_TARGET);
+    let release = flag_release.or(declared_release).unwrap_or(DEFAULT_TARGET);
+    // Announced, never silent: doctor run in someone else's installation
+    // directory would otherwise report on a release the operator never named,
+    // and the announcement is what makes that survivable.
+    let inferred = (flag_namespace.is_none() && declared_namespace.is_some())
+        || (flag_release.is_none() && declared_release.is_some());
+    Target {
+        namespace: namespace.to_string(),
+        release: release.to_string(),
+        announcement: inferred.then(|| {
+            format!("inferred from curie.yaml: --namespace {namespace} --release {release}")
+        }),
+    }
 }
 
 #[cfg(test)]
@@ -3715,6 +4029,160 @@ esac
     }
 }
 
+// -- reading the release's values ---------------------------------------------
+//
+// Pure, so every shape a real values file can take is a unit test rather than a
+// cluster fixture. They are extracted for that reason and no other: the reads
+// they replaced were type-strict, and a bug in one could only be found by
+// installing a release that had it.
+
+/// Read a scalar at `path`, coercing the JSON kinds a Helm values file produces.
+///
+/// A values file is YAML, and what reaches here depends on whether the author
+/// quoted the value: `githubAppId: 4475970` arrives as a number and
+/// `--set-string` arrives as a string. An `as_str()`-only read called an install
+/// with the unquoted form credential-less (#1253). Arrays, objects and null stay
+/// `None` -- widening to "stringify anything" would let structure leak into a
+/// report -- and the empty-string filter predates this and survives it, because
+/// a chart default of `""` is an unset field, not a value.
+fn scalar_at(values: &serde_json::Value, path: &[&str]) -> Option<String> {
+    let mut node = values;
+    for key in path {
+        node = node.get(key)?;
+    }
+    let rendered = match node {
+        serde_json::Value::String(s) => s.clone(),
+        serde_json::Value::Number(n) => render_number(n),
+        serde_json::Value::Bool(b) => b.to_string(),
+        _ => return None,
+    };
+    Some(rendered).filter(|s| !s.is_empty())
+}
+
+fn render_number(n: &serde_json::Number) -> String {
+    if let Some(i) = n.as_i64() {
+        return i.to_string();
+    }
+    if let Some(u) = n.as_u64() {
+        return u.to_string();
+    }
+    match n.as_f64() {
+        // The scientific-notation shape (#1253): an unquoted id can reach us as
+        // `4.47597e6`, which is the same id, not a new one. Rendering it as
+        // `4475970.0` would report a value nobody typed.
+        Some(f) if f.is_finite() && f.fract() == 0.0 => format!("{f:.0}"),
+        _ => n.to_string(),
+    }
+}
+
+/// Whether a values entry means `true`.
+///
+/// A real bool, or the literal string, case- and space-insensitively: both
+/// `--set-string api.ingress.enabled=true` and a quoted values-file entry record
+/// a string, and an `as_bool()`-only read reported an install whose ingress was
+/// already on as unexposed. Nothing else counts -- not `"1"`, not `"yes"`, not a
+/// number. Reading any non-empty string as true would report an install as
+/// exposed on a typo, in the one check whose job is to say whether the API is
+/// reachable from outside.
+fn truthy(node: Option<&serde_json::Value>) -> bool {
+    match node {
+        Some(serde_json::Value::Bool(b)) => *b,
+        Some(serde_json::Value::String(s)) => s.trim().eq_ignore_ascii_case("true"),
+        _ => false,
+    }
+}
+
+/// Which clone credential the release carries. NAMES and shapes only -- never
+/// the Secret's key name, and never key material.
+///
+/// The existing-Secret path is checked first because it is what the chart
+/// template actually consumes when it is set, and the chart calls it the
+/// recommended path while the inline flags are a quick trial (#1255). Reporting
+/// both would invite an operator to "fix" an install that is already working.
+fn clone_credential_from_values(values: &serde_json::Value) -> Option<String> {
+    if let Some(secret) = scalar_at(values, &["api", "githubAppExistingSecret"]) {
+        return Some(format!("github app (secret={secret})"));
+    }
+    match scalar_at(values, &["api", "githubAppId"]) {
+        Some(id) => Some(format!("github app (app_id={id})")),
+        None => scalar_at(values, &["api", "githubToken"]).map(|_| "personal access token".into()),
+    }
+}
+
+/// How the API is reachable from outside, given the release's values and the
+/// NodePort read (`None` when there is none, or when nothing looked).
+fn api_exposure_from_values(
+    values: &serde_json::Value,
+    nodeport: Option<String>,
+) -> Option<String> {
+    let ingress = values.get("api").and_then(|api| api.get("ingress"));
+    if truthy(ingress.and_then(|i| i.get("enabled"))) {
+        return Some(match scalar_at(values, &["api", "ingress", "host"]) {
+            Some(host) => format!("ingress ({host})"),
+            None => "ingress".to_string(),
+        });
+    }
+    nodeport.map(|port| format!("NodePort {port}"))
+}
+
+/// The recorded sandbox egress allowlist, and whether `cluster up` can re-supply
+/// it exactly.
+///
+/// Returns `(cidrs, is_reproducible)`, and **a false gate always returns an empty
+/// list**. `ops::up_value_plan` rewrites every `--allow-web-egress` entry as one
+/// TCP/443 rule, so an entry shaped any other way cannot be reproduced by the
+/// flag; an entry this reader cannot name makes the WHOLE allowlist
+/// non-reproducible rather than being skipped, because handing the operator a
+/// `cluster up` carrying fewer CIDRs than the release records narrows a live
+/// NetworkPolicy. The count bound is readability only and flips the gate -- it
+/// never truncates.
+fn sandbox_egress_from_values(values: &serde_json::Value) -> (Vec<String>, bool) {
+    // More than this and the fix stops being readable. Exceeding it refuses; it
+    // does not drop entries.
+    const READABILITY_BOUND: usize = 10;
+    let recorded = values
+        .get("security")
+        .and_then(|s| s.get("networkPolicy"))
+        .and_then(|n| n.get("allowedEgress"));
+    let entries = match recorded {
+        // No policy recorded is not a lossy read: emitting no flags reproduces
+        // "nothing" exactly. Otherwise every release without an allowlist would
+        // carry the hazard clause.
+        None | Some(serde_json::Value::Null) => return (Vec::new(), true),
+        Some(serde_json::Value::Array(entries)) => entries,
+        // A shape this reader does not understand is still a recorded policy.
+        Some(_) => return (Vec::new(), false),
+    };
+    if entries.len() > READABILITY_BOUND {
+        return (Vec::new(), false);
+    }
+    let mut cidrs = Vec::with_capacity(entries.len());
+    for entry in entries {
+        let cidr = scalar_at(entry, &["cidr"]).unwrap_or_default();
+        let cidr = cidr.trim();
+        if cidr.is_empty() || !is_plain_https(entry) {
+            return (Vec::new(), false);
+        }
+        cidrs.push(cidr.to_string());
+    }
+    (cidrs, true)
+}
+
+/// Whether one `allowedEgress` entry is exactly the one TCP/443 rule that
+/// `--allow-web-egress` produces. Anything else -- another protocol, another
+/// port, more than one rule, no rules at all -- would be COERCED to TCP/443 by
+/// re-supplying it, which is a narrowing wearing the shape of a fix.
+fn is_plain_https(entry: &serde_json::Value) -> bool {
+    let Some(serde_json::Value::Array(ports)) = entry.get("ports") else {
+        return false;
+    };
+    let [rule] = ports.as_slice() else {
+        return false;
+    };
+    scalar_at(rule, &["protocol"]).is_some_and(|p| p.eq_ignore_ascii_case("TCP"))
+        && scalar_at(rule, &["port"]).as_deref() == Some("443")
+}
+
 // -- observation --------------------------------------------------------------
 
 /// Gather the facts. Every probe is read-only and failure-tolerant: a missing
@@ -3723,8 +4191,10 @@ pub async fn gather(namespace: &str, release: &str, api: Option<(&str, &str)>) -
     let mut f = Facts {
         docker_ok: probe_ok("docker", &["info"]).await,
         bundle_name: bundle_name(),
-        // What this run was pointed at, so the model-pin fix names the release
-        // just diagnosed rather than curie/curie (#1358 item 1).
+        // What this run was pointed at, so every fix -- the model-pin `--set`
+        // and the four cluster commands alike -- names the release this run
+        // reported on rather than whatever `cluster up` happens to default to
+        // (#1358 item 1, #1950).
         target: Some((namespace.to_string(), release.to_string())),
         ..Default::default()
     };
@@ -3792,16 +4262,31 @@ pub async fn gather(namespace: &str, release: &str, api: Option<(&str, &str)>) -
     }
     f.kube_context = Some(ctx.trim().to_string());
 
+    // The probe runs here rather than through `ops::fetch_release_chart`, which
+    // collapses every nonzero exit to `Ok(None)` -- the collapse that made a
+    // missing helm, a cluster that could not answer and an empty namespace
+    // report identically. `fetch_release_chart` is left alone; installation.rs
+    // still calls it.
+    let helm_present = probe_ok("helm", &["version", "--short"]).await;
+    // helm's stderr is bound to `_` and never read, and that is the security
+    // property rather than an oversight: it is an arbitrary external line that
+    // can carry an `Authorization` header, an exec-plugin's argv, or a
+    // token-bearing URL, and this report is pasted into issues and chat. No
+    // prefix denylist can enumerate that risk, so no subprocess stderr reaches
+    // a check's `detail` or `fix` -- the chart, context and NodePort values a
+    // check does render are bounded, structured fields, not diagnostic text
+    // (#1348).
+    let (listed, stdout, _) = capture("helm", &["list", "-n", namespace, "-o", "json"]).await;
+    f.release = classify_release_probe(helm_present, listed, &stdout, release);
+    if !matches!(f.release, ReleaseProbe::Installed { .. }) {
+        return f;
+    }
+
     let common = crate::ops::CommonOpts {
         namespace: namespace.to_string(),
         release: release.to_string(),
         dry_run: false,
     };
-    let Ok(Some(chart)) = crate::ops::fetch_release_chart(&common).await else {
-        return f;
-    };
-    f.release = Some((release.to_string(), chart));
-
     // Two SEPARATE reads, deliberately, issued CONCURRENTLY.
     //
     // Separate: `fetch_release_values` reports only what the operator supplied,
@@ -3833,35 +4318,24 @@ pub async fn gather(namespace: &str, release: &str, api: Option<(&str, &str)>) -
     }
 
     if let Ok(Some(values)) = values {
-        let at = |path: &[&str]| -> Option<String> {
-            let mut node = &values;
-            for k in path {
-                node = node.get(k)?;
-            }
-            node.as_str().map(str::to_string).filter(|s| !s.is_empty())
+        // Presence only, both of them: socket mode needs the pair, and reading
+        // one while reporting both is what made a half-wired release read as Ok.
+        f.slack_bot_token = scalar_at(&values, &["dispatcher", "slack", "botToken"]).is_some();
+        f.slack_app_token = scalar_at(&values, &["dispatcher", "slack", "appToken"]).is_some();
+        // Ask the single decision function first with no NodePort. A `Some`
+        // means ingress already answered and the probe would only be discarded,
+        // so the kubectl round-trip is skipped on the wired path -- doctor is
+        // interactive and that is a subprocess plus an API call per run. The
+        // decision itself still lives in exactly one place; deciding it here
+        // too, to skip the read, is how a helper stays right while the report
+        // goes wrong.
+        f.api_exposure = match api_exposure_from_values(&values, None) {
+            Some(exposure) => Some(exposure),
+            None => api_exposure_from_values(&values, api_nodeport(namespace, release).await),
         };
-        f.slack_configured = at(&["dispatcher", "slack", "botToken"]).is_some();
-        let ingress_on = values
-            .get("api")
-            .and_then(|a| a.get("ingress"))
-            .and_then(|i| i.get("enabled"))
-            .and_then(serde_json::Value::as_bool)
-            .unwrap_or(false);
-        f.api_exposure = if ingress_on {
-            Some(match at(&["api", "ingress", "host"]) {
-                Some(host) => format!("ingress ({host})"),
-                None => "ingress".to_string(),
-            })
-        } else {
-            api_nodeport(namespace, release)
-                .await
-                .map(|p| format!("NodePort {p}"))
-        };
-        // NAMES and shapes only -- never the key or token itself.
-        f.clone_credential = match at(&["api", "githubAppId"]) {
-            Some(id) => Some(format!("github app (app_id={id})")),
-            None => at(&["api", "githubToken"]).map(|_| "personal access token".to_string()),
-        };
+        f.clone_credential = clone_credential_from_values(&values);
+        (f.sandbox_egress_cidrs, f.sandbox_egress_is_reproducible) =
+            sandbox_egress_from_values(&values);
     }
     f
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -878,12 +878,14 @@ enum Command {
     ///
     /// Read-only. Safe to run anywhere, including against production.
     Doctor {
-        /// Kubernetes namespace to inspect.
-        #[arg(long, default_value = "curie")]
-        namespace: String,
-        /// Helm release to inspect.
-        #[arg(long, default_value = "curie")]
-        release: String,
+        /// Kubernetes namespace to inspect. Defaults to `curie.yaml`'s `install:`
+        /// block when one is present in this directory, otherwise `curie`.
+        #[arg(long)]
+        namespace: Option<String>,
+        /// Helm release to inspect. Defaults to `curie.yaml`'s `install:` block
+        /// when one is present in this directory, otherwise `curie`.
+        #[arg(long)]
+        release: Option<String>,
         /// Platform API, to include the repo-binding check. Optional: every
         /// other check needs only kubectl and helm.
         #[arg(long, env = "CURIE_API_URL")]
@@ -4777,8 +4779,48 @@ async fn run(command: Option<Command>) -> Result<()> {
             api_url,
             api_key,
         }) => {
+            // Read-only, and its whole job is to report: a `curie.yaml` it
+            // cannot parse must narrow what doctor knows, never stop it
+            // answering, so the load is best-effort and never propagates. Saying
+            // so out loud matters -- silence would make doctor look like it
+            // ignored the operator's file. But an explicit --namespace/--release
+            // always wins over the file (see resolve_target's precedence), so
+            // only warn about whichever of the two the operator did NOT supply
+            // -- that's the only part an unreadable file could actually change.
+            let declared_path = std::path::Path::new("curie.yaml");
+            let declared = curie::installation::Installation::load(declared_path).ok();
+            if declared.is_none() && declared_path.exists() {
+                // The three sayable cases differ only in which defaults are
+                // being fallen back to, so only that noun phrase varies.
+                let defaults = match (namespace.is_some(), release.is_some()) {
+                    (true, true) => None,
+                    (false, false) => Some("--namespace and --release defaults"),
+                    (true, false) => Some("--release default"),
+                    (false, true) => Some("--namespace default"),
+                };
+                if let Some(defaults) = defaults {
+                    ui::ui().note(&format!(
+                        "a curie.yaml is here but could not be read; \
+                         falling back to the {defaults}"
+                    ));
+                }
+            }
+            let target = curie::doctor::resolve_target(
+                namespace.as_deref(),
+                release.as_deref(),
+                declared
+                    .as_ref()
+                    .map(|c| (c.install.namespace.as_str(), c.install.release.as_str())),
+            );
+            // On stderr, via `note`: `--json` owns stdout, and a machine
+            // consumer parses it whole. The resolution is a fact about how
+            // doctor was TARGETED, not about what it observed, so it also does
+            // not belong in a schema-validated check payload.
+            if let Some(announcement) = &target.announcement {
+                ui::ui().note(announcement);
+            }
             let api = api_url.as_deref().zip(api_key.as_deref());
-            emit(curie::doctor::doctor(&namespace, &release, api).await)
+            emit(curie::doctor::doctor(&target.namespace, &target.release, api).await)
         }
         Some(Command::Diff { file, chart }) => {
             let cfg = curie::installation::Installation::load(&file)?;

--- a/cli/tests/doctor_recovery.rs
+++ b/cli/tests/doctor_recovery.rs
@@ -1,5 +1,8 @@
 //! Integration: the missing-release recovery command uses the provider inferred
-//! by the same credential-prefix map as `curie cluster up`.
+//! by the same credential-prefix map as `curie cluster up`, and names the
+//! namespace and release doctor was actually invoked with (#1358 D1). The
+//! provider inference (#1813) must survive that rewrite unchanged: an absent or
+//! unrecognized credential still leaves egress sealed.
 
 use curie::doctor::{evaluate, Facts};
 use curie::ops::provider_from_credential_prefix;
@@ -10,6 +13,7 @@ fn missing_release_recovery(credential: Option<&str>) -> String {
         model_credential_source: credential.map(|_| "environment".into()),
         model_credential_provider: credential.and_then(provider_from_credential_prefix),
         kube_context: Some("minikube".into()),
+        target: Some(("acme".into(), "acme-bot".into())),
         ..Default::default()
     };
 
@@ -24,8 +28,8 @@ fn missing_release_recovery(credential: Option<&str>) -> String {
 fn missing_release_recovery_infers_egress_from_credential_prefix() {
     let openrouter = missing_release_recovery(Some("sk-or-PLACEHOLDER"));
     assert!(
-        openrouter.starts_with("curie cluster up --namespace <ns> --release <name>"),
-        "recovery command must be runnable: {openrouter}"
+        openrouter.starts_with("curie cluster up --namespace acme --release acme-bot"),
+        "recovery command must be runnable against the invoked target: {openrouter}"
     );
     assert!(
         openrouter.contains("--allow-egress-host openrouter"),
@@ -45,8 +49,22 @@ fn missing_release_recovery_infers_egress_from_credential_prefix() {
     for credential in [None, Some("unknown-PLACEHOLDER")] {
         assert_eq!(
             missing_release_recovery(credential),
-            "curie cluster up --namespace <ns> --release <name>",
+            "curie cluster up --namespace acme --release acme-bot",
             "no unambiguous provider means egress remains sealed"
+        );
+    }
+}
+
+/// The placeholders the recovery command used to print were not runnable, and
+/// worse, they hid that doctor had inspected a different release than the one
+/// the operator was about to act on.
+#[test]
+fn missing_release_recovery_never_prints_a_placeholder_target() {
+    for credential in [None, Some("sk-ant-PLACEHOLDER")] {
+        let command = missing_release_recovery(credential);
+        assert!(
+            !command.contains("<ns>") && !command.contains("<name>"),
+            "the real target replaces the placeholders: {command}"
         );
     }
 }

--- a/cli/tests/doctor_target.rs
+++ b/cli/tests/doctor_target.rs
@@ -1,0 +1,137 @@
+//! Integration (#1358 D6b): `curie doctor` resolves its target from the
+//! `curie.yaml` in the working directory, announces the inference, and never
+//! fails because of that file.
+//!
+//! Both properties here are structurally invisible to the pure
+//! `resolve_target` table in `cli/src/doctor.rs`: hand-passing `None` to the
+//! resolver bypasses the dispatch arm's fail-soft read entirely, and
+//! `DoctorOutput::to_json()` cannot observe which stream a line was written to.
+//! So these run the real binary.
+//!
+//! Offline by construction: `PATH` is emptied, so docker, kubectl and helm are
+//! all absent and every cluster check reports the laptop rung.
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_curie")
+}
+
+/// Run `curie <args>` with the working directory in `dir` and no tools on
+/// `PATH`, so the run needs no cluster and no network.
+fn run_doctor(dir: &Path, empty_path: &Path, args: &[&str]) -> (Option<i32>, String, String) {
+    let output = Command::new(bin())
+        .current_dir(dir)
+        .args(args)
+        .env("PATH", empty_path)
+        .env("LC_ALL", "C")
+        .env_remove("CURIE_API_URL")
+        .env_remove("CURIE_API_KEY")
+        .output()
+        .expect("run curie doctor");
+    (
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
+fn empty_path_dir(root: &Path) -> std::path::PathBuf {
+    let dir = root.join("no-tools");
+    fs::create_dir_all(&dir).expect("create empty PATH directory");
+    dir
+}
+
+/// doctor is read-only and its whole job is to report. A `curie.yaml` it cannot
+/// parse must narrow what it knows, never stop it answering -- which is exactly
+/// what a `?` or an `expect` on the load would do. The pure resolver cannot
+/// catch that: it is handed `None` either way.
+#[test]
+fn a_malformed_curie_yaml_does_not_fail_doctor() {
+    let temp = tempfile::tempdir().expect("create temporary directory");
+    let tools = empty_path_dir(temp.path());
+
+    let cases = [
+        // Not YAML this schema can make sense of at all.
+        ("garbage", ": : not: [valid\n  yaml at all\n"),
+        // Parses, but declares a schema version this binary refuses.
+        (
+            "unsupported version",
+            "version: 99\ninstall:\n  namespace: acme\n  release: acme\n",
+        ),
+    ];
+
+    for (what, body) in cases {
+        fs::write(temp.path().join("curie.yaml"), body).expect("write curie.yaml");
+        let (code, stdout, stderr) = run_doctor(temp.path(), &tools, &["--color=never", "doctor"]);
+
+        assert_eq!(
+            code,
+            Some(0),
+            "a {what} curie.yaml must not fail a read-only report\n\
+             stdout: {stdout}\nstderr: {stderr}"
+        );
+        for line in ["Model credential", "Bundle in this directory"] {
+            assert!(
+                stdout.contains(line),
+                "a {what} curie.yaml must still produce a full report; \
+                 missing {line:?}\nstdout: {stdout}\nstderr: {stderr}"
+            );
+        }
+        assert!(
+            stderr.contains("curie.yaml"),
+            "the operator must be told their file was not read, or doctor looks \
+             like it ignored it\nstderr: {stderr}"
+        );
+    }
+}
+
+/// `--json` owns stdout: a machine consumer parses it whole. An announcement
+/// printed with `println!` or `payload_plain` would corrupt that payload, and no
+/// `to_json()` assertion could ever see it -- only the real streams can.
+#[test]
+fn an_inferred_target_keeps_json_stdout_clean() {
+    let temp = tempfile::tempdir().expect("create temporary directory");
+    let tools = empty_path_dir(temp.path());
+    fs::write(
+        temp.path().join("curie.yaml"),
+        "version: 1\ninstall:\n  namespace: acme\n  release: acme\n",
+    )
+    .expect("write curie.yaml");
+
+    let (code, stdout, stderr) =
+        run_doctor(temp.path(), &tools, &["--color=never", "--json", "doctor"]);
+    assert_eq!(code, Some(0), "stdout: {stdout}\nstderr: {stderr}");
+
+    let values: Vec<serde_json::Value> = serde_json::Deserializer::from_str(&stdout)
+        .into_iter::<serde_json::Value>()
+        .collect::<Result<_, _>>()
+        .unwrap_or_else(|e| panic!("stdout must be JSON, got {stdout:?}: {e}"));
+    assert_eq!(
+        values.len(),
+        1,
+        "stdout must carry exactly one JSON value: {stdout:?}"
+    );
+    assert!(
+        values[0].is_object(),
+        "the one value must be the report object: {stdout:?}"
+    );
+    for noise in ["curie.yaml", "inferred"] {
+        assert!(
+            !stdout.contains(noise),
+            "{noise:?} reached the machine payload: {stdout:?}"
+        );
+    }
+
+    assert!(
+        stderr.contains("curie.yaml"),
+        "the inference must be announced, and named as coming from the file \
+         (INFER, DON'T ASK): {stderr}"
+    );
+    assert!(
+        stderr.contains("acme"),
+        "the announcement must name the target it resolved: {stderr}"
+    );
+}

--- a/cli/tests/json_contract.rs
+++ b/cli/tests/json_contract.rs
@@ -1769,13 +1769,18 @@ fn doctor_output_validates() {
         model_release_key: Some(curie::doctor::ReleaseModelKey::Runner),
         model_release_fake: false,
         model_agent_overrides: vec![],
-        target: Some(("curie".to_string(), "curie".to_string())),
         model_credential_provider: None,
         docker_ok: true,
         bundle_name: Some("my-agent".to_string()),
         kube_context: Some("minikube".to_string()),
-        release: Some(("acme".to_string(), "curie-0.6.0".to_string())),
-        slack_configured: true,
+        target: Some(("acme".to_string(), "acme".to_string())),
+        release: curie::doctor::ReleaseProbe::Installed {
+            chart: "curie-0.6.0".to_string(),
+        },
+        sandbox_egress_cidrs: vec!["160.79.104.0/23".to_string()],
+        sandbox_egress_is_reproducible: true,
+        slack_app_token: true,
+        slack_bot_token: true,
         clone_credential: Some("github app (app_id=1234567)".to_string()),
         api_exposure: None,
         agents: Some(vec![("bot".to_string(), None)]),
@@ -1798,6 +1803,15 @@ fn doctor_output_validates() {
     assert!(states.contains("ok"), "{states:?}");
     assert!(states.contains("missing"), "{states:?}");
 
+    // `ready` is the field a machine consumer gates on, and it was hardcoded
+    // true for long enough that no test ever read it. This fixture has two
+    // Missing checks (webhook, repo-binding), so `ready` must be false.
+    assert_eq!(
+        json["ready"],
+        serde_json::Value::Bool(false),
+        "a report carrying a missing check is not ready: {json}"
+    );
+
     // This payload is pasted into issues; it must never carry a secret value.
     let rendered = serde_json::to_string(&json).expect("serializes");
     for leaked in ["sk-ant-", "xoxb-", "xapp-", "ghp_", "BEGIN RSA"] {
@@ -1806,6 +1820,48 @@ fn doctor_output_validates() {
             "{leaked} in payload: {rendered}"
         );
     }
+}
+
+/// The other direction of the same gate: a fixture with nothing missing must
+/// report `ready: true`, so a constant in either position fails.
+#[test]
+fn doctor_ready_tracks_the_checks() {
+    let facts = curie::doctor::Facts {
+        model_credential: Some("CURIE_CREDENTIALS".to_string()),
+        model_credential_source: Some("environment".to_string()),
+        model_shell: Some("claude-haiku-4-5-20251001".to_string()),
+        model_release_default: None,
+        model_release_key: None,
+        model_release_fake: false,
+        model_agent_overrides: vec![],
+        model_credential_provider: None,
+        docker_ok: true,
+        bundle_name: Some("my-agent".to_string()),
+        kube_context: Some("minikube".to_string()),
+        target: Some(("acme".to_string(), "acme".to_string())),
+        release: curie::doctor::ReleaseProbe::Installed {
+            chart: "curie-0.6.0".to_string(),
+        },
+        sandbox_egress_cidrs: vec![],
+        sandbox_egress_is_reproducible: true,
+        slack_app_token: true,
+        slack_bot_token: true,
+        clone_credential: Some("github app (secret=gh-app)".to_string()),
+        api_exposure: Some("NodePort 30799".to_string()),
+        agents: Some(vec![("bot".to_string(), Some("acme/bot".to_string()))]),
+    };
+    let checks = curie::doctor::evaluate(&facts);
+    let out = curie::doctor::DoctorOutput {
+        summary: curie::doctor::summary(&checks),
+        checks,
+    };
+    let json = out.to_json();
+    assert_valid("doctor.schema.json", &json);
+    assert_eq!(
+        json["ready"],
+        serde_json::Value::Bool(true),
+        "a fully wired report is ready: {json}"
+    );
 }
 
 #[test]

--- a/docs/interfaces/cli-output/INTERFACE.md
+++ b/docs/interfaces/cli-output/INTERFACE.md
@@ -123,7 +123,7 @@ That set is not hand-maintained prose: `cli/schema/index.json` carries one
   longer schema-free: there are 46 committed schemas under `cli/schema/` with an
   index (`cli/schema/index.json`), a `syn`-based inventory gate over every `impl
   CliOutput`, and per-family output validation — all 46 are validated against real
-  `to_json()` output across 72 tests in `cli/tests/json_contract.rs`. Those tests
+  `to_json()` output across 73 tests in `cli/tests/json_contract.rs`. Those tests
   drive each output type's `to_json()` once per output variant rather than calling
   the pure builder functions behind it, so a variant whose `to_json()` arm drifts
   from the schema is caught even when the builder it delegates to still validates.


### PR DESCRIPTION
## Summary

`curie doctor` reported several things that were not true, so following its own advice could reconfigure a different release or break a working install. This fixes the eight defects issue #1358 enumerates: every fix string now carries the `--namespace`/`--release` doctor was invoked with; the webhook fix no longer strips the recorded sandbox egress allowlist; a BYO-Secret clone credential is recognised; two JSON-type-strict values reads now tolerate the shapes a values file produces; a missing `helm`, an uncontactable cluster and a genuinely absent release are four distinct outcomes instead of byte-identical ones; Slack needs both tokens; and a bare `curie doctor` reads `curie.yaml`'s `install:` block the way `apply` and `diff` do.

Two decisions are worth calling out. The target is emitted **unconditionally**, even when it equals the default, because making it conditional would couple doctor's defaults to `cluster up`'s — the assumption that produced the bug. And no transient-versus-permanent split is attempted on the probe: helm wraps permanent auth failures in the same `Kubernetes cluster unreachable` text, which is exactly why `is_connectivity_failure` (`cli/src/ops.rs:4226-4235`) excludes that wrapper. Attempting the split would regress #1136.

The egress fix **fails closed**. `--allow-web-egress` renders every entry as TCP/443, so a rule shaped any other way, an entry whose cidr cannot be read, or a list too long to print makes the *whole* allowlist non-reproducible and the fix names the hazard instead of emitting flags. There is no partial-emission path: a truncated or coerced list would silently narrow a live NetworkPolicy, which is worse than the bug being fixed.

No subprocess stderr reaches a check payload — helm's is never captured — so the report cannot leak a token or key that appeared in an error. The chart, context and NodePort values a check does render are bounded structured fields, not diagnostic text.

`cli/schema/doctor.schema.json` is byte-unchanged; both generated command manifests were regenerated by their own tools.

## Related issue

Closes #1358

## End-to-end verification

`deployed-surface` scale-up fired: the probe classification depends on helm's real exit statuses and `helm list -o json`'s real output shape, and the `curie.yaml` announcement depends on real stdout/stderr separation. Verified with the built binary against a deliberately broken kubeconfig (an exec credential naming a nonexistent binary) and against stub `helm` responses, each compared **against the pre-fix binary on identical input**.

| Scenario | Pre-fix (the reported bug) | This branch |
| --- | --- | --- |
| Unreachable cluster | `ok Cluster eia-tmp` / `MISS Curie release  not installed` | `MISS Cluster … helm list did not answer, so the cluster was not confirmed reachable`; release `--`, "nothing about the release is known" |
| `helm` absent from PATH | byte-identical to the row above | `ok Cluster … helm is not installed, so the cluster was not contacted` / `MISS Curie release  helm is not installed` |
| Reachable, no release | `→ curie cluster up --namespace <ns> --release <name>` | `→ curie cluster up --namespace acme --release acme` |
| Installed release | — | `--allow-web-egress 160.79.104.0/23 --allow-web-egress 192.0.2.0/24` re-supplied; partial Slack reports `MISS`, not "Fully wired" |
| Allowlist with a UDP/53 rule beside a valid TCP/443 one | — | **zero** `--allow-web-egress` flags emitted, plus a warning naming the hazard and pointing at `helm get values` |

`curie.yaml` handling: a bare `curie doctor` infers `acme/acme` and announces it on stderr; `--json` emits exactly one parseable JSON object on stdout with `ready: false` and no note text; an unreadable `curie.yaml` still exits 0 with all ten checks, and says nothing about a fallback when both flags were explicit.

- [x] No required tier is left unproved.

## Checklist

- [x] Tests pass for the area I touched — `cd cli && cargo test`: **1538 passed** (baseline on the base commit: 1500). `cargo fmt --check` and `cargo clippy -- -D warnings` clean. `curie dev docs-lint` and `curie dev contracts` pass. UI: `pnpm lint`/`typecheck`/`test` (147)/`build` all pass, since the generated manifest changed. Python gates (`uv lock --check`, `ruff`, `mypy`, alembic revision gate) pass.
- [x] Docs updated if behavior changed — `docs/interfaces/cli-output/INTERFACE.md` test count corrected (caught by `docs-lint`).
- [x] An ADR is added if this is an architectural decision — n/a, this is a bug fix; no schema, ADR, `packages/aci-protocol` or `packages/plugin-format` change.

## Test quality

Nine targeted mutations of the production code were applied and every one is killed by the suite, including the three the issue reports as previously surviving with 1147 tests green (`ready` hardcoded true, the `docker` check hardcoded Ok, and clone-credential never reaching Missing), the original D1 bug (fixes hardcoding `curie/curie`), the egress gate filtering instead of refusing, exit-0-with-unreadable-stdout classified as `NotInstalled`, ingress truthiness accepting any non-empty string, Slack going Ok on one token, and `scalar_at` stringifying structure.

## Known follow-ups, not fixed here

- **`cluster up` still drops a recorded `security.networkPolicy.allowedEgress`.** This PR fixes the *advice*; the deeper fix is adding that key to the same preservation mechanism that already re-supplies `COMMS_MANAGED_KEYS` / `GITHUB_APP_MANAGED_KEYS` (`cli/src/ops.rs:1070-1093`). `cli/src/ops.rs` was deliberately out of scope here.
- **`ops::lookup_dotted` (`cli/src/ops.rs:1261`) is still `as_str()`-only.** It feeds `preserved_value` and the github-app re-supply, so on a release with an unquoted numeric `api.githubAppId` (the #1253 shape) doctor now correctly reports the credential present while a plain `cluster up` cannot read it back and drops it. Doctor is now more type-tolerant than the command it advises running; the deeper fix is one shared values reader.
- `helm_list_cmd` and `svc_cmd`/`parse_service` in `ops.rs` are private, so doctor re-derives the `helm list` argv and the NodePort read. Worth sharing when `ops.rs` is next open.
