### PR TITLE
Fix external Langfuse host rendering

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -192,6 +192,11 @@ jobs:
           set -euo pipefail
           bash charts/curie/ci/otel-collector-langfuse-secret-assertions.sh
 
+      - name: helm render assertions (BYO Langfuse host)
+        run: |
+          set -euo pipefail
+          bash charts/curie/ci/langfuse-byo-assertions.sh
+
       # Prove Langfuse startup is gated on ClickHouse being up (issue #2009). A
       # Helm upgrade that recreates the ClickHouse Service otherwise lets the new
       # Langfuse pods start their migrations against an unresolvable name, so the

--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -406,6 +406,41 @@ Flipping any to `false` removes its resources from the render; consumers
 fields on the same block (`host`/`port` for stores, `otelCollector.endpoint`
 for an external collector).
 
+BYO Langfuse requires a bare external hostname in `langfuse.host`. Consumers
+compose its URL as
+`http://<langfuse.host>:<langfuse.web.service.port>`; do not include a scheme,
+port, or path in `langfuse.host`. With `langfuse.deploy: false`, the chart omits
+the Langfuse Service, web and worker Deployments, and model-pricing Job. Helm
+rendering fails with an error naming `langfuse.host` when that value is missing
+or empty, instead of emitting the hostname of a Service the chart did not
+create.
+
+```yaml
+langfuse:
+  deploy: false
+  host: langfuse.example.com
+  existingSecret: acme-langfuse-credentials
+  init:
+    projectPublicKey: pk-lf-acme-example
+  web:
+    service:
+      port: 3000
+```
+
+Set `langfuse.init.projectPublicKey` to the external project's public key. Its
+secret key must match: supply it as `langfuse.init.projectSecretKey`, or under
+`langfuseInitProjectSecretKey` in `langfuse.existingSecret`; otherwise the
+sealed chart-generated key will not authenticate to the external project. When
+the chart collector is enabled, that existing Secret must also supply its
+complete `otlpAuthHeader` value. As an alternative for collector
+authentication, set `otelCollector.otlpAuthHeader` explicitly; see the
+credential details below.
+
+This BYO path currently composes HTTP only and has no HTTPS/TLS selector.
+Deploy it only across a trusted private transport or through a proxy that
+provides the required protection: an on-path observer can recover the full
+project credential because the Basic header is encoded, not encrypted.
+
 ### Langfuse Postgres startup readiness
 
 `langfuse.web.postgresReadiness` is enabled by default. Before Langfuse web

