### PR TITLE
docs: label channel-ingress CLEAN and tag every parity seam with its enforcement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -326,37 +326,53 @@ rather than silently diverging.
 
 Sibling-path drift is the dominant historical bug class here: logic or hardening
 lands on one side of a structural seam while its twin keeps the old behavior.
-Known seam pairs:
+Known seam pairs, each tagged with what actually enforces it -- `vector:` (a
+frozen two-sided vector file), `gate:` (a test or CI job), `by construction:` (a
+shared module both sides route through), or `convention` (no gate covers the pair
+as a whole; remembered only):
 
 - worker vs CLI credential forwarding -- `_SDK_PASSTHROUGH_ENV`
   (`apps/worker/src/curie_worker/sandbox/docker.py`) and the CLI picker
   (`cli/src/commands.rs`) can't share code across Python/Rust, so they are frozen
   together in `tests/vectors/model-credential-forwarding.json`.
+  [vector: `tests/vectors/model-credential-forwarding.json`]
 - dispatcher vs CLI approval action ids -- the approval-card action-id constants
   (`apps/dispatcher/src/curie_dispatcher/approval_actions.py`) and the CLI's
   `APPROVE_ACTION_ID_PREFIX` (`cli/src/chat.rs`) can't share code across
   Python/Rust, so they are frozen together in
   `tests/vectors/approval-action-ids.json`.
