### PR TITLE
Let the bot start a platform upgrade, without ever holding the credential for one

### DIFF
--- a/cli/src/examples.rs
+++ b/cli/src/examples.rs
@@ -49,6 +49,10 @@ const WRITE_ALLOWLIST_ENV: &str = "K8S_WRITE_ALLOWLIST";
 const WRITE_GATE: &str = "mcp__k8s-write__restart_deployment";
 const SCALE_GATE: &str = "mcp__k8s-scale__scale_deployment";
 const UPGRADE_GATE: &str = "mcp__self-upgrade__upgrade_self";
+// The platform-upgrade verb. Stripped like the others on a read-only install:
+// its Job, its identity and its CronJob are all absent by default, so shipping
+// the gate without them would validate and never fire.
+const PLATFORM_UPGRADE_GATE: &str = "mcp__self-upgrade__upgrade_platform";
 // The one grant the write path may carry. Read from the shipped manifest and
 // asserted rather than assumed, so editing that file to widen the verb set stops
 // the install instead of shipping in it -- the same posture the connector and
@@ -1837,7 +1841,8 @@ fn runtime_plugin_manifest(source: &[u8], write_enabled: bool) -> Result<Vec<u8>
         "gates": [
             {"gate": WRITE_GATE, "route": "sre-approvals"},
             {"gate": SCALE_GATE, "route": "sre-approvals"},
-            {"gate": UPGRADE_GATE, "route": "sre-approvals"}
+            {"gate": UPGRADE_GATE, "route": "sre-approvals"},
+            {"gate": PLATFORM_UPGRADE_GATE, "route": "sre-approvals"}
         ]
     });
     if manifest.get("approvalPolicy") != Some(&expected_policy) {

--- a/examples/sre-bot/.claude-plugin/plugin.json
+++ b/examples/sre-bot/.claude-plugin/plugin.json
@@ -42,6 +42,10 @@
       {
         "gate": "mcp__self-upgrade__upgrade_self",
         "route": "sre-approvals"
+      },
+      {
+        "gate": "mcp__self-upgrade__upgrade_platform",
+        "route": "sre-approvals"
       }
     ]
   }

--- a/examples/sre-bot/connectors.yaml
+++ b/examples/sre-bot/connectors.yaml
@@ -308,6 +308,11 @@ connectors:
       # the network. Connector pods do have egress, so the read happens here and
       # the sandbox still learns only a URL.
       SELF_UPGRADE_RELEASE_REPO: curie-eng/curie
+      # The CronJob that upgrades the PLATFORM, as distinct from this bot's own
+      # bundle. EMPTY BY DEFAULT AND MEANT TO STAY THAT WAY unless you have read
+      # manifests/platform-upgrade-role.yaml and accepted the credential it
+      # describes. Empty means `upgrade_platform` refuses every call.
+      PLATFORM_UPGRADE_CRONJOB: ""
     # A FOURTH kubeconfig, bound to the ServiceAccount in
     # manifests/upgrade-role.yaml. Never one of the other three: those are
     # scoped to the workloads this bot may touch, and this one is scoped to the

--- a/examples/sre-bot/connectors/self-upgrade/server.py
+++ b/examples/sre-bot/connectors/self-upgrade/server.py
@@ -1,7 +1,11 @@
-"""One gated write -- start this bot's upgrade -- and one read beside it.
+"""Two gated upgrade buttons and one read. None of them takes an argument.
 
-`upgrade_self` starts the upgrade. `latest_release` says what version is
-available to upgrade TO. Both take no arguments.
+`upgrade_self` redeploys this bot's own bundle. `upgrade_platform` moves the
+Curie release underneath it. `latest_release` says what version is available.
+
+The two writes are the same mechanism pointed at different operator-written
+CronJob templates, which is why they share `_start_job_from` rather than being
+two files kept in step.
 
 Why the bot cannot just do the upgrade itself
 ---------------------------------------------
@@ -27,12 +31,16 @@ name, the image and the command all come from the CronJob's own `jobTemplate`,
 read from the cluster at call time. There is no field a caller can influence, so
 there is nothing to validate and nothing to escape.
 
-There are now two tools here, and the "one thing for a gate to miss" argument
-still holds, because the second one is a READ. `latest_release` takes no
-arguments either, holds no credential, and changes nothing; there is exactly one
-write on this server and exactly one gate in front of it. What would break the
-argument is a second WRITE, or either tool growing a parameter -- not a
-zero-argument read of a public page.
+There are three tools here now, and the "nothing for a gate to miss" argument
+holds differently than it did with one. Both writes are gated, and both are
+zero-argument buttons that copy a template verbatim -- so the property that
+matters is not the COUNT of tools but that no tool takes caller input. A gate
+cannot be missed here because there is no unclassified verb: two writes, two
+gates, one read that changes nothing and holds no credential.
+
+What would break it is a tool growing a parameter. That is the line, and it is
+worth restating because the obvious next request -- "let me name the version" --
+is exactly that.
 
 It lives here rather than in its own connector because it answers the same
 question from the other side. "What version is available" is what a person asks
