### PR TITLE
plugin-format: dual-profile skill-frontmatter validator (Draft ADR-0135)

### DIFF
--- a/cli/src/scaffold.rs
+++ b/cli/src/scaffold.rs
@@ -72,11 +72,16 @@ fn manifest(name: &str) -> String {
 
 /// The genericized starter skill for `<name>`: a believable, editable
 /// placeholder scoped to the bundle name (no weather demo). Keeps the
-/// correct-by-example `allowed-tools` key and the when/how/rules section shape
-/// a real skill uses.
+/// correct-by-example `allowed-tools` key -- now the single space-separated
+/// scalar the Agent Skills specification calls canonical (ADR-0135), since this
+/// template is a teaching surface and whatever it shows is what authors copy --
+/// and the when/how/rules section shape a real skill uses. The two tool names
+/// are literals we control, so a bare scalar is safe here exactly as it already
+/// is for `name:`; `render_skill_md` quotes its joined value because those
+/// entries are arbitrary agent-authored text.
 fn skill_md(name: &str) -> String {
     format!(
-        "---\nname: {name}\ndescription: Starter skill for the {name} agent. Replace this description with when the agent should invoke this skill -- it is the routing signal.\nallowed-tools:\n  - WebSearch\n  - WebFetch\n---\n\n# {name}\n\nThis is the starter skill scaffolded by `curie init`. Replace each section\nbelow with your agent's real behavior; keep the section shape.\n\n## When to run\nDescribe the requests this skill should handle.\n\n## How to answer\n1. Numbered, concrete steps the agent follows.\n2. Prefer verifiable sources and tools over recall.\n\n## Hard rules\n- Never invent an answer. If you cannot find one, say so and name what you tried.\n- Keep replies short enough to read in Slack without expanding.\n"
+        "---\nname: {name}\ndescription: Starter skill for the {name} agent. Replace this description with when the agent should invoke this skill -- it is the routing signal.\nallowed-tools: WebSearch WebFetch\n---\n\n# {name}\n\nThis is the starter skill scaffolded by `curie init`. Replace each section\nbelow with your agent's real behavior; keep the section shape.\n\n## When to run\nDescribe the requests this skill should handle.\n\n## How to answer\n1. Numbered, concrete steps the agent follows.\n2. Prefer verifiable sources and tools over recall.\n\n## Hard rules\n- Never invent an answer. If you cannot find one, say so and name what you tried.\n- Keep replies short enough to read in Slack without expanding.\n"
     )
 }
 
@@ -268,13 +273,20 @@ fn write_bundle(dir: &Path, files: Vec<(PathBuf, String)>) -> Result<Vec<PathBuf
 ///
 /// The frontmatter is rendered without a YAML crate. `name` is kebab-case
 /// (validated in `spec.rs`), so a bare scalar is always safe. `description` and
-/// each `allowed-tools` value are ARBITRARY agent-authored text, so they are
+/// the `allowed-tools` value are ARBITRARY agent-authored text, so they are
 /// emitted as JSON-encoded strings: a serde_json string is a valid YAML
 /// double-quoted scalar (YAML double-quoted supports the same `\n \t \" \\
 /// \uXXXX` escapes serde_json emits), so the round-trip is exact. A bare scalar
 /// here would corrupt or invalidate the frontmatter `plugin_format.validate_bundle`
 /// parses with `yaml.safe_load` -- a colon-space breaks parsing, a leading ` #`
 /// silently truncates as a comment, leading `"[{&*@` etc. error the scanner.
+///
+/// `allowed-tools` is emitted as ONE canonical space-separated scalar (ADR-0135)
+/// rather than a block list, and the JSON encoding now wraps the WHOLE joined
+/// value: quoting each entry individually made a space or a `#` inside an entry
+/// safe by construction, and joining gives that up, so `spec::validate` refuses
+/// any entry that carries a depth-0 separator or unbalanced parens before a byte
+/// is written. That refusal is what keeps this join lossless.
 fn render_skill_md(skill: &SkillSpec) -> String {
     let mut s = String::new();
     s.push_str("---\n");
@@ -286,13 +298,10 @@ fn render_skill_md(skill: &SkillSpec) -> String {
     // Omit the key entirely when empty: the wrong shape (an empty list) reads as
     // "no tools" but is noise; a real Claude Code bundle just leaves it out.
     if !skill.allowed_tools.is_empty() {
-        s.push_str("allowed-tools:\n");
-        for tool in &skill.allowed_tools {
-            s.push_str(&format!(
-                "  - {}\n",
-                serde_json::to_string(tool).expect("string serializes")
-            ));
-        }
+        s.push_str(&format!(
+            "allowed-tools: {}\n",
+            serde_json::to_string(&skill.allowed_tools.join(" ")).expect("string serializes")
+        ));
     }
     s.push_str("---\n\n");
     // Normalize to a single trailing newline regardless of how the author ended
@@ -550,7 +559,17 @@ mod tests {
             description_line.contains("deal-desk"),
             "description mentions the name: {description_line}"
         );
-        assert!(skill.contains("allowed-tools:"));
+        // The canonical single-line scalar (ADR-0135), asserted exactly: a bare
+        // `contains("allowed-tools:")` passes on the block form too, so the old
+        // shape has to be asserted ABSENT or a regression to it goes unnoticed.
+        assert!(
+            skill.contains("allowed-tools: WebSearch WebFetch\n"),
+            "starter skill must teach the canonical scalar: {skill}"
+        );
+        assert!(
+            !skill.contains("  - "),
+            "the block list form must be gone entirely: {skill}"
+        );
         assert!(
             !skill.contains("weather") && !skill.contains("Weather"),
             "starter skill must be genericized, not weather"

--- a/cli/src/spec.rs
+++ b/cli/src/spec.rs
@@ -22,6 +22,8 @@ pub struct SkillSpec {
     pub name: String,
     pub description: String,
     /// Verbatim Claude Code `allowed-tools` values; empty omits the key entirely.
+    /// The scaffold renders them as ONE canonical space-separated scalar
+    /// (ADR-0135), so `validate` refuses any entry that cannot survive that join.
     #[serde(default)]
     pub allowed_tools: Vec<String>,
     pub instructions: String,
@@ -125,6 +127,40 @@ fn validate_gate_namespacing(
     bail!("spec approvalPolicy gate {gate:?} is not a fully-namespaced live tool name; {hint}")
 }
 
+/// Whether `entry` survives the canonical `allowed-tools` round-trip. The
+/// scaffold joins the entries with a space into one scalar, and every consumer
+/// splits that scalar back apart on whitespace or a comma at paren DEPTH 0
+/// (`plugin_format.parse_allowed_tools`). So an entry carrying a depth-0
+/// separator comes back as two, and an entry whose parens never balance swallows
+/// the entry after it -- either way the list a consumer reads is not the list the
+/// author wrote. Depth-awareness is what makes `Bash(git commit:*)`, a real
+/// Claude Code permission rule, ACCEPTABLE: its space sits at depth 1.
+///
+/// Why refuse rather than absorb: the runner's #1852 gate-shadow check reads
+/// these entries, and a corrupted one drops out of shadow detection entirely
+/// (`_entry_tool("Bash(git")` is `None`, `_entry_tool("commit:*)")` is a garbage
+/// tool name), so the bundle would boot reporting a gate as armed while the tool
+/// runs unapproved. Refused before any write, like the skill-name rule above.
+fn round_trips_in_allowed_tools(entry: &str) -> bool {
+    if entry.is_empty() {
+        return false;
+    }
+    let mut depth = 0usize;
+    for ch in entry.chars() {
+        match ch {
+            '(' => depth += 1,
+            ')' if depth > 0 => depth -= 1,
+            // A close paren at depth 0 is unbalanced; a comma or whitespace at
+            // depth 0 is a separator. Both are fine at depth >= 1 (`Bash(a,b)`).
+            ')' => return false,
+            ',' if depth == 0 => return false,
+            c if depth == 0 && c.is_whitespace() => return false,
+            _ => {}
+        }
+    }
+    depth == 0
+}
+
 /// Deserialize the spec JSON (strict) then validate it. Returns actionable
 /// errors that name the offending value so an agent can self-correct.
 pub fn parse(json: &str) -> Result<AgentSpec> {
@@ -163,6 +199,24 @@ fn validate(spec: &AgentSpec) -> Result<()> {
                 "spec has two skills named {:?}; skill names must be unique",
                 skill.name
             );
+        }
+        // Same ethos, one field over: the emitted `allowed-tools` scalar is
+        // separator-delimited at paren depth 0, so an entry that cannot survive
+        // the join would be silently rewritten into a different list. Refuse it
+        // here, before any write, naming the entry the author has to fix.
+        for entry in &skill.allowed_tools {
+            if !round_trips_in_allowed_tools(entry) {
+                bail!(
+                    "spec skill {:?} allowed_tools entry {:?} cannot round-trip the canonical \
+                     `allowed-tools` scalar: entries are joined with a space and split back apart \
+                     on whitespace or a comma at paren depth 0, so each entry must be non-empty, \
+                     carry no whitespace or comma outside parentheses, and balance its \
+                     parentheses. A separator INSIDE a specifier is fine -- split the entry, or \
+                     close the parenthesis",
+                    skill.name,
+                    entry
+                );
+            }
         }
     }
 

--- a/cli/tests/spec_scaffold.rs
+++ b/cli/tests/spec_scaffold.rs
@@ -287,7 +287,8 @@ fn rejects_a_mis_namespaced_mcp_approval_gate() {
 }
 
 /// Every skill in a multi-skill spec becomes its own SKILL.md carrying that
-/// skill's name, description, allowed-tools (only when present), and body.
+/// skill's name, description, allowed-tools (only when present, as the single
+/// canonical space-separated scalar), and body.
 #[test]
 fn writes_one_skill_md_per_skill_with_frontmatter_and_body() {
     let dir = tempfile::tempdir().unwrap();
@@ -295,19 +296,29 @@ fn writes_one_skill_md_per_skill_with_frontmatter_and_body() {
     let spec = parse(valid_spec_json()).unwrap();
     scaffold_from_spec(&out, &spec).unwrap();
 
-    // Skill one: has allowed_tools -> allowed-tools YAML block with each tool.
-    // description and each tool are emitted as quoted YAML scalars (arbitrary
-    // agent-authored text must be a quoted scalar or it corrupts/invalidates the
-    // frontmatter `plugin_format.validate_bundle` parses with `yaml.safe_load`).
+    // Skill one: has allowed_tools -> ONE `allowed-tools` line carrying the
+    // space-joined entries, which is the shape the Agent Skills specification
+    // calls canonical (ADR-0135). description and the joined value are emitted as
+    // quoted YAML scalars (arbitrary agent-authored text must be a quoted scalar
+    // or it corrupts/invalidates the frontmatter `plugin_format.validate_bundle`
+    // parses with `yaml.safe_load`). The join is lossless because `spec::parse`
+    // refuses any entry that carries a depth-0 separator.
     let deal = std::fs::read_to_string(out.join("skills/deal-desk/SKILL.md")).unwrap();
     assert!(deal.starts_with("---\nname: deal-desk\n"), "{deal}");
     assert!(
         deal.contains("description: \"Invoke when a rep submits a pricing exception request.\""),
         "{deal}"
     );
-    assert!(deal.contains("allowed-tools:"), "{deal}");
-    assert!(deal.contains("  - \"WebSearch\""), "{deal}");
-    assert!(deal.contains("  - \"WebFetch\""), "{deal}");
+    assert!(
+        deal.contains("allowed-tools: \"WebSearch WebFetch\"\n"),
+        "the canonical single-line scalar, in spec order: {deal}"
+    );
+    // A bare `contains("allowed-tools:")` passes on BOTH shapes, so the block
+    // form has to be asserted absent or a regression to it goes unnoticed.
+    assert!(
+        !deal.contains("  - \""),
+        "the block list form must be gone entirely: {deal}"
+    );
     // Instructions body lands after the frontmatter.
     assert!(deal.contains("Deal desk skill body."), "{deal}");
     assert!(
@@ -812,4 +823,83 @@ fn cli_init_without_name_or_spec_errors_with_guidance() {
         "message must point at name or --from-spec\n{}",
         output_text(&output)
     );
+}
+
+// --- the canonical `allowed-tools` scalar and its entry rule (D4 / ADR-0135) --
+//
+// The emitted scalar is separator-delimited at paren depth 0, so an entry that
+// itself carries a depth-0 separator cannot round-trip: joining it and parsing it
+// back yields a DIFFERENT list. That is not cosmetic. The runner's #1852
+// gate-shadow check reads those entries, and `_entry_tool("Bash(git")` returns
+// None while `_entry_tool("commit:*)")` returns a garbage name -- so a corrupted
+// entry drops out of shadow detection entirely and the bundle boots reporting a
+// gate as armed while the tool runs unapproved. The spec refuses such an entry
+// before any byte is written.
+
+/// A specifier containing a SPACE is a legitimate Claude Code permission rule
+/// (`Bash(git commit:*)`), and the depth-aware join round-trips it, so the spec
+/// must ACCEPT it and the scaffold must emit it intact.
+#[test]
+fn accepts_a_specifier_containing_a_space_and_emits_it_intact() {
+    let body = r#"{
+      "name": "paren-desk",
+      "description": "Parens survive the join.",
+      "skills": [
+        {
+          "name": "paren-desk",
+          "description": "Invoke to commit.",
+          "allowed_tools": ["Bash(git commit:*)", "Read"],
+          "instructions": "Paren desk skill body.\n"
+        }
+      ],
+      "evals": [
+        { "id": "e1", "input": "go", "grader": { "kind": "contains", "expected": "ok" } }
+      ]
+    }"#;
+    let spec = parse(body).expect("a paren-bearing entry must be accepted");
+
+    let dir = tempfile::tempdir().unwrap();
+    let out = dir.path().join("bundle");
+    scaffold_from_spec(&out, &spec).unwrap();
+
+    let skill = std::fs::read_to_string(out.join("skills/paren-desk/SKILL.md")).unwrap();
+    assert!(
+        skill.contains("allowed-tools: \"Bash(git commit:*) Read\"\n"),
+        "the specifier must survive the join unsplit: {skill}"
+    );
+}
+
+/// A comma or space OUTSIDE parens, or an unbalanced paren, cannot survive the
+/// canonical join, so `parse` must Err and the message must name the entry --
+/// the author has to know which one to fix.
+#[test]
+fn rejects_an_allowed_tools_entry_that_cannot_round_trip() {
+    // A comma at depth 0; whitespace at depth 0; depth never returns to 0; a
+    // close paren at depth 0.
+    for entry in ["Read,Write", "Read Write", "Bash(git", "oops)"] {
+        let body = format!(
+            r#"{{
+              "name": "bad-desk",
+              "description": "An entry that cannot round-trip.",
+              "skills": [
+                {{
+                  "name": "bad-desk",
+                  "description": "Invoke never.",
+                  "allowed_tools": ["Read", {entry:?}],
+                  "instructions": "Bad desk skill body.\n"
+                }}
+              ],
+              "evals": [
+                {{ "id": "e1", "input": "go", "grader": {{ "kind": "contains", "expected": "ok" }} }}
+              ]
+            }}"#
+        );
+        let err = parse(&body)
+            .expect_err("an unserializable allowed_tools entry must error")
+            .to_string();
+        assert!(
+            err.contains(entry),
+            "message must name the offending entry {entry:?}: {err}"
+        );
+    }
 }

--- a/docs/adr/0135-a-skill-bundle-has-two-conformance-profiles.md
+++ b/docs/adr/0135-a-skill-bundle-has-two-conformance-profiles.md
@@ -1,0 +1,297 @@
+# 135. A skill bundle has two conformance profiles
+
+Date: 2026-08-29
+
+Status: Draft
+
+## Context
+
+Curie's bundle validator rejects a specification-conformant Agent Skill. A
+`SKILL.md` carrying `allowed-tools: "Read Bash"` — the shape the agentskills.io
+specification calls canonical — fails `validate_bundle` with
+`skill.frontmatter_invalid: allowed-tools: Input should be a valid list`,
+because `SkillFrontmatter.allowed_tools` is modelled as `list[str] | None`.
+
+That typing was never a decision to refuse the string. The model landed in one
+commit on 2026-07-05 that mirrored the `SKILL.md` shape *as understood then*,
+before the specification named the space-separated string canonical, and the
+package's own recorded reasoning is that the field is spelled `allowed-tools`
+rather than `tools` because "using the real field name is the compatibility
+choice (the wedge)". Rejecting the canonical spelling of that field's value
+contradicts the reason the field is spelled that way.
+
+The divergence runs in both directions, which is the part that makes this a
+decision rather than a bug fix. Curie *accepts* several shapes the reference
+validator and the claude.ai Skills upload path hard-reject:
+`disable-model-invocation`, any unknown key, and the empty list `allowed-tools:
+[]`. Those acceptances are also deliberate. Issue #540 made the validator refuse
+the *confusable* keys (`tools`, `allowed_tools`, `allowedTools`) precisely so
+that "unknown-but-not-confusable keys still validate clean and plugin-format
+stays lenient by design", and the package's contributor guidance says plainly
+that the wedge is compatibility, not schema purity. A bundle authored for Claude
+Code must keep validating unchanged.
+
+So there are two audiences with two different, both-legitimate definitions of
+"conformant", and today one validator silently answers for both. Nothing in the
+tree tells an author which way their bundle is drifting.
+
+Two things make this worth deciding now rather than tolerating.
+
+**Publishability became a product goal.** The frozen `plugin.json` marketplace
+epic (#513) establishes that "our unit is already Claude-plugin-compatible" and
+that the missing layer is catalog plus install, with the payoff that a bundle we
+publish "should be installable in a Claude Code or Cowork marketplace
+unchanged". Something eventually has to answer whether a given bundle clears
+that bar, and the ingestion validator cannot be that thing without breaking
+every bundle already deployed.
+
+**Widening the field touches an approval gate.** The #1852 gate-shadow boot
+check reads each skill's `allowed-tools` to refuse booting a gate the bundle's
+own skill permissions would bypass, and it reads the field directly, skipping
+anything that is not a list. The moment the model accepts a string, a skill
+declaring `allowed-tools: "Bash"` becomes invisible to that check — the bundle
+would report its `Bash` gate as armed while executing `Bash` unapproved. Today
+that fail-open is masked only because `validate_bundle` rejects strings before
+boot. Accepting the string without a single shared normalization boundary arms
+it.
+
+## Decision
+
+### 1. One validator, two profiles
+
+`validate_bundle` gains a keyword-only `profile`, defaulting to
+`claude-plugin`.
+
+- **`claude-plugin`** is the default and the **ingestion contract**. It keeps
+  today's leniency exactly — `extra="allow"` stays, unknown keys stay legal,
+  `[]` stays legal — and additionally accepts the canonical string form.
+  Everything the strict profile would reject is emitted as a
+  `skill.spec_nonconformant.*` **warning** rather than an error, so accepting a
+  new shape cannot break a deploy.
+- **`agent-skills-strict`** enforces the specification's six-field closed world
+  (`name`, `description`, `license`, `compatibility`, `metadata`,
+  `allowed-tools`), its name rules, its bounds, and the canonical
+  `allowed-tools` string. It is a **publishability** profile — the eventual
+  consumer is #513's catalog, not any deploy path.
+
+**Two surfaces are permanently `claude-plugin` and pass no profile at all:**
+`runner/src/curie_runner/plugin.py` at the boot validation, and
+`apps/api/src/curie_api/bundles.py` at the deploy-ingestion validation — "the
+only gate a bundle passes through", covering CLI deploy, the UI create-agent
+modal, and git-flow push. Passing the strict profile at either site would turn
+every bundle in the fleet into a boot or deploy failure. This is a hard
+constraint, and it is asserted by a test rather than left to review.
+
+An unrecognized profile id raises `ValueError` naming both valid ids. It is
+deliberately **not** a `ValidationIssue`: a typo'd `"agent-skills-strct"`
+silently falling back to the lenient profile would be a false PASS on a
+publishability gate — the same "a typo becomes permission widening" shape the
+package's `ToolPolicy` already refuses. This is a caller error, not a bundle
+error, and it is the one documented exception to `validate_bundle`'s otherwise
+absolute no-raise contract.
+
+### 2. The canonical serialized `allowed-tools` is a space-separated string, split paren-aware
+
+Curie **emits** the string form everywhere it authors a `SKILL.md` (`curie
+init` and `curie init --from-spec`) and **accepts** the string, the block list,
+and the flow list on the way in.
+
+The string is canonical rather than the block list because the specification
+prose says so. The reference validator's *acceptance* of a block list is not a
+durable basis to canonicalize on: it is one implementation's present tolerance,
+not the format. A shape that lives only in an implementation's leniency can
+narrow in any release — and the claude.ai upload path, which is the surface a
+published bundle actually meets, is stricter than the reference validator
+already. Emitting what the prose names canonical is the shape most likely to
+still be accepted by the next consumer we have not met. The block list stays
+accepted, and stays only a warning even under the strict profile, exactly
+because the reference validator does accept it today.
+
+**Splitting is paren-aware, and this is load-bearing rather than a nicety.**
+The string is split on whitespace or a comma **only at parenthesis depth 0**.
+`Bash(git commit:*)` is a realistic Claude Code permission rule, and Claude
+Code's "space- or comma-separated string" routinely puts spaces and commas
+*inside* a specifier. A naive splitter turns that entry into `Bash(git` and
+`commit:*)`, neither of which parses back to a tool name, so the entry drops out
+of the #1852 gate-shadow detection entirely — the same fail-open, arriving
+through the shape this ADR just made canonical.
+
+A single normalization function is the **only** way any consumer reads the
+field. The model preserves whatever the author wrote, verbatim, and normalizes
+nothing. Both the validator and the runner's gate-shadow check call the shared
+helper. A second reader with its own splitting rule is the two-parsers-for-one-
+rule defect that #1495 and #1564 were each about, and the #1852 commit's own
+stated reason for not sharing a helper — "with one implementation there is no
+second path to disagree with" — expires the moment this ADR creates the second
+implementation.
+
+**An entry that cannot survive the round trip is refused, not absorbed.**
+Entries are serializable iff joining them with a space and splitting the result
+back returns the same list. The equivalent per-entry rule, used to name the
+offender, is: the entry is empty, carries a comma at depth 0, carries whitespace
+at depth 0, or has unbalanced parentheses. Unbalanced parentheses need naming
+separately because `Bash(git` round-trips cleanly *on its own* — the loss
+appears only at list level, where the following entry is swallowed into the open
+parenthesis. `cli/src/spec.rs` applies that same rule at spec-parse time, so
+`curie init --from-spec` refuses such an entry **before any byte is written**,
+which is the module's existing ethos applied one field over. The validator
+reports it as `skill.spec_nonconformant.allowed_tools_unserializable`.
+
+### 3. Strict violations are warnings on the ingestion surface, errors only under the strict profile
+
+`[]`, `disable-model-invocation`, and unknown keys appear in real, working
+Claude Code skills. Making any of them an ingestion error would re-break exactly
+what #540 deliberately preserved and would turn the lenient model into a
+de-facto `extra="forbid"`. So on the ingestion surface they are warnings, and
+they are errors only when a caller explicitly asks for the publishability
+profile.
+
+**No production surface renders those warnings today, and this decision does
+not add one.** `apps/api/src/curie_api/deploy.py` receives the whole
+`ValidationResult` but raises from `result.errors` alone;
+`apps/api/src/curie_api/routers/bundles.py` returns only `errors` in its
+response body; `runner/src/curie_runner/plugin.py` reads only `valid` and
+`errors`; and `curie skill check` does not call `validate_bundle` at all. What
+this ADR establishes is the **vocabulary and the contract that produces it** —
+the thing a publish path, a lint verb, or a deploy response can later consume.
+Anywhere this decision reads as "an author sees", read "a caller of the library
+can see". Surfacing them is a named follow-up (**FU-1**), and until it lands the
+compatibility bridge is a library contract awaiting a consumer. That is stated
+here rather than left for a later reader to discover, because a warning tier
+nobody renders is easy to mistake for a shipped author-facing feature.
+
+### 4. The schema widens; the property set does not change
+
+`$defs.SkillFrontmatter.properties["allowed-tools"].anyOf` gains a
+`{"type": "string"}` member in the regenerated
+`packages/plugin-format/schema/plugin-format.schema.json`. Nothing else in the
+document changes.
+
+That is deliberate and it is what keeps this reviewable under the
+[ADR-0101](0101-schema-compatibility-for-closed-schemas.md) /
+[ADR-0103](0103-previous-schema-shape-gate.md) regime. The specification's
+`license`, `compatibility`, and `metadata` fields are **not** added as explicit
+model fields. Adding `metadata: dict[str, str]` to a *lenient* model would turn
+a `claude-plugin` bundle carrying `metadata: {retries: 3}` into a hard error —
+a straight regression against the leniency mandate. The strict profile validates
+those three keys off the raw frontmatter mapping instead, where it can apply
+strict types without touching the lenient path. The consequence is that the
+regenerated diff is exactly one widened `anyOf`: no property is added, renamed,
+or removed, so ADR-0103's name-based properties/required gate stays quiet, and
+the change is purely widening — no document that validated before stops
+validating.
+
+No version is bumped. The `plugin-format` package carries no `PROTOCOL_VERSION`
+and no ACI wire shape changes here, matching how `approvalPolicy`, `triggers`,
+and `toolPolicy` each landed.
+
+## Consequences
+
+The #1852 fail-open is closed rather than widened: the runner's gate-shadow
+check now sees string-form declarations, and sees a paren-bearing specifier as
+the one entry it is, which it did not do for the string form before this change.
+That closure has to land in the same change as the model widening; shipping the
+widening alone would arm the fail-open.
+
+The compatibility bridge is **latent**. Until FU-1 renders warnings on some
+surface, a bundle that is spec-nonconformant deploys exactly as it does today,
+silently. The change an author can observe immediately is narrower and real: a
+`SKILL.md` written the canonical way now deploys instead of being rejected, and
+`curie init` now teaches the canonical shape.
+
+`curie init --from-spec` becomes stricter in one specific way, and this is a
+broadened error surface, not only an acceptance: a spec whose `allowed_tools`
+carries an entry with a depth-0 space or comma, or unbalanced parentheses, now
+fails to parse where it previously scaffolded. Those specs previously produced a
+bundle whose entries were silently corrupted on the way back out, so the refusal
+replaces silent corruption with a loud, entry-naming error. Specs whose entries
+are separator-free — including every one in the tree — are unaffected.
+
+**A known limitation.** Distinguishing a flow list from a block list requires
+reading raw frontmatter text, because YAML parses `[Read, Bash]` and a `- Read`
+block into the identical value. The classifier decides string-vs-list from the
+parsed value and only then scans the raw text, including a forward scan that
+correctly classifies a multiline flow sequence. What it cannot classify is
+frontmatter with no literal sequence to read — an anchor, an alias, or a merge
+key resolving to a list. Those fall back to `"block"`, which is a warning rather
+than an error under both profiles. So exotic YAML can under-report under
+`agent-skills-strict`. That is a deliberate fail-lenient on a profile nothing
+gates on yet, not an oversight.
+
+The shipped example bundles and test fixtures keep their current shapes
+(`allowed-tools: []` and block lists). They stay valid under the default profile
+and gain warnings, and keeping them on the old shapes is useful: they are the
+standing regression proof that the default profile stayed lenient. Migrating
+them is **FU-2**.
+
+The strict profile has no CLI or UI surface. It ships as a library API only, and
+a `curie skill check --profile` flag is **FU-3** — it drags in the committed
+command manifest, the generated TypeScript manifest, and a new versioned CLI
+result schema, which is a separate lane.
+
+A bundle with twenty skills each carrying a block list and two Claude Code
+extras emits on the order of sixty warnings per validation. Nothing renders them
+today, so nothing degrades; deduplication and summarization belong with FU-1
+rather than ahead of it.
+
+Follow-ups: **FU-1** render `ValidationResult.warnings` on a production surface
+at all — the deploy path must stop dropping them, the bundles router must return
+them alongside `errors`, and the CLI must render them — then deduplicate;
+**FU-2** migrate the shipped example bundles and fixtures to the canonical form;
+**FU-3** a `--profile` flag on `curie skill check`; **FU-4** a conformance CI
+gate pinning the reference validator as an oracle against our fixture matrix;
+**FU-5** decide, once this ADR is accepted, whether the strict profile should
+ever gate a publish path.
+
+## Alternatives considered
+
+**Make `agent-skills-strict` the ingestion default.** Rejected. Every bundle in
+the fleet — including every example this repository ships and every fixture its
+own tests use — carries at least one shape the strict profile refuses. Making it
+the default fails the runner at boot and the API at deploy for bundles that work
+today, to enforce a bar whose only consumer (#513's catalog) does not exist yet.
+Leniency at ingestion is the wedge; strictness is a publishability question, and
+conflating them costs the wedge to buy nothing.
+
+**Add explicit `license`, `compatibility`, and `metadata` fields to
+`SkillFrontmatter`.** Rejected. Pydantic would then type-check them on the
+*lenient* path, so a Claude Code bundle carrying `metadata: {retries: 3}` — a
+mapping the current model happily ignores — becomes a hard ingestion error. It
+would also change the property set, which is precisely the shape ADR-0103's gate
+watches, turning a one-line `anyOf` widening into a reviewable schema
+restructure. The strict profile reads those keys off the raw mapping instead and
+gets the same enforcement with none of the blast radius.
+
+**Take a dependency on the reference validator and use it as the oracle at
+runtime.** Rejected. It would put a third-party package on the deploy-ingestion
+path, where its version choices would decide whether our customers' bundles
+deploy, and it answers only the strict question — it cannot express the lenient
+profile that ingestion actually needs. Pinning it as an *oracle in CI*, against
+our own fixture matrix, is the right use of it and is FU-4; making it the
+implementation is not.
+
+**Refuse a specifier containing a space (`Bash(git commit:*)`) instead of
+splitting paren-aware.** Rejected. It is a legitimate, common Claude Code
+permission rule, and refusing it would make Curie reject bundles Claude Code
+accepts — the exact divergence this ADR exists to remove. Depth-aware splitting
+is also the truer reading of what "space- or comma-separated" means for a
+grammar whose specifiers contain spaces. What genuinely cannot round-trip is an
+entry with unbalanced parentheses, and that is what the refusal now names.
+
+## Realizing code path
+
+`packages/plugin-format/src/plugin_format/skills.py` holds the profile ids, the
+shared paren-aware normalizer, the flow-vs-block classifier, and the
+serializability rule; `packages/plugin-format/src/plugin_format/validate.py`
+threads the profile and emits the `skill.spec_nonconformant.*` findings;
+`packages/plugin-format/src/plugin_format/models.py` widens the field;
+`runner/src/curie_runner/approval.py` adopts the shared normalizer, closing the
+#1852 fail-open; and `cli/src/scaffold.rs` plus `cli/src/spec.rs` emit the
+canonical scalar and refuse an entry that cannot survive it.
+
+This ADR is **Draft** and authorizes nothing by itself. Under
+[ADR-0085](0085-acceptance-not-implementation-authorizes-an-adr.md) as amended
+by [ADR-0102](0102-accepted-alongside-implementation-with-explicit-approval.md),
+acceptance is a maintainer act: either this ADR is published Accepted, or the
+coordinated exception is recorded with explicit maintainer approval naming the
+realizing code path above.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -164,4 +164,5 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0132 | [Gate evals on the worst cohort and require cross-family verifiers](0132-worst-cohort-eval-gates-and-cross-family-verifiers.md) | Draft |
 | 0133 | [The control agent renders screens; a human presses the buttons](0133-the-control-agent-renders-screens-a-human-presses.md) | Draft |
 | 0134 | [A hook shares one thread per partition](0134-a-hook-shares-one-thread-per-partition.md) | Draft |
+| 0135 | [A skill bundle has two conformance profiles](0135-a-skill-bundle-has-two-conformance-profiles.md) | Draft |
 <!-- END GENERATED: adr-index -->

--- a/docs/interfaces/bundle-format/INTERFACE.md
+++ b/docs/interfaces/bundle-format/INTERFACE.md
@@ -55,7 +55,12 @@ raising. The shapes it checks (`packages/plugin-format/src/plugin_format/models.
 `homepage`, `repository`, `license`, `keywords`, `commands`, `agents`, `hooks`, `mcpServers`;
 `SkillFrontmatter`
 (`packages/plugin-format/src/plugin_format/models.py::SkillFrontmatter`, a `SKILL.md` frontmatter)
-with `name`/`description` required and `allowed_tools` aliased to the verbatim `allowed-tools` key;
+with `name`/`description` required and `allowed_tools` aliased to the verbatim `allowed-tools` key,
+which accepts **either** a string or a list of strings — the canonical serialized shape is the
+space-separated string (`allowed-tools: Read Bash`), split on whitespace or a comma at parenthesis
+depth 0 so a specifier such as `Bash(git commit:*)` stays one entry, and the list forms are accepted
+for compatibility ([ADR-0135](../../adr/0135-a-skill-bundle-has-two-conformance-profiles.md), Draft,
+which also adds the second, non-default `agent-skills-strict` validation profile);
 `McpServer`/`McpConfig` (`packages/plugin-format/src/plugin_format/models.py::McpConfig`, the
 `.mcp.json` file) where the validator enforces each server define `command` (stdio) or `url`
 (remote).

--- a/docs/interfaces/bundle-format/workflow-agent-conversion.md
+++ b/docs/interfaces/bundle-format/workflow-agent-conversion.md
@@ -85,7 +85,10 @@ carries over unchanged.
 <!-- doclint:ignore-line -->
 `skills/deal-desk/SKILL.md`. The frontmatter needs `name` and `description`;
 `allowed-tools` is optional but is how you scope what the model may call. Use the
-**real** field name `allowed-tools` (not `tools`).
+**real** field name `allowed-tools` (not `tools`), and write its value as the canonical
+space-separated string — several tools go on the one line (`allowed-tools: pricing Read`), and a
+specifier keeps its own spaces because the value splits at parenthesis depth 0
+([ADR-0135](../../adr/0135-a-skill-bundle-has-two-conformance-profiles.md), Draft).
 
 The body is the procedure. Put the deterministic steps behind a tool call — the
 model's job is to *gather inputs, call the tool, and phrase the result*, never to do
@@ -95,8 +98,7 @@ the arithmetic itself.
 ---
 name: deal-desk
 description: Price a deal from a free-text ask. Invoke whenever a user asks for a quote, pricing, a discount check, or "how much for N seats".
-allowed-tools:
-  - pricing            # the MCP tool server wired in .mcp.json (Step 3)
+allowed-tools: pricing            # the MCP tool server wired in .mcp.json (Step 3)
 ---
 
 # Deal desk

--- a/packages/plugin-format/README.md
+++ b/packages/plugin-format/README.md
@@ -28,7 +28,10 @@ Pydantic models mirroring the Claude Code shapes:
   `homepage`, `repository`, `license`, `keywords`, `commands`, `agents`,
   `hooks`, `mcpServers`. Unknown keys are accepted and preserved.
 - `SkillFrontmatter` (`skills/**/SKILL.md` YAML frontmatter): `name` and
-  `description` required; `allowed-tools` optional.
+  `description` required; `allowed-tools` optional, accepted as either the
+  space- or comma-separated string the Agent Skills specification calls
+  canonical or as a YAML list. The authored shape is preserved verbatim;
+  `parse_allowed_tools` is the only thing that turns it into entries.
 - `McpServer` / `McpConfig` (`.mcp.json`): `mcpServers` maps a name to a server
   that is either stdio (`command`, `args?`, `env?`) or remote (`type`, `url`,
   `headers?`).
@@ -170,6 +173,28 @@ committed schema with `scripts/check-contracts.sh` (which runs
   field is `allowed-tools`; using the real field name is the compatibility
   choice (the wedge), so the model exposes `allowed_tools` aliased to
   `allowed-tools`. A bundle written for Claude Code validates unchanged.
+- **Two conformance profiles, one rule set (ADR-0135).** A bundle is judged
+  against Claude Code's ingestion shape and against the Agent Skills
+  specification, and the two genuinely diverge in both directions. So
+  `validate_bundle` takes a `profile`: `claude-plugin` (the **default**, and the
+  ingestion contract) reports every specification divergence as a
+  `skill.spec_nonconformant.*` **warning**, so widening what we accept can never
+  break a deploy; `agent-skills-strict` reports the same findings as **errors**
+  and is a publishability gate, never an ingestion default. Runner boot and
+  deploy ingestion pass no profile and stay lenient permanently. The one finding
+  that stays a warning in both profiles is the `allowed-tools` block list, which
+  the reference validator accepts even though the spec prose does not. A typo'd
+  profile id raises `ValueError` rather than falling back — a silent fallback to
+  the lenient profile would report a bundle as publishable that was never
+  strictly checked.
+- **The canonical `allowed-tools` is one space-separated string.** Both shapes
+  are accepted forever, but the string is what `curie init` emits and what the
+  strict profile asks for. It carries one consequence worth stating: entries are
+  separated by whitespace or a comma **at paren depth 0**, so `Bash(git
+  commit:*)` round-trips intact while `Bash(git` (unbalanced) and `Read,Write`
+  cannot and are reported as `allowed_tools_unserializable`. Every consumer must
+  read the field through `parse_allowed_tools`; a second reader is how a skill's
+  declared tools become invisible to the runner's gate-shadow check (#1852).
 - **Lenient models (`extra="allow"`).** Real bundles and future Claude Code
   versions carry manifest and frontmatter keys this MVP does not model. Rejecting
   them would reject valid bundles, so the models accept and preserve unknown

--- a/packages/plugin-format/schema/plugin-format.schema.json
+++ b/packages/plugin-format/schema/plugin-format.schema.json
@@ -493,10 +493,13 @@
     },
     "SkillFrontmatter": {
       "additionalProperties": true,
-      "description": "The YAML frontmatter of a `skills/<name>/SKILL.md` file.\n\n``name`` and ``description`` are required. The tool restriction field is the\nverbatim Claude Code key ``allowed-tools`` (see the package README Decisions\nfor why this differs from the task's shorthand \"tools\").",
+      "description": "The YAML frontmatter of a `skills/<name>/SKILL.md` file.\n\n``name`` and ``description`` are required. The tool restriction field is the\nverbatim Claude Code key ``allowed-tools`` (see the package README Decisions\nfor why this differs from the task's shorthand \"tools\").\n\n``allowed-tools`` accepts BOTH authored shapes, because both occur in real\nbundles: the space- or comma-separated string the Agent Skills specification\ncalls canonical, and the YAML list Claude Code equally accepts. The model\npreserves whichever the author wrote and deliberately does NOT normalize --\nthere is exactly one normalization boundary, ``plugin_format\n.parse_allowed_tools``, and every consumer must read the field through it\nrather than raw. A second reader is how the #1852 gate-shadow fail-open\nreturns: ``runner/src/curie_runner/approval.py`` parses the frontmatter YAML\nitself and never builds a ``SkillFrontmatter``, so a normalization living in\nthe model would be one the boot check never sees.",
       "properties": {
         "allowed-tools": {
           "anyOf": [
+            {
+              "type": "string"
+            },
             {
               "items": {
                 "type": "string"

--- a/packages/plugin-format/src/plugin_format/__init__.py
+++ b/packages/plugin-format/src/plugin_format/__init__.py
@@ -37,6 +37,11 @@ from .models import (
     TriggerDeclaration,
 )
 from .reserved_env import RESERVED_BOOT_ENV, is_reserved_boot_env_name
+from .skills import (
+    PROFILE_AGENT_SKILLS_STRICT,
+    PROFILE_CLAUDE_PLUGIN,
+    parse_allowed_tools,
+)
 from .tool_policy import (
     TOOL_POLICY_ENFORCEMENT,
     ToolPolicyDecision,
@@ -63,6 +68,9 @@ __all__ = [
     "PluginManifest",
     "Author",
     "SkillFrontmatter",
+    "parse_allowed_tools",
+    "PROFILE_CLAUDE_PLUGIN",
+    "PROFILE_AGENT_SKILLS_STRICT",
     "McpServer",
     "McpConfig",
     "HookDefinition",

--- a/packages/plugin-format/src/plugin_format/models.py
+++ b/packages/plugin-format/src/plugin_format/models.py
@@ -184,13 +184,24 @@ class SkillFrontmatter(BaseModel):
     ``name`` and ``description`` are required. The tool restriction field is the
     verbatim Claude Code key ``allowed-tools`` (see the package README Decisions
     for why this differs from the task's shorthand "tools").
+
+    ``allowed-tools`` accepts BOTH authored shapes, because both occur in real
+    bundles: the space- or comma-separated string the Agent Skills specification
+    calls canonical, and the YAML list Claude Code equally accepts. The model
+    preserves whichever the author wrote and deliberately does NOT normalize --
+    there is exactly one normalization boundary, ``plugin_format
+    .parse_allowed_tools``, and every consumer must read the field through it
+    rather than raw. A second reader is how the #1852 gate-shadow fail-open
+    returns: ``runner/src/curie_runner/approval.py`` parses the frontmatter YAML
+    itself and never builds a ``SkillFrontmatter``, so a normalization living in
+    the model would be one the boot check never sees.
     """
 
     model_config = _LENIENT
 
     name: str
     description: str
-    allowed_tools: list[str] | None = Field(default=None, alias="allowed-tools")
+    allowed_tools: str | list[str] | None = Field(default=None, alias="allowed-tools")
 
 
 class HookDefinition(BaseModel):

--- a/packages/plugin-format/src/plugin_format/skills.py
+++ b/packages/plugin-format/src/plugin_format/skills.py
@@ -1,0 +1,205 @@
+"""The Agent Skills conformance vocabulary and the ``allowed-tools`` boundary.
+
+Two things live here, both shared by the validator and (for
+``parse_allowed_tools``) by the runner:
+
+- **The profile ids.** ``validate_bundle`` runs one rule set under two profiles:
+  ``claude-plugin`` is the ingestion contract and reports every specification
+  divergence as a warning; ``agent-skills-strict`` is a publishability gate and
+  reports the same findings as errors (ADR-0135).
+- **``parse_allowed_tools``, the single normalization boundary (D1).** Everything
+  a consumer knows about ``allowed-tools`` comes through it. That is not a style
+  preference: ``runner/src/curie_runner/approval.py``'s #1852 gate-shadow check
+  reads the field, and an entry this helper loses is an entry the boot check
+  cannot see -- a bundle that reports its Bash gate as armed while executing Bash
+  unapproved. A second reader of this field is how that fail-open comes back.
+
+``allowed_tools_style`` and ``unserializable_entries`` are validator internals and
+are deliberately NOT exported from the package root: they answer "how was this
+authored" and "would this survive the canonical serialization", questions only a
+conformance check has, while a runtime consumer only ever needs the entries.
+"""
+
+import re
+
+# The two conformance profiles. `claude-plugin` is the DEFAULT everywhere and is
+# permanently what runner boot (`runner/src/curie_runner/plugin.py`) and deploy
+# ingestion (`apps/api/src/curie_api/bundles.py`) validate under.
+PROFILE_CLAUDE_PLUGIN = "claude-plugin"
+PROFILE_AGENT_SKILLS_STRICT = "agent-skills-strict"
+PROFILES = (PROFILE_CLAUDE_PLUGIN, PROFILE_AGENT_SKILLS_STRICT)
+
+# The Agent Skills specification's closed world, in spec order. This is an
+# ALLOWLIST on purpose: a denylist of the known Claude Code extras
+# (`disable-model-invocation`, `user-invocable`, `argument-hint`, ...) goes stale
+# the next time Claude Code adds a field, and a publishability gate that silently
+# passes an unknown field is a false PASS.
+SPEC_FIELDS = ("name", "description", "license", "compatibility", "metadata", "allowed-tools")
+
+# The specification's skill-name rule: lowercase alphanumerics with single
+# internal hyphens. Deliberately a LOCAL constant rather than a reuse of
+# ``validate._NAME_RE`` (the Claude Code plugin manifest's kebab rule): the two
+# rules happen to coincide today, and a future change to the manifest rule must
+# not silently move this one. Length (1-64) is checked separately so a finding
+# can name which of the two rules failed.
+SKILL_NAME_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+
+# The zero-indent ``allowed-tools:`` line, with whatever follows it on that line.
+# Anchored at column 0 so a nested key of the same name is never mistaken for the
+# top-level one.
+_KEY_LINE_RE = re.compile(r"^allowed-tools:[ \t]*(.*)$")
+
+
+def parse_allowed_tools(value: str | list[str] | None) -> list[str]:
+    """The entries a skill's ``allowed-tools`` declaration names, normalized.
+
+    The ONE reader of this field (D1). Accepts either authored shape -- the
+    canonical space-separated string or a YAML list -- and never raises, whatever
+    it is handed: ``_skill_allowed_tools`` is deliberately tolerant, and a bundle
+    whose frontmatter is nonsense is already reported by ``validate_bundle``.
+    Raising here would fail the gate-shadow boot check on the wrong defect and
+    hide the real one, so any other input yields ``[]``.
+
+    A **string** is split on whitespace or a comma at PAREN DEPTH 0 only (D4).
+    ``re.split(r"[\\s,]+", value)`` is explicitly the wrong implementation:
+    ``"Bash(git commit:*)"`` is a realistic Claude Code permission rule, and
+    splitting it into ``Bash(git`` / ``commit:*)`` makes ``_entry_tool`` return
+    ``None`` for one fragment and a garbage tool name for the other -- the entry
+    disappears from gate-shadow detection while looking like it was read.
+
+    A **list** is already itemized, so its ``str`` entries are kept VERBATIM
+    (surrounding whitespace stripped, empties dropped) and never re-split. Non-str
+    items are filtered rather than coerced.
+    """
+
+    if isinstance(value, str):
+        return _split_at_depth_zero(value)
+    if isinstance(value, list):
+        return [entry.strip() for entry in value if isinstance(entry, str) and entry.strip()]
+    return []
+
+
+def _split_at_depth_zero(value: str) -> list[str]:
+    """Cut ``value`` at whitespace or commas that are outside every paren group."""
+
+    entries: list[str] = []
+    current: list[str] = []
+    depth = 0
+    for char in value:
+        if char == "(":
+            depth += 1
+        elif char == ")":
+            # Floored at 0 so a stray close paren cannot drive the depth
+            # negative and thereby suppress every separator after it.
+            depth = max(0, depth - 1)
+        elif depth == 0 and (char.isspace() or char == ","):
+            if current:
+                entries.append("".join(current))
+                current = []
+            continue
+        current.append(char)
+    if current:
+        entries.append("".join(current))
+    return entries
+
+
+def unserializable_entries(entries: list[str]) -> list[str]:
+    """The entries that cannot survive the canonical ``" ".join`` round-trip (D4).
+
+    The invariant the canonical scalar rests on is a list-level identity:
+    ``parse_allowed_tools(" ".join(entries)) == entries``. This is the equivalent
+    PER-ENTRY predicate, so a finding can name the entry to fix rather than the
+    whole list -- an entry that is empty, or that carries a comma or whitespace at
+    paren depth 0, or whose parens are unbalanced.
+
+    Unbalanced parens have to be named separately because a depth-aware splitter
+    round-trips ``"Bash(git"`` cleanly ON ITS OWN; the loss appears only at the
+    list level, where the open paren swallows the following entry
+    (``["Bash(git", "Read"]`` joins to ``"Bash(git Read"``, which parses back as
+    ONE entry). The list-level identity alone would therefore miss it in the
+    single-entry case.
+    """
+
+    return [entry for entry in entries if _cannot_round_trip(entry)]
+
+
+def _cannot_round_trip(entry: str) -> bool:
+    if not entry:
+        return True
+    depth = 0
+    for char in entry:
+        if char == "(":
+            depth += 1
+        elif char == ")":
+            if depth == 0:
+                return True
+            depth -= 1
+        elif depth == 0 and (char.isspace() or char == ","):
+            return True
+    return depth != 0
+
+
+def allowed_tools_style(raw_frontmatter: str, parsed_value: object) -> str:
+    """How ``allowed-tools`` was AUTHORED: ``absent``/``string``/``block``/``flow``.
+
+    pyyaml parses ``[Read, Bash]`` and a ``- Read`` block into the same list, so
+    raw-text inspection is unavoidable to tell them apart. But raw text ALONE
+    misreads ``allowed-tools: "[Read]"`` -- a quoted string that merely begins
+    with ``[`` -- so the PARSED value decides absent-vs-string-vs-list first, and
+    the raw text is consulted only once the value is known to be a list (D3).
+
+    Within the list case the raw scan is a FORWARD scan, not a peek at the key's
+    line. ``allowed-tools:\\n  [Read]`` is a syntactically valid multiline flow
+    sequence; a single-line detector reads it as a block list, and since a block
+    list is only a warning under the strict profile while a flow list is an error,
+    that misread would be a false PASS on a publishability gate.
+
+    ``block`` is the fallback because it is the SAFE one: it is a warning in both
+    profiles. Falling back to ``flow`` would hard-fail a strict bundle on YAML the
+    detector simply could not read (a false FAIL); falling back to ``string``
+    would suppress the finding entirely (a false PASS). The fallback now survives
+    only for exotic YAML with no literal sequence at the key to read -- an anchor,
+    an alias, or a merge key resolving to a list -- recorded as a known limitation
+    in ADR-0135.
+    """
+
+    # `allowed-tools: null` parses to None exactly as an absent key does, and
+    # declares no tools either way, so it is reported as absent rather than as an
+    # empty declaration. A value that is neither a string nor a list is already a
+    # `skill.frontmatter_invalid` error from the model; there is no authored
+    # SHAPE to report about it.
+    if parsed_value is None or not isinstance(parsed_value, str | list):
+        return "absent"
+    if isinstance(parsed_value, str):
+        return "string"
+
+    # A `\r` left in place would be the remainder's first non-space character, so
+    # a CRLF file would never read as flow.
+    lines = raw_frontmatter.replace("\r\n", "\n").replace("\r", "\n").split("\n")
+    for index, line in enumerate(lines):
+        match = _KEY_LINE_RE.match(line)
+        if match is None:
+            continue
+        remainder = _strip_inline_comment(match.group(1)).strip()
+        if remainder:
+            return "flow" if remainder.startswith("[") else "block"
+        for following in lines[index + 1 :]:
+            stripped = following.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            return "flow" if stripped.startswith("[") else "block"
+        return "block"
+    return "block"
+
+
+def _strip_inline_comment(text: str) -> str:
+    """Drop a YAML trailing comment: a ``#`` at the start or after whitespace."""
+
+    if text.startswith("#"):
+        return ""
+    index = text.find("#")
+    while index > 0:
+        if text[index - 1] in " \t":
+            return text[:index]
+        index = text.find("#", index + 1)
+    return text

--- a/packages/plugin-format/src/plugin_format/validate.py
+++ b/packages/plugin-format/src/plugin_format/validate.py
@@ -9,7 +9,7 @@ import json
 import re
 from collections.abc import Callable, Mapping
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol
 
 import yaml
 from pydantic import BaseModel, TypeAdapter, ValidationError
@@ -43,6 +43,16 @@ from .models import (
     TriggerDeclaration,
 )
 from .reserved_env import SECRET_NAME_RE, is_reserved_boot_env_name
+from .skills import (
+    PROFILE_AGENT_SKILLS_STRICT,
+    PROFILE_CLAUDE_PLUGIN,
+    PROFILES,
+    SKILL_NAME_RE,
+    SPEC_FIELDS,
+    allowed_tools_style,
+    parse_allowed_tools,
+    unserializable_entries,
+)
 from .tool_policy import (
     TOOL_POLICY_ENFORCEMENT,
     check_policy_patterns,
@@ -88,7 +98,10 @@ class _Collector:
 
 
 def validate_bundle(
-    path: str | Path, *, enforces_tool_policy: str | None = None
+    path: str | Path,
+    *,
+    enforces_tool_policy: str | None = None,
+    profile: str = PROFILE_CLAUDE_PLUGIN,
 ) -> ValidationResult:
     """Validate the plugin bundle at ``path`` and return a ValidationResult.
 
@@ -111,7 +124,38 @@ def validate_bundle(
     The keyword-only ``None`` default keeps every existing call site
     source-compatible, and a bundle that declares no ``toolPolicy`` is entirely
     unaffected -- it yields the same ``valid``/``errors``/``warnings`` as before.
+
+    Profiles (ADR-0135)
+    -------------------
+    ``profile`` selects which conformance contract the skill checks report
+    against. One rule set, two verdicts:
+
+    - ``"claude-plugin"`` (the DEFAULT, and the ingestion contract) keeps today's
+      leniency exactly. Every Agent Skills divergence is a
+      ``skill.spec_nonconformant.*`` WARNING, so no bundle that deploys today
+      stops deploying. Runner boot and deploy ingestion pass no ``profile`` and
+      stay on this permanently.
+    - ``"agent-skills-strict"`` is a PUBLISHABILITY gate: the same findings are
+      errors, because a bundle the reference validator rejects must not clear it.
+      It is never the ingestion default anywhere.
+
+    An unrecognized ``profile`` raises ``ValueError`` naming both valid ids. That
+    is a deliberate exception to this function's otherwise absolute "returns
+    errors instead of raising" contract: a typo'd ``"agent-skills-strct"``
+    silently falling back to the lenient profile would report a bundle as
+    publishable that was never strictly checked -- a false PASS on a gate, the
+    same "a typo becomes permission widening" shape ``ToolPolicy`` refuses. It is
+    a CALLER error rather than a bundle error, and neither production caller
+    passes a profile, so neither can trigger it.
     """
+
+    if profile not in PROFILES:
+        raise ValueError(
+            f"unknown validation profile {profile!r}: expected "
+            f"{PROFILE_CLAUDE_PLUGIN!r} (the ingestion default, which reports every "
+            f"specification divergence as a warning) or {PROFILE_AGENT_SKILLS_STRICT!r} "
+            "(the publishability gate, which reports them as errors)"
+        )
 
     root = Path(path)
     c = _Collector()
@@ -122,7 +166,7 @@ def validate_bundle(
 
     manifest = _validate_manifest(root, c)
     if manifest is not None:
-        _validate_skills(root, c)
+        _validate_skills(root, c, profile)
         mcp_servers = _validate_mcp(root, manifest, c)
         _validate_hooks(root, manifest, c)
         _validate_triggers(manifest, c)
@@ -396,7 +440,7 @@ def _validate_manifest(root: Path, c: _Collector) -> PluginManifest | None:
     return manifest
 
 
-def _validate_skills(root: Path, c: _Collector) -> None:
+def _validate_skills(root: Path, c: _Collector, profile: str) -> None:
     skills_dir = root / "skills"
     if not skills_dir.is_dir():
         return
@@ -408,15 +452,20 @@ def _validate_skills(root: Path, c: _Collector) -> None:
 
     for skill_file in skill_files:
         rel = str(skill_file.relative_to(root))
-        frontmatter = _read_frontmatter(skill_file, rel, c)
-        if frontmatter is None:
+        read = _read_frontmatter(skill_file, rel, c)
+        if read is None:
             continue
+        frontmatter, raw = read
         _check_tools_confusable(frontmatter, rel, c)
         try:
             SkillFrontmatter.model_validate(frontmatter)
         except ValidationError as exc:
             for issue in _explain(exc):
                 c.error("skill.frontmatter_invalid", issue, rel)
+        # Runs in BOTH profiles and always after the two checks above, so every
+        # error code and ordering this file produced before the profiles existed
+        # is unchanged; the conformance findings are strictly additive.
+        _check_spec_conformance(frontmatter, raw, skill_file, rel, profile, c)
 
 
 # Keys an author reaches for instead of the verbatim Claude Code ``allowed-tools``.
@@ -440,6 +489,195 @@ def _check_tools_confusable(frontmatter: dict[str, Any], rel: str, c: _Collector
                 rel,
             )
             return
+
+
+# Every conformance finding shares this prefix, so a consumer can filter the
+# whole tier with one startswith and no existing code is renamed or removed.
+_SPEC_NONCONFORMANT = "skill.spec_nonconformant"
+
+# The specification's bounds. Named rather than inlined so a finding's message
+# and its test can quote the same number.
+_MAX_SKILL_NAME = 64
+_MAX_DESCRIPTION = 1024
+_MAX_COMPATIBILITY = 500
+
+
+class _ReportFn(Protocol):
+    """Emits one conformance finding at the profile's severity.
+
+    ``always_warning`` is the block-list carve-out: a finding the strict profile
+    reports as a warning too, because the reference validator accepts the shape.
+    """
+
+    def __call__(self, suffix: str, message: str, *, always_warning: bool = False) -> None: ...
+
+
+def _check_spec_conformance(
+    frontmatter: dict[str, Any],
+    raw: str,
+    skill_file: Path,
+    rel: str,
+    profile: str,
+    c: _Collector,
+) -> None:
+    """Report every Agent Skills divergence, as a warning or an error (ADR-0135).
+
+    ONE rule set, two verdicts. Under ``claude-plugin`` each finding is a warning
+    so the ingestion path keeps accepting everything it accepts today; under
+    ``agent-skills-strict`` the same finding is an error, because that profile
+    answers "would the reference validator publish this bundle".
+
+    The one deliberate exception is the block list, which stays a WARNING in both
+    profiles: ``skills-ref`` accepts it while the specification prose names the
+    string canonical, so erroring on it would fail bundles the reference
+    validator passes.
+
+    These checks read the RAW frontmatter mapping rather than a validated
+    ``SkillFrontmatter``, which is what lets the strict profile apply strict types
+    to ``license``/``compatibility``/``metadata`` without adding fields to the
+    lenient model (D2) -- but it also means every value here is unvalidated, so
+    each check guards its own type before it reads.
+    """
+
+    strict = profile == PROFILE_AGENT_SKILLS_STRICT
+
+    def report(suffix: str, message: str, *, always_warning: bool = False) -> None:
+        code = f"{_SPEC_NONCONFORMANT}.{suffix}"
+        if strict and not always_warning:
+            c.error(code, message, rel)
+        else:
+            c.warn(code, message, rel)
+
+    # An ALLOWLIST, not a denylist of the known Claude Code extras: a denylist
+    # goes stale the next time Claude Code adds a field, and a publishability
+    # gate that silently passes an unknown field is a false PASS.
+    for key in frontmatter:
+        if key not in SPEC_FIELDS:
+            report(
+                "unknown_field",
+                f"frontmatter key {str(key)!r} is not one of the Agent Skills fields "
+                f"{list(SPEC_FIELDS)}. Claude Code accepts it, but the specification's "
+                "field set is closed, so a strictly conformant skill cannot carry it.",
+            )
+
+    name = frontmatter.get("name")
+    if isinstance(name, str):
+        if not 1 <= len(name) <= _MAX_SKILL_NAME:
+            report(
+                "name_length",
+                f"skill name is {len(name)} characters; the specification allows "
+                f"1-{_MAX_SKILL_NAME}.",
+            )
+        if not SKILL_NAME_RE.match(name):
+            report(
+                "name_charset",
+                f"skill name {name!r} must be lowercase letters and digits separated by "
+                "single hyphens.",
+            )
+        # The IMMEDIATE parent directory: the specification pairs a skill with its
+        # own directory, and `rglob` accepts a skill at any depth.
+        if name != skill_file.parent.name:
+            report(
+                "name_dir_mismatch",
+                f"skill name {name!r} does not match its directory "
+                f"{skill_file.parent.name!r}; the specification pairs a skill with the "
+                "directory it lives in.",
+            )
+
+    # A missing or non-string `description` is already a
+    # `skill.frontmatter_invalid` error from the model, so only the bounds are
+    # this check's to report.
+    description = frontmatter.get("description")
+    if isinstance(description, str) and not 1 <= len(description) <= _MAX_DESCRIPTION:
+        report(
+            "description_length",
+            f"skill description is {len(description)} characters; the specification "
+            f"allows 1-{_MAX_DESCRIPTION}.",
+        )
+
+    if "license" in frontmatter and not isinstance(frontmatter["license"], str):
+        report("license_type", "`license` must be a string (an SPDX identifier).")
+
+    if "compatibility" in frontmatter:
+        compatibility = frontmatter["compatibility"]
+        if not isinstance(compatibility, str) or len(compatibility) > _MAX_COMPATIBILITY:
+            report(
+                "compatibility_length",
+                f"`compatibility` must be a string of at most {_MAX_COMPATIBILITY} characters.",
+            )
+
+    if "metadata" in frontmatter:
+        metadata = frontmatter["metadata"]
+        if not isinstance(metadata, dict) or not all(
+            isinstance(key, str) and isinstance(value, str) for key, value in metadata.items()
+        ):
+            report(
+                "metadata_shape",
+                "`metadata` must be a mapping of string keys to STRING values; the "
+                "specification does not allow a number, a boolean or a nested object "
+                "as a value.",
+            )
+
+    _check_spec_allowed_tools(frontmatter, raw, report)
+
+
+def _check_spec_allowed_tools(
+    frontmatter: dict[str, Any],
+    raw: str,
+    report: _ReportFn,
+) -> None:
+    """The ``allowed-tools`` half of the conformance checks (D3/D4)."""
+
+    if "allowed-tools" not in frontmatter:
+        return
+    declared = frontmatter["allowed-tools"]
+    style = allowed_tools_style(raw, declared)
+    if style == "absent":
+        # `allowed-tools: null` declares no tools exactly as an absent key does,
+        # so there is no authored shape to report on.
+        return
+
+    if style == "block":
+        # A warning in BOTH profiles: the reference validator accepts a block
+        # list, so erroring here would fail a bundle skills-ref publishes.
+        report(
+            "allowed_tools_block_list",
+            "`allowed-tools` is a YAML block list. The Agent Skills specification's "
+            "canonical shape is one space-separated string (the reference validator "
+            "accepts the list, so this is advisory).",
+            always_warning=True,
+        )
+    elif style == "flow":
+        report(
+            "allowed_tools_flow_list",
+            "`allowed-tools` is a YAML flow sequence. The Agent Skills specification's "
+            "canonical shape is one space-separated string.",
+        )
+
+    # Applies to the STRING form too, not only to lists: an entry with unbalanced
+    # parens is one `_entry_tool` cannot read, so it contributes nothing to the
+    # #1852 gate-shadow check while looking like a declared tool.
+    #
+    # A LIST is checked against its AUTHORED entries, not `parse_allowed_tools`'s
+    # normalized ones: that helper strips whitespace and drops empties before this
+    # check would ever see them, so `[" Read "]` looked clean even though it does
+    # not survive the canonical `parse_allowed_tools(" ".join(entries)) == entries`
+    # round-trip (it normalizes to `["Read"]`). A string, by contrast, decomposes
+    # into entries that round-trip by construction, so `parse_allowed_tools` is
+    # still the right input there.
+    if isinstance(declared, list):
+        candidates = [entry for entry in declared if isinstance(entry, str)]
+    else:
+        candidates = parse_allowed_tools(declared)
+    offenders = unserializable_entries(candidates)
+    if offenders:
+        report(
+            "allowed_tools_unserializable",
+            f"`allowed-tools` entries {offenders} cannot survive the canonical "
+            "space-separated form: an entry may not be empty, carry a comma or "
+            "whitespace outside a `(...)` specifier, or leave a paren unbalanced. "
+            "`Bash(git commit:*)` is fine; `Bash(git` and `Read,Write` are not.",
+        )
 
 
 def _validate_mcp(root: Path, manifest: PluginManifest, c: _Collector) -> set[str] | None:
@@ -1011,7 +1249,20 @@ def _validate_scripts(root: Path, c: _Collector) -> None:
         c.error("scripts.not_a_directory", "scripts must be a directory", "scripts")
 
 
-def _read_frontmatter(skill_file: Path, rel: str, c: _Collector) -> dict[str, Any] | None:
+def _read_frontmatter(
+    skill_file: Path, rel: str, c: _Collector
+) -> tuple[dict[str, Any], str] | None:
+    """The parsed frontmatter mapping AND the raw text it was parsed from.
+
+    The raw half is what ``allowed_tools_style`` needs: pyyaml parses a flow
+    sequence and a block list into the same list, so the authored shape survives
+    only in the source text (D3). It is ``parts[1]``, which is exactly the
+    frontmatter even when the body contains its own ``---`` rule, because the
+    split below is bounded at 2.
+
+    Every error code and message here is unchanged; only the success shape moved.
+    """
+
     text = skill_file.read_text(encoding="utf-8")
     if not text.startswith("---"):
         c.error("skill.frontmatter_missing", "SKILL.md has no YAML frontmatter block", rel)
@@ -1035,7 +1286,7 @@ def _read_frontmatter(skill_file: Path, rel: str, c: _Collector) -> dict[str, An
     if not isinstance(loaded, dict):
         c.error("skill.frontmatter_invalid", "frontmatter must be a YAML mapping", rel)
         return None
-    return loaded
+    return loaded, parts[1]
 
 
 def _explain(

--- a/packages/plugin-format/tests/test_models.py
+++ b/packages/plugin-format/tests/test_models.py
@@ -207,3 +207,82 @@ def test_manifest_tool_policy_field() -> None:
     assert manifest.model_dump(exclude_none=True)["toolPolicy"] == declared
 
     assert PluginManifest.model_validate({"name": "demo"}).toolPolicy is None
+
+
+def test_skill_frontmatter_accepts_the_canonical_string_form_verbatim() -> None:
+    """``allowed-tools`` accepts the space-separated string the spec calls canonical.
+
+    The model widening is the headline fix: a SKILL.md written for the Agent
+    Skills specification is rejected today with "Input should be a valid list".
+    Restoring it is a return to this model's ORIGINAL intent -- mirroring the
+    Claude Code shape verbatim -- not a departure from it.
+    """
+    fm = SkillFrontmatter.model_validate(
+        {"name": "greeter", "description": "greets", "allowed-tools": "Read Bash"}
+    )
+    assert fm.allowed_tools == "Read Bash"
+
+    # The comma-separated string Claude Code equally documents.
+    comma = SkillFrontmatter.model_validate(
+        {"name": "greeter", "description": "greets", "allowed-tools": "Read,Bash"}
+    )
+    assert comma.allowed_tools == "Read,Bash"
+
+    # Absent stays None, so every bundle shipped before this widening is untouched.
+    assert (
+        SkillFrontmatter.model_validate({"name": "greeter", "description": "d"}).allowed_tools
+        is None
+    )
+
+
+def test_the_model_preserves_the_authored_shape_and_does_not_normalize() -> None:
+    """One normalization boundary, and the model is not it (D1).
+
+    If the model normalized, there would be two places that know how to read the
+    field, and ``runner/src/curie_runner/approval.py`` -- which parses the raw
+    YAML itself and never builds a ``SkillFrontmatter`` -- would be the one left
+    behind. That divergence is the #1852 fail-open: a gate reported as armed
+    while the tool executes unapproved.
+    """
+    from plugin_format import parse_allowed_tools
+
+    fm = SkillFrontmatter.model_validate(
+        {"name": "greeter", "description": "greets", "allowed-tools": "Read Bash"}
+    )
+    # The model hands back exactly what the author wrote...
+    assert isinstance(fm.allowed_tools, str)
+    assert fm.allowed_tools == "Read Bash"
+    # ...and the helper is the only thing that turns it into entries.
+    assert parse_allowed_tools(fm.allowed_tools) == ["Read", "Bash"]
+
+    # The list form is likewise preserved, not rewritten into a string.
+    listed = SkillFrontmatter.model_validate(
+        {"name": "greeter", "description": "greets", "allowed-tools": ["Read", "Bash"]}
+    )
+    assert listed.allowed_tools == ["Read", "Bash"]
+    assert parse_allowed_tools(listed.allowed_tools) == ["Read", "Bash"]
+
+    # Round-tripping through the alias keeps the authored shape.
+    assert fm.model_dump(by_alias=True)["allowed-tools"] == "Read Bash"
+
+
+def test_the_committed_schema_declares_the_string_form() -> None:
+    """Intent-bearing cover for the regenerated schema, not just a byte diff.
+
+    ``test_schema_compat.py`` proves the committed file matches what pydantic
+    renders TODAY. It cannot tell you that a future regeneration silently
+    narrowed ``allowed-tools`` back to a list -- both sides would move together
+    and the gate would stay green. This asserts the meaning.
+    """
+    import json
+    from pathlib import Path
+
+    schema_path = Path(__file__).parents[1] / "schema" / "plugin-format.schema.json"
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    any_of = schema["$defs"]["SkillFrontmatter"]["properties"]["allowed-tools"]["anyOf"]
+
+    assert {"type": "string"} in any_of, any_of
+    # The widening is purely additive: the list and null members must survive, or
+    # every bundle carrying a block list stops validating against the schema.
+    assert {"type": "array", "items": {"type": "string"}} in any_of, any_of
+    assert {"type": "null"} in any_of, any_of

--- a/packages/plugin-format/tests/test_skills.py
+++ b/packages/plugin-format/tests/test_skills.py
@@ -1,0 +1,289 @@
+"""The single normalization boundary for skill ``allowed-tools`` (D1/D3/D4).
+
+Everything a consumer knows about ``allowed-tools`` comes through
+``parse_allowed_tools``. That is not a style preference: ``approval.py``'s #1852
+gate-shadow check reads the field, and an entry this helper loses is an entry the
+boot check cannot see -- a bundle that reports its gate as armed while executing
+the tool. So the coverage here is deliberately deeper than the field's surface
+area suggests, and the paren-aware cases are the load-bearing ones.
+"""
+
+import pytest
+from plugin_format import parse_allowed_tools
+from plugin_format.skills import allowed_tools_style, unserializable_entries
+
+# --- parse_allowed_tools: the string form ------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        # The canonical shape the Agent Skills specification names.
+        ("Read Bash", ["Read", "Bash"]),
+        # Claude Code documents "space- OR comma-separated", so both split.
+        ("Read,Bash", ["Read", "Bash"]),
+        ("Read, Bash", ["Read", "Bash"]),
+        # Any whitespace run, not just a single space.
+        ("Read\t Bash\n", ["Read", "Bash"]),
+        ("  Read   Bash  ", ["Read", "Bash"]),
+        # Separator-only and empty inputs yield nothing rather than an empty entry.
+        ("", []),
+        ("   ", []),
+        (",", []),
+        (" , , ", []),
+        # A specifier is part of the entry, never re-split.
+        ("Bash(git:*) Read", ["Bash(git:*)", "Read"]),
+        # D4: whitespace INSIDE a specifier must not split. A paren-blind
+        # splitter yields ["Bash(git", "commit:*)"], _entry_tool returns None for
+        # the first and a garbage name for the second, and the gate shadow is
+        # missed entirely. This is the fail-open in string form.
+        ("Bash(git commit:*) Read", ["Bash(git commit:*)", "Read"]),
+        ("Read Bash(git commit:*)", ["Read", "Bash(git commit:*)"]),
+        # A comma inside a specifier is likewise part of the entry.
+        ("Bash(a,b) Read", ["Bash(a,b)", "Read"]),
+        # Nested parens keep the depth walk honest.
+        ("Bash(a(b c)d) Read", ["Bash(a(b c)d)", "Read"]),
+        # Unbalanced parens absorb to end of string. Never raises; the entry is
+        # named later by unserializable_entries, not lost here.
+        ("Bash(git", ["Bash(git"]),
+        ("Bash(git Read", ["Bash(git Read"]),
+        # A stray close paren at depth 0 must not drive depth negative and
+        # thereby suppress the following separator.
+        ("oops) Read", ["oops)", "Read"]),
+    ],
+)
+def test_parse_allowed_tools_splits_a_string_at_paren_depth_zero(
+    value: str, expected: list[str]
+) -> None:
+    assert parse_allowed_tools(value) == expected
+
+
+# --- parse_allowed_tools: the list form --------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (["Read", "Bash"], ["Read", "Bash"]),
+        # A list is already itemized: entries are kept VERBATIM and never
+        # re-split, so a specifier survives whatever it contains.
+        (["Bash(git:*)"], ["Bash(git:*)"]),
+        (["Bash(git commit:*)"], ["Bash(git commit:*)"]),
+        (["Read Write"], ["Read Write"]),
+        # Non-str items are filtered rather than coerced: a tolerant consumer on
+        # a malformed bundle must not raise.
+        (["Read", 3, None, "Bash"], ["Read", "Bash"]),
+        ([3, None, {"a": 1}], []),
+        # Surrounding whitespace is stripped; empties are dropped.
+        (["  Read  ", "", "   ", "Bash"], ["Read", "Bash"]),
+        ([], []),
+    ],
+)
+def test_parse_allowed_tools_keeps_list_entries_verbatim(
+    value: list[object], expected: list[str]
+) -> None:
+    assert parse_allowed_tools(value) == expected
+
+
+@pytest.mark.parametrize("value", [None, 3, 0, {"a": 1}, True, False, 1.5, ("Read",), object()])
+def test_parse_allowed_tools_never_raises_on_a_malformed_value(value: object) -> None:
+    """Defensive by contract: ``_skill_allowed_tools`` is deliberately tolerant.
+
+    A bundle whose frontmatter is nonsense is already reported by
+    ``validate_bundle``; raising here would make the gate-shadow boot check fail
+    on the wrong defect and hide the real one.
+    """
+    assert parse_allowed_tools(value) == []
+
+
+def test_the_helper_is_exported_from_the_package_root() -> None:
+    """Consumers import the public name, not the module path (A7)."""
+    import plugin_format
+
+    assert "parse_allowed_tools" in plugin_format.__all__
+    assert plugin_format.PROFILE_CLAUDE_PLUGIN == "claude-plugin"
+    assert plugin_format.PROFILE_AGENT_SKILLS_STRICT == "agent-skills-strict"
+
+
+# --- the D4 round-trip identity ----------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "entries",
+    [
+        ["Read"],
+        ["Read", "Bash"],
+        ["Bash(git:*)", "Read"],
+        ["Bash(git commit:*)", "Read"],
+        ["Bash(a,b)", "Read"],
+        ["mcp__crm__send", "Read"],
+        [],
+    ],
+)
+def test_a_serializable_list_survives_the_canonical_join(entries: list[str]) -> None:
+    """The invariant the canonical scalar rests on: join then parse is identity.
+
+    ``cli/src/scaffold.rs`` emits ``" ".join(entries)`` as one YAML scalar. If
+    that does not parse back to the same list, the scaffold silently corrupts an
+    author's permission rules.
+    """
+    assert parse_allowed_tools(" ".join(entries)) == entries
+    assert unserializable_entries(entries) == []
+
+
+def test_an_unbalanced_entry_breaks_the_identity_at_the_LIST_level() -> None:
+    """Why unbalanced parens are a NAMED rejection and not caught by the join test.
+
+    ``"Bash(git"`` round-trips cleanly on its own -- a depth-aware splitter
+    returns it verbatim. The loss appears only once a following entry exists: the
+    open paren swallows it, and two entries collapse into one.
+    """
+    entries = ["Bash(git", "Read"]
+    assert parse_allowed_tools(" ".join(entries)) == ["Bash(git Read"]
+    assert parse_allowed_tools(" ".join(entries)) != entries
+    # ...which is exactly why the per-entry predicate names it independently.
+    assert unserializable_entries(entries) == ["Bash(git"]
+
+
+# --- unserializable_entries ---------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "entry",
+    [
+        "Read",
+        "Bash",
+        "Bash()",
+        "Bash(*)",
+        "Bash(git:*)",
+        # The correction to an earlier draft: paren-awareness makes this
+        # round-trip, so it is serializable and must NOT be flagged.
+        "Bash(git commit:*)",
+        "Bash(a,b)",
+        "Bash(a(b c)d)",
+        "mcp__crm__send",
+    ],
+)
+def test_a_separator_free_entry_is_serializable(entry: str) -> None:
+    assert unserializable_entries([entry]) == []
+
+
+@pytest.mark.parametrize(
+    "entry",
+    [
+        # Whitespace at depth 0.
+        "Read Write",
+        "Read\tWrite",
+        # A comma at depth 0.
+        "Read,Write",
+        "Read , Write",
+        # Unbalanced parens: depth never returns to 0...
+        "Bash(git",
+        "Bash(a(b)",
+        # ...or a close paren appears at depth 0.
+        "oops)",
+        "Bash(a))",
+    ],
+)
+def test_an_entry_that_cannot_round_trip_is_named(entry: str) -> None:
+    assert unserializable_entries([entry]) == [entry]
+
+
+def test_only_the_offending_entries_are_named() -> None:
+    """The message has to point at the entry to fix, not at the whole list."""
+    entries = ["Read", "Bash(git commit:*)", "Read Write", "Bash(git", "Bash(a,b)"]
+    assert unserializable_entries(entries) == ["Read Write", "Bash(git"]
+
+
+# --- allowed_tools_style (D3) -------------------------------------------------
+#
+# pyyaml parses `[Read, Bash]` and a `- Read` block identically, so raw text is
+# unavoidable. But raw text ALONE misclassifies a quoted "[Read]" string, so the
+# PARSED value decides string-vs-list first and raw text is consulted only for a
+# list.
+
+
+def _fm(body: str) -> str:
+    """The raw frontmatter text ``_read_frontmatter`` hands back (``parts[1]``)."""
+    return f"\nname: demo\ndescription: A demo skill.\n{body}"
+
+
+@pytest.mark.parametrize(
+    ("raw", "parsed", "expected"),
+    [
+        # Absent / null: the parsed value settles it before raw text is read.
+        (_fm(""), None, "absent"),
+        (_fm("allowed-tools:\n"), None, "absent"),
+        # String forms.
+        (_fm("allowed-tools: Read Bash\n"), "Read Bash", "string"),
+        (_fm('allowed-tools: "Read,Bash"\n'), "Read,Bash", "string"),
+        (_fm('allowed-tools: ""\n'), "", "string"),
+        # The trap: a QUOTED string that begins with `[`. Raw text alone reads
+        # this as a flow sequence; the parsed type is the authority.
+        (_fm('allowed-tools: "[Read]"\n'), "[Read]", "string"),
+        # Block list.
+        (_fm("allowed-tools:\n  - Read\n  - Bash\n"), ["Read", "Bash"], "block"),
+        (_fm("allowed-tools:\n- Read\n"), ["Read"], "block"),
+        # Flow list on the key's own line.
+        (_fm("allowed-tools: [Read, Bash]\n"), ["Read", "Bash"], "flow"),
+        (_fm("allowed-tools: [ Read ]\n"), ["Read"], "flow"),
+        # The empty flow list three runner fixtures ship.
+        (_fm("allowed-tools: []\n"), [], "flow"),
+        # A multi-line flow sequence that OPENS on the key line.
+        (_fm("allowed-tools: [Read,\n  Bash]\n"), ["Read", "Bash"], "flow"),
+        # F3: a multi-line flow sequence that opens on the NEXT line. A
+        # single-line peek reads this as a block list, and because a block list
+        # is only a warning under the strict profile while a flow list is an
+        # error, that misread is a false PASS on a publishability gate.
+        (_fm("allowed-tools:\n  [Read]\n"), ["Read"], "flow"),
+        (_fm("allowed-tools:\n  [Read, Bash]\n"), ["Read", "Bash"], "flow"),
+        # A trailing comment must not be read as the remainder.
+        (_fm("allowed-tools:  # the tools\n  - Read\n"), ["Read"], "block"),
+        (_fm("allowed-tools: # the tools\n  [Read]\n"), ["Read"], "flow"),
+        (_fm("allowed-tools: [Read]  # the tools\n"), ["Read"], "flow"),
+        # Blank and comment lines are skipped by the forward scan.
+        (_fm("allowed-tools:\n\n  # why\n  [Read]\n"), ["Read"], "flow"),
+        (_fm("allowed-tools:\n\n  # why\n  - Read\n"), ["Read"], "block"),
+    ],
+)
+def test_allowed_tools_style_classifies_the_authored_shape(
+    raw: str, parsed: object, expected: str
+) -> None:
+    assert allowed_tools_style(raw, parsed) == expected
+
+
+@pytest.mark.parametrize(
+    ("body", "parsed", "expected"),
+    [
+        ("allowed-tools:\r\n  - Read\r\n", ["Read"], "block"),
+        ("allowed-tools: [Read]\r\n", ["Read"], "flow"),
+        # The \r must be stripped BEFORE the scan: left in place it is the
+        # remainder's first non-space character and nothing ever reads as flow.
+        ("allowed-tools:\r\n  [Read]\r\n", ["Read"], "flow"),
+    ],
+)
+def test_allowed_tools_style_handles_crlf_line_endings(
+    body: str, parsed: object, expected: str
+) -> None:
+    raw = f"\r\nname: demo\r\ndescription: A demo skill.\r\n{body}"
+    assert allowed_tools_style(raw, parsed) == expected
+
+
+@pytest.mark.parametrize(
+    ("raw", "parsed"),
+    [
+        # An alias: the value is a list, but no literal sequence is present at
+        # the key to read. Recorded in ADR-0135 as a known limitation.
+        ("\nbase: &base\n  - Read\nallowed-tools: *base\n", ["Read"]),
+        # A key line the scan cannot find at all (indented under something else).
+        ("\nname: demo\nnested:\n  allowed-tools:\n    - Read\n", ["Read"]),
+    ],
+)
+def test_exotic_yaml_with_no_literal_sequence_falls_back_to_block(raw: str, parsed: object) -> None:
+    """Block is the SAFE fallback: it is a warning in both profiles.
+
+    Falling back to ``flow`` would hard-fail a strict-profile bundle on YAML the
+    detector simply could not read, which is a false FAIL; falling back to
+    ``string`` would suppress the finding entirely, which is a false PASS.
+    """
+    assert allowed_tools_style(raw, parsed) == "block"

--- a/packages/plugin-format/tests/test_validate.py
+++ b/packages/plugin-format/tests/test_validate.py
@@ -3,7 +3,12 @@ import shutil
 from pathlib import Path
 
 import pytest
-from plugin_format import TOOL_POLICY_ENFORCEMENT, validate_bundle, validate_pattern
+from plugin_format import (
+    TOOL_POLICY_ENFORCEMENT,
+    ValidationResult,
+    validate_bundle,
+    validate_pattern,
+)
 
 FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -870,9 +875,7 @@ _BUILT_CONNECTORS = (
 def _built_bundle(tmp_path: Path, connectors_yaml: str = _BUILT_CONNECTORS) -> Path:
     """A minimal bundle whose only connector is declared as source."""
 
-    root = _bundle(
-        tmp_path, '{"name": "acme-bot", "version": "0.1.0", "description": "t"}'
-    )
+    root = _bundle(tmp_path, '{"name": "acme-bot", "version": "0.1.0", "description": "t"}')
     (root / "skills" / "acme-bot").mkdir(parents=True, exist_ok=True)
     (root / "skills" / "acme-bot" / "SKILL.md").write_text(
         "---\nname: acme-bot\ndescription: t\n---\nhi\n", encoding="utf-8"
@@ -1707,3 +1710,443 @@ def test_a_policy_denying_everything_warns_but_still_validates(tmp_path: Path) -
     result = validate_bundle(bundle, enforces_tool_policy=TOOL_POLICY_ENFORCEMENT)
     assert result.valid, result.errors
     assert "tool_policy.denies_everything" in {i.code for i in result.warnings}
+
+
+# --- two conformance profiles (ADR-0135) -------------------------------------
+#
+# One validator, two profiles. `claude-plugin` is the INGESTION contract and
+# keeps today's leniency exactly -- every specification divergence is a WARNING,
+# so widening the accepted shapes can never break a deploy. `agent-skills-strict`
+# is a PUBLISHABILITY gate: the same findings are errors, because a bundle the
+# reference validator rejects must not clear it.
+#
+# Every row below is asserted under BOTH profiles. The expected verdicts are the
+# spike's confirmed fixture verdicts, not our reading of the spec prose.
+
+_PLUGIN = "claude-plugin"
+_STRICT = "agent-skills-strict"
+_SPEC = "skill.spec_nonconformant"
+
+_BLOCK_LIST = f"{_SPEC}.allowed_tools_block_list"
+_FLOW_LIST = f"{_SPEC}.allowed_tools_flow_list"
+_UNSERIALIZABLE = f"{_SPEC}.allowed_tools_unserializable"
+_UNKNOWN_FIELD = f"{_SPEC}.unknown_field"
+_NAME_LENGTH = f"{_SPEC}.name_length"
+_NAME_CHARSET = f"{_SPEC}.name_charset"
+_NAME_DIR_MISMATCH = f"{_SPEC}.name_dir_mismatch"
+_DESCRIPTION_LENGTH = f"{_SPEC}.description_length"
+_COMPATIBILITY_LENGTH = f"{_SPEC}.compatibility_length"
+_METADATA_SHAPE = f"{_SPEC}.metadata_shape"
+_LICENSE_TYPE = f"{_SPEC}.license_type"
+
+
+def _write_spec_skill(bundle: Path, frontmatter: str, *, dir_name: str = "demo") -> Path:
+    """Write ``skills/<dir_name>/SKILL.md`` with a VERBATIM frontmatter body.
+
+    Distinct from ``_write_skill`` above, which prepends a fixed name and
+    description. The conformance matrix has to vary both of those (name length,
+    name charset, description length) and has to control the skill DIRECTORY name
+    independently of the declared ``name`` for the dir-mismatch row, so it needs
+    a helper that writes the frontmatter exactly as given.
+    """
+    skill = bundle / "skills" / dir_name / "SKILL.md"
+    skill.parent.mkdir(parents=True, exist_ok=True)
+    skill.write_text(f"---\n{frontmatter}---\n\n# Demo\n", encoding="utf-8")
+    return skill
+
+
+def _spec_codes(result: ValidationResult) -> tuple[set[str], set[str]]:
+    """The ``skill.spec_nonconformant.*`` codes, split into (errors, warnings).
+
+    Filtered to this prefix so an unrelated pre-existing finding cannot make an
+    exact-set assertion brittle, while the exact set keeps the assertion strong
+    enough to catch a check that fires twice or fires on the wrong row.
+    """
+    errors = {i.code for i in result.errors if i.code.startswith(_SPEC)}
+    warnings = {i.code for i in result.warnings if i.code.startswith(_SPEC)}
+    return errors, warnings
+
+
+_D = "description: A demo skill.\n"
+
+# (frontmatter, dir_name, plugin_warnings, strict_valid, strict_errors, strict_warnings)
+_MATRIX = [
+    pytest.param(
+        f"name: demo\n{_D}allowed-tools:\n  - Bash\n",
+        "demo",
+        {_BLOCK_LIST},
+        True,
+        set(),
+        {_BLOCK_LIST},
+        id="block-list",
+    ),
+    pytest.param(
+        f"name: demo\n{_D}allowed-tools: [Read, Bash]\n",
+        "demo",
+        {_FLOW_LIST},
+        False,
+        {_FLOW_LIST},
+        set(),
+        id="flow-list",
+    ),
+    pytest.param(
+        f"name: demo\n{_D}allowed-tools: []\n",
+        "demo",
+        {_FLOW_LIST},
+        False,
+        {_FLOW_LIST},
+        set(),
+        id="empty-flow-list",
+    ),
+    pytest.param(
+        # F3: a flow sequence opening on the line AFTER the key. A single-line
+        # detector reads this as a block list, which is only a warning under the
+        # strict profile -- a false PASS on a publishability gate.
+        f"name: demo\n{_D}allowed-tools:\n  [Read]\n",
+        "demo",
+        {_FLOW_LIST},
+        False,
+        {_FLOW_LIST},
+        set(),
+        id="multiline-flow-list",
+    ),
+    pytest.param(
+        # The headline fix. Today this is a hard `skill.frontmatter_invalid`
+        # error ("Input should be a valid list") on the ingestion path.
+        f'name: demo\n{_D}allowed-tools: "Read Bash"\n',
+        "demo",
+        set(),
+        True,
+        set(),
+        set(),
+        id="space-separated-string",
+    ),
+    pytest.param(
+        f'name: demo\n{_D}allowed-tools: "Read,Bash"\n',
+        "demo",
+        set(),
+        True,
+        set(),
+        set(),
+        id="comma-separated-string",
+    ),
+    pytest.param(
+        f'name: demo\n{_D}allowed-tools: ""\n',
+        "demo",
+        set(),
+        True,
+        set(),
+        set(),
+        id="empty-string",
+    ),
+    pytest.param(
+        # Edge case 5: null parses to None, so the style is "absent", NOT
+        # "string", and no allowed-tools finding fires at all.
+        f"name: demo\n{_D}allowed-tools: null\n",
+        "demo",
+        set(),
+        True,
+        set(),
+        set(),
+        id="null-allowed-tools",
+    ),
+    pytest.param(
+        # A real Claude Code first-class field that the specification's closed
+        # world does not contain.
+        f"name: demo\n{_D}disable-model-invocation: true\n",
+        "demo",
+        {_UNKNOWN_FIELD},
+        False,
+        {_UNKNOWN_FIELD},
+        set(),
+        id="disable-model-invocation",
+    ),
+    pytest.param(
+        f"name: demo\n{_D}x-custom-field: anything\n",
+        "demo",
+        {_UNKNOWN_FIELD},
+        False,
+        {_UNKNOWN_FIELD},
+        set(),
+        id="unknown-field",
+    ),
+    pytest.param(
+        f"name: demo\n{_D}metadata:\n  team: sales\n",
+        "demo",
+        set(),
+        True,
+        set(),
+        set(),
+        id="metadata-str-to-str",
+    ),
+    pytest.param(
+        # D2: `metadata` is validated off the RAW dict by the strict profile, so
+        # the lenient model never hard-errors on it.
+        f"name: demo\n{_D}metadata:\n  retries: 3\n",
+        "demo",
+        {_METADATA_SHAPE},
+        False,
+        {_METADATA_SHAPE},
+        set(),
+        id="metadata-non-string-value",
+    ),
+    pytest.param(
+        f"name: demo\n{_D}license: 3\n",
+        "demo",
+        {_LICENSE_TYPE},
+        False,
+        {_LICENSE_TYPE},
+        set(),
+        id="license-not-a-string",
+    ),
+    pytest.param(
+        f"name: demo\n{_D}compatibility: {'c' * 501}\n",
+        "demo",
+        {_COMPATIBILITY_LENGTH},
+        False,
+        {_COMPATIBILITY_LENGTH},
+        set(),
+        id="compatibility-over-500",
+    ),
+    pytest.param(
+        # Edge case 10: the rule compares against the IMMEDIATE parent directory.
+        f"name: demo\n{_D}",
+        "not-demo",
+        {_NAME_DIR_MISMATCH},
+        False,
+        {_NAME_DIR_MISMATCH},
+        set(),
+        id="name-directory-mismatch",
+    ),
+    pytest.param(
+        f"name: {'a' * 65}\n{_D}",
+        "a" * 65,
+        {_NAME_LENGTH},
+        False,
+        {_NAME_LENGTH},
+        set(),
+        id="name-over-64-chars",
+    ),
+    pytest.param(
+        # Consecutive hyphens: the charset rule allows only SINGLE internal ones.
+        f"name: a--b\n{_D}",
+        "a--b",
+        {_NAME_CHARSET},
+        False,
+        {_NAME_CHARSET},
+        set(),
+        id="name-consecutive-hyphens",
+    ),
+    pytest.param(
+        f"name: demo\ndescription: {'d' * 1025}\n",
+        "demo",
+        {_DESCRIPTION_LENGTH},
+        False,
+        {_DESCRIPTION_LENGTH},
+        set(),
+        id="description-over-1024",
+    ),
+    pytest.param(
+        f'name: demo\n{_D}allowed-tools: "Bash(git:*) Read"\n',
+        "demo",
+        set(),
+        True,
+        set(),
+        set(),
+        id="specifier-string-form",
+    ),
+    pytest.param(
+        f'name: demo\n{_D}allowed-tools:\n  - "Bash(git:*)"\n',
+        "demo",
+        {_BLOCK_LIST},
+        True,
+        set(),
+        {_BLOCK_LIST},
+        id="specifier-list-form",
+    ),
+    pytest.param(
+        # D4, the correction to an earlier draft: the splitter is paren-aware, so
+        # whitespace INSIDE the specifier round-trips and this is NOT flagged as
+        # unserializable. A paren-blind splitter reports it and would refuse a
+        # perfectly legal Claude Code permission rule.
+        f'name: demo\n{_D}allowed-tools: "Bash(git commit:*) Read"\n',
+        "demo",
+        set(),
+        True,
+        set(),
+        set(),
+        id="paren-with-space-string-form",
+    ),
+    pytest.param(
+        f'name: demo\n{_D}allowed-tools:\n  - "Bash(git commit:*)"\n',
+        "demo",
+        {_BLOCK_LIST},
+        True,
+        set(),
+        {_BLOCK_LIST},
+        id="paren-with-space-list-form",
+    ),
+    pytest.param(
+        # Unbalanced parens: serializable on its own, lossy in a list, so it is
+        # named by a per-entry predicate rather than by the round-trip alone.
+        f'name: demo\n{_D}allowed-tools:\n  - "Bash(git"\n',
+        "demo",
+        {_BLOCK_LIST, _UNSERIALIZABLE},
+        False,
+        {_UNSERIALIZABLE},
+        {_BLOCK_LIST},
+        id="unbalanced-paren-entry",
+    ),
+    pytest.param(
+        f'name: demo\n{_D}allowed-tools:\n  - "Read,Write"\n',
+        "demo",
+        {_BLOCK_LIST, _UNSERIALIZABLE},
+        False,
+        {_UNSERIALIZABLE},
+        {_BLOCK_LIST},
+        id="depth-zero-comma-entry",
+    ),
+    pytest.param(
+        f'name: demo\n{_D}allowed-tools:\n  - "Read Write"\n',
+        "demo",
+        {_BLOCK_LIST, _UNSERIALIZABLE},
+        False,
+        {_UNSERIALIZABLE},
+        {_BLOCK_LIST},
+        id="depth-zero-whitespace-entry",
+    ),
+    pytest.param(
+        # Whitespace SURROUNDING an otherwise-clean entry: `parse_allowed_tools`
+        # strips a list entry's surrounding whitespace before this check used to
+        # see it, so `" Read "` looked clean even though it does not survive the
+        # canonical `parse_allowed_tools(" ".join(entries)) == entries`
+        # round-trip -- it normalizes to `"Read"`. The check now reads the
+        # AUTHORED entry, matching the Rust `round_trips_in_allowed_tools` check.
+        f'name: demo\n{_D}allowed-tools:\n  - " Read "\n',
+        "demo",
+        {_BLOCK_LIST, _UNSERIALIZABLE},
+        False,
+        {_UNSERIALIZABLE},
+        {_BLOCK_LIST},
+        id="surrounding-whitespace-entry",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("frontmatter", "dir_name", "plugin_warnings", "_sv", "_se", "_sw"), _MATRIX
+)
+def test_claude_plugin_profile_keeps_every_shape_valid(
+    tmp_path: Path,
+    frontmatter: str,
+    dir_name: str,
+    plugin_warnings: set[str],
+    _sv: bool,
+    _se: set[str],
+    _sw: set[str],
+) -> None:
+    """The ingestion contract: a nonconformance is a WARNING and never blocks.
+
+    This half of the matrix is the leniency mandate made executable. If any row
+    here turns into an error, a bundle that deploys today stops deploying --
+    which is the regression `packages/CLAUDE.md` forbids outright.
+    """
+    bundle = _bundle(tmp_path, '{"name": "demo"}')
+    _write_spec_skill(bundle, frontmatter, dir_name=dir_name)
+
+    result = validate_bundle(bundle, profile=_PLUGIN)
+    assert result.valid, result.errors
+    errors, warnings = _spec_codes(result)
+    assert errors == set(), "a conformance finding must never be an error here"
+    assert warnings == plugin_warnings
+
+
+@pytest.mark.parametrize(
+    ("frontmatter", "dir_name", "_pw", "strict_valid", "strict_errors", "strict_warnings"), _MATRIX
+)
+def test_agent_skills_strict_profile_enforces_the_specification(
+    tmp_path: Path,
+    frontmatter: str,
+    dir_name: str,
+    _pw: set[str],
+    strict_valid: bool,
+    strict_errors: set[str],
+    strict_warnings: set[str],
+) -> None:
+    """The publishability gate: the same findings, promoted to errors.
+
+    The one deliberate exception is the block list, which stays a WARNING even
+    here because the reference validator accepts it while the spec prose names
+    the string canonical. Erroring on it would fail bundles skills-ref passes.
+    """
+    bundle = _bundle(tmp_path, '{"name": "demo"}')
+    _write_spec_skill(bundle, frontmatter, dir_name=dir_name)
+
+    result = validate_bundle(bundle, profile=_STRICT)
+    errors, warnings = _spec_codes(result)
+    assert result.valid is strict_valid, (errors, warnings)
+    assert errors == strict_errors
+    assert warnings == strict_warnings
+
+
+def test_the_default_profile_is_claude_plugin(tmp_path: Path) -> None:
+    """The ingestion default is the lenient profile, and it is the DEFAULT.
+
+    A caller that passes nothing must get today's behavior. Both production
+    callers do exactly that, so this is the guarantee that keeps runner boot and
+    deploy ingestion source-compatible.
+    """
+    from plugin_format import PROFILE_AGENT_SKILLS_STRICT, PROFILE_CLAUDE_PLUGIN
+
+    assert PROFILE_CLAUDE_PLUGIN == _PLUGIN
+    assert PROFILE_AGENT_SKILLS_STRICT == _STRICT
+
+    bundle = _bundle(tmp_path, '{"name": "demo"}')
+    _write_spec_skill(bundle, f'name: demo\n{_D}allowed-tools: "Read Bash"\n')
+
+    implicit = validate_bundle(bundle)
+    explicit = validate_bundle(bundle, profile=PROFILE_CLAUDE_PLUGIN)
+    assert implicit.valid and explicit.valid
+    assert [i.code for i in implicit.warnings] == [i.code for i in explicit.warnings]
+
+
+def test_a_typoed_profile_raises_rather_than_silently_falling_back(tmp_path: Path) -> None:
+    """A typo must not become a false PASS on a publishability gate.
+
+    ``agent-skills-strct`` silently resolving to the lenient profile would report
+    a bundle as publishable that was never strictly checked. That is the same
+    "a typo becomes permission widening" shape ``ToolPolicy`` already refuses, so
+    it is a caller error (``ValueError``), not a ``ValidationIssue``.
+    """
+    bundle = _bundle(tmp_path, '{"name": "demo"}')
+    _write_spec_skill(bundle, f"name: demo\n{_D}")
+
+    with pytest.raises(ValueError) as exc:
+        validate_bundle(bundle, profile="agent-skills-strct")
+    message = str(exc.value)
+    assert "agent-skills-strct" in message
+    # Both valid ids must be named: the message is the only place an author
+    # learns what the alternatives are.
+    assert _PLUGIN in message
+    assert _STRICT in message
+
+
+@pytest.mark.parametrize(
+    "relative",
+    [
+        "runner/src/curie_runner/plugin.py",
+        "apps/api/src/curie_api/bundles.py",
+    ],
+)
+def test_production_callers_never_pass_a_profile(relative: str) -> None:
+    """The hard constraint made executable instead of left to review.
+
+    Runner boot and deploy ingestion stay on the lenient default permanently. If
+    either ever passed ``profile="agent-skills-strict"``, every bundle in the
+    fleet carrying a block list or ``allowed-tools: []`` would stop deploying.
+    Reviewers do not reliably catch a one-keyword addition; this test does.
+    """
+    repo_root = Path(__file__).parents[3]
+    source = (repo_root / relative).read_text(encoding="utf-8")
+    assert "validate_bundle(" in source, f"{relative} no longer calls validate_bundle"
+    assert "profile=" not in source, f"{relative} must call validate_bundle with no profile"

--- a/runner/src/curie_runner/approval.py
+++ b/runner/src/curie_runner/approval.py
@@ -53,6 +53,7 @@ from plugin_format import (
     declared_mcp_server_names,
     effective_operator_gates,
     grantable_routes,
+    parse_allowed_tools,
     resolve_manifest,
 )
 
@@ -1037,19 +1038,27 @@ def _entry_tool(entry: str) -> str | None:
 
 
 def _skill_allowed_tools(root: Path) -> list[tuple[str, list[str]]]:
-    """Read every skill's ``allowed-tools`` list from a bundle directory.
+    """Read every skill's ``allowed-tools`` declaration from a bundle directory.
 
     Deliberately tolerant: a skill whose frontmatter is missing, unterminated,
     unparseable, or not a mapping contributes nothing. ``validate_bundle`` already
     reports those, and failing the gate check on a malformed skill would report
     the wrong defect and hide the real one.
 
+    Normalization (list or comma/space-delimited string) goes through
+    ``plugin_format.parse_allowed_tools``, the single shared boundary for this
+    field. #1852's commit noted that with one implementation there was no
+    second path to disagree with, so a shared-helper extraction did not yet
+    apply -- the dual-profile validator now reads this same field too, so a
+    second call site exists and the shared helper is the required form to keep
+    both readings in agreement.
+
     Args:
         root: The bundle root directory.
 
     Returns:
-        ``(skill_path_relative_to_root, entries)`` per skill that declares a list,
-        sorted by path so output is deterministic.
+        ``(skill_path_relative_to_root, entries)`` per skill that declares
+        allowed-tools, sorted by path so output is deterministic.
     """
 
     skills_dir = root / "skills"
@@ -1072,15 +1081,10 @@ def _skill_allowed_tools(root: Path) -> list[tuple[str, list[str]]]:
             continue
         if not isinstance(loaded, dict):
             continue
-        entries = loaded.get("allowed-tools")
-        if not isinstance(entries, list):
+        entries = parse_allowed_tools(loaded.get("allowed-tools"))
+        if not entries:
             continue
-        found.append(
-            (
-                str(skill_file.relative_to(root)),
-                [entry for entry in entries if isinstance(entry, str)],
-            )
-        )
+        found.append((str(skill_file.relative_to(root)), entries))
     return found
 
 

--- a/runner/tests/test_gate_shadowing.py
+++ b/runner/tests/test_gate_shadowing.py
@@ -22,6 +22,7 @@ from curie_runner.approval import (
     ApprovalGate,
     ApprovalPolicyError,
     ApprovalPolicyResolution,
+    ShadowedGate,
     _entry_tool,
     _whole_tool_allowed,
     assert_gates_not_shadowed,
@@ -34,7 +35,7 @@ from curie_runner.approval import (
 def _bundle(
     root: Path,
     *,
-    skills: dict[str, list[str] | None],
+    skills: dict[str, list[str] | str | None],
     gates: list[str],
     mcp: dict[str, dict[str, object]] | None = None,
 ) -> str:
@@ -42,7 +43,10 @@ def _bundle(
 
     Args:
         root: Directory to build in.
-        skills: Skill name to its ``allowed-tools`` list, or None to omit the key.
+        skills: Skill name to its ``allowed-tools`` declaration -- a list (written
+            as a YAML block list), a **string** (written as one quoted scalar, the
+            shape the Agent Skills specification calls canonical), or None to omit
+            the key entirely.
         gates: Tool names the manifest's approvalPolicy gates.
         mcp: Optional ``.mcp.json`` server map.
 
@@ -67,7 +71,11 @@ def _bundle(
         skill_dir = root / "skills" / name
         skill_dir.mkdir(parents=True, exist_ok=True)
         lines = ["---", f"name: {name}", "description: A skill."]
-        if allowed is not None:
+        if isinstance(allowed, str):
+            # One canonical scalar. JSON-encoded so a specifier carrying parens,
+            # commas or a colon cannot corrupt the YAML the reader parses.
+            lines.append(f"allowed-tools: {json.dumps(allowed)}")
+        elif allowed is not None:
             lines.append("allowed-tools:")
             lines.extend(f"  - {entry}" for entry in allowed)
         lines += ["---", "", f"# {name}", ""]
@@ -263,3 +271,178 @@ def test_the_message_names_the_file_the_entry_and_the_remedy(tmp_path: Path) -> 
     # The reason has to travel with the message: read from a pod log by someone
     # who did not write the bundle, "conflict" alone is not actionable.
     assert "before the approval callback runs" in message
+
+
+# --- the string form of allowed-tools (#1852, D1/D4) --------------------------
+#
+# ``allowed-tools`` accepts a space- or comma-separated STRING, and the Agent
+# Skills specification calls that shape canonical. Until now the fail-open below
+# was masked only by accident: ``validate_bundle`` rejected a string BEFORE boot,
+# so ``_skill_allowed_tools``'s ``if not isinstance(entries, list): continue``
+# never saw one. Widening the model without normalizing here ARMS that path -- a
+# bundle whose skill preauthorizes Bash boots reporting its Bash gate as armed,
+# and every Bash call runs with no approval record.
+#
+# These tests write the string form on disk and assert detection. They do not
+# import ``parse_allowed_tools``, so they are the contract even before it exists.
+
+
+def test_a_narrowed_string_form_allowance_is_detected(tmp_path: Path) -> None:
+    """The #1852 regression in its canonical shape.
+
+    A string carrying a narrowed rule is skipped wholesale by the pre-fix reader.
+    Narrowing is not a remedy (see the block-list test above): ``Bash(ls:*)``
+    leaves every matching call ungated, which is a partial gate reporting as
+    whole.
+    """
+    plugin_dir = _bundle(tmp_path, skills={"demo": "Bash(ls:*) Read"}, gates=["Bash"])
+
+    conflicts = shadowed_gates(plugin_dir, frozenset({"Bash"}))
+    assert conflicts == (
+        ShadowedGate(skill="skills/demo/SKILL.md", entry="Bash(ls:*)", tool="Bash", whole=False),
+    )
+
+    gate = build_approval_gate(operator_tools=None, policy_routes={"Bash": "ops"})
+    assert gate is not None
+    with pytest.raises(ApprovalPolicyError) as exc:
+        assert_gates_not_shadowed(plugin_dir, gate)
+    assert "skills/demo/SKILL.md" in str(exc.value)
+
+
+def test_a_whole_tool_string_form_allowance_is_detected(tmp_path: Path) -> None:
+    """The bluntest shadow, in the shape the specification calls canonical."""
+    plugin_dir = _bundle(tmp_path, skills={"demo": "Bash"}, gates=["Bash"])
+
+    assert shadowed_gates(plugin_dir, frozenset({"Bash"})) == (
+        ShadowedGate(skill="skills/demo/SKILL.md", entry="Bash", tool="Bash", whole=True),
+    )
+
+    gate = build_approval_gate(operator_tools=None, policy_routes={"Bash": "ops"})
+    assert gate is not None
+    with pytest.raises(ApprovalPolicyError):
+        assert_gates_not_shadowed(plugin_dir, gate)
+
+
+def test_a_comma_separated_string_form_allowance_is_detected(tmp_path: Path) -> None:
+    """Claude Code documents "space- OR comma-separated"; both must be read.
+
+    A reader that split on whitespace alone would see the single entry
+    ``Bash,Read``, whose ``_entry_tool`` is the garbage name ``Bash,Read`` -- no
+    match against the armed ``Bash``, and the shadow is missed.
+    """
+    plugin_dir = _bundle(tmp_path, skills={"demo": "Bash,Read"}, gates=["Bash"])
+
+    assert shadowed_gates(plugin_dir, frozenset({"Bash"})) == (
+        ShadowedGate(skill="skills/demo/SKILL.md", entry="Bash", tool="Bash", whole=True),
+    )
+
+
+def test_a_specifier_containing_a_space_is_detected_intact(tmp_path: Path) -> None:
+    """The single most important test in this file (D4).
+
+    ``Bash(git commit:*)`` is an ordinary Claude Code permission rule, and Claude
+    Code's "space- or comma-separated string" routinely puts a space INSIDE the
+    specifier. A paren-blind splitter cuts it into ``Bash(git`` and ``commit:*)``:
+    ``_entry_tool("Bash(git")`` returns None (unterminated) so the fragment is
+    dropped, and ``_entry_tool("commit:*)")`` returns a name that matches nothing
+    armed. The rule preauthorizes Bash, the gate reports armed, and NOTHING is
+    reported -- the #1852 fail-open surviving in string form.
+
+    The entry must also survive VERBATIM into the message: an author told the
+    offender is ``Bash(git`` cannot find that line in their file.
+    """
+    plugin_dir = _bundle(tmp_path, skills={"demo": "Bash(git commit:*)"}, gates=["Bash"])
+
+    conflicts = shadowed_gates(plugin_dir, frozenset({"Bash"}))
+    assert conflicts == (
+        ShadowedGate(
+            skill="skills/demo/SKILL.md",
+            entry="Bash(git commit:*)",
+            tool="Bash",
+            whole=False,
+        ),
+    )
+    assert "Bash(git commit:*)" in describe_shadowed_gates(conflicts)
+
+    gate = build_approval_gate(operator_tools=None, policy_routes={"Bash": "ops"})
+    assert gate is not None
+    with pytest.raises(ApprovalPolicyError):
+        assert_gates_not_shadowed(plugin_dir, gate)
+
+
+def test_a_comma_inside_a_specifier_does_not_split_the_entry(tmp_path: Path) -> None:
+    """A comma at paren depth >= 1 is part of the rule, never a separator."""
+    plugin_dir = _bundle(tmp_path, skills={"demo": "Bash(ls,cat) Read"}, gates=["Bash"])
+
+    assert shadowed_gates(plugin_dir, frozenset({"Bash"})) == (
+        ShadowedGate(skill="skills/demo/SKILL.md", entry="Bash(ls,cat)", tool="Bash", whole=False),
+    )
+
+
+def test_an_mcp_shorthand_in_string_form_matches_the_armed_runtime_name(tmp_path: Path) -> None:
+    """Normalization still routes through ``effective_operator_gates``.
+
+    The string form must not become a second naming rule. One parser for one rule
+    is the #1495 / #1564 constraint, so the shorthand a skill author writes has to
+    reach the SAME normalization the list form reaches.
+    """
+    plugin_dir = _bundle(
+        tmp_path,
+        skills={"demo": "mcp__crm__send"},
+        gates=[],
+        mcp={"crm": {"command": "run-crm"}},
+    )
+    resolution = ApprovalPolicyResolution(
+        route_by_tool={},
+        grantable_by_route={},
+        bundle_name="demo",
+        mcp_servers={"crm"},
+        connector_servers=set(),
+    )
+    gate = build_approval_gate(
+        operator_tools=["mcp__crm__send"],
+        policy_routes={},
+        bundle_name="demo",
+        mcp_servers={"crm"},
+        connector_servers=set(),
+    )
+    assert gate is not None
+    assert gate.required == frozenset({"mcp__plugin_demo_crm__send"})
+    with pytest.raises(ApprovalPolicyError) as exc:
+        assert_gates_not_shadowed(plugin_dir, gate, resolution)
+    assert "mcp__plugin_demo_crm__send" in str(exc.value)
+
+
+def test_a_string_form_allowance_of_an_ungated_tool_stays_clean(tmp_path: Path) -> None:
+    """The negative control, so the tests above are not vacuously red.
+
+    A reader that reported EVERY string entry as a conflict would pass every
+    assertion above while refusing to boot any bundle with a canonical
+    ``allowed-tools``.
+    """
+    plugin_dir = _bundle(tmp_path, skills={"demo": "Read Write(docs/*)"}, gates=["Bash"])
+
+    assert shadowed_gates(plugin_dir, frozenset({"Bash"})) == ()
+    gate = build_approval_gate(operator_tools=None, policy_routes={"Bash": "ops"})
+    assert gate is not None
+    assert_gates_not_shadowed(plugin_dir, gate)
+
+
+def test_an_empty_string_form_declaration_contributes_nothing(tmp_path: Path) -> None:
+    """``allowed-tools: ""`` allows nothing, so it can shadow nothing."""
+    plugin_dir = _bundle(tmp_path, skills={"demo": ""}, gates=["Bash"])
+    assert shadowed_gates(plugin_dir, frozenset({"Bash"})) == ()
+
+
+@pytest.mark.parametrize("fixture", ["mcp_green", "mcp_red_pointer", "mcp_red_broken"])
+def test_the_empty_flow_list_fixtures_still_produce_no_conflicts(fixture: str) -> None:
+    """The shipped ``allowed-tools: []`` fixtures keep their observable behavior.
+
+    B2 changes the skip condition from "not a list" to "no entries". For these
+    three that is a behavior SHAPE change (they used to reach the found list with
+    an empty entry list; now they are skipped) with an identical outcome. Stating
+    it as a test keeps a reviewer from reading the change as a regression, and
+    keeps a future refactor from making an empty declaration mean something.
+    """
+    root = Path(__file__).parent / "fixtures" / fixture
+    assert shadowed_gates(root, frozenset({"Bash", "Read", "Write"})) == ()


### PR DESCRIPTION
## What & why

Curie's bundle validator rejected a **spec-conformant** Agent Skill: a `SKILL.md` carrying the canonical `allowed-tools: "Read Bash"` string failed with `allowed-tools: Input should be a valid list`, while `[]`, unknown keys, and `disable-model-invocation` passed. The two conformance surfaces diverged in both directions and nothing told an author which way they were drifting.

This lands **one validator with two profiles** in `packages/plugin-format`:

- **`claude-plugin`** (the default, and the ingestion contract) keeps today's leniency exactly and additionally **accepts the string form**. Everything the strict profile would reject becomes a `skill.spec_nonconformant.*` **warning**, so publishability drift is visible without a broken deploy.
- **`agent-skills-strict`** enforces the agentskills.io six-field closed world, the name rules (1-64, lowercase alnum + single internal hyphens, parent-directory match), description 1-1024, compatibility <=500, metadata `str->str`, and the canonical space-separated `allowed-tools` string (block list warns, flow list errors). It is a **publishability** profile and is **never** the ingestion default anywhere — `runner/src/curie_runner/plugin.py` and `apps/api/src/curie_api/bundles.py` stay on `claude-plugin`, pinned by an executable test.

### The security core (#1852)

The load-bearing piece is one normalization boundary, `plugin_format.parse_allowed_tools`, split on whitespace or a comma **at parenthesis depth 0** so `Bash(git commit:*)` stays one entry. Both `validate.py` and the runner's `_skill_allowed_tools` read the field through it. Widening the model to accept strings **without** this shared helper would re-open the #1852 gate-shadow fail-open: a string-declared tool would be invisible to the boot check while the gate reports armed. **Model widening, the helper, and the runner consumer land together in this PR** (repo rule: a contract change lands with its adoption).

### CLI & schema

`curie init` and `curie init --from-spec` now emit the canonical space-separated string; `cli/src/spec.rs` refuses an entry that cannot survive the join (a depth-0 comma or whitespace, or unbalanced parens) so a specifier is never silently corrupted. The plugin-format JSON schema is regenerated — the `allowed-tools` `anyOf` gains a string member, no other property changes (so ADR-0103's property-set gate stays quiet); no schema version bump, matching the `toolPolicy`/`approvalPolicy` precedent (no ACI wire change).

## Merge gate — ADR acceptance required

This PR carries **Draft ADR-0135** (`docs/adr/0135-a-skill-bundle-has-two-conformance-profiles.md`) **plus** its implementation. Per `docs/adr/AGENTS.md` step 4, a Draft ADR does **not** authorize implementation. **Do not merge** until a maintainer either:

- publishes **ADR-0135 as `Accepted`**, or
- records the **ADR-0102 coordinated exception** (explicit approval + a named realizing code path).

**Realizing code path:** `packages/plugin-format/src/plugin_format/{skills.py,validate.py,models.py}` (the two-profile validator + `parse_allowed_tools`) and `runner/src/curie_runner/approval.py` (`_skill_allowed_tools`, the #1852 adoption).

## Verification

- **plugin-format + runner approval suites:** `853 passed` (`uv run pytest packages/plugin-format/tests runner/tests/test_gate_shadowing.py runner/tests/test_approval.py`).
- **CLI:** `cargo test` full suite `1874 passed`; `spec_scaffold` `31 passed`; `cargo fmt --check` + `cargo clippy --all-targets -- -D warnings` clean.
- **Contracts / docs / parity gates:** `scripts/check-contracts.sh` OK, `scripts/check-docs.sh` OK, `cli/scripts/check-field-parity.sh` `7 passed`. `mypy` + `ruff` clean.
- **Guard demonstrations (executed, not read):**
  - `agent-skills-strict` turns a flow-list + unknown-field + dir-mismatch bundle into `valid=False` with three `skill.spec_nonconformant.*` **errors**, while `claude-plugin` returns `valid=True` with the same three as **warnings**.
  - The #1852 gate-shadow check now **raises `ApprovalPolicyError`** on a string-form `allowed-tools: "Bash(git commit:*) Read"` (`ShadowedGate(entry='Bash(git commit:*)', ...)`, specifier intact) — invisible pre-fix.
- **DW-17 live round-trip (real `curie` binary):** `curie init` emits `allowed-tools: WebSearch WebFetch`; `curie init --from-spec` (spec included `Bash(git commit:*)`) emits `allowed-tools: "WebSearch WebFetch Bash(git commit:*)"` intact; both scaffolded bundles validate `valid=True` under **both** profiles with zero nonconformant warnings.

## Reviews

Cross-engine adversarial review (Codex, read-only): Code, Scope, and Security passes. Scope review found no orphan hunks. Code review's one blocking finding — a Python/Rust divergence on a list entry with surrounding whitespace (`[" Read "]`) — is fixed (the validator now checks authored list entries, not normalized ones, so it agrees with `cli/src/spec.rs`). Security review confirmed **no fail-open**: string and list authorings normalize identically into the gate-shadow check.

## Default chosen under bounded ambiguity (noted per the task)

The security review surfaced one **security-null** residual: Python's `str.isspace()` treats the ASCII control separators U+001C through U+001F as whitespace while Rust's `char::is_whitespace()` does not, so an entry embedding one of those control characters is rejected by the Python predicate but accepted by the Rust one. The reviewer confirmed this **does not make any gated tool invisible** (the runner still sees both fragments). Aligning Unicode-whitespace semantics across the two languages risks its own bugs for an input no human authors, so it is left as a documented known-limitation rather than chased here.

## Deferred follow-ups (not in this PR)

`curie skill check --profile` surface; the `skills-ref` conformance CI gate (owned by the separately queued `curie-agent-skills-reference-gate` task); migrating the shipped example bundles and test fixtures to the canonical string; rendering `spec_nonconformant` warnings on the deploy/CLI ingestion surfaces (they are a library-level contract today — `deploy.py` and `routers/bundles.py` currently expose only errors).
