### PR TITLE
Route Slack approval actions only to the owning release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -356,6 +356,12 @@ as a whole; remembered only):
   (`apps/api/src/curie_api/approval_principal.py`) are frozen together in
   `tests/vectors/approval-principal.json`.
   [vector: `tests/vectors/approval-principal.json`]
+- dispatcher vs API approval-row miss -- the API 404 detail
+  (`apps/api/src/curie_api/routers/approvals.py`) and the dispatcher's
+  ownership-miss match (`apps/dispatcher/src/curie_dispatcher/approval_actions.py`)
+  cannot share code, so they are frozen together in
+  `tests/vectors/approval-ownership.json`.
+  [vector: `tests/vectors/approval-ownership.json`]
 - API vs worker vs CLI thread-reset SET -- `THREAD_RESET_SET` /
   `THREAD_RESET_INFLIGHT_SET` (`apps/api/src/curie_api/threadreset.py`,
   `apps/worker/src/curie_worker/consumer.py`) and the CLI's `THREAD_RESET_SET`

--- a/apps/api/src/curie_api/routers/approvals.py
+++ b/apps/api/src/curie_api/routers/approvals.py
@@ -50,7 +50,18 @@ from ..wirebody import ApprovalRequestBody
 
 logger = logging.getLogger(__name__)
 
+# Frozen with the dispatcher in tests/vectors/approval-ownership.json. A 404
+# with this exact detail means this release's database does not have the row;
+# a dispatcher sharing a Slack app treats that as an ownership miss and leaves
+# the Socket Mode envelope unacked so Slack retries the owner. Do not widen it
+# to a generic "Not Found" -- that is how an ingress/proxy miss would read.
+APPROVAL_NOT_FOUND_DETAIL = "approval not found"
+
 router = APIRouter(prefix="/approvals", tags=["approvals"])
+
+
+def _approval_not_found() -> HTTPException:
+    return HTTPException(status.HTTP_404_NOT_FOUND, APPROVAL_NOT_FOUND_DETAIL)
 
 
 @router.post(
@@ -157,7 +168,7 @@ async def list_approvals(
 async def get_approval(approval_id: uuid.UUID, session: SessionDep) -> ApprovalOut:
     approval = await crud.get_approval(session, approval_id)
     if approval is None:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, "approval not found")
+        raise _approval_not_found()
     return ApprovalOut.model_validate(approval)
 
 
@@ -172,7 +183,7 @@ async def get_approval_audit(approval_id: uuid.UUID, session: SessionDep) -> lis
 
     approval = await crud.get_approval(session, approval_id)
     if approval is None:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, "approval not found")
+        raise _approval_not_found()
     entries = await crud.list_approval_audit(session, approval_id)
     return [ApprovalAuditOut.model_validate(e) for e in entries]
 
@@ -201,7 +212,7 @@ async def resolve_approval(
 
     approval = await crud.get_approval(session, approval_id)
     if approval is None:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, "approval not found")
+        raise _approval_not_found()
     stored_parent = approval_trace_context(approval)
 
     # The route binding is read fresh at resolve time (#420), so revoking an
