### PR TITLE
Require every connector image build, and check the merge matrix

### DIFF
--- a/examples/tests/test_build_connectors_are_published.py
+++ b/examples/tests/test_build_connectors_are_published.py
@@ -23,6 +23,29 @@ the failure that stayed invisible.
 
 Naming: connector ``tempo`` in bundle ``sre-bot`` publishes as ``sre-bot-tempo``,
 the convention ``release.yaml``'s matrix already uses.
+
+Two ways the first version of this file could be made to lie, both fixed here
+(issue #1951), because "declared somewhere in the workflow" is not the same
+property as "a pullable image comes out the other end":
+
+  the merge matrix   The original guard read only the ``build`` job's matrix
+                     ``include`` rows. ``release.yaml``'s ``merge`` job -- the
+                     one that runs ``docker buildx imagetools create`` and is
+                     therefore the only thing that ever creates a *tag* -- has
+                     no ``include`` at all, just a ``name:`` list, so it was
+                     never read. Deleting a connector from that list left this
+                     whole suite green while the release pushed per-arch images
+                     by digest and tagged nothing: images that exist, cannot be
+                     pulled, and report exactly the same symptom as the missing
+                     image this file was written about.
+
+  the row's own dir  The original guard asserted only that the *name* appeared.
+                     Repointing ``sre-bot-k8s-scale``'s ``context`` and
+                     ``dockerfile`` at the tempo connector's directory stayed
+                     green, and would have published the tempo server under the
+                     ``k8s-scale`` name -- a bot answering with the wrong verb
+                     entirely, which is worse than the verb simply being absent
+                     because nothing about it looks broken.
 """
 
 from pathlib import Path
@@ -34,36 +57,110 @@ REPO = Path(__file__).resolve().parents[2]
 EXAMPLES = REPO / "examples"
 RELEASE_WORKFLOW = REPO / ".github" / "workflows" / "release.yaml"
 
+# The two halves of the publish pipeline. `build` pushes each architecture by
+# digest; `merge` assembles those digests into the multi-arch manifest that
+# carries the tag. Neither alone publishes anything usable.
+BUILD_JOB = "build"
+MERGE_JOB = "merge"
 
-def _published_image_names() -> set[str]:
-    """The image names ``release.yaml`` builds and pushes.
 
-    Read off the matrix's ``include`` entries rather than the ``name:`` list,
-    because an entry in the list with no ``include`` has no build context and so
-    publishes nothing -- the list alone would pass a half-wired addition.
+def _release_jobs() -> dict:
+    """``release.yaml``'s jobs."""
+
+    workflow = yaml.safe_load(RELEASE_WORKFLOW.read_text(encoding="utf-8")) or {}
+    return workflow.get("jobs") or {}
+
+
+def _image_pipeline_jobs() -> tuple[dict, dict]:
+    """The ``build`` and ``merge`` jobs, or a loud failure.
+
+    Looked up by name rather than scanned for, so renaming or removing either
+    job fails here with the job named. The alternative -- iterating every job
+    and collecting whatever matrices turn up -- degrades to an empty set on a
+    rename, which is the same vacuous pass this file exists to rule out.
     """
 
-    workflow = yaml.safe_load(RELEASE_WORKFLOW.read_text(encoding="utf-8"))
-    names: set[str] = set()
-    for job in (workflow.get("jobs") or {}).values():
-        include = (((job.get("strategy") or {}).get("matrix") or {}).get("include")) or []
-        for entry in include:
-            if isinstance(entry, dict) and entry.get("dockerfile") and entry.get("name"):
-                names.add(str(entry["name"]))
-    return names
+    jobs = _release_jobs()
+    missing = [name for name in (BUILD_JOB, MERGE_JOB) if name not in jobs]
+    assert not missing, (
+        f"release.yaml has no {missing} job(s): the publish pipeline was renamed or "
+        "restructured. This guard reads those two jobs by name and cannot tell a "
+        "rename from a deleted pipeline, so fix the names here deliberately rather "
+        "than letting the check quietly stop looking at anything."
+    )
+    return jobs[BUILD_JOB], jobs[MERGE_JOB]
+
+
+def _matrix(job: dict) -> dict:
+    return ((job.get("strategy") or {}).get("matrix") or {}) or {}
+
+
+def _build_include_rows(build_job: dict) -> dict[str, dict]:
+    """The given ``build`` job's matrix ``include`` rows, keyed by image name."""
+
+    rows: dict[str, dict] = {}
+    for entry in _matrix(build_job).get("include") or []:
+        if isinstance(entry, dict) and entry.get("name"):
+            rows[str(entry["name"])] = entry
+    return rows
+
+
+def _matrix_names(job: dict) -> set[str]:
+    return {str(name) for name in (_matrix(job).get("name") or [])}
+
+
+def _published_image_names() -> set[str]:
+    """The image names ``release.yaml`` builds AND tags.
+
+    An image counts as published only when all three agree, because each one on
+    its own passes a half-wired addition:
+
+    * a matrix ``include`` row carrying a ``dockerfile`` -- an entry in the
+      ``name:`` list with no ``include`` has no build context and so builds
+      nothing;
+    * membership in the ``build`` job's ``name:`` list -- an orphan ``include``
+      row is never expanded into a matrix leg and never runs;
+    * membership in the ``merge`` job's ``name:`` list -- ``build`` pushes each
+      architecture *by digest only*, and ``merge`` is what runs ``imagetools
+      create`` to give those digests a tag. A name absent from ``merge`` is an
+      image that is built, pushed, and unpullable, which presents to an operator
+      exactly like the never-published connector in this module's docstring.
+    """
+
+    build_job, merge_job = _image_pipeline_jobs()
+    with_dockerfile = {
+        name for name, row in _build_include_rows(build_job).items() if row.get("dockerfile")
+    }
+    return with_dockerfile & _matrix_names(build_job) & _matrix_names(merge_job)
+
+
+def _build_connectors_with_context() -> list[tuple[str, str, str]]:
+    """``(bundle, connector, build.context)`` for every connector declaring ``build:``.
+
+    The declared ``context`` is bundle-relative (``connectors/k8s-scale``), which
+    is what makes it usable as the expected release-row path instead of a
+    convention hardcoded here: if a connector ever builds from somewhere other
+    than ``connectors/<name>``, the expectation follows the declaration rather
+    than going stale against it.
+    """
+
+    found: list[tuple[str, str, str]] = []
+    for declaration in sorted(EXAMPLES.glob("*/connectors.yaml")):
+        bundle = declaration.parent.name
+        parsed = yaml.safe_load(declaration.read_text(encoding="utf-8")) or {}
+        for name, spec in (parsed.get("connectors") or {}).items():
+            if not isinstance(spec, dict) or "build" not in spec:
+                continue
+            build = spec.get("build") or {}
+            context = str(build.get("context") or "") if isinstance(build, dict) else ""
+            found.append((bundle, str(name), context))
+    return found
 
 
 def _build_connectors() -> list[tuple[str, str]]:
     """``(bundle, connector)`` for every connector declaring ``build:``."""
 
-    found: list[tuple[str, str]] = []
-    for declaration in sorted(EXAMPLES.glob("*/connectors.yaml")):
-        bundle = declaration.parent.name
-        parsed = yaml.safe_load(declaration.read_text(encoding="utf-8")) or {}
-        for name, spec in (parsed.get("connectors") or {}).items():
-            if isinstance(spec, dict) and "build" in spec:
-                found.append((bundle, str(name)))
-    return found
+    return [(bundle, connector) for bundle, connector, _ in _build_connectors_with_context()]
 
 
 def test_the_declaration_and_the_workflow_are_both_readable() -> None:
@@ -71,6 +168,13 @@ def test_the_declaration_and_the_workflow_are_both_readable() -> None:
     # mode of every check that reads files by glob.
     assert _build_connectors(), "no build-declaring connectors found: check the glob"
     assert _published_image_names(), "no publishable images found in release.yaml"
+    # The intersection above can also empty out because one of its three inputs
+    # did, which would read as "nothing is published" rather than as a parse
+    # that stopped finding the matrices.
+    build_job, merge_job = _image_pipeline_jobs()
+    assert _build_include_rows(build_job), "release.yaml's build job has no matrix include rows"
+    assert _matrix_names(build_job), "release.yaml's build job has no matrix name list"
+    assert _matrix_names(merge_job), "release.yaml's merge job has no matrix name list"
 
 
 @pytest.mark.parametrize("bundle,connector", _build_connectors())
@@ -81,6 +185,59 @@ def test_a_build_declaring_connector_has_a_publish_job(bundle: str, connector: s
         f"{bundle}'s '{connector}' connector declares build: but nothing publishes "
         f"'{expected}'. Without a published image it cannot be deployed at the "
         f"cluster tier, so it is a capability the live bot cannot have. Add it to "
-        f"release.yaml's image matrix (both the name list and an include entry "
-        f"naming its context and dockerfile), or drop the connector."
+        f"release.yaml's image matrix -- the build job's name list, an include entry "
+        f"naming its context and dockerfile, AND the merge job's name list, since "
+        f"merge is what turns the per-arch digests into a pullable tag."
+    )
+
+
+@pytest.mark.parametrize("bundle,connector,build_context", _build_connectors_with_context())
+def test_a_publish_row_points_at_that_connectors_own_directory(
+    bundle: str, connector: str, build_context: str
+) -> None:
+    """The release row must build the connector it is named after.
+
+    Presence of the name proves only that something is published under it. A row
+    whose ``context``/``dockerfile`` point at a *different* connector's directory
+    publishes that other connector's server under this name, and every other
+    check in this file stays green: the bundle validates, the image exists, the
+    connector reports healthy, and the bot answers the wrong verb. That is a
+    worse outcome than the missing image this module was written about, because
+    nothing about it looks broken from the outside.
+    """
+
+    assert build_context, (
+        f"{bundle}'s '{connector}' declares build: with no context, so there is "
+        "nothing to check the release row against"
+    )
+
+    expected_name = f"{bundle}-{connector}"
+    expected_dir = (EXAMPLES / bundle / build_context).resolve().relative_to(REPO).as_posix()
+    expected_dockerfile = f"{expected_dir}/Dockerfile"
+
+    build_job, _ = _image_pipeline_jobs()
+    rows = _build_include_rows(build_job)
+    assert expected_name in rows, (
+        f"release.yaml has no build matrix include row named '{expected_name}' for "
+        f"{bundle}'s '{connector}' connector"
+    )
+    row = rows[expected_name]
+
+    assert row.get("context") == expected_dir, (
+        f"release.yaml's '{expected_name}' row builds from {row.get('context')!r}, but "
+        f"{bundle}'s '{connector}' declares build.context {build_context!r}, i.e. "
+        f"{expected_dir!r}. As written the release publishes some other connector's "
+        f"image under the '{expected_name}' name."
+    )
+    assert row.get("dockerfile") == expected_dockerfile, (
+        f"release.yaml's '{expected_name}' row uses dockerfile "
+        f"{row.get('dockerfile')!r} instead of {expected_dockerfile!r}, so the "
+        f"published image is not built from {connector}'s own Dockerfile."
+    )
+    # The path agreeing with the declaration is not enough on its own: both could
+    # name a directory that does not exist, and the mismatch would first appear
+    # as a failed release build rather than as a failed test.
+    assert (REPO / expected_dockerfile).is_file(), (
+        f"{expected_dockerfile} does not exist, so the release row for "
+        f"'{expected_name}' cannot build"
     )

--- a/release/authorize.py
+++ b/release/authorize.py
@@ -68,6 +68,27 @@ PASSING_CONCLUSIONS = {"success", "neutral"}
 # runtime. It is the simpler of the two options ADR-0058 left open (issue
 # #733). Tests pin its required names to jobs in both workflows, so a job
 # rename or removal requires a matching edit here.
+#
+# EVERY first-party connector image build is required here, not just the
+# bundle's read-only `tempo` server (issue #1951). The `examples/` rows of
+# ci.yaml's `images` job are release-load-bearing in a way the one-sided
+# version of this list could not see. `release.yaml`'s `build` matrix rebuilds
+# those same Dockerfiles for real, and its `merge` job -- the job that
+# assembles the multi-arch manifest every published tag actually resolves to --
+# is gated `if: always() && needs.build.result == 'success'`. So one connector
+# image going red on `next` and not named here authorizes the tag, fails a
+# single `build` leg, and takes the manifest merge for EVERY image down with
+# it, while the CLI binaries and the GitHub Release -- which hang off
+# `authorize-release` alone -- publish regardless. The release ships binaries
+# whose images have per-arch blobs pushed by digest and no pullable manifest
+# tag anywhere.
+#
+# The subset test below cannot see that direction: it asserts every required
+# name is a real job, so ADDING a connector build to ci.yaml and forgetting it
+# here leaves the subset perfectly intact. That direction is now pinned by
+# `test_every_connector_image_build_is_a_required_check`, which derives the
+# connector rows from ci.yaml itself -- a new connector image is guarded by a
+# failing test, not by whoever remembers to read this comment.
 REQUIRED_CHECK_NAMES = frozenset(
     {
         "Python (ruff + mypy + pytest)",
@@ -81,6 +102,9 @@ REQUIRED_CHECK_NAMES = frozenset(
         "Build worker image (no push)",
         "Build ui image (no push)",
         "Build sre-bot-tempo image (no push)",
+        "Build sre-bot-k8s-write image (no push)",
+        "Build sre-bot-k8s-scale image (no push)",
+        "Build sre-bot-self-upgrade image (no push)",
         "Build worker-local overlay image (no push)",
         "Dispatcher image imports resolve",
         "Eval falsifiability gate (fake model, offline)",

--- a/release/tests/test_authorize.py
+++ b/release/tests/test_authorize.py
@@ -14,6 +14,7 @@ import importlib.util
 import inspect
 import json
 import os
+import posixpath
 import re
 import shutil
 import subprocess
@@ -892,6 +893,61 @@ def helm_ci_job_check_run_names() -> set[str]:
     return workflow_job_check_run_names(HELM_CI_YAML)
 
 
+def ci_connector_image_check_run_names() -> set[str]:
+    """The `(no push)` check-run names of ci.yaml's *connector* image rows (#1951).
+
+    Derived from `ci.yaml`, never from `REQUIRED_CHECK_NAMES`, for the same
+    reason `workflow_job_check_run_names` is: a set built from the constant can
+    only ever agree with itself, and the drift this guards is precisely a row
+    that exists in the workflow and nowhere in the constant.
+
+    A connector row is identified by its `dockerfile` path resolving under
+    `examples/`, not by its `context`. `dockerfile` is the discriminator
+    because it is not optional the way `context` is: the `images` job's build
+    step (`file: ${{ matrix.dockerfile }}`) has nothing to build without it, so
+    every row -- including `mail-adapter`, which has no `context` -- carries
+    one. A helper keyed on `context` would silently skip a connector row that
+    used an equivalent context-less form, exactly the drift this guard exists
+    to catch; keying on `dockerfile` closes that hole because there is no
+    context-less-but-valid way to omit it. The path is normalized
+    (`posixpath.normpath`, since workflow paths are always POSIX regardless of
+    the runner OS) before the prefix check so a form like `./examples/...`
+    still matches.
+
+    `mail-adapter` stays excluded under this rule too: its dockerfile is
+    `apps/mail-adapter/Dockerfile`, not under `examples/`, so the same row that
+    used to be excluded by missing `context` is now excluded on the merits --
+    it is a platform image, not a bundle connector.
+
+    A row with no `dockerfile` at all is not silently skipped: `dockerfile` is
+    the one field every row must have for the build step to do anything, so
+    its absence is a workflow defect in its own right, not an unrelated bug to
+    tolerate. Raising here surfaces that defect immediately instead of letting
+    this helper go quiet on a row that builds nothing.
+
+    The concrete name is produced by substituting the row into the job's own
+    `name:` template, so renaming the template moves both this set and the
+    constant's expected values together instead of silently emptying the guard.
+    """
+
+    doc = yaml.safe_load(CI_YAML.read_text())
+    job = doc["jobs"]["images"]
+    template = job["name"]
+    rows = ((job.get("strategy") or {}).get("matrix") or {}).get("include") or []
+    names: set[str] = set()
+    for row in rows:
+        dockerfile = row.get("dockerfile")
+        if not isinstance(dockerfile, str) or not dockerfile:
+            raise AssertionError(
+                f"ci.yaml images row {row!r} has no dockerfile -- the build "
+                "step has nothing to build for this row"
+            )
+        if not posixpath.normpath(dockerfile).startswith("examples/"):
+            continue
+        names.add(_MATRIX_REF.sub(lambda m, row=row: str(row[m.group(1)]), template))
+    return names
+
+
 class TestRustValkeyWorkflowContract:
     def test_rust_job_requires_and_connects_to_valkey_guarded_tests(self):
         workflow = yaml.safe_load(CI_YAML.read_text())
@@ -1130,6 +1186,16 @@ class TestRequiredNamesMatchCiWorkflows:
     So renaming or splitting a required job in a CI workflow without updating
     `REQUIRED_CHECK_NAMES` fails here (with the drifted names listed), rather
     than silently dropping a release gate.
+
+    That subset relation is one-directional, and the second test closes the
+    other direction for the connector images (#1951). Subset means ADDING a job
+    to `ci.yaml` and never requiring it here keeps this class green forever --
+    which is how three of the four `examples/` connector image builds came to
+    be unrequired while `sre-bot-tempo` alone was named. An unrequired connector
+    build that goes red on `next` still authorizes the tag, then fails its
+    `release.yaml` `build` leg, and `merge` (`needs.build.result == 'success'`)
+    skips the multi-arch manifest for EVERY image while the CLI binaries and
+    the GitHub Release publish anyway.
     """
 
     def test_every_required_name_is_a_real_ci_workflow_check_run_name(self):
@@ -1139,6 +1205,30 @@ class TestRequiredNamesMatchCiWorkflows:
         assert authorize_module.REQUIRED_CHECK_NAMES <= ci_names, (
             "REQUIRED_CHECK_NAMES has drifted from the CI workflows -- these required "
             f"names match no current job check-run: {sorted(stale)}"
+        )
+
+    def test_every_connector_image_build_is_a_required_check(self):
+        connector_names = ci_connector_image_check_run_names()
+
+        # A guard that finds nothing passes vacuously. If a matrix restructure,
+        # a `dockerfile` convention change, or a rename of the `images` job
+        # empties this set, that must read as a broken guard rather than as
+        # compliance.
+        assert connector_names, (
+            "no connector image rows found in ci.yaml's `images` job -- the matrix "
+            "shape or the `dockerfile: examples/...` convention changed, and "
+            "ci_connector_image_check_run_names() now guards nothing"
+        )
+
+        unrequired = connector_names - authorize_module.REQUIRED_CHECK_NAMES
+
+        assert unrequired == set(), (
+            "ci.yaml builds connector images that no required check names, so a red "
+            f"connector build would still authorize a release: {sorted(unrequired)}. "
+            "Add each of those names to REQUIRED_CHECK_NAMES in release/authorize.py. "
+            "A connector build failing on next without this authorizes the tag, fails "
+            "release.yaml's `build` leg, and skips the manifest `merge` for every "
+            "image while the binaries and the GitHub Release publish anyway."
         )
 
 


### PR DESCRIPTION
Closes #1951

Two gates around the connector publish path were one sided, so a broken connector build could authorize a release and a half wired publication passed the new guard.

## What changed

**`release/authorize.py`** — `REQUIRED_CHECK_NAMES` named `Build sre-bot-tempo image (no push)` alone, leaving the three connector image builds #1945 added outside release authorization. Added the `k8s-write`, `k8s-scale` and `self-upgrade` no push build checks, with the cascade recorded in the constant's comment: an unrequired connector build that goes red on `next` still authorizes the tag, then fails one `release.yaml` `build` leg, and `merge` (`if: always() && needs.build.result == 'success'`) skips the multi arch manifest for **every** image while the CLI binaries and the GitHub Release, gated only on `authorize-release`, publish anyway.

**`release/tests/test_authorize.py`** — `test_every_required_name_is_a_real_ci_workflow_check_run_name` is subset only, so adding a job to `ci.yaml` never tripped it. New `test_every_connector_image_build_is_a_required_check` closes that direction, deriving the connector rows from `ci.yaml` itself rather than from the constant. It keys on the `dockerfile` path rather than the optional `context` key, so a context less or `./examples/...` row cannot slip past, and a row with no `dockerfile` raises rather than being silently skipped. A vacuity guard fails the test if the derived set ever empties.

**`examples/tests/test_build_connectors_are_published.py`** — `_published_image_names()` read only the `build` matrix's `include` entries. The `merge` job has no `include`, only a `name:` list, so it was never checked. It now intersects the dockerfile carrying `include` rows with **both** the `build` and `merge` name lists. New `test_a_publish_row_points_at_that_connectors_own_directory` checks each row's `context` and `dockerfile` against the connector declaration's own bundle relative `build.context` and asserts the Dockerfile exists.

## Acceptance criteria

1. Met. `REQUIRED_CHECK_NAMES` now carries the no push build check for all four first party connector images, and `test_every_connector_image_build_is_a_required_check` fails when a connector build job exists in `ci.yaml` without one.
2. Met. Each published name must appear in both the `build` and `merge` name lists.
3. Met. Each row's `context` and `dockerfile` are checked against that connector's own declared directory.
4. Met. Every mutation below was executed and observed red.

## Guard demonstration (executed, not read)

| Mutation | Result |
|---|---|
| Revert the three `REQUIRED_CHECK_NAMES` additions | `test_every_connector_image_build_is_a_required_check` FAILED, naming all three missing checks. The pre-existing subset test passed, which is the hole. |
| Add a connector row to `ci.yaml` with an unrequired name | FAILED |
| Same row with **no `context:` key at all** | FAILED (the `context` keyed form would have skipped it) |
| Same row with `./examples/...` dot prefixed paths | FAILED |
| Delete `sre-bot-k8s-write` and `sre-bot-k8s-scale` from the **merge** job's `name:` list only | 2 failed, 7 passed |
| Point `sre-bot-k8s-scale`'s `context`/`dockerfile` at the tempo connector | 1 failed, 8 passed |

Negative control: with the last two mutations applied against `origin/next`'s version of the guard, the same suite reported **75 passed**. Against this branch's guard it reports **3 failed, 6 passed**.

## Checks

- `uv run pytest release/tests/test_authorize.py examples/tests/test_build_connectors_are_published.py -q` — 79 passed (74 on base).
- `uv run pytest -q` (the full suite CI's required Python check runs) — 4754 passed, 30 failed, 23 skipped. All 30 failures are environmental and outside the changed areas: 29 reproduce identically on a clean `origin/next` control tree (Postgres, Valkey stream and Langfuse at `localhost:23000` are not up on this box, and CI provides them). The 30th, `test_hook_partition.py::test_an_unconfigured_hook_enqueues_the_three_segment_id`, is a pre existing flake, it asserts `"41" not in` a conversation id built from a random UUID and passes on rerun (129 passed). Zero failures in `release/` or `examples/`.
- `uv run ruff check .` clean, `uv run mypy` clean across 235 source files.
- `scripts/check-commit-messages.sh` clean.

## Scope notes

- The third added required name, `Build sre-bot-self-upgrade image (no push)`, is not named in the issue body but is required by AC1's "every first party connector image", and `ci.yaml` builds it.
- The Dockerfile existence assertion in the new directory test goes slightly beyond AC3's literal wording. It is kept deliberately: a row and a declaration can agree on a path that does not exist, and without it that mismatch first appears as a failed release build rather than a failed test.
- Two adjacent holes were found and deliberately left out of scope: `ci.yaml`'s `mail-adapter` row carries no `context:` key at all, and `Build mail-adapter image (no push)` is not in `REQUIRED_CHECK_NAMES`. Both are platform image concerns rather than connector ones, and neither is in this issue's ACs.
