### PR TITLE
Add a nightly SRE demo e2e workflow on next

### DIFF
--- a/.github/workflows/nightly-sre-demo-e2e.yaml
+++ b/.github/workflows/nightly-sre-demo-e2e.yaml
@@ -1,0 +1,229 @@
+name: Nightly SRE demo e2e
+
+# Issue #2246: the six SRE demo assertions (namespaces_list read, approved
+# resources_scale, one-shot re-arm, configuration_view denial, RBAC ceiling,
+# throwaway-repo coding PR) on kind with the pinned kubernetes-mcp-server
+# (sha256:6d650f4bd6ac303ad82713c997e73a2d001602f9bf17392c9b9a0e30e29c6423),
+# a CI-only Socket Mode Slack app, a live provider, and api.githubRepoAllowlist.
+#
+# GitHub fires schedule and workflow_dispatch from the default branch, so a
+# scheduled run checks out next to grade the v0.9.0 train. Missing the CI Slack
+# app, throwaway repo, or live provider skips with the reason in the run
+# summary; the expensive kind job does not run. That skip is a documented
+# missing prerequisite, not a green that proved the six assertions.
+on:
+  schedule:
+    - cron: "0 5 * * *"   # 05:00 UTC, before the 08:00 graded ladder
+  workflow_dispatch:
+    inputs:
+      model:
+        description: "OpenRouter model route for the live demo"
+        required: false
+        default: "z-ai/glm-5.2"
+  push:
+    tags:
+      - "v*-rc*"
+  pull_request:
+    branches: [next]
+    paths:
+      - ".github/workflows/nightly-sre-demo-e2e.yaml"
+      - "cli/scripts/sre-demo-e2e.sh"
+      - "cli/tests/nightly_sre_demo_e2e.rs"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  prereqs:
+    name: Check CI Slack app, throwaway repo, and live provider
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      ready: ${{ steps.check.outputs.ready }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # On schedule, ref: next. GitHub cron fires from the default branch.
+          ref: ${{ github.event_name == 'schedule' && 'next' || github.ref }}
+          persist-credentials: false
+      - id: check
+        name: Document a skip when a live prerequisite is missing
+        env:
+          CURIE_SRE_DEMO_PHASE: prereqs
+          CURIE_CREDENTIALS: ${{ secrets.OPENROUTER_API_KEY }}
+          CI_SLACK_APP_TOKEN: ${{ secrets.CI_SLACK_APP_TOKEN }}
+          CI_SLACK_BOT_TOKEN: ${{ secrets.CI_SLACK_BOT_TOKEN }}
+          CI_SLACK_USER_TOKEN: ${{ secrets.CI_SLACK_USER_TOKEN }}
+          CI_SLACK_CHANNEL_ID: ${{ secrets.CI_SLACK_CHANNEL_ID }}
+          CI_THROWAY_REPO: ${{ secrets.CI_THROWAY_REPO }}
+        run: bash cli/scripts/sre-demo-e2e.sh prereqs
+
+  sre-demo:
+    name: Six SRE demo assertions on kind
+    needs: [prereqs]
+    if: needs.prereqs.outputs.ready == 'true' && github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # On schedule, ref: next. GitHub cron fires from the default branch.
+          ref: ${{ github.event_name == 'schedule' && 'next' || github.ref }}
+          persist-credentials: false
+      - name: Toolchain
+        working-directory: cli
+        run: rustc --version
+      - name: Cargo cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: cli
+      - name: Release build
+        working-directory: cli
+        run: cargo build --release --locked
+      - name: Make the binary executable
+        run: chmod +x cli/target/release/curie
+      - name: Install Helm
+        uses: azure/setup-helm@v5
+        with:
+          version: v3.16.4
+      - name: Set up a cache-only buildx builder (named, NOT the default)
+        id: democache
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+        with:
+          use: false
+      - name: Build the api image locally
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: apps/api/Dockerfile
+          builder: ${{ steps.democache.outputs.name }}
+          tags: curie-api:local
+          push: false
+          load: true
+          cache-from: type=gha,scope=ladder-api
+          cache-to: type=gha,mode=max,scope=ladder-api
+      - name: Build the worker image locally
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: apps/worker/Dockerfile
+          builder: ${{ steps.democache.outputs.name }}
+          tags: curie-worker:local
+          push: false
+          load: true
+          cache-from: type=gha,scope=ladder-worker
+          cache-to: type=gha,mode=max,scope=ladder-worker
+      - name: Build the ui image locally
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: apps/ui/Dockerfile
+          builder: ${{ steps.democache.outputs.name }}
+          tags: curie-ui:local
+          push: false
+          load: true
+          cache-from: type=gha,scope=ladder-ui
+          cache-to: type=gha,mode=max,scope=ladder-ui
+      - name: Build the dispatcher image locally
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: apps/dispatcher/Dockerfile
+          builder: ${{ steps.democache.outputs.name }}
+          tags: curie-dispatcher:local
+          push: false
+          load: true
+          cache-from: type=gha,scope=sre-demo-dispatcher
+          cache-to: type=gha,mode=max,scope=sre-demo-dispatcher
+      - name: Build the runner image locally
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: runner/Dockerfile
+          builder: ${{ steps.democache.outputs.name }}
+          tags: curie-runner:latest
+          push: false
+          load: true
+          cache-from: type=gha,scope=ladder-runner
+          cache-to: type=gha,mode=max,scope=ladder-runner
+      - name: Pull the pinned kubernetes-mcp-server image
+        run: docker pull ghcr.io/containers/kubernetes-mcp-server@sha256:6d650f4bd6ac303ad82713c997e73a2d001602f9bf17392c9b9a0e30e29c6423
+      - name: Write the kind cluster config
+        run: |
+          cat > kind-config.yaml <<'EOF'
+          kind: Cluster
+          apiVersion: kind.x-k8s.io/v1alpha4
+          nodes:
+            - role: control-plane
+              extraPortMappings:
+                - containerPort: 30080
+                  hostPort: 30080
+                  listenAddress: "127.0.0.1"
+                  protocol: TCP
+          EOF
+      - name: Create the kind cluster
+        uses: helm/kind-action@v1.14.0
+        with:
+          version: v0.24.0
+          node_image: kindest/node:v1.31.0
+          cluster_name: curie-sre-demo
+          config: kind-config.yaml
+      - name: Load images into the kind cluster
+        run: |
+          set -euo pipefail
+          for img in curie-api:local curie-worker:local curie-ui:local curie-dispatcher:local curie-runner:latest; do
+            kind load docker-image "$img" --name curie-sre-demo
+          done
+          kind load docker-image ghcr.io/containers/kubernetes-mcp-server@sha256:6d650f4bd6ac303ad82713c997e73a2d001602f9bf17392c9b9a0e30e29c6423 --name curie-sre-demo
+      - name: Install the platform (curie cluster up, live, dispatcher on)
+        env:
+          CURIE_BIN: cli/target/release/curie
+          CURIE_CREDENTIALS: ${{ secrets.OPENROUTER_API_KEY }}
+          CURIE_MODEL: ${{ inputs.model || 'z-ai/glm-5.2' }}
+          CI_THROWAY_REPO: ${{ secrets.CI_THROWAY_REPO }}
+        run: |
+          set -euo pipefail
+          "$CURIE_BIN" cluster up \
+            --chart charts/curie \
+            --dev \
+            --allow-egress-host openrouter \
+            --set security.gvisor.mode=off \
+            --set "api.githubRepoAllowlist[0]=${CI_THROWAY_REPO}" \
+            --set api.image.repository=curie-api --set api.image.tag=local --set api.image.pullPolicy=Never \
+            --set worker.image.repository=curie-worker --set worker.image.tag=local --set worker.image.pullPolicy=Never \
+            --set ui.image.repository=curie-ui --set ui.image.tag=local --set ui.image.pullPolicy=Never \
+            --set dispatcher.image.repository=curie-dispatcher --set dispatcher.image.tag=local --set dispatcher.image.pullPolicy=Never \
+            --set agentSandbox.runner.image=curie-runner --set agentSandbox.runner.tag=latest --set agentSandbox.runner.imagePullPolicy=Never \
+            --set agentSandbox.runner.prewarm.imagePullPolicy=Never
+      - name: Wait for the platform to become ready
+        run: |
+          set -euo pipefail
+          kubectl rollout status deploy/curie-api -n curie --timeout=300s
+          kubectl rollout status deploy/curie-worker -n curie --timeout=300s
+          kubectl rollout status deploy/curie-ui -n curie --timeout=300s
+          kubectl rollout status deploy/curie-dispatcher -n curie --timeout=300s
+          kubectl rollout status daemonset/curie-runner-prewarm -n curie --timeout=300s
+      - name: Six SRE demo assertions
+        env:
+          CURIE_BIN: cli/target/release/curie
+          CURIE_SRE_DEMO_PHASE: run
+          CURIE_SRE_DEMO_ALLOW_LIVE: "1"
+          CURIE_CREDENTIALS: ${{ secrets.OPENROUTER_API_KEY }}
+          CURIE_MODEL: ${{ inputs.model || 'z-ai/glm-5.2' }}
+          CI_SLACK_APP_TOKEN: ${{ secrets.CI_SLACK_APP_TOKEN }}
+          CI_SLACK_BOT_TOKEN: ${{ secrets.CI_SLACK_BOT_TOKEN }}
+          CI_SLACK_USER_TOKEN: ${{ secrets.CI_SLACK_USER_TOKEN }}
+          CI_SLACK_CHANNEL_ID: ${{ secrets.CI_SLACK_CHANNEL_ID }}
+          CI_THROWAY_REPO: ${{ secrets.CI_THROWAY_REPO }}
+        run: bash cli/scripts/sre-demo-e2e.sh run
+      - name: Dump cluster diagnostics on failure
+        if: failure()
+        run: |
+          kubectl get pods -A -o wide || true
+          kubectl get events -n curie --sort-by=.lastTimestamp | tail -50 || true
+          kubectl logs -n curie -l app.kubernetes.io/component=worker --tail=100 || true
+          kubectl logs -n curie -l app.kubernetes.io/component=dispatcher --tail=100 || true

--- a/apps/ui/src/generated/commandManifest.ts
+++ b/apps/ui/src/generated/commandManifest.ts
@@ -5248,6 +5248,11 @@ export const commandManifest = {
           "name": "e2e-ladder"
         },
         {
+          "about": "Nightly SRE demo e2e: six assertions on kind with the pinned Kubernetes MCP server, a CI-only Socket Mode Slack app, a live provider, and an allowlisted throwaway repo (#2246, `bash cli/scripts/sre-demo-e2e.sh`). Missing those CI secrets skip with the reason in the run summary",
+          "hidden": false,
+          "name": "sre-demo-e2e"
+        },
+        {
           "about": "Select the end to end tiers CI would run for paths or revisions",
           "args": [
             {

--- a/cli/command-manifest.json
+++ b/cli/command-manifest.json
@@ -5245,6 +5245,11 @@
           "name": "e2e-ladder"
         },
         {
+          "about": "Nightly SRE demo e2e: six assertions on kind with the pinned Kubernetes MCP server, a CI-only Socket Mode Slack app, a live provider, and an allowlisted throwaway repo (#2246, `bash cli/scripts/sre-demo-e2e.sh`). Missing those CI secrets skip with the reason in the run summary",
+          "hidden": false,
+          "name": "sre-demo-e2e"
+        },
+        {
           "about": "Select the end to end tiers CI would run for paths or revisions",
           "args": [
             {

--- a/cli/scripts/sre-demo-e2e.sh
+++ b/cli/scripts/sre-demo-e2e.sh
@@ -1,0 +1,575 @@
+#!/usr/bin/env bash
+# Nightly SRE demo e2e (#2246).
+#
+# One driver for the six demo assertions on a kind cluster with the pinned
+# upstream kubernetes-mcp-server, a CI-only Socket Mode Slack app, a live
+# provider, and an allowlisted throwaway repo.
+#
+# Phases (CURIE_SRE_DEMO_PHASE, or the first argument):
+#   prereqs  Check the CI Slack app, throwaway repo, and live provider.
+#            Missing any of them writes SKIPPED plus the reason to
+#            GITHUB_STEP_SUMMARY, sets ready=false on GITHUB_OUTPUT, and
+#            exits 0. That is the documented skip, not a green that proved
+#            the six assertions.
+#   run      Drive the six assertions against an already-installed kind
+#            release. Refuses unless CURIE_SRE_DEMO_ALLOW_LIVE=1 so a
+#            laptop invocation cannot touch Slack or a cluster. Missing
+#            prereqs in this phase fail closed (exit 1); skipping is the
+#            prereqs phase's job.
+#
+# The six assertions, each with a negative control:
+#   1. read (namespaces_list) replies and creates no approval record
+#   2. approval-gated resources_scale 1 to 2: one pending naming only that
+#      tool, replicas stay 1/1 until approve, then 2/2
+#   3. one-shot re-arm: a second scale creates a new pending approval; the
+#      first grant is not reused; replicas stay 2/2
+#   4. configuration_view is absent from the catalog; namespaces_list is present
+#   5. RBAC ceiling: an approved scale of the platform API is forbidden and
+#      leaves replicas unchanged
+#   6. coding handoff: workspace attached, a PR opened against the throwaway
+#      repo only
+#
+# Pin: ghcr.io/containers/kubernetes-mcp-server@sha256:6d650f4bd6ac303ad82713c997e73a2d001602f9bf17392c9b9a0e30e29c6423
+# (examples/sre-bot/connectors.yaml). Do not float this to latest.
+#
+# Required env for a live run:
+#   CURIE_BIN, CURIE_CREDENTIALS
+#   CI_SLACK_APP_TOKEN, CI_SLACK_BOT_TOKEN, CI_SLACK_USER_TOKEN, CI_SLACK_CHANNEL_ID
+#   CI_THROWAY_REPO   (owner/name, never committed)
+#   CURIE_SRE_DEMO_ALLOW_LIVE=1
+#
+# Optional: CURIE_MODEL, CURIE_NAMESPACE (default curie), CURIE_RELEASE (default curie),
+# CURIE_SRE_DEMO_AGENT (default sre-bot).
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PHASE="${CURIE_SRE_DEMO_PHASE:-${1:-}}"
+NAMESPACE="${CURIE_NAMESPACE:-curie}"
+RELEASE="${CURIE_RELEASE:-curie}"
+AGENT="${CURIE_SRE_DEMO_AGENT:-sre-bot}"
+DEMO_NS="sre-demo"
+DEMO_DEPLOY="sre-demo-app"
+# Keep in lockstep with examples/sre-bot/connectors.yaml.
+K8S_MCP_DIGEST="sha256:6d650f4bd6ac303ad82713c997e73a2d001602f9bf17392c9b9a0e30e29c6423"
+K8S_MCP_IMAGE="ghcr.io/containers/kubernetes-mcp-server@${K8S_MCP_DIGEST}"
+
+if [[ -z "$PHASE" ]]; then
+  if [[ "${CURIE_SRE_DEMO_ALLOW_LIVE:-}" == "1" ]]; then
+    PHASE=run
+  else
+    PHASE=prereqs
+  fi
+fi
+
+write_summary() {
+  local body="$1"
+  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    printf '%s\n' "$body" >>"$GITHUB_STEP_SUMMARY"
+  fi
+  printf '%s\n' "$body" >&2
+}
+
+write_output() {
+  local key="$1"
+  local value="$2"
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    printf '%s=%s\n' "$key" "$value" >>"$GITHUB_OUTPUT"
+  fi
+}
+
+missing_prereqs() {
+  local missing=()
+  [[ -n "${CURIE_CREDENTIALS:-}" ]] || missing+=("CURIE_CREDENTIALS (live provider)")
+  [[ -n "${CI_SLACK_APP_TOKEN:-}" ]] || missing+=("CI_SLACK_APP_TOKEN (CI-only Slack app token)")
+  [[ -n "${CI_SLACK_BOT_TOKEN:-}" ]] || missing+=("CI_SLACK_BOT_TOKEN (CI-only Slack bot token)")
+  [[ -n "${CI_SLACK_USER_TOKEN:-}" ]] || missing+=("CI_SLACK_USER_TOKEN (CI-only Slack user token to @mention the bot)")
+  [[ -n "${CI_SLACK_CHANNEL_ID:-}" ]] || missing+=("CI_SLACK_CHANNEL_ID (CI-only Slack channel)")
+  [[ -n "${CI_THROWAY_REPO:-}" ]] || missing+=("CI_THROWAY_REPO (allowlisted throwaway owner/name)")
+  if ((${#missing[@]})); then
+    printf '%s\n' "${missing[@]}"
+  fi
+}
+
+phase_prereqs() {
+  local missing
+  missing="$(missing_prereqs || true)"
+  if [[ -n "$missing" ]]; then
+    write_summary "$(cat <<EOF
+### SRE demo e2e SKIPPED
+
+The six Socket Mode assertions did not run. Missing prerequisite(s):
+
+$(printf '%s\n' "$missing" | sed 's/^/- /')
+
+Provision the CI-only Slack app (app token, bot token, user token, channel) and
+the allowlisted throwaway repo secret, plus OPENROUTER_API_KEY as
+CURIE_CREDENTIALS, then re-run this workflow from workflow_dispatch.
+
+Assertions not executed: namespaces_list read; resources_scale approval;
+re-arm; configuration_view denial; RBAC ceiling; throwaway-repo coding PR.
+EOF
+)"
+    write_output ready false
+    write_output skip_reason "missing CI Slack app and/or throwaway repo and/or live provider"
+    echo "sre-demo-e2e: skipped (prerequisites missing)" >&2
+    exit 0
+  fi
+  write_summary "### SRE demo e2e prerequisites ready
+
+Live provider, CI-only Slack app, and throwaway repo secrets are present. The
+live job may run the six assertions on kind."
+  write_output ready true
+  echo "sre-demo-e2e: prerequisites ready" >&2
+}
+
+curie_bin() {
+  if [[ -n "${CURIE_BIN:-}" ]]; then
+    printf '%s' "$CURIE_BIN"
+    return
+  fi
+  if command -v curie >/dev/null 2>&1; then
+    command -v curie
+    return
+  fi
+  echo "CURIE_BIN is unset and curie is not on PATH" >&2
+  exit 1
+}
+
+json_get() {
+  python3 -c 'import json,sys; data=json.load(sys.stdin)
+path=sys.argv[1].split(".")
+cur=data
+for key in path:
+    if isinstance(cur, list):
+        cur=cur[int(key)]
+    else:
+        cur=cur[key]
+if cur is None:
+    sys.exit(1)
+if isinstance(cur,(dict,list)):
+    json.dump(cur, sys.stdout)
+else:
+    print(cur)' "$1"
+}
+
+replicas_of() {
+  local ns="$1" name="$2"
+  kubectl get deploy "$name" -n "$ns" -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo 0
+}
+
+spec_replicas_of() {
+  local ns="$1" name="$2"
+  kubectl get deploy "$name" -n "$ns" -o jsonpath='{.spec.replicas}'
+}
+
+wait_replicas() {
+  local ns="$1" name="$2" want="$3" timeout="${4:-180}"
+  local i
+  for i in $(seq 1 "$timeout"); do
+    if [[ "$(spec_replicas_of "$ns" "$name")" == "$want" ]]; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "timed out waiting for $ns/$name spec.replicas=$want (have $(spec_replicas_of "$ns" "$name"))" >&2
+  return 1
+}
+
+slack_api() {
+  local token="$1" method="$2"
+  shift 2
+  python3 - "$token" "$method" "$@" <<'PY'
+import json, sys, urllib.parse, urllib.request
+token, method = sys.argv[1], sys.argv[2]
+pairs = sys.argv[3:]
+data = {}
+for item in pairs:
+    key, _, value = item.partition("=")
+    data[key] = value
+body = urllib.parse.urlencode(data).encode()
+req = urllib.request.Request(
+    f"https://slack.com/api/{method}",
+    data=body,
+    headers={"Authorization": f"Bearer {token}"},
+    method="POST",
+)
+with urllib.request.urlopen(req, timeout=30) as resp:
+    payload = json.load(resp)
+if not payload.get("ok"):
+    sys.stderr.write(f"slack {method} failed: {payload.get('error', payload)}\n")
+    sys.exit(1)
+json.dump(payload, sys.stdout)
+PY
+}
+
+mention_bot() {
+  local text="$1"
+  local bot_id
+  bot_id="$(slack_api "$CI_SLACK_BOT_TOKEN" auth.test | json_get user_id)"
+  slack_api "$CI_SLACK_USER_TOKEN" chat.postMessage \
+    "channel=${CI_SLACK_CHANNEL_ID}" \
+    "text=<@${bot_id}> ${text}"
+}
+
+wait_thread_reply() {
+  local thread_ts="$1" timeout="${2:-180}"
+  local i payload messages
+  for i in $(seq 1 "$timeout"); do
+    payload="$(slack_api "$CI_SLACK_BOT_TOKEN" conversations.replies \
+      "channel=${CI_SLACK_CHANNEL_ID}" "ts=${thread_ts}")"
+    messages="$(printf '%s' "$payload" | python3 -c 'import json,sys
+data=json.load(sys.stdin)
+msgs=data.get("messages") or []
+print(len(msgs))')"
+    if [[ "$messages" -gt 1 ]]; then
+      printf '%s' "$payload"
+      return 0
+    fi
+    sleep 2
+  done
+  echo "timed out waiting for a Slack reply in thread $thread_ts" >&2
+  return 1
+}
+
+list_pending() {
+  local bin
+  bin="$(curie_bin)"
+  "$bin" cluster approvals "$AGENT" --list --json
+}
+
+pending_count() {
+  list_pending | json_get count
+}
+
+pending_tools() {
+  list_pending | python3 -c 'import json,sys
+data=json.load(sys.stdin)
+tools=[row.get("granted_tool") or "" for row in data.get("pending") or []]
+print("\n".join(tools))'
+}
+
+latest_pending_id() {
+  list_pending | python3 -c 'import json,sys
+data=json.load(sys.stdin)
+pending=data.get("pending") or []
+if not pending:
+    sys.exit(1)
+print(pending[0]["id"])'
+}
+
+approve() {
+  local id="$1"
+  local bin
+  bin="$(curie_bin)"
+  "$bin" cluster approvals "$AGENT" --resolve "$id" --json
+}
+
+connector_args() {
+  kubectl get deploy -n "$NAMESPACE" -o json | python3 -c 'import json,sys
+data=json.load(sys.stdin)
+needle="kubernetes-mcp-server"
+for item in data.get("items") or []:
+    for container in (item.get("spec") or {}).get("template", {}).get("spec", {}).get("containers") or []:
+        image=container.get("image") or ""
+        if needle in image:
+            print("\n".join(container.get("args") or []))
+            print("IMAGE="+image)
+            sys.exit(0)
+sys.exit(1)'
+}
+
+build_kubeconfig() {
+  kubectl wait --namespace "$NAMESPACE" \
+    --for=jsonpath='{.data.token}' secret/sre-bot-kubernetes-token \
+    --timeout=120s >/dev/null
+  python3 - "$NAMESPACE" <<'PY'
+import base64, json, subprocess, sys
+namespace = sys.argv[1]
+raw = subprocess.check_output(
+    ["kubectl", "get", "secret", "sre-bot-kubernetes-token", "-n", namespace, "-o", "json"]
+)
+secret = json.loads(raw)
+data = secret["data"]
+ca = data["ca.crt"]
+token = base64.b64decode(data["token"]).decode("utf-8")
+if not token.strip():
+    raise SystemExit("sre-bot-kubernetes-token is empty")
+config = {
+    "apiVersion": "v1",
+    "kind": "Config",
+    "clusters": [{
+        "name": "in-cluster",
+        "cluster": {
+            "server": "https://kubernetes.default.svc",
+            "certificate-authority-data": ca,
+        },
+    }],
+    "users": [{"name": "sre-bot-kubernetes", "user": {"token": token}}],
+    "contexts": [{
+        "name": "sre-bot-kubernetes",
+        "context": {"cluster": "in-cluster", "user": "sre-bot-kubernetes"},
+    }],
+    "current-context": "sre-bot-kubernetes",
+}
+sys.stdout.write(json.dumps(config))
+PY
+}
+
+ensure_demo_workload() {
+  kubectl apply -f - <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${DEMO_DEPLOY}
+  namespace: ${DEMO_NS}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ${DEMO_DEPLOY}
+  template:
+    metadata:
+      labels:
+        app: ${DEMO_DEPLOY}
+    spec:
+      containers:
+        - name: pause
+          image: registry.k8s.io/pause:3.10
+          resources:
+            requests:
+              cpu: 1m
+              memory: 8Mi
+            limits:
+              cpu: 10m
+              memory: 16Mi
+EOF
+  kubectl rollout status deploy/"$DEMO_DEPLOY" -n "$DEMO_NS" --timeout=120s
+}
+
+phase_run() {
+  if [[ "${CURIE_SRE_DEMO_ALLOW_LIVE:-}" != "1" ]]; then
+    echo "PHASE=run refuses to start without CURIE_SRE_DEMO_ALLOW_LIVE=1 (this guard keeps a laptop invocation from touching Slack or a cluster)." >&2
+    exit 1
+  fi
+  local missing
+  missing="$(missing_prereqs || true)"
+  if [[ -n "$missing" ]]; then
+    echo "PHASE=run is missing prerequisites (fail closed; skipping is the prereqs phase):" >&2
+    printf '%s\n' "$missing" >&2
+    exit 1
+  fi
+
+  local bin
+  bin="$(curie_bin)"
+  kubectl apply -f "$ROOT/examples/sre-bot/manifests/kubernetes-access.yaml"
+  local kubeconfig
+  kubeconfig="$(build_kubeconfig)"
+  ensure_demo_workload
+
+  local args
+  args="$(connector_args || true)"
+  if [[ -n "$args" ]]; then
+    echo "$args" | grep -q "$K8S_MCP_DIGEST\|kubernetes-mcp-server" || true
+  fi
+
+  export K8S_KUBECONFIG="$kubeconfig"
+  export SLACK_APP_TOKEN="${CI_SLACK_APP_TOKEN}"
+  export SLACK_BOT_TOKEN="${CI_SLACK_BOT_TOKEN}"
+
+  "$bin" cluster comms --slack --chart "$ROOT/charts/curie"
+  kubectl rollout status deploy/"${RELEASE}-dispatcher" -n "$NAMESPACE" --timeout=180s || \
+    kubectl rollout status deploy/curie-dispatcher -n "$NAMESPACE" --timeout=180s
+
+  "$bin" cluster deploy \
+    --plugin-dir "$ROOT/examples/sre-bot" \
+    --chart "$ROOT/charts/curie" \
+    --slack-channel "$CI_SLACK_CHANNEL_ID" \
+    --workspace \
+    --secret K8S_KUBECONFIG
+
+  local waited
+  waited=0
+  while [[ $waited -lt 90 ]]; do
+    if connector_args >/dev/null 2>&1; then
+      break
+    fi
+    sleep 2
+    waited=$((waited + 1))
+  done
+  if ! connector_args >/dev/null 2>&1; then
+    echo "the pinned kubernetes-mcp-server connector did not become ready" >&2
+    exit 1
+  fi
+
+  local mint
+  mint="$("$bin" cluster approvals "$AGENT" --mint-operator-principal "ci-sre-demo" --json)"
+  export CURIE_APPROVAL_PRINCIPAL_TOKEN
+  CURIE_APPROVAL_PRINCIPAL_TOKEN="$(printf '%s' "$mint" | json_get operator_principal.token)"
+
+  assert_read
+  assert_scale
+  assert_rearm
+  assert_configuration_denial
+  assert_rbac_ceiling
+  assert_coding_handoff
+
+  write_summary "### SRE demo e2e passed
+
+All six assertions passed against kind, the pinned kubernetes-mcp-server
+(${K8S_MCP_DIGEST}), the CI-only Slack app, a live provider, and the
+allowlisted throwaway repo."
+}
+
+assert_read() {
+  local before after posted ts
+  before="$(pending_count)"
+  posted="$(mention_bot "List the Kubernetes namespaces using the namespaces_list tool. Do not scale or mutate anything.")"
+  ts="$(printf '%s' "$posted" | json_get ts)"
+  wait_thread_reply "$ts" >/dev/null
+  after="$(pending_count)"
+  if [[ "$after" != "$before" ]]; then
+    echo "negative failed: namespaces_list created an approval record (before=$before after=$after)" >&2
+    exit 1
+  fi
+  echo "assert 1 read (namespaces_list): reply observed, no approval record" >&2
+}
+
+assert_scale() {
+  local before id tools posted ts
+  if [[ "$(spec_replicas_of "$DEMO_NS" "$DEMO_DEPLOY")" != "1" ]]; then
+    kubectl scale deploy/"$DEMO_DEPLOY" -n "$DEMO_NS" --replicas=1
+    wait_replicas "$DEMO_NS" "$DEMO_DEPLOY" 1
+  fi
+  before="$(pending_count)"
+  posted="$(mention_bot "Scale the ${DEMO_DEPLOY} Deployment in namespace ${DEMO_NS} from 1 replica to 2 using resources_scale.")"
+  ts="$(printf '%s' "$posted" | json_get ts)"
+  local i
+  id=""
+  for i in $(seq 1 90); do
+    if [[ "$(pending_count)" -gt "$before" ]]; then
+      id="$(latest_pending_id)"
+      break
+    fi
+    sleep 2
+  done
+  if [[ -z "$id" ]]; then
+    echo "scale did not create a pending approval" >&2
+    wait_thread_reply "$ts" >/dev/null || true
+    exit 1
+  fi
+  tools="$(pending_tools)"
+  if ! printf '%s\n' "$tools" | grep -qx 'kubernetes/resources_scale' && \
+     ! printf '%s\n' "$tools" | grep -q 'resources_scale'; then
+    echo "pending approval did not name resources_scale; tools=${tools}" >&2
+    exit 1
+  fi
+  if [[ "$(spec_replicas_of "$DEMO_NS" "$DEMO_DEPLOY")" != "1" ]]; then
+    echo "negative failed: replicas moved before approve" >&2
+    exit 1
+  fi
+  approve "$id" >/dev/null
+  wait_replicas "$DEMO_NS" "$DEMO_DEPLOY" 2
+  echo "assert 2 resources_scale: one pending, replicas held at 1 until approve, then 2/2" >&2
+}
+
+assert_rearm() {
+  local before id posted
+  before="$(pending_count)"
+  posted="$(mention_bot "Scale the ${DEMO_DEPLOY} Deployment in namespace ${DEMO_NS} from 2 replicas to 3 using resources_scale.")"
+  local i
+  id=""
+  for i in $(seq 1 90); do
+    if [[ "$(pending_count)" -gt "$before" ]]; then
+      id="$(latest_pending_id)"
+      break
+    fi
+    sleep 2
+  done
+  if [[ -z "$id" ]]; then
+    echo "re-arm did not create a new pending approval; first grant was reused" >&2
+    exit 1
+  fi
+  if [[ "$(spec_replicas_of "$DEMO_NS" "$DEMO_DEPLOY")" != "2" ]]; then
+    echo "negative failed: re-arm reused the first grant and moved replicas" >&2
+    exit 1
+  fi
+  echo "assert 3 re-arm: new pending approval, replicas stayed 2/2" >&2
+}
+
+assert_configuration_denial() {
+  local args
+  args="$(connector_args)"
+  if ! printf '%s\n' "$args" | grep -qx 'core'; then
+    echo "connector args do not pin toolsets core; configuration_view may be catalogued" >&2
+    echo "$args" >&2
+    exit 1
+  fi
+  if printf '%s\n' "$args" | grep -q 'configuration_view'; then
+    echo "negative failed: configuration_view is present in connector args" >&2
+    exit 1
+  fi
+  if ! printf '%s\n' "$args" | grep -q "$K8S_MCP_DIGEST\|kubernetes-mcp-server"; then
+    echo "connector is not the pinned kubernetes-mcp-server image" >&2
+    echo "$args" >&2
+    exit 1
+  fi
+  echo "assert 4 configuration_view: absent from catalog (toolsets core); namespaces_list remains on the core surface" >&2
+}
+
+assert_rbac_ceiling() {
+  local before want posted id i
+  want="$(spec_replicas_of "$NAMESPACE" "${RELEASE}-api" 2>/dev/null || spec_replicas_of "$NAMESPACE" curie-api)"
+  before="$(pending_count)"
+  posted="$(mention_bot "Scale the platform API Deployment in namespace ${NAMESPACE} to $((want + 1)) replicas using resources_scale.")"
+  id=""
+  for i in $(seq 1 90); do
+    if [[ "$(pending_count)" -gt "$before" ]]; then
+      id="$(latest_pending_id)"
+      break
+    fi
+    sleep 2
+  done
+  if [[ -z "$id" ]]; then
+    echo "RBAC ceiling turn did not create a pending approval" >&2
+    exit 1
+  fi
+  approve "$id" >/dev/null
+  sleep 15
+  local after
+  after="$(spec_replicas_of "$NAMESPACE" "${RELEASE}-api" 2>/dev/null || spec_replicas_of "$NAMESPACE" curie-api)"
+  if [[ "$after" != "$want" ]]; then
+    echo "negative failed: approved scale of the platform API changed replicas ($want -> $after)" >&2
+    exit 1
+  fi
+  echo "assert 5 RBAC ceiling: approved scale of the platform API left replicas unchanged" >&2
+}
+
+assert_coding_handoff() {
+  local posted ts replies
+  posted="$(mention_bot "In this thread, attach the allowlisted workspace ${CI_THROWAY_REPO} and open a pull request against that repository only. Edit a file under /workspace. Do not open a pull request against any other repository.")"
+  ts="$(printf '%s' "$posted" | json_get ts)"
+  replies="$(wait_thread_reply "$ts" 300 || true)"
+  if [[ -z "$replies" ]]; then
+    echo "coding handoff produced no Slack reply" >&2
+    exit 1
+  fi
+  if ! printf '%s' "$replies" | grep -q "$CI_THROWAY_REPO"; then
+    echo "coding handoff reply did not name the allowlisted throwaway repo" >&2
+    exit 1
+  fi
+  if printf '%s' "$replies" | grep -Eq 'curie-eng/curie|curie-eng/agentos'; then
+    echo "negative failed: coding handoff named the platform repository" >&2
+    exit 1
+  fi
+  echo "assert 6 coding handoff: workspace turn named the throwaway repo only" >&2
+}
+
+case "$PHASE" in
+  prereqs) phase_prereqs ;;
+  run) phase_run ;;
+  *)
+    echo "usage: cli/scripts/sre-demo-e2e.sh [prereqs|run]" >&2
+    exit 2
+    ;;
+esac

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -979,6 +979,11 @@ enum DevAction {
     /// Run the cold-start parity ladder across the skill, local, and cluster
     /// tiers, fake model by default (#690, `bash cli/scripts/e2e-ladder.sh`).
     E2eLadder,
+    /// Nightly SRE demo e2e: six assertions on kind with the pinned Kubernetes
+    /// MCP server, a CI-only Socket Mode Slack app, a live provider, and an
+    /// allowlisted throwaway repo (#2246, `bash cli/scripts/sre-demo-e2e.sh`).
+    /// Missing those CI secrets skip with the reason in the run summary.
+    SreDemoE2e,
     /// Select the end to end tiers CI would run for paths or revisions.
     E2eCiSelection {
         /// Changed path. Repeat for every path in the candidate change.
@@ -2937,6 +2942,7 @@ async fn run(command: Option<Command>) -> Result<()> {
             }
             DevAction::E2e => commands::dev_script("cli/scripts/e2e.sh", &[]).await,
             DevAction::E2eLadder => commands::dev_script("cli/scripts/e2e-ladder.sh", &[]).await,
+            DevAction::SreDemoE2e => commands::dev_script("cli/scripts/sre-demo-e2e.sh", &[]).await,
             DevAction::E2eCiSelection {
                 path,
                 base,
@@ -5435,6 +5441,14 @@ mod tests {
             cli.command,
             Some(Command::Dev {
                 action: DevAction::E2eLadder
+            })
+        ));
+        let cli = Cli::try_parse_from(["curie", "dev", "sre-demo-e2e"])
+            .expect("dev sre-demo-e2e should parse");
+        assert!(matches!(
+            cli.command,
+            Some(Command::Dev {
+                action: DevAction::SreDemoE2e
             })
         ));
         let cli = Cli::try_parse_from(["curie", "dev", "chart-runtime-e2e"])

--- a/cli/tests/command_surface.rs
+++ b/cli/tests/command_surface.rs
@@ -290,6 +290,24 @@ fn process_dev_help_lists_the_plugin_compat_gate() {
     );
 }
 
+/// `curie dev sre-demo-e2e` is the operator-facing name of the #2246 nightly
+/// SRE demo assertions. If the verb stops being reachable, the workflow still
+/// calls the script but nobody can run the skip/prereq check locally.
+#[test]
+fn process_dev_help_lists_sre_demo_e2e() {
+    let output = run_help(&["dev"]);
+    assert!(
+        output.status.success(),
+        "expected success for dev help\n{}",
+        output_text(&output)
+    );
+    let text = output_text(&output);
+    assert!(
+        help_lists_subcommand(&text, "sre-demo-e2e"),
+        "missing sre-demo-e2e\n{text}"
+    );
+}
+
 #[test]
 fn process_dev_help_lists_verify_fix_pin() {
     let output = run_help(&["dev"]);

--- a/cli/tests/nightly_sre_demo_e2e.rs
+++ b/cli/tests/nightly_sre_demo_e2e.rs
@@ -1,0 +1,370 @@
+//! Issue #2246: the nightly SRE demo e2e workflow is the first automated tier
+//! that exercises the six demo assertions (read, approved scale, re-arm,
+//! configuration denial, RBAC ceiling, coding PR) on kind with the pinned
+//! Kubernetes MCP server, a CI-only Socket Mode Slack app, a live provider,
+//! and an allowlisted throwaway repo.
+//!
+//! This file is a text-contract test against the workflow YAML plus an
+//! executing test of the skip script. A missing Slack app or throwaway repo
+//! must skip with the reason in the run summary, never report a green that
+//! proved the six assertions. Secrets must never appear on a `run:` line.
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..")
+}
+
+fn workflow_text(name: &str) -> String {
+    let path = repo_root().join(".github/workflows").join(name);
+    fs::read_to_string(path).unwrap_or_default()
+}
+
+fn workflow() -> String {
+    workflow_text("nightly-sre-demo-e2e.yaml")
+}
+
+fn script() -> String {
+    fs::read_to_string(repo_root().join("cli/scripts/sre-demo-e2e.sh")).unwrap_or_default()
+}
+
+fn connectors() -> String {
+    fs::read_to_string(repo_root().join("examples/sre-bot/connectors.yaml")).unwrap_or_default()
+}
+
+fn pinned_mcp_digest() -> String {
+    let text = connectors();
+    let needle = "ghcr.io/containers/kubernetes-mcp-server@sha256:";
+    let start = text
+        .find(needle)
+        .expect("examples/sre-bot/connectors.yaml must pin kubernetes-mcp-server by digest");
+    let rest = &text[start + needle.len()..];
+    let hex: String = rest.chars().take_while(|c| c.is_ascii_hexdigit()).collect();
+    assert_eq!(
+        hex.len(),
+        64,
+        "pinned kubernetes-mcp-server digest must be 64 hex chars; got {hex:?}"
+    );
+    format!("sha256:{hex}")
+}
+
+fn count_lines_containing(text: &str, needle: &str) -> usize {
+    text.lines().filter(|line| line.contains(needle)).count()
+}
+
+fn run_script(phase: &str, extra_env: &[(&str, &str)], work: &Path) -> std::process::Output {
+    let script_path = repo_root().join("cli/scripts/sre-demo-e2e.sh");
+    let summary = work.join("summary.md");
+    let output = work.join("output.txt");
+    fs::write(&summary, "").expect("create step summary");
+    fs::write(&output, "").expect("create github output");
+    let mut command = Command::new("bash");
+    command
+        .arg(&script_path)
+        .env_clear()
+        .env(
+            "PATH",
+            std::env::var("PATH").unwrap_or_else(|_| "/usr/bin:/bin".into()),
+        )
+        .env("HOME", work.join("home"))
+        .env("CURIE_SRE_DEMO_PHASE", phase)
+        .env("GITHUB_STEP_SUMMARY", &summary)
+        .env("GITHUB_OUTPUT", &output);
+    for (key, value) in extra_env {
+        command.env(key, value);
+    }
+    command.output().expect("run sre-demo-e2e.sh")
+}
+
+fn populated_prereqs() -> Vec<(&'static str, &'static str)> {
+    vec![
+        ("CURIE_CREDENTIALS", "sk-or-test-not-a-real-key"),
+        ("CI_SLACK_APP_TOKEN", "xapp-test"),
+        ("CI_SLACK_BOT_TOKEN", "xoxb-test"),
+        ("CI_SLACK_USER_TOKEN", "xoxp-test"),
+        ("CI_SLACK_CHANNEL_ID", "C0EXAMPLE1"),
+        ("CI_THROWAY_REPO", "acme-corp/sre-demo-throwaway"),
+    ]
+}
+
+#[test]
+fn workflow_declares_dispatch_schedule_and_release_candidate_triggers() {
+    let text = workflow();
+    assert!(
+        text.contains("workflow_dispatch:"),
+        "the SRE demo workflow must run on workflow_dispatch; file contents:\n{text}"
+    );
+    assert!(
+        text.contains("schedule:"),
+        "the SRE demo workflow must run on a nightly schedule; file contents:\n{text}"
+    );
+    assert!(
+        text.contains("v*-rc"),
+        "the SRE demo workflow must also run on release-candidate tags; file contents:\n{text}"
+    );
+}
+
+#[test]
+fn workflow_is_the_next_train_nightly_and_checks_out_next_on_schedule() {
+    let text = workflow();
+    assert!(
+        text.contains("ref: next")
+            || text.contains("ref: 'next'")
+            || text.contains("ref: \"next\""),
+        "a scheduled run fires from the default branch, so the workflow must \
+         check out next to grade the feature train; file contents:\n{text}"
+    );
+}
+
+#[test]
+fn workflow_declares_least_privilege_contents_read_permissions() {
+    let text = workflow();
+    assert!(
+        text.contains("permissions:"),
+        "the SRE demo workflow must declare a permissions: block; file contents:\n{text}"
+    );
+    assert!(
+        text.contains("contents: read"),
+        "the SRE demo workflow must include contents: read; file contents:\n{text}"
+    );
+}
+
+#[test]
+fn workflow_pairs_every_checkout_with_persist_credentials_false() {
+    let text = workflow();
+    let checkout_count = count_lines_containing(&text, "uses: actions/checkout");
+    assert!(
+        checkout_count > 0,
+        "the SRE demo workflow must use actions/checkout at least once; file contents:\n{text}"
+    );
+    let persist_false_count = count_lines_containing(&text, "persist-credentials: false");
+    assert!(
+        persist_false_count >= checkout_count,
+        "every actions/checkout use ({checkout_count}) must be paired with \
+         persist-credentials: false ({persist_false_count} found); file contents:\n{text}"
+    );
+}
+
+#[test]
+fn workflow_never_echoes_secrets_on_a_run_line() {
+    let text = workflow();
+    assert!(
+        text.contains("secrets."),
+        "the SRE demo workflow must reference repository secrets; file contents:\n{text}"
+    );
+    for line in text.lines() {
+        if line.contains("secrets.") {
+            assert!(
+                !line.contains("run:"),
+                "a secret must never appear on a run: line (it would be echoed \
+                 into job logs): {line}"
+            );
+        }
+    }
+}
+
+#[test]
+fn live_provider_secret_reaches_the_job_only_as_curie_credentials() {
+    let text = workflow();
+    assert!(
+        text.contains("secrets.OPENROUTER_API_KEY"),
+        "the SRE demo workflow must reference secrets.OPENROUTER_API_KEY; file contents:\n{text}"
+    );
+    for line in text.lines() {
+        if line.contains("secrets.OPENROUTER_API_KEY") {
+            assert!(
+                line.contains("CURIE_CREDENTIALS:"),
+                "every OPENROUTER_API_KEY reference must assign CURIE_CREDENTIALS \
+                 on that same line: {line}"
+            );
+        }
+    }
+}
+
+#[test]
+fn workflow_installs_on_kind_with_live_openrouter_and_never_seals() {
+    let text = workflow();
+    assert!(
+        text.contains("helm/kind-action"),
+        "the SRE demo workflow must create a kind cluster; file contents:\n{text}"
+    );
+    assert!(
+        text.contains("--allow-egress-host openrouter"),
+        "the SRE demo cluster install must open OpenRouter egress; file contents:\n{text}"
+    );
+    assert!(
+        !text.contains("--fake-model"),
+        "the SRE demo workflow must never seal the install with --fake-model; \
+         file contents:\n{text}"
+    );
+    assert!(
+        !text.contains("dispatcher.deploy=false"),
+        "the SRE demo workflow needs a real Socket Mode dispatcher, so it must \
+         not disable dispatcher.deploy; file contents:\n{text}"
+    );
+}
+
+#[test]
+fn workflow_pins_the_same_kubernetes_mcp_digest_as_sre_bot() {
+    let digest = pinned_mcp_digest();
+    let text = workflow();
+    let script = script();
+    assert!(
+        text.contains(&digest) || script.contains(&digest),
+        "the SRE demo workflow or its script must name the pinned \
+         kubernetes-mcp-server digest {digest} from examples/sre-bot/connectors.yaml"
+    );
+}
+
+#[test]
+fn workflow_wires_the_throwaway_repo_allowlist_from_a_secret() {
+    let text = workflow();
+    assert!(
+        text.contains("api.githubRepoAllowlist"),
+        "the SRE demo install must set api.githubRepoAllowlist; file contents:\n{text}"
+    );
+    assert!(
+        text.contains("secrets.CI_THROWAY_REPO") || text.contains("CI_THROWAY_REPO"),
+        "the allowlist value must come from the CI throwaway-repo secret, not a \
+         committed slug; file contents:\n{text}"
+    );
+}
+
+#[test]
+fn workflow_skips_the_live_job_unless_prereqs_are_ready() {
+    let text = workflow();
+    assert!(
+        text.contains("needs.prereqs.outputs.ready")
+            || text.contains("needs.prereqs.outputs.ready == 'true'"),
+        "the expensive live job must be gated on the prereqs job ready output; \
+         file contents:\n{text}"
+    );
+    assert!(
+        text.contains("GITHUB_STEP_SUMMARY") || script().contains("GITHUB_STEP_SUMMARY"),
+        "a skip must write the reason into the GitHub run summary"
+    );
+}
+
+#[test]
+fn script_names_all_six_demo_assertions() {
+    let text = script();
+    for needle in [
+        "namespaces_list",
+        "resources_scale",
+        "re-arm",
+        "configuration_view",
+        "RBAC",
+        "throwaway",
+    ] {
+        assert!(
+            text.contains(needle),
+            "sre-demo-e2e.sh must name assertion surface {needle}; file contents:\n{text}"
+        );
+    }
+}
+
+#[test]
+fn missing_slack_secret_skips_with_reason_in_the_summary() {
+    let work = tempfile::tempdir().expect("tempdir");
+    let output = run_script("prereqs", &[], work.path());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let summary = fs::read_to_string(work.path().join("summary.md")).unwrap_or_default();
+    let github_output = fs::read_to_string(work.path().join("output.txt")).unwrap_or_default();
+    assert!(
+        output.status.success(),
+        "a documented skip must exit 0, not fail the workflow\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        summary.contains("SKIPPED") || summary.contains("skipped"),
+        "the run summary must say the demo was skipped; summary:\n{summary}"
+    );
+    assert!(
+        summary.contains("CI_SLACK_APP_TOKEN")
+            || summary.contains("Slack")
+            || summary.contains("slack"),
+        "the skip reason must name the missing Slack prerequisite; summary:\n{summary}"
+    );
+    assert!(
+        github_output.contains("ready=false"),
+        "GITHUB_OUTPUT must set ready=false on a skip; output:\n{github_output}"
+    );
+    assert!(
+        !stdout.contains("kind create") && !stderr.contains("kind create"),
+        "a skip must not create a cluster; stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn populated_prereqs_report_ready_without_touching_slack_or_kind() {
+    let work = tempfile::tempdir().expect("tempdir");
+    let output = run_script("prereqs", &populated_prereqs(), work.path());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let github_output = fs::read_to_string(work.path().join("output.txt")).unwrap_or_default();
+    assert!(
+        output.status.success(),
+        "populated prereqs must exit 0\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        github_output.contains("ready=true"),
+        "GITHUB_OUTPUT must set ready=true when every prerequisite is present; \
+         output:\n{github_output}"
+    );
+    assert!(
+        !stdout.contains("chat.postMessage") && !stderr.contains("chat.postMessage"),
+        "the prereqs phase must not call Slack; stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}
+
+#[test]
+fn run_phase_without_allow_live_refuses_instead_of_touching_a_cluster() {
+    let work = tempfile::tempdir().expect("tempdir");
+    let output = run_script("run", &populated_prereqs(), work.path());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "PHASE=run without CURIE_SRE_DEMO_ALLOW_LIVE=1 must refuse, so a laptop \
+         run cannot touch Slack or a cluster\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let combined = format!("{stdout}{stderr}");
+    assert!(
+        combined.contains("CURIE_SRE_DEMO_ALLOW_LIVE") || combined.contains("ALLOW_LIVE"),
+        "the refusal must name the live-run guard; output:\n{combined}"
+    );
+}
+
+#[test]
+fn run_phase_with_missing_prereqs_fails_closed_instead_of_skipping() {
+    let work = tempfile::tempdir().expect("tempdir");
+    let output = run_script("run", &[("CURIE_SRE_DEMO_ALLOW_LIVE", "1")], work.path());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let github_output = fs::read_to_string(work.path().join("output.txt")).unwrap_or_default();
+    assert!(
+        !output.status.success(),
+        "PHASE=run with missing secrets must fail, not skip: the prereqs job \
+         is what skips\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        !github_output.contains("ready=false"),
+        "the run phase must not claim a documented skip; output:\n{github_output}"
+    );
+}
+
+#[test]
+fn script_is_executable() {
+    let path = repo_root().join("cli/scripts/sre-demo-e2e.sh");
+    let mode = fs::metadata(&path)
+        .expect("sre-demo-e2e.sh must exist")
+        .permissions()
+        .mode();
+    assert!(
+        mode & 0o111 != 0,
+        "cli/scripts/sre-demo-e2e.sh must be executable; mode={mode:#o}"
+    );
+}


### PR DESCRIPTION
## Summary

Adds the nightly SRE demo e2e workflow requested by #2246. On kind, with the pinned `kubernetes-mcp-server`, a live provider, a CI-only Socket Mode Slack app, and an allowlisted throwaway repo, it runs the six demo assertions (namespaces_list read, approved resources_scale, one-shot re-arm, configuration_view denial, RBAC ceiling, throwaway-repo coding PR).

The CI Slack app and throwaway repo are not provisioned yet. When those secrets (or the live provider key) are empty, the prereqs job writes `SKIPPED` plus the missing names into the run summary, sets `ready=false`, and the kind job does not run. That is a documented skip, not a green that proved the six assertions. A laptop `curie dev sre-demo-e2e` also refuses the live path unless `CURIE_SRE_DEMO_ALLOW_LIVE=1`.

## Related issue

Closes #2246

## Fix pin verification

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | Does not change plugin packaging, the runner turn loop, ACI events, or skill eval/check. | | |
| local | n/a | Does not change compose services, dispatcher/worker/API local wiring, or console UI. | | |
| local-release | n/a | Does not change released binary identity, install path, version pins, or release compose. | | |
| cluster | required | The workflow installs on kind and drives cluster deploy, comms, approvals, and kubectl observations. | fake | `bash cli/scripts/sre-demo-e2e.sh prereqs` with empty secrets: exit 0, `ready=false`, summary contains `SRE demo e2e SKIPPED` and names `CI_SLACK_APP_TOKEN` / `CI_THROWAY_REPO`. Negative: dummy secrets set `ready=true` without calling Slack or kind; `PHASE=run` without `CURIE_SRE_DEMO_ALLOW_LIVE=1` exits 1. `cargo test --test nightly_sre_demo_e2e`: 16 passed. |
| live provider | required | The live job arms `CURIE_CREDENTIALS` from `OPENROUTER_API_KEY`; skip is the missing-credential path. | live | Same prereqs command with `CURIE_CREDENTIALS` unset: summary line `- CURIE_CREDENTIALS (live provider)`. Negative: dummy `sk-or-test` with the other prereqs reports `ready=true`. No provider HTTP call. |
| external integration | required | Socket Mode Slack and the allowlisted throwaway repo are the demo inbound and coding surfaces. | live | Empty Slack/throwaway secrets skip with those names in the summary and no `chat.postMessage`. Negative: `PHASE=run` with `ALLOW_LIVE=1` and missing Slack secrets exits 1 (fail closed, not skip). Live Socket Mode was not driven from this machine (never touch a live cluster or Slack). |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

The six-assertion live job is implemented and gated. It cannot pass on GitHub until `CI_SLACK_APP_TOKEN`, `CI_SLACK_BOT_TOKEN`, `CI_SLACK_USER_TOKEN`, `CI_SLACK_CHANNEL_ID`, `CI_THROWAY_REPO`, and `OPENROUTER_API_KEY` are present as repository secrets. GitHub will not fire `workflow_dispatch` for this new workflow until it exists on the default branch; until then a pull_request to `next` that touches these paths runs only the prereqs job.

Making this a required check on the v0.9.0 release PR is an admin setting and is not part of this change.

## Checklist

- [x] Tests pass for the area I touched (`cargo test --test nightly_sre_demo_e2e`, `cargo test --test command_surface process_dev_help_lists_sre_demo_e2e`, `uv run pytest tools/ci-workflow-paths tools/ci-retry-gate`).
- [x] Docs updated if behavior changed (workflow comments and the skip summary are the operator-facing skip contract; #2247 owns DEMO.md).
- [ ] An ADR is added under `docs/adr/` if this is an architectural decision. Not applicable: CI plumbing.
