### PR TITLE
Record pytest durations on every CI run

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -146,11 +146,31 @@ jobs:
           uv run python -m aci_protocol.wire_lock --check-base /tmp/base-wire.lock
       - name: Pytest
         run: uv run pytest -q
+      # Build ONLY when the body actually carries a declaration. tools/fix-pin-ci/
+      # check.py reaches the binary at exactly one place, the
+      # `curie dev verify-fix-pin` call, and only once `declaration.selector` is
+      # set; `n/a`, no declaration, a near-miss marker like `Fix-pin:`, and the
+      # bug-without-declaration rejection all return before touching it. So on
+      # every pull request that declares nothing -- the overwhelming majority --
+      # this was a 213s cold `cargo build --release` for a binary nothing ran,
+      # inside the longest job on the graph.
+      #
+      # `contains()` is case-insensitive and DECLARATION is the exact-case
+      # `Fix pin: <selector>`, so this condition is a strict superset of the
+      # cases that reach the binary: it cannot skip a build the gate then needs.
+      # It builds a few times it need not (`Fix pin: n/a`, a near miss), which is
+      # the safe direction. This stays a direct build inside the required Python
+      # status: no `needs`, no downloaded artifact, no Cargo cache, so nothing
+      # the gate's contract protects is traded away for the time.
       - name: Build the current curie binary for fix pin verification
-        if: github.event_name == 'pull_request'
+        if: >-
+          github.event_name == 'pull_request'
+          && contains(github.event.pull_request.body, 'Fix pin:')
         run: cargo build --release --locked --manifest-path cli/Cargo.toml
       - name: Install Helm for fix pin verification
-        if: github.event_name == 'pull_request'
+        if: >-
+          github.event_name == 'pull_request'
+          && contains(github.event.pull_request.body, 'Fix pin:')
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5
         with:
           version: v3.16.4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -144,8 +144,16 @@ jobs:
           git fetch --no-tags --depth=1 origin "${{ github.base_ref || 'main' }}" || true
           git show "origin/${{ github.base_ref || 'main' }}:packages/aci-protocol/schema/wire.lock" > /tmp/base-wire.lock 2>/dev/null || true
           uv run python -m aci_protocol.wire_lock --check-base /tmp/base-wire.lock
+      # --durations is why this line is not a bare `-q`. The suite is the largest
+      # single cost on the critical path (848s on run 33690551116, serial, 1370
+      # test files) and nothing in CI recorded where that time went, so the only
+      # profile available was a local one -- which turned out to be a bad proxy.
+      # Two tests read as ~59s each locally and about 4s on Linux, because a
+      # bound unlistening port is dropped on macOS and refused on Linux (#2233).
+      # Sharding on numbers like those would have split the suite along the wrong
+      # seam. This prints the real ones on every run, for the price of 25 lines.
       - name: Pytest
-        run: uv run pytest -q
+        run: uv run pytest -q --durations=25
       # Build ONLY when the body actually carries a declaration. tools/fix-pin-ci/
       # check.py reaches the binary at exactly one place, the
       # `curie dev verify-fix-pin` call, and only once `declaration.selector` is

--- a/tools/fix-pin-ci/tests/test_fix_pin_ci.py
+++ b/tools/fix-pin-ci/tests/test_fix_pin_ci.py
@@ -629,6 +629,63 @@ def test_ci_keeps_the_required_python_status_and_calls_fix_pin_after_pytest() ->
     assert gate_index < diagnostic_index
 
 
+DECLARATION_GUARD = "contains(github.event.pull_request.body, 'Fix pin:')"
+
+
+def test_selector_tooling_builds_only_when_the_body_declares_a_fix_pin() -> None:
+    """The cargo build must be gated on a declaration, and gated the safe way.
+
+    check.py reaches the binary at exactly one place, the `curie dev
+    verify-fix-pin` call, and only once `declaration.selector` is set. `n/a`, no
+    declaration, a near-miss marker and the bug-without-declaration rejection all
+    return first. Building unconditionally therefore spent a cold
+    `cargo build --release` inside the longest job on the graph for a binary that
+    the majority of pull requests never run.
+
+    The guard must stay a strict SUPERSET of the cases that reach the binary.
+    `contains()` is case-insensitive and DECLARATION is the exact-case
+    `Fix pin: <selector>`, so a body that reaches the binary always contains the
+    substring. Skipping a build the gate then needs would be the unsafe
+    direction, and this pins that it cannot happen.
+    """
+    document = _load_ci()
+    _, steps = _python_job(document)
+
+    for description, predicate in (
+        (
+            "direct current release build",
+            lambda step: _string(step, "run").strip()
+            == "cargo build --release --locked --manifest-path cli/Cargo.toml",
+        ),
+        (
+            "pinned Helm setup",
+            lambda step: _string(step, "uses")
+            == "azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310",
+        ),
+    ):
+        step = steps[_single_step_index(steps, predicate, description)]
+        condition = _string(step, "if")
+        assert PR_CONDITION.search(condition), f"{description} must stay pull-request only"
+        assert DECLARATION_GUARD in condition, (
+            f"{description} must build only when the body declares a Fix pin: {condition!r}"
+        )
+
+    # The gate itself must NOT carry the guard. It is the step that decides a
+    # missing declaration is acceptable, and a body-shaped `if` on it would turn
+    # the "closes a bug with no declaration" rejection into a skipped step.
+    gate = steps[
+        _single_step_index(
+            steps,
+            lambda step: "tools/fix-pin-ci/check.py" in _string(step, "run"),
+            "fix pin caller",
+        )
+    ]
+    assert DECLARATION_GUARD not in _string(gate, "if"), (
+        "the gate must still run for a body with no declaration, or the "
+        "bug-without-declaration rejection can never fire"
+    )
+
+
 def test_pull_request_template_documents_the_required_declaration() -> None:
     template = PR_TEMPLATE.read_text(encoding="utf-8")
 

