### PR TITLE
Pin chart ClickHouse to 25.12 for the Langfuse migration set

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -220,6 +220,14 @@ jobs:
           set -euo pipefail
           bash charts/curie/ci/langfuse-image-pin-assertions.sh
 
+      # Keep the chart ClickHouse default and Langfuse pin as one supported
+      # pair. ClickHouse 24.8 cannot apply Langfuse 3.225.x migration 39, so
+      # the default must stay on 25.12 and AVX-required (#2210).
+      - name: helm render assertions (clickhouse langfuse pin pair)
+        run: |
+          set -euo pipefail
+          bash charts/curie/ci/clickhouse-langfuse-pin-assertions.sh
+
       # Prove Langfuse startup is gated on ClickHouse being up (issue #2009). A
       # Helm upgrade that recreates the ClickHouse Service otherwise lets the new
       # Langfuse pods start their migrations against an unresolvable name, so the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,9 +198,13 @@ Host ports (non-default host ports to avoid local collisions):
 Config lives in `.env.example` (copy to the gitignored `.env` to override; the
 stack runs on the baked defaults without one). Load-bearing facts:
 
-- **ClickHouse is pinned to `:24.8`.** Newer ClickHouse requires AVX and SIGILLs
-  with exit 132 on CPUs without it. Keep the pin unless every target CPU has AVX.
-  `charts/curie` turns this into a chart preflight (`preflights.avxCheck`).
+- **ClickHouse:** `compose.dev.yaml` stays on `:24.8` so an SSE4.2-only
+  developer host can still boot the local stack (Langfuse `3.225.5` still
+  applies on 24.8). The Helm chart default is `:25.12`, required by the
+  Langfuse pin's ClickHouse migrations from 39 onward; AVX is a chart-default
+  requirement. `preflights.avxCheck` fails an AVX-less node unless the
+  operator pins a tag in `clickhouse.sse42SafeTags`. Do not move the two
+  chart pins independently (#2210).
 - **Langfuse OTLP ingest is HTTP-only** (gRPC is silently unsupported). Services
   may emit OTLP over gRPC or HTTP to the OTel Collector (4317/4318); the
   collector always exports to Langfuse over HTTP. Send app traces to the

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -686,7 +686,7 @@ Security rails are all chart defaults (ADR-0006,
 
 - **Default-deny egress NetworkPolicy** with an explicit `except: 169.254.169.254/32` carve-out so the cloud metadata endpoint stays blocked ([`charts/curie/templates/security-networkpolicy.yaml`](charts/curie/templates/security-networkpolicy.yaml)).
 - **gVisor RuntimeClass** option on the runner, plus a preflight Job that runs under the class and fails if the kernel is not gVisor ([`charts/curie/templates/preflight-gvisor.yaml`](charts/curie/templates/preflight-gvisor.yaml)).
-- **AVX (a CPU instruction-set extension)/ClickHouse preflight** — a blocking pre-install hook that fails when the CPU lacks AVX and the ClickHouse tag is not the SSE4.2-safe pin ([`charts/curie/templates/preflight-avx.yaml`](charts/curie/templates/preflight-avx.yaml)). It is the productized form of the `:24.8` pin documented in [`CLAUDE.md`](CLAUDE.md).
+- **AVX (a CPU instruction-set extension)/ClickHouse preflight** - a blocking pre-install hook that fails when the CPU lacks AVX and the ClickHouse tag is not in `clickhouse.sse42SafeTags` ([`charts/curie/templates/preflight-avx.yaml`](charts/curie/templates/preflight-avx.yaml)). Chart defaults pin ClickHouse `:25.12` (coupled to the Langfuse pin, #2210), so AVX is required unless the operator overrides to an SSE4.2-safe tag.
 - **Bundle-fetch init containers** on the sandbox template, fail-closed if a bundle ref is set but no archive is fetched ([`charts/curie/templates/agent-sandbox.yaml`](charts/curie/templates/agent-sandbox.yaml)), with a RustFS egress carve-out.
 - **A chart-managed platform Secret** ([`charts/curie/templates/secrets.yaml`](charts/curie/templates/secrets.yaml)) carries:
   - backing-store passwords

--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -6,9 +6,10 @@ ClickHouse + RustFS + OTel Collector, dev profile, BYO (bring-your-own)
 toggles, the two preflights) plus the security rails as chart defaults.
 
 The chart is a direct port of the proven `compose.dev.yaml` dev stack: same
-images, same tags, same `:24.8` ClickHouse pin, same headless-bootstrapped
-Langfuse dev project. So the compose stack and this chart verify
-the identical stack. Rather than vendoring the upstream Langfuse chart and its
+images and the same headless-bootstrapped Langfuse dev project. The chart
+ClickHouse default is `:25.12` (AVX required, coupled to `langfuse.image.tag`)
+while compose stays on `:24.8` so an SSE4.2-only developer host can still boot
+the local stack. Rather than vendoring the upstream Langfuse chart and its
 Bitnami subcharts, each component is a first-class template here -- this keeps
 the single-node footprint controllable and avoids the Bitnami-catalog
 (`bitnamilegacy/*`) instability. It still follows the Langfuse chart *idiom*:
@@ -342,7 +343,7 @@ pipeline and environment are applied on `helm upgrade`.
 | Langfuse web + worker | `langfuse/langfuse:3.225.5`, `langfuse/langfuse-worker:3.225.5` | Observability + eval backbone. Headless-bootstrapped dev org/project. Web and worker stay on one reviewed migration set; do not replace the version with floating `:3`. |
 | Postgres | `postgres:16-alpine` | Langfuse transactional store + app state. StatefulSet. |
 | Valkey | `valkey/valkey:8-alpine` | Langfuse cache/queue + dispatcher Streams queue. |
-| ClickHouse | `clickhouse/clickhouse-server:24.8` | Langfuse OLAP store. Tag pinned SSE4.2-safe (see preflight). |
+| ClickHouse | `clickhouse/clickhouse-server:25.12` | Langfuse OLAP store. Coupled to `langfuse.image.tag` 3.225.5; chart default requires AVX (see preflight). |
 | RustFS | `rustfs/rustfs:1.0.0-beta.12` plus `amazon/aws-cli:2.32.6` init | Langfuse object storage; BYO real S3 in prod. |
 | OTel Collector | `otel/opentelemetry-collector-contrib:0.119.0` | Bounded OTLP gateway (gRPC+HTTP), durable queue by default; traces -> Langfuse over HTTP, logs/metrics -> configured exporters. |
 | Mail adapter | `ghcr.io/curie-eng/curie-mail-adapter` | Off by default. One `Recreate` replica with durable SQLite on single-writer storage; no platform key/database credential or ServiceAccount token. |
@@ -649,12 +650,15 @@ pre-upgrade hook Job.
 
 - ClickHouse >= 25.x is compiled for AVX and SIGILLs with exit 132 on
   SSE4.2-only CPUs -- a crash-looping pod is a confusing way to learn that.
+- Chart defaults require AVX: `clickhouse.image.tag` is `25.12` because
+  `langfuse.image.tag` 3.225.5's migration set from 39 onward cannot apply on
+  24.8, and 25.12 is not in `clickhouse.sse42SafeTags`.
 - The Job reads the node's `/proc/cpuinfo`; if the node lacks AVX it FAILS
-  the install unless the configured ClickHouse tag is in
-  `clickhouse.sse42SafeTags` (`24.8`, `24.3`, `23.8`). Skipped when
-  `clickhouse.deploy: false`.
-- Test knob `preflights.avxCheck.forceNoAvx: true` exercises the SSE4.2
-  branch on an AVX-capable node.
+  the install unless the operator pins a tag in `clickhouse.sse42SafeTags`
+  (`24.8`, `24.3`, `23.8`). That override cannot apply the current Langfuse
+  migration set. Skipped when `clickhouse.deploy: false`.
+- Test knob `preflights.avxCheck.forceNoAvx: true` exercises the AVX-required
+  failure branch on an AVX-capable node when the default tag is set.
 - Read the verdict: `kubectl logs -n <ns> job/<release>-preflight-avx`.
 
 **(b) NetworkPolicy-enforcement probe** (`preflights.networkPolicyProbe`). A

--- a/charts/curie/ci/clickhouse-langfuse-pin-assertions.sh
+++ b/charts/curie/ci/clickhouse-langfuse-pin-assertions.sh
@@ -1,0 +1,393 @@
+#!/usr/bin/env bash
+#
+# Issue #2210: keep the chart ClickHouse default and the Langfuse pin as one
+# supported pair, and fail CI when either side drifts.
+#
+# Langfuse 3.225.x ClickHouse migration 39 cannot parse on 24.8 or 25.8. The
+# chart default must be 25.12 (the version Langfuse's own compose pins at
+# v3.225.7) so the Langfuse pin can be advanced, and AVX is a chart-default
+# requirement because 25.12 is not SSE4.2-safe. Comments on both values.yaml
+# keys must name the other pin so they are not moved independently.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART="$(cd "$SCRIPT_DIR/.." && pwd)"
+VALUES="$CHART/values.yaml"
+EXPECTED_LANGFUSE="3.225.5"
+EXPECTED_CLICKHOUSE="25.12"
+EXPECTED_CLICKHOUSE_IMAGE="clickhouse/clickhouse-server:${EXPECTED_CLICKHOUSE}"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+RENDER="$TMP/chart.yaml"
+CHECKER="$TMP/check.py"
+
+helm template curie "$CHART" >"$RENDER"
+
+cat >"$CHECKER" <<'PY'
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+
+import yaml
+
+(
+    chart_path,
+    values_path,
+    expected_langfuse,
+    expected_clickhouse,
+    expected_clickhouse_image,
+) = sys.argv[1:]
+
+documents = [
+    document
+    for document in yaml.safe_load_all(pathlib.Path(chart_path).read_text())
+    if document
+]
+
+problems = []
+clickhouse_images = []
+langfuse_images = {}
+preflight_env = {}
+preflight_script = None
+
+for document in documents:
+    kind = document.get("kind")
+    name = document.get("metadata", {}).get("name", "")
+    spec = document.get("spec", {})
+    template_spec = spec.get("template", {}).get("spec", {})
+    containers = template_spec.get("containers") or []
+
+    if kind == "StatefulSet":
+        for container in containers:
+            if container.get("name") == "clickhouse":
+                clickhouse_images.append(container.get("image"))
+
+    if kind == "Deployment":
+        for container in containers:
+            cname = container.get("name")
+            if cname in ("langfuse-web", "langfuse-worker"):
+                langfuse_images[cname] = container.get("image")
+
+    if kind == "Job" and str(name).endswith("-preflight-avx"):
+        for container in containers:
+            if container.get("name") != "avx-check":
+                continue
+            for item in container.get("env") or []:
+                preflight_env[item.get("name")] = item.get("value")
+            command = container.get("command") or []
+            if command:
+                preflight_script = command[-1]
+
+if clickhouse_images != [expected_clickhouse_image]:
+    problems.append(
+        f"chart clickhouse must use reviewed image {expected_clickhouse_image}; "
+        f"found {clickhouse_images!r}"
+    )
+
+expected_langfuse_images = {
+    "langfuse-web": f"langfuse/langfuse:{expected_langfuse}",
+    "langfuse-worker": f"langfuse/langfuse-worker:{expected_langfuse}",
+}
+for name, wanted in expected_langfuse_images.items():
+    actual = langfuse_images.get(name)
+    if actual != wanted:
+        problems.append(
+            f"chart {name} must use reviewed image {wanted}; found {actual!r}"
+        )
+
+if preflight_env.get("CLICKHOUSE_TAG") != expected_clickhouse:
+    problems.append(
+        "AVX preflight CLICKHOUSE_TAG must match the chart ClickHouse pin "
+        f"{expected_clickhouse}; found {preflight_env.get('CLICKHOUSE_TAG')!r}"
+    )
+if preflight_env.get("CLICKHOUSE_IMAGE") != expected_clickhouse_image:
+    problems.append(
+        "AVX preflight CLICKHOUSE_IMAGE must match the chart ClickHouse pin "
+        f"{expected_clickhouse_image}; found {preflight_env.get('CLICKHOUSE_IMAGE')!r}"
+    )
+
+safe_tags = (preflight_env.get("SSE42_SAFE_TAGS") or "").split()
+if expected_clickhouse in safe_tags:
+    problems.append(
+        f"chart-default ClickHouse {expected_clickhouse} must stay out of "
+        "sse42SafeTags so AVX remains required for the default pair; "
+        f"found {safe_tags!r}"
+    )
+if "24.8" not in safe_tags:
+    problems.append(
+        "sse42SafeTags must still list 24.8 as the explicit AVX-less override; "
+        f"found {safe_tags!r}"
+    )
+
+values_text = pathlib.Path(values_path).read_text()
+langfuse_idx = values_text.find('tag: "' + expected_langfuse + '"')
+clickhouse_idx = values_text.find('tag: "' + expected_clickhouse + '"')
+if langfuse_idx < 0:
+    problems.append(
+        f"values.yaml langfuse.image.tag must be {expected_langfuse}"
+    )
+if clickhouse_idx < 0:
+    problems.append(
+        f"values.yaml clickhouse.image.tag must be {expected_clickhouse}"
+    )
+
+def preceding_comment(text, idx, window=900):
+    start = max(0, idx - window)
+    return text[start:idx]
+
+
+if langfuse_idx >= 0:
+    langfuse_comment = preceding_comment(values_text, langfuse_idx)
+    if "clickhouse.image.tag" not in langfuse_comment or expected_clickhouse not in langfuse_comment:
+        problems.append(
+            "langfuse.image.tag comment must name clickhouse.image.tag "
+            f"{expected_clickhouse} as its constraint"
+        )
+if clickhouse_idx >= 0:
+    clickhouse_comment = preceding_comment(values_text, clickhouse_idx)
+    if "langfuse.image.tag" not in clickhouse_comment or expected_langfuse not in clickhouse_comment:
+        problems.append(
+            "clickhouse.image.tag comment must name langfuse.image.tag "
+            f"{expected_langfuse} as its constraint"
+        )
+
+if preflight_script is None:
+    problems.append("AVX preflight Job script was not rendered")
+else:
+    script_path = pathlib.Path(tempfile.mkdtemp()) / "avx-check.sh"
+    script_path.write_text(preflight_script)
+    env = os.environ.copy()
+    env.update({
+        "CLICKHOUSE_TAG": preflight_env.get("CLICKHOUSE_TAG") or "",
+        "CLICKHOUSE_IMAGE": preflight_env.get("CLICKHOUSE_IMAGE") or "",
+        "SSE42_SAFE_TAGS": preflight_env.get("SSE42_SAFE_TAGS") or "",
+        "FORCE_NO_AVX": "true",
+    })
+    completed = subprocess.run(
+        ["/bin/sh", str(script_path)],
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+    combined = completed.stdout + completed.stderr
+    if completed.returncode == 0:
+        problems.append(
+            "AVX preflight must FAIL without AVX on the chart-default "
+            f"ClickHouse {expected_clickhouse}; it passed:\n{combined}"
+        )
+    elif "FAIL" not in combined:
+        problems.append(
+            "AVX preflight failed without AVX but did not report FAIL for "
+            f"chart-default ClickHouse {expected_clickhouse}:\n{combined}"
+        )
+
+if problems:
+    raise SystemExit("\n".join(problems))
+
+print(
+    f"chart pins Langfuse {expected_langfuse} with ClickHouse {expected_clickhouse}, "
+    "comments name the pair, and AVX is required for the default tag"
+)
+PY
+
+python3 "$CHECKER" "$RENDER" "$VALUES" "$EXPECTED_LANGFUSE" "$EXPECTED_CLICKHOUSE" "$EXPECTED_CLICKHOUSE_IMAGE"
+
+# helm template does not emit NOTES.txt. Render it through tpl so the
+# operator-facing label is asserted on the same consumer path as `helm install`.
+NOTES_CHART="$TMP/notes-chart"
+cp -a "$CHART" "$NOTES_CHART"
+cp "$CHART/templates/NOTES.txt" "$NOTES_CHART/NOTES.txt"
+cat >"$NOTES_CHART/templates/notes-check.yaml" <<'EOF'
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: notes-check
+data:
+  notes: |
+{{ tpl (.Files.Get "NOTES.txt") . | nindent 4 }}
+EOF
+
+NOTES="$TMP/notes.yaml"
+helm template curie "$NOTES_CHART" --show-only templates/notes-check.yaml >"$NOTES"
+if ! grep -q '\[AVX required\]' "$NOTES"; then
+  echo "FAIL: default helm NOTES must label ClickHouse [AVX required]; got:" >&2
+  cat "$NOTES" >&2
+  exit 1
+fi
+if grep -q 'SSE4.2-pinned' "$NOTES"; then
+  echo "FAIL: default helm NOTES still claim SSE4.2-pinned" >&2
+  exit 1
+fi
+
+OVERRIDE_NOTES="$TMP/notes-24.8.yaml"
+helm template curie "$NOTES_CHART" --show-only templates/notes-check.yaml \
+  --set clickhouse.image.tag=24.8 >"$OVERRIDE_NOTES"
+if ! grep -q '\[SSE4.2-safe override\]' "$OVERRIDE_NOTES"; then
+  echo "FAIL: 24.8 override NOTES must label ClickHouse [SSE4.2-safe override]; got:" >&2
+  cat "$OVERRIDE_NOTES" >&2
+  exit 1
+fi
+echo "NOTES: default ClickHouse is [AVX required]; 24.8 override is [SSE4.2-safe override]"
+
+OVERRIDE_RENDER="$TMP/chart-24.8.yaml"
+helm template curie "$CHART" --set clickhouse.image.tag=24.8 >"$OVERRIDE_RENDER"
+python3 - "$OVERRIDE_RENDER" <<'PY'
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+
+import yaml
+
+documents = [
+    document
+    for document in yaml.safe_load_all(pathlib.Path(sys.argv[1]).read_text())
+    if document
+]
+preflight_env = {}
+preflight_script = None
+clickhouse_images = []
+for document in documents:
+    kind = document.get("kind")
+    name = document.get("metadata", {}).get("name", "")
+    spec = document.get("spec", {}).get("template", {}).get("spec", {})
+    containers = spec.get("containers") or []
+    if kind == "StatefulSet":
+        for container in containers:
+            if container.get("name") == "clickhouse":
+                clickhouse_images.append(container.get("image"))
+    if kind == "Job" and str(name).endswith("-preflight-avx"):
+        for container in containers:
+            if container.get("name") != "avx-check":
+                continue
+            for item in container.get("env") or []:
+                preflight_env[item.get("name")] = item.get("value")
+            command = container.get("command") or []
+            if command:
+                preflight_script = command[-1]
+if clickhouse_images != ["clickhouse/clickhouse-server:24.8"]:
+    raise SystemExit(f"24.8 override render must use ClickHouse 24.8; found {clickhouse_images!r}")
+if preflight_env.get("CLICKHOUSE_TAG") != "24.8":
+    raise SystemExit(
+        "24.8 override must flow clickhouse.image.tag into AVX preflight "
+        f"CLICKHOUSE_TAG; found {preflight_env.get('CLICKHOUSE_TAG')!r}"
+    )
+if preflight_script is None:
+    raise SystemExit("24.8 override did not render the AVX preflight Job")
+script_path = pathlib.Path(tempfile.mkdtemp()) / "avx-check.sh"
+script_path.write_text(preflight_script)
+env = os.environ.copy()
+env.update({
+    "CLICKHOUSE_TAG": preflight_env.get("CLICKHOUSE_TAG") or "",
+    "CLICKHOUSE_IMAGE": preflight_env.get("CLICKHOUSE_IMAGE") or "",
+    "SSE42_SAFE_TAGS": preflight_env.get("SSE42_SAFE_TAGS") or "",
+    "FORCE_NO_AVX": "true",
+})
+completed = subprocess.run(["/bin/sh", str(script_path)], env=env, text=True, capture_output=True)
+out = completed.stdout + completed.stderr
+if completed.returncode != 0:
+    raise SystemExit(
+        "AVX preflight must PASS without AVX on a helm-rendered 24.8 override; "
+        f"it failed:\n{out}"
+    )
+print("override: helm-rendered clickhouse.image.tag=24.8 passes AVX preflight without AVX")
+PY
+
+MUTANT_RENDER="$TMP/chart-old-clickhouse.yaml"
+python3 - "$RENDER" "$MUTANT_RENDER" "$EXPECTED_CLICKHOUSE" <<'PY'
+import pathlib
+import sys
+
+render, mutant, version = sys.argv[1:]
+pathlib.Path(mutant).write_text(
+    pathlib.Path(render).read_text().replace(f":{version}", ":24.8")
+)
+PY
+
+negative_output=""
+if negative_output="$(python3 "$CHECKER" "$MUTANT_RENDER" "$VALUES" "$EXPECTED_LANGFUSE" "$EXPECTED_CLICKHOUSE" "$EXPECTED_CLICKHOUSE_IMAGE" 2>&1)"; then
+  echo "FAIL: ClickHouse 24.8 mutation passed the Langfuse/ClickHouse pair contract" >&2
+  exit 1
+fi
+if [[ "$negative_output" != *"must use reviewed image ${EXPECTED_CLICKHOUSE_IMAGE}"* ]]; then
+  echo "FAIL: ClickHouse 24.8 mutation failed unexpectedly: $negative_output" >&2
+  exit 1
+fi
+
+echo "negative: replacing ClickHouse ${EXPECTED_CLICKHOUSE} with 24.8 is rejected"
+
+MUTANT_LANGFUSE="$TMP/chart-new-langfuse.yaml"
+python3 - "$RENDER" "$MUTANT_LANGFUSE" "$EXPECTED_LANGFUSE" <<'PY'
+import pathlib
+import sys
+
+render, mutant, version = sys.argv[1:]
+pathlib.Path(mutant).write_text(
+    pathlib.Path(render).read_text().replace(f":{version}", ":3")
+)
+PY
+
+if negative_output="$(python3 "$CHECKER" "$MUTANT_LANGFUSE" "$VALUES" "$EXPECTED_LANGFUSE" "$EXPECTED_CLICKHOUSE" "$EXPECTED_CLICKHOUSE_IMAGE" 2>&1)"; then
+  echo "FAIL: floating Langfuse :3 mutation passed the Langfuse/ClickHouse pair contract" >&2
+  exit 1
+fi
+if [[ "$negative_output" != *"must use reviewed image langfuse/langfuse:${EXPECTED_LANGFUSE}"* ]]; then
+  echo "FAIL: floating Langfuse :3 mutation failed unexpectedly: $negative_output" >&2
+  exit 1
+fi
+
+echo "negative: replacing Langfuse ${EXPECTED_LANGFUSE} with :3 is rejected"
+
+MUTANT_SSE42="$TMP/chart-sse42.yaml"
+python3 - "$RENDER" "$MUTANT_SSE42" "$EXPECTED_CLICKHOUSE" <<'PY'
+import pathlib
+import sys
+
+render, mutant, version = sys.argv[1:]
+text = pathlib.Path(render).read_text()
+old = 'value: "24.8 24.3 23.8"'
+new = f'value: "{version} 24.8 24.3 23.8"'
+if old not in text:
+    raise SystemExit(f"could not find AVX preflight SSE42_SAFE_TAGS assignment {old}")
+pathlib.Path(mutant).write_text(text.replace(old, new, 1))
+PY
+
+if negative_output="$(python3 "$CHECKER" "$MUTANT_SSE42" "$VALUES" "$EXPECTED_LANGFUSE" "$EXPECTED_CLICKHOUSE" "$EXPECTED_CLICKHOUSE_IMAGE" 2>&1)"; then
+  echo "FAIL: adding ${EXPECTED_CLICKHOUSE} to sse42SafeTags passed the pair contract" >&2
+  exit 1
+fi
+if [[ "$negative_output" != *"must stay out of sse42SafeTags"* ]]; then
+  echo "FAIL: sse42SafeTags mutation failed unexpectedly: $negative_output" >&2
+  exit 1
+fi
+
+echo "negative: adding ClickHouse ${EXPECTED_CLICKHOUSE} to sse42SafeTags is rejected"
+
+MUTANT_VALUES="$TMP/values-no-coupling.yaml"
+python3 - "$VALUES" "$MUTANT_VALUES" <<'PY'
+import pathlib
+import sys
+
+src, dest = sys.argv[1:]
+text = pathlib.Path(src).read_text().replace("clickhouse.image.tag", "image.tag").replace(
+    "langfuse.image.tag", "image.tag"
+)
+pathlib.Path(dest).write_text(text)
+PY
+
+if negative_output="$(python3 "$CHECKER" "$RENDER" "$MUTANT_VALUES" "$EXPECTED_LANGFUSE" "$EXPECTED_CLICKHOUSE" "$EXPECTED_CLICKHOUSE_IMAGE" 2>&1)"; then
+  echo "FAIL: stripping pin-coupling comments passed the pair contract" >&2
+  exit 1
+fi
+if [[ "$negative_output" != *"comment must name"* ]]; then
+  echo "FAIL: comment-stripping mutation failed unexpectedly: $negative_output" >&2
+  exit 1
+fi
+
+echo "negative: stripping the pin-coupling comments is rejected"
+echo "PASS: chart Langfuse ${EXPECTED_LANGFUSE} and ClickHouse ${EXPECTED_CLICKHOUSE} stay a documented pair"

--- a/charts/curie/templates/NOTES.txt
+++ b/charts/curie/templates/NOTES.txt
@@ -17,7 +17,14 @@ Components deployed:
   - Valkey: BYO at {{ .Values.valkey.host }}:{{ .Values.valkey.port }}
 {{- end }}
 {{- if .Values.clickhouse.deploy }}
-  - ClickHouse ({{ .Values.clickhouse.image.repository }}:{{ .Values.clickhouse.image.tag }})  [SSE4.2-pinned]
+{{- $chTag := .Values.clickhouse.image.tag | toString }}
+{{- $sse42 := false }}
+{{- range .Values.clickhouse.sse42SafeTags }}
+{{- if or (eq $chTag .) (hasPrefix (printf "%s." .) $chTag) (hasPrefix (printf "%s-" .) $chTag) }}
+{{- $sse42 = true }}
+{{- end }}
+{{- end }}
+  - ClickHouse ({{ .Values.clickhouse.image.repository }}:{{ $chTag }}){{ if $sse42 }}  [SSE4.2-safe override]{{ else }}  [AVX required]{{ end }}
 {{- else }}
   - ClickHouse: BYO at {{ .Values.clickhouse.host }}
 {{- end }}

--- a/charts/curie/templates/clickhouse.yaml
+++ b/charts/curie/templates/clickhouse.yaml
@@ -85,7 +85,8 @@ spec:
         {{- end }}
       containers:
         - name: clickhouse
-          # Pinned tag; the AVX preflight validates it against the node's CPU.
+          # Pinned tag (coupled to langfuse.image.tag); the AVX preflight
+          # validates it against the node's CPU.
           image: "{{ .Values.clickhouse.image.repository }}:{{ .Values.clickhouse.image.tag }}"
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           {{- with .Values.clickhouse.containerSecurityContext }}

--- a/charts/curie/templates/preflight-avx.yaml
+++ b/charts/curie/templates/preflight-avx.yaml
@@ -3,11 +3,13 @@
 Preflight (a): CPU-AVX / ClickHouse-pin check.
 
 Newer ClickHouse (>= 25.x) is compiled for AVX and SIGILLs with exit 132 on
-CPUs that only have SSE4.2. A crash-looping ClickHouse pod is a confusing way to
-discover this, so this hook catches it BEFORE the stores install: it reads the
-node's /proc/cpuinfo (a container shares the host kernel, so the flags are the
-node's), and if the node lacks AVX it FAILS the install unless the configured
-ClickHouse tag is in clickhouse.sse42SafeTags.
+CPUs that only have SSE4.2. The chart default is ClickHouse 25.12, required by
+the Langfuse pin (#2210); that tag is not SSE4.2-safe, so AVX is a
+chart-default requirement. This hook catches a missing AVX BEFORE the stores
+install: it reads the node's /proc/cpuinfo (a container shares the host kernel,
+so the flags are the node's), and if the node lacks AVX it FAILS the install
+unless the operator pins a tag in clickhouse.sse42SafeTags. That override
+cannot apply Langfuse ClickHouse migration 39.
 
 Runs as a pre-install / pre-upgrade hook (blocks a broken install) and is
 re-runnable via `helm test`. The Job is kept after success so its verdict log
@@ -101,9 +103,11 @@ spec:
               fi
 
               echo "RESULT: FAIL - node lacks AVX and ClickHouse tag '${CLICKHOUSE_TAG}' is NOT"
-              echo "        SSE4.2-safe. It will SIGILL (exit 132) and crash-loop on this node."
-              echo "REMEDY: pin clickhouse.image.tag to an SSE4.2-safe build (one of:"
-              echo "        ${SSE42_SAFE_TAGS}), e.g. --set clickhouse.image.tag=24.8"
+              echo "        SSE4.2-safe. Chart defaults require AVX because this tag is"
+              echo "        required by the Langfuse pin and will SIGILL (exit 132) here."
+              echo "REMEDY: install on AVX-capable nodes, or pin clickhouse.image.tag to an"
+              echo "        SSE4.2-safe build (one of: ${SSE42_SAFE_TAGS}) together with a"
+              echo "        Langfuse release whose ClickHouse migrations that tag can apply."
               exit 1
           resources:
             {{- toYaml .Values.preflights.avxCheck.resources | nindent 12 }}

--- a/charts/curie/values-dev.yaml
+++ b/charts/curie/values-dev.yaml
@@ -7,8 +7,9 @@
 # requests here is ~1.7 GB, leaving headroom for the kubelet/system and for
 # ClickHouse/Langfuse to burst toward their limits. Everything is single-replica
 # and ClickHouse cluster mode is off. This mirrors compose.dev.yaml (same
-# images, same :24.8 ClickHouse pin) so V1 (compose) and V3 (chart) verify the
-# same stack.
+# Langfuse pin; chart ClickHouse default is 25.12 / AVX-required, compose stays
+# 24.8 for SSE4.2-only local hosts) so V1 (compose) and V3 (chart) verify the
+# same application stack.
 
 langfuse:
   web:
@@ -39,7 +40,8 @@ valkey:
     limits: { cpu: 250m, memory: 256Mi }
 
 clickhouse:
-  # Keep the :24.8 SSE4.2-safe pin. Cluster mode off for single-node.
+  # Inherits the chart-default :25.12 pin (AVX required, coupled to Langfuse).
+  # Cluster mode off for single-node.
   clusterEnabled: false
   persistence:
     size: 3Gi

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -111,6 +111,9 @@ langfuse:
     worker: langfuse/langfuse-worker
     # Keep web and worker on one reviewed migration set. A floating :3 moved to
     # 3.225.6 during CI and left ClickHouse migration 39 dirty (#2190).
+    # Coupled to clickhouse.image.tag 25.12: Langfuse 3.225.x migrations from
+    # 39 onward need that ClickHouse version. Do not advance this pin without
+    # it, and do not move ClickHouse off 25.12 while this pin stays (#2210).
     tag: "3.225.5"
   telemetryEnabled: false
   enableExperimentalFeatures: true
@@ -338,20 +341,25 @@ valkey:
     minAvailable: 1
 
 # ---------------------------------------------------------------------------
-# ClickHouse. Langfuse's OLAP store for traces/observations/scores. The AVX
-# preflight guards the image tag: newer ClickHouse needs AVX and SIGILLs with
-# exit 132 on SSE4.2-only hosts, so the tag is pinned to an SSE4.2-safe build.
-# DO NOT bump `image.tag` past the sse42SafeTags list unless every node has AVX.
+# ClickHouse. Langfuse's OLAP store for traces/observations/scores. Coupled to
+# langfuse.image.tag 3.225.5: that release line's ClickHouse migrations from 39
+# onward need 25.12 (Langfuse v3.225.7 compose pins clickhouse-server:25.12).
+# AVX is a chart-default requirement because 25.12 is not SSE4.2-safe. Do not
+# move this pin independently of the Langfuse pin (#2210). The AVX preflight
+# still allows an explicit sse42SafeTags override on AVX-less nodes; that
+# override cannot apply the current Langfuse migration set.
 # BYO: deploy=false + host/httpPort/nativePort (existingSecret key clickhousePassword).
 # ---------------------------------------------------------------------------
 clickhouse:
   deploy: true
   image:
     repository: clickhouse/clickhouse-server
-    tag: "24.8"
+    tag: "25.12"
   # Tags whose upstream binaries still ship an SSE4.2 build (no AVX required).
   # The AVX preflight passes an AVX-less node only if the configured tag begins
-  # with one of these. 24.8/24.3 are LTS lines; 23.8 is the prior LTS.
+  # with one of these. Not a supported default: 25.12 is required by the
+  # Langfuse pin and is deliberately absent from this list. 24.8/24.3 are LTS
+  # lines; 23.8 is the prior LTS.
   sse42SafeTags:
     - "24.8"
     - "24.3"
@@ -1577,15 +1585,17 @@ ui:
 # ---------------------------------------------------------------------------
 preflights:
   # (a) CPU-AVX / ClickHouse-pin check. Runs as a pre-install/pre-upgrade hook
-  # Job on the cluster. It reads the node's /proc/cpuinfo, and if the node lacks
-  # AVX it FAILS the install unless the configured ClickHouse tag is SSE4.2-safe
-  # (in clickhouse.sse42SafeTags) -- catching the exit-132 SIGILL before pods
+  # Job on the cluster. Chart defaults require AVX: clickhouse.image.tag 25.12
+  # is required by langfuse.image.tag 3.225.5 and is not SSE4.2-safe. If the
+  # node lacks AVX the Job FAILS unless the operator pins a tag in
+  # clickhouse.sse42SafeTags -- catching the exit-132 SIGILL before pods
   # crash-loop. Skipped when clickhouse.deploy is false (BYO ClickHouse).
   avxCheck:
     enabled: true
     image: busybox:1.36
-    # Test knob: pretend the node has no AVX to exercise the fallback branch on
-    # an AVX-capable node. Never set true in a real install.
+    # Test knob: pretend the node has no AVX. With the default 25.12 tag this
+    # exercises the AVX-required failure branch; pin an sse42SafeTags tag to
+    # exercise the older-tag override. Never set true in a real install.
     forceNoAvx: false
     resources:
       requests: { cpu: 50m, memory: 32Mi }

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -30,6 +30,8 @@
 #
 # ClickHouse is pinned to :24.8 on purpose. Newer ClickHouse requires AVX and
 # SIGILLs with exit 132 on CPUs without it; :24.8 still ships an SSE4.2 build.
+# The Helm chart default is :25.12 (AVX required) so it can apply the Langfuse
+# pin's ClickHouse migrations; do not treat the two pins as the same knob.
 
 # Pin the Compose project name so `local up`/`down` target the same project
 # regardless of where this file sits (repo checkout or fetched cache dir).


### PR DESCRIPTION
## Summary

Chart defaults now pin ClickHouse at `25.12` so the Langfuse `3.225.5` pin can apply its ClickHouse migration set. AVX is a stated chart-default requirement because `25.12` is not SSE4.2-safe. Both `values.yaml` pins name each other as constraints, and a Helm CI render assertion fails when the pair drifts.

Issue #2210 listed three options and had no thread ruling. This PR takes option 1 (move the ClickHouse default to 25.12 and make AVX a stated requirement). Conservative choices noted below.

## Related issue

Closes #2210

## Fix pin verification

Fix pin: charts/curie/ci/clickhouse-langfuse-pin-assertions.sh

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | Does not reach plugin packaging, the runner turn loop, ACI events, or skill eval/check. | | |
| local | n/a | `compose.dev.yaml` stays on ClickHouse 24.8 so SSE4.2-only local hosts still boot while Langfuse is 3.225.5. Sibling named here and in AGENTS.md / chart README. | | |
| local-release | n/a | Does not change the released CLI binary, install path, or release compose. Chart.yaml remains 0.8.4; version bump belongs to the release cut. | | |
| cluster | required | Chart default ClickHouse tag, AVX preflight pairing with sse42SafeTags, helm NOTES label, and helm template output. | fake | Commit `f6f11124ae1fa7d4eef6ed853aa4946cbc631a02`. `helm template curie charts/curie` rendered `clickhouse/clickhouse-server:25.12` and AVX preflight `CLICKHOUSE_TAG=25.12` with `SSE42_SAFE_TAGS=24.8 24.3 23.8`. `bash charts/curie/ci/clickhouse-langfuse-pin-assertions.sh` passed, including helm NOTES `[AVX required]` and a helm-rendered `--set clickhouse.image.tag=24.8` override that still passes the AVX preflight without AVX. |
| live provider | n/a | Does not reach model routing, credential resolution, or token accounting. | | |
| external integration | n/a | Does not reach Slack, git webhooks, or connector OAuth. | | |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

Negatives from the same assertion on that commit:

- replacing rendered ClickHouse `25.12` with `24.8` is rejected
- replacing rendered Langfuse `3.225.5` with `:3` is rejected
- adding `25.12` to `sse42SafeTags` is rejected
- stripping the pin-coupling comments is rejected
- helm-rendered `clickhouse.image.tag=24.8` still passes the AVX preflight without AVX (override path)

## Conservative defaults

- Option 1, because the issue thread had no comments ruling otherwise.
- `sse42SafeTags` remains an explicit AVX-less override. Chart defaults (`25.12`) fail that preflight without AVX. The override cannot apply Langfuse ClickHouse migration 39; NOTES labels it `[SSE4.2-safe override]` rather than the old `[SSE4.2-pinned]`.
- Langfuse stays `3.225.5`. This unblocks advancing it; it does not advance it.
- `compose.dev.yaml` stays on `24.8` so an SSE4.2-only developer host can still boot the local stack while Langfuse is `3.225.5`. The two pins are no longer the same knob.
- `charts/curie/Chart.yaml` is not bumped; that belongs to the v0.8.5 release cut.

## Sibling path

`compose.dev.yaml` vs the chart ClickHouse tag. Named, not silently diverged: AGENTS.md, chart README, values-dev header, and the compose header now say the chart default is 25.12 / AVX-required while compose stays 24.8.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [x] An ADR is added under `docs/adr/` if this is an architectural decision.
