### PR TITLE
Fix Slack approval ownership across releases

### DIFF
--- a/apps/dispatcher/README.md
+++ b/apps/dispatcher/README.md
@@ -19,6 +19,13 @@ platform API key alone cannot resolve. Authorization still happens in the API: r
 equality neither grants nor denies, so the same authenticated requester may confirm only
 when the selected approver set admits them.
 
+Slack may distribute one app's interactive payloads across any of its open
+Socket Mode connections. If two Curie releases share that app, the release whose
+API does not contain the approval acknowledges the interaction without changing
+the approval or Slack card and asks the approver to retry; only the release whose
+API owns the row can pass the existing compare-and-set. Separate Slack apps per
+long-lived release avoid the retry UX.
+
 ## What is ingested, and what is refused
 
 Ingest admits more than it used to (#2006). A message whose body lives in Block Kit

--- a/apps/dispatcher/src/curie_dispatcher/approval_actions.py
+++ b/apps/dispatcher/src/curie_dispatcher/approval_actions.py
@@ -110,6 +110,14 @@ _DECISION_BY_ACTION_ID = {
     REJECT_NOTE_ACTION_ID: "rejected",
 }
 
+# FastAPI's approvals router uses this exact detail when the requested row is
+# absent from THIS release's database. With two releases sharing one Socket Mode
+# app, that absence is an ownership signal rather than proof that the approval
+# was deleted: Slack may have delivered the interaction to the other release.
+# Keep this narrower than status 404 so an ingress/proxy route miss ("Not Found")
+# does not masquerade as release affinity.
+_APPROVAL_NOT_FOUND_DETAIL = "approval not found"
+
 
 def is_approval_action(action_id: str) -> bool:
     """True when a Block Kit action id belongs to the approval card."""
@@ -758,7 +766,12 @@ def _refusal_text(outcome: ResolveOutcome) -> str:
     if outcome.status_code == 410:
         return "This approval expired and can no longer be resolved."
     if outcome.status_code == 404:
-        return "This approval no longer exists."
+        if outcome.detail.strip().casefold() == _APPROVAL_NOT_FOUND_DETAIL:
+            return (
+                "This Curie release does not have this approval, so nothing was "
+                "changed. Try again so the owning release can handle it."
+            )
+        return "Resolving failed; try again shortly."
     return "Resolving failed; try again shortly."
 
 
@@ -876,6 +889,15 @@ def _render_outcome(
             message=message,
             detail=_refusal_text(outcome),
             log=log,
+        )
+    elif (
+        outcome.status_code == 404
+        and outcome.detail.strip().casefold() == _APPROVAL_NOT_FOUND_DETAIL
+    ):
+        log.warning(
+            "approval %s was not found in this release and may be owned by "
+            "another Curie release",
+            approval_id,
         )
     log.info(
         "approval %s click by %s rejected: HTTP %s %s",

--- a/apps/dispatcher/tests/test_approval_actions.py
+++ b/apps/dispatcher/tests/test_approval_actions.py
@@ -220,6 +220,62 @@ def test_reject_button_resolves_with_rejected_decision(
     assert "Rejected by <@U_MANAGER>" in web_client.chat_update.call_args.kwargs["text"]
 
 
+def test_two_releases_only_the_owner_resolves_an_immediate_action(
+    redis_client: redis.Redis,
+    config: DispatcherConfig,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A loser may receive the shared-app envelope, but cannot settle it (#2202).
+
+    Drive the same approval id through two independent real Bolt apps. Release B
+    has its own API view and truthfully reports that the record is absent; release
+    A owns the row and is the only app allowed to stamp the card. This is both the
+    negative and positive half of the two-release regression.
+    """
+
+    non_owner = ScriptedResolver(
+        ResolveOutcome(status_code=404, detail="approval not found")
+    )
+    owner = ScriptedResolver(
+        ResolveOutcome(status_code=200, resolved_by="U_MANAGER", decision="approved")
+    )
+    non_owner_app, non_owner_web = _build(config, redis_client, non_owner)
+    owner_app, owner_web = _build(config, redis_client, owner)
+
+    non_owner_socket = FakeSocketClient()
+    SocketModeHandler(non_owner_app, app_token="xapp-test").handle(
+        non_owner_socket,
+        _approval_click("env-release-b", action_id=APPROVE_ACTION_ID),
+    )
+    _drain(non_owner_app)
+
+    assert non_owner_socket.acked_envelope_ids == ["env-release-b"]
+    assert len(non_owner.calls) == 1
+    non_owner_web.chat_update.assert_not_called()
+    non_owner_web.chat_postMessage.assert_not_called()
+    non_owner_web.chat_postEphemeral.assert_called_once()
+    notice = non_owner_web.chat_postEphemeral.call_args.kwargs["text"]
+    assert "nothing was changed" in notice
+    assert "owning release" in notice
+    assert any(
+        "may be owned by another Curie release" in record.getMessage()
+        for record in caplog.records
+    )
+
+    owner_socket = FakeSocketClient()
+    SocketModeHandler(owner_app, app_token="xapp-test").handle(
+        owner_socket,
+        _approval_click("env-release-a", action_id=APPROVE_ACTION_ID),
+    )
+    _drain(owner_app)
+
+    assert owner_socket.acked_envelope_ids == ["env-release-a"]
+    assert len(owner.calls) == 1
+    owner_web.chat_update.assert_called_once()
+    assert "Approved by <@U_MANAGER>" in owner_web.chat_update.call_args.kwargs["text"]
+    owner_web.chat_postEphemeral.assert_not_called()
+
+
 def test_non_approver_rejection_renders_the_api_reason(
     redis_client: redis.Redis, config: DispatcherConfig
 ) -> None:

--- a/apps/dispatcher/tests/test_approval_note_dialog.py
+++ b/apps/dispatcher/tests/test_approval_note_dialog.py
@@ -330,6 +330,71 @@ def test_submitting_the_dialog_resolves_with_the_typed_note(
     assert not any(b.get("type") == "actions" for b in kwargs["blocks"])
 
 
+def test_two_releases_only_the_owner_resolves_a_note_submission(
+    redis_client: redis.Redis, config: DispatcherConfig
+) -> None:
+    """The non-owner keeps the modal live and performs no Slack mutation (#2202)."""
+
+    non_owner = ScriptedResolver(
+        ResolveOutcome(status_code=404, detail="approval not found")
+    )
+    owner = ScriptedResolver(
+        ResolveOutcome(status_code=200, resolved_by="U_MANAGER", decision="approved")
+    )
+    non_owner_app, non_owner_web = _build(config, redis_client, non_owner)
+    owner_app, owner_web = _build(config, redis_client, owner)
+
+    non_owner_socket = FakeSocketClient()
+    SocketModeHandler(non_owner_app, app_token="xapp-test").handle(
+        non_owner_socket,
+        _note_submit("env-note-release-b", note="approved for Q3"),
+    )
+    _drain(non_owner_app)
+
+    refusal = non_owner_socket.ack_payload_for("env-note-release-b")
+    assert refusal is not None
+    assert refusal["response_action"] == "errors"
+    assert "nothing was changed" in refusal["errors"]["note"]
+    assert "owning release" in refusal["errors"]["note"]
+    assert len(non_owner.calls) == 1
+    non_owner_web.conversations_replies.assert_not_called()
+    non_owner_web.chat_update.assert_not_called()
+    non_owner_web.chat_postEphemeral.assert_not_called()
+
+    owner_socket = FakeSocketClient()
+    SocketModeHandler(owner_app, app_token="xapp-test").handle(
+        owner_socket,
+        _note_submit("env-note-release-a", note="approved for Q3"),
+    )
+    _drain(owner_app)
+
+    assert owner_socket.ack_payload_for("env-note-release-a") is None
+    assert len(owner.calls) == 1
+    assert owner.calls[0]["note"] == "approved for Q3"
+    owner_web.chat_update.assert_called_once()
+    assert "approved for Q3" in owner_web.chat_update.call_args.kwargs["text"]
+
+
+def test_an_unrelated_404_does_not_claim_cross_release_ownership() -> None:
+    """A missing proxy route and a missing approval row are different failures."""
+
+    assert (
+        _refusal_text(ResolveOutcome(status_code=404, detail="Not Found"))
+        == "Resolving failed; try again shortly."
+    )
+
+
+def test_an_approval_record_miss_asks_for_the_owning_release() -> None:
+    """The exact API row miss is retryable when two releases share one app."""
+
+    refusal = _refusal_text(
+        ResolveOutcome(status_code=404, detail="approval not found")
+    )
+
+    assert "nothing was changed" in refusal
+    assert "owning release" in refusal
+
+
 def test_modal_submit_posts_the_note_with_a_chat_principal(
     redis_client: redis.Redis, config: DispatcherConfig
 ) -> None:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -866,9 +866,14 @@ next operator.
 - **langfuse-web restarts ~2x during first boot** while ClickHouse and
   Postgres come up, then stabilizes. This is startup ordering, not a
   crashloop; do not treat the early restarts as a failure.
-- **Exactly one Slack Socket Mode owner at a time.** Stop a local dispatcher
-  before enabling `dispatcher.deploy=true` in the chart, and stop the
-  in-cluster dispatcher before switching back to a local one for dev.
+- **Give long-lived releases separate Slack Socket Mode apps.** Slack permits
+  up to ten connections for one app and may send each payload to any connection
+  without a predictable distribution pattern. During a temporary overlap, a
+  non-owning Curie release leaves an absent approval unchanged and asks the
+  approver to retry; a retry may be needed before the owning release receives
+  the interaction. Stop the local dispatcher after testing rather than leaving
+  it competing with the in-cluster release. See
+  [Slack's multiple-connections contract](https://docs.slack.dev/apis/events-api/using-socket-mode/#using-multiple-connections).
 - **kube-router applies NetworkPolicy a few seconds after pod start.** A
   brand-new pod can see open egress for the first seconds before the policy
   lands. This is functionally irrelevant for runners (the first model call

--- a/docs/slack-local-runbook.md
+++ b/docs/slack-local-runbook.md
@@ -192,14 +192,21 @@ docker compose -f compose.release.yaml exec valkey valkey-cli -a valkeypass XLEN
 `valkeypass` is the `.env.example` default (`VALKEY_PASSWORD`); substitute your
 own if you overrode it.
 
-## One Socket Mode owner per app token
+## Shared Socket Mode apps
 
-Slack allows exactly one Socket Mode owner per app token at a time. A local
-dispatcher and a cluster dispatcher on the SAME Slack app conflict: it is either
-or per app. Stop one before starting the other. This is exactly why the compose
-service is off by default behind the profile. The cluster side states the same
-constraint: see [`operations.md`](operations.md), which says to stop a local
-dispatcher before enabling `dispatcher.deploy=true` in the chart.
+Slack allows an app to maintain up to ten Socket Mode connections and may send
+each payload to any connection, with no distribution pattern an application can
+assume ([Slack's Socket Mode documentation](https://docs.slack.dev/apis/events-api/using-socket-mode/#using-multiple-connections)).
+A local dispatcher and a cluster dispatcher can therefore connect with the same
+app token, but they do not both receive each interaction.
+
+Prefer a separate Slack app per long-lived Curie release. When two Curie
+releases temporarily share one app, an approval interaction may first reach the
+release whose API does not contain that approval. That release leaves the
+approval and card unchanged and tells the approver to try again so Slack can
+deliver a later interaction to the owner. Stop the extra dispatcher after the
+overlap; the compose dispatcher remains off by default behind the Slack profile
+to make accidental overlap less likely.
 
 ## Teardown and return to Slack-free
 


### PR DESCRIPTION
## Summary

Treat the approvals API's exact record-miss response as a release-ownership miss when multiple Curie releases share one Slack Socket Mode app. The non-owning release acknowledges without changing the approval or card and asks the approver to retry; the release whose API owns the row remains the only release that can pass the existing resolve-once compare-and-set. Two independent Bolt-app regressions cover immediate actions and note submissions, and the operations guidance now reflects Slack's arbitrary connection distribution.

## Related issue

Closes #2202

## Fix pin verification

Fix pin: apps/dispatcher/tests/test_approval_note_dialog.py::test_an_approval_record_miss_asks_for_the_owning_release

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | No plugin packaging, runner loop, ACI event, skill eval, or skill check changes. | n/a | n/a |
| local | required | Dispatcher behavior and service wiring changed. | fake | `CURIE_BIN=/home/theconnman/.cargo/shared-targets/agentos/release/curie CURIE_E2E_TIERS=local curie dev e2e-ladder` on the exact production diff later committed as `fba75e742`: `LADDER PASS (tiers: local)`. Positive: a real local product turn finalized with correlated traces. Negative/secondary: zero-export control, injected non-retryable runner failure, causal error evidence, and a successful recovery turn. After rebasing onto current `main`, `TEST_VALKEY_PORT=36379 uv run pytest -q apps/dispatcher/tests` passed 209 tests on `c4d371c29`. A second ladder run on `c4d371c29` correctly refused stale deployments in the pinned shared project; its instructed wipe was not run because the volumes belonged to another task. |
| local-release | n/a | No released binary/image identity, installer, version pin, or release-compose change. | n/a | n/a |
| cluster | n/a | No chart, RBAC, NetworkPolicy, security context, sandbox, or init-container change. | n/a | n/a |
| live provider | n/a | No model routing, model credential, token, or cost behavior changed. | n/a | n/a |
| external integration | required | Slack Socket Mode delivery and Web API card behavior changed. | live | Disposable two-release harness on the production code in `c4d371c29`: two real `uvicorn curie_api.main:app` processes used isolated databases and two real `python -m curie_dispatcher` processes shared one development Socket Mode app. Negative: Slack delivered two submissions to release B; both returned the owner-retry notice while release A stayed `pending` with zero audit rows and the card retained both actions. Positive: a later retry reached release A, persisted the exact test note, created one authorized audit row, and settled the card with zero remaining approval actions. Both dispatchers remained connected throughout. All cards, processes, databases, containers, volumes, and private runtime artifacts were removed afterward. |

- [x] Every required tier above names its exact command, the commit it ran
      against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable
      negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in
      the table.

Additional gates on `c4d371c29`:

- `curie dev verify-fix-pin c4d371c291720a8a073e9722e84dc01c0bd2afc9 apps/dispatcher/tests/test_approval_note_dialog.py::test_an_approval_record_miss_asks_for_the_owning_release` — `PINNED` (candidate green, parent red with the former `This approval no longer exists.` behavior).
- `bash scripts/check-docs.sh` — interface catalog generated and drift-free.
- Gitleaks v8.30.1 over `origin/main..HEAD` — one commit scanned, no leaks found.
- Full Python baseline before the final rebase — 5,488 passed, 13 skipped; released-upgrade and wire-lock gates passed. The post-rebase dispatcher suite above covers the only overlapping upstream area.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [x] An ADR is added under `docs/adr/` if this is an architectural decision. (No new architecture: this preserves the existing API-owned CAS boundary and handles Slack's documented distribution behavior.)
