### PR TITLE
fix(chart): render Langfuse S3 upload regions from rustfs.region

### DIFF
--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -606,8 +606,9 @@ agentSandbox:
 The bundle fetch uses path style addressing, so it appends
 `agentSandbox.runner.bundleFetch.bucket` to this endpoint. For another AWS
 region, change the region in `rustfs.host` and set `rustfs.region` to control
-the SigV4 signing region used by the bundle fetch init container. This setting
-does not configure the API or worker S3 clients.
+the SigV4 signing region used by the bundle fetch init container and by
+Langfuse's event/media uploads. This setting does not configure the API or
+worker S3 clients.
 
 Scope the runner's role to the bundle bucket, **read-only**. NetworkPolicy
 selects pods rather than containers, so any identity the bundle-fetch init

--- a/charts/curie/ci/object-store-web-identity-assertions.sh
+++ b/charts/curie/ci/object-store-web-identity-assertions.sh
@@ -274,10 +274,67 @@ def assert_bundle_fetch_region(path, expected_region):
     print(f"ok: bundle-fetch AWS_DEFAULT_REGION renders {expected_region}")
 
 
+LANGFUSE_REGION_KEYS = (
+    "LANGFUSE_S3_EVENT_UPLOAD_REGION",
+    "LANGFUSE_S3_MEDIA_UPLOAD_REGION",
+)
+
+
+def langfuse_envs(path):
+    """Langfuse web and worker env, selected by container name.
+
+    The two Langfuse Deployment suffixes are more specific than `-worker`,
+    which also matches langfuse-worker. Container name, not index, is the
+    application container.
+    """
+    web = worker = None
+    with open(path) as fh:
+        for doc in yaml.safe_load_all(fh):
+            if not doc or doc.get("kind") != "Deployment":
+                continue
+            name = doc.get("metadata", {}).get("name", "")
+            containers = doc["spec"]["template"]["spec"].get("containers", [])
+            if name.endswith("-langfuse-web"):
+                matches = [c for c in containers if c.get("name") == "langfuse-web"]
+                assert len(matches) == 1, (
+                    f"{name} must render exactly one langfuse-web container, "
+                    f"got {len(matches)}"
+                )
+                web = env_for(matches[0])
+            elif name.endswith("-langfuse-worker"):
+                matches = [c for c in containers if c.get("name") == "langfuse-worker"]
+                assert len(matches) == 1, (
+                    f"{name} must render exactly one langfuse-worker container, "
+                    f"got {len(matches)}"
+                )
+                worker = env_for(matches[0])
+    assert web is not None, "langfuse-web Deployment not rendered"
+    assert worker is not None, "langfuse-worker Deployment not rendered"
+    return web, worker
+
+
+def assert_langfuse_upload_regions(path, expected_region):
+    web, worker = langfuse_envs(path)
+    for label, env in (("langfuse-web", web), ("langfuse-worker", worker)):
+        for key in LANGFUSE_REGION_KEYS:
+            rendered = env.get(key, {}).get("value")
+            assert rendered == expected_region, (
+                f"{label} {key} rendered as {rendered!r}; expected "
+                f"{expected_region!r} from rustfs.region"
+            )
+    print(
+        f"ok: langfuse event/media upload regions render {expected_region} "
+        "on web and worker"
+    )
+
+
 assert_static(sys.argv[1])
 assert_web_identity(sys.argv[2])
 assert_bundle_fetch_region(sys.argv[1], "us-east-1")
 assert_bundle_fetch_region(sys.argv[3], "eu-west-1")
+assert_langfuse_upload_regions(sys.argv[1], "us-east-1")
+assert_langfuse_upload_regions(sys.argv[2], "us-east-1")
+assert_langfuse_upload_regions(sys.argv[3], "eu-west-1")
 PY
 
 # Everything above reads the rendered YAML. That is necessary and not

--- a/charts/curie/templates/_helpers.tpl
+++ b/charts/curie/templates/_helpers.tpl
@@ -955,8 +955,12 @@ livenessProbe:
       key: valkeyPassword
 - name: LANGFUSE_S3_EVENT_UPLOAD_BUCKET
   value: {{ .Values.rustfs.bucket | quote }}
+{{- /* Both upload regions come from rustfs.region, never the literal
+       `auto` that in-chart RustFS accepts. Real S3 rejects `auto` with
+       AuthorizationHeaderMalformed and drops every trace while the
+       release reports healthy. See #2214. */}}
 - name: LANGFUSE_S3_EVENT_UPLOAD_REGION
-  value: auto
+  value: {{ .Values.rustfs.region | quote }}
 - name: LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID
   value: {{ .Values.rustfs.auth.accessKey | quote }}
 - name: LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY
