### PR TITLE
Wire tests/soak into `curie dev soak` and a report-only nightly rung

### DIFF
--- a/.github/workflows/nightly-graded-ladder.yaml
+++ b/.github/workflows/nightly-graded-ladder.yaml
@@ -453,7 +453,231 @@ jobs:
           CURIE_CREDENTIALS: ${{ secrets.OPENROUTER_API_KEY }}
           CURIE_MODEL: ${{ inputs.model || 'z-ai/glm-5.2' }}
         run: bash cli/scripts/e2e-ladder.sh
-      # Surface why on any failure above: pod states, recent events, and the
+      # --- Soak rung (REPORT ONLY, #2056) -----------------------------------
+      #
+      # `tests/soak/` had never run in any automated path: it needs a STANDING
+      # cluster with a claimable warm pool, and no CI job had one to lend it.
+      # This job does -- the kind cluster installed above is still up and its
+      # runner-prewarm daemonset has already rolled out -- so the soak runs
+      # HERE rather than paying for a second cluster install in a job of its
+      # own. That is what #2056 means by "the cluster tier where a sandbox
+      # exists".
+      #
+      # The rung is report only, on the #1603 precedent
+      # (`cli/scripts/e2e-ladder.sh`, the live cluster eval): it prints its
+      # result into the run log and the job summary so a reader can act on it,
+      # but nothing it observes can turn this nightly red. A soak is a
+      # load/chaos probe on a shared 2-CPU GitHub runner; graduating it to a
+      # gate needs a stable baseline first, and a flaky gate on the nightly
+      # would train the skim reflex on a workflow whose other rungs are real
+      # gates.
+      #
+      # HOW it is report only is load bearing. The whole rung is ONE step that
+      # captures every exit status inside the shell and ends in an
+      # unconditional `exit 0`, exactly the shape #1603 uses. It is
+      # deliberately NOT `continue-on-error: true`. The retry-eligibility gate
+      # (`tools/ci-retry-gate/tests/test_retry_eligibility.py`) draws a closed
+      # world around `continue-on-error`: it reads that marker as a retry, and
+      # a retry is permitted only on a step that acquires a third-party
+      # dependency before any repository code runs, never on one that builds,
+      # tests or gates this repository's code. A rung driving this repository's
+      # own soak harness is exactly what that world exists to exclude, so
+      # blanket-swallowing its failure would be the gate's central prohibition
+      # rather than an exemption from it. `exit 0` says the same thing without
+      # asking CI to swallow anything: the step really did succeed at its job,
+      # which is to report.
+      #
+      # Placement is deliberate: after the graded cluster rung (so the soak
+      # never perturbs the pods the graded turn is asserting on) and before the
+      # diagnostics dump (so a soak-visible break still gets pods, events and
+      # worker logs in the same run).
+      #
+      # The uv acquisition is the one part of the rung that stays outside that
+      # step: `uv sync` needs uv on PATH before the rung's own shell starts.
+      # It is a plain, unprotected `uses:` -- no `continue-on-error`, no
+      # `id:`, no endpoint probe, no backoff and no `(retry)` copy -- because
+      # that is exactly how this job already acquires every other third-party
+      # action it depends on: `actions/checkout`, `actions/download-artifact`,
+      # `azure/setup-helm`, `docker/setup-buildx-action`, four
+      # `docker/build-push-action` steps and the kind-cluster action, none of
+      # them retried. A retry here would buy a marginal reduction in a failure
+      # mode this job already accepts nine times over, and the price is an
+      # entry in an unrelated gate's policy table
+      # (`RETRY_ALLOWLIST` in `tools/ci-retry-gate/tests/test_retry_eligibility.py`)
+      # for a step that is not the soak rung itself. No `uv lock --check` here
+      # (unlike ci.yaml): the lockfile gate belongs to the PR CI that can act
+      # on it.
+      #
+      # The downstream consequence is already handled, and is recorded here so
+      # nobody "fixes" it: if uv never installs, the report-only step's
+      # `uv sync` fails and then `cli/target/release/curie --json dev soak`
+      # fails too. That step captures both statuses, writes them to the run log
+      # and the job summary, and still ends in its unconditional `exit 0`. The
+      # rung reports "could not run" -- which is the honest answer -- instead
+      # of reddening the nightly.
+      #
+      # Both soak steps carry `if: success() || failure()` so the rung runs
+      # whether or not an earlier step in this job succeeded. #2056 exists
+      # precisely because this scenario had no automated path anywhere; gating
+      # the rung on the graded cluster rung passing would reintroduce a whole
+      # class of night on which it still never runs -- and the nights the
+      # graded turn breaks are exactly the nights a soak signal is most worth
+      # having. The rung is report only and its result is independent of the
+      # graded turn's outcome, so running it after a failure costs nothing but
+      # runner minutes and cannot change the job's result (the step ends in an
+      # unconditional `exit 0`, and an earlier failure still fails the job).
+      # `success() || failure()` rather than a bare `always()`: `always()` also
+      # runs on job CANCELLATION, which burns a runner on a result nobody will
+      # read.
+      # The honest consequence, so nobody reads a skip as a break: if the
+      # cluster install itself failed, there is no reachable context, namespace
+      # or warm pool, and `curie dev soak`'s own preflight reports
+      # `status: "skipped"` with a NAMED reason and exits 0. A named skip in
+      # the summary is the correct, readable outcome -- neither a false green
+      # nor a false red.
+      - name: Install uv for the soak rung
+        if: success() || failure()
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          python-version: "3.13"
+      # The rung itself: workspace sync, Valkey port-forward, the scenario, and
+      # the teardown, all in one step so a single `exit 0` at the bottom is the
+      # only thing that decides this rung's effect on the job.
+      #
+      # `uv sync` resolves THIS repository's own lockfile, so it belongs inside
+      # the report-only body rather than beside the uv acquisition: it is
+      # repository code, not a bare third-party fetch.
+      #
+      # The soak harness (`tests/soak/harness.py`, `SoakConfig.from_env`)
+      # defaults `TEST_VALKEY_HOST`/`TEST_VALKEY_PORT` to localhost:26379 --
+      # the dev-stack compose Valkey a developer has running beside a standing
+      # cluster. This job has no dev stack: Valkey lives IN the kind cluster,
+      # deployed by the chart as the headless Service `curie-valkey` (release
+      # `curie`, `charts/curie/templates/valkey.yaml` renders
+      # `{{ include "curie.fullname" . }}-valkey`) on port 6379, with password
+      # `valkeypass` (charts/curie/values.yaml). Forwarding it to 26379 meets
+      # the harness's env contract without editing the harness.
+      #
+      # The readiness check is a bounded TCP-connect poll rather than a bare
+      # `sleep`: `kubectl port-forward` returns immediately and establishes the
+      # listener asynchronously, so a fixed sleep is either a false-ready race
+      # or wasted nightly minutes. That poll is why this step is on
+      # RUN_RETRY_EXEMPT in the retry gate -- it waits for a service it did not
+      # build to start answering and never re-invokes a command whose failure
+      # would be a defect, which is the gate's own stated definition of a
+      # readiness poll rather than a retry.
+      #
+      # `curie dev soak` is the one entry point for this scenario (CLAUDE.md's
+      # one-entry-point rule); it sets CURIE_SOAK=1 and preflights the kube
+      # context, so the workflow drives it purely with env.
+      #
+      # The verb's own skip path is what keeps this rung honest: with no
+      # reachable context, no such namespace, or no reachable SandboxWarmPool
+      # it emits `status: "skipped"` with a NAMED reason and exits 0. So a
+      # nightly whose install did not produce a claimable pool reports a skip
+      # -- not a false green (which a bare `|| true` would give) and not a
+      # false red. A non-zero exit means the scenario itself failed, and that
+      # is the signal worth reading in the summary below.
+      #
+      # CURIE_SOAK_CONCURRENCY=2 / CURIE_SOAK_BATCH=1 override the harness
+      # defaults (5 / 3) on purpose: the `pool_ready` fixture blocks until the
+      # warm pool reports concurrency + batch READY replicas, and a 2-CPU
+      # GitHub runner cannot hold the 8 ready sandboxes the defaults demand
+      # against the chart's default ResourceQuota -- it would sit out the
+      # fixture's 300s deadline every night. 3 is what fits, and it still
+      # exercises every phase (concurrent threads, a batch burst, a mid-run
+      # kill, a resume under load).
+      #
+      # CURIE_SOAK_RUNS=1: the three-consecutive-runs shape is the
+      # definition-of-done target for an operator-driven soak on real hardware,
+      # not something to spend nightly minutes on inside a 30-minute job.
+      - name: "Soak and chaos rung (curie dev soak, REPORT ONLY, #1603/#2056)"
+        # See the uv step above for why this is `success() || failure()` and
+        # not `always()`: the rung must still run on a night the graded rung
+        # failed (#2056's "it never runs anywhere"), but not on cancellation.
+        if: success() || failure()
+        env:
+          CURIE_SANDBOX_E2E_NAMESPACE: curie
+          # The chart names the default warm pool `<release>-runner-pool`
+          # (charts/curie/templates/agent-sandbox.yaml), so this install's pool
+          # is `curie-runner-pool` -- NOT the harness's `curie-g1` defaults,
+          # which name a developer's standing g1 cluster.
+          CURIE_SANDBOX_E2E_POOL: curie-runner-pool
+          CURIE_SOAK_CONCURRENCY: "2"
+          CURIE_SOAK_BATCH: "1"
+          CURIE_SOAK_RUNS: "1"
+          TEST_VALKEY_HOST: localhost
+          TEST_VALKEY_PORT: "26379"
+          TEST_VALKEY_PW: valkeypass
+        run: |
+          # `set +e` on purpose: GitHub's default shell is `bash -e {0}`, which
+          # would abort this step at the first non-zero status before it could
+          # be captured, summarized, or explained. This rung reports its
+          # status; it does not die on it.
+          set +e
+          set -uo pipefail
+
+          # The port-forward is torn down on every exit path, including the
+          # ones nobody planned for. A trap is not a retry construct: it fires
+          # once, on the way out, and re-invokes nothing.
+          pf_pid=""
+          cleanup() {
+            if [[ -n "$pf_pid" ]]; then
+              kill "$pf_pid" 2>/dev/null
+            fi
+          }
+          trap cleanup EXIT
+
+          uv sync
+          sync_status=$?
+
+          kubectl port-forward -n curie svc/curie-valkey 26379:6379 \
+            > /tmp/valkey-port-forward.log 2>&1 &
+          pf_pid="$!"
+          pf_ready=0
+          for attempt in $(seq 1 30); do
+            if (exec 3<>/dev/tcp/127.0.0.1/26379) 2>/dev/null; then
+              echo "valkey port-forward ready on 127.0.0.1:26379 after ${attempt} attempt(s)"
+              pf_ready=1
+              break
+            fi
+            sleep 2
+          done
+          if [[ "$pf_ready" -ne 1 ]]; then
+            echo "valkey port-forward did not become ready within 60s" >&2
+            cat /tmp/valkey-port-forward.log >&2
+          fi
+
+          # stdout and stderr are captured separately, not merged: under
+          # --json the verb puts exactly one result object on stdout and
+          # routes all pytest chatter to stderr, so redirecting only stdout
+          # keeps /tmp/soak-result.json a single parseable object for the
+          # summary block below, while the pytest transcript still reaches
+          # the job log in real time via stderr.
+          cli/target/release/curie --json dev soak > /tmp/soak-result.json
+          status=$?
+          echo "--- curie dev soak result (/tmp/soak-result.json) ---"
+          cat /tmp/soak-result.json
+          {
+            echo "### Soak and chaos rung (report only, #2056)"
+            echo
+            echo "\`uv sync\` exit status: \`${sync_status}\`"
+            echo
+            echo "Valkey port-forward ready: \`${pf_ready}\` (1 = ready)"
+            echo
+            echo "\`curie dev soak\` exit status: \`${status}\` — this rung cannot fail the nightly (#1603 precedent)."
+            echo
+            echo '```json'
+            cat /tmp/soak-result.json
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [[ "$status" -ne 0 ]]; then
+            echo "soak: the scenario reported a failure. Not failing the job: this rung is report only (#1603/#2056)." >&2
+          fi
+          # Unconditional, and the only exit in this body. This -- not
+          # `continue-on-error` -- is what makes the rung report only; see the
+          # block comment above for why the distinction is not cosmetic.
+          exit 0
       # worker/runner logs are what localize a reachability or scheduling break.
       # Deliberately no `kubectl get secret`: the credential reaches the pod via
       # secretKeyRef (not plaintext in the pod spec) and runner log redaction

--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -4330,6 +4330,50 @@ export const commandManifest = {
           "name": "chart-runtime-e2e"
         },
         {
+          "about": "Run the gated cluster soak and chaos scenario (`tests/soak/test_soak_resilience.py`) against the cluster the current kube context points at, with `CURIE_SOAK=1` set for you (#2056). See `tests/soak/README.md` for what the scenario proves and how to size the warm pool",
+          "args": [
+            {
+              "default_values": [
+                "curie-g1"
+              ],
+              "env": "CURIE_SANDBOX_E2E_NAMESPACE",
+              "global": false,
+              "help": "Namespace the standing cluster runs in",
+              "id": "namespace",
+              "long": "namespace",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "curie-g1-runner-pool"
+              ],
+              "env": "CURIE_SANDBOX_E2E_POOL",
+              "global": false,
+              "help": "Sandbox warm pool the scenario claims its sandboxes from. Reads `CURIE_SANDBOX_E2E_POOL` for the same reason `--namespace` does",
+              "id": "pool",
+              "long": "pool",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "1"
+              ],
+              "env": "CURIE_SOAK_RUNS",
+              "global": false,
+              "help": "Consecutive runs in one invocation. The definition-of-done target is three; the default of one keeps an exploratory run cheap",
+              "id": "runs",
+              "long": "runs",
+              "positional": false,
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "long_about": "Run the gated cluster soak and chaos scenario (`tests/soak/test_soak_resilience.py`) against the cluster the current kube context points at, with `CURIE_SOAK=1` set for you (#2056). See `tests/soak/README.md` for what the scenario proves and how to size the warm pool.\n\nThe scenario needs a STANDING cluster, so this verb preflights the kube context, the namespace, and the warm pool before spending anything. When any of the three is missing it SKIPS with a named reason and exits 0 rather than failing: an absent cluster is not a regression, and a red exit there would make the nightly rung uninterpretable. A real scenario failure exits non-zero, carrying the same result object.\n\nLong-running by construction (concurrent threads, a killed sandbox, a resume under load), and `--runs` multiplies it. No timeout is imposed.",
+          "name": "soak"
+        },
+        {
           "about": "Lint the interface catalog docs (`bash scripts/check-docs.sh`)",
           "hidden": false,
           "name": "docs-lint"

--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -37,10 +37,15 @@ Helm and the deployed release with `up`, `status`, `down`, `comms`, `message`,
   committed schemas stay byte-for-byte identical while the json-vs-human decision
   lives only in `Ui::emit`. The one intentional non-`CliOutput` emit is the
   centralized error path in `main.rs` (`error_json` under `--json`): generic
-  errors use `error.schema.json`, while `cluster deploy --all-targets`
-  reconciliation failures use `deploy.schema.json`. Errors are not success-path
-  values, so they stay on the error-emit mirror rather than the success-path
-  `CliOutput` contract.
+  errors use `error.schema.json`, `cluster deploy --all-targets` reconciliation
+  failures use `deploy.schema.json`, and `curie dev soak` failures use
+  `soak.schema.json` -- one family that also covers pass and skip, so a failing
+  run stays on its declared schema rather than degrading to `error.schema.json`;
+  it's the first `with_json_payload` call from `commands.rs` instead of
+  `main.rs`, the established shape for a verb whose failure is still a
+  structured result, not a deviation. Errors are not success-path values, so
+  they stay on the error-emit mirror rather than the success-path `CliOutput`
+  contract.
 - **The command manifest is a committed artifact; regenerate it in the same
   change as any command-surface edit (console/CLI parity, epic #145).** Any
   change to a clap `Command`/subcommand or an `*Action` enum — a renamed verb,

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -4327,6 +4327,50 @@
           "name": "chart-runtime-e2e"
         },
         {
+          "about": "Run the gated cluster soak and chaos scenario (`tests/soak/test_soak_resilience.py`) against the cluster the current kube context points at, with `CURIE_SOAK=1` set for you (#2056). See `tests/soak/README.md` for what the scenario proves and how to size the warm pool",
+          "args": [
+            {
+              "default_values": [
+                "curie-g1"
+              ],
+              "env": "CURIE_SANDBOX_E2E_NAMESPACE",
+              "global": false,
+              "help": "Namespace the standing cluster runs in",
+              "id": "namespace",
+              "long": "namespace",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "curie-g1-runner-pool"
+              ],
+              "env": "CURIE_SANDBOX_E2E_POOL",
+              "global": false,
+              "help": "Sandbox warm pool the scenario claims its sandboxes from. Reads `CURIE_SANDBOX_E2E_POOL` for the same reason `--namespace` does",
+              "id": "pool",
+              "long": "pool",
+              "positional": false,
+              "required": false
+            },
+            {
+              "default_values": [
+                "1"
+              ],
+              "env": "CURIE_SOAK_RUNS",
+              "global": false,
+              "help": "Consecutive runs in one invocation. The definition-of-done target is three; the default of one keeps an exploratory run cheap",
+              "id": "runs",
+              "long": "runs",
+              "positional": false,
+              "required": false
+            }
+          ],
+          "hidden": false,
+          "long_about": "Run the gated cluster soak and chaos scenario (`tests/soak/test_soak_resilience.py`) against the cluster the current kube context points at, with `CURIE_SOAK=1` set for you (#2056). See `tests/soak/README.md` for what the scenario proves and how to size the warm pool.\n\nThe scenario needs a STANDING cluster, so this verb preflights the kube context, the namespace, and the warm pool before spending anything. When any of the three is missing it SKIPS with a named reason and exits 0 rather than failing: an absent cluster is not a regression, and a red exit there would make the nightly rung uninterpretable. A real scenario failure exits non-zero, carrying the same result object.\n\nLong-running by construction (concurrent threads, a killed sandbox, a resume under load), and `--runs` multiplies it. No timeout is imposed.",
+          "name": "soak"
+        },
+        {
           "about": "Lint the interface catalog docs (`bash scripts/check-docs.sh`)",
           "hidden": false,
           "name": "docs-lint"

--- a/cli/schema/baseline/soak.schema.json
+++ b/cli/schema/baseline/soak.schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.curietech.ai/cli/soak/v1.json",
+  "title": "curie dev soak --json",
+  "description": "The agent-facing result of `curie dev soak`. One family covers all three outcomes: the scenario passed, the scenario failed, and the scenario was SKIPPED because no cluster was reachable (`status: \"skipped\"`, exit 0, with `reason` naming the concrete context, namespace or warm pool that was absent). The failure result -- the scenario failing, or `uv run pytest` failing to launch -- rides the error path via `exit::with_json_payload`, so a non-zero `curie dev soak --json` emits THIS schema on stdout rather than error.schema.json.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "status": {
+      "description": "The scenario outcome.",
+      "enum": [
+        "passed",
+        "failed",
+        "skipped"
+      ]
+    },
+    "reason": {
+      "description": "A complete sentence naming why the run skipped or failed, including the concrete context/namespace/pool values. Null on a pass.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "context": {
+      "description": "The kube context the scenario targeted. Null when no kubeconfig current-context is set.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "namespace": {
+      "type": "string"
+    },
+    "pool": {
+      "type": "string"
+    },
+    "runs": {
+      "description": "Consecutive scenario runs requested in this invocation.",
+      "type": "integer",
+      "minimum": 1
+    },
+    "exit_code": {
+      "description": "The pytest process exit code. Null when no pytest process produced one -- a preflight skip before pytest ran, or a `uv run pytest` that could not be launched at all.",
+      "type": [
+        "integer",
+        "null"
+      ]
+    }
+  },
+  "required": [
+    "status",
+    "reason",
+    "context",
+    "namespace",
+    "pool",
+    "runs",
+    "exit_code"
+  ]
+}

