### PR TITLE
Correct chart README image defaults, preflight hooks, and BYO buckets

### DIFF
--- a/charts/curie/Chart.yaml
+++ b/charts/curie/Chart.yaml
@@ -4,9 +4,10 @@ description: >-
   Curie (Relay) umbrella chart. Installs the whole self-hosted stack on a
   single node: Langfuse v3 (web + worker) plus its ClickHouse, Valkey, Postgres,
   and RustFS backing stores, and the OTel Collector that adapts app traces into
-  Langfuse. Every backing store is condition-gated with a bring-your-own block,
-  and two install-time preflights ship baked in: a CPU-AVX / ClickHouse-pin
-  check and a NetworkPolicy-enforcement probe.
+  Langfuse. Every backing store is condition-gated with a bring-your-own block.
+  A CPU-AVX / ClickHouse-pin check runs as a blocking pre-install, pre-upgrade
+  hook; a NetworkPolicy-enforcement probe ships as a helm test that must be run
+  explicitly.
 type: application
 version: 0.8.4
 appVersion: "0.8.4"

--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -368,26 +368,32 @@ workflow (`.github/workflows/release.yaml`) on every push to `main`, as
 `ghcr.io/curie-eng/curie-<service>` tagged with the commit SHA and `latest`.
 All six first-party services build in the matrix: `curie-api`,
 `curie-dispatcher`, `curie-mail-adapter`, `curie-worker`, `curie-ui`, and
-`curie-runner`. The chart defaults every first-party image at its
-`ghcr.io/curie-eng/curie-*` `:latest`, so the bare install (above) pulls from
+`curie-runner`. The chart defaults every first-party image to the chart
+`appVersion` (empty `tag` in values, resolved by the `curie.image` helper), so
+the bare install (above) pulls `ghcr.io/curie-eng/curie-*:<appVersion>` from
 GHCR with no image overrides -- except `curie-mail-adapter`, whose Deployment is
 off by default (`mailAdapter.deploy`), so its image is published and defaulted
-but not pulled until an operator enables the email channel.
+but not pulled until an operator enables the email channel. The workflow still
+publishes a mutable `latest` tag alongside the SHA and version tags; that is a
+fact about the release artifacts, not about what this chart resolves to.
 
 - **Pull policy for the five Deployment-managed services** (api, dispatcher,
-  mail-adapter, worker, ui): `imagePullPolicy: Always` -- they pull once per
-  rollout, so `Always` just keeps a fresh install from serving a stale `latest`
-  a node cached earlier.
+  mail-adapter, worker, ui): `imagePullPolicy: Always`. The default tag is the
+  chart `appVersion`, so this is a cheap no-op on a node that already has that
+  immutable ref, and it still self-heals a node that cached a same-named ref
+  under a different digest.
 - **The runner image is the exception:** it uses `imagePullPolicy: IfNotPresent`
   because a sandbox pod is cold-created per Slack thread, and an `Always`
   (re-)pull inside that boot window blew past the worker's claim timeout and
-  killed runs. Its freshness comes instead from the `runner-prewarm` DaemonSet
+  killed runs. Its presence on the node comes from the `runner-prewarm` DaemonSet
   (`agentSandbox.runner.prewarm`, default on with the sandbox substrate),
-  which pulls the runner image `Always` and keeps it pinned on every node; a
-  Release-revision annotation rolls those pods on every `helm upgrade` so the
-  pin refreshes a churned `latest`.
-- **Pin an immutable tag** for reproducible deploys, where the pull policies
-  are a cheap no-op.
+  which pulls the runner image `Always` and keeps that same `appVersion` ref
+  pinned on every node; a Release-revision annotation rolls those pods on every
+  `helm upgrade` so an upgraded chart's new `appVersion` is pulled before the
+  next claim.
+- **Override `tag` (or set `digest`)** to pin an explicit version. Empty `tag`
+  is the default and resolves to `.Chart.AppVersion`; `digest` wins over `tag`
+  when set.
 
 A GHCR package inherits its repo's visibility, so on a **private** repo the image
 is not anonymously pullable and the node needs credentials. Two supported paths:
@@ -586,6 +592,7 @@ rustfs:
   host: s3.us-east-1.amazonaws.com
   port: 443
   region: us-east-1
+  bucket: langfuse           # Langfuse event and media uploads
   auth:
     accessKey: ""            # selects the key-free path
 api:
@@ -593,15 +600,28 @@ api:
     annotations:
       eks.amazonaws.com/role-arn: arn:aws:iam::000000000000:role/curie-api
 worker:
+  workspace:
+    bucket: curie-workspaces # repository workspace archives
   serviceAccount:
     annotations:
       eks.amazonaws.com/role-arn: arn:aws:iam::000000000000:role/curie-worker
 agentSandbox:
   runner:
