### PR TITLE
Support external mail adapter credentials

### DIFF
--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -1185,11 +1185,11 @@ restarts.
 
 ### The other direct-passthrough credentials
 
-The GitHub App key was the first of nine credential keys read straight from
+The GitHub App key was the first of twelve credential keys read straight from
 `.Values` with no in-chart generation (`charts/curie/templates/secrets.yaml`
 calls these direct passthrough, as opposed to the eleven keys
 `curie.managedSecret` generates and persists). Issue #1759 gave the other
-eight the same `existingSecret` / `existingSecretKey` escape, one pair per
+eleven the same `existingSecret` / `existingSecretKey` escape, one pair per
 key, all winning over their plain value when set:
 
 | Credential | Plain value | BYO fields |
@@ -1202,6 +1202,9 @@ key, all winning over their plain value when set:
 | Slack app token | `dispatcher.slack.appToken` | `dispatcher.slack.appTokenExistingSecret` / `appTokenExistingSecretKey` (default key `slackAppToken`) |
 | Slack bot token | `dispatcher.slack.botToken` | `dispatcher.slack.botTokenExistingSecret` / `botTokenExistingSecretKey` (default key `slackBotToken`) |
 | Slack signing secret | `dispatcher.slack.signingSecret` | `dispatcher.slack.signingSecretExistingSecret` / `signingSecretExistingSecretKey` (default key `slackSigningSecret`) |
+| Mail channel token | `mailAdapter.channelToken` | `mailAdapter.channelTokenExistingSecret` / `channelTokenExistingSecretKey` (default key `mailChannelToken`) |
+| Mail egress secret | `mailAdapter.egressSecret` | `mailAdapter.egressSecretExistingSecret` / `egressSecretExistingSecretKey` (default key `mailEgressSecret`) -- when set, `worker.adapterCredentialsExistingSecret` must source the worker's paired credential map |
+| AgentMail API key | `mailAdapter.agentmail.apiKey` | `mailAdapter.agentmail.apiKeyExistingSecret` / `apiKeyExistingSecretKey` (default key `mailAgentmailApiKey`) |
 
 For example, to keep the model credential and both Slack tokens entirely out
 of helm values and release history:

--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -1226,7 +1226,7 @@ As with `githubAppExistingSecret`, a Secret missing the referenced key fails
 that one pod at `CreateContainerConfigError` rather than the chart silently
 falling back to an empty credential.
 
