### PR TITLE
fix(chart): give Langfuse the key-free object-store path

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -454,16 +454,17 @@ jobs:
       - name: Sync workspace
         run: uv sync
 
-      # Prove the key-free object store path (#1325). Pointing the bundle store
-      # at a real cloud object store used to REQUIRE static access keys: all
-      # three consumers supplied explicit credentials unconditionally, so an
-      # ambient role was never consulted. Clearing rustfs.auth.accessKey now
-      # omits every credential env and shell export, which only works if the
-      # omission is COMPLETE -- an empty AWS_ACCESS_KEY_ID is still a credential
-      # to the SDK, so it stops the provider chain and the web-identity provider
-      # is never reached. Also asserts the instance-role shortcut stays shut:
-      # NetworkPolicy selects pods and not containers, so opening IMDS for
-      # bundle-fetch would hand the node's IAM role to the runner as well.
+      # Prove the key-free object store path (#1325, #2211). Pointing the bundle
+      # store at a real cloud object store used to REQUIRE static access keys:
+      # all four consumers (api, worker, bundle-fetch, Langfuse) supplied
+      # explicit credentials unconditionally, so an ambient role was never
+      # consulted. Clearing rustfs.auth.accessKey now omits every credential env
+      # and shell export, which only works if the omission is COMPLETE -- an
+      # empty AWS_ACCESS_KEY_ID is still a credential to the SDK, so it stops
+      # the provider chain and the web-identity provider is never reached. Also
+      # asserts the instance-role shortcut stays shut: NetworkPolicy selects
+      # pods and not containers, so opening IMDS for bundle-fetch would hand
+      # the node's IAM role to the runner as well.
       - name: helm render assertions (object store web identity)
         run: |
           set -euo pipefail

