### PR TITLE
Bind the worker runner timeout to the delivery budget

### DIFF
--- a/apps/worker/src/curie_worker/config.py
+++ b/apps/worker/src/curie_worker/config.py
@@ -36,7 +36,7 @@ from aci_protocol.service_config import (
     derive_dead_letter_stream_name,
     warn_if_deprecated_api_url_env,
 )
-from pydantic import BeforeValidator, Field, model_validator
+from pydantic import AliasChoices, BeforeValidator, Field, model_validator
 from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 from pydantic_settings.sources import (
     PydanticBaseSettingsSource,
@@ -705,7 +705,14 @@ class WorkerConfig(BaseSettings):
 
     # Runner HTTP timeouts
     runner_connect_timeout_s: float = 10.0
-    runner_total_timeout_s: float = 600.0
+    runner_total_timeout_s: float = Field(
+        default=600.0,
+        gt=0.0,
+        le=1800.0,
+        validation_alias=AliasChoices(
+            "CURIE_RUNNER_TOTAL_TIMEOUT_S", "RUNNER_TOTAL_TIMEOUT_S"
+        ),
+    )
 
     # Eval stream (F3): a separate consumer group on curie:evals runs eval
     # suites and reports results to the platform API and Langfuse.

--- a/apps/worker/src/curie_worker/kernel.py
+++ b/apps/worker/src/curie_worker/kernel.py
@@ -2422,7 +2422,9 @@ class Kernel:
             ):
                 try:
                     snapshot = await self._runner.snapshot(
-                        routed.handle.base_url, token=routed.handle.token or None
+                        routed.handle.base_url,
+                        token=routed.handle.token or None,
+                        remaining_s=remaining_s,
                     )
                     if self._workspace is None:
                         raise WorkspacePreparationError(

--- a/apps/worker/src/curie_worker/runner_client.py
+++ b/apps/worker/src/curie_worker/runner_client.py
@@ -297,18 +297,6 @@ class RunnerClient:
         if remaining_s is None:
             return sentinel
         bounded = max(_MIN_REQUEST_TIMEOUT_S, min(self._total_timeout_s, remaining_s))
-        logger.info(
-            "runner request timeout bound: configured ceiling %.3fs, "
-            "remaining delivery %.3fs, effective timeout %.3fs",
-            self._total_timeout_s,
-            remaining_s,
-            bounded,
-            extra={
-                "effective_request_timeout_s": bounded,
-                "configured_runner_ceiling_s": self._total_timeout_s,
-                "remaining_delivery_s": remaining_s,
-            },
-        )
         return aiohttp.ClientTimeout(
             total=bounded, connect=self._connect_timeout_s, sock_read=bounded
         )
@@ -372,6 +360,19 @@ class RunnerClient:
             if request_timeout is sentinel
             else request_timeout.total
         )
+        if remaining_s is not None:
+            logger.info(
+                "runner request timeout bound: configured ceiling %.3fs, "
+                "remaining delivery %.3fs, effective timeout %.3fs",
+                self._total_timeout_s,
+                remaining_s,
+                stream_timeout_s,
+                extra={
+                    "effective_request_timeout_s": stream_timeout_s,
+                    "configured_runner_ceiling_s": self._total_timeout_s,
+                    "remaining_delivery_s": remaining_s,
+                },
+            )
 
         async def request(headers: dict[str, str] | None) -> tuple[TurnStream, str]:
             resp = await self._session.post(

--- a/apps/worker/src/curie_worker/runner_client.py
+++ b/apps/worker/src/curie_worker/runner_client.py
@@ -362,16 +362,9 @@ class RunnerClient:
         )
         if remaining_s is not None:
             logger.info(
-                "runner request timeout bound: configured ceiling %.3fs, "
-                "remaining delivery %.3fs, effective timeout %.3fs",
-                self._total_timeout_s,
-                remaining_s,
-                stream_timeout_s,
-                extra={
-                    "effective_request_timeout_s": stream_timeout_s,
-                    "configured_runner_ceiling_s": self._total_timeout_s,
-                    "remaining_delivery_s": remaining_s,
-                },
+                f"runner request timeout bound: configured ceiling {self._total_timeout_s:.3f}s, "
+                f"remaining delivery {remaining_s:.3f}s, effective timeout "
+                f"{stream_timeout_s:.3f}s"
             )
 
         async def request(headers: dict[str, str] | None) -> tuple[TurnStream, str]:

--- a/apps/worker/src/curie_worker/runner_client.py
+++ b/apps/worker/src/curie_worker/runner_client.py
@@ -297,6 +297,18 @@ class RunnerClient:
         if remaining_s is None:
             return sentinel
         bounded = max(_MIN_REQUEST_TIMEOUT_S, min(self._total_timeout_s, remaining_s))
+        logger.info(
+            "runner request timeout bound: configured ceiling %.3fs, "
+            "remaining delivery %.3fs, effective timeout %.3fs",
+            self._total_timeout_s,
+            remaining_s,
+            bounded,
+            extra={
+                "effective_request_timeout_s": bounded,
+                "configured_runner_ceiling_s": self._total_timeout_s,
+                "remaining_delivery_s": remaining_s,
+            },
+        )
         return aiohttp.ClientTimeout(
             total=bounded, connect=self._connect_timeout_s, sock_read=bounded
         )
