### PR TITLE
Refuse ephemeral cluster model downloads

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -118,6 +118,15 @@ jobs:
           set -euo pipefail
           bash charts/curie/ci/litellm-sidecar-assertions.sh
 
+      # Prove cluster-local inference cannot silently download model weights
+      # into an emptyDir (issue #1779): the unsafe pull+ephemeral combination
+      # fails with both recovery paths, while durable pulls and explicitly
+      # pre-provisioned/no-pull ephemeral models retain their intended shapes.
+      - name: helm render assertions (inference download guard)
+        run: |
+          set -euo pipefail
+          bash charts/curie/ci/inference-download-guard-assertions.sh
+
       # Prove the direct-passthrough existingSecret escape (issue #1759): the
       # eight keys that previously had none now resolve to the chart's own
       # Secret by default and to an operator-named Secret when

--- a/charts/curie/ci/inference-download-guard-assertions.sh
+++ b/charts/curie/ci/inference-download-guard-assertions.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+#
+# Render-assertion test for issue #1779. Enabling cluster-local inference with
+# the shipped pullModel=true and persistence.enabled=false values must fail
+# closed: the postStart hook would otherwise download model weights into an
+# emptyDir and repeat that implicit download whenever the pod is replaced.
+#
+# Proves all supported branches of the guard:
+#
+#   1. inference.deploy=true with the remaining defaults is refused with one
+#      exact, actionable message naming both supported recoveries.
+#   2. Durable persistence keeps the model pull and mounts the generated PVC.
+#   3. A pre-provisioned model (pullModel=false) may use ephemeral storage, but
+#      renders neither a postStart hook nor an `ollama pull` command.
+#   4. inference.deploy=false remains unaffected by inference value defaults.
+#
+# Runnable locally (from anywhere) and from CI. Fails loudly.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+TPL=templates/inference.yaml
+REFUSAL='inference.deploy=true with inference.pullModel=true would implicitly download model weights into an ephemeral emptyDir; enable durable storage with inference.persistence.enabled=true, or pre-provision the model and set inference.pullModel=false.'
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+expect_default_pull_refused() {
+  local stdout="$TMP/default-pull.stdout"
+  local stderr="$TMP/default-pull.stderr"
+
+  if helm template rel "$CHART" --show-only "$TPL" \
+    --set inference.deploy=true > "$stdout" 2> "$stderr"; then
+    fail "inference.deploy=true with the shipped ephemeral pull defaults must be refused."
+  fi
+  if ! grep -Fq -- "$REFUSAL" "$stdout" "$stderr"; then
+    fail "unsafe inference defaults failed without the required recovery message. Expected exact message: $REFUSAL"
+  fi
+  echo "  ok: implicit download to emptyDir was refused with both recoveries"
+}
+
+render_inference() {
+  local output="$1"
+  shift
+
+  if ! helm template rel "$CHART" --show-only "$TPL" "$@" > "$output"; then
+    fail "supported inference values failed to render: $*"
+  fi
+}
+
+assert_inference_shape() {
+  local output="$1"
+  local expected="$2"
+
+  python3 - "$output" "$expected" <<'PY'
+import sys
+
+import yaml
+
+
+path, expected = sys.argv[1:]
+with open(path, encoding="utf-8") as rendered:
+    text = rendered.read()
+docs = [doc for doc in yaml.safe_load_all(text) if doc]
+
+
+def one(kind):
+    matches = [doc for doc in docs if doc.get("kind") == kind]
+    if len(matches) != 1:
+        raise SystemExit(
+            f"{path}: expected exactly one {kind}, got {len(matches)}"
+        )
+    return matches[0]
+
+
+deployment = one("Deployment")
+pod_spec = deployment["spec"]["template"]["spec"]
+containers = {
+    container["name"]: container for container in pod_spec.get("containers") or []
+}
+if "ollama" not in containers:
+    raise SystemExit(f"{path}: inference Deployment has no ollama container")
+ollama = containers["ollama"]
+
+volumes = {volume["name"]: volume for volume in pod_spec.get("volumes") or []}
+if "ollama-data" not in volumes:
+    raise SystemExit(f"{path}: inference Deployment has no ollama-data volume")
+data_volume = volumes["ollama-data"]
+
+if expected == "persistent-pull":
+    pvc = one("PersistentVolumeClaim")
+    claim_name = data_volume.get("persistentVolumeClaim", {}).get("claimName")
+    if claim_name != pvc["metadata"]["name"]:
+        raise SystemExit(
+            f"{path}: ollama-data does not mount the rendered PVC; "
+            f"claimName={claim_name!r}, pvc={pvc['metadata']['name']!r}"
+        )
+    if "emptyDir" in data_volume:
+        raise SystemExit(f"{path}: durable inference also rendered an emptyDir")
+    post_start = (
+        (ollama.get("lifecycle") or {}).get("postStart") or {}
+    ).get("exec") or {}
+    command = post_start.get("command") or []
+    if not any("ollama pull" in str(part) for part in command):
+        raise SystemExit(
+            f"{path}: durable inference did not retain its postStart ollama pull"
+        )
+    print("  ok: durable inference renders a PVC mount and postStart model pull")
+elif expected == "ephemeral-no-pull":
+    pvcs = [doc for doc in docs if doc.get("kind") == "PersistentVolumeClaim"]
+    if pvcs:
+        raise SystemExit(f"{path}: pullModel=false ephemeral inference rendered a PVC")
+    if "emptyDir" not in data_volume:
+        raise SystemExit(f"{path}: ephemeral inference did not render an emptyDir")
+    if "persistentVolumeClaim" in data_volume:
+        raise SystemExit(f"{path}: ephemeral inference also rendered a PVC mount")
+    post_start = (ollama.get("lifecycle") or {}).get("postStart")
+    if post_start is not None:
+        raise SystemExit(
+            f"{path}: pullModel=false still rendered a postStart hook: {post_start!r}"
+        )
+    if "ollama pull" in text:
+        raise SystemExit(f"{path}: pullModel=false still rendered an ollama pull")
+    print("  ok: no-pull inference renders emptyDir without postStart or ollama pull")
+else:
+    raise SystemExit(f"unknown expected inference shape: {expected}")
+PY
+}
+
+assert_inference_disabled() {
+  local output="$1"
+
+  python3 - "$output" <<'PY'
+import sys
+
+import yaml
+
+
+path = sys.argv[1]
+with open(path, encoding="utf-8") as rendered:
+    docs = [doc for doc in yaml.safe_load_all(rendered) if doc]
+
+inference_resources = []
+for doc in docs:
+    metadata = doc.get("metadata") or {}
+    labels = metadata.get("labels") or {}
+    if labels.get("app.kubernetes.io/component") == "inference":
+        inference_resources.append(f"{doc.get('kind')}/{metadata.get('name')}")
+
+if inference_resources:
+    raise SystemExit(
+        f"{path}: inference.deploy=false rendered inference resources: "
+        f"{inference_resources}"
+    )
+print("  ok: inference.deploy=false renders no inference resources")
+PY
+}
+
+echo "=== Assertion 1: unsafe default local-model pull is refused ==="
+expect_default_pull_refused
+
+echo "=== Assertion 2: durable persistence permits the explicit model pull ==="
+PERSISTENT="$TMP/persistent-pull.yaml"
+render_inference "$PERSISTENT" \
+  --set inference.deploy=true \
+  --set inference.persistence.enabled=true
+assert_inference_shape "$PERSISTENT" persistent-pull
+
+echo "=== Assertion 3: pre-provisioned/no-pull permits ephemeral storage ==="
+NO_PULL="$TMP/ephemeral-no-pull.yaml"
+render_inference "$NO_PULL" \
+  --set inference.deploy=true \
+  --set inference.pullModel=false
+assert_inference_shape "$NO_PULL" ephemeral-no-pull
+
+echo "=== Assertion 4: inference.deploy=false is unaffected ==="
+DISABLED="$TMP/disabled.yaml"
+if ! helm template rel "$CHART" \
+  --set inference.deploy=false \
+  --set inference.pullModel=true \
+  --set inference.persistence.enabled=false > "$DISABLED"; then
+  fail "inference.deploy=false must not activate the download guard."
+fi
+assert_inference_disabled "$DISABLED"
+
+echo
+echo "PASS: cluster inference refuses implicit emptyDir downloads and accepts both explicit recovery paths."