--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -577,10 +577,10 @@ Pointing the bundle store at a real cloud object store (`rustfs.deploy: false`)
 normally means a scoped IAM user and long-lived keys in a Secret. That works and
 is genuinely least-privilege, but it is not the only option: clearing
 `rustfs.auth.accessKey` selects a key-free path (#1325) in which the chart omits
-every S3 credential from the API, the worker, and the sandbox bundle-fetch init
-container, so the AWS SDK falls through its provider chain to the **web-identity
-provider** (`AWS_ROLE_ARN` + `AWS_WEB_IDENTITY_TOKEN_FILE`) fed by a projected
-ServiceAccount token.
+every S3 credential from the API, the worker, the sandbox bundle-fetch init
+container, and Langfuse, so the AWS SDK falls through its provider chain to
+the **web-identity provider** (`AWS_ROLE_ARN` + `AWS_WEB_IDENTITY_TOKEN_FILE`)
+fed by a projected ServiceAccount token.
 
 Bind the role through the ServiceAccount annotations. On EKS with IRSA the
 pod-identity webhook reads the annotation and injects the projected token and
@@ -624,6 +624,10 @@ agentSandbox:
     serviceAccount:
       annotations:
         eks.amazonaws.com/role-arn: arn:aws:iam::000000000000:role/curie-runner
+langfuse:
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::000000000000:role/curie-langfuse
 ```
 
 The chart talks to **three buckets** on that same endpoint, not one. Create them

--- a/charts/curie/ci/object-store-web-identity-assertions.sh
+++ b/charts/curie/ci/object-store-web-identity-assertions.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 #
 # Pointing the bundle store at a real cloud object store used to REQUIRE static
-# access keys: the api, the worker, and the sandbox bundle-fetch init container
-# each supplied explicit credentials unconditionally, so an ambient role was
-# never consulted (#1325).
+# access keys: the api, the worker, the sandbox bundle-fetch init container, and
+# Langfuse each supplied explicit credentials unconditionally, so an ambient
+# role was never consulted (#1325, #2211).
 #
 # Clearing `rustfs.auth.accessKey` now selects a key-free path: every credential
 # env var is omitted so the AWS SDK falls through its provider chain to the
@@ -42,13 +42,15 @@ CHART=${CHART:-charts/curie}
 STATIC_RENDERED=""
 WEB_IDENTITY_RENDERED=""
 REGION_OVERRIDE_RENDERED=""
+CREATE_FALSE_RENDERED=""
 WEB_IDENTITY_VALUES=""
 WEB_IDENTITY_TOKEN=""
-trap 'rm -f "${STATIC_RENDERED:-}" "${WEB_IDENTITY_RENDERED:-}" "${REGION_OVERRIDE_RENDERED:-}" "${WEB_IDENTITY_VALUES:-}" "${WEB_IDENTITY_TOKEN:-}"' EXIT
+trap 'rm -f "${STATIC_RENDERED:-}" "${WEB_IDENTITY_RENDERED:-}" "${REGION_OVERRIDE_RENDERED:-}" "${CREATE_FALSE_RENDERED:-}" "${WEB_IDENTITY_VALUES:-}" "${WEB_IDENTITY_TOKEN:-}"' EXIT
 
 STATIC_RENDERED=$(mktemp)
 WEB_IDENTITY_RENDERED=$(mktemp)
 REGION_OVERRIDE_RENDERED=$(mktemp)
+CREATE_FALSE_RENDERED=$(mktemp)
 WEB_IDENTITY_VALUES=$(mktemp)
 # Stands in for the projected ServiceAccount token the EKS pod-identity webhook
 # mounts. Its CONTENT is never read here: the web-identity provider hands back
@@ -99,6 +101,10 @@ agentSandbox:
     serviceAccount:
       annotations:
         eks.amazonaws.com/role-arn: arn:aws:iam::000000000000:role/curie-runner
+langfuse:
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::000000000000:role/curie-langfuse
 EOF
 
 helm template curie "$CHART" --namespace dev > "$STATIC_RENDERED"
@@ -106,6 +112,14 @@ helm template curie "$CHART" --namespace dev \
   --values "$WEB_IDENTITY_VALUES" > "$WEB_IDENTITY_RENDERED"
 helm template curie "$CHART" --namespace dev \
   --set rustfs.region=eu-west-1 > "$REGION_OVERRIDE_RENDERED"
+# create: false plus a custom name is the BYO ServiceAccount path the values
+# block advertises. It must bind both Langfuse Deployments to that name and
+# must not emit a chart-owned Langfuse ServiceAccount.
+helm template curie "$CHART" --namespace dev \
+  --values "$WEB_IDENTITY_VALUES" \
+  --set langfuse.serviceAccount.create=false \
+  --set langfuse.serviceAccount.name=byo-langfuse-sa \
+  > "$CREATE_FALSE_RENDERED"
 
 # Assertion 1: clearing the access key while the in-chart RustFS is deployed is
 # refused at render. That store is configured with those very credentials and
@@ -138,10 +152,20 @@ if ! helm template curie "$CHART" --namespace dev \
 fi
 echo "ok: an existing RustFS Secret with an empty rustfs.auth.secretKey renders"
 
-python3 - "$STATIC_RENDERED" "$WEB_IDENTITY_RENDERED" "$REGION_OVERRIDE_RENDERED" <<'PY'
+python3 - "$STATIC_RENDERED" "$WEB_IDENTITY_RENDERED" "$REGION_OVERRIDE_RENDERED" "$CREATE_FALSE_RENDERED" <<'PY'
 import ipaddress, sys, yaml
 
 CREDENTIAL_KEYS = ("S3_ACCESS_KEY", "S3_SECRET_KEY")
+# Langfuse uses the AWS SDK for JavaScript under LANGFUSE_S3_* names, not the
+# S3_ACCESS_KEY pair the api and worker carry. An empty access-key id here is
+# the same trap: the SDK treats it as an explicit credential and never reaches
+# the web-identity provider (#2211).
+LANGFUSE_CREDENTIAL_KEYS = (
+    "LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID",
+    "LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY",
+    "LANGFUSE_S3_MEDIA_UPLOAD_ACCESS_KEY_ID",
+    "LANGFUSE_S3_MEDIA_UPLOAD_SECRET_ACCESS_KEY",
+)
 # The metadata address Rail 1 denies. An instance-role path would need this
 # reachable; the web-identity path must not make it so.
 IMDS = ipaddress.ip_address("169.254.169.254")
@@ -151,10 +175,29 @@ def env_for(container):
     return {entry["name"]: entry for entry in container.get("env", [])}
 
 
+def named_container_env(deployment, container_name):
+    """The application container's env, chosen by name, never by index.
+
+    Indexing containers[0] reads whichever container the pod spec lists first.
+    A sidecar prepended to the spec would carry no S3 credential env, so the
+    gate would pass while the real application container kept its keys.
+    """
+    containers = deployment["spec"]["template"]["spec"].get("containers", []) or []
+    matches = [c for c in containers if c.get("name") == container_name]
+    assert len(matches) == 1, (
+        f"Deployment {deployment['metadata']['name']} must run exactly one "
+        f"container named {container_name!r}, but it renders "
+        f"{[c.get('name') for c in containers]}"
+    )
+    return env_for(matches[0])
+
+
 def read(path):
-    api = worker = bundle_fetch = None
+    api = worker = bundle_fetch = langfuse_web = langfuse_worker = None
+    langfuse_web_sa = langfuse_worker_sa = None
     fetch_command = ""
     service_accounts = {}
+    sa_automount = {}
     egress_excepts = []
     with open(path) as fh:
         for doc in yaml.safe_load_all(fh):
@@ -165,12 +208,24 @@ def read(path):
             if kind == "Deployment":
                 containers = doc["spec"]["template"]["spec"].get("containers", [])
                 assert containers, f"{name} Deployment has no containers"
-                if name.endswith("-api"):
+                sa_name = doc["spec"]["template"]["spec"].get("serviceAccountName")
+                # `-langfuse-worker` must be matched before `-worker`: the
+                # suffix `-worker` also matches `<release>-langfuse-worker`,
+                # which is why this script used to read past Langfuse (#1500,
+                # #2211).
+                if name.endswith("-langfuse-web"):
+                    langfuse_web = named_container_env(doc, "langfuse-web")
+                    langfuse_web_sa = sa_name
+                elif name.endswith("-langfuse-worker"):
+                    langfuse_worker = named_container_env(doc, "langfuse-worker")
+                    langfuse_worker_sa = sa_name
+                elif name.endswith("-api"):
                     api = env_for(containers[0])
                 elif name.endswith("-worker"):
                     worker = env_for(containers[0])
             elif kind == "ServiceAccount":
                 service_accounts[name] = doc["metadata"].get("annotations") or {}
+                sa_automount[name] = doc.get("automountServiceAccountToken")
             elif kind == "SandboxTemplate":
                 pod_spec = doc["spec"]["podTemplate"]["spec"]
                 matches = [
@@ -192,13 +247,45 @@ def read(path):
     assert api is not None, "api Deployment not rendered"
     assert worker is not None, "worker Deployment not rendered"
     assert bundle_fetch is not None, "SandboxTemplate bundle-fetch not rendered"
-    return api, worker, bundle_fetch, fetch_command, service_accounts, egress_excepts
+    assert langfuse_web is not None, "langfuse-web Deployment not rendered"
+    assert langfuse_worker is not None, "langfuse-worker Deployment not rendered"
+    return (
+        api,
+        worker,
+        bundle_fetch,
+        fetch_command,
+        service_accounts,
+        egress_excepts,
+        langfuse_web,
+        langfuse_worker,
+        langfuse_web_sa,
+        langfuse_worker_sa,
+        sa_automount,
+    )
 
 
 def assert_static(path):
-    api, worker, bundle_fetch, fetch_command, _, _ = read(path)
+    (
+        api,
+        worker,
+        bundle_fetch,
+        fetch_command,
+        _,
+        _,
+        langfuse_web,
+        langfuse_worker,
+        langfuse_web_sa,
+        langfuse_worker_sa,
+        sa_automount,
+    ) = read(path)
     for label, env in (("api", api), ("worker", worker), ("bundle-fetch", bundle_fetch)):
         missing = [key for key in CREDENTIAL_KEYS if key not in env]
+        assert not missing, (
+            f"the DEFAULT install must keep static credentials; {label} is missing {missing}. "
+            "The in-chart RustFS accepts nothing else."
+        )
+    for label, env in (("langfuse-web", langfuse_web), ("langfuse-worker", langfuse_worker)):
+        missing = [key for key in LANGFUSE_CREDENTIAL_KEYS if key not in env]
         assert not missing, (
             f"the DEFAULT install must keep static credentials; {label} is missing {missing}. "
             "The in-chart RustFS accepts nothing else."
@@ -206,11 +293,35 @@ def assert_static(path):
     assert "AWS_ACCESS_KEY_ID" in fetch_command, (
         "the default bundle-fetch must still export AWS_ACCESS_KEY_ID"
     )
-    print("ok: static: api, worker, and bundle-fetch all carry S3_ACCESS_KEY and S3_SECRET_KEY")
+    # The dedicated SA is created on the default path too, so adding a role
+    # annotation later does not change which identity the pods run as.
+    assert langfuse_web_sa == "curie-langfuse", (
+        f"static: langfuse-web binds {langfuse_web_sa!r}, expected 'curie-langfuse'"
+    )
+    assert langfuse_worker_sa == "curie-langfuse", (
+        f"static: langfuse-worker binds {langfuse_worker_sa!r}, expected 'curie-langfuse'"
+    )
+    assert sa_automount.get("curie-langfuse") is False, (
+        "static: Langfuse ServiceAccount must set automountServiceAccountToken: false; "
+        f"got {sa_automount.get('curie-langfuse')!r}"
+    )
+    print("ok: static: api, worker, bundle-fetch, and both Langfuse Deployments carry static S3 credentials")
 
 
 def assert_web_identity(path):
-    api, worker, bundle_fetch, fetch_command, service_accounts, egress_excepts = read(path)
+    (
+        api,
+        worker,
+        bundle_fetch,
+        fetch_command,
+        service_accounts,
+        egress_excepts,
+        langfuse_web,
+        langfuse_worker,
+        langfuse_web_sa,
+        langfuse_worker_sa,
+        sa_automount,
+    ) = read(path)
 
     # Omission is complete: not present, not empty-valued. An empty explicit
     # credential stops the provider chain just as a real one does, so it would
@@ -221,6 +332,13 @@ def assert_web_identity(path):
             f"{label} still carries {present} on the key-free path. The env var must be "
             "ABSENT, not empty: the SDK treats an empty explicit credential as a credential "
             "and never reaches the web-identity provider."
+        )
+    for label, env in (("langfuse-web", langfuse_web), ("langfuse-worker", langfuse_worker)):
+        present = [key for key in LANGFUSE_CREDENTIAL_KEYS if key in env]
+        assert not present, (
+            f"{label} still carries {present} on the key-free path. The env var must be "
+            "ABSENT, not empty: Langfuse's AWS SDK treats an empty explicit credential as "
+            "a credential and never reaches the web-identity provider."
         )
 
     for name in ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"):
@@ -237,6 +355,14 @@ def assert_web_identity(path):
     assert api.get("S3_ENDPOINT_URL", {}).get("value") == "https://s3.example.com:443", (
         f"api lost its endpoint: {api.get('S3_ENDPOINT_URL')}"
     )
+    for label, env in (("langfuse-web", langfuse_web), ("langfuse-worker", langfuse_worker)):
+        for key in (
+            "LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT",
+            "LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT",
+        ):
+            assert env.get(key, {}).get("value") == "https://s3.example.com:443", (
+                f"{label} lost {key}: {env.get(key)}"
+            )
 
     # The role binds on the ServiceAccount, so an annotation that does not render
     # means there is no way to name an identity at all.
@@ -245,12 +371,31 @@ def assert_web_identity(path):
         for name, annotations in service_accounts.items()
         if "eks.amazonaws.com/role-arn" in annotations
     }
-    for suffix in ("-api", "-worker", "-runner"):
+    for suffix in ("-api", "-worker", "-runner", "-langfuse"):
         matches = [name for name in annotated if name.endswith(suffix)]
         assert matches, (
             f"no ServiceAccount ending in {suffix} carries eks.amazonaws.com/role-arn. "
             "Without it the key-free path has no identity to assume."
         )
+    # Follow the Deployment binding rather than suffix-matching alone: a
+    # rendered SA with an annotation is not the identity these pods run as
+    # unless serviceAccountName names it. Pin the exact default name so an
+    # empty-name fallback cannot silently change while a `-langfuse` suffix
+    # still matches.
+    assert langfuse_web_sa == "curie-langfuse", (
+        f"langfuse-web binds {langfuse_web_sa!r}, expected 'curie-langfuse'"
+    )
+    assert langfuse_worker_sa == "curie-langfuse", (
+        f"langfuse-worker binds {langfuse_worker_sa!r}, expected 'curie-langfuse'"
+    )
+    assert langfuse_web_sa in annotated, (
+        f"Langfuse ServiceAccount {langfuse_web_sa} carries no eks.amazonaws.com/role-arn. "
+        "Without it the key-free path has no identity to assume."
+    )
+    assert sa_automount.get("curie-langfuse") is False, (
+        "web-identity: Langfuse ServiceAccount must set automountServiceAccountToken: false; "
+        f"got {sa_automount.get('curie-langfuse')!r}"
+    )
     print(f"ok: web-identity: {len(annotated)} ServiceAccounts carry a role-arn annotation")
 
     # Rail 1 must be untouched by any of the above. Assert CONTAINMENT rather
@@ -275,7 +420,7 @@ def assert_web_identity(path):
 
 
 def assert_bundle_fetch_region(path, expected_region):
-    _, _, bundle_fetch, _, _, _ = read(path)
+    _, _, bundle_fetch, _, _, _, _, _, _, _, _ = read(path)
     rendered = bundle_fetch.get("AWS_DEFAULT_REGION", {}).get("value")
     assert rendered == expected_region, (
         f"bundle-fetch AWS_DEFAULT_REGION rendered as {rendered!r}; expected "
@@ -338,6 +483,37 @@ def assert_langfuse_upload_regions(path, expected_region):
     )
 
 
+def assert_create_false(path):
+    (
+        _,
+        _,
+        _,
+        _,
+        service_accounts,
+        _,
+        _,
+        _,
+        langfuse_web_sa,
+        langfuse_worker_sa,
+        _,
+    ) = read(path)
+    assert langfuse_web_sa == "byo-langfuse-sa", (
+        f"create=false: langfuse-web binds {langfuse_web_sa!r}, expected 'byo-langfuse-sa'"
+    )
+    assert langfuse_worker_sa == "byo-langfuse-sa", (
+        f"create=false: langfuse-worker binds {langfuse_worker_sa!r}, expected 'byo-langfuse-sa'"
+    )
+    chart_owned = [name for name in service_accounts if name.endswith("-langfuse")]
+    assert not chart_owned, (
+        f"create=false must not render a chart-owned Langfuse ServiceAccount; got {chart_owned}"
+    )
+    assert "byo-langfuse-sa" not in service_accounts, (
+        "create=false must not emit the operator-named ServiceAccount; the chart binds it, "
+        "it does not create it"
+    )
+    print("ok: create=false: both Langfuse Deployments bind byo-langfuse-sa and the chart emits no Langfuse ServiceAccount")
+
+
 assert_static(sys.argv[1])
 assert_web_identity(sys.argv[2])
 assert_bundle_fetch_region(sys.argv[1], "us-east-1")
@@ -345,6 +521,7 @@ assert_bundle_fetch_region(sys.argv[3], "eu-west-1")
 assert_langfuse_upload_regions(sys.argv[1], "us-east-1")
 assert_langfuse_upload_regions(sys.argv[2], "us-east-1")
 assert_langfuse_upload_regions(sys.argv[3], "eu-west-1")
+assert_create_false(sys.argv[4])
 PY
 
 # Everything above reads the rendered YAML. That is necessary and not
@@ -382,6 +559,16 @@ uv run --python 3.13 python - "$STATIC_RENDERED" "$WEB_IDENTITY_RENDERED" "$WEB_
 import base64, os, sys, boto3, yaml
 
 ROLE_ANNOTATION = "eks.amazonaws.com/role-arn"
+LANGFUSE_CREDENTIAL_KEYS = (
+    "LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID",
+    "LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY",
+    "LANGFUSE_S3_MEDIA_UPLOAD_ACCESS_KEY_ID",
+    "LANGFUSE_S3_MEDIA_UPLOAD_SECRET_ACCESS_KEY",
+)
+LANGFUSE_WORKLOADS = (
+    ("langfuse-web", "curie-langfuse-web", "langfuse-web"),
+    ("langfuse-worker", "curie-langfuse-worker", "langfuse-worker"),
+)
 
 
 def load_manifest(path):
@@ -628,7 +815,36 @@ for label, workload, container_name, build_client in WORKLOADS:
         "credential at all."
     )
     print(f"ok: key-free: {label} resolves credentials via {method}")
+
+# Langfuse uses the AWS SDK for JavaScript, not boto3 BundleStore, so this
+# block cannot ask a constructed client which provider won. It still follows
+# the rendered env (secretKeyRefs resolved) and the ServiceAccount each
+# Deployment actually names, which is the same identity path the api/worker
+# checks use before they build a client. An empty access-key id paired with a
+# chart Secret is the #2211 failure; it must not survive this resolution.
+for label, workload, container_name in LANGFUSE_WORKLOADS:
+    deployment = deployment_for(static_deployments, workload)
+    manifest_env = resolve_env(label, deployment, container_name, static_secrets)
+    missing = [key for key in LANGFUSE_CREDENTIAL_KEYS if key not in manifest_env]
+    assert not missing, (
+        f"static: {label} is missing {missing}; the default install must keep "
+        "static Langfuse S3 credentials"
+    )
+    account = deployment["spec"]["template"]["spec"].get("serviceAccountName")
+    assert account, f"static: {label} Deployment names no serviceAccountName"
+    print(f"ok: static: {label} carries static S3 credentials and binds {account}")
+
+for label, workload, container_name in LANGFUSE_WORKLOADS:
+    deployment = deployment_for(free_deployments, workload)
+    manifest_env = resolve_env(label, deployment, container_name, free_secrets)
+    present = [key for key in LANGFUSE_CREDENTIAL_KEYS if key in manifest_env]
+    assert not present, (
+        f"key-free: {label} still carries {present} after secretKeyRef resolution. "
+        "The env var must be ABSENT, not empty."
+    )
+    arn = resolve_role_arn(label, deployment, free_accounts)
+    print(f"ok: key-free: {label} omits S3 credentials and binds role {arn}")
 PY
 
 echo
-echo "PASS: the default install keeps static object-store credentials and still signs with the access key its manifest carries; clearing rustfs.auth.accessKey omits every credential env and shell export across api, worker, and bundle-fetch, binds identity through ServiceAccount annotations, is refused against the in-chart RustFS, leaves Rail 1's IMDS denial intact, and makes the api and worker BundleStore objects resolve real credentials through the web-identity provider rather than an explicit key."
+echo "PASS: the default install keeps static object-store credentials and still signs with the access key its manifest carries; clearing rustfs.auth.accessKey omits every credential env and shell export across api, worker, bundle-fetch, and both Langfuse Deployments, binds identity through ServiceAccount annotations (including Langfuse), is refused against the in-chart RustFS, leaves Rail 1's IMDS denial intact, and makes the api and worker BundleStore objects resolve real credentials through the web-identity provider rather than an explicit key."

--- a/charts/curie/templates/_helpers.tpl
+++ b/charts/curie/templates/_helpers.tpl
@@ -286,6 +286,14 @@ true
 {{- end -}}
 {{- end -}}
 
+{{/* Shared ServiceAccount name for both Langfuse Deployments. Empty
+     langfuse.serviceAccount.name falls back to <release>-langfuse so a
+     key-free install can bind one role without duplicating the name on
+     web and worker (#2211). */}}
+{{- define "curie.langfuse.serviceAccountName" -}}
+{{- .Values.langfuse.serviceAccount.name | default (printf "%s-langfuse" (include "curie.fullname" .)) -}}
+{{- end -}}
+
 {{/* Base URL of the platform API for a first-party service that calls it. Call
      with a dict: root (the top context) and baseUrl (the caller's own BYO
      override). An empty override derives the in-chart API Service; a set value
@@ -961,6 +969,12 @@ livenessProbe:
        release reports healthy. See #2214. */}}
 - name: LANGFUSE_S3_EVENT_UPLOAD_REGION
   value: {{ .Values.rustfs.region | quote }}
+{{- /* Credential env is gated the same way as api/worker/bundle-fetch
+       (#2211). An empty rustfs.auth.accessKey on the key-free path must
+       omit these, not emit them empty: Langfuse's AWS SDK treats an empty
+       explicit credential as a credential and never reaches the
+       web-identity provider. */}}
+{{- if include "curie.rustfs.staticCredentials" . }}
 - name: LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID
   value: {{ .Values.rustfs.auth.accessKey | quote }}
 - name: LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY
@@ -968,6 +982,7 @@ livenessProbe:
     secretKeyRef:
       name: {{ .Values.rustfs.existingSecret | default (include "curie.secretName" .) }}
       key: rustfsSecretKey
+{{- end }}
 {{- /* Both endpoints go through curie.rustfs.endpoint, never a literal
        scheme. They were hardcoded http:// while api/worker/sandbox used the
        helper, so a BYO store on rustfs.port 443 got https:// everywhere except
@@ -983,6 +998,7 @@ livenessProbe:
   value: {{ .Values.rustfs.bucket | quote }}
 - name: LANGFUSE_S3_MEDIA_UPLOAD_REGION
   value: {{ .Values.rustfs.region | quote }}
+{{- if include "curie.rustfs.staticCredentials" . }}
 - name: LANGFUSE_S3_MEDIA_UPLOAD_ACCESS_KEY_ID
   value: {{ .Values.rustfs.auth.accessKey | quote }}
 - name: LANGFUSE_S3_MEDIA_UPLOAD_SECRET_ACCESS_KEY
@@ -990,6 +1006,7 @@ livenessProbe:
     secretKeyRef:
       name: {{ .Values.rustfs.existingSecret | default (include "curie.secretName" .) }}
       key: rustfsSecretKey
+{{- end }}
 - name: LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT
   value: {{ include "curie.rustfs.endpoint" . }}
 - name: LANGFUSE_S3_MEDIA_UPLOAD_FORCE_PATH_STYLE

--- a/charts/curie/templates/langfuse.yaml
+++ b/charts/curie/templates/langfuse.yaml
@@ -1,4 +1,27 @@
 {{- if .Values.langfuse.deploy }}
+{{- if .Values.langfuse.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "curie.langfuse.serviceAccountName" . }}
+  labels:
+    {{- include "curie.labels" . | nindent 4 }}
+    app.kubernetes.io/component: langfuse
+  {{- with .Values.langfuse.serviceAccount.annotations }}
+  # Where a key-free object store binds Langfuse's identity (#2211): an IRSA
+  # install annotates this SA with `eks.amazonaws.com/role-arn`, and the
+  # pod-identity webhook injects the projected token and the two web-identity
+  # env vars. Both Langfuse Deployments share this account.
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+# Langfuse does not call the Kubernetes API. IRSA's projected web-identity
+# token is a separate volume, so this composes with key-free object-store
+# auth. Leaving automount at the Kubernetes default would mint a namespace
+# API token the previous `default` ServiceAccount path did not need.
+automountServiceAccountToken: false
+---
+{{- end }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -49,6 +72,7 @@ spec:
       {{- with (include "curie.placement.spec" (dict "root" $ "class" "platform")) }}
       {{- . | nindent 6 }}
       {{- end }}
+      serviceAccountName: {{ include "curie.langfuse.serviceAccountName" . }}
       {{- if or .Values.langfuse.clickhouseReadiness.enabled .Values.langfuse.web.postgresReadiness.enabled }}
       initContainers:
       {{- if .Values.langfuse.web.postgresReadiness.enabled }}
@@ -221,6 +245,7 @@ spec:
       {{- with (include "curie.placement.spec" (dict "root" $ "class" "platform")) }}
       {{- . | nindent 6 }}
       {{- end }}
+      serviceAccountName: {{ include "curie.langfuse.serviceAccountName" . }}
       {{- if .Values.langfuse.clickhouseReadiness.enabled }}
       initContainers:
         {{- include "curie.langfuse.clickhouseGate" (dict

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -148,6 +148,18 @@ langfuse:
   salt: dev-salt-change-me
   nextauthSecret: dev-nextauth-secret-change-me
   existingSecret: ""
+  # Shared ServiceAccount for both Langfuse Deployments (web and worker).
+  # The key-free object store path (#1325 / #2211) binds its IAM role here,
+  # e.g. `eks.amazonaws.com/role-arn: arn:aws:iam::<account>:role/<role>`.
+  # The chart-created account sets automountServiceAccountToken: false:
+  # Langfuse does not call the Kubernetes API, and IRSA uses a separate
+  # projected token.
+  serviceAccount:
+    create: true
+    # Empty -> <release>-langfuse. Set to bind a pre-created ServiceAccount
+    # (`create: false`).
+    name: ""
+    annotations: {}
   # Headless bootstrap seeds a fixed org/project on first boot. The project
   # secret key and user password are first boot inputs. Fresh chart installs
   # generate them unless development defaults are enabled; changing them during
@@ -499,12 +511,13 @@ rustfs:
   #
   # Clearing `accessKey` selects the key-free path (#1325), valid only with
   # `deploy: false` and an external store: every S3 credential env var is
-  # omitted from the api, the worker, and the sandbox bundle-fetch init
-  # container, so the AWS SDK falls through its provider chain to the
+  # omitted from the api, the worker, the sandbox bundle-fetch init container,
+  # and Langfuse, so the AWS SDK falls through its provider chain to the
   # web-identity provider (`AWS_ROLE_ARN` + `AWS_WEB_IDENTITY_TOKEN_FILE`) fed
   # by a projected ServiceAccount token. Bind the role with the
-  # `serviceAccount.annotations` blocks on `api`, `worker`, and
-  # `agentSandbox.runner`. Clearing it with `deploy: true` is refused at render.
+  # `serviceAccount.annotations` blocks on `api`, `worker`,
+  # `agentSandbox.runner`, and `langfuse`. Clearing it with `deploy: true` is
+  # refused at render.
   #
   # The instance role is NOT an option here, deliberately. Rail 1 denies
   # 169.254.169.254 by construction and computes an `except` so a broad


### PR DESCRIPTION
## Summary

Langfuse was the one S3 consumer left off the key-free (web identity / IRSA) object-store path. Clearing `rustfs.auth.accessKey` already omitted credentials for the API, worker, and bundle-fetch init container, but `curie.langfuse.env` still emitted an empty access-key id plus a `secretKeyRef` into the chart Secret, and both Langfuse Deployments ran as the namespace `default` ServiceAccount with no annotation knob.

This wraps both Langfuse S3 credential env pairs in `curie.rustfs.staticCredentials`, adds a shared `langfuse.serviceAccount` (`create`, `name`, `annotations`) bound on both Deployments, documents Langfuse in the README key-free example, and extends `ci/object-store-web-identity-assertions.sh` so a regression fails the render gate.

## Related issue

Closes #2211

## Fix pin verification

Fix pin: charts/curie/ci/object-store-web-identity-assertions.sh

## Conservative defaults

- One shared ServiceAccount for both Langfuse Deployments (web and worker), not two.
- `serviceAccountName` is always set, including on the static-credentials path, so adding a role annotation later does not change which identity the pods run as.
- Empty `langfuse.serviceAccount.name` defaults to `<release>-langfuse`.
- `create: false` plus a custom `name` binds that pre-created account and does not emit a chart-owned Langfuse ServiceAccount.
- The chart-created account sets `automountServiceAccountToken: false` (not a values knob). Langfuse does not call the Kubernetes API; IRSA uses a separate projected token. Added after independent review.
- Langfuse uses the AWS SDK for JavaScript, so the boto3 BundleStore provider-chain block still covers only api and worker. Langfuse is asserted from the rendered env and the ServiceAccount each Deployment names.

Upgrade note: Langfuse pods no longer run as the namespace `default` ServiceAccount. An out-of-chart role association on `default` will not follow them; move the role annotation to `langfuse.serviceAccount.annotations`.

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | Does not reach plugin packaging, the runner turn loop, ACI events, or skill eval/check. | | |
| local | n/a | Does not reach compose services, dispatcher, worker, API wiring, or the console UI. | | |
| local-release | n/a | Does not reach released binary or image identity, the install path, or release compose. | | |
| cluster | required | Chart templates, Langfuse ServiceAccount, and both Langfuse Deployments. The acceptance criteria are about rendered manifests. | fake | `bash charts/curie/ci/object-store-web-identity-assertions.sh` on `2e1b2b12e`: PASS. Key-free render: both Langfuse Deployments omit `LANGFUSE_S3_*ACCESS_KEY*` env, bind `curie-langfuse`, and that ServiceAccount carries `eks.amazonaws.com/role-arn` with `automountServiceAccountToken: false`. Static render still carries the four credential env vars. `create: false` plus `name=byo-langfuse-sa` binds both Deployments and emits no Langfuse ServiceAccount. Negative: the same script against origin/main failed with `AssertionError: static: langfuse-web Deployment names no serviceAccountName`. `helm lint charts/curie` passed. Sibling `worker-object-store-assertions.sh`, `langfuse-byo-assertions.sh`, and `langfuse-runasuser-assertions.sh` passed. |
| live provider | n/a | Does not reach model routing, product-model credential resolution, or token/cost accounting. | | |
| external integration | n/a | Does not reach Slack, git push webhooks, connector OAuth, or a third-party API shape. | | |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [x] An ADR is added under `docs/adr/` if this is an architectural decision.
