### PR TITLE
Report turns for undeployed agents

### DIFF
--- a/apps/worker/src/curie_worker/binding.py
+++ b/apps/worker/src/curie_worker/binding.py
@@ -233,6 +233,20 @@ WHERE c.kind = :kind AND c.address = :address
 ORDER BY (d.environment = 'prod') DESC, d.deployed_at DESC, d.id DESC
 """
 
+# ``resolve`` deliberately requires an active deployment: it is the only
+# deployment a worker may boot. When that lookup misses, the kernel needs this
+# narrower second query to distinguish an unbound route from an existing agent
+# that has not been deployed yet (#1522). It is never a routing fallback.
+_UNDEPLOYED_BINDING_SQL = """
+SELECT a.id AS agent_id,
+       a.name AS agent_name,
+       c.endpoint AS endpoint,
+       c.adapter AS adapter
+FROM {schema}.agents a
+JOIN {schema}.agent_channels c ON c.agent_id = a.id
+WHERE c.kind = :kind AND c.address = :address
+"""
+
 
 class ResolvedDeployment(BaseModel):
     """The agent binding for a channel: which version to run and its budget."""
@@ -289,6 +303,15 @@ class ResolvedDeployment(BaseModel):
     memory: bool = False
 
 
+class BoundAgent(BaseModel):
+    """An agent bound to a route but without a deployable active version."""
+
+    agent_id: uuid.UUID
+    agent_name: str
+    endpoint: str | None = None
+    adapter: str | None = None
+
+
 def warn_if_multiple_agents_bound(kind: str, address: str, rows: Sequence[Any]) -> None:
     """Warn when a binding resolves to more than one agent, naming the shadowed.
 
@@ -343,6 +366,9 @@ class BindingResolver:
         self._config = config
         # Table identifiers are not user input; the schema comes from config.
         self._sql = text(_RESOLVE_SQL.format(schema=config.db_schema))
+        self._undeployed_binding_sql = text(
+            _UNDEPLOYED_BINDING_SQL.format(schema=config.db_schema)
+        )
 
     async def resolve(self, kind: str, address: str) -> ResolvedDeployment | None:
         """Resolve the ``(kind, address)`` routing pair to its active deployment.
@@ -374,6 +400,20 @@ class BindingResolver:
         if isinstance(conn_secrets, str):
             data["secrets"] = json.loads(conn_secrets)
         return ResolvedDeployment.model_validate(data)
+
+    async def undeployed_binding(self, kind: str, address: str) -> BoundAgent | None:
+        """Return a bound agent after ``resolve`` found no active deployment.
+
+        The caller must use this only as a diagnostic after an active-resolution
+        miss. Returning this record never grants a runner boot: a route remains
+        runnable only through ``ResolvedDeployment`` above.
+        """
+        async with self._engine.connect() as conn:
+            result = await conn.execute(
+                self._undeployed_binding_sql, {"kind": kind, "address": address}
+            )
+            row = result.mappings().first()
+        return None if row is None else BoundAgent.model_validate(dict(row))
 
     async def repo_full_name(self, agent_id: uuid.UUID) -> str | None:
         """The agent's GitHub repo (owner/name), for the eval PR-check report."""

