### PR TITLE
Enforce the AI attribution rule on pull request bodies

### DIFF
--- a/.github/workflows/pr-body.yaml
+++ b/.github/workflows/pr-body.yaml
@@ -3,9 +3,10 @@ name: PR body guard
 on:
   pull_request:
     branches: [main, next]
-    # A PR body can be edited without a new commit. Re-run the literal-newline
-    # guard on that event so a formerly valid closing keyword cannot become
-    # inert after the rest of CI has already passed.
+    # A PR body can be edited without a new commit. Re-run the body guards on
+    # that event so a formerly valid closing keyword cannot become inert, and so
+    # an AI attribution footer cannot be pasted in, after the rest of CI has
+    # already passed.
     types: [opened, synchronize, reopened, edited]
 
 concurrency:
@@ -42,7 +43,7 @@ jobs:
       # its verdict against the event payload.
       - name: PR body guard self-test
         run: bash scripts/check-pr-body.sh --self-test
-      - name: Reject literal newline escapes in the pull request body
+      - name: Reject literal newline escapes and AI attribution in the pull request body
         env:
           PR_BODY_FILE: ${{ runner.temp }}/curie-pr-body.md
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -594,22 +594,33 @@ branch list, restores the `RELEASE_NEXT_BRANCH` environment alias and the
   inert. Run `scripts/check-pr-body.sh <body-file>` before opening or editing a
   PR.
 - **Never mention any AI assistant (Claude, Codex, GPT, etc.) or AI in general in