@@ -104,6 +112,11 @@ NAMESPACE = os.environ.get("SELF_UPGRADE_NAMESPACE", "").strip()
 # Read-only and public: no credential, and none is added here on purpose -- see
 # `latest_release`. Empty disables that tool's answer rather than guessing a repo.
 RELEASE_REPO = os.environ.get("SELF_UPGRADE_RELEASE_REPO", "").strip()
+
+# The CronJob that upgrades the PLATFORM, as distinct from this bot's bundle.
+# Empty means `upgrade_platform` refuses -- an install that has not decided to
+# grant a platform upgrade should not get one by default.
+PLATFORM_CRONJOB = os.environ.get("PLATFORM_UPGRADE_CRONJOB", "").strip()
 RELEASE_API = os.environ.get("SELF_UPGRADE_RELEASE_API", "https://api.github.com").rstrip("/")
 RELEASE_TIMEOUT = float(os.environ.get("SELF_UPGRADE_RELEASE_TIMEOUT_SECONDS", "15"))
 
@@ -224,8 +237,13 @@ def _namespace() -> str:
         return ""
 
 
-def _active_job(client, namespace: str) -> str | None:
-    """The name of a still-running Job for this CronJob, if there is one.
+def _active_job(client, namespace: str, cronjob: str) -> str | None:
+    """The name of a still-running Job for `cronjob`, if there is one.
+
+    Scoped to the named CronJob, not to this connector: the two upgrade verbs run
+    different templates and must not block one another. A platform upgrade and a
+    bundle redeploy are independent, and treating either as "an upgrade is
+    running" would refuse a call that is safe.
 
     Returns None when nothing is active. A listing failure also returns None:
     refusing to upgrade because a *status* read failed would be a worse outcome
@@ -235,7 +253,7 @@ def _active_job(client, namespace: str) -> str | None:
     try:
         listed = client.get(
             f"/apis/batch/v1/namespaces/{namespace}/jobs",
-            params={"labelSelector": f"curie.dev/self-upgrade-of={CRONJOB}"},
+            params={"labelSelector": f"curie.dev/self-upgrade-of={cronjob}"},
         )
     except httpx.HTTPError:
         return None
