### PR TITLE
Name the githubRepoAllowlist when a workspace selection is refused

### DIFF
--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -4907,6 +4907,14 @@ export const commandManifest = {
                   "long": "observability-namespace",
                   "positional": false,
                   "required": false
+                },
+                {
+                  "global": false,
+                  "help": "Allow this GitHub repository, or `owner/*`, for runtime workspace selection. Repeatable. Sets `api.githubRepoAllowlist` on the Curie install",
+                  "id": "workspace_repo",
+                  "long": "workspace-repo",
+                  "positional": false,
+                  "required": false
                 }
               ],
               "hidden": false,

--- a/apps/worker/src/curie_worker/workspace.py
+++ b/apps/worker/src/curie_worker/workspace.py
@@ -294,7 +294,8 @@ class WorkspaceCredentialClient:
             ) from exc
         if response.status == 403:
             raise WorkspaceSelectionRefused(
-                "That repository is not authorized for this installation."
+                "That repository is not in api.githubRepoAllowlist for this installation; "
+                "allow `owner/repo` or `owner/*` in the chart values."
             )
         if response.status == 409:
             try:

--- a/apps/worker/tests/kernel/test_kernel.py
+++ b/apps/worker/tests/kernel/test_kernel.py
@@ -515,7 +515,8 @@ def test_unallowlisted_runtime_repo_is_terminal_before_claim_or_model(
                     assert kwargs["deployment_id"] == deployment_id
                     assert kwargs["repo_full_name"] == "attacker/other-bot"
                     raise WorkspaceSelectionRefused(
-                        "That repository is not authorized for this installation."
+                        "That repository is not in api.githubRepoAllowlist for this installation; "
+                        "allow `owner/repo` or `owner/*` in the chart values."
                     )
 
                 def claim_or_resume_with_handle(self, **_kwargs: object) -> object:
@@ -535,7 +536,8 @@ def test_unallowlisted_runtime_repo_is_terminal_before_claim_or_model(
             assert h.runner.opened == []
             assert h.fake_k8s.claim_envs == []
             assert h.sink.last_text == (
-                "That repository is not authorized for this installation."
+                "That repository is not in api.githubRepoAllowlist for this installation; "
+                "allow `owner/repo` or `owner/*` in the chart values."
             )
 
     asyncio.run(go())

--- a/apps/worker/tests/test_workspace.py
+++ b/apps/worker/tests/test_workspace.py
@@ -432,6 +432,32 @@ def test_internal_workspace_selection_sends_author_thread_and_optional_repo(
     }
 
 
+def test_unallowlisted_selection_names_the_chart_allowlist(
+    workspace: Any,
+) -> None:
+    """A 403 must name api.githubRepoAllowlist, not the GitHub App install."""
+
+    def transport(**_request: Any) -> Any:
+        return SimpleNamespace(status=403, headers={}, body=b"")
+
+    client = workspace.WorkspaceCredentialClient(
+        api_url="https://api.example.com",
+        worker_token=WORKER_AUTH,
+        transport=transport,
+    )
+
+    with pytest.raises(workspace.WorkspaceSelectionRefused) as excinfo:
+        client.select(
+            DEPLOYMENT_ID, "1700000000.000100", "U0REQUEST1", "attacker/other-bot"
+        )
+
+    assert excinfo.value.public_detail == (
+        "That repository is not in api.githubRepoAllowlist for this installation; "
+        "allow `owner/repo` or `owner/*` in the chart values."
+    )
+    assert "not authorized for this installation" not in excinfo.value.public_detail
+
+
 def test_internal_workspace_selection_accepts_explicit_unselected_response(
     workspace: Any,
 ) -> None:

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -4904,6 +4904,14 @@
                   "long": "observability-namespace",
                   "positional": false,
                   "required": false
+                },
+                {
+                  "global": false,
+                  "help": "Allow this GitHub repository, or `owner/*`, for runtime workspace selection. Repeatable. Sets `api.githubRepoAllowlist` on the Curie install",
+                  "id": "workspace_repo",
+                  "long": "workspace-repo",
+                  "positional": false,
+                  "required": false
                 }
               ],
               "hidden": false,

--- a/cli/src/api.rs
+++ b/cli/src/api.rs
@@ -1024,6 +1024,16 @@ fn warn_if_insecure(base_url: &str) {
     }
 }
 
