### PR TITLE
Fix dispatcher startup readiness

### DIFF
--- a/apps/dispatcher/README.md
+++ b/apps/dispatcher/README.md
@@ -127,7 +127,7 @@ Read from the environment by `DispatcherConfig()` (a `pydantic_settings.BaseSett
 | `CURIE_API_URL` | `http://localhost:8000` | platform API used to resolve approval clicks (compose: `http://curie-api:8000`). `CURIE_API_BASE_URL` is a deprecated alias. |
 | `CURIE_API_KEY` | `curie-dev-key` | platform administrative key; sent for compatibility with API plumbing, but it is not resolver identity and cannot authorize a resolution alone |
 | `CURIE_APPROVAL_CHAT_ATTESTER_SECRET` | `curie-dev-approval-chat-attester` | independent HMAC secret shared only with the API; signs short-lived, approval-bound `chat` principals. Must be nonblank and must not equal `CURIE_API_KEY`. |
-| `CURIE_API_PREFLIGHT_TIMEOUT_SECONDS` | `30.0` | API-health budget, followed by a fresh same-size discovery-and-Slack budget; must be positive |
+| `CURIE_API_PREFLIGHT_TIMEOUT_SECONDS` | `30.0` | API-health budget, followed by a fresh same-size discovery-and-Slack budget; the Helm chart supplies 120 seconds while a directly run dispatcher keeps this 30-second default; must be positive |
 
 ### Boot preflights
 
@@ -165,10 +165,23 @@ timeout derived from the remaining phase budget and capped at two seconds. The
 phase budget prevents starting additional calls after it expires; a final
 already-started call can extend it only by that bounded timeout.
 
-The gate runs once at boot only. It is not a liveness monitor: an API restart
-later does not kill the dispatcher (the heartbeat probes own liveness, and the
-resolve call degrades per-call on its own). There is no off switch: the gate is
-the point, so a non-positive timeout is rejected as a config error at boot.
+API-health exhaustion exits nonzero with guidance to check `CURIE_API_URL` and
+whether the API pod is Ready. The Helm chart supplies 120 seconds for each
+phase and gives its startup probe an earliest failure cutoff of 260 seconds,
+strictly beyond the two 120-second budgets plus the final bounded two-second
+Slack call. Rendering rejects settings where the startup cutoff does not
+strictly outlast that full application startup envelope.
+
+The gates run once at boot only. The heartbeat starts only after every preflight
+succeeds, so Kubernetes startup, readiness, and liveness checks remain gated
+while the dispatcher is polling. The startup probe prevents Kubernetes from
+restarting the pod during the application startup envelope. If a dependency
+never becomes ready, the application still reaches its own bounded terminal
+failure before the startup probe can restart it. The gate is not a liveness monitor:
+an API restart later does not kill the dispatcher (the heartbeat probes own
+liveness, and the resolve call degrades per call on its own). There is no off
+switch: the gate is the point, so a nonpositive timeout is rejected as a config
+error at boot.
 
 `/health` is deliberately unauthenticated and proves reachability only. The
 following `/agents` discovery is authenticated with `CURIE_API_KEY`. Discovery

--- a/apps/dispatcher/src/curie_dispatcher/preflight.py
+++ b/apps/dispatcher/src/curie_dispatcher/preflight.py
@@ -82,6 +82,10 @@ if not _SLACK_SDK_SILENT_LOGGER.handlers:
 _SLACK_SDK_SILENT_LOGGER.propagate = False
 _SLACK_SDK_SILENT_LOGGER.setLevel(logging.CRITICAL + 1)
 
+# Keep polling throughout longer readiness windows even when the shared
+# reconnect backoff allows much longer sleeps. The deadline still bounds the
+# whole preflight and each request remains capped separately above.
+_MAX_POLL_INTERVAL_S = 10.0
 
 class ApiUnreachableError(RuntimeError):
     """The platform API did not answer ``GET /health`` before the deadline."""
@@ -171,12 +175,12 @@ def check_api_reachable(
             except httpx.HTTPError as exc:
                 last_error = str(exc)
 
-            delay = backoff.delay(attempt)
+            delay = min(backoff.delay(attempt), _MAX_POLL_INTERVAL_S)
             attempt += 1
             # Clamp to the remaining budget rather than breaking when the next
-            # delay would overshoot it: with the shipped defaults (backoff_max
-            # 30.0 vs a 30.0s deadline) breaking abandons half the budget, and
-            # raising the deadline then buys the operator nothing.
+            # delay would overshoot it. Combined with the poll ceiling above,
+            # this keeps probes near the end of a long readiness window while
+            # preserving the configured terminal deadline.
             remaining = deadline - monotonic()
             if remaining <= 0:
                 break
@@ -188,7 +192,8 @@ def check_api_reachable(
     elapsed = monotonic() - start
     raise ApiUnreachableError(
         f"cannot reach the platform API at {logged_base} after {elapsed:.1f}s "
-        f"({attempt} attempts, last error: {last_error}); check CURIE_API_URL"
+        f"({attempt} attempts, last error: {last_error}); check CURIE_API_URL; "
+        "the API may still be starting, so check that the API pod is Ready"
     )
 
 

--- a/apps/dispatcher/tests/test_preflight.py
+++ b/apps/dispatcher/tests/test_preflight.py
@@ -12,16 +12,24 @@ races the API's own startup, and in k8s pod start order is not ordered at all, s
 fail-immediately would crash-loop a healthy stack. Test 3 is the guard on that
 decision.
 
-The API and Slack provider are faked only at their client seams. The retry
-loops, deadline decisions, parsing, and URL construction are real. Slow-path
-tests use the injected monotonic/sleep seam so aggregate budgets are exact and
-the suite does not wait on wall-clock time.
+Focused cases fake the API at the ``client=`` seam with
+``httpx.MockTransport``. The entrypoint regressions use a real loopback HTTP
+server and let the preflight construct its production client. Slack is faked
+only at its provider client seam. In both forms the retry loops, deadline
+decisions, parsing, and URL construction are real. Slow-path tests use the
+injected monotonic/sleep seam so aggregate budgets are exact and the suite does
+not wait on wall-clock time.
 """
 
 from __future__ import annotations
 
 import logging
+import re
+import threading
 import time
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any
 
@@ -54,6 +62,73 @@ SLACK_TIMEOUT_MESSAGE = (
     "configured destination within the bounded startup budget. Check Slack "
     "API availability and retry."
 )
+
+
+@contextmanager
+def _loopback_health_server(
+    statuses: Sequence[int],
+    *,
+    userinfo: str = "",
+) -> Iterator[tuple[str, list[str]]]:
+    """Run a real loopback HTTP endpoint with a scripted ``/health`` result.
+
+    The entrypoint regressions below deliberately do not inject an httpx client:
+    they drive ``run.main`` through ``DispatcherConfig`` and the preflight's
+    production-owned client. Only the remote API's answers are scripted here.
+    """
+    if not statuses:
+        raise ValueError("statuses must contain at least one response")
+
+    requests: list[str] = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802 - stdlib handler API
+            requests.append(self.path)
+            status = statuses[min(len(requests) - 1, len(statuses) - 1)]
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(b'{"status":"ok"}')
+
+        def log_message(self, _format: str, *args: object) -> None:
+            """Keep the test server out of the process's terminal log."""
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = server.server_address
+    authority = f"{userinfo}@" if userinfo else ""
+    try:
+        yield f"http://{authority}{host}:{port}", requests
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=1)
+
+
+def _configure_main_env(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    api_url: str,
+    timeout_s: float,
+) -> None:
+    """Configure the real ``DispatcherConfig()`` used by ``run.main``."""
+    for name, field in DispatcherConfig.model_fields.items():
+        alias = field.validation_alias
+        monkeypatch.delenv(
+            alias if isinstance(alias, str) else name.upper(), raising=False
+        )
+    monkeypatch.setenv("CURIE_API_URL", api_url)
+    monkeypatch.setenv("CURIE_API_PREFLIGHT_TIMEOUT_SECONDS", str(timeout_s))
+    monkeypatch.setenv("CURIE_BACKOFF_INITIAL_SECONDS", "0.01")
+    monkeypatch.setenv("CURIE_BACKOFF_MAX_SECONDS", "0.02")
+    monkeypatch.setenv("CURIE_BACKOFF_MULTIPLIER", "2")
+    monkeypatch.setenv("CURIE_API_KEY", "dispatcher-platform-test-key")
+    monkeypatch.setenv(
+        "CURIE_APPROVAL_CHAT_ATTESTER_SECRET", "dispatcher-attester-test-secret"
+    )
+    monkeypatch.setenv("SLACK_APP_TOKEN", "xapp-entrypoint-test")
+    monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-entrypoint-test")
 
 
 def _config(**overrides: object) -> DispatcherConfig:
@@ -312,37 +387,48 @@ def test_health_url_tolerates_a_trailing_slash() -> None:
 
 
 def test_the_loop_spends_its_whole_budget_with_production_backoff_ratios() -> None:
-    """The gate must poll until its deadline, and report what it really spent.
+    """The gate must keep polling until its deadline and report what it spent.
 
-    The other cases run `backoff_max << timeout`, where the growing delay never
-    approaches the deadline. The shipped defaults are the opposite ratio
-    (`backoff_max` 30.0 against a 30.0s deadline), so the delays 1, 2, 4, 8, 16
-    reach t=15s and the next 16s delay overshoots. An implementation that breaks
-    on the overshoot instead of clamping to the remaining budget abandons half
-    its deadline and then reports the configured 30.0s it never spent. This
-    config is those defaults scaled by 100.
+    This uses the production 120-second chart budget and reconnect ratios on an
+    injected clock. Without the preflight-specific poll ceiling, the loop can
+    spend the end of its budget asleep, so an API becoming healthy late in the
+    advertised readiness window is never probed.
     """
-
     config = _config(
-        api_preflight_timeout_s=0.3,
-        backoff_initial_seconds=0.01,
-        backoff_max_seconds=0.3,
+        api_preflight_timeout_s=120.0,
+        backoff_initial_seconds=1.0,
+        backoff_max_seconds=30.0,
         backoff_multiplier=2.0,
     )
-    start = time.monotonic()
+    clock = _FakeClock()
+    request_started_at: list[float] = []
+
+    def refusing(request: httpx.Request) -> httpx.Response:
+        request_started_at.append(clock.monotonic())
+        raise httpx.ConnectError("connection refused", request=request)
+
     with pytest.raises(ApiUnreachableError) as excinfo:
         check_api_reachable(
-            config, logger=logging.getLogger("test-preflight"), client=_client(_refusing)
+            config,
+            logger=logging.getLogger("test-preflight"),
+            client=_client(refusing),
+            monotonic=clock.monotonic,
+            sleep=clock.sleep,
         )
-    elapsed = time.monotonic() - start
 
-    assert elapsed >= 0.27, (
-        f"the preflight gave up after {elapsed:.3f}s of its 0.3s budget; the "
+    last_probe_elapsed = request_started_at[-1]
+    assert last_probe_elapsed >= config.api_preflight_timeout_s * 0.9, (
+        f"the last probe started only {last_probe_elapsed:.1f}s into the "
+        f"{config.api_preflight_timeout_s:.0f}s budget; the loop slept through "
+        "the final readiness window instead of polling it"
+    )
+    assert clock.monotonic() == config.api_preflight_timeout_s, (
+        f"the preflight gave up after {clock.monotonic():.1f}s of its 120s budget; the "
         f"delay must be clamped to the remaining time, not abandoned when it "
         f"would overshoot"
     )
-    # 0.15s is the pre-fix elapsed: the message must never claim time it did not spend.
-    assert "after 0.3s" in str(excinfo.value), (
+    # The terminal message must never claim time the loop did not really spend.
+    assert "after 120.0s" in str(excinfo.value), (
         f"the error must report the time actually elapsed, not the configured "
         f"deadline; got {str(excinfo.value)!r}"
     )
@@ -1484,3 +1570,159 @@ def test_run_main_missing_scope_exits_before_supervisor_without_leaking(
     assert excinfo.value.code not in (0, None)
     assert events == ["api", "slack"]
     assert [record.getMessage() for record in caplog.records] == [MISSING_SCOPE_MESSAGE]
+
+
+def test_run_main_waits_for_delayed_api_then_starts_supervisor_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A normally slow API does not restart the dispatcher before Slack starts.
+
+    This enters through the process entrypoint, reads a real
+    ``DispatcherConfig`` from the environment, and lets the production preflight
+    create its own HTTP client and execute its own retry loop. Slack, heartbeat,
+    signals, and telemetry are process boundaries, so record them without opening
+    external connections or changing this pytest process's signal handlers.
+    """
+    from curie_dispatcher import run
+
+    events: list[str] = []
+    health_requests: list[str] = []
+    heartbeat_stop = threading.Event()
+
+    class Telemetry:
+        def shutdown(self) -> None:
+            events.append("telemetry.shutdown")
+
+    class Supervisor:
+        def run(self) -> None:
+            events.append("supervisor.run")
+
+        def request_stop(self) -> None:
+            events.append("supervisor.request_stop")
+
+    def check_slack(*args: object, **kwargs: object) -> None:
+        assert health_requests == ["/health", "/health", "/health"], (
+            "Slack capability preflight started before delayed API readiness passed"
+        )
+        events.append("slack_preflight")
+
+    def build_supervisor(
+        config: DispatcherConfig, *, logger: logging.Logger
+    ) -> Supervisor:
+        assert type(config) is DispatcherConfig
+        assert logger.name == "curie_dispatcher"
+        assert health_requests == ["/health", "/health", "/health"], (
+            "Slack wiring started before delayed API readiness passed"
+        )
+        assert events[-1] == "slack_preflight"
+        events.append("build_supervisor")
+        return Supervisor()
+
+    def start_heartbeat(path: str, interval_s: float) -> threading.Event:
+        assert path == "/tmp/curie-dispatcher.heartbeat"
+        assert interval_s == 10.0
+        events.append("heartbeat.start")
+        return heartbeat_stop
+
+    monkeypatch.setattr(
+        run,
+        "bootstrap_service_telemetry",
+        lambda *args, **kwargs: Telemetry(),
+    )
+    monkeypatch.setattr(run, "check_slack_channel_capabilities", check_slack)
+    monkeypatch.setattr(run, "build_supervisor", build_supervisor)
+    monkeypatch.setattr(run, "start_heartbeat", start_heartbeat)
+    monkeypatch.setattr(
+        run.signal,
+        "signal",
+        lambda signum, handler: events.append(f"signal.{signum}"),
+    )
+
+    with _loopback_health_server([503, 503, 200]) as (api_url, requests):
+        health_requests = requests
+        _configure_main_env(monkeypatch, api_url=api_url, timeout_s=0.5)
+        run.main()
+
+    assert requests == ["/health", "/health", "/health"], (
+        "the real preflight must retry delayed readiness to success before "
+        f"starting Slack; observed {requests!r}"
+    )
+    assert events.count("slack_preflight") == 1
+    assert events.count("build_supervisor") == 1
+    assert events.count("supervisor.run") == 1
+    assert events.index("supervisor.run") > events.index("build_supervisor")
+    assert events.count("heartbeat.start") == 1
+    assert heartbeat_stop.is_set(), "normal supervisor return must stop the heartbeat"
+    assert events[-1] == "telemetry.shutdown", (
+        f"telemetry must shut down after a clean supervisor exit; events={events!r}"
+    )
+
+
+def test_run_main_times_out_before_slack_with_actionable_sanitized_log(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A persistently unhealthy API exits once, bounded and actionable.
+
+    This is the timeout-negative sibling of delayed success. Userinfo in the URL
+    makes sanitization falsifiable, while a real loopback 503 keeps ``last error``
+    deterministic and proves the process made multiple attempts before giving up.
+    """
+    from curie_dispatcher import run
+
+    events: list[str] = []
+
+    class Telemetry:
+        def shutdown(self) -> None:
+            events.append("telemetry.shutdown")
+
+    def reached_slack_preflight(*args: object, **kwargs: object) -> None:
+        raise AssertionError("Slack preflight ran after the terminal API timeout")
+
+    def reached_supervisor(*args: object, **kwargs: object) -> object:
+        events.append("build_supervisor")
+        raise AssertionError("Slack was built after the terminal preflight timeout")
+
+    def reached_heartbeat(*args: object, **kwargs: object) -> threading.Event:
+        raise AssertionError("heartbeat started before the API preflight passed")
+
+    monkeypatch.setattr(
+        run,
+        "bootstrap_service_telemetry",
+        lambda *args, **kwargs: Telemetry(),
+    )
+    monkeypatch.setattr(
+        run, "check_slack_channel_capabilities", reached_slack_preflight
+    )
+    monkeypatch.setattr(run, "build_supervisor", reached_supervisor)
+    monkeypatch.setattr(run, "start_heartbeat", reached_heartbeat)
+
+    with _loopback_health_server(
+        [503], userinfo="operator:credential"
+    ) as (api_url, requests):
+        _configure_main_env(monkeypatch, api_url=api_url, timeout_s=0.3)
+        safe_url = api_url.replace("operator:credential@", "")
+        started = time.monotonic()
+        with caplog.at_level(logging.ERROR, logger="curie_dispatcher"):
+            with pytest.raises(SystemExit) as excinfo:
+                run.main()
+        elapsed = time.monotonic() - started
+
+    assert excinfo.value.code not in (0, None)
+    assert 0.27 <= elapsed < 0.8, (
+        f"the 0.3s entrypoint deadline was not bounded; elapsed={elapsed:.3f}s"
+    )
+    assert len(requests) >= 2, (
+        f"the timeout path did not retry before failing; requests={requests!r}"
+    )
+    assert events == ["telemetry.shutdown"], (
+        "terminal preflight failure must happen before Slack/heartbeat and still "
+        f"shut down telemetry; events={events!r}"
+    )
+
+    terminal = "\n".join(record.getMessage() for record in caplog.records)
+    assert safe_url in terminal
+    assert "operator" not in terminal and "credential" not in terminal
+    assert re.search(r"after \d+\.\d+s", terminal), terminal
+    assert re.search(r"\(\d+ attempts, last error: HTTP 503\)", terminal), terminal
+    assert "check CURIE_API_URL" in terminal

--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -96,6 +96,23 @@ helm upgrade curie charts/curie -n curie --reuse-values \
 | Value | Default | Meaning |
 | --- | --- | --- |
 | `dispatcher.apiBaseUrl` | `""` | Empty derives the in-chart API Service. A set value is used verbatim (BYO), and is **required** when `api.deploy: false`, where no in-chart Service exists to derive from. |
+| `dispatcher.apiPreflightTimeoutSeconds` | `120` | Bounded time for API `/health`, followed by a fresh same-size discovery-and-Slack budget. The bare dispatcher default remains 30 seconds. |
+| `dispatcher.startupProbe.initialDelaySeconds` | `0` | Delay before Kubernetes begins the dispatcher heartbeat startup probe. |
+| `dispatcher.startupProbe.periodSeconds` | `10` | Interval between dispatcher startup probes. |
+| `dispatcher.startupProbe.timeoutSeconds` | `5` | Timeout for each dispatcher startup probe. |
+| `dispatcher.startupProbe.failureThreshold` | `27` | Consecutive failures allowed. With the other defaults, the earliest failure cutoff is 260 seconds. |
+
+The dispatcher starts its heartbeat only after every boot preflight succeeds.
+Until then, the startup probe gates readiness and liveness so Kubernetes does
+not restart the pod during normal API warmup or the following Slack checks.
+With the defaults, API health and discovery/Slack each have a 120-second
+budget, a final started Slack call can use at most two more seconds, and the
+startup probe cannot fail the pod before 260 seconds. Helm rendering rejects a
+cutoff that does not strictly outlast that full application startup envelope
+and names the values to adjust. This keeps delayed API readiness restart free
+while preserving a bounded failure: if the API never becomes ready, the
+dispatcher exits with guidance to check `CURIE_API_URL` and whether the API pod
+is Ready before the startup probe budget expires.
 
 Two limits worth knowing. With `api.deploy: false` and an empty
 `dispatcher.apiBaseUrl` the dispatcher is pointed at a Service that does not

--- a/charts/curie/ci/dispatcher-api-wiring-assertions.sh
+++ b/charts/curie/ci/dispatcher-api-wiring-assertions.sh
@@ -13,7 +13,13 @@
 #   4. CURIE_API_KEY arrives by secretKeyRef to the chart Secret's `apiKey`
 #      key, never as an inline literal (which would land the credential in
 #      `helm get manifest` and in any rendered artifact CI uploads).
-#   5. A token-less install still renders no dispatcher at all (unchanged gate).
+#   5. The app preflight timeout defaults to 120s, renders exactly once, and an
+#      operator override reaches CURIE_API_PREFLIGHT_TIMEOUT_SECONDS.
+#   6. A dispatcher-only startup probe uses the same heartbeat command and its
+#      earliest fast-failure cutoff is strictly later than the app deadline.
+#      The existing readiness/liveness probes remain unchanged, including on the
+#      worker, which must not receive a startup probe.
+#   7. A token-less install still renders no dispatcher at all (unchanged gate).
 #
 # NOTE ON `--output-dir`: the sibling scripts in this directory capture
 # `helm template` through command substitution. Do NOT copy that here, and do not
@@ -105,6 +111,113 @@ env_value() { python3 "$ENV_PY" "$1" "$2" || true; }
 env_field() { python3 "$ENV_PY" "$1" "$2" "$3" || true; }
 env_has() { python3 "$ENV_PY" "$1" "$2" "$3" >/dev/null; }
 
+# Structural workload reader for probe and env cardinality assertions. Every
+# lookup resolves the named Deployment container first, so a value copied into
+# an annotation/comment or a sibling container cannot create a false pass.
+WORKLOAD_PY="$TMP/workload.py"
+cat > "$WORKLOAD_PY" <<'PY'
+import json
+import sys
+import yaml
+
+manifest, container_name, operation = sys.argv[1:4]
+
+with open(manifest) as f:
+    docs = [d for d in yaml.safe_load_all(f) if d]
+
+deployments = [d for d in docs if d.get("kind") == "Deployment"]
+if len(deployments) != 1:
+    sys.stderr.write("expected exactly one Deployment, found %d\n" % len(deployments))
+    sys.exit(2)
+
+containers = (
+    (((deployments[0].get("spec") or {}).get("template") or {}).get("spec") or {})
+    .get("containers")
+    or []
+)
+containers = [c for c in containers if c.get("name") == container_name]
+if len(containers) != 1:
+    sys.stderr.write(
+        "container %r appears %d times in Deployment\n"
+        % (container_name, len(containers))
+    )
+    sys.exit(2)
+container = containers[0]
+
+if operation == "env-count":
+    name = sys.argv[4]
+    print(sum(1 for entry in container.get("env") or [] if entry.get("name") == name))
+    sys.exit(0)
+
+if operation == "env-value":
+    name = sys.argv[4]
+    entries = [entry for entry in container.get("env") or [] if entry.get("name") == name]
+    if len(entries) != 1 or "value" not in entries[0]:
+        sys.exit(1)
+    print(entries[0]["value"], end="")
+    sys.exit(0)
+
+probe_name = sys.argv[4]
+if probe_name not in container:
+    sys.exit(1)
+node = container[probe_name]
+
+if operation == "probe-has":
+    sys.exit(0)
+if operation == "probe-json":
+    print(json.dumps(node, sort_keys=True, separators=(",", ":")), end="")
+    sys.exit(0)
+if operation == "probe-field":
+    for part in sys.argv[5].split("."):
+        if not isinstance(node, dict) or part not in node:
+            sys.exit(1)
+        node = node[part]
+    if isinstance(node, (dict, list)):
+        print(json.dumps(node, sort_keys=True, separators=(",", ":")), end="")
+    else:
+        print(node, end="")
+    sys.exit(0)
+
+sys.stderr.write("unknown operation %r\n" % operation)
+sys.exit(2)
+PY
+
+env_count() { python3 "$WORKLOAD_PY" "$1" "$2" env-count "$3"; }
+workload_env_value() { python3 "$WORKLOAD_PY" "$1" "$2" env-value "$3"; }
+probe_has() { python3 "$WORKLOAD_PY" "$1" "$2" probe-has "$3" >/dev/null; }
+probe_json() { python3 "$WORKLOAD_PY" "$1" "$2" probe-json "$3"; }
+probe_field() { python3 "$WORKLOAD_PY" "$1" "$2" probe-field "$3" "$4"; }
+
+assert_probe_field() {
+  local manifest="$1" container="$2" probe="$3" field="$4" expected="$5" label="$6"
+  local actual
+  actual="$(probe_field "$manifest" "$container" "$probe" "$field")" \
+    || fail "$label: $probe.$field is absent"
+  [ "$actual" = "$expected" ] \
+    || fail "$label: $probe.$field is '$actual', expected '$expected'"
+}
+
+# Return success only when Kubernetes cannot declare startup failed before the
+# app exhausts the API-health budget, the fresh discovery/Slack budget, and a
+# final already-started two-second Slack call. Kept as one reusable predicate so
+# the under-budget negative control below proves the assertion is falsifiable.
+probe_budget_is_safe() {
+  local manifest="$1" container="$2"
+  local app_timeout initial_delay period failure_threshold
+  app_timeout="$(workload_env_value "$manifest" "$container" CURIE_API_PREFLIGHT_TIMEOUT_SECONDS)" || return 1
+  initial_delay="$(probe_field "$manifest" "$container" startupProbe initialDelaySeconds)" || return 1
+  period="$(probe_field "$manifest" "$container" startupProbe periodSeconds)" || return 1
+  failure_threshold="$(probe_field "$manifest" "$container" startupProbe failureThreshold)" || return 1
+  python3 - "$app_timeout" "$initial_delay" "$period" "$failure_threshold" <<'PY'
+import sys
+
+app_timeout, initial_delay, period, failure_threshold = map(float, sys.argv[1:])
+earliest_failure = initial_delay + (failure_threshold - 1) * period
+application_envelope = 2 * app_timeout + 2
+sys.exit(0 if earliest_failure > application_envelope else 1)
+PY
+}
+
 # 1: default install renders the in-chart API Service name and port as a value.
 # This render is reused by assertion 4 below (identical arguments), so it is
 # deliberately kept in its own variable rather than re-rendered.
@@ -144,7 +257,99 @@ if env_has "$default_manifest" CURIE_API_KEY value; then
   fail "CURIE_API_KEY renders an inline literal value; the credential must come from the Secret by reference only"
 fi
 
-# 5: unchanged gate -- no Slack tokens, no dispatcher.
+# 5: the API preflight budget is explicit, singular, and operator-configurable.
+actual="$(env_count "$default_manifest" dispatcher CURIE_API_PREFLIGHT_TIMEOUT_SECONDS)"
+[ "$actual" = "1" ] \
+  || fail "default install: CURIE_API_PREFLIGHT_TIMEOUT_SECONDS appears $actual times, expected exactly one chart-owned env entry"
+actual="$(workload_env_value "$default_manifest" dispatcher CURIE_API_PREFLIGHT_TIMEOUT_SECONDS)"
+[ "$actual" = "120" ] \
+  || fail "default install: CURIE_API_PREFLIGHT_TIMEOUT_SECONDS is '$actual', expected the 120s delayed-readiness budget"
+
+override_manifest="$(render_dispatcher timeout-override --set dispatcher.apiPreflightTimeoutSeconds=125 "${TOKENS[@]}")"
+actual="$(env_count "$override_manifest" dispatcher CURIE_API_PREFLIGHT_TIMEOUT_SECONDS)"
+[ "$actual" = "1" ] \
+  || fail "operator timeout override: CURIE_API_PREFLIGHT_TIMEOUT_SECONDS appears $actual times, expected exactly one env entry"
+actual="$(workload_env_value "$override_manifest" dispatcher CURIE_API_PREFLIGHT_TIMEOUT_SECONDS)"
+[ "$actual" = "125" ] \
+  || fail "dispatcher.apiPreflightTimeoutSeconds=125 rendered '$actual', so the operator override does not reach the app"
+
+# 6: startup defers the heartbeat probe's fast-failure authority until after the
+# app's two bounded phases. Kubernetes counts the first failed sample at t=0, so the
+# earliest terminal failure is initialDelay + (failureThreshold - 1) * period:
+# 0 + (27 - 1) * 10 = 260s, strictly beyond the maximum 242s app envelope.
+probe_has "$default_manifest" dispatcher startupProbe \
+  || fail "default install: dispatcher has no startupProbe, so readiness/liveness can restart it during normal API warm-up"
+assert_probe_field "$default_manifest" dispatcher startupProbe initialDelaySeconds 0 "dispatcher startup gate"
+assert_probe_field "$default_manifest" dispatcher startupProbe periodSeconds 10 "dispatcher startup gate"
+assert_probe_field "$default_manifest" dispatcher startupProbe timeoutSeconds 5 "dispatcher startup gate"
+assert_probe_field "$default_manifest" dispatcher startupProbe failureThreshold 27 "dispatcher startup gate"
+
+startup_cutoff=$((
+  $(probe_field "$default_manifest" dispatcher startupProbe initialDelaySeconds) +
+  ($(probe_field "$default_manifest" dispatcher startupProbe failureThreshold) - 1) *
+  $(probe_field "$default_manifest" dispatcher startupProbe periodSeconds)
+))
+[ "$startup_cutoff" = "260" ] \
+  || fail "dispatcher startupProbe earliest fast-failure cutoff is ${startup_cutoff}s, expected 260s"
+probe_budget_is_safe "$default_manifest" dispatcher \
+  || fail "dispatcher startupProbe can fail before the default app startup envelope is exhausted"
+probe_budget_is_safe "$override_manifest" dispatcher \
+  || fail "dispatcher startupProbe can fail before the operator's 125s phase override exhausts the full startup envelope"
+
+# Startup must use the exact heartbeat check already proven by readiness and
+# liveness; a new command or path would create an untested second liveness seam.
+startup_command="$(probe_field "$default_manifest" dispatcher startupProbe exec.command)"
+readiness_command="$(probe_field "$default_manifest" dispatcher readinessProbe exec.command)"
+liveness_command="$(probe_field "$default_manifest" dispatcher livenessProbe exec.command)"
+[ "$startup_command" = "$readiness_command" ] \
+  || fail "dispatcher startupProbe command differs from the existing readiness heartbeat command"
+[ "$startup_command" = "$liveness_command" ] \
+  || fail "dispatcher startupProbe command differs from the existing liveness heartbeat command"
+
+# Pin the existing heartbeat behavior on both workloads. Comparing the complete
+# parsed probe objects catches command, timing, and threshold drift, while the
+# explicit fields make failures actionable.
+assert_probe_field "$default_manifest" dispatcher readinessProbe initialDelaySeconds 10 "dispatcher readiness"
+assert_probe_field "$default_manifest" dispatcher readinessProbe periodSeconds 10 "dispatcher readiness"
+assert_probe_field "$default_manifest" dispatcher readinessProbe timeoutSeconds 5 "dispatcher readiness"
+assert_probe_field "$default_manifest" dispatcher readinessProbe failureThreshold 3 "dispatcher readiness"
+assert_probe_field "$default_manifest" dispatcher livenessProbe initialDelaySeconds 30 "dispatcher liveness"
+assert_probe_field "$default_manifest" dispatcher livenessProbe periodSeconds 15 "dispatcher liveness"
+assert_probe_field "$default_manifest" dispatcher livenessProbe timeoutSeconds 5 "dispatcher liveness"
+assert_probe_field "$default_manifest" dispatcher livenessProbe failureThreshold 4 "dispatcher liveness"
+
+worker_manifest="$TMP/default/curie/templates/worker.yaml"
+[ -f "$worker_manifest" ] || fail "default install: worker.yaml did not render"
+if probe_has "$worker_manifest" worker startupProbe; then
+  fail "worker gained a startupProbe; issue #2203 is dispatcher-only and worker probe behavior must remain unchanged"
+fi
+[ "$(probe_json "$worker_manifest" worker readinessProbe)" = "$(probe_json "$default_manifest" dispatcher readinessProbe)" ] \
+  || fail "worker readinessProbe drifted from the existing shared dispatcher heartbeat probe"
+[ "$(probe_json "$worker_manifest" worker livenessProbe)" = "$(probe_json "$default_manifest" dispatcher livenessProbe)" ] \
+  || fail "worker livenessProbe drifted from the existing shared dispatcher heartbeat probe"
+
+# Falsifiable negative control: equality is unsafe because Kubernetes may make
+# its terminal startup decision at the same instant the app is entitled to use
+# its final budget. The chart must refuse this operator combination and name the
+# setting plus the startup-probe constraint that rejected it.
+under_budget_out="$TMP/under-budget"
+mkdir -p "$under_budget_out"
+if helm template curie "$CHART" --output-dir "$under_budget_out" \
+  --set dispatcher.apiPreflightTimeoutSeconds=129 "${TOKENS[@]}" \
+  >"$TMP/under-budget.stdout" 2>"$TMP/under-budget.stderr"; then
+  fail "dispatcher.apiPreflightTimeoutSeconds=129 rendered a 260s app envelope against a 260s startup probe cutoff; the chart must reject an unsafe equal budget"
+fi
+under_budget_stderr="$(<"$TMP/under-budget.stderr")"
+[[ "$under_budget_stderr" == *"dispatcher.apiPreflightTimeoutSeconds"* ]] \
+  || fail "unsafe timeout render failure did not name dispatcher.apiPreflightTimeoutSeconds: $under_budget_stderr"
+if [[ "$under_budget_stderr" != *"startupProbe"* && "$under_budget_stderr" != *"startup probe"* ]]; then
+  fail "unsafe timeout render failure did not name the startup probe: $under_budget_stderr"
+fi
+if [[ "$under_budget_stderr" != *"cutoff"* && "$under_budget_stderr" != *"budget"* ]]; then
+  fail "unsafe timeout render failure did not explain the startup probe cutoff/budget: $under_budget_stderr"
+fi
+
+# 7: unchanged gate -- no Slack tokens, no dispatcher.
 out="$TMP/tokenless"
 mkdir -p "$out"
 helm template curie "$CHART" --output-dir "$out" >/dev/null
@@ -152,4 +357,4 @@ if [ -f "$out/curie/templates/dispatcher.yaml" ]; then
   fail "a token-less default install rendered a dispatcher Deployment; the curie.dispatcher.enabled gate regressed"
 fi
 
-echo "OK: dispatcher platform-API wiring render assertions passed"
+echo "OK: dispatcher platform-API wiring and delayed-readiness render assertions passed"

--- a/charts/curie/templates/dispatcher.yaml
+++ b/charts/curie/templates/dispatcher.yaml
@@ -1,4 +1,13 @@
 {{- if include "curie.dispatcher.enabled" . }}
+{{- $apiPreflightTimeout := float64 .Values.dispatcher.apiPreflightTimeoutSeconds -}}
+{{- $startupInitialDelay := float64 .Values.dispatcher.startupProbe.initialDelaySeconds -}}
+{{- $startupPeriod := float64 .Values.dispatcher.startupProbe.periodSeconds -}}
+{{- $startupFailureThreshold := float64 .Values.dispatcher.startupProbe.failureThreshold -}}
+{{- $startupFailureCutoff := addf $startupInitialDelay (mulf (subf $startupFailureThreshold 1.0) $startupPeriod) -}}
+{{- $startupApplicationBudget := addf (mulf $apiPreflightTimeout 2.0) 2.0 -}}
+{{- if le $startupFailureCutoff $startupApplicationBudget -}}
+{{- fail (printf "dispatcher.apiPreflightTimeoutSeconds (%g) gives a maximum application startup envelope of %g seconds (API health budget + fresh discovery/Slack budget + the final bounded 2-second Slack call), which must be less than the startupProbe earliest failure cutoff (%g seconds = %g + (%g - 1) * %g). Raise dispatcher.startupProbe.initialDelaySeconds, dispatcher.startupProbe.periodSeconds, or dispatcher.startupProbe.failureThreshold, or lower dispatcher.apiPreflightTimeoutSeconds." $apiPreflightTimeout $startupApplicationBudget $startupFailureCutoff $startupInitialDelay $startupFailureThreshold $startupPeriod) -}}
+{{- end -}}
 {{/*
 The dispatcher runs Slack in Socket Mode: it dials Slack outbound over a
 websocket, so there is no inbound port and therefore no Service and no HTTP
@@ -68,6 +77,8 @@ spec:
                 secretKeyRef:
                   {{- include "curie.secretRef" (dict "root" . "existingSecret" .Values.dispatcher.slack.signingSecretExistingSecret "existingSecretKey" .Values.dispatcher.slack.signingSecretExistingSecretKey "defaultKey" "slackSigningSecret") | nindent 18 }}
             {{- include "curie.env.api" . | nindent 12 }}
+            - name: CURIE_API_PREFLIGHT_TIMEOUT_SECONDS
+              value: {{ .Values.dispatcher.apiPreflightTimeoutSeconds | quote }}
             # Independent HMAC credential for Slack click identity/channel
             # attestation. The platform API key authenticates API calls but is
             # intentionally unable to forge this evidence.
@@ -90,6 +101,20 @@ spec:
           # touches each tick. The dispatcher blocks the main thread in
           # supervisor.run(), so a wedged/hung process stops touching the file ->
           # it goes stale -> the probe fails -> restart.
+          # startupProbe suppresses readiness/liveness until all bounded boot preflights complete.
+          startupProbe:
+            exec:
+              command:
+                - python
+                - -c
+                - |
+                  import os, sys, time
+                  p = os.environ["CURIE_HEARTBEAT_FILE"]
+                  sys.exit(0 if os.path.exists(p) and time.time() - os.path.getmtime(p) < 30 else 1)
+            initialDelaySeconds: {{ .Values.dispatcher.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.dispatcher.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.dispatcher.startupProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.dispatcher.startupProbe.failureThreshold }}
           {{- include "curie.heartbeatProbes" . | nindent 10 }}
           resources:
             {{- toYaml .Values.dispatcher.resources | nindent 12 }}

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -960,6 +960,20 @@ dispatcher:
   # catch the mismatch since /health is unauthenticated and proves reachability
   # only, not that the key is right.
   apiBaseUrl: ""
+  # Bounded startup window for API /health, followed by a fresh same-size
+  # discovery-and-Slack budget. Normal in-chart API warm-up must fit inside the
+  # first deadline; the startup probe below outlasts both phases plus the final
+  # bounded two-second Slack call.
+  apiPreflightTimeoutSeconds: 120
+  # Startup uses the same heartbeat freshness check as readiness/liveness. The
+  # kubelet can count its first failure at t=0, so 27 samples every 10 seconds
+  # make the earliest fast-failure 260s -- strictly after the maximum 242s
+  # application startup envelope above.
+  startupProbe:
+    initialDelaySeconds: 0
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 27
   image:
     repository: ghcr.io/curie-eng/curie-dispatcher
     # Empty -> chart appVersion (immutable). Set to pin an explicit version tag.


### PR DESCRIPTION
## Summary

Keep the dispatcher alive through normal API startup delay by giving API health a bounded 120-second chart-owned budget, polling at least every 10 seconds, and keeping the heartbeat startup-probe cutoff beyond the complete boot envelope. After #2208, discovery and Slack checks receive a fresh same-size budget and a final started Slack call can use two more seconds, so the chart now uses a 260-second cutoff and rejects unsafe combinations. If the API never becomes ready, the dispatcher still exits first with a bounded, sanitized, actionable failure. Consumer-path regressions cover delayed success and timeout without changing worker probes.

## Related issue

Closes #2203

## Fix pin verification

Fix pin: charts/curie/ci/dispatcher-api-wiring-assertions.sh

## End-to-end verification

The original issue-specific Docker and Kubernetes runtime observations ran against `fde99f692`. After `main` added the Slack capability preflight, the conflict resolution in `e8ab3bf4d` retained those API semantics, added the ordered Slack boundary to the consumer regression, and widened the chart startup envelope. The complete affected local validation was rerun on `e8ab3bf4d`.

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | No plugin packaging, runner loop, ACI event, skill eval, or skill check changes. | n/a | Not reachable. |
| local | required | Dispatcher startup and chart-owned boot environment changed. | fake | `CURIE_E2E_TIERS=local curie dev e2e-ladder` passed the full local ladder. A delayed-API Docker run returned 503 for 35 seconds, then started the dispatcher at 37 seconds with a heartbeat and `RestartCount=0`. The never-ready run exited 1 in 4.276 seconds with `RestartCount=0`, HTTP 503, sanitized URL, and `check CURIE_API_URL`. The rebased `run.main()` regression proves delayed API success proceeds through the Slack preflight boundary exactly once before supervisor/heartbeat startup. |
| local-release | n/a | No released binary/image identity, install path, version pin, or release Compose contract changed. | n/a | Not reachable. |
| cluster | required | Helm env/probe behavior and Kubernetes restart semantics changed. | fake | `CURIE_E2E_TIERS=cluster curie dev e2e-ladder` installed the platform with all platform pods at 0 restarts, then hit an unrelated SandboxClaim dependency timeout later in the local run. A separate task-owned Helm runtime fixture proved the changed path: delayed API readiness became Ready after 41 seconds with heartbeat and restart count 0, while the never-ready short-budget case stayed non-Ready, restarted once, and retained the previous exit-1 actionable terminal log. The rebased chart assertion executes the new 242-second application-envelope/260-second probe arithmetic and rejects equality. |
| live provider | n/a | No model routing, provider auth, credentials, token, or cost behavior changed. | n/a | Not reachable. |
| external integration | n/a | Slack and third-party API contracts are unchanged by this PR; the newly based Slack preflight uses its existing repository fake and placeholders. | n/a | Not reachable. |

- [x] Every required tier above names its command, commit context, mode, and literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required issue-specific path is left unproved; the Docker and Helm runtime fixtures passed. The supplemental local full cluster ladder blocker occurred after dispatcher startup in the sandbox claim/eval path and is reported above rather than hidden.

Scoped checks on `e8ab3bf4d`: 207 dispatcher tests passed; `uv run ruff check apps/dispatcher`, `uv run mypy apps/dispatcher/src`, `helm lint charts/curie`, `bash charts/curie/ci/render-assertions.sh`, and `bash scripts/check-docs.sh` passed. `curie dev verify-fix-pin e8ab3bf4d charts/curie/ci/dispatcher-api-wiring-assertions.sh` passed on the candidate and failed on the base as expected.

## Implementation done-check

- [x] Behavior tests were committed before production edits.
- [x] Production edits were delegated; no public return type was broadened.
- [x] Final code review found no blocking issue.
- [x] Final scope review passed after removing the only passenger workflow edit.
- [x] Dispatcher/worker probe sibling parity was checked; worker readiness/liveness remain unchanged and no worker startup probe was added.
- [x] The chart guard was executed against an invalid equal app/probe envelope and rejected it with an actionable render error.
- [x] Consolidation was skipped because `/simplify` is unavailable in this session; no consolidation edit required re-review.
- [x] Security scale-up was not applicable; no auth, data-boundary, payment, PII, or multi-tenant behavior changed.
- [x] Independent E2E verification reproduced delayed success and bounded timeout in Docker and Kubernetes, including restart counts.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [x] ADR not required: this preserves the existing bounded startup contract and aligns its configured timing.
