### PR TITLE
Add authenticated approval principal credentials

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -1274,6 +1274,52 @@
         "title": "ApprovalOut",
         "type": "object"
       },
+      "ApprovalPrincipalMint": {
+        "description": "Administrative request to mint one operator approval credential.",
+        "properties": {
+          "subject": {
+            "minLength": 1,
+            "title": "Subject",
+            "type": "string"
+          }
+        },
+        "required": [
+          "subject"
+        ],
+        "title": "ApprovalPrincipalMint",
+        "type": "object"
+      },
+      "ApprovalPrincipalOut": {
+        "description": "One-time delivery of a short-lived operator approval credential.",
+        "properties": {
+          "expires_at": {
+            "format": "date-time",
+            "title": "Expires At",
+            "type": "string"
+          },
+          "kind": {
+            "const": "operator",
+            "default": "operator",
+            "title": "Kind",
+            "type": "string"
+          },
+          "subject": {
+            "title": "Subject",
+            "type": "string"
+          },
+          "token": {
+            "title": "Token",
+            "type": "string"
+          }
+        },
+        "required": [
+          "token",
+          "subject",
+          "expires_at"
+        ],
+        "title": "ApprovalPrincipalOut",
+        "type": "object"
+      },
       "ApprovalRequest": {
         "description": "A durable approval request (#244), created by the worker when a run ends\nawaiting-approval.\n\n``dedupe_key`` is the triggering event id, so a redelivered turn adopts the\nexisting record instead of forking a second one. ``route``/``card_channel``\n(#247) record the manifest route the request named and the channel the worker\nrouted the card to after binding resolution; the authorizer proves membership\nagainst ``card_channel``. ``gate_kind``/``granted_tool`` are the durable gate\nprovenance (#544, Decision C) written by the runner; both stay optional for\nthe rolling-deploy window.\n\n``reply_kind``/``reply_channel`` are the durable twin of ``ReplyHandle``'s\nrouting pair (ADR-0096), and ``reply_adapter`` the durable twin of its egress\nselector. ``reply_kind`` is REQUIRED, deliberately unlike ``gate_kind`` above:\nan absent kind puts the silent misroute back on the resume path, where it is\nleast observable, and ADR-0096 phase 2 buys the right to reject it with a\nquiescent cutover rather than a rolling-deploy window. ``reply_adapter`` is\nnullable because ``slack`` legitimately has no adapter -- its route is the\nworker's configured Slack origin.",
         "properties": {
@@ -7933,6 +7979,66 @@
           }
         },
         "summary": "Create Approval",