--- a/cli/schema/index.json
+++ b/cli/schema/index.json
@@ -238,6 +238,12 @@
       "version": "1.0"
     },
     {
+      "result": "SoakOutput",
+      "kind": "CliOutput",
+      "schema": "soak.schema.json",
+      "version": "1.0"
+    },
+    {
       "result": "StatusOutput",
       "kind": "CliOutput",
       "schema": "status.schema.json",

--- a/cli/schema/soak.schema.json
+++ b/cli/schema/soak.schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.curietech.ai/cli/soak/v1.json",
+  "title": "curie dev soak --json",
+  "description": "The agent-facing result of `curie dev soak`. One family covers all three outcomes: the scenario passed, the scenario failed, and the scenario was SKIPPED because no cluster was reachable (`status: \"skipped\"`, exit 0, with `reason` naming the concrete context, namespace or warm pool that was absent). The failure result -- the scenario failing, or `uv run pytest` failing to launch -- rides the error path via `exit::with_json_payload`, so a non-zero `curie dev soak --json` emits THIS schema on stdout rather than error.schema.json.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "status": {
+      "description": "The scenario outcome.",
+      "enum": [
+        "passed",
+        "failed",
+        "skipped"
+      ]
+    },
+    "reason": {
+      "description": "A complete sentence naming why the run skipped or failed, including the concrete context/namespace/pool values. Null on a pass.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "context": {
+      "description": "The kube context the scenario targeted. Null when no kubeconfig current-context is set.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "namespace": {
+      "type": "string"
+    },
+    "pool": {
+      "type": "string"
+    },
+    "runs": {
+      "description": "Consecutive scenario runs requested in this invocation.",
+      "type": "integer",
+      "minimum": 1
+    },
+    "exit_code": {
+      "description": "The pytest process exit code. Null when no pytest process produced one -- a preflight skip before pytest ran, or a `uv run pytest` that could not be launched at all.",
+      "type": [
+        "integer",
+        "null"
+      ]
+    }
+  },
+  "required": [
+    "status",
+    "reason",
+    "context",
+    "namespace",
+    "pool",
+    "runs",
+    "exit_code"
+  ]
+}

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -865,6 +865,377 @@ pub async fn dev_chart_check() -> Result<()> {
     Ok(())
 }
 
