### PR TITLE
Fix four sre-bot example hygiene defects

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,6 +90,12 @@ jobs:
       # cluster-free static gate, so it runs alongside the docs gate.
       - name: Wire tolerance gate (_AciModel model_validate call sites)
         run: bash scripts/check-wire-tolerance.sh
+      # The platform-upgrade Job runs examples/sre-bot/platform-upgrade/upgrade.sh
+      # as its body. That script had no test and no CI; a helm upgrade the bot
+      # can start must be shellchecked on every PR, cheap and cluster-free, so
+      # this sits with the other static gates before the dev stack boots.
+      - name: Shellcheck sre-bot platform-upgrade script
+        run: shellcheck --severity=warning examples/sre-bot/platform-upgrade/upgrade.sh
       # Integration tests dial the real dev stack (Postgres 25432, Valkey 26379,
       # RustFS 29000, Langfuse 23000 + ClickHouse + OTel Collector). Boot it after
       # ruff/mypy so cheap failures stay fast. The first up starts the one-shot

--- a/examples/sre-bot/deploy.yaml
+++ b/examples/sre-bot/deploy.yaml
@@ -38,8 +38,9 @@
 #         Reads this file. `--target` picks one entry; `--all-targets` walks
 #         every entry, which is how both agents get created in one command.
 #
-# So the golden path in the README does not touch these values, and the
-# documentation IDs below are inert until you name a target.
+# So the golden path in the README does not touch these values. The installer
+# (`curie example sre-bot install`) also ignores this file for routing: pass
+# `--slack-channel` there instead.
 #
 # ---------------------------------------------------------------------------
 # WHEN YOU DO USE TARGETS
@@ -54,15 +55,21 @@
 # **Use the ID, never the `#name`.** Binding by name is the single most common
 # "I deployed it and nothing happens" failure, and it fails the same silent way.
 #
-# Not using Slack? Drop the `slack_channel` lines. The targets still bind an
-# agent name and an environment, and `curie cluster message` talks to the agent
-# without a channel at all.
+# Documentation placeholders (`C0EXAMPLE1`, `C0EXAMPLE2`) match that id shape,
+# so they are not a safe stand-in. This file used to ship them as live values;
+# `curie cluster deploy --target` then rebound the bot to a nonexistent
+# channel and reported success. They stay in the comment below as the shape
+# to copy, not as values that can be deployed.
+#
+# Not using Slack? Leave the `slack_channel` lines commented. The targets
+# still bind an agent name and an environment, and `curie cluster message`
+# talks to the agent without a channel at all.
 targets:
   dev:
     agent: sre-bot-dev
     env: dev
-    slack_channel: C0EXAMPLE1
+    # slack_channel: C0EXAMPLE1
   prod:
     agent: sre-bot
     env: prod
-    slack_channel: C0EXAMPLE2
+    # slack_channel: C0EXAMPLE2

--- a/examples/sre-bot/docs/PERMISSION-MAP.md
+++ b/examples/sre-bot/docs/PERMISSION-MAP.md
@@ -39,7 +39,7 @@ advisory.
 | Kubernetes verbs | `get`, `patch` on `apps/deployments` |
 | Scoped by | `resourceNames`, one namespace |
 | Authorization | `approvalPolicy` gate — a human approves each call |
-| Status | Implemented, ships commented out |
+| Status | Implemented, ships with its credential absent |
 
 ### What that grant actually permits
 

--- a/examples/sre-bot/docs/STAGING-DEPLOY.md
+++ b/examples/sre-bot/docs/STAGING-DEPLOY.md
@@ -1,262 +1,191 @@
-# What actually runs in staging, and how to reproduce it
+# What the tree actually installs, and how to reproduce it
 
