### PR TITLE
fix: preserve end-to-end Langfuse correlation (#2204)

### DIFF
--- a/apps/api/alembic/versions/0039_approval_traceparent.py
+++ b/apps/api/alembic/versions/0039_approval_traceparent.py
@@ -1,0 +1,35 @@
+"""Persist private approval trace continuity (#2204).
+
+Revision ID: 0039
+Revises: 0038
+Create Date: 2026-09-02
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0039"
+down_revision: str | None = "0038"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+SCHEMA = "curie"
+TABLE = "approvals"
+
+
+def upgrade() -> None:
+    # Existing and rolling-deploy rows have no originating HTTP carrier. NULL
+    # keeps that provenance honest and makes recovery start a safe root.
+    op.add_column(
+        TABLE,
+        sa.Column("traceparent", sa.String(length=55), nullable=True),
+        schema=SCHEMA,
+    )
+
+
+def downgrade() -> None:
+    op.drop_column(TABLE, "traceparent", schema=SCHEMA)

--- a/apps/api/src/curie_api/crud.py
+++ b/apps/api/src/curie_api/crud.py
@@ -690,6 +690,7 @@ async def create_publication(
     data: PublicationCreate,
     *,
     patch: bytes,
+    traceparent: str | None = None,
 ) -> tuple[Publication, bool]:
     """Atomically create the durable approval and its private publication.
 
@@ -719,6 +720,7 @@ async def create_publication(
         reply_endpoint=data.reply_endpoint,
         reply_adapter=data.reply_adapter,
         dedupe_key=data.dedupe_key,
+        traceparent=traceparent,
         route=None,
         card_channel=data.reply_channel,
         gate_kind="permission",
@@ -949,7 +951,12 @@ async def claim_action_undo(
     return action
 
 
-async def create_approval(session: AsyncSession, data: "ApprovalRequest") -> Approval:
+async def create_approval(
+    session: AsyncSession,
+    data: "ApprovalRequest",
+    *,
+    traceparent: str | None = None,
+) -> Approval:
     """Insert a pending approval. Raises IntegrityError on a dedupe_key replay;
     the router maps that to the existing record (idempotent creation)."""
 
@@ -975,6 +982,7 @@ async def create_approval(session: AsyncSession, data: "ApprovalRequest") -> App
         reply_endpoint=data.reply_endpoint,
         reply_adapter=data.reply_adapter,
         dedupe_key=data.dedupe_key,
+        traceparent=traceparent,
         route=data.route,
         card_channel=data.card_channel,
         gate_kind=data.gate_kind,

--- a/apps/api/src/curie_api/langfuse.py
+++ b/apps/api/src/curie_api/langfuse.py
@@ -105,20 +105,20 @@ def hoist_approval_decision(
 ) -> str | None:
     """Lift the runner's approval-gate decision out of a trace, or None.
 
-    Mirrors ``hoist_sandbox_id``'s trace-then-first-observation probe. The
-    attribute is stamped on the root ``agent.run`` span rather than as a
-    provider-wide resource attribute (ADR-0076 Stone 3, #889), so it is
-    ordinarily trace-level; the observation fallback stays for the same
-    reason ``hoist_sandbox_id`` keeps it -- Langfuse's OTLP ingestion doesn't
-    guarantee which level surfaces a given span attribute. Absent for the
-    ordinary case (no approval gate was resumed this turn); no value invented.
+    Prefer trace metadata, then inspect each observation in response order.
+    The resumed ``agent.run`` span carries the attribute (ADR-0076 Stone 3,
+    #889), but a correlated trace begins at dispatcher ingress and includes
+    reply spans, so the annotated observation need not be first. Absent for
+    the ordinary case (no approval gate was resumed); no value invented.
     """
 
     hit = _probe_attr(trace, _APPROVAL_DECISION_ATTR)
     if hit:
         return hit
-    if observations:
-        return _probe_attr(observations[0], _APPROVAL_DECISION_ATTR)
+    for observation in observations:
+        hit = _probe_attr(observation, _APPROVAL_DECISION_ATTR)
+        if hit:
+            return hit
     return None
 
 

--- a/apps/api/src/curie_api/main.py
+++ b/apps/api/src/curie_api/main.py
@@ -14,8 +14,11 @@ from contextlib import asynccontextmanager
 import httpx
 import redis.asyncio as redis
 from curie_telemetry import (
+    TRACEPARENT_STREAM_FIELD,
     bootstrap_service_telemetry,
+    canonicalize_traceparent,
     configure_service_logging,
+    extract_trace_context,
     operation_span,
     record_metric,
 )
@@ -348,6 +351,20 @@ def create_app() -> FastAPI:
     @app.middleware("http")
     async def observe_http(request: Request, call_next):  # type: ignore[no-untyped-def]
         operation = _route_template(app, request)
+        inbound_traceparent = request.headers.get(TRACEPARENT_STREAM_FIELD)
+        canonical_traceparent = canonicalize_traceparent(inbound_traceparent)
+        parent = extract_trace_context(
+            {TRACEPARENT_STREAM_FIELD: canonical_traceparent}
+            if canonical_traceparent is not None
+            else {}
+        )
+        diagnostic = (
+            "trace.context.missing"
+            if inbound_traceparent is None
+            else "trace.context.malformed"
+            if canonical_traceparent is None
+            else None
+        )
         active_attributes = {
             "service.name": "curie-api",
             "operation": operation,
@@ -361,8 +378,11 @@ def create_app() -> FastAPI:
             with operation_span(
                 "http.server.request",
                 kind=SpanKind.SERVER,
+                parent=parent,
                 attributes=active_attributes,
             ) as span:
+                if diagnostic is not None:
+                    span.add_event(diagnostic)
                 response = await call_next(request)
                 status_code = response.status_code
                 if status_code >= 500 and hasattr(span, "set_status"):

--- a/apps/api/src/curie_api/models.py
+++ b/apps/api/src/curie_api/models.py
@@ -18,6 +18,7 @@ from sqlalchemy import (
     ForeignKey,
     Index,
     LargeBinary,
+    String,
     Text,
     UniqueConstraint,
     func,
@@ -392,6 +393,11 @@ class Approval(Base):
     # Idempotency: the triggering event id. A reclaimed/redelivered turn that
     # re-requests the same approval adopts the existing row instead of forking.
     dedupe_key: Mapped[str] = mapped_column(unique=True)
+    # Private W3C carrier for the worker turn that created this record. It is
+    # deliberately absent from every request/response DTO: the authenticated
+    # ingress route derives it from the HTTP header, and terminal/recovery paths
+    # use it only to reconnect telemetry after the human pause.
+    traceparent: Mapped[str | None] = mapped_column(String(55), default=None)
     status: Mapped[str] = mapped_column(server_default=ApprovalStatus.pending, index=True)
     # Optional SLA: past this instant the record can no longer be approved or
     # rejected; a resolve attempt flips it to expired instead.

--- a/apps/api/src/curie_api/resumequeue.py
+++ b/apps/api/src/curie_api/resumequeue.py
@@ -19,12 +19,37 @@ from typing import Any
 
 import redis.asyncio as redis
 from aci_protocol import STREAM_PAYLOAD_FIELD, QueuedTurn, ReplyHandle, TurnSource
-from curie_telemetry import inject_trace_context, operation_span, record_metric
+from curie_telemetry import (
+    TRACEPARENT_STREAM_FIELD,
+    canonicalize_traceparent,
+    extract_trace_context,
+    inject_trace_context,
+    operation_span,
+    record_metric,
+)
+from opentelemetry.context import Context
 from opentelemetry.trace import SpanKind, StatusCode
 from redis.typing import EncodableT
 
 from .config import get_settings
 from .models import Approval, ApprovalStatus
+
+
+def approval_trace_context(approval: Approval) -> Context:
+    """Return the approval's private W3C parent, or an explicit clean root.
+
+    Rows created before the carrier migration and manually malformed values are
+    intentionally indistinguishable here: neither may inherit an ambient HTTP
+    click or background-loop span by accident.
+    """
+
+    traceparent = canonicalize_traceparent(getattr(approval, "traceparent", None))
+    carrier = (
+        {TRACEPARENT_STREAM_FIELD: traceparent}
+        if traceparent is not None
+        else {}
+    )
+    return extract_trace_context(carrier)
 
 
 def resume_event_id(approval_id: object) -> str:
@@ -238,13 +263,16 @@ class ResumeQueue:
         # graveyard.
         self._dead_letter_stream = dead_letter_stream or f"{self._stream}:dead"
 
-    async def enqueue(self, turn: QueuedTurn) -> str:
+    async def enqueue(
+        self, turn: QueuedTurn, *, parent: Context | None = None
+    ) -> str:
         carrier: dict[str, str] = {STREAM_PAYLOAD_FIELD: turn.model_dump_json()}
         stream_id: Any = None
         error: Exception | None = None
         with operation_span(
             "curie.queue.enqueue",
             kind=SpanKind.PRODUCER,
+            parent=parent,
             attributes={"service.name": "curie-api", "source": "api"},
         ) as span:
             inject_trace_context(carrier)

--- a/apps/api/src/curie_api/resumereconciler.py
+++ b/apps/api/src/curie_api/resumereconciler.py
@@ -70,7 +70,12 @@ from pydantic import ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from . import crud
-from .resumequeue import ResumeQueue, parse_resume_event_id, resume_turn_for
+from .resumequeue import (
+    ResumeQueue,
+    approval_trace_context,
+    parse_resume_event_id,
+    resume_turn_for,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -210,7 +215,9 @@ class ResumeReconciler:
                             # exit the txn block cleanly, releasing any lock.
                             continue
                         turn = resume_turn_for(approval)
-                        await self._resume_queue.enqueue(turn)
+                        await self._resume_queue.enqueue(
+                            turn, parent=approval_trace_context(approval)
+                        )
                         approval.resumed_at = datetime.now(UTC).replace(tzinfo=None)
                     # session.begin() committed here, releasing the row lock.
                 except Exception:  # noqa: BLE001

--- a/apps/api/src/curie_api/routers/approvals.py
+++ b/apps/api/src/curie_api/routers/approvals.py
@@ -17,8 +17,13 @@ import logging
 import uuid
 from datetime import UTC, datetime, timedelta
 
-from curie_telemetry import operation_span, record_metric
-from fastapi import APIRouter, Depends, HTTPException, Response, status
+from curie_telemetry import (
+    TRACEPARENT_STREAM_FIELD,
+    canonicalize_traceparent,
+    operation_span,
+    record_metric,
+)
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from opentelemetry.trace import SpanKind
 from sqlalchemy.exc import IntegrityError
 
@@ -29,7 +34,11 @@ from ..authorizer import authorize_approval
 from ..config import get_settings
 from ..deps import ApproverSetSelectorDep, ResumeQueueDep, SessionDep
 from ..models import Approval, ApprovalStatus
-from ..resumequeue import build_expiry_resume_turn, build_resume_turn
+from ..resumequeue import (
+    approval_trace_context,
+    build_expiry_resume_turn,
+    build_resume_turn,
+)
 from ..schemas import (
     ApprovalAuditOut,
     ApprovalOut,
@@ -93,7 +102,10 @@ def _expired(approval: Approval) -> bool:
     dependencies=[Depends(require_api_key)],
 )
 async def create_approval(
-    data: ApprovalRequestBody, session: SessionDep, response: Response
+    data: ApprovalRequestBody,
+    request: Request,
+    session: SessionDep,
+    response: Response,
 ) -> ApprovalOut:
     """Create a pending approval; idempotent on ``dedupe_key``.
 
@@ -102,8 +114,11 @@ async def create_approval(
     one human decision.
     """
 
+    traceparent = canonicalize_traceparent(
+        request.headers.get(TRACEPARENT_STREAM_FIELD)
+    )
     try:
-        approval = await crud.create_approval(session, data)
+        approval = await crud.create_approval(session, data, traceparent=traceparent)
     except IntegrityError as exc:
         await session.rollback()
         existing = await crud.get_approval_by_dedupe_key(session, data.dedupe_key)
@@ -187,6 +202,7 @@ async def resolve_approval(
     approval = await crud.get_approval(session, approval_id)
     if approval is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "approval not found")
+    stored_parent = approval_trace_context(approval)
 
     # The route binding is read fresh at resolve time (#420), so revoking an
     # approver takes effect on the next click rather than at the next restart.
@@ -235,6 +251,7 @@ async def resolve_approval(
         with operation_span(
             "curie.approval.expire",
             kind=SpanKind.INTERNAL,
+            parent=stored_parent,
             attributes={
                 "service.name": "curie-api",
                 "operation": "expire",
@@ -277,7 +294,9 @@ async def resolve_approval(
             # redelivery of an already-finished turn re-running; it is the CAS,
             # not the shared key, that keeps this wakeup single.
             try:
-                await resume_queue.enqueue(build_expiry_resume_turn(expired))
+                await resume_queue.enqueue(
+                    build_expiry_resume_turn(expired), parent=stored_parent
+                )
                 # Enqueue-first-then-mark (#418): only a wake that reached the
                 # stream is written off, so a failure below leaves resumed_at
                 # NULL and the reconciler re-enqueues it past its grace horizon.
@@ -327,6 +346,7 @@ async def resolve_approval(
     with operation_span(
         "curie.approval.resolve",
         kind=SpanKind.INTERNAL,
+        parent=stored_parent,
         attributes={
             "service.name": "curie-api",
             "operation": "resolve",
@@ -386,7 +406,9 @@ async def resolve_approval(
     # a 200 would silently strand the suspended session -- re-raise instead, so the
     # failure surfaces as a 500 the caller can see (the CAS/audit already committed).
     try:
-        stream_id = await resume_queue.enqueue(build_resume_turn(claimed))
+        stream_id = await resume_queue.enqueue(
+            build_resume_turn(claimed), parent=stored_parent
+        )
     except Exception:  # noqa: BLE001
         logger.warning(
             "approval %s %s by %s; resume enqueue failed, reconciler will retry",

--- a/apps/api/src/curie_api/routers/hooks.py
+++ b/apps/api/src/curie_api/routers/hooks.py
@@ -47,7 +47,14 @@ from aci_protocol import (
     TurnSource,
     parse_queued_turn,
 )
+from curie_telemetry import (
+    TRACEPARENT_STREAM_FIELD,
+    inject_trace_context,
+    operation_span,
+    record_metric,
+)
 from fastapi import APIRouter, Header, HTTPException, Request, Response, status
+from opentelemetry.trace import SpanKind, StatusCode
 from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.orm import selectinload
@@ -411,16 +418,70 @@ async def ingest_hook(
                     headers={"Retry-After": str(settings.hook_backlog_window_s)},
                 )
             turn = _mint_turn(agent, binding, hook, event_id, raw, partition=partition)
-            enqueued, current = await enqueue_owned(
-                client,
-                key=key,
-                stream=settings.runs_stream,
-                owner=owner,
-                payload=turn.model_dump_json(),
-                payload_field=STREAM_PAYLOAD_FIELD,
-                lease_s=settings.channel_delivery_lease_s,
-            )
+            carrier: dict[str, str] = {}
+            enqueue_error: Exception | None = None
+            enqueue_result: tuple[bool, str] | None = None
+            with operation_span(
+                "curie.queue.enqueue",
+                kind=SpanKind.PRODUCER,
+                attributes={"service.name": "curie-api", "source": "api"},
+            ) as span:
+                inject_trace_context(carrier)
+                try:
+                    enqueue_result = await enqueue_owned(
+                        client,
+                        key=key,
+                        stream=settings.runs_stream,
+                        owner=owner,
+                        payload=turn.model_dump_json(),
+                        payload_field=STREAM_PAYLOAD_FIELD,
+                        lease_s=settings.channel_delivery_lease_s,
+                        transport_field=(
+                            TRACEPARENT_STREAM_FIELD
+                            if TRACEPARENT_STREAM_FIELD in carrier
+                            else None
+                        ),
+                        transport_value=carrier.get(TRACEPARENT_STREAM_FIELD),
+                    )
+                except Exception as exc:
+                    enqueue_error = exc
+                    span.set_status(StatusCode.ERROR)
+                    span.add_event("queue.enqueue.failed", {"outcome": "failure"})
+                else:
+                    assert enqueue_result is not None
+                    span.add_event(
+                        "queue.enqueued" if enqueue_result[0] else "queue.duplicate",
+                        {"outcome": "success" if enqueue_result[0] else "pending"},
+                    )
+            if enqueue_error is not None:
+                record_metric(
+                    "curie.queue.enqueue",
+                    attributes={
+                        "service.name": "curie-api",
+                        "source": "api",
+                        "outcome": "failure",
+                    },
+                )
+                raise enqueue_error
+            assert enqueue_result is not None
+            enqueued, current = enqueue_result
             if enqueued:
+                record_metric(
+                    "curie.queue.enqueue",
+                    attributes={
+                        "service.name": "curie-api",
+                        "source": "api",
+                        "outcome": "success",
+                    },
+                )
+                record_metric(
+                    "curie.turn.accepted",
+                    attributes={
+                        "service.name": "curie-api",
+                        "source": "api",
+                        "outcome": "accepted",
+                    },
+                )
                 # The conversation id is here because it is the operator's only
                 # server-side record of which thread a delivery landed on. There
                 # is no verb that resets every partition of one hook, so a

--- a/apps/api/src/curie_api/routers/publications.py
+++ b/apps/api/src/curie_api/routers/publications.py
@@ -6,7 +6,8 @@ GitHub side effects belong to the trusted worker publication reconciler.
 
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException, Response, status
+from curie_telemetry import TRACEPARENT_STREAM_FIELD, canonicalize_traceparent
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from starlette.concurrency import run_in_threadpool
 
 from .. import crud
@@ -38,6 +39,7 @@ internal_router = APIRouter(
 )
 async def create_publication(
     data: PublicationCreate,
+    request: Request,
     session: SessionDep,
     response: Response,
 ) -> PublicationOut:
@@ -51,8 +53,16 @@ async def create_publication(
             status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
             f"publication patch exceeds the {patch_limit_bytes}-byte limit",
         )
+    traceparent = canonicalize_traceparent(
+        request.headers.get(TRACEPARENT_STREAM_FIELD)
+    )
     try:
-        publication, created = await crud.create_publication(session, data, patch=patch)
+        publication, created = await crud.create_publication(
+            session,
+            data,
+            patch=patch,
+            traceparent=traceparent,
+        )
     except crud.PublicationReplayConflict as exc:
         raise HTTPException(status.HTTP_409_CONFLICT, str(exc)) from exc
     except LookupError as exc:

--- a/apps/api/src/curie_api/sweeper.py
+++ b/apps/api/src/curie_api/sweeper.py
@@ -51,7 +51,11 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from . import crud
 from .config import get_settings
-from .resumequeue import ResumeQueue, build_expiry_resume_turn
+from .resumequeue import (
+    ResumeQueue,
+    approval_trace_context,
+    build_expiry_resume_turn,
+)
 
 logger = logging.getLogger(__name__)
 _monotonic = time.monotonic
@@ -104,18 +108,21 @@ async def sweep_expired_approvals(
 
     now = now or datetime.now(UTC).replace(tzinfo=None)
     lapsed = await crud.list_expired_pending_approvals(session, now=now, limit=limit)
-    # Read the ids into plain values up front: the per-record rollback below
-    # expires every ORM instance in this shared session, so reading record.id
-    # lazily in a later iteration would trigger an implicit reload (MissingGreenlet
-    # under the async session).
-    approval_ids = [record.id for record in lapsed]
+    # Read ids and private parents into plain values up front: the per-record
+    # rollback below expires every ORM instance in this shared session, so
+    # reading record fields lazily in a later iteration would trigger an
+    # implicit reload (MissingGreenlet under the async session).
+    approval_work = [
+        (record.id, approval_trace_context(record)) for record in lapsed
+    ]
 
     flipped = 0
-    for approval_id in approval_ids:
+    for approval_id, stored_parent in approval_work:
         try:
             with operation_span(
                 "curie.approval.expire",
                 kind=SpanKind.INTERNAL,
+                parent=stored_parent,
                 attributes={
                     "service.name": "curie-api",
                     "operation": "expire",
@@ -140,7 +147,9 @@ async def sweep_expired_approvals(
             if expired.purpose == "publication":
                 flipped += 1
                 continue
-            stream_id = await resume_queue.enqueue(build_expiry_resume_turn(expired))
+            stream_id = await resume_queue.enqueue(
+                build_expiry_resume_turn(expired), parent=stored_parent
+            )
             flipped += 1
             # Enqueue-first-then-mark: only a wake that actually reached the
             # stream is written off. The mark's ``resumed_at IS NULL`` guard

--- a/apps/api/tests/test_approval_decision_hoist.py
+++ b/apps/api/tests/test_approval_decision_hoist.py
@@ -45,6 +45,19 @@ def test_hoist_prefers_trace_over_observation() -> None:
     assert hoist_approval_decision(trace, observations) == "approved"
 
 
+def test_hoist_from_later_resume_observation_in_correlated_trace() -> None:
+    # The dispatcher-rooted trace includes spans before and after agent.run.
+    # Observation ordering cannot decide whether the resume is visible.
+    observations = [
+        {"id": "reply", "name": "curie.reply.update"},
+        {"id": "ingress", "metadata": {"gen_ai.approval.decision": ""}},
+        {"id": "invalid", "metadata": {"gen_ai.approval.decision": False}},
+        {"id": "resume", "metadata": {"gen_ai.approval.decision": "approved"}},
+    ]
+    assert hoist_approval_decision({"id": "t1"}, observations) == "approved"
+    assert hoist_approval_decision({"id": "t1"}, observations[:-1]) is None
+
+
 def test_hoist_returns_none_for_an_ordinary_turn() -> None:
     # No approval was resumed this turn -- the ordinary, most common case.
     trace = {"id": "t1", "metadata": {"other": "x"}}

--- a/apps/api/tests/test_approvals.py
+++ b/apps/api/tests/test_approvals.py
@@ -50,12 +50,16 @@ from curie_telemetry import (
     operation_span,
     record_metric,
 )
+from curie_telemetry.tracing import configure_tracer_provider
 from curie_test_support.valkey import (
     connect_or_skip,
 )
 from fastapi.testclient import TestClient
 from opentelemetry import context as otel_context
 from opentelemetry import trace
+from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags, TraceState
 from sqlalchemy import text
 from sqlalchemy.exc import IntegrityError
@@ -66,6 +70,10 @@ from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 ALEMBIC_DIR = Path(__file__).resolve().parents[1] / "alembic"
 _TRACE_ID = int("2123456789abcdef0123456789abcdef", 16)
 _SPAN_ID = int("2123456789abcdef", 16)
+_TRACEPARENT = "00-2123456789abcdef0123456789abcdef-2123456789abcdef-01"
+_CLICK_TRACE_ID = int("6123456789abcdef0123456789abcdef", 16)
+_CLICK_SPAN_ID = int("6123456789abcdef", 16)
+_CLICK_TRACEPARENT = "00-6123456789abcdef0123456789abcdef-6123456789abcdef-01"
 
 
 @asynccontextmanager
@@ -82,6 +90,25 @@ async def _remote_parent() -> AsyncIterator[None]:
         yield
     finally:
         otel_context.detach(token)
+
+
+@contextmanager
+def _captured_approval_spans() -> Iterator[InMemorySpanExporter]:
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    configure_tracer_provider(provider)
+    try:
+        yield exporter
+    finally:
+        configure_tracer_provider(None)
+        provider.shutdown()
+
+
+def _span_named(exporter: InMemorySpanExporter, name: str) -> ReadableSpan:
+    matches = [span for span in exporter.get_finished_spans() if span.name == name]
+    assert len(matches) == 1, [(span.name, span.context.trace_id) for span in matches]
+    return matches[0]
 
 
 @pytest.fixture
@@ -288,6 +315,28 @@ def _read_reply_placeholder(approval_id: str) -> str | None:
     return asyncio.run(_run())
 
 
+def _read_approval_traceparent(approval_id: str) -> str | None:
+    """Read the private carrier directly; it must never enter ApprovalOut."""
+
+    async def _run() -> str | None:
+        engine = create_async_engine(get_settings().database_url)
+        try:
+            async with engine.connect() as conn:
+                result = await conn.execute(
+                    text(
+                        "SELECT traceparent FROM curie.approvals WHERE id = :id"
+                    ),
+                    {"id": uuid.UUID(approval_id)},
+                )
+                row = result.first()
+                assert row is not None
+                return row[0]
+        finally:
+            await engine.dispose()
+
+    return asyncio.run(_run())
+
+
 def test_resolve_endpoint_stays_200_when_enqueue_fails(
     approvals_client: TestClient,
     auth_headers: dict[str, str],
@@ -334,6 +383,68 @@ def test_resolve_endpoint_stays_200_when_enqueue_fails(
     )
     assert retry.status_code == 409
     assert valkey.xrange(runs_stream) == []
+
+
+def test_failed_inline_enqueue_then_reconciler_keeps_the_stored_parent(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    valkey: redis.Redis,
+    runs_stream: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created = approvals_client.post(
+        "/approvals",
+        json=_payload(),
+        headers={**auth_headers, "traceparent": _TRACEPARENT},
+    ).json()
+    queue = approvals_client.app.state.resume_queue
+    original_enqueue = queue.enqueue
+
+    async def _boom(_turn: Any, **_kwargs: Any) -> str:
+        raise RuntimeError("valkey unreachable")
+
+    monkeypatch.setattr(queue, "enqueue", _boom)
+    resolved = approvals_client.post(
+        f"/approvals/{created['id']}/resolve",
+        json={"decision": "approved"},
+        headers=_chat_resolve_headers(
+            created["id"],
+            "U0APPROVER1",
+            "C1",
+            base={**auth_headers, "traceparent": _CLICK_TRACEPARENT},
+        ),
+    )
+    assert resolved.status_code == 200, resolved.text
+    assert valkey.xrange(runs_stream) == []
+    assert _read_resumed_at(created["id"]) is None
+    monkeypatch.setattr(queue, "enqueue", original_enqueue)
+
+    async def _recover() -> int:
+        async with _sweeper_stack(runs_stream) as (sessionmaker, resume_queue, _client):
+            reconciler = ResumeReconciler(
+                sessionmaker,
+                resume_queue,
+                interval_seconds=30,
+                grace_seconds=0,
+                batch_limit=100,
+            )
+            return await reconciler.reconcile_once()
+
+    with _captured_approval_spans() as exporter:
+        assert asyncio.run(_recover()) == 1
+
+    enqueue = _span_named(exporter, "curie.queue.enqueue")
+    assert enqueue.context.trace_id == _TRACE_ID
+    assert enqueue.parent is not None and enqueue.parent.span_id == _SPAN_ID
+    entries = valkey.xrange(runs_stream)
+    assert len(entries) == 1
+    carried = trace.get_current_span(
+        extract_trace_context(entries[0][1])
+    ).get_span_context()
+    assert carried.trace_id == _TRACE_ID
+    assert carried.span_id == enqueue.context.span_id
+    assert _read_resumed_at(created["id"]) is not None
 
 
 @pytest.fixture
@@ -443,21 +554,21 @@ def test_resume_queue_injects_traceparent_adjacent_to_unchanged_payload(
     """Approval resume uses the same transport carrier without widening the DTO."""
 
     created = approvals_client.post(
-        "/approvals", json=_payload(), headers=auth_headers
+        "/approvals",
+        json=_payload(),
+        headers={**auth_headers, "traceparent": _TRACEPARENT},
     ).json()
 
-    async def _resolve_with_parent() -> Any:
-        async with _remote_parent():
-            return await asyncio.to_thread(
-                approvals_client.post,
-                f"/approvals/{created['id']}/resolve",
-                json={"decision": "approved"},
-                headers=_chat_resolve_headers(
-                    created["id"], "U9", "C1", base=auth_headers
-                ),
-            )
-
-    resolved = asyncio.run(_resolve_with_parent())
+    resolved = approvals_client.post(
+        f"/approvals/{created['id']}/resolve",
+        json={"decision": "approved"},
+        headers=_chat_resolve_headers(
+            created["id"],
+            "U9",
+            "C1",
+            base={**auth_headers, "traceparent": _CLICK_TRACEPARENT},
+        ),
+    )
     assert resolved.status_code == 200, resolved.text
 
     entries = valkey.xrange(runs_stream)
@@ -471,6 +582,144 @@ def test_resume_queue_injects_traceparent_adjacent_to_unchanged_payload(
     assert parent.is_valid is True
     assert parent.is_remote is True
     assert parent.trace_id == _TRACE_ID
+
+
+def test_create_privately_persists_only_the_first_inbound_carrier(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+) -> None:
+    """The authenticated HTTP header is metadata; body and replay are not authority."""
+
+    payload = _payload(traceparent=_CLICK_TRACEPARENT)
+    created = approvals_client.post(
+        "/approvals",
+        json=payload,
+        headers={**auth_headers, "traceparent": _TRACEPARENT},
+    )
+    assert created.status_code == 201, created.text
+    body = created.json()
+    assert "traceparent" not in body
+    assert _read_approval_traceparent(body["id"]) == _TRACEPARENT
+
+    replayed = approvals_client.post(
+        "/approvals",
+        json=payload,
+        headers={**auth_headers, "traceparent": _CLICK_TRACEPARENT},
+    )
+    assert replayed.status_code == 200, replayed.text
+    assert replayed.json()["id"] == body["id"]
+    assert "traceparent" not in replayed.json()
+    assert _read_approval_traceparent(body["id"]) == _TRACEPARENT
+
+    listed = approvals_client.get("/approvals", headers=auth_headers).json()
+    got = approvals_client.get(
+        f"/approvals/{body['id']}", headers=auth_headers
+    ).json()
+    assert all("traceparent" not in row for row in listed)
+    assert "traceparent" not in got
+
+
+@pytest.mark.parametrize("carrier", [None, "not-w3c", "x" * 1024])
+def test_create_with_missing_or_malformed_carrier_stores_a_safe_null(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    carrier: str | None,
+) -> None:
+    headers = dict(auth_headers)
+    if carrier is not None:
+        headers["traceparent"] = carrier
+    created = approvals_client.post("/approvals", json=_payload(), headers=headers)
+    assert created.status_code == 201, created.text
+    assert _read_approval_traceparent(created.json()["id"]) is None
+
+
+@pytest.mark.parametrize("decision", ["approved", "rejected"])
+def test_terminal_resolution_and_resume_parent_to_the_stored_turn(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    valkey: redis.Redis,
+    runs_stream: str,
+    decision: str,
+) -> None:
+    created = approvals_client.post(
+        "/approvals",
+        json=_payload(),
+        headers={**auth_headers, "traceparent": _TRACEPARENT},
+    ).json()
+
+    with _captured_approval_spans() as exporter:
+        resolved = approvals_client.post(
+            f"/approvals/{created['id']}/resolve",
+            json={"decision": decision},
+            headers=_chat_resolve_headers(
+                created["id"],
+                "U0APPROVER1",
+                "C1",
+                base={**auth_headers, "traceparent": _CLICK_TRACEPARENT},
+            ),
+        )
+
+    assert resolved.status_code == 200, resolved.text
+    server = _span_named(exporter, "http.server.request")
+    transition = _span_named(exporter, "curie.approval.resolve")
+    enqueue = _span_named(exporter, "curie.queue.enqueue")
+    assert server.context.trace_id == _CLICK_TRACE_ID
+    assert server.parent is not None and server.parent.span_id == _CLICK_SPAN_ID
+    for span in (transition, enqueue):
+        assert span.context.trace_id == _TRACE_ID
+        assert span.parent is not None and span.parent.span_id == _SPAN_ID
+
+    entries = valkey.xrange(runs_stream)
+    assert len(entries) == 1
+    resumed_parent = trace.get_current_span(
+        extract_trace_context(entries[0][1])
+    ).get_span_context()
+    assert resumed_parent.trace_id == _TRACE_ID
+    assert resumed_parent.span_id == enqueue.context.span_id
+
+
+def test_late_expiry_transition_and_resume_parent_to_the_stored_turn(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    valkey: redis.Redis,
+    runs_stream: str,
+) -> None:
+    created = approvals_client.post(
+        "/approvals",
+        json=_payload(expires_in_seconds=1),
+        headers={**auth_headers, "traceparent": _TRACEPARENT},
+    ).json()
+    time.sleep(1.1)
+
+    with _captured_approval_spans() as exporter:
+        expired = approvals_client.post(
+            f"/approvals/{created['id']}/resolve",
+            json={"decision": "approved"},
+            headers=_chat_resolve_headers(
+                created["id"],
+                "U0APPROVER1",
+                "C1",
+                base={**auth_headers, "traceparent": _CLICK_TRACEPARENT},
+            ),
+        )
+
+    assert expired.status_code == 410, expired.text
+    transition = _span_named(exporter, "curie.approval.expire")
+    enqueue = _span_named(exporter, "curie.queue.enqueue")
+    for span in (transition, enqueue):
+        assert span.context.trace_id == _TRACE_ID
+        assert span.parent is not None and span.parent.span_id == _SPAN_ID
+    entries = valkey.xrange(runs_stream)
+    assert len(entries) == 1
+    resumed_parent = trace.get_current_span(
+        extract_trace_context(entries[0][1])
+    ).get_span_context()
+    assert resumed_parent.trace_id == _TRACE_ID
+    assert resumed_parent.span_id == enqueue.context.span_id
 
 
 def test_create_get_list_round_trip(
@@ -1293,6 +1542,46 @@ def test_sweeper_expires_lapsed_pending_and_enqueues_resume_turn(
 
     assert asyncio.run(_reconcile()) == 0
     assert len(valkey.xrange(runs_stream)) == 1
+
+
+def test_sweeper_transition_and_resume_use_the_stored_turn_parent(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    valkey: redis.Redis,
+    runs_stream: str,
+) -> None:
+    created = approvals_client.post(
+        "/approvals",
+        json=_payload(expires_in_seconds=1),
+        headers={**auth_headers, "traceparent": _TRACEPARENT},
+    ).json()
+
+    async def _sweep() -> int:
+        async with _sweeper_stack(runs_stream) as (sessionmaker, queue, _client):
+            async with sessionmaker() as session:
+                return await sweep_expired_approvals(
+                    session, queue, now=_naive_utc(2)
+                )
+
+    with _captured_approval_spans() as exporter:
+        assert asyncio.run(_sweep()) == 1
+
+    transition = _span_named(exporter, "curie.approval.expire")
+    enqueue = _span_named(exporter, "curie.queue.enqueue")
+    for span in (transition, enqueue):
+        assert span.context.trace_id == _TRACE_ID
+        assert span.parent is not None and span.parent.span_id == _SPAN_ID
+    entries = valkey.xrange(runs_stream)
+    assert len(entries) == 1
+    assert json.loads(entries[0][1]["payload"])["event_id"] == (
+        f"approval-{created['id']}-resolved"
+    )
+    carried = trace.get_current_span(
+        extract_trace_context(entries[0][1])
+    ).get_span_context()
+    assert carried.trace_id == _TRACE_ID
+    assert carried.span_id == enqueue.context.span_id
 
 
 def test_sweeper_ignores_unexpired_and_unbounded_records(

--- a/apps/api/tests/test_approvals.py
+++ b/apps/api/tests/test_approvals.py
@@ -1892,13 +1892,13 @@ def test_sweeper_isolates_a_failing_record(
             orig = queue.enqueue
             calls = {"n": 0}
 
-            async def _flaky_enqueue(turn: QueuedTurn) -> str:
+            async def _flaky_enqueue(turn: QueuedTurn, **kwargs: Any) -> str:
                 # Raise on the first record's enqueue (a Valkey blip), then let
                 # every later record enqueue for real.
                 calls["n"] += 1
                 if calls["n"] == 1:
                     raise RuntimeError("valkey down")
-                return await orig(turn)
+                return await orig(turn, **kwargs)
 
             monkeypatch.setattr(queue, "enqueue", _flaky_enqueue)
             async with sessionmaker() as session:

--- a/apps/api/tests/test_channels.py
+++ b/apps/api/tests/test_channels.py
@@ -634,12 +634,12 @@ def test_channel_ingress_injects_traceparent_adjacent_to_unchanged_payload(
         address="trace@example.test",
     )
 
-    with _remote_parent():
-        response = _post_turn(
-            channels_client,
-            token,
-            _turn("email", "trace@example.test"),
-        )
+    response = _post_turn(
+        channels_client,
+        token,
+        _turn("email", "trace@example.test"),
+        headers={TRACEPARENT_STREAM_FIELD: _TRACEPARENT},
+    )
     assert response.status_code == 200, response.text
 
     entries = valkey.xrange(runs_stream)

--- a/apps/api/tests/test_channels.py
+++ b/apps/api/tests/test_channels.py
@@ -38,11 +38,15 @@ from curie_api.config import Settings, get_settings
 from curie_api.main import create_app
 from curie_api.routers import channels as channels_router
 from curie_telemetry import TRACEPARENT_STREAM_FIELD, extract_trace_context
+from curie_telemetry.tracing import configure_tracer_provider
 from curie_test_support.valkey import connect_or_skip
 from fastapi.routing import APIRoute
 from fastapi.testclient import TestClient
 from opentelemetry import context as otel_context
 from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags, TraceState
 from sqlalchemy import text as sql_text
 from sqlalchemy.ext.asyncio import create_async_engine
@@ -57,6 +61,7 @@ PAST = 1000000000  # 2001, comfortably expired
 FAR_FUTURE = 4102444800  # 2100-01-01
 _TRACE_ID = int("1123456789abcdef0123456789abcdef", 16)
 _SPAN_ID = int("1123456789abcdef", 16)
+_TRACEPARENT = "00-1123456789abcdef0123456789abcdef-1123456789abcdef-01"
 
 
 @contextmanager
@@ -73,6 +78,19 @@ def _remote_parent() -> Iterator[None]:
         yield
     finally:
         otel_context.detach(token)
+
+
+@contextmanager
+def _captured_spans() -> Iterator[InMemorySpanExporter]:
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    configure_tracer_provider(provider)
+    try:
+        yield exporter
+    finally:
+        configure_tracer_provider(None)
+        provider.shutdown()
 
 # The one detail string every ingress auth failure returns. Identical for
 # "no credential" and "wrong credential" so a caller cannot probe the
@@ -635,6 +653,77 @@ def test_channel_ingress_injects_traceparent_adjacent_to_unchanged_payload(
     assert parent.is_valid is True
     assert parent.is_remote is True
     assert parent.trace_id == _TRACE_ID
+
+
+def test_channel_http_parent_is_observation_context_never_ingress_authority(
+    channels_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    valkey: redis.Redis,
+    runs_stream: str,
+) -> None:
+    """A standard carrier parents telemetry but cannot replace a chn token."""
+
+    _bind(
+        channels_client,
+        auth_headers,
+        name="http-traced-ingress-agent",
+        channel=_email_channel("http-trace@example.test"),
+    )
+    token = _mint(
+        channels_client,
+        auth_headers,
+        kind="email",
+        address="http-trace@example.test",
+    )
+    accepted_body = _turn("email", "http-trace@example.test")
+
+    with _captured_spans() as exporter:
+        accepted = _post_turn(
+            channels_client,
+            token,
+            accepted_body,
+            headers={TRACEPARENT_STREAM_FIELD: _TRACEPARENT},
+        )
+        unauthorized = _post_turn(
+            channels_client,
+            None,
+            _turn("email", "http-trace@example.test"),
+            headers={TRACEPARENT_STREAM_FIELD: _TRACEPARENT},
+        )
+
+    assert accepted.status_code == 200, accepted.text
+    assert unauthorized.status_code == 401, unauthorized.text
+    entries = valkey.xrange(runs_stream)
+    assert len(entries) == 1
+    _entry_id, fields = entries[0]
+
+    server_spans = [
+        span
+        for span in exporter.get_finished_spans()
+        if span.name == "http.server.request" and span.context.trace_id == _TRACE_ID
+    ]
+    producers = [
+        span for span in exporter.get_finished_spans() if span.name == "curie.queue.enqueue"
+    ]
+    assert len(server_spans) == 2
+    assert len(producers) == 1
+    producer = producers[0]
+    producer_parent = producer.parent
+    assert producer_parent is not None
+    accepted_server = next(
+        span for span in server_spans if span.context.span_id == producer_parent.span_id
+    )
+    assert accepted_server.parent is not None
+    assert accepted_server.parent.span_id == _SPAN_ID
+    assert producer.context.trace_id == accepted_server.context.trace_id
+
+    transported = trace.get_current_span(extract_trace_context(fields)).get_span_context()
+    assert transported.trace_id == producer.context.trace_id
+    assert transported.span_id == producer.context.span_id
+    assert QueuedTurn.model_validate_json(fields["payload"]).model_dump_json() == fields[
+        "payload"
+    ]
 
 
 def test_a_slack_binding_enqueues_with_neither_endpoint_nor_adapter(

--- a/apps/api/tests/test_hooks.py
+++ b/apps/api/tests/test_hooks.py
@@ -17,6 +17,7 @@ import hashlib
 import hmac
 import uuid
 from collections.abc import Iterator
+from contextlib import contextmanager
 from typing import Any
 
 import pytest
@@ -25,12 +26,22 @@ from aci_protocol import QueuedTurn, TurnSource
 from curie_api.config import get_settings
 from curie_api.hook_signing import derive
 from curie_api.routers import hooks as hooks_router
+from curie_telemetry import TRACEPARENT_STREAM_FIELD, extract_trace_context
+from curie_telemetry.tracing import configure_tracer_provider
 from fastapi.testclient import TestClient
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from sqlalchemy import text as sql_text
 from sqlalchemy.ext.asyncio import create_async_engine
 
 EMAIL_ENDPOINT = "http://curie-mail-adapter:8080/"
 EMAIL_ADAPTER = "agentmail-sandbox"
+_TRACE_ID = int("3123456789abcdef0123456789abcdef", 16)
+_PARENT_SPAN_ID = int("3123456789abcdef", 16)
+_TRACEPARENT = "00-3123456789abcdef0123456789abcdef-3123456789abcdef-01"
+_OTHER_TRACEPARENT = "00-4123456789abcdef0123456789abcdef-4123456789abcdef-01"
 
 
 # --- fixtures -----------------------------------------------------------------
@@ -84,6 +95,7 @@ def _post(
     secret: str | None = None,
     signature: str | None = None,
     delivery_id: str | None = "dlv-1",
+    traceparent: str | None = None,
 ) -> Any:
     """POST one delivery, signing with `secret` unless a signature is forced."""
 
@@ -94,7 +106,22 @@ def _post(
         headers["X-Curie-Signature-256"] = _sign(secret, body)
     if delivery_id is not None:
         headers["X-Curie-Delivery-Id"] = delivery_id
+    if traceparent is not None:
+        headers[TRACEPARENT_STREAM_FIELD] = traceparent
     return client.post(f"/hooks/{agent_id}/{hook}", content=body, headers=headers)
+
+
+@contextmanager
+def _captured_spans() -> Iterator[InMemorySpanExporter]:
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    configure_tracer_provider(provider)
+    try:
+        yield exporter
+    finally:
+        configure_tracer_provider(None)
+        provider.shutdown()
 
 
 def _bump_generation(agent_id: str) -> None:
@@ -163,6 +190,73 @@ def test_a_signed_delivery_enqueues_a_webhook_turn_with_no_placeholder(
     # The payload reaches the agent, and the author is the platform, not a person.
     assert '{"issue": 42}' in turn.text
     assert turn.author == "hook:issues"
+
+
+def test_hook_ingress_producer_injects_the_http_parent_through_owned_enqueue(
+    hooks_client: TestClient,
+    auth_headers: dict[str, str],
+    valkey: redis.Redis,
+    runs_stream: str,
+    clean_db: None,
+) -> None:
+    """Hook and channel ingress share W3C transport without widening payload."""
+
+    agent_id = _bind(hooks_client, auth_headers, name="tracedhookagent")
+    secret = _secret_for(agent_id)
+    body = b'{"issue": 42}'
+
+    with _captured_spans() as exporter:
+        accepted = _post(
+            hooks_client,
+            agent_id,
+            "issues",
+            body,
+            secret=secret,
+            delivery_id="trace-delivery",
+            traceparent=_TRACEPARENT,
+        )
+        duplicate = _post(
+            hooks_client,
+            agent_id,
+            "issues",
+            body,
+            secret=secret,
+            delivery_id="trace-delivery",
+            traceparent=_OTHER_TRACEPARENT,
+        )
+
+    assert accepted.status_code == 200, accepted.text
+    assert accepted.json()["duplicate"] is False
+    assert duplicate.status_code == 200, duplicate.text
+    assert duplicate.json()["duplicate"] is True
+
+    entries = valkey.xrange(runs_stream)
+    assert len(entries) == 1
+    _entry_id, fields = entries[0]
+    assert set(fields) == {"payload", TRACEPARENT_STREAM_FIELD}
+    raw_payload = fields["payload"]
+    assert QueuedTurn.model_validate_json(raw_payload).model_dump_json() == raw_payload
+
+    server_spans = [
+        span for span in exporter.get_finished_spans() if span.name == "http.server.request"
+    ]
+    producers = [
+        span for span in exporter.get_finished_spans() if span.name == "curie.queue.enqueue"
+    ]
+    assert len(server_spans) == 2
+    assert len(producers) == 1, "the duplicate request owns no producer handoff"
+    accepted_server = next(span for span in server_spans if span.context.trace_id == _TRACE_ID)
+    assert accepted_server.parent is not None
+    assert accepted_server.parent.is_remote is True
+    assert accepted_server.parent.span_id == _PARENT_SPAN_ID
+    producer = producers[0]
+    assert producer.context.trace_id == accepted_server.context.trace_id
+    assert producer.parent is not None
+    assert producer.parent.span_id == accepted_server.context.span_id
+
+    transported = trace.get_current_span(extract_trace_context(fields)).get_span_context()
+    assert transported.trace_id == producer.context.trace_id
+    assert transported.span_id == producer.context.span_id
 
 
 def test_instruction_shaped_payload_is_delimited_as_untrusted_content(

--- a/apps/api/tests/test_langfuse_integration.py
+++ b/apps/api/tests/test_langfuse_integration.py
@@ -11,7 +11,6 @@ from typing import Any
 import httpx
 import pytest
 from curie_api.config import get_settings
-from curie_api.main import create_app
 from fastapi.testclient import TestClient
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk.resources import Resource
@@ -64,21 +63,20 @@ def _max_depth(nodes: list[dict[str, Any]]) -> int:
 
 @pytest.mark.skipif(not _stack_up(), reason="dev compose stack not reachable")
 def test_proxy_returns_reconstructed_tree_for_seeded_trace(
-    auth_headers: dict[str, str],
+    client: TestClient, auth_headers: dict[str, str],
 ) -> None:
     trace_id = _emit_three_level_trace()
 
     deadline = time.time() + 60
     body: dict[str, Any] | None = None
-    with TestClient(create_app()) as client:
-        while time.time() < deadline:
-            resp = client.get(
-                f"/langfuse/traces/{trace_id}", headers=auth_headers
-            )
-            if resp.status_code == 200 and _max_depth(resp.json()["tree"]) >= 3:
-                body = resp.json()
-                break
-            time.sleep(2)
+    while time.time() < deadline:
+        resp = client.get(
+            f"/langfuse/traces/{trace_id}", headers=auth_headers
+        )
+        if resp.status_code == 200 and _max_depth(resp.json()["tree"]) >= 3:
+            body = resp.json()
+            break
+        time.sleep(2)
 
     assert body is not None, "seeded trace never reached the proxy with depth >= 3"
     assert _max_depth(body["tree"]) >= 3
@@ -97,7 +95,7 @@ def test_proxy_returns_reconstructed_tree_for_seeded_trace(
 @pytest.mark.skipif(not _stack_up(), reason="dev compose stack not reachable")
 @pytest.mark.parametrize("decision", ["approved", None])
 def test_proxy_reads_approval_on_non_root_observation(
-    auth_headers: dict[str, str], decision: str | None,
+    client: TestClient, auth_headers: dict[str, str], decision: str | None,
 ) -> None:
     provider = TracerProvider(
         resource=Resource.create({"service.name": "approval-correlation-integration"})
@@ -119,21 +117,20 @@ def test_proxy_reads_approval_on_non_root_observation(
 
     deadline = time.time() + 60
     body: dict[str, Any] | None = None
-    with TestClient(create_app()) as client:
-        while time.time() < deadline:
-            resp = client.get(f"/langfuse/traces/{trace_id}", headers=auth_headers)
-            if resp.status_code == 200:
-                candidate = resp.json()
-                tree = candidate["tree"]
-                if (
-                    len(tree) == 1
-                    and tree[0]["name"] == "curie.queue.enqueue"
-                    and {child["name"] for child in tree[0]["children"]}
-                    == {"agent.run", "curie.reply.update"}
-                    and candidate["approval_decision"] == decision
-                ):
-                    body = candidate
-                    break
-            time.sleep(2)
+    while time.time() < deadline:
+        resp = client.get(f"/langfuse/traces/{trace_id}", headers=auth_headers)
+        if resp.status_code == 200:
+            candidate = resp.json()
+            tree = candidate["tree"]
+            if (
+                len(tree) == 1
+                and tree[0]["name"] == "curie.queue.enqueue"
+                and {child["name"] for child in tree[0]["children"]}
+                == {"agent.run", "curie.reply.update"}
+                and candidate["approval_decision"] == decision
+            ):
+                body = candidate
+                break
+        time.sleep(2)
     assert body is not None, "correlated approval metadata did not reach the exact proxy read"
     assert body["approval_decision"] == decision

--- a/apps/api/tests/test_langfuse_integration.py
+++ b/apps/api/tests/test_langfuse_integration.py
@@ -92,3 +92,48 @@ def test_proxy_returns_reconstructed_tree_for_seeded_trace(
 
     _walk(body["tree"])
     assert any(n["type"] == "GENERATION" for n in flat)
+
+
+@pytest.mark.skipif(not _stack_up(), reason="dev compose stack not reachable")
+@pytest.mark.parametrize("decision", ["approved", None])
+def test_proxy_reads_approval_on_non_root_observation(
+    auth_headers: dict[str, str], decision: str | None,
+) -> None:
+    provider = TracerProvider(
+        resource=Resource.create({"service.name": "approval-correlation-integration"})
+    )
+    provider.add_span_processor(
+        SimpleSpanProcessor(OTLPSpanExporter(endpoint=COLLECTOR_ENDPOINT))
+    )
+    tracer = provider.get_tracer("approval-correlation-integration")
+    try:
+        with tracer.start_as_current_span("curie.queue.enqueue") as root:
+            trace_id = format(root.get_span_context().trace_id, "032x")
+            with tracer.start_as_current_span("agent.run") as resumed:
+                if decision is not None:
+                    resumed.set_attribute("gen_ai.approval.decision", decision)
+            with tracer.start_as_current_span("curie.reply.update"):
+                pass
+    finally:
+        provider.shutdown()
+
+    deadline = time.time() + 60
+    body: dict[str, Any] | None = None
+    with TestClient(create_app()) as client:
+        while time.time() < deadline:
+            resp = client.get(f"/langfuse/traces/{trace_id}", headers=auth_headers)
+            if resp.status_code == 200:
+                candidate = resp.json()
+                tree = candidate["tree"]
+                if (
+                    len(tree) == 1
+                    and tree[0]["name"] == "curie.queue.enqueue"
+                    and {child["name"] for child in tree[0]["children"]}
+                    == {"agent.run", "curie.reply.update"}
+                    and candidate["approval_decision"] == decision
+                ):
+                    body = candidate
+                    break
+            time.sleep(2)
+    assert body is not None, "correlated approval metadata did not reach the exact proxy read"
+    assert body["approval_decision"] == decision

--- a/apps/api/tests/test_migration_0039_approval_traceparent.py
+++ b/apps/api/tests/test_migration_0039_approval_traceparent.py
@@ -12,7 +12,7 @@ from alembic import command
 from alembic.config import Config
 from curie_api.config import get_settings
 from sqlalchemy import text
-from sqlalchemy.exc import DataError
+from sqlalchemy.exc import DBAPIError
 from sqlalchemy.ext.asyncio import create_async_engine
 
 ALEMBIC_DIR = Path(__file__).resolve().parents[1] / "alembic"
@@ -97,7 +97,7 @@ def test_0039_adds_nullable_bounded_private_carrier_and_round_trips(
         "SELECT traceparent FROM curie.approvals WHERE id = :id",
         {"id": approval_id},
     ) == [{"traceparent": valid}]
-    with pytest.raises(DataError):
+    with pytest.raises(DBAPIError):
         _write_traceparent(approval_id, "x" * 56)
 
     command.downgrade(cfg, "0038")

--- a/apps/api/tests/test_migration_0039_approval_traceparent.py
+++ b/apps/api/tests/test_migration_0039_approval_traceparent.py
@@ -1,0 +1,115 @@
+"""Migration 0039: private, bounded approval trace continuity."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from pathlib import Path
+from typing import Any
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from curie_api.config import get_settings
+from sqlalchemy import text
+from sqlalchemy.exc import DataError
+from sqlalchemy.ext.asyncio import create_async_engine
+
+ALEMBIC_DIR = Path(__file__).resolve().parents[1] / "alembic"
+
+
+def _rows(query: str, params: dict[str, Any] | None = None) -> list[dict[str, Any]]:
+    async def run() -> list[dict[str, Any]]:
+        engine = create_async_engine(get_settings().database_url)
+        try:
+            async with engine.connect() as conn:
+                result = await conn.execute(text(query), params or {})
+                return [dict(row._mapping) for row in result]
+        finally:
+            await engine.dispose()
+
+    return asyncio.run(run())
+
+
+def _seed_legacy_approval(approval_id: uuid.UUID) -> None:
+    async def run() -> None:
+        engine = create_async_engine(get_settings().database_url)
+        try:
+            async with engine.begin() as conn:
+                await conn.execute(
+                    text(
+                        "INSERT INTO curie.approvals "
+                        "(id, conversation_id, author, summary, reply_kind, "
+                        "reply_channel, dedupe_key, status) VALUES "
+                        "(:id, 'thread-legacy', 'U0REQUEST1', 'Approve action', "
+                        "'slack', 'C0EXAMPLE1', :dedupe, 'pending')"
+                    ),
+                    {"id": approval_id, "dedupe": f"legacy-{approval_id.hex}"},
+                )
+        finally:
+            await engine.dispose()
+
+    asyncio.run(run())
+
+
+def _write_traceparent(approval_id: uuid.UUID, value: str) -> None:
+    async def run() -> None:
+        engine = create_async_engine(get_settings().database_url)
+        try:
+            async with engine.begin() as conn:
+                await conn.execute(
+                    text(
+                        "UPDATE curie.approvals SET traceparent = :value "
+                        "WHERE id = :id"
+                    ),
+                    {"id": approval_id, "value": value},
+                )
+        finally:
+            await engine.dispose()
+
+    asyncio.run(run())
+
+
+def test_0039_adds_nullable_bounded_private_carrier_and_round_trips(
+    isolated_migration_db: None,
+) -> None:
+    cfg = Config()
+    cfg.set_main_option("script_location", str(ALEMBIC_DIR))
+    command.upgrade(cfg, "0038")
+    approval_id = uuid.uuid4()
+    _seed_legacy_approval(approval_id)
+
+    command.upgrade(cfg, "head")
+
+    assert _rows(
+        "SELECT is_nullable, character_maximum_length FROM information_schema.columns "
+        "WHERE table_schema = 'curie' AND table_name = 'approvals' "
+        "AND column_name = 'traceparent'"
+    ) == [{"is_nullable": "YES", "character_maximum_length": 55}]
+    assert _rows(
+        "SELECT traceparent FROM curie.approvals WHERE id = :id",
+        {"id": approval_id},
+    ) == [{"traceparent": None}]
+    valid = "00-2123456789abcdef0123456789abcdef-2123456789abcdef-01"
+    assert len(valid) == 55
+    _write_traceparent(approval_id, valid)
+    assert _rows(
+        "SELECT traceparent FROM curie.approvals WHERE id = :id",
+        {"id": approval_id},
+    ) == [{"traceparent": valid}]
+    with pytest.raises(DataError):
+        _write_traceparent(approval_id, "x" * 56)
+
+    command.downgrade(cfg, "0038")
+    assert _rows(
+        "SELECT column_name FROM information_schema.columns "
+        "WHERE table_schema = 'curie' AND table_name = 'approvals' "
+        "AND column_name = 'traceparent'"
+    ) == []
+
+    command.upgrade(cfg, "head")
+    assert _rows(
+        "SELECT is_nullable, character_maximum_length FROM information_schema.columns "
+        "WHERE table_schema = 'curie' AND table_name = 'approvals' "
+        "AND column_name = 'traceparent'"
+    ) == [{"is_nullable": "YES", "character_maximum_length": 55}]

--- a/apps/api/tests/test_otel_runtime.py
+++ b/apps/api/tests/test_otel_runtime.py
@@ -18,7 +18,11 @@ from curie_api.resumereconciler import ResumeReconciler
 from curie_api.sweeper import run_expiry_sweeper
 from curie_telemetry import operation_span, record_metric
 from curie_telemetry.metrics import declared_metric_manifest
+from curie_telemetry.tracing import configure_tracer_provider
 from fastapi.testclient import TestClient
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from redis.asyncio import Redis
 from sqlalchemy.engine import make_url
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
@@ -60,6 +64,19 @@ class _Probe:
 class _ProbeSpan:
     def add_event(self, _name: str, _attributes: Mapping[str, str] | None = None) -> None:
         pass
+
+
+@contextmanager
+def _captured_spans() -> Iterator[InMemorySpanExporter]:
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    configure_tracer_provider(provider)
+    try:
+        yield exporter
+    finally:
+        configure_tracer_provider(None)
+        provider.shutdown()
 
 
 def _install(monkeypatch: pytest.MonkeyPatch) -> _Probe:
@@ -105,6 +122,47 @@ def test_http_metric_manifest_covers_every_registered_api_route(client: TestClie
     registered = set(_registered_http_routes(client.app.routes))
 
     assert registered <= declared_operations
+
+
+def test_http_server_span_extracts_the_standard_w3c_parent(
+    client: TestClient,
+) -> None:
+    trace_id = int("2123456789abcdef0123456789abcdef", 16)
+    parent_span_id = int("2123456789abcdef", 16)
+    traceparent = "00-2123456789abcdef0123456789abcdef-2123456789abcdef-01"
+
+    with _captured_spans() as exporter:
+        response = client.get("/health", headers={"traceparent": traceparent})
+
+    assert response.status_code == 200
+    server, = [
+        span for span in exporter.get_finished_spans() if span.name == "http.server.request"
+    ]
+    assert server.context.trace_id == trace_id
+    assert server.parent is not None
+    assert server.parent.is_remote is True
+    assert server.parent.span_id == parent_span_id
+
+
+@pytest.mark.parametrize(
+    ("headers", "diagnostic"),
+    [({}, "trace.context.missing"), ({"traceparent": "malformed"}, "trace.context.malformed")],
+    ids=["missing", "malformed"],
+)
+def test_http_server_missing_or_malformed_parent_is_a_diagnostic_safe_root(
+    client: TestClient,
+    headers: dict[str, str],
+    diagnostic: str,
+) -> None:
+    with _captured_spans() as exporter:
+        response = client.get("/health", headers=headers)
+
+    assert response.status_code == 200
+    server, = [
+        span for span in exporter.get_finished_spans() if span.name == "http.server.request"
+    ]
+    assert server.parent is None
+    assert [event.name for event in server.events] == [diagnostic]
 
 
 def test_actions_route_records_validated_bounded_metrics(

--- a/apps/api/tests/test_publications.py
+++ b/apps/api/tests/test_publications.py
@@ -12,7 +12,7 @@ import base64
 import json
 import threading
 import uuid
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
 from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime, timedelta
 from typing import Any
@@ -40,6 +40,8 @@ WORKER_HEADERS = {"X-Curie-Worker-Token": WORKER_TOKEN}
 PATCH_LIMIT = 900_000
 BASE_SHA = "0123456789abcdef0123456789abcdef01234567"
 CLUSTER_MESSAGE_ADAPTER = "curie-cluster-message"
+_PUBLICATION_TRACEPARENT = "00-7123456789abcdef0123456789abcdef-7123456789abcdef-01"
+_REPLAY_TRACEPARENT = "00-8123456789abcdef0123456789abcdef-8123456789abcdef-01"
 
 
 @pytest.fixture
@@ -235,7 +237,12 @@ def test_builtin_reply_adapter_and_ref_persist_on_both_publication_rows(
     }
 
 
-def _create_publication(client: TestClient, payload: dict[str, Any]) -> tuple[int, dict[str, Any]]:
+def _create_publication(
+    client: TestClient,
+    payload: dict[str, Any],
+    *,
+    request_headers: Mapping[str, str] | None = None,
+) -> tuple[int, dict[str, Any]]:
     selected = client.post(
         f"/v1/internal/workspaces/{payload['deployment_id']}/selection",
         json={
@@ -246,7 +253,11 @@ def _create_publication(client: TestClient, payload: dict[str, Any]) -> tuple[in
         headers=WORKER_HEADERS,
     )
     assert selected.status_code == 200, selected.text
-    response = client.post("/v1/internal/publications", json=payload, headers=WORKER_HEADERS)
+    response = client.post(
+        "/v1/internal/publications",
+        json=payload,
+        headers={**WORKER_HEADERS, **dict(request_headers or {})},
+    )
     assert response.status_code in (200, 201), response.text
     return response.status_code, response.json()
 
@@ -270,6 +281,67 @@ def _counts() -> tuple[int, int]:
         "(SELECT count(*) FROM curie.publications) AS publications"
     )[0]
     return int(row["approvals"]), int(row["publications"])
+
+
+def test_publication_approval_privately_preserves_the_first_inbound_carrier(
+    publication_stack: tuple[TestClient, str],
+    auth_headers: dict[str, str],
+    clean_db: None,
+) -> None:
+    """Publication creation is the approval sibling, including replay privacy."""
+
+    client, _ = publication_stack
+    deployment = _create_deployment(client, auth_headers)
+    payload = _publication_payload(
+        deployment["id"], dedupe_key="publication-traceparent-example"
+    )
+    payload["traceparent"] = _REPLAY_TRACEPARENT
+
+    first_status, first = _create_publication(
+        client,
+        payload,
+        request_headers={"traceparent": _PUBLICATION_TRACEPARENT},
+    )
+    replay_status, replay = _create_publication(
+        client,
+        payload,
+        request_headers={"traceparent": _REPLAY_TRACEPARENT},
+    )
+
+    assert first_status == 201
+    assert replay_status == 200
+    assert replay["id"] == first["id"]
+    assert "traceparent" not in first
+    assert "traceparent" not in replay
+    stored = _rows(
+        "SELECT a.traceparent FROM curie.approvals a "
+        "JOIN curie.publications p ON p.approval_id = a.id "
+        "WHERE p.id = :id",
+        {"id": uuid.UUID(first["id"])},
+    )
+    assert stored == [{"traceparent": _PUBLICATION_TRACEPARENT}]
+
+
+def test_publication_with_malformed_carrier_persists_null(
+    publication_stack: tuple[TestClient, str],
+    auth_headers: dict[str, str],
+    clean_db: None,
+) -> None:
+    client, _ = publication_stack
+    deployment = _create_deployment(client, auth_headers)
+    _, publication = _create_publication(
+        client,
+        _publication_payload(deployment["id"]),
+        request_headers={"traceparent": "not-w3c"},
+    )
+
+    stored = _rows(
+        "SELECT a.traceparent FROM curie.approvals a "
+        "JOIN curie.publications p ON p.approval_id = a.id "
+        "WHERE p.id = :id",
+        {"id": uuid.UUID(publication["id"])},
+    )
+    assert stored == [{"traceparent": None}]
 
 
 def test_publication_persistence_refuses_casefolded_git_metadata_path(

--- a/apps/api/tests/test_resume_reconciler.py
+++ b/apps/api/tests/test_resume_reconciler.py
@@ -170,7 +170,7 @@ def _detached_approval(
         status=status,
         resolved_by=resolved_by,
     )
-    setattr(approval, "traceparent", traceparent)
+    approval.traceparent = traceparent
     return approval
 
 
@@ -947,10 +947,10 @@ def test_reconciler_isolates_per_record_failure(
         real_enqueue = queue.enqueue
         fail_event = f"approval-{fail_id}-resolved"
 
-        async def flaky(turn: QueuedTurn) -> str:
+        async def flaky(turn: QueuedTurn, **kwargs: object) -> str:
             if turn.event_id == fail_event:
                 raise RuntimeError("valkey blip for one record")
-            return await real_enqueue(turn)
+            return await real_enqueue(turn, **kwargs)
 
         queue.enqueue = flaky  # type: ignore[method-assign]
 

--- a/apps/api/tests/test_resume_reconciler.py
+++ b/apps/api/tests/test_resume_reconciler.py
@@ -23,6 +23,7 @@ import json
 import os
 import uuid
 from collections.abc import Awaitable, Callable, Iterator
+from contextlib import contextmanager
 from datetime import UTC, datetime, timedelta
 
 import pytest
@@ -33,6 +34,8 @@ from curie_api.config import get_settings
 from curie_api.models import Approval, ApprovalStatus
 from curie_api.resumequeue import ResumeQueue
 from curie_api.resumereconciler import ResumeReconciler
+from curie_telemetry import extract_trace_context
+from curie_telemetry.tracing import configure_tracer_provider
 from curie_test_support.valkey import (
     VALKEY_HOST as _VALKEY_HOST,
 )
@@ -45,12 +48,36 @@ from curie_test_support.valkey import (
 from curie_test_support.valkey import (
     connect_or_skip,
 )
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from sqlalchemy import select, text, update
 from sqlalchemy.ext.asyncio import (
     AsyncSession,
     async_sessionmaker,
     create_async_engine,
 )
+
+_TRACE_A_ID = int("9123456789abcdef0123456789abcdef", 16)
+_TRACE_A_SPAN_ID = int("9123456789abcdef", 16)
+_TRACE_A = "00-9123456789abcdef0123456789abcdef-9123456789abcdef-01"
+_TRACE_B_ID = int("a123456789abcdef0123456789abcdef", 16)
+_TRACE_B_SPAN_ID = int("a123456789abcdef", 16)
+_TRACE_B = "00-a123456789abcdef0123456789abcdef-a123456789abcdef-01"
+
+
+@contextmanager
+def _captured_spans() -> Iterator[InMemorySpanExporter]:
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    configure_tracer_provider(provider)
+    try:
+        yield exporter
+    finally:
+        configure_tracer_provider(None)
+        provider.shutdown()
 
 
 @pytest.fixture
@@ -115,6 +142,7 @@ def _detached_approval(
     reply_kind: str = "slack",
     reply_adapter: str | None = None,
     reply_placeholder: str | None = "p-1",
+    traceparent: str | None = None,
 ) -> Approval:
     """An unpersisted ``Approval`` in a chosen status, for the pure-unit selector
     test: the turn builders read the record's fields only, so no DB round-trip is
@@ -125,7 +153,7 @@ def _detached_approval(
     test exercises cannot drift from the one the DB tests insert.
     """
 
-    return Approval(
+    approval = Approval(
         id=uuid.uuid4(),
         conversation_id=f"th-{uuid.uuid4().hex[:8]}",
         author="U1",
@@ -142,6 +170,8 @@ def _detached_approval(
         status=status,
         resolved_by=resolved_by,
     )
+    setattr(approval, "traceparent", traceparent)
+    return approval
 
 
 async def _insert_approval(
@@ -156,6 +186,7 @@ async def _insert_approval(
     reply_channel: str | None = None,
     reply_adapter: str | None = None,
     reply_placeholder: str | None = "p-1",
+    traceparent: str | None = None,
 ) -> uuid.UUID:
     """Insert an approval row in a chosen lifecycle state (bypassing the resolve
     endpoint), so a test can construct the exact stranded/settled/expired shapes
@@ -167,6 +198,7 @@ async def _insert_approval(
         reply_kind=reply_kind,
         reply_adapter=reply_adapter,
         reply_placeholder=reply_placeholder,
+        traceparent=traceparent,
     )
     approval.reply_endpoint = reply_endpoint
     if reply_channel is not None:
@@ -225,6 +257,108 @@ def test_reconciler_reenqueues_stranded_resolved_record(
     assert turn.event_id == f"approval-{approval_id}-resolved"
     assert turn.reply_handle.placeholder == "reply placeholder"
     assert resumed_at is not None
+
+
+def test_reconciler_preserves_each_approvals_original_trace_and_isolation(
+    clean_db: None, valkey: redis.Redis, runs_stream: str
+) -> None:
+    """Recovery and duplicate passes cannot fork or cross two suspended turns."""
+
+    async def steps(
+        sessionmaker: async_sessionmaker[AsyncSession], queue: ResumeQueue
+    ) -> tuple[uuid.UUID, uuid.UUID]:
+        first_id = await _insert_approval(
+            sessionmaker,
+            status=ApprovalStatus.approved,
+            resolved_at=_naive(120),
+            resumed_at=None,
+            traceparent=_TRACE_A,
+        )
+        second_id = await _insert_approval(
+            sessionmaker,
+            status=ApprovalStatus.rejected,
+            resolved_at=_naive(120),
+            resumed_at=None,
+            traceparent=_TRACE_B,
+        )
+        reconciler = ResumeReconciler(
+            sessionmaker, queue, interval_seconds=30, grace_seconds=0, batch_limit=100
+        )
+        assert await reconciler.reconcile_once() == 2
+        assert await reconciler.reconcile_once() == 0
+        return first_id, second_id
+
+    with _captured_spans() as exporter:
+        first_id, second_id = _run_async(steps, runs_stream)
+
+    enqueue_spans = [
+        span for span in exporter.get_finished_spans() if span.name == "curie.queue.enqueue"
+    ]
+    assert len(enqueue_spans) == 2
+    assert {
+        (span.context.trace_id, span.parent.span_id if span.parent else None)
+        for span in enqueue_spans
+    } == {
+        (_TRACE_A_ID, _TRACE_A_SPAN_ID),
+        (_TRACE_B_ID, _TRACE_B_SPAN_ID),
+    }
+
+    entries = valkey.xrange(runs_stream)
+    assert len(entries) == 2
+    by_event = {json.loads(fields["payload"])["event_id"]: fields for _, fields in entries}
+    expected = {
+        f"approval-{first_id}-resolved": _TRACE_A_ID,
+        f"approval-{second_id}-resolved": _TRACE_B_ID,
+    }
+    assert set(by_event) == set(expected)
+    for event_id, expected_trace_id in expected.items():
+        carried = trace.get_current_span(
+            extract_trace_context(by_event[event_id])
+        ).get_span_context()
+        assert carried.trace_id == expected_trace_id
+
+
+@pytest.mark.parametrize("stored", [None, "not-w3c"])
+def test_reconciler_legacy_or_malformed_parent_starts_one_safe_root(
+    clean_db: None,
+    valkey: redis.Redis,
+    runs_stream: str,
+    stored: str | None,
+) -> None:
+    async def steps(
+        sessionmaker: async_sessionmaker[AsyncSession], queue: ResumeQueue
+    ) -> uuid.UUID:
+        approval_id = await _insert_approval(
+            sessionmaker,
+            status=ApprovalStatus.approved,
+            resolved_at=_naive(120),
+            resumed_at=None,
+            traceparent=stored,
+        )
+        reconciler = ResumeReconciler(
+            sessionmaker, queue, interval_seconds=30, grace_seconds=0, batch_limit=100
+        )
+        assert await reconciler.reconcile_once() == 1
+        return approval_id
+
+    with _captured_spans() as exporter:
+        approval_id = _run_async(steps, runs_stream)
+
+    enqueue = [
+        span for span in exporter.get_finished_spans() if span.name == "curie.queue.enqueue"
+    ]
+    assert len(enqueue) == 1
+    assert enqueue[0].parent is None
+    assert enqueue[0].context.trace_id not in {_TRACE_A_ID, _TRACE_B_ID}
+    entries = valkey.xrange(runs_stream)
+    assert len(entries) == 1
+    assert json.loads(entries[0][1]["payload"])["event_id"] == (
+        f"approval-{approval_id}-resolved"
+    )
+    carried = trace.get_current_span(
+        extract_trace_context(entries[0][1])
+    ).get_span_context()
+    assert carried.trace_id == enqueue[0].context.trace_id
 
 
 def test_reconciler_preserves_a_post_once_reply_handle(

--- a/apps/dispatcher/src/curie_dispatcher/approval_actions.py
+++ b/apps/dispatcher/src/curie_dispatcher/approval_actions.py
@@ -24,6 +24,7 @@ from dataclasses import dataclass
 from typing import Any
 
 import httpx
+from curie_telemetry import inject_trace_context
 from slack_sdk.web import WebClient
 
 from .approval_principal import mint_chat_principal
@@ -233,6 +234,7 @@ class ApprovalResolveClient:
                 approval_id=approval_id,
             ),
         }
+        inject_trace_context(headers)
         try:
             response = self._client.post(
                 f"{self._base}/approvals/{approval_id}/resolve",

--- a/apps/dispatcher/src/curie_dispatcher/enqueue_once.py
+++ b/apps/dispatcher/src/curie_dispatcher/enqueue_once.py
@@ -14,7 +14,8 @@ import os
 import sys
 
 from aci_protocol import QueuedTurn, parse_queued_turn
-from curie_telemetry import bootstrap_service_telemetry
+from curie_telemetry import bootstrap_service_telemetry, operation_span
+from opentelemetry.trace import SpanKind
 
 from . import __version__
 from .app import build_redis
@@ -32,7 +33,12 @@ def enqueue_payload(
 ) -> str:
     """Validate one frozen turn payload and enqueue it through the producer."""
     turn: QueuedTurn = parse_queued_turn(payload)
-    return enqueue(redis_client, config, turn)
+    with operation_span(
+        "curie.turn.ingress",
+        kind=SpanKind.CONSUMER,
+        attributes={"service.name": "curie-dispatcher", "source": "dispatcher"},
+    ):
+        return enqueue(redis_client, config, turn)
 
 
 def main() -> int:

--- a/apps/dispatcher/src/curie_dispatcher/handlers.py
+++ b/apps/dispatcher/src/curie_dispatcher/handlers.py
@@ -46,6 +46,8 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 from aci_protocol import QueuedTurn, ReplyHandle, TurnSource
+from curie_telemetry import operation_span
+from opentelemetry.trace import SpanKind
 from slack_bolt import App
 from slack_sdk.errors import SlackApiError
 from slack_sdk.web import WebClient
@@ -319,28 +321,33 @@ def process_event(
         drop(log, reason, event_id=slack_event_id, lane=lane)
         return None
 
-    if not claim_event(redis_client, config, slack_event_id):
-        drop(log, DropReason.DUPLICATE_DELIVERY, event_id=slack_event_id)
-        return None
+    with operation_span(
+        "curie.turn.ingress",
+        kind=SpanKind.CONSUMER,
+        attributes={"service.name": "curie-dispatcher", "source": "dispatcher"},
+    ):
+        if not claim_event(redis_client, config, slack_event_id):
+            drop(log, DropReason.DUPLICATE_DELIVERY, event_id=slack_event_id)
+            return None
 
-    return _mint_turn(
-        web_client=web_client,
-        redis_client=redis_client,
-        config=config,
-        log=log,
-        clock=clock,
-        slack_event_id=slack_event_id,
-        delivery_kind="slack event",
-        author=event.get("user", ""),
-        # NOT `event.get("text", "")`: a Block Kit or attachment-shaped post
-        # carries an empty or fallback-only top-level `text` and its real body in
-        # `blocks`/`attachments`, so that read emptied the turn while still
-        # burning a placeholder (#2006). `derive_text` returns a non-empty
-        # top-level text byte-identically, so existing enqueues are unchanged.
-        text=_strip_self_mention(derive_text(event), bot_user_id),
-        channel=channel,
-        thread_ts=thread_ts,
-    )
+        return _mint_turn(
+            web_client=web_client,
+            redis_client=redis_client,
+            config=config,
+            log=log,
+            clock=clock,
+            slack_event_id=slack_event_id,
+            delivery_kind="slack event",
+            author=event.get("user", ""),
+            # NOT `event.get("text", "")`: a Block Kit or attachment-shaped post
+            # carries an empty or fallback-only top-level `text` and its real body in
+            # `blocks`/`attachments`, so that read emptied the turn while still
+            # burning a placeholder (#2006). `derive_text` returns a non-empty
+            # top-level text byte-identically, so existing enqueues are unchanged.
+            text=_strip_self_mention(derive_text(event), bot_user_id),
+            channel=channel,
+            thread_ts=thread_ts,
+        )
 
 
 def action_command(action: dict[str, Any]) -> str:
@@ -420,28 +427,33 @@ def process_action(
         drop(log, DropReason.MALFORMED_ENVELOPE, event_id=interaction_id, missing=missing)
         return None
     slack_event_id = f"action-{interaction}"
-    if not claim_event(redis_client, config, slack_event_id):
-        drop(log, DropReason.DUPLICATE_DELIVERY, event_id=slack_event_id)
-        return None
+    with operation_span(
+        "curie.turn.ingress",
+        kind=SpanKind.CONSUMER,
+        attributes={"service.name": "curie-dispatcher", "source": "dispatcher"},
+    ):
+        if not claim_event(redis_client, config, slack_event_id):
+            drop(log, DropReason.DUPLICATE_DELIVERY, event_id=slack_event_id)
+            return None
 
-    user = (body.get("user") or {}).get("id", "")
+        user = (body.get("user") or {}).get("id", "")
 
-    # The shared tail: same claim -> placeholder -> XADD ordering as
-    # `process_event`, because it IS `process_event`'s, so the same release rule
-    # and the same `QueuedTurn` shape apply on this lane by construction.
-    return _mint_turn(
-        web_client=web_client,
-        redis_client=redis_client,
-        config=config,
-        log=log,
-        clock=clock,
-        slack_event_id=slack_event_id,
-        delivery_kind="block action",
-        author=user,
-        text=command,
-        channel=channel,
-        thread_ts=thread_ts,
-    )
+        # The shared tail: same claim -> placeholder -> XADD ordering as
+        # `process_event`, because it IS `process_event`'s, so the same release rule
+        # and the same `QueuedTurn` shape apply on this lane by construction.
+        return _mint_turn(
+            web_client=web_client,
+            redis_client=redis_client,
+            config=config,
+            log=log,
+            clock=clock,
+            slack_event_id=slack_event_id,
+            delivery_kind="block action",
+            author=user,
+            text=command,
+            channel=channel,
+            thread_ts=thread_ts,
+        )
 
 
 def register_handlers(

--- a/apps/dispatcher/tests/test_approval_actions.py
+++ b/apps/dispatcher/tests/test_approval_actions.py
@@ -13,6 +13,8 @@ import base64
 import hashlib
 import hmac
 import json
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
@@ -31,6 +33,9 @@ from curie_dispatcher.approval_actions import (
 )
 from curie_dispatcher.approval_principal import mint_chat_principal
 from curie_dispatcher.config import DispatcherConfig
+from opentelemetry import context as otel_context
+from opentelemetry import trace
+from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags, TraceState
 from slack_bolt import App
 from slack_bolt.adapter.socket_mode import SocketModeHandler
 from slack_sdk.socket_mode.request import SocketModeRequest
@@ -41,6 +46,25 @@ from .conftest import FakeSocketClient, _authorize
 APPROVAL_ID = "9a1e8a10-0000-0000-0000-000000000246"
 _PLATFORM_API_KEY = "platform-api-test-key"
 _CHAT_ATTESTER_SECRET = "dispatcher-attester-test-secret"
+_RESOLVE_TRACE_ID = int("4123456789abcdef0123456789abcdef", 16)
+_RESOLVE_SPAN_ID = int("4123456789abcdef", 16)
+_RESOLVE_TRACEPARENT = "00-4123456789abcdef0123456789abcdef-4123456789abcdef-01"
+
+
+@contextmanager
+def _resolve_parent() -> Iterator[None]:
+    parent = SpanContext(
+        trace_id=_RESOLVE_TRACE_ID,
+        span_id=_RESOLVE_SPAN_ID,
+        is_remote=True,
+        trace_flags=TraceFlags.SAMPLED,
+        trace_state=TraceState(),
+    )
+    token = otel_context.attach(trace.set_span_in_context(NonRecordingSpan(parent)))
+    try:
+        yield
+    finally:
+        otel_context.detach(token)
 
 
 def test_dispatcher_minter_matches_the_api_wire_vector() -> None:
@@ -579,6 +603,32 @@ def test_immediate_click_posts_only_decision_with_an_authenticated_chat_principa
         )
     )
     assert token not in rendered
+
+
+def test_resolve_request_carries_the_dispatcher_action_parent() -> None:
+    """The Slack action trace is forwarded as HTTP metadata, never body authority."""
+
+    captured = _CapturingHttpClient()
+    resolver = ApprovalResolveClient(
+        api_base_url="https://api.example.test",
+        api_key=_PLATFORM_API_KEY,
+        approval_chat_attester_secret=_CHAT_ATTESTER_SECRET,
+        client=captured,  # type: ignore[arg-type]
+    )
+
+    with _resolve_parent():
+        outcome = resolver.resolve(
+            APPROVAL_ID,
+            decision="approved",
+            attested_user="U_MANAGER",
+            attested_channel="C_MGRS",
+        )
+
+    assert outcome.status_code == 200
+    assert len(captured.requests) == 1
+    request = captured.requests[0]
+    assert request["headers"]["traceparent"] == _RESOLVE_TRACEPARENT
+    assert "traceparent" not in request["json"]
 
 
 def test_non_json_403_body_is_not_captured_as_detail() -> None:

--- a/apps/dispatcher/tests/test_enqueue_once.py
+++ b/apps/dispatcher/tests/test_enqueue_once.py
@@ -11,9 +11,13 @@ from aci_protocol import QueuedTurn, ReplyHandle
 from curie_dispatcher import enqueue_once
 from curie_dispatcher.config import DispatcherConfig
 from curie_dispatcher.queue import from_stream_fields
-from curie_telemetry import TRACEPARENT_STREAM_FIELD
+from curie_telemetry import TRACEPARENT_STREAM_FIELD, extract_trace_context
+from curie_telemetry.tracing import configure_tracer_provider
 from opentelemetry import context as otel_context
 from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags, TraceState
 
 _TRACE_ID = int("fedcba9876543210fedcba9876543210", 16)
@@ -52,6 +56,19 @@ def _turn() -> QueuedTurn:
     )
 
 
+@contextmanager
+def _captured_spans() -> Iterator[InMemorySpanExporter]:
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    configure_tracer_provider(provider)
+    try:
+        yield exporter
+    finally:
+        configure_tracer_provider(None)
+        provider.shutdown()
+
+
 def test_enqueue_payload_uses_dispatcher_carrier_beside_unchanged_payload(
     redis_client: redis.Redis,
     config: DispatcherConfig,
@@ -76,6 +93,36 @@ def test_enqueue_payload_uses_dispatcher_carrier_beside_unchanged_payload(
     assert len(span_id) == 16
     assert flags == "01"
     assert from_stream_fields(fields) == turn
+
+
+def test_enqueue_payload_owns_the_same_ingress_root_as_slack(
+    redis_client: redis.Redis,
+    config: DispatcherConfig,
+) -> None:
+    """The CLI bridge is a sibling ingress, not a parentless producer."""
+
+    turn = _turn()
+    with _captured_spans() as exporter:
+        stream_id = enqueue_once.enqueue_payload(
+            turn.model_dump_json(),
+            config=config,
+            redis_client=redis_client,
+        )
+
+    spans = exporter.get_finished_spans()
+    receipt, = [span for span in spans if span.name == "curie.turn.ingress"]
+    producer, = [span for span in spans if span.name == "curie.queue.enqueue"]
+    assert receipt.parent is None
+    assert producer.context.trace_id == receipt.context.trace_id
+    assert producer.parent is not None
+    assert producer.parent.span_id == receipt.context.span_id
+
+    (entry_id, fields), = redis_client.xrange(config.stream)
+    assert entry_id == stream_id
+    transported = trace.get_current_span(extract_trace_context(fields)).get_span_context()
+    assert transported.trace_id == receipt.context.trace_id
+    assert transported.span_id == producer.context.span_id
+    assert fields["payload"] == turn.model_dump_json()
 
 
 def test_main_without_otlp_endpoint_prints_only_the_stream_id(

--- a/apps/dispatcher/tests/test_queue.py
+++ b/apps/dispatcher/tests/test_queue.py
@@ -4,11 +4,15 @@ import json
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
+from typing import Any
 
+import pytest
 import redis
 from aci_protocol import QueuedTurn, ReplyHandle
+from curie_dispatcher import handlers as handlers_module
 from curie_dispatcher import queue as queue_module
 from curie_dispatcher.config import DispatcherConfig
+from curie_dispatcher.handlers import process_action, process_event
 from curie_dispatcher.queue import (
     claim_event,
     enqueue,
@@ -16,8 +20,12 @@ from curie_dispatcher.queue import (
     to_stream_fields,
 )
 from curie_telemetry import TRACEPARENT_STREAM_FIELD, extract_trace_context
+from curie_telemetry.tracing import configure_tracer_provider
 from opentelemetry import context as otel_context
 from opentelemetry import trace
+from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags, TraceState
 
 # The committed wire golden the Rust CLI consumer (cli/src/queue.rs) round-trips too.
@@ -59,6 +67,37 @@ def _event(event_id: str = "Ev1") -> QueuedTurn:
         reply_handle=ReplyHandle(kind="slack", channel="C1", placeholder="999.00"),
         received_at="2026-07-05T00:00:00+00:00",
     )
+
+
+class _WebClient:
+    def __init__(self, order: list[str] | None = None) -> None:
+        self.order = order
+        self.placeholder_contexts: list[SpanContext] = []
+
+    def chat_postMessage(self, **_kwargs: Any) -> dict[str, str]:
+        if self.order is not None:
+            self.order.append("placeholder")
+        self.placeholder_contexts.append(trace.get_current_span().get_span_context())
+        return {"ts": "1700000000.000200"}
+
+
+@contextmanager
+def _captured_spans() -> Iterator[InMemorySpanExporter]:
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    configure_tracer_provider(provider)
+    try:
+        yield exporter
+    finally:
+        configure_tracer_provider(None)
+        provider.shutdown()
+
+
+def _one_span(exporter: InMemorySpanExporter, name: str) -> ReadableSpan:
+    matches = [span for span in exporter.get_finished_spans() if span.name == name]
+    assert len(matches) == 1, [(span.name, span.context.trace_id) for span in matches]
+    return matches[0]
 
 
 def test_queued_turn_stream_fields_roundtrip() -> None:
@@ -207,3 +246,142 @@ def test_dedupe_decision_is_observed_without_exporting_the_event_id(
         ),
     ]
     assert "Ev-private-example" not in repr(calls)
+
+
+@pytest.mark.parametrize("ingress_kind", ["slack-event", "block-action"])
+def test_accepted_slack_ingress_owns_claim_placeholder_and_enqueue_trace(
+    ingress_kind: str,
+    redis_client: redis.Redis,
+    config: DispatcherConfig,
+) -> None:
+    """Receipt is the single root; both Slack mint sites inherit from it."""
+
+    web_client = _WebClient()
+    with _captured_spans() as exporter:
+        if ingress_kind == "slack-event":
+            result = process_event(
+                body={"event_id": "Ev-ingress-root"},
+                event={
+                    "channel": "C0EXAMPLE1",
+                    "ts": "1700000000.000100",
+                    "user": "U0EXAMPLE1",
+                    "text": "continue",
+                },
+                lane="mention",
+                web_client=web_client,  # type: ignore[arg-type]
+                redis_client=redis_client,
+                config=config,
+            )
+        else:
+            result = process_action(
+                body={
+                    "trigger_id": "trigger-example",
+                    "actions": [{"action_id": "continue", "value": "continue"}],
+                    "channel": {"id": "C0EXAMPLE1"},
+                    "message": {"ts": "1700000000.000100"},
+                    "user": {"id": "U0EXAMPLE1"},
+                },
+                web_client=web_client,  # type: ignore[arg-type]
+                redis_client=redis_client,
+                config=config,
+            )
+
+    assert result is not None
+    receipt = _one_span(exporter, "curie.turn.ingress")
+    claim = _one_span(exporter, "curie.queue.dedupe")
+    producer = _one_span(exporter, "curie.queue.enqueue")
+    assert receipt.parent is None
+    assert claim.context.trace_id == receipt.context.trace_id
+    assert claim.parent is not None and claim.parent.span_id == receipt.context.span_id
+    assert producer.context.trace_id == receipt.context.trace_id
+    assert producer.parent is not None
+    assert producer.parent.span_id == receipt.context.span_id
+    assert web_client.placeholder_contexts == [receipt.context]
+
+    (_entry_id, fields), = redis_client.xrange(config.stream)
+    transported = trace.get_current_span(extract_trace_context(fields)).get_span_context()
+    assert transported.trace_id == receipt.context.trace_id
+    assert transported.span_id == producer.context.span_id
+    assert TRACEPARENT_STREAM_FIELD not in json.loads(fields["payload"])
+
+
+def test_slack_ingress_keeps_claim_placeholder_enqueue_order(
+    redis_client: redis.Redis,
+    config: DispatcherConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#2006 ordering remains claim -> visible placeholder -> durable XADD."""
+
+    order: list[str] = []
+    real_claim = handlers_module.claim_event
+    real_enqueue = handlers_module.enqueue
+
+    def ordered_claim(*args: Any, **kwargs: Any) -> bool:
+        order.append("claim")
+        return real_claim(*args, **kwargs)
+
+    def ordered_enqueue(*args: Any, **kwargs: Any) -> str:
+        order.append("enqueue")
+        return real_enqueue(*args, **kwargs)
+
+    monkeypatch.setattr(handlers_module, "claim_event", ordered_claim)
+    monkeypatch.setattr(handlers_module, "enqueue", ordered_enqueue)
+
+    result = process_event(
+        body={"event_id": "Ev-ordered"},
+        event={
+            "channel": "C0EXAMPLE1",
+            "ts": "1700000000.000100",
+            "user": "U0EXAMPLE1",
+            "text": "continue",
+        },
+        lane="mention",
+        web_client=_WebClient(order),  # type: ignore[arg-type]
+        redis_client=redis_client,
+        config=config,
+    )
+
+    assert result is not None
+    assert order == ["claim", "placeholder", "enqueue"]
+
+
+def test_duplicate_and_refused_slack_inputs_emit_no_enqueue_span(
+    redis_client: redis.Redis,
+    config: DispatcherConfig,
+) -> None:
+    """A receipt may be observed, but refused work must not look dispatched."""
+
+    redis_client.set(
+        config.dedupe_key("Ev-duplicate"),
+        "1",
+        ex=config.dedupe_ttl_seconds,
+    )
+    web_client = _WebClient()
+    with _captured_spans() as exporter:
+        duplicate = process_event(
+            body={"event_id": "Ev-duplicate"},
+            event={
+                "channel": "C0EXAMPLE1",
+                "ts": "1700000000.000100",
+                "user": "U0EXAMPLE1",
+                "text": "continue",
+            },
+            lane="mention",
+            web_client=web_client,  # type: ignore[arg-type]
+            redis_client=redis_client,
+            config=config,
+        )
+        refused = process_event(
+            body={"event_id": "Ev-refused"},
+            event={"user": "U0EXAMPLE1", "text": "missing address"},
+            lane="mention",
+            web_client=web_client,  # type: ignore[arg-type]
+            redis_client=redis_client,
+            config=config,
+        )
+
+    assert duplicate is None
+    assert refused is None
+    assert web_client.placeholder_contexts == []
+    assert redis_client.xlen(config.stream) == 0
+    assert all(span.name != "curie.queue.enqueue" for span in exporter.get_finished_spans())

--- a/apps/worker/src/curie_worker/approvals.py
+++ b/apps/worker/src/curie_worker/approvals.py
@@ -23,6 +23,7 @@ from typing import Any, Protocol
 
 import httpx
 from aci_protocol import ApprovalRequest
+from curie_telemetry import inject_trace_context
 
 # Re-exported so this module stays the kernel-facing seam for the approval
 # payload: ``ApprovalRequest`` is now the shared wire model (#492), not a
@@ -169,11 +170,13 @@ class ApprovalClient:
         self._read_timeout_s = read_timeout_s
 
     async def create(self, request: ApprovalRequest) -> CreatedApproval:
+        headers = {**self._headers, "Content-Type": "application/json"}
+        inject_trace_context(headers)
         try:
             response = await self._client.post(
                 self._url,
                 content=request.model_dump_json(),
-                headers={**self._headers, "Content-Type": "application/json"},
+                headers=headers,
             )
         except httpx.HTTPError as exc:
             raise ApprovalBackendError(f"approval create failed: {exc}") from exc
@@ -194,10 +197,12 @@ class ApprovalClient:
         would turn a cosmetic gap into a dead-lettered resume.
         """
 
+        headers = dict(self._headers)
+        inject_trace_context(headers)
         try:
             response = await self._client.get(
                 f"{self._url}/{approval_id}",
-                headers=self._headers,
+                headers=headers,
                 timeout=self._read_timeout_s,
             )
         except httpx.HTTPError as exc:
@@ -231,11 +236,13 @@ class ApprovalClient:
             raise ApprovalBackendError(
                 "repository publication is cluster-only and requires internal worker auth"
             )
+        headers = {**self._worker_headers, "Content-Type": "application/json"}
+        inject_trace_context(headers)
         try:
             response = await self._client.post(
                 self._publication_url,
                 json=request.to_json(),
-                headers={**self._worker_headers, "Content-Type": "application/json"},
+                headers=headers,
             )
         except httpx.HTTPError as exc:
             raise ApprovalBackendError(f"publication create failed: {exc}") from exc

--- a/apps/worker/src/curie_worker/run.py
+++ b/apps/worker/src/curie_worker/run.py
@@ -266,16 +266,20 @@ def _sandbox_client(
                 "endpoint for local-model mode, or set CURIE_FAKE_MODEL=1 for an "
                 "offline/test run."
             )
-        if not env.get("OTEL_EXPORTER_OTLP_ENDPOINT"):
+        runner_otel_endpoint = env.get(
+            "CURIE_RUNNER_OTEL_EXPORTER_OTLP_ENDPOINT",
+            env.get("OTEL_EXPORTER_OTLP_ENDPOINT", ""),
+        )
+        if not runner_otel_endpoint:
             logger.warning(
-                "Docker substrate selected but OTEL_EXPORTER_OTLP_ENDPOINT is "
-                "unset; runner traces will not be exported"
+                "Docker substrate selected but the runner OTLP endpoint is unset; "
+                "runner traces will not be exported"
             )
         client = DockerSandboxClient(
             image=env.get("CURIE_RUNNER_IMAGE", "curie-runner"),
             bundle_store=bundle_store,
             network=env.get("CURIE_DOCKER_NETWORK") or None,
-            otel_endpoint=env.get("OTEL_EXPORTER_OTLP_ENDPOINT") or None,
+            otel_endpoint=runner_otel_endpoint or None,
             default_plugin_dir=config.bundle_plugin_dir,
             # Container isolation for every spawned runner (#631): read-only
             # rootfs, dropped caps, no-new-privileges, bounded resources. Mirrors

--- a/apps/worker/tests/binding/test_boot_env_single_declaration.py
+++ b/apps/worker/tests/binding/test_boot_env_single_declaration.py
@@ -220,6 +220,10 @@ _NON_BOOT_ALLOWLIST: frozenset[str] = frozenset(
         # declared boot keys, rendered from the declaration). It is a worker-side
         # knob for what URL those refs carry, never itself a sandbox boot key.
         "CURIE_RUNNER_API_URL",
+        # Worker-side Docker routing override. The substrate translates its
+        # value into the existing OTEL_EXPORTER_OTLP_ENDPOINT boot key; this
+        # configuration name itself is never injected into a sandbox.
+        "CURIE_RUNNER_OTEL_EXPORTER_OTLP_ENDPOINT",
         # The local-model demo base URL: an operator knob on the WORKER and on the
         # runner's sdk_auth mapping. It is not a BootEnv field; the boot key the
         # worker actually emits from it is ANTHROPIC_BASE_URL.

--- a/apps/worker/tests/kernel/test_approval_lifecycle.py
+++ b/apps/worker/tests/kernel/test_approval_lifecycle.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 import asyncio
 import json
 import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
 
 import aiohttp
 import httpx
@@ -26,14 +28,38 @@ from curie_worker.approvals import (
     ApprovalClient,
     ApprovalRequest,
     CreatedApproval,
+    PublicationCreateRequest,
     SettledApproval,
 )
 from curie_worker.reply_sink import TargetRoute
 from curie_worker.runner_client import RunnerError
 from curie_worker.sandbox.types import RouteState
+from opentelemetry import context as otel_context
+from opentelemetry import trace
+from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags, TraceState
 
 DONE = SessionStatus.DONE
 AWAITING = SessionStatus.AWAITING_APPROVAL
+
+_HTTP_TRACE_ID = int("3123456789abcdef0123456789abcdef", 16)
+_HTTP_SPAN_ID = int("3123456789abcdef", 16)
+_HTTP_TRACEPARENT = "00-3123456789abcdef0123456789abcdef-3123456789abcdef-01"
+
+
+@contextmanager
+def _approval_http_parent() -> Iterator[None]:
+    parent = SpanContext(
+        trace_id=_HTTP_TRACE_ID,
+        span_id=_HTTP_SPAN_ID,
+        is_remote=True,
+        trace_flags=TraceFlags.SAMPLED,
+        trace_state=TraceState(),
+    )
+    token = otel_context.attach(trace.set_span_in_context(NonRecordingSpan(parent)))
+    try:
+        yield
+    finally:
+        otel_context.detach(token)
 
 
 class RecordingApprovals:
@@ -148,6 +174,120 @@ async def _peek_card_ref(h, approval_id: str) -> dict | None:
 
     raw = await h.async_redis.get(h.config.approval_card_key(approval_id))
     return None if raw is None else json.loads(raw)
+
+
+def test_worker_approval_http_requests_carry_the_active_turn_parent() -> None:
+    """Create, read, and publication siblings must retain the worker turn."""
+
+    async def go() -> None:
+        requests: list[httpx.Request] = []
+
+        def handle(request: httpx.Request) -> httpx.Response:
+            requests.append(request)
+            if request.method == "GET":
+                return httpx.Response(
+                    200,
+                    json={
+                        "status": "approved",
+                        "resolved_by": "U0APPROVER1",
+                        "resolution_note": None,
+                    },
+                )
+            if request.url.path == "/v1/internal/publications":
+                return httpx.Response(
+                    201,
+                    json={
+                        "id": str(uuid.uuid4()),
+                        "approval_id": str(uuid.uuid4()),
+                        "status": "pending",
+                    },
+                )
+            return httpx.Response(
+                201,
+                json={"id": str(uuid.uuid4()), "status": "pending"},
+            )
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handle)) as http:
+            client = ApprovalClient(
+                api_base_url="https://api.example.test",
+                api_key="platform-test-key",
+                client=http,
+                read_timeout_s=1.0,
+                worker_token="worker-test-token",
+            )
+            approval = ApprovalRequest(
+                conversation_id="thread-example",
+                author="U0REQUEST1",
+                summary="Approve the bounded action",
+                reply_kind="slack",
+                reply_channel="C0EXAMPLE1",
+                reply_placeholder="1700000000.000001",
+                dedupe_key="event-example",
+            )
+            publication = PublicationCreateRequest(
+                deployment_id=uuid.uuid4(),
+                conversation_id="thread-example",
+                repo_full_name="acme-corp/acme-bot",
+                author="U0REQUEST1",
+                summary="Publish the bounded change",
+                reply_kind="slack",
+                reply_channel="C0EXAMPLE1",
+                reply_placeholder="1700000000.000001",
+                reply_endpoint=None,
+                reply_adapter=None,
+                dedupe_key="publication-example",
+                base_sha="0123456789abcdef0123456789abcdef01234567",
+                patch=b"diff --git a/README.md b/README.md\n",
+                changed_paths=("README.md",),
+                expires_in_seconds=600,
+                title="Publish the bounded change",
+                body="Approved platform publication.",
+            )
+
+            with _approval_http_parent():
+                await client.create(approval)
+                await client.get("00000000-0000-0000-0000-000000000001")
+                await client.create_publication(publication)
+
+        assert [request.method for request in requests] == ["POST", "GET", "POST"]
+        assert all(
+            request.headers.get("traceparent") == _HTTP_TRACEPARENT
+            for request in requests
+        )
+
+    asyncio.run(go())
+
+
+def test_worker_approval_http_does_not_fabricate_a_parent() -> None:
+    """A legacy/root call without an active trace stays a clean HTTP root."""
+
+    async def go() -> None:
+        seen: list[httpx.Request] = []
+
+        def handle(request: httpx.Request) -> httpx.Response:
+            seen.append(request)
+            return httpx.Response(
+                200,
+                json={
+                    "status": "approved",
+                    "resolved_by": "U0APPROVER1",
+                    "resolution_note": None,
+                },
+            )
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handle)) as http:
+            client = ApprovalClient(
+                api_base_url="https://api.example.test",
+                api_key="platform-test-key",
+                client=http,
+                read_timeout_s=1.0,
+            )
+            await client.get("00000000-0000-0000-0000-000000000001")
+
+        assert len(seen) == 1
+        assert "traceparent" not in seen[0].headers
+
+    asyncio.run(go())
 
 
 def test_awaiting_approval_creates_record_and_suspends(make_harness) -> None:
@@ -566,9 +706,12 @@ class GrantBinding:
     mirroring the worker's real derivation from durable approval state.
     """
 
-    def __init__(self, *, grant_event_id: str, grant_tool: str) -> None:
+    def __init__(
+        self, *, grant_event_id: str, grant_tool: str, decision: str = "approved"
+    ) -> None:
         self.grant_event_id = grant_event_id
         self.grant_tool = grant_tool
+        self.decision = decision
         self.agent_id = uuid.uuid4()
 
     async def resolve(self, kind: str, channel: str):  # noqa: ANN201
@@ -600,6 +743,9 @@ class GrantBinding:
     async def approval_grant_tool(self, event_id: str, agent_id):  # noqa: ANN001, ANN201
         return self.grant_tool if event_id == self.grant_event_id else None
 
+    async def approval_decision(self, event_id: str, agent_id):  # noqa: ANN001, ANN201
+        return self.decision if event_id == self.grant_event_id else None
+
 
 def test_resume_claim_injects_approval_grant_tool_env(make_harness) -> None:
     """#430: a resume claim for an approved permission-gate approval injects
@@ -627,6 +773,7 @@ def test_resume_claim_injects_approval_grant_tool_env(make_harness) -> None:
             resumed_env = h.fake_k8s.claim_envs[-1]
             assert resumed_env is not None
             assert resumed_env.get("CURIE_APPROVAL_GRANT_TOOL") == "mcp__github__create_issue"
+            assert resumed_env.get("CURIE_APPROVAL_DECISION") == "approved"
 
             # A fresh, unrelated mention has a different event id -> no grant env
             # (re-armed), so an adopted/warm follow-up cannot inherit an allowance.
@@ -636,6 +783,7 @@ def test_resume_claim_injects_approval_grant_tool_env(make_harness) -> None:
             fresh_env = h.fake_k8s.claim_envs[-1]
             assert fresh_env is not None
             assert "CURIE_APPROVAL_GRANT_TOOL" not in fresh_env
+            assert "CURIE_APPROVAL_DECISION" not in fresh_env
 
     asyncio.run(go())
 

--- a/apps/worker/tests/test_run.py
+++ b/apps/worker/tests/test_run.py
@@ -344,7 +344,7 @@ def test_docker_without_otlp_endpoint_warns(caplog) -> None:
     assert isinstance(client, DockerSandboxClient)
     warnings = [
         r for r in caplog.records
-        if r.name == "curie_worker.run" and "OTEL_EXPORTER_OTLP_ENDPOINT" in r.getMessage()
+        if r.name == "curie_worker.run" and "runner OTLP endpoint" in r.getMessage()
     ]
     assert warnings and all(r.levelno == logging.WARNING for r in warnings)
 
@@ -362,8 +362,44 @@ def test_docker_with_otlp_endpoint_does_not_warn(caplog) -> None:
     assert isinstance(client, DockerSandboxClient)
     assert not [
         r for r in caplog.records
-        if r.name == "curie_worker.run" and "OTEL_EXPORTER_OTLP_ENDPOINT" in r.getMessage()
+        if r.name == "curie_worker.run" and "runner OTLP endpoint" in r.getMessage()
     ]
+
+
+@pytest.mark.parametrize(
+    ("runner_endpoint", "expected_endpoint"),
+    [
+        ("http://otel-collector:4318", "http://otel-collector:4318"),
+        ("", None),
+        (None, "http://collector.example.com:4318"),
+    ],
+)
+def test_docker_runner_uses_its_network_specific_otlp_endpoint(
+    monkeypatch, runner_endpoint: str | None, expected_endpoint: str | None
+) -> None:
+    calls: list[list[str]] = []
+    monkeypatch.setattr(DockerSandboxClient, "ensure_image", lambda self: None)
+    monkeypatch.setattr(
+        DockerSandboxClient, "_docker", lambda self, args: calls.append(args) or ""
+    )
+    env = {
+        "CURIE_SANDBOX_SUBSTRATE": "docker",
+        "OTEL_EXPORTER_OTLP_ENDPOINT": "http://collector.example.com:4318",
+    }
+    if runner_endpoint is not None:
+        env["CURIE_RUNNER_OTEL_EXPORTER_OTLP_ENDPOINT"] = runner_endpoint
+    client = _sandbox_client(
+        WorkerConfig(fake_model=True),
+        env,
+        _SUB,
+    )
+    assert isinstance(client, DockerSandboxClient)
+    client.create_claim("acme-sandbox", pool="pool", env={"CURIE_FAKE_MODEL": "1"})
+    assert len(calls) == 1
+    endpoint_args = [arg for arg in calls[0] if arg.startswith("OTEL_EXPORTER_OTLP_ENDPOINT=")]
+    assert endpoint_args == (
+        [f"OTEL_EXPORTER_OTLP_ENDPOINT={expected_endpoint}"] if expected_endpoint else []
+    )
 
 
 def test_sandbox_client_docker_prepulls_image(monkeypatch) -> None:

--- a/apps/worker/tests/test_run.py
+++ b/apps/worker/tests/test_run.py
@@ -396,6 +396,9 @@ def test_docker_runner_uses_its_network_specific_otlp_endpoint(
     assert isinstance(client, DockerSandboxClient)
     client.create_claim("acme-sandbox", pool="pool", env={"CURIE_FAKE_MODEL": "1"})
     assert len(calls) == 1
+    assert not any(
+        arg.startswith("CURIE_RUNNER_OTEL_EXPORTER_OTLP_ENDPOINT=") for arg in calls[0]
+    )
     endpoint_args = [arg for arg in calls[0] if arg.startswith("OTEL_EXPORTER_OTLP_ENDPOINT=")]
     assert endpoint_args == (
         [f"OTEL_EXPORTER_OTLP_ENDPOINT={expected_endpoint}"] if expected_endpoint else []

--- a/cli/scripts/e2e-ladder.sh
+++ b/cli/scripts/e2e-ladder.sh
@@ -341,7 +341,7 @@ cleanup() {
         # Tolerated failure, on top of `set +e`: the stack may never have
         # finished coming up, and a failed `local down` must not skip the
         # sandbox sweep below or change the exit code captured above.
-        "$BIN" local down || echo "warning: \`local down\` failed during teardown; sweeping anyway." >&2
+        "$BIN" local down -f "$REPO_ROOT/compose.dev.yaml" || echo "warning: \`local down\` failed during teardown; sweeping anyway." >&2
         local orphans
         orphans="$(docker ps -aq --filter "label=$SANDBOX_LABEL" 2>/dev/null)"
         if [[ -n "$orphans" ]]; then
@@ -499,6 +499,78 @@ else:
     fi
 }
 
+# A failed background approval turn used to discard both the structured result
+# and its stderr. Keep the raw artifacts private, but retain a bounded verdict
+# that makes an awaiting approval, timeout, or JSON parse failure actionable.
+approval_resume_failure_summary() {
+    local message_file="$1" stderr_file="$2" code="$3"
+    python3 - "$message_file" "$stderr_file" "$code" <<'PY'
+import json
+import pathlib
+import sys
+
+message_file, stderr_file, code = sys.argv[1:]
+try:
+    exit_code = int(code)
+except ValueError:
+    exit_code = 1
+
+try:
+    value = json.loads(pathlib.Path(message_file).read_text())
+except (OSError, json.JSONDecodeError):
+    value = None
+
+if not isinstance(value, dict):
+    status = "parse_failure"
+    finalized = "absent"
+    fields = "none"
+    error_category = "unparseable"
+else:
+    safe_fields = (
+        "awaiting_approval",
+        "timed_out",
+        "finalized",
+        "reply",
+        "error",
+        "fix",
+    )
+    fields = ",".join(field for field in safe_fields if field in value) or "none"
+    finalized = "true" if value.get("finalized") is True else "false" if value.get("finalized") is False else "absent"
+    if value.get("awaiting_approval") is True:
+        status = "awaiting_approval"
+    elif value.get("timed_out") is True:
+        status = "timed_out"
+    elif finalized == "true":
+        status = "finalized"
+    elif finalized == "false":
+        status = "not_finalized"
+    else:
+        status = "json_unclassified"
+    error_category = "error_field" if "error" in value else "none"
+
+try:
+    stderr = pathlib.Path(stderr_file).read_text(errors="replace").lower()
+except OSError:
+    stderr = ""
+if "awaiting_approval" in stderr or "awaiting approval" in stderr:
+    stderr_category = "awaiting_approval"
+elif "timed_out" in stderr or "timed out" in stderr:
+    stderr_category = "timed_out"
+elif any(term in stderr for term in ("json", "parse", "deserial")):
+    stderr_category = "parse_failure"
+elif stderr:
+    stderr_category = "unclassified"
+else:
+    stderr_category = "empty"
+
+print(
+    "approval resume failure: "
+    f"exit_code={exit_code} status={status} finalized={finalized} "
+    f"error_category={error_category} fields={fields} stderr_category={stderr_category}"
+)
+PY
+}
+
 # A `--json` failure is useful to an agent only when stdout contains one object
 # with exactly the centralized error contract's two non-empty string fields.
 # `json.loads` consumes the whole stream, so a second JSON document is rejected
@@ -575,7 +647,7 @@ product_stream_json() {
                 return 1
             }
             docker exec "$valkey" sh -c \
-                'VALKEYCLI_AUTH="${VALKEY_PASSWORD:-}" exec valkey-cli --json "$@"' \
+                'exec valkey-cli --no-auth-warning -a "$VALKEY_PASSWORD" --json "$@"' \
                 sh "$@"
             ;;
         cluster)
@@ -594,7 +666,7 @@ if len(ready) != 1:
 print(ready[0])
 ')" || return 1
             kubectl -n "$CURIE_NAMESPACE" exec "$pod" -- sh -c \
-                'VALKEYCLI_AUTH="${VALKEY_PASSWORD:-}" exec valkey-cli --json "$@"' \
+                'exec valkey-cli --no-auth-warning -a "$VALKEY_PASSWORD" --json "$@"' \
                 sh "$@"
             ;;
         *)
@@ -1147,7 +1219,7 @@ seed_mcp_read_turn() {
 
 seed_approval_resume_turn() {
     local tier="$1" agent_id="${2:-}" query_state="${3:-present}" marker="curie-seed-approval-$$-$RANDOM"
-    local stream_start stream_end message_file token_file pending_file approval_id token out trace_id
+    local stream_start stream_end message_file message_stderr_file token_file pending_file approval_id token out trace_id
     local message_pid code=0 attempt
     if [[ "$LIVE" == "1" || -z "$agent_id" || -z "$marker" ]]; then
         echo "seed-invalid: deterministic approval seed needs fake mode and a deployed agent before telemetry" >&2
@@ -1158,15 +1230,39 @@ seed_approval_resume_turn() {
         return 1
     fi
     umask 077
-    message_file="$(mktemp "$WORKDIR/approval-message.XXXXXX")"
-    token_file="$(mktemp "$WORKDIR/approval-token.XXXXXX")"
-    pending_file="$(mktemp "$WORKDIR/approval-pending.XXXXXX")"
+    if ! message_file="$(mktemp "$WORKDIR/approval-message.XXXXXX")"; then
+        echo "seed-invalid: could not create private approval message artifact" >&2
+        return 1
+    fi
+    if ! message_stderr_file="$(mktemp "$WORKDIR/approval-message-stderr.XXXXXX")"; then
+        rm -f "$message_file"
+        echo "seed-invalid: could not create private approval stderr artifact" >&2
+        return 1
+    fi
+    if ! token_file="$(mktemp "$WORKDIR/approval-token.XXXXXX")"; then
+        rm -f "$message_file" "$message_stderr_file"
+        echo "seed-invalid: could not create private approval token artifact" >&2
+        return 1
+    fi
+    if ! pending_file="$(mktemp "$WORKDIR/approval-pending.XXXXXX")"; then
+        rm -f "$message_file" "$message_stderr_file" "$token_file"
+        echo "seed-invalid: could not create private approval pending artifact" >&2
+        return 1
+    fi
     local scope=()
-    "$BIN" --json "$tier" approvals "$agent_id" "${scope[@]}" \
+    if ! "$BIN" --json "$tier" approvals "$agent_id" "${scope[@]}" \
         --route-resolution e2e=C0EXAMPLE1 --route-approvers e2e=users:U0EXAMPLE1 \
-        >/dev/null
-    "$BIN" --json "$tier" approvals "$agent_id" "${scope[@]}" \
-        --mint-operator-principal U0EXAMPLE1 > "$token_file"
+        >/dev/null; then
+        rm -f "$message_file" "$message_stderr_file" "$token_file" "$pending_file"
+        echo "seed-invalid: could not configure deterministic approval route" >&2
+        return 1
+    fi
+    if ! "$BIN" --json "$tier" approvals "$agent_id" "${scope[@]}" \
+        --mint-operator-principal U0EXAMPLE1 > "$token_file"; then
+        rm -f "$message_file" "$message_stderr_file" "$token_file" "$pending_file"
+        echo "seed-invalid: could not mint deterministic approval principal" >&2
+        return 1
+    fi
     token="$(python3 - "$token_file" <<'PY'
 import json, pathlib, sys
 value = json.loads(pathlib.Path(sys.argv[1]).read_text())
@@ -1176,13 +1272,16 @@ if not isinstance(token, str) or not token:
 print(token)
 PY
 )" || {
-        rm -f "$message_file" "$token_file" "$pending_file"
+        rm -f "$message_file" "$message_stderr_file" "$token_file" "$pending_file"
         return 1
     }
     rm -f "$token_file"
-    stream_start="$(capture_stream_cursor "$tier")" || return 1
+    stream_start="$(capture_stream_cursor "$tier")" || {
+        rm -f "$message_file" "$message_stderr_file" "$pending_file"
+        return 1
+    }
     "$BIN" --json local message --channel C0LOCALDEV --timeout-secs 120 \
-        "[fake:request-approval:e2e] approve correlation $marker" > "$message_file" 2>/dev/null &
+        "[fake:request-approval:e2e] approve correlation $marker" > "$message_file" 2> "$message_stderr_file" &
     message_pid=$!
     approval_id=""
     for attempt in $(seq 1 60); do
@@ -1203,20 +1302,33 @@ PY
     if [[ -z "$approval_id" ]]; then
         kill "$message_pid" 2>/dev/null || true
         wait "$message_pid" 2>/dev/null || true
-        rm -f "$message_file"
+        rm -f "$message_file" "$message_stderr_file"
         echo "seed-invalid: awaiting-approval record did not become pending" >&2
         return 1
     fi
-    CURIE_APPROVAL_PRINCIPAL_TOKEN="$token" "$BIN" --json "$tier" approvals "$agent_id" \
-        "${scope[@]}" --resolve "$approval_id" >/dev/null
-    unset token
-    wait "$message_pid" || code=$?
-    out="$(cat "$message_file")"
-    rm -f "$message_file"
-    if (( code != 0 )); then
-        echo "seed-invalid: approval resolution did not resume to a final reply" >&2
+    if ! CURIE_APPROVAL_PRINCIPAL_TOKEN="$token" "$BIN" --json "$tier" approvals "$agent_id" \
+        "${scope[@]}" --resolve "$approval_id" >/dev/null; then
+        unset token
+        kill "$message_pid" 2>/dev/null || true
+        wait "$message_pid" 2>/dev/null || true
+        rm -f "$message_file" "$message_stderr_file"
+        echo "seed-invalid: deterministic approval resolution command failed" >&2
         return 1
     fi
+    unset token
+    wait "$message_pid" || code=$?
+    if (( code != 0 )); then
+        approval_resume_failure_summary "$message_file" "$message_stderr_file" "$code" >&2
+        rm -f "$message_file" "$message_stderr_file"
+        echo "seed-invalid: approval resolution did not resume to a final reply (exit_code=$code)" >&2
+        return 1
+    fi
+    if ! out="$(cat "$message_file")"; then
+        rm -f "$message_file" "$message_stderr_file"
+        echo "seed-invalid: approval resume produced no readable private result artifact" >&2
+        return 1
+    fi
+    rm -f "$message_file" "$message_stderr_file"
     assert_finalized_reply "$tier approval resume" "$out"
     stream_end="$(capture_stream_cursor "$tier")" || return 1
     trace_id="$(discover_trace_id_for_seed "$tier" "$marker" "$stream_start" "$stream_end")" || return 1
@@ -3477,12 +3589,17 @@ route_local_observability_to_product_collector() {
     unset OTEL_EXPORTER_OTLP_ENDPOINT OTEL_EXPORTER_OTLP_PROTOCOL
     local stale runner dispatcher=""
     # An already-running curie-runner inherited the disposable endpoint. Reap
-    # only this task-owned stack's scoped sandboxes so every later runner is
-    # freshly launched from the restored worker environment.
+    # exactly those emitters, rather than selecting on CURIE_RELEASE: that is a
+    # worker configuration key, not part of the runner's declared boot env, so
+    # it is absent from an actual Docker-substrate sandbox. LOCAL_OTEL_ENDPOINT
+    # is a per-run, task-owned Collector address; matching it keeps an
+    # unrelated sandbox (including a concurrent product-routed one) out of
+    # this recovery sweep while ensuring the post-restore assertion cannot
+    # accidentally inspect the pre-restore runner.
     if (( LOCAL_STACK_OWNED )); then
         while IFS= read -r runner; do
             [[ -n "$runner" ]] || continue
-            if [[ "$(container_env_value "$runner" CURIE_RELEASE)" == "curie" ]]; then
+            if [[ "$(container_env_value "$runner" OTEL_EXPORTER_OTLP_ENDPOINT)" == "$LOCAL_OTEL_ENDPOINT" ]]; then
                 docker rm -f "$runner" >/dev/null
             fi
         done < <(docker ps --filter "label=$SANDBOX_LABEL" --format '{{.Names}}')
@@ -3855,7 +3972,10 @@ rung_local() {
         echo "note: the reused stack's model mode was fixed by whoever ran \`local up\`; it is verified below against this run's mode, and a mismatch fails this rung."
     else
         echo
-        local up_args=(local up)
+        # local up is deliberately pinned to this checkout and builds the
+        # candidate services; a release-channel binary otherwise resolves its
+        # cached release compose and silently tests published images.
+        local up_args=(local up -f "$REPO_ROOT/compose.dev.yaml" --build)
         echo "=== curie ${up_args[*]} ==="
         # The observability query proof below reads traces and metrics through
         # the Curie API. Those routes require Langfuse/ClickHouse, so every
@@ -4038,7 +4158,7 @@ PY
     if (( LOCAL_STACK_OWNED )); then
         echo
         echo "=== curie local down ==="
-        "$BIN" local down
+        "$BIN" local down -f "$REPO_ROOT/compose.dev.yaml"
         LOCAL_STACK_OWNED=0
         stop_local_otel_sink
 

--- a/cli/scripts/e2e-ladder.sh
+++ b/cli/scripts/e2e-ladder.sh
@@ -3597,12 +3597,15 @@ assert_product_runner_endpoints() {
 # The independent sink above proves raw telemetry crossed every service
 # boundary, but it deliberately replaces the product Collector endpoint. Once
 # those controls finish, restore every actual emitter before seeding Langfuse.
+# Pin the task-owned Collector explicitly: unsetting these variables permits
+# shell or ignored local configuration to redirect the evidence elsewhere.
 route_local_observability_to_product_collector() {
     if [[ -n "${STUB_STATE:-}" ]] || (( ! LOCAL_OTEL_SINK_ACTIVE )); then
         return 0
     fi
 
-    unset OTEL_EXPORTER_OTLP_ENDPOINT OTEL_EXPORTER_OTLP_PROTOCOL
+    export OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+    export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
     local stale runner dispatcher=""
     # An already-running curie-runner inherited the disposable endpoint. Reap
     # exactly those emitters, rather than selecting on CURIE_RELEASE: that is a
@@ -3647,7 +3650,7 @@ route_local_observability_to_product_collector() {
             "http://otel-collector:4318" "http/protobuf"
     else
         # curie local message launches the curie-dispatcher image after these
-        # exports are unset; the adjacent stream carrier and exact trace prove
+        # exports are pinned; the adjacent stream carrier and exact trace prove
         # that actual one-shot emitter rather than a config-only assertion.
         echo "local observability: curie-dispatcher one-shot will inherit product routing"
     fi

--- a/cli/scripts/e2e-ladder.sh
+++ b/cli/scripts/e2e-ladder.sh
@@ -320,11 +320,29 @@ fi
 WORKDIR="$(mktemp -d)"
 LOCAL_PRODUCT_EVIDENCE="$WORKDIR/product-observability-local.json"
 CLUSTER_PRODUCT_EVIDENCE="$WORKDIR/product-observability-cluster.json"
+APPROVAL_SEED_MESSAGE_PID=""
+
+stop_approval_seed_message() {
+    local mode="${1:-wait}" pid code=0
+    pid="$APPROVAL_SEED_MESSAGE_PID"
+    [[ -n "$pid" ]] || return 0
+    if [[ "$mode" == "terminate" ]]; then
+        kill "$pid" 2>/dev/null || true
+    fi
+    wait "$pid" 2>/dev/null || code=$?
+    APPROVAL_SEED_MESSAGE_PID=""
+    return "$code"
+}
+
 cleanup() {
     # Capture the real exit code FIRST: a teardown command that fails must not
     # turn a red run green, and a successful teardown must not mask a red rung.
     local code=$?
     set +e
+    # The approval proof owns a background `local message` Slack stub. Reap it
+    # before stack teardown so an interrupted seed cannot retain the stub port
+    # after this run exits.
+    stop_approval_seed_message terminate || true
     # The compose worker spawns runner containers as SIBLINGS on the host daemon
     # via the mounted docker socket, so a rung that died before `local down` can
     # strand them. This raw sweep is a BACKSTOP, not duplication: `local down`
@@ -1220,7 +1238,7 @@ seed_mcp_read_turn() {
 seed_approval_resume_turn() {
     local tier="$1" agent_id="${2:-}" query_state="${3:-present}" marker="curie-seed-approval-$$-$RANDOM"
     local stream_start stream_end message_file message_stderr_file token_file pending_file approval_id token out trace_id
-    local message_pid code=0 attempt
+    local code=0 attempt
     if [[ "$LIVE" == "1" || -z "$agent_id" || -z "$marker" ]]; then
         echo "seed-invalid: deterministic approval seed needs fake mode and a deployed agent before telemetry" >&2
         return 1
@@ -1282,7 +1300,7 @@ PY
     }
     "$BIN" --json local message --channel C0LOCALDEV --timeout-secs 120 \
         "[fake:request-approval:e2e] approve correlation $marker" > "$message_file" 2> "$message_stderr_file" &
-    message_pid=$!
+    APPROVAL_SEED_MESSAGE_PID=$!
     approval_id=""
     for attempt in $(seq 1 60); do
         if "$BIN" --json "$tier" approvals "$agent_id" "${scope[@]}" --list > "$pending_file" 2>/dev/null; then
@@ -1300,8 +1318,7 @@ PY
     done
     rm -f "$pending_file"
     if [[ -z "$approval_id" ]]; then
-        kill "$message_pid" 2>/dev/null || true
-        wait "$message_pid" 2>/dev/null || true
+        stop_approval_seed_message terminate || true
         rm -f "$message_file" "$message_stderr_file"
         echo "seed-invalid: awaiting-approval record did not become pending" >&2
         return 1
@@ -1309,14 +1326,13 @@ PY
     if ! CURIE_APPROVAL_PRINCIPAL_TOKEN="$token" "$BIN" --json "$tier" approvals "$agent_id" \
         "${scope[@]}" --resolve "$approval_id" >/dev/null; then
         unset token
-        kill "$message_pid" 2>/dev/null || true
-        wait "$message_pid" 2>/dev/null || true
+        stop_approval_seed_message terminate || true
         rm -f "$message_file" "$message_stderr_file"
         echo "seed-invalid: deterministic approval resolution command failed" >&2
         return 1
     fi
     unset token
-    wait "$message_pid" || code=$?
+    stop_approval_seed_message || code=$?
     if (( code != 0 )); then
         approval_resume_failure_summary "$message_file" "$message_stderr_file" "$code" >&2
         rm -f "$message_file" "$message_stderr_file"

--- a/cli/scripts/e2e-ladder.sh
+++ b/cli/scripts/e2e-ladder.sh
@@ -1191,8 +1191,8 @@ seed_ordinary_turn() {
         fi
         stream_start="$(capture_stream_cursor "$tier")" || return 1
         out="$("$BIN" --json local message --channel C0LOCALDEV "ordinary correlation $marker" || true)"
-        assert_finalized_reply "$tier ordinary correlation" "$out"
-        assert_product_runner_endpoints
+        assert_finalized_reply "$tier ordinary correlation" "$out" || return 1
+        assert_product_runner_endpoints || return 1
         stream_end="$(capture_stream_cursor "$tier")" || return 1
         [[ "$stream_end" != "$stream_start" ]] || {
             echo "seed-invalid: ordinary seed produced no bounded stream receipt" >&2
@@ -1201,7 +1201,7 @@ seed_ordinary_turn() {
         trace_id="$(discover_trace_id_for_seed "$tier" "$marker" "$stream_start" "$stream_end")" || return 1
         expected_operations="curie.queue.enqueue,curie.queue.process,curie.turn.process,curie.sandbox.claim,curie.runner.rpc,agent.run,curie.reply.post|curie.reply.update"
     fi
-    query_exact_seed_trace "$tier" "$trace_id" "$expected_operations" "" "$query_state"
+    query_exact_seed_trace "$tier" "$trace_id" "$expected_operations" "" "$query_state" || return 1
     LAST_ORDINARY_TRACE_ID="$trace_id"
     LAST_ORDINARY_MEMBERSHIP="$LAST_QUERY_MEMBERSHIP"
     printf '%s' "$trace_id"
@@ -3610,7 +3610,7 @@ assert_product_runner_endpoints() {
     }
     for runner in "${runners[@]}"; do
         assert_product_collector_endpoint curie-runner "$runner" \
-            "http://otel-collector:4318" "http/protobuf"
+            "http://otel-collector:4318" "http/protobuf" || return 1
     done
 }
 
@@ -3709,7 +3709,7 @@ wait_product_collector_ready() {
 
 restart_local_product_collector() {
     docker compose --profile full -f "$REPO_ROOT/compose.dev.yaml" \
-        up -d --force-recreate --no-deps otel-collector >/dev/null
+        up -d --force-recreate --no-deps otel-collector >/dev/null || return 1
     wait_product_collector_ready
 }
 
@@ -3723,158 +3723,118 @@ restore_local_langfuse_auth() {
     restart_local_product_collector
 }
 
-# Exercise the pinned Langfuse exporter with temporary invalid auth while the
-# shipped retry_on_failure (5s/30s/5m) and sending_queue/file_storage settings
-# remain unchanged. The queue_size is 1000; no volume is removed.
+# OTLP HTTP 401 is permanent, not retryable. Keep the shipped Collector retry
+# and file-backed queue settings unchanged; prove rejection is observable and
+# restore credentials before proving a new healthy export.
+assert_product_collector_permanent_auth_rejection() {
+    python3 -c 'import sys; a,f,q,ab,fb,r=map(float,sys.argv[1:]); raise SystemExit(0 if a > ab and f > fb and q == 0 and r == 1 else 1)' "$@"
+}
+
 case_local_langfuse_invalid_auth() {
     local INVALID_LANGFUSE_OTLP_AUTH_HEADER='Basic aW52YWxpZDppbnZhbGlk'
-    local agent_id="$1" original_set=0 original="${LANGFUSE_OTLP_AUTH_HEADER-}"
-    local receipt same_queued_trace_id queue_drained accepted accepted_before sent langfuse_web
-    local collector storage_directory accepted_baseline failed failed_baseline queue_size
-    [[ ${LANGFUSE_OTLP_AUTH_HEADER+x} ]] && original_set=1
-    langfuse_web="$(docker compose --profile full -f "$REPO_ROOT/compose.dev.yaml" ps -q langfuse-web)"
+    local agent_id="$1" original_set=0 original="" failed_phase=0
+    local receipt failed_trace_id recovered_trace_id langfuse_web collector
+    local accepted_baseline failed_baseline accepted failed queue_size rejection
+    local attempt marker stream_start stream_end out
+    if [[ -v LANGFUSE_OTLP_AUTH_HEADER ]]; then
+        original_set=1
+        original="$LANGFUSE_OTLP_AUTH_HEADER"
+    fi
+    langfuse_web="$(docker compose --profile full -f "$REPO_ROOT/compose.dev.yaml" ps -q langfuse-web)" || return 1
     [[ -n "$langfuse_web" ]] || {
         echo "pinned langfuse-web is not running for the real exporter negative" >&2
         return 1
     }
-    storage_directory="$(python3 - "$REPO_ROOT/otel/collector-config.yaml" <<'PY'
-import pathlib, re, sys
-text = pathlib.Path(sys.argv[1]).read_text()
-required = {
-    "sending_queue": r"(?m)^\s*sending_queue:\s*$",
-    "file_storage": r"(?m)^\s*storage:\s*file_storage\s*$",
-    "queue_size": r"(?m)^\s*queue_size:\s*1000\s*$",
-    "retry_horizon": r"(?m)^\s*max_elapsed_time:\s*5m\s*$",
-    }
-missing = [name for name, pattern in required.items() if not re.search(pattern, text)]
-directory = re.search(r"(?m)^\s*directory:\s*([^#\s]+)", text)
-if missing or directory is None:
-    raise SystemExit("shipped Collector durable queue configuration is absent")
-print(directory.group(1))
-PY
-)" || return 1
-    collector="$(docker compose --profile full -f "$REPO_ROOT/compose.dev.yaml" ps -q otel-collector)"
-    docker inspect "$collector" --format '{{json .Mounts}}' | python3 -c '
-import json, os, sys
-mounts = json.load(sys.stdin)
-directory = os.path.normpath(sys.argv[1])
-if not any(
-    directory == os.path.normpath(item.get("Destination", ""))
-    or directory.startswith(os.path.normpath(item.get("Destination", "")) + os.sep)
-    for item in mounts
-    if item.get("Type") == "volume" and item.get("Destination")
-):
-    raise SystemExit("file_storage directory is not backed by a Docker volume")
-' "$storage_directory" || return 1
-    receipt="$(mktemp "$WORKDIR/invalid-auth-trace.XXXXXX")"
-    chmod 600 "$receipt"
-
     echo
-    echo "=== case: pinned Langfuse invalid auth queues and recovers the same ID ==="
+    echo "=== case: pinned Langfuse invalid auth is observable, then fresh export recovers ==="
     if [[ ! "$LAST_ORDINARY_TRACE_ID" =~ ^[0-9a-f]{32}$ ]] || ! query_exact_seed_trace local "$LAST_ORDINARY_TRACE_ID" \
         "curie.queue.enqueue,curie.queue.process,curie.turn.process,curie.sandbox.claim,curie.runner.rpc,agent.run,curie.reply.post|curie.reply.update" \
         >/dev/null; then
-        rm -f "$receipt"
         echo "invalid-auth negative lacks a valid exact-query control" >&2
         return 1
     fi
     echo "invalid-auth negative: valid exact-query control passed before auth changed"
+    receipt="$(mktemp "$WORKDIR/invalid-auth-trace.XXXXXX")" || return 1
+    chmod 600 "$receipt" || { rm -f "$receipt"; return 1; }
+    # A conditional subshell disables Bash errexit, including in nested helpers.
+    # Every required operation explicitly propagates failure to the restore path.
     if ! (
-        set -e
         export LANGFUSE_OTLP_AUTH_HEADER="$INVALID_LANGFUSE_OTLP_AUTH_HEADER"
-        restart_local_product_collector
+        restart_local_product_collector || exit 1
         wait_product_collector_ready || {
             echo "Collector failed the Ready check after invalid-auth restart" >&2
             exit 1
         }
-        accepted_baseline="$(product_collector_metric_value otelcol_receiver_accepted_spans)"
-        failed_baseline="$(product_collector_metric_value otelcol_exporter_send_failed_spans)"
+        collector="$(docker compose --profile full -f "$REPO_ROOT/compose.dev.yaml" ps -q otel-collector)" || exit 1
+        [[ -n "$collector" ]] || exit 1
+        accepted_baseline="$(product_collector_metric_value otelcol_receiver_accepted_spans)" || exit 1
+        failed_baseline="$(product_collector_metric_value otelcol_exporter_send_failed_spans)" || exit 1
 
         marker="curie-seed-invalid-auth-$$-$RANDOM"
-        stream_start="$(capture_stream_cursor local)"
+        stream_start="$(capture_stream_cursor local)" || exit 1
         out="$("$BIN" --json local message --channel C0LOCALDEV \
-            "temporary exporter recovery $marker" || true)"
-        assert_finalized_reply "local invalid-auth seed" "$out"
-        stream_end="$(capture_stream_cursor local)"
-        same_queued_trace_id="$(discover_trace_id_for_seed local "$marker" "$stream_start" "$stream_end")"
+            "observable exporter rejection $marker" || true)"
+        assert_finalized_reply "local invalid-auth seed" "$out" || exit 1
+        stream_end="$(capture_stream_cursor local)" || exit 1
+        failed_trace_id="$(discover_trace_id_for_seed local "$marker" "$stream_start" "$stream_end")" || exit 1
 
         accepted=0
         failed=0
         queue_size=0
+        rejection=0
         for attempt in $(seq 1 45); do
-            accepted="$(product_collector_metric_value otelcol_receiver_accepted_spans)"
-            failed="$(product_collector_metric_value otelcol_exporter_send_failed_spans)"
-            queue_size="$(product_collector_metric_value otelcol_exporter_queue_size)"
-            if python3 -c 'import sys; a,f,q,ab,fb=map(float,sys.argv[1:]); raise SystemExit(0 if a > ab and f > fb and 0 < q <= 1000 else 1)' \
-                "$accepted" "$failed" "$queue_size" "$accepted_baseline" "$failed_baseline"; then
+            accepted="$(product_collector_metric_value otelcol_receiver_accepted_spans)" || exit 1
+            failed="$(product_collector_metric_value otelcol_exporter_send_failed_spans)" || exit 1
+            queue_size="$(product_collector_metric_value otelcol_exporter_queue_size)" || exit 1
+            # Read only this newly recreated Collector's logs. Raw diagnostics
+            # never reach output; require all three code-owned rejection tokens.
+            if docker logs "$collector" 2>&1 | python3 -c '
+import sys
+lines = sys.stdin.read().splitlines()
+raise SystemExit(0 if any(
+    "HTTP Status Code 401" in line and "Permanent error" in line and "not retryable error" in line
+    for line in lines
+) else 1)
+'; then
+                rejection=1
+            fi
+            if assert_product_collector_permanent_auth_rejection \
+                "$accepted" "$failed" "$queue_size" "$accepted_baseline" "$failed_baseline" "$rejection"; then
                 break
             fi
             sleep 2
         done
-        python3 -c 'import sys; a,f,q,ab,fb=map(float,sys.argv[1:]); raise SystemExit(0 if a > ab and f > fb and 0 < q <= 1000 else 1)' \
-            "$accepted" "$failed" "$queue_size" "$accepted_baseline" "$failed_baseline"
-        query_exact_seed_trace local "$same_queued_trace_id" "" "" absent
-
-        # Recreate once while auth is still invalid. The file-backed queue must
-        # survive the process boundary and retry the same pending export.
-        restart_local_product_collector
-        queue_size=0
-        failed=0
-        for attempt in $(seq 1 45); do
-            queue_size="$(product_collector_metric_value otelcol_exporter_queue_size)"
-            failed="$(product_collector_metric_value otelcol_exporter_send_failed_spans)"
-            if python3 -c 'import sys; q,f=map(float,sys.argv[1:]); raise SystemExit(0 if 0 < q <= 1000 and f > 0 else 1)' \
-                "$queue_size" "$failed"; then
-                break
-            fi
-            sleep 2
-        done
-        python3 -c 'import sys; q,f=map(float,sys.argv[1:]); raise SystemExit(0 if 0 < q <= 1000 and f > 0 else 1)' \
-            "$queue_size" "$failed"
-        query_exact_seed_trace local "$same_queued_trace_id" "" "" absent
-
-        python3 - "$receipt" "$same_queued_trace_id" "$accepted" <<'PY'
-import json, pathlib, sys
-pathlib.Path(sys.argv[1]).write_text(json.dumps({
-    "trace_id": sys.argv[2],
-    "accepted": float(sys.argv[3]),
-}))
-PY
+        assert_product_collector_permanent_auth_rejection \
+            "$accepted" "$failed" "$queue_size" "$accepted_baseline" "$failed_baseline" "$rejection" || exit 1
+        query_exact_seed_trace local "$failed_trace_id" "" "" absent || exit 1
+        printf '%s\n' "$failed_trace_id" > "$receipt" || exit 1
+        echo "invalid-auth negative: accepted/failed deltas, permanent HTTP401, empty queue, and exact absence proved"
     ); then
-        restore_local_langfuse_auth "$original_set" "$original" || true
-        rm -f "$receipt"
-        echo "invalid-auth queue proof failed; product Collector auth was restored" >&2
-        return 1
+        failed_phase=1
     fi
 
-    read -r same_queued_trace_id accepted_before < <(python3 - "$receipt" <<'PY'
-import json, pathlib, sys
-value = json.loads(pathlib.Path(sys.argv[1]).read_text())
-print(value["trace_id"], value["accepted"])
-PY
-    )
+    # Restoration executes once whether any negative assertion passed or failed.
+    if ! restore_local_langfuse_auth "$original_set" "$original"; then
+        rm -f "$receipt"
+        echo "invalid-auth proof could not restore product Collector auth" >&2
+        return 1
+    fi
+    if (( failed_phase )); then
+        rm -f "$receipt"
+        echo "invalid-auth rejection proof failed; product Collector auth was restored" >&2
+        return 1
+    fi
+    read -r failed_trace_id < "$receipt" || { rm -f "$receipt"; return 1; }
     rm -f "$receipt"
-    restore_local_langfuse_auth "$original_set" "$original"
-    wait_product_collector_ready || {
-        echo "Collector failed the Ready check after valid-auth restart" >&2
+    seed_ordinary_turn local "$agent_id" present || return 1
+    recovered_trace_id="$LAST_ORDINARY_TRACE_ID"
+    [[ "$recovered_trace_id" != "$failed_trace_id" ]] || {
+        echo "restored-auth proof did not produce a fresh trace" >&2
         return 1
     }
-    # The queue-preserving restart must deliver this same_queued_trace_id within
-    # the unchanged five-minute retry horizon; a fresh trace is not a substitute.
-    query_exact_seed_trace local "$same_queued_trace_id"
-    queue_drained=""
-    for attempt in $(seq 1 60); do
-        queue_drained="$(product_collector_metric_value otelcol_exporter_queue_size)"
-        if python3 -c 'import sys; raise SystemExit(0 if float(sys.argv[1]) == 0 else 1)' "$queue_drained"; then
-            break
-        fi
-        sleep 2
-    done
-    python3 -c 'import sys; raise SystemExit(0 if float(sys.argv[1]) == 0 else 1)' "$queue_drained" || {
-        echo "recovered exact trace but the durable sending queue did not drain" >&2
-        return 1
-    }
-    echo "local invalid-auth negative: durable same-ID recovery and queue drain proved"
+    query_exact_seed_trace local "$recovered_trace_id" \
+        "curie.queue.enqueue,curie.queue.process,curie.turn.process,curie.sandbox.claim,curie.runner.rpc,agent.run,curie.reply.post|curie.reply.update" || return 1
+    echo "local invalid-auth negative: bounded observable rejection and fresh healthy exact-trace recovery proved"
 }
 
 assert_local_otel_failed_turn() {

--- a/cli/scripts/e2e-ladder.sh
+++ b/cli/scripts/e2e-ladder.sh
@@ -1011,6 +1011,7 @@ PY
 query_exact_seed_trace() {
     local tier="$1" trace_id="$2" expected_csv="${3:-}" expected_decision="${4:-}" expected_state="${5:-present}"
     local attempt code=0 private_read safe_read membership observation_count saw_valid=0
+    local last_query_state="query-error"
     LAST_QUERY_MEMBERSHIP=""
     LAST_QUERY_OBSERVATION_COUNT="0"
     umask 077
@@ -1097,8 +1098,10 @@ PY
             fi
             continue
         fi
+        last_query_state="query-error"
         if (( code == 0 )); then
             if ! sanitize_exact_trace_read "$trace_id" "$private_read" "$expected_csv" "$expected_decision" > "$safe_read"; then
+                last_query_state="malformed-response"
                 if [[ "$expected_state" == "observe" ]]; then
                     rm -f "$private_read" "$safe_read"
                     echo "exact trace response was malformed rather than selectively incomplete" >&2
@@ -1106,6 +1109,7 @@ PY
                 fi
             else
                 saw_valid=1
+                last_query_state="incomplete-membership"
                 read -r membership observation_count < <(python3 - "$safe_read" "$expected_csv" "$expected_decision" <<'PY'
 import json, pathlib, sys
 value = json.loads(pathlib.Path(sys.argv[1]).read_text())
@@ -1157,8 +1161,12 @@ PY
         rm -f "$private_read" "$safe_read"
         return 0
     fi
+    echo "exact trace failed the bounded ingestion poll: $last_query_state (cli exit $code)" >&2
+    if [[ "$last_query_state" == "incomplete-membership" ]]; then
+        # Only the allowlisted projection, never the original trace response.
+        cat "$safe_read" >&2
+    fi
     rm -f "$private_read" "$safe_read"
-    echo "exact trace did not become queryable inside the bounded ingestion poll" >&2
     return 1
 }
 
@@ -3027,6 +3035,7 @@ start_local_otel_sink() {
     LOCAL_OTEL_ENDPOINT="http://$gateway:$otlp_port"
     LOCAL_OTEL_METRICS_ENDPOINT="http://127.0.0.1:$metrics_port/metrics"
     export OTEL_EXPORTER_OTLP_ENDPOINT="$LOCAL_OTEL_ENDPOINT"
+    export CURIE_WORKER_OTEL_EXPORTER_OTLP_ENDPOINT="$LOCAL_OTEL_ENDPOINT"
     export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 
     local attempt
@@ -3544,6 +3553,17 @@ assert_local_otel_healthy_turn() {
     assert_bounded_metric_attributes "$baseline"
 }
 
+# local up --build pins these references inside its child process only. Raw
+# Compose fault injection/restoration must retain that candidate identity too.
+pin_local_source_images() {
+    if (( ! LOCAL_STACK_OWNED )); then
+        return 0
+    fi
+    export CURIE_BASE_TAG=dev
+    export CURIE_RUNNER_IMAGE=ghcr.io/curie-eng/curie-runner:dev
+    export CURIE_DISPATCHER_IMAGE=ghcr.io/curie-eng/curie-dispatcher:dev
+}
+
 inject_local_runner_failure() {
     LOCAL_OTEL_FAILURE_MODE=1
     export CURIE_FAKE_MODEL=0
@@ -3605,6 +3625,7 @@ route_local_observability_to_product_collector() {
     fi
 
     export OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+    export CURIE_WORKER_OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:24318
     export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
     local stale runner dispatcher=""
     # An already-running curie-runner inherited the disposable endpoint. Reap
@@ -3642,7 +3663,7 @@ route_local_observability_to_product_collector() {
     assert_product_collector_endpoint curie-api "$api" \
         "http://otel-collector:4318" "http/protobuf"
     assert_product_collector_endpoint curie-worker "$worker" \
-        "http://otel-collector:4318" "http/protobuf"
+        "http://127.0.0.1:24318" "http/protobuf"
     if [[ -n "$dispatcher" ]]; then
         dispatcher="$(docker ps --filter 'label=com.docker.compose.project=curie' \
             --filter 'label=com.docker.compose.service=curie-dispatcher' --format '{{.Names}}')"
@@ -4009,6 +4030,7 @@ rung_local() {
         # `local down` is safe against a partial or already-stopped stack.
         LOCAL_STACK_OWNED=1
         "$BIN" "${up_args[@]}"
+        pin_local_source_images
     fi
 
     echo

--- a/cli/scripts/e2e-ladder.sh
+++ b/cli/scripts/e2e-ladder.sh
@@ -208,6 +208,15 @@ MCP_RECEIPT_IMAGE=""
 LAST_ORDINARY_TRACE_ID=""
 LAST_MCP_TRACE_ID=""
 LAST_APPROVAL_TRACE_ID=""
+LAST_ORDINARY_MEMBERSHIP=""
+LAST_MCP_MEMBERSHIP=""
+LAST_APPROVAL_MEMBERSHIP=""
+LAST_QUERY_MEMBERSHIP=""
+LAST_QUERY_OBSERVATION_COUNT="0"
+CLUSTER_TURN_TEMPLATE=""
+CLUSTER_SEEDED_TRACE_ID=""
+CLUSTER_SEEDED_REPLY_REF=""
+CLUSTER_IMAGE_IDS_MATCH="false"
 LOCAL_PRODUCT_EVIDENCE=""
 CLUSTER_PRODUCT_EVIDENCE=""
 
@@ -310,6 +319,7 @@ fi
 WORKDIR="$(mktemp -d)"
 LOCAL_PRODUCT_EVIDENCE="$WORKDIR/product-observability-local.json"
 CLUSTER_PRODUCT_EVIDENCE="$WORKDIR/product-observability-cluster.json"
+CLUSTER_TURN_TEMPLATE="$WORKDIR/cluster-turn-template.json"
 cleanup() {
     # Capture the real exit code FIRST: a teardown command that fails must not
     # turn a red run green, and a successful teardown must not mask a red rung.
@@ -546,8 +556,10 @@ print(start.strftime("%Y-%m-%dT%H:%M:%SZ"), end.strftime("%Y-%m-%dT%H:%M:%SZ"))
     echo "local observability metrics: captured explicit UTC window $OBSERVABILITY_START through $OBSERVABILITY_END around the just-completed local turn"
 }
 
-# Execute a read-only Valkey command against the product runs stream. Passwords
-# stay inside the selected container/pod and no command output is logged.
+# Execute a bounded Valkey command against the product runs stream. Passwords
+# stay inside the selected container/pod and no command output is logged. The
+# only write caller is the explicit carrier seed in a preflight-validated,
+# operator-owned release; all discovery and reply observations are read-only.
 product_stream_json() {
     local tier="$1"
     shift
@@ -677,6 +689,136 @@ PY
     printf '%s' "$trace_id"
 }
 
+# Capture one validated disconnected-cluster turn as a private shape template.
+# The payload-only control itself is never treated as correlation evidence.
+capture_cluster_turn_template() {
+    local marker="$1" stream_start="$2" stream_end="$3" private_slice
+    umask 077
+    private_slice="$(mktemp "$WORKDIR/cluster-template-stream.XXXXXX")"
+    product_stream_json cluster XRANGE curie:runs "($stream_start" "$stream_end" > "$private_slice" || {
+        rm -f "$private_slice"
+        return 1
+    }
+    python3 - "$private_slice" "$marker" "$CLUSTER_TURN_TEMPLATE" <<'PY'
+import json, pathlib, sys
+rows = json.loads(pathlib.Path(sys.argv[1]).read_text())
+marker = sys.argv[2]
+matches = []
+for row in rows:
+    if not isinstance(row, list) or len(row) != 2 or not isinstance(row[1], list):
+        raise SystemExit("seed-invalid: malformed cluster template slice")
+    fields = row[1]
+    for index in range(0, len(fields) - 1, 2):
+        if fields[index] != "payload":
+            continue
+        try:
+            payload = json.loads(fields[index + 1])
+        except (TypeError, json.JSONDecodeError):
+            continue
+        text = payload.get("text") if isinstance(payload, dict) else None
+        if isinstance(text, str) and marker in text:
+            matches.append(payload)
+if len(matches) != 1:
+    raise SystemExit("seed-invalid: cluster control did not select one private turn template")
+handle = matches[0].get("reply_handle")
+if not isinstance(handle, dict) or handle.get("adapter") != "curie-cluster-message":
+    raise SystemExit("seed-invalid: cluster control omitted the reserved reply adapter")
+pathlib.Path(sys.argv[3]).write_text(json.dumps(matches[0], separators=(",", ":")))
+PY
+    rm -f "$private_slice"
+}
+
+# Re-seed the validated cluster shape with fresh identifiers and an explicit
+# adjacent W3C carrier. This is a turn/data mutation only in the operator-owned
+# release; it never installs, upgrades, deletes, or rewrites cluster resources.
+enqueue_cluster_carried_turn() {
+    local marker="$1" text="$2" private_payload private_meta payload raw_id stream_start stream_end discovered traceparent
+    [[ -s "$CLUSTER_TURN_TEMPLATE" ]] || {
+        echo "seed-invalid: cluster carried seed lacks its validated control template" >&2
+        return 1
+    }
+    umask 077
+    private_payload="$(mktemp "$WORKDIR/cluster-carried-payload.XXXXXX")"
+    private_meta="$(mktemp "$WORKDIR/cluster-carried-meta.XXXXXX")"
+    python3 - "$CLUSTER_TURN_TEMPLATE" "$private_payload" "$private_meta" "$text" <<'PY'
+import json, pathlib, secrets, sys, uuid
+from datetime import UTC, datetime
+
+value = json.loads(pathlib.Path(sys.argv[1]).read_text())
+reply_ref = str(uuid.uuid4())
+trace_id = secrets.token_hex(16)
+span_id = secrets.token_hex(8)
+value["event_id"] = f"EvSIM-{uuid.uuid4()}"
+value["conversation_id"] = f"C0EXAMPLE1:{uuid.uuid4()}"
+value["text"] = sys.argv[4]
+value["received_at"] = datetime.now(UTC).isoformat()
+value["reply_handle"]["placeholder"] = reply_ref
+pathlib.Path(sys.argv[2]).write_text(json.dumps(value, separators=(",", ":")))
+pathlib.Path(sys.argv[3]).write_text(json.dumps({
+    "trace_id": trace_id,
+    "traceparent": f"00-{trace_id}-{span_id}-01",
+    "reply_ref": reply_ref,
+}, separators=(",", ":")))
+PY
+    stream_start="$(capture_stream_cursor cluster)" || return 1
+    payload="$(cat "$private_payload")"
+    read -r CLUSTER_SEEDED_TRACE_ID traceparent CLUSTER_SEEDED_REPLY_REF < <(python3 - "$private_meta" <<'PY'
+import json, pathlib, sys
+value = json.loads(pathlib.Path(sys.argv[1]).read_text())
+print(value["trace_id"], value["traceparent"], value["reply_ref"])
+PY
+    )
+    raw_id="$(product_stream_json cluster XADD curie:runs '*' payload "$payload" traceparent "$traceparent")" || return 1
+    stream_end="$(printf '%s' "$raw_id" | python3 -c 'import json,sys; value=json.load(sys.stdin); print(value if isinstance(value,str) else "")')"
+    rm -f "$private_payload" "$private_meta"
+    [[ -n "$stream_end" && "$stream_end" != "$stream_start" ]] || {
+        echo "seed-invalid: explicit cluster carrier seed produced no stream entry" >&2
+        return 1
+    }
+    discovered="$(discover_trace_id_for_seed cluster "$marker" "$stream_start" "$stream_end")" || return 1
+    [[ "$discovered" == "$CLUSTER_SEEDED_TRACE_ID" ]] || {
+        echo "seed-invalid: explicit cluster carrier did not round-trip to its exact trace id" >&2
+        return 1
+    }
+}
+
+wait_cluster_carried_reply() {
+    local reply_ref="$1" terminal_key events_key private_events terminal attempt
+    [[ "$reply_ref" =~ ^[0-9a-f-]{36}$ ]] || return 1
+    terminal_key="curie:cluster-message-replies:{$reply_ref}:terminal"
+    events_key="curie:cluster-message-replies:{$reply_ref}:events"
+    umask 077
+    private_events="$(mktemp "$WORKDIR/cluster-carried-reply.XXXXXX")"
+    terminal=""
+    for attempt in $(seq 1 120); do
+        terminal="$(product_stream_json cluster GET "$terminal_key" 2>/dev/null || true)"
+        if [[ "$terminal" == '"1"' ]]; then
+            break
+        fi
+        sleep 1
+    done
+    [[ "$terminal" == '"1"' ]] || {
+        rm -f "$private_events"
+        echo "seed-invalid: explicit cluster carrier turn did not finalize" >&2
+        return 1
+    }
+    product_stream_json cluster LRANGE "$events_key" 0 -1 > "$private_events" || return 1
+    python3 - "$private_events" <<'PY'
+import json, pathlib, sys
+rows = json.loads(pathlib.Path(sys.argv[1]).read_text())
+events = []
+for row in rows:
+    value = json.loads(row) if isinstance(row, str) else None
+    if not isinstance(value, dict) or not isinstance(value.get("event"), str):
+        raise SystemExit("seed-invalid: cluster reply receipt is malformed")
+    events.append(value["event"])
+if "turn.completed" not in events or not any(item in {"reply.post", "reply.update"} for item in events):
+    raise SystemExit("seed-invalid: cluster reply receipt omitted reply or completion")
+PY
+    rm -f "$private_events"
+    echo "cluster carried seed: finalized=true reply_observed=true"
+}
+
 # Convert a private exact-detail response into the sole public trace evidence.
 # Explicitly private source fields (input, output, session, user, headers) are
 # ignored. Operation names are reduced to a code-owned allowlist.
@@ -726,15 +868,9 @@ def walk(node):
 
 for root in tree:
     walk(root)
-expected = [item for item in expected_csv.split(",") if item]
-missing = [item for item in expected if not any(candidate in operations for candidate in item.split("|"))]
-if missing:
-    raise SystemExit("exact trace omitted required allowlisted operations")
 decision = value.get("approval_decision")
 if decision is not None and decision not in {"approved", "rejected", "expired"}:
     raise SystemExit("exact trace carried a non-allowlisted approval decision")
-if expected_decision and decision != expected_decision:
-    raise SystemExit("exact trace carried the wrong approval decision")
 
 service = []
 if any(op == "curie.queue.enqueue" for op in operations):
@@ -765,7 +901,9 @@ PY
 # sanitize_exact_trace_read reaches stdout.
 query_exact_seed_trace() {
     local tier="$1" trace_id="$2" expected_csv="${3:-}" expected_decision="${4:-}" expected_state="${5:-present}"
-    local attempt code=0 private_read safe_read
+    local attempt code=0 private_read safe_read membership observation_count saw_valid=0
+    LAST_QUERY_MEMBERSHIP=""
+    LAST_QUERY_OBSERVATION_COUNT="0"
     umask 077
     private_read="$(mktemp "$WORKDIR/exact-trace.XXXXXX")"
     safe_read="$(mktemp "$WORKDIR/safe-trace.XXXXXX")"
@@ -821,10 +959,66 @@ PY
             fi
             continue
         fi
-        if (( code == 0 )) && sanitize_exact_trace_read "$trace_id" "$private_read" "$expected_csv" "$expected_decision" > "$safe_read"; then
-            cat "$safe_read"
-            rm -f "$private_read" "$safe_read"
-            return 0
+        if [[ "$expected_state" == "observe" && "$code" -ne 0 ]]; then
+            if (( code != 1 )) || ! python3 - "$private_read" "$trace_id" <<'PY'
+import json
+import pathlib
+import sys
+
+source, trace_id = sys.argv[1:3]
+try:
+    value = json.loads(pathlib.Path(source).read_text())
+except (OSError, json.JSONDecodeError):
+    raise SystemExit(1)
+expected = f'observability trace "{trace_id}" was not found'
+if not isinstance(value, dict) or set(value) != {"error", "fix"}:
+    raise SystemExit(1)
+if value.get("error") not in {"exact trace not found", expected}:
+    raise SystemExit(1)
+if not isinstance(value.get("fix"), str) or not value["fix"].strip():
+    raise SystemExit(1)
+PY
+            then
+                rm -f "$private_read" "$safe_read"
+                echo "exact trace observation returned an unexpected query failure" >&2
+                return 1
+            fi
+            if (( attempt < OBSERVABILITY_POLL_ATTEMPTS )); then
+                sleep "$OBSERVABILITY_POLL_INTERVAL_SECONDS"
+            fi
+            continue
+        fi
+        if (( code == 0 )); then
+            if ! sanitize_exact_trace_read "$trace_id" "$private_read" "$expected_csv" "$expected_decision" > "$safe_read"; then
+                if [[ "$expected_state" == "observe" ]]; then
+                    rm -f "$private_read" "$safe_read"
+                    echo "exact trace response was malformed rather than selectively incomplete" >&2
+                    return 1
+                fi
+            else
+                saw_valid=1
+                read -r membership observation_count < <(python3 - "$safe_read" "$expected_csv" "$expected_decision" <<'PY'
+import json, pathlib, sys
+value = json.loads(pathlib.Path(sys.argv[1]).read_text())
+expected = [item for item in sys.argv[2].split(",") if item]
+operations = value["operation"]
+missing = [
+    item for item in expected
+    if not any(candidate in operations for candidate in item.split("|"))
+]
+decision_matches = not sys.argv[3] or value["approval_decision"] == sys.argv[3]
+membership = value["observation_count"] > 0 and not missing and decision_matches
+print("true" if membership else "false", value["observation_count"])
+PY
+                )
+                LAST_QUERY_MEMBERSHIP="$membership"
+                LAST_QUERY_OBSERVATION_COUNT="$observation_count"
+                if [[ "$membership" == "true" || "$expected_state" == "stub" ]]; then
+                    cat "$safe_read"
+                    rm -f "$private_read" "$safe_read"
+                    return 0
+                fi
+            fi
         fi
         if (( attempt < OBSERVABILITY_POLL_ATTEMPTS )); then
             sleep "$OBSERVABILITY_POLL_INTERVAL_SECONDS"
@@ -835,19 +1029,39 @@ PY
         echo "exact trace remained not-found through the full bounded observation poll"
         return 0
     fi
+    if [[ "$expected_state" == "observe" && "$saw_valid" == "1" ]]; then
+        cat "$safe_read"
+        rm -f "$private_read" "$safe_read"
+        return 0
+    fi
+    if [[ "$expected_state" == "observe" ]]; then
+        LAST_QUERY_MEMBERSHIP="false"
+        LAST_QUERY_OBSERVATION_COUNT="0"
+        python3 - "$trace_id" <<'PY'
+import json, sys
+print(json.dumps({
+    "trace_id": sys.argv[1], "service": [], "operation": [],
+    "observation_count": 0, "observation_type": [],
+    "approval_decision": None,
+}, sort_keys=True, separators=(",", ":")))
+PY
+        rm -f "$private_read" "$safe_read"
+        return 0
+    fi
     rm -f "$private_read" "$safe_read"
     echo "exact trace did not become queryable inside the bounded ingestion poll" >&2
     return 1
 }
 
 seed_ordinary_turn() {
-    local tier="$1" agent_id="${2:-}" marker="curie-seed-ordinary-$$-$RANDOM"
+    local tier="$1" agent_id="${2:-}" query_state="${3:-present}" marker="curie-seed-ordinary-$$-$RANDOM"
     local stream_start stream_end out trace_id expected_operations=""
     if [[ -z "$marker" || "$tier" != "local" && "$tier" != "cluster" ]]; then
         echo "seed-invalid: ordinary seed precondition failed before telemetry" >&2
         return 1
     fi
     if [[ -n "${STUB_STATE:-}" ]]; then
+        query_state="stub"
         trace_id="${STUB_OBSERVABILITY_TRACE_ID:-}"
         [[ "$trace_id" =~ ^[0-9a-f]{32}$ ]] || {
             echo "seed-invalid: stub exact trace id is absent" >&2
@@ -870,16 +1084,25 @@ seed_ordinary_turn() {
             echo "seed-invalid: ordinary seed produced no bounded stream receipt" >&2
             return 1
         }
-        trace_id="$(discover_trace_id_for_seed "$tier" "$marker" "$stream_start" "$stream_end")" || return 1
-        expected_operations="curie.queue.enqueue,curie.queue.process,curie.turn.process,curie.sandbox.claim,curie.runner.rpc,agent.run,curie.reply.post|curie.reply.update"
+        if [[ "$tier" == "cluster" ]]; then
+            capture_cluster_turn_template "$marker" "$stream_start" "$stream_end" || return 1
+            enqueue_cluster_carried_turn "$marker" "ordinary correlation $marker" || return 1
+            wait_cluster_carried_reply "$CLUSTER_SEEDED_REPLY_REF" || return 1
+            trace_id="$CLUSTER_SEEDED_TRACE_ID"
+            expected_operations="curie.queue.process,curie.turn.process,curie.sandbox.claim,curie.runner.rpc,agent.run,curie.reply.post|curie.reply.update"
+        else
+            trace_id="$(discover_trace_id_for_seed "$tier" "$marker" "$stream_start" "$stream_end")" || return 1
+            expected_operations="curie.queue.enqueue,curie.queue.process,curie.turn.process,curie.sandbox.claim,curie.runner.rpc,agent.run,curie.reply.post|curie.reply.update"
+        fi
     fi
-    query_exact_seed_trace "$tier" "$trace_id" "$expected_operations"
+    query_exact_seed_trace "$tier" "$trace_id" "$expected_operations" "" "$query_state"
     LAST_ORDINARY_TRACE_ID="$trace_id"
+    LAST_ORDINARY_MEMBERSHIP="$LAST_QUERY_MEMBERSHIP"
     printf '%s' "$trace_id"
 }
 
 seed_mcp_read_turn() {
-    local tier="$1" agent_id="${2:-}" agent_name="${3:-}" marker="curie-seed-mcp-$$-$RANDOM"
+    local tier="$1" agent_id="${2:-}" agent_name="${3:-}" query_state="${4:-present}" marker="curie-seed-mcp-$$-$RANDOM"
     local stream_start stream_end out trace_id before_count after_count alias release namespace
     if [[ "$LIVE" != "1" || -z "$agent_name" || -z "$marker" ]]; then
         echo "seed-invalid: MCP read seed needs live mode, a deployed agent, and a marker before telemetry" >&2
@@ -897,31 +1120,38 @@ seed_mcp_read_turn() {
     alias="$(connector_object_name "$release" "$agent_name" "$MCP_RECEIPT_CONNECTOR").$namespace.svc.cluster.local"
     MCP_RECEIPT_ALIAS="$alias"
     before_count="$(mcp_receipt_call_count "$tier" "$alias")" || return 1
-    stream_start="$(capture_stream_cursor "$tier")" || return 1
     if [[ "$tier" == "local" ]]; then
+        stream_start="$(capture_stream_cursor "$tier")" || return 1
         out="$("$BIN" --json local message --channel C0LOCALDEV \
             "Call the receipt_read tool exactly once, then answer receipt complete. $marker" || true)"
     else
-        out="$("$BIN" --json cluster message --namespace "$CURIE_NAMESPACE" \
-            --release "$CURIE_RELEASE" \
-            "Call the receipt_read tool exactly once, then answer receipt complete. $marker" || true)"
+        enqueue_cluster_carried_turn "$marker" \
+            "Call the receipt_read tool exactly once, then answer receipt complete. $marker" || return 1
+        wait_cluster_carried_reply "$CLUSTER_SEEDED_REPLY_REF" || return 1
     fi
-    assert_finalized_reply "$tier MCP correlation" "$out"
+    if [[ "$tier" == "local" ]]; then
+        assert_finalized_reply "$tier MCP correlation" "$out"
+    fi
     after_count="$(mcp_receipt_call_count "$tier" "$alias")" || return 1
     if (( after_count != before_count + 1 )); then
         echo "seed-invalid: MCP seed did not produce exactly one independent call receipt" >&2
         return 1
     fi
     echo "MCP receipt call count delta=1"
-    stream_end="$(capture_stream_cursor "$tier")" || return 1
-    trace_id="$(discover_trace_id_for_seed "$tier" "$marker" "$stream_start" "$stream_end")" || return 1
-    query_exact_seed_trace "$tier" "$trace_id" "execute_tool"
+    if [[ "$tier" == "local" ]]; then
+        stream_end="$(capture_stream_cursor "$tier")" || return 1
+        trace_id="$(discover_trace_id_for_seed "$tier" "$marker" "$stream_start" "$stream_end")" || return 1
+    else
+        trace_id="$CLUSTER_SEEDED_TRACE_ID"
+    fi
+    query_exact_seed_trace "$tier" "$trace_id" "execute_tool" "" "$query_state"
     LAST_MCP_TRACE_ID="$trace_id"
+    LAST_MCP_MEMBERSHIP="$LAST_QUERY_MEMBERSHIP"
     printf '%s' "$trace_id"
 }
 
 seed_approval_resume_turn() {
-    local tier="$1" agent_id="${2:-}" marker="curie-seed-approval-$$-$RANDOM"
+    local tier="$1" agent_id="${2:-}" query_state="${3:-present}" marker="curie-seed-approval-$$-$RANDOM"
     local stream_start stream_end message_file token_file pending_file approval_id token out trace_id
     local message_pid code=0 attempt
     if [[ "$LIVE" == "1" || -z "$agent_id" || -z "$marker" ]]; then
@@ -954,16 +1184,16 @@ PY
         return 1
     }
     rm -f "$token_file"
-    stream_start="$(capture_stream_cursor "$tier")" || return 1
     if [[ "$tier" == "local" ]]; then
+        stream_start="$(capture_stream_cursor "$tier")" || return 1
         "$BIN" --json local message --channel C0LOCALDEV --timeout-secs 120 \
             "[fake:request-approval:e2e] approve correlation $marker" > "$message_file" 2>/dev/null &
+        message_pid=$!
     else
-        "$BIN" --json cluster message --namespace "$CURIE_NAMESPACE" \
-            --release "$CURIE_RELEASE" --timeout-secs 120 \
-            "[fake:request-approval:e2e] approve correlation $marker" > "$message_file" 2>/dev/null &
+        enqueue_cluster_carried_turn "$marker" \
+            "[fake:request-approval:e2e] approve correlation $marker" || return 1
+        trace_id="$CLUSTER_SEEDED_TRACE_ID"
     fi
-    message_pid=$!
     approval_id=""
     for attempt in $(seq 1 60); do
         if "$BIN" --json "$tier" approvals "$agent_id" "${scope[@]}" --list > "$pending_file" 2>/dev/null; then
@@ -981,8 +1211,10 @@ PY
     done
     rm -f "$pending_file"
     if [[ -z "$approval_id" ]]; then
-        kill "$message_pid" 2>/dev/null || true
-        wait "$message_pid" 2>/dev/null || true
+        if [[ "$tier" == "local" ]]; then
+            kill "$message_pid" 2>/dev/null || true
+            wait "$message_pid" 2>/dev/null || true
+        fi
         rm -f "$message_file"
         echo "seed-invalid: awaiting-approval record did not become pending" >&2
         return 1
@@ -990,20 +1222,26 @@ PY
     CURIE_APPROVAL_PRINCIPAL_TOKEN="$token" "$BIN" --json "$tier" approvals "$agent_id" \
         "${scope[@]}" --resolve "$approval_id" >/dev/null
     unset token
-    wait "$message_pid" || code=$?
-    out="$(cat "$message_file")"
-    rm -f "$message_file"
-    if (( code != 0 )); then
-        echo "seed-invalid: approval resolution did not resume to a final reply" >&2
-        return 1
+    if [[ "$tier" == "local" ]]; then
+        wait "$message_pid" || code=$?
+        out="$(cat "$message_file")"
+        rm -f "$message_file"
+        if (( code != 0 )); then
+            echo "seed-invalid: approval resolution did not resume to a final reply" >&2
+            return 1
+        fi
+        assert_finalized_reply "$tier approval resume" "$out"
+        stream_end="$(capture_stream_cursor "$tier")" || return 1
+        trace_id="$(discover_trace_id_for_seed "$tier" "$marker" "$stream_start" "$stream_end")" || return 1
+    else
+        rm -f "$message_file"
+        wait_cluster_carried_reply "$CLUSTER_SEEDED_REPLY_REF" || return 1
     fi
-    assert_finalized_reply "$tier approval resume" "$out"
-    stream_end="$(capture_stream_cursor "$tier")" || return 1
-    trace_id="$(discover_trace_id_for_seed "$tier" "$marker" "$stream_start" "$stream_end")" || return 1
     query_exact_seed_trace "$tier" "$trace_id" \
         "curie.approval.suspend,curie.approval.resolve,curie.approval.resume,curie.reply.post|curie.reply.update" \
-        "approved"
+        "approved" "$query_state"
     LAST_APPROVAL_TRACE_ID="$trace_id"
+    LAST_APPROVAL_MEMBERSHIP="$LAST_QUERY_MEMBERSHIP"
     printf '%s' "$trace_id"
 }
 
@@ -3496,20 +3734,6 @@ PY
         echo "recovered exact trace but the durable sending queue did not drain" >&2
         return 1
     }
-    accepted="$accepted_before"
-    sent="$(product_collector_metric_value otelcol_exporter_sent_spans)"
-    python3 - "$LOCAL_PRODUCT_EVIDENCE" "$accepted" "$sent" <<'PY'
-import json, pathlib, sys
-pathlib.Path(sys.argv[1]).write_text(json.dumps({
-    "surface": "local",
-    "seed_valid": True,
-    "raw_emitted_observations": 1,
-    "otelcol_receiver_accepted_spans": float(sys.argv[2]),
-    "otelcol_exporter_sent_spans": float(sys.argv[3]),
-    "langfuse_observation_membership": True,
-    "image_ids_match": True,
-}, sort_keys=True))
-PY
     echo "local invalid-auth negative: durable same-ID recovery and queue drain proved"
 }
 
@@ -3766,21 +3990,46 @@ rung_local() {
     fi
     echo
     echo "=== exact ordinary product-observability seed ==="
-    seed_ordinary_turn local "$agent_id"
+    local product_accepted_before product_sent_before product_accepted_after product_sent_after
+    local product_accepted_delta product_sent_delta product_membership
+    if [[ -n "${STUB_STATE:-}" ]]; then
+        seed_ordinary_turn local "$agent_id" stub
+    else
+        product_accepted_before="$(product_collector_metric_value otelcol_receiver_accepted_spans)"
+        product_sent_before="$(product_collector_metric_value otelcol_exporter_sent_spans)"
+        seed_ordinary_turn local "$agent_id" observe
+        product_membership="$LAST_ORDINARY_MEMBERSHIP"
 
-    if [[ -z "${STUB_STATE:-}" && "$LIVE" == "0" ]]; then
+    if [[ "$LIVE" == "0" ]]; then
         echo
         echo "=== exact approval wait/resolve/resume product-observability seed ==="
-        seed_approval_resume_turn local "$agent_id"
+        seed_approval_resume_turn local "$agent_id" observe
+        [[ "$LAST_APPROVAL_MEMBERSHIP" == "true" ]] || product_membership="false"
     fi
-    if [[ -z "${STUB_STATE:-}" && "$LIVE" == "1" ]]; then
+    if [[ "$LIVE" == "1" ]]; then
         echo
         echo "=== exact hosted MCP read product-observability seed ==="
-        seed_mcp_read_turn local "$agent_id" "$agent_name"
+        seed_mcp_read_turn local "$agent_id" "$agent_name" observe
+        [[ "$LAST_MCP_MEMBERSHIP" == "true" ]] || product_membership="false"
     fi
 
-    if [[ -z "${STUB_STATE:-}" ]] && (( LOCAL_STACK_OWNED )); then
+    product_accepted_after="$(product_collector_metric_value otelcol_receiver_accepted_spans)"
+    product_sent_after="$(product_collector_metric_value otelcol_exporter_sent_spans)"
+    read -r product_accepted_delta product_sent_delta < <(python3 - \
+        "$product_accepted_after" "$product_accepted_before" "$product_sent_after" "$product_sent_before" <<'PY'
+import sys
+accepted_after, accepted_before, sent_after, sent_before = map(float, sys.argv[1:5])
+print(accepted_after - accepted_before, sent_after - sent_before)
+PY
+    )
+    write_product_observability_evidence "$LOCAL_PRODUCT_EVIDENCE" local \
+        "$product_accepted_delta" "$product_sent_delta" "$product_membership" not-applicable
+
+    if [[ -z "${STUB_STATE:-}" && "$LAST_ORDINARY_MEMBERSHIP" == "true" ]] && (( LOCAL_STACK_OWNED )); then
         case_local_langfuse_invalid_auth "$agent_id"
+    elif [[ -z "${STUB_STATE:-}" && "$LAST_ORDINARY_MEMBERSHIP" != "true" ]]; then
+        echo "local invalid-auth negative skipped: exact known-valid control was not queryable"
+    fi
     fi
 
     prove_local_observability_queries "$agent_id"
@@ -4037,6 +4286,7 @@ rung_local_release() {
 preflight_cluster_product_observability() {
     local namespace="${CURIE_NAMESPACE:-}" release="${CURIE_RELEASE:-}"
     local inventory component mapping tag runtime_id local_id normalized_runtime normalized_local
+    CLUSTER_IMAGE_IDS_MATCH="false"
     if [[ -z "$namespace" || -z "$release" ]]; then
         echo "product cluster mode requires explicit CURIE_NAMESPACE and CURIE_RELEASE" >&2
         return 1
@@ -4119,6 +4369,7 @@ PY
         fi
     done
     rm -f "$inventory"
+    CLUSTER_IMAGE_IDS_MATCH="true"
     echo "cluster product preflight: Ready product components and task image IDs match"
 }
 
@@ -4137,37 +4388,61 @@ print(total)
 ' "$metric"
 }
 
+write_product_observability_evidence() {
+    local destination="$1" surface="$2" accepted_delta="$3" sent_delta="$4" membership="$5" image_match="$6"
+    python3 - "$destination" "$surface" "$accepted_delta" "$sent_delta" "$membership" "$image_match" <<'PY'
+import json, pathlib, sys
+destination, surface, accepted_raw, sent_raw, membership_raw, image_raw = sys.argv[1:7]
+accepted = float(accepted_raw)
+sent = float(sent_raw)
+if membership_raw not in {"true", "false"}:
+    raise SystemExit("exact Langfuse membership was not observed")
+if image_raw not in {"true", "false", "not-applicable"}:
+    raise SystemExit("image identity verdict was not observed")
+record = {
+    "surface": surface,
+    "seed_valid": accepted > 0 and sent > 0,
+    "raw_emitted_observations": accepted,
+    "otelcol_receiver_accepted_spans": accepted,
+    "otelcol_exporter_sent_spans": sent,
+    "langfuse_observation_membership": membership_raw == "true",
+    "image_ids_match": None if image_raw == "not-applicable" else image_raw == "true",
+}
+encoded = json.dumps(record, sort_keys=True, separators=(",", ":"))
+pathlib.Path(destination).write_text(encoded)
+print(encoded)
+PY
+}
+
 run_cluster_product_observability() {
-    local agent_id="$1" agent_name="$2" accepted sent
+    local agent_id="$1" agent_name="$2" accepted_before sent_before accepted_after sent_after
+    local accepted_delta sent_delta membership
     preflight_cluster_product_observability
-    seed_ordinary_turn cluster "$agent_id"
+    accepted_before="$(cluster_collector_metric_value otelcol_receiver_accepted_spans)"
+    sent_before="$(cluster_collector_metric_value otelcol_exporter_sent_spans)"
+    seed_ordinary_turn cluster "$agent_id" observe
+    membership="$LAST_ORDINARY_MEMBERSHIP"
     if [[ "$LIVE" == "0" ]]; then
-        seed_approval_resume_turn cluster "$agent_id"
+        seed_approval_resume_turn cluster "$agent_id" observe
+        [[ "$LAST_APPROVAL_MEMBERSHIP" == "true" ]] || membership="false"
     else
-        seed_mcp_read_turn cluster "$agent_id" "$agent_name"
+        seed_mcp_read_turn cluster "$agent_id" "$agent_name" observe
+        [[ "$LAST_MCP_MEMBERSHIP" == "true" ]] || membership="false"
     fi
     # Each seed helper performs the exact candidate read equivalent to:
     # curie --json cluster observability run "$trace_id"
-    accepted="$(cluster_collector_metric_value otelcol_receiver_accepted_spans)"
-    sent="$(cluster_collector_metric_value otelcol_exporter_sent_spans)"
-    python3 -c 'import sys; raise SystemExit(0 if all(float(v) > 0 for v in sys.argv[1:]) else 1)' \
-        "$accepted" "$sent" || {
-        echo "cluster product Collector did not report positive accepted/sent spans" >&2
-        return 1
-    }
-    python3 - "$CLUSTER_PRODUCT_EVIDENCE" "$accepted" "$sent" <<'PY'
-import json, pathlib, sys
-pathlib.Path(sys.argv[1]).write_text(json.dumps({
-    "surface": "cluster",
-    "seed_valid": True,
-    "raw_emitted_observations": 1,
-    "otelcol_receiver_accepted_spans": float(sys.argv[2]),
-    "otelcol_exporter_sent_spans": float(sys.argv[3]),
-    "langfuse_observation_membership": True,
-    "image_ids_match": True,
-}, sort_keys=True))
+    accepted_after="$(cluster_collector_metric_value otelcol_receiver_accepted_spans)"
+    sent_after="$(cluster_collector_metric_value otelcol_exporter_sent_spans)"
+    read -r accepted_delta sent_delta < <(python3 - \
+        "$accepted_after" "$accepted_before" "$sent_after" "$sent_before" <<'PY'
+import sys
+accepted_after, accepted_before, sent_after, sent_before = map(float, sys.argv[1:5])
+print(accepted_after - accepted_before, sent_after - sent_before)
 PY
-    echo "cluster product observability: independent exact seed(s) exported and queried"
+    )
+    write_product_observability_evidence "$CLUSTER_PRODUCT_EVIDENCE" cluster \
+        "$accepted_delta" "$sent_delta" "$membership" "$CLUSTER_IMAGE_IDS_MATCH"
+    echo "cluster product observability: Collector deltas and exact-ID membership recorded"
 }
 
 classify_product_observability_owner() {
@@ -4190,7 +4465,7 @@ for surface in ("local", "cluster"):
     raw_emitted_observations = record.get("raw_emitted_observations", 0)
     otelcol_receiver_accepted_spans = record.get("otelcol_receiver_accepted_spans", 0)
     otelcol_exporter_sent_spans = record.get("otelcol_exporter_sent_spans", 0)
-    image_ids_match = record.get("image_ids_match") is True
+    image_ids_match = surface != "cluster" or record.get("image_ids_match") is True
     seed_valid = record.get("seed_valid") is True
     if not (
         raw_emitted_observations > 0
@@ -4202,12 +4477,14 @@ for surface in ("local", "cluster"):
         print("curie-owned: raw export, delivery, image identity, or seed precondition failed")
         raise SystemExit(0)
 
-langfuse_observation_membership = all(
-    records[surface].get("langfuse_observation_membership") is True
+memberships = dict(
+    (surface, records[surface].get("langfuse_observation_membership") is True)
     for surface in ("local", "cluster")
 )
-if not langfuse_observation_membership:
+if not memberships["local"] and not memberships["cluster"]:
     print("adopted-component: Langfuse omitted observations after successful local and cluster raw export")
+elif not all(memberships.values()):
+    print("curie-owned: local and cluster exact Langfuse membership disagreed")
 else:
     print("curie-clear: Langfuse exact observation membership passed on local and cluster")
 PY

--- a/cli/scripts/e2e-ladder.sh
+++ b/cli/scripts/e2e-ladder.sh
@@ -196,6 +196,21 @@ OBSERVABILITY_UNAVAILABLE_API_URL="http://127.0.0.1:1"
 OBSERVABILITY_POLL_ATTEMPTS=60
 OBSERVABILITY_POLL_INTERVAL_SECONDS=2
 
+# #2204 product correlation proof. Cluster product mode is intentionally
+# query-only: an operator installs a private release and loads task images
+# before invoking the ladder. The script refuses the shared defaults and never
+# installs, upgrades, uninstalls, or deletes cluster state in this mode.
+PRODUCT_OBSERVABILITY="${CURIE_E2E_PRODUCT_OBSERVABILITY:-0}"
+MCP_RECEIPT_FIXTURE="$REPO_ROOT/cli/scripts/fixtures/mcp-receipt"
+MCP_RECEIPT_CONNECTOR="mcp-receipt"
+MCP_RECEIPT_ALIAS=""
+MCP_RECEIPT_IMAGE=""
+LAST_ORDINARY_TRACE_ID=""
+LAST_MCP_TRACE_ID=""
+LAST_APPROVAL_TRACE_ID=""
+LOCAL_PRODUCT_EVIDENCE=""
+CLUSTER_PRODUCT_EVIDENCE=""
+
 # The component label every connector container carries, in both the skill start
 # path and the local compose overlay (cli/src/docker.rs
 # CONNECTOR_COMPONENT_LABEL). Teardown reaps by label, so this is the only
@@ -293,6 +308,8 @@ fi
 "$BIN" --version
 
 WORKDIR="$(mktemp -d)"
+LOCAL_PRODUCT_EVIDENCE="$WORKDIR/product-observability-local.json"
+CLUSTER_PRODUCT_EVIDENCE="$WORKDIR/product-observability-cluster.json"
 cleanup() {
     # Capture the real exit code FIRST: a teardown command that fails must not
     # turn a red run green, and a successful teardown must not mask a red rung.
@@ -349,6 +366,14 @@ cleanup() {
             echo "sweeping stranded connector container $survivor"
             docker rm -f "$survivor" >/dev/null 2>&1
         done
+    fi
+    if [[ -n "$MCP_RECEIPT_ALIAS" ]]; then
+        local receipt_container
+        receipt_container="$(connector_container_for_alias "$MCP_RECEIPT_ALIAS" 2>/dev/null)" || receipt_container=""
+        if [[ -n "$receipt_container" ]]; then
+            echo "sweeping stranded MCP receipt connector"
+            docker rm -f "$receipt_container" >/dev/null 2>&1
+        fi
     fi
     rm -rf "$WORKDIR"
     exit "$code"
@@ -523,6 +548,440 @@ print(start.strftime("%Y-%m-%dT%H:%M:%SZ"), end.strftime("%Y-%m-%dT%H:%M:%SZ"))
     echo "local observability metrics: captured explicit UTC window $OBSERVABILITY_START through $OBSERVABILITY_END around the just-completed local turn"
 }
 
+# Execute a read-only Valkey command against the product runs stream. Passwords
+# stay inside the selected container/pod and no command output is logged.
+product_stream_json() {
+    local tier="$1"
+    shift
+    case "$tier" in
+        local)
+            local valkey
+            valkey="$(docker ps \
+                --filter 'label=com.docker.compose.project=curie' \
+                --filter 'label=com.docker.compose.service=valkey' \
+                --format '{{.Names}}')"
+            [[ -n "$valkey" && "$valkey" != *$'\n'* ]] || {
+                echo "seed-invalid: expected exactly one product Valkey container" >&2
+                return 1
+            }
+            docker exec "$valkey" sh -c \
+                'VALKEYCLI_AUTH="${VALKEY_PASSWORD:-}" exec valkey-cli --json "$@"' \
+                sh "$@"
+            ;;
+        cluster)
+            local pod
+            pod="$(kubectl -n "$CURIE_NAMESPACE" get pods \
+                -l "app.kubernetes.io/instance=$CURIE_RELEASE,app.kubernetes.io/name=valkey" \
+                -o json | python3 -c '
+import json, sys
+ready = []
+for item in json.load(sys.stdin).get("items", []):
+    conditions = item.get("status", {}).get("conditions", [])
+    if any(c.get("type") == "Ready" and c.get("status") == "True" for c in conditions):
+        ready.append(item["metadata"]["name"])
+if len(ready) != 1:
+    raise SystemExit("expected exactly one Ready product Valkey pod")
+print(ready[0])
+')" || return 1
+            kubectl -n "$CURIE_NAMESPACE" exec "$pod" -- sh -c \
+                'VALKEYCLI_AUTH="${VALKEY_PASSWORD:-}" exec valkey-cli --json "$@"' \
+                sh "$@"
+            ;;
+        *)
+            echo "seed-invalid: unknown product stream tier" >&2
+            return 1
+            ;;
+    esac
+}
+
+capture_stream_cursor() {
+    local tier="$1" result
+    result="$(product_stream_json "$tier" XREVRANGE curie:runs + - COUNT 1)" || return 1
+    printf '%s' "$result" | python3 -c '
+import json, sys
+rows = json.load(sys.stdin)
+if not rows:
+    print("0-0")
+elif len(rows) == 1 and isinstance(rows[0], list) and isinstance(rows[0][0], str):
+    print(rows[0][0])
+else:
+    raise SystemExit("seed-invalid: malformed bounded stream cursor response")
+'
+}
+
+# Locate this seed's exact stream entry between two cursors, then extract only
+# the adjacent W3C carrier's 32-hex trace id. The private XRANGE slice is mode
+# 0600 and is deleted without ever being echoed, so payload and traceparent
+# bytes cannot enter public evidence.
+discover_trace_id_for_seed() {
+    local tier="$1" marker="$2" stream_start="$3" stream_end="$4"
+    local private_slice trace_id
+    umask 077
+    private_slice="$(mktemp "$WORKDIR/seed-stream.XXXXXX")"
+    if [[ -z "$marker" || -z "$stream_start" || -z "$stream_end" ]]; then
+        rm -f "$private_slice"
+        echo "seed-invalid: marker and bounded stream cursors are required" >&2
+        return 1
+    fi
+    product_stream_json "$tier" XRANGE curie:runs "($stream_start" "$stream_end" > "$private_slice" || {
+        rm -f "$private_slice"
+        return 1
+    }
+    trace_id="$(python3 - "$private_slice" "$marker" <<'PY'
+import json
+import pathlib
+import re
+import sys
+
+rows = json.loads(pathlib.Path(sys.argv[1]).read_text())
+marker = sys.argv[2]
+carrier = re.compile(r"^00-([0-9a-f]{32})-[0-9a-f]{16}-[0-9a-f]{2}$")
+
+def exact_marker(value):
+    if value == marker:
+        return True
+    if isinstance(value, dict):
+        return any(exact_marker(item) for item in value.values())
+    if isinstance(value, list):
+        return any(exact_marker(item) for item in value)
+    return False
+
+matches = []
+for row in rows:
+    if not isinstance(row, list) or len(row) != 2 or not isinstance(row[1], list):
+        raise SystemExit("seed-invalid: malformed bounded XRANGE entry")
+    fields = row[1]
+    if len(fields) % 2:
+        raise SystemExit("seed-invalid: malformed stream field pairs")
+    for index in range(0, len(fields), 2):
+        if fields[index] != "payload" or index + 3 >= len(fields):
+            continue
+        if fields[index + 2] != "traceparent":
+            continue
+        try:
+            payload = json.loads(fields[index + 1])
+        except (TypeError, json.JSONDecodeError):
+            continue
+        match = carrier.fullmatch(fields[index + 3]) if isinstance(fields[index + 3], str) else None
+        if exact_marker(payload) and match:
+            matches.append(match.group(1))
+matches = sorted(set(matches))
+if len(matches) != 1:
+    raise SystemExit("seed-invalid: exact marker did not select one adjacent carrier")
+print(matches[0])
+PY
+)" || {
+        rm -f "$private_slice"
+        return 1
+    }
+    rm -f "$private_slice"
+    [[ "$trace_id" =~ ^[0-9a-f]{32}$ ]] || {
+        echo "seed-invalid: selected carrier did not contain a 32-hex trace id" >&2
+        return 1
+    }
+    printf '%s' "$trace_id"
+}
+
+# Convert a private exact-detail response into the sole public trace evidence.
+# Explicitly private source fields (input, output, session, user, headers) are
+# ignored. Operation names are reduced to a code-owned allowlist.
+sanitize_exact_trace_read() {
+    local trace_id="$1" private_read="$2" expected_csv="${3:-}" expected_decision="${4:-}"
+    python3 - "$trace_id" "$private_read" "$expected_csv" "$expected_decision" <<'PY'
+import json
+import pathlib
+import sys
+
+trace_id, source, expected_csv, expected_decision = sys.argv[1:5]
+value = json.loads(pathlib.Path(source).read_text())
+trace = value.get("trace") if isinstance(value, dict) else None
+tree = value.get("tree") if isinstance(value, dict) else None
+if not isinstance(trace, dict) or trace.get("id") != trace_id or not isinstance(tree, list):
+    raise SystemExit("exact trace response did not match the requested id and tree shape")
+
+private_fields = {"input", "output", "session", "user", "headers"}
+safe_operations = {
+    "curie.queue.enqueue", "curie.queue.process", "curie.turn.process",
+    "curie.sandbox.claim", "curie.runner.rpc", "agent.run", "execute_tool",
+    "curie.reply.post", "curie.reply.update", "curie.slack.receipt",
+    "curie.approval.wait", "curie.approval.resolve", "curie.approval.resume",
+    "approval.wait", "approval.resolve", "approval.resume",
+    }
+operations = []
+types = set()
+observation_count = [0]
+
+def walk(node):
+    if not isinstance(node, dict):
+        raise SystemExit("exact trace tree contains a non-object node")
+    # Deliberately never dereference values in private_fields.
+    if private_fields.intersection(node):
+        pass
+    observation_count[0] += 1
+    name = node.get("name")
+    kind = node.get("type")
+    if name in safe_operations:
+        operations.append(name)
+    if isinstance(kind, str) and kind.upper() in {"SPAN", "GENERATION", "EVENT"}:
+        types.add(kind.upper())
+    children = node.get("children")
+    if not isinstance(children, list):
+        raise SystemExit("exact trace node omitted its child array")
+    for child in children:
+        walk(child)
+
+for root in tree:
+    walk(root)
+expected = [item for item in expected_csv.split(",") if item]
+missing = [item for item in expected if not any(candidate in operations for candidate in item.split("|"))]
+if missing:
+    raise SystemExit("exact trace omitted required allowlisted operations")
+decision = value.get("approval_decision")
+if decision is not None and decision not in {"approved", "rejected", "expired"}:
+    raise SystemExit("exact trace carried a non-allowlisted approval decision")
+if expected_decision and decision != expected_decision:
+    raise SystemExit("exact trace carried the wrong approval decision")
+
+service = []
+if any(op == "curie.queue.enqueue" for op in operations):
+    service.append("curie-dispatcher")
+if any(op.startswith("curie.queue.") or op.startswith("curie.turn.") or op.startswith("curie.sandbox.") or op.startswith("curie.approval.") for op in operations):
+    service.append("curie-worker")
+if any(op in {"curie.runner.rpc", "agent.run", "execute_tool"} for op in operations):
+    service.append("curie-runner")
+sanitized = {
+    "trace_id": trace_id,
+    "service": sorted(set(service)),
+    "operation": sorted(set(operations)),
+    "observation_count": observation_count[0],
+    "observation_type": sorted(types),
+    "approval_decision": decision,
+    }
+allowed_evidence_fields = {
+    "trace_id", "service", "operation", "observation_count",
+    "observation_type", "approval_decision",
+    }
+if set(sanitized) != allowed_evidence_fields:
+    raise SystemExit("sanitized evidence field set drifted")
+print(json.dumps(sanitized, sort_keys=True, separators=(",", ":")))
+PY
+}
+
+# Query one exact ID only. Raw CLI output remains in a mode-0600 file and only
+# sanitize_exact_trace_read reaches stdout.
+query_exact_seed_trace() {
+    local tier="$1" trace_id="$2" expected_csv="${3:-}" expected_decision="${4:-}" expected_state="${5:-present}"
+    local attempt code=0 private_read safe_read
+    umask 077
+    private_read="$(mktemp "$WORKDIR/exact-trace.XXXXXX")"
+    safe_read="$(mktemp "$WORKDIR/safe-trace.XXXXXX")"
+    [[ "$trace_id" =~ ^[0-9a-f]{32}$ ]] || {
+        rm -f "$private_read" "$safe_read"
+        echo "seed-invalid: exact trace id is not 32 lowercase hex characters" >&2
+        return 1
+    }
+    for attempt in $(seq 1 "$OBSERVABILITY_POLL_ATTEMPTS"); do
+        code=0
+        if [[ "$tier" == "local" ]]; then
+            "$BIN" --json local observability run "$trace_id" > "$private_read" 2>/dev/null || code=$?
+        elif [[ "$tier" == "cluster" ]]; then
+            "$BIN" --json cluster observability --namespace "$CURIE_NAMESPACE" \
+                --release "$CURIE_RELEASE" run "$trace_id" > "$private_read" 2>/dev/null || code=$?
+        else
+            rm -f "$private_read" "$safe_read"
+            echo "seed-invalid: exact trace query tier is unknown" >&2
+            return 1
+        fi
+        if [[ "$expected_state" == "absent" ]]; then
+            rm -f "$private_read" "$safe_read"
+            if (( code == 1 )); then
+                echo "exact trace temporarily absent as required"
+                return 0
+            fi
+            echo "exact trace was queryable while the exporter was required to be failing" >&2
+            return 1
+        fi
+        if (( code == 0 )) && sanitize_exact_trace_read "$trace_id" "$private_read" "$expected_csv" "$expected_decision" > "$safe_read"; then
+            cat "$safe_read"
+            rm -f "$private_read" "$safe_read"
+            return 0
+        fi
+        if (( attempt < OBSERVABILITY_POLL_ATTEMPTS )); then
+            sleep "$OBSERVABILITY_POLL_INTERVAL_SECONDS"
+        fi
+    done
+    rm -f "$private_read" "$safe_read"
+    echo "exact trace did not become queryable inside the bounded ingestion poll" >&2
+    return 1
+}
+
+seed_ordinary_turn() {
+    local tier="$1" agent_id="${2:-}" marker="curie-seed-ordinary-$$-$RANDOM"
+    local stream_start stream_end out trace_id expected_operations=""
+    if [[ -z "$marker" || "$tier" != "local" && "$tier" != "cluster" ]]; then
+        echo "seed-invalid: ordinary seed precondition failed before telemetry" >&2
+        return 1
+    fi
+    if [[ -n "${STUB_STATE:-}" ]]; then
+        trace_id="${STUB_OBSERVABILITY_TRACE_ID:-}"
+        [[ "$trace_id" =~ ^[0-9a-f]{32}$ ]] || {
+            echo "seed-invalid: stub exact trace id is absent" >&2
+            return 1
+        }
+    else
+        stream_start="$(capture_stream_cursor "$tier")" || return 1
+        if [[ "$tier" == "local" ]]; then
+            out="$("$BIN" --json local message --channel C0LOCALDEV "ordinary correlation $marker" || true)"
+        else
+            out="$("$BIN" --json cluster message --namespace "$CURIE_NAMESPACE" \
+                --release "$CURIE_RELEASE" "ordinary correlation $marker" || true)"
+        fi
+        assert_finalized_reply "$tier ordinary correlation" "$out"
+        if [[ "$tier" == "local" ]]; then
+            assert_product_runner_endpoints
+        fi
+        stream_end="$(capture_stream_cursor "$tier")" || return 1
+        [[ "$stream_end" != "$stream_start" ]] || {
+            echo "seed-invalid: ordinary seed produced no bounded stream receipt" >&2
+            return 1
+        }
+        trace_id="$(discover_trace_id_for_seed "$tier" "$marker" "$stream_start" "$stream_end")" || return 1
+        expected_operations="curie.queue.enqueue,curie.queue.process,curie.turn.process,curie.sandbox.claim,curie.runner.rpc,agent.run,curie.reply.post|curie.reply.update"
+    fi
+    query_exact_seed_trace "$tier" "$trace_id" "$expected_operations"
+    LAST_ORDINARY_TRACE_ID="$trace_id"
+    printf '%s' "$trace_id"
+}
+
+seed_mcp_read_turn() {
+    local tier="$1" agent_id="${2:-}" agent_name="${3:-}" marker="curie-seed-mcp-$$-$RANDOM"
+    local stream_start stream_end out trace_id before_count after_count alias release namespace
+    if [[ "$LIVE" != "1" || -z "$agent_name" || -z "$marker" ]]; then
+        echo "seed-invalid: MCP read seed needs live mode, a deployed agent, and a marker before telemetry" >&2
+        return 1
+    fi
+    if [[ "$tier" == "local" ]]; then
+        local worker
+        worker="$(local_worker_container)"
+        release="$(container_env_value "$worker" CURIE_RELEASE)"
+        namespace="$(container_env_value "$worker" CURIE_NAMESPACE)"
+    else
+        release="$CURIE_RELEASE"
+        namespace="$CURIE_NAMESPACE"
+    fi
+    alias="$(connector_object_name "$release" "$agent_name" "$MCP_RECEIPT_CONNECTOR").$namespace.svc.cluster.local"
+    MCP_RECEIPT_ALIAS="$alias"
+    before_count="$(mcp_receipt_call_count "$tier" "$alias")" || return 1
+    stream_start="$(capture_stream_cursor "$tier")" || return 1
+    if [[ "$tier" == "local" ]]; then
+        out="$("$BIN" --json local message --channel C0LOCALDEV \
+            "Call the receipt_read tool exactly once, then answer receipt complete. $marker" || true)"
+    else
+        out="$("$BIN" --json cluster message --namespace "$CURIE_NAMESPACE" \
+            --release "$CURIE_RELEASE" \
+            "Call the receipt_read tool exactly once, then answer receipt complete. $marker" || true)"
+    fi
+    assert_finalized_reply "$tier MCP correlation" "$out"
+    after_count="$(mcp_receipt_call_count "$tier" "$alias")" || return 1
+    if (( after_count != before_count + 1 )); then
+        echo "seed-invalid: MCP seed did not produce exactly one independent call receipt" >&2
+        return 1
+    fi
+    echo "MCP receipt call count delta=1"
+    stream_end="$(capture_stream_cursor "$tier")" || return 1
+    trace_id="$(discover_trace_id_for_seed "$tier" "$marker" "$stream_start" "$stream_end")" || return 1
+    query_exact_seed_trace "$tier" "$trace_id" "execute_tool"
+    LAST_MCP_TRACE_ID="$trace_id"
+    printf '%s' "$trace_id"
+}
+
+seed_approval_resume_turn() {
+    local tier="$1" agent_id="${2:-}" marker="curie-seed-approval-$$-$RANDOM"
+    local stream_start stream_end message_file token_file pending_file approval_id token out trace_id
+    local message_pid code=0 attempt
+    if [[ "$LIVE" == "1" || -z "$agent_id" || -z "$marker" ]]; then
+        echo "seed-invalid: deterministic approval seed needs fake mode and a deployed agent before telemetry" >&2
+        return 1
+    fi
+    umask 077
+    message_file="$(mktemp "$WORKDIR/approval-message.XXXXXX")"
+    token_file="$(mktemp "$WORKDIR/approval-token.XXXXXX")"
+    pending_file="$(mktemp "$WORKDIR/approval-pending.XXXXXX")"
+    local scope=()
+    if [[ "$tier" == "cluster" ]]; then
+        scope=(--namespace "$CURIE_NAMESPACE" --release "$CURIE_RELEASE")
+    fi
+    "$BIN" --json "$tier" approvals "$agent_id" "${scope[@]}" \
+        --route-resolution e2e=C0EXAMPLE1 --route-approvers e2e=users:U0EXAMPLE1 \
+        >/dev/null
+    "$BIN" --json "$tier" approvals "$agent_id" "${scope[@]}" \
+        --mint-operator-principal U0EXAMPLE1 > "$token_file"
+    token="$(python3 - "$token_file" <<'PY'
+import json, pathlib, sys
+value = json.loads(pathlib.Path(sys.argv[1]).read_text())
+token = value.get("operator_principal", {}).get("token")
+if not isinstance(token, str) or not token:
+    raise SystemExit("operator principal response omitted its token")
+print(token)
+PY
+)" || {
+        rm -f "$message_file" "$token_file" "$pending_file"
+        return 1
+    }
+    rm -f "$token_file"
+    stream_start="$(capture_stream_cursor "$tier")" || return 1
+    if [[ "$tier" == "local" ]]; then
+        "$BIN" --json local message --channel C0LOCALDEV --timeout-secs 120 \
+            "[fake:request-approval:e2e] approve correlation $marker" > "$message_file" 2>/dev/null &
+    else
+        "$BIN" --json cluster message --namespace "$CURIE_NAMESPACE" \
+            --release "$CURIE_RELEASE" --timeout-secs 120 \
+            "[fake:request-approval:e2e] approve correlation $marker" > "$message_file" 2>/dev/null &
+    fi
+    message_pid=$!
+    approval_id=""
+    for attempt in $(seq 1 60); do
+        if "$BIN" --json "$tier" approvals "$agent_id" "${scope[@]}" --list > "$pending_file" 2>/dev/null; then
+            approval_id="$(python3 - "$pending_file" <<'PY'
+import json, pathlib, sys
+value = json.loads(pathlib.Path(sys.argv[1]).read_text())
+rows = value.get("pending", [])
+matches = [row.get("id") for row in rows if row.get("status") == "pending" and row.get("route") == "e2e"]
+print(matches[0] if len(matches) == 1 and isinstance(matches[0], str) else "")
+PY
+)"
+            [[ -n "$approval_id" ]] && break
+        fi
+        sleep 1
+    done
+    rm -f "$pending_file"
+    if [[ -z "$approval_id" ]]; then
+        kill "$message_pid" 2>/dev/null || true
+        wait "$message_pid" 2>/dev/null || true
+        rm -f "$message_file"
+        echo "seed-invalid: awaiting-approval record did not become pending" >&2
+        return 1
+    fi
+    CURIE_APPROVAL_PRINCIPAL_TOKEN="$token" "$BIN" --json "$tier" approvals "$agent_id" \
+        "${scope[@]}" --resolve "$approval_id" >/dev/null
+    unset token
+    wait "$message_pid" || code=$?
+    out="$(cat "$message_file")"
+    rm -f "$message_file"
+    if (( code != 0 )); then
+        echo "seed-invalid: approval resolution did not resume to a final reply" >&2
+        return 1
+    fi
+    assert_finalized_reply "$tier approval resume" "$out"
+    stream_end="$(capture_stream_cursor "$tier")" || return 1
+    trace_id="$(discover_trace_id_for_seed "$tier" "$marker" "$stream_start" "$stream_end")" || return 1
+    query_exact_seed_trace "$tier" "$trace_id" \
+        "curie.approval.wait,curie.approval.resolve,curie.approval.resume,curie.reply.post|curie.reply.update" \
+        "approved"
+    LAST_APPROVAL_TRACE_ID="$trace_id"
+    printf '%s' "$trace_id"
+}
+
 # Langfuse ingestion is asynchronous to turn finalization. Poll through the
 # candidate CLI, never its backing API. Scan one bounded newest-first page and
 # select the newest complete row. The returned id is the sole input to the
@@ -530,10 +989,10 @@ print(start.strftime("%Y-%m-%dT%H:%M:%SZ"), end.strftime("%Y-%m-%dT%H:%M:%SZ"))
 # Correlation to this rung is proved independently by the explicit-window
 # metrics reads below; trace-list DTOs do not promise an agent identity field.
 discover_local_observability_trace() {
-    local attempt out code verdict state detail
+    local attempt out code verdict state detail limit=100
     DISCOVERED_OBSERVABILITY_TRACE_ID=""
     for attempt in $(seq 1 "$OBSERVABILITY_POLL_ATTEMPTS"); do
-        out="$("$BIN" --json local observability runs --limit 100)" && code=0 || code=$?
+        out="$("$BIN" --json local observability runs --limit "$limit")" && code=0 || code=$?
         if (( code != 0 )); then
             echo "local observability runs: bounded ingestion read exited $code, expected 0." >&2
             printf '%s\n' "$out" >&2
@@ -751,25 +1210,18 @@ else:
 }
 
 prove_local_observability_queries() {
-    local agent_id="$1" out code trace_id
+    local agent_id="$1" out code
 
     derive_observability_window
 
-    echo
-    echo "=== curie local observability runs --json (bounded ingestion poll) ==="
-    discover_local_observability_trace
-    trace_id="$DISCOVERED_OBSERVABILITY_TRACE_ID"
-
-    echo
-    echo "=== curie local observability run --json (discovered trace) ==="
-    out="$("$BIN" --json local observability run "$trace_id")" && code=0 || code=$?
-    if (( code != 0 )); then
-        echo "local observability run: discovered trace detail exited $code, expected 0." >&2
-        printf '%s\n' "$out" >&2
+    # seed_ordinary_turn has already made the only exact read through
+    # query_exact_seed_trace, whose sole public output comes from
+    # sanitize_exact_trace_read. Keeping the receipt here prevents metrics and
+    # negatives from running after a seed-invalid path.
+    if [[ ! "$LAST_ORDINARY_TRACE_ID" =~ ^[0-9a-f]{32}$ ]]; then
+        echo "local observability: ordinary exact-trace seed receipt is absent" >&2
         return 1
     fi
-    printf '%s\n' "$out"
-    assert_local_observability_detail "$trace_id" "$out"
 
     echo
     echo "=== curie local observability metrics --json (explicit UTC window) ==="
@@ -1450,6 +1902,26 @@ prepare_connector_bundle() {
     echo "connector fixture applied to $dir (connectors.yaml)"
 }
 
+# Add the independently countable, read-only MCP receipt server to a scratch
+# bundle. It goes through the ordinary connector build/lock path; no in-sandbox
+# file can be evidence because the sandbox is destroyed with the turn.
+prepare_mcp_receipt_bundle() {
+    local dir="$1"
+    local destination="$dir/connectors/mcp-receipt"
+    mkdir -p "$destination"
+    cp "$MCP_RECEIPT_FIXTURE/Dockerfile" "$MCP_RECEIPT_FIXTURE/server.py" "$destination/"
+    if [[ ! -f "$dir/connectors.yaml" ]]; then
+        printf '%s\n' 'connectors:' > "$dir/connectors.yaml"
+    fi
+    cat >> "$dir/connectors.yaml" <<'YAML'
+  mcp-receipt:
+    build:
+      context: connectors/mcp-receipt
+      platforms: [linux/amd64, linux/arm64]
+YAML
+    echo "MCP receipt fixture applied to $dir (fixtures/mcp-receipt)"
+}
+
 # One build before the first rung, so every rung consumes the same lock and the
 # bundle bytes each rung packs are identical (the PARITY_DIGEST assertion).
 #
@@ -1582,6 +2054,41 @@ connector_container_for_alias() {
         fi
     done < <(docker ps --filter "label=$CONNECTOR_LABEL" --format '{{.Names}}')
     return 1
+}
+
+# Read only the aggregate number of deterministic call markers. Neither the
+# marker lines nor any connector log payload is emitted into the evidence.
+mcp_receipt_call_count() {
+    local tier="$1" alias="$2" count=0 container pod
+    case "$tier" in
+        local)
+            container="$(connector_container_for_alias "$alias")" || {
+                echo "MCP receipt connector is not hosted at the expected alias" >&2
+                return 1
+            }
+            count="$(docker logs "$container" 2>&1 | awk '$0 == "MCP_RECEIPT tools/call" { count++ } END { print count + 0 }')"
+            ;;
+        cluster)
+            pod="$(kubectl -n "$CURIE_NAMESPACE" get pods \
+                -l "app.kubernetes.io/instance=$CURIE_RELEASE,curietech.ai/component=connector" \
+                -o json | python3 -c '
+import json, sys
+items = json.load(sys.stdin).get("items", [])
+want = sys.argv[1]
+matches = [item["metadata"]["name"] for item in items if want in item["metadata"]["name"]]
+if len(matches) != 1:
+    raise SystemExit("expected exactly one MCP receipt connector pod")
+print(matches[0])
+' "$MCP_RECEIPT_CONNECTOR")" || return 1
+            count="$(kubectl -n "$CURIE_NAMESPACE" logs "$pod" 2>/dev/null | awk '$0 == "MCP_RECEIPT tools/call" { count++ } END { print count + 0 }')"
+            ;;
+        *)
+            echo "unknown MCP receipt tier" >&2
+            return 1
+            ;;
+    esac
+    [[ "$count" =~ ^[0-9]+$ ]] || return 1
+    printf '%s' "$count"
 }
 
 # The MCP probe itself: an initialize / notifications/initialized / tools/list
@@ -2827,29 +3334,271 @@ restore_local_runner_health() {
     sleep 3
 }
 
+assert_product_collector_endpoint() {
+    local service="$1" container="$2" expected_endpoint="$3" expected_protocol="$4"
+    local endpoint protocol
+    endpoint="$(container_env_value "$container" OTEL_EXPORTER_OTLP_ENDPOINT)"
+    protocol="$(container_env_value "$container" OTEL_EXPORTER_OTLP_PROTOCOL)"
+    if [[ "$endpoint" != "$expected_endpoint" || "$protocol" != "$expected_protocol" ]]; then
+        echo "local observability: $service exporter does not target the shipped product Collector" >&2
+        return 1
+    fi
+    echo "local observability: $service exporter endpoint/protocol verified"
+}
+
+assert_product_runner_endpoints() {
+    local runners=() runner
+    while IFS= read -r runner; do
+        [[ -n "$runner" ]] && runners+=("$runner")
+    done < <(docker ps --filter "label=$SANDBOX_LABEL" --format '{{.Names}}')
+    (( ${#runners[@]} > 0 )) || {
+        echo "local observability: no actual curie-runner emitter survived long enough to inspect" >&2
+        return 1
+    }
+    for runner in "${runners[@]}"; do
+        assert_product_collector_endpoint curie-runner "$runner" \
+            "http://otel-collector:4318" "http/protobuf"
+    done
+}
+
 # The independent sink above proves raw telemetry crossed every service
 # boundary, but it deliberately replaces the product Collector endpoint. Once
-# those controls finish, put only the worker (and therefore newly spawned
-# runners) back on the shipped Collector so the API-backed #866 queries can
-# prove the product read path without changing the Collector configuration.
+# those controls finish, restore every actual emitter before seeding Langfuse.
 route_local_observability_to_product_collector() {
     if [[ -n "${STUB_STATE:-}" ]] || (( ! LOCAL_OTEL_SINK_ACTIVE )); then
         return 0
     fi
 
     unset OTEL_EXPORTER_OTLP_ENDPOINT OTEL_EXPORTER_OTLP_PROTOCOL
+    local stale runner dispatcher=""
+    # An already-running curie-runner inherited the disposable endpoint. Reap
+    # only this task-owned stack's scoped sandboxes so every later runner is
+    # freshly launched from the restored worker environment.
+    if (( LOCAL_STACK_OWNED )); then
+        while IFS= read -r runner; do
+            [[ -n "$runner" ]] || continue
+            if [[ "$(container_env_value "$runner" CURIE_RELEASE)" == "curie" ]]; then
+                docker rm -f "$runner" >/dev/null
+            fi
+        done < <(docker ps --filter "label=$SANDBOX_LABEL" --format '{{.Names}}')
+    fi
     docker compose --profile core --profile full -f "$REPO_ROOT/compose.dev.yaml" \
-        up -d --force-recreate --no-deps curie-worker >/dev/null
+        up -d --force-recreate --no-deps curie-api curie-worker >/dev/null
+    dispatcher="$(docker ps \
+        --filter 'label=com.docker.compose.project=curie' \
+        --filter 'label=com.docker.compose.service=curie-dispatcher' \
+        --format '{{.Names}}')"
+    if [[ -n "$dispatcher" ]]; then
+        docker compose --profile slack -f "$REPO_ROOT/compose.dev.yaml" \
+            up -d --force-recreate --no-deps curie-dispatcher >/dev/null
+    fi
     sleep 3
 
-    local worker endpoint
+    local api worker
+    api="$(docker ps --filter 'label=com.docker.compose.project=curie' \
+        --filter 'label=com.docker.compose.service=curie-api' --format '{{.Names}}')"
     worker="$(local_worker_container)"
-    endpoint="$(container_env_value "$worker" OTEL_EXPORTER_OTLP_ENDPOINT)"
-    if [[ "$endpoint" != "http://otel-collector:4318" ]]; then
-        echo "local observability: worker still targets '$endpoint', expected the product Collector." >&2
+    assert_product_collector_endpoint curie-api "$api" \
+        "http://otel-collector:4318" "http/protobuf"
+    assert_product_collector_endpoint curie-worker "$worker" \
+        "http://otel-collector:4318" "http/protobuf"
+    if [[ -n "$dispatcher" ]]; then
+        dispatcher="$(docker ps --filter 'label=com.docker.compose.project=curie' \
+            --filter 'label=com.docker.compose.service=curie-dispatcher' --format '{{.Names}}')"
+        assert_product_collector_endpoint curie-dispatcher "$dispatcher" \
+            "http://otel-collector:4318" "http/protobuf"
+    else
+        # curie local message launches the curie-dispatcher image after these
+        # exports are unset; the adjacent stream carrier and exact trace prove
+        # that actual one-shot emitter rather than a config-only assertion.
+        echo "local observability: curie-dispatcher one-shot will inherit product routing"
+    fi
+    # curie-runner is asserted after the first post-restore turn, when an
+    # actual sandbox emitter exists to inspect.
+    echo "local observability: curie-api, curie-dispatcher, curie-worker, and curie-runner routing restored"
+}
+
+product_collector_metric_value() {
+    local metric="$1"
+    curl -fsS http://127.0.0.1:28888/metrics | python3 -c '
+import re, sys
+name = sys.argv[1]
+total = 0.0
+for line in sys.stdin:
+    if re.match(r"^" + re.escape(name) + r"(?:\{|\s)", line):
+        total += float(line.rsplit(None, 1)[1])
+print(total)
+' "$metric"
+}
+
+wait_product_collector_ready() {
+    local attempt
+    for attempt in $(seq 1 60); do
+        if curl -fsS http://127.0.0.1:28888/metrics >/dev/null 2>&1; then
+            # The Collector's startup contract logs "Everything is ready";
+            # the live self-metrics endpoint is the stronger Ready probe.
+            return 0
+        fi
+        sleep 1
+    done
+    echo "product Collector did not become Ready" >&2
+    return 1
+}
+
+restart_local_product_collector() {
+    docker compose --profile full -f "$REPO_ROOT/compose.dev.yaml" \
+        up -d --force-recreate --no-deps otel-collector >/dev/null
+    wait_product_collector_ready
+}
+
+restore_local_langfuse_auth() {
+    local was_set="$1" original="$2"
+    if [[ "$was_set" == "1" ]]; then
+        export LANGFUSE_OTLP_AUTH_HEADER="$original"
+    else
+        unset LANGFUSE_OTLP_AUTH_HEADER
+    fi
+    restart_local_product_collector
+}
+
+# Exercise the pinned Langfuse exporter with temporary invalid auth while the
+# shipped retry_on_failure (5s/30s/5m) and sending_queue/file_storage settings
+# remain unchanged. The queue_size is 1000; no volume is removed.
+case_local_langfuse_invalid_auth() {
+    local INVALID_LANGFUSE_OTLP_AUTH_HEADER='Basic aW52YWxpZDppbnZhbGlk'
+    local agent_id="$1" original_set=0 original="${LANGFUSE_OTLP_AUTH_HEADER-}"
+    local receipt same_queued_trace_id queue_drained accepted accepted_before sent langfuse_web
+    local collector storage_directory
+    [[ ${LANGFUSE_OTLP_AUTH_HEADER+x} ]] && original_set=1
+    langfuse_web="$(docker compose --profile full -f "$REPO_ROOT/compose.dev.yaml" ps -q langfuse-web)"
+    [[ -n "$langfuse_web" ]] || {
+        echo "pinned langfuse-web is not running for the real exporter negative" >&2
+        return 1
+    }
+    storage_directory="$(python3 - "$REPO_ROOT/otel/collector-config.yaml" <<'PY'
+import pathlib, re, sys
+text = pathlib.Path(sys.argv[1]).read_text()
+required = {
+    "sending_queue": r"(?m)^\s*sending_queue:\s*$",
+    "file_storage": r"(?m)^\s*storage:\s*file_storage\s*$",
+    "queue_size": r"(?m)^\s*queue_size:\s*1000\s*$",
+    "retry_horizon": r"(?m)^\s*max_elapsed_time:\s*5m\s*$",
+    }
+missing = [name for name, pattern in required.items() if not re.search(pattern, text)]
+directory = re.search(r"(?m)^\s*directory:\s*([^#\s]+)", text)
+if missing or directory is None:
+    raise SystemExit("shipped Collector durable queue configuration is absent")
+print(directory.group(1))
+PY
+)" || return 1
+    collector="$(docker compose --profile full -f "$REPO_ROOT/compose.dev.yaml" ps -q otel-collector)"
+    docker inspect "$collector" --format '{{json .Mounts}}' | python3 -c '
+import json, os, sys
+mounts = json.load(sys.stdin)
+directory = os.path.normpath(sys.argv[1])
+if not any(
+    directory == os.path.normpath(item.get("Destination", ""))
+    or directory.startswith(os.path.normpath(item.get("Destination", "")) + os.sep)
+    for item in mounts
+    if item.get("Type") == "volume" and item.get("Destination")
+):
+    raise SystemExit("file_storage directory is not backed by a Docker volume")
+' "$storage_directory" || return 1
+    receipt="$(mktemp "$WORKDIR/invalid-auth-trace.XXXXXX")"
+    chmod 600 "$receipt"
+
+    echo
+    echo "=== case: pinned Langfuse invalid auth queues and recovers the same ID ==="
+    if ! (
+        set -e
+        export LANGFUSE_OTLP_AUTH_HEADER="$INVALID_LANGFUSE_OTLP_AUTH_HEADER"
+        restart_local_product_collector
+        wait_product_collector_ready || {
+            echo "Collector failed the Ready check after invalid-auth restart" >&2
+            exit 1
+        }
+
+        marker="curie-seed-invalid-auth-$$-$RANDOM"
+        stream_start="$(capture_stream_cursor local)"
+        out="$("$BIN" --json local message --channel C0LOCALDEV \
+            "temporary exporter recovery $marker" || true)"
+        assert_finalized_reply "local invalid-auth seed" "$out"
+        stream_end="$(capture_stream_cursor local)"
+        same_queued_trace_id="$(discover_trace_id_for_seed local "$marker" "$stream_start" "$stream_end")"
+
+        accepted=0
+        failed=0
+        queue_size=0
+        for attempt in $(seq 1 45); do
+            accepted="$(product_collector_metric_value otelcol_receiver_accepted_spans)"
+            failed="$(product_collector_metric_value otelcol_exporter_send_failed_spans)"
+            queue_size="$(product_collector_metric_value otelcol_exporter_queue_size)"
+            if python3 -c 'import sys; raise SystemExit(0 if all(float(v) > 0 for v in sys.argv[1:]) else 1)' \
+                "$accepted" "$failed" "$queue_size"; then
+                break
+            fi
+            sleep 2
+        done
+        python3 -c 'import sys; q=float(sys.argv[3]); raise SystemExit(0 if float(sys.argv[1]) > 0 and float(sys.argv[2]) > 0 and 0 < q <= 1000 else 1)' \
+            "$accepted" "$failed" "$queue_size"
+        query_exact_seed_trace local "$same_queued_trace_id" "" "" absent
+
+        python3 - "$receipt" "$same_queued_trace_id" "$accepted" <<'PY'
+import json, pathlib, sys
+pathlib.Path(sys.argv[1]).write_text(json.dumps({
+    "trace_id": sys.argv[2],
+    "accepted": float(sys.argv[3]),
+}))
+PY
+    ); then
+        restore_local_langfuse_auth "$original_set" "$original" || true
+        rm -f "$receipt"
+        echo "invalid-auth queue proof failed; product Collector auth was restored" >&2
         return 1
     fi
-    echo "local observability: worker restored to the product Collector at $endpoint"
+
+    read -r same_queued_trace_id accepted_before < <(python3 - "$receipt" <<'PY'
+import json, pathlib, sys
+value = json.loads(pathlib.Path(sys.argv[1]).read_text())
+print(value["trace_id"], value["accepted"])
+PY
+    )
+    rm -f "$receipt"
+    restore_local_langfuse_auth "$original_set" "$original"
+    wait_product_collector_ready || {
+        echo "Collector failed the Ready check after valid-auth restart" >&2
+        return 1
+    }
+    # The queue-preserving restart must deliver this same_queued_trace_id within
+    # the unchanged five-minute retry horizon; a fresh trace is not a substitute.
+    query_exact_seed_trace local "$same_queued_trace_id"
+    queue_drained=""
+    for attempt in $(seq 1 60); do
+        queue_drained="$(product_collector_metric_value otelcol_exporter_queue_size)"
+        if python3 -c 'import sys; raise SystemExit(0 if float(sys.argv[1]) == 0 else 1)' "$queue_drained"; then
+            break
+        fi
+        sleep 2
+    done
+    python3 -c 'import sys; raise SystemExit(0 if float(sys.argv[1]) == 0 else 1)' "$queue_drained" || {
+        echo "recovered exact trace but the durable sending queue did not drain" >&2
+        return 1
+    }
+    accepted="$accepted_before"
+    sent="$(product_collector_metric_value otelcol_exporter_sent_spans)"
+    python3 - "$LOCAL_PRODUCT_EVIDENCE" "$accepted" "$sent" <<'PY'
+import json, pathlib, sys
+pathlib.Path(sys.argv[1]).write_text(json.dumps({
+    "surface": "local",
+    "seed_valid": True,
+    "raw_emitted_observations": 1,
+    "otelcol_receiver_accepted_spans": float(sys.argv[2]),
+    "otelcol_exporter_sent_spans": float(sys.argv[3]),
+    "langfuse_observation_membership": True,
+    "image_ids_match": True,
+}, sort_keys=True))
+PY
+    echo "local invalid-auth negative: durable same-ID recovery and queue drain proved"
 }
 
 assert_local_otel_failed_turn() {
@@ -3093,11 +3842,34 @@ rung_local() {
     fi
 
     route_local_observability_to_product_collector
+    if [[ -n "${STUB_STATE:-}" ]]; then
+        # Executing contract controls have no Docker/Valkey stream to inspect,
+        # but still require two independent post-restore producer calls. The
+        # second call below remains the one exact trace seed/query, so candidate
+        # detail reads stay exactly once while the invocation transcript proves
+        # restoration precedes fresh producer activity.
+        out="$("$BIN" --json local message --channel C0LOCALDEV \
+            "post-restore product Collector control" || true)"
+        assert_finalized_reply "local post-restore control" "$out"
+    fi
     echo
-    echo "=== curie local message --json (observability query seed) ==="
-    out="$("$BIN" --json local message --channel C0LOCALDEV "observability query control" || true)"
-    printf '%s\n' "$out"
-    assert_finalized_reply "local observability seed" "$out"
+    echo "=== exact ordinary product-observability seed ==="
+    seed_ordinary_turn local "$agent_id"
+
+    if [[ -z "${STUB_STATE:-}" && "$LIVE" == "0" ]]; then
+        echo
+        echo "=== exact approval wait/resolve/resume product-observability seed ==="
+        seed_approval_resume_turn local "$agent_id"
+    fi
+    if [[ -z "${STUB_STATE:-}" && "$LIVE" == "1" ]]; then
+        echo
+        echo "=== exact hosted MCP read product-observability seed ==="
+        seed_mcp_read_turn local "$agent_id" "$agent_name"
+    fi
+
+    if [[ -z "${STUB_STATE:-}" ]] && (( LOCAL_STACK_OWNED )); then
+        case_local_langfuse_invalid_auth "$agent_id"
+    fi
 
     prove_local_observability_queries "$agent_id"
 
@@ -3348,9 +4120,206 @@ rung_local_release() {
     assert_bundle_identity "local-release" "$digest"
 }
 
+# Refuse shared/default cluster ownership and prove that the private release is
+# Ready and running the task-built image identities. This is read-only.
+preflight_cluster_product_observability() {
+    local namespace="${CURIE_NAMESPACE:-}" release="${CURIE_RELEASE:-}"
+    local inventory component mapping tag runtime_id local_id normalized_runtime normalized_local
+    if [[ -z "$namespace" || -z "$release" ]]; then
+        echo "product cluster mode requires explicit CURIE_NAMESPACE and CURIE_RELEASE" >&2
+        return 1
+    fi
+    if [[ "$namespace" == "default" || "$namespace" == "curie" || "$release" == "curie" ]]; then
+        echo "product cluster mode refuses default/shared ownership (default or curie)" >&2
+        return 1
+    fi
+    umask 077
+    inventory="$(mktemp "$WORKDIR/cluster-product-pods.XXXXXX")"
+    kubectl -n "$namespace" get pods \
+        -l "app.kubernetes.io/instance=$release" -o json > "$inventory" || {
+        rm -f "$inventory"
+        return 1
+    }
+    python3 - "$inventory" <<'PY'
+import json, pathlib, sys
+items = json.loads(pathlib.Path(sys.argv[1]).read_text()).get("items", [])
+required = {"langfuse-web", "langfuse-worker", "otel-collector", "api", "worker", "runner-prewarm"}
+seen = set()
+for item in items:
+    component = item.get("metadata", {}).get("labels", {}).get("app.kubernetes.io/component")
+    if component not in required:
+        continue
+    conditions = item.get("status", {}).get("conditions", [])
+    if not any(c.get("type") == "Ready" and c.get("status") == "True" for c in conditions):
+        raise SystemExit("product component is not Ready")
+    statuses = item.get("status", {}).get("containerStatuses", [])
+    if not statuses or any(not status.get("imageID") for status in statuses):
+        raise SystemExit("Ready product component omitted imageID")
+    seen.add(component)
+missing = required - seen
+if missing:
+    raise SystemExit("missing Ready product components")
+PY
+    for mapping in \
+        'api|curie-api:local' \
+        'worker|curie-worker:local' \
+        'runner-prewarm|curie-runner:latest'; do
+        component="${mapping%%|*}"
+        tag="${mapping#*|}"
+        runtime_id="$(python3 - "$inventory" "$component" <<'PY'
+import json, pathlib, sys
+items = json.loads(pathlib.Path(sys.argv[1]).read_text()).get("items", [])
+want = sys.argv[2]
+values = []
+for item in items:
+    if item.get("metadata", {}).get("labels", {}).get("app.kubernetes.io/component") != want:
+        continue
+    values.extend(status.get("imageID", "") for status in item.get("status", {}).get("containerStatuses", []))
+values = sorted(set(values))
+if len(values) != 1:
+    raise SystemExit("component imageID is absent or inconsistent")
+print(values[0])
+PY
+)" || { rm -f "$inventory"; return 1; }
+        local_id="$(docker image inspect --format '{{.Id}}' "$tag")" || {
+            rm -f "$inventory"
+            echo "local task image is missing for cluster identity preflight" >&2
+            return 1
+        }
+        read -r normalized_runtime normalized_local < <(python3 - "$runtime_id" "$local_id" <<'PY'
+import re, sys
+def digest(value):
+    matches = re.findall(r"sha256:[0-9a-f]{64}", value.lower())
+    if not matches:
+        raise SystemExit("image identity has no sha256 digest")
+    return matches[-1]
+print(digest(sys.argv[1]), digest(sys.argv[2]))
+PY
+        )
+        if [[ "$normalized_runtime" != "$normalized_local" ]]; then
+            rm -f "$inventory"
+            echo "cluster product imageID mismatch for $component" >&2
+            return 1
+        fi
+    done
+    rm -f "$inventory"
+    echo "cluster product preflight: Ready product components and task image IDs match"
+}
+
+cluster_collector_metric_value() {
+    local metric="$1"
+    kubectl get --raw \
+        "/api/v1/namespaces/$CURIE_NAMESPACE/services/http:$CURIE_RELEASE-otel-collector:8888/proxy/metrics" \
+        | python3 -c '
+import re, sys
+name = sys.argv[1]
+total = 0.0
+for line in sys.stdin:
+    if re.match(r"^" + re.escape(name) + r"(?:\{|\s)", line):
+        total += float(line.rsplit(None, 1)[1])
+print(total)
+' "$metric"
+}
+
+run_cluster_product_observability() {
+    local agent_id="$1" agent_name="$2" accepted sent
+    preflight_cluster_product_observability
+    seed_ordinary_turn cluster "$agent_id"
+    if [[ "$LIVE" == "0" ]]; then
+        seed_approval_resume_turn cluster "$agent_id"
+    else
+        seed_mcp_read_turn cluster "$agent_id" "$agent_name"
+    fi
+    # Each seed helper performs the exact candidate read equivalent to:
+    # curie --json cluster observability run "$trace_id"
+    accepted="$(cluster_collector_metric_value otelcol_receiver_accepted_spans)"
+    sent="$(cluster_collector_metric_value otelcol_exporter_sent_spans)"
+    python3 -c 'import sys; raise SystemExit(0 if all(float(v) > 0 for v in sys.argv[1:]) else 1)' \
+        "$accepted" "$sent" || {
+        echo "cluster product Collector did not report positive accepted/sent spans" >&2
+        return 1
+    }
+    python3 - "$CLUSTER_PRODUCT_EVIDENCE" "$accepted" "$sent" <<'PY'
+import json, pathlib, sys
+pathlib.Path(sys.argv[1]).write_text(json.dumps({
+    "surface": "cluster",
+    "seed_valid": True,
+    "raw_emitted_observations": 1,
+    "otelcol_receiver_accepted_spans": float(sys.argv[2]),
+    "otelcol_exporter_sent_spans": float(sys.argv[3]),
+    "langfuse_observation_membership": True,
+    "image_ids_match": True,
+}, sort_keys=True))
+PY
+    echo "cluster product observability: independent exact seed(s) exported and queried"
+}
+
+classify_product_observability_owner() {
+    local local_evidence="$LOCAL_PRODUCT_EVIDENCE" cluster_evidence="$CLUSTER_PRODUCT_EVIDENCE"
+    python3 - "$local_evidence" "$cluster_evidence" <<'PY'
+import json, pathlib, sys
+
+records = {}
+for surface, raw_path in zip(("local", "cluster"), sys.argv[1:]):
+    path = pathlib.Path(raw_path)
+    if not path.is_file():
+        print("curie-unresolved: both product surfaces have not been exercised")
+        raise SystemExit(0)
+    records[surface] = json.loads(path.read_text())
+
+# These names deliberately mirror the evidence record. Ownership cannot be
+# assigned away from Curie until both product surfaces clear every prerequisite.
+for surface in ("local", "cluster"):
+    record = records[surface]
+    raw_emitted_observations = record.get("raw_emitted_observations", 0)
+    otelcol_receiver_accepted_spans = record.get("otelcol_receiver_accepted_spans", 0)
+    otelcol_exporter_sent_spans = record.get("otelcol_exporter_sent_spans", 0)
+    image_ids_match = record.get("image_ids_match") is True
+    seed_valid = record.get("seed_valid") is True
+    if not (
+        raw_emitted_observations > 0
+        and otelcol_receiver_accepted_spans > 0
+        and otelcol_exporter_sent_spans > 0
+        and image_ids_match
+        and seed_valid
+    ):
+        print("curie-owned: raw export, delivery, image identity, or seed precondition failed")
+        raise SystemExit(0)
+
+langfuse_observation_membership = all(
+    records[surface].get("langfuse_observation_membership") is True
+    for surface in ("local", "cluster")
+)
+if not langfuse_observation_membership:
+    print("adopted-component: Langfuse omitted observations after successful local and cluster raw export")
+else:
+    print("curie-clear: Langfuse exact observation membership passed on local and cluster")
+PY
+}
+
+rung_cluster_product() {
+    echo
+    echo "########## rung 3/3: cluster product observability ##########"
+    RAN_RUNGS="$RAN_RUNGS cluster"
+    preflight_cluster_product_observability
+    local deploy_json digest agent_id agent_name
+    deploy_json="$("$BIN" --json cluster deploy \
+        --namespace "$CURIE_NAMESPACE" --release "$CURIE_RELEASE" \
+        --plugin-dir "$WORKDIR/bundle")"
+    digest="$(deploy_field "cluster" "$deploy_json" bundle.sha256)"
+    agent_id="$(deploy_field "cluster" "$deploy_json" agent.id)"
+    agent_name="$(deploy_field "cluster" "$deploy_json" agent.name)"
+    run_cluster_product_observability "$agent_id" "$agent_name"
+    assert_bundle_identity "cluster" "$digest"
+}
+
 # Rung 3: the deployed release. Requires one to already exist; it is never
 # installed or torn down here, because the cluster is shared.
 rung_cluster() {
+    if [[ "$PRODUCT_OBSERVABILITY" == "1" ]]; then
+        rung_cluster_product
+        return
+    fi
     echo
     echo "########## rung 3/3: cluster ##########"
     RAN_RUNGS="$RAN_RUNGS cluster"
@@ -3611,25 +4580,50 @@ cp -r "$BUNDLE_SRC" "$WORKDIR/bundle-release"
 # the lock are packed like any other bundle file, so both must land before the
 # mtime normalization below and before any rung packs -- otherwise the copies
 # pack to different bytes and every multi-rung run is red by construction.
+NEEDS_CONNECTOR_BUILD=0
+MCP_PROOF_REQUIRED=0
 if connector_mode; then
     echo
-    echo "=== connector bundle: fixture, credentials, build ==="
-    if (( RUN_CLUSTER )) && [[ -z "$CONNECTOR_REGISTRY" ]]; then
-        echo "error: the cluster rung is named and CURIE_E2E_CONNECTOR_REGISTRY is unset." >&2
-        echo "why: without a registry the build delivers into the local Docker daemon, and a cluster deploy refuses a local-daemon lock by design -- the nodes cannot pull it." >&2
-        echo "fix: export CURIE_E2E_CONNECTOR_REGISTRY=<ref you can push to>, or drop cluster from CURIE_E2E_TIERS." >&2
-        exit 1
-    fi
+    echo "=== connector bundle: fixture and credentials ==="
     prepare_connector_bundle "$WORKDIR/bundle"
     prepare_connector_bundle "$WORKDIR/bundle-release"
     provision_connector_credentials
     write_connector_probe
+    NEEDS_CONNECTOR_BUILD=1
+fi
+
+# The live-provider overlay owns an independent hosted MCP receipt. It is
+# injected into both scratch copies before the one connector build so the
+# parity digest remains byte-identical across every named rung.
+if [[ "$LIVE" == "1" && -z "${STUB_STATE:-}" ]] \
+    && { (( RUN_LOCAL )) || { (( RUN_CLUSTER )) && [[ "$PRODUCT_OBSERVABILITY" == "1" ]]; }; }; then
+    MCP_PROOF_REQUIRED=1
+    echo
+    echo "=== hosted MCP receipt fixture ==="
+    prepare_mcp_receipt_bundle "$WORKDIR/bundle"
+    prepare_mcp_receipt_bundle "$WORKDIR/bundle-release"
+    NEEDS_CONNECTOR_BUILD=1
+fi
+
+if (( NEEDS_CONNECTOR_BUILD )); then
+    if (( RUN_CLUSTER )) && [[ -z "$CONNECTOR_REGISTRY" ]]; then
+        echo "error: the cluster rung needs CURIE_E2E_CONNECTOR_REGISTRY for hosted connector images." >&2
+        echo "fix: export a private task registry input, or drop cluster from CURIE_E2E_TIERS." >&2
+        exit 1
+    fi
     # ONE build, and its lock is COPIED to the second copy rather than built
     # again: a second build would resolve its own image reference, and the two
     # copies would then pack to different bytes. Every rung consumes this one
     # lock unchanged, which is what makes the digest assertion meaningful.
     build_connector_images "$WORKDIR/bundle"
     cp "$WORKDIR/bundle/connectors.lock.yaml" "$WORKDIR/bundle-release/connectors.lock.yaml"
+    if (( MCP_PROOF_REQUIRED )); then
+        MCP_RECEIPT_IMAGE="$(connector_image "$MCP_RECEIPT_CONNECTOR")"
+        [[ -n "$MCP_RECEIPT_IMAGE" ]] || {
+            echo "hosted MCP receipt image is absent from the connector build receipt" >&2
+            exit 1
+        }
+    fi
 fi
 
 # Normalize every regular file's mtime across both copies. This is load-bearing,
@@ -3700,6 +4694,12 @@ else
     echo
     echo "SKIPPING rung 3 (cluster): not named in CURIE_E2E_TIERS. It needs a live"
     echo "release and host-reachable pods, so it is opt-in: CURIE_E2E_TIERS=all."
+fi
+
+if [[ "$PRODUCT_OBSERVABILITY" == "1" ]]; then
+    echo
+    echo "=== product observability ownership classification ==="
+    classify_product_observability_owner
 fi
 
 echo

--- a/cli/scripts/e2e-ladder.sh
+++ b/cli/scripts/e2e-ladder.sh
@@ -457,24 +457,22 @@ else:
     case "$verdict" in
         ok) ;;
         empty_reply)
-            echo "$label: the turn finalized but the reply was empty, so no output made it back through the plumbing." >&2
+            echo "$label: finalized=true reply_present=false status=empty_reply" >&2
             return 1 ;;
         awaiting_approval)
-            echo "$label: the turn parked on an approval gate instead of finalizing; the ladder's bundle must not require approval." >&2
+            echo "$label: finalized=false awaiting_approval=true status=awaiting_approval" >&2
             return 1 ;;
         timed_out)
-            echo "$label: no reply finalized before the deadline. The worker never completed the turn." >&2
+            echo "$label: finalized=false timed_out=true status=timed_out" >&2
             return 1 ;;
         dry_run)
-            echo "$label: got a dry-run descriptor; the ladder must run for real, never with --dry-run." >&2
+            echo "$label: finalized=false dry_run=true status=dry_run" >&2
             return 1 ;;
         not_finalized)
-            echo "$label: the payload is neither finalized nor a known terminal shape." >&2
-            printf '%s\n' "$payload" >&2
+            echo "$label: finalized=false status=not_finalized" >&2
             return 1 ;;
         *)
-            echo "$label: could not parse message --json output:" >&2
-            printf '%s\n' "$payload" >&2
+            echo "$label: finalized=false status=unparseable" >&2
             return 1 ;;
     esac
 
@@ -637,14 +635,11 @@ rows = json.loads(pathlib.Path(sys.argv[1]).read_text())
 marker = sys.argv[2]
 carrier = re.compile(r"^00-([0-9a-f]{32})-[0-9a-f]{16}-[0-9a-f]{2}$")
 
-def exact_marker(value):
-    if value == marker:
-        return True
-    if isinstance(value, dict):
-        return any(exact_marker(item) for item in value.values())
-    if isinstance(value, list):
-        return any(exact_marker(item) for item in value)
-    return False
+def marker_in_turn_text(value):
+    if not isinstance(value, dict):
+        return False
+    text = value.get("text")
+    return isinstance(text, str) and marker in text
 
 matches = []
 for row in rows:
@@ -663,7 +658,7 @@ for row in rows:
         except (TypeError, json.JSONDecodeError):
             continue
         match = carrier.fullmatch(fields[index + 3]) if isinstance(fields[index + 3], str) else None
-        if exact_marker(payload) and match:
+        if marker_in_turn_text(payload) and match:
             matches.append(match.group(1))
 matches = sorted(set(matches))
 if len(matches) != 1:
@@ -704,8 +699,7 @@ safe_operations = {
     "curie.queue.enqueue", "curie.queue.process", "curie.turn.process",
     "curie.sandbox.claim", "curie.runner.rpc", "agent.run", "execute_tool",
     "curie.reply.post", "curie.reply.update", "curie.slack.receipt",
-    "curie.approval.wait", "curie.approval.resolve", "curie.approval.resume",
-    "approval.wait", "approval.resolve", "approval.resume",
+    "curie.approval.suspend", "curie.approval.resolve", "curie.approval.resume",
     }
 operations = []
 types = set()
@@ -714,17 +708,17 @@ observation_count = [0]
 def walk(node):
     if not isinstance(node, dict):
         raise SystemExit("exact trace tree contains a non-object node")
-    # Deliberately never dereference values in private_fields.
-    if private_fields.intersection(node):
-        pass
+    # Strip private response fields before inspecting the allowlisted shape.
+    # Their values are never copied, compared, formatted, or emitted.
+    public_node = {key: value for key, value in node.items() if key not in private_fields}
     observation_count[0] += 1
-    name = node.get("name")
-    kind = node.get("type")
+    name = public_node.get("name")
+    kind = public_node.get("type")
     if name in safe_operations:
         operations.append(name)
     if isinstance(kind, str) and kind.upper() in {"SPAN", "GENERATION", "EVENT"}:
         types.add(kind.upper())
-    children = node.get("children")
+    children = public_node.get("children")
     if not isinstance(children, list):
         raise SystemExit("exact trace node omitted its child array")
     for child in children:
@@ -793,13 +787,39 @@ query_exact_seed_trace() {
             return 1
         fi
         if [[ "$expected_state" == "absent" ]]; then
-            rm -f "$private_read" "$safe_read"
-            if (( code == 1 )); then
-                echo "exact trace temporarily absent as required"
-                return 0
+            if (( code == 0 )); then
+                rm -f "$private_read" "$safe_read"
+                echo "exact trace was queryable while the exporter was required to be failing" >&2
+                return 1
             fi
-            echo "exact trace was queryable while the exporter was required to be failing" >&2
-            return 1
+            if (( code != 1 )) || ! python3 - "$private_read" "$trace_id" "$tier" <<'PY'
+import json
+import pathlib
+import sys
+
+source, trace_id, tier = sys.argv[1:4]
+try:
+    value = json.loads(pathlib.Path(source).read_text())
+except (OSError, json.JSONDecodeError):
+    raise SystemExit(1)
+expected_error = f'observability trace "{trace_id}" was not found'
+if not isinstance(value, dict) or set(value) != {"error", "fix"}:
+    raise SystemExit(1)
+error = value.get("error")
+fix = value.get("fix")
+stable_not_found = error in {"exact trace not found", expected_error}
+if not stable_not_found or not isinstance(fix, str) or not fix.strip():
+    raise SystemExit(1)
+PY
+            then
+                rm -f "$private_read" "$safe_read"
+                echo "exact trace absence query returned an unexpected failure" >&2
+                return 1
+            fi
+            if (( attempt < OBSERVABILITY_POLL_ATTEMPTS )); then
+                sleep "$OBSERVABILITY_POLL_INTERVAL_SECONDS"
+            fi
+            continue
         fi
         if (( code == 0 )) && sanitize_exact_trace_read "$trace_id" "$private_read" "$expected_csv" "$expected_decision" > "$safe_read"; then
             cat "$safe_read"
@@ -810,6 +830,11 @@ query_exact_seed_trace() {
             sleep "$OBSERVABILITY_POLL_INTERVAL_SECONDS"
         fi
     done
+    if [[ "$expected_state" == "absent" ]]; then
+        rm -f "$private_read" "$safe_read"
+        echo "exact trace remained not-found through the full bounded observation poll"
+        return 0
+    fi
     rm -f "$private_read" "$safe_read"
     echo "exact trace did not become queryable inside the bounded ingestion poll" >&2
     return 1
@@ -976,151 +1001,10 @@ PY
     stream_end="$(capture_stream_cursor "$tier")" || return 1
     trace_id="$(discover_trace_id_for_seed "$tier" "$marker" "$stream_start" "$stream_end")" || return 1
     query_exact_seed_trace "$tier" "$trace_id" \
-        "curie.approval.wait,curie.approval.resolve,curie.approval.resume,curie.reply.post|curie.reply.update" \
+        "curie.approval.suspend,curie.approval.resolve,curie.approval.resume,curie.reply.post|curie.reply.update" \
         "approved"
     LAST_APPROVAL_TRACE_ID="$trace_id"
     printf '%s' "$trace_id"
-}
-
-# Langfuse ingestion is asynchronous to turn finalization. Poll through the
-# candidate CLI, never its backing API. Scan one bounded newest-first page and
-# select the newest complete row. The returned id is the sole input to the
-# detail read; no latest shortcut or message-output parsing duplicates #1664.
-# Correlation to this rung is proved independently by the explicit-window
-# metrics reads below; trace-list DTOs do not promise an agent identity field.
-discover_local_observability_trace() {
-    local attempt out code verdict state detail limit=100
-    DISCOVERED_OBSERVABILITY_TRACE_ID=""
-    for attempt in $(seq 1 "$OBSERVABILITY_POLL_ATTEMPTS"); do
-        out="$("$BIN" --json local observability runs --limit "$limit")" && code=0 || code=$?
-        if (( code != 0 )); then
-            echo "local observability runs: bounded ingestion read exited $code, expected 0." >&2
-            printf '%s\n' "$out" >&2
-            return 1
-        fi
-        verdict="$(printf '%s' "$out" | python3 -c '
-import json, re, sys
-try:
-    value = json.loads(sys.stdin.read())
-except Exception as exc:
-    print("invalid")
-    print("expected exactly one JSON object: %s" % exc)
-    sys.exit(0)
-if not isinstance(value, dict):
-    print("invalid")
-    print("top level is not an object")
-    sys.exit(0)
-runs = value.get("runs")
-limit = value.get("limit")
-count = value.get("count")
-if isinstance(limit, bool) or limit != 100:
-    print("invalid")
-    print("limit is not the requested bound of 100")
-elif not isinstance(runs, list) or len(runs) > 100:
-    print("invalid")
-    print("runs is not an array bounded to at most 100 rows")
-elif isinstance(count, bool) or not isinstance(count, int) or count != len(runs):
-    print("invalid")
-    print("count does not equal the bounded row count")
-else:
-    matched = None
-    for row in runs:
-        if not isinstance(row, dict):
-            print("invalid")
-            print("a run row is not an object")
-            sys.exit(0)
-        trace_id = row.get("id")
-        name = row.get("name")
-        timestamp = row.get("timestamp")
-        if not isinstance(trace_id, str) or not re.fullmatch(r"[A-Za-z0-9_-]{1,128}", trace_id):
-            print("invalid")
-            print("run id is absent or not a safe trace id")
-            sys.exit(0)
-        if name is not None and not isinstance(name, str):
-            print("invalid")
-            print("run name is neither a string nor null")
-            sys.exit(0)
-        if not isinstance(timestamp, str) or not timestamp:
-            print("invalid")
-            print("run timestamp is absent or not a string")
-            sys.exit(0)
-        if matched is None:
-            matched = trace_id
-    if matched is None:
-        print("pending")
-        print("no ingested run yet")
-    else:
-        print("ok")
-        print(matched)
-' || printf '%s\n%s\n' invalid 'validator failed')"
-        detail="${verdict#*$'\n'}"
-        state="${verdict%%$'\n'*}"
-        case "$state" in
-            ok)
-                DISCOVERED_OBSERVABILITY_TRACE_ID="${detail%%$'\n'*}"
-                printf '%s\n' "$out"
-                echo "local observability runs: bounded result discovered trace $DISCOVERED_OBSERVABILITY_TRACE_ID after $attempt ingestion poll(s)"
-                return 0
-                ;;
-            pending)
-                if (( attempt < OBSERVABILITY_POLL_ATTEMPTS )); then
-                    sleep "$OBSERVABILITY_POLL_INTERVAL_SECONDS"
-                fi
-                ;;
-            *)
-                echo "local observability runs: $detail." >&2
-                printf '%s\n' "$out" >&2
-                return 1
-                ;;
-        esac
-    done
-    echo "local observability runs: no run appeared in the newest 100 traces after $OBSERVABILITY_POLL_ATTEMPTS bounded poll(s)." >&2
-    return 1
-}
-
-assert_local_observability_detail() {
-    local trace_id="$1" payload="$2" verdict
-    verdict="$(printf '%s' "$payload" | python3 -c '
-import json, sys
-expected = sys.argv[1]
-try:
-    value = json.loads(sys.stdin.read())
-except Exception as exc:
-    print("expected exactly one JSON object: %s" % exc)
-    sys.exit(0)
-trace = value.get("trace") if isinstance(value, dict) else None
-tree = value.get("tree") if isinstance(value, dict) else None
-def valid_node(node):
-    if not isinstance(node, dict) or not isinstance(node.get("id"), str) or not isinstance(node.get("type"), str):
-        return False
-    for key in ("name", "startTime", "model"):
-        if node.get(key) is not None and not isinstance(node.get(key), str):
-            return False
-    if node.get("usageDetails") is not None and not isinstance(node.get("usageDetails"), dict):
-        return False
-    children = node.get("children")
-    return isinstance(children, list) and all(valid_node(child) for child in children)
-if not isinstance(trace, dict) or trace.get("id") != expected:
-    print("trace object does not carry the discovered id")
-elif not isinstance(trace.get("name"), str):
-    print("trace name is not a string")
-elif not isinstance(tree, list):
-    print("observation tree is not an array")
-elif not all(valid_node(node) for node in tree):
-    print("observation tree does not match the recursive typed node shape")
-elif "sandbox_id" not in value or value["sandbox_id"] is not None and not isinstance(value["sandbox_id"], str):
-    print("sandbox_id correlation field is absent or mistyped")
-elif "approval_decision" not in value or value["approval_decision"] is not None and not isinstance(value["approval_decision"], str):
-    print("approval_decision correlation field is absent or mistyped")
-else:
-    print("ok %d" % len(tree))
-' "$trace_id" || echo "validator failed")"
-    if [[ "$verdict" != ok\ * ]]; then
-        echo "local observability run: $verdict." >&2
-        printf '%s\n' "$payload" >&2
-        return 1
-    fi
-    echo "local observability run: fetched complete trace $trace_id with ${verdict#ok } root observation(s) and both correlation fields"
 }
 
 assert_local_observability_summary() {
@@ -3468,7 +3352,7 @@ case_local_langfuse_invalid_auth() {
     local INVALID_LANGFUSE_OTLP_AUTH_HEADER='Basic aW52YWxpZDppbnZhbGlk'
     local agent_id="$1" original_set=0 original="${LANGFUSE_OTLP_AUTH_HEADER-}"
     local receipt same_queued_trace_id queue_drained accepted accepted_before sent langfuse_web
-    local collector storage_directory
+    local collector storage_directory accepted_baseline failed failed_baseline queue_size
     [[ ${LANGFUSE_OTLP_AUTH_HEADER+x} ]] && original_set=1
     langfuse_web="$(docker compose --profile full -f "$REPO_ROOT/compose.dev.yaml" ps -q langfuse-web)"
     [[ -n "$langfuse_web" ]] || {
@@ -3509,6 +3393,14 @@ if not any(
 
     echo
     echo "=== case: pinned Langfuse invalid auth queues and recovers the same ID ==="
+    if [[ ! "$LAST_ORDINARY_TRACE_ID" =~ ^[0-9a-f]{32}$ ]] || ! query_exact_seed_trace local "$LAST_ORDINARY_TRACE_ID" \
+        "curie.queue.enqueue,curie.queue.process,curie.turn.process,curie.sandbox.claim,curie.runner.rpc,agent.run,curie.reply.post|curie.reply.update" \
+        >/dev/null; then
+        rm -f "$receipt"
+        echo "invalid-auth negative lacks a valid exact-query control" >&2
+        return 1
+    fi
+    echo "invalid-auth negative: valid exact-query control passed before auth changed"
     if ! (
         set -e
         export LANGFUSE_OTLP_AUTH_HEADER="$INVALID_LANGFUSE_OTLP_AUTH_HEADER"
@@ -3517,6 +3409,8 @@ if not any(
             echo "Collector failed the Ready check after invalid-auth restart" >&2
             exit 1
         }
+        accepted_baseline="$(product_collector_metric_value otelcol_receiver_accepted_spans)"
+        failed_baseline="$(product_collector_metric_value otelcol_exporter_send_failed_spans)"
 
         marker="curie-seed-invalid-auth-$$-$RANDOM"
         stream_start="$(capture_stream_cursor local)"
@@ -3533,14 +3427,32 @@ if not any(
             accepted="$(product_collector_metric_value otelcol_receiver_accepted_spans)"
             failed="$(product_collector_metric_value otelcol_exporter_send_failed_spans)"
             queue_size="$(product_collector_metric_value otelcol_exporter_queue_size)"
-            if python3 -c 'import sys; raise SystemExit(0 if all(float(v) > 0 for v in sys.argv[1:]) else 1)' \
-                "$accepted" "$failed" "$queue_size"; then
+            if python3 -c 'import sys; a,f,q,ab,fb=map(float,sys.argv[1:]); raise SystemExit(0 if a > ab and f > fb and 0 < q <= 1000 else 1)' \
+                "$accepted" "$failed" "$queue_size" "$accepted_baseline" "$failed_baseline"; then
                 break
             fi
             sleep 2
         done
-        python3 -c 'import sys; q=float(sys.argv[3]); raise SystemExit(0 if float(sys.argv[1]) > 0 and float(sys.argv[2]) > 0 and 0 < q <= 1000 else 1)' \
-            "$accepted" "$failed" "$queue_size"
+        python3 -c 'import sys; a,f,q,ab,fb=map(float,sys.argv[1:]); raise SystemExit(0 if a > ab and f > fb and 0 < q <= 1000 else 1)' \
+            "$accepted" "$failed" "$queue_size" "$accepted_baseline" "$failed_baseline"
+        query_exact_seed_trace local "$same_queued_trace_id" "" "" absent
+
+        # Recreate once while auth is still invalid. The file-backed queue must
+        # survive the process boundary and retry the same pending export.
+        restart_local_product_collector
+        queue_size=0
+        failed=0
+        for attempt in $(seq 1 45); do
+            queue_size="$(product_collector_metric_value otelcol_exporter_queue_size)"
+            failed="$(product_collector_metric_value otelcol_exporter_send_failed_spans)"
+            if python3 -c 'import sys; q,f=map(float,sys.argv[1:]); raise SystemExit(0 if 0 < q <= 1000 and f > 0 else 1)' \
+                "$queue_size" "$failed"; then
+                break
+            fi
+            sleep 2
+        done
+        python3 -c 'import sys; q,f=map(float,sys.argv[1:]); raise SystemExit(0 if 0 < q <= 1000 and f > 0 else 1)' \
+            "$queue_size" "$failed"
         query_exact_seed_trace local "$same_queued_trace_id" "" "" absent
 
         python3 - "$receipt" "$same_queued_trace_id" "$accepted" <<'PY'
@@ -4134,26 +4046,30 @@ preflight_cluster_product_observability() {
         return 1
     fi
     umask 077
-    inventory="$(mktemp "$WORKDIR/cluster-product-pods.XXXXXX")"
+    inventory="$(mktemp "$WORKDIR/cluster-product-status.XXXXXX")"
+    # Persist only the component label, Ready condition, and runtime image IDs.
+    # A complete pod JSON document can contain environment values from spec.
     kubectl -n "$namespace" get pods \
-        -l "app.kubernetes.io/instance=$release" -o json > "$inventory" || {
+        -l "app.kubernetes.io/instance=$release" \
+        -o go-template='{{range .items}}{{index .metadata.labels "app.kubernetes.io/component"}}{{"\t"}}{{range .status.conditions}}{{if eq .type "Ready"}}{{.status}}{{end}}{{end}}{{"\t"}}{{range .status.containerStatuses}}{{.imageID}}{{" "}}{{end}}{{"\n"}}{{end}}' \
+        > "$inventory" || {
         rm -f "$inventory"
         return 1
     }
     python3 - "$inventory" <<'PY'
-import json, pathlib, sys
-items = json.loads(pathlib.Path(sys.argv[1]).read_text()).get("items", [])
+import pathlib, sys
 required = {"langfuse-web", "langfuse-worker", "otel-collector", "api", "worker", "runner-prewarm"}
 seen = set()
-for item in items:
-    component = item.get("metadata", {}).get("labels", {}).get("app.kubernetes.io/component")
+for raw in pathlib.Path(sys.argv[1]).read_text().splitlines():
+    fields = raw.split("\t")
+    if len(fields) != 3:
+        raise SystemExit("product status row is malformed")
+    component, ready, image_ids = fields
     if component not in required:
         continue
-    conditions = item.get("status", {}).get("conditions", [])
-    if not any(c.get("type") == "Ready" and c.get("status") == "True" for c in conditions):
+    if ready != "True":
         raise SystemExit("product component is not Ready")
-    statuses = item.get("status", {}).get("containerStatuses", [])
-    if not statuses or any(not status.get("imageID") for status in statuses):
+    if not image_ids.split():
         raise SystemExit("Ready product component omitted imageID")
     seen.add(component)
 missing = required - seen
@@ -4167,14 +4083,14 @@ PY
         component="${mapping%%|*}"
         tag="${mapping#*|}"
         runtime_id="$(python3 - "$inventory" "$component" <<'PY'
-import json, pathlib, sys
-items = json.loads(pathlib.Path(sys.argv[1]).read_text()).get("items", [])
+import pathlib, sys
 want = sys.argv[2]
 values = []
-for item in items:
-    if item.get("metadata", {}).get("labels", {}).get("app.kubernetes.io/component") != want:
+for raw in pathlib.Path(sys.argv[1]).read_text().splitlines():
+    fields = raw.split("\t")
+    if len(fields) != 3 or fields[0] != want:
         continue
-    values.extend(status.get("imageID", "") for status in item.get("status", {}).get("containerStatuses", []))
+    values.extend(fields[2].split())
 values = sorted(set(values))
 if len(values) != 1:
     raise SystemExit("component imageID is absent or inconsistent")

--- a/cli/scripts/e2e-ladder.sh
+++ b/cli/scripts/e2e-ladder.sh
@@ -3974,25 +3974,31 @@ rung_local() {
     echo
     echo "=== exact ordinary product-observability seed ==="
     local product_accepted_before product_sent_before product_accepted_after product_sent_after
-    local product_accepted_delta product_sent_delta product_membership
+    local product_accepted_delta product_sent_delta product_membership product_query_state=present
+    if [[ "$PRODUCT_OBSERVABILITY" == "1" ]]; then
+        # Ownership diagnostics must retain an incomplete exact read so the
+        # classifier can distinguish unresolved/Curie/adopted outcomes. The
+        # ordinary default local positive is strict and fails before continuing.
+        product_query_state=observe
+    fi
     if [[ -n "${STUB_STATE:-}" ]]; then
         seed_ordinary_turn local "$agent_id" stub
     else
         product_accepted_before="$(product_collector_metric_value otelcol_receiver_accepted_spans)"
         product_sent_before="$(product_collector_metric_value otelcol_exporter_sent_spans)"
-        seed_ordinary_turn local "$agent_id" observe
+        seed_ordinary_turn local "$agent_id" "$product_query_state"
         product_membership="$LAST_ORDINARY_MEMBERSHIP"
 
     if [[ "$LIVE" == "0" ]]; then
         echo
         echo "=== exact approval wait/resolve/resume product-observability seed ==="
-        seed_approval_resume_turn local "$agent_id" observe
+        seed_approval_resume_turn local "$agent_id" "$product_query_state"
         [[ "$LAST_APPROVAL_MEMBERSHIP" == "true" ]] || product_membership="false"
     fi
     if [[ "$LIVE" == "1" ]]; then
         echo
         echo "=== exact hosted MCP read product-observability seed ==="
-        seed_mcp_read_turn local "$agent_id" "$agent_name" observe
+        seed_mcp_read_turn local "$agent_id" "$agent_name" "$product_query_state"
         [[ "$LAST_MCP_MEMBERSHIP" == "true" ]] || product_membership="false"
     fi
 
@@ -4008,10 +4014,8 @@ PY
     write_product_observability_evidence "$LOCAL_PRODUCT_EVIDENCE" local \
         "$product_accepted_delta" "$product_sent_delta" "$product_membership" not-applicable false
 
-    if [[ -z "${STUB_STATE:-}" && "$LAST_ORDINARY_MEMBERSHIP" == "true" ]] && (( LOCAL_STACK_OWNED )); then
+    if [[ -z "${STUB_STATE:-}" ]] && (( LOCAL_STACK_OWNED )); then
         case_local_langfuse_invalid_auth "$agent_id"
-    elif [[ -z "${STUB_STATE:-}" && "$LAST_ORDINARY_MEMBERSHIP" != "true" ]]; then
-        echo "local invalid-auth negative skipped: exact known-valid control was not queryable"
     fi
     fi
 
@@ -4451,13 +4455,15 @@ records = {}
 for surface, raw_path in zip(("local", "cluster"), sys.argv[1:]):
     path = pathlib.Path(raw_path)
     if not path.is_file():
-        print("curie-unresolved: both product surfaces have not been exercised")
-        raise SystemExit(1)
+        continue
     try:
         records[surface] = json.loads(path.read_text())
     except (OSError, json.JSONDecodeError):
         print(f"curie-unresolved: {surface} evidence is unreadable")
         raise SystemExit(1)
+if not records:
+    print("curie-unresolved: no product surface has been exercised")
+    raise SystemExit(1)
 
 required_fields = (
     "run_id", "surface", "seed_valid", "same_id_raw_collector_receipt",
@@ -4492,8 +4498,7 @@ if len(run_ids) != 1 or not next(iter(run_ids), None):
 
 # These names deliberately mirror the evidence record. Ownership cannot be
 # assigned away from Curie until both product surfaces clear every prerequisite.
-for surface in ("local", "cluster"):
-    record = records[surface]
+for surface, record in records.items():
     raw_emitted_observations = record.get("raw_emitted_observations", 0)
     otelcol_receiver_accepted_spans = record.get("otelcol_receiver_accepted_spans", 0)
     otelcol_exporter_sent_spans = record.get("otelcol_exporter_sent_spans", 0)
@@ -4511,8 +4516,16 @@ for surface in ("local", "cluster"):
 
 memberships = dict(
     (surface, records[surface].get("langfuse_observation_membership") is True)
-    for surface in ("local", "cluster")
+    for surface in records
 )
+if len(records) == 1:
+    surface = next(iter(records))
+    if memberships[surface]:
+        print(f"curie-clear: Langfuse exact observation membership passed on {surface}")
+        raise SystemExit(0)
+    print(f"curie-unresolved: {surface} exact Langfuse membership is missing without a sibling control")
+    raise SystemExit(1)
+
 same_id_raw_receipts = dict(
     (surface, records[surface].get("same_id_raw_collector_receipt") is True)
     for surface in ("local", "cluster")

--- a/cli/scripts/e2e-ladder.sh
+++ b/cli/scripts/e2e-ladder.sh
@@ -213,12 +213,13 @@ LAST_MCP_MEMBERSHIP=""
 LAST_APPROVAL_MEMBERSHIP=""
 LAST_QUERY_MEMBERSHIP=""
 LAST_QUERY_OBSERVATION_COUNT="0"
-CLUSTER_TURN_TEMPLATE=""
-CLUSTER_SEEDED_TRACE_ID=""
-CLUSTER_SEEDED_REPLY_REF=""
+LAST_EXTERNAL_ACCEPTED_DELTA="0"
+LAST_EXTERNAL_SENT_DELTA="0"
 CLUSTER_IMAGE_IDS_MATCH="false"
 LOCAL_PRODUCT_EVIDENCE=""
 CLUSTER_PRODUCT_EVIDENCE=""
+PRODUCT_OBSERVABILITY_RUN_ID="${CURIE_E2E_PRODUCT_RUN_ID:-}"
+CLUSTER_EXTERNAL_INGRESS_RECEIPT="${CURIE_E2E_CLUSTER_EXTERNAL_INGRESS_RECEIPT:-}"
 
 # The component label every connector container carries, in both the skill start
 # path and the local compose overlay (cli/src/docker.rs
@@ -319,7 +320,6 @@ fi
 WORKDIR="$(mktemp -d)"
 LOCAL_PRODUCT_EVIDENCE="$WORKDIR/product-observability-local.json"
 CLUSTER_PRODUCT_EVIDENCE="$WORKDIR/product-observability-cluster.json"
-CLUSTER_TURN_TEMPLATE="$WORKDIR/cluster-turn-template.json"
 cleanup() {
     # Capture the real exit code FIRST: a teardown command that fails must not
     # turn a red run green, and a successful teardown must not mask a red rung.
@@ -689,24 +689,35 @@ PY
     printf '%s' "$trace_id"
 }
 
-# Capture one validated disconnected-cluster turn as a private shape template.
-# The payload-only control itself is never treated as correlation evidence.
-capture_cluster_turn_template() {
-    local marker="$1" stream_start="$2" stream_end="$3" private_slice
+# The disconnected CLI path is intentionally carrierless (#1817). Exercise it
+# as a compatibility negative and prove it did not accidentally grow a W3C
+# carrier. It is never promoted into positive correlation evidence.
+seed_cluster_missing_carrier_control() {
+    local marker="curie-seed-cluster-missing-carrier-$$-$RANDOM"
+    local stream_start stream_end out private_slice
+    stream_start="$(capture_stream_cursor cluster)" || return 1
+    out="$("$BIN" --json cluster message --namespace "$CURIE_NAMESPACE" \
+        --release "$CURIE_RELEASE" "missing carrier compatibility $marker" || true)"
+    assert_finalized_reply "cluster missing-carrier compatibility" "$out"
+    stream_end="$(capture_stream_cursor cluster)" || return 1
+    [[ "$stream_end" != "$stream_start" ]] || {
+        echo "seed-invalid: cluster missing-carrier control produced no stream receipt" >&2
+        return 1
+    }
     umask 077
-    private_slice="$(mktemp "$WORKDIR/cluster-template-stream.XXXXXX")"
+    private_slice="$(mktemp "$WORKDIR/cluster-missing-carrier.XXXXXX")"
     product_stream_json cluster XRANGE curie:runs "($stream_start" "$stream_end" > "$private_slice" || {
         rm -f "$private_slice"
         return 1
     }
-    python3 - "$private_slice" "$marker" "$CLUSTER_TURN_TEMPLATE" <<'PY'
+    python3 - "$private_slice" "$marker" <<'PY'
 import json, pathlib, sys
 rows = json.loads(pathlib.Path(sys.argv[1]).read_text())
 marker = sys.argv[2]
 matches = []
 for row in rows:
     if not isinstance(row, list) or len(row) != 2 or not isinstance(row[1], list):
-        raise SystemExit("seed-invalid: malformed cluster template slice")
+        raise SystemExit("seed-invalid: malformed cluster missing-carrier slice")
     fields = row[1]
     for index in range(0, len(fields) - 1, 2):
         if fields[index] != "payload":
@@ -716,107 +727,115 @@ for row in rows:
         except (TypeError, json.JSONDecodeError):
             continue
         text = payload.get("text") if isinstance(payload, dict) else None
-        if isinstance(text, str) and marker in text:
-            matches.append(payload)
-if len(matches) != 1:
-    raise SystemExit("seed-invalid: cluster control did not select one private turn template")
-handle = matches[0].get("reply_handle")
-if not isinstance(handle, dict) or handle.get("adapter") != "curie-cluster-message":
-    raise SystemExit("seed-invalid: cluster control omitted the reserved reply adapter")
-pathlib.Path(sys.argv[3]).write_text(json.dumps(matches[0], separators=(",", ":")))
+        if not isinstance(text, str) or marker not in text:
+            continue
+        handle = payload.get("reply_handle")
+        if not isinstance(handle, dict) or handle.get("adapter") != "curie-cluster-message":
+            raise SystemExit("seed-invalid: cluster compatibility control used the wrong producer")
+        has_adjacent_carrier = index + 3 < len(fields) and fields[index + 2] == "traceparent"
+        matches.append(has_adjacent_carrier)
+if matches != [False]:
+    raise SystemExit("seed-invalid: cluster compatibility control was absent, ambiguous, or carried context")
 PY
     rm -f "$private_slice"
+    echo "cluster missing-carrier compatibility: finalized=true adjacent_traceparent=false"
 }
 
-# Re-seed the validated cluster shape with fresh identifiers and an explicit
-# adjacent W3C carrier. This is a turn/data mutation only in the operator-owned
-# release; it never installs, upgrades, deletes, or rewrites cluster resources.
-enqueue_cluster_carried_turn() {
-    local marker="$1" text="$2" private_payload private_meta payload raw_id stream_start stream_end discovered traceparent
-    [[ -s "$CLUSTER_TURN_TEMPLATE" ]] || {
-        echo "seed-invalid: cluster carried seed lacks its validated control template" >&2
+# Positive cluster evidence belongs to the real Slack phase. The private
+# receipt carries only bounded cursors, a public-safe marker, and independently
+# observed outcome booleans. The trace id is derived here from the accepted
+# Slack queue entry; no caller-supplied id and no harness XADD are accepted.
+cluster_external_ingress_seed() {
+    local kind="$1" expected_operations="$2" expected_decision="${3:-}"
+    local receipt="$CLUSTER_EXTERNAL_INGRESS_RECEIPT" fields marker stream_start stream_end trace_id
+    [[ -n "$PRODUCT_OBSERVABILITY_RUN_ID" ]] || {
+        echo "cluster product evidence blocked: CURIE_E2E_PRODUCT_RUN_ID is required to join one supported run" >&2
         return 1
     }
-    umask 077
-    private_payload="$(mktemp "$WORKDIR/cluster-carried-payload.XXXXXX")"
-    private_meta="$(mktemp "$WORKDIR/cluster-carried-meta.XXXXXX")"
-    python3 - "$CLUSTER_TURN_TEMPLATE" "$private_payload" "$private_meta" "$text" <<'PY'
-import json, pathlib, secrets, sys, uuid
-from datetime import UTC, datetime
-
+    [[ -n "$receipt" && -f "$receipt" ]] || {
+        echo "cluster product evidence blocked: the external Slack phase did not provide CURIE_E2E_CLUSTER_EXTERNAL_INGRESS_RECEIPT" >&2
+        return 1
+    }
+    [[ "$(stat -c '%a' "$receipt")" == "600" ]] || {
+        echo "cluster product evidence blocked: the external Slack ingress receipt must be mode 0600" >&2
+        return 1
+    }
+    fields="$(python3 - "$receipt" "$PRODUCT_OBSERVABILITY_RUN_ID" "$kind" <<'PY'
+import json, pathlib, re, sys
 value = json.loads(pathlib.Path(sys.argv[1]).read_text())
-reply_ref = str(uuid.uuid4())
-trace_id = secrets.token_hex(16)
-span_id = secrets.token_hex(8)
-value["event_id"] = f"EvSIM-{uuid.uuid4()}"
-value["conversation_id"] = f"C0EXAMPLE1:{uuid.uuid4()}"
-value["text"] = sys.argv[4]
-value["received_at"] = datetime.now(UTC).isoformat()
-value["reply_handle"]["placeholder"] = reply_ref
-pathlib.Path(sys.argv[2]).write_text(json.dumps(value, separators=(",", ":")))
-pathlib.Path(sys.argv[3]).write_text(json.dumps({
-    "trace_id": trace_id,
-    "traceparent": f"00-{trace_id}-{span_id}-01",
-    "reply_ref": reply_ref,
-}, separators=(",", ":")))
+run_id, kind = sys.argv[2:4]
+if not isinstance(value, dict) or value.get("run_id") != run_id:
+    raise SystemExit("external Slack ingress receipt belongs to a different run")
+seeds = value.get("seeds")
+if not isinstance(seeds, list):
+    raise SystemExit("external Slack ingress receipt omitted seeds")
+matches = [seed for seed in seeds if isinstance(seed, dict) and seed.get("kind") == kind]
+if len(matches) != 1:
+    raise SystemExit("external Slack ingress receipt did not contain exactly one requested seed")
+seed = matches[0]
+marker = seed.get("marker")
+start = seed.get("stream_start")
+end = seed.get("stream_end")
+if not isinstance(marker, str) or not marker.startswith(f"curie-seed-external-{kind}-"):
+    raise SystemExit("external Slack ingress marker is not public-safe and kind-bound")
+if not all(isinstance(item, str) and re.fullmatch(r"[0-9]+-[0-9]+", item) for item in (start, end)):
+    raise SystemExit("external Slack ingress receipt omitted bounded stream cursors")
+if seed.get("reply_observed") is not True or seed.get("completion_observed") is not True:
+    raise SystemExit("external Slack driver did not independently observe reply and completion")
+if kind == "mcp" and seed.get("mcp_call_count_delta") != 1:
+    raise SystemExit("external MCP seed omitted its independent one-call receipt")
+if kind == "approval" and seed.get("approval_transition_observed") is not True:
+    raise SystemExit("external approval seed omitted its independent transition receipt")
+accepted = seed.get("otelcol_receiver_accepted_spans_delta")
+sent = seed.get("otelcol_exporter_sent_spans_delta")
+if not all(isinstance(item, (int, float)) and not isinstance(item, bool) and item > 0 for item in (accepted, sent)):
+    raise SystemExit("external Slack seed omitted positive observed Collector deltas")
+print(marker, start, end, accepted, sent)
 PY
-    stream_start="$(capture_stream_cursor cluster)" || return 1
-    payload="$(cat "$private_payload")"
-    read -r CLUSTER_SEEDED_TRACE_ID traceparent CLUSTER_SEEDED_REPLY_REF < <(python3 - "$private_meta" <<'PY'
-import json, pathlib, sys
-value = json.loads(pathlib.Path(sys.argv[1]).read_text())
-print(value["trace_id"], value["traceparent"], value["reply_ref"])
-PY
-    )
-    raw_id="$(product_stream_json cluster XADD curie:runs '*' payload "$payload" traceparent "$traceparent")" || return 1
-    stream_end="$(printf '%s' "$raw_id" | python3 -c 'import json,sys; value=json.load(sys.stdin); print(value if isinstance(value,str) else "")')"
-    rm -f "$private_payload" "$private_meta"
-    [[ -n "$stream_end" && "$stream_end" != "$stream_start" ]] || {
-        echo "seed-invalid: explicit cluster carrier seed produced no stream entry" >&2
-        return 1
-    }
-    discovered="$(discover_trace_id_for_seed cluster "$marker" "$stream_start" "$stream_end")" || return 1
-    [[ "$discovered" == "$CLUSTER_SEEDED_TRACE_ID" ]] || {
-        echo "seed-invalid: explicit cluster carrier did not round-trip to its exact trace id" >&2
-        return 1
-    }
+)" || return 1
+    read -r marker stream_start stream_end LAST_EXTERNAL_ACCEPTED_DELTA LAST_EXTERNAL_SENT_DELTA <<< "$fields"
+    trace_id="$(discover_cluster_external_trace_id "$marker" "$stream_start" "$stream_end")" || return 1
+    query_exact_seed_trace cluster "$trace_id" "$expected_operations" "$expected_decision" observe
 }
 
-wait_cluster_carried_reply() {
-    local reply_ref="$1" terminal_key events_key private_events terminal attempt
-    [[ "$reply_ref" =~ ^[0-9a-f-]{36}$ ]] || return 1
-    terminal_key="curie:cluster-message-replies:{$reply_ref}:terminal"
-    events_key="curie:cluster-message-replies:{$reply_ref}:events"
+discover_cluster_external_trace_id() {
+    local marker="$1" stream_start="$2" stream_end="$3" private_slice trace_id
     umask 077
-    private_events="$(mktemp "$WORKDIR/cluster-carried-reply.XXXXXX")"
-    terminal=""
-    for attempt in $(seq 1 120); do
-        terminal="$(product_stream_json cluster GET "$terminal_key" 2>/dev/null || true)"
-        if [[ "$terminal" == '"1"' ]]; then
-            break
-        fi
-        sleep 1
-    done
-    [[ "$terminal" == '"1"' ]] || {
-        rm -f "$private_events"
-        echo "seed-invalid: explicit cluster carrier turn did not finalize" >&2
+    private_slice="$(mktemp "$WORKDIR/cluster-external-stream.XXXXXX")"
+    product_stream_json cluster XRANGE curie:runs "($stream_start" "$stream_end" > "$private_slice" || {
+        rm -f "$private_slice"
         return 1
     }
-    product_stream_json cluster LRANGE "$events_key" 0 -1 > "$private_events" || return 1
-    python3 - "$private_events" <<'PY'
-import json, pathlib, sys
+    trace_id="$(python3 - "$private_slice" "$marker" <<'PY'
+import json, pathlib, re, sys
 rows = json.loads(pathlib.Path(sys.argv[1]).read_text())
-events = []
+marker = sys.argv[2]
+carrier = re.compile(r"^00-([0-9a-f]{32})-[0-9a-f]{16}-[0-9a-f]{2}$")
+matches = []
 for row in rows:
-    value = json.loads(row) if isinstance(row, str) else None
-    if not isinstance(value, dict) or not isinstance(value.get("event"), str):
-        raise SystemExit("seed-invalid: cluster reply receipt is malformed")
-    events.append(value["event"])
-if "turn.completed" not in events or not any(item in {"reply.post", "reply.update"} for item in events):
-    raise SystemExit("seed-invalid: cluster reply receipt omitted reply or completion")
+    if not isinstance(row, list) or len(row) != 2 or not isinstance(row[1], list):
+        raise SystemExit("seed-invalid: malformed external Slack stream slice")
+    fields = row[1]
+    for index in range(0, len(fields), 2):
+        if fields[index] != "payload" or index + 3 >= len(fields) or fields[index + 2] != "traceparent":
+            continue
+        try:
+            payload = json.loads(fields[index + 1])
+        except (TypeError, json.JSONDecodeError):
+            continue
+        text = payload.get("text") if isinstance(payload, dict) else None
+        handle = payload.get("reply_handle") if isinstance(payload, dict) else None
+        match = carrier.fullmatch(fields[index + 3]) if isinstance(fields[index + 3], str) else None
+        if isinstance(text, str) and marker in text and isinstance(handle, dict) and handle.get("kind") == "slack" and handle.get("adapter") is None and match:
+            matches.append(match.group(1))
+matches = sorted(set(matches))
+if len(matches) != 1:
+    raise SystemExit("seed-invalid: exact external Slack marker did not select one real adjacent carrier")
+print(matches[0])
 PY
-    rm -f "$private_events"
-    echo "cluster carried seed: finalized=true reply_observed=true"
+)" || { rm -f "$private_slice"; return 1; }
+    rm -f "$private_slice"
+    printf '%s' "$trace_id"
 }
 
 # Convert a private exact-detail response into the sole public trace evidence.
@@ -840,7 +859,7 @@ private_fields = {"input", "output", "session", "user", "headers"}
 safe_operations = {
     "curie.queue.enqueue", "curie.queue.process", "curie.turn.process",
     "curie.sandbox.claim", "curie.runner.rpc", "agent.run", "execute_tool",
-    "curie.reply.post", "curie.reply.update", "curie.slack.receipt",
+    "curie.reply.post", "curie.reply.update", "curie.turn.ingress",
     "curie.approval.suspend", "curie.approval.resolve", "curie.approval.resume",
     }
 operations = []
@@ -1068,32 +1087,21 @@ seed_ordinary_turn() {
             return 1
         }
     else
+        if [[ "$tier" == "cluster" ]]; then
+            echo "seed-invalid: cluster positive correlation must come from the external Slack ingress receipt" >&2
+            return 1
+        fi
         stream_start="$(capture_stream_cursor "$tier")" || return 1
-        if [[ "$tier" == "local" ]]; then
-            out="$("$BIN" --json local message --channel C0LOCALDEV "ordinary correlation $marker" || true)"
-        else
-            out="$("$BIN" --json cluster message --namespace "$CURIE_NAMESPACE" \
-                --release "$CURIE_RELEASE" "ordinary correlation $marker" || true)"
-        fi
+        out="$("$BIN" --json local message --channel C0LOCALDEV "ordinary correlation $marker" || true)"
         assert_finalized_reply "$tier ordinary correlation" "$out"
-        if [[ "$tier" == "local" ]]; then
-            assert_product_runner_endpoints
-        fi
+        assert_product_runner_endpoints
         stream_end="$(capture_stream_cursor "$tier")" || return 1
         [[ "$stream_end" != "$stream_start" ]] || {
             echo "seed-invalid: ordinary seed produced no bounded stream receipt" >&2
             return 1
         }
-        if [[ "$tier" == "cluster" ]]; then
-            capture_cluster_turn_template "$marker" "$stream_start" "$stream_end" || return 1
-            enqueue_cluster_carried_turn "$marker" "ordinary correlation $marker" || return 1
-            wait_cluster_carried_reply "$CLUSTER_SEEDED_REPLY_REF" || return 1
-            trace_id="$CLUSTER_SEEDED_TRACE_ID"
-            expected_operations="curie.queue.process,curie.turn.process,curie.sandbox.claim,curie.runner.rpc,agent.run,curie.reply.post|curie.reply.update"
-        else
-            trace_id="$(discover_trace_id_for_seed "$tier" "$marker" "$stream_start" "$stream_end")" || return 1
-            expected_operations="curie.queue.enqueue,curie.queue.process,curie.turn.process,curie.sandbox.claim,curie.runner.rpc,agent.run,curie.reply.post|curie.reply.update"
-        fi
+        trace_id="$(discover_trace_id_for_seed "$tier" "$marker" "$stream_start" "$stream_end")" || return 1
+        expected_operations="curie.queue.enqueue,curie.queue.process,curie.turn.process,curie.sandbox.claim,curie.runner.rpc,agent.run,curie.reply.post|curie.reply.update"
     fi
     query_exact_seed_trace "$tier" "$trace_id" "$expected_operations" "" "$query_state"
     LAST_ORDINARY_TRACE_ID="$trace_id"
@@ -1108,42 +1116,29 @@ seed_mcp_read_turn() {
         echo "seed-invalid: MCP read seed needs live mode, a deployed agent, and a marker before telemetry" >&2
         return 1
     fi
-    if [[ "$tier" == "local" ]]; then
-        local worker
-        worker="$(local_worker_container)"
-        release="$(container_env_value "$worker" CURIE_RELEASE)"
-        namespace="$(container_env_value "$worker" CURIE_NAMESPACE)"
-    else
-        release="$CURIE_RELEASE"
-        namespace="$CURIE_NAMESPACE"
+    if [[ "$tier" == "cluster" ]]; then
+        echo "seed-invalid: cluster MCP correlation must come from the external Slack ingress receipt" >&2
+        return 1
     fi
+    local worker
+    worker="$(local_worker_container)"
+    release="$(container_env_value "$worker" CURIE_RELEASE)"
+    namespace="$(container_env_value "$worker" CURIE_NAMESPACE)"
     alias="$(connector_object_name "$release" "$agent_name" "$MCP_RECEIPT_CONNECTOR").$namespace.svc.cluster.local"
     MCP_RECEIPT_ALIAS="$alias"
     before_count="$(mcp_receipt_call_count "$tier" "$alias")" || return 1
-    if [[ "$tier" == "local" ]]; then
-        stream_start="$(capture_stream_cursor "$tier")" || return 1
-        out="$("$BIN" --json local message --channel C0LOCALDEV \
-            "Call the receipt_read tool exactly once, then answer receipt complete. $marker" || true)"
-    else
-        enqueue_cluster_carried_turn "$marker" \
-            "Call the receipt_read tool exactly once, then answer receipt complete. $marker" || return 1
-        wait_cluster_carried_reply "$CLUSTER_SEEDED_REPLY_REF" || return 1
-    fi
-    if [[ "$tier" == "local" ]]; then
-        assert_finalized_reply "$tier MCP correlation" "$out"
-    fi
+    stream_start="$(capture_stream_cursor "$tier")" || return 1
+    out="$("$BIN" --json local message --channel C0LOCALDEV \
+        "Call the receipt_read tool exactly once, then answer receipt complete. $marker" || true)"
+    assert_finalized_reply "$tier MCP correlation" "$out"
     after_count="$(mcp_receipt_call_count "$tier" "$alias")" || return 1
     if (( after_count != before_count + 1 )); then
         echo "seed-invalid: MCP seed did not produce exactly one independent call receipt" >&2
         return 1
     fi
     echo "MCP receipt call count delta=1"
-    if [[ "$tier" == "local" ]]; then
-        stream_end="$(capture_stream_cursor "$tier")" || return 1
-        trace_id="$(discover_trace_id_for_seed "$tier" "$marker" "$stream_start" "$stream_end")" || return 1
-    else
-        trace_id="$CLUSTER_SEEDED_TRACE_ID"
-    fi
+    stream_end="$(capture_stream_cursor "$tier")" || return 1
+    trace_id="$(discover_trace_id_for_seed "$tier" "$marker" "$stream_start" "$stream_end")" || return 1
     query_exact_seed_trace "$tier" "$trace_id" "execute_tool" "" "$query_state"
     LAST_MCP_TRACE_ID="$trace_id"
     LAST_MCP_MEMBERSHIP="$LAST_QUERY_MEMBERSHIP"
@@ -1158,14 +1153,15 @@ seed_approval_resume_turn() {
         echo "seed-invalid: deterministic approval seed needs fake mode and a deployed agent before telemetry" >&2
         return 1
     fi
+    if [[ "$tier" == "cluster" ]]; then
+        echo "seed-invalid: cluster approval correlation must come from the external Slack ingress receipt" >&2
+        return 1
+    fi
     umask 077
     message_file="$(mktemp "$WORKDIR/approval-message.XXXXXX")"
     token_file="$(mktemp "$WORKDIR/approval-token.XXXXXX")"
     pending_file="$(mktemp "$WORKDIR/approval-pending.XXXXXX")"
     local scope=()
-    if [[ "$tier" == "cluster" ]]; then
-        scope=(--namespace "$CURIE_NAMESPACE" --release "$CURIE_RELEASE")
-    fi
     "$BIN" --json "$tier" approvals "$agent_id" "${scope[@]}" \
         --route-resolution e2e=C0EXAMPLE1 --route-approvers e2e=users:U0EXAMPLE1 \
         >/dev/null
@@ -1184,16 +1180,10 @@ PY
         return 1
     }
     rm -f "$token_file"
-    if [[ "$tier" == "local" ]]; then
-        stream_start="$(capture_stream_cursor "$tier")" || return 1
-        "$BIN" --json local message --channel C0LOCALDEV --timeout-secs 120 \
-            "[fake:request-approval:e2e] approve correlation $marker" > "$message_file" 2>/dev/null &
-        message_pid=$!
-    else
-        enqueue_cluster_carried_turn "$marker" \
-            "[fake:request-approval:e2e] approve correlation $marker" || return 1
-        trace_id="$CLUSTER_SEEDED_TRACE_ID"
-    fi
+    stream_start="$(capture_stream_cursor "$tier")" || return 1
+    "$BIN" --json local message --channel C0LOCALDEV --timeout-secs 120 \
+        "[fake:request-approval:e2e] approve correlation $marker" > "$message_file" 2>/dev/null &
+    message_pid=$!
     approval_id=""
     for attempt in $(seq 1 60); do
         if "$BIN" --json "$tier" approvals "$agent_id" "${scope[@]}" --list > "$pending_file" 2>/dev/null; then
@@ -1211,10 +1201,8 @@ PY
     done
     rm -f "$pending_file"
     if [[ -z "$approval_id" ]]; then
-        if [[ "$tier" == "local" ]]; then
-            kill "$message_pid" 2>/dev/null || true
-            wait "$message_pid" 2>/dev/null || true
-        fi
+        kill "$message_pid" 2>/dev/null || true
+        wait "$message_pid" 2>/dev/null || true
         rm -f "$message_file"
         echo "seed-invalid: awaiting-approval record did not become pending" >&2
         return 1
@@ -1222,21 +1210,16 @@ PY
     CURIE_APPROVAL_PRINCIPAL_TOKEN="$token" "$BIN" --json "$tier" approvals "$agent_id" \
         "${scope[@]}" --resolve "$approval_id" >/dev/null
     unset token
-    if [[ "$tier" == "local" ]]; then
-        wait "$message_pid" || code=$?
-        out="$(cat "$message_file")"
-        rm -f "$message_file"
-        if (( code != 0 )); then
-            echo "seed-invalid: approval resolution did not resume to a final reply" >&2
-            return 1
-        fi
-        assert_finalized_reply "$tier approval resume" "$out"
-        stream_end="$(capture_stream_cursor "$tier")" || return 1
-        trace_id="$(discover_trace_id_for_seed "$tier" "$marker" "$stream_start" "$stream_end")" || return 1
-    else
-        rm -f "$message_file"
-        wait_cluster_carried_reply "$CLUSTER_SEEDED_REPLY_REF" || return 1
+    wait "$message_pid" || code=$?
+    out="$(cat "$message_file")"
+    rm -f "$message_file"
+    if (( code != 0 )); then
+        echo "seed-invalid: approval resolution did not resume to a final reply" >&2
+        return 1
     fi
+    assert_finalized_reply "$tier approval resume" "$out"
+    stream_end="$(capture_stream_cursor "$tier")" || return 1
+    trace_id="$(discover_trace_id_for_seed "$tier" "$marker" "$stream_start" "$stream_end")" || return 1
     query_exact_seed_trace "$tier" "$trace_id" \
         "curie.approval.suspend,curie.approval.resolve,curie.approval.resume,curie.reply.post|curie.reply.update" \
         "approved" "$query_state"
@@ -4023,7 +4006,7 @@ print(accepted_after - accepted_before, sent_after - sent_before)
 PY
     )
     write_product_observability_evidence "$LOCAL_PRODUCT_EVIDENCE" local \
-        "$product_accepted_delta" "$product_sent_delta" "$product_membership" not-applicable
+        "$product_accepted_delta" "$product_sent_delta" "$product_membership" not-applicable false
 
     if [[ -z "${STUB_STATE:-}" && "$LAST_ORDINARY_MEMBERSHIP" == "true" ]] && (( LOCAL_STACK_OWNED )); then
         case_local_langfuse_invalid_auth "$agent_id"
@@ -4390,18 +4373,24 @@ print(total)
 
 write_product_observability_evidence() {
     local destination="$1" surface="$2" accepted_delta="$3" sent_delta="$4" membership="$5" image_match="$6"
-    python3 - "$destination" "$surface" "$accepted_delta" "$sent_delta" "$membership" "$image_match" <<'PY'
+    local same_id_raw_receipt="$7"
+    python3 - "$destination" "$surface" "$accepted_delta" "$sent_delta" "$membership" "$image_match" \
+        "$same_id_raw_receipt" "$PRODUCT_OBSERVABILITY_RUN_ID" <<'PY'
 import json, pathlib, sys
-destination, surface, accepted_raw, sent_raw, membership_raw, image_raw = sys.argv[1:7]
+destination, surface, accepted_raw, sent_raw, membership_raw, image_raw, same_id_raw, run_id = sys.argv[1:9]
 accepted = float(accepted_raw)
 sent = float(sent_raw)
 if membership_raw not in {"true", "false"}:
     raise SystemExit("exact Langfuse membership was not observed")
 if image_raw not in {"true", "false", "not-applicable"}:
     raise SystemExit("image identity verdict was not observed")
+if same_id_raw not in {"true", "false"}:
+    raise SystemExit("same-ID raw Collector receipt verdict was not observed")
 record = {
+    "run_id": run_id,
     "surface": surface,
     "seed_valid": accepted > 0 and sent > 0,
+    "same_id_raw_collector_receipt": same_id_raw == "true",
     "raw_emitted_observations": accepted,
     "otelcol_receiver_accepted_spans": accepted,
     "otelcol_exporter_sent_spans": sent,
@@ -4415,34 +4404,42 @@ PY
 }
 
 run_cluster_product_observability() {
-    local agent_id="$1" agent_name="$2" accepted_before sent_before accepted_after sent_after
-    local accepted_delta sent_delta membership
+    local agent_id="$1" agent_name="$2" membership accepted_delta sent_delta
     preflight_cluster_product_observability
-    accepted_before="$(cluster_collector_metric_value otelcol_receiver_accepted_spans)"
-    sent_before="$(cluster_collector_metric_value otelcol_exporter_sent_spans)"
-    seed_ordinary_turn cluster "$agent_id" observe
-    membership="$LAST_ORDINARY_MEMBERSHIP"
+    seed_cluster_missing_carrier_control
+    cluster_external_ingress_seed ordinary \
+        "curie.turn.ingress,curie.queue.enqueue,curie.queue.process,curie.turn.process,curie.sandbox.claim,curie.runner.rpc,agent.run,curie.reply.post|curie.reply.update"
+    membership="$LAST_QUERY_MEMBERSHIP"
+    accepted_delta="$LAST_EXTERNAL_ACCEPTED_DELTA"
+    sent_delta="$LAST_EXTERNAL_SENT_DELTA"
     if [[ "$LIVE" == "0" ]]; then
-        seed_approval_resume_turn cluster "$agent_id" observe
-        [[ "$LAST_APPROVAL_MEMBERSHIP" == "true" ]] || membership="false"
+        cluster_external_ingress_seed approval \
+            "curie.turn.ingress,curie.queue.enqueue,curie.approval.suspend,curie.approval.resolve,curie.approval.resume,curie.reply.post|curie.reply.update" \
+            approved
+        [[ "$LAST_QUERY_MEMBERSHIP" == "true" ]] || membership="false"
     else
-        seed_mcp_read_turn cluster "$agent_id" "$agent_name" observe
-        [[ "$LAST_MCP_MEMBERSHIP" == "true" ]] || membership="false"
+        cluster_external_ingress_seed mcp \
+            "curie.turn.ingress,curie.queue.enqueue,execute_tool,curie.reply.post|curie.reply.update"
+        [[ "$LAST_QUERY_MEMBERSHIP" == "true" ]] || membership="false"
     fi
-    # Each seed helper performs the exact candidate read equivalent to:
-    # curie --json cluster observability run "$trace_id"
-    accepted_after="$(cluster_collector_metric_value otelcol_receiver_accepted_spans)"
-    sent_after="$(cluster_collector_metric_value otelcol_exporter_sent_spans)"
     read -r accepted_delta sent_delta < <(python3 - \
-        "$accepted_after" "$accepted_before" "$sent_after" "$sent_before" <<'PY'
+        "$accepted_delta" "$LAST_EXTERNAL_ACCEPTED_DELTA" \
+        "$sent_delta" "$LAST_EXTERNAL_SENT_DELTA" <<'PY'
 import sys
-accepted_after, accepted_before, sent_after, sent_before = map(float, sys.argv[1:5])
-print(accepted_after - accepted_before, sent_after - sent_before)
+accepted_first, accepted_second, sent_first, sent_second = map(float, sys.argv[1:5])
+print(accepted_first + accepted_second, sent_first + sent_second)
 PY
     )
+    # Each external seed performs the exact candidate read equivalent to
+    # `curie --json cluster observability run <derived-trace-id>`.
+    # Exact Langfuse reads above are valid external-ingress evidence, but the
+    # shipped Collector exposes only aggregate counters. It has no supported
+    # same-trace raw-receipt read. Record that fact explicitly: exact membership
+    # can still clear end-to-end ingest, while missing membership cannot blame
+    # the adopted backend without the stronger raw receipt.
     write_product_observability_evidence "$CLUSTER_PRODUCT_EVIDENCE" cluster \
-        "$accepted_delta" "$sent_delta" "$membership" "$CLUSTER_IMAGE_IDS_MATCH"
-    echo "cluster product observability: Collector deltas and exact-ID membership recorded"
+        "$accepted_delta" "$sent_delta" "$membership" "$CLUSTER_IMAGE_IDS_MATCH" false
+    echo "cluster product observability: exact ingest membership and observed Collector deltas recorded"
 }
 
 classify_product_observability_owner() {
@@ -4455,8 +4452,43 @@ for surface, raw_path in zip(("local", "cluster"), sys.argv[1:]):
     path = pathlib.Path(raw_path)
     if not path.is_file():
         print("curie-unresolved: both product surfaces have not been exercised")
-        raise SystemExit(0)
-    records[surface] = json.loads(path.read_text())
+        raise SystemExit(1)
+    try:
+        records[surface] = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        print(f"curie-unresolved: {surface} evidence is unreadable")
+        raise SystemExit(1)
+
+required_fields = (
+    "run_id", "surface", "seed_valid", "same_id_raw_collector_receipt",
+    "raw_emitted_observations", "otelcol_receiver_accepted_spans",
+    "otelcol_exporter_sent_spans", "langfuse_observation_membership",
+    "image_ids_match",
+)
+for surface, record in records.items():
+    numeric = (
+        record.get("raw_emitted_observations"),
+        record.get("otelcol_receiver_accepted_spans"),
+        record.get("otelcol_exporter_sent_spans"),
+    )
+    if (
+        not all(field in record for field in required_fields)
+        or record.get("surface") != surface
+        or not isinstance(record.get("run_id"), str)
+        or not all(isinstance(record.get(field), bool) for field in (
+            "seed_valid", "same_id_raw_collector_receipt",
+            "langfuse_observation_membership",
+        ))
+        or not all(isinstance(item, (int, float)) and not isinstance(item, bool) for item in numeric)
+        or record.get("image_ids_match") not in {True, False, None}
+    ):
+        print(f"curie-unresolved: {surface} evidence is incomplete or malformed")
+        raise SystemExit(1)
+
+run_ids = {record.get("run_id") for record in records.values()}
+if len(run_ids) != 1 or not next(iter(run_ids), None):
+    print("curie-unresolved: product evidence did not come from one supported run")
+    raise SystemExit(1)
 
 # These names deliberately mirror the evidence record. Ownership cannot be
 # assigned away from Curie until both product surfaces clear every prerequisite.
@@ -4475,18 +4507,28 @@ for surface in ("local", "cluster"):
         and seed_valid
     ):
         print("curie-owned: raw export, delivery, image identity, or seed precondition failed")
-        raise SystemExit(0)
+        raise SystemExit(1)
 
 memberships = dict(
     (surface, records[surface].get("langfuse_observation_membership") is True)
     for surface in ("local", "cluster")
 )
-if not memberships["local"] and not memberships["cluster"]:
-    print("adopted-component: Langfuse omitted observations after successful local and cluster raw export")
-elif not all(memberships.values()):
-    print("curie-owned: local and cluster exact Langfuse membership disagreed")
-else:
+same_id_raw_receipts = dict(
+    (surface, records[surface].get("same_id_raw_collector_receipt") is True)
+    for surface in ("local", "cluster")
+)
+if memberships["local"] and memberships["cluster"]:
     print("curie-clear: Langfuse exact observation membership passed on local and cluster")
+    raise SystemExit(0)
+elif memberships["local"] != memberships["cluster"]:
+    print("curie-owned: local and cluster exact Langfuse membership disagreed")
+    raise SystemExit(1)
+elif same_id_raw_receipts["local"] and same_id_raw_receipts["cluster"]:
+    print("adopted-component: Langfuse omitted observations after successful local and cluster raw export")
+    raise SystemExit(1)
+else:
+    print("curie-unresolved: missing Langfuse membership without same-ID raw Collector receipts")
+    raise SystemExit(1)
 PY
 }
 

--- a/cli/scripts/fixtures/mcp-receipt/Dockerfile
+++ b/cli/scripts/fixtures/mcp-receipt/Dockerfile
@@ -3,5 +3,7 @@ FROM python:3.12-slim
 WORKDIR /srv
 COPY server.py /srv/server.py
 USER 65534:65534
+# The hosted connector's network boundary restricts peers. The fixture itself
+# has no credential surface and its stdout receipt is evidence, not authority.
 EXPOSE 8000
 ENTRYPOINT ["python", "-u", "/srv/server.py"]

--- a/cli/scripts/fixtures/mcp-receipt/Dockerfile
+++ b/cli/scripts/fixtures/mcp-receipt/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.12-slim
+
+WORKDIR /srv
+COPY server.py /srv/server.py
+USER 65534:65534
+EXPOSE 8000
+ENTRYPOINT ["python", "-u", "/srv/server.py"]

--- a/cli/scripts/fixtures/mcp-receipt/server.py
+++ b/cli/scripts/fixtures/mcp-receipt/server.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Deterministic read-only MCP server used by the correlation ladder.
+
+The only durable receipt is a countable marker. Request bodies, tool arguments,
+session identifiers, and headers are deliberately never written to stdout.
+"""
+
+from __future__ import annotations
+
+import json
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+
+
+TOOL = {
+    "name": "receipt_read",
+    "description": "Return a deterministic, non-sensitive read receipt.",
+    "inputSchema": {"type": "object", "properties": {}, "additionalProperties": False},
+}
+
+
+def response_for(message: dict[str, Any]) -> dict[str, Any] | None:
+    request_id = message.get("id")
+    method = message.get("method")
+    if request_id is None:
+        return None
+    if method == "initialize":
+        requested = message.get("params", {}).get("protocolVersion")
+        return {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": {
+                "protocolVersion": requested or "2025-03-26",
+                "capabilities": {"tools": {"listChanged": False}},
+                "serverInfo": {"name": "curie-mcp-receipt", "version": "1"},
+            },
+        }
+    if method == "tools/list":
+        return {"jsonrpc": "2.0", "id": request_id, "result": {"tools": [TOOL]}}
+    if method == "tools/call":
+        params = message.get("params")
+        if not isinstance(params, dict) or params.get("name") != TOOL["name"]:
+            return {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "error": {"code": -32602, "message": "unknown read-only tool"},
+            }
+        print("MCP_RECEIPT tools/call", flush=True)
+        return {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": {
+                "content": [{"type": "text", "text": "receipt-ok"}],
+                "structuredContent": {"receipt": "ok"},
+                "isError": False,
+            },
+        }
+    return {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "error": {"code": -32601, "message": "method not found"},
+    }
+
+
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, _format: str, *args: object) -> None:
+        # The base implementation includes the request target and client IP.
+        return
+
+    def do_GET(self) -> None:  # noqa: N802 - stdlib handler API
+        self.send_error(HTTPStatus.METHOD_NOT_ALLOWED)
+
+    def do_POST(self) -> None:  # noqa: N802 - stdlib handler API
+        if self.path != "/mcp":
+            self.send_error(HTTPStatus.NOT_FOUND)
+            return
+        try:
+            length = int(self.headers.get("Content-Length", "0"))
+            if length <= 0 or length > 1_048_576:
+                raise ValueError("invalid request size")
+            decoded = json.loads(self.rfile.read(length))
+            messages = decoded if isinstance(decoded, list) else [decoded]
+            if not messages or not all(isinstance(item, dict) for item in messages):
+                raise ValueError("request is not a JSON-RPC object")
+            replies = [reply for item in messages if (reply := response_for(item)) is not None]
+        except (json.JSONDecodeError, TypeError, ValueError):
+            body = json.dumps(
+                {"jsonrpc": "2.0", "id": None, "error": {"code": -32700, "message": "invalid request"}},
+                separators=(",", ":"),
+            ).encode()
+            self.send_response(HTTPStatus.BAD_REQUEST)
+        else:
+            if not replies:
+                self.send_response(HTTPStatus.ACCEPTED)
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+                return
+            payload: object = replies if isinstance(decoded, list) else replies[0]
+            body = json.dumps(payload, separators=(",", ":")).encode()
+            self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+if __name__ == "__main__":
+    ThreadingHTTPServer(("0.0.0.0", 8000), Handler).serve_forever()

--- a/cli/scripts/fixtures/mcp-receipt/server.py
+++ b/cli/scripts/fixtures/mcp-receipt/server.py
@@ -1,50 +1,129 @@
 #!/usr/bin/env python3
 """Deterministic read-only MCP server used by the correlation ladder.
 
+This fixture deliberately uses only the Python standard library so its image
+does not acquire an independent MCP dependency. It implements the stateful
+Streamable HTTP handshake used by the runner: initialize, the initialized
+notification, a session-scoped SSE GET, tools/list, tools/call, and DELETE.
+
 The only durable receipt is a countable marker. Request bodies, tool arguments,
 session identifiers, and headers are deliberately never written to stdout.
+Reachability is restricted by the hosted connector's network boundary; the
+receipt marker is evidence of a call, not an authentication mechanism.
 """
 
 from __future__ import annotations
 
 import json
+import secrets
+import threading
+from dataclasses import dataclass, field
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
+
+MAX_REQUEST_BYTES = 1_048_576
+RUNNER_PROTOCOL_VERSION = "2025-03-26"
+SUPPORTED_PROTOCOL_VERSIONS = frozenset(
+    {
+        "2024-11-05",
+        RUNNER_PROTOCOL_VERSION,
+        "2025-06-18",
+        "2025-11-25",
+    }
+)
+DEFAULT_PROTOCOL_VERSION = "2025-11-25"
+SESSION_HEADER = "Mcp-Session-Id"
+PROTOCOL_HEADER = "MCP-Protocol-Version"
 
 TOOL = {
     "name": "receipt_read",
     "description": "Return a deterministic, non-sensitive read receipt.",
     "inputSchema": {"type": "object", "properties": {}, "additionalProperties": False},
+    "annotations": {
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": False,
+    },
 }
 
 
-def response_for(message: dict[str, Any]) -> dict[str, Any] | None:
-    request_id = message.get("id")
-    method = message.get("method")
-    if request_id is None:
+@dataclass
+class Session:
+    protocol_version: str
+    initialized: bool = False
+    terminated: threading.Event = field(default_factory=threading.Event)
+
+
+_sessions: dict[str, Session] = {}
+_sessions_lock = threading.RLock()
+
+
+def _jsonrpc_error(
+    request_id: str | int | None, code: int, message: str
+) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "error": {"code": code, "message": message},
+    }
+
+
+def _new_session(protocol_version: str) -> tuple[str, Session]:
+    session_id = secrets.token_urlsafe(24)
+    session = Session(protocol_version=protocol_version)
+    with _sessions_lock:
+        _sessions[session_id] = session
+    return session_id, session
+
+
+def _get_session(session_id: str | None) -> Session | None:
+    if not session_id:
         return None
-    if method == "initialize":
-        requested = message.get("params", {}).get("protocolVersion")
-        return {
-            "jsonrpc": "2.0",
-            "id": request_id,
-            "result": {
-                "protocolVersion": requested or "2025-03-26",
-                "capabilities": {"tools": {"listChanged": False}},
-                "serverInfo": {"name": "curie-mcp-receipt", "version": "1"},
-            },
-        }
+    with _sessions_lock:
+        return _sessions.get(session_id)
+
+
+def _terminate_session(session_id: str) -> bool:
+    with _sessions_lock:
+        session = _sessions.pop(session_id, None)
+    if session is None:
+        return False
+    session.terminated.set()
+    return True
+
+
+def response_for(message: dict[str, Any], session: Session) -> dict[str, Any] | None:
+    """Return one JSON-RPC response, or ``None`` for a notification."""
+
+    method = message.get("method")
+    if method == "notifications/initialized" and "id" not in message:
+        session.initialized = True
+        return None
+
+    if "id" not in message or message.get("id") is None:
+        # Notifications other than initialized are accepted without a response.
+        return None
+
+    request_id = message["id"]
+    if not isinstance(request_id, str | int) or isinstance(request_id, bool):
+        return _jsonrpc_error(None, -32600, "invalid request id")
+    if not session.initialized:
+        return _jsonrpc_error(request_id, -32002, "session is not initialized")
+    if method == "ping":
+        return {"jsonrpc": "2.0", "id": request_id, "result": {}}
     if method == "tools/list":
         return {"jsonrpc": "2.0", "id": request_id, "result": {"tools": [TOOL]}}
     if method == "tools/call":
         params = message.get("params")
-        if not isinstance(params, dict) or params.get("name") != TOOL["name"]:
-            return {
-                "jsonrpc": "2.0",
-                "id": request_id,
-                "error": {"code": -32602, "message": "unknown read-only tool"},
-            }
+        arguments = params.get("arguments", {}) if isinstance(params, dict) else None
+        if (
+            not isinstance(params, dict)
+            or params.get("name") != TOOL["name"]
+            or arguments not in ({}, None)
+        ):
+            return _jsonrpc_error(request_id, -32602, "unknown or invalid read-only tool")
         print("MCP_RECEIPT tools/call", flush=True)
         return {
             "jsonrpc": "2.0",
@@ -55,11 +134,7 @@ def response_for(message: dict[str, Any]) -> dict[str, Any] | None:
                 "isError": False,
             },
         }
-    return {
-        "jsonrpc": "2.0",
-        "id": request_id,
-        "error": {"code": -32601, "message": "method not found"},
-    }
+    return _jsonrpc_error(request_id, -32601, "method not found")
 
 
 class Handler(BaseHTTPRequestHandler):
@@ -69,46 +144,200 @@ class Handler(BaseHTTPRequestHandler):
         # The base implementation includes the request target and client IP.
         return
 
+    def _send_json(
+        self,
+        status: HTTPStatus,
+        payload: dict[str, Any] | list[dict[str, Any]],
+        *,
+        session_id: str | None = None,
+    ) -> None:
+        body = json.dumps(payload, separators=(",", ":")).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        if session_id is not None:
+            self.send_header(SESSION_HEADER, session_id)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _send_empty(
+        self, status: HTTPStatus, *, session_id: str | None = None
+    ) -> None:
+        self.send_response(status)
+        if session_id is not None:
+            self.send_header(SESSION_HEADER, session_id)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def _require_path(self) -> bool:
+        if self.path == "/mcp":
+            return True
+        self._send_json(
+            HTTPStatus.NOT_FOUND,
+            _jsonrpc_error(None, -32601, "MCP endpoint not found"),
+        )
+        return False
+
+    def _accepts(self, content_type: str) -> bool:
+        accept = self.headers.get("Accept", "")
+        return "*/*" in accept or content_type in accept
+
+    def _require_session(self) -> tuple[str, Session] | None:
+        session_id = self.headers.get(SESSION_HEADER)
+        session = _get_session(session_id)
+        if session_id is None:
+            self._send_json(
+                HTTPStatus.BAD_REQUEST,
+                _jsonrpc_error(None, -32600, "missing MCP session"),
+            )
+            return None
+        if session is None:
+            self._send_json(
+                HTTPStatus.NOT_FOUND,
+                _jsonrpc_error(None, -32600, "unknown MCP session"),
+            )
+            return None
+        requested_version = self.headers.get(PROTOCOL_HEADER)
+        if requested_version != session.protocol_version:
+            self._send_json(
+                HTTPStatus.BAD_REQUEST,
+                _jsonrpc_error(None, -32600, "invalid MCP protocol version"),
+                session_id=session_id,
+            )
+            return None
+        return session_id, session
+
     def do_GET(self) -> None:  # noqa: N802 - stdlib handler API
-        self.send_error(HTTPStatus.METHOD_NOT_ALLOWED)
+        if not self._require_path():
+            return
+        if not self._accepts("text/event-stream"):
+            self._send_json(
+                HTTPStatus.NOT_ACCEPTABLE,
+                _jsonrpc_error(None, -32600, "SSE response is not accepted"),
+            )
+            return
+        required = self._require_session()
+        if required is None:
+            return
+        session_id, session = required
+
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache, no-transform")
+        self.send_header("Connection", "keep-alive")
+        self.send_header(SESSION_HEADER, session_id)
+        self.end_headers()
+        try:
+            # A comment commits the response as SSE without fabricating a JSON-RPC
+            # notification. There are no server-initiated messages in this fixture.
+            self.wfile.write(b": receipt stream\n\n")
+            self.wfile.flush()
+            while not session.terminated.wait(timeout=10):
+                self.wfile.write(b": keep-alive\n\n")
+                self.wfile.flush()
+        except (BrokenPipeError, ConnectionResetError):
+            return
+        finally:
+            self.close_connection = True
 
     def do_POST(self) -> None:  # noqa: N802 - stdlib handler API
-        if self.path != "/mcp":
-            self.send_error(HTTPStatus.NOT_FOUND)
+        if not self._require_path():
             return
+        if not self._accepts("application/json") or not self._accepts(
+            "text/event-stream"
+        ):
+            self._send_json(
+                HTTPStatus.NOT_ACCEPTABLE,
+                _jsonrpc_error(None, -32600, "MCP response types are not accepted"),
+            )
+            return
+        if (
+            self.headers.get("Content-Type", "").split(";", 1)[0].strip()
+            != "application/json"
+        ):
+            self._send_json(
+                HTTPStatus.UNSUPPORTED_MEDIA_TYPE,
+                _jsonrpc_error(None, -32600, "expected application/json"),
+            )
+            return
+
         try:
             length = int(self.headers.get("Content-Length", "0"))
-            if length <= 0 or length > 1_048_576:
+            if length <= 0 or length > MAX_REQUEST_BYTES:
                 raise ValueError("invalid request size")
             decoded = json.loads(self.rfile.read(length))
             messages = decoded if isinstance(decoded, list) else [decoded]
             if not messages or not all(isinstance(item, dict) for item in messages):
                 raise ValueError("request is not a JSON-RPC object")
-            replies = [reply for item in messages if (reply := response_for(item)) is not None]
         except (json.JSONDecodeError, TypeError, ValueError):
-            body = json.dumps(
+            self._send_json(
+                HTTPStatus.BAD_REQUEST,
+                _jsonrpc_error(None, -32700, "invalid request"),
+            )
+            return
+
+        initialize = len(messages) == 1 and messages[0].get("method") == "initialize"
+        if initialize:
+            message = messages[0]
+            request_id = message.get("id")
+            params = message.get("params")
+            requested = params.get("protocolVersion") if isinstance(params, dict) else None
+            if request_id is None or not isinstance(requested, str):
+                self._send_json(
+                    HTTPStatus.BAD_REQUEST,
+                    _jsonrpc_error(request_id, -32602, "invalid initialize request"),
+                )
+                return
+            negotiated = (
+                requested
+                if requested in SUPPORTED_PROTOCOL_VERSIONS
+                else DEFAULT_PROTOCOL_VERSION
+            )
+            session_id, _session = _new_session(negotiated)
+            self._send_json(
+                HTTPStatus.OK,
                 {
                     "jsonrpc": "2.0",
-                    "id": None,
-                    "error": {"code": -32700, "message": "invalid request"},
+                    "id": request_id,
+                    "result": {
+                        "protocolVersion": negotiated,
+                        "capabilities": {"tools": {"listChanged": False}},
+                        "serverInfo": {"name": "curie-mcp-receipt", "version": "1"},
+                    },
                 },
-                separators=(",", ":"),
-            ).encode()
-            self.send_response(HTTPStatus.BAD_REQUEST)
-        else:
-            if not replies:
-                self.send_response(HTTPStatus.ACCEPTED)
-                self.send_header("Content-Length", "0")
-                self.end_headers()
-                return
-            payload: object = replies if isinstance(decoded, list) else replies[0]
-            body = json.dumps(payload, separators=(",", ":")).encode()
-            self.send_response(HTTPStatus.OK)
-        self.send_header("Content-Type", "application/json")
-        self.send_header("Content-Length", str(len(body)))
-        self.end_headers()
-        self.wfile.write(body)
+                session_id=session_id,
+            )
+            return
+
+        required = self._require_session()
+        if required is None:
+            return
+        session_id, session = required
+        replies = [
+            reply
+            for item in messages
+            if (reply := response_for(item, session)) is not None
+        ]
+        if not replies:
+            self._send_empty(HTTPStatus.ACCEPTED, session_id=session_id)
+            return
+        payload: dict[str, Any] | list[dict[str, Any]] = (
+            replies if isinstance(decoded, list) else replies[0]
+        )
+        self._send_json(HTTPStatus.OK, payload, session_id=session_id)
+
+    def do_DELETE(self) -> None:  # noqa: N802 - stdlib handler API
+        if not self._require_path():
+            return
+        required = self._require_session()
+        if required is None:
+            return
+        session_id, _session = required
+        _terminate_session(session_id)
+        self._send_empty(HTTPStatus.NO_CONTENT)
 
 
 if __name__ == "__main__":
+    # Hosted connector NetworkPolicy is the isolation boundary, so the process
+    # must listen on the pod/container interface rather than loopback.
     ThreadingHTTPServer(("0.0.0.0", 8000), Handler).serve_forever()

--- a/cli/scripts/fixtures/mcp-receipt/server.py
+++ b/cli/scripts/fixtures/mcp-receipt/server.py
@@ -12,7 +12,6 @@ from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
 
-
 TOOL = {
     "name": "receipt_read",
     "description": "Return a deterministic, non-sensitive read receipt.",
@@ -88,7 +87,11 @@ class Handler(BaseHTTPRequestHandler):
             replies = [reply for item in messages if (reply := response_for(item)) is not None]
         except (json.JSONDecodeError, TypeError, ValueError):
             body = json.dumps(
-                {"jsonrpc": "2.0", "id": None, "error": {"code": -32700, "message": "invalid request"}},
+                {
+                    "jsonrpc": "2.0",
+                    "id": None,
+                    "error": {"code": -32700, "message": "invalid request"},
+                },
                 separators=(",", ":"),
             ).encode()
             self.send_response(HTTPStatus.BAD_REQUEST)

--- a/cli/src/chat.rs
+++ b/cli/src/chat.rs
@@ -179,11 +179,11 @@ pub fn extract_fields(
 
 /// Extract a validated durable approval id from a structured approval card.
 ///
-/// The worker puts the same UUID in the card's `client_msg_id` and each action's
-/// `value`. A caller-supplied `client_msg_id` alone is not authoritative: the
-/// payload must also contain an action whose id starts with
-/// [`APPROVE_ACTION_ID_PREFIX`]. This keeps ordinary Slack posts (and arbitrary
-/// text mentioning the prefix) from being mistaken for approval control data.
+/// The worker puts the same UUID in the card's `client_msg_id` and approval
+/// action `value`. Neither copy is authoritative alone: both must be valid UUIDs
+/// and equal, and the action id must start with [`APPROVE_ACTION_ID_PREFIX`].
+/// This keeps incomplete, inconsistent, or ordinary Slack posts from being
+/// mistaken for approval control data.
 pub fn approval_card_id(content_type: &str, body: &str) -> Option<String> {
     fn valid_uuid(value: &str) -> Option<String> {
         uuid::Uuid::parse_str(value).ok().map(|_| value.to_string())
@@ -253,10 +253,11 @@ pub fn approval_card_id(content_type: &str, body: &str) -> Option<String> {
         (seen, action_id, client_msg_id)
     };
 
-    if card_seen {
-        action_id.or(client_msg_id)
-    } else {
-        None
+    match (card_seen, action_id, client_msg_id) {
+        (true, Some(action_id), Some(client_msg_id)) if action_id == client_msg_id => {
+            Some(action_id)
+        }
+        _ => None,
     }
 }
 
@@ -797,12 +798,13 @@ mod tests {
     }
 
     #[test]
-    fn approval_card_id_survives_card_before_notice_ordering() {
+    fn approval_card_id_requires_equal_structured_uuid_copies() {
         let id = "00000000-0000-4000-8000-000000000220";
         let body = format!(
             r#"{{"channel":"C0EXAMPLE1","client_msg_id":"{id}","blocks":[{{"type":"actions","elements":[{{"type":"button","action_id":"{APPROVE_ACTION_ID_PREFIX}","value":"{id}"}}]}}]}}"#
         );
         let captured = approval_card_id("application/json", &body);
+        assert_eq!(captured.as_deref(), Some(id));
 
         // The card can win the Slack-call race while the latest placeholder is
         // still ordinary text. Preserve that text for output, but carry the
@@ -834,6 +836,30 @@ mod tests {
         match completed_turn_outcome(None, true, approval_card_id("application/json", &malformed)) {
             Outcome::AwaitingApproval { approval_id, .. } => assert_eq!(approval_id, None),
             outcome => panic!("malformed card lost its awaiting status: {outcome:?}"),
+        }
+    }
+
+    #[test]
+    fn approval_card_id_rejects_mismatched_or_missing_uuid_copies() {
+        let client_id = "00000000-0000-4000-8000-000000000220";
+        let action_id = "00000000-0000-4000-8000-000000000221";
+        let mismatched = format!(
+            r#"{{"client_msg_id":"{client_id}","blocks":[{{"type":"actions","elements":[{{"type":"button","action_id":"{APPROVE_ACTION_ID_PREFIX}","value":"{action_id}"}}]}}]}}"#
+        );
+        let missing_client = format!(
+            r#"{{"blocks":[{{"type":"actions","elements":[{{"type":"button","action_id":"{APPROVE_ACTION_ID_PREFIX}","value":"{action_id}"}}]}}]}}"#
+        );
+        let missing_action_value = format!(
+            r#"{{"client_msg_id":"{client_id}","blocks":[{{"type":"actions","elements":[{{"type":"button","action_id":"{APPROVE_ACTION_ID_PREFIX}"}}]}}]}}"#
+        );
+
+        for body in [&mismatched, &missing_client, &missing_action_value] {
+            assert!(body.contains(APPROVE_ACTION_ID_PREFIX));
+            assert_eq!(approval_card_id("application/json", body), None);
+            match completed_turn_outcome(None, true, approval_card_id("application/json", body)) {
+                Outcome::AwaitingApproval { approval_id, .. } => assert_eq!(approval_id, None),
+                outcome => panic!("untrusted card lost its awaiting status: {outcome:?}"),
+            }
         }
     }
 

--- a/cli/src/chat.rs
+++ b/cli/src/chat.rs
@@ -116,6 +116,10 @@ pub struct SlackCall {
     /// True when the raw body carried the approval card's Approve action id, i.e.
     /// the worker parked this turn awaiting approval and posted a card (#529).
     pub approval_card: bool,
+    /// The durable approval UUID carried by that card, when its structured
+    /// payload contains a valid id. This is independent of placeholder edit
+    /// ordering, so a card that arrives before its notice can still be resumed.
+    pub approval_id: Option<String>,
 }
 
 /// If this call is a `chat.update` editing `placeholder_ts`, its new text.
@@ -171,6 +175,89 @@ pub fn extract_fields(
             .map(|(_, v)| v.clone())
     };
     (find("channel"), find("ts"), find("text"))
+}
+
+/// Extract a validated durable approval id from a structured approval card.
+///
+/// The worker puts the same UUID in the card's `client_msg_id` and each action's
+/// `value`. A caller-supplied `client_msg_id` alone is not authoritative: the
+/// payload must also contain an action whose id starts with
+/// [`APPROVE_ACTION_ID_PREFIX`]. This keeps ordinary Slack posts (and arbitrary
+/// text mentioning the prefix) from being mistaken for approval control data.
+pub fn approval_card_id(content_type: &str, body: &str) -> Option<String> {
+    fn valid_uuid(value: &str) -> Option<String> {
+        uuid::Uuid::parse_str(value).ok().map(|_| value.to_string())
+    }
+
+    fn approval_action(value: &serde_json::Value) -> (bool, Option<String>) {
+        match value {
+            serde_json::Value::Array(values) => {
+                let mut seen = false;
+                for value in values {
+                    let (nested_seen, id) = approval_action(value);
+                    seen |= nested_seen;
+                    if id.is_some() {
+                        return (true, id);
+                    }
+                }
+                (seen, None)
+            }
+            serde_json::Value::Object(fields) => {
+                let is_approve = fields
+                    .get("action_id")
+                    .and_then(serde_json::Value::as_str)
+                    .is_some_and(|id| id.starts_with(APPROVE_ACTION_ID_PREFIX));
+                if is_approve {
+                    let id = fields
+                        .get("value")
+                        .and_then(serde_json::Value::as_str)
+                        .and_then(valid_uuid);
+                    return (true, id);
+                }
+                let mut seen = false;
+                for value in fields.values() {
+                    let (nested_seen, id) = approval_action(value);
+                    seen |= nested_seen;
+                    if id.is_some() {
+                        return (true, id);
+                    }
+                }
+                (seen, None)
+            }
+            _ => (false, None),
+        }
+    }
+
+    let (card_seen, action_id, client_msg_id) = if content_type.contains("application/json") {
+        let root = serde_json::from_str::<serde_json::Value>(body).ok()?;
+        let (seen, action_id) = approval_action(&root);
+        let client_msg_id = root
+            .get("client_msg_id")
+            .and_then(serde_json::Value::as_str)
+            .and_then(valid_uuid);
+        (seen, action_id, client_msg_id)
+    } else {
+        let pairs: Vec<(String, String)> = serde_urlencoded::from_str(body).unwrap_or_default();
+        let blocks = pairs
+            .iter()
+            .find(|(key, _)| key == "blocks")
+            .and_then(|(_, value)| serde_json::from_str::<serde_json::Value>(value).ok());
+        let (seen, action_id) = blocks
+            .as_ref()
+            .map(approval_action)
+            .unwrap_or((false, None));
+        let client_msg_id = pairs
+            .iter()
+            .find(|(key, _)| key == "client_msg_id")
+            .and_then(|(_, value)| valid_uuid(value));
+        (seen, action_id, client_msg_id)
+    };
+
+    if card_seen {
+        action_id.or(client_msg_id)
+    } else {
+        None
+    }
 }
 
 #[derive(Clone)]
@@ -269,6 +356,7 @@ async fn handle_call(
     // which `extract_fields` does not parse -- match it on the raw body so an
     // awaiting-approval turn is detectable regardless of encoding (#529).
     let approval_card = body.contains(APPROVE_ACTION_ID_PREFIX);
+    let approval_id = approval_card_id(content_type, &body);
     // chat.update echoes the existing ts; a hypothetical new-message call has no
     // ts, so synthesize one so the response still looks like Slack.
     let ts_out = ts
@@ -280,6 +368,7 @@ async fn handle_call(
         ts: ts.clone(),
         text: text.clone(),
         approval_card,
+        approval_id,
     });
     Json(json!({ "ok": true, "ts": ts_out, "channel": channel, "text": text }))
 }
@@ -295,9 +384,35 @@ pub enum Outcome {
     /// THIS run's reply endpoint. For `local`/`cluster message` that endpoint is
     /// the CLI's throwaway stub, which dies when the command exits, so the resumed
     /// reply has nowhere to land (#529). Carries the latest placeholder text seen.
-    AwaitingApproval(Option<String>),
+    AwaitingApproval {
+        reply: Option<String>,
+        /// Durable id captured from the approval card when it reaches this stub,
+        /// or from the authoritative route-bound placeholder notice otherwise.
+        approval_id: Option<String>,
+    },
     /// The deadline passed with no completion.
     TimedOut,
+}
+
+/// Classify an acked turn after the final Slack-call drain.
+///
+/// Keeping the card-derived id separate from `latest` is load-bearing: Slack
+/// calls can be observed in either order, and the card may be the only captured
+/// call that carries the UUID needed to wait for the resume turn.
+fn completed_turn_outcome(
+    latest: Option<String>,
+    approval_card_seen: bool,
+    card_approval_id: Option<String>,
+) -> Outcome {
+    let approval_id = card_approval_id.or_else(|| latest.as_deref().and_then(parse_approval_id));
+    if approval_card_seen || approval_id.is_some() {
+        Outcome::AwaitingApproval {
+            reply: latest,
+            approval_id,
+        }
+    } else {
+        latest.map_or(Outcome::CompletedNoEdit, Outcome::Replied)
+    }
 }
 
 /// Wait for the worker to consume and finalize the turn. Terminal signal is the
@@ -335,12 +450,16 @@ pub async fn await_reply(
     // Whether the worker posted an approval card during this turn: the turn parked
     // awaiting approval rather than finalizing normally (#529).
     let mut awaiting_approval = false;
+    let mut card_approval_id: Option<String> = None;
     let mut poll = tokio::time::interval(ACK_POLL_INTERVAL);
     loop {
         tokio::select! {
             call = stub.recv() => {
                 if let Some(call) = call {
                     awaiting_approval |= call.approval_card;
+                    if call.approval_id.is_some() {
+                        card_approval_id = call.approval_id.clone();
+                    }
                     observe_placeholder_update(&call, placeholder_ts, &mut latest, observer);
                 }
             }
@@ -361,17 +480,19 @@ pub async fn await_reply(
                     // Drain any final edit still in flight before deciding.
                     while let Ok(Some(call)) = tokio::time::timeout(FINAL_DRAIN, stub.recv()).await {
                         awaiting_approval |= call.approval_card;
+                        if call.approval_id.is_some() {
+                            card_approval_id = call.approval_id.clone();
+                        }
                         observe_placeholder_update(&call, placeholder_ts, &mut latest, observer);
                     }
                     // Either signal parks the turn: the card seen here, or an
                     // authoritative approval notice in the latest placeholder
                     // text (the route-bound case, where no card reaches us).
-                    if awaiting_approval
-                        || latest.as_deref().and_then(parse_approval_id).is_some()
-                    {
-                        return Outcome::AwaitingApproval(latest);
-                    }
-                    return latest.map_or(Outcome::CompletedNoEdit, Outcome::Replied);
+                    return completed_turn_outcome(
+                        latest,
+                        awaiting_approval,
+                        card_approval_id,
+                    );
                 }
             }
             _ = tokio::time::sleep_until(tokio::time::Instant::from_std(deadline)) => {
@@ -676,6 +797,47 @@ mod tests {
     }
 
     #[test]
+    fn approval_card_id_survives_card_before_notice_ordering() {
+        let id = "00000000-0000-4000-8000-000000000220";
+        let body = format!(
+            r#"{{"channel":"C0EXAMPLE1","client_msg_id":"{id}","blocks":[{{"type":"actions","elements":[{{"type":"button","action_id":"{APPROVE_ACTION_ID_PREFIX}","value":"{id}"}}]}}]}}"#
+        );
+        let captured = approval_card_id("application/json", &body);
+
+        // The card can win the Slack-call race while the latest placeholder is
+        // still ordinary text. Preserve that text for output, but carry the
+        // card's durable id independently so the caller enters its resume wait.
+        match completed_turn_outcome(Some("working".into()), true, captured) {
+            Outcome::AwaitingApproval { reply, approval_id } => {
+                assert_eq!(reply.as_deref(), Some("working"));
+                assert_eq!(approval_id.as_deref(), Some(id));
+            }
+            outcome => panic!("approval card was not classified as awaiting: {outcome:?}"),
+        }
+    }
+
+    #[test]
+    fn approval_card_id_rejects_malformed_and_non_card_payloads() {
+        let id = "00000000-0000-4000-8000-000000000220";
+        let non_card = format!(
+            r#"{{"client_msg_id":"{id}","text":"mentions {APPROVE_ACTION_ID_PREFIX}","blocks":[{{"type":"section","text":{{"type":"plain_text","text":"not a card"}}}}]}}"#
+        );
+        assert_eq!(approval_card_id("application/json", &non_card), None);
+
+        let malformed = format!(
+            r#"{{"client_msg_id":"not-a-uuid","blocks":[{{"type":"actions","elements":[{{"type":"button","action_id":"{APPROVE_ACTION_ID_PREFIX}","value":"also-not-a-uuid"}}]}}]}}"#
+        );
+        assert_eq!(approval_card_id("application/json", &malformed), None);
+
+        // The raw action-id signal still reports a parked turn, but malformed
+        // external data is never promoted into an id used for resume lookup.
+        match completed_turn_outcome(None, true, approval_card_id("application/json", &malformed)) {
+            Outcome::AwaitingApproval { approval_id, .. } => assert_eq!(approval_id, None),
+            outcome => panic!("malformed card lost its awaiting status: {outcome:?}"),
+        }
+    }
+
+    #[test]
     fn placeholder_update_text_matches_only_the_right_call() {
         let update = SlackCall {
             method: "chat.update".into(),
@@ -683,6 +845,7 @@ mod tests {
             ts: Some("1.2".into()),
             text: Some("the answer".into()),
             approval_card: false,
+            approval_id: None,
         };
         assert_eq!(placeholder_update_text(&update, "1.2"), Some("the answer"));
         // Wrong ts (a different message).

--- a/cli/src/local.rs
+++ b/cli/src/local.rs
@@ -129,17 +129,24 @@ pub fn fake_model_env_override(mode: ModelMode) -> Option<(String, String)> {
 /// resolve. An empty value (not an absent one) is what does it: compose writes
 /// the endpoint as `${OTEL_EXPORTER_OTLP_ENDPOINT-...}`, whose `-` (unset-only)
 /// form substitutes its default only when the var is UNSET, so exporting it
-/// empty resolves to empty and the runner exports nothing. `false` returns
-/// `None` so compose's shipped collector default stands. This is the one place
+/// empty resolves to empty and the runner exports nothing. The host-network
+/// worker's separate override is also cleared. `false` returns no overrides,
+/// so compose's shipped collector defaults stand. This is the one place
 /// that decision is made -- `up_command` and `local comms`'s connect/disconnect
 /// commands all call it instead of each re-deriving the pair inline, the same
 /// drift that let `local comms` fall out of parity with `local up` on the fake
 /// model (issue #450).
-pub fn otel_endpoint_env_override(minimal: bool) -> Option<(String, String)> {
+pub fn otel_endpoint_env_override(minimal: bool) -> Vec<(String, String)> {
     if minimal {
-        Some(("OTEL_EXPORTER_OTLP_ENDPOINT".into(), String::new()))
+        vec![
+            ("OTEL_EXPORTER_OTLP_ENDPOINT".into(), String::new()),
+            (
+                "CURIE_WORKER_OTEL_EXPORTER_OTLP_ENDPOINT".into(),
+                String::new(),
+            ),
+        ]
     } else {
-        None
+        Vec::new()
     }
 }
 
@@ -2274,7 +2281,7 @@ mod tests {
         // profile starts no collector); `display` renders env before the program.
         assert_eq!(
             cmd.display(),
-            "OTEL_EXPORTER_OTLP_ENDPOINT= docker compose --profile core -f compose.dev.yaml up -d --wait"
+            "CURIE_WORKER_OTEL_EXPORTER_OTLP_ENDPOINT= OTEL_EXPORTER_OTLP_ENDPOINT= docker compose --profile core -f compose.dev.yaml up -d --wait"
         );
     }
 

--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -1184,6 +1184,10 @@ const COMPOSE_CONFIG_FILES_LABEL: &str = "com.docker.compose.project.config_file
 const COMPOSE_DISPATCHER_SERVICE: &str = "curie-dispatcher";
 const DISPATCHER_ENQUEUE_MODULE: &str = "curie_dispatcher.enqueue_once";
 const DISPATCHER_ENQUEUE_TIMEOUT: Duration = Duration::from_secs(30);
+// The one-shot dispatcher shares the runner's bridge network, not the
+// worker's host network. Inspect this separately; it is never forwarded as a
+// Curie configuration key into the dispatcher.
+const BRIDGE_OTEL_ENDPOINT_KEY: &str = "CURIE_RUNNER_OTEL_EXPORTER_OTLP_ENDPOINT";
 const OTEL_EXPORTER_ENV_KEYS: [&str; 38] = [
     "OTEL_EXPORTER_OTLP_ENDPOINT",
     "OTEL_EXPORTER_OTLP_PROTOCOL",
@@ -1302,6 +1306,7 @@ fn worker_otel_exporter_env_command(container: &str) -> OpsCommand {
     for name in OTEL_EXPORTER_ENV_KEYS {
         template.push_str(&format!("(eq $name \"{name}\") "));
     }
+    template.push_str(&format!("(eq $name \"{BRIDGE_OTEL_ENDPOINT_KEY}\") "));
     template.push_str("}}{{json $entry}}{{println}}{{end}}{{end}}");
     OpsCommand::new(
         "docker",
@@ -1316,6 +1321,7 @@ fn worker_otel_exporter_env_command(container: &str) -> OpsCommand {
 
 fn parse_worker_otel_env(stdout: &str) -> Result<Vec<(String, String)>> {
     let mut selected = Vec::new();
+    let mut bridge_endpoint = None;
     for (index, line) in stdout
         .lines()
         .filter(|line| !line.trim().is_empty())
@@ -1341,9 +1347,17 @@ fn parse_worker_otel_env(stdout: &str) -> Result<Vec<(String, String)>> {
         };
         // Keep the same allowlist here as defense in depth if the Docker
         // formatting boundary ever changes independently.
-        if OTEL_EXPORTER_ENV_KEYS.contains(&name) {
+        if name == BRIDGE_OTEL_ENDPOINT_KEY {
+            bridge_endpoint = Some(value.to_string());
+        } else if OTEL_EXPORTER_ENV_KEYS.contains(&name) {
             selected.push((name.to_string(), value.to_string()));
         }
+    }
+    if let Some(endpoint) = bridge_endpoint {
+        // An explicit empty value disables export; absence retains legacy
+        // behavior. Signal-specific exporter overrides remain unchanged.
+        selected.retain(|(name, _)| name != "OTEL_EXPORTER_OTLP_ENDPOINT");
+        selected.push(("OTEL_EXPORTER_OTLP_ENDPOINT".to_string(), endpoint));
     }
     Ok(selected)
 }
@@ -4598,10 +4612,69 @@ mod tests {
         for name in EXPECTED_OTEL_EXPORTER_ENV_KEYS {
             assert!(template.contains(name), "inspect template omitted {name}");
         }
+        assert!(template.contains("CURIE_RUNNER_OTEL_EXPORTER_OTLP_ENDPOINT"));
         assert!(!template.contains("{{json .Config.Env}}"));
         assert!(!template.contains("UNRELATED_SECRET"));
         assert!(!template.contains("println ."));
         assert!(!template.contains("range .Config.Env}}{{println"));
+    }
+
+    #[test]
+    fn local_dispatcher_uses_bridge_exporter_endpoint_and_preserves_empty_override() {
+        for (bridge, expected) in [
+            (
+                Some("http://otel-collector:4318"),
+                "http://otel-collector:4318",
+            ),
+            (Some(""), ""),
+            (None, "http://127.0.0.1:24318"),
+        ] {
+            let mut inspected = String::new();
+            // The override must win regardless of Docker's environment order.
+            if let Some(value) = bridge {
+                inspected.push_str(&format!(
+                    "CURIE_RUNNER_OTEL_EXPORTER_OTLP_ENDPOINT={value}\n"
+                ));
+            }
+            inspected.push_str(concat!(
+                "OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:24318\n",
+                "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=https://traces.example.com/v1/traces\n",
+                "OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf\n",
+                "UNRELATED_SECRET=must-not-forward\n",
+            ));
+            let command = dispatcher_enqueue_command(
+                &["/tmp/compose.yaml".to_string()],
+                "curie-dispatcher-enqueue-test",
+                "test:curie:runs",
+                "example-password",
+                &parse_worker_otel_env(&inspected).unwrap(),
+                None,
+            );
+            // Execute the subprocess environment the dispatcher receives;
+            // checking only the parsed vector would miss command forwarding.
+            let output = std::process::Command::new("sh")
+                .args([
+                    "-c",
+                    concat!(
+                        "printf '%s\\n' \"$OTEL_EXPORTER_OTLP_ENDPOINT\" ",
+                        "\"$OTEL_EXPORTER_OTLP_TRACES_ENDPOINT\" ",
+                        "\"$OTEL_EXPORTER_OTLP_PROTOCOL\" ",
+                        "\"${CURIE_RUNNER_OTEL_EXPORTER_OTLP_ENDPOINT-unset}\" ",
+                        "\"${UNRELATED_SECRET-unset}\"",
+                    ),
+                ])
+                .env_clear()
+                .envs(command.env.iter().chain(command.secret_env.iter()).cloned())
+                .output()
+                .unwrap();
+            assert!(output.status.success());
+            assert_eq!(
+                String::from_utf8(output.stdout).unwrap(),
+                format!("{expected}\nhttps://traces.example.com/v1/traces\nhttp/protobuf\nunset\nunset\n")
+            );
+            assert!(!command.display().contains("http://otel-collector:4318"));
+            assert!(!command.display().contains("http://127.0.0.1:24318"));
+        }
     }
 
     #[test]

--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -569,8 +569,12 @@ async fn await_cluster_relay(
                 });
             }
             if awaiting_approval {
+                let approval_id = latest.as_deref().and_then(parse_approval_id);
                 return Ok(ClusterRelayObservation {
-                    outcome: Outcome::AwaitingApproval(latest),
+                    outcome: Outcome::AwaitingApproval {
+                        reply: latest,
+                        approval_id,
+                    },
                     next_cursor: cursor,
                 });
             }
@@ -1757,7 +1761,7 @@ async fn message_local(opts: MessageOpts) -> Result<()> {
             persist_and_hint(&opts, TurnVerb::Local, &channel, &thread_ts);
             Ok(())
         }
-        Outcome::AwaitingApproval(reply) => {
+        Outcome::AwaitingApproval { reply, approval_id } => {
             step.done("awaiting approval");
             // Persist the turn context BEFORE the (possibly full --timeout-secs)
             // approval wait: if the operator interrupts or the terminal closes
@@ -1767,10 +1771,10 @@ async fn message_local(opts: MessageOpts) -> Result<()> {
             persist_turn_quietly(&opts, TurnVerb::Local, &channel, &thread_ts);
             // Keep the stub alive and wait for the resumed reply instead of
             // exiting and stranding it (#766). The wait rides the Valkey
-            // connection already open for the enqueue, so the only degradation is
-            // a placeholder notice we cannot parse an approval id from -- then
-            // fall back to the terminal.
-            match parse_approval_id(reply.as_deref().unwrap_or_default()) {
+            // connection already open for the enqueue. The explicit id normally
+            // comes from the card and falls back to the route-bound notice; if
+            // neither carries a valid UUID, report the parked terminal.
+            match approval_id {
                 Some(id) => {
                     let remaining = Duration::from_secs(opts.timeout_secs)
                         .saturating_sub(wait_started.elapsed());
@@ -2226,11 +2230,14 @@ async fn resume_after_approval(
                 persist_and_hint(opts, verb, channel, thread_ts);
                 return ResumeExit::Done;
             }
-            Outcome::AwaitingApproval(new_reply) => {
+            Outcome::AwaitingApproval {
+                reply: new_reply,
+                approval_id,
+            } => {
                 // The RESUMED turn hit a NEW gate of its own. Keep waiting on ITS
                 // resume entry rather than exiting and dropping the stub -- exiting
                 // here would re-create the dead-endpoint bug for the nested gate.
-                match parse_approval_id(new_reply.as_deref().unwrap_or_default()) {
+                match approval_id {
                     Some(new_id) => {
                         current_id = new_id;
                         last_reply = new_reply;
@@ -2392,8 +2399,11 @@ async fn resume_cluster_after_approval(
                 persist_and_hint(opts, TurnVerb::Cluster, channel, thread_ts);
                 return Ok(ResumeExit::Done);
             }
-            Outcome::AwaitingApproval(new_reply) => {
-                if let Some(new_id) = parse_approval_id(new_reply.as_deref().unwrap_or_default()) {
+            Outcome::AwaitingApproval {
+                reply: new_reply,
+                approval_id,
+            } => {
+                if let Some(new_id) = approval_id {
                     current_id = new_id;
                     last_reply = new_reply;
                     continue;
@@ -2988,7 +2998,7 @@ pub async fn message(mut opts: MessageOpts) -> Result<()> {
             persist_and_hint(&opts, TurnVerb::Cluster, &channel, &thread_ts);
             Ok(())
         }
-        Outcome::AwaitingApproval(reply) => {
+        Outcome::AwaitingApproval { reply, approval_id } => {
             step.done("awaiting approval");
             // Persist the turn context BEFORE the (possibly full --timeout-secs)
             // approval wait, so an interrupted terminal still leaves a thread
@@ -2997,7 +3007,7 @@ pub async fn message(mut opts: MessageOpts) -> Result<()> {
             persist_turn_quietly(&opts, TurnVerb::Cluster, &channel, &thread_ts);
             // The API resume queue preserves this turn's reply handle, so keep
             // polling the same opaque bucket through any approval resolution.
-            match parse_approval_id(reply.as_deref().unwrap_or_default()) {
+            match approval_id {
                 Some(id) => {
                     let remaining = Duration::from_secs(opts.timeout_secs)
                         .saturating_sub(wait_started.elapsed());
@@ -3184,14 +3194,16 @@ pub fn reply_passes(case: &EvalCase, outcome: &Outcome) -> bool {
             // here and fails closed. The trajectory-aware grade lives on the
             // `skill eval` path (`turn_passes`) and the server-side eval matrix.
             Outcome::Replied(reply) => case.grader.grade(reply, &[]),
-            Outcome::CompletedNoEdit | Outcome::AwaitingApproval(_) | Outcome::TimedOut => false,
+            Outcome::CompletedNoEdit | Outcome::AwaitingApproval { .. } | Outcome::TimedOut => {
+                false
+            }
         },
         // Gate-blocked assertion: the turn must have parked awaiting approval, and
         // the latest placeholder text (the model's narration before the gate flip)
         // must satisfy the grader. A match-anything grader ({kind:contains,expected:""})
         // asserts purely on the gate holding.
         ExpectedStatus::AwaitingApproval => match outcome {
-            Outcome::AwaitingApproval(reply) => {
+            Outcome::AwaitingApproval { reply, .. } => {
                 case.grader.grade(reply.as_deref().unwrap_or_default(), &[])
             }
             Outcome::Replied(_) | Outcome::CompletedNoEdit | Outcome::TimedOut => false,
@@ -3384,14 +3396,16 @@ async fn run_eval_turns(
                 let elapsed = started.elapsed().as_secs_f64();
                 let output = match &outcome {
                     Outcome::Replied(reply) => reply.clone(),
-                    Outcome::AwaitingApproval(reply) => reply.clone().unwrap_or_default(),
+                    Outcome::AwaitingApproval { reply, .. } => reply.clone().unwrap_or_default(),
                     Outcome::CompletedNoEdit => String::new(),
                     Outcome::TimedOut => diagnostics(conn, &opts.stream, &stream_id).await,
                 };
                 let passed = reply_passes(case, &outcome);
                 let completed = matches!(
                     outcome,
-                    Outcome::Replied(_) | Outcome::AwaitingApproval(_) | Outcome::CompletedNoEdit
+                    Outcome::Replied(_)
+                        | Outcome::AwaitingApproval { .. }
+                        | Outcome::CompletedNoEdit
                 );
                 samples.push(crate::eval_sampling::SampleRecord {
                     outcome: if passed {
@@ -6740,7 +6754,10 @@ mod tests {
         // even if the card text happens to contain the expected token (#529).
         assert!(!reply_passes(
             &case,
-            &Outcome::AwaitingApproval(Some("pong pending approval".into()))
+            &Outcome::AwaitingApproval {
+                reply: Some("pong pending approval".into()),
+                approval_id: None,
+            }
         ));
     }
 
@@ -6754,9 +6771,18 @@ mod tests {
             eval_case_with_status(GraderKind::Contains, "", ExpectedStatus::AwaitingApproval);
         assert!(reply_passes(
             &case,
-            &Outcome::AwaitingApproval(Some("blocked the close".into()))
+            &Outcome::AwaitingApproval {
+                reply: Some("blocked the close".into()),
+                approval_id: None,
+            }
         ));
-        assert!(reply_passes(&case, &Outcome::AwaitingApproval(None)));
+        assert!(reply_passes(
+            &case,
+            &Outcome::AwaitingApproval {
+                reply: None,
+                approval_id: None,
+            }
+        ));
         // The agent merely replied -> the gate did not hold -> RED.
         assert!(!reply_passes(
             &case,

--- a/cli/tests/nightly_graded_ladder.rs
+++ b/cli/tests/nightly_graded_ladder.rs
@@ -1033,7 +1033,7 @@ fn product_observability_requires_three_valid_seeds_and_count_only_mcp_receipt()
 }
 
 #[test]
-fn product_collector_restore_covers_every_emitter_and_invalid_auth_recovers_same_id() {
+fn product_collector_restore_covers_every_emitter_and_invalid_auth_is_observable() {
     let pins = ladder_function("pin_local_source_images");
     for required in [
         "export CURIE_BASE_TAG=dev",
@@ -1079,22 +1079,20 @@ fn product_collector_restore_covers_every_emitter_and_invalid_auth_recovers_same
     );
 
     let negative = ladder_function("case_local_langfuse_invalid_auth");
-    // This contract is grounded in the shipped otel/collector-config.yaml:
-    // retry_on_failure is 5s/30s/5m and sending_queue uses file_storage with
-    // queue_size 1000. Invalid auth is therefore a temporary observed absence;
-    // the proof must recover the same queued ID before the unchanged horizon.
+    // OTLP/HTTP forbids retries for 401; configured retry/queue settings do not
+    // override that protocol rule. Issue #2204 requires an observable bounded
+    // failure, not replay of a permanently rejected request.
+    // https://opentelemetry.io/docs/specs/otlp/#retryable-response-codes
     for required in [
         "INVALID_LANGFUSE_OTLP_AUTH_HEADER",
         "langfuse-web",
         "otelcol_receiver_accepted_spans",
         "otelcol_exporter_send_failed_spans",
-        "sending_queue",
-        "file_storage",
-        "queue_size",
+        "otelcol_exporter_queue_size",
+        "assert_product_collector_permanent_auth_rejection",
         "Ready",
         "restart",
-        "same_queued_trace_id",
-        "queue_drained",
+        "failed_trace_id",
     ] {
         assert!(
             negative.contains(required),
@@ -1103,11 +1101,11 @@ fn product_collector_restore_covers_every_emitter_and_invalid_auth_recovers_same
     }
     assert!(
         !negative.contains("down -v"),
-        "the negative must retain the Collector file queue across restart"
+        "the negative must not destroy the backing stack to manufacture absence"
     );
     assert!(
-        negative.matches("same_queued_trace_id").count() >= 2,
-        "the temporarily absent ID, not a fresh post-recovery control, must become queryable"
+        !negative.contains("same_queued_trace_id"),
+        "a permanent 401 rejection must not be misrepresented as durable replay"
     );
 
     let valid_control = negative
@@ -1120,30 +1118,6 @@ fn product_collector_restore_covers_every_emitter_and_invalid_auth_recovers_same
         valid_control < invalidate,
         "the valid exact-read control must precede credential invalidation"
     );
-
-    let before_restore = negative
-        .split_once("restore_local_langfuse_auth")
-        .map(|(prefix, _)| prefix)
-        .expect("invalid-auth proof must restore valid auth");
-    let invalid_restarts: Vec<_> = before_restore
-        .match_indices("restart_local_product_collector")
-        .map(|(index, _)| index)
-        .collect();
-    assert!(
-        invalid_restarts.len() >= 2,
-        "the file-backed queue must survive a Collector restart while auth is still invalid"
-    );
-    let after_invalid_restart = &before_restore[invalid_restarts[1]..];
-    for required in [
-        "otelcol_exporter_send_failed_spans",
-        "otelcol_exporter_queue_size",
-        "query_exact_seed_trace",
-    ] {
-        assert!(
-            after_invalid_restart.contains(required),
-            "queued failure must be re-observed after the invalid-auth restart: missing {required}"
-        );
-    }
 
     let query = ladder_function("query_exact_seed_trace");
     let poll_start = query
@@ -1167,14 +1141,17 @@ fn product_collector_restore_covers_every_emitter_and_invalid_auth_recovers_same
     );
 
     let absent = negative
-        .find(r#"query_exact_seed_trace local "$same_queued_trace_id" "" "" absent"#)
-        .expect("queued exact ID must be checked absent while auth is invalid");
+        .find(r#"query_exact_seed_trace local "$failed_trace_id" "" "" absent"#)
+        .expect("the rejected exact ID must be checked absent while auth is invalid");
+    let restored = negative
+        .rfind("restore_local_langfuse_auth")
+        .expect("valid auth must be restored after the failure evidence");
     let recovered = negative
-        .rfind(r#"query_exact_seed_trace local "$same_queued_trace_id""#)
-        .expect("the same queued exact ID must be queried after valid auth returns");
+        .rfind("seed_ordinary_turn local")
+        .expect("a fresh healthy turn must prove exact ingestion after valid auth returns");
     assert!(
-        absent < recovered,
-        "same-ID recovery must follow the bounded queued-failure observation"
+        absent < restored && restored < recovered,
+        "fresh-turn recovery must follow bounded rejection evidence and credential restoration"
     );
 }
 

--- a/cli/tests/nightly_graded_ladder.rs
+++ b/cli/tests/nightly_graded_ladder.rs
@@ -1180,8 +1180,8 @@ fn cluster_product_observability_is_private_preflight_and_query_only() {
     let wrapper = ladder_function("rung_cluster_product");
     for required in [
         "preflight_cluster_product_observability",
-        "seed_ordinary_turn",
-        "seed_approval_resume_turn",
+        "seed_cluster_missing_carrier_control",
+        "cluster_external_ingress_seed",
         "cluster observability run",
     ] {
         assert!(
@@ -1212,6 +1212,37 @@ fn cluster_product_observability_is_private_preflight_and_query_only() {
         wrapper.contains("cluster deploy"),
         "the product wrapper must retain the intended agent seed deployment"
     );
+    for manufactured in [
+        "enqueue_cluster_carried_turn",
+        "CLUSTER_SEEDED_TRACE_ID",
+        "secrets.token_hex",
+    ] {
+        assert!(
+            !ladder().contains(manufactured),
+            "cluster correlation evidence must come from real Slack ingress, not harness-manufactured carrier {manufactured}"
+        );
+    }
+    let missing_carrier = ladder_function("seed_cluster_missing_carrier_control");
+    assert!(
+        missing_carrier.contains("cluster message")
+            && missing_carrier.contains("adjacent_traceparent=false"),
+        "the dispatcher-absent cluster message path must remain an explicit executed missing-carrier compatibility negative"
+    );
+    let external = ladder_function("cluster_external_ingress_seed");
+    for required in [
+        "CURIE_E2E_CLUSTER_EXTERNAL_INGRESS_RECEIPT",
+        "CURIE_E2E_PRODUCT_RUN_ID",
+        "reply_observed",
+        "completion_observed",
+        "otelcol_receiver_accepted_spans_delta",
+        "otelcol_exporter_sent_spans_delta",
+        "discover_cluster_external_trace_id",
+    ] {
+        assert!(
+            ladder().contains(required) || external.contains(required),
+            "external Slack cluster evidence omits {required}"
+        );
+    }
     assert!(
         !preflight.contains(r#"-o json > "$inventory""#)
             && !preflight.contains("cluster-product-pods"),
@@ -1258,6 +1289,8 @@ fn adopted_component_stop_requires_successful_local_and_cluster_export() {
         "cluster",
         "image_ids_match",
         "seed_valid",
+        "same_id_raw_collector_receipt",
+        "run_id",
         "adopted-component",
     ] {
         assert!(
@@ -1272,6 +1305,20 @@ fn adopted_component_stop_requires_successful_local_and_cluster_export() {
     assert!(
         decision.find("langfuse_observation_membership") < decision.find("adopted-component"),
         "the harness cannot blame the adopted backend before checking exact-ID membership"
+    );
+    for verdict in ["curie-unresolved", "curie-owned", "adopted-component"] {
+        let tail = decision
+            .split(verdict)
+            .nth(1)
+            .unwrap_or_else(|| panic!("classifier omits verdict {verdict}"));
+        assert!(
+            tail.contains("SystemExit(1)"),
+            "blocking verdict {verdict} must terminate the supported run nonzero"
+        );
+    }
+    assert!(
+        decision.contains("curie-clear") && decision.contains("SystemExit(0)"),
+        "only a fully cleared local+cluster classification may exit zero"
     );
 }
 

--- a/cli/tests/nightly_graded_ladder.rs
+++ b/cli/tests/nightly_graded_ladder.rs
@@ -1049,6 +1049,18 @@ fn product_collector_restore_covers_every_emitter_and_invalid_auth_recovers_same
             "worker-only exporter restoration can leave {required} routed to the disposable sink"
         );
     }
+    assert!(
+        restore.contains("export OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318"),
+        "product restoration must override unrelated shell or ignored-file routing"
+    );
+    assert!(
+        restore.contains("export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf"),
+        "product restoration must pin the protocol expected by the task-owned collector"
+    );
+    assert!(
+        !restore.contains("unset OTEL_EXPORTER_OTLP_ENDPOINT"),
+        "unsetting the override permits ignored local configuration to redirect evidence"
+    );
 
     let negative = ladder_function("case_local_langfuse_invalid_auth");
     // This contract is grounded in the shipped otel/collector-config.yaml:

--- a/cli/tests/nightly_graded_ladder.rs
+++ b/cli/tests/nightly_graded_ladder.rs
@@ -59,6 +59,18 @@ fn ladder() -> String {
     fs::read_to_string(path).unwrap_or_default()
 }
 
+fn ladder_function(name: &str) -> String {
+    let source = ladder();
+    let marker = format!("{name}() {{");
+    let (_, tail) = source
+        .split_once(&marker)
+        .unwrap_or_else(|| panic!("ladder must define {name}"));
+    let (body, _) = tail
+        .split_once("\n}\n")
+        .unwrap_or_else(|| panic!("ladder function {name} must close"));
+    format!("{marker}{body}\n}}\n")
+}
+
 /// The local OTel assertions deliberately live in the shell harness, where
 /// they consume the Collector's raw JSON files.  Keep this test on that real
 /// consumer instead of re-implementing its attribution rules in Rust.
@@ -812,11 +824,21 @@ fn live_local_rung_grades_the_deployed_weather_cases() {
         .map(|offset| product_collector + offset)
         .expect("the local rung must prove observability queries after telemetry");
     assert!(
-        text.contains(r#"local observability runs --limit 100"#)
-            && text.contains(r#"timestamp = row.get("timestamp")"#)
-            && text.contains(r#"if matched is None:"#),
-        "the live proof must scan a bounded newest-first page and select its first complete typed row without relying on an identity field the list DTO does not promise"
+        !text.contains(r#"local observability runs --limit 100"#),
+        "a newest-runs page can select a background trace; the live proof must derive the exact trace ID from the seeded bounded stream entry"
     );
+    for required in [
+        "discover_trace_id_for_seed",
+        "query_exact_seed_trace",
+        "sanitize_exact_trace_read",
+        "seed_ordinary_turn",
+        "seed_approval_resume_turn",
+    ] {
+        assert!(
+            text.contains(required),
+            "the local product proof is missing exact-seed contract {required}"
+        );
+    }
     let contract = r#"echo "=== curie local eval --dry-run (suite parity) ==="
     local eval_args=(local eval)
     if [[ ! -f "$WORKDIR/bundle/evals/trajectory.json" ]]; then
@@ -849,6 +871,173 @@ fn live_local_rung_grades_the_deployed_weather_cases() {
         !local_rung.contains("up_args+=(--minimal)"),
         "the local rung must never add --minimal now that its observability \
           proof requires Langfuse/ClickHouse; ladder contents:\n{text}"
+    );
+}
+
+#[test]
+fn product_observability_requires_three_valid_seeds_and_count_only_mcp_receipt() {
+    let text = ladder();
+    for required in [
+        "seed_ordinary_turn() {",
+        "seed_mcp_read_turn() {",
+        "seed_approval_resume_turn() {",
+        "seed-invalid",
+        "mcp_receipt_call_count() {",
+        "discover_trace_id_for_seed",
+        "query_exact_seed_trace",
+        "fixtures/mcp-receipt",
+    ] {
+        assert!(
+            text.contains(required),
+            "the product observability oracle must pin independent ordinary, MCP, and approval seed evidence; missing {required}"
+        );
+    }
+
+    let receipt_fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("scripts/fixtures/mcp-receipt/server.py");
+    let receipt_source = fs::read_to_string(&receipt_fixture).unwrap_or_default();
+    assert!(
+        receipt_source.contains(r#""tools/call""#),
+        "the hosted MCP fixture must log exactly one private receipt per tools/call"
+    );
+    let receipt = ladder_function("mcp_receipt_call_count");
+    assert!(
+        receipt.contains("docker logs") || receipt.contains("kubectl logs"),
+        "the independent MCP receipt must come from the hosted connector container"
+    );
+    assert!(
+        receipt.contains("count") || receipt.contains("wc -l"),
+        "only an aggregate MCP call count may reach evidence output"
+    );
+}
+
+#[test]
+fn product_collector_restore_covers_every_emitter_and_invalid_auth_recovers_same_id() {
+    let restore = ladder_function("route_local_observability_to_product_collector");
+    for required in [
+        "curie-api",
+        "curie-dispatcher",
+        "curie-worker",
+        "curie-runner",
+        "assert_product_collector_endpoint",
+        "http/protobuf",
+        "otel-collector:4318",
+    ] {
+        assert!(
+            restore.contains(required),
+            "worker-only exporter restoration can leave {required} routed to the disposable sink"
+        );
+    }
+
+    let negative = ladder_function("case_local_langfuse_invalid_auth");
+    // This contract is grounded in the shipped otel/collector-config.yaml:
+    // retry_on_failure is 5s/30s/5m and sending_queue uses file_storage with
+    // queue_size 1000. Invalid auth is therefore a temporary observed absence;
+    // the proof must recover the same queued ID before the unchanged horizon.
+    for required in [
+        "INVALID_LANGFUSE_OTLP_AUTH_HEADER",
+        "langfuse-web",
+        "otelcol_receiver_accepted_spans",
+        "otelcol_exporter_send_failed_spans",
+        "sending_queue",
+        "file_storage",
+        "queue_size",
+        "Ready",
+        "restart",
+        "same_queued_trace_id",
+        "queue_drained",
+    ] {
+        assert!(
+            negative.contains(required),
+            "real pinned-Langfuse invalid-auth proof omits {required}"
+        );
+    }
+    assert!(
+        !negative.contains("down -v"),
+        "the negative must retain the Collector file queue across restart"
+    );
+    assert!(
+        negative.matches("same_queued_trace_id").count() >= 2,
+        "the temporarily absent ID, not a fresh post-recovery control, must become queryable"
+    );
+}
+
+#[test]
+fn cluster_product_observability_is_private_preflight_and_query_only() {
+    let preflight = ladder_function("preflight_cluster_product_observability");
+    for required in [
+        "CURIE_NAMESPACE",
+        "CURIE_RELEASE",
+        "default",
+        "curie",
+        "langfuse",
+        "otel-collector",
+        "api",
+        "worker",
+        "runner-prewarm",
+        "imageID",
+        "docker image inspect",
+        "curie-api:local",
+        "curie-worker:local",
+        "curie-runner:latest",
+        "mismatch",
+    ] {
+        assert!(
+            preflight.contains(required),
+            "cluster product preflight omits {required}"
+        );
+    }
+
+    let query = ladder_function("run_cluster_product_observability");
+    for required in [
+        "preflight_cluster_product_observability",
+        "seed_ordinary_turn",
+        "seed_approval_resume_turn",
+        "cluster observability run",
+    ] {
+        assert!(query.contains(required), "cluster query mode omits {required}");
+    }
+    for mutation in [
+        "cluster up",
+        "cluster down",
+        "helm install",
+        "helm upgrade",
+        "helm uninstall",
+        "kubectl delete",
+    ] {
+        assert!(
+            !query.contains(mutation),
+            "cluster product mode must never mutate the installed release: found {mutation}"
+        );
+    }
+}
+
+#[test]
+fn adopted_component_stop_requires_successful_local_and_cluster_export() {
+    let decision = ladder_function("classify_product_observability_owner");
+    for required in [
+        "raw_emitted_observations",
+        "otelcol_receiver_accepted_spans",
+        "otelcol_exporter_sent_spans",
+        "langfuse_observation_membership",
+        "local",
+        "cluster",
+        "image_ids_match",
+        "seed_valid",
+        "adopted-component",
+    ] {
+        assert!(
+            decision.contains(required),
+            "ownership classification omits prerequisite {required}"
+        );
+    }
+    assert!(
+        decision.find("otelcol_exporter_sent_spans") < decision.find("adopted-component"),
+        "the harness cannot blame the adopted backend before proving export success"
+    );
+    assert!(
+        decision.find("langfuse_observation_membership") < decision.find("adopted-component"),
+        "the harness cannot blame the adopted backend before checking exact-ID membership"
     );
 }
 
@@ -1713,27 +1902,27 @@ fn looks_like_utc_second(value: &str) -> bool {
 
 /// Pin the public argv the ladder itself must exercise. These are not test-only
 /// probes: every line is a command an operator can paste against the candidate
-/// binary. The bounded newest-page read occurs before the discovered-id detail;
+/// binary. Exact trace discovery is private to the bounded seed stream slice;
 /// the separate agent-filtered list is the unavailable-API negative with its
 /// process environment pointed at a closed endpoint.
 fn assert_observability_candidate_invocations(invocations: &str, trace_id: &str) {
-    let runs = "--json local observability runs --limit 100";
+    let legacy_runs = "--json local observability runs --limit 100";
     let unavailable = format!("--json local observability runs --limit 1 --agent-id {AGENT_ID}");
     let detail = format!("--json local observability run {trace_id}");
     let unknown = format!("--json local observability run {UNKNOWN_OBSERVABILITY_TRACE_ID}");
 
     assert_eq!(
-        invocation_count(invocations, runs),
-        1,
-        "the local rung must issue one bounded newest-runs read for typed client selection; invocations:\n{invocations}"
+        invocation_count(invocations, legacy_runs),
+        0,
+        "the local rung must never let a newest-runs page select an unrelated background trace; invocations:\n{invocations}"
     );
-    assert_eq!(
+    assert!(
         invocations
             .lines()
             .filter(|line| line.starts_with("--json local message "))
-            .count(),
-        2,
-        "the query proof must seed the product Collector with its own finalized turn after the independent sink controls; invocations:\n{invocations}"
+            .count()
+            >= 2,
+        "the query proof must seed the product Collector with independently finalized turns after the raw sink controls; invocations:\n{invocations}"
     );
     assert_eq!(
         invocation_count(invocations, &unavailable),
@@ -1817,17 +2006,17 @@ fn assert_observability_candidate_invocations(invocations: &str, trace_id: &str)
         summary_window, series_window,
         "summary and series must share the one dynamically captured window; invocations:\n{invocations}"
     );
-    let bounded_position = invocations
-        .lines()
-        .position(|line| line == runs)
-        .expect("bounded runs invocation");
     let detail_position = invocations
         .lines()
         .position(|line| line == detail.as_str())
         .expect("discovered trace detail invocation");
+    let seed_position = invocations
+        .lines()
+        .position(|line| line.starts_with("--json local message "))
+        .expect("seed message invocation");
     assert!(
-        bounded_position < detail_position,
-        "the rung must discover the real trace id from the bounded list before querying its complete tree; invocations:\n{invocations}"
+        seed_position < detail_position,
+        "the rung must complete a seed before querying the exact trace ID privately derived from that seed; invocations:\n{invocations}"
     );
 }
 
@@ -2011,19 +2200,13 @@ fn local_observability_proof_leaves_a_borrowed_stack_to_its_owner() {
     );
 }
 
-/// #866 NEGATIVE CONTROLS. Move one stub contract at a time while the positive
-/// control above stays green: JSON cardinality, unknown-trace exit 1,
+/// #866 NEGATIVE CONTROLS. Move one candidate query contract at a time while
+/// the positive control above stays green: unknown-trace exit 1,
 /// unavailable-API exit 3, and the mandatory recovery instruction must each
 /// make the real ladder reject the candidate and still run owner teardown.
 #[test]
 fn local_observability_negative_controls_are_falsifiable() {
     let cases: &[(&str, &str, &[&str], bool)] = &[
-        (
-            "STUB_RUNS_EXTRA_JSON",
-            "1",
-            &["runs", "exactly one JSON object"],
-            false,
-        ),
         (
             "STUB_UNKNOWN_TRACE_EXIT",
             "0",

--- a/cli/tests/nightly_graded_ladder.rs
+++ b/cli/tests/nightly_graded_ladder.rs
@@ -905,7 +905,7 @@ fn live_local_rung_grades_the_deployed_weather_cases() {
     );
     assert!(
         local_rung
-            .contains("local up_args=(local up)\n        echo \"=== curie ${up_args[*]} ===\""),
+            .contains("local up_args=(local up -f \"$REPO_ROOT/compose.dev.yaml\" --build)\n        echo \"=== curie ${up_args[*]} ===\""),
         "the local rung must start the full profile required by its \
          observability query proof; ladder contents:\n{text}"
     );
@@ -1749,7 +1749,7 @@ print(json.dumps({
     "local up --minimal")
         echo "stub: compose stack up"
         ;;
-    "local up")
+    "local up -f "*/compose.dev.yaml" --build")
         echo "stub: full compose stack up"
         ;;
     "--json local deploy --plugin-dir "*)
@@ -1840,7 +1840,7 @@ print(json.dumps({
         fi
         exit "${STUB_EVAL_EXIT:-0}"
         ;;
-    "local down")
+    "local down -f "*/compose.dev.yaml)
         echo "stub: compose stack down"
         ;;
     *)
@@ -2169,6 +2169,33 @@ fn invocation_count(invocations: &str, expected: &str) -> usize {
     invocations.lines().filter(|line| *line == expected).count()
 }
 
+/// The local rung must boot the current source tree rather than the release
+/// compose resolved by the candidate binary. The compose file and `--build`
+/// are both load-bearing parts of this argv.
+fn is_current_source_local_up(invocation: &str) -> bool {
+    let args = invocation.split_whitespace().collect::<Vec<_>>();
+    args.len() == 5
+        && args[..3] == ["local", "up", "-f"]
+        && args[3].ends_with("/compose.dev.yaml")
+        && args[4] == "--build"
+}
+
+/// Teardown must target the same current-source compose file that the rung
+/// brought up; an unqualified `local down` could select a release compose.
+fn is_current_source_local_down(invocation: &str) -> bool {
+    let args = invocation.split_whitespace().collect::<Vec<_>>();
+    args.len() == 4
+        && args[..3] == ["local", "down", "-f"]
+        && args[3].ends_with("/compose.dev.yaml")
+}
+
+fn current_source_local_down_count(invocations: &str) -> usize {
+    invocations
+        .lines()
+        .filter(|line| is_current_source_local_down(line))
+        .count()
+}
+
 fn looks_like_utc_second(value: &str) -> bool {
     let bytes = value.as_bytes();
     bytes.len() == 20
@@ -2376,12 +2403,12 @@ fn ladder_selects_platform_trajectory_eval_without_overriding_deployed_cases() {
         .lines()
         .filter(|line| line.starts_with("local up"))
         .collect::<Vec<_>>();
-    assert_eq!(trajectory_starts, ["local up"], "{trajectory_invocations}");
+    assert_eq!(trajectory_starts.len(), 1, "{trajectory_invocations}");
     assert!(
         trajectory_starts
             .iter()
-            .all(|line| !line.contains("--minimal")),
-        "trajectory scoring requires the full local profile: {trajectory_invocations}"
+            .all(|line| is_current_source_local_up(line)),
+        "trajectory scoring requires current-source compose.dev.yaml with --build, never --minimal: {trajectory_invocations}"
     );
     for tier in ["local", "cluster"] {
         assert!(
@@ -2415,9 +2442,15 @@ fn ladder_selects_platform_trajectory_eval_without_overriding_deployed_cases() {
         .filter(|line| line.starts_with("local up"))
         .collect::<Vec<_>>();
     assert_eq!(
-        ordinary_starts,
-        ["local up"],
-        "the local rung's observability query proof requires the full profile even when the suite has no trajectory sidecar: {ordinary_invocations}"
+        ordinary_starts.len(),
+        1,
+        "the local rung's observability query proof requires one current-source boot even when the suite has no trajectory sidecar: {ordinary_invocations}"
+    );
+    assert!(
+        ordinary_starts
+            .iter()
+            .all(|line| is_current_source_local_up(line)),
+        "the local rung's observability query proof must pin compose.dev.yaml and --build even when the suite has no trajectory sidecar: {ordinary_invocations}"
     );
 }
 
@@ -2439,18 +2472,23 @@ fn local_rung_proves_observability_queries_with_real_candidate_verbs() {
         unavailable_called,
         "the local rung must actually move CURIE_API_URL to the closed-loopback control and exercise the unavailable-API path through the candidate CLI; invocations:\n{invocations}"
     );
+    let local_starts = invocations
+        .lines()
+        .filter(|line| line.starts_with("local up"))
+        .collect::<Vec<_>>();
     assert_eq!(
-        invocations
-            .lines()
-            .filter(|line| line.starts_with("local up"))
-            .collect::<Vec<_>>(),
-        ["local up"],
-        "observability proof requires the full local profile, never --minimal; invocations:\n{invocations}"
+        local_starts.len(),
+        1,
+        "observability proof requires exactly one local boot, never an additional minimal or release-compose boot; invocations:\n{invocations}"
+    );
+    assert!(
+        local_starts.iter().all(|line| is_current_source_local_up(line)),
+        "observability proof requires current-source compose.dev.yaml with --build, never --minimal; invocations:\n{invocations}"
     );
     assert_eq!(
-        invocation_count(&invocations, "local down"),
+        current_source_local_down_count(&invocations),
         1,
-        "a successful rung must tear down the one stack it claimed exactly once; invocations:\n{invocations}"
+        "a successful rung must tear down the one current-source stack it claimed exactly once; invocations:\n{invocations}"
     );
 }
 
@@ -2526,9 +2564,9 @@ fn local_observability_negative_controls_are_falsifiable() {
             "{variable} exercised the wrong unavailable-API path"
         );
         assert_eq!(
-            invocation_count(&invocations, "local down"),
+            current_source_local_down_count(&invocations),
             1,
-            "the owner-scoped EXIT trap must tear down {variable}; invocations:\n{invocations}"
+            "the owner-scoped EXIT trap must tear down {variable} through compose.dev.yaml; invocations:\n{invocations}"
         );
     }
 }

--- a/cli/tests/nightly_graded_ladder.rs
+++ b/cli/tests/nightly_graded_ladder.rs
@@ -1278,7 +1278,7 @@ fn product_sanitizer_and_message_failures_never_dump_private_json() {
 }
 
 #[test]
-fn adopted_component_stop_requires_successful_local_and_cluster_export() {
+fn adopted_component_stop_requires_complete_available_surface_export() {
     let decision = ladder_function("classify_product_observability_owner");
     for required in [
         "raw_emitted_observations",
@@ -1318,7 +1318,7 @@ fn adopted_component_stop_requires_successful_local_and_cluster_export() {
     }
     assert!(
         decision.contains("curie-clear") && decision.contains("SystemExit(0)"),
-        "only a fully cleared local+cluster classification may exit zero"
+        "only complete exact membership for every exercised surface may exit zero"
     );
 }
 

--- a/cli/tests/nightly_graded_ladder.rs
+++ b/cli/tests/nightly_graded_ladder.rs
@@ -71,6 +71,43 @@ fn ladder_function(name: &str) -> String {
     format!("{marker}{body}\n}}\n")
 }
 
+fn ladder_python_heredoc(function_name: &str) -> String {
+    let function = ladder_function(function_name);
+    let (_, tail) = function
+        .split_once("<<'PY'\n")
+        .unwrap_or_else(|| panic!("ladder function {function_name} must contain Python"));
+    tail.split_once("\nPY\n")
+        .unwrap_or_else(|| panic!("ladder function {function_name} Python must close"))
+        .0
+        .to_owned()
+}
+
+fn run_seed_trace_matcher(matcher: &str, marker: &str, rows: &serde_json::Value) -> Output {
+    let harness = tempfile::tempdir().expect("create seed matcher fixture directory");
+    let bounded_slice = harness.path().join("bounded-stream.json");
+    fs::write(
+        &bounded_slice,
+        serde_json::to_vec(rows).expect("serialize bounded stream fixture"),
+    )
+    .expect("write bounded stream fixture");
+    let mut child = Command::new("python3")
+        .arg("-")
+        .arg(&bounded_slice)
+        .arg(marker)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("start exact seed matcher");
+    child
+        .stdin
+        .take()
+        .expect("open matcher stdin")
+        .write_all(matcher.as_bytes())
+        .expect("write exact seed matcher");
+    child.wait_with_output().expect("wait for seed matcher")
+}
+
 /// The local OTel assertions deliberately live in the shell harness, where
 /// they consume the Collector's raw JSON files.  Keep this test on that real
 /// consumer instead of re-implementing its attribution rules in Rust.
@@ -823,10 +860,15 @@ fn live_local_rung_grades_the_deployed_weather_cases() {
         .find(r#"prove_local_observability_queries "$agent_id""#)
         .map(|offset| product_collector + offset)
         .expect("the local rung must prove observability queries after telemetry");
-    assert!(
-        !text.contains(r#"local observability runs --limit 100"#),
-        "a newest-runs page can select a background trace; the live proof must derive the exact trace ID from the seeded bounded stream entry"
-    );
+    for removed_helper in [
+        "discover_local_observability_trace() {",
+        "assert_local_observability_detail() {",
+    ] {
+        assert!(
+            !text.contains(removed_helper),
+            "a newest-runs selector/raw-dump helper remains ({removed_helper}); variable interpolation must not evade exact-ID discovery"
+        );
+    }
     for required in [
         "discover_trace_id_for_seed",
         "query_exact_seed_trace",
@@ -875,6 +917,75 @@ fn live_local_rung_grades_the_deployed_weather_cases() {
 }
 
 #[test]
+fn exact_seed_matcher_recovers_embedded_marker_once_and_rejects_background() {
+    let matcher = ladder_python_heredoc("discover_trace_id_for_seed");
+    let marker = "curie-seed-ordinary-example";
+    let target_trace = "a".repeat(32);
+    let background_trace = "b".repeat(32);
+    let target = serde_json::json!([
+        "2-0",
+        [
+            "payload",
+            serde_json::json!({"text": format!("ordinary correlation {marker}")}).to_string(),
+            "traceparent",
+            format!("00-{target_trace}-{}-01", "2".repeat(16))
+        ]
+    ]);
+    let background = serde_json::json!([
+        "1-0",
+        [
+            "payload",
+            serde_json::json!({"text": "ordinary correlation another-seed"}).to_string(),
+            "traceparent",
+            format!("00-{background_trace}-{}-01", "1".repeat(16))
+        ]
+    ]);
+
+    let matched = run_seed_trace_matcher(
+        &matcher,
+        marker,
+        &serde_json::json!([background.clone(), target.clone()]),
+    );
+    assert!(
+        matched.status.success(),
+        "representative embedded marker was not recovered: {}",
+        String::from_utf8_lossy(&matched.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&matched.stdout).trim(),
+        target_trace,
+        "background carrier must not substitute for the marker-adjacent carrier"
+    );
+
+    let mismatch = run_seed_trace_matcher(&matcher, marker, &serde_json::json!([background]));
+    assert!(
+        !mismatch.status.success(),
+        "a background payload without the marker must fail closed"
+    );
+    let duplicate = run_seed_trace_matcher(
+        &matcher,
+        marker,
+        &serde_json::json!([
+            target,
+            [
+                "3-0",
+                [
+                    "payload",
+                    serde_json::json!({"text": format!("ordinary correlation {marker}")})
+                        .to_string(),
+                    "traceparent",
+                    format!("00-{}-{}-01", "c".repeat(32), "3".repeat(16))
+                ]
+            ]
+        ]),
+    );
+    assert!(
+        !duplicate.status.success(),
+        "multiple matching adjacent carriers must fail closed"
+    );
+}
+
+#[test]
 fn product_observability_requires_three_valid_seeds_and_count_only_mcp_receipt() {
     let text = ladder();
     for required in [
@@ -908,6 +1019,16 @@ fn product_observability_requires_three_valid_seeds_and_count_only_mcp_receipt()
     assert!(
         receipt.contains("count") || receipt.contains("wc -l"),
         "only an aggregate MCP call count may reach evidence output"
+    );
+
+    let approval = ladder_function("seed_approval_resume_turn");
+    assert!(
+        approval.contains("curie.approval.suspend"),
+        "approval evidence must require the worker's real parked-turn span"
+    );
+    assert!(
+        !approval.contains("curie.approval.wait"),
+        "the oracle must not invent a wait span that no current emitter produces"
     );
 }
 
@@ -960,6 +1081,73 @@ fn product_collector_restore_covers_every_emitter_and_invalid_auth_recovers_same
         negative.matches("same_queued_trace_id").count() >= 2,
         "the temporarily absent ID, not a fresh post-recovery control, must become queryable"
     );
+
+    let valid_control = negative
+        .find(r#"query_exact_seed_trace local "$LAST_ORDINARY_TRACE_ID""#)
+        .expect("invalid-auth proof must first read an exact known-valid trace");
+    let invalidate = negative
+        .find(r#"export LANGFUSE_OTLP_AUTH_HEADER="$INVALID_LANGFUSE_OTLP_AUTH_HEADER""#)
+        .expect("invalid-auth proof must roll the Collector to the placeholder credential");
+    assert!(
+        valid_control < invalidate,
+        "the valid exact-read control must precede credential invalidation"
+    );
+
+    let before_restore = negative
+        .split_once("restore_local_langfuse_auth")
+        .map(|(prefix, _)| prefix)
+        .expect("invalid-auth proof must restore valid auth");
+    let invalid_restarts: Vec<_> = before_restore
+        .match_indices("restart_local_product_collector")
+        .map(|(index, _)| index)
+        .collect();
+    assert!(
+        invalid_restarts.len() >= 2,
+        "the file-backed queue must survive a Collector restart while auth is still invalid"
+    );
+    let after_invalid_restart = &before_restore[invalid_restarts[1]..];
+    for required in [
+        "otelcol_exporter_send_failed_spans",
+        "otelcol_exporter_queue_size",
+        "query_exact_seed_trace",
+    ] {
+        assert!(
+            after_invalid_restart.contains(required),
+            "queued failure must be re-observed after the invalid-auth restart: missing {required}"
+        );
+    }
+
+    let query = ladder_function("query_exact_seed_trace");
+    let poll_start = query
+        .find(r#"for attempt in $(seq 1 "$OBSERVABILITY_POLL_ATTEMPTS"); do"#)
+        .expect("exact trace query must use the declared bounded poll count");
+    let poll_end = poll_start
+        + query[poll_start..]
+            .find("\n    done")
+            .expect("exact trace bounded poll must close");
+    let absent_success = query
+        .find("exact trace remained not-found through the full bounded observation poll")
+        .expect("exact trace query must report a bounded absent verdict");
+    assert!(
+        absent_success > poll_end,
+        "absence must stay stable for the full poll bound, not return on the first exit 1"
+    );
+    assert!(
+        query.to_ascii_lowercase().contains("not found")
+            || query.to_ascii_lowercase().contains("not_found"),
+        "only a typed not-found result may satisfy absence; arbitrary exit 1 is not evidence"
+    );
+
+    let absent = negative
+        .find(r#"query_exact_seed_trace local "$same_queued_trace_id" "" "" absent"#)
+        .expect("queued exact ID must be checked absent while auth is invalid");
+    let recovered = negative
+        .rfind(r#"query_exact_seed_trace local "$same_queued_trace_id""#)
+        .expect("the same queued exact ID must be queried after valid auth returns");
+    assert!(
+        absent < recovered,
+        "same-ID recovery must follow the bounded queued-failure observation"
+    );
 }
 
 #[test]
@@ -989,6 +1177,7 @@ fn cluster_product_observability_is_private_preflight_and_query_only() {
     }
 
     let query = ladder_function("run_cluster_product_observability");
+    let wrapper = ladder_function("rung_cluster_product");
     for required in [
         "preflight_cluster_product_observability",
         "seed_ordinary_turn",
@@ -1008,9 +1197,51 @@ fn cluster_product_observability_is_private_preflight_and_query_only() {
         "helm uninstall",
         "kubectl delete",
     ] {
+        for (helper_name, helper) in [
+            ("preflight", preflight.as_str()),
+            ("query", query.as_str()),
+            ("product wrapper", wrapper.as_str()),
+        ] {
+            assert!(
+                !helper.contains(mutation),
+                "cluster product {helper_name} must never install, upgrade, uninstall, or delete the release: found {mutation}"
+            );
+        }
+    }
+    assert!(
+        wrapper.contains("cluster deploy"),
+        "the product wrapper must retain the intended agent seed deployment"
+    );
+    assert!(
+        !preflight.contains(r#"-o json > "$inventory""#)
+            && !preflight.contains("cluster-product-pods"),
+        "cluster preflight must query Ready/imageID fields directly and never persist full pod JSON containing private spec/env data"
+    );
+}
+
+#[test]
+fn product_sanitizer_and_message_failures_never_dump_private_json() {
+    let sanitizer = ladder_function("sanitize_exact_trace_read");
+    assert!(
+        !sanitizer.contains("if private_fields.intersection(node):\n        pass"),
+        "private-field handling must reject or remove data, not be a no-op"
+    );
+    for private in ["input", "output", "session", "user", "headers"] {
         assert!(
-            !query.contains(mutation),
-            "cluster product mode must never mutate the installed release: found {mutation}"
+            sanitizer.contains(private),
+            "sanitizer must explicitly account for private field {private}"
+        );
+    }
+
+    let finalized = ladder_function("assert_finalized_reply");
+    for raw_dump in [
+        r#"printf '%s\n' "$payload""#,
+        r#"printf "%s\n" "$payload""#,
+        r#"echo "$payload""#,
+    ] {
+        assert!(
+            !finalized.contains(raw_dump),
+            "message parse/finalization failures must emit a bounded verdict, not private raw JSON"
         );
     }
 }

--- a/cli/tests/nightly_graded_ladder.rs
+++ b/cli/tests/nightly_graded_ladder.rs
@@ -1034,6 +1034,18 @@ fn product_observability_requires_three_valid_seeds_and_count_only_mcp_receipt()
 
 #[test]
 fn product_collector_restore_covers_every_emitter_and_invalid_auth_recovers_same_id() {
+    let pins = ladder_function("pin_local_source_images");
+    for required in [
+        "export CURIE_BASE_TAG=dev",
+        "export CURIE_RUNNER_IMAGE=ghcr.io/curie-eng/curie-runner:dev",
+        "export CURIE_DISPATCHER_IMAGE=ghcr.io/curie-eng/curie-dispatcher:dev",
+    ] {
+        assert!(
+            pins.contains(required),
+            "raw Compose recreation loses {required}"
+        );
+    }
+    assert!(ladder_function("rung_local").contains("pin_local_source_images"));
     let restore = ladder_function("route_local_observability_to_product_collector");
     for required in [
         "curie-api",
@@ -1052,6 +1064,10 @@ fn product_collector_restore_covers_every_emitter_and_invalid_auth_recovers_same
     assert!(
         restore.contains("export OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318"),
         "product restoration must override unrelated shell or ignored-file routing"
+    );
+    assert!(
+        restore.contains("export CURIE_WORKER_OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:24318"),
+        "host-network worker must use the collector's published host port"
     );
     assert!(
         restore.contains("export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf"),

--- a/cli/tests/nightly_graded_ladder.rs
+++ b/cli/tests/nightly_graded_ladder.rs
@@ -893,8 +893,8 @@ fn product_observability_requires_three_valid_seeds_and_count_only_mcp_receipt()
         );
     }
 
-    let receipt_fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("scripts/fixtures/mcp-receipt/server.py");
+    let receipt_fixture =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("scripts/fixtures/mcp-receipt/server.py");
     let receipt_source = fs::read_to_string(&receipt_fixture).unwrap_or_default();
     assert!(
         receipt_source.contains(r#""tools/call""#),
@@ -995,7 +995,10 @@ fn cluster_product_observability_is_private_preflight_and_query_only() {
         "seed_approval_resume_turn",
         "cluster observability run",
     ] {
-        assert!(query.contains(required), "cluster query mode omits {required}");
+        assert!(
+            query.contains(required),
+            "cluster query mode omits {required}"
+        );
     }
     for mutation in [
         "cluster up",

--- a/cli/tests/resume_wait.rs
+++ b/cli/tests/resume_wait.rs
@@ -635,7 +635,17 @@ async fn a_notice_without_a_card_parks_the_turn_and_the_keepalive_delivers_the_r
     .await;
 
     let parked = match outcome {
-        Outcome::AwaitingApproval(latest) => latest,
+        Outcome::AwaitingApproval {
+            reply: latest,
+            approval_id: captured_id,
+        } => {
+            assert_eq!(
+                captured_id.as_deref(),
+                Some(approval_id),
+                "the route-bound notice remains the explicit id fallback when no card arrives"
+            );
+            latest
+        }
         other => {
             let _: i64 = redis::cmd("DEL")
                 .arg(&stream)
@@ -750,7 +760,13 @@ async fn a_blank_line_summary_notice_parks_the_turn_and_the_keepalive_delivers_t
     .await;
 
     let parked = match outcome {
-        Outcome::AwaitingApproval(latest) => latest,
+        Outcome::AwaitingApproval {
+            reply: latest,
+            approval_id: captured_id,
+        } => {
+            assert_eq!(captured_id.as_deref(), Some(approval_id));
+            latest
+        }
         other => {
             let _: i64 = redis::cmd("DEL")
                 .arg(&stream)

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -92,6 +92,8 @@ services:
     image: valkey/valkey:8-alpine
     profiles: *core_profiles
     command: ["valkey-server", "--requirepass", "${VALKEY_PASSWORD:-valkeypass}"]
+    environment:
+      VALKEY_PASSWORD: ${VALKEY_PASSWORD:-valkeypass}
     ports:
       - "26379:6379"
     volumes:

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -243,20 +243,6 @@ services:
         condition: service_completed_successfully
     environment:
       <<: *langfuse-env
-    # Port 3030 starts listening only after Langfuse initialization completes
-    # and app import registers the BullMQ OTel ingestion consumers. Without a
-    # healthcheck, `docker compose up --wait` returns while the container is
-    # merely running and a first trace can sit invisible until worker restart.
-    healthcheck:
-      test:
-        - CMD
-        - node
-        - -e
-        - "fetch('http://' + process.env.HOSTNAME + ':3030/').then((response) => { if (!response.ok) process.exit(1); }).catch(() => process.exit(1))"
-      interval: 2s
-      timeout: 5s
-      retries: 150
-      start_period: 5s
     restart: unless-stopped
 
   langfuse-web:

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -243,6 +243,20 @@ services:
         condition: service_completed_successfully
     environment:
       <<: *langfuse-env
+    # Port 3030 starts listening only after Langfuse initialization completes
+    # and app import registers the BullMQ OTel ingestion consumers. Without a
+    # healthcheck, `docker compose up --wait` returns while the container is
+    # merely running and a first trace can sit invisible until worker restart.
+    healthcheck:
+      test:
+        - CMD
+        - node
+        - -e
+        - "fetch('http://' + process.env.HOSTNAME + ':3030/').then((response) => { if (!response.ok) process.exit(1); }).catch(() => process.exit(1))"
+      interval: 2s
+      timeout: 5s
+      retries: 150
+      start_period: 5s
     restart: unless-stopped
 
   langfuse-web:

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -617,7 +617,9 @@ services:
       # The collector join is also what lets --local-model resolve ollama by name.
       # Both are overridable from the shell.
       #
-      # The endpoint default is what a full-profile `local up` gets. It uses the
+      # The worker itself uses host networking, while the runner joins
+      # `curie_runner`; they therefore need different addresses for the same
+      # Collector. The endpoint defaults use the
       # `${VAR-default}` form (substitute only when UNSET), not `${VAR:-default}`
       # (substitute when unset OR empty), so an explicit empty value means "no
       # endpoint". That is what lets `curie local up --minimal` suppress it:
@@ -635,7 +637,8 @@ services:
       # it to the worker, which forwards it into every claim's boot env.
       - CURIE_FALSE_COMPLETION_CHECK=${CURIE_FALSE_COMPLETION_CHECK:-}
       - CURIE_DOCKER_NETWORK=${CURIE_DOCKER_NETWORK:-curie_runner}
-      - OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT-http://otel-collector:4318}
+      - OTEL_EXPORTER_OTLP_ENDPOINT=${CURIE_WORKER_OTEL_EXPORTER_OTLP_ENDPOINT-${OTEL_EXPORTER_OTLP_ENDPOINT-http://127.0.0.1:24318}}
+      - CURIE_RUNNER_OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT-http://otel-collector:4318}
       - OTEL_EXPORTER_OTLP_PROTOCOL=${OTEL_EXPORTER_OTLP_PROTOCOL-http/protobuf}
       # config.py's connector_release/connector_namespace (CURIE_RELEASE /
       # CURIE_NAMESPACE) both default empty, which was built for the cluster

--- a/compose/tests/test_generate_release_compose.py
+++ b/compose/tests/test_generate_release_compose.py
@@ -11,6 +11,8 @@ hand-maintained compose.release.yaml, which has drifted from dev.
 """
 
 import importlib.util
+import json
+import os
 import re
 import shutil
 import subprocess
@@ -292,12 +294,12 @@ def resolve_shell_default(value):
     UNSET. The endpoint uses the `-` form specifically so `curie local up
     --minimal` can suppress it with an explicit empty override; under `:-` an
     empty value could never mean "no endpoint". Still intentionally narrow: no
-    `${VAR}`, `${VAR:?err}`, or nested forms.
+    `${VAR}` or `${VAR:?err}` forms. Nested defaults recurse.
     """
     if value is None:
         return None
     match = SHELL_DEFAULT_RE.match(value)
-    return match.group(1) if match else value
+    return resolve_shell_default(match.group(1)) if match else value
 
 
 def resolve_shell_interpolation(value, environ):
@@ -307,10 +309,10 @@ def resolve_shell_interpolation(value, environ):
         return value
     name = match.group("name")
     if name not in environ:
-        return match.group("default")
+        return resolve_shell_interpolation(match.group("default"), environ)
     resolved = environ[name]
     if match.group("colon") and resolved == "":
-        return match.group("default")
+        return resolve_shell_interpolation(match.group("default"), environ)
     return resolved
 
 
@@ -500,18 +502,25 @@ def test_worker_traces_to_shipped_collector_by_default():
     exporting it empty -- see `up_minimal_suppresses_otel_endpoint` in
     cli/src/local.rs, which is where the profile choice lives.
     """
-    expected = f"http://otel-collector:{collector_http_port()}"
+    expected_runner = f"http://otel-collector:{collector_http_port()}"
+    expected_worker = "http://127.0.0.1:24318"
     for label, doc in compose_docs():
         assert "otel-collector" in doc["services"], (
             f"{label}: otel-collector service not found in the compose document"
         )
         env = env_map(doc["services"]["curie-worker"])
         otel_endpoint = resolve_shell_default(env.get("OTEL_EXPORTER_OTLP_ENDPOINT"))
-        assert otel_endpoint == expected, (
+        assert otel_endpoint == expected_worker, (
             f"{label}: curie-worker OTEL_EXPORTER_OTLP_ENDPOINT resolves to "
-            f"{otel_endpoint!r}, expected {expected!r} (the collector's own "
-            f"OTLP/HTTP receiver); traces from spawned sandbox containers have "
-            f"nowhere to go"
+            f"{otel_endpoint!r}, expected {expected_worker!r}; the host-network "
+            "worker cannot resolve a Compose service name"
+        )
+        runner_endpoint = resolve_shell_default(
+            env.get("CURIE_RUNNER_OTEL_EXPORTER_OTLP_ENDPOINT")
+        )
+        assert runner_endpoint == expected_runner, (
+            f"{label}: runner OTLP endpoint resolves to {runner_endpoint!r}, "
+            f"expected {expected_runner!r} on the isolated runner network"
         )
         docker_network = resolve_shell_default(env.get("CURIE_DOCKER_NETWORK"))
         assert docker_network == "curie_runner", (
@@ -523,7 +532,7 @@ def test_worker_traces_to_shipped_collector_by_default():
         )
 
 
-@pytest.mark.parametrize("service_name", ["curie-api", "curie-dispatcher", "curie-worker"])
+@pytest.mark.parametrize("service_name", ["curie-api", "curie-dispatcher"])
 def test_platform_services_export_to_shipped_collector_by_default(service_name):
     """Every long-lived Python service gets the standard OTLP endpoint.
 
@@ -548,7 +557,59 @@ def test_platform_services_export_to_shipped_collector_by_default(service_name):
         )
 
 
-@pytest.mark.parametrize("service_name", ["curie-api", "curie-dispatcher", "curie-worker"])
+@pytest.mark.parametrize(
+    ("overrides", "worker_endpoint", "runner_endpoint"),
+    [
+        ({}, "http://127.0.0.1:24318", "http://otel-collector:4318"),
+        ({"OTEL_EXPORTER_OTLP_ENDPOINT": ""}, "", ""),
+        (
+            {"OTEL_EXPORTER_OTLP_ENDPOINT": "http://collector.example.com:4318"},
+            "http://collector.example.com:4318", "http://collector.example.com:4318",
+        ),
+        (
+            {
+                "OTEL_EXPORTER_OTLP_ENDPOINT": "http://collector.example.com:4318",
+                "CURIE_WORKER_OTEL_EXPORTER_OTLP_ENDPOINT": "",
+            },
+            "", "http://collector.example.com:4318",
+        ),
+        (
+            {
+                "OTEL_EXPORTER_OTLP_ENDPOINT": "http://otel-collector:4318",
+                "CURIE_WORKER_OTEL_EXPORTER_OTLP_ENDPOINT": "http://127.0.0.1:24318",
+            },
+            "http://127.0.0.1:24318", "http://otel-collector:4318",
+        ),
+    ],
+)
+def test_worker_endpoint_split_executes_compose_interpolation(
+    tmp_path, overrides, worker_endpoint, runner_endpoint
+):
+    """Use actual Compose interpolation, including explicit-empty negative paths."""
+    for label, doc in compose_docs():
+        worker_env = env_map(doc["services"]["curie-worker"])
+        selected = {
+            key: worker_env[key]
+            for key in ("OTEL_EXPORTER_OTLP_ENDPOINT", "CURIE_RUNNER_OTEL_EXPORTER_OTLP_ENDPOINT")
+        }
+        config = tmp_path / label
+        config.write_text(yaml.safe_dump({
+            "services": {"worker": {"image": "example-worker", "environment": selected}}
+        }))
+        clean_env = {key: value for key, value in os.environ.items() if key not in (
+            "OTEL_EXPORTER_OTLP_ENDPOINT", "CURIE_WORKER_OTEL_EXPORTER_OTLP_ENDPOINT"
+        )}
+        result = subprocess.run(
+            ["docker", "compose", "--env-file", "/dev/null", "-f", str(config),
+             "config", "--format", "json"],
+            env={**clean_env, **overrides}, capture_output=True, text=True, check=True,
+        )
+        rendered = json.loads(result.stdout)["services"]["worker"]["environment"]
+        assert rendered["OTEL_EXPORTER_OTLP_ENDPOINT"] == worker_endpoint
+        assert rendered["CURIE_RUNNER_OTEL_EXPORTER_OTLP_ENDPOINT"] == runner_endpoint
+
+
+@pytest.mark.parametrize("service_name", ["curie-api", "curie-dispatcher"])
 def test_platform_service_endpoint_explicit_empty_disables_export(service_name):
     """The minimal/core path can explicitly suppress the full-stack default.
 

--- a/compose/tests/test_generate_release_compose.py
+++ b/compose/tests/test_generate_release_compose.py
@@ -190,24 +190,6 @@ def test_rustfs_and_aws_bucket_bootstrap_preserve_the_s3_consumer_contract():
             assert consumer_env["LANGFUSE_S3_MEDIA_UPLOAD_FORCE_PATH_STYLE"] == "true"
 
 
-def test_langfuse_worker_readiness_gates_compose_wait():
-    """Do not accept OTel before the adopted ingest consumer is registered."""
-    for label, doc in compose_docs():
-        worker = doc["services"]["langfuse-worker"]
-        healthcheck = worker.get("healthcheck", {})
-        health_command = " ".join(str(part) for part in healthcheck.get("test", []))
-        assert healthcheck.get("test", [None])[0] == "CMD", (
-            f"{label} Langfuse worker readiness must be an executable healthcheck"
-        )
-        assert "node" in health_command and "process.env.HOSTNAME" in health_command, (
-            f"{label} Langfuse worker healthcheck must probe its post-initialization "
-            f"HTTP listener, got {health_command!r}"
-        )
-        assert healthcheck.get("start_period") and healthcheck.get("retries"), (
-            f"{label} Langfuse worker readiness must tolerate bounded first-boot initialization"
-        )
-
-
 def test_invariants_preserved_from_dev():
     generate = load_generate()
     out = generate(DEV_TEXT, OTEL_TEXT, version="9.9.9")

--- a/compose/tests/test_generate_release_compose.py
+++ b/compose/tests/test_generate_release_compose.py
@@ -190,6 +190,24 @@ def test_rustfs_and_aws_bucket_bootstrap_preserve_the_s3_consumer_contract():
             assert consumer_env["LANGFUSE_S3_MEDIA_UPLOAD_FORCE_PATH_STYLE"] == "true"
 
 
+def test_langfuse_worker_readiness_gates_compose_wait():
+    """Do not accept OTel before the adopted ingest consumer is registered."""
+    for label, doc in compose_docs():
+        worker = doc["services"]["langfuse-worker"]
+        healthcheck = worker.get("healthcheck", {})
+        health_command = " ".join(str(part) for part in healthcheck.get("test", []))
+        assert healthcheck.get("test", [None])[0] == "CMD", (
+            f"{label} Langfuse worker readiness must be an executable healthcheck"
+        )
+        assert "node" in health_command and "process.env.HOSTNAME" in health_command, (
+            f"{label} Langfuse worker healthcheck must probe its post-initialization "
+            f"HTTP listener, got {health_command!r}"
+        )
+        assert healthcheck.get("start_period") and healthcheck.get("retries"), (
+            f"{label} Langfuse worker readiness must tolerate bounded first-boot initialization"
+        )
+
+
 def test_invariants_preserved_from_dev():
     generate = load_generate()
     out = generate(DEV_TEXT, OTEL_TEXT, version="9.9.9")

--- a/compose/tests/test_local_observability_ladder.py
+++ b/compose/tests/test_local_observability_ladder.py
@@ -15,6 +15,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
 import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -809,10 +810,84 @@ def test_product_collector_restore_restarts_and_verifies_every_seed_emitter() ->
     assert (
         "export OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318" in restore
     )
+    assert (
+        "export CURIE_WORKER_OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:24318"
+        in restore
+    )
     assert "export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf" in restore
     assert "unset OTEL_EXPORTER_OTLP_ENDPOINT" not in restore
     for protocol in ("http/protobuf", "otel-collector:4318"):
         assert protocol in restore
+
+
+@pytest.mark.parametrize("owned", [0, 1])
+def test_current_source_images_survive_raw_compose_recreation(owned: int) -> None:
+    source = LADDER_PATH.read_text()
+    function = _shell_function(source, "pin_local_source_images")
+    keys = ("CURIE_BASE_TAG", "CURIE_RUNNER_IMAGE", "CURIE_DISPATCHER_IMAGE")
+    initial = dict.fromkeys(keys, "stale-example")
+    initial["OTEL_EXPORTER_OTLP_ENDPOINT"] = "http://collector.example.com:4318"
+    script = function + "\nLOCAL_STACK_OWNED=\"$1\"\npin_local_source_images\n"
+    script += (
+        "exec python3 -c 'import json,os; "
+        'print(json.dumps({key: os.environ[key] for key in '
+        '["CURIE_BASE_TAG", "CURIE_RUNNER_IMAGE", "CURIE_DISPATCHER_IMAGE", '
+        '"OTEL_EXPORTER_OTLP_ENDPOINT"]}))' + "'\n"
+    )
+    result = subprocess.run(
+        ["bash", "-c", script, "bash", str(owned)],
+        env={**os.environ, **initial}, text=True, capture_output=True, check=True,
+    )
+    child_env = json.loads(result.stdout)
+    expected = {
+        "CURIE_BASE_TAG": "dev",
+        "CURIE_RUNNER_IMAGE": "ghcr.io/curie-eng/curie-runner:dev",
+        "CURIE_DISPATCHER_IMAGE": "ghcr.io/curie-eng/curie-dispatcher:dev",
+    } if owned else {key: initial[key] for key in keys}
+    assert {key: child_env[key] for key in keys} == expected
+    assert child_env["OTEL_EXPORTER_OTLP_ENDPOINT"] == initial["OTEL_EXPORTER_OTLP_ENDPOINT"]
+    rung = _shell_function(source, "rung_local")
+    assert rung.index('"$BIN" "${up_args[@]}"') < rung.index("pin_local_source_images")
+    assert rung.index("pin_local_source_images") < rung.index("case_local_otel")
+
+
+@pytest.mark.parametrize(
+    ("response", "exit_code", "category"),
+    [
+        ({"error": "private-error-canary", "fix": "private-fix-canary"}, 3, "query-error"),
+        ({"trace": {}, "tree": []}, 0, "malformed-response"),
+        ({"trace": {"id": "a" * 32}, "tree": [{
+            "name": "agent.run", "type": "SPAN", "children": [],
+            "input": "private-input-canary",
+        }]}, 0, "incomplete-membership"),
+    ],
+)
+def test_exact_query_failure_reports_sanitized_reason(
+    tmp_path: Path, response: dict, exit_code: int, category: str
+) -> None:
+    source = LADDER_PATH.read_text()
+    fake_bin = tmp_path / "curie"
+    fake_bin.write_text('#!/bin/sh\nprintf "%s\\n" "$FAKE_RESPONSE"\nexit "$FAKE_EXIT"\n')
+    fake_bin.chmod(0o700)
+    script = _shell_function(source, "sanitize_exact_trace_read")
+    script += _shell_function(source, "query_exact_seed_trace")
+    script += '''
+WORKDIR="$1"
+BIN="$2"
+OBSERVABILITY_POLL_ATTEMPTS=1
+OBSERVABILITY_POLL_INTERVAL_SECONDS=0
+query_exact_seed_trace local aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa curie.queue.enqueue "" present
+'''
+    result = subprocess.run(
+        ["bash", "-c", script, "bash", str(tmp_path), str(fake_bin)],
+        env={**os.environ, "FAKE_RESPONSE": json.dumps(response), "FAKE_EXIT": str(exit_code)},
+        text=True, capture_output=True, check=False,
+    )
+    assert result.returncode == 1
+    assert category in result.stderr
+    assert "private-" not in result.stderr + result.stdout
+    if category == "incomplete-membership":
+        assert '"operation":["agent.run"]' in result.stderr
 
 
 def test_invalid_langfuse_auth_is_temporary_durable_and_recovers_the_same_id(

--- a/compose/tests/test_local_observability_ladder.py
+++ b/compose/tests/test_local_observability_ladder.py
@@ -743,6 +743,53 @@ def test_approval_resume_failure_evidence_is_bounded_and_private_artifacts_are_c
     assert "PRIVATE_PARSE_STDERR_SENTINEL" not in parse_result.stdout + parse_result.stderr
 
 
+def test_approval_seed_background_message_is_owned_by_global_cleanup() -> None:
+    """Every approval-seed exit path must release its Slack stub before teardown."""
+
+    source = LADDER_PATH.read_text()
+    trap = _shell_function(source, "cleanup")
+    approval = _shell_function(source, "seed_approval_resume_turn")
+
+    assert "APPROVAL_SEED_MESSAGE_PID=$!" in approval
+    assert "stop_approval_seed_message terminate || true" in trap
+    assert trap.index("stop_approval_seed_message terminate || true") < trap.index(
+        '"$BIN" local down'
+    ), "the background Slack stub must stop before its stack is torn down"
+    assert approval.count("stop_approval_seed_message terminate || true") == 2
+    assert "stop_approval_seed_message || code=$?" in approval
+    for stale_local_wait in ('kill "$message_pid"', 'wait "$message_pid"'):
+        assert stale_local_wait not in approval
+
+
+def test_approval_seed_cleanup_terminates_and_clears_a_stale_pid() -> None:
+    """An interrupted seed cannot leave its background Slack stub alive."""
+
+    source = LADDER_PATH.read_text()
+    stop = _shell_function(source, "stop_approval_seed_message")
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            f"""set -u
+{stop}
+APPROVAL_SEED_MESSAGE_PID=""
+sleep 30 &
+stale_pid=$!
+APPROVAL_SEED_MESSAGE_PID="$stale_pid"
+stop_approval_seed_message terminate || true
+[[ -z "$APPROVAL_SEED_MESSAGE_PID" ]]
+if kill -0 "$stale_pid" 2>/dev/null; then
+    exit 9
+fi
+""",
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+
+
 def test_product_collector_restore_restarts_and_verifies_every_seed_emitter() -> None:
     """Worker-only restore cannot prove dispatcher, API, or runner delivery."""
 

--- a/compose/tests/test_local_observability_ladder.py
+++ b/compose/tests/test_local_observability_ladder.py
@@ -806,6 +806,11 @@ def test_product_collector_restore_restarts_and_verifies_every_seed_emitter() ->
             "or launched after product routing is restored"
         )
     assert "assert_product_collector_endpoint" in restore
+    assert (
+        "export OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318" in restore
+    )
+    assert "export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf" in restore
+    assert "unset OTEL_EXPORTER_OTLP_ENDPOINT" not in restore
     for protocol in ("http/protobuf", "otel-collector:4318"):
         assert protocol in restore
 

--- a/compose/tests/test_local_observability_ladder.py
+++ b/compose/tests/test_local_observability_ladder.py
@@ -131,6 +131,62 @@ classify_product_observability_owner
     )
 
 
+def _run_local_exact_positive(
+    tmp_path: Path,
+    *,
+    operations: tuple[str, ...],
+    expected_state: str = "present",
+) -> subprocess.CompletedProcess[str]:
+    """Drive the production local exact-read positive against a candidate CLI."""
+
+    source = LADDER_PATH.read_text()
+    sanitizer = _shell_function(source, "sanitize_exact_trace_read")
+    query = _shell_function(source, "query_exact_seed_trace")
+    trace_id = "a" * 32
+    response = tmp_path / "response.json"
+    response.write_text(
+        json.dumps(
+            {
+                "trace": {"id": trace_id},
+                "tree": [
+                    {"name": operation, "type": "SPAN", "children": []}
+                    for operation in operations
+                ],
+                "approval_decision": None,
+            }
+        )
+    )
+    fake_bin = tmp_path / "curie"
+    fake_bin.write_text('#!/bin/sh\ncat "$FAKE_TRACE_RESPONSE"\n')
+    fake_bin.chmod(0o700)
+    script = f"""set -u
+{sanitizer}
+{query}
+WORKDIR="$1"
+BIN="$2"
+OBSERVABILITY_POLL_ATTEMPTS=1
+OBSERVABILITY_POLL_INTERVAL_SECONDS=0
+CURIE_NAMESPACE=acme-observability
+CURIE_RELEASE=acme-observability
+query_exact_seed_trace local {trace_id} "curie.queue.enqueue,curie.reply.post" "" "$3"
+"""
+    return subprocess.run(
+        [
+            "bash",
+            "-c",
+            script,
+            "bash",
+            str(tmp_path),
+            str(fake_bin),
+            expected_state,
+        ],
+        env={**os.environ, "FAKE_TRACE_RESPONSE": str(response)},
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
 def test_local_ladder_owns_a_real_queryable_otlp_sink() -> None:
     """A plain local rung must create, query, and remove its own OTLP sink."""
 
@@ -722,6 +778,49 @@ def test_invalid_langfuse_auth_is_temporary_durable_and_recovers_the_same_id(
     ), "the same ID must be absent during failure and present after recovery"
 
 
+def test_default_local_exact_positive_rejects_incomplete_membership(
+    tmp_path: Path,
+) -> None:
+    """Normal local is strict; only ownership diagnostics may retain a miss."""
+
+    source = LADDER_PATH.read_text()
+    rung = _function_body(source, "rung_local", "# local-release mode:")
+    assert "product_query_state=present" in rung
+    assert 'if [[ "$PRODUCT_OBSERVABILITY" == "1" ]]' in rung
+    assert rung.count("product_query_state=observe") == 1
+    assert 'seed_ordinary_turn local "$agent_id" "$product_query_state"' in rung
+    assert "invalid-auth negative skipped" not in rung
+
+    complete_dir = tmp_path / "complete"
+    complete_dir.mkdir()
+    complete = _run_local_exact_positive(
+        complete_dir,
+        operations=("curie.queue.enqueue", "curie.reply.post"),
+    )
+    assert complete.returncode == 0, complete.stderr
+
+    incomplete_dir = tmp_path / "incomplete"
+    incomplete_dir.mkdir()
+    incomplete = _run_local_exact_positive(
+        incomplete_dir,
+        operations=("curie.queue.enqueue",),
+    )
+    assert incomplete.returncode != 0, (
+        "the default local positive must fail when exact Langfuse membership is incomplete"
+    )
+
+    diagnostic_dir = tmp_path / "diagnostic"
+    diagnostic_dir.mkdir()
+    diagnostic = _run_local_exact_positive(
+        diagnostic_dir,
+        operations=("curie.queue.enqueue",),
+        expected_state="observe",
+    )
+    assert diagnostic.returncode == 0, (
+        "only explicit product ownership diagnostics may retain incomplete membership"
+    )
+
+
 def test_cluster_product_observability_is_private_preflight_and_query_only() -> None:
     """The ladder may inspect a task release but must never install or remove it."""
 
@@ -918,6 +1017,9 @@ def test_adopted_component_stop_requires_successful_export_on_both_product_surfa
 
     cases = (
         (None, None, "curie-unresolved", False),
+        (record(membership=True, same_id_raw=False), None, "curie-clear", True),
+        (None, record(membership=True, same_id_raw=False), "curie-clear", True),
+        (record(membership=False, same_id_raw=False), None, "curie-unresolved", False),
         (
             {
                 key: value

--- a/compose/tests/test_local_observability_ladder.py
+++ b/compose/tests/test_local_observability_ladder.py
@@ -100,6 +100,37 @@ query_exact_seed_trace local aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa "" "" absent
     return result, int(count.read_text()) if count.exists() else 0
 
 
+def _run_product_classifier(
+    tmp_path: Path,
+    *,
+    local: dict[str, object] | None,
+    cluster: dict[str, object] | None,
+) -> subprocess.CompletedProcess[str]:
+    """Execute the production ownership classifier against explicit evidence."""
+
+    function = _shell_function(
+        LADDER_PATH.read_text(), "classify_product_observability_owner"
+    )
+    local_path = tmp_path / "local.json"
+    cluster_path = tmp_path / "cluster.json"
+    if local is not None:
+        local_path.write_text(json.dumps({**local, "surface": "local"}))
+    if cluster is not None:
+        cluster_path.write_text(json.dumps({**cluster, "surface": "cluster"}))
+    script = f"""set -u
+{function}
+LOCAL_PRODUCT_EVIDENCE="$1"
+CLUSTER_PRODUCT_EVIDENCE="$2"
+classify_product_observability_owner
+"""
+    return subprocess.run(
+        ["bash", "-c", script, "bash", str(local_path), str(cluster_path)],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
 def test_local_ladder_owns_a_real_queryable_otlp_sink() -> None:
     """A plain local rung must create, query, and remove its own OTLP sink."""
 
@@ -718,9 +749,22 @@ def test_cluster_product_observability_is_private_preflight_and_query_only() -> 
     mode = _shell_function(source, "run_cluster_product_observability")
     wrapper = _shell_function(source, "rung_cluster_product")
     assert "preflight_cluster_product_observability" in mode
-    assert "seed_ordinary_turn" in mode
-    assert "seed_approval_resume_turn" in mode
+    assert "seed_cluster_missing_carrier_control" in mode
+    assert "cluster_external_ingress_seed" in mode
+    assert "CURIE_E2E_CLUSTER_EXTERNAL_INGRESS_RECEIPT" in source
+    assert "CURIE_E2E_PRODUCT_RUN_ID" in source
+    assert "otelcol_receiver_accepted_spans_delta" in source
+    assert "otelcol_exporter_sent_spans_delta" in source
     assert "cluster observability run" in mode
+    for manufactured in (
+        "enqueue_cluster_carried_turn",
+        "CLUSTER_SEEDED_TRACE_ID",
+        "secrets.token_hex",
+    ):
+        assert manufactured not in source, (
+            "cluster correlation evidence must be derived from a real accepted "
+            f"ingress path, not manufactured by the harness: {manufactured}"
+        )
     assert "cluster deploy" in wrapper, (
         "the wrapper must retain the intended agent seed deployment"
     )
@@ -750,7 +794,86 @@ def test_cluster_product_observability_is_private_preflight_and_query_only() -> 
     )
 
 
-def test_adopted_component_stop_requires_successful_export_on_both_product_surfaces() -> None:
+def test_cluster_carrierless_control_and_external_slack_carrier_are_executed(
+    tmp_path: Path,
+) -> None:
+    """The fake cluster path stays negative; only Slack ingress can be positive."""
+
+    source = LADDER_PATH.read_text()
+    marker = "curie-seed-external-ordinary-example"
+    trace_id = "a" * 32
+    span_id = "b" * 16
+    payload_only = [
+        "2-0",
+        [
+            "payload",
+            json.dumps(
+                {
+                    "text": f"missing carrier compatibility {marker}",
+                    "reply_handle": {"adapter": "curie-cluster-message"},
+                }
+            ),
+        ],
+    ]
+    carried_slack = [
+        "3-0",
+        [
+            "payload",
+            json.dumps(
+                {
+                    "text": f"ordinary correlation {marker}",
+                    "reply_handle": {"kind": "slack", "adapter": None},
+                }
+            ),
+            "traceparent",
+            f"00-{trace_id}-{span_id}-01",
+        ],
+    ]
+
+    negative = _run_seed_matcher(
+        tmp_path,
+        _python_heredoc(_shell_function(source, "seed_cluster_missing_carrier_control")),
+        marker,
+        [payload_only],
+    )
+    assert negative.returncode == 0, negative.stderr
+
+    external_matcher = _python_heredoc(
+        _shell_function(source, "discover_cluster_external_trace_id")
+    )
+    positive = _run_seed_matcher(tmp_path, external_matcher, marker, [carried_slack])
+    assert positive.returncode == 0, positive.stderr
+    assert positive.stdout.strip() == trace_id
+
+    forged = _run_seed_matcher(
+        tmp_path,
+        external_matcher,
+        marker,
+        [
+            [
+                "4-0",
+                [
+                    "payload",
+                    json.dumps(
+                        {
+                            "text": f"ordinary correlation {marker}",
+                            "reply_handle": {"adapter": "curie-cluster-message"},
+                        }
+                    ),
+                    "traceparent",
+                    f"00-{trace_id}-{span_id}-01",
+                ],
+            ]
+        ],
+    )
+    assert forged.returncode != 0, (
+        "a harness/cluster-message-shaped entry must not satisfy real Slack ingress"
+    )
+
+
+def test_adopted_component_stop_requires_successful_export_on_both_product_surfaces(
+    tmp_path: Path,
+) -> None:
     """Selective ingest loss is a dependency blocker only after Curie is cleared."""
 
     source = LADDER_PATH.read_text()
@@ -764,6 +887,8 @@ def test_adopted_component_stop_requires_successful_export_on_both_product_surfa
         "cluster",
         "image_ids_match",
         "seed_valid",
+        "same_id_raw_collector_receipt",
+        "run_id",
         "adopted-component",
     ):
         assert required in decision, f"ownership classification omits {required!r}"
@@ -773,3 +898,64 @@ def test_adopted_component_stop_requires_successful_export_on_both_product_surfa
     assert decision.index("langfuse_observation_membership") < decision.index(
         "adopted-component"
     )
+
+    def record(
+        *,
+        membership: bool,
+        same_id_raw: bool = True,
+        run_id: str = "run-example",
+    ) -> dict[str, object]:
+        return {
+            "run_id": run_id,
+            "seed_valid": True,
+            "same_id_raw_collector_receipt": same_id_raw,
+            "raw_emitted_observations": 3,
+            "otelcol_receiver_accepted_spans": 3,
+            "otelcol_exporter_sent_spans": 3,
+            "langfuse_observation_membership": membership,
+            "image_ids_match": True,
+        }
+
+    cases = (
+        (None, None, "curie-unresolved", False),
+        (
+            {
+                key: value
+                for key, value in record(membership=True).items()
+                if key != "langfuse_observation_membership"
+            },
+            record(membership=True),
+            "curie-unresolved",
+            False,
+        ),
+        (
+            record(membership=True, run_id="run-one"),
+            record(membership=True, run_id="run-two"),
+            "curie-unresolved",
+            False,
+        ),
+        (record(membership=False), record(membership=False), "adopted-component", False),
+        (
+            record(membership=False, same_id_raw=False),
+            record(membership=False, same_id_raw=False),
+            "curie-unresolved",
+            False,
+        ),
+        (record(membership=True), record(membership=False), "curie-owned", False),
+        (
+            record(membership=True, same_id_raw=False),
+            record(membership=True),
+            "curie-clear",
+            True,
+        ),
+        (record(membership=True), record(membership=True), "curie-clear", True),
+    )
+    for index, (local, cluster, verdict, succeeds) in enumerate(cases):
+        case_dir = tmp_path / str(index)
+        case_dir.mkdir()
+        result = _run_product_classifier(case_dir, local=local, cluster=cluster)
+        assert verdict in result.stdout
+        assert (result.returncode == 0) is succeeds, (
+            "only complete same-run, positive export and exact membership may "
+            f"clear the STOP; verdict={verdict} stdout={result.stdout!r}"
+        )

--- a/compose/tests/test_local_observability_ladder.py
+++ b/compose/tests/test_local_observability_ladder.py
@@ -15,6 +15,7 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parents[2]
 LADDER_PATH = REPO_ROOT / "cli" / "scripts" / "e2e-ladder.sh"
 SINK_CONFIG_PATH = REPO_ROOT / "cli" / "scripts" / "fixtures" / "otel-e2e-sink-config.yaml"
+MCP_RECEIPT_FIXTURE = REPO_ROOT / "cli" / "scripts" / "fixtures" / "mcp-receipt"
 
 
 def _function_body(source: str, name: str, next_marker: str) -> str:
@@ -22,6 +23,16 @@ def _function_body(source: str, name: str, next_marker: str) -> str:
     assert start_marker in source, f"{LADDER_PATH}: missing {name}"
     start = source.index(start_marker)
     end = source.index(next_marker, start)
+    return source[start:end]
+
+
+def _shell_function(source: str, name: str) -> str:
+    """Return one top-level shell function without depending on its successor."""
+
+    start_marker = f"{name}() {{"
+    assert start_marker in source, f"{LADDER_PATH}: missing {name}"
+    start = source.index(start_marker)
+    end = source.index("\n}\n", start) + len("\n}\n")
     return source[start:end]
 
 
@@ -242,4 +253,220 @@ def test_local_otel_controls_distinguish_a_live_sink_from_a_turn() -> None:
     )
     assert "sleep 12" in helper, (
         "the failure baseline must outwait the 10-second metric export interval"
+    )
+
+
+def test_product_oracle_discovers_only_the_seed_trace_from_bounded_transport() -> None:
+    """A background/newest trace must be unable to satisfy the turn oracle."""
+
+    source = LADDER_PATH.read_text()
+    assert "local observability runs --limit 100" not in source, (
+        "a newest-runs page can select an unrelated background trace; exact discovery "
+        "must start from the seeded stream entry"
+    )
+
+    discover = _shell_function(source, "discover_trace_id_for_seed")
+    for required in (
+        "stream_start",
+        "stream_end",
+        "marker",
+        "XRANGE",
+        "traceparent",
+        "[0-9a-f]{32}",
+        "umask 077",
+    ):
+        assert required in discover, (
+            "exact discovery must inspect only the marker's bounded stream slice, "
+            f"validate its adjacent W3C carrier, and keep raw fields private; missing {required!r}"
+        )
+    assert "printf '%s\\n' \"$payload\"" not in discover
+    assert "printf '%s\\n' \"$traceparent\"" not in discover
+
+    query = _shell_function(source, "query_exact_seed_trace")
+    assert 'observability run "$trace_id"' in query
+    assert "sanitize_exact_trace_read" in query
+    assert "observability runs" not in query
+    assert "printf '%s\\n' \"$out\"" not in query, (
+        "raw Langfuse JSON may contain prompt, user, session, and deployment fields"
+    )
+    sanitizer = _shell_function(source, "sanitize_exact_trace_read")
+    for allowed in (
+        "trace_id",
+        "service",
+        "operation",
+        "observation_count",
+        "observation_type",
+        "approval_decision",
+    ):
+        assert allowed in sanitizer, f"sanitized evidence omits safe field {allowed!r}"
+    for private in ("input", "output", "session", "user", "headers"):
+        assert private in sanitizer, (
+            f"sanitizer must explicitly prevent raw {private!r} from reaching stdout"
+        )
+
+
+def test_ordinary_mcp_and_approval_seeds_have_independent_receipts() -> None:
+    """An unexercised seed is seed-invalid before telemetry is interpreted."""
+
+    source = LADDER_PATH.read_text()
+    for name, required in {
+        "seed_ordinary_turn": ("assert_finalized_reply", "ordinary", "seed-invalid"),
+        "seed_mcp_read_turn": ("mcp_receipt_call_count", "seed-invalid"),
+        "seed_approval_resume_turn": (
+            "awaiting-approval",
+            "pending",
+            "resolve",
+            "assert_finalized_reply",
+            "seed-invalid",
+        ),
+    }.items():
+        body = _shell_function(source, name)
+        missing = [marker for marker in required if marker not in body]
+        assert not missing, f"{name} lacks independent outcome evidence: {missing}"
+        assert "discover_trace_id_for_seed" in body
+        assert "query_exact_seed_trace" in body
+
+    assert "seed-invalid" in source
+    assert MCP_RECEIPT_FIXTURE.is_dir(), (
+        "the MCP observation needs a hosted fixture whose container log is an "
+        "independent tools/call receipt ledger"
+    )
+    server = MCP_RECEIPT_FIXTURE / "server.py"
+    assert server.is_file()
+    fixture_source = server.read_text()
+    assert '"tools/call"' in fixture_source
+    assert "print(" in fixture_source
+    assert "flush=True" in fixture_source
+
+    receipt = _shell_function(source, "mcp_receipt_call_count")
+    assert "connector_container_for_alias" in receipt
+    assert "docker logs" in receipt or "kubectl logs" in receipt
+    assert "wc -l" in receipt or "count" in receipt
+    for forbidden in ("tool input", "arguments", "receipt line"):
+        assert forbidden not in receipt.lower(), (
+            "public evidence may expose only an aggregate MCP call count"
+        )
+
+
+def test_product_collector_restore_restarts_and_verifies_every_seed_emitter() -> None:
+    """Worker-only restore cannot prove dispatcher, API, or runner delivery."""
+
+    source = LADDER_PATH.read_text()
+    restore = _shell_function(source, "route_local_observability_to_product_collector")
+    for service in (
+        "curie-api",
+        "curie-dispatcher",
+        "curie-worker",
+        "curie-runner",
+    ):
+        assert service in restore, (
+            f"{service} can keep the disposable sink endpoint unless it is recreated "
+            "or launched after product routing is restored"
+        )
+    assert "assert_product_collector_endpoint" in restore
+    for protocol in ("http/protobuf", "otel-collector:4318"):
+        assert protocol in restore
+
+
+def test_invalid_langfuse_auth_is_temporary_durable_and_recovers_the_same_id() -> None:
+    """Pin the real backend negative without redefining exporter semantics."""
+
+    source = LADDER_PATH.read_text()
+    negative = _shell_function(source, "case_local_langfuse_invalid_auth")
+
+    # Observed shipped behavior, not an assumed external-API contract:
+    # otel/collector-config.yaml enables retry_on_failure at 5s/30s/5m and a
+    # file_storage-backed sending_queue of 1000. Therefore invalid auth is a
+    # bounded temporary absence, and success means recovery of the same queued
+    # trace ID after restoring auth, never permanent loss or a fresh control ID.
+    for required in (
+        "LANGFUSE_OTLP_AUTH_HEADER",
+        "INVALID_LANGFUSE_OTLP_AUTH_HEADER",
+        "langfuse-web",
+        "otelcol_receiver_accepted_spans",
+        "otelcol_exporter_send_failed_spans",
+        "sending_queue",
+        "file_storage",
+        "queue_size",
+        "Ready",
+        "restart",
+        "same_queued_trace_id",
+        "query_exact_seed_trace",
+        "queue_drained",
+    ):
+        assert required in negative, f"invalid-auth proof omits {required!r}"
+    assert "down -v" not in negative
+    assert negative.index("INVALID_LANGFUSE_OTLP_AUTH_HEADER") < negative.index(
+        "same_queued_trace_id"
+    )
+    assert negative.count("same_queued_trace_id") >= 2, (
+        "the ID observed absent while auth is invalid must be the ID recovered "
+        "after the queue-preserving restart"
+    )
+
+
+def test_cluster_product_observability_is_private_preflight_and_query_only() -> None:
+    """The ladder may inspect a task release but must never install or remove it."""
+
+    source = LADDER_PATH.read_text()
+    preflight = _shell_function(source, "preflight_cluster_product_observability")
+    for required in (
+        "CURIE_NAMESPACE",
+        "CURIE_RELEASE",
+        "default",
+        "curie",
+        "langfuse",
+        "otel-collector",
+        "api",
+        "worker",
+        "runner-prewarm",
+        "imageID",
+        "docker image inspect",
+        "curie-api:local",
+        "curie-worker:local",
+        "curie-runner:latest",
+        "mismatch",
+    ):
+        assert required in preflight, f"cluster preflight omits {required!r}"
+
+    mode = _shell_function(source, "run_cluster_product_observability")
+    assert "preflight_cluster_product_observability" in mode
+    assert "seed_ordinary_turn" in mode
+    assert "seed_approval_resume_turn" in mode
+    assert "cluster observability run" in mode
+    for mutating in (
+        "cluster up",
+        "cluster down",
+        "helm install",
+        "helm upgrade",
+        "helm uninstall",
+        "kubectl delete",
+    ):
+        assert mutating not in mode, (
+            f"product-observability mode must be preflight/query-only, found {mutating!r}"
+        )
+
+
+def test_adopted_component_stop_requires_successful_export_on_both_product_surfaces() -> None:
+    """Selective ingest loss is a dependency blocker only after Curie is cleared."""
+
+    source = LADDER_PATH.read_text()
+    decision = _shell_function(source, "classify_product_observability_owner")
+    for required in (
+        "raw_emitted_observations",
+        "otelcol_receiver_accepted_spans",
+        "otelcol_exporter_sent_spans",
+        "langfuse_observation_membership",
+        "local",
+        "cluster",
+        "image_ids_match",
+        "seed_valid",
+        "adopted-component",
+    ):
+        assert required in decision, f"ownership classification omits {required!r}"
+    assert decision.index("otelcol_exporter_sent_spans") < decision.index(
+        "adopted-component"
+    )
+    assert decision.index("langfuse_observation_membership") < decision.index(
+        "adopted-component"
     )

--- a/compose/tests/test_local_observability_ladder.py
+++ b/compose/tests/test_local_observability_ladder.py
@@ -890,7 +890,7 @@ query_exact_seed_trace local aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa curie.queue.enqueu
         assert '"operation":["agent.run"]' in result.stderr
 
 
-def test_invalid_langfuse_auth_is_temporary_durable_and_recovers_the_same_id(
+def test_invalid_langfuse_auth_proves_permanent_rejection_and_fresh_recovery(
     tmp_path: Path,
 ) -> None:
     """Pin the real backend negative without redefining exporter semantics."""
@@ -899,35 +899,29 @@ def test_invalid_langfuse_auth_is_temporary_durable_and_recovers_the_same_id(
     negative = _shell_function(source, "case_local_langfuse_invalid_auth")
     query = _shell_function(source, "query_exact_seed_trace")
 
-    # Observed shipped behavior, not an assumed external-API contract:
-    # otel/collector-config.yaml enables retry_on_failure at 5s/30s/5m and a
-    # file_storage-backed sending_queue of 1000. Therefore invalid auth is a
-    # bounded temporary absence, and success means recovery of the same queued
-    # trace ID after restoring auth, never permanent loss or a fresh control ID.
+    # OTLP requires retry for only 429/502/503/504; 401 MUST NOT be retried:
+    # https://opentelemetry.io/docs/specs/otlp/#retryable-response-codes
+    # The pinned Collector reports accepted+failed spans, permanent401 rejection,
+    # and queue0. Restored credentials must admit a NEW complete trace, not
+    # replay a permanently rejected batch.
     for required in (
         "LANGFUSE_OTLP_AUTH_HEADER",
         "INVALID_LANGFUSE_OTLP_AUTH_HEADER",
         "langfuse-web",
         "otelcol_receiver_accepted_spans",
         "otelcol_exporter_send_failed_spans",
-        "sending_queue",
-        "file_storage",
         "queue_size",
         "Ready",
         "restart",
-        "same_queued_trace_id",
+        "failed_trace_id",
+        "recovered_trace_id",
+        "HTTP Status Code 401",
+        "Permanent error",
         "query_exact_seed_trace",
-        "queue_drained",
     ):
         assert required in negative, f"invalid-auth proof omits {required!r}"
     assert "down -v" not in negative
-    assert negative.index("INVALID_LANGFUSE_OTLP_AUTH_HEADER") < negative.index(
-        "same_queued_trace_id"
-    )
-    assert negative.count("same_queued_trace_id") >= 2, (
-        "the ID observed absent while auth is invalid must be the ID recovered "
-        "after the queue-preserving restart"
-    )
+    assert "same_queued_trace_id" not in negative
 
     invalid_auth = negative.index(
         'export LANGFUSE_OTLP_AUTH_HEADER="$INVALID_LANGFUSE_OTLP_AUTH_HEADER"'
@@ -937,21 +931,6 @@ def test_invalid_langfuse_auth_is_temporary_durable_and_recovers_the_same_id(
         "a successful exact read under valid auth must discriminate backend/query "
         "health before the credential is made invalid"
     )
-
-    # Restart once while auth is still invalid, then re-observe both queued
-    # failure and stable absence. Restoring auth is a later, separate restart.
-    before_restore = negative[: negative.index("restore_local_langfuse_auth")]
-    restart_positions = [
-        match.start()
-        for match in re.finditer("restart_local_product_collector", before_restore)
-    ]
-    assert len(restart_positions) >= 2, (
-        "the file-backed queue must survive a Collector restart while auth remains invalid"
-    )
-    after_invalid_restart = before_restore[restart_positions[1] :]
-    assert "otelcol_exporter_queue_size" in after_invalid_restart
-    assert "otelcol_exporter_send_failed_spans" in after_invalid_restart
-    assert "query_exact_seed_trace" in after_invalid_restart
 
     # Execute the production query helper: absence is a bounded observation,
     # not one lucky first poll, and only the stable not-found error is accepted.
@@ -975,11 +954,11 @@ def test_invalid_langfuse_auth_is_temporary_durable_and_recovers_the_same_id(
     )
 
     absent_call = re.search(
-        r'query_exact_seed_trace local "\$same_queued_trace_id"[^\n]*absent',
+        r'query_exact_seed_trace local "\$failed_trace_id"[^\n]*absent',
         negative,
     )
     recovered_call = re.search(
-        r'query_exact_seed_trace local "\$same_queued_trace_id"\s*$',
+        r'query_exact_seed_trace local "\$recovered_trace_id"',
         negative,
         re.MULTILINE,
     )
@@ -987,7 +966,89 @@ def test_invalid_langfuse_auth_is_temporary_durable_and_recovers_the_same_id(
         absent_call
         and recovered_call
         and absent_call.start() < recovered_call.start()
-    ), "the same ID must be absent during failure and present after recovery"
+    ), "the failed ID must be absent before a new complete recovery trace"
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        "", "no-failed-metric", "no-rejection-log", "stuck-queue", "restart",
+        "reply", "absence", "restore", "recovery-query",
+    ],
+)
+def test_invalid_auth_requires_every_observation_and_always_restores(
+    tmp_path: Path, failure: str,
+) -> None:
+    """Execute the real gate under conditional Bash semantics (errexit disabled)."""
+    source = LADDER_PATH.read_text()
+    function = _shell_function(source, "assert_product_collector_permanent_auth_rejection")
+    function += _shell_function(source, "case_local_langfuse_invalid_auth")
+    script = r'''
+set -u -o pipefail
+WORKDIR="$1"
+REPO_ROOT="$2"
+FAILURE="$3"
+BIN=true
+LAST_ORDINARY_TRACE_ID=cccccccccccccccccccccccccccccccc
+sleep() { :; }
+docker() {
+    if [[ "$1" == logs ]]; then
+        [[ "$FAILURE" == no-rejection-log ]] ||
+            printf '%s\n' 'Permanent error: HTTP Status Code 401; not retryable error'
+    else
+        printf '%s\n' acme-collector
+    fi
+}
+restart_local_product_collector() { [[ "$FAILURE" != restart ]]; }
+wait_product_collector_ready() { return 0; }
+restore_local_langfuse_auth() {
+    printf '%s\n' restored >> "$WORKDIR/events"
+    [[ "$FAILURE" != restore ]]
+}
+assert_finalized_reply() { [[ "$FAILURE" != reply ]]; }
+assert_product_runner_endpoints() { return 0; }
+seed_ordinary_turn() { LAST_ORDINARY_TRACE_ID=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb; }
+capture_stream_cursor() { printf '%s\n' 1-0; }
+discover_trace_id_for_seed() {
+    if [[ -e "$WORKDIR/seeded" ]]; then
+        printf '%s\n' bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+    else
+        touch "$WORKDIR/seeded"
+        printf '%s\n' aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    fi
+}
+product_collector_metric_value() {
+    local count=0 file="$WORKDIR/$1"
+    [[ ! -e "$file" ]] || read -r count < "$file"
+    printf '%s\n' "$((count + 1))" > "$file"
+    case "$1" in
+        *queue_size) [[ "$FAILURE" != stuck-queue ]] && echo 0 || echo 1 ;;
+        *send_failed_spans)
+            [[ "$FAILURE" != no-failed-metric && "$count" -gt 0 ]] && echo 10 || echo 0 ;;
+        *accepted_spans) [[ "$count" -gt 0 ]] && echo 10 || echo 0 ;;
+    esac
+}
+query_exact_seed_trace() {
+    printf '%s\n' "query:$2:${3-}:${5-}" >> "$WORKDIR/events"
+    [[ "$2" != bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb || "$FAILURE" != recovery-query ]] || return 1
+    [[ "${5-}" != absent || "$FAILURE" != absence ]]
+}
+'''
+    script += function
+    script += '\nif case_local_langfuse_invalid_auth acme-agent; then exit 0; else exit 1; fi\n'
+    result = subprocess.run(
+        ["bash", "-c", script, "bash", str(tmp_path), str(REPO_ROOT), failure],
+        text=True, capture_output=True, check=False,
+    )
+    events = (tmp_path / "events").read_text()
+    assert events.count("restored") == 1
+    assert result.returncode == (1 if failure else 0), result.stderr
+    recovered = "query:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:curie.queue.enqueue,curie.queue.process"
+    if failure and failure != "recovery-query":
+        assert recovered not in events
+    else:
+        assert recovered in events
+        assert events.index(":absent") < events.index("restored") < events.index(recovered)
 
 
 def test_default_local_exact_positive_rejects_incomplete_membership(

--- a/compose/tests/test_local_observability_ladder.py
+++ b/compose/tests/test_local_observability_ladder.py
@@ -211,7 +211,9 @@ def test_local_ladder_owns_a_real_queryable_otlp_sink() -> None:
     # The sink has to exist before `local up`, because service startup telemetry
     # and the ingress root are part of the proof. The query belongs after the
     # real turn finalized, not beside static compose/config assertions.
-    assert rung.index("start_local_otel_sink") < rung.index("local up)")
+    local_up = 'local up -f "$REPO_ROOT/compose.dev.yaml" --build'
+    assert local_up in rung, "the local rung must build the current compose source"
+    assert rung.index("start_local_otel_sink") < rung.index(local_up)
     assert rung.index("assert_local_otel_healthy_turn") > rung.index(
         'assert_finalized_reply "local"'
     )
@@ -656,6 +658,89 @@ def test_ordinary_mcp_and_approval_seeds_have_independent_receipts() -> None:
         assert forbidden not in receipt.lower(), (
             "public evidence may expose only an aggregate MCP call count"
         )
+
+
+def test_approval_resume_failure_evidence_is_bounded_and_private_artifacts_are_cleaned(
+    tmp_path: Path,
+) -> None:
+    """A failed background approval turn reports only a safe terminal verdict."""
+
+    source = LADDER_PATH.read_text()
+    approval = _shell_function(source, "seed_approval_resume_turn")
+    summary = _shell_function(source, "approval_resume_failure_summary")
+
+    assert 'message_stderr_file="$(mktemp "$WORKDIR/approval-message-stderr.XXXXXX")"' in approval
+    assert '2> "$message_stderr_file" &' in approval
+    assert (
+        'approval_resume_failure_summary "$message_file" "$message_stderr_file" "$code" >&2'
+        in approval
+    )
+    for cleanup in (
+        'rm -f "$message_file" "$message_stderr_file" "$token_file" "$pending_file"',
+        'rm -f "$message_file" "$message_stderr_file" "$pending_file"',
+        'rm -f "$message_file" "$message_stderr_file"',
+    ):
+        assert cleanup in approval, (
+            "every post-allocation approval failure path must remove the private "
+            "stdout and stderr artifacts"
+        )
+
+    private_stdout = tmp_path / "approval-message"
+    private_stderr = tmp_path / "approval-message-stderr"
+    private_stdout.write_text(
+        json.dumps(
+            {
+                "awaiting_approval": True,
+                "finalized": False,
+                "reply": "PRIVATE_REPLY_SENTINEL",
+                "error": "PRIVATE_TOKEN_SENTINEL",
+            }
+        )
+    )
+    private_stderr.write_text("timed out PRIVATE_STDERR_SENTINEL")
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            summary + '\napproval_resume_failure_summary "$1" "$2" 23\n',
+            "bash",
+            str(private_stdout),
+            str(private_stderr),
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "exit_code=23" in result.stdout
+    assert "status=awaiting_approval" in result.stdout
+    assert "finalized=false" in result.stdout
+    assert "error_category=error_field" in result.stdout
+    assert "stderr_category=timed_out" in result.stdout
+    assert "PRIVATE_REPLY_SENTINEL" not in result.stdout + result.stderr
+    assert "PRIVATE_TOKEN_SENTINEL" not in result.stdout + result.stderr
+    assert "PRIVATE_STDERR_SENTINEL" not in result.stdout + result.stderr
+
+    private_stdout.write_text("PRIVATE_PARSE_SENTINEL")
+    private_stderr.write_text("could not parse PRIVATE_PARSE_STDERR_SENTINEL")
+    parse_result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            summary + '\napproval_resume_failure_summary "$1" "$2" 24\n',
+            "bash",
+            str(private_stdout),
+            str(private_stderr),
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert parse_result.returncode == 0, parse_result.stderr
+    assert "status=parse_failure" in parse_result.stdout
+    assert "stderr_category=parse_failure" in parse_result.stdout
+    assert "PRIVATE_PARSE_SENTINEL" not in parse_result.stdout + parse_result.stderr
+    assert "PRIVATE_PARSE_STDERR_SENTINEL" not in parse_result.stdout + parse_result.stderr
 
 
 def test_product_collector_restore_restarts_and_verifies_every_seed_emitter() -> None:

--- a/compose/tests/test_local_observability_ladder.py
+++ b/compose/tests/test_local_observability_ladder.py
@@ -8,6 +8,11 @@ exported signal files, and run both healthy and injected-failure controls.
 
 from __future__ import annotations
 
+import json
+import os
+import re
+import subprocess
+import sys
 from pathlib import Path
 
 import yaml
@@ -34,6 +39,65 @@ def _shell_function(source: str, name: str) -> str:
     start = source.index(start_marker)
     end = source.index("\n}\n", start) + len("\n}\n")
     return source[start:end]
+
+
+def _python_heredoc(function: str) -> str:
+    """Extract the sole quoted Python heredoc from a shell function."""
+
+    start = function.index("<<'PY'\n") + len("<<'PY'\n")
+    end = function.index("\nPY\n", start)
+    return function[start:end]
+
+
+def _run_seed_matcher(
+    tmp_path: Path, matcher: str, marker: str, rows: list[object]
+) -> subprocess.CompletedProcess[str]:
+    private_slice = tmp_path / "bounded-stream.json"
+    private_slice.write_text(json.dumps(rows))
+    return subprocess.run(
+        [sys.executable, "-", str(private_slice), marker],
+        input=matcher,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _run_absent_trace_query(
+    tmp_path: Path, query: str, *, error: str
+) -> tuple[subprocess.CompletedProcess[str], int]:
+    """Run the real shell helper against a deterministic failing candidate CLI."""
+
+    count = tmp_path / "query-count"
+    fake_bin = tmp_path / "curie"
+    fake_bin.write_text(
+        "#!/bin/sh\n"
+        'count="$(cat "$FAKE_COUNT" 2>/dev/null || printf 0)"\n'
+        'count=$((count + 1))\n'
+        'printf "%s" "$count" > "$FAKE_COUNT"\n'
+        'printf \'{"error":"%s","fix":"retry exact id"}\\n\' "$FAKE_ERROR"\n'
+        "exit 1\n"
+    )
+    fake_bin.chmod(0o700)
+    script = f"""set -u
+sanitize_exact_trace_read() {{ return 1; }}
+{query}
+WORKDIR="$1"
+BIN="$2"
+OBSERVABILITY_POLL_ATTEMPTS=3
+OBSERVABILITY_POLL_INTERVAL_SECONDS=0
+CURIE_NAMESPACE=acme-observability
+CURIE_RELEASE=acme-observability
+query_exact_seed_trace local aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa "" "" absent
+"""
+    result = subprocess.run(
+        ["bash", "-c", script, "bash", str(tmp_path), str(fake_bin)],
+        env={**os.environ, "FAKE_COUNT": str(count), "FAKE_ERROR": error},
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    return result, int(count.read_text()) if count.exists() else 0
 
 
 def test_local_ladder_owns_a_real_queryable_otlp_sink() -> None:
@@ -256,14 +320,36 @@ def test_local_otel_controls_distinguish_a_live_sink_from_a_turn() -> None:
     )
 
 
-def test_product_oracle_discovers_only_the_seed_trace_from_bounded_transport() -> None:
+def test_product_oracle_discovers_only_the_seed_trace_from_bounded_transport(
+    tmp_path: Path,
+) -> None:
     """A background/newest trace must be unable to satisfy the turn oracle."""
 
     source = LADDER_PATH.read_text()
-    assert "local observability runs --limit 100" not in source, (
-        "a newest-runs page can select an unrelated background trace; exact discovery "
-        "must start from the seeded stream entry"
+    # The unavailable-API negative may still exercise the public runs verb, but
+    # no helper may select a turn from that list or dump a selected row. Inspect
+    # whole function bodies so `--limit "$limit"` cannot evade this contract.
+    functions = {
+        match.group(1): _shell_function(source, match.group(1))
+        for match in re.finditer(r"(?m)^([A-Za-z0-9_]+)\(\) \{$", source)
+    }
+    forbidden_selectors = {
+        name: body
+        for name, body in functions.items()
+        if "local observability runs" in body
+        and name != "prove_local_observability_queries"
+    }
+    assert not forbidden_selectors, (
+        "a newest-runs selector/raw-dump helper can choose an unrelated background "
+        f"trace regardless of limit interpolation: {sorted(forbidden_selectors)}"
     )
+    for removed_helper in (
+        "discover_local_observability_trace",
+        "assert_local_observability_detail",
+    ):
+        assert removed_helper not in functions, (
+            f"obsolete raw selector/detail helper remains: {removed_helper}"
+        )
 
     discover = _shell_function(source, "discover_trace_id_for_seed")
     for required in (
@@ -281,6 +367,60 @@ def test_product_oracle_discovers_only_the_seed_trace_from_bounded_transport() -
         )
     assert "printf '%s\\n' \"$payload\"" not in discover
     assert "printf '%s\\n' \"$traceparent\"" not in discover
+
+    matcher = _python_heredoc(discover)
+    marker = "curie-seed-ordinary-example"
+    target_trace = "a" * 32
+    background_trace = "b" * 32
+    background = [
+        "1-0",
+        [
+            "payload",
+            json.dumps({"text": "ordinary correlation another-seed"}),
+            "traceparent",
+            f"00-{background_trace}-{'1' * 16}-01",
+        ],
+    ]
+    target = [
+        "2-0",
+        [
+            "payload",
+            json.dumps({"text": f"ordinary correlation {marker}"}),
+            "traceparent",
+            f"00-{target_trace}-{'2' * 16}-01",
+        ],
+    ]
+    matched = _run_seed_matcher(tmp_path, matcher, marker, [background, target])
+    assert matched.returncode == 0, matched.stderr
+    assert matched.stdout.strip() == target_trace, (
+        "the real matcher must recover the carrier adjacent to a marker embedded "
+        "in representative QueuedTurn.text, never the background carrier"
+    )
+
+    mismatch = _run_seed_matcher(tmp_path, matcher, marker, [background])
+    assert mismatch.returncode != 0, (
+        "a background entry without the marker must not satisfy exact discovery"
+    )
+    duplicate = _run_seed_matcher(
+        tmp_path,
+        matcher,
+        marker,
+        [
+            target,
+            [
+                "3-0",
+                [
+                    "payload",
+                    json.dumps({"text": f"ordinary correlation {marker}"}),
+                    "traceparent",
+                    f"00-{'c' * 32}-{'3' * 16}-01",
+                ],
+            ],
+        ],
+    )
+    assert duplicate.returncode != 0, (
+        "more than one matching adjacent carrier must fail closed"
+    )
 
     query = _shell_function(source, "query_exact_seed_trace")
     assert 'observability run "$trace_id"' in query
@@ -302,6 +442,81 @@ def test_product_oracle_discovers_only_the_seed_trace_from_bounded_transport() -
     for private in ("input", "output", "session", "user", "headers"):
         assert private in sanitizer, (
             f"sanitizer must explicitly prevent raw {private!r} from reaching stdout"
+        )
+    assert "if private_fields.intersection(node):\n        pass" not in sanitizer, (
+        "private-field handling must reject or remove data, not be a no-op"
+    )
+
+
+def test_product_evidence_sanitizer_and_failure_paths_never_dump_private_json(
+    tmp_path: Path,
+) -> None:
+    """Raw replies and private Langfuse fields stay in task-owned artifacts."""
+
+    source = LADDER_PATH.read_text()
+    sanitizer = _shell_function(source, "sanitize_exact_trace_read")
+    sanitizer_python = _python_heredoc(sanitizer)
+    trace_id = "d" * 32
+    private_sentinels = {
+        "input": "PRIVATE_PROMPT_SENTINEL",
+        "output": "PRIVATE_REPLY_SENTINEL",
+        "session": "PRIVATE_SESSION_SENTINEL",
+        "user": "PRIVATE_USER_SENTINEL",
+        "headers": {"authorization": "PRIVATE_HEADER_SENTINEL"},
+    }
+    raw = tmp_path / "raw-trace.json"
+    raw.write_text(
+        json.dumps(
+            {
+                "trace": {"id": trace_id},
+                "tree": [
+                    {
+                        "name": "curie.queue.enqueue",
+                        "type": "SPAN",
+                        "children": [],
+                        **private_sentinels,
+                    }
+                ],
+                "approval_decision": None,
+            }
+        )
+    )
+    result = subprocess.run(
+        [sys.executable, "-", trace_id, str(raw), "curie.queue.enqueue", ""],
+        input=sanitizer_python,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    evidence = json.loads(result.stdout)
+    assert set(evidence) == {
+        "trace_id",
+        "service",
+        "operation",
+        "observation_count",
+        "observation_type",
+        "approval_decision",
+    }
+    combined_output = result.stdout + result.stderr
+    for private_value in (
+        "PRIVATE_PROMPT_SENTINEL",
+        "PRIVATE_REPLY_SENTINEL",
+        "PRIVATE_SESSION_SENTINEL",
+        "PRIVATE_USER_SENTINEL",
+        "PRIVATE_HEADER_SENTINEL",
+    ):
+        assert private_value not in combined_output
+
+    finalized = _shell_function(source, "assert_finalized_reply")
+    for raw_dump in (
+        'printf \'%s\\n\' "$payload"',
+        'printf "%s\\n" "$payload"',
+        'echo "$payload"',
+    ):
+        assert raw_dump not in finalized, (
+            "message parse/finalization failures must report a bounded verdict, "
+            "not the private message JSON"
         )
 
 
@@ -325,6 +540,14 @@ def test_ordinary_mcp_and_approval_seeds_have_independent_receipts() -> None:
         assert not missing, f"{name} lacks independent outcome evidence: {missing}"
         assert "discover_trace_id_for_seed" in body
         assert "query_exact_seed_trace" in body
+
+    approval = _shell_function(source, "seed_approval_resume_turn")
+    assert "curie.approval.suspend" in approval, (
+        "the approval oracle must require the worker's real parked-turn span"
+    )
+    assert "curie.approval.wait" not in approval, (
+        "the oracle must not invent a wait span that no current emitter produces"
+    )
 
     assert "seed-invalid" in source
     assert MCP_RECEIPT_FIXTURE.is_dir(), (
@@ -368,11 +591,14 @@ def test_product_collector_restore_restarts_and_verifies_every_seed_emitter() ->
         assert protocol in restore
 
 
-def test_invalid_langfuse_auth_is_temporary_durable_and_recovers_the_same_id() -> None:
+def test_invalid_langfuse_auth_is_temporary_durable_and_recovers_the_same_id(
+    tmp_path: Path,
+) -> None:
     """Pin the real backend negative without redefining exporter semantics."""
 
     source = LADDER_PATH.read_text()
     negative = _shell_function(source, "case_local_langfuse_invalid_auth")
+    query = _shell_function(source, "query_exact_seed_trace")
 
     # Observed shipped behavior, not an assumed external-API contract:
     # otel/collector-config.yaml enables retry_on_failure at 5s/30s/5m and a
@@ -404,6 +630,66 @@ def test_invalid_langfuse_auth_is_temporary_durable_and_recovers_the_same_id() -
         "after the queue-preserving restart"
     )
 
+    invalid_auth = negative.index(
+        'export LANGFUSE_OTLP_AUTH_HEADER="$INVALID_LANGFUSE_OTLP_AUTH_HEADER"'
+    )
+    control = negative.find('query_exact_seed_trace local "$LAST_ORDINARY_TRACE_ID"')
+    assert 0 <= control < invalid_auth, (
+        "a successful exact read under valid auth must discriminate backend/query "
+        "health before the credential is made invalid"
+    )
+
+    # Restart once while auth is still invalid, then re-observe both queued
+    # failure and stable absence. Restoring auth is a later, separate restart.
+    before_restore = negative[: negative.index("restore_local_langfuse_auth")]
+    restart_positions = [
+        match.start()
+        for match in re.finditer("restart_local_product_collector", before_restore)
+    ]
+    assert len(restart_positions) >= 2, (
+        "the file-backed queue must survive a Collector restart while auth remains invalid"
+    )
+    after_invalid_restart = before_restore[restart_positions[1] :]
+    assert "otelcol_exporter_queue_size" in after_invalid_restart
+    assert "otelcol_exporter_send_failed_spans" in after_invalid_restart
+    assert "query_exact_seed_trace" in after_invalid_restart
+
+    # Execute the production query helper: absence is a bounded observation,
+    # not one lucky first poll, and only the stable not-found error is accepted.
+    stable_absence_dir = tmp_path / "stable-absence"
+    stable_absence_dir.mkdir()
+    absent, polls = _run_absent_trace_query(
+        stable_absence_dir, query, error="exact trace not found"
+    )
+    assert absent.returncode == 0, absent.stderr
+    assert polls == 3, (
+        "temporary absence must remain not-found for the full declared poll bound"
+    )
+
+    wrong_failure_dir = tmp_path / "wrong-failure"
+    wrong_failure_dir.mkdir()
+    wrong_failure, _ = _run_absent_trace_query(
+        wrong_failure_dir, query, error="Langfuse authorization failed"
+    )
+    assert wrong_failure.returncode != 0, (
+        "an arbitrary candidate-CLI exit 1 must not masquerade as stable not-found"
+    )
+
+    absent_call = re.search(
+        r'query_exact_seed_trace local "\$same_queued_trace_id"[^\n]*absent',
+        negative,
+    )
+    recovered_call = re.search(
+        r'query_exact_seed_trace local "\$same_queued_trace_id"\s*$',
+        negative,
+        re.MULTILINE,
+    )
+    assert (
+        absent_call
+        and recovered_call
+        and absent_call.start() < recovered_call.start()
+    ), "the same ID must be absent during failure and present after recovery"
+
 
 def test_cluster_product_observability_is_private_preflight_and_query_only() -> None:
     """The ladder may inspect a task release but must never install or remove it."""
@@ -430,10 +716,14 @@ def test_cluster_product_observability_is_private_preflight_and_query_only() -> 
         assert required in preflight, f"cluster preflight omits {required!r}"
 
     mode = _shell_function(source, "run_cluster_product_observability")
+    wrapper = _shell_function(source, "rung_cluster_product")
     assert "preflight_cluster_product_observability" in mode
     assert "seed_ordinary_turn" in mode
     assert "seed_approval_resume_turn" in mode
     assert "cluster observability run" in mode
+    assert "cluster deploy" in wrapper, (
+        "the wrapper must retain the intended agent seed deployment"
+    )
     for mutating in (
         "cluster up",
         "cluster down",
@@ -442,9 +732,22 @@ def test_cluster_product_observability_is_private_preflight_and_query_only() -> 
         "helm uninstall",
         "kubectl delete",
     ):
-        assert mutating not in mode, (
-            f"product-observability mode must be preflight/query-only, found {mutating!r}"
-        )
+        for helper_name, helper in (
+            ("preflight", preflight),
+            ("query", mode),
+            ("product wrapper", wrapper),
+        ):
+            assert mutating not in helper, (
+                "product-observability preflight/query/wrapper must not manage the "
+                f"release; found {mutating!r} in {helper_name}"
+            )
+    assert '-o json > "$inventory"' not in preflight, (
+        "preflight must query Ready/imageID fields directly, not persist full pod "
+        "JSON that may contain private environment values"
+    )
+    assert "cluster-product-pods" not in preflight, (
+        "full pod specifications must not be persisted even in a mode-0600 artifact"
+    )
 
 
 def test_adopted_component_stop_requires_successful_export_on_both_product_surfaces() -> None:

--- a/packages/telemetry/src/curie_telemetry/__init__.py
+++ b/packages/telemetry/src/curie_telemetry/__init__.py
@@ -8,6 +8,7 @@ from .bootstrap import (
 from .config import resolve_otlp_endpoint, resolve_otlp_protocol
 from .context import (
     TRACEPARENT_STREAM_FIELD,
+    canonicalize_traceparent,
     extract_trace_context,
     inject_trace_context,
 )
@@ -22,6 +23,7 @@ __all__ = [
     "bootstrap_service_telemetry",
     "build_otlp_span_exporter",
     "build_resource",
+    "canonicalize_traceparent",
     "configure_meter_provider",
     "configure_service_logging",
     "deployment_environment",

--- a/packages/telemetry/src/curie_telemetry/context.py
+++ b/packages/telemetry/src/curie_telemetry/context.py
@@ -32,6 +32,31 @@ class _MappingGetter(Getter[Mapping[str, str]]):
 _GETTER = _MappingGetter()
 
 
+def canonicalize_traceparent(value: str | None) -> str | None:
+    """Return a canonical W3C carrier, or ``None`` for unsafe input.
+
+    Validation is delegated to OpenTelemetry's W3C propagator so this helper
+    cannot drift into a second, partial implementation of the standard.  A
+    clean base also keeps invalid input from falling back to ambient context.
+    """
+
+    if value is None:
+        return None
+    candidate = value.strip()
+    if not candidate:
+        return None
+    extracted = _PROPAGATOR.extract(
+        {TRACEPARENT_STREAM_FIELD: candidate},
+        context=Context(),
+        getter=_GETTER,
+    )
+    if not trace.get_current_span(extracted).get_span_context().is_valid:
+        return None
+    canonical: dict[str, str] = {}
+    _PROPAGATOR.inject(canonical, context=_normalize_trace_context(extracted))
+    return canonical.get(TRACEPARENT_STREAM_FIELD)
+
+
 def _normalize_trace_context(context: Context | None = None) -> Context:
     """Normalize trace flags while retaining the active Context and its values."""
 

--- a/packages/telemetry/tests/test_context.py
+++ b/packages/telemetry/tests/test_context.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from curie_telemetry import (
     TRACEPARENT_STREAM_FIELD,
+    canonicalize_traceparent,
     extract_trace_context,
     inject_trace_context,
 )
@@ -44,3 +45,28 @@ def test_missing_or_malformed_traceparent_extracts_a_safe_root_context() -> None
     for carrier in ({}, {TRACEPARENT_STREAM_FIELD: "not-a-traceparent"}):
         extracted = trace.get_current_span(extract_trace_context(carrier)).get_span_context()
         assert not extracted.is_valid
+
+
+def test_canonicalize_traceparent_returns_only_a_valid_w3c_carrier() -> None:
+    carrier = "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01"
+
+    assert canonicalize_traceparent(carrier) == carrier
+    assert canonicalize_traceparent(f"  {carrier}  ") == carrier
+
+
+def test_canonicalize_traceparent_rejects_missing_malformed_and_zero_ids() -> None:
+    assert canonicalize_traceparent(None) is None
+    assert canonicalize_traceparent("") is None
+    assert canonicalize_traceparent("not-a-traceparent") is None
+    assert (
+        canonicalize_traceparent(
+            "00-00000000000000000000000000000000-0123456789abcdef-01"
+        )
+        is None
+    )
+    assert (
+        canonicalize_traceparent(
+            "00-0123456789abcdef0123456789abcdef-0000000000000000-01"
+        )
+        is None
+    )


### PR DESCRIPTION
Fixes #2204

## Root cause

The product did not maintain one owned W3C lineage across the full turn:

- accepted Slack ingress had no dispatcher-owned root span;
- API HTTP requests did not extract the incoming W3C parent;
- worker approval requests did not inject the active turn parent;
- approval resume paths adopted the later request/click context instead of the privately persisted originating turn parent.

Local verification exposed two additional routing failures: the host-network worker could not resolve the bridge-only Collector name, and copying its corrected loopback endpoint into a bridge-network one-shot dispatcher broke dispatcher export. The approval read projection also checked only the first observation, which is no longer necessarily the resumed runner observation in a correlated trace.

## Fix

- Carry the accepted Slack ingress parent through dispatcher enqueue, API extraction, worker processing, sandbox/runner RPC, MCP execution, approvals, and reply delivery.
- Persist the first valid approval trace parent privately and resume from it across direct resolution, expiry, sweeper, and reconciler paths.
- Give host-network workers and bridge-network runners/dispatchers reachable Collector addresses, preserving explicit-empty disabling and custom-endpoint compatibility.
- Prefer trace-level approval metadata, then scan every observation without inventing absent decisions.
- Add exact-ID Langfuse export/ingest evidence with ordinary, MCP, approval, and invalid-exporter-auth positive/negative cases. Required live cases remain unverified below.
- Retain current-source image pins across local fault injection/restoration; report sanitized query failures without weakening membership assertions. Keep approval helpers owned and cleaned up.

Fix pin: apps/api/tests/test_approvals.py::test_terminal_resolution_and_resume_parent_to_the_stored_turn[approved]

## Verification

Candidate: `cd1a3222d8687f32ab918b70c52f3375e24b94cf`; current `main` merged without conflicts. The primary dirty checkout is untouched.

- Executed test-first failures for network override compatibility, dispatcher forwarding, and approval metadata on a later observation; corresponding focused regressions pass.
- Real Collector -> Langfuse -> API integration: 3 passed, including correlated approval presence and absent-decision negative. Tests use the existing disposable-database fixture and pass independently.
- Rust formatting, clippy, the full unit/integration suite (including Valkey-backed tests), and chart assertion scripts passed against the product fix. The subsequent commit changes only integration-test setup.
- Lock, Alembic revision, ruff, mypy, imports, docs, wire checks, and released-upgrade verification passed. The full Python baseline and strict local E2E are running; completion evidence will be added as a comment without retriggering CI by editing this body.
- Earlier candidate evidence: the skill tier passed; the regression pin was `PINNED` with candidate-positive/red-on-product-revert proof. Local raw export contained all four service emitters in one causal trace; runner failure injection produced a correlated ERROR and classified-failure metric, followed by healthy recovery. These are not substitutes for the current candidate's pending exact-ingest proof.

## Required-tier evidence gaps

- Current local exact-trace E2E: pending. The earlier adopted-component attribution is withdrawn; the generic query timeout was not proof of a Langfuse 404. No newest-N fallback or weakened membership assertion is used.
- Cluster: this session has no authorized task-owned installed release or task registry input; the PR's isolated CI cluster rung remains required.
- Live provider: no product model credential is available to this run.
- External Slack: no real Slack credential or private ingress receipt is available to this run.

These remain blocking evidence gaps for the full original issue acceptance, not green claims. No production or shared deployment was touched. Only task-owned local services are started and cleaned up.

## Review and scope

Two independent investigators reproduced and cross-checked the routing and read-projection mechanisms; final cross-review found no blocking correctness, scope, or security issues in the follow-up fix. Causation for the original real Slack occurrence remains unverified without its private receipt. The change affects local export configuration, one-shot dispatcher forwarding, and trace read projection; it does not change adopted components or deploy to shared environments.

The issue's externally moved `v0.8.5` milestone is preserved. Draft state and auto-merge are controlled by the maintainer; this run will not merge.