+/// The gated cluster scenario `curie dev soak` runs. Only this file, never the
+/// whole `tests/soak` directory: `test_harness_unit.py` beside it is the offline
+/// half that default CI already collects, and re-running it here would say
+/// nothing about the cluster.
+pub const SOAK_SCENARIO: &str = "tests/soak/test_soak_resilience.py";
+
+/// The three outcomes `curie dev soak` reports.
+///
+/// A type, not a string: the wire forms are exactly the three `status` values
+/// `soak.schema.json` enumerates, and `rename_all = "lowercase"` is what mints
+/// them, so renaming a variant is a visible contract change rather than a typo
+/// the compiler cannot see. Every site that classifies an outcome matches on
+/// this exhaustively, which makes a fourth outcome a compile error instead of a
+/// silently mis-rendered result.
+#[derive(Serialize, Debug, Clone, Copy, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum SoakStatus {
+    Passed,
+    Failed,
+    Skipped,
+}
+
+/// The result of `curie dev soak`, in all three outcomes.
+///
+/// One family covers pass, fail AND skip on purpose. The skip is the common
+/// case for a contributor with no standing cluster, so it has to be a
+/// first-class machine-readable result with a NAMED reason rather than an
+/// absence -- an agent reading `status == "skipped"` plus `reason` can tell
+/// "no cluster here" apart from "the scenario ran and the cluster broke",
+/// which a bare exit code cannot express.
+#[derive(Serialize)]
+pub struct SoakOutput {
+    /// The outcome, as a type rather than a string.
+    pub status: SoakStatus,
+    /// Why it skipped or failed, as a complete sentence naming the concrete
+    /// context, namespace or pool involved. `None` on a pass.
+    pub reason: Option<String>,
+    /// The kube context the preflight found, `None` when none is set.
+    pub context: Option<String>,
+    pub namespace: String,
+    pub pool: String,
+    pub runs: u32,
+    /// The pytest process exit code, `None` when the preflight skipped before
+    /// pytest ever ran.
+    pub exit_code: Option<i32>,
+}
+
+impl crate::ui::CliOutput for SoakOutput {
+    fn to_json(&self) -> serde_json::Value {
+        serde_json::to_value(self).unwrap_or_else(|_| serde_json::json!({}))
+    }
+
+    fn render(&self, ui: &crate::ui::Ui) {
+        let reason = self
+            .reason
+            .as_deref()
+            .unwrap_or("no reason recorded, which is itself a bug");
+        // Exhaustive on purpose, with no catch-all: a new outcome must be
+        // rendered deliberately rather than inheriting the failure line.
+        match self.status {
+            SoakStatus::Passed => ui.success(&format!(
+                "soak scenario passed: {} run(s) against namespace {} (pool {})",
+                self.runs, self.namespace, self.pool
+            )),
+            SoakStatus::Skipped => ui.warn(&format!("soak scenario skipped: {reason}")),
+            SoakStatus::Failed => ui.failure(&format!("soak scenario failed: {reason}")),
+        }
+    }
+}
+
+impl SoakOutput {
+    /// The preflight-skip shape: exit 0, no pytest, a named reason.
+    ///
+    /// All three preflight stages emit the identical shape and differ only in
+    /// how far they got (`context`) and what was missing (`reason`), so those
+    /// are the only parameters; `status` and the absent `exit_code` are the
+    /// invariant "no child ever ran" half. The pass, pytest-failure and
+    /// launch-failure constructions stay inline literals: those vary in
+    /// `status`, `reason` AND `exit_code` together, so a shared constructor
+    /// there would relocate the field list rather than shrink it.
+    fn skipped(
+        namespace: &str,
+        pool: &str,
+        runs: u32,
+        context: Option<String>,
+        reason: String,
+    ) -> Self {
+        Self {
+            status: SoakStatus::Skipped,
+            reason: Some(reason),
+            context,
+            namespace: namespace.to_string(),
+            pool: pool.to_string(),
+            runs,
+            exit_code: None,
+        }
+    }
+}
+
+/// Map a pytest process exit code onto this verb's `(status, reason)` pair.
+///
+/// Pure, so the classification is testable with no cluster and no pytest. Only
+/// 0 passes; every other code is a failure with its OWN sentence, because the
+/// codes mean genuinely different things to whoever reads the result. Code 5 is
+/// the one worth naming explicitly: pytest collected nothing, so the scenario
+/// silently did not run at all -- the vacuity a summary line reading "no
+/// failures" would otherwise hide.
+pub fn soak_outcome_for_exit_code(code: i32) -> (SoakStatus, Option<String>) {
+    let reason = match code {
+        0 => return (SoakStatus::Passed, None),
+        1 => "the soak scenario ran and reported failing assertions (pytest exit 1).".to_string(),
+        2 => "the soak run was interrupted before it finished (pytest exit 2); its result says \
+              nothing about the cluster."
+            .to_string(),
+        3 => "pytest hit an internal error while running the soak scenario (pytest exit 3)."
+            .to_string(),
+        4 => "pytest rejected the soak invocation as a usage error (pytest exit 4); the scenario \
+              never started."
+            .to_string(),
+        5 => format!(
+            "pytest collected no tests: the scenario did not run (pytest exit 5). {SOAK_SCENARIO} \
+             collected nothing, so this run proves nothing about the cluster."
+        ),
+        other => format!(
+            "pytest exited with the unexpected status {other}; the soak scenario reported no \
+             result."
+        ),
+    };
+    (SoakStatus::Failed, Some(reason))
+}
+
+/// Run one preflight command, capturing its stdout AND stderr. Mirrors
+/// `doctor.rs`'s private `capture`: a failure to even spawn the program reads as
+/// a failed probe, which is what we want -- no `kubectl` on PATH means no
+/// cluster to soak, and that is a skip, not a crash. The stderr comes back
+/// because it is the only place `kubectl` says WHY a `get` failed, and "the
+/// object is not there" and "I could not ask the cluster" are different
+/// sentences to whoever reads the skip.
+async fn soak_capture(program: &str, args: &[&str]) -> (bool, String, String) {
+    let cmd = crate::ops::OpsCommand::new(
+        program,
+        args.iter().map(|a| crate::ops::plain(*a)).collect(),
+    );
+    match crate::ops::run_capture(&cmd).await {
+        Ok((ok, out, err)) => (ok, out, err),
+        // The spawn itself failed, so there is no child stderr; carry our own
+        // error text in its place rather than an empty string, which would read
+        // as "kubectl said nothing" instead of "kubectl never ran".
+        Err(err) => (false, String::new(), err.to_string()),
+    }
+}
+
+/// Does a failed `kubectl get` mean the object is ABSENT, or that the cluster
+/// could not be asked?
+///
+/// `kubectl` writes `Error from server (NotFound): namespaces "x" not found` --
+/// and `(Forbidden)`, TLS errors, and connection refusals -- to stderr, so its
+/// own words are the only honest discriminator available here.
+///
+/// Anything we cannot positively read as NotFound (empty stderr, a wrapper that
+/// swallowed it, an unrecognized shape) classifies as OPERATIONAL, never as
+/// NotFound. Claiming "the namespace is absent" when the real cause was expired
+/// credentials is the false statement this function exists to prevent: a wrong
+/// "absent" reads as a verdict about the CLUSTER, while "could not be checked"
+/// reads as a verdict about the PROBE, which is all an ambiguous failure
+/// supports.
+fn soak_probe_is_not_found(stderr: &str) -> bool {
+    let lowered = stderr.to_ascii_lowercase();
+    lowered.contains("notfound") || lowered.contains("not found")
+}
+
+/// The first non-empty line of a probe's stderr, for quoting inside a skip
+/// reason. One line only: `kubectl` errors can run long, and the reason is a
+/// sentence a human reads, not a transcript.
+fn soak_probe_error_line(stderr: &str) -> String {
+    stderr
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .unwrap_or("kubectl printed no error output")
+        .to_string()
+}
+
+/// `curie dev soak`: run the gated cluster soak and chaos scenario (#2056).
+///
+/// The scenario is `CURIE_SOAK=1`-gated and needs a standing cluster, so the
+/// verb preflights three things before spending a long run: a kube context, the
+/// namespace, and the sandbox warm pool the scenario claims from. Any one
+/// missing -- or a cluster that cannot be queried at all -- is a clean SKIP:
+/// exit 0, `status: "skipped"`, and a reason naming the concrete value, and
+/// saying whether it was absent or merely uncheckable, so the nightly rung can
+/// tell "there was no cluster tonight" from "the cluster failed the soak". A
+/// scenario that fails, or that cannot be launched, exits non-zero while still
+/// carrying this result family on stdout.
+///
+/// A release binary has no checkout, so this errors clearly outside one, same as
+/// `dev_script`.
+pub async fn dev_soak(namespace: &str, pool: &str, runs: u32) -> Result<()> {
+    let ui = crate::ui::ui();
+    let root = find_repo_root().context(
+        "runner/Dockerfile not found here or in any parent directory. Run `curie dev` \
+         from a curie source checkout -- a release binary has no dev scripts.",
+    )?;
+
+    // Preflight 1: is kubectl pointed anywhere at all?
+    let (ok, current_context, _) = soak_capture("kubectl", &["config", "current-context"]).await;
+    let context = current_context.trim().to_string();
+    if !ok || context.is_empty() {
+        ui.emit(&SoakOutput::skipped(
+            namespace,
+            pool,
+            runs,
+            None,
+            format!(
+                "no kubeconfig current-context is set, so there is no cluster to soak; the \
+                 scenario needs a standing curie cluster carrying namespace {namespace} and \
+                 sandbox warm pool {pool}."
+            ),
+        ));
+        return Ok(());
+    }
+
+    // Preflight 2: does the namespace the scenario drives exist on it?
+    let (ok, _, ns_stderr) = soak_capture("kubectl", &["get", "namespace", namespace]).await;
+    if !ok {
+        // Both branches skip and exit 0 -- neither a missing namespace nor an
+        // unreachable cluster is a soak regression -- but they get their own
+        // sentence, because "there is nothing to soak" and "I could not find
+        // out" are different things to whoever reads the nightly rung.
+        let reason = if soak_probe_is_not_found(&ns_stderr) {
+            format!(
+                "namespace {namespace} does not exist on kube context {context}, so the soak \
+                 scenario has no standing curie cluster to run against."
+            )
+        } else {
+            format!(
+                "namespace {namespace} could not be checked on kube context {context}: the \
+                 cluster could not be queried, so this is an access or reachability failure \
+                 rather than a missing namespace. kubectl said: {}",
+                soak_probe_error_line(&ns_stderr)
+            )
+        };
+        ui.emit(&SoakOutput::skipped(
+            namespace,
+            pool,
+            runs,
+            Some(context),
+            reason,
+        ));
+        return Ok(());
+    }
+
+    // Preflight 3: is the warm pool the scenario claims sandboxes from present?
+    // Without it every claim starves and the scenario fails for a reason that
+    // has nothing to do with resilience.
+    let pool_probe = ["get", "sandboxwarmpool", pool, "-n", namespace];
+    let (ok, _, pool_stderr) = soak_capture("kubectl", &pool_probe).await;
+    if !ok {
+        // Same split as the namespace probe, and for the same reason: only
+        // kubectl's own NotFound wording licenses the claim that the pool is
+        // absent; anything else we can say is that we could not check.
+        let reason = if soak_probe_is_not_found(&pool_stderr) {
+            format!(
+                "the sandbox warm pool {pool} the scenario claims from is absent from namespace \
+                 {namespace} on kube context {context}."
+            )
+        } else {
+            format!(
+                "the sandbox warm pool {pool} the scenario claims from could not be checked in \
+                 namespace {namespace} on kube context {context}: the cluster could not be \
+                 queried, so this is an access or reachability failure rather than a missing \
+                 warm pool. kubectl said: {}",
+                soak_probe_error_line(&pool_stderr)
+            )
+        };
+        ui.emit(&SoakOutput::skipped(
+            namespace,
+            pool,
+            runs,
+            Some(context),
+            reason,
+        ));
+        return Ok(());
+    }
+
+    ui.note(&format!(
+        "=== CURIE_SOAK=1 uv run pytest {SOAK_SCENARIO} -q ({runs} run(s), context {context}, \
+         namespace {namespace}, pool {pool}, in {}) ===",
+        root.display()
+    ));
+    // Child chatter goes to stderr so `--json` stdout stays exactly one result
+    // object, the same routing `run_chart_check_scripts` uses. No timeout: the
+    // scenario is long-running by construction and `--runs` multiplies it, so
+    // any bound we picked would be a false failure on a slow cluster.
+    let spawned = tokio::process::Command::new("uv")
+        .args(["run", "pytest", SOAK_SCENARIO, "-q"])
+        .env("CURIE_SOAK", "1")
+        .env("CURIE_SOAK_RUNS", runs.to_string())
+        .env("CURIE_SANDBOX_E2E_NAMESPACE", namespace)
+        .env("CURIE_SANDBOX_E2E_POOL", pool)
+        .current_dir(&root)
+        .stdout(std::io::stderr())
+        .stderr(std::process::Stdio::inherit())
+        .status()
+        .await;
+    // A launch failure is still a soak RESULT. Returning it as a bare error
+    // would put the generic `{error, fix}` payload on stdout under `--json`,
+    // contradicting soak.schema.json's claim that a non-zero run carries THIS
+    // family, so it rides the same payload path the pytest failures below use.
+    // There is no child, hence no `exit_code`.
+    let status = match spawned {
+        Ok(status) => status,
+        Err(err) => {
+            let output = SoakOutput {
+                status: SoakStatus::Failed,
+                reason: Some(format!(
+                    "failed to invoke `uv run pytest` for the soak scenario ({err}); is uv on \
+                     PATH? The scenario never started, so this run says nothing about the cluster."
+                )),
+                context: Some(context),
+                namespace: namespace.to_string(),
+                pool: pool.to_string(),
+                runs,
+                exit_code: None,
+            };
+            let message = output
+                .reason
+                .clone()
+                .unwrap_or_else(|| "the soak scenario could not be launched".to_string());
+            let payload = crate::ui::CliOutput::to_json(&output);
+            return Err(crate::exit::with_json_payload(
+                anyhow::anyhow!(message),
+                payload,
+            ));
+        }
+    };
+
+    // A signal death has no code; the mapper's catch-all names that rather than
+    // letting it read as a pass.
+    let code = status.code().unwrap_or(-1);
+    let (state, reason) = soak_outcome_for_exit_code(code);
+    let output = SoakOutput {
+        status: state,
+        reason,
+        context: Some(context),
+        namespace: namespace.to_string(),
+        pool: pool.to_string(),
+        runs,
+        exit_code: Some(code),
+    };
+    if state == SoakStatus::Passed {
+        ui.emit(&output);
+        return Ok(());
+    }
+
+    // The failure rides the ERROR path so the process exits non-zero
+    // (ExitClass::Failure), but carries this result family rather than the
+    // generic error payload -- the `cluster deploy --all-targets` precedent.
+    // Nothing is emitted to stdout here: main's centralized error emit does it,
+    // and emitting again would put two objects on stdout.
+    let message = output
+        .reason
+        .clone()
+        .unwrap_or_else(|| "the soak scenario failed".to_string());
+    let payload = crate::ui::CliOutput::to_json(&output);
+    Err(crate::exit::with_json_payload(
+        anyhow::anyhow!(message),
+        payload,
+    ))
+}
+
 /// `curie list-agents`: list the plugin bundles under `agents/`, a personal,
 /// gitignored directory (sibling of `examples/`) for in-progress agent
 /// projects ready to hand to `curie deploy-local <folder>`. A release binary has

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -629,6 +629,45 @@ enum DevAction {
         #[arg(long)]
         force: bool,
     },