-This bundle is not deployable to a cluster as it stands, and the thing running in
-our staging cluster is this bundle plus four deltas applied by hand. That gap is
-why a reviewer could interrogate the live bot and then find nothing in the
-repository that reproduces it. This file closes that gap: it records the deltas,
-why each exists, and the exact steps.
-
-Written after the fact from a working deployment rather than from intent, so every
-value here was read off the cluster.
-
-**The host is a single-node k3s cluster**, not a managed one, which is why the
-chart-hook and registry-access notes below bite here and may not bite on yours.
-Do not confuse it with the cluster the bot *reports on*: that is a separate,
-larger cluster the read-only connector points at.
-
-**Two placeholders**, kept out of the repository because they name someone's
-private deployment rather than this project (`.gitleaks.toml`'s
-`downstream-repo-slug` rule):
-
-| placeholder | what it is |
-|---|---|
-| `<ARCHIVED_ORG>` | the org publishing the archived predecessor repository's images -- the same org as this repo; operators of this install already know it |
-| `<ns>` | the release namespace of the install you are reproducing into |
-
-## Why the bundle is not directly deployable
-
-```
-kubernetes   image   ghcr.io/containers/kubernetes-mcp-server@sha256:6d650f4b...
-k8s-write    build   connectors/k8s-write
-k8s-scale    build   connectors/k8s-scale
-grafana      image   docker.io/grafana/mcp-grafana@sha256:5efeafd0...
-tempo        build   connectors/tempo
-```
-
-Three connectors declare `build:`. `curie build --plugin-dir <dir>` without
-`--registry` records a local image id, which is usable at the skill and local
-tiers and **refused at the cluster tier** — a cluster cannot pull an image that
-exists only in one machine's Docker daemon. So a cluster deploy of this bundle
-needs either a registry to push to, or images already published.
-
-`.claude-plugin/plugin.json` also declares two gates:
-
-```
-mcp__k8s-write__restart_deployment
-mcp__k8s-scale__scale_deployment
-```
-
-A gate naming a connector the deploy does not carry fails bundle validation, so
-dropping a connector means dropping its gate in the same edit.
-
-## The four deltas
-
-### 1. `k8s-scale` and its gate are removed
-
-No published image for it, so it cannot be deployed at the cluster tier without
-building and pushing one first. Its gate goes with it, or validation fails.
-
-This means **the live bot has one write verb, not two.** A reviewer asking "what
-write actions can you take" gets `restart_deployment` alone, and that is correct
-for what is deployed rather than a limitation of the bundle.
-
-### 2. `k8s-write` and `tempo` are pinned to published images
-
-```
-k8s-write  ghcr.io/<ARCHIVED_ORG>/sre-bot-k8s-write-mcp:sha-21130cbacf4f1df9e13d98b9b3141a68b73db48c
-tempo      ghcr.io/<ARCHIVED_ORG>/sre-bot-tempo-mcp:sha-3cf3bf30c968d22a0de67f9c69bf1cdd26d4f46d
-```
-
-These are the images built from the archived predecessor repository this bundle
-was extracted from, and they are what staging has been running. They are
-pullable; the `build:` contexts in this bundle are their source, but the two are
-not verified byte-identical here.
-
-**For a fresh install, do not pin the tempo one.** This repository publishes its
-own tempo connector image (`ghcr.io/curie-eng/curie-sre-bot-tempo`, built by the
-`Build sre-bot-tempo image` CI job), and `curie example sre-bot install` resolves
-that to a digest for you. The pin above is recorded because it is what *this*
-install is running, not because it is what a new one should run. No equivalent
-in-repo image exists for `k8s-write`, which is why that one still points at the
-archived org.
-
-### 3. The write allowlist carries real targets
-
-The bundle ships the sanctioned placeholder:
-
-```
-K8S_WRITE_ALLOWLIST: <namespace>/<deployment>
-```
-
-Staging uses:
-
-```
-K8S_WRITE_ALLOWLIST: curie-staging/curie-staging-api,curie-staging/curie-staging-worker,curie-staging/curie-staging-dispatcher
-```
-
-**This value and `manifests/write-role.yaml`'s `resourceNames` must be edited
-together.** They are two allowlists over the same question in two files. On this
-install they disagreed for four days: the Role was re-scoped by hand when the box
-was rebuilt, while the connector kept a target from the previous cluster
-(`public/api`). The intersection was empty, so the write path was inert and
-nothing reported it. `scripts/check-write-path-gated.py` is the check for exactly
-this and should be run before any deploy that touches either file.
-
-### 4. `deploy.yaml` is removed before deploying
-
-The shipped `deploy.yaml` carries placeholder Slack channel ids
-(`C0EXAMPLE1`, `C0EXAMPLE2`). Deploying with it can rebind an existing agent to a
-channel that does not exist, and the failure is silent — the bot simply stops
-answering, with nothing in any log naming the cause. Delete the file, or pass
-`--target` only when the ids are real.
-
-## Reproduction
-
-Assumes a Curie release in `<ns>` with the observability stack from
-`examples/sre-bot/observability/` already installed, and `manifests/read-access.yaml`
-applied.
-
-### Step 1 — build the deployable bundle
+The reproduction is one command. It used to be this bundle plus four deltas
+applied by hand; that gap is why a reviewer could interrogate a live bot and
+then find nothing in the repository that reproduced it. The installer has
+landed, so this file describes what `curie example sre-bot install` does
+today, including the two upgrade paths the previous write-up never named.
 
 ```bash
-cp -R examples/sre-bot /tmp/bundle
-rm -f /tmp/bundle/deploy.yaml
-python3 - <<'PY'
-import yaml, json, pathlib
-ALLOW = "<ns>/<deploy-a>,<ns>/<deploy-b>"          # your real targets
-IMAGES = {
-    "k8s-write": "ghcr.io/<ARCHIVED_ORG>/sre-bot-k8s-write-mcp:sha-21130cbacf4f1df9e13d98b9b3141a68b73db48c",
-    "tempo":     "ghcr.io/<ARCHIVED_ORG>/sre-bot-tempo-mcp:sha-3cf3bf30c968d22a0de67f9c69bf1cdd26d4f46d",
-}
-p = pathlib.Path("/tmp/bundle/connectors.yaml")
-d = yaml.safe_load(p.read_text()); c = d["connectors"]
-for name, image in IMAGES.items():
-    c[name].pop("build", None); c[name]["image"] = image
-c["k8s-write"]["env"]["K8S_WRITE_ALLOWLIST"] = ALLOW
-c.pop("k8s-scale", None)                            # no published image
-p.write_text(yaml.safe_dump(d, sort_keys=False))
-
-m = pathlib.Path("/tmp/bundle/.claude-plugin/plugin.json")
-j = json.loads(m.read_text())
-j["approvalPolicy"]["gates"] = [g for g in j["approvalPolicy"]["gates"]
-                                if "k8s-scale" not in g["gate"]]
-m.write_text(json.dumps(j, indent=2))
-PY
+curie example sre-bot install --observability
 ```
 
