### PR TITLE
Discover the platform API from a bare curie doctor

### DIFF
--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -5581,7 +5581,7 @@ export const commandManifest = {
         {
           "env": "CURIE_API_URL",
           "global": false,
-          "help": "Platform API, to include the repo-binding check. Optional: every other check needs only kubectl and helm",
+          "help": "Platform API, to include the repo-binding check. Optional: omitted values are discovered from the release, same as sibling cluster verbs",
           "id": "api_url",
           "long": "api-url",
           "positional": false,
@@ -5590,7 +5590,7 @@ export const commandManifest = {
         {
           "env": "CURIE_API_KEY",
           "global": false,
-          "help": "API key for `--api-url`",
+          "help": "API key for `--api-url`. Optional: discovered from the release Secret when omitted",
           "id": "api_key",
           "long": "api-key",
           "positional": false,

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -5578,7 +5578,7 @@
         {
           "env": "CURIE_API_URL",
           "global": false,
-          "help": "Platform API, to include the repo-binding check. Optional: every other check needs only kubectl and helm",
+          "help": "Platform API, to include the repo-binding check. Optional: omitted values are discovered from the release, same as sibling cluster verbs",
           "id": "api_url",
           "long": "api-url",
           "positional": false,
@@ -5587,7 +5587,7 @@
         {
           "env": "CURIE_API_KEY",
           "global": false,
-          "help": "API key for `--api-url`",
+          "help": "API key for `--api-url`. Optional: discovered from the release Secret when omitted",
           "id": "api_key",
           "long": "api-key",
           "positional": false,

--- a/cli/schema/baseline/doctor.schema.json
+++ b/cli/schema/baseline/doctor.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schemas.curietech.ai/cli/doctor/v2.0.json",
+  "$id": "https://schemas.curietech.ai/cli/doctor/v2.1.json",
   "title": "curie doctor --json",
   "description": "What is set up, what is missing, and the command that fixes it. Read-only. Credentials appear as the NAME of the variable holding them, never as a value.",
   "type": "object",
@@ -13,6 +13,10 @@
     "ready": {
       "type": "boolean",
       "description": "True when no check is `missing`. A `not_applicable` check does not make an install unready -- the laptop rung has no cluster and is not misconfigured."
+    },
+    "deploys_verified": {
+      "type": "boolean",
+      "description": "True when git-push deploys were checked and every agent is repo-bound. Distinct from `ready`: a `not_applicable` repo-binding check does not make an install unready, but it also does not mean deploys were verified."
     },
     "checks": {
       "type": "array",

--- a/cli/schema/doctor.schema.json
+++ b/cli/schema/doctor.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://schemas.curietech.ai/cli/doctor/v2.0.json",
+  "$id": "https://schemas.curietech.ai/cli/doctor/v2.1.json",
   "title": "curie doctor --json",
   "description": "What is set up, what is missing, and the command that fixes it. Read-only. Credentials appear as the NAME of the variable holding them, never as a value.",
   "type": "object",
@@ -13,6 +13,10 @@
     "ready": {
       "type": "boolean",
       "description": "True when no check is `missing`. A `not_applicable` check does not make an install unready -- the laptop rung has no cluster and is not misconfigured."
+    },
+    "deploys_verified": {
+      "type": "boolean",
+      "description": "True when git-push deploys were checked and every agent is repo-bound. Distinct from `ready`: a `not_applicable` repo-binding check does not make an install unready, but it also does not mean deploys were verified."
     },
     "checks": {
       "type": "array",

--- a/cli/schema/index.json
+++ b/cli/schema/index.json
@@ -109,7 +109,7 @@
       "result": "DoctorOutput",
       "kind": "CliOutput",
       "schema": "doctor.schema.json",
-      "version": "2.0"
+      "version": "2.1"
     },
     {
       "result": "DryRunPlan",

--- a/cli/src/doctor.rs
+++ b/cli/src/doctor.rs
@@ -933,11 +933,15 @@ pub fn evaluate(f: &Facts) -> Vec<Check> {
         None => skipped(
             "repo-binding",
             "Repo binding",
-            "platform API not reached — pass --api-url/--api-key to include this",
+            "platform API not reached — could not discover it from the release; \
+             pass --api-url/--api-key to include this",
         ),
-        Some(agents) if agents.is_empty() => {
-            skipped("repo-binding", "Repo binding", "no agents deployed yet")
-        }
+        Some(agents) if agents.is_empty() => missing(
+            "repo-binding",
+            "Repo binding",
+            "no agents deployed yet — a push matches nothing and is silently ignored",
+            targeted("deploy", namespace, release) + " --plugin-dir . --repo <owner>/<name>",
+        ),
         Some(agents) => {
             let unbound: Vec<&str> = agents
                 .iter()
@@ -1049,12 +1053,11 @@ pub fn summary(checks: &[Check]) -> String {
                 missing items above."
             .to_string();
     }
-    // repo-binding reads NotApplicable in two situations that both reach this
-    // point: the platform API was never consulted (no --api-url/--api-key, an
-    // unreachable API, or a rejected key -- indistinguishable from here) or it
-    // was reached and found no agents deployed yet. Neither is evidence a git
-    // push deploys anything, so claiming "Fully wired" here asserted the one
-    // capability the run did not check (#1354).
+    // repo-binding reads NotApplicable only when the platform API was never
+    // consulted (discovery failed, an unreachable API, or a rejected key --
+    // indistinguishable from here). Zero agents is Missing, not this hedge
+    // (#1367). Claiming "Fully wired" here asserted the one capability the
+    // run did not check (#1354).
     if !has("repo-binding") {
         return "Answering in Slack. Git-push deploys are unverified -- see the \
                 Repo binding line above."
@@ -2526,10 +2529,44 @@ mod tests {
         assert!(s.contains("Git-push deploys are unverified"), "{s}");
     }
 
-    /// The sibling NotApplicable path: the platform API WAS reached but no
-    /// agents are deployed yet. A different reason, the same lack of evidence
-    /// that a git push deploys anything, so both paths must land on the same
-    /// hedge rather than one of them slipping through to "Fully wired".
+    /// #1367 item 2: zero agents is a proven negative, not an unknown. A push
+    /// matching no agent is answered `ignored` with nothing logged. Reporting
+    /// NotApplicable shared the unverified verdict with "the API was never
+    /// reached", which is the wrong epistemic state.
+    #[test]
+    fn no_agents_deployed_is_a_missing_binding() {
+        let f = Facts {
+            agents: Some(vec![]),
+            ..wired()
+        };
+        let checks = evaluate(&f);
+        let c = find(&checks, "repo-binding").clone();
+        assert_eq!(c.state, State::Missing, "{}", c.detail);
+        assert!(
+            c.detail.contains("no agents"),
+            "must say the API was reached and found none: {}",
+            c.detail
+        );
+        let fix = c.fix.expect("a proven negative must carry a fix");
+        assert!(
+            fix.contains("cluster deploy"),
+            "the fix is to deploy an agent: {fix}"
+        );
+        assert!(fix.contains("--repo"), "{fix}");
+        let s = summary(&checks);
+        assert!(!s.contains("Fully wired"), "{s}");
+        assert!(
+            s.contains("Git-push deploys are not wired yet"),
+            "zero agents must route to the actionable verdict: {s}"
+        );
+        assert!(
+            !s.contains("unverified"),
+            "unverified is reserved for never having checked: {s}"
+        );
+    }
+
+    /// The sibling NotApplicable path is only "the platform API was never
+    /// reached". Reaching it and finding no agents is item 2 above.
     #[test]
     fn no_agents_deployed_does_not_claim_fully_wired() {
         let f = Facts {
@@ -2539,7 +2576,51 @@ mod tests {
         let checks = evaluate(&f);
         let s = summary(&checks);
         assert!(!s.contains("Fully wired"), "{s}");
-        assert!(s.contains("Git-push deploys are unverified"), "{s}");
+        assert!(s.contains("Git-push deploys are not wired yet"), "{s}");
+    }
+
+    /// #1367 item 3: `ready` stays the "no check is missing" carve-out, so an
+    /// unverified deploy path still reports ready=true. A machine consumer
+    /// needs the other half of what the summary already says.
+    #[test]
+    fn deploys_verified_tracks_repo_binding_ok() {
+        let bound = Facts {
+            agents: Some(vec![("bot".into(), Some("acme/bot".into()))]),
+            ..wired()
+        };
+        let bound_out = DoctorOutput {
+            checks: evaluate(&bound),
+            summary: summary(&evaluate(&bound)),
+        };
+        assert_eq!(bound_out.to_json()["deploys_verified"], json!(true));
+
+        let unread = DoctorOutput {
+            checks: evaluate(&wired()),
+            summary: summary(&evaluate(&wired())),
+        };
+        assert_eq!(unread.to_json()["deploys_verified"], json!(false));
+        assert_eq!(
+            unread.to_json()["ready"],
+            json!(true),
+            "ready must keep the not_applicable carve-out: {}",
+            unread.to_json()
+        );
+
+        let empty = Facts {
+            agents: Some(vec![]),
+            ..wired()
+        };
+        let empty_out = DoctorOutput {
+            checks: evaluate(&empty),
+            summary: summary(&evaluate(&empty)),
+        };
+        assert_eq!(empty_out.to_json()["deploys_verified"], json!(false));
+        assert_eq!(
+            empty_out.to_json()["ready"],
+            json!(false),
+            "zero agents is missing, so ready flips: {}",
+            empty_out.to_json()
+        );
     }
 
     /// Found by running this against a real install. sre-bot serves its webhook
@@ -4418,6 +4499,10 @@ impl crate::ui::CliOutput for DoctorOutput {
         serde_json::json!({
             "summary": self.summary,
             "ready": self.checks.iter().all(|c| c.state != State::Missing),
+            "deploys_verified": self
+                .checks
+                .iter()
+                .any(|c| c.id == "repo-binding" && c.state == State::Ok),
             "checks": self.checks,
             "guidance": guidance(&self.checks),
         })
@@ -4443,7 +4528,48 @@ impl crate::ui::CliOutput for DoctorOutput {
     }
 }
 
-pub async fn doctor(namespace: &str, release: &str, api: Option<(&str, &str)>) -> DoctorOutput {
+/// Resolve the platform API connection doctor should use.
+///
+/// Explicit `--api-url`/`--api-key` (and their env vars, via clap) win.
+/// Omitted values are discovered from the release with the same helpers
+/// sibling cluster verbs use. Discovery errors are discarded: gather is
+/// failure-tolerant, and an unreachable API narrows the report to
+/// `agents: None` rather than failing the whole run (#1367).
+pub async fn resolve_api(
+    namespace: &str,
+    release: &str,
+    api_url: Option<&str>,
+    api_key: Option<&str>,
+) -> Option<(String, String)> {
+    let url = match nonempty(api_url) {
+        Some(url) => url.to_string(),
+        None => crate::ops::discover_api_url(namespace, release)
+            .await
+            .ok()?,
+    };
+    let key = match nonempty(api_key) {
+        Some(key) => key.to_string(),
+        None => crate::ops::discover_api_key(namespace, release)
+            .await
+            .ok()?,
+    };
+    Some((url, key))
+}
+
+fn nonempty(value: Option<&str>) -> Option<&str> {
+    value.map(str::trim).filter(|value| !value.is_empty())
+}
+
+pub async fn doctor(
+    namespace: &str,
+    release: &str,
+    api_url: Option<&str>,
+    api_key: Option<&str>,
+) -> DoctorOutput {
+    let resolved = resolve_api(namespace, release, api_url, api_key).await;
+    let api = resolved
+        .as_ref()
+        .map(|(url, key)| (url.as_str(), key.as_str()));
     let checks = evaluate(&gather(namespace, release, api).await);
     let summary = summary(&checks);
     DoctorOutput { checks, summary }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -886,11 +886,12 @@ enum Command {
         /// when one is present in this directory, otherwise `curie`.
         #[arg(long)]
         release: Option<String>,
-        /// Platform API, to include the repo-binding check. Optional: every
-        /// other check needs only kubectl and helm.
+        /// Platform API, to include the repo-binding check. Optional: omitted
+        /// values are discovered from the release, same as sibling cluster verbs.
         #[arg(long, env = "CURIE_API_URL")]
         api_url: Option<String>,
-        /// API key for `--api-url`.
+        /// API key for `--api-url`. Optional: discovered from the release Secret
+        /// when omitted.
         #[arg(long, env = "CURIE_API_KEY")]
         api_key: Option<String>,
     },
@@ -4819,8 +4820,18 @@ async fn run(command: Option<Command>) -> Result<()> {
             if let Some(announcement) = &target.announcement {
                 ui::ui().note(announcement);
             }
-            let api = api_url.as_deref().zip(api_key.as_deref());
-            emit(curie::doctor::doctor(&target.namespace, &target.release, api).await)
+            // Discover independently. `zip` required both flags, so a bare
+            // `curie doctor` never reached the platform API (#1367). Errors
+            // are discarded inside `doctor`: gather is failure-tolerant.
+            emit(
+                curie::doctor::doctor(
+                    &target.namespace,
+                    &target.release,
+                    api_url.as_deref(),
+                    api_key.as_deref(),
+                )
+                .await,
+            )
         }
         Some(Command::Diff { file, chart }) => {
             let cfg = curie::installation::Installation::load(&file)?;

--- a/cli/tests/doctor_api.rs
+++ b/cli/tests/doctor_api.rs
@@ -1,0 +1,303 @@
+//! Integration (#1367): `curie doctor` discovers its API connection the way
+//! sibling cluster verbs do, so a bare invocation can check repo binding.
+//!
+//! `zip(--api-url, --api-key)` in the dispatch arm is structurally invisible
+//! to `gather()`: handing it `None` is the same whether the operator omitted
+//! both flags or the handler refused to look them up. These run the real
+//! binary against stubbed kubectl/helm and a wire-level platform API.
+
+mod support;
+
+use std::ffi::OsString;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use support::{serve, MockServer, Response};
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_curie")
+}
+
+fn write_executable(path: &Path, body: &str) {
+    fs::write(path, body).expect("write stub executable");
+    let mut permissions = fs::metadata(path)
+        .expect("read stub metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions).expect("make stub executable");
+}
+
+/// Stub docker/kubectl/helm for a default `curie/curie` install.
+///
+/// `node_port` is the mock platform API's host port. Discovery prefers the UI
+/// `/api` proxy on that NodePort, same as `ops::discover_api_url`.
+fn install_cluster_stubs(tools: &Path, node_port: u16, api_key: &str) {
+    write_executable(tools.join("docker").as_path(), "#!/bin/sh\nexit 0\n");
+    write_executable(
+        tools.join("kubectl").as_path(),
+        &format!(
+            r#"#!/bin/sh
+case "$*" in
+  "config current-context") printf '%s\n' 'doctor-stub-context' ;;
+  *"config view"*) printf '%s\n' 'https://127.0.0.1:6443' ;;
+  *component=api*) printf '%s\n' 'curie-api' ;;
+  *"get svc curie-ui"*)
+    printf '%s\n' '{{"spec":{{"type":"NodePort","ports":[{{"port":80,"nodePort":{node_port}}}]}}}}'
+    ;;
+  *"get secret"*go-template*) printf '%s\n' '{api_key}' ;;
+  *"get secret"*) printf '%s\n' 'curie-secrets' ;;
+  *"get svc curie-api"*)
+    printf '%s\n' '{{"spec":{{"type":"NodePort","ports":[{{"port":8000,"nodePort":{node_port}}}]}}}}'
+    ;;
+  *nodePort*) printf '%s\n' '{node_port}' ;;
+  *) printf 'unexpected kubectl invocation: %s\n' "$*" >&2; exit 64 ;;
+esac
+"#,
+            node_port = node_port,
+            api_key = api_key
+        ),
+    );
+    write_executable(
+        tools.join("helm").as_path(),
+        r#"#!/bin/sh
+case "$*" in
+  version*) printf 'v3.14.0+gstub\n' ;;
+  list*) printf '%s\n' '[{"name":"curie","chart":"curie-0.8.2"}]' ;;
+  *"--all"*) printf '%s\n' '{"dispatcher":{"slack":{"appToken":"x","botToken":"x"}},"api":{"githubApp":{"appId":"1"}}}' ;;
+  "get values"*) printf '%s\n' '{"dispatcher":{"slack":{"appToken":"x","botToken":"x"}}}' ;;
+  *) printf 'unexpected helm invocation: %s\n' "$*" >&2; exit 64 ;;
+esac
+"#,
+    );
+}
+
+/// Cluster tools that answer helm/kubectl enough for doctor to leave the
+/// laptop rung, but cannot discover a platform API URL or key.
+fn install_cluster_without_api(tools: &Path) {
+    write_executable(tools.join("docker").as_path(), "#!/bin/sh\nexit 0\n");
+    write_executable(
+        tools.join("kubectl").as_path(),
+        r#"#!/bin/sh
+case "$*" in
+  "config current-context") printf '%s\n' 'doctor-stub-context' ;;
+  *) printf 'unexpected kubectl invocation: %s\n' "$*" >&2; exit 64 ;;
+esac
+"#,
+    );
+    write_executable(
+        tools.join("helm").as_path(),
+        r#"#!/bin/sh
+case "$*" in
+  version*) printf 'v3.14.0+gstub\n' ;;
+  list*) printf '%s\n' '[{"name":"curie","chart":"curie-0.8.2"}]' ;;
+  *"--all"*) printf '%s\n' '{}' ;;
+  "get values"*) printf '%s\n' '{}' ;;
+  *) printf 'unexpected helm invocation: %s\n' "$*" >&2; exit 64 ;;
+esac
+"#,
+    );
+}
+
+fn stub_path(tools: &Path) -> OsString {
+    let mut entries = vec![tools.to_path_buf()];
+    entries.extend(["/bin", "/usr/bin"].iter().map(PathBuf::from));
+    std::env::join_paths(entries).expect("join stub PATH")
+}
+
+fn bound_agents_json() -> String {
+    r#"[{"id":"11111111-1111-1111-1111-111111111111","name":"acme-bot","channels":[{"kind":"slack","address":"C0EXAMPLE1"}],"memory":false,"repo_full_name":"acme-corp/acme-bot"}]"#.to_string()
+}
+
+fn serve_agents() -> MockServer {
+    let body = bound_agents_json();
+    serve(move |req| {
+        if req.method == "GET" && (req.path == "/agents" || req.path == "/api/agents") {
+            return Response::json(200, &body);
+        }
+        Response::json(404, "{\"error\":\"unexpected\"}")
+    })
+}
+
+fn run_doctor(
+    dir: &Path,
+    path: &OsString,
+    extra_env: &[(&str, &str)],
+    args: &[&str],
+) -> (Option<i32>, String, String) {
+    let mut cmd = Command::new(bin());
+    cmd.current_dir(dir)
+        .args(args)
+        .env("PATH", path)
+        .env("LC_ALL", "C")
+        .env_remove("CURIE_API_URL")
+        .env_remove("CURIE_API_KEY");
+    for (key, value) in extra_env {
+        cmd.env(key, value);
+    }
+    let output = cmd.output().expect("run curie doctor");
+    (
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
+fn repo_binding(stdout: &str) -> serde_json::Value {
+    let json: serde_json::Value = serde_json::from_str(stdout)
+        .unwrap_or_else(|e| panic!("stdout must be doctor JSON, got {stdout:?}: {e}"));
+    json["checks"]
+        .as_array()
+        .expect("checks array")
+        .iter()
+        .find(|c| c["id"] == "repo-binding")
+        .cloned()
+        .expect("repo-binding check")
+}
+
+/// The missing-flag path: a cluster answers, but discovery cannot find a URL
+/// or key, and the operator passed neither flag. doctor must still report
+/// (exit 0), and repo-binding stays the unread NotApplicable — never a usage
+/// error for omitted flags.
+#[test]
+fn bare_doctor_does_not_require_api_flags() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let tools = temp.path().join("tools");
+    fs::create_dir_all(&tools).expect("tools dir");
+    install_cluster_without_api(&tools);
+
+    let (code, stdout, stderr) = run_doctor(
+        temp.path(),
+        &stub_path(&tools),
+        &[],
+        &["--color=never", "--json", "doctor"],
+    );
+    assert_eq!(code, Some(0), "stdout: {stdout}\nstderr: {stderr}");
+    let binding = repo_binding(&stdout);
+    assert_eq!(
+        binding["state"], "not_applicable",
+        "unread API is a fact, not a failure: {binding}"
+    );
+}
+
+/// The discovered-connection path: neither --api-url nor --api-key, but the
+/// release exposes a NodePort UI proxy and an apiKey Secret. Bare doctor must
+/// reach GET /agents and report the binding.
+#[test]
+fn bare_doctor_discovers_api_and_checks_repo_binding() {
+    let server = serve_agents();
+    let port: u16 = server
+        .base_url
+        .rsplit(':')
+        .next()
+        .expect("port")
+        .parse()
+        .expect("port number");
+    let temp = tempfile::tempdir().expect("tempdir");
+    let tools = temp.path().join("tools");
+    fs::create_dir_all(&tools).expect("tools dir");
+    install_cluster_stubs(&tools, port, "curie-stub-key");
+
+    let (code, stdout, stderr) = run_doctor(
+        temp.path(),
+        &stub_path(&tools),
+        &[],
+        &["--color=never", "--json", "doctor"],
+    );
+    assert_eq!(code, Some(0), "stdout: {stdout}\nstderr: {stderr}");
+    let binding = repo_binding(&stdout);
+    assert_eq!(
+        binding["state"], "ok",
+        "discovered API must drive repo-binding: {binding}\nstderr: {stderr}"
+    );
+    assert!(
+        binding["detail"]
+            .as_str()
+            .is_some_and(|d| d.contains("acme-bot") || d.contains("all bound")),
+        "must report the bound agent: {binding}"
+    );
+    let requests = server.recorded();
+    assert!(
+        requests.iter().any(|r| r.method == "GET"
+            && (r.path == "/agents" || r.path == "/api/agents")
+            && r.header("X-API-Key") == Some("curie-stub-key")),
+        "doctor must call GET /agents with the discovered key: {requests:?}"
+    );
+}
+
+/// One flag is not both: --api-url without --api-key used to zip to None.
+/// The key must be discovered from the release Secret.
+#[test]
+fn doctor_with_only_api_url_discovers_the_key() {
+    let server = serve_agents();
+    let temp = tempfile::tempdir().expect("tempdir");
+    let tools = temp.path().join("tools");
+    fs::create_dir_all(&tools).expect("tools dir");
+    // node_port is unused for URL (explicit) but the secret read still needs
+    // a working kubectl stub.
+    install_cluster_stubs(&tools, 1, "curie-stub-key");
+
+    let (code, stdout, stderr) = run_doctor(
+        temp.path(),
+        &stub_path(&tools),
+        &[],
+        &[
+            "--color=never",
+            "--json",
+            "doctor",
+            "--api-url",
+            &server.base_url,
+        ],
+    );
+    assert_eq!(code, Some(0), "stdout: {stdout}\nstderr: {stderr}");
+    let binding = repo_binding(&stdout);
+    assert_eq!(
+        binding["state"], "ok",
+        "explicit URL plus discovered key must reach the API: {binding}\nstderr: {stderr}"
+    );
+}
+
+/// The other half of zip: --api-key without --api-url must still discover the
+/// NodePort URL.
+#[test]
+fn doctor_with_only_api_key_discovers_the_url() {
+    let server = serve_agents();
+    let port: u16 = server
+        .base_url
+        .rsplit(':')
+        .next()
+        .expect("port")
+        .parse()
+        .expect("port number");
+    let temp = tempfile::tempdir().expect("tempdir");
+    let tools = temp.path().join("tools");
+    fs::create_dir_all(&tools).expect("tools dir");
+    install_cluster_stubs(&tools, port, "unused-secret-key");
+
+    let (code, stdout, stderr) = run_doctor(
+        temp.path(),
+        &stub_path(&tools),
+        &[],
+        &[
+            "--color=never",
+            "--json",
+            "doctor",
+            "--api-key",
+            "curie-stub-key",
+        ],
+    );
+    assert_eq!(code, Some(0), "stdout: {stdout}\nstderr: {stderr}");
+    let binding = repo_binding(&stdout);
+    assert_eq!(
+        binding["state"], "ok",
+        "explicit key plus discovered URL must reach the API: {binding}\nstderr: {stderr}"
+    );
+    let requests = server.recorded();
+    assert!(
+        requests
+            .iter()
+            .any(|r| r.header("X-API-Key") == Some("curie-stub-key")),
+        "must send the explicit key, not the secret: {requests:?}"
+    );
+}

--- a/cli/tests/json_contract.rs
+++ b/cli/tests/json_contract.rs
@@ -1912,6 +1912,11 @@ fn doctor_output_validates() {
         serde_json::Value::Bool(false),
         "a report carrying a missing check is not ready: {json}"
     );
+    assert_eq!(
+        json["deploys_verified"],
+        serde_json::Value::Bool(false),
+        "an unbound agent is not a verified deploy path: {json}"
+    );
 
     // This payload is pasted into issues; it must never carry a secret value.
     let rendered = serde_json::to_string(&json).expect("serializes");
@@ -1962,6 +1967,11 @@ fn doctor_ready_tracks_the_checks() {
         json["ready"],
         serde_json::Value::Bool(true),
         "a fully wired report is ready: {json}"
+    );
+    assert_eq!(
+        json["deploys_verified"],
+        serde_json::Value::Bool(true),
+        "all-bound agents mean git-push deploys were verified: {json}"
     );
 }
 


