### PR TITLE
Correct what is actually missing before a platform-upgrade workflow

### DIFF
--- a/examples/sre-bot/docs/PERMISSION-MAP.md
+++ b/examples/sre-bot/docs/PERMISSION-MAP.md
@@ -315,9 +315,21 @@ read as if it had.
 ### Prerequisite, stated rather than worked around
 
 Curie today has approval-required gates and **allow-by-omission**: a published
-tool no gate names is callable, and nothing reports the omission. There is no
-builder-owned deny / approval-required / allow contract with unclassified
-denied by default.
+tool no gate names is callable, and nothing reports the omission.
+
+The builder-owned deny / approval-required / allow contract now EXISTS as a
+bundle format -- `toolPolicy` in `plugin-format`, with class precedence
+(`deny` > `approvalRequired` > `allow`), a versioned `enforcement`
+discriminator, and a docstring stating that a tool no collection matches is
+denied. What is missing is the wiring: nothing outside that package calls
+`classify_tool`, the runner has no reference to it, and the only bundle
+declaring one is a test fixture (curie#2119).
+
+So the prerequisite is half built, and the half that is missing is the half
+that binds. Until something applies the classification where tools are offered
+to the model, the live behaviour is still allow-by-omission and the paragraph
+below still holds -- but the remaining work is wiring an existing contract,
+not designing one.
 
 For entry 1 that gap is survivable, because a repository lint can compare a
 small set of source-carried connectors against the declared gates. For this


### PR DESCRIPTION
`PERMISSION-MAP.md` entry 4 names the prerequisite blocking the platform-upgrade workflow it proposes:

> There is no builder-owned deny / approval-required / allow contract with unclassified denied by default.

**Half of that is no longer true.** `toolPolicy` exists in `plugin-format` with class precedence (`deny` > `approvalRequired` > `allow`), a versioned `enforcement` discriminator, and a docstring stating an unmatched tool is denied.

What does not exist is anything that applies it — `classify_tool` has no caller outside its own package, the runner has no reference to it, and the only bundle declaring one is a test fixture. Filed separately as #2119.

The entry's **conclusion is unchanged**: live behaviour is still allow-by-omission, so a general-purpose Helm connector still should not ship. What changes is the size of the remaining work. Someone reading this entry today would go design a contract that is already designed and validated, and miss that what it needs is wiring.

Doc-only.