### PR TITLE
Warn on dead channel bindings in surfaces output

### DIFF
--- a/cli/schema/baseline/surfaces.schema.json
+++ b/cli/schema/baseline/surfaces.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schemas.curietech.ai/cli/surfaces/v1.json",
+  "$id": "https://schemas.curietech.ai/cli/surfaces/v1.1.json",
   "title": "curie <tier> surfaces --json",
-  "description": "The agent-facing payload of `curie <tier> surfaces <agent>`: the dry-run plan, or the agent's surface bindings as the API stored them (ADR-0118). An agent holds one or more bindings, and each is the PAIR `kind` + `address`, never a bare address: a consumer must be able to read the ingress kind without guessing it. `changed` is false for a list (no `--add`/`--remove` passed) and true when this invocation wrote, so a consumer can tell \"this is what it is\" from \"this is what it now is\" without diffing.",
+  "description": "The agent-facing payload of `curie <tier> surfaces <agent>`: the dry-run plan, or the agent's surface bindings as the API stored them (ADR-0118). The `kind` and `address` values are preserved verbatim, including the raw stored address. An agent holds one or more bindings, and each is the PAIR `kind` + `address`, never a bare address: a consumer must be able to read the ingress kind without guessing it. `changed` is false for a list (no `--add`/`--remove` passed) and true when this invocation wrote, so a consumer can tell \"this is what it is\" from \"this is what it now is\" without diffing.",
   "$defs": {
     "dryRun": {
       "type": "object",
@@ -32,6 +32,10 @@
         },
         "address": {
           "type": "string"
+        },
+        "warning": {
+          "type": "string",
+          "description": "Present only when the CLI proves that the stored binding never resolves."
         }
       },
       "required": [

--- a/cli/schema/index.json
+++ b/cli/schema/index.json
@@ -37,7 +37,7 @@
       "result": "ChannelsOutput",
       "kind": "CliOutput",
       "schema": "surfaces.schema.json",
-      "version": "1.0"
+      "version": "1.1"
     },
     {
       "result": "ChartCheckOutput",

--- a/cli/schema/surfaces.schema.json
+++ b/cli/schema/surfaces.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schemas.curietech.ai/cli/surfaces/v1.json",
+  "$id": "https://schemas.curietech.ai/cli/surfaces/v1.1.json",
   "title": "curie <tier> surfaces --json",
-  "description": "The agent-facing payload of `curie <tier> surfaces <agent>`: the dry-run plan, or the agent's surface bindings as the API stored them (ADR-0118). An agent holds one or more bindings, and each is the PAIR `kind` + `address`, never a bare address: a consumer must be able to read the ingress kind without guessing it. `changed` is false for a list (no `--add`/`--remove` passed) and true when this invocation wrote, so a consumer can tell \"this is what it is\" from \"this is what it now is\" without diffing.",
+  "description": "The agent-facing payload of `curie <tier> surfaces <agent>`: the dry-run plan, or the agent's surface bindings as the API stored them (ADR-0118). The `kind` and `address` values are preserved verbatim, including the raw stored address. An agent holds one or more bindings, and each is the PAIR `kind` + `address`, never a bare address: a consumer must be able to read the ingress kind without guessing it. `changed` is false for a list (no `--add`/`--remove` passed) and true when this invocation wrote, so a consumer can tell \"this is what it is\" from \"this is what it now is\" without diffing.",
   "$defs": {
     "dryRun": {
       "type": "object",
@@ -32,6 +32,10 @@
         },
         "address": {
           "type": "string"
+        },
+        "warning": {
+          "type": "string",
+          "description": "Present only when the CLI proves that the stored binding never resolves."
         }
       },
       "required": [

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -3006,6 +3006,32 @@ pub enum ChannelsOutput {
     },
 }
 
+const CHANNEL_BINDING_NEVER_RESOLVES_WARNING: &str =
+    "mentions match on the channel ID, not the name, so this binding never resolves";
+
+#[derive(Serialize)]
+struct ChannelBindingPresentation<'a> {
+    kind: &'a str,
+    address: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    warning: Option<&'static str>,
+}
+
+fn channel_binding_never_resolves(kind: &str, address: &str) -> bool {
+    kind == "slack" && address.trim_start().starts_with('#')
+}
+
+fn channel_binding_presentation(
+    binding: &crate::api::ChannelBinding,
+) -> ChannelBindingPresentation<'_> {
+    ChannelBindingPresentation {
+        kind: &binding.kind,
+        address: &binding.address,
+        warning: channel_binding_never_resolves(&binding.kind, &binding.address)
+            .then_some(CHANNEL_BINDING_NEVER_RESOLVES_WARNING),
+    }
+}
+
 impl crate::ui::CliOutput for ChannelsOutput {
     fn to_json(&self) -> serde_json::Value {
         match self {
@@ -3014,14 +3040,21 @@ impl crate::ui::CliOutput for ChannelsOutput {
                 agent,
                 channels,
                 changed,
-            } => serde_json::json!({
-                "agent": agent,
-                // Delegated to `Serialize` rather than hand-picked: a
-                // hand-projection could drop a field and would need its own
-                // `emits` declaration for the emit-parity gate (cli/CLAUDE.md).
-                "surfaces": serde_json::to_value(channels).unwrap_or(serde_json::Value::Null),
-                "changed": changed,
-            }),
+            } => {
+                let surfaces = channels
+                    .iter()
+                    .map(channel_binding_presentation)
+                    .collect::<Vec<_>>();
+                serde_json::json!({
+                    "agent": agent,
+                    // Serialize each CLI presentation row wholesale. The raw
+                    // API mirror remains unchanged while this output adds its
+                    // optional, derived warning without hand-projecting fields.
+                    "surfaces": serde_json::to_value(surfaces)
+                        .unwrap_or(serde_json::Value::Null),
+                    "changed": changed,
+                })
+            }
         }
     }
 
