### PR TITLE
Render a runner egress allow for a BYO object store

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -462,6 +462,15 @@ jobs:
           set -euo pipefail
           bash charts/curie/ci/object-store-web-identity-assertions.sh
 
+      # Prove a BYO object store gets a runner egress allow for S3 (and STS on
+      # the key-free path). Rail 1 is fail-closed and the in-chart rustfs pod
+      # selector does not render when rustfs.deploy is false, so a default-shaped
+      # BYO install used to hang every sandbox in Init (#2213).
+      - name: helm render assertions (BYO object store runner egress)
+        run: |
+          set -euo pipefail
+          bash charts/curie/ci/object-store-byo-egress-assertions.sh
+
       - name: helm template + kubeconform (values-dev overlay)
         run: |
           set -euo pipefail

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,7 +37,8 @@ The rails are the actual control. Every agent runs inside them:
   runner-sandbox pods is fail-closed: an empty `allowedEgress` means the sandbox
   can resolve DNS and ship traces, but reach nothing else. Arbitrary internet
   and the cloud metadata endpoint `169.254.169.254` are denied. Only
-  explicitly-declared egress is permitted: DNS, the in-chart collector, RustFS,
+  explicitly-declared egress is permitted: DNS, the in-chart collector, RustFS
+  (or `rustfs.egress` / `rustfs.stsEgress` when the object store is BYO),
   and inference when deployed, plus the operator's declared model API and MCP
   hosts via `allowedEgress`.
 - **gVisor kernel isolation** via a RuntimeClass (`security.gvisor.mode`).

--- a/charts/curie/CLAUDE.md
+++ b/charts/curie/CLAUDE.md
@@ -75,7 +75,10 @@ component and rail detail in `charts/curie/README.md`.
 - **Fail-closed egress, always.** `security.networkPolicy.allowedEgress` is
   empty by default; an unset allowlist must never mean allow-all. If you add
   a new egress destination the runner needs, it goes into this allowlist