-**Known gap, tracked in #1801.** None of these 16 new fields are yet covered
+**Known gap, tracked in #1801.** None of these 22 new fields are yet covered
 by the CLI's preserved-values mechanism (the same one `COMMS_MANAGED_KEYS` and
 `GITHUB_APP_MANAGED_KEYS` give the Slack tokens and the GitHub App identity in
 `cli/src/ops.rs`). A plain `curie cluster up` runs a full `helm upgrade

--- a/charts/curie/ci/mail-adapter-wiring-assertions.sh
+++ b/charts/curie/ci/mail-adapter-wiring-assertions.sh
@@ -24,7 +24,8 @@
 #      sourced key, and renders the worker's adapterCredentials entry alongside
 #      the chart-managed egress credential in the same render. An externally
 #      sourced adapter egress credential requires the worker's external
-#      credential map, with a value-safe render failure when that pair is split.
+#      credential map, omits the mail slug from the chart-managed map, and has a
+#      value-safe render failure when that pair is split.
 #   8  priorityClassName is the platform class (asserted here, not in
 #      render-assertions.sh, whose assertion 8 would break on the default render
 #      where this Deployment deliberately does not exist).
@@ -37,13 +38,13 @@
 #      must not exist), and the rollout strategy is Recreate. All routing state
 #      is process-local, and a rolling update runs two pods for the duration of
 #      every upgrade.
-#   12 checksum/mail-adapter-credentials is derived from the three live Secret
-#      sources, with a stable source-ref fallback when clusterless helm template
-#      cannot read them. Raw Helm credential values are not the checksum source.
-#   13 The egress pair cannot diverge: derived from mailAdapter.egressSecret when
-#      the operator writes only that half, unchanged when both halves agree, and
-#      a hard `helm template` FAILURE naming both keys when they differ -- and
-#      that failure message names the two KEYS without printing either live
+#   12 checksum/mail-adapter-credentials uses incoming Helm values for
+#      chart-managed credentials and live Secret data for external sources,
+#      with a stable source-ref fallback when no cluster read is available.
+#   13 The chart-managed egress pair cannot diverge: derived from
+#      mailAdapter.egressSecret when the operator writes only that half,
+#      unchanged when both halves agree, and a hard `helm template` FAILURE
+#      naming both keys when they differ -- without printing either live
 #      credential VALUE into terminal scrollback or a CI log.
 #   14 The worker's checksum/adapter-credentials sees the DERIVED entry, so
 #      rotating mailAdapter.egressSecret actually rolls the workers.
@@ -398,15 +399,17 @@ done
 # Secret exists during this clusterless render: the non-optional secretKeyRefs
 # are therefore also the falsifiable missing-reference path. The chart must not
 # silently keep a same-named key in its own Secret as a fallback.
-external_dir="$(render external-secrets "${ON[@]}" "${CREDS[@]}" \
-  --set mailAdapter.channelTokenExistingSecret=mail-channel-source \
-  --set mailAdapter.channelTokenExistingSecretKey=channel-token \
-  --set mailAdapter.egressSecretExistingSecret=mail-egress-source \
-  --set mailAdapter.egressSecretExistingSecretKey=egress-token \
-  --set mailAdapter.agentmail.apiKeyExistingSecret=mail-provider-source \
-  --set mailAdapter.agentmail.apiKeyExistingSecretKey=provider-token \
-  --set worker.adapterCredentialsExistingSecret=mail-worker-source \
-  --set worker.adapterCredentialsExistingSecretKey=adapter-egress-map)"
+EXTERNAL_REFS=(
+  --set mailAdapter.channelTokenExistingSecret=mail-channel-source
+  --set mailAdapter.channelTokenExistingSecretKey=channel-token
+  --set mailAdapter.egressSecretExistingSecret=mail-egress-source
+  --set mailAdapter.egressSecretExistingSecretKey=egress-token
+  --set mailAdapter.agentmail.apiKeyExistingSecret=mail-provider-source
+  --set mailAdapter.agentmail.apiKeyExistingSecretKey=provider-token
+  --set worker.adapterCredentialsExistingSecret=mail-worker-source
+  --set worker.adapterCredentialsExistingSecretKey=adapter-egress-map
+)
+external_dir="$(render external-secrets "${ON[@]}" "${CREDS[@]}" "${EXTERNAL_REFS[@]}")"
 assert_env_secret_ref "$external_dir" CURIE_CHANNEL_TOKEN mail-channel-source channel-token
 assert_env_secret_ref "$external_dir" CURIE_EGRESS_SECRET mail-egress-source egress-token
 assert_env_secret_ref "$external_dir" AGENTMAIL_API_KEY mail-provider-source provider-token
@@ -424,6 +427,27 @@ for key in mailChannelToken mailEgressSecret mailAgentmailApiKey; do
     fail "chart Secret key '$key' still renders when its mail-adapter existingSecret is set; a Helm upgrade would keep managing or overwrite the externally sourced credential"
   fi
 done
+
+# The raw egress value remains set in CREDS above on purpose. Once the adapter's
+# egress source is external, the chart-managed worker map must neither derive
+# the mail slug from that unused value nor divergence-check it against the
+# independently managed external map.
+external_chart_creds="$(field "$external_dir" Secret "$SECRET_NAME" stringData.adapterCredentials)"
+python3 -c '
+import json, sys
+if sys.argv[2] in json.loads(sys.argv[1]):
+    raise SystemExit("external egress source leaked the mail slug into chart-managed adapterCredentials")
+' "$external_chart_creds" "$SLUG" \
+  || fail "worker adapterCredentials still contains '$SLUG' when mailAdapter.egressSecretExistingSecret is set; the required external worker map must be the only paired egress source"
+
+# Even a stale plain worker entry must not be compared with the stale plain mail
+# value on the external path. Neither map is consumed there; the two external
+# references above are authoritative.
+external_stale_values_dir="$(render external-stale-values "${ON[@]}" "${EXTERNAL_REFS[@]}" \
+  --set mailAdapter.egressSecret=unused-mail-value \
+  --set worker.adapterCredentials.mail-adapter=unused-worker-value)"
+field "$external_stale_values_dir" Deployment "$DEPLOY_NAME" >/dev/null \
+  || fail "external egress sources failed to render when unused plain mail and worker values differed; the chart must not divergence-validate unconsumed values"
 
 # ---------------------------------------------------------------------------
 # 8: priorityClassName is the platform class. The control plane must outrank
@@ -853,10 +877,11 @@ if not expected.issubset(cidrs):
 PY
 
 # ---------------------------------------------------------------------------
-# 12: checksum/mail-adapter-credentials hashes the live data behind all three
-#     secretKeyRefs. `helm template` has no live cluster, so it must fall back to
-#     a deterministic digest of the three source refs rather than hashing the
-#     raw Helm credential values.
+# 12: checksum/mail-adapter-credentials hashes the incoming values for
+#     chart-managed credentials, because the live chart Secret still holds the
+#     old data during an upgrade. External references instead hash live Secret
+#     data and use a deterministic source-ref fallback when `helm template` has
+#     no cluster to read.
 # ---------------------------------------------------------------------------
 ANNOTATION=spec.template.metadata.annotations.checksum/mail-adapter-credentials
 base_sum="$(field "$on_dir" Deployment "$DEPLOY_NAME" "$ANNOTATION")" \
@@ -869,17 +894,41 @@ repeat_sum="$(field "$repeat_dir" Deployment "$DEPLOY_NAME" "$ANNOTATION")"
 [ "$repeat_sum" = "$base_sum" ] \
   || fail "clusterless checksum fallback is not deterministic: identical renders produced '$base_sum' and '$repeat_sum'"
 
-raw_values_dir="$(render checksum-raw-values "${ON[@]}" \
-  --set mailAdapter.channelToken=changed-channel-value \
-  --set mailAdapter.egressSecret=changed-egress-value \
+channel_rotation_dir="$(render checksum-channel-rotation "${ON[@]}" "${CREDS[@]}" \
+  --set mailAdapter.channelToken=changed-channel-value)"
+channel_rotation_sum="$(field "$channel_rotation_dir" Deployment "$DEPLOY_NAME" "$ANNOTATION")"
+[ "$channel_rotation_sum" != "$base_sum" ] \
+  || fail "rotating chart-managed mailAdapter.channelToken left the adapter checksum unchanged; an upgrade would keep the old environment value"
+
+egress_rotation_dir="$(render checksum-egress-rotation "${ON[@]}" "${CREDS[@]}" \
+  --set mailAdapter.egressSecret=changed-egress-value)"
+egress_rotation_sum="$(field "$egress_rotation_dir" Deployment "$DEPLOY_NAME" "$ANNOTATION")"
+[ "$egress_rotation_sum" != "$base_sum" ] \
+  || fail "rotating chart-managed mailAdapter.egressSecret left the adapter checksum unchanged; an upgrade would keep the old environment value"
+
+provider_rotation_dir="$(render checksum-provider-rotation "${ON[@]}" "${CREDS[@]}" \
   --set mailAdapter.agentmail.apiKey=changed-provider-value)"
-raw_values_sum="$(field "$raw_values_dir" Deployment "$DEPLOY_NAME" "$ANNOTATION")"
-[ "$raw_values_sum" = "$base_sum" ] \
-  || fail "clusterless checksum changed with raw Helm credential values; it must checksum live Secret data and use only the source refs as its no-live-object fallback"
+provider_rotation_sum="$(field "$provider_rotation_dir" Deployment "$DEPLOY_NAME" "$ANNOTATION")"
+[ "$provider_rotation_sum" != "$base_sum" ] \
+  || fail "rotating chart-managed mailAdapter.agentmail.apiKey left the adapter checksum unchanged; an upgrade would keep the old environment value"
 
 external_sum="$(field "$external_dir" Deployment "$DEPLOY_NAME" "$ANNOTATION")"
 [ "$external_sum" != "$base_sum" ] \
   || fail "checksum fallback ignored the external Secret names/keys; changing the credential source would leave the pod on its prior secretKeyRefs"
+
+external_raw_values_dir="$(render checksum-external-raw-values "${ON[@]}" "${EXTERNAL_REFS[@]}" \
+  --set mailAdapter.channelToken=unused-channel-value \
+  --set mailAdapter.egressSecret=unused-egress-value \
+  --set mailAdapter.agentmail.apiKey=unused-provider-value)"
+external_raw_values_sum="$(field "$external_raw_values_dir" Deployment "$DEPLOY_NAME" "$ANNOTATION")"
+[ "$external_raw_values_sum" = "$external_sum" ] \
+  || fail "external credential checksum changed with unused plain Helm values; existingSecret makes the referenced Secret the sole source"
+
+external_source_dir="$(render checksum-external-source "${ON[@]}" "${CREDS[@]}" "${EXTERNAL_REFS[@]}" \
+  --set mailAdapter.channelTokenExistingSecretKey=next-channel-token)"
+external_source_sum="$(field "$external_source_dir" Deployment "$DEPLOY_NAME" "$ANNOTATION")"
+[ "$external_source_sum" != "$external_sum" ] \
+  || fail "external checksum fallback ignored a referenced key change; clusterless renders must track the source ref"
 
 if ! grep -F 'lookup "v1" "Secret"' "$CHART/templates/mail-adapter.yaml" >/dev/null; then
   fail "mail-adapter checksum never looks up live Secret data; a Secret value rotated in place would not roll the adapter on the next Helm upgrade"

--- a/charts/curie/ci/mail-adapter-wiring-assertions.sh
+++ b/charts/curie/ci/mail-adapter-wiring-assertions.sh
@@ -16,10 +16,15 @@
 #      platform key; this is what keeps curie.env.api from being "helpfully"
 #      included later.
 #   6  CURIE_CHANNEL_TOKEN, CURIE_EGRESS_SECRET and AGENTMAIL_API_KEY each arrive
-#      by secretKeyRef to the chart Secret, never as inline literals.
+#      by secretKeyRef, never as inline literals. Each per-field existingSecret
+#      overrides both the Secret name and key without making the reference
+#      optional, so a missing external key fails closed.
 #   7  The chart Secret carries mailChannelToken, mailEgressSecret and
-#      mailAgentmailApiKey, and the worker's adapterCredentials entry for the
-#      same slug renders alongside them in the same render.
+#      mailAgentmailApiKey only for chart-managed values, omits each externally
+#      sourced key, and renders the worker's adapterCredentials entry alongside
+#      the chart-managed egress credential in the same render. An externally
+#      sourced adapter egress credential requires the worker's external
+#      credential map, with a value-safe render failure when that pair is split.
 #   8  priorityClassName is the platform class (asserted here, not in
 #      render-assertions.sh, whose assertion 8 would break on the default render
 #      where this Deployment deliberately does not exist).
@@ -32,9 +37,9 @@
 #      must not exist), and the rollout strategy is Recreate. All routing state
 #      is process-local, and a rolling update runs two pods for the duration of
 #      every upgrade.
-#   12 checksum/mail-adapter-credentials tracks ALL THREE credentials, proven by
-#      three independent one-credential pairs. A one-credential assertion passes
-#      against a two-thirds-correct checksum, which is the bug.
+#   12 checksum/mail-adapter-credentials is derived from the three live Secret
+#      sources, with a stable source-ref fallback when clusterless helm template
+#      cannot read them. Raw Helm credential values are not the checksum source.
 #   13 The egress pair cannot diverge: derived from mailAdapter.egressSecret when
 #      the operator writes only that half, unchanged when both halves agree, and
 #      a hard `helm template` FAILURE naming both keys when they differ -- and
@@ -233,16 +238,17 @@ assert_env_value() {
 
 # Assert one env entry arrives by secretKeyRef, with no inline literal.
 assert_env_secret_ref() {
-  # $1 = rendered dir, $2 = env name, $3 = expected Secret key
-  local dir="$1" name="$2" key="$3" got
+  # $1 = rendered dir, $2 = env name, $3 = expected Secret name,
+  # $4 = expected Secret key
+  local dir="$1" name="$2" secret="$3" key="$4" got
   if ! got="$(env_field "$dir" "$DEPLOY_NAME" "$name" valueFrom.secretKeyRef.name)"; then
     fail "env '$name' does not arrive by valueFrom.secretKeyRef; an inline credential lands in 'helm get manifest' and in every rendered artifact CI uploads"
   fi
-  [ "$got" = "$SECRET_NAME" ] \
-    || fail "env '$name' secretKeyRef names Secret '$got', expected the chart Secret '$SECRET_NAME'"
+  [ "$got" = "$secret" ] \
+    || fail "env '$name' secretKeyRef names Secret '$got', expected '$secret'"
   got="$(env_field "$dir" "$DEPLOY_NAME" "$name" valueFrom.secretKeyRef.key)"
   [ "$got" = "$key" ] \
-    || fail "env '$name' secretKeyRef uses key '$got', expected '$key' (the key secrets.yaml renders; a different key silently reads an empty credential)"
+    || fail "env '$name' secretKeyRef uses key '$got', expected '$key'; a different key leaves the required credential unavailable"
   if env_field "$dir" "$DEPLOY_NAME" "$name" value >/dev/null 2>&1; then
     got="$(env_field "$dir" "$DEPLOY_NAME" "$name" value)"
     fail "env '$name' renders an inline literal value '$got'; the credential must come from the Secret by reference only"
@@ -328,9 +334,9 @@ fi
 # ---------------------------------------------------------------------------
 # 6: all three credentials arrive by secretKeyRef, never inline.
 # ---------------------------------------------------------------------------
-assert_env_secret_ref "$on_dir" CURIE_CHANNEL_TOKEN mailChannelToken
-assert_env_secret_ref "$on_dir" CURIE_EGRESS_SECRET mailEgressSecret
-assert_env_secret_ref "$on_dir" AGENTMAIL_API_KEY mailAgentmailApiKey
+assert_env_secret_ref "$on_dir" CURIE_CHANNEL_TOKEN "$SECRET_NAME" mailChannelToken
+assert_env_secret_ref "$on_dir" CURIE_EGRESS_SECRET "$SECRET_NAME" mailEgressSecret
+assert_env_secret_ref "$on_dir" AGENTMAIL_API_KEY "$SECRET_NAME" mailAgentmailApiKey
 
 # ---------------------------------------------------------------------------
 # 7: the Secret carries the three keys, and the worker's adapterCredentials
@@ -357,6 +363,67 @@ if got != want:
     sys.exit(1)
 ' "$creds_json" "$SLUG" "egress-assert-secret" \
   || fail "the worker half of the egress pair is missing or wrong; the worker will present nothing (or the wrong secret) and every reply delivery 401s"
+
+# An externally sourced adapter egress credential cannot be copied into the
+# worker's chart-managed JSON map because Helm cannot read the external Secret's
+# credential data. Require the worker's external credential map and keep the
+# render failure actionable without interpolating any supplied value.
+PAIR_SECRET_VALUE=zzmailpairexternalsecretzz
+PAIR_KEY_VALUE=zzmailpairexternalkeyzz
+PAIR_CREDENTIAL_VALUE=zzmailpaircredentialzz
+set +e
+unpaired_egress_out="$(helm template "$RELEASE" "$CHART" "${ON[@]}" "${CREDS[@]}" \
+  --set-string mailAdapter.egressSecretExistingSecret="$PAIR_SECRET_VALUE" \
+  --set-string mailAdapter.egressSecretExistingSecretKey="$PAIR_KEY_VALUE" \
+  --set-string mailAdapter.egressSecret="$PAIR_CREDENTIAL_VALUE" 2>&1)"
+unpaired_egress_rc=$?
+set -e
+[ "$unpaired_egress_rc" -ne 0 ] \
+  || fail "mailAdapter.egressSecretExistingSecret rendered without worker.adapterCredentialsExistingSecret; the paired credential sources must fail closed"
+case "$unpaired_egress_out" in
+  *"mailAdapter.egressSecretExistingSecret"*) : ;;
+  *) fail "the split egress-source failure did not name mailAdapter.egressSecretExistingSecret; output was: $unpaired_egress_out" ;;
+esac
+case "$unpaired_egress_out" in
+  *"worker.adapterCredentialsExistingSecret"*) : ;;
+  *) fail "the split egress-source failure did not name worker.adapterCredentialsExistingSecret; output was: $unpaired_egress_out" ;;
+esac
+for supplied_value in "$PAIR_SECRET_VALUE" "$PAIR_KEY_VALUE" "$PAIR_CREDENTIAL_VALUE"; do
+  case "$unpaired_egress_out" in
+    *"$supplied_value"*) fail "the split egress-source failure printed a supplied value; name configuration keys without echoing their contents. Output was: $unpaired_egress_out" ;;
+  esac
+done
+
+# Each credential can instead point at an operator-managed Secret. No such
+# Secret exists during this clusterless render: the non-optional secretKeyRefs
+# are therefore also the falsifiable missing-reference path. The chart must not
+# silently keep a same-named key in its own Secret as a fallback.
+external_dir="$(render external-secrets "${ON[@]}" "${CREDS[@]}" \
+  --set mailAdapter.channelTokenExistingSecret=mail-channel-source \
+  --set mailAdapter.channelTokenExistingSecretKey=channel-token \
+  --set mailAdapter.egressSecretExistingSecret=mail-egress-source \
+  --set mailAdapter.egressSecretExistingSecretKey=egress-token \
+  --set mailAdapter.agentmail.apiKeyExistingSecret=mail-provider-source \
+  --set mailAdapter.agentmail.apiKeyExistingSecretKey=provider-token \
+  --set worker.adapterCredentialsExistingSecret=mail-worker-source \
+  --set worker.adapterCredentialsExistingSecretKey=adapter-egress-map)"
+assert_env_secret_ref "$external_dir" CURIE_CHANNEL_TOKEN mail-channel-source channel-token
+assert_env_secret_ref "$external_dir" CURIE_EGRESS_SECRET mail-egress-source egress-token
+assert_env_secret_ref "$external_dir" AGENTMAIL_API_KEY mail-provider-source provider-token
+
+for name in CURIE_CHANNEL_TOKEN CURIE_EGRESS_SECRET AGENTMAIL_API_KEY; do
+  if env_field "$external_dir" "$DEPLOY_NAME" "$name" valueFrom.secretKeyRef.optional >/dev/null 2>&1; then
+    fail "env '$name' makes its external secretKeyRef optional; a missing Secret or key must prevent the adapter container from starting"
+  fi
+done
+
+field "$external_dir" Secret "$SECRET_NAME" >/dev/null \
+  || fail "the chart Secret did not render, so existingSecret omission checks would pass vacuously"
+for key in mailChannelToken mailEgressSecret mailAgentmailApiKey; do
+  if field "$external_dir" Secret "$SECRET_NAME" "stringData.$key" >/dev/null 2>&1; then
+    fail "chart Secret key '$key' still renders when its mail-adapter existingSecret is set; a Helm upgrade would keep managing or overwrite the externally sourced credential"
+  fi
+done
 
 # ---------------------------------------------------------------------------
 # 8: priorityClassName is the platform class. The control plane must outrank
@@ -786,10 +853,10 @@ if not expected.issubset(cidrs):
 PY
 
 # ---------------------------------------------------------------------------
-# 12: checksum/mail-adapter-credentials tracks ALL THREE credentials. Three
-#     independent one-credential pairs: a checksum over the channel token alone
-#     passes a one-credential assertion while rotating the egress secret or the
-#     AgentMail key leaves the pod running on stale environment credentials.
+# 12: checksum/mail-adapter-credentials hashes the live data behind all three
+#     secretKeyRefs. `helm template` has no live cluster, so it must fall back to
+#     a deterministic digest of the three source refs rather than hashing the
+#     raw Helm credential values.
 # ---------------------------------------------------------------------------
 ANNOTATION=spec.template.metadata.annotations.checksum/mail-adapter-credentials
 base_sum="$(field "$on_dir" Deployment "$DEPLOY_NAME" "$ANNOTATION")" \
@@ -797,19 +864,26 @@ base_sum="$(field "$on_dir" Deployment "$DEPLOY_NAME" "$ANNOTATION")" \
 [ -n "$base_sum" ] \
   || fail "'checksum/mail-adapter-credentials' rendered empty"
 
-assert_checksum_tracks() {
-  # $1 = label, $2... = the single --set that differs from the baseline render
-  local label="$1"
-  shift
-  local dir sum
-  dir="$(render "sum-$label" "${ON[@]}" "${CREDS[@]}" "$@")"
-  sum="$(field "$dir" Deployment "$DEPLOY_NAME" "$ANNOTATION")"
-  [ "$sum" != "$base_sum" ] \
-    || fail "rotating $label did not change 'checksum/mail-adapter-credentials' (still '$base_sum'); that credential is not part of the hashed input, so a rotation leaves the pod running on the revoked value"
-}
-assert_checksum_tracks "mailAdapter.channelToken" --set mailAdapter.channelToken=chn-rotated
-assert_checksum_tracks "mailAdapter.egressSecret" --set mailAdapter.egressSecret=egress-rotated
-assert_checksum_tracks "mailAdapter.agentmail.apiKey" --set mailAdapter.agentmail.apiKey=am-rotated
+repeat_dir="$(render checksum-repeat "${ON[@]}" "${CREDS[@]}")"
+repeat_sum="$(field "$repeat_dir" Deployment "$DEPLOY_NAME" "$ANNOTATION")"
+[ "$repeat_sum" = "$base_sum" ] \
+  || fail "clusterless checksum fallback is not deterministic: identical renders produced '$base_sum' and '$repeat_sum'"
+
+raw_values_dir="$(render checksum-raw-values "${ON[@]}" \
+  --set mailAdapter.channelToken=changed-channel-value \
+  --set mailAdapter.egressSecret=changed-egress-value \
+  --set mailAdapter.agentmail.apiKey=changed-provider-value)"
+raw_values_sum="$(field "$raw_values_dir" Deployment "$DEPLOY_NAME" "$ANNOTATION")"
+[ "$raw_values_sum" = "$base_sum" ] \
+  || fail "clusterless checksum changed with raw Helm credential values; it must checksum live Secret data and use only the source refs as its no-live-object fallback"
+
+external_sum="$(field "$external_dir" Deployment "$DEPLOY_NAME" "$ANNOTATION")"
+[ "$external_sum" != "$base_sum" ] \
+  || fail "checksum fallback ignored the external Secret names/keys; changing the credential source would leave the pod on its prior secretKeyRefs"
+
+if ! grep -F 'lookup "v1" "Secret"' "$CHART/templates/mail-adapter.yaml" >/dev/null; then
+  fail "mail-adapter checksum never looks up live Secret data; a Secret value rotated in place would not roll the adapter on the next Helm upgrade"
+fi
 
 # ---------------------------------------------------------------------------
 # 13: the egress pair cannot diverge. (a) derived from mailAdapter.egressSecret

--- a/charts/curie/templates/NOTES.txt
+++ b/charts/curie/templates/NOTES.txt
@@ -210,7 +210,7 @@ manage yourself, so it never passes through helm values or release history:
 
   api.githubAppExistingSecret: my-github-app
 
-  The model credential, the Slack tokens, and five other direct-passthrough
+  The model credential, the Slack tokens, and eight other direct-passthrough
   keys carry the same escape (issue #1759): <field>ExistingSecret plus
   <field>ExistingSecretKey, one pair per key. See
   charts/curie/README.md#secrets-at-rest for the full list.

--- a/charts/curie/templates/_helpers.tpl
+++ b/charts/curie/templates/_helpers.tpl
@@ -812,16 +812,19 @@ http://{{ include "curie.fullname" . }}-otel-collector:{{ .Values.otelCollector.
 {{ include "curie.env.apiKey" . }}
 {{- end -}}
 
-{{/* Coalesce the worker's egress credentials and the first-party mail
-     adapter's paired credential. The chart Secret and the worker rollout
-     checksum must use this same rendered JSON so a rotation reaches both
-     sides. mailAdapter.egressSecret is the source of truth; accepting an equal
-     hand-written worker entry keeps migrations from hand-rolled manifests
-     possible, while a disagreement fails rather than deploying a reply path
-     that can only return 401. */}}
+{{/* Coalesce the worker's chart-managed egress credentials and the first-party
+     mail adapter's chart-managed paired credential. The chart Secret and the
+     worker rollout checksum must use this same rendered JSON so a rotation
+     reaches both sides. mailAdapter.egressSecret is the source of truth on
+     that path; accepting an equal hand-written worker entry keeps migrations
+     from hand-rolled manifests possible, while a disagreement fails rather
+     than deploying a reply path that can only return 401. When the adapter
+     uses egressSecretExistingSecret, the required external worker map is the
+     independent source of truth: never derive from or compare the unused plain
+     Helm value. */}}
 {{- define "curie.adapterCredentials" -}}
 {{- $creds := deepCopy (.Values.worker.adapterCredentials | default dict) -}}
-{{- if .Values.mailAdapter.deploy -}}
+{{- if and .Values.mailAdapter.deploy (not .Values.mailAdapter.egressSecretExistingSecret) -}}
 {{- $slug := .Values.mailAdapter.adapterSlug -}}
 {{- $derived := .Values.mailAdapter.egressSecret -}}
 {{- if hasKey $creds $slug -}}
@@ -1062,9 +1065,10 @@ true
 {{/* ---- BYO existingSecret escape for a direct-passthrough credential
      (issue #1759) ----
 
-     Eight keys (agentCredentials, adapterCredentials, githubToken,
+     Eleven keys (agentCredentials, adapterCredentials, githubToken,
      sealingPrivateKey, sealingPreviousPrivateKey, slackAppToken,
-     slackBotToken, slackSigningSecret) each grew a per-field
+     slackBotToken, slackSigningSecret, mailChannelToken, mailEgressSecret,
+     mailAgentmailApiKey) each grew a per-field
      `<field>ExistingSecret` / `<field>ExistingSecretKey` pair mirroring
      api.githubAppExistingSecret (ADR-0092): set, it wins over the plain
      value and the consumer's secretKeyRef points straight at the operator's
@@ -1072,7 +1076,7 @@ true
      CreateContainerConfigError instead of the chart emitting an empty
      credential.
 
-     One generic helper for all eight, following the dict-argument pattern
+     One generic helper for all eleven, following the dict-argument pattern
      `curie.image`/`curie.managedSecret` already use in this file, rather than
      a bespoke per-key helper or a hand-copied if/else at each consumer: every
      consumer of the SAME key -- there are three for slackBotToken, two for

--- a/charts/curie/templates/mail-adapter.yaml
+++ b/charts/curie/templates/mail-adapter.yaml
@@ -68,11 +68,51 @@ list order or an exact string comparison.
 {{- end -}}
 
 {{- if .Values.mailAdapter.deploy }}
+{{- if and .Values.mailAdapter.egressSecretExistingSecret (not .Values.worker.adapterCredentialsExistingSecret) }}
+{{- fail "mailAdapter.egressSecretExistingSecret requires worker.adapterCredentialsExistingSecret so the adapter and worker source the paired egress credential externally. Set both configuration keys; credential values are not printed." }}
+{{- end }}
 {{- if not .Values.mailAdapter.agentmail.httpsCidrs }}
 {{- fail "mailAdapter.deploy is true: set at least one mailAdapter.agentmail.httpsCidrs entry for AgentMail (or a controlled HTTPS egress proxy); provider egress fails closed" }}
 {{- end }}
 {{- if not (hasPrefix "https://" .Values.mailAdapter.agentmail.baseUrl) }}
 {{- fail "mailAdapter.deploy is true: mailAdapter.agentmail.baseUrl must use https:// because the mail egress policy permits provider traffic only on TCP 443" }}
+{{- end }}
+{{- /* Resolve the exact Secret sources used by the three secretKeyRefs, then
+     checksum their live data when Helm can reach the cluster. `helm template`
+     and a first install have no live object to read, so the source name/key is
+     the deterministic fallback. No credential data is emitted into the
+     manifest: only the resulting digest reaches the pod annotation. */}}
+{{- $chartSecretName := include "curie.secretName" . }}
+{{- $channelSecretName := .Values.mailAdapter.channelTokenExistingSecret | default $chartSecretName }}
+{{- $channelSecretKey := .Values.mailAdapter.channelTokenExistingSecretKey }}
+{{- if not .Values.mailAdapter.channelTokenExistingSecret }}
+{{- $channelSecretKey = "mailChannelToken" }}
+{{- end }}
+{{- $egressSecretName := .Values.mailAdapter.egressSecretExistingSecret | default $chartSecretName }}
+{{- $egressSecretKey := .Values.mailAdapter.egressSecretExistingSecretKey }}
+{{- if not .Values.mailAdapter.egressSecretExistingSecret }}
+{{- $egressSecretKey = "mailEgressSecret" }}
+{{- end }}
+{{- $agentmailSecretName := .Values.mailAdapter.agentmail.apiKeyExistingSecret | default $chartSecretName }}
+{{- $agentmailSecretKey := .Values.mailAdapter.agentmail.apiKeyExistingSecretKey }}
+{{- if not .Values.mailAdapter.agentmail.apiKeyExistingSecret }}
+{{- $agentmailSecretKey = "mailAgentmailApiKey" }}
+{{- end }}
+{{- $credentialChecksumSources := dict }}
+{{- range $name, $source := dict
+      "channelToken" (dict "secretName" $channelSecretName "secretKey" $channelSecretKey)
+      "egressSecret" (dict "secretName" $egressSecretName "secretKey" $egressSecretKey)
+      "agentmailApiKey" (dict "secretName" $agentmailSecretName "secretKey" $agentmailSecretKey) }}
+  {{- $liveSecret := lookup "v1" "Secret" $.Release.Namespace $source.secretName }}
+  {{- $liveData := dict }}
+  {{- if $liveSecret }}
+    {{- $liveData = (get $liveSecret "data") | default dict }}
+  {{- end }}
+  {{- if hasKey $liveData $source.secretKey }}
+    {{- $_ := set $credentialChecksumSources $name (dict "secretName" $source.secretName "secretKey" $source.secretKey "data" (get $liveData $source.secretKey)) }}
+  {{- else }}
+    {{- $_ := set $credentialChecksumSources $name (dict "secretName" $source.secretName "secretKey" $source.secretKey "state" "not-live") }}
+  {{- end }}
 {{- end }}
 {{- $agentmailCidrs := list }}
 {{- range .Values.mailAdapter.agentmail.httpsCidrs }}
@@ -122,13 +162,12 @@ Modeled on templates/dispatcher.yaml, with six deliberate divergences:
     recorded exception to the values-not-templates invariant in
     charts/curie/CLAUDE.md; horizontal scale needs a separately accepted shared
     store design, at which point the exception is removed, not extended.
- 5. A checksum/mail-adapter-credentials pod-template annotation, the same idiom
-    as worker.yaml:96-110 (see its comment for the canonical rationale) and
-    otel-collector.yaml / clickhouse.yaml. Env is read once at boot, so without
-    it a `helm upgrade` that rotates an expired token leaves the pod 401ing at
-    AgentMail behind a green /healthz. Scoped to this adapter's own three
-    credentials so an unrelated key rotating in the shared Secret does not
-    restart it.
+ 5. A checksum/mail-adapter-credentials pod-template annotation hashes the live
+    values behind the adapter's three secretKeyRefs. Env is read once at boot,
+    so without it a `helm upgrade` after an external Secret rotation leaves the
+    pod 401ing at AgentMail behind a green /healthz. A deterministic source-ref
+    fallback keeps clusterless renders stable. Scoped to this adapter's own
+    three credentials so an unrelated key rotating does not restart it.
  6. The deploy gate is a bare `.Values.mailAdapter.deploy`, deliberately NOT the
     dispatcher's three-way curie.dispatcher.enabled gate on deploy plus both
     tokens. mailAdapter.deploy defaults to false, so an operator who sets it true
@@ -171,7 +210,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/mail-adapter-credentials: {{ dict "channelToken" .Values.mailAdapter.channelToken "egressSecret" .Values.mailAdapter.egressSecret "agentmailApiKey" .Values.mailAdapter.agentmail.apiKey | toJson | sha256sum }}
+        checksum/mail-adapter-credentials: {{ $credentialChecksumSources | toJson | sha256sum }}
       labels:
         {{- include "curie.labels" . | nindent 8 }}
         {{- include "curie.selectorLabels" (dict "root" . "component" "mail-adapter") | nindent 8 }}
@@ -207,18 +246,15 @@ spec:
             - name: CURIE_CHANNEL_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "curie.secretName" . }}
-                  key: mailChannelToken
+                  {{- include "curie.secretRef" (dict "root" . "existingSecret" .Values.mailAdapter.channelTokenExistingSecret "existingSecretKey" .Values.mailAdapter.channelTokenExistingSecretKey "defaultKey" "mailChannelToken") | nindent 18 }}
             - name: CURIE_EGRESS_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "curie.secretName" . }}
-                  key: mailEgressSecret
+                  {{- include "curie.secretRef" (dict "root" . "existingSecret" .Values.mailAdapter.egressSecretExistingSecret "existingSecretKey" .Values.mailAdapter.egressSecretExistingSecretKey "defaultKey" "mailEgressSecret") | nindent 18 }}
             - name: AGENTMAIL_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "curie.secretName" . }}
-                  key: mailAgentmailApiKey
+                  {{- include "curie.secretRef" (dict "root" . "existingSecret" .Values.mailAdapter.agentmail.apiKeyExistingSecret "existingSecretKey" .Values.mailAdapter.agentmail.apiKeyExistingSecretKey "defaultKey" "mailAgentmailApiKey") | nindent 18 }}
             - name: AGENTMAIL_INBOX
               value: {{ .Values.mailAdapter.inbox | quote }}
             - name: AGENTMAIL_BASE_URL

--- a/charts/curie/templates/mail-adapter.yaml
+++ b/charts/curie/templates/mail-adapter.yaml
@@ -77,41 +77,33 @@ list order or an exact string comparison.
 {{- if not (hasPrefix "https://" .Values.mailAdapter.agentmail.baseUrl) }}
 {{- fail "mailAdapter.deploy is true: mailAdapter.agentmail.baseUrl must use https:// because the mail egress policy permits provider traffic only on TCP 443" }}
 {{- end }}
-{{- /* Resolve the exact Secret sources used by the three secretKeyRefs, then
-     checksum their live data when Helm can reach the cluster. `helm template`
-     and a first install have no live object to read, so the source name/key is
-     the deterministic fallback. No credential data is emitted into the
-     manifest: only the resulting digest reaches the pod annotation. */}}
-{{- $chartSecretName := include "curie.secretName" . }}
-{{- $channelSecretName := .Values.mailAdapter.channelTokenExistingSecret | default $chartSecretName }}
-{{- $channelSecretKey := .Values.mailAdapter.channelTokenExistingSecretKey }}
-{{- if not .Values.mailAdapter.channelTokenExistingSecret }}
-{{- $channelSecretKey = "mailChannelToken" }}
-{{- end }}
-{{- $egressSecretName := .Values.mailAdapter.egressSecretExistingSecret | default $chartSecretName }}
-{{- $egressSecretKey := .Values.mailAdapter.egressSecretExistingSecretKey }}
-{{- if not .Values.mailAdapter.egressSecretExistingSecret }}
-{{- $egressSecretKey = "mailEgressSecret" }}
-{{- end }}
-{{- $agentmailSecretName := .Values.mailAdapter.agentmail.apiKeyExistingSecret | default $chartSecretName }}
-{{- $agentmailSecretKey := .Values.mailAdapter.agentmail.apiKeyExistingSecretKey }}
-{{- if not .Values.mailAdapter.agentmail.apiKeyExistingSecret }}
-{{- $agentmailSecretKey = "mailAgentmailApiKey" }}
-{{- end }}
+{{- /* Chart-managed credentials must checksum the incoming values, not the
+     currently live chart Secret: on an upgrade Kubernetes has not applied the
+     next Secret yet, so hashing the old object would leave the pod template
+     unchanged and the process would keep its old environment. An externally
+     managed credential is the opposite lifecycle: its Helm value is only a
+     reference, so checksum the referenced Secret's live data when available.
+     Clusterless renders and a first install fall back to the external source
+     name/key. No credential data is emitted into the manifest: only the
+     resulting digest reaches the pod annotation. */}}
 {{- $credentialChecksumSources := dict }}
 {{- range $name, $source := dict
-      "channelToken" (dict "secretName" $channelSecretName "secretKey" $channelSecretKey)
-      "egressSecret" (dict "secretName" $egressSecretName "secretKey" $egressSecretKey)
-      "agentmailApiKey" (dict "secretName" $agentmailSecretName "secretKey" $agentmailSecretKey) }}
-  {{- $liveSecret := lookup "v1" "Secret" $.Release.Namespace $source.secretName }}
-  {{- $liveData := dict }}
-  {{- if $liveSecret }}
-    {{- $liveData = (get $liveSecret "data") | default dict }}
-  {{- end }}
-  {{- if hasKey $liveData $source.secretKey }}
-    {{- $_ := set $credentialChecksumSources $name (dict "secretName" $source.secretName "secretKey" $source.secretKey "data" (get $liveData $source.secretKey)) }}
+      "channelToken" (dict "existingSecret" .Values.mailAdapter.channelTokenExistingSecret "existingSecretKey" .Values.mailAdapter.channelTokenExistingSecretKey "value" .Values.mailAdapter.channelToken)
+      "egressSecret" (dict "existingSecret" .Values.mailAdapter.egressSecretExistingSecret "existingSecretKey" .Values.mailAdapter.egressSecretExistingSecretKey "value" .Values.mailAdapter.egressSecret)
+      "agentmailApiKey" (dict "existingSecret" .Values.mailAdapter.agentmail.apiKeyExistingSecret "existingSecretKey" .Values.mailAdapter.agentmail.apiKeyExistingSecretKey "value" .Values.mailAdapter.agentmail.apiKey) }}
+  {{- if $source.existingSecret }}
+    {{- $liveSecret := lookup "v1" "Secret" $.Release.Namespace $source.existingSecret }}
+    {{- $liveData := dict }}
+    {{- if $liveSecret }}
+      {{- $liveData = (get $liveSecret "data") | default dict }}
+    {{- end }}
+    {{- if hasKey $liveData $source.existingSecretKey }}
+      {{- $_ := set $credentialChecksumSources $name (dict "secretName" $source.existingSecret "secretKey" $source.existingSecretKey "data" (get $liveData $source.existingSecretKey)) }}
+    {{- else }}
+      {{- $_ := set $credentialChecksumSources $name (dict "secretName" $source.existingSecret "secretKey" $source.existingSecretKey "state" "not-live") }}
+    {{- end }}
   {{- else }}
-    {{- $_ := set $credentialChecksumSources $name (dict "secretName" $source.secretName "secretKey" $source.secretKey "state" "not-live") }}
+    {{- $_ := set $credentialChecksumSources $name (dict "source" "chart-managed" "value" $source.value) }}
   {{- end }}
 {{- end }}
 {{- $agentmailCidrs := list }}
@@ -162,12 +154,13 @@ Modeled on templates/dispatcher.yaml, with six deliberate divergences:
     recorded exception to the values-not-templates invariant in
     charts/curie/CLAUDE.md; horizontal scale needs a separately accepted shared
     store design, at which point the exception is removed, not extended.
- 5. A checksum/mail-adapter-credentials pod-template annotation hashes the live
-    values behind the adapter's three secretKeyRefs. Env is read once at boot,
-    so without it a `helm upgrade` after an external Secret rotation leaves the
-    pod 401ing at AgentMail behind a green /healthz. A deterministic source-ref
-    fallback keeps clusterless renders stable. Scoped to this adapter's own
-    three credentials so an unrelated key rotating does not restart it.
+ 5. A checksum/mail-adapter-credentials pod-template annotation hashes the next
+    Helm value for each chart-managed credential and the live data behind each
+    external secretKeyRef. Env is read once at boot, so without it a Helm-value
+    or external Secret rotation leaves the pod using the old credential behind
+    a green /healthz. A deterministic external source-ref fallback keeps
+    clusterless renders stable. Scoped to this adapter's own three credentials
+    so an unrelated key rotating does not restart it.
  6. The deploy gate is a bare `.Values.mailAdapter.deploy`, deliberately NOT the
     dispatcher's three-way curie.dispatcher.enabled gate on deploy plus both
     tokens. mailAdapter.deploy defaults to false, so an operator who sets it true

--- a/charts/curie/templates/secrets.yaml
+++ b/charts/curie/templates/secrets.yaml
@@ -9,17 +9,17 @@ its auth header (issue #1563). So this object always renders, synthesized from
 the values defaults -- override those (or supply an `existingSecret` per
 store) in any shared deployment.
 
-The nine direct-passthrough keys below (agentCredentials, adapterCredentials,
-githubToken, githubAppPrivateKey, sealingPrivateKey,
-sealingPreviousPrivateKey, slackAppToken, slackBotToken, slackSigningSecret)
-each carry a per-component `existingSecret`/`existingSecretKey` pair (issue
-#1759; githubAppPrivateKey's shipped first, under ADR-0092). The consuming
-template's `secretKeyRef` follows that pair when set and otherwise falls back
-to this Secret's own key, so a BYO Secret missing the referenced key fails
-that pod loudly with CreateContainerConfigError rather than the chart silently
-emitting an empty credential -- the same fail-loud property `otlpAuthHeader`
-below gets from never rendering a value the operator's own Secret would not
-be read for.
+The twelve direct-passthrough keys below (agentCredentials,
+adapterCredentials, githubToken, githubAppPrivateKey, sealingPrivateKey,
+sealingPreviousPrivateKey, slackAppToken, slackBotToken, slackSigningSecret,
+mailChannelToken, mailEgressSecret, mailAgentmailApiKey) each carry a
+per-component `existingSecret`/`existingSecretKey` pair (issue #1759;
+githubAppPrivateKey's shipped first, under ADR-0092). The consuming template's
+`secretKeyRef` follows that pair when set and otherwise falls back to this
+Secret's own key, so a BYO Secret missing the referenced key fails that pod
+loudly with CreateContainerConfigError rather than the chart silently emitting
+an empty credential -- the same fail-loud property `otlpAuthHeader` below gets
+from never rendering a value the operator's own Secret would not be read for.
 
 The twelve chart owned credentials (the four backing store passwords, the three
 Langfuse app secrets, both init credentials, the API key, approval chat
@@ -149,7 +149,15 @@ stringData:
        generated mailEgressSecret would silently diverge from the worker half in
        adapterCredentials, breaking egress with a 401 that reads like a code
        bug. All three are empty by default and the adapter refuses to boot
-       without them. */}}
+       without them. Each key is omitted when its per-field existingSecret is
+       set (issue #1759), so a Helm upgrade cannot overwrite the externally
+       managed source. */}}
+  {{- if not .Values.mailAdapter.agentmail.apiKeyExistingSecret }}
   mailAgentmailApiKey: {{ .Values.mailAdapter.agentmail.apiKey | quote }}
+  {{- end }}
+  {{- if not .Values.mailAdapter.channelTokenExistingSecret }}
   mailChannelToken: {{ .Values.mailAdapter.channelToken | quote }}
+  {{- end }}
+  {{- if not .Values.mailAdapter.egressSecretExistingSecret }}
   mailEgressSecret: {{ .Values.mailAdapter.egressSecret | quote }}
+  {{- end }}

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -1090,6 +1090,11 @@ mailAdapter:
     # sent to a third party as a bearer token and fail auth in a way that looks
     # like a permissions problem rather than a missing credential.
     apiKey: ""
+    # BYO Secret escape (issue #1759). When set, the adapter reads this Secret
+    # and key directly and the chart omits mailAgentmailApiKey from its own
+    # Secret, so an upgrade cannot replace externally managed credential data.
+    apiKeyExistingSecret: ""
+    apiKeyExistingSecretKey: mailAgentmailApiKey
     baseUrl: "https://api.agentmail.to/v0"
     # NetworkPolicy cannot authorize a DNS name. Supply the current provider
     # (or a controlled egress proxy) HTTPS CIDRs explicitly. Enabling the
@@ -1098,14 +1103,23 @@ mailAdapter:
   # The `chn` channel token minted by the API's POST /channels/token, scoped to
   # this adapter's channel binding. The adapter presents it on every inbound post.
   channelToken: ""
+  channelTokenExistingSecret: ""
+  channelTokenExistingSecretKey: mailChannelToken
   # The shared secret the worker presents as X-Curie-Adapter-Secret when it
   # delivers reply events here, and that the adapter verifies before any side
   # effect. THIS IS THE SINGLE SOURCE OF TRUTH FOR BOTH HALVES of the pair: the
   # chart derives the worker's half, worker.adapterCredentials[adapterSlug],
-  # from it, so setting this one value wires both sides. Do not also write that
-  # entry by hand. Coalesced by curie.adapterCredentials; see _helpers.tpl for
-  # why an equal value is accepted and a conflicting one fails the render.
+  # from the plain value, so setting this one value wires both sides. The BYO
+  # Secret fields below control the adapter's reference only. When
+  # egressSecretExistingSecret is set, worker.adapterCredentialsExistingSecret
+  # must also source the worker's JSON credential map because Helm cannot derive
+  # that map from externally managed Secret data; the render fails closed when
+  # only the adapter-side escape is set. Coalesced by curie.adapterCredentials;
+  # see _helpers.tpl for why an equal inline value is accepted and a conflicting
+  # one fails the render.
   egressSecret: ""
+  egressSecretExistingSecret: ""
+  egressSecretExistingSecretKey: mailEgressSecret
   # Must equal the `adapter` slug on the agent's channel binding row, and it is
   # also the key the derived worker.adapterCredentials entry lands under.
   adapterSlug: "mail-adapter"

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -483,29 +483,33 @@ Two platform-side steps come first, in this order:
    scoped `chn` token for that one binding. It refuses with 409 for a non-`slack`
    binding that has no reply route, which is why the binding comes first.
 
-Then turn the adapter on. Do not put any of its three credentials in `--set`:
-command arguments reach shell history and the process table. Keep the ordinary
-configuration in the installation's checked-in values and render the secret
-values from a secret manager into a gitignored mode-0600 file:
+Then turn the adapter on. Keep all three credentials out of `--set`, Helm
+values, and release history by having a secret manager materialize an
+operator-managed Kubernetes Secret before the install or upgrade. One Secret
+can carry the adapter's three keys plus the worker's JSON credential map. The
+map's `mail-adapter` entry must be generated from the same egress-secret source;
+do not copy the value by hand. The checked-in, non-secret values file then
+contains only references:
 
-```bash
-# One-time local guard for the private file. .git/info/exclude is local to this
-# checkout; it cannot accidentally publish the filename as a repo rule.
-printf '%s\n' '.curie-mail-secrets.yaml' >> .git/info/exclude
-install -m 0600 /dev/null .curie-mail-secrets.yaml
-
-# Have the secret manager/template step write this shape without echoing values:
-# mailAdapter:
-#   agentmail:
-#     apiKey: <secret>
-#   channelToken: <secret>
-#   egressSecret: <secret>
-${EDITOR:?set EDITOR} .curie-mail-secrets.yaml
-chmod 0600 .curie-mail-secrets.yaml
-
-helm upgrade <release> <chart> -n <ns> \
-  -f values.yaml -f .curie-mail-secrets.yaml
+```yaml
+mailAdapter:
+  channelTokenExistingSecret: curie-mail-credentials
+  channelTokenExistingSecretKey: channel-token
+  egressSecretExistingSecret: curie-mail-credentials
+  egressSecretExistingSecretKey: egress-secret
+  agentmail:
+    apiKeyExistingSecret: curie-mail-credentials
+    apiKeyExistingSecretKey: agentmail-api-key
+worker:
+  adapterCredentialsExistingSecret: curie-mail-credentials
+  adapterCredentialsExistingSecretKey: adapter-credentials
 ```
