### PR TITLE
Harden the Langfuse pin gate and the dev-stack failure dump

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -170,9 +170,12 @@ jobs:
           --event "$GITHUB_EVENT_PATH"
           --curie cli/target/release/curie
           --ref HEAD
+      # Every dev-stack service sits behind the compose `full` profile. Without
+      # --profile full, `docker compose logs` matches no service and prints
+      # nothing, so a real outage gets diagnosed with no container logs at all.
       - name: Dump dev stack logs on failure
         if: failure()
-        run: docker compose -f compose.dev.yaml logs --no-color --tail=200
+        run: docker compose --profile full -f compose.dev.yaml logs --no-color --tail=200
 
   rust:
     name: Rust (fmt + clippy + test)

--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -28,6 +28,11 @@ on:
       - "apps/worker/src/curie_worker/bundle_store.py"
       - "uv.lock"
       - "pyproject.toml"
+      # The Langfuse image-pin assertion step below renders compose.dev.yaml
+      # as the second shipping surface for the pinned Langfuse version. A PR
+      # that floats the tag only there would match no path here, skip this
+      # job, and never run the gate that catches exactly that.
+      - "compose.dev.yaml"
 
 permissions:
   contents: read

--- a/charts/curie/ci/langfuse-image-pin-assertions.sh
+++ b/charts/curie/ci/langfuse-image-pin-assertions.sh
@@ -1,70 +1,241 @@
 #!/usr/bin/env bash
+#
+# Issue #2190: keep the shipped Langfuse runtime on one reviewed version.
+#
+# On 2026-09-01T14:50:59Z upstream shipped v3.225.6 by rebuilding the
+# floating `:3` tag and the minor tag `3.225` in place onto its new digest,
+# rather than publishing a `3.225.6` tag — so a minor-tag pin would have
+# moved too (the exact patch tag `3.225.5` was unaffected). In CI, the
+# langfuse-web container reported healthy but never served
+# /api/public/health, timing out the bring-up gate. This gate renders both
+# user-facing consumers, requires one exact version, and proves a
+# floating-tag mutation is rejected.
+#
+# The chart runs Langfuse images in initContainers as well as application
+# containers (the wait-for-clickhouse helper reuses the same image), and both
+# are pulled and EXECUTED before the application container starts. Both
+# initContainers are named `wait-for-clickhouse`, in both Deployments, so a
+# name-keyed expectation cannot address them. The chart-side rule is therefore
+# positional-free: the enclosing Deployment decides which reviewed image
+# applies, and EVERY container and initContainer in it whose image is a
+# `langfuse/` image must equal that image exactly.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CHART="$(cd "$SCRIPT_DIR/.." && pwd)"
-ROOT="$(cd "$CHART/../.." && pwd)"
-PIN="3.225.5"
+REPO_ROOT="$(cd "$CHART/../.." && pwd)"
+EXPECTED_VERSION="3.225.5"
+
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
-fail() { echo "FAIL: $*" >&2; exit 1; }
+RENDER="$TMP/chart.yaml"
+COMPOSE_JSON="$TMP/compose.json"
+CHECKER="$TMP/check.py"
 