-Then edit `/tmp/bundle/manifests/write-role.yaml` so its namespace and
-`resourceNames` match `ALLOW` exactly, and verify before going further:
+`--observability` is required. With no targeting flags, Curie lands as release
+`curie` in namespace `curie`, and the Grafana/Loki/Alloy/Tempo/Prometheus stack
+lands in namespace `observability`. To install beside an existing release:
 
 ```bash
-python3 scripts/check-write-path-gated.py     # expects the bundle under examples/
+curie example sre-bot install --observability \
+  --namespace <ns> \
+  --release <release> \
+  --observability-namespace <obs-ns>
 ```
 
-### Step 2 — the write identity
+`--dry-run` prints the same plan without mutating the cluster. Read that
+output before accepting `--platform-upgrade`: it is the one listing that
+names the widest identity this installer can create.
+
+The installer copies a runtime bundle out of the checked-in tree. It does
+**not** apply `deploy.yaml` as routing. Agent name comes from `plugin.json`;
+Slack binding comes from `--slack-channel` if you pass it. `curie cluster
+deploy --plugin-dir examples/sre-bot --target ...` is a different path and
+is the one that reads `deploy.yaml`.
+
+## What the default install keeps
+
+| Connector     | Default install                                              |
+|---------------|--------------------------------------------------------------|
+| `kubernetes`  | kept, read-only                                              |
+| `grafana`     | kept, pointed at the bundled stack                           |
+| `tempo`       | kept, pinned to the published `curie-sre-bot-tempo` digest   |
+| `k8s-write`   | kept, with an empty `K8S_WRITE_ALLOWLIST`                    |
+| `k8s-scale`   | stripped                                                     |
+| `self-upgrade`| stripped                                                     |
+
+`k8s-write` ships declared, not commented out. With no `--write-allowlist`
+the connector is kept with an empty `K8S_WRITE_ALLOWLIST`. Empty means
+the process **refuses to start**, not that a healthy connector refuses
+every call: `connectors/k8s-write/server.py` exits 1 when the allowlist
+is empty, so the writer pod CrashLoopBackOffs until you name targets.
+**No Role is rendered.** An empty `resourceNames` would grant every
+Deployment, so the empty case omits the Role rather than rendering one
+with no names. The writer identity is still minted, because bring-up
+refuses without `K8S_WRITE_KUBECONFIG`.
+
+`k8s-scale` stays out even though a published image now exists. Scale to
+zero is an outage, and that blast radius is its own opt-in, not a ride on
+the write path.
+
+`self-upgrade` stays out for a stronger reason: its identity holds
+namespace-wide `create` on `jobs` in the namespace that holds the platform
+API key. That grant is an operator decision made while reading
+`manifests/upgrade-role.yaml`, never a side effect of the default install.
+
+The installer also applies `manifests/read-access.yaml` and mints the
+read-only kubeconfig the `kubernetes` connector needs.
+
+## The write allowlist
 
 ```bash
-kubectl apply -f /tmp/bundle/manifests/write-role.yaml
-kubectl auth can-i patch deployments/<deploy-a> -n <ns> \
-  --as=system:serviceaccount:<ns>:sre-bot-writer          # expect: yes
-kubectl auth can-i delete deployments -n <ns> \
-  --as=system:serviceaccount:<ns>:sre-bot-writer          # expect: no
-kubectl auth can-i get secrets -n <ns> \
-  --as=system:serviceaccount:<ns>:sre-bot-writer          # expect: no
+curie example sre-bot install --observability \
+  --write-allowlist <ns>/<deploy-a>,<ns>/<deploy-b>
 ```
 
