### PR TITLE
Fix local OTel recovery metric attribution

### DIFF
--- a/cli/scripts/e2e-ladder.sh
+++ b/cli/scripts/e2e-ladder.sh
@@ -2441,15 +2441,21 @@ def load_baseline():
     assert baseline_raw, f"{mode} requires a before snapshot"
     return json.loads(pathlib.Path(baseline_raw).read_text())
 
-def metric_total(series, name, **wanted):
+def metric_total(series, name, *, service=None, instances=None, **wanted):
     return sum(
         item["value"] for item in series
         if item["name"] == name
+        and (service is None or item["service"] == service)
+        and (instances is None or item["instance"] in instances)
         and all(item["attributes"].get(key) == value for key, value in wanted.items())
     )
 
-def delta(before, current, name, **wanted):
-    return metric_total(current, name, **wanted) - metric_total(before, name, **wanted)
+def delta(before, current, name, *, service=None, instances=None, **wanted):
+    return metric_total(
+        current, name, service=service, instances=instances, **wanted
+    ) - metric_total(
+        before, name, service=service, instances=instances, **wanted
+    )
 
 if mode == "snapshot":
     print(json.dumps(snapshot(), sort_keys=True))
@@ -2524,6 +2530,17 @@ if mode == "healthy":
         assert not failure_events, (
             f"healthy trace {trace_id} carried failure outcomes {failure_events}"
         )
+    healthy_worker_instances = {
+        resource.get("service.instance.id")
+        for trace_id in new_healthy
+        for _, resource in by_trace[trace_id]
+        if resource.get("service.name") == "curie-worker"
+        and resource.get("service.instance.id")
+    }
+    assert healthy_worker_instances, (
+        "new healthy trace had no curie-worker resource service.instance.id; "
+        f"trace_ids={sorted(new_healthy)}"
+    )
 
     # The health probe immediately before the turn exercises API telemetry;
     # the one-shot producer and turn exercise dispatcher, worker, and runner.