@@ -354,19 +366,25 @@ class RunnerClient:
         remaining_s: float | None = None,
     ) -> TurnStream:
         """Open a turn. Returns once the runner has accepted it (turn active)."""
+        request_timeout = self._request_timeout(remaining_s)
+        stream_timeout_s = (
+            self._total_timeout_s
+            if request_timeout is sentinel
+            else request_timeout.total
+        )
 
         async def request(headers: dict[str, str] | None) -> tuple[TurnStream, str]:
             resp = await self._session.post(
                 f"{base_url}/v1/event",
                 json=event.model_dump(),
                 headers=headers,
-                timeout=self._request_timeout(remaining_s),
+                timeout=request_timeout,
             )
             if resp.status != 200:
                 body = await resp.text()
                 resp.release()
                 raise RunnerError(f"/v1/event -> {resp.status}: {body}")
-            return TurnStream(resp, self._total_timeout_s), "success"
+            return TurnStream(resp, stream_timeout_s), "success"
 
         return await self._rpc("event", token, request)
 

--- a/apps/worker/tests/binding/test_boot_env_single_declaration.py
+++ b/apps/worker/tests/binding/test_boot_env_single_declaration.py
@@ -264,6 +264,9 @@ _NON_BOOT_ALLOWLIST: frozenset[str] = frozenset(
         # anything injected into a runner claim.
         # - CURIE_DELIVERY_BUDGET_S: the overall wall-clock deadline for one
         #   delivery (claim, every runner request, retries, reclaim, cleanup).
+        # - CURIE_RUNNER_TOTAL_TIMEOUT_S: the worker-side per-request HTTP
+        #   ceiling consumed by RunnerClient inside that delivery budget. It
+        #   bounds calls to a runner but is never injected into the sandbox.
         # - CURIE_DELIVERY_LEASE_TTL_S: how long the fenced ownership lease on
         #   an in-flight delivery is valid before it is reclaimable.
         # - CURIE_DELIVERY_LEASE_HEARTBEAT_S: how often the owner renews that
@@ -275,6 +278,7 @@ _NON_BOOT_ALLOWLIST: frozenset[str] = frozenset(
         #   CURIE_RECLAIM_MIN_IDLE_MS in the code above, worker-side policy
         #   decided before any sandbox exists.
         "CURIE_DELIVERY_BUDGET_S",
+        "CURIE_RUNNER_TOTAL_TIMEOUT_S",
         "CURIE_DELIVERY_LEASE_TTL_S",
         "CURIE_DELIVERY_LEASE_HEARTBEAT_S",
         "CURIE_DELIVERY_SHUTDOWN_RESERVE_S",

--- a/apps/worker/tests/kernel/test_approval_lifecycle.py
+++ b/apps/worker/tests/kernel/test_approval_lifecycle.py
@@ -29,6 +29,7 @@ from curie_worker.approvals import (
     SettledApproval,
 )
 from curie_worker.reply_sink import TargetRoute
+from curie_worker.runner_client import RunnerError
 from curie_worker.sandbox.types import RouteState
 
 DONE = SessionStatus.DONE
@@ -713,6 +714,54 @@ def test_unknown_gate_kind_escalates_instead_of_stranding_the_turn(make_harness)
             assert modes == ["Running"]
             # Terminally handled, so the entry is acked rather than redelivered.
             assert await h.async_redis.exists(h.config.done_key(ev.event_id))
+
+    asyncio.run(go())
+
+
+def test_publication_snapshot_inherits_the_attempts_remaining_delivery_budget(
+    make_harness, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The publication snapshot is part of the same delivery as the turn.
+
+    Pin the handoff at the kernel boundary: a snapshot must not silently regain
+    the configured runner ceiling after the streamed request has consumed part
+    of the delivery deadline.
+    """
+
+    async def go() -> None:
+        async with make_harness() as h:
+            h.runner.default_script = [
+                Final(
+                    text="Ready to publish",
+                    status=AWAITING,
+                    approval_summary="Publish the prepared changes",
+                    approval_gate_kind="permission",
+                    approval_granted_tool="mcp__curie__publish_changes",
+                )
+            ]
+            observed_remaining: list[float] = []
+
+            async def snapshot_spy(
+                _base_url: str,
+                token: str | None = None,
+                *,
+                remaining_s: float,
+            ) -> None:
+                observed_remaining.append(remaining_s)
+                # Stop after capturing the boundary; _attempt deliberately
+                # converts runner snapshot failures into a publication error.
+                raise RunnerError("captured snapshot deadline")
+
+            monkeypatch.setattr(h.kernel._runner, "snapshot", snapshot_spy)
+            outcome = await h.kernel._attempt(
+                _qevent("publish", thread="th-publication-deadline"),
+                TargetRoute(),
+                lambda: None,
+                remaining_s=17.25,
+            )
+
+            assert outcome.status is AWAITING
+            assert observed_remaining == [17.25]
 
     asyncio.run(go())
 

--- a/apps/worker/tests/kernel/test_runner_client.py
+++ b/apps/worker/tests/kernel/test_runner_client.py
@@ -551,7 +551,9 @@ def test_start_turn_uses_the_remaining_budget_when_it_is_shorter() -> None:
     asyncio.run(go())
 
 
-def test_start_turn_without_a_remaining_budget_uses_the_session_default() -> None:
+def test_start_turn_without_a_remaining_budget_uses_the_session_default(
+    caplog,
+) -> None:
     """``remaining_s=None`` must leave the session timeout in charge: that is the
     path every leaseless caller and every existing test takes, and it must stay
     byte-identical in behavior."""
@@ -565,9 +567,23 @@ def test_start_turn_without_a_remaining_budget_uses_the_session_default() -> Non
         try:
             loop = asyncio.get_event_loop()
             started = loop.time()
-            with pytest.raises(TimeoutError):
-                await client.start_turn(base_url, _event(), remaining_s=None)
+            with caplog.at_level(logging.INFO, logger="curie_worker.runner_client"):
+                with pytest.raises(TimeoutError):
+                    await client.start_turn(base_url, _event(), remaining_s=None)
             assert loop.time() - started < 5.0
+            budget_records = [
+                record
+                for record in caplog.records
+                if record.name == "curie_worker.runner_client"
+                and hasattr(record, "effective_request_timeout_s")
+            ]
+            assert budget_records == [], caplog.text
+            assert not any(
+                "remaining" in record.getMessage()
+                and "effective" in record.getMessage()
+                for record in caplog.records
+                if record.name == "curie_worker.runner_client"
+            ), caplog.text
         finally:
             runner.hang.set()
             await client.close()
@@ -595,6 +611,48 @@ def test_the_effective_timeout_is_the_min_of_the_budget_and_the_session_ceiling(
             assert loop.time() - started < 5.0
         finally:
             runner.hang.set()
+            await client.close()
+            await server.close()
+
+    asyncio.run(go())
+
+
+def test_budgeted_request_logs_the_effective_timeout_bound(caplog) -> None:
+    """A real request records the configured ceiling, the unmodified delivery
+    remainder, and the effective post-floor timeout handed to aiohttp."""
+
+    async def go() -> None:
+        runner = _HeaderRecordingRunner()
+        server = TestServer(runner.app)
+        await server.start_server()
+        base_url = f"http://127.0.0.1:{server.port}"
+        client = RunnerClient(total_timeout_s=30.0)
+        try:
+            with caplog.at_level(logging.INFO, logger="curie_worker.runner_client"):
+                turn = await client.start_turn(base_url, _event(), remaining_s=5.0)
+                await _drain(turn)
+
+            budget_records = [
+                record
+                for record in caplog.records
+                if record.name == "curie_worker.runner_client"
+                and hasattr(record, "effective_request_timeout_s")
+            ]
+            assert len(budget_records) == 1, caplog.text
+            record = budget_records[0]
+            assert record.levelno == logging.INFO
+            assert getattr(record, "configured_runner_ceiling_s", None) == 30.0
+            assert getattr(record, "remaining_delivery_s", None) == 5.0
+            assert getattr(record, "effective_request_timeout_s", None) == 5.0
+            message = record.getMessage()
+            normalized_message = message.lower()
+            assert "configured" in normalized_message
+            assert "ceiling" in normalized_message
+            assert "30.0" in message
+            assert "remaining" in normalized_message
+            assert "effective" in normalized_message
+            assert message.count("5.0") >= 2
+        finally:
             await client.close()
             await server.close()
 
@@ -686,10 +744,12 @@ def test_stream_timeout_raises_a_named_timeout_and_logs_the_expired_budget(
             h.runner.hold = hold
             h.runner.default_script = [TextDelta(text="x")]
             handle = await asyncio.to_thread(h.substrate.claim, "tStreamTimeout")
-            client = RunnerClient(total_timeout_s=0.5)
+            client = RunnerClient(total_timeout_s=5.0)
             try:
                 with caplog.at_level(logging.WARNING, logger="curie_worker.runner_client"):
-                    turn = await client.start_turn(handle.base_url, _event())
+                    turn = await client.start_turn(
+                        handle.base_url, _event(), remaining_s=0.2
+                    )
                     with pytest.raises(TimeoutError) as excinfo:
                         async with turn:
                             async for _frame in turn:
@@ -700,7 +760,10 @@ def test_stream_timeout_raises_a_named_timeout_and_logs_the_expired_budget(
                 assert isinstance(exc, TimeoutError)  # existing handlers still catch it
                 assert str(exc).strip(), "a stream timeout must not stringify to nothing"
                 assert "Timeout" in str(exc)  # the normalized underlying class
-                assert "0.5" in str(exc)  # the budget that expired, in seconds
+                # The delivery had only 0.2s left, so that effective request
+                # bound -- not the configured 5s ceiling -- is what expired.
+                assert "0.2" in str(exc)
+                assert "5.0s" not in str(exc)
 
                 warnings = [
                     record.getMessage()
@@ -709,9 +772,10 @@ def test_stream_timeout_raises_a_named_timeout_and_logs_the_expired_budget(
                     and record.levelno >= logging.WARNING
                 ]
                 assert warnings, caplog.text
-                assert any("Timeout" in message and "0.5" in message for message in warnings), (
-                    warnings
-                )
+                assert any(
+                    "Timeout" in message and "0.2" in message for message in warnings
+                ), warnings
+                assert all("5.0s" not in message for message in warnings)
             finally:
                 hold.set()
                 await client.close()

--- a/apps/worker/tests/kernel/test_runner_client.py
+++ b/apps/worker/tests/kernel/test_runner_client.py
@@ -659,6 +659,51 @@ def test_budgeted_request_logs_the_effective_timeout_bound(caplog) -> None:
     asyncio.run(go())
 
 
+def test_budgeted_status_does_not_log_the_turn_timeout_bound(caplog) -> None:
+    """Budget propagation still bounds control RPCs, but the effective turn
+    timeout record belongs only to the request that opens the streamed turn.
+    Polling status must not emit that operator-facing message or its structured
+    fields.
+    """
+
+    async def go() -> None:
+        app = web.Application()
+
+        async def status_handler(_request: web.Request) -> web.Response:
+            return web.json_response({"turn_active": False})
+
+        app.add_routes([web.get("/status", status_handler)])
+        server = TestServer(app)
+        await server.start_server()
+        base_url = f"http://127.0.0.1:{server.port}"
+        client = RunnerClient(total_timeout_s=30.0)
+        try:
+            caplog.clear()
+            with caplog.at_level(logging.INFO, logger="curie_worker.runner_client"):
+                status = await client.status(base_url, remaining_s=5.0)
+
+            assert status["turn_active"] is False
+            records = [
+                record
+                for record in caplog.records
+                if record.name == "curie_worker.runner_client"
+            ]
+            assert not any(
+                record.levelno == logging.INFO
+                and "runner request timeout bound" in record.getMessage()
+                for record in records
+            ), caplog.text
+            assert not any(
+                hasattr(record, "effective_request_timeout_s")
+                for record in records
+            ), caplog.text
+        finally:
+            await client.close()
+            await server.close()
+
+    asyncio.run(go())
+
+
 def test_a_remaining_budget_does_not_break_a_responsive_turn() -> None:
     """The positive control for the three timeout tests above: with a budget in
     hand and a runner that answers, the turn still opens and streams. Without it

--- a/apps/worker/tests/kernel/test_runner_client.py
+++ b/apps/worker/tests/kernel/test_runner_client.py
@@ -636,14 +636,11 @@ def test_budgeted_request_logs_the_effective_timeout_bound(caplog) -> None:
                 record
                 for record in caplog.records
                 if record.name == "curie_worker.runner_client"
-                and hasattr(record, "effective_request_timeout_s")
+                and "runner request timeout bound" in record.getMessage()
             ]
             assert len(budget_records) == 1, caplog.text
             record = budget_records[0]
             assert record.levelno == logging.INFO
-            assert getattr(record, "configured_runner_ceiling_s", None) == 30.0
-            assert getattr(record, "remaining_delivery_s", None) == 5.0
-            assert getattr(record, "effective_request_timeout_s", None) == 5.0
             message = record.getMessage()
             normalized_message = message.lower()
             assert "configured" in normalized_message
@@ -652,6 +649,10 @@ def test_budgeted_request_logs_the_effective_timeout_bound(caplog) -> None:
             assert "remaining" in normalized_message
             assert "effective" in normalized_message
             assert message.count("5.0") >= 2
+            # The numeric body is fully formatted before logging. OTLP log
+            # exporters receive this same body rather than a format template
+            # plus deferred arguments that lose their intended representation.
+            assert record.args == ()
         finally:
             await client.close()
             await server.close()
@@ -662,8 +663,7 @@ def test_budgeted_request_logs_the_effective_timeout_bound(caplog) -> None:
 def test_budgeted_status_does_not_log_the_turn_timeout_bound(caplog) -> None:
     """Budget propagation still bounds control RPCs, but the effective turn
     timeout record belongs only to the request that opens the streamed turn.
-    Polling status must not emit that operator-facing message or its structured
-    fields.
+    Polling status must not emit that operator-facing message.
     """
 
     async def go() -> None:
@@ -693,11 +693,40 @@ def test_budgeted_status_does_not_log_the_turn_timeout_bound(caplog) -> None:
                 and "runner request timeout bound" in record.getMessage()
                 for record in records
             ), caplog.text
-            assert not any(
-                hasattr(record, "effective_request_timeout_s")
-                for record in records
-            ), caplog.text
         finally:
+            await client.close()
+            await server.close()
+
+    asyncio.run(go())
+
+
+def test_budgeted_status_uses_the_remaining_delivery_timeout() -> None:
+    """A status read still consumes the delivery deadline even though it does
+    not emit the turn-start timeout record. A short remainder must bound the
+    request instead of inheriting the much larger configured ceiling.
+    """
+
+    async def go() -> None:
+        hold = asyncio.Event()
+        app = web.Application()
+
+        async def hanging_status(_request: web.Request) -> web.Response:
+            await hold.wait()
+            return web.json_response({"turn_active": False})
+
+        app.add_routes([web.get("/status", hanging_status)])
+        server = TestServer(app)
+        await server.start_server()
+        base_url = f"http://127.0.0.1:{server.port}"
+        client = RunnerClient(total_timeout_s=30.0)
+        try:
+            loop = asyncio.get_event_loop()
+            started = loop.time()
+            with pytest.raises(TimeoutError):
+                await client.status(base_url, remaining_s=0.2)
+            assert loop.time() - started < 5.0
+        finally:
+            hold.set()
             await client.close()
             await server.close()
 

--- a/apps/worker/tests/test_config.py
+++ b/apps/worker/tests/test_config.py
@@ -18,6 +18,7 @@ from types import ModuleType
 
 import pytest
 from curie_worker.config import WorkerConfig
+from pydantic import AliasChoices, ValidationError
 
 
 def _clear_all_config_env(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -31,8 +32,16 @@ def _clear_all_config_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """
     for name, field in WorkerConfig.model_fields.items():
         alias = field.validation_alias
-        key = alias if isinstance(alias, str) else name.upper()
-        monkeypatch.delenv(key, raising=False)
+        if isinstance(alias, str):
+            keys = (alias,)
+        elif isinstance(alias, AliasChoices):
+            keys = tuple(
+                choice for choice in alias.choices if isinstance(choice, str)
+            )
+        else:
+            keys = (name.upper(),)
+        for key in keys:
+            monkeypatch.delenv(key, raising=False)
 
 
 # Every env var the OLD hand-rolled ``WorkerConfig.from_env`` read (on
@@ -818,6 +827,97 @@ def test_delivery_knobs_read_their_curie_aliases(
     assert config.delivery_shutdown_reserve_s == 45.0
     assert config.termination_grace_period_s == 1860.0
     assert config.reclaim_interval_s == 10.0
+
+
+def test_runner_total_timeout_reads_the_canonical_curie_alias(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_all_config_env(monkeypatch)
+    monkeypatch.setenv("CURIE_RUNNER_TOTAL_TIMEOUT_S", "1700")
+    monkeypatch.setenv("CURIE_DELIVERY_BUDGET_S", "1800")
+
+    config = WorkerConfig()
+
+    assert config.runner_total_timeout_s == 1700.0
+
+
+def test_runner_total_timeout_keeps_the_legacy_alias(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_all_config_env(monkeypatch)
+    monkeypatch.setenv("RUNNER_TOTAL_TIMEOUT_S", "1600")
+    monkeypatch.setenv("CURIE_DELIVERY_BUDGET_S", "1800")
+
+    config = WorkerConfig()
+
+    assert config.runner_total_timeout_s == 1600.0
+
+
+def test_runner_total_timeout_canonical_alias_wins_over_legacy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_all_config_env(monkeypatch)
+    monkeypatch.setenv("CURIE_RUNNER_TOTAL_TIMEOUT_S", "1700")
+    monkeypatch.setenv("RUNNER_TOTAL_TIMEOUT_S", "1600")
+    monkeypatch.setenv("CURIE_DELIVERY_BUDGET_S", "1800")
+
+    config = WorkerConfig()
+
+    assert config.runner_total_timeout_s == 1700.0
+
+
+def test_runner_total_timeout_accepts_short_programmatic_values_and_maximum(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The chart and Python config accept positive timeout values, including
+    sub-minute values; only positivity and the 1800s ceiling apply here."""
+    _clear_all_config_env(monkeypatch)
+
+    short = _lease_config(runner_total_timeout_s=0.5)
+    maximum = _lease_config(
+        delivery_budget_s=1800.0,
+        runner_total_timeout_s=1800.0,
+    )
+
+    assert short.runner_total_timeout_s == 0.5
+    assert maximum.runner_total_timeout_s == 1800.0
+
+
+@pytest.mark.parametrize(
+    ("value", "error_type"),
+    [(0.0, "greater_than"), (-0.1, "greater_than"), (1800.1, "less_than_equal")],
+)
+def test_runner_total_timeout_rejects_programmatic_values_outside_its_bounds(
+    monkeypatch: pytest.MonkeyPatch,
+    value: float,
+    error_type: str,
+) -> None:
+    _clear_all_config_env(monkeypatch)
+
+    with pytest.raises(ValidationError) as exc_info:
+        _lease_config(delivery_budget_s=1800.0, runner_total_timeout_s=value)
+
+    assert any(
+        error["loc"] == ("runner_total_timeout_s",)
+        and error["type"] == error_type
+        for error in exc_info.value.errors()
+    )
+
+
+def test_runner_total_timeout_rejects_zero_from_the_canonical_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_all_config_env(monkeypatch)
+    monkeypatch.setenv("CURIE_RUNNER_TOTAL_TIMEOUT_S", "0")
+
+    with pytest.raises(ValidationError) as exc_info:
+        WorkerConfig()
+
+    assert any(
+        error["loc"] == ("CURIE_RUNNER_TOTAL_TIMEOUT_S",)
+        and error["type"] == "greater_than"
+        for error in exc_info.value.errors()
+    )
 
 
 def test_delivery_knobs_ignore_bare_field_name_env(

--- a/charts/curie/ci/upgrade-drain-assertions.sh
+++ b/charts/curie/ci/upgrade-drain-assertions.sh
@@ -69,6 +69,7 @@ helm template t "$CHART" \
   --set worker.terminationGracePeriodSeconds=1860 > "$TMP/raised.yaml"
 helm template t "$CHART" \
   --set worker.deliveryBudgetSeconds=60 \
+  --set worker.runnerTotalTimeoutSeconds=60 \
   --set worker.deliveryShutdownReserveSeconds=0 \
   --set worker.upgradeDrain.timeoutSeconds=120 \
   --set worker.upgradeDrain.quiesceTtlSeconds=300 > "$TMP/small.yaml"

--- a/charts/curie/ci/worker-ttl-bounds-assertions.sh
+++ b/charts/curie/ci/worker-ttl-bounds-assertions.sh
@@ -8,7 +8,7 @@
 # command`. That exception is not classified by the kernel, so the turn hangs,
 # the entry is re-delivered to dead-letter, and every attempt leaks a sandbox.
 # `values.schema.json` makes helm refuse the value at install/template time so it
-# never reaches worker env at all. Ten assertions:
+# never reaches worker env at all. Eleven assertions:
 #
 #   (a) POSITIVE, defaults: the render SUCCEEDS and the worker Deployment
 #       carries the three env vars at their shipped defaults.
@@ -66,12 +66,23 @@
 #       assertion in (a) only ever sees 1860 at the default; this is the half
 #       that actually exercises the inequality the ADR mandates, and the only
 #       assertion that demonstrates the guard REJECTING something.
-#
+#   (k) RUNNER CEILING, positive and negative: the shipped worker env contains
+#       CURIE_RUNNER_TOTAL_TIMEOUT_S=600 exactly once; 1700 under an 1800-second
+#       delivery budget renders and reaches the worker; equality at 600, a
+#       fractional 0.5-second ceiling, and the inclusive 1800 maximum render
+#       with coherent delivery budgets. The schema refuses 0 and 1800.1,
+#       proving the exclusive lower bound and inclusive upper bound. Finally,
+#       the relationship guard refuses the individually schema-valid combination
+#       runnerTotalTimeoutSeconds=1700 / deliveryBudgetSeconds=600 and names
+#       both keys, values, inequality, and corrective actions in chart-owned
+#       output. This is the cross-field negative JSON Schema cannot express.
 # SCHEMA WORDING IS NOT ASSERTED, AND MUST NOT BECOME ASSERTED. Every negative
-# below EXCEPT (j) checks only (1) that helm exited non-zero and (2) that the
-# captured output contains the bare knob name. The failure text comes from
-# helm's own bundled JSON-Schema validator, whose wording changed between the
-# CI-pinned helm and current helm while the pass/fail outcomes stayed identical:
+# below EXCEPT the relationship negatives in (j) and (k) checks only (1)
+# that helm exited non-zero and (2) that the captured output contains the bare
+# knob name. The schema-bound negatives in (k) follow this generic rule too.
+# The failure text comes from helm's own bundled JSON-Schema validator, whose
+# wording changed between the CI-pinned helm and current helm while the
+# pass/fail outcomes stayed identical:
 #
 #   helm 3.16.4 (the CI pin, .github/workflows/helm-ci.yaml:40):
 #     - worker.routeTtlSeconds: Must be greater than 0
@@ -86,11 +97,12 @@
 # passes on the author's machine and fails in CI, or the reverse, for a reason
 # that has nothing to do with the chart.
 #
-# (j) is the deliberate exception: its message is CHART-OWNED text from
-# `fail` in _helpers.tpl, not helm's validator, so it cannot drift with the
-# helm version and asserting it is what proves the guard -- rather than some
-# unrelated template error -- is what refused the render. It checks the three
-# key names and the arithmetic, not the full sentence.
+# The relationship negatives in (j), (k), and (l) are the deliberate
+# exceptions: their messages are CHART-OWNED text from `fail` in _helpers.tpl,
+# not helm's validator, so they cannot drift with the helm version and
+# asserting them is what proves each guard -- rather than some unrelated
+# template error -- is what refused the render. They check stable
+# operands/actions, not full sentences.
 #
 # Runnable locally (from anywhere) and from CI. Fails loudly.
 set -euo pipefail
@@ -116,13 +128,23 @@ if len(deploys) != 1:
     raise SystemExit(f"expected exactly one worker Deployment, rendered {len(deploys)}")
 containers = deploys[0]["spec"]["template"]["spec"]["containers"]
 env = {}
+counts = {}
 for c in containers:
     for e in c.get("env", []):
-        env[e["name"]] = e.get("value")
+        name = e["name"]
+        counts[name] = counts.get(name, 0) + 1
+        # Preserve this harness's historical last-value semantics for every
+        # pre-existing env assertion. Only the newly introduced runner ceiling
+        # has an exactly-once contract below.
+        env[name] = e.get("value")
 for pair in want:
     name, _, expected = pair.partition("=")
     if name not in env:
         raise SystemExit(f"{name} is not in the worker env (got {sorted(env)})")
+    if name == "CURIE_RUNNER_TOTAL_TIMEOUT_S" and counts[name] != 1:
+        raise SystemExit(
+            f"{name} occurs {counts[name]} times in the worker env, expected exactly once"
+        )
     got = env[name]
     if expected == "":
         # "present with an empty value". `nil | quote` emits a bare `value:`,
@@ -251,6 +273,7 @@ assert_env a -- \
   CURIE_ROUTE_TTL_SECONDS=3600 \
   CURIE_SUSPENDED_ROUTE_TTL_SECONDS=86400 \
   CURIE_DELIVERY_BUDGET_S=600 \
+  CURIE_RUNNER_TOTAL_TIMEOUT_S=600 \
   CURIE_DELIVERY_LEASE_TTL_S=45 \
   CURIE_DELIVERY_LEASE_HEARTBEAT_S=10 \
   CURIE_DELIVERY_SHUTDOWN_RESERVE_S=60 \
@@ -370,4 +393,69 @@ for token in \
   $(head -3 <<<"$J_NEGATIVE_OUT")"
 done
 
-echo "worker-ttl-bounds-assertions: all ten assertions passed"
+# (k) Runner per-request ceiling. The default is asserted in (a), including
+# exactly-once env placement. Exercise an operational override, equality, a
+# legal fractional ceiling, and the inclusive schema maximum with compatible
+# delivery budgets. The 1800 case also needs the matching ADR-0131 termination
+# grace.
+assert_env k \
+  --set worker.runnerTotalTimeoutSeconds=1700 \
+  --set worker.deliveryBudgetSeconds=1800 \
+  --set worker.terminationGracePeriodSeconds=1860 \
+  -- \
+  CURIE_RUNNER_TOTAL_TIMEOUT_S=1700 \
+  CURIE_DELIVERY_BUDGET_S=1800
+assert_env k \
+  --set worker.runnerTotalTimeoutSeconds=600 \
+  --set worker.deliveryBudgetSeconds=600 \
+  -- \
+  CURIE_RUNNER_TOTAL_TIMEOUT_S=600 \
+  CURIE_DELIVERY_BUDGET_S=600
+assert_env k \
+  --set-json worker.runnerTotalTimeoutSeconds=0.5 \
+  --set worker.deliveryBudgetSeconds=60 \
+  -- \
+  CURIE_RUNNER_TOTAL_TIMEOUT_S=0.5 \
+  CURIE_DELIVERY_BUDGET_S=60
+assert_env k \
+  --set worker.runnerTotalTimeoutSeconds=1800 \
+  --set worker.deliveryBudgetSeconds=1800 \
+  --set worker.terminationGracePeriodSeconds=1860 \
+  -- \
+  CURIE_RUNNER_TOTAL_TIMEOUT_S=1800 \
+  CURIE_DELIVERY_BUDGET_S=1800
+
+# Disable both resource templates so these failures isolate JSON Schema rather
+# than either cross-field guard. Use --set-json for 1800.1 so the schema sees a
+# genuine number and the refusal proves the inclusive maximum.
+assert_refused k runnerTotalTimeoutSeconds \
+  --set worker.deploy=false \
+  --set api.deploy=false \
+  --set worker.runnerTotalTimeoutSeconds=0
+assert_refused k runnerTotalTimeoutSeconds \
+  --set worker.deploy=false \
+  --set api.deploy=false \
+  --set-json worker.runnerTotalTimeoutSeconds=1800.1
+
+# Individually valid scalar values, relationally invalid together. Capture the
+# result directly so Helm's required non-zero status is the asserted outcome.
+K_RELATIONSHIP_OUT=""
+if K_RELATIONSHIP_OUT="$(helm template curie "$CHART" \
+  --set worker.runnerTotalTimeoutSeconds=1700 \
+  --set worker.deliveryBudgetSeconds=600 2>&1)"; then
+  fail k "helm ACCEPTED worker.runnerTotalTimeoutSeconds=1700 above worker.deliveryBudgetSeconds=600; the render must refuse a runner ceiling that exceeds the overall delivery budget"
+fi
+for token in \
+  "worker.runnerTotalTimeoutSeconds" \
+  "(1700)" \
+  "worker.deliveryBudgetSeconds" \
+  "(600)" \
+  "<=" \
+  "lower" \
+  "raise"; do
+  grep -qF "$token" <<<"$K_RELATIONSHIP_OUT" \
+    || fail k "the runner/delivery refusal does not mention $token; an operator cannot identify and correct the invalid timeout relationship
+  $(head -3 <<<"$K_RELATIONSHIP_OUT")"
+done
+
+echo "worker-ttl-bounds-assertions: all eleven assertions passed"

--- a/charts/curie/templates/_helpers.tpl
+++ b/charts/curie/templates/_helpers.tpl
@@ -1203,6 +1203,21 @@ securityContext:
 {{- end -}}
 {{- end -}}
 
+{{/* ---- Runner ceiling / delivery-budget relationship (worker) ----
+     Each runner request is bounded by `worker.runnerTotalTimeoutSeconds`, but
+     the request still has to fit inside the delivery's overall
+     `worker.deliveryBudgetSeconds`. JSON Schema cannot express this
+     cross-field relationship, so refuse it before an invalid worker Pod is
+     created. The worker's boot validator remains the backstop for non-Helm
+     configuration. */}}
+{{- define "curie.worker.validateRunnerBudget" -}}
+{{- $runnerCeiling := float64 .Values.worker.runnerTotalTimeoutSeconds -}}
+{{- $deliveryBudget := float64 .Values.worker.deliveryBudgetSeconds -}}
+{{- if gt $runnerCeiling $deliveryBudget -}}
+{{- fail (printf "worker.runnerTotalTimeoutSeconds (%g) must be <= worker.deliveryBudgetSeconds (%g). Fix: lower worker.runnerTotalTimeoutSeconds to %g or less, or raise worker.deliveryBudgetSeconds to at least %g." $runnerCeiling $deliveryBudget $deliveryBudget $runnerCeiling) -}}
+{{- end -}}
+{{- end -}}
+
 {{/* ---- Upgrade drain gate arithmetic (issue #2010) ----
      The gate's two clocks are DERIVED, with the values as floors, and only a
      self-contradictory pair is refused outright. The split is deliberate.

--- a/charts/curie/templates/worker.yaml
+++ b/charts/curie/templates/worker.yaml
@@ -14,6 +14,10 @@
      before its supervisor exists, so a bad value that reaches a Pod is a
      CrashLoopBackOff after a green `helm upgrade`. */}}
 {{- include "curie.worker.validateDrainBudget" . }}
+{{/* A runner request ceiling above the overall delivery budget is internally
+     inconsistent. Refuse it before creating a worker Pod; the worker boot
+     validator remains the backstop outside Helm. */}}
+{{- include "curie.worker.validateRunnerBudget" . }}
 {{- if .Values.worker.serviceAccount.create }}
 {{/*
 The worker drives the Kubernetes API to claim and manage agent-sandbox custom
@@ -348,6 +352,9 @@ spec:
             # cleanup.
             - name: CURIE_DELIVERY_BUDGET_S
               value: {{ .Values.worker.deliveryBudgetSeconds | quote }}
+            # Per-request runner ceiling within the overall delivery budget.
+            - name: CURIE_RUNNER_TOTAL_TIMEOUT_S
+              value: {{ .Values.worker.runnerTotalTimeoutSeconds | quote }}
             # How long the renewable ownership lease lives before it is
             # considered expired and transferable to a new owner.
             - name: CURIE_DELIVERY_LEASE_TTL_S

--- a/charts/curie/values.schema.json
+++ b/charts/curie/values.schema.json
@@ -42,6 +42,12 @@
           "maximum": 1800,
           "description": "Overall wall-clock deadline for one delivery (ADR-0131). Below 60s a budget cannot cover claim + one runner request + settle; above 1800s (the ADR's stated maximum) silently requires a termination grace the schema will not accept."
         },
+        "runnerTotalTimeoutSeconds": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "maximum": 1800,
+          "description": "Positive per-request ceiling for runner work, at most 1800 seconds. Must be no greater than worker.deliveryBudgetSeconds; the worker template enforces this cross-field relationship at render time."
+        },
         "deliveryLeaseTtlSeconds": {
           "type": "integer",
           "exclusiveMinimum": 0,

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -1351,9 +1351,9 @@ worker:
   # Delivery budget and ownership lease (ADR-0131, #1971). One overall
   # wall-clock deadline and one renewable fenced owner per delivery, replacing
   # the old dead pair of a flat per-request HTTP timeout and a 900s idle-based
-  # steal window. Integers, not floats -- as with routeTtlSeconds, a YAML
-  # float renders through the template's `| quote` as scientific notation for
-  # larger values, which the worker then cannot parse.
+  # steal window. deliveryBudgetSeconds is an integer -- as with
+  # routeTtlSeconds, a YAML float renders through the template's `| quote` as
+  # scientific notation for larger values, which the worker then cannot parse.
   #
   # The OVERALL deadline for one delivery: claim, every runner request, every
   # retry backoff, reclaim, and terminal cleanup. Must be between 60 and 1800
@@ -1361,6 +1361,12 @@ worker:
   # install/template time and the worker's own validator enforces it again at
   # boot.
   deliveryBudgetSeconds: 600
+  # Positive per-request ceiling for runner work within the overall delivery
+  # budget. Must be at most 1800 seconds and no greater than
+  # deliveryBudgetSeconds; fractional seconds are supported. values.schema.json
+  # enforces the scalar bounds and the worker template enforces the relationship
+  # at render time.
+  runnerTotalTimeoutSeconds: 600
   # How long the renewable ownership lease lives before it is considered
   # expired and transferable. Must span at least 3 heartbeat periods
   # (deliveryLeaseHeartbeatSeconds) so a single missed heartbeat never drops a


### PR DESCRIPTION
## Summary

- Bind `CURIE_RUNNER_TOTAL_TIMEOUT_S` and legacy `RUNNER_TOTAL_TIMEOUT_S` through `AliasChoices`, with the canonical name taking precedence.
- Add `worker.runnerTotalTimeoutSeconds` to chart values, schema, and worker environment wiring, and refuse a runner ceiling above the delivery budget during rendering.
- Log the configured ceiling, remaining delivery time, and effective request bound once when a turn opens; preserve the effective bound in stream timeout errors and publication snapshots.
- Preserve the mainline resume-reconciler grace derivation and all existing delivery, reclaim, and lock tuning.

## Done-check

- [x] Failing tests preceded implementation: the initial test commits were created before the first behavior commit and verified before consolidation.
- [x] All production edits were performed by delegated native workers; reviewers were read-only.
- [x] Broadened return types: N/A; no return type changed.
- [x] Agent-router Code review completed; the final delta review returned CLEAN.
- [x] Agent-router Scope review completed CLEAN; every final hunk maps to the timeout contract or required parity coverage.
- [x] Sibling-path parity covered: worker-only env classification, upgrade-drain fixture coherence, publication snapshot propagation, and stream timeout reporting are included; mainline resume-grace behavior remains authoritative.
- [x] Guard demonstration executed: valid `1700 / 1800` renders and the chart rejects `1700 / 600` with both keys, values, inequality, and corrective actions.
- [x] Consolidation was skipped because the `/simplify` capability is unavailable in this runtime; no consolidation edits were applied.
- [x] Security review: N/A; no security-sensitive boundary was flagged.
- [x] Observable verification completed for config binding, rendered worker env, refusal behavior, visible timeout values, and quiet control RPCs.
- [x] Dedicated E2E tester completed the deployed chart runtime gate; runner startup, init completion, positive/negative runtime assertions, and cleanup passed.
- [x] Full affected validation passed: focused worker tests, Ruff, mypy, docs validation, Helm lint/default/dev renders, 11 worker timeout assertions, 5 resume-grace assertions, and related chart assertion scripts. The local ladder was not run because another checkout owned the fixed ports; that owner was preserved.