-check_consumers() {
-  local chart="$1" compose="$2" label="$3"
-  local rendered="$TMP/${label}-rendered.yaml"
-  local compose_images="$TMP/${label}-compose-images.txt"
+helm template curie "$CHART" >"$RENDER"
+docker compose --profile full -f "$REPO_ROOT/compose.dev.yaml" config --format json >"$COMPOSE_JSON"
 
-  helm template rel "$chart" >"$rendered"
-  docker compose -f "$compose" --profile full config --images >"$compose_images"
-
-  grep -Fq "image: \"langfuse/langfuse:${PIN}\"" "$rendered" \
-    || fail "$label Helm web image is not pinned to ${PIN}"
-  grep -Fq "image: \"langfuse/langfuse-worker:${PIN}\"" "$rendered" \
-    || fail "$label Helm worker image is not pinned to ${PIN}"
-  grep -Fxq "langfuse/langfuse:${PIN}" "$compose_images" \
-    || fail "$label Compose web image is not pinned to ${PIN}"
-  grep -Fxq "langfuse/langfuse-worker:${PIN}" "$compose_images" \
-    || fail "$label Compose worker image is not pinned to ${PIN}"
-
-  if grep -Eq 'langfuse/langfuse(-worker)?:3(["[:space:]]|$)' "$rendered" "$compose_images"; then
-    fail "$label accepted a floating Langfuse major tag"
-  fi
-}
-
-check_consumers "$CHART" "$ROOT/compose.dev.yaml" baseline
-
-MUTANT_CHART="$TMP/chart"
-MUTANT_COMPOSE="$TMP/compose.dev.yaml"
-cp -a "$CHART" "$MUTANT_CHART"
-cp "$ROOT/compose.dev.yaml" "$MUTANT_COMPOSE"
-python3 - "$MUTANT_CHART/values.yaml" "$MUTANT_COMPOSE" "$PIN" <<'PY'
-from pathlib import Path
+cat >"$CHECKER" <<'PY'
+import json
+import pathlib
 import sys
 
-values_path = Path(sys.argv[1])
-compose_path = Path(sys.argv[2])
-pin = sys.argv[3]
+import yaml
 
-values = values_path.read_text()
-needle = f'tag: "{pin}"'
-if values.count(needle) != 1:
-    raise SystemExit(f"FAIL: expected one chart pin to mutate, found {values.count(needle)}")
-values_path.write_text(values.replace(needle, 'tag: "3"'))
+chart_path, compose_path, expected_version = sys.argv[1:]
+expected = {
+    "langfuse-web": f"langfuse/langfuse:{expected_version}",
+    "langfuse-worker": f"langfuse/langfuse-worker:{expected_version}",
+}
+LANGFUSE_IMAGE_PREFIX = "langfuse/"
+SECTIONS = ("initContainers", "containers")
 
