### PR TITLE
Pin Langfuse Deployments to Recreate so boot migrations cannot overlap

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -220,6 +220,13 @@ jobs:
           set -euo pipefail
           bash charts/curie/ci/langfuse-image-pin-assertions.sh
 
+      # Prove both Langfuse Deployments use Recreate so an image change never
+      # runs two boot migrations against the same database (#2216).
+      - name: helm render assertions (langfuse Recreate strategy)
+        run: |
+          set -euo pipefail
+          bash charts/curie/ci/langfuse-recreate-assertions.sh
+
       # Prove Langfuse startup is gated on ClickHouse being up (issue #2009). A
       # Helm upgrade that recreates the ClickHouse Service otherwise lets the new
       # Langfuse pods start their migrations against an unresolvable name, so the

--- a/charts/curie/CLAUDE.md
+++ b/charts/curie/CLAUDE.md
@@ -30,6 +30,18 @@ component and rail detail in `charts/curie/README.md`.
     when it lands, this exception is removed rather than extended. Do not
     generalize it into a rule about stateful services -- one named file, one
     named reason.
+  - **Second named exception: `templates/langfuse.yaml`**, which hardcodes
+    `replicas: 1` and `strategy: type: Recreate` on both the web and worker
+    Deployments. The reason is correctness, not sizing: both images run Prisma
+    and ClickHouse migrations at container boot with no cross-process lock, so
+    a RollingUpdate of a single replica (default `maxSurge: 25%`, which rounds
+    up to one extra pod) can apply two migration sets to the same database and
+    leave Prisma in a failed state (#2216). Any count other than 1, or any
+    strategy other than Recreate, is wrong at every cluster size. There is
+    deliberately **no `langfuse.web.replicas` / `langfuse.worker.replicas` /
+    strategy values key**. Pinned by `ci/langfuse-recreate-assertions.sh`.
+    Horizontal scale for Langfuse needs an Accepted out-of-band migrator; when
+    that lands, this exception is removed rather than extended.
 - **Mail-adapter egress is a separate fail-closed rail.** Enabling
   `mailAdapter.deploy` requires at least one
   `mailAdapter.agentmail.httpsCidrs` entry. Its single egress-only policy allows

--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -339,7 +339,7 @@ pipeline and environment are applied on `helm upgrade`.
 
 | Component | Image | Notes |
 |---|---|---|
-| Langfuse web + worker | `langfuse/langfuse:3.225.5`, `langfuse/langfuse-worker:3.225.5` | Observability + eval backbone. Headless-bootstrapped dev org/project. Web and worker stay on one reviewed migration set; do not replace the version with floating `:3`. |
+| Langfuse web + worker | `langfuse/langfuse:3.225.5`, `langfuse/langfuse-worker:3.225.5` | Observability + eval backbone. Headless-bootstrapped dev org/project. Web and worker stay on one reviewed migration set; do not replace the version with floating `:3`. Both Deployments use Recreate, so a Langfuse image change is a brief outage while boot migrations run. |
 | Postgres | `postgres:16-alpine` | Langfuse transactional store + app state. StatefulSet. |
 | Valkey | `valkey/valkey:8-alpine` | Langfuse cache/queue + dispatcher Streams queue. |
 | ClickHouse | `clickhouse/clickhouse-server:24.8` | Langfuse OLAP store. Tag pinned SSE4.2-safe (see preflight). |

--- a/charts/curie/ci/langfuse-recreate-assertions.sh
+++ b/charts/curie/ci/langfuse-recreate-assertions.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+#
+# Render-assertion test for issue #2216 (Langfuse RollingUpdate races boot
+# migrations). Both Langfuse Deployments run Prisma and ClickHouse migrations
+# at container boot with no cross-process lock. With replicas: 1 and no
+# strategy, Kubernetes defaults to RollingUpdate and maxSurge 25% rounds up to
+# one extra pod, so an image change runs two migrators against the same
+# database.
+#
+# This asserts that helm template renders spec.strategy.type Recreate on both
+# langfuse-web and langfuse-worker. Recreate stops the old pod before the new
+# one starts, so only one pod ever runs those boot migrations. A mutant that
+# restores RollingUpdate on either Deployment is rejected, so a checker that
+# only looked at one of the two siblings would not pass.
+#
+# Runnable locally (from anywhere) and from CI. Fails loudly, naming the
+# Deployment.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+RENDER="$TMP/langfuse.yaml"
+CHECKER="$TMP/check.py"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+echo "=== Rendering templates/langfuse.yaml ==="
+helm template curie "$CHART" --show-only templates/langfuse.yaml >"$RENDER"
+
+cat >"$CHECKER" <<'PY'
+import pathlib
+import sys
+
+import yaml
+
+path = sys.argv[1]
+wanted = ("-langfuse-web", "-langfuse-worker")
+found = {}
+
+for document in yaml.safe_load_all(pathlib.Path(path).read_text()):
+    if not document or document.get("kind") != "Deployment":
+        continue
+    name = document.get("metadata", {}).get("name", "")
+    for suffix in wanted:
+        if name.endswith(suffix):
+            found[suffix] = document
+            break
+
+problems = []
+for suffix in wanted:
+    document = found.get(suffix)
+    if document is None:
+        problems.append(
+            f"no Deployment ending in {suffix!r} rendered; cannot pin Recreate"
+        )
+        continue
+    name = document.get("metadata", {}).get("name")
+    spec = document.get("spec") or {}
+    strategy_type = (spec.get("strategy") or {}).get("type")
+    if strategy_type != "Recreate":
+        problems.append(
+            f"{name} spec.strategy.type must be Recreate so an image change "
+            f"never runs two boot migrations at once; found {strategy_type!r}"
+        )
+if problems:
+    raise SystemExit("\n".join(problems))
+
+print(
+    "langfuse-web and langfuse-worker Deployments both render "
+    "spec.strategy.type Recreate"
+)
+PY
+
+echo "=== Assertion: both Langfuse Deployments render Recreate ==="
+python3 "$CHECKER" "$RENDER"
+
+flip_strategy() {
+  local suffix="$1"
+  local dest="$2"
+  python3 - "$RENDER" "$dest" "$suffix" <<'PY'
+import pathlib
+import sys
+
+import yaml
+
+source, dest, suffix = sys.argv[1], sys.argv[2], sys.argv[3]
+documents = list(yaml.safe_load_all(pathlib.Path(source).read_text()))
+mutated = False
+for document in documents:
+    if not document or document.get("kind") != "Deployment":
+        continue
+    name = document.get("metadata", {}).get("name", "")
+    if name.endswith(suffix):
+        document.setdefault("spec", {}).setdefault("strategy", {})["type"] = "RollingUpdate"
+        mutated = True
+if not mutated:
+    raise SystemExit(f"mutant setup failed: no Deployment ending in {suffix!r} to flip")
+with pathlib.Path(dest).open("w") as handle:
+    yaml.safe_dump_all(documents, handle)
+PY
+}
+
+reject_rolling_update() {
+  local suffix="$1"
+  local mutant="$TMP/langfuse-rolling${suffix}.yaml"
+  echo "=== Negative: RollingUpdate on ${suffix#-} is rejected ==="
+  flip_strategy "$suffix" "$mutant"
+  local negative_output=""
+  if negative_output="$(python3 "$CHECKER" "$mutant" 2>&1)"; then
+    fail "RollingUpdate mutation on ${suffix#-} passed the Recreate contract"
+  fi
+  if [[ "$negative_output" != *"spec.strategy.type must be Recreate"* ]]; then
+    fail "RollingUpdate mutation on ${suffix#-} failed unexpectedly: $negative_output"
+  fi
+  if [[ "$negative_output" != *"${suffix#-}"* ]]; then
+    fail "RollingUpdate mutation did not name ${suffix#-}: $negative_output"
+  fi
+  echo "negative: flipping ${suffix#-} to RollingUpdate is rejected"
+}
+
+reject_rolling_update "-langfuse-web"
+reject_rolling_update "-langfuse-worker"
+
+echo "PASS: both Langfuse Deployments render Recreate and a RollingUpdate sibling is refused (issue #2216)"

--- a/charts/curie/templates/langfuse.yaml
+++ b/charts/curie/templates/langfuse.yaml
@@ -25,6 +25,11 @@ metadata:
     {{- include "curie.labels" . | nindent 4 }}
 spec:
   replicas: 1
+  # Boot migrations (Prisma + ClickHouse) have no cross-process lock. Recreate
+  # stops the old pod before the new one starts so two versions never migrate
+  # the same database at once (#2216).
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{- include "curie.selectorLabels" (dict "root" . "component" "langfuse-web") | nindent 6 }}
@@ -193,6 +198,10 @@ metadata:
     {{- include "curie.labels" . | nindent 4 }}
 spec:
   replicas: 1