@@ -279,10 +297,62 @@ def upgrade_self() -> str:
     `prior` is always null, because this action has no prior state to restore.
     """
 
-    if not CRONJOB:
+    return _start_job_from(CRONJOB, "SELF_UPGRADE_CRONJOB")
+
+
+@mcp.tool(annotations=UPGRADE)
+def upgrade_platform() -> str:
+    """Move the Curie platform this bot runs on to the newest published release.
+
+    THIS IS NOT `upgrade_self`. That one redeploys this bot's own bundle and
+    leaves the platform alone. This one upgrades the platform underneath every
+    agent on it, including you -- api, worker, dispatcher and the rest. Do not
+    call it when someone asks you to update yourself.
+
+    Starts an upgrade Job an operator installed. That Job reads the newest
+    published release itself, fetches its chart, and runs the Helm upgrade with
+    the values this install is already using. This tool takes no arguments: you
+    cannot choose the version, the chart or the values, and there is no way to
+    ask for a specific release through it. If someone names a version, say that
+    what runs is "the newest published release" and let them decide whether that
+    is what they wanted.
+
+    This is a WRITE, it is gated, and it is the widest one you have. Before
+    calling it, say plainly which version is installed now, which is newest, and
+    that every platform component restarts.
+
+    NOT REVERSIBLE by you, and not reliably reversible at all. `helm rollback`
+    restores objects but not the database: migrations run as an init container
+    and rollback does not undo them, so for a version pair that migrated,
+    recovery is restore-from-backup by an operator. Never describe this as
+    something that can be undone.
+
+    Starting the Job is not finishing it. The reply carries the Job's name; watch
+    it with the read-only Kubernetes tools and report what it actually did. Your
+    own sandbox may be replaced while it runs -- that is the upgrade working.
+
+    The reply is a JSON object: `ok`, `summary`, `prior`, `post`, `target`.
+    `prior` is always null, because this action has no prior state you can
+    restore.
+    """
+
+    return _start_job_from(PLATFORM_CRONJOB, "PLATFORM_UPGRADE_CRONJOB")
+
+
+def _start_job_from(cronjob: str, env_name: str) -> str:
+    """Create a Job from `cronjob`'s template, or say why not.
+
+    Shared by both upgrade verbs because they differ in exactly one thing: which
+    operator-written template runs. Everything the security argument rests on --
+    no caller input, the template copied verbatim, one at a time -- is a property
+    of this function, so it holds for both by construction rather than by two
+    files being kept in step.
+    """
+
+    if not cronjob:
         return _reply(
             False,
-            "refusing: SELF_UPGRADE_CRONJOB is not set, so this connector does not "
+            f"refusing: {env_name} is not set, so this connector does not "
             "know which upgrade to start. Setting it is an operator change.",
         )
 
@@ -299,7 +369,7 @@ def upgrade_self() -> str:
         return _reply(False, client)
 
     with client:
-        path = f"/apis/batch/v1/namespaces/{namespace}/cronjobs/{CRONJOB}"
+        path = f"/apis/batch/v1/namespaces/{namespace}/cronjobs/{cronjob}"
         try:
             existing = client.get(path)
         except httpx.HTTPError as exc:
@@ -307,18 +377,18 @@ def upgrade_self() -> str:
         if existing.status_code == 404:
             return _reply(
                 False,
-                f"no CronJob {namespace}/{CRONJOB}. The upgrade job is not installed "
+                f"no CronJob {namespace}/{cronjob}. The upgrade job is not installed "
                 "on this cluster; installing it is an operator change.",
             )
         if existing.status_code in (401, 403):
             return _reply(
                 False,
-                f"the upgrade identity may not read {namespace}/{CRONJOB} "
+                f"the upgrade identity may not read {namespace}/{cronjob} "
                 f"({existing.status_code}). It needs get on that cronjob.",
             )
         if existing.status_code >= 400:
             return _reply(
-                False, f"could not read {namespace}/{CRONJOB}: {existing.status_code}"
+                False, f"could not read {namespace}/{cronjob}: {existing.status_code}"
             )
 
         try:
@@ -329,11 +399,11 @@ def upgrade_self() -> str:
         if not job_spec:
             return _reply(
                 False,
-                f"{namespace}/{CRONJOB} has no jobTemplate.spec to run; the CronJob "
+                f"{namespace}/{cronjob} has no jobTemplate.spec to run; the CronJob "
                 "is malformed.",
             )
 
-        running = _active_job(client, namespace)
+        running = _active_job(client, namespace, cronjob)
         if running:
             return _reply(
                 False,
@@ -351,11 +421,11 @@ def upgrade_self() -> str:
             "apiVersion": "batch/v1",
             "kind": "Job",
             "metadata": {
-                "generateName": f"{CRONJOB}-",
+                "generateName": f"{cronjob}-",
                 "namespace": namespace,
                 "labels": {
                     **((template.get("metadata") or {}).get("labels") or {}),
-                    "curie.dev/self-upgrade-of": CRONJOB,
+                    "curie.dev/self-upgrade-of": cronjob,
                 },
                 "annotations": {
                     **((template.get("metadata") or {}).get("annotations") or {}),

--- a/examples/sre-bot/connectors/self-upgrade/test_server.py
+++ b/examples/sre-bot/connectors/self-upgrade/test_server.py
@@ -61,6 +61,7 @@ def _load(
     kubeconfig=GOOD_KUBECONFIG,
     cronjob="sre-bot-self-upgrade",
     release_repo="curie-eng/curie",
+    platform_cronjob="platform-upgrade",
 ):
     cfg = tmp_path / "kubeconfig"
     cfg.write_text(yaml.safe_dump(kubeconfig), encoding="utf-8")
@@ -68,6 +69,7 @@ def _load(
     os.environ["SELF_UPGRADE_CRONJOB"] = cronjob
     os.environ["SELF_UPGRADE_NAMESPACE"] = "curie"
     os.environ["SELF_UPGRADE_RELEASE_REPO"] = release_repo
+    os.environ["PLATFORM_UPGRADE_CRONJOB"] = platform_cronjob
     os.environ["SELF_UPGRADE_RELEASE_API"] = "https://api.github.test"
     sys.modules.pop(_MODULE_NAME, None)
     spec = importlib.util.spec_from_file_location(_MODULE_NAME, _SERVER_PY)
@@ -409,3 +411,78 @@ def test_a_body_with_no_tag_is_reported_not_guessed(tmp_path, monkeypatch):
     result = json.loads(srv.latest_release())
     assert result["ok"] is False
     assert "no tag_name" in result["summary"]
+
+
+# --- upgrade_platform -----------------------------------------------------
+
+
+def test_it_starts_the_platform_template_not_the_bundle_one(tmp_path, monkeypatch):
+    """The two verbs must not be able to run each other's template."""
+    srv = _load(tmp_path)
+    seen = {}
+    monkeypatch.setattr(srv, "_client", lambda: _FakeClient(seen))
+    result = json.loads(srv.upgrade_platform())
+    assert result["ok"] is True
+    assert seen["cronjob_path"].endswith("/cronjobs/platform-upgrade")
+    assert seen["post_body"]["metadata"]["generateName"].startswith("platform-upgrade")
+
+
+def test_an_unset_platform_cronjob_refuses(tmp_path, monkeypatch):
+    """An install that has not opted in does not get a platform upgrade."""
+    srv = _load(tmp_path, platform_cronjob="")
+    seen = {}
+    monkeypatch.setattr(srv, "_client", lambda: _FakeClient(seen))
+    result = json.loads(srv.upgrade_platform())
+    assert result["ok"] is False
+    assert "PLATFORM_UPGRADE_CRONJOB" in result["summary"]
+    assert seen == {}
+
+
+def test_the_two_verbs_do_not_block_each_other(tmp_path, monkeypatch):
+    """A running bundle redeploy must not refuse a platform upgrade.
+
+    They run different templates against different credentials and are
+    independent. The concurrency guard is scoped to the CronJob being started,
+    so a Job labelled for one does not look active to the other -- if that
+    scoping regresses, one in-flight upgrade silently blocks the unrelated verb.
+    """
+    srv = _load(tmp_path)
+    running_self = {
+        "items": [
+            {
+                "metadata": {
+                    "name": "in-flight",
+                    "labels": {"curie.dev/self-upgrade-of": "sre-bot-self-upgrade"},
+                },
+                "status": {"active": 1},
+            }
+        ]
+    }
+    seen = {}
+    # The fake echoes back whatever the selector asked for; a real API server
+    # filters. Assert on the selector the tool SENT, which is what the server
+    # would have filtered on.
+    monkeypatch.setattr(srv, "_client", lambda: _FakeClient(seen, jobs=(200, running_self)))
+    srv.upgrade_platform()
+    assert seen["jobs_params"]["labelSelector"] == (
+        "curie.dev/self-upgrade-of=platform-upgrade"
+    )
+
+
+def test_it_is_annotated_as_a_destructive_write(tmp_path):
+    srv = _load(tmp_path)
+    assert srv.UPGRADE.readOnlyHint is False
+    assert srv.UPGRADE.destructiveHint is True
+
+
+def test_the_platform_tool_exposes_no_parameters(tmp_path):
+    srv = _load(tmp_path)
+    assert inspect.signature(srv.upgrade_platform).parameters == {}
+
+
+def test_its_summary_refuses_to_imply_a_rollback(tmp_path, monkeypatch):
+    srv = _load(tmp_path)
+    monkeypatch.setattr(srv, "_client", lambda: _FakeClient({}))
+    result = json.loads(srv.upgrade_platform())
+    assert result["prior"] is None
+    assert "no undo" in result["summary"]