@@ -978,7 +982,7 @@ livenessProbe:
 - name: LANGFUSE_S3_MEDIA_UPLOAD_BUCKET
   value: {{ .Values.rustfs.bucket | quote }}
 - name: LANGFUSE_S3_MEDIA_UPLOAD_REGION
-  value: auto
+  value: {{ .Values.rustfs.region | quote }}
 - name: LANGFUSE_S3_MEDIA_UPLOAD_ACCESS_KEY_ID
   value: {{ .Values.rustfs.auth.accessKey | quote }}
 - name: LANGFUSE_S3_MEDIA_UPLOAD_SECRET_ACCESS_KEY

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -490,7 +490,8 @@ rustfs:
   # and Langfuse's event/media upload endpoints): an external RustFS on port 443 uses HTTPS. All other configurations use HTTP.
   host: ""
   port: 9000
-  # Signing region for sandbox bundle fetches. Keep it aligned with the regional S3 endpoint.
+  # Signing region for sandbox bundle fetches and Langfuse event/media uploads.
+  # Keep it aligned with the regional S3 endpoint.
   region: us-east-1
   consolePort: 9001
   bucket: langfuse


### PR DESCRIPTION
## Summary

Langfuse event and media S3 uploads were signing with the literal region `auto`. That is accepted by the in-chart RustFS and invisible on the default install, but a BYO object store rejects every upload with `AuthorizationHeaderMalformed` while pods stay Ready and `helm test` passes. Both `LANGFUSE_S3_EVENT_UPLOAD_REGION` and `LANGFUSE_S3_MEDIA_UPLOAD_REGION` now render from `rustfs.region`, the same knob the bundle-fetch init container already uses.

The issue allowed keeping `auto` when `rustfs.deploy` is true. This change renders `rustfs.region` unconditionally: the existing region-override CI render is `--set rustfs.region=eu-west-1` with default `rustfs.deploy=true`, and extending that render only holds if the in-chart path consumes the value too. Default `rustfs.region` remains `us-east-1`. In-chart RustFS accepts a real region string.

`compose.dev.yaml` still uses `auto` for the local RustFS stack; that sibling is out of scope. Related #2211 (key-free Langfuse object-store credentials) touches the same `curie.langfuse.env` block and is not mixed in here.

## Related issue

Closes #2214

## Fix pin verification

Fix pin: charts/curie/ci/object-store-web-identity-assertions.sh

`curie dev verify-fix-pin HEAD charts/curie/ci/object-store-web-identity-assertions.sh` reported `PINNED`. Baseline on the candidate commit passed, including `ok: langfuse event/media upload regions render eu-west-1 on web and worker`. Reversing only the product files failed with `langfuse-web LANGFUSE_S3_EVENT_UPLOAD_REGION rendered as 'auto'; expected 'us-east-1' from rustfs.region`.

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | Chart template and helm-ci render only; does not reach plugin packaging, the runner turn loop, ACI events, or skill eval/check. | | |
| local | n/a | Does not change compose services, dispatcher, worker, API wiring, or a `curie` verb. `compose.dev.yaml` keeps `LANGFUSE_S3_*_REGION=auto` because local RustFS accepts it. | | |
| local-release | n/a | Does not reach released binary identity, the install path, version pins, or release compose. | | |
| cluster | required | Changes `curie.langfuse.env` and the helm-ci object-store render assertions. The AC is the rendered Langfuse upload region matching `rustfs.region`. | fake | Commit `e8750c601`. `bash charts/curie/ci/object-store-web-identity-assertions.sh` printed `ok: langfuse event/media upload regions render eu-west-1 on web and worker` (and us-east-1 on the default and BYO renders) and `PASS`. `helm lint charts/curie` passed. Default `helm template curie charts/curie --namespace dev` rendered all four Langfuse region env vars as `us-east-1`. |
| live provider | n/a | Does not reach model routing, credential resolution, provider auth, or token/cost accounting. | | |
| external integration | n/a | Does not reach Slack, git push webhooks, connector OAuth, or a third-party API shape. Real S3 was the discovery environment; the AC is helm render of `rustfs.region`, not a live S3 call. | | |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

Positive: region-override render (`--set rustfs.region=eu-west-1`) asserts both Langfuse keys on web and worker equal `eu-west-1`. Negative: the same assertions failed on the unfixed template with `rendered as 'auto'`, and `verify-fix-pin` reproduced that after reversing product files (`PINNED`). Second path: default in-chart render still succeeds and uses `us-east-1` from `rustfs.region`.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [ ] An ADR is added under `docs/adr/` if this is an architectural decision.
