### PR TITLE
docs(adr): draft ADR 0135, Langfuse stays the shipped trace store

### DIFF
--- a/docs/adr/0135-langfuse-stays-the-shipped-trace-store.md
+++ b/docs/adr/0135-langfuse-stays-the-shipped-trace-store.md
@@ -1,0 +1,178 @@
+# 135. Langfuse stays the shipped trace store; the cost, and what would reopen it
+
+Date: 2026-08-29
+
+Status: Draft
+
+Raised by [#2055](https://github.com/curie-eng/curie/issues/2055).
+
+Records a decision the swap-readiness table in
+[`docs/architecture-vision.md`](../architecture-vision.md) already grades but never
+settles: the observability row is graded, the cheapest next step is named, and
+nothing says whether we intend to act on it. [ADR 0016](0016-swappable-jobs-around-an-opinionated-core.md)
+governs the rejected alternative, and [ADR 0004](0004-langfuse-observability-and-eval-backbone.md)
+is the adopt decision this one revisits rather than replaces.
+
+## Context
+
+**What the product actually reads.** The whole read surface funnels through one
+client, and the routes on top of it fan out across the Runs proxy plus the
+observability, evals and cost routers:
+`apps/api/src/curie_api/routers/observability.py:31` and `:43` for the two metrics
+routes, `apps/api/src/curie_api/routers/evals.py:106` for the eval matrix (calling
+`build_matrix` at `:121`), and `GET /cost` at
+`apps/api/src/curie_api/routers/control.py:169-191`, which per `control.py:5`
+"composes the OB1 metrics module filtered to the agent". That is exactly what
+`docs/architecture-vision.md:315` means by "read side spans several API modules plus
+routers". The one client, `apps/api/src/curie_api/langfuse.py:163`, calls itself a
+"Thin async client over Langfuse's public read API" and is 242 lines; its trace-list
+filter is not even server-side, since `langfuse.py:19-22` scans a bounded,
+newest-first page and matches in our own process because "Langfuse's list API has no
+substring filter", capped at `_TRACE_SCAN_LIMIT = 500`. `build_tree()` at
+`langfuse.py:125` rebuilds the nested observation tree from a flat list, again in our
+code. The proxy is `apps/api/src/curie_api/routers/runs.py:1`, "Langfuse read proxy
+powering the Runs view", three routes under the `/langfuse` prefix declared at
+`runs.py:14-18`. The only ClickHouse-featured read is
+`apps/api/src/curie_api/metrics.py`, 255 lines, assembling five aggregates
+(`SCALAR_METRICS` at `metrics.py:35` plus `error_rate` at `metrics.py:36`) in
+`summary()` at `metrics.py:151`. The eval matrix touches no scores at all:
+`apps/api/src/curie_api/evals.py:1-9` reads "the outcome straight off each suite
+trace's metadata", from the `version:` and `suite:` tags, "rather than joining a
+globally-paginated scores query".
+
+**What the rail costs to install.** Langfuse already reuses the shared Valkey
+(`charts/curie/templates/_helpers.tpl:618`), so that is not incremental. What is
+incremental is ClickHouse: `charts/curie/templates/clickhouse.yaml` is 148 template
+lines with a values block spanning `charts/curie/values.yaml:317-424`, plus
+`charts/curie/templates/langfuse-model-pricing.yaml` at 104 lines seeding the model
+price rows so cost is not reported as zero, plus
+`charts/curie/templates/preflight-avx.yaml` at 110 lines existing solely for this
+store. That preflight is the sharpest evidence: newer ClickHouse "is compiled for
+AVX and SIGILLs with exit 132 on CPUs that only have SSE4.2", so the hook reads the
+node's `/proc/cpuinfo` "and if the node lacks AVX it FAILS the install"
+(`charts/curie/templates/preflight-avx.yaml:1-11`). ADR 0004 predicted this gotcha
+in its Consequences; it is now shipped chart surface.
+
+**What the increment buys.** Four things the read surface above does not cover. The
+bundled trace/cost/score web UI as a first-class shipped endpoint, named "Langfuse UI
+(traces / cost / evals)" at `cli/src/observability.rs:116`. The memory-provenance
+deep-link target, `_trace_url()` at
+`apps/api/src/curie_api/routers/memory.py:132-135`, "A Langfuse deep link for a source
+trace id (the trace-back target)". The only rendering of `eval_pass` scores: the
+worker writes the score at `apps/worker/src/curie_worker/eval/recorder.py:142` (under
+`SCORE_NAME`, defined at `recorder.py:27`) and no production code path reads it back.
+Every other first-party reference to it is write-side or prose: the re-export at
+`apps/worker/src/curie_worker/eval/__init__.py:19`, and the eval-matrix docstring at
+`apps/api/src/curie_api/evals.py:5`, which is the matrix explaining that it reads
+metadata instead of the score. With no first-party reader, the bundled UI is the only
+thing that renders it. And the cost engine itself, the price-row matching
+`_cost_known()` documents at `metrics.py:180-190`: Langfuse "returns a generation's
+cost by matching its model to a stored price row; with no matching row it returns 0
+even when tokens were spent".
+
+The disproportion is real, and the repo already graded itself honestly on it:
+`docs/architecture-vision.md:315` marks observability "B+", write side clean but for
+three vendor span attributes and read side spanning several API modules plus routers;
+`docs/architecture-vision.md:316` marks evals "B", leaving the `version:`/`suite:` tag
+convention unfrozen; `docs/architecture-vision.md:109` concedes the read logic "would
+be rewritten, not ported". Those three attributes are frozen into an otherwise-neutral
+vocabulary at `packages/telemetry-schema/src/curie_telemetry_schema/__init__.py:15-17`.
+
+## Decision
+
+**Langfuse stays the shipped trace store.** The disproportion above is accepted
+deliberately, not overlooked.
+
+The obvious alternative -- a thinner store sized to the five aggregates and the tree
+we actually read -- is not merely unattractive. It is **barred by an existing
+decision.** ADR 0016 holds that a port "is promoted from convention to a frozen
+contract only when a real swap demand arrives", and that a PR adding a speculative
+abstraction ahead of a real second implementation violates that ADR "even when the
+code is clean". No such demand is recorded, so building the thin store today is
+exactly the negative work 0016 names.
+
+Related open issues #1645, #1765, #1817, #1818 and #1819 are operability items.
+None of them records this keep-versus-swap decision, which is why it needed its own
+ADR rather than a comment on one of them.
+
+## The revisit trigger
+
+This decision reopens when either of the following is observed, and a future reader
+can check both:
+
+1. **Install-footprint failures the tag pin cannot absorb.** Repeated install
+   failures or operator complaints on no-AVX or arm64 node fleets that pinning an
+   SSE4.2-safe ClickHouse tag does not resolve. The preflight proves this pain is
+   live, not hypothetical: a node without AVX fails the install outright today.
+   "Repeated" means more than one distinct operator or fleet, not one awkward
+   install.
+2. **A customer-demanded second trace store.** Somebody's deployment requires
+   traces in a store we do not ship. This is precisely the "real swap demand" ADR
+   0016 waits for, and its arrival is what would make the thin-store work
+   legitimate rather than speculative.
+
+Absent both, the disproportion is not by itself a trigger. It is the accepted cost.
+
+## Deferred options, costed, none authorized
+
+Listing these here does **not** authorize any of them. They are recorded so a later
+reader inherits the costing rather than redoing it; each still needs its own ticket
+and, where it changes a contract, its own decision.
+
+- **(a) Map the three `langfuse.*` span attributes to neutral names in the
+  collector.** Cost: a collector-side rename plus a change to the frozen
+  `TelemetryAttr` vocabulary at
+  `packages/telemetry-schema/src/curie_telemetry_schema/__init__.py:15-17`. Buys the
+  write-side grade `docs/architecture-vision.md:315` already names, and nothing the
+  product reads today.
+- **(b) Rename the `/langfuse/*` API routes** (`apps/api/src/curie_api/routers/runs.py:15`).
+  Cost: this is `--json` DTO and route surface, governed by
+  [ADR 0101](0101-schema-compatibility-for-closed-schemas.md) (closed schemas version
+  on every change) and [ADR 0103](0103-previous-schema-shape-gate.md) (the previous
+  schema shape gate). It is a versioned, gated schema change, not a rename.
+- **(c) Mark the `eval_pass` score write** at
+  `apps/worker/src/curie_worker/eval/recorder.py:142` **as UI-only rather than dropping
+  it.** Nothing first-party reads the score back, the matrix included: it reads tags
+  and metadata (`apps/api/src/curie_api/evals.py:1-9`). But the score feeds the
+  self-hosted score views at zero marginal cost, so the correct disposition is to
+  label it, not delete it.
+
+## Consequences
+
+Every install keeps paying the ClickHouse footprint, the AVX preflight and the
+price-row seeding, whether or not the operator opens the bundled UI. That is now a
+recorded choice, so a reviewer who rediscovers the disproportion finds this ADR
+instead of filing it again.
+
+The three vendor attributes stay frozen in the telemetry vocabulary and the
+`/langfuse/*` routes stay in the public CLI and API surface. Both are named above as
+deferred, so their presence is not evidence that nobody noticed. The vision doc's B+
+and B grades likewise stand as written: this ADR does not raise them, it records that
+we read them, priced the fix, and declined it for now.
+
+Cost figures stay only as accurate as the seeded price rows. A model with no matching
+row reports zero spend against non-zero tokens, and `_cost_known()` is the only thing
+between that and a wrong number on the dashboard.
+
+## Alternatives rejected
+
+**Build a thin first-party trace store sized to what we read.** Rejected as barred
+by ADR 0016 rather than merely as effort: there is no second implementation and no
+recorded swap demand, so the interface would encode guesses. It would also have to
+reimplement the cost engine, the score views, and the deep-link target, which are
+the parts we get for free and the parts nobody has scoped.
+
+**Do the cheapest-next-step renames now** (options (a) and (b) above). Rejected as
+sequencing: they improve a grade in a table without changing what any deployment
+installs, and (b) drags a gated schema version along with it. If the trigger fires
+they become prerequisites and get done then, with a swap depending on them.
+
+**Drop the `eval_pass` score write because no first-party reader consumes it.**
+Rejected: it costs nothing to keep and it is the only thing populating the
+self-hosted score views. The gap is that its status is undocumented, which option
+(c) fixes by labelling it.
+
+**Leave it unrecorded and let the vision doc's grade speak for it.** Rejected because
+a grade is an assessment, not a decision: the table says the seam is B+ and names a
+cheaper shape, but not that we are keeping the current one, why, or what would change
+our mind. That is the gap this ADR closes.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -145,4 +145,5 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0114 | [Cluster up infers detected install facts](0114-cluster-up-infers-detected-install-facts.md) | Accepted |
 | 0115 | [Agents call each other directly, with no third party in the path](0115-agents-call-each-other-with-no-third-party.md) | Draft |
 | 0123 | [A pending approval's approver set does not follow its route binding](0123-a-pending-approvals-approver-set-does-not-follow-its-route-binding.md) | Accepted |
+| 0135 | [Langfuse stays the shipped trace store; the cost, and what would reopen it](0135-langfuse-stays-the-shipped-trace-store.md) | Draft |
 <!-- END GENERATED: adr-index -->


### PR DESCRIPTION
Draft ADR 0135 recording the Langfuse keep-versus-swap decision that the swap-readiness
table in `docs/architecture-vision.md` grades but never settles. Docs only, no code change.

Ref #2055

## What it records

- **The decision.** Langfuse stays the shipped trace store. The disproportion between what
  the rail costs to install and what the product's own reads use is accepted deliberately.
- **The accepted cost.** ClickHouse (`charts/curie/templates/clickhouse.yaml`, 148 template
  lines, values block `charts/curie/values.yaml:317-424`), the AVX preflight that exists
  solely for it (`charts/curie/templates/preflight-avx.yaml`, 110 lines), and the
  model-pricing seed (`charts/curie/templates/langfuse-model-pricing.yaml`, 104 lines).
  Langfuse already reuses the shared Valkey (`_helpers.tpl:618`), so that is not incremental.
- **What the product actually reads.** One client
  (`apps/api/src/curie_api/langfuse.py:163`) with routes fanning out across the Runs proxy,
  observability, evals and cost routers; the trace list with a client-side substring filter
  (`langfuse.py:19-22`), the tree rebuilt in our code (`langfuse.py:125`), five metrics
  aggregates (`metrics.py:35-36`, `:151`), cost from matched price rows (`metrics.py:180-190`),
  and a tags-and-metadata-only eval matrix (`evals.py:1-9`).
- **`ADR 0016` bars the alternative.** Building a thinner store ahead of a recorded swap
  demand is the speculative-abstraction case ADR 0016 names, so the ADR says so explicitly
  rather than treating the thin store as merely unattractive.
- **A checkable revisit trigger.** Repeated install-footprint failures on no-AVX or arm64
  fleets that an SSE4.2-safe tag pin cannot absorb, or a customer-demanded second trace
  store. The AVX preflight is cited as evidence that this pain is already live.
- **Three deferred options, costed, none authorized.** Neutral span-attribute names in the
  collector; the `/langfuse/*` route rename (gated schema surface under ADR 0101 / ADR 0103);
  and marking the `eval_pass` score write UI-only rather than dropping it.
- Notes that #1645, #1765, #1817, #1818 and #1819 are operability items and do not record
  this decision.

## ADR number check: 0135 is free across main, next, and open PRs

```
$ { git ls-tree --name-only origin/main docs/adr/; git ls-tree --name-only origin/next docs/adr/; } \
    | grep -oP '^docs/adr/\K[0-9]{4}' | sort -u > /tmp/refnums.txt
count=134   max=0134

$ comm -13 /tmp/refnums.txt <(seq -w 1 140 | sed 's/^/0/' | cut -c1-4)     # first free numbers
0135 0136 0137 0138 0139 0140

$ for n in $(gh pr list --state open --limit 300 --json number -q '.[].number'); do
      gh api --paginate "repos/curie-eng/curie/pulls/$n/files" -q '.[].filename' | grep '^docs/adr/'
  done
(no output: none of the 10 open PRs touches docs/adr/)
```

The paginated API form is used deliberately: `gh pr view --json files` caps at 100 files, and
PR #1889 has 141. This is the #1949/#1957 collision class.

## Validation

`bash scripts/check-docs.sh` exits 0, all four phases:

```
== checking ADR numbers are unique ==
== regenerating the seam table, the ADR index, and per-doc headers ==
== checking for drift ==
== verifying generated counts, the verification contract, and every citation ==
OK: the interface catalog is generated and drift-free, every citation resolves, and every
command the verification contract names is real.
```

`docs/adr/README.md` is regenerated by that script and committed, never hand-edited.
`scripts/check-commit-messages.sh origin/main..HEAD` is clean. The ADR is pure ASCII
(`LC_ALL=C grep -n '[^ -~]'` returns nothing), so no em dash, en dash, or emoji.

## Note on the issue's line numbers

Several file:line citations in the issue body had drifted against `main` and were re-verified
before use: the client docstring is at `langfuse.py:163` (issue said `:162`); the
swap-readiness rows are `architecture-vision.md:315` and `:316` (issue said `:313-314`);
"rewritten, not ported" is at `:109`; the eval-matrix docstring is in
`apps/api/src/curie_api/evals.py`, not `routers/evals.py`; and the pricing chart is at
`charts/curie/templates/langfuse-model-pricing.yaml`. The ADR cites the verified locations.

## Done-check

- [x] **Adversarial code review** (agent-router, primary `claude` excluded, reviewer Codex
      `gpt-5.6-sol`): first pass returned five P1 citation defects, all independently confirmed
      against the tree and fixed. Re-review confirmed all five corrections and raised one P2
      (a search claim stated more broadly than what was checked), also fixed. See
      "Review findings" below.
- [x] **Adversarial scope review**: covered in the same sealed request. Every hunk traces to an
      AC in #2055; the single added `docs/adr/README.md` row is generated output.
- [x] **Docs gate**: `bash scripts/check-docs.sh` green, output above. This is the verify
      command for the docs package; no other package is touched.
- [ ] Failing-tests-first, delegated-executor edits, consolidation pass: **N/A**, docs-only
      change with no behavior and no test surface. `/simplify` targets code consolidation and
      has nothing to act on in a single prose file.
- [ ] Sibling-path parity, guard demonstration, E2E, security review: **N/A**, no seam, guard,
      deployed surface, or security surface is touched.

## Review findings, and what changed

| # | Finding | Fix |
|---|---|---|
| P1 | "The whole read surface is one client and three routes" was false: Langfuse is also read by `routers/observability.py:31,43`, `routers/evals.py:106`, and `routers/control.py:169-191` | Reworded to one client with routes fanning out across four routers, which is also what `architecture-vision.md:315` already says |
| P1 | The "Langfuse read proxy powering the Runs view" quote was cited to `runs.py:14-18`; it is the module docstring at `runs.py:1` | Split into two citations, each on what it supports |
| P1 | The ClickHouse values block was cited as `values.yaml:317-439`; it ends at 424 (426-439 are the RustFS and sealing headers) | Corrected to `:317-424` |
| P1 | "The only place `eval_pass` scores render" was not carried by its citations, which showed the write, not exclusivity | Regrounded on the writer at `recorder.py:142` plus the absence of any reader |
| P1 | The ADR 0016 quotation silently lowercased "A port" | Quotation now begins at "is promoted...", verbatim against `0016-...md:37-38` |
| P2 | The replacement claimed a repo-wide search "finds only" three references; prose docs mention the symbol too | Narrowed to the claim actually checked: no production code path reads the score back |

## Status

`Status: Draft`. Per [`docs/adr/AGENTS.md`](docs/adr/AGENTS.md) a Draft may merge for discussion
but does not authorize implementation, and the three deferred options are explicitly not
pre-authorized. Acceptance is a maintainer act.
