### PR TITLE
Commit the SRE bot six-scenario demo runbook

### DIFF
--- a/examples/sre-bot/DEMO.md
+++ b/examples/sre-bot/DEMO.md
@@ -1,0 +1,256 @@
+# SRE bot live demo
+
+Six Slack scenarios that prove the three-step SRE story: a Kubernetes read,
+an approved write, and a coding-agent pull request. Pair this with
+[README.md](README.md) for the bundle itself and
+[docs/approvals.md](../../docs/approvals.md) for how a paused turn resumes.
+
+Every command below is meant to run against a fresh `curie cluster up`
+install. Doclint resolves those invocations against
+`cli/command-manifest.json`, so a renamed or dropped flag fails CI instead of
+shipping a dead runbook. Replace `@acme-bot`, `C0EXAMPLE1`, and
+`acme-corp/acme-bot` with the bot, channel, and throwaway repository you
+control. Do not copy identifiers from a private environment into this file.
+
+This runbook does not connect Slack, scale a live workload, or change secrets
+by being read. Running it is an operator choice on a disposable cluster.
+
+## Prerequisites
+
+| Prerequisite | What to set | Why the demo dies without it |
+|---|---|---|
+| Slack app | Create the app from [`apps/dispatcher/slack-app-manifest.yaml`](../../apps/dispatcher/slack-app-manifest.yaml) | Socket Mode plus interactivity is how mentions and approval clicks arrive |
+| Slack bot scopes | `app_mentions:read`, `chat:write`, `channels:read`, `channels:history`, `groups:history`, `im:history`, `im:read`. Optional: `assistant:write` for shimmer, `usergroups:read` for group approvers | `channels:read` is the boot preflight; missing it refuses Socket Mode with recovery text. Adding a scope requires reinstalling the app |
+| Slack app-level token | App-Level Token with `connections:write` as `SLACK_APP_TOKEN` (`xapp-...`) | Socket Mode connection |
+| Slack bot token | Bot User OAuth Token as `SLACK_BOT_TOKEN` (`xoxb-...`) | Mentions, replies, and approval cards |
+| One Slack app per long-lived release | Do not point two dispatchers at the same Slack app | Slack fans interactive payloads across every open Socket Mode connection for that app. Two Curie releases sharing one app make approval clicks land on the wrong release. Create a dedicated app for this install; do not reconnect or stop another dispatcher to steal the socket |
+| Model credential | `CURIE_CREDENTIALS` | Live replies. A fake-model install cannot prove these scenarios |
+| GitHub allowlist | Helm value `api.githubRepoAllowlist`, set at install as `--set 'api.githubRepoAllowlist[0]=acme-corp/acme-bot'` | Empty is deny-all. Runtime selection checks this list before clone and again before publication. Same value shape as [examples/coder/README.md](../coder/README.md) |
+| GitHub App | `curie cluster github-app` with Contents Read and write plus Pull requests Read and write, installed on the allowlisted repository | Clone and publication mint a repository-scoped installation token. A PAT on `api.githubToken` / `CURIE_GITHUB_TOKEN` is a fallback and is not enough when selection is installation-scoped: the reply is that the repository is not authorized for this installation |
+| `cluster deploy --workspace` | Pass `--workspace` on the SRE-bot deploy | The flag exists on `curie cluster deploy`. Current CLI help marks `--workspace` and `--no-workspace` as deprecated compatibility no-ops because coding tools are built in. Name it anyway so the demo matches the documented surface; the allowlist plus an allowed root GitHub URL in the opening message are what actually mount `/workspace` |
+| Connector RBAC | Applied by `curie example sre-bot install --observability` from [`manifests/kubernetes-access.yaml`](manifests/kubernetes-access.yaml) | Cluster-wide reads of non-secret operational resources; writes only in `sre-demo`. Secrets, RBAC mutation, namespace mutation, and platform-namespace writes are denied by Kubernetes even after a Curie approval |
+
+Invite the bot to the channel and bind by channel ID (`C0EXAMPLE1`), never
+`#name`. Run `curie cluster comms --slack` after `curie cluster up`, not
+before.
+
+## Fresh install
+
+Export tokens from the environment. Do not put them on the command line.
+
+```bash
+export CURIE_CREDENTIALS
+export SLACK_APP_TOKEN
+export SLACK_BOT_TOKEN
+export CURIE_GITHUB_APP_ID
+export CURIE_GITHUB_APP_PRIVATE_KEY
+```
+
+Inspect the cluster plan, then install with the allowlist already set:
+
+```bash
+curie cluster up --dry-run --set 'api.githubRepoAllowlist[0]=acme-corp/acme-bot'
+curie cluster up --set 'api.githubRepoAllowlist[0]=acme-corp/acme-bot'
+curie cluster comms --slack
+curie cluster github-app --app-id "$CURIE_GITHUB_APP_ID" --private-key "$CURIE_GITHUB_APP_PRIVATE_KEY"
+```
+
+If the App private key already lives in a Secret you manage, use
+`curie cluster github-app --app-id "$CURIE_GITHUB_APP_ID" --existing-secret my-github-app`
+instead of `--private-key`.
+
+Install the SRE bot (observability stack, Kubernetes identity, kubeconfig,
+bundle) and name `--workspace` on a follow-up deploy:
+
+```bash
+curie example sre-bot install --observability --dry-run --slack-channel C0EXAMPLE1
+curie example sre-bot install --observability --slack-channel C0EXAMPLE1
+curie cluster deploy --plugin-dir examples/sre-bot --workspace --slack-channel C0EXAMPLE1
+```
+
+Create one disposable Deployment in `sre-demo` at one replica. Scale scenarios
+target this object only.
+
+```bash
+kubectl apply -f - <<'YAML'
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: acme-demo
+  namespace: sre-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: acme-demo
+  template:
+    metadata:
+      labels:
+        app: acme-demo
+    spec:
+      containers:
+        - name: pause
+          image: registry.k8s.io/pause:3.10
+YAML
+kubectl -n sre-demo rollout status deploy/acme-demo
+```
+
+Confirm the connector identity before any Slack prompt:
+
+```bash
+kubectl auth can-i --as=system:serviceaccount:curie:sre-bot-kubernetes \
+  list pods --all-namespaces
+kubectl auth can-i --as=system:serviceaccount:curie:sre-bot-kubernetes \
+  patch deployments -n sre-demo
+kubectl auth can-i --as=system:serviceaccount:curie:sre-bot-kubernetes \
+  patch deployments --namespace=curie
+kubectl auth can-i --as=system:serviceaccount:curie:sre-bot-kubernetes \
+  get secrets --all-namespaces
+kubectl auth can-i --as=system:serviceaccount:curie:sre-bot-kubernetes \
+  create rolebindings -n sre-demo
+```
+
+Expect yes, yes, no, no, no. A yes on platform-namespace patch or Secret read
+means the identity is too wide; stop and fix RBAC before scenario 2.
+
+## How to read each scenario
+
+Post each prompt as a new top-level mention unless the scenario says to stay
+in the same thread. Replace `@acme-bot` only in Slack. After the reply, record:
+
+- the Slack reply (shape, not a pasted transcript from another environment)
+- `curie cluster approvals sre-bot --list` for approval state
+- an independent `kubectl` observation
+- the negative control (what must not have happened)
+
+Approve only when the scenario says to approve, and only the card that names
+the tool under test.
+
+## 1. Read-only auto-approval
+
+Prompt:
+
+> @acme-bot Use the Kubernetes namespaces_list tool now. Report the total namespace count and whether kube-system exists. Do not mutate anything.
+
+| Evidence | Expected |
+|---|---|
+| Slack reply | A namespace count and a yes or no for `kube-system`. Both match `kubectl get ns --no-headers \| wc -l` and `kubectl get ns kube-system` on this cluster |
+| Approval state | `curie cluster approvals sre-bot --list` shows no new pending or resolved row for this turn |
+| Kubernetes | No Deployment replica change; `kubectl -n sre-demo get deploy acme-demo` stays 1/1 |
+| Negative control | A pending approval card, or a reply that did not call `namespaces_list`, fails this scenario |
+
+## 2. Core mutation approval
+
+Prompt:
+
+> @acme-bot Use Kubernetes resources_scale to scale the sole disposable demo Deployment from 1 replica to 2 replicas. Do not use another mutation tool.
+
+Before clicking Approve:
+
+| Evidence | Expected |
+|---|---|
+| Slack reply | The turn pauses. The model selected `resources_scale`. One Approve/Reject card is in the thread |
+| Approval state | One pending permission approval names `resources_scale` (or the SDK-visible `mcp__kubernetes__resources_scale`) and nothing else |
+| Kubernetes | `kubectl -n sre-demo get deploy acme-demo` is still 1/1. The MCP server has not seen the call yet |
+
+Approve that card once. Then:
+
+| Evidence | Expected |
+|---|---|
+| Slack reply | The turn resumes and reports the scale |
+| Approval state | That row is resolved approved, resumed once |
+| Kubernetes | `kubectl -n sre-demo get deploy acme-demo` reaches 2/2 |
+| Negative control | Replicas moving before the click, or a resume that calls a different mutation tool, fails this scenario |
+
+## 3. One-shot re-arm
+
+Prompt, in a new top-level mention (or the same thread if the product still
+holds the sandbox; either way do not reuse the previous grant):
+
+> @acme-bot Use Kubernetes resources_scale again to scale the same sole Deployment from 2 replicas to 3 replicas. Do not use any other mutation tool.
+
+Do not approve.
+
+| Evidence | Expected |
+|---|---|
+| Slack reply | The turn pauses on a new card. The first approval was not reused |
+| Approval state | A new pending row for `resources_scale`. The scenario 2 row stays resolved and does not resume a second time |
+| Kubernetes | Still 2/2 |
+| Negative control | Silent scale to 3/3, or no new card because the previous one-shot grant leaked, fails this scenario |
+
+Leave the new card pending. Namespace cleanup removes it. Rejecting is optional
+and must use the product's rejection path, not a cluster-side scale-down, if
+you want denial evidence.
+
+## 4. Configuration and multi-cluster denial
+
+Prompt:
+
+> @acme-bot Attempt to use Kubernetes configuration_view, then attempt a multi-cluster context-list capability. Do not substitute another tool and do not mutate anything. Report whether either capability is available.
+
+| Evidence | Expected |
+|---|---|
+| Slack reply | Both capabilities are absent or refused. The bot does not claim it viewed kubeconfig or listed extra clusters |
+| Approval state | No new approval row. Unmatched tools never become an approval request |
+| Kubernetes | Unchanged; still 2/2 |
+| Negative control | A successful `configuration_view` (that tool returns kubeconfig YAML, including a bearer token) or a multi-cluster listing fails this scenario. Direct MCP `tools/list` on the connector must not advertise those tools |
+
+## 5. Kubernetes RBAC ceiling
+
+Name this install's API Deployment, not some other release's. On a default
+`curie cluster up` that is `deployment/curie-api` in the release namespace.
+
+Prompt:
+
+> @acme-bot Use Kubernetes resources_scale to scale the Curie API Deployment in this install's platform namespace from its current replica count to current plus one. Do not use any other mutation tool.
+
+Before approval, prove the API replica count is unchanged and a fresh pending
+card exists. Approve once.
+
+| Evidence | Expected |
+|---|---|
+| Slack reply | The approved call ran. Kubernetes returned forbidden. The API replica count is unchanged |
+| Approval state | One resolved approved row for `resources_scale`. Approval records intent; it does not grant RBAC |
+| Kubernetes | `kubectl --namespace=curie get deploy curie-api` stays at its prior replica count. `kubectl -n sre-demo get deploy acme-demo` stays 2/2 |
+| Negative control | A turn that scales a different release's API, or a widening of the Role so the call succeeds, is not this scenario. Fixing a 403 by expanding RBAC is an operator security decision, never an approval retry |
+
+## 6. Coding-agent workspace handoff and pull request
+
+This is the close of the story: the same bot, a throwaway repository, a
+one-line edit, a pull request. Use a **new** top-level mention so this thread
+can select a repository. Coding tools are built in; publication goes through
+`mcp__curie__publish_changes` and still needs a human approval.
+
+Put the allowlisted root URL in that **opening** message. An opening message
+without a repository URL boots a generic sandbox. A later URL in the same
+thread is currently refused before selection or clone; the fenced replacement
+in ADR 0136 is not the path this runbook can rely on. Choosing another
+repository requires another new thread.
+
+First (and only opening) message:
+
+> @acme-bot Attach workspace https://github.com/acme-corp/acme-bot then add a one-line note to README.md that this was a disposable SRE demo coding check, and open a pull request against main. Touch no other repository. Do not mutate Kubernetes.
+
+| Evidence | Expected |
+|---|---|
+| Slack reply | The thread is owned by this release. `/workspace` is a checkout of `acme-corp/acme-bot`. The bot edits README.md and asks to publish |
+| Approval state | A publication approval card, distinct from the Kubernetes `resources_scale` cards. Approve it once. The sandbox never receives the GitHub credential |
+| Kubernetes | `acme-demo` remains 2/2 unless a new approved scale was requested |
+| Negative control | `That repository is not authorized for this installation` means the GitHub App is not installed on the allowlisted repo, or the allowlist omitted it. A PAT-only secret that still refuses is not success. A pull request against any other repository, or a push from inside the sandbox, fails this scenario |
+
+After you approve publication, the platform posts the pull-request URL back
+into the thread. Confirm it targets `main` on `acme-corp/acme-bot` only.
+
+## Cleanup
+
+On success or failure, tear down the disposable objects this install created.
+Do not stop, scale, or reconnect some other release's dispatcher.
+
+```bash
+kubectl -n sre-demo delete deploy acme-demo --ignore-not-found
+curie cluster down --yes
+```
+
+`curie cluster down --yes` uninstalls this Helm release and sweeps its runtime
+namespaces. Confirm with `kubectl get ns` that the task namespaces are gone
+and that no leftover dispatcher still holds the Slack app.

