### PR TITLE
Refuse ordinary next-to-main merges that would delete next

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -783,6 +783,25 @@ jobs:
           bash scripts/check-commit-messages.sh \
             "${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}"
 
+  # Issue #2090: an ordinary next to main merge deletes protected next when
+  # delete_branch_on_merge is on and the deletion ruleset is bypassable. This
+  # job never skips (a skipped required check is not a pass; see issue #1470)
+  # and refuses only that ordinary release path. Task-branch PRs, including
+  # this gate's own, succeed without an admin settings change.
+  preserve-next:
+    name: Preserve next on release merge
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Refuse an ordinary next-to-main merge that would delete next
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 release/preserve_next.py --repo "$GITHUB_REPOSITORY"
+
   # The three image builds here are GHA-layer-cached via a buildx builder that
   # is created but NOT made the default (`setup-buildx-action` with
   # `use: false`): two of the tags are consumed as Dockerfile FROM bases by a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -559,7 +559,15 @@ forward merge from `main` into `next` happens at release candidate prep, not
 after every individual fix. Do not routinely cherry pick fixes between release
 lines.
 
-When a release candidate is accepted, merge `next` into `main`, then run every
+When a release candidate is accepted, merge `next` into `main` through a pull
+request whose head is a short-lived `task/release-*` branch cut from `next`,
+not through a pull request whose head is `next` itself. Repository auto-delete
+of merged heads stays enabled so task branches still clean up; an ordinary
+`next` to `main` PR therefore deletes `next` when the merger can bypass the
+deletion ruleset (issue #2090). Run
+`python3 release/preserve_next.py --repo <owner/name>` before enabling
+auto-merge: it refuses that ordinary path until the head is not `next` or an
+active deletion ruleset covers `next` with an empty bypass list. Then run every
 parity ladder rung on the resulting `main` commit:
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -196,8 +196,15 @@ between the two branches. An administrator must protect both branches with the
 same pull request review and required check rules, and prohibit force pushes and
 branch deletion. Do not use an unprotected release train branch.
 
-When v0.7 is ready, merge `next` into `main`, then run every parity ladder rung
-on the resulting `main` commit:
+When v0.7 is ready, merge `next` into `main` through a pull request whose head
+is a short-lived `task/release-*` branch cut from `next`, not through a pull
+request whose head is `next` itself. Repository auto-delete of merged heads
+stays enabled so task branches still clean up; an ordinary `next` to `main` PR
+therefore deletes `next` when the merger can bypass the deletion ruleset
+(issue #2090). Run `python3 release/preserve_next.py --repo <owner/name>`
+before enabling auto-merge: it refuses that ordinary path until the head is
+not `next` or an active deletion ruleset covers `next` with an empty bypass
+list. Then run every parity ladder rung on the resulting `main` commit:
 
 ```bash
 CURIE_E2E_TIERS=all curie dev e2e-ladder

--- a/release/preserve_next.py
+++ b/release/preserve_next.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python3
+"""Refuse an ordinary next-to-main release merge that would delete `next`.
+
+Issue #2090: merging a pull request whose head is the protected `next` branch
+into `main` deleted `next` because the repository keeps
+`delete_branch_on_merge` enabled (so short-lived task branches still clean up)
+and the deletion ruleset that covers `next` lists bypass actors. GitHub then
+auto-deletes the PR head; a bypass-capable merger is not stopped by that
+ruleset.
+
+This script is the fail-closed preflight that must run before that ordinary
+path is merged. It allows:
+
+  * a short-lived `task/release-*` (or any non-`next`) head, which is the
+    repository-owned way to keep task-branch cleanup without deleting `next`;
+  * an active deletion ruleset that covers `next` and has an empty bypass
+    list, which is the durable GitHub configuration (admin-only to apply);
+  * `delete_branch_on_merge` turned off (loses task-branch cleanup);
+  * the documented retirement sequence, once `next` is no longer a release
+    train trigger branch.
+
+Anything else, including a lookup that did not complete, is a refusal. The
+predicate lives in separately-testable functions so the unsafe ordinary path
+is an ordinary pytest assertion against a constructed GitHub fixture, not a
+destructive merge of the live `next` branch. Only `main()` needs the network.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+NEXT_BRANCH = "next"
+DEFAULT_BASE = "main"
+RELEASE_WORKFLOW = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "release.yaml"
+_PUSH_BRANCHES = re.compile(r"^\s+branches:\s*\[([^\]]*)\]", re.MULTILINE)
+
+
+class PreserveNextError(Exception):
+    """An ordinary release merge would delete the protected next branch."""
+
+
+@dataclass(frozen=True)
+class BypassActor:
+    actor_id: object
+    actor_type: str
+    bypass_mode: str
+
+
+@dataclass(frozen=True)
+class Ruleset:
+    id: int
+    name: str
+    enforcement: str
+    include_refs: tuple[str, ...]
+    exclude_refs: tuple[str, ...]
+    rule_types: tuple[str, ...]
+    bypass_actors: tuple[BypassActor, ...] | None
+
+
+@dataclass(frozen=True)
+class RepoSettings:
+    delete_branch_on_merge: bool
+    default_branch: str
+
+
+@dataclass(frozen=True)
+class PullRequestRefs:
+    head_ref: str
+    base_ref: str
+
+
+def parse_repo_settings(payload: dict[str, object]) -> RepoSettings:
+    delete = payload.get("delete_branch_on_merge")
+    if not isinstance(delete, bool):
+        raise PreserveNextError(
+            "repository payload is missing a boolean delete_branch_on_merge"
+        )
+    default_branch = payload.get("default_branch")
+    if not isinstance(default_branch, str) or not default_branch:
+        raise PreserveNextError("repository payload is missing default_branch")
+    return RepoSettings(
+        delete_branch_on_merge=delete, default_branch=default_branch
+    )
+
+
+def parse_ruleset(payload: dict[str, object]) -> Ruleset:
+    conditions = payload.get("conditions")
+    ref_name: dict[str, object] = {}
+    if isinstance(conditions, dict):
+        raw_ref = conditions.get("ref_name")
+        if isinstance(raw_ref, dict):
+            ref_name = raw_ref
+    include = ref_name.get("include")
+    exclude = ref_name.get("exclude")
+    rules = payload.get("rules")
+    rule_types: list[str] = []
+    if isinstance(rules, list):
+        for rule in rules:
+            if isinstance(rule, dict) and isinstance(rule.get("type"), str):
+                rule_types.append(str(rule["type"]))
+    bypass: tuple[BypassActor, ...] | None
+    if "bypass_actors" not in payload:
+        bypass = None
+    else:
+        raw_bypass = payload.get("bypass_actors")
+        actors: list[BypassActor] = []
+        if isinstance(raw_bypass, list):
+            for item in raw_bypass:
+                if not isinstance(item, dict):
+                    continue
+                actors.append(
+                    BypassActor(
+                        actor_id=item.get("actor_id"),
+                        actor_type=str(item.get("actor_type") or ""),
+                        bypass_mode=str(item.get("bypass_mode") or ""),
+                    )
+                )
+        bypass = tuple(actors)
+    return Ruleset(
+        id=int(payload.get("id") or 0),
+        name=str(payload.get("name") or ""),
+        enforcement=str(payload.get("enforcement") or ""),
+        include_refs=tuple(str(item) for item in include) if isinstance(include, list) else (),
+        exclude_refs=tuple(str(item) for item in exclude) if isinstance(exclude, list) else (),
+        rule_types=tuple(rule_types),
+        bypass_actors=bypass,
+    )
+
+
+def _ref_names(branch: str, default_branch: str) -> set[str]:
+    names = {branch, f"refs/heads/{branch}"}
+    if branch == default_branch:
+        names.add("~DEFAULT_BRANCH")
+    return names
+
+
+def ruleset_covers_ref(ruleset: Ruleset, branch: str, default_branch: str) -> bool:
+    names = _ref_names(branch, default_branch)
+    if names.intersection(ruleset.exclude_refs):
+        return False
+    if "~ALL" in ruleset.include_refs:
+        return True
+    return bool(names.intersection(ruleset.include_refs))
+
+
+def deletion_rule_blocks_auto_delete(ruleset: Ruleset) -> bool:
+    if ruleset.enforcement != "active":
+        return False
+    if "deletion" not in ruleset.rule_types:
+        return False
+    if ruleset.bypass_actors is None:
+        # Missing bypass_actors cannot be treated as empty: the list endpoint
+        # omits them, and an omitted list would look like durable protection.
+        return False
+    return len(ruleset.bypass_actors) == 0
+
+
+def head_survives_auto_delete(
+    settings: RepoSettings,
+    rulesets: Sequence[Ruleset],
+    head_ref: str,
+) -> bool:
+    if not settings.delete_branch_on_merge:
+        return True
+    return any(
+        ruleset_covers_ref(ruleset, head_ref, settings.default_branch)
+        and deletion_rule_blocks_auto_delete(ruleset)
+        for ruleset in rulesets
+    )
+
+
+def next_survives_auto_delete_on_merge(
+    settings: RepoSettings,
+    rulesets: Sequence[Ruleset],
+    head_ref: str,
+    next_branch: str = NEXT_BRANCH,
+) -> bool:
+    if head_ref != next_branch:
+        return True
+    return head_survives_auto_delete(settings, rulesets, next_branch)
+
+
+def predict_head_branch_deleted_after_merge(
+    settings: RepoSettings,
+    rulesets: Sequence[Ruleset],
+    head_ref: str,
+) -> bool:
+    """Would GitHub auto-delete `head_ref` after merging this pull request?
+
+    Isolated fixture of GitHub's merge-deletion rule: auto-delete happens when
+    `delete_branch_on_merge` is on, unless an active deletion ruleset covers
+    the head and lists no bypass actors. Documented at
+    https://docs.github.com/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-the-automatic-deletion-of-branches
+    Observed on this repository's PR #2085 (`head_ref_deleted` for `next` six
+    seconds after merge).
+    """
+    return not head_survives_auto_delete(settings, rulesets, head_ref)
+
+
+def next_is_release_train_branch(
+    workflow: dict[str, object], next_branch: str = NEXT_BRANCH
+) -> bool:
+    on = workflow.get("on")
+    if not isinstance(on, dict):
+        return True
+    push = on.get("push")
+    if not isinstance(push, dict):
+        return True
+    branches = push.get("branches")
+    if not isinstance(branches, list):
+        return True
+    return next_branch in [str(item) for item in branches]
+
+
+def pull_request_refs_from_event(event: dict[str, object]) -> PullRequestRefs | None:
+    pull_request = event.get("pull_request")
+    if not isinstance(pull_request, dict):
+        return None
+    head = pull_request.get("head")
+    base = pull_request.get("base")
+    if not isinstance(head, dict) or not isinstance(base, dict):
+        return None
+    head_ref = head.get("ref")
+    base_ref = base.get("ref")
+    if not isinstance(head_ref, str) or not isinstance(base_ref, str):
+        return None
+    if not head_ref or not base_ref:
+        return None
+    return PullRequestRefs(head_ref=head_ref, base_ref=base_ref)
+
+
+def evaluate(
+    *,
+    event: dict[str, object],
+    settings: RepoSettings,
+    rulesets: Sequence[Ruleset],
+    workflow: dict[str, object],
+    next_branch: str = NEXT_BRANCH,
+    default_base: str = DEFAULT_BASE,
+) -> None:
+    refs = pull_request_refs_from_event(event)
+    if refs is None:
+        return
+    if refs.head_ref != next_branch or refs.base_ref != default_base:
+        return
+    if not next_is_release_train_branch(workflow, next_branch):
+        return
+    if next_survives_auto_delete_on_merge(
+        settings, rulesets, refs.head_ref, next_branch
+    ):
+        return
+    raise PreserveNextError(
+        "ordinary next-to-main release merge would delete protected next: "
+        "delete_branch_on_merge is enabled and no active deletion ruleset "
+        "covers next with an empty bypass list. Cut the release PR from a "
+        "short-lived task/release-* branch, or add a next-only deletion "
+        "ruleset with no bypass actors (issue #2090)."
+    )
+
+
+def _gh_env() -> dict[str, str]:
+    """Force plain JSON. `gh api` colorizes when CLICOLOR_FORCE is set."""
+    env = os.environ.copy()
+    env["NO_COLOR"] = "1"
+    env["GH_FORCE_TTY"] = "0"
+    env.pop("CLICOLOR_FORCE", None)
+    return env
+
+
+def _gh_get(endpoint: str) -> object:
+    result = subprocess.run(
+        ["gh", "api", "-X", "GET", endpoint],
+        capture_output=True,
+        text=True,
+        check=True,
+        env=_gh_env(),
+    )
+    return json.loads(result.stdout)
+
+
+def fetch_repo_settings(repo: str) -> RepoSettings:
+    payload = _gh_get(f"repos/{repo}")
+    if not isinstance(payload, dict):
+        raise PreserveNextError(f"repository payload for {repo} was not an object")
+    return parse_repo_settings(payload)
+
+
+def fetch_rulesets(repo: str) -> list[Ruleset]:
+    listing = _gh_get(f"repos/{repo}/rulesets")
+    if not isinstance(listing, list):
+        raise PreserveNextError(f"ruleset list for {repo} was not an array")
+    rulesets: list[Ruleset] = []
+    for item in listing:
+        if not isinstance(item, dict) or item.get("id") is None:
+            raise PreserveNextError(f"ruleset list for {repo} contained an entry without id")
+        detail = _gh_get(f"repos/{repo}/rulesets/{item['id']}")
+        if not isinstance(detail, dict):
+            raise PreserveNextError(
+                f"ruleset {item['id']} for {repo} was not an object"
+            )
+        rulesets.append(parse_ruleset(detail))
+    return rulesets
+
+
+def _push_branches_from_text(text: str) -> list[str]:
+    match = _PUSH_BRANCHES.search(text)
+    if match is None:
+        return [NEXT_BRANCH]
+    names: list[str] = []
+    for item in match.group(1).split(","):
+        token = item.strip()
+        if token:
+            names.append(token.split()[-1])
+    return names
+
+
+def load_release_workflow() -> dict[str, object]:
+    text = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+    return {"on": {"push": {"branches": _push_branches_from_text(text)}}}
+
+
+def _ordinary_release_event() -> dict[str, object]:
+    return {
+        "pull_request": {
+            "head": {"ref": NEXT_BRANCH},
+            "base": {"ref": DEFAULT_BASE},
+        }
+    }
+
+
+def _needs_live_github(
+    event: dict[str, object], workflow: dict[str, object]
+) -> bool:
+    refs = pull_request_refs_from_event(event)
+    return (
+        refs is not None
+        and refs.head_ref == NEXT_BRANCH
+        and refs.base_ref == DEFAULT_BASE
+        and next_is_release_train_branch(workflow)
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--repo", required=True, help="owner/name, e.g. curie-eng/curie"
+    )
+    parser.add_argument(
+        "--event",
+        help="GitHub event JSON path; defaults to GITHUB_EVENT_PATH, or the "
+        "ordinary next-to-main path when neither is set",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        workflow = load_release_workflow()
+        event_path = args.event or os.environ.get("GITHUB_EVENT_PATH")
+        if event_path:
+            event = json.loads(Path(event_path).read_text(encoding="utf-8"))
+            if not isinstance(event, dict):
+                raise PreserveNextError("GitHub event payload was not an object")
+        else:
+            event = _ordinary_release_event()
+        if _needs_live_github(event, workflow):
+            settings = fetch_repo_settings(args.repo)
+            rulesets = fetch_rulesets(args.repo)
+        else:
+            settings = RepoSettings(delete_branch_on_merge=True, default_branch=DEFAULT_BASE)
+            rulesets = []
+        evaluate(
+            event=event,
+            settings=settings,
+            rulesets=rulesets,
+            workflow=workflow,
+        )
+    except PreserveNextError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    except (subprocess.CalledProcessError, json.JSONDecodeError, KeyError, OSError) as exc:
+        detail = getattr(exc, "stderr", None)
+        suffix = f": {str(detail).strip()}" if detail else ""
+        print(
+            f"ERROR: could not retrieve repository settings for {args.repo} "
+            f"-- the lookup failed with {type(exc).__name__}{suffix}. "
+            "Refusing because whether next would be deleted is unknown.",
+            file=sys.stderr,
+        )
+        return 1
+    print("OK: merging this event will not auto-delete next")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/release/tests/test_preserve_next.py
+++ b/release/tests/test_preserve_next.py
@@ -1,0 +1,474 @@
+"""Contract tests for the next-branch preservation preflight (issue #2090).
+
+Merging the ordinary `next` -> `main` release PR deleted protected `next`
+because the repository keeps `delete_branch_on_merge` enabled (so short-lived
+task branches still clean up) and the deletion ruleset that covers `next` lists
+bypass actors. GitHub then auto-deletes the PR head, and a bypass-capable
+merger is not stopped by that ruleset.
+
+These tests drive the gate against constructed GitHub payloads, the same split
+`release/authorize.py` uses: the negative case is an ordinary pytest assertion,
+not a destructive merge of the live `next` branch. Live read-only evidence for
+the incident (PR #2085 `head_ref_deleted` six seconds after merge; repository
+`delete_branch_on_merge=true`; ruleset 18711121 covers `refs/heads/next` with a
+`deletion` rule and a bypass actor) is recorded in the issue and the pull
+request, not copied as real identifiers here.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "release" / "preserve_next.py"
+CI_YAML = REPO_ROOT / ".github" / "workflows" / "ci.yaml"
+RELEASE_YAML = REPO_ROOT / ".github" / "workflows" / "release.yaml"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("release_preserve_next", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    # Dataclasses read sys.modules[cls.__module__] while the class body runs.
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+preserve_next = load_module()
+
+
+def ruleset_payload(
+    *,
+    ruleset_id: int = 1,
+    name: str = "Default",
+    enforcement: str = "active",
+    include: list[str] | None = None,
+    exclude: list[str] | None = None,
+    rules: list[dict] | None = None,
+    bypass_actors: list[dict] | None = None,
+    omit_bypass_actors: bool = False,
+) -> dict:
+    payload = {
+        "id": ruleset_id,
+        "name": name,
+        "enforcement": enforcement,
+        "conditions": {
+            "ref_name": {
+                "include": include
+                if include is not None
+                else ["~DEFAULT_BRANCH", "refs/heads/next"],
+                "exclude": exclude if exclude is not None else [],
+            }
+        },
+        "rules": rules if rules is not None else [{"type": "deletion"}],
+    }
+    if not omit_bypass_actors:
+        payload["bypass_actors"] = (
+            bypass_actors
+            if bypass_actors is not None
+            else [
+                {
+                    "actor_id": 1001,
+                    "actor_type": "User",
+                    "bypass_mode": "always",
+                }
+            ]
+        )
+    return payload
+
+
+def repo_payload(*, delete_branch_on_merge: bool = True, default_branch: str = "main") -> dict:
+    return {
+        "delete_branch_on_merge": delete_branch_on_merge,
+        "default_branch": default_branch,
+        "name": "curie",
+    }
+
+
+def pr_event(head: str, base: str = "main") -> dict:
+    return {"action": "opened", "pull_request": {"head": {"ref": head}, "base": {"ref": base}}}
+
+
+def push_event(ref: str = "refs/heads/main") -> dict:
+    return {"ref": ref}
+
+
+def release_train_workflow(branches: list[str] | None = None) -> dict:
+    return {"on": {"push": {"branches": branches if branches is not None else ["main", "next"]}}}
+
+
+def settings_from(payload: dict):
+    return preserve_next.parse_repo_settings(payload)
+
+
+def rulesets_from(*payloads: dict):
+    return [preserve_next.parse_ruleset(payload) for payload in payloads]
+
+
+# Snapshot of the unsafe ordinary release path: auto-delete is on, `next` is
+# the PR head, and the deletion ruleset that covers `next` is bypassable.
+UNSAFE_REPO = repo_payload()
+UNSAFE_RULESET = ruleset_payload()
+UNSAFE_WORKFLOW = release_train_workflow()
+
+
+class TestPredictHeadBranchDeletedAfterMerge:
+    """Isolated GitHub merge/deletion fixture (issue #2090).
+
+    GitHub auto-deletes a merged PR head when `delete_branch_on_merge` is
+    true, unless a ruleset deletion rule covers that head and the merger
+    cannot bypass it. Documented at
+    https://docs.github.com/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-the-automatic-deletion-of-branches
+    Observed on this repository's PR #2085: `merged` at 2026-08-29T22:27:46Z,
+    `head_ref_deleted` for `next` at 2026-08-29T22:27:52Z.
+    """
+
+    def test_ordinary_next_to_main_merge_deletes_next_when_deletion_rule_is_bypassable(
+        self,
+    ):
+        settings = settings_from(UNSAFE_REPO)
+        rulesets = rulesets_from(UNSAFE_RULESET)
+
+        assert preserve_next.predict_head_branch_deleted_after_merge(
+            settings, rulesets, "next"
+        )
+        assert not preserve_next.next_survives_auto_delete_on_merge(
+            settings, rulesets, "next"
+        )
+
+    def test_task_branch_head_is_deleted_and_next_is_preserved(self):
+        settings = settings_from(UNSAFE_REPO)
+        rulesets = rulesets_from(UNSAFE_RULESET)
+
+        assert preserve_next.predict_head_branch_deleted_after_merge(
+            settings, rulesets, "task/release-v0.8.0"
+        )
+        assert preserve_next.next_survives_auto_delete_on_merge(
+            settings, rulesets, "task/release-v0.8.0"
+        )
+
+    def test_empty_bypass_deletion_ruleset_preserves_next(self):
+        settings = settings_from(UNSAFE_REPO)
+        rulesets = rulesets_from(ruleset_payload(bypass_actors=[]))
+
+        assert not preserve_next.predict_head_branch_deleted_after_merge(
+            settings, rulesets, "next"
+        )
+        assert preserve_next.next_survives_auto_delete_on_merge(
+            settings, rulesets, "next"
+        )
+
+    def test_auto_delete_disabled_preserves_next(self):
+        settings = settings_from(repo_payload(delete_branch_on_merge=False))
+        rulesets = rulesets_from(UNSAFE_RULESET)
+
+        assert not preserve_next.predict_head_branch_deleted_after_merge(
+            settings, rulesets, "next"
+        )
+        assert preserve_next.next_survives_auto_delete_on_merge(
+            settings, rulesets, "next"
+        )
+
+    def test_missing_bypass_actors_does_not_count_as_protection(self):
+        settings = settings_from(UNSAFE_REPO)
+        rulesets = rulesets_from(ruleset_payload(omit_bypass_actors=True))
+
+        assert preserve_next.predict_head_branch_deleted_after_merge(
+            settings, rulesets, "next"
+        )
+
+    def test_evaluate_enforcement_does_not_count_as_protection(self):
+        settings = settings_from(UNSAFE_REPO)
+        rulesets = rulesets_from(
+            ruleset_payload(enforcement="evaluate", bypass_actors=[])
+        )
+
+        assert preserve_next.predict_head_branch_deleted_after_merge(
+            settings, rulesets, "next"
+        )
+
+    def test_ruleset_that_does_not_cover_next_does_not_protect_it(self):
+        settings = settings_from(UNSAFE_REPO)
+        rulesets = rulesets_from(
+            ruleset_payload(include=["~DEFAULT_BRANCH"], bypass_actors=[])
+        )
+
+        assert preserve_next.predict_head_branch_deleted_after_merge(
+            settings, rulesets, "next"
+        )
+
+
+class TestEvaluatePreflight:
+    def test_refuses_ordinary_next_to_main_release_merge(self):
+        with pytest.raises(preserve_next.PreserveNextError) as exc_info:
+            preserve_next.evaluate(
+                event=pr_event("next"),
+                settings=settings_from(UNSAFE_REPO),
+                rulesets=rulesets_from(UNSAFE_RULESET),
+                workflow=UNSAFE_WORKFLOW,
+            )
+
+        message = str(exc_info.value)
+        assert "next" in message
+        assert "delete_branch_on_merge" in message
+        assert "bypass" in message
+
+    def test_allows_a_short_lived_release_task_branch(self):
+        preserve_next.evaluate(
+            event=pr_event("task/release-v0.8.0"),
+            settings=settings_from(UNSAFE_REPO),
+            rulesets=rulesets_from(UNSAFE_RULESET),
+            workflow=UNSAFE_WORKFLOW,
+        )
+
+    def test_allows_next_to_main_when_deletion_ruleset_has_no_bypass(self):
+        preserve_next.evaluate(
+            event=pr_event("next"),
+            settings=settings_from(UNSAFE_REPO),
+            rulesets=rulesets_from(ruleset_payload(bypass_actors=[])),
+            workflow=UNSAFE_WORKFLOW,
+        )
+
+    def test_allows_next_to_main_when_auto_delete_is_disabled(self):
+        preserve_next.evaluate(
+            event=pr_event("next"),
+            settings=settings_from(repo_payload(delete_branch_on_merge=False)),
+            rulesets=rulesets_from(UNSAFE_RULESET),
+            workflow=UNSAFE_WORKFLOW,
+        )
+
+    def test_allows_next_to_main_after_the_documented_retirement_sequence(self):
+        preserve_next.evaluate(
+            event=pr_event("next"),
+            settings=settings_from(UNSAFE_REPO),
+            rulesets=rulesets_from(UNSAFE_RULESET),
+            workflow=release_train_workflow(["main"]),
+        )
+
+    def test_push_events_are_not_release_merges(self):
+        preserve_next.evaluate(
+            event=push_event(),
+            settings=settings_from(UNSAFE_REPO),
+            rulesets=rulesets_from(UNSAFE_RULESET),
+            workflow=UNSAFE_WORKFLOW,
+        )
+
+    def test_next_into_next_is_not_the_ordinary_release_merge(self):
+        preserve_next.evaluate(
+            event=pr_event("next", base="next"),
+            settings=settings_from(UNSAFE_REPO),
+            rulesets=rulesets_from(UNSAFE_RULESET),
+            workflow=UNSAFE_WORKFLOW,
+        )
+
+
+class TestReleaseTrainDetection:
+    def test_committed_release_workflow_still_treats_next_as_a_release_train_branch(
+        self,
+    ):
+        workflow = yaml.load(RELEASE_YAML.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+
+        assert preserve_next.next_is_release_train_branch(workflow)
+        assert "next" in workflow["on"]["push"]["branches"]
+
+    def test_a_workflow_without_next_is_the_retirement_state(self):
+        assert not preserve_next.next_is_release_train_branch(
+            release_train_workflow(["main"])
+        )
+
+
+class TestFetchUsesGet:
+    """`gh api` must be pinned to GET, matching issue #732 on authorize.py."""
+
+    @staticmethod
+    def _capture(monkeypatch, responses: dict[str, dict]) -> list:
+        captured: list = []
+
+        def fake_run(argv, **kwargs):
+            captured.append(argv)
+            endpoint = next(
+                arg for arg in argv if isinstance(arg, str) and arg.startswith("repos/")
+            )
+            payload = responses[endpoint]
+            return subprocess.CompletedProcess(
+                argv, 0, stdout=json.dumps(payload), stderr=""
+            )
+
+        monkeypatch.setattr(preserve_next.subprocess, "run", fake_run)
+        return captured
+
+    def test_repo_settings_are_fetched_with_an_explicit_get(self, monkeypatch):
+        captured = self._capture(
+            monkeypatch, {"repos/curie-eng/curie": repo_payload()}
+        )
+
+        settings = preserve_next.fetch_repo_settings("curie-eng/curie")
+
+        argv = captured[0]
+        assert argv[argv.index("-X") + 1] == "GET"
+        assert settings.delete_branch_on_merge is True
+
+    def test_gh_env_disables_color_so_the_payload_stays_json(self, monkeypatch):
+        captured_env: list[dict] = []
+
+        def fake_run(argv, **kwargs):
+            captured_env.append(kwargs.get("env") or {})
+            return subprocess.CompletedProcess(
+                argv, 0, stdout=json.dumps(repo_payload()), stderr=""
+            )
+
+        monkeypatch.setattr(preserve_next.subprocess, "run", fake_run)
+        monkeypatch.setenv("CLICOLOR_FORCE", "1")
+
+        preserve_next.fetch_repo_settings("curie-eng/curie")
+
+        env = captured_env[0]
+        assert env["NO_COLOR"] == "1"
+        assert env["GH_FORCE_TTY"] == "0"
+        assert "CLICOLOR_FORCE" not in env
+
+    def test_rulesets_are_re_fetched_for_bypass_actors(self, monkeypatch):
+        list_payload = [{"id": 1, "name": "Default", "enforcement": "active"}]
+        detail = ruleset_payload()
+        captured = self._capture(
+            monkeypatch,
+            {
+                "repos/curie-eng/curie/rulesets": list_payload,
+                "repos/curie-eng/curie/rulesets/1": detail,
+            },
+        )
+
+        rulesets = preserve_next.fetch_rulesets("curie-eng/curie")
+
+        endpoints = [
+            next(arg for arg in argv if isinstance(arg, str) and arg.startswith("repos/"))
+            for argv in captured
+        ]
+        assert endpoints == [
+            "repos/curie-eng/curie/rulesets",
+            "repos/curie-eng/curie/rulesets/1",
+        ]
+        assert all(argv[argv.index("-X") + 1] == "GET" for argv in captured)
+        assert rulesets[0].bypass_actors is not None
+        assert len(rulesets[0].bypass_actors) == 1
+
+
+class TestMain:
+    @staticmethod
+    def _stub_live(monkeypatch, *, repo: dict, rulesets: list[dict]) -> None:
+        monkeypatch.setattr(
+            preserve_next,
+            "fetch_repo_settings",
+            lambda _repo: preserve_next.parse_repo_settings(repo),
+        )
+        monkeypatch.setattr(
+            preserve_next,
+            "fetch_rulesets",
+            lambda _repo: [preserve_next.parse_ruleset(item) for item in rulesets],
+        )
+        monkeypatch.setattr(
+            preserve_next,
+            "load_release_workflow",
+            lambda: UNSAFE_WORKFLOW,
+        )
+
+    def test_refuses_an_ordinary_next_to_main_pr(self, tmp_path, monkeypatch, capsys):
+        event_path = tmp_path / "event.json"
+        event_path.write_text(json.dumps(pr_event("next")), encoding="utf-8")
+        self._stub_live(monkeypatch, repo=UNSAFE_REPO, rulesets=[UNSAFE_RULESET])
+
+        exit_code = preserve_next.main(
+            ["--repo", "curie-eng/curie", "--event", str(event_path)]
+        )
+
+        assert exit_code == 1
+        err = capsys.readouterr().err
+        assert "ERROR:" in err
+        assert "delete_branch_on_merge" in err
+
+    def test_allows_a_task_branch_pr_without_requiring_the_admin_setting_change(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        event_path = tmp_path / "event.json"
+        event_path.write_text(
+            json.dumps(pr_event("task/2090-preserve-next-branch")), encoding="utf-8"
+        )
+        self._stub_live(monkeypatch, repo=UNSAFE_REPO, rulesets=[UNSAFE_RULESET])
+
+        exit_code = preserve_next.main(
+            ["--repo", "curie-eng/curie", "--event", str(event_path)]
+        )
+
+        assert exit_code == 0
+        assert "OK:" in capsys.readouterr().out
+
+    def test_operator_invocation_without_an_event_checks_the_ordinary_release_path(
+        self, monkeypatch, capsys
+    ):
+        self._stub_live(monkeypatch, repo=UNSAFE_REPO, rulesets=[UNSAFE_RULESET])
+        monkeypatch.delenv("GITHUB_EVENT_PATH", raising=False)
+
+        exit_code = preserve_next.main(["--repo", "curie-eng/curie"])
+
+        assert exit_code == 1
+        assert "delete_branch_on_merge" in capsys.readouterr().err
+
+    def test_lookup_failure_refuses_closed(self, tmp_path, monkeypatch, capsys):
+        event_path = tmp_path / "event.json"
+        event_path.write_text(json.dumps(pr_event("next")), encoding="utf-8")
+        monkeypatch.setattr(
+            preserve_next,
+            "fetch_repo_settings",
+            lambda _repo: (_ for _ in ()).throw(
+                subprocess.CalledProcessError(
+                    1,
+                    ["gh", "api", "-X", "GET", "repos/curie-eng/curie"],
+                    stderr="gh: Not Found (HTTP 404)",
+                )
+            ),
+        )
+        monkeypatch.setattr(
+            preserve_next, "load_release_workflow", lambda: UNSAFE_WORKFLOW
+        )
+
+        exit_code = preserve_next.main(
+            ["--repo", "curie-eng/curie", "--event", str(event_path)]
+        )
+
+        assert exit_code == 1
+        err = capsys.readouterr().err
+        assert "could not retrieve" in err
+        assert "gh: Not Found (HTTP 404)" in err
+
+
+class TestCiWorkflowContract:
+    """The consumer path is the CI job, not the helper sitting unused."""
+
+    def test_preserve_next_job_invokes_the_script_and_never_skips(self):
+        workflow = yaml.safe_load(CI_YAML.read_text(encoding="utf-8"))
+        job = workflow["jobs"]["preserve-next"]
+
+        assert "if" not in job
+        assert job.get("continue-on-error") is not True
+        runs = [step.get("run", "") for step in job["steps"]]
+        assert any("release/preserve_next.py" in run for run in runs)
+        assert any("--repo" in run and "GITHUB_REPOSITORY" in run for run in runs)
+
+    def test_preserve_next_job_supplies_a_token_for_gh_api(self):
+        workflow = yaml.safe_load(CI_YAML.read_text(encoding="utf-8"))
+        job = workflow["jobs"]["preserve-next"]
+        step = next(
+            item
+            for item in job["steps"]
+            if "release/preserve_next.py" in item.get("run", "")
+        )
+        env = step.get("env") or job.get("env") or {}
+        assert env.get("GH_TOKEN") == "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Summary

An ordinary reviewed `next` to `main` release merge deletes protected `next` when GitHub auto-deletes merged heads and the deletion ruleset that covers `next` lists bypass actors. PR #2085 is the incident: `merged` at 2026-08-29T22:27:46Z, `head_ref_deleted` for `next` at 2026-08-29T22:27:52Z. Read-only API on 2026-09-03 still reports `delete_branch_on_merge=true` and ruleset 18711121 covering `refs/heads/next` with a `deletion` rule plus bypass actors.

This change adds a repository-owned fail-closed preflight (`release/preserve_next.py`) and a never-skipped CI job. The ordinary next-to-main path is refused until either the PR head is not `next` (cut a short-lived `task/release-*` branch so task-branch cleanup can stay enabled) or an active deletion ruleset covers `next` with an empty bypass list. Isolated fixtures prove the unsafe merge would delete `next`, that a task-branch head preserves `next`, and that reverting the refusal fails the tests.

## Related issue

Closes #2090

## Fix pin verification

Fix pin: n/a - tests live under release/tests which is not a supported selector form; the refusal is pinned by release/tests/test_preserve_next.py::TestEvaluatePreflight::test_refuses_ordinary_next_to_main_release_merge

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | Does not reach plugin packaging, the runner turn loop, ACI events, or skill eval/check | | |
| local | n/a | Does not change compose services, dispatcher/worker/API wiring, the console UI, or any curie verb | | |
| local-release | n/a | Does not change released binary or image identity, the install path, version pins, or release compose | | |
| cluster | n/a | Does not reach chart templates, RBAC, securityContext, NetworkPolicy, sandbox claims, or init containers | | |
| live provider | n/a | Does not reach model routing, credential resolution, provider auth, or token/cost accounting | | |
| external integration | required | Preflight reads GitHub repo settings and rulesets; a live next merge is forbidden so merge deletion is proven on an isolated fixture | live | `python3 release/preserve_next.py --repo curie-eng/curie` on ae7471f23: `ERROR: ordinary next-to-main release merge would delete protected next: delete_branch_on_merge is enabled and no active deletion ruleset covers next with an empty bypass list.` Exit 1. |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

Positive proof (unsafe ordinary path refused):

```
python3 release/preserve_next.py --repo curie-eng/curie
```

Observed on ae7471f23: exit 1, message names `delete_branch_on_merge` and bypass.

Falsifiable negative / second path:

```
python3 release/preserve_next.py --repo curie-eng/curie --event task-branch.json
```

with head `task/2090-preserve-next-branch`: exit 0, `OK: merging this event will not auto-delete next`.

```
uv run pytest -q release/tests/test_preserve_next.py
```

25 passed, including refusal of the unsafe snapshot and acceptance of a task-branch head and of an empty-bypass deletion ruleset. Reverting `evaluate` so the ordinary path returns would fail `test_refuses_ordinary_next_to_main_release_merge`. Reverting the CI job would fail `TestCiWorkflowContract`.

Cause identification (read-only): repository auto-delete fired as the merger, who is a ruleset bypass actor (`bypass_mode: always`). The deletion rule on `next` did not stop GitHub from deleting the PR head.

## Residual admin action (not performed)

Do not set `delete_branch_on_merge=false` if task-branch cleanup should stay. Instead, add a ruleset that targets only `refs/heads/next`, enables Restrict deletions, and has an empty bypass list. Keep the existing Default ruleset bypass list for other admin work. Optionally add `Preserve next on release merge` as a required status check on `main`. This PR does not change live GitHub settings, rulesets, branches, tags, or deployments.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [x] An ADR is added under `docs/adr/` if this is an architectural decision.