-### Step 3 — the Grafana credential
+One input renders both ceilings: `manifests/write-role.yaml`'s
+`resourceNames` and the connector's `K8S_WRITE_ALLOWLIST`. They are two
+allowlists over the same question in two files, and editing one without
+the other is not hypothetical. Deriving both from one flag makes that
+disagreement unrepresentable.
 
-The bundle reads the Grafana token from a Secret named `curie-grafana-connector`:
+`--no-write` strips the connector and its gate together. `--no-write` and
+`--write-allowlist` contradict each other; the command refuses rather than
+picking one.
 
-```yaml
-secrets:
-  - name: GRAFANA_SERVICE_ACCOUNT_TOKEN
-    from_secret: curie-grafana-connector
-    key: GRAFANA_SERVICE_ACCOUNT_TOKEN
-```
+`scripts/check-write-path-gated.py` remains the check for a hand-edited
+bundle that did not go through this flag.
 
-That Secret is created by the chart's `grafanaConnector` hook, which **does not
-exist in chart 0.7.0**. On an older release, create it by hand or the connector
-pods fail with `CreateContainerConfigError: secret "curie-grafana-connector" not
-found` — and note that the *previous* ReplicaSet keeps serving, so
-`kubectl get deploy` still reads `1/1` while the new pods never start. Check pod
-names and ages, not the ready column.
+## The upgrade path: `--platform-upgrade`
 
-Mint a token against the Grafana the bot should observe (its own cluster's, for a
-self-observing install), then:
+This is the part the previous write-up omitted. Passing the flag keeps the
+`self-upgrade` connector and installs the **platform** upgrade Job:
 
 ```bash
-kubectl create secret generic curie-grafana-connector -n <ns> \
-  --from-literal=GRAFANA_SERVICE_ACCOUNT_TOKEN="$TOKEN"
+curie example sre-bot install --observability --platform-upgrade
 ```
 
-`GRAFANA_URL` in the bundle already points at
-`http://grafana.observability.svc.cluster.local`. If a deployment overrides it to
-a different Grafana, the token must match that Grafana — changing the URL without
-the token gives a connector that starts and cannot authenticate.
+That does four extra things, after the deploy, never before:
 
-### Step 4 — deploy
+1. Applies `manifests/upgrade-role.yaml`. This is the **connector**
+   identity (`sre-bot-upgrader`): `create` on `jobs`, so the bot can start
+   an upgrade. It cannot run `helm upgrade` itself.
+2. Applies `manifests/platform-upgrade-role.yaml`. This is the **Job**
+   identity (`curie-platform-upgrader`): namespace-admin in all but name,
+   because `helm upgrade` rewrites nearly every object the release owns.
+   Read that file before accepting the flag. The sandbox never sees this
+   credential; it exists for the ~90s an upgrade runs.
+3. Applies a ConfigMap whose body is `platform-upgrade/upgrade.sh`, and a
+   CronJob (`suspend: true`) that runs it. The CronJob never fires on its
+   own. The gated tool `mcp__self-upgrade__upgrade_platform` creates a Job
+   from that template when a human approves one.
+4. Mints `SELF_UPGRADE_KUBECONFIG` from the connector identity and
+   reconciles it onto the deployed version.
+
+The same connector also publishes `mcp__self-upgrade__upgrade_self`, which
+starts a Job from this bot's own CronJob template
+(`self-upgrade/cronjob.yaml`) rather than the platform one. The installer
+does not apply `self-upgrade/cronjob.yaml`. Without that hand apply,
+`upgrade_self` is a gated tool pointed at a CronJob that is not there.
+`--platform-upgrade` is what installs `upgrade_platform`; reproducing
+`upgrade_self` still means applying `self-upgrade/cronjob.yaml` yourself
+after reading `manifests/upgrade-role.yaml`.
+
+`--dry-run` lists those four applies. If they are not in the plan, the
+flag was not passed.
+
+The script the Job runs is `platform-upgrade/upgrade.sh`. It takes no
+target version from the bot: it reads the newest published release of the
+source repository, refuses when that is already installed, and does not
+roll back. Rollback is an operator action; `docs/PERMISSION-MAP.md`
+entry 4 says why.
+
+## Slack
 
 ```bash
-curie cluster deploy --plugin-dir /tmp/bundle \
-  --agent <agent> --env <dev|prod> \
-  --namespace <ns> --release <release>
+curie example sre-bot install --observability --slack-channel <channel-id>
 ```
 
