### PR TITLE
Pin Langfuse to the reviewed migration set

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -212,6 +212,14 @@ jobs:
           set -euo pipefail
           bash charts/curie/ci/langfuse-byo-assertions.sh
 
+      # Keep the shipped Helm and Compose Langfuse images on one exact,
+      # reviewed migration set. A floating major tag can move between jobs and
+      # leave the two stores on incompatible migration state (#2190).
+      - name: helm render assertions (langfuse image pin)
+        run: |
+          set -euo pipefail
+          bash charts/curie/ci/langfuse-image-pin-assertions.sh
+
       # Prove Langfuse startup is gated on ClickHouse being up (issue #2009). A
       # Helm upgrade that recreates the ClickHouse Service otherwise lets the new
       # Langfuse pods start their migrations against an unresolvable name, so the

--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -293,7 +293,7 @@ pipeline and environment are applied on `helm upgrade`.
 
 | Component | Image | Notes |
 |---|---|---|
-| Langfuse web + worker | `langfuse/langfuse:3`, `langfuse/langfuse-worker:3` | Observability + eval backbone. Headless-bootstrapped dev org/project. |
+| Langfuse web + worker | `langfuse/langfuse:3.225.5`, `langfuse/langfuse-worker:3.225.5` | Observability + eval backbone. Headless-bootstrapped dev org/project. Web and worker stay on one reviewed migration set; do not replace the version with floating `:3`. |
 | Postgres | `postgres:16-alpine` | Langfuse transactional store + app state. StatefulSet. |
 | Valkey | `valkey/valkey:8-alpine` | Langfuse cache/queue + dispatcher Streams queue. |
 | ClickHouse | `clickhouse/clickhouse-server:24.8` | Langfuse OLAP store. Tag pinned SSE4.2-safe (see preflight). |

--- a/charts/curie/ci/langfuse-image-pin-assertions.sh
+++ b/charts/curie/ci/langfuse-image-pin-assertions.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+#
+# Issue #2190: keep the shipped Langfuse runtime on one reviewed version.
+#
+# A floating `:3` moved from 3.225.5 to 3.225.6 during one CI run. The newly
+# pulled image left ClickHouse migration 39 dirty in the real delayed-Postgres
+# chart consumer and made the Compose observability query return 500. This gate
+# renders both user-facing consumers, requires one exact version, and proves a
+# floating-tag mutation is rejected.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$CHART/../.." && pwd)"
+EXPECTED_VERSION="3.225.5"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+RENDER="$TMP/chart.yaml"
+COMPOSE_JSON="$TMP/compose.json"
+CHECKER="$TMP/check.py"
+
+helm template curie "$CHART" >"$RENDER"
+docker compose --profile full -f "$REPO_ROOT/compose.dev.yaml" config --format json >"$COMPOSE_JSON"
+
+cat >"$CHECKER" <<'PY'
+import json
+import pathlib
+import sys
+
+import yaml
+
+chart_path, compose_path, expected_version = sys.argv[1:]
+expected = {
+    "langfuse-web": f"langfuse/langfuse:{expected_version}",
+    "langfuse-worker": f"langfuse/langfuse-worker:{expected_version}",
+}
+
+documents = [
+    document
+    for document in yaml.safe_load_all(pathlib.Path(chart_path).read_text())
+    if document
+]
+chart_images = {}
+for document in documents:
+    if document.get("kind") != "Deployment":
+        continue
+    containers = document.get("spec", {}).get("template", {}).get("spec", {}).get("containers", [])
+    for container in containers:
+        name = container.get("name")
+        if name in expected:
+            chart_images[name] = container.get("image")
+
+compose = json.loads(pathlib.Path(compose_path).read_text())
+compose_images = {
+    name: compose.get("services", {}).get(name, {}).get("image")
+    for name in expected
+}
+
+problems = []
+for name, wanted in expected.items():
+    for surface, actual in (("chart", chart_images.get(name)), ("compose", compose_images.get(name))):
+        if actual != wanted:
+            problems.append(
+                f"{surface} {name} must use reviewed image {wanted}; found {actual!r} "
+                "(floating Langfuse tags are forbidden)"
+            )
+if problems:
+    raise SystemExit("\n".join(problems))
+
+print(f"chart and Compose pin Langfuse web/worker to {expected_version}")
+PY
+
+python3 "$CHECKER" "$RENDER" "$COMPOSE_JSON" "$EXPECTED_VERSION"
+
+MUTANT_RENDER="$TMP/chart-floating.yaml"
+MUTANT_COMPOSE="$TMP/compose-floating.json"
+python3 - "$RENDER" "$COMPOSE_JSON" "$MUTANT_RENDER" "$MUTANT_COMPOSE" "$EXPECTED_VERSION" <<'PY'
+import pathlib
+import sys
+
+render, compose, mutant_render, mutant_compose, version = sys.argv[1:]
+pathlib.Path(mutant_render).write_text(pathlib.Path(render).read_text().replace(f":{version}", ":3"))
+pathlib.Path(mutant_compose).write_text(pathlib.Path(compose).read_text().replace(f":{version}", ":3"))
+PY
+
+negative_output=""
+if negative_output="$(python3 "$CHECKER" "$MUTANT_RENDER" "$MUTANT_COMPOSE" "$EXPECTED_VERSION" 2>&1)"; then
+  echo "FAIL: floating-tag mutation passed the Langfuse image contract" >&2
+  exit 1
+fi
+if [[ "$negative_output" != *"floating Langfuse tags are forbidden"* ]]; then
+  echo "FAIL: floating-tag mutation failed unexpectedly: $negative_output" >&2
+  exit 1
+fi
+
+echo "negative: replacing the reviewed version with :3 is rejected"
+echo "PASS: chart and Compose share one reviewed Langfuse version and reject floating tags"

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -109,7 +109,9 @@ langfuse:
   image:
     web: langfuse/langfuse
     worker: langfuse/langfuse-worker