+  [vector: `tests/vectors/approval-action-ids.json`]
 - API vs worker vs CLI thread-reset SET -- `THREAD_RESET_SET` /
   `THREAD_RESET_INFLIGHT_SET` (`apps/api/src/curie_api/threadreset.py`,
   `apps/worker/src/curie_worker/consumer.py`) and the CLI's `THREAD_RESET_SET`
   (`cli/src/queue.rs`) can't share code across Python/Rust. Operator
   `reset-thread` and `local`/`cluster` eval (#1534) both SADD the same set.
   Frozen in `tests/vectors/thread-reset-set.json`.
+  [vector: `tests/vectors/thread-reset-set.json`]
 - worker vs CLI eval-isolate prefix -- `EVAL_ISOLATE_THREAD_PREFIX`
   (`apps/worker/src/curie_worker/binding.py`) and the CLI copy
   (`cli/src/queue.rs`, stamped in `cli/src/message.rs::run_eval_turns`)
   cannot share code across Python/Rust, so they are frozen together in
   `tests/vectors/eval-memory-isolation.json`.
-- real SDK vs fake model session in the runner (`FakeModelSession`, `runner/src/curie_runner/fake.py`).
-- runs lane vs eval lane stream consumers (`apps/worker/src/curie_worker/consumer.py` vs `eval/stream.py`, both on the shared `stream_consumer.py`).
-- CLI-side vs API-side input validation (validate at the API/persistence boundary, mirror in the CLI).
+  [vector: `tests/vectors/eval-memory-isolation.json`]
+- real SDK vs fake model session in the runner (`FakeModelSession`,
+  `runner/src/curie_runner/fake.py`).
+  [by construction: `runner/src/curie_runner/adapter.py::ModelSession`]
+- runs lane vs eval lane stream consumers (`apps/worker/src/curie_worker/consumer.py`
+  vs `eval/stream.py`, both on the shared `stream_consumer.py`).
+  [by construction: `apps/worker/src/curie_worker/stream_consumer.py`]
+- CLI-side vs API-side input validation (validate at the API/persistence
+  boundary, mirror in the CLI). [convention]
 - `local up` vs `local down` compose profile sets.
+  [gate: `cli/src/local.rs::down_passes_every_up_profile`]
 - `compose.dev.yaml` vs the generated release compose.
+  [by construction: `compose/generate_release_compose.py`]
 - `core` vs `full` compose profiles.
-- `local` vs `cluster` verb pairs (reachability defaults, outcome enums).
-- CLI `--json` DTOs vs the API models they mirror.
-- deploy-time validators vs the runtime loaders that re-parse the same value (share normalization code).
+  [gate: `cli/src/local.rs::compose_file_declares_core_and_full_profiles`]
+- `local` vs `cluster` verb pairs (reachability defaults, outcome enums). [convention]
+- CLI `--json` DTOs vs the API models they mirror. [gate: `cli/tests/api_field_parity.rs`]
+- deploy-time validators vs the runtime loaders that re-parse the same value
+  (share normalization code). [convention]
 
 A PR touching one side of a seam must route the behavior through a shared helper
 both sides call, change both sides in the same PR, or name the sibling in the PR

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -15,7 +15,7 @@ is documentation of where the code already draws the line, not a new abstraction
 | Substrate / SandboxClient | CLEAN | 2 (k8s, docker) | not separately graded | #86, #44 | [Substrate / SandboxClient](interfaces/substrate/INTERFACE.md) |
 | Harness in-proc / ModelSession | CLEAN | 1 + fake | A- | (folds into #25) | [Harness in-proc / ModelSession](interfaces/harness-modelsession/INTERFACE.md) |
 | ACI producer (frozen protocol) | CLEAN, frozen | 1 + reference | A- | #25, #47 | [ACI producer (frozen protocol)](interfaces/aci-producer/INTERFACE.md) |
-| Channel / ingress | SOFT | 1 | B- | #7, #19, #27, #38, #1515 | [Channel / ingress](interfaces/channel-ingress/INTERFACE.md) |
+| Channel / ingress | CLEAN | 2 reply adapters behind the `ReplySink` port (Slack, HTTP) + a second wire ingress producer (Rust CLI) | B- | #7, #19, #27, #38, #1515 | [Channel / ingress](interfaces/channel-ingress/INTERFACE.md) |
 | Channel interaction message | CLEAN | 2 renderers (Slack, terminal) | not separately graded | ADR-0020 | [Channel interaction message](interfaces/channel-interaction/INTERFACE.md) |
 | Model provider / credentials | SOFT | 2 prefix-routed (Anthropic, OpenRouter) + base-URL-selected provider-native endpoints (Zhipu, Moonshot, DeepSeek, Ollama) | not separately graded | #24, #46 | [Model provider / credentials](interfaces/model-provider/INTERFACE.md) |
 | Telemetry / OTEL | SOFT | 1 | B+ | #47, #1817, #1818, #1819 | [Telemetry / OTEL](interfaces/telemetry-otel/INTERFACE.md) |

--- a/docs/interfaces/channel-ingress/INTERFACE.md
+++ b/docs/interfaces/channel-ingress/INTERFACE.md
@@ -1,7 +1,7 @@
 ---
 seam: Channel / ingress
-kind: SOFT
-impls: 1
+kind: CLEAN
+impls: 2 reply adapters behind the `ReplySink` port (Slack, HTTP) + a second wire ingress producer (Rust CLI)
 grade: B-
 vision_row: Communication
 epics:
@@ -16,7 +16,7 @@ order: 4
 
 > Part of the Curie swappable-seam catalog — see the [seam index](../../interfaces.md).
 <!-- BEGIN GENERATED: header (curie dev docs-lint) -->
-> **Kind:** SOFT &nbsp;·&nbsp; **Implementations today:** 1 &nbsp;·&nbsp; **Swap-readiness grade:** B-
+> **Kind:** CLEAN &nbsp;·&nbsp; **Implementations today:** 2 reply adapters behind the `ReplySink` port (Slack, HTTP) + a second wire ingress producer (Rust CLI) &nbsp;·&nbsp; **Swap-readiness grade:** B-
 <!-- END GENERATED: header -->
 
 **Kind legend:** CLEAN = a real `Protocol`/typed port class · SOFT = swap via env/URL/prefix/wire, no code interface · NONE = not built yet.
@@ -270,8 +270,9 @@ incomplete adapter coverage and conformance.
   resolves the required `(kind, address)` pair with uniqueness on that same pair. There is
   no address-only overload or default kind: two adapters can own the same address without
   silently selecting one another's binding.
-- **Still leaks — adapter coverage and conformance.** Slack is the only registered kind, and
-  there is no multi-channel adapter framework or a second adapter proving conformance yet
+- **Still leaks — adapter coverage and conformance.** Slack is the only registered kind:
+  `HttpReplyAdapter` ships as a second adapter behind the port, but there is no
+  multi-channel adapter framework and no second adapter proving conformance yet
   (#27). The routing pair removes the binding ambiguity; it does not by itself implement or
   verify another adapter's ingress and egress behavior.
 


### PR DESCRIPTION
Closes #2053

Two contract catalogs mixed enforced and remembered rows indistinguishably, so an agent reading them paid equal attention to every row. This makes both self-describing.

## 1. channel-ingress was filed `SOFT | 1` against a shipped Protocol

`apps/worker/src/curie_worker/reply_sink.py:124` declares `class ReplySink(Protocol)`, with `SlackReplyAdapter` and `HttpReplyAdapter` behind the kind-dispatching `ReplySinkRouter` (`reply_sink.py:395`), and the Rust CLI mints the `QueuedTurn` wire payload as a second ingress producer (`cli/src/queue.rs`). By the catalog's own kind legend (`docs/interfaces.md:41`, "CLEAN = a real `Protocol`/typed port class draws the line in code") that is CLEAN. This is a description fix, not a request to build a port — the port already exists.

Front-matter now reads `kind: CLEAN` / `impls: 2 reply adapters behind the ReplySink port (Slack, HTTP) + a second wire ingress producer (Rust CLI)`. The seam table and the per-doc header blockquote were regenerated via `bash scripts/check-docs.sh`, not hand-edited. `grade: B-` is unchanged — swap-readiness is a separate judgement and `docs/architecture-vision.md` still grades Communication B-.

## 2. Every parity-seam bullet in AGENTS.md now carries one enforcement tag

The 13 pairs had identical typographic authority while splitting three ways. Each bullet gains one trailing tag — `vector:` / `gate:` / `by construction:` / `convention` — so the prose-only pairs are visible as such. No bullet removed, none reworded (verified: 13 on `origin/next`, 13 here, identical opening text).

| tag | count |
|---|---|
| `vector:` | 4 |
| `gate:` | 3 |
| `by construction:` | 3 |
| `convention` | 3 |

## Reviewer findings, all fixed

A read-only cross-engine (Codex) adversarial pass over the diff raised three, each confirmed against the tree before fixing:

- **High** — the `real SDK vs fake model session` row was first tagged `gate: runner/tests/test_conformance.py`. That overclaims: `runner/src/curie_runner/conformance.py:24` builds `SessionRunner(session_factory=FakeModelSession)` and never instantiates the real `ClaudeAgentSession`, so it does not compare the two paths. Retagged `by construction: runner/src/curie_runner/adapter.py::ModelSession` — which is what actually holds them together, both being `session_factory` values for the same `SessionRunner`.
- **Medium** — the legend defined `convention` as "nothing enforces it", which was too strong: all three such rows have narrow shared-code or partial-gate slices (e.g. `cli/tests/observability_query.rs:223` gates local/cluster grammar for the observability leaves only). Softened to "no gate covers the pair as a whole". Judgement call worth flagging: I kept all three as `convention` rather than promoting one to a qualified `gate:`, because naming a partial gate on one row and not the other two would read as coverage the pair does not have.
- **Medium** — the Known-leakage bullet still said there is "no ... second adapter", contradicting the corrected count. Reworded to acknowledge `HttpReplyAdapter` ships while keeping the leak it reports (no adapter framework, no second adapter proving conformance, #27).

Codex separately confirmed CLEAN is correct, and that the four vector tags, the stream-consumer and release-compose `by construction` tags, both `cli/src/local.rs` profile gates, and the API field-parity gate all check out.

Explicitly out of scope, per the issue: telemetry-otel and triggers were not relabelled. Verified untouched.

## Verification

- `bash scripts/check-docs.sh` — green (generated regions drift-free, every citation resolves)
- `uv run pytest tools/doclint/tests -q` — 135 passed
- every artifact named in a tag exists, and each named test function resolves (`down_passes_every_up_profile`, `compose_file_declares_core_and_full_profiles`, `test_runner_passes_aci_conformance`)

Docs only; no code changed.