### PR TITLE
Surface the deployed bundle version into the sandbox env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -93,6 +93,7 @@ S3_SECRET_KEY=rustfssecret
 # CURIE_APPROVAL_RESUMED_KIND    producers: kernel
 # CURIE_BUDGET                   producers: worker, substrate
 # CURIE_BUNDLE_REF               producers: worker
+# CURIE_BUNDLE_VERSION           producers: worker
 # CURIE_CONNECTOR_AGENT          producers: worker
 # CURIE_CONNECTOR_NAMESPACE      producers: worker
 # CURIE_CONNECTOR_RELEASE        producers: worker

--- a/apps/worker/src/curie_worker/binding.py
+++ b/apps/worker/src/curie_worker/binding.py
@@ -81,9 +81,11 @@ logger = logging.getLogger(__name__)
 # dropped. ``env_key`` raises on an unknown field, so a typo fails at import.
 #
 # CURIE_BUNDLE_REF is the RustFS object key sandbox provisioning fetches into
-# CURIE_PLUGIN_DIR (a runner/chart handoff); the rest are the frozen ACI
-# SessionConfig env.
+# CURIE_PLUGIN_DIR (a runner/chart handoff). CURIE_BUNDLE_VERSION is the
+# agent-readable version_label of that same bundle (#2174). The rest are the
+# frozen ACI SessionConfig env.
 BUNDLE_REF_ENV = BootEnv.env_key("bundle_ref")
+BUNDLE_VERSION_ENV = BootEnv.env_key("bundle_version")
 PLUGIN_DIR_ENV = BootEnv.env_key("plugin_dir")
 BUDGET_ENV = BootEnv.env_key("budget")
 SESSION_ID_ENV = BootEnv.env_key("session_id")
@@ -755,6 +757,9 @@ class BindingResolver:
             memory_ref=memory_ref,
             history_ref=history_ref,
             bundle_ref=resolved.bundle_ref,
+            # Agent-readable identity (#2174): the platform-tracked
+            # version_label, not the RustFS object key. Blank is omitted.
+            bundle_version=resolved.version_label or None,
             # Not a model credential, so the model keys never see it; minted
             # fresh per claim and enforced by the runner on its ACI POST routes.
             runner_token=secrets.token_urlsafe(32),

--- a/apps/worker/src/curie_worker/eval/stream.py
+++ b/apps/worker/src/curie_worker/eval/stream.py
@@ -62,6 +62,7 @@ from redis.asyncio import Redis
 from ..binding import (
     BUDGET_ENV,
     BUNDLE_REF_ENV,
+    BUNDLE_VERSION_ENV,
     PLUGIN_DIR_ENV,
     RUNNER_TOKEN_ENV,
     SESSION_ID_ENV,
@@ -737,6 +738,8 @@ class EvalStreamConsumer(StreamConsumer):
         }
         if item.bundle_ref is not None:
             env[BUNDLE_REF_ENV] = item.bundle_ref
+        if item.sha:
+            env[BUNDLE_VERSION_ENV] = item.sha
         # Deliver the agent's connector secrets (#429) so an authed-MCP bundle
         # authenticates during eval exactly as it does on a bound run -- otherwise
         # its tool calls fail auth and the eval measures the wrong thing. The

--- a/apps/worker/src/curie_worker/sandbox/docker.py
+++ b/apps/worker/src/curie_worker/sandbox/docker.py
@@ -122,7 +122,8 @@ _OAUTH_TOKEN_PREFIX = "sk-ant-oat"
 # value loop must not also emit them: the plugin dir and sandbox id are set
 # explicitly, the bundle ref named a RustFS object the worker already fetched
 # (the runner never fetches), and the credential is forwarded by name (never as
-# a value in the argv).
+# a value in the argv). CURIE_BUNDLE_VERSION is deliberately not in this set:
+# it is the agent-readable version_label and must reach the child env (#2174).
 _WORKER_OWNED_ENV = frozenset({BUNDLE_REF_ENV, PLUGIN_DIR_ENV, "CURIE_SANDBOX_ID", CREDENTIALS_ENV})
 
 

--- a/apps/worker/tests/binding/test_boot_env_golden.py
+++ b/apps/worker/tests/binding/test_boot_env_golden.py
@@ -84,6 +84,7 @@ def test_plain_bound_run_renders_the_frozen_boot_env() -> None:
         "CURIE_SESSION_ID": f"agent-{_AGENT}-thread-{_THREAD}",
         "CURIE_PLUGIN_DIR": "/bundles/current",
         "CURIE_BUNDLE_REF": "bundles/x.zip",
+        "CURIE_BUNDLE_VERSION": "v1",
         "CURIE_MEMORY_REF": _MEMORY_REF,
         "CURIE_HISTORY_REF": _HISTORY_REF,
         "CURIE_STATE_URL": _STATE_URL,
@@ -177,6 +178,7 @@ def test_fully_loaded_run_renders_the_frozen_boot_env() -> None:
         "CURIE_SESSION_ID": f"agent-{_AGENT}-thread-{_THREAD}",
         "CURIE_PLUGIN_DIR": "/bundles/current",
         "CURIE_BUNDLE_REF": "bundles/x.zip",
