### PR TITLE
ADR 0141: admission pins Jobs a connector token may create

### DIFF
--- a/docs/adr/0141-admission-pins-jobs-a-connector-token-may-create.md
+++ b/docs/adr/0141-admission-pins-jobs-a-connector-token-may-create.md
@@ -1,0 +1,188 @@
+# 141. Admission pins the Jobs a connector token may create
+
+Date: 2026-09-03
+
+Status: Draft
+
+Implements [#2175](https://github.com/curie-eng/curie/issues/2175). Closes the
+escalation [PR #2163](https://github.com/curie-eng/curie/pull/2163) disclosed:
+a leaked `sre-bot-upgrader` token can select the `curie-platform-upgrader`
+ServiceAccount. [#2122](https://github.com/curie-eng/curie/pull/2122)'s claim
+that the platform-upgrade credential is isolated to a short-lived Job rests on
+this hole being closed.
+
+This Draft does not authorize implementation
+([ADR-0085](0085-acceptance-not-implementation-authorizes-an-adr.md), as
+amended by [ADR-0102](0102-accepted-alongside-implementation-with-explicit-approval.md)).
+The YAML under `examples/sre-bot/manifests/upgrade-job-admission.yaml` is a
+sketch of the realizing path, not an applied control.
+
+## Context
+
+`upgrade_platform` is a zero-argument connector tool that creates a Job from an
+operator-written, suspended CronJob. The Job runs as `curie-platform-upgrader`,
+whose Role is namespace-admin in all but name: it must, because `helm upgrade`
+rewrites the release's Secrets, workloads, and RBAC. The connector identity
+(`sre-bot-upgrader`) is deliberately weaker. It may `get` two named CronJobs
+and `create`/`list` Jobs. It does not hold the Helm credential. The sandbox
+never sees either kubeconfig.
+
+That isolation is real on the connector surface and false at the Kubernetes
+API. `create` on `jobs` cannot take `resourceNames`: a create has no name yet.
+RBAC also does not restrict `spec.template.spec.serviceAccountName`. A holder
+of the connector's long-lived token can POST an arbitrary Job whose pod runs
+as `curie-platform-upgrader` with an arbitrary image and command. The
+connector cannot construct that body; a token holder bypasses the connector.
+
+PR #2163 documented the path and listed three deployment-side options:
+constrain ServiceAccount choice with admission, separate the identities by
+namespace, or stop using a long-lived connector token. None of those is
+installed. `curie example sre-bot install --platform-upgrade` still applies
+both Roles together.
+
+A fourth option, "do not install the upgrade connector", remains the
+fail-closed default (`PLATFORM_UPGRADE_CRONJOB` empty, CronJob and identity
+absent). It is not a mitigation of an install that has already chosen to
+enable the path.
+
+## Attack path
+
+1. An operator installs `manifests/upgrade-role.yaml` beside
+   `manifests/platform-upgrade-role.yaml` in the release namespace (the
+   `--platform-upgrade` installer path).
+2. The self-upgrade connector pod holds a static kubeconfig for
+   `sre-bot-upgrader` (`sre-bot-upgrader-token`). That token does not expire
+   with the pod.
+3. The token leaks: file mount, process dump, a future tool that reads the
+   kubeconfig, backup of the Secret, or any other path that copies a bearer
+   token out of the connector container.
+4. The holder POSTs a Job in the release namespace with
+   `spec.template.spec.serviceAccountName: curie-platform-upgrader` and a
+   container image and command they chose.
+5. The API server authorizes the create against the connector Role. Nothing
+   in RBAC asks which ServiceAccount the Job selected.
+6. The Job's pod receives a projected `curie-platform-upgrader` token and
+   inherits that account's namespace-wide powers, including `get` on every
+   Secret in the release namespace (the platform API key and the model
+   credential among them) and rewrite of every workload the release owns.
+
+The same Job-create grant can also mount arbitrary Secrets via `secretKeyRef`
+on a pod that uses the default ServiceAccount. That is the older, already
+documented blast radius of namespace-wide Job create. Selecting
+`curie-platform-upgrader` is worse: it adds Helm-level rewrite, not only
+secret theft.
+
+## Decision
+
+**The ceiling Kubernetes RBAC cannot express is enforced by admission.** A
+request authenticated as the upgrade-connector ServiceAccount may create a
+Job only when that Job is a verbatim instantiation of a CronJob the same
+identity is already allowed to `get`. "Verbatim" means the security-critical
+fields of the pod spec -- ServiceAccount, containers (name, image, command,
+args, env, volumeMounts), volumes, host namespaces, and initContainers --
+equal the live CronJob's `jobTemplate`. The live CronJob is the source of
+truth, fetched as the admission policy's `params`; the policy does not
+duplicate those fields.
+
+**ServiceAccount-choice-only is not this control.** An allowlist that
+includes `curie-platform-upgrader` still lets the leaked token run an
+arbitrary image as that account. An allowlist that excludes it breaks the
+legitimate `upgrade_platform` path, whose template *does* select that
+account. The pin is the whole template, not the name of the account.
+
+**Installing both identities without this admission (or an equivalent
+admission control that enforces the same field pin) is forbidden.** The
+fail-closed alternative is to leave `PLATFORM_UPGRADE_CRONJOB` empty and not
+apply `platform-upgrade-role.yaml`. Kubernetes 1.30 is the floor for the
+in-tree `ValidatingAdmissionPolicy` sketch; on a cluster that cannot admit
+that API, the equivalent is some other admission plugin that enforces the
+same comparison, not a skip.
+
+**The realizing sketch is
+`examples/sre-bot/manifests/upgrade-job-admission.yaml`.** It is not wired
+into `curie example sre-bot install` and must not be applied from this Draft.
+Once this ADR is Accepted, the installer path that applies both Roles must
+apply this policy in the same step, or refuse.
+
+## Consequences
+
+- [#2122](https://github.com/curie-eng/curie/pull/2122)'s isolation claim
+  becomes true at the API, not only at the connector: a leaked connector
+  token can still create Jobs, but only Jobs that already exist as operator
+  templates.
+- Editing a CronJob template (image tag, env, command) updates what admission
+  will accept, because the policy reads the live object. Drift between a
+  hard-coded allowlist and the CronJob cannot reopen the hole or block a
+  legitimate start.
+- The connector's Python "copy the template verbatim" path stays defense in
+  depth for the MCP surface. It is no longer the only ceiling.
+- Operators on Kubernetes < 1.30, or with `ValidatingAdmissionPolicy`
+  disabled, cannot enable `--platform-upgrade` until they provide an
+  equivalent control. That is a documented incompatibility, not a silent
+  fail-open.
+- A future "button" connector that creates Jobs in a namespace that also
+  holds a more privileged ServiceAccount is the same decision: admit by
+  template pin, or do not give that connector Job create.
+
+## Alternatives considered
+
+1. **Admission that only constrains `serviceAccountName`.** Rejected as a
+   false mitigation. Allowing `curie-platform-upgrader` preserves the
+   escalation (arbitrary command as that account). Denying it breaks the
+   legitimate Job. PR #2163 named this option; it is not sufficient.
+
+2. **Separate namespaces.** Rejected as the primary control. A Job can only
+   use a ServiceAccount in its own namespace, so the legitimate upgrade Job
+   must be created in the release namespace where `curie-platform-upgrader`
+   lives. Moving Job create out of that namespace requires a new trigger
+   (a controller, a CR, or a cross-namespace impersonation) and is a
+   different architecture. It remains available as a later, larger change
+   if admission proves too brittle.
+
+3. **No long-lived connector token** (projected, bound ServiceAccount
+   tokens; drop the static kubeconfig Secret). Rejected as the primary
+   control. A projected token is still valid for the life of the connector
+   Deployment. It bounds persistence after the pod is deleted; it does not
+   stop the escalation while the connector is running. Worth doing later as
+   defense in depth. Out of scope here, and this Draft does not change
+   credential handling.
+
+4. **A Job-factory controller** that holds Job create, while the connector
+   only patches a namespaced trigger the controller watches. Correct by
+   construction, and closer to [ADR-0007](0007-adopt-not-build-boundaries.md)'s
+   "do not build" line being crossed than in-tree admission is. Rejected for
+   this decision: we do not add a controller to express a constraint
+   `ValidatingAdmissionPolicy` already can. Revisit if the template-pin
+   policy cannot be made correct under API defaulting.
+
+5. **Grant the connector `update` on the named CronJobs** and unsuspend or
+   rewrite the schedule instead of creating a Job. Rejected: `update` on the
+   CronJob includes rewriting `jobTemplate`, which is a wider grant than Job
+   create.
+
+6. **Leave the hole documented and unmitigated.** Rejected. #2122's
+   credential-isolation claim is load-bearing for enabling platform upgrade
+   at all. A documented hole is not isolation.
+
+## What this deliberately does not cover
+
+- **The platform-upgrader identity while a legitimate Job runs.** A human
+  who approved `upgrade_platform` still starts a ninety-second
+  namespace-admin Job. Admission does not shrink that Role. Recovery from a
+  migrating upgrade remains restore-from-backup, not `helm rollback`.
+- **Prompt injection against the zero-argument MCP tool.** The connector
+  still copies the CronJob verbatim; approval still gates who may press the
+  button. This ADR is about a leaked token bypassing that surface.
+- **Other Job- or Pod-creating identities in the release namespace**
+  (cluster-admin, Helm itself, a mis-scoped general Kubernetes connector).
+  The policy matches `system:serviceaccount:<ns>:sre-bot-upgrader` only.
+- **Clusters that cannot run the in-tree policy.** They do not get a weaker
+  substitute that fail-opens. They keep the path uninstalled.
+- **The static kubeconfigs of the other sre-bot connectors**, and rotating
+  or projecting `sre-bot-upgrader-token`. Credential handling does not
+  change in this Draft.
+- **RBAC on `jobs/create`.** There is still no `resourceNames` for a create.
+  This ADR does not pretend otherwise.
+- **Applying the sketch to any cluster, and wiring it into the example
+  installer.** Those are implementation, and implementation waits on
+  acceptance.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -169,4 +169,5 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0137 | [Coding tools are built in and an initial repository URL selects the workspace](0137-coding-tools-are-built-in-and-an-initial-repository-url-selects-the-workspace.md) | Draft |
 | 0138 | [Provider-side web search is a default-on bundle capability](0138-provider-side-web-search-is-a-default-on-bundle-capability.md) | Proposed |
 | 0139 | [Bundle owners classify every vanilla MCP tool](0139-bundle-owners-classify-every-vanilla-mcp-tool.md) | Draft |
+| 0141 | [Admission pins the Jobs a connector token may create](0141-admission-pins-jobs-a-connector-token-may-create.md) | Draft |
 <!-- END GENERATED: adr-index -->

--- a/examples/sre-bot/README.md
+++ b/examples/sre-bot/README.md
@@ -66,6 +66,10 @@ The `self-upgrade` connector continues to publish `upgrade_self()` and
 approval gates. It starts pinned Job templates; it is not part of the general
 Kubernetes connector, and its kubeconfig is never shared with it.
 
+A leaked connector token can still select the platform-upgrader ServiceAccount
+on Job create (PR #2163). Draft ADR-0141 proposes the admission pin; the
+installer does not apply it.
+
 ## Verification
 
 Use the real pinned image and a disposable cluster. A complete pass proves:

--- a/examples/sre-bot/docs/PERMISSION-MAP.md
+++ b/examples/sre-bot/docs/PERMISSION-MAP.md
@@ -94,8 +94,17 @@ Pod uses, so that Job inherits the platform upgrader's namespace-wide powers.
 
 The connector cannot construct that request: its zero-argument tool posts an
 operator-written CronJob template verbatim. A token holder can bypass the
-connector. Mitigate with admission policy constraining ServiceAccount choice,
-separate namespaces, or no long-lived connector token. If none is acceptable,
+connector. The hole is open. Draft
+[ADR-0141](../../../docs/adr/0141-admission-pins-jobs-a-connector-token-may-create.md)
+proposes in-tree admission that pins a Job from this identity to the live
+CronJob template (ServiceAccount, image, command, env, and volumes together).
+Constraining ServiceAccount choice alone is not enough: allowing
+`curie-platform-upgrader` preserves the escalation, and denying it breaks the
+legitimate Job.
+
+`manifests/upgrade-job-admission.yaml` is that sketch. It is not applied by
+`curie example sre-bot install --platform-upgrade`, and applying it is not
+authorized while the ADR is Draft. If the proposed control is not acceptable,
 do not install the upgrade connector.
 
 ## Retention and evidence

--- a/examples/sre-bot/docs/STAGING-DEPLOY.md
+++ b/examples/sre-bot/docs/STAGING-DEPLOY.md
@@ -65,8 +65,11 @@ After the ordinary deploy, the installer:
 Read both Role manifests before accepting this flag. Kubernetes lets a holder
 of the connector token create a Job selecting the wider platform-upgrader
 ServiceAccount; RBAC does not restrict `spec.serviceAccountName` on Job create.
-The connector cannot form that request, but a leaked token can bypass it. The
-permission map names mitigation choices and the residual risk.
+The connector cannot form that request, but a leaked token can bypass it.
+Draft ADR-0141 proposes admission that pins those Jobs to the live CronJob
+templates. The installer does not apply `manifests/upgrade-job-admission.yaml`;
+the residual risk is unchanged until that ADR is Accepted and the policy is
+installed with both identities.
 
 The same connector publishes the separate zero-argument `upgrade_self` tool,
 which targets `self-upgrade/cronjob.yaml`. The installer does not apply `self-upgrade/cronjob.yaml`;

--- a/examples/sre-bot/manifests/upgrade-job-admission.yaml
+++ b/examples/sre-bot/manifests/upgrade-job-admission.yaml
@@ -1,0 +1,194 @@
+# SKETCH of the control Draft ADR-0141 proposes.
+#
+# Do not kubectl apply this file. The ADR is Draft and does not authorize
+# implementation. `curie example sre-bot install --platform-upgrade` does not
+# apply it. Applying it from this branch would be implementing a Draft.
+#
+# When ADR-0141 is Accepted, this policy is the realizing path: a request
+# authenticated as sre-bot-upgrader may create a Job only when that Job is a
+# verbatim instantiation of a CronJob the same identity may already get.
+# ServiceAccount-choice-only is not sufficient (see the ADR).
+#
+# Requires Kubernetes 1.30+ with ValidatingAdmissionPolicy enabled. CHANGE ME
+# the namespace in the username and in each paramRef to the namespace the
+# Curie release, the two CronJobs, and sre-bot-upgrader actually live in.
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: curie-upgrade-job-template-pin
+spec:
+  failurePolicy: Fail
+  paramKind:
+    apiVersion: batch/v1
+    kind: CronJob
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ["batch"]
+        apiVersions: ["v1"]
+        operations: ["CREATE"]
+        resources: ["jobs"]
+  matchConditions:
+    - name: from-connector-upgrader
+      expression: >-
+        request.userInfo.username == "system:serviceaccount:curie:sre-bot-upgrader"
+  variables:
+    - name: pod
+      expression: object.spec.template.spec
+    - name: template
+      expression: params.spec.jobTemplate.spec.template.spec
+    - name: podSA
+      expression: >-
+        (has(variables.pod.serviceAccountName) &&
+         variables.pod.serviceAccountName != "")
+          ? variables.pod.serviceAccountName : "default"
+    - name: templateSA
+      expression: >-
+        (has(variables.template.serviceAccountName) &&
+         variables.template.serviceAccountName != "")
+          ? variables.template.serviceAccountName : "default"
+  validations:
+    - expression: >-
+        has(object.metadata.labels) &&
+        object.metadata.labels["curie.dev/self-upgrade-of"] == params.metadata.name
+      message: >-
+        Job must be labeled curie.dev/self-upgrade-of=<CronJob name> for the
+        CronJob this binding pins.
+    - expression: variables.podSA == variables.templateSA
+      message: >-
+        Job pod ServiceAccount must equal the CronJob template's ServiceAccount
+        (missing or empty means default).
+    - expression: >-
+        size(variables.pod.containers) == size(variables.template.containers) &&
+        variables.pod.containers.all(c,
+          variables.template.containers.exists(t,
+            t.name == c.name &&
+            t.image == c.image &&
+            t.command == c.command &&
+            ((!has(c.args) && !has(t.args)) || c.args == t.args) &&
+            ((!has(c.env) && !has(t.env)) || c.env == t.env) &&
+            ((!has(c.envFrom) && !has(t.envFrom)) || c.envFrom == t.envFrom) &&
+            ((!has(c.volumeMounts) && !has(t.volumeMounts)) || c.volumeMounts == t.volumeMounts)
+          )
+        )
+      message: >-
+        Job containers (name, image, command, args, env, envFrom, volumeMounts)
+        must equal the CronJob template.
+    - expression: >-
+        (!has(variables.pod.initContainers) || size(variables.pod.initContainers) == 0) &&
+        (!has(variables.template.initContainers) || size(variables.template.initContainers) == 0)
+      message: Job may not add initContainers the CronJob template does not have.
+    - expression: >-
+        (!has(variables.pod.volumes) && !has(variables.template.volumes)) ||
+        (
+          has(variables.pod.volumes) && has(variables.template.volumes) &&
+          size(variables.pod.volumes) == size(variables.template.volumes) &&
+          variables.pod.volumes.all(v,
+            !has(v.hostPath) &&
+            !has(v.secret) &&
+            !has(v.persistentVolumeClaim) &&
+            !has(v.nfs) &&
+            !has(v.iscsi) &&
+            !has(v.flexVolume) &&
+            !has(v.csi) &&
+            variables.template.volumes.exists(t,
+              t.name == v.name &&
+              ((!has(v.configMap) && !has(t.configMap)) ||
+                v.configMap.name == t.configMap.name) &&
+              has(v.emptyDir) == has(t.emptyDir)
+            )
+          )
+        )
+      message: >-
+        Job volumes must equal the CronJob template; hostPath, Secret, PVC,
+        NFS, iSCSI, flexVolume, and CSI sources are refused.
+    - expression: >-
+        (has(variables.pod.hostNetwork) && variables.pod.hostNetwork) ==
+        (has(variables.template.hostNetwork) && variables.template.hostNetwork) &&
+        (has(variables.pod.hostPID) && variables.pod.hostPID) ==
+        (has(variables.template.hostPID) && variables.template.hostPID) &&
+        (has(variables.pod.hostIPC) && variables.pod.hostIPC) ==
+        (has(variables.template.hostIPC) && variables.template.hostIPC)
+      message: Job may not enable hostNetwork, hostPID, or hostIPC.
+    - expression: >-
+        variables.pod.containers.all(c,
+          !(has(c.securityContext) &&
+            has(c.securityContext.privileged) &&
+            c.securityContext.privileged) &&
+          !(has(c.securityContext) &&
+            has(c.securityContext.allowPrivilegeEscalation) &&
+            c.securityContext.allowPrivilegeEscalation)
+        )
+      message: Job containers may not set privileged or allowPrivilegeEscalation.
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: curie-upgrade-job-template-pin-platform
+spec:
+  policyName: curie-upgrade-job-template-pin
+  validationActions: [Deny]
+  paramRef:
+    name: platform-upgrade
+    # CHANGE ME: the namespace the Curie release runs in.
+    namespace: curie
+    parameterNotFoundAction: Deny
+  matchResources:
+    objectSelector:
+      matchLabels:
+        curie.dev/self-upgrade-of: platform-upgrade
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: curie-upgrade-job-template-pin-self
+spec:
+  policyName: curie-upgrade-job-template-pin
+  validationActions: [Deny]
+  paramRef:
+    name: sre-bot-self-upgrade
+    # CHANGE ME: the namespace the Curie release runs in.
+    namespace: curie
+    parameterNotFoundAction: Deny
+  matchResources:
+    objectSelector:
+      matchLabels:
+        curie.dev/self-upgrade-of: sre-bot-self-upgrade
+---
+# Jobs this identity creates without one of the two labels never hit the
+# template-pin bindings, so they would otherwise be admitted. Deny them.
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: curie-upgrade-job-label-required
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ["batch"]
+        apiVersions: ["v1"]
+        operations: ["CREATE"]
+        resources: ["jobs"]
+  matchConditions:
+    - name: from-connector-upgrader
+      expression: >-
+        request.userInfo.username == "system:serviceaccount:curie:sre-bot-upgrader"
+    - name: unlabeled-or-unknown-cronjob
+      expression: >-
+        !has(object.metadata.labels) ||
+        !("curie.dev/self-upgrade-of" in object.metadata.labels) ||
+        !(object.metadata.labels["curie.dev/self-upgrade-of"] in
+          ["platform-upgrade", "sre-bot-self-upgrade"])
+  validations:
+    - expression: "false"
+      message: >-
+        sre-bot-upgrader may create a Job only when it is labeled as
+        instantiating platform-upgrade or sre-bot-self-upgrade.
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: curie-upgrade-job-label-required
+spec:
+  policyName: curie-upgrade-job-label-required
+  validationActions: [Deny]

--- a/examples/sre-bot/manifests/upgrade-role.yaml
+++ b/examples/sre-bot/manifests/upgrade-role.yaml
@@ -24,9 +24,11 @@
 # token can therefore create a Job that runs as `curie-platform-upgrader`,
 # inheriting that account's namespace-wide platform-upgrade permissions. The
 # connector cannot construct that Job, but a party holding its leaked token can.
-# Mitigations include an admission policy that constrains service-account choice
-# for this requesting identity, separating the wider identity into another
-# namespace, or avoiding a long-lived connector token.
+# Draft ADR-0141 proposes admission that pins the whole Job to the live CronJob
+# template; ServiceAccount-choice-only is not enough. The sketch lives in
+# `upgrade-job-admission.yaml`. Do not kubectl apply it while the ADR is Draft;
+# the installer does not apply it either. If that control is not acceptable,
+# do not install this connector next to the platform-upgrader identity.
 #
 # The connector surface is one tool that takes no arguments
 # and posts the named CronJob's `jobTemplate.spec` verbatim. There is no field a

--- a/examples/tests/test_upgrade_job_admission.py
+++ b/examples/tests/test_upgrade_job_admission.py
@@ -1,0 +1,202 @@
+"""The #2163 escalation stays disclosed until ADR-0141 is Accepted and applied.
+
+The failure this exists to stop is a sketch that claims to close the hole
+while (a) only allowlisting the privileged ServiceAccount, which preserves
+the escalation, (b) getting applied by the example installer from a Draft
+ADR, or (c) letting the permission map say the path is already mitigated.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+REPO = Path(__file__).resolve().parents[2]
+BUNDLE = REPO / "examples" / "sre-bot"
+ADMISSION = BUNDLE / "manifests" / "upgrade-job-admission.yaml"
+UPGRADE_ROLE = BUNDLE / "manifests" / "upgrade-role.yaml"
+PERMISSION_MAP = BUNDLE / "docs" / "PERMISSION-MAP.md"
+ADR = REPO / "docs" / "adr" / "0141-admission-pins-jobs-a-connector-token-may-create.md"
+EXAMPLES_RS = REPO / "cli" / "src" / "examples.rs"
+PLATFORM_CRONJOB = BUNDLE / "platform-upgrade" / "cronjob.yaml"
+SELF_CRONJOB = BUNDLE / "self-upgrade" / "cronjob.yaml"
+
+
+def _docs(path: Path) -> list[object]:
+    loaded = list(yaml.safe_load_all(path.read_text(encoding="utf-8")))
+    return [doc for doc in loaded if doc is not None]
+
+
+def _kinds(path: Path, kind: str) -> list[dict]:
+    return [doc for doc in _docs(path) if isinstance(doc, dict) and doc.get("kind") == kind]
+
+
+def _cronjob(path: Path) -> dict:
+    docs = _kinds(path, "CronJob")
+    assert len(docs) == 1, f"{path} must declare exactly one CronJob"
+    return docs[0]
+
+
+def _cel(policy: dict) -> str:
+    spec = policy.get("spec") or {}
+    chunks: list[str] = []
+    for condition in spec.get("matchConditions") or []:
+        chunks.append(str(condition.get("expression") or ""))
+    for variable in spec.get("variables") or []:
+        chunks.append(str(variable.get("expression") or ""))
+    for validation in spec.get("validations") or []:
+        chunks.append(str(validation.get("expression") or ""))
+        chunks.append(str(validation.get("message") or ""))
+    return "\n".join(chunks)
+
+
+def test_draft_adr_0141_names_the_attack_the_control_and_the_exclusions() -> None:
+    text = ADR.read_text(encoding="utf-8")
+    assert "\nStatus: Draft\n" in text, (
+        "ADR-0141 must stay Draft; acceptance is what would authorize applying "
+        "the sketch"
+    )
+    assert "does not authorize implementation" in text
+    for required in (
+        "sre-bot-upgrader",
+        "curie-platform-upgrader",
+        "spec.template.spec.serviceAccountName",
+        "ValidatingAdmissionPolicy",
+        "verbatim instantiation",
+        "ServiceAccount-choice-only is not this control",
+        "What this deliberately does not cover",
+        "upgrade-job-admission.yaml",
+        "#2163",
+        "#2175",
+        "#2122",
+    ):
+        assert required in text, f"ADR-0141 must name {required!r}"
+
+
+def test_admission_sketch_pins_live_cronjob_params_not_an_sa_allowlist() -> None:
+    policies = _kinds(ADMISSION, "ValidatingAdmissionPolicy")
+    names = {doc["metadata"]["name"] for doc in policies}
+    assert names == {
+        "curie-upgrade-job-template-pin",
+        "curie-upgrade-job-label-required",
+    }
+    pin = next(
+        doc
+        for doc in policies
+        if doc["metadata"]["name"] == "curie-upgrade-job-template-pin"
+    )
+    param = (pin.get("spec") or {}).get("paramKind") or {}
+    assert param.get("kind") == "CronJob", (
+        "the pin must fetch the live CronJob as params; an inlined SA "
+        "allowlist is the false mitigation ADR-0141 rejects"
+    )
+    cel = _cel(pin)
+    assert "params.spec.jobTemplate" in cel
+    assert "variables.podSA == variables.templateSA" in cel
+    assert "t.image == c.image" in cel
+    assert "t.command == c.command" in cel
+    assert "c.env == t.env" in cel
+    assert "!has(v.hostPath)" in cel
+    assert "system:serviceaccount:curie:sre-bot-upgrader" in cel
+    # An allowlist that names the privileged SA would preserve the escalation.
+    assert "curie-platform-upgrader" not in cel
+
+
+def test_admission_sketch_denies_jobs_that_are_not_labeled_as_a_named_cronjob() -> None:
+    deny = next(
+        doc
+        for doc in _kinds(ADMISSION, "ValidatingAdmissionPolicy")
+        if doc["metadata"]["name"] == "curie-upgrade-job-label-required"
+    )
+    cel = _cel(deny)
+    platform = _cronjob(PLATFORM_CRONJOB)["metadata"]["name"]
+    self_upgrade = _cronjob(SELF_CRONJOB)["metadata"]["name"]
+    assert platform in cel
+    assert self_upgrade in cel
+    assert "expression: false" in yaml.dump(deny, sort_keys=False) or any(
+        (v.get("expression") or "").strip().strip('"') == "false"
+        for v in (deny.get("spec") or {}).get("validations") or []
+    )
+
+
+def test_admission_bindings_point_at_the_shipped_cronjobs_and_deny() -> None:
+    bindings = _kinds(ADMISSION, "ValidatingAdmissionPolicyBinding")
+    by_name = {doc["metadata"]["name"]: doc for doc in bindings}
+    assert "curie-upgrade-job-template-pin-platform" in by_name
+    assert "curie-upgrade-job-template-pin-self" in by_name
+    assert "curie-upgrade-job-label-required" in by_name
+    platform = by_name["curie-upgrade-job-template-pin-platform"]
+    self_upgrade = by_name["curie-upgrade-job-template-pin-self"]
+    assert platform["spec"]["paramRef"]["name"] == _cronjob(PLATFORM_CRONJOB)["metadata"]["name"]
+    assert self_upgrade["spec"]["paramRef"]["name"] == _cronjob(SELF_CRONJOB)["metadata"]["name"]
+    for binding in (platform, self_upgrade):
+        assert binding["spec"]["validationActions"] == ["Deny"]
+        assert binding["spec"]["paramRef"]["parameterNotFoundAction"] == "Deny"
+        assert binding["spec"]["policyName"] == "curie-upgrade-job-template-pin"
+
+
+def test_cronjob_templates_still_carry_the_fields_the_attack_abuses() -> None:
+    """Positive: the legitimate platform Job does select the privileged SA.
+
+    Negative: the admission sketch does not hard-code that SA as allowed, so
+    selecting it with a different command is not a policy-shaped success.
+    """
+
+    platform = _cronjob(PLATFORM_CRONJOB)
+    pod = platform["spec"]["jobTemplate"]["spec"]["template"]["spec"]
+    assert pod["serviceAccountName"] == "curie-platform-upgrader"
+    assert pod["containers"][0]["command"] == ["sh", "/opt/platform-upgrade/upgrade.sh"]
+    self_upgrade = _cronjob(SELF_CRONJOB)
+    self_pod = self_upgrade["spec"]["jobTemplate"]["spec"]["template"]["spec"]
+    assert "serviceAccountName" not in self_pod
+    assert self_pod["containers"][0]["command"] == [
+        "python3",
+        "/opt/self-upgrade/redeploy.py",
+    ]
+    pin = next(
+        doc
+        for doc in _kinds(ADMISSION, "ValidatingAdmissionPolicy")
+        if doc["metadata"]["name"] == "curie-upgrade-job-template-pin"
+    )
+    assert "curie-platform-upgrader" not in _cel(pin)
+
+
+def test_installer_does_not_apply_the_draft_admission_sketch() -> None:
+    source = EXAMPLES_RS.read_text(encoding="utf-8")
+    assert "upgrade-job-admission.yaml" not in source, (
+        "wiring the sketch into cli/src/examples.rs would apply a Draft "
+        "control the next time someone runs --platform-upgrade"
+    )
+    include = (
+        'include_bytes!("../../examples/sre-bot/manifests/'
+        'upgrade-job-admission.yaml")'
+    )
+    assert include not in source
+
+
+def test_permission_map_still_discloses_the_hole_and_names_the_draft() -> None:
+    text = PERMISSION_MAP.read_text(encoding="utf-8")
+    assert "leaked `sre-bot-upgrader` token" in text
+    assert "curie-platform-upgrader" in text
+    assert "ADR-0141" in text
+    assert "Draft" in text
+    assert "does not apply" in text or "not applied" in text.lower() or "not authorize" in text
+    for closed in (
+        "the escalation is closed",
+        "this hole is closed",
+        "admission now prevents",
+        "RBAC now restricts spec.serviceAccountName",
+    ):
+        assert closed not in text, (
+            f"PERMISSION-MAP.md must not claim {closed!r} while the control "
+            "is a Draft sketch the installer does not apply"
+        )
+
+
+def test_upgrade_role_points_at_the_draft_without_claiming_enforcement() -> None:
+    text = UPGRADE_ROLE.read_text(encoding="utf-8")
+    assert "curie-platform-upgrader" in text
+    assert "ADR-0141" in text
+    assert "upgrade-job-admission.yaml" in text
+    assert "Do not kubectl apply" in text or "does not authorize" in text


### PR DESCRIPTION
Publishes Draft ADR 0141 and an admission policy sketch for the escalation disclosed in #2163. The proposed control pins Jobs created by the connector identity to the live CronJob template. This PR does not accept the ADR, install admission, or close the escalation path.

The sketch remains incomplete, including container lifecycle hook coverage. Effective enforcement still needs a complete field review and live negative testing before acceptance and installation. Existing tests preserve the requirement that the installer does not apply the sketch.

Rebased onto next. Documentation validation, all eight focused sketch tests, Ruff, and whitespace checks pass.

Closes #2175.