+    /// Run the gated cluster soak and chaos scenario
+    /// (`tests/soak/test_soak_resilience.py`) against the cluster the current
+    /// kube context points at, with `CURIE_SOAK=1` set for you (#2056). See
+    /// `tests/soak/README.md` for what the scenario proves and how to size the
+    /// warm pool.
+    ///
+    /// The scenario needs a STANDING cluster, so this verb preflights the kube
+    /// context, the namespace, and the warm pool before spending anything. When
+    /// any of the three is missing it SKIPS with a named reason and exits 0
+    /// rather than failing: an absent cluster is not a regression, and a red
+    /// exit there would make the nightly rung uninterpretable. A real scenario
+    /// failure exits non-zero, carrying the same result object.
+    ///
+    /// Long-running by construction (concurrent threads, a killed sandbox, a
+    /// resume under load), and `--runs` multiplies it. No timeout is imposed.
+    Soak {
+        /// Namespace the standing cluster runs in.
+        ///
+        /// This and `--pool` read the same environment variables the pytest
+        /// harness reads (tests/soak/harness.py), so a caller that already
+        /// exported the harness env -- the nightly soak rung does -- gets it
+        /// honored with no flag at all, and the flag stays available to
+        /// override it. Inferring from the facts already present beats
+        /// requiring a flag whose value we can derive.
+        #[arg(long, env = "CURIE_SANDBOX_E2E_NAMESPACE", default_value = "curie-g1")]
+        namespace: String,
+        /// Sandbox warm pool the scenario claims its sandboxes from. Reads
+        /// `CURIE_SANDBOX_E2E_POOL` for the same reason `--namespace` does.
+        #[arg(
+            long,
+            env = "CURIE_SANDBOX_E2E_POOL",
+            default_value = "curie-g1-runner-pool"
+        )]
+        pool: String,
+        /// Consecutive runs in one invocation. The definition-of-done target is
+        /// three; the default of one keeps an exploratory run cheap.
+        #[arg(long, env = "CURIE_SOAK_RUNS", default_value_t = 1, value_parser = clap::value_parser!(u32).range(1..))]
+        runs: u32,
+    },
     /// Lint the interface catalog docs (`bash scripts/check-docs.sh`).
     DocsLint,
     /// Validate every `examples/` bundle against Claude Code (`bash scripts/check-plugin-compat.sh`).
@@ -2306,6 +2345,11 @@ async fn run(command: Option<Command>) -> Result<()> {
                 let args: &[&str] = if force { &["--force"] } else { &[] };
                 commands::dev_script("scripts/chart-runtime-e2e.sh", args).await
             }