@@ -3044,6 +3077,14 @@ impl crate::ui::CliOutput for ChannelsOutput {
                         .join(", ")
                 };
                 ui.payload(&format!("surfaces for {agent}{verb}: {bound}"));
+                for channel in channels {
+                    if channel_binding_never_resolves(&channel.kind, &channel.address) {
+                        ui.warn(&format!(
+                            "{}:{}: {CHANNEL_BINDING_NEVER_RESOLVES_WARNING}",
+                            channel.kind, channel.address
+                        ));
+                    }
+                }
             }
         }
     }
@@ -6713,7 +6754,7 @@ pub async fn observability(open: bool) -> Result<crate::observability::Observabi
 /// and never routes -- a silently dead binding. Fail the deploy up front
 /// instead.
 fn validate_channel_binding(kind: &str, address: &str) -> Result<()> {
-    if kind == "slack" && address.trim_start().starts_with('#') {
+    if channel_binding_never_resolves(kind, address) {
         return Err(crate::exit::usage(format!(
             "slack channel {address:?} is a name, not an ID: real Slack events carry the \
              channel ID (e.g. C0EXAMPLE1) and the worker routes on it, so a #name binding \

--- a/cli/tests/cli_output_variants.rs
+++ b/cli/tests/cli_output_variants.rs
@@ -230,14 +230,20 @@ fn registry() -> BTreeMap<&'static str, Vec<VariantJson>> {
         "ChannelsOutput",
         samples![
             "DryRun" => ChannelsOutput::DryRun(plan()),
-            // Two bindings, because one is the case that hid the whole defect
-            // class: a payload shaped right for a single binding says nothing
-            // about the plural surface ADR-0118 introduced.
+            // The single Done sample keeps plural coverage while deliberately
+            // exercising both row shapes for the optional signal: a legacy stored name
+            // carries a warning, while a valid channel ID omits it.
             "Done" => ChannelsOutput::Done {
                 agent: "a".to_string(),
                 channels: vec![
-                    ChannelBinding { kind: "slack".to_string(), address: "C0EXAMPLE1".to_string() },
-                    ChannelBinding { kind: "slack".to_string(), address: "C0EXAMPLE2".to_string() },
+                    ChannelBinding {
+                        kind: "slack".to_string(),
+                        address: "#legacy-alerts".to_string(),
+                    },
+                    ChannelBinding {
+                        kind: "slack".to_string(),
+                        address: "C0EXAMPLE1".to_string(),
+                    },
                 ],
                 changed: true,
             },
@@ -558,6 +564,42 @@ fn every_variant_of_every_cli_output_enum_has_a_sample() {
         "variant(s) {failures:?} are declared in cli/src but have no sample (or name a \
          variant that no longer exists), so their `to_json()` never reaches the schema \
          gate (#965)"
+    );
+}
+
+#[test]
+fn channels_done_sample_covers_warning_present_and_absent_rows() {
+    let registry = registry();
+    let samples = registry
+        .get("ChannelsOutput")
+        .expect("ChannelsOutput has variant samples");
+    let done = samples
+        .iter()
+        .find_map(|(variant, value)| (*variant == "Done").then_some(value))
+        .expect("ChannelsOutput::Done has a sample");
+    let surfaces = done["surfaces"]
+        .as_array()
+        .expect("ChannelsOutput::Done carries surfaces");
+
+    let legacy = surfaces
+        .iter()
+        .find(|binding| binding["address"] == "#legacy-alerts")
+        .expect("the sample carries the legacy binding");
+    assert!(
+        legacy
+            .get("warning")
+            .and_then(serde_json::Value::as_str)
+            .is_some(),
+        "the legacy row must carry a string warning: {legacy}"
+    );
+
+    let valid = surfaces
+        .iter()
+        .find(|binding| binding["address"] == "C0EXAMPLE1")
+        .expect("the sample carries the valid binding");
+    assert!(
+        valid.get("warning").is_none(),
+        "the valid row must omit the warning field: {valid}"
     );
 }
 

--- a/cli/tests/surfaces_verb.rs
+++ b/cli/tests/surfaces_verb.rs
@@ -33,6 +33,8 @@ const AGENT_ID: &str = "44444444-4444-4444-4444-444444444444";
 const AGENT_NAME: &str = "deal-desk";
 /// The binding the fixture agent already holds.
 const BOUND: &str = "C0EXAMPLE1";
+/// A binding stored by a release that predated channel-ID validation.
+const LEGACY_NAME: &str = "#legacy-alerts";
 /// A second binding, the one `--add` asks for.
 const OTHER: &str = "C0EXAMPLE2";
 
@@ -76,6 +78,17 @@ fn api(write: impl Fn(&str, &str) -> Option<Response> + Send + Sync + 'static) -
             // "no write happened" check vacuous (see `cli/tests/api_deploy.rs`).
             _ => Response::json(200, &agent_json(&[BOUND, OTHER])),
         }
+    })
+}
+
+/// A read-only platform fixture for rows already stored by an older release.
+fn read_api(channels: &[&str]) -> MockServer {
+    let agent = agent_json(channels);
+    let agents = format!("[{agent}]");
+    serve(move |req| match (req.method.as_str(), req.path.as_str()) {
+        ("GET", "/agents") => Response::json(200, &agents),
+        ("GET", p) if p == format!("/agents/{AGENT_ID}") => Response::json(200, &agent),
+        _ => Response::json(405, r#"{"detail":"read-only fixture"}"#),
     })
 }
 
@@ -318,6 +331,86 @@ fn local_surfaces_list_reads_without_writing() {
 }
 
 #[test]
+fn local_surfaces_legacy_name_warns_without_failing_human_or_json() {
+    let server = read_api(&[LEGACY_NAME, BOUND]);
+
+    let human = run(&[
+        "local",
+        "surfaces",
+        AGENT_NAME,
+        "--api-url",
+        &server.base_url,
+        "--api-key",
+        "k",
+    ]);
+    assert_eq!(
+        human.code,
+        0,
+        "a legacy binding must remain readable: {}",
+        human.output()
+    );
+    assert!(
+        human.stdout.contains(LEGACY_NAME),
+        "the human result must preserve the stored address: {}",
+        human.output()
+    );
+    let human_output = human.output();
+    assert!(
+        human_output.contains("warn") && human_output.contains("slack:#legacy-alerts"),
+        "the human result must mark the exact dead binding: {human_output}"
+    );
+    assert!(
+        human_output.contains("mentions match on the channel ID")
+            && human_output.contains("never resolves"),
+        "the warning must explain the runtime consequence: {human_output}"
+    );
+
+    let json = run(&[
+        "local",
+        "surfaces",
+        AGENT_NAME,
+        "--api-url",
+        &server.base_url,
+        "--api-key",
+        "k",
+        "--json",
+    ]);
+    assert_eq!(
+        json.code,
+        0,
+        "a legacy binding must remain readable under --json: {}",
+        json.output()
+    );
+    let value: serde_json::Value = serde_json::from_str(json.stdout.trim()).unwrap_or_else(|e| {
+        panic!(
+            "--json must emit exactly one JSON object: {e}; stdout: {}",
+            json.stdout
+        )
+    });
+    let surfaces = value["surfaces"]
+        .as_array()
+        .expect("the JSON result must carry a surfaces array");
+    let legacy = surfaces
+        .iter()
+        .find(|binding| binding["address"] == LEGACY_NAME)
+        .expect("the JSON result must preserve the legacy address");
+    assert_eq!(legacy["kind"], "slack");
+    assert_eq!(legacy["address"], LEGACY_NAME);
+    let warning = legacy["warning"]
+        .as_str()
+        .expect("the dead binding must carry a machine-readable warning");
+    assert!(
+        warning.contains("mentions match on the channel ID") && warning.contains("never resolves"),
+        "the JSON warning must explain the same consequence: {warning}"
+    );
+    assert!(
+        writes(&server).is_empty(),
+        "human and JSON reads must issue no write, got {:?}",
+        writes(&server)
+    );
+}
+
+#[test]
 fn local_surfaces_json_carries_the_agent_and_its_bindings() {
     let server = api(|m, p| {
         (m == "POST" && p == channels_path())
@@ -478,6 +571,76 @@ fn cluster_surfaces_add_posts_the_pair_to_the_subresource() {
     let body: serde_json::Value =
         serde_json::from_slice(&posts[0].body).expect("the add body should be JSON");
     assert_eq!(body, serde_json::json!({"kind": "slack", "address": OTHER}));
+}
+
+#[test]
+fn cluster_surfaces_valid_channel_id_has_no_warning_human_or_json() {
+    let server = read_api(&[BOUND]);
+
+    let human = run(&[
+        "cluster",
+        "surfaces",
+        AGENT_NAME,
+        "--api-url",
+        &server.base_url,
+        "--api-key",
+        "k",
+    ]);
+    assert_eq!(
+        human.code,
+        0,
+        "a valid binding must remain readable: {}",
+        human.output()
+    );
+    assert!(
+        human.stdout.contains(BOUND),
+        "the human result must preserve the channel ID: {}",
+        human.output()
+    );
+    let human_output = human.output();
+    assert!(
+        !human_output.to_ascii_lowercase().contains("warn")
+            && !human_output.contains("never resolves"),
+        "a valid binding must not produce a human warning: {human_output}"
+    );
+
+    let json = run(&[
+        "cluster",
+        "surfaces",
+        AGENT_NAME,
+        "--api-url",
+        &server.base_url,
+        "--api-key",
+        "k",
+        "--json",
+    ]);
+    assert_eq!(
+        json.code,
+        0,
+        "a valid binding must remain readable under --json: {}",
+        json.output()
+    );
+    let value: serde_json::Value = serde_json::from_str(json.stdout.trim()).unwrap_or_else(|e| {
+        panic!(
+            "--json must emit exactly one JSON object: {e}; stdout: {}",
+            json.stdout
+        )
+    });
+    let binding = value["surfaces"]
+        .as_array()
+        .and_then(|surfaces| surfaces.first())
+        .expect("the JSON result must carry the valid binding");
+    assert_eq!(binding["kind"], "slack");
+    assert_eq!(binding["address"], BOUND);
+    assert!(
+        binding.get("warning").is_none(),
+        "a valid binding must omit the JSON warning field: {binding}"
+    );
+    assert!(
+        writes(&server).is_empty(),
+        "human and JSON reads must issue no write, got {:?}",
+        writes(&server)
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Keep tolerant `surfaces` reads successful for legacy Slack `#name` bindings while making the dead runtime binding explicit: human output warns, and each affected JSON binding carries an optional `warning` field. Raw `kind` and `address` remain unchanged; valid channel IDs remain warning-free.

## Related issue

Closes #1928

## Fix pin verification

Fix pin: cli/tests/surfaces_verb.rs::local_surfaces_legacy_name_warns_without_failing_human_or_json

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | No plugin packaging, runner loop, ACI event, eval, or check behavior changed. | n/a | n/a |
| local | required | A CLI result and its `--json` shape changed. | fake | `CURIE_E2E_TIERS=local CURIE_BIN=/home/theconnman/.cache/curie-cargo/1928-next-9d7055a5/debug/curie curie dev e2e-ladder` on the final tree at `be2ca42e`: `LADDER PASS (tiers: local)`. |
| local-release | n/a | No released binary/image identity, install path, version pin, or release compose changed. | n/a | n/a |
| cluster | n/a | No chart, RBAC, security context, network policy, sandbox claim, or init container changed; the cluster CLI dispatch leaf is covered by the built-binary integration test. | n/a | n/a |
| live provider | n/a | No model routing, credentials, provider auth, token, or cost behavior changed. | n/a | n/a |
| external integration | n/a | No Slack or other third-party API contract changed; this is presentation of an already stored binding. | n/a | n/a |

- [x] Every required tier above names its exact command, the commit/tree it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path. Live local API/SQL proof showed `#legacy-alerts` preserved with warning and exit 0 in human and JSON modes; restoring `C0EXAMPLE1` removed both warning signals while keeping exit 0.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.
- [ ] Or: this change is not behavior-bearing, so no tier applies, and the summary says why.

## Checklist

- [x] Tests pass for the area I touched: `cargo fmt --check`; `cargo clippy --all-targets -- -D warnings`; full debug `cargo test` with `CI_REQUIRE_VALKEY_TESTS=1`; schema and surfaces integration suites.
- [x] Docs checked. Existing guides already require channel IDs; the versioned CLI schema documents the new optional field, so no prose doc is stale.
- [x] No ADR is needed; this applies the detector and preserves the existing tolerant-read and deploy-validation contracts.

`curie dev verify-fix-pin HEAD cli/tests/surfaces_verb.rs::local_surfaces_legacy_name_warns_without_failing_human_or_json` passed the candidate, failed the exact test after reversing product hunks, and reported `PINNED`.