### PR TITLE
Make Rust test stream names collision-resistant

### DIFF
--- a/cli/tests/support/mod.rs
+++ b/cli/tests/support/mod.rs
@@ -46,14 +46,14 @@ pub async fn valkey_or_skip(test: &str) -> Option<redis::aio::MultiplexedConnect
 }
 
 /// Builds a unique test-scoped stream name under the given prefix (e.g.
-/// `"curie:test:chat:"`), so concurrent test runs never collide and each
-/// suite keeps its own distinct stream namespace.
+/// `"curie:test:chat:"`), so concurrent tests and processes never collide
+/// and each suite keeps its own distinct stream namespace.
+///
+/// Names include a UUID v4, not `SystemTime` nanos alone. Parallel tests on
+/// the hosted runner and on a separately owned Valkey collided when the
+/// suffix was timestamp-only (#2086).
 pub fn unique_stream(prefix: &str) -> String {
-    let nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    format!("{prefix}{nanos}")
+    format!("{prefix}{}", uuid::Uuid::new_v4())
 }
 
 #[derive(Debug, Clone)]

--- a/cli/tests/unique_stream.rs
+++ b/cli/tests/unique_stream.rs
@@ -1,0 +1,126 @@
+//! Isolation of Valkey stream names minted by CLI integration tests (#2086).
+//!
+//! `unique_stream` must stay collision-resistant across parallel test threads
+//! and across separate processes. Timestamp-only names failed that on hosted
+//! runners and on a separately owned Valkey.
+
+mod support;
+use support::unique_stream;
+
+use std::collections::HashSet;
+use std::process::{Command, Stdio};
+use std::sync::{Arc, Barrier};
+use std::thread;
+
+const PREFIX: &str = "curie:test:ns:";
+const CHILD_ENV: &str = "CURIE_UNIQUE_STREAM_CHILD_COUNT";
+
+fn suffix(name: &str) -> &str {
+    name.strip_prefix(PREFIX)
+        .expect("unique_stream must keep the caller prefix")
+}
+
+#[test]
+fn unique_stream_keeps_the_prefix() {
+    let name = unique_stream(PREFIX);
+    assert!(name.starts_with(PREFIX), "{name}");
+    assert!(!suffix(&name).is_empty(), "{name}");
+}
+
+#[test]
+fn unique_stream_suffix_is_not_timestamp_only() {
+    let name = unique_stream(PREFIX);
+    let suffix = suffix(&name);
+    assert!(
+        suffix.chars().any(|c| !c.is_ascii_digit()),
+        "unique_stream must not be prefix plus SystemTime nanos; got {name}"
+    );
+}
+
+#[test]
+fn unique_stream_names_are_unique_across_parallel_threads() {
+    const THREADS: usize = 64;
+    const PER_THREAD: usize = 32;
+    let barrier = Arc::new(Barrier::new(THREADS));
+    let mut joins = Vec::with_capacity(THREADS);
+    for _ in 0..THREADS {
+        let barrier = Arc::clone(&barrier);
+        joins.push(thread::spawn(move || {
+            barrier.wait();
+            (0..PER_THREAD)
+                .map(|_| unique_stream(PREFIX))
+                .collect::<Vec<_>>()
+        }));
+    }
+    let mut all = Vec::with_capacity(THREADS * PER_THREAD);
+    for join in joins {
+        all.extend(join.join().expect("unique_stream thread"));
+    }
+    let unique: HashSet<&String> = all.iter().collect();
+    assert_eq!(
+        unique.len(),
+        all.len(),
+        "parallel unique_stream calls collided"
+    );
+}
+
+#[test]
+fn unique_stream_names_are_unique_across_processes() {
+    if let Ok(count) = std::env::var(CHILD_ENV) {
+        let n: usize = count.parse().expect("child count");
+        for _ in 0..n {
+            println!("{}", unique_stream(PREFIX));
+        }
+        return;
+    }
+
+    const PROCESSES: usize = 4;
+    const PER_PROCESS: usize = 32;
+    let exe = std::env::current_exe().expect("current test binary");
+    let mut children = Vec::with_capacity(PROCESSES);
+    for _ in 0..PROCESSES {
+        children.push(
+            Command::new(&exe)
+                .env(CHILD_ENV, PER_PROCESS.to_string())
+                .args([
+                    "unique_stream_names_are_unique_across_processes",
+                    "--exact",
+                    "--nocapture",
+                ])
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()
+                .expect("spawn unique_stream child"),
+        );
+    }
+
+    let mut all = Vec::with_capacity(PROCESSES * PER_PROCESS);
+    for child in children {
+        let output = child
+            .wait_with_output()
+            .expect("wait for unique_stream child");
+        assert!(
+            output.status.success(),
+            "unique_stream child failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        for line in String::from_utf8_lossy(&output.stdout).lines() {
+            if let Some(rest) = line.strip_prefix(PREFIX) {
+                if !rest.is_empty() {
+                    all.push(format!("{PREFIX}{rest}"));
+                }
+            }
+        }
+    }
+    assert_eq!(
+        all.len(),
+        PROCESSES * PER_PROCESS,
+        "missing child unique_stream names: {all:?}"
+    );
+    let unique: HashSet<&String> = all.iter().collect();
+    assert_eq!(
+        unique.len(),
+        all.len(),
+        "cross-process unique_stream calls collided"
+    );
+}


### PR DESCRIPTION
## Summary

CLI integration tests minted Valkey stream names from `SystemTime` nanos alone. Parallel tests on the hosted runner, and on a separately owned Valkey, collided and shared consumer-group and entry state. `unique_stream` now suffixes a UUID v4 so names stay unique across threads and processes. The suite is not serialized.

## Related issue

Closes #2086

## Fix pin verification

Fix pin: n/a - unique_stream lives only in cli/tests/support; reversing product files cannot unmask a test-helper collision

## End-to-end verification

This change does not alter runtime behavior because unique_stream is a CLI integration-test helper and does not ship in the curie binary, compose services, charts, or any verb output.

Scoped verification:

- `cd cli && cargo fmt --check` - passed
- `cd cli && cargo clippy --all-targets --locked -- -D warnings` - passed
- `cd cli && cargo test --locked --test unique_stream` against timestamp-only unique_stream - failed: `unique_stream_suffix_is_not_timestamp_only` (suffix was digits only) and `unique_stream_names_are_unique_across_parallel_threads` (2041 unique of 2048)
- same tests after the UUID change - 4 passed
- timestamp-only revert of unique_stream - failed again: suffix digits-only and 2036 unique of 2048; UUID helper restored
- `CI_REQUIRE_VALKEY_TESTS=1 TEST_VALKEY_URL=redis://127.0.0.1:33186 cargo test --locked` from cli at d49af8092 against a disposable passwordless Valkey on host port 33186 (container `curie-2086-valkey-1509743`, image `valkey/valkey:8-alpine`) - passed, including `chat_enqueue` (9), `resume_wait` (6), `eval_thread_reset` (1), and `unique_stream` (4)
- Valkey container removed after the run; host port 33186 released

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [ ] Docs updated if behavior changed.
- [ ] An ADR is added under `docs/adr/` if this is an architectural decision.