@@ -2569,10 +2586,12 @@ if mode == "healthy":
     positive_deltas = {
         "curie.turn.accepted": delta(previous, current, "curie.turn.accepted"),
         "curie.turn.completed[done]": delta(
-            previous, current, "curie.turn.completed", outcome="done"
+            previous, current, "curie.turn.completed",
+            service="curie-worker", instances=healthy_worker_instances, outcome="done"
         ),
         "curie.turn.duration[done]": delta(
-            previous, current, "curie.turn.duration", outcome="done"
+            previous, current, "curie.turn.duration",
+            service="curie-worker", instances=healthy_worker_instances, outcome="done"
         ),
         "curie.queue.message.age": delta(previous, current, "curie.queue.message.age"),
         "curie.sandbox.lifecycle": delta(previous, current, "curie.sandbox.lifecycle"),
@@ -2584,7 +2603,9 @@ if mode == "healthy":
         f"successful turn did not move every required counter/measurement: {positive_deltas}"
     )
     classified_delta = delta(
-        previous, current, "curie.turn.completed", outcome="classified_failure"
+        previous, current, "curie.turn.completed",
+        service="curie-worker", instances=healthy_worker_instances,
+        outcome="classified_failure"
     )
     assert classified_delta == 0, (
         "healthy control changed the classified_failure counter by "
@@ -2647,15 +2668,31 @@ if mode == "failed":
     assert error_log_traces, (
         "the new failed trace had no ERROR LogRecord with the same traceId"
     )
+    failed_worker_instances = {
+        resource.get("service.instance.id")
+        for trace_id in failed_trace_ids
+        for _, resource in by_trace[trace_id]
+        if resource.get("service.name") == "curie-worker"
+        and resource.get("service.instance.id")
+    }
+    assert failed_worker_instances, (
+        "new failed trace had no curie-worker resource service.instance.id; "
+        f"trace_ids={sorted(failed_trace_ids)}"
+    )
     current = metric_series()
     previous = before["metrics"]
     classified_delta = delta(
-        previous, current, "curie.turn.completed", outcome="classified_failure"
+        previous, current, "curie.turn.completed",
+        service="curie-worker", instances=failed_worker_instances,
+        outcome="classified_failure"
     )
     assert classified_delta > 0, (
         "the injected failure did not increase curie.turn.completed{outcome=classified_failure}"
     )
-    done_delta = delta(previous, current, "curie.turn.completed", outcome="done")
+    done_delta = delta(
+        previous, current, "curie.turn.completed",
+        service="curie-worker", instances=failed_worker_instances, outcome="done"
+    )
     assert done_delta == 0, (
         f"the injected failure incorrectly increased successful completions by {done_delta}"
     )

--- a/cli/tests/nightly_graded_ladder.rs
+++ b/cli/tests/nightly_graded_ladder.rs
@@ -125,42 +125,83 @@ fn local_otel_failure_recovery_scopes_classified_metrics_to_the_traces_worker_in
 
     let attr = |key: &str, value: &str| json!({"key": key, "value": {"stringValue": value}});
     let resource = |service: &str, instance: &str| json!({"attributes": [attr("service.name", service), attr("service.instance.id", instance)]});
-    let span = |name: &str, service: &str, status: i64, trace: &str, id: &str| {
-        json!({"name": name, "traceId": trace, "spanId": id, "status": {"code": status}, "service": service, "instance": format!("{service}-{trace}")})
-    };
+    let span = |name: &str, service: &str, status: i64, trace: &str, id: &str| json!({"name": name, "traceId": trace, "spanId": id, "status": {"code": status}, "service": service, "instance": format!("{service}-{trace}")});
     let failure_trace = "failure-trace";
     let mut failed = vec![
-        span("curie.queue.enqueue", "curie-dispatcher", 1, failure_trace, "01"),
-        span("curie.queue.process", "curie-dispatcher", 1, failure_trace, "02"),
+        span(
+            "curie.queue.enqueue",
+            "curie-dispatcher",
+            1,
+            failure_trace,
+            "01",
+        ),
+        span(
+            "curie.queue.process",
+            "curie-dispatcher",
+            1,
+            failure_trace,
+            "02",
+        ),
         span("curie.turn.process", "curie-worker", 2, failure_trace, "03"),
-        span("curie.sandbox.claim", "curie-worker", 1, failure_trace, "04"),
+        span(
+            "curie.sandbox.claim",
+            "curie-worker",
+            1,
+            failure_trace,
+            "04",
+        ),
         span("curie.runner.rpc", "curie-worker", 1, failure_trace, "05"),
         span("agent.run", "curie-runner", 2, failure_trace, "06"),
     ];
     failed[2]["events"] = json!([{"attributes": [attr("curie.outcome", "classified_failure")]}]);
-    let trace_doc = |spans: Vec<serde_json::Value>| json!({"resourceSpans": spans.into_iter().map(|span| {
+    let trace_doc = |spans: Vec<serde_json::Value>| {
+        json!({"resourceSpans": spans.into_iter().map(|span| {
         let service = span["service"].as_str().expect("fixture service").to_owned();
         let instance = span["instance"].as_str().expect("fixture instance").to_owned();
         let mut span = span;
         span.as_object_mut().expect("fixture span").remove("service");
         span.as_object_mut().expect("fixture span").remove("instance");
         json!({"resource": resource(&service, &instance), "scopeSpans": [{"spans": [span]}]})
-    }).collect::<Vec<_>>()});
+    }).collect::<Vec<_>>()})
+    };
     write_otlp_fixture(root, "traces", &[trace_doc(failed)]);
-    write_otlp_fixture(root, "logs", &[json!({"resourceLogs": [{"resource": resource("curie-worker", "curie-worker-failure-trace"), "scopeLogs": [{"logRecords": [{"traceId": failure_trace, "spanId": "03", "severityNumber": 17}]}]}]})]);
-    let metric = |service: &str, instance: &str, name: &str, outcome: &str, value: i64, time: i64| json!({
-        "resourceMetrics": [{"resource": resource(service, instance), "scopeMetrics": [{"metrics": [{"name": name, "sum": {"dataPoints": [{"attributes": [attr("outcome", outcome)], "asInt": value, "timeUnixNano": time}]}}]}]}]
-    });
+    write_otlp_fixture(
+        root,
+        "logs",
+        &[
+            json!({"resourceLogs": [{"resource": resource("curie-worker", "curie-worker-failure-trace"), "scopeLogs": [{"logRecords": [{"traceId": failure_trace, "spanId": "03", "severityNumber": 17}]}]}]}),
+        ],
+    );
+    let metric = |service: &str,
+                  instance: &str,
+                  name: &str,
+                  outcome: &str,
+                  value: i64,
+                  time: i64| {
+        json!({
+            "resourceMetrics": [{"resource": resource(service, instance), "scopeMetrics": [{"metrics": [{"name": name, "sum": {"dataPoints": [{"attributes": [attr("outcome", outcome)], "asInt": value, "timeUnixNano": time}]}}]}]}]
+        })
+    };
 
     // The runner has already emitted the failed trace, but its worker-owned
     // completed counter has not yet crossed the BatchSpanProcessor boundary.
-    write_otlp_fixture(root, "metrics", &[metric("curie-runner", "curie-runner-failure-trace", "curie.turn.completed", "classified_failure", 1, 1)]);
+    write_otlp_fixture(
+        root,
+        "metrics",
+        &[metric(
+            "curie-runner",
+            "curie-runner-failure-trace",
+            "curie.turn.completed",
+            "classified_failure",
+            1,
+            1,
+        )],
+    );
     let runner_only = run_local_otel_query(&script, "failed", root, &empty);
     let racy_baseline = root.join("racy-baseline.json");
-    let runner_snapshot: serde_json::Value = serde_json::from_slice(
-        &run_local_otel_query(&script, "snapshot", root, &empty).stdout,
-    )
-    .expect("parse runner-only snapshot");
+    let runner_snapshot: serde_json::Value =
+        serde_json::from_slice(&run_local_otel_query(&script, "snapshot", root, &empty).stdout)
+            .expect("parse runner-only snapshot");
     fs::write(
         &racy_baseline,
         serde_json::to_vec(&runner_snapshot).expect("serialize recovery baseline"),
@@ -176,30 +217,87 @@ fn local_otel_failure_recovery_scopes_classified_metrics_to_the_traces_worker_in
     .expect("write failed metric baseline");
 
     // This is the late worker export that used to land after restored_before.
-    let mut metrics = vec![metric("curie-runner", "curie-runner-failure-trace", "curie.turn.completed", "classified_failure", 1, 1)];
-    metrics.push(metric("curie-worker", "curie-worker-failure-trace", "curie.turn.completed", "classified_failure", 1, 2));
+    let mut metrics = vec![metric(
+        "curie-runner",
+        "curie-runner-failure-trace",
+        "curie.turn.completed",
+        "classified_failure",
+        1,
+        1,
+    )];
+    metrics.push(metric(
+        "curie-worker",
+        "curie-worker-failure-trace",
+        "curie.turn.completed",
+        "classified_failure",
+        1,
+        2,
+    ));
     write_otlp_fixture(root, "metrics", &metrics);
-    let delayed_failed_worker = run_local_otel_query(
-        &script,
-        "failed",
-        root,
-        &failed_metric_baseline,
-    );
+    let delayed_failed_worker =
+        run_local_otel_query(&script, "failed", root, &failed_metric_baseline);
 
     let healthy_trace = "healthy-trace";
     let mut healthy = vec![
         span("curie.health", "curie-api", 1, healthy_trace, "10"),
-        span("curie.queue.enqueue", "curie-dispatcher", 1, healthy_trace, "11"),
-        span("curie.queue.process", "curie-dispatcher", 1, healthy_trace, "12"),
+        span(
+            "curie.queue.enqueue",
+            "curie-dispatcher",
+            1,
+            healthy_trace,
+            "11",
+        ),
+        span(
+            "curie.queue.process",
+            "curie-dispatcher",
+            1,
+            healthy_trace,
+            "12",
+        ),
         span("curie.turn.process", "curie-worker", 1, healthy_trace, "13"),
-        span("curie.sandbox.claim", "curie-worker", 1, healthy_trace, "14"),
+        span(
+            "curie.sandbox.claim",
+            "curie-worker",
+            1,
+            healthy_trace,
+            "14",
+        ),
         span("curie.runner.rpc", "curie-worker", 1, healthy_trace, "15"),
-        span("curie.reply.post", "curie-dispatcher", 1, healthy_trace, "16"),
+        span(
+            "curie.reply.post",
+            "curie-dispatcher",
+            1,
+            healthy_trace,
+            "16",
+        ),
         json!({"name": "agent.run", "traceId": healthy_trace, "spanId": "17", "status": {"code": 1}, "attributes": [attr("curie.phase", "provider_wait"), attr("curie.terminal.cause", "completed"), attr("curie.terminal.status", "succeeded")], "service": "curie-runner", "instance": "curie-runner-healthy-trace"}),
         json!({"name": "llm.generation", "traceId": healthy_trace, "spanId": "18", "parentSpanId": "17", "status": {"code": 1}, "attributes": [attr("curie.phase", "provider_wait"), attr("curie.phase.start_kind", "query_observed"), attr("curie.phase.end_kind", "result_observed"), json!({"key": "curie.generation.round", "value": {"intValue": "1"}})], "service": "curie-runner", "instance": "curie-runner-healthy-trace"}),
     ];
     let mut traces = vec![trace_doc(vec![
-        span("curie.queue.enqueue", "curie-dispatcher", 1, failure_trace, "01"), span("curie.queue.process", "curie-dispatcher", 1, failure_trace, "02"), span("curie.turn.process", "curie-worker", 2, failure_trace, "03"), span("curie.sandbox.claim", "curie-worker", 1, failure_trace, "04"), span("curie.runner.rpc", "curie-worker", 1, failure_trace, "05"), json!({"name": "agent.run", "traceId": failure_trace, "spanId": "06", "status": {"code": 2}, "events": [{"attributes": [attr("curie.outcome", "classified_failure")]}], "service": "curie-runner", "instance": "curie-runner-failure-trace"})
+        span(
+            "curie.queue.enqueue",
+            "curie-dispatcher",
+            1,
+            failure_trace,
+            "01",
+        ),
+        span(
+            "curie.queue.process",
+            "curie-dispatcher",
+            1,
+            failure_trace,
+            "02",
+        ),
+        span("curie.turn.process", "curie-worker", 2, failure_trace, "03"),
+        span(
+            "curie.sandbox.claim",
+            "curie-worker",
+            1,
+            failure_trace,
+            "04",
+        ),
+        span("curie.runner.rpc", "curie-worker", 1, failure_trace, "05"),
+        json!({"name": "agent.run", "traceId": failure_trace, "spanId": "06", "status": {"code": 2}, "events": [{"attributes": [attr("curie.outcome", "classified_failure")]}], "service": "curie-runner", "instance": "curie-runner-failure-trace"}),
     ])];
     traces.push(trace_doc(std::mem::take(&mut healthy)));
     write_otlp_fixture(root, "traces", &traces);
@@ -215,18 +313,54 @@ fn local_otel_failure_recovery_scopes_classified_metrics_to_the_traces_worker_in
     })
     .collect();
     write_otlp_fixture(root, "logs", &[json!({"resourceLogs": resource_logs})]);
