### PR TITLE
Reject PRs whose closed issues target the other release train

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -555,6 +555,13 @@ and the role is what selects your base.
 | General bug fix, security fix, or change shared by both lines | `main` |
 | Feature for the next feature release, or a bug unique to that unreleased work | `next` |
 
+The GitHub milestone-to-train mapping that CI enforces lives in
+[`tools/fix-pin-ci/milestone-trains.json`](tools/fix-pin-ci/milestone-trains.json).
+A patch milestone maps to `main`; a feature milestone maps to `next`. A pull
+request that closes an issue whose milestone belongs to the other train fails,
+and a pull request that closes a `bug` issue with no milestone fails. The check
+reuses the existing fix-pin gate rather than adding a second workflow.
+
 Create a short lived `task/<short-description>` branch from the selected base:
 
 ```bash

--- a/tools/fix-pin-ci/check.py
+++ b/tools/fix-pin-ci/check.py
@@ -71,14 +71,17 @@ DISCOVERY_FIELD = re.compile(
     re.MULTILINE,
 )
 WAIVER = re.compile(r"^Fix pin waiver:\s*(?P<reason>.*)$")
+ISSUE_JQ = "{labels:[.labels[].name],body:.body,milestone:.milestone.title}"
+MAPPING_PATH = Path(__file__).resolve().with_name("milestone-trains.json")
 
 
 @dataclass(frozen=True)
 class IssueRecord:
-    """Labels and body of a closed GitHub issue the gate inspects."""
+    """Labels, body, and milestone of a closed GitHub issue the gate inspects."""
 
     labels: list[str]
     body: str
+    milestone: str | None
 
 
 @dataclass(frozen=True)
@@ -128,6 +131,47 @@ def _repository(event: dict[str, object]) -> str | None:
         if isinstance(full_name, str) and full_name:
             return full_name
     return os.environ.get("GITHUB_REPOSITORY") or None
+
+
+def _base_ref(event: dict[str, object]) -> str:
+    pull_request = event.get("pull_request")
+    if not isinstance(pull_request, dict):
+        raise ValueError("pull request event is missing pull_request")
+    base = pull_request.get("base")
+    if not isinstance(base, dict):
+        raise ValueError("pull request is missing base")
+    ref = base.get("ref")
+    if not isinstance(ref, str) or not ref:
+        raise ValueError("pull request base ref is missing")
+    return ref
+
+
+def _milestone_trains(path: Path = MAPPING_PATH) -> dict[str, str]:
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValueError(f"could not read {path.name}: {error}") from error
+    if not isinstance(raw, dict):
+        raise ValueError(f"{path.name} must be an object")
+
+    trains = raw.get("trains")
+    milestones = raw.get("milestones")
+    if not isinstance(trains, dict) or not all(
+        isinstance(kind, str) and isinstance(branch, str) for kind, branch in trains.items()
+    ):
+        raise ValueError(f"{path.name} trains must map kind names to branches")
+    if not isinstance(milestones, dict) or not all(
+        isinstance(name, str) and isinstance(kind, str) for name, kind in milestones.items()
+    ):
+        raise ValueError(f"{path.name} milestones must map titles to train kinds")
+
+    mapping: dict[str, str] = {}
+    for name, kind in milestones.items():
+        branch = trains.get(kind)
+        if not isinstance(branch, str) or not branch:
+            raise ValueError(f"{path.name} milestone {name!r} has unknown train kind {kind!r}")
+        mapping[name] = branch
+    return mapping
 
 
 def _declaration(body: str) -> Declaration:
@@ -225,7 +269,7 @@ def _issue_record(repository: str | None, issue: int) -> IssueRecord:
             "api",
             f"repos/{repository}/issues/{issue}",
             "--jq",
-            "{labels:[.labels[].name],body:.body}",
+            ISSUE_JQ,
         ],
         capture_output=True,
         check=False,
@@ -249,7 +293,15 @@ def _issue_record(repository: str | None, issue: int) -> IssueRecord:
         body = ""
     if not isinstance(body, str):
         raise ValueError(f"could not parse the body of issue #{issue}: not a string")
-    return IssueRecord(labels=[label for label in labels if isinstance(label, str)], body=body)
+    milestone = payload.get("milestone")
+    if milestone is not None and not isinstance(milestone, str):
+        raise ValueError(f"could not parse the milestone of issue #{issue}")
+    title = milestone.strip() if isinstance(milestone, str) and milestone.strip() else None
+    return IssueRecord(
+        labels=[label for label in labels if isinstance(label, str)],
+        body=body,
+        milestone=title,
+    )
 
 
 def _closed_issue_records(
@@ -260,6 +312,34 @@ def _closed_issue_records(
         return []
     repository = _repository(event)
     return [(issue, _issue_record(repository, issue)) for issue in issues]
+
+
+def _check_milestone_trains(
+    event: dict[str, object], records: list[tuple[int, IssueRecord]]
+) -> None:
+    if not records:
+        return
+    base = _base_ref(event)
+    trains = _milestone_trains()
+    for number, record in records:
+        if record.milestone is None:
+            if BUG_LABEL in record.labels:
+                raise ValueError(
+                    f"bug issue #{number} has no milestone; "
+                    "assign a patch milestone (main) or a feature milestone (next)"
+                )
+            continue
+        train = trains.get(record.milestone)
+        if train is None:
+            raise ValueError(
+                f"issue #{number} milestone {record.milestone!r} is not in "
+                f"{MAPPING_PATH.name}; add it as patch (main) or feature (next)"
+            )
+        if train != base:
+            raise ValueError(
+                f"issue #{number} milestone {record.milestone} maps to {train}, "
+                f"but this pull request targets {base}"
+            )
 
 
 def _closed_bugs(event: dict[str, object], body: str) -> list[int]:
@@ -302,6 +382,18 @@ def main(argv: Sequence[str] | None = None) -> int:
             else "Fix pin declaration error"
         )
         print(f"{prefix}: {message}", file=sys.stderr)
+        return 1
+
+    try:
+        records = _closed_issue_records(event, body)
+    except ValueError as error:
+        print(f"Fix pin requirement error: {error}", file=sys.stderr)
+        return 1
+
+    try:
+        _check_milestone_trains(event, records)
+    except ValueError as error:
+        print(f"Milestone train error: {error}", file=sys.stderr)
         return 1
 
     if declaration.not_applicable is not None:

--- a/tools/fix-pin-ci/milestone-trains.json
+++ b/tools/fix-pin-ci/milestone-trains.json
@@ -1,0 +1,22 @@
+{
+  "trains": {
+    "patch": "main",
+    "feature": "next"
+  },
+  "milestones": {
+    "v0.6.0": "patch",
+    "v0.6.1": "patch",
+    "v0.6.2": "patch",
+    "v0.7.0": "patch",
+    "v0.7.1": "patch",
+    "v0.7.2": "patch",
+    "v0.7.3": "patch",
+    "v0.8.0": "patch",
+    "v0.8.1": "patch",
+    "v0.8.2": "patch",
+    "v0.8.3": "patch",
+    "v0.8.4": "patch",
+    "v0.8.5": "patch",
+    "v0.9.0": "feature"
+  }
+}

--- a/tools/fix-pin-ci/tests/test_fix_pin_ci.py
+++ b/tools/fix-pin-ci/tests/test_fix_pin_ci.py
@@ -41,8 +41,9 @@ def _write_event(
     *,
     action: str = "opened",
     include_body: bool = True,
+    base_ref: str = "next",
 ) -> Path:
-    pull_request: dict[str, object] = {}
+    pull_request: dict[str, object] = {"base": {"ref": base_ref}}
     if include_body:
         pull_request["body"] = body
     event_path = tmp_path / "event.json"
@@ -106,11 +107,15 @@ def _write_fake_curie(tmp_path: Path) -> tuple[Path, Path]:
     )
 
 
-def _gh_issue_payload(gh_labels: str, gh_body: str = "") -> str:
-    """The gate reads `{labels, body}` so a found:* form field is visible."""
+def _gh_issue_payload(
+    gh_labels: str, gh_body: str = "", gh_milestone: str | None = "v0.9.0"
+) -> str:
+    """The gate reads `{labels, body, milestone}` so found:* and train mapping work."""
     parsed = json.loads(gh_labels)
     if isinstance(parsed, list):
-        return json.dumps({"labels": parsed, "body": gh_body})
+        return json.dumps(
+            {"labels": parsed, "body": gh_body, "milestone": gh_milestone}
+        )
     return gh_labels
 
 
@@ -139,10 +144,14 @@ def _run_checker(
     timeout: float | None = None,
     gh_labels: str = "[]",
     gh_body: str = "",
+    gh_milestone: str | None = "v0.9.0",
     gh_exit: int = 0,
     gh_on_path: bool = True,
+    base_ref: str = "next",
 ) -> tuple[subprocess.CompletedProcess[str], Path]:
-    event_path = _write_event(tmp_path, body, action=action, include_body=include_body)
+    event_path = _write_event(
+        tmp_path, body, action=action, include_body=include_body, base_ref=base_ref
+    )
     curie, call_log = _write_fake_curie(tmp_path)
     binaries, gh_call_log = _write_fake_gh(tmp_path)
     environment = {
@@ -151,7 +160,7 @@ def _run_checker(
         "FIX_PIN_EXIT": str(verifier_exit),
         "FIX_PIN_OUTPUT": verifier_stdout,
         "FIX_PIN_GH_CALL_LOG": str(gh_call_log),
-        "FIX_PIN_GH_LABELS": _gh_issue_payload(gh_labels, gh_body),
+        "FIX_PIN_GH_LABELS": _gh_issue_payload(gh_labels, gh_body, gh_milestone),
         "FIX_PIN_GH_EXIT": str(gh_exit),
         "GITHUB_REPOSITORY": "curie-eng/curie",
         # An empty PATH is how "gh is not installed" is expressed; the checker
@@ -695,7 +704,7 @@ def test_closing_a_bug_issue_without_a_declaration_fails_and_names_the_issue(
         "api",
         "repos/curie-eng/curie/issues/12",
         "--jq",
-        "{labels:[.labels[].name],body:.body}",
+        "{labels:[.labels[].name],body:.body,milestone:.milestone.title}",
     ]
 
 
@@ -1070,3 +1079,139 @@ def test_pull_request_template_documents_the_tier_waiver() -> None:
     template = PR_TEMPLATE.read_text(encoding="utf-8")
     assert "Fix pin waiver: <reason>" in template
     assert "found:live" in template
+
+
+FEATURE_MILESTONE = "v0.9.0"
+PATCH_MILESTONE = "v0.8.5"
+MAPPING_PATH = REPO_ROOT / "tools" / "fix-pin-ci" / "milestone-trains.json"
+NA_BODY = "Closes #12\n\nFix pin: n/a - the fix is a chart template with no test surface\n"
+
+
+def test_matching_milestone_train_passes(tmp_path: Path) -> None:
+    completed, call_log = _run_checker(
+        tmp_path,
+        NA_BODY,
+        gh_labels=BUG_LABELS,
+        gh_milestone=FEATURE_MILESTONE,
+        base_ref="next",
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.startswith("SKIPPED: Fix pin declared not applicable")
+    assert _gh_call_log(tmp_path).exists(), "a closed issue must be looked up even when excused"
+    assert not call_log.exists(), "an excused declaration must not run curie"
+
+
+def test_matching_patch_milestone_on_main_passes(tmp_path: Path) -> None:
+    completed, call_log = _run_checker(
+        tmp_path,
+        NA_BODY,
+        gh_labels=BUG_LABELS,
+        gh_milestone=PATCH_MILESTONE,
+        base_ref="main",
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.startswith("SKIPPED: Fix pin declared not applicable")
+    assert _gh_call_log(tmp_path).exists(), "a closed issue must be looked up even when excused"
+    assert not call_log.exists(), "an excused declaration must not run curie"
+
+
+def test_mismatched_milestone_train_fails(tmp_path: Path) -> None:
+    completed, call_log = _run_checker(
+        tmp_path,
+        NA_BODY,
+        gh_labels=BUG_LABELS,
+        gh_milestone=PATCH_MILESTONE,
+        base_ref="next",
+    )
+    shown = f"{completed.stdout}\n{completed.stderr}"
+
+    assert completed.returncode != 0, shown
+    assert "#12" in completed.stderr, shown
+    assert PATCH_MILESTONE in completed.stderr, shown
+    assert "main" in completed.stderr, shown
+    assert "next" in completed.stderr, shown
+    assert not call_log.exists(), "a train mismatch must not reach curie"
+
+
+def test_missing_milestone_on_a_bug_fails(tmp_path: Path) -> None:
+    completed, call_log = _run_checker(
+        tmp_path,
+        NA_BODY,
+        gh_labels=BUG_LABELS,
+        gh_milestone=None,
+        base_ref="next",
+    )
+    shown = f"{completed.stdout}\n{completed.stderr}"
+
+    assert completed.returncode != 0, shown
+    assert "#12" in completed.stderr, shown
+    assert "milestone" in completed.stderr.lower(), shown
+    assert not call_log.exists(), "a bug without a milestone must not reach curie"
+
+
+def test_missing_milestone_on_a_non_bug_is_allowed(tmp_path: Path) -> None:
+    completed, call_log = _run_checker(
+        tmp_path,
+        "Closes #12\n",
+        gh_labels='["enhancement"]',
+        gh_milestone=None,
+        base_ref="next",
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.strip() == "SKIPPED: no Fix pin declaration"
+    assert not call_log.exists(), "a non bug without a milestone must not run curie"
+
+
+def test_mismatched_train_fails_even_when_a_selector_is_declared(tmp_path: Path) -> None:
+    completed, call_log = _run_checker(
+        tmp_path,
+        f"Closes #12\n\nFix pin: {VALID_SELECTOR}\n",
+        gh_labels=BUG_LABELS,
+        gh_milestone=PATCH_MILESTONE,
+        base_ref="next",
+    )
+    shown = f"{completed.stdout}\n{completed.stderr}"
+
+    assert completed.returncode != 0, shown
+    assert PATCH_MILESTONE in completed.stderr, shown
+    assert not call_log.exists(), "a train mismatch must not reach the verifier"
+
+
+def test_unknown_milestone_fails_closed(tmp_path: Path) -> None:
+    completed, call_log = _run_checker(
+        tmp_path,
+        NA_BODY,
+        gh_labels=BUG_LABELS,
+        gh_milestone="v9.9.9",
+        base_ref="next",
+    )
+    shown = f"{completed.stdout}\n{completed.stderr}"
+
+    assert completed.returncode != 0, shown
+    assert "v9.9.9" in completed.stderr, shown
+    assert not call_log.exists(), "an unmapped milestone must not open the gate"
+
+
+def test_milestone_mapping_sends_patch_to_main_and_feature_to_next() -> None:
+    mapping = json.loads(MAPPING_PATH.read_text(encoding="utf-8"))
+    trains = mapping["trains"]
+    milestones = mapping["milestones"]
+
+    assert trains == {"patch": "main", "feature": "next"}
+    assert milestones[FEATURE_MILESTONE] == "feature"
+    assert milestones[PATCH_MILESTONE] == "patch"
+    assert set(trains.values()) == {"main", "next"}
+    assert set(milestones.values()) <= {"patch", "feature"}
+
+
+def test_agents_md_cites_the_mapping_next_to_the_release_train_table() -> None:
+    agents = (REPO_ROOT / "AGENTS.md").read_text(encoding="utf-8")
+    heading = "## Release train, branch, and commit conventions"
+    start = agents.index(heading)
+    window = agents[start : start + 2500]
+
+    assert "milestone-trains.json" in window
+    assert "`main`" in window and "`next`" in window


### PR DESCRIPTION
## Summary

CI now rejects a pull request whose closed issues belong on the other release train, and rejects a `bug` issue with no milestone at all. The mapping of GitHub milestones to trains lives in `tools/fix-pin-ci/milestone-trains.json`, cited next to the release-train table in AGENTS.md. Patch milestones map to `main`; the current feature milestone (`v0.9.0`) maps to `next`.

The check extends the existing fix-pin gate. One `gh api` Issues lookup now returns labels and milestone together. There is no new workflow.

## Related issue

Closes #2244

## Fix pin verification

Fix pin: n/a - the gate's own selector grammar does not admit `tools/` paths (an existing test asserts `tools/fix-pin-ci/tests/test_fix_pin_ci.py::...` is unsupported), so there is no declarable selector for a change to the gate itself.

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | Plugin packaging, the runner turn loop, ACI events, and skill eval/check are unchanged. | n/a | n/a |
| local | required | The gate is `tools/fix-pin-ci/check.py` invoked the same way the Python CI job invokes it. | fake | `uv run pytest -q tools/fix-pin-ci/tests/test_fix_pin_ci.py` on `7bfa54e1c` - 81 passed, including matching train, mismatched train, and missing milestone. |
| local-release | n/a | Released binary and image identity are unchanged. | n/a | n/a |
| cluster | n/a | Chart templates, RBAC, sandbox claims, and init containers are unchanged. | n/a | n/a |
| live provider | n/a | Model routing, credentials, and provider auth are unchanged. | n/a | n/a |
| external integration | n/a | Does not drive Slack, git webhooks, or a live GitHub Issues API; `gh` is faked on the gate's existing consumer path. | n/a | n/a |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

Positive: matching `v0.9.0` on `next` (and `v0.8.5` on `main`) exits 0.
Negative: `v0.8.5` on `next` exits non-zero; a `bug` with no milestone exits non-zero even with `Fix pin: n/a`.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [ ] An ADR is added under `docs/adr/` if this is an architectural decision.
