### PR TITLE
Let a version with no commit still be upgraded

### DIFF
--- a/examples/sre-bot/self-upgrade/redeploy.py
+++ b/examples/sre-bot/self-upgrade/redeploy.py
@@ -462,6 +462,32 @@ def deploy(
     return version_id
 
 
+def upgrade_disposition(current: str | None, version_id: str | None) -> str:
+    """What to do about a deployed version, given what is known about it.
+
+    Two different absences, and only one is fatal:
+
+    - No VERSION means nothing to read the running connector env off, so a deploy
+      would ship the bundle's placeholder allowlists and produce a bot that
+      refuses every write while looking healthy. Refuse.
+    - No COMMIT means only the comparison is lost. "Am I behind?" becomes
+      unanswerable; "can I deploy?" does not.
+
+    Refusing on a missing commit was wrong, and stuck: `curie example sre-bot
+    install` creates versions with no commit, so an install deployed the
+    supported way could never be upgraded by this job again -- and the refusal
+    advised deploying through the installer, which is what caused it (#2128).
+
+    Returns one of ``refuse``, ``deploy-unknown``, ``deploy``.
+    """
+
+    if not version_id:
+        return "refuse"
+    if not current:
+        return "deploy-unknown"
+    return "deploy"
+
+
 def main() -> int:
     repo = os.environ.get("CURIE_SELF_UPGRADE_REPO", "curie-eng/curie")
     branch = os.environ.get("CURIE_SELF_UPGRADE_BRANCH", "main")
@@ -497,14 +523,37 @@ def main() -> int:
         print("dry run: would deploy the bundle at the tip", flush=True)
         return 0
 
-    if not current or not version_id:
+    # Two different absences, and only one of them is fatal.
+    #
+    # Without a VERSION there is nothing to read the running connector env off,
+    # so a deploy would ship the bundle's placeholder allowlists and produce a
+    # bot that refuses every write while looking healthy. That is worth refusing.
+    #
+    # Without a COMMIT the only thing lost is the comparison -- "am I behind?"
+    # becomes unanswerable, not "I cannot deploy". Refusing there was wrong, and
+    # wrong in a way that stuck: `curie example sre-bot install` creates versions
+    # with no commit, so an install deployed the supported way could never be
+    # upgraded by this job again, and the message told the reader to do the very
+    # thing that caused it (#2128).
+    #
+    # Deploying the tip is the safe answer to an unknown current: it is where the
+    # repository is, and the alternative is an install that can never move.
+    disposition = upgrade_disposition(current, version_id)
+    if disposition == "refuse":
         print(
-            "the deployed version records no commit, so there is nothing to compare "
-            "against and no connector declaration to carry forward. Deploy once "
-            "through the installer first.",
+            "the deployed version cannot be identified, so there is no connector "
+            "declaration to carry forward and a deploy would ship the bundle's "
+            "placeholder ceilings. Refusing.",
             flush=True,
         )
         return 1
+    if disposition == "deploy-unknown":
+        print(
+            "the deployed version records no commit, so whether this install is "
+            "behind cannot be determined. Deploying the tip, which is the only "
+            "answer that leaves it somewhere known.",
+            flush=True,
+        )
 
     try:
         archive = _get(

--- a/examples/tests/test_self_upgrade_detection.py
+++ b/examples/tests/test_self_upgrade_detection.py
@@ -22,7 +22,6 @@ import yaml
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "sre-bot" / "self-upgrade"))
 
 from redeploy import (  # noqa: E402
-    upgrade_disposition,
     BUNDLE_PREFIX,
     SelfUpgradeError,
     bundle_from_repo_tarball,
@@ -31,6 +30,7 @@ from redeploy import (  # noqa: E402
     member_of,
     pin_build_connectors,
     replace_member,
+    upgrade_disposition,
 )
 
 

--- a/examples/tests/test_self_upgrade_detection.py
+++ b/examples/tests/test_self_upgrade_detection.py
@@ -22,6 +22,7 @@ import yaml
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "sre-bot" / "self-upgrade"))
 
 from redeploy import (  # noqa: E402
+    upgrade_disposition,
     BUNDLE_PREFIX,
     SelfUpgradeError,
     bundle_from_repo_tarball,
@@ -310,3 +311,32 @@ def test_the_bundle_is_uploaded_as_a_multipart_file(
     # And the order still holds: create, upload, then deploy -- so a failure
     # never leaves a version marked active with no bundle behind it.
     assert [c["path"].rsplit("/", 1)[-1] for c in seen] == ["versions", "bundle", "deployments"]
+
+
+def test_a_version_with_no_commit_is_still_upgradable() -> None:
+    """The regression that stuck: an installer-created version could never move.
+
+    `curie example sre-bot install` records no commit, so this job refused --
+    and told the reader to deploy through the installer, which is what produced
+    the state. An install deployed the supported way could never be upgraded by
+    the supported job (#2128).
+
+    Losing the commit loses the COMPARISON, not the ability to deploy.
+    """
+    assert upgrade_disposition(None, "a-version-id") == "deploy-unknown"
+    assert upgrade_disposition("", "a-version-id") == "deploy-unknown"
+
+
+def test_no_version_is_still_refused() -> None:
+    """The half that must stay fatal.
+
+    Without a version there is no running connector env to carry forward, so a
+    deploy ships the bundle's placeholder ceilings -- a bot that refuses every
+    write and looks exactly like one that chose not to act.
+    """
+    assert upgrade_disposition("c" * 40, None) == "refuse"
+    assert upgrade_disposition(None, None) == "refuse"
+
+
+def test_a_fully_known_version_deploys_normally() -> None:
+    assert upgrade_disposition("c" * 40, "a-version-id") == "deploy"


### PR DESCRIPTION
`curie example sre-bot install` creates agent versions with no `commit_sha`. The self-upgrade Job then refused every run:

```
the deployed version records no commit, so there is nothing to compare against
and no connector declaration to carry forward. Deploy once through the installer first.
```

**The advice is what produced the state.** Deploying through the installer again makes another commit-less version, so an install deployed the supported way could never be upgraded by the supported job — and the message pointed at the loop rather than out of it.

Hit while trying to redeploy a bundle fix on a live install.

## Two absences, one condition

The refusal was `if not current or not version_id`. Those are different problems:

| missing | what is lost | verdict |
|---|---|---|
| **version** | nothing to read the running connector env off, so a deploy ships the bundle's placeholder allowlists — a bot that refuses every write while looking healthy | stays fatal |
| **commit** | only the comparison. *"Am I behind?"* becomes unanswerable; *"can I deploy?"* does not | deploy the tip |

Deploying the tip is the safe answer to an unknown current: it is where the repository is, and the alternative is an install that can never move.

## Testing

Split into `upgrade_disposition` so the decision is testable without a cluster or a registry — the reads are the parts that need those, and the reads were not what was wrong.

`examples/tests/` → 99 passed; `ruff` clean.

## Not fixed here

The installer still records no commit. That is the other half of #2128 and wants a build-time commit the CLI does not currently carry — there is no `build.rs` and nothing bakes a git SHA in.

This change makes the resulting state **recoverable rather than terminal**, which is the half worth having first.