### PR TITLE
Pin local build machinery resolution

### DIFF
--- a/cli/src/local.rs
+++ b/cli/src/local.rs
@@ -6,6 +6,7 @@
 //! (or the `--dry-run` printer) consumes it, so argv construction stays
 //! unit-testable with no Docker daemon.
 
+use std::future::Future;
 use std::path::Path;
 
 use anyhow::{bail, Context, Result};
@@ -508,13 +509,36 @@ fn image_present_command(image: &str) -> OpsCommand {
     )
 }
 
+async fn image_present_with<F, Fut>(image: &str, capture: &mut F) -> bool
+where
+    F: FnMut(OpsCommand) -> Fut,
+    Fut: Future<Output = Result<(bool, String, String)>>,
+{
+    matches!(capture(image_present_command(image)).await, Ok((true, ..)))
+}
+
 /// Whether `image` exists in the local daemon. Best-effort: an unreadable
 /// daemon reads as absent, which leaves compose's own default in force.
 pub async fn image_present(image: &str) -> bool {
-    matches!(
-        run_capture(&image_present_command(image)).await,
-        Ok((true, ..))
-    )
+    let mut capture = |command: OpsCommand| async move { run_capture(&command).await };
+    image_present_with(image, &mut capture).await
+}
+
+async fn running_stack_tag_with<F, Fut>(capture: &mut F) -> Option<String>
+where
+    F: FnMut(OpsCommand) -> Fut,
+    Fut: Future<Output = Result<(bool, String, String)>>,
+{
+    let (ok, stdout, _) = capture(api_ps_command()).await.ok()?;
+    if !ok {
+        return None;
+    }
+    let container = stdout.lines().map(str::trim).find(|l| !l.is_empty())?;
+    let (ok, image, _) = capture(container_image_command(container)).await.ok()?;
+    if !ok {
+        return None;
+    }
+    image_tag(image.trim()).map(str::to_string)
 }
 
 /// The image tag the RUNNING local stack was created with, or None when nothing
@@ -529,18 +553,27 @@ pub async fn image_present(image: &str) -> bool {
 /// Best-effort throughout: any unreadable step returns None and compose's
 /// defaults stand, which is the behaviour that existed before #1915.
 pub async fn running_stack_tag() -> Option<String> {
-    let (ok, stdout, _) = run_capture(&api_ps_command()).await.ok()?;
-    if !ok {
-        return None;
-    }
-    let container = stdout.lines().map(str::trim).find(|l| !l.is_empty())?;
-    let (ok, image, _) = run_capture(&container_image_command(container))
+    let mut capture = |command: OpsCommand| async move { run_capture(&command).await };
+    running_stack_tag_with(&mut capture).await
+}
+
+async fn running_stack_image_with<F, Fut>(image: &str, capture: &mut F) -> Option<String>
+where
+    F: FnMut(OpsCommand) -> Fut,
+    Fut: Future<Output = Result<(bool, String, String)>>,
+{
+    let tag = running_stack_tag_with(capture).await?;
+    let candidate = image_ref(image, &tag);
+    image_present_with(&candidate, capture)
         .await
-        .ok()?;
-    if !ok {
-        return None;
-    }
-    image_tag(image.trim()).map(str::to_string)
+        .then_some(candidate)
+}
+
+/// Resolve `image` at the running local stack's tag when that candidate exists.
+/// Best-effort: any unreadable probe leaves compose's own default in force.
+pub(crate) async fn running_stack_image(image: &str) -> Option<String> {
+    let mut capture = |command: OpsCommand| async move { run_capture(&command).await };
+    running_stack_image_with(image, &mut capture).await
 }
 
 /// The compose env pinning every image to `tag`, given which of the per-image
@@ -2477,6 +2510,126 @@ mod tests {
         );
     }
 
