### PR TITLE
Show the widest grant in the plan that exists to disclose it

### DIFF
--- a/cli/src/examples.rs
+++ b/cli/src/examples.rs
@@ -605,6 +605,44 @@ pub async fn install_sre_bot(opts: SreBotInstallOpts) -> Result<SreBotInstallRes
                     .to_string(),
             );
         }
+        if opts.platform_upgrade {
+            // The widest grant this installer can create, and the reason someone
+            // runs --dry-run at all. Omitting it was the first version of this
+            // flag: the live path applied these four objects and the plan said
+            // nothing, so an operator deciding whether to accept a
+            // namespace-admin-equivalent identity could not see it in the one
+            // output built for that decision.
+            lines.push(format!(
+                "kubectl apply -f examples/sre-bot/manifests/upgrade-role.yaml -- the CONNECTOR's \
+                 identity ({UPGRADER_IDENTITY}): create on jobs, so it can start an upgrade"
+            ));
+            lines.push(format!(
+                "kubectl apply -f examples/sre-bot/manifests/platform-upgrade-role.yaml -- the \
+                 JOB's identity ({PLATFORM_UPGRADER_IDENTITY}) in namespace {}: namespace-admin \
+                 in all but name, because `helm upgrade` rewrites nearly every object the release \
+                 owns. READ THAT FILE. It exists for the ~90s an upgrade runs and the sandbox \
+                 never sees it",
+                identity.namespace
+            ));
+            lines.push(format!(
+                "kubectl apply -f <rendered ConfigMap {PLATFORM_UPGRADE_CONFIGMAP}> -- the upgrade \
+                 script the Job runs, from examples/sre-bot/platform-upgrade/upgrade.sh"
+            ));
+            lines.push(format!(
+                "kubectl apply -f <rendered CronJob {PLATFORM_UPGRADE_CRONJOB_NAME}, suspend: \
+                 true> -- never fires on its own; the gated {PLATFORM_UPGRADE_GATE} creates a Job \
+                 from it when a human approves one"
+            ));
+            lines.push(format!(
+                "kubectl wait --namespace {} --for=jsonpath={{.data.token}} \
+                 secret/{UPGRADER_TOKEN_SECRET} --timeout={READER_TOKEN_TIMEOUT}",
+                identity.namespace
+            ));
+            lines.push(
+                "build the self-upgrade connector kubeconfig in memory from the ServiceAccount token"
+                    .to_string(),
+            );
+        }
         lines.push(
             "render and reconcile the deployed version connectors with the owned Kubernetes kubeconfig Secret override"
                 .to_string(),


### PR DESCRIPTION
`--dry-run` printed every step of the sre-bot install **except** the four that create a namespace-admin-equivalent identity. The live path applied them; the plan said nothing.

That is the wrong way round. `--platform-upgrade`'s own help text says to read `manifests/platform-upgrade-role.yaml` before using it, and `--dry-run` is the output built for exactly that decision — so the one step worth previewing was the one it hid.

Found while dry-running the flag I had just merged (#2124), before applying it to a live install.

## What the plan says now

```
kubectl apply -f .../upgrade-role.yaml -- the CONNECTOR's identity (sre-bot-upgrader):
  create on jobs, so it can start an upgrade
kubectl apply -f .../platform-upgrade-role.yaml -- the JOB's identity
  (curie-platform-upgrader) in namespace curie-staging: namespace-admin in all but name,
  because `helm upgrade` rewrites nearly every object the release owns. READ THAT FILE.
  It exists for the ~90s an upgrade runs and the sandbox never sees it
kubectl apply -f <rendered ConfigMap platform-upgrade> -- the upgrade script the Job runs
kubectl apply -f <rendered CronJob platform-upgrade, suspend: true> -- never fires on its
  own; the gated mcp__self-upgrade__upgrade_platform creates a Job from it when a human
  approves one
kubectl wait ... secret/sre-bot-upgrader-token ...
build the self-upgrade connector kubeconfig in memory from the ServiceAccount token
```

Each line names what the object is **for** rather than restating the filename.

## Verification

With the flag: six new lines. Without it: `grep -c platform-upgrade` over the plan returns **0**.

`cargo test --lib` 1105 passed, `clippy --all-targets -- -D warnings` clean.

## The gap is structural

The plan and the live path are **two hand-maintained lists of the same sequence**, so a step added to one is not added to the other — which is what happened here, on the step where it mattered most.

Making the plan a projection of the executed commands would close the class. This change closes the instance.