### PR TITLE
Fail closed on retired LiteLLM sidecar

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -110,9 +110,9 @@ jobs:
           set -euo pipefail
           bash charts/curie/ci/api-service-nodeport-assertions.sh
 
-      # Prove the BYO-model LiteLLM sidecar (issue #253) is off by default,
-      # renders fully when its values flag is enabled, and yields to local
-      # inference. Runs the chart-owned assertion script.
+      # Prove the retired BYO-model LiteLLM sidecar (issue #253) is absent by
+      # default and that enabling its values flag is refused by the chart
+      # guard. Runs the chart-owned assertion script.
       - name: helm render assertions (litellm sidecar)
         run: |
           set -euo pipefail
@@ -346,11 +346,10 @@ jobs:
           set -euo pipefail
           bash charts/curie/ci/tenant-capacity-assertions.sh
 
-      # Prove every sandbox container (runner, both bundle init containers, and
-      # the litellm sidecar when enabled) declares an ephemeral-storage request
-      # AND limit (ADR-0059 decision 1, issue #755), and that the ceiling is
-      # operator-overridable (decision 6). Before this, disk was the one
-      # resource dimension with no ceiling at all.
+      # Prove the runner and both bundle init containers declare an
+      # ephemeral-storage request AND limit (ADR-0059 decision 1, issue #755),
+      # and that the ceiling is operator-overridable (decision 6). Before this,
+      # disk was the one resource dimension with no ceiling at all.
       - name: helm render assertions (ephemeral-storage ceilings)
         run: |
           set -euo pipefail

--- a/charts/curie/ci/ephemeral-storage-assertions.sh
+++ b/charts/curie/ci/ephemeral-storage-assertions.sh
@@ -6,10 +6,7 @@
 #   1. DEFAULT render: the runner container and both bundle init containers
 #      (bundle-fetch, bundle-extract) each carry an `ephemeral-storage`
 #      request AND limit alongside cpu/memory in `resources`.
-#   2. LITELLM render (sidecar enabled): the litellm sidecar carries its own
-#      `ephemeral-storage` request AND limit too, so every container in the
-#      sandbox pod is covered, not just the three that render by default.
-#   3. OVERRIDE: an operator `--set` on `agentSandbox.runner.resources.limits`
+#   2. OVERRIDE: an operator `--set` on `agentSandbox.runner.resources.limits`
 #      changes the rendered ephemeral-storage limit, proving the ceiling is
 #      operator-overridable per ADR-0059 decision 6 (the `RunnerHardening`
 #      precedent), not hardcoded in the template.
@@ -34,16 +31,10 @@ TPL=templates/agent-sandbox.yaml
 fail() { echo "FAIL: $*" >&2; exit 1; }
 
 DEFAULT="$TMP/default.yaml"
-LITELLM="$TMP/litellm.yaml"
 OVERRIDE="$TMP/override.yaml"
 
 echo "=== Rendering SandboxTemplate (defaults) ==="
 helm template rel "$CHART" --show-only "$TPL" > "$DEFAULT"
-
-echo "=== Rendering SandboxTemplate (litellm sidecar enabled) ==="
-helm template rel "$CHART" --show-only "$TPL" \
-  --set agentSandbox.runner.liteLLM.enabled=true \
-  --set agentSandbox.runner.liteLLM.configExistingSecret=my-litellm-cfg > "$LITELLM"
 
 echo "=== Rendering SandboxTemplate (operator override of the runner limit) ==="
 helm template rel "$CHART" --show-only "$TPL" \
@@ -102,14 +93,13 @@ def check_override(path, expected_limit):
 
 
 check_present(sys.argv[1], {"bundle-fetch", "bundle-extract", "runner"})
-check_present(sys.argv[2], {"bundle-fetch", "bundle-extract", "runner", "litellm"})
-check_override(sys.argv[3], "9Gi")
+check_override(sys.argv[2], "9Gi")
 PY
 
-if ! out="$(python3 "$ASSERT_PY" "$DEFAULT" "$LITELLM" "$OVERRIDE" 2>&1)"; then
+if ! out="$(python3 "$ASSERT_PY" "$DEFAULT" "$OVERRIDE" 2>&1)"; then
   fail "$out"
 fi
 echo "$out"
 
 echo