+    /// The one-shot image resolver is one best-effort chain: identify the API
+    /// container, read its image tag, then check the requested sibling image at
+    /// that exact tag. Pin the API label and every argv in the chain so a caller
+    /// cannot silently derive the tag from the worker's untagged overlay.
+    #[tokio::test]
+    async fn running_stack_image_uses_the_api_tag_and_checks_the_candidate() {
+        let mut expected = std::collections::VecDeque::from([
+            (
+                "docker ps -a --filter label=com.docker.compose.service=curie-api --format '{{.Names}}'",
+                Ok::<_, anyhow::Error>((true, "curie-curie-api-1\n".into(), String::new())),
+            ),
+            (
+                "docker inspect --format '{{ .Config.Image }}' curie-curie-api-1",
+                Ok((
+                    true,
+                    "ghcr.io/curie-eng/curie-api:dev\n".into(),
+                    String::new(),
+                )),
+            ),
+            (
+                "docker image inspect --format '{{ .Id }}' ghcr.io/curie-eng/curie-dispatcher:dev",
+                Ok((true, "sha256:1\n".into(), String::new())),
+            ),
+        ]);
+        let mut issued = Vec::new();
+        let mut capture = |command: OpsCommand| {
+            let display = command.display();
+            issued.push(display.clone());
+            let (wanted, reply) = expected
+                .pop_front()
+                .expect("resolver issued more than the three expected docker probes");
+            std::future::ready(if display == wanted {
+                reply
+            } else {
+                Err(anyhow::anyhow!("expected `{wanted}`, received `{display}`"))
+            })
+        };
+
+        let image = running_stack_image_with("curie-dispatcher", &mut capture).await;
+
+        assert_eq!(
+            image.as_deref(),
+            Some("ghcr.io/curie-eng/curie-dispatcher:dev")
+        );
+        assert!(expected.is_empty(), "resolver skipped a docker probe");
+        assert_eq!(
+            issued,
+            [
+                "docker ps -a --filter label=com.docker.compose.service=curie-api --format '{{.Names}}'",
+                "docker inspect --format '{{ .Config.Image }}' curie-curie-api-1",
+                "docker image inspect --format '{{ .Id }}' ghcr.io/curie-eng/curie-dispatcher:dev",
+            ]
+        );
+
+        macro_rules! resolve_with {
+            ($replies:expr) => {{
+                let mut replies: std::collections::VecDeque<
+                    anyhow::Result<(bool, String, String)>,
+                > = $replies.into();
+                let mut capture = |_command: OpsCommand| {
+                    std::future::ready(
+                        replies
+                            .pop_front()
+                            .expect("resolver issued an unexpected docker probe"),
+                    )
+                };
+                let result = running_stack_image_with("curie-dispatcher", &mut capture).await;
+                assert!(
+                    replies.is_empty(),
+                    "resolver skipped an expected docker probe"
+                );
+                result
+            }};
+        }
+
+        assert_eq!(
+            resolve_with!([Ok((false, String::new(), "daemon unavailable".into()))]),
+            None,
+            "a nonzero docker probe must leave compose's default in force"
+        );
+        assert_eq!(
+            resolve_with!([Err(anyhow::anyhow!("docker is unreadable"))]),
+            None,
+            "an unreadable docker probe must leave compose's default in force"
+        );
+        assert_eq!(
+            resolve_with!([
+                Ok((true, "curie-curie-api-1\n".into(), String::new())),
+                Ok((true, "curie-api\n".into(), String::new())),
+            ]),
+            None,
+            "an untagged API image cannot identify a sibling image"
+        );
+        assert_eq!(
+            resolve_with!([
+                Ok((true, "curie-curie-api-1\n".into(), String::new())),
+                Ok((
+                    true,
+                    "ghcr.io/curie-eng/curie-api@sha256:abc\n".into(),
+                    String::new(),
+                )),
+            ]),
+            None,
+            "a digest-pinned API image has no reusable tag"
+        );
+        assert_eq!(
+            resolve_with!([
+                Ok((true, "curie-curie-api-1\n".into(), String::new())),
+                Ok((
+                    true,
+                    "ghcr.io/curie-eng/curie-api:dev\n".into(),
+                    String::new(),
+                )),
+                Ok((false, String::new(), "No such image".into())),
+            ]),
+            None,
+            "a missing dispatcher candidate must leave compose's default in force"
+        );
+    }
+
     /// A `--build` stack that was STOPPED rather than torn down still records
     /// its tag, and `up` is how an operator restarts it -- so that restart must
     /// not be the moment the stack quietly reverts to `:latest`. The stub answers
@@ -3089,23 +3242,29 @@ mod tests {
         )
         .expect("worker overlay");
 