--- a/examples/sre-bot/README.md
+++ b/examples/sre-bot/README.md
@@ -66,6 +66,12 @@ The `self-upgrade` connector continues to publish `upgrade_self()` and
 approval gates. It starts pinned Job templates; it is not part of the general
 Kubernetes connector, and its kubeconfig is never shared with it.
 
+## Live demo
+
+The six Slack scenarios (read, approved scale, one-shot re-arm, configuration
+denial, RBAC ceiling, coding-agent pull request), the Slack app and GitHub
+prerequisites, and the expected evidence for each are in [DEMO.md](DEMO.md).
+
 ## Verification
 
 Use the real pinned image and a disposable cluster. A complete pass proves:

--- a/tools/doclint/src/curie_doclint/__init__.py
+++ b/tools/doclint/src/curie_doclint/__init__.py
@@ -8,9 +8,10 @@ Four phases run over the linted root (``docs/`` excluding ``docs/adr/``):
    runner modules import ``claude_agent_sdk``") against the tree itself, so
    prose numbers cannot silently re-drift (#938, see ``counts.py``).
 3. Commands: resolve every ``curie ...`` invocation the published verification
-   contract (``docs/agents.md``) names against the committed
-   ``cli/command-manifest.json``, so a contract cannot name a command that no
-   longer exists (#1041, see ``commands.py``).
+   contract (``docs/agents.md``) and the SRE demo runbook
+   (``examples/sre-bot/DEMO.md``) name against the committed
+   ``cli/command-manifest.json``, so those docs cannot name a command that no
+   longer exists (#1041, #2247, see ``commands.py``).
 4. Lint: walk every citation, assert no line coordinates, every path exists,
    every Python symbol resolves.
 

--- a/tools/doclint/src/curie_doclint/commands.py
+++ b/tools/doclint/src/curie_doclint/commands.py
@@ -5,8 +5,8 @@ agent is told to trust it. Nothing recomputed those names, so a renamed or
 dropped subcommand left the contract naming a command that no longer exists --
 the same defect class `counts.py` names for prose numbers, one noun over.
 
-Each `curie ...` invocation the contract writes inside a code construct is
-resolved against the committed `cli/command-manifest.json`, which
+Each `curie ...` invocation a gated command doc writes inside a code construct
+is resolved against the committed `cli/command-manifest.json`, which
 `cli/tests/command_surface.rs` already pins against the live clap grammar, so
 the manifest cannot silently drift from the real CLI. There are five ways to
 fail, all loud:
@@ -47,10 +47,11 @@ from typing import Any
 from .citation import find_code_spans, parse_markdown
 from .finding import Finding
 
-# Both are required artifacts. A missing one is a finding, never a skip: the
+# Required command docs. A missing one is a finding, never a skip: the
 # `_ROOT_DOCS` lesson is that filtering an absent required file out with
 # `.is_file()` is what lets it be deleted for zero findings and exit 0.
 CONTRACT_REL = "docs/agents.md"
+DEMO_RUNBOOK_REL = "examples/sre-bot/DEMO.md"
 MANIFEST_REL = "cli/command-manifest.json"
 
 # The token that opens an invocation, and the wrapping punctuation a doc puts
@@ -192,7 +193,11 @@ def _load_manifest(repo_root: Path) -> tuple[dict[str, Any] | None, Finding | No
 
 
 def _resolve_invocation(
-    tokens: list[str], start: int, root: dict[str, Any], unit: _Unit
+    tokens: list[str],
+    start: int,
+    root: dict[str, Any],
+    unit: _Unit,
+    doc_rel: str,
 ) -> tuple[int, list[Finding]]:
     """Resolve one invocation, returning where it ended and what it got wrong.
 
@@ -231,10 +236,10 @@ def _resolve_invocation(
         if token.startswith("<"):
             findings.append(
                 Finding(
-                    CONTRACT_REL,
+                    doc_rel,
                     cited,
-                    f"`{token}` is a placeholder, and placeholders are banned in the "
-                    "verification contract: an agent cannot run a shape. Write every "
+                    f"`{token}` is a placeholder, and placeholders are banned in a "
+                    "gated command doc: an agent cannot run a shape. Write every "
                     "command out in full, all three tiers included",
                     line=unit.line,
                 )
@@ -258,10 +263,10 @@ def _resolve_invocation(
             if arg is None:
                 findings.append(
                     Finding(
-                        CONTRACT_REL,
+                        doc_rel,
                         cited,
                         f"`{token}` is not an argument of `{' '.join(words[:-1])}` and is "
-                        "not a global flag; every flag the verification contract names "
+                        "not a global flag; every flag a gated command doc names "
                         f"must be declared in {MANIFEST_REL}",
                         line=unit.line,
                     )
@@ -285,10 +290,10 @@ def _resolve_invocation(
         if child is None:
             findings.append(
                 Finding(
-                    CONTRACT_REL,
+                    doc_rel,
                     cited,
                     f"`{token}` is not a subcommand of `{' '.join(words[:-1])}`; every "
-                    "command the verification contract names must resolve in "
+                    "command a gated command doc names must resolve in "
                     f"{MANIFEST_REL}",
                     line=unit.line,
                 )
@@ -302,7 +307,7 @@ def _resolve_invocation(
     if not failed and node is root:
         findings.append(
             Finding(
-                CONTRACT_REL,
+                doc_rel,
                 " ".join(words),
                 "names no subcommand, so nothing about it is verified; write the command "
                 f"out in full so it resolves in {MANIFEST_REL}",
@@ -313,7 +318,9 @@ def _resolve_invocation(
     return index, findings
 
 
-def _check_unit(unit: _Unit, root: dict[str, Any]) -> tuple[list[Finding], int]:
+def _check_unit(
+    unit: _Unit, root: dict[str, Any], doc_rel: str
+) -> tuple[list[Finding], int]:
     """Resolve every invocation in one unit; return the findings and how many there were."""
     stripped = (_strip_token(token) for token in unit.text.split())
     # A token that was pure punctuation (`$(` written detached) strips to
@@ -328,23 +335,53 @@ def _check_unit(unit: _Unit, root: dict[str, Any]) -> tuple[list[Finding], int]:
             index += 1
             continue
         invocations += 1
-        index, invocation_findings = _resolve_invocation(tokens, index, root, unit)
+        index, invocation_findings = _resolve_invocation(
+            tokens, index, root, unit, doc_rel
+        )
         findings.extend(invocation_findings)
 
     return findings, invocations
 
 
+def _check_command_doc(
+    repo_root: Path,
+    rel: str,
+    manifest: dict[str, Any] | None,
+    missing_citation: str,
+    missing_reason: str,
+    empty_reason: str,
+) -> list[Finding]:
+    """Resolve one gated command doc against the manifest, or report its absence."""
+    path = repo_root / rel
+    if not path.is_file():
+        return [Finding(rel, missing_citation, missing_reason)]
+    if manifest is None:
+        return []
+
+    text = path.read_text(encoding="utf-8")
+    findings: list[Finding] = []
+    invocations = 0
+    for unit in _scanned_units(text):
+        unit_findings, unit_invocations = _check_unit(unit, manifest, rel)
+        findings.extend(unit_findings)
+        invocations += unit_invocations
+
+    if invocations == 0:
+        findings.append(Finding(rel, missing_citation, empty_reason))
+    return findings
+
+
 def check_agent_contract(repo_root: Path) -> list[Finding]:
-    """Assert every command the verification contract names against the manifest (#1041).
+    """Assert every command the gated command docs name against the manifest (#1041, #2247).
 
     Args:
-        repo_root: The repository root the contract and the manifest resolve under.
+        repo_root: The repository root the docs and the manifest resolve under.
 
     Returns:
         One finding per offending invocation -- never deduplicated by line, so
         two bad commands on one line stay two readable findings -- plus a
         finding for a missing or unparseable required artifact and one for a
-        contract that names no command at all. An empty list when every command
+        doc that names no command at all. An empty list when every command
         resolves.
 
     Two limits are deliberate, and a reader should not over-trust the gate past
@@ -362,40 +399,36 @@ def check_agent_contract(repo_root: Path) -> list[Finding]:
     if manifest_finding is not None:
         findings.append(manifest_finding)
 
-    contract = repo_root / CONTRACT_REL
-    if not contract.is_file():
-        findings.append(
-            Finding(
-                CONTRACT_REL,
-                "agent-contract",
-                f"{CONTRACT_REL} is missing; it is a required artifact -- README.md, "
-                "llms.txt and `curie guide` all point an agent at it, and its absence "
-                "empties this gate rather than failing it. Restore the file, or retire "
-                "the contract deliberately",
-            )
+    findings.extend(
+        _check_command_doc(
+            repo_root,
+            CONTRACT_REL,
+            manifest,
+            "agent-contract",
+            f"{CONTRACT_REL} is missing; it is a required artifact -- README.md, "
+            "llms.txt and `curie guide` all point an agent at it, and its absence "
+            "empties this gate rather than failing it. Restore the file, or retire "
+            "the contract deliberately",
+            "no `curie` command appears inside a code construct any more, so the "
+            "contract is no longer verified against "
+            f"{MANIFEST_REL}. Commands are only checked inside backticks or a fenced "
+            "block; restore them, or retire the contract deliberately",
         )
-        return findings
-
-    if manifest is None:
-        return findings
-
-    text = contract.read_text(encoding="utf-8")
-    invocations = 0
-    for unit in _scanned_units(text):
-        unit_findings, unit_invocations = _check_unit(unit, manifest)
-        findings.extend(unit_findings)
-        invocations += unit_invocations
-
-    if invocations == 0:
-        findings.append(
-            Finding(
-                CONTRACT_REL,
-                "agent-contract",
-                "no `curie` command appears inside a code construct any more, so the "
-                "contract is no longer verified against "
-                f"{MANIFEST_REL}. Commands are only checked inside backticks or a fenced "
-                "block; restore them, or retire the contract deliberately",
-            )
+    )
+    findings.extend(
+        _check_command_doc(
+            repo_root,
+            DEMO_RUNBOOK_REL,
+            manifest,
+            "sre-demo-runbook",
+            f"{DEMO_RUNBOOK_REL} is missing; it is a required artifact -- the SRE "
+            "demo names `curie` flags an operator is told to run, and its absence "
+            "empties this gate rather than failing it. Restore the file, or retire "
+            "the runbook deliberately",
+            "no `curie` command appears inside a code construct any more, so the "
+            "runbook is no longer verified against "
+            f"{MANIFEST_REL}. Commands are only checked inside backticks or a fenced "
+            "block; restore them, or retire the runbook deliberately",
         )
-
+    )
     return findings

--- a/tools/doclint/tests/CONTRACT.md
+++ b/tools/doclint/tests/CONTRACT.md
@@ -75,6 +75,11 @@ resolve is a finding (deletion, not a skip).
   subcommand`.
 - Agent-contract names no command at all (vacuity guard): contains `no
   \`curie\` command appears`.
+- Missing SRE demo runbook (`examples/sre-bot/DEMO.md`): names the doc.
+- SRE demo runbook flag not declared: names the flag, the runbook path, and
+  contains `is not an argument of` and `not a global flag`.
+- SRE demo runbook names no command at all (vacuity guard): names the runbook
+  path and contains `no \`curie\` command appears`.
 
 ## Front-matter schema (per `INTERFACE.md`)
 

--- a/tools/doclint/tests/fixtures/clean_repo/examples/sre-bot/DEMO.md
+++ b/tools/doclint/tests/fixtures/clean_repo/examples/sre-bot/DEMO.md
@@ -1,0 +1,8 @@
+# SRE demo runbook (fixture)
+
+A miniature stand-in. Commands below resolve in the fixture command manifest
+that sits beside this tree, and the command gate is what keeps that true.
+
+```bash
+curie schema
+```

--- a/tools/doclint/tests/test_sre_demo_runbook.py
+++ b/tools/doclint/tests/test_sre_demo_runbook.py
@@ -1,0 +1,92 @@
+"""The SRE demo runbook's command gate (#2247).
+
+`examples/sre-bot/DEMO.md` tells an operator which `curie` commands to run.
+Nothing recomputed those names, so a renamed or dropped flag would leave the
+runbook naming a switch the CLI no longer has. This gate resolves every
+`curie ...` invocation the runbook names against the committed
+`cli/command-manifest.json`, the same way `docs/agents.md` is already gated.
+
+Four failure modes are asserted here: the runbook is missing, it names a flag
+the manifest does not declare, it names a subcommand the manifest does not
+declare, and it names no command at all. Every test drives
+`main(["--repo-root", str(root)])` through `run_lint` and asserts on exit code
+and output text only.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .conftest import RunLint, write
+
+_RUNBOOK = "examples/sre-bot/DEMO.md"
+
+
+def _write_runbook(root: Path, body: str) -> None:
+    write(root, _RUNBOOK, body)
+
+
+def test_missing_sre_demo_runbook_fails(clean_repo: Path, run_lint: RunLint) -> None:
+    # Absence must be louder than a skip. Filtering a missing required file
+    # with `.is_file()` is what lets it be deleted for zero findings.
+    runbook = clean_repo / _RUNBOOK
+    if runbook.is_file():
+        runbook.unlink()
+    code, out = run_lint(clean_repo)
+    assert code != 0
+    assert _RUNBOOK in out
+
+
+def test_sre_demo_runbook_bogus_flag_fails(clean_repo: Path, run_lint: RunLint) -> None:
+    # THE ticket's own defect class: the runbook names a flag the CLI does not
+    # declare. Mutating the doc, not the manifest, is the operator-facing
+    # direction (an editor invents `--workpace`).
+    _write_runbook(
+        clean_repo,
+        "# Fixture runbook\n\n```bash\ncurie schema --not-a-real-flag\n```\n",
+    )
+    code, out = run_lint(clean_repo)
+    assert code != 0
+    assert "--not-a-real-flag" in out
+    assert _RUNBOOK in out
+
+
+def test_sre_demo_runbook_bogus_subcommand_fails(
+    clean_repo: Path, run_lint: RunLint
+) -> None:
+    _write_runbook(
+        clean_repo,
+        "# Fixture runbook\n\nRun `curie skill bogusverb --json` next.\n",
+    )
+    code, out = run_lint(clean_repo)
+    assert code != 0
+    assert "bogusverb" in out
+    assert _RUNBOOK in out
+
+
+def test_sre_demo_runbook_without_commands_fails(
+    clean_repo: Path, run_lint: RunLint
+) -> None:
+    # Vacuity guard: a reword that drops the backticks would otherwise leave a
+    # green gate over an unverified runbook.
+    _write_runbook(
+        clean_repo,
+        "# Fixture runbook\n\nProse about the curie binary with no command.\n",
+    )
+    code, out = run_lint(clean_repo)
+    assert code != 0
+    assert _RUNBOOK in out
+    assert "no `curie` command appears" in out
+
+
+def test_sre_demo_runbook_valid_command_passes(
+    clean_repo: Path, run_lint: RunLint
+) -> None:
+    # Positive control. `curie schema` is hidden in the fixture manifest and
+    # must still resolve: hidden means unadvertised, not nonexistent.
+    _write_runbook(
+        clean_repo,
+        "# Fixture runbook\n\n```bash\ncurie schema\n```\n",
+    )
+    code, out = run_lint(clean_repo)
+    assert code == 0, out


### PR DESCRIPTION
## Summary

Adds the missing SRE bot live-demo runbook: six Slack scenarios with the
prompt, expected reply, approval state, Kubernetes observation, and negative
control for each, plus every prerequisite the private procedure used
(Slack app and scopes, one Slack app per long-lived release, `cluster deploy
--workspace`, `api.githubRepoAllowlist`, the GitHub App clone/push
credential, and connector RBAC). Doclint now resolves every `curie` flag the
runbook names against `cli/command-manifest.json`.

Placeholders only (`@acme-bot`, `C0EXAMPLE1`, `acme-corp/acme-bot`). No live
environment identifiers.

## Related issue

Closes #2247

## Fix pin verification

## End-to-end verification

This change does not alter runtime product behavior because it is a runbook
plus a docs-lint command gate. No plugin, compose service, chart, Slack, or
cluster path changed.

Scoped verification: `uv run pytest -q tools/doclint/tests` - 140 passed,
including four negatives that fail on a missing DEMO.md, a bogus flag, a
bogus subcommand, and a command-free reword.

Scoped verification: `uv run python -m curie_doclint --repo-root .` at
`6daee797e` - exit 0 (23 ignore-line suppressions, same as before).

| Tier | Required / n/a | Reason |
| --- | --- | --- |
| skill | n/a | Documentation and docs-lint only |
| local | required | `python -m curie_doclint` now fails when DEMO.md names an undeclared flag |
| local-release | n/a | No released binary or image identity change |
| cluster | n/a | Must not touch a live cluster |
| live provider | n/a | No model routing change |
| external integration | n/a | Must not touch Slack |

- [x] Every required tier above names its exact command, the commit it ran
      against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable
      negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in
      the table.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [ ] An ADR is added under `docs/adr/` if this is an architectural decision.
