### PR TITLE
fix: bound the shipped SRE-bot Tempo memory and query envelope

### DIFF
--- a/charts/curie/ci/observability-stack-assertions.sh
+++ b/charts/curie/ci/observability-stack-assertions.sh
@@ -128,6 +128,7 @@ assert mutation in {
     "scrape-source-label-inert",
     "scrape-source-label-conditional",
     "scrape-namespace-names",
+    "tempo-envelope",
 }, f"unknown mutation {mutation!r}"
 
 assets = Path(assets_path)
@@ -305,7 +306,7 @@ expected_requests = {
     "Grafana": (grafana_docs, "grafana/grafana", Decimal(128)),
     "Loki": (loki_docs, "grafana/loki", Decimal(256)),
     "Alloy": (alloy_docs, "grafana/alloy", Decimal(128)),
-    "Tempo": (tempo_docs, "grafana/tempo", Decimal(192)),
+    "Tempo": (tempo_docs, "grafana/tempo", Decimal(256)),
     "Prometheus": (prometheus_docs, "prometheus/prometheus", Decimal(512)),
     "kube-state-metrics": (prometheus_docs, "kube-state-metrics", Decimal(64)),
     "node-exporter": (prometheus_docs, "node-exporter", Decimal(32)),
@@ -316,7 +317,7 @@ for label, (docs, image, expected) in expected_requests.items():
     actual = memory_mi(at(container, "resources", "requests", "memory"))
     assert actual == expected, f"{label} request must be {expected}Mi, got {actual}Mi"
     request_total += actual
-assert request_total == 1312, f"observability request total must be 1312Mi, got {request_total}Mi"
+assert request_total == 1376, f"observability request total must be 1376Mi, got {request_total}Mi"
 
 # The chart image itself closes the Loki config and image version contract.
 _, _, loki_container = image_container(loki_docs, "grafana/loki", "Loki")
@@ -693,6 +694,154 @@ assert len(tempo_configs) == 1, f"expected one Tempo config, found {len(tempo_co
 protocols = at(tempo_configs[0], "distributor", "receivers", "otlp", "protocols")
 assert at(protocols, "grpc", "endpoint") == "0.0.0.0:4317"
 assert at(protocols, "http", "endpoint") == "0.0.0.0:4318"
+
+# --- #2059: the shipped Tempo single-pod memory and query envelope ----------
+# Tempo runs as one pod under a fixed cgroup limit, but every knob it does not
+# set explicitly keeps Tempo's DISTRIBUTED-deployment default. Each bound below
+# is a measured value from #2059, not a preference; a "cleanup" that removes one
+# restores a default sized for a fleet of queriers.
+tempo_config = tempo_configs[0]
+tempo_pod_template = at(tempo_statefulsets[0], "spec", "template")
+
+if mutation == "tempo-envelope":
+    # Negative control: reproduce the exact pre-#2059 shape (bounds absent, no
+    # GOMEMLIMIT) so every assertion below is proved to be load bearing.
+    tempo_config.get("storage", {}).get("trace", {}).pop("pool", None)
+    tempo_config.get("storage", {}).get("trace", {}).pop("search", None)
+    tempo_config.get("ingester", {}).pop("max_block_bytes", None)
+    tempo_config.get("ingester", {}).pop("complete_block_timeout", None)
+    tempo_config.pop("querier", None)
+    tempo_config.pop("query_frontend", None)
+    tempo_config.pop("overrides", None)
+    tempo_container.pop("env", None)
+
+
+def tempo_bound(path):
+    """Read a dotted path out of the shipped Tempo config."""
+    return at(tempo_config, *path.split("."))
+
+
+# Adding a knob is one line here. Values are the measured #2059 envelope.
+tempo_envelope_bounds = {
+    "ingester.max_block_bytes": 52428800,
+    "ingester.complete_block_timeout": "5m",
+    "querier.max_concurrent_queries": 4,
+    "storage.trace.pool.max_workers": 20,
+    "storage.trace.pool.queue_depth": 2000,
+    "storage.trace.search.read_buffer_count": 8,
+    "storage.trace.search.read_buffer_size_bytes": 1048576,
+    "storage.trace.search.prefetch_trace_count": 100,
+    "query_frontend.max_outstanding_per_tenant": 200,
+    "query_frontend.trace_by_id.query_shards": 8,
+    "query_frontend.search.concurrent_jobs": 40,
+    "query_frontend.search.target_bytes_per_job": 26214400,
+    "query_frontend.search.max_duration": "24h",
+    "query_frontend.search.max_result_limit": 50,
+    "overrides.defaults.global.max_bytes_per_trace": 2000000,
+    "overrides.defaults.read.max_bytes_per_tag_values_query": 1000000,
+}
+for tempo_key, tempo_expected in tempo_envelope_bounds.items():
+    tempo_actual = tempo_bound(tempo_key)
+    assert tempo_actual == tempo_expected, (
+        f"Tempo envelope (#2059): {tempo_key} must be {tempo_expected!r}, "
+        f"got {tempo_actual!r}"
+    )
+
+tempo_request_mi = memory_mi(at(tempo_container, "resources", "requests", "memory"))
+tempo_limit_mi = memory_mi(at(tempo_container, "resources", "limits", "memory"))
+tempo_limit_bytes = tempo_limit_mi * 1024 * 1024
+
+# THE ASSERTION THAT ENCODES THE DEFECT (#2059). Tempo sizes its block-read
+# buffers as max_workers * read_buffer_count * read_buffer_size_bytes. At Tempo's
+# distributed defaults that is 400 * 32 * 1MiB = 12.8 GiB of worst-case read
+# buffers against the 512Mi limit the stack shipped -- 2560% of the pod, which is
+# why ordinary operator reads OOM-killed it (exit 137). Bounded it is
+# 20 * 8 * 1MiB = 160 MiB, 15.6% of the 1Gi limit. Raising the limit alone would
+# not close this: no small-node ceiling is above 12.8 GiB, so the product must be
+# bounded RELATIVE to the limit, not merely below some fixed number.
+tempo_read_buffer_bytes = (
+    tempo_bound("storage.trace.pool.max_workers")
+    * tempo_bound("storage.trace.search.read_buffer_count")
+    * tempo_bound("storage.trace.search.read_buffer_size_bytes")
+)
+tempo_read_buffer_ceiling = tempo_limit_bytes / 4
+assert tempo_read_buffer_bytes <= tempo_read_buffer_ceiling, (
+    "Tempo worst-case read buffers (#2059) must stay within 25% of "
+    f"resources.limits.memory: max_workers * read_buffer_count * "
+    f"read_buffer_size_bytes = {tempo_read_buffer_bytes} bytes vs a ceiling of "
+    f"{tempo_read_buffer_ceiling} bytes (25% of {tempo_limit_mi}Mi), which is "
+    f"{tempo_read_buffer_bytes / tempo_limit_bytes * 100:.1f}% of the limit"
+)
+
+
+def go_memory_bytes(text):
+    """Parse a Go GOMEMLIMIT quantity (Go accepts only binary suffixes)."""
+    match = re.fullmatch(r"([0-9]+)(B|KiB|MiB|GiB|TiB)?", str(text))
+    assert match, f"unsupported GOMEMLIMIT quantity {text!r}"
+    factors = {"": 1, "B": 1, "KiB": 1024, "MiB": 1024**2,
+               "GiB": 1024**3, "TiB": 1024**4}
+    return Decimal(match.group(1)) * factors[match.group(2) or ""]
+
+
+# GOMEMLIMIT is a SOFT Go heap ceiling; the cgroup limit is the hard one. It must
+# sit below the cgroup limit with real headroom because it governs only the Go
+# heap -- goroutine stacks, runtime overhead and the mmap'd block reads Tempo
+# does on the search path are outside it. 80% is that headroom (#2059).
+tempo_env = {
+    entry.get("name"): entry.get("value")
+    for entry in tempo_container.get("env", [])
+    if isinstance(entry, dict)
+}
+assert "GOMEMLIMIT" in tempo_env, (
+    "Tempo container must set GOMEMLIMIT (#2059) so the Go GC learns the cgroup "
+    f"ceiling instead of being killed at it, env has {sorted(tempo_env)}"
+)
+tempo_gomemlimit_bytes = go_memory_bytes(tempo_env["GOMEMLIMIT"])
+assert tempo_gomemlimit_bytes < tempo_limit_bytes, (
+    f"GOMEMLIMIT {tempo_env['GOMEMLIMIT']} ({tempo_gomemlimit_bytes} bytes) must "
+    f"be strictly below resources.limits.memory ({tempo_limit_bytes} bytes)"
+)
+assert tempo_gomemlimit_bytes <= Decimal("0.80") * tempo_limit_bytes, (
+    f"GOMEMLIMIT {tempo_env['GOMEMLIMIT']} ({tempo_gomemlimit_bytes} bytes) must "
+    f"leave non-heap headroom: at most 80% of resources.limits.memory "
+    f"({Decimal('0.80') * tempo_limit_bytes} bytes), got "
+    f"{tempo_gomemlimit_bytes / tempo_limit_bytes * 100:.1f}%"
+)
+
+assert tempo_request_mi <= tempo_limit_mi, (
+    f"Tempo resources.requests.memory ({tempo_request_mi}Mi) must not exceed "
+    f"resources.limits.memory ({tempo_limit_mi}Mi)"
+)
+
+# The server-side search bound mirrors the shipped connector's own clamp, turning
+# a client-side courtesy into a boundary that also binds a direct Grafana Explore
+# query. Read the connector rather than restating 50 here: if MAX_LIMIT moves,
+# this fails instead of silently disagreeing (#2059).
+tempo_connector_source = (assets.parent / "connectors" / "tempo" / "server.py").read_text()
+tempo_max_limit_match = re.search(
+    r"^MAX_LIMIT\s*=\s*([0-9]+)\s*$", tempo_connector_source, re.MULTILINE
+)
+assert tempo_max_limit_match, (
+    "could not read MAX_LIMIT from examples/sre-bot/connectors/tempo/server.py"
+)
+tempo_connector_max_limit = int(tempo_max_limit_match.group(1))
+assert tempo_bound("query_frontend.search.max_result_limit") == tempo_connector_max_limit, (
+    "Tempo query_frontend.search.max_result_limit must equal the shipped "
+    f"connector's MAX_LIMIT ({tempo_connector_max_limit}) in "
+    "examples/sre-bot/connectors/tempo/server.py, got "
+    f"{tempo_bound('query_frontend.search.max_result_limit')} -- the two move together"
+)
+
+# kubectl apply of a changed ConfigMap updates the map and leaves the StatefulSet
+# pod running its old config. Without a changed pod-template annotation nothing
+# rolls, so every assertion above passes while the live Tempo keeps the
+# unbounded defaults: a green change that fixes nothing (#2059).
+tempo_config_checksum = at(tempo_pod_template, "metadata", "annotations", "checksum/config")
+assert tempo_config_checksum != "v1", (
+    "Tempo pod template checksum/config must be bumped off 'v1' so the "
+    "StatefulSet actually rolls onto the bounded ConfigMap (#2059)"
+)
+# --- end #2059 envelope -----------------------------------------------------
 
 datasources = []
 for _, _, parsed, _ in embedded_yaml(grafana_docs):

--- a/cli/src/examples.rs
+++ b/cli/src/examples.rs
@@ -23,10 +23,17 @@ const OBSERVABILITY_NAMESPACE: &str = "observability";
 const CURIE_NAMESPACE: &str = "curie";
 #[allow(dead_code)] // clap --release default; kept beside the other identity names
 const CURIE_RELEASE: &str = "curie";
-// The issue text says 1248Mi, but its seven exact appendix requests total
-// 1312Mi on one node once the enabled 64Mi kube-state-metrics request is
-// included. Alloy and node exporter add 160Mi on every Ready schedulable node.
-const FIXED_MEMORY_MIB: u128 = 1152;
+// #1765's issue text says 1248Mi, but its seven exact appendix requests totalled
+// 1312Mi on one node once the enabled 64Mi kube-state-metrics request was
+// included. #2059 then raised Tempo's own request from 192Mi to 256Mi to fit the
+// measured single-pod envelope in examples/sre-bot/observability/tempo.yaml, so
+// the one-node total is now 1376Mi. FIXED_MEMORY_MIB is the part that lands once
+// per install regardless of node count: Grafana 128 + Loki 256 + Prometheus 512
+// + kube-state-metrics 64 + Tempo 256 = 1216Mi. Alloy 128 and node exporter 32
+// are DaemonSets, so PER_READY_NODE_MEMORY_MIB adds their 160Mi on every Ready
+// schedulable node -- 1216 + 160 = 1376Mi on a single-node cluster. Move the
+// Tempo term here whenever tempo.yaml's resources.requests.memory moves.
+const FIXED_MEMORY_MIB: u128 = 1216;
 const PER_READY_NODE_MEMORY_MIB: u128 = 160;
 const MIB: u128 = 1024 * 1024;
 const HELM_TIMEOUT: &str = "10m";
@@ -2169,7 +2176,10 @@ mod tests {
     #[test]
     fn memory_quantities_cover_the_kubernetes_shapes_used_by_nodes_and_pods() {
         assert_eq!(parse_memory_quantity("1Gi").unwrap(), 1024 * 1024 * 1024);
-        assert_eq!(parse_memory_quantity("1343488Ki").unwrap(), 1312 * MIB);
+        // 1409024Ki is the exact one-node required total (FIXED_MEMORY_MIB
+        // 1216 + PER_READY_NODE_MEMORY_MIB 160 = 1376Mi) in the Ki form a node
+        // reports allocatable memory in; it moved from 1312Mi under #2059.
+        assert_eq!(parse_memory_quantity("1409024Ki").unwrap(), 1376 * MIB);
         assert_eq!(parse_memory_quantity("500M").unwrap(), 500_000_000);
         assert_eq!(parse_memory_quantity("1e6").unwrap(), 1_000_000);
     }

--- a/cli/tests/example_sre_bot_install.rs
+++ b/cli/tests/example_sre_bot_install.rs
@@ -22,7 +22,7 @@ use support::{serve, MockServer, Response};
 
 const OBSERVABILITY_NAMESPACE: &str = "observability";
 const FIRST_RELEASE: &str = "grafana";
-const REQUIRED_MIB: u64 = 1312;
+const REQUIRED_MIB: u64 = 1376;
 const TEMPO_TAGGED_IMAGE: &str = "ghcr.io/curie-eng/curie-sre-bot-tempo:0.8.0";
 const REGISTRY_INDEX: &str =
     r#"{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","manifests":[]}"#;
@@ -818,7 +818,7 @@ fn managed_stack_pods(node_name: &str) -> Vec<Value> {
             node_name,
             OBSERVABILITY_NAMESPACE,
             json!({"app.kubernetes.io/name": "tempo"}),
-            "192Mi",
+            "256Mi",
         ),
         labeled_pod(
             "prometheus-server",
@@ -860,7 +860,7 @@ fn assert_reached_helm_upgrade(fixture: &Fixture, output: &Output) -> String {
     );
     let text = shown(output);
     assert!(
-        !text.contains("required 1312Mi") && !text.contains("available"),
+        !text.contains(&format!("required {REQUIRED_MIB}Mi")) && !text.contains("available"),
         "a cluster with enough capacity must not be refused: {text}"
     );
     text
@@ -1808,7 +1808,7 @@ fn optional_slack_channel_reaches_the_same_embedded_deploy_path() {
 
 #[test]
 fn exactly_required_memory_and_more_both_pass_the_capacity_gate() {
-    for memory in ["1343488Ki", "2Gi"] {
+    for memory in ["1409024Ki", "2Gi"] {
         let fixture = Fixture::new(nodes(vec![node("node-a", memory, true)]), pods(vec![]));
         let output = fixture.run(&[]);
         assert_reached_helm_upgrade(&fixture, &output);
@@ -1827,17 +1827,17 @@ fn rerun_replaces_managed_stack_requests_but_keeps_unrelated_observability_load(
     ));
 
     let fixture = Fixture::new(
-        nodes(vec![node("node-a", "1376Mi", true)]),
+        nodes(vec![node("node-a", "1440Mi", true)]),
         pods(items.clone()),
     );
     let output = fixture.run(&[]);
     assert_reached_helm_upgrade(&fixture, &output);
 
-    let insufficient = Fixture::new(nodes(vec![node("node-a", "1375Mi", true)]), pods(items));
+    let insufficient = Fixture::new(nodes(vec![node("node-a", "1439Mi", true)]), pods(items));
     let output = insufficient.run(&[]);
     let text = assert_refused_before_helm(&insufficient, &output);
     assert!(
-        text.contains("required 1312Mi") && text.contains("available 1311Mi"),
+        text.contains("required 1376Mi") && text.contains("available 1375Mi"),
         "only managed stack requests may be replaced during a rerun: {text}"
     );
 }
@@ -1846,8 +1846,8 @@ fn rerun_replaces_managed_stack_requests_but_keeps_unrelated_observability_load(
 fn daemonset_requests_scale_the_required_memory_per_ready_node() {
     let enough = Fixture::new(
         nodes(vec![
-            node("node-a", "736Mi", true),
-            node("node-b", "736Mi", true),
+            node("node-a", "768Mi", true),
+            node("node-b", "768Mi", true),
         ]),
         pods(vec![]),
     );
@@ -1856,15 +1856,15 @@ fn daemonset_requests_scale_the_required_memory_per_ready_node() {
 
     let insufficient = Fixture::new(
         nodes(vec![
-            node("node-a", "736Mi", true),
-            node("node-b", "735Mi", true),
+            node("node-a", "768Mi", true),
+            node("node-b", "767Mi", true),
         ]),
         pods(vec![]),
     );
     let output = insufficient.run(&[]);
     let text = assert_refused_before_helm(&insufficient, &output);
     assert!(
-        text.contains("required 1472Mi") && text.contains("available 1471Mi"),
+        text.contains("required 1536Mi") && text.contains("available 1535Mi"),
         "two Ready nodes must reserve two Alloy and node exporter requests: {text}"
     );
 }
@@ -1906,7 +1906,7 @@ fn capacity_aggregates_ready_nodes_and_only_their_nonterminal_scheduled_pods() {
     let fixture = Fixture::new(
         nodes(vec![
             node("ready-a", "1Gi", true),
-            node("ready-b", "1248Mi", true),
+            node("ready-b", "1312Mi", true),
             node("not-ready", "16Gi", false),
         ]),
         pods(items),
@@ -1949,20 +1949,20 @@ fn restartable_init_scheduling_semantics_pin_the_exact_five_hundred_mib_request(
     // restartable sidecars. Summing every init container would overcount;
     // taking only the largest single init container would undercount.
     let exact = Fixture::new(
-        nodes(vec![node("node-a", "1812Mi", true)]),
+        nodes(vec![node("node-a", "1876Mi", true)]),
         pods(vec![restartable_init_pod()]),
     );
     let exact_output = exact.run(&[]);
     assert_reached_helm_upgrade(&exact, &exact_output);
 
     let one_short = Fixture::new(
-        nodes(vec![node("node-a", "1811Mi", true)]),
+        nodes(vec![node("node-a", "1875Mi", true)]),
         pods(vec![restartable_init_pod()]),
     );
     let one_short_output = one_short.run(&[]);
     let text = assert_refused_before_helm(&one_short, &one_short_output);
     assert!(
-        text.contains("required 1312Mi") && text.contains("available 1311Mi"),
+        text.contains("required 1376Mi") && text.contains("available 1375Mi"),
         "the capacity boundary must use the effective 500Mi pod request: {text}"
     );
 }
@@ -2425,6 +2425,115 @@ fn custom_targets_thread_through_helm_kubectl_manifests_secret_discovery_and_con
     );
 }
 
+/// #2059: the memory envelope and query bounds must survive the INSTALLER path.
+///
+/// The OOM in #2059 was in the SHIPPED manifest -- the bytes the CLI actually
+/// hands `kubectl apply`, not the bytes sitting in
+/// `examples/sre-bot/observability/tempo.yaml`. The CLI embeds that file with
+/// `include_bytes!` (`cli/src/examples.rs`) and rewrites it before applying, so
+/// asserting the source file alone proves nothing about what an operator gets.
+/// This test reads the captured applied document and asserts the envelope there.
+///
+/// It parses the applied YAML rather than substring-matching, so a bound
+/// restored to Tempo's distributed default fails on the VALUE rather than
+/// passing a presence check. Each bound has its own assertion and its own
+/// message, so a failure names the key that went missing.
+#[test]
+fn applied_tempo_manifest_carries_the_bounded_memory_envelope() {
+    let fixture = Fixture::with_modes(
+        nodes(vec![node("node-a", "4Gi", true)]),
+        pods(vec![]),
+        "success",
+        "success",
+        "success",
+    );
+    let output = fixture.run(&[]);
+    let shown_output = shown(&output);
+    assert!(
+        output.status.success(),
+        "the default install must complete: {shown_output}"
+    );
+
+    let tempo = fixture.applied_file("tempo.yaml");
+    let documents = manifest_documents(&tempo);
+
+    let stateful_set = documents
+        .iter()
+        .find(|document| document["kind"] == "StatefulSet")
+        .unwrap_or_else(|| panic!("applied Tempo must carry a StatefulSet: {tempo}"));
+    let container = &stateful_set["spec"]["template"]["spec"]["containers"][0];
+
+    let resources = &container["resources"];
+    assert_eq!(
+        resources["requests"]["memory"], "256Mi",
+        "the applied Tempo container must request the measured 256Mi that the installer \
+         capacity preflight sums (REQUIRED_MIB {REQUIRED_MIB}Mi): {tempo}"
+    );
+    assert_eq!(
+        resources["limits"]["memory"], "1Gi",
+        "the applied Tempo container must carry the measured 1Gi hard ceiling: {tempo}"
+    );
+
+    let gomemlimit = container["env"]
+        .as_array()
+        .map(|env| env.to_vec())
+        .unwrap_or_default()
+        .into_iter()
+        .find(|entry| entry["name"] == "GOMEMLIMIT");
+    assert_eq!(
+        gomemlimit.as_ref().map(|entry| entry["value"].clone()),
+        Some(Value::from("600MiB")),
+        "the applied Tempo container must carry the soft Go heap ceiling below its cgroup \
+         limit; without it the Go GC never learns the cgroup ceiling: {tempo}"
+    );
+
+    let annotations = &stateful_set["spec"]["template"]["metadata"]["annotations"];
+    assert_ne!(
+        annotations["checksum/config"], "v1",
+        "checksum/config must move off v1, or `kubectl apply` updates the ConfigMap and the \
+         running pod keeps the unbounded config: {tempo}"
+    );
+
+    let config_map = documents
+        .iter()
+        .find(|document| document["kind"] == "ConfigMap")
+        .unwrap_or_else(|| panic!("applied Tempo must carry a ConfigMap: {tempo}"));
+    let config_text = config_map["data"]["tempo.yaml"]
+        .as_str()
+        .unwrap_or_else(|| panic!("applied Tempo ConfigMap must carry tempo.yaml: {tempo}"));
+    let config: Value = serde_norway::from_str(config_text)
+        .unwrap_or_else(|error| panic!("applied Tempo config must be valid YAML: {error}"));
+
+    // The read-buffer product `max_workers * read_buffer_count *
+    // read_buffer_size_bytes` is the structural defect: at Tempo's distributed
+    // defaults it is 12.8 GiB against a small-node limit. These two bounds are
+    // what turn it into a ceiling rather than a threshold.
+    assert_eq!(
+        config["storage"]["trace"]["pool"]["max_workers"], 20,
+        "storage.trace.pool.max_workers must be bounded (Tempo's distributed default is 400): \
+         {config_text}"
+    );
+    assert_eq!(
+        config["storage"]["trace"]["search"]["read_buffer_count"], 8,
+        "storage.trace.search.read_buffer_count must be bounded (default 32): {config_text}"
+    );
+    assert_eq!(
+        config["ingester"]["max_block_bytes"], 52428800,
+        "ingester.max_block_bytes must be bounded; the 500 MiB default lets one in-memory head \
+         block reach the whole pod limit: {config_text}"
+    );
+    assert_eq!(
+        config["query_frontend"]["search"]["concurrent_jobs"], 40,
+        "query_frontend.search.concurrent_jobs must be bounded (default 1000) so search fan-out \
+         does not scale with block count: {config_text}"
+    );
+    assert_eq!(
+        config["query_frontend"]["search"]["max_result_limit"], 50,
+        "query_frontend.search.max_result_limit must mirror MAX_LIMIT in \
+         examples/sre-bot/connectors/tempo/server.py; the two move together: {config_text}"
+    );
+}
+
 #[test]
 fn selected_observability_namespace_is_the_only_managed_capacity_namespace() {
     let mut items = managed_stack_pods("node-a");
@@ -2436,17 +2545,17 @@ fn selected_observability_namespace_is_the_only_managed_capacity_namespace() {
         "64Mi",
     ));
     let fixture = Fixture::new(
-        nodes(vec![node("node-a", "1376Mi", true)]),
+        nodes(vec![node("node-a", "1440Mi", true)]),
         pods(items.clone()),
     );
     let default_output = fixture.run(&[]);
     assert_reached_helm_upgrade(&fixture, &default_output);
 
-    let custom = Fixture::new(nodes(vec![node("node-a", "1376Mi", true)]), pods(items));
+    let custom = Fixture::new(nodes(vec![node("node-a", "1440Mi", true)]), pods(items));
     let output = custom.run(&custom_target_args());
     let text = assert_refused_before_helm(&custom, &output);
     assert!(
-        text.contains("required 1312Mi"),
+        text.contains("required 1376Mi"),
         "load in the default observability namespace must count when targeting soak-obs: {text}"
     );
 }

--- a/examples/sre-bot/observability/tempo.yaml
+++ b/examples/sre-bot/observability/tempo.yaml
@@ -16,10 +16,37 @@ data:
               endpoint: 0.0.0.0:4317
             http:
               endpoint: 0.0.0.0:4318
+    # --- #2059: the single-pod memory and query envelope ---------------------
+    # Every knob below that is not a path or a receiver exists because Tempo's
+    # default for it is a DISTRIBUTED-deployment default, and this stack runs
+    # ONE Tempo pod under the container limit set on the StatefulSet further
+    # down. These are values measured in #2059, not preferences: removing one
+    # as "redundant configuration" restores a default sized for a fleet of
+    # queriers and re-opens the OOM. The three that mattered most:
+    #   * ingester.max_block_bytes defaulted to 500MiB, so one in-memory head
+    #     block could reach the entire 512MiB container the stack shipped with.
+    #     That is the ordinary-traffic OOM (exit 137, CONSTRAINT_MEMCG) on its
+    #     own, with no query load at all.
+    #   * storage.trace.pool.max_workers defaulted to 400 and
+    #     storage.trace.search.read_buffer_count to 32, so worst-case read
+    #     buffers were 400 x 32 x 1MiB = 12.8 GiB against the pod's whole
+    #     limit. No plausible small-node limit is above 12.8 GiB, so this
+    #     product has to be BOUNDED; it cannot be out-run by raising memory.
+    #   * No GOMEMLIMIT, so the Go GC never learned there was a ceiling at all
+    #     (see the container env below).
     ingester:
       max_block_duration: 5m
+      # Cut the head block at 50MiB rather than the 500MiB default, and let a
+      # cut block leave memory after 5m rather than the default 15m, so
+      # complete blocks do not stack up behind the head block.
+      max_block_bytes: 52428800
+      complete_block_timeout: 5m
     compactor:
       compaction:
+        # NOT a memory knob, despite driving block count. 48h is the evidence
+        # window the SRE bot reads; shortening it destroys evidence rather than
+        # saving memory. Query fan-out over these blocks is bounded under
+        # query_frontend.search below instead.
         block_retention: 48h
     storage:
       trace:
@@ -28,6 +55,51 @@ data:
           path: /var/tempo/blocks
         wal:
           path: /var/tempo/wal
+        pool:
+          # 20 x 8 x 1MiB = 160MiB of worst-case read buffers, down from the
+          # default 400 x 32 x 1MiB = 12.8 GiB. Keep max_workers and
+          # search.read_buffer_count below in step: their product with
+          # read_buffer_size_bytes is the number that has to stay small
+          # relative to resources.limits.memory.
+          max_workers: 20
+          queue_depth: 2000
+        search:
+          read_buffer_count: 8
+          read_buffer_size_bytes: 1048576
+          # Default 1000. Prefetching a thousand traces to satisfy a query
+          # bounded at 50 results (see max_result_limit) is pure headroom loss.
+          prefetch_trace_count: 100
+    querier:
+      # Default 20. One pod serves both the read and write path here, so cap
+      # concurrent query execution well below the ingest path's needs.
+      max_concurrent_queries: 4
+    query_frontend:
+      max_outstanding_per_tenant: 200
+      trace_by_id:
+        query_shards: 8
+      search:
+        concurrent_jobs: 40
+        target_bytes_per_job: 26214400
+        # Must never exceed compactor.compaction.block_retention above. The
+        # 168h default was longer than retention, so a single search could fan
+        # out over the entire store.
+        max_duration: 24h
+        # Mirrors MAX_LIMIT in examples/sre-bot/connectors/tempo/server.py.
+        # That connector clamps client-side; setting the identical number here
+        # turns its courtesy cap into a server-side boundary that also binds a
+        # direct Grafana Explore query. The two move together -- chart CI fails
+        # if they disagree.
+        max_result_limit: 50
+    overrides:
+      defaults:
+        global:
+          # A single pathological trace cannot grow past 2MB in the ingester...
+          max_bytes_per_trace: 2000000
+        read:
+          # ...and a tag-values lookup (Grafana renders these on every Explore
+          # dropdown) cannot materialise more than 1MB of values.
+          max_bytes_per_tag_values_query: 1000000
+    # --- end #2059 envelope --------------------------------------------------
     usage_report:
       reporting_enabled: false
 ---
@@ -66,7 +138,12 @@ spec:
       labels:
         app.kubernetes.io/name: tempo
       annotations:
-        checksum/config: v1
+        # Bump this on EVERY change to the ConfigMap above. `kubectl apply` of a
+        # changed ConfigMap updates the map and leaves this StatefulSet's pod
+        # running its OLD config -- nothing rolls unless the pod template itself
+        # changes. Without the bump the #2059 bounds are present in git and
+        # absent from the cluster: every assertion passes and nothing is fixed.
+        checksum/config: v2
     spec:
       securityContext:
         fsGroup: 10001
@@ -79,6 +156,17 @@ spec:
         - name: tempo
           image: docker.io/grafana/tempo:2.9.1@sha256:290414580eabd1bde91f22e4a4579242fe77377c425223f45d59b8ad1540ce3c
           args: ["-config.file=/conf/tempo.yaml"]
+          env:
+            # A SOFT ceiling that the Go GC respects, set deliberately BELOW the
+            # hard cgroup limit in resources.limits.memory below: the runtime
+            # collects harder as it approaches this, instead of being killed at
+            # the cgroup limit with no warning. It governs the Go HEAP only --
+            # goroutine stacks, runtime overhead and the mmap'd block reads
+            # Tempo does on the search path all sit outside it -- which is why
+            # it is ~59% of the limit rather than just under it. Move it and
+            # resources.limits.memory together (#2059).
+            - name: GOMEMLIMIT
+              value: "600MiB"
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -99,9 +187,18 @@ spec:
           resources:
             requests:
               cpu: 50m
-              memory: 192Mi
+              # requests.memory is what the installer's capacity preflight sums:
+              # FIXED_MEMORY_MIB in cli/src/examples.rs must move in lockstep,
+              # or the preflight admits a node that cannot hold the stack.
+              # 256Mi/1Gi is the #2059 measured envelope (594MiB peak at
+              # soak scale, ~290 blocks) and matches the 256Mi request Loki --
+              # the comparable ingest+query backend in this same install --
+              # already ships.
+              memory: 256Mi
             limits:
-              memory: 512Mi
+              # The HARD cgroup ceiling; GOMEMLIMIT above must stay below it
+              # with real headroom for the non-heap memory it does not cover.
+              memory: 1Gi
           volumeMounts:
             - name: config
               mountPath: /conf

--- a/examples/tests/test_sre_bot_observability_runtime.py
+++ b/examples/tests/test_sre_bot_observability_runtime.py
@@ -183,7 +183,59 @@ def _render_loki_config(values: dict[str, Any]) -> str:
     return rendered
 
 
-def _tempo_config_and_image() -> tuple[str, str]:
+@dataclass(frozen=True)
+class TempoEnvelope:
+    """The memory envelope the shipped Tempo manifest declares (#2059).
+
+    Both fields are read from `examples/sre-bot/observability/tempo.yaml` and are
+    deliberately optional: the manifest is the single source of truth, so a
+    number restated here would keep the runtime regression green against a
+    reverted manifest. `None` means the manifest does not declare it, which the
+    regression asserts on by name rather than silently substituting a default.
+    """
+
+    memory_limit: str | None
+    gomemlimit: str | None
+
+
+_QUANTITY_SUFFIXES: tuple[tuple[str, int], ...] = (
+    # Longest suffix first: "Mi" must win over "M", "MiB" over "M".
+    ("KiB", 1024),
+    ("MiB", 1024**2),
+    ("GiB", 1024**3),
+    ("TiB", 1024**4),
+    ("Ki", 1024),
+    ("Mi", 1024**2),
+    ("Gi", 1024**3),
+    ("Ti", 1024**4),
+    ("B", 1),
+    ("k", 1000),
+    ("K", 1000),
+    ("M", 1000**2),
+    ("G", 1000**3),
+    ("T", 1000**4),
+)
+
+
+def _memory_bytes(value: str) -> int:
+    """Parse a Kubernetes quantity (`512Mi`) or a Go `GOMEMLIMIT` (`600MiB`).
+
+    One parser for both because the regression compares them against each other
+    and against `docker inspect`, which speaks only bytes.
+    """
+
+    text = value.strip()
+    assert text, "memory quantity must not be empty"
+    for suffix, multiplier in _QUANTITY_SUFFIXES:
+        if text.endswith(suffix):
+            digits = text[: -len(suffix)].strip()
+            assert digits.isdigit(), f"unparsable memory quantity {value!r}"
+            return int(digits) * multiplier
+    assert text.isdigit(), f"unparsable memory quantity {value!r}"
+    return int(text)
+
+
+def _tempo_config_and_image() -> tuple[str, str, TempoEnvelope]:
     documents = [
         document
         for document in yaml.safe_load_all((OBSERVABILITY / "tempo.yaml").read_text())
@@ -191,8 +243,22 @@ def _tempo_config_and_image() -> tuple[str, str]:
     ]
     config = next(document for document in documents if document["kind"] == "ConfigMap")
     stateful_set = next(document for document in documents if document["kind"] == "StatefulSet")
-    image = stateful_set["spec"]["template"]["spec"]["containers"][0]["image"]
-    return config["data"]["tempo.yaml"], image
+    container = stateful_set["spec"]["template"]["spec"]["containers"][0]
+    image = container["image"]
+    limit = container.get("resources", {}).get("limits", {}).get("memory")
+    gomemlimit = next(
+        (
+            entry.get("value")
+            for entry in container.get("env") or []
+            if entry.get("name") == "GOMEMLIMIT"
+        ),
+        None,
+    )
+    envelope = TempoEnvelope(
+        memory_limit=None if limit is None else str(limit),
+        gomemlimit=None if gomemlimit is None else str(gomemlimit),
+    )
+    return config["data"]["tempo.yaml"], image, envelope
 
 
 def _collector_config_and_image() -> tuple[dict[str, Any], str]:
@@ -211,14 +277,14 @@ def _collector_config_and_image() -> tuple[dict[str, Any], str]:
     return config, chart_values["otelCollector"]["image"]
 
 
-def _write_runtime_configs(root: Path) -> dict[str, str]:
+def _write_runtime_configs(root: Path) -> tuple[dict[str, str], TempoEnvelope]:
     root.mkdir(parents=True, exist_ok=True)
 
     loki_values = _load_yaml(OBSERVABILITY / "loki-values.yaml")
     (root / "loki.yaml").write_text(_render_loki_config(loki_values))
     (root / "loki-runtime.yaml").write_text("{}\n")
 
-    tempo_config, tempo_image = _tempo_config_and_image()
+    tempo_config, tempo_image, tempo_envelope = _tempo_config_and_image()
     (root / "tempo.yaml").write_text(tempo_config)
 
     grafana_values = _load_yaml(OBSERVABILITY / "grafana-values.yaml")
@@ -230,12 +296,13 @@ def _write_runtime_configs(root: Path) -> dict[str, str]:
 
     collector_config, collector_image = _collector_config_and_image()
     (root / "collector.yaml").write_text(yaml.safe_dump(collector_config, sort_keys=False))
-    return {
+    images = {
         "loki": f"docker.io/grafana/loki:{loki_values['loki']['image']['tag']}",
         "tempo": tempo_image,
         "grafana": f"docker.io/grafana/grafana:{grafana_values['image']['tag']}",
         "collector": collector_image,
     }
+    return images, tempo_envelope
 
 
 def _request(
@@ -316,6 +383,9 @@ class RuntimeStack:
     front_network: str
     back_network: str
     tempo_probe_container: str
+    tempo_container: str
+    tempo_url: str
+    tempo_envelope: TempoEnvelope
     grafana_url: str
     loki_url: str
     collector_url: str
@@ -383,8 +453,15 @@ def _run_container(
     named_volumes: tuple[tuple[str, str], ...] = (),
     publish: tuple[int, ...] = (),
     args: tuple[str, ...] = (),
+    memory: str | None = None,
 ) -> None:
     command = ["run", "-d", "--name", name, "--network", network]
+    if memory is not None:
+        # `--memory-swap` must be given AND equal to `--memory`: left unset the
+        # container gets swap equal to twice the limit, so it can swap instead
+        # of being OOM killed and any assertion about running "under the
+        # configured limit" becomes vacuous (#2059 edge case E8).
+        command.extend(["--memory", memory, "--memory-swap", memory])
     for alias in aliases:
         command.extend(["--network-alias", alias])
     for key in env or {}:
@@ -428,13 +505,16 @@ def _start_runtime_stack(root: Path) -> RuntimeStack:
     suffix = uuid.uuid4().hex[:10]
     front = f"curie-obs-front-{suffix}"
     back = f"curie-obs-back-{suffix}"
-    images = _write_runtime_configs(root)
+    images, tempo_envelope = _write_runtime_configs(root)
     tempo_connector_image = f"curie-sre-bot-tempo-runtime:{suffix}"
     stack = RuntimeStack(
         suffix=suffix,
         front_network=front,
         back_network=back,
         tempo_probe_container="",
+        tempo_container="",
+        tempo_url="",
+        tempo_envelope=tempo_envelope,
         grafana_url="",
         loki_url="",
         collector_url="",
@@ -502,18 +582,34 @@ def _populate_runtime_stack(stack: RuntimeStack, root: Path, images: dict[str, s
     _wait_http(f"{stack.loki_url}/ready", loki)
 
     tempo = _container_name("tempo", suffix)
+    # Run Tempo AT the envelope the shipped manifest declares (#2059). Started
+    # unbounded, this stack proves only that Tempo works, never that it works
+    # inside the cgroup it actually ships with. The values come from the
+    # manifest, never from a literal here, so a reverted manifest cannot leave
+    # this test green.
+    envelope = stack.tempo_envelope
+    tempo_env = None if envelope.gomemlimit is None else {"GOMEMLIMIT": envelope.gomemlimit}
+    tempo_memory = (
+        None if envelope.memory_limit is None else str(_memory_bytes(envelope.memory_limit))
+    )
     _run_container(
         stack,
         tempo,
         images["tempo"],
         back,
         aliases=("tempo.observability.svc.cluster.local",),
+        env=tempo_env,
         volumes=((root / "tempo.yaml", "/conf/tempo.yaml"),),
         named_volumes=((tempo_data, "/var/tempo"),),
         publish=(3200,),
         args=("-config.file=/conf/tempo.yaml",),
+        memory=tempo_memory,
     )
+    stack.tempo_container = tempo
     tempo_url = f"http://127.0.0.1:{_host_port(tempo, 3200)}"
+    stack.tempo_url = tempo_url
+    # Load bearing twice over: a config the pinned Tempo rejects never becomes
+    # ready, so this is also the version skew gate for every bound #2059 adds.
     _wait_http(f"{tempo_url}/ready", tempo)
 
     grafana = _container_name("grafana", suffix)
@@ -757,3 +853,292 @@ def test_tempo_connector_returns_a_real_curie_span_through_grafanas_uid_proxy(
         {"query": '{ resource.service.name = "curie-runtime-absent" }', "limit": 20},
     )
     assert json.loads(missing).get("traces") == []
+
+
+# #2059: the shipped Tempo ran every memory knob at Tempo's DISTRIBUTED
+# deployment defaults inside a single 512Mi pod, and ordinary ingest plus
+# bounded operator reads got the container kernel OOM killed (exit 137,
+# `Memory cgroup out of memory: Killed process (tempo)`,
+# `constraint=CONSTRAINT_MEMCG`), taking the evidence path down with it.
+#
+# Peak memory is driven by BLOCK COUNT, near independently of how much trace
+# data each block holds: search fans out over every block the ingester still
+# holds. Measured on this exact pinned image and config
+# (`.projects/plans/task-2059-tempo-query-oom.evidence.md`), two tiny traces per
+# wave with the ingester flushed between waves:
+#
+#   shipped config @512Mi, no GOMEMLIMIT, 150 blocks -> OOMKilled exit 137, 205/216 reads failed
+#   shipped config @512Mi, no GOMEMLIMIT, 290 blocks -> OOMKilled exit 137, 216/216 reads failed
+#   bounded config @1Gi + GOMEMLIMIT=600MiB, 290 blocks -> peak 549 MiB, 216/216 reads OK
+#   bounded config @1Gi + GOMEMLIMIT=600MiB, 450 blocks -> peak 685 MiB, 216/216 reads OK
+#
+# 150 is the SMALLEST measured block count that killed the unbounded shipped
+# envelope, and a wave of two ten span traces is enough to cut a block, so this
+# target stands on a load that demonstrably killed the pre-fix configuration
+# while keeping the run to a couple of minutes.
+#
+# The assertion direction is deliberate and is NOT reversible. The shipped
+# configuration is non monotonic near its ceiling -- 150 blocks died, 220 blocks
+# survived at a peak of exactly 512 MiB -- so whether it crosses is GC timing
+# dependent. A test asserting the UNBOUNDED config OOMs would be flaky; this one
+# asserts the CONFIGURED envelope SURVIVES.
+TEMPO_BLOCK_TARGET = 150
+# Each wave is two traces of ten spans. Cutting a block needs data in the head
+# block at flush time, and the collector batches, so a wave occasionally cuts
+# nothing; the cap bounds the retry rather than the target.
+TEMPO_INGEST_WAVE_CAP = TEMPO_BLOCK_TARGET * 3
+TEMPO_INGEST_DEADLINE_SECONDS = 420
+TEMPO_TRACES_PER_WAVE = 2
+TEMPO_TOOL_SPANS_PER_TRACE = 8
+# A block is only cut if the head block holds data when `/flush` arrives, and
+# the wave crosses the shipped collector, whose `batch` processor holds spans for
+# its 200ms default before exporting to Tempo. Flushing faster than that cuts
+# empty blocks: measured, 450 unpaced waves produced 16 blocks, 150 paced waves
+# produce one block each. This is the pacing, not a sleep-and-hope.
+TEMPO_COLLECTOR_SETTLE_SECONDS = 0.3
+# The read sequence an operator ran during the soak, repeated. Each round is one
+# search at the connector ceiling, three whole trace fetches, one tag listing and
+# one tag VALUES lookup -- the last is the only call that reaches
+# `overrides.defaults.read.max_bytes_per_tag_values_query`.
+TEMPO_READ_ROUNDS = 8
+TEMPO_TRACE_FETCHES_PER_ROUND = 3
+# Mirrors `examples/sre-bot/connectors/tempo/server.py:69` MAX_LIMIT. The
+# connector clamps to it, so this is the widest search an operator can drive
+# through the real MCP path.
+TEMPO_CONNECTOR_MAX_LIMIT = 50
+
+
+def _inspect(container: str) -> dict[str, Any]:
+    result = _docker("inspect", container, timeout=60)
+    payload = json.loads(result.stdout)
+    assert payload, f"docker inspect returned nothing for {container}"
+    return payload[0]
+
+
+def _tempo_block_count(container: str) -> int:
+    """Count the blocks Tempo has cut, which is what search fan out scales with.
+
+    A plain `ls | wc -l` on the tenant directory overcounts: Tempo's compactor
+    also writes tenant bookkeeping into that same directory, sibling to the
+    UUID block directories -- verified against tempo:2.9.1 as `index.json.gz`
+    plus its companion `index.pb.zst`, written by the blocklist poller on
+    every poll (including immediately at startup, not just on its 5m ticker).
+    A naive listing counts those as blocks too, so it can claim
+    TEMPO_BLOCK_TARGET blocks while one or more entries are not blocks at all.
+    That silently undershoots the real block count the regression depends on
+    -- 150 is the smallest measured count that OOM-killed the unbounded
+    config, so a false 150 no longer provably exercises that threshold. Count
+    real blocks instead: each one is a UUID-named directory holding a
+    `meta.json`, so `find -name meta.json` counts exactly the blocks with
+    metadata and can't be fooled by the tenant index or a stray file. (A
+    compacted block's metadata is `meta.compacted.json` in some Tempo versions
+    and is deliberately excluded -- it is no longer a searchable block.)
+    """
+
+    result = _docker(
+        "exec",
+        container,
+        "sh",
+        "-c",
+        "find /var/tempo/blocks/single-tenant -name meta.json 2>/dev/null | wc -l",
+        check=False,
+        timeout=60,
+    )
+    if result.returncode != 0:
+        return 0
+    digits = result.stdout.strip()
+    return int(digits) if digits.isdigit() else 0
+
+
+def _emit_trace_wave(tracer: RunTracer, marker: str, wave: int) -> None:
+    for index in range(TEMPO_TRACES_PER_WAVE):
+        with tracer.run_span(f"{marker}-{wave}-{index}", "fake-model") as generation:
+            generation.record_usage({"input_tokens": 1, "output_tokens": 1})
+            for tool in range(TEMPO_TOOL_SPANS_PER_TRACE):
+                generation.tool_span(f"probe-{tool}")
+
+
+def _read_json(stack: RuntimeStack, tool: str, arguments: dict[str, Any]) -> Any:
+    """One operator read through the real MCP connector, JSON or a failure.
+
+    The connector returns backend errors as prose rather than raising, so a dead
+    or stalled Tempo comes back as an unparsable body. Turning that into an
+    exception here is what lets the caller count it as a failed read instead of
+    silently treating a sentence as a successful answer.
+    """
+
+    text = stack.call_text("tempo", tool, arguments)
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as error:
+        raise AssertionError(f"tempo.{tool} did not return JSON: {text[:400]}") from error
+
+
+def _assert_tempo_survived(stack: RuntimeStack, phase: str) -> None:
+    state = _inspect(stack.tempo_container)["State"]
+    assert state.get("OOMKilled") is False, f"Tempo was OOM killed during {phase}: {state}"
+    assert state.get("ExitCode") != 137, (
+        f"Tempo exited 137 (SIGKILL, the cgroup OOM signature) during {phase}: {state}"
+    )
+    assert state.get("Status") == "running", f"Tempo is not running after {phase}: {state}"
+    assert state.get("Restarting") is False, f"Tempo is restarting after {phase}: {state}"
+    assert _inspect(stack.tempo_container).get("RestartCount") == 0, (
+        f"Tempo restarted during {phase}, so the evidence path went away: "
+        f"{_inspect(stack.tempo_container).get('RestartCount')}"
+    )
+
+
+def test_tempo_survives_ingest_and_bounded_reads_under_its_configured_memory_limit(
+    observability_runtime: RuntimeStack,
+) -> None:
+    """#2059: ingest plus representative operator reads, under the shipped limit.
+
+    This is the regression the issue asks for: the real pinned Tempo image, the
+    shipped config, inside the cgroup the manifest declares, driven by real
+    spans through the real collector and read back through the real MCP
+    connector.
+
+    What it does NOT prove: a 24h soak. Retention is 48h and blocks are cut every
+    5m, so a real deployment reaches roughly six times this block count and also
+    runs the compactor, which none of the read path bounds cover. The soak shaped
+    assurance comes from the static read buffer product assertion in
+    `charts/curie/ci/observability-stack-assertions.sh`, not from this test.
+    """
+
+    envelope = observability_runtime.tempo_envelope
+    # Read from the manifest, never restated here: a literal copy would keep this
+    # test green against a reverted `tempo.yaml`.
+    assert envelope.memory_limit is not None, (
+        "examples/sre-bot/observability/tempo.yaml must declare "
+        "spec.template.spec.containers[0].resources.limits.memory for the tempo "
+        "container: without it there is no configured limit to run under and this "
+        "regression cannot detect #2059"
+    )
+    assert envelope.gomemlimit is not None, (
+        "examples/sre-bot/observability/tempo.yaml must set a GOMEMLIMIT env var on "
+        "the tempo container (#2059): the Go GC otherwise never learns the cgroup "
+        "ceiling and grows the heap until the kernel kills the process"
+    )
+    limit_bytes = _memory_bytes(envelope.memory_limit)
+    gomemlimit_bytes = _memory_bytes(envelope.gomemlimit)
+    assert 0 < gomemlimit_bytes < limit_bytes, (
+        f"GOMEMLIMIT {envelope.gomemlimit} must be a soft ceiling strictly below the "
+        f"hard cgroup limit {envelope.memory_limit}"
+    )
+
+    # The manifest and the container the assertions below judge must agree, or a
+    # green run proves nothing about the shipped envelope.
+    inspected = _inspect(observability_runtime.tempo_container)
+    assert inspected["HostConfig"]["Memory"] == limit_bytes, (
+        f"Tempo is not running under the manifest's {envelope.memory_limit} limit: "
+        f"docker reports HostConfig.Memory={inspected['HostConfig']['Memory']}, "
+        f"expected {limit_bytes}. A daemon that silently ignored --memory would "
+        f"otherwise make this whole test vacuous"
+    )
+    assert inspected["HostConfig"]["MemorySwap"] == limit_bytes, (
+        "Tempo's --memory-swap must equal --memory or the container can swap "
+        f"instead of being OOM killed: {inspected['HostConfig']['MemorySwap']}"
+    )
+    assert f"GOMEMLIMIT={envelope.gomemlimit}" in inspected["Config"]["Env"], (
+        f"GOMEMLIMIT={envelope.gomemlimit} never reached the Tempo container; its "
+        f"env is {inspected['Config']['Env']}. A dropped value would let a low "
+        f"pressure workload pass without ever exercising the new GC ceiling"
+    )
+
+    marker = f"curie-observability-oom-{uuid.uuid4().hex}"
+    flush_url = f"{observability_runtime.tempo_url}/flush"
+    blocks = 0
+    waves = 0
+    deadline = time.monotonic() + TEMPO_INGEST_DEADLINE_SECONDS
+    with _otel_environment(observability_runtime.collector_url):
+        provider = build_tracer_provider(
+            OtelConfig(endpoint=observability_runtime.collector_url),
+            marker,
+            "runtime-sandbox",
+        )
+        assert provider is not None
+        tracer = RunTracer(provider)
+        try:
+            while (
+                blocks < TEMPO_BLOCK_TARGET
+                and waves < TEMPO_INGEST_WAVE_CAP
+                and time.monotonic() < deadline
+            ):
+                _emit_trace_wave(tracer, marker, waves)
+                tracer.force_flush()
+                time.sleep(TEMPO_COLLECTOR_SETTLE_SECONDS)
+                # Cut a block on demand rather than waiting out
+                # `ingester.max_block_duration: 5m`. This is how a two minute
+                # test reaches the block count a multi hour deployment reaches.
+                try:
+                    _request(flush_url, method="POST", expected=(200, 204), timeout=10)
+                except Exception:  # noqa: BLE001
+                    # A refused flush means Tempo is already gone; stop ingesting
+                    # so the container assertions below name the real cause.
+                    break
+                waves += 1
+                if waves % 10 == 0:
+                    blocks = _tempo_block_count(observability_runtime.tempo_container)
+        finally:
+            tracer.shutdown()
+    blocks = _tempo_block_count(observability_runtime.tempo_container)
+
+    _assert_tempo_survived(observability_runtime, f"ingest of {waves} waves ({blocks} blocks)")
+    assert blocks >= TEMPO_BLOCK_TARGET, (
+        f"only {blocks} blocks accumulated over {waves} flushed waves, below the "
+        f"{TEMPO_BLOCK_TARGET} the measured envelope is judged against; block count "
+        f"is what drives Tempo's search fan out, so a lighter run would pass "
+        f"without exercising #2059 at all"
+    )
+
+    read_failures: list[str] = []
+    reads = 0
+    for round_index in range(TEMPO_READ_ROUNDS):
+        try:
+            found = _read_json(
+                observability_runtime,
+                "search_traces",
+                {
+                    "query": '{ resource.service.name = "curie-runner" }',
+                    "limit": TEMPO_CONNECTOR_MAX_LIMIT,
+                },
+            )
+            reads += 1
+            traces = found.get("traces") or []
+            for trace in traces[:TEMPO_TRACE_FETCHES_PER_ROUND]:
+                _read_json(observability_runtime, "get_trace", {"trace_id": trace["traceID"]})
+                reads += 1
+            _read_json(observability_runtime, "list_trace_tags", {})
+            reads += 1
+            _read_json(
+                observability_runtime,
+                "list_trace_tag_values",
+                {"tag": "resource.service.name"},
+            )
+            reads += 1
+        except Exception as error:  # noqa: BLE001
+            read_failures.append(f"round {round_index}: {error}")
+
+    _assert_tempo_survived(observability_runtime, f"{reads} bounded reads over {blocks} blocks")
+
+    # A GOMEMLIMIT GC death spiral does NOT set OOMKilled: the process stays
+    # alive and stops answering. Liveness alone would pass that, so the envelope
+    # is only safe to ship if a read still RETURNS.
+    still_serving = _read_json(
+        observability_runtime,
+        "search_traces",
+        {
+            "query": '{ resource.service.name = "curie-runner" }',
+            "limit": TEMPO_CONNECTOR_MAX_LIMIT,
+        },
+    )
+    assert still_serving.get("traces"), (
+        "Tempo is still running but no longer answering operator searches over "
+        f"{blocks} blocks: {str(still_serving)[:400]}"
+    )
+
+    assert not read_failures, (
+        f"{len(read_failures)} of the operator read sequence failed under the "
+        f"configured {envelope.memory_limit} limit over {blocks} blocks: "
+        f"{read_failures}"
+    )


### PR DESCRIPTION
## Summary

The shipped SRE-bot Tempo set four config keys, leaving every memory-relevant knob at Tempo's **distributed-deployment defaults** while running as a single pod under a 512Mi limit. Read from the pinned image's own `/status/config`, that means `pool.max_workers: 400` x `search.read_buffer_count: 32` x 1MiB = **12.8 GiB** of theoretical read buffers, and `ingester.max_block_bytes: 500MiB` against a 512MiB container. No `GOMEMLIMIT`, so the Go GC never learned there was a ceiling.

Reproduced on the pinned image: kernel OOM kill under ordinary ingest plus bounded operator reads once blocks accumulate — `Memory cgroup out of memory: Killed process (tempo)`, `constraint=CONSTRAINT_MEMCG`, `anon-rss:514108kB` against the 512Mi cgroup, exit 137, with 207 of 216 operator reads failing because the evidence backend was dead or restarting.

This bounds the config rather than only raising memory. A ceiling the config can still exceed is a threshold, not an envelope: no small-node limit bounds a 12.8 GiB read-buffer product. The change adds 16 explicit bounds (product drops to **160 MiB**), a `GOMEMLIMIT=600MiB` soft Go ceiling below the hard cgroup limit, and raises requests 192Mi -> 256Mi / limits 512Mi -> 1Gi to match Loki, the comparable ingest+query backend in this same stack. `checksum/config` v1 -> v2, without which the ConfigMap changes and the pod keeps running the old config. `FIXED_MEMORY_MIB` 1152 -> 1216 follows, since the installer's capacity preflight sums requests.

Measured with the manifest's own limit applied: 290 blocks / 3480 traces peaks at **549 MiB serving 216/216 reads**, where the shipped config was OOM killed. Peak no longer tracks block count (549 MiB at 290 blocks, 685 MiB at 450); before the change, it did.

Three regression layers, none of which restates the envelope as a literal — each reads it from `tempo.yaml`, so all three go red if that manifest is reverted.

**Reviewer note, recorded against my own change:** raising the limit alone to 1Gi also survives the runtime test (795 MiB, 110 MiB heavier). The bounds are still the right fix — they are what makes peak independent of block count — but the control is stated so the trade can be judged rather than taken on faith.

`requests.memory` is the only figure the capacity preflight sums, so the small-node install goal costs +64Mi of reserved capacity; the refusal threshold moves 1312Mi -> 1376Mi.

## Related issue

Closes #2059

## Fix pin verification

Fix pin: charts/curie/ci/observability-stack-assertions.sh

`curie dev verify-fix-pin 0ccd4e0c charts/curie/ci/observability-stack-assertions.sh` -> `PINNED`. Baseline green; with the product change reversed the selector fails with `AssertionError: Tempo request must be 256Mi, got 192Mi`.

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | No skill-tier surface: this changes a shipped Kubernetes manifest and the installer's capacity constant. | — | — |
| local | required | The manifest is the artifact under change; it must be exercised as a running Tempo. | live (Docker, pinned image) | `TMPDIR=<repo-local> umask 022 uv run --python 3.13 pytest examples/tests/test_sre_bot_observability_runtime.py -q` at 0ccd4e0c -> **3 passed in 123.80s**. Boots Tempo at the manifest's own `limits.memory` with its `GOMEMLIMIT`, accumulates >=150 blocks by flushing the ingester between waves, drives sequential bounded reads through the real MCP connector, and asserts `OOMKilled` false, exit != 137, `RestartCount == 0`, still serving, `HostConfig.Memory`/`MemorySwap` == the manifest limit, and `GOMEMLIMIT=<manifest value>` in `Config.Env`. |
| local-release | n/a | No CLI release artifact changes; `FIXED_MEMORY_MIB` is covered by the installer suite below. | — | — |
| cluster | n/a | Deliberately not run: the constraint on this work forbade mutating any soak, staging or production cluster. The manifest is exercised against the real pinned image over Docker instead, at the same memory limit a pod would impose. | — | — |
| live provider | n/a | No provider surface. | — | — |
| external integration | n/a | No external integration. | — | — |

Additional gates at 0ccd4e0c:

- `bash charts/curie/ci/observability-stack-assertions.sh` -> `observability stack render assertions passed`
- `OBSERVABILITY_ASSERTION_MUTATION=tempo-envelope bash charts/curie/ci/observability-stack-assertions.sh` -> exit 1, `AssertionError: ingester.max_block_bytes is missing at 'max_block_bytes'` (negative control: the new assertions have teeth, demonstrated by execution)
- `cargo test --test example_sre_bot_install` -> 38 passed
- `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, `ruff check`, `ruff format --check` -> clean

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.
- [ ] Or: this change is not behavior-bearing, so no tier applies, and the summary says why.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed. No in-repo doc states a Tempo memory figure or the stack total; verified by grep across `examples/sre-bot/` and `docs/`.
- [ ] An ADR is added under `docs/adr/` if this is an architectural decision. Not added: this tunes a shipped component's resource envelope within the existing design. `GOMEMLIMIT` is new to this repository, so if maintainers consider "soft Go ceiling below a hard cgroup ceiling" a pattern worth establishing stack-wide, that warrants its own ADR alongside the follow-up below.

## Follow-ups worth filing

- **The observability mutation matrix never runs in CI.** `OBSERVABILITY_ASSERTION_MUTATION` appears in exactly one file — the script that reads it. No workflow sets it, so all thirteen negative controls (including the new `tempo-envelope`) are a manual lever, not a gate. Adding a matrix step also requires updating `release/tests/test_authorize.py`, which asserts exactly one helm-CI step runs the script.
- **The rest of the shipped stack has no equivalent envelope.** #1765 gave Loki `replay_memory_ceiling` and Prometheus `retentionSize`; Grafana and Alloy got neither, and no component besides Tempo now sets a `GOMEMLIMIT`.
- **The Tempo connector's own 256Mi ceiling is documented in a comment and asserted nowhere.**