-  explicitly -- never widen the default-deny baseline itself.
+  explicitly -- never widen the default-deny baseline itself. The exception
+  is a BYO object store (`rustfs.deploy: false`): that allow is
+  `rustfs.egress` (and `rustfs.stsEgress` on the key-free path), required at
+  render, not mixed into the model-API allowlist.
 - **NetworkPolicy allows are additive, never restrictive-intersecting
   (#765, ADR-0067).** A second NetworkPolicy selecting the same pods can only
   widen what Rail 1 permits, never narrow it -- there is no such thing as one

--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -588,6 +588,18 @@ rustfs:
   region: us-east-1
   auth:
     accessKey: ""            # selects the key-free path
+  # Rail 1 is fail-closed. The in-chart runner-allow-rustfs policy selects the
+  # in-cluster rustfs pod and does not render here. NetworkPolicy cannot
+  # target rustfs.host (a DNS name), so these CIDRs are required at render.
+  # On EKS the tight form is VPC interface endpoints for s3 and sts with
+  # private DNS enabled, which turns each requirement into a /32 rather than
+  # an AWS public service CIDR range.
+  egress:
+    - cidr: 192.0.2.10/32    # S3 VPC interface endpoint
+      ports: [{ protocol: TCP, port: 443 }]
+  stsEgress:
+    - cidr: 192.0.2.11/32    # STS VPC interface endpoint
+      ports: [{ protocol: TCP, port: 443 }]
 api:
   serviceAccount:
     annotations:
@@ -608,6 +620,28 @@ The bundle fetch uses path style addressing, so it appends
 region, change the region in `rustfs.host` and set `rustfs.region` to control
 the SigV4 signing region used by the bundle fetch init container. This setting
 does not configure the API or worker S3 clients.
+
+**Runner egress is a separate required list.** Rail 1 default-denies the
+sandbox, and the in-chart `runner-allow-rustfs` policy is a pod selector on
+this release's rustfs component, so it does not render when
+`rustfs.deploy` is false. Putting S3 in `security.networkPolicy.allowedEgress`
+alongside the model API used to be the only workaround, and a model-only
+allowlist then installed green while every sandbox hung in `Init` on the first
+turn. The chart now refuses that shape at render: `rustfs.egress` must cover
+the object-store endpoint, and on this key-free path `rustfs.stsEgress` must
+cover STS (`AssumeRoleWithWebIdentity`). Both are `{cidr, ports}` entries like
+`allowedEgress`. Do not put a DNS name here; NetworkPolicy has no hostname
+peer. A default route or a CIDR that reaches `169.254.169.254` is refused:
+these lists are store endpoints, not a second model allowlist.
+
+On EKS, create VPC **interface** endpoints for `s3` and `sts` in the cluster
+VPC with private DNS enabled, then put each endpoint's ENI address in as a
+`/32` on TCP 443. That keeps the fail-closed posture meaningful instead of
+opening an AWS public service CIDR range. Gateway endpoints for S3 do not
+give the sandbox a unicast address to allow. Static-key BYO still needs
+`rustfs.egress` (the fetch talks to S3) and does not need `rustfs.stsEgress`.
+Opting out of Rail 1 (`security.networkPolicy.enabled: false`) skips both
+requirements because there is then no runner NetworkPolicy to satisfy.
 
 Scope the runner's role to the bundle bucket, **read-only**. NetworkPolicy
 selects pods rather than containers, so any identity the bundle-fetch init
@@ -761,7 +795,10 @@ sandbox and renders whenever an in-chart store is deployed.
 **Fail-closed egress.** `security.networkPolicy.allowedEgress` is EMPTY by
 default: a fresh install denies all egress except DNS until the operator declares
 where the model API and MCP endpoints live (`{cidr, ports}` entries). An unset
-allowlist never means allow-all.
+allowlist never means allow-all. A BYO object store is not on that list: set
+`rustfs.egress` (and `rustfs.stsEgress` on the key-free path) so the sandbox
+bundle-fetch can reach S3 and STS without opening the model allowlist. See
+**Key-free object store auth** above.
 
 **The controller does not get a second vote on egress (#765, ADR-0067).**
 NetworkPolicy allows are additive across objects selecting the same pods -- Rail

--- a/charts/curie/ci/object-store-byo-egress-assertions.sh
+++ b/charts/curie/ci/object-store-byo-egress-assertions.sh
@@ -1,0 +1,403 @@
+#!/usr/bin/env bash
+#
+# Render-assertion test for issue #2213. With a BYO object store
+# (`rustfs.deploy: false`) Rail 1 is still fail-closed, and the only
+# object-store egress carve-out the chart used to render selected the in-chart
+# rustfs pod. Bundle-fetch then could not reach S3 or, on the key-free path,
+# STS, so every sandbox sat in Init and the turn timed out.
+#
+# This pins the replacement contract:
+#
+#   1. The default (in-chart rustfs) render is unchanged: runner-allow-rustfs
+#      still selects this release's rustfs pod on TCP 9000, and
+#      runner-allow-object-store does not render. allowedEgress stays empty.
+#   2. rustfs.deploy=false with rustfs.egress (and rustfs.stsEgress on the
+#      key-free path) renders runner-allow-object-store covering those CIDRs
+#      and does not render the in-chart rustfs pod selector.
+#   3. rustfs.deploy=false without rustfs.egress fails at render, naming the
+#      key, so a model-only allowedEgress list cannot ship a silently broken
+#      BYO install.
+#   4. The key-free path additionally requires rustfs.stsEgress (STS is a
+#      different endpoint than S3). Static credentials do not.
+#   5. Opting out of Rail 1 (`security.networkPolicy.enabled=false`) does not
+#      require the BYO CIDRs: there is no fail-closed runner policy to satisfy.
+#
+# NetworkPolicy speaks CIDRs, not DNS names, so the chart cannot derive an
+# allow from rustfs.host. The values-level CIDR lists are the mechanism; the
+# README's BYO section documents the EKS VPC interface-endpoint /32 pattern.
+#
+# Runnable locally and from CI. Fails loudly.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+RELEASE=curie
+NAMESPACE=dev
+RUSTFS_POLICY="${RELEASE}-runner-allow-rustfs"
+OBJECT_STORE_POLICY="${RELEASE}-runner-allow-object-store"
+DEFAULT_DENY_EGRESS="${RELEASE}-runner-default-deny-egress"
+ALLOW_EGRESS="${RELEASE}-runner-allow-egress"
+
+S3_CIDR=192.0.2.10/32
+STS_CIDR=192.0.2.11/32
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+render_dir() {
+  local name="$1"
+  shift
+  local out="$TMP/$name"
+  mkdir -p "$out"
+  helm template "$RELEASE" "$CHART" --namespace "$NAMESPACE" \
+    --output-dir "$out" "$@" >/dev/null
+  printf '%s\n' "$out"
+}
+
+CHECKER="$TMP/check.py"
+cat > "$CHECKER" <<'PY'
+import pathlib
+import sys
+
+import yaml
+
+ROOT = pathlib.Path(sys.argv[1])
+ACTION = sys.argv[2]
+
+
+def die(message):
+    raise SystemExit(message)
+
+
+def load(root):
+    docs = []
+    for path in sorted(root.rglob("*.yaml")):
+        for document in yaml.safe_load_all(path.read_text()):
+            if isinstance(document, dict):
+                docs.append(document)
+    if not docs:
+        die(f"{root}: Helm wrote no YAML documents")
+    return docs
+
+
+def policies(docs):
+    return [doc for doc in docs if doc.get("kind") == "NetworkPolicy"]
+
+
+def named(docs, name):
+    matches = [
+        doc
+        for doc in policies(docs)
+        if doc.get("metadata", {}).get("name") == name
+    ]
+    if len(matches) > 1:
+        die(f"expected at most one NetworkPolicy/{name}, found {len(matches)}")
+    return matches[0] if matches else None
+
+
+def ip_blocks(policy):
+    blocks = []
+    for rule in (policy or {}).get("spec", {}).get("egress", []) or []:
+        ports = rule.get("ports")
+        for peer in rule.get("to") or []:
+            block = peer.get("ipBlock") or {}
+            if "cidr" in block:
+                blocks.append((block["cidr"], ports, block.get("except") or []))
+    return blocks
+
+
+def pod_peers(policy):
+    peers = []
+    for rule in (policy or {}).get("spec", {}).get("egress", []) or []:
+        ports = rule.get("ports")
+        for peer in rule.get("to") or []:
+            if "podSelector" in peer:
+                peers.append((peer, ports))
+    return peers
+
+
+def runner_selector(policy):
+    return (policy or {}).get("spec", {}).get("podSelector", {}).get("matchLabels", {})
+
+
+docs = load(ROOT)
+
+if ACTION == "default":
+    rustfs = named(docs, sys.argv[3])
+    byo = named(docs, sys.argv[4])
+    deny = named(docs, sys.argv[5])
+    allow = named(docs, sys.argv[6])
+    if rustfs is None:
+        die("default render dropped runner-allow-rustfs")
+    if byo is not None:
+        die("default render must not emit runner-allow-object-store")
+    if deny is None:
+        die("default render dropped runner-default-deny-egress")
+    if allow is not None:
+        die("default render must keep allowedEgress empty (no runner-allow-egress)")
+    labels = runner_selector(rustfs)
+    if labels.get("app.kubernetes.io/component") != "runner-sandbox":
+        die(f"runner-allow-rustfs selects {labels!r}, not runner-sandbox")
+    peers = pod_peers(rustfs)
+    if len(peers) != 1:
+        die(f"runner-allow-rustfs expected one pod peer, found {len(peers)}")
+    peer, ports = peers[0]
+    component = (
+        peer.get("podSelector", {})
+        .get("matchLabels", {})
+        .get("app.kubernetes.io/component")
+    )
+    if component != "rustfs":
+        die(f"runner-allow-rustfs peer component is {component!r}, expected rustfs")
+    if ports != [{"protocol": "TCP", "port": 9000}]:
+        die(f"runner-allow-rustfs ports are {ports!r}, expected TCP 9000")
+    if ip_blocks(rustfs):
+        die("in-chart runner-allow-rustfs must keep using a pod selector, not ipBlock")
+    print("ok: default render keeps in-chart rustfs pod allow and no BYO object-store policy")
+
+elif ACTION == "byo-keyfree":
+    rustfs = named(docs, sys.argv[3])
+    byo = named(docs, sys.argv[4])
+    deny = named(docs, sys.argv[5])
+    allow = named(docs, sys.argv[6])
+    s3_cidr = sys.argv[7]
+    sts_cidr = sys.argv[8]
+    if rustfs is not None:
+        die("BYO render still emitted in-chart runner-allow-rustfs")
+    if byo is None:
+        die("BYO render missing runner-allow-object-store")
+    if deny is None:
+        die("BYO render dropped runner-default-deny-egress")
+    if allow is not None:
+        die("BYO render must keep allowedEgress empty (no runner-allow-egress)")
+    labels = runner_selector(byo)
+    if labels.get("app.kubernetes.io/component") != "runner-sandbox":
+        die(f"runner-allow-object-store selects {labels!r}, not runner-sandbox")
+    if byo.get("spec", {}).get("policyTypes") != ["Egress"]:
+        die("runner-allow-object-store must be egress-only")
+    blocks = ip_blocks(byo)
+    cidrs = {cidr for cidr, _ports, _except in blocks}
+    if cidrs != {s3_cidr, sts_cidr}:
+        die(
+            f"BYO object-store policy CIDRs are {sorted(cidrs)!r}; "
+            f"expected exactly {{{s3_cidr}, {sts_cidr}}}"
+        )
+    for cidr, ports, excepts in blocks:
+        if ports != [{"protocol": "TCP", "port": 443}]:
+            die(f"{cidr} ports are {ports!r}, expected TCP 443")
+        if excepts:
+            die(f"{cidr} must not except anything on a /32 host allow; got {excepts}")
+    print("ok: BYO key-free render allows the configured S3 and STS CIDRs")
+
+elif ACTION == "byo-static":
+    rustfs = named(docs, sys.argv[3])
+    byo = named(docs, sys.argv[4])
+    allow = named(docs, sys.argv[5])
+    s3_cidr = sys.argv[6]
+    sts_cidr = sys.argv[7]
+    if rustfs is not None:
+        die("static-key BYO render still emitted in-chart runner-allow-rustfs")
+    if byo is None:
+        die("static-key BYO render missing runner-allow-object-store")
+    if allow is not None:
+        die("static-key BYO render must keep allowedEgress empty (no runner-allow-egress)")
+    cidrs = {cidr for cidr, _ports, _except in ip_blocks(byo)}
+    if cidrs != {s3_cidr}:
+        die(
+            f"static-key BYO policy CIDRs are {sorted(cidrs)!r}; "
+            f"expected only the S3 CIDR {s3_cidr} (STS is key-free-only)"
+        )
+    if sts_cidr in cidrs:
+        die("static-key BYO must not require or emit an STS allow")
+    print("ok: static-key BYO render allows only the object-store CIDR")
+
+else:
+    die(f"unknown action {ACTION!r}")
+PY
+
+echo "=== Assertion 1: default render is unchanged (in-chart rustfs allow, no BYO policy) ==="
+DEFAULT_OUT="$(render_dir default)"
+python3 "$CHECKER" "$DEFAULT_OUT" default \
+  "$RUSTFS_POLICY" "$OBJECT_STORE_POLICY" "$DEFAULT_DENY_EGRESS" "$ALLOW_EGRESS" \
+  || fail "default render changed the in-chart rustfs egress carve-out or opened a BYO policy"
+
+echo "=== Assertion 2: BYO key-free path renders S3 and STS ipBlock allows ==="
+KEYFREE_VALUES="$TMP/keyfree.yaml"
+cat > "$KEYFREE_VALUES" <<EOF
+rustfs:
+  deploy: false
+  host: s3.example.com
+  port: 443
+  auth:
+    accessKey: ""
+  egress:
+    - cidr: ${S3_CIDR}
+      ports: [{ protocol: TCP, port: 443 }]
+  stsEgress:
+    - cidr: ${STS_CIDR}
+      ports: [{ protocol: TCP, port: 443 }]
+api:
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::000000000000:role/curie-api
+worker:
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::000000000000:role/curie-worker
+agentSandbox:
+  runner:
+    serviceAccount:
+      annotations:
+        eks.amazonaws.com/role-arn: arn:aws:iam::000000000000:role/curie-runner
+EOF
+KEYFREE_OUT="$(render_dir keyfree --values "$KEYFREE_VALUES")"
+python3 "$CHECKER" "$KEYFREE_OUT" byo-keyfree \
+  "$RUSTFS_POLICY" "$OBJECT_STORE_POLICY" "$DEFAULT_DENY_EGRESS" "$ALLOW_EGRESS" \
+  "$S3_CIDR" "$STS_CIDR" \
+  || fail "BYO key-free render did not emit runner-allow-object-store covering S3 and STS"
+
+echo "=== Assertion 3: static-key BYO renders only the object-store CIDR ==="
+STATIC_VALUES="$TMP/static.yaml"
+cat > "$STATIC_VALUES" <<EOF
+rustfs:
+  deploy: false
+  host: s3.example.com
+  port: 443
+  egress:
+    - cidr: ${S3_CIDR}
+      ports: [{ protocol: TCP, port: 443 }]
+EOF
+STATIC_OUT="$(render_dir static --values "$STATIC_VALUES")"
+python3 "$CHECKER" "$STATIC_OUT" byo-static \
+  "$RUSTFS_POLICY" "$OBJECT_STORE_POLICY" "$ALLOW_EGRESS" "$S3_CIDR" "$STS_CIDR" \
+  || fail "static-key BYO render did not emit a rustfs.egress-only object-store policy"
+
+echo "=== Assertion 4: BYO without rustfs.egress fails at render, naming the key ==="
+MISSING_EGRESS_VALUES="$TMP/missing-egress.yaml"
+cat > "$MISSING_EGRESS_VALUES" <<'EOF'
+rustfs:
+  deploy: false
+  host: s3.example.com
+  port: 443
+EOF
+MISSING_EGRESS="$TMP/missing-egress.txt"
+if helm template "$RELEASE" "$CHART" --namespace "$NAMESPACE" \
+  --values "$MISSING_EGRESS_VALUES" \
+  > /dev/null 2>"$MISSING_EGRESS"; then
+  fail "rustfs.deploy=false without rustfs.egress must fail Helm rendering"
+fi
+if ! grep -q "rustfs.egress" "$MISSING_EGRESS"; then
+  fail "missing-egress render failed without naming rustfs.egress; output was: $(cat "$MISSING_EGRESS")"
+fi
+echo "ok: BYO without rustfs.egress is refused at render"
+
+echo "=== Assertion 5: key-free BYO without rustfs.stsEgress fails at render, naming the key ==="
+MISSING_STS_VALUES="$TMP/missing-sts.yaml"
+cat > "$MISSING_STS_VALUES" <<EOF
+rustfs:
+  deploy: false
+  host: s3.example.com
+  port: 443
+  auth:
+    accessKey: ""
+  egress:
+    - cidr: ${S3_CIDR}
+      ports: [{ protocol: TCP, port: 443 }]
+api:
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::000000000000:role/curie-api
+worker:
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::000000000000:role/curie-worker
+agentSandbox:
+  runner:
+    serviceAccount:
+      annotations:
+        eks.amazonaws.com/role-arn: arn:aws:iam::000000000000:role/curie-runner
+EOF
+MISSING_STS="$TMP/missing-sts.txt"
+if helm template "$RELEASE" "$CHART" --namespace "$NAMESPACE" \
+  --values "$MISSING_STS_VALUES" \
+  > /dev/null 2>"$MISSING_STS"; then
+  fail "key-free BYO without rustfs.stsEgress must fail Helm rendering"
+fi
+if ! grep -q "rustfs.stsEgress" "$MISSING_STS"; then
+  fail "missing-sts render failed without naming rustfs.stsEgress; output was: $(cat "$MISSING_STS")"
+fi
+echo "ok: key-free BYO without rustfs.stsEgress is refused at render"
+
+echo "=== Assertion 6: Rail 1 off does not require BYO object-store CIDRs ==="
+if ! helm template "$RELEASE" "$CHART" --namespace "$NAMESPACE" \
+  --set rustfs.deploy=false \
+  --set rustfs.host=s3.example.com \
+  --set rustfs.port=443 \
+  --set security.networkPolicy.enabled=false \
+  > /dev/null; then
+  fail "rustfs.deploy=false with networkPolicy.enabled=false must still render"
+fi
+echo "ok: opting out of Rail 1 does not require rustfs.egress"
+
+must_fail_naming() {
+  local label="$1"
+  local needle="$2"
+  local values="$3"
+  local out="$TMP/${label}.txt"
+  if helm template "$RELEASE" "$CHART" --namespace "$NAMESPACE" \
+    --values "$values" \
+    > /dev/null 2>"$out"; then
+    fail "${label} must fail Helm rendering"
+  fi
+  if ! grep -q "$needle" "$out"; then
+    fail "${label} failed without naming ${needle}; output was: $(cat "$out")"
+  fi
+  echo "ok: ${label} is refused at render"
+}
+
+echo "=== Assertion 7: rustfs.egress default route is refused ==="
+DEFAULT_ROUTE_VALUES="$TMP/default-route.yaml"
+cat > "$DEFAULT_ROUTE_VALUES" <<'EOF'
+rustfs:
+  deploy: false
+  host: s3.example.com
+  port: 443
+  egress:
+    - cidr: 0.0.0.0/0
+      ports: [{ protocol: TCP, port: 443 }]
+EOF
+must_fail_naming "default-route rustfs.egress" "rustfs.egress" "$DEFAULT_ROUTE_VALUES"
+
+echo "=== Assertion 8: rustfs.egress must not allow the metadata host ==="
+IMDS_VALUES="$TMP/imds.yaml"
+cat > "$IMDS_VALUES" <<'EOF'
+rustfs:
+  deploy: false
+  host: s3.example.com
+  port: 443
+  egress:
+    - cidr: 169.254.169.254/32
+      ports: [{ protocol: TCP, port: 443 }]
+EOF
+must_fail_naming "metadata-host rustfs.egress" "169.254.169.254" "$IMDS_VALUES"
+
+echo "=== Assertion 9: rustfs.egress entries require ports ==="
+NO_PORTS_VALUES="$TMP/no-ports.yaml"
+cat > "$NO_PORTS_VALUES" <<'EOF'
+rustfs:
+  deploy: false
+  host: s3.example.com
+  port: 443
+  egress:
+    - cidr: 192.0.2.10/32
+EOF
+must_fail_naming "ports-missing rustfs.egress" "ports" "$NO_PORTS_VALUES"
+
+echo
+echo "PASS: BYO object-store egress is required and rendered as a runner NetworkPolicy; the default in-chart rustfs allow is unchanged."

--- a/charts/curie/ci/object-store-web-identity-assertions.sh
+++ b/charts/curie/ci/object-store-web-identity-assertions.sh
@@ -64,6 +64,16 @@ rustfs:
   port: 443
   auth:
     accessKey: ""
+  # Dedicated runner allows for the BYO store and STS (#2213). TEST-NET-1
+  # stands in for VPC interface-endpoint /32s. The broad allowedEgress list
+  # below is a separate Rail 1 pin: it is the configuration in which the IMDS
+  # carve-out is observable.
+  egress:
+    - cidr: 192.0.2.10/32
+      ports: [{ protocol: TCP, port: 443 }]
+  stsEgress:
+    - cidr: 192.0.2.11/32
+      ports: [{ protocol: TCP, port: 443 }]
 # A key-free BYO store still has to be REACHABLE, so this overlay carries the
 # broad allowlist such an install realistically sets. That is also the only
 # configuration in which Rail 1's IMDS carve-out is observable: with an empty

--- a/charts/curie/ci/worker-object-store-assertions.sh
+++ b/charts/curie/ci/worker-object-store-assertions.sh
@@ -30,6 +30,11 @@ rustfs:
   deploy: false
   host: s3.example.com
   port: 443
+  # Required once Rail 1 is on: the in-chart rustfs pod selector does not
+  # render on the BYO path (#2213). TEST-NET-1 stands in for the store CIDR.
+  egress:
+    - cidr: 192.0.2.10/32
+      ports: [{ protocol: TCP, port: 443 }]
 EOF
 
 # Capture Helm output in Python so a large manifest cannot be truncated by a
@@ -70,6 +75,8 @@ def assert_external_store_requires_hostname():
         "dev",
         "--set",
         "rustfs.deploy=false",
+        "--set",
+        "rustfs.egress[0].cidr=192.0.2.10/32",
     ]
     rendered = subprocess.run(command, capture_output=True, text=True)
     if rendered.returncode == 0:

--- a/charts/curie/templates/NOTES.txt
+++ b/charts/curie/templates/NOTES.txt
@@ -25,6 +25,7 @@ Components deployed:
   - RustFS ({{ .Values.rustfs.image }})
 {{- else }}
   - S3: BYO at {{ .Values.rustfs.host }}:{{ .Values.rustfs.port }}
+    Runner bundle-fetch egress: rustfs.egress{{ if not (include "curie.rustfs.staticCredentials" .) }} and rustfs.stsEgress{{ end }} (VPC interface endpoint /32s on EKS).
 {{- end }}
 {{- if .Values.otelCollector.deploy }}
   - OTel Collector ({{ .Values.otelCollector.image }}) at http://{{ include "curie.fullname" . }}-otel-collector:{{ .Values.otelCollector.service.httpPort }}

--- a/charts/curie/templates/security-networkpolicy.yaml
+++ b/charts/curie/templates/security-networkpolicy.yaml
@@ -46,6 +46,40 @@ per-entry `except:` list, which wins over this auto carve-out.
   {{- end -}}
 {{- end -}}
 {{- end -}}
+{{/*
+Validate one rustfs.egress / rustfs.stsEgress entry. These lists are store
+(and STS) endpoints, not the model allowlist: a default route or a CIDR that
+reaches the cloud metadata address would additively re-open the prompt-injectable
+runner. Require cidr + ports, refuse prefix 0/1, and refuse any CIDR that
+contains 169.254.169.254 or fd00:ec2::254.
+*/}}
+{{- define "curie.objectStore.egressEntry" -}}
+{{- $key := .key -}}
+{{- $cidr := trim (printf "%v" (.entry.cidr | default "")) -}}
+{{- if eq $cidr "" -}}
+{{- fail (printf "%s entries must set cidr" $key) -}}
+{{- end -}}
+{{- if not .entry.ports -}}
+{{- fail (printf "%s entries must set ports" $key) -}}
+{{- end -}}
+{{- $parts := splitList "/" $cidr -}}
+{{- if ne (len $parts) 2 -}}
+{{- fail (printf "%s entry %q is not a CIDR" $key $cidr) -}}
+{{- end -}}
+{{- $ip := index $parts 0 -}}
+{{- $prefixText := index $parts 1 -}}
+{{- if not (regexMatch "^(0|[1-9][0-9]{0,2})$" $prefixText) -}}
+{{- fail (printf "%s entry %q has an invalid prefix length" $key $cidr) -}}
+{{- end -}}
+{{- $prefix := int $prefixText -}}
+{{- if le $prefix 1 -}}
+{{- fail (printf "%s entry %q is a default or equivalently broad route; use a VPC interface endpoint /32 or a regional store/STS prefix, not a default route" $key $cidr) -}}
+{{- end -}}
+{{- $auto := include "curie.metadataExcept" $cidr | trim -}}
+{{- if or $auto (eq $ip "169.254.169.254") (hasPrefix "fd00:ec2:" $ip) -}}
+{{- fail (printf "%s entry %q must not cover the cloud metadata endpoint 169.254.169.254" $key $cidr) -}}
+{{- end -}}
+{{- end -}}
 {{- if and .Values.agentSandbox.deploy .Values.security.networkPolicy.enabled }}
 {{- $np := .Values.security.networkPolicy }}
 {{/*
@@ -162,13 +196,13 @@ spec:
       ports:
         - { protocol: TCP, port: 8000 }
 {{- end }}
-{{- if and .Values.rustfs.deploy (or .Values.agentSandbox.runner.bundleFetch.enabled .Values.agentSandbox.runner.workspace.enabled) }}
+{{- if or .Values.agentSandbox.runner.bundleFetch.enabled .Values.agentSandbox.runner.workspace.enabled }}
+{{- if .Values.rustfs.deploy }}
 ---
 {{/* Allow the runner's bundle-fetch or workspace-fetch init container to reach
      THIS release's in-chart RustFS for its exact object. Mirrors the collector carve out
      above: without it, rail 1's default-deny blocks the S3 fetch and every bound
-     sandbox fails closed. BYO S3 with rustfs.deploy=false is an external host, so it
-     goes through the operator's allowedEgress list instead. */}}
+     sandbox fails closed. */}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -191,6 +225,61 @@ spec:
               {{- include "curie.selectorLabels" (dict "root" . "component" "rustfs") | nindent 14 }}
       ports:
         - { protocol: TCP, port: 9000 }
