### PR TITLE
Fix receipt classification for read-only tools

### DIFF
--- a/docs/approvals.md
+++ b/docs/approvals.md
@@ -35,9 +35,13 @@ that may write — any tool not explicitly `readOnlyHint=true`, including an unk
 unreachable surface — or when an explicit actionable approval gate exists. A bundle with
 no MCP tools, or only explicitly read-only MCP tools and no actionable gate, does not
 carry it: explain that the bundle cannot perform the action instead of fabricating a
-remediation request. `readOnlyHint` controls this tool advertisement only; it is not
-authorization and does not change gates or tool execution. Publication's dedicated
-approval flow and the state tools remain independent.
+remediation request. `readOnlyHint` is not authorization and does not change gates or
+tool execution. When a live probe explicitly reports it as `true`, Curie also adds that
+MCP tool's SDK-visible name to the read-only classifier: it emits no side-effect flag,
+does not take the no-retry-after-side-effects path, and creates no receipt line. A
+missing or `false` hint, an unknown surface, or a failed probe remains potentially
+write-capable and is classified conservatively. Publication's dedicated approval flow
+and the state tools remain independent.
 
 **Permission gate.** Configuration marks a tool approval-required, and the runner denies
 the call through the SDK's `can_use_tool` callback before it runs. The denied call never

--- a/docs/interfaces/approval/INTERFACE.md
+++ b/docs/interfaces/approval/INTERFACE.md
@@ -68,9 +68,13 @@ in code now:
   tool not explicitly `readOnlyHint=true`, including an unknown or unreachable surface — or
   when an explicit actionable approval gate exists. A surface with no MCP tools or only
   explicitly read-only tools carries no generic pager, because approval cannot unlock an
-  action it cannot perform. `readOnlyHint` makes this advertisement decision only: it is not
-  authorization and does not change gates or tool execution. Publication's dedicated
-  approval flow and state tools remain independent. When the pager is used, the turn ends
+  action it cannot perform. `readOnlyHint` is not authorization and does not change gates
+  or tool execution. A live probe that explicitly reports `readOnlyHint=true` also feeds
+  the MCP tool's SDK-visible name to the read-only classifier, suppressing the side-effect
+  flag, no-retry-after-side-effects classification, and therefore its receipt line. A
+  missing or `false` hint, an unknown surface, or a failed probe remains potentially
+  write-capable and is classified conservatively. Publication's dedicated approval flow
+  and state tools remain independent. When the pager is used, the turn ends
   `awaiting-approval`, the worker persists the record and suspends the sandbox
   (`kernel._pause_for_approval` — the first live use of the dormant ADR-0003 suspend path);
   resolution enqueues a resume turn onto the ordinary runs stream