+            DevAction::Soak {
+                namespace,
+                pool,
+                runs,
+            } => commands::dev_soak(&namespace, &pool, runs).await,
             DevAction::DocsLint => commands::dev_script("scripts/check-docs.sh", &[]).await,
             DevAction::PluginCompat => {
                 commands::dev_script("scripts/check-plugin-compat.sh", &[]).await

--- a/cli/tests/dev_soak.rs
+++ b/cli/tests/dev_soak.rs
@@ -1,0 +1,965 @@
+//! `curie dev soak` skips cleanly, and says WHY (#2056).
+//!
+//! The scenario behind the verb (`tests/soak/test_soak_resilience.py`) needs a
+//! standing cluster, so the interesting property for everyone without one is the
+//! skip: exit 0, one machine-readable result object, and a reason naming the
+//! concrete context, namespace or warm pool that was absent. A skip that exits 0
+//! with a generic "not available" is indistinguishable from a soak that ran and
+//! found nothing, which is exactly the vacuity that makes a nightly rung
+//! unreadable.
+//!
+//! These tests therefore prove the skip BY EXECUTION rather than by unit-testing
+//! a predicate: a fake `kubectl` goes on the child's `PATH` (the stubbing shape
+//! `cli/src/doctor.rs` already uses for its cluster reads) and fails at one
+//! preflight stage per case, so the real verb walks its real preflight order.
+//! `PATH` is set on the child `Command` only, never on this process, so the
+//! stubs cannot leak into the rest of the suite and no environment lock is
+//! needed. A scratch directory carrying a `runner/Dockerfile` sentinel stands in
+//! for the source checkout `find_repo_root` looks for.
+//!
+//! The skip cases alone would leave the verb's whole POINT untested: the
+//! scenario is `CURIE_SOAK=1`-gated, so a regression that set `CURIE_SOAK=0`,
+//! dropped the variable, or retargeted the pytest file would make pytest skip
+//! or collect the wrong thing and still report a confident green -- every
+//! preflight test above returns before the child is ever spawned. So the same
+//! `PATH` trick carries a second stub: a fake `uv` that records its argv and
+//! the soak-relevant environment into a file the test names via an env var,
+//! prints chatter to its own stdout, and exits with a code the test picks. With
+//! both stubs the verb walks its entire happy path -- preflights, child
+//! invocation, exit-code classification, result emit -- with no cluster and no
+//! pytest.
+//!
+//! A failed probe is two different findings, and only kubectl's own stderr
+//! separates them: `NotFound` licenses saying the object is ABSENT, while
+//! anything else (RBAC, TLS, a refused connection, silence) supports only
+//! saying the probe could not be READ. The stubs therefore write realistic
+//! apiserver stderr, so both branches are walked by execution rather than
+//! asserted about a predicate. A last stub-free case gives the child a `PATH`
+//! holding only the stub dir, so `uv` resolves to nothing and the launch
+//! failure path runs too.
+//!
+//! Nothing here needs, or reaches, a cluster.
+
+use std::path::Path;
+use std::process::Command;
+
+use curie::commands::{soak_outcome_for_exit_code, SoakStatus};
+
+/// `kubectl` that cannot report a current context: the "no cluster configured
+/// at all" case.
+const KUBECTL_NO_CONTEXT: &str = r#"#!/bin/sh
+case "$*" in
+  "config current-context") exit 1 ;;
+  *) printf 'unexpected kubectl invocation: %s\n' "$*" >&2; exit 64 ;;
+esac
+"#;
+
+/// `kubectl` pointed at a cluster that has no such namespace.
+const KUBECTL_NO_NAMESPACE: &str = r#"#!/bin/sh
+case "$*" in
+  "config current-context") printf '%s\n' 'soak-stub-context' ;;
+  "get namespace "*) exit 1 ;;
+  *) printf 'unexpected kubectl invocation: %s\n' "$*" >&2; exit 64 ;;
+esac
+"#;
+
+/// `kubectl` pointed at a cluster with the namespace but no warm pool -- the
+/// deepest preflight, and the one the scenario's sandbox claims depend on.
+/// The failing branch also prints a line of its own to stdout before exiting
+/// 1 -- real `kubectl` failures do this (e.g. a server error body), and the
+/// stub needs that chatter so the leak assertion below has something real to
+/// catch: a stub that prints nothing on stdout makes that assertion vacuous.
+const KUBECTL_NO_POOL: &str = r#"#!/bin/sh
+case "$*" in
+  "config current-context") printf '%s\n' 'soak-stub-context' ;;
+  "get namespace "*) exit 0 ;;
+  "get sandboxwarmpool "*) printf 'soak-stub-chatter-on-stdout\n'; exit 1 ;;
+  *) printf 'unexpected kubectl invocation: %s\n' "$*" >&2; exit 64 ;;
+esac
+"#;
+
+/// `kubectl` pointed at a cluster that satisfies every preflight, so the verb
+/// proceeds to actually spawn the scenario.
+const KUBECTL_PREFLIGHT_OK: &str = r#"#!/bin/sh
+case "$*" in
+  "config current-context") printf '%s\n' 'soak-stub-context' ;;
+  "get namespace "*) exit 0 ;;
+  "get sandboxwarmpool "*) exit 0 ;;
+  *) printf 'unexpected kubectl invocation: %s\n' "$*" >&2; exit 64 ;;
+esac
+"#;
+
+/// A fake `uv` standing in for `uv run pytest`. It records what the verb asked
+/// it to do -- every argv element, and the four environment variables the
+/// scenario is steered by -- into the file named by `CURIE_SOAK_TEST_RECORD`,
+/// then prints a distinctive marker on its OWN stdout (so the leak assertion
+/// has something real to catch) and exits with `CURIE_SOAK_TEST_EXIT`. Both
+/// variables are set on the `curie` child, which passes its environment through
+/// to the scenario process. `UNSET` is recorded for a variable that is absent,
+/// so "dropped entirely" is distinguishable from "set to the empty string".
+const UV_RECORDER: &str = r#"#!/bin/sh
+: > "$CURIE_SOAK_TEST_RECORD"
+for arg in "$@"; do
+  printf 'argv\t%s\n' "$arg" >> "$CURIE_SOAK_TEST_RECORD"
+done
+for name in CURIE_SOAK CURIE_SOAK_RUNS CURIE_SANDBOX_E2E_NAMESPACE CURIE_SANDBOX_E2E_POOL; do
+  eval "value=\${$name-UNSET}"
+  printf 'env\t%s=%s\n' "$name" "$value" >> "$CURIE_SOAK_TEST_RECORD"
+done
+printf 'soak-stub-uv-chatter-on-stdout\n'
+exit "${CURIE_SOAK_TEST_EXIT:-0}"
+"#;
+
+/// The marker `UV_RECORDER` prints on its own stdout.
+const UV_STDOUT_MARKER: &str = "soak-stub-uv-chatter-on-stdout";
+
+/// A scratch source checkout: only the `runner/Dockerfile` sentinel
+/// `find_repo_root` keys on, so the verb believes it is in a checkout without
+/// this test touching the real one.
+fn scratch_checkout() -> tempfile::TempDir {
+    let scratch = tempfile::tempdir().expect("scratch repo");
+    std::fs::create_dir_all(scratch.path().join("runner")).expect("create repo sentinel dir");
+    std::fs::write(scratch.path().join("runner/Dockerfile"), "").expect("write repo sentinel");
+    scratch
+}
+
+/// A directory holding executable fakes named `(program, script)`, to be
+/// prepended to the child's `PATH`.
+fn stub_tools(tools: &[(&str, &str)]) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("stub tool dir");
+    for (program, body) in tools {
+        let path = dir.path().join(program);
+        std::fs::write(&path, body).unwrap_or_else(|e| panic!("write fake {program}: {e}"));
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))
+                .unwrap_or_else(|e| panic!("make fake {program} runnable: {e}"));
+        }
+    }
+    dir
+}
+
+/// Prepend `dir` to the inherited `PATH`, for the child `Command` only.
+fn path_with(dir: &Path) -> String {
+    let inherited = std::env::var("PATH").unwrap_or_default();
+    format!("{}:{inherited}", dir.display())
+}
+
+/// Parse the `--json` stream, which must be exactly one object however the run
+/// ended. Shared by the skip, pass and fail paths so none of them can quietly
+/// settle for a looser contract than the others.
+fn parse_single_result_object(stdout: &str, stderr: &str) -> serde_json::Value {
+    serde_json::from_str(stdout).unwrap_or_else(|error| {
+        panic!(
+            "--json stdout must be exactly one parseable result object: {error}; \
+             stdout: {stdout:?}; stderr: {stderr:?}"
+        )
+    })
+}
+
+/// Run `curie --json dev soak` in a scratch checkout with the stub `kubectl`
+/// winning on `PATH`, and return the parsed result object plus the raw streams.
+fn run_soak(
+    kubectl_body: &str,
+    namespace: &str,
+    pool: &str,
+) -> (serde_json::Value, String, std::process::Output) {
+    let checkout = scratch_checkout();
+    let tools = stub_tools(&[("kubectl", kubectl_body)]);
+    let path = path_with(tools.path());
+
+    let output = Command::new(env!("CARGO_BIN_EXE_curie"))
+        .args([
+            "--json",
+            "dev",
+            "soak",
+            "--namespace",
+            namespace,
+            "--pool",
+            pool,
+        ])
+        .current_dir(checkout.path())
+        .env("PATH", path)
+        .output()
+        .expect("run dev soak against a scratch checkout");
+
+    let stdout = String::from_utf8(output.stdout.clone()).expect("stdout is UTF-8");
+    let stderr = String::from_utf8(output.stderr.clone()).expect("stderr is UTF-8");
+    let payload = parse_single_result_object(&stdout, &stderr);
+    (payload, stderr, output)
+}
+
+/// Every skip is exit 0 with one object naming a reason. The three reasons must
+/// also DIFFER: a single catch-all string would satisfy "non-empty reason" at
+/// every stage while telling an operator nothing about which prerequisite is
+/// missing.
+#[test]
+fn each_missing_prerequisite_skips_with_its_own_named_reason() {
+    let namespace = "soak-scratch-ns";
+    let pool = "soak-scratch-pool";
+
+    let (no_context, stderr, output) = run_soak(KUBECTL_NO_CONTEXT, namespace, pool);
+    assert!(
+        output.status.success(),
+        "an unreachable cluster is a skip, not a failure; stderr: {stderr}"
+    );
+    assert_eq!(no_context["status"], "skipped", "{no_context}");
+    assert_eq!(
+        no_context["context"],
+        serde_json::Value::Null,
+        "{no_context}"
+    );
+    assert_eq!(
+        no_context["exit_code"],
+        serde_json::Value::Null,
+        "pytest never ran, so there is no exit code: {no_context}"
+    );
+    let context_reason = no_context["reason"]
+        .as_str()
+        .unwrap_or_else(|| panic!("a skip must carry a reason string: {no_context}"))
+        .to_string();
+    assert!(
+        !context_reason.is_empty(),
+        "the skip reason must not be empty: {no_context}"
+    );
+
+    let (no_namespace, stderr, output) = run_soak(KUBECTL_NO_NAMESPACE, namespace, pool);
+    assert!(
+        output.status.success(),
+        "a missing namespace is a skip, not a failure; stderr: {stderr}"
+    );
+    assert_eq!(no_namespace["status"], "skipped", "{no_namespace}");
+    let namespace_reason = no_namespace["reason"]
+        .as_str()
+        .unwrap_or_else(|| panic!("a skip must carry a reason string: {no_namespace}"))
+        .to_string();
+    assert!(
+        namespace_reason.contains(namespace),
+        "the reason must name the namespace that was asked for: {namespace_reason:?}"
+    );
+
+    let (no_pool, stderr, output) = run_soak(KUBECTL_NO_POOL, namespace, pool);
+    assert!(
+        output.status.success(),
+        "a missing warm pool is a skip, not a failure; stderr: {stderr}"
+    );
+    assert_eq!(no_pool["status"], "skipped", "{no_pool}");
+    let pool_reason = no_pool["reason"]
+        .as_str()
+        .unwrap_or_else(|| panic!("a skip must carry a reason string: {no_pool}"))
+        .to_string();
+    assert!(
+        pool_reason.contains(pool),
+        "the reason must name the warm pool that was asked for: {pool_reason:?}"
+    );
+
+    let mut distinct = vec![
+        context_reason.as_str(),
+        namespace_reason.as_str(),
+        pool_reason.as_str(),
+    ];
+    distinct.sort_unstable();
+    distinct.dedup();
+    assert_eq!(
+        distinct.len(),
+        3,
+        "each preflight must skip with its own reason, not one catch-all: \
+         {context_reason:?} / {namespace_reason:?} / {pool_reason:?}"
+    );
+}
+
+/// Under `--json`, stdout is exactly one result object: the preflight's child
+/// output belongs on stderr, and a second object (or a stray line) would break
+/// every consumer that reads one line and parses it.
+#[test]
+fn soak_json_keeps_preflight_chatter_off_stdout() {
+    let (payload, stderr, output) =
+        run_soak(KUBECTL_NO_POOL, "soak-scratch-ns", "soak-scratch-pool");
+    assert!(
+        output.status.success(),
+        "the skip path must exit 0; stderr: {stderr}"
+    );
+    assert!(
+        payload.is_object(),
+        "--json result must be an object: {payload}"
+    );
+    let stdout = String::from_utf8(output.stdout).expect("stdout is UTF-8");
+    assert_eq!(
+        stdout.trim().lines().count(),
+        1,
+        "--json stdout must be exactly one line: {stdout:?}"
+    );
+    assert!(
+        !stdout.contains("soak-stub-chatter-on-stdout"),
+        "the stub kubectl's own stdout must not reach the result stream: {stdout:?}"
+    );
+}
+
+/// Pytest's exit codes mean different things, and only 0 is a pass. Code 5 in
+/// particular is the silent-vacuity case: pytest collected nothing, so the
+/// scenario never ran even though it "did not fail".
+#[test]
+fn only_exit_code_zero_passes_and_five_names_the_empty_collection() {
+    let (status, reason) = soak_outcome_for_exit_code(0);
+    assert_eq!(status, SoakStatus::Passed);
+    assert!(reason.is_none(), "a pass carries no reason: {reason:?}");
+
+    let mut reasons = Vec::new();
+    for code in [1, 2, 3, 4, 5] {
+        let (status, reason) = soak_outcome_for_exit_code(code);
+        assert_eq!(
+            status,
+            SoakStatus::Failed,
+            "pytest exit {code} must not be reported as a pass"
+        );
+        let reason = reason.unwrap_or_else(|| panic!("pytest exit {code} must carry a reason"));
+        assert!(
+            !reason.is_empty(),
+            "pytest exit {code} must carry a non-empty reason"
+        );
+        reasons.push(reason);
+    }
+
+    let collected_nothing = &reasons[4];
+    assert!(
+        collected_nothing.contains("collected no tests"),
+        "pytest exit 5 must read as collecting no tests, the silent-vacuity case: \
+         {collected_nothing:?}"
+    );
+
+    let mut distinct: Vec<&str> = reasons.iter().map(String::as_str).collect();
+    distinct.sort_unstable();
+    distinct.dedup();
+    assert_eq!(
+        distinct.len(),
+        5,
+        "each failing pytest exit code needs its own reason: {reasons:?}"
+    );
+}
+
+/// The env-default wiring is the whole reason the nightly rung needs no flags.
+/// Dropping `env = ...` from a flag would still compile, still pass every test
+/// above (they pass the flags explicitly), and silently make an exported
+/// harness environment stop being honored -- so pin it on the help text.
+#[test]
+fn the_flags_declare_the_harness_environment_variables() {
+    let output = Command::new(env!("CARGO_BIN_EXE_curie"))
+        .args(["dev", "soak", "--help"])
+        .output()
+        .expect("run dev soak --help");
+    assert!(
+        output.status.success(),
+        "`dev soak --help` must succeed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let help = String::from_utf8(output.stdout).expect("help is UTF-8");
+    for variable in [
+        "CURIE_SANDBOX_E2E_NAMESPACE",
+        "CURIE_SANDBOX_E2E_POOL",
+        "CURIE_SOAK_RUNS",
+    ] {
+        assert!(
+            help.contains(variable),
+            "`dev soak --help` must name {variable} so the env default cannot be dropped \
+             silently: {help}"
+        );
+    }
+}
+
+/// The scenario the verb runs must actually be there. A rename on the pytest
+/// side would otherwise turn every real invocation into a pytest exit 4, which
+/// reads as a usage error rather than as the broken wiring it is.
+#[test]
+fn the_named_scenario_file_exists() {
+    let scenario =
+        Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/..")).join(curie::commands::SOAK_SCENARIO);
+    assert!(
+        scenario.is_file(),
+        "`curie dev soak` runs {}, which must exist in the checkout",
+        scenario.display()
+    );
+}
+
+/// The Rust and Python defaults for the namespace and pool must stay the same
+/// two strings.
+///
+/// `--namespace` and `--pool` carry clap `default_value`s, and clap ALWAYS
+/// exports a value for a defaulted arg -- so `dev_soak` always passes
+/// `CURIE_SANDBOX_E2E_NAMESPACE` and `CURIE_SANDBOX_E2E_POOL` to the child, and
+/// `SoakConfig.from_env`'s own `os.environ.get` fallbacks in
+/// `tests/soak/harness.py` are dead code under the verb. The Rust side is
+/// therefore authoritative, and the drift is silent in one direction: change the
+/// harness default and `curie dev soak` keeps targeting the old cluster while a
+/// bare `uv run pytest` targets the new one, with nothing failing. Pin the two
+/// literals on the harness so that edit has to come here.
+#[test]
+fn the_harness_defaults_match_the_flag_defaults() {
+    let harness =
+        Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/..")).join("tests/soak/harness.py");
+    let source = std::fs::read_to_string(&harness)
+        .unwrap_or_else(|error| panic!("read {}: {error}", harness.display()));
+    // The whole `os.environ.get` call, not the bare default: "curie-g1" is a
+    // prefix of "curie-g1-runner-pool", so asserting the bare literals would
+    // let a namespace default vanish and still pass on the pool's line.
+    for fallback in [
+        r#"os.environ.get("CURIE_SANDBOX_E2E_NAMESPACE", "curie-g1")"#,
+        r#"os.environ.get("CURIE_SANDBOX_E2E_POOL", "curie-g1-runner-pool")"#,
+    ] {
+        assert!(
+            source.contains(fallback),
+            "{} must still read `{fallback}`: `curie dev soak`'s clap defaults restate it, and \
+             clap always exports a defaulted arg, so a harness-only change would silently point \
+             the verb and a bare `uv run pytest` at different clusters",
+            harness.display()
+        );
+    }
+}
+
+/// What the fake `uv` was asked to do: its argv, and the soak-relevant slice of
+/// the environment it was handed.
+struct Recorded {
+    argv: Vec<String>,
+    env: std::collections::BTreeMap<String, String>,
+}
+
+impl Recorded {
+    /// The recorded value of `name`, or a panic naming the whole record --
+    /// `UNSET` is a recorded value, so a missing key here means the stub itself
+    /// never ran or never wrote its line.
+    fn env(&self, name: &str) -> &str {
+        self.env
+            .get(name)
+            .unwrap_or_else(|| panic!("the stub uv recorded no {name} line: {:?}", self.env))
+    }
+}
+
+/// Read back what `UV_RECORDER` wrote. The file's absence is itself a finding:
+/// it means the verb never reached the child at all.
+fn read_record(path: &Path, stderr: &str) -> Recorded {
+    let raw = std::fs::read_to_string(path).unwrap_or_else(|error| {
+        panic!(
+            "the soak verb never invoked its child (no record at {}): {error}; stderr: {stderr:?}",
+            path.display()
+        )
+    });
+    let mut argv = Vec::new();
+    let mut env = std::collections::BTreeMap::new();
+    for line in raw.lines() {
+        if let Some(arg) = line.strip_prefix("argv\t") {
+            argv.push(arg.to_string());
+        } else if let Some(rest) = line.strip_prefix("env\t") {
+            let (name, value) = rest
+                .split_once('=')
+                .unwrap_or_else(|| panic!("malformed recorded env line: {line:?}"));
+            env.insert(name.to_string(), value.to_string());
+        } else {
+            panic!("unexpected line in the uv record: {line:?}");
+        }
+    }
+    Recorded { argv, env }
+}
+
+/// The outcome of a run that got all the way past preflight and spawned the
+/// child: the parsed result object, the raw streams, the process status, and
+/// what the fake `uv` recorded.
+struct CompletedSoak {
+    payload: serde_json::Value,
+    stdout: String,
+    stderr: String,
+    status: std::process::ExitStatus,
+    recorded: Recorded,
+}
+
+/// Run `curie --json dev soak` with every preflight satisfied, so the verb
+/// spawns the fake `uv` -- which exits `uv_exit` after recording its call. Same
+/// scratch checkout and child-only `PATH` as `run_soak`; the two stubs simply
+/// share one directory.
+fn run_soak_to_completion(uv_exit: &str, namespace: &str, pool: &str, runs: &str) -> CompletedSoak {
+    let checkout = scratch_checkout();
+    let tools = stub_tools(&[("kubectl", KUBECTL_PREFLIGHT_OK), ("uv", UV_RECORDER)]);
+    let records = tempfile::tempdir().expect("record dir");
+    let record = records.path().join("uv-invocation");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_curie"))
+        .args([
+            "--json",
+            "dev",
+            "soak",
+            "--namespace",
+            namespace,
+            "--pool",
+            pool,
+            "--runs",
+            runs,
+        ])
+        .current_dir(checkout.path())
+        .env("PATH", path_with(tools.path()))
+        .env("CURIE_SOAK_TEST_RECORD", &record)
+        .env("CURIE_SOAK_TEST_EXIT", uv_exit)
+        // Decoys, so every environment assertion below proves the HANDLER set
+        // the value. The child inherits this process's environment, so a
+        // contributor who happens to export CURIE_SOAK=1 (the scenario's own
+        // gate) would otherwise make that assertion pass with the handler's
+        // `.env` deleted. Each decoy is a value the assertion rejects; for the
+        // three flag-backed variables it doubles as proof the explicit flag
+        // wins over clap's `env = ...` default.
+        .env("CURIE_SOAK", "0")
+        .env("CURIE_SOAK_RUNS", "999")
+        .env("CURIE_SANDBOX_E2E_NAMESPACE", "inherited-decoy-namespace")
+        .env("CURIE_SANDBOX_E2E_POOL", "inherited-decoy-pool")
+        .output()
+        .expect("run dev soak against a scratch checkout");
+
+    let stdout = String::from_utf8(output.stdout.clone()).expect("stdout is UTF-8");
+    let stderr = String::from_utf8(output.stderr.clone()).expect("stderr is UTF-8");
+    let payload = parse_single_result_object(&stdout, &stderr);
+    let recorded = read_record(&record, &stderr);
+    CompletedSoak {
+        payload,
+        stdout,
+        stderr,
+        status: output.status,
+        recorded,
+    }
+}
+
+/// `CURIE_SOAK=1` is the entire reason this verb exists (#2056: nothing ever set
+/// it), and it is invisible from the outside -- flipping it to `0`, or dropping
+/// it, makes pytest skip the gated scenario, exit 0, and let the verb report a
+/// confident `passed`. So assert it BY EXECUTION on the real child, alongside
+/// the pytest target: an accidental retarget fails here, while a deliberate
+/// rename moves `SOAK_SCENARIO` and stays honest.
+#[test]
+fn the_child_is_uv_run_pytest_on_the_gated_scenario_with_curie_soak_set() {
+    let run = run_soak_to_completion("0", "soak-scratch-ns", "soak-scratch-pool", "1");
+
+    assert_eq!(
+        run.recorded.env("CURIE_SOAK"),
+        "1",
+        "the scenario is CURIE_SOAK=1-gated; any other value (or none) makes pytest skip it \
+         and the verb report a green that proves nothing. The child inherited CURIE_SOAK=0, so \
+         a 0 here means the handler stopped setting it. stderr: {}",
+        run.stderr
+    );
+    assert_eq!(
+        run.recorded.argv,
+        vec![
+            "run".to_string(),
+            "pytest".to_string(),
+            curie::commands::SOAK_SCENARIO.to_string(),
+            "-q".to_string(),
+        ],
+        "the verb must invoke `uv run pytest {} -q`",
+        curie::commands::SOAK_SCENARIO
+    );
+}
+
+/// The flags are the verb's only steering, and they only steer anything if they
+/// reach the child as environment. Use values that match no default, so a
+/// handler that dropped the plumbing and let the scenario fall back could not
+/// pass by coincidence.
+#[test]
+fn the_flags_reach_the_child_as_environment() {
+    let namespace = "soak-flag-ns";
+    let pool = "soak-flag-pool";
+    let run = run_soak_to_completion("0", namespace, pool, "7");
+
+    assert_eq!(
+        run.recorded.env("CURIE_SANDBOX_E2E_NAMESPACE"),
+        namespace,
+        "--namespace must reach the scenario"
+    );
+    assert_eq!(
+        run.recorded.env("CURIE_SANDBOX_E2E_POOL"),
+        pool,
+        "--pool must reach the scenario"
+    );
+    assert_eq!(
+        run.recorded.env("CURIE_SOAK_RUNS"),
+        "7",
+        "--runs must reach the scenario, which owns the repetition"
+    );
+    assert_eq!(run.payload["runs"], 7, "{}", run.payload);
+}
+
+/// A child that exits 0 is the pass, and the pass must stay quiet: the
+/// scenario's own stdout is chatter, and letting it through would put a second
+/// line (or a non-JSON one) on the `--json` result stream that every consumer
+/// parses as a single object.
+#[test]
+fn a_passing_child_reports_passed_and_keeps_its_stdout_off_the_result_stream() {
+    let run = run_soak_to_completion("0", "soak-scratch-ns", "soak-scratch-pool", "1");
+
+    assert!(
+        run.status.success(),
+        "a passing scenario must exit 0; stderr: {}",
+        run.stderr
+    );
+    assert_eq!(run.payload["status"], "passed", "{}", run.payload);
+    assert_eq!(
+        run.payload["exit_code"], 0,
+        "the pytest exit code must be reported: {}",
+        run.payload
+    );
+    assert_eq!(
+        run.payload["reason"],
+        serde_json::Value::Null,
+        "a pass carries no reason: {}",
+        run.payload
+    );
+    assert_eq!(
+        run.stdout.trim().lines().count(),
+        1,
+        "--json stdout must be exactly one line: {:?}",
+        run.stdout
+    );
+    assert!(
+        !run.stdout.contains(UV_STDOUT_MARKER),
+        "the scenario's own stdout must not reach the result stream: {:?}",
+        run.stdout
+    );
+    assert!(
+        run.stderr.contains(UV_STDOUT_MARKER),
+        "the scenario's stdout must still be visible, on stderr: {:?}",
+        run.stderr
+    );
+}
+
+/// A real soak failure exits non-zero, but it must NOT degrade into the generic
+/// `{error, fix}` payload: an agent reading the result needs the same
+/// `status`/`reason`/`exit_code` family the pass and skip emit, which is exactly
+/// what `with_json_payload` is for. Still exactly one object on stdout, and
+/// still no child chatter in it.
+#[test]
+fn a_failing_child_reports_failed_on_the_same_result_family() {
+    let run = run_soak_to_completion("1", "soak-fail-ns", "soak-fail-pool", "1");
+
+    assert!(
+        !run.status.success(),
+        "a failing scenario must exit non-zero; stdout: {:?}",
+        run.stdout
+    );
+    assert_eq!(run.payload["status"], "failed", "{}", run.payload);
+    assert_eq!(
+        run.payload["exit_code"], 1,
+        "the pytest exit code must be reported: {}",
+        run.payload
+    );
+    assert_eq!(
+        run.payload["namespace"], "soak-fail-ns",
+        "the failure must carry the soak result family, not the generic error payload: {}",
+        run.payload
+    );
+    assert!(
+        run.payload.get("fix").is_none() && run.payload.get("error").is_none(),
+        "a soak failure must not degrade into the generic error payload: {}",
+        run.payload
+    );
+    let reason = run.payload["reason"]
+        .as_str()
+        .unwrap_or_else(|| panic!("a failure must carry a reason string: {}", run.payload));
+    assert!(
+        reason.contains("pytest exit 1"),
+        "the reason must name what pytest reported: {reason:?}"
+    );
+    assert_eq!(
+        run.stdout.trim().lines().count(),
+        1,
+        "--json stdout must be exactly one line even on the failure path: {:?}",
+        run.stdout
+    );
+    assert!(
+        !run.stdout.contains(UV_STDOUT_MARKER),
+        "the scenario's own stdout must not reach the result stream: {:?}",
+        run.stdout
+    );
+}
+
+/// `kubectl` on a reachable cluster that genuinely has no such namespace: it
+/// says so in its own words, on STDERR, in the shape a real apiserver uses.
+/// The `KUBECTL_NO_NAMESPACE` stub above exits 1 saying nothing, which is the
+/// ambiguous case; this one is the only case that licenses "absent".
+const KUBECTL_NAMESPACE_NOT_FOUND: &str = r#"#!/bin/sh
+case "$*" in
+  "config current-context") printf '%s\n' 'soak-stub-context' ;;
+  "get namespace "*)
+    printf 'Error from server (NotFound): namespaces "%s" not found\n' "$3" >&2
+    exit 1 ;;
+  *) printf 'unexpected kubectl invocation: %s\n' "$*" >&2; exit 64 ;;
+esac
+"#;
+
+/// The same NotFound shape one probe deeper: the namespace is there, the warm
+/// pool the scenario claims from is not.
+const KUBECTL_POOL_NOT_FOUND: &str = r#"#!/bin/sh
+case "$*" in
+  "config current-context") printf '%s\n' 'soak-stub-context' ;;
+  "get namespace "*) exit 0 ;;
+  "get sandboxwarmpool "*)
+    printf 'Error from server (NotFound): sandboxwarmpools.curie.dev "%s" not found\n' "$3" >&2
+    exit 1 ;;
+  *) printf 'unexpected kubectl invocation: %s\n' "$*" >&2; exit 64 ;;
+esac
+"#;
+
+/// `kubectl` that cannot ASK the cluster about the namespace: RBAC refuses the
+/// read. The object may well exist; nothing here supports a claim either way,
+/// so this is the case a wrong "absent" would misreport as a verdict about the
+/// cluster.
+const KUBECTL_NAMESPACE_FORBIDDEN: &str = r#"#!/bin/sh
+case "$*" in
+  "config current-context") printf '%s\n' 'soak-stub-context' ;;
+  "get namespace "*)
+    printf 'Error from server (Forbidden): namespaces "%s" is forbidden: User "soak-stub-user" cannot get resource "namespaces" in API group "" at the cluster scope\n' "$3" >&2
+    exit 1 ;;
+  *) printf 'unexpected kubectl invocation: %s\n' "$*" >&2; exit 64 ;;
+esac
+"#;
+
+/// The same unreadable-probe case one stage deeper, on the warm pool.
+const KUBECTL_POOL_FORBIDDEN: &str = r#"#!/bin/sh
+case "$*" in
+  "config current-context") printf '%s\n' 'soak-stub-context' ;;
+  "get namespace "*) exit 0 ;;
+  "get sandboxwarmpool "*)
+    printf 'Error from server (Forbidden): sandboxwarmpools.curie.dev "%s" is forbidden: User "soak-stub-user" cannot get resource "sandboxwarmpools" in API group "curie.dev" in the namespace "%s"\n' "$3" "$5" >&2
+    exit 1 ;;
+  *) printf 'unexpected kubectl invocation: %s\n' "$*" >&2; exit 64 ;;
+esac
+"#;
+
+/// The clause the namespace reason uses ONLY when kubectl itself said NotFound:
+/// a verdict about the cluster ("there is nothing to soak").
+const NAMESPACE_ABSENT_WORDING: &str = "does not exist on kube context";
+
+/// The same clause for the warm pool.
+const POOL_ABSENT_WORDING: &str = "is absent from namespace";
+
+/// The clause both operational reasons use instead: a verdict about the PROBE
+/// ("I could not find out"), which is all an unreadable failure supports.
+const UNCHECKABLE_WORDING: &str = "could not be checked";
+
+/// A distinctive fragment of the two RBAC stubs' stderr. The reason has to
+/// quote kubectl's own words, or the operator is left with "something went
+/// wrong" and no way to tell an expired credential from a broken kubeconfig.
+const KUBECTL_ERROR_FRAGMENT: &str = "Forbidden";
+
+/// Run one preflight-failure case and return its reason, having first pinned
+/// the parts every skip shares: exit 0, and `status: "skipped"`. Shared by the
+/// NotFound and operational cases below so neither can drift into asserting on
+/// the reason wording while quietly tolerating a non-zero exit.
+fn skip_reason(kubectl_body: &str, namespace: &str, pool: &str) -> String {
+    let (payload, stderr, output) = run_soak(kubectl_body, namespace, pool);
+    assert!(
+        output.status.success(),
+        "a failed preflight probe is a skip, not a failure; stderr: {stderr}"
+    );
+    assert_eq!(payload["status"], "skipped", "{payload}");
+    assert_eq!(
+        payload["exit_code"],
+        serde_json::Value::Null,
+        "pytest never ran, so there is no exit code: {payload}"
+    );
+    payload["reason"]
+        .as_str()
+        .unwrap_or_else(|| panic!("a skip must carry a reason string: {payload}"))
+        .to_string()
+}
+
+/// kubectl's own `NotFound` is the only thing that licenses the ABSENT wording,
+/// so it needs a case that actually produces it. Every other stub in this file
+/// fails with empty stderr, which is the ambiguous case -- without this test the
+/// absent branch is unreached, and a mutation deleting it (or inverting the
+/// predicate) would leave the whole suite green.
+#[test]
+fn a_notfound_namespace_probe_reports_the_namespace_absent() {
+    let namespace = "soak-notfound-ns";
+    let reason = skip_reason(KUBECTL_NAMESPACE_NOT_FOUND, namespace, "soak-notfound-pool");
+
+    assert!(
+        reason.contains(namespace),
+        "the reason must name the namespace that was asked for: {reason:?}"
+    );
+    assert!(
+        reason.contains(NAMESPACE_ABSENT_WORDING),
+        "kubectl said NotFound, so the reason may state the namespace is absent: {reason:?}"
+    );
+    assert!(
+        !reason.contains(UNCHECKABLE_WORDING),
+        "a positive NotFound is not an uncheckable probe; hedging here would make the two \
+         branches indistinguishable: {reason:?}"
+    );
+}
+
+/// The same licensing rule one probe deeper. The pool branch is a separate
+/// `if`, so it can regress on its own.
+#[test]
+fn a_notfound_warm_pool_probe_reports_the_pool_absent() {
+    let pool = "soak-notfound-pool";
+    let reason = skip_reason(KUBECTL_POOL_NOT_FOUND, "soak-notfound-ns", pool);
+
+    assert!(
+        reason.contains(pool),
+        "the reason must name the warm pool that was asked for: {reason:?}"
+    );
+    assert!(
+        reason.contains(POOL_ABSENT_WORDING),
+        "kubectl said NotFound, so the reason may state the pool is absent: {reason:?}"
+    );
+    assert!(
+        !reason.contains(UNCHECKABLE_WORDING),
+        "a positive NotFound is not an uncheckable probe: {reason:?}"
+    );
+}
+
+/// An RBAC refusal says nothing about whether the namespace exists. Reporting
+/// it as absent is a false statement about the CLUSTER, and it is the exact
+/// statement that would send someone creating a namespace that is already
+/// there. Two-sided on purpose: the claim must be dropped AND kubectl's own
+/// words must survive into the reason, or the operator gets a hedge with no
+/// diagnostic in it.
+#[test]
+fn an_unreadable_namespace_probe_says_uncheckable_and_quotes_kubectl() {
+    let namespace = "soak-forbidden-ns";
+    let reason = skip_reason(
+        KUBECTL_NAMESPACE_FORBIDDEN,
+        namespace,
+        "soak-forbidden-pool",
+    );
+
+    assert!(
+        !reason.contains(NAMESPACE_ABSENT_WORDING),
+        "an access failure does not license claiming the namespace is absent: {reason:?}"
+    );
+    assert!(
+        reason.contains(UNCHECKABLE_WORDING),
+        "the reason must say the probe could not be read: {reason:?}"
+    );
+    assert!(
+        reason.contains(KUBECTL_ERROR_FRAGMENT),
+        "the reason must quote kubectl's own error, or the skip is undiagnosable: {reason:?}"
+    );
+    assert!(
+        reason.contains(namespace),
+        "the reason must still name the namespace that was asked for: {reason:?}"
+    );
+}
+
+/// Same two-sided property on the warm-pool probe, which has its own copy of
+/// the branch.
+#[test]
+fn an_unreadable_warm_pool_probe_says_uncheckable_and_quotes_kubectl() {
+    let pool = "soak-forbidden-pool";
+    let reason = skip_reason(KUBECTL_POOL_FORBIDDEN, "soak-forbidden-ns", pool);
+
+    assert!(
+        !reason.contains(POOL_ABSENT_WORDING),
+        "an access failure does not license claiming the warm pool is absent: {reason:?}"
+    );
+    assert!(
+        reason.contains(UNCHECKABLE_WORDING),
+        "the reason must say the probe could not be read: {reason:?}"
+    );
+    assert!(
+        reason.contains(KUBECTL_ERROR_FRAGMENT),
+        "the reason must quote kubectl's own error, or the skip is undiagnosable: {reason:?}"
+    );
+    assert!(
+        reason.contains(pool),
+        "the reason must still name the warm pool that was asked for: {reason:?}"
+    );
+}
+
+/// The wording assertions above are all substring checks, so a refactor that
+/// collapsed both branches into one sentence carrying every phrase would keep
+/// them green. Pin the distinction itself: for the SAME probe, "absent" and
+/// "could not be checked" must be different sentences, because the split is the
+/// entire point of reading kubectl's stderr at all.
+#[test]
+fn the_absent_and_uncheckable_reasons_are_different_sentences() {
+    let namespace = "soak-split-ns";
+    let pool = "soak-split-pool";
+
+    let namespace_absent = skip_reason(KUBECTL_NAMESPACE_NOT_FOUND, namespace, pool);
+    let namespace_uncheckable = skip_reason(KUBECTL_NAMESPACE_FORBIDDEN, namespace, pool);
+    assert_ne!(
+        namespace_absent, namespace_uncheckable,
+        "a missing namespace and an unqueryable cluster must not read the same"
+    );
+
+    let pool_absent = skip_reason(KUBECTL_POOL_NOT_FOUND, namespace, pool);
+    let pool_uncheckable = skip_reason(KUBECTL_POOL_FORBIDDEN, namespace, pool);
+    assert_ne!(
+        pool_absent, pool_uncheckable,
+        "a missing warm pool and an unqueryable cluster must not read the same"
+    );
+}
+
+/// A `PATH` holding ONLY `dir`, for the child `Command` only. `path_with`
+/// prepends to the inherited `PATH`, which is right for every stub that must
+/// WIN a lookup; proving a lookup FAILS needs the inherited entries gone, or a
+/// contributor with `uv` installed silently tests the happy path instead.
+fn path_only(dir: &Path) -> String {
+    dir.display().to_string()
+}
+
+/// A child that could not be SPAWNED is still a soak result. The natural
+/// implementation -- returning a bare error -- would put the generic
+/// `{error, fix}` payload on stdout, so an agent reading a non-zero `dev soak`
+/// would find no `status`, no `exit_code`, and no way to tell "uv is missing"
+/// from "the cluster broke". Driven by execution with every preflight passing
+/// and no `uv` anywhere on the child's `PATH`.
+#[test]
+fn a_child_that_never_launched_reports_failed_on_the_same_result_family() {
+    let checkout = scratch_checkout();
+    let tools = stub_tools(&[("kubectl", KUBECTL_PREFLIGHT_OK)]);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_curie"))
+        .args([
+            "--json",
+            "dev",
+            "soak",
+            "--namespace",
+            "soak-launch-ns",
+            "--pool",
+            "soak-launch-pool",
+        ])
+        .current_dir(checkout.path())
+        // Only the stub dir: the point of the case is that `uv` resolves to
+        // nothing at all.
+        .env("PATH", path_only(tools.path()))
+        .output()
+        .expect("run dev soak against a scratch checkout");
+
+    let stdout = String::from_utf8(output.stdout.clone()).expect("stdout is UTF-8");
+    let stderr = String::from_utf8(output.stderr.clone()).expect("stderr is UTF-8");
+    assert!(
+        !output.status.success(),
+        "a scenario that never launched must exit non-zero; stdout: {stdout:?}"
+    );
+    assert_eq!(
+        stdout.trim().lines().count(),
+        1,
+        "--json stdout must be exactly one line even when the child never started: {stdout:?}"
+    );
+
+    let payload = parse_single_result_object(&stdout, &stderr);
+    assert_eq!(payload["status"], "failed", "{payload}");
+    assert_eq!(
+        payload["exit_code"],
+        serde_json::Value::Null,
+        "there is no child, so there is no exit code to report: {payload}"
+    );
+    assert!(
+        payload.get("fix").is_none() && payload.get("error").is_none(),
+        "a launch failure must not degrade into the generic error payload: {payload}"
+    );
+    let reason = payload["reason"]
+        .as_str()
+        .unwrap_or_else(|| panic!("a failure must carry a reason string: {payload}"));
+    assert!(
+        reason.contains("uv"),
+        "the reason must name what could not be launched: {reason:?}"
+    );
+}

