### PR TITLE
Seed the released-upgrade gate and read the rows back through the current models

### DIFF
--- a/apps/api/tests/test_released_upgrade_gate.py
+++ b/apps/api/tests/test_released_upgrade_gate.py
@@ -16,8 +16,9 @@ surface the gate and its read-back runner are built to:
 * `SeedAgent` / `SEED_FIXTURE` -- the seeded rows, asserted here against the
   LIVE `_validate_channel_binding`, so a fixture softened to make the gate green
   goes red instead.
-* `ColumnInfo` / `_plan_seed_statements` -- the schema-adaptive planner, which
-  must never silently seed nothing.
+* `ColumnInfo` / `_plan_seed_statements` / `_detect_approval_route_era` -- the
+  schema-adaptive planner, which must never silently seed nothing and must pick
+  the 0021 channel era and the 0034 approval-route era INDEPENDENTLY (#2098).
 * `scripts/released_upgrade_readback.py::_collect_failures` -- the pure
   assertion helper, which must not pass vacuously and must name the DATA before
   it names Pydantic.
@@ -31,6 +32,7 @@ from __future__ import annotations
 
 import dataclasses
 import importlib.util
+import json
 import sys
 from pathlib import Path
 from types import ModuleType
@@ -387,7 +389,10 @@ def _agent_channels_columns(gate: ModuleType) -> tuple[Any, ...]:
 def test_legacy_column_branch_writes_every_address_into_curie_agents(
     gate: ModuleType,
 ) -> None:
-    statements = gate._plan_seed_statements(_legacy_columns(gate))
+    statements = gate._plan_seed_statements(
+        _legacy_columns(gate),
+        approval_route_era=gate.APPROVAL_ROUTE_ERA_LEGACY,
+    )
 
     rendered = "\n".join(statements)
     assert statements, "the seed must never plan nothing"
@@ -402,7 +407,10 @@ def test_legacy_column_branch_writes_every_address_into_curie_agents(
 def test_agent_channels_branch_writes_agent_id_kind_and_address(
     gate: ModuleType,
 ) -> None:
-    statements = gate._plan_seed_statements(_agent_channels_columns(gate))
+    statements = gate._plan_seed_statements(
+        _agent_channels_columns(gate),
+        approval_route_era=gate.APPROVAL_ROUTE_ERA_SPLIT,
+    )
 
     rendered = "\n".join(statements)
     binding_statements = [
@@ -423,7 +431,12 @@ def test_legacy_branch_seeds_the_pre_0034_approval_route_shape(
     gate: ModuleType,
 ) -> None:
     """Pre-0034 storage: `{"deploy": {"channel": ...}}`, rewritten on the way up."""
-    rendered = "\n".join(gate._plan_seed_statements(_legacy_columns(gate)))
+    rendered = "\n".join(
+        gate._plan_seed_statements(
+            _legacy_columns(gate),
+            approval_route_era=gate.APPROVAL_ROUTE_ERA_LEGACY,
+        )
+    )
 
     routed = next(
         agent
@@ -439,7 +452,12 @@ def test_agent_channels_branch_seeds_the_post_0034_approval_route_shape(
     gate: ModuleType,
 ) -> None:
     """Post-0034 storage: the split `{"resolution": {"kind", "address"}}` shape."""
-    rendered = "\n".join(gate._plan_seed_statements(_agent_channels_columns(gate)))
+    rendered = "\n".join(
+        gate._plan_seed_statements(
+            _agent_channels_columns(gate),
+            approval_route_era=gate.APPROVAL_ROUTE_ERA_SPLIT,
+        )
+    )
 
     routed = next(
         agent
@@ -449,6 +467,163 @@ def test_agent_channels_branch_seeds_the_post_0034_approval_route_shape(
     assert "approval_routes" in rendered
     assert "resolution" in rendered
     assert routed.approval_route_address in rendered
+
+
+def _routed_agent(gate: ModuleType) -> Any:
+    """The one fixture row that carries an approval route."""
+    return next(
+        agent
+        for agent in gate.SEED_FIXTURE
+        if agent.approval_route_address is not None
+    )
+
+
+def _legacy_route_json(gate: ModuleType) -> str:
+    """The pre-0034 route literal, built the way the planner builds it."""
+    routed = _routed_agent(gate)
+    return json.dumps({"deploy": {"channel": routed.approval_route_address}})
+
+
+def _split_route_json(gate: ModuleType) -> str:
+    """The post-0034 route literal, key order included (#1460)."""
+    routed = _routed_agent(gate)
+    return json.dumps(
+        {
+            "deploy": {
+                "resolution": {
+                    "kind": routed.kind,
+                    "address": routed.approval_route_address,
+                }
+            }
+        }
+    )
+
+
+def _fake_released_tree(tmp_path: Path, *, revisions: tuple[str, ...]) -> Path:
+    """A worktree-shaped directory holding just the named revision files."""
+    versions = tmp_path / "apps" / "api" / "alembic" / "versions"
+    versions.mkdir(parents=True)
+    for name in revisions:
+        (versions / name).write_text("# stub revision\n", encoding="utf-8")
+    return tmp_path
+
+
+def test_agent_channels_branch_with_a_legacy_route_era_seeds_the_channel_shape(
+    gate: ModuleType,
+) -> None:
+    """The between-eras quadrant: post-0021 bindings, pre-0034 route (#2098).
+
+    A released ref in v0.7.0..v0.7.3 binds channels through `agent_channels` and
+    STILL stores `{"deploy": {"channel": ...}}`. Reading the route shape off the
+    0021 discriminator seeds `resolution` there -- a future-shaped fixture the
+    released code could never have produced -- and the candidate's 0034 (#1460)
+    then rejects it as an unknown legacy key, so the gate blames the migration
+    for its own seed. Revert the era split and this test goes red.
+    """
+
+    rendered = "\n".join(
+        gate._plan_seed_statements(
+            _agent_channels_columns(gate),
+            approval_route_era=gate.APPROVAL_ROUTE_ERA_LEGACY,
+        )
+    )
+
+    assert "curie.agent_channels" in rendered
+    assert _legacy_route_json(gate) in rendered
+    assert "resolution" not in rendered
+
+
+def test_agent_channels_branch_with_a_split_route_era_seeds_the_resolution_shape(
+    gate: ModuleType,
+) -> None:
+    """Post-0034 released refs keep the split shape: the era is a choice, not a drop."""
+
+    rendered = "\n".join(
+        gate._plan_seed_statements(
+            _agent_channels_columns(gate),
+            approval_route_era=gate.APPROVAL_ROUTE_ERA_SPLIT,
+        )
+    )
+
+    assert _split_route_json(gate) in rendered
+    assert _legacy_route_json(gate) not in rendered
+
+
+def test_legacy_column_branch_with_a_legacy_route_era_seeds_the_channel_shape(
+    gate: ModuleType,
+) -> None:
+    """Pre-0021 implies pre-0034, so this quadrant is unchanged by the era split."""
+
+    rendered = "\n".join(
+        gate._plan_seed_statements(
+            _legacy_columns(gate),
+            approval_route_era=gate.APPROVAL_ROUTE_ERA_LEGACY,
+        )
+    )
+
+    assert "slack_channel" in rendered
+    assert _legacy_route_json(gate) in rendered
+    assert "resolution" not in rendered
+
+
+def test_a_released_tree_holding_0034_is_the_split_era(
+    gate: ModuleType,
+    tmp_path: Path,
+) -> None:
+    """The released WORKTREE is the authority: 0034 adds no schema to introspect."""
+
+    tree = _fake_released_tree(
+        tmp_path,
+        revisions=("0021_agent_channels.py", "0034_approval_route_targets.py"),
+    )
+
+    assert gate._detect_approval_route_era(tree) == gate.APPROVAL_ROUTE_ERA_SPLIT
+
+
+def test_a_released_tree_without_0034_is_the_legacy_era(
+    gate: ModuleType,
+    tmp_path: Path,
+) -> None:
+    """v0.7.0..v0.7.3's shape: 0021 has run, 0034 has not."""
+
+    tree = _fake_released_tree(
+        tmp_path,
+        revisions=("0021_agent_channels.py", "0033_action_gate_approval.py"),
+    )
+
+    assert gate._detect_approval_route_era(tree) == gate.APPROVAL_ROUTE_ERA_LEGACY
+
+
+def test_a_released_tree_with_no_versions_directory_raises(
+    gate: ModuleType,
+    tmp_path: Path,
+) -> None:
+    """No versions directory means the tree is not what we think it is.
+
+    Guessing an era from a tree we cannot read is how a future-shaped fixture
+    gets seeded in the first place, so refuse instead of defaulting.
+    """
+
+    with pytest.raises(gate.GateError) as excinfo:
+        gate._detect_approval_route_era(tmp_path)
+
+    assert "alembic versions directory" in str(excinfo.value)
+
+
+def test_an_unrecognized_approval_route_era_raises_naming_the_value(
+    gate: ModuleType,
+) -> None:
+    """No default and no fallthrough: a bad era must never select a shape."""
+
+    with pytest.raises(gate.GateError) as excinfo:
+        gate._plan_seed_statements(
+            _agent_channels_columns(gate), approval_route_era="0034"
+        )
+
+    message = str(excinfo.value)
+    assert "0034" in message
+    assert gate.APPROVAL_ROUTE_ERA_LEGACY in message
+    assert gate.APPROVAL_ROUTE_ERA_SPLIT in message
 
 
 def test_neither_binding_location_raises_naming_both_candidates(
@@ -461,7 +636,9 @@ def test_neither_binding_location_raises_naming_both_candidates(
     )
 
     with pytest.raises(gate.GateError) as excinfo:
-        gate._plan_seed_statements(columns)
+        gate._plan_seed_statements(
+            columns, approval_route_era=gate.APPROVAL_ROUTE_ERA_LEGACY
+        )
 
     message = str(excinfo.value)
     assert "agents.slack_channel" in message
@@ -483,7 +660,9 @@ def test_an_unfilled_mandatory_column_raises_naming_that_column(
     )
 
     with pytest.raises(gate.GateError) as excinfo:
-        gate._plan_seed_statements(columns)
+        gate._plan_seed_statements(
+            columns, approval_route_era=gate.APPROVAL_ROUTE_ERA_LEGACY
+        )
 
     assert "gate_probe_required" in str(excinfo.value)
 

--- a/apps/api/tests/test_released_upgrade_gate.py
+++ b/apps/api/tests/test_released_upgrade_gate.py
@@ -34,6 +34,7 @@ import dataclasses
 import importlib.util
 import json
 import sys
+from collections.abc import Callable
 from pathlib import Path
 from types import ModuleType
 from typing import Any
@@ -85,15 +86,21 @@ def readback() -> ModuleType:
     return _load_script("released_upgrade_readback", READBACK_SCRIPT)
 
 
-def _direction(gate: ModuleType, candidate_ref: str) -> Any:
-    matching = [
-        direction
-        for direction in gate.SELF_TEST_DIRECTIONS
-        if direction.candidate_ref == candidate_ref
-    ]
+def _direction(
+    gate: ModuleType,
+    description: str,
+    predicate: Callable[[Any], bool],
+) -> Any:
+    """The single direction matching `predicate`, or a failure naming the count.
+
+    Every caller wants EXACTLY one row, so the count assertion lives here rather
+    than at each call site: a table that grew a second matching direction fails
+    loudly instead of silently handing back the first match.
+    """
+
+    matching = [row for row in gate.SELF_TEST_DIRECTIONS if predicate(row)]
     assert len(matching) == 1, (
-        f"expected exactly one direction with candidate ref {candidate_ref}, "
-        f"got {len(matching)}"
+        f"expected exactly one direction {description}, got {len(matching)}"
     )
     return matching[0]
 
@@ -122,35 +129,37 @@ def test_direction_is_a_frozen_record_of_refs_expectation_and_markers(
 
 def test_exactly_one_direction_pins_a_read_back_failure(gate: ModuleType) -> None:
     """#1914's reproduction: v0.6.2 upgrades cleanly to v0.7.3 and still fails."""
-    read_back = [
-        direction
-        for direction in gate.SELF_TEST_DIRECTIONS
-        if direction.expect_failure_phase == "read-back"
-    ]
+    read_back = _direction(
+        gate,
+        "expecting a read-back failure",
+        lambda row: row.expect_failure_phase == "read-back",
+    )
 
-    assert len(read_back) == 1
-    assert read_back[0].released_ref == "v0.6.2"
-    assert read_back[0].candidate_ref == "v0.7.3"
+    assert read_back.released_ref == "v0.6.2"
+    assert read_back.candidate_ref == "v0.7.3"
 
 
 def test_exactly_one_direction_must_pass_cleanly(gate: ModuleType) -> None:
     """The must-PASS direction. Without it the self test only knows how to fail."""
-    passing = [
-        direction
-        for direction in gate.SELF_TEST_DIRECTIONS
-        if direction.expect_failure_phase is None
-    ]
+    passing = _direction(
+        gate,
+        "that must pass cleanly",
+        lambda row: row.expect_failure_phase is None,
+    )
 
-    assert len(passing) == 1
-    assert passing[0].released_ref == "v0.6.2"
-    assert passing[0].candidate_ref == "v0.8.0"
+    assert passing.released_ref == "v0.6.2"
+    assert passing.candidate_ref == "v0.8.0"
 
 
 def test_the_1706_collision_direction_is_retained_with_all_three_markers(
     gate: ModuleType,
 ) -> None:
     """#1706's coverage is EXTENDED here, never replaced."""
-    direction = _direction(gate, "v0.7.0-rc.1")
+    direction = _direction(
+        gate,
+        "with candidate ref v0.7.0-rc.1",
+        lambda row: row.candidate_ref == "v0.7.0-rc.1",
+    )
 
     assert direction.released_ref == "v0.6.2"
     assert direction.expect_failure_phase == "candidate upgrade"
@@ -386,6 +395,15 @@ def _agent_channels_columns(gate: ModuleType) -> tuple[Any, ...]:
     )
 
 
+def _routed_agent(gate: ModuleType) -> Any:
+    """The one fixture row that carries an approval route."""
+    return next(
+        agent
+        for agent in gate.SEED_FIXTURE
+        if agent.approval_route_address is not None
+    )
+
+
 def test_legacy_column_branch_writes_every_address_into_curie_agents(
     gate: ModuleType,
 ) -> None:
@@ -438,11 +456,7 @@ def test_legacy_branch_seeds_the_pre_0034_approval_route_shape(
         )
     )
 
-    routed = next(
-        agent
-        for agent in gate.SEED_FIXTURE
-        if agent.approval_route_address is not None
-    )
+    routed = _routed_agent(gate)
     assert "approval_routes" in rendered
     assert "channel" in rendered
     assert routed.approval_route_address in rendered
@@ -459,23 +473,10 @@ def test_agent_channels_branch_seeds_the_post_0034_approval_route_shape(
         )
     )
 
-    routed = next(
-        agent
-        for agent in gate.SEED_FIXTURE
-        if agent.approval_route_address is not None
-    )
+    routed = _routed_agent(gate)
     assert "approval_routes" in rendered
     assert "resolution" in rendered
     assert routed.approval_route_address in rendered
-
-
-def _routed_agent(gate: ModuleType) -> Any:
-    """The one fixture row that carries an approval route."""
-    return next(
-        agent
-        for agent in gate.SEED_FIXTURE
-        if agent.approval_route_address is not None
-    )
 
 
 def _legacy_route_json(gate: ModuleType) -> str:

--- a/apps/api/tests/test_released_upgrade_gate.py
+++ b/apps/api/tests/test_released_upgrade_gate.py
@@ -1,0 +1,634 @@
+"""The released-upgrade gate must prove the migrated database is READABLE (#2098).
+
+`scripts/check-released-upgrade.py` proves migrations RUN against a released
+database. It cannot prove the result loads: #1914 is a row migration 0021
+backfilled verbatim out of `agents.slack_channel`, which then failed
+`ChannelBinding`'s address rule and made `GET /agents` return 500 for every
+agent, not just the one holding it.
+
+Two phases close that gap -- a `seed` before the candidate upgrade and a
+`read-back` after it -- and this module is their contract. It is the frozen API
+surface the gate and its read-back runner are built to:
+
+* `SelfTestDirection` / `SELF_TEST_DIRECTIONS` -- the pinned direction table,
+  which must keep #1706's negative control (a must-FAIL direction) while adding
+  a must-PASS one, because a self test that only knows how to fail is inert.
+* `SeedAgent` / `SEED_FIXTURE` -- the seeded rows, asserted here against the
+  LIVE `_validate_channel_binding`, so a fixture softened to make the gate green
+  goes red instead.
+* `ColumnInfo` / `_plan_seed_statements` -- the schema-adaptive planner, which
+  must never silently seed nothing.
+* `scripts/released_upgrade_readback.py::_collect_failures` -- the pure
+  assertion helper, which must not pass vacuously and must name the DATA before
+  it names Pydantic.
+
+Everything here is a pure unit test with stubs. No test creates a git worktree,
+runs `uv sync`, runs alembic, or touches Postgres; the live gate is exercised by
+running it, not by a pytest that costs four minutes.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+from curie_api.schemas import _validate_channel_binding
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+GATE_SCRIPT = REPO_ROOT / "scripts" / "check-released-upgrade.py"
+READBACK_SCRIPT = REPO_ROOT / "scripts" / "released_upgrade_readback.py"
+
+# Direction 1, retained verbatim from #1706. The markers are the defense against
+# a MissingGreenlet (or any other incidental error) masquerading as the expected
+# revision collision, so they are quoted here exactly, not paraphrased.
+COLLISION_MARKERS = (
+    "asyncpg.exceptions.UndefinedTableError",
+    'relation "curie.agent_channels" does not exist',
+    "0022_approvals_reply_kind.py",
+)
+
+
+def _load_script(module_name: str, path: Path) -> ModuleType:
+    """Load a `scripts/` file by path.
+
+    `check-released-upgrade.py` has a hyphen and is not importable by name, so
+    both modules load the same way, following `test_alembic_revision_gate.py`'s
+    `REPO_ROOT` anchor. A missing file fails this one test loudly instead of
+    taking the whole collection down with an import error.
+    """
+
+    if not path.is_file():
+        pytest.fail(f"expected {path} to exist")
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        pytest.fail(f"could not build an import spec for {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def gate() -> ModuleType:
+    return _load_script("check_released_upgrade", GATE_SCRIPT)
+
+
+@pytest.fixture(scope="module")
+def readback() -> ModuleType:
+    return _load_script("released_upgrade_readback", READBACK_SCRIPT)
+
+
+def _direction(gate: ModuleType, candidate_ref: str) -> Any:
+    matching = [
+        direction
+        for direction in gate.SELF_TEST_DIRECTIONS
+        if direction.candidate_ref == candidate_ref
+    ]
+    assert len(matching) == 1, (
+        f"expected exactly one direction with candidate ref {candidate_ref}, "
+        f"got {len(matching)}"
+    )
+    return matching[0]
+
+
+# --------------------------------------------------------------------------
+# T1 -- the direction table
+# --------------------------------------------------------------------------
+
+
+def test_direction_is_a_frozen_record_of_refs_expectation_and_markers(
+    gate: ModuleType,
+) -> None:
+    """The row shape: two refs, an expected failure phase, and pinned markers."""
+    field_names = {field.name for field in dataclasses.fields(gate.SelfTestDirection)}
+
+    assert field_names == {
+        "released_ref",
+        "candidate_ref",
+        "expect_failure_phase",
+        "markers",
+    }
+    assert isinstance(gate.SELF_TEST_DIRECTIONS, tuple)
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        gate.SELF_TEST_DIRECTIONS[0].released_ref = "v0.0.0"
+
+
+def test_exactly_one_direction_pins_a_read_back_failure(gate: ModuleType) -> None:
+    """#1914's reproduction: v0.6.2 upgrades cleanly to v0.7.3 and still fails."""
+    read_back = [
+        direction
+        for direction in gate.SELF_TEST_DIRECTIONS
+        if direction.expect_failure_phase == "read-back"
+    ]
+
+    assert len(read_back) == 1
+    assert read_back[0].released_ref == "v0.6.2"
+    assert read_back[0].candidate_ref == "v0.7.3"
+
+
+def test_exactly_one_direction_must_pass_cleanly(gate: ModuleType) -> None:
+    """The must-PASS direction. Without it the self test only knows how to fail."""
+    passing = [
+        direction
+        for direction in gate.SELF_TEST_DIRECTIONS
+        if direction.expect_failure_phase is None
+    ]
+
+    assert len(passing) == 1
+    assert passing[0].released_ref == "v0.6.2"
+    assert passing[0].candidate_ref == "v0.8.0"
+
+
+def test_the_1706_collision_direction_is_retained_with_all_three_markers(
+    gate: ModuleType,
+) -> None:
+    """#1706's coverage is EXTENDED here, never replaced."""
+    direction = _direction(gate, "v0.7.0-rc.1")
+
+    assert direction.released_ref == "v0.6.2"
+    assert direction.expect_failure_phase == "candidate upgrade"
+    for marker in COLLISION_MARKERS:
+        assert marker in direction.markers, f"lost collision marker {marker!r}"
+
+
+# --------------------------------------------------------------------------
+# T2 -- `_run_self_test` fails loudly on either mismatch shape
+# --------------------------------------------------------------------------
+
+
+def _matching_result(gate: ModuleType, direction: Any) -> Any:
+    """The `PairResult` a direction declares it expects."""
+    if direction.expect_failure_phase is None:
+        return gate.PairResult("read-back", 0, "")
+    return gate.PairResult(
+        direction.expect_failure_phase, 1, "\n".join(direction.markers)
+    )
+
+
+def _stub_pair_walk(
+    gate: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    overrides: dict[str, Any],
+) -> None:
+    """Every direction returns what it declared, except the named overrides.
+
+    Keyed on candidate ref, since the released ref is `v0.6.2` for all three.
+    """
+
+    results = {
+        direction.candidate_ref: _matching_result(gate, direction)
+        for direction in gate.SELF_TEST_DIRECTIONS
+    }
+    results.update(overrides)
+
+    def _fake_resolve_ref(ref: str) -> str:
+        return "0" * 40
+
+    def _fake_run_pair(**kwargs: Any) -> Any:
+        return results[kwargs["candidate_ref"]]
+
+    monkeypatch.setattr(gate, "_resolve_ref", _fake_resolve_ref)
+    monkeypatch.setattr(gate, "_run_pair", _fake_run_pair)
+
+
+def test_self_test_passes_when_every_direction_matches_its_expectation(
+    gate: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Positive control: without it the mismatch tests could pass vacuously."""
+    _stub_pair_walk(gate, monkeypatch, {})
+
+    assert gate._run_self_test() == 0
+
+
+def test_an_expected_failure_that_passed_names_that_direction(
+    gate: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A gate that silently stopped exercising the read path must not read green."""
+    _stub_pair_walk(
+        gate, monkeypatch, {"v0.7.3": gate.PairResult("read-back", 0, "")}
+    )
+
+    with pytest.raises(gate.GateError) as excinfo:
+        gate._run_self_test()
+
+    message = str(excinfo.value)
+    assert "v0.7.3" in message
+    assert "v0.7.0-rc.1" not in message
+    assert "v0.8.0" not in message
+
+
+def test_an_expected_pass_that_failed_names_the_direction_and_the_phase(
+    gate: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The other half of AC6: both mismatch shapes are loud, not just one."""
+    _stub_pair_walk(
+        gate,
+        monkeypatch,
+        {"v0.8.0": gate.PairResult("candidate upgrade", 1, "boom")},
+    )
+
+    with pytest.raises(gate.GateError) as excinfo:
+        gate._run_self_test()
+
+    message = str(excinfo.value)
+    assert "v0.8.0" in message
+    assert "candidate upgrade" in message
+    assert "v0.7.3" not in message
+    assert "v0.7.0-rc.1" not in message
+
+
+def test_a_failure_in_the_right_phase_missing_a_marker_names_the_marker(
+    gate: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The marker set is the defense against the RIGHT phase failing WRONG.
+
+    A `MissingGreenlet`, or any incidental error, still lands in the declared
+    phase. Only the markers separate "the failure we pinned" from "some failure",
+    so a direction that loses one is a mismatch, not a pass.
+    """
+
+    partial_output = "\n".join(COLLISION_MARKERS[:2])
+    _stub_pair_walk(
+        gate,
+        monkeypatch,
+        {"v0.7.0-rc.1": gate.PairResult("candidate upgrade", 1, partial_output)},
+    )
+
+    with pytest.raises(gate.GateError) as excinfo:
+        gate._run_self_test()
+
+    message = str(excinfo.value)
+    assert "0022_approvals_reply_kind.py" in message
+    assert "v0.7.3" not in message
+    assert "v0.8.0" not in message
+
+
+# --------------------------------------------------------------------------
+# T3 -- the fixture is legacy-shaped, not validator-shaped
+# --------------------------------------------------------------------------
+
+
+def test_the_fixture_carries_both_a_legacy_and_a_valid_neighbour(
+    gate: ModuleType,
+) -> None:
+    """A fixture of only-legacy or only-valid rows cannot prove the property."""
+    legacy = [agent for agent in gate.SEED_FIXTURE if agent.legacy]
+    valid = [agent for agent in gate.SEED_FIXTURE if not agent.legacy]
+
+    assert len(legacy) >= 2, "both documented legacy families must be seeded"
+    assert len(valid) >= 1, "the valid neighbour proves every agent is returned"
+    assert len({agent.name for agent in gate.SEED_FIXTURE}) == len(gate.SEED_FIXTURE)
+    assert len({agent.address for agent in gate.SEED_FIXTURE}) == len(
+        gate.SEED_FIXTURE
+    )
+
+
+def test_every_legacy_fixture_address_is_rejected_by_the_live_validator(
+    gate: ModuleType,
+) -> None:
+    """The AC1 guarantee: shapes the RELEASED code permitted, read from the gate.
+
+    Read from `SEED_FIXTURE` rather than restated as literals on purpose. If
+    someone softens an address to make the gate green, the address stops being a
+    shape the current write path rejects, and this goes red.
+    """
+
+    for agent in gate.SEED_FIXTURE:
+        if not agent.legacy:
+            continue
+        with pytest.raises(ValueError):
+            _validate_channel_binding(agent.kind, agent.address)
+
+
+def test_the_valid_fixture_address_is_accepted_by_the_live_validator(
+    gate: ModuleType,
+) -> None:
+    for agent in gate.SEED_FIXTURE:
+        if agent.legacy:
+            continue
+        assert _validate_channel_binding(agent.kind, agent.address) == agent.address
+
+
+def test_the_seeded_approval_route_reuses_a_rejected_legacy_address(
+    gate: ModuleType,
+) -> None:
+    """The sibling read projections are only pinned if the route address is legacy."""
+    routed = [
+        agent
+        for agent in gate.SEED_FIXTURE
+        if agent.approval_route_address is not None
+    ]
+
+    assert len(routed) == 1
+    assert routed[0].legacy
+    assert routed[0].approval_route_address == routed[0].address
+
+
+# --------------------------------------------------------------------------
+# T4 -- the seed planner branches correctly
+# --------------------------------------------------------------------------
+
+
+def _column(
+    gate: ModuleType,
+    table_name: str,
+    column_name: str,
+    *,
+    nullable: bool = True,
+    default: str | None = None,
+) -> Any:
+    return gate.ColumnInfo(
+        table_name=table_name,
+        column_name=column_name,
+        is_nullable="YES" if nullable else "NO",
+        column_default=default,
+    )
+
+
+def _legacy_columns(gate: ModuleType) -> tuple[Any, ...]:
+    """v0.6.2's shape: `agents.slack_channel` NOT NULL, no `agent_channels`."""
+    return (
+        _column(gate, "agents", "id", nullable=False, default="gen_random_uuid()"),
+        _column(gate, "agents", "name", nullable=False),
+        _column(gate, "agents", "slack_channel", nullable=False),
+        _column(gate, "agents", "created_at", nullable=False, default="now()"),
+        _column(gate, "agents", "approval_routes"),
+    )
+
+
+def _agent_channels_columns(gate: ModuleType) -> tuple[Any, ...]:
+    """v0.8.0's shape: `slack_channel` gone, `agent_channels` present."""
+    return (
+        _column(gate, "agents", "id", nullable=False, default="gen_random_uuid()"),
+        _column(gate, "agents", "name", nullable=False),
+        _column(gate, "agents", "created_at", nullable=False, default="now()"),
+        _column(gate, "agents", "approval_routes"),
+        _column(
+            gate,
+            "agent_channels",
+            "id",
+            nullable=False,
+            default="gen_random_uuid()",
+        ),
+        _column(gate, "agent_channels", "agent_id", nullable=False),
+        _column(gate, "agent_channels", "kind", nullable=False),
+        _column(gate, "agent_channels", "address", nullable=False),
+        _column(gate, "agent_channels", "generation", nullable=False, default="0"),
+        _column(gate, "agent_channels", "endpoint"),
+        _column(gate, "agent_channels", "adapter"),
+    )
+
+
+def test_legacy_column_branch_writes_every_address_into_curie_agents(
+    gate: ModuleType,
+) -> None:
+    statements = gate._plan_seed_statements(_legacy_columns(gate))
+
+    rendered = "\n".join(statements)
+    assert statements, "the seed must never plan nothing"
+    assert "curie.agents" in rendered
+    assert "slack_channel" in rendered
+    assert "curie.agent_channels" not in rendered
+    for agent in gate.SEED_FIXTURE:
+        assert agent.name in rendered
+        assert agent.address in rendered
+
+
+def test_agent_channels_branch_writes_agent_id_kind_and_address(
+    gate: ModuleType,
+) -> None:
+    statements = gate._plan_seed_statements(_agent_channels_columns(gate))
+
+    rendered = "\n".join(statements)
+    binding_statements = [
+        statement for statement in statements if "curie.agent_channels" in statement
+    ]
+    assert binding_statements, "the agent_channels branch must write bindings"
+    binding_text = "\n".join(binding_statements)
+    for column in ("agent_id", "kind", "address"):
+        assert column in binding_text
+    assert "slack_channel" not in rendered
+    for agent in gate.SEED_FIXTURE:
+        assert agent.name in rendered
+        assert agent.address in binding_text
+        assert agent.kind in binding_text
+
+
+def test_legacy_branch_seeds_the_pre_0034_approval_route_shape(
+    gate: ModuleType,
+) -> None:
+    """Pre-0034 storage: `{"deploy": {"channel": ...}}`, rewritten on the way up."""
+    rendered = "\n".join(gate._plan_seed_statements(_legacy_columns(gate)))
+
+    routed = next(
+        agent
+        for agent in gate.SEED_FIXTURE
+        if agent.approval_route_address is not None
+    )
+    assert "approval_routes" in rendered
+    assert "channel" in rendered
+    assert routed.approval_route_address in rendered
+
+
+def test_agent_channels_branch_seeds_the_post_0034_approval_route_shape(
+    gate: ModuleType,
+) -> None:
+    """Post-0034 storage: the split `{"resolution": {"kind", "address"}}` shape."""
+    rendered = "\n".join(gate._plan_seed_statements(_agent_channels_columns(gate)))
+
+    routed = next(
+        agent
+        for agent in gate.SEED_FIXTURE
+        if agent.approval_route_address is not None
+    )
+    assert "approval_routes" in rendered
+    assert "resolution" in rendered
+    assert routed.approval_route_address in rendered
+
+
+def test_neither_binding_location_raises_naming_both_candidates(
+    gate: ModuleType,
+) -> None:
+    """A seed that no-ops turns the read-back into a vacuous pass. Fail instead."""
+    columns = (
+        _column(gate, "agents", "id", nullable=False, default="gen_random_uuid()"),
+        _column(gate, "agents", "name", nullable=False),
+    )
+
+    with pytest.raises(gate.GateError) as excinfo:
+        gate._plan_seed_statements(columns)
+
+    message = str(excinfo.value)
+    assert "agents.slack_channel" in message
+    assert "agent_channels" in message
+
+
+def test_an_unfilled_mandatory_column_raises_naming_that_column(
+    gate: ModuleType,
+) -> None:
+    """The next person to add a NOT NULL column is told what to add.
+
+    Without this they get a bare Postgres not-null error from inside a CI gate
+    they did not write.
+    """
+
+    columns = (
+        *_legacy_columns(gate),
+        _column(gate, "agents", "gate_probe_required", nullable=False),
+    )
+
+    with pytest.raises(gate.GateError) as excinfo:
+        gate._plan_seed_statements(columns)
+
+    assert "gate_probe_required" in str(excinfo.value)
+
+
+# --------------------------------------------------------------------------
+# T5 -- the read-back runner's pure assertion helper
+# --------------------------------------------------------------------------
+
+PYDANTIC_TEXT = (
+    "1 validation error for AgentOut\nchannel.address\n  Value error, "
+    "slack channel 'C-0a1b2c3d' is not a Slack channel ID"
+)
+
+
+def _expected_names(gate: ModuleType) -> tuple[str, ...]:
+    return tuple(agent.name for agent in gate.SEED_FIXTURE)
+
+
+def _expected_addresses(gate: ModuleType) -> tuple[str, ...]:
+    return tuple(agent.address for agent in gate.SEED_FIXTURE)
+
+
+def _dump(readback: ModuleType, name: str, address: str) -> Any:
+    """One agent that serialized cleanly, with its address nested as it really is."""
+    return readback.AgentDump(
+        name=name,
+        addresses=(address,),
+        dump={
+            "name": name,
+            "channels": [{"kind": "slack", "address": address}],
+        },
+        error=None,
+    )
+
+
+def _all_dumps(gate: ModuleType, readback: ModuleType) -> tuple[Any, ...]:
+    return tuple(
+        _dump(readback, agent.name, agent.address) for agent in gate.SEED_FIXTURE
+    )
+
+
+def test_an_empty_result_set_is_a_failure_not_a_pass(
+    gate: ModuleType, readback: ModuleType
+) -> None:
+    """The vacuous-pass guard: zero rows means the seed did nothing."""
+    failures = readback._collect_failures(
+        (),
+        expected_agents=_expected_names(gate),
+        expected_addresses=_expected_addresses(gate),
+    )
+
+    assert failures
+    assert any("no agents" in failure.lower() for failure in failures)
+
+
+def test_all_expectations_met_reports_no_failures(
+    gate: ModuleType, readback: ModuleType
+) -> None:
+    """Positive control for the helper."""
+    failures = readback._collect_failures(
+        _all_dumps(gate, readback),
+        expected_agents=_expected_names(gate),
+        expected_addresses=_expected_addresses(gate),
+    )
+
+    assert failures == ()
+
+
+def test_a_dump_missing_an_expected_address_names_that_address(
+    gate: ModuleType, readback: ModuleType
+) -> None:
+    """A migration that silently drops the seeded row must not read green."""
+    dropped = gate.SEED_FIXTURE[1]
+    dumps = tuple(
+        readback.AgentDump(
+            name=dropped.name, addresses=(), dump={"name": dropped.name}, error=None
+        )
+        if agent.name == dropped.name
+        else _dump(readback, agent.name, agent.address)
+        for agent in gate.SEED_FIXTURE
+    )
+
+    failures = readback._collect_failures(
+        dumps,
+        expected_agents=_expected_names(gate),
+        expected_addresses=_expected_addresses(gate),
+    )
+
+    assert any(dropped.address in failure for failure in failures)
+
+
+def test_a_missing_expected_agent_name_is_reported(
+    gate: ModuleType, readback: ModuleType
+) -> None:
+    missing = gate.SEED_FIXTURE[0]
+    dumps = tuple(
+        _dump(readback, agent.name, agent.address)
+        for agent in gate.SEED_FIXTURE
+        if agent.name != missing.name
+    )
+
+    failures = readback._collect_failures(
+        dumps,
+        expected_agents=_expected_names(gate),
+        expected_addresses=_expected_addresses(gate),
+    )
+
+    assert any(missing.name in failure for failure in failures)
+
+
+def test_a_validation_failure_names_the_data_before_pydantic(
+    gate: ModuleType, readback: ModuleType
+) -> None:
+    """#1914's literal complaint: "an error naming Pydantic rather than the data".
+
+    Ordering, not membership. An operator reading the CI log must see WHICH agent
+    and WHICH address before the traceback text explains itself.
+    """
+
+    broken = gate.SEED_FIXTURE[1]
+    dumps = tuple(
+        readback.AgentDump(
+            name=broken.name,
+            addresses=(broken.address,),
+            dump=None,
+            error=PYDANTIC_TEXT,
+        )
+        if agent.name == broken.name
+        else _dump(readback, agent.name, agent.address)
+        for agent in gate.SEED_FIXTURE
+    )
+
+    failures = readback._collect_failures(
+        dumps,
+        expected_agents=_expected_names(gate),
+        expected_addresses=_expected_addresses(gate),
+    )
+
+    rendered = next(
+        failure
+        for failure in failures
+        if broken.name in failure and "validation error" in failure
+    )
+    name_index = rendered.index(broken.name)
+    address_index = rendered.index(broken.address)
+    pydantic_index = rendered.index("1 validation error for AgentOut")
+    assert name_index < pydantic_index
+    assert address_index < pydantic_index

--- a/scripts/check-released-upgrade.py
+++ b/scripts/check-released-upgrade.py
@@ -166,6 +166,14 @@ SEED_FIXTURE: tuple[SeedAgent, ...] = (
 )
 
 
+# The two `agents.approval_routes` storage eras, split by migration 0034
+# (#1460). They are named constants because the era is a REQUIRED argument to
+# the seed planner: a mistyped string must raise rather than quietly select a
+# shape, which is the failure #2098 is closing here.
+APPROVAL_ROUTE_ERA_LEGACY = "legacy"
+APPROVAL_ROUTE_ERA_SPLIT = "split"
+
+
 @dataclass(frozen=True)
 class ColumnInfo:
     """One `information_schema.columns` row from the scratch database.
@@ -549,21 +557,75 @@ def _verify_mandatory_columns(
         )
 
 
-def _plan_seed_statements(columns: tuple[ColumnInfo, ...]) -> tuple[str, ...]:
+def _detect_approval_route_era(released_tree: Path) -> str:
+    """Decide which `approval_routes` shape the RELEASED code actually stored.
+
+    This is a SECOND era, independent of the 0021 channel-storage era that
+    `_plan_seed_statements` branches on (#2098). 0021 moved the channel binding
+    into `curie.agent_channels`; 0034 (#1460) rewrote the approval route from
+    `{"deploy": {"channel": X}}` into the split
+    `{"deploy": {"resolution": {"kind": ..., "address": X}}}`. A released ref can
+    sit BETWEEN them -- v0.7.0..v0.7.3 is post-0021 and pre-0034 -- so reading
+    the route shape off the channel discriminator seeds a FUTURE-shaped row the
+    released code could never have produced. The candidate's 0034 then rejects
+    `resolution` as an unknown legacy key and the gate blames the migration for
+    its own fixture, which is the worst failure mode a truth-telling gate has.
+
+    The DATABASE cannot answer this, so do not "fix" this into an
+    `information_schema` query. 0034 rewrites JSONB *content* only: it adds no
+    column, drops none, and adds no constraint, and the freshly-upgraded scratch
+    database is still empty, so there is no row whose shape could be observed.
+
+    The released WORKTREE is the authority instead. `_upgrade_pair` runs
+    `alembic upgrade head` against this tree, so every revision file present in
+    it HAS been applied by the time the seed runs.
+    """
+
+    versions = released_tree / "apps" / "api" / "alembic" / "versions"
+    if not versions.is_dir():
+        # No versions directory means the tree is not what we think it is.
+        # Guessing an era there is exactly how the bug above happens, so refuse.
+        raise GateError(
+            f"the released worktree has no alembic versions directory at "
+            f"{versions}, so the approval-route era cannot be determined; "
+            "refusing to guess an era and seed a route shape the released "
+            "code may never have stored"
+        )
+    if any(versions.glob("0034_*.py")):
+        return APPROVAL_ROUTE_ERA_SPLIT
+    return APPROVAL_ROUTE_ERA_LEGACY
+
+
+def _plan_seed_statements(
+    columns: tuple[ColumnInfo, ...],
+    *,
+    approval_route_era: str,
+) -> tuple[str, ...]:
     """Render the SQL that writes `SEED_FIXTURE` into the released schema.
 
-    Branches on `agents.slack_channel` -- the pre/post-0021 discriminator -- and
-    that same discriminator selects the `approval_routes` shape, because the 0021
-    era and the 0034 era coincide at both refs we pin. That coupling is an
-    assumption rather than a law, and it is made safe by the read-back: a future
-    released ref landing between the eras makes the seeded route go missing from
-    the dump, and the read-back FAILS naming the address instead of passing
-    vacuously.
+    Branches on `agents.slack_channel` -- the pre/post-0021 discriminator -- for
+    the channel binding, and on `approval_route_era` for the route shape. The two
+    are INDEPENDENT migration eras and must not be read off one discriminator
+    (#2098): a released ref between 0021 and 0034 gets the channel binding from
+    the schema and the route shape from the released tree.
+
+    `approval_route_era` is a required keyword with NO default on purpose. A
+    default is a silent wrong-era guess, and a silent wrong-era guess is the bug.
 
     Raises `GateError` rather than returning an empty plan when neither binding
     location exists. A seed that no-ops turns the read-back into a vacuous pass,
     which is the exact class of failure #2098 exists to close.
     """
+
+    if approval_route_era not in (
+        APPROVAL_ROUTE_ERA_LEGACY,
+        APPROVAL_ROUTE_ERA_SPLIT,
+    ):
+        raise GateError(
+            f"unrecognized approval route era {approval_route_era!r}; expected "
+            f"{APPROVAL_ROUTE_ERA_LEGACY!r} (pre-0034) or "
+            f"{APPROVAL_ROUTE_ERA_SPLIT!r} (post-0034)"
+        )
 
     present = {(column.table_name, column.column_name) for column in columns}
     statements: list[str] = []
@@ -574,12 +636,15 @@ def _plan_seed_statements(columns: tuple[ColumnInfo, ...]) -> tuple[str, ...]:
             filled={"agents": {"id", "name", "slack_channel", "approval_routes"}},
         )
         for agent in SEED_FIXTURE:
+            # `slack_channel` present means pre-0021, and 0021 precedes 0034, so
+            # this branch is pre-0034 by construction: the `slack_channel` +
+            # `split` quadrant cannot exist and nothing here is conditioned on
+            # the era. Pre-0034 storage; migration 0034 (#1460) rewrites it into
+            # the split `resolution` shape on the way up with NO validation,
+            # which is what carries the legacy address into the read models.
             route = _json_literal(
                 None
                 if agent.approval_route_address is None
-                # Pre-0034 storage. Migration 0034 rewrites it into the split
-                # `resolution` shape on the way up with NO validation, which is
-                # what carries the legacy address forward into the read models.
                 else {"deploy": {"channel": agent.approval_route_address}}
             )
             statements.append(
@@ -598,12 +663,13 @@ def _plan_seed_statements(columns: tuple[ColumnInfo, ...]) -> tuple[str, ...]:
                 "agent_channels": {"id", "agent_id", "kind", "address"},
             },
         )
+        split_era = approval_route_era == APPROVAL_ROUTE_ERA_SPLIT
         for agent in SEED_FIXTURE:
-            route = _json_literal(
-                None
-                if agent.approval_route_address is None
+            if agent.approval_route_address is None:
+                route_value: dict[str, Any] | None = None
+            elif split_era:
                 # Post-0034 storage: already the split shape.
-                else {
+                route_value = {
                     "deploy": {
                         "resolution": {
                             "kind": agent.kind,
@@ -611,7 +677,14 @@ def _plan_seed_statements(columns: tuple[ColumnInfo, ...]) -> tuple[str, ...]:
                         }
                     }
                 }
-            )
+            else:
+                # Post-0021 but pre-0034 (v0.7.0..v0.7.3). The channel binding
+                # already lives in `agent_channels`, yet the route is still the
+                # legacy `channel` shape -- seeding `resolution` here writes a
+                # fixture the released code could never have produced, and the
+                # candidate's 0034 rejects it as an unknown legacy key (#2098).
+                route_value = {"deploy": {"channel": agent.approval_route_address}}
+            route = _json_literal(route_value)
             # One statement per agent, so the binding is written in the same
             # transaction as the row it belongs to and the new id never has to be
             # round-tripped back through psql. `endpoint` / `adapter` are left
@@ -639,7 +712,12 @@ def _plan_seed_statements(columns: tuple[ColumnInfo, ...]) -> tuple[str, ...]:
     )
 
 
-def _seed_released_database(database_name: str, *, phase: str) -> None:
+def _seed_released_database(
+    database_name: str,
+    *,
+    phase: str,
+    approval_route_era: str,
+) -> None:
     """Write the fixture into the released database, between the two upgrades.
 
     Every failure in here is a SETUP fault, not a gate verdict: it raises
@@ -650,7 +728,9 @@ def _seed_released_database(database_name: str, *, phase: str) -> None:
 
     print(f"=== {phase}: {database_name} ===", flush=True)
     columns = _introspect_columns(database_name)
-    statements = _plan_seed_statements(columns)
+    statements = _plan_seed_statements(
+        columns, approval_route_era=approval_route_era
+    )
     for statement in statements:
         _checked_output(
             _database_command(statement, database_name=database_name),
@@ -722,7 +802,15 @@ def _upgrade_pair(
     # window in which the released schema is what an operator's database actually
     # looks like. Seeding earlier has no schema to write into; seeding later
     # writes rows the candidate migrations never had to carry.
-    _seed_released_database(database_name, phase="seed")
+    #
+    # The route era is detected HERE, from the released tree, and not from the
+    # schema the seed introspects: the 0021 and 0034 eras are independent and a
+    # released ref can sit between them (#2098).
+    _seed_released_database(
+        database_name,
+        phase="seed",
+        approval_route_era=_detect_approval_route_era(released_tree),
+    )
 
     for phase, tree, ref, commit, arguments in candidate_phases:
         result = _run_alembic(

--- a/scripts/check-released-upgrade.py
+++ b/scripts/check-released-upgrade.py
@@ -1,6 +1,28 @@
-"""Verify that the candidate migrations upgrade the latest released database."""
+"""Verify that the candidate migrations upgrade the latest released database.
+
+The gate walks six phases per pair:
+
+    released upgrade -> released head check -> SEED
+        -> candidate upgrade -> candidate head check -> READ-BACK
+
+The four alembic phases are #1706's original contract: they prove the candidate
+migrations RUN against a database stamped by the released line. The two phases
+added by #2098 prove the RESULT IS READABLE, which is a different claim and the
+one #1914 needed: migration 0021 backfilled `curie.agent_channels` verbatim out
+of `agents.slack_channel`, the copied rows then failed `ChannelBinding`'s
+address rule, and `GET /agents` returned 500 for every agent while every
+migration in the chain had reported success.
+
+SEED writes rows in the shapes the RELEASED code actually permitted, straight
+into the scratch database over SQL. It deliberately does not go through a
+current-HEAD model: constructing rows that satisfy today's validators would
+prove only that today's validators accept what they just produced. READ-BACK
+then serializes the migrated rows through the CANDIDATE tree's `AgentOut` and
+requires that they load.
+"""
 
 import argparse
+import json
 import os
 import re
 import secrets
@@ -11,13 +33,152 @@ import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from types import FrameType
+from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 COMPOSE_FILE = REPO_ROOT / "compose.dev.yaml"
 STABLE_TAG_PATTERN = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
 COMMIT_PATTERN = re.compile(r"^[0-9a-f]+$")
-SELF_TEST_RELEASED_REF = "v0.6.2"
-SELF_TEST_CANDIDATE_REF = "v0.7.0-rc.1"
+# Always HEAD's copy of the runner, never the tree being judged. See that file's
+# docstring: it is one fixed assertion harness executed inside the candidate's
+# environment, so the thing that varies across directions is the package it
+# imports, not the assertions themselves.
+READBACK_SCRIPT = REPO_ROOT / "scripts" / "released_upgrade_readback.py"
+
+
+@dataclass(frozen=True)
+class SelfTestDirection:
+    """One pinned `--self-test` pair and the outcome it must produce.
+
+    `expect_failure_phase` is the phase the pair MUST fail in, or `None` for a
+    direction that must pass cleanly. `markers` are substrings the failure output
+    must contain -- they are the defense against the right phase failing for the
+    wrong reason, which is not hypothetical: a `MissingGreenlet` in the read-back
+    also lands in the `read-back` phase, and only the markers separate "the
+    failure we pinned" from "some failure".
+    """
+
+    released_ref: str
+    candidate_ref: str
+    expect_failure_phase: str | None
+    markers: tuple[str, ...]
+
+
+# The pinned directions. #1706's negative control is the FIRST row and is
+# retained verbatim, markers included -- a self test that only knows how to fail
+# is inert, and one that has lost its must-fail direction is worse. The other two
+# rows are #2098's addition, and they are what keep both seed branches alive:
+# every direction seeds through the legacy `agents.slack_channel` column (v0.6.2
+# is pre-0021), while the bare gate is `v0.8.0 -> HEAD` and seeds through
+# `agent_channels`.
+SELF_TEST_DIRECTIONS: tuple[SelfTestDirection, ...] = (
+    SelfTestDirection(
+        released_ref="v0.6.2",
+        candidate_ref="v0.7.0-rc.1",
+        expect_failure_phase="candidate upgrade",
+        markers=(
+            "asyncpg.exceptions.UndefinedTableError",
+            'relation "curie.agent_channels" does not exist',
+            "0022_approvals_reply_kind.py",
+        ),
+    ),
+    SelfTestDirection(
+        # #1914's reproduction. v0.6.2 upgrades to v0.7.3 CLEANLY today, so the
+        # only thing that can redden this direction is the read-back phase --
+        # which makes it a clean pin on the read path rather than on migrations.
+        released_ref="v0.6.2",
+        candidate_ref="v0.7.3",
+        expect_failure_phase="read-back",
+        markers=("C-0a1b2c3d", "is not a Slack channel ID"),
+    ),
+    SelfTestDirection(
+        # The must-PASS direction: v0.8.0 is the first tag containing the
+        # tolerant `ChannelBindingOut`, so the same legacy rows that break
+        # v0.7.3 must serialize here.
+        released_ref="v0.6.2",
+        candidate_ref="v0.8.0",
+        expect_failure_phase=None,
+        markers=(),
+    ),
+)
+
+
+@dataclass(frozen=True)
+class SeedAgent:
+    """One row the seed writes before the candidate upgrade.
+
+    `legacy` means the address is a shape the RELEASED code stored but the
+    CURRENT write validator rejects. That flag is asserted against the live
+    `curie_api.schemas._validate_channel_binding` in the gate's tests, so an
+    address softened to make the gate green stops being legacy and reddens the
+    suite instead.
+
+    `approval_route_address` seeds `agents.approval_routes` with a route
+    resolving to the same rejected address. Without it the sibling read
+    projections (`ApprovalTargetOut`, `ApprovalApproversOut`,
+    `ApprovalRouteBindingOut`) -- made tolerant by the SAME fix commit as
+    `ChannelBindingOut` -- could be reverted with the gate staying green.
+    """
+
+    name: str
+    address: str
+    kind: str
+    legacy: bool
+    approval_route_address: str | None
+
+
+# Three agents, one binding each. The names are prefixed `gate-` so they are
+# unmistakably synthetic, and all three names and all three addresses are
+# distinct so neither the seed nor 0021's backfill can trip
+# `agents_slack_channel_key` / `agent_channels_kind_address_key`.
+#
+# `C0EXAMPLE1` is the repo's sanctioned placeholder Slack id (`.gitleaks.toml`
+# stopword); `#general` and `C-0a1b2c3d` cannot match the scanner's
+# conversation-id rule at all.
+SEED_FIXTURE: tuple[SeedAgent, ...] = (
+    SeedAgent(
+        # #143's shape: a literal channel NAME, stored before the validator
+        # existed and reported as a success at the time.
+        name="gate-legacy-hash",
+        address="#general",
+        kind="slack",
+        legacy=True,
+        approval_route_address=None,
+    ),
+    SeedAgent(
+        # #1914's shape, exactly: a `C-<hex>` address.
+        name="gate-legacy-prefix",
+        address="C-0a1b2c3d",
+        kind="slack",
+        legacy=True,
+        approval_route_address="C-0a1b2c3d",
+    ),
+    SeedAgent(
+        # The valid neighbour. It is what proves the "one bad row takes the
+        # whole endpoint down" property: a tolerant read path must return
+        # EVERY agent, not merely the ones that happen to be well-formed.
+        name="gate-valid",
+        address="C0EXAMPLE1",
+        kind="slack",
+        legacy=False,
+        approval_route_address=None,
+    ),
+)
+
+
+@dataclass(frozen=True)
+class ColumnInfo:
+    """One `information_schema.columns` row from the scratch database.
+
+    `is_nullable` keeps Postgres' verbatim `"YES"` / `"NO"` rather than being
+    coerced to a bool, so a mis-parsed introspection row cannot quietly read as
+    "nullable" and disarm the mandatory-column check below.
+    """
+
+    table_name: str
+    column_name: str
+    is_nullable: str
+    column_default: str | None
 
 
 class GateError(RuntimeError):
@@ -119,7 +280,15 @@ def _check_postgres() -> None:
     )
 
 
-def _database_command(sql: str) -> list[str]:
+def _database_command(sql: str, *, database_name: str = "postgres") -> list[str]:
+    """psql into `database_name`, defaulting to the maintenance database.
+
+    The default keeps every pre-#2098 caller (`_reset_database`, `_cleanup`)
+    byte-for-byte identical: DROP/CREATE DATABASE cannot be issued from inside
+    the database being dropped. The seed is the only caller that needs the
+    SCRATCH database, and it is the reason this parameter exists.
+    """
+
     return _compose_command(
         "exec",
         "-T",
@@ -128,11 +297,39 @@ def _database_command(sql: str) -> list[str]:
         "-U",
         "postgres",
         "-d",
-        "postgres",
+        database_name,
         "-v",
         "ON_ERROR_STOP=1",
         "-c",
         sql,
+    )
+
+
+def _scratch_query(database_name: str, sql: str) -> str:
+    """Run a read-only query against the scratch database and return stdout.
+
+    `-t -A` strips the header, the row-count footer and the column padding, so
+    the caller parses `|`-separated fields instead of psql's table art.
+    """
+
+    return _checked_output(
+        _compose_command(
+            "exec",
+            "-T",
+            "postgres",
+            "psql",
+            "-U",
+            "postgres",
+            "-d",
+            database_name,
+            "-t",
+            "-A",
+            "-v",
+            "ON_ERROR_STOP=1",
+            "-c",
+            sql,
+        ),
+        description=f"querying scratch database {database_name}",
     )
 
 
@@ -198,17 +395,285 @@ def _run_alembic(
     return CommandResult(completed.returncode, output)
 
 
+def _readback_command(tree: Path, *arguments: str) -> list[str]:
+    """Run HEAD's read-back runner inside `tree`'s environment.
+
+    The `uv run --frozen --project <tree> --directory <tree>/apps/api` prefix is
+    `_alembic_command`'s, verbatim, because it is the same trick: resolve the
+    executable's dependencies from the tree under judgement. The inversion here
+    is that the SCRIPT is HEAD's (`READBACK_SCRIPT`, never `tree`'s copy) while
+    the `curie_api` it imports is the tree's -- one fixed assertion harness
+    pointed at whichever read models we are judging.
+    """
+
+    return [
+        "uv",
+        "run",
+        "--frozen",
+        "--project",
+        str(tree),
+        "--directory",
+        str(tree / "apps" / "api"),
+        "python",
+        str(READBACK_SCRIPT),
+        *arguments,
+    ]
+
+
+def _run_readback(
+    tree: Path,
+    *,
+    database_url: str,
+    phase: str,
+    ref: str,
+    commit: str,
+) -> CommandResult:
+    """Follow `_run_alembic`'s contract exactly: banner, env, combined output.
+
+    The output has to come back combined and echoed for the same reason the
+    alembic phases do -- `_run_self_test` pins markers against it, and a marker
+    that landed on a stderr stream the caller never captured is a marker that
+    silently stops defending anything.
+
+    Only `DATABASE_URL` is added to the environment. `curie_api` was verified to
+    import with nothing else set at v0.7.3, v0.8.0 and HEAD; a candidate that
+    needs more would fail here loudly rather than skip the phase.
+    """
+
+    arguments: list[str] = []
+    for agent in SEED_FIXTURE:
+        arguments.extend(("--expect-agent", agent.name))
+    for agent in SEED_FIXTURE:
+        arguments.extend(("--expect-address", agent.address))
+
+    print(f"=== {phase}: {ref} ({commit}) ===", flush=True)
+    environment = os.environ.copy()
+    environment["DATABASE_URL"] = database_url
+    try:
+        completed = subprocess.run(
+            _readback_command(tree, *arguments),
+            cwd=REPO_ROOT,
+            env=environment,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+    except OSError as exc:
+        raise GateError(f"could not run {phase}: {exc}") from exc
+    output = completed.stdout or ""
+    if output:
+        print(output, end="" if output.endswith("\n") else "\n")
+    return CommandResult(completed.returncode, output)
+
+
+def _sql_literal(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _json_literal(payload: dict[str, Any] | None) -> str:
+    if payload is None:
+        return "NULL"
+    return f"{_sql_literal(json.dumps(payload))}::jsonb"
+
+
+def _introspect_columns(database_name: str) -> tuple[ColumnInfo, ...]:
+    """Read the scratch database's `curie` schema after the released upgrade.
+
+    The seed cannot be written against one hard-coded schema: the released ref is
+    `v0.6.2` for the `--self-test` directions (pre-0021, `agents.slack_channel`)
+    and the latest stable tag for the bare gate (post-0021, `agent_channels`).
+    Introspecting is what lets one fixture serve both.
+    """
+
+    rows = _scratch_query(
+        database_name,
+        "SELECT table_name, column_name, is_nullable, "
+        "coalesce(column_default, '') FROM information_schema.columns "
+        "WHERE table_schema = 'curie' ORDER BY table_name, ordinal_position",
+    )
+    columns: list[ColumnInfo] = []
+    for line in rows.splitlines():
+        if not line.strip():
+            continue
+        # maxsplit=3: a column DEFAULT expression may itself contain a `|`, and
+        # it is the last field, so everything after the third separator is it.
+        fields = line.split("|", 3)
+        if len(fields) != 4:
+            raise GateError(f"could not parse an information_schema row: {line!r}")
+        table_name, column_name, is_nullable, column_default = fields
+        columns.append(
+            ColumnInfo(
+                table_name=table_name,
+                column_name=column_name,
+                is_nullable=is_nullable,
+                # psql renders SQL NULL as an empty field under `-t -A`, and a
+                # real default is never the empty string, so the round-trip is
+                # unambiguous.
+                column_default=column_default or None,
+            )
+        )
+    return tuple(columns)
+
+
+def _verify_mandatory_columns(
+    columns: tuple[ColumnInfo, ...],
+    *,
+    filled: dict[str, set[str]],
+) -> None:
+    """Refuse to seed if a mandatory column the fixture does not fill exists.
+
+    Only the tables this branch actually writes are checked; a table the branch
+    ignores has no rows to be incomplete.
+
+    The value here is the message, not the rejection: without it, the next person
+    to add a NOT NULL column without a server default gets a bare Postgres
+    not-null error from inside a CI gate they did not write. With it, they are
+    told which column to teach the fixture about.
+    """
+
+    unfilled = [
+        f"{column.table_name}.{column.column_name}"
+        for column in columns
+        if column.table_name in filled
+        and column.is_nullable == "NO"
+        and column.column_default is None
+        and column.column_name not in filled[column.table_name]
+    ]
+    if unfilled:
+        raise GateError(
+            "the released-upgrade seed fixture does not fill these mandatory "
+            f"columns: {', '.join(unfilled)}. Add a value for each to "
+            "SEED_FIXTURE's rendered statements in scripts/"
+            "check-released-upgrade.py."
+        )
+
+
+def _plan_seed_statements(columns: tuple[ColumnInfo, ...]) -> tuple[str, ...]:
+    """Render the SQL that writes `SEED_FIXTURE` into the released schema.
+
+    Branches on `agents.slack_channel` -- the pre/post-0021 discriminator -- and
+    that same discriminator selects the `approval_routes` shape, because the 0021
+    era and the 0034 era coincide at both refs we pin. That coupling is an
+    assumption rather than a law, and it is made safe by the read-back: a future
+    released ref landing between the eras makes the seeded route go missing from
+    the dump, and the read-back FAILS naming the address instead of passing
+    vacuously.
+
+    Raises `GateError` rather than returning an empty plan when neither binding
+    location exists. A seed that no-ops turns the read-back into a vacuous pass,
+    which is the exact class of failure #2098 exists to close.
+    """
+
+    present = {(column.table_name, column.column_name) for column in columns}
+    statements: list[str] = []
+
+    if ("agents", "slack_channel") in present:
+        _verify_mandatory_columns(
+            columns,
+            filled={"agents": {"id", "name", "slack_channel", "approval_routes"}},
+        )
+        for agent in SEED_FIXTURE:
+            route = _json_literal(
+                None
+                if agent.approval_route_address is None
+                # Pre-0034 storage. Migration 0034 rewrites it into the split
+                # `resolution` shape on the way up with NO validation, which is
+                # what carries the legacy address forward into the read models.
+                else {"deploy": {"channel": agent.approval_route_address}}
+            )
+            statements.append(
+                "INSERT INTO curie.agents (id, name, slack_channel, "
+                "approval_routes)\n"
+                f"VALUES (gen_random_uuid(), {_sql_literal(agent.name)}, "
+                f"{_sql_literal(agent.address)}, {route})"
+            )
+        return tuple(statements)
+
+    if ("agent_channels", "address") in present:
+        _verify_mandatory_columns(
+            columns,
+            filled={
+                "agents": {"id", "name", "approval_routes"},
+                "agent_channels": {"id", "agent_id", "kind", "address"},
+            },
+        )
+        for agent in SEED_FIXTURE:
+            route = _json_literal(
+                None
+                if agent.approval_route_address is None
+                # Post-0034 storage: already the split shape.
+                else {
+                    "deploy": {
+                        "resolution": {
+                            "kind": agent.kind,
+                            "address": agent.approval_route_address,
+                        }
+                    }
+                }
+            )
+            # One statement per agent, so the binding is written in the same
+            # transaction as the row it belongs to and the new id never has to be
+            # round-tripped back through psql. `endpoint` / `adapter` are left
+            # NULL, which is the posture `agent_channels_route_pair_ck` permits
+            # and the one 0024 backfills existing rows to.
+            statements.append(
+                "WITH seeded AS (\n"
+                "    INSERT INTO curie.agents (id, name, approval_routes)\n"
+                f"    VALUES (gen_random_uuid(), {_sql_literal(agent.name)}, "
+                f"{route})\n"
+                "    RETURNING id\n"
+                ")\n"
+                "INSERT INTO curie.agent_channels (id, agent_id, kind, address)\n"
+                f"SELECT gen_random_uuid(), seeded.id, "
+                f"{_sql_literal(agent.kind)}, {_sql_literal(agent.address)}\n"
+                "FROM seeded"
+            )
+        return tuple(statements)
+
+    raise GateError(
+        "the released schema has neither agents.slack_channel nor an "
+        "agent_channels.address column, so the seed has nowhere to write a "
+        "channel binding; refusing to run a read-back that would pass "
+        "vacuously"
+    )
+
+
+def _seed_released_database(database_name: str, *, phase: str) -> None:
+    """Write the fixture into the released database, between the two upgrades.
+
+    Every failure in here is a SETUP fault, not a gate verdict: it raises
+    `GateError`, which `main` reports as `Released upgrade gate failed:` and
+    exit 1, distinct from a `PairResult` verdict. A broken seed must never be
+    reported as "the migration is fine" or as "the read path is broken".
+    """
+
+    print(f"=== {phase}: {database_name} ===", flush=True)
+    columns = _introspect_columns(database_name)
+    statements = _plan_seed_statements(columns)
+    for statement in statements:
+        _checked_output(
+            _database_command(statement, database_name=database_name),
+            description=f"seeding the released database {database_name}",
+        )
+    print(
+        f"Seeded {len(statements)} released-shaped agent rows into "
+        f"{database_name}."
+    )
+
+
 def _upgrade_pair(
     released_tree: Path,
     candidate_tree: Path,
     *,
     database_url: str,
+    database_name: str,
     released_ref: str,
     released_commit: str,
     candidate_ref: str,
     candidate_commit: str,
 ) -> PairResult:
-    phases = (
+    released_phases = (
         (
             "released upgrade",
             released_tree,
@@ -223,6 +688,8 @@ def _upgrade_pair(
             released_commit,
             ("current", "--check-heads"),
         ),
+    )
+    candidate_phases = (
         (
             "candidate upgrade",
             candidate_tree,
@@ -238,7 +705,8 @@ def _upgrade_pair(
             ("current", "--check-heads"),
         ),
     )
-    for phase, tree, ref, commit, arguments in phases:
+
+    for phase, tree, ref, commit, arguments in released_phases:
         result = _run_alembic(
             tree,
             database_url=database_url,
@@ -249,7 +717,33 @@ def _upgrade_pair(
         )
         if result.returncode != 0:
             return PairResult(phase, result.returncode, result.output)
-    return PairResult("candidate head check", 0, "")
+
+    # The seed sits HERE, between the two lines' phases, because that is the only
+    # window in which the released schema is what an operator's database actually
+    # looks like. Seeding earlier has no schema to write into; seeding later
+    # writes rows the candidate migrations never had to carry.
+    _seed_released_database(database_name, phase="seed")
+
+    for phase, tree, ref, commit, arguments in candidate_phases:
+        result = _run_alembic(
+            tree,
+            database_url=database_url,
+            phase=phase,
+            ref=ref,
+            commit=commit,
+            arguments=arguments,
+        )
+        if result.returncode != 0:
+            return PairResult(phase, result.returncode, result.output)
+
+    readback = _run_readback(
+        candidate_tree,
+        database_url=database_url,
+        phase="read-back",
+        ref=candidate_ref,
+        commit=candidate_commit,
+    )
+    return PairResult("read-back", readback.returncode, readback.output)
 
 
 def _cleanup(
@@ -329,6 +823,7 @@ def _run_pair(
                 released_tree,
                 candidate_tree,
                 database_url=database_url,
+                database_name=database_name,
                 released_ref=released_ref,
                 released_commit=released_commit,
                 candidate_ref=candidate_ref,
@@ -342,39 +837,86 @@ def _run_pair(
             )
 
 
-def _run_self_test() -> int:
-    released_commit = _resolve_ref(SELF_TEST_RELEASED_REF)
-    candidate_commit = _resolve_ref(SELF_TEST_CANDIDATE_REF)
+def _describe(direction: SelfTestDirection) -> str:
+    return f"{direction.released_ref} to {direction.candidate_ref}"
+
+
+def _check_direction(direction: SelfTestDirection) -> str | None:
+    """Run one pinned direction. Returns a mismatch description, or None on match.
+
+    It RETURNS the mismatch instead of raising it so `_run_self_test` can walk
+    every direction and report all of them. A self test that stops at the first
+    mismatch hides the second one behind a fix for the first, and the whole point
+    of the table is that the directions defend different properties.
+    """
+
     result = _run_pair(
-        released_ref=SELF_TEST_RELEASED_REF,
-        released_commit=released_commit,
-        candidate_ref=SELF_TEST_CANDIDATE_REF,
-        candidate_commit=candidate_commit,
+        released_ref=direction.released_ref,
+        released_commit=_resolve_ref(direction.released_ref),
+        candidate_ref=direction.candidate_ref,
+        candidate_commit=_resolve_ref(direction.candidate_ref),
         current_candidate=False,
     )
+
+    if direction.expect_failure_phase is None:
+        if result.returncode != 0:
+            return (
+                f"self test direction {_describe(direction)} was expected to "
+                f"upgrade and read back cleanly, but failed during "
+                f"{result.phase} with exit code {result.returncode}"
+            )
+        return None
+
     if result.returncode == 0:
-        raise GateError("self test pair unexpectedly upgraded successfully")
-    if result.phase != "candidate upgrade":
-        raise GateError(
-            f"self test failed during {result.phase}, before the expected "
-            "candidate collision"
+        return (
+            f"self test direction {_describe(direction)} unexpectedly "
+            f"succeeded; it must fail during {direction.expect_failure_phase}"
         )
-    expected_markers = (
-        "asyncpg.exceptions.UndefinedTableError",
-        'relation "curie.agent_channels" does not exist',
-        "0022_approvals_reply_kind.py",
-    )
+    if result.phase != direction.expect_failure_phase:
+        return (
+            f"self test direction {_describe(direction)} failed during "
+            f"{result.phase}, before the expected "
+            f"{direction.expect_failure_phase} failure"
+        )
     missing_markers = [
-        marker for marker in expected_markers if marker not in result.output
+        marker for marker in direction.markers if marker not in result.output
     ]
     if missing_markers:
-        raise GateError(
-            "self test candidate failure did not report the known revision "
-            f"collision markers: {', '.join(missing_markers)}"
+        # The markers are what separate "the failure we pinned" from "some
+        # failure in the right phase". Dropping this check would let a
+        # MissingGreenlet, or any incidental error, stand in for the defect the
+        # direction exists to reproduce.
+        return (
+            f"self test direction {_describe(direction)} failed during "
+            f"{result.phase} but did not report the known markers: "
+            f"{', '.join(missing_markers)}"
         )
+    return None
+
+
+def _run_self_test() -> int:
+    mismatches: list[str] = []
+    for direction in SELF_TEST_DIRECTIONS:
+        expectation = (
+            "must pass"
+            if direction.expect_failure_phase is None
+            else f"must fail during {direction.expect_failure_phase}"
+        )
+        print(
+            f"=== self test direction {_describe(direction)} ({expectation}) ===",
+            flush=True,
+        )
+        mismatch = _check_direction(direction)
+        if mismatch is not None:
+            mismatches.append(mismatch)
+
+    if mismatches:
+        rendered = "\n".join(f"  {mismatch}" for mismatch in mismatches)
+        raise GateError(f"released upgrade self test mismatched:\n{rendered}")
+
     print(
-        "Released upgrade self test passed by observing the known candidate "
-        "revision collision."
+        f"Released upgrade self test passed across {len(SELF_TEST_DIRECTIONS)} "
+        "pinned directions."
     )
     return 0
 
@@ -445,7 +987,10 @@ def main() -> int:
     parser.add_argument(
         "--self-test",
         action="store_true",
-        help="Require the known v0.6.2 to v0.7.0-rc.1 collision.",
+        help=(
+            "Require every pinned direction: the known revision collision, the "
+            "known read-back failure, and the direction that must pass."
+        ),
     )
     args = parser.parse_args()
 

--- a/scripts/check-released-upgrade.py
+++ b/scripts/check-released-upgrade.py
@@ -45,6 +45,22 @@ COMMIT_PATTERN = re.compile(r"^[0-9a-f]+$")
 # imports, not the assertions themselves.
 READBACK_SCRIPT = REPO_ROOT / "scripts" / "released_upgrade_readback.py"
 
+# The six phase names, in the order `_upgrade_pair` walks them. Each one is a
+# THREE-way coupling -- it is printed in a banner the marker checks read, it is
+# what a `PairResult` reports, and `SELF_TEST_DIRECTIONS.expect_failure_phase`
+# names it -- so they are constants rather than literals hand-synced across the
+# module. The strings themselves are load-bearing and must not be reworded.
+RELEASED_UPGRADE_PHASE = "released upgrade"
+RELEASED_HEAD_CHECK_PHASE = "released head check"
+SEED_PHASE = "seed"
+CANDIDATE_UPGRADE_PHASE = "candidate upgrade"
+CANDIDATE_HEAD_CHECK_PHASE = "candidate head check"
+READBACK_PHASE = "read-back"
+
+# One alembic phase, as `_upgrade_pair` walks it:
+# (phase name, tree, ref, commit, alembic arguments).
+_AlembicPhase = tuple[str, Path, str, str, tuple[str, ...]]
+
 
 @dataclass(frozen=True)
 class SelfTestDirection:
@@ -75,7 +91,7 @@ SELF_TEST_DIRECTIONS: tuple[SelfTestDirection, ...] = (
     SelfTestDirection(
         released_ref="v0.6.2",
         candidate_ref="v0.7.0-rc.1",
-        expect_failure_phase="candidate upgrade",
+        expect_failure_phase=CANDIDATE_UPGRADE_PHASE,
         markers=(
             "asyncpg.exceptions.UndefinedTableError",
             'relation "curie.agent_channels" does not exist',
@@ -88,7 +104,7 @@ SELF_TEST_DIRECTIONS: tuple[SelfTestDirection, ...] = (
         # which makes it a clean pin on the read path rather than on migrations.
         released_ref="v0.6.2",
         candidate_ref="v0.7.3",
-        expect_failure_phase="read-back",
+        expect_failure_phase=READBACK_PHASE,
         markers=("C-0a1b2c3d", "is not a Slack channel ID"),
     ),
     SelfTestDirection(
@@ -288,13 +304,21 @@ def _check_postgres() -> None:
     )
 
 
-def _database_command(sql: str, *, database_name: str = "postgres") -> list[str]:
+def _database_command(
+    sql: str,
+    *,
+    database_name: str = "postgres",
+    flags: tuple[str, ...] = (),
+) -> list[str]:
     """psql into `database_name`, defaulting to the maintenance database.
 
     The default keeps every pre-#2098 caller (`_reset_database`, `_cleanup`)
     byte-for-byte identical: DROP/CREATE DATABASE cannot be issued from inside
     the database being dropped. The seed is the only caller that needs the
     SCRATCH database, and it is the reason this parameter exists.
+
+    `flags` is spliced in ahead of `-v`, so the default empty tuple leaves those
+    callers' argv unchanged; `_scratch_query` is the only caller that passes it.
     """
 
     return _compose_command(
@@ -306,6 +330,7 @@ def _database_command(sql: str, *, database_name: str = "postgres") -> list[str]
         "postgres",
         "-d",
         database_name,
+        *flags,
         "-v",
         "ON_ERROR_STOP=1",
         "-c",
@@ -321,22 +346,7 @@ def _scratch_query(database_name: str, sql: str) -> str:
     """
 
     return _checked_output(
-        _compose_command(
-            "exec",
-            "-T",
-            "postgres",
-            "psql",
-            "-U",
-            "postgres",
-            "-d",
-            database_name,
-            "-t",
-            "-A",
-            "-v",
-            "ON_ERROR_STOP=1",
-            "-c",
-            sql,
-        ),
+        _database_command(sql, database_name=database_name, flags=("-t", "-A")),
         description=f"querying scratch database {database_name}",
     )
 
@@ -359,7 +369,13 @@ def _add_worktree(path: Path, commit: str, *, label: str) -> None:
     )
 
 
-def _alembic_command(tree: Path, *arguments: str) -> list[str]:
+def _tree_command(tree: Path, *arguments: str) -> list[str]:
+    """Resolve an executable's dependencies from the tree under judgement.
+
+    Every phase that runs code runs it this way, so `uv` builds the environment
+    from `<tree>`'s own lockfile rather than from HEAD's.
+    """
+
     return [
         "uv",
         "run",
@@ -368,9 +384,69 @@ def _alembic_command(tree: Path, *arguments: str) -> list[str]:
         str(tree),
         "--directory",
         str(tree / "apps" / "api"),
-        "alembic",
         *arguments,
     ]
+
+
+def _alembic_command(tree: Path, *arguments: str) -> list[str]:
+    return _tree_command(tree, "alembic", *arguments)
+
+
+def _readback_command(tree: Path, *arguments: str) -> list[str]:
+    """Run HEAD's read-back runner inside `tree`'s environment.
+
+    It shares `_alembic_command`'s `_tree_command` prefix because it is the same
+    trick: resolve the executable's dependencies from the tree under judgement.
+    The inversion here is that the SCRIPT is HEAD's (`READBACK_SCRIPT`, never
+    `tree`'s copy) while the `curie_api` it imports is the tree's -- one fixed
+    assertion harness pointed at whichever read models we are judging.
+    """
+
+    return _tree_command(tree, "python", str(READBACK_SCRIPT), *arguments)
+
+
+def _run_in_tree(
+    command: list[str],
+    *,
+    database_url: str,
+    phase: str,
+    ref: str,
+    commit: str,
+) -> CommandResult:
+    """Announce a phase, run it against the scratch database, echo its output.
+
+    Both code-running phase families go through here so neither can drift off
+    the other's contract: banner, copied environment plus `DATABASE_URL`, and
+    stderr folded into stdout.
+
+    The output has to come back combined AND echoed -- `_run_self_test` pins
+    markers against it, and a marker that landed on a stderr stream the caller
+    never captured is a marker that silently stops defending anything.
+
+    Only `DATABASE_URL` is added to the environment. `curie_api` was verified to
+    import with nothing else set at v0.7.3, v0.8.0 and HEAD; a candidate that
+    needs more would fail here loudly rather than skip the phase.
+    """
+
+    print(f"=== {phase}: {ref} ({commit}) ===", flush=True)
+    environment = os.environ.copy()
+    environment["DATABASE_URL"] = database_url
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=REPO_ROOT,
+            env=environment,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+    except OSError as exc:
+        raise GateError(f"could not run {phase}: {exc}") from exc
+    output = completed.stdout or ""
+    if output:
+        print(output, end="" if output.endswith("\n") else "\n")
+    return CommandResult(completed.returncode, output)
 
 
 def _run_alembic(
@@ -382,50 +458,13 @@ def _run_alembic(
     commit: str,
     arguments: tuple[str, ...],
 ) -> CommandResult:
-    print(f"=== {phase}: {ref} ({commit}) ===", flush=True)
-    environment = os.environ.copy()
-    environment["DATABASE_URL"] = database_url
-    try:
-        completed = subprocess.run(
-            _alembic_command(tree, *arguments),
-            cwd=REPO_ROOT,
-            env=environment,
-            check=False,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
-        )
-    except OSError as exc:
-        raise GateError(f"could not run {phase}: {exc}") from exc
-    output = completed.stdout or ""
-    if output:
-        print(output, end="" if output.endswith("\n") else "\n")
-    return CommandResult(completed.returncode, output)
-
-
-def _readback_command(tree: Path, *arguments: str) -> list[str]:
-    """Run HEAD's read-back runner inside `tree`'s environment.
-
-    The `uv run --frozen --project <tree> --directory <tree>/apps/api` prefix is
-    `_alembic_command`'s, verbatim, because it is the same trick: resolve the
-    executable's dependencies from the tree under judgement. The inversion here
-    is that the SCRIPT is HEAD's (`READBACK_SCRIPT`, never `tree`'s copy) while
-    the `curie_api` it imports is the tree's -- one fixed assertion harness
-    pointed at whichever read models we are judging.
-    """
-
-    return [
-        "uv",
-        "run",
-        "--frozen",
-        "--project",
-        str(tree),
-        "--directory",
-        str(tree / "apps" / "api"),
-        "python",
-        str(READBACK_SCRIPT),
-        *arguments,
-    ]
+    return _run_in_tree(
+        _alembic_command(tree, *arguments),
+        database_url=database_url,
+        phase=phase,
+        ref=ref,
+        commit=commit,
+    )
 
 
 def _run_readback(
@@ -436,43 +475,20 @@ def _run_readback(
     ref: str,
     commit: str,
 ) -> CommandResult:
-    """Follow `_run_alembic`'s contract exactly: banner, env, combined output.
-
-    The output has to come back combined and echoed for the same reason the
-    alembic phases do -- `_run_self_test` pins markers against it, and a marker
-    that landed on a stderr stream the caller never captured is a marker that
-    silently stops defending anything.
-
-    Only `DATABASE_URL` is added to the environment. `curie_api` was verified to
-    import with nothing else set at v0.7.3, v0.8.0 and HEAD; a candidate that
-    needs more would fail here loudly rather than skip the phase.
-    """
-
     arguments: list[str] = []
     for agent in SEED_FIXTURE:
+        # Both options are `action="append"` on the runner side, so pairing them
+        # per agent builds the same two lists a pass per option would.
         arguments.extend(("--expect-agent", agent.name))
-    for agent in SEED_FIXTURE:
         arguments.extend(("--expect-address", agent.address))
 
-    print(f"=== {phase}: {ref} ({commit}) ===", flush=True)
-    environment = os.environ.copy()
-    environment["DATABASE_URL"] = database_url
-    try:
-        completed = subprocess.run(
-            _readback_command(tree, *arguments),
-            cwd=REPO_ROOT,
-            env=environment,
-            check=False,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
-        )
-    except OSError as exc:
-        raise GateError(f"could not run {phase}: {exc}") from exc
-    output = completed.stdout or ""
-    if output:
-        print(output, end="" if output.endswith("\n") else "\n")
-    return CommandResult(completed.returncode, output)
+    return _run_in_tree(
+        _readback_command(tree, *arguments),
+        database_url=database_url,
+        phase=phase,
+        ref=ref,
+        commit=commit,
+    )
 
 
 def _sql_literal(value: str) -> str:
@@ -498,7 +514,13 @@ def _introspect_columns(database_name: str) -> tuple[ColumnInfo, ...]:
         database_name,
         "SELECT table_name, column_name, is_nullable, "
         "coalesce(column_default, '') FROM information_schema.columns "
-        "WHERE table_schema = 'curie' ORDER BY table_name, ordinal_position",
+        "WHERE table_schema = 'curie' "
+        # The two tables the fixture can write. Narrowing here rather than in the
+        # consumers keeps `_verify_mandatory_columns` honest: it only reports a
+        # mandatory column for a table the branch actually fills, so every other
+        # table's rows were dead weight the caller had to filter back out.
+        "AND table_name IN ('agents', 'agent_channels') "
+        "ORDER BY table_name, ordinal_position",
     )
     columns: list[ColumnInfo] = []
     for line in rows.splitlines():
@@ -596,6 +618,34 @@ def _detect_approval_route_era(released_tree: Path) -> str:
     return APPROVAL_ROUTE_ERA_LEGACY
 
 
+def _route_literal(agent: SeedAgent, era: str) -> str:
+    """Render one `agents.approval_routes` value in `era`'s storage shape.
+
+    Both eras are reachable from `_plan_seed_statements`' `agent_channels`
+    branch; only the legacy one is reachable from its pre-0021 `slack_channel`
+    branch, which passes the era explicitly rather than inferring it.
+    """
+
+    if agent.approval_route_address is None:
+        return _json_literal(None)
+    if era == APPROVAL_ROUTE_ERA_SPLIT:
+        # Post-0034 storage: already the split shape.
+        return _json_literal(
+            {
+                "deploy": {
+                    "resolution": {
+                        "kind": agent.kind,
+                        "address": agent.approval_route_address,
+                    }
+                }
+            }
+        )
+    # Pre-0034 storage; migration 0034 (#1460) rewrites it into the split
+    # `resolution` shape on the way up with NO validation, which is what carries
+    # the legacy address into the read models.
+    return _json_literal({"deploy": {"channel": agent.approval_route_address}})
+
+
 def _plan_seed_statements(
     columns: tuple[ColumnInfo, ...],
     *,
@@ -639,14 +689,9 @@ def _plan_seed_statements(
             # `slack_channel` present means pre-0021, and 0021 precedes 0034, so
             # this branch is pre-0034 by construction: the `slack_channel` +
             # `split` quadrant cannot exist and nothing here is conditioned on
-            # the era. Pre-0034 storage; migration 0034 (#1460) rewrites it into
-            # the split `resolution` shape on the way up with NO validation,
-            # which is what carries the legacy address into the read models.
-            route = _json_literal(
-                None
-                if agent.approval_route_address is None
-                else {"deploy": {"channel": agent.approval_route_address}}
-            )
+            # the era. The legacy era is therefore passed as a constant, NOT
+            # forwarded from `approval_route_era`.
+            route = _route_literal(agent, APPROVAL_ROUTE_ERA_LEGACY)
             statements.append(
                 "INSERT INTO curie.agents (id, name, slack_channel, "
                 "approval_routes)\n"
@@ -663,28 +708,15 @@ def _plan_seed_statements(
                 "agent_channels": {"id", "agent_id", "kind", "address"},
             },
         )
-        split_era = approval_route_era == APPROVAL_ROUTE_ERA_SPLIT
         for agent in SEED_FIXTURE:
-            if agent.approval_route_address is None:
-                route_value: dict[str, Any] | None = None
-            elif split_era:
-                # Post-0034 storage: already the split shape.
-                route_value = {
-                    "deploy": {
-                        "resolution": {
-                            "kind": agent.kind,
-                            "address": agent.approval_route_address,
-                        }
-                    }
-                }
-            else:
-                # Post-0021 but pre-0034 (v0.7.0..v0.7.3). The channel binding
-                # already lives in `agent_channels`, yet the route is still the
-                # legacy `channel` shape -- seeding `resolution` here writes a
-                # fixture the released code could never have produced, and the
-                # candidate's 0034 rejects it as an unknown legacy key (#2098).
-                route_value = {"deploy": {"channel": agent.approval_route_address}}
-            route = _json_literal(route_value)
+            # This is the branch that can reach BOTH eras, so the era is
+            # forwarded rather than assumed. Post-0021 but pre-0034
+            # (v0.7.0..v0.7.3) is the quadrant that only exists here: the channel
+            # binding already lives in `agent_channels`, yet the route is still
+            # the legacy `channel` shape -- seeding `resolution` there writes a
+            # fixture the released code could never have produced, and the
+            # candidate's 0034 rejects it as an unknown legacy key (#2098).
+            route = _route_literal(agent, approval_route_era)
             # One statement per agent, so the binding is written in the same
             # transaction as the row it belongs to and the new id never has to be
             # round-tripped back through psql. `endpoint` / `adapter` are left
@@ -731,11 +763,14 @@ def _seed_released_database(
     statements = _plan_seed_statements(
         columns, approval_route_era=approval_route_era
     )
-    for statement in statements:
-        _checked_output(
-            _database_command(statement, database_name=database_name),
-            description=f"seeding the released database {database_name}",
-        )
+    # One psql invocation for the whole plan, not one per row. psql runs a
+    # multi-statement simple query inside a single implicit transaction, so the
+    # fixture now lands whole or not at all -- and a PARTIAL seed is worse than
+    # none, because the read-back would then pass on whichever rows survived.
+    _checked_output(
+        _database_command(";\n".join(statements), database_name=database_name),
+        description=f"seeding the released database {database_name}",
+    )
     print(
         f"Seeded {len(statements)} released-shaped agent rows into "
         f"{database_name}."
@@ -753,32 +788,32 @@ def _upgrade_pair(
     candidate_ref: str,
     candidate_commit: str,
 ) -> PairResult:
-    released_phases = (
+    released_phases: tuple[_AlembicPhase, ...] = (
         (
-            "released upgrade",
+            RELEASED_UPGRADE_PHASE,
             released_tree,
             released_ref,
             released_commit,
             ("upgrade", "head"),
         ),
         (
-            "released head check",
+            RELEASED_HEAD_CHECK_PHASE,
             released_tree,
             released_ref,
             released_commit,
             ("current", "--check-heads"),
         ),
     )
-    candidate_phases = (
+    candidate_phases: tuple[_AlembicPhase, ...] = (
         (
-            "candidate upgrade",
+            CANDIDATE_UPGRADE_PHASE,
             candidate_tree,
             candidate_ref,
             candidate_commit,
             ("upgrade", "head"),
         ),
         (
-            "candidate head check",
+            CANDIDATE_HEAD_CHECK_PHASE,
             candidate_tree,
             candidate_ref,
             candidate_commit,
@@ -786,17 +821,30 @@ def _upgrade_pair(
         ),
     )
 
-    for phase, tree, ref, commit, arguments in released_phases:
-        result = _run_alembic(
-            tree,
-            database_url=database_url,
-            phase=phase,
-            ref=ref,
-            commit=commit,
-            arguments=arguments,
-        )
-        if result.returncode != 0:
-            return PairResult(phase, result.returncode, result.output)
+    def _walk(phases: tuple[_AlembicPhase, ...]) -> PairResult | None:
+        """Run phases in order; return the FIRST failure, or None if all passed.
+
+        Returning `None` for success rather than a `PairResult` is what keeps the
+        caller's control flow honest: only a failing phase short-circuits the
+        pair, and the pair's real verdict is the read-back at the end.
+        """
+
+        for phase, tree, ref, commit, arguments in phases:
+            result = _run_alembic(
+                tree,
+                database_url=database_url,
+                phase=phase,
+                ref=ref,
+                commit=commit,
+                arguments=arguments,
+            )
+            if result.returncode != 0:
+                return PairResult(phase, result.returncode, result.output)
+        return None
+
+    failure = _walk(released_phases)
+    if failure is not None:
+        return failure
 
     # The seed sits HERE, between the two lines' phases, because that is the only
     # window in which the released schema is what an operator's database actually
@@ -808,30 +856,22 @@ def _upgrade_pair(
     # released ref can sit between them (#2098).
     _seed_released_database(
         database_name,
-        phase="seed",
+        phase=SEED_PHASE,
         approval_route_era=_detect_approval_route_era(released_tree),
     )
 
-    for phase, tree, ref, commit, arguments in candidate_phases:
-        result = _run_alembic(
-            tree,
-            database_url=database_url,
-            phase=phase,
-            ref=ref,
-            commit=commit,
-            arguments=arguments,
-        )
-        if result.returncode != 0:
-            return PairResult(phase, result.returncode, result.output)
+    failure = _walk(candidate_phases)
+    if failure is not None:
+        return failure
 
     readback = _run_readback(
         candidate_tree,
         database_url=database_url,
-        phase="read-back",
+        phase=READBACK_PHASE,
         ref=candidate_ref,
         commit=candidate_commit,
     )
-    return PairResult("read-back", readback.returncode, readback.output)
+    return PairResult(READBACK_PHASE, readback.returncode, readback.output)
 
 
 def _cleanup(

--- a/scripts/released_upgrade_readback.py
+++ b/scripts/released_upgrade_readback.py
@@ -1,0 +1,320 @@
+"""Read the migrated database back through the CANDIDATE tree's read models.
+
+`check-released-upgrade.py` proves the migrations RUN. It cannot prove the
+result LOADS, which is exactly what #1914 was: migration 0021 backfilled
+`curie.agent_channels` verbatim out of `agents.slack_channel`, and the rows it
+copied then failed `ChannelBinding`'s address rule, so `GET /agents` returned
+500 for every agent -- not only the one holding the offending address.
+
+This file is the second half of the gate (#2098). It is committed at HEAD and
+never changes across directions, but it is EXECUTED inside the candidate tree's
+environment:
+
+    uv run --frozen --project <candidate_tree> \
+        --directory <candidate_tree>/apps/api \
+        python <REPO_ROOT>/scripts/released_upgrade_readback.py \
+        --expect-agent ... --expect-address ...
+
+so `import curie_api` resolves to the CANDIDATE's package. One fixed assertion
+harness, pointed at whichever version of the read models is under judgement.
+
+Three constraints follow from that inversion, and all three are load-bearing:
+
+1. **Only stdlib, sqlalchemy and `curie_api` may be imported.** `sys.path[0]` is
+   HEAD's `scripts/` while the installed package is the candidate's, so an
+   import of a sibling module in `scripts/` would silently mix two versions.
+   In particular this file does NOT import `check-released-upgrade.py`; the
+   fixture arrives entirely through argv.
+2. **No field name may be hard-coded.** `AgentOut` carries a singular
+   `channel: ChannelBinding` at v0.7.3 and a plural
+   `channels: list[ChannelBindingOut]` on main, so naming either attribute
+   would make the runner work on exactly one side of the fix it is judging.
+   ORM rows are loaded and handed whole to `AgentOut.model_validate`, and the
+   address expectations are checked by searching the SERIALIZED dump rather
+   than by reading a named field.
+3. **It cannot pass vacuously.** Zero agents is a FAILURE. A seed that silently
+   wrote nothing, or a migration that silently dropped the seeded rows, is the
+   precise failure mode this gate exists to close, so "the read path raised
+   nothing" is not sufficient evidence on its own.
+"""
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from dataclasses import dataclass
+from typing import Any
+
+from curie_api import models
+from curie_api.schemas import AgentOut
+from sqlalchemy import inspect as sqlalchemy_inspect
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import Session
+
+# JSON keys whose string values are treated as channel addresses when scraping
+# an agent's `approval_routes` for the error message. BOTH eras are listed on
+# purpose: pre-0034 storage is `{"deploy": {"channel": X}}` and post-0034 is
+# `{"deploy": {"resolution": {"kind": ..., "address": X}}}`, and the runner has
+# to name the offending address on either side of that rewrite.
+_ADDRESS_KEYS = frozenset({"address", "channel"})
+
+
+@dataclass(frozen=True)
+class AgentDump:
+    """One agent as the candidate read models saw it.
+
+    `dump` is the serialized payload when `AgentOut.model_validate` succeeded and
+    `None` when it raised; `error` is the mirror of that. `addresses` is scraped
+    from the ORM row itself rather than from `dump`, because the case that
+    matters most -- a validation failure -- has no dump to read the address out
+    of, and #1914's complaint was precisely that the failure named Pydantic
+    instead of the data.
+    """
+
+    name: str
+    addresses: tuple[str, ...]
+    dump: dict[str, Any] | None
+    error: str | None
+
+
+def _json_strings_under(value: Any, keys: frozenset[str]) -> list[str]:
+    """Collect every string stored under one of `keys`, at any depth."""
+
+    found: list[str] = []
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            if key in keys and isinstance(nested, str):
+                found.append(nested)
+            found.extend(_json_strings_under(nested, keys))
+    elif isinstance(value, list):
+        for nested in value:
+            found.extend(_json_strings_under(nested, keys))
+    return found
+
+
+def _related_addresses(agent: Any) -> tuple[str, ...]:
+    """Every channel address reachable from an ORM agent row.
+
+    Walks the mapper's relationships and reads an `address` attribute off
+    whatever they yield, rather than naming the relationship. That is the same
+    version-agnostic requirement as constraint 2 in the module docstring: the
+    binding relationship is `channel` (singular) at v0.7.3 and `channels`
+    (plural) on main, and this runner must work identically on both.
+
+    The walk touches unrelated relationships (`versions`, `deployments`) too and
+    will load them. That is deliberate and cheap -- the seeded database holds
+    three agents and nothing else -- and it keeps the traversal free of any
+    per-version knowledge.
+    """
+
+    addresses: list[str] = []
+    mapper = sqlalchemy_inspect(type(agent))
+    for relationship in mapper.relationships:
+        try:
+            value = getattr(agent, relationship.key)
+        except Exception:  # noqa: BLE001 - a relationship we cannot load is not a verdict
+            continue
+        related_objects = value if isinstance(value, (list, set, tuple)) else [value]
+        for related in related_objects:
+            address = getattr(related, "address", None)
+            if isinstance(address, str):
+                addresses.append(address)
+    addresses.extend(
+        _json_strings_under(getattr(agent, "approval_routes", None), _ADDRESS_KEYS)
+    )
+    # Order-preserving dedupe: the same address legitimately appears as both a
+    # binding and an approval-route target in the fixture, and naming it twice
+    # in a failure line reads like two separate problems.
+    return tuple(dict.fromkeys(addresses))
+
+
+def _dump_agents(session: Session) -> tuple[AgentDump, ...]:
+    """Serialize every agent through `AgentOut`, capturing failures per row.
+
+    Runs on a SYNC session (via `AsyncSession.run_sync`) so lazy relationship
+    loading works regardless of the candidate's `lazy=` strategy. Both tags we
+    pin happen to use `lazy="selectin"`, but depending on that would make the
+    gate's correctness a property of the version under test.
+
+    Per-row capture rather than a single try/except around the loop: the whole
+    point of #1914 is that ONE bad row took down the response for all 19 agents,
+    so the gate has to be able to say which rows loaded and which did not.
+    """
+
+    agents = (
+        session.execute(select(models.Agent).order_by(models.Agent.name))
+        .scalars()
+        .all()
+    )
+    dumps: list[AgentDump] = []
+    for agent in agents:
+        addresses = _related_addresses(agent)
+        try:
+            payload = AgentOut.model_validate(agent).model_dump(mode="json")
+        except Exception as exc:  # noqa: BLE001 - any read failure is the verdict
+            dumps.append(
+                AgentDump(
+                    name=agent.name, addresses=addresses, dump=None, error=str(exc)
+                )
+            )
+        else:
+            dumps.append(
+                AgentDump(
+                    name=agent.name, addresses=addresses, dump=payload, error=None
+                )
+            )
+    return tuple(dumps)
+
+
+async def _load_dumps(database_url: str) -> tuple[AgentDump, ...]:
+    engine = create_async_engine(database_url)
+    try:
+        async with AsyncSession(engine) as session:
+            return await session.run_sync(_dump_agents)
+    finally:
+        await engine.dispose()
+
+
+def _rendered_addresses(addresses: tuple[str, ...]) -> str:
+    if not addresses:
+        return "no address recorded"
+    return ", ".join(repr(address) for address in addresses)
+
+
+def _collect_failures(
+    dumps: tuple[AgentDump, ...],
+    *,
+    expected_agents: tuple[str, ...],
+    expected_addresses: tuple[str, ...],
+) -> tuple[str, ...]:
+    """Judge a set of dumps against the seeded expectations. Empty tuple == pass.
+
+    Pure by construction -- no engine, no session, no I/O -- so the gate's
+    assertions are unit-testable without a four-minute pair walk.
+    """
+
+    if not dumps:
+        # The vacuous-pass guard. Without it a seed that wrote nothing, or a
+        # migration that dropped the seeded rows, reads as "nothing failed to
+        # serialize" -- which is exactly the class of green-but-inert gate
+        # #1706 built its negative control against.
+        return (
+            "read-back found no agents in the migrated database: the seed wrote "
+            "nothing or the migration dropped it, so the read path was never "
+            "exercised",
+        )
+
+    failures: list[str] = []
+
+    # Serialization failures first, and the DATA before the Pydantic text. #1914
+    # was reported as "an error naming Pydantic rather than the data", so an
+    # operator reading the CI log must see WHICH agent and WHICH address before
+    # the validation traceback starts explaining itself. The ordering is the
+    # deliverable here, not merely the content.
+    for dump in dumps:
+        if dump.error is None:
+            continue
+        failures.append(
+            f"agent {dump.name!r} (address {_rendered_addresses(dump.addresses)}) "
+            "did not serialize through the candidate read models:\n"
+            f"{dump.error}"
+        )
+
+    seen_names = {dump.name for dump in dumps}
+    for name in expected_agents:
+        if name not in seen_names:
+            failures.append(
+                f"expected agent {name!r} was not returned by the migrated "
+                "database: the seeded row did not survive the upgrade"
+            )
+
+    # Address presence is checked against the SERIALIZED payload, not against a
+    # named field, so the same assertion covers the channel binding and the
+    # approval-route target under either era's typing (`dict[str, Any]` at
+    # v0.7.3, `dict[str, ApprovalRouteBindingOut]` on main).
+    serialized = "\n".join(
+        json.dumps(dump.dump, sort_keys=True)
+        for dump in dumps
+        if dump.dump is not None
+    )
+    for address in expected_addresses:
+        if address not in serialized:
+            failures.append(
+                f"expected address {address!r} is absent from every serialized "
+                "agent: the seeded binding was dropped, rewritten, or never read "
+                "back"
+            )
+
+    return tuple(failures)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Serialize a migrated Curie database through this tree's read "
+            "models and require the seeded rows to load."
+        )
+    )
+    # The expectations arrive as arguments so this runner carries no fixture
+    # knowledge: `check-released-upgrade.py` owns `SEED_FIXTURE`, and importing
+    # it here would violate the sys.path constraint in the module docstring.
+    parser.add_argument(
+        "--expect-agent",
+        action="append",
+        default=[],
+        metavar="NAME",
+        help="An agent name that must be present in the migrated database.",
+    )
+    parser.add_argument(
+        "--expect-address",
+        action="append",
+        default=[],
+        metavar="ADDRESS",
+        help="A channel address that must survive into the serialized agent.",
+    )
+    args = parser.parse_args()
+
+    database_url = os.environ.get("DATABASE_URL", "")
+    if not database_url:
+        print("read-back requires DATABASE_URL to be set", file=sys.stderr)
+        return 1
+    if not args.expect_agent or not args.expect_address:
+        # Refusing an empty expectation set is part of the vacuous-pass guard: a
+        # caller that forgot to pass the fixture would otherwise get a green
+        # read-back that asserted nothing at all.
+        print(
+            "read-back requires at least one --expect-agent and one "
+            "--expect-address",
+            file=sys.stderr,
+        )
+        return 1
+
+    dumps = asyncio.run(_load_dumps(database_url))
+    for dump in dumps:
+        status = "failed" if dump.error is not None else "loaded"
+        print(
+            f"read-back: agent {dump.name!r} ({_rendered_addresses(dump.addresses)}) "
+            f"{status}"
+        )
+
+    failures = _collect_failures(
+        dumps,
+        expected_agents=tuple(args.expect_agent),
+        expected_addresses=tuple(args.expect_address),
+    )
+    if failures:
+        print("Released upgrade read-back failed:")
+        for failure in failures:
+            print(f"  - {failure}")
+        return 1
+    print(
+        f"Released upgrade read-back passed: {len(dumps)} agents serialized "
+        "through this tree's read models."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The released-upgrade gate ran every migration against an **empty** database. It proved the
migrations applied; it could not prove the result was readable. #1914 is what that missed:
migration `0021_agent_channels` backfills `agent_channels` from `agents.slack_channel` verbatim,
a validating read model then rejected one legacy row, and `GET /agents` returned 500 for all 19
agents on a real install — reporting a Pydantic error instead of the bad value.

The gate now seeds the released database **before** the upgrade with rows in the shapes the
released code actually permitted, and serializes the migrated rows back through the **candidate
tree's own** read models afterwards.

Closes #2098

## Fix pin

- **Seeding + read-back exist at all** — `apps/api/tests/test_released_upgrade_gate.py`
  (23 tests). Every one failed on the tests-first commit `f259efae`, before any implementation.
- **The fixture is legacy-shaped, not validator-shaped** —
  `test_every_legacy_fixture_address_is_rejected_by_the_live_validator` asserts each seeded
  address against `curie_api.schemas._validate_channel_binding`. Soften a fixture address to make
  the gate green and this goes red.
- **The read-back cannot pass vacuously** — `test_an_empty_result_set_is_a_failure_not_a_pass`.
- **`--self-test` covers both directions** —
  `test_an_expected_failure_that_passed_names_that_direction` and
  `test_an_expected_pass_that_failed_names_the_direction_and_the_phase`. Collapse the direction
  table back to a single pinned pair and both go red.
- **The era fix (`17b3d037`)** — `test_agent_channels_branch_with_a_legacy_route_era_seeds_the_channel_shape`.
  Demonstrated: forcing the pre-fix `split_era = True` reddens exactly this test and nothing else.

## Done when

| criterion | evidence |
|---|---|
| Fails against the pre-fix pairing (reproduces #1914) | `--released-ref v0.6.2 --candidate-ref v0.7.3` → **exit 1 in phase `read-back`**, naming `'#general'` and `'C-0a1b2c3d'` |
| Passes once the read path tolerates stored rows | `v0.6.2 → v0.8.0` → exit 0, all three agents serialized |
| `--self-test` covers both directions | three pinned directions, **exit 0**; the retained v0.6.2→v0.7.0-rc.1 collision from #1706 is untouched |

All verified live against the compose Postgres, not by code-tracing. The bare gate
(`v0.8.0 → HEAD`) also passes, and no scratch database, worktree, or tmp dir leaked across the runs.

## One bug found and fixed mid-review

Adversarial code review (Codex `gpt-5.6-sol` via agent-router) caught that the seed chose **both**
the channel shape and the approval-route shape off a single discriminator — whether 0021 had run.
0021 and 0034 are independent eras and a released ref can sit between them. Reproduced:

```
$ ... --released-ref v0.7.3 --candidate-ref HEAD
RuntimeError: cannot split approval resolution from notification (#1460): these legacy
bindings are malformed -- gate-legacy-prefix (deploy: unknown keys ['resolution']).
```

The gate blamed the migration for a fixture it wrote itself, and seeded a shape the released code
could never have produced. Fixed in `17b3d037`; that pairing now exits 0.

The route era is read from the **released worktree's revision files**, not the database. The
database provably cannot answer it: 0034 rewrites JSONB content, adds no column and no constraint,
and the scratch database is empty when the seed runs.

## Scope annotations

Adversarial scope review raised four P2s. All kept, with reasons:

- **The valid neighbour row (`C0EXAMPLE1`)** — without a good row you cannot distinguish "the read
  path tolerates stored rows" from "the read path returned nothing". It is what makes the passing
  direction meaningful, and it reproduces #1914's "one bad row took down its neighbours" shape.
- **The mandatory-column preflight** — not speculative hardening. This change introduces a *filter*
  of fixture columns against the released schema; the preflight is the correctness check on that
  filter, riding on introspection the schema-adaptive branch already performs.
- **Data-before-Pydantic message ordering** — traceable to the ticket's own words: "an error naming
  Pydantic rather than the data".
- **The frozen-dataclass shape assertion** — weakest of the four; those field names are the seam
  the both-directions test is written against.

Deliberately **not** edited: `.github/workflows/ci.yaml`, `AGENTS.md`,
`apps/api/tests/test_alembic_revision_gate.py` (15/15 still pass unmodified — that is the evidence
the CI wiring is unchanged), `.gitleaks.toml`, and everything under `apps/api/src/`.

## Behavior change to know about

`--released-ref v0.6.2 --candidate-ref v0.7.3` **exits 0 today and non-zero after this PR**. That
is the intended reproduction of #1914, not a regression.

The consolidation commit also makes the seed atomic (one psql request rather than one per row), so
a failing statement rolls the earlier ones back. A gate that seeds half a fixture and then reports
on the upgrade is reporting about a database no release ever produced.

## CI cost

`--self-test` goes from 1 pair to 3, roughly **+8 minutes** on the `python` job (~6.5 → ~14.5 min).
Named rather than slipped in. The obvious saving — hoisting the shared `v0.6.2` released worktree
across directions — is deferred, because it means restructuring `_run_pair`'s `finally: _cleanup(...)`
lifecycle whose failure mode is leaked worktrees and scratch databases on a shared runner.

## Follow-ups (not in this PR)

- Share the released worktree across `--self-test` directions to claw back the CI time above.
- Generalize era detection into a revision-prefix → era table when a third content era arrives;
  speculative with one caller today.

## Done-check

- [x] **Failing tests committed first** — `f259efae` precedes `df55f636`
- [x] **All production edits delegated** — driver ran only git, tests, and the live gate
- [x] **Broadened signatures checked at every caller** — `_database_command` gained defaulted
      `database_name`/`flags` (all 5 callers verified byte-identical argv); `_upgrade_pair` gained a
      required `database_name` (1 caller); `_check_direction -> str | None` is new and private
      (1 caller)
- [x] **Code review** — agent-router → Codex `gpt-5.6-sol`; 1 blocking finding, reproduced and fixed
- [x] **Scope review** — agent-router → Codex `gpt-5.6-sol`; 4 P2s adjudicated above
- [x] **Sibling-path parity** — all three entry points (`_run_self_test`, `_run_requested_pair`,
      `_run_normal`) reach `_run_pair` and therefore get both new phases; each exercised live
- [x] **Guard demonstration** — all 11 refusal paths executed by name (seed planner's two refusals,
      NOT-NULL verifier, era validator, vacuous-pass guard, three self-test mismatch shapes)
- [x] **Consolidation** — 4-angle pass applied, revalidated live, re-reviewed; the re-review caught
      that the commit message overclaimed "no behavior change" and it was corrected
- [ ] Security review — N/A, not flagged
- [ ] Observable verification — N/A, no user-facing surface
- [x] **E2E** — `deployed-surface`; gate run live against compose Postgres, not code-traced
- [x] **Full affected suite** — `apps/api` 1517 passed / 2 failed, both baselined as pre-existing
      environmental failures (one needs repo-root cwd, one needs langfuse; the latter fails
      identically on `origin/main` content). `ruff check .` and `mypy` clean.