+{{- else }}
+{{/* BYO object store (#2213). There is no in-chart rustfs pod to select, and
+     NetworkPolicy cannot target rustfs.host (a DNS name). The operator must
+     declare CIDRs. Empty keeps fail-closed: a model-only allowedEgress list
+     used to install green and then hang every sandbox in Init. On EKS the
+     tight form is VPC interface endpoints for s3 and (key-free) sts with
+     private DNS enabled; see the chart README, "Key-free object store auth". */}}
+{{- if not .Values.rustfs.egress }}
+{{- fail "rustfs.deploy is false: set rustfs.egress to the object-store endpoint CIDRs the runner bundle-fetch must reach. Rail 1 is fail-closed and the in-chart runner-allow-rustfs policy does not render without an in-cluster rustfs pod. NetworkPolicy cannot target rustfs.host. On EKS the tight form is a VPC interface endpoint /32 for S3 with private DNS enabled (see the chart README, 'Key-free object store auth')." }}
+{{- end }}
+{{- if not (include "curie.rustfs.staticCredentials" .) }}
+{{- if not .Values.rustfs.stsEgress }}
+{{- fail "rustfs.deploy is false and rustfs.auth.accessKey is empty: set rustfs.stsEgress to the STS endpoint CIDRs AssumeRoleWithWebIdentity must reach. On EKS the tight form is a VPC interface endpoint /32 for STS with private DNS enabled (see the chart README, 'Key-free object store auth')." }}
+{{- end }}
+{{- end }}
+{{- range .Values.rustfs.egress }}
+{{- include "curie.objectStore.egressEntry" (dict "key" "rustfs.egress" "entry" .) }}
+{{- end }}
+{{- range .Values.rustfs.stsEgress }}
+{{- include "curie.objectStore.egressEntry" (dict "key" "rustfs.stsEgress" "entry" .) }}
+{{- end }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "curie.fullname" . }}-runner-allow-object-store
+  labels:
+    {{- include "curie.labels" . | nindent 4 }}
+    app.kubernetes.io/component: agent-sandbox
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "curie.selectorLabels" (dict "root" . "component" "runner-sandbox") | nindent 6 }}
+  policyTypes: [Egress]
+  egress:
+    {{- range concat (.Values.rustfs.egress | default list) (.Values.rustfs.stsEgress | default list) }}
+    - to:
+        - ipBlock:
+            cidr: {{ .cidr }}
+            {{- if .except }}
+            except:
+              {{- toYaml .except | nindent 14 }}
+            {{- else }}
+            {{- $auto := include "curie.metadataExcept" .cidr | trim }}
+            {{- if $auto }}
+            except:
+              - {{ $auto }}
+            {{- end }}
+            {{- end }}
+      {{- with .ports }}
+      ports:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- end }}
+{{- end }}
 {{- end }}
 {{- if .Values.inference.deploy }}
 ---

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -517,6 +517,28 @@ rustfs:
     accessKey: rustfs
     secretKey: rustfssecret
   existingSecret: ""