+    bundleFetch:
+      bucket: curie-bundles  # plugin bundles (API writes, runner reads)
     serviceAccount:
       annotations:
         eks.amazonaws.com/role-arn: arn:aws:iam::000000000000:role/curie-runner
 ```
+
+The chart talks to **three buckets** on that same endpoint, not one. Create them
+before install; the in-chart RustFS Job creates them only while `rustfs.deploy`
+is true. The defaults are three distinct names, so a single-bucket BYO install
+fails on two of the three paths.
+
+- `rustfs.bucket` (default `langfuse`): Langfuse event and media uploads.
+- `worker.workspace.bucket` (default `curie-workspaces`): repository workspace archives.
+- `agentSandbox.runner.bundleFetch.bucket` (default `curie-bundles`): plugin bundles.
 
 The bundle fetch uses path style addressing, so it appends
 `agentSandbox.runner.bundleFetch.bucket` to this endpoint. For another AWS
@@ -609,10 +629,20 @@ region, change the region in `rustfs.host` and set `rustfs.region` to control
 the SigV4 signing region used by the bundle fetch init container. This setting
 does not configure the API or worker S3 clients.
 
-Scope the runner's role to the bundle bucket, **read-only**. NetworkPolicy
-selects pods rather than containers, so any identity the bundle-fetch init
-container can assume is equally reachable by the runner beside it, and the
-runner is prompt-injectable by design.
+Scope each role to the bucket it actually uses:
+
+- **API role:** read/write on the bundle bucket. The API writes each uploaded bundle.
+- **Worker role:** read/write on the workspace bucket, and read on the bundle
+  bucket (the eval lane fetches the same objects the API wrote).
+- **Runner role:** read-only on the bundle bucket. NetworkPolicy selects pods
+  rather than containers, so any identity the bundle-fetch init container can
+  assume is equally reachable by the runner beside it, and the runner is
+  prompt-injectable by design.
+- **Langfuse:** `rustfs.bucket` for the `events/` and `media/` prefixes. Langfuse
+  still consumes `rustfs.auth` static keys for that bucket; the key-free path
+  only omits credentials from the API, the worker, and the sandbox bundle-fetch
+  init container. Scope those keys (or a Langfuse-specific IAM user) to
+  `rustfs.bucket`.
 
 Two constraints are worth stating plainly.
 
@@ -641,8 +671,11 @@ around.
 
 ## The two preflights
 
-Both run as Helm hooks (blocking a broken install) and are re-runnable via
-`helm test <release> -n <ns>`.
+(a) is a blocking `pre-install,pre-upgrade` hook. (b) is a `helm test` that
+must be run explicitly; it never runs during `helm install`. A green
+`helm install` does not prove NetworkPolicy is enforced, so run
+`helm test <release> -n <ns>` before treating the security rails as live.
+Both are re-runnable via that same `helm test` command.
 
 **(a) CPU-AVX / ClickHouse-pin check** (`preflights.avxCheck`). A pre-install /
 pre-upgrade hook Job.
@@ -948,9 +981,9 @@ to install only the control plane + backing stores without the runner substrate.
   with an externally-managed controller) given the residual cluster-wide
   pod/service/PVC reach.
 - **Runner image**: the pool runs `curie-runner`, defaulting to
-  `ghcr.io/curie-eng/curie-runner:latest` with `imagePullPolicy: IfNotPresent`
+  `ghcr.io/curie-eng/curie-runner:<appVersion>` with `imagePullPolicy: IfNotPresent`
   (per-thread cold boots must not contain a pull; the `runner-prewarm` DaemonSet
-  keeps the image fresh on every node -- see "Publishing and pulling images").
+  keeps the image on every node -- see "Publishing and pulling images").
   For offline
   dev/e2e, `-f values-dev.yaml` overrides it to a locally-built, cluster-imported
   tag with `imagePullPolicy: Never` (`docker build -f runner/Dockerfile -t


### PR DESCRIPTION
## Summary

The chart README (and the Chart.yaml description) stated three things the chart does not do: first-party images defaulting to `:latest`, both preflights blocking `helm install`, and a BYO object store that is one endpoint with no bucket names. All three are wrong against `values.yaml` and the templates, and all three were hit on a fresh install. This change makes those operator-facing sentences match the chart.

No template or values change.

## Related issue

Closes #2212

## Fix pin verification

## End-to-end verification

This change does not alter runtime behavior because it only rewrites operator-facing prose in `charts/curie/README.md` and the Chart.yaml description. Templates, values, and hook annotations are untouched.

Scoped verification:

- `helm lint charts/curie` - 1 chart linted, 0 failed.
- `helm template curie charts/curie --namespace curie` on commit 5999645f0 - first-party images render as `ghcr.io/curie-eng/curie-*:0.8.4` (chart `appVersion`), AVX hook is `pre-install,pre-upgrade,test`, NetworkPolicy probe objects are `helm.sh/hook: test` only.
- Negative: the three quoted README sentences (`:latest` as the chart default, "Both run as Helm hooks (blocking a broken install)", one-bucket BYO example with no bucket keys) are absent after the edit. `git diff --name-only` is `charts/curie/README.md` and `charts/curie/Chart.yaml` only.

## Conservative defaults

- Also corrected the runner-image bullet that still said `curie-runner:latest`. That is the same AC as the quoted publishing paragraph; the issue line numbers had drifted on main.
- Left `charts/curie/CLAUDE.md` and the `values-e2e-harness.yaml` comment that still call the NetworkPolicy probe install-blocking / talk about `:latest` pull policy. The ticket named one file plus a line of Chart.yaml.
- IAM scoping includes worker read on the bundle bucket (eval lane) and notes that Langfuse still consumes `rustfs.auth` static keys for `rustfs.bucket`; the key-free path only omits credentials from the API, worker, and sandbox bundle-fetch init container.

## Checklist

- [x] Tests pass for the area I touched (`helm lint charts/curie`).
- [x] Docs updated if behavior changed (this change is the docs).
- [ ] An ADR is added under `docs/adr/` if this is an architectural decision.
