### PR TITLE
Verify coder changes before publication

### DIFF
--- a/examples/coder/skills/coder/SKILL.md
+++ b/examples/coder/skills/coder/SKILL.md
@@ -28,6 +28,10 @@ session thread. If you cannot identify or run an appropriate command, report
 that fact and do not publish. If the command fails, report the failure and do not
 publish.
 
+If verification generates artifacts, do not publish unrequested artifacts. Use
+the repository's documented cleanup procedure when one exists; otherwise report
+the generated artifacts in the session thread and do not publish.
+
 When the user asks to publish the current changes, call
 `mcp__curie__publish_changes`. The platform will post an approval card in the
 session thread and will report the pull-request URL there after approval. Only

--- a/examples/coder/skills/coder/SKILL.md
+++ b/examples/coder/skills/coder/SKILL.md
@@ -20,7 +20,16 @@ Make only the requested change. Do not reset, discard, or overwrite work already
 present in the checkout. Report the paths changed and one short description per
 path; if nothing changed, say so plainly.
 
+After making a requested change, and before any publication request, inspect the
+repository's own documentation in `/workspace` to identify the focused test or
+check command for the changed area. Run that command from `/workspace` with
+`Bash`, then report the exact command, exit status, and a concise result in the
+session thread. If you cannot identify or run an appropriate command, report
+that fact and do not publish. If the command fails, report the failure and do not
+publish.
+
 When the user asks to publish the current changes, call
 `mcp__curie__publish_changes`. The platform will post an approval card in the
-session thread and will report the pull-request URL there after approval. Do not
-push, mint credentials, or open a pull request from the workspace.
+session thread and will report the pull-request URL there after approval. Only
+call it after the verification step above succeeds. Do not push, mint
+credentials, or open a pull request from the workspace.

--- a/examples/coder/skills/coder/SKILL.md
+++ b/examples/coder/skills/coder/SKILL.md
@@ -29,8 +29,10 @@ that fact and do not publish. If the command fails, report the failure and do no
 publish.
 
 If verification generates artifacts, do not publish unrequested artifacts. Use
-the repository's documented cleanup procedure when one exists; otherwise report
-the generated artifacts in the session thread and do not publish.
+the repository's documented cleanup procedure when one exists, but remove only
+artifacts created by this verification; never remove requested or unrelated
+checkout work. Otherwise report the generated artifacts in the session thread
+and do not publish.
 
 When the user asks to publish the current changes, call
 `mcp__curie__publish_changes`. The platform will post an approval card in the

--- a/examples/tests/test_coder_skill_verification.py
+++ b/examples/tests/test_coder_skill_verification.py
@@ -10,7 +10,6 @@ verification language after it would be too late to guide the coder.
 import re
 from pathlib import Path
 
-
 REPO = Path(__file__).resolve().parents[2]
 CODER_SKILL = REPO / "examples" / "coder" / "skills" / "coder" / "SKILL.md"
 PUBLISH_TOOL = "mcp__curie__publish_changes"
@@ -26,7 +25,6 @@ def _skill_body() -> str:
 
 def test_coder_verifies_and_reports_changes_before_publication() -> None:
     body = _skill_body()
-    lowered = body.casefold()
 
     # Keep the assertion tied to the actual publication paragraph, rather than
     # the same tool name in front matter or an incidental example.
@@ -36,7 +34,6 @@ def test_coder_verifies_and_reports_changes_before_publication() -> None:
         flags=re.IGNORECASE | re.DOTALL,
     )
     assert publication, "coder skill must retain an explicit publication instruction"
-    before_publish = body[: publication.start()]
 
     # Anchor these checks to the verification section itself. The opening
     # workspace instructions alone must not satisfy the contract.