--- a/tools/fix-pin-ci/tests/test_fix_pin_ci.py
+++ b/tools/fix-pin-ci/tests/test_fix_pin_ci.py
@@ -563,10 +563,22 @@ def test_ci_keeps_the_required_python_status_and_calls_fix_pin_after_pytest() ->
         lambda step: "uv run alembic upgrade head" in _string(step, "run"),
         "shared database migration",
     )
+    # Matched on the prefix, not on equality. What this assertion is for is that
+    # the normal suite runs, unfiltered, before the gate; reporting flags like
+    # --durations do not bear on that, and pinning the exact string made a
+    # profiling flag look like a contract change.
     pytest_index = _single_step_index(
         steps,
-        lambda step: _string(step, "run").strip() == "uv run pytest -q",
+        lambda step: _string(step, "run").strip().startswith("uv run pytest -q"),
         "normal Python suite",
+    )
+    pytest_command = shlex.split(_string(steps[pytest_index], "run").strip())
+    assert pytest_command[:4] == ["uv", "run", "pytest", "-q"]
+    assert all(
+        argument.startswith("--durations") for argument in pytest_command[4:]
+    ), (
+        "the Python suite must run unfiltered: only reporting flags may be added "
+        f"to `uv run pytest -q`, got {pytest_command!r}"
     )
     gate_index = _single_step_index(
         steps,


### PR DESCRIPTION
## Summary

`uv run pytest -q` is the largest single cost on the critical path: 848s on run [33690551116](https://github.com/curie-eng/curie/actions/runs/33690551116), serial, across 1370 test files. Nothing in CI recorded where that time went.

So the only profile available was a local one, and it turned out to be a bad proxy. Two tests read as ~59s each on macOS and about 4s on Linux, because a bound unlistening loopback port is dropped on one and refused on the other (#2233). Sharding on numbers like those would have split the suite along the wrong seam.

This prints the real ones on every run, for the price of 25 lines of output. It is the cheapest thing that unblocks the sharding work in #2230.

## The contract assertion had to move, and it is worth saying why

`test_ci_keeps_the_required_python_status_and_calls_fix_pin_after_pytest` pinned this step by **exact string equality**:

```python
lambda step: _string(step, "run").strip() == "uv run pytest -q"
```

which made a reporting flag read as a contract change. What the assertion is for is that the suite runs **unfiltered, before the gate**, and `--durations` does not bear on that. It now matches the prefix and asserts the real property: anything after `uv run pytest -q` must be a `--durations` flag.

That is a weaker matcher, so it was checked against the thing it exists to catch rather than assumed.

## Related issue

Ref #2230

## Fix pin verification

Fix pin: n/a - this adds a reporting flag and relaxes one assertion, and closes no issue labeled `bug`

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | Adds an output flag to one CI step and relaxes one workflow assertion. No product code, chart, image, or runtime path is touched, and no test is added, removed, or filtered. | | |
| local | n/a | Same | | |
| local-release | n/a | Same | | |
| cluster | n/a | Same | | |
| live provider | n/a | Same | | |
| external integration | n/a | Same | | |

Run at commit `14f336f7`:

```
uv run pytest tools/ release/tests -q
  496 passed in 26.52s
uv run pytest tools/fix-pin-ci/tests -q
  72 passed in 9.42s
```

**Positive proof.** The 72 fix pin assertions pass with the new command in place, so the ordering, the argv, the pull-request-only conditions and the three forbidden shortcuts are all still enforced.

**Falsifiable negative, aimed at the relaxation itself.** A prefix match could have let a filtered suite through, which is exactly what the original equality was guarding. Each of these was substituted into the step and re-run against the relaxed matcher:

| substituted command | result |
| --- | --- |
| `uv run pytest -q -k "not slow"` | **1 failed** |
| `uv run pytest -q --ignore=apps/worker/tests` | **1 failed** |
| `uv run pytest -q -x` | **1 failed** |
| `uv run pytest -q --durations=25` | 1 passed |

So the matcher still rejects filtering, early exit and path exclusion, and accepts only reporting flags.

**The output itself** is visible in this pull request's own `Python (ruff + mypy + pytest)` job, which is the first CI-side profile of this suite.

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.
- [x] Or: this change is not behavior-bearing, so no tier applies, and the summary says why.

## Note on the base

This is stacked on `task/ci-critical-path-2` (#2228), which touches the same two files. It will show that PR's commit until #2228 merges, after which this diff is the top commit alone.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed. The reason for the flag is in the workflow comment beside it.
- [x] An ADR is added under `docs/adr/` if this is an architectural decision. Not one: an output flag.
