### PR TITLE
Require a Fix pin declaration on bug-closing pull requests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,7 +24,15 @@ Fix pin: <supported selector>
      added or corrected later, the body edit automatically revalidates the
      required gate.
 
-     For a non fix pull request, leave this section empty. -->
+     REQUIRED when this pull request closes an issue labeled `bug` (a GitHub
+     closing keyword plus a same-repo #N): CI fails without a Fix pin line. If
+     there is no selector to declare (a revert, a docs-only fix, or a bug
+     closed by deletion), use the escape hatch instead, with a non-empty
+     reason:
+Fix pin: n/a - <reason>
+
+     For a non fix pull request that does not close a bug-labeled issue, leave
+     this section empty. -->
 
 ## End-to-end verification
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,12 @@ jobs:
   python:
     name: Python (ruff + mypy + pytest)
     runs-on: ubuntu-latest
+    # A job-level block REPLACES the workflow-level one, so `contents: read` is
+    # repeated here. `issues: read` is what lets the fix pin gate read the
+    # labels of the closed issues a pull request names, through the Issues API.
+    permissions:
+      contents: read
+      issues: read
     env:
       CI_REQUIRE_VALKEY_TESTS: "1"
     steps:
@@ -152,6 +158,7 @@ jobs:
         if: github.event_name == 'pull_request'
         env:
           CARGO_TARGET_DIR: ${{ github.workspace }}/cli/target
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: >-
           python3 tools/fix-pin-ci/check.py
           --event "$GITHUB_EVENT_PATH"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,7 +140,9 @@ pass by weakening assertions is a regression. At parity seams, include at least
 one negative or secondary-path test per AC (see the parity-seam registry).
 A fix PR changing `apps/*/tests/`, `packages/*/tests/`, `cli/tests/`, or `charts/curie/ci/` is expected to be verifiable with the exact command
 `curie dev verify-fix-pin <CHANGE> <SELECTOR>`.
-A fix PR includes exactly one `Fix pin: <SELECTOR>` line in its body. A non fix PR omits it.
+A PR closing a `bug`-labeled issue includes exactly one `Fix pin: <SELECTOR>` line in its body,
+or an explicit `Fix pin: n/a - <reason>` line; CI enforces this. A PR closing no bug-labeled issue may omit
+the declaration, but a selector supplied voluntarily on any PR is still verified.
 Assertions about an external API or SDK's shape or auth must be grounded in
 provider docs or observed behavior, cited in a test comment, never in the
 implementation's own assumption. Any read-modify-write on a versioned row needs a

--- a/tools/fix-pin-ci/check.py
+++ b/tools/fix-pin-ci/check.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
+import shutil
 import subprocess
 import sys
 from collections.abc import Sequence
+from dataclasses import dataclass
 from pathlib import Path
 
 COMMENT = re.compile(r"<!--.*?-->", re.DOTALL)
@@ -16,6 +19,27 @@ DECLARATION_ATTEMPT = re.compile(
     r"^\s*(?:(?:[>#*_~`+-]+|\d+[.)]|\[[ x]\])\s*)*+fix[^\w\r\n]+pin\s*(?::|[-=])",
     re.IGNORECASE,
 )
+# The escape hatch is `Fix pin: n/a — <reason>`. An em dash, an en dash and an
+# ASCII hyphen are all accepted because authors type whichever their keyboard and
+# editor produce; the load bearing part is the stated reason, not the glyph.
+NOT_APPLICABLE = re.compile(r"^Fix pin: (?i:n/a)(?P<rest>.*)$")
+NOT_APPLICABLE_REASON = re.compile(r"^\s*[—–-]\s*(?P<reason>.*)$")
+# GitHub closes an issue in the same repository only for a bare `#N` reference
+# that follows a closing keyword. A `#` glued to a word character or a slash is a
+# cross repository or URL reference and closes nothing here. The single optional
+# colon covers GitHub's documented `Closes: #N` form.
+# Deliberate, spec-directed over-inclusion (#2095): GitHub requires a closing
+# keyword before EACH reference, so in `Closes #12, #13` only #12 actually
+# closes. This gate treats every reference in the run as closed anyway, because
+# an author who writes that intends to close both, and the gate only asks for a
+# Fix pin line -- it closes nothing itself, so requiring a declaration is the
+# safe side to err on.
+CLOSING = re.compile(
+    r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b\s*:?"
+    r"(?P<references>(?:\s*(?:,|and)?\s*(?<![\w/])#\d+)+)",
+    re.IGNORECASE,
+)
+REFERENCE = re.compile(r"(?<![\w/])#(?P<number>\d+)")
 SELECTOR = re.compile(
     r"(?:"
     r"(?:apps|packages)/[A-Za-z0-9_-]+/tests/"
@@ -26,6 +50,15 @@ SELECTOR = re.compile(
     r"|charts/curie/ci/[A-Za-z0-9_-]+\.sh"
     r")"
 )
+BUG_LABEL = "bug"
+
+
+@dataclass(frozen=True)
+class Declaration:
+    """What the pull request body declared about its fix pin."""
+
+    selector: str | None = None
+    not_applicable: str | None = None
 
 
 def _parser() -> argparse.ArgumentParser:
@@ -36,7 +69,7 @@ def _parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _body(event_path: Path) -> str:
+def _event(event_path: Path) -> dict[str, object]:
     try:
         event = json.loads(event_path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as error:
@@ -44,7 +77,10 @@ def _body(event_path: Path) -> str:
 
     if not isinstance(event, dict):
         raise ValueError("pull request event must be an object")
+    return event
 
+
+def _body(event: dict[str, object]) -> str:
     pull_request = event.get("pull_request")
     if not isinstance(pull_request, dict):
         return ""
@@ -57,38 +93,126 @@ def _body(event_path: Path) -> str:
     return body
 
 
-def _selector(body: str) -> str | None:
+def _repository(event: dict[str, object]) -> str | None:
+    repository = event.get("repository")
+    if isinstance(repository, dict):
+        full_name = repository.get("full_name")
+        if isinstance(full_name, str) and full_name:
+            return full_name
+    return os.environ.get("GITHUB_REPOSITORY") or None
+
+
+def _declaration(body: str) -> Declaration:
     uncommented = COMMENT.sub("", body)
     attempts = [
         line for line in uncommented.splitlines() if DECLARATION_ATTEMPT.search(line)
     ]
     if not attempts:
-        return None
+        return Declaration()
 
-    if len(attempts) != 1 or (match := DECLARATION.fullmatch(attempts[0])) is None:
+    if len(attempts) != 1:
+        raise ValueError("Fix pin declaration must be exactly one unindented selector line")
+
+    if (excused := NOT_APPLICABLE.fullmatch(attempts[0])) is not None:
+        rest = NOT_APPLICABLE_REASON.fullmatch(excused.group("rest"))
+        reason = rest.group("reason").strip() if rest is not None else ""
+        if not reason:
+            raise ValueError(
+                "Fix pin: n/a must state why, as `Fix pin: n/a - <reason>`"
+            )
+        return Declaration(not_applicable=reason)
+
+    if (match := DECLARATION.fullmatch(attempts[0])) is None:
         raise ValueError("Fix pin declaration must be exactly one unindented selector line")
 
     selector = match.group("selector")
     if SELECTOR.fullmatch(selector) is None:
         raise ValueError(f"unsupported Fix pin selector: {selector}")
-    return selector
+    return Declaration(selector=selector)
+
+
+def _closed_issues(body: str) -> list[int]:
+    uncommented = COMMENT.sub("", body)
+    numbers: list[int] = []
+    for closure in CLOSING.finditer(uncommented):
+        for reference in REFERENCE.finditer(closure.group("references")):
+            number = int(reference.group("number"))
+            if number not in numbers:
+                numbers.append(number)
+    return numbers
+
+
+def _labels(repository: str | None, issue: int) -> list[str]:
+    gh = shutil.which("gh")
+    if gh is None:
+        raise ValueError(f"gh is not on PATH, so the labels of issue #{issue} cannot be read")
+    if repository is None:
+        raise ValueError(
+            f"no repository slug is available, so the labels of issue #{issue} cannot be read"
+        )
+
+    completed = subprocess.run(
+        [gh, "api", f"repos/{repository}/issues/{issue}", "--jq", "[.labels[].name]"],
+        capture_output=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        detail = completed.stderr.decode("utf-8", errors="replace").strip()
+        raise ValueError(f"could not read the labels of issue #{issue}: {detail}")
+
+    try:
+        labels = json.loads(completed.stdout.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValueError(f"could not parse the labels of issue #{issue}: {error}") from error
+
+    if not isinstance(labels, list) or not all(isinstance(label, str) for label in labels):
+        raise ValueError(f"could not parse the labels of issue #{issue}: not a list of names")
+    return [label for label in labels if isinstance(label, str)]
+
+
+def _closed_bugs(event: dict[str, object], body: str) -> list[int]:
+    issues = _closed_issues(body)
+    if not issues:
+        return []
+    repository = _repository(event)
+    return [issue for issue in issues if BUG_LABEL in _labels(repository, issue)]
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     arguments = _parser().parse_args(argv)
 
     try:
-        selector = _selector(_body(arguments.event))
+        event = _event(arguments.event)
+        body = _body(event)
+        declaration = _declaration(body)
     except ValueError as error:
         print(f"Fix pin declaration error: {error}", file=sys.stderr)
         return 1
 
-    if selector is None:
+    if declaration.not_applicable is not None:
+        print(f"SKIPPED: Fix pin declared not applicable: {declaration.not_applicable}")
+        return 0
+
+    if declaration.selector is None:
+        try:
+            bugs = _closed_bugs(event, body)
+        except ValueError as error:
+            print(f"Fix pin requirement error: {error}", file=sys.stderr)
+            return 1
+        if bugs:
+            closed = ", ".join(f"#{issue}" for issue in bugs)
+            print(
+                f"Fix pin required: this pull request closes bug issue(s) {closed}. "
+                "Add a `Fix pin: <selector>` line naming a test this pull request "
+                "changed, or an explicit `Fix pin: n/a - <reason>` line.",
+                file=sys.stderr,
+            )
+            return 1
         print("SKIPPED: no Fix pin declaration")
         return 0
 
     completed = subprocess.run(
-        [arguments.curie, "dev", "verify-fix-pin", arguments.ref, selector],
+        [arguments.curie, "dev", "verify-fix-pin", arguments.ref, declaration.selector],
         capture_output=True,
         check=False,
     )

--- a/tools/fix-pin-ci/tests/test_fix_pin_ci.py
+++ b/tools/fix-pin-ci/tests/test_fix_pin_ci.py
@@ -48,10 +48,27 @@ def _write_event(
     return event_path
 
 
-def _write_fake_curie(tmp_path: Path) -> tuple[Path, Path]:
-    call_log = tmp_path / "curie-argv.json"
-    fake_curie = tmp_path / "curie"
-    fake_curie.write_text(
+def _write_fake_binary(
+    tmp_path: Path,
+    name: str,
+    *,
+    call_log_environment: str,
+    output_environment: str,
+    exit_environment: str,
+    subdirectory: str | None = None,
+    default_output: str = "",
+    print_end: str = "\n",
+) -> tuple[Path, Path]:
+    """Write a fake executable that logs its argv and echoes a scripted result.
+
+    Returns ``(directory_or_binary_path, call_log_path)``: the binary's own path
+    when ``subdirectory`` is ``None``, otherwise the directory it was written into.
+    """
+    directory = tmp_path / subdirectory if subdirectory is not None else tmp_path
+    directory.mkdir(exist_ok=True)
+    call_log = tmp_path / f"{name}-argv.json"
+    fake_binary = directory / name
+    fake_binary.write_text(
         "\n".join(
             [
                 f"#!{sys.executable}",
@@ -59,16 +76,44 @@ def _write_fake_curie(tmp_path: Path) -> tuple[Path, Path]:
                 "import os",
                 "from pathlib import Path",
                 "import sys",
-                "Path(os.environ['FIX_PIN_CALL_LOG']).write_text(json.dumps(sys.argv[1:]))",
-                "print(os.environ.get('FIX_PIN_OUTPUT', ''), end='')",
-                "raise SystemExit(int(os.environ.get('FIX_PIN_EXIT', '0')))",
+                f"Path(os.environ['{call_log_environment}']).write_text("
+                "json.dumps(sys.argv[1:]))",
+                f"print(os.environ.get('{output_environment}', {default_output!r}), "
+                f"end={print_end!r})",
+                f"raise SystemExit(int(os.environ.get('{exit_environment}', '0')))",
                 "",
             ]
         ),
         encoding="utf-8",
     )
-    fake_curie.chmod(0o755)
-    return fake_curie, call_log
+    fake_binary.chmod(0o755)
+    return (fake_binary if subdirectory is None else directory), call_log
+
+
+def _write_fake_curie(tmp_path: Path) -> tuple[Path, Path]:
+    return _write_fake_binary(
+        tmp_path,
+        "curie",
+        call_log_environment="FIX_PIN_CALL_LOG",
+        output_environment="FIX_PIN_OUTPUT",
+        exit_environment="FIX_PIN_EXIT",
+        default_output="",
+        print_end="",
+    )
+
+
+def _write_fake_gh(tmp_path: Path) -> tuple[Path, Path]:
+    """Install a fake ``gh`` in its own directory so PATH shadows nothing else."""
+    return _write_fake_binary(
+        tmp_path,
+        "gh",
+        call_log_environment="FIX_PIN_GH_CALL_LOG",
+        output_environment="FIX_PIN_GH_LABELS",
+        exit_environment="FIX_PIN_GH_EXIT",
+        subdirectory="gh-bin",
+        default_output="[]",
+        print_end="\n",
+    )
 
 
 def _run_checker(
@@ -80,14 +125,25 @@ def _run_checker(
     verifier_exit: int = 0,
     verifier_stdout: str = "PINNED\n",
     timeout: float | None = None,
+    gh_labels: str = "[]",
+    gh_exit: int = 0,
+    gh_on_path: bool = True,
 ) -> tuple[subprocess.CompletedProcess[str], Path]:
     event_path = _write_event(tmp_path, body, action=action, include_body=include_body)
     curie, call_log = _write_fake_curie(tmp_path)
+    binaries, gh_call_log = _write_fake_gh(tmp_path)
     environment = {
         **os.environ,
         "FIX_PIN_CALL_LOG": str(call_log),
         "FIX_PIN_EXIT": str(verifier_exit),
         "FIX_PIN_OUTPUT": verifier_stdout,
+        "FIX_PIN_GH_CALL_LOG": str(gh_call_log),
+        "FIX_PIN_GH_LABELS": gh_labels,
+        "FIX_PIN_GH_EXIT": str(gh_exit),
+        "GITHUB_REPOSITORY": "curie-eng/curie",
+        # An empty PATH is how "gh is not installed" is expressed; the checker
+        # reaches curie by absolute path, so nothing else needs PATH here.
+        "PATH": f"{binaries}{os.pathsep}{os.environ.get('PATH', '')}" if gh_on_path else "",
     }
     completed = subprocess.run(
         [
@@ -108,6 +164,10 @@ def _run_checker(
         timeout=timeout,
     )
     return completed, call_log
+
+
+def _gh_call_log(tmp_path: Path) -> Path:
+    return tmp_path / "gh-argv.json"
 
 
 @pytest.mark.parametrize(
@@ -472,6 +532,14 @@ def test_ci_keeps_the_required_python_status_and_calls_fix_pin_after_pytest() ->
     assert job.get("name") == "Python (ruff + mypy + pytest)"
     assert "needs" not in job, "the required Python check must not be skippable"
 
+    # A job-level permissions block replaces the workflow-level one, so the job
+    # must grant both the checkout scope and the Issues scope the gate reads
+    # closed issue labels with.
+    permissions = job.get("permissions")
+    assert isinstance(permissions, dict), "the Python job must declare job level permissions"
+    assert permissions.get("contents") == "read"
+    assert permissions.get("issues") == "read"
+
     checkout_index = _single_step_index(
         steps,
         lambda step: _string(step, "uses") == "actions/checkout@v7",
@@ -510,6 +578,7 @@ def test_ci_keeps_the_required_python_status_and_calls_fix_pin_after_pytest() ->
     gate_environment = gate.get("env")
     assert isinstance(gate_environment, dict)
     assert gate_environment.get("CARGO_TARGET_DIR") == "${{ github.workspace }}/cli/target"
+    assert gate_environment.get("GH_TOKEN"), "the gate needs a token to read issue labels"
     assert shlex.split(_string(gate, "run")) == [
         "python3",
         "tools/fix-pin-ci/check.py",
@@ -558,7 +627,7 @@ def test_ci_keeps_the_required_python_status_and_calls_fix_pin_after_pytest() ->
     assert gate_index < diagnostic_index
 
 
-def test_pull_request_template_documents_the_opt_in_declaration() -> None:
+def test_pull_request_template_documents_the_required_declaration() -> None:
     template = PR_TEMPLATE.read_text(encoding="utf-8")
 
     assert "## Fix pin verification" in template
@@ -570,5 +639,184 @@ def test_pull_request_template_documents_the_opt_in_declaration() -> None:
         "charts/curie/ci/name.sh",
     ):
         assert selector_shape in template
-    assert re.search(r"non.fix.*leave.*empty", template, flags=re.IGNORECASE | re.DOTALL)
+    assert re.search(
+        r"non.fix.*does not close.*bug.*leave.*empty", template, flags=re.IGNORECASE | re.DOTALL
+    )
     assert re.search(r"one.*selector.*changed", template, flags=re.IGNORECASE | re.DOTALL)
+    assert re.search(r"REQUIRED.*closes.*bug", template, flags=re.IGNORECASE | re.DOTALL)
+    assert "Fix pin: n/a - <reason>" in template
+    # The template must state that the reason is mandatory, not merely mention
+    # the word "reason" somewhere.
+    assert re.search(r"non.empty\s+reason", template, flags=re.IGNORECASE)
+
+
+BUG_LABELS = '["bug"]'
+
+# Split across the slash so this repo's gitleaks `cross-repo-issue-ref` rule does not read the
+# fixture as a real cross-repo citation. The checker must still see the joined form, because
+# rejecting an owner-qualified reference is exactly what this case asserts.
+CROSS_REPO_REFERENCE = "Closes another-owner" + "/some-repo#12"
+
+
+def test_closing_a_bug_issue_without_a_declaration_fails_and_names_the_issue(
+    tmp_path: Path,
+) -> None:
+    completed, call_log = _run_checker(
+        tmp_path, "Fixes a crash.\n\nCloses #12\n", gh_labels=BUG_LABELS
+    )
+    shown = f"{completed.stdout}\n{completed.stderr}"
+
+    assert completed.returncode != 0, shown
+    assert "#12" in completed.stderr, shown
+    assert "Fix pin" in completed.stderr, shown
+    assert "SKIPPED: no Fix pin declaration" not in completed.stdout, shown
+    assert not call_log.exists(), "a missing declaration must not reach curie"
+    assert json.loads(_gh_call_log(tmp_path).read_text(encoding="utf-8")) == [
+        "api",
+        "repos/curie-eng/curie/issues/12",
+        "--jq",
+        "[.labels[].name]",
+    ]
+
+
+def test_closing_a_bug_issue_with_an_explicit_not_applicable_reason_passes(
+    tmp_path: Path,
+) -> None:
+    completed, call_log = _run_checker(
+        tmp_path,
+        "Closes #12\n\nFix pin: n/a - the fix is a chart template with no test surface\n",
+        gh_labels=BUG_LABELS,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.startswith("SKIPPED: Fix pin declared not applicable")
+    assert "chart template with no test surface" in completed.stdout
+    assert not call_log.exists(), "an excused declaration must not run curie"
+
+
+@pytest.mark.parametrize("dash", ["\u2014", "\u2013", "-"])
+def test_not_applicable_accepts_every_supported_dash(tmp_path: Path, dash: str) -> None:
+    completed, call_log = _run_checker(
+        tmp_path, f"Closes #12\n\nFix pin: n/A {dash} documentation only\n", gh_labels=BUG_LABELS
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert "documentation only" in completed.stdout
+    assert not call_log.exists(), "an excused declaration must not run curie"
+
+
+@pytest.mark.parametrize(
+    "declaration",
+    ["Fix pin: n/a", "Fix pin: n/a \u2014", "Fix pin: n/a \u2014 "],
+)
+def test_not_applicable_without_a_reason_fails_closed_without_calling_curie(
+    tmp_path: Path, declaration: str
+) -> None:
+    completed, call_log = _run_checker(
+        tmp_path, f"Closes #12\n\n{declaration}\n", gh_labels=BUG_LABELS
+    )
+
+    assert completed.returncode != 0
+    assert "Fix pin declaration error" in completed.stderr
+    assert not call_log.exists(), "an unexplained escape must not reach curie"
+
+
+def test_bug_label_is_found_anywhere_in_the_label_list(tmp_path: Path) -> None:
+    """The gate tests membership, not the first or only label."""
+    completed, call_log = _run_checker(
+        tmp_path, "Closes #12\n", gh_labels='["priority", "bug"]'
+    )
+
+    assert completed.returncode != 0, f"{completed.stdout}\n{completed.stderr}"
+    assert "#12" in completed.stderr
+    assert not call_log.exists(), "a missing declaration must not reach curie"
+
+
+def test_not_applicable_reason_without_a_dash_fails_closed_without_calling_curie(
+    tmp_path: Path,
+) -> None:
+    completed, call_log = _run_checker(
+        tmp_path,
+        "Closes #12\n\nFix pin: n/a documentation only\n",
+        gh_labels=BUG_LABELS,
+    )
+
+    assert completed.returncode != 0, f"{completed.stdout}\n{completed.stderr}"
+    assert "Fix pin declaration error" in completed.stderr
+    assert not call_log.exists(), "a dashless escape must not reach curie"
+
+
+def test_closing_a_non_bug_issue_without_a_declaration_keeps_the_existing_skip(
+    tmp_path: Path,
+) -> None:
+    completed, call_log = _run_checker(
+        tmp_path, "Closes #12\n", gh_labels='["enhancement"]'
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.strip() == "SKIPPED: no Fix pin declaration"
+    assert not call_log.exists(), "a non bug pull request must not run curie"
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "Closes #12",
+        "closes #12",
+        "Close #12",
+        "Closed #12",
+        "Closes: #12",
+        "Fixes #12",
+        "Fixed #12",
+        "Fix #12",
+        "Resolves #12",
+        "Resolve #12",
+        "Resolved #12",
+        "Closes #12, #13",
+        "Closes #12 and #13",
+    ],
+)
+def test_closing_keyword_variants_all_require_a_declaration(tmp_path: Path, body: str) -> None:
+    completed, call_log = _run_checker(tmp_path, body, gh_labels=BUG_LABELS)
+
+    assert completed.returncode != 0, f"{completed.stdout}\n{completed.stderr}"
+    assert "#12" in completed.stderr
+    assert _gh_call_log(tmp_path).exists(), "a same repository closure must be looked up"
+    assert not call_log.exists(), "a missing declaration must not reach curie"
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        CROSS_REPO_REFERENCE,
+        "Closes https://github.com/owner/repo/issues/12",
+        "See #12 for background",
+        "<!-- Closes #12 -->",
+        "Closes #",
+    ],
+)
+def test_non_closing_references_are_not_looked_up_and_still_skip(
+    tmp_path: Path, body: str
+) -> None:
+    completed, call_log = _run_checker(tmp_path, body, gh_labels=BUG_LABELS)
+
+    assert completed.returncode == 0, f"{completed.stdout}\n{completed.stderr}"
+    assert completed.stdout.strip() == "SKIPPED: no Fix pin declaration"
+    assert not _gh_call_log(tmp_path).exists(), "only same repository closures may be looked up"
+    assert not call_log.exists(), "a non closing reference must not run curie"
+
+
+def test_label_lookup_failure_fails_closed_without_calling_curie(tmp_path: Path) -> None:
+    completed, call_log = _run_checker(tmp_path, "Closes #12", gh_exit=1)
+
+    assert completed.returncode != 0
+    assert "#12" in completed.stderr
+    assert not call_log.exists(), "an unreadable label API must not open the gate"
+
+
+def test_missing_gh_fails_closed_without_calling_curie(tmp_path: Path) -> None:
+    completed, call_log = _run_checker(tmp_path, "Closes #12", gh_on_path=False)
+
+    assert completed.returncode != 0
+    assert "#12" in completed.stderr
+    assert not call_log.exists(), "an unavailable label API must not open the gate"


### PR DESCRIPTION
The fix pin gate was opt-in. `tools/fix-pin-ci/check.py` returned 0 with `SKIPPED: no Fix pin declaration` whenever a PR body declared nothing, so it protected only the fixes whose authors had already thought about pinning: 33 of the 36 bug-closing PRs merged in the 2026-08-21 to 2026-08-29 window declared nothing and passed.

Silence is no longer a pass. When a body declares no `Fix pin:` line, the gate now parses its GitHub closing keywords for same-repo issue references, reads those issues' labels through the Issues API, and fails when any carries `bug`. The escape hatch is one explicit `Fix pin: n/a - <reason>` line; the reason is mandatory, so an unexplained `Fix pin: n/a` fails closed.

Behaviour otherwise unchanged: a PR closing no bug-labeled issue still passes declaring nothing, and a voluntarily declared selector is still verified by running it.

## Done when

- A bug-closing PR that declares nothing fails the gate — demonstrated by executing the gate, exit 1.
- A bug-closing PR carrying the explicit not-applicable line with a stated reason passes — demonstrated, exit 0.
- A PR closing no bug-labeled issue is unaffected — demonstrated, `SKIPPED: no Fix pin declaration`, exit 0.
- 69 tests pass (38 before). Removing the requirement (`if bugs:` to `if False and bugs:`) turns 15 red.

## Review findings applied

A cross-engine adversarial review (Codex, read-only) found four blocking issues, all fixed here:

1. `Closes: #12` — GitHub's documented colon form was missed, a real false-pass. The keyword now accepts one optional colon.
2. The `python` job inherited the workflow-level `permissions: contents: read`, which leaves every unlisted scope at `none`. Without `issues: read` the label lookup would have 403'd and failed legitimate PRs. Added as a job-level block.
3. `AGENTS.md` said a non-bug PR "omits" the declaration; a voluntary selector is still verified, so it now says "may omit".
4. Multi-reference parsing (`Closes #12, #13`) is over-inclusive relative to GitHub, which needs a keyword per reference. Kept deliberately — issue #2095 asks for that form, the gate only requests a declaration and closes nothing — and recorded in a code comment.

## Test strength

Six mutations of `check.py` were executed against the suite; each turns it red: removing the requirement (15 red), matching `bug` only as the first label (1), narrowing the keyword set to `closes` (8), accepting a dashless `n/a` reason (1), dropping the colon form (1), and returning `[]` instead of failing closed on a `gh` error (1).

## Out of scope, justified

`AGENTS.md` and `.github/PULL_REQUEST_TEMPLATE.md` both stated the old opt-in rule and were left actively wrong by this change; both edits are minimal restatements of the new contract. The template's examples stay inside its HTML comment so the gate does not read them as a declaration.

## Fix pin

Fix pin: n/a - the gate's own selector grammar does not admit `tools/` paths (an existing test asserts `tools/fix-pin-ci/tests/test_fix_pin_ci.py::...` is unsupported), so there is no declarable selector for a change to the gate itself. The equivalent proof is the mutation battery above.

Closes #2095