+
+The referenced Secret keys carry, respectively, the scoped channel token, the
+shared adapter egress credential, the AgentMail API key, and a JSON object that
+maps the configured `mailAdapter.adapterSlug` to that same egress credential.
+All `secretKeyRef`s are non-optional: a missing Secret or key prevents the pod
+from starting instead of falling back to an empty or chart-held value.
 
 The non-secret `values.yaml` contains the switch, inbox, allowed senders, and
 network destination. Kubernetes NetworkPolicy cannot authorize an FQDN, so use
@@ -550,25 +554,42 @@ mailAdapter:
 | `mailAdapter.allowedSenders` | Who may start a turn. Empty denies everyone, and with ingress on the pod refuses to boot rather than run an inbox that answers nobody; `*` is the explicit allow-all. |
 | `mailAdapter.ingressEnabled` | `false` serves egress while sending nothing inbound. That is the staged-cutover position while the platform side of a new binding is being wired. |
 | `mailAdapter.egressSecret` | The shared secret the worker presents on `X-Curie-Adapter-Secret` and the adapter checks before any side effect. |
+| `mailAdapter.channelTokenExistingSecret` / `channelTokenExistingSecretKey` | Source the scoped channel token from an operator-managed Secret instead of the chart Secret (default key `mailChannelToken`). |
+| `mailAdapter.egressSecretExistingSecret` / `egressSecretExistingSecretKey` | Source the adapter's egress credential externally (default key `mailEgressSecret`). This requires `worker.adapterCredentialsExistingSecret` to supply the paired worker map. |
+| `mailAdapter.agentmail.apiKeyExistingSecret` / `apiKeyExistingSecretKey` | Source the AgentMail API key from an operator-managed Secret instead of the chart Secret (default key `mailAgentmailApiKey`). |
 | `mailAdapter.agentmail.httpsCidrs` | Required provider/proxy destination CIDRs on TCP 443. The mail pod's egress policy otherwise allows only DNS and this release's API pods. |
 | `mailAdapter.apiEgress.httpsCidrs` / `port` | Required narrow destination peers when `api.deploy=false`; default port `8000`. Ignored for the in-chart API, whose pod selector and service port are used instead. |
 | `mailAdapter.persistence.size` / `storageClass` | Chart-managed RWO SQLite PVC. The default size is `1Gi`; empty storage class inherits `global.storageClass` and then the cluster default. |
 | `mailAdapter.persistence.existingClaim` | Mount an existing same-namespace RWO Filesystem PVC instead of rendering one. An install/upgrade hook checks the exact claim before replacing the pod. |
 
