### PR TITLE
Build the fix pin binary only when a fix pin is declared

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -146,11 +146,31 @@ jobs:
           uv run python -m aci_protocol.wire_lock --check-base /tmp/base-wire.lock
       - name: Pytest
         run: uv run pytest -q
+      # Build ONLY when the body actually carries a declaration. tools/fix-pin-ci/
+      # check.py reaches the binary at exactly one place, the
+      # `curie dev verify-fix-pin` call, and only once `declaration.selector` is
+      # set; `n/a`, no declaration, a near-miss marker like `Fix-pin:`, and the
+      # bug-without-declaration rejection all return before touching it. So on
+      # every pull request that declares nothing -- the overwhelming majority --
+      # this was a 213s cold `cargo build --release` for a binary nothing ran,
+      # inside the longest job on the graph.
+      #
+      # `contains()` is case-insensitive and DECLARATION is the exact-case
+      # `Fix pin: <selector>`, so this condition is a strict superset of the
+      # cases that reach the binary: it cannot skip a build the gate then needs.
+      # It builds a few times it need not (`Fix pin: n/a`, a near miss), which is
+      # the safe direction. This stays a direct build inside the required Python
+      # status: no `needs`, no downloaded artifact, no Cargo cache, so nothing
+      # the gate's contract protects is traded away for the time.
       - name: Build the current curie binary for fix pin verification
-        if: github.event_name == 'pull_request'
+        if: >-
+          github.event_name == 'pull_request'
+          && contains(github.event.pull_request.body, 'Fix pin:')
         run: cargo build --release --locked --manifest-path cli/Cargo.toml
       - name: Install Helm for fix pin verification
-        if: github.event_name == 'pull_request'
+        if: >-
+          github.event_name == 'pull_request'
+          && contains(github.event.pull_request.body, 'Fix pin:')
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5
         with:
           version: v3.16.4

--- a/tools/fix-pin-ci/tests/test_fix_pin_ci.py
+++ b/tools/fix-pin-ci/tests/test_fix_pin_ci.py
@@ -629,6 +629,63 @@ def test_ci_keeps_the_required_python_status_and_calls_fix_pin_after_pytest() ->
     assert gate_index < diagnostic_index
 
 
+DECLARATION_GUARD = "contains(github.event.pull_request.body, 'Fix pin:')"
+
+
+def test_selector_tooling_builds_only_when_the_body_declares_a_fix_pin() -> None:
+    """The cargo build must be gated on a declaration, and gated the safe way.
+
+    check.py reaches the binary at exactly one place, the `curie dev
+    verify-fix-pin` call, and only once `declaration.selector` is set. `n/a`, no
+    declaration, a near-miss marker and the bug-without-declaration rejection all
+    return first. Building unconditionally therefore spent a cold
+    `cargo build --release` inside the longest job on the graph for a binary that
+    the majority of pull requests never run.
+
+    The guard must stay a strict SUPERSET of the cases that reach the binary.
+    `contains()` is case-insensitive and DECLARATION is the exact-case
+    `Fix pin: <selector>`, so a body that reaches the binary always contains the
+    substring. Skipping a build the gate then needs would be the unsafe
+    direction, and this pins that it cannot happen.
+    """
+    document = _load_ci()
+    _, steps = _python_job(document)
+
+    for description, predicate in (
+        (
+            "direct current release build",
+            lambda step: _string(step, "run").strip()
+            == "cargo build --release --locked --manifest-path cli/Cargo.toml",
+        ),
+        (
+            "pinned Helm setup",
+            lambda step: _string(step, "uses")
+            == "azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310",
+        ),
+    ):
+        step = steps[_single_step_index(steps, predicate, description)]
+        condition = _string(step, "if")
+        assert PR_CONDITION.search(condition), f"{description} must stay pull-request only"
+        assert DECLARATION_GUARD in condition, (
+            f"{description} must build only when the body declares a Fix pin: {condition!r}"
+        )
+
+    # The gate itself must NOT carry the guard. It is the step that decides a
+    # missing declaration is acceptable, and a body-shaped `if` on it would turn
+    # the "closes a bug with no declaration" rejection into a skipped step.
+    gate = steps[
+        _single_step_index(
+            steps,
+            lambda step: "tools/fix-pin-ci/check.py" in _string(step, "run"),
+            "fix pin caller",
+        )
+    ]
+    assert DECLARATION_GUARD not in _string(gate, "if"), (
+        "the gate must still run for a body with no declaration, or the "
+        "bug-without-declaration rejection can never fire"
+    )
+
+
 def test_pull_request_template_documents_the_required_declaration() -> None:
     template = PR_TEMPLATE.read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary

`tools/fix-pin-ci/check.py` reaches the curie binary at exactly one place, the `curie dev verify-fix-pin` call at [check.py:218](https://github.com/curie-eng/curie/blob/main/tools/fix-pin-ci/check.py#L218), and only once `declaration.selector` is set. `Fix pin: n/a`, no declaration at all, a near-miss marker like `Fix-pin:`, and the bug-without-declaration rejection every one return before touching it.

So on the majority of pull requests, which declare nothing, CI spent a cold 213s `cargo build --release --locked` producing a binary that nothing then ran, inside the Python job. On run [33690551116](https://github.com/curie-eng/curie/actions/runs/33690551116) that job was 20 minutes and the longest on the graph; on the most recent run it is 21m58s and now the sole critical path.

This gates the build, and the Helm setup beside it, on the body actually carrying a declaration.

**The guard is deliberately a strict superset, not an exact match.** `contains()` is case-insensitive while `DECLARATION` is the exact-case `Fix pin: <selector>`, so a body that reaches the binary always contains the substring: the build can never be skipped where the gate then needs it. It does build a few times it need not, for `Fix pin: n/a` and for a near miss. That is the safe direction to be wrong in, and it is the direction chosen.

**Nothing the gate's contract protects is traded away.** This stays a direct build inside the required Python status: no `needs`, no downloaded artifact, no Cargo cache. Those three are forbidden by `test_ci_keeps_the_required_python_status_and_calls_fix_pin_after_pytest`, because #1479 and #2095 put this gate inside an already-required check rather than let it become a separate job a skip could satisfy. That holds unchanged; the existing 71 assertions pass untouched.

## Related issue

Ref #1479, Ref #2095

## Fix pin verification

Fix pin: n/a - this changes when a CI step runs, and closes no issue labeled `bug`

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | Changes one `if` condition on two CI steps plus its contract test. No product code, chart, image, or runtime path is touched. | | |
| local | n/a | Same | | |
| local-release | n/a | Same | | |
| cluster | n/a | Same | | |
| live provider | n/a | Same | | |
| external integration | n/a | Same | | |

The registry maps `.github/workflows/ci.yaml` to every tier, so all of them run on this pull request regardless; the table records why none of them is the evidence that matters here.

Run at commit `07d9473e`:

```
uv run pytest tools/ release/tests -q
  485 passed in 29.36s
uv run pytest tools/fix-pin-ci/tests -q
  72 passed in 9.60s
```

**Positive proof.** The 71 pre-existing assertions in the fix pin contract still pass, so the ordering, the argv, the pull-request-only condition and the three forbidden shortcuts are all unchanged. The 72nd is new and asserts the guard on both gated steps.

**Falsifiable negative.** Reverting the condition to the unconditional `github.event_name == 'pull_request'` fails the new test at `test_fix_pin_ci.py:669`; restoring it passes. So the test is pinned to the guard, not to the step existing.

**Second independent path, on the one way this could have weakened the gate.** Putting the same body-shaped condition on the *gate step* would turn the "closes a bug with no declaration" rejection into a skipped step, which is exactly the opt-in failure #2095 was filed to close. The new test asserts the guard is absent there, so the safe and unsafe placements are pinned apart rather than one being pinned and the other assumed.

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.
- [x] Or: this change is not behavior-bearing, so no tier applies, and the summary says why.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed. The reasoning lives in the workflow comment and the test docstring, next to what it explains.
- [x] An ADR is added under `docs/adr/` if this is an architectural decision. Not one: this changes when a step runs, not what CI guarantees.
