### PR TITLE
Scope the CI image layer cache per image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -531,8 +531,21 @@ jobs:
           platforms: ${{ matrix.platforms }}
           push: false
           load: false
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Scope the layer cache per image. Every leg of this matrix runs at
+          # once, and an unscoped `type=gha` puts all ten of them in ONE cache
+          # namespace, where they contend for the same reservation instead of
+          # sharing anything: the legs build different Dockerfiles, so there is
+          # no cross-image reuse to give up by separating them. Left unscoped,
+          # the export -- not the build -- became the job. On run 33690551116
+          # sre-bot-tempo built in 80.5s and then spent 1057.7s writing a single
+          # layer into the shared namespace, for a 19 minute job on a 2 minute
+          # image, while the same run logged `Unable to reserve cache with key
+          # docker.io--tonistiigi--binfmt-latest-linux-x64, another job may be
+          # creating this cache`. The ladder jobs below already scope their
+          # builds this way (`scope=ladder-runner`); this matrix was the one
+          # place left on the default.
+          cache-from: type=gha,scope=${{ matrix.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.name }}
 
   # The worker-local overlay is FROM the published curie-worker image, so it
   # cannot be built purely from the checkout. Build the base worker image

--- a/release/tests/test_authorize.py
+++ b/release/tests/test_authorize.py
@@ -989,6 +989,30 @@ class TestReleaseWorkflowContract:
         )
         assert "Build sre-bot-tempo image (no push)" in authorize_module.REQUIRED_CHECK_NAMES
 
+    def test_image_matrix_scopes_its_layer_cache_per_image(self):
+        """Every leg of the images matrix must name its own gha cache scope.
+
+        All ten legs run concurrently and build different Dockerfiles, so an
+        unscoped ``type=gha`` gives them one shared namespace with nothing to
+        share: they only contend for the same reservation. Unscoped, the cache
+        export outgrew the build it was meant to save -- sre-bot-tempo built in
+        80.5s and spent 1057.7s writing one layer, turning a 2 minute image into
+        a 19 minute job on the critical path.
+        """
+        workflow = yaml.load(CI_YAML.read_text(), Loader=yaml.BaseLoader)
+        image_job = workflow["jobs"]["images"]
+        build_step = next(
+            step for step in image_job["steps"] if step.get("name") == "Build (no push)"
+        )
+
+        assert build_step["with"]["cache-from"] == "type=gha,scope=${{ matrix.name }}"
+        assert build_step["with"]["cache-to"] == "type=gha,mode=max,scope=${{ matrix.name }}"
+
+        # The scope is only per image if the key it reads is unique per leg, so
+        # assert the matrix names are distinct rather than trusting the template.
+        names = [row["name"] for row in image_job["strategy"]["matrix"]["include"]]
+        assert len(names) == len(set(names)), f"image matrix names must be unique: {names}"
+
     def test_observability_stack_assertions_run_in_helm_ci(self):
         workflow = yaml.load(HELM_CI_YAML.read_text(), Loader=yaml.BaseLoader)
         chart_steps = workflow["jobs"]["helm"]["steps"]


### PR DESCRIPTION
## Summary

All ten legs of the `images` matrix run concurrently and every one of them wrote `cache-to: type=gha` with no scope, putting them in a single shared cache namespace. They build different Dockerfiles, so there was nothing to share there: they only contended for the same reservation. This names `scope=${{ matrix.name }}` on both `cache-from` and `cache-to`, giving each leg its own namespace. The ladder jobs further down the same workflow already build this way (`scope=ladder-runner`); this matrix was the one place left on the default.

Unscoped, the cache export outgrew the build it was meant to save. On CI run [33690551116](https://github.com/curie-eng/curie/actions/runs/33690551116) the `sre-bot-tempo` leg built in 80.5s and then spent 1057.7s in `#20 exporting to GitHub Actions Cache` writing a single layer:

```
#15 [linux/arm64 5/6] RUN pip install --no-cache-dir -r requirements.txt
#15 DONE 80.5s
...
#20 exporting to GitHub Actions Cache
#20 writing layer sha256:a1a26f26... 1057.7s done
#20 DONE 1063.3s
```

That is a 19 minute job on a 2 minute image, and it sat on the critical path of a 21m54s run. The same run logged the contention directly: `Failed to save: Unable to reserve cache with key docker.io--tonistiigi--binfmt-latest-linux-x64, another job may be creating this cache`.

Scope on this. The stall is a shared-namespace reservation problem, which scoping addresses. If a future run still shows a multi-minute export on one of the four example connectors, the follow-up is to drop `cache-to` for them entirely rather than to widen the scope: their whole build is `FROM python:3.12-slim` plus a two line `pip install`, so an 80s cold build is cheaper than exporting a base image that Docker Hub already serves.

## Related issue

<!-- No issue; this came out of profiling the CI critical path. -->

## Fix pin verification

<!-- Not a fix pull request and it closes no bug-labeled issue. -->

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | Changes only the GitHub Actions layer cache key for the no-push image matrix. No product code, chart, image content, or runtime path is touched. | | |
| local | n/a | Same | | |
| local-release | n/a | Same | | |
| cluster | n/a | Same | | |
| live provider | n/a | Same | | |
| external integration | n/a | Same | | |

The affected surface is CI itself, so the real verification is CI, plus the contract suites that read `ci.yaml`, run at commit `9c0e8868`:

```
uv run pytest release/tests tools/ci-workflow-paths/tests tools/ci-retry-gate/tests tools/e2e-ci-selection/tests tools/fix-pin-ci/tests -q
329 passed in 23.49s
```

Falsifiable negative for the new test: reverting both cache lines to the unscoped `type=gha` and re-running it fails on the `cache-from` comparison (`release/tests/test_authorize.py:1008`), and restoring the scope passes it again. The test also asserts the matrix names are unique, because the scope is only per image if the key it reads is.

The positive proof that the stall is gone is this pull request's own `Build sre-bot-tempo image (no push)` check.

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.
- [x] Or: this change is not behavior-bearing, so no tier applies, and the summary says why.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed. No product behavior changed; the reasoning lives in the workflow comment and the test docstring, next to the thing it explains.
- [x] An ADR is added under `docs/adr/` if this is an architectural decision. Not one: this is a cache key, not a decision about structure.

## What this deliberately does not do

Two other critical-path costs came out of the same profiling, and both are blocked by executable contracts that were written on purpose. They are described in the review thread rather than changed here.
