### PR TITLE
Accept finalized cluster replies at timeout boundary

### DIFF
--- a/cli/scripts/e2e-ladder.sh
+++ b/cli/scripts/e2e-ladder.sh
@@ -1197,11 +1197,20 @@ print("yes" if isinstance(d, dict) and d.get("release_found") is True else "no")
     retention_rc=$?
     set -e
     printf '%s\n' "$retention_out"
-    if [[ "$retention_rc" -eq 124 ]]; then
-        echo "cluster: message after repeated eval timed out at 45s; eval-owned sandboxes likely still hold the quota (#1534)." >&2
+    # GNU timeout can return 124 at the same boundary where the CLI has already
+    # emitted its complete finalized JSON but has not quite exited. The reply is
+    # the outcome this check exists to prove, so validate the captured outcome
+    # before diagnosing the process status. A timeout with absent, partial, or
+    # non-finalized JSON still fails here and retains the #1534 diagnosis.
+    if ! assert_finalized_reply "cluster" "$retention_out"; then
+        if [[ "$retention_rc" -eq 124 ]]; then
+            echo "cluster: message after repeated eval timed out at 45s without a finalized reply; eval-owned sandboxes likely still hold the quota (#1534)." >&2
+        fi
         return 1
     fi
-    assert_finalized_reply "cluster" "$retention_out"
+    if [[ "$retention_rc" -eq 124 ]]; then
+        echo "cluster: finalized reply was captured at the 45s timeout boundary; accepting the proved outcome."
+    fi
 
     assert_bundle_identity "cluster" "$digest"
 }

--- a/cli/tests/nightly_graded_ladder.rs
+++ b/cli/tests/nightly_graded_ladder.rs
@@ -425,6 +425,18 @@ fn cluster_rung_repeats_eval_then_messages_inside_claim_timeout() {
         "the post-eval message must still finalize a reply, proving a normal \
          turn can claim after repeated evals; ladder contents:\n{text}"
     );
+    let finalized_assertion = text
+        .find(r#"if ! assert_finalized_reply "cluster" "$retention_out"; then"#)
+        .expect("the bounded post-eval message must validate its captured reply");
+    let timeout_rejection = text
+        .find(r#"if [[ "$retention_rc" -eq 124 ]]; then"#)
+        .expect("the bounded post-eval message must still diagnose a real timeout");
+    assert!(
+        finalized_assertion < timeout_rejection,
+        "a response that finalized at the timeout boundary must be accepted from \
+         its captured JSON before exit 124 is diagnosed; otherwise the ladder can \
+         reject the exact successful outcome it exists to prove; ladder contents:\n{text}"
+    );
 }
 
 // --- Assertion group 6: the EXECUTING parity controls -----------------------


### PR DESCRIPTION
## Summary

- validate the cluster retention check's captured JSON before diagnosing GNU `timeout` exit 124
- accept only a complete, non-empty finalized reply at the boundary
- retain the #1534 timeout failure for absent, partial, or non-finalized output

## Why

The exact v0.7.3 candidate commit's cluster rung captured a complete `{"finalized":true,...}` reply at the 45-second boundary but rejected it solely because `timeout` returned 124. The required-check gate correctly preserves that failure, so this follow-up commit makes the harness judge the observable outcome without weakening the negative path.

## Verification

- `cargo test --test nightly_graded_ladder`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `git diff --check`

## E2E tiers

- skill: not applicable; harness decision is cluster-only
- local: not applicable; local message path is unchanged
- local-release: not applicable; release-compose behavior is unchanged
- cluster: required; PR CI must run and pass the real kind cluster rung
- live provider: not applicable; fake-model plumbing assertion only
- external integration: not applicable; no external API shape changed