-echo "PASS: every sandbox container (runner, bundle-fetch, bundle-extract, and the litellm sidecar when enabled) renders an ephemeral-storage request and limit, and the ceiling is operator-overridable (ADR-0059 decisions 1 and 6)."
+echo "PASS: the runner and bundle-fetch/bundle-extract init containers render an ephemeral-storage request and limit, and the ceiling is operator-overridable (ADR-0059 decisions 1 and 6)."

--- a/charts/curie/ci/litellm-sidecar-assertions.sh
+++ b/charts/curie/ci/litellm-sidecar-assertions.sh
@@ -1,18 +1,13 @@
 #!/usr/bin/env bash
 #
-# Render-assertion test for issue #253 (BYO model: values-gated LiteLLM
-# Anthropic-format sidecar in the chart). Proves:
+# Render-assertion test for the retired LiteLLM sandbox sidecar. Proves:
 #
-#   1. DEFAULT render (agentSandbox.runner.liteLLM.enabled defaults false): the
-#      sidecar container, its config volume, and the localhost ANTHROPIC_BASE_URL
-#      override are ALL absent from the rendered SandboxTemplate.
-#   2. ENABLED render (liteLLM.enabled=true + a configExistingSecret): the
-#      `litellm` sidecar container renders, mounts the operator Secret at
-#      /etc/litellm/config.yaml, and the runner's ANTHROPIC_BASE_URL is repointed
-#      at http://localhost:<port>.
-#   3. PRECEDENCE: with local inference.deploy=true the sidecar's localhost
-#      ANTHROPIC_BASE_URL override does NOT render (the in-cluster inference
-#      endpoint path wins), matching the values-doc contract.
+#   1. DEFAULT and explicit false renders preserve the supported sandbox path:
+#      no LiteLLM container, image, config volume, Secret surface, localhost
+#      ANTHROPIC_BASE_URL override, or mutable main-stable image reference.
+#   2. Every truthy enablement path is refused by Helm with the same actionable
+#      ADR-0037 recovery message, before deployment or inference toggles can
+#      bypass the guard.
 #
 # Runnable locally (from anywhere) and from CI. Fails loudly.
 set -euo pipefail
@@ -24,6 +19,7 @@ TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
 TPL=templates/agent-sandbox.yaml
+REFUSAL='agentSandbox.runner.liteLLM.enabled is unsupported by ADR-0037: in-path LiteLLM gateways are unsupported; remove or disable agentSandbox.runner.liteLLM.enabled and use direct session-pinned provider routing.'
 
 fail() { echo "FAIL: $*" >&2; exit 1; }
 
@@ -32,44 +28,60 @@ render() {
   helm template rel "$CHART" --show-only "$TPL" "$@"
 }
 
-echo "=== Assertion 1: DEFAULT render omits the sidecar ==="
-DEFAULT="$TMP/default.yaml"
-render > "$DEFAULT"
-if grep -qE '^\s*-?\s*name: litellm' "$DEFAULT"; then
-  fail "default render must NOT contain a litellm sidecar/volume; found one (sidecar rendered while disabled)."
-fi
-if grep -q "localhost:" "$DEFAULT"; then
-  fail "default render must NOT repoint ANTHROPIC_BASE_URL at localhost."
-fi
-echo "  ok: no litellm sidecar, no localhost base-url override by default"
+expect_safe_render() {
+  local name="$1"
+  shift
+  local output="$TMP/$name.yaml"
 
-echo "=== Assertion 2: ENABLED render adds the sidecar + repoints the runner ==="
-ENABLED="$TMP/enabled.yaml"
-render \
+  render "$@" > "$output"
+
+  if grep -qi 'litellm' "$output"; then
+    fail "$name render must NOT contain a LiteLLM container, image, config volume, or Secret surface."
+  fi
+  if grep -q 'localhost:' "$output"; then
+    fail "$name render must NOT repoint ANTHROPIC_BASE_URL at localhost."
+  fi
+  if grep -q 'main-stable' "$output"; then
+    fail "$name render must NOT contain a mutable main-stable image reference."
+  fi
+  echo "  ok: $name render has no retired LiteLLM or localhost surface"
+}
+
+expect_refused() {
+  local name="$1"
+  shift
+  local stdout="$TMP/$name.stdout"
+  local stderr="$TMP/$name.stderr"
+
+  if render "$@" > "$stdout" 2> "$stderr"; then
+    fail "$name must be refused when agentSandbox.runner.liteLLM.enabled is truthy."
+  fi
+  if ! grep -Fq -- "$REFUSAL" "$stdout" "$stderr"; then
+    fail "$name failed without the required LiteLLM refusal. Expected exact message: $REFUSAL"
+  fi
+  echo "  ok: $name was refused with the ADR-0037 recovery message"
+}
+
+echo "=== Assertion 1: supported renders omit the retired LiteLLM surface ==="
+expect_safe_render default
+expect_safe_render explicit-false \
+  --set agentSandbox.runner.liteLLM.enabled=false
+
+echo "=== Assertion 2: every truthy LiteLLM enablement is refused ==="
+expect_refused enabled \
+  --set agentSandbox.runner.liteLLM.enabled=true
+expect_refused sandbox-disabled \
   --set agentSandbox.runner.liteLLM.enabled=true \
