### PR TITLE
Fix installer commit provenance

### DIFF
--- a/cli/build.rs
+++ b/cli/build.rs
@@ -1,5 +1,6 @@
 use std::fmt::Write as _;
 use std::path::Path;
+use std::process::Command;
 
 fn main() {
     println!("cargo:rerun-if-env-changed=CURIE_BUILD_CHANNEL");
@@ -10,7 +11,65 @@ fn main() {
     }
     println!("cargo:rustc-env=CURIE_BUILD_CHANNEL={channel}");
 
+    stamp_repo_commit();
     embed_result_schemas();
+}
+
+/// Stamp the repository HEAD into binaries built from a Git checkout. Source
+/// archives and other no-Git builds deliberately carry no commit provenance.
+fn stamp_repo_commit() {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR");
+    let manifest_dir = Path::new(&manifest_dir);
+
+    // Cargo otherwise has no reason to rerun this build script when only HEAD
+    // moves. Watch both the worktree HEAD and its loose branch ref; packed-refs
+    // covers checkouts whose branch has not been materialized as a loose ref.
+    if let Some(git_dir) = git_output(manifest_dir, &["rev-parse", "--absolute-git-dir"]) {
+        println!("cargo:rerun-if-changed={git_dir}/HEAD");
+    }
+    if let (Some(common_dir), Some(head_ref)) = (
+        git_output(manifest_dir, &["rev-parse", "--git-common-dir"]),
+        git_output(manifest_dir, &["symbolic-ref", "-q", "HEAD"]),
+    ) {
+        let common_dir = Path::new(&common_dir);
+        let common_dir = if common_dir.is_absolute() {
+            common_dir.to_path_buf()
+        } else {
+            manifest_dir.join(common_dir)
+        };
+        println!(
+            "cargo:rerun-if-changed={}",
+            common_dir.join(head_ref).display()
+        );
+        println!(
+            "cargo:rerun-if-changed={}",
+            common_dir.join("packed-refs").display()
+        );
+    }
+
+    let Some(commit) = git_output(manifest_dir, &["rev-parse", "--verify", "HEAD"]) else {
+        return;
+    };
+    if commit.len() == 40 && commit.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        println!("cargo:rustc-env=CURIE_BUILD_COMMIT={commit}");
+    }
+}
+
+fn git_output(current_dir: &Path, args: &[&str]) -> Option<String> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(current_dir)
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    String::from_utf8(output.stdout)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
 }
 
 /// Embed every committed CLI result JSON Schema (issue #634) into the binary so a

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -47,12 +47,29 @@ fn stamp_repo_commit() {
         );
     }
 
+    // The embedded installer is built from the checkout's working files, so
+    // only claim HEAD provenance when those files match it. This keeps the
+    // build-time override aligned with ordinary deploy provenance discovery.
+    if !git_worktree_is_clean(manifest_dir) {
+        return;
+    }
+
     let Some(commit) = git_output(manifest_dir, &["rev-parse", "--verify", "HEAD"]) else {
         return;
     };
     if commit.len() == 40 && commit.bytes().all(|byte| byte.is_ascii_hexdigit()) {
         println!("cargo:rustc-env=CURIE_BUILD_COMMIT={commit}");
     }
+}
+
+fn git_worktree_is_clean(current_dir: &Path) -> bool {
+    Command::new("git")
+        .args(["status", "--porcelain"])
+        .current_dir(current_dir)
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .output()
+        .is_ok_and(|output| output.status.success() && output.stdout.is_empty())
 }
 
 fn git_output(current_dir: &Path, args: &[&str]) -> Option<String> {

--- a/cli/src/artifacts.rs
+++ b/cli/src/artifacts.rs
@@ -51,6 +51,14 @@ pub fn version() -> &'static str {
     env!("CARGO_PKG_VERSION")
 }
 