-**`--env` defaults to `dev`.** Deploying a prod-environment agent without
-`--env prod` creates a version that is never applied: the command prints
-`deployed <agent> ... -> dev` and `[dev] active`, the connector reconciler reports
-`applied, 0 failed`, and the running connectors keep their old configuration. The
-only way to catch it is to read the connector env afterwards. `--target` normally
-supplies this, which is why removing `deploy.yaml` makes it explicit.
+Bind by channel ID, never by `#name`. The dispatcher routes by ID, so a
+name binds nothing and the deploy still reports success.
 
-### Step 5 — verify, by reading the cluster rather than the deploy output
+`deploy.yaml` used to ship documentation placeholder ids (`C0EXAMPLE1`,
+`C0EXAMPLE2`) as live `slack_channel` values. Those match the Slack id
+shape, so `curie cluster deploy --target` reported success and rebound
+the bot to a channel that does not exist. The shipped file no longer
+carries live `slack_channel` lines. Uncomment them only with a real id,
+and only when you are using `--target` / `--all-targets` rather than this
+installer.
 
-```bash
-kubectl get deploy -n <ns> <release>-<agent>-mcp-k8s-write \
-  -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="K8S_WRITE_ALLOWLIST")].value}'
-kubectl get role -n <ns> sre-bot-writer -o jsonpath='{.rules[0].resourceNames}'
-kubectl get pods -n <ns> | grep mcp-        # names and ages, not just ready counts
-```
+## What a hand deploy still has to do
 
-The allowlist and the `resourceNames` must name the same set. If they do not, the
-write path is either inert or will 403 after a human approves a call.
+The installer is the cluster-tier path. A manual
+`curie cluster deploy --plugin-dir examples/sre-bot` of the checked-in
+tree is a different shape:
 
-## What removes all of this
+- Four connectors declare `build:` (`k8s-write`, `k8s-scale`,
+  `self-upgrade`, `tempo`). `curie build --plugin-dir` without
+  `--registry` records a local image id, which the cluster tier refuses.
+  The installer resolves published digests instead.
+- `.claude-plugin/plugin.json` declares gates for every write the bundle
+  names. A gate naming a connector the deploy does not carry fails bundle
+  validation, so dropping a connector means dropping its gate in the same
+  edit. The installer does that pairing; a hand edit must too.
+- Both kubeconfigs must be available (`K8S_READONLY_KUBECONFIG` and, if
+  the write connector is kept, `K8S_WRITE_KUBECONFIG`). The installer
+  mints those as one-off secret overrides and does not persist them to
+  the host vault, so a later manual deploy still needs them supplied.
 
-Every delta above is hand work that a tool should do. PR #1923 adds
-`curie example sre-bot install --write-allowlist ns/name[,ns/name]`, which renders
-the Role's `resourceNames` and the connector's `K8S_WRITE_ALLOWLIST` from one
-input — making their disagreement unrepresentable rather than merely detectable —
-keeps exactly the gate for the connector it keeps, and mints the writer kubeconfig
-the same way the reader one is minted. Once that lands, Steps 1 through 4 collapse
-into one command and this file describes history.
+`--env` defaults to `dev`. Deploying a prod-environment agent without
+`--env prod` creates a version that is never applied. `--target` supplies
+this when you use `deploy.yaml`; the installer does not.
 
-The remaining delta it does not cover is `k8s-scale`: it needs a published image
-before any cluster deploy can carry it.
+## Historical staging cluster
 
-## Verified after the fact
+The original write-up of this file was read off a single-node k3s host
+that was running a hand-patched copy of this bundle: `k8s-scale` removed,
+`k8s-write` and `tempo` pinned to images from an archived predecessor
+repository, a real write allowlist typed into two files by hand, and
+`deploy.yaml` deleted so its placeholder channel ids could not rebind
+the bot.
 
-Both of the things this file originally left open were checked.
+Do not copy those deltas onto a fresh install. The installer is the
+source of truth for what this tree deploys: published images under
+`ghcr.io/curie-eng/curie-sre-bot-*`, one allowlist flag, and
+`--platform-upgrade` for the two upgrade identities.
 
