### PR TITLE
Skip Python-job cargo unless the fix-pin parser would invoke curie

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -154,31 +154,40 @@ jobs:
       # seam. This prints the real ones on every run, for the price of 25 lines.
       - name: Pytest
         run: uv run pytest -q --durations=25
-      # Build ONLY when the body actually carries a declaration. tools/fix-pin-ci/
-      # check.py reaches the binary at exactly one place, the
+      # Build ONLY when the declaration parser would invoke the curie binary.
+      # tools/fix-pin-ci/check.py reaches it at exactly one place, the
       # `curie dev verify-fix-pin` call, and only once `declaration.selector` is
-      # set; `n/a`, no declaration, a near-miss marker like `Fix-pin:`, and the
-      # bug-without-declaration rejection all return before touching it. So on
-      # every pull request that declares nothing -- the overwhelming majority --
-      # this was a 213s cold `cargo build --release` for a binary nothing ran,
-      # inside the longest job on the graph.
+      # set; `n/a`, no declaration, a near-miss marker like `Fix-pin:`, HTML
+      # comments in the pull request template, and the bug-without-declaration
+      # rejection all return before touching it.
       #
-      # `contains()` is case-insensitive and DECLARATION is the exact-case
-      # `Fix pin: <selector>`, so this condition is a strict superset of the
-      # cases that reach the binary: it cannot skip a build the gate then needs.
-      # It builds a few times it need not (`Fix pin: n/a`, a near miss), which is
-      # the safe direction. This stays a direct build inside the required Python
-      # status: no `needs`, no downloaded artifact, no Cargo cache, so nothing
-      # the gate's contract protects is traded away for the time.
+      # `#2228` gated cargo with `contains(..., 'Fix pin:')`. That is true for
+      # every pull request that keeps the default template, because the template
+      # embeds those exact bytes inside `<!-- -->`. The probe reuses
+      # `_declaration` so a commented example cannot trigger a cold
+      # `cargo build --release` inside the longest job on the graph, and a live
+      # selector line cannot skip it.
+      #
+      # `n/a` used to pay that extra build as a safe over-match. The parser does
+      # not invoke curie for `n/a`, so the probe reports needed=false. This
+      # stays a direct build inside the required Python status: no `needs`, no
+      # downloaded artifact, no Cargo cache.
+      - name: Decide whether the current curie binary is needed
+        id: fix-pin-curie
+        if: github.event_name == 'pull_request'
+        run: >-
+          python3 tools/fix-pin-ci/check.py
+          --event "$GITHUB_EVENT_PATH"
+          --needs-curie
       - name: Build the current curie binary for fix pin verification
         if: >-
           github.event_name == 'pull_request'
-          && contains(github.event.pull_request.body, 'Fix pin:')
+          && steps.fix-pin-curie.outputs.needed == 'true'
         run: cargo build --release --locked --manifest-path cli/Cargo.toml
       - name: Install Helm for fix pin verification
         if: >-
           github.event_name == 'pull_request'
-          && contains(github.event.pull_request.body, 'Fix pin:')
+          && steps.fix-pin-curie.outputs.needed == 'true'
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5
         with:
           version: v3.16.4

--- a/tools/fix-pin-ci/check.py
+++ b/tools/fix-pin-ci/check.py
@@ -67,8 +67,13 @@ class Declaration:
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
     parser.add_argument("--event", type=Path, required=True)
-    parser.add_argument("--curie", required=True)
-    parser.add_argument("--ref", required=True)
+    parser.add_argument("--curie")
+    parser.add_argument("--ref")
+    parser.add_argument(
+        "--needs-curie",
+        action="store_true",
+        help="report whether this body would invoke the curie binary",
+    )
     return parser
 
 
@@ -134,6 +139,37 @@ def _declaration(body: str) -> Declaration:
     return Declaration(selector=selector)
 
 
+def _needs_curie(body: str) -> bool:
+    """True iff ``main`` would invoke the curie binary for this body."""
+    try:
+        return _declaration(body).selector is not None
+    except ValueError:
+        return False
+
+
+def _report_needs_curie(event_path: Path) -> int:
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if not output_path:
+        print("Fix pin cargo guard error: GITHUB_OUTPUT is required", file=sys.stderr)
+        return 1
+
+    try:
+        needed = _needs_curie(_body(_event(event_path)))
+    except ValueError as error:
+        print(f"Fix pin declaration error: {error}", file=sys.stderr)
+        return 1
+
+    line = f"needed={'true' if needed else 'false'}\n"
+    try:
+        with Path(output_path).open("a", encoding="utf-8") as stream:
+            stream.write(line)
+    except OSError as error:
+        print(f"Fix pin cargo guard error: could not write GITHUB_OUTPUT: {error}", file=sys.stderr)
+        return 1
+    sys.stdout.write(line)
+    return 0
+
+
 def _closed_issues(body: str) -> list[int]:
     uncommented = COMMENT.sub("", body)
     numbers: list[int] = []