+  # Runner sandbox egress to a BYO object store (#2213). Rail 1 is fail-closed,
+  # and the in-chart runner-allow-rustfs policy selects this release's rustfs
+  # pod, so it does not render when deploy is false. Each entry is
+  # {cidr, ports, except?} like security.networkPolicy.allowedEgress.
+  # NetworkPolicy cannot target a DNS name, so rustfs.host is not enough.
+  # Empty (the default) keeps fail-closed: a BYO install with Rail 1 on and
+  # bundle-fetch or workspace enabled is refused at render until these CIDRs
+  # are set. Each entry must set cidr and ports. Default routes and CIDRs that
+  # reach 169.254.169.254 are refused: this is a store-endpoint list, not a
+  # second model allowlist. On EKS the tight form is VPC interface endpoints
+  # for s3 (and sts on the key-free path) with private DNS enabled, which
+  # turns each requirement into a /32 rather than an AWS public service CIDR
+  # range. See the chart README, "Key-free object store auth".
+  egress: []
+  #  - cidr: 192.0.2.10/32
+  #    ports: [{ protocol: TCP, port: 443 }]
+  # Extra CIDRs for STS. Required when deploy is false and accessKey is empty,
+  # because AssumeRoleWithWebIdentity talks to STS, not S3. Unused on the
+  # static-key path.
+  stsEgress: []
+  #  - cidr: 192.0.2.11/32
+  #    ports: [{ protocol: TCP, port: 443 }]
   # RustFS runs as uid 10001. The matching group owns the mounted data volume.
   # Operators using another image can override both security context blocks.
   podSecurityContext:


