### PR TITLE
Collect the shipped SRE-bot connectors' tests

### DIFF
--- a/examples/tests/test_shipped_connector_tests_are_collected.py
+++ b/examples/tests/test_shipped_connector_tests_are_collected.py
@@ -1,0 +1,108 @@
+"""Every ``build:``-declaring connector's own tests are actually collected.
+
+The failure this exists to stop, from the install it actually happened on:
+
+The four shipped SRE-bot connectors (``tempo``, ``k8s-write``, ``k8s-scale``,
+``self-upgrade``) each ship a ``test_server.py`` next to their Dockerfile. The
+tests exist, they are green when run by hand, and CI builds and
+``release.yaml`` publishes the images regardless of whether anyone ever runs
+them. But ``pyproject.toml``'s ``[tool.pytest.ini_options] testpaths`` never
+listed the directory those tests live in, so ``uv run pytest -q`` never
+collected a single one of them, on any branch. Nothing reported it -- the
+suite was green, coverage looked fine, and a shipped, published connector's
+tests simply never ran (#2093).
+
+The check is deliberately shallow and cheap: it reads the declaration and
+``pyproject.toml``, not pytest's actual collection output. It cannot tell you
+whether a collected test currently passes. It is parametrized per
+build-declaring connector, not per test file, so a connector that ships zero
+test files fails its own case instead of silently vanishing from the
+parametrize list while its siblings keep the suite green -- the same
+per-connector requirement its sibling check,
+``test_build_connectors_are_published.py``, already holds every build-declaring
+connector to. For each connector it tells you whether the connector shipped at
+least one test file at all, and whether every one of those files falls under a
+configured ``testpaths`` root, which is the failure that stayed invisible.
+"""
+
+import tomllib
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO = Path(__file__).resolve().parents[2]
+EXAMPLES = REPO / "examples"
+PYPROJECT = REPO / "pyproject.toml"
+
+
+def _build_connector_dirs() -> list[Path]:
+    """Directories of every connector declaring ``build:`` in its bundle."""
+
+    found: list[Path] = []
+    for declaration in sorted(EXAMPLES.glob("*/connectors.yaml")):
+        parsed = yaml.safe_load(declaration.read_text(encoding="utf-8")) or {}
+        for name, spec in (parsed.get("connectors") or {}).items():
+            if isinstance(spec, dict) and "build" in spec:
+                found.append(declaration.parent / "connectors" / str(name))
+    return found
+
+
+def _test_files() -> list[Path]:
+    """Every ``test_*.py`` file directly inside a build-declaring connector dir."""
+
+    files: list[Path] = []
+    for connector_dir in _build_connector_dirs():
+        if connector_dir.is_dir():
+            files.extend(sorted(connector_dir.glob("test_*.py")))
+    return files
+
+
+def _testpaths() -> list[str]:
+    with PYPROJECT.open("rb") as handle:
+        parsed = tomllib.load(handle)
+    return list(parsed["tool"]["pytest"]["ini_options"]["testpaths"])
+
+
+def _is_collected(test_file: Path, testpaths: list[str]) -> bool:
+    relative = test_file.relative_to(REPO)
+    for root in testpaths:
+        root_path = Path(root)
+        if relative == root_path or root_path in relative.parents:
+            return True
+    return False
+
+
+def test_the_discovery_finds_connectors_and_test_files() -> None:
+    # A guard that silently finds nothing passes vacuously, which is the
+    # failure mode of every check that reads files by glob.
+    assert _build_connector_dirs(), "no build-declaring connectors found: check the glob"
+    assert _test_files(), "no connector test files found: check the glob"
+
+
+@pytest.mark.parametrize(
+    "connector_dir",
+    _build_connector_dirs(),
+    ids=[str(d.relative_to(REPO)) for d in _build_connector_dirs()],
+)
+def test_a_connectors_tests_are_collected(connector_dir: Path) -> None:
+    relative_dir = connector_dir.relative_to(REPO)
+    test_files = sorted(connector_dir.glob("test_*.py")) if connector_dir.is_dir() else []
+    assert test_files, (
+        f"'{relative_dir}' declares build: but ships no test_*.py file. The "
+        f"image it produces is still built by CI and published by "
+        f"release.yaml with no test signal at all. Add a test_*.py file next "
+        f"to the connector's Dockerfile, or drop the connector."
+    )
+
+    testpaths = _testpaths()
+    for test_file in test_files:
+        relative_file = test_file.relative_to(REPO)
+        assert _is_collected(test_file, testpaths), (
+            f"'{relative_file}' exists but falls under none of "
+            f"pyproject.toml's testpaths {testpaths!r}, so `uv run pytest -q` "
+            f"never collects it. The image it tests is still built by CI and "
+            f"published by release.yaml with no test signal at all. Add the "
+            f"connector's directory (or its bundle's connectors root) to "
+            f"testpaths."
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,6 +169,12 @@ testpaths = [
     "compose/tests",
     "release/tests",
     "examples/tests",
+    # The four shipped SRE-bot connectors (tempo, k8s-write, k8s-scale,
+    # self-upgrade) are built by CI and published by release.yaml, but each
+    # ships its own test_server.py outside every collection root above -- so
+    # the only CI signal on the shipped images was "the Dockerfile builds"
+    # (#2093).
+    "examples/sre-bot/connectors",
     "tools/doclint/tests",
     "tools/wire-tolerance-gate/tests",
     "tools/ci-retry-gate/tests",


### PR DESCRIPTION
The four SRE-bot connectors CI builds and `release.yaml` publishes — `tempo`,
`k8s-write`, `k8s-scale`, `self-upgrade` — each ship a `test_server.py` that sat
outside every `testpaths` root, so `uv run pytest -q` never ran one of them on any
branch. The only CI signal on four published images was "the Dockerfile builds".

- `pyproject.toml`: adds `examples/sre-bot/connectors` to `testpaths`. This PR's CI run
  collected 82 more tests than `main` does (5197 passed, 14 skipped).
- `examples/tests/test_shipped_connector_tests_are_collected.py`: the regression pin. Discovers
  every `build:`-declaring connector from `examples/*/connectors.yaml` (same shape as its sibling
  `test_build_connectors_are_published.py`), parses `testpaths` with `tomllib`, and asserts
  per connector that it ships at least one `test_*.py` and that each falls under a configured
  root. Parametrized over connector dirs, not test files, so a connector that loses its tests
  cannot silently produce zero cases.

## Regression pin

`examples/tests/test_shipped_connector_tests_are_collected.py::test_a_connectors_tests_are_collected`

Both arms demonstrated by execution, not by reading:

- Removing the `testpaths` entry turns it red on all four connectors (4 failed, 1 passed).
- Hiding one connector's `test_server.py` turns it red on that connector alone (1 failed, 4 passed).

It is declared here in prose rather than in the machine-parsed form, because
`tools/fix-pin-ci/check.py`'s selector regex accepts only `apps/*/tests/`,
`packages/*/tests/`, `cli/tests/*.rs` and `charts/curie/ci/*.sh`. A pin whose test lives in
`examples/tests/` cannot be expressed, so the declared form fails the gate outright. Widening
that regex is a CI-gate change outside this issue's Scope; flagging it rather than doing it
here.

## No ruff/mypy change, deliberately

The issue's Scope asks that `ruff`/`mypy` treat these files consistently with the rest of the
tree. `uv run ruff check .` already scans whole-tree and passes on all four files unmodified;
`[tool.mypy] files=` lists only `src` directories and excludes all of `examples/`, so adding
these paths would make them *less* consistent, not more. The adversarial scope reviewer was
asked to judge that reasoning and agreed.

## Stated limit — this does not close #1947

That defect survives its own suite because the test double is `def patch(self, path, body)`,
which accepts the positional call the pinned `httpx==0.28.1` client rejects. Collecting the
tests makes them run; it does not make them faithful. The fidelity gap is separate work.

## Done-check

- [x] Failing tests committed before implementation — **N/A** (quick tier)
- [x] All edits performed by delegated sub-agents; driver ran only git/test/validation commands
- [x] No broadened return types — **N/A** (no function signatures changed)
- [x] Agent-router Code Reviewer completed (codex / gpt-5.6-sol). One P2: the pin's vacuity
      guard was global, so a connector losing its test files produced no parametrized case and
      the pin stayed green. Fixed by parametrizing per connector dir and asserting each ships
      tests; re-validated
- [x] Agent-router Scope Reviewer completed (codex / gpt-5.6-sol): both hunks trace to this
      issue, no passengers, no unaddressed AC
- [x] Sibling-path parity: `examples/sre-bot/connectors` is the only bundle with a
      `connectors/` tree shipping tests; the pin is driven by the `build:` declaration, so a
      future bundle is covered without a config edit
- [x] Guard demonstration: both arms of the new guard executed against violating inputs, not
      read
- [x] Consolidation pass — **N/A** (quick tier)
- [x] Security Reviewer — **N/A** (not flagged)
- [x] Observable verification — **N/A** (no user-facing surface)
- [x] E2E — **N/A** (no deployed surface)
- [x] `uv run ruff check .` clean, `uv run mypy` clean (240 files), full suite green in CI

Ref #2093