-    tag: "3"
+    # Keep web and worker on one reviewed migration set. A floating :3 moved to
+    # 3.225.6 during CI and left ClickHouse migration 39 dirty (#2190).
+    tag: "3.225.5"
   telemetryEnabled: false
   enableExperimentalFeatures: true
   # Startup gate on the ClickHouse endpoint Langfuse boots against (issue

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -224,7 +224,7 @@ services:
     restart: "no"
 
   langfuse-worker:
-    image: langfuse/langfuse-worker:3
+    image: langfuse/langfuse-worker:3.225.5
     profiles: *full_profiles
     depends_on:
       postgres:
@@ -244,7 +244,7 @@ services:
     restart: unless-stopped
 
   langfuse-web:
-    image: langfuse/langfuse:3
+    image: langfuse/langfuse:3.225.5
     profiles: *full_profiles
     depends_on:
       postgres:


### PR DESCRIPTION
## Summary

Pin Langfuse web and worker to the reviewed 3.225.5 migration set in both Helm and Compose. A floating `:3` tag moved to 3.225.6 during CI, leaving ClickHouse migration 39 dirty in the real chart consumer and making local observability return HTTP 500. The executable contract renders both shipping surfaces and rejects any return to a floating tag.

## Related issue

Closes #2190

## Fix pin verification

Fix pin: charts/curie/ci/langfuse-image-pin-assertions.sh

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | The pin changes backing observability services, not plugin packaging, the runner loop, ACI events, or skill eval/check. | n/a | n/a |
| local | required | Compose ships both Langfuse images and the local observability path reads them. | fake | `CURIE_BIN=/home/theconnman/.cargo/shared-targets/agentos/release/curie CURIE_E2E_TIERS=local bash cli/scripts/e2e-ladder.sh` on `4b4101adf`: a cold stack deployed the exact bundle, completed a turn, exported correlated traces/logs/metrics, classified an injected runner failure, recovered to a healthy turn, returned Langfuse runs/detail/metrics, distinguished unknown-trace exit 1 from unavailable-API exit 3, matched eval identity, and left no Curie containers. |
| local-release | required | The generated release Compose artifact inherits these image pins. | fake | After rebuilding the release images from `4b4101adf` and wiping the local volumes, `CURIE_BIN=/home/theconnman/.cargo/shared-targets/agentos/release/curie CURIE_E2E_TIERS=local-release bash cli/scripts/e2e-ladder.sh`: generated `compose.release.yaml` cold-started, deployed the exact bundle, completed a worker turn, matched eval identity, and left no Curie containers. |
| cluster | required | The Helm chart ships both pinned images and their startup/migration gates. | fake | `KUBECONFIG=/tmp/curie-2191.kubeconfig READINESS_NAMESPACE=curie-2191-runtime READINESS_RELEASE=curie-2191-runtime READINESS_POSTGRES_IMAGE=curie-postgres-readiness:2190 bash charts/curie/ci/runtime/langfuse-postgres-readiness-runtime.sh --namespace curie-2191-runtime --release curie-2191-runtime --postgres-image curie-postgres-readiness:2190` on `4b4101adf`: delayed Postgres recovered to Ready with zero web restarts/BackOff; valid migrations exited 0. Invalid credentials failed terminally with P1000; unreachable Postgres exhausted the bounded two-attempt gate without starting web. |
| live provider | n/a | No model routing, credentials, provider auth, token, or cost behavior changes. | n/a | n/a |
| external integration | n/a | No Slack, webhook, OAuth, or third-party connector API shape changes. | n/a | n/a |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

Additional candidate evidence:

- `curie dev verify-fix-pin 2191 charts/curie/ci/langfuse-image-pin-assertions.sh` — `PINNED`; the selector passed on the candidate and failed on the parent with all four floating chart/Compose web/worker images identified.
- `bash charts/curie/ci/langfuse-image-pin-assertions.sh` — both chart and Compose render 3.225.5 for web/worker; a synthetic `:3` mutation is rejected on all four surfaces.
- `curie dev chart-check` — all 37 chart assertions passed, including the new contract.
- Full Python baseline on behavior commit `bd9076775` — 5,470 passed, 13 skipped; ruff, mypy (246 files), import contracts, docs, wire tolerance, migrations, and released-upgrade checks all passed. The only follow-up commit adds the same executable assertion to Helm CI; final-head remote Python, Rust, UI, Helm, skill/local, local-release, cluster, and E2E-required jobs all passed on `4b4101adf`.
- `bash scripts/check-docs.sh`, `helm lint charts/curie`, and `docker compose --profile full -f compose.dev.yaml config` passed.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [x] No new ADR is required: this restores deterministic deployment of the existing observability architecture and does not introduce a new architectural decision.