+  # Same boot-migration race as langfuse-web (#2216): Recreate so an image
+  # change never runs two worker pods against the same stores at once.
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{- include "curie.selectorLabels" (dict "root" . "component" "langfuse-worker") | nindent 6 }}


### PR DESCRIPTION
## Summary

Langfuse web and worker run database migrations at container boot with no cross-process lock. Neither Deployment declared an update strategy, so Kubernetes used RollingUpdate and an image change could run two migrators against the same Postgres and ClickHouse. Both Deployments now set `strategy.type: Recreate`, a render assertion rejects a RollingUpdate mutant on either sibling, and the chart README notes the brief outage that already existed while a single replica was Unready during migration.

Conservative default: no values knob for replica count or strategy. A configurable RollingUpdate would reintroduce the race. `charts/curie/CLAUDE.md` records this as a second named exception to the values-not-templates invariant, next to the mail-adapter Recreate exception.

## Related issue

Closes #2216

## Fix pin verification

Fix pin: charts/curie/ci/langfuse-recreate-assertions.sh

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | Chart Deployment strategy only; does not reach plugin packaging, the runner, ACI, or skill eval. | | |
| local | n/a | Compose Langfuse services are not Helm Deployments and do not use Kubernetes rollout strategy. | | |
| local-release | n/a | Does not change released binary, image identity, install path, version pins, or release compose. | | |
| cluster | required | Touches `charts/curie/templates/langfuse.yaml` Deployment `spec.strategy`. | fake | Commit `661fa2ba81781c90c601f685e9033773faa6de63`. `helm template curie charts/curie --show-only templates/langfuse.yaml` rendered `curie-langfuse-web: replicas=1 strategy={'type': 'Recreate'}` and `curie-langfuse-worker: replicas=1 strategy={'type': 'Recreate'}`. Second path: full `helm template curie charts/curie -f charts/curie/values-dev.yaml` showed the same two Recreate Deployments. `bash charts/curie/ci/langfuse-recreate-assertions.sh` passed, including RollingUpdate mutants on each sibling. `curie dev verify-fix-pin HEAD charts/curie/ci/langfuse-recreate-assertions.sh` printed `PINNED`; reversing product files left both strategy types `None`. No cluster was left running; helm template only. A live Recreate rollout was not run: the ticket's done-when is the rendered field plus the assertion, and Recreate semantics belong to Kubernetes. |
| live provider | n/a | Does not reach model routing, credential resolution, provider auth, or token accounting. | | |
| external integration | n/a | Does not reach Slack, git webhooks, connector OAuth, or a third-party API. | | |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [ ] An ADR is added under `docs/adr/` if this is an architectural decision.
