### PR TITLE
Bound the Valkey test connect instead of retrying for a minute

### DIFF
--- a/packages/test-support/src/curie_test_support/valkey.py
+++ b/packages/test-support/src/curie_test_support/valkey.py
@@ -13,10 +13,28 @@ import os
 
 import pytest
 import redis
+from redis.backoff import NoBackoff
+from redis.retry import Retry
 
 VALKEY_HOST = os.environ.get("TEST_VALKEY_HOST", "localhost")
 VALKEY_PORT = int(os.environ.get("TEST_VALKEY_PORT", "26379"))
 VALKEY_PW = os.environ.get("TEST_VALKEY_PW", "valkeypass")
+
+# How long one connect attempt may block. redis-py leaves socket_connect_timeout
+# at None by default, so a connect to an unreachable Valkey blocks on the OS
+# default rather than on anything this repo chose.
+CONNECT_TIMEOUT_SECONDS = float(os.environ.get("TEST_VALKEY_CONNECT_TIMEOUT", "2"))
+
+# No retries, deliberately. redis-py 8.x defaults to Retry(ExponentialWithJitter,
+# 3), which is a MULTIPLIER on the timeout above and is what actually made an
+# unreachable Valkey cost a minute: measured on redis-py 8.1.0 against a bound
+# but unlistening port, socket_connect_timeout=5 still took 58.74s and the
+# unbounded default took 59.66s, while no-retry with a bounded timeout returns in
+# the timeout. Retrying is wrong for this helper regardless of the cost. Its
+# whole contract is one ping that decides skip-or-raise, the compose Valkey is
+# either up before the suite starts or it is not, and a helper that retries turns
+# "your stack is not running" into a minute of silence per fixture.
+NO_RETRY = Retry(NoBackoff(), 0)
 
 
 def connect_or_skip(*, decode_responses: bool = True) -> redis.Redis:
@@ -27,12 +45,19 @@ def connect_or_skip(*, decode_responses: bool = True) -> redis.Redis:
     ``CI_REQUIRE_VALKEY_TESTS`` is absent. Its presence makes the original
     ``RedisError`` fail the required CI job instead. The caller owns the returned
     client (yield it from a fixture and ``.close()`` on teardown).
+
+    The connect is bounded by ``CONNECT_TIMEOUT_SECONDS`` and does not retry, so
+    an unreachable Valkey costs that timeout once rather than a minute. See the
+    constants above for why; ``TEST_VALKEY_CONNECT_TIMEOUT`` raises the bound for
+    a slow environment.
     """
     client: redis.Redis = redis.Redis(
         host=VALKEY_HOST,
         port=VALKEY_PORT,
         password=VALKEY_PW or None,
         decode_responses=decode_responses,
+        socket_connect_timeout=CONNECT_TIMEOUT_SECONDS,
+        retry=NO_RETRY,
     )
     try:
         client.ping()

--- a/packages/test-support/tests/test_valkey.py
+++ b/packages/test-support/tests/test_valkey.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import socket
+import time
 
 import pytest
 import redis
@@ -29,6 +30,14 @@ def test_connect_or_skip_skips_an_unreachable_valkey_locally(
             valkey.connect_or_skip()
 
 
+# Which error an unreachable port produces is a platform detail, not a contract.
+# A bound but unlistening loopback port refuses on Linux (ConnectionError) and is
+# dropped on macOS (TimeoutError), so pinning ConnectionError alone made this
+# test fail on every Mac. What connect_or_skip promises is that a required run
+# RAISES rather than skips; both classes are that promise kept.
+UNREACHABLE = (redis.exceptions.ConnectionError, redis.exceptions.TimeoutError)
+
+
 def test_connect_or_skip_fails_for_an_unreachable_valkey_when_required(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -36,5 +45,32 @@ def test_connect_or_skip_fails_for_an_unreachable_valkey_when_required(
     listener = _configure_unreachable_valkey(monkeypatch)
 
     with listener:
-        with pytest.raises(redis.exceptions.ConnectionError):
+        with pytest.raises(UNREACHABLE):
             valkey.connect_or_skip()
+
+
+def test_an_unreachable_valkey_costs_the_bounded_timeout_not_a_retry_ladder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The bound must hold end to end, not just be passed to the constructor.
+
+    redis-py 8.x defaults to Retry(ExponentialWithJitterBackoff(), 3), which
+    multiplies socket_connect_timeout rather than capping it: measured on 8.1.0
+    against a bound but unlistening port, socket_connect_timeout=5 still took
+    58.74s and the unbounded default took 59.66s. So asserting the constructor
+    received a timeout would not catch a reintroduced retry policy. Assert the
+    wall clock instead, which is the thing that was wrong.
+    """
+    monkeypatch.delenv("CI_REQUIRE_VALKEY_TESTS", raising=False)
+    monkeypatch.setattr(valkey, "CONNECT_TIMEOUT_SECONDS", 0.25)
+    listener = _configure_unreachable_valkey(monkeypatch)
+
+    with listener:
+        started = time.monotonic()
+        with pytest.raises(pytest.skip.Exception):
+            valkey.connect_or_skip()
+        elapsed = time.monotonic() - started
+
+    # Generous next to a 0.25s bound, and still two orders of magnitude under the
+    # ~59s the retry ladder cost.
+    assert elapsed < 5, f"an unreachable Valkey took {elapsed:.2f}s, so the bound is not holding"