--- a/cli/tests/json_contract.rs
+++ b/cli/tests/json_contract.rs
@@ -878,7 +878,7 @@ use curie::commands::{
     ApprovalsOutput, BudgetOutput, BumpVersionOutput, ChartCheckOutcome, ChartCheckOutput,
     CheckMatch, CheckReport, DeclaredServer, DeleteOutput, DeployOutput, KillOutput,
     ListAgentsOutput, LocalAgentSummary, MemoryOutput, ResetThreadOutput, ResumeOutput,
-    SkillApprovalsOutput, SkillMessageOutput, SweepRow, VersionsOutput,
+    SkillApprovalsOutput, SkillMessageOutput, SoakOutput, SoakStatus, SweepRow, VersionsOutput,
 };
 use curie::comms::CommsOutput;
 use curie::local::{
@@ -929,6 +929,38 @@ fn chart_check_output_validates() {
         ],
     };
     assert_valid("chart-check.schema.json", &output.to_json());
+}
+
+/// `curie dev soak` emits ONE family for pass, fail and skip, so both a real
+/// pass and the far more common no-cluster skip are built here. The skip is the
+/// load-bearing half: it is the shape with `context` and `exit_code` null, and a
+/// schema that only ever saw the pass would accept a null-free result and
+/// silently reject the skip an agent actually reads.
+#[test]
+fn soak_output_validates() {
+    let passed = SoakOutput {
+        status: SoakStatus::Passed,
+        reason: None,
+        context: Some("k8scratch".to_string()),
+        namespace: "curie-g1".to_string(),
+        pool: "curie-g1-runner-pool".to_string(),
+        runs: 3,
+        exit_code: Some(0),
+    };
+    assert_valid("soak.schema.json", &passed.to_json());
+
+    let skipped = SoakOutput {
+        status: SoakStatus::Skipped,
+        reason: Some(
+            "no kubeconfig current-context is set, so there is no cluster to soak.".to_string(),
+        ),
+        context: None,
+        namespace: "curie-g1".to_string(),
+        pool: "curie-g1-runner-pool".to_string(),
+        runs: 1,
+        exit_code: None,
+    };
+    assert_valid("soak.schema.json", &skipped.to_json());
 }
 
 #[test]

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -29,7 +29,7 @@ is documentation of where the code already draws the line, not a new abstraction
 | Memory | CLEAN | 1 loader (StateApiMemoryStore) | not separately graded | #28 | [Memory](interfaces/memory/INTERFACE.md) |
 | Conversation history | CLEAN | 1 loader (StateApiTranscriptStore) | not separately graded | #20 | [Conversation history](interfaces/conversation-history/INTERFACE.md) |
 | Triggers | SOFT | 3 hardcoded (Slack, GH push, commit poll) | not separately graded | #29 | [Triggers](interfaces/triggers/INTERFACE.md) |