+/// The full repository commit stamped by `build.rs`, when this binary was
+/// built from a Git checkout. Source archives and other no-Git builds return
+/// `None` rather than inventing provenance.
+pub fn commit_sha() -> Option<&'static str> {
+    option_env!("CURIE_BUILD_COMMIT")
+        .filter(|commit| commit.len() == 40 && commit.bytes().all(|byte| byte.is_ascii_hexdigit()))
+}
+
 /// XDG_CACHE_HOME or $HOME/.cache, joined with "curie". Err (never panic) when
 /// neither env var is set, with a message naming the vars + the override flags.
 pub fn cache_root() -> Result<PathBuf> {

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -4534,6 +4534,17 @@ impl PreparedDeploy {
 }
 
 pub async fn prepare_deploy(opts: DeployOpts) -> Result<PreparedDeploy> {
+    prepare_deploy_with_commit_sha(opts, None).await
+}
+
+/// Prepare a deploy with commit provenance supplied by an installer binary.
+/// Ordinary deploys pass no override and continue discovering the clean bundle
+/// checkout's HEAD. The override is deliberately crate-private: it is not a
+/// user-facing way to claim arbitrary provenance.
+async fn prepare_deploy_with_commit_sha(
+    opts: DeployOpts,
+    installer_commit_sha: Option<&str>,
+) -> Result<PreparedDeploy> {
     let plugin_dir = opts
         .plugin_dir
         .canonicalize()
@@ -4600,41 +4611,11 @@ pub async fn prepare_deploy(opts: DeployOpts) -> Result<PreparedDeploy> {
         validate_channel_binding("slack", channel)?;
     }
     let archive = pack_tar_gz(&plugin_dir)?;
-    let git_prefix = tokio::process::Command::new("git")
-        .args(["rev-parse", "--show-prefix"])
-        .current_dir(&plugin_dir)
-        .env_remove("GIT_DIR")
-        .env_remove("GIT_WORK_TREE")
-        .output()
-        .await
-        .ok()
-        .filter(|output| output.status.success())
-        .and_then(|output| String::from_utf8(output.stdout).ok())
-        .map(|prefix| PathBuf::from(prefix.trim_end_matches(['\r', '\n'])));
-    let git_status = tokio::process::Command::new("git")
-        .args([
-            "status",
-            "--porcelain=v1",
-            "-z",
-            "--no-renames",
-            "--untracked-files=all",
-            "--ignored=matching",
-            "--",
-            ".",
-        ])
-        .current_dir(&plugin_dir)
-        .env_remove("GIT_DIR")
-        .env_remove("GIT_WORK_TREE")
-        .output()
-        .await
-        .ok();
-    let commit_sha = match (git_prefix, git_status) {
-        (Some(prefix), Some(output))
-            if output.status.success()
-                && git_status_is_clean_for_pack(&plugin_dir, &prefix, &output.stdout) =>
-        {
-            tokio::process::Command::new("git")
-                .args(["rev-parse", "HEAD"])
+    let commit_sha = match installer_commit_sha {
+        Some(commit_sha) => Some(commit_sha.to_string()),
+        None => {
+            let git_prefix = tokio::process::Command::new("git")
+                .args(["rev-parse", "--show-prefix"])
                 .current_dir(&plugin_dir)
                 .env_remove("GIT_DIR")
                 .env_remove("GIT_WORK_TREE")
@@ -4643,10 +4624,45 @@ pub async fn prepare_deploy(opts: DeployOpts) -> Result<PreparedDeploy> {
                 .ok()
                 .filter(|output| output.status.success())
                 .and_then(|output| String::from_utf8(output.stdout).ok())
-                .map(|sha| sha.trim().to_string())
-                .filter(|sha| !sha.is_empty())
+                .map(|prefix| PathBuf::from(prefix.trim_end_matches(['\r', '\n'])));
+            let git_status = tokio::process::Command::new("git")
+                .args([
+                    "status",
+                    "--porcelain=v1",
+                    "-z",
+                    "--no-renames",
+                    "--untracked-files=all",
+                    "--ignored=matching",
+                    "--",
+                    ".",
+                ])
+                .current_dir(&plugin_dir)
+                .env_remove("GIT_DIR")
+                .env_remove("GIT_WORK_TREE")
+                .output()
+                .await
+                .ok();
+            match (git_prefix, git_status) {
+                (Some(prefix), Some(output))
+                    if output.status.success()
+                        && git_status_is_clean_for_pack(&plugin_dir, &prefix, &output.stdout) =>
+                {
+                    tokio::process::Command::new("git")
+                        .args(["rev-parse", "HEAD"])
+                        .current_dir(&plugin_dir)
+                        .env_remove("GIT_DIR")
+                        .env_remove("GIT_WORK_TREE")
+                        .output()
+                        .await
+                        .ok()
+                        .filter(|output| output.status.success())
+                        .and_then(|output| String::from_utf8(output.stdout).ok())
+                        .map(|sha| sha.trim().to_string())
+                        .filter(|sha| !sha.is_empty())
+                }
+                _ => None,
+            }
         }
-        _ => None,
     };
     let client = ApiClient::new(&opts.api_url, &opts.api_key)?;
     // Resolve a declared target, if one was named (ADR-0089). The file is sent
@@ -4957,7 +4973,17 @@ pub async fn deploy_prepared(prepared: PreparedDeploy) -> Result<DeployOutput> {
 }
 
 pub async fn deploy(opts: DeployOpts) -> Result<DeployOutput> {
-    deploy_prepared(prepare_deploy(opts).await?).await
+    deploy_with_commit_sha(opts, None).await
+}
+
+/// Installer-only deploy entry point. A stamped binary commit takes precedence
+/// over bundle-directory Git discovery; `None` preserves ordinary deploy
+/// behavior for no-Git builds.
+pub(crate) async fn deploy_with_commit_sha(
+    opts: DeployOpts,
+    installer_commit_sha: Option<&str>,
+) -> Result<DeployOutput> {
+    deploy_prepared(prepare_deploy_with_commit_sha(opts, installer_commit_sha).await?).await
 }
 
 /// Output of `<tier> deploy`: the deployed agent/version/channel/bundle/deployment

--- a/cli/src/examples.rs
+++ b/cli/src/examples.rs
@@ -1358,22 +1358,25 @@ async fn deploy_embedded_sre_bot(
         "the platform API at {} is unreachable; confirm the Curie release with `curie cluster status` and retry this installer",
         connection.api_url
     );
-    commands::deploy(DeployOpts {
-        agent: None,
-        target: None,
-        plugin_dir: bundle_dir.to_path_buf(),
-        api_url: connection.api_url.clone(),
-        api_key: connection.api_key.clone(),
-        slack_channel: slack_channel.map(str::to_string),
-        repo: None,
-        workspace: commands::WorkspaceIntent::Preserve,
-        env: None,
-        label: None,
-        secret: vec![],
-        secret_binding_supported: false,
-        connect_hint,
-        tier: DeployTier::Cluster,
-    })
+    commands::deploy_with_commit_sha(
+        DeployOpts {
+            agent: None,
+            target: None,
+            plugin_dir: bundle_dir.to_path_buf(),
+            api_url: connection.api_url.clone(),
+            api_key: connection.api_key.clone(),
+            slack_channel: slack_channel.map(str::to_string),
+            repo: None,
+            workspace: commands::WorkspaceIntent::Preserve,
+            env: None,
+            label: None,
+            secret: vec![],
+            secret_binding_supported: false,
+            connect_hint,
+            tier: DeployTier::Cluster,
+        },
+        crate::artifacts::commit_sha(),
+    )
     .await
 }
 

--- a/cli/tests/example_sre_bot_install.rs
+++ b/cli/tests/example_sre_bot_install.rs
@@ -1524,6 +1524,41 @@ fn successful_install_uploads_only_the_resolved_tempo_index_digest() {
 }
 
 #[test]
+fn install_records_the_current_commit_sha_on_the_created_version() {
+    let fixture = Fixture::with_modes(
+        nodes(vec![node("node-a", "4Gi", true)]),
+        pods(vec![]),
+        "success",
+        "success",
+        "success",
+    );
+    let output = fixture.run(&[]);
+    let text = shown(&output);
+    assert!(
+        output.status.success(),
+        "full install fixture must deploy: {text}"
+    );
+
+    let version_request = fixture
+        .api
+        .recorded()
+        .into_iter()
+        .find(|request| {
+            request.method == "POST" && request.path == format!("/agents/{AGENT_ID}/versions")
+        })
+        .expect("the installer must create a version");
+    let body: Value = serde_json::from_slice(&version_request.body)
+        .expect("the version-create request body must be valid JSON");
+    let commit_sha = body["commit_sha"]
+        .as_str()
+        .expect("the version-create request must record the installer commit SHA");
+    assert!(
+        commit_sha.len() == 40 && commit_sha.bytes().all(|byte| byte.is_ascii_hexdigit()),
+        "the recorded commit SHA must be a 40-character ASCII hex value: {commit_sha:?}"
+    );
+}
+
+#[test]
 fn released_binary_path_uses_cached_chart_and_embedded_assets_outside_checkout() {
     let fixture = Fixture::with_modes(
         nodes(vec![node("node-a", "4Gi", true)]),

--- a/cli/tests/example_sre_bot_install.rs
+++ b/cli/tests/example_sre_bot_install.rs
@@ -1549,13 +1549,26 @@ fn install_records_the_current_commit_sha_on_the_created_version() {
         .expect("the installer must create a version");
     let body: Value = serde_json::from_slice(&version_request.body)
         .expect("the version-create request body must be valid JSON");
-    let commit_sha = body["commit_sha"]
-        .as_str()
-        .expect("the version-create request must record the installer commit SHA");
-    assert!(
-        commit_sha.len() == 40 && commit_sha.bytes().all(|byte| byte.is_ascii_hexdigit()),
-        "the recorded commit SHA must be a 40-character ASCII hex value: {commit_sha:?}"
-    );
+    match option_env!("CURIE_BUILD_COMMIT") {
+        Some(expected_commit_sha) => {
+            let commit_sha = body["commit_sha"]
+                .as_str()
+                .expect("the version-create request must record the installer commit SHA");
+            assert_eq!(
+                commit_sha, expected_commit_sha,
+                "the installer must forward this binary's build commit"
+            );
+            assert!(
+                commit_sha.len() == 40 && commit_sha.bytes().all(|byte| byte.is_ascii_hexdigit()),
+                "the recorded commit SHA must be a 40-character ASCII hex value: {commit_sha:?}"
+            );
+        }
+        None => assert_eq!(
+            body.get("commit_sha"),
+            Some(&Value::Null),
+            "a binary built without Git provenance must send a JSON null commit SHA"
+        ),
+    }
 }
 
 #[test]


### PR DESCRIPTION
Fixes #2128.

Installer-built SRE bot versions now forward the binary's clean source commit into the existing deploy/version flow, allowing self-upgrade to compare the installed revision. Dirty and no-Git builds intentionally record no provenance.

Done check:
- [x] Regression committed before implementation (`572a384ee`)
- [x] `cargo fmt --check`, `cargo clippy -- -D warnings`, and `cargo test --test example_sre_bot_install` (39 passed)
- [x] Installer fixture exercised both stamped and dirty-tree/no-provenance branches
- [x] Independent code and scope reviews completed; findings reconciled
- [x] No cluster, staging, production, release, or publish action