### PR TITLE
Tell the skill about the verb it was told did not exist

### DIFF
--- a/examples/sre-bot/skills/sre-bot/SKILL.md
+++ b/examples/sre-bot/skills/sre-bot/SKILL.md
@@ -40,10 +40,26 @@ yourself does not touch the platform.
   own bundle from its repository. It takes no version argument -- it deploys
   whatever the operator's job template considers newest -- and it is gated, so a
   human approves before anything happens.
-- **The platform: no.** Moving the Curie release from one version to another is
-  a Helm operation across every object the release owns, and you have no tool
-  for it by design. Say so plainly and hand over what a human would run; do not
-  imply `upgrade_self` covers it.
+- **The platform: only if `upgrade_platform` is on your tool list.** It starts a
+  Job that moves the Curie release to the **newest published** version. It takes
+  no version argument, so you cannot target a specific release -- if someone
+  names one, say what will actually run and let them decide. It is gated, and it
+  is the widest thing you can do: every platform component restarts, and it
+  cannot be undone by you, because a rollback restores objects and not the
+  database.
+- **The platform, without that tool: no.** Moving the release is a Helm
+  operation across every object it owns. Say so plainly and hand over what a
+  human would run; do not imply `upgrade_self` covers it.
+
+**These are two different verbs and confusing them is the mistake to avoid.**
+`upgrade_self` redeploys *your bundle* and leaves the platform alone;
+`upgrade_platform` upgrades *the platform underneath you*. "Upgrade yourself" is
+the first. "Upgrade Curie" or "upgrade the platform" is the second.
+
+**Never report an upgrade you did not perform.** If the tool is not on your list,
+say you cannot. If you called it, the reply carries a Job name and starting a Job
+is not finishing one -- watch it and report what it did. "All done" after calling
+nothing is the one answer that is always wrong.
 
 If `latest_release` is on your tool list, use it to say what the newest published
 Curie release is. Without it you cannot know: **your sandbox has no general

--- a/examples/tests/test_the_skill_knows_its_gated_verbs.py
+++ b/examples/tests/test_the_skill_knows_its_gated_verbs.py
@@ -1,0 +1,81 @@
+"""A bundle's skill names every gated verb the bundle ships.
+
+The failure this exists to stop, from the install it happened on:
+
+`upgrade_platform` shipped as a connector tool, was published, was gated, was
+installed, and answered `tools/list` correctly. Asked to use it, the bot called
+`Bash` once and replied "all done" -- having done nothing.
+
+The cause was one stale sentence. The skill had been written when the verb did
+not exist, and said so:
+
+    **The platform: no.** Moving the Curie release from one version to another
+    is a Helm operation ... and you have no tool for it by design.
+
+That instruction outlived the fact. Nothing connected the two: the gate validates
+against the connector that publishes it, the connector's own tests validate the
+tool, and neither has any view of the prose that tells the model whether to reach
+for it. A capability the skill talks the model out of is indistinguishable, from
+every surface an operator watches, from one that was never built.
+
+The check is deliberately shallow -- the tool's bare name must appear somewhere
+in the bundle's skill. It cannot tell you the skill describes the verb correctly,
+or that the description is current. It tells you the skill has heard of it, which
+is the step that was skipped.
+
+Naming: the gate `mcp__self-upgrade__upgrade_platform` is satisfied by the skill
+mentioning `upgrade_platform`, because that is how a skill refers to a tool.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+EXAMPLES = REPO / "examples"
+
+
+def _gated_verbs() -> list[tuple[str, str, Path]]:
+    """``(bundle, tool name, skill file)`` for every gated connector verb.
+
+    Scoped to ``mcp__`` gates for the same reason the permission-map guard is: a
+    gate on a built-in like ``Bash`` is not a capability the bundle ships, and
+    demanding the skill name it would fail on a fixture with no skill at all.
+    """
+
+    found: list[tuple[str, str, Path]] = []
+    for manifest in sorted(EXAMPLES.glob("*/.claude-plugin/plugin.json")):
+        bundle_dir = manifest.parent.parent
+        parsed = json.loads(manifest.read_text(encoding="utf-8"))
+        gates = ((parsed.get("approvalPolicy") or {}).get("gates")) or []
+        for gate in gates:
+            name = gate.get("gate") if isinstance(gate, dict) else None
+            if not name or not str(name).startswith("mcp__"):
+                continue
+            # `mcp__<server>__<tool>` -> `<tool>`
+            tool = str(name).rsplit("__", 1)[-1]
+            for skill in sorted(bundle_dir.glob("skills/*/SKILL.md")):
+                found.append((bundle_dir.name, tool, skill))
+    return found
+
+
+def test_the_bundles_and_their_skills_are_readable() -> None:
+    # A guard that silently finds nothing passes vacuously, which is the failure
+    # mode of every check that reads files by glob.
+    assert _gated_verbs(), "no gated verbs with skills found: check the glob"
+
+
+@pytest.mark.parametrize(
+    "bundle,tool,skill",
+    _gated_verbs(),
+    ids=[f"{b}:{t}" for b, t, _ in _gated_verbs()],
+)
+def test_the_skill_names_the_gated_verb(bundle: str, tool: str, skill: Path) -> None:
+    assert tool in skill.read_text(encoding="utf-8"), (
+        f"{bundle} ships the gated verb '{tool}' and {skill.name} never mentions "
+        f"it. The model reads that file to decide what it can do, so a verb the "
+        f"skill is silent about -- or worse, one it says does not exist -- is a "
+        f"capability the bot will not use and may deny having. Describe it there, "
+        f"or drop the gate and its connector."
+    )


### PR DESCRIPTION
Asked to upgrade the platform, the deployed bot called `Bash` once and answered **"all done"** — having done nothing. No Job, no approval, no upgrade.

```
tool calls in that turn:   1 × Bash
platform-upgrade Jobs:     none
approvals:                 none
```

## The cause

`upgrade_platform` was published, gated, installed, and answering `tools/list` correctly. What stopped it was one sentence in the skill, written before the verb existed and left behind when it shipped:

> **The platform: no.** Moving the Curie release from one version to another is a Helm operation ... and **you have no tool for it by design.**

I wrote that in #2118 (teaching the bot what platform it runs on), gave it the tool in #2122, and never came back. **The model was following instructions.**

## The fix

The section now describes both verbs and the distinction between them — `upgrade_self` redeploys the bundle, `upgrade_platform` moves the platform underneath it — since conflating them is the obvious next failure.

It also says that starting a Job is not finishing one, and that *"all done" after calling nothing is the one answer that is always wrong*. Because that is what it said.

## The guard is the part that matters

Nothing connected a shipped gate to the prose that decides whether the model reaches for it:

| validates | against |
|---|---|
| the gate | the connector that publishes it |
| the connector's tests | the tool |
| **nothing** | **the skill** |

So a capability the skill talks the model out of is indistinguishable — from every surface an operator watches — from one that was never built. The connector was healthy, the tool listed, the gate deployed, and the answer was still "all done".

`test_the_skill_knows_its_gated_verbs` asserts every `mcp__*` gate's tool name appears in the bundle's skill. Shallow on purpose: it cannot tell you the description is correct or current, only that the skill has heard of the verb — the step that was skipped.

## Verification

- Removing `upgrade_platform` from the skill fails the guard by name.
- `examples/tests/` → 96 passed.