--- a/charts/curie/ci/langfuse-byo-assertions.sh
+++ b/charts/curie/ci/langfuse-byo-assertions.sh
@@ -1,0 +1,317 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Issue #1505: langfuse.deploy selects one shared endpoint for the API, worker,
+# and OTel Collector. A chart-owned install must ignore langfuse.host; BYO mode
+# must require it, route every consumer to it, and leave no dead in-chart
+# Langfuse resources or Service hostname behind.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART="$(cd "$SCRIPT_DIR/.." && pwd)"
+TMP="$(mktemp -d)"
+
+cleanup() {
+  [[ -n "${TMP:-}" && -d "$TMP" ]] && rm -rf -- "$TMP"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+render() {
+  local chart="$1"
+  local name="$2"
+  shift 2
+  helm template curie "$chart" --output-dir "$TMP/$name" "$@" >/dev/null
+}
+
+CHECKER="$TMP/check-render.py"
+cat > "$CHECKER" <<'PY'
+import pathlib
+import sys
+
+import yaml
+
+
+def die(message):
+    raise SystemExit(message)
+
+
+def load_documents(root):
+    root = pathlib.Path(root)
+    loaded = []
+    for path in sorted(root.rglob("*.yaml")):
+        for index, document in enumerate(yaml.safe_load_all(path.read_text()), start=1):
+            if isinstance(document, dict):
+                loaded.append((path, index, document))
+    if not loaded:
+        die(f"{root}: Helm wrote no YAML documents")
+    return root, loaded
+
+
+def one_resource(documents, kind, name):
+    matches = [
+        document
+        for _, _, document in documents
+        if document.get("kind") == kind
+        and document.get("metadata", {}).get("name") == name
+    ]
+    if len(matches) != 1:
+        die(f"expected exactly one {kind}/{name}, found {len(matches)}")
+    return matches[0]
+
+
+def env_value(deployment, variable):
+    entries = [
+        entry
+        for container in deployment.get("spec", {})
+        .get("template", {})
+        .get("spec", {})
+        .get("containers", [])
+        for entry in container.get("env", [])
+        if entry.get("name") == variable
+    ]
+    resource = deployment.get("metadata", {}).get("name")
+    if len(entries) != 1:
+        die(
+            f"Deployment/{resource}: expected exactly one {variable} entry, "
+            f"found {len(entries)}"
+        )
+    if set(entries[0]) != {"name", "value"}:
+        die(
+            f"Deployment/{resource}: {variable} must be one literal value, "
+            f"got {entries[0]!r}"
+        )
+    return entries[0]["value"]
+
+
+def assert_endpoints(documents, expected_base):
+    for deployment_name in ("curie-api", "curie-worker"):
+        deployment = one_resource(documents, "Deployment", deployment_name)
+        actual = env_value(deployment, "LANGFUSE_HOST")
+        if actual != expected_base:
+            die(
+                f"Deployment/{deployment_name}: LANGFUSE_HOST is {actual!r}, "
+                f"expected {expected_base!r}"
+            )
+
+    config_map = one_resource(documents, "ConfigMap", "curie-otel-collector")
+    raw_config = config_map.get("data", {}).get("collector-config.yaml")
+    if not isinstance(raw_config, str) or not raw_config.strip():
+        die("ConfigMap/curie-otel-collector: collector-config.yaml is missing")
+    config = yaml.safe_load(raw_config)
+    try:
+        actual_endpoint = config["exporters"]["otlphttp/langfuse"]["endpoint"]
+    except (KeyError, TypeError) as exc:
+        die(
+            "ConfigMap/curie-otel-collector: exporters.otlphttp/langfuse.endpoint "
+            f"is missing ({exc})"
+        )
+    expected_endpoint = f"{expected_base}/api/public/otel"
+    if actual_endpoint != expected_endpoint:
+        die(
+            "ConfigMap/curie-otel-collector: Langfuse endpoint is "
+            f"{actual_endpoint!r}, expected {expected_endpoint!r}"
+        )
+
+
+def scalar_residue(value, needle, path="$"):
+    found = []
+    if isinstance(value, dict):
+        for key, child in value.items():
+            found.extend(scalar_residue(child, needle, f"{path}.{key}"))
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            found.extend(scalar_residue(child, needle, f"{path}[{index}]"))
+    elif isinstance(value, str) and needle in value:
+        found.append(path)
+    return found
+
+
+command, root_arg, expected_base = sys.argv[1:4]
+root, documents = load_documents(root_arg)
+
+if command == "internal":
+    assert_endpoints(documents, expected_base)
+    one_resource(documents, "Service", "curie-langfuse-web")
+    one_resource(documents, "Deployment", "curie-langfuse-web")
+    one_resource(documents, "Deployment", "curie-langfuse-worker")
+elif command == "external":
+    assert_endpoints(documents, expected_base)
+    forbidden = {
+        ("Service", "curie-langfuse-web"),
+        ("Deployment", "curie-langfuse-web"),
+        ("Deployment", "curie-langfuse-worker"),
+        ("Job", "curie-langfuse-model-pricing"),
+    }
+    present = sorted(
+        (document.get("kind"), document.get("metadata", {}).get("name"))
+        for _, _, document in documents
+        if (document.get("kind"), document.get("metadata", {}).get("name"))
+        in forbidden
+    )
+    if present:
+        die(f"BYO render still contains chart-owned Langfuse resources: {present!r}")
+
+    forbidden_files = {
+        "langfuse.yaml",
+        "langfuse-model-pricing.yaml",
+    }
+    rendered_files = sorted(
+        str(path.relative_to(root))
+        for path in root.rglob("*.yaml")
+        if path.name in forbidden_files
+    )
+    if rendered_files:
+        die(f"BYO render wrote gated Langfuse template files: {rendered_files!r}")
+
+    residue = []
+    for path, index, document in documents:
+        for value_path in scalar_residue(document, "curie-langfuse-web"):
+            residue.append(f"{path.relative_to(root)} document {index} {value_path}")
+    if residue:
+        die(
+            "BYO render retains the internal Service hostname curie-langfuse-web "
+            f"at {residue!r}"
+        )
+elif command == "harness":
+    api = one_resource(documents, "Deployment", "curie-api")
+    actual = env_value(api, "LANGFUSE_HOST")
+    if actual != expected_base:
+        die(
+            f"Deployment/curie-api: LANGFUSE_HOST is {actual!r}, "
+            f"expected {expected_base!r}"
+        )
+    langfuse_services = [
+        document.get("metadata", {}).get("name")
+        for _, _, document in documents
+        if document.get("kind") == "Service"
+        and document.get("metadata", {}).get("name") == "curie-langfuse-web"
+    ]
+    if langfuse_services:
+        die(
+            "trimmed harness render still contains the chart-owned Langfuse "
+            f"Service: {langfuse_services!r}"
+        )
+else:
+    die(f"unknown checker command {command!r}")
+PY
+
+echo "=== BYO Langfuse assertion 1: chart-owned mode ignores an external host override ==="
+render "$CHART" internal --set-string langfuse.host=ignored.example.com
+python3 "$CHECKER" internal "$TMP/internal" "http://curie-langfuse-web:3000"
+echo "  ok: API, worker, and collector use the chart-owned Langfuse Service"
+
+echo "=== BYO Langfuse assertion 2: external host and non-default port reach every consumer ==="
+render "$CHART" external \
+  --set langfuse.deploy=false \
+  --set-string langfuse.host=langfuse.example.com \
+  --set langfuse.web.service.port=4319
+python3 "$CHECKER" external "$TMP/external" "http://langfuse.example.com:4319"
+echo "  ok: exact BYO endpoint is shared and no chart-owned Langfuse residue remains"
+
+echo "=== BYO Langfuse assertion 3: trimmed runtime harness supplies its own Langfuse host ==="
+render "$CHART" harness \
+  -f "$CHART/values-e2e-nogvisor.yaml" \
+  -f "$CHART/values-e2e-harness.yaml" \
+  --set api.deploy=true \
+  --set api.replicas=0 \
+  --set api.service.type=NodePort \
+  --set api.service.nodePort=30181 \
+  --set-string postgres.host=postgres.example.com \
+  --set-string valkey.host=valkey.example.com
+python3 "$CHECKER" harness "$TMP/harness" "http://langfuse.example.com:3000"
+echo "  ok: the API uses the harness Langfuse endpoint without a chart-owned Service"
+
+expect_host_failure() {
+  local name="$1"
+  shift
+  local stderr="$TMP/$name.stderr"
+  if helm template curie "$CHART" --output-dir "$TMP/$name" "$@" \
+    >/dev/null 2>"$stderr"; then
+    fail "$name: langfuse.deploy=false rendered without a non-empty langfuse.host"
+  fi
+  if ! grep -qF "langfuse.host" "$stderr"; then
+    fail "$name: render failed without naming langfuse.host: $(<"$stderr")"
+  fi
+}
+
+echo "=== BYO Langfuse assertion 4: missing and empty external hosts fail closed ==="
+expect_host_failure missing-host --set langfuse.deploy=false
+expect_host_failure empty-host \
+  --set langfuse.deploy=false \
+  --set-string 'langfuse.host='
+echo "  ok: both rejected renders name langfuse.host"
+
+echo "=== BYO Langfuse assertion 5: reverting the shared host helper is detected ==="
+MUTANT="$TMP/mutant-chart"
+cp -a "$CHART" "$MUTANT"
+python3 - "$MUTANT/templates/_helpers.tpl" <<'PY'
+import pathlib
+import re
+import sys
+
+
+path = pathlib.Path(sys.argv[1])
+text = path.read_text()
+tokens = list(re.finditer(r"{{-?\s*(.*?)\s*-?}}", text, re.DOTALL))
+start = None
+end = None
+depth = 0
+
+for token in tokens:
+    directive = token.group(1).strip()
+    if start is None:
+        if re.fullmatch(r'define\s+"curie\.langfuse\.webHost"', directive):
+            start = token.start()
+            depth = 1
+        continue
+
+    keyword = directive.split(None, 1)[0] if directive else ""
+    if keyword in {"block", "define", "if", "range", "with"}:
+        depth += 1
+    elif keyword == "end":
+        depth -= 1
+        if depth == 0:
+            end = token.end()
+            break
+
+if start is None or end is None:
+    sys.exit(
+        "negative control could not locate the complete "
+        "curie.langfuse.webHost helper block"
+    )
+
+old_unconditional = """{{- define "curie.langfuse.webHost" -}}
+{{- printf "%s-langfuse-web" (include "curie.fullname" .) -}}
+{{- end -}}"""
+current = text[start:end]
+if current == old_unconditional:
+    sys.exit(
+        "negative control found the old unconditional curie.langfuse.webHost "
+        "already present; there is no deploy-aware helper to revert"
+    )
+
+path.write_text(text[:start] + old_unconditional + text[end:])
+PY
+
+render "$MUTANT" mutant-external \
+  --set langfuse.deploy=false \
+  --set-string langfuse.host=langfuse.example.com \
+  --set langfuse.web.service.port=4319
+
+mutation_error=""
+if mutation_error="$(
+  python3 "$CHECKER" external "$TMP/mutant-external" \
+    "http://langfuse.example.com:4319" 2>&1
+)"; then
+  fail "negative control did not fire: the old unconditional Service helper passed the BYO endpoint contract"
+fi
+if [[ "$mutation_error" != *"curie-langfuse-web"* ]]; then
+  fail "negative control failed for an unexpected reason: $mutation_error"
+fi
+echo "  ok: the external-consumer checker rejects the reverted helper"
+
+echo "BYO Langfuse host assertions passed"