--- a/apps/worker/src/curie_worker/kernel.py
+++ b/apps/worker/src/curie_worker/kernel.py
@@ -987,11 +987,11 @@ class Kernel:
         """
         event_id = qevent.event_id
         thread_key = _thread_key_for(qevent)
-        # The turn's route starts as the one the server minted onto the wire and
-        # is REPLACED by the binding row's once this turn resolves (EB-B2's two
-        # sanctioned sources, in precedence order). Everything before resolution
-        # -- the prior-side-effect escalation, the unmapped-address drop -- can
-        # only reach the handle's, which is the point of it being carried.
+        # The turn's route starts as the one the server minted onto the wire. A
+        # bound route replaces it either when the turn resolves or, solely for a
+        # bound-but-undeployed status reply, when the diagnostic binding lookup
+        # supplies the server-controlled endpoint. Other pre-resolution paths
+        # can only reach the handle's route, which is why it travels on the wire.
         route = _route_from_handle(qevent)
 
         # Acquire the per-thread order lock BEFORE any await, so concurrent
@@ -1108,10 +1108,21 @@ class Kernel:
                     qevent.reply_handle.kind, qevent.reply_handle.channel
                 )
                 if resolved is None:
-                    undeployed = await self._binding.undeployed_binding(
-                        qevent.reply_handle.kind, qevent.reply_handle.channel
+                    # Binding doubles predate the diagnostic lookup; keep a miss
+                    # on those doubles on the established polite-drop path.
+                    undeployed_lookup = getattr(
+                        self._binding, "undeployed_binding", None
+                    )
+                    undeployed = (
+                        await undeployed_lookup(
+                            qevent.reply_handle.kind, qevent.reply_handle.channel
+                        )
+                        if undeployed_lookup is not None
+                        else None
                     )
                     if undeployed is not None:
+                        # A bound non-Slack route may carry the only endpoint the
+                        # platform can use to deliver this status reply.
                         route = TargetRoute(
                             endpoint=undeployed.endpoint or qevent.reply_handle.endpoint,
                             adapter=undeployed.adapter or qevent.reply_handle.adapter,
@@ -1142,8 +1153,8 @@ class Kernel:
                         lease=lease,
                     )
                     return
-                # The FIRST sanctioned route source, and the normal path: once a
-                # turn has resolved, its egress target is the binding row's,
+                # The normal route source: once a turn has resolved, its egress
+                # target is the binding row's,
                 # because endpoints are server-controlled (D4.1). A row that
                 # names none leaves the server-minted handle standing -- the
                 # dispatcher and CLI bind no endpoint of their own.

--- a/apps/worker/src/curie_worker/kernel.py
+++ b/apps/worker/src/curie_worker/kernel.py
@@ -1108,6 +1108,28 @@ class Kernel:
                     qevent.reply_handle.kind, qevent.reply_handle.channel
                 )
                 if resolved is None:
+                    undeployed = await self._binding.undeployed_binding(
+                        qevent.reply_handle.kind, qevent.reply_handle.channel
+                    )
+                    if undeployed is not None:
+                        route = TargetRoute(
+                            endpoint=undeployed.endpoint or qevent.reply_handle.endpoint,
+                            adapter=undeployed.adapter or qevent.reply_handle.adapter,
+                        )
+                        logger.warning(
+                            "undeployed agent turn dropped for agent=%s route=%s:%s",
+                            undeployed.agent_name,
+                            qevent.reply_handle.kind,
+                            qevent.reply_handle.channel,
+                        )
+                        await self._drop_with_message(
+                            qevent,
+                            route,
+                            "This agent does not have an active deployment yet. "
+                            "Deploy it, then try again.",
+                            lease=lease,
+                        )
+                        return
                     # Name BOTH halves: since the kind routes, a kind typo is a
                     # newly reachable drop, and a message naming only the address
                     # sends an operator hunting a binding that is right there.

--- a/apps/worker/tests/binding/test_resolver.py
+++ b/apps/worker/tests/binding/test_resolver.py
@@ -45,6 +45,7 @@ from curie_worker.binding import (
     HISTORY_TOKEN_ENV,
     MEMORY_TOKEN_ENV,
     BindingResolver,
+    BoundAgent,
     ResolvedDeployment,
     warn_if_multiple_agents_bound,
 )
@@ -386,6 +387,43 @@ def test_two_agents_share_one_address_under_different_kinds() -> None:
                 assert by_email.bundle_ref == f"bundles/email-{token}.zip"
             finally:
                 await _cleanup(engine, [slack_agent, email_agent])
+        finally:
+            await engine.dispose()
+
+    asyncio.run(go())
+
+
+def test_bound_agent_without_active_deployment_is_identified() -> None:
+    """#1522: distinguish a bound channel that cannot start a sandbox yet."""
+
+    async def go() -> None:
+        engine = create_async_engine(_DB_URL)
+        try:
+            try:
+                async with engine.connect():
+                    pass
+            except SQLAlchemyError as exc:
+                pytest.skip(f"Postgres not reachable at {_DB_URL}: {exc}")
+
+            token = uuid.uuid4().hex[:8]
+            channel = f"C0EXAMPLE1-{token}"
+            agent_id = await _seed_agent(
+                engine,
+                channel=channel,
+                name=f"undeployed-{token}",
+                max_usd=None,
+                max_tokens=None,
+            )
+            try:
+                resolver = _resolver(engine)
+                assert await resolver.resolve("slack", channel) is None
+                binding = await resolver.undeployed_binding("slack", channel)
+                assert binding == BoundAgent(agent_id=agent_id, agent_name=f"undeployed-{token}")
+                # The kind remains part of the lookup; this is not an address-only
+                # fallback that could surface another channel's agent.
+                assert await resolver.undeployed_binding("email", channel) is None
+            finally:
+                await _cleanup(engine, [agent_id])
         finally:
             await engine.dispose()
 