-    for (name, outcome) in [("curie.turn.accepted", ""), ("curie.turn.completed", "done"), ("curie.turn.duration", "done"), ("curie.queue.message.age", ""), ("curie.sandbox.lifecycle", ""), ("curie.runner.rpc.result", "success")] {
-        metrics.push(metric("curie-worker", "curie-worker-healthy-trace", name, outcome, 1, 3));
+    for (name, outcome) in [
+        ("curie.turn.accepted", ""),
+        ("curie.turn.completed", "done"),
+        ("curie.turn.duration", "done"),
+        ("curie.queue.message.age", ""),
+        ("curie.sandbox.lifecycle", ""),
+        ("curie.runner.rpc.result", "success"),
+    ] {
+        metrics.push(metric(
+            "curie-worker",
+            "curie-worker-healthy-trace",
+            name,
+            outcome,
+            1,
+            3,
+        ));
     }
     write_otlp_fixture(root, "metrics", &metrics);
     let racy_healthy = run_local_otel_query(&script, "healthy", root, &racy_baseline);
-    assert!(!runner_only.status.success(), "runner-only classified_failure must not prove the worker failure");
-    assert!(delayed_failed_worker.status.success(), "the causally matched failed worker metric must retain the failure proof: {}", String::from_utf8_lossy(&delayed_failed_worker.stderr));
-    assert!(racy_healthy.status.success(), "a delayed failure from the old worker instance must not poison healthy recovery: {}", String::from_utf8_lossy(&racy_healthy.stderr));
-    metrics.push(metric("curie-worker", "curie-worker-healthy-trace", "curie.turn.completed", "classified_failure", 1, 4));
+    assert!(
+        !runner_only.status.success(),
+        "runner-only classified_failure must not prove the worker failure"
+    );
+    assert!(
+        delayed_failed_worker.status.success(),
+        "the causally matched failed worker metric must retain the failure proof: {}",
+        String::from_utf8_lossy(&delayed_failed_worker.stderr)
+    );
+    assert!(
+        racy_healthy.status.success(),
+        "a delayed failure from the old worker instance must not poison healthy recovery: {}",
+        String::from_utf8_lossy(&racy_healthy.stderr)
+    );
+    metrics.push(metric(
+        "curie-worker",
+        "curie-worker-healthy-trace",
+        "curie.turn.completed",
+        "classified_failure",
+        1,
+        4,
+    ));
     write_otlp_fixture(root, "metrics", &metrics);
-    let same_healthy_worker_failure = run_local_otel_query(&script, "healthy", root, &racy_baseline);
-    assert!(!same_healthy_worker_failure.status.success(), "classified_failure on the healthy worker instance must remain a negative control");
+    let same_healthy_worker_failure =
+        run_local_otel_query(&script, "healthy", root, &racy_baseline);
+    assert!(
+        !same_healthy_worker_failure.status.success(),
+        "classified_failure on the healthy worker instance must remain a negative control"
+    );
 }
 
 fn chart_runtime_e2e() -> String {

--- a/cli/tests/nightly_graded_ladder.rs
+++ b/cli/tests/nightly_graded_ladder.rs
@@ -32,7 +32,7 @@ use std::io::{Read, Write};
 use std::net::TcpListener;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Output};