--- a/runner/src/curie_runner/__main__.py
+++ b/runner/src/curie_runner/__main__.py
@@ -389,7 +389,12 @@ def build_runner(
         ceiling=config.ceiling,
         tracer=RunTracer(provider),
         classifier=SideEffectClassifier(
-            readonly_tools=harness.readonly_tools | observed_readonly_tools
+            readonly_tools=harness.readonly_tools
+            | (
+                observed_readonly_tools - approval_gate.required
+                if approval_gate is not None
+                else observed_readonly_tools
+            )
         ),
         trace_name=f"curie-run:{config.session.session_id}",
         session_id=config.session.session_id,

--- a/runner/src/curie_runner/__main__.py
+++ b/runner/src/curie_runner/__main__.py
@@ -281,38 +281,33 @@ def build_runner(
     )
 
     real_options: ClaudeAgentOptions | None = None
+    observed_readonly_tools: frozenset[str] = frozenset()
     if not fake_model:
-        # An actionable explicit gate already proves the generic pager is
-        # required, so avoid spawning or dialing every MCP server merely to
-        # reach the same conclusion. A publication-only gate deliberately does
-        # not take this shortcut: it has its own tool and still needs the MCP
-        # surface decision below.
-        carries_request_approval = carries_explicit_action_gate
-        if not carries_explicit_action_gate:
-            # The bundle's live MCP ``tools/list`` response is the actual
-            # advertised MCP surface. Only a complete response where every
-            # observed tool says readOnlyHint=true -- including a complete
-            # surface with zero MCP tools -- proves that this generic MCP pager
-            # cannot unlock an action. Built-in Claude tools are outside this
-            # capability decision. Missing hints, uninspectable declarations,
-            # and probe failures preserve the historical tool. The annotation
-            # remains a non-authoritative hint: it never authorizes or denies
-            # tool execution.
-            capability = anyio.run(
-                probe_mcp_tool_capability,
-                config.session.plugin_dir,
-                derived_mcp_servers,
-                sdk_env,
+        # The bundle's live MCP ``tools/list`` response is the actual advertised
+        # MCP surface. Probe even when an explicit gate already requires the
+        # generic pager: exact readOnlyHint=true observations also drive receipt
+        # and retry classification. Missing hints, uninspectable declarations,
+        # and probe failures preserve the historical fail-closed behavior. The
+        # annotation remains a non-authoritative hint: it never authorizes or
+        # denies tool execution.
+        capability = anyio.run(
+            probe_mcp_tool_capability,
+            config.session.plugin_dir,
+            derived_mcp_servers,
+            sdk_env,
+        )
+        observed_readonly_tools = capability.readonly_tools
+        carries_request_approval = (
+            carries_explicit_action_gate or capability.has_potential_write_tool
+        )
+        if not carries_request_approval:
+            logger.info(
+                "request_approval omitted: observed MCP surface has no actionable"
+                " tools tool_count=%d probe_complete=%s failures=%d",
+                capability.tool_count,
+                capability.complete,
+                len(capability.failures),
             )
-            carries_request_approval = capability.has_potential_write_tool
-            if not carries_request_approval:
-                logger.info(
-                    "request_approval omitted: observed MCP surface has no actionable"
-                    " tools tool_count=%d probe_complete=%s failures=%d",
-                    capability.tool_count,
-                    capability.complete,
-                    len(capability.failures),
-                )
 
         platform_servers = {
             **(
@@ -393,7 +388,9 @@ def build_runner(
         session_factory=factory,
         ceiling=config.ceiling,
         tracer=RunTracer(provider),
-        classifier=SideEffectClassifier(readonly_tools=harness.readonly_tools),
+        classifier=SideEffectClassifier(
+            readonly_tools=harness.readonly_tools | observed_readonly_tools
+        ),
         trace_name=f"curie-run:{config.session.session_id}",
         session_id=config.session.session_id,
         model=config.model,

--- a/runner/src/curie_runner/mcp_tool_capability.py
+++ b/runner/src/curie_runner/mcp_tool_capability.py
@@ -6,7 +6,8 @@ eventually perform. MCP already carries the relevant capability metadata on
 second bundle-format declaration that can drift from what a server publishes.
 The annotation is only a hint and is not used as an authorization decision:
 permission gates and tool execution are unchanged. It controls whether Curie's
-non-authoritative, model-invoked generic pager is advertised.
+non-authoritative, model-invoked generic pager is advertised and which exact
+runtime tool names are treated as read-only for receipts and retry safety.
 
 Only an entirely observed, explicitly read-only surface proves that the generic
 approval tool should be omitted. A complete surface with zero MCP tools also
@@ -38,6 +39,7 @@ from mcp.client.stdio import stdio_client
 from mcp.client.streamable_http import streamable_http_client
 from mcp.shared._httpx_utils import create_mcp_http_client
 from plugin_format import PluginManifest, resolve_manifest
+from plugin_format.approval_policy import connector_tool_prefix, effective_tool_prefix
 
 logger = logging.getLogger(__name__)
 
@@ -53,6 +55,7 @@ class McpToolCapabilityProbe:
     has_potential_write_tool: bool
     tool_count: int
     failures: tuple[str, ...] = ()
+    readonly_tools: frozenset[str] = frozenset()
 
 
 def _expand(value: str, env: Mapping[str, str]) -> str:
@@ -61,7 +64,9 @@ def _expand(value: str, env: Mapping[str, str]) -> str:
     return _VARIABLE.sub(lambda match: env.get(match.group(1), match.group(0)), value)
 
 
-def _bundle_server_configs(plugin_dir: Path) -> list[tuple[str, dict[str, Any]]]:
+def _bundle_server_configs(
+    plugin_dir: Path,
+) -> list[tuple[str, dict[str, Any], str]]:
     """Read both plugin MCP declaration surfaces without collapsing duplicates.
 
     Every declared server must be inspectable here. In particular, the plugin
@@ -71,7 +76,7 @@ def _bundle_server_configs(plugin_dir: Path) -> list[tuple[str, dict[str, Any]]]
     shapes raise and the caller conservatively retains ``request_approval``.
     """
 
-    def append_payload(payload: object, source: str) -> None:
+    def append_payload(payload: object, source: str, bundle_name: str) -> None:
         if not isinstance(payload, dict):
             raise ValueError(f"{source} MCP declaration is not an object")
         servers = payload.get("mcpServers", payload)
@@ -80,24 +85,35 @@ def _bundle_server_configs(plugin_dir: Path) -> list[tuple[str, dict[str, Any]]]
         for name, config in servers.items():
             if not isinstance(config, dict):
                 raise ValueError(f"{source} MCP server {name!r} is not an object")
-            configs.append((str(name), dict(config)))
+            server_name = str(name)
+            configs.append(
+                (
+                    server_name,
+                    dict(config),
+                    effective_tool_prefix(bundle_name, server_name),
+                )
+            )
 
-    configs: list[tuple[str, dict[str, Any]]] = []
+    configs: list[tuple[str, dict[str, Any], str]] = []
     manifest_path = resolve_manifest(plugin_dir)
+    bundle_name: str | None = None
     if manifest_path is not None:
         raw = json.loads(manifest_path.read_text(encoding="utf-8"))
         manifest = PluginManifest.model_validate(raw)
+        bundle_name = manifest.name
         if isinstance(manifest.mcpServers, str):
             raise ValueError(
                 "plugin manifest mcpServers path strings cannot be inspected at runtime"
             )
         if manifest.mcpServers is not None:
-            append_payload(manifest.mcpServers, "plugin manifest")
+            append_payload(manifest.mcpServers, "plugin manifest", bundle_name)
 
     root_config = plugin_dir / ".mcp.json"
     if root_config.is_file():
+        if bundle_name is None:
+            raise ValueError("bundle MCP declarations require a manifest name")
         raw = json.loads(root_config.read_text(encoding="utf-8"))
-        append_payload(raw, ".mcp.json")
+        append_payload(raw, ".mcp.json", bundle_name)
     return configs
 
 
@@ -165,13 +181,15 @@ async def _server_streams(
 async def _probe_server(
     config: Mapping[str, Any],
     *,
+    tool_prefix: str,
     plugin_dir: Path | None,
     inherited_env: Mapping[str, str],
-) -> tuple[int, bool]:
-    """Return ``(tool_count, has_potential_write_tool)`` for one MCP server."""
+) -> tuple[int, bool, frozenset[str]]:
+    """Return count, write capability, and exact read-only runtime tool names."""
 
     count = 0
     has_potential_write = False
+    readonly_tools: set[str] = set()
     with anyio.fail_after(_PROBE_TIMEOUT_SECONDS):
         async with _server_streams(
             config, plugin_dir=plugin_dir, inherited_env=inherited_env
@@ -192,10 +210,16 @@ async def _probe_server(
                         for tool in result.tools
                     ):
                         has_potential_write = True
+                    readonly_tools.update(
+                        f"{tool_prefix}{tool.name}"
+                        for tool in result.tools
+                        if tool.annotations is not None
+                        and tool.annotations.readOnlyHint is True
+                    )
                     cursor = result.nextCursor
                     if not cursor:
                         break
-    return count, has_potential_write
+    return count, has_potential_write, frozenset(readonly_tools)
 
 
 async def probe_mcp_tool_capability(
@@ -208,12 +232,13 @@ async def probe_mcp_tool_capability(
     ``derived_servers`` is the connector map already produced for the SDK. A
     failed or unreadable source is an unknown surface, which keeps
     ``request_approval`` mounted by returning ``has_potential_write_tool=True``.
+    Exact read-only names from successful sibling servers remain available.
     """
 
     root = Path(plugin_dir) if plugin_dir is not None else None
     env = {**os.environ, **dict(inherited_env or {})}
     failures: list[str] = []
-    observations: list[tuple[int, bool]] = []
+    observations: list[tuple[int, bool, frozenset[str]]] = []
 
     try:
         declared = _bundle_server_configs(root) if root is not None else []
@@ -226,8 +251,8 @@ async def probe_mcp_tool_capability(
             failures=("bundle-config",),
         )
 
-    work: list[tuple[str, Mapping[str, Any], Path | None]] = [
-        (name, config, root) for name, config in declared
+    work: list[tuple[str, Mapping[str, Any], Path | None, str]] = [
+        (name, config, root, tool_prefix) for name, config, tool_prefix in declared
     ]
     for name, config in derived_servers.items():
         if not isinstance(config, Mapping):
@@ -237,12 +262,23 @@ async def probe_mcp_tool_capability(
                 name,
             )
             continue
-        work.append((str(name), config, None))
+        server_name = str(name)
+        work.append((server_name, config, None, connector_tool_prefix(server_name)))
 
-    async def inspect(name: str, config: Mapping[str, Any], cwd: Path | None) -> None:
+    async def inspect(
+        name: str,
+        config: Mapping[str, Any],
+        cwd: Path | None,
+        tool_prefix: str,
+    ) -> None:
         try:
             observations.append(
-                await _probe_server(config, plugin_dir=cwd, inherited_env=env)
+                await _probe_server(
+                    config,
+                    tool_prefix=tool_prefix,
+                    plugin_dir=cwd,
+                    inherited_env=env,
+                )
             )
         except Exception as exc:
             failures.append(name)
@@ -253,14 +289,20 @@ async def probe_mcp_tool_capability(
             )
 
     async with anyio.create_task_group() as task_group:
-        for name, config, cwd in work:
-            task_group.start_soon(inspect, name, config, cwd)
+        for name, config, cwd, tool_prefix in work:
+            task_group.start_soon(inspect, name, config, cwd, tool_prefix)
 
-    tool_count = sum(count for count, _write in observations)
-    has_write = bool(failures) or any(write for _count, write in observations)
+    tool_count = sum(count for count, _write, _readonly in observations)
+    has_write = bool(failures) or any(write for _count, write, _readonly in observations)
+    readonly_tools = frozenset(
+        tool
+        for _count, _write, observed_readonly in observations
+        for tool in observed_readonly
+    )
     return McpToolCapabilityProbe(
         complete=not failures,
         has_potential_write_tool=has_write,
         tool_count=tool_count,
         failures=tuple(sorted(set(failures))),
+        readonly_tools=readonly_tools,
     )

--- a/runner/src/curie_runner/side_effects.py
+++ b/runner/src/curie_runner/side_effects.py
@@ -55,6 +55,7 @@ CLAUDE_READONLY_TOOLS: frozenset[str] = frozenset(
         "NotebookRead",
         "WebFetch",
         "WebSearch",
+        "ToolSearch",
         "TodoRead",
     }
 )

--- a/runner/tests/test_approval_gate_enforcement.py
+++ b/runner/tests/test_approval_gate_enforcement.py
@@ -84,6 +84,7 @@ from curie_runner.fake import FakeModelSession
 from curie_runner.otel import RunTracer
 from curie_runner.session import SessionRunner
 from curie_runner.side_effects import SideEffectClassifier
+from curie_runner.translate import TurnState, translate_message
 
 _BUDGET = '{"max_output_tokens_per_run": 10000, "max_usd_per_day": 1.0}'
 _CAPABILITY_SERVER = Path(__file__).parent / "fixtures" / "mcp_tool_capability_server.py"
@@ -880,23 +881,64 @@ def test_boot_keeps_request_approval_for_an_observed_write_capable_bundle(
     assert options.mcp_servers[APPROVAL_SERVER_NAME]["name"] == APPROVAL_SERVER_NAME
 
 
-def test_boot_keeps_request_approval_for_an_explicit_gate_on_a_read_only_surface(
+def test_explicit_gate_keeps_pager_and_annotations_classify_receipt_actions(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    plugin_dir = _bundle(tmp_path, gates=["Bash"])
-    _add_capability_server(plugin_dir, "read-only")
+    monkeypatch.setattr(boot, "ClaudeAgentSession", _CapturedSession)
+    expected_flags = {
+        "read-only": [],
+        "write": ["mcp__operations__inspect_or_change"],
+        "unknown": ["mcp__operations__inspect_or_change"],
+    }
+    read_only_runner: SessionRunner | None = None
 
-    async def unexpected_probe(*_args: Any, **_kwargs: Any) -> typing.NoReturn:
-        raise AssertionError("an actionable explicit gate must skip the MCP probe")
+    for mode, flagged_tools in expected_flags.items():
+        plugin_dir = _bundle(tmp_path / mode, gates=["Bash"])
+        _add_capability_server(plugin_dir, mode)
 
-    monkeypatch.setattr(boot, "probe_mcp_tool_capability", unexpected_probe)
+        runner = build_runner(_config(plugin_dir))
+        if mode == "read-only":
+            read_only_runner = runner
+        session = runner._factory()
+        assert isinstance(session, _CapturedSession)
 
-    options = _options_from_boot(monkeypatch, _config(plugin_dir))
+        # An explicit actionable gate retains the pager regardless of MCP hints.
+        assert APPROVAL_SERVER_NAME in session.options.mcp_servers
+        assert "request_approval" in anyio.run(
+            _mcp_tool_names,
+            session.options.mcp_servers[APPROVAL_SERVER_NAME],
+        )
 
-    assert APPROVAL_SERVER_NAME in options.mcp_servers
-    assert "request_approval" in anyio.run(
-        _mcp_tool_names, options.mcp_servers[APPROVAL_SERVER_NAME]
+        tool = "mcp__operations__inspect_or_change"
+        events = translate_message(
+            AssistantMessage(
+                content=[ToolUseBlock(id=f"call-{mode}", name=tool, input={})],
+                model="m",
+            ),
+            TurnState(),
+            runner._classifier,
+            None,
+        )
+        assert [event.tool for event in events if event.type == "side_effect_flag"] == (
+            flagged_tools
+        )
+
+    # The annotation is exact and fail-closed: it cannot bless an unadvertised
+    # tool merely because that call shares the same MCP server.
+    assert read_only_runner is not None
+    unadvertised = "mcp__operations__not_advertised"
+    events = translate_message(
+        AssistantMessage(
+            content=[ToolUseBlock(id="call-unadvertised", name=unadvertised, input={})],
+            model="m",
+        ),
+        TurnState(),
+        read_only_runner._classifier,
+        None,
     )
+    assert [event.tool for event in events if event.type == "side_effect_flag"] == [
+        unadvertised
+    ]
 
 
 def test_publish_only_gate_does_not_recreate_the_generic_pager(

--- a/runner/tests/test_approval_gate_enforcement.py
+++ b/runner/tests/test_approval_gate_enforcement.py
@@ -941,6 +941,46 @@ def test_explicit_gate_keeps_pager_and_annotations_classify_receipt_actions(
     ]
 
 
+def test_explicit_tool_gate_overrides_its_read_only_annotation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(boot, "ClaudeAgentSession", _CapturedSession)
+    tool = "mcp__plugin_approval-demo_operations__inspect_or_change"
+    cases = (
+        ("tool-gated", tool, [tool]),
+        # Control: a gate on an unrelated built-in must not turn this annotated
+        # MCP read into a receipt mutation.
+        ("bash-gated", "Bash", []),
+    )
+
+    for directory, gated_tool, expected_flags in cases:
+        plugin_dir = _bundle(tmp_path / directory)
+        _add_capability_server(plugin_dir, "read-only")
+        runner = build_runner(
+            _config(plugin_dir, CURIE_APPROVAL_REQUIRED_TOOLS=gated_tool)
+        )
+        session = runner._factory()
+        assert isinstance(session, _CapturedSession)
+        assert "request_approval" in anyio.run(
+            _mcp_tool_names,
+            session.options.mcp_servers[APPROVAL_SERVER_NAME],
+        )
+
+        events = translate_message(
+            AssistantMessage(
+                content=[ToolUseBlock(id=f"call-{directory}", name=tool, input={})],
+                model="m",
+            ),
+            TurnState(),
+            runner._classifier,
+            None,
+        )
+
+        assert [event.tool for event in events if event.type == "side_effect_flag"] == (
+            expected_flags
+        )
+
+
 def test_publish_only_gate_does_not_recreate_the_generic_pager(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/runner/tests/test_approval_gate_enforcement.py
+++ b/runner/tests/test_approval_gate_enforcement.py
@@ -885,10 +885,11 @@ def test_explicit_gate_keeps_pager_and_annotations_classify_receipt_actions(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr(boot, "ClaudeAgentSession", _CapturedSession)
+    tool = "mcp__plugin_approval-demo_operations__inspect_or_change"
     expected_flags = {
         "read-only": [],
-        "write": ["mcp__operations__inspect_or_change"],
-        "unknown": ["mcp__operations__inspect_or_change"],
+        "write": [tool],
+        "unknown": [tool],
     }
     read_only_runner: SessionRunner | None = None
 
@@ -909,7 +910,6 @@ def test_explicit_gate_keeps_pager_and_annotations_classify_receipt_actions(
             session.options.mcp_servers[APPROVAL_SERVER_NAME],
         )
 
-        tool = "mcp__operations__inspect_or_change"
         events = translate_message(
             AssistantMessage(
                 content=[ToolUseBlock(id=f"call-{mode}", name=tool, input={})],
@@ -926,7 +926,7 @@ def test_explicit_gate_keeps_pager_and_annotations_classify_receipt_actions(
     # The annotation is exact and fail-closed: it cannot bless an unadvertised
     # tool merely because that call shares the same MCP server.
     assert read_only_runner is not None
-    unadvertised = "mcp__operations__not_advertised"
+    unadvertised = "mcp__plugin_approval-demo_operations__not_advertised"
     events = translate_message(
         AssistantMessage(
             content=[ToolUseBlock(id="call-unadvertised", name=unadvertised, input={})],

--- a/runner/tests/test_mcp_tool_capability.py
+++ b/runner/tests/test_mcp_tool_capability.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import anyio
 from curie_runner.mcp_tool_capability import probe_mcp_tool_capability
+from plugin_format.approval_policy import connector_tool_prefix
 
 _SERVER = Path(__file__).parent / "fixtures" / "mcp_tool_capability_server.py"
 
@@ -103,6 +104,61 @@ def test_mixed_read_only_and_write_tools_keep_write_capability(tmp_path: Path) -
     # remains available to the receipt classifier by its SDK-visible name.
     assert result.readonly_tools == frozenset(
         {"mcp__plugin_acme-bot_inventory__inspect_or_change"}
+    )
+
+
+def test_successful_read_only_names_survive_a_sibling_probe_failure(
+    tmp_path: Path,
+) -> None:
+    root = _bundle(tmp_path, mode="read-only")
+    (root / ".mcp.json").write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "inventory": {
+                        "command": sys.executable,
+                        "args": [str(_SERVER)],
+                        "env": {"CURIE_TEST_TOOL_MODE": "read-only"},
+                    },
+                    "operations": {"command": str(root / "missing-server")},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = _probe(root)
+
+    assert not result.complete
+    assert result.has_potential_write_tool
+    assert result.tool_count == 1
+    assert result.failures == ("operations",)
+    assert result.readonly_tools == frozenset(
+        {"mcp__plugin_acme-bot_inventory__inspect_or_change"}
+    )
+
+
+def test_derived_connector_read_only_tool_uses_connector_runtime_prefix(
+    tmp_path: Path,
+) -> None:
+    root = _bundle(tmp_path, mode="read-only")
+    (root / ".mcp.json").unlink()
+    connector_name = "inventory"
+    derived = {
+        connector_name: {
+            "command": sys.executable,
+            "args": [str(_SERVER)],
+            "env": {"CURIE_TEST_TOOL_MODE": "read-only"},
+        }
+    }
+
+    result = anyio.run(probe_mcp_tool_capability, root, derived)
+
+    assert result.complete
+    assert not result.has_potential_write_tool
+    assert result.tool_count == 1
+    assert result.readonly_tools == frozenset(
+        {f"{connector_tool_prefix(connector_name)}inspect_or_change"}
     )
 
 

--- a/runner/tests/test_mcp_tool_capability.py
+++ b/runner/tests/test_mcp_tool_capability.py
@@ -51,6 +51,9 @@ def test_all_tools_explicitly_read_only_proves_no_write_capability(tmp_path: Pat
     assert result.complete
     assert not result.has_potential_write_tool
     assert result.tool_count == 1
+    assert result.readonly_tools == frozenset(
+        {"mcp__operations__inspect_or_change"}
+    )
 
 
 def test_explicit_write_tool_keeps_write_capability(tmp_path: Path) -> None:
@@ -58,6 +61,7 @@ def test_explicit_write_tool_keeps_write_capability(tmp_path: Path) -> None:
 
     assert result.complete
     assert result.has_potential_write_tool
+    assert result.readonly_tools == frozenset()
 
 
 def test_missing_read_only_hint_is_conservatively_write_capable(tmp_path: Path) -> None:
@@ -65,6 +69,7 @@ def test_missing_read_only_hint_is_conservatively_write_capable(tmp_path: Path) 
 
     assert result.complete
     assert result.has_potential_write_tool
+    assert result.readonly_tools == frozenset()
 
 
 def test_mixed_read_only_and_write_tools_keep_write_capability(tmp_path: Path) -> None:
@@ -94,6 +99,11 @@ def test_mixed_read_only_and_write_tools_keep_write_capability(tmp_path: Path) -
     assert result.complete
     assert result.has_potential_write_tool
     assert result.tool_count == 2
+    # Even on a mixed surface that keeps the pager, the observed read-only tool
+    # remains available to the receipt classifier by its SDK-visible name.
+    assert result.readonly_tools == frozenset(
+        {"mcp__inventory__inspect_or_change"}
+    )
 
 
 def test_manifest_mcp_path_string_is_an_unknown_surface(tmp_path: Path) -> None:
@@ -109,6 +119,7 @@ def test_manifest_mcp_path_string_is_an_unknown_surface(tmp_path: Path) -> None:
     assert not result.complete
     assert result.has_potential_write_tool
     assert result.failures == ("bundle-config",)
+    assert result.readonly_tools == frozenset()
 
 
 def test_malformed_server_entry_is_an_unknown_surface(tmp_path: Path) -> None:
@@ -123,6 +134,7 @@ def test_malformed_server_entry_is_an_unknown_surface(tmp_path: Path) -> None:
     assert not result.complete
     assert result.has_potential_write_tool
     assert result.failures == ("bundle-config",)
+    assert result.readonly_tools == frozenset()
 
 
 def test_unreachable_server_cannot_be_mistaken_for_read_only(tmp_path: Path) -> None:
@@ -145,6 +157,7 @@ def test_unreachable_server_cannot_be_mistaken_for_read_only(tmp_path: Path) -> 
     assert not result.complete
     assert result.has_potential_write_tool
     assert result.failures == ("operations",)
+    assert result.readonly_tools == frozenset()
 
 
 def test_no_mcp_servers_is_a_complete_empty_surface(tmp_path: Path) -> None:
@@ -156,3 +169,4 @@ def test_no_mcp_servers_is_a_complete_empty_surface(tmp_path: Path) -> None:
     assert result.complete
     assert not result.has_potential_write_tool
     assert result.tool_count == 0
+    assert result.readonly_tools == frozenset()

--- a/runner/tests/test_mcp_tool_capability.py
+++ b/runner/tests/test_mcp_tool_capability.py
@@ -52,7 +52,7 @@ def test_all_tools_explicitly_read_only_proves_no_write_capability(tmp_path: Pat
     assert not result.has_potential_write_tool
     assert result.tool_count == 1
     assert result.readonly_tools == frozenset(
-        {"mcp__operations__inspect_or_change"}
+        {"mcp__plugin_acme-bot_operations__inspect_or_change"}
     )
 
 
@@ -102,7 +102,7 @@ def test_mixed_read_only_and_write_tools_keep_write_capability(tmp_path: Path) -
     # Even on a mixed surface that keeps the pager, the observed read-only tool
     # remains available to the receipt classifier by its SDK-visible name.
     assert result.readonly_tools == frozenset(
-        {"mcp__inventory__inspect_or_change"}
+        {"mcp__plugin_acme-bot_inventory__inspect_or_change"}
     )
 
 

--- a/runner/tests/test_translate.py
+++ b/runner/tests/test_translate.py
@@ -54,6 +54,19 @@ def test_read_only_tool_notes_without_flag() -> None:
     assert [e.type for e in events] == ["tool_note"]
 
 
+def test_tool_search_notes_without_flag() -> None:
+    """#2130: Claude's tool-discovery read is not a receipt mutation."""
+
+    msg = AssistantMessage(
+        content=[ToolUseBlock(id="1", name="ToolSearch", input={"query": "resources"})],
+        model="m",
+    )
+
+    events = _translate(msg)
+
+    assert [event.type for event in events] == ["tool_note"]
+
+
 def test_result_success_is_final_done() -> None:
     msg = ResultMessage(
         subtype="success", duration_ms=1, duration_api_ms=1, is_error=False,


### PR DESCRIPTION
Fixes #2130.\n\nHonors explicit MCP read-only annotations for receipt/retry classification while preserving fail-closed unknowns and operator-gated tool receipts.