--- a/charts/curie/templates/NOTES.txt
+++ b/charts/curie/templates/NOTES.txt
@@ -3,6 +3,8 @@ Curie umbrella chart installed as release "{{ .Release.Name }}" in namespace "{{
 Components deployed:
 {{- if .Values.langfuse.deploy }}
   - Langfuse web + worker (v{{ .Values.langfuse.image.tag }})
+{{- else }}
+  - Langfuse: BYO at http://{{ include "curie.langfuse.webHost" . }}:{{ .Values.langfuse.web.service.port }}
 {{- end }}
 {{- if .Values.postgres.deploy }}
   - Postgres ({{ .Values.postgres.image }})

--- a/charts/curie/templates/_helpers.tpl
+++ b/charts/curie/templates/_helpers.tpl
@@ -270,7 +270,11 @@ true
 {{- end -}}
 
 {{- define "curie.langfuse.webHost" -}}
+{{- if .Values.langfuse.deploy -}}
 {{- printf "%s-langfuse-web" (include "curie.fullname" .) -}}
+{{- else -}}
+{{- required "langfuse.deploy is false: set langfuse.host to your external Langfuse hostname" .Values.langfuse.host -}}
+{{- end -}}
 {{- end -}}
 
 {{/* Base URL of the platform API for a first-party service that calls it. Call

--- a/charts/curie/values-e2e-harness.yaml
+++ b/charts/curie/values-e2e-harness.yaml
@@ -21,7 +21,9 @@
 
 # Backing stores the bundle-fetch/runner path does not touch.
 langfuse:
+  # The harness selectively re-enables a zero-replica API, which still renders this dependency env.
   deploy: false
+  host: langfuse.example.com
 postgres:
   deploy: false
 valkey:

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -103,6 +103,9 @@ priorityClasses:
 # ---------------------------------------------------------------------------
 langfuse:
   deploy: true
+  # Bare external hostname required only when deploy is false. Consumers append
+  # langfuse.web.service.port; do not include a scheme or port here.
+  host: ""
   image:
     web: langfuse/langfuse
     worker: langfuse/langfuse-worker

--- a/scripts/chart-runtime-e2e.sh
+++ b/scripts/chart-runtime-e2e.sh
@@ -1071,6 +1071,7 @@ banner "INSTALL trimmed chart"
 CHART_VALUES=(
   -f "$CHART_PATH/values-e2e-nogvisor.yaml"
   -f "$CHART_PATH/values-e2e-harness.yaml"
+  -f "$OTEL_OVERLAY"
   --set api.deploy=true
   --set api.replicas=0
   --set api.service.type=NodePort


### PR DESCRIPTION
Closes #1505

## Summary

- require a bare `langfuse.host` when `langfuse.deploy=false` and route API, worker, and OTel consumers through the shared external endpoint
- assert managed, BYO, trimmed-harness, missing-host, and reverted-helper behavior in the chart CI matrix
- document the HTTP-only transport and matching project credential requirements; report the BYO endpoint in Helm NOTES
- apply the runtime E2E OTel overlay that the mandatory harness already generated but did not load

## Evidence

- Precondition: issue OPEN in milestone v0.8.2; baseline `helm template` created zero Langfuse Services but emitted three references to the absent in-cluster Service
- `curie dev chart-check`: all 33 chart assertion scripts passed
- `bash scripts/check-docs.sh`: passed
- Helm lint: default, values-dev, and values-dev + no-gVisor overlays passed
- `curie dev verify-fix-pin HEAD charts/curie/ci/langfuse-byo-assertions.sh`: `PINNED`
- `curie dev chart-runtime-e2e --force` on a fresh task-owned kind cluster: passed bundle init, runtime security, OTel delivery/outage/restart/recovery/overflow, and teardown
- live positive: API Deployment had `LANGFUSE_HOST=http://langfuse.example.com:3000`; no Langfuse Service, Deployment, StatefulSet, or Job existed
- live negative: empty `langfuse.host` failed install naming the key; no Helm release or labeled resources were created

## Tier classification

| Tier | Decision | Evidence / reason |
| --- | --- | --- |
| skill | N/A | no plugin packaging, runner loop, ACI event, eval, or skill-check surface |
| local | N/A | no compose service, console, API wiring, or CLI output/exit-code change |
| local-release | N/A | no released binary/image identity, install path, version pin, or release compose change |
| cluster | Required | chart templates and harness path changed; fresh kind runtime E2E and live positive/negative installs passed |
| live provider | N/A | no model routing, provider auth, token, or cost-accounting behavior |
| external integration | N/A | no Slack, webhook, OAuth, or third-party API-shape change |

## Done-check

- [x] Failing tests were committed before implementation: `9724a4e7` preceded `fb61282d`; the harness regression contract `8e1563ca` preceded its fix `1f255b2c` (pipeline commits inspected before squash).
- [x] All production and documentation edits were made by delegated native Codex workers; the driver performed only validation, git, and run bookkeeping.
- [x] No public return type was broadened; `curie.langfuse.webHost` remains a string-valued helper with a new fail-closed branch.
- [x] Routed Code reviews approved the implementation, harness repair, and final docs with file:line evidence.
- [x] Routed Scope reviews mapped every hunk to #1505 or the mandatory E2E harness repair; no passengers were found.
- [x] Sibling-path parity is covered: API, worker, and OTel use the shared helper; chart-owned web/worker/Service/model-pricing resources remain jointly gated; the trimmed harness is an asserted secondary path.
- [x] The new guard was executed against missing and empty hosts; both failed naming `langfuse.host`, and live install created no release/resources.
- [x] Consolidation ran after review and found no safe simplification; no consolidation diff required revalidation.
- [x] Routed Security review approved the external-host, auth, placeholder, and HTTP-only documentation; findings were reconciled.
- [x] Observable verification proved the rendered URL, resource omission, NOTES output, and negative render behavior.
- [x] An independent E2E verifier observed the deployed API endpoint and absence of chart-owned Langfuse resources on the task-owned cluster.
- [x] Full affected validation passed: docs lint, three Helm lint variants, dev render, all 33 chart assertions, focused NOTES check, runtime E2E, and fix pin.

No merge, deployment, release, publication, tag, production/soak mutation, frozen-contract change, or ADR change was performed.