+use std::process::{Command, Output, Stdio};
 use std::thread;
 
 /// Read a workflow file's raw text, or an empty string when it does not exist
@@ -57,6 +57,176 @@ fn ci() -> String {
 fn ladder() -> String {
     let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("scripts/e2e-ladder.sh");
     fs::read_to_string(path).unwrap_or_default()
+}
+
+/// The local OTel assertions deliberately live in the shell harness, where
+/// they consume the Collector's raw JSON files.  Keep this test on that real
+/// consumer instead of re-implementing its attribution rules in Rust.
+fn local_otel_query_python() -> String {
+    let source = ladder();
+    let (_, after_command) = source
+        .split_once("python3 - \"$mode\" \"$WORKDIR/otel-sink\"")
+        .expect("local OTel query command must remain in the ladder");
+    let (_, script) = after_command
+        .split_once("<<'PY'\n")
+        .expect("local OTel query must retain its Python heredoc");
+    script
+        .split_once("\nPY\n}")
+        .expect("local OTel query heredoc must have a closing delimiter")
+        .0
+        .to_owned()
+}
+
+fn run_local_otel_query(script: &str, mode: &str, root: &Path, baseline: &Path) -> Output {
+    let mut command = Command::new("python3");
+    command
+        .arg("-")
+        .arg(mode)
+        .arg(root)
+        .arg(baseline)
+        .arg("fixture prompt")
+        .arg("fixture sentinel")
+        .arg(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(".."))
+        // The fixture has one canonical generation, not the live two-round
+        // tool path; the live switch keeps that unrelated shape requirement out
+        // of this metric-attribution regression.
+        .arg("1")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = command.spawn().expect("start extracted local OTel query");
+    child
+        .stdin
+        .take()
+        .expect("open query stdin")
+        .write_all(script.as_bytes())
+        .expect("write extracted local OTel query");
+    child.wait_with_output().expect("wait for local OTel query")
+}
+
+fn write_otlp_fixture(root: &Path, name: &str, documents: &[serde_json::Value]) {
+    let mut rendered = String::new();
+    for document in documents {
+        rendered.push_str(&serde_json::to_string(document).expect("serialize OTLP fixture"));
+        rendered.push('\n');
+    }
+    fs::write(root.join(format!("{name}.json")), rendered).expect("write OTLP fixture");
+}
+
+#[test]
+fn local_otel_failure_recovery_scopes_classified_metrics_to_the_traces_worker_instance() {
+    use serde_json::json;
+
+    let harness = tempfile::tempdir().expect("create local OTel fixture directory");
+    let root = harness.path();
+    let script = local_otel_query_python();
+    let empty = root.join("empty.json");
+    fs::write(&empty, r#"{"trace_ids":[],"metrics":[]}"#).expect("write empty baseline");
+
+    let attr = |key: &str, value: &str| json!({"key": key, "value": {"stringValue": value}});
+    let resource = |service: &str, instance: &str| json!({"attributes": [attr("service.name", service), attr("service.instance.id", instance)]});
+    let span = |name: &str, service: &str, status: i64, trace: &str, id: &str| {
+        json!({"name": name, "traceId": trace, "spanId": id, "status": {"code": status}, "service": service, "instance": format!("{service}-{trace}")})
+    };
+    let failure_trace = "failure-trace";
+    let mut failed = vec![
+        span("curie.queue.enqueue", "curie-dispatcher", 1, failure_trace, "01"),
+        span("curie.queue.process", "curie-dispatcher", 1, failure_trace, "02"),
+        span("curie.turn.process", "curie-worker", 2, failure_trace, "03"),
+        span("curie.sandbox.claim", "curie-worker", 1, failure_trace, "04"),
+        span("curie.runner.rpc", "curie-worker", 1, failure_trace, "05"),
+        span("agent.run", "curie-runner", 2, failure_trace, "06"),
+    ];
+    failed[2]["events"] = json!([{"attributes": [attr("curie.outcome", "classified_failure")]}]);
+    let trace_doc = |spans: Vec<serde_json::Value>| json!({"resourceSpans": spans.into_iter().map(|span| {
+        let service = span["service"].as_str().expect("fixture service").to_owned();
+        let instance = span["instance"].as_str().expect("fixture instance").to_owned();
+        let mut span = span;
+        span.as_object_mut().expect("fixture span").remove("service");
+        span.as_object_mut().expect("fixture span").remove("instance");
+        json!({"resource": resource(&service, &instance), "scopeSpans": [{"spans": [span]}]})
+    }).collect::<Vec<_>>()});
+    write_otlp_fixture(root, "traces", &[trace_doc(failed)]);
+    write_otlp_fixture(root, "logs", &[json!({"resourceLogs": [{"resource": resource("curie-worker", "curie-worker-failure-trace"), "scopeLogs": [{"logRecords": [{"traceId": failure_trace, "spanId": "03", "severityNumber": 17}]}]}]})]);
+    let metric = |service: &str, instance: &str, name: &str, outcome: &str, value: i64, time: i64| json!({
+        "resourceMetrics": [{"resource": resource(service, instance), "scopeMetrics": [{"metrics": [{"name": name, "sum": {"dataPoints": [{"attributes": [attr("outcome", outcome)], "asInt": value, "timeUnixNano": time}]}}]}]}]
+    });
+
+    // The runner has already emitted the failed trace, but its worker-owned
+    // completed counter has not yet crossed the BatchSpanProcessor boundary.
+    write_otlp_fixture(root, "metrics", &[metric("curie-runner", "curie-runner-failure-trace", "curie.turn.completed", "classified_failure", 1, 1)]);
+    let runner_only = run_local_otel_query(&script, "failed", root, &empty);
+    let racy_baseline = root.join("racy-baseline.json");
+    let runner_snapshot: serde_json::Value = serde_json::from_slice(
+        &run_local_otel_query(&script, "snapshot", root, &empty).stdout,
+    )
+    .expect("parse runner-only snapshot");
+    fs::write(
+        &racy_baseline,
+        serde_json::to_vec(&runner_snapshot).expect("serialize recovery baseline"),
+    )
+    .expect("write pre-export recovery baseline");
+    let failed_metric_baseline = root.join("failed-metric-baseline.json");
+    let mut failed_metric_snapshot = runner_snapshot;
+    failed_metric_snapshot["trace_ids"] = json!([]);
+    fs::write(
+        &failed_metric_baseline,
+        serde_json::to_vec(&failed_metric_snapshot).expect("serialize failed metric baseline"),
+    )
+    .expect("write failed metric baseline");
+
+    // This is the late worker export that used to land after restored_before.
+    let mut metrics = vec![metric("curie-runner", "curie-runner-failure-trace", "curie.turn.completed", "classified_failure", 1, 1)];
+    metrics.push(metric("curie-worker", "curie-worker-failure-trace", "curie.turn.completed", "classified_failure", 1, 2));
+    write_otlp_fixture(root, "metrics", &metrics);
+    let delayed_failed_worker = run_local_otel_query(
+        &script,
+        "failed",
+        root,
+        &failed_metric_baseline,
+    );
+
+    let healthy_trace = "healthy-trace";
+    let mut healthy = vec![
+        span("curie.health", "curie-api", 1, healthy_trace, "10"),
+        span("curie.queue.enqueue", "curie-dispatcher", 1, healthy_trace, "11"),
+        span("curie.queue.process", "curie-dispatcher", 1, healthy_trace, "12"),
+        span("curie.turn.process", "curie-worker", 1, healthy_trace, "13"),
+        span("curie.sandbox.claim", "curie-worker", 1, healthy_trace, "14"),
+        span("curie.runner.rpc", "curie-worker", 1, healthy_trace, "15"),
+        span("curie.reply.post", "curie-dispatcher", 1, healthy_trace, "16"),
+        json!({"name": "agent.run", "traceId": healthy_trace, "spanId": "17", "status": {"code": 1}, "attributes": [attr("curie.phase", "provider_wait"), attr("curie.terminal.cause", "completed"), attr("curie.terminal.status", "succeeded")], "service": "curie-runner", "instance": "curie-runner-healthy-trace"}),
+        json!({"name": "llm.generation", "traceId": healthy_trace, "spanId": "18", "parentSpanId": "17", "status": {"code": 1}, "attributes": [attr("curie.phase", "provider_wait"), attr("curie.phase.start_kind", "query_observed"), attr("curie.phase.end_kind", "result_observed"), json!({"key": "curie.generation.round", "value": {"intValue": "1"}})], "service": "curie-runner", "instance": "curie-runner-healthy-trace"}),
+    ];
+    let mut traces = vec![trace_doc(vec![
+        span("curie.queue.enqueue", "curie-dispatcher", 1, failure_trace, "01"), span("curie.queue.process", "curie-dispatcher", 1, failure_trace, "02"), span("curie.turn.process", "curie-worker", 2, failure_trace, "03"), span("curie.sandbox.claim", "curie-worker", 1, failure_trace, "04"), span("curie.runner.rpc", "curie-worker", 1, failure_trace, "05"), json!({"name": "agent.run", "traceId": failure_trace, "spanId": "06", "status": {"code": 2}, "events": [{"attributes": [attr("curie.outcome", "classified_failure")]}], "service": "curie-runner", "instance": "curie-runner-failure-trace"})
+    ])];
+    traces.push(trace_doc(std::mem::take(&mut healthy)));
+    write_otlp_fixture(root, "traces", &traces);
+    let resource_logs: Vec<serde_json::Value> = [
+        "curie-api",
+        "curie-dispatcher",
+        "curie-worker",
+        "curie-runner",
+    ]
+    .into_iter()
+    .map(|service| {
+        json!({"resource": resource(service, &format!("{service}-{healthy_trace}")), "scopeLogs": [{"logRecords": [{"traceId": healthy_trace, "spanId": "11", "severityNumber": 9}]}]})
+    })
+    .collect();
+    write_otlp_fixture(root, "logs", &[json!({"resourceLogs": resource_logs})]);
+    for (name, outcome) in [("curie.turn.accepted", ""), ("curie.turn.completed", "done"), ("curie.turn.duration", "done"), ("curie.queue.message.age", ""), ("curie.sandbox.lifecycle", ""), ("curie.runner.rpc.result", "success")] {
+        metrics.push(metric("curie-worker", "curie-worker-healthy-trace", name, outcome, 1, 3));
+    }
+    write_otlp_fixture(root, "metrics", &metrics);
+    let racy_healthy = run_local_otel_query(&script, "healthy", root, &racy_baseline);
+    assert!(!runner_only.status.success(), "runner-only classified_failure must not prove the worker failure");
+    assert!(delayed_failed_worker.status.success(), "the causally matched failed worker metric must retain the failure proof: {}", String::from_utf8_lossy(&delayed_failed_worker.stderr));
+    assert!(racy_healthy.status.success(), "a delayed failure from the old worker instance must not poison healthy recovery: {}", String::from_utf8_lossy(&racy_healthy.stderr));
+    metrics.push(metric("curie-worker", "curie-worker-healthy-trace", "curie.turn.completed", "classified_failure", 1, 4));
+    write_otlp_fixture(root, "metrics", &metrics);
+    let same_healthy_worker_failure = run_local_otel_query(&script, "healthy", root, &racy_baseline);
+    assert!(!same_healthy_worker_failure.status.success(), "classified_failure on the healthy worker instance must remain a negative control");
 }
 
 fn chart_runtime_e2e() -> String {


### PR DESCRIPTION
The local OTel ladder now attributes turn outcome metrics to the `curie-worker` `service.instance.id` in each causally matched trace. This prevents a recreated failure worker's delayed cumulative export from contaminating the restored worker baseline while retaining both failure and healthy controls.

Done-check

- [x] Failing tests committed before implementation: `76983b4c1` precedes `1eba0daf3` in the branch history; the focused test failed because runner-only `classified_failure` incorrectly proved the worker failure.
- [x] All production-code edits were performed by the delegated Codex implementation worker; the driver made no production edits.
- [x] Broadened return types: none reported; the script's external surface and CLI output remain unchanged.
- [x] Agent-router Code Reviewer approved the candidate with file-level spec, correctness, test-quality, prior-intent, and docs-drift evidence; no blocking findings.
- [x] Agent-router Scope Reviewer approved every non-trivial hunk as required by the acceptance criteria; no scope creep found.
- [x] Sibling-path parity: both injected-failure and restored-healthy metric paths use the causally matched worker instance; global trace/log/cardinality assertions remain intact.
- [x] Guard demonstration: the extracted real query rejects a runner-only classified metric and a same-healthy-worker classified failure, while accepting the causally matched failed worker and the restored healthy worker.
- [x] Consolidation skipped because `/simplify` is unavailable in this session; both adversarial reviewers approved the existing diff as the smallest scoped fix, and squashing was skipped to retain the exact hands-on candidate SHA and test-first history.
- [x] Security review: N/A; no auth, secrets, PII, API, persistence, or tenant boundary changed.
- [x] Observable user-facing verification: N/A; product behavior and CLI output are unchanged.
- [x] Deployed E2E: skill tier passed, then three consecutive fresh task-owned local tiers passed on candidate `9604f427e`, each proving injected failure trace/log/`classified_failure` evidence and restored healthy trace/log/done/duration evidence with zero healthy `classified_failure` delta.
- [x] Full affected validation passed: shell syntax, Rust formatting, focused Clippy, and all 31 `nightly_graded_ladder` tests.

The regression proof is falsifiable: reverting the attribution fix while retaining the test fails with `runner-only classified_failure must not prove the worker failure`.