-  commit messages, and never add `Co-Authored-By` lines referencing AI.**
-  CI enforces this on every PR (issue #962); check before pushing with:
+  commit messages OR pull request bodies, and never add `Co-Authored-By` lines
+  referencing AI.** This applies to the PR body as much as to the commits: many
+  assistants append a "Generated with" footer to a PR description by default, and
+  that footer is a claim of authorship on the artifact a reviewer reads first.
+  Strip it. CI enforces both surfaces on every PR (issue #962); check before
+  pushing with:
 
   ```bash
   scripts/check-commit-messages.sh origin/<base>..HEAD
+  scripts/check-pr-body.sh <body-file>
   scripts/check-commit-messages.sh --self-test
+  scripts/check-pr-body.sh --self-test
   ```
+
+  Both surfaces run ONE matcher: `check-pr-body.sh` delegates to
+  `check-commit-messages.sh --message-file`, so a vendor added in one place is
+  covered in the other and the two cannot drift apart.
 
   The gate flags *attribution*, not mention: a `Co-Authored-By` trailer naming an
   assistant, the robot-emoji "Generated with" footer, or an attribution phrase next
   to a bare assistant name. Technical references (`CLAUDE.md`, `claude_agent_sdk`,
   `claude-sonnet-5`, `harness.claude`) are deliberately fine, and the script's
-  `--self-test` pins both halves so the distinction cannot silently rot. A commit
-  range the script cannot resolve is a hard failure naming the range, not a silent
-  pass. It checks only the PR's own commits, so pre-gate history is not
-  retroactively enforced.
+  `--self-test` pins both halves so the distinction cannot silently rot. Scanning
+  the last 150 merged PR bodies flags exactly one, and it is a real footer, so the
+  body half is not a broad net either. A commit range the script cannot resolve is
+  a hard failure naming the range, not a silent pass. It checks only the PR's own
+  commits, so pre-gate history is not retroactively enforced.
 - No dashes/emdashes in prose content; no emojis in code or docs.
 
 ## Ticket implementation

--- a/scripts/check-commit-messages.sh
+++ b/scripts/check-commit-messages.sh
@@ -25,8 +25,15 @@
 #      never trip it.
 #
 # Usage:
-#   scripts/check-commit-messages.sh [<range>]   # default: origin/main..HEAD
-#   scripts/check-commit-messages.sh --self-test # prove the matcher is not vacuous
+#   scripts/check-commit-messages.sh [<range>]        # default: origin/main..HEAD
+#   scripts/check-commit-messages.sh --message-file <path>
+#   scripts/check-commit-messages.sh --self-test      # prove the matcher is not vacuous
+#
+# `--message-file` runs the SAME matcher over one file of message text instead of
+# a commit range. It exists so scripts/check-pr-body.sh can apply this rule to a
+# pull request body without a second copy of the regexes: the vendor lists and
+# the bare-name boundary above are the part most likely to rot, and two copies
+# rot apart. The caller owns the file; this mode only reads it.
 #
 # An unresolvable range is a hard failure, never a silent pass, so `--self-test`
 # re-invokes this script once with a bogus range and must run inside a git repo.
@@ -146,8 +153,54 @@ self_test() {
     echo "commit-message gate self-test: ${#bad[@]} caught, ${#good[@]} correctly ignored"
 }
 
+# Scan one file of message text. Shares offending_reason() with the range mode,
+# so a vendor added to the matcher is covered in both places at once.
+check_message_file() {
+    local message_file="$1"
+    local line reason violations=0
+
+    if [[ ! -f "$message_file" ]]; then
+        echo "message-file check failed: '$message_file' is not a regular file" >&2
+        return 1
+    fi
+    if [[ ! -r "$message_file" ]]; then
+        echo "message-file check failed: '$message_file' is not readable" >&2
+        return 1
+    fi
+
+    # A final line with no trailing newline is still a line: `read` returns
+    # non-zero on it while leaving it in the variable, so the loop body must run
+    # once more for a footer appended without a newline.
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        reason="$(offending_reason "$line")"
+        if [[ -n "$reason" ]]; then
+            if ((violations == 0)); then
+                echo "AGENTS.md forbids AI attribution in commit messages and pull" >&2
+                echo "request bodies (#962). Offending:" >&2
+            fi
+            violations=$((violations + 1))
+            echo "  [$reason] $line" >&2
+        fi
+    done <"$message_file"
+
+    if ((violations)); then
+        echo "Remove the attribution above and try again." >&2
+        return 1
+    fi
+    echo "message text clean: no AI attribution in '$message_file'"
+}
+
 if [[ "${1:-}" == "--self-test" ]]; then
     self_test
+    exit 0
+fi
+
+if [[ "${1:-}" == "--message-file" ]]; then
+    if (($# != 2)); then
+        echo "Usage: scripts/check-commit-messages.sh --message-file <path>" >&2
+        exit 2
+    fi
+    check_message_file "$2"
     exit 0
 fi
 

--- a/scripts/check-pr-body.sh
+++ b/scripts/check-pr-body.sh
@@ -1,14 +1,24 @@
 #!/usr/bin/env bash
-# Reject PR bodies that contain a literal "\\n" escape. GitHub displays that
-# escape as text rather than a line break, so a following `Closes #<issue>` is
-# not parsed as a closing keyword.
+# Two guards on a pull request body.
+#
+# 1. Reject a literal "\\n" escape. GitHub displays that escape as text rather
+#    than a line break, so a following `Closes #<issue>` is not parsed as a
+#    closing keyword.
+# 2. Reject AI attribution, delegating to check-commit-messages.sh
+#    --message-file so both surfaces share ONE matcher. AGENTS.md forbids
+#    attribution in commit messages and pull request bodies alike, but only the
+#    commit half was enforced, so agent-authored bodies kept arriving with the
+#    robot-emoji footer and were merged (#2225). The body is the half a human
+#    reviewer sees first and the half no rebase can rewrite.
 #
 # Usage:
 #   scripts/check-pr-body.sh <body-file>
 #   scripts/check-pr-body.sh --self-test
 set -euo pipefail
 
-SCRIPT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_PATH="$SCRIPT_DIR/$(basename "${BASH_SOURCE[0]}")"
+COMMIT_GATE="$SCRIPT_DIR/check-commit-messages.sh"
 
 usage() {
     echo "Usage: scripts/check-pr-body.sh <body-file>" >&2
@@ -42,19 +52,38 @@ check_body_file() {
         fi
     fi
 
-    echo "PR body check passed: no literal \\n escape sequences"
+    if [[ ! -x "$COMMIT_GATE" && ! -r "$COMMIT_GATE" ]]; then
+        echo "PR body check failed: cannot read '$COMMIT_GATE'" >&2
+        return 1
+    fi
+    if ! bash "$COMMIT_GATE" --message-file "$body_file" >/dev/null; then
+        echo "PR body check failed: the body claims AI authorship." >&2
+        echo "AGENTS.md forbids AI attribution in commit messages and PR bodies alike." >&2
+        return 1
+    fi
+
+    echo "PR body check passed: real newlines, no AI attribution"
 }
 
 self_test() {
-    local temp_dir real_newline_body literal_escape_body
+    local temp_dir real_newline_body literal_escape_body attributed_body footer_no_newline_body
 
     temp_dir="$(mktemp -d "${TMPDIR:-/tmp}/curie-pr-body-check.XXXXXX")"
     trap 'rm -rf -- "$temp_dir"' RETURN
     real_newline_body="$temp_dir/real-newline.md"
     literal_escape_body="$temp_dir/literal-escape.md"
 
+    attributed_body="$temp_dir/attributed.md"
+    footer_no_newline_body="$temp_dir/footer-no-newline.md"
+
     printf 'Describe a fix.\n\nCloses #1713\n' >"$real_newline_body"
     printf 'Describe a fix.\\n\\nCloses #1713\n' >"$literal_escape_body"
+    # The exact footer that reached #2225, and the same footer with no trailing
+    # newline, which is the shape a body pasted from a tool actually has.
+    printf 'Describe a fix.\n\n\xf0\x9f\xa4\x96 Generated with [Claude Code](https://claude.com/claude-code)\n' \
+        >"$attributed_body"
+    printf 'Describe a fix.\n\n\xf0\x9f\xa4\x96 Generated with [Claude Code](https://claude.com/claude-code)' \
+        >"$footer_no_newline_body"
 
     if ! bash "$SCRIPT_PATH" "$real_newline_body" >/dev/null; then
         echo "PR body check self-test failed: real newlines were rejected" >&2
@@ -65,7 +94,16 @@ self_test() {
         return 1
     fi
 
-    echo "PR body check self-test passed: real newlines accepted, literal \\n rejected"
+    if bash "$SCRIPT_PATH" "$attributed_body" >/dev/null 2>&1; then
+        echo "PR body check self-test failed: AI attribution footer was accepted" >&2
+        return 1
+    fi
+    if bash "$SCRIPT_PATH" "$footer_no_newline_body" >/dev/null 2>&1; then
+        echo "PR body check self-test failed: unterminated AI attribution footer was accepted" >&2
+        return 1
+    fi
+
+    echo "PR body check self-test passed: clean body accepted, literal \\n and AI attribution rejected"
 }
 
 if [[ "${1:-}" == "--self-test" ]]; then

--- a/tools/ci-retry-gate/tests/test_pr_body.py
+++ b/tools/ci-retry-gate/tests/test_pr_body.py
@@ -1,4 +1,10 @@
-"""Executable regression for PR bodies that defeat GitHub auto-close (#1713)."""
+"""Executable regressions for the pull request body guards.
+
+Two rules share this checker: bodies that defeat GitHub auto-close (#1713),
+and bodies that claim AI authorship (#962). The second half exists because
+AGENTS.md forbade attribution on both surfaces while only the commit half was
+enforced, so footers kept reaching merged pull requests.
+"""
 
 from __future__ import annotations
 
@@ -53,3 +59,81 @@ def test_pr_body_check_rejects_literal_backslash_n_before_it_inerts_a_closing_ke
     assert completed.returncode != 0, diagnostics
     assert r"\n" in diagnostics, diagnostics
     assert "replace" in diagnostics.lower(), diagnostics
+
+
+FOOTER = "\N{ROBOT FACE} Generated with [Claude Code](https://claude.com/claude-code)"
+
+
+@pytest.mark.parametrize(
+    "body",
+    (
+        # The exact footer that reached merged pull requests.
+        f"Describe a fix.\n\n{FOOTER}\n",
+        # The same footer with no trailing newline, which is the shape a body
+        # pasted straight out of a tool actually has. A `while read` loop drops
+        # that last line unless it is written to handle it.
+        f"Describe a fix.\n\n{FOOTER}",
+        "Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>\n",
+        "This patch was generated with Claude\n",
+    ),
+)
+def test_pr_body_check_rejects_ai_attribution(tmp_path: Path, body: str) -> None:
+    completed = _check_body(tmp_path, body)
+
+    assert completed.returncode != 0, _diagnostics(completed)
+    assert "AI" in completed.stderr, _diagnostics(completed)
+
+
+@pytest.mark.parametrize(
+    "body",
+    (
+        # Attribution, not mention. These are this repo's ordinary vocabulary and
+        # must stay mergeable, or the gate gets switched off.
+        "Update apps/ui/CLAUDE.md and the harness.claude import boundary.\n",
+        "Pin claude-agent-sdk==0.2.110 so claude_agent_sdk spans stay schema-clean.\n",
+        "Describe the Claude harness port and its registry.\n\nCloses #1713\n",
+    ),
+)
+def test_pr_body_check_accepts_technical_references_to_the_harness(
+    tmp_path: Path, body: str
+) -> None:
+    completed = _check_body(tmp_path, body)
+
+    assert completed.returncode == 0, _diagnostics(completed)
+
+
+def test_pr_body_guard_delegates_to_one_matcher() -> None:
+    """Both surfaces must share a matcher, or the vendor lists drift apart."""
+    checker = CHECKER.read_text(encoding="utf-8")
+
+    assert "check-commit-messages.sh" in checker
+    assert "--message-file" in checker
+
+
+def test_pr_body_self_test_covers_the_attribution_half() -> None:
+    """CI trusts --self-test before running the gate, so it must not be vacuous."""
+    completed = subprocess.run(
+        ["bash", str(CHECKER), "--self-test"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, _diagnostics(completed)
+    assert "AI attribution" in completed.stdout, _diagnostics(completed)
+
+
+def test_pr_body_gate_inherits_the_commit_matcher_boundary(tmp_path: Path) -> None:
+    """A bare name followed by `.` is out of scope, by the shared matcher's design.
+
+    BARE_ASSISTANT excludes a trailing `[._-]` so `harness.claude`, `CLAUDE.md`
+    and `claude-sonnet-5` never trip rule C. A sentence that ends "generated with
+    Claude." rides that same exclusion. Widening it belongs to the commit gate
+    and its false-positive budget, not here; this pins the boundary so the next
+    reader knows it is inherited rather than overlooked. The footer forms that
+    actually reach pull requests are caught by rule B regardless.
+    """
+    completed = _check_body(tmp_path, "This patch was generated with Claude.\n")
+
+    assert completed.returncode == 0, _diagnostics(completed)


### PR DESCRIPTION
## Summary

AGENTS.md forbids AI attribution in commit messages and pull request bodies alike, but only the commit half was ever enforced. Assistants append a "Generated with" footer to a PR description by default, so the unenforced half kept arriving: scanning the last 150 merged pull requests flags exactly one body, #2013, carrying that footer into `main`. The body is the half a reviewer reads first, and the half no rebase can rewrite.

This closes that half without adding a workflow or a required check. `pr-body.yaml` already writes the event payload body to a file, runs the gate's `--self-test`, and then runs `scripts/check-pr-body.sh` on that file, on `opened`, `synchronize`, `reopened` and `edited`. Extending the script extends the gate that is already running, PR body edits included.

- `scripts/check-commit-messages.sh` gains `--message-file <path>`, running its existing `offending_reason()` matcher over a file of message text instead of a commit range.
- `scripts/check-pr-body.sh` delegates to it, so both surfaces share **one** matcher. The vendor lists and the bare-name boundary are the part most likely to rot, and two copies rot apart.
- AGENTS.md states the rule for both surfaces, so an agent reading the repo conventions learns it before opening a PR rather than after CI rejects one.
- The `pr-body.yaml` step is renamed, since it no longer only checks newlines.

## Related issue

Ref #962

## Fix pin verification

Fix pin: n/a - this closes an enforcement gap in a convention, and no issue labeled `bug` is closed by it

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | Changes two CI shell gates, their tests, and AGENTS.md. No product code, chart, image, or runtime path is touched. | | |
| local | n/a | Same | | |
| local-release | n/a | Same | | |
| cluster | n/a | Same | | |
| live provider | n/a | Same | | |
| external integration | n/a | Same | | |

The affected surface is a CI gate, so the verification is the gate itself, at commit `e5aff1f6`:

```
bash scripts/check-commit-messages.sh --self-test
  commit-message gate self-test: 25 caught, 6 correctly ignored
bash scripts/check-pr-body.sh --self-test
  PR body check self-test passed: clean body accepted, literal newline-escape and AI attribution rejected
uv run pytest tools/ release/tests -q
  494 passed in 26.08s
bash scripts/check-docs.sh
  OK: the interface catalog is generated and drift-free, every citation resolves [...]
```

(That self-test line is quoted with the escape spelled out, because this body is itself checked by the gate and the literal two-byte form is exactly what the other half rejects.)

**Positive proof.** A body carrying the exact footer that reached #2013 and #2225 is rejected, and the failure names the rule that caught it (`robot-emoji AI generation footer`) followed by the offending line. The footer is not quoted here, because this body is checked by the gate and a verbatim citation would be rejected on its own terms. That is a deliberate property of a bright-line matcher, not an oversight: the fixtures that do carry it verbatim live in the test suite and the two `--self-test` blocks, where they are checked rather than displayed.

**Falsifiable negative.** Reverting both scripts to their `main` versions and re-running the suite fails 6 of the 13 cases, including both delegation assertions and the self-test coverage assertion; restoring them passes all 13. So the tests are pinned to the change rather than to the file existing.

**Second independent path, against the false-positive risk.** The commit gate's own design note argues that a gate on the *name* would red-flag honest work and be switched off within a week. That risk is larger for bodies, which discuss the Claude harness far more than commit subjects do, so I measured it rather than assuming: running the new matcher over the last 150 merged PR bodies produces exactly one flag, and it is a real footer. `CLAUDE.md`, `claude_agent_sdk`, `claude-sonnet-5` and "the Claude harness" all stay mergeable, and the accept direction is pinned by its own parametrized test, not just the reject direction.

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.
- [x] Or: this change is not behavior-bearing, so no tier applies, and the summary says why.

## One inherited boundary, deliberately not fixed here

`BARE_ASSISTANT` excludes a trailing `[._-]` so `harness.claude`, `CLAUDE.md` and `claude-sonnet-5` never trip rule C. A sentence ending "generated with Claude." rides that same exclusion and is not caught. Widening it belongs to the commit gate and its false-positive budget, not to this change, so a test pins the boundary instead, and the next reader can see it was inherited rather than overlooked. The footer forms that actually reach pull requests are caught by rule B regardless of the surrounding punctuation.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed. AGENTS.md now states the rule for both surfaces and names both commands.
- [x] An ADR is added under `docs/adr/` if this is an architectural decision. Not one: this enforces a convention AGENTS.md already states, rather than deciding anything new.
