### PR TITLE
Document upgrade connector RBAC escalation

### DIFF
--- a/examples/sre-bot/docs/PERMISSION-MAP.md
+++ b/examples/sre-bot/docs/PERMISSION-MAP.md
@@ -183,6 +183,22 @@ namespace if the token escapes the connector pod. It does not leave the pod, for
 the same reason the read connector drops `configuration_view`: the sandbox learns
 a URL and never holds a credential.
 
+### The service-account escalation RBAC also cannot prevent
+
+When this Role is installed beside `manifests/platform-upgrade-role.yaml`, a
+leaked `sre-bot-upgrader` token can create a Job with
+`spec.serviceAccountName: curie-platform-upgrader`. Kubernetes RBAC authorizes
+the Job create but does not restrict which service account the created Pod runs
+as, so that Job inherits the platform upgrader's namespace-wide permissions.
+The connector cannot make that request -- its one tool posts an operator-written
+CronJob template verbatim -- but a holder of the leaked token bypasses the
+connector entirely.
+
+This is a disclosure, not a permission change. Mitigate it with an admission
+policy that constrains service-account choice for the connector identity, by
+placing the wider identity in a separate namespace, or by avoiding a long-lived
+connector token. If none is acceptable, do not install this connector.
+
 ### Why this is not the abstraction entry 5 rejects
 
 Entry 4 rejects `upgrade_release(target_version)` -- a connector validating a

--- a/examples/sre-bot/manifests/upgrade-role.yaml
+++ b/examples/sre-bot/manifests/upgrade-role.yaml
@@ -19,6 +19,16 @@
 # with any command in this namespace, which is the namespace holding the
 # platform's API key.
 #
+# There is a second, more serious consequence when this manifest is installed
+# alongside `platform-upgrade-role.yaml`: RBAC does not restrict the
+# `spec.serviceAccountName` a Job creator chooses. A leaked `sre-bot-upgrader`
+# token can therefore create a Job that runs as `curie-platform-upgrader`,
+# inheriting that account's namespace-wide platform-upgrade permissions. The
+# connector cannot construct that Job, but a party holding its leaked token can.
+# Mitigations include an admission policy that constrains service-account choice
+# for this requesting identity, separating the wider identity into another
+# namespace, or avoiding a long-lived connector token.
+#
 # That is the same shape as `write-role.yaml`'s `patch` on `deployments`, which
 # RBAC also cannot separate from `set image`, and it gets the same answer: the
 # real ceiling is the connector, which exposes ONE tool that takes NO arguments


### PR DESCRIPTION
## Summary

- disclose that a leaked connector token can select the platform upgrader service account
- list deployment-side mitigation options without changing permissions

## Verification

- `git diff --check`
- `bash scripts/check-docs.sh`

Documentation only; no cluster, staging, production, release, or publish action was performed.