### PR TITLE
Preserve legacy state through multibinding migration

### DIFF
--- a/apps/api/alembic/versions/0037_multibinding_state_identity.py
+++ b/apps/api/alembic/versions/0037_multibinding_state_identity.py
@@ -1,0 +1,204 @@
+"""Preserve legacy shared state and make its NULL identity singular (#1901).
+
+Revision 0031 added ``binding_scope`` and defaulted every agent to
+``memory=false``.  Rows written before that revision correctly retained NULL --
+they were agent-wide -- but their owners then routed general-state requests to
+a binding-specific scope and could no longer see those rows.  This repair turns
+only unambiguous owners of legacy general state back to the shared posture.
+
+PostgreSQL's ordinary unique constraints treat every NULL as distinct, so the
+four-column state identity added by 0031 also allowed concurrent creators to
+insert more than one shared row.  Recreating that same named constraint with
+``NULLS NOT DISTINCT`` makes NULL the single shared binding identity while
+leaving distinct non-NULL binding scopes isolated.
+
+Revision ID: 0037
+Revises: 0036
+Create Date: 2026-08-30
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0037"
+down_revision: str | None = "0036"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+SCHEMA = "curie"
+AGENTS_TABLE = "agents"
+STATE_TABLE = "workflow_state_entries"
+STATE_CONSTRAINT = "uq_state_agent_scope_ns_key"
+
+# Keep these literals pinned to ``routers.state.RESERVED_NAMESPACES`` and
+# ``curie_runner.state.RESERVED_NAMESPACES``.  Memory and transcript are always
+# agent-wide; their NULL rows are not evidence that general state was legacy
+# shared state.
+MEMORY_NAMESPACE = "memory"
+TRANSCRIPT_NAMESPACE = "transcript"
+_RESERVED_PARAMS = {
+    "memory_namespace": MEMORY_NAMESPACE,
+    "transcript_namespace": TRANSCRIPT_NAMESPACE,
+}
+
+
+def _lock_tables() -> None:
+    """Freeze every inspected/written row in one deadlock-safe order."""
+
+    conn = op.get_bind()
+    # Agents must be first: deleting one cascades into workflow state, so taking
+    # the locks in the opposite order could deadlock with that delete.  SHARE ROW
+    # EXCLUSIVE blocks concurrent INSERT/UPDATE/DELETE while preserving reads,
+    # and PostgreSQL holds both locks through Alembic's transaction boundary.
+    conn.execute(sa.text(f"LOCK TABLE {SCHEMA}.{AGENTS_TABLE} IN SHARE ROW EXCLUSIVE MODE"))
+    conn.execute(sa.text(f"LOCK TABLE {SCHEMA}.{STATE_TABLE} IN SHARE ROW EXCLUSIVE MODE"))
+
+
+def _duplicate_null_identities() -> list[sa.Row[tuple[Any, ...]]]:
+    """Return every identity that the stricter constraint cannot represent."""
+
+    return list(
+        op.get_bind()
+        .execute(
+            sa.text(
+                f"""
+                SELECT agent_id, namespace, key, count(*) AS row_count
+                FROM {SCHEMA}.{STATE_TABLE}
+                WHERE binding_scope IS NULL
+                GROUP BY agent_id, namespace, key
+                HAVING count(*) > 1
+                ORDER BY agent_id, namespace, key
+                """
+            )
+        )
+        .all()
+    )
+
+
+def _mixed_scope_flip_candidates() -> list[sa.Row[tuple[Any, ...]]]:
+    """Return false agents whose general-state posture is ambiguous."""
+
+    return list(
+        op.get_bind()
+        .execute(
+            sa.text(
+                f"""
+                SELECT agents.id AS agent_id,
+                       count(*) FILTER (
+                           WHERE state.binding_scope IS NULL
+                       ) AS shared_rows,
+                       count(*) FILTER (
+                           WHERE state.binding_scope IS NOT NULL
+                       ) AS isolated_rows
+                FROM {SCHEMA}.{AGENTS_TABLE} AS agents
+                JOIN {SCHEMA}.{STATE_TABLE} AS state
+                  ON state.agent_id = agents.id
+                WHERE agents.memory = false
+                  AND state.namespace NOT IN (
+                      :memory_namespace, :transcript_namespace
+                  )
+                GROUP BY agents.id
+                HAVING bool_or(state.binding_scope IS NULL)
+                   AND bool_or(state.binding_scope IS NOT NULL)
+                ORDER BY agents.id
+                """
+            ),
+            _RESERVED_PARAMS,
+        )
+        .all()
+    )
+
+
+def _refuse_ambiguous_state(
+    duplicates: list[sa.Row[tuple[Any, ...]]],
+    mixed_scope: list[sa.Row[tuple[Any, ...]]],
+) -> None:
+    if not duplicates and not mixed_scope:
+        return
+
+    findings: list[str] = []
+    if duplicates:
+        detail = "; ".join(
+            f"{row.agent_id} {row.namespace}/{row.key} ({row.row_count} NULL rows)"
+            for row in duplicates
+        )
+        findings.append(f"duplicate NULL identities: {detail}")
+    if mixed_scope:
+        detail = "; ".join(
+            f"{row.agent_id} ({row.shared_rows} shared, {row.isolated_rows} isolated general rows)"
+            for row in mixed_scope
+        )
+        findings.append(f"memory=false agents with mixed shared/isolated state: {detail}")
+
+    raise RuntimeError(
+        "cannot repair shared workflow-state identity (#1901); no agent, state "
+        "row, or constraint was changed -- "
+        + " | ".join(findings)
+        + ". For each duplicate NULL identity, inspect its values and versions "
+        "and explicitly merge or delete rows until one remains. For each "
+        "memory=false mixed-scope agent, choose the intended shared or isolated "
+        "policy and move/merge every general row into that one shape. Re-run "
+        "this migration only after resolving every named finding."
+    )
+
+
+def upgrade() -> None:
+    _lock_tables()
+
+    # Complete both preflights before refusing so one failed attempt gives the
+    # operator the whole deterministic remediation set.  They precede every
+    # write and DDL operation; Alembic's transaction releases the locks and
+    # leaves both data and revision stamp unchanged on refusal.
+    duplicates = _duplicate_null_identities()
+    mixed_scope = _mixed_scope_flip_candidates()
+    _refuse_ambiguous_state(duplicates, mixed_scope)
+
+    # A NULL row in memory/transcript is permanently shared and must not change
+    # an agent's general-state policy.  Only a false owner of NULL non-reserved
+    # state has the unambiguous pre-0031 shape this migration repairs.
+    op.get_bind().execute(
+        sa.text(
+            f"""
+            UPDATE {SCHEMA}.{AGENTS_TABLE} AS agents
+            SET memory = true
+            WHERE agents.memory = false
+              AND EXISTS (
+                  SELECT 1
+                  FROM {SCHEMA}.{STATE_TABLE} AS state
+                  WHERE state.agent_id = agents.id
+                    AND state.binding_scope IS NULL
+                    AND state.namespace NOT IN (
+                        :memory_namespace, :transcript_namespace
+                    )
+              )
+            """
+        ),
+        _RESERVED_PARAMS,
+    )
+
+    op.drop_constraint(STATE_CONSTRAINT, STATE_TABLE, type_="unique", schema=SCHEMA)
+    op.create_unique_constraint(
+        STATE_CONSTRAINT,
+        STATE_TABLE,
+        ["agent_id", "binding_scope", "namespace", "key"],
+        schema=SCHEMA,
+        postgresql_nulls_not_distinct=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(STATE_CONSTRAINT, STATE_TABLE, type_="unique", schema=SCHEMA)
+    op.create_unique_constraint(
+        STATE_CONSTRAINT,
+        STATE_TABLE,
+        ["agent_id", "binding_scope", "namespace", "key"],
+        schema=SCHEMA,
+    )
+    # Do not revert repaired memory flags.  This revision did not record their
+    # provenance, so an operator-enabled shared agent is indistinguishable from
+    # one repaired above; setting either false would knowingly hide shared rows.

--- a/apps/api/alembic/versions/0037_multibinding_state_identity.py
+++ b/apps/api/alembic/versions/0037_multibinding_state_identity.py
@@ -3,8 +3,13 @@
 Revision 0031 added ``binding_scope`` and defaulted every agent to
 ``memory=false``.  Rows written before that revision correctly retained NULL --
 they were agent-wide -- but their owners then routed general-state requests to
-a binding-specific scope and could no longer see those rows.  This repair turns
-only unambiguous owners of legacy general state back to the shared posture.
+a binding-specific scope and could no longer see those rows.  PostgreSQL stores
+no provenance that distinguishes those legacy NULL rows from a later,
+operator- or platform-key-written unscoped row.  For a ``memory=false`` owner
+whose non-reserved general state is NULL-only, the lossless default is therefore
+to preserve it as shared state and set ``memory=true``.  Owners with both NULL
+and non-NULL general state still refuse migration: their competing shared and
+isolated postures require an explicit operator decision.
 
 PostgreSQL's ordinary unique constraints treat every NULL as distinct, so the
 four-column state identity added by 0031 also allowed concurrent creators to
@@ -159,8 +164,11 @@ def upgrade() -> None:
     _refuse_ambiguous_state(duplicates, mixed_scope)
 
     # A NULL row in memory/transcript is permanently shared and must not change
-    # an agent's general-state policy.  Only a false owner of NULL non-reserved
-    # state has the unambiguous pre-0031 shape this migration repairs.
+    # an agent's general-state policy.  PostgreSQL cannot tell pre-0031 legacy
+    # NULL general state from a later operator/platform-key unscoped write, so
+    # a false owner with NULL-only non-reserved state takes the lossless shared
+    # preservation default.  Mixed scoped+NULL candidates refused above still
+    # need an explicit policy choice.
     op.get_bind().execute(
         sa.text(
             f"""

--- a/apps/api/src/curie_api/models.py
+++ b/apps/api/src/curie_api/models.py
@@ -704,7 +704,12 @@ class WorkflowStateEntry(Base):
     __tablename__ = "workflow_state_entries"
     __table_args__ = (
         UniqueConstraint(
-            "agent_id", "binding_scope", "namespace", "key", name="uq_state_agent_scope_ns_key"
+            "agent_id",
+            "binding_scope",
+            "namespace",
+            "key",
+            name="uq_state_agent_scope_ns_key",
+            postgresql_nulls_not_distinct=True,
         ),
     )
 
@@ -712,13 +717,14 @@ class WorkflowStateEntry(Base):
     agent_id: Mapped[uuid.UUID] = mapped_column(
         ForeignKey(f"{SCHEMA}.agents.id", ondelete="CASCADE")
     )
-    # NULL when the owning agent has `memory=True` (one shared namespace); the
-    # binding's own `"{kind}:{address}"` when `memory=False` (#1525 follow-up).
-    # Minted into the worker's `state.app`/`state` token per turn from the
-    # agent's CURRENT `memory` value, never read back off this column -- the
-    # column only picks which row a request lands on. Part of the unique key
-    # (not just an extra filter) so a memory=False agent's two bindings get
-    # two independent rows for the same namespace+key instead of colliding.
+    # NULL is one agent-wide shared identity: for general state when the owning
+    # agent has `memory=True`, and always for the reserved `memory`/`transcript`
+    # namespaces. The binding's own `"{kind}:{address}"` is the isolated identity
+    # for general state when `memory=False` (#1525 follow-up). Minted into the
+    # worker's `state.app`/`state` token per turn from the agent's CURRENT
+    # `memory` value, never read back off this column -- the column only picks
+    # which row a request lands on. The NULLS-NOT-DISTINCT unique key makes the
+    # shared identity singular while distinct non-NULL scopes remain isolated.
     binding_scope: Mapped[str | None] = mapped_column(default=None)
     namespace: Mapped[str]
     key: Mapped[str]

