### PR TITLE
Fix initial Helm chart index publication

### DIFF
--- a/.github/workflows/chart-index.yaml
+++ b/.github/workflows/chart-index.yaml
@@ -4,6 +4,7 @@ on:
   workflow_run:
     workflows: [Release images and binaries]
     types: [completed]
+  workflow_dispatch: {}
   push:
     branches: [next]
     paths:
@@ -21,6 +22,7 @@ jobs:
     name: Verify the release and publish its chart index
     if: >-
       github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'workflow_run' &&
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'push' &&
@@ -191,7 +193,9 @@ jobs:
 
           git config user.name github-actions
           git config user.email github-actions@users.noreply.github.com
-          cr index --config cr.yaml --push
+          index_path="$RUNNER_TEMP/curie-chart-index/index.yaml"
+          mkdir -p "$(dirname "$index_path")"
+          cr index --config cr.yaml --index-path "$index_path" --push
 
       - name: Install Helm
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1

--- a/release/tests/test_chart_index_workflow.py
+++ b/release/tests/test_chart_index_workflow.py
@@ -31,11 +31,12 @@ class TestChartIndexWorkflowContract:
         trigger = workflow["on"]
         job = next(iter(workflow["jobs"].values()))
 
-        assert set(trigger) == {"workflow_run", "push"}
+        assert set(trigger) == {"workflow_run", "workflow_dispatch", "push"}
         assert trigger["workflow_run"] == {
             "workflows": ["Release images and binaries"],
             "types": ["completed"],
         }
+        assert trigger["workflow_dispatch"] == {}
         assert trigger["push"]["branches"] == ["next"]
         assert len(trigger["push"]["paths"]) == 2
         assert set(trigger["push"]["paths"]) == {
@@ -44,6 +45,7 @@ class TestChartIndexWorkflowContract:
         }
         condition = " ".join(job["if"].split())
         assert "github.event_name == 'push'" in condition
+        assert "github.event_name == 'workflow_dispatch'" in condition
         assert "github.event_name == 'workflow_run'" in condition
         assert "github.event.workflow_run.conclusion == 'success'" in condition
         assert "github.event.workflow_run.event == 'push'" in condition
@@ -240,6 +242,21 @@ class TestChartIndexWorkflowContract:
         assert tracking_fetch is not None
         tracking_position = seed_push.end() + tracking_fetch.start()
         assert orphan.start() < seed_push.start() < tracking_position < index.start()
+
+    def test_chart_releaser_output_parent_exists_before_indexing(self):
+        workflow = load_yaml(WORKFLOW_PATH)
+        publication_script = next(
+            run_script(step)
+            for step in workflow_steps(workflow)
+            if re.search(r"\bcr\s+index\b", run_script(step))
+        )
+
+        output_path = publication_script.index('index_path="$RUNNER_TEMP/')
+        parent = publication_script.index('mkdir -p "$(dirname "$index_path")"')
+        index = publication_script.index('cr index --config cr.yaml')
+
+        assert output_path < parent < index
+        assert '--index-path "$index_path"' in publication_script[index:]
 
     def test_chart_releaser_cli_is_literal_digest_verified_before_it_can_run(self):
         workflow = load_yaml(WORKFLOW_PATH)


### PR DESCRIPTION
## Summary

The first v0.8.3 Helm index publication created `gh-pages` successfully, then chart-releaser v1.7.0 failed because its default local output parent did not exist. Give the output an explicit runner-temporary parent before indexing, and add a manual-dispatch recovery path that selects and re-verifies the latest stable release through the same job.

## Related issue

Failed release follow-up: https://github.com/curie-eng/curie/actions/runs/33520321514

## Fix pin verification

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | The workflow does not reach plugin packaging, runner turns, or ACI events. | n/a | n/a |
| local | n/a | The workflow does not start or change the compose product loop or CLI output. | n/a | n/a |
| local-release | n/a | Release artifacts are consumed unchanged; the build/install path is not modified. | n/a | n/a |
| cluster | n/a | No chart template, RBAC, sandbox, or cluster runtime behavior changes. | n/a | n/a |
| live provider | n/a | No model routing, credential, token, or provider behavior changes. | n/a | n/a |
| external integration | required | This changes the GitHub Pages Helm-index publisher. | live | On merge `ad1c88958`, `gh workflow run chart-index.yaml --ref main` produced run 33523046176: all release authorization, signature, provenance, index publication, `helm search`, and `helm pull` steps passed. Negative on `510c510e`: run 33520321514 failed at `open .cr-index/index.yaml...: no such file or directory`. Independent path: a fresh local Helm home found `curie/curie 0.8.3`, pulled it, and its bytes matched the verified release chart. |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path. The regression contract failed before the workflow edit and passes after it; the failed live run is the negative external observation.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

## Verification

- `uv run pytest -q release/tests/test_chart_index_workflow.py` - 15 passed; the two new assertions failed before the implementation.
- `uv run pytest -q release/tests` - 133 passed.
- `bash scripts/check-docs.sh` - passed.
- `git diff --check` - passed.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed. The workflow is the operator contract; no user-facing command changed.
- [x] An ADR is added under `docs/adr/` if this is an architectural decision. No architectural decision changed.
