### PR TITLE
Accept ADR-0075 on the next release train

### DIFF
--- a/docs/adr/0032-explicit-provider-egress.md
+++ b/docs/adr/0032-explicit-provider-egress.md
@@ -8,6 +8,11 @@ The first Decision clause and rejected Alternative 1 no longer require an
 explicit provider when the effective credential prefix selects one provider.
 Every other egress rule remains unchanged.
 
+**Superseded in part by [ADR 0075](0075-the-agent-proxy-credential-and-egress-boundary.md).**
+The install-time CIDR resolve is the interim FQDN mechanism this ADR deferred;
+ADR-0075 is that durable proxy. The CIDR path remains the fallback where the
+proxy is not deployed.
+
 Implements [#362](https://github.com/curie-eng/curie/issues/362).
 
 ## Context

--- a/docs/adr/0075-the-agent-proxy-credential-and-egress-boundary.md
+++ b/docs/adr/0075-the-agent-proxy-credential-and-egress-boundary.md
@@ -1,9 +1,9 @@
 # 75. The Agent Proxy: credentials and egress leave the sandbox
 
 Date: 2026-07-23
-Status: Draft
+Status: Accepted
 
-Supersedes-when-accepted: [ADR-0032](0032-explicit-provider-egress.md) (the
+Supersedes: [ADR-0032](0032-explicit-provider-egress.md) (the
 interim install-time CIDR resolve becomes the FQDN proxy the durable-mechanism
 clause of that ADR already promised).
 
@@ -183,8 +183,7 @@ its own decision when it lands:
 
 ## Status note
 
-Draft. Once Accepted, this ADR supersedes ADR-0032, and ADR-0032's status line is
-updated to point here. It remains Draft because the substrate and
-TLS-termination decisions above are unresolved and the shape of the credential
-injection contract is not yet pinned; it records the direction both reviews
-converged on so the future ADRs build to it.
+Accepted. This ADR supersedes ADR-0032's install-time CIDR resolve as the
+durable FQDN mechanism. Substrate, TLS-termination, and the credential
+injection contract remain the follow-up ADRs listed above; they are not pinned
+by this acceptance.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -104,7 +104,7 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0072 | [Keep the hand-rolled Rust ACI emitter; typify cannot express the wire contract's runtime semantics](0072-keep-the-hand-rolled-rust-aci-emitter-over-typify.md) | Accepted |
 | 0073 | [The durable state store reaches bundle code as an auto-mounted MCP server, not a bundle-shipped one](0073-agentos-state-mcp-server-and-state-boot-env.md) | Accepted |
 | 0074 | [Versioned JSON Schemas for every agent-facing CLI result](0074-versioned-json-schemas-for-cli-results.md) | Accepted |
-| 0075 | [The Agent Proxy: credentials and egress leave the sandbox](0075-the-agent-proxy-credential-and-egress-boundary.md) | Draft |
+| 0075 | [The Agent Proxy: credentials and egress leave the sandbox](0075-the-agent-proxy-credential-and-egress-boundary.md) | Accepted |
 | 0076 | [A closed, versioned attribute schema for the runner's OTel span stream](0076-closed-typed-telemetry-attribute-schema.md) | Accepted |
 | 0077 | [Skill-tier durable approvals stay unavailable, reported not absent](0077-skill-tier-durable-approvals-stay-unavailable.md) | Accepted |
 | 0078 | [Route message-driven approval cards through the connected Slack transport](0078-approval-cards-over-connected-transport.md) | Accepted |


### PR DESCRIPTION
## Summary

- Records Brian's explicit maintainer approval of ADR-0075 on the `next` release train.
- Marks the Agent Proxy direction Accepted while leaving substrate, TLS behavior, and protocol injection to the follow-up ADR.
- Marks ADR-0032's install-time CIDR resolution as the retained fallback and regenerates the ADR index.

## Verification

- `bash scripts/check-docs.sh`
- `scripts/check-commit-messages.sh origin/next..HEAD`
- `scripts/check-commit-messages.sh --self-test`
- `git diff --check origin/next...HEAD`

## Scope

Documentation only. This PR does not implement the Agent Proxy and does not claim ADR-0075 complete.

Fix pin: n/a - documentation-only ADR acceptance; no bug-labeled issue is closed.