@@ -362,7 +373,7 @@ async def resolve_approval(
     if claimed is None:
         current = await crud.get_approval(session, approval_id)
         if current is None:
-            raise HTTPException(status.HTTP_404_NOT_FOUND, "approval not found")
+            raise _approval_not_found()
         if current.status == ApprovalStatus.expired:
             raise HTTPException(
                 status.HTTP_410_GONE,

--- a/apps/api/tests/test_approvals.py
+++ b/apps/api/tests/test_approvals.py
@@ -951,6 +951,22 @@ def test_expired_approval_resolve_returns_410_and_resumes(
     assert _read_resumed_at(created["id"]) is not None
 
 
+_OWNERSHIP_VECTOR = (
+    Path(__file__).resolve().parents[3] / "tests" / "vectors" / "approval-ownership.json"
+)
+_EXPECTED_OWNERSHIP_VECTOR_KEYS = frozenset({"comment", "not_found_detail"})
+
+
+def test_api_ownership_detail_constant_matches_the_frozen_vector() -> None:
+    """The API constant is the dispatcher ownership-miss detail, frozen in the vector."""
+
+    from curie_api.routers.approvals import APPROVAL_NOT_FOUND_DETAIL
+
+    vector = json.loads(_OWNERSHIP_VECTOR.read_text(encoding="utf-8"))
+    assert set(vector) == _EXPECTED_OWNERSHIP_VECTOR_KEYS
+    assert APPROVAL_NOT_FOUND_DETAIL == vector["not_found_detail"]
+
+
 def test_unknown_approval_is_404(
     approvals_client: TestClient, auth_headers: dict[str, str], clean_db: None
 ) -> None:
@@ -961,6 +977,26 @@ def test_unknown_approval_is_404(
         headers=_operator_resolve_headers("U9", base=auth_headers),
     )
     assert missing.status_code == 404
+
+
+def test_unknown_approval_uses_the_frozen_ownership_detail(
+    approvals_client: TestClient, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    """GET and resolve of a missing row share the dispatcher ownership-miss detail (#2248)."""
+
+    vector = json.loads(_OWNERSHIP_VECTOR.read_text(encoding="utf-8"))
+    assert set(vector) == _EXPECTED_OWNERSHIP_VECTOR_KEYS
+    missing_id = str(uuid.uuid4())
+    got = approvals_client.get(f"/approvals/{missing_id}", headers=auth_headers)
+    resolve = approvals_client.post(
+        f"/approvals/{missing_id}/resolve",
+        json={"decision": "approved"},
+        headers=_operator_resolve_headers("U9", base=auth_headers),
+    )
+    assert got.status_code == 404
+    assert resolve.status_code == 404
+    assert got.json()["detail"] == vector["not_found_detail"]
+    assert resolve.json()["detail"] == vector["not_found_detail"]
 
 
 def test_requires_api_key(

--- a/apps/dispatcher/README.md
+++ b/apps/dispatcher/README.md
@@ -21,10 +21,10 @@ when the selected approver set admits them.
 
 Slack may distribute one app's interactive payloads across any of its open
 Socket Mode connections. If two Curie releases share that app, the release whose
-API does not contain the approval acknowledges the interaction without changing
-the approval or Slack card and asks the approver to retry; only the release whose
-API owns the row can pass the existing compare-and-set. Separate Slack apps per
-long-lived release avoid the retry UX.
+API does not contain the approval leaves the Socket Mode envelope unacked, so
+Slack retries another connection; only the release whose API owns the row
+acknowledges and can pass the existing compare-and-set. Separate Slack apps per
+long-lived release still avoid sharing a connection pool.
 
 ## What is ingested, and what is refused
 

--- a/apps/dispatcher/src/curie_dispatcher/approval_actions.py
+++ b/apps/dispatcher/src/curie_dispatcher/approval_actions.py
@@ -18,6 +18,8 @@ because the worker already depends on this package for the queue seam; the
 card renderer imports them so the two sides cannot drift.
 """
 
+from __future__ import annotations
+
 import json
 import logging
 from dataclasses import dataclass
@@ -124,6 +126,56 @@ def is_approval_action(action_id: str) -> bool:
     """True when a Block Kit action id belongs to the approval card."""
 
     return action_id in _APPROVAL_ACTION_IDS
+
+
+def is_release_ownership_miss(outcome: ResolveOutcome) -> bool:
+    """True when this release's API does not have the approval row (#2248)."""
+
+    return (
+        outcome.status_code == 404
+        and outcome.detail.strip().casefold() == _APPROVAL_NOT_FOUND_DETAIL
+    )
+
+
+def decline_unowned_envelope(ack: Any, *, approval_id: str, log: logging.Logger) -> None:
+    """Leave the Socket Mode envelope unacked so Slack retries another connection.
+
+    Bolt's SocketModeHandler only emits the envelope ack when the BoltResponse
+    status is 200 (slack_bolt.adapter.socket_mode.internals.send_response).
+    Assigning a non-200 to ack.response unblocks the listener runner, which
+    waits on ``ack.response is None``, without acknowledging. Slack then
+    retries the same envelope on another connection of the same app.
+    """
+
+    from slack_bolt.response import BoltResponse
+
+    log.warning(
+        "approval %s was not found in this release and may be owned by another Curie release",
+        approval_id,
+    )
+    ack.response = BoltResponse(status=404, body="")
+
+
+def this_release_owns_action(body: dict[str, Any], resolver: ApprovalResolveClient) -> bool | None:
+    """Ownership probe for a note-dialog click, before views.open."""
+
+    actions = body.get("actions") or []
+    approval_id = str(actions[0].get("value") or "") if actions else ""
+    if not approval_id:
+        return True
+    return resolver.exists(approval_id)
+
+
+def _http_json(response: httpx.Response) -> tuple[str, dict[str, Any] | None]:
+    """Parse a JSON body for detail; never surface a non-JSON intermediary page."""
+
+    try:
+        parsed = response.json()
+    except ValueError:
+        return "", None
+    if not isinstance(parsed, dict):
+        return "", None
+    return str(parsed.get("detail", "")), parsed
 
 
 @dataclass(frozen=True)
@@ -244,27 +296,40 @@ class ApprovalResolveClient:
         except httpx.HTTPError as exc:
             logger.warning("approval resolve call failed for %s: %s", approval_id, exc)
             return ResolveOutcome(status_code=0, detail=str(exc))
-        detail = ""
-        resolved = None
-        decided = None
-        try:
-            body = response.json()
-            if isinstance(body, dict):
-                detail = str(body.get("detail", ""))
-                resolved = body.get("resolved_by")
-                decided = body.get("status")
-        except ValueError:
-            # A non-JSON body (e.g. from an ingress/proxy/WAF intermediary)
-            # may carry an internal hostname or request id. Do not surface
-            # that raw text to the Slack clicker; fall back to empty so the
-            # caller's class-neutral fallback applies instead (#453 LOW-1).
-            detail = ""
+        detail, parsed = _http_json(response)
+        resolved = parsed.get("resolved_by") if parsed else None
+        decided = parsed.get("status") if parsed else None
         return ResolveOutcome(
             status_code=response.status_code,
             detail=detail,
             resolved_by=str(resolved) if resolved else None,
             decision=str(decided) if decided else None,
         )
+
+    def exists(self, approval_id: str) -> bool | None:
+        """Whether THIS release's API has the approval row.
+
+        True when GET /approvals/{id} is 200. False when the response is the
+        exact row-miss 404 the API and dispatcher freeze in
+        tests/vectors/approval-ownership.json -- that is the ownership signal
+        for two dispatchers sharing one Slack app. None when the probe failed
+        or returned some other error; callers treat None as "do not decline".
+        """
+
+        try:
+            response = self._client.get(
+                f"{self._base}/approvals/{approval_id}",
+                headers=self._headers,
+            )
+        except httpx.HTTPError as exc:
+            logger.warning("approval existence probe failed for %s: %s", approval_id, exc)
+            return None
+        if response.status_code == 200:
+            return True
+        detail, _parsed = _http_json(response)
+        if response.status_code == 404 and detail.strip().casefold() == _APPROVAL_NOT_FOUND_DETAIL:
+            return False
+        return None
 
 
 def settled_approval_card(
@@ -897,8 +962,7 @@ def _render_outcome(
         and outcome.detail.strip().casefold() == _APPROVAL_NOT_FOUND_DETAIL
     ):
         log.warning(
-            "approval %s was not found in this release and may be owned by "
-            "another Curie release",
+            "approval %s was not found in this release and may be owned by another Curie release",
             approval_id,
         )
     log.info(
@@ -910,25 +974,32 @@ def _render_outcome(
     )
 
 
-def process_approval_action(
+@dataclass(frozen=True)
+class ImmediateClick:
+    """A no-dialog click that has already been resolved, carried across the ack.
+
+    Same split as ``NoteSubmission`` (#1077, #2248): resolve (API only) before
+    ack, render Slack after. Ownership miss never reaches render; the handler
+    declines the envelope instead.
+    """
+
+    approval_id: str
+    decision: str
+    user: str
+    channel: str
+    card_ts: str
+    message: dict[str, Any]
+    outcome: ResolveOutcome
+
+
+def resolve_approval_action(
     *,
     body: dict[str, Any],
     decision: str,
-    web_client: WebClient,
     resolver: ApprovalResolveClient,
     logger: logging.Logger | None = None,
-) -> ResolveOutcome | None:
-    """Resolve one card click immediately and render the verdict back into Slack.
-
-    The no-dialog path, for a card rendered without ``allow_free_text``. It shares
-    ``_render_outcome`` with the dialog path so the two cannot disagree about what
-    a settled card looks like; only the surface a refusal is rendered on
-    differs, and that difference is real: here nothing is open, so an ephemeral is
-    the right place for it.
-
-    Returns the API outcome (for tests/logging), or None when the interaction
-    payload is not a resolvable card click (missing value/channel/message).
-    """
+) -> ImmediateClick | None:
+    """Parse one immediate card click and POST resolve. No Slack I/O."""
 
     log = logger or logging.getLogger(__name__)
 
@@ -942,27 +1013,58 @@ def process_approval_action(
         log.info("approval action without id/channel/user/message, skipping")
         return None
 
-    outcome = _resolve_and_render(
+    outcome = resolver.resolve(
+        approval_id,
+        decision=decision,
+        attested_user=user,
+        attested_channel=channel,
+        note=None,
+    )
+    return ImmediateClick(
         approval_id=approval_id,
         decision=decision,
         user=user,
         channel=channel,
         card_ts=card_ts,
         message=message,
-        note=None,
-        web_client=web_client,
-        resolver=resolver,
-        log=log,
+        outcome=outcome,
     )
-    if outcome.status_code != 200:
-        _ephemeral(
-            web_client,
-            channel=channel,
-            user=user,
-            text=_refusal_text(outcome),
+
+
+def render_approval_action(
+    click: ImmediateClick,
+    *,
+    web_client: WebClient,
+    logger: logging.Logger | None = None,
+) -> None:
+    """Stamp or refuse an already-resolved immediate click. Post-ack; never raises."""
+
+    log = logger or logging.getLogger(__name__)
+    if is_release_ownership_miss(click.outcome):
+        return
+    try:
+        _render_outcome(
+            approval_id=click.approval_id,
+            decision=click.decision,
+            user=click.user,
+            channel=click.channel,
+            card_ts=click.card_ts,
+            message=click.message,
+            note=None,
+            outcome=click.outcome,
+            web_client=web_client,
             log=log,
         )
-    return outcome
+        if click.outcome.status_code != 200:
+            _ephemeral(
+                web_client,
+                channel=click.channel,
+                user=click.user,
+                text=_refusal_text(click.outcome),
+                log=log,
+            )
+    except Exception as exc:  # noqa: BLE001 - a raise past the ack eats the ack
+        log.warning("post-ack render failed for approval %s: %s", click.approval_id, exc)
 
 
 def _refresh_settled_card(

--- a/apps/dispatcher/src/curie_dispatcher/handlers.py
+++ b/apps/dispatcher/src/curie_dispatcher/handlers.py
@@ -60,11 +60,15 @@ from .approval_actions import (
     REJECT_NOTE_ACTION_ID,
     ApprovalResolveClient,
     build_resolver,
+    decline_unowned_envelope,
     is_approval_action,
+    is_release_ownership_miss,
     open_note_dialog,
-    process_approval_action,
+    render_approval_action,
     render_note_submission,
+    resolve_approval_action,
     resolve_note_submission,
+    this_release_owns_action,
 )
 from .config import DispatcherConfig
 from .inbound_text import derive_text
@@ -358,6 +362,11 @@ def action_command(action: dict[str, Any]) -> str:
     return str(value) if value else str(action.get("action_id", ""))
 
 
+def _action_approval_id(body: dict[str, Any]) -> str:
+    actions = body.get("actions") or []
+    return str(actions[0].get("value") or "") if actions else ""
+
+
 def process_action(
     *,
     body: dict[str, Any],
@@ -493,9 +502,7 @@ def register_handlers(
         )
 
     @app.event("message")
-    def _on_message(
-        body: dict[str, Any], event: dict[str, Any], context: dict[str, Any]
-    ) -> None:
+    def _on_message(body: dict[str, Any], event: dict[str, Any], context: dict[str, Any]) -> None:
         # ENVELOPE VALIDATION, not a relevance decision (#2006). The manifest at
         # `apps/dispatcher/slack-app-manifest.yaml` subscribes bot_events to
         # exactly `app_mention` and `message.im`, so a message on any other
@@ -542,26 +549,38 @@ def register_handlers(
     # approval created before the deploy that introduced the note variants --
     # checked per install, not assumed after some interval.
     @app.action(APPROVE_ACTION_ID)
-    def _on_approve(ack: Callable[..., None], body: dict[str, Any]) -> None:
-        ack()
-        process_approval_action(
+    def _on_approve(ack: Callable[..., Any], body: dict[str, Any]) -> None:
+        click = resolve_approval_action(
             body=body,
             decision="approved",
-            web_client=web_client,
             resolver=approval_resolver,
             logger=logger,
         )
+        if click is None:
+            ack()
+            return
+        if is_release_ownership_miss(click.outcome):
+            decline_unowned_envelope(ack, approval_id=click.approval_id, log=log)
+            return
+        ack()
+        render_approval_action(click, web_client=web_client, logger=logger)
 
     @app.action(REJECT_ACTION_ID)
-    def _on_reject(ack: Callable[..., None], body: dict[str, Any]) -> None:
-        ack()
-        process_approval_action(
+    def _on_reject(ack: Callable[..., Any], body: dict[str, Any]) -> None:
+        click = resolve_approval_action(
             body=body,
             decision="rejected",
-            web_client=web_client,
             resolver=approval_resolver,
             logger=logger,
         )
+        if click is None:
+            ack()
+            return
+        if is_release_ownership_miss(click.outcome):
+            decline_unowned_envelope(ack, approval_id=click.approval_id, log=log)
+            return
+        ack()
+        render_approval_action(click, web_client=web_client, logger=logger)
 
     # The note-collecting variants (#1053): a click OPENS a dialog and resolves
     # nothing; the submission below does the resolving. This is the pair EVERY
@@ -570,7 +589,10 @@ def register_handlers(
     # (#1076). The pair above is the migration entry point for older cards, not
     # a second live behavior; the earlier wording claimed otherwise.
     @app.action(APPROVE_NOTE_ACTION_ID)
-    def _on_approve_with_note(ack: Callable[..., None], body: dict[str, Any]) -> None:
+    def _on_approve_with_note(ack: Callable[..., Any], body: dict[str, Any]) -> None:
+        if this_release_owns_action(body, approval_resolver) is False:
+            decline_unowned_envelope(ack, approval_id=_action_approval_id(body), log=log)
+            return
         ack()
         open_note_dialog(
             body=body,
@@ -581,7 +603,10 @@ def register_handlers(
         )
 
     @app.action(REJECT_NOTE_ACTION_ID)
-    def _on_reject_with_note(ack: Callable[..., None], body: dict[str, Any]) -> None:
+    def _on_reject_with_note(ack: Callable[..., Any], body: dict[str, Any]) -> None:
+        if this_release_owns_action(body, approval_resolver) is False:
+            decline_unowned_envelope(ack, approval_id=_action_approval_id(body), log=log)
+            return
         ack()
         open_note_dialog(
             body=body,
@@ -610,6 +635,9 @@ def register_handlers(
             # Unusable private_metadata: nothing resolved, nothing to render.
             ack()
             return
+        if is_release_ownership_miss(submission.outcome):
+            decline_unowned_envelope(ack, approval_id=submission.approval_id, log=log)
+            return
         response = submission.response_action
         if response is None:
             ack()
@@ -623,11 +651,19 @@ def register_handlers(
         render_note_submission(submission, web_client=web_client, logger=logger)
 
     # Any other Block Kit button click (a reply's action) becomes a turn. The
-    # catch-all matches every action_id (including the approval ids above --
-    # Bolt runs all matching listeners -- so process_action skips those); ack
-    # first (Bolt's 3s budget), then normalize+enqueue.
+    # catch-all matcher fires on every action_id, including the approval ids
+    # above; process_action still skips those, and this listener must not ack
+    # them -- the dedicated approval listeners own ack-or-decline so a
+    # non-owning release can leave the envelope for Slack to retry (#2248).
     @app.action(re.compile(r".+"))
     def _on_action(ack: Callable[..., None], body: dict[str, Any]) -> None:
+        actions = body.get("actions") or []
+        action_id = str(actions[0].get("action_id", "")) if actions else ""
+        if is_approval_action(action_id):
+            # The dedicated approval listeners own ack-or-decline. Acking here
+            # would consume an envelope the non-owning release must leave for
+            # Slack to retry (#2248).
+            return
         ack()
         process_action(
             body=body,

--- a/apps/dispatcher/tests/conftest.py
+++ b/apps/dispatcher/tests/conftest.py
@@ -63,6 +63,26 @@ class FakeSocketClient:
         return self.ack_payloads.get(envelope_id)
 
 
+def deliver_until_acked(
+    connections: list[tuple[Any, FakeSocketClient, Any]],
+    request: Any,
+) -> FakeSocketClient | None:
+    """Deliver one Socket Mode envelope to each connection until one acks.
+
+    Slack retries an unacked envelope on another connection of the same app
+    (https://docs.slack.dev/apis/events-api/using-socket-mode/#using-multiple-connections).
+    This is the fake-app stand-in for that retry: the same envelope_id, in
+    order, stopping at the first ack.
+    """
+
+    for handler, sock, app in connections:
+        handler.handle(sock, request)
+        app.listener_runner.listener_executor.shutdown(wait=True)
+        if request.envelope_id in sock.acked_envelope_ids:
+            return sock
+    return None
+
+
 @contextmanager
 def _black_hole_api() -> Iterator[str]:
     """A real port that completes the TCP handshake and then never answers.

--- a/apps/dispatcher/tests/test_approval_actions.py
+++ b/apps/dispatcher/tests/test_approval_actions.py
@@ -13,12 +13,14 @@ import base64
 import hashlib
 import hmac
 import json
+import threading
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
 
+import httpx
 import pytest
 import redis
 from curie_dispatcher.app import build_app
@@ -41,7 +43,7 @@ from slack_bolt.adapter.socket_mode import SocketModeHandler
 from slack_sdk.socket_mode.request import SocketModeRequest
 from slack_sdk.web import WebClient
 
-from .conftest import FakeSocketClient, _authorize
+from .conftest import FakeSocketClient, _authorize, deliver_until_acked
 
 APPROVAL_ID = "9a1e8a10-0000-0000-0000-000000000246"
 _PLATFORM_API_KEY = "platform-api-test-key"
@@ -137,6 +139,16 @@ class ScriptedResolver:
             }
         )
         return self.outcome
+
+    def exists(self, approval_id: str) -> bool | None:
+        # Mirror the production ownership probe: only the exact API row-miss
+        # is "not this release". Any other outcome means this release has a
+        # row (or the probe failed open).
+        del approval_id
+        return not (
+            self.outcome.status_code == 404
+            and self.outcome.detail.strip().casefold() == "approval not found"
+        )
 
 
 def _build(
@@ -249,55 +261,100 @@ def test_two_releases_only_the_owner_resolves_an_immediate_action(
     config: DispatcherConfig,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """A loser may receive the shared-app envelope, but cannot settle it (#2202).
+    """One fake Slack app, two dispatchers: only the owner consumes the click (#2248).
 
-    Drive the same approval id through two independent real Bolt apps. Release B
-    has its own API view and truthfully reports that the record is absent; release
-    A owns the row and is the only app allowed to stamp the card. This is both the
-    negative and positive half of the two-release regression.
+    Slack delivers the same envelope to the non-owner first. That release must
+    leave the envelope unacked (so Slack retries) and must not mutate the card
+    or post an ephemeral. The retry reaches the owner, who acks and stamps.
     """
 
-    non_owner = ScriptedResolver(
-        ResolveOutcome(status_code=404, detail="approval not found")
-    )
+    non_owner = ScriptedResolver(ResolveOutcome(status_code=404, detail="approval not found"))
     owner = ScriptedResolver(
         ResolveOutcome(status_code=200, resolved_by="U_MANAGER", decision="approved")
     )
     non_owner_app, non_owner_web = _build(config, redis_client, non_owner)
     owner_app, owner_web = _build(config, redis_client, owner)
-
     non_owner_socket = FakeSocketClient()
-    SocketModeHandler(non_owner_app, app_token="xapp-test").handle(
-        non_owner_socket,
-        _approval_click("env-release-b", action_id=APPROVE_ACTION_ID),
-    )
-    _drain(non_owner_app)
+    owner_socket = FakeSocketClient()
+    click = _approval_click("env-shared-immediate", action_id=APPROVE_ACTION_ID)
 
-    assert non_owner_socket.acked_envelope_ids == ["env-release-b"]
+    acked_by = deliver_until_acked(
+        [
+            (
+                SocketModeHandler(non_owner_app, app_token="xapp-test"),
+                non_owner_socket,
+                non_owner_app,
+            ),
+            (
+                SocketModeHandler(owner_app, app_token="xapp-test"),
+                owner_socket,
+                owner_app,
+            ),
+        ],
+        click,
+    )
+
+    assert acked_by is owner_socket
+    assert non_owner_socket.acked_envelope_ids == []
+    assert owner_socket.acked_envelope_ids == ["env-shared-immediate"]
     assert len(non_owner.calls) == 1
+    assert len(owner.calls) == 1
     non_owner_web.chat_update.assert_not_called()
     non_owner_web.chat_postMessage.assert_not_called()
-    non_owner_web.chat_postEphemeral.assert_called_once()
-    notice = non_owner_web.chat_postEphemeral.call_args.kwargs["text"]
-    assert "nothing was changed" in notice
-    assert "owning release" in notice
-    assert any(
-        "may be owned by another Curie release" in record.getMessage()
-        for record in caplog.records
-    )
-
-    owner_socket = FakeSocketClient()
-    SocketModeHandler(owner_app, app_token="xapp-test").handle(
-        owner_socket,
-        _approval_click("env-release-a", action_id=APPROVE_ACTION_ID),
-    )
-    _drain(owner_app)
-
-    assert owner_socket.acked_envelope_ids == ["env-release-a"]
-    assert len(owner.calls) == 1
+    non_owner_web.chat_postEphemeral.assert_not_called()
     owner_web.chat_update.assert_called_once()
     assert "Approved by <@U_MANAGER>" in owner_web.chat_update.call_args.kwargs["text"]
     owner_web.chat_postEphemeral.assert_not_called()
+    assert any(
+        "may be owned by another Curie release" in record.getMessage() for record in caplog.records
+    )
+
+
+def test_a_proxy_404_still_consumes_the_envelope(
+    redis_client: redis.Redis, config: DispatcherConfig
+) -> None:
+    """A generic ingress 404 is not an ownership miss and must still be acked."""
+
+    resolver = ScriptedResolver(ResolveOutcome(status_code=404, detail="Not Found"))
+    app, web_client = _build(config, redis_client, resolver)
+    handler = SocketModeHandler(app, app_token="xapp-test")
+    sock = FakeSocketClient()
+
+    handler.handle(sock, _approval_click("env-proxy-404", action_id=APPROVE_ACTION_ID))
+    _drain(app)
+
+    assert sock.acked_envelope_ids == ["env-proxy-404"]
+    web_client.chat_postEphemeral.assert_called_once()
+    assert "try again shortly" in web_client.chat_postEphemeral.call_args.kwargs["text"]
+
+
+def test_the_ack_lands_before_any_slack_call_on_the_immediate_path(
+    redis_client: redis.Redis, config: DispatcherConfig
+) -> None:
+    """Owned immediate clicks ack before chat_update (#2248, #1077)."""
+
+    resolver = ScriptedResolver(
+        ResolveOutcome(status_code=200, resolved_by="U_MANAGER", decision="approved")
+    )
+    app, web_client = _build(config, redis_client, resolver)
+    gate = threading.Event()
+
+    def _gated_update(**_kwargs: Any) -> dict[str, bool]:
+        gate.wait(5)
+        return {"ok": True}
+
+    web_client.chat_update = MagicMock(side_effect=_gated_update)  # type: ignore[method-assign]
+    handler = SocketModeHandler(app, app_token="xapp-test")
+    sock = FakeSocketClient()
+    try:
+        handler.handle(sock, _approval_click("env-slow-immediate", action_id=APPROVE_ACTION_ID))
+        assert sock.acked_envelope_ids == ["env-slow-immediate"], (
+            "the click was not acked while the Slack call was still outstanding"
+        )
+    finally:
+        gate.set()
+    _drain(app)
+    web_client.chat_update.assert_called_once()
 
 
 def test_non_approver_rejection_renders_the_api_reason(
@@ -637,10 +694,9 @@ def test_non_json_403_body_is_not_captured_as_detail() -> None:
     but an intermediary (ingress/WAF) in front of the API can return a
     non-JSON body -- an HTML block page that may embed an internal hostname
     or request id. Before this PR the 403 branch showed a hardcoded string,
-    so this raw text never reached the clicker; now
-    process_approval_action renders outcome.detail verbatim (#453 AC4/AC5),
-    so a non-JSON body reaching resolve() must not become a renderable
-    reason in the first place.
+    so this raw text never reached the clicker; now the immediate render
+    path shows ``outcome.detail`` verbatim (#453 AC4/AC5), so a non-JSON
+    body reaching resolve() must not become a renderable reason.
     """
 
     raw_body = "<html>403 Forbidden - waf-node-7.internal</html>"
@@ -661,6 +717,114 @@ def test_non_json_403_body_is_not_captured_as_detail() -> None:
 
     assert outcome.status_code == 403
     assert raw_body not in outcome.detail
+
+
+_OWNERSHIP_VECTOR = (
+    Path(__file__).resolve().parents[3] / "tests" / "vectors" / "approval-ownership.json"
+)
+_EXPECTED_OWNERSHIP_VECTOR_KEYS = frozenset({"comment", "not_found_detail"})
+
+
+class _JsonHttpResponse:
+    def __init__(self, *, status_code: int, body: dict[str, Any]) -> None:
+        self.status_code = status_code
+        self._body = body
+        self.text = json.dumps(body)
+
+    def json(self) -> dict[str, Any]:
+        return self._body
+
+
+class _JsonHttpClient:
+    def __init__(self, response: _JsonHttpResponse) -> None:
+        self._response = response
+        self.urls: list[str] = []
+
+    def get(self, url: str, *, headers: dict[str, str]) -> _JsonHttpResponse:
+        del headers
+        self.urls.append(url)
+        return self._response
+
+    def post(self, url: str, *, json: dict[str, Any], headers: dict[str, str]) -> _JsonHttpResponse:
+        raise AssertionError(f"exists() must not POST ({url})")
+
+
+def test_ownership_miss_detail_matches_the_frozen_vector() -> None:
+    from curie_dispatcher.approval_actions import _APPROVAL_NOT_FOUND_DETAIL
+
+    vector = json.loads(_OWNERSHIP_VECTOR.read_text(encoding="utf-8"))
+    assert set(vector) == _EXPECTED_OWNERSHIP_VECTOR_KEYS
+    assert vector["not_found_detail"] == _APPROVAL_NOT_FOUND_DETAIL
+
+
+def test_exists_treats_approval_not_found_as_unowned() -> None:
+    vector = json.loads(_OWNERSHIP_VECTOR.read_text(encoding="utf-8"))
+    fake = _JsonHttpClient(
+        _JsonHttpResponse(status_code=404, body={"detail": vector["not_found_detail"]})
+    )
+    client = ApprovalResolveClient(
+        api_base_url="https://api.example.test",
+        api_key=_PLATFORM_API_KEY,
+        approval_chat_attester_secret=_CHAT_ATTESTER_SECRET,
+        client=fake,  # type: ignore[arg-type]
+    )
+
+    assert client.exists(APPROVAL_ID) is False
+    assert fake.urls == [f"https://api.example.test/approvals/{APPROVAL_ID}"]
+
+
+def test_exists_treats_a_present_row_as_owned() -> None:
+    fake = _JsonHttpClient(
+        _JsonHttpResponse(status_code=200, body={"id": APPROVAL_ID, "status": "pending"})
+    )
+    client = ApprovalResolveClient(
+        api_base_url="https://api.example.test",
+        api_key=_PLATFORM_API_KEY,
+        approval_chat_attester_secret=_CHAT_ATTESTER_SECRET,
+        client=fake,  # type: ignore[arg-type]
+    )
+
+    assert client.exists(APPROVAL_ID) is True
+
+
+def test_exists_treats_a_proxy_404_as_unknown() -> None:
+    fake = _JsonHttpClient(_JsonHttpResponse(status_code=404, body={"detail": "Not Found"}))
+    client = ApprovalResolveClient(
+        api_base_url="https://api.example.test",
+        api_key=_PLATFORM_API_KEY,
+        approval_chat_attester_secret=_CHAT_ATTESTER_SECRET,
+        client=fake,  # type: ignore[arg-type]
+    )
+
+    assert client.exists(APPROVAL_ID) is None
+
+
+def test_exists_treats_a_probe_error_as_unknown() -> None:
+    fake = _JsonHttpClient(_JsonHttpResponse(status_code=500, body={"detail": "boom"}))
+    client = ApprovalResolveClient(
+        api_base_url="https://api.example.test",
+        api_key=_PLATFORM_API_KEY,
+        approval_chat_attester_secret=_CHAT_ATTESTER_SECRET,
+        client=fake,  # type: ignore[arg-type]
+    )
+
+    assert client.exists(APPROVAL_ID) is None
+
+
+class _RaisingHttpClient:
+    def get(self, url: str, *, headers: dict[str, str]) -> Any:
+        raise httpx.ConnectError("refused")
+
+
+def test_exists_treats_an_http_error_as_unknown() -> None:
+    client = ApprovalResolveClient(
+        api_base_url="https://api.example.test",
+        api_key=_PLATFORM_API_KEY,
+        approval_chat_attester_secret=_CHAT_ATTESTER_SECRET,
+        client=_RaisingHttpClient(),  # type: ignore[arg-type]
+    )
+
+    assert client.exists(APPROVAL_ID) is None
 
 
 _ACTION_ID_VECTOR = (

--- a/apps/dispatcher/tests/test_approval_note_dialog.py
+++ b/apps/dispatcher/tests/test_approval_note_dialog.py
@@ -44,7 +44,7 @@ from slack_sdk.errors import SlackApiError
 from slack_sdk.socket_mode.request import SocketModeRequest
 from slack_sdk.web import WebClient
 
-from .conftest import FakeSocketClient, _authorize, _black_hole_api
+from .conftest import FakeSocketClient, _authorize, _black_hole_api, deliver_until_acked
 
 APPROVAL_ID = "9a1e8a10-0000-0000-0000-000000001053"
 CARD_TS = "1700.0042"
@@ -89,6 +89,13 @@ class ScriptedResolver:
         )
         return self.outcome
 
+    def exists(self, approval_id: str) -> bool | None:
+        del approval_id
+        return not (
+            self.outcome.status_code == 404
+            and self.outcome.detail.strip().casefold() == "approval not found"
+        )
+
 
 class _CapturingHttpResponse:
     status_code = 200
@@ -107,7 +114,11 @@ class _CapturingHttpClient:
     def post(
         self, url: str, *, json: dict[str, Any], headers: dict[str, str]
     ) -> _CapturingHttpResponse:
-        self.requests.append({"url": url, "json": json, "headers": headers})
+        self.requests.append({"method": "POST", "url": url, "json": json, "headers": headers})
+        return _CapturingHttpResponse()
+
+    def get(self, url: str, *, headers: dict[str, str]) -> _CapturingHttpResponse:
+        self.requests.append({"method": "GET", "url": url, "headers": headers})
         return _CapturingHttpResponse()
 
 
@@ -333,46 +344,86 @@ def test_submitting_the_dialog_resolves_with_the_typed_note(
 def test_two_releases_only_the_owner_resolves_a_note_submission(
     redis_client: redis.Redis, config: DispatcherConfig
 ) -> None:
-    """The non-owner keeps the modal live and performs no Slack mutation (#2202)."""
+    """One fake Slack app, two dispatchers: only the owner acks the submit (#2248)."""
 
-    non_owner = ScriptedResolver(
-        ResolveOutcome(status_code=404, detail="approval not found")
-    )
+    non_owner = ScriptedResolver(ResolveOutcome(status_code=404, detail="approval not found"))
     owner = ScriptedResolver(
         ResolveOutcome(status_code=200, resolved_by="U_MANAGER", decision="approved")
     )
     non_owner_app, non_owner_web = _build(config, redis_client, non_owner)
     owner_app, owner_web = _build(config, redis_client, owner)
-
     non_owner_socket = FakeSocketClient()
-    SocketModeHandler(non_owner_app, app_token="xapp-test").handle(
-        non_owner_socket,
-        _note_submit("env-note-release-b", note="approved for Q3"),
-    )
-    _drain(non_owner_app)
+    owner_socket = FakeSocketClient()
+    submit = _note_submit("env-shared-note", note="approved for Q3")
 
-    refusal = non_owner_socket.ack_payload_for("env-note-release-b")
-    assert refusal is not None
-    assert refusal["response_action"] == "errors"
-    assert "nothing was changed" in refusal["errors"]["note"]
-    assert "owning release" in refusal["errors"]["note"]
+    acked_by = deliver_until_acked(
+        [
+            (
+                SocketModeHandler(non_owner_app, app_token="xapp-test"),
+                non_owner_socket,
+                non_owner_app,
+            ),
+            (
+                SocketModeHandler(owner_app, app_token="xapp-test"),
+                owner_socket,
+                owner_app,
+            ),
+        ],
+        submit,
+    )
+
+    assert acked_by is owner_socket
+    assert non_owner_socket.acked_envelope_ids == []
+    assert owner_socket.acked_envelope_ids == ["env-shared-note"]
+    assert owner_socket.ack_payload_for("env-shared-note") is None
     assert len(non_owner.calls) == 1
+    assert len(owner.calls) == 1
+    assert owner.calls[0]["note"] == "approved for Q3"
     non_owner_web.conversations_replies.assert_not_called()
     non_owner_web.chat_update.assert_not_called()
     non_owner_web.chat_postEphemeral.assert_not_called()
-
-    owner_socket = FakeSocketClient()
-    SocketModeHandler(owner_app, app_token="xapp-test").handle(
-        owner_socket,
-        _note_submit("env-note-release-a", note="approved for Q3"),
-    )
-    _drain(owner_app)
-
-    assert owner_socket.ack_payload_for("env-note-release-a") is None
-    assert len(owner.calls) == 1
-    assert owner.calls[0]["note"] == "approved for Q3"
     owner_web.chat_update.assert_called_once()
     assert "approved for Q3" in owner_web.chat_update.call_args.kwargs["text"]
+
+
+def test_two_releases_only_the_owner_opens_a_note_dialog(
+    redis_client: redis.Redis, config: DispatcherConfig
+) -> None:
+    """The non-owner must not ack a note click, so the owner opens the dialog."""
+
+    non_owner = ScriptedResolver(ResolveOutcome(status_code=404, detail="approval not found"))
+    owner = ScriptedResolver(
+        ResolveOutcome(status_code=200, resolved_by="U_MANAGER", decision="approved")
+    )
+    non_owner_app, non_owner_web = _build(config, redis_client, non_owner)
+    owner_app, owner_web = _build(config, redis_client, owner)
+    non_owner_socket = FakeSocketClient()
+    owner_socket = FakeSocketClient()
+    click = _note_click("env-shared-note-open", action_id=APPROVE_NOTE_ACTION_ID)
+
+    acked_by = deliver_until_acked(
+        [
+            (
+                SocketModeHandler(non_owner_app, app_token="xapp-test"),
+                non_owner_socket,
+                non_owner_app,
+            ),
+            (
+                SocketModeHandler(owner_app, app_token="xapp-test"),
+                owner_socket,
+                owner_app,
+            ),
+        ],
+        click,
+    )
+
+    assert acked_by is owner_socket
+    assert non_owner_socket.acked_envelope_ids == []
+    assert owner_socket.acked_envelope_ids == ["env-shared-note-open"]
+    assert non_owner.calls == []
+    assert owner.calls == []
+    non_owner_web.views_open.assert_not_called()
+    owner_web.views_open.assert_called_once()
 
 
 def test_an_unrelated_404_does_not_claim_cross_release_ownership() -> None:
@@ -387,9 +438,7 @@ def test_an_unrelated_404_does_not_claim_cross_release_ownership() -> None:
 def test_an_approval_record_miss_asks_for_the_owning_release() -> None:
     """The exact API row miss is retryable when two releases share one app."""
 
-    refusal = _refusal_text(
-        ResolveOutcome(status_code=404, detail="approval not found")
-    )
+    refusal = _refusal_text(ResolveOutcome(status_code=404, detail="approval not found"))
 
     assert "nothing was changed" in refusal
     assert "owning release" in refusal
@@ -461,8 +510,8 @@ def test_failed_modal_open_falls_forward_with_the_same_chat_principal(
     )
     _drain(app)
 
-    assert len(captured.requests) == 1
-    request = captured.requests[0]
+    assert [request.get("method", "POST") for request in captured.requests] == ["GET", "POST"]
+    request = captured.requests[1]
     assert request["json"] == {"decision": "approved"}
     claims = _claims(request["headers"]["X-Curie-Approval-Principal"])
     expected_claims = {

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -869,10 +869,10 @@ next operator.
 - **Give long-lived releases separate Slack Socket Mode apps.** Slack permits
   up to ten connections for one app and may send each payload to any connection
   without a predictable distribution pattern. During a temporary overlap, a
-  non-owning Curie release leaves an absent approval unchanged and asks the
-  approver to retry; a retry may be needed before the owning release receives
-  the interaction. Stop the local dispatcher after testing rather than leaving
-  it competing with the in-cluster release. See
+  non-owning Curie release leaves the Socket Mode envelope unacked so Slack
+  retries the owner; the non-owner does not resolve, reject, or mutate the
+  card. Stop the local dispatcher after testing rather than leaving it
+  competing with the in-cluster release. See
   [Slack's multiple-connections contract](https://docs.slack.dev/apis/events-api/using-socket-mode/#using-multiple-connections).
 - **kube-router applies NetworkPolicy a few seconds after pod start.** A
   brand-new pod can see open egress for the first seconds before the policy

--- a/docs/slack-local-runbook.md
+++ b/docs/slack-local-runbook.md
@@ -203,10 +203,10 @@ app token, but they do not both receive each interaction.
 Prefer a separate Slack app per long-lived Curie release. When two Curie
 releases temporarily share one app, an approval interaction may first reach the
 release whose API does not contain that approval. That release leaves the
-approval and card unchanged and tells the approver to try again so Slack can
-deliver a later interaction to the owner. Stop the extra dispatcher after the
-overlap; the compose dispatcher remains off by default behind the Slack profile
-to make accidental overlap less likely.
+Socket Mode envelope unacked so Slack retries the owner; it does not resolve
+the record or change the card. Stop the extra dispatcher after the overlap;
+the compose dispatcher remains off by default behind the Slack profile to make
+accidental overlap less likely.
 
 ## Teardown and return to Slack-free
 

--- a/tests/vectors/approval-ownership.json
+++ b/tests/vectors/approval-ownership.json
@@ -1,0 +1,4 @@
+{
+  "comment": "Single source of truth for the approval-row miss detail duplicated across the API and the dispatcher. FastAPI's approvals router returns this exact string on GET, audit, and resolve when the row is absent from THIS release's database (apps/api/src/curie_api/routers/approvals.py). The dispatcher treats that detail, and only that detail, as a release-ownership miss rather than a deleted card or a proxy 404 (apps/dispatcher/src/curie_dispatcher/approval_actions.py). The two lanes cannot share code, so the literal is frozen here: changing one language without this file fails that language's test. Read by apps/api/tests/test_approvals.py::test_unknown_approval_uses_the_frozen_ownership_detail and by apps/dispatcher/tests/test_approval_actions.py::test_ownership_miss_detail_matches_the_frozen_vector. Both lanes reject unknown top-level keys so a key one lane cannot see cannot pass vacuously.",
+  "not_found_detail": "approval not found"
+}


### PR DESCRIPTION
## Summary

Two Curie dispatchers sharing one Slack Socket Mode app no longer consume each other's approval clicks. A dispatcher whose API returns the frozen `approval not found` detail leaves the envelope unacked so Slack retries another connection; only the release that owns the row acks and resolves. Immediate clicks resolve before ack and render after, so an owned click stays inside Slack's three second budget.

## Related issue

Closes #2248

## Fix pin verification

Fix pin: apps/dispatcher/tests/test_approval_actions.py::test_two_releases_only_the_owner_resolves_an_immediate_action

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | No plugin packaging, runner loop, ACI event, skill eval, or skill check. | n/a | n/a |
| local | required | Dispatcher ack/routing and the API 404 ownership contract. | fake | `uv run pytest -q apps/dispatcher/tests/test_approval_actions.py::test_two_releases_only_the_owner_resolves_an_immediate_action apps/dispatcher/tests/test_approval_note_dialog.py::test_two_releases_only_the_owner_resolves_a_note_submission apps/dispatcher/tests/test_approval_note_dialog.py::test_two_releases_only_the_owner_opens_a_note_dialog apps/dispatcher/tests/test_approval_actions.py::test_a_proxy_404_still_consumes_the_envelope` on `187ec09a961c14e5b09b33688767f76cdfdc7143`: 4 passed. Positive: the same envelope is retried to the owner, who acks and stamps. Negative: the non-owner does not ack, mutate the card, or post an ephemeral; a proxy `"Not Found"` 404 still acks. Full dispatcher suite: 220 passed. |
| local-release | n/a | No released binary, image identity, installer, or release-compose change. | n/a | n/a |
| cluster | n/a | No chart, RBAC, NetworkPolicy, sandbox, or init-container change. | n/a | n/a |
| live provider | n/a | No model routing, credential, token, or cost behavior. | n/a | n/a |
| external integration | n/a | This run must not touch live Slack. Ownership routing is proved with two real Bolt SocketModeHandlers on one fake Slack app that retries an unacked envelope. | n/a | n/a |

- [x] Every required tier above names its exact command, the commit it ran
      against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable
      negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in
      the table.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [x] An ADR is added under `docs/adr/` if this is an architectural decision. (No new architecture: this uses the existing API-owned row as the ownership signal and Slack's documented unacked-envelope retry.)