-        let mut overridable = std::collections::BTreeSet::new();
-        for line in compose.lines().chain(overlay.lines()) {
-            let line = line.trim();
-            let interpolates = line.contains("${CURIE_BASE_TAG")
-                || line.contains("${BASE_TAG")
-                || line.contains("${CURIE_RUNNER_IMAGE")
-                || line.contains("${CURIE_UI_IMAGE")
-                || line.contains("${CURIE_DISPATCHER_IMAGE");
-            if !interpolates {
-                continue;
+        fn interpolated_curie_image(line: &str) -> Option<&str> {
+            if !line.contains("${") {
+                return None;
             }
-            if let Some(idx) = line.find("ghcr.io/curie-eng/") {
-                let rest = &line[idx + "ghcr.io/curie-eng/".len()..];
-                let name = rest.split(':').next().unwrap_or_default();
-                overridable.insert(name.to_string());
-            }
+            let (_, image) = line.split_once("ghcr.io/curie-eng/")?;
+            let name = image.split(':').next().unwrap_or_default();
+            (!name.is_empty()).then_some(name)
         }
+
+        assert_eq!(
+            interpolated_curie_image(
+                "image: ${CURIE_MAIL_IMAGE:-ghcr.io/curie-eng/curie-mail:latest}"
+            ),
+            Some("curie-mail"),
+            "a new interpolation variable must be discovered without an allowlist"
+        );
+
+        let overridable: std::collections::BTreeSet<String> = compose
+            .lines()
+            .chain(overlay.lines())
+            .filter_map(interpolated_curie_image)
+            .map(str::to_string)
+            .collect();
 
         let mut o = opts(DEFAULT_COMPOSE_FILE);
         o.build = Some(BuildReach::Substitutes);

--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -1881,11 +1881,7 @@ fn compose_config_files(label: &str) -> Result<Vec<String>> {
 /// recreates a service needs the same derivation -- this one just narrows it to
 /// the single image the one-shot producer runs.
 async fn one_shot_dispatcher_image() -> Option<String> {
-    let tag = crate::local::running_stack_tag().await?;
-    let candidate = crate::local::image_ref("curie-dispatcher", &tag);
-    crate::local::image_present(&candidate)
-        .await
-        .then_some(candidate)
+    crate::local::running_stack_image("curie-dispatcher").await
 }
 
 fn worker_compose_config_command(container: &str) -> OpsCommand {

--- a/cli/tests/platform_image_builder.rs
+++ b/cli/tests/platform_image_builder.rs
@@ -335,6 +335,23 @@ fn runner_tags_are_one_identity_across_both_paths() {
     );
 }
 
+/// The one-shot producer must use the same named running-stack resolver as the
+/// other recreating local verbs, not rebuild half of that chain in message.rs.
+#[test]
+fn one_shot_dispatcher_image_uses_the_shared_running_stack_resolver() {
+    let body = function_body("message.rs", "one_shot_dispatcher_image");
+    assert!(
+        body.contains("crate::local::running_stack_image("),
+        "one_shot_dispatcher_image must delegate to the shared named-image resolver; body: {body}"
+    );
+    assert!(
+        !body.contains("running_stack_tag(")
+            && !body.contains("image_ref(")
+            && !body.contains("image_present("),
+        "one_shot_dispatcher_image must not independently compose the tag and presence probes; body: {body}"
+    );
+}
+
 /// Sanity: the scanner still sees the files it claims to police.
 #[test]
 fn scanner_sees_the_two_callers() {


### PR DESCRIPTION
## Summary

- Pin the exact API container, container image, and candidate image probe chain behind an injected capture seam.
- Route the one-shot dispatcher through the shared running-stack image resolver.
- Make the compose build-set guard discover new Curie image variables without a hardcoded variable-name allowlist.

This targets `next` because issue #1927 is a defect in unreleased `next` work, matching the AGENTS.md release-train table. Production behavior is unchanged except for a behavior-preserving shared helper extraction. The tag identity was already shared by `source_image_ref` on current `next`, so this change retains that implementation and pins it with mutation evidence.

## Red and mutation evidence

All Cargo runs used debug mode and an isolated `CARGO_TARGET_DIR`.

- New resolver-chain test on pre-change code: compilation failed with `E0425: cannot find function running_stack_image_with in this scope`.
- New one-shot delegation test on pre-change code: failed with `one_shot_dispatcher_image must delegate to the shared named-image resolver`; the reported body showed the independent `running_stack_tag`, `image_ref`, and `image_present` composition.
- AC1 mutation, changing the compose service label from `curie-api` to `curie-worker`: `running_stack_image_uses_the_api_tag_and_checks_the_candidate` failed with `left: None`, `right: Some("ghcr.io/curie-eng/curie-dispatcher:dev")`.
- AC2 mutation, replacing only the compose caller with the duplicated tag literal: `runner_tags_are_one_identity_across_both_paths` failed with `compose_model_env must use source_image_ref so the stack runs what --build built`.
- AC3 pre-change mutation, adding `CURIE_MAIL_IMAGE` without a `source_images()` entry: `every_overridable_compose_image_is_in_the_build_set` failed with left set `{curie-api, curie-dispatcher, curie-mail, curie-runner, curie-ui, curie-worker}` and right set `{curie-api, curie-dispatcher, curie-runner, curie-ui, curie-worker}`.

## Done check

- `cargo fmt --manifest-path cli/Cargo.toml --check`: passed.
- `cargo clippy --manifest-path cli/Cargo.toml --all-targets -- -D warnings`: passed.
- `cargo test -p curie`: passed in debug on the final candidate, including 1,099 library tests and all integration and doc tests.
- `curie dev verify-fix-pin HEAD cli/tests/platform_image_builder.rs::one_shot_dispatcher_image_uses_the_shared_running_stack_resolver`: `PINNED`.
- `CURIE_E2E_TIERS=local curie dev e2e-ladder`: passed against the candidate debug binary using the matching local `:dev` source images; local message finalized, the injected failure recovered, and cleanup reported no Curie containers running.
- Routed code review: approved with no blocking findings.
- Routed scope review: approved with no blocking findings.
- Documentation review: no changes needed.
- Security review: not applicable because no auth, credential, data boundary, or external API behavior changed.
- Consolidation: the requested `/simplify` command was unavailable; direct diff inspection found no extra consolidation edits to make.

Closes #1927
