### PR TITLE
Preflight Slack channel capabilities safely

### DIFF
--- a/apps/dispatcher/README.md
+++ b/apps/dispatcher/README.md
@@ -127,29 +127,70 @@ Read from the environment by `DispatcherConfig()` (a `pydantic_settings.BaseSett
 | `CURIE_API_URL` | `http://localhost:8000` | platform API used to resolve approval clicks (compose: `http://curie-api:8000`). `CURIE_API_BASE_URL` is a deprecated alias. |
 | `CURIE_API_KEY` | `curie-dev-key` | platform administrative key; sent for compatibility with API plumbing, but it is not resolver identity and cannot authorize a resolution alone |
 | `CURIE_APPROVAL_CHAT_ATTESTER_SECRET` | `curie-dev-approval-chat-attester` | independent HMAC secret shared only with the API; signs short-lived, approval-bound `chat` principals. Must be nonblank and must not equal `CURIE_API_KEY`. |
-| `CURIE_API_PREFLIGHT_TIMEOUT_SECONDS` | `30.0` | deadline for the boot gate below; must be positive |
+| `CURIE_API_PREFLIGHT_TIMEOUT_SECONDS` | `30.0` | API-health budget, followed by a fresh same-size discovery-and-Slack budget; must be positive |
 
-### Boot gate on the platform API
+### Boot preflights
 
-Before any Slack wiring, `main()` polls `GET {CURIE_API_URL}/health` until
-it answers 200 or `CURIE_API_PREFLIGHT_TIMEOUT_SECONDS` elapses, reusing the
-`CURIE_BACKOFF_*` tunables for the poll interval. On success it logs the
-resolved URL once at INFO. On the deadline it logs an error naming that URL and
-the time actually spent, and
-exits non-zero, so a misconfigured base URL is dead on arrival instead of
-dead-ending every Slack Approve click much later (the previous behavior was a
-single warning at click time). It retries rather than probing once so a
-slow-starting API does not fail a healthy stack; in Kubernetes the restart
-backoff is the outer retry loop and `CrashLoopBackOff` is the operator signal.
+Before Socket Mode starts, `main()` runs these bounded preflights in order:
+
+1. Platform API reachability: poll `GET {CURIE_API_URL}/health`, reusing the
+   `CURIE_BACKOFF_*` tunables for the poll interval, within
+   `CURIE_API_PREFLIGHT_TIMEOUT_SECONDS`.
+2. Destination discovery: make an authenticated `GET {CURIE_API_URL}/agents`
+   using `CURIE_API_KEY` and collect configured Slack destinations.
+3. Slack metadata capability attempts: make one bounded
+   `conversations.list(types=public_channel, limit=1)` public-channel
+   capability call, then use `conversations.info` for every configured
+   destination before opening the Socket Mode connection.
+
+After health succeeds, discovery and Slack metadata checks share a fresh
+`CURIE_API_PREFLIGHT_TIMEOUT_SECONDS` budget. The reachability and discovery
+phases retry rather than probing once so a slow-starting API does not fail a
+healthy stack. If the health budget is exhausted, correct `CURIE_API_URL`. If
+discovery cannot finish, check platform API availability and configuration,
+then retry.
+
+If the Slack phase cannot attempt every configured destination before its
+budget, startup refuses safely; restore Slack availability or increase
+`CURIE_API_PREFLIGHT_TIMEOUT_SECONDS`, then retry. These failures identify only
+the failing phase and recovery action; they never print configured Slack
+destinations or credentials.
+
+The public-channel capability call always runs after discovery, including when
+there are zero configured destinations. Its Slack `missing_scope` or documented
+`invalid_types` permission outcome maps unambiguously to the recovery below
+without reading or logging its `needed` or `provided` sets. Production creates
+a dedicated no-retry Slack WebClient for each metadata attempt, with an integer
+timeout derived from the remaining phase budget and capped at two seconds. The
+phase budget prevents starting additional calls after it expires; a final
+already-started call can extend it only by that bounded timeout.
 
 The gate runs once at boot only. It is not a liveness monitor: an API restart
 later does not kill the dispatcher (the heartbeat probes own liveness, and the
 resolve call degrades per-call on its own). There is no off switch: the gate is
 the point, so a non-positive timeout is rejected as a config error at boot.
 
-**Known limit: the gate proves reachability, not credentials.** `/health` is
-unauthenticated, so a mismatched API key or chat-attester secret still passes the gate and
-fails at click time. This check catches the base-URL class of misconfiguration only.
+`/health` is deliberately unauthenticated and proves reachability only. The
+following `/agents` discovery is authenticated with `CURIE_API_KEY`. Discovery
+failures remain a fixed, redaction-safe platform API failure rather than
+printing credentials or response bodies. The independent approval chat-attester
+secret is not checked by these preflights.
+
+The only boot-fatal Slack metadata responses are `missing_scope` and
+`invalid_types` from that fixed public-channel capability request. Both use the
+same missing-public-permission recovery:
+`Slack channel capability preflight failed: bot token is missing required scope channels:read. Add channels:read under OAuth & Permissions > Bot Token Scopes, then reinstall the app to the workspace.`
+The preflight logs only a safe public capability state (`verified` or
+`unverified`) and aggregate checked or unverified destination counts. Other
+capability-call failures, plus private, stale, or transient per-destination
+`conversations.info` outcomes, remain aggregate unverified warnings and do not
+stop Socket Mode once every destination has been attempted; no tokens or
+destination identifiers are printed.
+
+An unverified warning can recur for a private channel, DM, stale destination,
+or transient provider outcome. It is deliberately non-terminal and does not
+assert private-channel or DM scope coverage; inspect the trusted configuration
+and correct the destination or access separately.
 
 The two Slack tokens and the independent approval chat-attester key are secrets. When a workspace exists the Slack tokens come from
 the app's install (App-Level Token with `connections:write` for `SLACK_APP_TOKEN`;
@@ -168,9 +209,12 @@ python -m curie_dispatcher
 
 1. Create a Slack app. Fastest path: at <https://api.slack.com/apps> choose
    "From a manifest" and paste [`slack-app-manifest.yaml`](slack-app-manifest.yaml),
-   which already sets Socket Mode on, the bot scopes (`app_mentions:read`,
-   `chat:write`, `im:history`, `im:read`), and the `app_mention` + `message.im`
-   event subscriptions. (To do it by hand, configure exactly those.)
+   which already sets Socket Mode on and the bot scopes (`app_mentions:read`,
+   `chat:write`, `channels:read`, `im:history`, `im:read`), plus the
+   `app_mention` and `message.im` event subscriptions. If the app was already
+   installed before `channels:read` was added, reinstall it to the workspace so
+   its bot-token grant is refreshed. (To configure the app manually, include
+   those same scopes.)
 2. Generate an App-Level Token with `connections:write` -> `SLACK_APP_TOKEN`
    (`xapp-...`); copy the Bot User OAuth Token -> `SLACK_BOT_TOKEN` (`xoxb-...`).
 3. Set both env vars (plus `VALKEY_*` for the target Valkey) and run

--- a/apps/dispatcher/slack-app-manifest.yaml
+++ b/apps/dispatcher/slack-app-manifest.yaml
@@ -20,6 +20,10 @@ oauth_config:
     bot:
       - app_mentions:read
       - chat:write
+      # The boot preflight proves public-channel metadata access with a bounded
+      # conversations.list call. Adding this scope requires reinstalling the app
+      # to the workspace so the existing bot-token grant is refreshed.
+      - channels:read
       - channels:history
       - groups:history
       - im:history

--- a/apps/dispatcher/src/curie_dispatcher/preflight.py
+++ b/apps/dispatcher/src/curie_dispatcher/preflight.py
@@ -1,4 +1,4 @@
-"""Boot-time gate on the platform API wiring (#442, AC2).
+"""Boot-time platform API and Slack channel capability gates (#442, #2205).
 
 The dispatcher resolves Slack approval clicks by calling the platform API. When
 ``CURIE_API_URL`` points somewhere unreachable, the only symptom today is
@@ -13,23 +13,35 @@ fail-immediately would crash-loop a healthy stack. Restart backoff is the outer
 retry loop there, and a CrashLoopBackOff with the named URL in the log is the
 operator signal.
 
-It is a wiring gate, not a liveness monitor: one shot at boot only. The heartbeat
-probes own liveness and ``ApprovalResolveClient`` owns per-call degradation, so an
-API restart hours later must not kill the dispatcher.
+These are wiring gates, not liveness monitors: one shot at boot only. The API
+health probe proves reachability; authenticated agent discovery loads the Slack
+destinations before Slack starts. The Slack phase probes destination visibility,
+but not message deliverability. Only the definitive ``missing_scope`` and
+``invalid_types`` responses from the public-channel ``conversations.list`` probe
+receive the exact ``channels:read`` recovery. Discovery failures and aggregate
+deadline exhaustion also refuse startup; ambiguous Slack provider outcomes remain
+``unverified`` so one destination cannot crash-loop every agent.
 
-``/health`` is unauthenticated by design, so this gate proves reachability only: a
-wrong ``CURIE_API_KEY`` still passes it and surfaces as a 401 at the first
-approval click.
+API health retains its full configured startup budget. Once health succeeds,
+authenticated discovery and all Slack checks share one fresh aggregate budget.
+If that second deadline leaves any configured destination unattempted, startup
+refuses rather than silently treating an absent scope check as success.
 """
 
 from __future__ import annotations
 
 import logging
+import math
 import time
+from collections.abc import Callable, Mapping
+from typing import Any, Protocol
 from urllib.parse import urlsplit, urlunsplit
 
 import httpx
+from slack_sdk.errors import SlackApiError
+from slack_sdk.web import WebClient
 
+from .app import _SLACK_API_TIMEOUT_SECONDS
 from .config import DispatcherConfig
 from .supervisor import BackoffPolicy
 
@@ -39,9 +51,58 @@ from .supervisor import BackoffPolicy
 # refusing fast like a closed port does.
 _MAX_PROBE_TIMEOUT_S = 5.0
 
+_MISSING_CHANNELS_READ_MESSAGE = (
+    "Slack channel capability preflight failed: bot token is missing required "
+    "scope channels:read. Add channels:read under OAuth & Permissions > Bot "
+    "Token Scopes, then reinstall the app to the workspace."
+)
+_AGENT_DISCOVERY_FAILURE_MESSAGE = (
+    "Slack channel capability preflight failed: could not load configured "
+    "channel destinations from the platform API."
+)
+_AGENT_DISCOVERY_CONNECTIVITY_MESSAGE = (
+    "Slack channel capability preflight failed: platform API agent discovery "
+    "could not connect after bounded retries."
+)
+_AGENT_DISCOVERY_RESPONSE_SHAPE_MESSAGE = (
+    "Slack channel capability preflight failed: platform API agent discovery "
+    "returned an invalid response shape."
+)
+_SLACK_CAPABILITY_DEADLINE_MESSAGE = (
+    "Slack channel capability preflight failed: could not attempt every configured "
+    "destination within the bounded startup budget. Check Slack API availability "
+    "and retry."
+)
+# slack_sdk logs request and response context at DEBUG/ERROR. Production
+# preflight calls cross a redaction boundary, so give their clients a dedicated
+# sink rather than allowing SDK records to inherit application/root handlers.
+_SLACK_SDK_SILENT_LOGGER = logging.getLogger(f"{__name__}.slack_sdk_silent")
+if not _SLACK_SDK_SILENT_LOGGER.handlers:
+    _SLACK_SDK_SILENT_LOGGER.addHandler(logging.NullHandler())
+_SLACK_SDK_SILENT_LOGGER.propagate = False
+_SLACK_SDK_SILENT_LOGGER.setLevel(logging.CRITICAL + 1)
+
 
 class ApiUnreachableError(RuntimeError):
     """The platform API did not answer ``GET /health`` before the deadline."""
+
+
+class SlackChannelPreflightError(RuntimeError):
+    """Configured Slack destinations could not be safely capability-checked."""
+
+
+class SlackChannelClient(Protocol):
+    """The narrow Slack Web API surface used by the channel preflight."""
+
+    def conversations_list(
+        self,
+        *,
+        types: str,
+        exclude_archived: bool,
+        limit: int,
+    ) -> Any: ...
+
+    def conversations_info(self, *, channel: str) -> Any: ...
 
 
 def _safe_for_log(url: str) -> str:
@@ -65,6 +126,8 @@ def check_api_reachable(
     *,
     logger: logging.Logger,
     client: httpx.Client | None = None,
+    monotonic: Callable[[], float] = time.monotonic,
+    sleep: Callable[[float], None] = time.sleep,
 ) -> None:
     """Poll ``GET {api_base_url}/health`` until it answers 200 or the deadline passes.
 
@@ -84,7 +147,7 @@ def check_api_reachable(
     )
     http = client or httpx.Client(timeout=min(_MAX_PROBE_TIMEOUT_S, timeout_s))
     owned = client is None
-    start = time.monotonic()
+    start = monotonic()
     deadline = start + timeout_s
     attempt = 0
     last_error = ""
@@ -94,7 +157,7 @@ def check_api_reachable(
             # start a request it has no time for and then block past the deadline
             # on that request's own timeout. Without this a 30s deadline takes
             # ~35s and a short one nearly doubles.
-            remaining = deadline - time.monotonic()
+            remaining = deadline - monotonic()
             if remaining <= 0:
                 break
             try:
@@ -114,16 +177,283 @@ def check_api_reachable(
             # delay would overshoot it: with the shipped defaults (backoff_max
             # 30.0 vs a 30.0s deadline) breaking abandons half the budget, and
             # raising the deadline then buys the operator nothing.
-            remaining = deadline - time.monotonic()
+            remaining = deadline - monotonic()
             if remaining <= 0:
                 break
-            time.sleep(min(delay, remaining))
+            sleep(min(delay, remaining))
     finally:
         if owned:
             http.close()
 
-    elapsed = time.monotonic() - start
+    elapsed = monotonic() - start
     raise ApiUnreachableError(
         f"cannot reach the platform API at {logged_base} after {elapsed:.1f}s "
         f"({attempt} attempts, last error: {last_error}); check CURIE_API_URL"
+    )
+
+
+def _collect_slack_addresses(payload: object) -> set[str]:
+    """Extract Slack destinations from the display-safe ``AgentOut`` projection."""
+    if not isinstance(payload, list):
+        raise ValueError("agent list is not an array")
+
+    addresses: set[str] = set()
+
+    def collect_target(target: object) -> None:
+        if not isinstance(target, Mapping):
+            raise ValueError("channel target is not an object")
+        kind = target.get("kind")
+        if not isinstance(kind, str):
+            raise ValueError("channel target kind is malformed")
+        if kind != "slack":
+            return
+        address = target.get("address")
+        if not isinstance(address, str) or not address:
+            raise ValueError("Slack channel target is malformed")
+        addresses.add(address)
+
+    for agent in payload:
+        if not isinstance(agent, Mapping):
+            raise ValueError("agent is not an object")
+
+        channels = agent.get("channels")
+        if not isinstance(channels, list):
+            raise ValueError("agent channels are not an array")
+        for target in channels:
+            collect_target(target)
+
+        approval_routes = agent.get("approval_routes")
+        if approval_routes is None:
+            continue
+        if not isinstance(approval_routes, Mapping):
+            raise ValueError("approval routes are not an object")
+        for route in approval_routes.values():
+            if not isinstance(route, Mapping) or "resolution" not in route:
+                raise ValueError("approval route is malformed")
+            collect_target(route["resolution"])
+            notification = route.get("notification")
+            if notification is not None:
+                collect_target(notification)
+
+    return addresses
+
+
+def _slack_response_field(response: object, field: str) -> object:
+    """Read a Slack response field without assuming a printable response shape."""
+    getter = getattr(response, "get", None)
+    if not callable(getter):
+        return None
+    try:
+        return getter(field)
+    except Exception:
+        return None
+
+
+def _slack_error_code(exc: SlackApiError) -> str | None:
+    """Read only Slack's documented string error code from an SDK exception."""
+    error = _slack_response_field(exc.response, "error")
+    return error if isinstance(error, str) else None
+
+
+def _is_conversations_list_success(response: object) -> bool:
+    """Accept only the documented successful public-channel listing shape."""
+    return _slack_response_field(response, "ok") is True and isinstance(
+        _slack_response_field(response, "channels"), list
+    )
+
+
+def _is_conversations_info_success(response: object) -> bool:
+    """Fail closed if a client returns a malformed success instead of raising."""
+    return _slack_response_field(response, "ok") is True and isinstance(
+        _slack_response_field(response, "channel"), Mapping
+    )
+
+
+def _slack_probe_client(
+    config: DispatcherConfig,
+    *,
+    injected: SlackChannelClient | None,
+    remaining: float,
+) -> SlackChannelClient:
+    """Return the injected seam or a no-retry client bounded by remaining time."""
+    if injected is not None:
+        return injected
+
+    # Ceil retains usable sub-second remainder while the one-second minimum
+    # satisfies slack_sdk's integer timeout contract. With retries disabled,
+    # aggregate overshoot is bounded to this one in-flight provider call.
+    probe_timeout = max(
+        1,
+        min(_SLACK_API_TIMEOUT_SECONDS, math.ceil(remaining)),
+    )
+    return WebClient(
+        token=config.slack_bot_token,
+        timeout=probe_timeout,
+        retry_handlers=[],
+        logger=_SLACK_SDK_SILENT_LOGGER,
+    )
+
+
+def check_slack_channel_capabilities(
+    config: DispatcherConfig,
+    *,
+    logger: logging.Logger,
+    web_client: SlackChannelClient | None = None,
+    api_client: httpx.Client | None = None,
+    monotonic: Callable[[], float] = time.monotonic,
+    sleep: Callable[[float], None] = time.sleep,
+) -> None:
+    """Probe visibility of each unique Slack destination within a fixed budget.
+
+    Agent discovery and Slack calls share one fresh configured deadline after the
+    API health gate. A 401 fails immediately with a generic redaction-safe
+    refusal, while deterministic response-shape failures fail promptly. A bounded
+    public-channel-only ``conversations.list`` call proves ``channels:read``
+    directly; its documented ``missing_scope`` and ``invalid_types`` errors are
+    provider-terminal because the request fixes ``types=public_channel``.
+    Ambiguous capability and destination outcomes are counted as unverified.
+    Production builds a no-retry client for each provider call, with its integer
+    timeout capped by both the remaining aggregate budget and the dispatcher's
+    two-second Slack policy. If time expires before the capability probe or every
+    destination is attempted, startup refuses with a fixed recovery message.
+    Output never exposes credentials, destinations, scopes, bodies, or deployment
+    identifiers.
+    """
+    timeout_s = config.api_preflight_timeout_s
+    http = api_client or httpx.Client(timeout=min(_MAX_PROBE_TIMEOUT_S, timeout_s))
+    owned = api_client is None
+    backoff = BackoffPolicy(
+        initial_seconds=config.backoff_initial_seconds,
+        max_seconds=config.backoff_max_seconds,
+        multiplier=config.backoff_multiplier,
+    )
+    headers = {"X-API-Key": config.api_key}
+    deadline = monotonic() + timeout_s
+    attempt = 0
+    addresses: set[str] | None = None
+    discovery_failure_message = _AGENT_DISCOVERY_FAILURE_MESSAGE
+    try:
+        while True:
+            remaining = deadline - monotonic()
+            if remaining <= 0:
+                break
+
+            try:
+                response = http.get(
+                    f"{config.api_base_url.rstrip('/')}/agents",
+                    headers=headers,
+                    timeout=min(_MAX_PROBE_TIMEOUT_S, remaining),
+                )
+                if response.status_code == 401:
+                    raise SlackChannelPreflightError(
+                        _AGENT_DISCOVERY_FAILURE_MESSAGE
+                    ) from None
+                if response.status_code == 200:
+                    try:
+                        addresses = _collect_slack_addresses(response.json())
+                    except Exception:
+                        raise SlackChannelPreflightError(
+                            _AGENT_DISCOVERY_RESPONSE_SHAPE_MESSAGE
+                        ) from None
+                    break
+                status_class = response.status_code // 100
+                discovery_failure_message = (
+                    "Slack channel capability preflight failed: platform API "
+                    f"agent discovery returned HTTP {status_class}xx after "
+                    "bounded retries."
+                )
+            except SlackChannelPreflightError:
+                raise
+            except Exception:
+                # Provider bodies, exception messages, and request metadata are
+                # deliberately discarded at this redaction boundary.
+                discovery_failure_message = _AGENT_DISCOVERY_CONNECTIVITY_MESSAGE
+
+            delay = backoff.delay(attempt)
+            attempt += 1
+            remaining = deadline - monotonic()
+            if remaining <= 0:
+                break
+            sleep(min(delay, remaining))
+    finally:
+        if owned:
+            http.close()
+
+    if addresses is None:
+        raise SlackChannelPreflightError(discovery_failure_message) from None
+
+    ordered_addresses = sorted(addresses)
+    checked = 0
+    unverified = 0
+    capability_status = "verified"
+
+    remaining = deadline - monotonic()
+    if remaining <= 0:
+        raise SlackChannelPreflightError(
+            _SLACK_CAPABILITY_DEADLINE_MESSAGE
+        ) from None
+
+    capability_client = _slack_probe_client(
+        config,
+        injected=web_client,
+        remaining=remaining,
+    )
+    try:
+        capability_response = capability_client.conversations_list(
+            types="public_channel",
+            exclude_archived=True,
+            limit=1,
+        )
+    except SlackApiError as exc:
+        error = _slack_error_code(exc)
+        if error in {"missing_scope", "invalid_types"}:
+            raise SlackChannelPreflightError(
+                _MISSING_CHANNELS_READ_MESSAGE
+            ) from None
+        capability_status = "unverified"
+    except Exception:
+        capability_status = "unverified"
+    else:
+        if not _is_conversations_list_success(capability_response):
+            capability_status = "unverified"
+
+    for address in ordered_addresses:
+        remaining = deadline - monotonic()
+        if remaining <= 0:
+            raise SlackChannelPreflightError(
+                _SLACK_CAPABILITY_DEADLINE_MESSAGE
+            ) from None
+
+        probe_client = _slack_probe_client(
+            config,
+            injected=web_client,
+            remaining=remaining,
+        )
+
+        try:
+            slack_response = probe_client.conversations_info(channel=address)
+        except SlackApiError:
+            unverified += 1
+            continue
+        except Exception:
+            unverified += 1
+            continue
+
+        if not _is_conversations_info_success(slack_response):
+            unverified += 1
+            continue
+
+        checked += 1
+
+    log = (
+        logger.warning
+        if capability_status == "unverified" or unverified
+        else logger.info
+    )
+    log(
+        "Slack channel capability preflight public-channel capability %s; checked "
+        "%d configured destinations; unverified %d",
+        capability_status,
+        checked,
+        unverified,
     )

--- a/apps/dispatcher/src/curie_dispatcher/run.py
+++ b/apps/dispatcher/src/curie_dispatcher/run.py
@@ -16,7 +16,12 @@ from . import __version__
 from .app import SocketModeConnection, build_app, build_redis, build_web_client
 from .config import DispatcherConfig
 from .heartbeat import start_heartbeat
-from .preflight import ApiUnreachableError, check_api_reachable
+from .preflight import (
+    ApiUnreachableError,
+    SlackChannelPreflightError,
+    check_api_reachable,
+    check_slack_channel_capabilities,
+)
 from .supervisor import BackoffPolicy, Supervisor
 
 
@@ -56,6 +61,15 @@ def main() -> None:
         try:
             check_api_reachable(config, logger=logger)
         except ApiUnreachableError as exc:
+            logger.error("%s", exc)
+            raise SystemExit(1) from exc
+
+        try:
+            check_slack_channel_capabilities(
+                config,
+                logger=logger,
+            )
+        except SlackChannelPreflightError as exc:
             logger.error("%s", exc)
             raise SystemExit(1) from exc
 

--- a/apps/dispatcher/tests/test_preflight.py
+++ b/apps/dispatcher/tests/test_preflight.py
@@ -1,4 +1,4 @@
-"""Boot-time platform-API wiring gate (#442, AC2).
+"""Boot-time platform-API and Slack capability gates (#442, #2205).
 
 The dispatcher resolves Slack approval clicks by calling the platform API. When
 it is wired to the wrong place the only symptom today is a warning at click time
@@ -12,27 +12,48 @@ races the API's own startup, and in k8s pod start order is not ordered at all, s
 fail-immediately would crash-loop a healthy stack. Test 3 is the guard on that
 decision.
 
-Only the API is faked, at the ``client=`` seam, with ``httpx.MockTransport`` --
-the same "fake the platform API, drive the real code" discipline as
-test_approval_actions.py's scripted resolver. The retry loop, the deadline, and
-the URL construction are all real. Tests stay fast by configuring tiny backoff
-values (real settings, not a patched clock), so the poll loop under test is the
-one that ships.
+The API and Slack provider are faked only at their client seams. The retry
+loops, deadline decisions, parsing, and URL construction are real. Slow-path
+tests use the injected monotonic/sleep seam so aggregate budgets are exact and
+the suite does not wait on wall-clock time.
 """
 
 from __future__ import annotations
 
 import logging
 import time
+from pathlib import Path
+from typing import Any
 
 import httpx
 import pytest
+import yaml
 from curie_dispatcher.config import DispatcherConfig
-from curie_dispatcher.preflight import ApiUnreachableError, check_api_reachable
+from curie_dispatcher.preflight import (
+    ApiUnreachableError,
+    SlackChannelPreflightError,
+    check_api_reachable,
+    check_slack_channel_capabilities,
+)
+from slack_sdk.errors import SlackApiError
+from slack_sdk.web.slack_response import SlackResponse
 
 from .conftest import _black_hole_api
 
 API_URL = "http://curie-api:8000"
+CHANNEL_A = "C0EXAMPLE1"
+CHANNEL_B = "C0EXAMPLE2"
+CHANNEL_C = "C0EXAMPLE3"
+MISSING_SCOPE_MESSAGE = (
+    "Slack channel capability preflight failed: bot token is missing required "
+    "scope channels:read. Add channels:read under OAuth & Permissions > Bot "
+    "Token Scopes, then reinstall the app to the workspace."
+)
+SLACK_TIMEOUT_MESSAGE = (
+    "Slack channel capability preflight failed: could not attempt every "
+    "configured destination within the bounded startup budget. Check Slack "
+    "API availability and retry."
+)
 
 
 def _config(**overrides: object) -> DispatcherConfig:
@@ -59,6 +80,117 @@ def _config(**overrides: object) -> DispatcherConfig:
 
 def _client(handler) -> httpx.Client:
     return httpx.Client(transport=httpx.MockTransport(handler))
+
+
+def _agent(
+    *,
+    channels: list[dict[str, str]],
+    approval_routes: dict[str, dict[str, Any]] | None,
+) -> dict[str, Any]:
+    """A complete, public-placeholder ``AgentOut`` response fixture."""
+    return {
+        "id": "00000000-0000-0000-0000-000000000001",
+        "name": "acme-bot",
+        "channels": channels,
+        "repo_full_name": None,
+        "behavior_packs": None,
+        "model": None,
+        "thinking": None,
+        "approval_required_tools": None,
+        "approval_routes": approval_routes,
+        "hook_partitions": None,
+        "secrets": None,
+        "memory": True,
+        "created_at": "2026-01-01T00:00:00Z",
+    }
+
+
+class _RecordingSlackClient:
+    """The only Slack fake: it records the real SDK method boundary."""
+
+    def __init__(
+        self,
+        *,
+        side_effect: Exception | None = None,
+        list_side_effect: Exception | None = None,
+        list_response: object | None = None,
+    ) -> None:
+        self.channels: list[str] = []
+        self.list_calls: list[dict[str, object]] = []
+        self.side_effect = side_effect
+        self.list_side_effect = list_side_effect
+        self.list_response = (
+            {
+                "ok": True,
+                "channels": [],
+                "response_metadata": {"next_cursor": ""},
+            }
+            if list_response is None
+            else list_response
+        )
+
+    def conversations_list(
+        self,
+        *,
+        types: str,
+        exclude_archived: bool,
+        limit: int,
+    ) -> object:
+        self.list_calls.append(
+            {
+                "types": types,
+                "exclude_archived": exclude_archived,
+                "limit": limit,
+            }
+        )
+        if self.list_side_effect is not None:
+            raise self.list_side_effect
+        return self.list_response
+
+    def conversations_info(self, *, channel: str) -> Any:
+        self.channels.append(channel)
+        if self.side_effect is not None:
+            raise self.side_effect
+        return {"ok": True, "channel": {"id": channel}}
+
+
+class _FakeClock:
+    """Deterministic monotonic clock for bounded boot-preflight tests."""
+
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.now += seconds
+
+
+class _AdvancingSlackClient(_RecordingSlackClient):
+    """Successful Slack fake whose calls consume a deterministic budget."""
+
+    def __init__(self, *, clock: _FakeClock, seconds_per_call: float) -> None:
+        super().__init__()
+        self._clock = clock
+        self._seconds_per_call = seconds_per_call
+
+    def conversations_info(self, *, channel: str) -> dict[str, Any]:
+        response = super().conversations_info(channel=channel)
+        self._clock.sleep(self._seconds_per_call)
+        return response
+
+
+class _StaticSlackClient(_RecordingSlackClient):
+    """Slack fake for malformed non-exception response shapes."""
+
+    def __init__(self, response: object) -> None:
+        super().__init__()
+        self._response = response
+
+    def conversations_info(self, *, channel: str) -> object:
+        self.channels.append(channel)
+        return self._response
 
 
 def _refusing(request: httpx.Request) -> httpx.Response:
@@ -297,6 +429,914 @@ def test_userinfo_is_stripped_from_the_error_too() -> None:
     assert "curie-api:8000" in str(excinfo.value)
 
 
+def test_slack_preflight_discovers_all_destinations_deduplicates_and_logs_count(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Every display-safe Slack destination is checked exactly once.
+
+    Slack documents ``channel`` as the required conversation ID argument and
+    ``{\"ok\": true, \"channel\": {...}}`` as the success response:
+    https://docs.slack.dev/reference/methods/conversations.info/
+    """
+    api_key = "fake-platform-key-sentinel"
+    config = _config(api_key=api_key)
+    agent = _agent(
+        channels=[
+            {"kind": "slack", "address": CHANNEL_A},
+            {"kind": "mail", "address": "mail-room-example"},
+        ],
+        approval_routes={
+            "security": {
+                "resolution": {"kind": "slack", "address": CHANNEL_B},
+                "notification": {"kind": "slack", "address": CHANNEL_C},
+            },
+            "operations": {
+                # Repeat the ordinary binding to prove the call is de-duplicated
+                # across AgentOut.channels and every approval route target.
+                "resolution": {"kind": "slack", "address": CHANNEL_A},
+                "notification": {
+                    "kind": "mail",
+                    "address": "mail-approval-example",
+                },
+            },
+        },
+    )
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, json=[agent])
+
+    slack = _RecordingSlackClient()
+    logger = logging.getLogger("test-slack-preflight-success")
+    with caplog.at_level(logging.INFO, logger=logger.name):
+        check_slack_channel_capabilities(
+            config,
+            logger=logger,
+            web_client=slack,
+            api_client=_client(handler),
+        )
+
+    assert len(requests) == 1
+    assert requests[0].method == "GET"
+    assert str(requests[0].url) == f"{API_URL}/agents"
+    assert requests[0].headers["X-API-Key"] == api_key
+    assert len(slack.channels) == 3
+    assert sorted(slack.channels) == sorted([CHANNEL_A, CHANNEL_B, CHANNEL_C])
+    assert slack.list_calls == [
+        {"types": "public_channel", "exclude_archived": True, "limit": 1}
+    ]
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert messages == [
+        "Slack channel capability preflight public-channel capability verified; "
+        "checked 3 configured destinations; unverified 0"
+    ]
+    logged = " ".join(messages)
+    for private_value in (api_key, CHANNEL_A, CHANNEL_B, CHANNEL_C):
+        assert private_value not in logged, (
+            f"success logs must contain only an aggregate count, not {private_value!r}"
+        )
+
+
+def test_slack_preflight_empty_destination_set_still_checks_public_capability(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An unbound Slack surface still proves the workspace-level public scope."""
+    agent = _agent(
+        channels=[{"kind": "mail", "address": "mail-room-example"}],
+        approval_routes=None,
+    )
+    slack = _RecordingSlackClient()
+    logger = logging.getLogger("test-slack-preflight-empty")
+    with caplog.at_level(logging.INFO, logger=logger.name):
+        check_slack_channel_capabilities(
+            _config(),
+            logger=logger,
+            web_client=slack,
+            api_client=_client(lambda _request: httpx.Response(200, json=[agent])),
+        )
+
+    assert slack.list_calls == [
+        {"types": "public_channel", "exclude_archived": True, "limit": 1}
+    ]
+    assert slack.channels == []
+    assert [record.getMessage() for record in caplog.records] == [
+        "Slack channel capability preflight public-channel capability verified; "
+        "checked 0 configured destinations; unverified 0"
+    ]
+
+
+def test_discovery_ignores_malformed_non_slack_target_before_reading_address() -> None:
+    """Only Slack targets make the Slack address field part of this gate."""
+    agent = _agent(
+        channels=[
+            {"kind": "mail"},
+            {"kind": "slack", "address": CHANNEL_A},
+        ],
+        approval_routes=None,
+    )
+    slack = _RecordingSlackClient()
+
+    check_slack_channel_capabilities(
+        _config(),
+        logger=logging.getLogger("test-non-slack-malformed-target"),
+        web_client=slack,
+        api_client=_client(lambda _request: httpx.Response(200, json=[agent])),
+    )
+
+    assert slack.list_calls == [
+        {"types": "public_channel", "exclude_archived": True, "limit": 1}
+    ]
+    assert slack.channels == [CHANNEL_A]
+
+
+def test_discovery_refuses_malformed_slack_target_without_leaking(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A Slack target still requires a nonempty string destination address."""
+    agent = _agent(
+        channels=[
+            {"kind": "slack", "private": "hostile-target-field-sentinel"},
+        ],
+        approval_routes=None,
+    )
+    slack = _RecordingSlackClient()
+    logger = logging.getLogger("test-slack-malformed-target")
+
+    with caplog.at_level(logging.INFO, logger=logger.name):
+        with pytest.raises(SlackChannelPreflightError) as excinfo:
+            check_slack_channel_capabilities(
+                _config(),
+                logger=logger,
+                web_client=slack,
+                api_client=_client(
+                    lambda _request: httpx.Response(200, json=[agent])
+                ),
+            )
+
+    assert "returned an invalid response shape" in str(excinfo.value)
+    assert slack.list_calls == []
+    assert slack.channels == []
+    emitted = " ".join(
+        [str(excinfo.value), *(record.getMessage() for record in caplog.records)]
+    )
+    assert "hostile-target-field-sentinel" not in emitted
+
+
+def test_slack_preflight_retries_transient_agent_discovery_then_succeeds() -> None:
+    """Authenticated discovery retries transient 5xx and connection failures.
+
+    ``GET /health`` can answer before the API's database-backed ``GET /agents``
+    is ready. The latter therefore needs the same bounded startup tolerance.
+    """
+    api_key = "fake-platform-key-sentinel"
+    attempts: list[httpx.Request] = []
+    clock = _FakeClock()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        attempts.append(request)
+        if len(attempts) == 1:
+            return httpx.Response(503, text="transient-body-sentinel")
+        if len(attempts) == 2:
+            raise httpx.ConnectError("transient-connect-sentinel", request=request)
+        return httpx.Response(200, json=[])
+
+    check_slack_channel_capabilities(
+        _config(
+            api_key=api_key,
+            api_preflight_timeout_s=1.0,
+            backoff_initial_seconds=0.1,
+            backoff_max_seconds=0.2,
+        ),
+        logger=logging.getLogger("test-slack-preflight-discovery-retry"),
+        web_client=_RecordingSlackClient(),
+        api_client=_client(handler),
+        monotonic=clock.monotonic,
+        sleep=clock.sleep,
+    )
+
+    assert len(attempts) == 3
+    assert all(request.headers["X-API-Key"] == api_key for request in attempts)
+    assert clock.now == pytest.approx(0.3)
+
+
+def test_slack_preflight_api_discovery_failure_is_redaction_safe(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Exhausted discovery fails closed without relaying bodies or credentials."""
+    api_key = "hostile-api-key-sentinel"
+    raw_body = "hostile-api-response-body-sentinel"
+    logger = logging.getLogger("test-slack-preflight-api-failure")
+    clock = _FakeClock()
+
+    with caplog.at_level(logging.INFO, logger=logger.name):
+        with pytest.raises(SlackChannelPreflightError) as excinfo:
+            check_slack_channel_capabilities(
+                _config(
+                    api_key=api_key,
+                    api_preflight_timeout_s=0.2,
+                    backoff_initial_seconds=0.1,
+                    backoff_max_seconds=0.1,
+                ),
+                logger=logger,
+                web_client=_RecordingSlackClient(),
+                api_client=_client(
+                    lambda _request: httpx.Response(503, text=raw_body)
+                ),
+                monotonic=clock.monotonic,
+                sleep=clock.sleep,
+            )
+
+    emitted = " ".join(
+        [str(excinfo.value), *(record.getMessage() for record in caplog.records)]
+    )
+    assert "Slack channel capability preflight failed" in emitted
+    assert api_key not in emitted
+    assert raw_body not in emitted
+
+
+@pytest.mark.parametrize(
+    ("provider_failure", "private_values"),
+    [
+        pytest.param(
+            SlackApiError(
+                "hostile-info-scope-sdk-message-sentinel",
+                {
+                    "ok": False,
+                    "error": "missing_scope",
+                    "needed": "channels:read",
+                    "provided": "groups:read",
+                    "detail": "hostile-info-scope-body-sentinel",
+                },
+            ),
+            (
+                "channels:read",
+                "groups:read",
+                "hostile-info-scope-sdk-message-sentinel",
+                "hostile-info-scope-body-sentinel",
+            ),
+            id="destination-public-scope-is-not-global-proof",
+        ),
+        pytest.param(
+            SlackApiError(
+                "hostile-groups-sdk-message-sentinel",
+                {
+                    "ok": False,
+                    "error": "missing_scope",
+                    "needed": "groups:read",
+                    "provided": "chat:write",
+                    "detail": "hostile-groups-body-sentinel",
+                },
+            ),
+            (
+                "groups:read",
+                "chat:write",
+                "hostile-groups-sdk-message-sentinel",
+                "hostile-groups-body-sentinel",
+            ),
+            id="private-channel-scope",
+        ),
+        pytest.param(
+            SlackApiError(
+                "hostile-stale-sdk-message-sentinel",
+                {
+                    "ok": False,
+                    "error": "channel_not_found",
+                    "detail": "hostile-stale-body-sentinel",
+                },
+            ),
+            (
+                "channel_not_found",
+                "hostile-stale-sdk-message-sentinel",
+                "hostile-stale-body-sentinel",
+            ),
+            id="stale-binding",
+        ),
+        pytest.param(
+            SlackApiError(
+                "hostile-rate-sdk-message-sentinel",
+                {
+                    "ok": False,
+                    "error": "ratelimited",
+                    "retry_after": "hostile-retry-after-sentinel",
+                },
+            ),
+            (
+                "ratelimited",
+                "hostile-rate-sdk-message-sentinel",
+                "hostile-retry-after-sentinel",
+            ),
+            id="rate-limit",
+        ),
+        pytest.param(
+            RuntimeError("hostile-transport-error-sentinel"),
+            ("hostile-transport-error-sentinel",),
+            id="transport-error",
+        ),
+        pytest.param(
+            SlackApiError(
+                "hostile-sdk-message-sentinel",
+                {
+                    "ok": False,
+                    "error": "hostile-sdk-error-sentinel",
+                    "detail": "hostile-sdk-body-sentinel",
+                },
+            ),
+            (
+                "hostile-sdk-message-sentinel",
+                "hostile-sdk-error-sentinel",
+                "hostile-sdk-body-sentinel",
+            ),
+            id="generic-sdk-error",
+        ),
+    ],
+)
+def test_slack_preflight_nondefinitive_failures_warn_aggregately_and_continue(
+    provider_failure: Exception,
+    private_values: tuple[str, ...],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Private, stale, rate-limited, and transport outcomes are not boot-fatal.
+
+    Slack documents ``missing_scope``, ``channel_not_found``, and
+    ``ratelimited`` for ``conversations.info``. A missing-scope response that
+    does not include public-channel ``channels:read`` remains nondefinitive:
+    https://docs.slack.dev/reference/methods/conversations.info/#errors
+    """
+    logger = logging.getLogger("test-slack-preflight-nondefinitive-failure")
+    with caplog.at_level(logging.WARNING, logger=logger.name):
+        check_slack_channel_capabilities(
+            _config(slack_bot_token="hostile-bot-token-sentinel"),
+            logger=logger,
+            web_client=_RecordingSlackClient(side_effect=provider_failure),
+            api_client=_client(
+                lambda _request: httpx.Response(
+                    200,
+                    json=[
+                        _agent(
+                            channels=[{"kind": "slack", "address": CHANNEL_A}],
+                            approval_routes=None,
+                        )
+                    ],
+                )
+            ),
+        )
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert messages == [
+        "Slack channel capability preflight public-channel capability verified; "
+        "checked 0 configured destinations; unverified 1"
+    ]
+    logged = " ".join(messages)
+    for private_value in (
+        "hostile-bot-token-sentinel",
+        CHANNEL_A,
+        *private_values,
+    ):
+        assert private_value not in logged
+
+
+def test_malformed_falsey_conversations_list_response_is_unverified_and_redacted(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A falsey provider mapping cannot be replaced by the fake's happy default."""
+
+    class FalseySlackResponse(dict[str, object]):
+        def __bool__(self) -> bool:
+            return False
+
+    provider_response = FalseySlackResponse(
+        ok=True,
+        channels="hostile-provider-channels-sentinel",
+        detail="hostile-provider-body-sentinel",
+    )
+    slack = _RecordingSlackClient(list_response=provider_response)
+    logger = logging.getLogger("test-slack-malformed-capability-response")
+    agent = _agent(
+        channels=[{"kind": "slack", "address": CHANNEL_A}],
+        approval_routes=None,
+    )
+
+    with caplog.at_level(logging.WARNING, logger=logger.name):
+        check_slack_channel_capabilities(
+            _config(slack_bot_token="hostile-bot-token-sentinel"),
+            logger=logger,
+            web_client=slack,
+            api_client=_client(lambda _request: httpx.Response(200, json=[agent])),
+        )
+
+    assert slack.list_calls == [
+        {"types": "public_channel", "exclude_archived": True, "limit": 1}
+    ]
+    assert slack.channels == [CHANNEL_A]
+    messages = [record.getMessage() for record in caplog.records]
+    assert messages == [
+        "Slack channel capability preflight public-channel capability unverified; "
+        "checked 1 configured destinations; unverified 0"
+    ]
+    logged = " ".join(messages)
+    for private_value in (
+        "hostile-bot-token-sentinel",
+        "hostile-provider-channels-sentinel",
+        "hostile-provider-body-sentinel",
+        CHANNEL_A,
+    ):
+        assert private_value not in logged
+
+
+@pytest.mark.parametrize(
+    ("provider_response", "private_values"),
+    [
+        pytest.param({"ok": False}, (), id="ok-false"),
+        pytest.param(
+            {
+                "ok": True,
+                "error": "hostile-missing-channel-error-sentinel",
+                "detail": "hostile-missing-channel-body-sentinel",
+            },
+            (
+                "hostile-missing-channel-error-sentinel",
+                "hostile-missing-channel-body-sentinel",
+            ),
+            id="missing-channel",
+        ),
+        pytest.param(
+            {
+                "ok": True,
+                "channel": "hostile-nonmapping-channel-sentinel",
+                "detail": "hostile-nonmapping-body-sentinel",
+            },
+            (
+                "hostile-nonmapping-channel-sentinel",
+                "hostile-nonmapping-body-sentinel",
+            ),
+            id="nonmapping-channel",
+        ),
+    ],
+)
+def test_slack_preflight_malformed_success_is_nonfatal_unverified_and_redacted(
+    provider_response: object,
+    private_values: tuple[str, ...],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Malformed success shapes are ambiguous and cannot make startup terminal.
+
+    Slack documents a successful ``conversations.info`` response as
+    ``{"ok": true, "channel": {...}}``. Any other non-exception shape is
+    unverified, and its provider-controlled fields stay out of logs:
+    https://docs.slack.dev/reference/methods/conversations.info/
+    """
+    logger = logging.getLogger("test-slack-preflight-malformed-response")
+    slack = _StaticSlackClient(provider_response)
+    with caplog.at_level(logging.WARNING, logger=logger.name):
+        check_slack_channel_capabilities(
+            _config(slack_bot_token="hostile-bot-token-sentinel"),
+            logger=logger,
+            web_client=slack,
+            api_client=_client(
+                lambda _request: httpx.Response(
+                    200,
+                    json=[
+                        _agent(
+                            channels=[{"kind": "slack", "address": CHANNEL_A}],
+                            approval_routes=None,
+                        )
+                    ],
+                )
+            ),
+        )
+
+    assert slack.channels == [CHANNEL_A]
+    messages = [record.getMessage() for record in caplog.records]
+    assert messages == [
+        "Slack channel capability preflight public-channel capability verified; "
+        "checked 0 configured destinations; unverified 1"
+    ]
+    logged = " ".join(messages)
+    for private_value in (
+        "hostile-bot-token-sentinel",
+        CHANNEL_A,
+        *private_values,
+    ):
+        assert private_value not in logged
+
+
+def test_slack_preflight_stops_at_aggregate_deadline_and_logs_safe_counts(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Unattempted destinations make aggregate-budget exhaustion terminal."""
+    clock = _FakeClock()
+    slack = _AdvancingSlackClient(clock=clock, seconds_per_call=1.0)
+    logger = logging.getLogger("test-slack-preflight-aggregate-budget")
+    agent = _agent(
+        channels=[
+            {"kind": "slack", "address": CHANNEL_A},
+            {"kind": "slack", "address": CHANNEL_B},
+            {"kind": "slack", "address": CHANNEL_C},
+        ],
+        approval_routes=None,
+    )
+
+    with caplog.at_level(logging.WARNING, logger=logger.name):
+        with pytest.raises(SlackChannelPreflightError) as excinfo:
+            check_slack_channel_capabilities(
+                _config(
+                    slack_bot_token="hostile-bot-token-sentinel",
+                    api_preflight_timeout_s=2.0,
+                ),
+                logger=logger,
+                web_client=slack,
+                api_client=_client(
+                    lambda _request: httpx.Response(
+                        200,
+                        json=[agent],
+                        headers={"X-Provider-Detail": "hostile-provider-sentinel"},
+                    )
+                ),
+                monotonic=clock.monotonic,
+                sleep=clock.sleep,
+            )
+
+    assert slack.channels == [CHANNEL_A, CHANNEL_B]
+    assert clock.now == pytest.approx(2.0)
+    assert str(excinfo.value) == SLACK_TIMEOUT_MESSAGE
+    emitted = " ".join(
+        [str(excinfo.value), *(record.getMessage() for record in caplog.records)]
+    )
+    for private_value in (
+        "hostile-bot-token-sentinel",
+        "hostile-provider-sentinel",
+        CHANNEL_A,
+        CHANNEL_B,
+        CHANNEL_C,
+    ):
+        assert private_value not in emitted
+
+
+def test_health_and_slack_each_receive_the_full_configured_budget(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Health has its own budget; discovery plus Slack gets a fresh budget."""
+    clock = _FakeClock()
+    config = _config(api_preflight_timeout_s=2.0)
+
+    def health_handler(_request: httpx.Request) -> httpx.Response:
+        clock.sleep(2.0)
+        return httpx.Response(200, json={"status": "ok"})
+
+    check_api_reachable(
+        config,
+        logger=logging.getLogger("test-separate-budget-health"),
+        client=_client(health_handler),
+        monotonic=clock.monotonic,
+        sleep=clock.sleep,
+    )
+
+    agent = _agent(
+        channels=[
+            {"kind": "slack", "address": CHANNEL_A},
+            {"kind": "slack", "address": CHANNEL_B},
+            {"kind": "slack", "address": CHANNEL_C},
+        ],
+        approval_routes=None,
+    )
+
+    def discovery_handler(_request: httpx.Request) -> httpx.Response:
+        clock.sleep(1.0)
+        return httpx.Response(200, json=[agent])
+
+    slack = _AdvancingSlackClient(clock=clock, seconds_per_call=1.0)
+    logger = logging.getLogger("test-separate-budget-slack")
+    with caplog.at_level(logging.WARNING, logger=logger.name):
+        with pytest.raises(SlackChannelPreflightError) as excinfo:
+            check_slack_channel_capabilities(
+                config,
+                logger=logger,
+                web_client=slack,
+                api_client=_client(discovery_handler),
+                monotonic=clock.monotonic,
+                sleep=clock.sleep,
+            )
+
+    # Health consumed its full 2s before the Slack preflight started. Discovery
+    # plus metadata still received another full 2s, ending at t=4 rather than
+    # inheriting health's exhausted deadline at t=2.
+    assert clock.now == pytest.approx(4.0)
+    assert slack.channels == [CHANNEL_A]
+    assert str(excinfo.value) == SLACK_TIMEOUT_MESSAGE
+    emitted = " ".join(
+        [str(excinfo.value), *(record.getMessage() for record in caplog.records)]
+    )
+    for private_value in (CHANNEL_A, CHANNEL_B, CHANNEL_C):
+        assert private_value not in emitted
+
+
+def test_production_slack_clients_are_per_destination_bounded_and_nonretrying(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Production probes cannot hide an unattempted destination behind retries."""
+    from curie_dispatcher import preflight
+
+    clock = _FakeClock()
+    constructor_calls: list[dict[str, Any]] = []
+    attempted: list[str] = []
+    capability_calls: list[dict[str, object]] = []
+    call_durations = iter([1.2, 1.5, 1.0])
+
+    class RecordingProductionClient:
+        def conversations_list(
+            self,
+            *,
+            types: str,
+            exclude_archived: bool,
+            limit: int,
+        ) -> dict[str, Any]:
+            capability_calls.append(
+                {
+                    "types": types,
+                    "exclude_archived": exclude_archived,
+                    "limit": limit,
+                }
+            )
+            clock.sleep(next(call_durations))
+            return {
+                "ok": True,
+                "channels": [],
+                "response_metadata": {"next_cursor": ""},
+            }
+
+        def conversations_info(self, *, channel: str) -> dict[str, Any]:
+            attempted.append(channel)
+            clock.sleep(next(call_durations))
+            return {"ok": True, "channel": {"id": channel}}
+
+    def construct_web_client(**kwargs: Any) -> RecordingProductionClient:
+        constructor_calls.append(kwargs)
+        return RecordingProductionClient()
+
+    monkeypatch.setattr(preflight, "WebClient", construct_web_client)
+    agent = _agent(
+        channels=[
+            {"kind": "slack", "address": CHANNEL_A},
+            {"kind": "slack", "address": CHANNEL_B},
+            {"kind": "slack", "address": CHANNEL_C},
+        ],
+        approval_routes=None,
+    )
+
+    def discovery_handler(_request: httpx.Request) -> httpx.Response:
+        clock.sleep(0.4)
+        return httpx.Response(
+            200,
+            json=[agent],
+            headers={"X-Provider-Detail": "hostile-provider-sentinel"},
+        )
+
+    logger = logging.getLogger("test-production-slack-client-budget")
+    with caplog.at_level(logging.WARNING, logger=logger.name):
+        with pytest.raises(SlackChannelPreflightError) as excinfo:
+            check_slack_channel_capabilities(
+                _config(
+                    slack_bot_token="hostile-bot-token-sentinel",
+                    api_preflight_timeout_s=4.0,
+                ),
+                logger=logger,
+                api_client=_client(discovery_handler),
+                monotonic=clock.monotonic,
+                sleep=clock.sleep,
+            )
+
+    assert capability_calls == [
+        {"types": "public_channel", "exclude_archived": True, "limit": 1}
+    ]
+    assert attempted == [CHANNEL_A, CHANNEL_B]
+    assert len(constructor_calls) == 3
+    assert [call["timeout"] for call in constructor_calls] == [2, 2, 1]
+    assert all(isinstance(call["timeout"], int) for call in constructor_calls)
+    assert all(call["retry_handlers"] == [] for call in constructor_calls)
+    assert all(isinstance(call["logger"], logging.Logger) for call in constructor_calls)
+    assert all(not call["logger"].propagate for call in constructor_calls)
+    assert all(
+        not call["logger"].isEnabledFor(logging.CRITICAL)
+        for call in constructor_calls
+    )
+    assert all(
+        any(isinstance(handler, logging.NullHandler) for handler in call["logger"].handlers)
+        for call in constructor_calls
+    )
+    assert all(
+        call["token"] == "hostile-bot-token-sentinel"
+        for call in constructor_calls
+    )
+    assert str(excinfo.value) == SLACK_TIMEOUT_MESSAGE
+    emitted = " ".join(
+        [str(excinfo.value), *(record.getMessage() for record in caplog.records)]
+    )
+    for private_value in (
+        "hostile-bot-token-sentinel",
+        "hostile-provider-sentinel",
+        CHANNEL_A,
+        CHANNEL_B,
+        CHANNEL_C,
+    ):
+        assert private_value not in emitted
+
+
+def test_production_provider_error_uses_silent_sdk_logger_and_safe_aggregate(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """SDK diagnostics cannot bypass the preflight's redaction boundary."""
+    from curie_dispatcher import preflight
+
+    constructor_calls: list[dict[str, Any]] = []
+    raw_message = "hostile-production-sdk-message-sentinel"
+    raw_body = "hostile-production-sdk-body-sentinel"
+
+    class FailingProductionClient:
+        def __init__(self, logger: logging.Logger) -> None:
+            self._logger = logger
+
+        def conversations_list(
+            self,
+            *,
+            types: str,
+            exclude_archived: bool,
+            limit: int,
+        ) -> object:
+            assert (types, exclude_archived, limit) == ("public_channel", True, 1)
+            self._logger.debug("%s %s", CHANNEL_A, raw_body)
+            self._logger.error("%s %s", raw_message, raw_body)
+            raise SlackApiError(
+                raw_message,
+                {
+                    "ok": False,
+                    "error": "ratelimited",
+                    "detail": raw_body,
+                    "channel": CHANNEL_A,
+                },
+            )
+
+        def conversations_info(self, *, channel: str) -> object:
+            raise AssertionError(f"unexpected destination call for {channel}")
+
+    def construct_web_client(**kwargs: Any) -> FailingProductionClient:
+        constructor_calls.append(kwargs)
+        return FailingProductionClient(kwargs["logger"])
+
+    monkeypatch.setattr(preflight, "WebClient", construct_web_client)
+    logger = logging.getLogger("test-production-provider-error")
+    with caplog.at_level(logging.DEBUG):
+        with caplog.at_level(logging.DEBUG, logger="slack_sdk.web.base_client"):
+            check_slack_channel_capabilities(
+                _config(slack_bot_token="hostile-bot-token-sentinel"),
+                logger=logger,
+                api_client=_client(lambda _request: httpx.Response(200, json=[])),
+            )
+
+    assert len(constructor_calls) == 1
+    constructor = constructor_calls[0]
+    assert constructor["retry_handlers"] == []
+    assert isinstance(constructor["timeout"], int)
+    silent_logger = constructor["logger"]
+    assert isinstance(silent_logger, logging.Logger)
+    assert silent_logger.propagate is False
+    assert not silent_logger.isEnabledFor(logging.CRITICAL)
+    assert any(
+        isinstance(handler, logging.NullHandler)
+        for handler in silent_logger.handlers
+    )
+    app_messages = [
+        record.getMessage() for record in caplog.records if record.name == logger.name
+    ]
+    assert app_messages == [
+        "Slack channel capability preflight public-channel capability unverified; "
+        "checked 0 configured destinations; unverified 0"
+    ]
+    emitted = " ".join(record.getMessage() for record in caplog.records)
+    for private_value in (
+        "hostile-bot-token-sentinel",
+        raw_message,
+        raw_body,
+        CHANNEL_A,
+        "ratelimited",
+    ):
+        assert private_value not in emitted
+
+
+@pytest.mark.parametrize(
+    "error_code",
+    [
+        pytest.param("missing_scope", id="missing-scope"),
+        pytest.param("invalid_types", id="types-rejected-by-granted-scopes"),
+    ],
+)
+def test_slack_public_capability_scope_error_has_exact_redacted_recovery(
+    error_code: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The workspace-level public-channel probe supplies precise recovery.
+
+    Slack documents ``channels:read`` for public-channel metadata returned by
+    ``conversations.list``. Its error table says ``missing_scope`` means the
+    token lacks necessary scope and ``invalid_types`` may mean the requested
+    type cannot be used with the token's granted permission scopes. Neither
+    response needs a provider ``needed`` hint for this public-only probe:
+    https://docs.slack.dev/reference/methods/conversations.list/#errors
+    https://docs.slack.dev/reference/scopes/channels.read/
+    """
+    raw_message = "hostile-slack-sdk-message-sentinel"
+    response = SlackResponse(
+        client=None,
+        http_verb="GET",
+        api_url="https://slack.com/api/conversations.list",
+        req_args={
+            "params": {
+                "types": "public_channel",
+                "exclude_archived": True,
+                "limit": 1,
+            }
+        },
+        data={
+            "ok": False,
+            "error": error_code,
+            "provided": "chat:write",
+            "detail": "hostile-response-body-sentinel",
+        },
+        headers={"X-Slack-Req-Id": "hostile-request-id-sentinel"},
+        status_code=200,
+    )
+    missing_scope = SlackApiError(raw_message, response)
+    logger = logging.getLogger("test-slack-preflight-missing-scope")
+    slack = _RecordingSlackClient(list_side_effect=missing_scope)
+
+    with caplog.at_level(logging.INFO, logger=logger.name):
+        with pytest.raises(SlackChannelPreflightError) as excinfo:
+            check_slack_channel_capabilities(
+                _config(slack_bot_token="hostile-bot-token-sentinel"),
+                logger=logger,
+                web_client=slack,
+                api_client=_client(
+                    lambda _request: httpx.Response(
+                        200,
+                        json=[
+                            _agent(
+                                channels=[{"kind": "slack", "address": CHANNEL_A}],
+                                approval_routes=None,
+                            )
+                        ],
+                    )
+                ),
+            )
+
+    assert str(excinfo.value) == MISSING_SCOPE_MESSAGE
+    assert slack.list_calls == [
+        {"types": "public_channel", "exclude_archived": True, "limit": 1}
+    ]
+    assert slack.channels == []
+    emitted = " ".join(
+        [str(excinfo.value), *(record.getMessage() for record in caplog.records)]
+    )
+    for private_value in (
+        "hostile-bot-token-sentinel",
+        CHANNEL_A,
+        raw_message,
+        error_code,
+        "chat:write",
+        "hostile-response-body-sentinel",
+        "hostile-request-id-sentinel",
+    ):
+        assert private_value not in emitted
+
+
+def test_slack_manifest_declares_the_preflight_scope() -> None:
+    """The installable manifest must grant what the boot gate exercises."""
+    manifest = yaml.safe_load(
+        (Path(__file__).parents[1] / "slack-app-manifest.yaml").read_text()
+    )
+
+    assert "channels:read" in manifest["oauth_config"]["scopes"]["bot"]
+
+
+def _set_run_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Clear ambient dispatcher config and install only public test values."""
+    for name, field in DispatcherConfig.model_fields.items():
+        alias = field.validation_alias
+        monkeypatch.delenv(
+            alias if isinstance(alias, str) else name.upper(), raising=False
+        )
+    monkeypatch.setenv(
+        "CURIE_APPROVAL_CHAT_ATTESTER_SECRET", "dispatcher-attester-test-secret"
+    )
+
+
+class _TestTelemetry:
+    def shutdown(self) -> None:
+        pass
+
+
 def test_run_main_gates_before_connecting_slack(monkeypatch: pytest.MonkeyPatch) -> None:
     """The ordering contract: the wiring gate precedes any Slack wiring.
 
@@ -309,27 +1349,31 @@ def test_run_main_gates_before_connecting_slack(monkeypatch: pytest.MonkeyPatch)
     """
     from curie_dispatcher import run
 
-    reached_slack: list[str] = []
+    reached_after_api: list[str] = []
+
+    def _unexpected_slack_preflight(*args: object, **kwargs: object) -> None:
+        reached_after_api.append("slack_preflight")
+        raise AssertionError(
+            "Slack capability preflight ran before API reachability passed"
+        )
 
     def _recording_build_supervisor(*args: object, **kwargs: object) -> object:
-        reached_slack.append("build_supervisor")
+        reached_after_api.append("build_supervisor")
         raise AssertionError(
             "build_supervisor was called with an unreachable API: the dispatcher "
             "wired up Slack before (or instead of) gating on the platform API"
         )
 
+    monkeypatch.setattr(
+        run, "check_slack_channel_capabilities", _unexpected_slack_preflight
+    )
     monkeypatch.setattr(run, "build_supervisor", _recording_build_supervisor)
-    for name, field in DispatcherConfig.model_fields.items():
-        alias = field.validation_alias
-        monkeypatch.delenv(alias if isinstance(alias, str) else name.upper(), raising=False)
+    _set_run_env(monkeypatch)
     # Port 1 is reserved and never listening: a real, immediate connection refusal.
     monkeypatch.setenv("CURIE_API_URL", "http://127.0.0.1:1")
     monkeypatch.setenv("CURIE_API_PREFLIGHT_TIMEOUT_SECONDS", "0.2")
     monkeypatch.setenv("CURIE_BACKOFF_INITIAL_SECONDS", "0.01")
     monkeypatch.setenv("CURIE_BACKOFF_MAX_SECONDS", "0.02")
-    monkeypatch.setenv(
-        "CURIE_APPROVAL_CHAT_ATTESTER_SECRET", "dispatcher-attester-test-secret"
-    )
 
     with pytest.raises(SystemExit) as excinfo:
         run.main()
@@ -338,4 +1382,105 @@ def test_run_main_gates_before_connecting_slack(monkeypatch: pytest.MonkeyPatch)
         f"the dispatcher must exit non-zero on an unreachable API so a "
         f"CrashLoopBackOff surfaces it; exited {excinfo.value.code!r}"
     )
-    assert reached_slack == []
+    assert reached_after_api == []
+
+
+def test_run_main_orders_api_then_slack_preflight_then_supervisor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A successful boot reaches Socket Mode only after both ordered gates."""
+    from curie_dispatcher import run
+
+    events: list[str] = []
+
+    class RecordingSupervisor:
+        def run(self) -> None:
+            events.append("supervisor.run")
+
+        def request_stop(self) -> None:
+            events.append("supervisor.request_stop")
+
+    class RecordingHeartbeat:
+        def set(self) -> None:
+            events.append("heartbeat.stop")
+
+    def check_api(*args: object, **kwargs: object) -> None:
+        assert "deadline" not in kwargs
+        events.append("api")
+
+    def check_slack(
+        *args: object,
+        **kwargs: object,
+    ) -> None:
+        assert "web_client" not in kwargs
+        assert "deadline" not in kwargs
+        events.append("slack")
+
+    def build_supervisor(
+        _config: DispatcherConfig,
+        *,
+        logger: logging.Logger,
+    ) -> RecordingSupervisor:
+        assert logger.name == "curie_dispatcher"
+        events.append("supervisor")
+        return RecordingSupervisor()
+
+    _set_run_env(monkeypatch)
+    monkeypatch.setattr(
+        run, "bootstrap_service_telemetry", lambda *a, **k: _TestTelemetry()
+    )
+    monkeypatch.setattr(run, "check_api_reachable", check_api)
+    monkeypatch.setattr(run, "check_slack_channel_capabilities", check_slack)
+    monkeypatch.setattr(run, "build_supervisor", build_supervisor)
+    monkeypatch.setattr(
+        run, "start_heartbeat", lambda *a, **k: RecordingHeartbeat()
+    )
+    monkeypatch.setattr(run.signal, "signal", lambda *a, **k: None)
+
+    run.main()
+
+    assert events[:3] == ["api", "slack", "supervisor"]
+    assert "supervisor.run" in events
+
+
+def test_run_main_missing_scope_exits_before_supervisor_without_leaking(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The actionable Slack refusal is terminal before Socket Mode wiring."""
+    from curie_dispatcher import run
+
+    events: list[str] = []
+
+    def check_api(*args: object, **kwargs: object) -> None:
+        events.append("api")
+
+    def refuse_slack(*args: object, **kwargs: object) -> None:
+        assert "web_client" not in kwargs
+        events.append("slack")
+        raise SlackChannelPreflightError(MISSING_SCOPE_MESSAGE)
+
+    def unexpected_supervisor(
+        _config: DispatcherConfig,
+        *,
+        logger: logging.Logger,
+    ) -> object:
+        assert logger.name == "curie_dispatcher"
+        events.append("supervisor")
+        raise AssertionError("missing_scope reached supervisor/Socket Mode wiring")
+
+    _set_run_env(monkeypatch)
+    monkeypatch.setattr(
+        run, "bootstrap_service_telemetry", lambda *a, **k: _TestTelemetry()
+    )
+    monkeypatch.setattr(run, "check_api_reachable", check_api)
+    monkeypatch.setattr(run, "check_slack_channel_capabilities", refuse_slack)
+    monkeypatch.setattr(run, "build_supervisor", unexpected_supervisor)
+
+    with caplog.at_level(logging.ERROR, logger="curie_dispatcher"):
+        with pytest.raises(SystemExit) as excinfo:
+            run.main()
+
+    assert excinfo.value.code not in (0, None)
+    assert events == ["api", "slack"]
+    assert [record.getMessage() for record in caplog.records] == [MISSING_SCOPE_MESSAGE]

--- a/apps/dispatcher/tests/test_slack_channel_preflight_fix_pin.py
+++ b/apps/dispatcher/tests/test_slack_channel_preflight_fix_pin.py
@@ -1,0 +1,72 @@
+"""Reverse-diff pin for the dispatcher Slack capability boot gate (#2205)."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+MISSING_SCOPE_MESSAGE = (
+    "Slack channel capability preflight failed: bot token is missing required "
+    "scope channels:read. Add channels:read under OAuth & Permissions > Bot "
+    "Token Scopes, then reinstall the app to the workspace."
+)
+
+
+class _TestTelemetry:
+    def shutdown(self) -> None:
+        pass
+
+
+def test_missing_scope_refuses_boot_before_slack_wiring(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The real process entrypoint must stop on the actionable scope refusal.
+
+    Imports stay at the consumer module boundary so the reverse-diff verifier
+    attributes a missing gate to this selected test instead of failing during
+    collection when the new preflight symbols have been removed.
+    """
+    from curie_dispatcher import run
+
+    assert hasattr(run, "check_slack_channel_capabilities"), (
+        "dispatcher startup has no Slack channel capability preflight"
+    )
+    assert hasattr(run, "SlackChannelPreflightError"), (
+        "dispatcher startup cannot handle Slack channel preflight refusals"
+    )
+
+    events: list[str] = []
+
+    def check_api(*args: object, **kwargs: object) -> None:
+        events.append("api")
+
+    def refuse_slack(*args: object, **kwargs: object) -> None:
+        events.append("slack")
+        error_type = run.SlackChannelPreflightError
+        raise error_type(MISSING_SCOPE_MESSAGE)
+
+    def unexpected_supervisor(*args: object, **kwargs: object) -> object:
+        events.append("supervisor")
+        raise AssertionError("missing scope reached Slack wiring")
+
+    monkeypatch.setenv(
+        "CURIE_APPROVAL_CHAT_ATTESTER_SECRET", "dispatcher-attester-test-secret"
+    )
+    monkeypatch.setattr(
+        run, "bootstrap_service_telemetry", lambda *a, **k: _TestTelemetry()
+    )
+    monkeypatch.setattr(run, "check_api_reachable", check_api)
+    monkeypatch.setattr(run, "check_slack_channel_capabilities", refuse_slack)
+    monkeypatch.setattr(run, "build_supervisor", unexpected_supervisor)
+
+    with caplog.at_level(logging.ERROR, logger="curie_dispatcher"):
+        with pytest.raises(SystemExit) as excinfo:
+            run.main()
+
+    assert excinfo.value.code == 1
+    assert events == ["api", "slack"]
+    assert [record.getMessage() for record in caplog.records] == [
+        MISSING_SCOPE_MESSAGE
+    ]

--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -102,9 +102,9 @@ Two limits worth knowing. With `api.deploy: false` and an empty
 exist; its boot preflight fails and the pod CrashLoopBackOffs naming the
 unreachable URL. That is intentional (a loud boot failure beats a silent
 dead-end at click time) and the fix is to set `dispatcher.apiBaseUrl`. And
-because the API's `/health` is unauthenticated, that preflight proves only
-reachability, not that the key is right: a BYO API expecting a different key
-still passes boot and fails at click time. Match `apiKey` to the API you point at.
+because the API's `/health` is unauthenticated, that first preflight proves only
+reachability. The following authenticated `/agents` discovery refuses startup
+when a BYO API expects a different key. Match `apiKey` to the API you point at.
 
 **Cluster variants:**
 

--- a/docs/diagrams/kubernetes.md
+++ b/docs/diagrams/kubernetes.md
@@ -27,6 +27,8 @@ flowchart TB
         OTel["OTel Collector"]
     end
 
+    Slack["Slack Web API"]
+
     subgraph sandbox["Sandbox substrate (agent-sandbox controller)"]
         Tmpl["SandboxTemplate<br/>the pod spec claims build from"]
         Pool["SandboxWarmPool<br/>referenced by name; replicas 0 by default"]
@@ -38,7 +40,8 @@ flowchart TB
     API --> PG
     API --> RustFS
     Disp --> Valkey
-    Disp -- "GET /health preflight" --> API
+    Disp -- "GET /health + authenticated /agents preflights" --> API
+    Disp -- "bounded channel metadata preflight" --> Slack
     Worker --> Valkey
     Worker -- "create SandboxClaim" --> Pod
     Pool -. "referenced by warmPoolRef;<br/>pre-warms pods only at replicas > 0" .-> Tmpl

--- a/docs/slack-local-runbook.md
+++ b/docs/slack-local-runbook.md
@@ -38,8 +38,9 @@ subscriptions are correct from the start.
    It encodes:
 
    - Socket Mode on
-   - the bot scopes (`app_mentions:read`, `chat:write`, `channels:history`,
-     `groups:history`, `im:history`, `im:read`, and `assistant:write`)
+   - the bot scopes (`app_mentions:read`, `chat:write`, `channels:read`,
+     `channels:history`, `groups:history`, `im:history`, `im:read`, and
+     `assistant:write`)
    - the `app_mention` and `message.im` event subscriptions
    - interactivity on (so button and block-action clicks arrive over Socket
      Mode)
@@ -48,7 +49,8 @@ subscriptions are correct from the start.
    `SLACK_APP_TOKEN`, used for the Socket Mode connection.
 3. **Install to Workspace** (Install App), then copy the **Bot User OAuth
    Token**. This `xoxb-...` value is your `SLACK_BOT_TOKEN`, used by the Web API
-   to post replies.
+   to post replies. If this app was installed before `channels:read` was added,
+   reinstall it to the workspace so the existing bot-token grant is refreshed.
 4. `SLACK_SIGNING_SECRET` is optional and unused in Socket Mode (kept only for
    Bolt app construction); leave it empty.
 
@@ -132,6 +134,43 @@ What each export does:
 
 Socket Mode is outbound-only: the dispatcher dials Slack over an outbound
 WebSocket, so your laptop needs no public ingress, port-forward, or tunnel.
+
+Before opening that Socket Mode connection, the dispatcher performs bounded
+preflights in this order: platform API `/health` reachability within
+`CURIE_API_PREFLIGHT_TIMEOUT_SECONDS`, then authenticated `/agents` destination
+discovery with `CURIE_API_KEY` and Slack metadata capability attempts together
+within a fresh budget of the same size. `/health` is unauthenticated. If the
+health budget expires, correct `CURIE_API_URL`; if discovery cannot finish,
+check platform API availability and configuration, then retry.
+
+If Slack cannot attempt every configured destination before its budget,
+startup refuses safely: restore Slack availability or increase
+`CURIE_API_PREFLIGHT_TIMEOUT_SECONDS`, then retry. These failures name only the
+phase and recovery action, never configured Slack destinations or credentials.
+After discovery, the dispatcher always makes one bounded public-channel
+`conversations.list(types=public_channel, limit=1)` capability call, even with
+zero configured destinations, then attempts `conversations.info` for every
+configured destination. A Slack `missing_scope` or documented `invalid_types`
+permission outcome on that public capability call maps unambiguously to the
+recovery below without reading or logging its `needed` or `provided` sets.
+Production creates a dedicated no-retry Slack WebClient for each metadata call,
+with an integer timeout derived from the remaining phase budget and capped at
+two seconds. The phase budget stops new attempts; a final already-started call
+can extend it only by that bounded timeout.
+
+The only boot-fatal Slack metadata responses are `missing_scope` and
+`invalid_types` from that fixed public-channel capability request. Both use the
+same missing-public-permission recovery:
+`Slack channel capability preflight failed: bot token is missing required scope channels:read. Add channels:read under OAuth & Permissions > Bot Token Scopes, then reinstall the app to the workspace.`
+The preflight logs only a safe public capability state (`verified` or
+`unverified`) and aggregate checked or unverified destination counts. Other
+capability-call failures, plus private, stale, or transient per-destination
+`conversations.info` outcomes, remain aggregate unverified warnings once every
+destination has been attempted; no tokens or channel identifiers are printed.
+An unverified warning can recur for a private channel, DM, stale destination,
+or transient provider outcome; it is non-terminal and does not prove
+private-channel or DM scope coverage. Correct the destination or access through
+trusted configuration separately.
 
 For the dispatcher-internals angle (its process, reconnect behavior, and app
 creation details), see the runbook in


### PR DESCRIPTION
## Summary

Add an early, bounded dispatcher startup preflight that authenticates destination discovery, exercises Slack's public-channel metadata capability before Socket Mode, and attempts every configured Slack destination without logging tokens or identifiers. A definitive public-channel permission failure now stops startup with the exact `channels:read` plus reinstall recovery; ambiguous provider, private-channel, stale-destination, and transient outcomes remain redaction-safe aggregate warnings.

The installable Slack manifest and operator docs now add `channels:read` and the required reinstall step. Provider-shape regressions use Slack SDK response objects and cite Slack's official [`conversations.list`](https://docs.slack.dev/reference/methods/conversations.list/), [`channels:read`](https://docs.slack.dev/reference/scopes/channels.read/), and [`conversations.info`](https://docs.slack.dev/reference/methods/conversations.info/) contracts.

## Related issue

Closes #2205

## Fix pin verification

Fix pin: apps/dispatcher/tests/test_slack_channel_preflight_fix_pin.py::test_missing_scope_refuses_boot_before_slack_wiring

`curie dev verify-fix-pin f84eaf62b apps/dispatcher/tests/test_slack_channel_preflight_fix_pin.py::test_missing_scope_refuses_boot_before_slack_wiring` passed the selected test, reversed the product diff, observed the selected test fail because the startup gate was absent, and reported `PINNED`.

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | No plugin packaging, runner loop, ACI event, skill eval, or skill check surface changed. | — | — |
| local | required | Dispatcher startup wiring changed. | fake | `CURIE_BIN=/home/theconnman/.cargo/shared-targets/agentos/release/curie CURIE_E2E_TIERS=local curie dev e2e-ladder` at `f84eaf62b` reported `LADDER PASS (tiers: local)`. Its zero-export control, injected runner-failure/recovery case, unknown-trace refusal, and unavailable-API refusal supplied falsifiable negatives. A first run correctly refused stale deployment ambiguity; after `curie local down --wipe --yes`, the clean rerun passed. |
| local-release | n/a | No released binary/image identity, install path, version pin, or release Compose surface changed. | — | — |
| cluster | n/a | No chart template, RBAC, securityContext, NetworkPolicy, sandbox, or init-container behavior changed. | — | — |
| live provider | n/a | No model routing, model credentials, token accounting, or cost accounting changed. | — | — |
| external integration | required | The change depends on Slack Web API capability and response semantics. | live | `uv run python -` at `f84eaf62b` ran a redaction-safe harness over production `check_slack_channel_capabilities`: a real configured public metadata lookup succeeded with one checked destination, and a second real provider call using placeholder credentials/destination produced the non-definitive unverified path. Output contained only booleans: both provider outcomes were true and token/identifier absence was true for both logs. `uv run pytest -q apps/dispatcher/tests/test_preflight.py::test_slack_preflight_discovers_all_destinations_deduplicates_and_logs_count apps/dispatcher/tests/test_preflight.py::test_slack_public_capability_scope_error_has_exact_redacted_recovery` reported `3 passed`, covering provider-grounded success plus `missing_scope` and documented `invalid_types` recovery without relying on Slack's `needed` field. |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

Additional exact-head verification:

- `TEST_VALKEY_PORT=26405 CI_REQUIRE_VALKEY_TESTS=1 uv run pytest -q apps/dispatcher/tests` — 205 passed.
- `uv run pytest -q apps/dispatcher/tests/test_preflight.py apps/dispatcher/tests/test_slack_channel_preflight_fix_pin.py` — 36 passed.
- `uv run ruff check .`, `uv run mypy`, `uv run lint-imports`, `bash scripts/check-docs.sh`, wire tolerance, Alembic, released-upgrade, and the full Python suite all passed on the identical product/docs tree before the final standalone fix-pin test was added; the full suite result was 5,510 passed and 13 skipped. The final test-only delta was then covered by the exact-head focused and dispatcher suites above.
- Final blocking code-quality, scope-creep, and security reviews passed with no findings.

The live evidence intentionally records only capability status, counts, and redaction booleans. It contains no Slack token, channel identifier, workspace identifier, or deployment identifier.

## Checklist

- [x] Tests pass for the area I touched (see verification above).
- [x] Docs updated for the new startup behavior and recovery.
- [x] ADR not required: this is a narrow provider capability guard at the existing dispatcher boot boundary.
