### PR TITLE
Prove the approval gate against a real provider, and on an SDK lock bump

### DIFF
--- a/.github/workflows/sdk-approval-gate.yaml
+++ b/.github/workflows/sdk-approval-gate.yaml
@@ -1,0 +1,198 @@
+name: SDK approval-gate live proof
+
+# The approval gate has escaped to production three times (#245, #453, #1852).
+# Every automated proof in the tree -- runner/tests/test_approval_gate_enforcement.py,
+# runner/tests/test_gate_shadowing.py, and (as of #2094) the live ladder case
+# case_live_approval_gate_denies -- sits behind FakeModelSession or, for the
+# live case, behind the nightly's cron trigger. None of them re-run on the
+# event that actually produces the regression class #1852 fixed: a bump of
+# `claude-agent-sdk`, the third-party dependency that owns how the real Claude
+# Agent SDK dispatches permission rules against a real model. FakeModelSession
+# cannot exhibit either failure mode (the prose-only-deny hang, or the
+# executed-anyway race) because both are properties of the real SDK's
+# scheduling against a real model, not of anything this repo's code decides.
+#
+# `runner/pyproject.toml` declares `claude-agent-sdk>=0.2.135` -- a floor, not
+# a pin -- and Dependabot groups every Python bump into one weekly PR whose
+# only gate is the offline fake suite above. So today, a `claude-agent-sdk`
+# bump that reintroduces #1852 merges on green CI and is only caught by the
+# next 08:00 UTC nightly, or by a human noticing in production.
+#
+# This workflow closes that gap without paying live-model cost on every PR:
+# `detect` (job below) is a cheap, no-build TOML diff that fires only when the
+# `claude-agent-sdk` entry in `uv.lock` actually changed (tools/sdk-lock-gate);
+# the live job runs the SAME skill-tier ladder case the nightly runs, live,
+# but only when `detect` says so. See the plan at
+# .projects/plans/task-2094-live-approval-gate.md for the full design record.
+
+on:
+  pull_request:
+    branches: [main, next]
+    paths:
+      - "uv.lock"
+      - ".github/workflows/sdk-approval-gate.yaml"
+      - "tools/sdk-lock-gate/**"
+
+permissions:
+  contents: read
+
+jobs:
+  # Cheap and cacheless: no build, no Docker, no credential. Materializes the
+  # base and head uv.lock and asks the pure detector in tools/sdk-lock-gate
+  # whether the resolved claude-agent-sdk entry (or any other line naming it)
+  # actually changed. Fails open (reports changed=true) on anything it cannot
+  # parse -- a missing base file, malformed TOML -- because this gate must
+  # never silently go dark; over-triggering only costs one live run.
+  detect:
+    name: Detect a claude-agent-sdk lock change
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      changed: ${{ steps.detect.outputs.changed }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      # fetch-depth: 0 pulls this PR's own ref history; the base branch tip
+      # is not guaranteed to be present locally until fetched explicitly.
+      - name: Fetch the base ref
+        run: git fetch origin "${{ github.base_ref }}"
+      # git show can fail legitimately (uv.lock did not exist on the base --
+      # e.g. it was just added). Do not let that fail the step: leave old.lock
+      # absent and let the detector's own fail-open rule (old_text is None ->
+      # changed=true) decide, per tools/sdk-lock-gate's contract.
+      - name: Materialize the base and head uv.lock
+        run: |
+          set -euo pipefail
+          if git show "origin/${{ github.base_ref }}:uv.lock" > old.lock 2>/dev/null; then
+            echo "base uv.lock materialized"
+          else
+            rm -f old.lock
+            echo "uv.lock is absent on the base ref; the detector treats this as a change (fail-open)"
+          fi
+      - id: detect
+        name: Compare the claude-agent-sdk lock entry
+        run: python3 tools/sdk-lock-gate/detect.py --old-file old.lock --new-file uv.lock
+
+  # Runs the SAME skill-tier live case the nightly runs
+  # (case_live_approval_gate_denies in cli/scripts/e2e-ladder.sh, #2094), on
+  # demand, only when detect says the claude-agent-sdk entry actually moved.
+  # Gated on BOTH `needs: [detect]` and the `if:` below -- needs alone still
+  # runs this job (skipped or not) on every uv.lock touch; the if: alone,
+  # without needs, would evaluate before detect's output exists.
+  live-approval-gate:
+    name: Live approval-gate proof (claude-agent-sdk changed)
+    needs: [detect]
+    if: needs.detect.outputs.changed == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      # No credential means NO PROOF, and no proof must never read as a pass.
+      #
+      # Two routes reach this branch, and neither can be fixed by re-running
+      # the same event: a fork PR, whose `pull_request` run is issued a
+      # GITHUB_TOKEN that cannot read repository secrets at all, and -- the
+      # case this workflow was actually built for -- a Dependabot PR, whose
+      # `pull_request` runs read the separate Dependabot secret store rather
+      # than the regular `secrets.*` one. The ticket's own motivating scenario
+      # is "Dependabot groups every Python bump into one weekly PR", so the
+      # primary trigger for this gate is exactly the one that arrives without
+      # OPENROUTER_API_KEY.
+      #
+      # An earlier revision reported-and-passed here (summary notice, exit 0).
+      # That is the precise defect class this workflow exists to close: a green
+      # check that proved nothing, which is how #1852 shipped in the first
+      # place. A skipped live proof that still reports success lets a
+      # claude-agent-sdk bump merge on a vacuous green, so this step FAILS.
+      # The GITHUB_STEP_SUMMARY notice stays -- it is what tells a maintainer
+      # which trusted path re-establishes the proof -- but the check goes red
+      # until one of them actually runs. Deliberately NOT solved with
+      # `pull_request_target`: that would run untrusted PR code with the live
+      # credential in scope, trading a vacuous green for a secret-exfiltration
+      # vector.
+      #
+      # Because this step FAILS rather than skipping, every later step in this
+      # job is skipped by the implicit `success()` condition: the expensive
+      # build and the live ladder never execute without a credential, and no
+      # per-step condition is needed to arrange that. (An action's own post
+      # step still runs -- those default to `always()` -- which is checkout
+      # cleanup, not proof work.) A step guard here would be unreachable, and
+      # an unreachable guard reads as load-bearing to the next editor.
+      - id: fork_guard
+        name: Require a usable model credential (no credential == no proof, fail)
+        run: |
+          set -euo pipefail
+          if [[ -z "${{ secrets.OPENROUTER_API_KEY }}" ]]; then
+            {
+              echo "### SDK approval-gate live proof DID NOT RUN -- this check is red on purpose"
+              echo ""
+              echo "This PR changes the \`claude-agent-sdk\` entry in \`uv.lock\`. That dependency owns how the real Claude Agent SDK dispatches permission rules against a real model, so it is the one change that can reintroduce the approval-gate escapes of #245, #453 and #1852 -- and no offline fake-model test in this repo can detect either failure mode."
+              echo ""
+              echo "The live approval-gate proof could not run: **no model credential was available to this run**. \`OPENROUTER_API_KEY\` is empty here, which happens for a fork PR (a \`pull_request\` run from a fork is never issued repository secrets) and for a Dependabot PR (those runs read the separate Dependabot secret store). Re-running this same workflow will not change that."
+              echo ""
+              echo "A maintainer must establish the proof by one of:"
+              echo ""
+              echo "1. Run the **Nightly graded parity ladder** workflow (\`.github/workflows/nightly-graded-ladder.yaml\`) manually -- Actions -> Nightly graded parity ladder -> Run workflow -- against this PR's merge result. Its \`default\` matrix leg runs the same skill-tier ladder live (\`CURIE_E2E_LIVE=1\`) and so executes \`case_live_approval_gate_denies\`; the \`model\` input selects the OpenRouter route."
+              echo "2. Push this branch to a branch **in this repository** rather than a fork, and open the PR from there, so this workflow's \`pull_request\` run receives \`OPENROUTER_API_KEY\` and proves the gate itself."
+              echo ""
+              echo "Do not merge on this red check without one of the above. See #2094, #1852, #2068."
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::error title=Live approval-gate proof did not run::No OPENROUTER_API_KEY is available to this run, so the live claude-agent-sdk approval-gate proof could not execute. Failing rather than reporting a green check that proved nothing -- see the job summary for the two trusted ways to run it." >&2
+            exit 1
+          fi
+      - name: Toolchain
+        working-directory: cli
+        run: rustc --version
+      - name: Cargo cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: cli
+      - name: Release build
+        working-directory: cli
+        run: cargo build --release --locked
+      # Image build mirrors nightly-graded-ladder.yaml's ladder-skill-local job
+      # exactly: a named cache-only buildx builder that is NOT made the
+      # default (`use: false`) so the compose-triggered worker-local overlay
+      # build still resolves `:ci-local` FROM bases from the plain docker
+      # builder's daemon store (#697/#791/#803). Only the runner image is
+      # needed -- CURIE_E2E_TIERS=skill boots a bare runner container, not the
+      # compose stack, so no api/worker/ui build here.
+      - name: Set up a cache-only buildx builder (named, NOT the default -- preserves compose FROM, #803)
+        id: laddercache
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+        with:
+          use: false
+      - name: Build the runner image locally (gha layer cache)
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: runner/Dockerfile
+          builder: ${{ steps.laddercache.outputs.name }}
+          tags: curie-runner
+          push: false
+          load: true
+          cache-from: type=gha,scope=ladder-runner
+          cache-to: type=gha,mode=max,scope=ladder-runner
+      # Live grading: CURIE_E2E_LIVE drops the fake fixture and the ladder
+      # reads the OpenRouter credential from CURIE_CREDENTIALS (the one env
+      # key the CLI reads; an sk-or- key auto-selects OPENROUTER_BASE_URL).
+      # The secret travels only as this env mapping, never on a run: or argv
+      # line.
+      #
+      # CURIE_E2E_LIVE: "1" is the single most important line in this file --
+      # without it, case_live_approval_gate_denies prints its skip line and
+      # this job runs sealed and green forever while proving nothing about
+      # #1852/#2068.
+      - name: Live approval-gate ladder case (skill rung)
+        env:
+          CURIE_BIN: cli/target/release/curie
+          CURIE_BASE_TAG: ci-local
+          CURIE_E2E_TIERS: skill
+          CURIE_E2E_LIVE: "1"
+          CURIE_CREDENTIALS: ${{ secrets.OPENROUTER_API_KEY }}
+          CURIE_MODEL: z-ai/glm-5.2
+        run: bash cli/scripts/e2e-ladder.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,13 @@ CI (`.github/workflows/ci.yaml`) runs the same commands below. Run the ones for
 the area you touched before opening a PR. Scope test runs to what you changed;
 CI covers the rest.
 
+A PR whose `uv.lock` changes the `claude-agent-sdk` entry also triggers a
+separate, conditional check
+(`.github/workflows/sdk-approval-gate.yaml`) that runs a live approval-gate
+turn against a real model. It needs an `OPENROUTER_API_KEY` configured in the
+repo, not in your fork, so it can go red for reasons outside your diff; ping a
+maintainer rather than trying to fix it yourself.
+
 **Python (all packages, from the repo root):**
 
 ```bash

--- a/cli/CLAUDE.md
+++ b/cli/CLAUDE.md
@@ -261,7 +261,12 @@ selects rungs; `local-release` is NOT folded into `all` since it needs those
 extra images built first, so name it explicitly (e.g.
 `skill,local,local-release`). `CURIE_E2E_LIVE` (default fake, `1` for live)
 governs every named rung, including rung 1 -- `e2e.sh` reads the same env var
-directly rather than being told by the ladder. The standard pre release gate is:
+directly rather than being told by the ladder. Rung 1 also carries a
+live-only case, `case_live_approval_gate_denies` (#2094): it gates `Bash`
+through `CURIE_APPROVAL_REQUIRED_TOOLS`, runs its own runner on
+`CURIE_E2E_GATE_PORT` (default 7246), and asserts a real SDK dispatch against a
+real model denies the call and the turn parks `awaiting-approval` rather than
+running it; it skips under a fake run. The standard pre release gate is:
 ```bash
 CURIE_E2E_TIERS=all curie dev e2e-ladder
 ```

--- a/cli/scripts/e2e-ladder.sh
+++ b/cli/scripts/e2e-ladder.sh
@@ -98,6 +98,13 @@
 #                            provisioning. The falsifiable negative: the rung
 #                            must then fail closed on the missing credential
 #                            rather than starting a connector without it.
+#   CURIE_E2E_GATE_PORT   port for the live approval-gate case's own runner
+#                            (case_live_approval_gate_denies, #2094, rides
+#                            rung_skill). Default 7246, one above e2e.sh's own
+#                            CURIE_E2E_PORT default of 7245 so the two runners
+#                            never collide. Live-only (CURIE_E2E_LIVE=1); it
+#                            skips under a fake run since FakeModelSession
+#                            cannot exhibit the failure mode it proves absent.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -162,6 +169,12 @@ HERMETIC_RUNNER_NAME="curie-ladder-hermetic-$$"
 # could green-light an occupied 8155 and then hang on the message timeout.
 STUB_PORT=8155
 PROMPT="What is the weather in Denver right now?"
+# The live approval-gate case's turn (#2094). Deliberately explicit and
+# imperative, and deliberately NOT a weather question: the bundle's skill only
+# activates on those, so this prompt reaches the base agent's own tool set,
+# which is why it provokes `Bash` -- the one tool the case gates -- rather than
+# the skill's declared WebSearch/WebFetch.
+GATE_PROMPT="Use the Bash tool to run exactly: echo curie-2094-canary > /tmp/curie-2094-canary. Then tell me it is done."
 # The fake model's only reply (runner/src/curie_runner/fake.py). It is used
 # ONLY as a live-mode negative control -- "the reply must not be this" -- never
 # as a pass condition. Matching it to green is the #612 bypass.
@@ -253,6 +266,15 @@ SANDBOX_LABEL="curietech.ai/managed-by=curie-sandbox-substrate"
 # removes what it names.
 CONFLICT_NAME="curie-ladder-747-leftover-$$"
 CONFLICT_CREATED=0
+# The live approval-gate case (#2094) stands in a container of its own, for the
+# same reason: it removes what it names, so it must never name the default. The
+# port is one above e2e.sh's CURIE_E2E_PORT default of 7245, so this case cannot
+# collide with rung 1's own runner. $GATE_CASE_BUNDLE is filled in by the case
+# and stays empty on every run that never reaches it.
+GATE_CASE_NAME="curie-ladder-2094-gate-$$"
+GATE_CASE_CREATED=0
+GATE_CASE_PORT="${CURIE_E2E_GATE_PORT:-7246}"
+GATE_CASE_BUNDLE=""
 # The image that case creates its stand-in from. Already a requirement of the
 # ladder (rung 1 boots a real runner), so this adds no new prerequisite.
 RUNNER_IMAGE="curie-runner"
@@ -307,6 +329,12 @@ cleanup() {
     # the case itself once `skill down` has removed it.
     if (( CONFLICT_CREATED )); then
         docker rm -f "$CONFLICT_NAME" >/dev/null 2>&1
+    fi
+    # The live approval-gate case's runner (#2094), by its exact unique name for
+    # the same reason. Its bundle copy lives under $WORKDIR, which the `rm -rf`
+    # below already covers, so there is no second removal path for it here.
+    if (( GATE_CASE_CREATED )); then
+        docker rm -f "$GATE_CASE_NAME" >/dev/null 2>&1
     fi
     # Connector containers this run's own bundle started, matched by the exact
     # aliases derived from the scope a rung recorded -- never a bare sweep of
@@ -1157,6 +1185,180 @@ case_leftover_runner_container() {
     fi
     CONFLICT_CREATED=0
     echo "skill down --name cleared the leftover with no recorded state"
+}
+
+# The operator approval gate, proven against a REAL provider and the real
+# claude-agent-sdk dispatch (#1852, #2068).
+#
+# What this proves: with the gate armed on `Bash`, a turn that asks for a shell
+# command must PARK awaiting approval -- bounded, and with the command unrun.
+# Three assertions, one per observed failure mode:
+#   (a) `timeout` did not fire            -- the #1852 hang, where the deny was
+#       prose only and a real model simply spun until the caller gave up. This
+#       is what a revert of #2068 produces, so it is the negative control.
+#   (b) the terminal status is `awaiting-approval` -- the parked terminal that
+#       actually carries the approval state.
+#   (c) the canary file does not exist inside the runner -- the executed-anyway
+#       shape, judged independently of whatever the final frame claims.
+#
+# Why the fake tier structurally cannot prove this: both failure modes are
+# properties of how the real SDK dispatches permission rules against a real
+# model deciding to call a tool. `CURIE_FAKE_MODEL` makes no model call at all,
+# so it can neither spin nor choose `Bash`; every offline approval test in the
+# tree (runner/tests/test_approval_gate_enforcement.py, test_gate_shadowing.py)
+# asserts the gate's logic, and none of them exercise that dispatch. A sealed
+# run of this case would therefore be a green that proves nothing, which is why
+# it returns early rather than degrading to the fake model.
+#
+# Two traps worth naming, because both fail SILENTLY:
+#   - `--secret` takes a bare variable NAME. `--secret NAME=VALUE` is filtered
+#     out of the container environment without a word (cli/src/docker.rs), so
+#     the gate would never arm and the turn would end `done`.
+#   - `curie skill message` has no timeout of any kind, so an unbounded turn
+#     wedges the whole ladder forever instead of failing it. The `timeout` is
+#     the (a) assertion, not defensive padding.
+#
+# The case gates `Bash` and not the skill's own tools on purpose: the runner
+# refuses to boot when a gate's required set intersects a skill's declared
+# `allowed-tools` (assert_gates_not_shadowed), and this bundle's skill declares
+# WebSearch/WebFetch. `Bash` appears in no skill frontmatter here, and the
+# adapter sets no allowed_tools at all, so it is both reachable and ungated
+# until this case arms it.
+case_live_approval_gate_denies() {
+    echo
+    echo "=== case: a live gated tool call is denied and the turn parks (#2094) ==="
+    if [[ "$LIVE" != "1" ]]; then
+        echo "skipped: CURIE_E2E_LIVE is not 1. This case proves a REAL model + real SDK dispatch (#1852/#2068); the fake tier cannot exhibit either failure mode, so running it sealed would be a false green."
+        return 0
+    fi
+
+    if ! docker image inspect "$RUNNER_IMAGE" >/dev/null 2>&1; then
+        echo "error: image '$RUNNER_IMAGE' is not present, and the #2094 case boots its own runner from it." >&2
+        echo "fix: build it with \`curie build\`, then re-run." >&2
+        return 1
+    fi
+    if ! command -v timeout >/dev/null 2>&1; then
+        echo "error: \`timeout\` (coreutils) is not on PATH, and the #2094 case's bound IS its hang assertion." >&2
+        echo "fix: install coreutils, then re-run. Running this case unbounded would wedge the ladder instead of failing it." >&2
+        return 1
+    fi
+    # Same shape as assert_stub_port_free, against this case's own port.
+    if (exec 3<>"/dev/tcp/127.0.0.1/$GATE_CASE_PORT") 2>/dev/null; then
+        echo "error: port $GATE_CASE_PORT is already in use, and the #2094 case's runner must bind it." >&2
+        echo "fix: stop the process holding it (another ladder run, or a stale \`skill up\`), or set CURIE_E2E_GATE_PORT to a free port, then re-run." >&2
+        return 1
+    fi
+
+    # A COPY, never the shared parity artifact: `skill up` writes `.curie/`
+    # state into its CWD bundle, and the ladder's bundle is the artifact
+    # assert_bundle_identity compares across rungs (#1608). Perturbing it would
+    # regress that check. The copy lives under $WORKDIR, so the existing trap
+    # reaps it and this adds no cleanup path.
+    GATE_CASE_BUNDLE="$WORKDIR/gate-bundle"
+    cp -a "$WORKDIR/bundle" "$GATE_CASE_BUNDLE"
+
+    # Claim ownership BEFORE booting, the same rule the #747 case above states:
+    # a signal between the two must not strand the container, and `docker rm -f`
+    # on a name that never existed is a no-op.
+    GATE_CASE_CREATED=1
+    (
+        cd "$GATE_CASE_BUNDLE"
+        # The operator override, armed by NAME only. No sealed-model flag and
+        # no model override: the ambient credential and CURIE_MODEL govern here
+        # exactly as they do for every other live rung.
+        export CURIE_APPROVAL_REQUIRED_TOOLS=Bash
+        "$BIN" skill up --name "$GATE_CASE_NAME" --port "$GATE_CASE_PORT" \
+            --secret CURIE_APPROVAL_REQUIRED_TOOLS
+    )
+
+    local attempt out code status
+    status=""
+    # A live model may answer without calling any tool at all, which ends the
+    # turn `done` and is a flake rather than a regression. One retry, then a
+    # failure that names the model and the prompt so a maintainer can tell the
+    # two apart. Only this shape is retried: a timeout or a run canary is a real
+    # failure and is never retried.
+    for attempt in 1 2; do
+        out="$(cd "$GATE_CASE_BUNDLE" && timeout 240 "$BIN" --json skill message \
+            --url "http://127.0.0.1:$GATE_CASE_PORT" "$GATE_PROMPT")" && code=0 || code=$?
+
+        # (a) bounded. `timeout` exiting 124 IS the #1852 hang: the deny reached
+        # the model as prose only, the model never ended its turn, and the
+        # caller spun with the stream entry pending and no approval record.
+        if (( code == 124 )); then
+            echo "the gated turn never ended: \`timeout\` fired at 240s. This is the #1852 hang -- the deny did not stop the turn -- and is what a revert of #2068's PreToolUse wiring produces." >&2
+            return 1
+        fi
+
+        # stdout only: --json puts the payload on stdout and human text on
+        # stderr, so a combined-stream parse fails intermittently and reads like
+        # a product bug.
+        status="$(printf '%s' "$out" | python3 -c '
+import json, sys
+try:
+    payload = json.loads(sys.stdin.read())
+except Exception:
+    print("unparseable")
+    sys.exit(0)
+print(payload.get("status") if isinstance(payload, dict) else "unparseable")
+' || echo "unparseable")"
+
+        # (b) parked. Deliberately NOT the ladder's finalized-reply helper,
+        # which treats an approval park as a failure; and deliberately not
+        # `finalized` (the skill tier hardcodes it true) nor the exit code (a
+        # parked turn exits 0).
+        if [[ "$status" == "awaiting-approval" ]]; then
+            break
+        fi
+        if [[ "$status" == "done" && "$attempt" == "1" ]]; then
+            echo "retrying: the model answered without calling Bash"
+            continue
+        fi
+        echo "the gated turn ended '$status', expected 'awaiting-approval'. Model: ${CURIE_MODEL:-<sdk default>}. Prompt: $GATE_PROMPT" >&2
+        echo "a 'done' here twice running means the model declined to call Bash on both attempts (a flake); any other status means the gate did not park the turn (a regression)." >&2
+        printf '%s\n' "$out" >&2
+        return 1
+    done
+    echo "the gated turn parked: status=$status"
+
+    # (c) unrun, asserted inside the container that would have run it. Confirm
+    # the runner is still up first, purely for the precise diagnostic: a dead
+    # container is a distinct, nameable cause, and saying so beats the generic
+    # probe-failure message below.
+    if [[ -z "$(docker ps -q --filter "name=^${GATE_CASE_NAME}$")" ]]; then
+        echo "the gate case's runner '$GATE_CASE_NAME' is no longer running, so the side-effect assertion cannot be trusted." >&2
+        return 1
+    fi
+    # THREE outcomes, never two. `docker exec` exits non-zero both when the
+    # canary is absent AND when it could not run the command at all (the
+    # container died in the gap above, the daemon errored), so a bare
+    # `docker exec ... test -e` lets an infrastructure failure read as proof
+    # that the gate held -- a false pass on the one thing this case exists to
+    # prove. So the container prints a definite token, and ONLY a clean exit
+    # whose output is exactly the absent token is accepted as the pass.
+    local canary_out canary_code
+    canary_out="$(docker exec "$GATE_CASE_NAME" sh -c \
+        'if [ -e /tmp/curie-2094-canary ]; then echo CANARY_PRESENT; else echo CANARY_ABSENT; fi' 2>&1)" \
+        && canary_code=0 || canary_code=$?
+    if (( canary_code == 0 )) && [[ "$canary_out" == "CANARY_PRESENT" ]]; then
+        echo "the gated Bash command RAN: /tmp/curie-2094-canary exists inside '$GATE_CASE_NAME'. The gate reported a park but did not stop the tool call (#1852's executed-anyway shape)." >&2
+        return 1
+    fi
+    if (( canary_code != 0 )) || [[ "$canary_out" != "CANARY_ABSENT" ]]; then
+        echo "the side-effect probe could not run inside '$GATE_CASE_NAME' (exit $canary_code, output: ${canary_out:-<empty>}), so this assertion cannot be trusted. This is NOT evidence that the gate held; the canary was never read." >&2
+        return 1
+    fi
+    echo "the gated command did not run: /tmp/curie-2094-canary is absent"
+
+    # `skill down` takes no --plugin-dir and acts on the CWD bundle.
+    (cd "$GATE_CASE_BUNDLE" && "$BIN" skill down)
+    # Exact-name filter, never a substring: `name=curie` is host-wide and would
+    # report another session's runner as this case's failure.
+    if [[ -n "$(docker ps -aq --filter "name=^${GATE_CASE_NAME}$")" ]]; then
+        echo "skill down left '$GATE_CASE_NAME' behind." >&2
+        return 1
+    fi
+    GATE_CASE_CREATED=0
 }
 
 # ---------------------------------------------------------------------------
@@ -2672,6 +2874,7 @@ rung_skill() {
     assert_bundle_identity "skill" "$digest"
 
     case_leftover_runner_container
+    case_live_approval_gate_denies
 
     if connector_mode; then
         case_connector_hosting_skill

--- a/docs/VISION_PARITY_LADDER.md
+++ b/docs/VISION_PARITY_LADDER.md
@@ -16,6 +16,20 @@ Local brings up the development compose stack, deploys the same bundle, sends a 
 
 Cluster deploys the bundle and messages an already installed release. The nightly cluster job uses kind, and a live green has the same finalized reply and fake sentinel checks as local. [Ladder script](../cli/scripts/e2e-ladder.sh) [Nightly workflow](../.github/workflows/nightly-graded-ladder.yaml) [ADR 0081](adr/0081-nightly-graded-parity-ladder.md)
 
+## Approval gate
+
+Skill rung 1 also carries a live-only case, `case_live_approval_gate_denies`
+(issue #2094): it gates `Bash` through `CURIE_APPROVAL_REQUIRED_TOOLS`, sends a
+prompt that provokes exactly that tool, and asserts a real Claude Agent SDK
+dispatch against a real model denies the call and the turn parks
+`awaiting-approval` within a bounded time, with the gated command never
+running. It is skipped under a fake run: `FakeModelSession` cannot exhibit the
+failure modes this case proves absent. A separate PR check,
+[SDK approval-gate live workflow](../.github/workflows/sdk-approval-gate.yaml),
+runs this same case on any pull request whose `uv.lock` changes the
+`claude-agent-sdk` entry, so a dependency bump that could reopen that failure
+class is checked before merge rather than only at the next nightly run.
+
 ## What runs nightly
 
 GitHub Actions runs the core skill, local, and cluster rungs against a real OpenRouter model at 08:00 UTC. Local release is separate companion coverage of the generated release compose path, not a fourth core rung. [Nightly workflow](../.github/workflows/nightly-graded-ladder.yaml) [Ladder script](../cli/scripts/e2e-ladder.sh)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,6 +174,7 @@ testpaths = [
     "tools/ci-retry-gate/tests",
     "tools/ci-workflow-paths/tests",
     "tools/e2e-ci-selection/tests",
+    "tools/sdk-lock-gate/tests",
     # Only the offline harness unit tests -- NOT the whole tree: the cluster
     # scenario in test_soak_resilience.py stays out of default collection and
     # runs only under CURIE_SOAK=1 (#499).

--- a/release/tests/test_sdk_approval_gate_workflow.py
+++ b/release/tests/test_sdk_approval_gate_workflow.py
@@ -1,0 +1,164 @@
+"""Contract tests for the SDK-bump live approval-gate PR workflow.
+
+This workflow runs on a rare trigger -- a pull request that touches `uv.lock` --
+so a maintainer will not notice in the ordinary course of review if a future edit
+quietly narrows its `paths` filter, decouples its `if:` gate from `detect`, or
+strips the `CURIE_E2E_LIVE` flag that makes the ladder step actually dispatch a
+real model instead of running sealed. Any of those regressions makes the gate
+silently stop proving anything while still reporting green on every PR that
+bumps the Claude Agent SDK. This file pins the contract so a revert of any of
+those properties fails CI here, not in production three months from now.
+"""
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "sdk-approval-gate.yaml"
+
+
+def load_workflow() -> dict:
+    return yaml.load(WORKFLOW_PATH.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+
+
+def all_steps(workflow: dict) -> list[dict]:
+    return [step for job in workflow["jobs"].values() for step in job["steps"]]
+
+
+class TestSdkApprovalGateWorkflowContract:
+    def test_trigger_is_pull_request_on_main_and_next_scoped_to_the_lock_file(self) -> None:
+        workflow = load_workflow()
+        trigger = workflow["on"]
+
+        assert set(trigger) == {"pull_request"}
+        assert trigger["pull_request"]["branches"] == ["main", "next"]
+        assert set(trigger["pull_request"]["paths"]) == {
+            "uv.lock",
+            ".github/workflows/sdk-approval-gate.yaml",
+            "tools/sdk-lock-gate/**",
+        }
+        assert len(trigger["pull_request"]["paths"]) == 3
+
+    def test_detect_job_runs_detect_py_and_exposes_its_output(self) -> None:
+        workflow = load_workflow()
+        detect_job = workflow["jobs"]["detect"]
+
+        detect_steps = [
+            step
+            for step in detect_job["steps"]
+            if "tools/sdk-lock-gate/detect.py" in step.get("run", "")
+        ]
+        assert detect_steps
+        detect_step = detect_steps[0]
+        step_id = detect_step.get("id")
+        assert step_id
+
+        assert detect_job["outputs"]["changed"] == f"${{{{ steps.{step_id}.outputs.changed }}}}"
+
+    def test_live_job_is_gated_on_both_needs_and_the_changed_output(self) -> None:
+        workflow = load_workflow()
+        jobs = workflow["jobs"]
+        live_job = next(job for name, job in jobs.items() if name != "detect")
+
+        needs = live_job["needs"]
+        needs_list = [needs] if isinstance(needs, str) else list(needs)
+        assert "detect" in needs_list
+
+        condition = " ".join(live_job["if"].split())
+        assert "needs.detect.outputs.changed == 'true'" in condition
+
+    def test_ladder_step_runs_the_skill_tier_live(self) -> None:
+        workflow = load_workflow()
+        jobs = workflow["jobs"]
+        live_job = next(job for name, job in jobs.items() if name != "detect")
+
+        ladder_steps = [
+            step
+            for step in live_job["steps"]
+            if step.get("run") == "bash cli/scripts/e2e-ladder.sh"
+        ]
+        assert len(ladder_steps) == 1
+        env = ladder_steps[0]["env"]
+
+        assert env["CURIE_E2E_TIERS"] == "skill"
+        # This is the single most important assertion in this file: without
+        # CURIE_E2E_LIVE: "1" the ladder runs sealed against a fake model and
+        # this job is green forever while proving nothing about #1852/#2068.
+        assert env["CURIE_E2E_LIVE"] == "1"
+        assert "CURIE_BIN" in env
+        assert "CURIE_BASE_TAG" in env
+        assert "secrets.OPENROUTER_API_KEY" in env["CURIE_CREDENTIALS"]
+        assert "CURIE_MODEL" in env
+
+    def test_missing_credential_summarizes_and_then_fails_the_job(self) -> None:
+        """A run with no model credential must go RED, not green-with-a-notice.
+
+        The posture this pins is the whole point of the workflow: when
+        `OPENROUTER_API_KEY` is absent -- a fork PR, or the Dependabot PR that
+        is this gate's own motivating trigger -- the live approval-gate proof
+        cannot run, and a check that reports success anyway is exactly the
+        vacuous green that let #1852 ship.
+
+        A saboteur reverting to the report-don't-block posture would flip the
+        guard's `exit 1` to `exit 0`, delete the exit so the branch falls
+        through, or leave the exit in place and neutralize it with
+        `continue-on-error: true`. So this asserts the structure each of those
+        edits breaks: inside the empty-credential branch itself there is a
+        nonzero `exit` and no zero `exit`, and neither the step nor the job
+        swallows that failure. Asserting on the summary prose alone would
+        survive every one of those three edits.
+        """
+        workflow = load_workflow()
+        jobs = workflow["jobs"]
+        live_job = next(job for name, job in jobs.items() if name != "detect")
+
+        guard_steps = [
+            step
+            for step in live_job["steps"]
+            if "GITHUB_STEP_SUMMARY" in step.get("run", "")
+            and "OPENROUTER_API_KEY" in step.get("run", "")
+        ]
+        assert len(guard_steps) == 1
+        guard = guard_steps[0]
+
+        lines = guard["run"].splitlines()
+        branch_starts = [
+            index
+            for index, line in enumerate(lines)
+            if line.strip().startswith("if ") and "OPENROUTER_API_KEY" in line and "-z" in line
+        ]
+        assert len(branch_starts) == 1, "expected one empty-credential branch in the guard"
+        start = branch_starts[0]
+        ends = [index for index, line in enumerate(lines) if index > start and line.strip() == "fi"]
+        assert ends, "the empty-credential branch is unterminated"
+        branch = [line.strip() for line in lines[start + 1 : ends[0]]]
+
+        assert any(line.startswith("echo") or line == "{" for line in branch), branch
+        assert any("GITHUB_STEP_SUMMARY" in line for line in branch), branch
+
+        exits = [line for line in branch if line.split("#")[0].strip().startswith("exit")]
+        assert exits, "the empty-credential branch must terminate the job explicitly"
+        codes = [int(line.split()[1]) for line in exits]
+        assert all(code != 0 for code in codes), (
+            f"a missing credential must fail the job, not exit 0 (found {codes})"
+        )
+
+        # An `exit 1` that the runner is told to ignore is the same vacuous
+        # green by another name, at either the step or the job level.
+        assert guard.get("continue-on-error", "false") == "false"
+        assert live_job.get("continue-on-error", "false") == "false"
+        # And the guard itself must be unconditional: an `if:` on this step
+        # would let the missing-credential case route around the failure.
+        assert "if" not in guard
+
+    def test_every_checkout_step_disables_persisted_credentials(self) -> None:
+        workflow = load_workflow()
+        checkouts = [
+            step
+            for step in all_steps(workflow)
+            if step.get("uses", "").startswith("actions/checkout@")
+        ]
+
+        assert checkouts
+        assert all(step.get("with", {}).get("persist-credentials") == "false" for step in checkouts)

--- a/runner/tests/test_ladder_approval_gate_case.py
+++ b/runner/tests/test_ladder_approval_gate_case.py
@@ -1,0 +1,305 @@
+"""Source contracts for the ladder's live approval-gate case (#2094).
+
+The real proof is ``case_live_approval_gate_denies`` in
+``cli/scripts/e2e-ladder.sh``: it boots a runner against a real provider with
+the operator gate armed on ``Bash`` and asserts the turn parks awaiting
+approval instead of executing the command or spinning until the caller gives
+up (#1852, #2068). That proof fires on two triggers only -- the nightly graded
+ladder's live leg, and the SDK-lock PR workflow -- so a silent collapse of the
+case would go unnoticed for a long time, and every way it can collapse is
+quiet: a dropped ``--secret`` value never arms the gate, a missing ``LIVE``
+guard runs it sealed, a missing ``timeout`` wedges the run instead of failing
+it, and an uninvoked case is simply dead code.
+
+These fast tests pin the shape that makes the live case mean something. They
+do not run it; they keep it from becoming a green that proves nothing.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LADDER_PATH = REPO_ROOT / "cli" / "scripts" / "e2e-ladder.sh"
+
+CASE_NAME = "case_live_approval_gate_denies"
+# The case is inserted beside the other `case_*` helpers, above the connector
+# block that opens the ADR-0113 section.
+CASE_END_MARKER = "# The connector rung (ADR 0113"
+CANARY_PATH = "/tmp/curie-2094-canary"
+# The probe answers with one of two definite tokens, so that "docker could not
+# run the command" stays distinguishable from "the file is absent".
+CANARY_PRESENT = "CANARY_PRESENT"
+CANARY_ABSENT = "CANARY_ABSENT"
+PARITY_BUNDLE = "$WORKDIR/bundle"
+CASE_BUNDLE = "$WORKDIR/gate-bundle"
+
+
+def _function_body(source: str, name: str, next_marker: str) -> str:
+    start_marker = f"{name}() {{"
+    assert start_marker in source, f"{LADDER_PATH}: missing {name}"
+    start = source.index(start_marker)
+    end = source.index(next_marker, start)
+    return source[start:end]
+
+
+def _case_body() -> str:
+    return _function_body(LADDER_PATH.read_text(), CASE_NAME, CASE_END_MARKER)
+
+
+def _logical_line_at(body: str, needle: str) -> str:
+    """Return the whole backslash-continued command containing ``needle``.
+
+    The `skill message` invocation is wrapped across continuation lines, so a
+    per-physical-line search would not see the `timeout` that guards it, and a
+    whole-body search would happily accept the unrelated `command -v timeout`
+    preflight far above it. This reconstructs exactly the one command.
+    """
+
+    assert needle in body, f"{LADDER_PATH}: {CASE_NAME} never invokes {needle!r}"
+    lines = body.split("\n")
+    hit = next(index for index, line in enumerate(lines) if needle in line)
+    first = hit
+    while first > 0 and lines[first - 1].rstrip().endswith("\\"):
+        first -= 1
+    last = hit
+    while last + 1 < len(lines) and lines[last].rstrip().endswith("\\"):
+        last += 1
+    return "\n".join(lines[first : last + 1])
+
+
+def test_skill_rung_invokes_the_live_approval_gate_case() -> None:
+    """An uninvoked case is dead code that can never go red."""
+
+    rung = _function_body(LADDER_PATH.read_text(), "rung_skill", "# Rung 2: the compose tier")
+    assert CASE_NAME in rung, (
+        "the skill rung must call the live approval-gate case; a case defined "
+        "but never invoked proves nothing and fails no run"
+    )
+
+
+def test_case_returns_early_before_booting_when_not_live() -> None:
+    """A sealed run of this case would be a false green, not a cheap one."""
+
+    body = _case_body()
+    assert "LIVE" in body, (
+        f"{CASE_NAME} must guard on $LIVE; the fake tier cannot exhibit either "
+        "failure mode from #1852/#2068, so a sealed run reports a green that "
+        "means nothing"
+    )
+    assert "skill up" in body, f"{CASE_NAME} must boot its own runner with `skill up`"
+    assert body.index("LIVE") < body.index("skill up"), (
+        "the $LIVE guard must come before the runner is booted, or the case "
+        "runs sealed against the fake model and passes for the wrong reason"
+    )
+
+
+def test_case_arms_the_gate_with_a_name_only_secret() -> None:
+    """`--secret NAME=VALUE` is silently dropped, and the gate never arms."""
+
+    body = _case_body()
+    assert "--secret CURIE_APPROVAL_REQUIRED_TOOLS" in body, (
+        f"{CASE_NAME} must arm the operator gate via "
+        "`--secret CURIE_APPROVAL_REQUIRED_TOOLS`"
+    )
+
+    # cli/src/docker.rs forwards a variable literally named as passed, so
+    # `--secret CURIE_APPROVAL_REQUIRED_TOOLS=Bash` forwards nothing, the gate
+    # never arms, and the turn ends `done` with a misleading message.
+    #
+    # This checks the ARGUMENT of each `--secret`, not the body text, because
+    # the case legitimately contains `export CURIE_APPROVAL_REQUIRED_TOOLS=Bash`
+    # -- a bare `"CURIE_APPROVAL_REQUIRED_TOOLS=" not in body` would make the
+    # pin unsatisfiable. Walking the good string
+    # `--secret CURIE_APPROVAL_REQUIRED_TOOLS` yields the next token
+    # `CURIE_APPROVAL_REQUIRED_TOOLS`, which has no `=`; the bad string
+    # `--secret CURIE_APPROVAL_REQUIRED_TOOLS=Bash` yields
+    # `CURIE_APPROVAL_REQUIRED_TOOLS=Bash`, which does -- so this catches it.
+    # The `export` line is never a `--secret` argument and is untouched.
+    tokens = body.split()
+    offenders: list[str] = []
+    for position, token in enumerate(tokens):
+        if token.startswith("--secret="):
+            value = token[len("--secret=") :]
+        elif token == "--secret":
+            following = [candidate for candidate in tokens[position + 1 :] if candidate != "\\"]
+            value = following[0] if following else ""
+        else:
+            continue
+        if "=" in value:
+            offenders.append(value)
+    assert not offenders, (
+        "`--secret` takes a bare variable NAME; a NAME=VALUE form is filtered "
+        f"out of the container environment without a word, got: {offenders}"
+    )
+
+
+def test_case_bounds_the_turn_with_timeout() -> None:
+    """`curie skill message` has no timeout, so an unbounded turn hangs forever."""
+
+    body = _case_body()
+    invocation = _logical_line_at(body, "skill message")
+    assert "timeout " in invocation, (
+        "the `skill message` turn must run under `timeout`; nothing on that "
+        "path bounds itself, so a #2068 revert wedges the whole ladder instead "
+        f"of failing it. Unbounded invocation: {invocation!r}"
+    )
+
+
+def test_case_asserts_the_parked_status_and_the_unrun_canary() -> None:
+    """Parked-and-unrun is the claim; a finalized reply is its inverse.
+
+    Both halves are pinned by STRUCTURE, not by the presence of a string.
+    `awaiting-approval` and the canary path both appear in this case's
+    diagnostics, so a saboteur who replaces the real status comparison with an
+    unconditional success, or the canary conditional with `false`, leaves every
+    such string in place. What that saboteur must destroy is the comparison
+    itself -- so that is what these assertions read.
+    """
+
+    body = _case_body()
+
+    # --- (b) parked -------------------------------------------------------
+    # Neutering shape 1: `if [[ "$status" == "awaiting-approval" ]]` becomes
+    # `if true` / `if :`. That deletes this expression while the message a few
+    # lines down still says "awaiting-approval".
+    assert re.search(r'\[\[\s*"\$\{?status\}?"\s*==\s*"awaiting-approval"\s*\]\]', body), (
+        "the case must compare the turn's parsed terminal status against "
+        "`awaiting-approval` in a real test expression; the literal appearing "
+        "only in a diagnostic proves nothing about what the case enforces"
+    )
+
+    # Neutering shape 2: keep the comparison, but hardcode what it reads
+    # (`status="awaiting-approval"`). So the value must come from parsing the
+    # captured turn output, and must never be assigned the expected literal.
+    status_assignments = re.findall(r'^\s*status=(.*)$', body, flags=re.MULTILINE)
+    assert status_assignments, f"{CASE_NAME} must capture the turn's status"
+    assert any('$(' in value and '"$out"' in value for value in status_assignments), (
+        "the compared status must be parsed out of the captured `skill message` "
+        f"payload, not synthesized; got assignments: {status_assignments}"
+    )
+    assert not any("awaiting-approval" in value for value in status_assignments), (
+        "the expected status must never be assigned to the variable the case "
+        f"then compares against it; got assignments: {status_assignments}"
+    )
+
+    # --- (c) unrun --------------------------------------------------------
+    # Neutering shape 3: drop the in-container probe, or stop asking it a
+    # definite question. The probe must run inside the container, name the
+    # canary path, and print one of two unambiguous tokens.
+    # The needle keeps the opening quote of the container name so it matches
+    # the invocation and not the prose comment above it, which names the
+    # rejected `docker exec ... test -e` shape.
+    probe = _logical_line_at(body, 'docker exec "')
+    for fragment in (CANARY_PATH, CANARY_PRESENT, CANARY_ABSENT):
+        assert fragment in probe, (
+            "the side-effect probe must run in the container and print a "
+            f"definite token; {fragment!r} missing from: {probe!r}"
+        )
+
+    # Neutering shape 4: `if <condition>` becomes `if false`, so the
+    # ran-anyway branch can never fire. Both tokens must be compared in a real
+    # test expression, and each comparison must lead to a failure.
+    for token in (CANARY_PRESENT, CANARY_ABSENT):
+        assert re.search(rf'\[\[\s*"\$\{{?\w+\}}?"\s*[=!]=\s*"{token}"\s*\]\]', body), (
+            f"the case must compare the probe's output against {token!r} in a "
+            "real test expression; a conditional that cannot be false asserts "
+            "nothing"
+        )
+
+    # Neutering shape 5: the original defect -- treat a probe that could not
+    # run as proof the file is absent. The probe's exit status must be
+    # captured AND inspected, so "docker could not answer" is its own failure
+    # rather than a pass.
+    code_vars = re.findall(r'(\w+)=\$\?', probe)
+    assert code_vars, (
+        "the probe must capture its own exit status: `docker exec` exits "
+        "non-zero both when the canary is absent and when the command could "
+        f"not run at all. Probe: {probe!r}"
+    )
+    assert any(re.search(rf'\(\(\s*{name}\s*[=!]=\s*0\s*\)\)', body) for name in code_vars), (
+        "the probe's captured exit status must be inspected; capturing it and "
+        "ignoring it lets a daemon or container failure read as `the gate held`"
+    )
+
+    # Both non-pass outcomes must end the case red.
+    lines = body.split("\n")
+    for index, line in enumerate(lines):
+        if CANARY_PRESENT not in line and CANARY_ABSENT not in line:
+            continue
+        if "[[" not in line:
+            continue
+        assert any("return 1" in follower for follower in lines[index : index + 5]), (
+            "every canary outcome other than a clean, definite absent token "
+            f"must fail the case; this branch does not: {line.strip()!r}"
+        )
+
+    assert "--fake-model" not in body, (
+        "the case proves real SDK dispatch against a real model; a "
+        "`--fake-model` boot cannot exhibit either failure mode"
+    )
+    assert "assert_finalized_reply" not in body, (
+        "assert_finalized_reply treats `awaiting_approval` as a FAILURE, which "
+        "is the exact inverse of this case's claim; do not reuse it here"
+    )
+
+
+def test_cleanup_trap_reaps_the_gate_case_container() -> None:
+    """The case boots a container; a run that dies mid-case must not strand it."""
+
+    trap = _function_body(LADDER_PATH.read_text(), "cleanup", "trap cleanup EXIT")
+    assert "GATE_CASE_CREATED" in trap, (
+        "the global EXIT trap must reap the gate case's runner by its exact "
+        "unique name, even when the case never reaches its own teardown"
+    )
+
+
+def test_case_uses_its_own_bundle_copy() -> None:
+    """`skill up` writes state into its CWD bundle; the parity artifact is shared."""
+
+    body = _case_body()
+    assert CASE_BUNDLE in body, (
+        f"the case must operate in its own {CASE_BUNDLE} copy: `skill up` "
+        "writes .curie/ state into the CWD bundle, and $WORKDIR/bundle is the "
+        "artifact assert_bundle_identity compares across rungs (#1608)"
+    )
+
+    # Mentioning $WORKDIR/bundle is not itself the defect -- `cp -a
+    # "$WORKDIR/bundle" "$GATE_CASE_BUNDLE"` names it as the SOURCE and is
+    # exactly what the case is supposed to do. The defect is the case
+    # *operating in* it. So: every mention must be a `cp` source (a `cp` line,
+    # and not that line's final argument, which is the destination), and no
+    # `cd` may target it.
+    for line in body.split("\n"):
+        if PARITY_BUNDLE not in line:
+            continue
+        for chunk in line.replace("&&", ";").split(";"):
+            if PARITY_BUNDLE not in chunk:
+                continue
+            tokens = chunk.split()
+            assert tokens[0] == "cp", (
+                f"{PARITY_BUNDLE} may only appear as the source of the bundle "
+                f"copy, never as a path the case works in; got: {chunk.strip()!r}"
+            )
+            mentions = [index for index, token in enumerate(tokens) if PARITY_BUNDLE in token]
+            assert max(mentions) < len(tokens) - 1, (
+                f"{PARITY_BUNDLE} is the destination of this copy, which would "
+                f"overwrite the shared parity artifact: {chunk.strip()!r}"
+            )
+
+    targets: list[str] = []
+    for raw in body.split("\n"):
+        # A `cd` may open a subshell (`(cd "$X" && ...)`) or a command
+        # substitution (`out="$(cd "$X" && ...)"`), so strip the leading
+        # punctuation rather than requiring the line to start with `cd`.
+        statement = raw.strip().lstrip("(").lstrip()
+        statement = statement.split('="$(', 1)[-1].lstrip()
+        if statement.startswith("cd "):
+            targets.append(statement.split()[1])
+    assert targets, f"{CASE_NAME} must cd into the bundle copy before `skill up`"
+    for target in targets:
+        assert PARITY_BUNDLE not in target, (
+            "the case must never cd into the shared parity bundle; "
+            f"got `cd {target}`"
+        )

--- a/tools/sdk-lock-gate/detect.py
+++ b/tools/sdk-lock-gate/detect.py
@@ -1,0 +1,168 @@
+"""Detect whether a ``uv.lock`` diff changes what is resolved as ``claude-agent-sdk`` (#2094).
+
+The live approval-gate proof in the e2e ladder is the only thing that exercises a real
+model against a real SDK permission dispatch. It is expensive, so it cannot run on every
+pull request -- but it MUST run whenever the SDK bytes underneath it move. This module is
+the trigger: it compares the base and head ``uv.lock`` and answers one question, "did the
+resolved ``claude-agent-sdk`` entry change?".
+
+The two error directions do not cost the same. A false positive costs one live ladder run.
+A false negative lets a new SDK build reach production without the approval gate ever
+being re-proven against it -- the exact escape #2094 exists to close. So the rule is
+deliberately over-triggering: the whole ``[[package]]`` table is fingerprinted (version,
+``source``, ``dependencies``, ``sdist``, ``wheels``), and so is every other line naming the
+SDK. A same-version wheel re-upload, a hash change, or a transitive dependency swap all
+mean different bytes execute the permission dispatch, and all of them return ``True``.
+
+For the same reason the detector fails **open**: a missing side or a lock that is not valid
+TOML returns ``True``. A corrupt lock is somebody else's CI failure and must never silently
+disarm this gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import tomllib
+from pathlib import Path
+from typing import Any
+
+SDK_NAME = "claude-agent-sdk"
+PACKAGE_HEADER = "[[package]]"
+
+# (parsed SDK tables, sorted other lines naming the SDK). Comparable, not hashable:
+# the tables stay nested dicts and are compared with ``==``, never hashed.
+Fingerprint = tuple[list[dict[str, Any]], tuple[str, ...]]
+
+
+def _sdk_tables(document: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return the ``[[package]]`` tables whose ``name`` is exactly ``claude-agent-sdk``.
+
+    The match is equality on the parsed ``name`` key, never a substring of the file text,
+    so a distinct package such as ``claude-agent-sdk-extras`` is not mistaken for the SDK.
+    """
+    packages = document.get("package")
+    if not isinstance(packages, list):
+        return []
+    return [
+        package
+        for package in packages
+        if isinstance(package, dict) and package.get("name") == SDK_NAME
+    ]
+
+
+def _sections(text: str) -> list[list[str]]:
+    """Split the lock into TOML sections, each starting at a header line.
+
+    A header is a line that begins at column zero with ``[`` and ends with ``]``:
+    ``[[package]]`` or ``[package.metadata]``. Array continuation lines are indented and
+    the closing ``]`` of an array does not begin with ``[``, so neither is misread.
+    """
+    sections: list[list[str]] = [[]]
+    for line in text.splitlines():
+        if line.startswith("[") and line.rstrip().endswith("]"):
+            sections.append([])
+        sections[-1].append(line)
+    return sections
+
+
+def _back_reference_lines(text: str) -> tuple[str, ...]:
+    """Return the sorted stripped lines naming the SDK from outside its own table.
+
+    This is the second half of the fingerprint. The parsed table alone does not see the
+    ``requires-dist`` specifier in ``[package.metadata]`` or the ``dependencies``
+    back-reference from ``curie-runner``: both can move while the resolved table stays
+    byte-identical, and both change which SDK build a fresh resolve would pick. Collecting
+    the raw lines catches them without modelling the whole dependency graph.
+
+    Lines inside the SDK's own ``[[package]]`` table are dropped because the first half
+    already covers them. The section scan is a heuristic; if it ever fails to recognise the
+    table, those lines are merely counted twice, which cannot turn a change into a
+    non-change.
+    """
+    own_name = f'name = "{SDK_NAME}"'
+    collected: list[str] = []
+    for section in _sections(text):
+        if not section:
+            continue
+        is_sdk_table = section[0].strip() == PACKAGE_HEADER and any(
+            line.strip() == own_name for line in section
+        )
+        if is_sdk_table:
+            continue
+        collected.extend(line.strip() for line in section if SDK_NAME in line)
+    return tuple(sorted(collected))
+
+
+def _fingerprint(text: str | None) -> Fingerprint | None:
+    """Fingerprint one side of the diff, or ``None`` when it cannot be read.
+
+    ``None`` means "unknown", and every unknown side fails open in
+    :func:`sdk_entry_changed`.
+    """
+    if text is None:
+        return None
+    try:
+        document = tomllib.loads(text)
+    except tomllib.TOMLDecodeError as error:
+        print(
+            f"sdk-lock-gate: uv.lock is not valid TOML ({error}); failing open",
+            file=sys.stderr,
+        )
+        return None
+    return _sdk_tables(document), _back_reference_lines(text)
+
+
+def sdk_entry_changed(old_text: str | None, new_text: str | None) -> bool:
+    """Report whether the resolved ``claude-agent-sdk`` entry differs between two locks.
+
+    ``old_text`` and ``new_text`` are the full ``uv.lock`` contents on the base and head
+    refs, or ``None`` when the file is absent on that ref. Returns ``True`` when either
+    side is unknown or malformed, and otherwise when the two fingerprints differ.
+
+    There is deliberately no ``old_text == new_text`` shortcut: identical text is already
+    an identical fingerprint, and a shortcut would skip the parse that reports a malformed
+    lock.
+    """
+    old = _fingerprint(old_text)
+    new = _fingerprint(new_text)
+    if old is None or new is None:
+        return True
+    return old != new
+
+
+def _read(path: Path) -> str | None:
+    """Read a lock file, treating an absent path as absent on that ref."""
+    try:
+        return path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--old-file", required=True, type=Path)
+    parser.add_argument("--new-file", required=True, type=Path)
+    return parser
+
+
+def _run() -> None:
+    args = _parser().parse_args()
+    changed = sdk_entry_changed(_read(args.old_file), _read(args.new_file))
+
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if not output_path:
+        raise ValueError("GITHUB_OUTPUT is required")
+    with Path(output_path).open("a", encoding="utf-8") as stream:
+        stream.write(f"changed={'true' if changed else 'false'}\n")
+
+
+def main() -> int:
+    """Write the verdict and always exit 0; the workflow reads the output, not the code."""
+    _run()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/sdk-lock-gate/tests/test_sdk_lock_gate.py
+++ b/tools/sdk-lock-gate/tests/test_sdk_lock_gate.py
@@ -1,0 +1,284 @@
+"""Executable contract for the ``claude-agent-sdk`` lock-entry detector (#2094).
+
+The detector answers one question for a PR workflow: did this ``uv.lock`` diff
+change what the runner will actually import as ``claude-agent-sdk``? A ``True``
+answer costs one live ladder run against a real provider. A ``False`` answer
+costs nothing -- and, if it is wrong, lets a new SDK build reach production
+without the live approval gate ever being re-proven, which is the exact escape
+#2094 exists to close.
+
+The two costs are not symmetric, so the rule is deliberately over-triggering:
+the whole ``[[package]]`` table is fingerprinted (version, ``source``,
+``dependencies``, ``sdist``, ``wheels``), plus every other line in the file
+naming ``claude-agent-sdk`` -- the back-reference and the ``requires-dist``
+specifier. A same-version wheel re-upload, a hash change, or a transitive
+dependency swap all mean different SDK bytes execute the permission dispatch
+that PR #2068 rewired, so all of them must return ``True``. Malformed TOML and
+a missing side fail **open** for the same reason: a corrupt lock is somebody
+else's CI failure and must never silently disarm this gate.
+
+The fixtures below are cut down from the real ``uv.lock`` in this repo (the
+``claude-agent-sdk`` table at ``uv.lock:604`` and its two back-references at
+``:837`` and ``:849``), so the shapes the detector parses here are the shapes
+it meets in production.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+from functools import cache
+from pathlib import Path
+from types import ModuleType
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+DETECTOR = REPO_ROOT / "tools" / "sdk-lock-gate" / "detect.py"
+
+
+@cache
+def _detector() -> ModuleType:
+    """Load ``detect.py`` by path: ``tools/*`` holds scripts, not packages."""
+    spec = importlib.util.spec_from_file_location("curie_sdk_lock_gate", DETECTOR)
+    assert spec is not None and spec.loader is not None, f"cannot load {DETECTOR}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def changed(old_text: str | None, new_text: str | None) -> bool:
+    """Call the detector and pin that it returns a real ``bool``, not a truthy proxy."""
+    result = _detector().sdk_entry_changed(old_text, new_text)
+    assert isinstance(result, bool), f"sdk_entry_changed returned {type(result)!r}, not bool"
+    return result
+
+
+# --- fixtures ---------------------------------------------------------------
+# Trimmed from the real uv.lock: fewer wheels and fewer packages, but the same
+# table shapes, the same key order, and both claude-agent-sdk back-references.
+
+BASE_LOCK = """version = 1
+revision = 3
+requires-python = ">=3.13"
+
+[[package]]
+name = "anyio"
+version = "4.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/aa/anyio-4.12.0.tar.gz", \
+hash = "sha256:1111111111111111111111111111111111111111111111111111111111111111", size = 219823 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/anyio-4.12.0-py3-none-any.whl", \
+hash = "sha256:2222222222222222222222222222222222222222222222222222222222222222", size = 107213 },
+]
+
+[[package]]
+name = "claude-agent-sdk"
+version = "0.2.135"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "mcp" },
+    { name = "sniffio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d8/claude_agent_sdk-0.2.135.tar.gz", \
+hash = "sha256:471ae3769d7814c658fa0a37dbd95bb4b1e365563d6a794dcdd99586a29ec53b", size = 312219 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/\
+claude_agent_sdk-0.2.135-py3-none-manylinux_2_17_aarch64.whl", \
+hash = "sha256:5306f142ea018eca519cb7d0c3d7b4e97702ae009285d9e1c4896357fe87e27c", size = 92281562 },
+    { url = "https://files.pythonhosted.org/packages/1b/\
+claude_agent_sdk-0.2.135-py3-none-manylinux_2_17_x86_64.whl", \
+hash = "sha256:01a4ded2b5b19edf2395ab77a38ce0d0e6cc0d6e1a263f85c701de5eb3764e20", size = 93366910 },
+]
+
+[[package]]
+name = "claude-agent-sdk-extras"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/\
+claude_agent_sdk_extras-0.1.0-py3-none-any.whl", \
+hash = "sha256:3333333333333333333333333333333333333333333333333333333333333333", size = 4211 },
+]
+
+[[package]]
+name = "click"
+version = "8.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/click-8.5.0.tar.gz", \
+hash = "sha256:ba0d2089de75ea0310e2dde03160e6ca10009947fb95a182f9b54021bb272e34", size = 382235 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/click-8.5.0-py3-none-any.whl", \
+hash = "sha256:255bc9599cf7748b4b1a446ccc735421bd08a2ae529a8b88597d3de5664ee360", size = 125251 },
+]
+
+[[package]]
+name = "curie-runner"
+version = "0.0.0"
+source = { editable = "runner" }
+dependencies = [
+    { name = "anyio" },
+    { name = "claude-agent-sdk" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "anyio", specifier = ">=4.6" },
+    { name = "claude-agent-sdk", specifier = ">=0.2.135" },
+]
+"""
+
+
+def without_sdk(text: str) -> str:
+    """Drop the SDK's own table and both of its back-references.
+
+    Models the shape uv actually writes when the dependency is dropped from
+    ``runner/pyproject.toml``: the resolved entry disappears *and* so do the
+    lines naming it elsewhere.
+    """
+    exact = '"claude-agent-sdk"'
+    kept: list[str] = []
+    for block in text.split("\n\n"):
+        if f"\nname = {exact}\n" in f"\n{block}\n":
+            continue
+        kept.append("\n".join(line for line in block.splitlines() if exact not in line))
+    return "\n\n".join(kept)
+
+
+# --- the rule ---------------------------------------------------------------
+
+
+def test_an_sdk_version_bump_is_reported_as_changed() -> None:
+    new = BASE_LOCK.replace('version = "0.2.135"', 'version = "0.2.140"')
+    assert new != BASE_LOCK
+    assert changed(BASE_LOCK, new) is True
+
+
+def test_an_untouched_lock_file_is_reported_as_unchanged() -> None:
+    assert changed(BASE_LOCK, BASE_LOCK) is False
+
+
+def test_reformatting_an_unrelated_package_is_reported_as_unchanged() -> None:
+    """Whitespace and key order elsewhere are not SDK bytes."""
+    new = BASE_LOCK.replace(
+        '[[package]]\nname = "click"\nversion = "8.5.0"\n'
+        'source = { registry = "https://pypi.org/simple" }\n',
+        '[[package]]\n\nversion   = "8.5.0"\nname = "click"\n'
+        'source = {registry = "https://pypi.org/simple"}\n',
+    )
+    assert new != BASE_LOCK
+    assert changed(BASE_LOCK, new) is False
+
+
+def test_bumping_an_unrelated_package_is_reported_as_unchanged() -> None:
+    """The whole point of the gate: a routine dependency bump costs no live run."""
+    new = BASE_LOCK.replace('version = "8.5.0"', 'version = "8.6.0"').replace(
+        "click-8.5.0", "click-8.6.0"
+    )
+    assert new != BASE_LOCK
+    assert changed(BASE_LOCK, new) is False
+
+
+def test_a_republished_sdk_wheel_at_the_same_version_is_reported_as_changed() -> None:
+    """Same version, different bytes -- the case a version-only rule would miss."""
+    new = BASE_LOCK.replace(
+        "sha256:5306f142ea018eca519cb7d0c3d7b4e97702ae009285d9e1c4896357fe87e27c",
+        "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+    )
+    assert new != BASE_LOCK
+    assert changed(BASE_LOCK, new) is True
+
+
+def test_a_change_to_the_sdks_own_dependencies_is_reported_as_changed() -> None:
+    new = BASE_LOCK.replace('    { name = "sniffio" },\n', "")
+    assert new != BASE_LOCK
+    assert changed(BASE_LOCK, new) is True
+
+
+def test_a_requires_dist_specifier_change_is_reported_as_changed() -> None:
+    """The resolved table is byte-identical; only the back-reference moved."""
+    new = BASE_LOCK.replace('specifier = ">=0.2.135"', 'specifier = ">=0.2.140"')
+    assert new != BASE_LOCK
+    assert '\nversion = "0.2.135"\n' in new
+    assert changed(BASE_LOCK, new) is True
+
+
+def test_adding_the_sdk_to_the_lock_is_reported_as_changed() -> None:
+    assert changed(without_sdk(BASE_LOCK), BASE_LOCK) is True
+
+
+def test_removing_the_sdk_from_the_lock_is_reported_as_changed() -> None:
+    assert changed(BASE_LOCK, without_sdk(BASE_LOCK)) is True
+
+
+def test_a_lock_without_the_sdk_on_either_side_is_reported_as_unchanged() -> None:
+    """No SDK anywhere means nothing this gate defends can have moved."""
+    old = without_sdk(BASE_LOCK)
+    new = old.replace('version = "8.5.0"', 'version = "8.6.0"')
+    assert '"claude-agent-sdk"' not in old
+    assert new != old
+    assert changed(old, new) is False
+
+
+def test_a_similarly_named_package_is_not_mistaken_for_the_sdk() -> None:
+    """``claude-agent-sdk-extras`` is a different package: exact ``name`` match."""
+    new = BASE_LOCK.replace('version = "0.1.0"', 'version = "0.2.0"').replace(
+        "claude_agent_sdk_extras-0.1.0", "claude_agent_sdk_extras-0.2.0"
+    )
+    assert new != BASE_LOCK
+    assert changed(BASE_LOCK, new) is False
+
+
+# --- fail-open --------------------------------------------------------------
+
+
+def test_a_malformed_lock_file_fails_open() -> None:
+    """A corrupt lock is a separate CI failure; it must not disarm this gate."""
+    assert changed(BASE_LOCK, BASE_LOCK + '\n[[package\nname = "broken\n') is True
+
+
+def test_a_missing_base_side_fails_open() -> None:
+    """``uv.lock`` absent on the base ref: nothing to compare, so run the proof."""
+    assert changed(None, BASE_LOCK) is True
+
+
+# --- the CLI ----------------------------------------------------------------
+
+
+def test_the_cli_writes_the_verdict_to_github_output(tmp_path: Path) -> None:
+    """The only surface the workflow reads: ``changed=true`` / ``changed=false``."""
+    old_file = tmp_path / "old.lock"
+    new_file = tmp_path / "new.lock"
+    old_file.write_text(BASE_LOCK, encoding="utf-8")
+
+    def run(new_text: str, output_name: str) -> str:
+        new_file.write_text(new_text, encoding="utf-8")
+        github_output = tmp_path / output_name
+        env = dict(os.environ, GITHUB_OUTPUT=str(github_output))
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(DETECTOR),
+                "--old-file",
+                str(old_file),
+                "--new-file",
+                str(new_file),
+            ],
+            capture_output=True,
+            text=True,
+            env=env,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+        return github_output.read_text(encoding="utf-8")
+
+    bumped = BASE_LOCK.replace('version = "0.2.135"', 'version = "0.2.140"')
+    assert "changed=true" in run(bumped, "bumped.txt")
+
+    unrelated = BASE_LOCK.replace('version = "8.5.0"', 'version = "8.6.0"')
+    assert "changed=false" in run(unrelated, "unrelated.txt")


### PR DESCRIPTION
Closes #2094.

The approval gate has escaped three times through the same mechanism (#245, #453, #1852). Every existing test sits at the `FakeModelSession` seam, which structurally cannot see either failure mode, and the evidence that #2068 fixed it correctly was prose in a docstring. `runner/pyproject.toml` declares `claude-agent-sdk>=0.2.135` — a floor, not a pin — and dependabot groups every Python bump into one weekly PR whose only gate is that offline fake-model suite.

This adds one live case and one path trigger. No new nightly rung, no blanket live E2E, no change to `ci.yaml` or `nightly-graded-ladder.yaml`.

## What is here

- **`cli/scripts/e2e-ladder.sh`** — `case_live_approval_gate_denies`, invoked from `rung_skill()`, returning a printed skip line unless `CURIE_E2E_LIVE=1`. It copies the ladder bundle (never the cross-rung parity artifact #1608 compares), boots its own runner with `Bash` gated through the operator override `CURIE_APPROVAL_REQUIRED_TOOLS`, sends one turn under `timeout 240`, and asserts three things: the turn was **bounded** (no `timeout` 124 — #1852's hang), it **parked** `awaiting-approval`, and the gated command **did not run** (a canary file, probed three-way so a dead container or a daemon error fails the case instead of reading as proof).
- **`.github/workflows/sdk-approval-gate.yaml`** — on a PR touching `uv.lock`, a cheap `detect` job decides whether the `claude-agent-sdk` entry actually moved; only then does the live job run the skill rung. When no model credential is available it **fails** with an actionable job summary rather than reporting a green check that proved nothing.
- **`tools/sdk-lock-gate/`** — the pure detector behind that, deliberately over-triggering: a false positive costs one live run, a false negative is the escape this ticket exists to close.
- **Three offline pins** so the live proof cannot silently collapse, plus one `pyproject.toml` `testpaths` line (omitting it reproduces #1752 exactly).

## Live evidence

Five runs of the skill rung against a real OpenRouter model:

| runner build | result |
|---|---|
| this branch, unmodified | parked `awaiting-approval`, canary absent, `LADDER PASS` |
| both gate layers disabled | **red**, `LADDER_EXIT=1`, `the gated Bash command RAN` |

The second is the teeth test: it confirms the case detects an ungated tool call, and that assertion (c) — not the status check — is what catches it.

## AC2 is not met, and cannot be

> Reverting #2068's PreToolUse wiring turns that case red.

It does not. Removing `_merge_pre_tool_use_hooks`'s approval hook left the case **green**; so did additionally removing `interrupt=True` from `can_use_tool`'s deny. Two causes: the hook is only load-bearing when a permission rule preauthorizes the gated tool, and since #1875 `assert_gates_not_shadowed` **refuses to boot** exactly that configuration (verified: gating `WebSearch` on `examples/weather` fails to start); and #1852's hang was specific to `claude-sonnet-4.5`, while the ladder's model ended its turn on the prose deny.

The hook remains genuine defence-in-depth against an SDK that reintroduces a preauthorization path — which is what the `uv.lock` trigger is for — but nothing executable pins the hook *layer* outside the offline tests. Written up as **#2106**, with the full evidence table.

## Reviewer findings

Two independent agent-router reviews (Code, Scope; both `codex/gpt-5.6-sol`) raised five and four findings. Fixed: the canary probe's false-pass on a failed `docker exec`; the vacuous green on a secretless PR (the ticket's own dependabot scenario reached it); and a pin that matched diagnostic strings rather than the enforcing structure — each fixer verified its fix by mutation. Consolidation (`/simplify`, four angles) removed six step guards the failing credential check made unreachable.

Recorded rather than fixed, with reasons: the live job runs the whole skill rung rather than one case (the ladder has no case-selection mechanism, and the altitude review's verdict was that building one for a single caller is the wrong depth); the detector's over-trigger on a formatting-only back-reference edit (deliberate); and the skill tier proving a runner status rather than a durable approval record (**#2108** — `curie skill message --json` discards every approval field).

Follow-ups filed: **#2106**, **#2107** (the case at the local/local-release/cluster rungs), **#2108**.

No `Fix pin:` line: `tools/fix-pin-ci/check.py` accepts selectors only under `apps/*/tests/`, `packages/*/tests/`, `cli/tests/` and `charts/curie/ci/`, and all three of this PR's pins live in `runner/tests/`, `tools/*/tests/` and `release/tests/`. The gate skips cleanly when absent; widening it is not this ticket's call.

## Done-check

- [x] Failing tests committed before implementation — 27 failing pins in the first commit.
- [x] Production edits delegated to sub-agents — except the `/simplify` phase-2 edits, which that stage applies directly by design.
- [x] Broadened return types — none; both implementers reported explicitly.
- [x] Agent-router Code Reviewer — completed, file:line evidence, findings reconciled.
- [x] Agent-router Scope Reviewer — completed, every hunk mapped.
- [x] Sibling-path parity — 20 sites enumerated; the local/local-release/cluster rungs deferred to #2107.
- [x] Guard demonstration — the credential guard executed with an empty secret: exit 1 plus the summary notice; the ladder case's assertions demonstrated by the teeth run above.
- [x] Consolidation pass ran; revalidated and re-reviewed.
- [ ] Security Reviewer — N/A, not flagged.
- [ ] Observable verification — N/A, no user-facing surface.
- [x] E2E observed deployed behaviour — five live ladder runs.
- [x] Full affected suite passes; ruff, mypy and import-linter clean.

Pre-existing failures on this box, reproduced on the base and unrelated to this branch: the Valkey-backed `apps/worker/tests/eval/` suite, `apps/api/tests/test_control_integration.py`, and the live-Grafana `examples/tests/test_sre_bot_observability_runtime.py`. `runner/tests/test_otel.py` fails only when the shell exports `OTEL_EXPORTER_OTLP_ENDPOINT`; clean without it.