--- a/apps/worker/tests/binding/test_resolver.py
+++ b/apps/worker/tests/binding/test_resolver.py
@@ -73,6 +73,8 @@ async def _seed_agent(
     secrets: dict | None = None,
     schema: str = _SCHEMA,
     kind: str = "slack",
+    endpoint: str | None = None,
+    adapter: str | None = None,
 ) -> uuid.UUID:
     """Seed one agent and its single channel binding (ADR-0096, #1459).
 
@@ -109,14 +111,17 @@ async def _seed_agent(
         )
         await conn.execute(
             text(
-                f"INSERT INTO {schema}.agent_channels (id, agent_id, kind, address) "
-                "VALUES (:id, :agent_id, :kind, :address)"
+                f"INSERT INTO {schema}.agent_channels "
+                "(id, agent_id, kind, address, endpoint, adapter) "
+                "VALUES (:id, :agent_id, :kind, :address, :endpoint, :adapter)"
             ),
             {
                 "id": uuid.uuid4(),
                 "agent_id": agent_id,
                 "kind": kind,
                 "address": channel,
+                "endpoint": endpoint,
+                "adapter": adapter,
             },
         )
     return agent_id
@@ -413,12 +418,19 @@ def test_bound_agent_without_active_deployment_is_identified() -> None:
                 name=f"undeployed-{token}",
                 max_usd=None,
                 max_tokens=None,
+                endpoint="https://adapter.example.com/replies",
+                adapter="mail",
             )
             try:
                 resolver = _resolver(engine)
                 assert await resolver.resolve("slack", channel) is None
                 binding = await resolver.undeployed_binding("slack", channel)
-                assert binding == BoundAgent(agent_id=agent_id, agent_name=f"undeployed-{token}")
+                assert binding == BoundAgent(
+                    agent_id=agent_id,
+                    agent_name=f"undeployed-{token}",
+                    endpoint="https://adapter.example.com/replies",
+                    adapter="mail",
+                )
                 # The kind remains part of the lookup; this is not an address-only
                 # fallback that could surface another channel's agent.
                 assert await resolver.undeployed_binding("email", channel) is None

--- a/apps/worker/tests/kernel/test_binding_integration.py
+++ b/apps/worker/tests/kernel/test_binding_integration.py
@@ -6,9 +6,12 @@ the kernel behaviors are exercised deterministically."""
 from __future__ import annotations
 
 import asyncio
+import logging
 import time
 import uuid
 from collections.abc import Callable
+from types import SimpleNamespace
+from typing import Any
 
 from aci_protocol import Final, QueuedTurn, ReplyHandle, SessionStatus, TextDelta
 from curie_worker.behaviorpacks import BehaviorPacks
@@ -35,11 +38,20 @@ class StubBinding:
     misroute the pair predicate exists to close.
     """
 
-    def __init__(self, by_route: dict[tuple[str, str], ResolvedDeployment]) -> None:
+    def __init__(
+        self,
+        by_route: dict[tuple[str, str], ResolvedDeployment],
+        *,
+        undeployed: dict[tuple[str, str], Any] | None = None,
+    ) -> None:
         self._by_route = by_route
+        self._undeployed = undeployed or {}
 
     async def resolve(self, kind: str, address: str) -> ResolvedDeployment | None:
         return self._by_route.get((kind, address))
+
+    async def undeployed_binding(self, kind: str, address: str) -> Any | None:
+        return self._undeployed.get((kind, address))
 
     def boot_env(
         self,
@@ -143,6 +155,36 @@ def test_unmapped_channel_is_a_polite_drop(make_harness) -> None:
             assert h.runner.opened == []  # no turn ever opened
             assert h.sink.last_text is not None and "no agent" in h.sink.last_text.lower()
             assert await h.async_redis.exists(h.config.done_key(ev.event_id))
+
+    asyncio.run(go())
+
+
+def test_bound_channel_without_deployment_replies_and_logs_loudly(make_harness, caplog) -> None:
+    """#1522: an undeployed binding is visible, not a silent acknowledged turn."""
+
+    async def go() -> None:
+        agent_id = uuid.uuid4()
+        binding = StubBinding(
+            {},
+            undeployed={
+                ("slack", "C-bound"): SimpleNamespace(
+                    agent_id=agent_id, agent_name="test-agent", endpoint=None, adapter=None
+                )
+            },
+        )
+        async with make_harness(binding=binding) as h:
+            ev = _qevent("hello", channel="C-bound")
+            with caplog.at_level(logging.WARNING, logger="curie_worker.kernel"):
+                await h.kernel.process_event(ev)
+
+            assert h.runner.opened == []
+            assert h.sink.last_text is not None
+            assert "active deployment" in h.sink.last_text.lower()
+            assert await h.async_redis.exists(h.config.done_key(ev.event_id))
+            assert any(
+                "undeployed agent turn" in message and "test-agent" in message
+                for message in caplog.messages
+            )
 
     asyncio.run(go())
 

--- a/apps/worker/tests/kernel/test_binding_integration.py
+++ b/apps/worker/tests/kernel/test_binding_integration.py
@@ -24,6 +24,7 @@ from curie_worker.binding import (
 )
 from curie_worker.config import WorkerConfig
 from curie_worker.killswitch import kill_key