--- a/apps/api/tests/test_migration_0037_multibinding_state_identity.py
+++ b/apps/api/tests/test_migration_0037_multibinding_state_identity.py
@@ -278,6 +278,86 @@ def test_legacy_state_runner_url_and_value_survive_upgrade(
     assert visible.json()["value"] == legacy_value
 
 
+def test_legacy_unscoped_general_state_deliberately_flips_when_provenance_is_ambiguous(
+    isolated_migration_db: None,
+) -> None:
+    cfg = _alembic_config()
+    command.upgrade(cfg, BELOW)
+    agent_id = _seed_agent("ambiguous-provenance-owner", memory=False)
+    original_value = {"policy": "operator-or-legacy", "sequence": [3, 1, 4]}
+    _seed_state(
+        agent_id,
+        "workflow",
+        "ambiguous-key",
+        original_value,
+        binding_scope=None,
+    )
+    before = _state_rows(agent_id)
+
+    command.upgrade(cfg, REVISION)
+
+    assert _memory_by_name() == {"ambiguous-provenance-owner": True}
+    assert _state_rows(agent_id) == before
+    visible = _api_get(
+        f"http://migration-api.test/agents/{agent_id}/state/workflow/ambiguous-key"
+    )
+    assert visible.status_code == 200, visible.text
+    assert visible.json()["value"] == original_value
+
+
+def test_downgrade_keeps_repaired_memory_and_restores_null_distinct_identity(
+    isolated_migration_db: None,
+) -> None:
+    cfg = _alembic_config()
+    command.upgrade(cfg, "0030")
+    agent_id = _seed_agent("downgrade-repaired-owner")
+    original_value = {"survives": "forward-and-back"}
+    _seed_state(
+        agent_id,
+        "workflow",
+        "durable-key",
+        original_value,
+    )
+    command.upgrade(cfg, BELOW)
+    assert _memory_by_name() == {"downgrade-repaired-owner": False}
+    before = _state_rows(agent_id)
+
+    command.upgrade(cfg, REVISION)
+    assert _memory_by_name() == {"downgrade-repaired-owner": True}
+
+    command.downgrade(cfg, BELOW)
+
+    assert _stamped_revision() == BELOW
+    assert _memory_by_name() == {"downgrade-repaired-owner": True}
+    assert _state_rows(agent_id) == before
+    assert _sql(
+        """
+        SELECT backing_index.indnullsnotdistinct
+        FROM pg_constraint AS catalog_constraint
+        JOIN pg_class AS relation ON relation.oid = catalog_constraint.conrelid
+        JOIN pg_index AS backing_index
+          ON backing_index.indexrelid = catalog_constraint.conindid
+        JOIN pg_namespace AS namespace ON namespace.oid = relation.relnamespace
+        WHERE namespace.nspname = 'curie'
+          AND relation.relname = 'workflow_state_entries'
+          AND catalog_constraint.conname = 'uq_state_agent_scope_ns_key'
+        """
+    ) == [(False,)]
+    _seed_state(
+        agent_id,
+        "workflow",
+        "durable-key",
+        {"second-null-row": True},
+        binding_scope=None,
+    )
+    assert _sql(
+        "SELECT count(*) FROM curie.workflow_state_entries "
+        "WHERE agent_id = :agent_id AND binding_scope IS NULL "
+        "AND namespace = 'workflow' AND key = 'durable-key'",
+        {"agent_id": agent_id},
+    ) == [(2,)]
+
+
 def test_reserved_only_legacy_state_does_not_flip_memory(
     isolated_migration_db: None,
 ) -> None:

--- a/apps/api/tests/test_migration_0037_multibinding_state_identity.py
+++ b/apps/api/tests/test_migration_0037_multibinding_state_identity.py
@@ -1,0 +1,501 @@
+"""Migration 0037 preserves legacy shared state and makes its identity singular.
+
+These tests intentionally exercise the migration against a disposable real
+Postgres database.  The migration has two jobs that cannot be proved by model
+fixtures: restore the runner-visible posture of unambiguously shared pre-0031
+state, and ask Postgres to treat NULL as the one shared binding identity.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from curie_api.config import get_settings
+from curie_api.deps import get_session
+from curie_api.main import create_app
+from curie_api.models import WorkflowStateEntry
+from curie_worker.binding import BindingResolver
+from curie_worker.config import WorkerConfig
+from fastapi.testclient import TestClient
+from sqlalchemy import UniqueConstraint
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import NullPool
+from sqlalchemy.sql import text
+
+ALEMBIC_DIR = Path(__file__).resolve().parents[1] / "alembic"
+BELOW = "0036"
+REVISION = "0037"
+SCHEMA = "curie"
+STATE_URL_ENV = "CURIE_STATE_URL"
+KIND = "slack"
+ADDRESS = "C0EXAMPLE1"
+_UNSET = object()
+
+
+def _alembic_config() -> Config:
+    cfg = Config()
+    cfg.set_main_option("script_location", str(ALEMBIC_DIR))
+    return cfg
+
+
+def _sql(statement: str, params: dict[str, Any] | None = None) -> list[Any]:
+    async def go() -> list[Any]:
+        engine = create_async_engine(get_settings().database_url)
+        try:
+            async with engine.begin() as conn:
+                result = await conn.execute(text(statement), params or {})
+                return list(result.all()) if result.returns_rows else []
+        finally:
+            await engine.dispose()
+
+    return asyncio.run(go())
+
+
+def _stamped_revision() -> str:
+    rows = _sql("SELECT version_num FROM curie.alembic_version")
+    assert len(rows) == 1
+    revision: str = rows[0][0]
+    return revision
+
+
+def _seed_agent(name: str, *, memory: bool | None = None) -> uuid.UUID:
+    agent_id = uuid.uuid4()
+    if memory is None:
+        _sql(
+            "INSERT INTO curie.agents (id, name) VALUES (:id, :name)",
+            {"id": agent_id, "name": name},
+        )
+    else:
+        _sql(
+            "INSERT INTO curie.agents (id, name, memory) VALUES (:id, :name, :memory)",
+            {"id": agent_id, "name": name, "memory": memory},
+        )
+    return agent_id
+
+
+def _seed_binding(agent_id: uuid.UUID, *, address: str = ADDRESS) -> None:
+    _sql(
+        "INSERT INTO curie.agent_channels (id, agent_id, kind, address) "
+        "VALUES (:id, :agent_id, :kind, :address)",
+        {
+            "id": uuid.uuid4(),
+            "agent_id": agent_id,
+            "kind": KIND,
+            "address": address,
+        },
+    )
+
+
+def _seed_active_deployment(agent_id: uuid.UUID) -> None:
+    version_id = uuid.uuid4()
+    _sql(
+        "INSERT INTO curie.agent_versions "
+        "(id, agent_id, version_label, bundle_ref, created_by) "
+        "VALUES (:id, :agent_id, :label, :bundle_ref, :created_by)",
+        {
+            "id": version_id,
+            "agent_id": agent_id,
+            "label": "migration-fixture",
+            "bundle_ref": "bundles/migration-fixture.zip",
+            "created_by": "test",
+        },
+    )
+    _sql(
+        "INSERT INTO curie.deployments "
+        "(id, agent_id, version_id, environment, status) "
+        "VALUES (:id, :agent_id, :version_id, "
+        "CAST('prod' AS curie.environment), 'active')",
+        {
+            "id": uuid.uuid4(),
+            "agent_id": agent_id,
+            "version_id": version_id,
+        },
+    )
+
+
+def _seed_runnable_agent(
+    name: str, *, memory: bool | None = None, address: str = ADDRESS
+) -> uuid.UUID:
+    agent_id = _seed_agent(name, memory=memory)
+    _seed_binding(agent_id, address=address)
+    _seed_active_deployment(agent_id)
+    return agent_id
+
+
+def _seed_state(
+    agent_id: uuid.UUID,
+    namespace: str,
+    key: str,
+    value: Any,
+    *,
+    binding_scope: str | None | object = _UNSET,
+) -> uuid.UUID:
+    entry_id = uuid.uuid4()
+    params = {
+        "id": entry_id,
+        "agent_id": agent_id,
+        "namespace": namespace,
+        "key": key,
+        "value": json.dumps(value),
+    }
+    if binding_scope is _UNSET:
+        _sql(
+            "INSERT INTO curie.workflow_state_entries "
+            "(id, agent_id, namespace, key, value) "
+            "VALUES (:id, :agent_id, :namespace, :key, CAST(:value AS jsonb))",
+            params,
+        )
+    else:
+        params["binding_scope"] = binding_scope
+        _sql(
+            "INSERT INTO curie.workflow_state_entries "
+            "(id, agent_id, binding_scope, namespace, key, value) "
+            "VALUES (:id, :agent_id, :binding_scope, :namespace, :key, "
+            "CAST(:value AS jsonb))",
+            params,
+        )
+    return entry_id
+
+
+def _memory_by_name() -> dict[str, bool]:
+    return {row[0]: row[1] for row in _sql("SELECT name, memory FROM curie.agents")}
+
+
+def _state_rows(agent_id: uuid.UUID) -> list[tuple[Any, ...]]:
+    return [
+        tuple(row)
+        for row in _sql(
+            "SELECT id::text, binding_scope, namespace, key, value::text, version "
+            "FROM curie.workflow_state_entries WHERE agent_id = :agent_id "
+            "ORDER BY id",
+            {"agent_id": agent_id},
+        )
+    ]
+
+
+def _runner_state_url(*, kind: str, address: str) -> str:
+    async def go() -> str:
+        engine = create_async_engine(get_settings().database_url)
+        config = WorkerConfig(
+            database_url=get_settings().database_url,
+            db_schema=SCHEMA,
+            api_base_url="http://migration-api.test",
+        )
+        try:
+            resolver = BindingResolver(engine, config)
+            resolved = await resolver.resolve(kind, address)
+            assert resolved is not None
+            env = resolver.boot_env(
+                resolved,
+                "migration-thread",
+                kind=kind,
+                address=address,
+            )
+            return env[STATE_URL_ENV]
+        finally:
+            await engine.dispose()
+
+    return asyncio.run(go())
+
+
+def _api_get(url: str) -> Any:
+    """Call the real state router without starting unrelated app resources."""
+
+    engine = create_async_engine(get_settings().database_url, poolclass=NullPool)
+    sessions = async_sessionmaker(engine, expire_on_commit=False)
+
+    async def isolated_session() -> AsyncIterator[AsyncSession]:
+        async with sessions() as session:
+            yield session
+
+    app = create_app()
+    app.dependency_overrides[get_session] = isolated_session
+    client = TestClient(app)
+    try:
+        parsed = urlsplit(url)
+        return client.get(parsed.path, headers={"X-API-Key": get_settings().api_key})
+    finally:
+        client.close()
+        asyncio.run(engine.dispose())
+
+
+def test_legacy_state_runner_url_and_value_survive_upgrade(
+    isolated_migration_db: None,
+) -> None:
+    cfg = _alembic_config()
+    command.upgrade(cfg, "0030")
+    legacy_id = _seed_runnable_agent("legacy-state-owner")
+    _seed_agent("fresh-no-state-agent")
+    legacy_value = {"step": "approved", "attempts": [1, 2]}
+    _seed_state(legacy_id, "workflow", "legacy-key", legacy_value)
+
+    command.upgrade(cfg, BELOW)
+    assert _stamped_revision() == BELOW
+    assert _memory_by_name() == {
+        "fresh-no-state-agent": False,
+        "legacy-state-owner": False,
+    }
+
+    isolated_url = _runner_state_url(kind=KIND, address=ADDRESS)
+    assert isolated_url.endswith(
+        f"/agents/{legacy_id}/state/bindings/{KIND}/{ADDRESS}"
+    )
+    hidden = _api_get(f"{isolated_url}/workflow/legacy-key")
+    assert hidden.status_code == 404
+    assert hidden.json() == {"detail": "state entry not found"}
+    assert _sql(
+        "SELECT binding_scope IS NULL FROM curie.workflow_state_entries "
+        "WHERE agent_id = :agent_id AND namespace = 'workflow' AND key = 'legacy-key'",
+        {"agent_id": legacy_id},
+    ) == [(True,)]
+
+    command.upgrade(cfg, REVISION)
+    assert _stamped_revision() == REVISION
+    assert _memory_by_name() == {
+        "fresh-no-state-agent": False,
+        "legacy-state-owner": True,
+    }
+
+    shared_url = _runner_state_url(kind=KIND, address=ADDRESS)
+    assert shared_url.endswith(f"/agents/{legacy_id}/state")
+    assert "/bindings/" not in shared_url
+    visible = _api_get(f"{shared_url}/workflow/legacy-key")
+    assert visible.status_code == 200, visible.text
+    assert visible.json()["value"] == legacy_value
+
+
+def test_reserved_only_legacy_state_does_not_flip_memory(
+    isolated_migration_db: None,
+) -> None:
+    cfg = _alembic_config()
+    command.upgrade(cfg, BELOW)
+    agent_id = _seed_agent("reserved-only", memory=False)
+    _seed_state(agent_id, "memory", "summary", {"text": "remembered"}, binding_scope=None)
+    _seed_state(
+        agent_id,
+        "transcript",
+        "thread-1",
+        [{"role": "user", "content": "hello"}],
+        binding_scope=None,
+    )
+    before = _state_rows(agent_id)
+
+    command.upgrade(cfg, REVISION)
+
+    assert _memory_by_name() == {"reserved-only": False}
+    assert _state_rows(agent_id) == before
+
+
+def test_reserved_shared_plus_scoped_general_state_stays_isolated(
+    isolated_migration_db: None,
+) -> None:
+    cfg = _alembic_config()
+    command.upgrade(cfg, BELOW)
+    agent_id = _seed_agent("healthy-isolated", memory=False)
+    _seed_binding(agent_id)
+    reserved_value = {"summary": "agent-wide"}
+    scoped_value = {"queue": ["ticket-1"]}
+    _seed_state(agent_id, "memory", "summary", reserved_value, binding_scope=None)
+    _seed_state(
+        agent_id,
+        "workflow",
+        "queue",
+        scoped_value,
+        binding_scope=f"{KIND}:{ADDRESS}",
+    )
+    before = _state_rows(agent_id)
+
+    command.upgrade(cfg, REVISION)
+
+    assert _memory_by_name() == {"healthy-isolated": False}
+    assert _state_rows(agent_id) == before
+    reserved = _api_get(f"http://migration-api.test/agents/{agent_id}/state/memory/summary")
+    scoped = _api_get(
+        f"http://migration-api.test/agents/{agent_id}/state/bindings/"
+        f"{KIND}/{ADDRESS}/workflow/queue"
+    )
+    assert reserved.status_code == 200, reserved.text
+    assert reserved.json()["value"] == reserved_value
+    assert scoped.status_code == 200, scoped.text
+    assert scoped.json()["value"] == scoped_value
+
+
+def test_memory_true_mixed_scope_general_state_remains_supported(
+    isolated_migration_db: None,
+) -> None:
+    cfg = _alembic_config()
+    command.upgrade(cfg, BELOW)
+    agent_id = _seed_runnable_agent("already-shared", memory=True)
+    shared_value = {"mode": "shared"}
+    scoped_value = {"mode": "old-isolated"}
+    _seed_state(
+        agent_id,
+        "workflow",
+        "shared-key",
+        shared_value,
+        binding_scope=None,
+    )
+    _seed_state(
+        agent_id,
+        "workflow",
+        "scoped-key",
+        scoped_value,
+        binding_scope=f"{KIND}:{ADDRESS}",
+    )
+    before = _state_rows(agent_id)
+
+    command.upgrade(cfg, REVISION)
+
+    assert _memory_by_name() == {"already-shared": True}
+    assert _state_rows(agent_id) == before
+    shared_url = _runner_state_url(kind=KIND, address=ADDRESS)
+    assert shared_url.endswith(f"/agents/{agent_id}/state")
+    shared = _api_get(f"{shared_url}/workflow/shared-key")
+    scoped = _api_get(
+        f"http://migration-api.test/agents/{agent_id}/state/bindings/"
+        f"{KIND}/{ADDRESS}/workflow/scoped-key"
+    )
+    assert shared.status_code == 200, shared.text
+    assert shared.json()["value"] == shared_value
+    assert scoped.status_code == 200, scoped.text
+    assert scoped.json()["value"] == scoped_value
+
+
+@pytest.mark.parametrize("namespace", ["memory", "workflow"], ids=("reserved", "general"))
+def test_duplicate_null_identity_is_refused_atomically(
+    namespace: str,
+    isolated_migration_db: None,
+) -> None:
+    cfg = _alembic_config()
+    command.upgrade(cfg, BELOW)
+    agent_id = _seed_agent(f"duplicate-{namespace}", memory=False)
+    _seed_state(agent_id, namespace, "same-key", {"winner": 1}, binding_scope=None)
+    _seed_state(agent_id, namespace, "same-key", {"winner": 2}, binding_scope=None)
+    before_rows = _state_rows(agent_id)
+    before_memory = _memory_by_name()
+
+    with pytest.raises(RuntimeError) as caught:
+        command.upgrade(cfg, REVISION)
+
+    message = str(caught.value)
+    lowered = message.lower()
+    assert "duplicate" in lowered
+    assert "null" in lowered
+    assert str(agent_id) in message
+    assert namespace in message
+    assert "same-key" in message
+    assert "merge or delete" in lowered
+    assert _stamped_revision() == BELOW
+    assert _memory_by_name() == before_memory
+    assert _state_rows(agent_id) == before_rows
+
+
+def test_false_mixed_scope_flip_candidate_is_refused_atomically(
+    isolated_migration_db: None,
+) -> None:
+    cfg = _alembic_config()
+    command.upgrade(cfg, BELOW)
+    agent_id = _seed_agent("ambiguous-false-owner", memory=False)
+    _seed_state(
+        agent_id,
+        "workflow",
+        "shared-key",
+        {"shape": "shared"},
+        binding_scope=None,
+    )
+    _seed_state(
+        agent_id,
+        "workflow",
+        "scoped-key",
+        {"shape": "isolated"},
+        binding_scope=f"{KIND}:{ADDRESS}",
+    )
+    before_rows = _state_rows(agent_id)
+    before_memory = _memory_by_name()
+
+    with pytest.raises(RuntimeError) as caught:
+        command.upgrade(cfg, REVISION)
+
+    message = str(caught.value)
+    lowered = message.lower()
+    assert str(agent_id) in message
+    assert "memory=false" in lowered
+    assert "shared" in lowered
+    assert "isolated" in lowered
+    assert "move" in lowered
+    assert "merge" in lowered
+    assert _stamped_revision() == BELOW
+    assert _memory_by_name() == before_memory
+    assert _state_rows(agent_id) == before_rows
+
+
+def test_duplicate_null_constraint_catalog_and_scoped_controls(
+    isolated_migration_db: None,
+) -> None:
+    cfg = _alembic_config()
+    command.upgrade(cfg, BELOW)
+    agent_id = _seed_agent("identity-controls", memory=True)
+    command.upgrade(cfg, REVISION)
+
+    assert _sql(
+        """
+        SELECT constraint.connullsnotdistinct
+        FROM pg_constraint AS constraint
+        JOIN pg_class AS relation ON relation.oid = constraint.conrelid
+        JOIN pg_namespace AS namespace ON namespace.oid = relation.relnamespace
+        WHERE namespace.nspname = 'curie'
+          AND relation.relname = 'workflow_state_entries'
+          AND constraint.conname = 'uq_state_agent_scope_ns_key'
+        """
+    ) == [(True,)]
+
+    _seed_state(agent_id, "workflow", "shared-key", {"writer": 1}, binding_scope=None)
+    with pytest.raises(IntegrityError) as caught:
+        _seed_state(agent_id, "workflow", "shared-key", {"writer": 2}, binding_scope=None)
+    assert "uq_state_agent_scope_ns_key" in str(caught.value)
+    assert _sql(
+        "SELECT count(*) FROM curie.workflow_state_entries "
+        "WHERE agent_id = :agent_id AND binding_scope IS NULL "
+        "AND namespace = 'workflow' AND key = 'shared-key'",
+        {"agent_id": agent_id},
+    ) == [(1,)]
+
+    for scope in ("slack:C0EXAMPLE2", "webhook:acme-room-3"):
+        _seed_state(
+            agent_id,
+            "workflow",
+            "isolated-key",
+            {"scope": scope},
+            binding_scope=scope,
+        )
+    assert _sql(
+        "SELECT binding_scope FROM curie.workflow_state_entries "
+        "WHERE agent_id = :agent_id AND namespace = 'workflow' "
+        "AND key = 'isolated-key' ORDER BY binding_scope",
+        {"agent_id": agent_id},
+    ) == [("slack:C0EXAMPLE2",), ("webhook:acme-room-3",)]
+
+
+def test_duplicate_null_orm_metadata_declares_shared_identity() -> None:
+    constraint = next(
+        candidate
+        for candidate in WorkflowStateEntry.__table__.constraints
+        if isinstance(candidate, UniqueConstraint)
+        and candidate.name == "uq_state_agent_scope_ns_key"
+    )
+
+    assert constraint.dialect_options["postgresql"]["nulls_not_distinct"] is True

--- a/apps/api/tests/test_migration_0037_multibinding_state_identity.py
+++ b/apps/api/tests/test_migration_0037_multibinding_state_identity.py
@@ -453,13 +453,15 @@ def test_duplicate_null_constraint_catalog_and_scoped_controls(
 
     assert _sql(
         """
-        SELECT constraint.connullsnotdistinct
-        FROM pg_constraint AS constraint
-        JOIN pg_class AS relation ON relation.oid = constraint.conrelid
+        SELECT backing_index.indnullsnotdistinct
+        FROM pg_constraint AS catalog_constraint
+        JOIN pg_class AS relation ON relation.oid = catalog_constraint.conrelid
+        JOIN pg_index AS backing_index
+          ON backing_index.indexrelid = catalog_constraint.conindid
         JOIN pg_namespace AS namespace ON namespace.oid = relation.relnamespace
         WHERE namespace.nspname = 'curie'
           AND relation.relname = 'workflow_state_entries'
-          AND constraint.conname = 'uq_state_agent_scope_ns_key'
+          AND catalog_constraint.conname = 'uq_state_agent_scope_ns_key'
         """
     ) == [(True,)]
 

--- a/apps/api/tests/test_released_upgrade_gate.py
+++ b/apps/api/tests/test_released_upgrade_gate.py
@@ -18,10 +18,13 @@ surface the gate and its read-back runner are built to:
   goes red instead.
 * `ColumnInfo` / `_plan_seed_statements` / `_detect_approval_route_era` -- the
   schema-adaptive planner, which must never silently seed nothing and must pick
-  the 0021 channel era and the 0034 approval-route era INDEPENDENTLY (#2098).
+  the 0021 channel era and the 0034 approval-route era INDEPENDENTLY (#2098),
+  while carrying one non-reserved legacy-state sentinel whenever the released
+  schema can represent it (#1901).
 * `scripts/released_upgrade_readback.py::_collect_failures` -- the pure
-  assertion helper, which must not pass vacuously and must name the DATA before
-  it names Pydantic.
+  assertion helper, which must not pass vacuously, must name the DATA before it
+  names Pydantic, and must reject every way the legacy-state sentinel can stop
+  being one shared runner-visible identity.
 
 Everything here is a pure unit test with stubs. No test creates a git worktree,
 runs `uv sync`, runs alembic, or touches Postgres; the live gate is exercised by
@@ -54,6 +57,8 @@ COLLISION_MARKERS = (
     'relation "curie.agent_channels" does not exist',
     "0022_approvals_reply_kind.py",
 )
+
+RESERVED_STATE_NAMESPACES = frozenset({"memory", "transcript"})
 
 
 def _load_script(module_name: str, path: Path) -> ModuleType:
@@ -165,6 +170,27 @@ def test_the_1706_collision_direction_is_retained_with_all_three_markers(
     assert direction.expect_failure_phase == "candidate upgrade"
     for marker in COLLISION_MARKERS:
         assert marker in direction.markers, f"lost collision marker {marker!r}"
+
+
+def test_released_state_historical_directions_keep_exact_verdicts_without_0037(
+    gate: ModuleType,
+) -> None:
+    """#1901 extends HEAD without rewriting any pre-0037 self-test verdict."""
+    assert tuple(dataclasses.astuple(row) for row in gate.SELF_TEST_DIRECTIONS) == (
+        (
+            "v0.6.2",
+            "v0.7.0-rc.1",
+            "candidate upgrade",
+            COLLISION_MARKERS,
+        ),
+        (
+            "v0.6.2",
+            "v0.7.3",
+            "read-back",
+            ("C-0a1b2c3d", "is not a Slack channel ID"),
+        ),
+        ("v0.6.2", "v0.8.0", None, ()),
+    )
 
 
 # --------------------------------------------------------------------------
@@ -395,6 +421,102 @@ def _agent_channels_columns(gate: ModuleType) -> tuple[Any, ...]:
     )
 
 