### PR DESCRIPTION
## Summary

`connect_or_skip` built a `redis.Redis` with no `socket_connect_timeout`, so a connect to an unreachable Valkey blocked on the OS default rather than on anything this repo chose. redis-py 8.x then multiplies that by its default `Retry(ExponentialWithJitterBackoff(), 3)`.

Measured on redis-py 8.1.0 against a bound but unlistening loopback port:

| | elapsed |
| --- | --- |
| unbounded default (today) | 59.66s |
| `socket_connect_timeout=5` | 58.74s |
| bounded + no retry | 0.25s |

The middle row is the point: **a timeout alone bounds nothing here**, because the retry ladder is the multiplier. Both had to change.

Retrying is wrong for this helper on its own terms, cost aside. Its whole contract is one ping that decides skip-or-raise. The compose Valkey is either up before the suite starts or it is not, and a helper that retries turns "your stack is not running" into a minute of silence per fixture, across the twenty-odd fixtures that call it.

## This is not a CI win, and I first read it as one

Profiling put these two tests near the top of a local run at ~59s each, and I initially reported that as ~14% of CI's pytest time. That was wrong, and checking it on Linux is what caught it:

```
Linux, bound-not-listening:   4.053s -> ConnectionError
macOS, same port:            59.66s -> TimeoutError
```

Linux refuses immediately, so on CI these two tests cost about 4s each and the 4s is backoff sleep, not connect. The 59s is macOS, where the connect is dropped rather than refused. **What this buys is the local loop**: 2s instead of a minute, on every fixture, for anyone whose dev stack is not running. The CI saving is a few seconds and is not the reason to take it.

## It also fixes a test that failed on every Mac

`test_connect_or_skip_fails_for_an_unreachable_valkey_when_required` pinned `redis.exceptions.ConnectionError`, which is what Linux raises for a refused port; macOS raises `TimeoutError` for the same unreachable port. Which class arrives is a platform detail. What `connect_or_skip` promises is that a required run **raises** rather than skips, and both classes are that promise kept, so the assertion now names both.

## Related issue

Ref #2230

## Fix pin verification

Fix pin: packages/test-support/tests/test_valkey.py::test_an_unreachable_valkey_costs_the_bounded_timeout_not_a_retry_ladder

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | Changes a test-support helper used only by test fixtures. Nothing under `apps/`, `runner/`, `cli/` or `charts/` imports it, so no shipped code path changes. | | |
| local | n/a | Same | | |
| local-release | n/a | Same | | |
| cluster | n/a | Same | | |
| live provider | n/a | Same | | |
| external integration | n/a | Same | | |

Run at commit `79823033`:

**Positive proof, the bound holds.**

```
uv run pytest packages/test-support/tests/test_valkey.py -q --durations=5
  2.01s  test_connect_or_skip_skips_an_unreachable_valkey_locally      (was 58.65s)
  2.00s  test_connect_or_skip_fails_for_an_unreachable_valkey_when_required  (was 59.80s)
  0.25s  test_an_unreachable_valkey_costs_the_bounded_timeout_not_a_retry_ladder
  3 passed in 4.33s
```

All three pass on macOS, where one of them failed before this change.

**Second independent path, the live connection still works.** A bound that also broke real connects would be invisible to the tests above, since every one of them targets an unreachable port. So the fixtures that dial the running compose Valkey were run against the live dev stack:

```
CI_REQUIRE_VALKEY_TESTS=1 uv run pytest apps/dispatcher/tests apps/worker/tests/sandbox packages/test-support/tests -q
  326 passed, 1 skipped in 19.08s
```

**Falsifiable negative.** Reverting the helper fails the new test. It fails at `monkeypatch.setattr` rather than on the wall-clock assertion, because reverting removes the `CONNECT_TIMEOUT_SECONDS` constant the test tunes, so the test cannot pass without the change but does not itself sit through the 59s. The 59s numbers in the table above come from the direct measurement quoted in the commit, not from the suite.

The new test asserts wall clock rather than inspecting the constructor arguments deliberately: a reintroduced retry policy would leave those arguments correct and the behaviour wrong, which is exactly the bug being fixed.

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.
- [x] Or: this change is not behavior-bearing, so no tier applies, and the summary says why.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands). One unrelated failure, `test_connector_lock.py::test_a_context_resolving_outside_the_bundle_is_refused`, reproduces on an untouched checkout of this tree and is a local macOS path issue.
- [x] Docs updated if behavior changed. The reasoning and the measurements live next to the constants they explain.
- [x] An ADR is added under `docs/adr/` if this is an architectural decision. Not one: a timeout on a test helper.