--- a/examples/tests/test_coder_skill_verification.py
+++ b/examples/tests/test_coder_skill_verification.py
@@ -1,0 +1,71 @@
+"""The coder skill must verify changes before offering platform publication.
+
+This is a skill-contract test rather than an implementation test: the coder
+operates in an arbitrary target repository, so the contract must make it run
+that repository's documented check and report the observable result in-thread.
+The publication instruction is deliberately treated as the final boundary;
+verification language after it would be too late to guide the coder.
+"""
+
+import re
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[2]
+CODER_SKILL = REPO / "examples" / "coder" / "skills" / "coder" / "SKILL.md"
+PUBLISH_TOOL = "mcp__curie__publish_changes"
+
+
+def _skill_body() -> str:
+    """Read the instructions, excluding the YAML tool allow-list."""
+    text = CODER_SKILL.read_text(encoding="utf-8")
+    _front_matter, separator, body = text.partition("\n---\n")
+    assert separator, "coder skill has no front-matter separator"
+    return body
+
+
+def test_coder_verifies_and_reports_changes_before_publication() -> None:
+    body = _skill_body()
+    lowered = body.casefold()
+
+    # Keep the assertion tied to the actual publication paragraph, rather than
+    # the same tool name in front matter or an incidental example.
+    publication = re.search(
+        r"when the user asks[^.\n]*publish.*?" + re.escape(PUBLISH_TOOL),
+        body,
+        flags=re.IGNORECASE | re.DOTALL,
+    )
+    assert publication, "coder skill must retain an explicit publication instruction"
+    before_publish = body[: publication.start()]
+
+    assert "/workspace" in before_publish, "verification must run inside the sandbox"
+    assert re.search(
+        r"(?:repository(?:'s)?\s+own|repo[- ]owned|own\s+repository)"
+        r".{0,140}(?:document(?:ed|ation)?).{0,140}"
+        r"(?:test\s+or\s+check|test/check|check\s+or\s+test).{0,80}command",
+        before_publish,
+        flags=re.IGNORECASE | re.DOTALL,
+    ), "run the target repository's documented test/check command"
+    assert re.search(
+        r"(?:after|once|following).{0,100}(?:change|edit|modif)",
+        before_publish,
+        flags=re.IGNORECASE | re.DOTALL,
+    ), "verification must happen after the requested changes"
+
+    assert "thread" in lowered
+    assert "exit status" in lowered
+    assert re.search(r"\bcommand\b", before_publish, flags=re.IGNORECASE)
+    assert re.search(r"\bresult\b", before_publish, flags=re.IGNORECASE)
+
+    # A failed check must be an observable stop condition, not merely a report.
+    failure_blocks_publish = re.search(
+        r"(?:fail(?:s|ed|ure|ing)?|non[- ]zero).{0,140}"
+        r"(?:block|prevent|do not|must not|never).{0,100}publish"
+        r"|(?:do not|must not|never|block|prevent).{0,100}publish"
+        r".{0,140}(?:fail(?:s|ed|ure|ing)?|non[- ]zero)",
+        before_publish,
+        flags=re.IGNORECASE | re.DOTALL,
+    )
+    assert failure_blocks_publish, "a failed verification must prevent publication"
+
+    assert publication.start() > 0, "publication cannot precede verification instructions"

--- a/examples/tests/test_coder_skill_verification.py
+++ b/examples/tests/test_coder_skill_verification.py
@@ -38,24 +38,53 @@ def test_coder_verifies_and_reports_changes_before_publication() -> None:
     assert publication, "coder skill must retain an explicit publication instruction"
     before_publish = body[: publication.start()]
 
-    assert "/workspace" in before_publish, "verification must run inside the sandbox"
+    # Anchor these checks to the verification section itself. The opening
+    # workspace instructions alone must not satisfy the contract.
+    verification = re.search(
+        r"After making a requested change,.*?(?=\nWhen the user asks to publish|\Z)",
+        body,
+        flags=re.IGNORECASE | re.DOTALL,
+    )
+    assert verification, "coder skill must have a distinct pre-publication verification section"
+    verification_text = verification.group(0)
+    assert verification.end() <= publication.start(), (
+        "verification instructions must appear before publication"
+    )
+    assert re.search(
+        r"run\s+(?:that\s+)?command\s+from\s+[`\"']?/workspace[`\"']?",
+        verification_text,
+        flags=re.IGNORECASE,
+    ), "the repository command must explicitly run from /workspace"
     assert re.search(
         r"(?:repository(?:'s)?\s+own|repo[- ]owned|own\s+repository)"
         r".{0,140}(?:document(?:ed|ation)?).{0,140}"
         r"(?:test\s+or\s+check|test/check|check\s+or\s+test).{0,80}command",
-        before_publish,
+        verification_text,
         flags=re.IGNORECASE | re.DOTALL,
     ), "run the target repository's documented test/check command"
     assert re.search(
         r"(?:after|once|following).{0,100}(?:change|edit|modif)",
-        before_publish,
+        verification_text,
         flags=re.IGNORECASE | re.DOTALL,
     ), "verification must happen after the requested changes"
 
