### PR TITLE
Preserve skill approval metadata in JSON

### DIFF
--- a/cli/schema/baseline/skill-message.schema.json
+++ b/cli/schema/baseline/skill-message.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schemas.curietech.ai/cli/skill-message/v1.json",
+  "$id": "https://schemas.curietech.ai/cli/skill-message/v1.1.json",
   "title": "curie skill message --json",
-  "description": "The agent-facing payload of `curie skill message` under `--json`: the full buffered model reply and the final ACI session status (the human path streams tokens live and never builds this).",
+  "description": "The agent-facing payload of `curie skill message` under `--json`: the full buffered model reply, final ACI session status, and approval metadata from the final frame (the human path streams tokens live and never builds this).",
   "type": "object",
   "additionalProperties": false,
   "properties": {
@@ -13,7 +13,24 @@
       "type": "string"
     },
     "finalized": {
-      "type": "boolean"
+      "type": "boolean",
+      "description": "Whether the turn is terminal. This is false for an awaiting-approval park, which can resume after an approval decision, and true for every other final-frame status."
+    },
+    "approval_summary": {
+      "type": ["string", "null"],
+      "description": "The runner-provided human-readable approval request summary, or null when the final frame carries no approval request."
+    },
+    "approval_route": {
+      "type": ["string", "null"],
+      "description": "The runner-provided approval route name, or null when no route applies."
+    },
+    "approval_gate_kind": {
+      "type": ["string", "null"],
+      "description": "The runner-provided kind of approval gate that parked or governed the turn, or null when no gate applies."
+    },
+    "approval_granted_tool": {
+      "type": ["string", "null"],
+      "description": "The runner-provided tool name associated with a granted approval, or null when no tool grant applies."
     }
   },
   "required": [

--- a/cli/schema/baseline/skill-message.schema.json
+++ b/cli/schema/baseline/skill-message.schema.json
@@ -30,7 +30,7 @@
     },
     "approval_granted_tool": {
       "type": ["string", "null"],
-      "description": "The runner-provided tool name associated with a granted approval, or null when no tool grant applies."
+      "description": "The runner-provided tool name associated with a permission approval request, or null when no tool-specific approval applies."
     }
   },
   "required": [

--- a/cli/schema/index.json
+++ b/cli/schema/index.json
@@ -265,7 +265,7 @@
       "result": "SkillMessageOutput",
       "kind": "CliOutput",
       "schema": "skill-message.schema.json",
-      "version": "1.0"
+      "version": "1.1"
     },
     {
       "result": "StatusOutput",

--- a/cli/schema/skill-message.schema.json
+++ b/cli/schema/skill-message.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schemas.curietech.ai/cli/skill-message/v1.json",
+  "$id": "https://schemas.curietech.ai/cli/skill-message/v1.1.json",
   "title": "curie skill message --json",
-  "description": "The agent-facing payload of `curie skill message` under `--json`: the full buffered model reply and the final ACI session status (the human path streams tokens live and never builds this).",
+  "description": "The agent-facing payload of `curie skill message` under `--json`: the full buffered model reply, final ACI session status, and approval metadata from the final frame (the human path streams tokens live and never builds this).",
   "type": "object",
   "additionalProperties": false,
   "properties": {
@@ -13,7 +13,24 @@
       "type": "string"
     },
     "finalized": {
-      "type": "boolean"
+      "type": "boolean",
+      "description": "Whether the turn is terminal. This is false for an awaiting-approval park, which can resume after an approval decision, and true for every other final-frame status."
+    },
+    "approval_summary": {
+      "type": ["string", "null"],
+      "description": "The runner-provided human-readable approval request summary, or null when the final frame carries no approval request."
+    },
+    "approval_route": {
+      "type": ["string", "null"],
+      "description": "The runner-provided approval route name, or null when no route applies."
+    },
+    "approval_gate_kind": {
+      "type": ["string", "null"],
+      "description": "The runner-provided kind of approval gate that parked or governed the turn, or null when no gate applies."
+    },
+    "approval_granted_tool": {
+      "type": ["string", "null"],
+      "description": "The runner-provided tool name associated with a granted approval, or null when no tool grant applies."
     }
   },
   "required": [

--- a/cli/schema/skill-message.schema.json
+++ b/cli/schema/skill-message.schema.json
@@ -30,7 +30,7 @@
     },
     "approval_granted_tool": {
       "type": ["string", "null"],
-      "description": "The runner-provided tool name associated with a granted approval, or null when no tool grant applies."
+      "description": "The runner-provided tool name associated with a permission approval request, or null when no tool-specific approval applies."
     }
   },
   "required": [

--- a/cli/scripts/e2e-ladder.sh
+++ b/cli/scripts/e2e-ladder.sh
@@ -1271,7 +1271,7 @@ case_live_approval_gate_denies() {
             --secret CURIE_APPROVAL_REQUIRED_TOOLS
     )
 
-    local attempt out code status
+    local attempt out code status parked_shape parsed
     status=""
     # A live model may answer without calling any tool at all, which ends the
     # turn `done` and is a flake rather than a regression. One retry, then a
@@ -1293,22 +1293,39 @@ case_live_approval_gate_denies() {
         # stdout only: --json puts the payload on stdout and human text on
         # stderr, so a combined-stream parse fails intermittently and reads like
         # a product bug.
-        status="$(printf '%s' "$out" | python3 -c '
+        parsed="$(printf '%s' "$out" | python3 -c '
 import json, sys
 try:
     payload = json.loads(sys.stdin.read())
 except Exception:
-    print("unparseable")
+    print("unparseable invalid")
     sys.exit(0)
-print(payload.get("status") if isinstance(payload, dict) else "unparseable")
-' || echo "unparseable")"
+if not isinstance(payload, dict):
+    print("unparseable invalid")
+    sys.exit(0)
+status = payload.get("status")
+parked_shape = (
+    "valid"
+    if payload.get("finalized") is False
+    and isinstance(payload.get("approval_summary"), str)
+    else "invalid"
+)
+print(status, parked_shape)
+' || echo "unparseable invalid")"
+        status="${parsed%% *}"
+        parked_shape="${parsed#* }"
 
         # (b) parked. Deliberately NOT the ladder's finalized-reply helper,
-        # which treats an approval park as a failure; and deliberately not
-        # `finalized` (the skill tier hardcodes it true) nor the exit code (a
-        # parked turn exits 0).
-        if [[ "$status" == "awaiting-approval" ]]; then
+        # which treats an approval park as a failure. The runner final-frame
+        # contract requires status=awaiting-approval, finalized=false, and a
+        # non-null approval_summary; a parked turn still exits 0.
+        if [[ "$status" == "awaiting-approval" && "$parked_shape" == "valid" ]]; then
             break
+        fi
+        if [[ "$status" == "awaiting-approval" ]]; then
+            echo "the gated turn parked without finalized=false and a non-null approval_summary." >&2
+            printf '%s\n' "$out" >&2
+            return 1
         fi
         if [[ "$status" == "done" && "$attempt" == "1" ]]; then
             echo "retrying: the model answered without calling Bash"
@@ -1319,7 +1336,7 @@ print(payload.get("status") if isinstance(payload, dict) else "unparseable")
         printf '%s\n' "$out" >&2
         return 1
     done
-    echo "the gated turn parked: status=$status"
+    echo "the gated turn parked: status=$status finalized=false approval_summary=present"
 
     # (c) unrun, asserted inside the container that would have run it. Confirm
     # the runner is still up first, purely for the precise diagnostic: a dead

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -3336,16 +3336,15 @@ pub async fn send(
         step.clear();
     }
 
-    if let Some(OutboundEvent::Final { status, .. }) = events.last() {
-        // Under `--json`, emit the one buffered turn object (reply + final
-        // status) rather than the streamed/human trailer (#485). Emit BEFORE any
-        // exit so a classified failure still carries its data to the consumer.
+    if let Some(final_event @ OutboundEvent::Final { status, .. }) = events.last() {
+        // Under `--json`, project the real final frame into one buffered turn
+        // object (reply, status, and approval metadata) rather than the
+        // streamed/human trailer (#485, #2108). Emit BEFORE any exit so a
+        // classified failure still carries its data to the consumer.
         if json {
-            ui.emit(&SkillMessageOutput {
-                reply: std::mem::take(&mut reply),
-                status: status_str(status).to_string(),
-                finalized: true,
-            });
+            let output = SkillMessageOutput::from_final(std::mem::take(&mut reply), final_event)
+                .expect("the matched outbound event is final");
+            ui.emit(&output);
             return Ok(*status == SessionStatus::ClassifiedFailure);
         }
         // Close the streamed answer on stdout only if the last thing written was
@@ -3361,14 +3360,48 @@ pub async fn send(
     Ok(false)
 }
 
-/// Output of `skill message` under `--json`: the full buffered reply plus the
-/// final session status. The human path streams tokens live and never builds
-/// this; it exists so `--json` emits one object instead of empty stdout (#485).
+/// Output of `skill message` under `--json`: the full buffered reply, final
+/// session status, and approval metadata copied from the runner's final frame.
+/// The human path streams tokens live and never builds this; it exists so
+/// `--json` emits one complete object instead of empty stdout (#485, #2108).
 #[derive(Debug)]
 pub struct SkillMessageOutput {
     pub reply: String,
     pub status: String,
     pub finalized: bool,
+    pub approval_summary: Option<String>,
+    pub approval_route: Option<String>,
+    pub approval_gate_kind: Option<String>,
+    pub approval_granted_tool: Option<String>,
+}
+
+impl SkillMessageOutput {
+    /// Project a runner final frame into the agent-facing result without
+    /// inventing terminal state. An approval park is resumable, so it is the
+    /// only final-frame status for which `finalized` is false.
+    pub fn from_final(reply: String, event: &OutboundEvent) -> Option<Self> {
+        let OutboundEvent::Final {
+            status,
+            approval_summary,
+            approval_route,
+            approval_gate_kind,
+            approval_granted_tool,
+            ..
+        } = event
+        else {
+            return None;
+        };
+
+        Some(Self {
+            reply,
+            status: status_str(status).to_string(),
+            finalized: !matches!(status, SessionStatus::AwaitingApproval),
+            approval_summary: approval_summary.clone(),
+            approval_route: approval_route.clone(),
+            approval_gate_kind: approval_gate_kind.clone(),
+            approval_granted_tool: approval_granted_tool.clone(),
+        })
+    }
 }
 
 fn editable_bundle_warning(saved: Option<&state::RunnerState>, url: &str) -> Option<String> {
@@ -3398,12 +3431,14 @@ impl crate::ui::CliOutput for SkillMessageOutput {
             "reply": self.reply,
             "status": self.status,
             "finalized": self.finalized,
+            "approval_summary": self.approval_summary,
+            "approval_route": self.approval_route,
+            "approval_gate_kind": self.approval_gate_kind,
+            "approval_granted_tool": self.approval_granted_tool,
         })
     }
 
     fn render(&self, ui: &crate::ui::Ui) {
-        // Only reached if a caller routes this through the human path; mirror the
-        // streamed output as a single block for completeness.
         ui.answer(&self.reply);
         ui.note(&format!("-- final ({})", self.status));
     }

--- a/cli/tests/json_contract.rs
+++ b/cli/tests/json_contract.rs
@@ -12,7 +12,7 @@ use curie::exit;
 use curie::message::{message_dry_run_json, MessageOutcomeOutput};
 use curie::observability::{local_endpoints, Endpoint, ObservabilityOutput};
 use curie::ui::{CliOutput, DryRunPlan};
-use curie_aci_protocol::SessionStatus;
+use curie_aci_protocol::{OutboundEvent, SessionStatus, PROTOCOL_VERSION};
 
 fn load_schema(name: &str) -> serde_json::Value {
     let path = format!("{}/schema/{}", env!("CARGO_MANIFEST_DIR"), name);
@@ -1156,13 +1156,105 @@ fn bump_version_output_validates() {
 }
 
 #[test]
-fn skill_message_output_validates() {
-    let out = SkillMessageOutput {
-        reply: "the answer is 42".to_string(),
-        status: "done".to_string(),
-        finalized: true,
+fn skill_message_awaiting_approval_output_preserves_final_approval_fields() {
+    let final_frame = OutboundEvent::Final {
+        version: PROTOCOL_VERSION.to_string(),
+        text: "the answer is 42".to_string(),
+        status: SessionStatus::AwaitingApproval,
+        approval_summary: Some("Approve the proposed operation".to_string()),
+        approval_route: Some("reviewers".to_string()),
+        approval_gate_kind: Some("permission".to_string()),
+        approval_granted_tool: Some("ExampleTool".to_string()),
+        input_tokens: Some(10),
+        output_tokens: Some(5),
     };
-    assert_valid("skill-message.schema.json", &out.to_json());
+    let out = SkillMessageOutput::from_final("the answer is 42".to_string(), &final_frame)
+        .expect("a final frame produces skill message output");
+    let value = out.to_json();
+    assert_valid("skill-message.schema.json", &value);
+    assert_eq!(value["reply"], serde_json::json!("the answer is 42"));
+    assert_eq!(value["status"], serde_json::json!("awaiting-approval"));
+    assert_eq!(value["finalized"], serde_json::json!(false));
+    assert_eq!(
+        value["approval_summary"],
+        serde_json::json!("Approve the proposed operation")
+    );
+    assert_eq!(value["approval_route"], serde_json::json!("reviewers"));
+    assert_eq!(value["approval_gate_kind"], serde_json::json!("permission"));
+    assert_eq!(
+        value["approval_granted_tool"],
+        serde_json::json!("ExampleTool")
+    );
+}
+
+#[test]
+fn skill_message_awaiting_approval_output_is_not_finalized() {
+    let final_frame = OutboundEvent::Final {
+        version: PROTOCOL_VERSION.to_string(),
+        text: "I need approval before continuing".to_string(),
+        status: SessionStatus::AwaitingApproval,
+        approval_summary: Some("Approve the proposed operation".to_string()),
+        approval_route: Some("reviewers".to_string()),
+        approval_gate_kind: Some("policy".to_string()),
+        approval_granted_tool: None,
+        input_tokens: None,
+        output_tokens: None,
+    };
+    let out = SkillMessageOutput::from_final(
+        "I need approval before continuing".to_string(),
+        &final_frame,
+    )
+    .expect("an awaiting-approval final frame produces skill message output");
+    let value = out.to_json();
+    assert_valid("skill-message.schema.json", &value);
+    assert_eq!(value["status"], serde_json::json!("awaiting-approval"));
+    assert_eq!(value["finalized"], serde_json::json!(false));
+    assert_eq!(
+        value["approval_summary"],
+        serde_json::json!("Approve the proposed operation")
+    );
+    assert_eq!(value["approval_route"], serde_json::json!("reviewers"));
+    assert_eq!(value["approval_gate_kind"], serde_json::json!("policy"));
+    assert_eq!(value["approval_granted_tool"], serde_json::Value::Null);
+}
+
+#[test]
+fn skill_message_only_marks_awaiting_approval_as_not_finalized() {
+    for status in [
+        SessionStatus::Done,
+        SessionStatus::IdleAwaitingInput,
+        SessionStatus::ClassifiedFailure,
+    ] {
+        let final_frame = OutboundEvent::Final {
+            version: PROTOCOL_VERSION.to_string(),
+            text: String::new(),
+            status,
+            approval_summary: None,
+            approval_route: None,
+            approval_gate_kind: None,
+            approval_granted_tool: None,
+            input_tokens: None,
+            output_tokens: None,
+        };
+        let out = SkillMessageOutput::from_final(String::new(), &final_frame)
+            .expect("a final frame produces skill message output");
+        assert!(
+            out.finalized,
+            "non-parked status must be finalized: {out:?}"
+        );
+    }
+}
+
+#[test]
+fn skill_message_v1_payload_without_approval_metadata_remains_valid() {
+    assert_valid(
+        "skill-message.schema.json",
+        &serde_json::json!({
+            "reply": "done",
+            "status": "done",
+            "finalized": true
+        }),
+    );
 }
 
 #[test]

--- a/cli/tests/json_contract.rs
+++ b/cli/tests/json_contract.rs
@@ -1242,6 +1242,12 @@ fn skill_message_only_marks_awaiting_approval_as_not_finalized() {
             out.finalized,
             "non-parked status must be finalized: {out:?}"
         );
+        let json = out.to_json();
+        assert_valid("skill-message.schema.json", &json);
+        assert!(json["approval_summary"].is_null());
+        assert!(json["approval_route"].is_null());
+        assert!(json["approval_gate_kind"].is_null());
+        assert!(json["approval_granted_tool"].is_null());
     }
 }
 

--- a/docs/interfaces/cli-output/INTERFACE.md
+++ b/docs/interfaces/cli-output/INTERFACE.md
@@ -123,7 +123,7 @@ That set is not hand-maintained prose: `cli/schema/index.json` carries one
   longer schema-free: there are 46 committed schemas under `cli/schema/` with an
   index (`cli/schema/index.json`), a `syn`-based inventory gate over every `impl
   CliOutput`, and per-family output validation — all 46 are validated against real
-  `to_json()` output across 73 tests in `cli/tests/json_contract.rs`. Those tests
+  `to_json()` output across 76 tests in `cli/tests/json_contract.rs`. Those tests
   drive each output type's `to_json()` once per output variant rather than calling
   the pure builder functions behind it, so a variant whose `to_json()` arm drifts
   from the schema is caught even when the builder it delegates to still validates.

--- a/runner/tests/test_ladder_approval_gate_case.py
+++ b/runner/tests/test_ladder_approval_gate_case.py
@@ -170,19 +170,41 @@ def test_case_asserts_the_parked_status_and_the_unrun_canary() -> None:
         "only in a diagnostic proves nothing about what the case enforces"
     )
 
-    # Neutering shape 2: keep the comparison, but hardcode what it reads
-    # (`status="awaiting-approval"`). So the value must come from parsing the
-    # captured turn output, and must never be assigned the expected literal.
+    # Neutering shape 2: keep the comparison, but hardcode what it reads. The
+    # parser must consume the captured turn output and derive both compared
+    # variables from that parsed result.
+    parsed_assignments = re.findall(r'^\s*parsed=(.*)$', body, flags=re.MULTILINE)
+    assert parsed_assignments, f"{CASE_NAME} must parse the captured turn output"
+    assert any('$(' in value and '"$out"' in value for value in parsed_assignments), (
+        "the parked-turn checks must be parsed out of the captured `skill message` "
+        f"payload, not synthesized; got assignments: {parsed_assignments}"
+    )
+
     status_assignments = re.findall(r'^\s*status=(.*)$', body, flags=re.MULTILINE)
     assert status_assignments, f"{CASE_NAME} must capture the turn's status"
-    assert any('$(' in value and '"$out"' in value for value in status_assignments), (
-        "the compared status must be parsed out of the captured `skill message` "
-        f"payload, not synthesized; got assignments: {status_assignments}"
+    assert any("parsed" in value for value in status_assignments), (
+        "the compared status must be derived from the parsed payload; got "
+        f"assignments: {status_assignments}"
     )
     assert not any("awaiting-approval" in value for value in status_assignments), (
         "the expected status must never be assigned to the variable the case "
         f"then compares against it; got assignments: {status_assignments}"
     )
+
+    parked_shape_assignments = re.findall(
+        r'^\s*parked_shape=(.*)$', body, flags=re.MULTILINE
+    )
+    assert parked_shape_assignments, f"{CASE_NAME} must capture the parked JSON shape"
+    assert any("parsed" in value for value in parked_shape_assignments), (
+        "the compared parked shape must be derived from the parsed payload; got "
+        f"assignments: {parked_shape_assignments}"
+    )
+    assert not any("valid" in value for value in parked_shape_assignments), (
+        "the expected parked shape must never be assigned to the variable the "
+        f"case compares; got assignments: {parked_shape_assignments}"
+    )
+    assert 'payload.get("finalized") is False' in body
+    assert 'isinstance(payload.get("approval_summary"), str)' in body
 
     # --- (c) unrun --------------------------------------------------------
     # Neutering shape 3: drop the in-container probe, or stop asking it a

--- a/runner/tests/test_ladder_approval_gate_case.py
+++ b/runner/tests/test_ladder_approval_gate_case.py
@@ -203,8 +203,18 @@ def test_case_asserts_the_parked_status_and_the_unrun_canary() -> None:
         "the expected parked shape must never be assigned to the variable the "
         f"case compares; got assignments: {parked_shape_assignments}"
     )
-    assert 'payload.get("finalized") is False' in body
-    assert 'isinstance(payload.get("approval_summary"), str)' in body
+    assert re.search(
+        r'parked_shape\s*=\s*\(\s*"valid"\s*if\s*'
+        r'payload\.get\("finalized"\)\s+is\s+False\s+and\s*'
+        r'isinstance\(payload\.get\("approval_summary"\),\s*str\)\s*'
+        r'else\s*"invalid"\s*\)',
+        body,
+    ), "parked_shape must be computed from finalized=false and approval_summary"
+    assert re.search(
+        r'\[\[\s*"\$\{?status\}?"\s*==\s*"awaiting-approval"\s*'
+        r'&&\s*"\$\{?parked_shape\}?"\s*==\s*"valid"\s*\]\]',
+        body,
+    ), "the success branch must require both the parked status and JSON shape"
 
     # --- (c) unrun --------------------------------------------------------
     # Neutering shape 3: drop the in-container probe, or stop asking it a


### PR DESCRIPTION
## Summary

Preserve the runner final frame's approval metadata in `curie skill message --json`, report approval-parked turns as `finalized: false`, and govern the expanded optional JSON shape as skill-message schema v1.1. The live ladder assertion and its source-contract test now require the parked status, non-finalized flag, and runner approval summary together.

## Related issue

Closes #2108

## Fix pin verification

Fix pin: cli/tests/json_contract.rs::skill_message_awaiting_approval_output_is_not_finalized

`curie dev verify-fix-pin d279fb493 cli/tests/json_contract.rs::skill_message_awaiting_approval_output_is_not_finalized` reported `PINNED`. Reverting the product projection removes `SkillMessageOutput::from_final`, so the selected changed test fails.

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | required | The change reaches `skill message` output and the runner final-frame seam. | fake | At candidate `0ae538e38`: `CURIE_BIN=/home/theconnman/.cargo/shared-targets/agentos/release/curie CURIE_E2E_TIERS=skill curie dev e2e-ladder` -> `LADDER PASS (tiers: skill)`; completed JSON included all four approval keys as null and `finalized: true`. |
| local | required | A `curie` verb's `--json` shape changed. | fake | At candidate `0ae538e38`: `CURIE_BIN=/home/theconnman/.cargo/shared-targets/agentos/release/curie CURIE_E2E_TIERS=local CURIE_BASE_TAG=dev CURIE_RUNNER_IMAGE=ghcr.io/curie-eng/curie-runner:dev CURIE_DISPATCHER_IMAGE=ghcr.io/curie-eng/curie-dispatcher:dev CURIE_UI_IMAGE=ghcr.io/curie-eng/curie-ui:dev curie dev e2e-ladder` -> `LADDER PASS (tiers: local)`; the healthy turn finalized, the injected `model_not_found` turn produced `classified_failure_delta: 1` and `done_delta: 0`, and recovery finalized normally. |
| local-release | n/a | No released binary/image identity, installation path, version pin, or release compose changed. | n/a | Not reachable. |
| cluster | n/a | No chart, Kubernetes resource, sandbox claim, RBAC, init container, or cluster wiring changed. | n/a | Not reachable. |
| live provider | n/a | No model routing, provider authentication, credential resolution, token, or cost behavior changed. | n/a | Not reachable. |
| external integration | n/a | No Slack, webhook, OAuth, connector, or third-party API shape changed. | n/a | Not reachable. |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.
- [ ] Or: this change is not behavior-bearing, so no tier applies, and the summary says why.

Acceptance-criterion evidence:

- Positive approval projection: `skill_message_awaiting_approval_output_preserves_final_approval_fields` constructs a legal permission-gate final frame, projects it through production code, validates the schema, and asserts all four runner values verbatim.
- Parked-turn negative: `skill_message_awaiting_approval_output_is_not_finalized` constructs a policy-gate park with no tool-specific approval and proves `finalized: false` plus JSON null for the tool field. `skill_message_only_marks_awaiting_approval_as_not_finalized` independently proves Done, IdleAwaitingInput, and ClassifiedFailure remain finalized with null approval metadata.
- Compatibility path: `skill_message_v1_payload_without_approval_metadata_remains_valid` proves the new properties remain optional.
- Anti-neutering path: `runner/tests/test_ladder_approval_gate_case.py` proves the live ladder parses the captured JSON and gates success on status `awaiting-approval`, `finalized is False`, and a string `approval_summary`.

## Checklist

- [x] Tests pass for the area I touched.
  - `cargo fmt --manifest-path cli/Cargo.toml --check`
  - `cargo clippy --manifest-path cli/Cargo.toml -- -D warnings`
  - `cargo test --manifest-path cli/Cargo.toml`
  - Full Python static/docs/wire/released-upgrade baseline passed; with unrelated host `OTEL_*` exports removed, full pytest passed: `5339 passed, 13 skipped`.
  - `uv run pytest -q runner/tests/test_ladder_approval_gate_case.py` -> `7 passed`.
  - Both final independent code/scope reviews returned `PASS`.
- [x] Docs updated if behavior changed (`docs/interfaces/cli-output/INTERFACE.md` and governed JSON schema/baseline/index).
- [x] ADR not required: this fixes an existing CLI projection bug without changing architecture or a frozen contract.
