### PR TITLE
Resolve Langfuse store credentials through <store>.existingSecret

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -142,6 +142,17 @@ jobs:
           set -euo pipefail
           bash charts/curie/ci/clickhouse-logging-assertions.sh
 
+      # Prove Langfuse honors valkey.existingSecret on a BYO valkey install
+      # (#2052). A supported BYO install (valkey.deploy=false + host +
+      # existingSecret) had every component read the operator's Secret except
+      # Langfuse, which stayed pinned to the chart-managed Secret -- so trace
+      # ingestion died alone while the rest of the release stayed healthy,
+      # which is why nothing pointed at the cause.
+      - name: helm render assertions (langfuse valkey existingSecret)
+        run: |
+          set -euo pipefail
+          bash charts/curie/ci/valkey-existing-secret-assertions.sh
+
       # Prove the tenant capacity ceiling actually binds the pods it is meant to.
       # The quota is PriorityClass-scoped, so if its scope is not the name the
       # sandbox pods carry it matches nothing and enforces nothing -- silently,

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,11 @@ oauth.env
 # render-assertion script, not secret material. Without this the `*secret*` rule
 # drops it and the CI step that runs it goes red on a missing file.
 !charts/curie/ci/otel-collector-langfuse-secret-assertions.sh
+# Same exception for the Langfuse valkey.existingSecret wiring assertions
+# (#2052): a render-assertion script, not secret material. Without this the
+# `*secret*` rule drops it and the CI step that runs it goes red on a missing
+# file.
+!charts/curie/ci/valkey-existing-secret-assertions.sh
 # Same exception for the direct-passthrough existingSecret assertions (#1759):
 # a render-assertion script, not secret material. Without this the `*secret*`
 # rule drops it and the CI step that runs it goes red on a missing file.

--- a/charts/curie/CLAUDE.md
+++ b/charts/curie/CLAUDE.md
@@ -17,6 +17,15 @@ component and rail detail in `charts/curie/README.md`.
   BYO `host`/`port`/`auth`/`existingSecret` fields on the same block. A new
   backing store must follow this exact pattern -- do not add a store with a
   different enable/disable shape.
+  Known exceptions: in `curie.langfuse.env` (`_helpers.tpl`), `POSTGRES_PASSWORD`
+  (`postgresPassword`) still ignores `postgres.existingSecret`, and `SALT`
+  (`langfuseSalt`) / `ENCRYPTION_KEY` (`langfuseEncryptionKey`) still ignore
+  `langfuse.existingSecret` -- #2052 fixed the valkey and clickhouse half of
+  this idiom and enumerated these three as the remainder, not yet tracked by
+  an issue. Until they're fixed the invariant is aspirational for them: an
+  operator on BYO postgres or a BYO `langfuse.existingSecret` gets the
+  chart-generated value instead of theirs. `ENCRYPTION_KEY` is the sharpest --
+  a mismatched key means previously written encrypted columns stop decrypting.
 - **Values keys are camelCase, not hyphenated.** Go templates cannot
   dot-index a hyphenated key. Keep this consistent across any new values
   additions.

--- a/charts/curie/ci/clickhouse-logging-assertions.sh
+++ b/charts/curie/ci/clickhouse-logging-assertions.sh
@@ -29,6 +29,15 @@
 #      mistake was made while developing this change, so it is asserted.
 #   8. `clickhouse.deploy=false` renders nothing, and `persistence.enabled=false`
 #      still gets its `data` emptyDir alongside the new `config` volume.
+#   9. `clickhouse.existingSecret` reaches Langfuse, not just the in-chart
+#      server. Both langfuse containers' CLICKHOUSE_PASSWORD and the StatefulSet's
+#      own must resolve to the SAME named Secret, with the default render still
+#      resolving to the chart's own. Langfuse hardcoded the chart Secret (#2052),
+#      which fails silently in two directions: with `deploy=false` + `host` +
+#      `existingSecret` only Langfuse authenticated against the wrong password,
+#      and with `deploy=true` + `existingSecret` the in-chart server and Langfuse
+#      disagreed about the password entirely (split-brain auth). Either way the
+#      release comes up green and trace ingestion is simply gone.
 #
 # Why this is worth a gate: stock ClickHouse config is sized for a dedicated
 # analytics box, and the chart runs it as an embedded store for kilobytes of
