### PR TITLE
Tell the bot what it is running on, and let it read what version is available

### DIFF
--- a/examples/sre-bot/connectors.yaml
+++ b/examples/sre-bot/connectors.yaml
@@ -23,7 +23,9 @@
 #                           subresource-scoped identity. Same shape as
 #                           k8s-write: no K8S_SCALE_KUBECONFIG, no scale path.
 #   self-upgrade  DECLARED. One gated verb that starts this bot's own upgrade,
-#                           so it happens when asked rather than on a schedule.
+#                           so it happens when asked rather than on a schedule,
+#                           plus an ungated read saying which version is
+#                           available to upgrade to.
 #                           Needs SELF_UPGRADE_KUBECONFIG and the CronJob it
 #                           starts. Read manifests/upgrade-role.yaml first: its
 #                           grant is the widest in this bundle.
@@ -296,6 +298,16 @@ connectors:
       # its own ServiceAccount namespace, which is the same place -- stated here
       # so a cross-namespace install does not silently look in the wrong one.
       SELF_UPGRADE_NAMESPACE: ""
+      # Which project's published releases answer "what version is available".
+      # A public, read-only lookup with NO credential -- the connector holds none
+      # for it on purpose. Empty disables that tool's answer rather than guessing.
+      #
+      # This is what closes the question the sandbox cannot answer for itself:
+      # the runner has no general internet egress (deliberately -- it is
+      # prompt-injectable), so a direct fetch of a releases page is refused at
+      # the network. Connector pods do have egress, so the read happens here and
+      # the sandbox still learns only a URL.
+      SELF_UPGRADE_RELEASE_REPO: curie-eng/curie
     # A FOURTH kubeconfig, bound to the ServiceAccount in
     # manifests/upgrade-role.yaml. Never one of the other three: those are
     # scoped to the workloads this bot may touch, and this one is scoped to the

--- a/examples/sre-bot/connectors/self-upgrade/server.py
+++ b/examples/sre-bot/connectors/self-upgrade/server.py
@@ -1,4 +1,7 @@
-"""A write connector that can do exactly one thing: start this bot's upgrade.
+"""One gated write -- start this bot's upgrade -- and one read beside it.
+
+`upgrade_self` starts the upgrade. `latest_release` says what version is
+available to upgrade TO. Both take no arguments.
 
 Why the bot cannot just do the upgrade itself
 ---------------------------------------------
@@ -18,11 +21,24 @@ Why a separate server, and why zero arguments
 ----------------------------------------------
 `k8s-write`'s docstring is the standing argument: it exposes ONE tool, so there
 is no second thing for a gate to miss, and "there is no parameter through which a
-caller could reach an image, an env var, a command". This tool goes one step
+caller could reach an image, an env var, a command". `upgrade_self` goes one step
 further and takes NO arguments at all. The repository, the branch, the agent
 name, the image and the command all come from the CronJob's own `jobTemplate`,
 read from the cluster at call time. There is no field a caller can influence, so
 there is nothing to validate and nothing to escape.
+
+There are now two tools here, and the "one thing for a gate to miss" argument
+still holds, because the second one is a READ. `latest_release` takes no
+arguments either, holds no credential, and changes nothing; there is exactly one
+write on this server and exactly one gate in front of it. What would break the
+argument is a second WRITE, or either tool growing a parameter -- not a
+zero-argument read of a public page.
+
+It lives here rather than in its own connector because it answers the same
+question from the other side. "What version is available" is what a person asks
+immediately before "can we upgrade", and splitting them across two images, two
+publish jobs and two declarations buys separation between a read and a write
+that share a repository, a domain, and no credential at all.
 
 The grant RBAC cannot narrow, and what stands in for it
 --------------------------------------------------------
@@ -84,6 +100,13 @@ CRONJOB = os.environ.get("SELF_UPGRADE_CRONJOB", "").strip()
 # this defaults to the one the ServiceAccount is bound to when set.
 NAMESPACE = os.environ.get("SELF_UPGRADE_NAMESPACE", "").strip()
 