-compose = compose_path.read_text()
-for image in ("langfuse/langfuse", "langfuse/langfuse-worker"):
-    needle = f"{image}:{pin}"
-    if compose.count(needle) != 1:
-        raise SystemExit(
-            f"FAIL: expected one Compose pin for {image} to mutate, found {compose.count(needle)}"
+documents = [
+    document
+    for document in yaml.safe_load_all(pathlib.Path(chart_path).read_text())
+    if document
+]
+
+problems = []
+# name -> {"deployment": str, "initContainers": int, "containers": int}. Counts
+# are the anti-vacuity ledger: a scan that finds nothing must not report PASS.
+found = {}
+
+for document in documents:
+    if document.get("kind") != "Deployment":
+        continue
+    deployment = document.get("metadata", {}).get("name")
+    pod = document.get("spec", {}).get("template", {}).get("spec", {})
+    sections = {section: pod.get(section) or [] for section in SECTIONS}
+    langfuse_refs = [
+        (section, container)
+        for section in SECTIONS
+        for container in sections[section]
+        if str(container.get("image", "")).startswith(LANGFUSE_IMAGE_PREFIX)
+    ]
+    # The application container's name is what identifies which reviewed image
+    # governs this Deployment; the initContainers inherit that decision.
+    owners = [
+        container.get("name")
+        for container in sections["containers"]
+        if container.get("name") in expected
+    ]
+    if len(owners) != 1:
+        if langfuse_refs or owners:
+            problems.append(
+                f"chart Deployment {deployment} carries {len(langfuse_refs)} Langfuse image "
+                f"reference(s) but {len(owners)} known Langfuse application container(s) "
+                f"{owners!r}, so no reviewed image can be attributed to it "
+                "(floating Langfuse tags are forbidden)"
+            )
+        continue
+
+    owner = owners[0]
+    wanted = expected[owner]
+    if owner in found:
+        problems.append(
+            f"chart application container {owner} rendered twice "
+            f"({found[owner]['deployment']} and {deployment})"
         )
-    compose = compose.replace(needle, f"{image}:3")
-compose_path.write_text(compose)
+        continue
+    seen = found.setdefault(
+        owner, {"deployment": deployment, "initContainers": 0, "containers": 0}
+    )
+
+    # Positive, name-keyed assertion on the application container itself, so a
+    # non-`langfuse/` image there cannot slip past the prefix rule below. Any
+    # `langfuse/` image is already covered (and counted) by that rule.
+    owner_container = next(
+        container for container in sections["containers"] if container.get("name") == owner
+    )
+    owner_image = owner_container.get("image")
+    if not str(owner_image).startswith(LANGFUSE_IMAGE_PREFIX):
+        seen["containers"] += 1
+        problems.append(
+            f"chart {deployment} container {owner} must use reviewed image {wanted}; "
+            f"found {owner_image!r} (floating Langfuse tags are forbidden)"
+        )
+
+    for section, container in langfuse_refs:
+        seen[section] += 1
+        actual = container.get("image")
+        if actual != wanted:
+            problems.append(
+                f"chart {deployment} {section[:-1]} {container.get('name')} must use "
+                f"reviewed image {wanted}; found {actual!r} "
+                "(floating Langfuse tags are forbidden)"
+            )
+
+for name, wanted in expected.items():
+    if name not in found:
+        problems.append(
+            f"chart renders no {name} container at all; expected {wanted} "
+            "(floating Langfuse tags are forbidden)"
+        )
+        continue
+    for section in SECTIONS:
+        if not found[name][section]:
+            problems.append(
+                f"chart {found[name]['deployment']} has no {section[:-1]} running a "
+                f"{LANGFUSE_IMAGE_PREFIX}* image, so the pin check over that section is "
+                f"vacuous; expected {wanted} (floating Langfuse tags are forbidden)"
+            )
+
+compose = json.loads(pathlib.Path(compose_path).read_text())
+compose_images = {
+    name: compose.get("services", {}).get(name, {}).get("image")
+    for name in expected
+}
+for name, wanted in expected.items():
+    actual = compose_images.get(name)
+    if actual != wanted:
+        problems.append(
+            f"compose {name} must use reviewed image {wanted}; found {actual!r} "
+            "(floating Langfuse tags are forbidden)"
+        )
+
+if problems:
+    raise SystemExit("\n".join(problems))
+
+checked = sum(found[name][section] for name in expected for section in SECTIONS)
+print(
+    f"chart pins {checked} Langfuse image references (containers + initContainers) "
+    f"and Compose pins web/worker to {expected_version}"
+)
 PY
 
-if (check_consumers "$MUTANT_CHART" "$MUTANT_COMPOSE" mutation) >/dev/null 2>&1; then
-  fail "floating Langfuse tag mutation was accepted"
+python3 "$CHECKER" "$RENDER" "$COMPOSE_JSON" "$EXPECTED_VERSION"
+
+# Negative control 1: a floating tag on every surface is rejected.
+MUTANT_RENDER="$TMP/chart-floating.yaml"
+MUTANT_COMPOSE="$TMP/compose-floating.json"
+python3 - "$RENDER" "$COMPOSE_JSON" "$MUTANT_RENDER" "$MUTANT_COMPOSE" "$EXPECTED_VERSION" <<'PY'
+import pathlib
+import sys
+
+render, compose, mutant_render, mutant_compose, version = sys.argv[1:]
+pathlib.Path(mutant_render).write_text(pathlib.Path(render).read_text().replace(f":{version}", ":3"))
+pathlib.Path(mutant_compose).write_text(pathlib.Path(compose).read_text().replace(f":{version}", ":3"))
+PY
+
+negative_output=""
+if negative_output="$(python3 "$CHECKER" "$MUTANT_RENDER" "$MUTANT_COMPOSE" "$EXPECTED_VERSION" 2>&1)"; then
+  echo "FAIL: floating-tag mutation passed the Langfuse image contract" >&2
+  exit 1
+fi
+if [[ "$negative_output" != *"floating Langfuse tags are forbidden"* ]]; then
+  echo "FAIL: floating-tag mutation failed unexpectedly: $negative_output" >&2
+  exit 1
 fi
 
-echo "Langfuse image pin assertions passed"
+echo "negative: replacing the reviewed version with :3 is rejected"
+
+# Negative control 2: the initContainer coverage is not decorative. Float ONLY
+# the initContainer images, leaving both application containers and the whole
+# Compose surface correctly pinned, and require the gate to still fail.
+INIT_MUTANT_RENDER="$TMP/chart-floating-init.yaml"
+python3 - "$RENDER" "$INIT_MUTANT_RENDER" <<'PY'
+import pathlib
+import sys
+
+import yaml
+
+render, mutant_render = sys.argv[1:]
+documents = [
+    document
+    for document in yaml.safe_load_all(pathlib.Path(render).read_text())
+    if document
+]
+mutated = 0
+for document in documents:
+    if document.get("kind") != "Deployment":
+        continue
+    pod = document.get("spec", {}).get("template", {}).get("spec", {})
+    for container in pod.get("initContainers") or []:
+        if str(container.get("image", "")).startswith("langfuse/"):
+            container["image"] = container["image"].rsplit(":", 1)[0] + ":3"
+            mutated += 1
+if mutated != 2:
+    raise SystemExit(
+        f"expected 2 Langfuse initContainer images to mutate, mutated {mutated}"
+    )
+pathlib.Path(mutant_render).write_text(yaml.safe_dump_all(documents))
+PY
+
+init_negative_output=""
+if init_negative_output="$(python3 "$CHECKER" "$INIT_MUTANT_RENDER" "$COMPOSE_JSON" "$EXPECTED_VERSION" 2>&1)"; then
+  echo "FAIL: floating initContainer image passed the Langfuse image contract" >&2
+  exit 1
+fi
+if [[ "$init_negative_output" != *" initContainer "* ]]; then
+  echo "FAIL: initContainer mutation failed for the wrong reason: $init_negative_output" >&2
+  exit 1
+fi
+if [[ "$init_negative_output" == *" container langfuse-"* ]]; then
+  echo "FAIL: initContainer mutation also tripped an application-container check, so it does not isolate the initContainer coverage: $init_negative_output" >&2
+  exit 1
+fi
+
+echo "negative: a floating :3 image in an initContainer position is rejected"
+echo "PASS: chart and Compose share one reviewed Langfuse version and reject floating tags"

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -109,8 +109,10 @@ langfuse:
   image:
     web: langfuse/langfuse
     worker: langfuse/langfuse-worker
-    # Keep web and worker on one reviewed migration set. A floating major tag
-    # moved during CI and left ClickHouse migration 39 dirty (#2190).
+    # Keep web and worker on one reviewed version. On 2026-09-01 upstream
+    # rebuilt both the `3` and `3.225` tags in place to ship v3.225.6 without
+    # ever publishing a 3.225.6 tag, breaking CI bring-up. Neither major nor
+    # minor tags are safe -- only the exact patch tag is stable (#2190).
     tag: "3.225.5"
   telemetryEnabled: false
   enableExperimentalFeatures: true

--- a/release/tests/test_authorize.py
+++ b/release/tests/test_authorize.py
@@ -1247,6 +1247,10 @@ class TestHelmCiWorkflowTriggers:
         # web-identity gate executes those repository files against each
         # rendered workload, so a PR touching only them (a revert of the
         # credential fix) must still match this filter or the gate never runs.
+        # The same holds for compose.dev.yaml: the Langfuse image-pin
+        # assertion this job runs renders it as the second shipping surface
+        # for the pinned Langfuse version, so a PR that floats the tag only
+        # in Compose must still match this filter or that gate never runs.
         assert triggers["pull_request"]["paths"] == [
             "charts/curie/**",
             "examples/sre-bot/observability/**",
@@ -1258,6 +1262,7 @@ class TestHelmCiWorkflowTriggers:
             "apps/worker/src/curie_worker/bundle_store.py",
             "uv.lock",
             "pyproject.toml",
+            "compose.dev.yaml",
         ]
 
 


### PR DESCRIPTION
## Summary

The Langfuse `3.225.5` pin that ended the repo-wide CI outage has already landed on both trains (#2191 into `main`, and #2189's forward merge into `next`). This PR is the leftover hardening from diagnosing that outage: three gaps around the pin, none of which the pin itself closed. It is deliberately small and each hunk can be dropped independently.

Root cause recap, since it is not what a floating-tag guess alone gives you: upstream rebuilt `langfuse/langfuse:3` **and** the minor tag `3.225` **in place** at `2026-09-01T14:50:59Z` to ship v3.225.6. No `3.225.6` tag was ever published, so searching for a new tag finds nothing — the mutation is only visible by digest. `3.225.5` did not move, so it is the only safe pin; **`3.225` would not have been**.

## Related issue

Ref #2190

## What this changes

**1. The dev-stack failure dump printed nothing at all.** `.github/workflows/ci.yaml` ran `docker compose -f compose.dev.yaml logs` with no profile and no service names. Every dev-stack service sits behind the compose `full` profile, so that command matched no services and emitted zero lines. This is why the outage was diagnosed with no container logs whatsoever — job `99917342054`'s dump step is empty. Verified against a live stack: without the flag, no output; with `--profile full`, all 8 services (`postgres`, `valkey`, `clickhouse`, `rustfs`, `rustfs-init`, `langfuse-web`, `langfuse-worker`, `otel-collector`).

**2. helm-ci could skip the job that runs the pin gate.** `compose.dev.yaml` was not in the workflow's `paths` filter, yet the pin gate renders it as the second shipping surface. A pull request floating the Langfuse tag *only* in Compose would have matched no path, skipped the job, and never run the gate that exists to catch precisely that.

**3. The gate did not cover every Langfuse image reference.** It asserted the two application images were pinned and rejected a literal `:3` anywhere, but did not require *every* Langfuse reference to equal the reviewed version. Both Deployments also run a `wait-for-clickhouse` initContainer on a Langfuse image:

```
curie-langfuse-web     initContainers  wait-for-clickhouse   langfuse/langfuse:3.225.5
curie-langfuse-web     containers      langfuse-web          langfuse/langfuse:3.225.5
curie-langfuse-worker  initContainers  wait-for-clickhouse   langfuse/langfuse-worker:3.225.5
curie-langfuse-worker  containers      langfuse-worker       langfuse/langfuse-worker:3.225.5
```

So a wrong-but-not-floating version in an initContainer (say `langfuse/langfuse:3.226.0`) passed, while being pulled and executed *before* the checked application container. That is the exact class that caused this outage — a version change, not specifically a `:3`. The gate now parses the render and requires every container and initContainer whose image starts with `langfuse/` to equal its Deployment's reviewed image, name-independently, with anti-vacuity checks so a vanished container or an empty render fails instead of silently passing.

Plus a comment correction on `charts/curie/values.yaml`: the landed comment does not say that `3.225` moved too, which is the actionable part. I dropped the "left ClickHouse migration 39 dirty" clause because this investigation did not reproduce it.

## Verification

| Check | Result |
| --- | --- |
| `bash charts/curie/ci/langfuse-image-pin-assertions.sh` | `chart pins 4 Langfuse image references (containers + initContainers) and Compose pins web/worker to 3.225.5`; both negative controls fire; exit 0 |
| Gate can actually fail | `EXPECTED_VERSION=9.9.9` exits 1 and names all six mismatches (4 chart + 2 compose) |
| `cargo test --test chart_check` | **7 passed, 0 failed** — includes the full 37-script sweep and `helm_ci_and_the_chart_ci_directory_cannot_diverge` |
| `bash charts/curie/ci/render-assertions.sh` | PASS |
| `helm lint charts/curie` | 0 failed |
| Both workflows | `yaml.safe_load` OK; no duplicated script invocations |

Note on hunk 2: the divergence test scans this workflow for `charts/curie/ci/*.sh` references, so the new comment deliberately refers to the gate in prose rather than by path — spelling out the path made the test read it as a duplicated step.

## Not behavior-bearing

No tier applies. This changes CI wiring, a CI diagnostic command, an assertion script, and a comment. It ships no runtime behavior: the image pin itself is already on `next` and is untouched here.

- [x] Or: this change is not behavior-bearing, so no tier applies, and the summary says why.

## Checklist

- [x] Tests pass for the area I touched.
- [x] Docs updated if behavior changed (n/a; the chart README image table already reflects the pin).
- [x] No new ADR is required.