+        "CURIE_BUNDLE_VERSION": "v1",
         "CURIE_APPROVAL_REQUIRED_TOOLS": "Bash,Write",
         "CURIE_MEMORY_REF": _MEMORY_REF,
         "CURIE_HISTORY_REF": _HISTORY_REF,
@@ -208,11 +210,29 @@ def test_no_api_key_path_mints_no_state_token() -> None:
         "CURIE_SESSION_ID": f"agent-{_AGENT}-thread-{_THREAD}",
         "CURIE_PLUGIN_DIR": "/bundles/current",
         "CURIE_BUNDLE_REF": "bundles/x.zip",
+        "CURIE_BUNDLE_VERSION": "v1",
         "CURIE_MEMORY_REF": _MEMORY_REF,
         "CURIE_HISTORY_REF": _HISTORY_REF,
         "CURIE_STATE_URL": _STATE_URL,
     }
     assert set(minted) == {"CURIE_RUNNER_TOKEN"}
+
+
+def test_boot_env_forwards_version_label_as_bundle_version() -> None:
+    """#2174: the platform-tracked version_label is readable inside the sandbox.
+
+    CURIE_BUNDLE_REF stays the RustFS object key the substrate fetches with;
+    CURIE_BUNDLE_VERSION is the agent-facing identity. A blank label is omitted
+    so an empty string cannot masquerade as a version.
+    """
+
+    env = _boot_env(WorkerConfig(), _resolved(version_label="abc123def456"))
+    assert env["CURIE_BUNDLE_VERSION"] == "abc123def456"
+    assert env["CURIE_BUNDLE_REF"] == "bundles/x.zip"
+
+    omitted = _boot_env(WorkerConfig(), _resolved(version_label=""))
+    assert "CURIE_BUNDLE_VERSION" not in omitted
+    assert omitted["CURIE_BUNDLE_REF"] == "bundles/x.zip"
 
 
 def test_boot_env_omits_agent_id() -> None:

--- a/apps/worker/tests/binding/test_eval_memory_isolation.py
+++ b/apps/worker/tests/binding/test_eval_memory_isolation.py
@@ -55,6 +55,7 @@ def test_eval_isolate_thread_omits_memory_ref() -> None:
     assert "CURIE_HISTORY_REF" in env
     assert "CURIE_HISTORY_TOKEN" in env
     assert env["CURIE_BUNDLE_REF"] == "bundles/x.zip"
+    assert env["CURIE_BUNDLE_VERSION"] == "v1"
     assert str(_AGENT) in env["CURIE_SESSION_ID"]
 
 

--- a/apps/worker/tests/eval/test_stream.py
+++ b/apps/worker/tests/eval/test_stream.py
@@ -1224,6 +1224,29 @@ def test_eval_lane_boot_env_omits_memory_ref() -> None:
     assert "CURIE_HISTORY_REF" not in env
 
 