-**The pinned `k8s-write` image is behaviourally the same code as this bundle's
-source.** Its `/app/server.py` matches the archived repository's file exactly
-(`md5 3c9b4919573ba43e62b79ae86a8d5c35`) and differs from
-`connectors/k8s-write/server.py` here (`md5 217a4eb009a1f21fa5c964e557e26687`) by
-thirteen lines: one docstring cross-reference, and two long strings wrapped for
-line length. The allowlist check, the constant patch body, and the
-`insecure-skip-tls-verify` refusal are identical. So reading the source in this
-directory tells you what the running connector does — but the digests above remain
-the authority for what actually ran.
-
-**`k8s-scale` has no published image.** Confirmed by pulling from the cluster that
-does have registry access:
-
-```
-없음  ghcr.io/curie-eng/curie-sre-bot-k8s-scale:0.8.0
-없음  ghcr.io/<ARCHIVED_ORG>/sre-bot-k8s-scale-mcp:latest
-없음  ghcr.io/curie-eng/curie-sre-bot-k8s-scale:latest
-```
-
-The same run pulled `sre-bot-k8s-write-mcp` successfully, so this is an absent
-image rather than a credentials problem. Until one is published, no cluster deploy
-can carry that connector, and the bundle's second gate has nothing to guard.
+The chart-hook note from that host still bites on an older release: the
+Grafana connector Secret named `curie-grafana-connector` is created by
+the chart's `grafanaConnector` hook, which did not exist in chart 0.7.0.
+On such a release the connector pods fail with
+`CreateContainerConfigError` while the previous ReplicaSet keeps serving,
+so `kubectl get deploy` still reads `1/1`. Check pod names and ages, not
+the ready column.