+def _state_columns(
+    gate: ModuleType,
+    *,
+    binding_scope: bool,
+) -> tuple[Any, ...]:
+    """The state table before or after 0031 added `binding_scope`."""
+    columns = (
+        _column(
+            gate,
+            "workflow_state_entries",
+            "id",
+            nullable=False,
+            default="gen_random_uuid()",
+        ),
+        _column(
+            gate,
+            "workflow_state_entries",
+            "agent_id",
+            nullable=False,
+        ),
+        _column(
+            gate,
+            "workflow_state_entries",
+            "namespace",
+            nullable=False,
+        ),
+        _column(
+            gate,
+            "workflow_state_entries",
+            "key",
+            nullable=False,
+        ),
+        _column(
+            gate,
+            "workflow_state_entries",
+            "value",
+            nullable=False,
+        ),
+        _column(
+            gate,
+            "workflow_state_entries",
+            "version",
+            nullable=False,
+            default="1",
+        ),
+        _column(
+            gate,
+            "workflow_state_entries",
+            "created_at",
+            nullable=False,
+            default="now()",
+        ),
+        _column(
+            gate,
+            "workflow_state_entries",
+            "updated_at",
+            nullable=False,
+            default="now()",
+        ),
+    )
+    if not binding_scope:
+        return columns
+    return (
+        *columns,
+        _column(gate, "workflow_state_entries", "binding_scope"),
+    )
+
+
+def _plan_seed(
+    gate: ModuleType,
+    columns: tuple[Any, ...],
+    *,
+    approval_route_era: str,
+) -> tuple[tuple[str, ...], Any]:
+    """The planner's SQL and the exact metadata that describes what it wrote."""
+    statements, metadata = gate._plan_seed_statements(
+        columns,
+        approval_route_era=approval_route_era,
+    )
+    assert isinstance(statements, tuple)
+    return statements, metadata
+
+
+def _planned_statements(
+    gate: ModuleType,
+    columns: tuple[Any, ...],
+    *,
+    approval_route_era: str,
+) -> tuple[str, ...]:
+    return _plan_seed(
+        gate,
+        columns,
+        approval_route_era=approval_route_era,
+    )[0]
+
+
 def _routed_agent(gate: ModuleType) -> Any:
     """The one fixture row that carries an approval route."""
     return next(
@@ -407,7 +529,8 @@ def _routed_agent(gate: ModuleType) -> Any:
 def test_legacy_column_branch_writes_every_address_into_curie_agents(
     gate: ModuleType,
 ) -> None:
-    statements = gate._plan_seed_statements(
+    statements = _planned_statements(
+        gate,
         _legacy_columns(gate),
         approval_route_era=gate.APPROVAL_ROUTE_ERA_LEGACY,
     )
@@ -425,7 +548,8 @@ def test_legacy_column_branch_writes_every_address_into_curie_agents(
 def test_agent_channels_branch_writes_agent_id_kind_and_address(
     gate: ModuleType,
 ) -> None:
-    statements = gate._plan_seed_statements(
+    statements = _planned_statements(
+        gate,
         _agent_channels_columns(gate),
         approval_route_era=gate.APPROVAL_ROUTE_ERA_SPLIT,
     )
@@ -445,12 +569,104 @@ def test_agent_channels_branch_writes_agent_id_kind_and_address(
         assert agent.kind in binding_text
 
 
+@pytest.mark.parametrize("binding_scope", [False, True])
+def test_released_state_planner_adds_one_non_reserved_sentinel_in_each_schema_era(
+    gate: ModuleType,
+    binding_scope: bool,
+) -> None:
+    """The released row is old-shaped SQL, not a current-model construction."""
+    statements, metadata = _plan_seed(
+        gate,
+        (
+            *_agent_channels_columns(gate),
+            *_state_columns(gate, binding_scope=binding_scope),
+        ),
+        approval_route_era=gate.APPROVAL_ROUTE_ERA_SPLIT,
+    )
+
+    state_statements = [
+        statement
+        for statement in statements
+        if "curie.workflow_state_entries" in statement
+    ]
+    assert len(state_statements) == 1
+    state_sql = state_statements[0]
+    sentinel = metadata.legacy_state
+    assert sentinel is not None
+    assert sentinel.owner_name in {agent.name for agent in gate.SEED_FIXTURE}
+    assert sentinel.namespace not in RESERVED_STATE_NAMESPACES
+    assert sentinel.owner_name in state_sql
+    assert sentinel.namespace in state_sql
+    assert sentinel.key in state_sql
+    assert json.dumps(sentinel.value) in state_sql
+    if binding_scope:
+        assert "binding_scope" in state_sql
+        assert "NULL" in state_sql
+    else:
+        assert "binding_scope" not in state_sql
+
+
+@pytest.mark.parametrize("channel_era", ["legacy", "agent_channels"])
+def test_released_state_planner_keeps_old_schemas_without_the_table_supported(
+    gate: ModuleType,
+    channel_era: str,
+) -> None:
+    columns = (
+        _legacy_columns(gate)
+        if channel_era == "legacy"
+        else _agent_channels_columns(gate)
+    )
+    route_era = (
+        gate.APPROVAL_ROUTE_ERA_LEGACY
+        if channel_era == "legacy"
+        else gate.APPROVAL_ROUTE_ERA_SPLIT
+    )
+
+    statements, metadata = _plan_seed(
+        gate,
+        columns,
+        approval_route_era=route_era,
+    )
+
+    assert statements
+    assert metadata.legacy_state is None
+    assert all("workflow_state_entries" not in statement for statement in statements)
+
+
+def test_released_state_introspection_includes_the_workflow_state_table(
+    gate: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, str] = {}
+
+    def _fake_query(database_name: str, sql: str) -> str:
+        captured["database_name"] = database_name
+        captured["sql"] = sql
+        return "workflow_state_entries|namespace|NO|"
+
+    monkeypatch.setattr(gate, "_scratch_query", _fake_query)
+
+    columns = gate._introspect_columns("released_state_introspection")
+
+    assert captured["database_name"] == "released_state_introspection"
+    assert "workflow_state_entries" in captured["sql"]
+    assert columns == (
+        gate.ColumnInfo(
+            table_name="workflow_state_entries",
+            column_name="namespace",
+            is_nullable="NO",
+            column_default=None,
+        ),
+    )
+
+
 def test_legacy_branch_seeds_the_pre_0034_approval_route_shape(
     gate: ModuleType,
 ) -> None:
     """Pre-0034 storage: `{"deploy": {"channel": ...}}`, rewritten on the way up."""
     rendered = "\n".join(
-        gate._plan_seed_statements(
+        _planned_statements(
+            gate,
             _legacy_columns(gate),
             approval_route_era=gate.APPROVAL_ROUTE_ERA_LEGACY,
         )
@@ -467,7 +683,8 @@ def test_agent_channels_branch_seeds_the_post_0034_approval_route_shape(
 ) -> None:
     """Post-0034 storage: the split `{"resolution": {"kind", "address"}}` shape."""
     rendered = "\n".join(
-        gate._plan_seed_statements(
+        _planned_statements(
+            gate,
             _agent_channels_columns(gate),
             approval_route_era=gate.APPROVAL_ROUTE_ERA_SPLIT,
         )
@@ -509,6 +726,191 @@ def _fake_released_tree(tmp_path: Path, *, revisions: tuple[str, ...]) -> Path:
     return tmp_path
 
 
+@pytest.mark.parametrize(
+    ("revisions", "expected"),
+    [
+        (("0036_agents_hook_partitions.py",), False),
+        (("0037_multibinding_state_identity.py",), True),
+        (("0037.py",), False),
+        (("00370_not_the_repair.py",), False),
+    ],
+)
+def test_released_state_candidate_capability_is_pinned_to_an_exact_0037_file(
+    gate: ModuleType,
+    tmp_path: Path,
+    revisions: tuple[str, ...],
+    expected: bool,
+) -> None:
+    tree = _fake_released_tree(tmp_path, revisions=revisions)
+
+    assert gate._candidate_supports_legacy_state(tree) is expected
+
+
+def _metadata_with_released_state(gate: ModuleType) -> Any:
+    return _plan_seed(
+        gate,
+        (
+            *_agent_channels_columns(gate),
+            *_state_columns(gate, binding_scope=True),
+        ),
+        approval_route_era=gate.APPROVAL_ROUTE_ERA_SPLIT,
+    )[1]
+
+
+def _argument_value(command: list[str], option: str) -> str:
+    index = command.index(option)
+    return command[index + 1]
+
+
+def test_released_state_readback_arguments_are_enabled_only_by_exact_0037(
+    gate: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    metadata = _metadata_with_released_state(gate)
+    sentinel = metadata.legacy_state
+    assert sentinel is not None
+    captured: list[list[str]] = []
+
+    def _fake_run_in_tree(command: list[str], **_kwargs: Any) -> Any:
+        captured.append(command)
+        return gate.CommandResult(0, "ok")
+
+    monkeypatch.setattr(gate, "_run_in_tree", _fake_run_in_tree)
+    without_repair = _fake_released_tree(
+        tmp_path / "without-repair",
+        revisions=("0036_agents_hook_partitions.py",),
+    )
+    with_repair = _fake_released_tree(
+        tmp_path / "with-repair",
+        revisions=("0037_multibinding_state_identity.py",),
+    )
+
+    for candidate_tree in (without_repair, with_repair):
+        result = gate._run_readback(
+            candidate_tree,
+            database_url="postgresql+asyncpg://gate/test",
+            phase=gate.READBACK_PHASE,
+            ref="candidate",
+            commit="0" * 40,
+            seed_metadata=metadata,
+        )
+        assert result.returncode == 0
+
+    state_options = {
+        "--expect-state-owner",
+        "--expect-state-namespace",
+        "--expect-state-key",
+        "--expect-state-value",
+    }
+    assert state_options.isdisjoint(captured[0])
+    assert _argument_value(captured[1], "--expect-state-owner") == sentinel.owner_name
+    assert (
+        _argument_value(captured[1], "--expect-state-namespace")
+        == sentinel.namespace
+    )
+    assert _argument_value(captured[1], "--expect-state-key") == sentinel.key
+    assert json.loads(_argument_value(captured[1], "--expect-state-value")) == (
+        sentinel.value
+    )
+
+
+def test_seed_released_database_returns_the_exact_released_state_metadata(
+    gate: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    metadata = _metadata_with_released_state(gate)
+    monkeypatch.setattr(gate, "_introspect_columns", lambda _database: ())
+    monkeypatch.setattr(
+        gate,
+        "_plan_seed_statements",
+        lambda _columns, *, approval_route_era: (("SELECT 1",), metadata),
+    )
+    monkeypatch.setattr(gate, "_checked_output", lambda *_args, **_kwargs: "")
+
+    returned = gate._seed_released_database(
+        "released_state_seed",
+        phase=gate.SEED_PHASE,
+        approval_route_era=gate.APPROVAL_ROUTE_ERA_SPLIT,
+    )
+
+    assert returned is metadata
+
+
+def test_seed_released_database_refuses_state_capable_schema_without_a_sentinel(
+    gate: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    columns = (
+        *_agent_channels_columns(gate),
+        *_state_columns(gate, binding_scope=True),
+    )
+    metadata = _metadata_with_released_state(gate)
+    empty_metadata = dataclasses.replace(metadata, legacy_state=None)
+    monkeypatch.setattr(gate, "_introspect_columns", lambda _database: columns)
+    monkeypatch.setattr(
+        gate,
+        "_plan_seed_statements",
+        lambda _columns, *, approval_route_era: (("SELECT 1",), empty_metadata),
+    )
+
+    with pytest.raises(gate.GateError) as excinfo:
+        gate._seed_released_database(
+            "released_state_vacuity",
+            phase=gate.SEED_PHASE,
+            approval_route_era=gate.APPROVAL_ROUTE_ERA_SPLIT,
+        )
+
+    message = str(excinfo.value)
+    assert "workflow_state_entries" in message
+    assert "sentinel" in message
+
+
+def test_upgrade_pair_threads_the_exact_released_state_metadata_into_readback(
+    gate: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    metadata = _metadata_with_released_state(gate)
+    captured: dict[str, Any] = {}
+
+    monkeypatch.setattr(
+        gate,
+        "_run_alembic",
+        lambda *_args, **_kwargs: gate.CommandResult(0, "ok"),
+    )
+    monkeypatch.setattr(
+        gate,
+        "_detect_approval_route_era",
+        lambda _tree: gate.APPROVAL_ROUTE_ERA_SPLIT,
+    )
+    monkeypatch.setattr(
+        gate,
+        "_seed_released_database",
+        lambda *_args, **_kwargs: metadata,
+    )
+
+    def _fake_readback(*_args: Any, **kwargs: Any) -> Any:
+        captured.update(kwargs)
+        return gate.CommandResult(0, "read-back ok")
+
+    monkeypatch.setattr(gate, "_run_readback", _fake_readback)
+
+    result = gate._upgrade_pair(
+        tmp_path / "released",
+        tmp_path / "candidate",
+        database_url="postgresql+asyncpg://gate/test",
+        database_name="released_state_upgrade",
+        released_ref="v0.8.0",
+        released_commit="1" * 40,
+        candidate_ref="HEAD",
+        candidate_commit="2" * 40,
+    )
+
+    assert result == gate.PairResult(gate.READBACK_PHASE, 0, "read-back ok")
+    assert captured["seed_metadata"] is metadata
+
+
 def test_agent_channels_branch_with_a_legacy_route_era_seeds_the_channel_shape(
     gate: ModuleType,
 ) -> None:
@@ -523,7 +925,8 @@ def test_agent_channels_branch_with_a_legacy_route_era_seeds_the_channel_shape(
     """
 
     rendered = "\n".join(
-        gate._plan_seed_statements(
+        _planned_statements(
+            gate,
             _agent_channels_columns(gate),
             approval_route_era=gate.APPROVAL_ROUTE_ERA_LEGACY,
         )
@@ -540,7 +943,8 @@ def test_agent_channels_branch_with_a_split_route_era_seeds_the_resolution_shape
     """Post-0034 released refs keep the split shape: the era is a choice, not a drop."""
 
     rendered = "\n".join(
-        gate._plan_seed_statements(
+        _planned_statements(
+            gate,
             _agent_channels_columns(gate),
             approval_route_era=gate.APPROVAL_ROUTE_ERA_SPLIT,
         )
@@ -556,7 +960,8 @@ def test_legacy_column_branch_with_a_legacy_route_era_seeds_the_channel_shape(
     """Pre-0021 implies pre-0034, so this quadrant is unchanged by the era split."""
 
     rendered = "\n".join(
-        gate._plan_seed_statements(
+        _planned_statements(
+            gate,
             _legacy_columns(gate),
             approval_route_era=gate.APPROVAL_ROUTE_ERA_LEGACY,
         )
@@ -812,3 +1217,163 @@ def test_a_validation_failure_names_the_data_before_pydantic(
     pydantic_index = rendered.index("1 validation error for AgentOut")
     assert name_index < pydantic_index
     assert address_index < pydantic_index
+
+
+def _released_state_expectation(gate: ModuleType, readback: ModuleType) -> Any:
+    seeded = _metadata_with_released_state(gate).legacy_state
+    assert seeded is not None
+    return readback.StateSentinelExpectation(
+        owner_name=seeded.owner_name,
+        namespace=seeded.namespace,
+        key=seeded.key,
+        value=seeded.value,
+    )
+
+
+def _released_state_observation(
+    readback: ModuleType,
+    expectation: Any,
+    **overrides: Any,
+) -> Any:
+    values = {
+        "owner_name": expectation.owner_name,
+        "binding_scope": None,
+        "namespace": expectation.namespace,
+        "key": expectation.key,
+        "value": expectation.value,
+        "owner_memory": True,
+    }
+    values.update(overrides)
+    return readback.StateSentinelObservation(**values)
+
+
+def _released_state_failures(
+    gate: ModuleType,
+    readback: ModuleType,
+    observations: tuple[Any, ...],
+) -> tuple[str, ...]:
+    return readback._collect_failures(
+        _all_dumps(gate, readback),
+        expected_agents=_expected_names(gate),
+        expected_addresses=_expected_addresses(gate),
+        state_expectation=_released_state_expectation(gate, readback),
+        state_observations=observations,
+    )
+
+
+def test_released_state_readback_accepts_one_shared_unchanged_visible_sentinel(
+    gate: ModuleType,
+    readback: ModuleType,
+) -> None:
+    expectation = _released_state_expectation(gate, readback)
+    reserved_neighbour = _released_state_observation(
+        readback,
+        expectation,
+        namespace="memory",
+        key="runner-reserved",
+        value={"reserved": True},
+    )
+    sentinel = _released_state_observation(readback, expectation)
+
+    failures = _released_state_failures(
+        gate,
+        readback,
+        (reserved_neighbour, sentinel),
+    )
+
+    assert failures == ()
+
+
+def test_released_state_readback_rejects_a_missing_sentinel(
+    gate: ModuleType,
+    readback: ModuleType,
+) -> None:
+    failures = _released_state_failures(gate, readback, ())
+
+    rendered = "\n".join(failures)
+    assert "exactly one" in rendered
+    assert "found 0" in rendered
+
+
+def test_released_state_readback_does_not_mistake_reserved_state_for_the_sentinel(
+    gate: ModuleType,
+    readback: ModuleType,
+) -> None:
+    expectation = _released_state_expectation(gate, readback)
+    reserved_only = _released_state_observation(
+        readback,
+        expectation,
+        namespace="transcript",
+    )
+
+    failures = _released_state_failures(gate, readback, (reserved_only,))
+
+    rendered = "\n".join(failures)
+    assert expectation.namespace in rendered
+    assert "found 0" in rendered
+
+
+def test_released_state_readback_rejects_duplicate_shared_identity(
+    gate: ModuleType,
+    readback: ModuleType,
+) -> None:
+    expectation = _released_state_expectation(gate, readback)
+    sentinel = _released_state_observation(readback, expectation)
+
+    failures = _released_state_failures(gate, readback, (sentinel, sentinel))
+
+    rendered = "\n".join(failures)
+    assert "exactly one" in rendered
+    assert "found 2" in rendered
+
+
+def test_released_state_readback_rejects_a_scoped_sentinel(
+    gate: ModuleType,
+    readback: ModuleType,
+) -> None:
+    expectation = _released_state_expectation(gate, readback)
+    scoped = _released_state_observation(
+        readback,
+        expectation,
+        binding_scope="slack:C0EXAMPLE1",
+    )
+
+    failures = _released_state_failures(gate, readback, (scoped,))
+
+    rendered = "\n".join(failures)
+    assert "binding_scope" in rendered
+    assert "NULL" in rendered
+
+
+def test_released_state_readback_rejects_a_changed_json_value(
+    gate: ModuleType,
+    readback: ModuleType,
+) -> None:
+    expectation = _released_state_expectation(gate, readback)
+    changed = _released_state_observation(
+        readback,
+        expectation,
+        value={"changed": True},
+    )
+
+    failures = _released_state_failures(gate, readback, (changed,))
+
+    assert any("value" in failure.lower() for failure in failures)
+
+
+def test_released_state_readback_rejects_an_owner_that_remains_memory_false(
+    gate: ModuleType,
+    readback: ModuleType,
+) -> None:
+    expectation = _released_state_expectation(gate, readback)
+    hidden = _released_state_observation(
+        readback,
+        expectation,
+        owner_memory=False,
+    )
+
+    failures = _released_state_failures(gate, readback, (hidden,))
+
+    rendered = "\n".join(failures).lower()
+    assert "memory" in rendered
+    assert "true" in rendered

--- a/apps/api/tests/test_released_upgrade_gate.py
+++ b/apps/api/tests/test_released_upgrade_gate.py
@@ -815,6 +815,51 @@ def test_released_state_readback_arguments_are_enabled_only_by_exact_0037(
     )
 
 
+def test_released_state_readback_names_pre_table_skip_for_a_0037_candidate(
+    gate: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    metadata = dataclasses.replace(
+        _metadata_with_released_state(gate),
+        legacy_state=None,
+    )
+    captured: dict[str, list[str]] = {}
+
+    def _fake_run_in_tree(command: list[str], **_kwargs: Any) -> Any:
+        captured["command"] = command
+        return gate.CommandResult(0, "ok")
+
+    monkeypatch.setattr(gate, "_run_in_tree", _fake_run_in_tree)
+    candidate_tree = _fake_released_tree(
+        tmp_path,
+        revisions=("0037_multibinding_state_identity.py",),
+    )
+
+    result = gate._run_readback(
+        candidate_tree,
+        database_url="postgresql+asyncpg://gate/test",
+        phase=gate.READBACK_PHASE,
+        ref="candidate",
+        commit="0" * 40,
+        seed_metadata=metadata,
+    )
+
+    assert result.returncode == 0
+    state_options = {
+        "--expect-state-owner",
+        "--expect-state-namespace",
+        "--expect-state-key",
+        "--expect-state-value",
+    }
+    assert state_options.isdisjoint(captured["command"])
+    output = capsys.readouterr().out.lower()
+    assert "skip" in output
+    assert "released schema predates" in output
+    assert "workflow_state_entries" in output
+
+
 def test_seed_released_database_returns_the_exact_released_state_metadata(
     gate: ModuleType,
     monkeypatch: pytest.MonkeyPatch,

--- a/apps/api/tests/test_released_upgrade_gate.py
+++ b/apps/api/tests/test_released_upgrade_gate.py
@@ -494,11 +494,13 @@ def _plan_seed(
     columns: tuple[Any, ...],
     *,
     approval_route_era: str,
+    released_state_repaired: bool = False,
 ) -> tuple[tuple[str, ...], Any]:
     """The planner's SQL and the exact metadata that describes what it wrote."""
     statements, metadata = gate._plan_seed_statements(
         columns,
         approval_route_era=approval_route_era,
+        released_state_repaired=released_state_repaired,
     )
     assert isinstance(statements, tuple)
     return statements, metadata
@@ -869,7 +871,10 @@ def test_seed_released_database_returns_the_exact_released_state_metadata(
     monkeypatch.setattr(
         gate,
         "_plan_seed_statements",
-        lambda _columns, *, approval_route_era: (("SELECT 1",), metadata),
+        lambda _columns, *, approval_route_era, released_state_repaired: (
+            ("SELECT 1",),
+            metadata,
+        ),
     )
     monkeypatch.setattr(gate, "_checked_output", lambda *_args, **_kwargs: "")
 
@@ -896,7 +901,10 @@ def test_seed_released_database_refuses_state_capable_schema_without_a_sentinel(
     monkeypatch.setattr(
         gate,
         "_plan_seed_statements",
-        lambda _columns, *, approval_route_era: (("SELECT 1",), empty_metadata),
+        lambda _columns, *, approval_route_era, released_state_repaired: (
+            ("SELECT 1",),
+            empty_metadata,
+        ),
     )
 
     with pytest.raises(gate.GateError) as excinfo:
@@ -954,6 +962,98 @@ def test_upgrade_pair_threads_the_exact_released_state_metadata_into_readback(
 
     assert result == gate.PairResult(gate.READBACK_PHASE, 0, "read-back ok")
     assert captured["seed_metadata"] is metadata
+
+
+def test_upgrade_pair_from_released_0037_seeds_a_valid_shared_state_owner(
+    gate: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A stable 0037 line must not recreate the pre-repair invalid owner shape.
+
+    The sentinel remains enabled in the candidate read-back so this direction
+    still proves exactly one NULL-scope row, unchanged value, and a
+    runner-visible memory owner. Only the one-shot false-to-true migration repair
+    is no longer fabricated after that migration has already shipped.
+    """
+    released_tree = _fake_released_tree(
+        tmp_path / "released",
+        revisions=("0037_multibinding_state_identity.py",),
+    )
+    candidate_tree = _fake_released_tree(
+        tmp_path / "candidate",
+        revisions=("0037_multibinding_state_identity.py",),
+    )
+    columns = (
+        *_agent_channels_columns(gate),
+        _column(gate, "agents", "memory", nullable=False, default="false"),
+        *_state_columns(gate, binding_scope=True),
+    )
+    captured: dict[str, Any] = {}
+
+    monkeypatch.setattr(
+        gate,
+        "_run_alembic",
+        lambda *_args, **_kwargs: gate.CommandResult(0, "ok"),
+    )
+    monkeypatch.setattr(
+        gate,
+        "_detect_approval_route_era",
+        lambda _tree: gate.APPROVAL_ROUTE_ERA_SPLIT,
+    )
+
+    def _fake_seed(*_args: Any, **kwargs: Any) -> Any:
+        captured["released_state_repaired"] = kwargs["released_state_repaired"]
+        statements, metadata = gate._plan_seed_statements(
+            columns,
+            approval_route_era=kwargs["approval_route_era"],
+            released_state_repaired=kwargs["released_state_repaired"],
+        )
+        captured["statements"] = statements
+        return metadata
+
+    def _fake_run_in_tree(command: list[str], **_kwargs: Any) -> Any:
+        captured["readback_command"] = command
+        return gate.CommandResult(0, "read-back ok")
+
+    monkeypatch.setattr(gate, "_seed_released_database", _fake_seed)
+    monkeypatch.setattr(gate, "_run_in_tree", _fake_run_in_tree)
+
+    result = gate._upgrade_pair(
+        released_tree,
+        candidate_tree,
+        database_url="postgresql+asyncpg://gate/test",
+        database_name="released_state_already_repaired",
+        released_ref="v0.9.0",
+        released_commit="1" * 40,
+        candidate_ref="HEAD",
+        candidate_commit="2" * 40,
+    )
+
+    assert result == gate.PairResult(gate.READBACK_PHASE, 0, "read-back ok")
+    assert captured["released_state_repaired"] is True
+    owner_insert = next(
+        statement
+        for statement in captured["statements"]
+        if gate.LEGACY_STATE_SEED.owner_name in statement
+        and "INSERT INTO curie.agents" in statement
+    )
+    assert "memory" in owner_insert
+    assert "TRUE" in owner_insert
+    state_insert = next(
+        statement
+        for statement in captured["statements"]
+        if "INSERT INTO curie.workflow_state_entries" in statement
+    )
+    assert "binding_scope" in state_insert
+    assert "NULL" in state_insert
+    for option in (
+        "--expect-state-owner",
+        "--expect-state-namespace",
+        "--expect-state-key",
+        "--expect-state-value",
+    ):
+        assert option in captured["readback_command"]
 
 
 def test_agent_channels_branch_with_a_legacy_route_era_seeds_the_channel_shape(

--- a/apps/api/tests/test_state.py
+++ b/apps/api/tests/test_state.py
@@ -17,6 +17,7 @@ from curie_api.config import get_settings
 from curie_api.routers.state import _NAMESPACE_LOCK_CLASS, _namespace_lock_key
 from curie_api.sandbox_token import mint
 from sqlalchemy import make_url
+from sqlalchemy.exc import IntegrityError
 
 # Scoped-sandbox-token auth matrix constants (#410).
 _FAR_FUTURE = 4102444800  # 2100-01-01, valid at test time
@@ -567,10 +568,17 @@ def _hold_advisory_lock(
         acquired.set()
 
 
-def _run_ordered_state_requests(
+def _request_result_or_exception(request: Future[Any]) -> Any:
+    try:
+        return request.result(timeout=10)
+    except Exception as error:
+        return error
+
+
+def _run_ordered_state_request_outcomes(
     first: Callable[[], Any], second: Callable[[], Any]
 ) -> tuple[Any, Any]:
-    """Run two real requests concurrently, both parked at the INSERT gate.
+    """Return each real request's response or exception after the INSERT gate.
 
     Ordering is established by the database, not by a timer: `first` is submitted
     and confirmed blocked before `second` is submitted, and both are confirmed
@@ -601,8 +609,8 @@ def _run_ordered_state_requests(
                 asyncio.run(_wait_for_blocked_state_requests(2, [first_request, second_request]))
             finally:
                 release.set()
-            first_response = first_request.result(timeout=10)
-            second_response = second_request.result(timeout=10)
+            first_outcome = _request_result_or_exception(first_request)
+            second_outcome = _request_result_or_exception(second_request)
     finally:
         # An INSERT gate left installed would block essentially every later test
         # in the session, so it comes down even if the orchestration failed.
@@ -612,7 +620,19 @@ def _run_ordered_state_requests(
 
     assert not lock_thread.is_alive(), "database gate did not release"
     assert not lock_errors, lock_errors
-    return first_response, second_response
+    return first_outcome, second_outcome
+
+
+def _run_ordered_state_requests(
+    first: Callable[[], Any], second: Callable[[], Any]
+) -> tuple[Any, Any]:
+    """Success-only wrapper preserving the original #933 helper contract."""
+    first_outcome, second_outcome = _run_ordered_state_request_outcomes(first, second)
+    if isinstance(first_outcome, Exception):
+        raise first_outcome
+    if isinstance(second_outcome, Exception):
+        raise second_outcome
+    return first_outcome, second_outcome
 
 
 def _state_writer(
@@ -790,6 +810,50 @@ def test_concurrent_writes_to_the_same_new_namespace_both_succeed(
         assert by_ns["shared-new"]["key_count"] == 2, body
     finally:
         get_settings.cache_clear()
+
+
+def test_concurrent_initial_shared_state_creation_is_database_unique(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    """#1901: PostgreSQL arbitrates concurrent creation of one NULL identity.
+
+    Seeding a different key makes both PUTs take `_enforce_caps`' intentional
+    existing-namespace hot path. They therefore race all the way to INSERT,
+    where the shared NULL scope must be protected by the named constraint.
+    """
+    aid = _agent(client, auth_headers)
+    namespace = "shared-race"
+    target_key = "target"
+    seed = client.put(
+        f"/agents/{aid}/state/{namespace}/seed",
+        json={"value": "existing namespace"},
+        headers=auth_headers,
+    )
+    assert seed.status_code == 200, seed.text
+
+    outcomes = _run_ordered_state_request_outcomes(
+        _state_writer(client, auth_headers, aid, namespace, target_key),
+        _state_writer(client, auth_headers, aid, namespace, target_key),
+    )
+    responses = [outcome for outcome in outcomes if not isinstance(outcome, Exception)]
+    errors = [outcome for outcome in outcomes if isinstance(outcome, Exception)]
+
+    assert len(responses) == 1, outcomes
+    assert responses[0].status_code == 200, responses[0].text
+    assert len(errors) == 1, outcomes
+    assert isinstance(errors[0], IntegrityError), repr(errors[0])
+    assert "uq_state_agent_scope_ns_key" in str(errors[0])
+
+    listing = client.get(f"/agents/{aid}/state/{namespace}", headers=auth_headers)
+    assert listing.status_code == 200, listing.text
+    target_rows = [entry for entry in listing.json() if entry["key"] == target_key]
+    assert len(target_rows) == 1, listing.text
+
+    readback = client.get(
+        f"/agents/{aid}/state/{namespace}/{target_key}", headers=auth_headers
+    )
+    assert readback.status_code == 200, readback.text
+    assert readback.json()["value"] == 1
 
 
 def test_list_namespaces_summarizes_the_store_recent_first(

--- a/docs/interfaces/relational-db/INTERFACE.md
+++ b/docs/interfaces/relational-db/INTERFACE.md
@@ -34,8 +34,9 @@ non-Postgres store is ever demanded.
 
 ## Current contract
 
-A second implementation must be a Postgres speaking the async `asyncpg` dialect and
-honoring the models/migrations verbatim:
+A second implementation must be PostgreSQL 15 or newer, speaking the async `asyncpg`
+dialect and honoring the models/migrations verbatim. Compose and the chart ship
+PostgreSQL 16:
 
 - **DSN + schema** (`apps/api/src/curie_api/db.py::SCHEMA`, `apps/api/src/curie_api/db.py::create_engine`): `SCHEMA = get_settings().db_schema` (default `"curie"`, `apps/api/src/curie_api/config.py::Settings`); the engine is built from `database_url` (env `DATABASE_URL`) via `create_async_engine(..., pool_pre_ping=True)`.
 - **Schema-scoped metadata** (`apps/api/src/curie_api/db.py::Base`): `Base.metadata = MetaData(schema=SCHEMA)` — every table is qualified into the `curie` schema.
@@ -89,18 +90,30 @@ is a judgement call, not something derivable from the tree.
    `SELECT`, and `apps/worker/src/curie_worker/binding.py::_RESOLVE_SQL` orders on
    `(d.environment = 'prod')`, comparing the native enum of item 2 against a string
    literal.
+5. **`UNIQUE NULLS NOT DISTINCT` workflow-state identity** —
+   `workflow_state_entries` treats `binding_scope IS NULL` as the one real shared scope
+   identity, rather than as an absent value. This preserves the shared state of a
+   `memory=True` agent (including a legacy general-state row) and the permanently
+   agent-wide `memory` and `transcript` namespaces. The named
+   `uq_state_agent_scope_ns_key` constraint therefore makes
+   `(agent_id, binding_scope, namespace, key)` unique with `NULLS NOT DISTINCT`;
+   ordinary Postgres unique semantics would allow duplicate NULL tuples. This clause is
+   PostgreSQL-specific and was added in PostgreSQL 15, which is the minimum server
+   version for this relational contract.
 
 Items 1 to 3 are cheap within the Postgres family: any managed Postgres speaks all three
-natively, so the DSN-only swap is unaffected by them. Item 4 is different in kind. It is
+natively, so the DSN-only swap is unaffected by them. Item 4 is different in kind: it is
 dialect-specific and driver-specific SQL living in application code, so it leaks past the
-stated contract as well as past Postgres: swapping the models and migrations would not
-carry it, and a reader looking only at `models.py` would not find it. All of them would
-need rework for a different RDBMS, which is the marker that a real port should be
-extracted first.
+stated contract as well as past Postgres; swapping the models and migrations would not
+carry it, and a reader looking only at `models.py` would not find it. Item 5 is likewise
+a database-level contract rather than a model type: it is native on a supported managed
+Postgres, but a pre-15 server cannot represent Curie's singular NULL shared identity.
+All five items would need rework for a different RDBMS, which is the marker that a real
+port should be extracted first.
 
 ## Cross-links
 
-- **Swap guide + validation:** [managed-postgres-swap.md](./managed-postgres-swap.md) — the DSN-only swap to RDS/Cloud SQL/Neon, with the `apps/api/tests/test_managed_pg_swap.py` smoke test that proves the migration chain applies against a DSN-selected throwaway database (#283). That test covers leakage items 1 and 2 only; items 3 and 4 have no equivalent assertion.
+- **Swap guide + validation:** [managed-postgres-swap.md](./managed-postgres-swap.md) — the DSN-only swap to RDS/Cloud SQL/Neon, with the `apps/api/tests/test_managed_pg_swap.py` smoke test that proves the migration chain applies against a DSN-selected throwaway database (#283). That test covers leakage items 1 and 2 only; items 3 through 5 have no equivalent managed-swap assertion.
 - **Epic(s):** #84 — vision epic for the relational-DB seam (keep the swap a DSN change; extract a port only for a non-Postgres store).
 - **Vision doc:** [architecture-vision.md](../../architecture-vision.md) — Job 5 (Relational database), grade A-
 - **ADR(s):** [ADR-0007](../../adr/0007-adopt-not-build-boundaries.md) — Adopt-not-build boundaries ("vanilla Postgres" adopted for app state)

--- a/docs/interfaces/relational-db/managed-postgres-swap.md
+++ b/docs/interfaces/relational-db/managed-postgres-swap.md
@@ -10,10 +10,13 @@ and the one validation that proves it.
 
 ## The swap
 
-1. **Provision a Postgres** on your managed provider (RDS, Cloud SQL, Neon, or any
-   standard Postgres). No extensions are required. Curie confines its tables to a
-   dedicated `curie` schema (`config.db_schema`), so it can share a database with
-   Langfuse without colliding with Langfuse's `public`-schema Prisma baseline.
+1. **Provision PostgreSQL 15 or newer** on your managed provider (RDS, Cloud SQL,
+   Neon, or any standard Postgres). No extensions are required. Curie uses
+   `UNIQUE NULLS NOT DISTINCT` for shared workflow-state identity, which requires
+   PostgreSQL 15+; the shipped compose stack and chart use PostgreSQL 16. Curie
+   confines its tables to a dedicated `curie` schema (`config.db_schema`), so it
+   can share a database with Langfuse without colliding with Langfuse's
+   `public`-schema Prisma baseline.
 
 2. **Point `DATABASE_URL` at it.** Two services read it, each building its own
    engine from it: the API (`apps/api/src/curie_api/config.py`,
@@ -64,6 +67,9 @@ so any managed Postgres is unaffected (the full, cited list lives in
    raw-SQL reads also decode JSONB with `json.loads`, because asyncpg hands back a
    `str` for a raw-text `SELECT`. Postgres-only and asyncpg-specific, but unchanged
    by which Postgres sits behind the DSN.
+5. **`UNIQUE NULLS NOT DISTINCT`** — the shared (`NULL`) scope in
+   `workflow_state_entries` is one identity rather than PostgreSQL's ordinary
+   many-NULLs behavior. This needs PostgreSQL 15+ on every managed target.
 
 Cross-database portability (MySQL, etc.) is explicitly a non-goal
 ([ADR-0007](../../adr/0007-adopt-not-build-boundaries.md)); if a non-Postgres store
@@ -78,8 +84,9 @@ shape of pointing the app at a managed Postgres. The test then asserts that item
 and 2 materialized as expected: native `uuid` id columns on `agents`,
 `agent_versions` and `deployments`; the `environment` enum type in the `curie`
 schema with the right labels; zero tables in `public`. Items 3 and 4 have no
-assertion here, so the JSONB columns and the raw `DISTINCT ON` queries are covered
-only by the ordinary API and worker suites.
+assertion here: the ordinary API and worker suites cover JSONB and raw
+`DISTINCT ON`, while the migration suite covers the singular shared-state
+identity (item 5).
 
 ```bash
 cd apps/api

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -567,6 +567,47 @@ A chart upgrade is a **full** upgrade: anything the new chart does not render is
 deleted. For a Deployment that means a restart. For a StatefulSet it means the
 data too.
 
+### State-identity migration (Alembic revision 0037)
+
+Before upgrading to a release containing revision 0037, take a
+transaction-consistent database backup. The revision restores the shared posture
+for unambiguous legacy general state and makes a NULL `binding_scope` a single
+state identity. Run these **read-only** preflights against the target database
+immediately before the upgrade:
+
+```sql
+-- Every duplicate shared identity, including reserved namespaces.
+SELECT agent_id, namespace, key, count(*) AS row_count
+FROM curie.workflow_state_entries
+WHERE binding_scope IS NULL
+GROUP BY agent_id, namespace, key
+HAVING count(*) > 1
+ORDER BY agent_id, namespace, key;
+
+-- memory=false owners that 0037 would promote, but whose general state is
+-- already split between shared and binding-scoped rows.
+SELECT agents.id AS agent_id,
+       count(*) FILTER (WHERE state.binding_scope IS NULL) AS shared_rows,
+       count(*) FILTER (WHERE state.binding_scope IS NOT NULL) AS isolated_rows
+FROM curie.agents AS agents
+JOIN curie.workflow_state_entries AS state ON state.agent_id = agents.id
+WHERE agents.memory = false
+  AND state.namespace NOT IN ('memory', 'transcript')
+GROUP BY agents.id
+HAVING bool_or(state.binding_scope IS NULL)
+   AND bool_or(state.binding_scope IS NOT NULL)
+ORDER BY agents.id;
+```
+
+Both result sets must be empty. Do not auto-merge a reported row: the database
+cannot choose between state values or versions, nor infer whether a mixed
+agent's general state should be shared or isolated. For each duplicate, inspect
+its values and versions, then explicitly merge or delete until one row remains.
+For each mixed `memory=false` agent, choose shared or isolated policy and
+move/merge every general-state row into that one shape. Re-run the preflights,
+then the upgrade. On any refusal, the whole 0037 transaction rolls back: agent
+flags, state rows, the constraint, and the Alembic revision stay unchanged.
+
 ### Before you upgrade, check what would be removed
 
 ```bash

--- a/scripts/check-released-upgrade.py
+++ b/scripts/check-released-upgrade.py
@@ -706,6 +706,7 @@ def _plan_seed_statements(
     columns: tuple[ColumnInfo, ...],
     *,
     approval_route_era: str,
+    released_state_repaired: bool = False,
 ) -> tuple[tuple[str, ...], SeedMetadata]:
     """Render released-shaped SQL and exact metadata for optional seeded rows.
 
@@ -717,6 +718,12 @@ def _plan_seed_statements(
 
     `approval_route_era` is a required keyword with NO default on purpose. A
     default is a silent wrong-era guess, and a silent wrong-era guess is the bug.
+
+    `released_state_repaired` distinguishes the first upgrade that applies 0037
+    from a later stable-to-candidate direction where the released line already
+    contains it. In the latter direction the sentinel owner is seeded with
+    memory enabled up front: a post-0037 released database could legitimately
+    contain that shared identity, but not under a memory-disabled owner.
 
     Raises `GateError` rather than returning an empty plan when neither binding
     location exists. A seed that no-ops turns the read-back into a vacuous pass,
@@ -736,6 +743,13 @@ def _plan_seed_statements(
     present = {(column.table_name, column.column_name) for column in columns}
     statements: list[str] = []
 
+    if released_state_repaired and ("agents", "memory") not in present:
+        raise GateError(
+            "the released tree contains the 0037 state repair but the released "
+            "schema has no agents.memory column; refusing to fabricate an "
+            "impossible repaired-state seed"
+        )
+
     if ("agents", "slack_channel") in present:
         _verify_mandatory_columns(
             columns,
@@ -748,11 +762,20 @@ def _plan_seed_statements(
             # the era. The legacy era is therefore passed as a constant, NOT
             # forwarded from `approval_route_era`.
             route = _route_literal(agent, APPROVAL_ROUTE_ERA_LEGACY)
+            insert_columns = "id, name, slack_channel, approval_routes"
+            insert_values = (
+                f"gen_random_uuid(), {_sql_literal(agent.name)}, "
+                f"{_sql_literal(agent.address)}, {route}"
+            )
+            if (
+                released_state_repaired
+                and agent.name == LEGACY_STATE_SEED.owner_name
+            ):
+                insert_columns += ", memory"
+                insert_values += ", TRUE"
             statements.append(
-                "INSERT INTO curie.agents (id, name, slack_channel, "
-                "approval_routes)\n"
-                f"VALUES (gen_random_uuid(), {_sql_literal(agent.name)}, "
-                f"{_sql_literal(agent.address)}, {route})"
+                f"INSERT INTO curie.agents ({insert_columns})\n"
+                f"VALUES ({insert_values})"
             )
     elif ("agent_channels", "address") in present:
         _verify_mandatory_columns(
@@ -771,6 +794,14 @@ def _plan_seed_statements(
             # fixture the released code could never have produced, and the
             # candidate's 0034 rejects it as an unknown legacy key (#2098).
             route = _route_literal(agent, approval_route_era)
+            insert_columns = "id, name, approval_routes"
+            insert_values = f"gen_random_uuid(), {_sql_literal(agent.name)}, {route}"
+            if (
+                released_state_repaired
+                and agent.name == LEGACY_STATE_SEED.owner_name
+            ):
+                insert_columns += ", memory"
+                insert_values += ", TRUE"
             # One statement per agent, so the binding is written in the same
             # transaction as the row it belongs to and the new id never has to be
             # round-tripped back through psql. `endpoint` / `adapter` are left
@@ -778,9 +809,8 @@ def _plan_seed_statements(
             # and the one 0024 backfills existing rows to.
             statements.append(
                 "WITH seeded AS (\n"
-                "    INSERT INTO curie.agents (id, name, approval_routes)\n"
-                f"    VALUES (gen_random_uuid(), {_sql_literal(agent.name)}, "
-                f"{route})\n"
+                f"    INSERT INTO curie.agents ({insert_columns})\n"
+                f"    VALUES ({insert_values})\n"
                 "    RETURNING id\n"
                 ")\n"
                 "INSERT INTO curie.agent_channels (id, agent_id, kind, address)\n"
@@ -842,6 +872,7 @@ def _seed_released_database(
     *,
     phase: str,
     approval_route_era: str,
+    released_state_repaired: bool = False,
 ) -> SeedMetadata:
     """Write the fixture into the released database, between the two upgrades.
 
@@ -854,7 +885,9 @@ def _seed_released_database(
     print(f"=== {phase}: {database_name} ===", flush=True)
     columns = _introspect_columns(database_name)
     statements, metadata = _plan_seed_statements(
-        columns, approval_route_era=approval_route_era
+        columns,
+        approval_route_era=approval_route_era,
+        released_state_repaired=released_state_repaired,
     )
     state_capable = any(
         column.table_name == "workflow_state_entries" for column in columns
@@ -966,6 +999,7 @@ def _upgrade_pair(
         database_name,
         phase=SEED_PHASE,
         approval_route_era=_detect_approval_route_era(released_tree),
+        released_state_repaired=_candidate_supports_legacy_state(released_tree),
     )
 
     failure = _walk(candidate_phases)

--- a/scripts/check-released-upgrade.py
+++ b/scripts/check-released-upgrade.py
@@ -143,6 +143,23 @@ class SeedAgent:
     approval_route_address: str | None
 
 
+@dataclass(frozen=True)
+class LegacyStateSeed:
+    """The released-shaped general-state row carried through the upgrade."""
+
+    owner_name: str
+    namespace: str
+    key: str
+    value: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class SeedMetadata:
+    """Exact optional rows represented by a rendered seed plan."""
+
+    legacy_state: LegacyStateSeed | None
+
+
 # Three agents, one binding each. The names are prefixed `gate-` so they are
 # unmistakably synthetic, and all three names and all three addresses are
 # distinct so neither the seed nor 0021's backfill can trip
@@ -179,6 +196,16 @@ SEED_FIXTURE: tuple[SeedAgent, ...] = (
         legacy=False,
         approval_route_address=None,
     ),
+)
+
+# One pre-0031 general-state row. Its non-reserved namespace is load-bearing:
+# `memory` and `transcript` are permanently shared reserved state and therefore
+# do not prove that migration 0037 repaired a legacy general-state owner.
+LEGACY_STATE_SEED = LegacyStateSeed(
+    owner_name="gate-valid",
+    namespace="upgrade-gate",
+    key="legacy-shared-state",
+    value={"survived": "released-upgrade"},
 )
 
 
@@ -474,6 +501,7 @@ def _run_readback(
     phase: str,
     ref: str,
     commit: str,
+    seed_metadata: SeedMetadata,
 ) -> CommandResult:
     arguments: list[str] = []
     for agent in SEED_FIXTURE:
@@ -481,6 +509,15 @@ def _run_readback(
         # per agent builds the same two lists a pass per option would.
         arguments.extend(("--expect-agent", agent.name))
         arguments.extend(("--expect-address", agent.address))
+
+    legacy_state = seed_metadata.legacy_state
+    if legacy_state is not None and _candidate_supports_legacy_state(tree):
+        arguments.extend(("--expect-state-owner", legacy_state.owner_name))
+        arguments.extend(("--expect-state-namespace", legacy_state.namespace))
+        arguments.extend(("--expect-state-key", legacy_state.key))
+        arguments.extend(
+            ("--expect-state-value", json.dumps(legacy_state.value, sort_keys=True))
+        )
 
     return _run_in_tree(
         _readback_command(tree, *arguments),
@@ -515,11 +552,12 @@ def _introspect_columns(database_name: str) -> tuple[ColumnInfo, ...]:
         "SELECT table_name, column_name, is_nullable, "
         "coalesce(column_default, '') FROM information_schema.columns "
         "WHERE table_schema = 'curie' "
-        # The two tables the fixture can write. Narrowing here rather than in the
+        # The tables the fixture can write. Narrowing here rather than in the
         # consumers keeps `_verify_mandatory_columns` honest: it only reports a
         # mandatory column for a table the branch actually fills, so every other
         # table's rows were dead weight the caller had to filter back out.
-        "AND table_name IN ('agents', 'agent_channels') "
+        "AND table_name IN "
+        "('agents', 'agent_channels', 'workflow_state_entries') "
         "ORDER BY table_name, ordinal_position",
     )
     columns: list[ColumnInfo] = []
@@ -618,6 +656,18 @@ def _detect_approval_route_era(released_tree: Path) -> str:
     return APPROVAL_ROUTE_ERA_LEGACY
 
 
+def _candidate_supports_legacy_state(candidate_tree: Path) -> bool:
+    """Whether the candidate contains the exact 0037 repair capability.
+
+    Older candidates used by the pinned self-test must never be asked to import
+    or inspect the newer state model. The revision filename is authoritative:
+    an arbitrary filename beginning with ``0037`` is not the repair.
+    """
+
+    versions = candidate_tree / "apps" / "api" / "alembic" / "versions"
+    return any(path.is_file() for path in versions.glob("0037_*.py"))
+
+
 def _route_literal(agent: SeedAgent, era: str) -> str:
     """Render one `agents.approval_routes` value in `era`'s storage shape.
 
@@ -650,8 +700,8 @@ def _plan_seed_statements(
     columns: tuple[ColumnInfo, ...],
     *,
     approval_route_era: str,
-) -> tuple[str, ...]:
-    """Render the SQL that writes `SEED_FIXTURE` into the released schema.
+) -> tuple[tuple[str, ...], SeedMetadata]:
+    """Render released-shaped SQL and exact metadata for optional seeded rows.
 
     Branches on `agents.slack_channel` -- the pre/post-0021 discriminator -- for
     the channel binding, and on `approval_route_era` for the route shape. The two
@@ -698,9 +748,7 @@ def _plan_seed_statements(
                 f"VALUES (gen_random_uuid(), {_sql_literal(agent.name)}, "
                 f"{_sql_literal(agent.address)}, {route})"
             )
-        return tuple(statements)
-
-    if ("agent_channels", "address") in present:
+    elif ("agent_channels", "address") in present:
         _verify_mandatory_columns(
             columns,
             filled={
@@ -734,14 +782,53 @@ def _plan_seed_statements(
                 f"{_sql_literal(agent.kind)}, {_sql_literal(agent.address)}\n"
                 "FROM seeded"
             )
-        return tuple(statements)
+    else:
+        raise GateError(
+            "the released schema has neither agents.slack_channel nor an "
+            "agent_channels.address column, so the seed has nowhere to write a "
+            "channel binding; refusing to run a read-back that would pass "
+            "vacuously"
+        )
 
-    raise GateError(
-        "the released schema has neither agents.slack_channel nor an "
-        "agent_channels.address column, so the seed has nowhere to write a "
-        "channel binding; refusing to run a read-back that would pass "
-        "vacuously"
-    )
+    legacy_state: LegacyStateSeed | None = None
+    if any(table == "workflow_state_entries" for table, _column in present):
+        state_filled = {"id", "agent_id", "namespace", "key", "value"}
+        has_binding_scope = (
+            "workflow_state_entries",
+            "binding_scope",
+        ) in present
+        if has_binding_scope:
+            state_filled.add("binding_scope")
+        _verify_mandatory_columns(
+            columns,
+            filled={"workflow_state_entries": state_filled},
+        )
+
+        legacy_state = LEGACY_STATE_SEED
+        insert_columns = "id, agent_id, namespace, key, value"
+        select_values = (
+            "gen_random_uuid(), id, "
+            f"{_sql_literal(legacy_state.namespace)}, "
+            f"{_sql_literal(legacy_state.key)}, "
+            f"{_json_literal(legacy_state.value)}"
+        )
+        if has_binding_scope:
+            insert_columns = "id, agent_id, binding_scope, namespace, key, value"
+            select_values = (
+                "gen_random_uuid(), id, NULL, "
+                f"{_sql_literal(legacy_state.namespace)}, "
+                f"{_sql_literal(legacy_state.key)}, "
+                f"{_json_literal(legacy_state.value)}"
+            )
+        statements.append(
+            "INSERT INTO curie.workflow_state_entries "
+            f"({insert_columns})\n"
+            f"SELECT {select_values}\n"
+            "FROM curie.agents\n"
+            f"WHERE name = {_sql_literal(legacy_state.owner_name)}"
+        )
+
+    return tuple(statements), SeedMetadata(legacy_state=legacy_state)
 
 
 def _seed_released_database(
@@ -749,7 +836,7 @@ def _seed_released_database(
     *,
     phase: str,
     approval_route_era: str,
-) -> None:
+) -> SeedMetadata:
     """Write the fixture into the released database, between the two upgrades.
 
     Every failure in here is a SETUP fault, not a gate verdict: it raises
@@ -760,9 +847,23 @@ def _seed_released_database(
 
     print(f"=== {phase}: {database_name} ===", flush=True)
     columns = _introspect_columns(database_name)
-    statements = _plan_seed_statements(
+    statements, metadata = _plan_seed_statements(
         columns, approval_route_era=approval_route_era
     )
+    state_capable = any(
+        column.table_name == "workflow_state_entries" for column in columns
+    )
+    state_statement_planned = any(
+        "curie.workflow_state_entries" in statement for statement in statements
+    )
+    if state_capable and (
+        metadata.legacy_state is None or not state_statement_planned
+    ):
+        raise GateError(
+            "the released schema contains workflow_state_entries but the seed "
+            "planner produced no legacy-state sentinel; refusing a vacuous "
+            "released-state upgrade check"
+        )
     # One psql invocation for the whole plan, not one per row. psql runs a
     # multi-statement simple query inside a single implicit transaction, so the
     # fixture now lands whole or not at all -- and a PARTIAL seed is worse than
@@ -772,9 +873,10 @@ def _seed_released_database(
         description=f"seeding the released database {database_name}",
     )
     print(
-        f"Seeded {len(statements)} released-shaped agent rows into "
+        f"Seeded {len(statements)} released-shaped rows into "
         f"{database_name}."
     )
+    return metadata
 
 
 def _upgrade_pair(
@@ -854,7 +956,7 @@ def _upgrade_pair(
     # The route era is detected HERE, from the released tree, and not from the
     # schema the seed introspects: the 0021 and 0034 eras are independent and a
     # released ref can sit between them (#2098).
-    _seed_released_database(
+    seed_metadata = _seed_released_database(
         database_name,
         phase=SEED_PHASE,
         approval_route_era=_detect_approval_route_era(released_tree),
@@ -870,6 +972,7 @@ def _upgrade_pair(
         phase=READBACK_PHASE,
         ref=candidate_ref,
         commit=candidate_commit,
+        seed_metadata=seed_metadata,
     )
     return PairResult(READBACK_PHASE, readback.returncode, readback.output)
 

--- a/scripts/check-released-upgrade.py
+++ b/scripts/check-released-upgrade.py
@@ -511,13 +511,19 @@ def _run_readback(
         arguments.extend(("--expect-address", agent.address))
 
     legacy_state = seed_metadata.legacy_state
-    if legacy_state is not None and _candidate_supports_legacy_state(tree):
-        arguments.extend(("--expect-state-owner", legacy_state.owner_name))
-        arguments.extend(("--expect-state-namespace", legacy_state.namespace))
-        arguments.extend(("--expect-state-key", legacy_state.key))
-        arguments.extend(
-            ("--expect-state-value", json.dumps(legacy_state.value, sort_keys=True))
-        )
+    if _candidate_supports_legacy_state(tree):
+        if legacy_state is None:
+            print(
+                "Skipping released-state sentinel: released schema predates "
+                "workflow_state_entries."
+            )
+        else:
+            arguments.extend(("--expect-state-owner", legacy_state.owner_name))
+            arguments.extend(("--expect-state-namespace", legacy_state.namespace))
+            arguments.extend(("--expect-state-key", legacy_state.key))
+            arguments.extend(
+                ("--expect-state-value", json.dumps(legacy_state.value, sort_keys=True))
+            )
 
     return _run_in_tree(
         _readback_command(tree, *arguments),

--- a/scripts/released_upgrade_readback.py
+++ b/scripts/released_upgrade_readback.py
@@ -25,13 +25,15 @@ Three constraints follow from that inversion, and all three are load-bearing:
    import of a sibling module in `scripts/` would silently mix two versions.
    In particular this file does NOT import `check-released-upgrade.py`; the
    fixture arrives entirely through argv.
-2. **No field name may be hard-coded.** `AgentOut` carries a singular
+2. **No agent-output field name may be hard-coded.** `AgentOut` carries a singular
    `channel: ChannelBinding` at v0.7.3 and a plural
    `channels: list[ChannelBindingOut]` on main, so naming either attribute
    would make the runner work on exactly one side of the fix it is judging.
    ORM rows are loaded and handed whole to `AgentOut.model_validate`, and the
    address expectations are checked by searching the SERIALIZED dump rather
-   than by reading a named field.
+   than by reading a named field. The optional state assertion is different: it
+   is passed only to candidates containing revision 0037, whose exact state
+   fields are the contract being proved.
 3. **It cannot pass vacuously.** Zero agents is a FAILURE. A seed that silently
    wrote nothing, or a migration that silently dropped the seeded rows, is the
    precise failure mode this gate exists to close, so "the read path raised
@@ -77,6 +79,28 @@ class AgentDump:
     addresses: tuple[str, ...]
     dump: dict[str, Any] | None
     error: str | None
+
+
+@dataclass(frozen=True)
+class StateSentinelExpectation:
+    """Identity and exact JSON of the released legacy-state sentinel."""
+
+    owner_name: str
+    namespace: str
+    key: str
+    value: Any
+
+
+@dataclass(frozen=True)
+class StateSentinelObservation:
+    """One candidate state row plus the visibility posture of its owner."""
+
+    owner_name: str
+    binding_scope: str | None
+    namespace: str
+    key: str
+    value: Any
+    owner_memory: bool
 
 
 def _json_strings_under(value: Any, keys: frozenset[str]) -> list[str]:
@@ -177,6 +201,53 @@ async def _load_dumps(database_url: str) -> tuple[AgentDump, ...]:
         await engine.dispose()
 
 
+def _read_state_observations(
+    session: Session,
+    expectation: StateSentinelExpectation,
+) -> tuple[StateSentinelObservation, ...]:
+    """Load every row with the sentinel identity and its owning candidate agent."""
+
+    rows = session.execute(
+        select(models.WorkflowStateEntry, models.Agent)
+        .join(models.Agent, models.WorkflowStateEntry.agent_id == models.Agent.id)
+        .where(
+            models.Agent.name == expectation.owner_name,
+            models.WorkflowStateEntry.namespace == expectation.namespace,
+            models.WorkflowStateEntry.key == expectation.key,
+        )
+        .order_by(models.WorkflowStateEntry.id)
+    ).all()
+    return tuple(
+        StateSentinelObservation(
+            owner_name=agent.name,
+            binding_scope=entry.binding_scope,
+            namespace=entry.namespace,
+            key=entry.key,
+            value=entry.value,
+            owner_memory=agent.memory,
+        )
+        for entry, agent in rows
+    )
+
+
+async def _load_state_observations(
+    database_url: str,
+    expectation: StateSentinelExpectation,
+) -> tuple[StateSentinelObservation, ...]:
+    """Read state only when the caller enabled the revision-0037 expectation."""
+
+    engine = create_async_engine(database_url)
+    try:
+        async with AsyncSession(engine) as session:
+            return await session.run_sync(
+                lambda sync_session: _read_state_observations(
+                    sync_session, expectation
+                )
+            )
+    finally:
+        await engine.dispose()
+
+
 def _rendered_addresses(addresses: tuple[str, ...]) -> str:
     if not addresses:
         return "no address recorded"
@@ -188,6 +259,8 @@ def _collect_failures(
     *,
     expected_agents: tuple[str, ...],
     expected_addresses: tuple[str, ...],
+    state_expectation: StateSentinelExpectation | None = None,
+    state_observations: tuple[StateSentinelObservation, ...] = (),
 ) -> tuple[str, ...]:
     """Judge a set of dumps against the seeded expectations. Empty tuple == pass.
 
@@ -247,6 +320,40 @@ def _collect_failures(
                 "back"
             )
 
+    if state_expectation is not None:
+        matching_state = [
+            observation
+            for observation in state_observations
+            if observation.owner_name == state_expectation.owner_name
+            and observation.namespace == state_expectation.namespace
+            and observation.key == state_expectation.key
+        ]
+        if len(matching_state) != 1:
+            failures.append(
+                "expected exactly one legacy state sentinel for agent "
+                f"{state_expectation.owner_name!r}, namespace "
+                f"{state_expectation.namespace!r}, key "
+                f"{state_expectation.key!r}; found {len(matching_state)}"
+            )
+        else:
+            observation = matching_state[0]
+            if observation.binding_scope is not None:
+                failures.append(
+                    "legacy state sentinel must retain binding_scope NULL, "
+                    f"but found {observation.binding_scope!r}"
+                )
+            if observation.value != state_expectation.value:
+                failures.append(
+                    "legacy state sentinel value changed during the upgrade: "
+                    f"expected {json.dumps(state_expectation.value, sort_keys=True)}, "
+                    f"found {json.dumps(observation.value, sort_keys=True)}"
+                )
+            if observation.owner_memory is not True:
+                failures.append(
+                    "legacy state sentinel owner must have memory true after "
+                    "the upgrade so runners select the shared state identity"
+                )
+
     return tuple(failures)
 
 
@@ -274,6 +381,26 @@ def main() -> int:
         metavar="ADDRESS",
         help="A channel address that must survive into the serialized agent.",
     )
+    parser.add_argument(
+        "--expect-state-owner",
+        metavar="NAME",
+        help="Agent owning the optional released legacy-state sentinel.",
+    )
+    parser.add_argument(
+        "--expect-state-namespace",
+        metavar="NAMESPACE",
+        help="Namespace of the optional released legacy-state sentinel.",
+    )
+    parser.add_argument(
+        "--expect-state-key",
+        metavar="KEY",
+        help="Key of the optional released legacy-state sentinel.",
+    )
+    parser.add_argument(
+        "--expect-state-value",
+        metavar="JSON",
+        help="Exact JSON value of the optional released legacy-state sentinel.",
+    )
     args = parser.parse_args()
 
     database_url = os.environ.get("DATABASE_URL", "")
@@ -291,6 +418,40 @@ def main() -> int:
         )
         return 1
 
+    state_parts = (
+        args.expect_state_owner,
+        args.expect_state_namespace,
+        args.expect_state_key,
+        args.expect_state_value,
+    )
+    if any(part is not None for part in state_parts) and not all(
+        part is not None for part in state_parts
+    ):
+        print(
+            "read-back state expectation requires all of "
+            "--expect-state-owner, --expect-state-namespace, "
+            "--expect-state-key, and --expect-state-value",
+            file=sys.stderr,
+        )
+        return 1
+
+    state_expectation: StateSentinelExpectation | None = None
+    if all(part is not None for part in state_parts):
+        try:
+            expected_state_value = json.loads(args.expect_state_value)
+        except json.JSONDecodeError as exc:
+            print(
+                f"read-back --expect-state-value is not valid JSON: {exc}",
+                file=sys.stderr,
+            )
+            return 1
+        state_expectation = StateSentinelExpectation(
+            owner_name=args.expect_state_owner,
+            namespace=args.expect_state_namespace,
+            key=args.expect_state_key,
+            value=expected_state_value,
+        )
+
     dumps = asyncio.run(_load_dumps(database_url))
     for dump in dumps:
         status = "failed" if dump.error is not None else "loaded"
@@ -299,10 +460,26 @@ def main() -> int:
             f"{status}"
         )
 
+    state_observations: tuple[StateSentinelObservation, ...] = ()
+    if state_expectation is not None:
+        state_observations = asyncio.run(
+            _load_state_observations(database_url, state_expectation)
+        )
+        for observation in state_observations:
+            print(
+                "read-back: state sentinel candidate for agent "
+                f"{observation.owner_name!r}, namespace "
+                f"{observation.namespace!r}, key {observation.key!r}, "
+                f"binding_scope {observation.binding_scope!r}, memory "
+                f"{observation.owner_memory!r}"
+            )
+
     failures = _collect_failures(
         dumps,
         expected_agents=tuple(args.expect_agent),
         expected_addresses=tuple(args.expect_address),
+        state_expectation=state_expectation,
+        state_observations=state_observations,
     )
     if failures:
         print("Released upgrade read-back failed:")


### PR DESCRIPTION
## Summary

Preserves legacy NULL-scoped general state during the multi-binding upgrade by restoring its owner to shared-memory routing, and recreates the state identity constraint with PostgreSQL `NULLS NOT DISTINCT` so concurrent shared-state creation cannot duplicate. The released-upgrade gate now proves the legacy row survives both before and after revision 0037 becomes part of a stable release. Operator preflight and PostgreSQL 15 guidance are included.

## Related issue

Closes #1901

## Fix pin verification

Fix pin: apps/api/tests/test_state.py::test_concurrent_initial_shared_state_creation_is_database_unique

## End-to-end verification

| Tier | Required / n/a | Reason | Mode | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | No plugin, runner-loop, ACI, eval, or check surface. | fake | n/a |
| local | required, blocked | API/worker routing and PostgreSQL identity are reached. | fake | `curie dev verify-fix-pin 5e9d6eec apps/api/tests/test_migration_0037_multibinding_state_identity.py::test_legacy_state_runner_url_and_value_survive_upgrade` and the shared-race selector both reported `PINNED`: candidate `32aeddec` passed and reversed product code failed. `CURIE_E2E_TIERS=local curie dev e2e-ladder` exited 1 during `curie-migrate`; the host's hard-coded `curie` Compose project is owned by another session and cannot be wiped or torn down safely. |
| local-release | required, blocked on generic ladder | Released data and candidate migration behavior changed. | fake | `uv run python scripts/check-released-upgrade.py` passed from published v0.8.0 (`9d7055a5`) to candidate `32aeddec`; readback found one NULL-scoped sentinel with exact value and `memory=True`. The generic `CURIE_E2E_TIERS=local-release` rung intentionally runs `local down --wipe` on the occupied shared project, so it was not run. |
| cluster | n/a | No chart, RBAC, security context, policy, claim, or init-container change. | fake | n/a |
| live provider | n/a | No model routing, credentials, token, or cost surface. | live | n/a |
| external integration | n/a | No Slack, webhook, OAuth, connector, or third-party API shape. | live | n/a |

- [ ] Every required tier is proved by its mandated parity-ladder command. Blocked by the occupied shared `curie` Compose project; do not wipe another session's volumes.
- [x] Each acceptance criterion has positive proof plus a falsifiable negative or second path: both fix pins pass candidate/fail reversed code; migration refusal controls execute; released readback is independent.
- [x] Blocked tiers name their exact blocker above.

Before merge, re-fetch `main` and rerun `uv run python scripts/check-alembic-revisions.py`; a competing `0037` is a blocker and this migration must be re-parented/renumbered with its exact capability tests updated.

## Evidence

- Alembic revision gate: head `0037`.
- Affected real-Postgres/API/worker suite: `130 passed`.
- Released-upgrade self-test: all 3 pinned historical directions passed.
- Published release upgrade: v0.8.0 -> `32aeddec` passed with exact shared-state readback.
- Ruff passed; mypy passed for 240 source files; docs gate passed.
- Independent Code review: no blocking findings. Independent Scope review: pass.

## `/implement` done-check

- [x] Failing tests were committed before implementation (`14492a3d`).
- [x] Production edits were made by delegated native implementers/fixers; reviewers were read-only.
- [x] No public return type was broadened; callers of extended optional keyword signatures were updated and covered.
- [x] Agent-router Code Reviewer completed with file:line evidence and no blocking findings.
- [x] Agent-router Scope Reviewer mapped the complete diff and passed it.
- [x] Sibling paths were enumerated in the plan; reserved/general NULL identities and distinct non-NULL scopes are covered.
- [x] Guards were executed: duplicate/mixed migration refusals roll back; both fix pins fail with product hunks reversed.
- [x] Consolidation ran and applied no edits.
- [x] Security review n/a: no auth, secrets, PII, payment, or tenant-boundary surface.
- [x] Observable behavior proved: legacy bound URL 404s before repair and exact shared value reads after repair.
- [ ] Generic deployed parity ladders are blocked by the occupied hard-coded Compose project; change-specific real-Postgres and published-release checks passed.
- [x] Full affected suite, typing, lint, revision, release self-test, and docs checks pass.

## Checklist

- [x] Tests pass for the area touched.
- [x] Docs updated for the migration and PostgreSQL requirement.
- [x] ADR not required; this repairs the existing multi-binding contract rather than introducing a new architecture decision.
