### PR TITLE
fix: keep approval-required MCP mutations model-visible

### DIFF
--- a/docs/adr/0139-bundle-owners-classify-every-vanilla-mcp-tool.md
+++ b/docs/adr/0139-bundle-owners-classify-every-vanilla-mcp-tool.md
@@ -7,10 +7,7 @@ Status: Draft
 This Draft records the requested architecture decision backfill. It does not
 accept itself or authorize implementation. The frozen declaration and
 validation slice merged in [PR #2058](https://github.com/curie-eng/curie/pull/2058).
-The realizing runtime work is still open in
-[PR #2147](https://github.com/curie-eng/curie/pull/2147), tracked by
-[#2119](https://github.com/curie-eng/curie/issues/2119), so runtime enforcement
-must not be described as shipped on `next` yet.
+The realizing runtime work is now present on `next`.
 
 ## Context
 
@@ -138,32 +135,25 @@ runtime. Absence means that no tri state MCP classification was declared, not
 that an empty deny policy was declared. This compatibility path covers every
 bundle that predates the field.
 
-### Visibility filtering is deferred and is not authorization
+### Visibility filtering is not authorization
 
-Denied and unmatched tools may remain visible in the catalogue offered to the
-model. Hiding them can prevent futile calls and reduce model churn, but it
-cannot replace execution enforcement. The visibility work is deliberately
-deferred to [#2182](https://github.com/curie-eng/curie/issues/2182), which must
-retain the independent `PreToolUse` and `can_use_tool` refusals after filtering
-is added.
+Tools classified as `approvalRequired` remain visible in the catalogue offered
+to the model so the existing approval lifecycle can be entered at `PreToolUse`.
+Denied and unmatched tools are removed from the SDK catalogue. This filtering
+can prevent futile calls and reduce model churn, but it cannot replace
+execution enforcement: independent `PreToolUse` and `can_use_tool` refusals
+remain the authorization boundary.
 
 ## Current implementation state
 
-[PR #2058](https://github.com/curie-eng/curie/pull/2058) is merged. It added the
-optional frozen `toolPolicy` shape, canonical glob validation, shared
-classification helpers, and the enforcement identifier handshake. On current
-`next`, API intake and runner boot do not claim that identifier, so a policy
-bearing bundle is refused rather than accepted without enforcement.
-
-[PR #2147](https://github.com/curie-eng/curie/pull/2147) is open. It proposes
-the canonical runtime name mapping, the shared decision at `PreToolUse` and
-`can_use_tool`, and the API, validator, loader, and runner handshake that makes
-policy bearing bundles deployable. Until that PR or an equivalent realization
-merges, the runtime portion of this decision is not shipped on `next`.
-
-[#2182](https://github.com/curie-eng/curie/issues/2182) remains a follow-up. It
-does not block deterministic authorization in #2147 and must not be used as
-evidence that authorization is complete.
+[PR #2058](https://github.com/curie-eng/curie/pull/2058) is merged. Current
+`next` also realizes the canonical runtime name mapping; the shared decision at
+`PreToolUse` and `can_use_tool`; and the API, validator, loader, and runner
+handshake that makes policy-bearing bundles deployable. The implementation
+keeps `approvalRequired` tools model-visible until `PreToolUse`, while it
+removes denied and unmatched tools from the SDK catalogue. Independent runtime
+enforcement still rejects denied or unmatched calls, so catalogue filtering is
+not an authorization boundary.
 
 ## Consequences
 
@@ -187,8 +177,7 @@ bundles require a platform release and runner that both claim version 1
 enforcement, which turns unsafe skew into a visible deploy or boot failure.
 
 Denied tool visibility remains an efficiency and ergonomics concern, not a
-security claim. Runtime interception remains the authorization boundary even
-after #2182 lands.
+security claim. Runtime interception remains the authorization boundary.
 
 ## Alternatives considered
 
@@ -218,7 +207,7 @@ different decision path. Both interception points must share the classifier.
 
 Rejected. Visibility can reduce futile calls but does not prove that an
 attempted call cannot execute through another path or under version skew.
-Filtering remains the deferred defense in depth work in #2182.
+Filtering is defense in depth, not authorization.
 
 ### Apply unmatched denial to built-in tools
 

--- a/runner/src/curie_runner/__main__.py
+++ b/runner/src/curie_runner/__main__.py
@@ -34,6 +34,7 @@ from .approval import (
     build_approval_hook,
     build_approval_server,
     build_can_use_tool,
+    policy_disallowed_tools,
     resolve_approval_policy,
 )
 from .config import RunnerConfig
@@ -304,6 +305,11 @@ def build_runner(
             sdk_env,
         )
         observed_readonly_tools = capability.readonly_tools
+        policy_hidden_tools = (
+            policy_disallowed_tools(approval_gate, capability.observed_tools)
+            if approval_gate is not None
+            else ()
+        )
         carries_request_approval = (
             carries_explicit_action_gate or capability.has_potential_write_tool
         )
@@ -372,6 +378,7 @@ def build_runner(
             can_use_tool=(build_can_use_tool(approval_gate) if approval_gate is not None else None),
             cwd=workspace_cwd,
             web_search_enabled=web_search_enabled,
+            policy_disallowed_tools=policy_hidden_tools,
         )
 
     def factory() -> ModelSession:

--- a/runner/src/curie_runner/adapter.py
+++ b/runner/src/curie_runner/adapter.py
@@ -19,7 +19,7 @@ import contextlib
 import json
 import os
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Iterable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Protocol, cast
@@ -307,6 +307,7 @@ def build_options(
     can_use_tool: CanUseTool | None = None,
     cwd: str | None = None,
     web_search_enabled: bool = True,
+    policy_disallowed_tools: Iterable[str] = (),
 ) -> ClaudeAgentOptions:
     """Assemble ClaudeAgentOptions for the session.
 
@@ -336,6 +337,12 @@ def build_options(
     # install has always said and must keep saying.
     thinking_option: dict[str, Any] = {"thinking": cast("Any", thinking)} if thinking else {}
     cwd_option: dict[str, Any] = {"cwd": cwd} if cwd is not None else {}
+    disallowed_tools = sorted(set(policy_disallowed_tools))
+    if not web_search_enabled:
+        disallowed_tools = [
+            "WebSearch",
+            *(tool_name for tool_name in disallowed_tools if tool_name != "WebSearch"),
+        ]
     return ClaudeAgentOptions(
         plugins=plugins,
         model=model,
@@ -350,7 +357,7 @@ def build_options(
         # ``allowed_tools`` it is not a permission preauthorization. See:
         # https://platform.claude.com/docs/en/agents-and-tools/tool-use/web-search-tool
         # https://github.com/anthropics/claude-agent-sdk-python#using-tools
-        disallowed_tools=[] if web_search_enabled else ["WebSearch"],
+        disallowed_tools=disallowed_tools,
         **thinking_option,
         **cwd_option,
         system_prompt=system_prompt,

--- a/runner/src/curie_runner/approval.py
+++ b/runner/src/curie_runner/approval.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 
 import json
 import logging
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, NamedTuple
@@ -712,13 +712,13 @@ def canonical_tool_name(
 
     if not is_mcp_tool(live_tool_name):
         return None
-    for server in sorted(connector_servers or ()):
+    for server in sorted(connector_servers or (), key=lambda name: (-len(name), name)):
         prefix = connector_tool_prefix(server)
         if live_tool_name.startswith(prefix):
             tool = live_tool_name[len(prefix) :]
             return f"{server}/{tool}" if tool else None
     if bundle_name:
-        for server in sorted(mcp_servers or ()):
+        for server in sorted(mcp_servers or (), key=lambda name: (-len(name), name)):
             prefix = effective_tool_prefix(bundle_name, server)
             if live_tool_name.startswith(prefix):
                 tool = live_tool_name[len(prefix) :]
@@ -740,6 +740,27 @@ def _tool_policy_outcome(gate: ApprovalGate, tool_name: str) -> ToolPolicyDecisi
     if canonical is None:
         return ToolPolicyDecision.DENY
     return classify_tool(gate.tool_policy, canonical)
+
+
+def policy_disallowed_tools(
+    gate: ApprovalGate, observed_tools: Iterable[str]
+) -> tuple[str, ...]:
+    """Project observed policy refusals into exact SDK-visible tool names.
+
+    Catalog visibility is not authorization. This projection therefore uses
+    only the side-effect-free policy classification and never consumes a grant
+    or records a pending approval on ``gate``.
+    """
+
+    return tuple(
+        sorted(
+            {
+                tool_name
+                for tool_name in observed_tools
+                if _tool_policy_outcome(gate, tool_name) is ToolPolicyDecision.DENY
+            }
+        )
+    )
 
 
 def _decide_gate(gate: ApprovalGate, tool_name: str, tool_input: dict[str, Any]) -> _GateDecision:

--- a/runner/src/curie_runner/mcp_tool_capability.py
+++ b/runner/src/curie_runner/mcp_tool_capability.py
@@ -38,6 +38,7 @@ from mcp.client.sse import sse_client
 from mcp.client.stdio import stdio_client
 from mcp.client.streamable_http import streamable_http_client
 from mcp.shared._httpx_utils import create_mcp_http_client
+from mcp.shared.tool_name_validation import validate_tool_name
 from plugin_format import PluginManifest, resolve_manifest
 from plugin_format.approval_policy import connector_tool_prefix, effective_tool_prefix
 
@@ -56,6 +57,7 @@ class McpToolCapabilityProbe:
     tool_count: int
     failures: tuple[str, ...] = ()
     readonly_tools: frozenset[str] = frozenset()
+    observed_tools: frozenset[str] = frozenset()
 
 
 def _expand(value: str, env: Mapping[str, str]) -> str:
@@ -184,11 +186,12 @@ async def _probe_server(
     tool_prefix: str,
     plugin_dir: Path | None,
     inherited_env: Mapping[str, str],
-) -> tuple[int, bool, frozenset[str]]:
-    """Return count, write capability, and exact read-only runtime tool names."""
+) -> tuple[int, bool, frozenset[str], frozenset[str]]:
+    """Return count, write capability, and exact observed/read-only tool names."""
 
     count = 0
     has_potential_write = False
+    observed_tools: set[str] = set()
     readonly_tools: set[str] = set()
     with anyio.fail_after(_PROBE_TIMEOUT_SECONDS):
         async with _server_streams(
@@ -203,7 +206,15 @@ async def _probe_server(
                 cursor: str | None = None
                 while True:
                     result = await session.list_tools(cursor=cursor)
+                    if any(
+                        not validate_tool_name(tool.name).is_valid
+                        for tool in result.tools
+                    ):
+                        raise ValueError("MCP server returned a nonconforming tool name")
                     count += len(result.tools)
+                    observed_tools.update(
+                        f"{tool_prefix}{tool.name}" for tool in result.tools
+                    )
                     if any(
                         tool.annotations is None
                         or tool.annotations.readOnlyHint is not True
@@ -219,7 +230,12 @@ async def _probe_server(
                     cursor = result.nextCursor
                     if not cursor:
                         break
-    return count, has_potential_write, frozenset(readonly_tools)
+    return (
+        count,
+        has_potential_write,
+        frozenset(observed_tools),
+        frozenset(readonly_tools),
+    )
 
 
 async def probe_mcp_tool_capability(
@@ -238,7 +254,7 @@ async def probe_mcp_tool_capability(
     root = Path(plugin_dir) if plugin_dir is not None else None
     env = {**os.environ, **dict(inherited_env or {})}
     failures: list[str] = []
-    observations: list[tuple[int, bool, frozenset[str]]] = []
+    observations: list[tuple[int, bool, frozenset[str], frozenset[str]]] = []
 
     try:
         declared = _bundle_server_configs(root) if root is not None else []
@@ -292,11 +308,18 @@ async def probe_mcp_tool_capability(
         for name, config, cwd, tool_prefix in work:
             task_group.start_soon(inspect, name, config, cwd, tool_prefix)
 
-    tool_count = sum(count for count, _write, _readonly in observations)
-    has_write = bool(failures) or any(write for _count, write, _readonly in observations)
+    tool_count = sum(count for count, _write, _observed, _readonly in observations)
+    has_write = bool(failures) or any(
+        write for _count, write, _observed, _readonly in observations
+    )
+    observed_tools = frozenset(
+        tool
+        for _count, _write, observed, _readonly in observations
+        for tool in observed
+    )
     readonly_tools = frozenset(
         tool
-        for _count, _write, observed_readonly in observations
+        for _count, _write, _observed, observed_readonly in observations
         for tool in observed_readonly
     )
     return McpToolCapabilityProbe(
@@ -304,5 +327,6 @@ async def probe_mcp_tool_capability(
         has_potential_write_tool=has_write,
         tool_count=tool_count,
         failures=tuple(sorted(set(failures))),
+        observed_tools=observed_tools,
         readonly_tools=readonly_tools,
     )

--- a/runner/tests/fixtures/mcp_tool_capability_server.py
+++ b/runner/tests/fixtures/mcp_tool_capability_server.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 import anyio
 from mcp import Tool
@@ -17,6 +18,36 @@ async def main() -> None:
     @server.list_tools()
     async def list_tools() -> list[Tool]:
         mode = os.environ.get("CURIE_TEST_TOOL_MODE", "unknown")
+        if mode == "policy-catalog":
+            return [
+                Tool(
+                    name="read_allowed",
+                    description="Read a test value without changing external state.",
+                    inputSchema={"type": "object"},
+                    annotations=ToolAnnotations(readOnlyHint=True),
+                ),
+                Tool(
+                    name="write_approval",
+                    description="Write one test marker after approval.",
+                    inputSchema={
+                        "type": "object",
+                        "properties": {"value": {"type": "string"}},
+                        "required": ["value"],
+                    },
+                    annotations=ToolAnnotations(readOnlyHint=False),
+                ),
+                Tool(
+                    name="write_denied",
+                    description="A test write forbidden by policy.",
+                    inputSchema={"type": "object"},
+                    annotations=ToolAnnotations(readOnlyHint=False),
+                ),
+                Tool(
+                    name="write_unmatched",
+                    description="A test write omitted from policy.",
+                    inputSchema={"type": "object"},
+                ),
+            ]
         annotations = None
         if mode == "read-only":
             annotations = ToolAnnotations(readOnlyHint=True)
@@ -32,8 +63,12 @@ async def main() -> None:
         ]
 
     @server.call_tool()
-    async def call_tool(_name: str, _arguments: dict[str, object]) -> list[TextContent]:
-        return [TextContent(type="text", text="ok")]
+    async def call_tool(name: str, _arguments: dict[str, object]) -> list[TextContent]:
+        marker = os.environ.get("CURIE_TEST_CALL_MARKER")
+        if marker:
+            with Path(marker).open("a", encoding="utf-8") as output:
+                output.write(f"{name}\n")
+        return [TextContent(type="text", text=f"executed {name}")]
 
     async with stdio_server() as (read_stream, write_stream):
         await server.run(

--- a/runner/tests/test_approval.py
+++ b/runner/tests/test_approval.py
@@ -479,10 +479,14 @@ def test_build_options_permission_posture() -> None:
     assert plain.allowed_tools == []
     assert plain.permission_mode == "bypassPermissions"
     assert plain.can_use_tool is None
+    assert plain.disallowed_tools == []
     assert plain.cwd == "/workspace"
     assert plain.hooks == hooks
 
-    gate = ApprovalGate(required=frozenset({"Bash"}))
+    approval_required = "mcp__plugin_acme-bot_operations__write_approval"
+    denied = "mcp__plugin_acme-bot_operations__write_denied"
+    unmatched = "mcp__plugin_acme-bot_operations__write_unmatched"
+    gate = ApprovalGate(required=frozenset({approval_required}))
     gated = build_options(
         plugins=[],
         model=None,
@@ -491,15 +495,43 @@ def test_build_options_permission_posture() -> None:
         max_budget_usd=None,
         resume=None,
         can_use_tool=build_can_use_tool(gate),
+        policy_disallowed_tools=[unmatched, denied, unmatched],
         cwd="/workspace",
         hooks=hooks,
     )
     assert gated.tools == {"type": "preset", "preset": "claude_code"}
     assert gated.allowed_tools == []
+    assert gated.disallowed_tools == [denied, unmatched]
     assert gated.permission_mode == "default"
     assert gated.can_use_tool is not None
     assert gated.cwd == "/workspace"
     assert gated.hooks == hooks
+
+    web_search_disabled = build_options(
+        plugins=[],
+        model=None,
+        system_prompt=None,
+        max_turns=1,
+        max_budget_usd=None,
+        resume=None,
+        web_search_enabled=False,
+    )
+    assert web_search_disabled.allowed_tools == []
+    assert web_search_disabled.disallowed_tools == ["WebSearch"]
+
+    combined = build_options(
+        plugins=[],
+        model=None,
+        system_prompt=None,
+        max_turns=1,
+        max_budget_usd=None,
+        resume=None,
+        can_use_tool=build_can_use_tool(gate),
+        policy_disallowed_tools=[unmatched, "WebSearch", denied, unmatched],
+        web_search_enabled=False,
+    )
+    assert combined.allowed_tools == []
+    assert combined.disallowed_tools == ["WebSearch", denied, unmatched]
 
 
 def test_runner_config_parses_approval_required_tools() -> None:

--- a/runner/tests/test_connectors.py
+++ b/runner/tests/test_connectors.py
@@ -55,12 +55,17 @@ def _boot_options(
     config: RunnerConfig,
     *,
     potential_write: bool,
+    observed_tools: frozenset[str] | None = None,
+    readonly_tools: frozenset[str] | None = None,
 ) -> Any:
     async def probe(*_args: Any, **_kwargs: Any) -> McpToolCapabilityProbe:
+        observed = observed_tools or frozenset()
         return McpToolCapabilityProbe(
             complete=True,
             has_potential_write_tool=potential_write,
-            tool_count=1 if potential_write else 0,
+            tool_count=len(observed) or (1 if potential_write else 0),
+            observed_tools=observed,
+            readonly_tools=readonly_tools or frozenset(),
         )
 
     monkeypatch.setattr(boot, "probe_mcp_tool_capability", probe)
@@ -238,6 +243,7 @@ def _config_for(
     release: str | None = None,
     agent: str | None = None,
     namespace: str | None = None,
+    approval_grant_tool: str | None = None,
 ) -> RunnerConfig:
     """A RunnerConfig built the way a real boot builds one.
 
@@ -259,7 +265,106 @@ def _config_for(
         )
         | _SUBSTRATE_ENV
     )
+    if approval_grant_tool is not None:
+        env[BootEnv.env_key("approval_grant_tool")] = approval_grant_tool
     return RunnerConfig.from_env(env)
+
+
+def _approval_state(gate: Any) -> tuple[Any, ...]:
+    """Every mutable pending/grant value catalog projection must leave alone."""
+
+    return (
+        gate.pending_summary,
+        gate.pending_route,
+        gate.pending_gate_kind,
+        gate.pending_granted_tool,
+        gate.policy_requested,
+        gate.policy_rejected,
+        gate.policy_route,
+        gate.grant_tool,
+        tuple(sorted(gate.grantable_by_route.items())),
+        gate.publication_title,
+        gate.publication_body,
+        gate.pending_halt,
+        gate._boot_turn_seen,  # noqa: SLF001 - projection mutation is the assertion
+    )
+
+
+def test_boot_threads_only_policy_hidden_observations_without_spending_gate_state(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _bundle(
+        tmp_path,
+        mcp={"mcpServers": {"operations": {"command": "fixture-command"}}},
+    )
+    manifest_path = root / ".claude-plugin" / "plugin.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["toolPolicy"] = {
+        "enforcement": "curie/mcp-tool-policy@1",
+        "allow": ["operations/read_allowed"],
+        "approvalRequired": ["operations/write_approval"],
+        "deny": ["operations/write_denied"],
+    }
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    prefix = "mcp__plugin_b_operations__"
+    read_allowed = f"{prefix}read_allowed"
+    write_approval = f"{prefix}write_approval"
+    write_denied = f"{prefix}write_denied"
+    write_unmatched = f"{prefix}write_unmatched"
+    observed = frozenset(
+        {read_allowed, write_approval, write_denied, write_unmatched}
+    )
+
+    real_projection = boot.policy_disallowed_tools
+    projection_states: list[tuple[tuple[Any, ...], tuple[Any, ...]]] = []
+
+    def observe_projection(gate: Any, tools: frozenset[str]):
+        before = _approval_state(gate)
+        hidden = tuple(real_projection(gate, tools))
+        after = _approval_state(gate)
+        projection_states.append((before, after))
+        return hidden
+
+    monkeypatch.setattr(boot, "policy_disallowed_tools", observe_projection)
+    options = _boot_options(
+        monkeypatch,
+        _config_for(root, approval_grant_tool=write_approval),
+        potential_write=True,
+        observed_tools=observed,
+        readonly_tools=frozenset({read_allowed}),
+    )
+
+    assert set(options.disallowed_tools) == {write_denied, write_unmatched}
+    assert len(options.disallowed_tools) == 2
+    assert write_approval not in options.disallowed_tools
+    assert projection_states
+    assert all(before == after for before, after in projection_states)
+    assert projection_states[0][0][7] == write_approval
+
+
+def test_boot_with_no_policy_adds_no_observed_mcp_names_to_disallowed_tools(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _bundle(
+        tmp_path,
+        mcp={"mcpServers": {"operations": {"command": "fixture-command"}}},
+    )
+    observed = frozenset(
+        {
+            "mcp__plugin_b_operations__write_denied",
+            "mcp__plugin_b_operations__write_unmatched",
+        }
+    )
+
+    options = _boot_options(
+        monkeypatch,
+        _config_for(root),
+        potential_write=True,
+        observed_tools=observed,
+    )
+
+    assert options.disallowed_tools == []
 
 
 def test_a_scope_rendered_by_the_worker_reaches_the_mounted_connector(tmp_path: Path) -> None:

--- a/runner/tests/test_live.py
+++ b/runner/tests/test_live.py
@@ -9,8 +9,10 @@ course, and turn 2 shows a warm prompt cache
 A third live test covers the OpenRouter path, gated on ``OPENROUTER_API_KEY``.
 """
 
+import json
 import os
 import shlex
+import sys
 from pathlib import Path
 from typing import Any
 from uuid import uuid4
@@ -500,20 +502,17 @@ def test_live_structured_replay_cache_hit_and_changed_prefix_negative(tmp_path) 
 
 @pytest.mark.skipif(
     not _LIVE_REQUESTED,
-    reason="set CURIE_E2E_LIVE=1 for disposable structured-replay provider evidence",
+    reason="set CURIE_E2E_LIVE=1 for real SDK approval-catalog evidence",
 )
-def test_live_cross_runner_approval_exact_once_and_cache_observable(
-    tmp_path, monkeypatch
+def test_live_mcp_policy_catalog_approval_exact_once_and_cache_observable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A suspended real tool call resumes once, then its one-shot grant expires."""
+    """A real SDK catalog hides refusals while one-shot approval stays visible."""
 
-    from claude_agent_sdk.types import PermissionResultAllow, PermissionResultDeny
+    from claude_agent_sdk import SystemMessage
+    from curie_runner import __main__ as boot
     from curie_runner import session as session_module
-    from curie_runner.approval import (
-        ApprovalGate,
-        build_approval_hook,
-        build_can_use_tool,
-    )
+    from curie_runner.config import RunnerConfig
 
     metric_calls: list[tuple[str, float, dict[str, str] | None]] = []
     real_record_metric = session_module.record_metric
@@ -530,13 +529,236 @@ def test_live_cross_runner_approval_exact_once_and_cache_observable(
     monkeypatch.setattr(session_module, "record_metric", observe_metric)
 
     marker_file = tmp_path / "approval-executions.txt"
+    fixture = (
+        Path(__file__).parent / "fixtures" / "mcp_tool_capability_server.py"
+    ).resolve()
+    bundle = tmp_path / "approval-catalog"
+    (bundle / ".claude-plugin").mkdir(parents=True)
+    (bundle / ".claude-plugin" / "plugin.json").write_text(
+        json.dumps(
+            {
+                "name": "acme-bot",
+                "systemPrompt": (
+                    "You are a deterministic test agent. When asked to write a test "
+                    "marker, call the operations write_approval MCP tool exactly once "
+                    "with the requested value, wait for its result, and then stop."
+                ),
+                "toolPolicy": {
+                    "enforcement": "curie/mcp-tool-policy@1",
+                    "allow": ["operations/read_allowed"],
+                    "approvalRequired": ["operations/write_approval"],
+                    "deny": ["operations/write_denied"],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    (bundle / ".mcp.json").write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "operations": {
+                        "command": sys.executable,
+                        "args": [str(fixture)],
+                        "env": {
+                            "CURIE_TEST_TOOL_MODE": "policy-catalog",
+                            "CURIE_TEST_CALL_MARKER": str(marker_file),
+                        },
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    prefix = "mcp__plugin_acme-bot_operations__"
+    read_allowed = f"{prefix}read_allowed"
+    write_approval = f"{prefix}write_approval"
+    write_denied = f"{prefix}write_denied"
+    write_unmatched = f"{prefix}write_unmatched"
+    session_id = str(uuid4())
+    store = _LiveTranscriptStore()
+
+    def config_for(*, grant_tool: str | None = None) -> RunnerConfig:
+        env = {
+            "CURIE_PLUGIN_DIR": str(bundle),
+            "CURIE_SESSION_ID": session_id,
+            "CURIE_SANDBOX_ID": f"sandbox-{session_id}",
+            "CURIE_BUDGET": (
+                '{"max_output_tokens_per_run": 10000, "max_usd_per_day": 1.0}'
+            ),
+        }
+        if model := os.environ.get("CURIE_MODEL"):
+            env["CURIE_MODEL"] = model
+        if grant_tool is not None:
+            env["CURIE_APPROVAL_GRANT_TOOL"] = grant_tool
+            env["CURIE_APPROVAL_DECISION"] = "approved"
+        return RunnerConfig.from_env(env)
+
+    catalogs: list[tuple[str, ...]] = []
+
+    class CatalogObservingSession(ClaudeAgentSession):
+        def receive_turn(self):
+            upstream = super().receive_turn()
+
+            async def observe():
+                async for message in upstream:
+                    if isinstance(message, SystemMessage) and message.subtype == "init":
+                        tools = message.data.get("tools")
+                        if isinstance(tools, list):
+                            catalogs.append(tuple(str(tool) for tool in tools))
+                    yield message
+
+            return observe()
+
+    monkeypatch.setattr(boot, "ClaudeAgentSession", CatalogObservingSession)
+
+    async def drive(runner: SessionRunner, text: str, ts: str) -> Final:
+        await runner.start()
+        final: Final | None = None
+        try:
+            async for line in runner.run_turn(
+                Event(type="message", text=text, user="U0EXAMPLE", ts=ts)
+            ):
+                event = parse_ndjson_line(line)
+                if isinstance(event, Final):
+                    final = event
+        finally:
+            await runner.close()
+        assert final is not None
+        return final
+
+    blocked = boot.build_runner(config_for(), history_store=store)
+    first = anyio.run(
+        drive,
+        blocked,
+        (
+            "Write one test marker by calling write_approval exactly once with "
+            "value `approved-once`. Do not call any other tool."
+        ),
+        "1",
+    )
+    assert first.status is SessionStatus.AWAITING_APPROVAL
+    assert first.approval_summary is not None
+    assert write_approval in first.approval_summary
+    assert "approved-once" in first.approval_summary
+    assert not marker_file.exists()
+
+    # claude-agent-sdk 0.2.135 is pinned in uv.lock. Its types.py:1850-1855
+    # specifies that disallowed_tools are removed from model context, and its
+    # message_parser.py:281-284 preserves the CLI init frame as
+    # SystemMessage(subtype="init"). Inspecting that frame proves the real SDK
+    # catalog behavior rather than only asserting Curie's option construction.
+    assert catalogs
+    initial_catalog = set(catalogs[0])
+    assert {read_allowed, write_approval} <= initial_catalog
+    assert write_denied not in initial_catalog
+    assert write_unmatched not in initial_catalog
+
+    assert len(store.records) == 1
+    assert store.records[0].harness_replay is not None
+    replay, summary = build_conversation_replay(store.records)
+    assert summary is None
+    assert replay.messages[-1].role == "user"
+    assert replay.messages[-1].content[0]["type"] == "tool_result"
+
+    resumed = boot.build_runner(
+        config_for(grant_tool=write_approval),
+        conversation_replay=replay,
+    )
+
+    async def drive_resumed_turns() -> tuple[Final, Final]:
+        await resumed.start()
+        finals: list[Final] = []
+        try:
+            for text, ts in (
+                (
+                    "The prior write_approval call is approved. Retry it exactly once "
+                    "with value `approved-once`, wait for the result, and stop.",
+                    "2",
+                ),
+                (
+                    "Write another test marker by calling write_approval exactly once "
+                    "with value `duplicate`.",
+                    "3",
+                ),
+            ):
+                final: Final | None = None
+                async for line in resumed.run_turn(
+                    Event(type="message", text=text, user="U0EXAMPLE", ts=ts)
+                ):
+                    event = parse_ndjson_line(line)
+                    if isinstance(event, Final):
+                        final = event
+                assert final is not None
+                finals.append(final)
+        finally:
+            await resumed.close()
+        return finals[0], finals[1]
+
+    approved, duplicate = anyio.run(drive_resumed_turns)
+    assert approved.status is SessionStatus.DONE
+    assert marker_file.read_text(encoding="utf-8").splitlines() == [
+        "write_approval"
+    ]
+
+    cache_calls = [
+        call for call in metric_calls if call[0] == "curie.history.resume.cache_read"
+    ]
+    assert len(cache_calls) == 1
+    assert cache_calls[0][1] > 0
+    assert cache_calls[0][2] == {
+        "service.name": "curie-runner",
+        "source": "runner",
+        "cache_hit": "true",
+    }
+
+    # The projection at resumed boot must not spend the grant. The first real
+    # call consumes it; the same tool on the next turn creates a fresh pause.
+    assert duplicate.status is SessionStatus.AWAITING_APPROVAL
+    assert duplicate.approval_summary is not None
+    assert write_approval in duplicate.approval_summary
+    assert "duplicate" in duplicate.approval_summary
+    assert marker_file.read_text(encoding="utf-8").splitlines() == [
+        "write_approval"
+    ]
+
+
+@pytest.mark.skipif(
+    not _LIVE_REQUESTED,
+    reason="set CURIE_E2E_LIVE=1 for disposable structured-replay provider evidence",
+)
+def test_live_cross_runner_approval_exact_once_and_cache_observable(
+    tmp_path, monkeypatch
+) -> None:
+    """A suspended real tool call resumes once, then its one-shot grant expires."""
+    from claude_agent_sdk.types import PermissionResultAllow, PermissionResultDeny
+    from curie_runner import session as session_module
+    from curie_runner.approval import (
+        ApprovalGate,
+        build_approval_hook,
+        build_can_use_tool,
+    )
+
+    metric_calls: list[tuple[str, float, dict[str, str] | None]] = []
+    real_record_metric = session_module.record_metric
+    def observe_metric(
+        name: str,
+        value: float = 1,
+        *,
+        attributes: dict[str, str] | None = None,
+    ) -> None:
+        metric_calls.append((name, value, attributes))
+        real_record_metric(name, value, attributes=attributes)
+
+    monkeypatch.setattr(session_module, "record_metric", observe_metric)
+    marker_file = tmp_path / "approval-executions.txt"
     command = f"printf 'approved-once\\n' >> {shlex.quote(str(marker_file))}"
     system_prompt = (
         "You are a deterministic test agent. When explicitly asked to run a shell "
         "command, call Bash with that exact command once and then stop."
     )
     store = _LiveTranscriptStore()
-
     def options_for(
         gate: ApprovalGate,
         replay: tuple[ConversationMessage, ...],
@@ -561,7 +783,6 @@ def test_live_cross_runner_approval_exact_once_and_cache_observable(
             can_use_tool=build_can_use_tool(gate),
             cwd=str(tmp_path),
         )
-
     async def drive(runner: SessionRunner, text: str) -> Final:
         await runner.start()
         final: Final | None = None
@@ -576,7 +797,6 @@ def test_live_cross_runner_approval_exact_once_and_cache_observable(
             await runner.close()
         assert final is not None
         return final
-
     blocked_gate = ApprovalGate(required=frozenset({"Bash"}))
     blocked = SessionRunner(
         session_factory=lambda: ClaudeAgentSession(options_for(blocked_gate, ())),
@@ -593,7 +813,6 @@ def test_live_cross_runner_approval_exact_once_and_cache_observable(
     assert not marker_file.exists()
     assert len(store.records) == 1
     assert store.records[0].harness_replay is not None
-
     replay, summary = build_conversation_replay(store.records)
     assert summary is None
     assert replay.messages[-1].role == "user"
@@ -602,14 +821,12 @@ def test_live_cross_runner_approval_exact_once_and_cache_observable(
     allowed_commands: list[str] = []
     resumed_gate = ApprovalGate(required=frozenset({"Bash"}), grant_tool="Bash")
     permission_callback = build_can_use_tool(resumed_gate)
-
     async def observe_permission(tool_name, tool_input, context):
         decision = await permission_callback(tool_name, tool_input, context)
         if isinstance(decision, PermissionResultAllow):
             allowed_commands.append(str(tool_input.get("command") or ""))
         assert isinstance(decision, (PermissionResultAllow, PermissionResultDeny))
         return decision
-
     resumed_options = options_for(
         resumed_gate, replay.messages, replay.harness_replay
     )
@@ -647,17 +864,14 @@ def test_live_cross_runner_approval_exact_once_and_cache_observable(
         finally:
             await resumed.close()
         return finals[0], finals[1]
-
     approved, duplicate = anyio.run(drive_resumed_turns)
     assert approved.status is SessionStatus.DONE
     assert marker_file.read_text().splitlines() == ["approved-once"]
-
     # Same runner, later turn: reset() expires the one-shot grant. Asking for the
     # action again must pause without another write.
     assert duplicate.status is SessionStatus.AWAITING_APPROVAL
     assert marker_file.read_text().splitlines() == ["approved-once"]
     assert allowed_commands == []  # hook allow skips can_use_tool in the pinned SDK
-
     cache_calls = [
         call for call in metric_calls if call[0] == "curie.history.resume.cache_read"
     ]

--- a/runner/tests/test_mcp_tool_capability.py
+++ b/runner/tests/test_mcp_tool_capability.py
@@ -52,6 +52,9 @@ def test_all_tools_explicitly_read_only_proves_no_write_capability(tmp_path: Pat
     assert result.complete
     assert not result.has_potential_write_tool
     assert result.tool_count == 1
+    assert result.observed_tools == frozenset(
+        {"mcp__plugin_acme-bot_operations__inspect_or_change"}
+    )
     assert result.readonly_tools == frozenset(
         {"mcp__plugin_acme-bot_operations__inspect_or_change"}
     )
@@ -62,6 +65,9 @@ def test_explicit_write_tool_keeps_write_capability(tmp_path: Path) -> None:
 
     assert result.complete
     assert result.has_potential_write_tool
+    assert result.observed_tools == frozenset(
+        {"mcp__plugin_acme-bot_operations__inspect_or_change"}
+    )
     assert result.readonly_tools == frozenset()
 
 
@@ -70,6 +76,9 @@ def test_missing_read_only_hint_is_conservatively_write_capable(tmp_path: Path) 
 
     assert result.complete
     assert result.has_potential_write_tool
+    assert result.observed_tools == frozenset(
+        {"mcp__plugin_acme-bot_operations__inspect_or_change"}
+    )
     assert result.readonly_tools == frozenset()
 
 
@@ -100,10 +109,66 @@ def test_mixed_read_only_and_write_tools_keep_write_capability(tmp_path: Path) -
     assert result.complete
     assert result.has_potential_write_tool
     assert result.tool_count == 2
+    assert result.observed_tools == frozenset(
+        {
+            "mcp__plugin_acme-bot_inventory__inspect_or_change",
+            "mcp__plugin_acme-bot_operations__inspect_or_change",
+        }
+    )
     # Even on a mixed surface that keeps the pager, the observed read-only tool
     # remains available to the receipt classifier by its SDK-visible name.
     assert result.readonly_tools == frozenset(
         {"mcp__plugin_acme-bot_inventory__inspect_or_change"}
+    )
+
+
+def test_successful_observed_names_survive_a_sibling_probe_failure(
+    tmp_path: Path,
+) -> None:
+    root = _bundle(tmp_path, mode="policy-catalog")
+    (root / ".mcp.json").write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "inventory": {
+                        "command": sys.executable,
+                        "args": [str(_SERVER)],
+                        "env": {"CURIE_TEST_TOOL_MODE": "policy-catalog"},
+                    },
+                    "operations": {"command": str(root / "missing-server")},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    connector_name = "audit"
+    derived = {
+        connector_name: {
+            "command": sys.executable,
+            "args": [str(_SERVER)],
+            "env": {"CURIE_TEST_TOOL_MODE": "policy-catalog"},
+        }
+    }
+
+    result = anyio.run(probe_mcp_tool_capability, root, derived)
+
+    assert not result.complete
+    assert result.has_potential_write_tool
+    assert result.tool_count == 8
+    assert result.failures == ("operations",)
+    plugin_prefix = "mcp__plugin_acme-bot_inventory__"
+    connector_prefix = connector_tool_prefix(connector_name)
+    names = {"read_allowed", "write_approval", "write_denied", "write_unmatched"}
+    assert result.observed_tools == frozenset(
+        {f"{plugin_prefix}{name}" for name in names}
+        | {f"{connector_prefix}{name}" for name in names}
+    )
+    assert (
+        "mcp__plugin_acme-bot_operations__write_unmatched"
+        not in result.observed_tools
+    )
+    assert result.readonly_tools == frozenset(
+        {f"{plugin_prefix}read_allowed", f"{connector_prefix}read_allowed"}
     )
 
 
@@ -126,7 +191,6 @@ def test_successful_read_only_names_survive_a_sibling_probe_failure(
         ),
         encoding="utf-8",
     )
-
     result = _probe(root)
 
     assert not result.complete
@@ -157,6 +221,9 @@ def test_derived_connector_read_only_tool_uses_connector_runtime_prefix(
     assert result.complete
     assert not result.has_potential_write_tool
     assert result.tool_count == 1
+    assert result.observed_tools == frozenset(
+        {f"{connector_tool_prefix(connector_name)}inspect_or_change"}
+    )
     assert result.readonly_tools == frozenset(
         {f"{connector_tool_prefix(connector_name)}inspect_or_change"}
     )
@@ -175,6 +242,7 @@ def test_manifest_mcp_path_string_is_an_unknown_surface(tmp_path: Path) -> None:
     assert not result.complete
     assert result.has_potential_write_tool
     assert result.failures == ("bundle-config",)
+    assert result.observed_tools == frozenset()
     assert result.readonly_tools == frozenset()
 
 
@@ -190,6 +258,7 @@ def test_malformed_server_entry_is_an_unknown_surface(tmp_path: Path) -> None:
     assert not result.complete
     assert result.has_potential_write_tool
     assert result.failures == ("bundle-config",)
+    assert result.observed_tools == frozenset()
     assert result.readonly_tools == frozenset()
 
 
@@ -213,6 +282,7 @@ def test_unreachable_server_cannot_be_mistaken_for_read_only(tmp_path: Path) -> 
     assert not result.complete
     assert result.has_potential_write_tool
     assert result.failures == ("operations",)
+    assert result.observed_tools == frozenset()
     assert result.readonly_tools == frozenset()
 
 
@@ -225,4 +295,5 @@ def test_no_mcp_servers_is_a_complete_empty_surface(tmp_path: Path) -> None:
     assert result.complete
     assert not result.has_potential_write_tool
     assert result.tool_count == 0
+    assert result.observed_tools == frozenset()
     assert result.readonly_tools == frozenset()

--- a/runner/tests/test_tool_policy_canonical_names.py
+++ b/runner/tests/test_tool_policy_canonical_names.py
@@ -3,11 +3,15 @@
 `plugin_format.tool_policy` states the split of work outright: "Mapping canonical
 -> live SDK name is the runtime lane's job and is out of scope here." This is
 that mapping run backwards, and these tests pin the two things that make it more
-than a string split.
+than a string split, plus the specificity rule for overlapping server names.
 
 **Underscores.** Neither mount shape can be parsed by splitting on `__`, because
 a server name may contain them. The known-server sets are what disambiguate, and
 a test that only ever uses hyphenated names would pass with a naive split.
+
+**Specificity.** When more than one declared server prefix matches, the longest
+server name owns the tool. Otherwise a shorter server can shadow a more specific
+policy.
 
 **The refusal.** `None` for an `mcp__` name is not "ungoverned", it is "could not
 attribute this to a declared server". Collapsing that with "not an MCP tool" is
@@ -15,7 +19,17 @@ the fail-open the unclassified-is-denied default exists to prevent, which is why
 `is_mcp_tool` is asked separately.
 """
 
-from curie_runner.approval import canonical_tool_name, is_mcp_tool
+import anyio
+from claude_agent_sdk.types import PermissionResultDeny, ToolPermissionContext
+from curie_runner.approval import (
+    ApprovalGate,
+    build_approval_hook,
+    build_can_use_tool,
+    canonical_tool_name,
+    is_mcp_tool,
+    policy_disallowed_tools,
+)
+from plugin_format import ToolPolicy
 
 
 def _canonical(live: str, **kwargs: object) -> str | None:
@@ -64,6 +78,49 @@ def test_an_underscored_server_name_still_resolves() -> None:
         _canonical("mcp__plugin_sre-bot_my_probe__ping", mcp_servers={"my_probe"})
         == "my_probe/ping"
     )
+
+
+def test_overlapping_plugin_servers_use_the_longest_policy_name_everywhere() -> None:
+    live_short = "mcp__plugin_sre-bot_logs__read"
+    live_long = "mcp__plugin_sre-bot_logs__audit__export"
+
+    def gate() -> ApprovalGate:
+        return ApprovalGate(
+            tool_policy=ToolPolicy(
+                enforcement="curie/mcp-tool-policy@1",
+                approvalRequired=["logs__audit/export"],
+                deny=["logs/*"],
+            ),
+            bundle_name="sre-bot",
+            mcp_servers={"logs", "logs__audit"},
+            connector_servers=set(),
+        )
+
+    assert (
+        _canonical(live_long, mcp_servers={"logs", "logs__audit"})
+        == "logs__audit/export"
+    )
+    assert policy_disallowed_tools(gate(), [live_short, live_long]) == (live_short,)
+
+    hook_gate = gate()
+    hook = build_approval_hook(hook_gate)["PreToolUse"][0].hooks[0]
+    hook_result = anyio.run(
+        hook, {"tool_name": live_long, "tool_input": {}}, None, None
+    )
+    assert hook_result["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert "denied by this agent's tool policy" not in hook_result["stopReason"]
+    assert hook_gate.pending_granted_tool == live_long
+
+    callback_gate = gate()
+    callback_result = anyio.run(
+        build_can_use_tool(callback_gate),
+        live_long,
+        {},
+        ToolPermissionContext(),
+    )
+    assert isinstance(callback_result, PermissionResultDeny)
+    assert "denied by this agent's tool policy" not in callback_result.message
+    assert callback_gate.pending_granted_tool == live_long
 
 
 def test_an_underscored_tool_name_survives_intact() -> None:

--- a/runner/tests/test_tool_policy_enforcement.py
+++ b/runner/tests/test_tool_policy_enforcement.py
@@ -11,14 +11,23 @@ callback would be a policy a bundle can walk around by declaring its own
 permissions, and every other test here would still pass.
 """
 
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
 from typing import Any
 
+import anyio
 import pytest
+from claude_agent_sdk.types import PermissionResultDeny
+from curie_runner import mcp_tool_capability
 from curie_runner.approval import (
     ApprovalGate,
     build_approval_hook,
     build_can_use_tool,
+    policy_disallowed_tools,
 )
+from mcp import Tool
+from mcp.types import ToolAnnotations
 from plugin_format import ToolPolicy
 
 
@@ -45,8 +54,6 @@ def _hook_call(gate: ApprovalGate, tool_name: str) -> dict[str, Any]:
     hooks = build_approval_hook(gate)
     matcher = hooks["PreToolUse"][0]
     callback = matcher.hooks[0]
-    import anyio
-
     return anyio.run(
         callback, {"tool_name": tool_name, "tool_input": {}}, None, None
     )
@@ -59,6 +66,177 @@ def _denied(result: dict[str, Any]) -> bool:
 
 def _reason(result: dict[str, Any]) -> str:
     return (result.get("hookSpecificOutput") or {}).get("permissionDecisionReason", "")
+
+
+def _catalog_gate() -> ApprovalGate:
+    return ApprovalGate(
+        tool_policy=_policy(
+            allow=["operations/read_allowed"],
+            approval_required=["operations/write_approval"],
+            deny=["operations/write_denied"],
+        ),
+        bundle_name="acme-bot",
+        mcp_servers={"operations", "failed"},
+        connector_servers={"operations"},
+    )
+
+
+def _assert_no_approval_was_recorded(gate: ApprovalGate) -> None:
+    assert gate.pending_summary is None
+    assert gate.pending_route is None
+    assert gate.pending_gate_kind is None
+    assert gate.pending_granted_tool is None
+    assert gate.policy_requested is False
+    assert gate.policy_rejected is False
+    assert gate.policy_route is None
+    assert gate.pending_halt is False
+
+
+def _probe_advertised_tools(
+    monkeypatch: pytest.MonkeyPatch, names: list[str]
+) -> mcp_tool_capability.McpToolCapabilityProbe:
+    @asynccontextmanager
+    async def server_streams(
+        *_args: Any, **_kwargs: Any
+    ) -> AsyncIterator[tuple[object, object]]:
+        yield object(), object()
+
+    class ToolListSession:
+        def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> "ToolListSession":
+            return self
+
+        async def __aexit__(self, *_args: Any) -> None:
+            pass
+
+        async def initialize(self) -> None:
+            pass
+
+        async def list_tools(self, *, cursor: str | None) -> SimpleNamespace:
+            assert cursor is None
+            # MCP recommends this restricted alphabet but its Tool model accepts
+            # other strings. Exercise the raw server response at Curie's probe
+            # boundary. https://modelcontextprotocol.io/specification/2025-11-25/server/tools#tool-names
+            return SimpleNamespace(
+                tools=[
+                    Tool(
+                        name=name,
+                        description="Test-only MCP tool.",
+                        inputSchema={"type": "object"},
+                        annotations=ToolAnnotations(readOnlyHint=False),
+                    )
+                    for name in names
+                ],
+                nextCursor=None,
+            )
+
+    monkeypatch.setattr(mcp_tool_capability, "_server_streams", server_streams)
+    monkeypatch.setattr(mcp_tool_capability, "ClientSession", ToolListSession)
+    return anyio.run(
+        mcp_tool_capability.probe_mcp_tool_capability,
+        None,
+        {"operations": {}},
+    )
+
+
+@pytest.mark.parametrize(
+    "unsafe_name",
+    [
+        "write_denied,Bash",
+        "write_denied Bash",
+        "write_denied(Bash)",
+        "write_denied*",
+    ],
+    ids=["comma", "space", "parentheses", "wildcard"],
+)
+def test_nonconforming_mcp_tool_name_fails_catalog_probe_closed(
+    monkeypatch: pytest.MonkeyPatch, unsafe_name: str
+) -> None:
+    result = _probe_advertised_tools(monkeypatch, ["read_allowed", unsafe_name])
+
+    assert not result.complete
+    assert result.has_potential_write_tool
+    assert result.failures == ("operations",)
+    assert result.tool_count == 0
+    assert result.observed_tools == frozenset()
+    assert result.readonly_tools == frozenset()
+    assert policy_disallowed_tools(_catalog_gate(), result.observed_tools) == ()
+
+    live_name = f"mcp__operations__{unsafe_name}"
+    hook_gate = _catalog_gate()
+    assert _denied(_hook_call(hook_gate, live_name))
+    _assert_no_approval_was_recorded(hook_gate)
+
+    callback_gate = _catalog_gate()
+    callback_result = anyio.run(
+        build_can_use_tool(callback_gate), live_name, {}, None
+    )
+    assert isinstance(callback_result, PermissionResultDeny)
+    _assert_no_approval_was_recorded(callback_gate)
+
+
+def test_conforming_mcp_tool_name_punctuation_reaches_catalog_projection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    valid_names = ["write.denied", "write-denied", "write_denied"]
+    result = _probe_advertised_tools(monkeypatch, valid_names)
+    expected = {
+        f"mcp__operations__{tool_name}" for tool_name in valid_names
+    }
+
+    assert result.complete
+    assert result.has_potential_write_tool
+    assert result.failures == ()
+    assert result.tool_count == len(valid_names)
+    assert result.observed_tools == frozenset(expected)
+    assert set(policy_disallowed_tools(_catalog_gate(), result.observed_tools)) == expected
+
+
+def test_policy_disallowed_tools_project_only_denied_observed_runtime_names() -> None:
+    plugin_prefix = "mcp__plugin_acme-bot_operations__"
+    connector_prefix = "mcp__operations__"
+    suffixes = {"read_allowed", "write_approval", "write_denied", "write_unmatched"}
+    observed = frozenset(
+        {f"{plugin_prefix}{suffix}" for suffix in suffixes}
+        | {f"{connector_prefix}{suffix}" for suffix in suffixes}
+    )
+    expected_hidden = {
+        f"{plugin_prefix}write_denied",
+        f"{plugin_prefix}write_unmatched",
+        f"{connector_prefix}write_denied",
+        f"{connector_prefix}write_unmatched",
+    }
+
+    hidden = set(policy_disallowed_tools(_catalog_gate(), observed))
+
+    assert hidden == expected_hidden
+    assert all(name.startswith("mcp__") for name in hidden)
+    assert all("/" not in name and "*" not in name for name in hidden)
+    assert f"{plugin_prefix}read_allowed" not in hidden
+    assert f"{connector_prefix}read_allowed" not in hidden
+    assert f"{plugin_prefix}write_approval" not in hidden
+    assert f"{connector_prefix}write_approval" not in hidden
+
+    # A failed sibling was never observed, so catalog projection must not invent
+    # its exact SDK name. Authorization remains fail-closed independently.
+    failed_sibling = "mcp__plugin_acme-bot_failed__write_unmatched"
+    assert failed_sibling not in hidden
+    for tool_name in expected_hidden | {failed_sibling}:
+        hook_gate = _catalog_gate()
+        hook_result = _hook_call(hook_gate, tool_name)
+        assert _denied(hook_result)
+        assert "denied by this agent's tool policy" in _reason(hook_result)
+        _assert_no_approval_was_recorded(hook_gate)
+
+        callback_gate = _catalog_gate()
+        callback_result = anyio.run(
+            build_can_use_tool(callback_gate), tool_name, {}, None
+        )
+        assert isinstance(callback_result, PermissionResultDeny)
+        assert "denied by this agent's tool policy" in callback_result.message
+        _assert_no_approval_was_recorded(callback_gate)
 
 
 def test_a_denied_tool_is_refused_by_the_hook_not_only_the_callback() -> None:
@@ -134,8 +312,6 @@ def test_a_bundle_with_no_policy_is_unchanged() -> None:
 def test_the_callback_agrees_with_the_hook(tool: str) -> None:
     """Both interception points share `_decide_gate`, so they must not disagree
     -- the defect class #1852 closed for the two invocation contexts."""
-    import anyio
-
     gate = _gate(_policy(deny=["k8s-write/restart_deployment"]))
     callback = build_can_use_tool(gate)
     result = anyio.run(callback, tool, {}, None)


### PR DESCRIPTION
Fixes #2201

## Outcome

- Keep policy `approvalRequired` vanilla MCP tools in the real SDK catalog until Curie's `PreToolUse` and `can_use_tool` interceptors classify the attempted call.
- Keep explicit-deny and unmatched MCP tools out of the catalog, with both interceptors independently refusing them if attempted.
- Preserve one-shot approval semantics: the authorized resume executes once, and a later call requires a fresh approval.

## Implementation

- Retain the full set of safely validated SDK-observed MCP names alongside the read-only subset.
- Project only policy-denied/unmatched observed names into `disallowed_tools`; approval-required names remain visible.
- Match overlapping MCP server prefixes longest-first while preserving connector precedence.
- Fail the capability probe closed for SDK-invalid tool names before constructing the comma-delimited deny list.

## Regression evidence

- `CURIE_E2E_LIVE=1 uv run pytest -q runner/tests/test_live.py::test_live_mcp_policy_catalog_approval_exact_once_and_cache_observable` — passed against the real SDK and live provider (`1 passed`). It observes the SDK init catalog, proves allowed + approval-required are present, explicit-deny + unmatched are absent, proves no execution before approval, one execution after the one-shot grant, and a fresh approval on the next call.
- `uv run pytest -q runner/tests` — `855 passed, 8 skipped`.
- `uv run ruff check runner/` — passed.
- `uv run mypy` — passed across 247 source files.
- `bash scripts/check-docs.sh` — passed.
- `curie dev verify-fix-pin 835f14ca40a3321e1f72876b43c262d4e68d44aa runner/tests/test_connectors.py::test_boot_threads_only_policy_hidden_observations_without_spending_gate_state` — `PINNED` (passes on the candidate and fails after reversing it).
- Repository Python baseline static gates passed through wire tolerance. Its runtime stack start is blocked by a foreign, separately-owned Compose project holding fixed port 25432; that project was not stopped or modified.
- Direct candidate-image skill eval against the live provider passed `1/1` (`reports-a-temperature`, `plumbing_ok=0`) on runner image `sha256:4b9ad537ae0fbe9660027b8a615e92f84864c26ee53b2d2d3195a86c22ae21dc`.
- Live graded ladder on immutable candidate `835f14ca40a3321e1f72876b43c262d4e68d44aa`: https://github.com/curie-eng/curie/actions/runs/33653153723. The cluster installed healthy/live, completed a real message, passed suite parity, and reported three passing live evals; its later repeated-eval retention message timed out with the ladder's existing `#1534` quota-retention diagnosis, so the tier remains partial.
- The complete skill wrapper reaches a healthy live runner and final message, then exits at its post-boot-source-mutation/eval boundary before its approval canary. A direct eval without that harness mutation passes, but the wrapper remains red.
- Slack bot authentication, configured-channel visibility, and membership passed read-only checks. No owner/user credential is available, so an owner-authored request and authenticated approval action were not attempted; bot-authored or forged events are not counted.

## Required tiers

| Tier | State | Evidence |
| --- | --- | --- |
| skill | partial | Direct candidate-image live eval passed; complete wrapper red before its approval canary |
| local | blocked | Foreign owner holds the fixed Compose ports; the live workflow stopped in its preceding skill rung |
| cluster | partial | Healthy/live install, real message, and three live evals passed; later retention message timed out (`#1534`) |
| live provider | passed at issue seam | Real SDK catalog/approval/one-shot regression passed |
| Slack external integration | blocked | Bot transport is ready, but no owner/user credential is available for the required human interaction |

Fix pin: runner/tests/test_connectors.py::test_boot_threads_only_policy_hidden_observations_without_spending_gate_state