+fn valid_github_owner(owner: &str) -> bool {
+    (1..=39).contains(&owner.len())
+        && owner
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+        && !owner.starts_with('-')
+        && !owner.ends_with('-')
+        && !owner.contains("--")
+}
+
 fn validate_repo_full_name(repo_full_name: &str) -> Result<()> {
     let Some((owner, repository)) = repo_full_name.split_once('/') else {
         bail!(
@@ -1033,13 +1043,6 @@ fn validate_repo_full_name(repo_full_name: &str) -> Result<()> {
         );
     };
 
-    let owner_valid = (1..=39).contains(&owner.len())
-        && owner
-            .bytes()
-            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
-        && !owner.starts_with('-')
-        && !owner.ends_with('-')
-        && !owner.contains("--");
     let repository_valid = (1..=100).contains(&repository.len())
         && repository != "."
         && repository != ".."
@@ -1047,7 +1050,7 @@ fn validate_repo_full_name(repo_full_name: &str) -> Result<()> {
             .bytes()
             .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'));
 
-    if !owner_valid || !repository_valid {
+    if !valid_github_owner(owner) || !repository_valid {
         bail!(
             "invalid repo_full_name: expected one owner/name pair; the owner must use 1 to 39 \
              ASCII letters or digits with single nonterminal hyphens, and the name must use 1 \
@@ -1056,6 +1059,21 @@ fn validate_repo_full_name(repo_full_name: &str) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Accept exact `owner/repository` or owner-wide `owner/*` chart allowlist entries.
+pub(crate) fn validate_allowlist_entry(entry: &str) -> Result<()> {
+    if let Some((owner, rest)) = entry.split_once('/') {
+        if rest == "*" && valid_github_owner(owner) {
+            return Ok(());
+        }
+    }
+    validate_repo_full_name(entry).map_err(|_| {
+        anyhow::anyhow!(
+            "invalid --workspace-repo {entry}: expected `owner/repo` or `owner/*` in the \
+             api.githubRepoAllowlist shape"
+        )
+    })
 }
 
 /// The `POST /agents` body. Pure so the shape is testable without a live API.
@@ -2677,7 +2695,19 @@ impl ApiClient {
 
 #[cfg(test)]
 mod tests {
-    use super::{add_channel_body, agent_create_body, agent_update_body, is_insecure_endpoint};
+    use super::{
+        add_channel_body, agent_create_body, agent_update_body, is_insecure_endpoint,
+        validate_allowlist_entry,
+    };
+
+    #[test]
+    fn allowlist_entries_accept_owner_repo_and_owner_wildcard() {
+        validate_allowlist_entry("acme-corp/acme-bot").expect("exact repo");
+        validate_allowlist_entry("acme-labs/*").expect("owner wildcard");
+        assert!(validate_allowlist_entry("not a repo").is_err());
+        assert!(validate_allowlist_entry("acme-corp/").is_err());
+        assert!(validate_allowlist_entry("*/acme-bot").is_err());
+    }
 
     #[test]
     fn create_agent_body_omits_repo_unless_asked() {

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -4433,6 +4433,42 @@ pub enum DeployTier {
 
 pub use crate::api::WorkspaceIntent;
 
+pub const EMPTY_GITHUB_REPO_ALLOWLIST_WARNING: &str =
+    "api.githubRepoAllowlist is empty, so runtime workspace selection denies every repository. \
+     Allow `owner/repo` or `owner/*` in the chart values, for example \
+     `curie cluster up --set 'api.githubRepoAllowlist[0]=owner/repo'`";
+
+pub fn github_repo_allowlist_is_empty(values: &serde_json::Value) -> bool {
+    match values.pointer("/api/githubRepoAllowlist") {
+        None | Some(serde_json::Value::Null) => true,
+        Some(serde_json::Value::Array(items)) => items.iter().all(|item| {
+            item.as_str()
+                .map(|entry| entry.trim().is_empty())
+                .unwrap_or(true)
+        }),
+        Some(serde_json::Value::String(raw)) => {
+            let trimmed = raw.trim();
+            trimmed.is_empty() || trimmed == "[]"
+        }
+        Some(_) => false,
+    }
+}
+
+/// Best-effort warning when `--workspace` is passed against an empty chart allowlist.
+pub async fn warn_if_empty_github_repo_allowlist(namespace: &str, release: &str) {
+    let opts = crate::ops::CommonOpts {
+        namespace: namespace.to_string(),
+        release: release.to_string(),
+        dry_run: false,
+    };
+    let Ok(Some(values)) = crate::ops::fetch_release_computed_values(&opts).await else {
+        return;
+    };
+    if github_repo_allowlist_is_empty(&values) {
+        crate::ui::ui().warn(EMPTY_GITHUB_REPO_ALLOWLIST_WARNING);
+    }
+}
+
 /// The declared connector-secret NAMES not present in the operator's bound
 /// `--secret` set (#464). A non-empty result is a deploy-time gap: the bundle
 /// expects a secret nothing will bind, which would surface at runtime as an
@@ -7630,16 +7666,38 @@ pub fn skill_approval_routes_unavailable() -> anyhow::Error {
 #[cfg(test)]
 mod tests {
     use super::{
-        absent_container_note, merge_secret_env, model_credential_summary,
-        parse_credential_env_file, parse_manifest_gates, plan_recorded_state,
-        plan_recorded_teardown, plan_skill_down, recorded_ids_match, replace_first_line,
-        report_sweep, resolve_cases_path, resolve_env_file_credentials, routing_warning,
-        seed_env_if_missing, select_in_force_deployment, select_passthrough_env, sweep_json_row,
-        sweep_table_row, validate_channel_binding, ApprovalGateDecl, DownPlan, EnvSeed,
-        RecordedStatePlan, RecordedStateQuery, RecordedTeardown, SweepRow,
+        absent_container_note, github_repo_allowlist_is_empty, merge_secret_env,
+        model_credential_summary, parse_credential_env_file, parse_manifest_gates,
+        plan_recorded_state, plan_recorded_teardown, plan_skill_down, recorded_ids_match,
+        replace_first_line, report_sweep, resolve_cases_path, resolve_env_file_credentials,
+        routing_warning, seed_env_if_missing, select_in_force_deployment, select_passthrough_env,
+        sweep_json_row, sweep_table_row, validate_channel_binding, ApprovalGateDecl, DownPlan,
+        EnvSeed, RecordedStatePlan, RecordedStateQuery, RecordedTeardown, SweepRow,
     };
     use serde::Deserialize;
+    use serde_json::json;
     use std::path::{Path, PathBuf};
+
+    #[test]
+    fn github_repo_allowlist_is_empty_for_missing_null_and_empty_values() {
+        assert!(github_repo_allowlist_is_empty(&json!({})));
+        assert!(github_repo_allowlist_is_empty(&json!({"api": {}})));
+        assert!(github_repo_allowlist_is_empty(
+            &json!({"api": {"githubRepoAllowlist": serde_json::Value::Null}})
+        ));
+        assert!(github_repo_allowlist_is_empty(
+            &json!({"api": {"githubRepoAllowlist": []}})
+        ));
+        assert!(github_repo_allowlist_is_empty(
+            &json!({"api": {"githubRepoAllowlist": ["", "  "]}})
+        ));
+        assert!(!github_repo_allowlist_is_empty(
+            &json!({"api": {"githubRepoAllowlist": ["acme-corp/acme-bot"]}})
+        ));
+        assert!(!github_repo_allowlist_is_empty(
+            &json!({"api": {"githubRepoAllowlist": ["acme-labs/*"]}})
+        ));
+    }
 
     // --- the eval exit-code contract (#2007) --------------------------------
     //

--- a/cli/src/examples.rs
+++ b/cli/src/examples.rs
@@ -199,6 +199,8 @@ pub struct SreBotInstallOpts {
     pub namespace: String,
     pub release: String,
     pub observability_namespace: String,
+    /// Repeatable `owner/repo` or `owner/*` entries for `api.githubRepoAllowlist`.
+    pub workspace_repo: Vec<String>,
 }
 
 struct InstallIdentity {
@@ -462,6 +464,10 @@ pub async fn install_sre_bot(opts: SreBotInstallOpts) -> Result<SreBotInstallRes
             "the SRE bot example installer currently requires --observability",
         ));
     }
+    for entry in &opts.workspace_repo {
+        crate::api::validate_allowlist_entry(entry)
+            .map_err(|err| crate::exit::usage(err.to_string()))?;
+    }
 
     let identity = InstallIdentity::from_opts(&opts);
 
@@ -488,7 +494,7 @@ pub async fn install_sre_bot(opts: SreBotInstallOpts) -> Result<SreBotInstallRes
             identity.observability_namespace
         ));
         lines.extend(stack_commands.iter().map(|command| command.display(&chart)));
-        lines.extend(apply_curie_platform(&chart, true, &identity).await?);
+        lines.extend(apply_curie_platform(&chart, true, &identity, &opts.workspace_repo).await?);
         lines.push(integration_command.display(&chart));
         lines.push(read_access_command.display(&chart));
         lines.push(format!(
@@ -572,7 +578,7 @@ pub async fn install_sre_bot(opts: SreBotInstallOpts) -> Result<SreBotInstallRes
     // Before the apply, not after: the point is to refuse while the credential
     // still exists.
     refuse_to_drop_a_recorded_model_credential(&identity).await?;
-    apply_curie_platform(&chart, false, &identity).await?;
+    apply_curie_platform(&chart, false, &identity, &opts.workspace_repo).await?;
     run_install_command(&integration_command, &workspace, &chart).await?;
     run_install_command(&read_access_command, &workspace, &chart).await?;
     let kubeconfig = kubernetes_connector_kubeconfig(&identity.namespace).await?;
@@ -703,10 +709,19 @@ async fn refuse_to_drop_a_recorded_model_credential(identity: &InstallIdentity) 
     )))
 }
 
+fn github_repo_allowlist_sets(repos: &[String]) -> BTreeMap<String, String> {
+    repos
+        .iter()
+        .enumerate()
+        .map(|(index, repo)| (format!("api.githubRepoAllowlist[{index}]"), repo.clone()))
+        .collect()
+}
+
 async fn apply_curie_platform(
     chart: &Path,
     dry_run: bool,
     identity: &InstallIdentity,
+    workspace_repo: &[String],
 ) -> Result<Vec<String>> {
     let installation = crate::installation::Installation {
         version: crate::installation::SUPPORTED_VERSION,
@@ -717,7 +732,7 @@ async fn apply_curie_platform(
         platform: crate::installation::Platform::default(),
         credentials: crate::installation::Credentials::default(),
         comms: crate::installation::Comms::default(),
-        set: BTreeMap::new(),
+        set: github_repo_allowlist_sets(workspace_repo),
     };
     let local = crate::installation::plan_installation(installation, dry_run)?;
     match crate::installation::apply(crate::installation::ApplyOpts {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -955,6 +955,11 @@ enum SreBotAction {
         /// Kubernetes namespace of the retained observability stack. Default: observability.
         #[arg(long, default_value = "observability")]
         observability_namespace: String,
+        /// Allow this GitHub repository, or `owner/*`, for runtime workspace
+        /// selection. Repeatable. Sets `api.githubRepoAllowlist` on the Curie
+        /// install.
+        #[arg(long = "workspace-repo", value_name = "OWNER/REPO")]
+        workspace_repo: Vec<String>,
     },
 }
 
@@ -2861,6 +2866,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                             namespace,
                             release,
                             observability_namespace,
+                            workspace_repo,
                         },
                 },
         }) => match curie::examples::install_sre_bot(curie::examples::SreBotInstallOpts {
@@ -2871,6 +2877,7 @@ async fn run(command: Option<Command>) -> Result<()> {
             namespace,
             release,
             observability_namespace,
+            workspace_repo,
         })
         .await?
         {
@@ -4062,6 +4069,9 @@ async fn run(command: Option<Command>) -> Result<()> {
                 secret,
                 api_local_port,
             } => {
+                if workspace {
+                    commands::warn_if_empty_github_repo_allowlist(&namespace, &release).await;
+                }
                 let api_key = commands::normalize_deploy_api_key(api_key);
                 // ADR-0057 (supersedes ADR-0024's deploy transport): with no
                 // explicit --api-key, discover the release's strong Secret key;

--- a/cli/tests/example_sre_bot_install.rs
+++ b/cli/tests/example_sre_bot_install.rs
@@ -788,6 +788,10 @@ fn clap_routes_the_one_command_and_exposes_no_operator_configuration_or_credenti
         text.contains("--slack-channel"),
         "the install surface must permit the optional Slack binding: {text}"
     );
+    assert!(
+        text.contains("--workspace-repo"),
+        "the install surface must expose the runtime GitHub allowlist flag: {text}"
+    );
     for required in ["--namespace", "--release", "--observability-namespace"] {
         assert!(
             text.contains(required),
@@ -2018,6 +2022,58 @@ fn assert_no_default_curie_or_observability_targets(lines: &[String]) {
             "custom targeting must not retain default identity `{forbidden}`: {lines:?}"
         );
     }
+}
+
+#[test]
+fn workspace_repo_flags_set_github_repo_allowlist_in_the_dry_run_plan() {
+    let fixture = Fixture::new(nodes(vec![node("node-a", "4Gi", true)]), pods(vec![]));
+    let output = fixture.run(&[
+        "--dry-run",
+        "--json",
+        "--workspace-repo",
+        "acme-corp/acme-bot",
+        "--workspace-repo",
+        "acme-labs/*",
+    ]);
+    let text = shown(&output);
+    assert!(
+        output.status.success(),
+        "workspace-repo dry run must succeed: {text}"
+    );
+    let lines = dry_run_plan_lines(&output);
+    let plan = lines.join("\n");
+    assert!(
+        plan.contains("api.githubRepoAllowlist[0]=acme-corp/acme-bot"),
+        "first --workspace-repo must become allowlist index 0: {lines:?}"
+    );
+    assert!(
+        plan.contains("api.githubRepoAllowlist[1]=acme-labs/*"),
+        "second --workspace-repo must become allowlist index 1: {lines:?}"
+    );
+}
+
+#[test]
+fn workspace_repo_flag_rejects_a_malformed_entry_before_cluster_reads() {
+    let fixture = Fixture::with_modes(
+        nodes(vec![node("node-a", "4Gi", true)]),
+        pods(vec![]),
+        "success",
+        "success",
+        "success",
+    );
+    let output = fixture.run(&["--workspace-repo", "not a repo"]);
+    let text = shown(&output);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "malformed --workspace-repo must be a usage error: {text}"
+    );
+    assert!(
+        text.contains("owner/repo") || text.contains("allowlist"),
+        "usage error must name the expected allowlist shape: {text}"
+    );
+    assert!(fixture.kubectl_calls().is_empty());
+    assert!(fixture.helm_calls().is_empty());
 }
 
 #[test]

--- a/cli/tests/remote_dev_workspace.rs
+++ b/cli/tests/remote_dev_workspace.rs
@@ -75,6 +75,18 @@ fn deploy_response(req: &support::Request, existing: ExistingAgent) -> Response 
             })
             .to_string(),
         ),
+        ("GET", path) if path.contains("/versions/") && path.contains("/connectors?") => {
+            Response::json(
+                200,
+                &json!({
+                    "manifests": [],
+                    "owned_secret_name": "",
+                    "owned_secret_keys": [],
+                    "mcp_entries": {}
+                })
+                .to_string(),
+            )
+        }
         ("POST", "/deployments") => {
             let body: Value = serde_json::from_slice(&req.body).expect("deployment body is JSON");
             let mut result = json!({
@@ -193,6 +205,26 @@ fn workspace_and_no_workspace_are_mutually_exclusive_on_both_tiers() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         assert!(stderr.contains("cannot be used with"), "{tier}: {stderr}");
     }
+}
+
+fn write_helm_values_stub(dir: &Path, values: &str) {
+    let path = dir.join("helm");
+    let script = format!(
+        r#"#!/bin/sh
+case "$*" in
+  *"get values"*" -o json"|*"get values"*"-o json"*)
+    printf '%s\n' '{values}' ;;
+  *) printf 'unexpected helm invocation: %s\n' "$*" >&2; exit 64 ;;
+esac
+"#,
+        values = values.replace('\'', "'\\''")
+    );
+    fs::write(&path, script).expect("write helm stub");
+    let mut permissions = fs::metadata(&path)
+        .expect("helm stub metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&path, permissions).expect("make helm stub executable");
 }
 
 fn write_kubectl_stub(dir: &Path) -> PathBuf {
@@ -360,6 +392,55 @@ fn run_fanout(
     (command.output().expect("run cluster fanout"), server)
 }
 
+fn run_cluster_workspace_with_helm(
+    helm_values: Value,
+    workspace_flag: bool,
+) -> (Output, MockServer) {
+    let plugin = tempfile::tempdir().expect("plugin tempdir");
+    scaffold(plugin.path(), "acme-bot").expect("scaffold bundle");
+    let tools = tempfile::tempdir().expect("tool tempdir");
+    write_kubectl_stub(tools.path());
+    write_helm_values_stub(tools.path(), &helm_values.to_string());
+    let mut paths = vec![tools.path().to_path_buf()];
+    paths.extend(std::env::split_paths(
+        &std::env::var_os("PATH").unwrap_or_default(),
+    ));
+    let path = std::env::join_paths(paths).expect("join PATH");
+    let server = serve(move |req| deploy_response(req, ExistingAgent::Unbound));
+    let mut command = Command::new(bin());
+    command
+        .args(["cluster", "deploy", "--plugin-dir"])
+        .arg(plugin.path())
+        .args([
+            "--api-url",
+            &server.base_url,
+            "--api-key",
+            "test-key",
+            "--namespace",
+            "curie",
+            "--release",
+            "curie",
+            "--agent",
+            "acme-bot",
+            "--env",
+            "dev",
+            "--slack-channel",
+            "C0EXAMPLE1",
+            "--label",
+            LABEL,
+        ])
+        .env("PATH", path)
+        .env_remove("CURIE_API_URL")
+        .env_remove("CURIE_API_KEY");
+    if workspace_flag {
+        command.arg("--workspace");
+    }
+    (
+        command.output().expect("run cluster workspace deploy"),
+        server,
+    )
+}
+
 #[test]
 fn all_targets_serialize_legacy_workspace_true_independently() {
     let (output, server) = run_fanout(
@@ -426,6 +507,60 @@ fn deploy_args(manifest: &Value, tier: &str) -> Vec<Value> {
         .as_array()
         .expect("deploy args")
         .clone()
+}
+
+#[test]
+fn cluster_workspace_warns_when_github_repo_allowlist_is_empty() {
+    let (output, _server) =
+        run_cluster_workspace_with_helm(json!({"api": {"githubRepoAllowlist": []}}), true);
+    assert!(
+        output.status.success(),
+        "deploy failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("api.githubRepoAllowlist"),
+        "empty allowlist must name the chart key: {stderr}"
+    );
+    assert!(
+        stderr.contains("empty") || stderr.contains("denies"),
+        "warning must say the empty allowlist denies selection: {stderr}"
+    );
+}
+
+#[test]
+fn cluster_workspace_stays_quiet_when_github_repo_allowlist_has_entries() {
+    let (output, _server) = run_cluster_workspace_with_helm(
+        json!({"api": {"githubRepoAllowlist": ["acme-corp/acme-bot"]}}),
+        true,
+    );
+    assert!(
+        output.status.success(),
+        "deploy failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("api.githubRepoAllowlist is empty"),
+        "a populated allowlist must not warn: {stderr}"
+    );
+}
+
+#[test]
+fn cluster_deploy_without_workspace_does_not_warn_on_empty_allowlist() {
+    let (output, _server) =
+        run_cluster_workspace_with_helm(json!({"api": {"githubRepoAllowlist": []}}), false);
+    assert!(
+        output.status.success(),
+        "deploy failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("api.githubRepoAllowlist"),
+        "omitting --workspace must not inspect or warn about the allowlist: {stderr}"
+    );
 }
 
 #[test]

--- a/docs/agent-install.md
+++ b/docs/agent-install.md
@@ -126,3 +126,18 @@ jq -cn \
    set to `doctor`.
 
 Return the final `INSTALL_RESULT` line unchanged with the command transcript.
+
+## Runtime repository allowlist
+
+Managed `/workspace` checkouts are selected by one allowed root GitHub URL in
+the opening message. The chart default `api.githubRepoAllowlist: []` denies
+every selection. Set it when you install or upgrade:
+
+```bash
+curie cluster up --set 'api.githubRepoAllowlist[0]=acme-corp/acme-bot'
+```
+
+`owner/*` allows every repository under that owner. `curie cluster deploy
+--workspace` warns when the allowlist is empty. The `--workspace` flag itself
+is a deprecated compatibility no-op; the allowlist is the real control. The
+SRE bot installer also accepts `--workspace-repo owner/repo` (repeatable).

--- a/examples/coder/README.md
+++ b/examples/coder/README.md
@@ -22,6 +22,11 @@ curie cluster deploy --plugin-dir examples/coder \
   --agent acme-dev --env dev --slack-channel C0EXAMPLE1
 ```
 
+The chart default `api.githubRepoAllowlist: []` denies every runtime selection.
+`curie cluster deploy --workspace` warns when that list is empty. The retained
+`--workspace` flag is a deprecated compatibility no-op; the allowlist is the
+real control. `owner/*` allows every repository under that owner.
+
 Invite the bot to the channel. In the opening message, include the single
 allowed root repository URL, for example
 `https://github.com/acme-corp/acme-bot`, together with a focused change. Curie

--- a/examples/sre-bot/README.md
+++ b/examples/sre-bot/README.md
@@ -37,6 +37,20 @@ stores the credential outside bundle content:
 curie example sre-bot install --observability
 ```
 
+Runtime repository workspaces need `api.githubRepoAllowlist`. The chart default
+is empty and denies every selection, including after `curie cluster deploy
+--workspace` (that flag is a deprecated compatibility no-op; the allowlist is
+the real control). Pass `--workspace-repo owner/repo` (repeatable; `owner/*`
+is also accepted), or set the chart value yourself:
+
+```bash
+curie example sre-bot install --observability \
+  --workspace-repo acme-corp/acme-bot
+curie cluster up --set 'api.githubRepoAllowlist[0]=acme-corp/acme-bot'
+```
+
+`curie cluster deploy --workspace` warns when the allowlist is empty.
+
 Inspect the mutation plan first with `--dry-run`. Add `--platform-upgrade` only
 after reading `manifests/platform-upgrade-role.yaml`; it creates a separate,
 purpose-built upgrade path with much wider authority.


### PR DESCRIPTION
When a runtime workspace selection is outside `api.githubRepoAllowlist`, the worker used to say the GitHub App was not installed on the repository. The chart default is `[]` (deny-all), so that copy sent operators to the wrong fix. The refusal now names the chart allowlist. `curie cluster deploy --workspace` warns when the list is empty. `curie example sre-bot install` accepts repeatable `--workspace-repo owner/repo` (or `owner/*`), and the sre-bot, coder, and agent-install docs name the `--set` line next to `--workspace`.

`--workspace` remains a deprecated compatibility no-op on this branch (coding tools are built in). The warning still keys off that flag because that is the operator invocation the ticket names.

## Related issue

Closes #2249

## Fix pin verification

Fix pin: apps/worker/tests/test_workspace.py::test_unallowlisted_selection_names_the_chart_allowlist

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | No plugin packaging, runner turn loop, ACI events, or skill eval | | |
| local | required | Worker 403 copy and CLI verb output (`cluster deploy --workspace` warning, `example sre-bot install --workspace-repo`) | fake | `uv run pytest -q apps/worker/tests/test_workspace.py::test_unallowlisted_selection_names_the_chart_allowlist` against `8da8b9ed5`: PASSED, public_detail names `api.githubRepoAllowlist`. `cargo test --test remote_dev_workspace -- --exact cluster_workspace_warns_when_github_repo_allowlist_is_empty cluster_workspace_stays_quiet_when_github_repo_allowlist_has_entries cluster_deploy_without_workspace_does_not_warn_on_empty_allowlist`: 3 passed. `cargo test --test example_sre_bot_install -- --exact clap_routes_the_one_command_and_exposes_no_operator_configuration_or_credential_flags workspace_repo_flags_set_github_repo_allowlist_in_the_dry_run_plan workspace_repo_flag_rejects_a_malformed_entry_before_cluster_reads`: 3 passed |
| local-release | n/a | No released binary identity, install path, version pin, or release compose | | |
| cluster | n/a | Chart templates, RBAC, sandbox claims, and init containers are unchanged; the allowlist key already exists | | |
| live provider | n/a | No model routing, credential resolution, or provider auth | | |
| external integration | n/a | No Slack, git webhook, or third-party API shape | | |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

Positive and negative per AC:

- Refusal copy: 403 from `WorkspaceCredentialClient.select` now names `api.githubRepoAllowlist`; the old "not authorized for this installation" string is asserted absent. Kernel test posts the same public copy before claim.
- Empty-allowlist warning: `cluster deploy --workspace` with helm values `[]` prints the chart key; the same deploy with `["acme-corp/acme-bot"]` stays quiet; omitting `--workspace` does not inspect or warn.
- Install flag: `--workspace-repo` is on `--help`; two flags become `api.githubRepoAllowlist[0]` and `[1]` in the dry-run plan; `not a repo` is usage exit 2 before helm/kubectl.

## Checklist

- [x] Tests pass for the area I touched (worker workspace tests, CLI remote_dev_workspace, example_sre_bot_install, command_surface, ruff, clippy).
- [x] Docs updated if behavior changed.
- [x] An ADR is added under `docs/adr/` if this is an architectural decision.