-| CLI output (agent-facing `--json`) | CLEAN | 41 outputs behind one trait | not separately graded | #456 | [CLI output (agent-facing `--json`)](interfaces/cli-output/INTERFACE.md) |
+| CLI output (agent-facing `--json`) | CLEAN | 42 outputs behind one trait | not separately graded | #456 | [CLI output (agent-facing `--json`)](interfaces/cli-output/INTERFACE.md) |
 | Harness package (declared contribution) | CLEAN | 1 (built-in Claude) behind the entry-point registry | not separately graded | #844 | [Harness package (declared contribution)](interfaces/harness-package/INTERFACE.md) |
 | Connector host (bundle-declared MCP servers) | CLEAN | 1 (Kubernetes) + in-memory fake | not separately graded | #1063, #1184 | [Connector host (bundle-declared MCP servers)](interfaces/connector-host/INTERFACE.md) |
 | Sealed credential (cluster-sealed connector secrets) | SOFT | 2 halves (Rust sealer, Python opener) over one frozen wire | not separately graded | #1240 | [Sealed credential (cluster-sealed connector secrets)](interfaces/sealed-credential/INTERFACE.md) |

--- a/docs/interfaces/cli-output/INTERFACE.md
+++ b/docs/interfaces/cli-output/INTERFACE.md
@@ -1,7 +1,7 @@
 ---
 seam: CLI output (agent-facing `--json`)
 kind: CLEAN
-impls: 41 outputs behind one trait
+impls: 42 outputs behind one trait
 grade: not separately graded
 epics:
   - "#456"
@@ -13,7 +13,7 @@ order: 18
 > Part of the Curie swappable-seam catalog — see the [seam index](../../interfaces.md).
 
 <!-- BEGIN GENERATED: header (curie dev docs-lint) -->
-> **Kind:** CLEAN &nbsp;·&nbsp; **Implementations today:** 41 outputs behind one trait &nbsp;·&nbsp; **Swap-readiness grade:** not separately graded
+> **Kind:** CLEAN &nbsp;·&nbsp; **Implementations today:** 42 outputs behind one trait &nbsp;·&nbsp; **Swap-readiness grade:** not separately graded
 <!-- END GENERATED: header -->
 
 **Kind legend:** CLEAN = a real `Protocol`/typed port class · SOFT = swap via env/URL/prefix/wire, no code interface · NONE = not built yet.
@@ -65,7 +65,7 @@ This is the catalog's first **Rust** seam. It is listed here because the agent-f
 
 ## Implementations today
 
-41 `CliOutput` implementations, all in the CLI crate, grouped by owning module:
+42 `CliOutput` implementations, all in the CLI crate, grouped by owning module:
 
 - **`DryRunPlan`** (`cli/src/ui.rs`) — the generic `--dry-run` plan; JSON is
   `{"dry_run":true,"plan":[lines]}` and the human render is the same lines verbatim,
@@ -80,7 +80,7 @@ This is the catalog's first **Rust** seam. It is listed here because the agent-f
   `EvalOutput`, `DeployOutput`, `AllTargetsDeployOutput`, `KillOutput`, `ResumeOutput`,
   `BudgetOutput`, `ResetThreadOutput`,
   `DeleteOutput`, `VersionsOutput`, `MemoryOutput`, `ApprovalsOutput`,
-  `SkillApprovalsOutput`, `OverridesOutput`.
+  `SkillApprovalsOutput`, `OverridesOutput`, `SoakOutput`.
 - **`cli/src/local.rs`** and **`cli/src/ops.rs`**, the operator verbs, one output per
   verb per tier: `LocalUpOutput`, `LocalRebuildOutput`, `LocalStatusOutput`,
   `LocalDownOutput`; `ClusterUpOutput`, `ClusterStatusOutput`, `ClusterDownOutput`,