### PR DESCRIPTION
## Summary

Rail 1 is fail-closed, and the only object-store egress carve-out the chart rendered selected the in-chart rustfs pod. A BYO store (`rustfs.deploy: false`) therefore installed green with a model-only `allowedEgress` list, then hung every sandbox in `Init` because bundle-fetch could not reach S3 or, on the key-free path, STS.

This change renders `runner-allow-object-store` from dedicated `rustfs.egress` (S3) and `rustfs.stsEgress` (STS, key-free only) CIDR lists, keeps the default in-chart rustfs pod allow and empty `allowedEgress` unchanged, and refuses a BYO install that does not declare those CIDRs.

NetworkPolicy cannot target `rustfs.host` (a DNS name), so the chart does not try to derive an ipBlock from the hostname. On EKS the documented tight form is VPC interface endpoints for `s3` and `sts` with private DNS enabled, each as a `/32` on TCP 443.

## Related issue

Closes #2213

## Fix pin verification

Fix pin: charts/curie/ci/object-store-byo-egress-assertions.sh

## Conservative defaults noted

- Dedicated `rustfs.egress` / `rustfs.stsEgress` rather than mixing the store into `security.networkPolicy.allowedEgress`. A model-only allowlist was the incident shape; treating any non-empty `allowedEgress` as sufficient would not have caught it.
- Helm `fail` when those lists are empty (Rail 1 on, bundle-fetch or workspace on). Stronger than documenting `allowedEgress`, and the same idiom as mail-adapter provider CIDRs. Existing BYO overlays that only opened S3 via `allowedEgress` must now also set `rustfs.egress`.
- Store lists refuse a default route, a missing `ports` field, and any CIDR that reaches `169.254.169.254`. They are store endpoints, not a second model allowlist. Regional S3/STS prefixes still render; `0.0.0.0/0` belongs on `allowedEgress` if an operator truly needs it.
- `curie cluster up` / `curie doctor` still only inspect `allowedEgress`. No CLI flag was added; operators set the new keys in values. Same as mail-adapter `httpsCidrs`.

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | Chart NetworkPolicy templates and README only; no plugin, runner turn loop, or skill eval. | | |
| local | n/a | Does not reach compose services, dispatcher, worker, API, console, or a `curie` verb's output. | | |
| local-release | n/a | Does not change released binary or image identity, install path, version pins, or release compose. | | |
| cluster | required | Chart templates and runner NetworkPolicy. The ticket AC is helm-template shaped. | fake | Commit `c290b81be`. `bash charts/curie/ci/object-store-byo-egress-assertions.sh` PASS (default rustfs pod allow unchanged; BYO key-free renders S3+STS ipBlocks; empty lists / `0.0.0.0/0` / IMDS host / missing ports fail at render). Negative: `--set rustfs.deploy=false` without `rustfs.egress` fails naming `rustfs.egress`. No kube context on this runner, so `curie dev chart-runtime-e2e` was not run; that path uses in-chart rustfs (`deploy: true`) and would not exercise this BYO policy. |
| live provider | n/a | No model routing, credential resolution, or token accounting. | | |
| external integration | n/a | No Slack, git webhook, or third-party API shape. | | |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

Sibling checks: `bash charts/curie/ci/worker-object-store-assertions.sh` PASS; `bash charts/curie/ci/object-store-web-identity-assertions.sh` PASS; `helm lint charts/curie` PASS; `bash scripts/check-docs.sh` PASS.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [ ] An ADR is added under `docs/adr/` if this is an architectural decision. Not an ADR: this fills the existing Rail 1 fail-closed contract for a BYO store, it does not change the rail.