--- a/charts/curie/ci/litellm-sidecar-assertions.sh
+++ b/charts/curie/ci/litellm-sidecar-assertions.sh
@@ -89,11 +89,13 @@ expect_refused sandbox-disabled \
   --set agentSandbox.deploy=false
 expect_refused inference-enabled \
   --set agentSandbox.runner.liteLLM.enabled=true \
-  --set inference.deploy=true
+  --set inference.deploy=true \
+  --set inference.persistence.enabled=true
 expect_refused both-bypasses \
   --set agentSandbox.runner.liteLLM.enabled=true \
   --set agentSandbox.deploy=false \
-  --set inference.deploy=true
+  --set inference.deploy=true \
+  --set inference.persistence.enabled=true
 expect_refused string-enabled \
   --set-string agentSandbox.runner.liteLLM.enabled=true
 

--- a/charts/curie/ci/render-assertions.sh
+++ b/charts/curie/ci/render-assertions.sh
@@ -386,6 +386,7 @@ check_runner_env "$CHART" "default values" \
 check_runner_env "$CHART" "credentials + in-cluster inference" \
   --set agentSandbox.runner.credentials=dummy \
   --set inference.deploy=true \
+  --set inference.persistence.enabled=true \
   || fail "widened render carries a runner env name that is not a declared boot-env key."
 
 echo "=== Assertion 7: negative control -- a misspelled runner env name FAILS ==="
@@ -1069,6 +1070,7 @@ PLACEMENT_HELM_ARGS=(
   --set dispatcher.slack.appToken=xapp-placement-render
   --set dispatcher.slack.botToken=xoxb-placement-render
   --set inference.deploy=true
+  --set inference.persistence.enabled=true
   --set security.gvisor.mode=require
 )
 