-    assert "thread" in before_publish.casefold()
-    assert "exit status" in before_publish.casefold()
-    assert re.search(r"\bcommand\b", before_publish, flags=re.IGNORECASE)
-    assert re.search(r"\bresult\b", before_publish, flags=re.IGNORECASE)
+    assert "thread" in verification_text.casefold()
+    assert "exit status" in verification_text.casefold()
+    assert re.search(r"\bcommand\b", verification_text, flags=re.IGNORECASE)
+    assert re.search(r"\bresult\b", verification_text, flags=re.IGNORECASE)
+
+    assert re.search(
+        r"cannot\s+identify\s+or\s+run\s+an?\s+appropriate\s+command"
+        r".{0,120}(?:do\s+not|must\s+not|never)\s+publish",
+        verification_text,
+        flags=re.IGNORECASE | re.DOTALL,
+    ), "inability to identify or run a command must prevent publication"
+    assert re.search(
+        r"(?:if\s+)?verification\s+generates\s+artifacts?"
+        r".{0,140}(?:do\s+not|must\s+not|never)\s+publish\s+unrequested\s+artifacts?",
+        verification_text,
+        flags=re.IGNORECASE | re.DOTALL,
+    ), "verification artifacts must not publish unrequested artifacts"
 
     # A failed check must be an observable stop condition, not merely a report.
     failure_blocks_publish = re.search(
@@ -63,7 +92,7 @@ def test_coder_verifies_and_reports_changes_before_publication() -> None:
         r"(?:block|prevent|do not|must not|never).{0,100}publish"
         r"|(?:do not|must not|never|block|prevent).{0,100}publish"
         r".{0,140}(?:fail(?:s|ed|ure|ing)?|non[- ]zero)",
-        before_publish,
+        verification_text,
         flags=re.IGNORECASE | re.DOTALL,
     )
     assert failure_blocks_publish, "a failed verification must prevent publication"

--- a/examples/tests/test_coder_skill_verification.py
+++ b/examples/tests/test_coder_skill_verification.py
@@ -52,8 +52,8 @@ def test_coder_verifies_and_reports_changes_before_publication() -> None:
         flags=re.IGNORECASE | re.DOTALL,
     ), "verification must happen after the requested changes"
 
-    assert "thread" in lowered
-    assert "exit status" in lowered
+    assert "thread" in before_publish.casefold()
+    assert "exit status" in before_publish.casefold()
     assert re.search(r"\bcommand\b", before_publish, flags=re.IGNORECASE)
     assert re.search(r"\bresult\b", before_publish, flags=re.IGNORECASE)
 
@@ -67,5 +67,3 @@ def test_coder_verifies_and_reports_changes_before_publication() -> None:
         flags=re.IGNORECASE | re.DOTALL,
     )
     assert failure_blocks_publish, "a failed verification must prevent publication"
-
-    assert publication.start() > 0, "publication cannot precede verification instructions"


### PR DESCRIPTION
## Summary

- Require the coder skill to run and report a repository-owned verification command before publication.
- Add a focused contract test for ordering, failure, and artifact handling.

## Verification

- `uv run pytest examples/tests/test_coder_skill_verification.py -q`
- `bash scripts/check-agent-skills.sh`
- `CURIE_E2E_TIERS=skill curie dev e2e-ladder`