@@ -183,6 +219,11 @@ def _closed_bugs(event: dict[str, object], body: str) -> list[int]:
 
 def main(argv: Sequence[str] | None = None) -> int:
     arguments = _parser().parse_args(argv)
+    if arguments.needs_curie:
+        return _report_needs_curie(arguments.event)
+    if not arguments.curie or not arguments.ref:
+        print("Fix pin invocation error: --curie and --ref are required", file=sys.stderr)
+        return 2
 
     try:
         event = _event(arguments.event)

--- a/tools/fix-pin-ci/tests/test_fix_pin_ci.py
+++ b/tools/fix-pin-ci/tests/test_fix_pin_ci.py
@@ -170,6 +170,54 @@ def _gh_call_log(tmp_path: Path) -> Path:
     return tmp_path / "gh-argv.json"
 
 
+def _github_output(tmp_path: Path) -> Path:
+    return tmp_path / "github-output.txt"
+
+
+def _run_needs_curie(
+    tmp_path: Path,
+    body: str | None,
+    *,
+    include_body: bool = True,
+    github_output: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    """Invoke the cargo-guard probe. It must reuse the declaration parser."""
+    event_path = _write_event(tmp_path, body, include_body=include_body)
+    environment = {**os.environ}
+    if github_output:
+        environment["GITHUB_OUTPUT"] = str(_github_output(tmp_path))
+    else:
+        environment.pop("GITHUB_OUTPUT", None)
+    return subprocess.run(
+        [
+            sys.executable,
+            str(CHECKER),
+            "--event",
+            str(event_path),
+            "--needs-curie",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        check=False,
+        env=environment,
+        text=True,
+    )
+
+
+def _needed_output(tmp_path: Path) -> str:
+    return _github_output(tmp_path).read_text(encoding="utf-8")
+
+
+def _is_fix_pin_gate(step: dict[str, Any]) -> bool:
+    run = _string(step, "run")
+    return "tools/fix-pin-ci/check.py" in run and "--needs-curie" not in run
+
+
+def _is_fix_pin_probe(step: dict[str, Any]) -> bool:
+    run = _string(step, "run")
+    return "tools/fix-pin-ci/check.py" in run and "--needs-curie" in run
+
+
 @pytest.mark.parametrize(
     ("body", "include_body"),
     [
@@ -580,11 +628,8 @@ def test_ci_keeps_the_required_python_status_and_calls_fix_pin_after_pytest() ->
         "the Python suite must run unfiltered: only reporting flags may be added "
         f"to `uv run pytest -q`, got {pytest_command!r}"
     )
-    gate_index = _single_step_index(
-        steps,
-        lambda step: "tools/fix-pin-ci/check.py" in _string(step, "run"),
-        "fix pin caller",
-    )
+    probe_index = _single_step_index(steps, _is_fix_pin_probe, "fix pin cargo probe")
+    gate_index = _single_step_index(steps, _is_fix_pin_gate, "fix pin caller")
     gate = steps[gate_index]
     assert _pull_request_only(gate), "the verifier must not run for pushes"
     assert stack_index < migration_index < pytest_index < gate_index
@@ -605,6 +650,21 @@ def test_ci_keeps_the_required_python_status_and_calls_fix_pin_after_pytest() ->
     ]
     assert '--event "$GITHUB_EVENT_PATH"' in _string(gate, "run")
 
+    probe = steps[probe_index]
+    assert _string(probe, "if") == "github.event_name == 'pull_request'", (
+        "the cargo probe must run for every pull request, including bodies with "
+        "no live selector; gating it on its own output would skip the decision"
+    )
+    assert probe.get("id") == "fix-pin-curie"
+    assert shlex.split(_string(probe, "run")) == [
+        "python3",
+        "tools/fix-pin-ci/check.py",
+        "--event",
+        "$GITHUB_EVENT_PATH",
+        "--needs-curie",
+    ]
+    assert '--event "$GITHUB_EVENT_PATH"' in _string(probe, "run")
+
     release_build_index = _single_step_index(
         steps,
         lambda step: _string(step, "run").strip()
@@ -621,7 +681,7 @@ def test_ci_keeps_the_required_python_status_and_calls_fix_pin_after_pytest() ->
     for index in (release_build_index, helm_index):
         assert _pull_request_only(steps[index]), "selector tooling must not affect push runs"
         assert pytest_index < index < gate_index
-    assert release_build_index < helm_index < gate_index
+    assert pytest_index < probe_index < release_build_index < helm_index < gate_index
     assert not any(
         _string(step, "uses") == "Swatinem/rust-cache@v2" for step in steps
     ), "the Python job must build directly without a Cargo cache dependency"
@@ -641,27 +701,30 @@ def test_ci_keeps_the_required_python_status_and_calls_fix_pin_after_pytest() ->
     assert gate_index < diagnostic_index
 
 
-DECLARATION_GUARD = "contains(github.event.pull_request.body, 'Fix pin:')"
+CARGO_NEEDED_GUARD = "steps.fix-pin-curie.outputs.needed == 'true'"
+SUBSTRING_GUARD = "contains(github.event.pull_request.body, 'Fix pin:')"
 
 
-def test_selector_tooling_builds_only_when_the_body_declares_a_fix_pin() -> None:
-    """The cargo build must be gated on a declaration, and gated the safe way.
+def test_selector_tooling_builds_only_when_the_parser_would_invoke_curie() -> None:
+    """The cargo build must be gated on the declaration parser, not a substring.
 
     check.py reaches the binary at exactly one place, the `curie dev
     verify-fix-pin` call, and only once `declaration.selector` is set. `n/a`, no
-    declaration, a near-miss marker and the bug-without-declaration rejection all
-    return first. Building unconditionally therefore spent a cold
-    `cargo build --release` inside the longest job on the graph for a binary that
-    the majority of pull requests never run.
+    declaration, a near-miss marker, HTML-comment examples in the pull request
+    template, and the bug-without-declaration rejection all return first.
 
-    The guard must stay a strict SUPERSET of the cases that reach the binary.
-    `contains()` is case-insensitive and DECLARATION is the exact-case
-    `Fix pin: <selector>`, so a body that reaches the binary always contains the
-    substring. Skipping a build the gate then needs would be the unsafe
-    direction, and this pins that it cannot happen.
+    `#2228` gated cargo with `contains(..., 'Fix pin:')`. The default template
+    embeds those exact bytes inside `<!-- -->`, so the 3.5 min release build
+    still ran on every pull request that kept the template. The probe must
+    reuse `_declaration` so a commented example cannot trigger the build, and
+    a live `Fix pin: <selector>` line still cannot skip it.
     """
     document = _load_ci()
     _, steps = _python_job(document)
+
+    probe = steps[_single_step_index(steps, _is_fix_pin_probe, "fix pin cargo probe")]
+    assert probe.get("id") == "fix-pin-curie"
+    assert "--needs-curie" in shlex.split(_string(probe, "run"))
 
     for description, predicate in (
         (
@@ -678,24 +741,84 @@ def test_selector_tooling_builds_only_when_the_body_declares_a_fix_pin() -> None
         step = steps[_single_step_index(steps, predicate, description)]
         condition = _string(step, "if")
         assert PR_CONDITION.search(condition), f"{description} must stay pull-request only"
-        assert DECLARATION_GUARD in condition, (
-            f"{description} must build only when the body declares a Fix pin: {condition!r}"
+        assert CARGO_NEEDED_GUARD in condition, (
+            f"{description} must build only when the parser says the binary "
+            f"is needed: {condition!r}"
+        )
+        assert SUBSTRING_GUARD not in condition, (
+            f"{description} must not use the template-matching substring: {condition!r}"
         )
 
-    # The gate itself must NOT carry the guard. It is the step that decides a
-    # missing declaration is acceptable, and a body-shaped `if` on it would turn
-    # the "closes a bug with no declaration" rejection into a skipped step.
-    gate = steps[
-        _single_step_index(
-            steps,
-            lambda step: "tools/fix-pin-ci/check.py" in _string(step, "run"),
-            "fix pin caller",
-        )
-    ]
-    assert DECLARATION_GUARD not in _string(gate, "if"), (
+    # The gate itself must NOT carry the cargo guard. It is the step that
+    # decides a missing declaration is acceptable, and a body-shaped `if` on it
+    # would turn the "closes a bug with no declaration" rejection into a
+    # skipped step.
+    gate = steps[_single_step_index(steps, _is_fix_pin_gate, "fix pin caller")]
+    assert CARGO_NEEDED_GUARD not in _string(gate, "if"), (
         "the gate must still run for a body with no declaration, or the "
         "bug-without-declaration rejection can never fire"
     )
+    assert SUBSTRING_GUARD not in _string(gate, "if")
+
+
+def test_default_template_body_does_not_need_curie(tmp_path: Path) -> None:
+    """The template's commented `Fix pin:` examples must not trigger cargo."""
+    completed = _run_needs_curie(tmp_path, PR_TEMPLATE.read_text(encoding="utf-8"))
+
+    assert completed.returncode == 0, completed.stderr
+    assert _needed_output(tmp_path) == "needed=false\n"
+
+
+def test_real_selector_line_needs_curie(tmp_path: Path) -> None:
+    completed = _run_needs_curie(tmp_path, f"Fix pin: {VALID_SELECTOR}\n")
+
+    assert completed.returncode == 0, completed.stderr
+    assert _needed_output(tmp_path) == "needed=true\n"
+
+
+def test_template_plus_real_selector_still_needs_curie(tmp_path: Path) -> None:
+    body = PR_TEMPLATE.read_text(encoding="utf-8") + f"\nFix pin: {VALID_SELECTOR}\n"
+    completed = _run_needs_curie(tmp_path, body)
+
+    assert completed.returncode == 0, completed.stderr
+    assert _needed_output(tmp_path) == "needed=true\n"
+
+
+def test_not_applicable_does_not_need_curie(tmp_path: Path) -> None:
+    """`n/a` skips the verifier today, so cargo is extra work, not a requirement.
+
+    `#2228` documented building on `n/a` as a safe extra because `contains()`
+    could not tell it from a selector. The parser can, and the binary is not
+    invoked, so the probe reports needed=false.
+    """
+    completed = _run_needs_curie(
+        tmp_path, "Fix pin: n/a - the fix is a chart template with no test surface\n"
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert _needed_output(tmp_path) == "needed=false\n"
+
+
+def test_html_comment_selector_does_not_need_curie(tmp_path: Path) -> None:
+    completed = _run_needs_curie(tmp_path, f"<!-- Fix pin: {VALID_SELECTOR} -->\n")
+
+    assert completed.returncode == 0, completed.stderr
+    assert _needed_output(tmp_path) == "needed=false\n"
+
+
+def test_malformed_declaration_does_not_need_curie(tmp_path: Path) -> None:
+    """A declaration error fails the gate without calling curie."""
+    completed = _run_needs_curie(tmp_path, f" Fix pin: {VALID_SELECTOR}\n")
+
+    assert completed.returncode == 0, completed.stderr
+    assert _needed_output(tmp_path) == "needed=false\n"
+
+
+def test_needs_curie_fails_closed_without_github_output(tmp_path: Path) -> None:
+    completed = _run_needs_curie(tmp_path, f"Fix pin: {VALID_SELECTOR}\n", github_output=False)
+
+    assert completed.returncode != 0
+    assert "GITHUB_OUTPUT" in completed.stderr
 
 
 def test_pull_request_template_documents_the_required_declaration() -> None:


### PR DESCRIPTION
## Summary

Python CI was still spending about 3.5 minutes on a release cargo build after #2228 because the default pull request template embeds the declaration marker inside HTML comments and the job gated cargo with a substring match on the body. This PR asks `tools/fix-pin-ci/check.py` whether `_declaration` would actually invoke the curie binary, and builds only then.

A live selector line still builds. The default template does not. An explicit not-applicable reason no longer pays the extra build: the parser already skips the verifier for that case, and the probe now matches it.

This pull request body has no live selector line, so the Python job on this PR is the no-declaration proof: it must omit `cargo build --release`.

## Related issue

None. Spike 2026-09-03 option 1 (sequence A, before selector work and the Python job split).

## Fix pin verification

Not a bug-closing change. No selector.

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | Does not reach plugin or skill packaging, the runner turn loop, ACI events, or skill eval. | | |
| local | required | The change is the required Python CI job's cargo step. | live | This PR's Python job. Positive: probe writes needed=false and cargo is skipped. Negative: tests show a live selector writes needed=true. |
| local-release | n/a | Does not reach released binary identity, install path, version pins, or release compose. | | |
| cluster | n/a | Does not reach chart templates, RBAC, sandbox claims, or init containers. | | |
| live provider | n/a | Does not reach model routing or provider credentials. | | |
| external integration | n/a | Does not reach Slack, git push webhooks, connector OAuth, or a third-party API shape. | | |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

Local unit proof on this branch:

```
uv run pytest tools/fix-pin-ci/tests/test_fix_pin_ci.py -q
79 passed
```

- Default template body -> needed=false
- A live unindented selector line -> needed=true
- An explicit not-applicable reason -> needed=false
- HTML-comment selector -> needed=false

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [x] An ADR is added under `docs/adr/` if this is an architectural decision.