--- a/charts/curie/templates/inference.yaml
+++ b/charts/curie/templates/inference.yaml
@@ -1,3 +1,6 @@
+{{- if and .Values.inference.deploy .Values.inference.pullModel (not .Values.inference.persistence.enabled) }}
+{{- fail "inference.deploy=true with inference.pullModel=true would implicitly download model weights into an ephemeral emptyDir; enable durable storage with inference.persistence.enabled=true, or pre-provision the model and set inference.pullModel=false." }}
+{{- end }}
 {{- if .Values.inference.deploy }}
 {{- if .Values.inference.persistence.enabled }}
 apiVersion: v1

--- a/cli/src/installation.rs
+++ b/cli/src/installation.rs
@@ -61,6 +61,10 @@ pub struct Platform {
     pub ui: Option<bool>,
     #[serde(default)]
     pub inference: Option<bool>,
+    #[serde(default)]
+    pub inference_persistence: Option<bool>,
+    #[serde(default)]
+    pub inference_pull_model: Option<bool>,
     /// Named providers, resolved to narrow host CIDRs at install time. Named
     /// hosts rather than hand-written CIDRs because the allowlist is a security
     /// control, and a hand-copied range is how it silently goes wrong.
@@ -148,6 +152,24 @@ impl Installation {
             if e.host.trim().is_empty() {
                 bail!("platform.egress[].host must not be empty");
             }
+        }
+        if self.platform.inference == Some(true)
+            && !crate::ops::inference_asset_policy_is_safe(
+                self.platform.inference_persistence,
+                self.platform.inference_pull_model,
+            )
+        {
+            return Err(crate::exit::CliError::usage(
+                "`platform.inference: true` requires an explicit model-weight policy: set \
+                 `inference_persistence: true` under `platform` to pull weights into persistent \
+                 storage, or set `inference_pull_model: false` there when the model is already \
+                 present",
+            )
+            .with_fix(
+                "add either `platform.inference_persistence: true` or \
+                 `platform.inference_pull_model: false` to curie.yaml",
+            )
+            .into());
         }
         for (key, value) in &self.set {
             let trimmed = value.trim();
@@ -244,9 +266,18 @@ impl Installation {
         }
         if let Some(inference) = self.platform.inference {
             out.push(format!("inference.deploy={inference}"));
-            if inference {
-                out.push("inference.persistence.enabled=true".to_string());
-            }
+        }
+        if let Some(persistence) = self.platform.inference_persistence {
+            out.push(format!(
+                "{}={persistence}",
+                crate::ops::INFERENCE_PERSISTENCE_ENABLED_KEY
+            ));
+        }
+        if let Some(pull_model) = self.platform.inference_pull_model {
+            out.push(format!(
+                "{}={pull_model}",
+                crate::ops::INFERENCE_PULL_MODEL_KEY
+            ));
         }
         out
     }

--- a/cli/src/installation.rs
+++ b/cli/src/installation.rs
@@ -244,6 +244,9 @@ impl Installation {
         }
         if let Some(inference) = self.platform.inference {
             out.push(format!("inference.deploy={inference}"));
+            if inference {
+                out.push("inference.persistence.enabled=true".to_string());
+            }
         }
         out
     }

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -604,6 +604,16 @@ pub fn model_credential_env() -> Result<Option<String>> {
 /// The helm value key that pins the sandbox runner model in the chart.
 const RUNNER_MODEL_KEY: &str = "agentSandbox.runner.model";
 
+pub(crate) const INFERENCE_PERSISTENCE_ENABLED_KEY: &str = "inference.persistence.enabled";
+pub(crate) const INFERENCE_PULL_MODEL_KEY: &str = "inference.pullModel";
+
+pub(crate) fn inference_asset_policy_is_safe(
+    persistence_enabled: Option<bool>,
+    pull_model: Option<bool>,
+) -> bool {
+    persistence_enabled == Some(true) || pull_model == Some(false)
+}
+
 /// The value of the last explicit `--set agentSandbox.runner.model=VAL` in
 /// `set`, if the operator passed one (last wins, matching helm precedence).
 /// Helm accepts comma-joined `--set a=1,b=2`, so each element is split on `,`
@@ -662,6 +672,7 @@ pub(crate) fn validate_up_inputs(
     github_token: Option<&str>,
     clear_github_token: bool,
 ) -> Result<()> {
+    validate_local_model_asset_policy(opts)?;
     validate_web_egress_cidrs(&opts.allow_web_egress)
         .context("invalid --allow-web-egress value")?;
     let operator_sets = opts.operator_sets();
@@ -671,6 +682,41 @@ pub(crate) fn validate_up_inputs(
         parse_egress_provider(host)?;
     }
     Ok(())
+}
+
+fn last_typed_bool(sets: &[String], key: &str) -> Option<bool> {
+    operator_set_entries(sets)
+        .into_iter()
+        .filter_map(|(candidate, value)| (candidate.trim() == key).then_some(value.trim()))
+        .next_back()
+        .and_then(|value| match value {
+            "true" => Some(true),
+            "false" => Some(false),
+            _ => None,
+        })
+}
+
+fn validate_local_model_asset_policy(opts: &UpOpts) -> Result<()> {
+    if opts.local_model.is_none() {
+        return Ok(());
+    }
+    let persistence_enabled = last_typed_bool(&opts.set, INFERENCE_PERSISTENCE_ENABLED_KEY);
+    let pull_model = last_typed_bool(&opts.set, INFERENCE_PULL_MODEL_KEY);
+    if inference_asset_policy_is_safe(persistence_enabled, pull_model) {
+        return Ok(());
+    }
+
+    Err(crate::exit::CliError::usage(
+        "`--local-model` requires an explicit model-weight policy: pass \
+         `--set inference.persistence.enabled=true` to pull weights into persistent storage, \
+         or pass `--set inference.pullModel=false` when the model is already present; \
+         `--set-string` cannot express the required typed boolean policy",
+    )
+    .with_fix(
+        "re-run with `--set inference.persistence.enabled=true` or \
+         `--set inference.pullModel=false`",
+    )
+    .into())
 }
 
 /// Validate every operator-supplied `--allow-web-egress` value is a real CIDR

--- a/cli/tests/cluster_up_inference.rs
+++ b/cli/tests/cluster_up_inference.rs
@@ -39,6 +39,7 @@ struct Fixture {
     _temp: tempfile::TempDir,
     bin_dir: PathBuf,
     helm_log: PathBuf,
+    kubectl_log: PathBuf,
     upgrade_log: PathBuf,
     existing_values: String,
 }
@@ -49,6 +50,7 @@ impl Fixture {
         let bin_dir = temp.path().join("bin");
         fs::create_dir(&bin_dir).expect("create fake binary directory");
         let helm_log = temp.path().join("helm.log");
+        let kubectl_log = temp.path().join("kubectl.log");
         let upgrade_log = temp.path().join("upgrades.log");
 
         write_exec(
@@ -95,6 +97,8 @@ exit 64
             &bin_dir,
             "kubectl",
             r#"#!/bin/sh
+printf '%s\n' "$*" >> "$CURIE_TEST_KUBECTL_LOG"
+
 if [ "$1" = "get" ] && [ "$2" = "namespace" ]; then
     exit 0
 fi
@@ -120,6 +124,7 @@ exit 64
             _temp: temp,
             bin_dir,
             helm_log,
+            kubectl_log,
             upgrade_log,
             existing_values: existing_values.to_string(),
         }
@@ -165,6 +170,7 @@ exit 64
             .env("TERM", "dumb")
             .env("NO_COLOR", "1")
             .env("CURIE_TEST_HELM_LOG", &self.helm_log)
+            .env("CURIE_TEST_KUBECTL_LOG", &self.kubectl_log)
             .env("CURIE_TEST_UPGRADE_LOG", &self.upgrade_log)
             .env("CURIE_TEST_EXISTING_VALUES", &self.existing_values)
             .env("CURIE_TEST_PROVIDER_EGRESS_JSON", resolver)
@@ -185,6 +191,10 @@ exit 64
 
     fn upgrade_log(&self) -> String {
         fs::read_to_string(&self.upgrade_log).unwrap_or_default()
+    }
+
+    fn kubectl_log(&self) -> String {
+        fs::read_to_string(&self.kubectl_log).unwrap_or_default()
     }
 
     fn upgrade_count(&self) -> usize {
@@ -534,6 +544,95 @@ fn inference_uses_the_effective_credential_precedence() {
     assert_success(&preserved, &output);
     assert!(preserved.upgrade_log().contains("1.1.1.1/32"));
     assert_inference_once(&stderr(&output), "--allow-egress-host openrouter");
+}
+
+#[test]
+fn local_model_without_an_explicit_asset_policy_refuses_before_cluster_access() {
+    let fixture = Fixture::new("");
+    let output = fixture.run(&[], VALID_RESOLVER, &["--local-model", "qwen3:4b"]);
+    let shown = all_output(&output);
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "an ambiguous local-model asset policy is a usage error: {shown}"
+    );
+    for recovery in [
+        "--set inference.persistence.enabled=true",
+        "--set inference.pullModel=false",
+    ] {
+        assert!(
+            shown.contains(recovery),
+            "the refusal must include both runnable recovery choices ({recovery}): {shown}"
+        );
+    }
+    assert!(
+        fixture.helm_log().is_empty(),
+        "the asset-policy refusal must precede every Helm read or mutation: {}",
+        fixture.helm_log()
+    );
+    assert!(
+        fixture.kubectl_log().is_empty(),
+        "the asset-policy refusal must precede every cluster interaction: {}",
+        fixture.kubectl_log()
+    );
+}
+
+#[test]
+fn local_model_accepts_each_explicit_typed_asset_policy() {
+    for policy in [
+        "inference.persistence.enabled=true",
+        "inference.pullModel=false",
+    ] {
+        let fixture = Fixture::new("");
+        let output = fixture.run(
+            &[],
+            VALID_RESOLVER,
+            &["--local-model", "qwen3:4b", "--set", policy],
+        );
+        assert_success(&fixture, &output);
+
+        let upgrade = fixture.upgrade_log();
+        for expected in ["inference.deploy=true", "inference.model=qwen3:4b", policy] {
+            assert!(
+                upgrade.contains(&format!("--set {expected}")),
+                "the accepted local-model policy must stay in Helm's typed lane ({expected}): {upgrade}"
+            );
+        }
+        assert!(
+            !upgrade.contains(&format!("--set-string {policy}")),
+            "a modeled boolean policy must never be passed as a Helm string: {upgrade}"
+        );
+    }
+}
+
+#[test]
+fn string_false_is_not_a_valid_no_pull_recovery() {
+    let fixture = Fixture::new("");
+    let output = fixture.run(
+        &[],
+        VALID_RESOLVER,
+        &[
+            "--local-model",
+            "qwen3:4b",
+            "--set-string",
+            "inference.pullModel=false",
+        ],
+    );
+    let shown = all_output(&output);
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "a Helm string false is truthy and must not satisfy no-pull: {shown}"
+    );
+    assert_eq!(fixture.upgrade_count(), 0, "string false must not install");
+    assert!(
+        fixture.helm_log().is_empty() && fixture.kubectl_log().is_empty(),
+        "string false must be rejected before cluster access; helm: {}; kubectl: {}",
+        fixture.helm_log(),
+        fixture.kubectl_log()
+    );
 }
 
 /// #1145, through the real consumer path: `curie cluster up --dev` against a

--- a/cli/tests/credential_resolution.rs
+++ b/cli/tests/credential_resolution.rs
@@ -767,7 +767,15 @@ fn local_credential_free_modes_do_not_read_private_storage() {
 fn cluster_credential_free_modes_do_not_read_private_storage() {
     for (label, mode_args) in [
         ("fake model", vec!["--fake-model"]),
-        ("local model", vec!["--local-model", "qwen3:8b"]),
+        (
+            "local model",
+            vec![
+                "--local-model",
+                "qwen3:8b",
+                "--set",
+                "inference.pullModel=false",
+            ],
+        ),
     ] {
         let fixture = unreadable_vault_with_saved_curie_credentials();
         let mut cmd = promotion_command(&fixture);

--- a/cli/tests/installation_plan_parity.rs
+++ b/cli/tests/installation_plan_parity.rs
@@ -1091,7 +1091,7 @@ fn live_both_store_statefulsets() -> String {
 }
 
 fn installation_with_effective_values() -> &'static str {
-    "version: 1\ninstall:\n  namespace: parity\n  release: parity\ncredentials:\n  model: CURIE_APPLY_TEST_MODEL_KEY\n  github_token: CURIE_APPLY_TEST_GITHUB_TOKEN\nplatform:\n  ui: false\n  inference: true\nset:\n  example.mode: disabled\n  worker.replicas: \"3\"\n"
+    "version: 1\ninstall:\n  namespace: parity\n  release: parity\ncredentials:\n  model: CURIE_APPLY_TEST_MODEL_KEY\n  github_token: CURIE_APPLY_TEST_GITHUB_TOKEN\nplatform:\n  ui: false\n  inference: true\n  inference_persistence: true\nset:\n  example.mode: disabled\n  worker.replicas: \"3\"\n"
 }
 
 fn installation_with_provider_contradiction() -> &'static str {
@@ -2067,6 +2067,42 @@ fn cluster_up_fresh_release_without_credentials_stays_fake() {
 }
 
 #[test]
+fn apply_and_diff_refuse_inference_without_an_explicit_asset_policy_before_helm() {
+    let config = "version: 1\ninstall:\n  namespace: parity\n  release: parity\nplatform:\n  inference: true\n";
+
+    for verb in ["apply", "diff"] {
+        let fixture = HelmFixture::new(config, HelmValuesResponse::Absent);
+        let output = match verb {
+            "apply" => fixture.apply_dry_run(&[]),
+            "diff" => fixture.diff(&[]),
+            _ => unreachable!(),
+        };
+
+        assert_eq!(
+            output.status.code(),
+            Some(2),
+            "an ambiguous inference asset policy is a usage error for {verb}"
+        );
+        let error = json_error(output, verb);
+        let guidance = format!("{} {}", error["error"], error["fix"]);
+        for recovery in [
+            "inference_persistence: true",
+            "inference_pull_model: false",
+        ] {
+            assert!(
+                guidance.contains(recovery),
+                "{verb} must give both explicit curie.yaml recovery choices ({recovery}): {error}"
+            );
+        }
+        assert!(
+            fixture.calls().is_empty(),
+            "{verb} must refuse before reading or mutating Helm state: {}",
+            fixture.calls()
+        );
+    }
+}
+
+#[test]
 fn absent_release_diff_matches_apply_dry_run_for_effective_installation_values() {
     let fixture = HelmFixture::new(
         installation_with_effective_values(),
@@ -2138,6 +2174,90 @@ fn absent_release_diff_matches_apply_dry_run_for_effective_installation_values()
         .map(String::as_str)
         .collect::<BTreeSet<_>>();
     assert_eq!(diff_keys, apply_keys, "apply plan: {apply}; diff: {diff}");
+}
+
+#[test]
+fn explicit_no_pull_inference_policy_matches_apply_and_diff_typed_plans() {
+    let fixture = HelmFixture::new(
+        "version: 1\ninstall:\n  namespace: parity\n  release: parity\nplatform:\n  inference: true\n  inference_pull_model: false\n",
+        HelmValuesResponse::Absent,
+    );
+
+    let apply = plan(fixture.apply_dry_run(&[]));
+    let diff = json_output(fixture.diff(&[]), "diff");
+    for (key, value) in [
+        ("inference.deploy", "true"),
+        ("inference.pullModel", "false"),
+    ] {
+        let typed = format!("--set {key}={value}");
+        assert!(
+            apply.contains(&typed),
+            "apply must plan the modeled inference value through Helm's typed lane: {apply}"
+        );
+        assert_added(&diff, key, value);
+    }
+    assert!(
+        !apply.contains("--set-string inference.pullModel=false"),
+        "a string false is truthy to Helm and must not represent no-pull: {apply}"
+    );
+}
+
+#[test]
+fn inference_absent_or_false_needs_no_asset_policy_and_keeps_prior_plans() {
+    for (label, config, expected_deploy) in [
+        (
+            "absent",
+            "version: 1\ninstall:\n  namespace: parity\n  release: parity\nplatform:\n  ui: false\n",
+            None,
+        ),
+        (
+            "false",
+            "version: 1\ninstall:\n  namespace: parity\n  release: parity\nplatform:\n  inference: false\n",
+            Some("false"),
+        ),
+    ] {
+        let fixture = HelmFixture::new(config, HelmValuesResponse::Absent);
+        let apply = plan(fixture.apply_dry_run(&[]));
+        let diff = json_output(fixture.diff(&[]), "diff");
+
+        match expected_deploy {
+            Some(value) => {
+                assert!(
+                    apply.contains(&format!("--set inference.deploy={value}")),
+                    "explicit inference=false must retain its typed apply value: {apply}"
+                );
+                assert_added(&diff, "inference.deploy", value);
+            }
+            None => {
+                assert!(
+                    !apply.contains("inference.deploy"),
+                    "absent inference must continue to leave the chart default alone: {apply}"
+                );
+                assert!(
+                    diff["entries"]
+                        .as_array()
+                        .expect("diff entries array")
+                        .iter()
+                        .all(|entry| entry["key"] != "inference.deploy"),
+                    "absent inference must not appear in diff: {diff}"
+                );
+            }
+        }
+        for policy_key in ["inference.persistence.enabled", "inference.pullModel"] {
+            assert!(
+                !apply.contains(policy_key),
+                "inference {label} must not invent {policy_key}: {apply}"
+            );
+            assert!(
+                diff["entries"]
+                    .as_array()
+                    .expect("diff entries array")
+                    .iter()
+                    .all(|entry| entry["key"] != policy_key),
+                "inference {label} must not invent {policy_key}: {diff}"
+            );
+        }
+    }
 }
 
 #[test]

--- a/cli/tests/installation_plan_parity.rs
+++ b/cli/tests/installation_plan_parity.rs
@@ -2100,6 +2100,14 @@ fn absent_release_diff_matches_apply_dry_run_for_effective_installation_values()
     );
     assert_added(&diff, "agentSandbox.runner.credentials", "<secret>");
     assert_added(&diff, "api.githubToken", "<secret>");
+    for key in ["inference.deploy", "inference.persistence.enabled"] {
+        let setting = format!("--set {key}=true");
+        assert!(
+            apply.contains(&setting),
+            "apply must plan the modeled inference boolean through Helm's typed lane: {apply}"
+        );
+        assert_added(&diff, key, "true");
+    }
 
     let apply_values = helm_values(&apply);
     for (key, apply_value) in &apply_values {

--- a/cli/tests/installation_plan_parity.rs
+++ b/cli/tests/installation_plan_parity.rs
@@ -2085,10 +2085,7 @@ fn apply_and_diff_refuse_inference_without_an_explicit_asset_policy_before_helm(
         );
         let error = json_error(output, verb);
         let guidance = format!("{} {}", error["error"], error["fix"]);
-        for recovery in [
-            "inference_persistence: true",
-            "inference_pull_model: false",
-        ] {
+        for recovery in ["inference_persistence: true", "inference_pull_model: false"] {
             assert!(
                 guidance.contains(recovery),
                 "{verb} must give both explicit curie.yaml recovery choices ({recovery}): {error}"

--- a/cli/tests/installation_plan_parity.rs
+++ b/cli/tests/installation_plan_parity.rs
@@ -1939,7 +1939,12 @@ fn cluster_up_explicit_model_modes_suppress_recorded_provider_configuration() {
     for (name, args, expected_value) in [
         (
             "local model",
-            &["--local-model", "qwen3:4b"] as &[&str],
+            &[
+                "--local-model",
+                "qwen3:4b",
+                "--set",
+                "inference.pullModel=false",
+            ] as &[&str],
             Some("inference.model=qwen3:4b"),
         ),
         ("fake model", &["--fake-model"], None),

--- a/docs/local-model.md
+++ b/docs/local-model.md
@@ -11,10 +11,12 @@ Use the flag on whichever target you are running:
 ```bash
 curie skill up --local-model
 curie local up --local-model
-curie cluster up --local-model
+# Cluster pulls require durable storage sized for the selected model.
+curie cluster up --local-model qwen3-coder:30b --set inference.persistence.enabled=true --set inference.persistence.size=40Gi
 ```
 
-Bare `--local-model` uses `qwen3:4b`. Override it by passing a model name:
+At the `skill` and `local` tiers, bare `--local-model` uses `qwen3:4b`.
+Override it by passing a model name:
 
 ```bash
 curie local up --local-model qwen3-coder:30b
@@ -65,13 +67,11 @@ download from a wedged one (issue #1183). Once both assets are cached the flag i
 never needed again and `up` is unchanged — measured at **17.9s warm**, against
 **232s** for the same command on a cold machine over a fast link.
 
-`cluster up --local-model` has **no** such preflight and no `--pull-model` flag,
-because there is no host-side Ollama to provision. That is not the same as
-nothing being downloaded: the chart's inference Deployment pulls the weights
-*inside the cluster* instead, and does it implicitly. See
-[the cluster tier](#the-cluster-tier-downloads-implicitly) below before running
-this against a real cluster with a large model
-([#1779](https://github.com/curie-eng/curie/issues/1779)).
+`cluster up --local-model` has no host-side Ollama to provision and no
+`--pull-model` flag. Instead, the chart requires an explicit durable-storage
+choice before it can pull weights inside the cluster; see
+[the cluster tier](#the-cluster-tier-durable-storage-or-a-pre-provisioned-model)
+below.
 
 ## How it runs
 
@@ -87,38 +87,29 @@ reclaimed with `docker volume rm <volume>` — after which the next
 Service and Deployment, opens the runner egress carve-out automatically, and
 bakes `ANTHROPIC_BASE_URL` plus the inference model into the runner template.
 
-### The cluster tier downloads implicitly
+### The cluster tier: durable storage or a pre-provisioned model
 
-Unlike the other two tiers, the cluster tier fetches the weights for you, and
-nothing announces it. `inference.pullModel` defaults to `true`, and the chart
-pulls from a `postStart` lifecycle hook on the Ollama container, so:
+The default cluster values set `inference.pullModel=true` and
+`inference.persistence.enabled=false`. `curie cluster up --local-model` with
+those defaults fails at chart render time, before Helm creates any resources:
+the chart refuses to download weights into its default `emptyDir`.
 
-- **the pod is not-ready for the whole download.** kubelet does not mark a
-  container started until `postStart` returns, so the readiness probe has not
-  begun yet and the wait is unbounded. A large model looks identical to a wedged
-  deploy, which is the failure ADR-0093 removed at the other two tiers;
-- **a failed pull restarts the container.** A non-zero `postStart` makes kubelet
-  kill it, so a network error or an unknown model name surfaces as
-  `CrashLoopBackOff` with the reason in a `FailedPostStartHook` event, and each
-  restart retries the whole download;
-- **the default does not keep the weights.** `inference.persistence.enabled`
-  defaults to `false`, so the data directory is an `emptyDir` and `cluster up`
-  requests no PVC. Kubernetes preserves an `emptyDir` across a container restart
-  within the same Pod, so that alone does not touch the weights. Pod removal or
-  replacement -- eviction, node drain -- does: the replacement Pod's `postStart`
-  pulls the weights again.
-
-With the `qwen3:4b` default (~2.5GB) this is mostly invisible. With a documented
-upgrade such as `qwen3-coder:30b` (~17-19GB) it is not. Until
-[#1779](https://github.com/curie-eng/curie/issues/1779) is resolved, deploy a
-large model with persistence turned on so an evicted or rescheduled Pod does not
-re-fetch it:
+For the normal stock Ollama image, enable persistent storage and size it for the
+model. The chart still pulls the model from the Ollama container's `postStart`
+hook, so the Pod remains unready during the initial download and a failed pull
+can restart the container. The weights are stored on the PVC, however, and
+survive Pod replacement rather than downloading again:
 
 ```bash
 curie cluster up --local-model qwen3-coder:30b --set inference.persistence.enabled=true --set inference.persistence.size=40Gi
 ```
 
-and expect that first `up` to sit at not-ready for as long as the pull takes.
+The advanced alternative is for operators whose custom image or other
+provisioning already supplies the requested model: disable the chart pull with
+`--set inference.pullModel=false`. Do this only when the model is actually
+available at Ollama's data path. The stock Ollama image with an `emptyDir` has no
+weights, so disabling the pull there starts an endpoint that cannot serve the
+requested model.
 
 ## Choosing a model
 

--- a/docs/local-model.md
+++ b/docs/local-model.md
@@ -94,8 +94,10 @@ bakes `ANTHROPIC_BASE_URL` plus the inference model into the runner template.
 
 The default cluster values set `inference.pullModel=true` and
 `inference.persistence.enabled=false`. `curie cluster up --local-model` with
-those defaults fails at chart render time, before Helm or Kubernetes creates any
-resources: the chart refuses to download weights into its default `emptyDir`.
+those defaults is rejected during CLI input validation, before Helm or
+Kubernetes creates resources. A direct Helm install with the same unsafe values
+fails at chart render time, also before resources: the chart refuses to download
+weights into its default `emptyDir`.
 
 For the normal stock Ollama image, enable persistent storage and size it for the
 model. The chart still pulls the model from the Ollama container's `postStart`

--- a/docs/local-model.md
+++ b/docs/local-model.md
@@ -68,8 +68,11 @@ never needed again and `up` is unchanged — measured at **17.9s warm**, against
 **232s** for the same command on a cold machine over a fast link.
 
 `cluster up --local-model` has no host-side Ollama to provision and no
-`--pull-model` flag. Instead, the chart requires an explicit durable-storage
-choice before it can pull weights inside the cluster; see
+`--pull-model` flag. A bare cluster command refuses before Helm or Kubernetes
+creates resources: choose either typed `--set inference.persistence.enabled=true`
+to permit a pull into durable storage, or typed
+`--set inference.pullModel=false` when weights are pre-provisioned. Direct Helm
+installs receive the same chart guard. See
 [the cluster tier](#the-cluster-tier-durable-storage-or-a-pre-provisioned-model)
 below.
 
@@ -91,8 +94,8 @@ bakes `ANTHROPIC_BASE_URL` plus the inference model into the runner template.
 
 The default cluster values set `inference.pullModel=true` and
 `inference.persistence.enabled=false`. `curie cluster up --local-model` with
-those defaults fails at chart render time, before Helm creates any resources:
-the chart refuses to download weights into its default `emptyDir`.
+those defaults fails at chart render time, before Helm or Kubernetes creates any
+resources: the chart refuses to download weights into its default `emptyDir`.
 
 For the normal stock Ollama image, enable persistent storage and size it for the
 model. The chart still pulls the model from the Ollama container's `postStart`
@@ -103,6 +106,10 @@ survive Pod replacement rather than downloading again:
 ```bash
 curie cluster up --local-model qwen3-coder:30b --set inference.persistence.enabled=true --set inference.persistence.size=40Gi
 ```
+
+Persistence defaults to the chart's `10Gi` size unless
+`--set inference.persistence.size=<size>` supplies a non-boolean string. Size
+storage for the selected model; larger models need more than that default.
 
 The advanced alternative is for operators whose custom image or other
 provisioning already supplies the requested model: disable the chart pull with

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -90,6 +90,41 @@ curie apply
 
 Use `curie cluster up` below for flag driven installs.
 
+#### Declarative local inference
+
+`platform.inference: true` opts into the in-chart Ollama inference deployment.
+It does not permit the default implicit pull to an `emptyDir`: `curie apply`
+refuses before Helm or Kubernetes creates resources unless the manifest chooses
+durable storage or declares that its model is already provisioned. For the stock
+Ollama image, enable persistence and size it for the model:
+
+```yaml
+platform:
+  inference: true
+  inference_persistence: true
+set:
+  inference.persistence.size: 40Gi
+```
+
+With `inference_persistence: true`, the existing `postStart` hook pulls the
+model into the PVC. If `set.inference.persistence.size` is absent, the chart
+uses `10Gi`; when supplied it must be a non-boolean string, and large models
+need a larger size.
+
+The advanced alternative is a custom image or other provisioning that already
+has the requested weights. Declare that explicitly instead:
+
+```yaml
+platform:
+  inference: true
+  inference_pull_model: false
+```
+
+This disables the `postStart` pull. The stock Ollama image on the default
+`emptyDir` has no weights, so it cannot serve a model unless provisioning has
+placed those weights at Ollama's data path. Direct Helm installs have the same
+chart guard.
+
 ### `curie cluster up`
 
 Installs (or upgrades) Curie's Helm chart onto the cluster you're pointed at:


### PR DESCRIPTION
## Summary

Refuse cluster inference configurations that would pull model weights through `postStart` onto the default ephemeral `emptyDir`. The CLI now requires an explicit durable-storage or pre-provisioned/no-pull policy for both `cluster up --local-model` and declarative `curie apply`, while direct Helm installs enforce the same guard.

## Related issue

Closes #1779

## Fix pin verification

Fix pin: charts/curie/ci/inference-download-guard-assertions.sh

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | No plugin packaging, runner loop, ACI event, skill eval, or check behavior changed. | n/a | n/a |
| local | required | CLI validation and `apply`/`diff` plan behavior changed. | fake | At `239570f1`, PR CI ran `CURIE_E2E_TIERS=skill,local curie dev e2e-ladder` and passed in 5m21s. The host-local run was not started because another session owns the fixed-port backing stack. |
| local-release | n/a | No released binary/image identity, install artifact, version pin, or release Compose behavior changed. | n/a | n/a |
| cluster | required | Helm inference rendering and `cluster up --local-model` behavior changed. | fake | At `239570f1`, PR CI ran `CURIE_E2E_TIERS=cluster curie dev e2e-ladder` on kind and passed. Candidate `curie cluster up --local-model qwen3:4b --json` against a disposable context exited 2 with both recovery commands and created no namespace/release. Independent positive path: a task-owned Helm install with `inference.deploy=true,inference.pullModel=false` was `deployed`; the admitted Deployment had `lifecycle=null`, one `emptyDir`, and zero PVCs. The release and namespace were then absent. |
| live provider | n/a | Refusal happens before Ollama or a model provider is contacted. | n/a | n/a |
| external integration | n/a | No Slack, webhook, OAuth, or third-party API contract changed. | n/a | n/a |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.
- [ ] Or: this change is not behavior-bearing, so no tier applies, and the summary says why.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [x] An ADR is added under `docs/adr/` if this is an architectural decision. (N/A: this applies ADR-0093's existing fail-closed policy to the cluster path; accepted ADR text remains immutable.)