@@ -116,10 +116,10 @@ That set is not hand-maintained prose: `cli/schema/index.json` carries one
   syntactic call-site inventory, not a type-level proof that *every* verb returns
   a `CliOutput`.
 - **Committed JSON Schemas with a drift gate (since #841).** Each `to_json` is no
-  longer schema-free: there are 41 committed schemas under `cli/schema/` with an
+  longer schema-free: there are 42 committed schemas under `cli/schema/` with an
   index (`cli/schema/index.json`), a `syn`-based inventory gate over every `impl
-  CliOutput`, and per-family output validation — all 41 are validated against real
-  `to_json()` output across 68 tests in `cli/tests/json_contract.rs`. Those tests
+  CliOutput`, and per-family output validation — all 42 are validated against real
+  `to_json()` output across 69 tests in `cli/tests/json_contract.rs`. Those tests
   drive each output type's `to_json()` once per output variant rather than calling
   the pure builder functions behind it, so a variant whose `to_json()` arm drifts
   from the schema is caught even when the builder it delegates to still validates.

--- a/tests/soak/README.md
+++ b/tests/soak/README.md
@@ -14,9 +14,26 @@ sandbox pod followed by `POST /v1/event` (NDJSON frames ending in a `final`).
 
 ## Opt-in gate
 
-The scenario never runs in default CI. It is gated on `CURIE_SOAK=1` and skips
-cleanly with no cluster. The pure-helper unit tests in `test_harness_unit.py`
-always run (offline, no cluster) and cover the deterministic harness logic.
+The scenario never runs in default (PR) CI. It is gated on `CURIE_SOAK=1`, and
+`curie dev soak` is the one entry point that runs it (the repo's one-entry-point
+rule, `CLAUDE.md`) — the verb sets `CURIE_SOAK=1` itself and preflights the
+cluster before invoking the suite.
+
+It does run nightly: the graded parity ladder's `ladder-cluster` job
+(`.github/workflows/nightly-graded-ladder.yaml`) drives `curie dev soak` against
+the standing kind cluster it already installed, as a **report-only** rung. The
+rung is a single step that captures the verb's exit status, prints its JSON
+result to the run log and the job summary, and then ends in an explicit
+`exit 0` — that, not a blanket `continue-on-error: true`, is what makes it
+**unable to fail the nightly** (the #1603 report-only precedent; see #2056). Its
+uv acquisition sits outside that step as a plain, unretried toolchain fetch, on
+the same footing as the job's other third-party actions; if uv never installs,
+the rung's captured statuses make it report "could not run" rather than redden
+the job. The rung overrides the concurrency and batch knobs downward because a
+2-CPU GitHub runner cannot hold the eight ready sandboxes the defaults demand.
+
+The pure-helper unit tests in `test_harness_unit.py` always run (offline, no
+cluster) and cover the deterministic harness logic.
 
 Only `test_harness_unit.py` is in the pytest `testpaths` (`pyproject.toml`), so
 the offline helpers run in default CI while `test_soak_resilience.py` (the
@@ -25,13 +42,34 @@ explicit path or under `CURIE_SOAK=1`.
 
 ## How to run
 
+The scenario, against a standing cluster and dev stack:
+
+```bash
+curie dev soak
+curie dev soak --namespace curie-g1 --pool curie-g1-runner-pool --runs 3
+```
+
+Each flag also reads its environment variable — `--namespace` from
+`CURIE_SANDBOX_E2E_NAMESPACE`, `--pool` from `CURIE_SANDBOX_E2E_POOL`, `--runs`
+from `CURIE_SOAK_RUNS` — so an already-exported harness environment is honored
+and the bare `curie dev soak` above is the normal invocation.
+
+**Skip contract.** With no reachable kube context, no such namespace, or no
+reachable `SandboxWarmPool`, the verb emits `status: "skipped"` with a named
+reason and exits **0**. It exits non-zero only when the scenario itself fails or
+could not be launched.
+That is what lets the nightly report-only rung distinguish "there was nothing to
+soak against" from "the soak found something", instead of reporting a false
+green or a false red.
+
 Offline unit tests (no cluster, always green):
 
 ```bash
 uv run pytest tests/soak/test_harness_unit.py -q
 ```
 
-Full scenario, three consecutive runs, against a standing cluster and dev stack:
+The underlying implementation, if you need to drive pytest directly (three
+consecutive runs shown; `curie dev soak --runs 3` is the supported form):
 
 ```bash
 CURIE_SOAK=1 CURIE_SOAK_RUNS=3 uv run pytest tests/soak -q
@@ -45,7 +83,7 @@ so the concurrent claims and the batch burst never starve.
 
 | Variable | Default | Meaning |
 |---|---|---|
-| `CURIE_SOAK` | unset | Set to `1` to enable the scenario. Unset skips it. |
+| `CURIE_SOAK` | unset | Set to `1` to enable the scenario. Unset skips it. `curie dev soak` sets it itself, so you only set it by hand when driving pytest directly. |
 | `CURIE_SOAK_CONCURRENCY` | `5` | Distinct concurrent Phase-A threads. |
 | `CURIE_SOAK_BATCH` | `3` | Concurrent Phase-B batch-burst threads. |
 | `CURIE_SOAK_RUNS` | `1` | Consecutive runs in one invocation (set `3` for the DoD). |

--- a/tools/ci-retry-gate/tests/test_retry_eligibility.py
+++ b/tools/ci-retry-gate/tests/test_retry_eligibility.py
@@ -149,10 +149,11 @@ NON_INVOCATION_HEADS = frozenset(
 )
 SHELL_KEYWORDS = frozenset({"do", "done", "fi", "then", "else", "esac", "true", "false"})
 
-# The one step in the repository that has the shape of a retry loop without
-# being one: a readiness poll. It waits for a service it did not build to start
-# answering, and it never re invokes a command whose failure would be a defect,
-# so a second iteration cannot bury anything. A readiness poll is not a retry.
+# The steps in the repository that have the shape of a retry loop without
+# being one: readiness polls. Each entry waits for a service it did not build
+# to start answering, and never re invokes a command whose failure would be a
+# defect, so a second iteration cannot bury anything. A readiness poll is not
+# a retry.
 #
 # This is the ONLY escape from the closed world rule 4 draws around in `run:`
 # retry constructs. Every other step in every workflow must either be on
@@ -161,6 +162,17 @@ SHELL_KEYWORDS = frozenset({"do", "done", "fi", "then", "else", "esac", "true", 
 RUN_RETRY_EXEMPT: frozenset[tuple[str, str, str]] = frozenset(
     {
         ("ci.yaml", "python", "Wait for Langfuse to serve"),
+        # The second readiness poll, same shape and same reasoning. `kubectl
+        # port-forward` returns before its listener is established, so the soak
+        # rung waits on a TCP connect to 127.0.0.1:26379 until the forwarder --
+        # a service this repository did not build -- starts answering. The loop
+        # re-attempts a bare connect, never a command whose failure would be a
+        # defect, so a second iteration cannot bury anything.
+        (
+            "nightly-graded-ladder.yaml",
+            "ladder-cluster",
+            "Soak and chaos rung (curie dev soak, REPORT ONLY, #1603/#2056)",
+        ),
     }
 )
 


### PR DESCRIPTION
Wires `tests/soak/` into an automated path for the first time. Closes #2056.

The 332-line cluster scenario had never run anywhere: no workflow, no `curie dev`
subcommand, no `scripts/` reference invoked it, and its last substantive commit
predated the July rename. It was drifting evidence, not a gate.

## What this adds

- **`curie dev soak`** (`cli/src/main.rs` clap surface, `cli/src/commands.rs`
  handler). Sets `CURIE_SOAK=1`, preflights the kube context, then runs
  `tests/soak/test_soak_resilience.py`. `--namespace`, `--pool` and `--runs` each
  default from the harness's own env vars, so an already-exported harness
  environment is honored with no flag.
- **A `SoakOutput` result family** with a committed `cli/schema/soak.schema.json`
  registered in `cli/schema/index.json`. One family covers pass, fail and skip.
- **A report-only soak rung** on the nightly graded ladder's `ladder-cluster` job,
  reusing the kind cluster that job already installs rather than paying for a
  second install.
- **`tests/soak/README.md`** now names the verb and the rung.

No test is deleted or weakened, and the scenario's own assertions are untouched.

## The skip contract is the load-bearing part

With no reachable context, no such namespace, or no reachable `SandboxWarmPool`,
the verb emits `status: "skipped"` with a **named reason** and exits 0. That is
what lets the nightly rung tell "there was nothing to soak against" from "the soak
found something", instead of a false green or a false red.

The reasons distinguish a genuinely absent object (kubectl `NotFound`) from a
cluster that could not be queried at all (expired credentials, RBAC `Forbidden`,
API outage) — the latter quotes kubectl's own error line. Anything not positively
readable as `NotFound` classifies as operational, never as absent: a wrong
"absent" is a verdict about the cluster, while "could not be checked" is a verdict
about the probe, which is all an ambiguous failure supports.

## Proof against a real cluster

All three skip paths, run against k8scratch, each with its own named reason and
exit 0. And a full run that reached pytest and produced the scenario's real
pass/fail JSON:

```json
{"context":"k8scratch","exit_code":1,"namespace":"curie","pool":"curie-runner-pool",
 "reason":"the soak scenario ran and reported failing assertions (pytest exit 1).",
 "runs":1,"status":"failed"}
```

That `failed` is an honest cluster fact, not a verb defect: this install's warm
pool sits at 0 replicas and its sandbox pods crash-loop on a pre-existing
`PluginBundleError: invalid plugin bundle at /unused`, so `pool_ready` times out.
The cluster was left exactly as found.

## Two things a reviewer should judge, not take on trust

Both were flagged by independent spec-vs-impl and scope-creep reviews of this
commit. Neither is papered over.

**1. The uv acquisition can still redden the nightly.** The soak rung's own work
cannot: it captures the verb's exit status and ends in an unconditional `exit 0`,
the #1603 precedent — not `continue-on-error`, which the retry gate reads as a
retry marker on a step that gates repository code.

An earlier revision wrapped `setup-uv` in a retry trio with an endpoint re-probe.
Both reviews independently rejected it: nothing mandated it, the probe did not
cover the surfaces `setup-uv` actually fails on (GitHub API version resolution,
the python-build-standalone download), and it forced a `RETRY_ALLOWLIST` entry in
an unrelated gate's policy table. It is gone. uv is now a plain pinned `uses:`
step.

That leaves the residual: if `setup-uv` fails, the job goes red. The measurement
that decides whether this matters — `ladder-cluster` **already runs nine
unprotected third-party action steps** (`actions/checkout`,
`actions/download-artifact`, `azure/setup-helm`, `docker/setup-buildx-action`,
four `docker/build-push-action`s, and the kind-cluster action), none with a retry,
each able to redden the nightly on a third-party outage. This adds a tenth at the
same risk level rather than a new class of failure. **If you want zero red-risk,
say so and I will move acquisition inside the `exit 0` body** (a pinned
`python3 -m pip install uv==...`), which closes it at the cost of an acquisition
path unlike every other job's.

**2. The cluster proof shows wiring, not phase execution.** The run above reached
pytest against a real cluster and returned the scenario's real result object — but
`exit 1` there is also what a `pool_ready` fixture timeout yields, and that is what
happened. Both k8scratch installs have a warm pool whose sandbox pods crash-loop on
a pre-existing, unrelated `PluginBundleError: invalid plugin bundle at /unused`, so
no pool on this box can reach ready replicas. I scaled each pool up to try, saw the
same crash-loop, and restored both to 0.

So this proves verb → preflight → pytest → cluster end to end. It does **not**
prove the soak's phases (concurrent threads, batch burst, mid-run kill, resume)
ever executed. That needs a cluster with a healthy warm pool — the nightly rung
itself, or a fixed install. Calling that out rather than letting a green-looking
`failed` JSON imply more than it does.

## Follow-ups deliberately left out (this branch is additive-only)

- `soak_capture` duplicates the private `capture` in `cli/src/doctor.rs:2646`.
  Worth hoisting into `ops.rs` beside `run_capture`/`plain` — and this branch's
  copy is the better one, since it preserves the spawn error `doctor.rs` discards.
- The namespace probe could build its argv from `ops::namespace_get_cmd` so the two
  cannot drift on flags.
- The retry gate has no notion of a rung that cannot fail its job, which is why the
  endpoint re-probe above had to be invented. A third eligibility category would let
  the next such rung use `continue-on-error` on both attempts.

## Verification

`cli/` suite green in debug (including 16 new `dev_soak` tests), `cargo fmt --check`,
`cargo clippy -- -D warnings`, ruff, mypy, retry gate + doclint, release gate, and
the UI lint/typecheck/vitest suite. Both command manifests regenerated via the
documented commands and verified idempotent.

Because this touches `.github/workflows/**`, the full Python suite was run rather
than a per-package subset — it caught four gates a focused run would have missed
(two retry-gate rules, two doclint count claims), all fixed here.