### PR DESCRIPTION
## Summary

`curie doctor` was the only cluster-scoped verb that required both `--api-url` and `--api-key` before it would talk to the platform API. A bare invocation therefore never checked repo binding, even on an install where git-push deploys work. This uses the same `discover_api_url` / `discover_api_key` helpers as sibling cluster verbs, discards discovery errors into the existing unread path, and classifies zero deployed agents as missing rather than unverified. `doctor --json` also grows an optional `deploys_verified` field (schema v2.1) so a machine consumer can tell wired from never-checked without redefining `ready`.

## Related issue

Closes #1367

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | Does not reach plugin packaging, the runner turn loop, ACI events, or skill eval/check | | |
| local | required | `curie doctor` verb output, exit code, and `--json` shape change | fake | `cargo test --offline --test doctor_api` at 54b740679: 4 passed. Bare doctor with stubbed discovery hit GET /agents and reported repo-binding `ok`; omitting flags against a cluster that cannot discover stayed `not_applicable` exit 0. `curie dev verify-fix-pin 54b740679 cli/tests/doctor_api.rs::bare_doctor_discovers_api_and_checks_repo_binding` printed PINNED. |
| local-release | n/a | Does not change released binary identity, install path, version pins, or release compose | | |
| cluster | n/a | Does not change chart templates, RBAC, securityContext, NetworkPolicy, sandbox claims, or init containers | | |
| live provider | n/a | Does not reach model routing, credential resolution, provider auth, or token/cost accounting | | |
| external integration | n/a | Does not reach Slack, git-push webhooks, connector OAuth, or a third-party API shape | | |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [ ] An ADR is added under `docs/adr/` if this is an architectural decision.