+# The repository whose published releases answer "what is the newest version".
+# Read-only and public: no credential, and none is added here on purpose -- see
+# `latest_release`. Empty disables that tool's answer rather than guessing a repo.
+RELEASE_REPO = os.environ.get("SELF_UPGRADE_RELEASE_REPO", "").strip()
+RELEASE_API = os.environ.get("SELF_UPGRADE_RELEASE_API", "https://api.github.com").rstrip("/")
+RELEASE_TIMEOUT = float(os.environ.get("SELF_UPGRADE_RELEASE_TIMEOUT_SECONDS", "15"))
+
 mcp = FastMCP(
     "self-upgrade",
     host=os.environ.get("BIND_ADDRESS", "0.0.0.0"),
@@ -96,6 +119,15 @@ mcp = FastMCP(
 # destructiveHint=True: it replaces the running bot with a different build of
 # itself. idempotentHint=False: calling it twice starts two upgrades, which is
 # exactly what the active-Job check below exists to prevent.
+# A read. Its own annotation rather than reusing UPGRADE, because a client that
+# filters on readOnlyHint must be able to tell these two apart.
+READ = ToolAnnotations(
+    readOnlyHint=True,
+    destructiveHint=False,
+    idempotentHint=True,
+    openWorldHint=True,
+)
+
 UPGRADE = ToolAnnotations(
     readOnlyHint=False,
     destructiveHint=True,
@@ -371,6 +403,130 @@ def upgrade_self() -> str:
         prior=None,
         post={"job": name},
         target={"kind": "Job", "namespace": namespace, "name": name},
+    )
+
+
+@mcp.tool(annotations=READ)
+def latest_release() -> str:
+    """The newest published release of the platform this bot runs on.
+
+    Answers "what is the latest available version" -- the question a person asks
+    right before "can we upgrade". It reads the repository's published releases
+    and reports the newest tag; it changes nothing and needs no approval.
+
+    THIS IS NOT WHAT THIS BOT IS RUNNING. The installed platform version is a
+    property of the cluster, readable from `app.kubernetes.io/version` on the
+    platform's own objects with the read-only Kubernetes tools. Report both and
+    say which is which; a newer tag here does not mean anything was upgraded.
+
+    Nor is it your own bundle's version, which moves independently.
+
+    The reply is a JSON object: `ok`, `summary`, and `latest` (tag, name, url,
+    published_at) when the read succeeded.
+    """
+
+    if not RELEASE_REPO:
+        return json.dumps(
+            {
+                "ok": False,
+                "summary": (
+                    "refusing: SELF_UPGRADE_RELEASE_REPO is not set, so this "
+                    "connector does not know which project's releases to read. "
+                    "Setting it is an operator change."
+                ),
+                "latest": None,
+            },
+            sort_keys=True,
+        )
+
+    url = f"{RELEASE_API}/repos/{RELEASE_REPO}/releases/latest"
+    try:
+        # No credential, deliberately. A public repository needs none, and a
+        # token here would put a credential in a connector whose whole job is to
+        # answer one read -- the thing the read-only Kubernetes connector drops
+        # `configuration_view` to avoid. The cost is GitHub's unauthenticated
+        # rate limit, which a question asked a few times a day does not reach.
+        with httpx.Client(timeout=RELEASE_TIMEOUT) as client:
+            response = client.get(
+                url,
+                headers={
+                    "Accept": "application/vnd.github+json",
+                    "User-Agent": "curie-sre-bot-self-upgrade",
+                },
+            )
+    except httpx.HTTPError as exc:
+        return json.dumps(
+            {
+                "ok": False,
+                "summary": f"could not reach {RELEASE_API}: {exc}",
+                "latest": None,
+            },
+            sort_keys=True,
+        )
+
+    if response.status_code == 404:
+        return json.dumps(
+            {
+                "ok": False,
+                "summary": (
+                    f"{RELEASE_REPO} has no published releases, or is not visible "
+                    "without a credential this connector deliberately does not hold."
+                ),
+                "latest": None,
+            },
+            sort_keys=True,
+        )
+    if response.status_code == 403:
+        return json.dumps(
+            {
+                "ok": False,
+                "summary": (
+                    "the releases API refused this read (403). Unauthenticated "
+                    "rate limits are the usual cause; it clears on its own."
+                ),
+                "latest": None,
+            },
+            sort_keys=True,
+        )
+    if response.status_code >= 400:
+        return json.dumps(
+            {
+                "ok": False,
+                "summary": f"the releases API returned HTTP {response.status_code}",
+                "latest": None,
+            },
+            sort_keys=True,
+        )
+
+    try:
+        payload = response.json()
+        tag = payload["tag_name"]
+    except (ValueError, KeyError, TypeError):
+        return json.dumps(
+            {
+                "ok": False,
+                "summary": "the releases API returned a body with no tag_name",
+                "latest": None,
+            },
+            sort_keys=True,
+        )
+
+    return json.dumps(
+        {
+            "ok": True,
+            "summary": (
+                f"the newest published release of {RELEASE_REPO} is {tag}. This is "
+                "what is available, NOT what this install is running -- read the "
+                "installed version from the platform's own Kubernetes objects."
+            ),
+            "latest": {
+                "tag": tag,
+                "name": payload.get("name"),
+                "url": payload.get("html_url"),
+                "published_at": payload.get("published_at"),
+            },
+        },
+        sort_keys=True,
     )
 
 

--- a/examples/sre-bot/connectors/self-upgrade/test_server.py
+++ b/examples/sre-bot/connectors/self-upgrade/test_server.py
@@ -21,6 +21,7 @@ import os
 import sys
 from pathlib import Path
 
+import httpx
 import pytest
 import yaml
 
@@ -55,12 +56,19 @@ JOB_TEMPLATE = {
 }
 
 
-def _load(tmp_path, kubeconfig=GOOD_KUBECONFIG, cronjob="sre-bot-self-upgrade"):
+def _load(
+    tmp_path,
+    kubeconfig=GOOD_KUBECONFIG,
+    cronjob="sre-bot-self-upgrade",
+    release_repo="curie-eng/curie",
+):
     cfg = tmp_path / "kubeconfig"
     cfg.write_text(yaml.safe_dump(kubeconfig), encoding="utf-8")
     os.environ["KUBECONFIG_PATH"] = str(cfg)
     os.environ["SELF_UPGRADE_CRONJOB"] = cronjob
     os.environ["SELF_UPGRADE_NAMESPACE"] = "curie"
+    os.environ["SELF_UPGRADE_RELEASE_REPO"] = release_repo
+    os.environ["SELF_UPGRADE_RELEASE_API"] = "https://api.github.test"
     sys.modules.pop(_MODULE_NAME, None)
     spec = importlib.util.spec_from_file_location(_MODULE_NAME, _SERVER_PY)
     module = importlib.util.module_from_spec(spec)
@@ -280,8 +288,6 @@ def test_the_fake_client_cannot_accept_a_call_the_real_one_rejects():
     fake from quietly drifting looser than the client it stands in for.
     """
 
-    import httpx
-
     for method in ("get", "post"):
         real = inspect.signature(getattr(httpx.Client, method)).parameters
         fake = inspect.signature(getattr(_FakeClient, method)).parameters
@@ -290,3 +296,116 @@ def test_the_fake_client_cannot_accept_a_call_the_real_one_rejects():
             assert name in real, f"_FakeClient.{method} accepts {name!r}, httpx does not"
             assert param.kind is inspect.Parameter.KEYWORD_ONLY
             assert real[name].kind is inspect.Parameter.KEYWORD_ONLY
+
+
+# --- latest_release -------------------------------------------------------
+#
+# These keep the REAL httpx.Client and swap only its transport, for the reason
+# the sibling scale connector had to learn the hard way (#1947): a hand-written
+# double accepted a call the real client rejects, and every test passed while the
+# tool could never run.
+
+RELEASE_BODY = {
+    "tag_name": "v0.8.1",
+    "name": "v0.8.1",
+    "html_url": "https://github.test/curie-eng/curie/releases/tag/v0.8.1",
+    "published_at": "2026-08-30T20:40:35Z",
+}
+
+
+def _with_release_response(srv, monkeypatch, status=200, body=RELEASE_BODY, seen=None):
+    """Point the module's httpx at a mock transport, keeping the real client."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if seen is not None:
+            seen["request"] = request
+        return httpx.Response(status, json=body)
+
+    real_client = httpx.Client
+
+    def factory(*args, **kwargs):
+        kwargs["transport"] = httpx.MockTransport(handler)
+        return real_client(*args, **kwargs)
+
+    monkeypatch.setattr(srv.httpx, "Client", factory)
+
+
+def test_it_reports_the_newest_published_tag(tmp_path, monkeypatch):
+    srv = _load(tmp_path)
+    _with_release_response(srv, monkeypatch)
+    result = json.loads(srv.latest_release())
+    assert result["ok"] is True
+    assert result["latest"]["tag"] == "v0.8.1"
+    assert result["latest"]["published_at"] == "2026-08-30T20:40:35Z"
+
+
+def test_the_summary_says_this_is_not_what_is_installed(tmp_path, monkeypatch):
+    """The exact confusion this tool exists next to, so it is pinned.
+
+    A bot that reports the newest tag as its own version is worse than one that
+    cannot answer: the installed version is a property of the cluster and this
+    number is a property of a repository, and they are routinely different.
+    """
+    srv = _load(tmp_path)
+    _with_release_response(srv, monkeypatch)
+    summary = json.loads(srv.latest_release())["summary"]
+    assert "NOT what this install is running" in summary
+
+
+def test_it_sends_no_credential(tmp_path, monkeypatch):
+    """A connector whose whole job is one public read must not hold a token."""
+    srv = _load(tmp_path)
+    seen = {}
+    _with_release_response(srv, monkeypatch, seen=seen)
+    srv.latest_release()
+    assert "authorization" not in {k.lower() for k in seen["request"].headers}
+
+
+def test_it_asks_the_configured_repository(tmp_path, monkeypatch):
+    srv = _load(tmp_path, release_repo="acme/widget")
+    seen = {}
+    _with_release_response(srv, monkeypatch, seen=seen)
+    srv.latest_release()
+    assert seen["request"].url.path == "/repos/acme/widget/releases/latest"
+
+
+def test_the_tool_exposes_no_parameters(tmp_path):
+    srv = _load(tmp_path)
+    assert inspect.signature(srv.latest_release).parameters == {}
+
+
+def test_it_is_annotated_as_a_read(tmp_path):
+    srv = _load(tmp_path)
+    assert srv.READ.readOnlyHint is True
+    assert srv.READ.destructiveHint is False
+
+
+def test_an_unset_repository_refuses_without_a_network_call(tmp_path, monkeypatch):
+    srv = _load(tmp_path, release_repo="")
+    seen = {}
+    _with_release_response(srv, monkeypatch, seen=seen)
+    result = json.loads(srv.latest_release())
+    assert result["ok"] is False
+    assert result["latest"] is None
+    assert seen == {}
+
+
+@pytest.mark.parametrize(
+    "status,expected",
+    [(404, "no published releases"), (403, "rate limits"), (500, "HTTP 500")],
+)
+def test_failures_explain_themselves(tmp_path, monkeypatch, status, expected):
+    srv = _load(tmp_path)
+    _with_release_response(srv, monkeypatch, status=status, body={})
+    result = json.loads(srv.latest_release())
+    assert result["ok"] is False
+    assert result["latest"] is None
+    assert expected in result["summary"]
+
+
+def test_a_body_with_no_tag_is_reported_not_guessed(tmp_path, monkeypatch):
+    srv = _load(tmp_path)
+    _with_release_response(srv, monkeypatch, body={"name": "no tag here"})
+    result = json.loads(srv.latest_release())
+    assert result["ok"] is False
+    assert "no tag_name" in result["summary"]

--- a/examples/sre-bot/skills/sre-bot/SKILL.md
+++ b/examples/sre-bot/skills/sre-bot/SKILL.md
@@ -11,6 +11,47 @@ which datasource holds what. They will ask things like "is anything broken?"
 or "why is checkout slow?". Your job is to turn that into the right queries,
 then answer in plain language.
 
+## What you are running on
+
+You are an agent deployed on **Curie**: a self-hostable platform that runs
+Claude Code-style agents against a team's own infrastructure. It is where your
+bundle, your connectors and your approval gates come from, and it is what put
+this Kubernetes cluster in front of you.
+
+**Curie here is the platform, not the OpenAI model.** There was a GPT-3-era
+completion model called `curie`, long retired, and it has nothing to do with
+this. Someone asking "what version of Curie are you on" is asking about the
+platform you are deployed on. Answer that question; do not volunteer a history
+of a deprecated model.
+
+### Two version numbers, and they are not the same
+
+| | What it is | Where to read it |
+|---|---|---|
+| **Platform version** | The Curie release this install runs | `app.kubernetes.io/version` / `helm.sh/chart` on the platform's own objects (api, dispatcher, worker), via `resources_get` or `resources_list` |
+| **Your bundle version** | The agent bundle *you* are, deployed from its repository | your own agent version, which the platform tracks; the platform's objects do not carry it |
+
+They move independently. A newer platform does not update you, and upgrading
+yourself does not touch the platform.
+
+### What you can and cannot upgrade
+
+- **Yourself: yes, if `upgrade_self` is on your tool list.** It redeploys your
+  own bundle from its repository. It takes no version argument -- it deploys
+  whatever the operator's job template considers newest -- and it is gated, so a
+  human approves before anything happens.
+- **The platform: no.** Moving the Curie release from one version to another is
+  a Helm operation across every object the release owns, and you have no tool
+  for it by design. Say so plainly and hand over what a human would run; do not
+  imply `upgrade_self` covers it.
+
+If `latest_release` is on your tool list, use it to say what the newest published
+Curie release is. Without it you cannot know: **your sandbox has no general
+internet egress**, so a direct fetch of a project page fails at the network
+rather than returning a 404. Search tools may still work, because they run
+server-side rather than from this pod -- so "search found the project but fetch
+was refused" is the expected shape here, not a fault to investigate.
+
 ## When to run
 
 Anyone asks whether the system is healthy, what broke, what changed, what an


### PR DESCRIPTION
Asked *"what version of Curie are you on and what's the latest available"*, the deployed bot answered that it is **not** running on Curie, that Curie was an OpenAI GPT-3 completion model retired years ago, and offered to talk about Claude instead. It took two corrections in the thread before it accepted the premise.

## It was not confabulating

`SKILL.md` mentions "curie" exactly once — inside the tool name `mcp__curie__request_approval`. Nothing in the bundle says what platform the bot is deployed on, so the only Curie in its context was the model.

Everything *after* the correction was right: it read `0.7.2` off the platform's own Kubernetes objects, separated its own bundle version from the platform's, correctly said `upgrade_self` cannot move the platform, and handed over what a human would run instead. The gap was the premise, not the reasoning.

## Two changes

**1. `SKILL.md` gains a "What you are running on" section.**

Names the platform. Says plainly it is not the OpenAI model of the same name. Gives the two version numbers and where each is read:

| | What it is | Where |
|---|---|---|
| Platform version | the Curie release this install runs | `app.kubernetes.io/version` on the platform's objects |
| Bundle version | the agent bundle it *is* | tracked by the platform, not on those objects |

And states what it can and cannot upgrade — itself yes, the platform no, and not to imply otherwise.

It also names the network shape, because the bot inferred it live and got it right in a way worth writing down: **search tools work and direct fetches are refused**, since search runs server-side while a fetch leaves the pod, and the sandbox has no general internet egress. "Search found it, fetch was refused" is the expected shape here, not a fault to investigate.

**2. `latest_release` answers the half it could not.**

A second tool on the self-upgrade connector: zero arguments, read-only, no credential. Connector pods have egress where the sandbox deliberately does not, so the read happens there and the sandbox still learns only a URL.

The *"ONE tool, so there is no second thing for a gate to miss"* argument survives, because the second tool is a **read**. There is still exactly one write here and exactly one gate in front of it. What would break the argument is a second write, or either tool growing a parameter — not a zero-argument read of a public page.

Its reply says, in the summary the model actually reads, that the tag is what is *available* and **NOT** what is installed. A test pins that string: a bot reporting the newest tag as its own version is worse than one that cannot answer.

## Verification

- `examples/tests/` → 85 passed; connector tests → 29 passed; `ruff` clean.
- Confirmed on the live install that a connector pod reaches `api.github.com` and returns the current tag, while the sandbox's own egress allows exactly one internet destination.
- Tests keep the real `httpx` client and swap only the transport, per #1947.

## Not in this PR

Moving the **platform** between versions still has no tool, by design — `docs/PERMISSION-MAP.md` entry 4 explains why, and that has not changed here.