-  --set agentSandbox.runner.liteLLM.configExistingSecret=my-litellm-cfg \
-  --set agentSandbox.runner.liteLLM.port=4000 > "$ENABLED"
-
-grep -qE '^\s*- name: litellm$' "$ENABLED" \
-  || fail "enabled render must contain a container named 'litellm'."
-grep -q 'secretName: "my-litellm-cfg"' "$ENABLED" \
-  || fail "enabled render must mount the operator config Secret (my-litellm-cfg)."
-grep -q 'mountPath: /etc/litellm' "$ENABLED" \
-  || fail "enabled render must mount the config at /etc/litellm."
-grep -q 'value: http://localhost:4000' "$ENABLED" \
-  || fail "enabled render must repoint ANTHROPIC_BASE_URL at http://localhost:4000."
-echo "  ok: sidecar container, config Secret mount, and localhost base-url all present"
-
-echo "=== Assertion 3: local inference wins over the sidecar base-url override ==="
-INFER="$TMP/infer.yaml"
-render \
+  --set agentSandbox.deploy=false
+expect_refused inference-enabled \
   --set agentSandbox.runner.liteLLM.enabled=true \
-  --set agentSandbox.runner.liteLLM.configExistingSecret=my-litellm-cfg \
-  --set inference.deploy=true > "$INFER"
-if grep -q 'value: http://localhost:' "$INFER"; then
-  fail "with inference.deploy=true the sidecar localhost ANTHROPIC_BASE_URL must NOT render (inference path wins)."
-fi
-echo "  ok: inference.deploy=true suppresses the localhost base-url override"
+  --set inference.deploy=true
+expect_refused both-bypasses \
+  --set agentSandbox.runner.liteLLM.enabled=true \
+  --set agentSandbox.deploy=false \
+  --set inference.deploy=true
+expect_refused string-enabled \
+  --set-string agentSandbox.runner.liteLLM.enabled=true
 
 echo
-echo "PASS: LiteLLM sidecar is off by default, renders fully when enabled, and yields to local inference."
+echo "PASS: LiteLLM remains absent by default and all truthy enablement is fail-closed."

--- a/charts/curie/ci/litellm-sidecar-assertions.sh
+++ b/charts/curie/ci/litellm-sidecar-assertions.sh
@@ -2,9 +2,9 @@
 #
 # Render-assertion test for the retired LiteLLM sandbox sidecar. Proves:
 #
-#   1. DEFAULT and explicit false renders preserve the supported sandbox path:
-#      no LiteLLM container, image, config volume, Secret surface, localhost
-#      ANTHROPIC_BASE_URL override, or mutable main-stable image reference.
+#   1. The DEFAULT full-chart render contains no LiteLLM surface in any
+#      manifest (container, image, volume, or Secret). SandboxTemplate-only
+#      checks also keep its ANTHROPIC_BASE_URL and image references safe.
 #   2. Every truthy enablement path is refused by Helm with the same actionable
 #      ADR-0037 recovery message, before deployment or inference toggles can
 #      bypass the guard.
