### PR TITLE
Stop the hook partition test colliding with UUID hex

### DIFF
--- a/apps/api/tests/test_hook_partition.py
+++ b/apps/api/tests/test_hook_partition.py
@@ -488,9 +488,10 @@ def test_an_unconfigured_hook_enqueues_the_three_segment_id(
     assert answer.status_code == 200, answer.text
     (turn,) = _queued(valkey, runs_stream)
     assert turn.conversation_id == f"hook:{agent_id}:issues"
-    assert turn.conversation_id.count(":") == 2
-    # The body carried a value a pointer COULD have read. Nothing read it.
-    assert "41" not in turn.conversation_id
+    assert turn.conversation_id.split(":") == ["hook", agent_id, "issues"]
+    # The body carried number 41. A substring search on conversation_id is not
+    # the proof: agent UUIDs are hex and can contain "41", which is what failed
+    # on 4fc0d1c6. The segment list is the proof the payload was not read.
 
 
 def test_a_hook_with_no_entry_in_a_populated_map_is_unpartitioned(


### PR DESCRIPTION
## Summary

Correct a flaky test assertion for unconfigured hook partitioning. The production path and expected conversation id are unchanged; the test now proves the exact three-segment id instead of rejecting payload digits that may legitimately occur inside a UUID.

This architecture-tracked test change must land before the v0.8.0 atlas pin is rebuilt.

## Related issue

Ref #1858

## Fix pin verification

Not applicable: this pull request changes only a test assertion and contains no product files to reverse.

## End-to-end verification

This is not behavior-bearing. It changes no runtime surface, so the six runtime tiers do not apply. Candidate-bound CI on the head commit remains the release gate for the corrected full test suite.

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | No plugin, runner, ACI, or skill-eval behavior changes. | n/a | n/a |
| local | n/a | API runtime behavior is unchanged; only its test assertion changes. | n/a | n/a |
| local-release | n/a | No released binary, image, chart, or version pin changes. | n/a | n/a |
| cluster | n/a | No chart, RBAC, sandbox, or init-container changes. | n/a | n/a |
| live provider | n/a | No model or credential changes. | n/a | n/a |
| external integration | n/a | No third-party API shape changes. | n/a | n/a |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.
- [x] Or: this change is not behavior-bearing, so no tier applies, and the summary says why.

Positive proof: the exact conversation id assertion remains and the segment list must equal `["hook", agent_id, "issues"]`.

Falsifiable negative: a UUID containing the hex digits `41` no longer fails the test, because those digits are not evidence that the request payload was read.

Independent path: `test_a_hook_with_no_entry_in_a_populated_map_is_unpartitioned` still covers an unconfigured hook on a partitioned agent.

## Checklist

- [x] Tests pass for the area touched; the candidate-bound suite reached the policy step after the product tests passed, and this body edit revalidates the policy gate without a product-fix declaration.
- [x] Docs updated if behavior changed. Runtime behavior did not change.
- [x] An ADR is added under `docs/adr/` if this is an architectural decision. No architectural decision was introduced.
