### PR TITLE
Enable default provider-side web search for bundles

### DIFF
--- a/cli/src/bundle.rs
+++ b/cli/src/bundle.rs
@@ -392,6 +392,11 @@ mod tests {
         crate::scaffold::scaffold(dir.path(), "deal-desk").unwrap();
         std::fs::create_dir_all(dir.path().join(".curie")).unwrap();
         std::fs::write(dir.path().join(".curie/runner.json"), "{}").unwrap();
+        std::fs::write(
+            dir.path().join("curie.bundle.json"),
+            r#"{"webSearch":false}"#,
+        )
+        .unwrap();
         std::fs::create_dir_all(dir.path().join(".git")).unwrap();
         std::fs::write(dir.path().join(".git/HEAD"), "ref").unwrap();
 
@@ -399,6 +404,7 @@ mod tests {
         assert!(names.contains(&".claude-plugin/plugin.json".to_string()));
         assert!(names.contains(&"skills/deal-desk/SKILL.md".to_string()));
         assert!(names.contains(&".mcp.json".to_string()));
+        assert!(names.contains(&"curie.bundle.json".to_string()));
         assert_eq!(
             digest_source(dir.path()).unwrap(),
             snapshot(dir.path()).unwrap().digest,

--- a/docs/adr/0138-provider-side-web-search-is-a-default-on-bundle-capability.md
+++ b/docs/adr/0138-provider-side-web-search-is-a-default-on-bundle-capability.md
@@ -1,0 +1,192 @@
+# 138. Provider-side web search is a default-on bundle capability
+
+Date: 2026-09-01
+
+Status: Proposed
+
+This proposal records the maintainer direction in #2177. It does not accept
+itself or authorize a merge; acceptance remains a separate maintainer action.
+
+## Context
+
+Bots need current public-web facts for the end-to-end demo, but a general
+sandbox egress allowance would weaken Curie's default-deny boundary. DNS and
+HTTP from model-controlled processes would need an open-ended destination
+policy, expose another credential and request path to govern, and reproduce a
+capability the model provider already operates.
+
+Anthropic's [tool reference](https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-reference)
+distinguishes server tools from client tools. Its
+[`web_search` server tool](https://platform.claude.com/docs/en/agents-and-tools/tool-use/web-search-tool)
+executes on Anthropic infrastructure and returns server-tool use and result
+blocks in the model response. In the Claude Agent SDK, the corresponding Claude
+Code built-in is named `WebSearch`. The sandbox therefore needs only the same
+provider connection the model turn already uses; it does not connect to search
+engines or result hosts itself.
+
+Curie's Claude harness already selects the complete Claude Code tool preset.
+That establishes the tool catalogue, but there is no bundle-level declaration
+for a bot which must not search. Skill `allowed-tools` frontmatter is the wrong
+boundary: it applies when a skill is active, means permission preauthorization
+rather than catalogue membership, and can shadow Curie's approval callback.
+
+The Claude plugin manifest is a frozen compatibility contract. Adding a
+Curie-only field to `.claude-plugin/plugin.json` would turn this feature into a
+plugin-format change and require a separately reviewed contract change before
+the runner could consume it. `curie.yaml` is also unavailable: ADR 0097 assigns
+that file to installation intent, not an immutable agent bundle.
+
+GitHub repository reads are a different capability. They require the
+first-party credential and egress boundary in ADR 0075 and are not web-search
+traffic.
+
+## Decision
+
+**The Claude harness offers Anthropic's provider-side `WebSearch` tool by
+default. An immutable bundle may opt out through a Curie-owned bundle config;
+the opt-out removes the tool from the model catalogue and never changes sandbox
+egress.**
+
+### The bundle config is `curie.bundle.json`
+
+An optional `curie.bundle.json` at the bundle root carries Curie runtime
+configuration that is not part of the frozen Claude plugin format. Its first
+shape is:
+
+```json
+{
+  "webSearch": false
+}
+```
+
+An absent file, or an explicit boolean `true`, means web search is enabled. An
+explicit boolean `false` is the per-bundle opt-out. The file is part of the
+immutable bundle snapshot and archive, so one deployed bundle version cannot
+change the capability of an already-running version.
+
+The document is a strict Curie-owned object. Invalid JSON, a non-object root, an
+unknown key, or a non-boolean `webSearch` value fails runner boot with the file
+and defect named. A misspelled opt-out must not silently widen capability.
+
+The runner is the authoritative loader. This sidecar deliberately does not add
+a field to `packages/plugin-format`, `packages/aci-protocol`, the worker boot
+environment, deployment state, or installation configuration.
+
+### Default-on and opt-out use the SDK's availability controls
+
+The default continues to pass the Claude Code tool preset through
+`ClaudeAgentOptions.tools`, under which `WebSearch` is offered. Curie does not
+add `WebSearch` to `allowed_tools`: that option preauthorizes execution and can
+bypass permission callbacks rather than controlling availability.
+
+When `webSearch` is `false`, the runner passes `WebSearch` through
+`ClaudeAgentOptions.disallowed_tools`. The initialized model tool catalogue must
+then omit `WebSearch`; suppressing a prompt mention or merely denying a later
+call is insufficient. The bundle's ordinary approval policy and hooks remain
+unchanged for every other tool.
+
+Provider organization policy remains authoritative. If Anthropic has disabled
+web search for the organization, a bundle cannot override it and the provider
+error remains visible. Curie does not fall back to a sandbox HTTP client, an MCP
+search service, or unverified model recall.
+
+### The provider connection is the only network path
+
+Search requests and results ride the model session's existing provider
+connection. This decision authorizes no NetworkPolicy edits, DNS or CIDR
+allowances, generic web egress, new proxy route, credential forwarding, or
+credential storage. It also does not enable `WebFetch`; fetching arbitrary
+result URLs is a separate capability and egress decision.
+
+GitHub reads remain entirely out of scope. They ride the ADR 0075 Agent Proxy
+when that implementation lands, never a web-search exception or a repository
+CIDR carve-out.
+
+### Verification proves availability at the real consumer boundary
+
+The realization must prove both halves against the pinned Claude Agent SDK:
+
+- with no `curie.bundle.json`, the initialized Claude tool catalogue contains
+  `WebSearch` and a live Anthropic turn can invoke provider-side search; and
+- with `{"webSearch": false}`, the initialized catalogue omits `WebSearch`.
+
+The negative uses the same bundle and runner path with only the opt-out changed.
+Unit tests also pin strict config parsing and the exact SDK option mapping.
+
+This change reaches the runner turn loop, so the `skill` tier is required. It
+changes provider-tool availability, so a live-provider observation is also
+required before completion. The `local`, `local-release`, and `cluster` tiers
+are not required because the change does not alter compose wiring, released
+artifact identity, chart templates, sandbox claims, or service boot env. The
+external-integration tier is not separate from the live-provider observation:
+the only external system exercised is the model provider itself.
+
+## Consequences
+
+Every Claude-backed bot can search current public-web information without
+authors copying tool permissions into skills. Bundles with policy, cost, or
+determinism reasons to avoid search have a versioned opt-out whose effect is
+visible in the initialized tool catalogue.
+
+The security posture does not gain a new sandbox destination. Search content is
+still untrusted model input, and provider-side execution does not make a result
+authoritative; skills and evals remain responsible for source quality and
+citation requirements.
+
+Provider web search may incur separate usage charges and may be unavailable for
+a model, gateway, region, or organization policy. Those failures stay explicit.
+Curie does not silently substitute a client-side implementation whose egress or
+provenance differs.
+
+`curie.bundle.json` creates a small Curie-owned bundle surface alongside, not
+inside, the Claude plugin format. Future keys require their own decision and
+runtime validation; older runners will not understand such keys and must not be
+claimed as enforcing them.
+
+The implementation prepared alongside this proposal is review evidence only.
+Its presence does not accept this ADR, make either pull request ready to merge,
+or authorize merging implementation before the maintainer decides the ADR.
+
+## Alternatives considered
+
+### Add public-web CIDRs or hostnames to sandbox NetworkPolicy
+
+Rejected. Search destinations and result hosts are open-ended, DNS changes over
+time, and the sandbox does not need to contact them when the provider executes
+the tool.
+
+### Run a search client or MCP server inside the sandbox
+
+Rejected. It adds sandbox egress, another runtime and credential boundary, and a
+second result path without improving the demo capability.
+
+### Put `WebSearch` in every skill's `allowed-tools`
+
+Rejected. Skill activation is not bundle capability configuration, and
+`allowed-tools` preauthorizes calls rather than deciding which tools the model
+can see. It can also shadow Curie's permission gates.
+
+### Add `webSearch` to `.claude-plugin/plugin.json`
+
+Rejected for this realization. The manifest is part of the frozen
+plugin-format interface; changing it would require a separately landed contract
+PR before dependent runner work, which is unnecessary for a Curie-only runtime
+choice.
+
+### Put the opt-out in `curie.yaml` or deployment metadata
+
+Rejected. `curie.yaml` describes an installation and deployment metadata is
+mutable operator state. Search policy belongs to the immutable bundle version
+whose behavior it changes.
+
+### Default off and require each bundle to opt in
+
+Rejected. Current public-web facts are a baseline bot capability for the demo,
+and provider-side execution preserves the existing sandbox boundary. A narrow
+opt-out expresses the exceptional bundle instead of making every ordinary
+bundle repeat configuration.
+
+### Treat GitHub repository reads as web search
+
+Rejected. Repository reads cross a first-party authorization and credential
+boundary. ADR 0075 owns that path; search must not become a back door around it.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -167,4 +167,5 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0135 | [A skill bundle has two conformance profiles](0135-a-skill-bundle-has-two-conformance-profiles.md) | Draft |
 | 0136 | [A late workspace handoff replaces the sandbox at a fenced turn boundary](0136-a-late-workspace-handoff-replaces-the-sandbox-at-a-fenced-turn-boundary.md) | Accepted |
 | 0137 | [Coding tools are built in and an initial repository URL selects the workspace](0137-coding-tools-are-built-in-and-an-initial-repository-url-selects-the-workspace.md) | Draft |
+| 0138 | [Provider-side web search is a default-on bundle capability](0138-provider-side-web-search-is-a-default-on-bundle-capability.md) | Proposed |
 <!-- END GENERATED: adr-index -->

--- a/runner/README.md
+++ b/runner/README.md
@@ -20,6 +20,10 @@ locally in Docker.
 - Emits `side_effect_flag` when a non-idempotent tool executes (read-only
   allowlist, deny-by-default; see `side_effects.py`).
 - Loads and validates the mounted plugin bundle via `plugin_format.validate_bundle`.
+- Offers Anthropic's provider-side `WebSearch` tool by default. A bundle can
+  suppress it with a root `curie.bundle.json` containing
+  `{"webSearch": false}`; the provider connection remains the only network
+  path, so this adds no sandbox web egress.
 - Exports gen_ai OTel spans (`agent.run` -> `llm.generation` -> `execute_tool`)
   via OTLP-HTTP (the OpenTelemetry Protocol over HTTP) to the collector, which
   forwards to Langfuse.
@@ -122,5 +126,9 @@ uv run pytest runner/tests -q   # unit + integration + conformance
 uv run ruff check . && uv run mypy
 ```
 
-Live tests (`runner/tests/test_live.py`) run only when `CLAUDE_CODE_OAUTH_TOKEN`
-or `ANTHROPIC_API_KEY` is present; otherwise they are skipped.
+Most live tests (`runner/tests/test_live.py`) run only when
+`CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY` is present. Disposable tests
+explicitly selected with `CURIE_E2E_LIVE=1`, including the provider-side web
+search proof, may instead use an already-authenticated local Claude SDK. Without
+either authentication path they fail honestly rather than fabricating a live
+result.

--- a/runner/src/curie_runner/__init__.py
+++ b/runner/src/curie_runner/__init__.py
@@ -32,7 +32,12 @@ from .memory import (
     resolve_memory,
 )
 from .otel import SCHEMA_VERSION, RunTracer, SpanAttributeKey, build_tracer_provider
-from .plugin import PluginBundleError, load_bundle_system_prompt, load_plugins
+from .plugin import (
+    PluginBundleError,
+    load_bundle_system_prompt,
+    load_bundle_web_search_enabled,
+    load_plugins,
+)
 from .server import create_app
 from .session import SessionRunner
 from .side_effects import (
@@ -60,6 +65,7 @@ __all__ = [
     "PluginBundleError",
     "load_plugins",
     "load_bundle_system_prompt",
+    "load_bundle_web_search_enabled",
     "load_bundle_hooks",
     "create_app",
     "SessionRunner",

--- a/runner/src/curie_runner/__main__.py
+++ b/runner/src/curie_runner/__main__.py
@@ -57,6 +57,7 @@ from .history import (
 from .hooks import load_bundle_hooks
 from .memory import MemoryRecord, MemoryStore, format_memory_preamble, resolve_memory
 from .otel import RunTracer, build_tracer_provider
+from .plugin import load_bundle_web_search_enabled
 from .redact import install_stdout_redaction
 from .sdk_auth import UnsupportedCredentialError
 from .server import create_app
@@ -185,6 +186,7 @@ def build_runner(
     # bundle's plugins feed the session factory below.
     compiled = harness.compile_bundle(config.session.plugin_dir)
     system_prompt = compiled.system_prompt
+    web_search_enabled = load_bundle_web_search_enabled(config.session.plugin_dir)
     # Prior memory (#264) still leads the system prompt. Conversation history
     # (#20) deliberately does not: ADR-0119 sends its ordered messages through
     # the harness adapter below. The configured model identity is appended after
@@ -349,6 +351,7 @@ def build_runner(
             ),
             can_use_tool=(build_can_use_tool(approval_gate) if approval_gate is not None else None),
             cwd=workspace_cwd,
+            web_search_enabled=web_search_enabled,
         )
         return ClaudeAgentSession(options)
 

--- a/runner/src/curie_runner/adapter.py
+++ b/runner/src/curie_runner/adapter.py
@@ -295,6 +295,7 @@ def build_options(
     mcp_servers: dict[str, McpSdkServerConfig] | None = None,
     can_use_tool: CanUseTool | None = None,
     cwd: str | None = None,
+    web_search_enabled: bool = True,
 ) -> ClaudeAgentOptions:
     """Assemble ClaudeAgentOptions for the session.
 
@@ -333,6 +334,12 @@ def build_options(
         # any call or bypass Curie's permission/approval callbacks.
         tools=cast("Any", {"type": "preset", "preset": "claude_code"}),
         allowed_tools=[],
+        # Anthropic documents WebSearch as a provider-executed server tool.
+        # ``disallowed_tools`` removes a tool from the model catalogue; unlike
+        # ``allowed_tools`` it is not a permission preauthorization. See:
+        # https://platform.claude.com/docs/en/agents-and-tools/tool-use/web-search-tool
+        # https://github.com/anthropics/claude-agent-sdk-python#using-tools
+        disallowed_tools=[] if web_search_enabled else ["WebSearch"],
         **thinking_option,
         **cwd_option,
         system_prompt=system_prompt,

--- a/runner/src/curie_runner/plugin.py
+++ b/runner/src/curie_runner/plugin.py
@@ -15,9 +15,51 @@ from pathlib import Path
 from claude_agent_sdk import SdkPluginConfig
 from plugin_format import PluginManifest, resolve_manifest, validate_bundle
 
+BUNDLE_CONFIG_NAME = "curie.bundle.json"
+
 
 class PluginBundleError(RuntimeError):
     """Raised when the mounted plugin bundle fails validation."""
+
+
+def load_bundle_web_search_enabled(plugin_dir: str | None) -> bool:
+    """Return the bundle's provider-side web-search choice (ADR-0138).
+
+    ``curie.bundle.json`` is a Curie-owned sidecar beside, not inside, the
+    frozen Claude plugin-format contract. An absent sidecar defaults on. A
+    present document is strict because a misspelled opt-out would otherwise
+    widen the model's capability while appearing to disable it.
+    """
+
+    if not plugin_dir:
+        return True
+    config_path = Path(plugin_dir) / BUNDLE_CONFIG_NAME
+    try:
+        raw = config_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return True
+    except OSError as exc:
+        raise PluginBundleError(f"cannot read {config_path}: {exc}") from exc
+
+    try:
+        loaded = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise PluginBundleError(
+            f"invalid {config_path}: expected JSON object ({exc.msg})"
+        ) from exc
+    if not isinstance(loaded, dict):
+        raise PluginBundleError(f"invalid {config_path}: root must be a JSON object")
+    unknown = sorted(set(loaded) - {"webSearch"})
+    if unknown:
+        raise PluginBundleError(
+            f"invalid {config_path}: unknown key(s): {', '.join(unknown)}"
+        )
+    enabled = loaded.get("webSearch", True)
+    if not isinstance(enabled, bool):
+        raise PluginBundleError(
+            f"invalid {config_path}: webSearch must be a JSON boolean"
+        )
+    return enabled
 
 
 def load_bundle_system_prompt(plugin_dir: str | None) -> str | None:

--- a/runner/tests/test_harness_boot_wiring.py
+++ b/runner/tests/test_harness_boot_wiring.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 
 import pytest
+from curie_runner import PluginBundleError
 from curie_runner import __main__ as boot
 from curie_runner.__main__ import DEFAULT_HARNESS, _resolve_harness, build_runner
 from curie_runner.config import RunnerConfig
@@ -92,6 +93,39 @@ def test_claude_runner_materializes_history_without_system_prompt_preamble(tmp_p
     assert options.resume is not None
     assert options.session_store is not None
     assert runner._history_resumed is True
+
+
+def test_claude_runner_offers_provider_web_search_by_default(tmp_path) -> None:
+    runner = build_runner(_config(tmp_path))
+    options = runner._factory()._options
+
+    assert options.tools == {"type": "preset", "preset": "claude_code"}
+    assert "WebSearch" not in options.disallowed_tools
+    assert options.allowed_tools == []
+
+
+def test_claude_runner_bundle_opt_out_suppresses_provider_web_search(tmp_path) -> None:
+    config = _config(tmp_path)
+    (tmp_path / "curie.bundle.json").write_text(
+        json.dumps({"webSearch": False}), encoding="utf-8"
+    )
+
+    runner = build_runner(config)
+    options = runner._factory()._options
+
+    assert options.tools == {"type": "preset", "preset": "claude_code"}
+    assert options.disallowed_tools == ["WebSearch"]
+    assert options.allowed_tools == []
+
+
+def test_claude_runner_refuses_a_misspelled_bundle_opt_out(tmp_path) -> None:
+    config = _config(tmp_path)
+    (tmp_path / "curie.bundle.json").write_text(
+        json.dumps({"websearch": False}), encoding="utf-8"
+    )
+
+    with pytest.raises(PluginBundleError, match="unknown key.*websearch"):
+        build_runner(config)
 
 
 def test_build_runner_uses_the_harness_readonly_set(tmp_path) -> None:

--- a/runner/tests/test_live.py
+++ b/runner/tests/test_live.py
@@ -11,7 +11,9 @@ A third live test covers the OpenRouter path, gated on ``OPENROUTER_API_KEY``.
 
 import os
 import shlex
+from pathlib import Path
 from typing import Any
+from uuid import uuid4
 
 import anyio
 import pytest
@@ -254,6 +256,102 @@ def test_live_permission_gate_pauses_awaiting_approval() -> None:
     # The blocked command never executed and never produced output text
     # claiming it ran; the summary records what WOULD have run.
     assert "echo curie-gate-live" in final.approval_summary
+
+
+@pytest.mark.skipif(
+    not _LIVE_REQUESTED,
+    reason="set CURIE_E2E_LIVE=1 for provider-side web-search evidence",
+)
+def test_live_provider_web_search_default_and_bundle_opt_out(tmp_path: Path) -> None:
+    """The provider executes default WebSearch; the opt-out removes it.
+
+    Anthropic documents ``web_search`` as a server tool whose result blocks
+    arrive in the model response, and the Agent SDK documents ``WebSearch`` as
+    the Claude Code built-in name. These are external API facts, not inferred
+    from Curie's option mapping:
+    https://platform.claude.com/docs/en/agents-and-tools/tool-use/web-search-tool
+    https://github.com/anthropics/claude-agent-sdk-python#using-tools
+    """
+
+    from claude_agent_sdk import (
+        AssistantMessage,
+        ClaudeAgentOptions,
+        ClaudeSDKClient,
+        ResultMessage,
+        SystemMessage,
+        ToolResultBlock,
+        ToolUseBlock,
+        UserMessage,
+    )
+    from curie_runner.__main__ import build_runner
+    from curie_runner.config import RunnerConfig
+
+    def bundle_options(enabled: bool) -> ClaudeAgentOptions:
+        bundle = tmp_path / ("default" if enabled else "opted-out")
+        manifest = bundle / ".claude-plugin" / "plugin.json"
+        manifest.parent.mkdir(parents=True)
+        manifest.write_text('{"name": "acme-web-search"}', encoding="utf-8")
+        if not enabled:
+            (bundle / "curie.bundle.json").write_text(
+                '{"webSearch": false}', encoding="utf-8"
+            )
+        run_id = str(uuid4())
+        config = RunnerConfig.from_env(
+            {
+                "CURIE_PLUGIN_DIR": str(bundle),
+                "CURIE_SESSION_ID": run_id,
+                "CURIE_SANDBOX_ID": run_id,
+                "CURIE_BUDGET": (
+                    '{"max_output_tokens_per_run": 10000, "max_usd_per_day": 1.0}'
+                ),
+            }
+        )
+        return build_runner(config)._factory()._options
+
+    async def observe(options: ClaudeAgentOptions, prompt: str) -> dict[str, Any]:
+        observed: dict[str, Any] = {
+            "catalog": None,
+            "tool_ids": {},
+            "result_ids": set(),
+            "terminal_success": False,
+        }
+        async with ClaudeSDKClient(options) as client:
+            await client.query(prompt)
+            async for message in client.receive_response():
+                if isinstance(message, SystemMessage) and message.subtype == "init":
+                    observed["catalog"] = "WebSearch" in (message.data.get("tools") or [])
+                if isinstance(message, AssistantMessage):
+                    for block in message.content:
+                        if isinstance(block, ToolUseBlock):
+                            observed["tool_ids"][block.name] = block.id
+                if isinstance(message, UserMessage):
+                    for block in message.content:
+                        if isinstance(block, ToolResultBlock):
+                            observed["result_ids"].add(block.tool_use_id)
+                if isinstance(message, ResultMessage):
+                    observed["terminal_success"] = not message.is_error
+                    break
+        return observed
+
+    async def go() -> tuple[dict[str, Any], dict[str, Any]]:
+        default = await observe(
+            bundle_options(True),
+            "Use WebSearch to find Anthropic's official web search tool "
+            "documentation, then reply with only: done",
+        )
+        opted_out = await observe(bundle_options(False), "Reply with only: done")
+        return default, opted_out
+
+    default, opted_out = anyio.run(go)
+
+    assert default["catalog"] is True
+    assert "WebSearch" in default["tool_ids"]
+    assert default["tool_ids"]["WebSearch"] in default["result_ids"]
+    assert default["terminal_success"] is True
+
+    assert opted_out["catalog"] is False
+    assert "WebSearch" not in opted_out["tool_ids"]
+    assert opted_out["terminal_success"] is True
 
 
 @pytest.mark.skipif(

--- a/runner/tests/test_plugin.py
+++ b/runner/tests/test_plugin.py
@@ -57,3 +57,36 @@ def test_bundle_system_prompt_bad_manifest_is_none(tmp_path: Path) -> None:
     (tmp_path / ".claude-plugin").mkdir()
     (tmp_path / ".claude-plugin" / "plugin.json").write_text("{ not json", encoding="utf-8")
     assert load_bundle_system_prompt(str(tmp_path)) is None
+
+
+def test_bundle_web_search_defaults_on_and_accepts_explicit_boolean(tmp_path: Path) -> None:
+    from curie_runner import load_bundle_web_search_enabled
+
+    assert load_bundle_web_search_enabled(None) is True
+    assert load_bundle_web_search_enabled(str(tmp_path)) is True
+
+    config = tmp_path / "curie.bundle.json"
+    config.write_text('{"webSearch": true}', encoding="utf-8")
+    assert load_bundle_web_search_enabled(str(tmp_path)) is True
+
+    config.write_text('{"webSearch": false}', encoding="utf-8")
+    assert load_bundle_web_search_enabled(str(tmp_path)) is False
+
+
+@pytest.mark.parametrize(
+    ("body", "message"),
+    [
+        ("not json", "expected JSON object"),
+        ("[]", "root must be a JSON object"),
+        ('{"websearch": false}', "unknown key"),
+        ('{"webSearch": "false"}', "must be a JSON boolean"),
+    ],
+)
+def test_bundle_web_search_invalid_config_fails_closed(
+    tmp_path: Path, body: str, message: str
+) -> None:
+    from curie_runner import load_bundle_web_search_enabled
+
+    (tmp_path / "curie.bundle.json").write_text(body, encoding="utf-8")
+    with pytest.raises(PluginBundleError, match=message):
+        load_bundle_web_search_enabled(str(tmp_path))


### PR DESCRIPTION
## Summary

- add strict root bundle config `curie.bundle.json` with default-on `webSearch`
- preserve the Claude Code tool preset by default and map the per-bundle opt-out to `disallowed_tools=["WebSearch"]`
- prove default offering and opt-out suppression through runner boot wiring and a live Anthropic provider stream

This implementation is stacked on proposed ADR #2178. Merge #2178 first; this PR intentionally remains a draft for Brian's review. The branch targets `next` and includes the ADR commit beneath the implementation commit.

Closes #2177

## Boundaries

- no NetworkPolicy or other sandbox-egress changes
- no credential-discovery, forwarding, or handling changes
- no frozen ACI or plugin-format contract changes
- no GitHub-read implementation; that remains on the ADR-0075 agent-proxy path

## Verification

### Provider behavior and opt-out

```text
$ CURIE_E2E_LIVE=1 uv run pytest runner/tests/test_live.py -k provider_web_search -q -s
.
1 passed, 6 deselected in 25.63s
```

The live test asserts that the default bundle's initialization catalogue offers `WebSearch`, the model invokes it, a corresponding tool result returns through the SDK stream, and the turn succeeds. Its independent opt-out path asserts the catalogue omits `WebSearch`, no web-search call occurs, and the turn still succeeds.

### Required skill tier

Cargo is configured to use this checkout's shared target directory, so the source-built binary was supplied explicitly to the repository harness:

```text
$ CURIE_BIN=/home/theconnman/.cargo/shared-targets/agentos/release/curie CURIE_E2E_TIERS=skill curie dev e2e-ladder
...
E2E PASS
...
LADDER PASS (tiers: skill)
```

### Regression suites

```text
$ uv run pytest runner/tests/test_plugin.py runner/tests/test_harness_boot_wiring.py -q
23 passed in 1.11s

$ env -u OTEL_EXPORTER_OTLP_ENDPOINT -u OTEL_EXPORTER_OTLP_HEADERS -u OTEL_EXPORTER_OTLP_PROTOCOL uv run pytest runner/tests -q
736 passed, 7 skipped in 36.61s

$ uv run ruff check runner/
All checks passed!

$ uv run mypy
Success: no issues found in 243 source files

$ bash scripts/check-docs.sh
OK: 35 interface docs, 138 ADRs; 23 intentional symbol suppressions

$ cd cli && cargo fmt --check && cargo clippy -- -D warnings && cargo test
all unit, integration, and documentation tests passed
```

## Tier classification

| Tier | Decision | Evidence / reason |
| --- | --- | --- |
| skill | required | exact skill ladder passed against the source-built runner image |
| local | not applicable | no compose service, API, worker, dispatcher, UI, or CLI output contract changed |
| local-release | not applicable | no released binary/image identity, install path, version pin, or release compose changed |
| cluster | not applicable | no chart, RBAC, security context, NetworkPolicy, sandbox claim, or init container changed |
| live provider | required | live Anthropic SDK stream proved default invocation/result and opt-out suppression |
| external integration | not applicable | no Slack, webhook, OAuth, connector, or other third-party integration changed |

## Review state

- [x] ADR PR #2178 is open and Proposed
- [x] implementation is a distinct commit stacked on the ADR commit
- [x] both PRs target `next`
- [ ] maintainer review and acceptance