@@ -23,28 +23,39 @@ REFUSAL='agentSandbox.runner.liteLLM.enabled is unsupported by ADR-0037: in-path
 
 fail() { echo "FAIL: $*" >&2; exit 1; }
 
-render() {
+render_sandbox_template() {
   # $@ = extra --set flags. agentSandbox.deploy is on by default in values.yaml.
   helm template rel "$CHART" --show-only "$TPL" "$@"
 }
 
-expect_safe_render() {
+expect_default_full_chart_without_litellm() {
+  local output="$TMP/default-full-chart.yaml"
+
+  helm template rel "$CHART" > "$output"
+
+  if grep -qi 'litellm' "$output"; then
+    fail "default full-chart render must NOT contain a LiteLLM container, image, config volume, or Secret surface."
+  fi
+  echo "  ok: default full-chart render has no retired LiteLLM surface"
+}
+
+expect_safe_sandbox_template_render() {
   local name="$1"
   shift
   local output="$TMP/$name.yaml"
 
-  render "$@" > "$output"
+  render_sandbox_template "$@" > "$output"
 
   if grep -qi 'litellm' "$output"; then
-    fail "$name render must NOT contain a LiteLLM container, image, config volume, or Secret surface."
+    fail "$name SandboxTemplate render must NOT contain a LiteLLM surface."
   fi
   if grep -q 'localhost:' "$output"; then
-    fail "$name render must NOT repoint ANTHROPIC_BASE_URL at localhost."
+    fail "$name SandboxTemplate render must NOT repoint ANTHROPIC_BASE_URL at localhost."
   fi
   if grep -q 'main-stable' "$output"; then
-    fail "$name render must NOT contain a mutable main-stable image reference."
+    fail "$name SandboxTemplate render must NOT contain a mutable main-stable image reference."
   fi
-  echo "  ok: $name render has no retired LiteLLM or localhost surface"
+  echo "  ok: $name SandboxTemplate render has no retired LiteLLM or localhost surface"
 }
 
 expect_refused() {
@@ -53,7 +64,7 @@ expect_refused() {
   local stdout="$TMP/$name.stdout"
   local stderr="$TMP/$name.stderr"
 
-  if render "$@" > "$stdout" 2> "$stderr"; then
+  if render_sandbox_template "$@" > "$stdout" 2> "$stderr"; then
     fail "$name must be refused when agentSandbox.runner.liteLLM.enabled is truthy."
   fi
   if ! grep -Fq -- "$REFUSAL" "$stdout" "$stderr"; then
@@ -63,9 +74,12 @@ expect_refused() {
 }
 
 echo "=== Assertion 1: supported renders omit the retired LiteLLM surface ==="
-expect_safe_render default
-expect_safe_render explicit-false \
+expect_default_full_chart_without_litellm
+expect_safe_sandbox_template_render default
+expect_safe_sandbox_template_render explicit-false \
   --set agentSandbox.runner.liteLLM.enabled=false
+expect_safe_sandbox_template_render explicit-null \
+  --set agentSandbox.runner.liteLLM=null
 
 echo "=== Assertion 2: every truthy LiteLLM enablement is refused ==="
 expect_refused enabled \

--- a/charts/curie/ci/sandbox-hardening-assertions.sh
+++ b/charts/curie/ci/sandbox-hardening-assertions.sh
@@ -2,12 +2,11 @@
 #
 # Render-assertion test for issue #493 (Rail 3 container hardening). The
 # container-level securityContext lockdown is applied to EVERY container in the
-# untrusted sandbox pod -- the runner, both bundle init containers, and the
-# litellm sidecar when enabled -- and was previously copy-pasted four times. It
-# now renders from one `curie.sandboxHardening.securityContext` helper; this
-# test pins that the rendered lockdown is present and identical on every
-# container, so a helper edit that weakens (or a container that skips) the
-# lockdown fails CI.
+# untrusted sandbox pod -- the runner, both bundle init containers, and
+# workspace-init -- and was previously copy-pasted four times. It now renders
+# from one `curie.sandboxHardening.securityContext` helper; this test pins that
+# the rendered lockdown is present and identical on every container, so a
+# helper edit that weakens (or a container that skips) the lockdown fails CI.
 #
 # Runnable locally (from anywhere) and from CI. Fails loudly.
 set -euo pipefail
@@ -23,15 +22,9 @@ TPL=templates/agent-sandbox.yaml
 fail() { echo "FAIL: $*" >&2; exit 1; }
 
 DEFAULT="$TMP/default.yaml"
-LITELLM="$TMP/litellm.yaml"
 
 echo "=== Rendering SandboxTemplate (defaults; hardening on) ==="
 helm template rel "$CHART" --show-only "$TPL" > "$DEFAULT"
-
-echo "=== Rendering SandboxTemplate (litellm sidecar enabled) ==="
-helm template rel "$CHART" --show-only "$TPL" \
-  --set agentSandbox.runner.liteLLM.enabled=true \
-  --set agentSandbox.runner.liteLLM.configExistingSecret=my-litellm-cfg > "$LITELLM"
 
 ASSERT_PY="$TMP/assert.py"
 cat > "$ASSERT_PY" <<'PY'
@@ -71,14 +64,13 @@ def check(path, expected_names):
     print(f"  ok: {sorted(names)} all carry the identical hardened securityContext")
 
 
-check(sys.argv[1], {"bundle-fetch", "bundle-extract", "runner"})
-check(sys.argv[2], {"bundle-fetch", "bundle-extract", "runner", "litellm"})
+check(sys.argv[1], {"bundle-fetch", "bundle-extract", "runner", "workspace-init"})
 PY
 
-if ! out="$(python3 "$ASSERT_PY" "$DEFAULT" "$LITELLM" 2>&1)"; then
+if ! out="$(python3 "$ASSERT_PY" "$DEFAULT" 2>&1)"; then
   fail "$out"
 fi
 echo "$out"
 
 echo
-echo "PASS: every sandbox container (runner, bundle-fetch, bundle-extract, and the litellm sidecar when enabled) renders the identical Rail 3 hardened securityContext from the shared helper."
+echo "PASS: every sandbox container (runner, bundle-fetch, bundle-extract, and workspace-init) renders the identical Rail 3 hardened securityContext from the shared helper."

--- a/charts/curie/templates/_helpers.tpl
+++ b/charts/curie/templates/_helpers.tpl
@@ -1105,7 +1105,8 @@ true
 
 {{/* ---- Sandbox container hardening (Rail 3) ----
      The identical container-level lockdown applied to the runner and every
-     helper container in the sandbox pod (bundle-fetch, bundle-extract, litellm).
+     helper container in the sandbox pod (bundle-fetch, bundle-extract,
+     workspace-init).
      Extracted so the four copies cannot drift (#493); callers keep their own
      `{{- if $runner.hardening.enabled }}` guard and apply `nindent 10`. This is
      the container securityContext only -- the pod-level securityContext

--- a/charts/curie/templates/agent-sandbox.yaml
+++ b/charts/curie/templates/agent-sandbox.yaml
@@ -26,6 +26,9 @@ the worker claims from, plus (optionally) the vendored upstream controller.
   behavior would otherwise silently widen (not be narrowed by) Rail 1's
   default-deny + allowlist in security-networkpolicy.yaml.
 */}}
+{{- if .Values.agentSandbox.runner.liteLLM.enabled }}
+{{- fail "agentSandbox.runner.liteLLM.enabled is unsupported by ADR-0037: in-path LiteLLM gateways are unsupported; remove or disable agentSandbox.runner.liteLLM.enabled and use direct session-pinned provider routing." }}
+{{- end }}
 {{- if .Values.agentSandbox.controller.deploy }}
 {{/*
 ADR-0059 decision 5 / issue #816: the vendored controller carries no
@@ -243,21 +246,8 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       {{- end }}
-      {{- if or $bf.enabled $wf.enabled $runner.hardening.enabled $runner.liteLLM.enabled }}
+      {{- if or $bf.enabled $wf.enabled $runner.hardening.enabled }}
       volumes:
-        {{- if $runner.liteLLM.enabled }}
-        # LiteLLM proxy config (model_list + router/fallback), mounted read-only
-        # into the sidecar. Sourced from the operator-provided Secret so provider
-        # keys referenced by the config are never inlined into a manifest.
-        - name: litellm-config
-          secret:
-            secretName: {{ $runner.liteLLM.configExistingSecret | quote }}
-            # Map the config key onto the fixed filename the sidecar reads,
-            # regardless of how the operator named it in the Secret.
-            items:
-              - key: {{ $runner.liteLLM.configKey | quote }}
-                path: config.yaml
-        {{- end }}
         {{- if $bf.enabled }}
         # Shared bundle volume: the init pair populates <mountPath>/current, the
         # runner reads it as CURIE_PLUGIN_DIR. sizeLimit is ADR-0059 decision
@@ -530,39 +520,6 @@ spec:
         {{- end }}
       {{- end }}
       containers:
-        {{- if $runner.liteLLM.enabled }}
-        # BYO model (#24): LiteLLM Anthropic-format proxy sidecar. Off by default;
-        # enabled only for genuine multi-model routing/fallback. Serves the
-        # Anthropic API shape on localhost:<port>, which the runner targets via
-        # ANTHROPIC_BASE_URL above. Config (model_list, router/fallback) comes from
-        # the operator-provided Secret; provider keys come from liteLLM.extraEnv.
-        - name: litellm
-          image: {{ $runner.liteLLM.image | quote }}
-          imagePullPolicy: {{ $runner.liteLLM.imagePullPolicy }}
-          {{- if $runner.hardening.enabled }}
-          # Same container-level lockdown as the runner: the proxy only reads its
-          # mounted config and talks upstream, so a read-only rootfs is safe.
-          {{- include "curie.sandboxHardening.securityContext" . | nindent 10 }}
-          {{- end }}
-          args:
-            - --config
-            - /etc/litellm/config.yaml
-            - --port
-            - {{ $runner.liteLLM.port | quote }}
-          ports:
-            - name: litellm
-              containerPort: {{ $runner.liteLLM.port }}
-          {{- with $runner.liteLLM.extraEnv }}
-          env:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          volumeMounts:
-            - name: litellm-config
-              mountPath: /etc/litellm
-              readOnly: true
-          resources:
-            {{- toYaml $runner.liteLLM.resources | nindent 12 }}
-        {{- end }}
         - name: runner
           image: {{ include "curie.image" (dict "repository" $runner.image "tag" $runner.tag "digest" $runner.digest "defaultTag" .Chart.AppVersion) | quote }}
           imagePullPolicy: {{ $runner.imagePullPolicy }}
@@ -607,13 +564,6 @@ spec:
             # non-zero.
             - name: CURIE_MODEL
               value: {{ $runner.model | quote }}
-            {{- end }}
-            {{- if and $runner.liteLLM.enabled (not .Values.inference.deploy) }}
-            # BYO model (#24): route through the in-pod LiteLLM sidecar, which
-            # serves the Anthropic API shape on localhost. Multi-model routing /
-            # fallback lives in the sidecar's config; the runner just points at it.
-            - name: ANTHROPIC_BASE_URL
-              value: http://localhost:{{ $runner.liteLLM.port }}
             {{- end }}
             {{- if or $runner.credentials $runner.credentialsExistingSecret }}
             # Warm-pod fallback credential; the worker's per-claim Overrides

--- a/charts/curie/templates/agent-sandbox.yaml
+++ b/charts/curie/templates/agent-sandbox.yaml
@@ -26,7 +26,7 @@ the worker claims from, plus (optionally) the vendored upstream controller.
   behavior would otherwise silently widen (not be narrowed by) Rail 1's
   default-deny + allowlist in security-networkpolicy.yaml.
 */}}
-{{- if .Values.agentSandbox.runner.liteLLM.enabled }}
+{{- if (dig "liteLLM" "enabled" false .Values.agentSandbox.runner) }}
 {{- fail "agentSandbox.runner.liteLLM.enabled is unsupported by ADR-0037: in-path LiteLLM gateways are unsupported; remove or disable agentSandbox.runner.liteLLM.enabled and use direct session-pinned provider routing." }}
 {{- end }}
 {{- if .Values.agentSandbox.controller.deploy }}

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -1742,8 +1742,10 @@ agentSandbox:
     # Per-workload OTEL_EXPORTER_OTLP_* overrides still win over the
     # chart-owned collector endpoint.
     extraEnv: []
-    # Compatibility tombstone: true is rejected by ADR-0037; direct provider
-    # routing is session-pinned at claim time.
+    # Compatibility tombstone: only unquoted boolean false is supported; true
+    # and any non-empty non-boolean value (including quoted "false") are
+    # rejected by ADR-0037. Direct provider routing is session-pinned at claim
+    # time.
     liteLLM:
       enabled: false
     # --- Bundle-fetch provisioning ---

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -1742,10 +1742,9 @@ agentSandbox:
     # Per-workload OTEL_EXPORTER_OTLP_* overrides still win over the
     # chart-owned collector endpoint.
     extraEnv: []
-    # Compatibility tombstone: only unquoted boolean false is supported; true
-    # and any non-empty non-boolean value (including quoted "false") are
-    # rejected by ADR-0037. Direct provider routing is session-pinned at claim
-    # time.
+    # Compatibility tombstone: ADR-0037 refuses any truthy `enabled` value.
+    # Disabled forms may be absent, null, or boolean false. Direct provider
+    # routing remains session-pinned at claim time.
     liteLLM:
       enabled: false
     # --- Bundle-fetch provisioning ---

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -1742,45 +1742,10 @@ agentSandbox:
     # Per-workload OTEL_EXPORTER_OTLP_* overrides still win over the
     # chart-owned collector endpoint.
     extraEnv: []
-    # --- BYO model: LiteLLM Anthropic-format sidecar (part of #24) ---
-    # Off by default. Enable ONLY for genuine multi-model routing/fallback: a
-    # LiteLLM proxy runs as a sidecar in the sandbox pod, serving the Anthropic
-    # API shape on localhost, and the runner's ANTHROPIC_BASE_URL is repointed at
-    # it (http://localhost:<port>). For a single model per agent prefer the
-    # OpenRouter / provider-native path (leave this off and set runner.model +
-    # runner.credentials, or a per-agent credential) -- a sidecar per sandbox pod
-    # is pure overhead when no routing is needed. Ignored while local
-    # inference.deploy is on (that path already binds ANTHROPIC_BASE_URL to the
-    # in-cluster Ollama endpoint).
+    # Compatibility tombstone: true is rejected by ADR-0037; direct provider
+    # routing is session-pinned at claim time.
     liteLLM:
       enabled: false
-      image: ghcr.io/berriai/litellm:main-stable
-      imagePullPolicy: IfNotPresent
-      # Port the proxy listens on inside the pod; the runner reaches it over
-      # localhost, so it is never exposed as a Service.
-      port: 4000
-      # Name of a pre-created Secret (or ConfigMap-shaped Secret) holding the
-      # LiteLLM config.yaml -- the model_list and router/fallback settings. It is
-      # mounted read-only at /etc/litellm/config.yaml and passed to the proxy via
-      # --config. REQUIRED when enabled; provider API keys the config references
-      # are supplied through extraEnv (secretKeyRef), never inlined here.
-      configExistingSecret: ""
-      # Key within that Secret that carries the config file body.
-      configKey: config.yaml
-      # Extra env for the sidecar, list of {name, value} (or full env entries with
-      # valueFrom.secretKeyRef for provider credentials, e.g. OPENAI_API_KEY).
-      extraEnv: []
-      # ephemeral-storage alongside cpu/memory (ADR-0059 decision 1): the sidecar
-      # only reads its mounted config and proxies to an upstream model API, with
-      # no bundle/writable-path volume of its own, so its own disk footprint is
-      # just its writable layer and logs -- a small, fixed ceiling is enough.
-      # Both request (the scheduling-time floor that keeps the node from being
-      # overcommitted) and limit (the periodic-measurement backstop) are
-      # required and do different jobs (decision 2); override either for a
-      # heavier sidecar image.
-      resources:
-        requests: { cpu: 50m, memory: 128Mi, ephemeral-storage: 64Mi }
-        limits: { cpu: "1", memory: 512Mi, ephemeral-storage: 256Mi }
     # --- Bundle-fetch provisioning ---
     # CURIE_BUNDLE_REF is an S3 object key the substrate injects per claim.
     # (bound sandboxes carry it; warm/unbound pods do not). Before the runner


### PR DESCRIPTION
## Summary

Fail closed on the retired LiteLLM sidecar scaffold. The default Curie chart still renders a direct-provider, session-pinned runner with no LiteLLM container, image, volume, base URL, or credential surface. Any truthy `agentSandbox.runner.liteLLM.enabled` value now stops Helm rendering with an actionable ADR-0037 message. This is a safety refusal, not evidence that an in-path gateway passed.

No Accepted ADR, ACI contract, plugin-format contract, runner authentication, worker routing, credentials, staging, or production code changed.

## Related issue

None. This is the scoped Bonus Drain safety task `curie-litellm-gateway-implementation`.

## Fix pin verification

Fix pin: charts/curie/ci/litellm-sidecar-assertions.sh

`curie dev verify-fix-pin 2113 charts/curie/ci/litellm-sidecar-assertions.sh` reported `PINNED`. The pull request head passed. Reversing the product change to restore the scaffold failed the focused assertion at the old template's null dereference, proving the test is sensitive to restoration or loss of the refusal.

## End-to-end verification

Candidate commit: `4cd44bc5f8307a0e37dec41851cf2f763144438e`.

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | No plugin packaging, skill evaluation, runner turn loop, or ACI event changed. | n/a | Not run. |
| local | n/a | No compose service, dispatcher, worker, API, console, or CLI behavior changed. | n/a | Not run. |
| local-release | n/a | No released binary, image identity, install path, version pin, or release compose changed. | n/a | Not run. |
| cluster | required | The change modifies Helm values and the SandboxTemplate. | fake | `curie dev chart-runtime-e2e --force` passed: the chart installed, both bundle init containers completed, the bound sandbox runner reached Running, runtime security assertions passed, and the harness reported `PASS: API Service NodePort and runtime security assertions`. The known harness defect documented by the LiteLLM spike required a disposable one-line repair to include its generated OTel values overlay; that repair was removed after the run and is absent from this diff. |
| live provider | n/a | Direct-provider routing and provider credentials are unchanged; this change removes and refuses the unsupported gateway path. | n/a | Not run. |
| external integration | n/a | No Slack, git webhook, OAuth connector, or third-party API surface changed. | n/a | Not run. |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.
- [ ] Or: this change is not behavior-bearing, so no tier applies, and the summary says why.

### Positive and negative evidence

- `bash charts/curie/ci/litellm-sidecar-assertions.sh` passed for the default full chart plus default, false, and null SandboxTemplate values. It found no LiteLLM surface, `localhost:` base URL, or `main-stable` image reference.
- The same assertion refused boolean true, string true, deploy-disabled, inference-enabled, and combined bypass attempts with the exact ADR-0037 recovery message.
- A real `helm install litellm-refusal charts/curie --namespace default --set agentSandbox.runner.liteLLM.enabled=true` exited 1 with the ADR-0037 message. Follow-up checks observed `release_absent=true` and `release_secret_absent=true`, proving refusal before cluster mutation.
- The fix-pin reversal failed the focused assertion, proving restoration of the scaffold or removal of the refusal is detected.

### Static verification

- `helm lint charts/curie`
- `helm lint charts/curie -f charts/curie/values-dev.yaml`
- `helm lint charts/curie -f charts/curie/values-dev.yaml -f charts/curie/values-e2e-nogvisor.yaml`
- `bash charts/curie/ci/litellm-sidecar-assertions.sh`
- `bash charts/curie/ci/sandbox-hardening-assertions.sh`
- `bash charts/curie/ci/ephemeral-storage-assertions.sh`
- `bash scripts/check-docs.sh`
- `bash scripts/check-commit-messages.sh --self-test`
- `bash scripts/check-commit-messages.sh origin/main..HEAD`
- `git diff --check`

All passed on the candidate commit.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [x] No new ADR is required; this change enforces Accepted ADR-0037 without editing it.