--- a/examples/sre-bot/docs/PERMISSION-MAP.md
+++ b/examples/sre-bot/docs/PERMISSION-MAP.md
@@ -88,7 +88,7 @@ Two limits to state rather than imply:
 - Curie's posture today is approval-required plus **allow-by-omission**. A tool
   no gate names is callable. So "which tools are gated" is the whole policy, and
   a forgotten gate is a silent grant rather than a refusal. See the prerequisite
-  in entry 4.
+  in entry 5.
 
 ### Deliberately not granted
 
@@ -183,7 +183,7 @@ namespace if the token escapes the connector pod. It does not leave the pod, for
 the same reason the read connector drops `configuration_view`: the sandbox learns
 a URL and never holds a credential.
 
-### Why this is not the abstraction entry 4 rejects
+### Why this is not the abstraction entry 5 rejects
 
 Entry 4 rejects `upgrade_release(target_version)` -- a connector validating a
 version against a list it holds itself -- because that makes the connector the
@@ -193,7 +193,7 @@ This tool holds no policy. It has no version list, no sequencing, and no
 decision: which repository, which branch, which image and which command all come
 from a CronJob an operator wrote and can read. The connector's entire
 contribution is "start that, now, if nothing like it is already running". Move
-any of those choices into the connector and entry 4's objection would apply here
+any of those choices into the connector and entry 5's objection would apply here
 too.
 
 ### Why the bot does not simply do the upgrade
@@ -224,7 +224,59 @@ erase the evidence of what it started.
 
 ---
 
-## 4. Upgrading Curie's own release — a workflow, not a tool
+## 4. `upgrade_platform` — moving the release to the newest published version
+
+| | |
+|---|---|
+| Tool | `mcp__self-upgrade__upgrade_platform()` — no arguments |
+| Kubernetes verbs | `get` on `batch/cronjobs`; `create`, `list` on `batch/jobs` |
+| The JOB's verbs | namespace-wide write across the kinds the chart owns — see `manifests/platform-upgrade-role.yaml` |
+| Authorization | `approvalPolicy` gate — a human approves each call |
+| Status | Implemented, ships with its CronJob and identity absent |
+
+This is entry 5's problem solved by giving up the thing entry 5 wanted most: a
+**named version**. It upgrades to whatever the project published last, and there
+is no way to ask it for a particular release.
+
+That trade is what makes it shippable now. Entry 5's design needs a
+general-purpose Helm tool surface, which cannot be safely classified while the
+platform's live behaviour is allow-by-omission (curie#2119). One no-argument
+verb has no surface to classify.
+
+### The grant, and where it actually lives
+
+The bot's own grant is the same as entry 3's: start a Job, read its name. The
+credential that can rewrite the release belongs to the **Job**, not to the bot
+and not to a connector — it exists for the ninety seconds the upgrade runs and
+the sandbox never sees it.
+
+Read `manifests/platform-upgrade-role.yaml` before installing this. Its rules are
+namespace-admin in all but name, and the file says so and enumerates them rather
+than burying it. What bounds it is lifetime, an operator-written script the bot
+cannot edit, and the namespace; what does NOT bound it is the gate or the bot's
+good behaviour, which govern only who starts the Job.
+
+### Why the version is not a parameter
+
+A version argument is caller input, and the caller is a language model. Entry 5
+is right that the allowlist of acceptable versions is builder config rather than
+connector state — so until there is a builder-owned place to put it, "newest
+published" is the only target this can honestly offer.
+
+In practice that is usually the question being asked. The request that produced
+this entry named a specific version, and that version was already two releases
+stale; what the person wanted was "get us current".
+
+### Deliberately not granted
+
+No rollback verb. `helm rollback` restores objects but not the database —
+migrations run as an init container and rollback does not undo them — so for a
+version pair that migrated, recovery is restore-from-backup by an operator. A
+rollback tool here would read as an undo that this cannot perform.
+
+---
+
+## 5. Upgrading Curie by naming a version — a workflow, not a tool
 
 **PROPOSED. Not implemented.** Superseded as a weekly requirement — issue #1857
 asks for "rollback or recovery behavior", not a named-version upgrade — so this