-**Do not write `worker.adapterCredentials.mail-adapter` by hand.** The chart derives it
-from `mailAdapter.egressSecret`, so the pair cannot drift. An equal value is accepted; a
-conflicting one fails the render by design. Rotating `mailAdapter.channelToken`,
-`mailAdapter.egressSecret` or `mailAdapter.agentmail.apiKey` and running `helm upgrade`
-restarts the adapter pod on its own, with no `kubectl rollout restart`. The one
-`Recreate` replica reopens the same SQLite file and resumes pending work. The
-adapter cannot mint a replacement `chn` token because it deliberately holds no
-platform key.
+On the chart-managed path, do not write
+`worker.adapterCredentials.mail-adapter` by hand. The chart derives it from
+`mailAdapter.egressSecret`, accepts an equal migration value, and refuses a
+conflict. Changing any of the three plain mail credential values and running
+`helm upgrade` changes the adapter pod-template checksum; changing the egress
+value also changes the derived worker map and rolls the worker.
 
-The chart Secret still contains the three values because the pods need them.
-Using secret references keeps them out of rendered Deployment manifests; it does
-not hide them from a release administrator who can read Helm's release Secret or
-the chart Secret. Restrict those permissions with cluster RBAC, and rotate at the
-provider/platform when an administrator loses that trust.
+On the external path, `mailAdapter.egressSecretExistingSecret` requires
+`worker.adapterCredentialsExistingSecret`. The chart neither derives the mail
+entry nor compares it with the unused plain egress value: the two referenced
+Secret keys are the authority. Rotate both representations from one source,
+then run `helm upgrade` so the adapter hashes the live referenced data and
+recreates its pod. The worker reads its external JSON map only at pod start and
+its checksum tracks the reference, not same-Secret data changes, so restart the
+worker after an in-place external rotation with `kubectl -n <ns> rollout
+restart deployment/<release>-worker`. A source name/key change through Helm
+rolls both consumers through their source-reference checksums. The one
+`Recreate` adapter replica reopens the same SQLite file and resumes pending
+work. The adapter cannot mint a replacement channel token because it
+deliberately holds no platform key.
+
+The chart Secret contains a mail key only while that field is chart-managed;
+setting its `existingSecret` omits the key so later upgrades cannot overwrite
+the external source. Secret references keep credentials out of Deployment
+manifests, and external references also keep their data out of Helm values and
+release history. They do not hide data from a cluster administrator who can
+read the referenced Secret. Restrict those permissions with cluster RBAC, and
+rotate at the provider/platform when an administrator loses that trust.
 
 Only a new SQLite file primes the current inbox as history. A restart performs
 one provider confirmation without marking messages seen, then resumes durable


### PR DESCRIPTION
Adds per-field existing Secret references for mail adapter channel, provider API, and egress credentials. The chart omits externally managed keys, keeps refs required, and rolls the adapter on supported credential-source changes. Fixes #1759.