@@ -74,6 +83,7 @@ manifest_for() {
 echo "=== Rendering ClickHouse (defaults) ==="
 render default "$CHART"
 DEFAULT="$(manifest_for "$RENDER_DIR")"
+DEFAULT_TEMPLATES="$RENDER_DIR/curie/templates"
 
 echo "=== Rendering ClickHouse (systemLogs.enabled=true, retentionDays=7) ==="
 render verbose "$CHART" \
@@ -90,6 +100,10 @@ render off "$CHART" \
   --set clickhouse.deploy=false \
   --set clickhouse.host=clickhouse.example.com
 OFF="$RENDER_DIR"
+
+echo "=== Rendering ClickHouse (existingSecret=acme-ch) ==="
+render existing-secret "$CHART" --set clickhouse.existingSecret=acme-ch
+EXISTING_SECRET_TEMPLATES="$RENDER_DIR/curie/templates"
 
 CHECKSUM_VALUES=(
   --set clickhouse.logLevel=warning
@@ -273,6 +287,97 @@ if [[ -d "$OFF" ]] && [[ -n "$(find "$OFF" -type f -path "*/templates/clickhouse
   fail "clickhouse.deploy=false still rendered the ClickHouse manifest"
 fi
 echo "  clickhouse.deploy=false renders no ClickHouse manifest: OK"
+
+# ------------------------------------------------------------------------ 9
+# clickhouse.existingSecret must reach EVERY consumer of the password, not just
+# the in-chart server. Structural check via PyYAML rather than grep: a
+# line-oriented reader silently mis-reads a requoted value or a reordered key.
+DEFAULT_TEMPLATES="$DEFAULT_TEMPLATES" \
+EXISTING_SECRET_TEMPLATES="$EXISTING_SECRET_TEMPLATES" \
+python3 <<'PY'
+import os, sys, yaml
+
+DEFAULT_TEMPLATES = os.environ["DEFAULT_TEMPLATES"]
+BYO_TEMPLATES = os.environ["EXISTING_SECRET_TEMPLATES"]
+
+# `helm template rel <chart>` -> fullname `rel-curie`.
+CHART_SECRET_NAME = "rel-curie-secrets"
+BYO_SECRET_NAME = "acme-ch"
+KEY = "clickhousePassword"
+
+failures = []
+
+
+def containers(obj, acc):
+    if isinstance(obj, dict):
+        if isinstance(obj.get("containers"), list):
+            acc.extend(obj["containers"])
+        for v in obj.values():
+            containers(v, acc)
+    elif isinstance(obj, list):
+        for item in obj:
+            containers(item, acc)
+
+
+def check(aid, manifest, container, expected, ctx):
+    if not os.path.isfile(manifest):
+        failures.append(f"[{aid}] {ctx}: {manifest} did not render")
+        return
+    with open(manifest) as f:
+        docs = [d for d in yaml.safe_load_all(f) if d]
+    found = []
+    containers(docs, found)
+    matched = [c for c in found if isinstance(c, dict) and c.get("name") == container]
+    entries = [e for c in matched for e in (c.get("env") or [])
+               if e.get("name") == "CLICKHOUSE_PASSWORD"]
+    if len(entries) != 1:
+        failures.append(f"[{aid}] {ctx}: CLICKHOUSE_PASSWORD rendered {len(entries)} times "
+                        f"on container {container!r}, expected exactly 1")
+        return
+    ref = (entries[0].get("valueFrom") or {}).get("secretKeyRef")
+    if not ref:
+        failures.append(f"[{aid}] {ctx}: CLICKHOUSE_PASSWORD has no valueFrom.secretKeyRef "
+                        "(an inline value would put the password in the manifest)")
+        return
+    if ref.get("name") != expected:
+        failures.append(f"[{aid}] {ctx}: CLICKHOUSE_PASSWORD secretKeyRef.name = "
+                        f"{ref.get('name')!r}, expected {expected!r}")
+    if ref.get("key") != KEY:
+        failures.append(f"[{aid}] {ctx}: CLICKHOUSE_PASSWORD secretKeyRef.key = "
+                        f"{ref.get('key')!r}, expected {KEY!r}")
+
+
+# 9a/9b: no-regression -- the default render still resolves to the chart Secret,
+# so the escape does not repoint an install that never set existingSecret.
+for i, c in enumerate(("langfuse-web", "langfuse-worker")):
+    check(f"9a{i}", f"{DEFAULT_TEMPLATES}/langfuse.yaml", c, CHART_SECRET_NAME,
+          f"default render, {c}")
+
+# 9c/9d: both langfuse Deployments include the shared env helper separately, so
+# a fix applied to one include site and not the other renders half a release.
+for i, c in enumerate(("langfuse-web", "langfuse-worker")):
+    check(f"9c{i}", f"{BYO_TEMPLATES}/langfuse.yaml", c, BYO_SECRET_NAME,
+          f"clickhouse.existingSecret set, {c}")
+
+# 9e: the in-chart server in the SAME render. With deploy=true + existingSecret,
+# the server and Langfuse reading different Secrets is split-brain auth -- both
+# sides are asserted together so a future edit cannot "fix" the split by
+# breaking the server instead.
+check("9e", f"{BYO_TEMPLATES}/clickhouse.yaml", "clickhouse", BYO_SECRET_NAME,
+      "clickhouse.existingSecret set, in-chart StatefulSet")
+
+if failures:
+    for msg in failures:
+        print(f"FAIL {msg}", file=sys.stderr)
+    print(f"{len(failures)} of 5 assertion-9 checks failed. See #2052: Langfuse "
+          "hardcoded the chart Secret while every other consumer honoured "
+          "clickhouse.existingSecret, so trace ingestion died with the release green.",
+          file=sys.stderr)
+    sys.exit(1)
+
+print("  clickhouse.existingSecret reaches langfuse web+worker and the StatefulSet, "
+      "default unchanged: OK")
+PY
 
 echo
 echo "PASS: ClickHouse self-telemetry defaults are bounded."

--- a/charts/curie/ci/valkey-existing-secret-assertions.sh
+++ b/charts/curie/ci/valkey-existing-secret-assertions.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+#
+# Render-assertion test for `valkey.existingSecret` reaching Langfuse (#2052).
+#
+# The chart's stated invariant (charts/curie/CLAUDE.md, "Every backing store
+# follows the same toggle + BYO idiom") is that flipping `<store>.deploy` to
+# false repoints EVERY consumer at the BYO `host`/`port`/`auth`/`existingSecret`
+# fields on the same block. Valkey had two consumer groups and only one of them
+# honoured it: `curie.env.valkey` (api + worker) read
+# `valkey.existingSecret | default <chart secret>`, while `curie.langfuse.env`
+# hardcoded the chart Secret for REDIS_AUTH.
+#
+# The consequence is silent and asymmetric, which is why it is worth a gate. On
+# a BYO valkey install (`deploy=false` + `host` + `existingSecret`) the chart
+# Secret still renders and still holds the chart-generated valkeyPassword, so
+# nothing errors at template or install time. The api and worker authenticate
+# against the real instance and stay healthy; only Langfuse presents the wrong
+# password, so trace ingestion dies while every other component reports green.
+# There is no failing manifest, no failing preflight, and no unhealthy pod to
+# point at the cause -- exactly the shape of the rustfs endpoint bug already
+# tombstoned in the same `curie.langfuse.env` block.
+#
+# Asserts:
+#
+#   1. DEFAULT render: REDIS_AUTH on BOTH langfuse containers resolves to the
+#      chart's own Secret, key `valkeyPassword`. The no-regression case -- the
+#      fix must not repoint an install that never set existingSecret.
+#   2. `valkey.existingSecret=acme-valkey`: REDIS_AUTH on BOTH langfuse
+#      containers resolves to `acme-valkey`. Both, because web and worker are
+#      separate Deployments that each include the shared env helper; a fix
+#      applied to one include site and not the other renders half a release.
+#   3. Parity in the SAME render: VALKEY_PASSWORD on the api and worker
+#      containers also resolves to `acme-valkey`. This is the pair that was
+#      split, so both sides are asserted together -- asserting only the langfuse
+#      half would let a future edit "fix" the split by breaking the app services
+#      instead.
+#   4. The realistic full BYO shape (`deploy=false` + `host` + `existingSecret`):
+#      no valkey StatefulSet renders AND langfuse still resolves `acme-valkey`.
+#      This is the exact supported configuration the bug broke, and it is not
+#      the same render as (2) -- (2) keeps the in-chart valkey, so it alone
+#      cannot prove the deploy=false path.
+#   5. NEGATIVE CONTROL: under the BYO render, the chart Secret name must NOT
+#      appear as the REDIS_AUTH secretKeyRef on either langfuse container.
+#      Without this, assertions 2 and 4 would still pass against a template that
+#      emitted REDIS_AUTH twice or fell back to the chart Secret, and the gate
+#      would be vacuous.
+#
+# Deliberately NOT asserted: POSTGRES_PASSWORD, SALT and ENCRYPTION_KEY in the
+# same `curie.langfuse.env` block still hardcode the chart Secret even though
+# `postgres.existingSecret` and `langfuse.existingSecret` exist. That is a known
+# gap tracked separately; pinning their current values here would freeze the bug
+# into the gate.
+#
+# Every render goes through `--output-dir`, never a stdout pipe: piping
+# `helm template` in this environment silently truncates a large render at
+# exit 0 with empty stderr, which reads as a passing assertion against manifests
+# that were never examined. Structural checks go through PyYAML rather than
+# grep, for the reason dispatcher-api-wiring-assertions.sh gives -- a
+# line-oriented reader mis-reads a requoted value or a reordered key.
+#
+# Runnable locally (from anywhere) and from CI. Fails loudly.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+render() {
+  local name="$1"
+  shift
+  RENDER_DIR="$TMP/$name"
+  rm -rf "$RENDER_DIR"
+  helm template rel "$CHART" --output-dir "$RENDER_DIR" "$@" >/dev/null \
+    || fail "helm template failed for render '$name'"
+}
+
+echo "=== Rendering Langfuse (defaults) ==="
+render default
+DEFAULT_DIR="$RENDER_DIR/curie/templates"
+
+echo "=== Rendering Langfuse (valkey.existingSecret=acme-valkey) ==="
+render byo --set valkey.existingSecret=acme-valkey
+BYO_DIR="$RENDER_DIR/curie/templates"
+
+echo "=== Rendering Langfuse (valkey.deploy=false + host + existingSecret) ==="
+render byo-full \
+  --set valkey.deploy=false \
+  --set valkey.host=redis.acme.internal \
+  --set valkey.existingSecret=acme-valkey
+BYO_FULL_DIR="$RENDER_DIR/curie/templates"
+
+# ---------------------------------------------------------------------- 4a
+# A missing manifest file is --output-dir's signal that the whole template
+# rendered nothing (the same check direct-passthrough-existing-secret-
+# assertions.sh uses); an empty document would not be distinguishable.
+if [[ -s "$BYO_FULL_DIR/valkey.yaml" ]]; then
+  fail "[4a] valkey.deploy=false still rendered templates/valkey.yaml"
+fi
+echo "  [4a] valkey.deploy=false renders no in-chart valkey manifest: OK"
+
+# ------------------------------------------------------------- 1, 2, 3, 4b, 5
+DEFAULT_DIR="$DEFAULT_DIR" BYO_DIR="$BYO_DIR" BYO_FULL_DIR="$BYO_FULL_DIR" \
+python3 <<'PY'
+import os
+import sys
+
+import yaml
+
+DEFAULT_DIR = os.environ["DEFAULT_DIR"]
+BYO_DIR = os.environ["BYO_DIR"]
+BYO_FULL_DIR = os.environ["BYO_FULL_DIR"]
+
+# `helm template rel <chart>` -> fullname `rel-curie`, so the chart's own
+# Secret is `rel-curie-secrets`. Hardcoded rather than derived: the point of
+# the negative control is that this exact name must NOT appear.
+CHART_SECRET_NAME = "rel-curie-secrets"
+BYO_SECRET_NAME = "acme-valkey"
+
+failures = []
+
+
+def load_docs(path):
+    if not os.path.isfile(path):
+        return []
+    with open(path) as f:
+        return [d for d in yaml.safe_load_all(f) if d]
+
+
+def find_containers(obj, acc):
+    if isinstance(obj, dict):
+        containers = obj.get("containers")
+        if isinstance(containers, list):
+            acc.extend(containers)
+        for v in obj.values():
+            find_containers(v, acc)
+    elif isinstance(obj, list):
+        for item in obj:
+            find_containers(item, acc)
+
+
+def find_env(manifest, container_name, env_name):
+    """Return (secretKeyRef-or-None, match-count) for one env entry.
+
+    Searches every container across every document in the file, so one helper
+    covers langfuse.yaml's two Deployments (langfuse-web / langfuse-worker) as
+    well as api.yaml and worker.yaml.
+    """
+    containers = []
+    for d in load_docs(manifest):
+        find_containers(d, containers)
+    matched = [c for c in containers
+               if isinstance(c, dict) and c.get("name") == container_name]
+    entries = [e for c in matched for e in (c.get("env") or [])
+               if e.get("name") == env_name]
+    if len(entries) != 1:
+        return None, len(entries)
+    ref = (entries[0].get("valueFrom") or {}).get("secretKeyRef")
+    return ref, 1
+
+
+def check_ref(aid, manifest, container, env_name, expected_secret, expected_key, ctx):
+    ref, n = find_env(manifest, container, env_name)
+    if n == 0:
+        failures.append(f"[{aid}] {ctx}: {env_name} did not render on container "
+                        f"{container!r} in {manifest}")
+        return
+    if n > 1:
+        failures.append(f"[{aid}] {ctx}: {env_name} rendered {n} times on container "
+                        f"{container!r}, expected exactly 1")
+        return
+    if not ref:
+        failures.append(f"[{aid}] {ctx}: {env_name} has no valueFrom.secretKeyRef "
+                        "(an inline value would put this credential in the manifest)")
+        return
+    if ref.get("name") != expected_secret:
+        failures.append(f"[{aid}] {ctx}: {env_name} secretKeyRef.name = "
+                        f"{ref.get('name')!r}, expected {expected_secret!r}")
+    if ref.get("key") != expected_key:
+        failures.append(f"[{aid}] {ctx}: {env_name} secretKeyRef.key = "
+                        f"{ref.get('key')!r}, expected {expected_key!r}")
+
+
+LANGFUSE_CONTAINERS = ["langfuse-web", "langfuse-worker"]
+
+# ---- 1: default render still resolves to the chart's own Secret. ----
+for i, c in enumerate(LANGFUSE_CONTAINERS):
+    check_ref(f"1{chr(ord('a') + i)}", f"{DEFAULT_DIR}/langfuse.yaml", c,
+              "REDIS_AUTH", CHART_SECRET_NAME, "valkeyPassword",
+              f"default render, {c}")
+
+# ---- 2: valkey.existingSecret reaches BOTH langfuse containers. ----
+for i, c in enumerate(LANGFUSE_CONTAINERS):
+    check_ref(f"2{chr(ord('a') + i)}", f"{BYO_DIR}/langfuse.yaml", c,
+              "REDIS_AUTH", BYO_SECRET_NAME, "valkeyPassword",
+              f"valkey.existingSecret set, {c}")
+
+# ---- 3: parity with the app services in the SAME render. This is the pair
+#         that was split, so both halves are asserted together. ----
+check_ref("3a", f"{BYO_DIR}/api.yaml", "api", "VALKEY_PASSWORD",
+          BYO_SECRET_NAME, "valkeyPassword", "valkey.existingSecret set, api")
+check_ref("3b", f"{BYO_DIR}/worker.yaml", "worker", "VALKEY_PASSWORD",
+          BYO_SECRET_NAME, "valkeyPassword", "valkey.existingSecret set, worker")
+
+# ---- 4b: the realistic full BYO shape (deploy=false + host + existingSecret)
+#          -- the exact supported configuration the bug broke. ----
+for i, c in enumerate(LANGFUSE_CONTAINERS):
+    check_ref(f"4b{chr(ord('i') + i)}", f"{BYO_FULL_DIR}/langfuse.yaml", c,
+              "REDIS_AUTH", BYO_SECRET_NAME, "valkeyPassword",
+              f"valkey.deploy=false + host + existingSecret, {c}")
+
+# ---- 5: NEGATIVE CONTROL. Proves the assertion catches the #2052 bug rather
+#         than passing vacuously: under both BYO renders the chart Secret must
+#         not back REDIS_AUTH on either langfuse container. ----
+for label, d in (("byo", BYO_DIR), ("byo-full", BYO_FULL_DIR)):
+    for c in LANGFUSE_CONTAINERS:
+        ref, n = find_env(f"{d}/langfuse.yaml", c, "REDIS_AUTH")
+        if n == 1 and ref and ref.get("name") == CHART_SECRET_NAME:
+            failures.append(
+                f"[5] negative control ({label}, {c}): REDIS_AUTH still resolves to the "
+                f"chart-managed Secret {CHART_SECRET_NAME!r} with valkey.existingSecret="
+                f"{BYO_SECRET_NAME!r} set. This is issue #2052: the app services read the BYO "
+                "Secret while Langfuse alone reads the chart one, so Langfuse presents the "
+                "wrong password and trace ingestion dies silently with the rest of the "
+                "release healthy.")
+
+if failures:
+    for msg in failures:
+        print(f"FAIL {msg}", file=sys.stderr)
+    print(f"{len(failures)} of 10 python-side assertions failed", file=sys.stderr)
+    sys.exit(1)
+
+print("  [1] default render: REDIS_AUTH -> chart Secret on web + worker: OK")
+print("  [2] valkey.existingSecret: REDIS_AUTH -> BYO Secret on web + worker: OK")
+print("  [3] same render: VALKEY_PASSWORD -> BYO Secret on api + worker: OK")
+print("  [4b] deploy=false + host + existingSecret: langfuse -> BYO Secret: OK")
+print("  [5] negative control: chart Secret never backs REDIS_AUTH under BYO: OK")
+PY
+
+echo
+echo "PASS: valkey.existingSecret reaches every consumer, Langfuse included (#2052)."

--- a/charts/curie/ci/valkey-existing-secret-assertions.sh
+++ b/charts/curie/ci/valkey-existing-secret-assertions.sh
@@ -184,17 +184,19 @@ def check_ref(aid, manifest, container, env_name, expected_secret, expected_key,
                         f"{ref.get('key')!r}, expected {expected_key!r}")
 
 
-LANGFUSE_CONTAINERS = ["langfuse-web", "langfuse-worker"]
+# Paired with a literal id suffix so every per-container assertion id follows the
+# same a/b convention as the single-container ones (3a/3b) in this file.
+LANGFUSE_CONTAINERS = [("a", "langfuse-web"), ("b", "langfuse-worker")]
 
 # ---- 1: default render still resolves to the chart's own Secret. ----
-for i, c in enumerate(LANGFUSE_CONTAINERS):
-    check_ref(f"1{chr(ord('a') + i)}", f"{DEFAULT_DIR}/langfuse.yaml", c,
+for suffix, c in LANGFUSE_CONTAINERS:
+    check_ref(f"1{suffix}", f"{DEFAULT_DIR}/langfuse.yaml", c,
               "REDIS_AUTH", CHART_SECRET_NAME, "valkeyPassword",
               f"default render, {c}")
 
 # ---- 2: valkey.existingSecret reaches BOTH langfuse containers. ----
-for i, c in enumerate(LANGFUSE_CONTAINERS):
-    check_ref(f"2{chr(ord('a') + i)}", f"{BYO_DIR}/langfuse.yaml", c,
+for suffix, c in LANGFUSE_CONTAINERS:
+    check_ref(f"2{suffix}", f"{BYO_DIR}/langfuse.yaml", c,
               "REDIS_AUTH", BYO_SECRET_NAME, "valkeyPassword",
               f"valkey.existingSecret set, {c}")
 
@@ -207,8 +209,8 @@ check_ref("3b", f"{BYO_DIR}/worker.yaml", "worker", "VALKEY_PASSWORD",
 
 # ---- 4b: the realistic full BYO shape (deploy=false + host + existingSecret)
 #          -- the exact supported configuration the bug broke. ----
-for i, c in enumerate(LANGFUSE_CONTAINERS):
-    check_ref(f"4b{chr(ord('i') + i)}", f"{BYO_FULL_DIR}/langfuse.yaml", c,
+for suffix, c in LANGFUSE_CONTAINERS:
+    check_ref(f"4b{suffix}", f"{BYO_FULL_DIR}/langfuse.yaml", c,
               "REDIS_AUTH", BYO_SECRET_NAME, "valkeyPassword",
               f"valkey.deploy=false + host + existingSecret, {c}")
 
@@ -216,7 +218,7 @@ for i, c in enumerate(LANGFUSE_CONTAINERS):
 #         than passing vacuously: under both BYO renders the chart Secret must
 #         not back REDIS_AUTH on either langfuse container. ----
 for label, d in (("byo", BYO_DIR), ("byo-full", BYO_FULL_DIR)):
-    for c in LANGFUSE_CONTAINERS:
+    for _suffix, c in LANGFUSE_CONTAINERS:
         ref, n = find_env(f"{d}/langfuse.yaml", c, "REDIS_AUTH")
         if n == 1 and ref and ref.get("name") == CHART_SECRET_NAME:
             failures.append(

--- a/charts/curie/templates/_helpers.tpl
+++ b/charts/curie/templates/_helpers.tpl
@@ -607,10 +607,18 @@ livenessProbe:
   value: http://{{ include "curie.clickhouse.host" . }}:{{ .Values.clickhouse.httpPort }}
 - name: CLICKHOUSE_USER
   value: {{ .Values.clickhouse.auth.username | quote }}
+{{- /* Both of these honour the store's own existingSecret, the same escape
+       clickhouse.yaml:101 and curie.env.valkey already use. They were pinned to
+       the chart Secret while every other consumer read the BYO one, so a
+       `deploy=false` + `host` + `existingSecret` install left Langfuse alone
+       authenticating with the chart-generated password and trace ingestion died
+       silently with the rest of the release healthy. With clickhouse.deploy=true
+       and clickhouse.existingSecret set it was worse: the in-chart server and
+       Langfuse disagreed on the same password (split-brain auth). See #2052. */}}
 - name: CLICKHOUSE_PASSWORD
   valueFrom:
     secretKeyRef:
-      name: {{ include "curie.secretName" . }}
+      name: {{ .Values.clickhouse.existingSecret | default (include "curie.secretName" .) }}
       key: clickhousePassword
 - name: CLICKHOUSE_CLUSTER_ENABLED
   value: {{ .Values.clickhouse.clusterEnabled | quote }}
@@ -621,7 +629,7 @@ livenessProbe:
 - name: REDIS_AUTH
   valueFrom:
     secretKeyRef:
-      name: {{ include "curie.secretName" . }}
+      name: {{ .Values.valkey.existingSecret | default (include "curie.secretName" .) }}
       key: valkeyPassword
 - name: LANGFUSE_S3_EVENT_UPLOAD_BUCKET
   value: {{ .Values.rustfs.bucket | quote }}


### PR DESCRIPTION
## Summary

`curie.langfuse.env` pinned `CLICKHOUSE_PASSWORD` and `REDIS_AUTH` to the chart-managed Secret while every other consumer of those same credentials honoured the store's BYO escape — `curie.env.valkey` for the api and worker, `templates/clickhouse.yaml:101` for the in-chart server, and the rustfs entries a few lines below in the same block. On a supported BYO install (`<store>.deploy=false` + `host` + `existingSecret`) nothing errored at template or install time, because the chart Secret still rendered and still held a generated password; the api and worker authenticated against the real instance and stayed healthy while Langfuse alone presented the wrong password and trace ingestion died. With `clickhouse.deploy=true` + `clickhouse.existingSecret`, the in-chart server and Langfuse simply disagreed about the password. Both env vars now resolve through `<store>.existingSecret | default (include "curie.secretName" .)`, and the consumer side — where the bug actually lived — is now gated for both stores.

Two hunks are mechanical necessities rather than scope: without the `.gitignore` negation the repo's blanket `*secret*` rule silently drops the new assertion script so it can never be tracked, and without the `helm-ci.yaml` step the new gate never runs in CI, because that workflow names each chart CI script explicitly rather than listing the directory. `curie dev chart-check` discovers by listing, so the two disagree and only the workflow is release-blocking.

`POSTGRES_PASSWORD`, `SALT` and `ENCRYPTION_KEY` in the same block have the identical defect against `postgres.existingSecret` and `langfuse.existingSecret`. They are deliberately **not** fixed here, to keep this change to what the issue named; `charts/curie/CLAUDE.md` is updated so its BYO invariant stops being an actively false installation contract in the meantime. **These still need an issue filed** — see "Follow-up" below.

## Related issue

Closes #2052

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | No plugin or skill packaging, runner turn loop, ACI event, or skill eval touched. | — | — |
| local | n/a | No compose service, dispatcher, worker or API wiring, no boot env crossing a service boundary, no console UI, and no `curie` verb whose output, exit code or `--json` shape changed. Chart templates only. | — | — |
| local-release | n/a | No released binary or image identity, install path, version pin, or release compose touched. | — | — |
| cluster | **Required** | Chart templates — `charts/curie/templates/_helpers.tpl`. | live (k8scratch, k3s v1.36.2) | See "Cluster evidence" below. |
| live provider | n/a | The credentials here are backing-store passwords (valkey, clickhouse), not the product's model/integration credentials. No model routing, provider auth, or token/cost accounting is reached. | — | — |
| external integration | n/a | No Slack, git push webhook, connector OAuth, or third-party API shape. | — | — |

### Cluster evidence

Candidate commit: this branch's single commit, based on `origin/main` `d517e863`.

The two env entries were extracted **verbatim** from the rendered `langfuse-web` container (`helm template --set valkey.existingSecret=acme-valkey --set clickhouse.existingSecret=acme-ch`) into a probe Pod, so what ran on the cluster is the manifest this change produces, not a hand-written approximation.

**Falsifiable negative** — operator Secrets absent:

```
kubectl -n curie-2052 apply -f probe.yaml
kubectl -n curie-2052 get pod byo-secret-probe -o jsonpath='{.status.containerStatuses[0].state}'
{"waiting":{"message":"secret \"acme-ch\" not found","reason":"CreateContainerConfigError"}}
```

The kubelet resolves the operator's Secret name — the reference is real, not cosmetic.

**Positive** — operator Secrets created with distinctive values:

```
kubectl -n curie-2052 create secret generic acme-valkey --from-literal=valkeyPassword='OPERATOR-VALKEY-PW-2052'
kubectl -n curie-2052 create secret generic acme-ch     --from-literal=clickhousePassword='OPERATOR-CH-PW-2052'
kubectl -n curie-2052 logs byo-secret-probe
REDIS_AUTH=OPERATOR-VALKEY-PW-2052 CLICKHOUSE_PASSWORD=OPERATOR-CH-PW-2052
```

The operator's values reach the container env. Namespace deleted afterwards.

### Evidence per acceptance criterion

**AC1 — both env vars resolve through `<store>.existingSecret`.**
Positive: with both `existingSecret` values set, the rendered `langfuse-web` and `langfuse-worker` containers reference `acme-valkey` / `acme-ch`; before the change both referenced `rel-curie-secrets`.
Negative: the default render (no `existingSecret`) still resolves to `rel-curie-secrets`, and the live probe above fails closed with `CreateContainerConfigError` when the named Secret is absent.

**AC2 — chart CI asserts the consumer side for both stores, green.**
Positive: `curie dev chart-check` → `all 26 chart assertion scripts passed` (25 before this change; the new script is discovered and green).
Negative: the assertions were proven non-vacuous by mutation, not assumed. Reverting the `valkey` line alone in a throwaway copy produced 8 failures including all four negative-control hits; reverting the `clickhouse` line produced failures in 9c0/9c1 while 9a/9b (default render) and 9e (StatefulSet) correctly still passed, confirming the mutation is localized to the Langfuse consumer. The valkey script also ships an explicit negative control asserting the chart Secret never backs `REDIS_AUTH` under a BYO render.

**AC3 — default renders byte-identical.**
Positive: with every generated credential pinned (so `randAlphaNum` is deterministic), `diff -r` of the full `--output-dir` tree before vs after is **byte-identical across all 24 manifests**.
Second independent path: without pinning, only `secrets.yaml` differs — and rendering the *same* post-fix tree twice reproduces that same class of diff, establishing it as per-render credential generation rather than an effect of this change.

Renders use `--output-dir` throughout: piping `helm template` in this environment silently truncates a large render at exit 0 with empty stderr, which reads as a passing assertion against manifests that were never examined.

### Other gates run

- `curie dev chart-check` — 26/26 pass (baseline before the change: 25/25 pass).
- `uv run pytest tools/ci-workflow-paths release/tests/test_authorize.py` — 76 passed. Run because this touches `.github/workflows/**`; `test_authorize.py` pins helm-ci's `pull_request.paths` list and the required check-run names, neither of which changed. The workflow-path gate initially and correctly **failed** while the new script was untracked, which is a second independent confirmation of the `.gitignore` problem.
- `cd cli && cargo test` — 1690 passed across 68 suites. Run because `cli/tests/chart_check.rs` executes every chart CI script, so a chart-CI change is also a Rust test change.
- `helm lint charts/curie` — 1 chart linted, 0 failed.
- `curie dev docs-lint` — OK, drift-free.

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.
- [ ] Or: this change is not behavior-bearing, so no tier applies, and the summary says why.

## Follow-up (needs an issue)

Enumerated by the sibling-path parity check on this change and **not yet tracked**. In the same `curie.langfuse.env` block:

- `POSTGRES_PASSWORD` (`postgresPassword`) ignores `postgres.existingSecret`, which *is* honoured by `curie.env.postgres` for the api and worker and by `templates/postgres.yaml:71`.
- `SALT` (`langfuseSalt`) and `ENCRYPTION_KEY` (`langfuseEncryptionKey`) ignore `langfuse.existingSecret`, even though `values.yaml` documents that the Secret it names must carry both keys, and sibling env in the same pod (`NEXTAUTH_SECRET`, `LANGFUSE_INIT_PROJECT_SECRET_KEY`, `LANGFUSE_INIT_USER_PASSWORD`) already honour it in `templates/langfuse.yaml`.

Observed with `--set postgres.existingSecret=acme-pg --set langfuse.existingSecret=acme-lf`:

```
langfuse-web  POSTGRES_PASSWORD  rel-curie-secrets  postgresPassword
langfuse-web  SALT               rel-curie-secrets  langfuseSalt
langfuse-web  ENCRYPTION_KEY     rel-curie-secrets  langfuseEncryptionKey
langfuse-web  NEXTAUTH_SECRET    acme-lf            langfuseNextauthSecret   <- honoured
```

`ENCRYPTION_KEY` is the sharpest: a BYO `langfuse.existingSecret` install runs Langfuse against a different encryption key than the operator supplied, so previously written encrypted columns stop decrypting.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed. (`charts/curie/CLAUDE.md` — the BYO invariant is qualified with the three credentials it does not yet hold for.)
- [ ] An ADR is added under `docs/adr/` if this is an architectural decision. — n/a, this restores an existing documented invariant rather than deciding anything new. The issue states no ADR is required.