--- a/examples/tests/test_sre_bot_hygiene.py
+++ b/examples/tests/test_sre_bot_hygiene.py
@@ -1,0 +1,202 @@
+"""Pins that keep examples/sre-bot's shipped files honest about what they do.
+
+Four independent ways this example has already lied, each of which reached a
+reviewer as a confident wrong answer rather than as a missing file:
+
+1. ``docs/STAGING-DEPLOY.md`` described four hand-applied deltas and never
+   named the self-upgrade connector or the platform-upgrade Job the tree
+   actually installs today. A reviewer following it would reproduce a bot
+   that cannot start either upgrade.
+2. ``deploy.yaml`` shipped ``C0EXAMPLE1`` / ``C0EXAMPLE2`` as live
+   ``slack_channel`` values. Those match the Slack id shape, so
+   ``curie cluster deploy --target`` reports success and rebinds the bot to
+   a channel that does not exist. The bot then goes silent with nothing in
+   any log naming the cause.
+3. ``docs/PERMISSION-MAP.md`` said ``restart_deployment`` "ships commented
+   out" while ``connectors.yaml`` declares ``k8s-write`` live. The document
+   that claims to list every write is then wrong about the one write that
+   actually ships.
+4. ``platform-upgrade/upgrade.sh`` is the script the platform-upgrade Job
+   runs, and nothing in CI shellchecked it. A script with zero tests and no
+   CI is a script whose next edit lands unreviewed.
+
+Each test below fails closed on the matching lie. They are deliberately
+shallow -- they read the shipped files and the workflow -- because the
+failure is the file saying the wrong thing, not a runtime of the bot.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import yaml
+from plugin_format.deploy_targets import validate_deploy_targets
+
+REPO = Path(__file__).resolve().parents[2]
+BUNDLE = REPO / "examples" / "sre-bot"
+CI_WORKFLOW = REPO / ".github" / "workflows" / "ci.yaml"
+UPGRADE_SCRIPT = BUNDLE / "platform-upgrade" / "upgrade.sh"
+# Named allowlisted ids, not a prefix-plus-digit regex. A bare prefix
+# of the sanctioned placeholders matches slack-conversation-id and is
+# not a gitleaks stopword; C0EXAMPLE1 and C0EXAMPLE2 are.
+PLACEHOLDER_CHANNELS = frozenset({"C0EXAMPLE1", "C0EXAMPLE2"})
+
+
+def test_staging_deploy_doc_names_what_the_tree_installs_today() -> None:
+    """The reproduction doc must describe the installer that exists, including
+    the two upgrade paths it currently never mentioned."""
+
+    text = (BUNDLE / "docs" / "STAGING-DEPLOY.md").read_text(encoding="utf-8")
+    assert "curie example sre-bot install" in text, (
+        "docs/STAGING-DEPLOY.md must name `curie example sre-bot install`; "
+        "that is the command the tree actually uses to stand this bot up"
+    )
+    assert "--platform-upgrade" in text, (
+        "docs/STAGING-DEPLOY.md never mentions --platform-upgrade, so a "
+        "reviewer following it cannot reproduce the platform-upgrade Job "
+        "the tree installs"
+    )
+    assert "self-upgrade" in text, (
+        "docs/STAGING-DEPLOY.md never mentions self-upgrade, so a reviewer "
+        "following it cannot reproduce the connector the tree ships"
+    )
+    assert "platform-upgrade" in text, (
+        "docs/STAGING-DEPLOY.md never mentions platform-upgrade, so a "
+        "reviewer following it cannot reproduce the Job the tree ships"
+    )
+    # PR #1923 landed. Describing the installer as a future change is the
+    # original lie this file now exists to stop.
+    assert "Once that lands" not in text, (
+        "docs/STAGING-DEPLOY.md still describes `curie example sre-bot "
+        "install` as unlanded. The command is in the tree; this file is "
+        "the reproduction doc, not the history of a PR"
+    )
+    # The installer does not apply self-upgrade/cronjob.yaml. Claiming
+    # --platform-upgrade makes upgrade_self live is the next lie: the
+    # connector is kept, the bot's own CronJob is not.
+    assert "does not apply `self-upgrade/cronjob.yaml`" in text, (
+        "docs/STAGING-DEPLOY.md must say the installer does not apply "
+        "self-upgrade/cronjob.yaml; --platform-upgrade installs the "
+        "platform Job, not this bot's own upgrade CronJob"
+    )
+    # Empty K8S_WRITE_ALLOWLIST refuses to start the process (server.py
+    # main() exits 1). "every call is refused" is the stale comment in
+    # that file, not what a default install does.
+    assert "refuses to start" in text, (
+        "docs/STAGING-DEPLOY.md must say an empty write allowlist refuses "
+        "to start the connector; a healthy pod that refuses calls is not "
+        "what the default install produces"
+    )
+    assert "every call is refused" not in text, (
+        "docs/STAGING-DEPLOY.md still claims the default write connector "
+        "refuses every call; the process exits 1 on an empty allowlist"
+    )
+
+
+def test_deploy_yaml_placeholder_channels_cannot_silently_rebind() -> None:
+    """A live documentation placeholder is a valid-shaped Slack id.
+
+    ``validate_deploy_targets`` accepts ``C0EXAMPLE1`` because the shape
+    check cannot tell a fixture from a real channel. Deploying that file
+    with ``--target`` therefore succeeds and rebinds the bot to nothing.
+    The shipped file must not carry those as live values, and it must
+    still parse: the installer uploads this file through the real bundle
+    validator.
+    """
+
+    raw = (BUNDLE / "deploy.yaml").read_text(encoding="utf-8")
+    data = yaml.safe_load(raw)
+    parsed, errors = validate_deploy_targets(data)
+    assert errors == [], (
+        "examples/sre-bot/deploy.yaml must remain a valid deploy.yaml "
+        f"(the installer uploads it through validate_bundle): {errors}"
+    )
+    assert parsed is not None
+    targets = data.get("targets") or {}
+    live_placeholders: list[str] = []
+    for name, target in targets.items():
+        channel = (target or {}).get("slack_channel")
+        if channel is None:
+            continue
+        if str(channel) in PLACEHOLDER_CHANNELS:
+            live_placeholders.append(f"targets.{name}.slack_channel={channel}")
+    assert not live_placeholders, (
+        "examples/sre-bot/deploy.yaml ships documentation placeholder "
+        "Slack channel ids as live values: "
+        + ", ".join(live_placeholders)
+        + ". Those match the Slack id shape, so `curie cluster deploy "
+        "--target` reports success and rebinds the bot to a channel that "
+        "does not exist. Comment the slack_channel lines out (or put a "
+        "real id) so a target cannot silently rebind Slack."
+    )
+
+
+def test_permission_map_restart_status_matches_live_connectors_yaml() -> None:
+    """PERMISSION-MAP must not claim restart_deployment ships commented out
+    while connectors.yaml declares k8s-write live."""
+
+    connectors = yaml.safe_load((BUNDLE / "connectors.yaml").read_text(encoding="utf-8"))
+    declared = connectors.get("connectors") or {}
+    assert "k8s-write" in declared, (
+        "connectors.yaml no longer declares k8s-write; this test needs a "
+        "new status string, not a pass, if the connector was removed"
+    )
+    text = (BUNDLE / "docs" / "PERMISSION-MAP.md").read_text(encoding="utf-8")
+    assert "ships commented out" not in text, (
+        "docs/PERMISSION-MAP.md says restart_deployment 'ships commented "
+        "out' but connectors.yaml declares k8s-write live. Update the "
+        "Status row to match the other declared-but-uncredentialed writes "
+        "('ships with its credential absent')."
+    )
+
+
+def test_ci_shellchecks_the_platform_upgrade_script() -> None:
+    """upgrade.sh is the Job body. CI must run shellcheck on that path.
+
+    A pytest that shells out to shellcheck is not enough on its own: if
+    that test were deleted, CI would still have zero coverage of this
+    script. The workflow must invoke shellcheck on this path so the gate
+    is visible in the job that actually runs on every PR.
+
+    Comments do not count. An earlier pin matched the path and the word
+    ``shellcheck`` anywhere in the file, so deleting the ``run:`` line
+    left both asserts green.
+    """
+
+    workflow = yaml.safe_load(CI_WORKFLOW.read_text(encoding="utf-8")) or {}
+    python_job = (workflow.get("jobs") or {}).get("python") or {}
+    steps = python_job.get("steps") or []
+    runs = [step.get("run") or "" for step in steps if isinstance(step, dict)]
+    matching = [
+        run
+        for run in runs
+        if "shellcheck" in run and "examples/sre-bot/platform-upgrade/upgrade.sh" in run
+    ]
+    assert matching, (
+        "the python CI job has no step whose run: invokes shellcheck on "
+        "examples/sre-bot/platform-upgrade/upgrade.sh. A comment naming "
+        "the path is not a gate. Add a step that runs "
+        "`shellcheck --severity=warning examples/sre-bot/platform-upgrade/upgrade.sh`."
+    )
+
+
+def test_platform_upgrade_script_is_shellcheck_clean() -> None:
+    """The Job script itself must be clean, not merely mentioned in CI.
+
+    The sibling test asserts the workflow names the path. This one runs
+    shellcheck against the script so a syntax error still fails even if
+    the workflow step is later pointed at a different file.
+    """
+
+    assert UPGRADE_SCRIPT.is_file(), f"missing {UPGRADE_SCRIPT}"
+    result = subprocess.run(
+        ["shellcheck", "--severity=warning", str(UPGRADE_SCRIPT)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        "shellcheck failed on examples/sre-bot/platform-upgrade/upgrade.sh:\n"
+        f"{result.stdout}{result.stderr}"
+    )


### PR DESCRIPTION
## Summary

Four still-present hygiene defects in `examples/sre-bot` on `origin/next`. None were already fixed, so none are skipped.

- `docs/STAGING-DEPLOY.md` now describes `curie example sre-bot install` as it exists, including `--platform-upgrade` (platform CronJob and identities) and the self-upgrade connector. It no longer describes the installer as unlanded, and it does not claim `--platform-upgrade` applies `self-upgrade/cronjob.yaml`.
- `deploy.yaml` no longer ships live `C0EXAMPLE1` / `C0EXAMPLE2` Slack ids. Those match the Slack id shape, so `--target` used to report success and rebind the bot to a nonexistent channel. They are commented; the file still parses so the installer can upload it through `validate_bundle`.
- `docs/PERMISSION-MAP.md` entry 1 Status now matches the live `k8s-write` declaration: "ships with its credential absent", not "ships commented out".
- CI runs `shellcheck --severity=warning examples/sre-bot/platform-upgrade/upgrade.sh` in the python job, and pytest both parses that `run:` line and shells out to shellcheck.

Bounded default for the placeholder channels: do not change `plugin-format`. `C0EXAMPLE*` is a valid-shaped fixture used across the tree; rejecting it in `validate_deploy_targets` would be a frozen-package change and would break the installer's bundle upload. Commenting the live values out stops the silent rebind without making the example bundle invalid.

Failing tests landed in the first commit, then the fixes, then a review correction so the reproduction doc matches the installer rather than the stale connector header.

Please do not merge or self-approve.

## Related issue

No ticket. Bonus hygiene sweep against `origin/next`.

## End-to-end verification

Behavior-bearing surface is the example bundle files and a static CI gate. No cluster, staging, or production mutation.

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | does not reach plugin packaging, the runner turn loop, ACI events, or skill eval | | |
| local | required | pytest guards plus the python CI shellcheck step | fake | `uv run pytest -q examples/tests/test_sre_bot_hygiene.py` on `d24788bec`: 5 passed. `uv run pytest -q examples/tests` on `2bda8b588`: 104 passed. `shellcheck --severity=warning examples/sre-bot/platform-upgrade/upgrade.sh`: exit 0. Negative: the first commit left those tests red (`4 failed, 1 passed`) for the intended reasons (missing `--platform-upgrade` in the doc, live `C0EXAMPLE*` channels, `ships commented out`, CI path absent). |
| local-release | n/a | does not change released binary identity, install path, version pins, or release compose; the installer ignores `deploy.yaml` for routing | | |
| cluster | n/a | task forbids cluster/staging/production mutation; no chart or sandbox templates change | | |
| live provider | n/a | does not reach model routing or credential resolution | | |
| external integration | n/a | does not drive Slack, git webhooks, or a third-party API | | |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [ ] An ADR is added under `docs/adr/` if this is an architectural decision.