+def test_eval_boot_env_forwards_sha_as_bundle_version() -> None:
+    """#2174 sibling: the eval lane boots the same agent-readable version key.
+
+    EvalJob carries ``sha`` rather than version_label; that is the version the
+    suite is scoring, so it is what the provisioned sandbox must be able to
+    name. CURIE_BUNDLE_REF stays the object key used to fetch the bundle.
+    """
+
+    consumer = EvalStreamConsumer(
+        redis=None,  # type: ignore[arg-type]
+        config=WorkerConfig(),
+        bundle_store=None,  # type: ignore[arg-type]
+        substrate=None,  # type: ignore[arg-type]
+        reporter=None,  # type: ignore[arg-type]
+        recorder=None,  # type: ignore[arg-type]
+        repo_lookup=None,
+    )
+    item = _item(suite="s", sha="deadbeef", bundle_ref="bundles/x.zip", target_url=None)
+    env = consumer._boot_env(item)
+    assert env["CURIE_BUNDLE_VERSION"] == "deadbeef"
+    assert env[BUNDLE_REF_ENV] == "bundles/x.zip"
+
+
 def test_eval_requested_model_boots_and_tags_that_model() -> None:
     """#526: a work item's ``model`` is booted into the provisioned sandbox
     (CURIE_MODEL wins over the worker default) AND becomes the run's model

--- a/apps/worker/tests/sandbox/test_docker.py
+++ b/apps/worker/tests/sandbox/test_docker.py
@@ -152,7 +152,11 @@ def test_create_claim_fetches_and_unwraps_bundle() -> None:
     client.create_claim(
         "t1",
         pool="pool",
-        env={"CURIE_BUNDLE_REF": "bundles/b.tar.gz", "CURIE_PLUGIN_DIR": "/bundles/current"},
+        env={
+            "CURIE_BUNDLE_REF": "bundles/b.tar.gz",
+            "CURIE_PLUGIN_DIR": "/bundles/current",
+            "CURIE_BUNDLE_VERSION": "abc123def456",
+        },
     )
     assert store.requested == ["bundles/b.tar.gz"]  # the worker fetched the bundle
     mounts = _flag_values(client.calls[0], "-v")
@@ -162,8 +166,12 @@ def test_create_claim_fetches_and_unwraps_bundle() -> None:
     assert mode == "ro"
     # Unwrapped: the manifest sits at the mount root, not under the wrapper dir.
     assert (Path(host_dir) / ".claude-plugin" / "plugin.json").is_file()
+    child_env = _flag_values(client.calls[0], "-e")
     # The RustFS object key itself is not forwarded into the container env.
-    assert all("CURIE_BUNDLE_REF" not in e for e in _flag_values(client.calls[0], "-e"))
+    # Updated deliberately (#2174): keep stripping the object key, and forward
+    # the platform-tracked version_label so a sandboxed agent can name itself.
+    assert all("CURIE_BUNDLE_REF" not in e for e in child_env)
+    assert "CURIE_BUNDLE_VERSION=abc123def456" in child_env
 
 
 def test_create_claim_without_bundle_ref_mounts_nothing() -> None:

--- a/apps/worker/tests/sandbox/test_k8s_claim.py
+++ b/apps/worker/tests/sandbox/test_k8s_claim.py
@@ -107,6 +107,33 @@ def test_bundle_ref_targets_init_containers_by_name() -> None:
         assert named[(container, "CURIE_BUNDLE_REF")] == "bundles/x.tar.gz"
 
 
+def test_bundle_version_reaches_the_runner_not_the_init_containers() -> None:
+    """#2174: the agent-readable version is runner env, not an object-store key.
+
+    Init containers still receive only CURIE_BUNDLE_REF (the fetch key). The
+    version_label is an unnamed main-container entry so the sandboxed agent
+    can read it, matching the docker substrate's forward of the same key.
+    """
+
+    api = _FakeApi()
+    _client(api).create_claim(
+        "claim-1",
+        pool="pool",
+        env={
+            "CURIE_BUNDLE_REF": "bundles/x.tar.gz",
+            "CURIE_BUNDLE_VERSION": "abc123def456",
+            "CURIE_BUDGET": "{}",
+        },
+    )
+    entries = _env_entries(api)
+
+    assert {"name": "CURIE_BUNDLE_VERSION", "value": "abc123def456"} in entries
+    named = {
+        (e["containerName"], e["name"]): e["value"] for e in entries if "containerName" in e
+    }
+    assert all(key[1] != "CURIE_BUNDLE_VERSION" for key in named)
+
+
 def test_no_named_env_without_bundle_ref() -> None:
     api = _FakeApi()
     _client(api).create_claim(

--- a/docs/diagrams/aci.md
+++ b/docs/diagrams/aci.md
@@ -107,7 +107,7 @@ regenerated and committed together it **always goes green**. It pins artifact
 *sync*; it never pinned *compatibility*. Three things carry the contract
 instead:
 
-- **Semver, not a freeze.** `PROTOCOL_VERSION` is `0.4.2`
+- **Semver, not a freeze.** `PROTOCOL_VERSION` is `0.4.3`
   ([`packages/aci-protocol/src/aci_protocol/version.py`](../../packages/aci-protocol/src/aci_protocol/version.py)),
   versioned independently of the Curie release. Under 0.x a consumer accepts
   the same `major.minor`; only a new optional field is compatible (patch), and

--- a/docs/interfaces/aci-producer/implementing-an-aci-server.md
+++ b/docs/interfaces/aci-producer/implementing-an-aci-server.md
@@ -70,7 +70,7 @@ Import everything from `aci_protocol`; do not hand-roll JSON.
   made and once when its result arrives, joined on `call_id` (ADR-0117)
 
 **Version gate (strict producer, tolerant consumer).** Your producer emits its
-**exact build `PROTOCOL_VERSION`** (currently `0.4.2`) on every outbound event and
+**exact build `PROTOCOL_VERSION`** (currently `0.4.3`) on every outbound event and
 constructs strictly -- an unknown field is an error at construction, catching your
 mistakes at the source. A **consumer** decoding the wire is tolerant the other way:
 it accepts any version compatible with its own build (`major.minor` match under

--- a/examples/sre-bot/skills/sre-bot/SKILL.md
+++ b/examples/sre-bot/skills/sre-bot/SKILL.md
@@ -29,7 +29,7 @@ of a deprecated model.
 | | What it is | Where to read it |
 |---|---|---|
 | **Platform version** | The Curie release this install runs | `app.kubernetes.io/version` / `helm.sh/chart` on the platform's own objects (api, dispatcher, worker), via `resources_get` or `resources_list` |
-| **Your bundle version** | The agent bundle *you* are, deployed from its repository | your own agent version, which the platform tracks; the platform's objects do not carry it |
+| **Your bundle version** | The agent bundle *you* are, deployed from its repository | `CURIE_BUNDLE_VERSION` in this sandbox's environment. That is the platform-tracked version_label of the bundle you booted with. The platform's Kubernetes objects do not carry it, and `CURIE_BUNDLE_REF` is an internal fetch key, not a version to report. |
 
 They move independently. A newer platform does not update you, and upgrading
 yourself does not touch the platform.

--- a/packages/aci-protocol/README.md
+++ b/packages/aci-protocol/README.md
@@ -24,9 +24,9 @@ string rather than a `const`. Artifact sync is enforced by the
 schema-compat gate (`tests/test_schema_compat.py`); an unbumped wire change is
 caught by the wire-lock gate (`tests/test_wire_lock.py`).
 
-## Contract surface (v0.4.2)
+## Contract surface (v0.4.3)
 
-`PROTOCOL_VERSION = "0.4.2"` is embedded in the schema and in every outbound
+`PROTOCOL_VERSION = "0.4.3"` is embedded in the schema and in every outbound
 event.
 
 **Session setup** (`SessionConfig`, with `to_env()` / `from_env()`):

--- a/packages/aci-protocol/generated/rust/src/lib.rs
+++ b/packages/aci-protocol/generated/rust/src/lib.rs
@@ -6,7 +6,7 @@
 
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: &str = "0.4.2";
+pub const PROTOCOL_VERSION: &str = "0.4.3";
 
 pub const RUNS_STREAM_DEFAULT: &str = "curie:runs";
 
@@ -151,6 +151,8 @@ pub struct BootEnv {
     #[serde(default)]
     pub bundle_ref: Option<String>,
     #[serde(default)]
+    pub bundle_version: Option<String>,
+    #[serde(default)]
     pub runner_token: Option<String>,
     #[serde(default)]
     pub model: Option<String>,
@@ -211,6 +213,7 @@ pub mod env_keys {
     pub const CURIE_APPROVAL_RESUMED_KIND: &str = "CURIE_APPROVAL_RESUMED_KIND";
     pub const CURIE_BUDGET: &str = "CURIE_BUDGET";
     pub const CURIE_BUNDLE_REF: &str = "CURIE_BUNDLE_REF";
+    pub const CURIE_BUNDLE_VERSION: &str = "CURIE_BUNDLE_VERSION";
     pub const CURIE_CONNECTOR_AGENT: &str = "CURIE_CONNECTOR_AGENT";
     pub const CURIE_CONNECTOR_NAMESPACE: &str = "CURIE_CONNECTOR_NAMESPACE";
     pub const CURIE_CONNECTOR_RELEASE: &str = "CURIE_CONNECTOR_RELEASE";
@@ -482,13 +485,13 @@ mod tests {
 
     #[test]
     fn accepts_compatible_patch() {
-        let raw = r#"{"type":"final","version":"0.4.3","text":"x","status":"done"}"#;
+        let raw = r#"{"type":"final","version":"0.4.4","text":"x","status":"done"}"#;
         assert!(serde_json::from_str::<OutboundEvent>(raw).is_ok());
     }
 
     #[test]
     fn accepts_unknown_fields() {
-        let raw = r#"{"type":"final","version":"0.4.2","text":"x","status":"done","extra":1}"#;
+        let raw = r#"{"type":"final","version":"0.4.3","text":"x","status":"done","extra":1}"#;
         assert!(serde_json::from_str::<OutboundEvent>(raw).is_ok());
     }
 }

--- a/packages/aci-protocol/generated/ts/aci-protocol.ts
+++ b/packages/aci-protocol/generated/ts/aci-protocol.ts
@@ -20,7 +20,7 @@ export type ExpiresInSeconds = number | null;
  * authority-bearing per #544/ADR-0046, so the value domain is a named, exported
  * part of the contract rather than an inline annotation.
  *
- * This interface was referenced by `ACIProtocolV042`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV043`'s JSON-Schema
  * via the `definition` "GateKind".
  */
 export type GateKind = "permission" | "policy";
@@ -39,6 +39,7 @@ export type ApprovalRequiredTools = string[] | null;
 export type ApprovalResumedKind = string | null;
 export type BaseUrl = string | null;
 export type BundleRef = string | null;
+export type BundleVersion = string | null;
 export type ConnectorAgent = string | null;
 export type ConnectorNamespace = string | null;
 export type ConnectorRelease = string | null;
@@ -107,14 +108,14 @@ export type Text1 = string;
 export type Type2 = "final";
 export type Version1 = string;
 /**
- * This interface was referenced by `ACIProtocolV042`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV043`'s JSON-Schema
  * via the `definition` "InboundMessage".
  */
 export type InboundMessage = Event | Interrupt;
 export type Kind1 = "interrupt";
 export type Reason = string;
 /**
- * This interface was referenced by `ACIProtocolV042`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV043`'s JSON-Schema
  * via the `definition` "OutboundEvent".
  */
 export type OutboundEvent = TextDelta | ToolNote | Final | ErrorEvent | SideEffectFlag;
@@ -178,7 +179,7 @@ export type Text4 = string;
  * Wire tokens follow the section 0 spelling; ``classified failure`` in prose
  * becomes the token ``classified-failure`` on the wire.
  *
- * This interface was referenced by `ACIProtocolV042`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV043`'s JSON-Schema
  * via the `definition` "SessionStatus".
  */
 export type SessionStatus1 = "done" | "idle-awaiting-input" | "classified-failure" | "awaiting-approval";
@@ -206,12 +207,12 @@ export type SessionStatus1 = "done" | "idle-awaiting-input" | "classified-failur
  * ENUM VALUE -- breaking under this package's rules, so it is a deliberate,
  * separately-decided bump rather than something this change assumes.
  *
- * This interface was referenced by `ACIProtocolV042`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV043`'s JSON-Schema
  * via the `definition` "TurnSource".
  */
 export type TurnSource1 = "slack" | "webhook" | "cron";
 
-export interface ACIProtocolV042 {
+export interface ACIProtocolV043 {
   [k: string]: unknown;
 }
 /**
@@ -235,7 +236,7 @@ export interface ACIProtocolV042 {
  * nullable because ``slack`` legitimately has no adapter -- its route is the
  * worker's configured Slack origin.
  *
- * This interface was referenced by `ACIProtocolV042`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV043`'s JSON-Schema
  * via the `definition` "ApprovalRequest".
  */
 export interface ApprovalRequest {
@@ -282,7 +283,7 @@ export interface ApprovalRequest {
  * baked template default, the worker's value is per-agent model routing. Do not
  * collapse either producer list to a single value.
  *
- * This interface was referenced by `ACIProtocolV042`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV043`'s JSON-Schema
  * via the `definition` "BootEnv".
  */
 export interface BootEnv {
@@ -293,6 +294,7 @@ export interface BootEnv {
   approval_resumed_kind?: ApprovalResumedKind;
   base_url?: BaseUrl;
   bundle_ref?: BundleRef;
+  bundle_version?: BundleVersion;
   connector_agent?: ConnectorAgent;
   connector_namespace?: ConnectorNamespace;
   connector_release?: ConnectorRelease;
@@ -321,7 +323,7 @@ export interface BootEnv {
  * section 0 describes these as per-tool secrets via K8s Secret refs, so the
  * contract carries the reference, not the secret material itself.
  *
- * This interface was referenced by `ACIProtocolV042`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV043`'s JSON-Schema
  * via the `definition` "SessionConfig".
  */
 export interface SessionConfig {
@@ -340,7 +342,7 @@ export interface SessionConfig {
  * ``task_budget_hint`` is the optional hint passed through to the model so it
  * self paces (section 6b); it is not a hard ceiling.
  *
- * This interface was referenced by `ACIProtocolV042`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV043`'s JSON-Schema
  * via the `definition` "Budget".
  */
 export interface Budget {
@@ -356,7 +358,7 @@ export interface Budget {
  * fields the prototype used (endpoint, headers, protocol); any others pass
  * through as raw env vars untouched and are out of scope for this typed view.
  *
- * This interface was referenced by `ACIProtocolV042`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV043`'s JSON-Schema
  * via the `definition` "OtelConfig".
  */
 export interface OtelConfig {
@@ -368,7 +370,7 @@ export interface OtelConfig {
 /**
  * A classified failure surfaced to the platform.
  *
- * This interface was referenced by `ACIProtocolV042`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV043`'s JSON-Schema
  * via the `definition` "ErrorEvent".
  */
 export interface ErrorEvent {
@@ -385,7 +387,7 @@ export interface ErrorEvent {
  * worker consumes off it (formerly the API's ``EvalJobRequest`` and the
  * worker's ``EvalWorkItem``, which had drifted on ``bundle_ref``).
  *
- * This interface was referenced by `ACIProtocolV042`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV043`'s JSON-Schema
  * via the `definition` "EvalJob".
  */
 export interface EvalJob {
@@ -405,7 +407,7 @@ export interface EvalJob {
  * Byte-identical across both lanes before this promotion, so it carries no
  * semantic decisions.
  *
- * This interface was referenced by `ACIProtocolV042`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV043`'s JSON-Schema
  * via the `definition` "EvalReport".
  */
 export interface EvalReport {
@@ -419,7 +421,7 @@ export interface EvalReport {
 /**
  * An inbound event delivered into a live session (initial or follow-up).
  *
- * This interface was referenced by `ACIProtocolV042`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV043`'s JSON-Schema
  * via the `definition` "Event".
  */
 export interface Event {
@@ -464,7 +466,7 @@ export interface Event {
  * scalars: a tolerant consumer decoding an older producer's ``final`` simply
  * sees them absent.
  *
- * This interface was referenced by `ACIProtocolV042`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV043`'s JSON-Schema
  * via the `definition` "Final".
  */
 export interface Final {
@@ -483,7 +485,7 @@ export interface Final {
 /**
  * A hard stop delivered on the control channel, distinct from a steer.
  *
- * This interface was referenced by `ACIProtocolV042`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV043`'s JSON-Schema
  * via the `definition` "Interrupt".
  */
 export interface Interrupt {
@@ -494,7 +496,7 @@ export interface Interrupt {
 /**
  * A streamed chunk of assistant text.
  *
- * This interface was referenced by `ACIProtocolV042`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV043`'s JSON-Schema
  * via the `definition` "TextDelta".
  */
 export interface TextDelta {
@@ -506,7 +508,7 @@ export interface TextDelta {
 /**
  * A human readable note about a tool call the harness is making.
  *
- * This interface was referenced by `ACIProtocolV042`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV043`'s JSON-Schema
  * via the `definition` "ToolNote".
  */
 export interface ToolNote {
@@ -535,7 +537,7 @@ export interface ToolNote {
  * turn that calls the same tool twice is otherwise indistinguishable from one
  * that called it once.
  *
- * This interface was referenced by `ACIProtocolV042`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV043`'s JSON-Schema
  * via the `definition` "SideEffectFlag".
  */
 export interface SideEffectFlag {
@@ -565,7 +567,7 @@ export interface SideEffectFlag {
  * to the non-job value is also the safe direction -- an unset ``source`` reads
  * as a person's message, so a job can never be created by omission.
  *
- * This interface was referenced by `ACIProtocolV042`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV043`'s JSON-Schema
  * via the `definition` "QueuedTurn".
  */
 export interface QueuedTurn {
@@ -614,7 +616,7 @@ export interface QueuedTurn {
  * third-party or pre-upgrade producer is not rejected outright, but every
  * first-party mint site sets it explicitly.
  *
- * This interface was referenced by `ACIProtocolV042`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV043`'s JSON-Schema
  * via the `definition` "ReplyHandle".
  */
 export interface ReplyHandle {

--- a/packages/aci-protocol/schema/aci-protocol.schema.json
+++ b/packages/aci-protocol/schema/aci-protocol.schema.json
@@ -274,6 +274,22 @@
           ],
           "title": "Bundle Ref"
         },
+        "bundle_version": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "env": "CURIE_BUNDLE_VERSION",
+          "producer": [
+            "worker"
+          ],
+          "title": "Bundle Version"
+        },
         "connector_agent": {
           "anyOf": [
             {
@@ -1356,6 +1372,6 @@
   },
   "$id": "https://curietech.ai/schemas/aci-protocol.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "protocolVersion": "0.4.2",
-  "title": "ACI Protocol v0.4.2"
+  "protocolVersion": "0.4.3",
+  "title": "ACI Protocol v0.4.3"
 }

--- a/packages/aci-protocol/schema/wire.lock
+++ b/packages/aci-protocol/schema/wire.lock
@@ -1,4 +1,4 @@
 {
-  "protocol_version": "0.4.2",
-  "wire_sha256": "359045d1f5ba7459b989026411beb01c5de6bf9cb04eaa81193be5dfe4701aec"
+  "protocol_version": "0.4.3",
+  "wire_sha256": "95750642b79c70c1ffb45b68425c73a9abb141897673bc61000d6ca4f6c24bea"
 }

--- a/packages/aci-protocol/src/aci_protocol/session.py
+++ b/packages/aci-protocol/src/aci_protocol/session.py
@@ -287,6 +287,12 @@ class BootEnv(_AciModel):
     bundle_ref: str | None = Field(
         default=None, json_schema_extra=_env("CURIE_BUNDLE_REF", "worker")
     )
+    # The platform-tracked agent version_label, so a sandboxed agent can name
+    # the bundle it is running (#2174). Distinct from bundle_ref, which is the
+    # object-store fetch key and is not the agent-facing identity.
+    bundle_version: str | None = Field(
+        default=None, json_schema_extra=_env("CURIE_BUNDLE_VERSION", "worker")
+    )
     # Per-claim bearer token the runner enforces on its ACI POST routes (#63).
     # Enforced only when configured, so local/fake sandboxes are unaffected.
     runner_token: str | None = Field(
@@ -510,6 +516,7 @@ class BootEnv(_AciModel):
         memory_ref: str,
         history_ref: str,
         bundle_ref: str | None = None,
+        bundle_version: str | None = None,
         runner_token: str | None = None,
         model: str | None = None,
         fake_model: bool | None = None,
@@ -558,6 +565,8 @@ class BootEnv(_AciModel):
         }
         if bundle_ref:
             env[cls.env_key("bundle_ref")] = bundle_ref
+        if bundle_version:
+            env[cls.env_key("bundle_version")] = bundle_version
         if runner_token:
             env[cls.env_key("runner_token")] = runner_token
         if approval_required_tools:
@@ -608,6 +617,8 @@ class BootEnv(_AciModel):
         env = self.session.to_env()
         if self.bundle_ref is not None:
             env[self.env_key("bundle_ref")] = self.bundle_ref
+        if self.bundle_version is not None:
+            env[self.env_key("bundle_version")] = self.bundle_version
         if self.runner_token is not None:
             env[self.env_key("runner_token")] = self.runner_token
         if self.model is not None:
@@ -676,6 +687,7 @@ class BootEnv(_AciModel):
         return cls(
             session=SessionConfig.from_env(env),
             bundle_ref=_str_or_none(env.get("CURIE_BUNDLE_REF")),
+            bundle_version=_str_or_none(env.get("CURIE_BUNDLE_VERSION")),
             runner_token=_str_or_none(env.get("CURIE_RUNNER_TOKEN")),
             model=_str_or_none(env.get("CURIE_MODEL")),
             fake_model=_fake_model_or_none(env.get("CURIE_FAKE_MODEL")),

--- a/packages/aci-protocol/src/aci_protocol/version.py
+++ b/packages/aci-protocol/src/aci_protocol/version.py
@@ -20,7 +20,7 @@ the guard.
 import re
 from typing import Final
 
-PROTOCOL_VERSION: Final = "0.4.2"
+PROTOCOL_VERSION: Final = "0.4.3"
 
 # The wire field carrying the protocol version on every outbound event. Both
 # exporters special-case this field by name; do not rename without updating them.

--- a/packages/aci-protocol/tests/test_session.py
+++ b/packages/aci-protocol/tests/test_session.py
@@ -122,6 +122,7 @@ def _worker_env(**overrides: object) -> dict[str, str]:
         "memory_ref": _MEMORY_REF,
         "history_ref": _HISTORY_REF,
         "bundle_ref": "bundles/demo/abc123.tar.gz",
+        "bundle_version": "abc123def456",
         "runner_token": "rt-plain-token",
         "model": "claude-opus-4-6",
         "history_token": "st-scoped-token",
@@ -164,6 +165,7 @@ def _full_boot_env() -> BootEnv:
             ),
         ),
         bundle_ref="bundles/demo/abc123.tar.gz",
+        bundle_version="abc123def456",
         runner_token="rt-full-token",
         model="claude-opus-4-6",
         fake_model=True,
@@ -342,6 +344,20 @@ def test_boot_env_declares_the_approval_resumed_kind_marker() -> None:
     assert BootEnv.from_env(env).approval_resumed_kind == "policy"
 
 
+def test_boot_env_declares_bundle_version() -> None:
+    """#2174: the agent-readable bundle version is a worker-produced boot key.
+
+    Distinct from CURIE_BUNDLE_REF (the RustFS object key). Unset is omitted.
+    """
+    assert "CURIE_BUNDLE_VERSION" in BootEnv.env_keys(producer="worker")
+    boot = BootEnv(session=_boot_session(), bundle_version="abc123def456")
+    env = boot.to_env()
+    assert env["CURIE_BUNDLE_VERSION"] == "abc123def456"
+    assert BootEnv.from_env(env | _SUBSTRATE_ENV).bundle_version == "abc123def456"
+    omitted = BootEnv(session=_boot_session()).to_env()
+    assert "CURIE_BUNDLE_VERSION" not in omitted
+
+
 def test_malformed_budget_json_raises_through_boot_env() -> None:
     env = BootEnv(session=_boot_session()).to_env()
     env["CURIE_BUDGET"] = "{not json"
@@ -370,6 +386,7 @@ def test_render_worker_matches_the_frozen_plain_bound_run_wire() -> None:
             "https://api.example.test/agents/11111111-2222-3333-4444-555555555555/state/memory"
         ),
         "CURIE_BUNDLE_REF": "bundles/demo/abc123.tar.gz",
+        "CURIE_BUNDLE_VERSION": "abc123def456",
         "CURIE_RUNNER_TOKEN": "rt-plain-token",
         "CURIE_MODEL": "claude-opus-4-6",
         "CURIE_HISTORY_REF": (
@@ -400,6 +417,7 @@ def test_render_worker_matches_the_frozen_resume_boot_wire() -> None:
             "https://api.example.test/agents/11111111-2222-3333-4444-555555555555/state/memory"
         ),
         "CURIE_BUNDLE_REF": "bundles/demo/abc123.tar.gz",
+        "CURIE_BUNDLE_VERSION": "abc123def456",
         "CURIE_RUNNER_TOKEN": "rt-resume-token",
         "CURIE_MODEL": "claude-opus-4-6",
         "CURIE_HISTORY_REF": (
@@ -435,6 +453,7 @@ def test_render_worker_matches_the_frozen_fake_local_boot_wire() -> None:
             "https://api.example.test/agents/11111111-2222-3333-4444-555555555555/state/memory"
         ),
         "CURIE_BUNDLE_REF": "bundles/demo/abc123.tar.gz",
+        "CURIE_BUNDLE_VERSION": "abc123def456",
         "CURIE_RUNNER_TOKEN": "rt-fake-token",
         # apply_model_env renders the flag as the literal "1", never "true".
         "CURIE_FAKE_MODEL": "1",
@@ -448,10 +467,16 @@ def test_render_worker_matches_the_frozen_fake_local_boot_wire() -> None:
 def test_render_worker_omits_unset_optionals_rather_than_emitting_empty_strings() -> None:
     """Unset optionals are absent, never present-and-empty (Edge case 7)."""
     env = _worker_env(
-        bundle_ref=None, model=None, history_token=None, memory_token=None, runner_token=None
+        bundle_ref=None,
+        bundle_version=None,
+        model=None,
+        history_token=None,
+        memory_token=None,
+        runner_token=None,
     )
     for key in (
         "CURIE_BUNDLE_REF",
+        "CURIE_BUNDLE_VERSION",
         "CURIE_RUNNER_TOKEN",
         "CURIE_MODEL",
         "CURIE_FAKE_MODEL",
@@ -521,6 +546,7 @@ def test_render_worker_emits_exactly_the_worker_owned_key_subset() -> None:
         connector_release="curie",
         connector_agent="acme-dev",
         connector_namespace="curie",
+        bundle_version="abc123def456",
     )
     worker_owned = set(BootEnv.env_keys(producer="worker"))
     assert set(maximal) <= worker_owned
@@ -572,6 +598,7 @@ def test_from_env_parses_the_worker_subset_plus_the_substrate_fixture() -> None:
     assert boot.model == "claude-opus-4-6"
     assert boot.runner_token == "rt-plain-token"
     assert boot.bundle_ref == "bundles/demo/abc123.tar.gz"
+    assert boot.bundle_version == "abc123def456"
     assert boot.history_ref == _HISTORY_REF
     assert boot.history_token == "st-scoped-token"
     assert boot.memory_token == "st-scoped-token"
@@ -740,6 +767,7 @@ def test_env_keys_declares_the_whole_flattened_boot_surface() -> None:
         "OTEL_EXPORTER_OTLP_PROTOCOL",
         # platform-operational, declared on BootEnv itself
         "CURIE_BUNDLE_REF",
+        "CURIE_BUNDLE_VERSION",
         "CURIE_RUNNER_TOKEN",
         "CURIE_MODEL",
         "CURIE_FAKE_MODEL",

--- a/packages/plugin-format/src/plugin_format/reserved_env.py
+++ b/packages/plugin-format/src/plugin_format/reserved_env.py
@@ -91,6 +91,7 @@ _CURIE_BOOT_KEYS = frozenset(
         "CURIE_BUDGET",
         "CURIE_SESSION_ID",
         "CURIE_BUNDLE_REF",
+        "CURIE_BUNDLE_VERSION",
         "CURIE_PLUGIN_DIR",
         "CURIE_MEMORY_REF",
         "CURIE_MEMORY_TOKEN",


### PR DESCRIPTION
## Summary

A sandboxed agent can now read the bundle version it booted with. The worker injects `CURIE_BUNDLE_VERSION` (the platform-tracked `version_label` on a bound run, the eval `sha` on an eval boot) into the claim env. Docker still strips `CURIE_BUNDLE_REF`, the RustFS object key, so the existing env-stripping posture is unchanged.

The SRE bot skill now tells the bot to read `CURIE_BUNDLE_VERSION` instead of looking for the version on platform Kubernetes objects.

This is a backward-compatible optional BootEnv field (ACI 0.4.2 to 0.4.3). The single-declaration gate requires a sandbox-readable `CURIE_*` key to be declared on BootEnv rather than injected as an undeclared literal.

## Related issue

Closes #2174

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | Does not change plugin packaging, the runner turn loop, ACI events, or skill eval/check. The example SKILL.md only documents where to read the injected env. | | |
| local | required | Worker binding boot env and the Docker sandbox substrate are the local compose worker path. | fake | `uv run pytest -q apps/worker/tests/sandbox/test_docker.py::test_create_claim_fetches_and_unwraps_bundle apps/worker/tests/binding/test_boot_env_golden.py::test_boot_env_forwards_version_label_as_bundle_version` against `51bb66812`. 2 passed. Docker argv contains `CURIE_BUNDLE_VERSION=abc123def456` and no `CURIE_BUNDLE_REF`. Binding emits `CURIE_BUNDLE_VERSION=abc123def456` and omits it when `version_label` is blank. |
| local-release | n/a | Does not change released binary identity, install path, version pins, or release compose. | | |
| cluster | n/a | Chart templates, init containers, RBAC, and NetworkPolicy are unchanged. Kubernetes already forwards unnamed claim env onto the runner; `test_bundle_version_reaches_the_runner_not_the_init_containers` pins `CURIE_BUNDLE_VERSION` on that existing path. | | |
| live provider | n/a | Does not reach model routing, credential resolution, provider auth, or token/cost accounting. | | |
| external integration | n/a | Does not reach Slack, git webhooks, connector OAuth, or any third-party API shape. | | |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

Positive proof: Docker child env carries `CURIE_BUNDLE_VERSION=abc123def456`. Negative: the same argv still has no `CURIE_BUNDLE_REF`, and a blank `version_label` omits `CURIE_BUNDLE_VERSION`. Second path: eval `_boot_env` injects `EvalJob.sha` as the same key; k8s claim env places it on the runner only.

## Sibling paths

- Docker vs Kubernetes claim env: both covered in this PR.
- Runs binding vs eval `_boot_env`: both emit `CURIE_BUNDLE_VERSION`.
- CLI `skill up` / `local` Docker argv does not inject this key. A local plugin can still read `plugin.json`. Follow-up if skill-tier bots need the same env without a deployment.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [ ] An ADR is added under `docs/adr/` if this is an architectural decision.