+        "tags": [
+          "approvals"
+        ]
+      }
+    },
+    "/approvals/principals/operator": {
+      "post": {
+        "description": "Mint an operator credential; the platform key authorizes issuance only.\n\nThe token is returned once and marked non-cacheable.  Resolution will\nauthenticate the subject from this credential rather than accepting a\ncaller-supplied actor string.",
+        "operationId": "mint_operator_principal_approvals_principals_operator_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApprovalPrincipalMint"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApprovalPrincipalOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Mint Operator Principal",
         "tags": [
           "approvals"
         ]

--- a/apps/api/src/curie_api/approval_principal.py
+++ b/apps/api/src/curie_api/approval_principal.py
@@ -1,0 +1,129 @@
+"""Authenticated principals for approval resolution (ADR-0106, #1531).
+
+An approval principal is a short-lived HMAC credential, signed with the
+platform API key but accepted only by the approval resolver.  Its subject and
+proof kind are claims in the credential, never values supplied in a resolution
+body.  ``chat`` principals also attest the channel Slack delivered with the
+interaction; ``operator`` principals deliberately cannot assert a channel.
+"""
+
+from __future__ import annotations
+
+import hmac
+import json
+import time
+from dataclasses import dataclass
+from typing import Literal
+
+from .sandbox_token import _b64url, _b64url_decode, _signature
+
+_PREFIX = "apr"
+APPROVE_SCOPE = "approval.resolve"
+OPERATOR_TOKEN_TTL_SECONDS = 12 * 60 * 60
+PrincipalKind = Literal["chat", "operator"]
+
+
+@dataclass(frozen=True)
+class ApprovalPrincipalClaims:
+    """The authenticated identity and evidence carried by one credential."""
+
+    subject: str
+    kind: PrincipalKind
+    actor_channel: str | None
+
+
+def mint(
+    api_key: str,
+    *,
+    subject: str,
+    kind: PrincipalKind,
+    scope: str,
+    exp: int,
+    actor_channel: str | None = None,
+) -> str:
+    """Mint a strict approval-principal credential.
+
+    A chat attestation is meaningful only with its channel.  An operator token
+    carries no channel by design, so it can satisfy only an explicit-user
+    approver set rather than manufacturing channel-membership evidence.
+    """
+
+    if not isinstance(subject, str) or not subject.strip():
+        raise ValueError("approval principal subject must be non-empty")
+    if kind not in ("chat", "operator"):
+        raise ValueError("approval principal kind must be chat or operator")
+    if not isinstance(exp, int) or isinstance(exp, bool):
+        raise ValueError("approval principal expiry must be an integer")
+    if kind == "chat":
+        if not isinstance(actor_channel, str) or not actor_channel.strip():
+            raise ValueError("chat approval principals must attest a channel")
+    elif actor_channel is not None:
+        raise ValueError("operator approval principals cannot attest a channel")
+
+    payload = json.dumps(
+        {
+            "sub": subject,
+            "kind": kind,
+            "actor_channel": actor_channel,
+            "scope": scope,
+            "exp": exp,
+        },
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode()
+    payload_seg = _b64url(payload)
+    signing_input = f"{_PREFIX}.{payload_seg}"
+    return f"{signing_input}.{_signature(api_key, signing_input)}"
+
+
+def verify_claims(
+    token: str,
+    api_key: str,
+    *,
+    scope: str,
+    now: int | None = None,
+) -> ApprovalPrincipalClaims | None:
+    """Return authenticated claims, or ``None`` for every invalid token."""
+
+    try:
+        prefix, payload_seg, sig_seg = token.split(".")
+    except (ValueError, AttributeError, TypeError):
+        return None
+    if prefix != _PREFIX:
+        return None
+    expected_sig = _signature(api_key, f"{_PREFIX}.{payload_seg}")
+    try:
+        signature_ok = hmac.compare_digest(sig_seg, expected_sig)
+    except TypeError:
+        return None
+    if not signature_ok:
+        return None
+    try:
+        payload = json.loads(_b64url_decode(payload_seg))
+    except (ValueError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict) or payload.get("scope") != scope:
+        return None
+    subject = payload.get("sub")
+    kind = payload.get("kind")
+    actor_channel = payload.get("actor_channel")
+    exp = payload.get("exp")
+    if not isinstance(subject, str) or not subject.strip():
+        return None
+    if kind not in ("chat", "operator"):
+        return None
+    if not isinstance(exp, int) or isinstance(exp, bool):
+        return None
+    current = now if now is not None else int(time.time())
+    if exp <= current:
+        return None
+    if kind == "chat":
+        if not isinstance(actor_channel, str) or not actor_channel.strip():
+            return None
+    elif actor_channel is not None:
+        return None
+    return ApprovalPrincipalClaims(
+        subject=subject,
+        kind=kind,
+        actor_channel=actor_channel,
+    )

--- a/apps/api/src/curie_api/routers/approvals.py
+++ b/apps/api/src/curie_api/routers/approvals.py
@@ -15,21 +15,27 @@ on the server that owns the record, never inside the sandbox.
 
 import logging
 import uuid
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 from curie_telemetry import operation_span, record_metric
 from fastapi import APIRouter, Depends, HTTPException, Response, status
 from opentelemetry.trace import SpanKind
 from sqlalchemy.exc import IntegrityError
 
-from .. import crud
+from .. import approval_principal, crud
 from ..auth import require_api_key
 from ..authorizer import authorize_approval
 from ..config import get_settings
 from ..deps import ApproverSetSelectorDep, ResumeQueueDep, SessionDep
 from ..models import Approval, ApprovalStatus
 from ..resumequeue import build_expiry_resume_turn, build_resume_turn
-from ..schemas import ApprovalAuditOut, ApprovalOut, ApprovalResolve
+from ..schemas import (
+    ApprovalAuditOut,
+    ApprovalOut,
+    ApprovalPrincipalMint,
+    ApprovalPrincipalOut,
+    ApprovalResolve,
+)
 from ..wirebody import ApprovalRequestBody
 
 logger = logging.getLogger(__name__)
@@ -37,6 +43,40 @@ logger = logging.getLogger(__name__)
 router = APIRouter(
     prefix="/approvals", tags=["approvals"], dependencies=[Depends(require_api_key)]
 )
+
+
+@router.post(
+    "/principals/operator",
+    response_model=ApprovalPrincipalOut,
+    status_code=status.HTTP_201_CREATED,
+)
+async def mint_operator_principal(
+    data: ApprovalPrincipalMint, response: Response
+) -> ApprovalPrincipalOut:
+    """Mint an operator credential; the platform key authorizes issuance only.
+
+    The token is returned once and marked non-cacheable.  Resolution will
+    authenticate the subject from this credential rather than accepting a
+    caller-supplied actor string.
+    """
+
+    now = datetime.now(UTC)
+    expires_at = now + timedelta(
+        seconds=approval_principal.OPERATOR_TOKEN_TTL_SECONDS
+    )
+    token = approval_principal.mint(
+        get_settings().api_key,
+        subject=data.subject,
+        kind="operator",
+        scope=approval_principal.APPROVE_SCOPE,
+        exp=int(expires_at.timestamp()),
+    )
+    response.headers["Cache-Control"] = "no-store"
+    return ApprovalPrincipalOut(
+        token=token,
+        subject=data.subject,
+        expires_at=expires_at,
+    )
 
 
 def _expired(approval: Approval) -> bool:

--- a/apps/api/src/curie_api/schemas.py
+++ b/apps/api/src/curie_api/schemas.py
@@ -1520,6 +1520,28 @@ class ApprovalResolve(BaseModel):
     actor_channel: str | None = None
 
 
+class ApprovalPrincipalMint(BaseModel):
+    """Administrative request to mint one operator approval credential."""
+
+    subject: str = Field(min_length=1)
+
+    @field_validator("subject")
+    @classmethod
+    def _nonblank_subject(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("subject must not be blank")
+        return value
+
+
+class ApprovalPrincipalOut(BaseModel):
+    """One-time delivery of a short-lived operator approval credential."""
+
+    token: str
+    subject: str
+    kind: Literal["operator"] = "operator"
+    expires_at: datetime
+
+
 class ApprovalOut(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 

--- a/apps/api/tests/test_approval_principal.py
+++ b/apps/api/tests/test_approval_principal.py
@@ -1,0 +1,157 @@
+"""Authenticated approval-principal credential contract (ADR-0106, #1531)."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from curie_api import approval_principal
+from curie_api.config import get_settings
+
+SUBJECT = "U0EXAMPLE1"
+CHANNEL = "C0EXAMPLE1"
+
+
+def test_operator_principal_round_trip_and_claim_shape() -> None:
+    token = approval_principal.mint(
+        get_settings().api_key,
+        subject=SUBJECT,
+        kind="operator",
+        scope=approval_principal.APPROVE_SCOPE,
+        exp=int(time.time()) + 60,
+    )
+
+    claims = approval_principal.verify_claims(
+        token,
+        get_settings().api_key,
+        scope=approval_principal.APPROVE_SCOPE,
+    )
+
+    assert claims == approval_principal.ApprovalPrincipalClaims(
+        subject=SUBJECT,
+        kind="operator",
+        actor_channel=None,
+    )
+
+
+def test_chat_principal_carries_attested_channel() -> None:
+    token = approval_principal.mint(
+        get_settings().api_key,
+        subject=SUBJECT,
+        kind="chat",
+        actor_channel=CHANNEL,
+        scope=approval_principal.APPROVE_SCOPE,
+        exp=int(time.time()) + 60,
+    )
+
+    claims = approval_principal.verify_claims(
+        token,
+        get_settings().api_key,
+        scope=approval_principal.APPROVE_SCOPE,
+    )
+
+    assert claims == approval_principal.ApprovalPrincipalClaims(
+        subject=SUBJECT,
+        kind="chat",
+        actor_channel=CHANNEL,
+    )
+
+
+def test_principal_token_fails_closed_on_tamper_expiry_scope_and_claim_shape() -> None:
+    api_key = get_settings().api_key
+    valid = approval_principal.mint(
+        api_key,
+        subject=SUBJECT,
+        kind="operator",
+        scope=approval_principal.APPROVE_SCOPE,
+        exp=200,
+    )
+    chat = approval_principal.mint(
+        api_key,
+        subject=SUBJECT,
+        kind="chat",
+        actor_channel=CHANNEL,
+        scope=approval_principal.APPROVE_SCOPE,
+        exp=200,
+    )
+
+    assert approval_principal.verify_claims(
+        valid + "x", api_key, scope=approval_principal.APPROVE_SCOPE, now=100
+    ) is None
+    assert approval_principal.verify_claims(
+        valid, api_key, scope=approval_principal.APPROVE_SCOPE, now=200
+    ) is None
+    assert approval_principal.verify_claims(
+        valid, api_key, scope="approval.read", now=100
+    ) is None
+    assert approval_principal.verify_claims(
+        chat, api_key, scope=approval_principal.APPROVE_SCOPE, now=100
+    ) == approval_principal.ApprovalPrincipalClaims(
+        subject=SUBJECT,
+        kind="chat",
+        actor_channel=CHANNEL,
+    )
+
+    # The mint itself refuses ambiguous credentials: chat must attest a channel,
+    # while operator credentials are never allowed to claim one.
+    for kwargs in (
+        {"kind": "chat"},
+        {"kind": "operator", "actor_channel": CHANNEL},
+        {"kind": "machine"},
+        {"kind": "operator", "subject": ""},
+    ):
+        values: dict[str, Any] = {
+            "subject": SUBJECT,
+            "kind": "operator",
+            "scope": approval_principal.APPROVE_SCOPE,
+            "exp": 200,
+            **kwargs,
+        }
+        try:
+            approval_principal.mint(api_key, **values)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError(f"mint accepted invalid approval claims: {values}")
+
+
+def test_operator_principal_mint_endpoint_is_platform_admin_only(
+    client: Any, auth_headers: dict[str, str]
+) -> None:
+    unauthenticated = client.post(
+        "/approvals/principals/operator", json={"subject": SUBJECT}
+    )
+    assert unauthenticated.status_code == 401
+
+    minted = client.post(
+        "/approvals/principals/operator",
+        headers=auth_headers,
+        json={"subject": SUBJECT},
+    )
+    assert minted.status_code == 201, minted.text
+    assert minted.headers["cache-control"] == "no-store"
+    body = minted.json()
+    assert body["subject"] == SUBJECT
+    assert body["kind"] == "operator"
+    assert body["expires_at"]
+    claims = approval_principal.verify_claims(
+        body["token"],
+        get_settings().api_key,
+        scope=approval_principal.APPROVE_SCOPE,
+    )
+    assert claims == approval_principal.ApprovalPrincipalClaims(
+        subject=SUBJECT,
+        kind="operator",
+        actor_channel=None,
+    )
+
+
+def test_operator_principal_mint_rejects_blank_subject(
+    client: Any, auth_headers: dict[str, str]
+) -> None:
+    rejected = client.post(
+        "/approvals/principals/operator",
+        headers=auth_headers,
+        json={"subject": "   "},
+    )
+    assert rejected.status_code == 422

--- a/packages/telemetry/schema/metrics.json
+++ b/packages/telemetry/schema/metrics.json
@@ -922,6 +922,7 @@
           "/agents/{agent_id}/versions/{version_id}/connectors",
           "/agents/{agent_id}/versions/{version_id}/files",
           "/approvals",
+          "/approvals/principals/operator",
           "/approvals/{approval_id}",
           "/approvals/{approval_id}/audit",
           "/approvals/{approval_id}/resolve",
@@ -983,7 +984,7 @@
           "5xx"
         ]
       },
-      "cardinality_bound": 2760
+      "cardinality_bound": 2800
     },
     "curie.http.server.request.duration": {
       "type": "histogram",
@@ -1025,6 +1026,7 @@
           "/agents/{agent_id}/versions/{version_id}/connectors",
           "/agents/{agent_id}/versions/{version_id}/files",
           "/approvals",
+          "/approvals/principals/operator",
           "/approvals/{approval_id}",
           "/approvals/{approval_id}/audit",
           "/approvals/{approval_id}/resolve",
@@ -1086,7 +1088,7 @@
           "5xx"
         ]
       },
-      "cardinality_bound": 2760
+      "cardinality_bound": 2800
     },
     "curie.http.server.active": {
       "type": "up_down_counter",
@@ -1128,6 +1130,7 @@
           "/agents/{agent_id}/versions/{version_id}/connectors",
           "/agents/{agent_id}/versions/{version_id}/files",
           "/approvals",
+          "/approvals/principals/operator",
           "/approvals/{approval_id}",
           "/approvals/{approval_id}/audit",
           "/approvals/{approval_id}/resolve",
@@ -1182,7 +1185,7 @@
           "OTHER"
         ]
       },
-      "cardinality_bound": 552
+      "cardinality_bound": 560
     },
     "curie.background.loop": {
       "type": "counter",

--- a/packages/telemetry/src/curie_telemetry/metrics.py
+++ b/packages/telemetry/src/curie_telemetry/metrics.py
@@ -174,6 +174,7 @@ _HTTP_OPERATIONS = [
     "/agents/{agent_id}/versions/{version_id}/connectors",
     "/agents/{agent_id}/versions/{version_id}/files",
     "/approvals",
+    "/approvals/principals/operator",
     "/approvals/{approval_id}",
     "/approvals/{approval_id}/audit",
     "/approvals/{approval_id}/resolve",


### PR DESCRIPTION
Adds the backward-compatible credential foundation required by accepted ADR-0106: strict HMAC approval-principal claims for operator and chat identities, plus an admin-only operator-token mint endpoint.

This PR deliberately does not change resolution behavior or callers. The dependent #1531 work will derive the resolver from these credentials, migrate Slack/CLI/console, then remove the legacy caller-asserted actor fields.

Refs #1531