--- a/examples/sre-bot/manifests/platform-upgrade-role.yaml
+++ b/examples/sre-bot/manifests/platform-upgrade-role.yaml
@@ -1,0 +1,111 @@
+# The identity the platform-upgrade JOB runs as. Read this before applying it.
+#
+#     kubectl apply -f examples/sre-bot/manifests/platform-upgrade-role.yaml
+#
+# ---------------------------------------------------------------------------
+# THIS IS THE BROADEST GRANT IN THIS BUNDLE, BY A LARGE MARGIN
+# ---------------------------------------------------------------------------
+#
+# `helm upgrade` rewrites nearly every namespaced object the release owns:
+# Deployments, StatefulSets, Services, ServiceAccounts, Roles, RoleBindings,
+# Jobs, ConfigMaps, NetworkPolicies, and Helm's own release Secrets. There is no
+# RBAC expression for "may run that one upgrade". The rules below are the honest
+# enumeration of what it needs, and they add up to namespace-admin in all but
+# name: a holder of this credential can read every Secret in the namespace --
+# including the platform API key and the model credential -- and replace any
+# workload in it.
+#
+# Do not apply this because the bundle ships it. Apply it when you have decided
+# that a human-approved, no-argument platform upgrade is worth that credential
+# existing in this namespace.
+#
+# ---------------------------------------------------------------------------
+# WHAT KEEPS IT BOUNDED, AND WHAT DOES NOT
+# ---------------------------------------------------------------------------
+#
+# What does NOT bound it: the connector, the approval gate, or the bot's good
+# behaviour. Those bound who can START the Job. None of them bound what the Job's
+# credential could do if it were used for something else.
+#
+# What DOES bound it:
+#
+#   - **Lifetime.** This is a Job's identity, not a connector's. The token exists
+#     inside a pod that lives for the duration of one upgrade. No long-running
+#     process holds it, and in particular the sandbox -- which is
+#     prompt-injectable -- never sees it.
+#   - **The script, which is yours.** The Job runs
+#     `platform-upgrade/upgrade.sh` from a ConfigMap you create. The bot supplies
+#     no argument: not the version, not the chart, not the values. Every choice
+#     is made in files you wrote.
+#   - **The namespace.** Nothing here is cluster-scoped. It cannot touch another
+#     tenant, another release, or any cluster-wide object.
+#
+# If you are not willing to accept a namespace-admin-equivalent credential
+# existing, do not install this. The bot remains able to REPORT that an upgrade
+# is available (`latest_release`) without it, which is most of the operational
+# value at none of the risk.
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: curie-platform-upgrader
+  # CHANGE ME: the namespace the Curie release runs in.
+  namespace: curie
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: curie-platform-upgrader
+  namespace: curie
+rules:
+  # Helm's release state. `secrets` is also what makes this grant equivalent to
+  # namespace-admin, and it cannot be narrowed: Helm stores releases as Secrets
+  # whose names it computes, so `resourceNames` cannot enumerate them ahead of
+  # time, and reading one requires `get` on the kind.
+  - apiGroups: [""]
+    resources: ["secrets", "configmaps", "services", "serviceaccounts", "persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "statefulsets", "daemonsets", "replicasets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["batch"]
+    resources: ["jobs", "cronjobs"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["networkpolicies", "ingresses"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # The chart renders the identities its own components run as, so an upgrade
+  # that changes one has to be able to write it. Kubernetes requires the writer
+  # to already hold every permission it grants (privilege escalation prevention),
+  # so this line is only usable for rules this Role itself covers.
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["roles", "rolebindings"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # Read-only. `helm --wait` polls pod readiness, and the script re-reads the
+  # release afterwards rather than trusting the command's exit code.
+  - apiGroups: [""]
+    resources: ["pods", "events"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: curie-platform-upgrader
+  namespace: curie
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: curie-platform-upgrader
+subjects:
+  - kind: ServiceAccount
+    name: curie-platform-upgrader
+    # Easy to miss: indented under `subjects`, not `metadata.namespace`. Getting
+    # it wrong does not fail `kubectl apply` -- every object still reports
+    # `created` and the identity simply grants nothing.
+    namespace: curie
+---
+# The upgrade Job's identity is projected by Kubernetes into its own pod, so
+# unlike the connector identities in this directory it needs NO static token
+# Secret. That is a real difference and worth keeping: a static token is a
+# credential that outlives the thing that needed it, and this one is exactly the
+# credential you least want lying around.

--- a/examples/sre-bot/manifests/upgrade-role.yaml
+++ b/examples/sre-bot/manifests/upgrade-role.yaml
@@ -73,6 +73,10 @@ rules:
       # purpose, so a ceiling stated once cannot move when someone edits the
       # other place.
       - sre-bot-self-upgrade
+      # The platform upgrade's template, if you installed it. Harmless to list
+      # when that CronJob does not exist: `resourceNames` grants nothing for a
+      # name with no object behind it.
+      - platform-upgrade
     verbs: ["get"]
   - apiGroups: ["batch"]
     resources: ["jobs"]

--- a/examples/sre-bot/platform-upgrade/cronjob.yaml
+++ b/examples/sre-bot/platform-upgrade/cronjob.yaml
@@ -1,0 +1,101 @@
+# Move the Curie release to the newest published version, when asked.
+#
+#   kubectl -n <curie-namespace> create configmap platform-upgrade \
+#     --from-file=upgrade.sh=examples/sre-bot/platform-upgrade/upgrade.sh
+#   kubectl -n <curie-namespace> apply -f examples/sre-bot/manifests/platform-upgrade-role.yaml
+#   kubectl -n <curie-namespace> apply -f examples/sre-bot/platform-upgrade/cronjob.yaml
+#
+# EDIT BEFORE APPLYING: the namespace on both objects, and the three
+# PLATFORM_UPGRADE_* values naming your repository, release and namespace.
+#
+# SUSPENDED, AND STARTED BY ASKING. Like `self-upgrade/cronjob.yaml`, the
+# schedule exists because a CronJob must carry one; it never fires. The
+# `upgrade_platform` connector tool creates a Job from this template when a
+# human approves, and that is the only way it runs. Set `suspend: false` if you
+# also want it on a timer -- but read the next paragraph first, because a
+# platform upgrade is a materially worse thing to have happen unattended than a
+# bundle redeploy.
+#
+# WHY THE BOT DOES NOT HOLD THIS CREDENTIAL. `helm upgrade` rewrites nearly every
+# namespaced object the release owns, so the identity below is namespace-admin in
+# all but name (manifests/platform-upgrade-role.yaml says so plainly and
+# enumerates it). A connector holding that would hold it for the life of its pod.
+# A Job holds it for the ninety seconds it runs, and the bot holds it never: it
+# creates a Job from this template, which it cannot edit, with no arguments.
+#
+# WHAT THE BOT CANNOT CHOOSE. Not the version -- the script reads the newest
+# published release itself. Not the chart, the values, the timeout, or the
+# namespace. Every one of those is in this file, which is yours.
+#
+# THIS UPGRADES THE PLATFORM, NOT THE BOT. `self-upgrade/cronjob.yaml` redeploys
+# the agent bundle; this moves Curie itself. They are separate versions, separate
+# Jobs and separate credentials, and conflating them is the mistake this pair of
+# files exists to make hard.
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: platform-upgrade
+  # CHANGE ME: the namespace the Curie release runs in.
+  namespace: curie
+spec:
+  # Never fires while suspended; a CronJob must still carry a valid schedule.
+  schedule: "43 4 * * *"
+  suspend: true
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        spec:
+          restartPolicy: Never
+          serviceAccountName: curie-platform-upgrader
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            seccompProfile: { type: RuntimeDefault }
+          containers:
+            - name: upgrade
+              # Carries helm and kubectl, and is already used by this chart, so
+              # the upgrade path pulls nothing the cluster has not pulled before.
+              image: alpine/k8s:1.31.2
+              command: ["sh", "/opt/platform-upgrade/upgrade.sh"]
+              env:
+                # CHANGE ME: the project whose releases define "newest".
+                - name: PLATFORM_UPGRADE_REPO
+                  value: curie-eng/curie
+                # CHANGE ME: the Helm release name.
+                - name: PLATFORM_UPGRADE_RELEASE
+                  value: curie
+                # CHANGE ME: the namespace it lives in.
+                - name: PLATFORM_UPGRADE_NAMESPACE
+                  value: curie
+                - name: PLATFORM_UPGRADE_TIMEOUT
+                  value: 12m
+                # Helm keeps release state in Secrets in the namespace it is
+                # told about; HOME must be writable for its cache.
+                - name: HOME
+                  value: /tmp
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities: { drop: ["ALL"] }
+              resources:
+                requests: { cpu: 50m, memory: 128Mi }
+                limits: { cpu: 500m, memory: 512Mi }
+              volumeMounts:
+                - name: script
+                  mountPath: /opt/platform-upgrade
+                  readOnly: true
+                # readOnlyRootFilesystem, so the chart extraction and helm's
+                # cache both need a real writable path.
+                - name: scratch
+                  mountPath: /tmp
+          volumes:
+            - name: script
+              configMap:
+                name: platform-upgrade
+            - name: scratch
+              emptyDir: {}

--- a/examples/sre-bot/platform-upgrade/upgrade.sh
+++ b/examples/sre-bot/platform-upgrade/upgrade.sh
@@ -1,0 +1,104 @@
+#!/bin/sh
+# Move the Curie release to the newest published chart, and verify it landed.
+#
+# Runs as a Job. The bot can start this Job and nothing else -- it supplies no
+# argument, so every choice below is the operator's, made when this file and its
+# CronJob were installed.
+#
+# WHY A SCRIPT AND NOT A CONNECTOR TOOL. `helm upgrade` rewrites essentially
+# every namespaced object the release owns, which is namespace-admin in every
+# honest formulation. A connector holding that credential would hold it for the
+# life of the pod; a Job holds it for the ninety seconds it runs. The bot never
+# holds it at all: it creates a Job from a template it cannot edit.
+#
+# WHAT IT DELIBERATELY WILL NOT DO:
+#   - take a target version from anywhere but the repository's own releases
+#   - run when the newest release is what is already installed
+#   - roll back on its own (see RECOVERY below)
+set -eu
+
+REPO="${PLATFORM_UPGRADE_REPO:?PLATFORM_UPGRADE_REPO is required}"
+RELEASE="${PLATFORM_UPGRADE_RELEASE:?PLATFORM_UPGRADE_RELEASE is required}"
+NAMESPACE="${PLATFORM_UPGRADE_NAMESPACE:?PLATFORM_UPGRADE_NAMESPACE is required}"
+CHART_PATH="${PLATFORM_UPGRADE_CHART_PATH:-charts/curie}"
+TIMEOUT="${PLATFORM_UPGRADE_TIMEOUT:-12m}"
+
+echo "release=${RELEASE} namespace=${NAMESPACE} repo=${REPO}"
+
+installed="$(helm list -n "${NAMESPACE}" -f "^${RELEASE}\$" -o json \
+  | sed -n 's/.*"app_version":"\([^"]*\)".*/\1/p')"
+if [ -z "${installed}" ]; then
+  echo "no release ${RELEASE} in ${NAMESPACE}; refusing" >&2
+  exit 1
+fi
+
+# The target is whatever the project published last. Read here rather than
+# passed in: a version this Job accepted from outside would be a version the
+# caller chose, and the caller is a language model.
+tag="$(wget -qO- --header='Accept: application/vnd.github+json' \
+  "https://api.github.com/repos/${REPO}/releases/latest" \
+  | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' | head -1)"
+if [ -z "${tag}" ]; then
+  echo "could not read the newest release of ${REPO}" >&2
+  exit 1
+fi
+target="${tag#v}"
+
+echo "installed=${installed} newest=${target}"
+if [ "${installed}" = "${target}" ]; then
+  echo "already on the newest release; nothing to do"
+  exit 0
+fi
+
+# The chart ships in the repository rather than a chart registry, so the release
+# tarball IS the distribution. Extracted under /tmp, which is the only writable
+# path this Job has.
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+echo "fetching ${tag}"
+wget -qO "${workdir}/src.tgz" \
+  "https://github.com/${REPO}/archive/refs/tags/${tag}.tar.gz"
+mkdir -p "${workdir}/src"
+tar -xzf "${workdir}/src.tgz" -C "${workdir}/src" --strip-components=1
+chart="${workdir}/src/${CHART_PATH}"
+[ -f "${chart}/Chart.yaml" ] || { echo "no chart at ${CHART_PATH}" >&2; exit 1; }
+
+# --reset-then-reuse-values, NOT --reuse-values. The plain form carries forward
+# only what was previously set and silently drops values the new chart adds,
+# which lands as a nil-pointer template error mid-upgrade or, worse, a rendered
+# object missing a field nothing checks.
+#
+# Clearing the image tags is the load-bearing part: the chart renders its own
+# appVersion when a tag is empty, so an install pinned to a git-sha tag would
+# otherwise upgrade the CHART to the new version while still running the OLD
+# images -- a state that reports as upgraded and is not.
+echo "upgrading ${installed} -> ${target}"
+helm upgrade "${RELEASE}" "${chart}" \
+  -n "${NAMESPACE}" \
+  --reset-then-reuse-values \
+  --set api.image.tag= \
+  --set worker.image.tag= \
+  --set dispatcher.image.tag= \
+  --set ui.image.tag= \
+  --set agentSandbox.runner.tag= \
+  --wait --timeout "${TIMEOUT}"
+
+# Helm's own --wait covers rollout readiness. This re-reads the release because
+# "the command exited 0" and "the release records the new version" are not the
+# same statement, and the second is the one an operator will be told.
+landed="$(helm list -n "${NAMESPACE}" -f "^${RELEASE}\$" -o json \
+  | sed -n 's/.*"app_version":"\([^"]*\)".*/\1/p')"
+if [ "${landed}" != "${target}" ]; then
+  echo "upgrade reported success but the release records ${landed}" >&2
+  exit 1
+fi
+echo "upgraded ${RELEASE} from ${installed} to ${landed}"
+
+# RECOVERY IS NOT AUTOMATIC, AND SAYING SO IS THE POINT.
+#
+# `helm rollback` restores objects; it does not restore the database. Migrations
+# run as the api initContainer (`alembic upgrade head`) and rollback does not run
+# `alembic downgrade`. For a version pair that migrated, recovery is
+# restore-from-backup, and a rollback alone would leave old code against a new
+# schema. So this Job does not roll back, and the runbook must not imply it can.
+echo "note: rollback is an operator action; see docs/PERMISSION-MAP.md entry 4"

--- a/packages/plugin-format/tests/test_approval_policy.py
+++ b/packages/plugin-format/tests/test_approval_policy.py
@@ -136,6 +136,10 @@ def test_sre_bot_declares_gated_write_connector_and_validates(tmp_path: Path) ->
             "gate": "mcp__self-upgrade__upgrade_self",
             "route": "sre-approvals",
         },
+        {
+            "gate": "mcp__self-upgrade__upgrade_platform",
+            "route": "sre-approvals",
+        },
     ]
     assert connectors["connectors"]["k8s-write"]["build"] == {
         "context": "connectors/k8s-write",


### PR DESCRIPTION
Asked to move the platform to a newer version, the bot correctly said it had no tool for it and handed the job to a human. The install was **three releases behind** and nobody had noticed until someone asked.

Closes the capability half of #2121.

## Why not entry 5's design

`PERMISSION-MAP` entry 5 proposes the general answer — a Helm connector publishing `helm_upgrade` / `helm_rollback` / `helm_history`, workflow in a skill. It is still not shippable: that design needs a general tool surface, and one cannot be safely classified while the platform's live behaviour is allow-by-omission (#2119).

## The narrow answer

`upgrade_platform` takes **no arguments** and cannot be asked for a version. It creates a Job from an operator-written CronJob template; the Job reads the newest published release itself, fetches that tag's chart, and runs the upgrade with the values the install already uses. Version, chart, values, timeout and namespace all live in files the operator wrote and the bot cannot edit.

That trade is not as bad as it sounds: the request that prompted this named a specific version, and **that version was already two releases stale**. What was wanted was "get us current".

## Where the credential lives — the whole design

`helm upgrade` rewrites nearly every namespaced object the release owns, which is namespace-admin in all but name. `manifests/platform-upgrade-role.yaml` enumerates it and says so rather than burying it.

That credential belongs to the **Job**: it exists for the ninety seconds the upgrade runs, the sandbox never sees it, and no long-lived connector holds it. The bot's own grant is unchanged from `upgrade_self` — start a Job, read its name.

| | bounds it | does NOT bound it |
|---|---|---|
| lifetime of one Job pod | ✓ | |
| operator-written script the bot cannot edit | ✓ | |
| namespace scope | ✓ | |
| the approval gate | | only governs *who starts* it |
| the bot's good behaviour | | not a control |

## Details worth review

- The two write verbs share `_start_job_from`, so "no caller input, template copied verbatim, one at a time" holds for both by construction rather than by two files being kept in step.
- The concurrency check is now scoped to the CronJob being started, so a bundle redeploy in flight does not refuse an unrelated platform upgrade. A test pins this; the regression would be silent.
- `--reset-then-reuse-values` plus cleared image tags, which is what I verified by hand upgrading staging 0.7.2 → 0.8.1 earlier today. The plain `--reuse-values` drops values the new chart adds; leaving sha-pinned tags in place upgrades the *chart* while still running the *old images*, a state that reports as upgraded and is not.
- **No rollback verb**, deliberately — `helm rollback` restores objects but not the database, so recovery for a migrating pair is restore-from-backup by an operator.

## Ships off

`PLATFORM_UPGRADE_CRONJOB` is empty and the CronJob and identity are absent, so every call refuses until an operator installs them deliberately. Nothing changes for an existing install that does nothing.

## Verification

- connector tests 35 passed; `examples/tests/` 86 passed; `ruff`, `cargo fmt`, `cargo clippy` clean; CLI examples tests 17 passed.
- Pre-existing, unrelated: 7 failures in `installation_plan_parity` reproduce identically on the unmodified base.
- The upgrade mechanics themselves are not theoretical — the same helm invocation moved this project's staging install 0.7.2 → 0.8.1 today, migrations 0034 → 0036, no unhealthy pods.