### PR TITLE
Clarify documentation E2E exemptions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -37,9 +37,21 @@ Fix pin: n/a - <reason>
 
 ## End-to-end verification
 
-<!-- Behavior-bearing changes only. Classify every tier required or n/a with a
-     concrete reason, and paste the exact command plus what you observed for
-     each required tier. See "E2E verification is mandatory" in AGENTS.md. -->
+<!-- Choose exactly one path.
+
+     Behavior-bearing: keep the tier table and three evidence checkboxes below.
+     Classify every tier required or n/a with a concrete reason, and paste the
+     exact command plus what you observed for each required tier.
+
+     No runtime behavior: delete the tier table and three evidence checkboxes.
+     Replace them with one explanation and the scoped checks you ran:
+
+     This change does not alter runtime behavior because <reason>.
+     Scoped verification: `<command>` - <observed outcome>.
+
+     Documentation and ADR changes are not automatically exempt. If they alter
+     runtime behavior, use the behavior-bearing path. See "E2E verification is
+     mandatory" in AGENTS.md. -->
 
 | Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
 | --- | --- | --- | --- | --- |
@@ -56,8 +68,6 @@ Fix pin: n/a - <reason>
       negative or a second independent path.
 - [ ] No required tier is left unproved; any blocked tier names its blocker in
       the table.
-- [ ] Or: this change is not behavior-bearing, so no tier applies, and the
-      summary says why.
 
 ## Checklist
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -453,10 +453,18 @@ a claim that the change alters no runtime behavior on any surface: either say
 that plainly and carry no tier, or the tier set is wrong for this change and
 the maintainer decides, but do not proceed on all six not applicable while
 still calling the change behavior-bearing. A change that genuinely bears no
-runtime behavior, which is the documentation, ADR, and strictly
-behavior-preserving refactor case, records that reason once and is exempt,
-including on the build path. Promoting a tier to required is always allowed;
-dropping a required tier is not.
+runtime behavior records that reason once and is exempt from tier
+classification and E2E evidence for each acceptance criterion, including on
+the build path. Examples include an explanatory documentation edit, an ADR
+pointer repair that leaves the decision unchanged, and a strictly
+behavior-preserving refactor. Run and report the checks appropriate to the
+changed artifact instead: the repository's applicable formatting, link,
+command, or documentation validators for prose; review that an ADR repair did
+not change its decision; and the touched area's tests for a behavior-preserving
+refactor. File type alone does not grant the exemption: a documentation or ADR
+change that alters runtime behavior remains behavior-bearing and follows the
+full tier rule. Promoting a tier to required is always allowed; dropping a
+required tier is not.
 
 Classification is taken at triage and re-checked whenever the diff grows past
 the scope that was triaged. A tier that becomes reachable is promoted to

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,6 +126,14 @@ the regenerated files.
 - Every behavior-bearing change must be verified end-to-end through the real
   product loop (the `curie` CLI, the compose services, or a real sandbox on a
   local `kind`/`k3s` cluster), not just by unit tests.
+- A change with no runtime behavior is exempt from E2E tier classification and
+  E2E evidence for each acceptance criterion. State the reason once and report
+  the checks appropriate to the changed artifact instead: applicable prose
+  validators for documentation, confirmation that an ADR repair leaves its
+  decision unchanged, or the touched area's tests for a behavior-preserving
+  refactor. Documentation, ADR, and strictly behavior-preserving refactor
+  changes can qualify; the file type alone does not. If a documentation or ADR
+  change alters runtime behavior, the full E2E tier rule still applies.
 - If you touch one side of a known parity seam (see the registry in
   AGENTS.md), do one of:
   - Change the sibling in the same PR.


### PR DESCRIPTION
## Summary

Clarify the behavior-based E2E exemption across the authoritative agent rules, contributor guidance, and pull request template. Changes with no runtime behavior now state one rationale and report artifact-scoped checks, while documentation or ADR changes that alter runtime behavior retain the complete tier and per-acceptance-criterion evidence requirements.

## Related issue

Ref #1976

## Fix pin verification

Not a fix pull request.

## End-to-end verification

This change does not alter runtime behavior because it changes contributor and process guidance only; it does not modify code, runtime contracts, CI enforcement, schemas, or release artifacts.

Scoped verification: `git diff --check HEAD^ HEAD` passed on `a5bc424e5`; the commit changes exactly `AGENTS.md`, `CONTRIBUTING.md`, and `.github/PULL_REQUEST_TEMPLATE.md`; `packages/aci-protocol` and `packages/plugin-format` are unchanged.

## Checklist

- [x] Scoped diff verification passed for the three contributor/process files.
- [x] Behavior-bearing changes still require the full E2E tier classification and evidence path.
- [x] Documentation and ADR file types are explicitly not automatic exemptions.
- [x] Frozen contract packages are unchanged.