+from curie_worker.reply_sink import TargetRoute
 
 DONE = SessionStatus.DONE
 IDLE = SessionStatus.IDLE_AWAITING_INPUT
@@ -168,7 +169,10 @@ def test_bound_channel_without_deployment_replies_and_logs_loudly(make_harness, 
             {},
             undeployed={
                 ("slack", "C-bound"): SimpleNamespace(
-                    agent_id=agent_id, agent_name="test-agent", endpoint=None, adapter=None
+                    agent_id=agent_id,
+                    agent_name="test-agent",
+                    endpoint="https://adapter.example.com/replies",
+                    adapter="mail",
                 )
             },
         )
@@ -180,11 +184,36 @@ def test_bound_channel_without_deployment_replies_and_logs_loudly(make_harness, 
             assert h.runner.opened == []
             assert h.sink.last_text is not None
             assert "active deployment" in h.sink.last_text.lower()
+            assert h.sink.routes_for("reply.update") == [
+                TargetRoute(
+                    endpoint="https://adapter.example.com/replies",
+                    adapter="mail",
+                )
+            ]
             assert await h.async_redis.exists(h.config.done_key(ev.event_id))
             assert any(
                 "undeployed agent turn" in message and "test-agent" in message
                 for message in caplog.messages
             )
+
+    asyncio.run(go())
+
+
+def test_unmapped_channel_with_legacy_binding_double_is_a_polite_drop(make_harness) -> None:
+    """Older binding doubles need not implement the diagnostic lookup."""
+
+    class LegacyBinding:
+        async def resolve(self, kind: str, address: str) -> None:
+            return None
+
+    async def go() -> None:
+        async with make_harness(binding=LegacyBinding()) as h:
+            ev = _qevent("hello", channel="C-unknown")
+            await h.kernel.process_event(ev)
+
+            assert h.runner.opened == []
+            assert h.sink.last_text is not None and "no agent" in h.sink.last_text.lower()
+            assert await h.async_redis.exists(h.config.done_key(ev.event_id))
 
     asyncio.run(go())
 


### PR DESCRIPTION
## Summary

Report bound-but-undeployed turns instead of treating them as unbound: the worker now resolves the existing binding for a safe reply route, emits a WARNING with the placeholder agent and route, sends a deployment-required status reply, and completes the established bounded drop path without launching a runner. Active deployments continue through the existing claim path. No protocol, plugin-format, ADR, chart, or release contract changes are included.

## Related issue

Closes #1522

## Fix pin verification

Fix pin: apps/worker/tests/kernel/test_binding_integration.py::test_bound_channel_without_deployment_replies_and_logs_loudly

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | Does not change plugin packaging, runner turn loop, ACI events, eval, or check. | n/a | n/a |
| local | required | Changes worker binding and turn handling. | fake | `CURIE_E2E_TIERS=local bash cli/scripts/e2e-ladder.sh` on final `e4822971`: CI reported `LADDER PASS (tiers: local)`. Independent hands-on proof on the same production diff: an undeployed `acme-undeployed` turn finalized with `This agent does not have an active deployment yet. Deploy it, then try again.`, emitted `WARNING ... undeployed agent turn dropped ... route=slack:C0EXAMPLE1`, and launched zero runners; deployed control `C0LOCALDEV` finalized with `all done`. |
| local-release | n/a | Does not change released binary/image identity, installation, pins, or release compose. | n/a | n/a |
| cluster | n/a | Does not change charts, RBAC, claims, security context, network policy, or init containers. | n/a | n/a |
| live provider | n/a | Does not change model routing, provider credentials, auth, tokens, or cost accounting. | n/a | n/a |
| external integration | n/a | The worker emits the existing channel-neutral reply event; no Slack API shape, adapter, credential, or third-party call changed. | n/a | n/a |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved.
- [ ] Or: this change is not behavior-bearing, so no tier applies, and the summary says why.

Positive/negative evidence:
- Undeployed: user-visible deployment status, WARNING log, terminal done marker, binding-derived endpoint/adapter, and no runner.
- Still deployed: the existing binding claim path remains green and the runtime control replied `all done`.
- Pin control: the candidate passed; reversing the full PR production diff makes the declared test fail on the old generic `No agent is configured...` reply.

## Checklist

- [x] Tests pass for the area I touched: `uv run pytest -q apps/worker/tests/binding apps/worker/tests/kernel` (`447 passed, 2 skipped`), affected-file Ruff, and worker mypy.
- [x] Docs are unchanged because this narrows an existing documented polite-drop behavior and does not change a public interface.
- [x] No ADR is needed; this is a worker-local bug fix using the existing reply and completion contracts.