### PR TITLE
Accept ADR-0075, the Agent Proxy

### DIFF
--- a/docs/adr/0032-explicit-provider-egress.md
+++ b/docs/adr/0032-explicit-provider-egress.md
@@ -8,6 +8,11 @@ The first Decision clause and rejected Alternative 1 no longer require an
 explicit provider when the effective credential prefix selects one provider.
 Every other egress rule remains unchanged.
 
+**Superseded in part by [ADR 0075](0075-the-agent-proxy-credential-and-egress-boundary.md).**
+The install-time CIDR resolve is the interim FQDN mechanism this ADR deferred;
+ADR-0075 is that durable proxy. The CIDR path remains the fallback where the
+proxy is not deployed.
+
 Implements [#362](https://github.com/curie-eng/curie/issues/362).
 
 ## Context

--- a/docs/adr/0075-the-agent-proxy-credential-and-egress-boundary.md
+++ b/docs/adr/0075-the-agent-proxy-credential-and-egress-boundary.md
@@ -1,9 +1,9 @@
 # 75. The Agent Proxy: credentials and egress leave the sandbox
 
 Date: 2026-07-23
-Status: Draft
+Status: Accepted
 
-Supersedes-when-accepted: [ADR-0032](0032-explicit-provider-egress.md) (the
+Supersedes: [ADR-0032](0032-explicit-provider-egress.md) (the
 interim install-time CIDR resolve becomes the FQDN proxy the durable-mechanism
 clause of that ADR already promised).
 
@@ -183,8 +183,7 @@ its own decision when it lands:
 
 ## Status note
 
-Draft. Once Accepted, this ADR supersedes ADR-0032, and ADR-0032's status line is
-updated to point here. It remains Draft because the substrate and
-TLS-termination decisions above are unresolved and the shape of the credential
-injection contract is not yet pinned; it records the direction both reviews
-converged on so the future ADRs build to it.
+Accepted. This ADR supersedes ADR-0032's install-time CIDR resolve as the
+durable FQDN mechanism. Substrate, TLS-termination, and the credential
+injection contract remain the follow-up ADRs listed above; they are not pinned
+by this acceptance.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -104,7 +104,7 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0072 | [Keep the hand-rolled Rust ACI emitter; typify cannot express the wire contract's runtime semantics](0072-keep-the-hand-rolled-rust-aci-emitter-over-typify.md) | Accepted |
 | 0073 | [The durable state store reaches bundle code as an auto-mounted MCP server, not a bundle-shipped one](0073-agentos-state-mcp-server-and-state-boot-env.md) | Accepted |
 | 0074 | [Versioned JSON Schemas for every agent-facing CLI result](0074-versioned-json-schemas-for-cli-results.md) | Accepted |
-| 0075 | [The Agent Proxy: credentials and egress leave the sandbox](0075-the-agent-proxy-credential-and-egress-boundary.md) | Draft |
+| 0075 | [The Agent Proxy: credentials and egress leave the sandbox](0075-the-agent-proxy-credential-and-egress-boundary.md) | Accepted |
 | 0076 | [A closed, versioned attribute schema for the runner's OTel span stream](0076-closed-typed-telemetry-attribute-schema.md) | Accepted |
 | 0077 | [Skill-tier durable approvals stay unavailable, reported not absent](0077-skill-tier-durable-approvals-stay-unavailable.md) | Accepted |
 | 0078 | [Route message-driven approval cards through the connected Slack transport](0078-approval-cards-over-connected-transport.md) | Accepted |


### PR DESCRIPTION
## Summary

Publishes ADR-0075 as Accepted. The Agent Proxy is now the recorded direction: credentials and egress leave the sandbox through an in-path proxy. No implementation lands in this PR.

Maintainer approval for this acceptance is the merge of this PR. Substrate, TLS-termination, and the credential injection contract remain the follow-up ADRs ADR-0075 already named.

ADR-0032 is superseded in part: its install-time CIDR resolve stays as the fallback where the proxy is not deployed.

## Related issue

No closing issue. This is an ADR status publication.

## End-to-end verification

This change is not behavior-bearing. It updates ADR status lines and the generated ADR index.

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | Docs only | | |
| local | n/a | Docs only | | |
| local-release | n/a | Docs only | | |
| cluster | n/a | Docs only | | |
| live provider | n/a | Docs only | | |
| external integration | n/a | Docs only | | |

- [ ] Or: this change is not behavior-bearing, so no tier applies, and the
      summary says why.

## Checklist

- [x] Tests pass for the area I touched (`bash scripts/check-docs.sh`)
- [x] Docs updated if behavior changed
- [x] An ADR is added under `docs/adr/` if this is an architectural decision
