### PR TITLE
Implement prefix-preserving structured conversation replay

### DIFF
--- a/docs/adr/0119-a-resumed-thread-rebuilds-its-prefix-so-the-prompt-cache-still-hits.md
+++ b/docs/adr/0119-a-resumed-thread-rebuilds-its-prefix-so-the-prompt-cache-still-hits.md
@@ -2,7 +2,13 @@
 
 Date: 2026-08-22
 
-Status: Draft
+Status: Accepted
+
+**Maintainer approval:** @TheConnMan explicitly approved coordinated acceptance
+and implementation on 2026-08-30 for [issue #1902](https://github.com/curie-eng/curie/issues/1902).
+The realizing code path is the conversation-history loader and SDK session
+integration in `runner/src/curie_runner/history.py` and
+`runner/src/curie_runner/session.py`.
 
 Depends on [ADR-0116](0116-session-identity-arrives-over-the-aci-so-a-sandbox-can-be-pre-bound.md),
 whose decision 5 creates the problem this one answers. It changes **how**

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -148,7 +148,7 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0116 | [Session identity arrives over the ACI so a sandbox can be pre-bound](0116-session-identity-arrives-over-the-aci-so-a-sandbox-can-be-pre-bound.md) | Accepted |
 | 0117 | [A tool that changes the world reports what it changed, and the platform can put it back](0117-a-tool-that-changes-the-world-reports-what-it-changed.md) | Accepted |
 | 0118 | [Binding cardinality is the multi surface opt in](0118-binding-cardinality-is-the-multi-surface-opt-in.md) | Accepted |
-| 0119 | [A resumed thread rebuilds its prefix so the prompt cache still hits](0119-a-resumed-thread-rebuilds-its-prefix-so-the-prompt-cache-still-hits.md) | Draft |
+| 0119 | [A resumed thread rebuilds its prefix so the prompt cache still hits](0119-a-resumed-thread-rebuilds-its-prefix-so-the-prompt-cache-still-hits.md) | Accepted |
 | 0120 | [First-party email delivery state is local durable single-writer state](0120-durable-first-party-email-state.md) | Accepted |
 | 0121 | [A restore is the connector's own verb, run under the same pinned connector](0121-a-restore-is-the-connectors-own-verb-run-under-the-same-pinned-connector.md) | Draft |
 | 0122 | [A warm pool's runner token is per version, not per pod](0122-a-warm-pools-runner-token-is-per-version-not-per-pod.md) | Draft |

--- a/docs/architecture-vision.md
+++ b/docs/architecture-vision.md
@@ -70,13 +70,13 @@ does not change. The runner's conformance suite
 format. `packages/plugin-format` is the Claude Code plugin shape verbatim (a
 deliberate distribution wedge), so a non-Claude harness must interpret Claude
 Code plugin bundles or translate them into its own configuration; "implement
-the ACI server" understates that work. Resume, by contrast, is harness-agnostic:
-the boot path passes `resume=None`, and `CURIE_HISTORY_REF` is a durable
-state-store URL for the thread's transcript that the runner loads and replays as a
-boot-time system-prompt preamble
-(`runner/src/curie_runner/history.py::format_conversation_preamble`), not an
-SDK-native resume identifier (ADR-0029). A second harness rehydrates the same way
-by reusing that state-store contract.
+the ACI server" understates that work. Resume's durable contract, by contrast,
+is harness-agnostic: `CURIE_HISTORY_REF` is a durable state-store URL whose
+ordered role/content records the runner reconstructs through a declared harness
+capability (`runner/src/curie_runner/history.py::build_conversation_replay`). The
+Claude adapter rebuilds an ephemeral SDK resume envelope from those messages;
+another harness must implement equivalent structured replay or fail visibly
+rather than render history into system instructions (ADR-0119).
 
 ### 2. Observability / OTel store (Langfuse today)
 

--- a/docs/architecture-vision.md
+++ b/docs/architecture-vision.md
@@ -74,7 +74,8 @@ the ACI server" understates that work. Resume's durable contract, by contrast,
 is harness-agnostic: `CURIE_HISTORY_REF` is a durable state-store URL whose
 ordered role/content records the runner reconstructs through a declared harness
 capability (`runner/src/curie_runner/history.py::build_conversation_replay`). The
-Claude adapter rebuilds an ephemeral SDK resume envelope from those messages;
+Claude adapter prefers its optional opaque native checkpoint for cache fidelity
+and otherwise rebuilds an ephemeral SDK resume envelope from those messages;
 another harness must implement equivalent structured replay or fail visibly
 rather than render history into system instructions (ADR-0119).
 

--- a/docs/interfaces/aci-producer/INTERFACE.md
+++ b/docs/interfaces/aci-producer/INTERFACE.md
@@ -75,11 +75,10 @@ CI-guarded by `packages/aci-protocol/tests/test_schema_compat.py`.
 Plugin-format entanglement: the ACI server must interpret Claude Code plugin bundles mounted at
 `CURIE_PLUGIN_DIR` (see the [bundle-format seam](../bundle-format/INTERFACE.md)), so a genuinely
 foreign harness inherits that shape too — the A- is docked for exactly this. Rehydration is no
-longer a second dock: ADR-0029 retired the SDK-shaped resume, so the boot path passes
-`resume=None` (`runner/src/curie_runner/__main__.py`) and the thread's transcript arrives from
-the durable state store named by `CURIE_HISTORY_REF`, replayed as a boot-time system-prompt
-preamble (`runner/src/curie_runner/history.py::format_conversation_preamble`). A second harness
-rehydrates by reusing that state-store contract, with nothing SDK-specific in the path.
+longer a second dock: ADR-0119 keeps the durable contract provider-neutral as ordered role/content
+messages from the state store named by `CURIE_HISTORY_REF`. Each harness must materialize that
+prefix structurally (the Claude adapter rebuilds an ephemeral SDK resume envelope), or declare
+the capability absent and fail the resume; rendered system-prompt fallback is forbidden.
 Otherwise the line is clean and frozen: a producer constructs strictly (stray
 keys are rejected at construction), while a consumer tolerates unknown fields and rejects only an
 **incompatible** wire version, raising `ProtocolVersionError` naming both versions (see ADR-0036).

--- a/docs/interfaces/aci-producer/INTERFACE.md
+++ b/docs/interfaces/aci-producer/INTERFACE.md
@@ -77,7 +77,8 @@ Plugin-format entanglement: the ACI server must interpret Claude Code plugin bun
 foreign harness inherits that shape too — the A- is docked for exactly this. Rehydration is no
 longer a second dock: ADR-0119 keeps the durable contract provider-neutral as ordered role/content
 messages from the state store named by `CURIE_HISTORY_REF`. Each harness must materialize that
-prefix structurally (the Claude adapter rebuilds an ephemeral SDK resume envelope), or declare
+prefix structurally (the Claude adapter may consume its optional opaque native checkpoint, or
+rebuild an ephemeral SDK resume envelope from portable messages), or declare
 the capability absent and fail the resume; rendered system-prompt fallback is forbidden.
 Otherwise the line is clean and frozen: a producer constructs strictly (stray
 keys are rejected at construction), while a consumer tolerates unknown fields and rejects only an

--- a/docs/interfaces/conversation-history/INTERFACE.md
+++ b/docs/interfaces/conversation-history/INTERFACE.md
@@ -31,7 +31,9 @@ class TranscriptStore(Protocol):
 
 A `TurnRecord` preserves ordered `user`/`assistant` messages and JSON content
 blocks (including tool calls/results), terminal status, approval context, and a
-legacy text projection. A `SummaryRecord` is an explicit stable compaction
+legacy text projection. It may carry a matching harness's opaque checkpoint or
+append delta; this is a cache optimization, never the portable source of truth.
+A `SummaryRecord` is an explicit stable compaction
 boundary plus its un-compacted structured tail. `CURIE_HISTORY_REF` (a
 runner-local env, NOT a frozen ACI `SessionConfig` field) is resolved to a
 concrete `TranscriptStore` at runner boot by `resolve_history`. The state-API bearer is a runner-local knob
@@ -50,8 +52,9 @@ conversation, reconstructed through the selected harness adapter.
   and rejected loudly.
 - **Load side.** `load()` returns prior turns/summaries oldest-first (empty when
   none). At boot `build_conversation_replay` reconstructs the ordered portable
-  prefix. The Claude adapter materializes deterministic provider-local session
-  entries from only role/content; the fake consumes the same prefix, and a
+  prefix. The Claude adapter prefers an optional native checkpoint so its exact
+  cache-breakpoint shape survives; without one it materializes deterministic
+  provider-local entries from role/content. The fake consumes the same portable prefix, and a
   harness declaring no structured-replay capability fails rather than receiving
   rendered system text. A configured load failure blocks boot because continuing
   without approval/tool context could duplicate an operation.
@@ -66,7 +69,9 @@ conversation, reconstructed through the selected harness adapter.
   synthetic incomplete fallback finals are not recorded.
 - **Compaction and cache.** Crossing the turn/byte bound appends one deterministic
   `SummaryRecord`; ordinary appends retain the exact prefix until the next
-  boundary. The first resumed terminal result records
+  boundary. Compaction deliberately drops the old native checkpoint; the first
+  turn over the new portable summary writes a fresh one, while later turns append
+  only deltas. The first resumed terminal result records
   `curie.history.resume.cache_read` with the provider's observed cache-read token
   count and a bounded `cache_hit` attribute.
 

--- a/docs/interfaces/conversation-history/INTERFACE.md
+++ b/docs/interfaces/conversation-history/INTERFACE.md
@@ -25,20 +25,22 @@ The port is the `TranscriptStore` `Protocol` in
 
 ```python
 class TranscriptStore(Protocol):
-    async def load(self) -> list[TurnRecord]: ...
-    async def append(self, record: TurnRecord) -> None: ...
+    async def load(self) -> list[HistoryRecord]: ...
+    async def append(self, record: HistoryRecord) -> None: ...
 ```
 
-A `TurnRecord` is `user: str` plus `assistant: str` (and a `ts`) — one
-conversation turn. `CURIE_HISTORY_REF` (a runner-local env, NOT a frozen ACI
-`SessionConfig` field) is resolved to a concrete `TranscriptStore` at runner boot
-by `resolve_history`. The state-API bearer is a runner-local knob
+A `TurnRecord` preserves ordered `user`/`assistant` messages and JSON content
+blocks (including tool calls/results), terminal status, approval context, and a
+legacy text projection. A `SummaryRecord` is an explicit stable compaction
+boundary plus its un-compacted structured tail. `CURIE_HISTORY_REF` (a
+runner-local env, NOT a frozen ACI `SessionConfig` field) is resolved to a
+concrete `TranscriptStore` at runner boot by `resolve_history`. The state-API bearer is a runner-local knob
 (`CURIE_HISTORY_TOKEN`), like `CURIE_MEMORY_TOKEN`.
 
-This is the sibling seam of [Memory](../memory/INTERFACE.md): same store, same
-boot-preamble delivery, a different scope. Memory is per-agent durable lessons;
-history is *this thread's* conversation, so a restarted sandbox can rehydrate the
-turns already spoken.
+This is the sibling seam of [Memory](../memory/INTERFACE.md): same store, a
+different scope and delivery shape. Memory is per-agent durable lessons and
+still enters the system prompt; history is *this thread's* structured
+conversation, reconstructed through the selected harness adapter.
 
 ## Current contract
 
@@ -46,19 +48,27 @@ turns already spoken.
   `NullTranscriptStore`; an `http(s)://` ref → `StateApiTranscriptStore`; any
   other scheme (an old SDK-resume id, `s3://` …) is reserved for a future loader
   and rejected loudly.
-- **Load side.** `load()` returns prior turns oldest-first (empty when none). At
-  boot the runner loads the transcript and composes it into the effective system
-  prompt as a conversation preamble (after the memory preamble, before the
-  bundle/env prompt) — this is how history is *delivered into the sandbox*,
-  harness-agnostically (plain prompt text, not any one harness's resume API). A
-  transient load failure degrades to "no history" and does not block boot.
+- **Load side.** `load()` returns prior turns/summaries oldest-first (empty when
+  none). At boot `build_conversation_replay` reconstructs the ordered portable
+  prefix. The Claude adapter materializes deterministic provider-local session
+  entries from only role/content; the fake consumes the same prefix, and a
+  harness declaring no structured-replay capability fails rather than receiving
+  rendered system text. A configured load failure blocks boot because continuing
+  without approval/tool context could duplicate an operation.
 - **Append side.** `append(record)` durably writes one turn. The runner appends
-  `{user, assistant}` only for a successful model-produced/translated terminal
-  `final` with `DONE` status (`SessionRunner._record_turn`), best-effort — a
-  store failure never fails a turn the user already received. Classified
-  failures, budget/auth halts, awaiting-approval outcomes, and synthetic
-  incomplete fallback finals (including idle or otherwise incomplete outcomes)
-  are not recorded.
+  structured messages after each persistable terminal `final`
+  (`SessionRunner._record_turn`): either a successful model-produced `DONE`
+  reply or an `AWAITING_APPROVAL` suspension whose structured tool and approval
+  context must survive the runner boundary. A
+  dangling denied tool call gets an explicit non-executed result so the next
+  provider request is structurally valid. Append remains best-effort after a
+  delivered turn; classified failures, budget/auth halts, idle outcomes, and
+  synthetic incomplete fallback finals are not recorded.
+- **Compaction and cache.** Crossing the turn/byte bound appends one deterministic
+  `SummaryRecord`; ordinary appends retain the exact prefix until the next
+  boundary. The first resumed terminal result records
+  `curie.history.resume.cache_read` with the provider's observed cache-read token
+  count and a bounded `cache_hit` attribute.
 
 ## Implementations today
 
@@ -83,19 +93,16 @@ unplanned-restart case needs no special worker/kernel branch.
   agent-bound, HMAC-signed `state` token minted per turn, accepted only by the
   state router and bound to this agent's namespace, so the sandbox credential can
   no longer resolve approvals or reach another agent's state.
-- **Unbounded append log under the state-store size caps.** A very long thread
+- **Unbounded source log under the state-store size caps.** A very long thread
   will eventually hit the per-namespace/per-value cap on the stored transcript.
-  Delivery-side windowing now bounds the *rehydrated preamble* to a tail window
-  (most-recent turns, byte-capped; `CURIE_HISTORY_MAX_TURNS` /
-  `CURIE_HISTORY_MAX_BYTES`, overridable) -- but the stored transcript itself
-  stays unwindowed, so the append log still grows unbounded until it hits the
-  state-store cap. The replay is a prompt preamble, not a token-exact
-  reconstruction, so it does not restore the model's original prompt cache
-  (consistent with ADR-0003, which assumes cache-cold on a restart).
+  Delivery-side stable summarization bounds the reconstructed prefix
+  (`CURIE_HISTORY_MAX_TURNS` / `CURIE_HISTORY_MAX_BYTES`, overridable), but the
+  source turns and append-only summary records remain in the state log. A later
+  retention/rollup mechanism is still needed before the state-store cap.
 - **History lives OUTSIDE the sandbox** (ADR-0003) — the store is
   network-reachable and rehydratable, never pod-local state.
 
 ## Cross-links
 
 - **Issue:** [#20](https://github.com/curie-eng/curie/issues/20) — transcript persistence across unplanned runner restarts
-- **ADR(s):** [ADR-0029](../../adr/0029-conversation-history-port-and-first-loader.md) — the port + first loader; [ADR-0025](../../adr/0025-memory-port-and-first-loader.md) — the sibling memory port; [ADR-0003](../../adr/0003-stateless-first-rehydrate-on-resume.md) — stateless-first; rehydrate on resume; externalize session state
+- **ADR(s):** [ADR-0119](../../adr/0119-a-resumed-thread-rebuilds-its-prefix-so-the-prompt-cache-still-hits.md) — structured prefix replay and cache observability; [ADR-0029](../../adr/0029-conversation-history-port-and-first-loader.md) — the port + first loader; [ADR-0025](../../adr/0025-memory-port-and-first-loader.md) — the sibling memory port; [ADR-0003](../../adr/0003-stateless-first-rehydrate-on-resume.md) — stateless-first; rehydrate on resume; externalize session state

--- a/docs/spikes/1902-claude-agent-sdk-structured-replay.md
+++ b/docs/spikes/1902-claude-agent-sdk-structured-replay.md
@@ -44,8 +44,12 @@ to deterministic entries whose only durable inputs were each message's `role`
 and `content`; UUIDs, parent links, CLI version, working directory, and timestamp
 were reconstructed adapter metadata. A fresh client recovered the exact marker
 and observed 67,641 cache-read tokens and 345 cache-creation tokens. This is the
-shape implemented by `build_structured_resume`: provider JSONL is never Curie's
-durable contract.
+fallback shape implemented by `build_structured_resume`. Provider JSONL is never
+Curie's authoritative durable contract. The matching Claude harness does persist
+it as an opaque optional checkpoint/delta optimization because reconstructed
+minimal entries preserve semantics but do not preserve the provider's
+message-cache breakpoint. A different harness ignores that checkpoint and uses
+role/content.
 
 ## Cache-breakpoint negative arm
 
@@ -76,13 +80,23 @@ runtime. The observed usage counters prove that runtime's stable breakpoints;
 Curie must treat explicit caller placement as unavailable and must not claim
 that its portable harness contract controls provider cache directives.
 
-Implementation may proceed using two distinct layers:
+Anthropic's current prompt-caching documentation states that automatic caching
+moves the breakpoint forward with a growing conversation, while exact matching
+is required for a hit. It also documents independent tools, system, and messages
+cache levels. Those properties explain both the native-checkpoint requirement
+and why a changed-history negative may retain an earlier system/tool read:
+[prompt caching](https://platform.claude.com/docs/en/build-with-claude/prompt-caching)
+and [tool-use cache hierarchy](https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-use-with-prompt-caching).
+
+Implementation therefore uses three layers:
 
 1. A harness-neutral durable structured conversation and stable-summary model
    owned by Curie.
-2. An optional Claude harness adapter that restores the provider-native
-   structured session through `SessionStore` and reports the first resumed
-   turn's observed cache-read tokens.
+2. An optional opaque checkpoint/delta from the matching harness. Claude uses
+   this to restore the provider-native structured session through `SessionStore`;
+   portable replay remains sufficient when the checkpoint is absent or belongs
+   to another harness.
+3. A first-resumed-turn metric reporting observed cache-read tokens.
 
 A harness that implements neither structured message replay nor an equivalent
 provider-native restore must declare the capability absent and fail the resume;
@@ -92,17 +106,20 @@ it must not fall back to the legacy rendered transcript preamble.
 
 The implementation leaves both offline and opt-in provider regressions in the
 repository. On 2026-08-30 the following disposable provider command passed in
-27.32 seconds against two selected tests:
+30.41 seconds against two selected tests:
 
 ```text
 CURIE_E2E_LIVE=1 uv run pytest -q runner/tests/test_live.py \
   -k 'structured_replay_cache_hit or cross_runner_approval_exact_once' -vv
 ```
 
-The cache test primes one portable prefix, reconstructs it in a fresh client,
-and then changes one durable user message in a third fresh client. It asserts a
-positive cache read for the identical prefix, a lower read for the changed
-prefix, and greater cache creation for the changed arm. The approval test blocks
+The cache test captures one tool-bearing portable prefix plus its optional native
+checkpoint, primes a continuation, reconstructs that exact checkpoint in a fresh
+client, and then changes one recovered native user message in another fresh
+client. It asserts exact marker recovery, a positive cache read for the identical
+prefix, and either a lower read or renewed creation for the changed arm. The
+total read may remain positive because the unchanged SDK/system layer has an
+independent breakpoint. The approval test blocks
 a disposable Bash append in runner A (the file remains absent), persists the
 structured suspension including an explicit non-executed tool result, resumes
 runner B with a one-shot grant, and asserts the file has exactly one line. A

--- a/docs/spikes/1902-claude-agent-sdk-structured-replay.md
+++ b/docs/spikes/1902-claude-agent-sdk-structured-replay.md
@@ -1,0 +1,91 @@
+# Issue 1902 Claude Agent SDK structured replay spike
+
+Date: 2026-08-30
+
+Outcome: **PASS**
+
+This disposable spike closes the SDK prerequisite recorded by
+[ADR-0119](../adr/0119-a-resumed-thread-rebuilds-its-prefix-so-the-prompt-cache-still-hits.md)
+and issue #1902. It ran against the repository-pinned `claude-agent-sdk`
+0.2.135 and its bundled Claude Code 2.1.227 with a real supported provider.
+No provider or gateway credential was written to a manifest or printed in the
+evidence.
+
+## Capability observed
+
+The pinned SDK now exposes `ClaudeAgentOptions.session_store`. A first
+`ClaudeSDKClient` mirrored its structured session transcript into a
+`SessionStore`; a second client with no local transcript materialized that
+store and resumed the session by UUID. This is a provider-native restoration
+capability. Issue #1902 still needs Curie's durable representation and harness
+boundary to remain portable rather than making the Claude transcript format the
+platform contract.
+
+The mirrored transcript contained ordered `user` and `assistant` entries plus
+an assistant `tool_use` content block and its user `tool_result` content block.
+The second client recovered a fixed marker from the prior tool result without
+calling the tool again.
+
+Observed positive run:
+
+- session: `22649fa5-4979-438f-b79c-f5caf21fb07c`
+- mirrored entries: 8
+- structured `tool_use`: present
+- structured `tool_result`: present
+- runner A result: exact marker
+- runner B result: exact marker
+- runner B cache creation: 56 input tokens
+- runner B cache read: 67,170 input tokens
+
+## Cache-breakpoint negative arm
+
+A separate run cloned the externally stored transcript twice. One fresh client
+resumed the byte-stable history. Before the other fresh client resumed, the
+spike changed the stored content of the first structured user message while
+leaving the system and tool prefix unchanged.
+
+Observed comparison for session
+`7ad5365f-4748-4da4-a8af-34d9b22d6ee5`:
+
+| Resume | Cache read input tokens | Cache creation input tokens |
+| --- | ---: | ---: |
+| unchanged stored history | 103,169 | 663 |
+| changed stored history | 52,933 | 50,905 |
+
+The changed-history arm lost the history-layer hit and rewrote that layer. Its
+remaining cache read is expected: the unchanged earlier SDK/system/tool layer
+has its own stable breakpoint. This positive/negative pair proves that the
+fresh-client resume preserves the stored prefix and that changing the recovered
+prefix invalidates the corresponding cache layer.
+
+## SDK boundary found
+
+The Python SDK does not expose caller-authored `cache_control` blocks on
+`ClaudeAgentOptions`. Cache placement is owned by the bundled Claude Code
+runtime. The observed usage counters prove that runtime's stable breakpoints;
+Curie must treat explicit caller placement as unavailable and must not claim
+that its portable harness contract controls provider cache directives.
+
+Implementation may proceed using two distinct layers:
+
+1. A harness-neutral durable structured conversation and stable-summary model
+   owned by Curie.
+2. An optional Claude harness adapter that restores the provider-native
+   structured session through `SessionStore` and reports the first resumed
+   turn's observed cache-read tokens.
+
+A harness that implements neither structured message replay nor an equivalent
+provider-native restore must declare the capability absent and fail the resume;
+it must not fall back to the legacy rendered transcript preamble.
+
+## Reproduction shape
+
+The spike used two sequential `ClaudeSDKClient` instances with the same working
+directory and UUID but separate session stores. The first store's JSON-safe
+entries were serialized and copied into a new store before the second client
+connected. The negative arm deep-copied those entries and changed the first
+structured user message before connecting another fresh client. Each client
+consumed a terminal `ResultMessage`; evidence came from the stored content-block
+types and `ResultMessage.usage` counters. The exact local transcript created by
+the disposable first client was deleted after its mirrored copy had been
+verified.

--- a/docs/spikes/1902-claude-agent-sdk-structured-replay.md
+++ b/docs/spikes/1902-claude-agent-sdk-structured-replay.md
@@ -37,6 +37,16 @@ Observed positive run:
 - runner B cache creation: 56 input tokens
 - runner B cache read: 67,170 input tokens
 
+The SDK's streaming-input API rejects a caller-authored assistant message as a
+new query (`Expected message role 'user', got 'assistant'`), so Curie does not
+inject history through that surface. A second spike reduced the restored store
+to deterministic entries whose only durable inputs were each message's `role`
+and `content`; UUIDs, parent links, CLI version, working directory, and timestamp
+were reconstructed adapter metadata. A fresh client recovered the exact marker
+and observed 67,641 cache-read tokens and 345 cache-creation tokens. This is the
+shape implemented by `build_structured_resume`: provider JSONL is never Curie's
+durable contract.
+
 ## Cache-breakpoint negative arm
 
 A separate run cloned the externally stored transcript twice. One fresh client
@@ -77,6 +87,37 @@ Implementation may proceed using two distinct layers:
 A harness that implements neither structured message replay nor an equivalent
 provider-native restore must declare the capability absent and fail the resume;
 it must not fall back to the legacy rendered transcript preamble.
+
+## Durable regression evidence
+
+The implementation leaves both offline and opt-in provider regressions in the
+repository. On 2026-08-30 the following disposable provider command passed in
+27.32 seconds against two selected tests:
+
+```text
+CURIE_E2E_LIVE=1 uv run pytest -q runner/tests/test_live.py \
+  -k 'structured_replay_cache_hit or cross_runner_approval_exact_once' -vv
+```
+
+The cache test primes one portable prefix, reconstructs it in a fresh client,
+and then changes one durable user message in a third fresh client. It asserts a
+positive cache read for the identical prefix, a lower read for the changed
+prefix, and greater cache creation for the changed arm. The approval test blocks
+a disposable Bash append in runner A (the file remains absent), persists the
+structured suspension including an explicit non-executed tool result, resumes
+runner B with a one-shot grant, and asserts the file has exactly one line. A
+second attempt on runner B pauses again and the file remains one line. The same
+run asserts exactly one `curie.history.resume.cache_read` observation with a
+positive value and `cache_hit=true`.
+
+The two approval-runner identities in that evidence are the distinct trace names
+`live-structured-approval-block` (runner A) and
+`live-structured-approval-resume` (runner B), both bound to the same portable
+thread identity `live-approval-thread-1902`.
+
+The offline companion in `runner/tests/test_structured_replay_e2e.py` proves the
+same one-shot/re-arm flow without a provider and proves rejected and expired
+resume decisions authorize zero calls.
 
 ## Reproduction shape
 

--- a/packages/telemetry/schema/metrics.json
+++ b/packages/telemetry/schema/metrics.json
@@ -91,6 +91,25 @@
       },
       "cardinality_bound": 168
     },
+    "curie.history.resume.cache_read": {
+      "type": "histogram",
+      "unit": "{token}",
+      "description": "Provider cache read input tokens on the first turn after structured replay.",
+      "monotonic": false,
+      "attributes": {
+        "service.name": [
+          "curie-runner"
+        ],
+        "source": [
+          "runner"
+        ],
+        "cache_hit": [
+          "true",
+          "false"
+        ]
+      },
+      "cardinality_bound": 2
+    },
     "curie.queue.enqueue": {
       "type": "counter",
       "unit": "{message}",

--- a/packages/telemetry/src/curie_telemetry/metrics.py
+++ b/packages/telemetry/src/curie_telemetry/metrics.py
@@ -58,6 +58,11 @@ _TURN_COMPLETED_ATTRIBUTES = {
     "source": _TURN_SOURCES,
     "outcome": _TURN_OUTCOMES,
 }
+_HISTORY_CACHE_ATTRIBUTES = {
+    "service.name": ["curie-runner"],
+    "source": ["runner"],
+    "cache_hit": ["true", "false"],
+}
 _QUEUE_ATTRIBUTES = {
     "service.name": ["curie-api", "curie-dispatcher", "curie-worker"],
     "source": ["api", "dispatcher", "worker", "local", "eval"],
@@ -255,6 +260,13 @@ _METRICS: dict[str, dict[str, Any]] = {
     ),
     "curie.turn.duration": _definition(
         "histogram", "s", "End to end turn duration.", False, _TURN_COMPLETED_ATTRIBUTES
+    ),
+    "curie.history.resume.cache_read": _definition(
+        "histogram",
+        "{token}",
+        "Provider cache read input tokens on the first turn after structured replay.",
+        False,
+        _HISTORY_CACHE_ATTRIBUTES,
     ),
     "curie.queue.enqueue": _definition(
         "counter", "{message}", "Messages enqueued.", True, _QUEUE_ATTRIBUTES

--- a/packages/telemetry/tests/test_metrics.py
+++ b/packages/telemetry/tests/test_metrics.py
@@ -160,6 +160,25 @@ def test_side_effect_halt_is_a_distinct_terminal_turn_class() -> None:
         assert "side_effect_halted" in manifest[name]["attributes"]["outcome"]
 
 
+def test_history_resume_cache_read_is_declared_and_rejects_unbounded_attributes(
+    metrics: tuple[MeterProvider, InMemoryMetricReader],
+) -> None:
+    del metrics
+    attributes = {
+        "service.name": "curie-runner",
+        "source": "runner",
+        "cache_hit": "true",
+    }
+    record_metric("curie.history.resume.cache_read", 321, attributes=attributes)
+
+    with pytest.raises(ValueError, match="undeclared attribute"):
+        record_metric(
+            "curie.history.resume.cache_read",
+            321,
+            attributes={**attributes, "session.id": "session-example"},
+        )
+
+
 def test_record_metric_rejects_undeclared_instrument_by_execution(
     metrics: tuple[MeterProvider, InMemoryMetricReader],
 ) -> None:

--- a/runner/CLAUDE.md
+++ b/runner/CLAUDE.md
@@ -36,7 +36,9 @@ Docker via `curie skill up`. Full behavior spec in `runner/README.md`.
   (`history.py`, ADR-0119/0029), while `CURIE_MEMORY_REF` is the agent's durable
   memory and still enters the system prompt (`memory.py`, ADR-0025).
   `CURIE_HISTORY_REF` is never itself an SDK resume id; the harness adapter may
-  reconstruct an ephemeral provider resume envelope from its portable messages.
+  consume optional opaque checkpoint/delta data for cache fidelity or reconstruct
+  an ephemeral provider resume envelope from its portable messages. The portable
+  messages remain authoritative across harnesses.
   Never write a code path that depends on the runner having been "the same
   process" as an earlier turn.
 - **One turn consumes the SDK generator at a time.** Steer and interrupt are

--- a/runner/CLAUDE.md
+++ b/runner/CLAUDE.md
@@ -31,12 +31,12 @@ Docker via `curie skill up`. Full behavior spec in `runner/README.md`.
   conservative.
 - **Rehydration on start is stateless-first** (ADR-0003): the runner
   rehydrates external state on boot rather than assuming any surviving
-  in-process state. Two distinct external refs, each resolved to a store over
-  the durable state API and delivered as a system-prompt preamble, never a
-  surviving process: `CURIE_HISTORY_REF` is this thread's conversation
-  transcript (`history.py`, ADR-0029), `CURIE_MEMORY_REF` is the agent's
-  durable memory (`memory.py`, ADR-0025). `CURIE_HISTORY_REF` is a state-API
-  URL, no longer an SDK `resume` id, and is not fed to the SDK `resume=` path.
+  in-process state. Two distinct external refs resolve over the durable state
+  API: `CURIE_HISTORY_REF` is this thread's structured conversation transcript
+  (`history.py`, ADR-0119/0029), while `CURIE_MEMORY_REF` is the agent's durable
+  memory and still enters the system prompt (`memory.py`, ADR-0025).
+  `CURIE_HISTORY_REF` is never itself an SDK resume id; the harness adapter may
+  reconstruct an ephemeral provider resume envelope from its portable messages.
   Never write a code path that depends on the runner having been "the same
   process" as an earlier turn.
 - **One turn consumes the SDK generator at a time.** Steer and interrupt are
@@ -61,10 +61,12 @@ uv run pytest runner/tests -q                            # unit + integration + 
 uv run ruff check runner/ && uv run mypy
 ```
 
-`runner/tests/test_live.py` runs only when `CLAUDE_CODE_OAUTH_TOKEN` or
-`ANTHROPIC_API_KEY` is present; it is skipped otherwise, so a green local run
-without a credential does not exercise the real model path -- do not treat
-it as equivalent to a `@live` pass. The conformance suite
+The ordinary provider smokes in `runner/tests/test_live.py` run only when
+`CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY` is present. The disposable
+structured-replay/cross-runner cases require an explicit `CURIE_E2E_LIVE=1` and
+may use an already authenticated local Claude SDK. Without those gates they are
+skipped, so a green default run does not exercise the real model path -- do not
+treat it as equivalent to a live pass. The conformance suite
 (`run_conformance` from `packages/aci-protocol`) must return `passed=True`
 against this runner's producer; a change that breaks conformance is a
 contract violation even if the runner's own tests pass.

--- a/runner/README.md
+++ b/runner/README.md
@@ -56,10 +56,10 @@ readinessProbe hits `/healthz`).
   `CURIE_SESSION_ID`, `CURIE_SANDBOX_ID`, `CURIE_BUDGET`, optional
   `CURIE_MEMORY_REF` / `CURIE_CREDENTIALS`, `OTEL_EXPORTER_OTLP_*`.
 - **Runner-local**: `CURIE_MODEL`, `CURIE_MAX_TURNS`,
-  `CURIE_HISTORY_REF` (rehydrate; falls back to `CURIE_MEMORY_REF`),
+  `CURIE_HISTORY_REF` (rehydrate this thread from the durable state API),
   `CURIE_HISTORY_MAX_TURNS` / `CURIE_HISTORY_MAX_BYTES` (bound the rehydrated
-  history preamble to a tail window; defaults 40 turns / 16000 bytes, a
-  nonpositive value falls back to the default),
+  structured prefix with stable summary boundaries; defaults 40 turns / 16000
+  bytes, a nonpositive value falls back to the default),
   `CURIE_RUNNER_PORT`, `CURIE_RUNNER_TOKEN` (per-sandbox bearer token gating
   the three ACI POST routes; enforced only when set), `CURIE_FAKE_MODEL`
   (offline smoke; no model call).

--- a/runner/src/curie_runner/__main__.py
+++ b/runner/src/curie_runner/__main__.py
@@ -289,6 +289,7 @@ def build_runner(
             conversation_replay.messages,
             curie_session_id=config.session.session_id,
             cwd=workspace_cwd,
+            harness_replay=conversation_replay.harness_replay,
         )
         options = build_options(
             plugins=plugins,
@@ -297,8 +298,9 @@ def build_runner(
             max_turns=config.max_turns,
             max_budget_usd=config.max_usd_per_day,
             # Curie's durable contract is ordered role/content messages. The
-            # Claude adapter materializes them into a process-local SDK resume
-            # envelope; no provider-native transcript is persisted.
+            # Claude adapter prefers its optional opaque checkpoint to preserve
+            # native cache shape, and otherwise materializes a deterministic
+            # process-local SDK resume envelope from the portable messages.
             resume=structured_resume.resume,
             session_id=structured_resume.session_id,
             session_store=structured_resume.session_store,

--- a/runner/src/curie_runner/__main__.py
+++ b/runner/src/curie_runner/__main__.py
@@ -19,7 +19,12 @@ from claude_agent_sdk import HookMatcher
 from curie_telemetry import bootstrap_service_telemetry
 
 from . import __version__
-from .adapter import ClaudeAgentSession, ModelSession, build_options
+from .adapter import (
+    ClaudeAgentSession,
+    ModelSession,
+    build_options,
+    build_structured_resume,
+)
 from .approval import (
     APPROVAL_SERVER_NAME,
     ApprovalPolicyError,
@@ -40,11 +45,13 @@ from .harness.registry import (
     resolve_harness,
 )
 from .history import (
-    DEFAULT_PREAMBLE_MAX_BYTES,
-    DEFAULT_PREAMBLE_MAX_TURNS,
+    DEFAULT_REPLAY_MAX_BYTES,
+    DEFAULT_REPLAY_MAX_TURNS,
+    ConversationReplay,
+    HistoryError,
+    StructuredReplayUnsupported,
     TranscriptStore,
-    TurnRecord,
-    format_conversation_preamble,
+    build_conversation_replay,
     resolve_history,
 )
 from .hooks import load_bundle_hooks
@@ -93,21 +100,17 @@ def _resolve_harness(name: str = DEFAULT_HARNESS) -> HarnessContribution:
 def _compose_system_prompt(
     base: str | None,
     memory_preamble: str | None,
-    conversation_preamble: str | None = None,
     *,
     model: str | None,
 ) -> str | None:
-    """Compose the system prompt with recovered context and model identity.
+    """Compose durable memory, bundle instructions, and model identity.
 
-    State delivered from outside the sandbox becomes durable model context by
-    leading the system prompt: durable memory (ADR-0025) first, then this thread's
-    recovered conversation (ADR-0029), then the bundle/env system prompt. The
-    configured model identity follows the bundle prompt when present. Any part
-    may be absent.
+    Conversation history is deliberately absent: ADR-0119 requires it to cross
+    the harness boundary as ordered messages, never rendered system text.
     """
 
     model_preamble = f"Configured model: {model}" if model else None
-    parts = [p for p in (memory_preamble, conversation_preamble, base, model_preamble) if p]
+    parts = [p for p in (memory_preamble, base, model_preamble) if p]
     return "\n\n".join(parts) if parts else None
 
 
@@ -148,7 +151,7 @@ def build_runner(
     memory_store: MemoryStore | None = None,
     memory_preamble: str | None = None,
     history_store: TranscriptStore | None = None,
-    conversation_preamble: str | None = None,
+    conversation_replay: ConversationReplay | None = None,
     harness: HarnessContribution | None = None,
     workspace_path: Path | None = None,
 ) -> SessionRunner:
@@ -169,6 +172,12 @@ def build_runner(
     # compiles into session inputs, replacing the direct module imports these
     # used to be. Defaults to the built-in Claude harness.
     harness = harness or _resolve_harness()
+    conversation_replay = conversation_replay or ConversationReplay()
+    if conversation_replay.present and not harness.supports_structured_replay and not fake_model:
+        raise StructuredReplayUnsupported(
+            f"harness {harness.name!r} declares structured replay absent; "
+            "refusing recovered history instead of rendering a prompt preamble"
+        )
     # The bundle compiles once into this harness's native inputs (compile_bundle):
     # the ``systemPrompt`` shipped in the manifest (versioned with the agent, epic
     # #30) is the declared surface and always wins -- an env override let an
@@ -176,14 +185,13 @@ def build_runner(
     # bundle's plugins feed the session factory below.
     compiled = harness.compile_bundle(config.session.plugin_dir)
     system_prompt = compiled.system_prompt
-    # Prior memory (#264) and this thread's recovered conversation (#20), both
-    # loaded from outside the sandbox, lead the system prompt so the model sees
-    # learned lessons and the prior exchange as durable context. The configured
-    # model identity is appended after the bundle prompt.
+    # Prior memory (#264) still leads the system prompt. Conversation history
+    # (#20) deliberately does not: ADR-0119 sends its ordered messages through
+    # the harness adapter below. The configured model identity is appended after
+    # the bundle prompt.
     system_prompt = _compose_system_prompt(
         system_prompt,
         memory_preamble,
-        conversation_preamble,
         model=config.model,
     )
     # In-bundle PreToolUse guardrails declared in the manifest hooks field (#272),
@@ -274,19 +282,26 @@ def build_runner(
                 # Share the same gate so a scripted request_approval resolves its
                 # route through the real decision table on the offline tier (#561).
                 approval_gate=approval_gate,
+                replay_messages=conversation_replay.messages,
             )
         plugins = compiled.plugins
+        structured_resume = build_structured_resume(
+            conversation_replay.messages,
+            curie_session_id=config.session.session_id,
+            cwd=workspace_cwd,
+        )
         options = build_options(
             plugins=plugins,
             model=config.model,
             system_prompt=system_prompt,
             max_turns=config.max_turns,
             max_budget_usd=config.max_usd_per_day,
-            # History is rehydrated harness-agnostically as a conversation preamble
-            # (ADR-0029), not through the SDK-specific resume path, so history_ref
-            # no longer feeds resume. build_options keeps the param for an explicit
-            # caller; the boot path passes None.
-            resume=None,
+            # Curie's durable contract is ordered role/content messages. The
+            # Claude adapter materializes them into a process-local SDK resume
+            # envelope; no provider-native transcript is persisted.
+            resume=structured_resume.resume,
+            session_id=structured_resume.session_id,
+            session_store=structured_resume.session_store,
             # Operator-set thinking depth (#1182, ADR-0098); None omits the SDK
             # option entirely rather than defaulting it.
             thinking=config.thinking,
@@ -354,6 +369,7 @@ def build_runner(
         approval_resumed_kind=config.approval_resumed_kind,
         approval_decision=config.approval_decision,
         false_completion_check=config.false_completion_check,
+        history_resumed=conversation_replay.present,
     )
 
 
@@ -385,18 +401,16 @@ def _load_memory(config: RunnerConfig) -> tuple[MemoryStore, str | None]:
     return store, format_memory_preamble(records)
 
 
-def _load_history(config: RunnerConfig) -> tuple[TranscriptStore, str | None]:
-    """Resolve CURIE_HISTORY_REF and load this thread's transcript into a preamble.
+def _load_history(config: RunnerConfig) -> tuple[TranscriptStore, ConversationReplay]:
+    """Resolve, compact when needed, and load the structured replay prefix.
 
-    Mirrors ``_load_memory`` (ADR-0029): runs synchronously at boot so a bad ref
-    fails the process visibly, but a transient load failure degrades to "no
-    history" rather than blocking boot -- a thread must still run when its
-    transcript store is briefly unavailable (the answer just lacks prior context).
+    A configured history ref is continuity-critical. Failure is fatal: silently
+    answering without the prior tool/approval context can duplicate an operation.
 
-    The delivered preamble is windowed to a recent tail so a long thread does not
-    balloon the boot prompt; the operator's window knobs override the sane
-    defaults. They arrive through the declared boot env (parsed defensively, so a
-    typo degrades to the default rather than failing boot), which is why the
+    The replay is windowed to a recent structured tail so a long thread does not
+    balloon provider context; the operator's window knobs override the sane
+    defaults. They arrive through the declared boot env (parsed defensively, so
+    a typo degrades to the default rather than failing boot), which is why the
     defaults are applied here rather than read off the process env at this call.
     """
 
@@ -404,29 +418,41 @@ def _load_history(config: RunnerConfig) -> tuple[TranscriptStore, str | None]:
     max_turns = (
         config.history_max_turns
         if config.history_max_turns is not None
-        else DEFAULT_PREAMBLE_MAX_TURNS
+        else DEFAULT_REPLAY_MAX_TURNS
     )
     max_bytes = (
         config.history_max_bytes
         if config.history_max_bytes is not None
-        else DEFAULT_PREAMBLE_MAX_BYTES
+        else DEFAULT_REPLAY_MAX_BYTES
     )
 
-    async def _load() -> list[TurnRecord]:
-        return await store.load()
+    async def _load() -> tuple[ConversationReplay, int, bool]:
+        records = await store.load()
+        replay, summary = build_conversation_replay(
+            records, max_turns=max_turns, max_bytes=max_bytes
+        )
+        if summary is not None:
+            await store.append(summary)
+        return replay, len(records), summary is not None
 
     try:
-        turns = anyio.run(_load)
-    except Exception as exc:  # noqa: BLE001 - degrade to no-history, never fail boot
-        logger.warning(
-            "history load failed session=%s error_class=%s: %s (booting without history)",
+        replay, record_count, compacted = anyio.run(_load)
+    except Exception as exc:  # noqa: BLE001 - translate loader failures consistently
+        logger.error(
+            "history load failed session=%s error_class=%s: %s",
             config.session.session_id,
             type(exc).__name__,
             exc,
         )
-        return store, None
-    logger.info("history loaded session=%s turns=%d", config.session.session_id, len(turns))
-    return store, format_conversation_preamble(turns, max_turns=max_turns, max_bytes=max_bytes)
+        raise HistoryError("configured structured history could not be loaded") from exc
+    logger.info(
+        "history loaded session=%s records=%d messages=%d compacted=%s",
+        config.session.session_id,
+        record_count,
+        len(replay.messages),
+        compacted,
+    )
+    return store, replay
 
 
 def _serve() -> None:
@@ -468,7 +494,7 @@ def _serve() -> None:
             logger.error("credential resolution failed: %s", exc)
             raise
     memory_store, memory_preamble = _load_memory(config)
-    history_store, conversation_preamble = _load_history(config)
+    history_store, conversation_replay = _load_history(config)
     workspace_candidate = Path("/workspace")
     workspace_path: Path | None = (
         workspace_candidate
@@ -482,7 +508,7 @@ def _serve() -> None:
         memory_store=memory_store,
         memory_preamble=memory_preamble,
         history_store=history_store,
-        conversation_preamble=conversation_preamble,
+        conversation_replay=conversation_replay,
         harness=harness,
         workspace_path=workspace_path,
     )

--- a/runner/src/curie_runner/adapter.py
+++ b/runner/src/curie_runner/adapter.py
@@ -49,24 +49,55 @@ from claude_agent_sdk.types import (
     SessionStoreEntry,
 )
 
-from .history import ConversationMessage
+from .history import ConversationMessage, HarnessReplayState
 
 _SDK_SESSION_NAMESPACE = uuid.UUID("83efb74f-f09e-4db6-b898-9ed8d7084ba8")
 
 
 class _SeededSessionStore:
-    """Process-local SDK store used only to materialize a portable prefix."""
+    """SDK mirror seeded from portable messages or an optional native checkpoint."""
 
-    def __init__(self, key: SessionKey, entries: list[SessionStoreEntry]) -> None:
+    def __init__(
+        self,
+        key: SessionKey,
+        entries: list[SessionStoreEntry],
+        *,
+        checkpoint_required: bool,
+    ) -> None:
         self._key = key
-        self._entries = list(entries)
+        self._entries = json.loads(json.dumps(entries))
+        self._exported_from = len(entries)
+        self._checkpoint_required = checkpoint_required
 
     async def append(self, key: SessionKey, entries: list[SessionStoreEntry]) -> None:
         if key == self._key:
-            self._entries.extend(entries)
+            self._entries.extend(json.loads(json.dumps(entries)))
 
     async def load(self, key: SessionKey) -> list[SessionStoreEntry] | None:
-        return list(self._entries) if key == self._key and self._entries else None
+        return (
+            cast("list[SessionStoreEntry]", json.loads(json.dumps(self._entries)))
+            if key == self._key and self._entries
+            else None
+        )
+
+    async def export_replay_state(self) -> HarnessReplayState | None:
+        """Return a full checkpoint once, then only newly mirrored SDK entries."""
+
+        if self._checkpoint_required:
+            kind = "checkpoint"
+            selected = self._entries
+        else:
+            kind = "delta"
+            selected = self._entries[self._exported_from :]
+        self._checkpoint_required = False
+        self._exported_from = len(self._entries)
+        if not selected:
+            return None
+        return HarnessReplayState(
+            harness="claude",
+            kind=kind,
+            entries=tuple(json.loads(json.dumps(selected))),
+        )
 
 
 @dataclass(frozen=True)
@@ -84,12 +115,15 @@ def build_structured_resume(
     *,
     curie_session_id: str,
     cwd: str | None,
+    harness_replay: HarnessReplayState | None = None,
 ) -> StructuredResume:
     """Materialize portable messages into the SDK's ephemeral resume envelope.
 
-    Only role/content is sourced from durable storage. UUIDs and the local JSONL
-    envelope are deterministic adapter details reconstructed on every runner;
-    no provider-native transcript is made into Curie's persistence contract.
+    Portable role/content is always sufficient. When the matching harness left
+    an opaque native checkpoint, it is preferred to retain the SDK's exact
+    cache-breakpoint shape; otherwise UUIDs and the local JSONL envelope are
+    deterministic adapter details reconstructed on this runner. Native entries
+    are an optional optimization, never Curie's portable persistence contract.
     """
 
     session_id = str(uuid.uuid5(_SDK_SESSION_NAMESPACE, curie_session_id))
@@ -97,11 +131,34 @@ def build_structured_resume(
         "project_key": project_key_for_directory(cwd),
         "session_id": session_id,
     }
+    if (
+        harness_replay is not None
+        and harness_replay.harness == "claude"
+        and harness_replay.kind == "checkpoint"
+        and harness_replay.entries
+    ):
+        native_entries = cast(
+            "list[SessionStoreEntry]",
+            json.loads(json.dumps(harness_replay.entries)),
+        )
+        store = _SeededSessionStore(
+            key,
+            native_entries,
+            checkpoint_required=False,
+        )
+        return StructuredResume(
+            session_id=session_id,
+            resume=session_id,
+            session_store=cast("SessionStore", store),
+            session_key=key,
+        )
+
     if not messages:
+        store = _SeededSessionStore(key, [], checkpoint_required=True)
         return StructuredResume(
             session_id=session_id,
             resume=None,
-            session_store=None,
+            session_store=cast("SessionStore", store),
             session_key=key,
         )
 
@@ -131,7 +188,7 @@ def build_structured_resume(
         )
         entries.append(entry)
         parent_uuid = entry_uuid
-    store = _SeededSessionStore(key, entries)
+    store = _SeededSessionStore(key, entries, checkpoint_required=True)
     return StructuredResume(
         session_id=session_id,
         resume=session_id,
@@ -278,6 +335,7 @@ def build_options(
         resume=resume,
         session_id=session_id if resume is None else None,
         session_store=session_store,
+        session_store_flush="eager" if session_store is not None else "batched",
         task_budget=task_budget,
         permission_mode=permission_mode,
         can_use_tool=can_use_tool,
@@ -312,3 +370,11 @@ class ClaudeAgentSession:
 
     async def close(self) -> None:
         await self._client.disconnect()
+
+    async def export_replay_state(self) -> HarnessReplayState | None:
+        """Export the provider transcript checkpoint/delta mirrored this turn."""
+
+        store = self._options.session_store
+        if isinstance(store, _SeededSessionStore):
+            return await store.export_replay_state()
+        return None

--- a/runner/src/curie_runner/adapter.py
+++ b/runner/src/curie_runner/adapter.py
@@ -15,17 +15,186 @@ this boundary and nothing above it is. ``aci-protocol`` is never mocked.
 
 from __future__ import annotations
 
+import json
+import os
+import uuid
 from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Protocol, cast
 
 from claude_agent_sdk import (
+    AssistantMessage,
     ClaudeAgentOptions,
     ClaudeSDKClient,
     HookMatcher,
     SdkPluginConfig,
+    ServerToolResultBlock,
+    ServerToolUseBlock,
     TaskBudget,
+    TextBlock,
+    ThinkingBlock,
+    ToolResultBlock,
+    ToolUseBlock,
+    UserMessage,
 )
-from claude_agent_sdk.types import CanUseTool, McpSdkServerConfig, PermissionMode
+from claude_agent_sdk._cli_version import __cli_version__
+from claude_agent_sdk._internal.session_store import project_key_for_directory
+from claude_agent_sdk.types import (
+    CanUseTool,
+    McpSdkServerConfig,
+    PermissionMode,
+    SessionKey,
+    SessionStore,
+    SessionStoreEntry,
+)
+
+from .history import ConversationMessage
+
+_SDK_SESSION_NAMESPACE = uuid.UUID("83efb74f-f09e-4db6-b898-9ed8d7084ba8")
+
+
+class _SeededSessionStore:
+    """Process-local SDK store used only to materialize a portable prefix."""
+
+    def __init__(self, key: SessionKey, entries: list[SessionStoreEntry]) -> None:
+        self._key = key
+        self._entries = list(entries)
+
+    async def append(self, key: SessionKey, entries: list[SessionStoreEntry]) -> None:
+        if key == self._key:
+            self._entries.extend(entries)
+
+    async def load(self, key: SessionKey) -> list[SessionStoreEntry] | None:
+        return list(self._entries) if key == self._key and self._entries else None
+
+
+@dataclass(frozen=True)
+class StructuredResume:
+    """Claude SDK options needed to reconstruct one portable prefix."""
+
+    session_id: str
+    resume: str | None
+    session_store: SessionStore | None
+    session_key: SessionKey
+
+
+def build_structured_resume(
+    messages: tuple[ConversationMessage, ...],
+    *,
+    curie_session_id: str,
+    cwd: str | None,
+) -> StructuredResume:
+    """Materialize portable messages into the SDK's ephemeral resume envelope.
+
+    Only role/content is sourced from durable storage. UUIDs and the local JSONL
+    envelope are deterministic adapter details reconstructed on every runner;
+    no provider-native transcript is made into Curie's persistence contract.
+    """
+
+    session_id = str(uuid.uuid5(_SDK_SESSION_NAMESPACE, curie_session_id))
+    key: SessionKey = {
+        "project_key": project_key_for_directory(cwd),
+        "session_id": session_id,
+    }
+    if not messages:
+        return StructuredResume(
+            session_id=session_id,
+            resume=None,
+            session_store=None,
+            session_key=key,
+        )
+
+    effective_cwd = str(Path(cwd).resolve()) if cwd is not None else os.getcwd()
+    entries: list[SessionStoreEntry] = []
+    parent_uuid: str | None = None
+    for index, message in enumerate(messages):
+        canonical = json.dumps(message.to_dict(), separators=(",", ":"), sort_keys=True)
+        entry_uuid = str(uuid.uuid5(uuid.UUID(session_id), f"{index}:{canonical}"))
+        entry = cast(
+            "SessionStoreEntry",
+            {
+                "parentUuid": parent_uuid,
+                "isSidechain": False,
+                "userType": "external",
+                "cwd": effective_cwd,
+                "sessionId": session_id,
+                "version": __cli_version__,
+                "gitBranch": "",
+                "type": message.role,
+                "message": message.to_dict(),
+                "uuid": entry_uuid,
+                # This is adapter envelope metadata, not conversation time. Keep it
+                # stable so separate runners materialize identical local transcripts.
+                "timestamp": "1970-01-01T00:00:00.000Z",
+            },
+        )
+        entries.append(entry)
+        parent_uuid = entry_uuid
+    store = _SeededSessionStore(key, entries)
+    return StructuredResume(
+        session_id=session_id,
+        resume=session_id,
+        session_store=cast("SessionStore", store),
+        session_key=key,
+    )
+
+
+def _content_block_to_dict(block: object) -> dict[str, Any] | None:
+    if isinstance(block, TextBlock):
+        return {"type": "text", "text": block.text}
+    if isinstance(block, ThinkingBlock):
+        return {"type": "thinking", "thinking": block.thinking, "signature": block.signature}
+    if isinstance(block, ToolUseBlock):
+        return {"type": "tool_use", "id": block.id, "name": block.name, "input": block.input}
+    if isinstance(block, ToolResultBlock):
+        result: dict[str, Any] = {
+            "type": "tool_result",
+            "tool_use_id": block.tool_use_id,
+            "content": block.content,
+        }
+        if block.is_error is not None:
+            result["is_error"] = block.is_error
+        return result
+    if isinstance(block, ServerToolUseBlock):
+        return {
+            "type": "server_tool_use",
+            "id": block.id,
+            "name": block.name,
+            "input": block.input,
+        }
+    if isinstance(block, ServerToolResultBlock):
+        return {
+            "type": "server_tool_result",
+            "tool_use_id": block.tool_use_id,
+            "content": block.content,
+        }
+    return None
+
+
+def model_message_to_conversation(message: object) -> ConversationMessage | None:
+    """Project one SDK message into Curie's portable role/content shape."""
+
+    if isinstance(message, UserMessage):
+        if isinstance(message.content, str):
+            content: str | list[dict[str, Any]] = message.content
+        else:
+            content = [
+                projected
+                for block in message.content
+                if (projected := _content_block_to_dict(block)) is not None
+            ]
+        return ConversationMessage(role="user", content=content)
+    if isinstance(message, AssistantMessage):
+        return ConversationMessage(
+            role="assistant",
+            content=[
+                projected
+                for block in message.content
+                if (projected := _content_block_to_dict(block)) is not None
+            ],
+        )
+    return None
 
 
 class ModelSession(Protocol):
@@ -60,6 +229,8 @@ def build_options(
     max_turns: int,
     max_budget_usd: float | None,
     resume: str | None,
+    session_id: str | None = None,
+    session_store: SessionStore | None = None,
     thinking: dict[str, Any] | None = None,
     task_budget_hint: int | None = None,
     env: dict[str, str] | None = None,
@@ -70,10 +241,10 @@ def build_options(
 ) -> ClaudeAgentOptions:
     """Assemble ClaudeAgentOptions for the session.
 
-    ``resume`` is the rehydrate path (ADR-0003, stateless-first): when a history
-    ref is supplied it is passed as the SDK ``resume`` session id so a resumed
-    thread reconstructs its history from the store rather than assuming a
-    surviving in-RAM process.
+    ``resume`` is the provider-native rehydrate path (ADR-0003,
+    stateless-first). For Curie's portable history it names an ephemeral SDK
+    session envelope rebuilt by :func:`build_structured_resume`; it never points
+    the provider at Curie's durable state URL or assumes surviving local state.
 
     The three ACI budget fields map to distinct SDK controls: ``max_budget_usd``
     is the daily USD cap enforced natively; ``task_budget_hint`` becomes the SDK
@@ -105,6 +276,8 @@ def build_options(
         max_turns=max_turns,
         max_budget_usd=max_budget_usd,
         resume=resume,
+        session_id=session_id if resume is None else None,
+        session_store=session_store,
         task_budget=task_budget,
         permission_mode=permission_mode,
         can_use_tool=can_use_tool,

--- a/runner/src/curie_runner/config.py
+++ b/runner/src/curie_runner/config.py
@@ -83,9 +83,9 @@ class RunnerConfig:
     false_completion_check: bool
     port: int
     runner_token: str | None
-    # Operator bounds on the rehydrated history preamble, reachable through the
-    # chart's runner.extraEnv. None hands the consumer its own default, so the
-    # defaults live at the call site rather than here.
+    # Operator bounds on the rehydrated structured history, reachable through
+    # the chart's runner.extraEnv. None hands the consumer its own default, so
+    # the defaults live at the call site rather than here.
     history_max_turns: int | None
     history_max_bytes: int | None
 
@@ -107,7 +107,7 @@ class RunnerConfig:
         var raises there. ``history_ref`` is read only from an explicit
         ``CURIE_HISTORY_REF``, the URL of this thread's transcript namespace on
         the state API (ADR-0029, resolved by ``history.py`` into a
-        ``TranscriptStore`` and delivered as a boot preamble). It is deliberately
+        ``TranscriptStore`` and delivered as ordered harness messages). It is deliberately
         NOT derived from ``CURIE_MEMORY_REF``: memory is per-agent durable
         lessons, history is this thread's conversation (ADR-0025 keeps them
         distinct). Both live outside the sandbox and are rehydrated at boot

--- a/runner/src/curie_runner/fake.py
+++ b/runner/src/curie_runner/fake.py
@@ -25,6 +25,7 @@ from claude_agent_sdk import (
 from claude_agent_sdk.types import CanUseTool, PermissionResultDeny, ToolPermissionContext
 
 from .approval import APPROVAL_TOOL_NAME, ApprovalGate, process_approval_request
+from .history import ConversationMessage
 
 
 def _assistant(*blocks: Any, usage: dict[str, Any] | None = None) -> AssistantMessage:
@@ -185,6 +186,7 @@ class FakeModelSession:
         truncate_on_interrupt: bool = True,
         can_use_tool: CanUseTool | None = None,
         approval_gate: ApprovalGate | None = None,
+        replay_messages: tuple[ConversationMessage, ...] = (),
     ) -> None:
         self._script_factory = script_factory or self._default_script
         self._truncate_on_interrupt = truncate_on_interrupt
@@ -194,6 +196,7 @@ class FakeModelSession:
         # the fake tier omits the sole-route auto-bind / unknown-route refusal and
         # silently widens the card -- the exact real-path regression #544 closed.
         self._approval_gate = approval_gate
+        self.replay_messages = replay_messages
         self.connected = False
         self.queries: list[str] = []
         self.interrupts = 0

--- a/runner/src/curie_runner/harness/claude.py
+++ b/runner/src/curie_runner/harness/claude.py
@@ -45,6 +45,7 @@ CLAUDE_CONTRIBUTION = HarnessContribution(
     ),
     build_spawn_env=sdk_auth.resolve_sdk_env,
     compile_bundle=_compile_bundle,
+    supports_structured_replay=True,
 )
 
 

--- a/runner/src/curie_runner/harness/contribution.py
+++ b/runner/src/curie_runner/harness/contribution.py
@@ -59,5 +59,9 @@ class HarnessContribution:
     model_override_env_keys: tuple[str, ...]
     build_spawn_env: Callable[[MutableMapping[str, str]], dict[str, str] | None]
     compile_bundle: Callable[[str | None], BundleCompileResult]
+    # A harness must opt in only when it can consume Curie's ordered portable
+    # role/content prefix. False means recovered history is refused explicitly;
+    # rendering it into the system prompt is never a fallback (ADR-0119).
+    supports_structured_replay: bool = False
     aliases: frozenset[str] = field(default_factory=frozenset)
     labels: frozenset[str] = field(default_factory=frozenset)

--- a/runner/src/curie_runner/history.py
+++ b/runner/src/curie_runner/history.py
@@ -1,12 +1,11 @@
-"""The conversation-history port: resolve ``CURIE_HISTORY_REF`` and load/append
-this thread's transcript.
+"""Durable, harness-neutral structured conversation history.
 
-This is the first loader for the history seam (issue #20). Until now
-``CURIE_HISTORY_REF`` was a runner-local ref read into ``RunnerConfig`` and fed
-to the SDK ``resume=`` option, but nothing produced a usable value and the SDK
-transcript it pointed at lived on the pod's emptyDir (lost on any restart). This
-module is the sibling of ``memory.py`` (ADR-0025): the same durable state store,
-the same boot-preamble delivery, a different scope.
+ADR-0119 replaces the legacy rendered boot-prompt transcript with ordered
+role/content messages. The durable record is provider-neutral: user and assistant
+roles, opaque JSON content blocks (including tool calls/results), terminal and
+approval context, plus an explicit stable summary record at compaction boundaries.
+The Claude adapter materializes these records into its provider-native resume
+envelope at boot; no provider transcript format is persisted here.
 
 Design (ADR-0029):
 
@@ -18,10 +17,9 @@ Design (ADR-0029):
   rather than inventing a new datastore. The thread's transcript is the
   log-shaped key ``.../state/transcript/<thread_key>``: the ``append`` endpoint
   gives the append-only write and ``get`` gives load.
-- **Harness-agnostic delivery.** Loaded turns are composed into the effective
-  system prompt as a conversation preamble, not replayed through any one
-  harness's resume API, so a second harness (ADR-0011/0021) rehydrates the same
-  way.
+- **Harness-agnostic storage.** A harness must consume the structured prefix or
+  explicitly declare the capability absent. Rendering this data into a system
+  prompt is not a supported fallback.
 
 ``CURIE_HISTORY_REF`` resolution: the ref is the URL of the thread's transcript
 key on the state API (e.g. ``http://api:8000/agents/<id>/state/transcript/<thread>``).
@@ -33,12 +31,13 @@ loader and rejected loudly today.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, Protocol, cast, runtime_checkable
 
 import aiohttp
 from aci_protocol import BootEnv
@@ -56,9 +55,92 @@ class HistoryError(RuntimeError):
     """A history reference could not be resolved or dereferenced."""
 
 
+class StructuredReplayUnsupported(HistoryError):
+    """The selected harness cannot consume a recovered structured prefix."""
+
+
+JsonContent = str | list[dict[str, Any]]
+
+
+def _json_copy(value: JsonContent) -> JsonContent:
+    """Return a detached JSON-safe copy of message content."""
+
+    return cast("JsonContent", json.loads(json.dumps(value)))
+
+
+@dataclass(frozen=True)
+class ConversationMessage:
+    """One portable prior message, preserving its role and content blocks."""
+
+    role: str
+    content: JsonContent
+
+    def __post_init__(self) -> None:
+        if self.role not in ("user", "assistant"):
+            raise HistoryError(f"unsupported conversation role: {self.role!r}")
+        if not isinstance(self.content, (str, list)):
+            raise HistoryError("conversation message content must be a string or block list")
+        if isinstance(self.content, list) and not all(
+            isinstance(block, Mapping) for block in self.content
+        ):
+            raise HistoryError("conversation content blocks must be JSON objects")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"role": self.role, "content": _json_copy(self.content)}
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> ConversationMessage:
+        role = data.get("role")
+        content = data.get("content")
+        if not isinstance(role, str) or not isinstance(content, (str, list)):
+            raise HistoryError("invalid structured conversation message")
+        blocks: JsonContent
+        if isinstance(content, str):
+            blocks = content
+        elif all(isinstance(block, Mapping) for block in content):
+            blocks = [dict(block) for block in content]
+        else:
+            raise HistoryError("conversation content blocks must be JSON objects")
+        return cls(role=role, content=blocks)
+
+
+@dataclass(frozen=True)
+class ApprovalContext:
+    """Durable approval/suspend context carried with the turn that paused."""
+
+    summary: str | None = None
+    route: str | None = None
+    gate_kind: str | None = None
+    granted_tool: str | None = None
+    decision: str | None = None
+
+    def to_dict(self) -> dict[str, str | None]:
+        return {
+            "summary": self.summary,
+            "route": self.route,
+            "gate_kind": self.gate_kind,
+            "granted_tool": self.granted_tool,
+            "decision": self.decision,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> ApprovalContext:
+        def optional_string(name: str) -> str | None:
+            value = data.get(name)
+            return value if isinstance(value, str) else None
+
+        return cls(
+            summary=optional_string("summary"),
+            route=optional_string("route"),
+            gate_kind=optional_string("gate_kind"),
+            granted_tool=optional_string("granted_tool"),
+            decision=optional_string("decision"),
+        )
+
+
 @dataclass(frozen=True)
 class TurnRecord:
-    """One conversation turn: the user message and the assistant's reply.
+    """One durable turn with a legacy projection and structured messages.
 
     ``ts`` is set at append time (RFC3339 UTC) so a reloaded transcript keeps its
     order and a turn is timestamped for debugging. The pair is the minimal
@@ -68,33 +150,207 @@ class TurnRecord:
     user: str
     assistant: str
     ts: str = ""
+    messages: tuple[ConversationMessage, ...] = ()
+    status: str = "done"
+    approval: ApprovalContext | None = None
+
+    def __post_init__(self) -> None:
+        if not self.messages:
+            object.__setattr__(
+                self,
+                "messages",
+                (
+                    ConversationMessage(role="user", content=self.user),
+                    ConversationMessage(
+                        role="assistant",
+                        content=[{"type": "text", "text": self.assistant}],
+                    ),
+                ),
+            )
 
     def to_dict(self) -> dict[str, Any]:
-        return {"user": self.user, "assistant": self.assistant, "ts": self.ts}
+        return {
+            "type": "turn",
+            "user": self.user,
+            "assistant": self.assistant,
+            "ts": self.ts,
+            "messages": [message.to_dict() for message in self.messages],
+            "status": self.status,
+            "approval": self.approval.to_dict() if self.approval is not None else None,
+        }
 
     @classmethod
     def from_dict(cls, data: Mapping[str, Any]) -> TurnRecord:
+        raw_messages = data.get("messages")
+        messages: tuple[ConversationMessage, ...] = ()
+        if raw_messages is not None:
+            if not isinstance(raw_messages, list) or not all(
+                isinstance(item, Mapping) for item in raw_messages
+            ):
+                raise HistoryError("invalid structured conversation messages")
+            messages = tuple(
+                ConversationMessage.from_dict(item)
+                for item in raw_messages
+            )
+        raw_approval = data.get("approval")
         return cls(
-            user=data.get("user", ""),
-            assistant=data.get("assistant", ""),
-            ts=data.get("ts", ""),
+            user=str(data.get("user", "")),
+            assistant=str(data.get("assistant", "")),
+            ts=str(data.get("ts", "")),
+            messages=messages,
+            status=str(data.get("status", "done")),
+            approval=(
+                ApprovalContext.from_dict(raw_approval)
+                if isinstance(raw_approval, Mapping)
+                else None
+            ),
         )
+
+
+@dataclass(frozen=True)
+class SummaryRecord:
+    """A stable compaction boundary plus the un-compacted structured tail."""
+
+    content: str
+    digest: str
+    source_turns: int
+    through_ts: str
+    tail: tuple[TurnRecord, ...] = ()
+    ts: str = ""
+
+    @property
+    def messages(self) -> tuple[ConversationMessage, ...]:
+        prefix = (
+            ConversationMessage(
+                role="user",
+                content=(
+                    "# Durable conversation summary\n\n"
+                    "This summary was persisted at an explicit compaction boundary.\n\n"
+                    f"{self.content}"
+                ),
+            ),
+            ConversationMessage(
+                role="assistant",
+                content=[
+                    {
+                        "type": "text",
+                        "text": "I will preserve this stable summary as prior context.",
+                    }
+                ],
+            ),
+        )
+        return prefix + tuple(message for turn in self.tail for message in turn.messages)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "type": "summary",
+            "content": self.content,
+            "digest": self.digest,
+            "source_turns": self.source_turns,
+            "through_ts": self.through_ts,
+            "tail": [turn.to_dict() for turn in self.tail],
+            "ts": self.ts,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> SummaryRecord:
+        raw_tail = data.get("tail")
+        if raw_tail is not None and (
+            not isinstance(raw_tail, list)
+            or not all(isinstance(item, Mapping) for item in raw_tail)
+        ):
+            raise HistoryError("invalid structured summary tail")
+        tail = (
+            tuple(TurnRecord.from_dict(item) for item in raw_tail)
+            if isinstance(raw_tail, list)
+            else ()
+        )
+        return cls(
+            content=str(data.get("content", "")),
+            digest=str(data.get("digest", "")),
+            source_turns=int(data.get("source_turns", 0)),
+            through_ts=str(data.get("through_ts", "")),
+            tail=tail,
+            ts=str(data.get("ts", "")),
+        )
+
+
+HistoryRecord = TurnRecord | SummaryRecord
+
+
+@dataclass(frozen=True)
+class ConversationReplay:
+    """The exact portable prefix a fresh harness must reconstruct."""
+
+    messages: tuple[ConversationMessage, ...] = ()
+    source_turns: int = 0
+    summary_digest: str | None = None
+
+    @property
+    def present(self) -> bool:
+        return bool(self.messages)
+
+
+def close_suspended_tool_calls(
+    messages: Sequence[ConversationMessage],
+) -> tuple[ConversationMessage, ...]:
+    """Close dangling permission-gated tool calls with a denial result.
+
+    An interrupting permission denial can end the harness iterator immediately
+    after its ``tool_use`` message. Provider APIs require every prior tool call
+    to have a following ``tool_result`` before another user message can be
+    submitted. Persist an explicit, truthful negative result for only the calls
+    that remain unmatched; a result already supplied by the harness is preserved
+    byte-for-byte and this operation is idempotent.
+    """
+
+    pending: dict[str, None] = {}
+    for message in messages:
+        if not isinstance(message.content, list):
+            continue
+        for block in message.content:
+            block_type = block.get("type")
+            if message.role == "assistant" and block_type == "tool_use":
+                tool_use_id = block.get("id")
+                if isinstance(tool_use_id, str):
+                    pending[tool_use_id] = None
+            elif message.role == "user" and block_type == "tool_result":
+                tool_use_id = block.get("tool_use_id")
+                if isinstance(tool_use_id, str):
+                    pending.pop(tool_use_id, None)
+    if not pending:
+        return tuple(messages)
+    return (
+        *messages,
+        ConversationMessage(
+            role="user",
+            content=[
+                {
+                    "type": "tool_result",
+                    "tool_use_id": tool_use_id,
+                    "content": "Tool call was not executed; awaiting human approval.",
+                    "is_error": True,
+                }
+                for tool_use_id in pending
+            ],
+        ),
+    )
 
 
 @runtime_checkable
 class TranscriptStore(Protocol):
     """The history port: load prior turns, append the latest one.
 
-    Deliberately narrow -- no query language, no summarization (windowing is a
-    later slice). A concrete store dereferences a ``history_ref`` to a durable,
-    rehydratable backing that lives outside the sandbox.
+    Deliberately narrow -- no query language and no in-place rewrite. A concrete
+    store dereferences a ``history_ref`` to a durable, rehydratable backing that
+    lives outside the sandbox; compaction is itself an append-only summary.
     """
 
-    async def load(self) -> list[TurnRecord]:
+    async def load(self) -> list[HistoryRecord]:
         """Return prior turns, oldest first (empty when none)."""
         ...
 
-    async def append(self, record: TurnRecord) -> None:
+    async def append(self, record: HistoryRecord) -> None:
         """Durably append one turn; it must survive an unplanned restart."""
         ...
 
@@ -106,10 +362,10 @@ class NullTranscriptStore:
     per-turn paths are uniform whether or not a thread has a transcript ref.
     """
 
-    async def load(self) -> list[TurnRecord]:
+    async def load(self) -> list[HistoryRecord]:
         return []
 
-    async def append(self, record: TurnRecord) -> None:  # noqa: ARG002 - null sink
+    async def append(self, record: HistoryRecord) -> None:  # noqa: ARG002 - null sink
         return None
 
 
@@ -131,7 +387,7 @@ class StateApiTranscriptStore:
     def _headers(self) -> dict[str, str]:
         return {"X-API-Key": self._token} if self._token else {}
 
-    async def load(self) -> list[TurnRecord]:
+    async def load(self) -> list[HistoryRecord]:
         timeout = aiohttp.ClientTimeout(total=15)
         async with aiohttp.ClientSession(timeout=timeout) as session:
             async with session.get(self._key_url, headers=self._headers()) as resp:
@@ -145,13 +401,19 @@ class StateApiTranscriptStore:
         value = payload.get("value")
         if not isinstance(value, list):
             raise HistoryError("transcript log is not a JSON array")
-        turns: list[TurnRecord] = []
+        records: list[HistoryRecord] = []
         for item in value:
-            if isinstance(item, Mapping) and "user" in item:
-                turns.append(TurnRecord.from_dict(item))
-        return turns
+            if not isinstance(item, Mapping):
+                raise HistoryError("invalid transcript record: expected a JSON object")
+            if item.get("type") == "summary":
+                records.append(SummaryRecord.from_dict(item))
+            elif "user" in item:
+                records.append(TurnRecord.from_dict(item))
+            else:
+                raise HistoryError("invalid transcript record: unknown record shape")
+        return records
 
-    async def append(self, record: TurnRecord) -> None:
+    async def append(self, record: HistoryRecord) -> None:
         timeout = aiohttp.ClientTimeout(total=15)
         body = json.dumps({"item": record.to_dict()})
         headers = {**self._headers(), "Content-Type": "application/json"}
@@ -184,80 +446,173 @@ def resolve_history(history_ref: str | None, env: Mapping[str, str]) -> Transcri
     )
 
 
-# Sane preamble caps. A restarted thread should see recent context without the
-# system prompt ballooning: ~40 turns keeps a long conversation's continuity, and
-# ~16 KB bounds the rendered history to a few KB of the boot prompt. Both are
-# overridable at the boot call site (CURIE_HISTORY_MAX_TURNS/_BYTES) and either
-# can be disabled with None.
-DEFAULT_PREAMBLE_MAX_TURNS = 40
-DEFAULT_PREAMBLE_MAX_BYTES = 16_000
-
-# Prepended when older turns were dropped, so the model knows its recovered
-# context is a tail window, not the whole thread. Must contain "elided".
-_ELISION_NOTE = "(earlier turns elided to fit the context budget)"
+def _replay_bytes(messages: Sequence[ConversationMessage]) -> int:
+    return len(
+        json.dumps(
+            [message.to_dict() for message in messages],
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+    )
 
 
-def _render_preamble(records: Sequence[TurnRecord], *, elided: bool) -> str:
-    """Render the given turns to the preamble text (with an optional elision note).
+def _turn_summary_line(turn: TurnRecord) -> str:
+    tool_names: list[str] = []
+    tool_results: list[str] = []
+    for message in turn.messages:
+        if not isinstance(message.content, list):
+            continue
+        for block in message.content:
+            if block.get("type") == "tool_use":
+                tool_names.append(str(block.get("name") or "unknown"))
+            elif block.get("type") == "tool_result":
+                result = str(block.get("content") or "")
+                tool_results.append(result[:300])
+    parts = [f"User: {turn.user}", f"Assistant: {turn.assistant}"]
+    if tool_names:
+        parts.append(f"Tools: {', '.join(tool_names)}")
+    if tool_results:
+        parts.append(f"Tool results: {' | '.join(tool_results)}")
+    if turn.approval is not None:
+        approval = turn.approval
+        parts.append(
+            "Approval: "
+            f"status={turn.status} kind={approval.gate_kind or '-'} "
+            f"route={approval.route or '-'} decision={approval.decision or '-'} "
+            f"summary={approval.summary or '-'}"
+        )
+    return "\n".join(parts)
 
-    With ``elided=False`` this is byte-identical to the original unbounded render,
-    so an under-cap transcript is unchanged.
-    """
 
-    lines = [
-        "# Conversation so far (recovered after a restart)",
-        "",
-        "This thread continued from earlier turns. Prior exchange, oldest first:",
-        "",
-    ]
-    if elided:
-        lines.append(_ELISION_NOTE)
-        lines.append("")
-    for record in records:
-        lines.append(f"User: {record.user}")
-        lines.append(f"Assistant: {record.assistant}")
-        lines.append("")
-    return "\n".join(lines).rstrip()
-
-
-def format_conversation_preamble(
-    records: Sequence[TurnRecord],
+def _make_summary(
+    prior: SummaryRecord | None,
+    compacted: Sequence[TurnRecord],
+    tail: Sequence[TurnRecord],
     *,
-    max_turns: int | None = DEFAULT_PREAMBLE_MAX_TURNS,
-    max_bytes: int | None = DEFAULT_PREAMBLE_MAX_BYTES,
-) -> str | None:
-    """Render prior turns as a bounded system-prompt preamble, or None when empty.
+    max_bytes: int | None,
+) -> SummaryRecord:
+    source = {
+        "prior_digest": prior.digest if prior is not None else None,
+        "prior_content": prior.content if prior is not None else None,
+        "turns": [turn.to_dict() for turn in compacted],
+    }
+    canonical = json.dumps(source, separators=(",", ":"), sort_keys=True)
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    sections: list[str] = []
+    if prior is not None:
+        sections.append(prior.content)
+    sections.extend(_turn_summary_line(turn) for turn in compacted)
+    content = "\n\n".join(sections)
+    # The summary is written once at this explicit boundary. Bounding it here is
+    # stable: later appends never rewrite it; only a later compaction creates a
+    # new record. The digest keeps omitted material falsifiable.
+    budget = max(512, (max_bytes // 2) if max_bytes is not None else 8_000)
+    encoded = content.encode("utf-8")
+    if len(encoded) > budget:
+        prefix = encoded[: max(0, budget - 96)].decode("utf-8", errors="ignore")
+        content = f"{prefix}\n\n[older detail summarized; digest={digest}]"
+    source_turns = (prior.source_turns if prior is not None else 0) + len(compacted)
+    through_ts = compacted[-1].ts if compacted else (prior.through_ts if prior else "")
+    return SummaryRecord(
+        content=content,
+        digest=digest,
+        source_turns=source_turns,
+        through_ts=through_ts,
+        tail=tuple(tail),
+        ts=datetime.now(UTC).isoformat(),
+    )
 
-    This is how a reloaded transcript is delivered into the sandbox: it is
-    composed into the runner's effective system prompt at boot, so a restarted
-    session sees the prior exchange as context (harness-agnostic -- it is plain
-    prompt text, not a resume through any one harness's API).
 
-    The preamble is windowed to the most-recent (tail) turns: when the turn count
-    exceeds ``max_turns`` or the rendered size exceeds ``max_bytes``, the oldest
-    turns are dropped until it fits and an elision note is prepended. Either cap is
-    disabled by passing None; with both None the render is byte-identical to the
-    unbounded output and carries no note (delivery-side windowing only -- the
-    stored transcript is untouched).
+def build_conversation_replay(
+    records: Sequence[HistoryRecord],
+    *,
+    max_turns: int | None = 40,
+    max_bytes: int | None = 16_000,
+) -> tuple[ConversationReplay, SummaryRecord | None]:
+    """Build a structured prefix and, only at a boundary, a new stable summary.
+
+    Summary records are append-only. A record embeds the short un-compacted tail,
+    so appending the summary after the turns it represents does not reorder or
+    rewrite stored history. Subsequent turns extend that exact replay prefix until
+    one of the bounds is crossed again.
     """
 
-    if not records:
-        return None
-    total = len(records)
-    kept = list(records)
-    # Cap by turn count: keep the most-recent ``max_turns`` turns.
-    if max_turns is not None and len(kept) > max_turns:
-        kept = kept[-max_turns:]
-    # Cap by rendered size: drop oldest turns until the render fits the byte
-    # budget, always keeping at least the single most-recent turn. Render with the
-    # elision flag it will actually carry so the note's own bytes are accounted for,
-    # and only re-render when ``kept`` actually shrinks (no duplicate final render).
-    rendered = _render_preamble(kept, elided=len(kept) < total)
-    if max_bytes is not None:
-        while len(kept) > 1 and len(rendered.encode("utf-8")) > max_bytes:
-            kept = kept[1:]
-            rendered = _render_preamble(kept, elided=len(kept) < total)
-    return rendered
+    latest_summary: SummaryRecord | None = None
+    latest_summary_index = -1
+    for index, record in enumerate(records):
+        if isinstance(record, SummaryRecord):
+            latest_summary = record
+            latest_summary_index = index
+
+    appended_turns = [
+        record
+        for record in records[latest_summary_index + 1 :]
+        if isinstance(record, TurnRecord)
+    ]
+    active_turns = [
+        *((latest_summary.tail) if latest_summary is not None else ()),
+        *appended_turns,
+    ]
+
+    if latest_summary is not None:
+        current_messages = latest_summary.messages + tuple(
+            message for turn in appended_turns for message in turn.messages
+        )
+        source_turns = latest_summary.source_turns + len(active_turns)
+    else:
+        current_messages = tuple(
+            message for turn in active_turns for message in turn.messages
+        )
+        source_turns = len(active_turns)
+
+    over_turns = max_turns is not None and len(active_turns) > max_turns
+    over_bytes = max_bytes is not None and _replay_bytes(current_messages) > max_bytes
+    if not over_turns and not over_bytes:
+        return (
+            ConversationReplay(
+                messages=current_messages,
+                source_turns=source_turns,
+                summary_digest=latest_summary.digest if latest_summary else None,
+            ),
+            None,
+        )
+
+    if not active_turns:
+        return ConversationReplay(), None
+    keep_count = max(
+        1,
+        min(len(active_turns), (max_turns or len(active_turns)) // 2),
+    )
+    compacted = active_turns[:-keep_count]
+    tail: Sequence[TurnRecord] = active_turns[-keep_count:]
+    if not compacted:
+        compacted = active_turns[:-1]
+        tail = active_turns[-1:]
+    summary = _make_summary(latest_summary, compacted, tail, max_bytes=max_bytes)
+
+    # If a byte-only bound is still exceeded, move more of the tail into the
+    # stable summary until the remaining replay fits or one latest turn remains.
+    while max_bytes is not None and len(summary.tail) > 1:
+        if _replay_bytes(summary.messages) <= max_bytes:
+            break
+        compacted = [*compacted, summary.tail[0]]
+        tail = summary.tail[1:]
+        summary = _make_summary(latest_summary, compacted, tail, max_bytes=max_bytes)
+
+    return (
+        ConversationReplay(
+            messages=summary.messages,
+            source_turns=summary.source_turns + len(summary.tail),
+            summary_digest=summary.digest,
+        ),
+        summary,
+    )
+
+
+# Sane structured-replay caps. Crossing one creates a new durable summary;
+# ordinary appends never move or rewrite the already-cached prefix.
+DEFAULT_REPLAY_MAX_TURNS = 40
+DEFAULT_REPLAY_MAX_BYTES = 16_000
 
 
 def utcnow_iso() -> str:

--- a/runner/src/curie_runner/history.py
+++ b/runner/src/curie_runner/history.py
@@ -5,7 +5,9 @@ role/content messages. The durable record is provider-neutral: user and assistan
 roles, opaque JSON content blocks (including tool calls/results), terminal and
 approval context, plus an explicit stable summary record at compaction boundaries.
 The Claude adapter materializes these records into its provider-native resume
-envelope at boot; no provider transcript format is persisted here.
+envelope at boot. It may also persist opaque checkpoint/delta entries as a
+matching-harness cache optimization; those entries are never authoritative and
+another harness reconstructs from the portable messages alone.
 
 Design (ADR-0029):
 
@@ -35,7 +37,7 @@ import hashlib
 import json
 import logging
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from typing import Any, Protocol, cast, runtime_checkable
 
@@ -139,6 +141,52 @@ class ApprovalContext:
 
 
 @dataclass(frozen=True)
+class HarnessReplayState:
+    """Optional opaque harness-native checkpoint or append delta.
+
+    Portable role/content messages remain authoritative. This state is an
+    optimization a matching harness may consume to restore provider-native
+    request shape (and therefore its message cache); every other harness ignores
+    it and replays the portable messages.
+    """
+
+    harness: str
+    kind: str
+    entries: tuple[dict[str, Any], ...]
+
+    def __post_init__(self) -> None:
+        if not self.harness:
+            raise HistoryError("harness replay state requires a harness name")
+        if self.kind not in ("checkpoint", "delta"):
+            raise HistoryError(f"invalid harness replay state kind: {self.kind!r}")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "harness": self.harness,
+            "kind": self.kind,
+            "entries": json.loads(json.dumps(self.entries)),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> HarnessReplayState:
+        harness = data.get("harness")
+        kind = data.get("kind")
+        entries = data.get("entries")
+        if (
+            not isinstance(harness, str)
+            or not isinstance(kind, str)
+            or not isinstance(entries, list)
+            or not all(isinstance(entry, Mapping) for entry in entries)
+        ):
+            raise HistoryError("invalid harness replay state")
+        return cls(
+            harness=harness,
+            kind=kind,
+            entries=tuple(dict(entry) for entry in entries),
+        )
+
+
+@dataclass(frozen=True)
 class TurnRecord:
     """One durable turn with a legacy projection and structured messages.
 
@@ -153,6 +201,7 @@ class TurnRecord:
     messages: tuple[ConversationMessage, ...] = ()
     status: str = "done"
     approval: ApprovalContext | None = None
+    harness_replay: HarnessReplayState | None = None
 
     def __post_init__(self) -> None:
         if not self.messages:
@@ -177,6 +226,9 @@ class TurnRecord:
             "messages": [message.to_dict() for message in self.messages],
             "status": self.status,
             "approval": self.approval.to_dict() if self.approval is not None else None,
+            "harness_replay": (
+                self.harness_replay.to_dict() if self.harness_replay is not None else None
+            ),
         }
 
     @classmethod
@@ -193,6 +245,7 @@ class TurnRecord:
                 for item in raw_messages
             )
         raw_approval = data.get("approval")
+        raw_harness_replay = data.get("harness_replay")
         return cls(
             user=str(data.get("user", "")),
             assistant=str(data.get("assistant", "")),
@@ -202,6 +255,11 @@ class TurnRecord:
             approval=(
                 ApprovalContext.from_dict(raw_approval)
                 if isinstance(raw_approval, Mapping)
+                else None
+            ),
+            harness_replay=(
+                HarnessReplayState.from_dict(raw_harness_replay)
+                if isinstance(raw_harness_replay, Mapping)
                 else None
             ),
         )
@@ -285,6 +343,7 @@ class ConversationReplay:
     messages: tuple[ConversationMessage, ...] = ()
     source_turns: int = 0
     summary_digest: str | None = None
+    harness_replay: HarnessReplayState | None = None
 
     @property
     def present(self) -> bool:
@@ -456,6 +515,27 @@ def _replay_bytes(messages: Sequence[ConversationMessage]) -> int:
     )
 
 
+def _fold_harness_replay(turns: Sequence[TurnRecord]) -> HarnessReplayState | None:
+    """Fold the latest checkpoint and its following deltas into one checkpoint."""
+
+    harness: str | None = None
+    entries: list[dict[str, Any]] = []
+    checkpoint_seen = False
+    for turn in turns:
+        state = turn.harness_replay
+        if state is None:
+            continue
+        if state.kind == "checkpoint":
+            harness = state.harness
+            entries = [json.loads(json.dumps(entry)) for entry in state.entries]
+            checkpoint_seen = True
+        elif checkpoint_seen and state.harness == harness:
+            entries.extend(json.loads(json.dumps(entry)) for entry in state.entries)
+    if not checkpoint_seen or harness is None:
+        return None
+    return HarnessReplayState(harness=harness, kind="checkpoint", entries=tuple(entries))
+
+
 def _turn_summary_line(turn: TurnRecord) -> str:
     tool_names: list[str] = []
     tool_results: list[str] = []
@@ -491,10 +571,18 @@ def _make_summary(
     *,
     max_bytes: int | None,
 ) -> SummaryRecord:
+    portable_turns: list[dict[str, Any]] = []
+    for turn in compacted:
+        portable = turn.to_dict()
+        portable.pop("harness_replay", None)
+        portable_turns.append(portable)
     source = {
         "prior_digest": prior.digest if prior is not None else None,
         "prior_content": prior.content if prior is not None else None,
-        "turns": [turn.to_dict() for turn in compacted],
+        # Provider-native checkpoint metadata (timestamps, UUIDs, working dirs)
+        # is deliberately excluded: a portable summary boundary must not change
+        # because the matching harness encoded the same messages differently.
+        "turns": portable_turns,
     }
     canonical = json.dumps(source, separators=(",", ":"), sort_keys=True)
     digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
@@ -518,7 +606,10 @@ def _make_summary(
         digest=digest,
         source_turns=source_turns,
         through_ts=through_ts,
-        tail=tuple(tail),
+        # A summary is a new portable prefix. Native state for its old turns is
+        # both unusable and potentially large, so do not embed it in the durable
+        # summary tail.
+        tail=tuple(replace(turn, harness_replay=None) for turn in tail),
         ts=datetime.now(UTC).isoformat(),
     )
 
@@ -568,11 +659,16 @@ def build_conversation_replay(
     over_turns = max_turns is not None and len(active_turns) > max_turns
     over_bytes = max_bytes is not None and _replay_bytes(current_messages) > max_bytes
     if not over_turns and not over_bytes:
+        # A summary changes the portable prefix. Native state from its embedded
+        # tail still represents the pre-summary conversation and is unusable;
+        # only a post-summary turn's fresh checkpoint may restore that shape.
+        replay_state_turns = appended_turns if latest_summary is not None else active_turns
         return (
             ConversationReplay(
                 messages=current_messages,
                 source_turns=source_turns,
                 summary_digest=latest_summary.digest if latest_summary else None,
+                harness_replay=_fold_harness_replay(replay_state_turns),
             ),
             None,
         )
@@ -604,6 +700,10 @@ def build_conversation_replay(
             messages=summary.messages,
             source_turns=summary.source_turns + len(summary.tail),
             summary_digest=summary.digest,
+            # The explicit compaction boundary intentionally changes the prefix.
+            # The matching harness writes a new checkpoint after the first turn
+            # over this synthetic summary.
+            harness_replay=None,
         ),
         summary,
     )

--- a/runner/src/curie_runner/session.py
+++ b/runner/src/curie_runner/session.py
@@ -45,6 +45,7 @@ from .budget import BUDGET_CLASSIFICATION, BudgetTracker
 from .history import (
     ApprovalContext,
     ConversationMessage,
+    HarnessReplayState,
     NullTranscriptStore,
     TranscriptStore,
     TurnRecord,
@@ -318,6 +319,18 @@ class SessionRunner:
             and state.approval_gate_kind == "permission"
         ):
             messages = close_suspended_tool_calls(messages)
+        harness_replay: HarnessReplayState | None = None
+        exporter = getattr(self._session, "export_replay_state", None)
+        if callable(exporter):
+            try:
+                harness_replay = await exporter()
+            except Exception as exc:  # noqa: BLE001 - portable replay remains valid
+                logger.warning(
+                    "harness replay export failed session=%s error_class=%s: %s",
+                    self._session_id,
+                    type(exc).__name__,
+                    exc,
+                )
         try:
             await self._history.append(
                 TurnRecord(
@@ -345,6 +358,7 @@ class SessionRunner:
                         )
                         else None
                     ),
+                    harness_replay=harness_replay,
                 )
             )
         except Exception as exc:  # noqa: BLE001 - best-effort; never fail a completed turn

--- a/runner/src/curie_runner/session.py
+++ b/runner/src/curie_runner/session.py
@@ -39,10 +39,17 @@ from claude_agent_sdk import AssistantMessage, ResultMessage
 from curie_telemetry import record_metric
 from opentelemetry.context import Context
 
-from .adapter import ModelSession
+from .adapter import ModelSession, model_message_to_conversation
 from .approval import ApprovalGate
 from .budget import BUDGET_CLASSIFICATION, BudgetTracker
-from .history import NullTranscriptStore, TranscriptStore, TurnRecord
+from .history import (
+    ApprovalContext,
+    ConversationMessage,
+    NullTranscriptStore,
+    TranscriptStore,
+    TurnRecord,
+    close_suspended_tool_calls,
+)
 from .memory import (
     ConsolidationResult,
     MemoryRecord,
@@ -187,6 +194,7 @@ class SessionRunner:
         approval_resumed_kind: str | None = None,
         approval_decision: str | None = None,
         false_completion_check: bool = False,
+        history_resumed: bool = False,
     ) -> None:
         self._factory = session_factory
         self._ceiling = ceiling
@@ -200,9 +208,9 @@ class SessionRunner:
         # (append + provenance). NullMemoryStore when no CURIE_MEMORY_REF.
         self._memory: MemoryStore = memory_store or NullMemoryStore()
         # The conversation-history port (#20). Prior turns are loaded at boot and
-        # delivered via the system prompt; this store is the write side, appended
-        # once per successful turn so a restarted sandbox rehydrates the thread.
-        # NullTranscriptStore when no CURIE_HISTORY_REF.
+        # reconstructed as the harness's structured prefix; this store is the
+        # write side, appended once per terminal turn so a restarted sandbox
+        # rehydrates the thread. NullTranscriptStore when no CURIE_HISTORY_REF.
         self._history: TranscriptStore = history_store or NullTranscriptStore()
         # The permission gate (#245): the can_use_tool callback records a
         # blocked approval-required call here, and the turn's final is flipped
@@ -220,6 +228,8 @@ class SessionRunner:
         # Opt-in, observe-only false-completion check (#517): warn when a turn
         # ends DONE with a substantive answer but zero tool calls. Off by default.
         self._false_completion_check = false_completion_check
+        self._history_resumed = history_resumed
+        self._resume_cache_metric_recorded = False
 
         self._session: ModelSession | None = None
         # One turn consumes the SDK generator at a time. This MUST be a
@@ -289,22 +299,52 @@ class SessionRunner:
     async def _record_turn(self, event: Event, state: TurnState) -> None:
         """Append one completed turn to the durable conversation transcript (#20).
 
-        Only a successful DONE terminal final sets ``state.final_text``; failed,
-        budget-halted, auth-halted, awaiting-approval, and idle turns leave it
-        None and are not persisted, so the transcript holds the delivered
-        exchange, not error stubs. Best-effort:
+        A successful DONE terminal final or an AWAITING_APPROVAL suspension sets
+        ``state.final_text``. Failed, budget-halted, auth-halted, and idle turns
+        leave it None and are not persisted, so the transcript holds delivered
+        exchanges and resumable approval context, not error stubs. Best-effort:
         a transient store failure is logged and never propagated -- recording
         history must not fail a turn the user already received an answer to.
         """
 
         if state.final_text is None:
             return
+        messages = (
+            ConversationMessage(role="user", content=event.text),
+            *state.history_messages,
+        )
+        if (
+            self._status is SessionStatus.AWAITING_APPROVAL
+            and state.approval_gate_kind == "permission"
+        ):
+            messages = close_suspended_tool_calls(messages)
         try:
             await self._history.append(
                 TurnRecord(
                     user=event.text,
                     assistant=state.final_text,
                     ts=utcnow_iso(),
+                    messages=messages,
+                    status=self._status.value,
+                    approval=(
+                        ApprovalContext(
+                            summary=state.approval_summary,
+                            route=state.approval_route,
+                            gate_kind=state.approval_gate_kind,
+                            granted_tool=state.approval_granted_tool,
+                            decision=self._approval_decision,
+                        )
+                        if any(
+                            (
+                                state.approval_summary,
+                                state.approval_route,
+                                state.approval_gate_kind,
+                                state.approval_granted_tool,
+                                self._approval_decision,
+                            )
+                        )
+                        else None
+                    ),
                 )
             )
         except Exception as exc:  # noqa: BLE001 - best-effort; never fail a completed turn
@@ -357,8 +397,8 @@ class SessionRunner:
         tears down the current SDK session and reconnects a new one from the same
         factory, so the next turn starts with no accumulated conversation; a
         thread with a durable ``CURIE_HISTORY_REF`` still rehydrates its own
-        history preamble on reconnect (that is the thread's real history, not a
-        cross-case leak), while an eval runner (no history ref) comes up empty.
+        structured replay on reconnect (that is the thread's real history, not
+        a cross-case leak), while an eval runner (no history ref) comes up empty.
 
         This is a deliberate, explicit control -- NOT per-turn session churn. The
         one-long-lived-session-per-process invariant (prompt-cache affinity
@@ -562,12 +602,44 @@ class SessionRunner:
                 for line in self._auth_halt_lines():
                     yield line
                 return
+            history_message = model_message_to_conversation(message)
+            if history_message is not None:
+                # Some harness streams echo the submitted user prompt before
+                # assistant output. The durable turn already prepends the exact
+                # inbound event, so drop only that leading duplicate.
+                if not (
+                    not state.history_messages
+                    and history_message.role == "user"
+                    and history_message.content == event.text
+                ):
+                    state.history_messages.append(history_message)
             usage = getattr(message, "usage", None)
             # The terminal result carries the authoritative turn total; streaming
             # assistant messages carry per-message output. Fold them differently
             # so the same tokens are not counted twice (see BudgetTracker).
             if isinstance(message, ResultMessage):
                 tracker.set_total(usage)
+                if self._history_resumed and not self._resume_cache_metric_recorded:
+                    cache_read = (
+                        int(usage.get("cache_read_input_tokens") or 0)
+                        if isinstance(usage, dict)
+                        else 0
+                    )
+                    record_metric(
+                        "curie.history.resume.cache_read",
+                        cache_read,
+                        attributes={
+                            "service.name": "curie-runner",
+                            "source": "runner",
+                            "cache_hit": "true" if cache_read > 0 else "false",
+                        },
+                    )
+                    logger.info(
+                        "history resume cache observed session=%s cache_read_input_tokens=%d",
+                        self._session_id,
+                        cache_read,
+                    )
+                    self._resume_cache_metric_recorded = True
             else:
                 tracker.add_increment(usage)
             budget_hit = tracker.exceeded
@@ -595,10 +667,12 @@ class SessionRunner:
                         yield line
                     self._status = final.status
                     self._turn_open = False
-                    # Only a clean DONE reply belongs in the conversation
-                    # transcript. Classified failures and approval pauses are
-                    # terminal delivery outcomes, not assistant answers (#20).
-                    if final.status is SessionStatus.DONE:
+                    # Persist clean replies and resumable approval suspensions;
+                    # classified failures remain delivery outcomes, not history.
+                    if final.status in {
+                        SessionStatus.DONE,
+                        SessionStatus.AWAITING_APPROVAL,
+                    }:
                         state.final_text = final.text
                     yield to_ndjson_line(final)
                     return
@@ -628,6 +702,11 @@ class SessionRunner:
             yield line
         self._status = final.status
         self._turn_open = False
+        # A missing provider ResultMessage is still incomplete for a nominal
+        # DONE turn. The one resumable exception is a runner-owned approval
+        # halt: its structured tool call and gate context must cross runners.
+        if final.status is SessionStatus.AWAITING_APPROVAL:
+            state.final_text = final.text or state.assistant_text
         yield to_ndjson_line(final)
 
     def _approval_not_acted_lines(self, state: TurnState, final: Final) -> list[str]:

--- a/runner/src/curie_runner/translate.py
+++ b/runner/src/curie_runner/translate.py
@@ -39,6 +39,7 @@ from claude_agent_sdk import (
 )
 
 from .approval import APPROVAL_TOOL_NAME, guard_reserved_summary
+from .history import ConversationMessage
 from .otel import _GenerationSpan
 from .side_effects import SideEffectClassifier
 
@@ -86,11 +87,15 @@ class TurnState:
     # leaves ``side_effect_emitted`` False, so this counter -- not that flag -- is
     # the right "did any tool run" signal.
     tool_call_count: int = 0
-    # The delivered text of a clean DONE terminal ``final``, set by the session
-    # loop. It is the assistant reply recorded into the conversation transcript
-    # (#20); left None for failure, budget, auth, awaiting-approval, and idle
-    # outcomes so those turns are not persisted as history.
+    # The delivered text of a clean DONE terminal ``final`` or an approval
+    # suspension, set by the session loop. It is recorded with the structured
+    # conversation transcript (#20/#1902); left None for failure, budget, auth,
+    # and idle outcomes so those turns are not persisted as history.
     final_text: str | None = None
+    # Ordered provider-neutral messages captured from the harness stream for
+    # durable replay. The inbound user message is prepended by SessionRunner;
+    # this list holds assistant output and user-shaped tool results.
+    history_messages: list[ConversationMessage] = field(default_factory=list)
     # Call id -> tool name, for side-effecting calls whose result has not arrived
     # yet. A tool result lands on a LATER message, so the name has to be
     # remembered to attribute it, and the id is what joins the two frames of one

--- a/runner/tests/test_harness_boot_wiring.py
+++ b/runner/tests/test_harness_boot_wiring.py
@@ -22,6 +22,7 @@ from curie_runner.harness.registry import (
     MalformedHarnessContributionError,
     UnknownHarnessError,
 )
+from curie_runner.history import ConversationMessage, ConversationReplay
 
 _BUDGET = '{"max_output_tokens_per_run": 10000, "max_usd_per_day": 1.0}'
 
@@ -57,6 +58,40 @@ def _harness(**overrides) -> HarnessContribution:
     )
     defaults.update(overrides)
     return HarnessContribution(**defaults)
+
+
+def test_harness_without_structured_replay_refuses_recovered_history(tmp_path) -> None:
+    from curie_runner.history import StructuredReplayUnsupported
+
+    replay = ConversationReplay(
+        messages=(ConversationMessage(role="user", content="prior turn"),),
+        source_turns=1,
+    )
+    harness = _harness(supports_structured_replay=False)
+
+    with pytest.raises(StructuredReplayUnsupported, match="declares structured replay absent"):
+        build_runner(_config(tmp_path), conversation_replay=replay, harness=harness)
+
+
+def test_claude_runner_materializes_history_without_system_prompt_preamble(tmp_path) -> None:
+    config = _config(tmp_path)
+    replay = ConversationReplay(
+        messages=(
+            ConversationMessage(role="user", content="prior question"),
+            ConversationMessage(
+                role="assistant", content=[{"type": "text", "text": "prior answer"}]
+            ),
+        ),
+        source_turns=1,
+    )
+
+    runner = build_runner(config, conversation_replay=replay)
+    options = runner._factory()._options
+
+    assert options.system_prompt is None
+    assert options.resume is not None
+    assert options.session_store is not None
+    assert runner._history_resumed is True
 
 
 def test_build_runner_uses_the_harness_readonly_set(tmp_path) -> None:

--- a/runner/tests/test_history.py
+++ b/runner/tests/test_history.py
@@ -11,12 +11,18 @@ import anyio
 import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestServer
+from curie_runner.adapter import build_structured_resume
 from curie_runner.history import (
+    ApprovalContext,
+    ConversationMessage,
+    ConversationReplay,
     HistoryError,
     NullTranscriptStore,
     StateApiTranscriptStore,
+    SummaryRecord,
     TranscriptStore,
     TurnRecord,
+    build_conversation_replay,
     format_conversation_preamble,
     resolve_history,
 )
@@ -52,6 +58,169 @@ def test_turn_record_round_trip() -> None:
         user="what changed?", assistant="the deploy bumped v3", ts="2026-07-14T00:00:00+00:00"
     )
     assert TurnRecord.from_dict(rec.to_dict()) == rec
+
+
+def test_structured_turn_round_trip_preserves_tools_and_approval_context() -> None:
+    record = TurnRecord(
+        user="deploy release",
+        assistant="approval required",
+        ts="2026-08-30T00:00:00Z",
+        status="awaiting_approval",
+        messages=(
+            ConversationMessage(role="user", content="deploy release"),
+            ConversationMessage(
+                role="assistant",
+                content=[
+                    {
+                        "type": "tool_use",
+                        "id": "call-1",
+                        "name": "Bash",
+                        "input": {"command": "deploy --release"},
+                    }
+                ],
+            ),
+            ConversationMessage(
+                role="user",
+                content=[
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "call-1",
+                        "content": "permission denied",
+                        "is_error": True,
+                    }
+                ],
+            ),
+        ),
+        approval=ApprovalContext(
+            summary="Deploy release",
+            route="release-managers",
+            gate_kind="permission",
+            granted_tool="Bash",
+            decision=None,
+        ),
+    )
+
+    loaded = TurnRecord.from_dict(record.to_dict())
+
+    assert loaded == record
+    assert [message.role for message in loaded.messages] == ["user", "assistant", "user"]
+    assert loaded.messages[1].content[0]["type"] == "tool_use"
+    assert loaded.messages[2].content[0]["type"] == "tool_result"
+    assert loaded.approval == record.approval
+
+
+def test_legacy_turn_becomes_structured_user_assistant_messages() -> None:
+    record = TurnRecord.from_dict(
+        {"user": "old question", "assistant": "old answer", "ts": "2026-07-14T00:00:00Z"}
+    )
+
+    assert record.messages == (
+        ConversationMessage(role="user", content="old question"),
+        ConversationMessage(
+            role="assistant", content=[{"type": "text", "text": "old answer"}]
+        ),
+    )
+
+
+def test_long_history_compacts_once_then_keeps_prefix_stable_until_next_boundary() -> None:
+    records = [
+        TurnRecord(user=f"u{i}", assistant=f"a{i}", ts=f"2026-08-30T00:00:0{i}Z")
+        for i in range(6)
+    ]
+
+    replay, summary = build_conversation_replay(records, max_turns=4, max_bytes=None)
+
+    assert summary is not None
+    assert summary.source_turns == 4
+    assert replay.summary_digest == summary.digest
+    assert replay.messages[0].role == "user"
+    assert "Durable conversation summary" in str(replay.messages[0].content)
+    assert replay.messages[-2:] == records[-1].messages
+
+    persisted = [*records, summary]
+    with_one_more = [
+        *persisted,
+        TurnRecord(user="u6", assistant="a6", ts="2026-08-30T00:00:06Z"),
+    ]
+    replay_after, next_summary = build_conversation_replay(
+        with_one_more, max_turns=4, max_bytes=None
+    )
+
+    assert next_summary is None
+    assert replay_after.messages[: len(replay.messages)] == replay.messages
+
+
+def test_changed_compacted_prefix_changes_summary_digest() -> None:
+    records = [TurnRecord(user=f"u{i}", assistant=f"a{i}") for i in range(6)]
+    _, original = build_conversation_replay(records, max_turns=4, max_bytes=None)
+    changed = list(records)
+    changed[0] = TurnRecord(user="changed-u0", assistant="a0")
+    _, different = build_conversation_replay(changed, max_turns=4, max_bytes=None)
+
+    assert original is not None
+    assert different is not None
+    assert different.digest != original.digest
+
+
+def test_structured_resume_materializes_ordered_sdk_entries_without_rendering_text(
+    tmp_path,
+) -> None:
+    messages = (
+        ConversationMessage(role="user", content="run it"),
+        ConversationMessage(
+            role="assistant",
+            content=[
+                {
+                    "type": "tool_use",
+                    "id": "call-1",
+                    "name": "Bash",
+                    "input": {"command": "echo ok"},
+                }
+            ],
+        ),
+        ConversationMessage(
+            role="user",
+            content=[
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "call-1",
+                    "content": "ok",
+                }
+            ],
+        ),
+        ConversationMessage(
+            role="assistant", content=[{"type": "text", "text": "done"}]
+        ),
+    )
+
+    first = build_structured_resume(
+        messages, curie_session_id="curie-thread-1", cwd=str(tmp_path)
+    )
+    second = build_structured_resume(
+        messages, curie_session_id="curie-thread-1", cwd=str(tmp_path)
+    )
+
+    assert first.resume == first.session_id
+    assert first.session_id == second.session_id
+    assert first.session_store is not None
+    entries = anyio.run(first.session_store.load, first.session_key)
+    assert entries is not None
+    assert [entry["message"]["role"] for entry in entries] == [
+        "user",
+        "assistant",
+        "user",
+        "assistant",
+    ]
+    assert entries[1]["message"]["content"][0]["type"] == "tool_use"
+    assert entries[2]["message"]["content"][0]["type"] == "tool_result"
+    assert [entry["parentUuid"] for entry in entries][1:] == [
+        entry["uuid"] for entry in entries[:-1]
+    ]
+
+    fresh = build_structured_resume((), curie_session_id="curie-thread-1", cwd=str(tmp_path))
+    assert fresh.resume is None
+    assert fresh.session_store is None
+    assert fresh.session_id == first.session_id
 
 
 def test_resolve_absent_ref_is_null_store() -> None:
@@ -259,6 +428,22 @@ def test_successful_turn_is_appended_to_the_transcript() -> None:
     # default_turn's terminal result text.
     assert store.turns[0].assistant == "all done"
     assert store.turns[0].ts  # a timestamp was stamped
+    assert [message.role for message in store.turns[0].messages] == [
+        "user",
+        "assistant",
+        "assistant",
+        "user",
+    ]
+    assert any(
+        isinstance(message.content, list)
+        and any(block.get("type") == "tool_use" for block in message.content)
+        for message in store.turns[0].messages
+    )
+    assert any(
+        isinstance(message.content, list)
+        and any(block.get("type") == "tool_result" for block in message.content)
+        for message in store.turns[0].messages
+    )
 
 
 def test_synthetic_done_after_incomplete_turn_is_not_appended_to_the_transcript() -> None:

--- a/runner/tests/test_history.py
+++ b/runner/tests/test_history.py
@@ -1,4 +1,4 @@
-"""The conversation-history port: resolution, turn shape, preamble, the state-API
+"""The conversation-history port: resolution, structured replay, the state-API
 store, and the per-turn append that persists a thread's transcript (#20).
 
 The StateApiTranscriptStore is exercised against a tiny in-memory fake of the
@@ -15,15 +15,12 @@ from curie_runner.adapter import build_structured_resume
 from curie_runner.history import (
     ApprovalContext,
     ConversationMessage,
-    ConversationReplay,
     HistoryError,
     NullTranscriptStore,
     StateApiTranscriptStore,
-    SummaryRecord,
     TranscriptStore,
     TurnRecord,
     build_conversation_replay,
-    format_conversation_preamble,
     resolve_history,
 )
 
@@ -121,6 +118,16 @@ def test_legacy_turn_becomes_structured_user_assistant_messages() -> None:
         ),
     )
 
+
+def test_malformed_structured_turn_is_rejected_instead_of_falling_back_to_legacy() -> None:
+    with pytest.raises(HistoryError, match="structured conversation messages"):
+        TurnRecord.from_dict(
+            {
+                "user": "must not silently survive",
+                "assistant": "legacy fallback",
+                "messages": [42],
+            }
+        )
 
 def test_long_history_compacts_once_then_keeps_prefix_stable_until_next_boundary() -> None:
     records = [
@@ -245,77 +252,6 @@ def test_resolve_unsupported_scheme_raises() -> None:
         resolve_history("s3://bucket/hist", {})
 
 
-def test_preamble_empty_is_none() -> None:
-    assert format_conversation_preamble([]) is None
-
-
-def test_preamble_includes_user_and_assistant_text_oldest_first() -> None:
-    turns = [
-        TurnRecord(user="deploy the app", assistant="pushed to dev"),
-        TurnRecord(user="and prod?", assistant="promoted to prod"),
-    ]
-    preamble = format_conversation_preamble(turns)
-    assert preamble is not None
-    assert "deploy the app" in preamble
-    assert "pushed to dev" in preamble
-    assert "and prod?" in preamble
-    assert "promoted to prod" in preamble
-    # Oldest first: the first turn's user text precedes the second turn's.
-    assert preamble.index("deploy the app") < preamble.index("and prod?")
-
-
-# --- preamble windowing (the preamble must be bounded) ---------------------------
-
-
-def test_preamble_windows_by_max_turns_keeping_the_tail() -> None:
-    # A long thread must not render an unbounded preamble: with an explicit small
-    # max_turns, only the most-recent turns survive and an elision note flags that
-    # earlier turns were dropped.
-    turns = [
-        TurnRecord(user=f"user-msg-{i}", assistant=f"assistant-msg-{i}") for i in range(50)
-    ]
-    preamble = format_conversation_preamble(turns, max_turns=5)
-    assert preamble is not None
-    # The newest turn's content is kept; an old (dropped) turn's is not.
-    assert "user-msg-49" in preamble
-    assert "user-msg-0" not in preamble
-    # The truncation is announced.
-    assert "elided" in preamble
-
-
-def test_preamble_windows_by_max_bytes_keeping_the_tail() -> None:
-    # A tiny byte budget caps the rendered size: the oldest turns are dropped, the
-    # most-recent kept, and the elision note appears. Driven by an explicit
-    # max_bytes so the test does not depend on the default's exact value.
-    turns = [TurnRecord(user=f"u{i}", assistant=f"a{i}") for i in range(50)]
-    unbounded = format_conversation_preamble(turns, max_turns=None, max_bytes=None)
-    assert unbounded is not None
-    preamble = format_conversation_preamble(turns, max_bytes=400)
-    assert preamble is not None
-    assert "elided" in preamble
-    # Most-recent kept, oldest dropped.
-    assert "u49" in preamble
-    assert "u0" not in preamble
-    # Truncation actually shrank the output and stayed near the budget.
-    assert len(preamble.encode("utf-8")) < len(unbounded.encode("utf-8"))
-    assert len(preamble.encode("utf-8")) <= 2 * 400
-
-
-def test_preamble_short_transcript_is_byte_identical_and_unnoted() -> None:
-    # Backward-compat: a small transcript under the defaults renders with NO
-    # elision note and is byte-identical to the uncapped (max_turns=None,
-    # max_bytes=None) output for the same records.
-    turns = [
-        TurnRecord(user="deploy the app", assistant="pushed to dev"),
-        TurnRecord(user="and prod?", assistant="promoted to prod"),
-    ]
-    uncapped = format_conversation_preamble(turns, max_turns=None, max_bytes=None)
-    defaulted = format_conversation_preamble(turns)
-    assert defaulted == uncapped
-    assert defaulted is not None
-    assert "elided" not in defaulted
-
-
 def test_state_store_load_empty_is_empty() -> None:
     app, _ = _fake_state_app()
 
@@ -364,6 +300,26 @@ def test_state_store_load_rejects_non_array() -> None:
             url = str(server.make_url("/agents/A/state/transcript/t1"))
             store = StateApiTranscriptStore(url, token=None)
             with pytest.raises(HistoryError):
+                await store.load()
+
+    anyio.run(go)
+
+
+def test_state_store_load_rejects_malformed_log_entry() -> None:
+    app = web.Application()
+
+    async def get_key(_request: web.Request) -> web.Response:
+        return web.json_response(
+            {"namespace": "transcript", "key": "t1", "value": [42], "version": 1}
+        )
+
+    app.router.add_get("/agents/A/state/transcript/t1", get_key)
+
+    async def go() -> None:
+        async with TestServer(app) as server:
+            url = str(server.make_url("/agents/A/state/transcript/t1"))
+            store = StateApiTranscriptStore(url, token=None)
+            with pytest.raises(HistoryError, match="invalid transcript record"):
                 await store.load()
 
     anyio.run(go)
@@ -433,6 +389,7 @@ def test_successful_turn_is_appended_to_the_transcript() -> None:
         "assistant",
         "assistant",
         "user",
+        "assistant",
     ]
     assert any(
         isinstance(message.content, list)
@@ -540,7 +497,7 @@ def test_budget_halted_turn_is_not_appended_to_the_transcript() -> None:
     assert store.turns == []
 
 
-def test_awaiting_approval_turn_is_not_appended_to_the_transcript() -> None:
+def test_awaiting_approval_turn_is_appended_with_suspend_context() -> None:
     from aci_protocol import Event, SessionStatus
     from curie_runner.fake import approval_turn
 
@@ -551,7 +508,11 @@ def test_awaiting_approval_turn_is_not_appended_to_the_transcript() -> None:
     )
 
     assert final.status is SessionStatus.AWAITING_APPROVAL
-    assert store.turns == []
+    assert len(store.turns) == 1
+    assert store.turns[0].status == SessionStatus.AWAITING_APPROVAL.value
+    assert store.turns[0].approval is not None
+    assert store.turns[0].approval.gate_kind == "policy"
+    assert store.turns[0].approval.summary == "Approve the action"
 
 
 def test_interrupted_turn_is_not_appended_to_the_transcript() -> None:
@@ -579,23 +540,22 @@ def test_interrupted_turn_is_not_appended_to_the_transcript() -> None:
     assert store.turns == []
 
 
-def test_compose_system_prompt_orders_memory_then_conversation_then_base() -> None:
-    # Boot delivery (ADR-0029): durable memory leads, then this thread's recovered
-    # conversation, then the bundle/env system prompt. Any part may be absent.
+def test_compose_system_prompt_excludes_conversation_history() -> None:
+    # ADR-0119: only memory and bundle instructions belong in the system prompt;
+    # conversation history crosses as structured messages.
     from curie_runner.__main__ import _compose_system_prompt
 
-    assert _compose_system_prompt("BASE", "MEM", "CONV", model=None) == "MEM\n\nCONV\n\nBASE"
-    assert _compose_system_prompt("BASE", None, "CONV", model=None) == "CONV\n\nBASE"
-    assert _compose_system_prompt("BASE", "MEM", None, model=None) == "MEM\n\nBASE"
-    assert _compose_system_prompt(None, None, None, model=None) is None
+    assert _compose_system_prompt("BASE", "MEM", model=None) == "MEM\n\nBASE"
+    assert _compose_system_prompt("BASE", None, model=None) == "BASE"
+    assert _compose_system_prompt(None, None, model=None) is None
 
 
 def test_compose_system_prompt_appends_configured_model() -> None:
     from curie_runner.__main__ import _compose_system_prompt
 
     assert (
-        _compose_system_prompt("BASE", "MEM", "CONV", model="z-ai/glm-5.2")
-        == "MEM\n\nCONV\n\nBASE\n\nConfigured model: z-ai/glm-5.2"
+        _compose_system_prompt("BASE", "MEM", model="z-ai/glm-5.2")
+        == "MEM\n\nBASE\n\nConfigured model: z-ai/glm-5.2"
     )
 
 

--- a/runner/tests/test_history.py
+++ b/runner/tests/test_history.py
@@ -11,10 +11,11 @@ import anyio
 import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestServer
-from curie_runner.adapter import build_structured_resume
+from curie_runner.adapter import ClaudeAgentSession, build_options, build_structured_resume
 from curie_runner.history import (
     ApprovalContext,
     ConversationMessage,
+    HarnessReplayState,
     HistoryError,
     NullTranscriptStore,
     StateApiTranscriptStore,
@@ -95,6 +96,11 @@ def test_structured_turn_round_trip_preserves_tools_and_approval_context() -> No
             granted_tool="Bash",
             decision=None,
         ),
+        harness_replay=HarnessReplayState(
+            harness="claude",
+            kind="checkpoint",
+            entries=({"type": "user", "uuid": "entry-1"},),
+        ),
     )
 
     loaded = TurnRecord.from_dict(record.to_dict())
@@ -139,6 +145,7 @@ def test_long_history_compacts_once_then_keeps_prefix_stable_until_next_boundary
 
     assert summary is not None
     assert summary.source_turns == 4
+    assert all(turn.harness_replay is None for turn in summary.tail)
     assert replay.summary_digest == summary.digest
     assert replay.messages[0].role == "user"
     assert "Durable conversation summary" in str(replay.messages[0].content)
@@ -167,6 +174,29 @@ def test_changed_compacted_prefix_changes_summary_digest() -> None:
     assert original is not None
     assert different is not None
     assert different.digest != original.digest
+
+
+def test_summary_digest_ignores_optional_harness_checkpoint_metadata() -> None:
+    def records(entry_uuid: str) -> list[TurnRecord]:
+        return [
+            TurnRecord(
+                user=f"u{i}",
+                assistant=f"a{i}",
+                harness_replay=HarnessReplayState(
+                    harness="claude",
+                    kind="checkpoint" if i == 0 else "delta",
+                    entries=({"uuid": f"{entry_uuid}-{i}"},),
+                ),
+            )
+            for i in range(4)
+        ]
+
+    _, first = build_conversation_replay(records("runner-a"), max_turns=2)
+    _, second = build_conversation_replay(records("runner-b"), max_turns=2)
+
+    assert first is not None
+    assert second is not None
+    assert first.digest == second.digest
 
 
 def test_structured_resume_materializes_ordered_sdk_entries_without_rendering_text(
@@ -226,8 +256,89 @@ def test_structured_resume_materializes_ordered_sdk_entries_without_rendering_te
 
     fresh = build_structured_resume((), curie_session_id="curie-thread-1", cwd=str(tmp_path))
     assert fresh.resume is None
-    assert fresh.session_store is None
+    assert fresh.session_store is not None
+    assert anyio.run(fresh.session_store.load, fresh.session_key) is None
     assert fresh.session_id == first.session_id
+
+
+def test_claude_native_checkpoint_is_restored_and_then_exports_only_a_delta(tmp_path) -> None:
+    checkpoint = HarnessReplayState(
+        harness="claude",
+        kind="checkpoint",
+        entries=(
+            {
+                "type": "user",
+                "uuid": "entry-1",
+                "timestamp": "1970-01-01T00:00:00.000Z",
+                "message": {"role": "user", "content": "prior"},
+            },
+        ),
+    )
+    resume = build_structured_resume(
+        (ConversationMessage(role="user", content="prior"),),
+        curie_session_id="curie-thread-native",
+        cwd=str(tmp_path),
+        harness_replay=checkpoint,
+    )
+    assert resume.session_store is not None
+    assert anyio.run(resume.session_store.load, resume.session_key) == list(
+        checkpoint.entries
+    )
+
+    options = build_options(
+        plugins=[],
+        model=None,
+        system_prompt=None,
+        max_turns=2,
+        max_budget_usd=1.0,
+        resume=resume.resume,
+        session_id=resume.session_id,
+        session_store=resume.session_store,
+    )
+    session = ClaudeAgentSession(options)
+    delta_entry = {"type": "assistant", "uuid": "entry-2"}
+    anyio.run(resume.session_store.append, resume.session_key, [delta_entry])
+
+    exported = anyio.run(session.export_replay_state)
+
+    assert exported == HarnessReplayState(
+        harness="claude", kind="delta", entries=(delta_entry,)
+    )
+
+
+def test_replay_folds_native_checkpoint_and_deltas_but_drops_them_at_compaction() -> None:
+    turns = [
+        TurnRecord(
+            user="u0",
+            assistant="a0",
+            harness_replay=HarnessReplayState(
+                harness="claude", kind="checkpoint", entries=({"uuid": "one"},)
+            ),
+        ),
+        TurnRecord(
+            user="u1",
+            assistant="a1",
+            harness_replay=HarnessReplayState(
+                harness="claude", kind="delta", entries=({"uuid": "two"},)
+            ),
+        ),
+    ]
+
+    replay, summary = build_conversation_replay(turns, max_turns=4, max_bytes=None)
+    assert summary is None
+    assert replay.harness_replay == HarnessReplayState(
+        harness="claude",
+        kind="checkpoint",
+        entries=({"uuid": "one"}, {"uuid": "two"}),
+    )
+
+    compacted, summary = build_conversation_replay(
+        [*turns, TurnRecord(user="u2", assistant="a2")],
+        max_turns=2,
+        max_bytes=None,
+    )
+    assert summary is not None
+    assert compacted.harness_replay is None
 
 
 def test_resolve_absent_ref_is_null_store() -> None:

--- a/runner/tests/test_live.py
+++ b/runner/tests/test_live.py
@@ -10,16 +10,38 @@ A third live test covers the OpenRouter path, gated on ``OPENROUTER_API_KEY``.
 """
 
 import os
+import shlex
+from typing import Any
 
 import anyio
 import pytest
-from aci_protocol import Event, SessionStatus, parse_ndjson
+from aci_protocol import Event, Final, SessionStatus, parse_ndjson, parse_ndjson_line
 from curie_runner import RunTracer, SideEffectClassifier, build_options
-from curie_runner.adapter import ClaudeAgentSession
+from curie_runner.adapter import (
+    ClaudeAgentSession,
+    build_structured_resume,
+)
+from curie_runner.history import (
+    ConversationMessage,
+    TurnRecord,
+    build_conversation_replay,
+)
 from curie_runner.session import SessionRunner
 
 _HAS_CRED = bool(os.environ.get("CLAUDE_CODE_OAUTH_TOKEN") or os.environ.get("ANTHROPIC_API_KEY"))
 _OPENROUTER_KEY = os.environ.get("OPENROUTER_API_KEY", "")
+_LIVE_REQUESTED = os.environ.get("CURIE_E2E_LIVE") == "1"
+
+
+class _LiveTranscriptStore:
+    def __init__(self) -> None:
+        self.records: list[TurnRecord] = []
+
+    async def load(self) -> list[TurnRecord]:
+        return list(self.records)
+
+    async def append(self, record: TurnRecord) -> None:
+        self.records.append(record)
 
 
 @pytest.mark.skipif(
@@ -230,3 +252,247 @@ def test_live_permission_gate_pauses_awaiting_approval() -> None:
     # The blocked command never executed and never produced output text
     # claiming it ran; the summary records what WOULD have run.
     assert "echo curie-gate-live" in final.approval_summary
+
+
+@pytest.mark.skipif(
+    not _LIVE_REQUESTED,
+    reason="set CURIE_E2E_LIVE=1 for disposable structured-replay provider evidence",
+)
+def test_live_structured_replay_cache_hit_and_changed_prefix_negative(tmp_path) -> None:
+    """Fresh SDK clients hit only for an identical portable history prefix.
+
+    The provider behavior behind this test was observed with the pinned SDK and
+    is recorded with version/output evidence in
+    ``docs/spikes/1902-claude-agent-sdk-structured-replay.md``. Durable storage
+    supplies only role/content; the SDK JSONL envelope is rebuilt per client.
+    """
+
+    from claude_agent_sdk import ClaudeSDKClient, ResultMessage
+
+    stable_text = f"stable-prefix-{tmp_path.name} " * 900
+    original = (
+        ConversationMessage(role="user", content=stable_text),
+        ConversationMessage(
+            role="assistant",
+            content=[{"type": "text", "text": "Stable prefix acknowledged."}],
+        ),
+    )
+    changed = (
+        ConversationMessage(role="user", content=f"changed {stable_text}"),
+        original[1],
+    )
+
+    async def run_prefix(messages: tuple[ConversationMessage, ...]) -> dict[str, Any]:
+        resume = build_structured_resume(
+            messages,
+            curie_session_id="live-cache-prefix-1902",
+            cwd=str(tmp_path),
+        )
+        options = build_options(
+            plugins=[],
+            model=None,
+            system_prompt="Reply tersely and do not use tools.",
+            max_turns=2,
+            max_budget_usd=1.0,
+            resume=resume.resume,
+            session_id=resume.session_id,
+            session_store=resume.session_store,
+            cwd=str(tmp_path),
+        )
+        async with ClaudeSDKClient(options) as client:
+            await client.query("Reply with the single word: observed")
+            async for message in client.receive_response():
+                if isinstance(message, ResultMessage):
+                    return message.usage if isinstance(message.usage, dict) else {}
+        raise AssertionError("live SDK response had no terminal result")
+
+    async def go() -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+        # First call primes the provider cache. The second reconstructs the exact
+        # same prefix in a fresh client; the third changes one durable message.
+        return (
+            await run_prefix(original),
+            await run_prefix(original),
+            await run_prefix(changed),
+        )
+
+    primed, identical, different = anyio.run(go)
+    identical_read = int(identical.get("cache_read_input_tokens") or 0)
+    different_read = int(different.get("cache_read_input_tokens") or 0)
+    identical_create = int(identical.get("cache_creation_input_tokens") or 0)
+    different_create = int(different.get("cache_creation_input_tokens") or 0)
+
+    assert (
+        int(primed.get("cache_read_input_tokens") or 0)
+        + int(primed.get("cache_creation_input_tokens") or 0)
+        > 0
+    )
+    assert identical_read > 0
+    assert different_read < identical_read
+    assert different_create > identical_create
+
+
+@pytest.mark.skipif(
+    not _LIVE_REQUESTED,
+    reason="set CURIE_E2E_LIVE=1 for disposable structured-replay provider evidence",
+)
+def test_live_cross_runner_approval_exact_once_and_cache_observable(
+    tmp_path, monkeypatch
+) -> None:
+    """A suspended real tool call resumes once, then its one-shot grant expires."""
+
+    from claude_agent_sdk.types import PermissionResultAllow, PermissionResultDeny
+    from curie_runner import session as session_module
+    from curie_runner.approval import (
+        ApprovalGate,
+        build_approval_hook,
+        build_can_use_tool,
+    )
+
+    metric_calls: list[tuple[str, float, dict[str, str] | None]] = []
+    real_record_metric = session_module.record_metric
+
+    def observe_metric(
+        name: str,
+        value: float = 1,
+        *,
+        attributes: dict[str, str] | None = None,
+    ) -> None:
+        metric_calls.append((name, value, attributes))
+        real_record_metric(name, value, attributes=attributes)
+
+    monkeypatch.setattr(session_module, "record_metric", observe_metric)
+
+    marker_file = tmp_path / "approval-executions.txt"
+    command = f"printf 'approved-once\\n' >> {shlex.quote(str(marker_file))}"
+    system_prompt = (
+        "You are a deterministic test agent. When explicitly asked to run a shell "
+        "command, call Bash with that exact command once and then stop."
+    )
+    store = _LiveTranscriptStore()
+
+    def options_for(
+        gate: ApprovalGate,
+        replay: tuple[ConversationMessage, ...],
+    ):
+        resume = build_structured_resume(
+            replay,
+            curie_session_id="live-approval-thread-1902",
+            cwd=str(tmp_path),
+        )
+        return build_options(
+            plugins=[],
+            model=None,
+            system_prompt=system_prompt,
+            max_turns=4,
+            max_budget_usd=1.0,
+            resume=resume.resume,
+            session_id=resume.session_id,
+            session_store=resume.session_store,
+            hooks=build_approval_hook(gate),
+            can_use_tool=build_can_use_tool(gate),
+            cwd=str(tmp_path),
+        )
+
+    async def drive(runner: SessionRunner, text: str) -> Final:
+        await runner.start()
+        final: Final | None = None
+        try:
+            async for line in runner.run_turn(
+                Event(type="message", text=text, user="U0EXAMPLE", ts="1")
+            ):
+                event = parse_ndjson_line(line)
+                if isinstance(event, Final):
+                    final = event
+        finally:
+            await runner.close()
+        assert final is not None
+        return final
+
+    blocked_gate = ApprovalGate(required=frozenset({"Bash"}))
+    blocked = SessionRunner(
+        session_factory=lambda: ClaudeAgentSession(options_for(blocked_gate, ())),
+        ceiling=0,
+        tracer=RunTracer(None),
+        classifier=SideEffectClassifier(),
+        trace_name="live-structured-approval-block",
+        session_id="live-approval-thread-1902",
+        history_store=store,
+        approval_gate=blocked_gate,
+    )
+    first = anyio.run(drive, blocked, f"Run this exact shell command: {command}")
+    assert first.status is SessionStatus.AWAITING_APPROVAL
+    assert not marker_file.exists()
+    assert len(store.records) == 1
+
+    replay, summary = build_conversation_replay(store.records)
+    assert summary is None
+    assert replay.messages[-1].role == "user"
+    assert replay.messages[-1].content[0]["type"] == "tool_result"
+
+    allowed_commands: list[str] = []
+    resumed_gate = ApprovalGate(required=frozenset({"Bash"}), grant_tool="Bash")
+    permission_callback = build_can_use_tool(resumed_gate)
+
+    async def observe_permission(tool_name, tool_input, context):
+        decision = await permission_callback(tool_name, tool_input, context)
+        if isinstance(decision, PermissionResultAllow):
+            allowed_commands.append(str(tool_input.get("command") or ""))
+        assert isinstance(decision, (PermissionResultAllow, PermissionResultDeny))
+        return decision
+
+    resumed_options = options_for(resumed_gate, replay.messages)
+    # Production's PreToolUse hook spends the grant. Keep can_use_tool as an
+    # observation-only wrapper for any SDK path that reaches it.
+    resumed_options.can_use_tool = observe_permission
+    resumed = SessionRunner(
+        session_factory=lambda: ClaudeAgentSession(resumed_options),
+        ceiling=0,
+        tracer=RunTracer(None),
+        classifier=SideEffectClassifier(),
+        trace_name="live-structured-approval-resume",
+        session_id="live-approval-thread-1902",
+        approval_gate=resumed_gate,
+        approval_decision="approved",
+        history_resumed=True,
+    )
+    async def drive_resumed_turns() -> tuple[Final, Final]:
+        await resumed.start()
+        finals: list[Final] = []
+        try:
+            for text in (
+                "The prior Bash call is approved. Retry that exact call once now, then stop.",
+                "Attempt the same Bash command one more time.",
+            ):
+                final: Final | None = None
+                async for line in resumed.run_turn(
+                    Event(type="message", text=text, user="U0EXAMPLE", ts="2")
+                ):
+                    event = parse_ndjson_line(line)
+                    if isinstance(event, Final):
+                        final = event
+                assert final is not None
+                finals.append(final)
+        finally:
+            await resumed.close()
+        return finals[0], finals[1]
+
+    approved, duplicate = anyio.run(drive_resumed_turns)
+    assert approved.status is SessionStatus.DONE
+    assert marker_file.read_text().splitlines() == ["approved-once"]
+
+    # Same runner, later turn: reset() expires the one-shot grant. Asking for the
+    # action again must pause without another write.
+    assert duplicate.status is SessionStatus.AWAITING_APPROVAL
+    assert marker_file.read_text().splitlines() == ["approved-once"]
+    assert allowed_commands == []  # hook allow skips can_use_tool in the pinned SDK
+
+    cache_calls = [
+        call for call in metric_calls if call[0] == "curie.history.resume.cache_read"
+    ]
+    assert len(cache_calls) == 1
+    assert cache_calls[0][1] > 0
+    assert cache_calls[0][2] == {
+        "service.name": "curie-runner",
+        "source": "runner",
+        "cache_hit": "true",
+    }

--- a/runner/tests/test_live.py
+++ b/runner/tests/test_live.py
@@ -20,9 +20,11 @@ from curie_runner import RunTracer, SideEffectClassifier, build_options
 from curie_runner.adapter import (
     ClaudeAgentSession,
     build_structured_resume,
+    model_message_to_conversation,
 )
 from curie_runner.history import (
     ConversationMessage,
+    HarnessReplayState,
     TurnRecord,
     build_conversation_replay,
 )
@@ -259,39 +261,81 @@ def test_live_permission_gate_pauses_awaiting_approval() -> None:
     reason="set CURIE_E2E_LIVE=1 for disposable structured-replay provider evidence",
 )
 def test_live_structured_replay_cache_hit_and_changed_prefix_negative(tmp_path) -> None:
-    """Fresh SDK clients hit only for an identical portable history prefix.
+    """Fresh SDK clients hit only for an identical native history checkpoint.
 
     The provider behavior behind this test was observed with the pinned SDK and
     is recorded with version/output evidence in
-    ``docs/spikes/1902-claude-agent-sdk-structured-replay.md``. Durable storage
-    supplies only role/content; the SDK JSONL envelope is rebuilt per client.
+    ``docs/spikes/1902-claude-agent-sdk-structured-replay.md``. Portable
+    role/content stays authoritative; the matching Claude harness additionally
+    persists an opaque checkpoint so the provider's own cache-breakpoint shape
+    survives the runner boundary.
     """
 
-    from claude_agent_sdk import ClaudeSDKClient, ResultMessage
-
-    stable_text = f"stable-prefix-{tmp_path.name} " * 900
-    original = (
-        ConversationMessage(role="user", content=stable_text),
-        ConversationMessage(
-            role="assistant",
-            content=[{"type": "text", "text": "Stable prefix acknowledged."}],
-        ),
-    )
-    changed = (
-        ConversationMessage(role="user", content=f"changed {stable_text}"),
-        original[1],
+    from claude_agent_sdk import (
+        AssistantMessage,
+        ClaudeSDKClient,
+        ResultMessage,
+        TextBlock,
     )
 
-    async def run_prefix(messages: tuple[ConversationMessage, ...]) -> dict[str, Any]:
-        resume = build_structured_resume(
-            messages,
-            curie_session_id="live-cache-prefix-1902",
-            cwd=str(tmp_path),
+    marker = f"native-cache-marker-{tmp_path.name}"
+    source_prompt = f"Use Bash to run exactly `printf '{marker}\\n'`, then report its output."
+    system_prompt = (
+        "You are a deterministic test agent. Use Bash exactly when asked, then "
+        "answer tersely and do not repeat a tool call."
+    )
+
+    async def source_checkpoint() -> tuple[
+        tuple[ConversationMessage, ...], HarnessReplayState
+    ]:
+        seeded = build_structured_resume(
+            (), curie_session_id="live-cache-prefix-1902", cwd=str(tmp_path)
         )
         options = build_options(
             plugins=[],
             model=None,
-            system_prompt="Reply tersely and do not use tools.",
+            system_prompt=system_prompt,
+            max_turns=4,
+            max_budget_usd=1.0,
+            resume=seeded.resume,
+            session_id=seeded.session_id,
+            session_store=seeded.session_store,
+            cwd=str(tmp_path),
+        )
+        session = ClaudeAgentSession(options)
+        portable: list[ConversationMessage] = [
+            ConversationMessage(role="user", content=source_prompt)
+        ]
+        await session.connect()
+        try:
+            await session.query(source_prompt)
+            async for message in session.receive_turn():
+                projected = model_message_to_conversation(message)
+                if projected is not None:
+                    portable.append(projected)
+                if isinstance(message, ResultMessage):
+                    break
+            checkpoint = await session.export_replay_state()
+        finally:
+            await session.close()
+        assert checkpoint is not None
+        assert checkpoint.kind == "checkpoint"
+        return tuple(portable), checkpoint
+
+    async def run_checkpoint(
+        messages: tuple[ConversationMessage, ...],
+        checkpoint: HarnessReplayState,
+    ) -> tuple[dict[str, Any], str]:
+        resume = build_structured_resume(
+            messages,
+            curie_session_id="live-cache-prefix-1902",
+            cwd=str(tmp_path),
+            harness_replay=checkpoint,
+        )
+        options = build_options(
+            plugins=[],
+            model=None,
+            system_prompt=system_prompt,
             max_turns=2,
             max_budget_usd=1.0,
             resume=resume.resume,
@@ -300,35 +344,60 @@ def test_live_structured_replay_cache_hit_and_changed_prefix_negative(tmp_path) 
             cwd=str(tmp_path),
         )
         async with ClaudeSDKClient(options) as client:
-            await client.query("Reply with the single word: observed")
+            await client.query(
+                "What exact output did the prior Bash call produce? Do not use tools."
+            )
+            texts: list[str] = []
             async for message in client.receive_response():
+                if isinstance(message, AssistantMessage):
+                    texts.extend(
+                        block.text for block in message.content if isinstance(block, TextBlock)
+                    )
                 if isinstance(message, ResultMessage):
-                    return message.usage if isinstance(message.usage, dict) else {}
+                    usage = message.usage if isinstance(message.usage, dict) else {}
+                    return usage, "".join(texts)
         raise AssertionError("live SDK response had no terminal result")
 
-    async def go() -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
-        # First call primes the provider cache. The second reconstructs the exact
-        # same prefix in a fresh client; the third changes one durable message.
-        return (
-            await run_prefix(original),
-            await run_prefix(original),
-            await run_prefix(changed),
-        )
+    async def go() -> tuple[dict[str, Any], dict[str, Any], str, dict[str, Any]]:
+        messages, checkpoint = await source_checkpoint()
+        # Negative arm: keep portable recovery identical but change one message
+        # in the optional native checkpoint. Exact provider prefix matching must
+        # invalidate that layer.
+        changed_payload = checkpoint.to_dict()
+        changed_one = False
+        for entry in changed_payload["entries"]:
+            message = entry.get("message")
+            if not isinstance(message, dict) or message.get("role") != "user":
+                continue
+            content = message.get("content")
+            if isinstance(content, str):
+                message["content"] = f"changed-prefix {content}"
+                changed_one = True
+                break
+        assert changed_one, "captured SDK checkpoint had no mutable user message"
+        changed = HarnessReplayState.from_dict(changed_payload)
+        primed, _ = await run_checkpoint(messages, checkpoint)
+        identical, recovered = await run_checkpoint(messages, checkpoint)
+        different, _ = await run_checkpoint(messages, changed)
+        return primed, identical, recovered, different
 
-    primed, identical, different = anyio.run(go)
+    primed, identical, recovered, different = anyio.run(go)
     identical_read = int(identical.get("cache_read_input_tokens") or 0)
     different_read = int(different.get("cache_read_input_tokens") or 0)
     identical_create = int(identical.get("cache_creation_input_tokens") or 0)
     different_create = int(different.get("cache_creation_input_tokens") or 0)
 
+    assert marker in recovered
     assert (
         int(primed.get("cache_read_input_tokens") or 0)
         + int(primed.get("cache_creation_input_tokens") or 0)
         > 0
     )
     assert identical_read > 0
-    assert different_read < identical_read
-    assert different_create > identical_create
+    assert different_read < identical_read or different_create > identical_create, (
+        "changing the recovered native history did not invalidate its cache layer: "
+        f"identical={identical!r}, changed={different!r}"
+    )
 
 
 @pytest.mark.skipif(
@@ -373,11 +442,13 @@ def test_live_cross_runner_approval_exact_once_and_cache_observable(
     def options_for(
         gate: ApprovalGate,
         replay: tuple[ConversationMessage, ...],
+        harness_replay: HarnessReplayState | None = None,
     ):
         resume = build_structured_resume(
             replay,
             curie_session_id="live-approval-thread-1902",
             cwd=str(tmp_path),
+            harness_replay=harness_replay,
         )
         return build_options(
             plugins=[],
@@ -423,6 +494,7 @@ def test_live_cross_runner_approval_exact_once_and_cache_observable(
     assert first.status is SessionStatus.AWAITING_APPROVAL
     assert not marker_file.exists()
     assert len(store.records) == 1
+    assert store.records[0].harness_replay is not None
 
     replay, summary = build_conversation_replay(store.records)
     assert summary is None
@@ -440,7 +512,9 @@ def test_live_cross_runner_approval_exact_once_and_cache_observable(
         assert isinstance(decision, (PermissionResultAllow, PermissionResultDeny))
         return decision
 
-    resumed_options = options_for(resumed_gate, replay.messages)
+    resumed_options = options_for(
+        resumed_gate, replay.messages, replay.harness_replay
+    )
     # Production's PreToolUse hook spends the grant. Keep can_use_tool as an
     # observation-only wrapper for any SDK path that reaches it.
     resumed_options.can_use_tool = observe_permission

--- a/runner/tests/test_session.py
+++ b/runner/tests/test_session.py
@@ -49,6 +49,63 @@ def test_happy_turn_stream_shape() -> None:
     assert runner.status == SessionStatus.DONE
 
 
+def test_first_resumed_turn_records_cache_read_metric_once(monkeypatch) -> None:
+    calls: list[tuple[str, int | float | None, dict[str, object] | None]] = []
+
+    def record(name, value=None, *, attributes=None):
+        calls.append((name, value, attributes))
+
+    monkeypatch.setattr("curie_runner.session.record_metric", record)
+
+    def turn():
+        return [
+            AssistantMessage(content=[TextBlock(text="ok")], model="fake"),
+            ResultMessage(
+                subtype="success",
+                duration_ms=1,
+                duration_api_ms=1,
+                is_error=False,
+                num_turns=1,
+                session_id="sdk-session",
+                usage={
+                    "input_tokens": 1,
+                    "output_tokens": 1,
+                    "cache_read_input_tokens": 321,
+                    "cache_creation_input_tokens": 0,
+                },
+                result="ok",
+            ),
+        ]
+
+    runner = SessionRunner(
+        session_factory=lambda: FakeModelSession(turn),
+        ceiling=0,
+        tracer=RunTracer(None),
+        classifier=SideEffectClassifier(),
+        trace_name="resume-cache",
+        history_resumed=True,
+    )
+
+    async def go() -> None:
+        await runner.start()
+        for ts in ("1", "2"):
+            async for _ in runner.run_turn(
+                Event(type="message", text="continue", user="U", ts=ts)
+            ):
+                pass
+
+    anyio.run(go)
+
+    cache_calls = [call for call in calls if call[0] == "curie.history.resume.cache_read"]
+    assert cache_calls == [
+        (
+            "curie.history.resume.cache_read",
+            321,
+            {"service.name": "curie-runner", "source": "runner", "cache_hit": True},
+        )
+    ]
+
+
 def test_turn_lifecycle_logged(caplog) -> None:
     runner, _ = _runner()
     event = Event(type="message", text="go", user="U-log", ts="1")

--- a/runner/tests/test_session.py
+++ b/runner/tests/test_session.py
@@ -101,7 +101,7 @@ def test_first_resumed_turn_records_cache_read_metric_once(monkeypatch) -> None:
         (
             "curie.history.resume.cache_read",
             321,
-            {"service.name": "curie-runner", "source": "runner", "cache_hit": True},
+            {"service.name": "curie-runner", "source": "runner", "cache_hit": "true"},
         )
     ]
 

--- a/runner/tests/test_structured_replay_e2e.py
+++ b/runner/tests/test_structured_replay_e2e.py
@@ -1,0 +1,235 @@
+"""Offline cross-runner proofs for structured replay and approval authority."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import anyio
+import pytest
+from aci_protocol import Event, Final, SessionStatus, parse_ndjson_line
+from claude_agent_sdk import AssistantMessage, ResultMessage, ToolUseBlock
+from claude_agent_sdk.types import (
+    PermissionResultAllow,
+    PermissionResultDeny,
+    ToolPermissionContext,
+)
+from curie_runner.approval import ApprovalGate, build_can_use_tool
+from curie_runner.fake import FakeModelSession
+from curie_runner.history import (
+    ConversationMessage,
+    TranscriptStore,
+    TurnRecord,
+    build_conversation_replay,
+    close_suspended_tool_calls,
+)
+from curie_runner.otel import RunTracer
+from curie_runner.session import SessionRunner
+from curie_runner.side_effects import SideEffectClassifier
+
+
+class _Store:
+    def __init__(self) -> None:
+        self.records: list[TurnRecord] = []
+
+    async def load(self) -> list[TurnRecord]:
+        return list(self.records)
+
+    async def append(self, record: TurnRecord) -> None:
+        self.records.append(record)
+
+
+def _tool_turn(*commands: str) -> list[Any]:
+    messages: list[Any] = [
+        AssistantMessage(
+            content=[
+                ToolUseBlock(
+                    id=f"tool-{index}",
+                    name="Bash",
+                    input={"command": command},
+                )
+            ],
+            model="fake",
+        )
+        for index, command in enumerate(commands, start=1)
+    ]
+    messages.append(
+        ResultMessage(
+            subtype="success",
+            duration_ms=1,
+            duration_api_ms=1,
+            is_error=False,
+            num_turns=1,
+            session_id="fake-session",
+            result="done",
+        )
+    )
+    return messages
+
+
+def _runner(
+    session: FakeModelSession,
+    gate: ApprovalGate,
+    *,
+    store: TranscriptStore | None = None,
+    decision: str | None = None,
+) -> SessionRunner:
+    return SessionRunner(
+        session_factory=lambda: session,
+        ceiling=0,
+        tracer=RunTracer(None),
+        classifier=SideEffectClassifier(),
+        trace_name="structured-replay-e2e",
+        session_id="curie-thread-e2e",
+        history_store=store,
+        approval_gate=gate,
+        approval_decision=decision,
+    )
+
+
+async def _turn(runner: SessionRunner, text: str) -> Final:
+    await runner.start()
+    final: Final | None = None
+    async for line in runner.run_inbound(
+        Event(type="message", text=text, user="U0EXAMPLE", ts="1")
+    ):
+        event = parse_ndjson_line(line)
+        if isinstance(event, Final):
+            final = event
+    await runner.close()
+    assert final is not None
+    return final
+
+
+def test_suspended_permission_call_gets_a_structurally_valid_tool_result() -> None:
+    messages = (
+        ConversationMessage(role="user", content="deploy it"),
+        ConversationMessage(
+            role="assistant",
+            content=[
+                {
+                    "type": "tool_use",
+                    "id": "tool-1",
+                    "name": "Bash",
+                    "input": {"command": "deploy --release"},
+                }
+            ],
+        ),
+    )
+
+    closed = close_suspended_tool_calls(messages)
+
+    assert closed[:2] == messages
+    assert closed[-1] == ConversationMessage(
+        role="user",
+        content=[
+            {
+                "type": "tool_result",
+                "tool_use_id": "tool-1",
+                "content": "Tool call was not executed; awaiting human approval.",
+                "is_error": True,
+            }
+        ],
+    )
+    assert close_suspended_tool_calls(closed) == closed
+
+
+def test_cross_runner_approval_executes_once_then_rearms() -> None:
+    store = _Store()
+    blocked_gate = ApprovalGate(required=frozenset({"Bash"}))
+    blocked_session = FakeModelSession(
+        lambda: _tool_turn("deploy --release"),
+        can_use_tool=build_can_use_tool(blocked_gate),
+    )
+
+    first = anyio.run(
+        _turn,
+        _runner(blocked_session, blocked_gate, store=store),
+        "deploy release",
+    )
+    assert first.status is SessionStatus.AWAITING_APPROVAL
+    assert len(store.records) == 1
+    suspended = store.records[0]
+    assert suspended.status == SessionStatus.AWAITING_APPROVAL.value
+    assert suspended.approval is not None
+    assert suspended.approval.gate_kind == "permission"
+    assert suspended.approval.granted_tool == "Bash"
+
+    replay, summary = build_conversation_replay(store.records)
+    assert summary is None
+    assert replay.messages[-1].role == "user"
+    assert replay.messages[-1].content[0]["type"] == "tool_result"
+
+    executions: list[str] = []
+    resumed_gate = ApprovalGate(required=frozenset({"Bash"}), grant_tool="Bash")
+    inner = build_can_use_tool(resumed_gate)
+
+    async def execute_if_allowed(
+        tool_name: str,
+        tool_input: dict[str, Any],
+        context: ToolPermissionContext,
+    ) -> PermissionResultAllow | PermissionResultDeny:
+        decision = await inner(tool_name, tool_input, context)
+        if isinstance(decision, PermissionResultAllow):
+            executions.append(str(tool_input["command"]))
+        return decision
+
+    resumed_session = FakeModelSession(
+        lambda: _tool_turn("deploy --release", "deploy --release"),
+        can_use_tool=execute_if_allowed,
+        replay_messages=replay.messages,
+    )
+    second = anyio.run(
+        _turn,
+        _runner(resumed_session, resumed_gate, decision="approved"),
+        "approval granted; continue",
+    )
+
+    assert resumed_session.replay_messages == replay.messages
+    assert executions == ["deploy --release"]
+    assert second.status is SessionStatus.AWAITING_APPROVAL
+    assert second.approval_summary is not None
+
+
+@pytest.mark.parametrize("decision", ["rejected", "expired"])
+def test_cross_runner_non_approved_decision_has_zero_authority(decision: str) -> None:
+    replay_messages = (
+        ConversationMessage(role="user", content="deploy release"),
+        ConversationMessage(
+            role="assistant",
+            content=[
+                {
+                    "type": "tool_use",
+                    "id": "tool-1",
+                    "name": "Bash",
+                    "input": {"command": "deploy --release"},
+                }
+            ],
+        ),
+    )
+    executions: list[str] = []
+    gate = ApprovalGate(required=frozenset({"Bash"}), grant_tool=None)
+    inner = build_can_use_tool(gate)
+
+    async def execute_if_allowed(
+        tool_name: str,
+        tool_input: dict[str, Any],
+        context: ToolPermissionContext,
+    ) -> PermissionResultAllow | PermissionResultDeny:
+        result = await inner(tool_name, tool_input, context)
+        if isinstance(result, PermissionResultAllow):
+            executions.append(str(tool_input["command"]))
+        return result
+
+    session = FakeModelSession(
+        lambda: _tool_turn("deploy --release"),
+        can_use_tool=execute_if_allowed,
+        replay_messages=close_suspended_tool_calls(replay_messages),
+    )
+    final = anyio.run(
+        _turn,
+        _runner(session, gate, decision=decision),
+        f"approval {decision}",
+    )
+
+    assert executions == []
+    assert final.status is SessionStatus.AWAITING_APPROVAL


### PR DESCRIPTION
## Summary

Accept ADR-0119 and replace prompt-preamble conversation history with prefix-preserving structured replay. Durable turns now preserve roles, tool calls/results, approval suspension context, stable compaction summaries, optional Claude-native cache checkpoints, cross-runner replay, and bounded cache-read telemetry; malformed or unsupported replay fails closed.

## Related issue

Closes #1902

## Fix pin verification

## End-to-end verification

Candidate: `fc96398c2623f0d7dbac267365686e81b9954a77`

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | required | Changes the runner turn loop and fake/real harness replay seam. | fake | `env -u CURIE_E2E_LIVE CURIE_BIN=/home/theconnman/.cargo/shared-targets/agentos/release/curie CURIE_E2E_TIERS=skill /home/theconnman/.cargo/shared-targets/agentos/release/curie dev e2e-ladder` → `LADDER PASS (tiers: skill)` on the candidate. |
| local | n/a | No compose service, API/worker/dispatcher wiring, UI, or CLI output contract changed. | — | — |
| local-release | n/a | No released binary/image identity, install path, version pin, or release compose changed. | — | — |
| cluster | n/a | No chart, RBAC, sandbox claim, security context, network policy, or init container changed. | — | — |
| live provider | required | Claude structured replay and prompt-cache behavior require a real provider. | live | `CURIE_E2E_LIVE=1 uv run pytest -q runner/tests/test_live.py -k 'structured_replay_cache_hit or cross_runner_approval_exact_once' -vv` → `2 passed, 4 deselected in 37.79s`; identical replay retained cache reuse, changed recovered history invalidated that history cache layer, and approval executed exactly once across distinct runners. |
| external integration | n/a | No Slack, git webhook, connector OAuth, or other integration shape changed; Claude is covered by the live-provider tier. | — | — |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.
- [ ] Or: this change is not behavior-bearing, so no tier applies, and the summary says why.

Acceptance evidence:

- Structured role/tool ordering and cross-runner replay: `runner/tests/test_structured_replay_e2e.py`; malformed records and unsupported harnesses are rejected by executable negative tests.
- Approval exact-once: runner A persists a suspended tool call, runner B grants and executes it once; duplicate/rejected/expired decisions re-arm or execute zero times.
- Stable summaries: deterministic digest tests prove ordinary appends preserve the prefix, compaction changes it at the explicit boundary, and provider-native metadata cannot perturb the durable summary.
- Cache observability: the real-provider test observes cache-read reuse for an identical recovered prefix and renewed creation/lower history reuse after deliberately mutating it.
- Full affected suite: `env -u OTEL_EXPORTER_OTLP_ENDPOINT -u OTEL_EXPORTER_OTLP_PROTOCOL -u OTEL_LOGS_EXPORTER -u OTEL_METRICS_EXPORTER uv run pytest -q runner/tests packages/telemetry/tests/test_metrics.py` → `739 passed, 6 skipped in 37.61s`.
- Static/docs: `bash scripts/check-docs.sh`, `uv run ruff check runner/ packages/telemetry`, and `uv run mypy` all passed.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [x] ADR-0119 is accepted under `docs/adr/` with explicit maintainer approval and the prerequisite SDK spike is recorded.
