### PR TITLE
Require a fix-pin at the issue discovery-surface tier

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -30,18 +30,21 @@ body:
       required: true
 
   - type: dropdown
-    id: tier
+    id: found
     attributes:
-      label: Which tier were you running?
+      label: Discovery surface
       description: >-
-        `skill` is a local runner session for one bundle, `local` is the
-        Docker Compose stack, `cluster` is a deployed Kubernetes release.
+        Where the defect was observed. Apply the matching `found:*` label on
+        the issue; the fix-pin gate reads that label and rejects a pin below
+        this surface unless the pull request carries `Fix pin waiver:`.
+        `found:unit` is a unit test or skill runner, `found:local` is the
+        Docker Compose stack, `found:cluster` is a deployed Kubernetes
+        release, `found:live` is a live provider or Slack.
       options:
-        - skill
-        - local
-        - cluster
-        - Not sure
-        - Other (describe below)
+        - found:unit
+        - found:local
+        - found:cluster
+        - found:live
     validations:
       required: true
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -32,6 +32,14 @@ Fix pin: <supported selector>
      reason:
 Fix pin: n/a - <reason>
 
+     The pin's tier is derived from the selector's location, not from prose:
+     unit tests, charts/curie/ci/* (cluster helm-render), or test_live.py
+     (live). If the closed issue carries found:unit, found:local,
+     found:cluster, or found:live and the pin is below that surface, add:
+Fix pin waiver: <reason>
+
+     A unit pin for a found:live issue fails without that waiver.
+
      For a non fix pull request that does not close a bug-labeled issue, leave
      this section empty. -->
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,6 +142,10 @@ A fix PR changing `apps/*/tests/`, `packages/*/tests/`, `runner/tests/`, `cli/te
 A PR closing a `bug`-labeled issue includes exactly one `Fix pin: <SELECTOR>` line in its body,
 or an explicit `Fix pin: n/a - <reason>` line; CI enforces this. A PR closing no bug-labeled issue may omit
 the declaration, but a selector supplied voluntarily on any PR is still verified.
+The pin's tier is derived from the selector's location (unit tests, `charts/curie/ci/*`,
+`test_live.py`), not from prose. A pin below the closed issue's `found:unit` /
+`found:local` / `found:cluster` / `found:live` label fails unless the body also carries
+`Fix pin waiver: <reason>`.
 Assertions about an external API or SDK's shape or auth must be grounded in
 provider docs or observed behavior, cited in a test comment, never in the
 implementation's own assumption. Any read-modify-write on a versioned row needs a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,6 +181,7 @@ testpaths = [
     "tools/ci-workflow-paths/tests",
     "tools/e2e-ci-selection/tests",
     "tools/sdk-lock-gate/tests",
+    "tools/fix-pin-ci/tests",
 ]
 
 [tool.ruff]

--- a/tools/fix-pin-ci/check.py
+++ b/tools/fix-pin-ci/check.py
@@ -54,6 +54,31 @@ SELECTOR = re.compile(
     r")"
 )
 BUG_LABEL = "bug"
+# Discovery surfaces and pin tiers share this order. A pin whose location maps
+# below the closed issue's found:* label fails unless the body also carries
+# `Fix pin waiver: <reason>`. Location, not prose, decides the pin tier:
+# */test_live.py -> live, charts/curie/ci/* -> cluster, everything else that
+# the selector grammar admits -> unit. Ladder rungs are not a declared
+# selector form yet, so a found:local issue with a unit pin needs a waiver.
+TIERS = ("unit", "local", "cluster", "live")
+TIER_RANK = {name: index for index, name in enumerate(TIERS)}
+FOUND_LABELS = {f"found:{name}": name for name in TIERS}
+# GitHub issue forms render the required dropdown as a heading plus the
+# selected option. Scan only that section so a narrative "not found:live" in
+# the reproduction notes cannot raise the floor.
+DISCOVERY_FIELD = re.compile(
+    r"^### Discovery surface[ \t]*\r?\n+(?:[ \t]*\r?\n)*found:(?P<tier>unit|local|cluster|live)\b",
+    re.MULTILINE,
+)
+WAIVER = re.compile(r"^Fix pin waiver:\s*(?P<reason>.*)$")
+
+
+@dataclass(frozen=True)
+class IssueRecord:
+    """Labels and body of a closed GitHub issue the gate inspects."""
+
+    labels: list[str]
+    body: str
 
 
 @dataclass(frozen=True)
@@ -134,6 +159,46 @@ def _declaration(body: str) -> Declaration:
     return Declaration(selector=selector)
 
 
+def _waiver(body: str) -> str | None:
+    uncommented = COMMENT.sub("", body)
+    reasons = [
+        match.group("reason").strip()
+        for line in uncommented.splitlines()
+        if (match := WAIVER.fullmatch(line)) is not None
+    ]
+    if not reasons:
+        return None
+    if len(reasons) != 1:
+        raise ValueError("Fix pin waiver must be exactly one unindented line")
+    if not reasons[0]:
+        raise ValueError("Fix pin waiver must state why, as `Fix pin waiver: <reason>`")
+    return reasons[0]
+
+
+def _pin_tier(selector: str) -> str:
+    path = selector.split("::", 1)[0]
+    filename = path.rsplit("/", 1)[-1]
+    # Location only. test_live.py is the live pin the ticket names; the Python
+    # CI job does not currently export CURIE_E2E_LIVE, so a live selector still
+    # has to survive verify-fix-pin on its own. Until that job can run live
+    # tests, a found:live bug is expected to use a lower-tier pin plus
+    # `Fix pin waiver:`.
+    if filename == "test_live.py":
+        return "live"
+    if path.startswith("charts/curie/ci/"):
+        return "cluster"
+    return "unit"
+
+
+def _discovery_tier(labels: Sequence[str], body: str = "") -> str | None:
+    found = [FOUND_LABELS[label] for label in labels if label in FOUND_LABELS]
+    if (field := DISCOVERY_FIELD.search(body)) is not None:
+        found.append(field.group("tier"))
+    if not found:
+        return None
+    return max(found, key=lambda tier: TIER_RANK[tier])
+
+
 def _closed_issues(body: str) -> list[int]:
     uncommented = COMMENT.sub("", body)
     numbers: list[int] = []
@@ -145,7 +210,7 @@ def _closed_issues(body: str) -> list[int]:
     return numbers
 
 
-def _labels(repository: str | None, issue: int) -> list[str]:
+def _issue_record(repository: str | None, issue: int) -> IssueRecord:
     gh = shutil.which("gh")
     if gh is None:
         raise ValueError(f"gh is not on PATH, so the labels of issue #{issue} cannot be read")
@@ -155,7 +220,13 @@ def _labels(repository: str | None, issue: int) -> list[str]:
         )
 
     completed = subprocess.run(
-        [gh, "api", f"repos/{repository}/issues/{issue}", "--jq", "[.labels[].name]"],
+        [
+            gh,
+            "api",
+            f"repos/{repository}/issues/{issue}",
+            "--jq",
+            "{labels:[.labels[].name],body:.body}",
+        ],
         capture_output=True,
         check=False,
     )
@@ -164,21 +235,55 @@ def _labels(repository: str | None, issue: int) -> list[str]:
         raise ValueError(f"could not read the labels of issue #{issue}: {detail}")
 
     try:
-        labels = json.loads(completed.stdout.decode("utf-8"))
+        payload = json.loads(completed.stdout.decode("utf-8"))
     except (UnicodeDecodeError, json.JSONDecodeError) as error:
         raise ValueError(f"could not parse the labels of issue #{issue}: {error}") from error
 
+    if not isinstance(payload, dict):
+        raise ValueError(f"could not parse the labels of issue #{issue}: not an object")
+    labels = payload.get("labels")
     if not isinstance(labels, list) or not all(isinstance(label, str) for label in labels):
         raise ValueError(f"could not parse the labels of issue #{issue}: not a list of names")
-    return [label for label in labels if isinstance(label, str)]
+    body = payload.get("body")
+    if body is None:
+        body = ""
+    if not isinstance(body, str):
+        raise ValueError(f"could not parse the body of issue #{issue}: not a string")
+    return IssueRecord(labels=[label for label in labels if isinstance(label, str)], body=body)
 
 
-def _closed_bugs(event: dict[str, object], body: str) -> list[int]:
+def _closed_issue_records(
+    event: dict[str, object], body: str
+) -> list[tuple[int, IssueRecord]]:
     issues = _closed_issues(body)
     if not issues:
         return []
     repository = _repository(event)
-    return [issue for issue in issues if BUG_LABEL in _labels(repository, issue)]
+    return [(issue, _issue_record(repository, issue)) for issue in issues]
+
+
+def _closed_bugs(event: dict[str, object], body: str) -> list[int]:
+    return [
+        issue
+        for issue, record in _closed_issue_records(event, body)
+        if BUG_LABEL in record.labels
+    ]
+
+
+def _required_discovery(
+    event: dict[str, object], body: str
+) -> str | None:
+    """Highest found:* label or body field among closed bug issues."""
+    found: list[str] = []
+    for _issue, record in _closed_issue_records(event, body):
+        if BUG_LABEL not in record.labels:
+            continue
+        tier = _discovery_tier(record.labels, record.body)
+        if tier is not None:
+            found.append(tier)
+    if not found:
+        return None
+    return max(found, key=lambda tier: TIER_RANK[tier])
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -188,8 +293,15 @@ def main(argv: Sequence[str] | None = None) -> int:
         event = _event(arguments.event)
         body = _body(event)
         declaration = _declaration(body)
+        waiver = _waiver(body)
     except ValueError as error:
-        print(f"Fix pin declaration error: {error}", file=sys.stderr)
+        message = str(error)
+        prefix = (
+            "Fix pin waiver error"
+            if message.startswith("Fix pin waiver")
+            else "Fix pin declaration error"
+        )
+        print(f"{prefix}: {message}", file=sys.stderr)
         return 1
 
     if declaration.not_applicable is not None:
@@ -213,6 +325,22 @@ def main(argv: Sequence[str] | None = None) -> int:
             return 1
         print("SKIPPED: no Fix pin declaration")
         return 0
+
+    try:
+        required = _required_discovery(event, body)
+    except ValueError as error:
+        print(f"Fix pin requirement error: {error}", file=sys.stderr)
+        return 1
+    if required is not None:
+        pin = _pin_tier(declaration.selector)
+        if TIER_RANK[pin] < TIER_RANK[required] and waiver is None:
+            print(
+                f"Fix pin tier error: selector {declaration.selector} is a {pin} "
+                f"pin, which is below the discovery surface found:{required}. "
+                f"Pin at found:{required} or add a `Fix pin waiver: <reason>` line.",
+                file=sys.stderr,
+            )
+            return 1
 
     completed = subprocess.run(
         [arguments.curie, "dev", "verify-fix-pin", arguments.ref, declaration.selector],

--- a/tools/fix-pin-ci/tests/test_fix_pin_ci.py
+++ b/tools/fix-pin-ci/tests/test_fix_pin_ci.py
@@ -25,9 +25,13 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 CHECKER = REPO_ROOT / "tools" / "fix-pin-ci" / "check.py"
 CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yaml"
 PR_TEMPLATE = REPO_ROOT / ".github" / "PULL_REQUEST_TEMPLATE.md"
+BUG_REPORT = REPO_ROOT / ".github" / "ISSUE_TEMPLATE" / "bug_report.yml"
+PYPROJECT = REPO_ROOT / "pyproject.toml"
 VERIFY_FIX_PIN = REPO_ROOT / "cli" / "scripts" / "verify-fix-pin.sh"
 
 VALID_SELECTOR = "apps/api/tests/test_fix_pin_ci_gate.py::test_exact_declaration"
+LIVE_SELECTOR = "runner/tests/test_live.py::test_example"
+CHART_SELECTOR = "charts/curie/ci/render-assertions.sh"
 PR_CONDITION = re.compile(r"github\.event_name\s*==\s*['\"]pull_request['\"]")
 
 
@@ -102,6 +106,14 @@ def _write_fake_curie(tmp_path: Path) -> tuple[Path, Path]:
     )
 
 
+def _gh_issue_payload(gh_labels: str, gh_body: str = "") -> str:
+    """The gate reads `{labels, body}` so a found:* form field is visible."""
+    parsed = json.loads(gh_labels)
+    if isinstance(parsed, list):
+        return json.dumps({"labels": parsed, "body": gh_body})
+    return gh_labels
+
+
 def _write_fake_gh(tmp_path: Path) -> tuple[Path, Path]:
     """Install a fake ``gh`` in its own directory so PATH shadows nothing else."""
     return _write_fake_binary(
@@ -126,6 +138,7 @@ def _run_checker(
     verifier_stdout: str = "PINNED\n",
     timeout: float | None = None,
     gh_labels: str = "[]",
+    gh_body: str = "",
     gh_exit: int = 0,
     gh_on_path: bool = True,
 ) -> tuple[subprocess.CompletedProcess[str], Path]:
@@ -138,7 +151,7 @@ def _run_checker(
         "FIX_PIN_EXIT": str(verifier_exit),
         "FIX_PIN_OUTPUT": verifier_stdout,
         "FIX_PIN_GH_CALL_LOG": str(gh_call_log),
-        "FIX_PIN_GH_LABELS": gh_labels,
+        "FIX_PIN_GH_LABELS": _gh_issue_payload(gh_labels, gh_body),
         "FIX_PIN_GH_EXIT": str(gh_exit),
         "GITHUB_REPOSITORY": "curie-eng/curie",
         # An empty PATH is how "gh is not installed" is expressed; the checker
@@ -622,7 +635,7 @@ def test_ci_keeps_the_required_python_status_and_calls_fix_pin_after_pytest() ->
 
     diagnostic_index = _single_step_index(
         steps,
-        lambda step: "docker compose -f compose.dev.yaml logs" in _string(step, "run")
+        lambda step: "compose.dev.yaml logs" in _string(step, "run")
         and _string(step, "if") == "failure()",
         "failure stack diagnostic",
     )
@@ -654,6 +667,10 @@ def test_pull_request_template_documents_the_required_declaration() -> None:
 
 
 BUG_LABELS = '["bug"]'
+FOUND_LIVE_LABELS = '["bug", "found:live"]'
+FOUND_UNIT_LABELS = '["bug", "found:unit"]'
+FOUND_LOCAL_LABELS = '["bug", "found:local"]'
+FOUND_CLUSTER_LABELS = '["bug", "found:cluster"]'
 
 # Split across the slash so this repo's gitleaks `cross-repo-issue-ref` rule does not read the
 # fixture as a real cross-repo citation. The checker must still see the joined form, because
@@ -678,7 +695,7 @@ def test_closing_a_bug_issue_without_a_declaration_fails_and_names_the_issue(
         "api",
         "repos/curie-eng/curie/issues/12",
         "--jq",
-        "[.labels[].name]",
+        "{labels:[.labels[].name],body:.body}",
     ]
 
 
@@ -823,3 +840,233 @@ def test_missing_gh_fails_closed_without_calling_curie(tmp_path: Path) -> None:
     assert completed.returncode != 0
     assert "#12" in completed.stderr
     assert not call_log.exists(), "an unavailable label API must not open the gate"
+
+
+def test_unit_pin_for_a_found_live_issue_fails_without_a_waiver(tmp_path: Path) -> None:
+    """A unit selector cannot pin a defect found on a live surface (#2243)."""
+    completed, call_log = _run_checker(
+        tmp_path,
+        f"Closes #12\n\nFix pin: {VALID_SELECTOR}\n",
+        gh_labels=FOUND_LIVE_LABELS,
+    )
+    shown = f"{completed.stdout}\n{completed.stderr}"
+
+    assert completed.returncode != 0, shown
+    assert "found:live" in completed.stderr, shown
+    assert "unit" in completed.stderr, shown
+    assert "Fix pin waiver:" in completed.stderr, shown
+    assert not call_log.exists(), "a pin below the discovery surface must not reach curie"
+
+
+def test_unit_pin_for_a_found_live_issue_passes_with_a_waiver(tmp_path: Path) -> None:
+    """The explicit waiver is the only way a below-surface pin may proceed."""
+    completed, call_log = _run_checker(
+        tmp_path,
+        (
+            f"Closes #12\n\nFix pin: {VALID_SELECTOR}\n"
+            "Fix pin waiver: live retest is manual; the unit pin covers the regression\n"
+        ),
+        gh_labels=FOUND_LIVE_LABELS,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert json.loads(call_log.read_text(encoding="utf-8")) == [
+        "dev",
+        "verify-fix-pin",
+        "HEAD",
+        VALID_SELECTOR,
+    ]
+
+
+def test_live_pin_for_a_found_live_issue_passes_without_a_waiver(tmp_path: Path) -> None:
+    completed, call_log = _run_checker(
+        tmp_path,
+        f"Closes #12\n\nFix pin: {LIVE_SELECTOR}\n",
+        gh_labels=FOUND_LIVE_LABELS,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert json.loads(call_log.read_text(encoding="utf-8")) == [
+        "dev",
+        "verify-fix-pin",
+        "HEAD",
+        LIVE_SELECTOR,
+    ]
+
+
+def test_helm_render_pin_for_a_found_live_issue_fails_without_a_waiver(
+    tmp_path: Path,
+) -> None:
+    completed, call_log = _run_checker(
+        tmp_path,
+        f"Closes #12\n\nFix pin: {CHART_SELECTOR}\n",
+        gh_labels=FOUND_LIVE_LABELS,
+    )
+    shown = f"{completed.stdout}\n{completed.stderr}"
+
+    assert completed.returncode != 0, shown
+    assert "found:live" in completed.stderr, shown
+    assert "cluster" in completed.stderr, shown
+    assert not call_log.exists(), "a helm-render pin must not pass for a live-found issue"
+
+
+def test_unit_pin_for_a_found_unit_issue_passes_without_a_waiver(tmp_path: Path) -> None:
+    completed, call_log = _run_checker(
+        tmp_path,
+        f"Closes #12\n\nFix pin: {VALID_SELECTOR}\n",
+        gh_labels=FOUND_UNIT_LABELS,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert call_log.exists(), "an at-surface pin must still be verified"
+
+
+def test_unit_pin_for_a_found_local_issue_fails_without_a_waiver(tmp_path: Path) -> None:
+    completed, call_log = _run_checker(
+        tmp_path,
+        f"Closes #12\n\nFix pin: {VALID_SELECTOR}\n",
+        gh_labels=FOUND_LOCAL_LABELS,
+    )
+    shown = f"{completed.stdout}\n{completed.stderr}"
+
+    assert completed.returncode != 0, shown
+    assert "found:local" in completed.stderr, shown
+    assert not call_log.exists(), "a unit pin must not pass for a local-found issue"
+
+
+def test_helm_render_pin_for_a_found_cluster_issue_passes_without_a_waiver(
+    tmp_path: Path,
+) -> None:
+    completed, call_log = _run_checker(
+        tmp_path,
+        f"Closes #12\n\nFix pin: {CHART_SELECTOR}\n",
+        gh_labels=FOUND_CLUSTER_LABELS,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert json.loads(call_log.read_text(encoding="utf-8")) == [
+        "dev",
+        "verify-fix-pin",
+        "HEAD",
+        CHART_SELECTOR,
+    ]
+
+
+def test_unlabeled_bug_with_a_unit_pin_keeps_no_tier_floor(tmp_path: Path) -> None:
+    """Existing bugs without a found:* label keep the pre-#2243 behaviour."""
+    completed, call_log = _run_checker(
+        tmp_path,
+        f"Closes #12\n\nFix pin: {VALID_SELECTOR}\n",
+        gh_labels=BUG_LABELS,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert call_log.exists(), "an unlabeled bug must still verify a declared selector"
+
+
+def test_waiver_without_a_reason_fails_closed_without_calling_curie(tmp_path: Path) -> None:
+    completed, call_log = _run_checker(
+        tmp_path,
+        f"Closes #12\n\nFix pin: {VALID_SELECTOR}\nFix pin waiver:\n",
+        gh_labels=FOUND_LIVE_LABELS,
+    )
+
+    assert completed.returncode != 0, f"{completed.stdout}\n{completed.stderr}"
+    assert "Fix pin waiver" in completed.stderr
+    assert not call_log.exists(), "an unexplained waiver must not reach curie"
+
+
+def test_duplicate_waiver_lines_fail_closed_without_calling_curie(tmp_path: Path) -> None:
+    completed, call_log = _run_checker(
+        tmp_path,
+        (
+            f"Closes #12\n\nFix pin: {VALID_SELECTOR}\n"
+            "Fix pin waiver: first\n"
+            "Fix pin waiver: second\n"
+        ),
+        gh_labels=FOUND_LIVE_LABELS,
+    )
+
+    assert completed.returncode != 0, f"{completed.stdout}\n{completed.stderr}"
+    assert "Fix pin waiver" in completed.stderr
+    assert not call_log.exists(), "duplicate waivers must not reach curie"
+
+
+def test_pin_tier_comes_from_selector_location_not_from_prose(tmp_path: Path) -> None:
+    completed, call_log = _run_checker(
+        tmp_path,
+        (
+            f"Closes #12\n\nThis pin is a live Slack test.\n"
+            f"Fix pin: {VALID_SELECTOR}\n"
+        ),
+        gh_labels=FOUND_LIVE_LABELS,
+    )
+    shown = f"{completed.stdout}\n{completed.stderr}"
+
+    assert completed.returncode != 0, shown
+    assert "unit" in completed.stderr, shown
+    assert not call_log.exists(), "prose claiming a higher tier must not raise the pin"
+
+
+def test_found_live_in_the_issue_body_without_the_label_still_raises_the_floor(
+    tmp_path: Path,
+) -> None:
+    completed, call_log = _run_checker(
+        tmp_path,
+        f"Closes #12\n\nFix pin: {VALID_SELECTOR}\n",
+        gh_labels=BUG_LABELS,
+        gh_body="### Discovery surface\n\nfound:live\n",
+    )
+    shown = f"{completed.stdout}\n{completed.stderr}"
+
+    assert completed.returncode != 0, shown
+    assert "found:live" in completed.stderr, shown
+    assert not call_log.exists()
+
+
+def test_found_live_mentioned_in_issue_prose_does_not_raise_the_floor(
+    tmp_path: Path,
+) -> None:
+    completed, call_log = _run_checker(
+        tmp_path,
+        f"Closes #12\n\nFix pin: {VALID_SELECTOR}\n",
+        gh_labels=BUG_LABELS,
+        gh_body=(
+            "### Discovery surface\n\nfound:unit\n\n"
+            "### What happened\n\nThis was not found:live; it failed in pytest.\n"
+        ),
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert call_log.exists(), "narrative found:* mentions must not raise the floor"
+
+
+def test_strictest_found_label_across_closed_bugs_is_the_floor(tmp_path: Path) -> None:
+    """A fake gh returns one label list; the gate must still fail on found:live."""
+    completed, call_log = _run_checker(
+        tmp_path,
+        f"Closes #12, #13\n\nFix pin: {VALID_SELECTOR}\n",
+        gh_labels='["bug", "found:unit", "found:live"]',
+    )
+    shown = f"{completed.stdout}\n{completed.stderr}"
+
+    assert completed.returncode != 0, shown
+    assert "found:live" in completed.stderr, shown
+    assert not call_log.exists()
+
+
+def test_python_suite_collects_the_fix_pin_gate_tests() -> None:
+    text = PYPROJECT.read_text(encoding="utf-8")
+    assert '"tools/fix-pin-ci/tests"' in text
+
+
+def test_bug_report_template_records_the_discovery_surface() -> None:
+    template = BUG_REPORT.read_text(encoding="utf-8")
+    for label in ("found:unit", "found:local", "found:cluster", "found:live"):
+        assert label in template, f"bug template must name {label}"
+
+
+def test_pull_request_template_documents_the_tier_waiver() -> None:
+    template = PR_TEMPLATE.read_text(encoding="utf-8")
+    assert "Fix pin waiver: <reason>" in template
+    assert "found:live" in template


### PR DESCRIPTION
The fix-pin gate accepted a pin at any tier. Live-found defects in v0.8.1 through v0.8.4 (#2201, #2202, #2203, #2205) were therefore pinned by unit tests or helm-render, and the next instance of the same class could not reach a unit pin.

The gate now reads the closed bug's discovery surface (`found:unit`, `found:local`, `found:cluster`, `found:live` as a label or the bug-form field) and fails when the declared selector's location ranks below that surface, unless the body carries `Fix pin waiver: <reason>`. Pin tier is derived from selector location (unit tests, `charts/curie/ci/*`, `test_live.py`), not from prose.

Defaults recorded in the change: a bug with no `found:*` label keeps the pre-#2243 no-floor behaviour so existing unlabeled issues are not blocked. Ladder rungs are not a declared selector form yet, so `found:local` plus a unit pin needs a waiver. `test_live.py` is classified as live, but the Python CI job does not export `CURIE_E2E_LIVE`, so a live selector still cannot pin in that job; a `found:live` bug is expected to use a lower-tier pin plus the waiver until that job can run live tests.

## Done when

- A unit pin for a `found:live` issue fails the gate (meta-test, exit nonzero, verifier not invoked).
- The same pin with `Fix pin waiver: <reason>` passes and still runs verify-fix-pin.
- 88 tests in `tools/fix-pin-ci/tests/test_fix_pin_ci.py`, now collected by the Python suite.

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | CI gate only; no plugin, runner turn loop, or skill eval | | |
| local | required | meta-tests execute `tools/fix-pin-ci/check.py`, the real consumer path | fake | `uv run pytest -q tools/fix-pin-ci/tests/test_fix_pin_ci.py` against `3f84359e5`: 88 passed. Key pair: `test_unit_pin_for_a_found_live_issue_fails_without_a_waiver` PASSED; `test_unit_pin_for_a_found_live_issue_passes_with_a_waiver` PASSED |
| local-release | n/a | no released binary, install path, or release compose | | |
| cluster | n/a | no chart, RBAC, or sandbox change | | |
| live provider | n/a | no model routing or credentials | | |
| external integration | n/a | GitHub Issues API is mocked in the gate tests | | |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

## Fix pin

Fix pin: n/a - the gate's own selector grammar does not admit `tools/` paths (an existing test asserts `tools/fix-pin-ci/tests/test_fix_pin_ci.py::...` is unsupported), so there is no declarable selector for a change to the gate itself. The equivalent proof is the meta-test pair above.

Closes #2243
