### PR TITLE
Forward-merge stable v0.8.5 into next

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -146,11 +146,31 @@ jobs:
           uv run python -m aci_protocol.wire_lock --check-base /tmp/base-wire.lock
       - name: Pytest
         run: uv run pytest -q
+      # Build ONLY when the body actually carries a declaration. tools/fix-pin-ci/
+      # check.py reaches the binary at exactly one place, the
+      # `curie dev verify-fix-pin` call, and only once `declaration.selector` is
+      # set; `n/a`, no declaration, a near-miss marker like `Fix-pin:`, and the
+      # bug-without-declaration rejection all return before touching it. So on
+      # every pull request that declares nothing -- the overwhelming majority --
+      # this was a 213s cold `cargo build --release` for a binary nothing ran,
+      # inside the longest job on the graph.
+      #
+      # `contains()` is case-insensitive and DECLARATION is the exact-case
+      # `Fix pin: <selector>`, so this condition is a strict superset of the
+      # cases that reach the binary: it cannot skip a build the gate then needs.
+      # It builds a few times it need not (`Fix pin: n/a`, a near miss), which is
+      # the safe direction. This stays a direct build inside the required Python
+      # status: no `needs`, no downloaded artifact, no Cargo cache, so nothing
+      # the gate's contract protects is traded away for the time.
       - name: Build the current curie binary for fix pin verification
-        if: github.event_name == 'pull_request'
+        if: >-
+          github.event_name == 'pull_request'
+          && contains(github.event.pull_request.body, 'Fix pin:')
         run: cargo build --release --locked --manifest-path cli/Cargo.toml
       - name: Install Helm for fix pin verification
-        if: github.event_name == 'pull_request'
+        if: >-
+          github.event_name == 'pull_request'
+          && contains(github.event.pull_request.body, 'Fix pin:')
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5
         with:
           version: v3.16.4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -531,8 +531,21 @@ jobs:
           platforms: ${{ matrix.platforms }}
           push: false
           load: false
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Scope the layer cache per image. Every leg of this matrix runs at
+          # once, and an unscoped `type=gha` puts all ten of them in ONE cache
+          # namespace, where they contend for the same reservation instead of
+          # sharing anything: the legs build different Dockerfiles, so there is
+          # no cross-image reuse to give up by separating them. Left unscoped,
+          # the export -- not the build -- became the job. On run 33690551116
+          # sre-bot-tempo built in 80.5s and then spent 1057.7s writing a single
+          # layer into the shared namespace, for a 19 minute job on a 2 minute
+          # image, while the same run logged `Unable to reserve cache with key
+          # docker.io--tonistiigi--binfmt-latest-linux-x64, another job may be
+          # creating this cache`. The ladder jobs below already scope their
+          # builds this way (`scope=ladder-runner`); this matrix was the one
+          # place left on the default.
+          cache-from: type=gha,scope=${{ matrix.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.name }}
 
   # The worker-local overlay is FROM the published curie-worker image, so it
   # cannot be built purely from the checkout. Build the base worker image

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -783,6 +783,25 @@ jobs:
           bash scripts/check-commit-messages.sh \
             "${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}"
 
+  # Issue #2090: an ordinary next to main merge deletes protected next when
+  # delete_branch_on_merge is on and the deletion ruleset is bypassable. This
+  # job never skips (a skipped required check is not a pass; see issue #1470)
+  # and refuses only that ordinary release path. Task-branch PRs, including
+  # this gate's own, succeed without an admin settings change.
+  preserve-next:
+    name: Preserve next on release merge
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Refuse an ordinary next-to-main merge that would delete next
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 release/preserve_next.py --repo "$GITHUB_REPOSITORY"
+
   # The three image builds here are GHA-layer-cached via a buildx builder that
   # is created but NOT made the default (`setup-buildx-action` with
   # `use: false`): two of the tags are consumed as Dockerfile FROM bases by a

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -144,8 +144,16 @@ jobs:
           git fetch --no-tags --depth=1 origin "${{ github.base_ref || 'main' }}" || true
           git show "origin/${{ github.base_ref || 'main' }}:packages/aci-protocol/schema/wire.lock" > /tmp/base-wire.lock 2>/dev/null || true
           uv run python -m aci_protocol.wire_lock --check-base /tmp/base-wire.lock
+      # --durations is why this line is not a bare `-q`. The suite is the largest
+      # single cost on the critical path (848s on run 33690551116, serial, 1370
+      # test files) and nothing in CI recorded where that time went, so the only
+      # profile available was a local one -- which turned out to be a bad proxy.
+      # Two tests read as ~59s each locally and about 4s on Linux, because a
+      # bound unlistening port is dropped on macOS and refused on Linux (#2233).
+      # Sharding on numbers like those would have split the suite along the wrong
+      # seam. This prints the real ones on every run, for the price of 25 lines.
       - name: Pytest
-        run: uv run pytest -q
+        run: uv run pytest -q --durations=25
       # Build ONLY when the body actually carries a declaration. tools/fix-pin-ci/
       # check.py reaches the binary at exactly one place, the
       # `curie dev verify-fix-pin` call, and only once `declaration.selector` is

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -154,31 +154,40 @@ jobs:
       # seam. This prints the real ones on every run, for the price of 25 lines.
       - name: Pytest
         run: uv run pytest -q --durations=25
-      # Build ONLY when the body actually carries a declaration. tools/fix-pin-ci/
-      # check.py reaches the binary at exactly one place, the
+      # Build ONLY when the declaration parser would invoke the curie binary.
+      # tools/fix-pin-ci/check.py reaches it at exactly one place, the
       # `curie dev verify-fix-pin` call, and only once `declaration.selector` is
-      # set; `n/a`, no declaration, a near-miss marker like `Fix-pin:`, and the
-      # bug-without-declaration rejection all return before touching it. So on
-      # every pull request that declares nothing -- the overwhelming majority --
-      # this was a 213s cold `cargo build --release` for a binary nothing ran,
-      # inside the longest job on the graph.
+      # set; `n/a`, no declaration, a near-miss marker like `Fix-pin:`, HTML
+      # comments in the pull request template, and the bug-without-declaration
+      # rejection all return before touching it.
       #
-      # `contains()` is case-insensitive and DECLARATION is the exact-case
-      # `Fix pin: <selector>`, so this condition is a strict superset of the
-      # cases that reach the binary: it cannot skip a build the gate then needs.
-      # It builds a few times it need not (`Fix pin: n/a`, a near miss), which is
-      # the safe direction. This stays a direct build inside the required Python
-      # status: no `needs`, no downloaded artifact, no Cargo cache, so nothing
-      # the gate's contract protects is traded away for the time.
+      # `#2228` gated cargo with `contains(..., 'Fix pin:')`. That is true for
+      # every pull request that keeps the default template, because the template
+      # embeds those exact bytes inside `<!-- -->`. The probe reuses
+      # `_declaration` so a commented example cannot trigger a cold
+      # `cargo build --release` inside the longest job on the graph, and a live
+      # selector line cannot skip it.
+      #
+      # `n/a` used to pay that extra build as a safe over-match. The parser does
+      # not invoke curie for `n/a`, so the probe reports needed=false. This
+      # stays a direct build inside the required Python status: no `needs`, no
+      # downloaded artifact, no Cargo cache.
+      - name: Decide whether the current curie binary is needed
+        id: fix-pin-curie
+        if: github.event_name == 'pull_request'
+        run: >-
+          python3 tools/fix-pin-ci/check.py
+          --event "$GITHUB_EVENT_PATH"
+          --needs-curie
       - name: Build the current curie binary for fix pin verification
         if: >-
           github.event_name == 'pull_request'
-          && contains(github.event.pull_request.body, 'Fix pin:')
+          && steps.fix-pin-curie.outputs.needed == 'true'
         run: cargo build --release --locked --manifest-path cli/Cargo.toml
       - name: Install Helm for fix pin verification
         if: >-
           github.event_name == 'pull_request'
-          && contains(github.event.pull_request.body, 'Fix pin:')
+          && steps.fix-pin-curie.outputs.needed == 'true'
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5
         with:
           version: v3.16.4

--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -220,6 +220,13 @@ jobs:
           set -euo pipefail
           bash charts/curie/ci/langfuse-image-pin-assertions.sh
 
+      # Prove both Langfuse Deployments use Recreate so an image change never
+      # runs two boot migrations against the same database (#2216).
+      - name: helm render assertions (langfuse Recreate strategy)
+        run: |
+          set -euo pipefail
+          bash charts/curie/ci/langfuse-recreate-assertions.sh
+
       # Prove Langfuse startup is gated on ClickHouse being up (issue #2009). A
       # Helm upgrade that recreates the ClickHouse Service otherwise lets the new
       # Langfuse pods start their migrations against an unresolvable name, so the

--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -454,16 +454,17 @@ jobs:
       - name: Sync workspace
         run: uv sync
 
-      # Prove the key-free object store path (#1325). Pointing the bundle store
-      # at a real cloud object store used to REQUIRE static access keys: all
-      # three consumers supplied explicit credentials unconditionally, so an
-      # ambient role was never consulted. Clearing rustfs.auth.accessKey now
-      # omits every credential env and shell export, which only works if the
-      # omission is COMPLETE -- an empty AWS_ACCESS_KEY_ID is still a credential
-      # to the SDK, so it stops the provider chain and the web-identity provider
-      # is never reached. Also asserts the instance-role shortcut stays shut:
-      # NetworkPolicy selects pods and not containers, so opening IMDS for
-      # bundle-fetch would hand the node's IAM role to the runner as well.
+      # Prove the key-free object store path (#1325, #2211). Pointing the bundle
+      # store at a real cloud object store used to REQUIRE static access keys:
+      # all four consumers (api, worker, bundle-fetch, Langfuse) supplied
+      # explicit credentials unconditionally, so an ambient role was never
+      # consulted. Clearing rustfs.auth.accessKey now omits every credential env
+      # and shell export, which only works if the omission is COMPLETE -- an
+      # empty AWS_ACCESS_KEY_ID is still a credential to the SDK, so it stops
+      # the provider chain and the web-identity provider is never reached. Also
+      # asserts the instance-role shortcut stays shut: NetworkPolicy selects
+      # pods and not containers, so opening IMDS for bundle-fetch would hand
+      # the node's IAM role to the runner as well.
       - name: helm render assertions (object store web identity)
         run: |
           set -euo pipefail

--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -220,6 +220,14 @@ jobs:
           set -euo pipefail
           bash charts/curie/ci/langfuse-image-pin-assertions.sh
 
+      # Keep the chart ClickHouse default and Langfuse pin as one supported
+      # pair. ClickHouse 24.8 cannot apply Langfuse 3.225.x migration 39, so
+      # the default must stay on 25.12 and AVX-required (#2210).
+      - name: helm render assertions (clickhouse langfuse pin pair)
+        run: |
+          set -euo pipefail
+          bash charts/curie/ci/clickhouse-langfuse-pin-assertions.sh
+
       # Prove Langfuse startup is gated on ClickHouse being up (issue #2009). A
       # Helm upgrade that recreates the ClickHouse Service otherwise lets the new
       # Langfuse pods start their migrations against an unresolvable name, so the

--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -462,6 +462,15 @@ jobs:
           set -euo pipefail
           bash charts/curie/ci/object-store-web-identity-assertions.sh
 
+      # Prove a BYO object store gets a runner egress allow for S3 (and STS on
+      # the key-free path). Rail 1 is fail-closed and the in-chart rustfs pod
+      # selector does not render when rustfs.deploy is false, so a default-shaped
+      # BYO install used to hang every sandbox in Init (#2213).
+      - name: helm render assertions (BYO object store runner egress)
+        run: |
+          set -euo pipefail
+          bash charts/curie/ci/object-store-byo-egress-assertions.sh
+
       - name: helm template + kubeconform (values-dev overlay)
         run: |
           set -euo pipefail

--- a/.github/workflows/pr-body.yaml
+++ b/.github/workflows/pr-body.yaml
@@ -3,9 +3,10 @@ name: PR body guard
 on:
   pull_request:
     branches: [main, next]
-    # A PR body can be edited without a new commit. Re-run the literal-newline
-    # guard on that event so a formerly valid closing keyword cannot become
-    # inert after the rest of CI has already passed.
+    # A PR body can be edited without a new commit. Re-run the body guards on
+    # that event so a formerly valid closing keyword cannot become inert, and so
+    # an AI attribution footer cannot be pasted in, after the rest of CI has
+    # already passed.
     types: [opened, synchronize, reopened, edited]
 
 concurrency:
@@ -42,7 +43,7 @@ jobs:
       # its verdict against the event payload.
       - name: PR body guard self-test
         run: bash scripts/check-pr-body.sh --self-test
-      - name: Reject literal newline escapes in the pull request body
+      - name: Reject literal newline escapes and AI attribution in the pull request body
         env:
           PR_BODY_FILE: ${{ runner.temp }}/curie-pr-body.md
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -559,7 +559,15 @@ forward merge from `main` into `next` happens at release candidate prep, not
 after every individual fix. Do not routinely cherry pick fixes between release
 lines.
 
-When a release candidate is accepted, merge `next` into `main`, then run every
+When a release candidate is accepted, merge `next` into `main` through a pull
+request whose head is a short-lived `task/release-*` branch cut from `next`,
+not through a pull request whose head is `next` itself. Repository auto-delete
+of merged heads stays enabled so task branches still clean up; an ordinary
+`next` to `main` PR therefore deletes `next` when the merger can bypass the
+deletion ruleset (issue #2090). Run
+`python3 release/preserve_next.py --repo <owner/name>` before enabling
+auto-merge: it refuses that ordinary path until the head is not `next` or an
+active deletion ruleset covers `next` with an empty bypass list. Then run every
 parity ladder rung on the resulting `main` commit:
 
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -594,22 +594,33 @@ branch list, restores the `RELEASE_NEXT_BRANCH` environment alias and the
   inert. Run `scripts/check-pr-body.sh <body-file>` before opening or editing a
   PR.
 - **Never mention any AI assistant (Claude, Codex, GPT, etc.) or AI in general in
-  commit messages, and never add `Co-Authored-By` lines referencing AI.**
-  CI enforces this on every PR (issue #962); check before pushing with:
+  commit messages OR pull request bodies, and never add `Co-Authored-By` lines
+  referencing AI.** This applies to the PR body as much as to the commits: many
+  assistants append a "Generated with" footer to a PR description by default, and
+  that footer is a claim of authorship on the artifact a reviewer reads first.
+  Strip it. CI enforces both surfaces on every PR (issue #962); check before
+  pushing with:
 
   ```bash
   scripts/check-commit-messages.sh origin/<base>..HEAD
+  scripts/check-pr-body.sh <body-file>
   scripts/check-commit-messages.sh --self-test
+  scripts/check-pr-body.sh --self-test
   ```
+
+  Both surfaces run ONE matcher: `check-pr-body.sh` delegates to
+  `check-commit-messages.sh --message-file`, so a vendor added in one place is
+  covered in the other and the two cannot drift apart.
 
   The gate flags *attribution*, not mention: a `Co-Authored-By` trailer naming an
   assistant, the robot-emoji "Generated with" footer, or an attribution phrase next
   to a bare assistant name. Technical references (`CLAUDE.md`, `claude_agent_sdk`,
   `claude-sonnet-5`, `harness.claude`) are deliberately fine, and the script's
-  `--self-test` pins both halves so the distinction cannot silently rot. A commit
-  range the script cannot resolve is a hard failure naming the range, not a silent
-  pass. It checks only the PR's own commits, so pre-gate history is not
-  retroactively enforced.
+  `--self-test` pins both halves so the distinction cannot silently rot. Scanning
+  the last 150 merged PR bodies flags exactly one, and it is a real footer, so the
+  body half is not a broad net either. A commit range the script cannot resolve is
+  a hard failure naming the range, not a silent pass. It checks only the PR's own
+  commits, so pre-gate history is not retroactively enforced.
 - No dashes/emdashes in prose content; no emojis in code or docs.
 
 ## Ticket implementation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,9 +198,13 @@ Host ports (non-default host ports to avoid local collisions):
 Config lives in `.env.example` (copy to the gitignored `.env` to override; the
 stack runs on the baked defaults without one). Load-bearing facts:
 
-- **ClickHouse is pinned to `:24.8`.** Newer ClickHouse requires AVX and SIGILLs
-  with exit 132 on CPUs without it. Keep the pin unless every target CPU has AVX.
-  `charts/curie` turns this into a chart preflight (`preflights.avxCheck`).
+- **ClickHouse:** `compose.dev.yaml` stays on `:24.8` so an SSE4.2-only
+  developer host can still boot the local stack (Langfuse `3.225.5` still
+  applies on 24.8). The Helm chart default is `:25.12`, required by the
+  Langfuse pin's ClickHouse migrations from 39 onward; AVX is a chart-default
+  requirement. `preflights.avxCheck` fails an AVX-less node unless the
+  operator pins a tag in `clickhouse.sse42SafeTags`. Do not move the two
+  chart pins independently (#2210).
 - **Langfuse OTLP ingest is HTTP-only** (gRPC is silently unsupported). Services
   may emit OTLP over gRPC or HTTP to the OTel Collector (4317/4318); the
   collector always exports to Langfuse over HTTP. Send app traces to the

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -686,7 +686,7 @@ Security rails are all chart defaults (ADR-0006,
 
 - **Default-deny egress NetworkPolicy** with an explicit `except: 169.254.169.254/32` carve-out so the cloud metadata endpoint stays blocked ([`charts/curie/templates/security-networkpolicy.yaml`](charts/curie/templates/security-networkpolicy.yaml)).
 - **gVisor RuntimeClass** option on the runner, plus a preflight Job that runs under the class and fails if the kernel is not gVisor ([`charts/curie/templates/preflight-gvisor.yaml`](charts/curie/templates/preflight-gvisor.yaml)).
-- **AVX (a CPU instruction-set extension)/ClickHouse preflight** — a blocking pre-install hook that fails when the CPU lacks AVX and the ClickHouse tag is not the SSE4.2-safe pin ([`charts/curie/templates/preflight-avx.yaml`](charts/curie/templates/preflight-avx.yaml)). It is the productized form of the `:24.8` pin documented in [`CLAUDE.md`](CLAUDE.md).
+- **AVX (a CPU instruction-set extension)/ClickHouse preflight** - a blocking pre-install hook that fails when the CPU lacks AVX and the ClickHouse tag is not in `clickhouse.sse42SafeTags` ([`charts/curie/templates/preflight-avx.yaml`](charts/curie/templates/preflight-avx.yaml)). Chart defaults pin ClickHouse `:25.12` (coupled to the Langfuse pin, #2210), so AVX is required unless the operator overrides to an SSE4.2-safe tag.
 - **Bundle-fetch init containers** on the sandbox template, fail-closed if a bundle ref is set but no archive is fetched ([`charts/curie/templates/agent-sandbox.yaml`](charts/curie/templates/agent-sandbox.yaml)), with a RustFS egress carve-out.
 - **A chart-managed platform Secret** ([`charts/curie/templates/secrets.yaml`](charts/curie/templates/secrets.yaml)) carries:
   - backing-store passwords

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -196,8 +196,15 @@ between the two branches. An administrator must protect both branches with the
 same pull request review and required check rules, and prohibit force pushes and
 branch deletion. Do not use an unprotected release train branch.
 
-When v0.7 is ready, merge `next` into `main`, then run every parity ladder rung
-on the resulting `main` commit:
+When v0.7 is ready, merge `next` into `main` through a pull request whose head
+is a short-lived `task/release-*` branch cut from `next`, not through a pull
+request whose head is `next` itself. Repository auto-delete of merged heads
+stays enabled so task branches still clean up; an ordinary `next` to `main` PR
+therefore deletes `next` when the merger can bypass the deletion ruleset
+(issue #2090). Run `python3 release/preserve_next.py --repo <owner/name>`
+before enabling auto-merge: it refuses that ordinary path until the head is
+not `next` or an active deletion ruleset covers `next` with an empty bypass
+list. Then run every parity ladder rung on the resulting `main` commit:
 
 ```bash
 CURIE_E2E_TIERS=all curie dev e2e-ladder

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,7 +37,8 @@ The rails are the actual control. Every agent runs inside them:
   runner-sandbox pods is fail-closed: an empty `allowedEgress` means the sandbox
   can resolve DNS and ship traces, but reach nothing else. Arbitrary internet
   and the cloud metadata endpoint `169.254.169.254` are denied. Only
-  explicitly-declared egress is permitted: DNS, the in-chart collector, RustFS,
+  explicitly-declared egress is permitted: DNS, the in-chart collector, RustFS
+  (or `rustfs.egress` / `rustfs.stsEgress` when the object store is BYO),
   and inference when deployed, plus the operator's declared model API and MCP
   hosts via `allowedEgress`.
 - **gVisor kernel isolation** via a RuntimeClass (`security.gvisor.mode`).

--- a/apps/api/alembic/versions/0039_approval_traceparent.py
+++ b/apps/api/alembic/versions/0039_approval_traceparent.py
@@ -1,0 +1,35 @@
+"""Persist private approval trace continuity (#2204).
+
+Revision ID: 0039
+Revises: 0038
+Create Date: 2026-09-02
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0039"
+down_revision: str | None = "0038"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+SCHEMA = "curie"
+TABLE = "approvals"
+
+
+def upgrade() -> None:
+    # Existing and rolling-deploy rows have no originating HTTP carrier. NULL
+    # keeps that provenance honest and makes recovery start a safe root.
+    op.add_column(
+        TABLE,
+        sa.Column("traceparent", sa.String(length=55), nullable=True),
+        schema=SCHEMA,
+    )
+
+
+def downgrade() -> None:
+    op.drop_column(TABLE, "traceparent", schema=SCHEMA)

--- a/apps/api/src/curie_api/crud.py
+++ b/apps/api/src/curie_api/crud.py
@@ -690,6 +690,7 @@ async def create_publication(
     data: PublicationCreate,
     *,
     patch: bytes,
+    traceparent: str | None = None,
 ) -> tuple[Publication, bool]:
     """Atomically create the durable approval and its private publication.
 
@@ -719,6 +720,7 @@ async def create_publication(
         reply_endpoint=data.reply_endpoint,
         reply_adapter=data.reply_adapter,
         dedupe_key=data.dedupe_key,
+        traceparent=traceparent,
         route=None,
         card_channel=data.reply_channel,
         gate_kind="permission",
@@ -949,7 +951,12 @@ async def claim_action_undo(
     return action
 
 
-async def create_approval(session: AsyncSession, data: "ApprovalRequest") -> Approval:
+async def create_approval(
+    session: AsyncSession,
+    data: "ApprovalRequest",
+    *,
+    traceparent: str | None = None,
+) -> Approval:
     """Insert a pending approval. Raises IntegrityError on a dedupe_key replay;
     the router maps that to the existing record (idempotent creation)."""
 
@@ -975,6 +982,7 @@ async def create_approval(session: AsyncSession, data: "ApprovalRequest") -> App
         reply_endpoint=data.reply_endpoint,
         reply_adapter=data.reply_adapter,
         dedupe_key=data.dedupe_key,
+        traceparent=traceparent,
         route=data.route,
         card_channel=data.card_channel,
         gate_kind=data.gate_kind,

--- a/apps/api/src/curie_api/langfuse.py
+++ b/apps/api/src/curie_api/langfuse.py
@@ -105,20 +105,20 @@ def hoist_approval_decision(
 ) -> str | None:
     """Lift the runner's approval-gate decision out of a trace, or None.
 
-    Mirrors ``hoist_sandbox_id``'s trace-then-first-observation probe. The
-    attribute is stamped on the root ``agent.run`` span rather than as a
-    provider-wide resource attribute (ADR-0076 Stone 3, #889), so it is
-    ordinarily trace-level; the observation fallback stays for the same
-    reason ``hoist_sandbox_id`` keeps it -- Langfuse's OTLP ingestion doesn't
-    guarantee which level surfaces a given span attribute. Absent for the
-    ordinary case (no approval gate was resumed this turn); no value invented.
+    Prefer trace metadata, then inspect each observation in response order.
+    The resumed ``agent.run`` span carries the attribute (ADR-0076 Stone 3,
+    #889), but a correlated trace begins at dispatcher ingress and includes
+    reply spans, so the annotated observation need not be first. Absent for
+    the ordinary case (no approval gate was resumed); no value invented.
     """
 
     hit = _probe_attr(trace, _APPROVAL_DECISION_ATTR)
     if hit:
         return hit
-    if observations:
-        return _probe_attr(observations[0], _APPROVAL_DECISION_ATTR)
+    for observation in observations:
+        hit = _probe_attr(observation, _APPROVAL_DECISION_ATTR)
+        if hit:
+            return hit
     return None
 
 

--- a/apps/api/src/curie_api/main.py
+++ b/apps/api/src/curie_api/main.py
@@ -14,8 +14,11 @@ from contextlib import asynccontextmanager
 import httpx
 import redis.asyncio as redis
 from curie_telemetry import (
+    TRACEPARENT_STREAM_FIELD,
     bootstrap_service_telemetry,
+    canonicalize_traceparent,
     configure_service_logging,
+    extract_trace_context,
     operation_span,
     record_metric,
 )
@@ -348,6 +351,20 @@ def create_app() -> FastAPI:
     @app.middleware("http")
     async def observe_http(request: Request, call_next):  # type: ignore[no-untyped-def]
         operation = _route_template(app, request)
+        inbound_traceparent = request.headers.get(TRACEPARENT_STREAM_FIELD)
+        canonical_traceparent = canonicalize_traceparent(inbound_traceparent)
+        parent = extract_trace_context(
+            {TRACEPARENT_STREAM_FIELD: canonical_traceparent}
+            if canonical_traceparent is not None
+            else {}
+        )
+        diagnostic = (
+            "trace.context.missing"
+            if inbound_traceparent is None
+            else "trace.context.malformed"
+            if canonical_traceparent is None
+            else None
+        )
         active_attributes = {
             "service.name": "curie-api",
             "operation": operation,
@@ -361,8 +378,11 @@ def create_app() -> FastAPI:
             with operation_span(
                 "http.server.request",
                 kind=SpanKind.SERVER,
+                parent=parent,
                 attributes=active_attributes,
             ) as span:
+                if diagnostic is not None:
+                    span.add_event(diagnostic)
                 response = await call_next(request)
                 status_code = response.status_code
                 if status_code >= 500 and hasattr(span, "set_status"):

--- a/apps/api/src/curie_api/models.py
+++ b/apps/api/src/curie_api/models.py
@@ -18,6 +18,7 @@ from sqlalchemy import (
     ForeignKey,
     Index,
     LargeBinary,
+    String,
     Text,
     UniqueConstraint,
     func,
@@ -392,6 +393,11 @@ class Approval(Base):
     # Idempotency: the triggering event id. A reclaimed/redelivered turn that
     # re-requests the same approval adopts the existing row instead of forking.
     dedupe_key: Mapped[str] = mapped_column(unique=True)
+    # Private W3C carrier for the worker turn that created this record. It is
+    # deliberately absent from every request/response DTO: the authenticated
+    # ingress route derives it from the HTTP header, and terminal/recovery paths
+    # use it only to reconnect telemetry after the human pause.
+    traceparent: Mapped[str | None] = mapped_column(String(55), default=None)
     status: Mapped[str] = mapped_column(server_default=ApprovalStatus.pending, index=True)
     # Optional SLA: past this instant the record can no longer be approved or
     # rejected; a resolve attempt flips it to expired instead.

--- a/apps/api/src/curie_api/resumequeue.py
+++ b/apps/api/src/curie_api/resumequeue.py
@@ -19,12 +19,37 @@ from typing import Any
 
 import redis.asyncio as redis
 from aci_protocol import STREAM_PAYLOAD_FIELD, QueuedTurn, ReplyHandle, TurnSource
-from curie_telemetry import inject_trace_context, operation_span, record_metric
+from curie_telemetry import (
+    TRACEPARENT_STREAM_FIELD,
+    canonicalize_traceparent,
+    extract_trace_context,
+    inject_trace_context,
+    operation_span,
+    record_metric,
+)
+from opentelemetry.context import Context
 from opentelemetry.trace import SpanKind, StatusCode
 from redis.typing import EncodableT
 
 from .config import get_settings
 from .models import Approval, ApprovalStatus
+
+
+def approval_trace_context(approval: Approval) -> Context:
+    """Return the approval's private W3C parent, or an explicit clean root.
+
+    Rows created before the carrier migration and manually malformed values are
+    intentionally indistinguishable here: neither may inherit an ambient HTTP
+    click or background-loop span by accident.
+    """
+
+    traceparent = canonicalize_traceparent(getattr(approval, "traceparent", None))
+    carrier = (
+        {TRACEPARENT_STREAM_FIELD: traceparent}
+        if traceparent is not None
+        else {}
+    )
+    return extract_trace_context(carrier)
 
 
 def resume_event_id(approval_id: object) -> str:
@@ -238,13 +263,16 @@ class ResumeQueue:
         # graveyard.
         self._dead_letter_stream = dead_letter_stream or f"{self._stream}:dead"
 
-    async def enqueue(self, turn: QueuedTurn) -> str:
+    async def enqueue(
+        self, turn: QueuedTurn, *, parent: Context | None = None
+    ) -> str:
         carrier: dict[str, str] = {STREAM_PAYLOAD_FIELD: turn.model_dump_json()}
         stream_id: Any = None
         error: Exception | None = None
         with operation_span(
             "curie.queue.enqueue",
             kind=SpanKind.PRODUCER,
+            parent=parent,
             attributes={"service.name": "curie-api", "source": "api"},
         ) as span:
             inject_trace_context(carrier)

--- a/apps/api/src/curie_api/resumereconciler.py
+++ b/apps/api/src/curie_api/resumereconciler.py
@@ -70,7 +70,12 @@ from pydantic import ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from . import crud
-from .resumequeue import ResumeQueue, parse_resume_event_id, resume_turn_for
+from .resumequeue import (
+    ResumeQueue,
+    approval_trace_context,
+    parse_resume_event_id,
+    resume_turn_for,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -210,7 +215,9 @@ class ResumeReconciler:
                             # exit the txn block cleanly, releasing any lock.
                             continue
                         turn = resume_turn_for(approval)
-                        await self._resume_queue.enqueue(turn)
+                        await self._resume_queue.enqueue(
+                            turn, parent=approval_trace_context(approval)
+                        )
                         approval.resumed_at = datetime.now(UTC).replace(tzinfo=None)
                     # session.begin() committed here, releasing the row lock.
                 except Exception:  # noqa: BLE001

--- a/apps/api/src/curie_api/routers/approvals.py
+++ b/apps/api/src/curie_api/routers/approvals.py
@@ -17,8 +17,13 @@ import logging
 import uuid
 from datetime import UTC, datetime, timedelta
 
-from curie_telemetry import operation_span, record_metric
-from fastapi import APIRouter, Depends, HTTPException, Response, status
+from curie_telemetry import (
+    TRACEPARENT_STREAM_FIELD,
+    canonicalize_traceparent,
+    operation_span,
+    record_metric,
+)
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from opentelemetry.trace import SpanKind
 from sqlalchemy.exc import IntegrityError
 
@@ -29,7 +34,11 @@ from ..authorizer import authorize_approval
 from ..config import get_settings
 from ..deps import ApproverSetSelectorDep, ResumeQueueDep, SessionDep
 from ..models import Approval, ApprovalStatus
-from ..resumequeue import build_expiry_resume_turn, build_resume_turn
+from ..resumequeue import (
+    approval_trace_context,
+    build_expiry_resume_turn,
+    build_resume_turn,
+)
 from ..schemas import (
     ApprovalAuditOut,
     ApprovalOut,
@@ -93,7 +102,10 @@ def _expired(approval: Approval) -> bool:
     dependencies=[Depends(require_api_key)],
 )
 async def create_approval(
-    data: ApprovalRequestBody, session: SessionDep, response: Response
+    data: ApprovalRequestBody,
+    request: Request,
+    session: SessionDep,
+    response: Response,
 ) -> ApprovalOut:
     """Create a pending approval; idempotent on ``dedupe_key``.
 
@@ -102,8 +114,11 @@ async def create_approval(
     one human decision.
     """
 
+    traceparent = canonicalize_traceparent(
+        request.headers.get(TRACEPARENT_STREAM_FIELD)
+    )
     try:
-        approval = await crud.create_approval(session, data)
+        approval = await crud.create_approval(session, data, traceparent=traceparent)
     except IntegrityError as exc:
         await session.rollback()
         existing = await crud.get_approval_by_dedupe_key(session, data.dedupe_key)
@@ -187,6 +202,7 @@ async def resolve_approval(
     approval = await crud.get_approval(session, approval_id)
     if approval is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "approval not found")
+    stored_parent = approval_trace_context(approval)
 
     # The route binding is read fresh at resolve time (#420), so revoking an
     # approver takes effect on the next click rather than at the next restart.
@@ -235,6 +251,7 @@ async def resolve_approval(
         with operation_span(
             "curie.approval.expire",
             kind=SpanKind.INTERNAL,
+            parent=stored_parent,
             attributes={
                 "service.name": "curie-api",
                 "operation": "expire",
@@ -277,7 +294,9 @@ async def resolve_approval(
             # redelivery of an already-finished turn re-running; it is the CAS,
             # not the shared key, that keeps this wakeup single.
             try:
-                await resume_queue.enqueue(build_expiry_resume_turn(expired))
+                await resume_queue.enqueue(
+                    build_expiry_resume_turn(expired), parent=stored_parent
+                )
                 # Enqueue-first-then-mark (#418): only a wake that reached the
                 # stream is written off, so a failure below leaves resumed_at
                 # NULL and the reconciler re-enqueues it past its grace horizon.
@@ -327,6 +346,7 @@ async def resolve_approval(
     with operation_span(
         "curie.approval.resolve",
         kind=SpanKind.INTERNAL,
+        parent=stored_parent,
         attributes={
             "service.name": "curie-api",
             "operation": "resolve",
@@ -386,7 +406,9 @@ async def resolve_approval(
     # a 200 would silently strand the suspended session -- re-raise instead, so the
     # failure surfaces as a 500 the caller can see (the CAS/audit already committed).
     try:
-        stream_id = await resume_queue.enqueue(build_resume_turn(claimed))
+        stream_id = await resume_queue.enqueue(
+            build_resume_turn(claimed), parent=stored_parent
+        )
     except Exception:  # noqa: BLE001
         logger.warning(
             "approval %s %s by %s; resume enqueue failed, reconciler will retry",

--- a/apps/api/src/curie_api/routers/hooks.py
+++ b/apps/api/src/curie_api/routers/hooks.py
@@ -47,7 +47,14 @@ from aci_protocol import (
     TurnSource,
     parse_queued_turn,
 )
+from curie_telemetry import (
+    TRACEPARENT_STREAM_FIELD,
+    inject_trace_context,
+    operation_span,
+    record_metric,
+)
 from fastapi import APIRouter, Header, HTTPException, Request, Response, status
+from opentelemetry.trace import SpanKind, StatusCode
 from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.orm import selectinload
@@ -411,16 +418,70 @@ async def ingest_hook(
                     headers={"Retry-After": str(settings.hook_backlog_window_s)},
                 )
             turn = _mint_turn(agent, binding, hook, event_id, raw, partition=partition)
-            enqueued, current = await enqueue_owned(
-                client,
-                key=key,
-                stream=settings.runs_stream,
-                owner=owner,
-                payload=turn.model_dump_json(),
-                payload_field=STREAM_PAYLOAD_FIELD,
-                lease_s=settings.channel_delivery_lease_s,
-            )
+            carrier: dict[str, str] = {}
+            enqueue_error: Exception | None = None
+            enqueue_result: tuple[bool, str] | None = None
+            with operation_span(
+                "curie.queue.enqueue",
+                kind=SpanKind.PRODUCER,
+                attributes={"service.name": "curie-api", "source": "api"},
+            ) as span:
+                inject_trace_context(carrier)
+                try:
+                    enqueue_result = await enqueue_owned(
+                        client,
+                        key=key,
+                        stream=settings.runs_stream,
+                        owner=owner,
+                        payload=turn.model_dump_json(),
+                        payload_field=STREAM_PAYLOAD_FIELD,
+                        lease_s=settings.channel_delivery_lease_s,
+                        transport_field=(
+                            TRACEPARENT_STREAM_FIELD
+                            if TRACEPARENT_STREAM_FIELD in carrier
+                            else None
+                        ),
+                        transport_value=carrier.get(TRACEPARENT_STREAM_FIELD),
+                    )
+                except Exception as exc:
+                    enqueue_error = exc
+                    span.set_status(StatusCode.ERROR)
+                    span.add_event("queue.enqueue.failed", {"outcome": "failure"})
+                else:
+                    assert enqueue_result is not None
+                    span.add_event(
+                        "queue.enqueued" if enqueue_result[0] else "queue.duplicate",
+                        {"outcome": "success" if enqueue_result[0] else "pending"},
+                    )
+            if enqueue_error is not None:
+                record_metric(
+                    "curie.queue.enqueue",
+                    attributes={
+                        "service.name": "curie-api",
+                        "source": "api",
+                        "outcome": "failure",
+                    },
+                )
+                raise enqueue_error
+            assert enqueue_result is not None
+            enqueued, current = enqueue_result
             if enqueued:
+                record_metric(
+                    "curie.queue.enqueue",
+                    attributes={
+                        "service.name": "curie-api",
+                        "source": "api",
+                        "outcome": "success",
+                    },
+                )
+                record_metric(
+                    "curie.turn.accepted",
+                    attributes={
+                        "service.name": "curie-api",
+                        "source": "api",
+                        "outcome": "accepted",
+                    },
+                )
                 # The conversation id is here because it is the operator's only
                 # server-side record of which thread a delivery landed on. There
                 # is no verb that resets every partition of one hook, so a

--- a/apps/api/src/curie_api/routers/publications.py
+++ b/apps/api/src/curie_api/routers/publications.py
@@ -6,7 +6,8 @@ GitHub side effects belong to the trusted worker publication reconciler.
 
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException, Response, status
+from curie_telemetry import TRACEPARENT_STREAM_FIELD, canonicalize_traceparent
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from starlette.concurrency import run_in_threadpool
 
 from .. import crud
@@ -38,6 +39,7 @@ internal_router = APIRouter(
 )
 async def create_publication(
     data: PublicationCreate,
+    request: Request,
     session: SessionDep,
     response: Response,
 ) -> PublicationOut:
@@ -51,8 +53,16 @@ async def create_publication(
             status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
             f"publication patch exceeds the {patch_limit_bytes}-byte limit",
         )
+    traceparent = canonicalize_traceparent(
+        request.headers.get(TRACEPARENT_STREAM_FIELD)
+    )
     try:
-        publication, created = await crud.create_publication(session, data, patch=patch)
+        publication, created = await crud.create_publication(
+            session,
+            data,
+            patch=patch,
+            traceparent=traceparent,
+        )
     except crud.PublicationReplayConflict as exc:
         raise HTTPException(status.HTTP_409_CONFLICT, str(exc)) from exc
     except LookupError as exc:

--- a/apps/api/src/curie_api/sweeper.py
+++ b/apps/api/src/curie_api/sweeper.py
@@ -51,7 +51,11 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from . import crud
 from .config import get_settings
-from .resumequeue import ResumeQueue, build_expiry_resume_turn
+from .resumequeue import (
+    ResumeQueue,
+    approval_trace_context,
+    build_expiry_resume_turn,
+)
 
 logger = logging.getLogger(__name__)
 _monotonic = time.monotonic
@@ -104,18 +108,21 @@ async def sweep_expired_approvals(
 
     now = now or datetime.now(UTC).replace(tzinfo=None)
     lapsed = await crud.list_expired_pending_approvals(session, now=now, limit=limit)
-    # Read the ids into plain values up front: the per-record rollback below
-    # expires every ORM instance in this shared session, so reading record.id
-    # lazily in a later iteration would trigger an implicit reload (MissingGreenlet
-    # under the async session).
-    approval_ids = [record.id for record in lapsed]
+    # Read ids and private parents into plain values up front: the per-record
+    # rollback below expires every ORM instance in this shared session, so
+    # reading record fields lazily in a later iteration would trigger an
+    # implicit reload (MissingGreenlet under the async session).
+    approval_work = [
+        (record.id, approval_trace_context(record)) for record in lapsed
+    ]
 
     flipped = 0
-    for approval_id in approval_ids:
+    for approval_id, stored_parent in approval_work:
         try:
             with operation_span(
                 "curie.approval.expire",
                 kind=SpanKind.INTERNAL,
+                parent=stored_parent,
                 attributes={
                     "service.name": "curie-api",
                     "operation": "expire",
@@ -140,7 +147,9 @@ async def sweep_expired_approvals(
             if expired.purpose == "publication":
                 flipped += 1
                 continue
-            stream_id = await resume_queue.enqueue(build_expiry_resume_turn(expired))
+            stream_id = await resume_queue.enqueue(
+                build_expiry_resume_turn(expired), parent=stored_parent
+            )
             flipped += 1
             # Enqueue-first-then-mark: only a wake that actually reached the
             # stream is written off. The mark's ``resumed_at IS NULL`` guard

--- a/apps/api/tests/test_approval_decision_hoist.py
+++ b/apps/api/tests/test_approval_decision_hoist.py
@@ -45,6 +45,19 @@ def test_hoist_prefers_trace_over_observation() -> None:
     assert hoist_approval_decision(trace, observations) == "approved"
 
 
+def test_hoist_from_later_resume_observation_in_correlated_trace() -> None:
+    # The dispatcher-rooted trace includes spans before and after agent.run.
+    # Observation ordering cannot decide whether the resume is visible.
+    observations = [
+        {"id": "reply", "name": "curie.reply.update"},
+        {"id": "ingress", "metadata": {"gen_ai.approval.decision": ""}},
+        {"id": "invalid", "metadata": {"gen_ai.approval.decision": False}},
+        {"id": "resume", "metadata": {"gen_ai.approval.decision": "approved"}},
+    ]
+    assert hoist_approval_decision({"id": "t1"}, observations) == "approved"
+    assert hoist_approval_decision({"id": "t1"}, observations[:-1]) is None
+
+
 def test_hoist_returns_none_for_an_ordinary_turn() -> None:
     # No approval was resumed this turn -- the ordinary, most common case.
     trace = {"id": "t1", "metadata": {"other": "x"}}

--- a/apps/api/tests/test_approvals.py
+++ b/apps/api/tests/test_approvals.py
@@ -50,12 +50,16 @@ from curie_telemetry import (
     operation_span,
     record_metric,
 )
+from curie_telemetry.tracing import configure_tracer_provider
 from curie_test_support.valkey import (
     connect_or_skip,
 )
 from fastapi.testclient import TestClient
 from opentelemetry import context as otel_context
 from opentelemetry import trace
+from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags, TraceState
 from sqlalchemy import text
 from sqlalchemy.exc import IntegrityError
@@ -66,6 +70,10 @@ from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 ALEMBIC_DIR = Path(__file__).resolve().parents[1] / "alembic"
 _TRACE_ID = int("2123456789abcdef0123456789abcdef", 16)
 _SPAN_ID = int("2123456789abcdef", 16)
+_TRACEPARENT = "00-2123456789abcdef0123456789abcdef-2123456789abcdef-01"
+_CLICK_TRACE_ID = int("6123456789abcdef0123456789abcdef", 16)
+_CLICK_SPAN_ID = int("6123456789abcdef", 16)
+_CLICK_TRACEPARENT = "00-6123456789abcdef0123456789abcdef-6123456789abcdef-01"
 
 
 @asynccontextmanager
@@ -82,6 +90,25 @@ async def _remote_parent() -> AsyncIterator[None]:
         yield
     finally:
         otel_context.detach(token)
+
+
+@contextmanager
+def _captured_approval_spans() -> Iterator[InMemorySpanExporter]:
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    configure_tracer_provider(provider)
+    try:
+        yield exporter
+    finally:
+        configure_tracer_provider(None)
+        provider.shutdown()
+
+
+def _span_named(exporter: InMemorySpanExporter, name: str) -> ReadableSpan:
+    matches = [span for span in exporter.get_finished_spans() if span.name == name]
+    assert len(matches) == 1, [(span.name, span.context.trace_id) for span in matches]
+    return matches[0]
 
 
 @pytest.fixture
@@ -288,6 +315,28 @@ def _read_reply_placeholder(approval_id: str) -> str | None:
     return asyncio.run(_run())
 
 
+def _read_approval_traceparent(approval_id: str) -> str | None:
+    """Read the private carrier directly; it must never enter ApprovalOut."""
+
+    async def _run() -> str | None:
+        engine = create_async_engine(get_settings().database_url)
+        try:
+            async with engine.connect() as conn:
+                result = await conn.execute(
+                    text(
+                        "SELECT traceparent FROM curie.approvals WHERE id = :id"
+                    ),
+                    {"id": uuid.UUID(approval_id)},
+                )
+                row = result.first()
+                assert row is not None
+                return row[0]
+        finally:
+            await engine.dispose()
+
+    return asyncio.run(_run())
+
+
 def test_resolve_endpoint_stays_200_when_enqueue_fails(
     approvals_client: TestClient,
     auth_headers: dict[str, str],
@@ -334,6 +383,68 @@ def test_resolve_endpoint_stays_200_when_enqueue_fails(
     )
     assert retry.status_code == 409
     assert valkey.xrange(runs_stream) == []
+
+
+def test_failed_inline_enqueue_then_reconciler_keeps_the_stored_parent(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    valkey: redis.Redis,
+    runs_stream: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created = approvals_client.post(
+        "/approvals",
+        json=_payload(),
+        headers={**auth_headers, "traceparent": _TRACEPARENT},
+    ).json()
+    queue = approvals_client.app.state.resume_queue
+    original_enqueue = queue.enqueue
+
+    async def _boom(_turn: Any, **_kwargs: Any) -> str:
+        raise RuntimeError("valkey unreachable")
+
+    monkeypatch.setattr(queue, "enqueue", _boom)
+    resolved = approvals_client.post(
+        f"/approvals/{created['id']}/resolve",
+        json={"decision": "approved"},
+        headers=_chat_resolve_headers(
+            created["id"],
+            "U0APPROVER1",
+            "C1",
+            base={**auth_headers, "traceparent": _CLICK_TRACEPARENT},
+        ),
+    )
+    assert resolved.status_code == 200, resolved.text
+    assert valkey.xrange(runs_stream) == []
+    assert _read_resumed_at(created["id"]) is None
+    monkeypatch.setattr(queue, "enqueue", original_enqueue)
+
+    async def _recover() -> int:
+        async with _sweeper_stack(runs_stream) as (sessionmaker, resume_queue, _client):
+            reconciler = ResumeReconciler(
+                sessionmaker,
+                resume_queue,
+                interval_seconds=30,
+                grace_seconds=0,
+                batch_limit=100,
+            )
+            return await reconciler.reconcile_once()
+
+    with _captured_approval_spans() as exporter:
+        assert asyncio.run(_recover()) == 1
+
+    enqueue = _span_named(exporter, "curie.queue.enqueue")
+    assert enqueue.context.trace_id == _TRACE_ID
+    assert enqueue.parent is not None and enqueue.parent.span_id == _SPAN_ID
+    entries = valkey.xrange(runs_stream)
+    assert len(entries) == 1
+    carried = trace.get_current_span(
+        extract_trace_context(entries[0][1])
+    ).get_span_context()
+    assert carried.trace_id == _TRACE_ID
+    assert carried.span_id == enqueue.context.span_id
+    assert _read_resumed_at(created["id"]) is not None
 
 
 @pytest.fixture
@@ -443,21 +554,21 @@ def test_resume_queue_injects_traceparent_adjacent_to_unchanged_payload(
     """Approval resume uses the same transport carrier without widening the DTO."""
 
     created = approvals_client.post(
-        "/approvals", json=_payload(), headers=auth_headers
+        "/approvals",
+        json=_payload(),
+        headers={**auth_headers, "traceparent": _TRACEPARENT},
     ).json()
 
-    async def _resolve_with_parent() -> Any:
-        async with _remote_parent():
-            return await asyncio.to_thread(
-                approvals_client.post,
-                f"/approvals/{created['id']}/resolve",
-                json={"decision": "approved"},
-                headers=_chat_resolve_headers(
-                    created["id"], "U9", "C1", base=auth_headers
-                ),
-            )
-
-    resolved = asyncio.run(_resolve_with_parent())
+    resolved = approvals_client.post(
+        f"/approvals/{created['id']}/resolve",
+        json={"decision": "approved"},
+        headers=_chat_resolve_headers(
+            created["id"],
+            "U9",
+            "C1",
+            base={**auth_headers, "traceparent": _CLICK_TRACEPARENT},
+        ),
+    )
     assert resolved.status_code == 200, resolved.text
 
     entries = valkey.xrange(runs_stream)
@@ -471,6 +582,144 @@ def test_resume_queue_injects_traceparent_adjacent_to_unchanged_payload(
     assert parent.is_valid is True
     assert parent.is_remote is True
     assert parent.trace_id == _TRACE_ID
+
+
+def test_create_privately_persists_only_the_first_inbound_carrier(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+) -> None:
+    """The authenticated HTTP header is metadata; body and replay are not authority."""
+
+    payload = _payload(traceparent=_CLICK_TRACEPARENT)
+    created = approvals_client.post(
+        "/approvals",
+        json=payload,
+        headers={**auth_headers, "traceparent": _TRACEPARENT},
+    )
+    assert created.status_code == 201, created.text
+    body = created.json()
+    assert "traceparent" not in body
+    assert _read_approval_traceparent(body["id"]) == _TRACEPARENT
+
+    replayed = approvals_client.post(
+        "/approvals",
+        json=payload,
+        headers={**auth_headers, "traceparent": _CLICK_TRACEPARENT},
+    )
+    assert replayed.status_code == 200, replayed.text
+    assert replayed.json()["id"] == body["id"]
+    assert "traceparent" not in replayed.json()
+    assert _read_approval_traceparent(body["id"]) == _TRACEPARENT
+
+    listed = approvals_client.get("/approvals", headers=auth_headers).json()
+    got = approvals_client.get(
+        f"/approvals/{body['id']}", headers=auth_headers
+    ).json()
+    assert all("traceparent" not in row for row in listed)
+    assert "traceparent" not in got
+
+
+@pytest.mark.parametrize("carrier", [None, "not-w3c", "x" * 1024])
+def test_create_with_missing_or_malformed_carrier_stores_a_safe_null(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    carrier: str | None,
+) -> None:
+    headers = dict(auth_headers)
+    if carrier is not None:
+        headers["traceparent"] = carrier
+    created = approvals_client.post("/approvals", json=_payload(), headers=headers)
+    assert created.status_code == 201, created.text
+    assert _read_approval_traceparent(created.json()["id"]) is None
+
+
+@pytest.mark.parametrize("decision", ["approved", "rejected"])
+def test_terminal_resolution_and_resume_parent_to_the_stored_turn(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    valkey: redis.Redis,
+    runs_stream: str,
+    decision: str,
+) -> None:
+    created = approvals_client.post(
+        "/approvals",
+        json=_payload(),
+        headers={**auth_headers, "traceparent": _TRACEPARENT},
+    ).json()
+
+    with _captured_approval_spans() as exporter:
+        resolved = approvals_client.post(
+            f"/approvals/{created['id']}/resolve",
+            json={"decision": decision},
+            headers=_chat_resolve_headers(
+                created["id"],
+                "U0APPROVER1",
+                "C1",
+                base={**auth_headers, "traceparent": _CLICK_TRACEPARENT},
+            ),
+        )
+
+    assert resolved.status_code == 200, resolved.text
+    server = _span_named(exporter, "http.server.request")
+    transition = _span_named(exporter, "curie.approval.resolve")
+    enqueue = _span_named(exporter, "curie.queue.enqueue")
+    assert server.context.trace_id == _CLICK_TRACE_ID
+    assert server.parent is not None and server.parent.span_id == _CLICK_SPAN_ID
+    for span in (transition, enqueue):
+        assert span.context.trace_id == _TRACE_ID
+        assert span.parent is not None and span.parent.span_id == _SPAN_ID
+
+    entries = valkey.xrange(runs_stream)
+    assert len(entries) == 1
+    resumed_parent = trace.get_current_span(
+        extract_trace_context(entries[0][1])
+    ).get_span_context()
+    assert resumed_parent.trace_id == _TRACE_ID
+    assert resumed_parent.span_id == enqueue.context.span_id
+
+
+def test_late_expiry_transition_and_resume_parent_to_the_stored_turn(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    valkey: redis.Redis,
+    runs_stream: str,
+) -> None:
+    created = approvals_client.post(
+        "/approvals",
+        json=_payload(expires_in_seconds=1),
+        headers={**auth_headers, "traceparent": _TRACEPARENT},
+    ).json()
+    time.sleep(1.1)
+
+    with _captured_approval_spans() as exporter:
+        expired = approvals_client.post(
+            f"/approvals/{created['id']}/resolve",
+            json={"decision": "approved"},
+            headers=_chat_resolve_headers(
+                created["id"],
+                "U0APPROVER1",
+                "C1",
+                base={**auth_headers, "traceparent": _CLICK_TRACEPARENT},
+            ),
+        )
+
+    assert expired.status_code == 410, expired.text
+    transition = _span_named(exporter, "curie.approval.expire")
+    enqueue = _span_named(exporter, "curie.queue.enqueue")
+    for span in (transition, enqueue):
+        assert span.context.trace_id == _TRACE_ID
+        assert span.parent is not None and span.parent.span_id == _SPAN_ID
+    entries = valkey.xrange(runs_stream)
+    assert len(entries) == 1
+    resumed_parent = trace.get_current_span(
+        extract_trace_context(entries[0][1])
+    ).get_span_context()
+    assert resumed_parent.trace_id == _TRACE_ID
+    assert resumed_parent.span_id == enqueue.context.span_id
 
 
 def test_create_get_list_round_trip(
@@ -1293,6 +1542,46 @@ def test_sweeper_expires_lapsed_pending_and_enqueues_resume_turn(
 
     assert asyncio.run(_reconcile()) == 0
     assert len(valkey.xrange(runs_stream)) == 1
+
+
+def test_sweeper_transition_and_resume_use_the_stored_turn_parent(
+    approvals_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    valkey: redis.Redis,
+    runs_stream: str,
+) -> None:
+    created = approvals_client.post(
+        "/approvals",
+        json=_payload(expires_in_seconds=1),
+        headers={**auth_headers, "traceparent": _TRACEPARENT},
+    ).json()
+
+    async def _sweep() -> int:
+        async with _sweeper_stack(runs_stream) as (sessionmaker, queue, _client):
+            async with sessionmaker() as session:
+                return await sweep_expired_approvals(
+                    session, queue, now=_naive_utc(2)
+                )
+
+    with _captured_approval_spans() as exporter:
+        assert asyncio.run(_sweep()) == 1
+
+    transition = _span_named(exporter, "curie.approval.expire")
+    enqueue = _span_named(exporter, "curie.queue.enqueue")
+    for span in (transition, enqueue):
+        assert span.context.trace_id == _TRACE_ID
+        assert span.parent is not None and span.parent.span_id == _SPAN_ID
+    entries = valkey.xrange(runs_stream)
+    assert len(entries) == 1
+    assert json.loads(entries[0][1]["payload"])["event_id"] == (
+        f"approval-{created['id']}-resolved"
+    )
+    carried = trace.get_current_span(
+        extract_trace_context(entries[0][1])
+    ).get_span_context()
+    assert carried.trace_id == _TRACE_ID
+    assert carried.span_id == enqueue.context.span_id
 
 
 def test_sweeper_ignores_unexpired_and_unbounded_records(

--- a/apps/api/tests/test_approvals.py
+++ b/apps/api/tests/test_approvals.py
@@ -1892,13 +1892,13 @@ def test_sweeper_isolates_a_failing_record(
             orig = queue.enqueue
             calls = {"n": 0}
 
-            async def _flaky_enqueue(turn: QueuedTurn) -> str:
+            async def _flaky_enqueue(turn: QueuedTurn, **kwargs: Any) -> str:
                 # Raise on the first record's enqueue (a Valkey blip), then let
                 # every later record enqueue for real.
                 calls["n"] += 1
                 if calls["n"] == 1:
                     raise RuntimeError("valkey down")
-                return await orig(turn)
+                return await orig(turn, **kwargs)
 
             monkeypatch.setattr(queue, "enqueue", _flaky_enqueue)
             async with sessionmaker() as session:

--- a/apps/api/tests/test_channels.py
+++ b/apps/api/tests/test_channels.py
@@ -634,12 +634,12 @@ def test_channel_ingress_injects_traceparent_adjacent_to_unchanged_payload(
         address="trace@example.test",
     )
 
-    with _remote_parent():
-        response = _post_turn(
-            channels_client,
-            token,
-            _turn("email", "trace@example.test"),
-        )
+    response = _post_turn(
+        channels_client,
+        token,
+        _turn("email", "trace@example.test"),
+        headers={TRACEPARENT_STREAM_FIELD: _TRACEPARENT},
+    )
     assert response.status_code == 200, response.text
 
     entries = valkey.xrange(runs_stream)

--- a/apps/api/tests/test_channels.py
+++ b/apps/api/tests/test_channels.py
@@ -38,11 +38,15 @@ from curie_api.config import Settings, get_settings
 from curie_api.main import create_app
 from curie_api.routers import channels as channels_router
 from curie_telemetry import TRACEPARENT_STREAM_FIELD, extract_trace_context
+from curie_telemetry.tracing import configure_tracer_provider
 from curie_test_support.valkey import connect_or_skip
 from fastapi.routing import APIRoute
 from fastapi.testclient import TestClient
 from opentelemetry import context as otel_context
 from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags, TraceState
 from sqlalchemy import text as sql_text
 from sqlalchemy.ext.asyncio import create_async_engine
@@ -57,6 +61,7 @@ PAST = 1000000000  # 2001, comfortably expired
 FAR_FUTURE = 4102444800  # 2100-01-01
 _TRACE_ID = int("1123456789abcdef0123456789abcdef", 16)
 _SPAN_ID = int("1123456789abcdef", 16)
+_TRACEPARENT = "00-1123456789abcdef0123456789abcdef-1123456789abcdef-01"
 
 
 @contextmanager
@@ -73,6 +78,19 @@ def _remote_parent() -> Iterator[None]:
         yield
     finally:
         otel_context.detach(token)
+
+
+@contextmanager
+def _captured_spans() -> Iterator[InMemorySpanExporter]:
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    configure_tracer_provider(provider)
+    try:
+        yield exporter
+    finally:
+        configure_tracer_provider(None)
+        provider.shutdown()
 
 # The one detail string every ingress auth failure returns. Identical for
 # "no credential" and "wrong credential" so a caller cannot probe the
@@ -635,6 +653,77 @@ def test_channel_ingress_injects_traceparent_adjacent_to_unchanged_payload(
     assert parent.is_valid is True
     assert parent.is_remote is True
     assert parent.trace_id == _TRACE_ID
+
+
+def test_channel_http_parent_is_observation_context_never_ingress_authority(
+    channels_client: TestClient,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    valkey: redis.Redis,
+    runs_stream: str,
+) -> None:
+    """A standard carrier parents telemetry but cannot replace a chn token."""
+
+    _bind(
+        channels_client,
+        auth_headers,
+        name="http-traced-ingress-agent",
+        channel=_email_channel("http-trace@example.test"),
+    )
+    token = _mint(
+        channels_client,
+        auth_headers,
+        kind="email",
+        address="http-trace@example.test",
+    )
+    accepted_body = _turn("email", "http-trace@example.test")
+
+    with _captured_spans() as exporter:
+        accepted = _post_turn(
+            channels_client,
+            token,
+            accepted_body,
+            headers={TRACEPARENT_STREAM_FIELD: _TRACEPARENT},
+        )
+        unauthorized = _post_turn(
+            channels_client,
+            None,
+            _turn("email", "http-trace@example.test"),
+            headers={TRACEPARENT_STREAM_FIELD: _TRACEPARENT},
+        )
+
+    assert accepted.status_code == 200, accepted.text
+    assert unauthorized.status_code == 401, unauthorized.text
+    entries = valkey.xrange(runs_stream)
+    assert len(entries) == 1
+    _entry_id, fields = entries[0]
+
+    server_spans = [
+        span
+        for span in exporter.get_finished_spans()
+        if span.name == "http.server.request" and span.context.trace_id == _TRACE_ID
+    ]
+    producers = [
+        span for span in exporter.get_finished_spans() if span.name == "curie.queue.enqueue"
+    ]
+    assert len(server_spans) == 2
+    assert len(producers) == 1
+    producer = producers[0]
+    producer_parent = producer.parent
+    assert producer_parent is not None
+    accepted_server = next(
+        span for span in server_spans if span.context.span_id == producer_parent.span_id
+    )
+    assert accepted_server.parent is not None
+    assert accepted_server.parent.span_id == _SPAN_ID
+    assert producer.context.trace_id == accepted_server.context.trace_id
+
+    transported = trace.get_current_span(extract_trace_context(fields)).get_span_context()
+    assert transported.trace_id == producer.context.trace_id
+    assert transported.span_id == producer.context.span_id
+    assert QueuedTurn.model_validate_json(fields["payload"]).model_dump_json() == fields[
+        "payload"
+    ]
 
 
 def test_a_slack_binding_enqueues_with_neither_endpoint_nor_adapter(

--- a/apps/api/tests/test_hooks.py
+++ b/apps/api/tests/test_hooks.py
@@ -17,6 +17,7 @@ import hashlib
 import hmac
 import uuid
 from collections.abc import Iterator
+from contextlib import contextmanager
 from typing import Any
 
 import pytest
@@ -25,12 +26,22 @@ from aci_protocol import QueuedTurn, TurnSource
 from curie_api.config import get_settings
 from curie_api.hook_signing import derive
 from curie_api.routers import hooks as hooks_router
+from curie_telemetry import TRACEPARENT_STREAM_FIELD, extract_trace_context
+from curie_telemetry.tracing import configure_tracer_provider
 from fastapi.testclient import TestClient
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from sqlalchemy import text as sql_text
 from sqlalchemy.ext.asyncio import create_async_engine
 
 EMAIL_ENDPOINT = "http://curie-mail-adapter:8080/"
 EMAIL_ADAPTER = "agentmail-sandbox"
+_TRACE_ID = int("3123456789abcdef0123456789abcdef", 16)
+_PARENT_SPAN_ID = int("3123456789abcdef", 16)
+_TRACEPARENT = "00-3123456789abcdef0123456789abcdef-3123456789abcdef-01"
+_OTHER_TRACEPARENT = "00-4123456789abcdef0123456789abcdef-4123456789abcdef-01"
 
 
 # --- fixtures -----------------------------------------------------------------
@@ -84,6 +95,7 @@ def _post(
     secret: str | None = None,
     signature: str | None = None,
     delivery_id: str | None = "dlv-1",
+    traceparent: str | None = None,
 ) -> Any:
     """POST one delivery, signing with `secret` unless a signature is forced."""
 
@@ -94,7 +106,22 @@ def _post(
         headers["X-Curie-Signature-256"] = _sign(secret, body)
     if delivery_id is not None:
         headers["X-Curie-Delivery-Id"] = delivery_id
+    if traceparent is not None:
+        headers[TRACEPARENT_STREAM_FIELD] = traceparent
     return client.post(f"/hooks/{agent_id}/{hook}", content=body, headers=headers)
+
+
+@contextmanager
+def _captured_spans() -> Iterator[InMemorySpanExporter]:
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    configure_tracer_provider(provider)
+    try:
+        yield exporter
+    finally:
+        configure_tracer_provider(None)
+        provider.shutdown()
 
 
 def _bump_generation(agent_id: str) -> None:
@@ -163,6 +190,73 @@ def test_a_signed_delivery_enqueues_a_webhook_turn_with_no_placeholder(
     # The payload reaches the agent, and the author is the platform, not a person.
     assert '{"issue": 42}' in turn.text
     assert turn.author == "hook:issues"
+
+
+def test_hook_ingress_producer_injects_the_http_parent_through_owned_enqueue(
+    hooks_client: TestClient,
+    auth_headers: dict[str, str],
+    valkey: redis.Redis,
+    runs_stream: str,
+    clean_db: None,
+) -> None:
+    """Hook and channel ingress share W3C transport without widening payload."""
+
+    agent_id = _bind(hooks_client, auth_headers, name="tracedhookagent")
+    secret = _secret_for(agent_id)
+    body = b'{"issue": 42}'
+
+    with _captured_spans() as exporter:
+        accepted = _post(
+            hooks_client,
+            agent_id,
+            "issues",
+            body,
+            secret=secret,
+            delivery_id="trace-delivery",
+            traceparent=_TRACEPARENT,
+        )
+        duplicate = _post(
+            hooks_client,
+            agent_id,
+            "issues",
+            body,
+            secret=secret,
+            delivery_id="trace-delivery",
+            traceparent=_OTHER_TRACEPARENT,
+        )
+
+    assert accepted.status_code == 200, accepted.text
+    assert accepted.json()["duplicate"] is False
+    assert duplicate.status_code == 200, duplicate.text
+    assert duplicate.json()["duplicate"] is True
+
+    entries = valkey.xrange(runs_stream)
+    assert len(entries) == 1
+    _entry_id, fields = entries[0]
+    assert set(fields) == {"payload", TRACEPARENT_STREAM_FIELD}
+    raw_payload = fields["payload"]
+    assert QueuedTurn.model_validate_json(raw_payload).model_dump_json() == raw_payload
+
+    server_spans = [
+        span for span in exporter.get_finished_spans() if span.name == "http.server.request"
+    ]
+    producers = [
+        span for span in exporter.get_finished_spans() if span.name == "curie.queue.enqueue"
+    ]
+    assert len(server_spans) == 2
+    assert len(producers) == 1, "the duplicate request owns no producer handoff"
+    accepted_server = next(span for span in server_spans if span.context.trace_id == _TRACE_ID)
+    assert accepted_server.parent is not None
+    assert accepted_server.parent.is_remote is True
+    assert accepted_server.parent.span_id == _PARENT_SPAN_ID
+    producer = producers[0]
+    assert producer.context.trace_id == accepted_server.context.trace_id
+    assert producer.parent is not None
+    assert producer.parent.span_id == accepted_server.context.span_id
+
+    transported = trace.get_current_span(extract_trace_context(fields)).get_span_context()
+    assert transported.trace_id == producer.context.trace_id
+    assert transported.span_id == producer.context.span_id
 
 
 def test_instruction_shaped_payload_is_delimited_as_untrusted_content(

--- a/apps/api/tests/test_langfuse_integration.py
+++ b/apps/api/tests/test_langfuse_integration.py
@@ -11,7 +11,6 @@ from typing import Any
 import httpx
 import pytest
 from curie_api.config import get_settings
-from curie_api.main import create_app
 from fastapi.testclient import TestClient
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk.resources import Resource
@@ -64,21 +63,20 @@ def _max_depth(nodes: list[dict[str, Any]]) -> int:
 
 @pytest.mark.skipif(not _stack_up(), reason="dev compose stack not reachable")
 def test_proxy_returns_reconstructed_tree_for_seeded_trace(
-    auth_headers: dict[str, str],
+    client: TestClient, auth_headers: dict[str, str],
 ) -> None:
     trace_id = _emit_three_level_trace()
 
     deadline = time.time() + 60
     body: dict[str, Any] | None = None
-    with TestClient(create_app()) as client:
-        while time.time() < deadline:
-            resp = client.get(
-                f"/langfuse/traces/{trace_id}", headers=auth_headers
-            )
-            if resp.status_code == 200 and _max_depth(resp.json()["tree"]) >= 3:
-                body = resp.json()
-                break
-            time.sleep(2)
+    while time.time() < deadline:
+        resp = client.get(
+            f"/langfuse/traces/{trace_id}", headers=auth_headers
+        )
+        if resp.status_code == 200 and _max_depth(resp.json()["tree"]) >= 3:
+            body = resp.json()
+            break
+        time.sleep(2)
 
     assert body is not None, "seeded trace never reached the proxy with depth >= 3"
     assert _max_depth(body["tree"]) >= 3
@@ -97,7 +95,7 @@ def test_proxy_returns_reconstructed_tree_for_seeded_trace(
 @pytest.mark.skipif(not _stack_up(), reason="dev compose stack not reachable")
 @pytest.mark.parametrize("decision", ["approved", None])
 def test_proxy_reads_approval_on_non_root_observation(
-    auth_headers: dict[str, str], decision: str | None,
+    client: TestClient, auth_headers: dict[str, str], decision: str | None,
 ) -> None:
     provider = TracerProvider(
         resource=Resource.create({"service.name": "approval-correlation-integration"})
@@ -119,21 +117,20 @@ def test_proxy_reads_approval_on_non_root_observation(
 
     deadline = time.time() + 60
     body: dict[str, Any] | None = None
-    with TestClient(create_app()) as client:
-        while time.time() < deadline:
-            resp = client.get(f"/langfuse/traces/{trace_id}", headers=auth_headers)
-            if resp.status_code == 200:
-                candidate = resp.json()
-                tree = candidate["tree"]
-                if (
-                    len(tree) == 1
-                    and tree[0]["name"] == "curie.queue.enqueue"
-                    and {child["name"] for child in tree[0]["children"]}
-                    == {"agent.run", "curie.reply.update"}
-                    and candidate["approval_decision"] == decision
-                ):
-                    body = candidate
-                    break
-            time.sleep(2)
+    while time.time() < deadline:
+        resp = client.get(f"/langfuse/traces/{trace_id}", headers=auth_headers)
+        if resp.status_code == 200:
+            candidate = resp.json()
+            tree = candidate["tree"]
+            if (
+                len(tree) == 1
+                and tree[0]["name"] == "curie.queue.enqueue"
+                and {child["name"] for child in tree[0]["children"]}
+                == {"agent.run", "curie.reply.update"}
+                and candidate["approval_decision"] == decision
+            ):
+                body = candidate
+                break
+        time.sleep(2)
     assert body is not None, "correlated approval metadata did not reach the exact proxy read"
     assert body["approval_decision"] == decision

--- a/apps/api/tests/test_langfuse_integration.py
+++ b/apps/api/tests/test_langfuse_integration.py
@@ -92,3 +92,48 @@ def test_proxy_returns_reconstructed_tree_for_seeded_trace(
 
     _walk(body["tree"])
     assert any(n["type"] == "GENERATION" for n in flat)
+
+
+@pytest.mark.skipif(not _stack_up(), reason="dev compose stack not reachable")
+@pytest.mark.parametrize("decision", ["approved", None])
+def test_proxy_reads_approval_on_non_root_observation(
+    auth_headers: dict[str, str], decision: str | None,
+) -> None:
+    provider = TracerProvider(
+        resource=Resource.create({"service.name": "approval-correlation-integration"})
+    )
+    provider.add_span_processor(
+        SimpleSpanProcessor(OTLPSpanExporter(endpoint=COLLECTOR_ENDPOINT))
+    )
+    tracer = provider.get_tracer("approval-correlation-integration")
+    try:
+        with tracer.start_as_current_span("curie.queue.enqueue") as root:
+            trace_id = format(root.get_span_context().trace_id, "032x")
+            with tracer.start_as_current_span("agent.run") as resumed:
+                if decision is not None:
+                    resumed.set_attribute("gen_ai.approval.decision", decision)
+            with tracer.start_as_current_span("curie.reply.update"):
+                pass
+    finally:
+        provider.shutdown()
+
+    deadline = time.time() + 60
+    body: dict[str, Any] | None = None
+    with TestClient(create_app()) as client:
+        while time.time() < deadline:
+            resp = client.get(f"/langfuse/traces/{trace_id}", headers=auth_headers)
+            if resp.status_code == 200:
+                candidate = resp.json()
+                tree = candidate["tree"]
+                if (
+                    len(tree) == 1
+                    and tree[0]["name"] == "curie.queue.enqueue"
+                    and {child["name"] for child in tree[0]["children"]}
+                    == {"agent.run", "curie.reply.update"}
+                    and candidate["approval_decision"] == decision
+                ):
+                    body = candidate
+                    break
+            time.sleep(2)
+    assert body is not None, "correlated approval metadata did not reach the exact proxy read"
+    assert body["approval_decision"] == decision

--- a/apps/api/tests/test_migration_0039_approval_traceparent.py
+++ b/apps/api/tests/test_migration_0039_approval_traceparent.py
@@ -12,7 +12,7 @@ from alembic import command
 from alembic.config import Config
 from curie_api.config import get_settings
 from sqlalchemy import text
-from sqlalchemy.exc import DataError
+from sqlalchemy.exc import DBAPIError
 from sqlalchemy.ext.asyncio import create_async_engine
 
 ALEMBIC_DIR = Path(__file__).resolve().parents[1] / "alembic"
@@ -97,7 +97,7 @@ def test_0039_adds_nullable_bounded_private_carrier_and_round_trips(
         "SELECT traceparent FROM curie.approvals WHERE id = :id",
         {"id": approval_id},
     ) == [{"traceparent": valid}]
-    with pytest.raises(DataError):
+    with pytest.raises(DBAPIError):
         _write_traceparent(approval_id, "x" * 56)
 
     command.downgrade(cfg, "0038")

--- a/apps/api/tests/test_migration_0039_approval_traceparent.py
+++ b/apps/api/tests/test_migration_0039_approval_traceparent.py
@@ -1,0 +1,115 @@
+"""Migration 0039: private, bounded approval trace continuity."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from pathlib import Path
+from typing import Any
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from curie_api.config import get_settings
+from sqlalchemy import text
+from sqlalchemy.exc import DataError
+from sqlalchemy.ext.asyncio import create_async_engine
+
+ALEMBIC_DIR = Path(__file__).resolve().parents[1] / "alembic"
+
+
+def _rows(query: str, params: dict[str, Any] | None = None) -> list[dict[str, Any]]:
+    async def run() -> list[dict[str, Any]]:
+        engine = create_async_engine(get_settings().database_url)
+        try:
+            async with engine.connect() as conn:
+                result = await conn.execute(text(query), params or {})
+                return [dict(row._mapping) for row in result]
+        finally:
+            await engine.dispose()
+
+    return asyncio.run(run())
+
+
+def _seed_legacy_approval(approval_id: uuid.UUID) -> None:
+    async def run() -> None:
+        engine = create_async_engine(get_settings().database_url)
+        try:
+            async with engine.begin() as conn:
+                await conn.execute(
+                    text(
+                        "INSERT INTO curie.approvals "
+                        "(id, conversation_id, author, summary, reply_kind, "
+                        "reply_channel, dedupe_key, status) VALUES "
+                        "(:id, 'thread-legacy', 'U0REQUEST1', 'Approve action', "
+                        "'slack', 'C0EXAMPLE1', :dedupe, 'pending')"
+                    ),
+                    {"id": approval_id, "dedupe": f"legacy-{approval_id.hex}"},
+                )
+        finally:
+            await engine.dispose()
+
+    asyncio.run(run())
+
+
+def _write_traceparent(approval_id: uuid.UUID, value: str) -> None:
+    async def run() -> None:
+        engine = create_async_engine(get_settings().database_url)
+        try:
+            async with engine.begin() as conn:
+                await conn.execute(
+                    text(
+                        "UPDATE curie.approvals SET traceparent = :value "
+                        "WHERE id = :id"
+                    ),
+                    {"id": approval_id, "value": value},
+                )
+        finally:
+            await engine.dispose()
+
+    asyncio.run(run())
+
+
+def test_0039_adds_nullable_bounded_private_carrier_and_round_trips(
+    isolated_migration_db: None,
+) -> None:
+    cfg = Config()
+    cfg.set_main_option("script_location", str(ALEMBIC_DIR))
+    command.upgrade(cfg, "0038")
+    approval_id = uuid.uuid4()
+    _seed_legacy_approval(approval_id)
+
+    command.upgrade(cfg, "head")
+
+    assert _rows(
+        "SELECT is_nullable, character_maximum_length FROM information_schema.columns "
+        "WHERE table_schema = 'curie' AND table_name = 'approvals' "
+        "AND column_name = 'traceparent'"
+    ) == [{"is_nullable": "YES", "character_maximum_length": 55}]
+    assert _rows(
+        "SELECT traceparent FROM curie.approvals WHERE id = :id",
+        {"id": approval_id},
+    ) == [{"traceparent": None}]
+    valid = "00-2123456789abcdef0123456789abcdef-2123456789abcdef-01"
+    assert len(valid) == 55
+    _write_traceparent(approval_id, valid)
+    assert _rows(
+        "SELECT traceparent FROM curie.approvals WHERE id = :id",
+        {"id": approval_id},
+    ) == [{"traceparent": valid}]
+    with pytest.raises(DataError):
+        _write_traceparent(approval_id, "x" * 56)
+
+    command.downgrade(cfg, "0038")
+    assert _rows(
+        "SELECT column_name FROM information_schema.columns "
+        "WHERE table_schema = 'curie' AND table_name = 'approvals' "
+        "AND column_name = 'traceparent'"
+    ) == []
+
+    command.upgrade(cfg, "head")
+    assert _rows(
+        "SELECT is_nullable, character_maximum_length FROM information_schema.columns "
+        "WHERE table_schema = 'curie' AND table_name = 'approvals' "
+        "AND column_name = 'traceparent'"
+    ) == [{"is_nullable": "YES", "character_maximum_length": 55}]

--- a/apps/api/tests/test_otel_runtime.py
+++ b/apps/api/tests/test_otel_runtime.py
@@ -18,7 +18,11 @@ from curie_api.resumereconciler import ResumeReconciler
 from curie_api.sweeper import run_expiry_sweeper
 from curie_telemetry import operation_span, record_metric
 from curie_telemetry.metrics import declared_metric_manifest
+from curie_telemetry.tracing import configure_tracer_provider
 from fastapi.testclient import TestClient
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from redis.asyncio import Redis
 from sqlalchemy.engine import make_url
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
@@ -60,6 +64,19 @@ class _Probe:
 class _ProbeSpan:
     def add_event(self, _name: str, _attributes: Mapping[str, str] | None = None) -> None:
         pass
+
+
+@contextmanager
+def _captured_spans() -> Iterator[InMemorySpanExporter]:
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    configure_tracer_provider(provider)
+    try:
+        yield exporter
+    finally:
+        configure_tracer_provider(None)
+        provider.shutdown()
 
 
 def _install(monkeypatch: pytest.MonkeyPatch) -> _Probe:
@@ -105,6 +122,47 @@ def test_http_metric_manifest_covers_every_registered_api_route(client: TestClie
     registered = set(_registered_http_routes(client.app.routes))
 
     assert registered <= declared_operations
+
+
+def test_http_server_span_extracts_the_standard_w3c_parent(
+    client: TestClient,
+) -> None:
+    trace_id = int("2123456789abcdef0123456789abcdef", 16)
+    parent_span_id = int("2123456789abcdef", 16)
+    traceparent = "00-2123456789abcdef0123456789abcdef-2123456789abcdef-01"
+
+    with _captured_spans() as exporter:
+        response = client.get("/health", headers={"traceparent": traceparent})
+
+    assert response.status_code == 200
+    server, = [
+        span for span in exporter.get_finished_spans() if span.name == "http.server.request"
+    ]
+    assert server.context.trace_id == trace_id
+    assert server.parent is not None
+    assert server.parent.is_remote is True
+    assert server.parent.span_id == parent_span_id
+
+
+@pytest.mark.parametrize(
+    ("headers", "diagnostic"),
+    [({}, "trace.context.missing"), ({"traceparent": "malformed"}, "trace.context.malformed")],
+    ids=["missing", "malformed"],
+)
+def test_http_server_missing_or_malformed_parent_is_a_diagnostic_safe_root(
+    client: TestClient,
+    headers: dict[str, str],
+    diagnostic: str,
+) -> None:
+    with _captured_spans() as exporter:
+        response = client.get("/health", headers=headers)
+
+    assert response.status_code == 200
+    server, = [
+        span for span in exporter.get_finished_spans() if span.name == "http.server.request"
+    ]
+    assert server.parent is None
+    assert [event.name for event in server.events] == [diagnostic]
 
 
 def test_actions_route_records_validated_bounded_metrics(

--- a/apps/api/tests/test_publications.py
+++ b/apps/api/tests/test_publications.py
@@ -12,7 +12,7 @@ import base64
 import json
 import threading
 import uuid
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
 from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime, timedelta
 from typing import Any
@@ -40,6 +40,8 @@ WORKER_HEADERS = {"X-Curie-Worker-Token": WORKER_TOKEN}
 PATCH_LIMIT = 900_000
 BASE_SHA = "0123456789abcdef0123456789abcdef01234567"
 CLUSTER_MESSAGE_ADAPTER = "curie-cluster-message"
+_PUBLICATION_TRACEPARENT = "00-7123456789abcdef0123456789abcdef-7123456789abcdef-01"
+_REPLAY_TRACEPARENT = "00-8123456789abcdef0123456789abcdef-8123456789abcdef-01"
 
 
 @pytest.fixture
@@ -235,7 +237,12 @@ def test_builtin_reply_adapter_and_ref_persist_on_both_publication_rows(
     }
 
 
-def _create_publication(client: TestClient, payload: dict[str, Any]) -> tuple[int, dict[str, Any]]:
+def _create_publication(
+    client: TestClient,
+    payload: dict[str, Any],
+    *,
+    request_headers: Mapping[str, str] | None = None,
+) -> tuple[int, dict[str, Any]]:
     selected = client.post(
         f"/v1/internal/workspaces/{payload['deployment_id']}/selection",
         json={
@@ -246,7 +253,11 @@ def _create_publication(client: TestClient, payload: dict[str, Any]) -> tuple[in
         headers=WORKER_HEADERS,
     )
     assert selected.status_code == 200, selected.text
-    response = client.post("/v1/internal/publications", json=payload, headers=WORKER_HEADERS)
+    response = client.post(
+        "/v1/internal/publications",
+        json=payload,
+        headers={**WORKER_HEADERS, **dict(request_headers or {})},
+    )
     assert response.status_code in (200, 201), response.text
     return response.status_code, response.json()
 
@@ -270,6 +281,67 @@ def _counts() -> tuple[int, int]:
         "(SELECT count(*) FROM curie.publications) AS publications"
     )[0]
     return int(row["approvals"]), int(row["publications"])
+
+
+def test_publication_approval_privately_preserves_the_first_inbound_carrier(
+    publication_stack: tuple[TestClient, str],
+    auth_headers: dict[str, str],
+    clean_db: None,
+) -> None:
+    """Publication creation is the approval sibling, including replay privacy."""
+
+    client, _ = publication_stack
+    deployment = _create_deployment(client, auth_headers)
+    payload = _publication_payload(
+        deployment["id"], dedupe_key="publication-traceparent-example"
+    )
+    payload["traceparent"] = _REPLAY_TRACEPARENT
+
+    first_status, first = _create_publication(
+        client,
+        payload,
+        request_headers={"traceparent": _PUBLICATION_TRACEPARENT},
+    )
+    replay_status, replay = _create_publication(
+        client,
+        payload,
+        request_headers={"traceparent": _REPLAY_TRACEPARENT},
+    )
+
+    assert first_status == 201
+    assert replay_status == 200
+    assert replay["id"] == first["id"]
+    assert "traceparent" not in first
+    assert "traceparent" not in replay
+    stored = _rows(
+        "SELECT a.traceparent FROM curie.approvals a "
+        "JOIN curie.publications p ON p.approval_id = a.id "
+        "WHERE p.id = :id",
+        {"id": uuid.UUID(first["id"])},
+    )
+    assert stored == [{"traceparent": _PUBLICATION_TRACEPARENT}]
+
+
+def test_publication_with_malformed_carrier_persists_null(
+    publication_stack: tuple[TestClient, str],
+    auth_headers: dict[str, str],
+    clean_db: None,
+) -> None:
+    client, _ = publication_stack
+    deployment = _create_deployment(client, auth_headers)
+    _, publication = _create_publication(
+        client,
+        _publication_payload(deployment["id"]),
+        request_headers={"traceparent": "not-w3c"},
+    )
+
+    stored = _rows(
+        "SELECT a.traceparent FROM curie.approvals a "
+        "JOIN curie.publications p ON p.approval_id = a.id "
+        "WHERE p.id = :id",
+        {"id": uuid.UUID(publication["id"])},
+    )
+    assert stored == [{"traceparent": None}]
 
 
 def test_publication_persistence_refuses_casefolded_git_metadata_path(

--- a/apps/api/tests/test_resume_reconciler.py
+++ b/apps/api/tests/test_resume_reconciler.py
@@ -170,7 +170,7 @@ def _detached_approval(
         status=status,
         resolved_by=resolved_by,
     )
-    setattr(approval, "traceparent", traceparent)
+    approval.traceparent = traceparent
     return approval
 
 
@@ -947,10 +947,10 @@ def test_reconciler_isolates_per_record_failure(
         real_enqueue = queue.enqueue
         fail_event = f"approval-{fail_id}-resolved"
 
-        async def flaky(turn: QueuedTurn) -> str:
+        async def flaky(turn: QueuedTurn, **kwargs: object) -> str:
             if turn.event_id == fail_event:
                 raise RuntimeError("valkey blip for one record")
-            return await real_enqueue(turn)
+            return await real_enqueue(turn, **kwargs)
 
         queue.enqueue = flaky  # type: ignore[method-assign]
 

--- a/apps/api/tests/test_resume_reconciler.py
+++ b/apps/api/tests/test_resume_reconciler.py
@@ -23,6 +23,7 @@ import json
 import os
 import uuid
 from collections.abc import Awaitable, Callable, Iterator
+from contextlib import contextmanager
 from datetime import UTC, datetime, timedelta
 
 import pytest
@@ -33,6 +34,8 @@ from curie_api.config import get_settings
 from curie_api.models import Approval, ApprovalStatus
 from curie_api.resumequeue import ResumeQueue
 from curie_api.resumereconciler import ResumeReconciler
+from curie_telemetry import extract_trace_context
+from curie_telemetry.tracing import configure_tracer_provider
 from curie_test_support.valkey import (
     VALKEY_HOST as _VALKEY_HOST,
 )
@@ -45,12 +48,36 @@ from curie_test_support.valkey import (
 from curie_test_support.valkey import (
     connect_or_skip,
 )
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from sqlalchemy import select, text, update
 from sqlalchemy.ext.asyncio import (
     AsyncSession,
     async_sessionmaker,
     create_async_engine,
 )
+
+_TRACE_A_ID = int("9123456789abcdef0123456789abcdef", 16)
+_TRACE_A_SPAN_ID = int("9123456789abcdef", 16)
+_TRACE_A = "00-9123456789abcdef0123456789abcdef-9123456789abcdef-01"
+_TRACE_B_ID = int("a123456789abcdef0123456789abcdef", 16)
+_TRACE_B_SPAN_ID = int("a123456789abcdef", 16)
+_TRACE_B = "00-a123456789abcdef0123456789abcdef-a123456789abcdef-01"
+
+
+@contextmanager
+def _captured_spans() -> Iterator[InMemorySpanExporter]:
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    configure_tracer_provider(provider)
+    try:
+        yield exporter
+    finally:
+        configure_tracer_provider(None)
+        provider.shutdown()
 
 
 @pytest.fixture
@@ -115,6 +142,7 @@ def _detached_approval(
     reply_kind: str = "slack",
     reply_adapter: str | None = None,
     reply_placeholder: str | None = "p-1",
+    traceparent: str | None = None,
 ) -> Approval:
     """An unpersisted ``Approval`` in a chosen status, for the pure-unit selector
     test: the turn builders read the record's fields only, so no DB round-trip is
@@ -125,7 +153,7 @@ def _detached_approval(
     test exercises cannot drift from the one the DB tests insert.
     """
 
-    return Approval(
+    approval = Approval(
         id=uuid.uuid4(),
         conversation_id=f"th-{uuid.uuid4().hex[:8]}",
         author="U1",
@@ -142,6 +170,8 @@ def _detached_approval(
         status=status,
         resolved_by=resolved_by,
     )
+    setattr(approval, "traceparent", traceparent)
+    return approval
 
 
 async def _insert_approval(
@@ -156,6 +186,7 @@ async def _insert_approval(
     reply_channel: str | None = None,
     reply_adapter: str | None = None,
     reply_placeholder: str | None = "p-1",
+    traceparent: str | None = None,
 ) -> uuid.UUID:
     """Insert an approval row in a chosen lifecycle state (bypassing the resolve
     endpoint), so a test can construct the exact stranded/settled/expired shapes
@@ -167,6 +198,7 @@ async def _insert_approval(
         reply_kind=reply_kind,
         reply_adapter=reply_adapter,
         reply_placeholder=reply_placeholder,
+        traceparent=traceparent,
     )
     approval.reply_endpoint = reply_endpoint
     if reply_channel is not None:
@@ -225,6 +257,108 @@ def test_reconciler_reenqueues_stranded_resolved_record(
     assert turn.event_id == f"approval-{approval_id}-resolved"
     assert turn.reply_handle.placeholder == "reply placeholder"
     assert resumed_at is not None
+
+
+def test_reconciler_preserves_each_approvals_original_trace_and_isolation(
+    clean_db: None, valkey: redis.Redis, runs_stream: str
+) -> None:
+    """Recovery and duplicate passes cannot fork or cross two suspended turns."""
+
+    async def steps(
+        sessionmaker: async_sessionmaker[AsyncSession], queue: ResumeQueue
+    ) -> tuple[uuid.UUID, uuid.UUID]:
+        first_id = await _insert_approval(
+            sessionmaker,
+            status=ApprovalStatus.approved,
+            resolved_at=_naive(120),
+            resumed_at=None,
+            traceparent=_TRACE_A,
+        )
+        second_id = await _insert_approval(
+            sessionmaker,
+            status=ApprovalStatus.rejected,
+            resolved_at=_naive(120),
+            resumed_at=None,
+            traceparent=_TRACE_B,
+        )
+        reconciler = ResumeReconciler(
+            sessionmaker, queue, interval_seconds=30, grace_seconds=0, batch_limit=100
+        )
+        assert await reconciler.reconcile_once() == 2
+        assert await reconciler.reconcile_once() == 0
+        return first_id, second_id
+
+    with _captured_spans() as exporter:
+        first_id, second_id = _run_async(steps, runs_stream)
+
+    enqueue_spans = [
+        span for span in exporter.get_finished_spans() if span.name == "curie.queue.enqueue"
+    ]
+    assert len(enqueue_spans) == 2
+    assert {
+        (span.context.trace_id, span.parent.span_id if span.parent else None)
+        for span in enqueue_spans
+    } == {
+        (_TRACE_A_ID, _TRACE_A_SPAN_ID),
+        (_TRACE_B_ID, _TRACE_B_SPAN_ID),
+    }
+
+    entries = valkey.xrange(runs_stream)
+    assert len(entries) == 2
+    by_event = {json.loads(fields["payload"])["event_id"]: fields for _, fields in entries}
+    expected = {
+        f"approval-{first_id}-resolved": _TRACE_A_ID,
+        f"approval-{second_id}-resolved": _TRACE_B_ID,
+    }
+    assert set(by_event) == set(expected)
+    for event_id, expected_trace_id in expected.items():
+        carried = trace.get_current_span(
+            extract_trace_context(by_event[event_id])
+        ).get_span_context()
+        assert carried.trace_id == expected_trace_id
+
+
+@pytest.mark.parametrize("stored", [None, "not-w3c"])
+def test_reconciler_legacy_or_malformed_parent_starts_one_safe_root(
+    clean_db: None,
+    valkey: redis.Redis,
+    runs_stream: str,
+    stored: str | None,
+) -> None:
+    async def steps(
+        sessionmaker: async_sessionmaker[AsyncSession], queue: ResumeQueue
+    ) -> uuid.UUID:
+        approval_id = await _insert_approval(
+            sessionmaker,
+            status=ApprovalStatus.approved,
+            resolved_at=_naive(120),
+            resumed_at=None,
+            traceparent=stored,
+        )
+        reconciler = ResumeReconciler(
+            sessionmaker, queue, interval_seconds=30, grace_seconds=0, batch_limit=100
+        )
+        assert await reconciler.reconcile_once() == 1
+        return approval_id
+
+    with _captured_spans() as exporter:
+        approval_id = _run_async(steps, runs_stream)
+
+    enqueue = [
+        span for span in exporter.get_finished_spans() if span.name == "curie.queue.enqueue"
+    ]
+    assert len(enqueue) == 1
+    assert enqueue[0].parent is None
+    assert enqueue[0].context.trace_id not in {_TRACE_A_ID, _TRACE_B_ID}
+    entries = valkey.xrange(runs_stream)
+    assert len(entries) == 1
+    assert json.loads(entries[0][1]["payload"])["event_id"] == (
+        f"approval-{approval_id}-resolved"
+    )
+    carried = trace.get_current_span(
+        extract_trace_context(entries[0][1])
+    ).get_span_context()
+    assert carried.trace_id == enqueue[0].context.trace_id
 
 
 def test_reconciler_preserves_a_post_once_reply_handle(

--- a/apps/dispatcher/src/curie_dispatcher/approval_actions.py
+++ b/apps/dispatcher/src/curie_dispatcher/approval_actions.py
@@ -24,6 +24,7 @@ from dataclasses import dataclass
 from typing import Any
 
 import httpx
+from curie_telemetry import inject_trace_context
 from slack_sdk.web import WebClient
 
 from .approval_principal import mint_chat_principal
@@ -233,6 +234,7 @@ class ApprovalResolveClient:
                 approval_id=approval_id,
             ),
         }
+        inject_trace_context(headers)
         try:
             response = self._client.post(
                 f"{self._base}/approvals/{approval_id}/resolve",

--- a/apps/dispatcher/src/curie_dispatcher/enqueue_once.py
+++ b/apps/dispatcher/src/curie_dispatcher/enqueue_once.py
@@ -14,7 +14,8 @@ import os
 import sys
 
 from aci_protocol import QueuedTurn, parse_queued_turn
-from curie_telemetry import bootstrap_service_telemetry
+from curie_telemetry import bootstrap_service_telemetry, operation_span
+from opentelemetry.trace import SpanKind
 
 from . import __version__
 from .app import build_redis
@@ -32,7 +33,12 @@ def enqueue_payload(
 ) -> str:
     """Validate one frozen turn payload and enqueue it through the producer."""
     turn: QueuedTurn = parse_queued_turn(payload)
-    return enqueue(redis_client, config, turn)
+    with operation_span(
+        "curie.turn.ingress",
+        kind=SpanKind.CONSUMER,
+        attributes={"service.name": "curie-dispatcher", "source": "dispatcher"},
+    ):
+        return enqueue(redis_client, config, turn)
 
 
 def main() -> int:

--- a/apps/dispatcher/src/curie_dispatcher/handlers.py
+++ b/apps/dispatcher/src/curie_dispatcher/handlers.py
@@ -46,6 +46,8 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 from aci_protocol import QueuedTurn, ReplyHandle, TurnSource
+from curie_telemetry import operation_span
+from opentelemetry.trace import SpanKind
 from slack_bolt import App
 from slack_sdk.errors import SlackApiError
 from slack_sdk.web import WebClient
@@ -319,28 +321,33 @@ def process_event(
         drop(log, reason, event_id=slack_event_id, lane=lane)
         return None
 
-    if not claim_event(redis_client, config, slack_event_id):
-        drop(log, DropReason.DUPLICATE_DELIVERY, event_id=slack_event_id)
-        return None
+    with operation_span(
+        "curie.turn.ingress",
+        kind=SpanKind.CONSUMER,
+        attributes={"service.name": "curie-dispatcher", "source": "dispatcher"},
+    ):
+        if not claim_event(redis_client, config, slack_event_id):
+            drop(log, DropReason.DUPLICATE_DELIVERY, event_id=slack_event_id)
+            return None
 
-    return _mint_turn(
-        web_client=web_client,
-        redis_client=redis_client,
-        config=config,
-        log=log,
-        clock=clock,
-        slack_event_id=slack_event_id,
-        delivery_kind="slack event",
-        author=event.get("user", ""),
-        # NOT `event.get("text", "")`: a Block Kit or attachment-shaped post
-        # carries an empty or fallback-only top-level `text` and its real body in
-        # `blocks`/`attachments`, so that read emptied the turn while still
-        # burning a placeholder (#2006). `derive_text` returns a non-empty
-        # top-level text byte-identically, so existing enqueues are unchanged.
-        text=_strip_self_mention(derive_text(event), bot_user_id),
-        channel=channel,
-        thread_ts=thread_ts,
-    )
+        return _mint_turn(
+            web_client=web_client,
+            redis_client=redis_client,
+            config=config,
+            log=log,
+            clock=clock,
+            slack_event_id=slack_event_id,
+            delivery_kind="slack event",
+            author=event.get("user", ""),
+            # NOT `event.get("text", "")`: a Block Kit or attachment-shaped post
+            # carries an empty or fallback-only top-level `text` and its real body in
+            # `blocks`/`attachments`, so that read emptied the turn while still
+            # burning a placeholder (#2006). `derive_text` returns a non-empty
+            # top-level text byte-identically, so existing enqueues are unchanged.
+            text=_strip_self_mention(derive_text(event), bot_user_id),
+            channel=channel,
+            thread_ts=thread_ts,
+        )
 
 
 def action_command(action: dict[str, Any]) -> str:
@@ -420,28 +427,33 @@ def process_action(
         drop(log, DropReason.MALFORMED_ENVELOPE, event_id=interaction_id, missing=missing)
         return None
     slack_event_id = f"action-{interaction}"
-    if not claim_event(redis_client, config, slack_event_id):
-        drop(log, DropReason.DUPLICATE_DELIVERY, event_id=slack_event_id)
-        return None
+    with operation_span(
+        "curie.turn.ingress",
+        kind=SpanKind.CONSUMER,
+        attributes={"service.name": "curie-dispatcher", "source": "dispatcher"},
+    ):
+        if not claim_event(redis_client, config, slack_event_id):
+            drop(log, DropReason.DUPLICATE_DELIVERY, event_id=slack_event_id)
+            return None
 
-    user = (body.get("user") or {}).get("id", "")
+        user = (body.get("user") or {}).get("id", "")
 
-    # The shared tail: same claim -> placeholder -> XADD ordering as
-    # `process_event`, because it IS `process_event`'s, so the same release rule
-    # and the same `QueuedTurn` shape apply on this lane by construction.
-    return _mint_turn(
-        web_client=web_client,
-        redis_client=redis_client,
-        config=config,
-        log=log,
-        clock=clock,
-        slack_event_id=slack_event_id,
-        delivery_kind="block action",
-        author=user,
-        text=command,
-        channel=channel,
-        thread_ts=thread_ts,
-    )
+        # The shared tail: same claim -> placeholder -> XADD ordering as
+        # `process_event`, because it IS `process_event`'s, so the same release rule
+        # and the same `QueuedTurn` shape apply on this lane by construction.
+        return _mint_turn(
+            web_client=web_client,
+            redis_client=redis_client,
+            config=config,
+            log=log,
+            clock=clock,
+            slack_event_id=slack_event_id,
+            delivery_kind="block action",
+            author=user,
+            text=command,
+            channel=channel,
+            thread_ts=thread_ts,
+        )
 
 
 def register_handlers(

--- a/apps/dispatcher/tests/test_approval_actions.py
+++ b/apps/dispatcher/tests/test_approval_actions.py
@@ -13,6 +13,8 @@ import base64
 import hashlib
 import hmac
 import json
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
@@ -31,6 +33,9 @@ from curie_dispatcher.approval_actions import (
 )
 from curie_dispatcher.approval_principal import mint_chat_principal
 from curie_dispatcher.config import DispatcherConfig
+from opentelemetry import context as otel_context
+from opentelemetry import trace
+from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags, TraceState
 from slack_bolt import App
 from slack_bolt.adapter.socket_mode import SocketModeHandler
 from slack_sdk.socket_mode.request import SocketModeRequest
@@ -41,6 +46,25 @@ from .conftest import FakeSocketClient, _authorize
 APPROVAL_ID = "9a1e8a10-0000-0000-0000-000000000246"
 _PLATFORM_API_KEY = "platform-api-test-key"
 _CHAT_ATTESTER_SECRET = "dispatcher-attester-test-secret"
+_RESOLVE_TRACE_ID = int("4123456789abcdef0123456789abcdef", 16)
+_RESOLVE_SPAN_ID = int("4123456789abcdef", 16)
+_RESOLVE_TRACEPARENT = "00-4123456789abcdef0123456789abcdef-4123456789abcdef-01"
+
+
+@contextmanager
+def _resolve_parent() -> Iterator[None]:
+    parent = SpanContext(
+        trace_id=_RESOLVE_TRACE_ID,
+        span_id=_RESOLVE_SPAN_ID,
+        is_remote=True,
+        trace_flags=TraceFlags.SAMPLED,
+        trace_state=TraceState(),
+    )
+    token = otel_context.attach(trace.set_span_in_context(NonRecordingSpan(parent)))
+    try:
+        yield
+    finally:
+        otel_context.detach(token)
 
 
 def test_dispatcher_minter_matches_the_api_wire_vector() -> None:
@@ -579,6 +603,32 @@ def test_immediate_click_posts_only_decision_with_an_authenticated_chat_principa
         )
     )
     assert token not in rendered
+
+
+def test_resolve_request_carries_the_dispatcher_action_parent() -> None:
+    """The Slack action trace is forwarded as HTTP metadata, never body authority."""
+
+    captured = _CapturingHttpClient()
+    resolver = ApprovalResolveClient(
+        api_base_url="https://api.example.test",
+        api_key=_PLATFORM_API_KEY,
+        approval_chat_attester_secret=_CHAT_ATTESTER_SECRET,
+        client=captured,  # type: ignore[arg-type]
+    )
+
+    with _resolve_parent():
+        outcome = resolver.resolve(
+            APPROVAL_ID,
+            decision="approved",
+            attested_user="U_MANAGER",
+            attested_channel="C_MGRS",
+        )
+
+    assert outcome.status_code == 200
+    assert len(captured.requests) == 1
+    request = captured.requests[0]
+    assert request["headers"]["traceparent"] == _RESOLVE_TRACEPARENT
+    assert "traceparent" not in request["json"]
 
 
 def test_non_json_403_body_is_not_captured_as_detail() -> None:

--- a/apps/dispatcher/tests/test_enqueue_once.py
+++ b/apps/dispatcher/tests/test_enqueue_once.py
@@ -11,9 +11,13 @@ from aci_protocol import QueuedTurn, ReplyHandle
 from curie_dispatcher import enqueue_once
 from curie_dispatcher.config import DispatcherConfig
 from curie_dispatcher.queue import from_stream_fields
-from curie_telemetry import TRACEPARENT_STREAM_FIELD
+from curie_telemetry import TRACEPARENT_STREAM_FIELD, extract_trace_context
+from curie_telemetry.tracing import configure_tracer_provider
 from opentelemetry import context as otel_context
 from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags, TraceState
 
 _TRACE_ID = int("fedcba9876543210fedcba9876543210", 16)
@@ -52,6 +56,19 @@ def _turn() -> QueuedTurn:
     )
 
 
+@contextmanager
+def _captured_spans() -> Iterator[InMemorySpanExporter]:
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    configure_tracer_provider(provider)
+    try:
+        yield exporter
+    finally:
+        configure_tracer_provider(None)
+        provider.shutdown()
+
+
 def test_enqueue_payload_uses_dispatcher_carrier_beside_unchanged_payload(
     redis_client: redis.Redis,
     config: DispatcherConfig,
@@ -76,6 +93,36 @@ def test_enqueue_payload_uses_dispatcher_carrier_beside_unchanged_payload(
     assert len(span_id) == 16
     assert flags == "01"
     assert from_stream_fields(fields) == turn
+
+
+def test_enqueue_payload_owns_the_same_ingress_root_as_slack(
+    redis_client: redis.Redis,
+    config: DispatcherConfig,
+) -> None:
+    """The CLI bridge is a sibling ingress, not a parentless producer."""
+
+    turn = _turn()
+    with _captured_spans() as exporter:
+        stream_id = enqueue_once.enqueue_payload(
+            turn.model_dump_json(),
+            config=config,
+            redis_client=redis_client,
+        )
+
+    spans = exporter.get_finished_spans()
+    receipt, = [span for span in spans if span.name == "curie.turn.ingress"]
+    producer, = [span for span in spans if span.name == "curie.queue.enqueue"]
+    assert receipt.parent is None
+    assert producer.context.trace_id == receipt.context.trace_id
+    assert producer.parent is not None
+    assert producer.parent.span_id == receipt.context.span_id
+
+    (entry_id, fields), = redis_client.xrange(config.stream)
+    assert entry_id == stream_id
+    transported = trace.get_current_span(extract_trace_context(fields)).get_span_context()
+    assert transported.trace_id == receipt.context.trace_id
+    assert transported.span_id == producer.context.span_id
+    assert fields["payload"] == turn.model_dump_json()
 
 
 def test_main_without_otlp_endpoint_prints_only_the_stream_id(

--- a/apps/dispatcher/tests/test_queue.py
+++ b/apps/dispatcher/tests/test_queue.py
@@ -4,11 +4,15 @@ import json
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
+from typing import Any
 
+import pytest
 import redis
 from aci_protocol import QueuedTurn, ReplyHandle
+from curie_dispatcher import handlers as handlers_module
 from curie_dispatcher import queue as queue_module
 from curie_dispatcher.config import DispatcherConfig
+from curie_dispatcher.handlers import process_action, process_event
 from curie_dispatcher.queue import (
     claim_event,
     enqueue,
@@ -16,8 +20,12 @@ from curie_dispatcher.queue import (
     to_stream_fields,
 )
 from curie_telemetry import TRACEPARENT_STREAM_FIELD, extract_trace_context
+from curie_telemetry.tracing import configure_tracer_provider
 from opentelemetry import context as otel_context
 from opentelemetry import trace
+from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags, TraceState
 
 # The committed wire golden the Rust CLI consumer (cli/src/queue.rs) round-trips too.
@@ -59,6 +67,37 @@ def _event(event_id: str = "Ev1") -> QueuedTurn:
         reply_handle=ReplyHandle(kind="slack", channel="C1", placeholder="999.00"),
         received_at="2026-07-05T00:00:00+00:00",
     )
+
+
+class _WebClient:
+    def __init__(self, order: list[str] | None = None) -> None:
+        self.order = order
+        self.placeholder_contexts: list[SpanContext] = []
+
+    def chat_postMessage(self, **_kwargs: Any) -> dict[str, str]:
+        if self.order is not None:
+            self.order.append("placeholder")
+        self.placeholder_contexts.append(trace.get_current_span().get_span_context())
+        return {"ts": "1700000000.000200"}
+
+
+@contextmanager
+def _captured_spans() -> Iterator[InMemorySpanExporter]:
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    configure_tracer_provider(provider)
+    try:
+        yield exporter
+    finally:
+        configure_tracer_provider(None)
+        provider.shutdown()
+
+
+def _one_span(exporter: InMemorySpanExporter, name: str) -> ReadableSpan:
+    matches = [span for span in exporter.get_finished_spans() if span.name == name]
+    assert len(matches) == 1, [(span.name, span.context.trace_id) for span in matches]
+    return matches[0]
 
 
 def test_queued_turn_stream_fields_roundtrip() -> None:
@@ -207,3 +246,142 @@ def test_dedupe_decision_is_observed_without_exporting_the_event_id(
         ),
     ]
     assert "Ev-private-example" not in repr(calls)
+
+
+@pytest.mark.parametrize("ingress_kind", ["slack-event", "block-action"])
+def test_accepted_slack_ingress_owns_claim_placeholder_and_enqueue_trace(
+    ingress_kind: str,
+    redis_client: redis.Redis,
+    config: DispatcherConfig,
+) -> None:
+    """Receipt is the single root; both Slack mint sites inherit from it."""
+
+    web_client = _WebClient()
+    with _captured_spans() as exporter:
+        if ingress_kind == "slack-event":
+            result = process_event(
+                body={"event_id": "Ev-ingress-root"},
+                event={
+                    "channel": "C0EXAMPLE1",
+                    "ts": "1700000000.000100",
+                    "user": "U0EXAMPLE1",
+                    "text": "continue",
+                },
+                lane="mention",
+                web_client=web_client,  # type: ignore[arg-type]
+                redis_client=redis_client,
+                config=config,
+            )
+        else:
+            result = process_action(
+                body={
+                    "trigger_id": "trigger-example",
+                    "actions": [{"action_id": "continue", "value": "continue"}],
+                    "channel": {"id": "C0EXAMPLE1"},
+                    "message": {"ts": "1700000000.000100"},
+                    "user": {"id": "U0EXAMPLE1"},
+                },
+                web_client=web_client,  # type: ignore[arg-type]
+                redis_client=redis_client,
+                config=config,
+            )
+
+    assert result is not None
+    receipt = _one_span(exporter, "curie.turn.ingress")
+    claim = _one_span(exporter, "curie.queue.dedupe")
+    producer = _one_span(exporter, "curie.queue.enqueue")
+    assert receipt.parent is None
+    assert claim.context.trace_id == receipt.context.trace_id
+    assert claim.parent is not None and claim.parent.span_id == receipt.context.span_id
+    assert producer.context.trace_id == receipt.context.trace_id
+    assert producer.parent is not None
+    assert producer.parent.span_id == receipt.context.span_id
+    assert web_client.placeholder_contexts == [receipt.context]
+
+    (_entry_id, fields), = redis_client.xrange(config.stream)
+    transported = trace.get_current_span(extract_trace_context(fields)).get_span_context()
+    assert transported.trace_id == receipt.context.trace_id
+    assert transported.span_id == producer.context.span_id
+    assert TRACEPARENT_STREAM_FIELD not in json.loads(fields["payload"])
+
+
+def test_slack_ingress_keeps_claim_placeholder_enqueue_order(
+    redis_client: redis.Redis,
+    config: DispatcherConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#2006 ordering remains claim -> visible placeholder -> durable XADD."""
+
+    order: list[str] = []
+    real_claim = handlers_module.claim_event
+    real_enqueue = handlers_module.enqueue
+
+    def ordered_claim(*args: Any, **kwargs: Any) -> bool:
+        order.append("claim")
+        return real_claim(*args, **kwargs)
+
+    def ordered_enqueue(*args: Any, **kwargs: Any) -> str:
+        order.append("enqueue")
+        return real_enqueue(*args, **kwargs)
+
+    monkeypatch.setattr(handlers_module, "claim_event", ordered_claim)
+    monkeypatch.setattr(handlers_module, "enqueue", ordered_enqueue)
+
+    result = process_event(
+        body={"event_id": "Ev-ordered"},
+        event={
+            "channel": "C0EXAMPLE1",
+            "ts": "1700000000.000100",
+            "user": "U0EXAMPLE1",
+            "text": "continue",
+        },
+        lane="mention",
+        web_client=_WebClient(order),  # type: ignore[arg-type]
+        redis_client=redis_client,
+        config=config,
+    )
+
+    assert result is not None
+    assert order == ["claim", "placeholder", "enqueue"]
+
+
+def test_duplicate_and_refused_slack_inputs_emit_no_enqueue_span(
+    redis_client: redis.Redis,
+    config: DispatcherConfig,
+) -> None:
+    """A receipt may be observed, but refused work must not look dispatched."""
+
+    redis_client.set(
+        config.dedupe_key("Ev-duplicate"),
+        "1",
+        ex=config.dedupe_ttl_seconds,
+    )
+    web_client = _WebClient()
+    with _captured_spans() as exporter:
+        duplicate = process_event(
+            body={"event_id": "Ev-duplicate"},
+            event={
+                "channel": "C0EXAMPLE1",
+                "ts": "1700000000.000100",
+                "user": "U0EXAMPLE1",
+                "text": "continue",
+            },
+            lane="mention",
+            web_client=web_client,  # type: ignore[arg-type]
+            redis_client=redis_client,
+            config=config,
+        )
+        refused = process_event(
+            body={"event_id": "Ev-refused"},
+            event={"user": "U0EXAMPLE1", "text": "missing address"},
+            lane="mention",
+            web_client=web_client,  # type: ignore[arg-type]
+            redis_client=redis_client,
+            config=config,
+        )
+
+    assert duplicate is None
+    assert refused is None
+    assert web_client.placeholder_contexts == []
+    assert redis_client.xlen(config.stream) == 0
+    assert all(span.name != "curie.queue.enqueue" for span in exporter.get_finished_spans())

--- a/apps/worker/src/curie_worker/approvals.py
+++ b/apps/worker/src/curie_worker/approvals.py
@@ -23,6 +23,7 @@ from typing import Any, Protocol
 
 import httpx
 from aci_protocol import ApprovalRequest
+from curie_telemetry import inject_trace_context
 
 # Re-exported so this module stays the kernel-facing seam for the approval
 # payload: ``ApprovalRequest`` is now the shared wire model (#492), not a
@@ -169,11 +170,13 @@ class ApprovalClient:
         self._read_timeout_s = read_timeout_s
 
     async def create(self, request: ApprovalRequest) -> CreatedApproval:
+        headers = {**self._headers, "Content-Type": "application/json"}
+        inject_trace_context(headers)
         try:
             response = await self._client.post(
                 self._url,
                 content=request.model_dump_json(),
-                headers={**self._headers, "Content-Type": "application/json"},
+                headers=headers,
             )
         except httpx.HTTPError as exc:
             raise ApprovalBackendError(f"approval create failed: {exc}") from exc
@@ -194,10 +197,12 @@ class ApprovalClient:
         would turn a cosmetic gap into a dead-lettered resume.
         """
 
+        headers = dict(self._headers)
+        inject_trace_context(headers)
         try:
             response = await self._client.get(
                 f"{self._url}/{approval_id}",
-                headers=self._headers,
+                headers=headers,
                 timeout=self._read_timeout_s,
             )
         except httpx.HTTPError as exc:
@@ -231,11 +236,13 @@ class ApprovalClient:
             raise ApprovalBackendError(
                 "repository publication is cluster-only and requires internal worker auth"
             )
+        headers = {**self._worker_headers, "Content-Type": "application/json"}
+        inject_trace_context(headers)
         try:
             response = await self._client.post(
                 self._publication_url,
                 json=request.to_json(),
-                headers={**self._worker_headers, "Content-Type": "application/json"},
+                headers=headers,
             )
         except httpx.HTTPError as exc:
             raise ApprovalBackendError(f"publication create failed: {exc}") from exc

--- a/apps/worker/src/curie_worker/run.py
+++ b/apps/worker/src/curie_worker/run.py
@@ -266,16 +266,20 @@ def _sandbox_client(
                 "endpoint for local-model mode, or set CURIE_FAKE_MODEL=1 for an "
                 "offline/test run."
             )
-        if not env.get("OTEL_EXPORTER_OTLP_ENDPOINT"):
+        runner_otel_endpoint = env.get(
+            "CURIE_RUNNER_OTEL_EXPORTER_OTLP_ENDPOINT",
+            env.get("OTEL_EXPORTER_OTLP_ENDPOINT", ""),
+        )
+        if not runner_otel_endpoint:
             logger.warning(
-                "Docker substrate selected but OTEL_EXPORTER_OTLP_ENDPOINT is "
-                "unset; runner traces will not be exported"
+                "Docker substrate selected but the runner OTLP endpoint is unset; "
+                "runner traces will not be exported"
             )
         client = DockerSandboxClient(
             image=env.get("CURIE_RUNNER_IMAGE", "curie-runner"),
             bundle_store=bundle_store,
             network=env.get("CURIE_DOCKER_NETWORK") or None,
-            otel_endpoint=env.get("OTEL_EXPORTER_OTLP_ENDPOINT") or None,
+            otel_endpoint=runner_otel_endpoint or None,
             default_plugin_dir=config.bundle_plugin_dir,
             # Container isolation for every spawned runner (#631): read-only
             # rootfs, dropped caps, no-new-privileges, bounded resources. Mirrors

--- a/apps/worker/tests/binding/test_boot_env_single_declaration.py
+++ b/apps/worker/tests/binding/test_boot_env_single_declaration.py
@@ -220,6 +220,10 @@ _NON_BOOT_ALLOWLIST: frozenset[str] = frozenset(
         # declared boot keys, rendered from the declaration). It is a worker-side
         # knob for what URL those refs carry, never itself a sandbox boot key.
         "CURIE_RUNNER_API_URL",
+        # Worker-side Docker routing override. The substrate translates its
+        # value into the existing OTEL_EXPORTER_OTLP_ENDPOINT boot key; this
+        # configuration name itself is never injected into a sandbox.
+        "CURIE_RUNNER_OTEL_EXPORTER_OTLP_ENDPOINT",
         # The local-model demo base URL: an operator knob on the WORKER and on the
         # runner's sdk_auth mapping. It is not a BootEnv field; the boot key the
         # worker actually emits from it is ANTHROPIC_BASE_URL.

--- a/apps/worker/tests/kernel/test_approval_lifecycle.py
+++ b/apps/worker/tests/kernel/test_approval_lifecycle.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 import asyncio
 import json
 import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
 
 import aiohttp
 import httpx
@@ -26,14 +28,38 @@ from curie_worker.approvals import (
     ApprovalClient,
     ApprovalRequest,
     CreatedApproval,
+    PublicationCreateRequest,
     SettledApproval,
 )
 from curie_worker.reply_sink import TargetRoute
 from curie_worker.runner_client import RunnerError
 from curie_worker.sandbox.types import RouteState
+from opentelemetry import context as otel_context
+from opentelemetry import trace
+from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags, TraceState
 
 DONE = SessionStatus.DONE
 AWAITING = SessionStatus.AWAITING_APPROVAL
+
+_HTTP_TRACE_ID = int("3123456789abcdef0123456789abcdef", 16)
+_HTTP_SPAN_ID = int("3123456789abcdef", 16)
+_HTTP_TRACEPARENT = "00-3123456789abcdef0123456789abcdef-3123456789abcdef-01"
+
+
+@contextmanager
+def _approval_http_parent() -> Iterator[None]:
+    parent = SpanContext(
+        trace_id=_HTTP_TRACE_ID,
+        span_id=_HTTP_SPAN_ID,
+        is_remote=True,
+        trace_flags=TraceFlags.SAMPLED,
+        trace_state=TraceState(),
+    )
+    token = otel_context.attach(trace.set_span_in_context(NonRecordingSpan(parent)))
+    try:
+        yield
+    finally:
+        otel_context.detach(token)
 
 
 class RecordingApprovals:
@@ -148,6 +174,120 @@ async def _peek_card_ref(h, approval_id: str) -> dict | None:
 
     raw = await h.async_redis.get(h.config.approval_card_key(approval_id))
     return None if raw is None else json.loads(raw)
+
+
+def test_worker_approval_http_requests_carry_the_active_turn_parent() -> None:
+    """Create, read, and publication siblings must retain the worker turn."""
+
+    async def go() -> None:
+        requests: list[httpx.Request] = []
+
+        def handle(request: httpx.Request) -> httpx.Response:
+            requests.append(request)
+            if request.method == "GET":
+                return httpx.Response(
+                    200,
+                    json={
+                        "status": "approved",
+                        "resolved_by": "U0APPROVER1",
+                        "resolution_note": None,
+                    },
+                )
+            if request.url.path == "/v1/internal/publications":
+                return httpx.Response(
+                    201,
+                    json={
+                        "id": str(uuid.uuid4()),
+                        "approval_id": str(uuid.uuid4()),
+                        "status": "pending",
+                    },
+                )
+            return httpx.Response(
+                201,
+                json={"id": str(uuid.uuid4()), "status": "pending"},
+            )
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handle)) as http:
+            client = ApprovalClient(
+                api_base_url="https://api.example.test",
+                api_key="platform-test-key",
+                client=http,
+                read_timeout_s=1.0,
+                worker_token="worker-test-token",
+            )
+            approval = ApprovalRequest(
+                conversation_id="thread-example",
+                author="U0REQUEST1",
+                summary="Approve the bounded action",
+                reply_kind="slack",
+                reply_channel="C0EXAMPLE1",
+                reply_placeholder="1700000000.000001",
+                dedupe_key="event-example",
+            )
+            publication = PublicationCreateRequest(
+                deployment_id=uuid.uuid4(),
+                conversation_id="thread-example",
+                repo_full_name="acme-corp/acme-bot",
+                author="U0REQUEST1",
+                summary="Publish the bounded change",
+                reply_kind="slack",
+                reply_channel="C0EXAMPLE1",
+                reply_placeholder="1700000000.000001",
+                reply_endpoint=None,
+                reply_adapter=None,
+                dedupe_key="publication-example",
+                base_sha="0123456789abcdef0123456789abcdef01234567",
+                patch=b"diff --git a/README.md b/README.md\n",
+                changed_paths=("README.md",),
+                expires_in_seconds=600,
+                title="Publish the bounded change",
+                body="Approved platform publication.",
+            )
+
+            with _approval_http_parent():
+                await client.create(approval)
+                await client.get("00000000-0000-0000-0000-000000000001")
+                await client.create_publication(publication)
+
+        assert [request.method for request in requests] == ["POST", "GET", "POST"]
+        assert all(
+            request.headers.get("traceparent") == _HTTP_TRACEPARENT
+            for request in requests
+        )
+
+    asyncio.run(go())
+
+
+def test_worker_approval_http_does_not_fabricate_a_parent() -> None:
+    """A legacy/root call without an active trace stays a clean HTTP root."""
+
+    async def go() -> None:
+        seen: list[httpx.Request] = []
+
+        def handle(request: httpx.Request) -> httpx.Response:
+            seen.append(request)
+            return httpx.Response(
+                200,
+                json={
+                    "status": "approved",
+                    "resolved_by": "U0APPROVER1",
+                    "resolution_note": None,
+                },
+            )
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handle)) as http:
+            client = ApprovalClient(
+                api_base_url="https://api.example.test",
+                api_key="platform-test-key",
+                client=http,
+                read_timeout_s=1.0,
+            )
+            await client.get("00000000-0000-0000-0000-000000000001")
+
+        assert len(seen) == 1
+        assert "traceparent" not in seen[0].headers
+
+    asyncio.run(go())
 
 
 def test_awaiting_approval_creates_record_and_suspends(make_harness) -> None:
@@ -566,9 +706,12 @@ class GrantBinding:
     mirroring the worker's real derivation from durable approval state.
     """
 
-    def __init__(self, *, grant_event_id: str, grant_tool: str) -> None:
+    def __init__(
+        self, *, grant_event_id: str, grant_tool: str, decision: str = "approved"
+    ) -> None:
         self.grant_event_id = grant_event_id
         self.grant_tool = grant_tool
+        self.decision = decision
         self.agent_id = uuid.uuid4()
 
     async def resolve(self, kind: str, channel: str):  # noqa: ANN201
@@ -600,6 +743,9 @@ class GrantBinding:
     async def approval_grant_tool(self, event_id: str, agent_id):  # noqa: ANN001, ANN201
         return self.grant_tool if event_id == self.grant_event_id else None
 
+    async def approval_decision(self, event_id: str, agent_id):  # noqa: ANN001, ANN201
+        return self.decision if event_id == self.grant_event_id else None
+
 
 def test_resume_claim_injects_approval_grant_tool_env(make_harness) -> None:
     """#430: a resume claim for an approved permission-gate approval injects
@@ -627,6 +773,7 @@ def test_resume_claim_injects_approval_grant_tool_env(make_harness) -> None:
             resumed_env = h.fake_k8s.claim_envs[-1]
             assert resumed_env is not None
             assert resumed_env.get("CURIE_APPROVAL_GRANT_TOOL") == "mcp__github__create_issue"
+            assert resumed_env.get("CURIE_APPROVAL_DECISION") == "approved"
 
             # A fresh, unrelated mention has a different event id -> no grant env
             # (re-armed), so an adopted/warm follow-up cannot inherit an allowance.
@@ -636,6 +783,7 @@ def test_resume_claim_injects_approval_grant_tool_env(make_harness) -> None:
             fresh_env = h.fake_k8s.claim_envs[-1]
             assert fresh_env is not None
             assert "CURIE_APPROVAL_GRANT_TOOL" not in fresh_env
+            assert "CURIE_APPROVAL_DECISION" not in fresh_env
 
     asyncio.run(go())
 

--- a/apps/worker/tests/test_run.py
+++ b/apps/worker/tests/test_run.py
@@ -344,7 +344,7 @@ def test_docker_without_otlp_endpoint_warns(caplog) -> None:
     assert isinstance(client, DockerSandboxClient)
     warnings = [
         r for r in caplog.records
-        if r.name == "curie_worker.run" and "OTEL_EXPORTER_OTLP_ENDPOINT" in r.getMessage()
+        if r.name == "curie_worker.run" and "runner OTLP endpoint" in r.getMessage()
     ]
     assert warnings and all(r.levelno == logging.WARNING for r in warnings)
 
@@ -362,8 +362,44 @@ def test_docker_with_otlp_endpoint_does_not_warn(caplog) -> None:
     assert isinstance(client, DockerSandboxClient)
     assert not [
         r for r in caplog.records
-        if r.name == "curie_worker.run" and "OTEL_EXPORTER_OTLP_ENDPOINT" in r.getMessage()
+        if r.name == "curie_worker.run" and "runner OTLP endpoint" in r.getMessage()
     ]
+
+
+@pytest.mark.parametrize(
+    ("runner_endpoint", "expected_endpoint"),
+    [
+        ("http://otel-collector:4318", "http://otel-collector:4318"),
+        ("", None),
+        (None, "http://collector.example.com:4318"),
+    ],
+)
+def test_docker_runner_uses_its_network_specific_otlp_endpoint(
+    monkeypatch, runner_endpoint: str | None, expected_endpoint: str | None
+) -> None:
+    calls: list[list[str]] = []
+    monkeypatch.setattr(DockerSandboxClient, "ensure_image", lambda self: None)
+    monkeypatch.setattr(
+        DockerSandboxClient, "_docker", lambda self, args: calls.append(args) or ""
+    )
+    env = {
+        "CURIE_SANDBOX_SUBSTRATE": "docker",
+        "OTEL_EXPORTER_OTLP_ENDPOINT": "http://collector.example.com:4318",
+    }
+    if runner_endpoint is not None:
+        env["CURIE_RUNNER_OTEL_EXPORTER_OTLP_ENDPOINT"] = runner_endpoint
+    client = _sandbox_client(
+        WorkerConfig(fake_model=True),
+        env,
+        _SUB,
+    )
+    assert isinstance(client, DockerSandboxClient)
+    client.create_claim("acme-sandbox", pool="pool", env={"CURIE_FAKE_MODEL": "1"})
+    assert len(calls) == 1
+    endpoint_args = [arg for arg in calls[0] if arg.startswith("OTEL_EXPORTER_OTLP_ENDPOINT=")]
+    assert endpoint_args == (
+        [f"OTEL_EXPORTER_OTLP_ENDPOINT={expected_endpoint}"] if expected_endpoint else []
+    )
 
 
 def test_sandbox_client_docker_prepulls_image(monkeypatch) -> None:

--- a/apps/worker/tests/test_run.py
+++ b/apps/worker/tests/test_run.py
@@ -396,6 +396,9 @@ def test_docker_runner_uses_its_network_specific_otlp_endpoint(
     assert isinstance(client, DockerSandboxClient)
     client.create_claim("acme-sandbox", pool="pool", env={"CURIE_FAKE_MODEL": "1"})
     assert len(calls) == 1
+    assert not any(
+        arg.startswith("CURIE_RUNNER_OTEL_EXPORTER_OTLP_ENDPOINT=") for arg in calls[0]
+    )
     endpoint_args = [arg for arg in calls[0] if arg.startswith("OTEL_EXPORTER_OTLP_ENDPOINT=")]
     assert endpoint_args == (
         [f"OTEL_EXPORTER_OTLP_ENDPOINT={expected_endpoint}"] if expected_endpoint else []

--- a/charts/curie/CLAUDE.md
+++ b/charts/curie/CLAUDE.md
@@ -30,6 +30,18 @@ component and rail detail in `charts/curie/README.md`.
     when it lands, this exception is removed rather than extended. Do not
     generalize it into a rule about stateful services -- one named file, one
     named reason.
+  - **Second named exception: `templates/langfuse.yaml`**, which hardcodes
+    `replicas: 1` and `strategy: type: Recreate` on both the web and worker
+    Deployments. The reason is correctness, not sizing: both images run Prisma
+    and ClickHouse migrations at container boot with no cross-process lock, so
+    a RollingUpdate of a single replica (default `maxSurge: 25%`, which rounds
+    up to one extra pod) can apply two migration sets to the same database and
+    leave Prisma in a failed state (#2216). Any count other than 1, or any
+    strategy other than Recreate, is wrong at every cluster size. There is
+    deliberately **no `langfuse.web.replicas` / `langfuse.worker.replicas` /
+    strategy values key**. Pinned by `ci/langfuse-recreate-assertions.sh`.
+    Horizontal scale for Langfuse needs an Accepted out-of-band migrator; when
+    that lands, this exception is removed rather than extended.
 - **Mail-adapter egress is a separate fail-closed rail.** Enabling
   `mailAdapter.deploy` requires at least one
   `mailAdapter.agentmail.httpsCidrs` entry. Its single egress-only policy allows

--- a/charts/curie/CLAUDE.md
+++ b/charts/curie/CLAUDE.md
@@ -75,7 +75,10 @@ component and rail detail in `charts/curie/README.md`.
 - **Fail-closed egress, always.** `security.networkPolicy.allowedEgress` is
   empty by default; an unset allowlist must never mean allow-all. If you add
   a new egress destination the runner needs, it goes into this allowlist
-  explicitly -- never widen the default-deny baseline itself.
+  explicitly -- never widen the default-deny baseline itself. The exception
+  is a BYO object store (`rustfs.deploy: false`): that allow is
+  `rustfs.egress` (and `rustfs.stsEgress` on the key-free path), required at
+  render, not mixed into the model-API allowlist.
 - **NetworkPolicy allows are additive, never restrictive-intersecting
   (#765, ADR-0067).** A second NetworkPolicy selecting the same pods can only
   widen what Rail 1 permits, never narrow it -- there is no such thing as one

--- a/charts/curie/Chart.yaml
+++ b/charts/curie/Chart.yaml
@@ -4,9 +4,10 @@ description: >-
   Curie (Relay) umbrella chart. Installs the whole self-hosted stack on a
   single node: Langfuse v3 (web + worker) plus its ClickHouse, Valkey, Postgres,
   and RustFS backing stores, and the OTel Collector that adapts app traces into
-  Langfuse. Every backing store is condition-gated with a bring-your-own block,
-  and two install-time preflights ship baked in: a CPU-AVX / ClickHouse-pin
-  check and a NetworkPolicy-enforcement probe.
+  Langfuse. Every backing store is condition-gated with a bring-your-own block.
+  A CPU-AVX / ClickHouse-pin check runs as a blocking pre-install, pre-upgrade
+  hook; a NetworkPolicy-enforcement probe ships as a helm test that must be run
+  explicitly.
 type: application
 version: 0.8.4
 appVersion: "0.8.4"

--- a/charts/curie/Chart.yaml
+++ b/charts/curie/Chart.yaml
@@ -9,8 +9,8 @@ description: >-
   hook; a NetworkPolicy-enforcement probe ships as a helm test that must be run
   explicitly.
 type: application
-version: 0.8.4
-appVersion: "0.8.4"
+version: 0.8.5
+appVersion: "0.8.5"
 kubeVersion: ">=1.25.0-0"
 maintainers:
   - name: Curie

--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -588,6 +588,18 @@ rustfs:
   region: us-east-1
   auth:
     accessKey: ""            # selects the key-free path
+  # Rail 1 is fail-closed. The in-chart runner-allow-rustfs policy selects the
+  # in-cluster rustfs pod and does not render here. NetworkPolicy cannot
+  # target rustfs.host (a DNS name), so these CIDRs are required at render.
+  # On EKS the tight form is VPC interface endpoints for s3 and sts with
+  # private DNS enabled, which turns each requirement into a /32 rather than
+  # an AWS public service CIDR range.
+  egress:
+    - cidr: 192.0.2.10/32    # S3 VPC interface endpoint
+      ports: [{ protocol: TCP, port: 443 }]
+  stsEgress:
+    - cidr: 192.0.2.11/32    # STS VPC interface endpoint
+      ports: [{ protocol: TCP, port: 443 }]
 api:
   serviceAccount:
     annotations:
@@ -608,6 +620,28 @@ The bundle fetch uses path style addressing, so it appends
 region, change the region in `rustfs.host` and set `rustfs.region` to control
 the SigV4 signing region used by the bundle fetch init container. This setting
 does not configure the API or worker S3 clients.
+
+**Runner egress is a separate required list.** Rail 1 default-denies the
+sandbox, and the in-chart `runner-allow-rustfs` policy is a pod selector on
+this release's rustfs component, so it does not render when
+`rustfs.deploy` is false. Putting S3 in `security.networkPolicy.allowedEgress`
+alongside the model API used to be the only workaround, and a model-only
+allowlist then installed green while every sandbox hung in `Init` on the first
+turn. The chart now refuses that shape at render: `rustfs.egress` must cover
+the object-store endpoint, and on this key-free path `rustfs.stsEgress` must
+cover STS (`AssumeRoleWithWebIdentity`). Both are `{cidr, ports}` entries like
+`allowedEgress`. Do not put a DNS name here; NetworkPolicy has no hostname
+peer. A default route or a CIDR that reaches `169.254.169.254` is refused:
+these lists are store endpoints, not a second model allowlist.
+
+On EKS, create VPC **interface** endpoints for `s3` and `sts` in the cluster
+VPC with private DNS enabled, then put each endpoint's ENI address in as a
+`/32` on TCP 443. That keeps the fail-closed posture meaningful instead of
+opening an AWS public service CIDR range. Gateway endpoints for S3 do not
+give the sandbox a unicast address to allow. Static-key BYO still needs
+`rustfs.egress` (the fetch talks to S3) and does not need `rustfs.stsEgress`.
+Opting out of Rail 1 (`security.networkPolicy.enabled: false`) skips both
+requirements because there is then no runner NetworkPolicy to satisfy.
 
 Scope the runner's role to the bundle bucket, **read-only**. NetworkPolicy
 selects pods rather than containers, so any identity the bundle-fetch init
@@ -761,7 +795,10 @@ sandbox and renders whenever an in-chart store is deployed.
 **Fail-closed egress.** `security.networkPolicy.allowedEgress` is EMPTY by
 default: a fresh install denies all egress except DNS until the operator declares
 where the model API and MCP endpoints live (`{cidr, ports}` entries). An unset
-allowlist never means allow-all.
+allowlist never means allow-all. A BYO object store is not on that list: set
+`rustfs.egress` (and `rustfs.stsEgress` on the key-free path) so the sandbox
+bundle-fetch can reach S3 and STS without opening the model allowlist. See
+**Key-free object store auth** above.
 
 **The controller does not get a second vote on egress (#765, ADR-0067).**
 NetworkPolicy allows are additive across objects selecting the same pods -- Rail

--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -339,7 +339,7 @@ pipeline and environment are applied on `helm upgrade`.
 
 | Component | Image | Notes |
 |---|---|---|
-| Langfuse web + worker | `langfuse/langfuse:3.225.5`, `langfuse/langfuse-worker:3.225.5` | Observability + eval backbone. Headless-bootstrapped dev org/project. Web and worker stay on one reviewed migration set; do not replace the version with floating `:3`. |
+| Langfuse web + worker | `langfuse/langfuse:3.225.5`, `langfuse/langfuse-worker:3.225.5` | Observability + eval backbone. Headless-bootstrapped dev org/project. Web and worker stay on one reviewed migration set; do not replace the version with floating `:3`. Both Deployments use Recreate, so a Langfuse image change is a brief outage while boot migrations run. |
 | Postgres | `postgres:16-alpine` | Langfuse transactional store + app state. StatefulSet. |
 | Valkey | `valkey/valkey:8-alpine` | Langfuse cache/queue + dispatcher Streams queue. |
 | ClickHouse | `clickhouse/clickhouse-server:24.8` | Langfuse OLAP store. Tag pinned SSE4.2-safe (see preflight). |

--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -368,26 +368,32 @@ workflow (`.github/workflows/release.yaml`) on every push to `main`, as
 `ghcr.io/curie-eng/curie-<service>` tagged with the commit SHA and `latest`.
 All six first-party services build in the matrix: `curie-api`,
 `curie-dispatcher`, `curie-mail-adapter`, `curie-worker`, `curie-ui`, and
-`curie-runner`. The chart defaults every first-party image at its
-`ghcr.io/curie-eng/curie-*` `:latest`, so the bare install (above) pulls from
+`curie-runner`. The chart defaults every first-party image to the chart
+`appVersion` (empty `tag` in values, resolved by the `curie.image` helper), so
+the bare install (above) pulls `ghcr.io/curie-eng/curie-*:<appVersion>` from
 GHCR with no image overrides -- except `curie-mail-adapter`, whose Deployment is
 off by default (`mailAdapter.deploy`), so its image is published and defaulted
-but not pulled until an operator enables the email channel.
+but not pulled until an operator enables the email channel. The workflow still
+publishes a mutable `latest` tag alongside the SHA and version tags; that is a
+fact about the release artifacts, not about what this chart resolves to.
 
 - **Pull policy for the five Deployment-managed services** (api, dispatcher,
-  mail-adapter, worker, ui): `imagePullPolicy: Always` -- they pull once per
-  rollout, so `Always` just keeps a fresh install from serving a stale `latest`
-  a node cached earlier.
+  mail-adapter, worker, ui): `imagePullPolicy: Always`. The default tag is the
+  chart `appVersion`, so this is a cheap no-op on a node that already has that
+  immutable ref, and it still self-heals a node that cached a same-named ref
+  under a different digest.
 - **The runner image is the exception:** it uses `imagePullPolicy: IfNotPresent`
   because a sandbox pod is cold-created per Slack thread, and an `Always`
   (re-)pull inside that boot window blew past the worker's claim timeout and
-  killed runs. Its freshness comes instead from the `runner-prewarm` DaemonSet
+  killed runs. Its presence on the node comes from the `runner-prewarm` DaemonSet
   (`agentSandbox.runner.prewarm`, default on with the sandbox substrate),
-  which pulls the runner image `Always` and keeps it pinned on every node; a
-  Release-revision annotation rolls those pods on every `helm upgrade` so the
-  pin refreshes a churned `latest`.
-- **Pin an immutable tag** for reproducible deploys, where the pull policies
-  are a cheap no-op.
+  which pulls the runner image `Always` and keeps that same `appVersion` ref
+  pinned on every node; a Release-revision annotation rolls those pods on every
+  `helm upgrade` so an upgraded chart's new `appVersion` is pulled before the
+  next claim.
+- **Override `tag` (or set `digest`)** to pin an explicit version. Empty `tag`
+  is the default and resolves to `.Chart.AppVersion`; `digest` wins over `tag`
+  when set.
 
 A GHCR package inherits its repo's visibility, so on a **private** repo the image
 is not anonymously pullable and the node needs credentials. Two supported paths:
@@ -586,6 +592,7 @@ rustfs:
   host: s3.us-east-1.amazonaws.com
   port: 443
   region: us-east-1
+  bucket: langfuse           # Langfuse event and media uploads
   auth:
     accessKey: ""            # selects the key-free path
 api:
@@ -593,15 +600,28 @@ api:
     annotations:
       eks.amazonaws.com/role-arn: arn:aws:iam::000000000000:role/curie-api
 worker:
+  workspace:
+    bucket: curie-workspaces # repository workspace archives
   serviceAccount:
     annotations:
       eks.amazonaws.com/role-arn: arn:aws:iam::000000000000:role/curie-worker
 agentSandbox:
   runner:
+    bundleFetch:
+      bucket: curie-bundles  # plugin bundles (API writes, runner reads)
     serviceAccount:
       annotations:
         eks.amazonaws.com/role-arn: arn:aws:iam::000000000000:role/curie-runner
 ```
+
+The chart talks to **three buckets** on that same endpoint, not one. Create them
+before install; the in-chart RustFS Job creates them only while `rustfs.deploy`
+is true. The defaults are three distinct names, so a single-bucket BYO install
+fails on two of the three paths.
+
+- `rustfs.bucket` (default `langfuse`): Langfuse event and media uploads.
+- `worker.workspace.bucket` (default `curie-workspaces`): repository workspace archives.
+- `agentSandbox.runner.bundleFetch.bucket` (default `curie-bundles`): plugin bundles.
 
 The bundle fetch uses path style addressing, so it appends
 `agentSandbox.runner.bundleFetch.bucket` to this endpoint. For another AWS
@@ -609,10 +629,20 @@ region, change the region in `rustfs.host` and set `rustfs.region` to control
 the SigV4 signing region used by the bundle fetch init container. This setting
 does not configure the API or worker S3 clients.
 
-Scope the runner's role to the bundle bucket, **read-only**. NetworkPolicy
-selects pods rather than containers, so any identity the bundle-fetch init
-container can assume is equally reachable by the runner beside it, and the
-runner is prompt-injectable by design.
+Scope each role to the bucket it actually uses:
+
+- **API role:** read/write on the bundle bucket. The API writes each uploaded bundle.
+- **Worker role:** read/write on the workspace bucket, and read on the bundle
+  bucket (the eval lane fetches the same objects the API wrote).
+- **Runner role:** read-only on the bundle bucket. NetworkPolicy selects pods
+  rather than containers, so any identity the bundle-fetch init container can
+  assume is equally reachable by the runner beside it, and the runner is
+  prompt-injectable by design.
+- **Langfuse:** `rustfs.bucket` for the `events/` and `media/` prefixes. Langfuse
+  still consumes `rustfs.auth` static keys for that bucket; the key-free path
+  only omits credentials from the API, the worker, and the sandbox bundle-fetch
+  init container. Scope those keys (or a Langfuse-specific IAM user) to
+  `rustfs.bucket`.
 
 Two constraints are worth stating plainly.
 
@@ -641,8 +671,11 @@ around.
 
 ## The two preflights
 
-Both run as Helm hooks (blocking a broken install) and are re-runnable via
-`helm test <release> -n <ns>`.
+(a) is a blocking `pre-install,pre-upgrade` hook. (b) is a `helm test` that
+must be run explicitly; it never runs during `helm install`. A green
+`helm install` does not prove NetworkPolicy is enforced, so run
+`helm test <release> -n <ns>` before treating the security rails as live.
+Both are re-runnable via that same `helm test` command.
 
 **(a) CPU-AVX / ClickHouse-pin check** (`preflights.avxCheck`). A pre-install /
 pre-upgrade hook Job.
@@ -948,9 +981,9 @@ to install only the control plane + backing stores without the runner substrate.
   with an externally-managed controller) given the residual cluster-wide
   pod/service/PVC reach.
 - **Runner image**: the pool runs `curie-runner`, defaulting to
-  `ghcr.io/curie-eng/curie-runner:latest` with `imagePullPolicy: IfNotPresent`
+  `ghcr.io/curie-eng/curie-runner:<appVersion>` with `imagePullPolicy: IfNotPresent`
   (per-thread cold boots must not contain a pull; the `runner-prewarm` DaemonSet
-  keeps the image fresh on every node -- see "Publishing and pulling images").
+  keeps the image on every node -- see "Publishing and pulling images").
   For offline
   dev/e2e, `-f values-dev.yaml` overrides it to a locally-built, cluster-imported
   tag with `imagePullPolicy: Never` (`docker build -f runner/Dockerfile -t

--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -6,9 +6,10 @@ ClickHouse + RustFS + OTel Collector, dev profile, BYO (bring-your-own)
 toggles, the two preflights) plus the security rails as chart defaults.
 
 The chart is a direct port of the proven `compose.dev.yaml` dev stack: same
-images, same tags, same `:24.8` ClickHouse pin, same headless-bootstrapped
-Langfuse dev project. So the compose stack and this chart verify
-the identical stack. Rather than vendoring the upstream Langfuse chart and its
+images and the same headless-bootstrapped Langfuse dev project. The chart
+ClickHouse default is `:25.12` (AVX required, coupled to `langfuse.image.tag`)
+while compose stays on `:24.8` so an SSE4.2-only developer host can still boot
+the local stack. Rather than vendoring the upstream Langfuse chart and its
 Bitnami subcharts, each component is a first-class template here -- this keeps
 the single-node footprint controllable and avoids the Bitnami-catalog
 (`bitnamilegacy/*`) instability. It still follows the Langfuse chart *idiom*:
@@ -342,7 +343,7 @@ pipeline and environment are applied on `helm upgrade`.
 | Langfuse web + worker | `langfuse/langfuse:3.225.5`, `langfuse/langfuse-worker:3.225.5` | Observability + eval backbone. Headless-bootstrapped dev org/project. Web and worker stay on one reviewed migration set; do not replace the version with floating `:3`. |
 | Postgres | `postgres:16-alpine` | Langfuse transactional store + app state. StatefulSet. |
 | Valkey | `valkey/valkey:8-alpine` | Langfuse cache/queue + dispatcher Streams queue. |
-| ClickHouse | `clickhouse/clickhouse-server:24.8` | Langfuse OLAP store. Tag pinned SSE4.2-safe (see preflight). |
+| ClickHouse | `clickhouse/clickhouse-server:25.12` | Langfuse OLAP store. Coupled to `langfuse.image.tag` 3.225.5; chart default requires AVX (see preflight). |
 | RustFS | `rustfs/rustfs:1.0.0-beta.12` plus `amazon/aws-cli:2.32.6` init | Langfuse object storage; BYO real S3 in prod. |
 | OTel Collector | `otel/opentelemetry-collector-contrib:0.119.0` | Bounded OTLP gateway (gRPC+HTTP), durable queue by default; traces -> Langfuse over HTTP, logs/metrics -> configured exporters. |
 | Mail adapter | `ghcr.io/curie-eng/curie-mail-adapter` | Off by default. One `Recreate` replica with durable SQLite on single-writer storage; no platform key/database credential or ServiceAccount token. |
@@ -649,12 +650,15 @@ pre-upgrade hook Job.
 
 - ClickHouse >= 25.x is compiled for AVX and SIGILLs with exit 132 on
   SSE4.2-only CPUs -- a crash-looping pod is a confusing way to learn that.
+- Chart defaults require AVX: `clickhouse.image.tag` is `25.12` because
+  `langfuse.image.tag` 3.225.5's migration set from 39 onward cannot apply on
+  24.8, and 25.12 is not in `clickhouse.sse42SafeTags`.
 - The Job reads the node's `/proc/cpuinfo`; if the node lacks AVX it FAILS
-  the install unless the configured ClickHouse tag is in
-  `clickhouse.sse42SafeTags` (`24.8`, `24.3`, `23.8`). Skipped when
-  `clickhouse.deploy: false`.
-- Test knob `preflights.avxCheck.forceNoAvx: true` exercises the SSE4.2
-  branch on an AVX-capable node.
+  the install unless the operator pins a tag in `clickhouse.sse42SafeTags`
+  (`24.8`, `24.3`, `23.8`). That override cannot apply the current Langfuse
+  migration set. Skipped when `clickhouse.deploy: false`.
+- Test knob `preflights.avxCheck.forceNoAvx: true` exercises the AVX-required
+  failure branch on an AVX-capable node when the default tag is set.
 - Read the verdict: `kubectl logs -n <ns> job/<release>-preflight-avx`.
 
 **(b) NetworkPolicy-enforcement probe** (`preflights.networkPolicyProbe`). A

--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -577,10 +577,10 @@ Pointing the bundle store at a real cloud object store (`rustfs.deploy: false`)
 normally means a scoped IAM user and long-lived keys in a Secret. That works and
 is genuinely least-privilege, but it is not the only option: clearing
 `rustfs.auth.accessKey` selects a key-free path (#1325) in which the chart omits
-every S3 credential from the API, the worker, and the sandbox bundle-fetch init
-container, so the AWS SDK falls through its provider chain to the **web-identity
-provider** (`AWS_ROLE_ARN` + `AWS_WEB_IDENTITY_TOKEN_FILE`) fed by a projected
-ServiceAccount token.
+every S3 credential from the API, the worker, the sandbox bundle-fetch init
+container, and Langfuse, so the AWS SDK falls through its provider chain to
+the **web-identity provider** (`AWS_ROLE_ARN` + `AWS_WEB_IDENTITY_TOKEN_FILE`)
+fed by a projected ServiceAccount token.
 
 Bind the role through the ServiceAccount annotations. On EKS with IRSA the
 pod-identity webhook reads the annotation and injects the projected token and
@@ -624,6 +624,10 @@ agentSandbox:
     serviceAccount:
       annotations:
         eks.amazonaws.com/role-arn: arn:aws:iam::000000000000:role/curie-runner
+langfuse:
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::000000000000:role/curie-langfuse
 ```
 
 The chart talks to **three buckets** on that same endpoint, not one. Create them

--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -606,8 +606,9 @@ agentSandbox:
 The bundle fetch uses path style addressing, so it appends
 `agentSandbox.runner.bundleFetch.bucket` to this endpoint. For another AWS
 region, change the region in `rustfs.host` and set `rustfs.region` to control
-the SigV4 signing region used by the bundle fetch init container. This setting
-does not configure the API or worker S3 clients.
+the SigV4 signing region used by the bundle fetch init container and by
+Langfuse's event/media uploads. This setting does not configure the API or
+worker S3 clients.
 
 Scope the runner's role to the bundle bucket, **read-only**. NetworkPolicy
 selects pods rather than containers, so any identity the bundle-fetch init

--- a/charts/curie/ci/clickhouse-langfuse-pin-assertions.sh
+++ b/charts/curie/ci/clickhouse-langfuse-pin-assertions.sh
@@ -1,0 +1,393 @@
+#!/usr/bin/env bash
+#
+# Issue #2210: keep the chart ClickHouse default and the Langfuse pin as one
+# supported pair, and fail CI when either side drifts.
+#
+# Langfuse 3.225.x ClickHouse migration 39 cannot parse on 24.8 or 25.8. The
+# chart default must be 25.12 (the version Langfuse's own compose pins at
+# v3.225.7) so the Langfuse pin can be advanced, and AVX is a chart-default
+# requirement because 25.12 is not SSE4.2-safe. Comments on both values.yaml
+# keys must name the other pin so they are not moved independently.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART="$(cd "$SCRIPT_DIR/.." && pwd)"
+VALUES="$CHART/values.yaml"
+EXPECTED_LANGFUSE="3.225.5"
+EXPECTED_CLICKHOUSE="25.12"
+EXPECTED_CLICKHOUSE_IMAGE="clickhouse/clickhouse-server:${EXPECTED_CLICKHOUSE}"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+RENDER="$TMP/chart.yaml"
+CHECKER="$TMP/check.py"
+
+helm template curie "$CHART" >"$RENDER"
+
+cat >"$CHECKER" <<'PY'
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+
+import yaml
+
+(
+    chart_path,
+    values_path,
+    expected_langfuse,
+    expected_clickhouse,
+    expected_clickhouse_image,
+) = sys.argv[1:]
+
+documents = [
+    document
+    for document in yaml.safe_load_all(pathlib.Path(chart_path).read_text())
+    if document
+]
+
+problems = []
+clickhouse_images = []
+langfuse_images = {}
+preflight_env = {}
+preflight_script = None
+
+for document in documents:
+    kind = document.get("kind")
+    name = document.get("metadata", {}).get("name", "")
+    spec = document.get("spec", {})
+    template_spec = spec.get("template", {}).get("spec", {})
+    containers = template_spec.get("containers") or []
+
+    if kind == "StatefulSet":
+        for container in containers:
+            if container.get("name") == "clickhouse":
+                clickhouse_images.append(container.get("image"))
+
+    if kind == "Deployment":
+        for container in containers:
+            cname = container.get("name")
+            if cname in ("langfuse-web", "langfuse-worker"):
+                langfuse_images[cname] = container.get("image")
+
+    if kind == "Job" and str(name).endswith("-preflight-avx"):
+        for container in containers:
+            if container.get("name") != "avx-check":
+                continue
+            for item in container.get("env") or []:
+                preflight_env[item.get("name")] = item.get("value")
+            command = container.get("command") or []
+            if command:
+                preflight_script = command[-1]
+
+if clickhouse_images != [expected_clickhouse_image]:
+    problems.append(
+        f"chart clickhouse must use reviewed image {expected_clickhouse_image}; "
+        f"found {clickhouse_images!r}"
+    )
+
+expected_langfuse_images = {
+    "langfuse-web": f"langfuse/langfuse:{expected_langfuse}",
+    "langfuse-worker": f"langfuse/langfuse-worker:{expected_langfuse}",
+}
+for name, wanted in expected_langfuse_images.items():
+    actual = langfuse_images.get(name)
+    if actual != wanted:
+        problems.append(
+            f"chart {name} must use reviewed image {wanted}; found {actual!r}"
+        )
+
+if preflight_env.get("CLICKHOUSE_TAG") != expected_clickhouse:
+    problems.append(
+        "AVX preflight CLICKHOUSE_TAG must match the chart ClickHouse pin "
+        f"{expected_clickhouse}; found {preflight_env.get('CLICKHOUSE_TAG')!r}"
+    )
+if preflight_env.get("CLICKHOUSE_IMAGE") != expected_clickhouse_image:
+    problems.append(
+        "AVX preflight CLICKHOUSE_IMAGE must match the chart ClickHouse pin "
+        f"{expected_clickhouse_image}; found {preflight_env.get('CLICKHOUSE_IMAGE')!r}"
+    )
+
+safe_tags = (preflight_env.get("SSE42_SAFE_TAGS") or "").split()
+if expected_clickhouse in safe_tags:
+    problems.append(
+        f"chart-default ClickHouse {expected_clickhouse} must stay out of "
+        "sse42SafeTags so AVX remains required for the default pair; "
+        f"found {safe_tags!r}"
+    )
+if "24.8" not in safe_tags:
+    problems.append(
+        "sse42SafeTags must still list 24.8 as the explicit AVX-less override; "
+        f"found {safe_tags!r}"
+    )
+
+values_text = pathlib.Path(values_path).read_text()
+langfuse_idx = values_text.find('tag: "' + expected_langfuse + '"')
+clickhouse_idx = values_text.find('tag: "' + expected_clickhouse + '"')
+if langfuse_idx < 0:
+    problems.append(
+        f"values.yaml langfuse.image.tag must be {expected_langfuse}"
+    )
+if clickhouse_idx < 0:
+    problems.append(
+        f"values.yaml clickhouse.image.tag must be {expected_clickhouse}"
+    )
+
+def preceding_comment(text, idx, window=900):
+    start = max(0, idx - window)
+    return text[start:idx]
+
+
+if langfuse_idx >= 0:
+    langfuse_comment = preceding_comment(values_text, langfuse_idx)
+    if "clickhouse.image.tag" not in langfuse_comment or expected_clickhouse not in langfuse_comment:
+        problems.append(
+            "langfuse.image.tag comment must name clickhouse.image.tag "
+            f"{expected_clickhouse} as its constraint"
+        )
+if clickhouse_idx >= 0:
+    clickhouse_comment = preceding_comment(values_text, clickhouse_idx)
+    if "langfuse.image.tag" not in clickhouse_comment or expected_langfuse not in clickhouse_comment:
+        problems.append(
+            "clickhouse.image.tag comment must name langfuse.image.tag "
+            f"{expected_langfuse} as its constraint"
+        )
+
+if preflight_script is None:
+    problems.append("AVX preflight Job script was not rendered")
+else:
+    script_path = pathlib.Path(tempfile.mkdtemp()) / "avx-check.sh"
+    script_path.write_text(preflight_script)
+    env = os.environ.copy()
+    env.update({
+        "CLICKHOUSE_TAG": preflight_env.get("CLICKHOUSE_TAG") or "",
+        "CLICKHOUSE_IMAGE": preflight_env.get("CLICKHOUSE_IMAGE") or "",
+        "SSE42_SAFE_TAGS": preflight_env.get("SSE42_SAFE_TAGS") or "",
+        "FORCE_NO_AVX": "true",
+    })
+    completed = subprocess.run(
+        ["/bin/sh", str(script_path)],
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+    combined = completed.stdout + completed.stderr
+    if completed.returncode == 0:
+        problems.append(
+            "AVX preflight must FAIL without AVX on the chart-default "
+            f"ClickHouse {expected_clickhouse}; it passed:\n{combined}"
+        )
+    elif "FAIL" not in combined:
+        problems.append(
+            "AVX preflight failed without AVX but did not report FAIL for "
+            f"chart-default ClickHouse {expected_clickhouse}:\n{combined}"
+        )
+
+if problems:
+    raise SystemExit("\n".join(problems))
+
+print(
+    f"chart pins Langfuse {expected_langfuse} with ClickHouse {expected_clickhouse}, "
+    "comments name the pair, and AVX is required for the default tag"
+)
+PY
+
+python3 "$CHECKER" "$RENDER" "$VALUES" "$EXPECTED_LANGFUSE" "$EXPECTED_CLICKHOUSE" "$EXPECTED_CLICKHOUSE_IMAGE"
+
+# helm template does not emit NOTES.txt. Render it through tpl so the
+# operator-facing label is asserted on the same consumer path as `helm install`.
+NOTES_CHART="$TMP/notes-chart"
+cp -a "$CHART" "$NOTES_CHART"
+cp "$CHART/templates/NOTES.txt" "$NOTES_CHART/NOTES.txt"
+cat >"$NOTES_CHART/templates/notes-check.yaml" <<'EOF'
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: notes-check
+data:
+  notes: |
+{{ tpl (.Files.Get "NOTES.txt") . | nindent 4 }}
+EOF
+
+NOTES="$TMP/notes.yaml"
+helm template curie "$NOTES_CHART" --show-only templates/notes-check.yaml >"$NOTES"
+if ! grep -q '\[AVX required\]' "$NOTES"; then
+  echo "FAIL: default helm NOTES must label ClickHouse [AVX required]; got:" >&2
+  cat "$NOTES" >&2
+  exit 1
+fi
+if grep -q 'SSE4.2-pinned' "$NOTES"; then
+  echo "FAIL: default helm NOTES still claim SSE4.2-pinned" >&2
+  exit 1
+fi
+
+OVERRIDE_NOTES="$TMP/notes-24.8.yaml"
+helm template curie "$NOTES_CHART" --show-only templates/notes-check.yaml \
+  --set clickhouse.image.tag=24.8 >"$OVERRIDE_NOTES"
+if ! grep -q '\[SSE4.2-safe override\]' "$OVERRIDE_NOTES"; then
+  echo "FAIL: 24.8 override NOTES must label ClickHouse [SSE4.2-safe override]; got:" >&2
+  cat "$OVERRIDE_NOTES" >&2
+  exit 1
+fi
+echo "NOTES: default ClickHouse is [AVX required]; 24.8 override is [SSE4.2-safe override]"
+
+OVERRIDE_RENDER="$TMP/chart-24.8.yaml"
+helm template curie "$CHART" --set clickhouse.image.tag=24.8 >"$OVERRIDE_RENDER"
+python3 - "$OVERRIDE_RENDER" <<'PY'
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+
+import yaml
+
+documents = [
+    document
+    for document in yaml.safe_load_all(pathlib.Path(sys.argv[1]).read_text())
+    if document
+]
+preflight_env = {}
+preflight_script = None
+clickhouse_images = []
+for document in documents:
+    kind = document.get("kind")
+    name = document.get("metadata", {}).get("name", "")
+    spec = document.get("spec", {}).get("template", {}).get("spec", {})
+    containers = spec.get("containers") or []
+    if kind == "StatefulSet":
+        for container in containers:
+            if container.get("name") == "clickhouse":
+                clickhouse_images.append(container.get("image"))
+    if kind == "Job" and str(name).endswith("-preflight-avx"):
+        for container in containers:
+            if container.get("name") != "avx-check":
+                continue
+            for item in container.get("env") or []:
+                preflight_env[item.get("name")] = item.get("value")
+            command = container.get("command") or []
+            if command:
+                preflight_script = command[-1]
+if clickhouse_images != ["clickhouse/clickhouse-server:24.8"]:
+    raise SystemExit(f"24.8 override render must use ClickHouse 24.8; found {clickhouse_images!r}")
+if preflight_env.get("CLICKHOUSE_TAG") != "24.8":
+    raise SystemExit(
+        "24.8 override must flow clickhouse.image.tag into AVX preflight "
+        f"CLICKHOUSE_TAG; found {preflight_env.get('CLICKHOUSE_TAG')!r}"
+    )
+if preflight_script is None:
+    raise SystemExit("24.8 override did not render the AVX preflight Job")
+script_path = pathlib.Path(tempfile.mkdtemp()) / "avx-check.sh"
+script_path.write_text(preflight_script)
+env = os.environ.copy()
+env.update({
+    "CLICKHOUSE_TAG": preflight_env.get("CLICKHOUSE_TAG") or "",
+    "CLICKHOUSE_IMAGE": preflight_env.get("CLICKHOUSE_IMAGE") or "",
+    "SSE42_SAFE_TAGS": preflight_env.get("SSE42_SAFE_TAGS") or "",
+    "FORCE_NO_AVX": "true",
+})
+completed = subprocess.run(["/bin/sh", str(script_path)], env=env, text=True, capture_output=True)
+out = completed.stdout + completed.stderr
+if completed.returncode != 0:
+    raise SystemExit(
+        "AVX preflight must PASS without AVX on a helm-rendered 24.8 override; "
+        f"it failed:\n{out}"
+    )
+print("override: helm-rendered clickhouse.image.tag=24.8 passes AVX preflight without AVX")
+PY
+
+MUTANT_RENDER="$TMP/chart-old-clickhouse.yaml"
+python3 - "$RENDER" "$MUTANT_RENDER" "$EXPECTED_CLICKHOUSE" <<'PY'
+import pathlib
+import sys
+
+render, mutant, version = sys.argv[1:]
+pathlib.Path(mutant).write_text(
+    pathlib.Path(render).read_text().replace(f":{version}", ":24.8")
+)
+PY
+
+negative_output=""
+if negative_output="$(python3 "$CHECKER" "$MUTANT_RENDER" "$VALUES" "$EXPECTED_LANGFUSE" "$EXPECTED_CLICKHOUSE" "$EXPECTED_CLICKHOUSE_IMAGE" 2>&1)"; then
+  echo "FAIL: ClickHouse 24.8 mutation passed the Langfuse/ClickHouse pair contract" >&2
+  exit 1
+fi
+if [[ "$negative_output" != *"must use reviewed image ${EXPECTED_CLICKHOUSE_IMAGE}"* ]]; then
+  echo "FAIL: ClickHouse 24.8 mutation failed unexpectedly: $negative_output" >&2
+  exit 1
+fi
+
+echo "negative: replacing ClickHouse ${EXPECTED_CLICKHOUSE} with 24.8 is rejected"
+
+MUTANT_LANGFUSE="$TMP/chart-new-langfuse.yaml"
+python3 - "$RENDER" "$MUTANT_LANGFUSE" "$EXPECTED_LANGFUSE" <<'PY'
+import pathlib
+import sys
+
+render, mutant, version = sys.argv[1:]
+pathlib.Path(mutant).write_text(
+    pathlib.Path(render).read_text().replace(f":{version}", ":3")
+)
+PY
+
+if negative_output="$(python3 "$CHECKER" "$MUTANT_LANGFUSE" "$VALUES" "$EXPECTED_LANGFUSE" "$EXPECTED_CLICKHOUSE" "$EXPECTED_CLICKHOUSE_IMAGE" 2>&1)"; then
+  echo "FAIL: floating Langfuse :3 mutation passed the Langfuse/ClickHouse pair contract" >&2
+  exit 1
+fi
+if [[ "$negative_output" != *"must use reviewed image langfuse/langfuse:${EXPECTED_LANGFUSE}"* ]]; then
+  echo "FAIL: floating Langfuse :3 mutation failed unexpectedly: $negative_output" >&2
+  exit 1
+fi
+
+echo "negative: replacing Langfuse ${EXPECTED_LANGFUSE} with :3 is rejected"
+
+MUTANT_SSE42="$TMP/chart-sse42.yaml"
+python3 - "$RENDER" "$MUTANT_SSE42" "$EXPECTED_CLICKHOUSE" <<'PY'
+import pathlib
+import sys
+
+render, mutant, version = sys.argv[1:]
+text = pathlib.Path(render).read_text()
+old = 'value: "24.8 24.3 23.8"'
+new = f'value: "{version} 24.8 24.3 23.8"'
+if old not in text:
+    raise SystemExit(f"could not find AVX preflight SSE42_SAFE_TAGS assignment {old}")
+pathlib.Path(mutant).write_text(text.replace(old, new, 1))
+PY
+
+if negative_output="$(python3 "$CHECKER" "$MUTANT_SSE42" "$VALUES" "$EXPECTED_LANGFUSE" "$EXPECTED_CLICKHOUSE" "$EXPECTED_CLICKHOUSE_IMAGE" 2>&1)"; then
+  echo "FAIL: adding ${EXPECTED_CLICKHOUSE} to sse42SafeTags passed the pair contract" >&2
+  exit 1
+fi
+if [[ "$negative_output" != *"must stay out of sse42SafeTags"* ]]; then
+  echo "FAIL: sse42SafeTags mutation failed unexpectedly: $negative_output" >&2
+  exit 1
+fi
+
+echo "negative: adding ClickHouse ${EXPECTED_CLICKHOUSE} to sse42SafeTags is rejected"
+
+MUTANT_VALUES="$TMP/values-no-coupling.yaml"
+python3 - "$VALUES" "$MUTANT_VALUES" <<'PY'
+import pathlib
+import sys
+
+src, dest = sys.argv[1:]
+text = pathlib.Path(src).read_text().replace("clickhouse.image.tag", "image.tag").replace(
+    "langfuse.image.tag", "image.tag"
+)
+pathlib.Path(dest).write_text(text)
+PY
+
+if negative_output="$(python3 "$CHECKER" "$RENDER" "$MUTANT_VALUES" "$EXPECTED_LANGFUSE" "$EXPECTED_CLICKHOUSE" "$EXPECTED_CLICKHOUSE_IMAGE" 2>&1)"; then
+  echo "FAIL: stripping pin-coupling comments passed the pair contract" >&2
+  exit 1
+fi
+if [[ "$negative_output" != *"comment must name"* ]]; then
+  echo "FAIL: comment-stripping mutation failed unexpectedly: $negative_output" >&2
+  exit 1
+fi
+
+echo "negative: stripping the pin-coupling comments is rejected"
+echo "PASS: chart Langfuse ${EXPECTED_LANGFUSE} and ClickHouse ${EXPECTED_CLICKHOUSE} stay a documented pair"

--- a/charts/curie/ci/langfuse-recreate-assertions.sh
+++ b/charts/curie/ci/langfuse-recreate-assertions.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+#
+# Render-assertion test for issue #2216 (Langfuse RollingUpdate races boot
+# migrations). Both Langfuse Deployments run Prisma and ClickHouse migrations
+# at container boot with no cross-process lock. With replicas: 1 and no
+# strategy, Kubernetes defaults to RollingUpdate and maxSurge 25% rounds up to
+# one extra pod, so an image change runs two migrators against the same
+# database.
+#
+# This asserts that helm template renders spec.strategy.type Recreate on both
+# langfuse-web and langfuse-worker. Recreate stops the old pod before the new
+# one starts, so only one pod ever runs those boot migrations. A mutant that
+# restores RollingUpdate on either Deployment is rejected, so a checker that
+# only looked at one of the two siblings would not pass.
+#
+# Runnable locally (from anywhere) and from CI. Fails loudly, naming the
+# Deployment.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+RENDER="$TMP/langfuse.yaml"
+CHECKER="$TMP/check.py"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+echo "=== Rendering templates/langfuse.yaml ==="
+helm template curie "$CHART" --show-only templates/langfuse.yaml >"$RENDER"
+
+cat >"$CHECKER" <<'PY'
+import pathlib
+import sys
+
+import yaml
+
+path = sys.argv[1]
+wanted = ("-langfuse-web", "-langfuse-worker")
+found = {}
+
+for document in yaml.safe_load_all(pathlib.Path(path).read_text()):
+    if not document or document.get("kind") != "Deployment":
+        continue
+    name = document.get("metadata", {}).get("name", "")
+    for suffix in wanted:
+        if name.endswith(suffix):
+            found[suffix] = document
+            break
+
+problems = []
+for suffix in wanted:
+    document = found.get(suffix)
+    if document is None:
+        problems.append(
+            f"no Deployment ending in {suffix!r} rendered; cannot pin Recreate"
+        )
+        continue
+    name = document.get("metadata", {}).get("name")
+    spec = document.get("spec") or {}
+    strategy_type = (spec.get("strategy") or {}).get("type")
+    if strategy_type != "Recreate":
+        problems.append(
+            f"{name} spec.strategy.type must be Recreate so an image change "
+            f"never runs two boot migrations at once; found {strategy_type!r}"
+        )
+if problems:
+    raise SystemExit("\n".join(problems))
+
+print(
+    "langfuse-web and langfuse-worker Deployments both render "
+    "spec.strategy.type Recreate"
+)
+PY
+
+echo "=== Assertion: both Langfuse Deployments render Recreate ==="
+python3 "$CHECKER" "$RENDER"
+
+flip_strategy() {
+  local suffix="$1"
+  local dest="$2"
+  python3 - "$RENDER" "$dest" "$suffix" <<'PY'
+import pathlib
+import sys
+
+import yaml
+
+source, dest, suffix = sys.argv[1], sys.argv[2], sys.argv[3]
+documents = list(yaml.safe_load_all(pathlib.Path(source).read_text()))
+mutated = False
+for document in documents:
+    if not document or document.get("kind") != "Deployment":
+        continue
+    name = document.get("metadata", {}).get("name", "")
+    if name.endswith(suffix):
+        document.setdefault("spec", {}).setdefault("strategy", {})["type"] = "RollingUpdate"
+        mutated = True
+if not mutated:
+    raise SystemExit(f"mutant setup failed: no Deployment ending in {suffix!r} to flip")
+with pathlib.Path(dest).open("w") as handle:
+    yaml.safe_dump_all(documents, handle)
+PY
+}
+
+reject_rolling_update() {
+  local suffix="$1"
+  local mutant="$TMP/langfuse-rolling${suffix}.yaml"
+  echo "=== Negative: RollingUpdate on ${suffix#-} is rejected ==="
+  flip_strategy "$suffix" "$mutant"
+  local negative_output=""
+  if negative_output="$(python3 "$CHECKER" "$mutant" 2>&1)"; then
+    fail "RollingUpdate mutation on ${suffix#-} passed the Recreate contract"
+  fi
+  if [[ "$negative_output" != *"spec.strategy.type must be Recreate"* ]]; then
+    fail "RollingUpdate mutation on ${suffix#-} failed unexpectedly: $negative_output"
+  fi
+  if [[ "$negative_output" != *"${suffix#-}"* ]]; then
+    fail "RollingUpdate mutation did not name ${suffix#-}: $negative_output"
+  fi
+  echo "negative: flipping ${suffix#-} to RollingUpdate is rejected"
+}
+
+reject_rolling_update "-langfuse-web"
+reject_rolling_update "-langfuse-worker"
+
+echo "PASS: both Langfuse Deployments render Recreate and a RollingUpdate sibling is refused (issue #2216)"

--- a/charts/curie/ci/object-store-byo-egress-assertions.sh
+++ b/charts/curie/ci/object-store-byo-egress-assertions.sh
@@ -1,0 +1,403 @@
+#!/usr/bin/env bash
+#
+# Render-assertion test for issue #2213. With a BYO object store
+# (`rustfs.deploy: false`) Rail 1 is still fail-closed, and the only
+# object-store egress carve-out the chart used to render selected the in-chart
+# rustfs pod. Bundle-fetch then could not reach S3 or, on the key-free path,
+# STS, so every sandbox sat in Init and the turn timed out.
+#
+# This pins the replacement contract:
+#
+#   1. The default (in-chart rustfs) render is unchanged: runner-allow-rustfs
+#      still selects this release's rustfs pod on TCP 9000, and
+#      runner-allow-object-store does not render. allowedEgress stays empty.
+#   2. rustfs.deploy=false with rustfs.egress (and rustfs.stsEgress on the
+#      key-free path) renders runner-allow-object-store covering those CIDRs
+#      and does not render the in-chart rustfs pod selector.
+#   3. rustfs.deploy=false without rustfs.egress fails at render, naming the
+#      key, so a model-only allowedEgress list cannot ship a silently broken
+#      BYO install.
+#   4. The key-free path additionally requires rustfs.stsEgress (STS is a
+#      different endpoint than S3). Static credentials do not.
+#   5. Opting out of Rail 1 (`security.networkPolicy.enabled=false`) does not
+#      require the BYO CIDRs: there is no fail-closed runner policy to satisfy.
+#
+# NetworkPolicy speaks CIDRs, not DNS names, so the chart cannot derive an
+# allow from rustfs.host. The values-level CIDR lists are the mechanism; the
+# README's BYO section documents the EKS VPC interface-endpoint /32 pattern.
+#
+# Runnable locally and from CI. Fails loudly.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+RELEASE=curie
+NAMESPACE=dev
+RUSTFS_POLICY="${RELEASE}-runner-allow-rustfs"
+OBJECT_STORE_POLICY="${RELEASE}-runner-allow-object-store"
+DEFAULT_DENY_EGRESS="${RELEASE}-runner-default-deny-egress"
+ALLOW_EGRESS="${RELEASE}-runner-allow-egress"
+
+S3_CIDR=192.0.2.10/32
+STS_CIDR=192.0.2.11/32
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+render_dir() {
+  local name="$1"
+  shift
+  local out="$TMP/$name"
+  mkdir -p "$out"
+  helm template "$RELEASE" "$CHART" --namespace "$NAMESPACE" \
+    --output-dir "$out" "$@" >/dev/null
+  printf '%s\n' "$out"
+}
+
+CHECKER="$TMP/check.py"
+cat > "$CHECKER" <<'PY'
+import pathlib
+import sys
+
+import yaml
+
+ROOT = pathlib.Path(sys.argv[1])
+ACTION = sys.argv[2]
+
+
+def die(message):
+    raise SystemExit(message)
+
+
+def load(root):
+    docs = []
+    for path in sorted(root.rglob("*.yaml")):
+        for document in yaml.safe_load_all(path.read_text()):
+            if isinstance(document, dict):
+                docs.append(document)
+    if not docs:
+        die(f"{root}: Helm wrote no YAML documents")
+    return docs
+
+
+def policies(docs):
+    return [doc for doc in docs if doc.get("kind") == "NetworkPolicy"]
+
+
+def named(docs, name):
+    matches = [
+        doc
+        for doc in policies(docs)
+        if doc.get("metadata", {}).get("name") == name
+    ]
+    if len(matches) > 1:
+        die(f"expected at most one NetworkPolicy/{name}, found {len(matches)}")
+    return matches[0] if matches else None
+
+
+def ip_blocks(policy):
+    blocks = []
+    for rule in (policy or {}).get("spec", {}).get("egress", []) or []:
+        ports = rule.get("ports")
+        for peer in rule.get("to") or []:
+            block = peer.get("ipBlock") or {}
+            if "cidr" in block:
+                blocks.append((block["cidr"], ports, block.get("except") or []))
+    return blocks
+
+
+def pod_peers(policy):
+    peers = []
+    for rule in (policy or {}).get("spec", {}).get("egress", []) or []:
+        ports = rule.get("ports")
+        for peer in rule.get("to") or []:
+            if "podSelector" in peer:
+                peers.append((peer, ports))
+    return peers
+
+
+def runner_selector(policy):
+    return (policy or {}).get("spec", {}).get("podSelector", {}).get("matchLabels", {})
+
+
+docs = load(ROOT)
+
+if ACTION == "default":
+    rustfs = named(docs, sys.argv[3])
+    byo = named(docs, sys.argv[4])
+    deny = named(docs, sys.argv[5])
+    allow = named(docs, sys.argv[6])
+    if rustfs is None:
+        die("default render dropped runner-allow-rustfs")
+    if byo is not None:
+        die("default render must not emit runner-allow-object-store")
+    if deny is None:
+        die("default render dropped runner-default-deny-egress")
+    if allow is not None:
+        die("default render must keep allowedEgress empty (no runner-allow-egress)")
+    labels = runner_selector(rustfs)
+    if labels.get("app.kubernetes.io/component") != "runner-sandbox":
+        die(f"runner-allow-rustfs selects {labels!r}, not runner-sandbox")
+    peers = pod_peers(rustfs)
+    if len(peers) != 1:
+        die(f"runner-allow-rustfs expected one pod peer, found {len(peers)}")
+    peer, ports = peers[0]
+    component = (
+        peer.get("podSelector", {})
+        .get("matchLabels", {})
+        .get("app.kubernetes.io/component")
+    )
+    if component != "rustfs":
+        die(f"runner-allow-rustfs peer component is {component!r}, expected rustfs")
+    if ports != [{"protocol": "TCP", "port": 9000}]:
+        die(f"runner-allow-rustfs ports are {ports!r}, expected TCP 9000")
+    if ip_blocks(rustfs):
+        die("in-chart runner-allow-rustfs must keep using a pod selector, not ipBlock")
+    print("ok: default render keeps in-chart rustfs pod allow and no BYO object-store policy")
+
+elif ACTION == "byo-keyfree":
+    rustfs = named(docs, sys.argv[3])
+    byo = named(docs, sys.argv[4])
+    deny = named(docs, sys.argv[5])
+    allow = named(docs, sys.argv[6])
+    s3_cidr = sys.argv[7]
+    sts_cidr = sys.argv[8]
+    if rustfs is not None:
+        die("BYO render still emitted in-chart runner-allow-rustfs")
+    if byo is None:
+        die("BYO render missing runner-allow-object-store")
+    if deny is None:
+        die("BYO render dropped runner-default-deny-egress")
+    if allow is not None:
+        die("BYO render must keep allowedEgress empty (no runner-allow-egress)")
+    labels = runner_selector(byo)
+    if labels.get("app.kubernetes.io/component") != "runner-sandbox":
+        die(f"runner-allow-object-store selects {labels!r}, not runner-sandbox")
+    if byo.get("spec", {}).get("policyTypes") != ["Egress"]:
+        die("runner-allow-object-store must be egress-only")
+    blocks = ip_blocks(byo)
+    cidrs = {cidr for cidr, _ports, _except in blocks}
+    if cidrs != {s3_cidr, sts_cidr}:
+        die(
+            f"BYO object-store policy CIDRs are {sorted(cidrs)!r}; "
+            f"expected exactly {{{s3_cidr}, {sts_cidr}}}"
+        )
+    for cidr, ports, excepts in blocks:
+        if ports != [{"protocol": "TCP", "port": 443}]:
+            die(f"{cidr} ports are {ports!r}, expected TCP 443")
+        if excepts:
+            die(f"{cidr} must not except anything on a /32 host allow; got {excepts}")
+    print("ok: BYO key-free render allows the configured S3 and STS CIDRs")
+
+elif ACTION == "byo-static":
+    rustfs = named(docs, sys.argv[3])
+    byo = named(docs, sys.argv[4])
+    allow = named(docs, sys.argv[5])
+    s3_cidr = sys.argv[6]
+    sts_cidr = sys.argv[7]
+    if rustfs is not None:
+        die("static-key BYO render still emitted in-chart runner-allow-rustfs")
+    if byo is None:
+        die("static-key BYO render missing runner-allow-object-store")
+    if allow is not None:
+        die("static-key BYO render must keep allowedEgress empty (no runner-allow-egress)")
+    cidrs = {cidr for cidr, _ports, _except in ip_blocks(byo)}
+    if cidrs != {s3_cidr}:
+        die(
+            f"static-key BYO policy CIDRs are {sorted(cidrs)!r}; "
+            f"expected only the S3 CIDR {s3_cidr} (STS is key-free-only)"
+        )
+    if sts_cidr in cidrs:
+        die("static-key BYO must not require or emit an STS allow")
+    print("ok: static-key BYO render allows only the object-store CIDR")
+
+else:
+    die(f"unknown action {ACTION!r}")
+PY
+
+echo "=== Assertion 1: default render is unchanged (in-chart rustfs allow, no BYO policy) ==="
+DEFAULT_OUT="$(render_dir default)"
+python3 "$CHECKER" "$DEFAULT_OUT" default \
+  "$RUSTFS_POLICY" "$OBJECT_STORE_POLICY" "$DEFAULT_DENY_EGRESS" "$ALLOW_EGRESS" \
+  || fail "default render changed the in-chart rustfs egress carve-out or opened a BYO policy"
+
+echo "=== Assertion 2: BYO key-free path renders S3 and STS ipBlock allows ==="
+KEYFREE_VALUES="$TMP/keyfree.yaml"
+cat > "$KEYFREE_VALUES" <<EOF
+rustfs:
+  deploy: false
+  host: s3.example.com
+  port: 443
+  auth:
+    accessKey: ""
+  egress:
+    - cidr: ${S3_CIDR}
+      ports: [{ protocol: TCP, port: 443 }]
+  stsEgress:
+    - cidr: ${STS_CIDR}
+      ports: [{ protocol: TCP, port: 443 }]
+api:
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::000000000000:role/curie-api
+worker:
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::000000000000:role/curie-worker
+agentSandbox:
+  runner:
+    serviceAccount:
+      annotations:
+        eks.amazonaws.com/role-arn: arn:aws:iam::000000000000:role/curie-runner
+EOF
+KEYFREE_OUT="$(render_dir keyfree --values "$KEYFREE_VALUES")"
+python3 "$CHECKER" "$KEYFREE_OUT" byo-keyfree \
+  "$RUSTFS_POLICY" "$OBJECT_STORE_POLICY" "$DEFAULT_DENY_EGRESS" "$ALLOW_EGRESS" \
+  "$S3_CIDR" "$STS_CIDR" \
+  || fail "BYO key-free render did not emit runner-allow-object-store covering S3 and STS"
+
+echo "=== Assertion 3: static-key BYO renders only the object-store CIDR ==="
+STATIC_VALUES="$TMP/static.yaml"
+cat > "$STATIC_VALUES" <<EOF
+rustfs:
+  deploy: false
+  host: s3.example.com
+  port: 443
+  egress:
+    - cidr: ${S3_CIDR}
+      ports: [{ protocol: TCP, port: 443 }]
+EOF
+STATIC_OUT="$(render_dir static --values "$STATIC_VALUES")"
+python3 "$CHECKER" "$STATIC_OUT" byo-static \
+  "$RUSTFS_POLICY" "$OBJECT_STORE_POLICY" "$ALLOW_EGRESS" "$S3_CIDR" "$STS_CIDR" \
+  || fail "static-key BYO render did not emit a rustfs.egress-only object-store policy"
+
+echo "=== Assertion 4: BYO without rustfs.egress fails at render, naming the key ==="
+MISSING_EGRESS_VALUES="$TMP/missing-egress.yaml"
+cat > "$MISSING_EGRESS_VALUES" <<'EOF'
+rustfs:
+  deploy: false
+  host: s3.example.com
+  port: 443
+EOF
+MISSING_EGRESS="$TMP/missing-egress.txt"
+if helm template "$RELEASE" "$CHART" --namespace "$NAMESPACE" \
+  --values "$MISSING_EGRESS_VALUES" \
+  > /dev/null 2>"$MISSING_EGRESS"; then
+  fail "rustfs.deploy=false without rustfs.egress must fail Helm rendering"
+fi
+if ! grep -q "rustfs.egress" "$MISSING_EGRESS"; then
+  fail "missing-egress render failed without naming rustfs.egress; output was: $(cat "$MISSING_EGRESS")"
+fi
+echo "ok: BYO without rustfs.egress is refused at render"
+
+echo "=== Assertion 5: key-free BYO without rustfs.stsEgress fails at render, naming the key ==="
+MISSING_STS_VALUES="$TMP/missing-sts.yaml"
+cat > "$MISSING_STS_VALUES" <<EOF
+rustfs:
+  deploy: false
+  host: s3.example.com
+  port: 443
+  auth:
+    accessKey: ""
+  egress:
+    - cidr: ${S3_CIDR}
+      ports: [{ protocol: TCP, port: 443 }]
+api:
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::000000000000:role/curie-api
+worker:
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::000000000000:role/curie-worker
+agentSandbox:
+  runner:
+    serviceAccount:
+      annotations:
+        eks.amazonaws.com/role-arn: arn:aws:iam::000000000000:role/curie-runner
+EOF
+MISSING_STS="$TMP/missing-sts.txt"
+if helm template "$RELEASE" "$CHART" --namespace "$NAMESPACE" \
+  --values "$MISSING_STS_VALUES" \
+  > /dev/null 2>"$MISSING_STS"; then
+  fail "key-free BYO without rustfs.stsEgress must fail Helm rendering"
+fi
+if ! grep -q "rustfs.stsEgress" "$MISSING_STS"; then
+  fail "missing-sts render failed without naming rustfs.stsEgress; output was: $(cat "$MISSING_STS")"
+fi
+echo "ok: key-free BYO without rustfs.stsEgress is refused at render"
+
+echo "=== Assertion 6: Rail 1 off does not require BYO object-store CIDRs ==="
+if ! helm template "$RELEASE" "$CHART" --namespace "$NAMESPACE" \
+  --set rustfs.deploy=false \
+  --set rustfs.host=s3.example.com \
+  --set rustfs.port=443 \
+  --set security.networkPolicy.enabled=false \
+  > /dev/null; then
+  fail "rustfs.deploy=false with networkPolicy.enabled=false must still render"
+fi
+echo "ok: opting out of Rail 1 does not require rustfs.egress"
+
+must_fail_naming() {
+  local label="$1"
+  local needle="$2"
+  local values="$3"
+  local out="$TMP/${label}.txt"
+  if helm template "$RELEASE" "$CHART" --namespace "$NAMESPACE" \
+    --values "$values" \
+    > /dev/null 2>"$out"; then
+    fail "${label} must fail Helm rendering"
+  fi
+  if ! grep -q "$needle" "$out"; then
+    fail "${label} failed without naming ${needle}; output was: $(cat "$out")"
+  fi
+  echo "ok: ${label} is refused at render"
+}
+
+echo "=== Assertion 7: rustfs.egress default route is refused ==="
+DEFAULT_ROUTE_VALUES="$TMP/default-route.yaml"
+cat > "$DEFAULT_ROUTE_VALUES" <<'EOF'
+rustfs:
+  deploy: false
+  host: s3.example.com
+  port: 443
+  egress:
+    - cidr: 0.0.0.0/0
+      ports: [{ protocol: TCP, port: 443 }]
+EOF
+must_fail_naming "default-route rustfs.egress" "rustfs.egress" "$DEFAULT_ROUTE_VALUES"
+
+echo "=== Assertion 8: rustfs.egress must not allow the metadata host ==="
+IMDS_VALUES="$TMP/imds.yaml"
+cat > "$IMDS_VALUES" <<'EOF'
+rustfs:
+  deploy: false
+  host: s3.example.com
+  port: 443
+  egress:
+    - cidr: 169.254.169.254/32
+      ports: [{ protocol: TCP, port: 443 }]
+EOF
+must_fail_naming "metadata-host rustfs.egress" "169.254.169.254" "$IMDS_VALUES"
+
+echo "=== Assertion 9: rustfs.egress entries require ports ==="
+NO_PORTS_VALUES="$TMP/no-ports.yaml"
+cat > "$NO_PORTS_VALUES" <<'EOF'
+rustfs:
+  deploy: false
+  host: s3.example.com
+  port: 443
+  egress:
+    - cidr: 192.0.2.10/32
+EOF
+must_fail_naming "ports-missing rustfs.egress" "ports" "$NO_PORTS_VALUES"
+
+echo
+echo "PASS: BYO object-store egress is required and rendered as a runner NetworkPolicy; the default in-chart rustfs allow is unchanged."

--- a/charts/curie/ci/object-store-web-identity-assertions.sh
+++ b/charts/curie/ci/object-store-web-identity-assertions.sh
@@ -64,6 +64,16 @@ rustfs:
   port: 443
   auth:
     accessKey: ""
+  # Dedicated runner allows for the BYO store and STS (#2213). TEST-NET-1
+  # stands in for VPC interface-endpoint /32s. The broad allowedEgress list
+  # below is a separate Rail 1 pin: it is the configuration in which the IMDS
+  # carve-out is observable.
+  egress:
+    - cidr: 192.0.2.10/32
+      ports: [{ protocol: TCP, port: 443 }]
+  stsEgress:
+    - cidr: 192.0.2.11/32
+      ports: [{ protocol: TCP, port: 443 }]
 # A key-free BYO store still has to be REACHABLE, so this overlay carries the
 # broad allowlist such an install realistically sets. That is also the only
 # configuration in which Rail 1's IMDS carve-out is observable: with an empty

--- a/charts/curie/ci/object-store-web-identity-assertions.sh
+++ b/charts/curie/ci/object-store-web-identity-assertions.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 #
 # Pointing the bundle store at a real cloud object store used to REQUIRE static
-# access keys: the api, the worker, and the sandbox bundle-fetch init container
-# each supplied explicit credentials unconditionally, so an ambient role was
-# never consulted (#1325).
+# access keys: the api, the worker, the sandbox bundle-fetch init container, and
+# Langfuse each supplied explicit credentials unconditionally, so an ambient
+# role was never consulted (#1325, #2211).
 #
 # Clearing `rustfs.auth.accessKey` now selects a key-free path: every credential
 # env var is omitted so the AWS SDK falls through its provider chain to the
@@ -42,13 +42,15 @@ CHART=${CHART:-charts/curie}
 STATIC_RENDERED=""
 WEB_IDENTITY_RENDERED=""
 REGION_OVERRIDE_RENDERED=""
+CREATE_FALSE_RENDERED=""
 WEB_IDENTITY_VALUES=""
 WEB_IDENTITY_TOKEN=""
-trap 'rm -f "${STATIC_RENDERED:-}" "${WEB_IDENTITY_RENDERED:-}" "${REGION_OVERRIDE_RENDERED:-}" "${WEB_IDENTITY_VALUES:-}" "${WEB_IDENTITY_TOKEN:-}"' EXIT
+trap 'rm -f "${STATIC_RENDERED:-}" "${WEB_IDENTITY_RENDERED:-}" "${REGION_OVERRIDE_RENDERED:-}" "${CREATE_FALSE_RENDERED:-}" "${WEB_IDENTITY_VALUES:-}" "${WEB_IDENTITY_TOKEN:-}"' EXIT
 
 STATIC_RENDERED=$(mktemp)
 WEB_IDENTITY_RENDERED=$(mktemp)
 REGION_OVERRIDE_RENDERED=$(mktemp)
+CREATE_FALSE_RENDERED=$(mktemp)
 WEB_IDENTITY_VALUES=$(mktemp)
 # Stands in for the projected ServiceAccount token the EKS pod-identity webhook
 # mounts. Its CONTENT is never read here: the web-identity provider hands back
@@ -99,6 +101,10 @@ agentSandbox:
     serviceAccount:
       annotations:
         eks.amazonaws.com/role-arn: arn:aws:iam::000000000000:role/curie-runner
+langfuse:
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::000000000000:role/curie-langfuse
 EOF
 
 helm template curie "$CHART" --namespace dev > "$STATIC_RENDERED"
@@ -106,6 +112,14 @@ helm template curie "$CHART" --namespace dev \
   --values "$WEB_IDENTITY_VALUES" > "$WEB_IDENTITY_RENDERED"
 helm template curie "$CHART" --namespace dev \
   --set rustfs.region=eu-west-1 > "$REGION_OVERRIDE_RENDERED"
+# create: false plus a custom name is the BYO ServiceAccount path the values
+# block advertises. It must bind both Langfuse Deployments to that name and
+# must not emit a chart-owned Langfuse ServiceAccount.
+helm template curie "$CHART" --namespace dev \
+  --values "$WEB_IDENTITY_VALUES" \
+  --set langfuse.serviceAccount.create=false \
+  --set langfuse.serviceAccount.name=byo-langfuse-sa \
+  > "$CREATE_FALSE_RENDERED"
 
 # Assertion 1: clearing the access key while the in-chart RustFS is deployed is
 # refused at render. That store is configured with those very credentials and
@@ -138,10 +152,20 @@ if ! helm template curie "$CHART" --namespace dev \
 fi
 echo "ok: an existing RustFS Secret with an empty rustfs.auth.secretKey renders"
 
-python3 - "$STATIC_RENDERED" "$WEB_IDENTITY_RENDERED" "$REGION_OVERRIDE_RENDERED" <<'PY'
+python3 - "$STATIC_RENDERED" "$WEB_IDENTITY_RENDERED" "$REGION_OVERRIDE_RENDERED" "$CREATE_FALSE_RENDERED" <<'PY'
 import ipaddress, sys, yaml
 
 CREDENTIAL_KEYS = ("S3_ACCESS_KEY", "S3_SECRET_KEY")
+# Langfuse uses the AWS SDK for JavaScript under LANGFUSE_S3_* names, not the
+# S3_ACCESS_KEY pair the api and worker carry. An empty access-key id here is
+# the same trap: the SDK treats it as an explicit credential and never reaches
+# the web-identity provider (#2211).
+LANGFUSE_CREDENTIAL_KEYS = (
+    "LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID",
+    "LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY",
+    "LANGFUSE_S3_MEDIA_UPLOAD_ACCESS_KEY_ID",
+    "LANGFUSE_S3_MEDIA_UPLOAD_SECRET_ACCESS_KEY",
+)
 # The metadata address Rail 1 denies. An instance-role path would need this
 # reachable; the web-identity path must not make it so.
 IMDS = ipaddress.ip_address("169.254.169.254")
@@ -151,10 +175,29 @@ def env_for(container):
     return {entry["name"]: entry for entry in container.get("env", [])}
 
 
+def named_container_env(deployment, container_name):
+    """The application container's env, chosen by name, never by index.
+
+    Indexing containers[0] reads whichever container the pod spec lists first.
+    A sidecar prepended to the spec would carry no S3 credential env, so the
+    gate would pass while the real application container kept its keys.
+    """
+    containers = deployment["spec"]["template"]["spec"].get("containers", []) or []
+    matches = [c for c in containers if c.get("name") == container_name]
+    assert len(matches) == 1, (
+        f"Deployment {deployment['metadata']['name']} must run exactly one "
+        f"container named {container_name!r}, but it renders "
+        f"{[c.get('name') for c in containers]}"
+    )
+    return env_for(matches[0])
+
+
 def read(path):
-    api = worker = bundle_fetch = None
+    api = worker = bundle_fetch = langfuse_web = langfuse_worker = None
+    langfuse_web_sa = langfuse_worker_sa = None
     fetch_command = ""
     service_accounts = {}
+    sa_automount = {}
     egress_excepts = []
     with open(path) as fh:
         for doc in yaml.safe_load_all(fh):
@@ -165,12 +208,24 @@ def read(path):
             if kind == "Deployment":
                 containers = doc["spec"]["template"]["spec"].get("containers", [])
                 assert containers, f"{name} Deployment has no containers"
-                if name.endswith("-api"):
+                sa_name = doc["spec"]["template"]["spec"].get("serviceAccountName")
+                # `-langfuse-worker` must be matched before `-worker`: the
+                # suffix `-worker` also matches `<release>-langfuse-worker`,
+                # which is why this script used to read past Langfuse (#1500,
+                # #2211).
+                if name.endswith("-langfuse-web"):
+                    langfuse_web = named_container_env(doc, "langfuse-web")
+                    langfuse_web_sa = sa_name
+                elif name.endswith("-langfuse-worker"):
+                    langfuse_worker = named_container_env(doc, "langfuse-worker")
+                    langfuse_worker_sa = sa_name
+                elif name.endswith("-api"):
                     api = env_for(containers[0])
                 elif name.endswith("-worker"):
                     worker = env_for(containers[0])
             elif kind == "ServiceAccount":
                 service_accounts[name] = doc["metadata"].get("annotations") or {}
+                sa_automount[name] = doc.get("automountServiceAccountToken")
             elif kind == "SandboxTemplate":
                 pod_spec = doc["spec"]["podTemplate"]["spec"]
                 matches = [
@@ -192,13 +247,45 @@ def read(path):
     assert api is not None, "api Deployment not rendered"
     assert worker is not None, "worker Deployment not rendered"
     assert bundle_fetch is not None, "SandboxTemplate bundle-fetch not rendered"
-    return api, worker, bundle_fetch, fetch_command, service_accounts, egress_excepts
+    assert langfuse_web is not None, "langfuse-web Deployment not rendered"
+    assert langfuse_worker is not None, "langfuse-worker Deployment not rendered"
+    return (
+        api,
+        worker,
+        bundle_fetch,
+        fetch_command,
+        service_accounts,
+        egress_excepts,
+        langfuse_web,
+        langfuse_worker,
+        langfuse_web_sa,
+        langfuse_worker_sa,
+        sa_automount,
+    )
 
 
 def assert_static(path):
-    api, worker, bundle_fetch, fetch_command, _, _ = read(path)
+    (
+        api,
+        worker,
+        bundle_fetch,
+        fetch_command,
+        _,
+        _,
+        langfuse_web,
+        langfuse_worker,
+        langfuse_web_sa,
+        langfuse_worker_sa,
+        sa_automount,
+    ) = read(path)
     for label, env in (("api", api), ("worker", worker), ("bundle-fetch", bundle_fetch)):
         missing = [key for key in CREDENTIAL_KEYS if key not in env]
+        assert not missing, (
+            f"the DEFAULT install must keep static credentials; {label} is missing {missing}. "
+            "The in-chart RustFS accepts nothing else."
+        )
+    for label, env in (("langfuse-web", langfuse_web), ("langfuse-worker", langfuse_worker)):
+        missing = [key for key in LANGFUSE_CREDENTIAL_KEYS if key not in env]
         assert not missing, (
             f"the DEFAULT install must keep static credentials; {label} is missing {missing}. "
             "The in-chart RustFS accepts nothing else."
@@ -206,11 +293,35 @@ def assert_static(path):
     assert "AWS_ACCESS_KEY_ID" in fetch_command, (
         "the default bundle-fetch must still export AWS_ACCESS_KEY_ID"
     )
-    print("ok: static: api, worker, and bundle-fetch all carry S3_ACCESS_KEY and S3_SECRET_KEY")
+    # The dedicated SA is created on the default path too, so adding a role
+    # annotation later does not change which identity the pods run as.
+    assert langfuse_web_sa == "curie-langfuse", (
+        f"static: langfuse-web binds {langfuse_web_sa!r}, expected 'curie-langfuse'"
+    )
+    assert langfuse_worker_sa == "curie-langfuse", (
+        f"static: langfuse-worker binds {langfuse_worker_sa!r}, expected 'curie-langfuse'"
+    )
+    assert sa_automount.get("curie-langfuse") is False, (
+        "static: Langfuse ServiceAccount must set automountServiceAccountToken: false; "
+        f"got {sa_automount.get('curie-langfuse')!r}"
+    )
+    print("ok: static: api, worker, bundle-fetch, and both Langfuse Deployments carry static S3 credentials")
 
 
 def assert_web_identity(path):
-    api, worker, bundle_fetch, fetch_command, service_accounts, egress_excepts = read(path)
+    (
+        api,
+        worker,
+        bundle_fetch,
+        fetch_command,
+        service_accounts,
+        egress_excepts,
+        langfuse_web,
+        langfuse_worker,
+        langfuse_web_sa,
+        langfuse_worker_sa,
+        sa_automount,
+    ) = read(path)
 
     # Omission is complete: not present, not empty-valued. An empty explicit
     # credential stops the provider chain just as a real one does, so it would
@@ -221,6 +332,13 @@ def assert_web_identity(path):
             f"{label} still carries {present} on the key-free path. The env var must be "
             "ABSENT, not empty: the SDK treats an empty explicit credential as a credential "
             "and never reaches the web-identity provider."
+        )
+    for label, env in (("langfuse-web", langfuse_web), ("langfuse-worker", langfuse_worker)):
+        present = [key for key in LANGFUSE_CREDENTIAL_KEYS if key in env]
+        assert not present, (
+            f"{label} still carries {present} on the key-free path. The env var must be "
+            "ABSENT, not empty: Langfuse's AWS SDK treats an empty explicit credential as "
+            "a credential and never reaches the web-identity provider."
         )
 
     for name in ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"):
@@ -237,6 +355,14 @@ def assert_web_identity(path):
     assert api.get("S3_ENDPOINT_URL", {}).get("value") == "https://s3.example.com:443", (
         f"api lost its endpoint: {api.get('S3_ENDPOINT_URL')}"
     )
+    for label, env in (("langfuse-web", langfuse_web), ("langfuse-worker", langfuse_worker)):
+        for key in (
+            "LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT",
+            "LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT",
+        ):
+            assert env.get(key, {}).get("value") == "https://s3.example.com:443", (
+                f"{label} lost {key}: {env.get(key)}"
+            )
 
     # The role binds on the ServiceAccount, so an annotation that does not render
     # means there is no way to name an identity at all.
@@ -245,12 +371,31 @@ def assert_web_identity(path):
         for name, annotations in service_accounts.items()
         if "eks.amazonaws.com/role-arn" in annotations
     }
-    for suffix in ("-api", "-worker", "-runner"):
+    for suffix in ("-api", "-worker", "-runner", "-langfuse"):
         matches = [name for name in annotated if name.endswith(suffix)]
         assert matches, (
             f"no ServiceAccount ending in {suffix} carries eks.amazonaws.com/role-arn. "
             "Without it the key-free path has no identity to assume."
         )
+    # Follow the Deployment binding rather than suffix-matching alone: a
+    # rendered SA with an annotation is not the identity these pods run as
+    # unless serviceAccountName names it. Pin the exact default name so an
+    # empty-name fallback cannot silently change while a `-langfuse` suffix
+    # still matches.
+    assert langfuse_web_sa == "curie-langfuse", (
+        f"langfuse-web binds {langfuse_web_sa!r}, expected 'curie-langfuse'"
+    )
+    assert langfuse_worker_sa == "curie-langfuse", (
+        f"langfuse-worker binds {langfuse_worker_sa!r}, expected 'curie-langfuse'"
+    )
+    assert langfuse_web_sa in annotated, (
+        f"Langfuse ServiceAccount {langfuse_web_sa} carries no eks.amazonaws.com/role-arn. "
+        "Without it the key-free path has no identity to assume."
+    )
+    assert sa_automount.get("curie-langfuse") is False, (
+        "web-identity: Langfuse ServiceAccount must set automountServiceAccountToken: false; "
+        f"got {sa_automount.get('curie-langfuse')!r}"
+    )
     print(f"ok: web-identity: {len(annotated)} ServiceAccounts carry a role-arn annotation")
 
     # Rail 1 must be untouched by any of the above. Assert CONTAINMENT rather
@@ -275,7 +420,7 @@ def assert_web_identity(path):
 
 
 def assert_bundle_fetch_region(path, expected_region):
-    _, _, bundle_fetch, _, _, _ = read(path)
+    _, _, bundle_fetch, _, _, _, _, _, _, _, _ = read(path)
     rendered = bundle_fetch.get("AWS_DEFAULT_REGION", {}).get("value")
     assert rendered == expected_region, (
         f"bundle-fetch AWS_DEFAULT_REGION rendered as {rendered!r}; expected "
@@ -338,6 +483,37 @@ def assert_langfuse_upload_regions(path, expected_region):
     )
 
 
+def assert_create_false(path):
+    (
+        _,
+        _,
+        _,
+        _,
+        service_accounts,
+        _,
+        _,
+        _,
+        langfuse_web_sa,
+        langfuse_worker_sa,
+        _,
+    ) = read(path)
+    assert langfuse_web_sa == "byo-langfuse-sa", (
+        f"create=false: langfuse-web binds {langfuse_web_sa!r}, expected 'byo-langfuse-sa'"
+    )
+    assert langfuse_worker_sa == "byo-langfuse-sa", (
+        f"create=false: langfuse-worker binds {langfuse_worker_sa!r}, expected 'byo-langfuse-sa'"
+    )
+    chart_owned = [name for name in service_accounts if name.endswith("-langfuse")]
+    assert not chart_owned, (
+        f"create=false must not render a chart-owned Langfuse ServiceAccount; got {chart_owned}"
+    )
+    assert "byo-langfuse-sa" not in service_accounts, (
+        "create=false must not emit the operator-named ServiceAccount; the chart binds it, "
+        "it does not create it"
+    )
+    print("ok: create=false: both Langfuse Deployments bind byo-langfuse-sa and the chart emits no Langfuse ServiceAccount")
+
+
 assert_static(sys.argv[1])
 assert_web_identity(sys.argv[2])
 assert_bundle_fetch_region(sys.argv[1], "us-east-1")
@@ -345,6 +521,7 @@ assert_bundle_fetch_region(sys.argv[3], "eu-west-1")
 assert_langfuse_upload_regions(sys.argv[1], "us-east-1")
 assert_langfuse_upload_regions(sys.argv[2], "us-east-1")
 assert_langfuse_upload_regions(sys.argv[3], "eu-west-1")
+assert_create_false(sys.argv[4])
 PY
 
 # Everything above reads the rendered YAML. That is necessary and not
@@ -382,6 +559,16 @@ uv run --python 3.13 python - "$STATIC_RENDERED" "$WEB_IDENTITY_RENDERED" "$WEB_
 import base64, os, sys, boto3, yaml
 
 ROLE_ANNOTATION = "eks.amazonaws.com/role-arn"
+LANGFUSE_CREDENTIAL_KEYS = (
+    "LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID",
+    "LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY",
+    "LANGFUSE_S3_MEDIA_UPLOAD_ACCESS_KEY_ID",
+    "LANGFUSE_S3_MEDIA_UPLOAD_SECRET_ACCESS_KEY",
+)
+LANGFUSE_WORKLOADS = (
+    ("langfuse-web", "curie-langfuse-web", "langfuse-web"),
+    ("langfuse-worker", "curie-langfuse-worker", "langfuse-worker"),
+)
 
 
 def load_manifest(path):
@@ -628,7 +815,36 @@ for label, workload, container_name, build_client in WORKLOADS:
         "credential at all."
     )
     print(f"ok: key-free: {label} resolves credentials via {method}")
+
+# Langfuse uses the AWS SDK for JavaScript, not boto3 BundleStore, so this
+# block cannot ask a constructed client which provider won. It still follows
+# the rendered env (secretKeyRefs resolved) and the ServiceAccount each
+# Deployment actually names, which is the same identity path the api/worker
+# checks use before they build a client. An empty access-key id paired with a
+# chart Secret is the #2211 failure; it must not survive this resolution.
+for label, workload, container_name in LANGFUSE_WORKLOADS:
+    deployment = deployment_for(static_deployments, workload)
+    manifest_env = resolve_env(label, deployment, container_name, static_secrets)
+    missing = [key for key in LANGFUSE_CREDENTIAL_KEYS if key not in manifest_env]
+    assert not missing, (
+        f"static: {label} is missing {missing}; the default install must keep "
+        "static Langfuse S3 credentials"
+    )
+    account = deployment["spec"]["template"]["spec"].get("serviceAccountName")
+    assert account, f"static: {label} Deployment names no serviceAccountName"
+    print(f"ok: static: {label} carries static S3 credentials and binds {account}")
+
+for label, workload, container_name in LANGFUSE_WORKLOADS:
+    deployment = deployment_for(free_deployments, workload)
+    manifest_env = resolve_env(label, deployment, container_name, free_secrets)
+    present = [key for key in LANGFUSE_CREDENTIAL_KEYS if key in manifest_env]
+    assert not present, (
+        f"key-free: {label} still carries {present} after secretKeyRef resolution. "
+        "The env var must be ABSENT, not empty."
+    )
+    arn = resolve_role_arn(label, deployment, free_accounts)
+    print(f"ok: key-free: {label} omits S3 credentials and binds role {arn}")
 PY
 
 echo
-echo "PASS: the default install keeps static object-store credentials and still signs with the access key its manifest carries; clearing rustfs.auth.accessKey omits every credential env and shell export across api, worker, and bundle-fetch, binds identity through ServiceAccount annotations, is refused against the in-chart RustFS, leaves Rail 1's IMDS denial intact, and makes the api and worker BundleStore objects resolve real credentials through the web-identity provider rather than an explicit key."
+echo "PASS: the default install keeps static object-store credentials and still signs with the access key its manifest carries; clearing rustfs.auth.accessKey omits every credential env and shell export across api, worker, bundle-fetch, and both Langfuse Deployments, binds identity through ServiceAccount annotations (including Langfuse), is refused against the in-chart RustFS, leaves Rail 1's IMDS denial intact, and makes the api and worker BundleStore objects resolve real credentials through the web-identity provider rather than an explicit key."

--- a/charts/curie/ci/object-store-web-identity-assertions.sh
+++ b/charts/curie/ci/object-store-web-identity-assertions.sh
@@ -274,10 +274,67 @@ def assert_bundle_fetch_region(path, expected_region):
     print(f"ok: bundle-fetch AWS_DEFAULT_REGION renders {expected_region}")
 
 
+LANGFUSE_REGION_KEYS = (
+    "LANGFUSE_S3_EVENT_UPLOAD_REGION",
+    "LANGFUSE_S3_MEDIA_UPLOAD_REGION",
+)
+
+
+def langfuse_envs(path):
+    """Langfuse web and worker env, selected by container name.
+
+    The two Langfuse Deployment suffixes are more specific than `-worker`,
+    which also matches langfuse-worker. Container name, not index, is the
+    application container.
+    """
+    web = worker = None
+    with open(path) as fh:
+        for doc in yaml.safe_load_all(fh):
+            if not doc or doc.get("kind") != "Deployment":
+                continue
+            name = doc.get("metadata", {}).get("name", "")
+            containers = doc["spec"]["template"]["spec"].get("containers", [])
+            if name.endswith("-langfuse-web"):
+                matches = [c for c in containers if c.get("name") == "langfuse-web"]
+                assert len(matches) == 1, (
+                    f"{name} must render exactly one langfuse-web container, "
+                    f"got {len(matches)}"
+                )
+                web = env_for(matches[0])
+            elif name.endswith("-langfuse-worker"):
+                matches = [c for c in containers if c.get("name") == "langfuse-worker"]
+                assert len(matches) == 1, (
+                    f"{name} must render exactly one langfuse-worker container, "
+                    f"got {len(matches)}"
+                )
+                worker = env_for(matches[0])
+    assert web is not None, "langfuse-web Deployment not rendered"
+    assert worker is not None, "langfuse-worker Deployment not rendered"
+    return web, worker
+
+
+def assert_langfuse_upload_regions(path, expected_region):
+    web, worker = langfuse_envs(path)
+    for label, env in (("langfuse-web", web), ("langfuse-worker", worker)):
+        for key in LANGFUSE_REGION_KEYS:
+            rendered = env.get(key, {}).get("value")
+            assert rendered == expected_region, (
+                f"{label} {key} rendered as {rendered!r}; expected "
+                f"{expected_region!r} from rustfs.region"
+            )
+    print(
+        f"ok: langfuse event/media upload regions render {expected_region} "
+        "on web and worker"
+    )
+
+
 assert_static(sys.argv[1])
 assert_web_identity(sys.argv[2])
 assert_bundle_fetch_region(sys.argv[1], "us-east-1")
 assert_bundle_fetch_region(sys.argv[3], "eu-west-1")
+assert_langfuse_upload_regions(sys.argv[1], "us-east-1")
+assert_langfuse_upload_regions(sys.argv[2], "us-east-1")
+assert_langfuse_upload_regions(sys.argv[3], "eu-west-1")
 PY
 
 # Everything above reads the rendered YAML. That is necessary and not

--- a/charts/curie/ci/worker-object-store-assertions.sh
+++ b/charts/curie/ci/worker-object-store-assertions.sh
@@ -30,6 +30,11 @@ rustfs:
   deploy: false
   host: s3.example.com
   port: 443
+  # Required once Rail 1 is on: the in-chart rustfs pod selector does not
+  # render on the BYO path (#2213). TEST-NET-1 stands in for the store CIDR.
+  egress:
+    - cidr: 192.0.2.10/32
+      ports: [{ protocol: TCP, port: 443 }]
 EOF
 
 # Capture Helm output in Python so a large manifest cannot be truncated by a
@@ -70,6 +75,8 @@ def assert_external_store_requires_hostname():
         "dev",
         "--set",
         "rustfs.deploy=false",
+        "--set",
+        "rustfs.egress[0].cidr=192.0.2.10/32",
     ]
     rendered = subprocess.run(command, capture_output=True, text=True)
     if rendered.returncode == 0:

--- a/charts/curie/templates/NOTES.txt
+++ b/charts/curie/templates/NOTES.txt
@@ -17,7 +17,14 @@ Components deployed:
   - Valkey: BYO at {{ .Values.valkey.host }}:{{ .Values.valkey.port }}
 {{- end }}
 {{- if .Values.clickhouse.deploy }}
-  - ClickHouse ({{ .Values.clickhouse.image.repository }}:{{ .Values.clickhouse.image.tag }})  [SSE4.2-pinned]
+{{- $chTag := .Values.clickhouse.image.tag | toString }}
+{{- $sse42 := false }}
+{{- range .Values.clickhouse.sse42SafeTags }}
+{{- if or (eq $chTag .) (hasPrefix (printf "%s." .) $chTag) (hasPrefix (printf "%s-" .) $chTag) }}
+{{- $sse42 = true }}
+{{- end }}
+{{- end }}
+  - ClickHouse ({{ .Values.clickhouse.image.repository }}:{{ $chTag }}){{ if $sse42 }}  [SSE4.2-safe override]{{ else }}  [AVX required]{{ end }}
 {{- else }}
   - ClickHouse: BYO at {{ .Values.clickhouse.host }}
 {{- end }}

--- a/charts/curie/templates/NOTES.txt
+++ b/charts/curie/templates/NOTES.txt
@@ -25,6 +25,7 @@ Components deployed:
   - RustFS ({{ .Values.rustfs.image }})
 {{- else }}
   - S3: BYO at {{ .Values.rustfs.host }}:{{ .Values.rustfs.port }}
+    Runner bundle-fetch egress: rustfs.egress{{ if not (include "curie.rustfs.staticCredentials" .) }} and rustfs.stsEgress{{ end }} (VPC interface endpoint /32s on EKS).
 {{- end }}
 {{- if .Values.otelCollector.deploy }}
   - OTel Collector ({{ .Values.otelCollector.image }}) at http://{{ include "curie.fullname" . }}-otel-collector:{{ .Values.otelCollector.service.httpPort }}

--- a/charts/curie/templates/_helpers.tpl
+++ b/charts/curie/templates/_helpers.tpl
@@ -286,6 +286,14 @@ true
 {{- end -}}
 {{- end -}}
 
+{{/* Shared ServiceAccount name for both Langfuse Deployments. Empty
+     langfuse.serviceAccount.name falls back to <release>-langfuse so a
+     key-free install can bind one role without duplicating the name on
+     web and worker (#2211). */}}
+{{- define "curie.langfuse.serviceAccountName" -}}
+{{- .Values.langfuse.serviceAccount.name | default (printf "%s-langfuse" (include "curie.fullname" .)) -}}
+{{- end -}}
+
 {{/* Base URL of the platform API for a first-party service that calls it. Call
      with a dict: root (the top context) and baseUrl (the caller's own BYO
      override). An empty override derives the in-chart API Service; a set value
@@ -961,6 +969,12 @@ livenessProbe:
        release reports healthy. See #2214. */}}
 - name: LANGFUSE_S3_EVENT_UPLOAD_REGION
   value: {{ .Values.rustfs.region | quote }}
+{{- /* Credential env is gated the same way as api/worker/bundle-fetch
+       (#2211). An empty rustfs.auth.accessKey on the key-free path must
+       omit these, not emit them empty: Langfuse's AWS SDK treats an empty
+       explicit credential as a credential and never reaches the
+       web-identity provider. */}}
+{{- if include "curie.rustfs.staticCredentials" . }}
 - name: LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID
   value: {{ .Values.rustfs.auth.accessKey | quote }}
 - name: LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY
@@ -968,6 +982,7 @@ livenessProbe:
     secretKeyRef:
       name: {{ .Values.rustfs.existingSecret | default (include "curie.secretName" .) }}
       key: rustfsSecretKey
+{{- end }}
 {{- /* Both endpoints go through curie.rustfs.endpoint, never a literal
        scheme. They were hardcoded http:// while api/worker/sandbox used the
        helper, so a BYO store on rustfs.port 443 got https:// everywhere except
@@ -983,6 +998,7 @@ livenessProbe:
   value: {{ .Values.rustfs.bucket | quote }}
 - name: LANGFUSE_S3_MEDIA_UPLOAD_REGION
   value: {{ .Values.rustfs.region | quote }}
+{{- if include "curie.rustfs.staticCredentials" . }}
 - name: LANGFUSE_S3_MEDIA_UPLOAD_ACCESS_KEY_ID
   value: {{ .Values.rustfs.auth.accessKey | quote }}
 - name: LANGFUSE_S3_MEDIA_UPLOAD_SECRET_ACCESS_KEY
@@ -990,6 +1006,7 @@ livenessProbe:
     secretKeyRef:
       name: {{ .Values.rustfs.existingSecret | default (include "curie.secretName" .) }}
       key: rustfsSecretKey
+{{- end }}
 - name: LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT
   value: {{ include "curie.rustfs.endpoint" . }}
 - name: LANGFUSE_S3_MEDIA_UPLOAD_FORCE_PATH_STYLE

--- a/charts/curie/templates/_helpers.tpl
+++ b/charts/curie/templates/_helpers.tpl
@@ -955,8 +955,12 @@ livenessProbe:
       key: valkeyPassword
 - name: LANGFUSE_S3_EVENT_UPLOAD_BUCKET
   value: {{ .Values.rustfs.bucket | quote }}
+{{- /* Both upload regions come from rustfs.region, never the literal
+       `auto` that in-chart RustFS accepts. Real S3 rejects `auto` with
+       AuthorizationHeaderMalformed and drops every trace while the
+       release reports healthy. See #2214. */}}
 - name: LANGFUSE_S3_EVENT_UPLOAD_REGION
-  value: auto
+  value: {{ .Values.rustfs.region | quote }}
 - name: LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID
   value: {{ .Values.rustfs.auth.accessKey | quote }}
 - name: LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY
@@ -978,7 +982,7 @@ livenessProbe:
 - name: LANGFUSE_S3_MEDIA_UPLOAD_BUCKET
   value: {{ .Values.rustfs.bucket | quote }}
 - name: LANGFUSE_S3_MEDIA_UPLOAD_REGION
-  value: auto
+  value: {{ .Values.rustfs.region | quote }}
 - name: LANGFUSE_S3_MEDIA_UPLOAD_ACCESS_KEY_ID
   value: {{ .Values.rustfs.auth.accessKey | quote }}
 - name: LANGFUSE_S3_MEDIA_UPLOAD_SECRET_ACCESS_KEY

--- a/charts/curie/templates/clickhouse.yaml
+++ b/charts/curie/templates/clickhouse.yaml
@@ -85,7 +85,8 @@ spec:
         {{- end }}
       containers:
         - name: clickhouse
-          # Pinned tag; the AVX preflight validates it against the node's CPU.
+          # Pinned tag (coupled to langfuse.image.tag); the AVX preflight
+          # validates it against the node's CPU.
           image: "{{ .Values.clickhouse.image.repository }}:{{ .Values.clickhouse.image.tag }}"
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           {{- with .Values.clickhouse.containerSecurityContext }}

--- a/charts/curie/templates/langfuse.yaml
+++ b/charts/curie/templates/langfuse.yaml
@@ -1,4 +1,27 @@
 {{- if .Values.langfuse.deploy }}
+{{- if .Values.langfuse.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "curie.langfuse.serviceAccountName" . }}
+  labels:
+    {{- include "curie.labels" . | nindent 4 }}
+    app.kubernetes.io/component: langfuse
+  {{- with .Values.langfuse.serviceAccount.annotations }}
+  # Where a key-free object store binds Langfuse's identity (#2211): an IRSA
+  # install annotates this SA with `eks.amazonaws.com/role-arn`, and the
+  # pod-identity webhook injects the projected token and the two web-identity
+  # env vars. Both Langfuse Deployments share this account.
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+# Langfuse does not call the Kubernetes API. IRSA's projected web-identity
+# token is a separate volume, so this composes with key-free object-store
+# auth. Leaving automount at the Kubernetes default would mint a namespace
+# API token the previous `default` ServiceAccount path did not need.
+automountServiceAccountToken: false
+---
+{{- end }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -49,6 +72,7 @@ spec:
       {{- with (include "curie.placement.spec" (dict "root" $ "class" "platform")) }}
       {{- . | nindent 6 }}
       {{- end }}
+      serviceAccountName: {{ include "curie.langfuse.serviceAccountName" . }}
       {{- if or .Values.langfuse.clickhouseReadiness.enabled .Values.langfuse.web.postgresReadiness.enabled }}
       initContainers:
       {{- if .Values.langfuse.web.postgresReadiness.enabled }}
@@ -221,6 +245,7 @@ spec:
       {{- with (include "curie.placement.spec" (dict "root" $ "class" "platform")) }}
       {{- . | nindent 6 }}
       {{- end }}
+      serviceAccountName: {{ include "curie.langfuse.serviceAccountName" . }}
       {{- if .Values.langfuse.clickhouseReadiness.enabled }}
       initContainers:
         {{- include "curie.langfuse.clickhouseGate" (dict

--- a/charts/curie/templates/langfuse.yaml
+++ b/charts/curie/templates/langfuse.yaml
@@ -25,6 +25,11 @@ metadata:
     {{- include "curie.labels" . | nindent 4 }}
 spec:
   replicas: 1
+  # Boot migrations (Prisma + ClickHouse) have no cross-process lock. Recreate
+  # stops the old pod before the new one starts so two versions never migrate
+  # the same database at once (#2216).
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{- include "curie.selectorLabels" (dict "root" . "component" "langfuse-web") | nindent 6 }}
@@ -193,6 +198,10 @@ metadata:
     {{- include "curie.labels" . | nindent 4 }}
 spec:
   replicas: 1
+  # Same boot-migration race as langfuse-web (#2216): Recreate so an image
+  # change never runs two worker pods against the same stores at once.
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{- include "curie.selectorLabels" (dict "root" . "component" "langfuse-worker") | nindent 6 }}

--- a/charts/curie/templates/preflight-avx.yaml
+++ b/charts/curie/templates/preflight-avx.yaml
@@ -3,11 +3,13 @@
 Preflight (a): CPU-AVX / ClickHouse-pin check.
 
 Newer ClickHouse (>= 25.x) is compiled for AVX and SIGILLs with exit 132 on
-CPUs that only have SSE4.2. A crash-looping ClickHouse pod is a confusing way to
-discover this, so this hook catches it BEFORE the stores install: it reads the
-node's /proc/cpuinfo (a container shares the host kernel, so the flags are the
-node's), and if the node lacks AVX it FAILS the install unless the configured
-ClickHouse tag is in clickhouse.sse42SafeTags.
+CPUs that only have SSE4.2. The chart default is ClickHouse 25.12, required by
+the Langfuse pin (#2210); that tag is not SSE4.2-safe, so AVX is a
+chart-default requirement. This hook catches a missing AVX BEFORE the stores
+install: it reads the node's /proc/cpuinfo (a container shares the host kernel,
+so the flags are the node's), and if the node lacks AVX it FAILS the install
+unless the operator pins a tag in clickhouse.sse42SafeTags. That override
+cannot apply Langfuse ClickHouse migration 39.
 
 Runs as a pre-install / pre-upgrade hook (blocks a broken install) and is
 re-runnable via `helm test`. The Job is kept after success so its verdict log
@@ -101,9 +103,11 @@ spec:
               fi
 
               echo "RESULT: FAIL - node lacks AVX and ClickHouse tag '${CLICKHOUSE_TAG}' is NOT"
-              echo "        SSE4.2-safe. It will SIGILL (exit 132) and crash-loop on this node."
-              echo "REMEDY: pin clickhouse.image.tag to an SSE4.2-safe build (one of:"
-              echo "        ${SSE42_SAFE_TAGS}), e.g. --set clickhouse.image.tag=24.8"
+              echo "        SSE4.2-safe. Chart defaults require AVX because this tag is"
+              echo "        required by the Langfuse pin and will SIGILL (exit 132) here."
+              echo "REMEDY: install on AVX-capable nodes, or pin clickhouse.image.tag to an"
+              echo "        SSE4.2-safe build (one of: ${SSE42_SAFE_TAGS}) together with a"
+              echo "        Langfuse release whose ClickHouse migrations that tag can apply."
               exit 1
           resources:
             {{- toYaml .Values.preflights.avxCheck.resources | nindent 12 }}

--- a/charts/curie/templates/security-networkpolicy.yaml
+++ b/charts/curie/templates/security-networkpolicy.yaml
@@ -46,6 +46,40 @@ per-entry `except:` list, which wins over this auto carve-out.
   {{- end -}}
 {{- end -}}
 {{- end -}}
+{{/*
+Validate one rustfs.egress / rustfs.stsEgress entry. These lists are store
+(and STS) endpoints, not the model allowlist: a default route or a CIDR that
+reaches the cloud metadata address would additively re-open the prompt-injectable
+runner. Require cidr + ports, refuse prefix 0/1, and refuse any CIDR that
+contains 169.254.169.254 or fd00:ec2::254.
+*/}}
+{{- define "curie.objectStore.egressEntry" -}}
+{{- $key := .key -}}
+{{- $cidr := trim (printf "%v" (.entry.cidr | default "")) -}}
+{{- if eq $cidr "" -}}
+{{- fail (printf "%s entries must set cidr" $key) -}}
+{{- end -}}
+{{- if not .entry.ports -}}
+{{- fail (printf "%s entries must set ports" $key) -}}
+{{- end -}}
+{{- $parts := splitList "/" $cidr -}}
+{{- if ne (len $parts) 2 -}}
+{{- fail (printf "%s entry %q is not a CIDR" $key $cidr) -}}
+{{- end -}}
+{{- $ip := index $parts 0 -}}
+{{- $prefixText := index $parts 1 -}}
+{{- if not (regexMatch "^(0|[1-9][0-9]{0,2})$" $prefixText) -}}
+{{- fail (printf "%s entry %q has an invalid prefix length" $key $cidr) -}}
+{{- end -}}
+{{- $prefix := int $prefixText -}}
+{{- if le $prefix 1 -}}
+{{- fail (printf "%s entry %q is a default or equivalently broad route; use a VPC interface endpoint /32 or a regional store/STS prefix, not a default route" $key $cidr) -}}
+{{- end -}}
+{{- $auto := include "curie.metadataExcept" $cidr | trim -}}
+{{- if or $auto (eq $ip "169.254.169.254") (hasPrefix "fd00:ec2:" $ip) -}}
+{{- fail (printf "%s entry %q must not cover the cloud metadata endpoint 169.254.169.254" $key $cidr) -}}
+{{- end -}}
+{{- end -}}
 {{- if and .Values.agentSandbox.deploy .Values.security.networkPolicy.enabled }}
 {{- $np := .Values.security.networkPolicy }}
 {{/*
@@ -162,13 +196,13 @@ spec:
       ports:
         - { protocol: TCP, port: 8000 }
 {{- end }}
-{{- if and .Values.rustfs.deploy (or .Values.agentSandbox.runner.bundleFetch.enabled .Values.agentSandbox.runner.workspace.enabled) }}
+{{- if or .Values.agentSandbox.runner.bundleFetch.enabled .Values.agentSandbox.runner.workspace.enabled }}
+{{- if .Values.rustfs.deploy }}
 ---
 {{/* Allow the runner's bundle-fetch or workspace-fetch init container to reach
      THIS release's in-chart RustFS for its exact object. Mirrors the collector carve out
      above: without it, rail 1's default-deny blocks the S3 fetch and every bound
-     sandbox fails closed. BYO S3 with rustfs.deploy=false is an external host, so it
-     goes through the operator's allowedEgress list instead. */}}
+     sandbox fails closed. */}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -191,6 +225,61 @@ spec:
               {{- include "curie.selectorLabels" (dict "root" . "component" "rustfs") | nindent 14 }}
       ports:
         - { protocol: TCP, port: 9000 }
+{{- else }}
+{{/* BYO object store (#2213). There is no in-chart rustfs pod to select, and
+     NetworkPolicy cannot target rustfs.host (a DNS name). The operator must
+     declare CIDRs. Empty keeps fail-closed: a model-only allowedEgress list
+     used to install green and then hang every sandbox in Init. On EKS the
+     tight form is VPC interface endpoints for s3 and (key-free) sts with
+     private DNS enabled; see the chart README, "Key-free object store auth". */}}
+{{- if not .Values.rustfs.egress }}
+{{- fail "rustfs.deploy is false: set rustfs.egress to the object-store endpoint CIDRs the runner bundle-fetch must reach. Rail 1 is fail-closed and the in-chart runner-allow-rustfs policy does not render without an in-cluster rustfs pod. NetworkPolicy cannot target rustfs.host. On EKS the tight form is a VPC interface endpoint /32 for S3 with private DNS enabled (see the chart README, 'Key-free object store auth')." }}
+{{- end }}
+{{- if not (include "curie.rustfs.staticCredentials" .) }}
+{{- if not .Values.rustfs.stsEgress }}
+{{- fail "rustfs.deploy is false and rustfs.auth.accessKey is empty: set rustfs.stsEgress to the STS endpoint CIDRs AssumeRoleWithWebIdentity must reach. On EKS the tight form is a VPC interface endpoint /32 for STS with private DNS enabled (see the chart README, 'Key-free object store auth')." }}
+{{- end }}
+{{- end }}
+{{- range .Values.rustfs.egress }}
+{{- include "curie.objectStore.egressEntry" (dict "key" "rustfs.egress" "entry" .) }}
+{{- end }}
+{{- range .Values.rustfs.stsEgress }}
+{{- include "curie.objectStore.egressEntry" (dict "key" "rustfs.stsEgress" "entry" .) }}
+{{- end }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "curie.fullname" . }}-runner-allow-object-store
+  labels:
+    {{- include "curie.labels" . | nindent 4 }}
+    app.kubernetes.io/component: agent-sandbox
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "curie.selectorLabels" (dict "root" . "component" "runner-sandbox") | nindent 6 }}
+  policyTypes: [Egress]
+  egress:
+    {{- range concat (.Values.rustfs.egress | default list) (.Values.rustfs.stsEgress | default list) }}
+    - to:
+        - ipBlock:
+            cidr: {{ .cidr }}
+            {{- if .except }}
+            except:
+              {{- toYaml .except | nindent 14 }}
+            {{- else }}
+            {{- $auto := include "curie.metadataExcept" .cidr | trim }}
+            {{- if $auto }}
+            except:
+              - {{ $auto }}
+            {{- end }}
+            {{- end }}
+      {{- with .ports }}
+      ports:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- end }}
+{{- end }}
 {{- end }}
 {{- if .Values.inference.deploy }}
 ---

--- a/charts/curie/values-dev.yaml
+++ b/charts/curie/values-dev.yaml
@@ -7,8 +7,9 @@
 # requests here is ~1.7 GB, leaving headroom for the kubelet/system and for
 # ClickHouse/Langfuse to burst toward their limits. Everything is single-replica
 # and ClickHouse cluster mode is off. This mirrors compose.dev.yaml (same
-# images, same :24.8 ClickHouse pin) so V1 (compose) and V3 (chart) verify the
-# same stack.
+# Langfuse pin; chart ClickHouse default is 25.12 / AVX-required, compose stays
+# 24.8 for SSE4.2-only local hosts) so V1 (compose) and V3 (chart) verify the
+# same application stack.
 
 langfuse:
   web:
@@ -39,7 +40,8 @@ valkey:
     limits: { cpu: 250m, memory: 256Mi }
 
 clickhouse:
-  # Keep the :24.8 SSE4.2-safe pin. Cluster mode off for single-node.
+  # Inherits the chart-default :25.12 pin (AVX required, coupled to Langfuse).
+  # Cluster mode off for single-node.
   clusterEnabled: false
   persistence:
     size: 3Gi

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -111,6 +111,9 @@ langfuse:
     worker: langfuse/langfuse-worker
     # Keep web and worker on one reviewed migration set. A floating :3 moved to
     # 3.225.6 during CI and left ClickHouse migration 39 dirty (#2190).
+    # Coupled to clickhouse.image.tag 25.12: Langfuse 3.225.x migrations from
+    # 39 onward need that ClickHouse version. Do not advance this pin without
+    # it, and do not move ClickHouse off 25.12 while this pin stays (#2210).
     tag: "3.225.5"
   telemetryEnabled: false
   enableExperimentalFeatures: true
@@ -338,20 +341,25 @@ valkey:
     minAvailable: 1
 
 # ---------------------------------------------------------------------------
-# ClickHouse. Langfuse's OLAP store for traces/observations/scores. The AVX
-# preflight guards the image tag: newer ClickHouse needs AVX and SIGILLs with
-# exit 132 on SSE4.2-only hosts, so the tag is pinned to an SSE4.2-safe build.
-# DO NOT bump `image.tag` past the sse42SafeTags list unless every node has AVX.
+# ClickHouse. Langfuse's OLAP store for traces/observations/scores. Coupled to
+# langfuse.image.tag 3.225.5: that release line's ClickHouse migrations from 39
+# onward need 25.12 (Langfuse v3.225.7 compose pins clickhouse-server:25.12).
+# AVX is a chart-default requirement because 25.12 is not SSE4.2-safe. Do not
+# move this pin independently of the Langfuse pin (#2210). The AVX preflight
+# still allows an explicit sse42SafeTags override on AVX-less nodes; that
+# override cannot apply the current Langfuse migration set.
 # BYO: deploy=false + host/httpPort/nativePort (existingSecret key clickhousePassword).
 # ---------------------------------------------------------------------------
 clickhouse:
   deploy: true
   image:
     repository: clickhouse/clickhouse-server
-    tag: "24.8"
+    tag: "25.12"
   # Tags whose upstream binaries still ship an SSE4.2 build (no AVX required).
   # The AVX preflight passes an AVX-less node only if the configured tag begins
-  # with one of these. 24.8/24.3 are LTS lines; 23.8 is the prior LTS.
+  # with one of these. Not a supported default: 25.12 is required by the
+  # Langfuse pin and is deliberately absent from this list. 24.8/24.3 are LTS
+  # lines; 23.8 is the prior LTS.
   sse42SafeTags:
     - "24.8"
     - "24.3"
@@ -1577,15 +1585,17 @@ ui:
 # ---------------------------------------------------------------------------
 preflights:
   # (a) CPU-AVX / ClickHouse-pin check. Runs as a pre-install/pre-upgrade hook
-  # Job on the cluster. It reads the node's /proc/cpuinfo, and if the node lacks
-  # AVX it FAILS the install unless the configured ClickHouse tag is SSE4.2-safe
-  # (in clickhouse.sse42SafeTags) -- catching the exit-132 SIGILL before pods
+  # Job on the cluster. Chart defaults require AVX: clickhouse.image.tag 25.12
+  # is required by langfuse.image.tag 3.225.5 and is not SSE4.2-safe. If the
+  # node lacks AVX the Job FAILS unless the operator pins a tag in
+  # clickhouse.sse42SafeTags -- catching the exit-132 SIGILL before pods
   # crash-loop. Skipped when clickhouse.deploy is false (BYO ClickHouse).
   avxCheck:
     enabled: true
     image: busybox:1.36
-    # Test knob: pretend the node has no AVX to exercise the fallback branch on
-    # an AVX-capable node. Never set true in a real install.
+    # Test knob: pretend the node has no AVX. With the default 25.12 tag this
+    # exercises the AVX-required failure branch; pin an sse42SafeTags tag to
+    # exercise the older-tag override. Never set true in a real install.
     forceNoAvx: false
     resources:
       requests: { cpu: 50m, memory: 32Mi }

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -490,7 +490,8 @@ rustfs:
   # and Langfuse's event/media upload endpoints): an external RustFS on port 443 uses HTTPS. All other configurations use HTTP.
   host: ""
   port: 9000
-  # Signing region for sandbox bundle fetches. Keep it aligned with the regional S3 endpoint.
+  # Signing region for sandbox bundle fetches and Langfuse event/media uploads.
+  # Keep it aligned with the regional S3 endpoint.
   region: us-east-1
   consolePort: 9001
   bucket: langfuse

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -148,6 +148,18 @@ langfuse:
   salt: dev-salt-change-me
   nextauthSecret: dev-nextauth-secret-change-me
   existingSecret: ""
+  # Shared ServiceAccount for both Langfuse Deployments (web and worker).
+  # The key-free object store path (#1325 / #2211) binds its IAM role here,
+  # e.g. `eks.amazonaws.com/role-arn: arn:aws:iam::<account>:role/<role>`.
+  # The chart-created account sets automountServiceAccountToken: false:
+  # Langfuse does not call the Kubernetes API, and IRSA uses a separate
+  # projected token.
+  serviceAccount:
+    create: true
+    # Empty -> <release>-langfuse. Set to bind a pre-created ServiceAccount
+    # (`create: false`).
+    name: ""
+    annotations: {}
   # Headless bootstrap seeds a fixed org/project on first boot. The project
   # secret key and user password are first boot inputs. Fresh chart installs
   # generate them unless development defaults are enabled; changing them during
@@ -499,12 +511,13 @@ rustfs:
   #
   # Clearing `accessKey` selects the key-free path (#1325), valid only with
   # `deploy: false` and an external store: every S3 credential env var is
-  # omitted from the api, the worker, and the sandbox bundle-fetch init
-  # container, so the AWS SDK falls through its provider chain to the
+  # omitted from the api, the worker, the sandbox bundle-fetch init container,
+  # and Langfuse, so the AWS SDK falls through its provider chain to the
   # web-identity provider (`AWS_ROLE_ARN` + `AWS_WEB_IDENTITY_TOKEN_FILE`) fed
   # by a projected ServiceAccount token. Bind the role with the
-  # `serviceAccount.annotations` blocks on `api`, `worker`, and
-  # `agentSandbox.runner`. Clearing it with `deploy: true` is refused at render.
+  # `serviceAccount.annotations` blocks on `api`, `worker`,
+  # `agentSandbox.runner`, and `langfuse`. Clearing it with `deploy: true` is
+  # refused at render.
   #
   # The instance role is NOT an option here, deliberately. Rail 1 denies
   # 169.254.169.254 by construction and computes an `except` so a broad

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -517,6 +517,28 @@ rustfs:
     accessKey: rustfs
     secretKey: rustfssecret
   existingSecret: ""
+  # Runner sandbox egress to a BYO object store (#2213). Rail 1 is fail-closed,
+  # and the in-chart runner-allow-rustfs policy selects this release's rustfs
+  # pod, so it does not render when deploy is false. Each entry is
+  # {cidr, ports, except?} like security.networkPolicy.allowedEgress.
+  # NetworkPolicy cannot target a DNS name, so rustfs.host is not enough.
+  # Empty (the default) keeps fail-closed: a BYO install with Rail 1 on and
+  # bundle-fetch or workspace enabled is refused at render until these CIDRs
+  # are set. Each entry must set cidr and ports. Default routes and CIDRs that
+  # reach 169.254.169.254 are refused: this is a store-endpoint list, not a
+  # second model allowlist. On EKS the tight form is VPC interface endpoints
+  # for s3 (and sts on the key-free path) with private DNS enabled, which
+  # turns each requirement into a /32 rather than an AWS public service CIDR
+  # range. See the chart README, "Key-free object store auth".
+  egress: []
+  #  - cidr: 192.0.2.10/32
+  #    ports: [{ protocol: TCP, port: 443 }]
+  # Extra CIDRs for STS. Required when deploy is false and accessKey is empty,
+  # because AssumeRoleWithWebIdentity talks to STS, not S3. Unused on the
+  # static-key path.
+  stsEgress: []
+  #  - cidr: 192.0.2.11/32
+  #    ports: [{ protocol: TCP, port: 443 }]
   # RustFS runs as uid 10001. The matching group owns the mounted data volume.
   # Operators using another image can override both security context blocks.
   podSecurityContext:

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -749,7 +749,7 @@ dependencies = [
 
 [[package]]
 name = "curie"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "anstream",
  "anstyle",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "curie"
-version = "0.8.4"
+version = "0.8.5"
 edition = "2021"
 description = "Curie CLI: init/start/send/eval a plugin against a local runner (task I1)"
 

--- a/cli/scripts/e2e-ladder.sh
+++ b/cli/scripts/e2e-ladder.sh
@@ -341,7 +341,7 @@ cleanup() {
         # Tolerated failure, on top of `set +e`: the stack may never have
         # finished coming up, and a failed `local down` must not skip the
         # sandbox sweep below or change the exit code captured above.
-        "$BIN" local down || echo "warning: \`local down\` failed during teardown; sweeping anyway." >&2
+        "$BIN" local down -f "$REPO_ROOT/compose.dev.yaml" || echo "warning: \`local down\` failed during teardown; sweeping anyway." >&2
         local orphans
         orphans="$(docker ps -aq --filter "label=$SANDBOX_LABEL" 2>/dev/null)"
         if [[ -n "$orphans" ]]; then
@@ -499,6 +499,78 @@ else:
     fi
 }
 
+# A failed background approval turn used to discard both the structured result
+# and its stderr. Keep the raw artifacts private, but retain a bounded verdict
+# that makes an awaiting approval, timeout, or JSON parse failure actionable.
+approval_resume_failure_summary() {
+    local message_file="$1" stderr_file="$2" code="$3"
+    python3 - "$message_file" "$stderr_file" "$code" <<'PY'
+import json
+import pathlib
+import sys
+
+message_file, stderr_file, code = sys.argv[1:]
+try:
+    exit_code = int(code)
+except ValueError:
+    exit_code = 1
+
+try:
+    value = json.loads(pathlib.Path(message_file).read_text())
+except (OSError, json.JSONDecodeError):
+    value = None
+
+if not isinstance(value, dict):
+    status = "parse_failure"
+    finalized = "absent"
+    fields = "none"
+    error_category = "unparseable"
+else:
+    safe_fields = (
+        "awaiting_approval",
+        "timed_out",
+        "finalized",
+        "reply",
+        "error",
+        "fix",
+    )
+    fields = ",".join(field for field in safe_fields if field in value) or "none"
+    finalized = "true" if value.get("finalized") is True else "false" if value.get("finalized") is False else "absent"
+    if value.get("awaiting_approval") is True:
+        status = "awaiting_approval"
+    elif value.get("timed_out") is True:
+        status = "timed_out"
+    elif finalized == "true":
+        status = "finalized"
+    elif finalized == "false":
+        status = "not_finalized"
+    else:
+        status = "json_unclassified"
+    error_category = "error_field" if "error" in value else "none"
+
+try:
+    stderr = pathlib.Path(stderr_file).read_text(errors="replace").lower()
+except OSError:
+    stderr = ""
+if "awaiting_approval" in stderr or "awaiting approval" in stderr:
+    stderr_category = "awaiting_approval"
+elif "timed_out" in stderr or "timed out" in stderr:
+    stderr_category = "timed_out"
+elif any(term in stderr for term in ("json", "parse", "deserial")):
+    stderr_category = "parse_failure"
+elif stderr:
+    stderr_category = "unclassified"
+else:
+    stderr_category = "empty"
+
+print(
+    "approval resume failure: "
+    f"exit_code={exit_code} status={status} finalized={finalized} "
+    f"error_category={error_category} fields={fields} stderr_category={stderr_category}"
+)
+PY
+}
+
 # A `--json` failure is useful to an agent only when stdout contains one object
 # with exactly the centralized error contract's two non-empty string fields.
 # `json.loads` consumes the whole stream, so a second JSON document is rejected
@@ -575,7 +647,7 @@ product_stream_json() {
                 return 1
             }
             docker exec "$valkey" sh -c \
-                'VALKEYCLI_AUTH="${VALKEY_PASSWORD:-}" exec valkey-cli --json "$@"' \
+                'exec valkey-cli --no-auth-warning -a "$VALKEY_PASSWORD" --json "$@"' \
                 sh "$@"
             ;;
         cluster)
@@ -594,7 +666,7 @@ if len(ready) != 1:
 print(ready[0])
 ')" || return 1
             kubectl -n "$CURIE_NAMESPACE" exec "$pod" -- sh -c \
-                'VALKEYCLI_AUTH="${VALKEY_PASSWORD:-}" exec valkey-cli --json "$@"' \
+                'exec valkey-cli --no-auth-warning -a "$VALKEY_PASSWORD" --json "$@"' \
                 sh "$@"
             ;;
         *)
@@ -1147,7 +1219,7 @@ seed_mcp_read_turn() {
 
 seed_approval_resume_turn() {
     local tier="$1" agent_id="${2:-}" query_state="${3:-present}" marker="curie-seed-approval-$$-$RANDOM"
-    local stream_start stream_end message_file token_file pending_file approval_id token out trace_id
+    local stream_start stream_end message_file message_stderr_file token_file pending_file approval_id token out trace_id
     local message_pid code=0 attempt
     if [[ "$LIVE" == "1" || -z "$agent_id" || -z "$marker" ]]; then
         echo "seed-invalid: deterministic approval seed needs fake mode and a deployed agent before telemetry" >&2
@@ -1158,15 +1230,39 @@ seed_approval_resume_turn() {
         return 1
     fi
     umask 077
-    message_file="$(mktemp "$WORKDIR/approval-message.XXXXXX")"
-    token_file="$(mktemp "$WORKDIR/approval-token.XXXXXX")"
-    pending_file="$(mktemp "$WORKDIR/approval-pending.XXXXXX")"
+    if ! message_file="$(mktemp "$WORKDIR/approval-message.XXXXXX")"; then
+        echo "seed-invalid: could not create private approval message artifact" >&2
+        return 1
+    fi
+    if ! message_stderr_file="$(mktemp "$WORKDIR/approval-message-stderr.XXXXXX")"; then
+        rm -f "$message_file"
+        echo "seed-invalid: could not create private approval stderr artifact" >&2
+        return 1
+    fi
+    if ! token_file="$(mktemp "$WORKDIR/approval-token.XXXXXX")"; then
+        rm -f "$message_file" "$message_stderr_file"
+        echo "seed-invalid: could not create private approval token artifact" >&2
+        return 1
+    fi
+    if ! pending_file="$(mktemp "$WORKDIR/approval-pending.XXXXXX")"; then
+        rm -f "$message_file" "$message_stderr_file" "$token_file"
+        echo "seed-invalid: could not create private approval pending artifact" >&2
+        return 1
+    fi
     local scope=()
-    "$BIN" --json "$tier" approvals "$agent_id" "${scope[@]}" \
+    if ! "$BIN" --json "$tier" approvals "$agent_id" "${scope[@]}" \
         --route-resolution e2e=C0EXAMPLE1 --route-approvers e2e=users:U0EXAMPLE1 \
-        >/dev/null
-    "$BIN" --json "$tier" approvals "$agent_id" "${scope[@]}" \
-        --mint-operator-principal U0EXAMPLE1 > "$token_file"
+        >/dev/null; then
+        rm -f "$message_file" "$message_stderr_file" "$token_file" "$pending_file"
+        echo "seed-invalid: could not configure deterministic approval route" >&2
+        return 1
+    fi
+    if ! "$BIN" --json "$tier" approvals "$agent_id" "${scope[@]}" \
+        --mint-operator-principal U0EXAMPLE1 > "$token_file"; then
+        rm -f "$message_file" "$message_stderr_file" "$token_file" "$pending_file"
+        echo "seed-invalid: could not mint deterministic approval principal" >&2
+        return 1
+    fi
     token="$(python3 - "$token_file" <<'PY'
 import json, pathlib, sys
 value = json.loads(pathlib.Path(sys.argv[1]).read_text())
@@ -1176,13 +1272,16 @@ if not isinstance(token, str) or not token:
 print(token)
 PY
 )" || {
-        rm -f "$message_file" "$token_file" "$pending_file"
+        rm -f "$message_file" "$message_stderr_file" "$token_file" "$pending_file"
         return 1
     }
     rm -f "$token_file"
-    stream_start="$(capture_stream_cursor "$tier")" || return 1
+    stream_start="$(capture_stream_cursor "$tier")" || {
+        rm -f "$message_file" "$message_stderr_file" "$pending_file"
+        return 1
+    }
     "$BIN" --json local message --channel C0LOCALDEV --timeout-secs 120 \
-        "[fake:request-approval:e2e] approve correlation $marker" > "$message_file" 2>/dev/null &
+        "[fake:request-approval:e2e] approve correlation $marker" > "$message_file" 2> "$message_stderr_file" &
     message_pid=$!
     approval_id=""
     for attempt in $(seq 1 60); do
@@ -1203,20 +1302,33 @@ PY
     if [[ -z "$approval_id" ]]; then
         kill "$message_pid" 2>/dev/null || true
         wait "$message_pid" 2>/dev/null || true
-        rm -f "$message_file"
+        rm -f "$message_file" "$message_stderr_file"
         echo "seed-invalid: awaiting-approval record did not become pending" >&2
         return 1
     fi
-    CURIE_APPROVAL_PRINCIPAL_TOKEN="$token" "$BIN" --json "$tier" approvals "$agent_id" \
-        "${scope[@]}" --resolve "$approval_id" >/dev/null
-    unset token
-    wait "$message_pid" || code=$?
-    out="$(cat "$message_file")"
-    rm -f "$message_file"
-    if (( code != 0 )); then
-        echo "seed-invalid: approval resolution did not resume to a final reply" >&2
+    if ! CURIE_APPROVAL_PRINCIPAL_TOKEN="$token" "$BIN" --json "$tier" approvals "$agent_id" \
+        "${scope[@]}" --resolve "$approval_id" >/dev/null; then
+        unset token
+        kill "$message_pid" 2>/dev/null || true
+        wait "$message_pid" 2>/dev/null || true
+        rm -f "$message_file" "$message_stderr_file"
+        echo "seed-invalid: deterministic approval resolution command failed" >&2
         return 1
     fi
+    unset token
+    wait "$message_pid" || code=$?
+    if (( code != 0 )); then
+        approval_resume_failure_summary "$message_file" "$message_stderr_file" "$code" >&2
+        rm -f "$message_file" "$message_stderr_file"
+        echo "seed-invalid: approval resolution did not resume to a final reply (exit_code=$code)" >&2
+        return 1
+    fi
+    if ! out="$(cat "$message_file")"; then
+        rm -f "$message_file" "$message_stderr_file"
+        echo "seed-invalid: approval resume produced no readable private result artifact" >&2
+        return 1
+    fi
+    rm -f "$message_file" "$message_stderr_file"
     assert_finalized_reply "$tier approval resume" "$out"
     stream_end="$(capture_stream_cursor "$tier")" || return 1
     trace_id="$(discover_trace_id_for_seed "$tier" "$marker" "$stream_start" "$stream_end")" || return 1
@@ -3477,12 +3589,17 @@ route_local_observability_to_product_collector() {
     unset OTEL_EXPORTER_OTLP_ENDPOINT OTEL_EXPORTER_OTLP_PROTOCOL
     local stale runner dispatcher=""
     # An already-running curie-runner inherited the disposable endpoint. Reap
-    # only this task-owned stack's scoped sandboxes so every later runner is
-    # freshly launched from the restored worker environment.
+    # exactly those emitters, rather than selecting on CURIE_RELEASE: that is a
+    # worker configuration key, not part of the runner's declared boot env, so
+    # it is absent from an actual Docker-substrate sandbox. LOCAL_OTEL_ENDPOINT
+    # is a per-run, task-owned Collector address; matching it keeps an
+    # unrelated sandbox (including a concurrent product-routed one) out of
+    # this recovery sweep while ensuring the post-restore assertion cannot
+    # accidentally inspect the pre-restore runner.
     if (( LOCAL_STACK_OWNED )); then
         while IFS= read -r runner; do
             [[ -n "$runner" ]] || continue
-            if [[ "$(container_env_value "$runner" CURIE_RELEASE)" == "curie" ]]; then
+            if [[ "$(container_env_value "$runner" OTEL_EXPORTER_OTLP_ENDPOINT)" == "$LOCAL_OTEL_ENDPOINT" ]]; then
                 docker rm -f "$runner" >/dev/null
             fi
         done < <(docker ps --filter "label=$SANDBOX_LABEL" --format '{{.Names}}')
@@ -3855,7 +3972,10 @@ rung_local() {
         echo "note: the reused stack's model mode was fixed by whoever ran \`local up\`; it is verified below against this run's mode, and a mismatch fails this rung."
     else
         echo
-        local up_args=(local up)
+        # local up is deliberately pinned to this checkout and builds the
+        # candidate services; a release-channel binary otherwise resolves its
+        # cached release compose and silently tests published images.
+        local up_args=(local up -f "$REPO_ROOT/compose.dev.yaml" --build)
         echo "=== curie ${up_args[*]} ==="
         # The observability query proof below reads traces and metrics through
         # the Curie API. Those routes require Langfuse/ClickHouse, so every
@@ -4038,7 +4158,7 @@ PY
     if (( LOCAL_STACK_OWNED )); then
         echo
         echo "=== curie local down ==="
-        "$BIN" local down
+        "$BIN" local down -f "$REPO_ROOT/compose.dev.yaml"
         LOCAL_STACK_OWNED=0
         stop_local_otel_sink
 

--- a/cli/scripts/e2e-ladder.sh
+++ b/cli/scripts/e2e-ladder.sh
@@ -3597,12 +3597,15 @@ assert_product_runner_endpoints() {
 # The independent sink above proves raw telemetry crossed every service
 # boundary, but it deliberately replaces the product Collector endpoint. Once
 # those controls finish, restore every actual emitter before seeding Langfuse.
+# Pin the task-owned Collector explicitly: unsetting these variables permits
+# shell or ignored local configuration to redirect the evidence elsewhere.
 route_local_observability_to_product_collector() {
     if [[ -n "${STUB_STATE:-}" ]] || (( ! LOCAL_OTEL_SINK_ACTIVE )); then
         return 0
     fi
 
-    unset OTEL_EXPORTER_OTLP_ENDPOINT OTEL_EXPORTER_OTLP_PROTOCOL
+    export OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+    export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
     local stale runner dispatcher=""
     # An already-running curie-runner inherited the disposable endpoint. Reap
     # exactly those emitters, rather than selecting on CURIE_RELEASE: that is a
@@ -3647,7 +3650,7 @@ route_local_observability_to_product_collector() {
             "http://otel-collector:4318" "http/protobuf"
     else
         # curie local message launches the curie-dispatcher image after these
-        # exports are unset; the adjacent stream carrier and exact trace prove
+        # exports are pinned; the adjacent stream carrier and exact trace prove
         # that actual one-shot emitter rather than a config-only assertion.
         echo "local observability: curie-dispatcher one-shot will inherit product routing"
     fi

--- a/cli/scripts/e2e-ladder.sh
+++ b/cli/scripts/e2e-ladder.sh
@@ -320,11 +320,29 @@ fi
 WORKDIR="$(mktemp -d)"
 LOCAL_PRODUCT_EVIDENCE="$WORKDIR/product-observability-local.json"
 CLUSTER_PRODUCT_EVIDENCE="$WORKDIR/product-observability-cluster.json"
+APPROVAL_SEED_MESSAGE_PID=""
+
+stop_approval_seed_message() {
+    local mode="${1:-wait}" pid code=0
+    pid="$APPROVAL_SEED_MESSAGE_PID"
+    [[ -n "$pid" ]] || return 0
+    if [[ "$mode" == "terminate" ]]; then
+        kill "$pid" 2>/dev/null || true
+    fi
+    wait "$pid" 2>/dev/null || code=$?
+    APPROVAL_SEED_MESSAGE_PID=""
+    return "$code"
+}
+
 cleanup() {
     # Capture the real exit code FIRST: a teardown command that fails must not
     # turn a red run green, and a successful teardown must not mask a red rung.
     local code=$?
     set +e
+    # The approval proof owns a background `local message` Slack stub. Reap it
+    # before stack teardown so an interrupted seed cannot retain the stub port
+    # after this run exits.
+    stop_approval_seed_message terminate || true
     # The compose worker spawns runner containers as SIBLINGS on the host daemon
     # via the mounted docker socket, so a rung that died before `local down` can
     # strand them. This raw sweep is a BACKSTOP, not duplication: `local down`
@@ -1220,7 +1238,7 @@ seed_mcp_read_turn() {
 seed_approval_resume_turn() {
     local tier="$1" agent_id="${2:-}" query_state="${3:-present}" marker="curie-seed-approval-$$-$RANDOM"
     local stream_start stream_end message_file message_stderr_file token_file pending_file approval_id token out trace_id
-    local message_pid code=0 attempt
+    local code=0 attempt
     if [[ "$LIVE" == "1" || -z "$agent_id" || -z "$marker" ]]; then
         echo "seed-invalid: deterministic approval seed needs fake mode and a deployed agent before telemetry" >&2
         return 1
@@ -1282,7 +1300,7 @@ PY
     }
     "$BIN" --json local message --channel C0LOCALDEV --timeout-secs 120 \
         "[fake:request-approval:e2e] approve correlation $marker" > "$message_file" 2> "$message_stderr_file" &
-    message_pid=$!
+    APPROVAL_SEED_MESSAGE_PID=$!
     approval_id=""
     for attempt in $(seq 1 60); do
         if "$BIN" --json "$tier" approvals "$agent_id" "${scope[@]}" --list > "$pending_file" 2>/dev/null; then
@@ -1300,8 +1318,7 @@ PY
     done
     rm -f "$pending_file"
     if [[ -z "$approval_id" ]]; then
-        kill "$message_pid" 2>/dev/null || true
-        wait "$message_pid" 2>/dev/null || true
+        stop_approval_seed_message terminate || true
         rm -f "$message_file" "$message_stderr_file"
         echo "seed-invalid: awaiting-approval record did not become pending" >&2
         return 1
@@ -1309,14 +1326,13 @@ PY
     if ! CURIE_APPROVAL_PRINCIPAL_TOKEN="$token" "$BIN" --json "$tier" approvals "$agent_id" \
         "${scope[@]}" --resolve "$approval_id" >/dev/null; then
         unset token
-        kill "$message_pid" 2>/dev/null || true
-        wait "$message_pid" 2>/dev/null || true
+        stop_approval_seed_message terminate || true
         rm -f "$message_file" "$message_stderr_file"
         echo "seed-invalid: deterministic approval resolution command failed" >&2
         return 1
     fi
     unset token
-    wait "$message_pid" || code=$?
+    stop_approval_seed_message || code=$?
     if (( code != 0 )); then
         approval_resume_failure_summary "$message_file" "$message_stderr_file" "$code" >&2
         rm -f "$message_file" "$message_stderr_file"

--- a/cli/scripts/e2e-ladder.sh
+++ b/cli/scripts/e2e-ladder.sh
@@ -1191,8 +1191,8 @@ seed_ordinary_turn() {
         fi
         stream_start="$(capture_stream_cursor "$tier")" || return 1
         out="$("$BIN" --json local message --channel C0LOCALDEV "ordinary correlation $marker" || true)"
-        assert_finalized_reply "$tier ordinary correlation" "$out"
-        assert_product_runner_endpoints
+        assert_finalized_reply "$tier ordinary correlation" "$out" || return 1
+        assert_product_runner_endpoints || return 1
         stream_end="$(capture_stream_cursor "$tier")" || return 1
         [[ "$stream_end" != "$stream_start" ]] || {
             echo "seed-invalid: ordinary seed produced no bounded stream receipt" >&2
@@ -1201,7 +1201,7 @@ seed_ordinary_turn() {
         trace_id="$(discover_trace_id_for_seed "$tier" "$marker" "$stream_start" "$stream_end")" || return 1
         expected_operations="curie.queue.enqueue,curie.queue.process,curie.turn.process,curie.sandbox.claim,curie.runner.rpc,agent.run,curie.reply.post|curie.reply.update"
     fi
-    query_exact_seed_trace "$tier" "$trace_id" "$expected_operations" "" "$query_state"
+    query_exact_seed_trace "$tier" "$trace_id" "$expected_operations" "" "$query_state" || return 1
     LAST_ORDINARY_TRACE_ID="$trace_id"
     LAST_ORDINARY_MEMBERSHIP="$LAST_QUERY_MEMBERSHIP"
     printf '%s' "$trace_id"
@@ -3610,7 +3610,7 @@ assert_product_runner_endpoints() {
     }
     for runner in "${runners[@]}"; do
         assert_product_collector_endpoint curie-runner "$runner" \
-            "http://otel-collector:4318" "http/protobuf"
+            "http://otel-collector:4318" "http/protobuf" || return 1
     done
 }
 
@@ -3709,7 +3709,7 @@ wait_product_collector_ready() {
 
 restart_local_product_collector() {
     docker compose --profile full -f "$REPO_ROOT/compose.dev.yaml" \
-        up -d --force-recreate --no-deps otel-collector >/dev/null
+        up -d --force-recreate --no-deps otel-collector >/dev/null || return 1
     wait_product_collector_ready
 }
 
@@ -3723,158 +3723,118 @@ restore_local_langfuse_auth() {
     restart_local_product_collector
 }
 
-# Exercise the pinned Langfuse exporter with temporary invalid auth while the
-# shipped retry_on_failure (5s/30s/5m) and sending_queue/file_storage settings
-# remain unchanged. The queue_size is 1000; no volume is removed.
+# OTLP HTTP 401 is permanent, not retryable. Keep the shipped Collector retry
+# and file-backed queue settings unchanged; prove rejection is observable and
+# restore credentials before proving a new healthy export.
+assert_product_collector_permanent_auth_rejection() {
+    python3 -c 'import sys; a,f,q,ab,fb,r=map(float,sys.argv[1:]); raise SystemExit(0 if a > ab and f > fb and q == 0 and r == 1 else 1)' "$@"
+}
+
 case_local_langfuse_invalid_auth() {
     local INVALID_LANGFUSE_OTLP_AUTH_HEADER='Basic aW52YWxpZDppbnZhbGlk'
-    local agent_id="$1" original_set=0 original="${LANGFUSE_OTLP_AUTH_HEADER-}"
-    local receipt same_queued_trace_id queue_drained accepted accepted_before sent langfuse_web
-    local collector storage_directory accepted_baseline failed failed_baseline queue_size
-    [[ ${LANGFUSE_OTLP_AUTH_HEADER+x} ]] && original_set=1
-    langfuse_web="$(docker compose --profile full -f "$REPO_ROOT/compose.dev.yaml" ps -q langfuse-web)"
+    local agent_id="$1" original_set=0 original="" failed_phase=0
+    local receipt failed_trace_id recovered_trace_id langfuse_web collector
+    local accepted_baseline failed_baseline accepted failed queue_size rejection
+    local attempt marker stream_start stream_end out
+    if [[ -v LANGFUSE_OTLP_AUTH_HEADER ]]; then
+        original_set=1
+        original="$LANGFUSE_OTLP_AUTH_HEADER"
+    fi
+    langfuse_web="$(docker compose --profile full -f "$REPO_ROOT/compose.dev.yaml" ps -q langfuse-web)" || return 1
     [[ -n "$langfuse_web" ]] || {
         echo "pinned langfuse-web is not running for the real exporter negative" >&2
         return 1
     }
-    storage_directory="$(python3 - "$REPO_ROOT/otel/collector-config.yaml" <<'PY'
-import pathlib, re, sys
-text = pathlib.Path(sys.argv[1]).read_text()
-required = {
-    "sending_queue": r"(?m)^\s*sending_queue:\s*$",
-    "file_storage": r"(?m)^\s*storage:\s*file_storage\s*$",
-    "queue_size": r"(?m)^\s*queue_size:\s*1000\s*$",
-    "retry_horizon": r"(?m)^\s*max_elapsed_time:\s*5m\s*$",
-    }
-missing = [name for name, pattern in required.items() if not re.search(pattern, text)]
-directory = re.search(r"(?m)^\s*directory:\s*([^#\s]+)", text)
-if missing or directory is None:
-    raise SystemExit("shipped Collector durable queue configuration is absent")
-print(directory.group(1))
-PY
-)" || return 1
-    collector="$(docker compose --profile full -f "$REPO_ROOT/compose.dev.yaml" ps -q otel-collector)"
-    docker inspect "$collector" --format '{{json .Mounts}}' | python3 -c '
-import json, os, sys
-mounts = json.load(sys.stdin)
-directory = os.path.normpath(sys.argv[1])
-if not any(
-    directory == os.path.normpath(item.get("Destination", ""))
-    or directory.startswith(os.path.normpath(item.get("Destination", "")) + os.sep)
-    for item in mounts
-    if item.get("Type") == "volume" and item.get("Destination")
-):
-    raise SystemExit("file_storage directory is not backed by a Docker volume")
-' "$storage_directory" || return 1
-    receipt="$(mktemp "$WORKDIR/invalid-auth-trace.XXXXXX")"
-    chmod 600 "$receipt"
-
     echo
-    echo "=== case: pinned Langfuse invalid auth queues and recovers the same ID ==="
+    echo "=== case: pinned Langfuse invalid auth is observable, then fresh export recovers ==="
     if [[ ! "$LAST_ORDINARY_TRACE_ID" =~ ^[0-9a-f]{32}$ ]] || ! query_exact_seed_trace local "$LAST_ORDINARY_TRACE_ID" \
         "curie.queue.enqueue,curie.queue.process,curie.turn.process,curie.sandbox.claim,curie.runner.rpc,agent.run,curie.reply.post|curie.reply.update" \
         >/dev/null; then
-        rm -f "$receipt"
         echo "invalid-auth negative lacks a valid exact-query control" >&2
         return 1
     fi
     echo "invalid-auth negative: valid exact-query control passed before auth changed"
+    receipt="$(mktemp "$WORKDIR/invalid-auth-trace.XXXXXX")" || return 1
+    chmod 600 "$receipt" || { rm -f "$receipt"; return 1; }
+    # A conditional subshell disables Bash errexit, including in nested helpers.
+    # Every required operation explicitly propagates failure to the restore path.
     if ! (
-        set -e
         export LANGFUSE_OTLP_AUTH_HEADER="$INVALID_LANGFUSE_OTLP_AUTH_HEADER"
-        restart_local_product_collector
+        restart_local_product_collector || exit 1
         wait_product_collector_ready || {
             echo "Collector failed the Ready check after invalid-auth restart" >&2
             exit 1
         }
-        accepted_baseline="$(product_collector_metric_value otelcol_receiver_accepted_spans)"
-        failed_baseline="$(product_collector_metric_value otelcol_exporter_send_failed_spans)"
+        collector="$(docker compose --profile full -f "$REPO_ROOT/compose.dev.yaml" ps -q otel-collector)" || exit 1
+        [[ -n "$collector" ]] || exit 1
+        accepted_baseline="$(product_collector_metric_value otelcol_receiver_accepted_spans)" || exit 1
+        failed_baseline="$(product_collector_metric_value otelcol_exporter_send_failed_spans)" || exit 1
 
         marker="curie-seed-invalid-auth-$$-$RANDOM"
-        stream_start="$(capture_stream_cursor local)"
+        stream_start="$(capture_stream_cursor local)" || exit 1
         out="$("$BIN" --json local message --channel C0LOCALDEV \
-            "temporary exporter recovery $marker" || true)"
-        assert_finalized_reply "local invalid-auth seed" "$out"
-        stream_end="$(capture_stream_cursor local)"
-        same_queued_trace_id="$(discover_trace_id_for_seed local "$marker" "$stream_start" "$stream_end")"
+            "observable exporter rejection $marker" || true)"
+        assert_finalized_reply "local invalid-auth seed" "$out" || exit 1
+        stream_end="$(capture_stream_cursor local)" || exit 1
+        failed_trace_id="$(discover_trace_id_for_seed local "$marker" "$stream_start" "$stream_end")" || exit 1
 
         accepted=0
         failed=0
         queue_size=0
+        rejection=0
         for attempt in $(seq 1 45); do
-            accepted="$(product_collector_metric_value otelcol_receiver_accepted_spans)"
-            failed="$(product_collector_metric_value otelcol_exporter_send_failed_spans)"
-            queue_size="$(product_collector_metric_value otelcol_exporter_queue_size)"
-            if python3 -c 'import sys; a,f,q,ab,fb=map(float,sys.argv[1:]); raise SystemExit(0 if a > ab and f > fb and 0 < q <= 1000 else 1)' \
-                "$accepted" "$failed" "$queue_size" "$accepted_baseline" "$failed_baseline"; then
+            accepted="$(product_collector_metric_value otelcol_receiver_accepted_spans)" || exit 1
+            failed="$(product_collector_metric_value otelcol_exporter_send_failed_spans)" || exit 1
+            queue_size="$(product_collector_metric_value otelcol_exporter_queue_size)" || exit 1
+            # Read only this newly recreated Collector's logs. Raw diagnostics
+            # never reach output; require all three code-owned rejection tokens.
+            if docker logs "$collector" 2>&1 | python3 -c '
+import sys
+lines = sys.stdin.read().splitlines()
+raise SystemExit(0 if any(
+    "HTTP Status Code 401" in line and "Permanent error" in line and "not retryable error" in line
+    for line in lines
+) else 1)
+'; then
+                rejection=1
+            fi
+            if assert_product_collector_permanent_auth_rejection \
+                "$accepted" "$failed" "$queue_size" "$accepted_baseline" "$failed_baseline" "$rejection"; then
                 break
             fi
             sleep 2
         done
-        python3 -c 'import sys; a,f,q,ab,fb=map(float,sys.argv[1:]); raise SystemExit(0 if a > ab and f > fb and 0 < q <= 1000 else 1)' \
-            "$accepted" "$failed" "$queue_size" "$accepted_baseline" "$failed_baseline"
-        query_exact_seed_trace local "$same_queued_trace_id" "" "" absent
-
-        # Recreate once while auth is still invalid. The file-backed queue must
-        # survive the process boundary and retry the same pending export.
-        restart_local_product_collector
-        queue_size=0
-        failed=0
-        for attempt in $(seq 1 45); do
-            queue_size="$(product_collector_metric_value otelcol_exporter_queue_size)"
-            failed="$(product_collector_metric_value otelcol_exporter_send_failed_spans)"
-            if python3 -c 'import sys; q,f=map(float,sys.argv[1:]); raise SystemExit(0 if 0 < q <= 1000 and f > 0 else 1)' \
-                "$queue_size" "$failed"; then
-                break
-            fi
-            sleep 2
-        done
-        python3 -c 'import sys; q,f=map(float,sys.argv[1:]); raise SystemExit(0 if 0 < q <= 1000 and f > 0 else 1)' \
-            "$queue_size" "$failed"
-        query_exact_seed_trace local "$same_queued_trace_id" "" "" absent
-
-        python3 - "$receipt" "$same_queued_trace_id" "$accepted" <<'PY'
-import json, pathlib, sys
-pathlib.Path(sys.argv[1]).write_text(json.dumps({
-    "trace_id": sys.argv[2],
-    "accepted": float(sys.argv[3]),
-}))
-PY
+        assert_product_collector_permanent_auth_rejection \
+            "$accepted" "$failed" "$queue_size" "$accepted_baseline" "$failed_baseline" "$rejection" || exit 1
+        query_exact_seed_trace local "$failed_trace_id" "" "" absent || exit 1
+        printf '%s\n' "$failed_trace_id" > "$receipt" || exit 1
+        echo "invalid-auth negative: accepted/failed deltas, permanent HTTP401, empty queue, and exact absence proved"
     ); then
-        restore_local_langfuse_auth "$original_set" "$original" || true
-        rm -f "$receipt"
-        echo "invalid-auth queue proof failed; product Collector auth was restored" >&2
-        return 1
+        failed_phase=1
     fi
 
-    read -r same_queued_trace_id accepted_before < <(python3 - "$receipt" <<'PY'
-import json, pathlib, sys
-value = json.loads(pathlib.Path(sys.argv[1]).read_text())
-print(value["trace_id"], value["accepted"])
-PY
-    )
+    # Restoration executes once whether any negative assertion passed or failed.
+    if ! restore_local_langfuse_auth "$original_set" "$original"; then
+        rm -f "$receipt"
+        echo "invalid-auth proof could not restore product Collector auth" >&2
+        return 1
+    fi
+    if (( failed_phase )); then
+        rm -f "$receipt"
+        echo "invalid-auth rejection proof failed; product Collector auth was restored" >&2
+        return 1
+    fi
+    read -r failed_trace_id < "$receipt" || { rm -f "$receipt"; return 1; }
     rm -f "$receipt"
-    restore_local_langfuse_auth "$original_set" "$original"
-    wait_product_collector_ready || {
-        echo "Collector failed the Ready check after valid-auth restart" >&2
+    seed_ordinary_turn local "$agent_id" present || return 1
+    recovered_trace_id="$LAST_ORDINARY_TRACE_ID"
+    [[ "$recovered_trace_id" != "$failed_trace_id" ]] || {
+        echo "restored-auth proof did not produce a fresh trace" >&2
         return 1
     }
-    # The queue-preserving restart must deliver this same_queued_trace_id within
-    # the unchanged five-minute retry horizon; a fresh trace is not a substitute.
-    query_exact_seed_trace local "$same_queued_trace_id"
-    queue_drained=""
-    for attempt in $(seq 1 60); do
-        queue_drained="$(product_collector_metric_value otelcol_exporter_queue_size)"
-        if python3 -c 'import sys; raise SystemExit(0 if float(sys.argv[1]) == 0 else 1)' "$queue_drained"; then
-            break
-        fi
-        sleep 2
-    done
-    python3 -c 'import sys; raise SystemExit(0 if float(sys.argv[1]) == 0 else 1)' "$queue_drained" || {
-        echo "recovered exact trace but the durable sending queue did not drain" >&2
-        return 1
-    }
-    echo "local invalid-auth negative: durable same-ID recovery and queue drain proved"
+    query_exact_seed_trace local "$recovered_trace_id" \
+        "curie.queue.enqueue,curie.queue.process,curie.turn.process,curie.sandbox.claim,curie.runner.rpc,agent.run,curie.reply.post|curie.reply.update" || return 1
+    echo "local invalid-auth negative: bounded observable rejection and fresh healthy exact-trace recovery proved"
 }
 
 assert_local_otel_failed_turn() {

--- a/cli/scripts/e2e-ladder.sh
+++ b/cli/scripts/e2e-ladder.sh
@@ -1011,6 +1011,7 @@ PY
 query_exact_seed_trace() {
     local tier="$1" trace_id="$2" expected_csv="${3:-}" expected_decision="${4:-}" expected_state="${5:-present}"
     local attempt code=0 private_read safe_read membership observation_count saw_valid=0
+    local last_query_state="query-error"
     LAST_QUERY_MEMBERSHIP=""
     LAST_QUERY_OBSERVATION_COUNT="0"
     umask 077
@@ -1097,8 +1098,10 @@ PY
             fi
             continue
         fi
+        last_query_state="query-error"
         if (( code == 0 )); then
             if ! sanitize_exact_trace_read "$trace_id" "$private_read" "$expected_csv" "$expected_decision" > "$safe_read"; then
+                last_query_state="malformed-response"
                 if [[ "$expected_state" == "observe" ]]; then
                     rm -f "$private_read" "$safe_read"
                     echo "exact trace response was malformed rather than selectively incomplete" >&2
@@ -1106,6 +1109,7 @@ PY
                 fi
             else
                 saw_valid=1
+                last_query_state="incomplete-membership"
                 read -r membership observation_count < <(python3 - "$safe_read" "$expected_csv" "$expected_decision" <<'PY'
 import json, pathlib, sys
 value = json.loads(pathlib.Path(sys.argv[1]).read_text())
@@ -1157,8 +1161,12 @@ PY
         rm -f "$private_read" "$safe_read"
         return 0
     fi
+    echo "exact trace failed the bounded ingestion poll: $last_query_state (cli exit $code)" >&2
+    if [[ "$last_query_state" == "incomplete-membership" ]]; then
+        # Only the allowlisted projection, never the original trace response.
+        cat "$safe_read" >&2
+    fi
     rm -f "$private_read" "$safe_read"
-    echo "exact trace did not become queryable inside the bounded ingestion poll" >&2
     return 1
 }
 
@@ -3027,6 +3035,7 @@ start_local_otel_sink() {
     LOCAL_OTEL_ENDPOINT="http://$gateway:$otlp_port"
     LOCAL_OTEL_METRICS_ENDPOINT="http://127.0.0.1:$metrics_port/metrics"
     export OTEL_EXPORTER_OTLP_ENDPOINT="$LOCAL_OTEL_ENDPOINT"
+    export CURIE_WORKER_OTEL_EXPORTER_OTLP_ENDPOINT="$LOCAL_OTEL_ENDPOINT"
     export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 
     local attempt
@@ -3544,6 +3553,17 @@ assert_local_otel_healthy_turn() {
     assert_bounded_metric_attributes "$baseline"
 }
 
+# local up --build pins these references inside its child process only. Raw
+# Compose fault injection/restoration must retain that candidate identity too.
+pin_local_source_images() {
+    if (( ! LOCAL_STACK_OWNED )); then
+        return 0
+    fi
+    export CURIE_BASE_TAG=dev
+    export CURIE_RUNNER_IMAGE=ghcr.io/curie-eng/curie-runner:dev
+    export CURIE_DISPATCHER_IMAGE=ghcr.io/curie-eng/curie-dispatcher:dev
+}
+
 inject_local_runner_failure() {
     LOCAL_OTEL_FAILURE_MODE=1
     export CURIE_FAKE_MODEL=0
@@ -3605,6 +3625,7 @@ route_local_observability_to_product_collector() {
     fi
 
     export OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+    export CURIE_WORKER_OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:24318
     export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
     local stale runner dispatcher=""
     # An already-running curie-runner inherited the disposable endpoint. Reap
@@ -3642,7 +3663,7 @@ route_local_observability_to_product_collector() {
     assert_product_collector_endpoint curie-api "$api" \
         "http://otel-collector:4318" "http/protobuf"
     assert_product_collector_endpoint curie-worker "$worker" \
-        "http://otel-collector:4318" "http/protobuf"
+        "http://127.0.0.1:24318" "http/protobuf"
     if [[ -n "$dispatcher" ]]; then
         dispatcher="$(docker ps --filter 'label=com.docker.compose.project=curie' \
             --filter 'label=com.docker.compose.service=curie-dispatcher' --format '{{.Names}}')"
@@ -4009,6 +4030,7 @@ rung_local() {
         # `local down` is safe against a partial or already-stopped stack.
         LOCAL_STACK_OWNED=1
         "$BIN" "${up_args[@]}"
+        pin_local_source_images
     fi
 
     echo

--- a/cli/scripts/e2e-ladder.sh
+++ b/cli/scripts/e2e-ladder.sh
@@ -208,6 +208,15 @@ MCP_RECEIPT_IMAGE=""
 LAST_ORDINARY_TRACE_ID=""
 LAST_MCP_TRACE_ID=""
 LAST_APPROVAL_TRACE_ID=""
+LAST_ORDINARY_MEMBERSHIP=""
+LAST_MCP_MEMBERSHIP=""
+LAST_APPROVAL_MEMBERSHIP=""
+LAST_QUERY_MEMBERSHIP=""
+LAST_QUERY_OBSERVATION_COUNT="0"
+CLUSTER_TURN_TEMPLATE=""
+CLUSTER_SEEDED_TRACE_ID=""
+CLUSTER_SEEDED_REPLY_REF=""
+CLUSTER_IMAGE_IDS_MATCH="false"
 LOCAL_PRODUCT_EVIDENCE=""
 CLUSTER_PRODUCT_EVIDENCE=""
 
@@ -310,6 +319,7 @@ fi
 WORKDIR="$(mktemp -d)"
 LOCAL_PRODUCT_EVIDENCE="$WORKDIR/product-observability-local.json"
 CLUSTER_PRODUCT_EVIDENCE="$WORKDIR/product-observability-cluster.json"
+CLUSTER_TURN_TEMPLATE="$WORKDIR/cluster-turn-template.json"
 cleanup() {
     # Capture the real exit code FIRST: a teardown command that fails must not
     # turn a red run green, and a successful teardown must not mask a red rung.
@@ -546,8 +556,10 @@ print(start.strftime("%Y-%m-%dT%H:%M:%SZ"), end.strftime("%Y-%m-%dT%H:%M:%SZ"))
     echo "local observability metrics: captured explicit UTC window $OBSERVABILITY_START through $OBSERVABILITY_END around the just-completed local turn"
 }
 
-# Execute a read-only Valkey command against the product runs stream. Passwords
-# stay inside the selected container/pod and no command output is logged.
+# Execute a bounded Valkey command against the product runs stream. Passwords
+# stay inside the selected container/pod and no command output is logged. The
+# only write caller is the explicit carrier seed in a preflight-validated,
+# operator-owned release; all discovery and reply observations are read-only.
 product_stream_json() {
     local tier="$1"
     shift
@@ -677,6 +689,136 @@ PY
     printf '%s' "$trace_id"
 }
 
+# Capture one validated disconnected-cluster turn as a private shape template.
+# The payload-only control itself is never treated as correlation evidence.
+capture_cluster_turn_template() {
+    local marker="$1" stream_start="$2" stream_end="$3" private_slice
+    umask 077
+    private_slice="$(mktemp "$WORKDIR/cluster-template-stream.XXXXXX")"
+    product_stream_json cluster XRANGE curie:runs "($stream_start" "$stream_end" > "$private_slice" || {
+        rm -f "$private_slice"
+        return 1
+    }
+    python3 - "$private_slice" "$marker" "$CLUSTER_TURN_TEMPLATE" <<'PY'
+import json, pathlib, sys
+rows = json.loads(pathlib.Path(sys.argv[1]).read_text())
+marker = sys.argv[2]
+matches = []
+for row in rows:
+    if not isinstance(row, list) or len(row) != 2 or not isinstance(row[1], list):
+        raise SystemExit("seed-invalid: malformed cluster template slice")
+    fields = row[1]
+    for index in range(0, len(fields) - 1, 2):
+        if fields[index] != "payload":
+            continue
+        try:
+            payload = json.loads(fields[index + 1])
+        except (TypeError, json.JSONDecodeError):
+            continue
+        text = payload.get("text") if isinstance(payload, dict) else None
+        if isinstance(text, str) and marker in text:
+            matches.append(payload)
+if len(matches) != 1:
+    raise SystemExit("seed-invalid: cluster control did not select one private turn template")
+handle = matches[0].get("reply_handle")
+if not isinstance(handle, dict) or handle.get("adapter") != "curie-cluster-message":
+    raise SystemExit("seed-invalid: cluster control omitted the reserved reply adapter")
+pathlib.Path(sys.argv[3]).write_text(json.dumps(matches[0], separators=(",", ":")))
+PY
+    rm -f "$private_slice"
+}
+
+# Re-seed the validated cluster shape with fresh identifiers and an explicit
+# adjacent W3C carrier. This is a turn/data mutation only in the operator-owned
+# release; it never installs, upgrades, deletes, or rewrites cluster resources.
+enqueue_cluster_carried_turn() {
+    local marker="$1" text="$2" private_payload private_meta payload raw_id stream_start stream_end discovered traceparent
+    [[ -s "$CLUSTER_TURN_TEMPLATE" ]] || {
+        echo "seed-invalid: cluster carried seed lacks its validated control template" >&2
+        return 1
+    }
+    umask 077
+    private_payload="$(mktemp "$WORKDIR/cluster-carried-payload.XXXXXX")"
+    private_meta="$(mktemp "$WORKDIR/cluster-carried-meta.XXXXXX")"
+    python3 - "$CLUSTER_TURN_TEMPLATE" "$private_payload" "$private_meta" "$text" <<'PY'
+import json, pathlib, secrets, sys, uuid
+from datetime import UTC, datetime
+
+value = json.loads(pathlib.Path(sys.argv[1]).read_text())
+reply_ref = str(uuid.uuid4())
+trace_id = secrets.token_hex(16)
+span_id = secrets.token_hex(8)
+value["event_id"] = f"EvSIM-{uuid.uuid4()}"
+value["conversation_id"] = f"C0EXAMPLE1:{uuid.uuid4()}"
+value["text"] = sys.argv[4]
+value["received_at"] = datetime.now(UTC).isoformat()
+value["reply_handle"]["placeholder"] = reply_ref
+pathlib.Path(sys.argv[2]).write_text(json.dumps(value, separators=(",", ":")))
+pathlib.Path(sys.argv[3]).write_text(json.dumps({
+    "trace_id": trace_id,
+    "traceparent": f"00-{trace_id}-{span_id}-01",
+    "reply_ref": reply_ref,
+}, separators=(",", ":")))
+PY
+    stream_start="$(capture_stream_cursor cluster)" || return 1
+    payload="$(cat "$private_payload")"
+    read -r CLUSTER_SEEDED_TRACE_ID traceparent CLUSTER_SEEDED_REPLY_REF < <(python3 - "$private_meta" <<'PY'
+import json, pathlib, sys
+value = json.loads(pathlib.Path(sys.argv[1]).read_text())
+print(value["trace_id"], value["traceparent"], value["reply_ref"])
+PY
+    )
+    raw_id="$(product_stream_json cluster XADD curie:runs '*' payload "$payload" traceparent "$traceparent")" || return 1
+    stream_end="$(printf '%s' "$raw_id" | python3 -c 'import json,sys; value=json.load(sys.stdin); print(value if isinstance(value,str) else "")')"
+    rm -f "$private_payload" "$private_meta"
+    [[ -n "$stream_end" && "$stream_end" != "$stream_start" ]] || {
+        echo "seed-invalid: explicit cluster carrier seed produced no stream entry" >&2
+        return 1
+    }
+    discovered="$(discover_trace_id_for_seed cluster "$marker" "$stream_start" "$stream_end")" || return 1
+    [[ "$discovered" == "$CLUSTER_SEEDED_TRACE_ID" ]] || {
+        echo "seed-invalid: explicit cluster carrier did not round-trip to its exact trace id" >&2
+        return 1
+    }
+}
+
+wait_cluster_carried_reply() {
+    local reply_ref="$1" terminal_key events_key private_events terminal attempt
+    [[ "$reply_ref" =~ ^[0-9a-f-]{36}$ ]] || return 1
+    terminal_key="curie:cluster-message-replies:{$reply_ref}:terminal"
+    events_key="curie:cluster-message-replies:{$reply_ref}:events"
+    umask 077
+    private_events="$(mktemp "$WORKDIR/cluster-carried-reply.XXXXXX")"
+    terminal=""
+    for attempt in $(seq 1 120); do
+        terminal="$(product_stream_json cluster GET "$terminal_key" 2>/dev/null || true)"
+        if [[ "$terminal" == '"1"' ]]; then
+            break
+        fi
+        sleep 1
+    done
+    [[ "$terminal" == '"1"' ]] || {
+        rm -f "$private_events"
+        echo "seed-invalid: explicit cluster carrier turn did not finalize" >&2
+        return 1
+    }
+    product_stream_json cluster LRANGE "$events_key" 0 -1 > "$private_events" || return 1
+    python3 - "$private_events" <<'PY'
+import json, pathlib, sys
+rows = json.loads(pathlib.Path(sys.argv[1]).read_text())
+events = []
+for row in rows:
+    value = json.loads(row) if isinstance(row, str) else None
+    if not isinstance(value, dict) or not isinstance(value.get("event"), str):
+        raise SystemExit("seed-invalid: cluster reply receipt is malformed")
+    events.append(value["event"])
+if "turn.completed" not in events or not any(item in {"reply.post", "reply.update"} for item in events):
+    raise SystemExit("seed-invalid: cluster reply receipt omitted reply or completion")
+PY
+    rm -f "$private_events"
+    echo "cluster carried seed: finalized=true reply_observed=true"
+}
+
 # Convert a private exact-detail response into the sole public trace evidence.
 # Explicitly private source fields (input, output, session, user, headers) are
 # ignored. Operation names are reduced to a code-owned allowlist.
@@ -726,15 +868,9 @@ def walk(node):
 
 for root in tree:
     walk(root)
-expected = [item for item in expected_csv.split(",") if item]
-missing = [item for item in expected if not any(candidate in operations for candidate in item.split("|"))]
-if missing:
-    raise SystemExit("exact trace omitted required allowlisted operations")
 decision = value.get("approval_decision")
 if decision is not None and decision not in {"approved", "rejected", "expired"}:
     raise SystemExit("exact trace carried a non-allowlisted approval decision")
-if expected_decision and decision != expected_decision:
-    raise SystemExit("exact trace carried the wrong approval decision")
 
 service = []
 if any(op == "curie.queue.enqueue" for op in operations):
@@ -765,7 +901,9 @@ PY
 # sanitize_exact_trace_read reaches stdout.
 query_exact_seed_trace() {
     local tier="$1" trace_id="$2" expected_csv="${3:-}" expected_decision="${4:-}" expected_state="${5:-present}"
-    local attempt code=0 private_read safe_read
+    local attempt code=0 private_read safe_read membership observation_count saw_valid=0
+    LAST_QUERY_MEMBERSHIP=""
+    LAST_QUERY_OBSERVATION_COUNT="0"
     umask 077
     private_read="$(mktemp "$WORKDIR/exact-trace.XXXXXX")"
     safe_read="$(mktemp "$WORKDIR/safe-trace.XXXXXX")"
@@ -821,10 +959,66 @@ PY
             fi
             continue
         fi
-        if (( code == 0 )) && sanitize_exact_trace_read "$trace_id" "$private_read" "$expected_csv" "$expected_decision" > "$safe_read"; then
-            cat "$safe_read"
-            rm -f "$private_read" "$safe_read"
-            return 0
+        if [[ "$expected_state" == "observe" && "$code" -ne 0 ]]; then
+            if (( code != 1 )) || ! python3 - "$private_read" "$trace_id" <<'PY'
+import json
+import pathlib
+import sys
+
+source, trace_id = sys.argv[1:3]
+try:
+    value = json.loads(pathlib.Path(source).read_text())
+except (OSError, json.JSONDecodeError):
+    raise SystemExit(1)
+expected = f'observability trace "{trace_id}" was not found'
+if not isinstance(value, dict) or set(value) != {"error", "fix"}:
+    raise SystemExit(1)
+if value.get("error") not in {"exact trace not found", expected}:
+    raise SystemExit(1)
+if not isinstance(value.get("fix"), str) or not value["fix"].strip():
+    raise SystemExit(1)
+PY
+            then
+                rm -f "$private_read" "$safe_read"
+                echo "exact trace observation returned an unexpected query failure" >&2
+                return 1
+            fi
+            if (( attempt < OBSERVABILITY_POLL_ATTEMPTS )); then
+                sleep "$OBSERVABILITY_POLL_INTERVAL_SECONDS"
+            fi
+            continue
+        fi
+        if (( code == 0 )); then
+            if ! sanitize_exact_trace_read "$trace_id" "$private_read" "$expected_csv" "$expected_decision" > "$safe_read"; then
+                if [[ "$expected_state" == "observe" ]]; then
+                    rm -f "$private_read" "$safe_read"
+                    echo "exact trace response was malformed rather than selectively incomplete" >&2
+                    return 1
+                fi
+            else
+                saw_valid=1
+                read -r membership observation_count < <(python3 - "$safe_read" "$expected_csv" "$expected_decision" <<'PY'
+import json, pathlib, sys
+value = json.loads(pathlib.Path(sys.argv[1]).read_text())
+expected = [item for item in sys.argv[2].split(",") if item]
+operations = value["operation"]
+missing = [
+    item for item in expected
+    if not any(candidate in operations for candidate in item.split("|"))
+]
+decision_matches = not sys.argv[3] or value["approval_decision"] == sys.argv[3]
+membership = value["observation_count"] > 0 and not missing and decision_matches
+print("true" if membership else "false", value["observation_count"])
+PY
+                )
+                LAST_QUERY_MEMBERSHIP="$membership"
+                LAST_QUERY_OBSERVATION_COUNT="$observation_count"
+                if [[ "$membership" == "true" || "$expected_state" == "stub" ]]; then
+                    cat "$safe_read"
+                    rm -f "$private_read" "$safe_read"
+                    return 0
+                fi
+            fi
         fi
         if (( attempt < OBSERVABILITY_POLL_ATTEMPTS )); then
             sleep "$OBSERVABILITY_POLL_INTERVAL_SECONDS"
@@ -835,19 +1029,39 @@ PY
         echo "exact trace remained not-found through the full bounded observation poll"
         return 0
     fi
+    if [[ "$expected_state" == "observe" && "$saw_valid" == "1" ]]; then
+        cat "$safe_read"
+        rm -f "$private_read" "$safe_read"
+        return 0
+    fi
+    if [[ "$expected_state" == "observe" ]]; then
+        LAST_QUERY_MEMBERSHIP="false"
+        LAST_QUERY_OBSERVATION_COUNT="0"
+        python3 - "$trace_id" <<'PY'
+import json, sys
+print(json.dumps({
+    "trace_id": sys.argv[1], "service": [], "operation": [],
+    "observation_count": 0, "observation_type": [],
+    "approval_decision": None,
+}, sort_keys=True, separators=(",", ":")))
+PY
+        rm -f "$private_read" "$safe_read"
+        return 0
+    fi
     rm -f "$private_read" "$safe_read"
     echo "exact trace did not become queryable inside the bounded ingestion poll" >&2
     return 1
 }
 
 seed_ordinary_turn() {
-    local tier="$1" agent_id="${2:-}" marker="curie-seed-ordinary-$$-$RANDOM"
+    local tier="$1" agent_id="${2:-}" query_state="${3:-present}" marker="curie-seed-ordinary-$$-$RANDOM"
     local stream_start stream_end out trace_id expected_operations=""
     if [[ -z "$marker" || "$tier" != "local" && "$tier" != "cluster" ]]; then
         echo "seed-invalid: ordinary seed precondition failed before telemetry" >&2
         return 1
     fi
     if [[ -n "${STUB_STATE:-}" ]]; then
+        query_state="stub"
         trace_id="${STUB_OBSERVABILITY_TRACE_ID:-}"
         [[ "$trace_id" =~ ^[0-9a-f]{32}$ ]] || {
             echo "seed-invalid: stub exact trace id is absent" >&2
@@ -870,16 +1084,25 @@ seed_ordinary_turn() {
             echo "seed-invalid: ordinary seed produced no bounded stream receipt" >&2
             return 1
         }
-        trace_id="$(discover_trace_id_for_seed "$tier" "$marker" "$stream_start" "$stream_end")" || return 1
-        expected_operations="curie.queue.enqueue,curie.queue.process,curie.turn.process,curie.sandbox.claim,curie.runner.rpc,agent.run,curie.reply.post|curie.reply.update"
+        if [[ "$tier" == "cluster" ]]; then
+            capture_cluster_turn_template "$marker" "$stream_start" "$stream_end" || return 1
+            enqueue_cluster_carried_turn "$marker" "ordinary correlation $marker" || return 1
+            wait_cluster_carried_reply "$CLUSTER_SEEDED_REPLY_REF" || return 1
+            trace_id="$CLUSTER_SEEDED_TRACE_ID"
+            expected_operations="curie.queue.process,curie.turn.process,curie.sandbox.claim,curie.runner.rpc,agent.run,curie.reply.post|curie.reply.update"
+        else
+            trace_id="$(discover_trace_id_for_seed "$tier" "$marker" "$stream_start" "$stream_end")" || return 1
+            expected_operations="curie.queue.enqueue,curie.queue.process,curie.turn.process,curie.sandbox.claim,curie.runner.rpc,agent.run,curie.reply.post|curie.reply.update"
+        fi
     fi
-    query_exact_seed_trace "$tier" "$trace_id" "$expected_operations"
+    query_exact_seed_trace "$tier" "$trace_id" "$expected_operations" "" "$query_state"
     LAST_ORDINARY_TRACE_ID="$trace_id"
+    LAST_ORDINARY_MEMBERSHIP="$LAST_QUERY_MEMBERSHIP"
     printf '%s' "$trace_id"
 }
 
 seed_mcp_read_turn() {
-    local tier="$1" agent_id="${2:-}" agent_name="${3:-}" marker="curie-seed-mcp-$$-$RANDOM"
+    local tier="$1" agent_id="${2:-}" agent_name="${3:-}" query_state="${4:-present}" marker="curie-seed-mcp-$$-$RANDOM"
     local stream_start stream_end out trace_id before_count after_count alias release namespace
     if [[ "$LIVE" != "1" || -z "$agent_name" || -z "$marker" ]]; then
         echo "seed-invalid: MCP read seed needs live mode, a deployed agent, and a marker before telemetry" >&2
@@ -897,31 +1120,38 @@ seed_mcp_read_turn() {
     alias="$(connector_object_name "$release" "$agent_name" "$MCP_RECEIPT_CONNECTOR").$namespace.svc.cluster.local"
     MCP_RECEIPT_ALIAS="$alias"
     before_count="$(mcp_receipt_call_count "$tier" "$alias")" || return 1
-    stream_start="$(capture_stream_cursor "$tier")" || return 1
     if [[ "$tier" == "local" ]]; then
+        stream_start="$(capture_stream_cursor "$tier")" || return 1
         out="$("$BIN" --json local message --channel C0LOCALDEV \
             "Call the receipt_read tool exactly once, then answer receipt complete. $marker" || true)"
     else
-        out="$("$BIN" --json cluster message --namespace "$CURIE_NAMESPACE" \
-            --release "$CURIE_RELEASE" \
-            "Call the receipt_read tool exactly once, then answer receipt complete. $marker" || true)"
+        enqueue_cluster_carried_turn "$marker" \
+            "Call the receipt_read tool exactly once, then answer receipt complete. $marker" || return 1
+        wait_cluster_carried_reply "$CLUSTER_SEEDED_REPLY_REF" || return 1
     fi
-    assert_finalized_reply "$tier MCP correlation" "$out"
+    if [[ "$tier" == "local" ]]; then
+        assert_finalized_reply "$tier MCP correlation" "$out"
+    fi
     after_count="$(mcp_receipt_call_count "$tier" "$alias")" || return 1
     if (( after_count != before_count + 1 )); then
         echo "seed-invalid: MCP seed did not produce exactly one independent call receipt" >&2
         return 1
     fi
     echo "MCP receipt call count delta=1"
-    stream_end="$(capture_stream_cursor "$tier")" || return 1
-    trace_id="$(discover_trace_id_for_seed "$tier" "$marker" "$stream_start" "$stream_end")" || return 1
-    query_exact_seed_trace "$tier" "$trace_id" "execute_tool"
+    if [[ "$tier" == "local" ]]; then
+        stream_end="$(capture_stream_cursor "$tier")" || return 1
+        trace_id="$(discover_trace_id_for_seed "$tier" "$marker" "$stream_start" "$stream_end")" || return 1
+    else
+        trace_id="$CLUSTER_SEEDED_TRACE_ID"
+    fi
+    query_exact_seed_trace "$tier" "$trace_id" "execute_tool" "" "$query_state"
     LAST_MCP_TRACE_ID="$trace_id"
+    LAST_MCP_MEMBERSHIP="$LAST_QUERY_MEMBERSHIP"
     printf '%s' "$trace_id"
 }
 
 seed_approval_resume_turn() {
-    local tier="$1" agent_id="${2:-}" marker="curie-seed-approval-$$-$RANDOM"
+    local tier="$1" agent_id="${2:-}" query_state="${3:-present}" marker="curie-seed-approval-$$-$RANDOM"
     local stream_start stream_end message_file token_file pending_file approval_id token out trace_id
     local message_pid code=0 attempt
     if [[ "$LIVE" == "1" || -z "$agent_id" || -z "$marker" ]]; then
@@ -954,16 +1184,16 @@ PY
         return 1
     }
     rm -f "$token_file"
-    stream_start="$(capture_stream_cursor "$tier")" || return 1
     if [[ "$tier" == "local" ]]; then
+        stream_start="$(capture_stream_cursor "$tier")" || return 1
         "$BIN" --json local message --channel C0LOCALDEV --timeout-secs 120 \
             "[fake:request-approval:e2e] approve correlation $marker" > "$message_file" 2>/dev/null &
+        message_pid=$!
     else
-        "$BIN" --json cluster message --namespace "$CURIE_NAMESPACE" \
-            --release "$CURIE_RELEASE" --timeout-secs 120 \
-            "[fake:request-approval:e2e] approve correlation $marker" > "$message_file" 2>/dev/null &
+        enqueue_cluster_carried_turn "$marker" \
+            "[fake:request-approval:e2e] approve correlation $marker" || return 1
+        trace_id="$CLUSTER_SEEDED_TRACE_ID"
     fi
-    message_pid=$!
     approval_id=""
     for attempt in $(seq 1 60); do
         if "$BIN" --json "$tier" approvals "$agent_id" "${scope[@]}" --list > "$pending_file" 2>/dev/null; then
@@ -981,8 +1211,10 @@ PY
     done
     rm -f "$pending_file"
     if [[ -z "$approval_id" ]]; then
-        kill "$message_pid" 2>/dev/null || true
-        wait "$message_pid" 2>/dev/null || true
+        if [[ "$tier" == "local" ]]; then
+            kill "$message_pid" 2>/dev/null || true
+            wait "$message_pid" 2>/dev/null || true
+        fi
         rm -f "$message_file"
         echo "seed-invalid: awaiting-approval record did not become pending" >&2
         return 1
@@ -990,20 +1222,26 @@ PY
     CURIE_APPROVAL_PRINCIPAL_TOKEN="$token" "$BIN" --json "$tier" approvals "$agent_id" \
         "${scope[@]}" --resolve "$approval_id" >/dev/null
     unset token
-    wait "$message_pid" || code=$?
-    out="$(cat "$message_file")"
-    rm -f "$message_file"
-    if (( code != 0 )); then
-        echo "seed-invalid: approval resolution did not resume to a final reply" >&2
-        return 1
+    if [[ "$tier" == "local" ]]; then
+        wait "$message_pid" || code=$?
+        out="$(cat "$message_file")"
+        rm -f "$message_file"
+        if (( code != 0 )); then
+            echo "seed-invalid: approval resolution did not resume to a final reply" >&2
+            return 1
+        fi
+        assert_finalized_reply "$tier approval resume" "$out"
+        stream_end="$(capture_stream_cursor "$tier")" || return 1
+        trace_id="$(discover_trace_id_for_seed "$tier" "$marker" "$stream_start" "$stream_end")" || return 1
+    else
+        rm -f "$message_file"
+        wait_cluster_carried_reply "$CLUSTER_SEEDED_REPLY_REF" || return 1
     fi
-    assert_finalized_reply "$tier approval resume" "$out"
-    stream_end="$(capture_stream_cursor "$tier")" || return 1
-    trace_id="$(discover_trace_id_for_seed "$tier" "$marker" "$stream_start" "$stream_end")" || return 1
     query_exact_seed_trace "$tier" "$trace_id" \
         "curie.approval.suspend,curie.approval.resolve,curie.approval.resume,curie.reply.post|curie.reply.update" \
-        "approved"
+        "approved" "$query_state"
     LAST_APPROVAL_TRACE_ID="$trace_id"
+    LAST_APPROVAL_MEMBERSHIP="$LAST_QUERY_MEMBERSHIP"
     printf '%s' "$trace_id"
 }
 
@@ -3496,20 +3734,6 @@ PY
         echo "recovered exact trace but the durable sending queue did not drain" >&2
         return 1
     }
-    accepted="$accepted_before"
-    sent="$(product_collector_metric_value otelcol_exporter_sent_spans)"
-    python3 - "$LOCAL_PRODUCT_EVIDENCE" "$accepted" "$sent" <<'PY'
-import json, pathlib, sys
-pathlib.Path(sys.argv[1]).write_text(json.dumps({
-    "surface": "local",
-    "seed_valid": True,
-    "raw_emitted_observations": 1,
-    "otelcol_receiver_accepted_spans": float(sys.argv[2]),
-    "otelcol_exporter_sent_spans": float(sys.argv[3]),
-    "langfuse_observation_membership": True,
-    "image_ids_match": True,
-}, sort_keys=True))
-PY
     echo "local invalid-auth negative: durable same-ID recovery and queue drain proved"
 }
 
@@ -3766,21 +3990,46 @@ rung_local() {
     fi
     echo
     echo "=== exact ordinary product-observability seed ==="
-    seed_ordinary_turn local "$agent_id"
+    local product_accepted_before product_sent_before product_accepted_after product_sent_after
+    local product_accepted_delta product_sent_delta product_membership
+    if [[ -n "${STUB_STATE:-}" ]]; then
+        seed_ordinary_turn local "$agent_id" stub
+    else
+        product_accepted_before="$(product_collector_metric_value otelcol_receiver_accepted_spans)"
+        product_sent_before="$(product_collector_metric_value otelcol_exporter_sent_spans)"
+        seed_ordinary_turn local "$agent_id" observe
+        product_membership="$LAST_ORDINARY_MEMBERSHIP"
 
-    if [[ -z "${STUB_STATE:-}" && "$LIVE" == "0" ]]; then
+    if [[ "$LIVE" == "0" ]]; then
         echo
         echo "=== exact approval wait/resolve/resume product-observability seed ==="
-        seed_approval_resume_turn local "$agent_id"
+        seed_approval_resume_turn local "$agent_id" observe
+        [[ "$LAST_APPROVAL_MEMBERSHIP" == "true" ]] || product_membership="false"
     fi
-    if [[ -z "${STUB_STATE:-}" && "$LIVE" == "1" ]]; then
+    if [[ "$LIVE" == "1" ]]; then
         echo
         echo "=== exact hosted MCP read product-observability seed ==="
-        seed_mcp_read_turn local "$agent_id" "$agent_name"
+        seed_mcp_read_turn local "$agent_id" "$agent_name" observe
+        [[ "$LAST_MCP_MEMBERSHIP" == "true" ]] || product_membership="false"
     fi
 
-    if [[ -z "${STUB_STATE:-}" ]] && (( LOCAL_STACK_OWNED )); then
+    product_accepted_after="$(product_collector_metric_value otelcol_receiver_accepted_spans)"
+    product_sent_after="$(product_collector_metric_value otelcol_exporter_sent_spans)"
+    read -r product_accepted_delta product_sent_delta < <(python3 - \
+        "$product_accepted_after" "$product_accepted_before" "$product_sent_after" "$product_sent_before" <<'PY'
+import sys
+accepted_after, accepted_before, sent_after, sent_before = map(float, sys.argv[1:5])
+print(accepted_after - accepted_before, sent_after - sent_before)
+PY
+    )
+    write_product_observability_evidence "$LOCAL_PRODUCT_EVIDENCE" local \
+        "$product_accepted_delta" "$product_sent_delta" "$product_membership" not-applicable
+
+    if [[ -z "${STUB_STATE:-}" && "$LAST_ORDINARY_MEMBERSHIP" == "true" ]] && (( LOCAL_STACK_OWNED )); then
         case_local_langfuse_invalid_auth "$agent_id"
+    elif [[ -z "${STUB_STATE:-}" && "$LAST_ORDINARY_MEMBERSHIP" != "true" ]]; then
+        echo "local invalid-auth negative skipped: exact known-valid control was not queryable"
+    fi
     fi
 
     prove_local_observability_queries "$agent_id"
@@ -4037,6 +4286,7 @@ rung_local_release() {
 preflight_cluster_product_observability() {
     local namespace="${CURIE_NAMESPACE:-}" release="${CURIE_RELEASE:-}"
     local inventory component mapping tag runtime_id local_id normalized_runtime normalized_local
+    CLUSTER_IMAGE_IDS_MATCH="false"
     if [[ -z "$namespace" || -z "$release" ]]; then
         echo "product cluster mode requires explicit CURIE_NAMESPACE and CURIE_RELEASE" >&2
         return 1
@@ -4119,6 +4369,7 @@ PY
         fi
     done
     rm -f "$inventory"
+    CLUSTER_IMAGE_IDS_MATCH="true"
     echo "cluster product preflight: Ready product components and task image IDs match"
 }
 
@@ -4137,37 +4388,61 @@ print(total)
 ' "$metric"
 }
 
+write_product_observability_evidence() {
+    local destination="$1" surface="$2" accepted_delta="$3" sent_delta="$4" membership="$5" image_match="$6"
+    python3 - "$destination" "$surface" "$accepted_delta" "$sent_delta" "$membership" "$image_match" <<'PY'
+import json, pathlib, sys
+destination, surface, accepted_raw, sent_raw, membership_raw, image_raw = sys.argv[1:7]
+accepted = float(accepted_raw)
+sent = float(sent_raw)
+if membership_raw not in {"true", "false"}:
+    raise SystemExit("exact Langfuse membership was not observed")
+if image_raw not in {"true", "false", "not-applicable"}:
+    raise SystemExit("image identity verdict was not observed")
+record = {
+    "surface": surface,
+    "seed_valid": accepted > 0 and sent > 0,
+    "raw_emitted_observations": accepted,
+    "otelcol_receiver_accepted_spans": accepted,
+    "otelcol_exporter_sent_spans": sent,
+    "langfuse_observation_membership": membership_raw == "true",
+    "image_ids_match": None if image_raw == "not-applicable" else image_raw == "true",
+}
+encoded = json.dumps(record, sort_keys=True, separators=(",", ":"))
+pathlib.Path(destination).write_text(encoded)
+print(encoded)
+PY
+}
+
 run_cluster_product_observability() {
-    local agent_id="$1" agent_name="$2" accepted sent
+    local agent_id="$1" agent_name="$2" accepted_before sent_before accepted_after sent_after
+    local accepted_delta sent_delta membership
     preflight_cluster_product_observability
-    seed_ordinary_turn cluster "$agent_id"
+    accepted_before="$(cluster_collector_metric_value otelcol_receiver_accepted_spans)"
+    sent_before="$(cluster_collector_metric_value otelcol_exporter_sent_spans)"
+    seed_ordinary_turn cluster "$agent_id" observe
+    membership="$LAST_ORDINARY_MEMBERSHIP"
     if [[ "$LIVE" == "0" ]]; then
-        seed_approval_resume_turn cluster "$agent_id"
+        seed_approval_resume_turn cluster "$agent_id" observe
+        [[ "$LAST_APPROVAL_MEMBERSHIP" == "true" ]] || membership="false"
     else
-        seed_mcp_read_turn cluster "$agent_id" "$agent_name"
+        seed_mcp_read_turn cluster "$agent_id" "$agent_name" observe
+        [[ "$LAST_MCP_MEMBERSHIP" == "true" ]] || membership="false"
     fi
     # Each seed helper performs the exact candidate read equivalent to:
     # curie --json cluster observability run "$trace_id"
-    accepted="$(cluster_collector_metric_value otelcol_receiver_accepted_spans)"
-    sent="$(cluster_collector_metric_value otelcol_exporter_sent_spans)"
-    python3 -c 'import sys; raise SystemExit(0 if all(float(v) > 0 for v in sys.argv[1:]) else 1)' \
-        "$accepted" "$sent" || {
-        echo "cluster product Collector did not report positive accepted/sent spans" >&2
-        return 1
-    }
-    python3 - "$CLUSTER_PRODUCT_EVIDENCE" "$accepted" "$sent" <<'PY'
-import json, pathlib, sys
-pathlib.Path(sys.argv[1]).write_text(json.dumps({
-    "surface": "cluster",
-    "seed_valid": True,
-    "raw_emitted_observations": 1,
-    "otelcol_receiver_accepted_spans": float(sys.argv[2]),
-    "otelcol_exporter_sent_spans": float(sys.argv[3]),
-    "langfuse_observation_membership": True,
-    "image_ids_match": True,
-}, sort_keys=True))
+    accepted_after="$(cluster_collector_metric_value otelcol_receiver_accepted_spans)"
+    sent_after="$(cluster_collector_metric_value otelcol_exporter_sent_spans)"
+    read -r accepted_delta sent_delta < <(python3 - \
+        "$accepted_after" "$accepted_before" "$sent_after" "$sent_before" <<'PY'
+import sys
+accepted_after, accepted_before, sent_after, sent_before = map(float, sys.argv[1:5])
+print(accepted_after - accepted_before, sent_after - sent_before)
 PY
-    echo "cluster product observability: independent exact seed(s) exported and queried"
+    )
+    write_product_observability_evidence "$CLUSTER_PRODUCT_EVIDENCE" cluster \
+        "$accepted_delta" "$sent_delta" "$membership" "$CLUSTER_IMAGE_IDS_MATCH"
+    echo "cluster product observability: Collector deltas and exact-ID membership recorded"
 }
 
 classify_product_observability_owner() {
@@ -4190,7 +4465,7 @@ for surface in ("local", "cluster"):
     raw_emitted_observations = record.get("raw_emitted_observations", 0)
     otelcol_receiver_accepted_spans = record.get("otelcol_receiver_accepted_spans", 0)
     otelcol_exporter_sent_spans = record.get("otelcol_exporter_sent_spans", 0)
-    image_ids_match = record.get("image_ids_match") is True
+    image_ids_match = surface != "cluster" or record.get("image_ids_match") is True
     seed_valid = record.get("seed_valid") is True
     if not (
         raw_emitted_observations > 0
@@ -4202,12 +4477,14 @@ for surface in ("local", "cluster"):
         print("curie-owned: raw export, delivery, image identity, or seed precondition failed")
         raise SystemExit(0)
 
-langfuse_observation_membership = all(
-    records[surface].get("langfuse_observation_membership") is True
+memberships = dict(
+    (surface, records[surface].get("langfuse_observation_membership") is True)
     for surface in ("local", "cluster")
 )
-if not langfuse_observation_membership:
+if not memberships["local"] and not memberships["cluster"]:
     print("adopted-component: Langfuse omitted observations after successful local and cluster raw export")
+elif not all(memberships.values()):
+    print("curie-owned: local and cluster exact Langfuse membership disagreed")
 else:
     print("curie-clear: Langfuse exact observation membership passed on local and cluster")
 PY

--- a/cli/scripts/e2e-ladder.sh
+++ b/cli/scripts/e2e-ladder.sh
@@ -196,6 +196,21 @@ OBSERVABILITY_UNAVAILABLE_API_URL="http://127.0.0.1:1"
 OBSERVABILITY_POLL_ATTEMPTS=60
 OBSERVABILITY_POLL_INTERVAL_SECONDS=2
 
+# #2204 product correlation proof. Cluster product mode is intentionally
+# query-only: an operator installs a private release and loads task images
+# before invoking the ladder. The script refuses the shared defaults and never
+# installs, upgrades, uninstalls, or deletes cluster state in this mode.
+PRODUCT_OBSERVABILITY="${CURIE_E2E_PRODUCT_OBSERVABILITY:-0}"
+MCP_RECEIPT_FIXTURE="$REPO_ROOT/cli/scripts/fixtures/mcp-receipt"
+MCP_RECEIPT_CONNECTOR="mcp-receipt"
+MCP_RECEIPT_ALIAS=""
+MCP_RECEIPT_IMAGE=""
+LAST_ORDINARY_TRACE_ID=""
+LAST_MCP_TRACE_ID=""
+LAST_APPROVAL_TRACE_ID=""
+LOCAL_PRODUCT_EVIDENCE=""
+CLUSTER_PRODUCT_EVIDENCE=""
+
 # The component label every connector container carries, in both the skill start
 # path and the local compose overlay (cli/src/docker.rs
 # CONNECTOR_COMPONENT_LABEL). Teardown reaps by label, so this is the only
@@ -293,6 +308,8 @@ fi
 "$BIN" --version
 
 WORKDIR="$(mktemp -d)"
+LOCAL_PRODUCT_EVIDENCE="$WORKDIR/product-observability-local.json"
+CLUSTER_PRODUCT_EVIDENCE="$WORKDIR/product-observability-cluster.json"
 cleanup() {
     # Capture the real exit code FIRST: a teardown command that fails must not
     # turn a red run green, and a successful teardown must not mask a red rung.
@@ -349,6 +366,14 @@ cleanup() {
             echo "sweeping stranded connector container $survivor"
             docker rm -f "$survivor" >/dev/null 2>&1
         done
+    fi
+    if [[ -n "$MCP_RECEIPT_ALIAS" ]]; then
+        local receipt_container
+        receipt_container="$(connector_container_for_alias "$MCP_RECEIPT_ALIAS" 2>/dev/null)" || receipt_container=""
+        if [[ -n "$receipt_container" ]]; then
+            echo "sweeping stranded MCP receipt connector"
+            docker rm -f "$receipt_container" >/dev/null 2>&1
+        fi
     fi
     rm -rf "$WORKDIR"
     exit "$code"
@@ -523,6 +548,440 @@ print(start.strftime("%Y-%m-%dT%H:%M:%SZ"), end.strftime("%Y-%m-%dT%H:%M:%SZ"))
     echo "local observability metrics: captured explicit UTC window $OBSERVABILITY_START through $OBSERVABILITY_END around the just-completed local turn"
 }
 
+# Execute a read-only Valkey command against the product runs stream. Passwords
+# stay inside the selected container/pod and no command output is logged.
+product_stream_json() {
+    local tier="$1"
+    shift
+    case "$tier" in
+        local)
+            local valkey
+            valkey="$(docker ps \
+                --filter 'label=com.docker.compose.project=curie' \
+                --filter 'label=com.docker.compose.service=valkey' \
+                --format '{{.Names}}')"
+            [[ -n "$valkey" && "$valkey" != *$'\n'* ]] || {
+                echo "seed-invalid: expected exactly one product Valkey container" >&2
+                return 1
+            }
+            docker exec "$valkey" sh -c \
+                'VALKEYCLI_AUTH="${VALKEY_PASSWORD:-}" exec valkey-cli --json "$@"' \
+                sh "$@"
+            ;;
+        cluster)
+            local pod
+            pod="$(kubectl -n "$CURIE_NAMESPACE" get pods \
+                -l "app.kubernetes.io/instance=$CURIE_RELEASE,app.kubernetes.io/name=valkey" \
+                -o json | python3 -c '
+import json, sys
+ready = []
+for item in json.load(sys.stdin).get("items", []):
+    conditions = item.get("status", {}).get("conditions", [])
+    if any(c.get("type") == "Ready" and c.get("status") == "True" for c in conditions):
+        ready.append(item["metadata"]["name"])
+if len(ready) != 1:
+    raise SystemExit("expected exactly one Ready product Valkey pod")
+print(ready[0])
+')" || return 1
+            kubectl -n "$CURIE_NAMESPACE" exec "$pod" -- sh -c \
+                'VALKEYCLI_AUTH="${VALKEY_PASSWORD:-}" exec valkey-cli --json "$@"' \
+                sh "$@"
+            ;;
+        *)
+            echo "seed-invalid: unknown product stream tier" >&2
+            return 1
+            ;;
+    esac
+}
+
+capture_stream_cursor() {
+    local tier="$1" result
+    result="$(product_stream_json "$tier" XREVRANGE curie:runs + - COUNT 1)" || return 1
+    printf '%s' "$result" | python3 -c '
+import json, sys
+rows = json.load(sys.stdin)
+if not rows:
+    print("0-0")
+elif len(rows) == 1 and isinstance(rows[0], list) and isinstance(rows[0][0], str):
+    print(rows[0][0])
+else:
+    raise SystemExit("seed-invalid: malformed bounded stream cursor response")
+'
+}
+
+# Locate this seed's exact stream entry between two cursors, then extract only
+# the adjacent W3C carrier's 32-hex trace id. The private XRANGE slice is mode
+# 0600 and is deleted without ever being echoed, so payload and traceparent
+# bytes cannot enter public evidence.
+discover_trace_id_for_seed() {
+    local tier="$1" marker="$2" stream_start="$3" stream_end="$4"
+    local private_slice trace_id
+    umask 077
+    private_slice="$(mktemp "$WORKDIR/seed-stream.XXXXXX")"
+    if [[ -z "$marker" || -z "$stream_start" || -z "$stream_end" ]]; then
+        rm -f "$private_slice"
+        echo "seed-invalid: marker and bounded stream cursors are required" >&2
+        return 1
+    fi
+    product_stream_json "$tier" XRANGE curie:runs "($stream_start" "$stream_end" > "$private_slice" || {
+        rm -f "$private_slice"
+        return 1
+    }
+    trace_id="$(python3 - "$private_slice" "$marker" <<'PY'
+import json
+import pathlib
+import re
+import sys
+
+rows = json.loads(pathlib.Path(sys.argv[1]).read_text())
+marker = sys.argv[2]
+carrier = re.compile(r"^00-([0-9a-f]{32})-[0-9a-f]{16}-[0-9a-f]{2}$")
+
+def exact_marker(value):
+    if value == marker:
+        return True
+    if isinstance(value, dict):
+        return any(exact_marker(item) for item in value.values())
+    if isinstance(value, list):
+        return any(exact_marker(item) for item in value)
+    return False
+
+matches = []
+for row in rows:
+    if not isinstance(row, list) or len(row) != 2 or not isinstance(row[1], list):
+        raise SystemExit("seed-invalid: malformed bounded XRANGE entry")
+    fields = row[1]
+    if len(fields) % 2:
+        raise SystemExit("seed-invalid: malformed stream field pairs")
+    for index in range(0, len(fields), 2):
+        if fields[index] != "payload" or index + 3 >= len(fields):
+            continue
+        if fields[index + 2] != "traceparent":
+            continue
+        try:
+            payload = json.loads(fields[index + 1])
+        except (TypeError, json.JSONDecodeError):
+            continue
+        match = carrier.fullmatch(fields[index + 3]) if isinstance(fields[index + 3], str) else None
+        if exact_marker(payload) and match:
+            matches.append(match.group(1))
+matches = sorted(set(matches))
+if len(matches) != 1:
+    raise SystemExit("seed-invalid: exact marker did not select one adjacent carrier")
+print(matches[0])
+PY
+)" || {
+        rm -f "$private_slice"
+        return 1
+    }
+    rm -f "$private_slice"
+    [[ "$trace_id" =~ ^[0-9a-f]{32}$ ]] || {
+        echo "seed-invalid: selected carrier did not contain a 32-hex trace id" >&2
+        return 1
+    }
+    printf '%s' "$trace_id"
+}
+
+# Convert a private exact-detail response into the sole public trace evidence.
+# Explicitly private source fields (input, output, session, user, headers) are
+# ignored. Operation names are reduced to a code-owned allowlist.
+sanitize_exact_trace_read() {
+    local trace_id="$1" private_read="$2" expected_csv="${3:-}" expected_decision="${4:-}"
+    python3 - "$trace_id" "$private_read" "$expected_csv" "$expected_decision" <<'PY'
+import json
+import pathlib
+import sys
+
+trace_id, source, expected_csv, expected_decision = sys.argv[1:5]
+value = json.loads(pathlib.Path(source).read_text())
+trace = value.get("trace") if isinstance(value, dict) else None
+tree = value.get("tree") if isinstance(value, dict) else None
+if not isinstance(trace, dict) or trace.get("id") != trace_id or not isinstance(tree, list):
+    raise SystemExit("exact trace response did not match the requested id and tree shape")
+
+private_fields = {"input", "output", "session", "user", "headers"}
+safe_operations = {
+    "curie.queue.enqueue", "curie.queue.process", "curie.turn.process",
+    "curie.sandbox.claim", "curie.runner.rpc", "agent.run", "execute_tool",
+    "curie.reply.post", "curie.reply.update", "curie.slack.receipt",
+    "curie.approval.wait", "curie.approval.resolve", "curie.approval.resume",
+    "approval.wait", "approval.resolve", "approval.resume",
+    }
+operations = []
+types = set()
+observation_count = [0]
+
+def walk(node):
+    if not isinstance(node, dict):
+        raise SystemExit("exact trace tree contains a non-object node")
+    # Deliberately never dereference values in private_fields.
+    if private_fields.intersection(node):
+        pass
+    observation_count[0] += 1
+    name = node.get("name")
+    kind = node.get("type")
+    if name in safe_operations:
+        operations.append(name)
+    if isinstance(kind, str) and kind.upper() in {"SPAN", "GENERATION", "EVENT"}:
+        types.add(kind.upper())
+    children = node.get("children")
+    if not isinstance(children, list):
+        raise SystemExit("exact trace node omitted its child array")
+    for child in children:
+        walk(child)
+
+for root in tree:
+    walk(root)
+expected = [item for item in expected_csv.split(",") if item]
+missing = [item for item in expected if not any(candidate in operations for candidate in item.split("|"))]
+if missing:
+    raise SystemExit("exact trace omitted required allowlisted operations")
+decision = value.get("approval_decision")
+if decision is not None and decision not in {"approved", "rejected", "expired"}:
+    raise SystemExit("exact trace carried a non-allowlisted approval decision")
+if expected_decision and decision != expected_decision:
+    raise SystemExit("exact trace carried the wrong approval decision")
+
+service = []
+if any(op == "curie.queue.enqueue" for op in operations):
+    service.append("curie-dispatcher")
+if any(op.startswith("curie.queue.") or op.startswith("curie.turn.") or op.startswith("curie.sandbox.") or op.startswith("curie.approval.") for op in operations):
+    service.append("curie-worker")
+if any(op in {"curie.runner.rpc", "agent.run", "execute_tool"} for op in operations):
+    service.append("curie-runner")
+sanitized = {
+    "trace_id": trace_id,
+    "service": sorted(set(service)),
+    "operation": sorted(set(operations)),
+    "observation_count": observation_count[0],
+    "observation_type": sorted(types),
+    "approval_decision": decision,
+    }
+allowed_evidence_fields = {
+    "trace_id", "service", "operation", "observation_count",
+    "observation_type", "approval_decision",
+    }
+if set(sanitized) != allowed_evidence_fields:
+    raise SystemExit("sanitized evidence field set drifted")
+print(json.dumps(sanitized, sort_keys=True, separators=(",", ":")))
+PY
+}
+
+# Query one exact ID only. Raw CLI output remains in a mode-0600 file and only
+# sanitize_exact_trace_read reaches stdout.
+query_exact_seed_trace() {
+    local tier="$1" trace_id="$2" expected_csv="${3:-}" expected_decision="${4:-}" expected_state="${5:-present}"
+    local attempt code=0 private_read safe_read
+    umask 077
+    private_read="$(mktemp "$WORKDIR/exact-trace.XXXXXX")"
+    safe_read="$(mktemp "$WORKDIR/safe-trace.XXXXXX")"
+    [[ "$trace_id" =~ ^[0-9a-f]{32}$ ]] || {
+        rm -f "$private_read" "$safe_read"
+        echo "seed-invalid: exact trace id is not 32 lowercase hex characters" >&2
+        return 1
+    }
+    for attempt in $(seq 1 "$OBSERVABILITY_POLL_ATTEMPTS"); do
+        code=0
+        if [[ "$tier" == "local" ]]; then
+            "$BIN" --json local observability run "$trace_id" > "$private_read" 2>/dev/null || code=$?
+        elif [[ "$tier" == "cluster" ]]; then
+            "$BIN" --json cluster observability --namespace "$CURIE_NAMESPACE" \
+                --release "$CURIE_RELEASE" run "$trace_id" > "$private_read" 2>/dev/null || code=$?
+        else
+            rm -f "$private_read" "$safe_read"
+            echo "seed-invalid: exact trace query tier is unknown" >&2
+            return 1
+        fi
+        if [[ "$expected_state" == "absent" ]]; then
+            rm -f "$private_read" "$safe_read"
+            if (( code == 1 )); then
+                echo "exact trace temporarily absent as required"
+                return 0
+            fi
+            echo "exact trace was queryable while the exporter was required to be failing" >&2
+            return 1
+        fi
+        if (( code == 0 )) && sanitize_exact_trace_read "$trace_id" "$private_read" "$expected_csv" "$expected_decision" > "$safe_read"; then
+            cat "$safe_read"
+            rm -f "$private_read" "$safe_read"
+            return 0
+        fi
+        if (( attempt < OBSERVABILITY_POLL_ATTEMPTS )); then
+            sleep "$OBSERVABILITY_POLL_INTERVAL_SECONDS"
+        fi
+    done
+    rm -f "$private_read" "$safe_read"
+    echo "exact trace did not become queryable inside the bounded ingestion poll" >&2
+    return 1
+}
+
+seed_ordinary_turn() {
+    local tier="$1" agent_id="${2:-}" marker="curie-seed-ordinary-$$-$RANDOM"
+    local stream_start stream_end out trace_id expected_operations=""
+    if [[ -z "$marker" || "$tier" != "local" && "$tier" != "cluster" ]]; then
+        echo "seed-invalid: ordinary seed precondition failed before telemetry" >&2
+        return 1
+    fi
+    if [[ -n "${STUB_STATE:-}" ]]; then
+        trace_id="${STUB_OBSERVABILITY_TRACE_ID:-}"
+        [[ "$trace_id" =~ ^[0-9a-f]{32}$ ]] || {
+            echo "seed-invalid: stub exact trace id is absent" >&2
+            return 1
+        }
+    else
+        stream_start="$(capture_stream_cursor "$tier")" || return 1
+        if [[ "$tier" == "local" ]]; then
+            out="$("$BIN" --json local message --channel C0LOCALDEV "ordinary correlation $marker" || true)"
+        else
+            out="$("$BIN" --json cluster message --namespace "$CURIE_NAMESPACE" \
+                --release "$CURIE_RELEASE" "ordinary correlation $marker" || true)"
+        fi
+        assert_finalized_reply "$tier ordinary correlation" "$out"
+        if [[ "$tier" == "local" ]]; then
+            assert_product_runner_endpoints
+        fi
+        stream_end="$(capture_stream_cursor "$tier")" || return 1
+        [[ "$stream_end" != "$stream_start" ]] || {
+            echo "seed-invalid: ordinary seed produced no bounded stream receipt" >&2
+            return 1
+        }
+        trace_id="$(discover_trace_id_for_seed "$tier" "$marker" "$stream_start" "$stream_end")" || return 1
+        expected_operations="curie.queue.enqueue,curie.queue.process,curie.turn.process,curie.sandbox.claim,curie.runner.rpc,agent.run,curie.reply.post|curie.reply.update"
+    fi
+    query_exact_seed_trace "$tier" "$trace_id" "$expected_operations"
+    LAST_ORDINARY_TRACE_ID="$trace_id"
+    printf '%s' "$trace_id"
+}
+
+seed_mcp_read_turn() {
+    local tier="$1" agent_id="${2:-}" agent_name="${3:-}" marker="curie-seed-mcp-$$-$RANDOM"
+    local stream_start stream_end out trace_id before_count after_count alias release namespace
+    if [[ "$LIVE" != "1" || -z "$agent_name" || -z "$marker" ]]; then
+        echo "seed-invalid: MCP read seed needs live mode, a deployed agent, and a marker before telemetry" >&2
+        return 1
+    fi
+    if [[ "$tier" == "local" ]]; then
+        local worker
+        worker="$(local_worker_container)"
+        release="$(container_env_value "$worker" CURIE_RELEASE)"
+        namespace="$(container_env_value "$worker" CURIE_NAMESPACE)"
+    else
+        release="$CURIE_RELEASE"
+        namespace="$CURIE_NAMESPACE"
+    fi
+    alias="$(connector_object_name "$release" "$agent_name" "$MCP_RECEIPT_CONNECTOR").$namespace.svc.cluster.local"
+    MCP_RECEIPT_ALIAS="$alias"
+    before_count="$(mcp_receipt_call_count "$tier" "$alias")" || return 1
+    stream_start="$(capture_stream_cursor "$tier")" || return 1
+    if [[ "$tier" == "local" ]]; then
+        out="$("$BIN" --json local message --channel C0LOCALDEV \
+            "Call the receipt_read tool exactly once, then answer receipt complete. $marker" || true)"
+    else
+        out="$("$BIN" --json cluster message --namespace "$CURIE_NAMESPACE" \
+            --release "$CURIE_RELEASE" \
+            "Call the receipt_read tool exactly once, then answer receipt complete. $marker" || true)"
+    fi
+    assert_finalized_reply "$tier MCP correlation" "$out"
+    after_count="$(mcp_receipt_call_count "$tier" "$alias")" || return 1
+    if (( after_count != before_count + 1 )); then
+        echo "seed-invalid: MCP seed did not produce exactly one independent call receipt" >&2
+        return 1
+    fi
+    echo "MCP receipt call count delta=1"
+    stream_end="$(capture_stream_cursor "$tier")" || return 1
+    trace_id="$(discover_trace_id_for_seed "$tier" "$marker" "$stream_start" "$stream_end")" || return 1
+    query_exact_seed_trace "$tier" "$trace_id" "execute_tool"
+    LAST_MCP_TRACE_ID="$trace_id"
+    printf '%s' "$trace_id"
+}
+
+seed_approval_resume_turn() {
+    local tier="$1" agent_id="${2:-}" marker="curie-seed-approval-$$-$RANDOM"
+    local stream_start stream_end message_file token_file pending_file approval_id token out trace_id
+    local message_pid code=0 attempt
+    if [[ "$LIVE" == "1" || -z "$agent_id" || -z "$marker" ]]; then
+        echo "seed-invalid: deterministic approval seed needs fake mode and a deployed agent before telemetry" >&2
+        return 1
+    fi
+    umask 077
+    message_file="$(mktemp "$WORKDIR/approval-message.XXXXXX")"
+    token_file="$(mktemp "$WORKDIR/approval-token.XXXXXX")"
+    pending_file="$(mktemp "$WORKDIR/approval-pending.XXXXXX")"
+    local scope=()
+    if [[ "$tier" == "cluster" ]]; then
+        scope=(--namespace "$CURIE_NAMESPACE" --release "$CURIE_RELEASE")
+    fi
+    "$BIN" --json "$tier" approvals "$agent_id" "${scope[@]}" \
+        --route-resolution e2e=C0EXAMPLE1 --route-approvers e2e=users:U0EXAMPLE1 \
+        >/dev/null
+    "$BIN" --json "$tier" approvals "$agent_id" "${scope[@]}" \
+        --mint-operator-principal U0EXAMPLE1 > "$token_file"
+    token="$(python3 - "$token_file" <<'PY'
+import json, pathlib, sys
+value = json.loads(pathlib.Path(sys.argv[1]).read_text())
+token = value.get("operator_principal", {}).get("token")
+if not isinstance(token, str) or not token:
+    raise SystemExit("operator principal response omitted its token")
+print(token)
+PY
+)" || {
+        rm -f "$message_file" "$token_file" "$pending_file"
+        return 1
+    }
+    rm -f "$token_file"
+    stream_start="$(capture_stream_cursor "$tier")" || return 1
+    if [[ "$tier" == "local" ]]; then
+        "$BIN" --json local message --channel C0LOCALDEV --timeout-secs 120 \
+            "[fake:request-approval:e2e] approve correlation $marker" > "$message_file" 2>/dev/null &
+    else
+        "$BIN" --json cluster message --namespace "$CURIE_NAMESPACE" \
+            --release "$CURIE_RELEASE" --timeout-secs 120 \
+            "[fake:request-approval:e2e] approve correlation $marker" > "$message_file" 2>/dev/null &
+    fi
+    message_pid=$!
+    approval_id=""
+    for attempt in $(seq 1 60); do
+        if "$BIN" --json "$tier" approvals "$agent_id" "${scope[@]}" --list > "$pending_file" 2>/dev/null; then
+            approval_id="$(python3 - "$pending_file" <<'PY'
+import json, pathlib, sys
+value = json.loads(pathlib.Path(sys.argv[1]).read_text())
+rows = value.get("pending", [])
+matches = [row.get("id") for row in rows if row.get("status") == "pending" and row.get("route") == "e2e"]
+print(matches[0] if len(matches) == 1 and isinstance(matches[0], str) else "")
+PY
+)"
+            [[ -n "$approval_id" ]] && break
+        fi
+        sleep 1
+    done
+    rm -f "$pending_file"
+    if [[ -z "$approval_id" ]]; then
+        kill "$message_pid" 2>/dev/null || true
+        wait "$message_pid" 2>/dev/null || true
+        rm -f "$message_file"
+        echo "seed-invalid: awaiting-approval record did not become pending" >&2
+        return 1
+    fi
+    CURIE_APPROVAL_PRINCIPAL_TOKEN="$token" "$BIN" --json "$tier" approvals "$agent_id" \
+        "${scope[@]}" --resolve "$approval_id" >/dev/null
+    unset token
+    wait "$message_pid" || code=$?
+    out="$(cat "$message_file")"
+    rm -f "$message_file"
+    if (( code != 0 )); then
+        echo "seed-invalid: approval resolution did not resume to a final reply" >&2
+        return 1
+    fi
+    assert_finalized_reply "$tier approval resume" "$out"
+    stream_end="$(capture_stream_cursor "$tier")" || return 1
+    trace_id="$(discover_trace_id_for_seed "$tier" "$marker" "$stream_start" "$stream_end")" || return 1
+    query_exact_seed_trace "$tier" "$trace_id" \
+        "curie.approval.wait,curie.approval.resolve,curie.approval.resume,curie.reply.post|curie.reply.update" \
+        "approved"
+    LAST_APPROVAL_TRACE_ID="$trace_id"
+    printf '%s' "$trace_id"
+}
+
 # Langfuse ingestion is asynchronous to turn finalization. Poll through the
 # candidate CLI, never its backing API. Scan one bounded newest-first page and
 # select the newest complete row. The returned id is the sole input to the
@@ -530,10 +989,10 @@ print(start.strftime("%Y-%m-%dT%H:%M:%SZ"), end.strftime("%Y-%m-%dT%H:%M:%SZ"))
 # Correlation to this rung is proved independently by the explicit-window
 # metrics reads below; trace-list DTOs do not promise an agent identity field.
 discover_local_observability_trace() {
-    local attempt out code verdict state detail
+    local attempt out code verdict state detail limit=100
     DISCOVERED_OBSERVABILITY_TRACE_ID=""
     for attempt in $(seq 1 "$OBSERVABILITY_POLL_ATTEMPTS"); do
-        out="$("$BIN" --json local observability runs --limit 100)" && code=0 || code=$?
+        out="$("$BIN" --json local observability runs --limit "$limit")" && code=0 || code=$?
         if (( code != 0 )); then
             echo "local observability runs: bounded ingestion read exited $code, expected 0." >&2
             printf '%s\n' "$out" >&2
@@ -751,25 +1210,18 @@ else:
 }
 
 prove_local_observability_queries() {
-    local agent_id="$1" out code trace_id
+    local agent_id="$1" out code
 
     derive_observability_window
 
-    echo
-    echo "=== curie local observability runs --json (bounded ingestion poll) ==="
-    discover_local_observability_trace
-    trace_id="$DISCOVERED_OBSERVABILITY_TRACE_ID"
-
-    echo
-    echo "=== curie local observability run --json (discovered trace) ==="
-    out="$("$BIN" --json local observability run "$trace_id")" && code=0 || code=$?
-    if (( code != 0 )); then
-        echo "local observability run: discovered trace detail exited $code, expected 0." >&2
-        printf '%s\n' "$out" >&2
+    # seed_ordinary_turn has already made the only exact read through
+    # query_exact_seed_trace, whose sole public output comes from
+    # sanitize_exact_trace_read. Keeping the receipt here prevents metrics and
+    # negatives from running after a seed-invalid path.
+    if [[ ! "$LAST_ORDINARY_TRACE_ID" =~ ^[0-9a-f]{32}$ ]]; then
+        echo "local observability: ordinary exact-trace seed receipt is absent" >&2
         return 1
     fi
-    printf '%s\n' "$out"
-    assert_local_observability_detail "$trace_id" "$out"
 
     echo
     echo "=== curie local observability metrics --json (explicit UTC window) ==="
@@ -1450,6 +1902,26 @@ prepare_connector_bundle() {
     echo "connector fixture applied to $dir (connectors.yaml)"
 }
 
+# Add the independently countable, read-only MCP receipt server to a scratch
+# bundle. It goes through the ordinary connector build/lock path; no in-sandbox
+# file can be evidence because the sandbox is destroyed with the turn.
+prepare_mcp_receipt_bundle() {
+    local dir="$1"
+    local destination="$dir/connectors/mcp-receipt"
+    mkdir -p "$destination"
+    cp "$MCP_RECEIPT_FIXTURE/Dockerfile" "$MCP_RECEIPT_FIXTURE/server.py" "$destination/"
+    if [[ ! -f "$dir/connectors.yaml" ]]; then
+        printf '%s\n' 'connectors:' > "$dir/connectors.yaml"
+    fi
+    cat >> "$dir/connectors.yaml" <<'YAML'
+  mcp-receipt:
+    build:
+      context: connectors/mcp-receipt
+      platforms: [linux/amd64, linux/arm64]
+YAML
+    echo "MCP receipt fixture applied to $dir (fixtures/mcp-receipt)"
+}
+
 # One build before the first rung, so every rung consumes the same lock and the
 # bundle bytes each rung packs are identical (the PARITY_DIGEST assertion).
 #
@@ -1582,6 +2054,41 @@ connector_container_for_alias() {
         fi
     done < <(docker ps --filter "label=$CONNECTOR_LABEL" --format '{{.Names}}')
     return 1
+}
+
+# Read only the aggregate number of deterministic call markers. Neither the
+# marker lines nor any connector log payload is emitted into the evidence.
+mcp_receipt_call_count() {
+    local tier="$1" alias="$2" count=0 container pod
+    case "$tier" in
+        local)
+            container="$(connector_container_for_alias "$alias")" || {
+                echo "MCP receipt connector is not hosted at the expected alias" >&2
+                return 1
+            }
+            count="$(docker logs "$container" 2>&1 | awk '$0 == "MCP_RECEIPT tools/call" { count++ } END { print count + 0 }')"
+            ;;
+        cluster)
+            pod="$(kubectl -n "$CURIE_NAMESPACE" get pods \
+                -l "app.kubernetes.io/instance=$CURIE_RELEASE,curietech.ai/component=connector" \
+                -o json | python3 -c '
+import json, sys
+items = json.load(sys.stdin).get("items", [])
+want = sys.argv[1]
+matches = [item["metadata"]["name"] for item in items if want in item["metadata"]["name"]]
+if len(matches) != 1:
+    raise SystemExit("expected exactly one MCP receipt connector pod")
+print(matches[0])
+' "$MCP_RECEIPT_CONNECTOR")" || return 1
+            count="$(kubectl -n "$CURIE_NAMESPACE" logs "$pod" 2>/dev/null | awk '$0 == "MCP_RECEIPT tools/call" { count++ } END { print count + 0 }')"
+            ;;
+        *)
+            echo "unknown MCP receipt tier" >&2
+            return 1
+            ;;
+    esac
+    [[ "$count" =~ ^[0-9]+$ ]] || return 1
+    printf '%s' "$count"
 }
 
 # The MCP probe itself: an initialize / notifications/initialized / tools/list
@@ -2827,29 +3334,271 @@ restore_local_runner_health() {
     sleep 3
 }
 
+assert_product_collector_endpoint() {
+    local service="$1" container="$2" expected_endpoint="$3" expected_protocol="$4"
+    local endpoint protocol
+    endpoint="$(container_env_value "$container" OTEL_EXPORTER_OTLP_ENDPOINT)"
+    protocol="$(container_env_value "$container" OTEL_EXPORTER_OTLP_PROTOCOL)"
+    if [[ "$endpoint" != "$expected_endpoint" || "$protocol" != "$expected_protocol" ]]; then
+        echo "local observability: $service exporter does not target the shipped product Collector" >&2
+        return 1
+    fi
+    echo "local observability: $service exporter endpoint/protocol verified"
+}
+
+assert_product_runner_endpoints() {
+    local runners=() runner
+    while IFS= read -r runner; do
+        [[ -n "$runner" ]] && runners+=("$runner")
+    done < <(docker ps --filter "label=$SANDBOX_LABEL" --format '{{.Names}}')
+    (( ${#runners[@]} > 0 )) || {
+        echo "local observability: no actual curie-runner emitter survived long enough to inspect" >&2
+        return 1
+    }
+    for runner in "${runners[@]}"; do
+        assert_product_collector_endpoint curie-runner "$runner" \
+            "http://otel-collector:4318" "http/protobuf"
+    done
+}
+
 # The independent sink above proves raw telemetry crossed every service
 # boundary, but it deliberately replaces the product Collector endpoint. Once
-# those controls finish, put only the worker (and therefore newly spawned
-# runners) back on the shipped Collector so the API-backed #866 queries can
-# prove the product read path without changing the Collector configuration.
+# those controls finish, restore every actual emitter before seeding Langfuse.
 route_local_observability_to_product_collector() {
     if [[ -n "${STUB_STATE:-}" ]] || (( ! LOCAL_OTEL_SINK_ACTIVE )); then
         return 0
     fi
 
     unset OTEL_EXPORTER_OTLP_ENDPOINT OTEL_EXPORTER_OTLP_PROTOCOL
+    local stale runner dispatcher=""
+    # An already-running curie-runner inherited the disposable endpoint. Reap
+    # only this task-owned stack's scoped sandboxes so every later runner is
+    # freshly launched from the restored worker environment.
+    if (( LOCAL_STACK_OWNED )); then
+        while IFS= read -r runner; do
+            [[ -n "$runner" ]] || continue
+            if [[ "$(container_env_value "$runner" CURIE_RELEASE)" == "curie" ]]; then
+                docker rm -f "$runner" >/dev/null
+            fi
+        done < <(docker ps --filter "label=$SANDBOX_LABEL" --format '{{.Names}}')
+    fi
     docker compose --profile core --profile full -f "$REPO_ROOT/compose.dev.yaml" \
-        up -d --force-recreate --no-deps curie-worker >/dev/null
+        up -d --force-recreate --no-deps curie-api curie-worker >/dev/null
+    dispatcher="$(docker ps \
+        --filter 'label=com.docker.compose.project=curie' \
+        --filter 'label=com.docker.compose.service=curie-dispatcher' \
+        --format '{{.Names}}')"
+    if [[ -n "$dispatcher" ]]; then
+        docker compose --profile slack -f "$REPO_ROOT/compose.dev.yaml" \
+            up -d --force-recreate --no-deps curie-dispatcher >/dev/null
+    fi
     sleep 3
 
-    local worker endpoint
+    local api worker
+    api="$(docker ps --filter 'label=com.docker.compose.project=curie' \
+        --filter 'label=com.docker.compose.service=curie-api' --format '{{.Names}}')"
     worker="$(local_worker_container)"
-    endpoint="$(container_env_value "$worker" OTEL_EXPORTER_OTLP_ENDPOINT)"
-    if [[ "$endpoint" != "http://otel-collector:4318" ]]; then
-        echo "local observability: worker still targets '$endpoint', expected the product Collector." >&2
+    assert_product_collector_endpoint curie-api "$api" \
+        "http://otel-collector:4318" "http/protobuf"
+    assert_product_collector_endpoint curie-worker "$worker" \
+        "http://otel-collector:4318" "http/protobuf"
+    if [[ -n "$dispatcher" ]]; then
+        dispatcher="$(docker ps --filter 'label=com.docker.compose.project=curie' \
+            --filter 'label=com.docker.compose.service=curie-dispatcher' --format '{{.Names}}')"
+        assert_product_collector_endpoint curie-dispatcher "$dispatcher" \
+            "http://otel-collector:4318" "http/protobuf"
+    else
+        # curie local message launches the curie-dispatcher image after these
+        # exports are unset; the adjacent stream carrier and exact trace prove
+        # that actual one-shot emitter rather than a config-only assertion.
+        echo "local observability: curie-dispatcher one-shot will inherit product routing"
+    fi
+    # curie-runner is asserted after the first post-restore turn, when an
+    # actual sandbox emitter exists to inspect.
+    echo "local observability: curie-api, curie-dispatcher, curie-worker, and curie-runner routing restored"
+}
+
+product_collector_metric_value() {
+    local metric="$1"
+    curl -fsS http://127.0.0.1:28888/metrics | python3 -c '
+import re, sys
+name = sys.argv[1]
+total = 0.0
+for line in sys.stdin:
+    if re.match(r"^" + re.escape(name) + r"(?:\{|\s)", line):
+        total += float(line.rsplit(None, 1)[1])
+print(total)
+' "$metric"
+}
+
+wait_product_collector_ready() {
+    local attempt
+    for attempt in $(seq 1 60); do
+        if curl -fsS http://127.0.0.1:28888/metrics >/dev/null 2>&1; then
+            # The Collector's startup contract logs "Everything is ready";
+            # the live self-metrics endpoint is the stronger Ready probe.
+            return 0
+        fi
+        sleep 1
+    done
+    echo "product Collector did not become Ready" >&2
+    return 1
+}
+
+restart_local_product_collector() {
+    docker compose --profile full -f "$REPO_ROOT/compose.dev.yaml" \
+        up -d --force-recreate --no-deps otel-collector >/dev/null
+    wait_product_collector_ready
+}
+
+restore_local_langfuse_auth() {
+    local was_set="$1" original="$2"
+    if [[ "$was_set" == "1" ]]; then
+        export LANGFUSE_OTLP_AUTH_HEADER="$original"
+    else
+        unset LANGFUSE_OTLP_AUTH_HEADER
+    fi
+    restart_local_product_collector
+}
+
+# Exercise the pinned Langfuse exporter with temporary invalid auth while the
+# shipped retry_on_failure (5s/30s/5m) and sending_queue/file_storage settings
+# remain unchanged. The queue_size is 1000; no volume is removed.
+case_local_langfuse_invalid_auth() {
+    local INVALID_LANGFUSE_OTLP_AUTH_HEADER='Basic aW52YWxpZDppbnZhbGlk'
+    local agent_id="$1" original_set=0 original="${LANGFUSE_OTLP_AUTH_HEADER-}"
+    local receipt same_queued_trace_id queue_drained accepted accepted_before sent langfuse_web
+    local collector storage_directory
+    [[ ${LANGFUSE_OTLP_AUTH_HEADER+x} ]] && original_set=1
+    langfuse_web="$(docker compose --profile full -f "$REPO_ROOT/compose.dev.yaml" ps -q langfuse-web)"
+    [[ -n "$langfuse_web" ]] || {
+        echo "pinned langfuse-web is not running for the real exporter negative" >&2
+        return 1
+    }
+    storage_directory="$(python3 - "$REPO_ROOT/otel/collector-config.yaml" <<'PY'
+import pathlib, re, sys
+text = pathlib.Path(sys.argv[1]).read_text()
+required = {
+    "sending_queue": r"(?m)^\s*sending_queue:\s*$",
+    "file_storage": r"(?m)^\s*storage:\s*file_storage\s*$",
+    "queue_size": r"(?m)^\s*queue_size:\s*1000\s*$",
+    "retry_horizon": r"(?m)^\s*max_elapsed_time:\s*5m\s*$",
+    }
+missing = [name for name, pattern in required.items() if not re.search(pattern, text)]
+directory = re.search(r"(?m)^\s*directory:\s*([^#\s]+)", text)
+if missing or directory is None:
+    raise SystemExit("shipped Collector durable queue configuration is absent")
+print(directory.group(1))
+PY
+)" || return 1
+    collector="$(docker compose --profile full -f "$REPO_ROOT/compose.dev.yaml" ps -q otel-collector)"
+    docker inspect "$collector" --format '{{json .Mounts}}' | python3 -c '
+import json, os, sys
+mounts = json.load(sys.stdin)
+directory = os.path.normpath(sys.argv[1])
+if not any(
+    directory == os.path.normpath(item.get("Destination", ""))
+    or directory.startswith(os.path.normpath(item.get("Destination", "")) + os.sep)
+    for item in mounts
+    if item.get("Type") == "volume" and item.get("Destination")
+):
+    raise SystemExit("file_storage directory is not backed by a Docker volume")
+' "$storage_directory" || return 1
+    receipt="$(mktemp "$WORKDIR/invalid-auth-trace.XXXXXX")"
+    chmod 600 "$receipt"
+
+    echo
+    echo "=== case: pinned Langfuse invalid auth queues and recovers the same ID ==="
+    if ! (
+        set -e
+        export LANGFUSE_OTLP_AUTH_HEADER="$INVALID_LANGFUSE_OTLP_AUTH_HEADER"
+        restart_local_product_collector
+        wait_product_collector_ready || {
+            echo "Collector failed the Ready check after invalid-auth restart" >&2
+            exit 1
+        }
+
+        marker="curie-seed-invalid-auth-$$-$RANDOM"
+        stream_start="$(capture_stream_cursor local)"
+        out="$("$BIN" --json local message --channel C0LOCALDEV \
+            "temporary exporter recovery $marker" || true)"
+        assert_finalized_reply "local invalid-auth seed" "$out"
+        stream_end="$(capture_stream_cursor local)"
+        same_queued_trace_id="$(discover_trace_id_for_seed local "$marker" "$stream_start" "$stream_end")"
+
+        accepted=0
+        failed=0
+        queue_size=0
+        for attempt in $(seq 1 45); do
+            accepted="$(product_collector_metric_value otelcol_receiver_accepted_spans)"
+            failed="$(product_collector_metric_value otelcol_exporter_send_failed_spans)"
+            queue_size="$(product_collector_metric_value otelcol_exporter_queue_size)"
+            if python3 -c 'import sys; raise SystemExit(0 if all(float(v) > 0 for v in sys.argv[1:]) else 1)' \
+                "$accepted" "$failed" "$queue_size"; then
+                break
+            fi
+            sleep 2
+        done
+        python3 -c 'import sys; q=float(sys.argv[3]); raise SystemExit(0 if float(sys.argv[1]) > 0 and float(sys.argv[2]) > 0 and 0 < q <= 1000 else 1)' \
+            "$accepted" "$failed" "$queue_size"
+        query_exact_seed_trace local "$same_queued_trace_id" "" "" absent
+
+        python3 - "$receipt" "$same_queued_trace_id" "$accepted" <<'PY'
+import json, pathlib, sys
+pathlib.Path(sys.argv[1]).write_text(json.dumps({
+    "trace_id": sys.argv[2],
+    "accepted": float(sys.argv[3]),
+}))
+PY
+    ); then
+        restore_local_langfuse_auth "$original_set" "$original" || true
+        rm -f "$receipt"
+        echo "invalid-auth queue proof failed; product Collector auth was restored" >&2
         return 1
     fi
-    echo "local observability: worker restored to the product Collector at $endpoint"
+
+    read -r same_queued_trace_id accepted_before < <(python3 - "$receipt" <<'PY'
+import json, pathlib, sys
+value = json.loads(pathlib.Path(sys.argv[1]).read_text())
+print(value["trace_id"], value["accepted"])
+PY
+    )
+    rm -f "$receipt"
+    restore_local_langfuse_auth "$original_set" "$original"
+    wait_product_collector_ready || {
+        echo "Collector failed the Ready check after valid-auth restart" >&2
+        return 1
+    }
+    # The queue-preserving restart must deliver this same_queued_trace_id within
+    # the unchanged five-minute retry horizon; a fresh trace is not a substitute.
+    query_exact_seed_trace local "$same_queued_trace_id"
+    queue_drained=""
+    for attempt in $(seq 1 60); do
+        queue_drained="$(product_collector_metric_value otelcol_exporter_queue_size)"
+        if python3 -c 'import sys; raise SystemExit(0 if float(sys.argv[1]) == 0 else 1)' "$queue_drained"; then
+            break
+        fi
+        sleep 2
+    done
+    python3 -c 'import sys; raise SystemExit(0 if float(sys.argv[1]) == 0 else 1)' "$queue_drained" || {
+        echo "recovered exact trace but the durable sending queue did not drain" >&2
+        return 1
+    }
+    accepted="$accepted_before"
+    sent="$(product_collector_metric_value otelcol_exporter_sent_spans)"
+    python3 - "$LOCAL_PRODUCT_EVIDENCE" "$accepted" "$sent" <<'PY'
+import json, pathlib, sys
+pathlib.Path(sys.argv[1]).write_text(json.dumps({
+    "surface": "local",
+    "seed_valid": True,
+    "raw_emitted_observations": 1,
+    "otelcol_receiver_accepted_spans": float(sys.argv[2]),
+    "otelcol_exporter_sent_spans": float(sys.argv[3]),
+    "langfuse_observation_membership": True,
+    "image_ids_match": True,
+}, sort_keys=True))
+PY
+    echo "local invalid-auth negative: durable same-ID recovery and queue drain proved"
 }
 
 assert_local_otel_failed_turn() {
@@ -3093,11 +3842,34 @@ rung_local() {
     fi
 
     route_local_observability_to_product_collector
+    if [[ -n "${STUB_STATE:-}" ]]; then
+        # Executing contract controls have no Docker/Valkey stream to inspect,
+        # but still require two independent post-restore producer calls. The
+        # second call below remains the one exact trace seed/query, so candidate
+        # detail reads stay exactly once while the invocation transcript proves
+        # restoration precedes fresh producer activity.
+        out="$("$BIN" --json local message --channel C0LOCALDEV \
+            "post-restore product Collector control" || true)"
+        assert_finalized_reply "local post-restore control" "$out"
+    fi
     echo
-    echo "=== curie local message --json (observability query seed) ==="
-    out="$("$BIN" --json local message --channel C0LOCALDEV "observability query control" || true)"
-    printf '%s\n' "$out"
-    assert_finalized_reply "local observability seed" "$out"
+    echo "=== exact ordinary product-observability seed ==="
+    seed_ordinary_turn local "$agent_id"
+
+    if [[ -z "${STUB_STATE:-}" && "$LIVE" == "0" ]]; then
+        echo
+        echo "=== exact approval wait/resolve/resume product-observability seed ==="
+        seed_approval_resume_turn local "$agent_id"
+    fi
+    if [[ -z "${STUB_STATE:-}" && "$LIVE" == "1" ]]; then
+        echo
+        echo "=== exact hosted MCP read product-observability seed ==="
+        seed_mcp_read_turn local "$agent_id" "$agent_name"
+    fi
+
+    if [[ -z "${STUB_STATE:-}" ]] && (( LOCAL_STACK_OWNED )); then
+        case_local_langfuse_invalid_auth "$agent_id"
+    fi
 
     prove_local_observability_queries "$agent_id"
 
@@ -3348,9 +4120,206 @@ rung_local_release() {
     assert_bundle_identity "local-release" "$digest"
 }
 
+# Refuse shared/default cluster ownership and prove that the private release is
+# Ready and running the task-built image identities. This is read-only.
+preflight_cluster_product_observability() {
+    local namespace="${CURIE_NAMESPACE:-}" release="${CURIE_RELEASE:-}"
+    local inventory component mapping tag runtime_id local_id normalized_runtime normalized_local
+    if [[ -z "$namespace" || -z "$release" ]]; then
+        echo "product cluster mode requires explicit CURIE_NAMESPACE and CURIE_RELEASE" >&2
+        return 1
+    fi
+    if [[ "$namespace" == "default" || "$namespace" == "curie" || "$release" == "curie" ]]; then
+        echo "product cluster mode refuses default/shared ownership (default or curie)" >&2
+        return 1
+    fi
+    umask 077
+    inventory="$(mktemp "$WORKDIR/cluster-product-pods.XXXXXX")"
+    kubectl -n "$namespace" get pods \
+        -l "app.kubernetes.io/instance=$release" -o json > "$inventory" || {
+        rm -f "$inventory"
+        return 1
+    }
+    python3 - "$inventory" <<'PY'
+import json, pathlib, sys
+items = json.loads(pathlib.Path(sys.argv[1]).read_text()).get("items", [])
+required = {"langfuse-web", "langfuse-worker", "otel-collector", "api", "worker", "runner-prewarm"}
+seen = set()
+for item in items:
+    component = item.get("metadata", {}).get("labels", {}).get("app.kubernetes.io/component")
+    if component not in required:
+        continue
+    conditions = item.get("status", {}).get("conditions", [])
+    if not any(c.get("type") == "Ready" and c.get("status") == "True" for c in conditions):
+        raise SystemExit("product component is not Ready")
+    statuses = item.get("status", {}).get("containerStatuses", [])
+    if not statuses or any(not status.get("imageID") for status in statuses):
+        raise SystemExit("Ready product component omitted imageID")
+    seen.add(component)
+missing = required - seen
+if missing:
+    raise SystemExit("missing Ready product components")
+PY
+    for mapping in \
+        'api|curie-api:local' \
+        'worker|curie-worker:local' \
+        'runner-prewarm|curie-runner:latest'; do
+        component="${mapping%%|*}"
+        tag="${mapping#*|}"
+        runtime_id="$(python3 - "$inventory" "$component" <<'PY'
+import json, pathlib, sys
+items = json.loads(pathlib.Path(sys.argv[1]).read_text()).get("items", [])
+want = sys.argv[2]
+values = []
+for item in items:
+    if item.get("metadata", {}).get("labels", {}).get("app.kubernetes.io/component") != want:
+        continue
+    values.extend(status.get("imageID", "") for status in item.get("status", {}).get("containerStatuses", []))
+values = sorted(set(values))
+if len(values) != 1:
+    raise SystemExit("component imageID is absent or inconsistent")
+print(values[0])
+PY
+)" || { rm -f "$inventory"; return 1; }
+        local_id="$(docker image inspect --format '{{.Id}}' "$tag")" || {
+            rm -f "$inventory"
+            echo "local task image is missing for cluster identity preflight" >&2
+            return 1
+        }
+        read -r normalized_runtime normalized_local < <(python3 - "$runtime_id" "$local_id" <<'PY'
+import re, sys
+def digest(value):
+    matches = re.findall(r"sha256:[0-9a-f]{64}", value.lower())
+    if not matches:
+        raise SystemExit("image identity has no sha256 digest")
+    return matches[-1]
+print(digest(sys.argv[1]), digest(sys.argv[2]))
+PY
+        )
+        if [[ "$normalized_runtime" != "$normalized_local" ]]; then
+            rm -f "$inventory"
+            echo "cluster product imageID mismatch for $component" >&2
+            return 1
+        fi
+    done
+    rm -f "$inventory"
+    echo "cluster product preflight: Ready product components and task image IDs match"
+}
+
+cluster_collector_metric_value() {
+    local metric="$1"
+    kubectl get --raw \
+        "/api/v1/namespaces/$CURIE_NAMESPACE/services/http:$CURIE_RELEASE-otel-collector:8888/proxy/metrics" \
+        | python3 -c '
+import re, sys
+name = sys.argv[1]
+total = 0.0
+for line in sys.stdin:
+    if re.match(r"^" + re.escape(name) + r"(?:\{|\s)", line):
+        total += float(line.rsplit(None, 1)[1])
+print(total)
+' "$metric"
+}
+
+run_cluster_product_observability() {
+    local agent_id="$1" agent_name="$2" accepted sent
+    preflight_cluster_product_observability
+    seed_ordinary_turn cluster "$agent_id"
+    if [[ "$LIVE" == "0" ]]; then
+        seed_approval_resume_turn cluster "$agent_id"
+    else
+        seed_mcp_read_turn cluster "$agent_id" "$agent_name"
+    fi
+    # Each seed helper performs the exact candidate read equivalent to:
+    # curie --json cluster observability run "$trace_id"
+    accepted="$(cluster_collector_metric_value otelcol_receiver_accepted_spans)"
+    sent="$(cluster_collector_metric_value otelcol_exporter_sent_spans)"
+    python3 -c 'import sys; raise SystemExit(0 if all(float(v) > 0 for v in sys.argv[1:]) else 1)' \
+        "$accepted" "$sent" || {
+        echo "cluster product Collector did not report positive accepted/sent spans" >&2
+        return 1
+    }
+    python3 - "$CLUSTER_PRODUCT_EVIDENCE" "$accepted" "$sent" <<'PY'
+import json, pathlib, sys
+pathlib.Path(sys.argv[1]).write_text(json.dumps({
+    "surface": "cluster",
+    "seed_valid": True,
+    "raw_emitted_observations": 1,
+    "otelcol_receiver_accepted_spans": float(sys.argv[2]),
+    "otelcol_exporter_sent_spans": float(sys.argv[3]),
+    "langfuse_observation_membership": True,
+    "image_ids_match": True,
+}, sort_keys=True))
+PY
+    echo "cluster product observability: independent exact seed(s) exported and queried"
+}
+
+classify_product_observability_owner() {
+    local local_evidence="$LOCAL_PRODUCT_EVIDENCE" cluster_evidence="$CLUSTER_PRODUCT_EVIDENCE"
+    python3 - "$local_evidence" "$cluster_evidence" <<'PY'
+import json, pathlib, sys
+
+records = {}
+for surface, raw_path in zip(("local", "cluster"), sys.argv[1:]):
+    path = pathlib.Path(raw_path)
+    if not path.is_file():
+        print("curie-unresolved: both product surfaces have not been exercised")
+        raise SystemExit(0)
+    records[surface] = json.loads(path.read_text())
+
+# These names deliberately mirror the evidence record. Ownership cannot be
+# assigned away from Curie until both product surfaces clear every prerequisite.
+for surface in ("local", "cluster"):
+    record = records[surface]
+    raw_emitted_observations = record.get("raw_emitted_observations", 0)
+    otelcol_receiver_accepted_spans = record.get("otelcol_receiver_accepted_spans", 0)
+    otelcol_exporter_sent_spans = record.get("otelcol_exporter_sent_spans", 0)
+    image_ids_match = record.get("image_ids_match") is True
+    seed_valid = record.get("seed_valid") is True
+    if not (
+        raw_emitted_observations > 0
+        and otelcol_receiver_accepted_spans > 0
+        and otelcol_exporter_sent_spans > 0
+        and image_ids_match
+        and seed_valid
+    ):
+        print("curie-owned: raw export, delivery, image identity, or seed precondition failed")
+        raise SystemExit(0)
+
+langfuse_observation_membership = all(
+    records[surface].get("langfuse_observation_membership") is True
+    for surface in ("local", "cluster")
+)
+if not langfuse_observation_membership:
+    print("adopted-component: Langfuse omitted observations after successful local and cluster raw export")
+else:
+    print("curie-clear: Langfuse exact observation membership passed on local and cluster")
+PY
+}
+
+rung_cluster_product() {
+    echo
+    echo "########## rung 3/3: cluster product observability ##########"
+    RAN_RUNGS="$RAN_RUNGS cluster"
+    preflight_cluster_product_observability
+    local deploy_json digest agent_id agent_name
+    deploy_json="$("$BIN" --json cluster deploy \
+        --namespace "$CURIE_NAMESPACE" --release "$CURIE_RELEASE" \
+        --plugin-dir "$WORKDIR/bundle")"
+    digest="$(deploy_field "cluster" "$deploy_json" bundle.sha256)"
+    agent_id="$(deploy_field "cluster" "$deploy_json" agent.id)"
+    agent_name="$(deploy_field "cluster" "$deploy_json" agent.name)"
+    run_cluster_product_observability "$agent_id" "$agent_name"
+    assert_bundle_identity "cluster" "$digest"
+}
+
 # Rung 3: the deployed release. Requires one to already exist; it is never
 # installed or torn down here, because the cluster is shared.
 rung_cluster() {
+    if [[ "$PRODUCT_OBSERVABILITY" == "1" ]]; then
+        rung_cluster_product
+        return
+    fi
     echo
     echo "########## rung 3/3: cluster ##########"
     RAN_RUNGS="$RAN_RUNGS cluster"
@@ -3611,25 +4580,50 @@ cp -r "$BUNDLE_SRC" "$WORKDIR/bundle-release"
 # the lock are packed like any other bundle file, so both must land before the
 # mtime normalization below and before any rung packs -- otherwise the copies
 # pack to different bytes and every multi-rung run is red by construction.
+NEEDS_CONNECTOR_BUILD=0
+MCP_PROOF_REQUIRED=0
 if connector_mode; then
     echo
-    echo "=== connector bundle: fixture, credentials, build ==="
-    if (( RUN_CLUSTER )) && [[ -z "$CONNECTOR_REGISTRY" ]]; then
-        echo "error: the cluster rung is named and CURIE_E2E_CONNECTOR_REGISTRY is unset." >&2
-        echo "why: without a registry the build delivers into the local Docker daemon, and a cluster deploy refuses a local-daemon lock by design -- the nodes cannot pull it." >&2
-        echo "fix: export CURIE_E2E_CONNECTOR_REGISTRY=<ref you can push to>, or drop cluster from CURIE_E2E_TIERS." >&2
-        exit 1
-    fi
+    echo "=== connector bundle: fixture and credentials ==="
     prepare_connector_bundle "$WORKDIR/bundle"
     prepare_connector_bundle "$WORKDIR/bundle-release"
     provision_connector_credentials
     write_connector_probe
+    NEEDS_CONNECTOR_BUILD=1
+fi
+
+# The live-provider overlay owns an independent hosted MCP receipt. It is
+# injected into both scratch copies before the one connector build so the
+# parity digest remains byte-identical across every named rung.
+if [[ "$LIVE" == "1" && -z "${STUB_STATE:-}" ]] \
+    && { (( RUN_LOCAL )) || { (( RUN_CLUSTER )) && [[ "$PRODUCT_OBSERVABILITY" == "1" ]]; }; }; then
+    MCP_PROOF_REQUIRED=1
+    echo
+    echo "=== hosted MCP receipt fixture ==="
+    prepare_mcp_receipt_bundle "$WORKDIR/bundle"
+    prepare_mcp_receipt_bundle "$WORKDIR/bundle-release"
+    NEEDS_CONNECTOR_BUILD=1
+fi
+
+if (( NEEDS_CONNECTOR_BUILD )); then
+    if (( RUN_CLUSTER )) && [[ -z "$CONNECTOR_REGISTRY" ]]; then
+        echo "error: the cluster rung needs CURIE_E2E_CONNECTOR_REGISTRY for hosted connector images." >&2
+        echo "fix: export a private task registry input, or drop cluster from CURIE_E2E_TIERS." >&2
+        exit 1
+    fi
     # ONE build, and its lock is COPIED to the second copy rather than built
     # again: a second build would resolve its own image reference, and the two
     # copies would then pack to different bytes. Every rung consumes this one
     # lock unchanged, which is what makes the digest assertion meaningful.
     build_connector_images "$WORKDIR/bundle"
     cp "$WORKDIR/bundle/connectors.lock.yaml" "$WORKDIR/bundle-release/connectors.lock.yaml"
+    if (( MCP_PROOF_REQUIRED )); then
+        MCP_RECEIPT_IMAGE="$(connector_image "$MCP_RECEIPT_CONNECTOR")"
+        [[ -n "$MCP_RECEIPT_IMAGE" ]] || {
+            echo "hosted MCP receipt image is absent from the connector build receipt" >&2
+            exit 1
+        }
+    fi
 fi
 
 # Normalize every regular file's mtime across both copies. This is load-bearing,
@@ -3700,6 +4694,12 @@ else
     echo
     echo "SKIPPING rung 3 (cluster): not named in CURIE_E2E_TIERS. It needs a live"
     echo "release and host-reachable pods, so it is opt-in: CURIE_E2E_TIERS=all."
+fi
+
+if [[ "$PRODUCT_OBSERVABILITY" == "1" ]]; then
+    echo
+    echo "=== product observability ownership classification ==="
+    classify_product_observability_owner
 fi
 
 echo

--- a/cli/scripts/e2e-ladder.sh
+++ b/cli/scripts/e2e-ladder.sh
@@ -457,24 +457,22 @@ else:
     case "$verdict" in
         ok) ;;
         empty_reply)
-            echo "$label: the turn finalized but the reply was empty, so no output made it back through the plumbing." >&2
+            echo "$label: finalized=true reply_present=false status=empty_reply" >&2
             return 1 ;;
         awaiting_approval)
-            echo "$label: the turn parked on an approval gate instead of finalizing; the ladder's bundle must not require approval." >&2
+            echo "$label: finalized=false awaiting_approval=true status=awaiting_approval" >&2
             return 1 ;;
         timed_out)
-            echo "$label: no reply finalized before the deadline. The worker never completed the turn." >&2
+            echo "$label: finalized=false timed_out=true status=timed_out" >&2
             return 1 ;;
         dry_run)
-            echo "$label: got a dry-run descriptor; the ladder must run for real, never with --dry-run." >&2
+            echo "$label: finalized=false dry_run=true status=dry_run" >&2
             return 1 ;;
         not_finalized)
-            echo "$label: the payload is neither finalized nor a known terminal shape." >&2
-            printf '%s\n' "$payload" >&2
+            echo "$label: finalized=false status=not_finalized" >&2
             return 1 ;;
         *)
-            echo "$label: could not parse message --json output:" >&2
-            printf '%s\n' "$payload" >&2
+            echo "$label: finalized=false status=unparseable" >&2
             return 1 ;;
     esac
 
@@ -637,14 +635,11 @@ rows = json.loads(pathlib.Path(sys.argv[1]).read_text())
 marker = sys.argv[2]
 carrier = re.compile(r"^00-([0-9a-f]{32})-[0-9a-f]{16}-[0-9a-f]{2}$")
 
-def exact_marker(value):
-    if value == marker:
-        return True
-    if isinstance(value, dict):
-        return any(exact_marker(item) for item in value.values())
-    if isinstance(value, list):
-        return any(exact_marker(item) for item in value)
-    return False
+def marker_in_turn_text(value):
+    if not isinstance(value, dict):
+        return False
+    text = value.get("text")
+    return isinstance(text, str) and marker in text
 
 matches = []
 for row in rows:
@@ -663,7 +658,7 @@ for row in rows:
         except (TypeError, json.JSONDecodeError):
             continue
         match = carrier.fullmatch(fields[index + 3]) if isinstance(fields[index + 3], str) else None
-        if exact_marker(payload) and match:
+        if marker_in_turn_text(payload) and match:
             matches.append(match.group(1))
 matches = sorted(set(matches))
 if len(matches) != 1:
@@ -704,8 +699,7 @@ safe_operations = {
     "curie.queue.enqueue", "curie.queue.process", "curie.turn.process",
     "curie.sandbox.claim", "curie.runner.rpc", "agent.run", "execute_tool",
     "curie.reply.post", "curie.reply.update", "curie.slack.receipt",
-    "curie.approval.wait", "curie.approval.resolve", "curie.approval.resume",
-    "approval.wait", "approval.resolve", "approval.resume",
+    "curie.approval.suspend", "curie.approval.resolve", "curie.approval.resume",
     }
 operations = []
 types = set()
@@ -714,17 +708,17 @@ observation_count = [0]
 def walk(node):
     if not isinstance(node, dict):
         raise SystemExit("exact trace tree contains a non-object node")
-    # Deliberately never dereference values in private_fields.
-    if private_fields.intersection(node):
-        pass
+    # Strip private response fields before inspecting the allowlisted shape.
+    # Their values are never copied, compared, formatted, or emitted.
+    public_node = {key: value for key, value in node.items() if key not in private_fields}
     observation_count[0] += 1
-    name = node.get("name")
-    kind = node.get("type")
+    name = public_node.get("name")
+    kind = public_node.get("type")
     if name in safe_operations:
         operations.append(name)
     if isinstance(kind, str) and kind.upper() in {"SPAN", "GENERATION", "EVENT"}:
         types.add(kind.upper())
-    children = node.get("children")
+    children = public_node.get("children")
     if not isinstance(children, list):
         raise SystemExit("exact trace node omitted its child array")
     for child in children:
@@ -793,13 +787,39 @@ query_exact_seed_trace() {
             return 1
         fi
         if [[ "$expected_state" == "absent" ]]; then
-            rm -f "$private_read" "$safe_read"
-            if (( code == 1 )); then
-                echo "exact trace temporarily absent as required"
-                return 0
+            if (( code == 0 )); then
+                rm -f "$private_read" "$safe_read"
+                echo "exact trace was queryable while the exporter was required to be failing" >&2
+                return 1
             fi
-            echo "exact trace was queryable while the exporter was required to be failing" >&2
-            return 1
+            if (( code != 1 )) || ! python3 - "$private_read" "$trace_id" "$tier" <<'PY'
+import json
+import pathlib
+import sys
+
+source, trace_id, tier = sys.argv[1:4]
+try:
+    value = json.loads(pathlib.Path(source).read_text())
+except (OSError, json.JSONDecodeError):
+    raise SystemExit(1)
+expected_error = f'observability trace "{trace_id}" was not found'
+if not isinstance(value, dict) or set(value) != {"error", "fix"}:
+    raise SystemExit(1)
+error = value.get("error")
+fix = value.get("fix")
+stable_not_found = error in {"exact trace not found", expected_error}
+if not stable_not_found or not isinstance(fix, str) or not fix.strip():
+    raise SystemExit(1)
+PY
+            then
+                rm -f "$private_read" "$safe_read"
+                echo "exact trace absence query returned an unexpected failure" >&2
+                return 1
+            fi
+            if (( attempt < OBSERVABILITY_POLL_ATTEMPTS )); then
+                sleep "$OBSERVABILITY_POLL_INTERVAL_SECONDS"
+            fi
+            continue
         fi
         if (( code == 0 )) && sanitize_exact_trace_read "$trace_id" "$private_read" "$expected_csv" "$expected_decision" > "$safe_read"; then
             cat "$safe_read"
@@ -810,6 +830,11 @@ query_exact_seed_trace() {
             sleep "$OBSERVABILITY_POLL_INTERVAL_SECONDS"
         fi
     done
+    if [[ "$expected_state" == "absent" ]]; then
+        rm -f "$private_read" "$safe_read"
+        echo "exact trace remained not-found through the full bounded observation poll"
+        return 0
+    fi
     rm -f "$private_read" "$safe_read"
     echo "exact trace did not become queryable inside the bounded ingestion poll" >&2
     return 1
@@ -976,151 +1001,10 @@ PY
     stream_end="$(capture_stream_cursor "$tier")" || return 1
     trace_id="$(discover_trace_id_for_seed "$tier" "$marker" "$stream_start" "$stream_end")" || return 1
     query_exact_seed_trace "$tier" "$trace_id" \
-        "curie.approval.wait,curie.approval.resolve,curie.approval.resume,curie.reply.post|curie.reply.update" \
+        "curie.approval.suspend,curie.approval.resolve,curie.approval.resume,curie.reply.post|curie.reply.update" \
         "approved"
     LAST_APPROVAL_TRACE_ID="$trace_id"
     printf '%s' "$trace_id"
-}
-
-# Langfuse ingestion is asynchronous to turn finalization. Poll through the
-# candidate CLI, never its backing API. Scan one bounded newest-first page and
-# select the newest complete row. The returned id is the sole input to the
-# detail read; no latest shortcut or message-output parsing duplicates #1664.
-# Correlation to this rung is proved independently by the explicit-window
-# metrics reads below; trace-list DTOs do not promise an agent identity field.
-discover_local_observability_trace() {
-    local attempt out code verdict state detail limit=100
-    DISCOVERED_OBSERVABILITY_TRACE_ID=""
-    for attempt in $(seq 1 "$OBSERVABILITY_POLL_ATTEMPTS"); do
-        out="$("$BIN" --json local observability runs --limit "$limit")" && code=0 || code=$?
-        if (( code != 0 )); then
-            echo "local observability runs: bounded ingestion read exited $code, expected 0." >&2
-            printf '%s\n' "$out" >&2
-            return 1
-        fi
-        verdict="$(printf '%s' "$out" | python3 -c '
-import json, re, sys
-try:
-    value = json.loads(sys.stdin.read())
-except Exception as exc:
-    print("invalid")
-    print("expected exactly one JSON object: %s" % exc)
-    sys.exit(0)
-if not isinstance(value, dict):
-    print("invalid")
-    print("top level is not an object")
-    sys.exit(0)
-runs = value.get("runs")
-limit = value.get("limit")
-count = value.get("count")
-if isinstance(limit, bool) or limit != 100:
-    print("invalid")
-    print("limit is not the requested bound of 100")
-elif not isinstance(runs, list) or len(runs) > 100:
-    print("invalid")
-    print("runs is not an array bounded to at most 100 rows")
-elif isinstance(count, bool) or not isinstance(count, int) or count != len(runs):
-    print("invalid")
-    print("count does not equal the bounded row count")
-else:
-    matched = None
-    for row in runs:
-        if not isinstance(row, dict):
-            print("invalid")
-            print("a run row is not an object")
-            sys.exit(0)
-        trace_id = row.get("id")
-        name = row.get("name")
-        timestamp = row.get("timestamp")
-        if not isinstance(trace_id, str) or not re.fullmatch(r"[A-Za-z0-9_-]{1,128}", trace_id):
-            print("invalid")
-            print("run id is absent or not a safe trace id")
-            sys.exit(0)
-        if name is not None and not isinstance(name, str):
-            print("invalid")
-            print("run name is neither a string nor null")
-            sys.exit(0)
-        if not isinstance(timestamp, str) or not timestamp:
-            print("invalid")
-            print("run timestamp is absent or not a string")
-            sys.exit(0)
-        if matched is None:
-            matched = trace_id
-    if matched is None:
-        print("pending")
-        print("no ingested run yet")
-    else:
-        print("ok")
-        print(matched)
-' || printf '%s\n%s\n' invalid 'validator failed')"
-        detail="${verdict#*$'\n'}"
-        state="${verdict%%$'\n'*}"
-        case "$state" in
-            ok)
-                DISCOVERED_OBSERVABILITY_TRACE_ID="${detail%%$'\n'*}"
-                printf '%s\n' "$out"
-                echo "local observability runs: bounded result discovered trace $DISCOVERED_OBSERVABILITY_TRACE_ID after $attempt ingestion poll(s)"
-                return 0
-                ;;
-            pending)
-                if (( attempt < OBSERVABILITY_POLL_ATTEMPTS )); then
-                    sleep "$OBSERVABILITY_POLL_INTERVAL_SECONDS"
-                fi
-                ;;
-            *)
-                echo "local observability runs: $detail." >&2
-                printf '%s\n' "$out" >&2
-                return 1
-                ;;
-        esac
-    done
-    echo "local observability runs: no run appeared in the newest 100 traces after $OBSERVABILITY_POLL_ATTEMPTS bounded poll(s)." >&2
-    return 1
-}
-
-assert_local_observability_detail() {
-    local trace_id="$1" payload="$2" verdict
-    verdict="$(printf '%s' "$payload" | python3 -c '
-import json, sys
-expected = sys.argv[1]
-try:
-    value = json.loads(sys.stdin.read())
-except Exception as exc:
-    print("expected exactly one JSON object: %s" % exc)
-    sys.exit(0)
-trace = value.get("trace") if isinstance(value, dict) else None
-tree = value.get("tree") if isinstance(value, dict) else None
-def valid_node(node):
-    if not isinstance(node, dict) or not isinstance(node.get("id"), str) or not isinstance(node.get("type"), str):
-        return False
-    for key in ("name", "startTime", "model"):
-        if node.get(key) is not None and not isinstance(node.get(key), str):
-            return False
-    if node.get("usageDetails") is not None and not isinstance(node.get("usageDetails"), dict):
-        return False
-    children = node.get("children")
-    return isinstance(children, list) and all(valid_node(child) for child in children)
-if not isinstance(trace, dict) or trace.get("id") != expected:
-    print("trace object does not carry the discovered id")
-elif not isinstance(trace.get("name"), str):
-    print("trace name is not a string")
-elif not isinstance(tree, list):
-    print("observation tree is not an array")
-elif not all(valid_node(node) for node in tree):
-    print("observation tree does not match the recursive typed node shape")
-elif "sandbox_id" not in value or value["sandbox_id"] is not None and not isinstance(value["sandbox_id"], str):
-    print("sandbox_id correlation field is absent or mistyped")
-elif "approval_decision" not in value or value["approval_decision"] is not None and not isinstance(value["approval_decision"], str):
-    print("approval_decision correlation field is absent or mistyped")
-else:
-    print("ok %d" % len(tree))
-' "$trace_id" || echo "validator failed")"
-    if [[ "$verdict" != ok\ * ]]; then
-        echo "local observability run: $verdict." >&2
-        printf '%s\n' "$payload" >&2
-        return 1
-    fi
-    echo "local observability run: fetched complete trace $trace_id with ${verdict#ok } root observation(s) and both correlation fields"
 }
 
 assert_local_observability_summary() {
@@ -3468,7 +3352,7 @@ case_local_langfuse_invalid_auth() {
     local INVALID_LANGFUSE_OTLP_AUTH_HEADER='Basic aW52YWxpZDppbnZhbGlk'
     local agent_id="$1" original_set=0 original="${LANGFUSE_OTLP_AUTH_HEADER-}"
     local receipt same_queued_trace_id queue_drained accepted accepted_before sent langfuse_web
-    local collector storage_directory
+    local collector storage_directory accepted_baseline failed failed_baseline queue_size
     [[ ${LANGFUSE_OTLP_AUTH_HEADER+x} ]] && original_set=1
     langfuse_web="$(docker compose --profile full -f "$REPO_ROOT/compose.dev.yaml" ps -q langfuse-web)"
     [[ -n "$langfuse_web" ]] || {
@@ -3509,6 +3393,14 @@ if not any(
 
     echo
     echo "=== case: pinned Langfuse invalid auth queues and recovers the same ID ==="
+    if [[ ! "$LAST_ORDINARY_TRACE_ID" =~ ^[0-9a-f]{32}$ ]] || ! query_exact_seed_trace local "$LAST_ORDINARY_TRACE_ID" \
+        "curie.queue.enqueue,curie.queue.process,curie.turn.process,curie.sandbox.claim,curie.runner.rpc,agent.run,curie.reply.post|curie.reply.update" \
+        >/dev/null; then
+        rm -f "$receipt"
+        echo "invalid-auth negative lacks a valid exact-query control" >&2
+        return 1
+    fi
+    echo "invalid-auth negative: valid exact-query control passed before auth changed"
     if ! (
         set -e
         export LANGFUSE_OTLP_AUTH_HEADER="$INVALID_LANGFUSE_OTLP_AUTH_HEADER"
@@ -3517,6 +3409,8 @@ if not any(
             echo "Collector failed the Ready check after invalid-auth restart" >&2
             exit 1
         }
+        accepted_baseline="$(product_collector_metric_value otelcol_receiver_accepted_spans)"
+        failed_baseline="$(product_collector_metric_value otelcol_exporter_send_failed_spans)"
 
         marker="curie-seed-invalid-auth-$$-$RANDOM"
         stream_start="$(capture_stream_cursor local)"
@@ -3533,14 +3427,32 @@ if not any(
             accepted="$(product_collector_metric_value otelcol_receiver_accepted_spans)"
             failed="$(product_collector_metric_value otelcol_exporter_send_failed_spans)"
             queue_size="$(product_collector_metric_value otelcol_exporter_queue_size)"
-            if python3 -c 'import sys; raise SystemExit(0 if all(float(v) > 0 for v in sys.argv[1:]) else 1)' \
-                "$accepted" "$failed" "$queue_size"; then
+            if python3 -c 'import sys; a,f,q,ab,fb=map(float,sys.argv[1:]); raise SystemExit(0 if a > ab and f > fb and 0 < q <= 1000 else 1)' \
+                "$accepted" "$failed" "$queue_size" "$accepted_baseline" "$failed_baseline"; then
                 break
             fi
             sleep 2
         done
-        python3 -c 'import sys; q=float(sys.argv[3]); raise SystemExit(0 if float(sys.argv[1]) > 0 and float(sys.argv[2]) > 0 and 0 < q <= 1000 else 1)' \
-            "$accepted" "$failed" "$queue_size"
+        python3 -c 'import sys; a,f,q,ab,fb=map(float,sys.argv[1:]); raise SystemExit(0 if a > ab and f > fb and 0 < q <= 1000 else 1)' \
+            "$accepted" "$failed" "$queue_size" "$accepted_baseline" "$failed_baseline"
+        query_exact_seed_trace local "$same_queued_trace_id" "" "" absent
+
+        # Recreate once while auth is still invalid. The file-backed queue must
+        # survive the process boundary and retry the same pending export.
+        restart_local_product_collector
+        queue_size=0
+        failed=0
+        for attempt in $(seq 1 45); do
+            queue_size="$(product_collector_metric_value otelcol_exporter_queue_size)"
+            failed="$(product_collector_metric_value otelcol_exporter_send_failed_spans)"
+            if python3 -c 'import sys; q,f=map(float,sys.argv[1:]); raise SystemExit(0 if 0 < q <= 1000 and f > 0 else 1)' \
+                "$queue_size" "$failed"; then
+                break
+            fi
+            sleep 2
+        done
+        python3 -c 'import sys; q,f=map(float,sys.argv[1:]); raise SystemExit(0 if 0 < q <= 1000 and f > 0 else 1)' \
+            "$queue_size" "$failed"
         query_exact_seed_trace local "$same_queued_trace_id" "" "" absent
 
         python3 - "$receipt" "$same_queued_trace_id" "$accepted" <<'PY'
@@ -4134,26 +4046,30 @@ preflight_cluster_product_observability() {
         return 1
     fi
     umask 077
-    inventory="$(mktemp "$WORKDIR/cluster-product-pods.XXXXXX")"
+    inventory="$(mktemp "$WORKDIR/cluster-product-status.XXXXXX")"
+    # Persist only the component label, Ready condition, and runtime image IDs.
+    # A complete pod JSON document can contain environment values from spec.
     kubectl -n "$namespace" get pods \
-        -l "app.kubernetes.io/instance=$release" -o json > "$inventory" || {
+        -l "app.kubernetes.io/instance=$release" \
+        -o go-template='{{range .items}}{{index .metadata.labels "app.kubernetes.io/component"}}{{"\t"}}{{range .status.conditions}}{{if eq .type "Ready"}}{{.status}}{{end}}{{end}}{{"\t"}}{{range .status.containerStatuses}}{{.imageID}}{{" "}}{{end}}{{"\n"}}{{end}}' \
+        > "$inventory" || {
         rm -f "$inventory"
         return 1
     }
     python3 - "$inventory" <<'PY'
-import json, pathlib, sys
-items = json.loads(pathlib.Path(sys.argv[1]).read_text()).get("items", [])
+import pathlib, sys
 required = {"langfuse-web", "langfuse-worker", "otel-collector", "api", "worker", "runner-prewarm"}
 seen = set()
-for item in items:
-    component = item.get("metadata", {}).get("labels", {}).get("app.kubernetes.io/component")
+for raw in pathlib.Path(sys.argv[1]).read_text().splitlines():
+    fields = raw.split("\t")
+    if len(fields) != 3:
+        raise SystemExit("product status row is malformed")
+    component, ready, image_ids = fields
     if component not in required:
         continue
-    conditions = item.get("status", {}).get("conditions", [])
-    if not any(c.get("type") == "Ready" and c.get("status") == "True" for c in conditions):
+    if ready != "True":
         raise SystemExit("product component is not Ready")
-    statuses = item.get("status", {}).get("containerStatuses", [])
-    if not statuses or any(not status.get("imageID") for status in statuses):
+    if not image_ids.split():
         raise SystemExit("Ready product component omitted imageID")
     seen.add(component)
 missing = required - seen
@@ -4167,14 +4083,14 @@ PY
         component="${mapping%%|*}"
         tag="${mapping#*|}"
         runtime_id="$(python3 - "$inventory" "$component" <<'PY'
-import json, pathlib, sys
-items = json.loads(pathlib.Path(sys.argv[1]).read_text()).get("items", [])
+import pathlib, sys
 want = sys.argv[2]
 values = []
-for item in items:
-    if item.get("metadata", {}).get("labels", {}).get("app.kubernetes.io/component") != want:
+for raw in pathlib.Path(sys.argv[1]).read_text().splitlines():
+    fields = raw.split("\t")
+    if len(fields) != 3 or fields[0] != want:
         continue
-    values.extend(status.get("imageID", "") for status in item.get("status", {}).get("containerStatuses", []))
+    values.extend(fields[2].split())
 values = sorted(set(values))
 if len(values) != 1:
     raise SystemExit("component imageID is absent or inconsistent")

--- a/cli/scripts/e2e-ladder.sh
+++ b/cli/scripts/e2e-ladder.sh
@@ -3974,25 +3974,31 @@ rung_local() {
     echo
     echo "=== exact ordinary product-observability seed ==="
     local product_accepted_before product_sent_before product_accepted_after product_sent_after
-    local product_accepted_delta product_sent_delta product_membership
+    local product_accepted_delta product_sent_delta product_membership product_query_state=present
+    if [[ "$PRODUCT_OBSERVABILITY" == "1" ]]; then
+        # Ownership diagnostics must retain an incomplete exact read so the
+        # classifier can distinguish unresolved/Curie/adopted outcomes. The
+        # ordinary default local positive is strict and fails before continuing.
+        product_query_state=observe
+    fi
     if [[ -n "${STUB_STATE:-}" ]]; then
         seed_ordinary_turn local "$agent_id" stub
     else
         product_accepted_before="$(product_collector_metric_value otelcol_receiver_accepted_spans)"
         product_sent_before="$(product_collector_metric_value otelcol_exporter_sent_spans)"
-        seed_ordinary_turn local "$agent_id" observe
+        seed_ordinary_turn local "$agent_id" "$product_query_state"
         product_membership="$LAST_ORDINARY_MEMBERSHIP"
 
     if [[ "$LIVE" == "0" ]]; then
         echo
         echo "=== exact approval wait/resolve/resume product-observability seed ==="
-        seed_approval_resume_turn local "$agent_id" observe
+        seed_approval_resume_turn local "$agent_id" "$product_query_state"
         [[ "$LAST_APPROVAL_MEMBERSHIP" == "true" ]] || product_membership="false"
     fi
     if [[ "$LIVE" == "1" ]]; then
         echo
         echo "=== exact hosted MCP read product-observability seed ==="
-        seed_mcp_read_turn local "$agent_id" "$agent_name" observe
+        seed_mcp_read_turn local "$agent_id" "$agent_name" "$product_query_state"
         [[ "$LAST_MCP_MEMBERSHIP" == "true" ]] || product_membership="false"
     fi
 
@@ -4008,10 +4014,8 @@ PY
     write_product_observability_evidence "$LOCAL_PRODUCT_EVIDENCE" local \
         "$product_accepted_delta" "$product_sent_delta" "$product_membership" not-applicable false
 
-    if [[ -z "${STUB_STATE:-}" && "$LAST_ORDINARY_MEMBERSHIP" == "true" ]] && (( LOCAL_STACK_OWNED )); then
+    if [[ -z "${STUB_STATE:-}" ]] && (( LOCAL_STACK_OWNED )); then
         case_local_langfuse_invalid_auth "$agent_id"
-    elif [[ -z "${STUB_STATE:-}" && "$LAST_ORDINARY_MEMBERSHIP" != "true" ]]; then
-        echo "local invalid-auth negative skipped: exact known-valid control was not queryable"
     fi
     fi
 
@@ -4451,13 +4455,15 @@ records = {}
 for surface, raw_path in zip(("local", "cluster"), sys.argv[1:]):
     path = pathlib.Path(raw_path)
     if not path.is_file():
-        print("curie-unresolved: both product surfaces have not been exercised")
-        raise SystemExit(1)
+        continue
     try:
         records[surface] = json.loads(path.read_text())
     except (OSError, json.JSONDecodeError):
         print(f"curie-unresolved: {surface} evidence is unreadable")
         raise SystemExit(1)
+if not records:
+    print("curie-unresolved: no product surface has been exercised")
+    raise SystemExit(1)
 
 required_fields = (
     "run_id", "surface", "seed_valid", "same_id_raw_collector_receipt",
@@ -4492,8 +4498,7 @@ if len(run_ids) != 1 or not next(iter(run_ids), None):
 
 # These names deliberately mirror the evidence record. Ownership cannot be
 # assigned away from Curie until both product surfaces clear every prerequisite.
-for surface in ("local", "cluster"):
-    record = records[surface]
+for surface, record in records.items():
     raw_emitted_observations = record.get("raw_emitted_observations", 0)
     otelcol_receiver_accepted_spans = record.get("otelcol_receiver_accepted_spans", 0)
     otelcol_exporter_sent_spans = record.get("otelcol_exporter_sent_spans", 0)
@@ -4511,8 +4516,16 @@ for surface in ("local", "cluster"):
 
 memberships = dict(
     (surface, records[surface].get("langfuse_observation_membership") is True)
-    for surface in ("local", "cluster")
+    for surface in records
 )
+if len(records) == 1:
+    surface = next(iter(records))
+    if memberships[surface]:
+        print(f"curie-clear: Langfuse exact observation membership passed on {surface}")
+        raise SystemExit(0)
+    print(f"curie-unresolved: {surface} exact Langfuse membership is missing without a sibling control")
+    raise SystemExit(1)
+
 same_id_raw_receipts = dict(
     (surface, records[surface].get("same_id_raw_collector_receipt") is True)
     for surface in ("local", "cluster")

--- a/cli/scripts/e2e-ladder.sh
+++ b/cli/scripts/e2e-ladder.sh
@@ -213,12 +213,13 @@ LAST_MCP_MEMBERSHIP=""
 LAST_APPROVAL_MEMBERSHIP=""
 LAST_QUERY_MEMBERSHIP=""
 LAST_QUERY_OBSERVATION_COUNT="0"
-CLUSTER_TURN_TEMPLATE=""
-CLUSTER_SEEDED_TRACE_ID=""
-CLUSTER_SEEDED_REPLY_REF=""
+LAST_EXTERNAL_ACCEPTED_DELTA="0"
+LAST_EXTERNAL_SENT_DELTA="0"
 CLUSTER_IMAGE_IDS_MATCH="false"
 LOCAL_PRODUCT_EVIDENCE=""
 CLUSTER_PRODUCT_EVIDENCE=""
+PRODUCT_OBSERVABILITY_RUN_ID="${CURIE_E2E_PRODUCT_RUN_ID:-}"
+CLUSTER_EXTERNAL_INGRESS_RECEIPT="${CURIE_E2E_CLUSTER_EXTERNAL_INGRESS_RECEIPT:-}"
 
 # The component label every connector container carries, in both the skill start
 # path and the local compose overlay (cli/src/docker.rs
@@ -319,7 +320,6 @@ fi
 WORKDIR="$(mktemp -d)"
 LOCAL_PRODUCT_EVIDENCE="$WORKDIR/product-observability-local.json"
 CLUSTER_PRODUCT_EVIDENCE="$WORKDIR/product-observability-cluster.json"
-CLUSTER_TURN_TEMPLATE="$WORKDIR/cluster-turn-template.json"
 cleanup() {
     # Capture the real exit code FIRST: a teardown command that fails must not
     # turn a red run green, and a successful teardown must not mask a red rung.
@@ -689,24 +689,35 @@ PY
     printf '%s' "$trace_id"
 }
 
-# Capture one validated disconnected-cluster turn as a private shape template.
-# The payload-only control itself is never treated as correlation evidence.
-capture_cluster_turn_template() {
-    local marker="$1" stream_start="$2" stream_end="$3" private_slice
+# The disconnected CLI path is intentionally carrierless (#1817). Exercise it
+# as a compatibility negative and prove it did not accidentally grow a W3C
+# carrier. It is never promoted into positive correlation evidence.
+seed_cluster_missing_carrier_control() {
+    local marker="curie-seed-cluster-missing-carrier-$$-$RANDOM"
+    local stream_start stream_end out private_slice
+    stream_start="$(capture_stream_cursor cluster)" || return 1
+    out="$("$BIN" --json cluster message --namespace "$CURIE_NAMESPACE" \
+        --release "$CURIE_RELEASE" "missing carrier compatibility $marker" || true)"
+    assert_finalized_reply "cluster missing-carrier compatibility" "$out"
+    stream_end="$(capture_stream_cursor cluster)" || return 1
+    [[ "$stream_end" != "$stream_start" ]] || {
+        echo "seed-invalid: cluster missing-carrier control produced no stream receipt" >&2
+        return 1
+    }
     umask 077
-    private_slice="$(mktemp "$WORKDIR/cluster-template-stream.XXXXXX")"
+    private_slice="$(mktemp "$WORKDIR/cluster-missing-carrier.XXXXXX")"
     product_stream_json cluster XRANGE curie:runs "($stream_start" "$stream_end" > "$private_slice" || {
         rm -f "$private_slice"
         return 1
     }
-    python3 - "$private_slice" "$marker" "$CLUSTER_TURN_TEMPLATE" <<'PY'
+    python3 - "$private_slice" "$marker" <<'PY'
 import json, pathlib, sys
 rows = json.loads(pathlib.Path(sys.argv[1]).read_text())
 marker = sys.argv[2]
 matches = []
 for row in rows:
     if not isinstance(row, list) or len(row) != 2 or not isinstance(row[1], list):
-        raise SystemExit("seed-invalid: malformed cluster template slice")
+        raise SystemExit("seed-invalid: malformed cluster missing-carrier slice")
     fields = row[1]
     for index in range(0, len(fields) - 1, 2):
         if fields[index] != "payload":
@@ -716,107 +727,115 @@ for row in rows:
         except (TypeError, json.JSONDecodeError):
             continue
         text = payload.get("text") if isinstance(payload, dict) else None
-        if isinstance(text, str) and marker in text:
-            matches.append(payload)
-if len(matches) != 1:
-    raise SystemExit("seed-invalid: cluster control did not select one private turn template")
-handle = matches[0].get("reply_handle")
-if not isinstance(handle, dict) or handle.get("adapter") != "curie-cluster-message":
-    raise SystemExit("seed-invalid: cluster control omitted the reserved reply adapter")
-pathlib.Path(sys.argv[3]).write_text(json.dumps(matches[0], separators=(",", ":")))
+        if not isinstance(text, str) or marker not in text:
+            continue
+        handle = payload.get("reply_handle")
+        if not isinstance(handle, dict) or handle.get("adapter") != "curie-cluster-message":
+            raise SystemExit("seed-invalid: cluster compatibility control used the wrong producer")
+        has_adjacent_carrier = index + 3 < len(fields) and fields[index + 2] == "traceparent"
+        matches.append(has_adjacent_carrier)
+if matches != [False]:
+    raise SystemExit("seed-invalid: cluster compatibility control was absent, ambiguous, or carried context")
 PY
     rm -f "$private_slice"
+    echo "cluster missing-carrier compatibility: finalized=true adjacent_traceparent=false"
 }
 
-# Re-seed the validated cluster shape with fresh identifiers and an explicit
-# adjacent W3C carrier. This is a turn/data mutation only in the operator-owned
-# release; it never installs, upgrades, deletes, or rewrites cluster resources.
-enqueue_cluster_carried_turn() {
-    local marker="$1" text="$2" private_payload private_meta payload raw_id stream_start stream_end discovered traceparent
-    [[ -s "$CLUSTER_TURN_TEMPLATE" ]] || {
-        echo "seed-invalid: cluster carried seed lacks its validated control template" >&2
+# Positive cluster evidence belongs to the real Slack phase. The private
+# receipt carries only bounded cursors, a public-safe marker, and independently
+# observed outcome booleans. The trace id is derived here from the accepted
+# Slack queue entry; no caller-supplied id and no harness XADD are accepted.
+cluster_external_ingress_seed() {
+    local kind="$1" expected_operations="$2" expected_decision="${3:-}"
+    local receipt="$CLUSTER_EXTERNAL_INGRESS_RECEIPT" fields marker stream_start stream_end trace_id
+    [[ -n "$PRODUCT_OBSERVABILITY_RUN_ID" ]] || {
+        echo "cluster product evidence blocked: CURIE_E2E_PRODUCT_RUN_ID is required to join one supported run" >&2
         return 1
     }
-    umask 077
-    private_payload="$(mktemp "$WORKDIR/cluster-carried-payload.XXXXXX")"
-    private_meta="$(mktemp "$WORKDIR/cluster-carried-meta.XXXXXX")"
-    python3 - "$CLUSTER_TURN_TEMPLATE" "$private_payload" "$private_meta" "$text" <<'PY'
-import json, pathlib, secrets, sys, uuid
-from datetime import UTC, datetime
-
+    [[ -n "$receipt" && -f "$receipt" ]] || {
+        echo "cluster product evidence blocked: the external Slack phase did not provide CURIE_E2E_CLUSTER_EXTERNAL_INGRESS_RECEIPT" >&2
+        return 1
+    }
+    [[ "$(stat -c '%a' "$receipt")" == "600" ]] || {
+        echo "cluster product evidence blocked: the external Slack ingress receipt must be mode 0600" >&2
+        return 1
+    }
+    fields="$(python3 - "$receipt" "$PRODUCT_OBSERVABILITY_RUN_ID" "$kind" <<'PY'
+import json, pathlib, re, sys
 value = json.loads(pathlib.Path(sys.argv[1]).read_text())
-reply_ref = str(uuid.uuid4())
-trace_id = secrets.token_hex(16)
-span_id = secrets.token_hex(8)
-value["event_id"] = f"EvSIM-{uuid.uuid4()}"
-value["conversation_id"] = f"C0EXAMPLE1:{uuid.uuid4()}"
-value["text"] = sys.argv[4]
-value["received_at"] = datetime.now(UTC).isoformat()
-value["reply_handle"]["placeholder"] = reply_ref
-pathlib.Path(sys.argv[2]).write_text(json.dumps(value, separators=(",", ":")))
-pathlib.Path(sys.argv[3]).write_text(json.dumps({
-    "trace_id": trace_id,
-    "traceparent": f"00-{trace_id}-{span_id}-01",
-    "reply_ref": reply_ref,
-}, separators=(",", ":")))
+run_id, kind = sys.argv[2:4]
+if not isinstance(value, dict) or value.get("run_id") != run_id:
+    raise SystemExit("external Slack ingress receipt belongs to a different run")
+seeds = value.get("seeds")
+if not isinstance(seeds, list):
+    raise SystemExit("external Slack ingress receipt omitted seeds")
+matches = [seed for seed in seeds if isinstance(seed, dict) and seed.get("kind") == kind]
+if len(matches) != 1:
+    raise SystemExit("external Slack ingress receipt did not contain exactly one requested seed")
+seed = matches[0]
+marker = seed.get("marker")
+start = seed.get("stream_start")
+end = seed.get("stream_end")
+if not isinstance(marker, str) or not marker.startswith(f"curie-seed-external-{kind}-"):
+    raise SystemExit("external Slack ingress marker is not public-safe and kind-bound")
+if not all(isinstance(item, str) and re.fullmatch(r"[0-9]+-[0-9]+", item) for item in (start, end)):
+    raise SystemExit("external Slack ingress receipt omitted bounded stream cursors")
+if seed.get("reply_observed") is not True or seed.get("completion_observed") is not True:
+    raise SystemExit("external Slack driver did not independently observe reply and completion")
+if kind == "mcp" and seed.get("mcp_call_count_delta") != 1:
+    raise SystemExit("external MCP seed omitted its independent one-call receipt")
+if kind == "approval" and seed.get("approval_transition_observed") is not True:
+    raise SystemExit("external approval seed omitted its independent transition receipt")
+accepted = seed.get("otelcol_receiver_accepted_spans_delta")
+sent = seed.get("otelcol_exporter_sent_spans_delta")
+if not all(isinstance(item, (int, float)) and not isinstance(item, bool) and item > 0 for item in (accepted, sent)):
+    raise SystemExit("external Slack seed omitted positive observed Collector deltas")
+print(marker, start, end, accepted, sent)
 PY
-    stream_start="$(capture_stream_cursor cluster)" || return 1
-    payload="$(cat "$private_payload")"
-    read -r CLUSTER_SEEDED_TRACE_ID traceparent CLUSTER_SEEDED_REPLY_REF < <(python3 - "$private_meta" <<'PY'
-import json, pathlib, sys
-value = json.loads(pathlib.Path(sys.argv[1]).read_text())
-print(value["trace_id"], value["traceparent"], value["reply_ref"])
-PY
-    )
-    raw_id="$(product_stream_json cluster XADD curie:runs '*' payload "$payload" traceparent "$traceparent")" || return 1
-    stream_end="$(printf '%s' "$raw_id" | python3 -c 'import json,sys; value=json.load(sys.stdin); print(value if isinstance(value,str) else "")')"
-    rm -f "$private_payload" "$private_meta"
-    [[ -n "$stream_end" && "$stream_end" != "$stream_start" ]] || {
-        echo "seed-invalid: explicit cluster carrier seed produced no stream entry" >&2
-        return 1
-    }
-    discovered="$(discover_trace_id_for_seed cluster "$marker" "$stream_start" "$stream_end")" || return 1
-    [[ "$discovered" == "$CLUSTER_SEEDED_TRACE_ID" ]] || {
-        echo "seed-invalid: explicit cluster carrier did not round-trip to its exact trace id" >&2
-        return 1
-    }
+)" || return 1
+    read -r marker stream_start stream_end LAST_EXTERNAL_ACCEPTED_DELTA LAST_EXTERNAL_SENT_DELTA <<< "$fields"
+    trace_id="$(discover_cluster_external_trace_id "$marker" "$stream_start" "$stream_end")" || return 1
+    query_exact_seed_trace cluster "$trace_id" "$expected_operations" "$expected_decision" observe
 }
 
-wait_cluster_carried_reply() {
-    local reply_ref="$1" terminal_key events_key private_events terminal attempt
-    [[ "$reply_ref" =~ ^[0-9a-f-]{36}$ ]] || return 1
-    terminal_key="curie:cluster-message-replies:{$reply_ref}:terminal"
-    events_key="curie:cluster-message-replies:{$reply_ref}:events"
+discover_cluster_external_trace_id() {
+    local marker="$1" stream_start="$2" stream_end="$3" private_slice trace_id
     umask 077
-    private_events="$(mktemp "$WORKDIR/cluster-carried-reply.XXXXXX")"
-    terminal=""
-    for attempt in $(seq 1 120); do
-        terminal="$(product_stream_json cluster GET "$terminal_key" 2>/dev/null || true)"
-        if [[ "$terminal" == '"1"' ]]; then
-            break
-        fi
-        sleep 1
-    done
-    [[ "$terminal" == '"1"' ]] || {
-        rm -f "$private_events"
-        echo "seed-invalid: explicit cluster carrier turn did not finalize" >&2
+    private_slice="$(mktemp "$WORKDIR/cluster-external-stream.XXXXXX")"
+    product_stream_json cluster XRANGE curie:runs "($stream_start" "$stream_end" > "$private_slice" || {
+        rm -f "$private_slice"
         return 1
     }
-    product_stream_json cluster LRANGE "$events_key" 0 -1 > "$private_events" || return 1
-    python3 - "$private_events" <<'PY'
-import json, pathlib, sys
+    trace_id="$(python3 - "$private_slice" "$marker" <<'PY'
+import json, pathlib, re, sys
 rows = json.loads(pathlib.Path(sys.argv[1]).read_text())
-events = []
+marker = sys.argv[2]
+carrier = re.compile(r"^00-([0-9a-f]{32})-[0-9a-f]{16}-[0-9a-f]{2}$")
+matches = []
 for row in rows:
-    value = json.loads(row) if isinstance(row, str) else None
-    if not isinstance(value, dict) or not isinstance(value.get("event"), str):
-        raise SystemExit("seed-invalid: cluster reply receipt is malformed")
-    events.append(value["event"])
-if "turn.completed" not in events or not any(item in {"reply.post", "reply.update"} for item in events):
-    raise SystemExit("seed-invalid: cluster reply receipt omitted reply or completion")
+    if not isinstance(row, list) or len(row) != 2 or not isinstance(row[1], list):
+        raise SystemExit("seed-invalid: malformed external Slack stream slice")
+    fields = row[1]
+    for index in range(0, len(fields), 2):
+        if fields[index] != "payload" or index + 3 >= len(fields) or fields[index + 2] != "traceparent":
+            continue
+        try:
+            payload = json.loads(fields[index + 1])
+        except (TypeError, json.JSONDecodeError):
+            continue
+        text = payload.get("text") if isinstance(payload, dict) else None
+        handle = payload.get("reply_handle") if isinstance(payload, dict) else None
+        match = carrier.fullmatch(fields[index + 3]) if isinstance(fields[index + 3], str) else None
+        if isinstance(text, str) and marker in text and isinstance(handle, dict) and handle.get("kind") == "slack" and handle.get("adapter") is None and match:
+            matches.append(match.group(1))
+matches = sorted(set(matches))
+if len(matches) != 1:
+    raise SystemExit("seed-invalid: exact external Slack marker did not select one real adjacent carrier")
+print(matches[0])
 PY
-    rm -f "$private_events"
-    echo "cluster carried seed: finalized=true reply_observed=true"
+)" || { rm -f "$private_slice"; return 1; }
+    rm -f "$private_slice"
+    printf '%s' "$trace_id"
 }
 
 # Convert a private exact-detail response into the sole public trace evidence.
@@ -840,7 +859,7 @@ private_fields = {"input", "output", "session", "user", "headers"}
 safe_operations = {
     "curie.queue.enqueue", "curie.queue.process", "curie.turn.process",
     "curie.sandbox.claim", "curie.runner.rpc", "agent.run", "execute_tool",
-    "curie.reply.post", "curie.reply.update", "curie.slack.receipt",
+    "curie.reply.post", "curie.reply.update", "curie.turn.ingress",
     "curie.approval.suspend", "curie.approval.resolve", "curie.approval.resume",
     }
 operations = []
@@ -1068,32 +1087,21 @@ seed_ordinary_turn() {
             return 1
         }
     else
+        if [[ "$tier" == "cluster" ]]; then
+            echo "seed-invalid: cluster positive correlation must come from the external Slack ingress receipt" >&2
+            return 1
+        fi
         stream_start="$(capture_stream_cursor "$tier")" || return 1
-        if [[ "$tier" == "local" ]]; then
-            out="$("$BIN" --json local message --channel C0LOCALDEV "ordinary correlation $marker" || true)"
-        else
-            out="$("$BIN" --json cluster message --namespace "$CURIE_NAMESPACE" \
-                --release "$CURIE_RELEASE" "ordinary correlation $marker" || true)"
-        fi
+        out="$("$BIN" --json local message --channel C0LOCALDEV "ordinary correlation $marker" || true)"
         assert_finalized_reply "$tier ordinary correlation" "$out"
-        if [[ "$tier" == "local" ]]; then
-            assert_product_runner_endpoints
-        fi
+        assert_product_runner_endpoints
         stream_end="$(capture_stream_cursor "$tier")" || return 1
         [[ "$stream_end" != "$stream_start" ]] || {
             echo "seed-invalid: ordinary seed produced no bounded stream receipt" >&2
             return 1
         }
-        if [[ "$tier" == "cluster" ]]; then
-            capture_cluster_turn_template "$marker" "$stream_start" "$stream_end" || return 1
-            enqueue_cluster_carried_turn "$marker" "ordinary correlation $marker" || return 1
-            wait_cluster_carried_reply "$CLUSTER_SEEDED_REPLY_REF" || return 1
-            trace_id="$CLUSTER_SEEDED_TRACE_ID"
-            expected_operations="curie.queue.process,curie.turn.process,curie.sandbox.claim,curie.runner.rpc,agent.run,curie.reply.post|curie.reply.update"
-        else
-            trace_id="$(discover_trace_id_for_seed "$tier" "$marker" "$stream_start" "$stream_end")" || return 1
-            expected_operations="curie.queue.enqueue,curie.queue.process,curie.turn.process,curie.sandbox.claim,curie.runner.rpc,agent.run,curie.reply.post|curie.reply.update"
-        fi
+        trace_id="$(discover_trace_id_for_seed "$tier" "$marker" "$stream_start" "$stream_end")" || return 1
+        expected_operations="curie.queue.enqueue,curie.queue.process,curie.turn.process,curie.sandbox.claim,curie.runner.rpc,agent.run,curie.reply.post|curie.reply.update"
     fi
     query_exact_seed_trace "$tier" "$trace_id" "$expected_operations" "" "$query_state"
     LAST_ORDINARY_TRACE_ID="$trace_id"
@@ -1108,42 +1116,29 @@ seed_mcp_read_turn() {
         echo "seed-invalid: MCP read seed needs live mode, a deployed agent, and a marker before telemetry" >&2
         return 1
     fi
-    if [[ "$tier" == "local" ]]; then
-        local worker
-        worker="$(local_worker_container)"
-        release="$(container_env_value "$worker" CURIE_RELEASE)"
-        namespace="$(container_env_value "$worker" CURIE_NAMESPACE)"
-    else
-        release="$CURIE_RELEASE"
-        namespace="$CURIE_NAMESPACE"
+    if [[ "$tier" == "cluster" ]]; then
+        echo "seed-invalid: cluster MCP correlation must come from the external Slack ingress receipt" >&2
+        return 1
     fi
+    local worker
+    worker="$(local_worker_container)"
+    release="$(container_env_value "$worker" CURIE_RELEASE)"
+    namespace="$(container_env_value "$worker" CURIE_NAMESPACE)"
     alias="$(connector_object_name "$release" "$agent_name" "$MCP_RECEIPT_CONNECTOR").$namespace.svc.cluster.local"
     MCP_RECEIPT_ALIAS="$alias"
     before_count="$(mcp_receipt_call_count "$tier" "$alias")" || return 1
-    if [[ "$tier" == "local" ]]; then
-        stream_start="$(capture_stream_cursor "$tier")" || return 1
-        out="$("$BIN" --json local message --channel C0LOCALDEV \
-            "Call the receipt_read tool exactly once, then answer receipt complete. $marker" || true)"
-    else
-        enqueue_cluster_carried_turn "$marker" \
-            "Call the receipt_read tool exactly once, then answer receipt complete. $marker" || return 1
-        wait_cluster_carried_reply "$CLUSTER_SEEDED_REPLY_REF" || return 1
-    fi
-    if [[ "$tier" == "local" ]]; then
-        assert_finalized_reply "$tier MCP correlation" "$out"
-    fi
+    stream_start="$(capture_stream_cursor "$tier")" || return 1
+    out="$("$BIN" --json local message --channel C0LOCALDEV \
+        "Call the receipt_read tool exactly once, then answer receipt complete. $marker" || true)"
+    assert_finalized_reply "$tier MCP correlation" "$out"
     after_count="$(mcp_receipt_call_count "$tier" "$alias")" || return 1
     if (( after_count != before_count + 1 )); then
         echo "seed-invalid: MCP seed did not produce exactly one independent call receipt" >&2
         return 1
     fi
     echo "MCP receipt call count delta=1"
-    if [[ "$tier" == "local" ]]; then
-        stream_end="$(capture_stream_cursor "$tier")" || return 1
-        trace_id="$(discover_trace_id_for_seed "$tier" "$marker" "$stream_start" "$stream_end")" || return 1
-    else
-        trace_id="$CLUSTER_SEEDED_TRACE_ID"
-    fi
+    stream_end="$(capture_stream_cursor "$tier")" || return 1
+    trace_id="$(discover_trace_id_for_seed "$tier" "$marker" "$stream_start" "$stream_end")" || return 1
     query_exact_seed_trace "$tier" "$trace_id" "execute_tool" "" "$query_state"
     LAST_MCP_TRACE_ID="$trace_id"
     LAST_MCP_MEMBERSHIP="$LAST_QUERY_MEMBERSHIP"
@@ -1158,14 +1153,15 @@ seed_approval_resume_turn() {
         echo "seed-invalid: deterministic approval seed needs fake mode and a deployed agent before telemetry" >&2
         return 1
     fi
+    if [[ "$tier" == "cluster" ]]; then
+        echo "seed-invalid: cluster approval correlation must come from the external Slack ingress receipt" >&2
+        return 1
+    fi
     umask 077
     message_file="$(mktemp "$WORKDIR/approval-message.XXXXXX")"
     token_file="$(mktemp "$WORKDIR/approval-token.XXXXXX")"
     pending_file="$(mktemp "$WORKDIR/approval-pending.XXXXXX")"
     local scope=()
-    if [[ "$tier" == "cluster" ]]; then
-        scope=(--namespace "$CURIE_NAMESPACE" --release "$CURIE_RELEASE")
-    fi
     "$BIN" --json "$tier" approvals "$agent_id" "${scope[@]}" \
         --route-resolution e2e=C0EXAMPLE1 --route-approvers e2e=users:U0EXAMPLE1 \
         >/dev/null
@@ -1184,16 +1180,10 @@ PY
         return 1
     }
     rm -f "$token_file"
-    if [[ "$tier" == "local" ]]; then
-        stream_start="$(capture_stream_cursor "$tier")" || return 1
-        "$BIN" --json local message --channel C0LOCALDEV --timeout-secs 120 \
-            "[fake:request-approval:e2e] approve correlation $marker" > "$message_file" 2>/dev/null &
-        message_pid=$!
-    else
-        enqueue_cluster_carried_turn "$marker" \
-            "[fake:request-approval:e2e] approve correlation $marker" || return 1
-        trace_id="$CLUSTER_SEEDED_TRACE_ID"
-    fi
+    stream_start="$(capture_stream_cursor "$tier")" || return 1
+    "$BIN" --json local message --channel C0LOCALDEV --timeout-secs 120 \
+        "[fake:request-approval:e2e] approve correlation $marker" > "$message_file" 2>/dev/null &
+    message_pid=$!
     approval_id=""
     for attempt in $(seq 1 60); do
         if "$BIN" --json "$tier" approvals "$agent_id" "${scope[@]}" --list > "$pending_file" 2>/dev/null; then
@@ -1211,10 +1201,8 @@ PY
     done
     rm -f "$pending_file"
     if [[ -z "$approval_id" ]]; then
-        if [[ "$tier" == "local" ]]; then
-            kill "$message_pid" 2>/dev/null || true
-            wait "$message_pid" 2>/dev/null || true
-        fi
+        kill "$message_pid" 2>/dev/null || true
+        wait "$message_pid" 2>/dev/null || true
         rm -f "$message_file"
         echo "seed-invalid: awaiting-approval record did not become pending" >&2
         return 1
@@ -1222,21 +1210,16 @@ PY
     CURIE_APPROVAL_PRINCIPAL_TOKEN="$token" "$BIN" --json "$tier" approvals "$agent_id" \
         "${scope[@]}" --resolve "$approval_id" >/dev/null
     unset token
-    if [[ "$tier" == "local" ]]; then
-        wait "$message_pid" || code=$?
-        out="$(cat "$message_file")"
-        rm -f "$message_file"
-        if (( code != 0 )); then
-            echo "seed-invalid: approval resolution did not resume to a final reply" >&2
-            return 1
-        fi
-        assert_finalized_reply "$tier approval resume" "$out"
-        stream_end="$(capture_stream_cursor "$tier")" || return 1
-        trace_id="$(discover_trace_id_for_seed "$tier" "$marker" "$stream_start" "$stream_end")" || return 1
-    else
-        rm -f "$message_file"
-        wait_cluster_carried_reply "$CLUSTER_SEEDED_REPLY_REF" || return 1
+    wait "$message_pid" || code=$?
+    out="$(cat "$message_file")"
+    rm -f "$message_file"
+    if (( code != 0 )); then
+        echo "seed-invalid: approval resolution did not resume to a final reply" >&2
+        return 1
     fi
+    assert_finalized_reply "$tier approval resume" "$out"
+    stream_end="$(capture_stream_cursor "$tier")" || return 1
+    trace_id="$(discover_trace_id_for_seed "$tier" "$marker" "$stream_start" "$stream_end")" || return 1
     query_exact_seed_trace "$tier" "$trace_id" \
         "curie.approval.suspend,curie.approval.resolve,curie.approval.resume,curie.reply.post|curie.reply.update" \
         "approved" "$query_state"
@@ -4023,7 +4006,7 @@ print(accepted_after - accepted_before, sent_after - sent_before)
 PY
     )
     write_product_observability_evidence "$LOCAL_PRODUCT_EVIDENCE" local \
-        "$product_accepted_delta" "$product_sent_delta" "$product_membership" not-applicable
+        "$product_accepted_delta" "$product_sent_delta" "$product_membership" not-applicable false
 
     if [[ -z "${STUB_STATE:-}" && "$LAST_ORDINARY_MEMBERSHIP" == "true" ]] && (( LOCAL_STACK_OWNED )); then
         case_local_langfuse_invalid_auth "$agent_id"
@@ -4390,18 +4373,24 @@ print(total)
 
 write_product_observability_evidence() {
     local destination="$1" surface="$2" accepted_delta="$3" sent_delta="$4" membership="$5" image_match="$6"
-    python3 - "$destination" "$surface" "$accepted_delta" "$sent_delta" "$membership" "$image_match" <<'PY'
+    local same_id_raw_receipt="$7"
+    python3 - "$destination" "$surface" "$accepted_delta" "$sent_delta" "$membership" "$image_match" \
+        "$same_id_raw_receipt" "$PRODUCT_OBSERVABILITY_RUN_ID" <<'PY'
 import json, pathlib, sys
-destination, surface, accepted_raw, sent_raw, membership_raw, image_raw = sys.argv[1:7]
+destination, surface, accepted_raw, sent_raw, membership_raw, image_raw, same_id_raw, run_id = sys.argv[1:9]
 accepted = float(accepted_raw)
 sent = float(sent_raw)
 if membership_raw not in {"true", "false"}:
     raise SystemExit("exact Langfuse membership was not observed")
 if image_raw not in {"true", "false", "not-applicable"}:
     raise SystemExit("image identity verdict was not observed")
+if same_id_raw not in {"true", "false"}:
+    raise SystemExit("same-ID raw Collector receipt verdict was not observed")
 record = {
+    "run_id": run_id,
     "surface": surface,
     "seed_valid": accepted > 0 and sent > 0,
+    "same_id_raw_collector_receipt": same_id_raw == "true",
     "raw_emitted_observations": accepted,
     "otelcol_receiver_accepted_spans": accepted,
     "otelcol_exporter_sent_spans": sent,
@@ -4415,34 +4404,42 @@ PY
 }
 
 run_cluster_product_observability() {
-    local agent_id="$1" agent_name="$2" accepted_before sent_before accepted_after sent_after
-    local accepted_delta sent_delta membership
+    local agent_id="$1" agent_name="$2" membership accepted_delta sent_delta
     preflight_cluster_product_observability
-    accepted_before="$(cluster_collector_metric_value otelcol_receiver_accepted_spans)"
-    sent_before="$(cluster_collector_metric_value otelcol_exporter_sent_spans)"
-    seed_ordinary_turn cluster "$agent_id" observe
-    membership="$LAST_ORDINARY_MEMBERSHIP"
+    seed_cluster_missing_carrier_control
+    cluster_external_ingress_seed ordinary \
+        "curie.turn.ingress,curie.queue.enqueue,curie.queue.process,curie.turn.process,curie.sandbox.claim,curie.runner.rpc,agent.run,curie.reply.post|curie.reply.update"
+    membership="$LAST_QUERY_MEMBERSHIP"
+    accepted_delta="$LAST_EXTERNAL_ACCEPTED_DELTA"
+    sent_delta="$LAST_EXTERNAL_SENT_DELTA"
     if [[ "$LIVE" == "0" ]]; then
-        seed_approval_resume_turn cluster "$agent_id" observe
-        [[ "$LAST_APPROVAL_MEMBERSHIP" == "true" ]] || membership="false"
+        cluster_external_ingress_seed approval \
+            "curie.turn.ingress,curie.queue.enqueue,curie.approval.suspend,curie.approval.resolve,curie.approval.resume,curie.reply.post|curie.reply.update" \
+            approved
+        [[ "$LAST_QUERY_MEMBERSHIP" == "true" ]] || membership="false"
     else
-        seed_mcp_read_turn cluster "$agent_id" "$agent_name" observe
-        [[ "$LAST_MCP_MEMBERSHIP" == "true" ]] || membership="false"
+        cluster_external_ingress_seed mcp \
+            "curie.turn.ingress,curie.queue.enqueue,execute_tool,curie.reply.post|curie.reply.update"
+        [[ "$LAST_QUERY_MEMBERSHIP" == "true" ]] || membership="false"
     fi
-    # Each seed helper performs the exact candidate read equivalent to:
-    # curie --json cluster observability run "$trace_id"
-    accepted_after="$(cluster_collector_metric_value otelcol_receiver_accepted_spans)"
-    sent_after="$(cluster_collector_metric_value otelcol_exporter_sent_spans)"
     read -r accepted_delta sent_delta < <(python3 - \
-        "$accepted_after" "$accepted_before" "$sent_after" "$sent_before" <<'PY'
+        "$accepted_delta" "$LAST_EXTERNAL_ACCEPTED_DELTA" \
+        "$sent_delta" "$LAST_EXTERNAL_SENT_DELTA" <<'PY'
 import sys
-accepted_after, accepted_before, sent_after, sent_before = map(float, sys.argv[1:5])
-print(accepted_after - accepted_before, sent_after - sent_before)
+accepted_first, accepted_second, sent_first, sent_second = map(float, sys.argv[1:5])
+print(accepted_first + accepted_second, sent_first + sent_second)
 PY
     )
+    # Each external seed performs the exact candidate read equivalent to
+    # `curie --json cluster observability run <derived-trace-id>`.
+    # Exact Langfuse reads above are valid external-ingress evidence, but the
+    # shipped Collector exposes only aggregate counters. It has no supported
+    # same-trace raw-receipt read. Record that fact explicitly: exact membership
+    # can still clear end-to-end ingest, while missing membership cannot blame
+    # the adopted backend without the stronger raw receipt.
     write_product_observability_evidence "$CLUSTER_PRODUCT_EVIDENCE" cluster \
-        "$accepted_delta" "$sent_delta" "$membership" "$CLUSTER_IMAGE_IDS_MATCH"
-    echo "cluster product observability: Collector deltas and exact-ID membership recorded"
+        "$accepted_delta" "$sent_delta" "$membership" "$CLUSTER_IMAGE_IDS_MATCH" false
+    echo "cluster product observability: exact ingest membership and observed Collector deltas recorded"
 }
 
 classify_product_observability_owner() {
@@ -4455,8 +4452,43 @@ for surface, raw_path in zip(("local", "cluster"), sys.argv[1:]):
     path = pathlib.Path(raw_path)
     if not path.is_file():
         print("curie-unresolved: both product surfaces have not been exercised")
-        raise SystemExit(0)
-    records[surface] = json.loads(path.read_text())
+        raise SystemExit(1)
+    try:
+        records[surface] = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        print(f"curie-unresolved: {surface} evidence is unreadable")
+        raise SystemExit(1)
+
+required_fields = (
+    "run_id", "surface", "seed_valid", "same_id_raw_collector_receipt",
+    "raw_emitted_observations", "otelcol_receiver_accepted_spans",
+    "otelcol_exporter_sent_spans", "langfuse_observation_membership",
+    "image_ids_match",
+)
+for surface, record in records.items():
+    numeric = (
+        record.get("raw_emitted_observations"),
+        record.get("otelcol_receiver_accepted_spans"),
+        record.get("otelcol_exporter_sent_spans"),
+    )
+    if (
+        not all(field in record for field in required_fields)
+        or record.get("surface") != surface
+        or not isinstance(record.get("run_id"), str)
+        or not all(isinstance(record.get(field), bool) for field in (
+            "seed_valid", "same_id_raw_collector_receipt",
+            "langfuse_observation_membership",
+        ))
+        or not all(isinstance(item, (int, float)) and not isinstance(item, bool) for item in numeric)
+        or record.get("image_ids_match") not in {True, False, None}
+    ):
+        print(f"curie-unresolved: {surface} evidence is incomplete or malformed")
+        raise SystemExit(1)
+
+run_ids = {record.get("run_id") for record in records.values()}
+if len(run_ids) != 1 or not next(iter(run_ids), None):
+    print("curie-unresolved: product evidence did not come from one supported run")
+    raise SystemExit(1)
 
 # These names deliberately mirror the evidence record. Ownership cannot be
 # assigned away from Curie until both product surfaces clear every prerequisite.
@@ -4475,18 +4507,28 @@ for surface in ("local", "cluster"):
         and seed_valid
     ):
         print("curie-owned: raw export, delivery, image identity, or seed precondition failed")
-        raise SystemExit(0)
+        raise SystemExit(1)
 
 memberships = dict(
     (surface, records[surface].get("langfuse_observation_membership") is True)
     for surface in ("local", "cluster")
 )
-if not memberships["local"] and not memberships["cluster"]:
-    print("adopted-component: Langfuse omitted observations after successful local and cluster raw export")
-elif not all(memberships.values()):
-    print("curie-owned: local and cluster exact Langfuse membership disagreed")
-else:
+same_id_raw_receipts = dict(
+    (surface, records[surface].get("same_id_raw_collector_receipt") is True)
+    for surface in ("local", "cluster")
+)
+if memberships["local"] and memberships["cluster"]:
     print("curie-clear: Langfuse exact observation membership passed on local and cluster")
+    raise SystemExit(0)
+elif memberships["local"] != memberships["cluster"]:
+    print("curie-owned: local and cluster exact Langfuse membership disagreed")
+    raise SystemExit(1)
+elif same_id_raw_receipts["local"] and same_id_raw_receipts["cluster"]:
+    print("adopted-component: Langfuse omitted observations after successful local and cluster raw export")
+    raise SystemExit(1)
+else:
+    print("curie-unresolved: missing Langfuse membership without same-ID raw Collector receipts")
+    raise SystemExit(1)
 PY
 }
 

--- a/cli/scripts/fixtures/mcp-receipt/Dockerfile
+++ b/cli/scripts/fixtures/mcp-receipt/Dockerfile
@@ -3,5 +3,7 @@ FROM python:3.12-slim
 WORKDIR /srv
 COPY server.py /srv/server.py
 USER 65534:65534
+# The hosted connector's network boundary restricts peers. The fixture itself
+# has no credential surface and its stdout receipt is evidence, not authority.
 EXPOSE 8000
 ENTRYPOINT ["python", "-u", "/srv/server.py"]

--- a/cli/scripts/fixtures/mcp-receipt/Dockerfile
+++ b/cli/scripts/fixtures/mcp-receipt/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.12-slim
+
+WORKDIR /srv
+COPY server.py /srv/server.py
+USER 65534:65534
+EXPOSE 8000
+ENTRYPOINT ["python", "-u", "/srv/server.py"]

--- a/cli/scripts/fixtures/mcp-receipt/server.py
+++ b/cli/scripts/fixtures/mcp-receipt/server.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Deterministic read-only MCP server used by the correlation ladder.
+
+The only durable receipt is a countable marker. Request bodies, tool arguments,
+session identifiers, and headers are deliberately never written to stdout.
+"""
+
+from __future__ import annotations
+
+import json
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+
+
+TOOL = {
+    "name": "receipt_read",
+    "description": "Return a deterministic, non-sensitive read receipt.",
+    "inputSchema": {"type": "object", "properties": {}, "additionalProperties": False},
+}
+
+
+def response_for(message: dict[str, Any]) -> dict[str, Any] | None:
+    request_id = message.get("id")
+    method = message.get("method")
+    if request_id is None:
+        return None
+    if method == "initialize":
+        requested = message.get("params", {}).get("protocolVersion")
+        return {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": {
+                "protocolVersion": requested or "2025-03-26",
+                "capabilities": {"tools": {"listChanged": False}},
+                "serverInfo": {"name": "curie-mcp-receipt", "version": "1"},
+            },
+        }
+    if method == "tools/list":
+        return {"jsonrpc": "2.0", "id": request_id, "result": {"tools": [TOOL]}}
+    if method == "tools/call":
+        params = message.get("params")
+        if not isinstance(params, dict) or params.get("name") != TOOL["name"]:
+            return {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "error": {"code": -32602, "message": "unknown read-only tool"},
+            }
+        print("MCP_RECEIPT tools/call", flush=True)
+        return {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": {
+                "content": [{"type": "text", "text": "receipt-ok"}],
+                "structuredContent": {"receipt": "ok"},
+                "isError": False,
+            },
+        }
+    return {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "error": {"code": -32601, "message": "method not found"},
+    }
+
+
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, _format: str, *args: object) -> None:
+        # The base implementation includes the request target and client IP.
+        return
+
+    def do_GET(self) -> None:  # noqa: N802 - stdlib handler API
+        self.send_error(HTTPStatus.METHOD_NOT_ALLOWED)
+
+    def do_POST(self) -> None:  # noqa: N802 - stdlib handler API
+        if self.path != "/mcp":
+            self.send_error(HTTPStatus.NOT_FOUND)
+            return
+        try:
+            length = int(self.headers.get("Content-Length", "0"))
+            if length <= 0 or length > 1_048_576:
+                raise ValueError("invalid request size")
+            decoded = json.loads(self.rfile.read(length))
+            messages = decoded if isinstance(decoded, list) else [decoded]
+            if not messages or not all(isinstance(item, dict) for item in messages):
+                raise ValueError("request is not a JSON-RPC object")
+            replies = [reply for item in messages if (reply := response_for(item)) is not None]
+        except (json.JSONDecodeError, TypeError, ValueError):
+            body = json.dumps(
+                {"jsonrpc": "2.0", "id": None, "error": {"code": -32700, "message": "invalid request"}},
+                separators=(",", ":"),
+            ).encode()
+            self.send_response(HTTPStatus.BAD_REQUEST)
+        else:
+            if not replies:
+                self.send_response(HTTPStatus.ACCEPTED)
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+                return
+            payload: object = replies if isinstance(decoded, list) else replies[0]
+            body = json.dumps(payload, separators=(",", ":")).encode()
+            self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+if __name__ == "__main__":
+    ThreadingHTTPServer(("0.0.0.0", 8000), Handler).serve_forever()

--- a/cli/scripts/fixtures/mcp-receipt/server.py
+++ b/cli/scripts/fixtures/mcp-receipt/server.py
@@ -1,50 +1,129 @@
 #!/usr/bin/env python3
 """Deterministic read-only MCP server used by the correlation ladder.
 
+This fixture deliberately uses only the Python standard library so its image
+does not acquire an independent MCP dependency. It implements the stateful
+Streamable HTTP handshake used by the runner: initialize, the initialized
+notification, a session-scoped SSE GET, tools/list, tools/call, and DELETE.
+
 The only durable receipt is a countable marker. Request bodies, tool arguments,
 session identifiers, and headers are deliberately never written to stdout.
+Reachability is restricted by the hosted connector's network boundary; the
+receipt marker is evidence of a call, not an authentication mechanism.
 """
 
 from __future__ import annotations
 
 import json
+import secrets
+import threading
+from dataclasses import dataclass, field
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
+
+MAX_REQUEST_BYTES = 1_048_576
+RUNNER_PROTOCOL_VERSION = "2025-03-26"
+SUPPORTED_PROTOCOL_VERSIONS = frozenset(
+    {
+        "2024-11-05",
+        RUNNER_PROTOCOL_VERSION,
+        "2025-06-18",
+        "2025-11-25",
+    }
+)
+DEFAULT_PROTOCOL_VERSION = "2025-11-25"
+SESSION_HEADER = "Mcp-Session-Id"
+PROTOCOL_HEADER = "MCP-Protocol-Version"
 
 TOOL = {
     "name": "receipt_read",
     "description": "Return a deterministic, non-sensitive read receipt.",
     "inputSchema": {"type": "object", "properties": {}, "additionalProperties": False},
+    "annotations": {
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": False,
+    },
 }
 
 
-def response_for(message: dict[str, Any]) -> dict[str, Any] | None:
-    request_id = message.get("id")
-    method = message.get("method")
-    if request_id is None:
+@dataclass
+class Session:
+    protocol_version: str
+    initialized: bool = False
+    terminated: threading.Event = field(default_factory=threading.Event)
+
+
+_sessions: dict[str, Session] = {}
+_sessions_lock = threading.RLock()
+
+
+def _jsonrpc_error(
+    request_id: str | int | None, code: int, message: str
+) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "error": {"code": code, "message": message},
+    }
+
+
+def _new_session(protocol_version: str) -> tuple[str, Session]:
+    session_id = secrets.token_urlsafe(24)
+    session = Session(protocol_version=protocol_version)
+    with _sessions_lock:
+        _sessions[session_id] = session
+    return session_id, session
+
+
+def _get_session(session_id: str | None) -> Session | None:
+    if not session_id:
         return None
-    if method == "initialize":
-        requested = message.get("params", {}).get("protocolVersion")
-        return {
-            "jsonrpc": "2.0",
-            "id": request_id,
-            "result": {
-                "protocolVersion": requested or "2025-03-26",
-                "capabilities": {"tools": {"listChanged": False}},
-                "serverInfo": {"name": "curie-mcp-receipt", "version": "1"},
-            },
-        }
+    with _sessions_lock:
+        return _sessions.get(session_id)
+
+
+def _terminate_session(session_id: str) -> bool:
+    with _sessions_lock:
+        session = _sessions.pop(session_id, None)
+    if session is None:
+        return False
+    session.terminated.set()
+    return True
+
+
+def response_for(message: dict[str, Any], session: Session) -> dict[str, Any] | None:
+    """Return one JSON-RPC response, or ``None`` for a notification."""
+
+    method = message.get("method")
+    if method == "notifications/initialized" and "id" not in message:
+        session.initialized = True
+        return None
+
+    if "id" not in message or message.get("id") is None:
+        # Notifications other than initialized are accepted without a response.
+        return None
+
+    request_id = message["id"]
+    if not isinstance(request_id, str | int) or isinstance(request_id, bool):
+        return _jsonrpc_error(None, -32600, "invalid request id")
+    if not session.initialized:
+        return _jsonrpc_error(request_id, -32002, "session is not initialized")
+    if method == "ping":
+        return {"jsonrpc": "2.0", "id": request_id, "result": {}}
     if method == "tools/list":
         return {"jsonrpc": "2.0", "id": request_id, "result": {"tools": [TOOL]}}
     if method == "tools/call":
         params = message.get("params")
-        if not isinstance(params, dict) or params.get("name") != TOOL["name"]:
-            return {
-                "jsonrpc": "2.0",
-                "id": request_id,
-                "error": {"code": -32602, "message": "unknown read-only tool"},
-            }
+        arguments = params.get("arguments", {}) if isinstance(params, dict) else None
+        if (
+            not isinstance(params, dict)
+            or params.get("name") != TOOL["name"]
+            or arguments not in ({}, None)
+        ):
+            return _jsonrpc_error(request_id, -32602, "unknown or invalid read-only tool")
         print("MCP_RECEIPT tools/call", flush=True)
         return {
             "jsonrpc": "2.0",
@@ -55,11 +134,7 @@ def response_for(message: dict[str, Any]) -> dict[str, Any] | None:
                 "isError": False,
             },
         }
-    return {
-        "jsonrpc": "2.0",
-        "id": request_id,
-        "error": {"code": -32601, "message": "method not found"},
-    }
+    return _jsonrpc_error(request_id, -32601, "method not found")
 
 
 class Handler(BaseHTTPRequestHandler):
@@ -69,46 +144,200 @@ class Handler(BaseHTTPRequestHandler):
         # The base implementation includes the request target and client IP.
         return
 
+    def _send_json(
+        self,
+        status: HTTPStatus,
+        payload: dict[str, Any] | list[dict[str, Any]],
+        *,
+        session_id: str | None = None,
+    ) -> None:
+        body = json.dumps(payload, separators=(",", ":")).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        if session_id is not None:
+            self.send_header(SESSION_HEADER, session_id)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _send_empty(
+        self, status: HTTPStatus, *, session_id: str | None = None
+    ) -> None:
+        self.send_response(status)
+        if session_id is not None:
+            self.send_header(SESSION_HEADER, session_id)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def _require_path(self) -> bool:
+        if self.path == "/mcp":
+            return True
+        self._send_json(
+            HTTPStatus.NOT_FOUND,
+            _jsonrpc_error(None, -32601, "MCP endpoint not found"),
+        )
+        return False
+
+    def _accepts(self, content_type: str) -> bool:
+        accept = self.headers.get("Accept", "")
+        return "*/*" in accept or content_type in accept
+
+    def _require_session(self) -> tuple[str, Session] | None:
+        session_id = self.headers.get(SESSION_HEADER)
+        session = _get_session(session_id)
+        if session_id is None:
+            self._send_json(
+                HTTPStatus.BAD_REQUEST,
+                _jsonrpc_error(None, -32600, "missing MCP session"),
+            )
+            return None
+        if session is None:
+            self._send_json(
+                HTTPStatus.NOT_FOUND,
+                _jsonrpc_error(None, -32600, "unknown MCP session"),
+            )
+            return None
+        requested_version = self.headers.get(PROTOCOL_HEADER)
+        if requested_version != session.protocol_version:
+            self._send_json(
+                HTTPStatus.BAD_REQUEST,
+                _jsonrpc_error(None, -32600, "invalid MCP protocol version"),
+                session_id=session_id,
+            )
+            return None
+        return session_id, session
+
     def do_GET(self) -> None:  # noqa: N802 - stdlib handler API
-        self.send_error(HTTPStatus.METHOD_NOT_ALLOWED)
+        if not self._require_path():
+            return
+        if not self._accepts("text/event-stream"):
+            self._send_json(
+                HTTPStatus.NOT_ACCEPTABLE,
+                _jsonrpc_error(None, -32600, "SSE response is not accepted"),
+            )
+            return
+        required = self._require_session()
+        if required is None:
+            return
+        session_id, session = required
+
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache, no-transform")
+        self.send_header("Connection", "keep-alive")
+        self.send_header(SESSION_HEADER, session_id)
+        self.end_headers()
+        try:
+            # A comment commits the response as SSE without fabricating a JSON-RPC
+            # notification. There are no server-initiated messages in this fixture.
+            self.wfile.write(b": receipt stream\n\n")
+            self.wfile.flush()
+            while not session.terminated.wait(timeout=10):
+                self.wfile.write(b": keep-alive\n\n")
+                self.wfile.flush()
+        except (BrokenPipeError, ConnectionResetError):
+            return
+        finally:
+            self.close_connection = True
 
     def do_POST(self) -> None:  # noqa: N802 - stdlib handler API
-        if self.path != "/mcp":
-            self.send_error(HTTPStatus.NOT_FOUND)
+        if not self._require_path():
             return
+        if not self._accepts("application/json") or not self._accepts(
+            "text/event-stream"
+        ):
+            self._send_json(
+                HTTPStatus.NOT_ACCEPTABLE,
+                _jsonrpc_error(None, -32600, "MCP response types are not accepted"),
+            )
+            return
+        if (
+            self.headers.get("Content-Type", "").split(";", 1)[0].strip()
+            != "application/json"
+        ):
+            self._send_json(
+                HTTPStatus.UNSUPPORTED_MEDIA_TYPE,
+                _jsonrpc_error(None, -32600, "expected application/json"),
+            )
+            return
+
         try:
             length = int(self.headers.get("Content-Length", "0"))
-            if length <= 0 or length > 1_048_576:
+            if length <= 0 or length > MAX_REQUEST_BYTES:
                 raise ValueError("invalid request size")
             decoded = json.loads(self.rfile.read(length))
             messages = decoded if isinstance(decoded, list) else [decoded]
             if not messages or not all(isinstance(item, dict) for item in messages):
                 raise ValueError("request is not a JSON-RPC object")
-            replies = [reply for item in messages if (reply := response_for(item)) is not None]
         except (json.JSONDecodeError, TypeError, ValueError):
-            body = json.dumps(
+            self._send_json(
+                HTTPStatus.BAD_REQUEST,
+                _jsonrpc_error(None, -32700, "invalid request"),
+            )
+            return
+
+        initialize = len(messages) == 1 and messages[0].get("method") == "initialize"
+        if initialize:
+            message = messages[0]
+            request_id = message.get("id")
+            params = message.get("params")
+            requested = params.get("protocolVersion") if isinstance(params, dict) else None
+            if request_id is None or not isinstance(requested, str):
+                self._send_json(
+                    HTTPStatus.BAD_REQUEST,
+                    _jsonrpc_error(request_id, -32602, "invalid initialize request"),
+                )
+                return
+            negotiated = (
+                requested
+                if requested in SUPPORTED_PROTOCOL_VERSIONS
+                else DEFAULT_PROTOCOL_VERSION
+            )
+            session_id, _session = _new_session(negotiated)
+            self._send_json(
+                HTTPStatus.OK,
                 {
                     "jsonrpc": "2.0",
-                    "id": None,
-                    "error": {"code": -32700, "message": "invalid request"},
+                    "id": request_id,
+                    "result": {
+                        "protocolVersion": negotiated,
+                        "capabilities": {"tools": {"listChanged": False}},
+                        "serverInfo": {"name": "curie-mcp-receipt", "version": "1"},
+                    },
                 },
-                separators=(",", ":"),
-            ).encode()
-            self.send_response(HTTPStatus.BAD_REQUEST)
-        else:
-            if not replies:
-                self.send_response(HTTPStatus.ACCEPTED)
-                self.send_header("Content-Length", "0")
-                self.end_headers()
-                return
-            payload: object = replies if isinstance(decoded, list) else replies[0]
-            body = json.dumps(payload, separators=(",", ":")).encode()
-            self.send_response(HTTPStatus.OK)
-        self.send_header("Content-Type", "application/json")
-        self.send_header("Content-Length", str(len(body)))
-        self.end_headers()
-        self.wfile.write(body)
+                session_id=session_id,
+            )
+            return
+
+        required = self._require_session()
+        if required is None:
+            return
+        session_id, session = required
+        replies = [
+            reply
+            for item in messages
+            if (reply := response_for(item, session)) is not None
+        ]
+        if not replies:
+            self._send_empty(HTTPStatus.ACCEPTED, session_id=session_id)
+            return
+        payload: dict[str, Any] | list[dict[str, Any]] = (
+            replies if isinstance(decoded, list) else replies[0]
+        )
+        self._send_json(HTTPStatus.OK, payload, session_id=session_id)
+
+    def do_DELETE(self) -> None:  # noqa: N802 - stdlib handler API
+        if not self._require_path():
+            return
+        required = self._require_session()
+        if required is None:
+            return
+        session_id, _session = required
+        _terminate_session(session_id)
+        self._send_empty(HTTPStatus.NO_CONTENT)
 
 
 if __name__ == "__main__":
+    # Hosted connector NetworkPolicy is the isolation boundary, so the process
+    # must listen on the pod/container interface rather than loopback.
     ThreadingHTTPServer(("0.0.0.0", 8000), Handler).serve_forever()

--- a/cli/scripts/fixtures/mcp-receipt/server.py
+++ b/cli/scripts/fixtures/mcp-receipt/server.py
@@ -12,7 +12,6 @@ from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
 
-
 TOOL = {
     "name": "receipt_read",
     "description": "Return a deterministic, non-sensitive read receipt.",
@@ -88,7 +87,11 @@ class Handler(BaseHTTPRequestHandler):
             replies = [reply for item in messages if (reply := response_for(item)) is not None]
         except (json.JSONDecodeError, TypeError, ValueError):
             body = json.dumps(
-                {"jsonrpc": "2.0", "id": None, "error": {"code": -32700, "message": "invalid request"}},
+                {
+                    "jsonrpc": "2.0",
+                    "id": None,
+                    "error": {"code": -32700, "message": "invalid request"},
+                },
                 separators=(",", ":"),
             ).encode()
             self.send_response(HTTPStatus.BAD_REQUEST)

--- a/cli/src/chat.rs
+++ b/cli/src/chat.rs
@@ -179,11 +179,11 @@ pub fn extract_fields(
 
 /// Extract a validated durable approval id from a structured approval card.
 ///
-/// The worker puts the same UUID in the card's `client_msg_id` and each action's
-/// `value`. A caller-supplied `client_msg_id` alone is not authoritative: the
-/// payload must also contain an action whose id starts with
-/// [`APPROVE_ACTION_ID_PREFIX`]. This keeps ordinary Slack posts (and arbitrary
-/// text mentioning the prefix) from being mistaken for approval control data.
+/// The worker puts the same UUID in the card's `client_msg_id` and approval
+/// action `value`. Neither copy is authoritative alone: both must be valid UUIDs
+/// and equal, and the action id must start with [`APPROVE_ACTION_ID_PREFIX`].
+/// This keeps incomplete, inconsistent, or ordinary Slack posts from being
+/// mistaken for approval control data.
 pub fn approval_card_id(content_type: &str, body: &str) -> Option<String> {
     fn valid_uuid(value: &str) -> Option<String> {
         uuid::Uuid::parse_str(value).ok().map(|_| value.to_string())
@@ -253,10 +253,11 @@ pub fn approval_card_id(content_type: &str, body: &str) -> Option<String> {
         (seen, action_id, client_msg_id)
     };
 
-    if card_seen {
-        action_id.or(client_msg_id)
-    } else {
-        None
+    match (card_seen, action_id, client_msg_id) {
+        (true, Some(action_id), Some(client_msg_id)) if action_id == client_msg_id => {
+            Some(action_id)
+        }
+        _ => None,
     }
 }
 
@@ -797,12 +798,13 @@ mod tests {
     }
 
     #[test]
-    fn approval_card_id_survives_card_before_notice_ordering() {
+    fn approval_card_id_requires_equal_structured_uuid_copies() {
         let id = "00000000-0000-4000-8000-000000000220";
         let body = format!(
             r#"{{"channel":"C0EXAMPLE1","client_msg_id":"{id}","blocks":[{{"type":"actions","elements":[{{"type":"button","action_id":"{APPROVE_ACTION_ID_PREFIX}","value":"{id}"}}]}}]}}"#
         );
         let captured = approval_card_id("application/json", &body);
+        assert_eq!(captured.as_deref(), Some(id));
 
         // The card can win the Slack-call race while the latest placeholder is
         // still ordinary text. Preserve that text for output, but carry the
@@ -834,6 +836,30 @@ mod tests {
         match completed_turn_outcome(None, true, approval_card_id("application/json", &malformed)) {
             Outcome::AwaitingApproval { approval_id, .. } => assert_eq!(approval_id, None),
             outcome => panic!("malformed card lost its awaiting status: {outcome:?}"),
+        }
+    }
+
+    #[test]
+    fn approval_card_id_rejects_mismatched_or_missing_uuid_copies() {
+        let client_id = "00000000-0000-4000-8000-000000000220";
+        let action_id = "00000000-0000-4000-8000-000000000221";
+        let mismatched = format!(
+            r#"{{"client_msg_id":"{client_id}","blocks":[{{"type":"actions","elements":[{{"type":"button","action_id":"{APPROVE_ACTION_ID_PREFIX}","value":"{action_id}"}}]}}]}}"#
+        );
+        let missing_client = format!(
+            r#"{{"blocks":[{{"type":"actions","elements":[{{"type":"button","action_id":"{APPROVE_ACTION_ID_PREFIX}","value":"{action_id}"}}]}}]}}"#
+        );
+        let missing_action_value = format!(
+            r#"{{"client_msg_id":"{client_id}","blocks":[{{"type":"actions","elements":[{{"type":"button","action_id":"{APPROVE_ACTION_ID_PREFIX}"}}]}}]}}"#
+        );
+
+        for body in [&mismatched, &missing_client, &missing_action_value] {
+            assert!(body.contains(APPROVE_ACTION_ID_PREFIX));
+            assert_eq!(approval_card_id("application/json", body), None);
+            match completed_turn_outcome(None, true, approval_card_id("application/json", body)) {
+                Outcome::AwaitingApproval { approval_id, .. } => assert_eq!(approval_id, None),
+                outcome => panic!("untrusted card lost its awaiting status: {outcome:?}"),
+            }
         }
     }
 

--- a/cli/src/chat.rs
+++ b/cli/src/chat.rs
@@ -116,6 +116,10 @@ pub struct SlackCall {
     /// True when the raw body carried the approval card's Approve action id, i.e.
     /// the worker parked this turn awaiting approval and posted a card (#529).
     pub approval_card: bool,
+    /// The durable approval UUID carried by that card, when its structured
+    /// payload contains a valid id. This is independent of placeholder edit
+    /// ordering, so a card that arrives before its notice can still be resumed.
+    pub approval_id: Option<String>,
 }
 
 /// If this call is a `chat.update` editing `placeholder_ts`, its new text.
@@ -171,6 +175,89 @@ pub fn extract_fields(
             .map(|(_, v)| v.clone())
     };
     (find("channel"), find("ts"), find("text"))
+}
+
+/// Extract a validated durable approval id from a structured approval card.
+///
+/// The worker puts the same UUID in the card's `client_msg_id` and each action's
+/// `value`. A caller-supplied `client_msg_id` alone is not authoritative: the
+/// payload must also contain an action whose id starts with
+/// [`APPROVE_ACTION_ID_PREFIX`]. This keeps ordinary Slack posts (and arbitrary
+/// text mentioning the prefix) from being mistaken for approval control data.
+pub fn approval_card_id(content_type: &str, body: &str) -> Option<String> {
+    fn valid_uuid(value: &str) -> Option<String> {
+        uuid::Uuid::parse_str(value).ok().map(|_| value.to_string())
+    }
+
+    fn approval_action(value: &serde_json::Value) -> (bool, Option<String>) {
+        match value {
+            serde_json::Value::Array(values) => {
+                let mut seen = false;
+                for value in values {
+                    let (nested_seen, id) = approval_action(value);
+                    seen |= nested_seen;
+                    if id.is_some() {
+                        return (true, id);
+                    }
+                }
+                (seen, None)
+            }
+            serde_json::Value::Object(fields) => {
+                let is_approve = fields
+                    .get("action_id")
+                    .and_then(serde_json::Value::as_str)
+                    .is_some_and(|id| id.starts_with(APPROVE_ACTION_ID_PREFIX));
+                if is_approve {
+                    let id = fields
+                        .get("value")
+                        .and_then(serde_json::Value::as_str)
+                        .and_then(valid_uuid);
+                    return (true, id);
+                }
+                let mut seen = false;
+                for value in fields.values() {
+                    let (nested_seen, id) = approval_action(value);
+                    seen |= nested_seen;
+                    if id.is_some() {
+                        return (true, id);
+                    }
+                }
+                (seen, None)
+            }
+            _ => (false, None),
+        }
+    }
+
+    let (card_seen, action_id, client_msg_id) = if content_type.contains("application/json") {
+        let root = serde_json::from_str::<serde_json::Value>(body).ok()?;
+        let (seen, action_id) = approval_action(&root);
+        let client_msg_id = root
+            .get("client_msg_id")
+            .and_then(serde_json::Value::as_str)
+            .and_then(valid_uuid);
+        (seen, action_id, client_msg_id)
+    } else {
+        let pairs: Vec<(String, String)> = serde_urlencoded::from_str(body).unwrap_or_default();
+        let blocks = pairs
+            .iter()
+            .find(|(key, _)| key == "blocks")
+            .and_then(|(_, value)| serde_json::from_str::<serde_json::Value>(value).ok());
+        let (seen, action_id) = blocks
+            .as_ref()
+            .map(approval_action)
+            .unwrap_or((false, None));
+        let client_msg_id = pairs
+            .iter()
+            .find(|(key, _)| key == "client_msg_id")
+            .and_then(|(_, value)| valid_uuid(value));
+        (seen, action_id, client_msg_id)
+    };
+
+    if card_seen {
+        action_id.or(client_msg_id)
+    } else {
+        None
+    }
 }
 
 #[derive(Clone)]
@@ -269,6 +356,7 @@ async fn handle_call(
     // which `extract_fields` does not parse -- match it on the raw body so an
     // awaiting-approval turn is detectable regardless of encoding (#529).
     let approval_card = body.contains(APPROVE_ACTION_ID_PREFIX);
+    let approval_id = approval_card_id(content_type, &body);
     // chat.update echoes the existing ts; a hypothetical new-message call has no
     // ts, so synthesize one so the response still looks like Slack.
     let ts_out = ts
@@ -280,6 +368,7 @@ async fn handle_call(
         ts: ts.clone(),
         text: text.clone(),
         approval_card,
+        approval_id,
     });
     Json(json!({ "ok": true, "ts": ts_out, "channel": channel, "text": text }))
 }
@@ -295,9 +384,35 @@ pub enum Outcome {
     /// THIS run's reply endpoint. For `local`/`cluster message` that endpoint is
     /// the CLI's throwaway stub, which dies when the command exits, so the resumed
     /// reply has nowhere to land (#529). Carries the latest placeholder text seen.
-    AwaitingApproval(Option<String>),
+    AwaitingApproval {
+        reply: Option<String>,
+        /// Durable id captured from the approval card when it reaches this stub,
+        /// or from the authoritative route-bound placeholder notice otherwise.
+        approval_id: Option<String>,
+    },
     /// The deadline passed with no completion.
     TimedOut,
+}
+
+/// Classify an acked turn after the final Slack-call drain.
+///
+/// Keeping the card-derived id separate from `latest` is load-bearing: Slack
+/// calls can be observed in either order, and the card may be the only captured
+/// call that carries the UUID needed to wait for the resume turn.
+fn completed_turn_outcome(
+    latest: Option<String>,
+    approval_card_seen: bool,
+    card_approval_id: Option<String>,
+) -> Outcome {
+    let approval_id = card_approval_id.or_else(|| latest.as_deref().and_then(parse_approval_id));
+    if approval_card_seen || approval_id.is_some() {
+        Outcome::AwaitingApproval {
+            reply: latest,
+            approval_id,
+        }
+    } else {
+        latest.map_or(Outcome::CompletedNoEdit, Outcome::Replied)
+    }
 }
 
 /// Wait for the worker to consume and finalize the turn. Terminal signal is the
@@ -335,12 +450,16 @@ pub async fn await_reply(
     // Whether the worker posted an approval card during this turn: the turn parked
     // awaiting approval rather than finalizing normally (#529).
     let mut awaiting_approval = false;
+    let mut card_approval_id: Option<String> = None;
     let mut poll = tokio::time::interval(ACK_POLL_INTERVAL);
     loop {
         tokio::select! {
             call = stub.recv() => {
                 if let Some(call) = call {
                     awaiting_approval |= call.approval_card;
+                    if call.approval_id.is_some() {
+                        card_approval_id = call.approval_id.clone();
+                    }
                     observe_placeholder_update(&call, placeholder_ts, &mut latest, observer);
                 }
             }
@@ -361,17 +480,19 @@ pub async fn await_reply(
                     // Drain any final edit still in flight before deciding.
                     while let Ok(Some(call)) = tokio::time::timeout(FINAL_DRAIN, stub.recv()).await {
                         awaiting_approval |= call.approval_card;
+                        if call.approval_id.is_some() {
+                            card_approval_id = call.approval_id.clone();
+                        }
                         observe_placeholder_update(&call, placeholder_ts, &mut latest, observer);
                     }
                     // Either signal parks the turn: the card seen here, or an
                     // authoritative approval notice in the latest placeholder
                     // text (the route-bound case, where no card reaches us).
-                    if awaiting_approval
-                        || latest.as_deref().and_then(parse_approval_id).is_some()
-                    {
-                        return Outcome::AwaitingApproval(latest);
-                    }
-                    return latest.map_or(Outcome::CompletedNoEdit, Outcome::Replied);
+                    return completed_turn_outcome(
+                        latest,
+                        awaiting_approval,
+                        card_approval_id,
+                    );
                 }
             }
             _ = tokio::time::sleep_until(tokio::time::Instant::from_std(deadline)) => {
@@ -676,6 +797,47 @@ mod tests {
     }
 
     #[test]
+    fn approval_card_id_survives_card_before_notice_ordering() {
+        let id = "00000000-0000-4000-8000-000000000220";
+        let body = format!(
+            r#"{{"channel":"C0EXAMPLE1","client_msg_id":"{id}","blocks":[{{"type":"actions","elements":[{{"type":"button","action_id":"{APPROVE_ACTION_ID_PREFIX}","value":"{id}"}}]}}]}}"#
+        );
+        let captured = approval_card_id("application/json", &body);
+
+        // The card can win the Slack-call race while the latest placeholder is
+        // still ordinary text. Preserve that text for output, but carry the
+        // card's durable id independently so the caller enters its resume wait.
+        match completed_turn_outcome(Some("working".into()), true, captured) {
+            Outcome::AwaitingApproval { reply, approval_id } => {
+                assert_eq!(reply.as_deref(), Some("working"));
+                assert_eq!(approval_id.as_deref(), Some(id));
+            }
+            outcome => panic!("approval card was not classified as awaiting: {outcome:?}"),
+        }
+    }
+
+    #[test]
+    fn approval_card_id_rejects_malformed_and_non_card_payloads() {
+        let id = "00000000-0000-4000-8000-000000000220";
+        let non_card = format!(
+            r#"{{"client_msg_id":"{id}","text":"mentions {APPROVE_ACTION_ID_PREFIX}","blocks":[{{"type":"section","text":{{"type":"plain_text","text":"not a card"}}}}]}}"#
+        );
+        assert_eq!(approval_card_id("application/json", &non_card), None);
+
+        let malformed = format!(
+            r#"{{"client_msg_id":"not-a-uuid","blocks":[{{"type":"actions","elements":[{{"type":"button","action_id":"{APPROVE_ACTION_ID_PREFIX}","value":"also-not-a-uuid"}}]}}]}}"#
+        );
+        assert_eq!(approval_card_id("application/json", &malformed), None);
+
+        // The raw action-id signal still reports a parked turn, but malformed
+        // external data is never promoted into an id used for resume lookup.
+        match completed_turn_outcome(None, true, approval_card_id("application/json", &malformed)) {
+            Outcome::AwaitingApproval { approval_id, .. } => assert_eq!(approval_id, None),
+            outcome => panic!("malformed card lost its awaiting status: {outcome:?}"),
+        }
+    }
+
+    #[test]
     fn placeholder_update_text_matches_only_the_right_call() {
         let update = SlackCall {
             method: "chat.update".into(),
@@ -683,6 +845,7 @@ mod tests {
             ts: Some("1.2".into()),
             text: Some("the answer".into()),
             approval_card: false,
+            approval_id: None,
         };
         assert_eq!(placeholder_update_text(&update, "1.2"), Some("the answer"));
         // Wrong ts (a different message).

--- a/cli/src/local.rs
+++ b/cli/src/local.rs
@@ -129,17 +129,24 @@ pub fn fake_model_env_override(mode: ModelMode) -> Option<(String, String)> {
 /// resolve. An empty value (not an absent one) is what does it: compose writes
 /// the endpoint as `${OTEL_EXPORTER_OTLP_ENDPOINT-...}`, whose `-` (unset-only)
 /// form substitutes its default only when the var is UNSET, so exporting it
-/// empty resolves to empty and the runner exports nothing. `false` returns
-/// `None` so compose's shipped collector default stands. This is the one place
+/// empty resolves to empty and the runner exports nothing. The host-network
+/// worker's separate override is also cleared. `false` returns no overrides,
+/// so compose's shipped collector defaults stand. This is the one place
 /// that decision is made -- `up_command` and `local comms`'s connect/disconnect
 /// commands all call it instead of each re-deriving the pair inline, the same
 /// drift that let `local comms` fall out of parity with `local up` on the fake
 /// model (issue #450).
-pub fn otel_endpoint_env_override(minimal: bool) -> Option<(String, String)> {
+pub fn otel_endpoint_env_override(minimal: bool) -> Vec<(String, String)> {
     if minimal {
-        Some(("OTEL_EXPORTER_OTLP_ENDPOINT".into(), String::new()))
+        vec![
+            ("OTEL_EXPORTER_OTLP_ENDPOINT".into(), String::new()),
+            (
+                "CURIE_WORKER_OTEL_EXPORTER_OTLP_ENDPOINT".into(),
+                String::new(),
+            ),
+        ]
     } else {
-        None
+        Vec::new()
     }
 }
 
@@ -2274,7 +2281,7 @@ mod tests {
         // profile starts no collector); `display` renders env before the program.
         assert_eq!(
             cmd.display(),
-            "OTEL_EXPORTER_OTLP_ENDPOINT= docker compose --profile core -f compose.dev.yaml up -d --wait"
+            "CURIE_WORKER_OTEL_EXPORTER_OTLP_ENDPOINT= OTEL_EXPORTER_OTLP_ENDPOINT= docker compose --profile core -f compose.dev.yaml up -d --wait"
         );
     }
 

--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -1184,6 +1184,10 @@ const COMPOSE_CONFIG_FILES_LABEL: &str = "com.docker.compose.project.config_file
 const COMPOSE_DISPATCHER_SERVICE: &str = "curie-dispatcher";
 const DISPATCHER_ENQUEUE_MODULE: &str = "curie_dispatcher.enqueue_once";
 const DISPATCHER_ENQUEUE_TIMEOUT: Duration = Duration::from_secs(30);
+// The one-shot dispatcher shares the runner's bridge network, not the
+// worker's host network. Inspect this separately; it is never forwarded as a
+// Curie configuration key into the dispatcher.
+const BRIDGE_OTEL_ENDPOINT_KEY: &str = "CURIE_RUNNER_OTEL_EXPORTER_OTLP_ENDPOINT";
 const OTEL_EXPORTER_ENV_KEYS: [&str; 38] = [
     "OTEL_EXPORTER_OTLP_ENDPOINT",
     "OTEL_EXPORTER_OTLP_PROTOCOL",
@@ -1302,6 +1306,7 @@ fn worker_otel_exporter_env_command(container: &str) -> OpsCommand {
     for name in OTEL_EXPORTER_ENV_KEYS {
         template.push_str(&format!("(eq $name \"{name}\") "));
     }
+    template.push_str(&format!("(eq $name \"{BRIDGE_OTEL_ENDPOINT_KEY}\") "));
     template.push_str("}}{{json $entry}}{{println}}{{end}}{{end}}");
     OpsCommand::new(
         "docker",
@@ -1316,6 +1321,7 @@ fn worker_otel_exporter_env_command(container: &str) -> OpsCommand {
 
 fn parse_worker_otel_env(stdout: &str) -> Result<Vec<(String, String)>> {
     let mut selected = Vec::new();
+    let mut bridge_endpoint = None;
     for (index, line) in stdout
         .lines()
         .filter(|line| !line.trim().is_empty())
@@ -1341,9 +1347,17 @@ fn parse_worker_otel_env(stdout: &str) -> Result<Vec<(String, String)>> {
         };
         // Keep the same allowlist here as defense in depth if the Docker
         // formatting boundary ever changes independently.
-        if OTEL_EXPORTER_ENV_KEYS.contains(&name) {
+        if name == BRIDGE_OTEL_ENDPOINT_KEY {
+            bridge_endpoint = Some(value.to_string());
+        } else if OTEL_EXPORTER_ENV_KEYS.contains(&name) {
             selected.push((name.to_string(), value.to_string()));
         }
+    }
+    if let Some(endpoint) = bridge_endpoint {
+        // An explicit empty value disables export; absence retains legacy
+        // behavior. Signal-specific exporter overrides remain unchanged.
+        selected.retain(|(name, _)| name != "OTEL_EXPORTER_OTLP_ENDPOINT");
+        selected.push(("OTEL_EXPORTER_OTLP_ENDPOINT".to_string(), endpoint));
     }
     Ok(selected)
 }
@@ -4598,10 +4612,69 @@ mod tests {
         for name in EXPECTED_OTEL_EXPORTER_ENV_KEYS {
             assert!(template.contains(name), "inspect template omitted {name}");
         }
+        assert!(template.contains("CURIE_RUNNER_OTEL_EXPORTER_OTLP_ENDPOINT"));
         assert!(!template.contains("{{json .Config.Env}}"));
         assert!(!template.contains("UNRELATED_SECRET"));
         assert!(!template.contains("println ."));
         assert!(!template.contains("range .Config.Env}}{{println"));
+    }
+
+    #[test]
+    fn local_dispatcher_uses_bridge_exporter_endpoint_and_preserves_empty_override() {
+        for (bridge, expected) in [
+            (
+                Some("http://otel-collector:4318"),
+                "http://otel-collector:4318",
+            ),
+            (Some(""), ""),
+            (None, "http://127.0.0.1:24318"),
+        ] {
+            let mut inspected = String::new();
+            // The override must win regardless of Docker's environment order.
+            if let Some(value) = bridge {
+                inspected.push_str(&format!(
+                    "CURIE_RUNNER_OTEL_EXPORTER_OTLP_ENDPOINT={value}\n"
+                ));
+            }
+            inspected.push_str(concat!(
+                "OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:24318\n",
+                "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=https://traces.example.com/v1/traces\n",
+                "OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf\n",
+                "UNRELATED_SECRET=must-not-forward\n",
+            ));
+            let command = dispatcher_enqueue_command(
+                &["/tmp/compose.yaml".to_string()],
+                "curie-dispatcher-enqueue-test",
+                "test:curie:runs",
+                "example-password",
+                &parse_worker_otel_env(&inspected).unwrap(),
+                None,
+            );
+            // Execute the subprocess environment the dispatcher receives;
+            // checking only the parsed vector would miss command forwarding.
+            let output = std::process::Command::new("sh")
+                .args([
+                    "-c",
+                    concat!(
+                        "printf '%s\\n' \"$OTEL_EXPORTER_OTLP_ENDPOINT\" ",
+                        "\"$OTEL_EXPORTER_OTLP_TRACES_ENDPOINT\" ",
+                        "\"$OTEL_EXPORTER_OTLP_PROTOCOL\" ",
+                        "\"${CURIE_RUNNER_OTEL_EXPORTER_OTLP_ENDPOINT-unset}\" ",
+                        "\"${UNRELATED_SECRET-unset}\"",
+                    ),
+                ])
+                .env_clear()
+                .envs(command.env.iter().chain(command.secret_env.iter()).cloned())
+                .output()
+                .unwrap();
+            assert!(output.status.success());
+            assert_eq!(
+                String::from_utf8(output.stdout).unwrap(),
+                format!("{expected}\nhttps://traces.example.com/v1/traces\nhttp/protobuf\nunset\nunset\n")
+            );
+            assert!(!command.display().contains("http://otel-collector:4318"));
+            assert!(!command.display().contains("http://127.0.0.1:24318"));
+        }
     }
 
     #[test]

--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -569,8 +569,12 @@ async fn await_cluster_relay(
                 });
             }
             if awaiting_approval {
+                let approval_id = latest.as_deref().and_then(parse_approval_id);
                 return Ok(ClusterRelayObservation {
-                    outcome: Outcome::AwaitingApproval(latest),
+                    outcome: Outcome::AwaitingApproval {
+                        reply: latest,
+                        approval_id,
+                    },
                     next_cursor: cursor,
                 });
             }
@@ -1757,7 +1761,7 @@ async fn message_local(opts: MessageOpts) -> Result<()> {
             persist_and_hint(&opts, TurnVerb::Local, &channel, &thread_ts);
             Ok(())
         }
-        Outcome::AwaitingApproval(reply) => {
+        Outcome::AwaitingApproval { reply, approval_id } => {
             step.done("awaiting approval");
             // Persist the turn context BEFORE the (possibly full --timeout-secs)
             // approval wait: if the operator interrupts or the terminal closes
@@ -1767,10 +1771,10 @@ async fn message_local(opts: MessageOpts) -> Result<()> {
             persist_turn_quietly(&opts, TurnVerb::Local, &channel, &thread_ts);
             // Keep the stub alive and wait for the resumed reply instead of
             // exiting and stranding it (#766). The wait rides the Valkey
-            // connection already open for the enqueue, so the only degradation is
-            // a placeholder notice we cannot parse an approval id from -- then
-            // fall back to the terminal.
-            match parse_approval_id(reply.as_deref().unwrap_or_default()) {
+            // connection already open for the enqueue. The explicit id normally
+            // comes from the card and falls back to the route-bound notice; if
+            // neither carries a valid UUID, report the parked terminal.
+            match approval_id {
                 Some(id) => {
                     let remaining = Duration::from_secs(opts.timeout_secs)
                         .saturating_sub(wait_started.elapsed());
@@ -2226,11 +2230,14 @@ async fn resume_after_approval(
                 persist_and_hint(opts, verb, channel, thread_ts);
                 return ResumeExit::Done;
             }
-            Outcome::AwaitingApproval(new_reply) => {
+            Outcome::AwaitingApproval {
+                reply: new_reply,
+                approval_id,
+            } => {
                 // The RESUMED turn hit a NEW gate of its own. Keep waiting on ITS
                 // resume entry rather than exiting and dropping the stub -- exiting
                 // here would re-create the dead-endpoint bug for the nested gate.
-                match parse_approval_id(new_reply.as_deref().unwrap_or_default()) {
+                match approval_id {
                     Some(new_id) => {
                         current_id = new_id;
                         last_reply = new_reply;
@@ -2392,8 +2399,11 @@ async fn resume_cluster_after_approval(
                 persist_and_hint(opts, TurnVerb::Cluster, channel, thread_ts);
                 return Ok(ResumeExit::Done);
             }
-            Outcome::AwaitingApproval(new_reply) => {
-                if let Some(new_id) = parse_approval_id(new_reply.as_deref().unwrap_or_default()) {
+            Outcome::AwaitingApproval {
+                reply: new_reply,
+                approval_id,
+            } => {
+                if let Some(new_id) = approval_id {
                     current_id = new_id;
                     last_reply = new_reply;
                     continue;
@@ -2988,7 +2998,7 @@ pub async fn message(mut opts: MessageOpts) -> Result<()> {
             persist_and_hint(&opts, TurnVerb::Cluster, &channel, &thread_ts);
             Ok(())
         }
-        Outcome::AwaitingApproval(reply) => {
+        Outcome::AwaitingApproval { reply, approval_id } => {
             step.done("awaiting approval");
             // Persist the turn context BEFORE the (possibly full --timeout-secs)
             // approval wait, so an interrupted terminal still leaves a thread
@@ -2997,7 +3007,7 @@ pub async fn message(mut opts: MessageOpts) -> Result<()> {
             persist_turn_quietly(&opts, TurnVerb::Cluster, &channel, &thread_ts);
             // The API resume queue preserves this turn's reply handle, so keep
             // polling the same opaque bucket through any approval resolution.
-            match parse_approval_id(reply.as_deref().unwrap_or_default()) {
+            match approval_id {
                 Some(id) => {
                     let remaining = Duration::from_secs(opts.timeout_secs)
                         .saturating_sub(wait_started.elapsed());
@@ -3184,14 +3194,16 @@ pub fn reply_passes(case: &EvalCase, outcome: &Outcome) -> bool {
             // here and fails closed. The trajectory-aware grade lives on the
             // `skill eval` path (`turn_passes`) and the server-side eval matrix.
             Outcome::Replied(reply) => case.grader.grade(reply, &[]),
-            Outcome::CompletedNoEdit | Outcome::AwaitingApproval(_) | Outcome::TimedOut => false,
+            Outcome::CompletedNoEdit | Outcome::AwaitingApproval { .. } | Outcome::TimedOut => {
+                false
+            }
         },
         // Gate-blocked assertion: the turn must have parked awaiting approval, and
         // the latest placeholder text (the model's narration before the gate flip)
         // must satisfy the grader. A match-anything grader ({kind:contains,expected:""})
         // asserts purely on the gate holding.
         ExpectedStatus::AwaitingApproval => match outcome {
-            Outcome::AwaitingApproval(reply) => {
+            Outcome::AwaitingApproval { reply, .. } => {
                 case.grader.grade(reply.as_deref().unwrap_or_default(), &[])
             }
             Outcome::Replied(_) | Outcome::CompletedNoEdit | Outcome::TimedOut => false,
@@ -3384,14 +3396,16 @@ async fn run_eval_turns(
                 let elapsed = started.elapsed().as_secs_f64();
                 let output = match &outcome {
                     Outcome::Replied(reply) => reply.clone(),
-                    Outcome::AwaitingApproval(reply) => reply.clone().unwrap_or_default(),
+                    Outcome::AwaitingApproval { reply, .. } => reply.clone().unwrap_or_default(),
                     Outcome::CompletedNoEdit => String::new(),
                     Outcome::TimedOut => diagnostics(conn, &opts.stream, &stream_id).await,
                 };
                 let passed = reply_passes(case, &outcome);
                 let completed = matches!(
                     outcome,
-                    Outcome::Replied(_) | Outcome::AwaitingApproval(_) | Outcome::CompletedNoEdit
+                    Outcome::Replied(_)
+                        | Outcome::AwaitingApproval { .. }
+                        | Outcome::CompletedNoEdit
                 );
                 samples.push(crate::eval_sampling::SampleRecord {
                     outcome: if passed {
@@ -6740,7 +6754,10 @@ mod tests {
         // even if the card text happens to contain the expected token (#529).
         assert!(!reply_passes(
             &case,
-            &Outcome::AwaitingApproval(Some("pong pending approval".into()))
+            &Outcome::AwaitingApproval {
+                reply: Some("pong pending approval".into()),
+                approval_id: None,
+            }
         ));
     }
 
@@ -6754,9 +6771,18 @@ mod tests {
             eval_case_with_status(GraderKind::Contains, "", ExpectedStatus::AwaitingApproval);
         assert!(reply_passes(
             &case,
-            &Outcome::AwaitingApproval(Some("blocked the close".into()))
+            &Outcome::AwaitingApproval {
+                reply: Some("blocked the close".into()),
+                approval_id: None,
+            }
         ));
-        assert!(reply_passes(&case, &Outcome::AwaitingApproval(None)));
+        assert!(reply_passes(
+            &case,
+            &Outcome::AwaitingApproval {
+                reply: None,
+                approval_id: None,
+            }
+        ));
         // The agent merely replied -> the gate did not hold -> RED.
         assert!(!reply_passes(
             &case,

--- a/cli/tests/nightly_graded_ladder.rs
+++ b/cli/tests/nightly_graded_ladder.rs
@@ -1033,7 +1033,7 @@ fn product_observability_requires_three_valid_seeds_and_count_only_mcp_receipt()
 }
 
 #[test]
-fn product_collector_restore_covers_every_emitter_and_invalid_auth_recovers_same_id() {
+fn product_collector_restore_covers_every_emitter_and_invalid_auth_is_observable() {
     let pins = ladder_function("pin_local_source_images");
     for required in [
         "export CURIE_BASE_TAG=dev",
@@ -1079,22 +1079,20 @@ fn product_collector_restore_covers_every_emitter_and_invalid_auth_recovers_same
     );
 
     let negative = ladder_function("case_local_langfuse_invalid_auth");
-    // This contract is grounded in the shipped otel/collector-config.yaml:
-    // retry_on_failure is 5s/30s/5m and sending_queue uses file_storage with
-    // queue_size 1000. Invalid auth is therefore a temporary observed absence;
-    // the proof must recover the same queued ID before the unchanged horizon.
+    // OTLP/HTTP forbids retries for 401; configured retry/queue settings do not
+    // override that protocol rule. Issue #2204 requires an observable bounded
+    // failure, not replay of a permanently rejected request.
+    // https://opentelemetry.io/docs/specs/otlp/#retryable-response-codes
     for required in [
         "INVALID_LANGFUSE_OTLP_AUTH_HEADER",
         "langfuse-web",
         "otelcol_receiver_accepted_spans",
         "otelcol_exporter_send_failed_spans",
-        "sending_queue",
-        "file_storage",
-        "queue_size",
+        "otelcol_exporter_queue_size",
+        "assert_product_collector_permanent_auth_rejection",
         "Ready",
         "restart",
-        "same_queued_trace_id",
-        "queue_drained",
+        "failed_trace_id",
     ] {
         assert!(
             negative.contains(required),
@@ -1103,11 +1101,11 @@ fn product_collector_restore_covers_every_emitter_and_invalid_auth_recovers_same
     }
     assert!(
         !negative.contains("down -v"),
-        "the negative must retain the Collector file queue across restart"
+        "the negative must not destroy the backing stack to manufacture absence"
     );
     assert!(
-        negative.matches("same_queued_trace_id").count() >= 2,
-        "the temporarily absent ID, not a fresh post-recovery control, must become queryable"
+        !negative.contains("same_queued_trace_id"),
+        "a permanent 401 rejection must not be misrepresented as durable replay"
     );
 
     let valid_control = negative
@@ -1120,30 +1118,6 @@ fn product_collector_restore_covers_every_emitter_and_invalid_auth_recovers_same
         valid_control < invalidate,
         "the valid exact-read control must precede credential invalidation"
     );
-
-    let before_restore = negative
-        .split_once("restore_local_langfuse_auth")
-        .map(|(prefix, _)| prefix)
-        .expect("invalid-auth proof must restore valid auth");
-    let invalid_restarts: Vec<_> = before_restore
-        .match_indices("restart_local_product_collector")
-        .map(|(index, _)| index)
-        .collect();
-    assert!(
-        invalid_restarts.len() >= 2,
-        "the file-backed queue must survive a Collector restart while auth is still invalid"
-    );
-    let after_invalid_restart = &before_restore[invalid_restarts[1]..];
-    for required in [
-        "otelcol_exporter_send_failed_spans",
-        "otelcol_exporter_queue_size",
-        "query_exact_seed_trace",
-    ] {
-        assert!(
-            after_invalid_restart.contains(required),
-            "queued failure must be re-observed after the invalid-auth restart: missing {required}"
-        );
-    }
 
     let query = ladder_function("query_exact_seed_trace");
     let poll_start = query
@@ -1167,14 +1141,17 @@ fn product_collector_restore_covers_every_emitter_and_invalid_auth_recovers_same
     );
 
     let absent = negative
-        .find(r#"query_exact_seed_trace local "$same_queued_trace_id" "" "" absent"#)
-        .expect("queued exact ID must be checked absent while auth is invalid");
+        .find(r#"query_exact_seed_trace local "$failed_trace_id" "" "" absent"#)
+        .expect("the rejected exact ID must be checked absent while auth is invalid");
+    let restored = negative
+        .rfind("restore_local_langfuse_auth")
+        .expect("valid auth must be restored after the failure evidence");
     let recovered = negative
-        .rfind(r#"query_exact_seed_trace local "$same_queued_trace_id""#)
-        .expect("the same queued exact ID must be queried after valid auth returns");
+        .rfind("seed_ordinary_turn local")
+        .expect("a fresh healthy turn must prove exact ingestion after valid auth returns");
     assert!(
-        absent < recovered,
-        "same-ID recovery must follow the bounded queued-failure observation"
+        absent < restored && restored < recovered,
+        "fresh-turn recovery must follow bounded rejection evidence and credential restoration"
     );
 }
 

--- a/cli/tests/nightly_graded_ladder.rs
+++ b/cli/tests/nightly_graded_ladder.rs
@@ -1180,8 +1180,8 @@ fn cluster_product_observability_is_private_preflight_and_query_only() {
     let wrapper = ladder_function("rung_cluster_product");
     for required in [
         "preflight_cluster_product_observability",
-        "seed_ordinary_turn",
-        "seed_approval_resume_turn",
+        "seed_cluster_missing_carrier_control",
+        "cluster_external_ingress_seed",
         "cluster observability run",
     ] {
         assert!(
@@ -1212,6 +1212,37 @@ fn cluster_product_observability_is_private_preflight_and_query_only() {
         wrapper.contains("cluster deploy"),
         "the product wrapper must retain the intended agent seed deployment"
     );
+    for manufactured in [
+        "enqueue_cluster_carried_turn",
+        "CLUSTER_SEEDED_TRACE_ID",
+        "secrets.token_hex",
+    ] {
+        assert!(
+            !ladder().contains(manufactured),
+            "cluster correlation evidence must come from real Slack ingress, not harness-manufactured carrier {manufactured}"
+        );
+    }
+    let missing_carrier = ladder_function("seed_cluster_missing_carrier_control");
+    assert!(
+        missing_carrier.contains("cluster message")
+            && missing_carrier.contains("adjacent_traceparent=false"),
+        "the dispatcher-absent cluster message path must remain an explicit executed missing-carrier compatibility negative"
+    );
+    let external = ladder_function("cluster_external_ingress_seed");
+    for required in [
+        "CURIE_E2E_CLUSTER_EXTERNAL_INGRESS_RECEIPT",
+        "CURIE_E2E_PRODUCT_RUN_ID",
+        "reply_observed",
+        "completion_observed",
+        "otelcol_receiver_accepted_spans_delta",
+        "otelcol_exporter_sent_spans_delta",
+        "discover_cluster_external_trace_id",
+    ] {
+        assert!(
+            ladder().contains(required) || external.contains(required),
+            "external Slack cluster evidence omits {required}"
+        );
+    }
     assert!(
         !preflight.contains(r#"-o json > "$inventory""#)
             && !preflight.contains("cluster-product-pods"),
@@ -1258,6 +1289,8 @@ fn adopted_component_stop_requires_successful_local_and_cluster_export() {
         "cluster",
         "image_ids_match",
         "seed_valid",
+        "same_id_raw_collector_receipt",
+        "run_id",
         "adopted-component",
     ] {
         assert!(
@@ -1272,6 +1305,20 @@ fn adopted_component_stop_requires_successful_local_and_cluster_export() {
     assert!(
         decision.find("langfuse_observation_membership") < decision.find("adopted-component"),
         "the harness cannot blame the adopted backend before checking exact-ID membership"
+    );
+    for verdict in ["curie-unresolved", "curie-owned", "adopted-component"] {
+        let tail = decision
+            .split(verdict)
+            .nth(1)
+            .unwrap_or_else(|| panic!("classifier omits verdict {verdict}"));
+        assert!(
+            tail.contains("SystemExit(1)"),
+            "blocking verdict {verdict} must terminate the supported run nonzero"
+        );
+    }
+    assert!(
+        decision.contains("curie-clear") && decision.contains("SystemExit(0)"),
+        "only a fully cleared local+cluster classification may exit zero"
     );
 }
 

--- a/cli/tests/nightly_graded_ladder.rs
+++ b/cli/tests/nightly_graded_ladder.rs
@@ -1049,6 +1049,18 @@ fn product_collector_restore_covers_every_emitter_and_invalid_auth_recovers_same
             "worker-only exporter restoration can leave {required} routed to the disposable sink"
         );
     }
+    assert!(
+        restore.contains("export OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318"),
+        "product restoration must override unrelated shell or ignored-file routing"
+    );
+    assert!(
+        restore.contains("export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf"),
+        "product restoration must pin the protocol expected by the task-owned collector"
+    );
+    assert!(
+        !restore.contains("unset OTEL_EXPORTER_OTLP_ENDPOINT"),
+        "unsetting the override permits ignored local configuration to redirect evidence"
+    );
 
     let negative = ladder_function("case_local_langfuse_invalid_auth");
     // This contract is grounded in the shipped otel/collector-config.yaml:

--- a/cli/tests/nightly_graded_ladder.rs
+++ b/cli/tests/nightly_graded_ladder.rs
@@ -59,6 +59,18 @@ fn ladder() -> String {
     fs::read_to_string(path).unwrap_or_default()
 }
 
+fn ladder_function(name: &str) -> String {
+    let source = ladder();
+    let marker = format!("{name}() {{");
+    let (_, tail) = source
+        .split_once(&marker)
+        .unwrap_or_else(|| panic!("ladder must define {name}"));
+    let (body, _) = tail
+        .split_once("\n}\n")
+        .unwrap_or_else(|| panic!("ladder function {name} must close"));
+    format!("{marker}{body}\n}}\n")
+}
+
 /// The local OTel assertions deliberately live in the shell harness, where
 /// they consume the Collector's raw JSON files.  Keep this test on that real
 /// consumer instead of re-implementing its attribution rules in Rust.
@@ -812,11 +824,21 @@ fn live_local_rung_grades_the_deployed_weather_cases() {
         .map(|offset| product_collector + offset)
         .expect("the local rung must prove observability queries after telemetry");
     assert!(
-        text.contains(r#"local observability runs --limit 100"#)
-            && text.contains(r#"timestamp = row.get("timestamp")"#)
-            && text.contains(r#"if matched is None:"#),
-        "the live proof must scan a bounded newest-first page and select its first complete typed row without relying on an identity field the list DTO does not promise"
+        !text.contains(r#"local observability runs --limit 100"#),
+        "a newest-runs page can select a background trace; the live proof must derive the exact trace ID from the seeded bounded stream entry"
     );
+    for required in [
+        "discover_trace_id_for_seed",
+        "query_exact_seed_trace",
+        "sanitize_exact_trace_read",
+        "seed_ordinary_turn",
+        "seed_approval_resume_turn",
+    ] {
+        assert!(
+            text.contains(required),
+            "the local product proof is missing exact-seed contract {required}"
+        );
+    }
     let contract = r#"echo "=== curie local eval --dry-run (suite parity) ==="
     local eval_args=(local eval)
     if [[ ! -f "$WORKDIR/bundle/evals/trajectory.json" ]]; then
@@ -849,6 +871,173 @@ fn live_local_rung_grades_the_deployed_weather_cases() {
         !local_rung.contains("up_args+=(--minimal)"),
         "the local rung must never add --minimal now that its observability \
           proof requires Langfuse/ClickHouse; ladder contents:\n{text}"
+    );
+}
+
+#[test]
+fn product_observability_requires_three_valid_seeds_and_count_only_mcp_receipt() {
+    let text = ladder();
+    for required in [
+        "seed_ordinary_turn() {",
+        "seed_mcp_read_turn() {",
+        "seed_approval_resume_turn() {",
+        "seed-invalid",
+        "mcp_receipt_call_count() {",
+        "discover_trace_id_for_seed",
+        "query_exact_seed_trace",
+        "fixtures/mcp-receipt",
+    ] {
+        assert!(
+            text.contains(required),
+            "the product observability oracle must pin independent ordinary, MCP, and approval seed evidence; missing {required}"
+        );
+    }
+
+    let receipt_fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("scripts/fixtures/mcp-receipt/server.py");
+    let receipt_source = fs::read_to_string(&receipt_fixture).unwrap_or_default();
+    assert!(
+        receipt_source.contains(r#""tools/call""#),
+        "the hosted MCP fixture must log exactly one private receipt per tools/call"
+    );
+    let receipt = ladder_function("mcp_receipt_call_count");
+    assert!(
+        receipt.contains("docker logs") || receipt.contains("kubectl logs"),
+        "the independent MCP receipt must come from the hosted connector container"
+    );
+    assert!(
+        receipt.contains("count") || receipt.contains("wc -l"),
+        "only an aggregate MCP call count may reach evidence output"
+    );
+}
+
+#[test]
+fn product_collector_restore_covers_every_emitter_and_invalid_auth_recovers_same_id() {
+    let restore = ladder_function("route_local_observability_to_product_collector");
+    for required in [
+        "curie-api",
+        "curie-dispatcher",
+        "curie-worker",
+        "curie-runner",
+        "assert_product_collector_endpoint",
+        "http/protobuf",
+        "otel-collector:4318",
+    ] {
+        assert!(
+            restore.contains(required),
+            "worker-only exporter restoration can leave {required} routed to the disposable sink"
+        );
+    }
+
+    let negative = ladder_function("case_local_langfuse_invalid_auth");
+    // This contract is grounded in the shipped otel/collector-config.yaml:
+    // retry_on_failure is 5s/30s/5m and sending_queue uses file_storage with
+    // queue_size 1000. Invalid auth is therefore a temporary observed absence;
+    // the proof must recover the same queued ID before the unchanged horizon.
+    for required in [
+        "INVALID_LANGFUSE_OTLP_AUTH_HEADER",
+        "langfuse-web",
+        "otelcol_receiver_accepted_spans",
+        "otelcol_exporter_send_failed_spans",
+        "sending_queue",
+        "file_storage",
+        "queue_size",
+        "Ready",
+        "restart",
+        "same_queued_trace_id",
+        "queue_drained",
+    ] {
+        assert!(
+            negative.contains(required),
+            "real pinned-Langfuse invalid-auth proof omits {required}"
+        );
+    }
+    assert!(
+        !negative.contains("down -v"),
+        "the negative must retain the Collector file queue across restart"
+    );
+    assert!(
+        negative.matches("same_queued_trace_id").count() >= 2,
+        "the temporarily absent ID, not a fresh post-recovery control, must become queryable"
+    );
+}
+
+#[test]
+fn cluster_product_observability_is_private_preflight_and_query_only() {
+    let preflight = ladder_function("preflight_cluster_product_observability");
+    for required in [
+        "CURIE_NAMESPACE",
+        "CURIE_RELEASE",
+        "default",
+        "curie",
+        "langfuse",
+        "otel-collector",
+        "api",
+        "worker",
+        "runner-prewarm",
+        "imageID",
+        "docker image inspect",
+        "curie-api:local",
+        "curie-worker:local",
+        "curie-runner:latest",
+        "mismatch",
+    ] {
+        assert!(
+            preflight.contains(required),
+            "cluster product preflight omits {required}"
+        );
+    }
+
+    let query = ladder_function("run_cluster_product_observability");
+    for required in [
+        "preflight_cluster_product_observability",
+        "seed_ordinary_turn",
+        "seed_approval_resume_turn",
+        "cluster observability run",
+    ] {
+        assert!(query.contains(required), "cluster query mode omits {required}");
+    }
+    for mutation in [
+        "cluster up",
+        "cluster down",
+        "helm install",
+        "helm upgrade",
+        "helm uninstall",
+        "kubectl delete",
+    ] {
+        assert!(
+            !query.contains(mutation),
+            "cluster product mode must never mutate the installed release: found {mutation}"
+        );
+    }
+}
+
+#[test]
+fn adopted_component_stop_requires_successful_local_and_cluster_export() {
+    let decision = ladder_function("classify_product_observability_owner");
+    for required in [
+        "raw_emitted_observations",
+        "otelcol_receiver_accepted_spans",
+        "otelcol_exporter_sent_spans",
+        "langfuse_observation_membership",
+        "local",
+        "cluster",
+        "image_ids_match",
+        "seed_valid",
+        "adopted-component",
+    ] {
+        assert!(
+            decision.contains(required),
+            "ownership classification omits prerequisite {required}"
+        );
+    }
+    assert!(
+        decision.find("otelcol_exporter_sent_spans") < decision.find("adopted-component"),
+        "the harness cannot blame the adopted backend before proving export success"
+    );
+    assert!(
+        decision.find("langfuse_observation_membership") < decision.find("adopted-component"),
+        "the harness cannot blame the adopted backend before checking exact-ID membership"
     );
 }
 
@@ -1713,27 +1902,27 @@ fn looks_like_utc_second(value: &str) -> bool {
 
 /// Pin the public argv the ladder itself must exercise. These are not test-only
 /// probes: every line is a command an operator can paste against the candidate
-/// binary. The bounded newest-page read occurs before the discovered-id detail;
+/// binary. Exact trace discovery is private to the bounded seed stream slice;
 /// the separate agent-filtered list is the unavailable-API negative with its
 /// process environment pointed at a closed endpoint.
 fn assert_observability_candidate_invocations(invocations: &str, trace_id: &str) {
-    let runs = "--json local observability runs --limit 100";
+    let legacy_runs = "--json local observability runs --limit 100";
     let unavailable = format!("--json local observability runs --limit 1 --agent-id {AGENT_ID}");
     let detail = format!("--json local observability run {trace_id}");
     let unknown = format!("--json local observability run {UNKNOWN_OBSERVABILITY_TRACE_ID}");
 
     assert_eq!(
-        invocation_count(invocations, runs),
-        1,
-        "the local rung must issue one bounded newest-runs read for typed client selection; invocations:\n{invocations}"
+        invocation_count(invocations, legacy_runs),
+        0,
+        "the local rung must never let a newest-runs page select an unrelated background trace; invocations:\n{invocations}"
     );
-    assert_eq!(
+    assert!(
         invocations
             .lines()
             .filter(|line| line.starts_with("--json local message "))
-            .count(),
-        2,
-        "the query proof must seed the product Collector with its own finalized turn after the independent sink controls; invocations:\n{invocations}"
+            .count()
+            >= 2,
+        "the query proof must seed the product Collector with independently finalized turns after the raw sink controls; invocations:\n{invocations}"
     );
     assert_eq!(
         invocation_count(invocations, &unavailable),
@@ -1817,17 +2006,17 @@ fn assert_observability_candidate_invocations(invocations: &str, trace_id: &str)
         summary_window, series_window,
         "summary and series must share the one dynamically captured window; invocations:\n{invocations}"
     );
-    let bounded_position = invocations
-        .lines()
-        .position(|line| line == runs)
-        .expect("bounded runs invocation");
     let detail_position = invocations
         .lines()
         .position(|line| line == detail.as_str())
         .expect("discovered trace detail invocation");
+    let seed_position = invocations
+        .lines()
+        .position(|line| line.starts_with("--json local message "))
+        .expect("seed message invocation");
     assert!(
-        bounded_position < detail_position,
-        "the rung must discover the real trace id from the bounded list before querying its complete tree; invocations:\n{invocations}"
+        seed_position < detail_position,
+        "the rung must complete a seed before querying the exact trace ID privately derived from that seed; invocations:\n{invocations}"
     );
 }
 
@@ -2011,19 +2200,13 @@ fn local_observability_proof_leaves_a_borrowed_stack_to_its_owner() {
     );
 }
 
-/// #866 NEGATIVE CONTROLS. Move one stub contract at a time while the positive
-/// control above stays green: JSON cardinality, unknown-trace exit 1,
+/// #866 NEGATIVE CONTROLS. Move one candidate query contract at a time while
+/// the positive control above stays green: unknown-trace exit 1,
 /// unavailable-API exit 3, and the mandatory recovery instruction must each
 /// make the real ladder reject the candidate and still run owner teardown.
 #[test]
 fn local_observability_negative_controls_are_falsifiable() {
     let cases: &[(&str, &str, &[&str], bool)] = &[
-        (
-            "STUB_RUNS_EXTRA_JSON",
-            "1",
-            &["runs", "exactly one JSON object"],
-            false,
-        ),
         (
             "STUB_UNKNOWN_TRACE_EXIT",
             "0",

--- a/cli/tests/nightly_graded_ladder.rs
+++ b/cli/tests/nightly_graded_ladder.rs
@@ -905,7 +905,7 @@ fn live_local_rung_grades_the_deployed_weather_cases() {
     );
     assert!(
         local_rung
-            .contains("local up_args=(local up)\n        echo \"=== curie ${up_args[*]} ===\""),
+            .contains("local up_args=(local up -f \"$REPO_ROOT/compose.dev.yaml\" --build)\n        echo \"=== curie ${up_args[*]} ===\""),
         "the local rung must start the full profile required by its \
          observability query proof; ladder contents:\n{text}"
     );
@@ -1749,7 +1749,7 @@ print(json.dumps({
     "local up --minimal")
         echo "stub: compose stack up"
         ;;
-    "local up")
+    "local up -f "*/compose.dev.yaml" --build")
         echo "stub: full compose stack up"
         ;;
     "--json local deploy --plugin-dir "*)
@@ -1840,7 +1840,7 @@ print(json.dumps({
         fi
         exit "${STUB_EVAL_EXIT:-0}"
         ;;
-    "local down")
+    "local down -f "*/compose.dev.yaml)
         echo "stub: compose stack down"
         ;;
     *)
@@ -2169,6 +2169,33 @@ fn invocation_count(invocations: &str, expected: &str) -> usize {
     invocations.lines().filter(|line| *line == expected).count()
 }
 
+/// The local rung must boot the current source tree rather than the release
+/// compose resolved by the candidate binary. The compose file and `--build`
+/// are both load-bearing parts of this argv.
+fn is_current_source_local_up(invocation: &str) -> bool {
+    let args = invocation.split_whitespace().collect::<Vec<_>>();
+    args.len() == 5
+        && args[..3] == ["local", "up", "-f"]
+        && args[3].ends_with("/compose.dev.yaml")
+        && args[4] == "--build"
+}
+
+/// Teardown must target the same current-source compose file that the rung
+/// brought up; an unqualified `local down` could select a release compose.
+fn is_current_source_local_down(invocation: &str) -> bool {
+    let args = invocation.split_whitespace().collect::<Vec<_>>();
+    args.len() == 4
+        && args[..3] == ["local", "down", "-f"]
+        && args[3].ends_with("/compose.dev.yaml")
+}
+
+fn current_source_local_down_count(invocations: &str) -> usize {
+    invocations
+        .lines()
+        .filter(|line| is_current_source_local_down(line))
+        .count()
+}
+
 fn looks_like_utc_second(value: &str) -> bool {
     let bytes = value.as_bytes();
     bytes.len() == 20
@@ -2376,12 +2403,12 @@ fn ladder_selects_platform_trajectory_eval_without_overriding_deployed_cases() {
         .lines()
         .filter(|line| line.starts_with("local up"))
         .collect::<Vec<_>>();
-    assert_eq!(trajectory_starts, ["local up"], "{trajectory_invocations}");
+    assert_eq!(trajectory_starts.len(), 1, "{trajectory_invocations}");
     assert!(
         trajectory_starts
             .iter()
-            .all(|line| !line.contains("--minimal")),
-        "trajectory scoring requires the full local profile: {trajectory_invocations}"
+            .all(|line| is_current_source_local_up(line)),
+        "trajectory scoring requires current-source compose.dev.yaml with --build, never --minimal: {trajectory_invocations}"
     );
     for tier in ["local", "cluster"] {
         assert!(
@@ -2415,9 +2442,15 @@ fn ladder_selects_platform_trajectory_eval_without_overriding_deployed_cases() {
         .filter(|line| line.starts_with("local up"))
         .collect::<Vec<_>>();
     assert_eq!(
-        ordinary_starts,
-        ["local up"],
-        "the local rung's observability query proof requires the full profile even when the suite has no trajectory sidecar: {ordinary_invocations}"
+        ordinary_starts.len(),
+        1,
+        "the local rung's observability query proof requires one current-source boot even when the suite has no trajectory sidecar: {ordinary_invocations}"
+    );
+    assert!(
+        ordinary_starts
+            .iter()
+            .all(|line| is_current_source_local_up(line)),
+        "the local rung's observability query proof must pin compose.dev.yaml and --build even when the suite has no trajectory sidecar: {ordinary_invocations}"
     );
 }
 
@@ -2439,18 +2472,23 @@ fn local_rung_proves_observability_queries_with_real_candidate_verbs() {
         unavailable_called,
         "the local rung must actually move CURIE_API_URL to the closed-loopback control and exercise the unavailable-API path through the candidate CLI; invocations:\n{invocations}"
     );
+    let local_starts = invocations
+        .lines()
+        .filter(|line| line.starts_with("local up"))
+        .collect::<Vec<_>>();
     assert_eq!(
-        invocations
-            .lines()
-            .filter(|line| line.starts_with("local up"))
-            .collect::<Vec<_>>(),
-        ["local up"],
-        "observability proof requires the full local profile, never --minimal; invocations:\n{invocations}"
+        local_starts.len(),
+        1,
+        "observability proof requires exactly one local boot, never an additional minimal or release-compose boot; invocations:\n{invocations}"
+    );
+    assert!(
+        local_starts.iter().all(|line| is_current_source_local_up(line)),
+        "observability proof requires current-source compose.dev.yaml with --build, never --minimal; invocations:\n{invocations}"
     );
     assert_eq!(
-        invocation_count(&invocations, "local down"),
+        current_source_local_down_count(&invocations),
         1,
-        "a successful rung must tear down the one stack it claimed exactly once; invocations:\n{invocations}"
+        "a successful rung must tear down the one current-source stack it claimed exactly once; invocations:\n{invocations}"
     );
 }
 
@@ -2526,9 +2564,9 @@ fn local_observability_negative_controls_are_falsifiable() {
             "{variable} exercised the wrong unavailable-API path"
         );
         assert_eq!(
-            invocation_count(&invocations, "local down"),
+            current_source_local_down_count(&invocations),
             1,
-            "the owner-scoped EXIT trap must tear down {variable}; invocations:\n{invocations}"
+            "the owner-scoped EXIT trap must tear down {variable} through compose.dev.yaml; invocations:\n{invocations}"
         );
     }
 }

--- a/cli/tests/nightly_graded_ladder.rs
+++ b/cli/tests/nightly_graded_ladder.rs
@@ -1278,7 +1278,7 @@ fn product_sanitizer_and_message_failures_never_dump_private_json() {
 }
 
 #[test]
-fn adopted_component_stop_requires_successful_local_and_cluster_export() {
+fn adopted_component_stop_requires_complete_available_surface_export() {
     let decision = ladder_function("classify_product_observability_owner");
     for required in [
         "raw_emitted_observations",
@@ -1318,7 +1318,7 @@ fn adopted_component_stop_requires_successful_local_and_cluster_export() {
     }
     assert!(
         decision.contains("curie-clear") && decision.contains("SystemExit(0)"),
-        "only a fully cleared local+cluster classification may exit zero"
+        "only complete exact membership for every exercised surface may exit zero"
     );
 }
 

--- a/cli/tests/nightly_graded_ladder.rs
+++ b/cli/tests/nightly_graded_ladder.rs
@@ -71,6 +71,43 @@ fn ladder_function(name: &str) -> String {
     format!("{marker}{body}\n}}\n")
 }
 
+fn ladder_python_heredoc(function_name: &str) -> String {
+    let function = ladder_function(function_name);
+    let (_, tail) = function
+        .split_once("<<'PY'\n")
+        .unwrap_or_else(|| panic!("ladder function {function_name} must contain Python"));
+    tail.split_once("\nPY\n")
+        .unwrap_or_else(|| panic!("ladder function {function_name} Python must close"))
+        .0
+        .to_owned()
+}
+
+fn run_seed_trace_matcher(matcher: &str, marker: &str, rows: &serde_json::Value) -> Output {
+    let harness = tempfile::tempdir().expect("create seed matcher fixture directory");
+    let bounded_slice = harness.path().join("bounded-stream.json");
+    fs::write(
+        &bounded_slice,
+        serde_json::to_vec(rows).expect("serialize bounded stream fixture"),
+    )
+    .expect("write bounded stream fixture");
+    let mut child = Command::new("python3")
+        .arg("-")
+        .arg(&bounded_slice)
+        .arg(marker)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("start exact seed matcher");
+    child
+        .stdin
+        .take()
+        .expect("open matcher stdin")
+        .write_all(matcher.as_bytes())
+        .expect("write exact seed matcher");
+    child.wait_with_output().expect("wait for seed matcher")
+}
+
 /// The local OTel assertions deliberately live in the shell harness, where
 /// they consume the Collector's raw JSON files.  Keep this test on that real
 /// consumer instead of re-implementing its attribution rules in Rust.
@@ -823,10 +860,15 @@ fn live_local_rung_grades_the_deployed_weather_cases() {
         .find(r#"prove_local_observability_queries "$agent_id""#)
         .map(|offset| product_collector + offset)
         .expect("the local rung must prove observability queries after telemetry");
-    assert!(
-        !text.contains(r#"local observability runs --limit 100"#),
-        "a newest-runs page can select a background trace; the live proof must derive the exact trace ID from the seeded bounded stream entry"
-    );
+    for removed_helper in [
+        "discover_local_observability_trace() {",
+        "assert_local_observability_detail() {",
+    ] {
+        assert!(
+            !text.contains(removed_helper),
+            "a newest-runs selector/raw-dump helper remains ({removed_helper}); variable interpolation must not evade exact-ID discovery"
+        );
+    }
     for required in [
         "discover_trace_id_for_seed",
         "query_exact_seed_trace",
@@ -875,6 +917,75 @@ fn live_local_rung_grades_the_deployed_weather_cases() {
 }
 
 #[test]
+fn exact_seed_matcher_recovers_embedded_marker_once_and_rejects_background() {
+    let matcher = ladder_python_heredoc("discover_trace_id_for_seed");
+    let marker = "curie-seed-ordinary-example";
+    let target_trace = "a".repeat(32);
+    let background_trace = "b".repeat(32);
+    let target = serde_json::json!([
+        "2-0",
+        [
+            "payload",
+            serde_json::json!({"text": format!("ordinary correlation {marker}")}).to_string(),
+            "traceparent",
+            format!("00-{target_trace}-{}-01", "2".repeat(16))
+        ]
+    ]);
+    let background = serde_json::json!([
+        "1-0",
+        [
+            "payload",
+            serde_json::json!({"text": "ordinary correlation another-seed"}).to_string(),
+            "traceparent",
+            format!("00-{background_trace}-{}-01", "1".repeat(16))
+        ]
+    ]);
+
+    let matched = run_seed_trace_matcher(
+        &matcher,
+        marker,
+        &serde_json::json!([background.clone(), target.clone()]),
+    );
+    assert!(
+        matched.status.success(),
+        "representative embedded marker was not recovered: {}",
+        String::from_utf8_lossy(&matched.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&matched.stdout).trim(),
+        target_trace,
+        "background carrier must not substitute for the marker-adjacent carrier"
+    );
+
+    let mismatch = run_seed_trace_matcher(&matcher, marker, &serde_json::json!([background]));
+    assert!(
+        !mismatch.status.success(),
+        "a background payload without the marker must fail closed"
+    );
+    let duplicate = run_seed_trace_matcher(
+        &matcher,
+        marker,
+        &serde_json::json!([
+            target,
+            [
+                "3-0",
+                [
+                    "payload",
+                    serde_json::json!({"text": format!("ordinary correlation {marker}")})
+                        .to_string(),
+                    "traceparent",
+                    format!("00-{}-{}-01", "c".repeat(32), "3".repeat(16))
+                ]
+            ]
+        ]),
+    );
+    assert!(
+        !duplicate.status.success(),
+        "multiple matching adjacent carriers must fail closed"
+    );
+}
+
+#[test]
 fn product_observability_requires_three_valid_seeds_and_count_only_mcp_receipt() {
     let text = ladder();
     for required in [
@@ -908,6 +1019,16 @@ fn product_observability_requires_three_valid_seeds_and_count_only_mcp_receipt()
     assert!(
         receipt.contains("count") || receipt.contains("wc -l"),
         "only an aggregate MCP call count may reach evidence output"
+    );
+
+    let approval = ladder_function("seed_approval_resume_turn");
+    assert!(
+        approval.contains("curie.approval.suspend"),
+        "approval evidence must require the worker's real parked-turn span"
+    );
+    assert!(
+        !approval.contains("curie.approval.wait"),
+        "the oracle must not invent a wait span that no current emitter produces"
     );
 }
 
@@ -960,6 +1081,73 @@ fn product_collector_restore_covers_every_emitter_and_invalid_auth_recovers_same
         negative.matches("same_queued_trace_id").count() >= 2,
         "the temporarily absent ID, not a fresh post-recovery control, must become queryable"
     );
+
+    let valid_control = negative
+        .find(r#"query_exact_seed_trace local "$LAST_ORDINARY_TRACE_ID""#)
+        .expect("invalid-auth proof must first read an exact known-valid trace");
+    let invalidate = negative
+        .find(r#"export LANGFUSE_OTLP_AUTH_HEADER="$INVALID_LANGFUSE_OTLP_AUTH_HEADER""#)
+        .expect("invalid-auth proof must roll the Collector to the placeholder credential");
+    assert!(
+        valid_control < invalidate,
+        "the valid exact-read control must precede credential invalidation"
+    );
+
+    let before_restore = negative
+        .split_once("restore_local_langfuse_auth")
+        .map(|(prefix, _)| prefix)
+        .expect("invalid-auth proof must restore valid auth");
+    let invalid_restarts: Vec<_> = before_restore
+        .match_indices("restart_local_product_collector")
+        .map(|(index, _)| index)
+        .collect();
+    assert!(
+        invalid_restarts.len() >= 2,
+        "the file-backed queue must survive a Collector restart while auth is still invalid"
+    );
+    let after_invalid_restart = &before_restore[invalid_restarts[1]..];
+    for required in [
+        "otelcol_exporter_send_failed_spans",
+        "otelcol_exporter_queue_size",
+        "query_exact_seed_trace",
+    ] {
+        assert!(
+            after_invalid_restart.contains(required),
+            "queued failure must be re-observed after the invalid-auth restart: missing {required}"
+        );
+    }
+
+    let query = ladder_function("query_exact_seed_trace");
+    let poll_start = query
+        .find(r#"for attempt in $(seq 1 "$OBSERVABILITY_POLL_ATTEMPTS"); do"#)
+        .expect("exact trace query must use the declared bounded poll count");
+    let poll_end = poll_start
+        + query[poll_start..]
+            .find("\n    done")
+            .expect("exact trace bounded poll must close");
+    let absent_success = query
+        .find("exact trace remained not-found through the full bounded observation poll")
+        .expect("exact trace query must report a bounded absent verdict");
+    assert!(
+        absent_success > poll_end,
+        "absence must stay stable for the full poll bound, not return on the first exit 1"
+    );
+    assert!(
+        query.to_ascii_lowercase().contains("not found")
+            || query.to_ascii_lowercase().contains("not_found"),
+        "only a typed not-found result may satisfy absence; arbitrary exit 1 is not evidence"
+    );
+
+    let absent = negative
+        .find(r#"query_exact_seed_trace local "$same_queued_trace_id" "" "" absent"#)
+        .expect("queued exact ID must be checked absent while auth is invalid");
+    let recovered = negative
+        .rfind(r#"query_exact_seed_trace local "$same_queued_trace_id""#)
+        .expect("the same queued exact ID must be queried after valid auth returns");
+    assert!(
+        absent < recovered,
+        "same-ID recovery must follow the bounded queued-failure observation"
+    );
 }
 
 #[test]
@@ -989,6 +1177,7 @@ fn cluster_product_observability_is_private_preflight_and_query_only() {
     }
 
     let query = ladder_function("run_cluster_product_observability");
+    let wrapper = ladder_function("rung_cluster_product");
     for required in [
         "preflight_cluster_product_observability",
         "seed_ordinary_turn",
@@ -1008,9 +1197,51 @@ fn cluster_product_observability_is_private_preflight_and_query_only() {
         "helm uninstall",
         "kubectl delete",
     ] {
+        for (helper_name, helper) in [
+            ("preflight", preflight.as_str()),
+            ("query", query.as_str()),
+            ("product wrapper", wrapper.as_str()),
+        ] {
+            assert!(
+                !helper.contains(mutation),
+                "cluster product {helper_name} must never install, upgrade, uninstall, or delete the release: found {mutation}"
+            );
+        }
+    }
+    assert!(
+        wrapper.contains("cluster deploy"),
+        "the product wrapper must retain the intended agent seed deployment"
+    );
+    assert!(
+        !preflight.contains(r#"-o json > "$inventory""#)
+            && !preflight.contains("cluster-product-pods"),
+        "cluster preflight must query Ready/imageID fields directly and never persist full pod JSON containing private spec/env data"
+    );
+}
+
+#[test]
+fn product_sanitizer_and_message_failures_never_dump_private_json() {
+    let sanitizer = ladder_function("sanitize_exact_trace_read");
+    assert!(
+        !sanitizer.contains("if private_fields.intersection(node):\n        pass"),
+        "private-field handling must reject or remove data, not be a no-op"
+    );
+    for private in ["input", "output", "session", "user", "headers"] {
         assert!(
-            !query.contains(mutation),
-            "cluster product mode must never mutate the installed release: found {mutation}"
+            sanitizer.contains(private),
+            "sanitizer must explicitly account for private field {private}"
+        );
+    }
+
+    let finalized = ladder_function("assert_finalized_reply");
+    for raw_dump in [
+        r#"printf '%s\n' "$payload""#,
+        r#"printf "%s\n" "$payload""#,
+        r#"echo "$payload""#,
+    ] {
+        assert!(
+            !finalized.contains(raw_dump),
+            "message parse/finalization failures must emit a bounded verdict, not private raw JSON"
         );
     }
 }

--- a/cli/tests/nightly_graded_ladder.rs
+++ b/cli/tests/nightly_graded_ladder.rs
@@ -1034,6 +1034,18 @@ fn product_observability_requires_three_valid_seeds_and_count_only_mcp_receipt()
 
 #[test]
 fn product_collector_restore_covers_every_emitter_and_invalid_auth_recovers_same_id() {
+    let pins = ladder_function("pin_local_source_images");
+    for required in [
+        "export CURIE_BASE_TAG=dev",
+        "export CURIE_RUNNER_IMAGE=ghcr.io/curie-eng/curie-runner:dev",
+        "export CURIE_DISPATCHER_IMAGE=ghcr.io/curie-eng/curie-dispatcher:dev",
+    ] {
+        assert!(
+            pins.contains(required),
+            "raw Compose recreation loses {required}"
+        );
+    }
+    assert!(ladder_function("rung_local").contains("pin_local_source_images"));
     let restore = ladder_function("route_local_observability_to_product_collector");
     for required in [
         "curie-api",
@@ -1052,6 +1064,10 @@ fn product_collector_restore_covers_every_emitter_and_invalid_auth_recovers_same
     assert!(
         restore.contains("export OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318"),
         "product restoration must override unrelated shell or ignored-file routing"
+    );
+    assert!(
+        restore.contains("export CURIE_WORKER_OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:24318"),
+        "host-network worker must use the collector's published host port"
     );
     assert!(
         restore.contains("export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf"),

--- a/cli/tests/nightly_graded_ladder.rs
+++ b/cli/tests/nightly_graded_ladder.rs
@@ -893,8 +893,8 @@ fn product_observability_requires_three_valid_seeds_and_count_only_mcp_receipt()
         );
     }
 
-    let receipt_fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("scripts/fixtures/mcp-receipt/server.py");
+    let receipt_fixture =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("scripts/fixtures/mcp-receipt/server.py");
     let receipt_source = fs::read_to_string(&receipt_fixture).unwrap_or_default();
     assert!(
         receipt_source.contains(r#""tools/call""#),
@@ -995,7 +995,10 @@ fn cluster_product_observability_is_private_preflight_and_query_only() {
         "seed_approval_resume_turn",
         "cluster observability run",
     ] {
-        assert!(query.contains(required), "cluster query mode omits {required}");
+        assert!(
+            query.contains(required),
+            "cluster query mode omits {required}"
+        );
     }
     for mutation in [
         "cluster up",

--- a/cli/tests/resume_wait.rs
+++ b/cli/tests/resume_wait.rs
@@ -635,7 +635,17 @@ async fn a_notice_without_a_card_parks_the_turn_and_the_keepalive_delivers_the_r
     .await;
 
     let parked = match outcome {
-        Outcome::AwaitingApproval(latest) => latest,
+        Outcome::AwaitingApproval {
+            reply: latest,
+            approval_id: captured_id,
+        } => {
+            assert_eq!(
+                captured_id.as_deref(),
+                Some(approval_id),
+                "the route-bound notice remains the explicit id fallback when no card arrives"
+            );
+            latest
+        }
         other => {
             let _: i64 = redis::cmd("DEL")
                 .arg(&stream)
@@ -750,7 +760,13 @@ async fn a_blank_line_summary_notice_parks_the_turn_and_the_keepalive_delivers_t
     .await;
 
     let parked = match outcome {
-        Outcome::AwaitingApproval(latest) => latest,
+        Outcome::AwaitingApproval {
+            reply: latest,
+            approval_id: captured_id,
+        } => {
+            assert_eq!(captured_id.as_deref(), Some(approval_id));
+            latest
+        }
         other => {
             let _: i64 = redis::cmd("DEL")
                 .arg(&stream)

--- a/cli/tests/support/mod.rs
+++ b/cli/tests/support/mod.rs
@@ -46,14 +46,14 @@ pub async fn valkey_or_skip(test: &str) -> Option<redis::aio::MultiplexedConnect
 }
 
 /// Builds a unique test-scoped stream name under the given prefix (e.g.
-/// `"curie:test:chat:"`), so concurrent test runs never collide and each
-/// suite keeps its own distinct stream namespace.
+/// `"curie:test:chat:"`), so concurrent tests and processes never collide
+/// and each suite keeps its own distinct stream namespace.
+///
+/// Names include a UUID v4, not `SystemTime` nanos alone. Parallel tests on
+/// the hosted runner and on a separately owned Valkey collided when the
+/// suffix was timestamp-only (#2086).
 pub fn unique_stream(prefix: &str) -> String {
-    let nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    format!("{prefix}{nanos}")
+    format!("{prefix}{}", uuid::Uuid::new_v4())
 }
 
 #[derive(Debug, Clone)]

--- a/cli/tests/unique_stream.rs
+++ b/cli/tests/unique_stream.rs
@@ -1,0 +1,126 @@
+//! Isolation of Valkey stream names minted by CLI integration tests (#2086).
+//!
+//! `unique_stream` must stay collision-resistant across parallel test threads
+//! and across separate processes. Timestamp-only names failed that on hosted
+//! runners and on a separately owned Valkey.
+
+mod support;
+use support::unique_stream;
+
+use std::collections::HashSet;
+use std::process::{Command, Stdio};
+use std::sync::{Arc, Barrier};
+use std::thread;
+
+const PREFIX: &str = "curie:test:ns:";
+const CHILD_ENV: &str = "CURIE_UNIQUE_STREAM_CHILD_COUNT";
+
+fn suffix(name: &str) -> &str {
+    name.strip_prefix(PREFIX)
+        .expect("unique_stream must keep the caller prefix")
+}
+
+#[test]
+fn unique_stream_keeps_the_prefix() {
+    let name = unique_stream(PREFIX);
+    assert!(name.starts_with(PREFIX), "{name}");
+    assert!(!suffix(&name).is_empty(), "{name}");
+}
+
+#[test]
+fn unique_stream_suffix_is_not_timestamp_only() {
+    let name = unique_stream(PREFIX);
+    let suffix = suffix(&name);
+    assert!(
+        suffix.chars().any(|c| !c.is_ascii_digit()),
+        "unique_stream must not be prefix plus SystemTime nanos; got {name}"
+    );
+}
+
+#[test]
+fn unique_stream_names_are_unique_across_parallel_threads() {
+    const THREADS: usize = 64;
+    const PER_THREAD: usize = 32;
+    let barrier = Arc::new(Barrier::new(THREADS));
+    let mut joins = Vec::with_capacity(THREADS);
+    for _ in 0..THREADS {
+        let barrier = Arc::clone(&barrier);
+        joins.push(thread::spawn(move || {
+            barrier.wait();
+            (0..PER_THREAD)
+                .map(|_| unique_stream(PREFIX))
+                .collect::<Vec<_>>()
+        }));
+    }
+    let mut all = Vec::with_capacity(THREADS * PER_THREAD);
+    for join in joins {
+        all.extend(join.join().expect("unique_stream thread"));
+    }
+    let unique: HashSet<&String> = all.iter().collect();
+    assert_eq!(
+        unique.len(),
+        all.len(),
+        "parallel unique_stream calls collided"
+    );
+}
+
+#[test]
+fn unique_stream_names_are_unique_across_processes() {
+    if let Ok(count) = std::env::var(CHILD_ENV) {
+        let n: usize = count.parse().expect("child count");
+        for _ in 0..n {
+            println!("{}", unique_stream(PREFIX));
+        }
+        return;
+    }
+
+    const PROCESSES: usize = 4;
+    const PER_PROCESS: usize = 32;
+    let exe = std::env::current_exe().expect("current test binary");
+    let mut children = Vec::with_capacity(PROCESSES);
+    for _ in 0..PROCESSES {
+        children.push(
+            Command::new(&exe)
+                .env(CHILD_ENV, PER_PROCESS.to_string())
+                .args([
+                    "unique_stream_names_are_unique_across_processes",
+                    "--exact",
+                    "--nocapture",
+                ])
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()
+                .expect("spawn unique_stream child"),
+        );
+    }
+
+    let mut all = Vec::with_capacity(PROCESSES * PER_PROCESS);
+    for child in children {
+        let output = child
+            .wait_with_output()
+            .expect("wait for unique_stream child");
+        assert!(
+            output.status.success(),
+            "unique_stream child failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        for line in String::from_utf8_lossy(&output.stdout).lines() {
+            if let Some(rest) = line.strip_prefix(PREFIX) {
+                if !rest.is_empty() {
+                    all.push(format!("{PREFIX}{rest}"));
+                }
+            }
+        }
+    }
+    assert_eq!(
+        all.len(),
+        PROCESSES * PER_PROCESS,
+        "missing child unique_stream names: {all:?}"
+    );
+    let unique: HashSet<&String> = all.iter().collect();
+    assert_eq!(
+        unique.len(),
+        all.len(),
+        "cross-process unique_stream calls collided"
+    );
+}

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -30,6 +30,8 @@
 #
 # ClickHouse is pinned to :24.8 on purpose. Newer ClickHouse requires AVX and
 # SIGILLs with exit 132 on CPUs without it; :24.8 still ships an SSE4.2 build.
+# The Helm chart default is :25.12 (AVX required) so it can apply the Langfuse
+# pin's ClickHouse migrations; do not treat the two pins as the same knob.
 
 # Pin the Compose project name so `local up`/`down` target the same project
 # regardless of where this file sits (repo checkout or fetched cache dir).

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -92,6 +92,8 @@ services:
     image: valkey/valkey:8-alpine
     profiles: *core_profiles
     command: ["valkey-server", "--requirepass", "${VALKEY_PASSWORD:-valkeypass}"]
+    environment:
+      VALKEY_PASSWORD: ${VALKEY_PASSWORD:-valkeypass}
     ports:
       - "26379:6379"
     volumes:

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -243,20 +243,6 @@ services:
         condition: service_completed_successfully
     environment:
       <<: *langfuse-env
-    # Port 3030 starts listening only after Langfuse initialization completes
-    # and app import registers the BullMQ OTel ingestion consumers. Without a
-    # healthcheck, `docker compose up --wait` returns while the container is
-    # merely running and a first trace can sit invisible until worker restart.
-    healthcheck:
-      test:
-        - CMD
-        - node
-        - -e
-        - "fetch('http://' + process.env.HOSTNAME + ':3030/').then((response) => { if (!response.ok) process.exit(1); }).catch(() => process.exit(1))"
-      interval: 2s
-      timeout: 5s
-      retries: 150
-      start_period: 5s
     restart: unless-stopped
 
   langfuse-web:

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -243,6 +243,20 @@ services:
         condition: service_completed_successfully
     environment:
       <<: *langfuse-env
+    # Port 3030 starts listening only after Langfuse initialization completes
+    # and app import registers the BullMQ OTel ingestion consumers. Without a
+    # healthcheck, `docker compose up --wait` returns while the container is
+    # merely running and a first trace can sit invisible until worker restart.
+    healthcheck:
+      test:
+        - CMD
+        - node
+        - -e
+        - "fetch('http://' + process.env.HOSTNAME + ':3030/').then((response) => { if (!response.ok) process.exit(1); }).catch(() => process.exit(1))"
+      interval: 2s
+      timeout: 5s
+      retries: 150
+      start_period: 5s
     restart: unless-stopped
 
   langfuse-web:

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -617,7 +617,9 @@ services:
       # The collector join is also what lets --local-model resolve ollama by name.
       # Both are overridable from the shell.
       #
-      # The endpoint default is what a full-profile `local up` gets. It uses the
+      # The worker itself uses host networking, while the runner joins
+      # `curie_runner`; they therefore need different addresses for the same
+      # Collector. The endpoint defaults use the
       # `${VAR-default}` form (substitute only when UNSET), not `${VAR:-default}`
       # (substitute when unset OR empty), so an explicit empty value means "no
       # endpoint". That is what lets `curie local up --minimal` suppress it:
@@ -635,7 +637,8 @@ services:
       # it to the worker, which forwards it into every claim's boot env.
       - CURIE_FALSE_COMPLETION_CHECK=${CURIE_FALSE_COMPLETION_CHECK:-}
       - CURIE_DOCKER_NETWORK=${CURIE_DOCKER_NETWORK:-curie_runner}
-      - OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT-http://otel-collector:4318}
+      - OTEL_EXPORTER_OTLP_ENDPOINT=${CURIE_WORKER_OTEL_EXPORTER_OTLP_ENDPOINT-${OTEL_EXPORTER_OTLP_ENDPOINT-http://127.0.0.1:24318}}
+      - CURIE_RUNNER_OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT-http://otel-collector:4318}
       - OTEL_EXPORTER_OTLP_PROTOCOL=${OTEL_EXPORTER_OTLP_PROTOCOL-http/protobuf}
       # config.py's connector_release/connector_namespace (CURIE_RELEASE /
       # CURIE_NAMESPACE) both default empty, which was built for the cluster

--- a/compose/tests/test_generate_release_compose.py
+++ b/compose/tests/test_generate_release_compose.py
@@ -11,6 +11,8 @@ hand-maintained compose.release.yaml, which has drifted from dev.
 """
 
 import importlib.util
+import json
+import os
 import re
 import shutil
 import subprocess
@@ -292,12 +294,12 @@ def resolve_shell_default(value):
     UNSET. The endpoint uses the `-` form specifically so `curie local up
     --minimal` can suppress it with an explicit empty override; under `:-` an
     empty value could never mean "no endpoint". Still intentionally narrow: no
-    `${VAR}`, `${VAR:?err}`, or nested forms.
+    `${VAR}` or `${VAR:?err}` forms. Nested defaults recurse.
     """
     if value is None:
         return None
     match = SHELL_DEFAULT_RE.match(value)
-    return match.group(1) if match else value
+    return resolve_shell_default(match.group(1)) if match else value
 
 
 def resolve_shell_interpolation(value, environ):
@@ -307,10 +309,10 @@ def resolve_shell_interpolation(value, environ):
         return value
     name = match.group("name")
     if name not in environ:
-        return match.group("default")
+        return resolve_shell_interpolation(match.group("default"), environ)
     resolved = environ[name]
     if match.group("colon") and resolved == "":
-        return match.group("default")
+        return resolve_shell_interpolation(match.group("default"), environ)
     return resolved
 
 
@@ -500,18 +502,25 @@ def test_worker_traces_to_shipped_collector_by_default():
     exporting it empty -- see `up_minimal_suppresses_otel_endpoint` in
     cli/src/local.rs, which is where the profile choice lives.
     """
-    expected = f"http://otel-collector:{collector_http_port()}"
+    expected_runner = f"http://otel-collector:{collector_http_port()}"
+    expected_worker = "http://127.0.0.1:24318"
     for label, doc in compose_docs():
         assert "otel-collector" in doc["services"], (
             f"{label}: otel-collector service not found in the compose document"
         )
         env = env_map(doc["services"]["curie-worker"])
         otel_endpoint = resolve_shell_default(env.get("OTEL_EXPORTER_OTLP_ENDPOINT"))
-        assert otel_endpoint == expected, (
+        assert otel_endpoint == expected_worker, (
             f"{label}: curie-worker OTEL_EXPORTER_OTLP_ENDPOINT resolves to "
-            f"{otel_endpoint!r}, expected {expected!r} (the collector's own "
-            f"OTLP/HTTP receiver); traces from spawned sandbox containers have "
-            f"nowhere to go"
+            f"{otel_endpoint!r}, expected {expected_worker!r}; the host-network "
+            "worker cannot resolve a Compose service name"
+        )
+        runner_endpoint = resolve_shell_default(
+            env.get("CURIE_RUNNER_OTEL_EXPORTER_OTLP_ENDPOINT")
+        )
+        assert runner_endpoint == expected_runner, (
+            f"{label}: runner OTLP endpoint resolves to {runner_endpoint!r}, "
+            f"expected {expected_runner!r} on the isolated runner network"
         )
         docker_network = resolve_shell_default(env.get("CURIE_DOCKER_NETWORK"))
         assert docker_network == "curie_runner", (
@@ -523,7 +532,7 @@ def test_worker_traces_to_shipped_collector_by_default():
         )
 
 
-@pytest.mark.parametrize("service_name", ["curie-api", "curie-dispatcher", "curie-worker"])
+@pytest.mark.parametrize("service_name", ["curie-api", "curie-dispatcher"])
 def test_platform_services_export_to_shipped_collector_by_default(service_name):
     """Every long-lived Python service gets the standard OTLP endpoint.
 
@@ -548,7 +557,59 @@ def test_platform_services_export_to_shipped_collector_by_default(service_name):
         )
 
 
-@pytest.mark.parametrize("service_name", ["curie-api", "curie-dispatcher", "curie-worker"])
+@pytest.mark.parametrize(
+    ("overrides", "worker_endpoint", "runner_endpoint"),
+    [
+        ({}, "http://127.0.0.1:24318", "http://otel-collector:4318"),
+        ({"OTEL_EXPORTER_OTLP_ENDPOINT": ""}, "", ""),
+        (
+            {"OTEL_EXPORTER_OTLP_ENDPOINT": "http://collector.example.com:4318"},
+            "http://collector.example.com:4318", "http://collector.example.com:4318",
+        ),
+        (
+            {
+                "OTEL_EXPORTER_OTLP_ENDPOINT": "http://collector.example.com:4318",
+                "CURIE_WORKER_OTEL_EXPORTER_OTLP_ENDPOINT": "",
+            },
+            "", "http://collector.example.com:4318",
+        ),
+        (
+            {
+                "OTEL_EXPORTER_OTLP_ENDPOINT": "http://otel-collector:4318",
+                "CURIE_WORKER_OTEL_EXPORTER_OTLP_ENDPOINT": "http://127.0.0.1:24318",
+            },
+            "http://127.0.0.1:24318", "http://otel-collector:4318",
+        ),
+    ],
+)
+def test_worker_endpoint_split_executes_compose_interpolation(
+    tmp_path, overrides, worker_endpoint, runner_endpoint
+):
+    """Use actual Compose interpolation, including explicit-empty negative paths."""
+    for label, doc in compose_docs():
+        worker_env = env_map(doc["services"]["curie-worker"])
+        selected = {
+            key: worker_env[key]
+            for key in ("OTEL_EXPORTER_OTLP_ENDPOINT", "CURIE_RUNNER_OTEL_EXPORTER_OTLP_ENDPOINT")
+        }
+        config = tmp_path / label
+        config.write_text(yaml.safe_dump({
+            "services": {"worker": {"image": "example-worker", "environment": selected}}
+        }))
+        clean_env = {key: value for key, value in os.environ.items() if key not in (
+            "OTEL_EXPORTER_OTLP_ENDPOINT", "CURIE_WORKER_OTEL_EXPORTER_OTLP_ENDPOINT"
+        )}
+        result = subprocess.run(
+            ["docker", "compose", "--env-file", "/dev/null", "-f", str(config),
+             "config", "--format", "json"],
+            env={**clean_env, **overrides}, capture_output=True, text=True, check=True,
+        )
+        rendered = json.loads(result.stdout)["services"]["worker"]["environment"]
+        assert rendered["OTEL_EXPORTER_OTLP_ENDPOINT"] == worker_endpoint
+        assert rendered["CURIE_RUNNER_OTEL_EXPORTER_OTLP_ENDPOINT"] == runner_endpoint
+
+
+@pytest.mark.parametrize("service_name", ["curie-api", "curie-dispatcher"])
 def test_platform_service_endpoint_explicit_empty_disables_export(service_name):
     """The minimal/core path can explicitly suppress the full-stack default.
 

--- a/compose/tests/test_generate_release_compose.py
+++ b/compose/tests/test_generate_release_compose.py
@@ -190,24 +190,6 @@ def test_rustfs_and_aws_bucket_bootstrap_preserve_the_s3_consumer_contract():
             assert consumer_env["LANGFUSE_S3_MEDIA_UPLOAD_FORCE_PATH_STYLE"] == "true"
 
 
-def test_langfuse_worker_readiness_gates_compose_wait():
-    """Do not accept OTel before the adopted ingest consumer is registered."""
-    for label, doc in compose_docs():
-        worker = doc["services"]["langfuse-worker"]
-        healthcheck = worker.get("healthcheck", {})
-        health_command = " ".join(str(part) for part in healthcheck.get("test", []))
-        assert healthcheck.get("test", [None])[0] == "CMD", (
-            f"{label} Langfuse worker readiness must be an executable healthcheck"
-        )
-        assert "node" in health_command and "process.env.HOSTNAME" in health_command, (
-            f"{label} Langfuse worker healthcheck must probe its post-initialization "
-            f"HTTP listener, got {health_command!r}"
-        )
-        assert healthcheck.get("start_period") and healthcheck.get("retries"), (
-            f"{label} Langfuse worker readiness must tolerate bounded first-boot initialization"
-        )
-
-
 def test_invariants_preserved_from_dev():
     generate = load_generate()
     out = generate(DEV_TEXT, OTEL_TEXT, version="9.9.9")

--- a/compose/tests/test_generate_release_compose.py
+++ b/compose/tests/test_generate_release_compose.py
@@ -190,6 +190,24 @@ def test_rustfs_and_aws_bucket_bootstrap_preserve_the_s3_consumer_contract():
             assert consumer_env["LANGFUSE_S3_MEDIA_UPLOAD_FORCE_PATH_STYLE"] == "true"
 
 
+def test_langfuse_worker_readiness_gates_compose_wait():
+    """Do not accept OTel before the adopted ingest consumer is registered."""
+    for label, doc in compose_docs():
+        worker = doc["services"]["langfuse-worker"]
+        healthcheck = worker.get("healthcheck", {})
+        health_command = " ".join(str(part) for part in healthcheck.get("test", []))
+        assert healthcheck.get("test", [None])[0] == "CMD", (
+            f"{label} Langfuse worker readiness must be an executable healthcheck"
+        )
+        assert "node" in health_command and "process.env.HOSTNAME" in health_command, (
+            f"{label} Langfuse worker healthcheck must probe its post-initialization "
+            f"HTTP listener, got {health_command!r}"
+        )
+        assert healthcheck.get("start_period") and healthcheck.get("retries"), (
+            f"{label} Langfuse worker readiness must tolerate bounded first-boot initialization"
+        )
+
+
 def test_invariants_preserved_from_dev():
     generate = load_generate()
     out = generate(DEV_TEXT, OTEL_TEXT, version="9.9.9")

--- a/compose/tests/test_local_observability_ladder.py
+++ b/compose/tests/test_local_observability_ladder.py
@@ -15,6 +15,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
 import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -809,10 +810,84 @@ def test_product_collector_restore_restarts_and_verifies_every_seed_emitter() ->
     assert (
         "export OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318" in restore
     )
+    assert (
+        "export CURIE_WORKER_OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:24318"
+        in restore
+    )
     assert "export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf" in restore
     assert "unset OTEL_EXPORTER_OTLP_ENDPOINT" not in restore
     for protocol in ("http/protobuf", "otel-collector:4318"):
         assert protocol in restore
+
+
+@pytest.mark.parametrize("owned", [0, 1])
+def test_current_source_images_survive_raw_compose_recreation(owned: int) -> None:
+    source = LADDER_PATH.read_text()
+    function = _shell_function(source, "pin_local_source_images")
+    keys = ("CURIE_BASE_TAG", "CURIE_RUNNER_IMAGE", "CURIE_DISPATCHER_IMAGE")
+    initial = dict.fromkeys(keys, "stale-example")
+    initial["OTEL_EXPORTER_OTLP_ENDPOINT"] = "http://collector.example.com:4318"
+    script = function + "\nLOCAL_STACK_OWNED=\"$1\"\npin_local_source_images\n"
+    script += (
+        "exec python3 -c 'import json,os; "
+        'print(json.dumps({key: os.environ[key] for key in '
+        '["CURIE_BASE_TAG", "CURIE_RUNNER_IMAGE", "CURIE_DISPATCHER_IMAGE", '
+        '"OTEL_EXPORTER_OTLP_ENDPOINT"]}))' + "'\n"
+    )
+    result = subprocess.run(
+        ["bash", "-c", script, "bash", str(owned)],
+        env={**os.environ, **initial}, text=True, capture_output=True, check=True,
+    )
+    child_env = json.loads(result.stdout)
+    expected = {
+        "CURIE_BASE_TAG": "dev",
+        "CURIE_RUNNER_IMAGE": "ghcr.io/curie-eng/curie-runner:dev",
+        "CURIE_DISPATCHER_IMAGE": "ghcr.io/curie-eng/curie-dispatcher:dev",
+    } if owned else {key: initial[key] for key in keys}
+    assert {key: child_env[key] for key in keys} == expected
+    assert child_env["OTEL_EXPORTER_OTLP_ENDPOINT"] == initial["OTEL_EXPORTER_OTLP_ENDPOINT"]
+    rung = _shell_function(source, "rung_local")
+    assert rung.index('"$BIN" "${up_args[@]}"') < rung.index("pin_local_source_images")
+    assert rung.index("pin_local_source_images") < rung.index("case_local_otel")
+
+
+@pytest.mark.parametrize(
+    ("response", "exit_code", "category"),
+    [
+        ({"error": "private-error-canary", "fix": "private-fix-canary"}, 3, "query-error"),
+        ({"trace": {}, "tree": []}, 0, "malformed-response"),
+        ({"trace": {"id": "a" * 32}, "tree": [{
+            "name": "agent.run", "type": "SPAN", "children": [],
+            "input": "private-input-canary",
+        }]}, 0, "incomplete-membership"),
+    ],
+)
+def test_exact_query_failure_reports_sanitized_reason(
+    tmp_path: Path, response: dict, exit_code: int, category: str
+) -> None:
+    source = LADDER_PATH.read_text()
+    fake_bin = tmp_path / "curie"
+    fake_bin.write_text('#!/bin/sh\nprintf "%s\\n" "$FAKE_RESPONSE"\nexit "$FAKE_EXIT"\n')
+    fake_bin.chmod(0o700)
+    script = _shell_function(source, "sanitize_exact_trace_read")
+    script += _shell_function(source, "query_exact_seed_trace")
+    script += '''
+WORKDIR="$1"
+BIN="$2"
+OBSERVABILITY_POLL_ATTEMPTS=1
+OBSERVABILITY_POLL_INTERVAL_SECONDS=0
+query_exact_seed_trace local aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa curie.queue.enqueue "" present
+'''
+    result = subprocess.run(
+        ["bash", "-c", script, "bash", str(tmp_path), str(fake_bin)],
+        env={**os.environ, "FAKE_RESPONSE": json.dumps(response), "FAKE_EXIT": str(exit_code)},
+        text=True, capture_output=True, check=False,
+    )
+    assert result.returncode == 1
+    assert category in result.stderr
+    assert "private-" not in result.stderr + result.stdout
+    if category == "incomplete-membership":
+        assert '"operation":["agent.run"]' in result.stderr
 
 
 def test_invalid_langfuse_auth_is_temporary_durable_and_recovers_the_same_id(

--- a/compose/tests/test_local_observability_ladder.py
+++ b/compose/tests/test_local_observability_ladder.py
@@ -743,6 +743,53 @@ def test_approval_resume_failure_evidence_is_bounded_and_private_artifacts_are_c
     assert "PRIVATE_PARSE_STDERR_SENTINEL" not in parse_result.stdout + parse_result.stderr
 
 
+def test_approval_seed_background_message_is_owned_by_global_cleanup() -> None:
+    """Every approval-seed exit path must release its Slack stub before teardown."""
+
+    source = LADDER_PATH.read_text()
+    trap = _shell_function(source, "cleanup")
+    approval = _shell_function(source, "seed_approval_resume_turn")
+
+    assert "APPROVAL_SEED_MESSAGE_PID=$!" in approval
+    assert "stop_approval_seed_message terminate || true" in trap
+    assert trap.index("stop_approval_seed_message terminate || true") < trap.index(
+        '"$BIN" local down'
+    ), "the background Slack stub must stop before its stack is torn down"
+    assert approval.count("stop_approval_seed_message terminate || true") == 2
+    assert "stop_approval_seed_message || code=$?" in approval
+    for stale_local_wait in ('kill "$message_pid"', 'wait "$message_pid"'):
+        assert stale_local_wait not in approval
+
+
+def test_approval_seed_cleanup_terminates_and_clears_a_stale_pid() -> None:
+    """An interrupted seed cannot leave its background Slack stub alive."""
+
+    source = LADDER_PATH.read_text()
+    stop = _shell_function(source, "stop_approval_seed_message")
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            f"""set -u
+{stop}
+APPROVAL_SEED_MESSAGE_PID=""
+sleep 30 &
+stale_pid=$!
+APPROVAL_SEED_MESSAGE_PID="$stale_pid"
+stop_approval_seed_message terminate || true
+[[ -z "$APPROVAL_SEED_MESSAGE_PID" ]]
+if kill -0 "$stale_pid" 2>/dev/null; then
+    exit 9
+fi
+""",
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+
+
 def test_product_collector_restore_restarts_and_verifies_every_seed_emitter() -> None:
     """Worker-only restore cannot prove dispatcher, API, or runner delivery."""
 

--- a/compose/tests/test_local_observability_ladder.py
+++ b/compose/tests/test_local_observability_ladder.py
@@ -806,6 +806,11 @@ def test_product_collector_restore_restarts_and_verifies_every_seed_emitter() ->
             "or launched after product routing is restored"
         )
     assert "assert_product_collector_endpoint" in restore
+    assert (
+        "export OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318" in restore
+    )
+    assert "export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf" in restore
+    assert "unset OTEL_EXPORTER_OTLP_ENDPOINT" not in restore
     for protocol in ("http/protobuf", "otel-collector:4318"):
         assert protocol in restore
 

--- a/compose/tests/test_local_observability_ladder.py
+++ b/compose/tests/test_local_observability_ladder.py
@@ -131,6 +131,62 @@ classify_product_observability_owner
     )
 
 
+def _run_local_exact_positive(
+    tmp_path: Path,
+    *,
+    operations: tuple[str, ...],
+    expected_state: str = "present",
+) -> subprocess.CompletedProcess[str]:
+    """Drive the production local exact-read positive against a candidate CLI."""
+
+    source = LADDER_PATH.read_text()
+    sanitizer = _shell_function(source, "sanitize_exact_trace_read")
+    query = _shell_function(source, "query_exact_seed_trace")
+    trace_id = "a" * 32
+    response = tmp_path / "response.json"
+    response.write_text(
+        json.dumps(
+            {
+                "trace": {"id": trace_id},
+                "tree": [
+                    {"name": operation, "type": "SPAN", "children": []}
+                    for operation in operations
+                ],
+                "approval_decision": None,
+            }
+        )
+    )
+    fake_bin = tmp_path / "curie"
+    fake_bin.write_text('#!/bin/sh\ncat "$FAKE_TRACE_RESPONSE"\n')
+    fake_bin.chmod(0o700)
+    script = f"""set -u
+{sanitizer}
+{query}
+WORKDIR="$1"
+BIN="$2"
+OBSERVABILITY_POLL_ATTEMPTS=1
+OBSERVABILITY_POLL_INTERVAL_SECONDS=0
+CURIE_NAMESPACE=acme-observability
+CURIE_RELEASE=acme-observability
+query_exact_seed_trace local {trace_id} "curie.queue.enqueue,curie.reply.post" "" "$3"
+"""
+    return subprocess.run(
+        [
+            "bash",
+            "-c",
+            script,
+            "bash",
+            str(tmp_path),
+            str(fake_bin),
+            expected_state,
+        ],
+        env={**os.environ, "FAKE_TRACE_RESPONSE": str(response)},
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
 def test_local_ladder_owns_a_real_queryable_otlp_sink() -> None:
     """A plain local rung must create, query, and remove its own OTLP sink."""
 
@@ -722,6 +778,49 @@ def test_invalid_langfuse_auth_is_temporary_durable_and_recovers_the_same_id(
     ), "the same ID must be absent during failure and present after recovery"
 
 
+def test_default_local_exact_positive_rejects_incomplete_membership(
+    tmp_path: Path,
+) -> None:
+    """Normal local is strict; only ownership diagnostics may retain a miss."""
+
+    source = LADDER_PATH.read_text()
+    rung = _function_body(source, "rung_local", "# local-release mode:")
+    assert "product_query_state=present" in rung
+    assert 'if [[ "$PRODUCT_OBSERVABILITY" == "1" ]]' in rung
+    assert rung.count("product_query_state=observe") == 1
+    assert 'seed_ordinary_turn local "$agent_id" "$product_query_state"' in rung
+    assert "invalid-auth negative skipped" not in rung
+
+    complete_dir = tmp_path / "complete"
+    complete_dir.mkdir()
+    complete = _run_local_exact_positive(
+        complete_dir,
+        operations=("curie.queue.enqueue", "curie.reply.post"),
+    )
+    assert complete.returncode == 0, complete.stderr
+
+    incomplete_dir = tmp_path / "incomplete"
+    incomplete_dir.mkdir()
+    incomplete = _run_local_exact_positive(
+        incomplete_dir,
+        operations=("curie.queue.enqueue",),
+    )
+    assert incomplete.returncode != 0, (
+        "the default local positive must fail when exact Langfuse membership is incomplete"
+    )
+
+    diagnostic_dir = tmp_path / "diagnostic"
+    diagnostic_dir.mkdir()
+    diagnostic = _run_local_exact_positive(
+        diagnostic_dir,
+        operations=("curie.queue.enqueue",),
+        expected_state="observe",
+    )
+    assert diagnostic.returncode == 0, (
+        "only explicit product ownership diagnostics may retain incomplete membership"
+    )
+
+
 def test_cluster_product_observability_is_private_preflight_and_query_only() -> None:
     """The ladder may inspect a task release but must never install or remove it."""
 
@@ -918,6 +1017,9 @@ def test_adopted_component_stop_requires_successful_export_on_both_product_surfa
 
     cases = (
         (None, None, "curie-unresolved", False),
+        (record(membership=True, same_id_raw=False), None, "curie-clear", True),
+        (None, record(membership=True, same_id_raw=False), "curie-clear", True),
+        (record(membership=False, same_id_raw=False), None, "curie-unresolved", False),
         (
             {
                 key: value

--- a/compose/tests/test_local_observability_ladder.py
+++ b/compose/tests/test_local_observability_ladder.py
@@ -100,6 +100,37 @@ query_exact_seed_trace local aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa "" "" absent
     return result, int(count.read_text()) if count.exists() else 0
 
 
+def _run_product_classifier(
+    tmp_path: Path,
+    *,
+    local: dict[str, object] | None,
+    cluster: dict[str, object] | None,
+) -> subprocess.CompletedProcess[str]:
+    """Execute the production ownership classifier against explicit evidence."""
+
+    function = _shell_function(
+        LADDER_PATH.read_text(), "classify_product_observability_owner"
+    )
+    local_path = tmp_path / "local.json"
+    cluster_path = tmp_path / "cluster.json"
+    if local is not None:
+        local_path.write_text(json.dumps({**local, "surface": "local"}))
+    if cluster is not None:
+        cluster_path.write_text(json.dumps({**cluster, "surface": "cluster"}))
+    script = f"""set -u
+{function}
+LOCAL_PRODUCT_EVIDENCE="$1"
+CLUSTER_PRODUCT_EVIDENCE="$2"
+classify_product_observability_owner
+"""
+    return subprocess.run(
+        ["bash", "-c", script, "bash", str(local_path), str(cluster_path)],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
 def test_local_ladder_owns_a_real_queryable_otlp_sink() -> None:
     """A plain local rung must create, query, and remove its own OTLP sink."""
 
@@ -718,9 +749,22 @@ def test_cluster_product_observability_is_private_preflight_and_query_only() -> 
     mode = _shell_function(source, "run_cluster_product_observability")
     wrapper = _shell_function(source, "rung_cluster_product")
     assert "preflight_cluster_product_observability" in mode
-    assert "seed_ordinary_turn" in mode
-    assert "seed_approval_resume_turn" in mode
+    assert "seed_cluster_missing_carrier_control" in mode
+    assert "cluster_external_ingress_seed" in mode
+    assert "CURIE_E2E_CLUSTER_EXTERNAL_INGRESS_RECEIPT" in source
+    assert "CURIE_E2E_PRODUCT_RUN_ID" in source
+    assert "otelcol_receiver_accepted_spans_delta" in source
+    assert "otelcol_exporter_sent_spans_delta" in source
     assert "cluster observability run" in mode
+    for manufactured in (
+        "enqueue_cluster_carried_turn",
+        "CLUSTER_SEEDED_TRACE_ID",
+        "secrets.token_hex",
+    ):
+        assert manufactured not in source, (
+            "cluster correlation evidence must be derived from a real accepted "
+            f"ingress path, not manufactured by the harness: {manufactured}"
+        )
     assert "cluster deploy" in wrapper, (
         "the wrapper must retain the intended agent seed deployment"
     )
@@ -750,7 +794,86 @@ def test_cluster_product_observability_is_private_preflight_and_query_only() -> 
     )
 
 
-def test_adopted_component_stop_requires_successful_export_on_both_product_surfaces() -> None:
+def test_cluster_carrierless_control_and_external_slack_carrier_are_executed(
+    tmp_path: Path,
+) -> None:
+    """The fake cluster path stays negative; only Slack ingress can be positive."""
+
+    source = LADDER_PATH.read_text()
+    marker = "curie-seed-external-ordinary-example"
+    trace_id = "a" * 32
+    span_id = "b" * 16
+    payload_only = [
+        "2-0",
+        [
+            "payload",
+            json.dumps(
+                {
+                    "text": f"missing carrier compatibility {marker}",
+                    "reply_handle": {"adapter": "curie-cluster-message"},
+                }
+            ),
+        ],
+    ]
+    carried_slack = [
+        "3-0",
+        [
+            "payload",
+            json.dumps(
+                {
+                    "text": f"ordinary correlation {marker}",
+                    "reply_handle": {"kind": "slack", "adapter": None},
+                }
+            ),
+            "traceparent",
+            f"00-{trace_id}-{span_id}-01",
+        ],
+    ]
+
+    negative = _run_seed_matcher(
+        tmp_path,
+        _python_heredoc(_shell_function(source, "seed_cluster_missing_carrier_control")),
+        marker,
+        [payload_only],
+    )
+    assert negative.returncode == 0, negative.stderr
+
+    external_matcher = _python_heredoc(
+        _shell_function(source, "discover_cluster_external_trace_id")
+    )
+    positive = _run_seed_matcher(tmp_path, external_matcher, marker, [carried_slack])
+    assert positive.returncode == 0, positive.stderr
+    assert positive.stdout.strip() == trace_id
+
+    forged = _run_seed_matcher(
+        tmp_path,
+        external_matcher,
+        marker,
+        [
+            [
+                "4-0",
+                [
+                    "payload",
+                    json.dumps(
+                        {
+                            "text": f"ordinary correlation {marker}",
+                            "reply_handle": {"adapter": "curie-cluster-message"},
+                        }
+                    ),
+                    "traceparent",
+                    f"00-{trace_id}-{span_id}-01",
+                ],
+            ]
+        ],
+    )
+    assert forged.returncode != 0, (
+        "a harness/cluster-message-shaped entry must not satisfy real Slack ingress"
+    )
+
+
+def test_adopted_component_stop_requires_successful_export_on_both_product_surfaces(
+    tmp_path: Path,
+) -> None:
     """Selective ingest loss is a dependency blocker only after Curie is cleared."""
 
     source = LADDER_PATH.read_text()
@@ -764,6 +887,8 @@ def test_adopted_component_stop_requires_successful_export_on_both_product_surfa
         "cluster",
         "image_ids_match",
         "seed_valid",
+        "same_id_raw_collector_receipt",
+        "run_id",
         "adopted-component",
     ):
         assert required in decision, f"ownership classification omits {required!r}"
@@ -773,3 +898,64 @@ def test_adopted_component_stop_requires_successful_export_on_both_product_surfa
     assert decision.index("langfuse_observation_membership") < decision.index(
         "adopted-component"
     )
+
+    def record(
+        *,
+        membership: bool,
+        same_id_raw: bool = True,
+        run_id: str = "run-example",
+    ) -> dict[str, object]:
+        return {
+            "run_id": run_id,
+            "seed_valid": True,
+            "same_id_raw_collector_receipt": same_id_raw,
+            "raw_emitted_observations": 3,
+            "otelcol_receiver_accepted_spans": 3,
+            "otelcol_exporter_sent_spans": 3,
+            "langfuse_observation_membership": membership,
+            "image_ids_match": True,
+        }
+
+    cases = (
+        (None, None, "curie-unresolved", False),
+        (
+            {
+                key: value
+                for key, value in record(membership=True).items()
+                if key != "langfuse_observation_membership"
+            },
+            record(membership=True),
+            "curie-unresolved",
+            False,
+        ),
+        (
+            record(membership=True, run_id="run-one"),
+            record(membership=True, run_id="run-two"),
+            "curie-unresolved",
+            False,
+        ),
+        (record(membership=False), record(membership=False), "adopted-component", False),
+        (
+            record(membership=False, same_id_raw=False),
+            record(membership=False, same_id_raw=False),
+            "curie-unresolved",
+            False,
+        ),
+        (record(membership=True), record(membership=False), "curie-owned", False),
+        (
+            record(membership=True, same_id_raw=False),
+            record(membership=True),
+            "curie-clear",
+            True,
+        ),
+        (record(membership=True), record(membership=True), "curie-clear", True),
+    )
+    for index, (local, cluster, verdict, succeeds) in enumerate(cases):
+        case_dir = tmp_path / str(index)
+        case_dir.mkdir()
+        result = _run_product_classifier(case_dir, local=local, cluster=cluster)
+        assert verdict in result.stdout
+        assert (result.returncode == 0) is succeeds, (
+            "only complete same-run, positive export and exact membership may "
+            f"clear the STOP; verdict={verdict} stdout={result.stdout!r}"
+        )

--- a/compose/tests/test_local_observability_ladder.py
+++ b/compose/tests/test_local_observability_ladder.py
@@ -15,6 +15,7 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parents[2]
 LADDER_PATH = REPO_ROOT / "cli" / "scripts" / "e2e-ladder.sh"
 SINK_CONFIG_PATH = REPO_ROOT / "cli" / "scripts" / "fixtures" / "otel-e2e-sink-config.yaml"
+MCP_RECEIPT_FIXTURE = REPO_ROOT / "cli" / "scripts" / "fixtures" / "mcp-receipt"
 
 
 def _function_body(source: str, name: str, next_marker: str) -> str:
@@ -22,6 +23,16 @@ def _function_body(source: str, name: str, next_marker: str) -> str:
     assert start_marker in source, f"{LADDER_PATH}: missing {name}"
     start = source.index(start_marker)
     end = source.index(next_marker, start)
+    return source[start:end]
+
+
+def _shell_function(source: str, name: str) -> str:
+    """Return one top-level shell function without depending on its successor."""
+
+    start_marker = f"{name}() {{"
+    assert start_marker in source, f"{LADDER_PATH}: missing {name}"
+    start = source.index(start_marker)
+    end = source.index("\n}\n", start) + len("\n}\n")
     return source[start:end]
 
 
@@ -242,4 +253,220 @@ def test_local_otel_controls_distinguish_a_live_sink_from_a_turn() -> None:
     )
     assert "sleep 12" in helper, (
         "the failure baseline must outwait the 10-second metric export interval"
+    )
+
+
+def test_product_oracle_discovers_only_the_seed_trace_from_bounded_transport() -> None:
+    """A background/newest trace must be unable to satisfy the turn oracle."""
+
+    source = LADDER_PATH.read_text()
+    assert "local observability runs --limit 100" not in source, (
+        "a newest-runs page can select an unrelated background trace; exact discovery "
+        "must start from the seeded stream entry"
+    )
+
+    discover = _shell_function(source, "discover_trace_id_for_seed")
+    for required in (
+        "stream_start",
+        "stream_end",
+        "marker",
+        "XRANGE",
+        "traceparent",
+        "[0-9a-f]{32}",
+        "umask 077",
+    ):
+        assert required in discover, (
+            "exact discovery must inspect only the marker's bounded stream slice, "
+            f"validate its adjacent W3C carrier, and keep raw fields private; missing {required!r}"
+        )
+    assert "printf '%s\\n' \"$payload\"" not in discover
+    assert "printf '%s\\n' \"$traceparent\"" not in discover
+
+    query = _shell_function(source, "query_exact_seed_trace")
+    assert 'observability run "$trace_id"' in query
+    assert "sanitize_exact_trace_read" in query
+    assert "observability runs" not in query
+    assert "printf '%s\\n' \"$out\"" not in query, (
+        "raw Langfuse JSON may contain prompt, user, session, and deployment fields"
+    )
+    sanitizer = _shell_function(source, "sanitize_exact_trace_read")
+    for allowed in (
+        "trace_id",
+        "service",
+        "operation",
+        "observation_count",
+        "observation_type",
+        "approval_decision",
+    ):
+        assert allowed in sanitizer, f"sanitized evidence omits safe field {allowed!r}"
+    for private in ("input", "output", "session", "user", "headers"):
+        assert private in sanitizer, (
+            f"sanitizer must explicitly prevent raw {private!r} from reaching stdout"
+        )
+
+
+def test_ordinary_mcp_and_approval_seeds_have_independent_receipts() -> None:
+    """An unexercised seed is seed-invalid before telemetry is interpreted."""
+
+    source = LADDER_PATH.read_text()
+    for name, required in {
+        "seed_ordinary_turn": ("assert_finalized_reply", "ordinary", "seed-invalid"),
+        "seed_mcp_read_turn": ("mcp_receipt_call_count", "seed-invalid"),
+        "seed_approval_resume_turn": (
+            "awaiting-approval",
+            "pending",
+            "resolve",
+            "assert_finalized_reply",
+            "seed-invalid",
+        ),
+    }.items():
+        body = _shell_function(source, name)
+        missing = [marker for marker in required if marker not in body]
+        assert not missing, f"{name} lacks independent outcome evidence: {missing}"
+        assert "discover_trace_id_for_seed" in body
+        assert "query_exact_seed_trace" in body
+
+    assert "seed-invalid" in source
+    assert MCP_RECEIPT_FIXTURE.is_dir(), (
+        "the MCP observation needs a hosted fixture whose container log is an "
+        "independent tools/call receipt ledger"
+    )
+    server = MCP_RECEIPT_FIXTURE / "server.py"
+    assert server.is_file()
+    fixture_source = server.read_text()
+    assert '"tools/call"' in fixture_source
+    assert "print(" in fixture_source
+    assert "flush=True" in fixture_source
+
+    receipt = _shell_function(source, "mcp_receipt_call_count")
+    assert "connector_container_for_alias" in receipt
+    assert "docker logs" in receipt or "kubectl logs" in receipt
+    assert "wc -l" in receipt or "count" in receipt
+    for forbidden in ("tool input", "arguments", "receipt line"):
+        assert forbidden not in receipt.lower(), (
+            "public evidence may expose only an aggregate MCP call count"
+        )
+
+
+def test_product_collector_restore_restarts_and_verifies_every_seed_emitter() -> None:
+    """Worker-only restore cannot prove dispatcher, API, or runner delivery."""
+
+    source = LADDER_PATH.read_text()
+    restore = _shell_function(source, "route_local_observability_to_product_collector")
+    for service in (
+        "curie-api",
+        "curie-dispatcher",
+        "curie-worker",
+        "curie-runner",
+    ):
+        assert service in restore, (
+            f"{service} can keep the disposable sink endpoint unless it is recreated "
+            "or launched after product routing is restored"
+        )
+    assert "assert_product_collector_endpoint" in restore
+    for protocol in ("http/protobuf", "otel-collector:4318"):
+        assert protocol in restore
+
+
+def test_invalid_langfuse_auth_is_temporary_durable_and_recovers_the_same_id() -> None:
+    """Pin the real backend negative without redefining exporter semantics."""
+
+    source = LADDER_PATH.read_text()
+    negative = _shell_function(source, "case_local_langfuse_invalid_auth")
+
+    # Observed shipped behavior, not an assumed external-API contract:
+    # otel/collector-config.yaml enables retry_on_failure at 5s/30s/5m and a
+    # file_storage-backed sending_queue of 1000. Therefore invalid auth is a
+    # bounded temporary absence, and success means recovery of the same queued
+    # trace ID after restoring auth, never permanent loss or a fresh control ID.
+    for required in (
+        "LANGFUSE_OTLP_AUTH_HEADER",
+        "INVALID_LANGFUSE_OTLP_AUTH_HEADER",
+        "langfuse-web",
+        "otelcol_receiver_accepted_spans",
+        "otelcol_exporter_send_failed_spans",
+        "sending_queue",
+        "file_storage",
+        "queue_size",
+        "Ready",
+        "restart",
+        "same_queued_trace_id",
+        "query_exact_seed_trace",
+        "queue_drained",
+    ):
+        assert required in negative, f"invalid-auth proof omits {required!r}"
+    assert "down -v" not in negative
+    assert negative.index("INVALID_LANGFUSE_OTLP_AUTH_HEADER") < negative.index(
+        "same_queued_trace_id"
+    )
+    assert negative.count("same_queued_trace_id") >= 2, (
+        "the ID observed absent while auth is invalid must be the ID recovered "
+        "after the queue-preserving restart"
+    )
+
+
+def test_cluster_product_observability_is_private_preflight_and_query_only() -> None:
+    """The ladder may inspect a task release but must never install or remove it."""
+
+    source = LADDER_PATH.read_text()
+    preflight = _shell_function(source, "preflight_cluster_product_observability")
+    for required in (
+        "CURIE_NAMESPACE",
+        "CURIE_RELEASE",
+        "default",
+        "curie",
+        "langfuse",
+        "otel-collector",
+        "api",
+        "worker",
+        "runner-prewarm",
+        "imageID",
+        "docker image inspect",
+        "curie-api:local",
+        "curie-worker:local",
+        "curie-runner:latest",
+        "mismatch",
+    ):
+        assert required in preflight, f"cluster preflight omits {required!r}"
+
+    mode = _shell_function(source, "run_cluster_product_observability")
+    assert "preflight_cluster_product_observability" in mode
+    assert "seed_ordinary_turn" in mode
+    assert "seed_approval_resume_turn" in mode
+    assert "cluster observability run" in mode
+    for mutating in (
+        "cluster up",
+        "cluster down",
+        "helm install",
+        "helm upgrade",
+        "helm uninstall",
+        "kubectl delete",
+    ):
+        assert mutating not in mode, (
+            f"product-observability mode must be preflight/query-only, found {mutating!r}"
+        )
+
+
+def test_adopted_component_stop_requires_successful_export_on_both_product_surfaces() -> None:
+    """Selective ingest loss is a dependency blocker only after Curie is cleared."""
+
+    source = LADDER_PATH.read_text()
+    decision = _shell_function(source, "classify_product_observability_owner")
+    for required in (
+        "raw_emitted_observations",
+        "otelcol_receiver_accepted_spans",
+        "otelcol_exporter_sent_spans",
+        "langfuse_observation_membership",
+        "local",
+        "cluster",
+        "image_ids_match",
+        "seed_valid",
+        "adopted-component",
+    ):
+        assert required in decision, f"ownership classification omits {required!r}"
+    assert decision.index("otelcol_exporter_sent_spans") < decision.index(
+        "adopted-component"
+    )
+    assert decision.index("langfuse_observation_membership") < decision.index(
+        "adopted-component"
     )

--- a/compose/tests/test_local_observability_ladder.py
+++ b/compose/tests/test_local_observability_ladder.py
@@ -890,7 +890,7 @@ query_exact_seed_trace local aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa curie.queue.enqueu
         assert '"operation":["agent.run"]' in result.stderr
 
 
-def test_invalid_langfuse_auth_is_temporary_durable_and_recovers_the_same_id(
+def test_invalid_langfuse_auth_proves_permanent_rejection_and_fresh_recovery(
     tmp_path: Path,
 ) -> None:
     """Pin the real backend negative without redefining exporter semantics."""
@@ -899,35 +899,29 @@ def test_invalid_langfuse_auth_is_temporary_durable_and_recovers_the_same_id(
     negative = _shell_function(source, "case_local_langfuse_invalid_auth")
     query = _shell_function(source, "query_exact_seed_trace")
 
-    # Observed shipped behavior, not an assumed external-API contract:
-    # otel/collector-config.yaml enables retry_on_failure at 5s/30s/5m and a
-    # file_storage-backed sending_queue of 1000. Therefore invalid auth is a
-    # bounded temporary absence, and success means recovery of the same queued
-    # trace ID after restoring auth, never permanent loss or a fresh control ID.
+    # OTLP requires retry for only 429/502/503/504; 401 MUST NOT be retried:
+    # https://opentelemetry.io/docs/specs/otlp/#retryable-response-codes
+    # The pinned Collector reports accepted+failed spans, permanent401 rejection,
+    # and queue0. Restored credentials must admit a NEW complete trace, not
+    # replay a permanently rejected batch.
     for required in (
         "LANGFUSE_OTLP_AUTH_HEADER",
         "INVALID_LANGFUSE_OTLP_AUTH_HEADER",
         "langfuse-web",
         "otelcol_receiver_accepted_spans",
         "otelcol_exporter_send_failed_spans",
-        "sending_queue",
-        "file_storage",
         "queue_size",
         "Ready",
         "restart",
-        "same_queued_trace_id",
+        "failed_trace_id",
+        "recovered_trace_id",
+        "HTTP Status Code 401",
+        "Permanent error",
         "query_exact_seed_trace",
-        "queue_drained",
     ):
         assert required in negative, f"invalid-auth proof omits {required!r}"
     assert "down -v" not in negative
-    assert negative.index("INVALID_LANGFUSE_OTLP_AUTH_HEADER") < negative.index(
-        "same_queued_trace_id"
-    )
-    assert negative.count("same_queued_trace_id") >= 2, (
-        "the ID observed absent while auth is invalid must be the ID recovered "
-        "after the queue-preserving restart"
-    )
+    assert "same_queued_trace_id" not in negative
 
     invalid_auth = negative.index(
         'export LANGFUSE_OTLP_AUTH_HEADER="$INVALID_LANGFUSE_OTLP_AUTH_HEADER"'
@@ -937,21 +931,6 @@ def test_invalid_langfuse_auth_is_temporary_durable_and_recovers_the_same_id(
         "a successful exact read under valid auth must discriminate backend/query "
         "health before the credential is made invalid"
     )
-
-    # Restart once while auth is still invalid, then re-observe both queued
-    # failure and stable absence. Restoring auth is a later, separate restart.
-    before_restore = negative[: negative.index("restore_local_langfuse_auth")]
-    restart_positions = [
-        match.start()
-        for match in re.finditer("restart_local_product_collector", before_restore)
-    ]
-    assert len(restart_positions) >= 2, (
-        "the file-backed queue must survive a Collector restart while auth remains invalid"
-    )
-    after_invalid_restart = before_restore[restart_positions[1] :]
-    assert "otelcol_exporter_queue_size" in after_invalid_restart
-    assert "otelcol_exporter_send_failed_spans" in after_invalid_restart
-    assert "query_exact_seed_trace" in after_invalid_restart
 
     # Execute the production query helper: absence is a bounded observation,
     # not one lucky first poll, and only the stable not-found error is accepted.
@@ -975,11 +954,11 @@ def test_invalid_langfuse_auth_is_temporary_durable_and_recovers_the_same_id(
     )
 
     absent_call = re.search(
-        r'query_exact_seed_trace local "\$same_queued_trace_id"[^\n]*absent',
+        r'query_exact_seed_trace local "\$failed_trace_id"[^\n]*absent',
         negative,
     )
     recovered_call = re.search(
-        r'query_exact_seed_trace local "\$same_queued_trace_id"\s*$',
+        r'query_exact_seed_trace local "\$recovered_trace_id"',
         negative,
         re.MULTILINE,
     )
@@ -987,7 +966,89 @@ def test_invalid_langfuse_auth_is_temporary_durable_and_recovers_the_same_id(
         absent_call
         and recovered_call
         and absent_call.start() < recovered_call.start()
-    ), "the same ID must be absent during failure and present after recovery"
+    ), "the failed ID must be absent before a new complete recovery trace"
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        "", "no-failed-metric", "no-rejection-log", "stuck-queue", "restart",
+        "reply", "absence", "restore", "recovery-query",
+    ],
+)
+def test_invalid_auth_requires_every_observation_and_always_restores(
+    tmp_path: Path, failure: str,
+) -> None:
+    """Execute the real gate under conditional Bash semantics (errexit disabled)."""
+    source = LADDER_PATH.read_text()
+    function = _shell_function(source, "assert_product_collector_permanent_auth_rejection")
+    function += _shell_function(source, "case_local_langfuse_invalid_auth")
+    script = r'''
+set -u -o pipefail
+WORKDIR="$1"
+REPO_ROOT="$2"
+FAILURE="$3"
+BIN=true
+LAST_ORDINARY_TRACE_ID=cccccccccccccccccccccccccccccccc
+sleep() { :; }
+docker() {
+    if [[ "$1" == logs ]]; then
+        [[ "$FAILURE" == no-rejection-log ]] ||
+            printf '%s\n' 'Permanent error: HTTP Status Code 401; not retryable error'
+    else
+        printf '%s\n' acme-collector
+    fi
+}
+restart_local_product_collector() { [[ "$FAILURE" != restart ]]; }
+wait_product_collector_ready() { return 0; }
+restore_local_langfuse_auth() {
+    printf '%s\n' restored >> "$WORKDIR/events"
+    [[ "$FAILURE" != restore ]]
+}
+assert_finalized_reply() { [[ "$FAILURE" != reply ]]; }
+assert_product_runner_endpoints() { return 0; }
+seed_ordinary_turn() { LAST_ORDINARY_TRACE_ID=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb; }
+capture_stream_cursor() { printf '%s\n' 1-0; }
+discover_trace_id_for_seed() {
+    if [[ -e "$WORKDIR/seeded" ]]; then
+        printf '%s\n' bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+    else
+        touch "$WORKDIR/seeded"
+        printf '%s\n' aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    fi
+}
+product_collector_metric_value() {
+    local count=0 file="$WORKDIR/$1"
+    [[ ! -e "$file" ]] || read -r count < "$file"
+    printf '%s\n' "$((count + 1))" > "$file"
+    case "$1" in
+        *queue_size) [[ "$FAILURE" != stuck-queue ]] && echo 0 || echo 1 ;;
+        *send_failed_spans)
+            [[ "$FAILURE" != no-failed-metric && "$count" -gt 0 ]] && echo 10 || echo 0 ;;
+        *accepted_spans) [[ "$count" -gt 0 ]] && echo 10 || echo 0 ;;
+    esac
+}
+query_exact_seed_trace() {
+    printf '%s\n' "query:$2:${3-}:${5-}" >> "$WORKDIR/events"
+    [[ "$2" != bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb || "$FAILURE" != recovery-query ]] || return 1
+    [[ "${5-}" != absent || "$FAILURE" != absence ]]
+}
+'''
+    script += function
+    script += '\nif case_local_langfuse_invalid_auth acme-agent; then exit 0; else exit 1; fi\n'
+    result = subprocess.run(
+        ["bash", "-c", script, "bash", str(tmp_path), str(REPO_ROOT), failure],
+        text=True, capture_output=True, check=False,
+    )
+    events = (tmp_path / "events").read_text()
+    assert events.count("restored") == 1
+    assert result.returncode == (1 if failure else 0), result.stderr
+    recovered = "query:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:curie.queue.enqueue,curie.queue.process"
+    if failure and failure != "recovery-query":
+        assert recovered not in events
+    else:
+        assert recovered in events
+        assert events.index(":absent") < events.index("restored") < events.index(recovered)
 
 
 def test_default_local_exact_positive_rejects_incomplete_membership(

--- a/compose/tests/test_local_observability_ladder.py
+++ b/compose/tests/test_local_observability_ladder.py
@@ -211,7 +211,9 @@ def test_local_ladder_owns_a_real_queryable_otlp_sink() -> None:
     # The sink has to exist before `local up`, because service startup telemetry
     # and the ingress root are part of the proof. The query belongs after the
     # real turn finalized, not beside static compose/config assertions.
-    assert rung.index("start_local_otel_sink") < rung.index("local up)")
+    local_up = 'local up -f "$REPO_ROOT/compose.dev.yaml" --build'
+    assert local_up in rung, "the local rung must build the current compose source"
+    assert rung.index("start_local_otel_sink") < rung.index(local_up)
     assert rung.index("assert_local_otel_healthy_turn") > rung.index(
         'assert_finalized_reply "local"'
     )
@@ -656,6 +658,89 @@ def test_ordinary_mcp_and_approval_seeds_have_independent_receipts() -> None:
         assert forbidden not in receipt.lower(), (
             "public evidence may expose only an aggregate MCP call count"
         )
+
+
+def test_approval_resume_failure_evidence_is_bounded_and_private_artifacts_are_cleaned(
+    tmp_path: Path,
+) -> None:
+    """A failed background approval turn reports only a safe terminal verdict."""
+
+    source = LADDER_PATH.read_text()
+    approval = _shell_function(source, "seed_approval_resume_turn")
+    summary = _shell_function(source, "approval_resume_failure_summary")
+
+    assert 'message_stderr_file="$(mktemp "$WORKDIR/approval-message-stderr.XXXXXX")"' in approval
+    assert '2> "$message_stderr_file" &' in approval
+    assert (
+        'approval_resume_failure_summary "$message_file" "$message_stderr_file" "$code" >&2'
+        in approval
+    )
+    for cleanup in (
+        'rm -f "$message_file" "$message_stderr_file" "$token_file" "$pending_file"',
+        'rm -f "$message_file" "$message_stderr_file" "$pending_file"',
+        'rm -f "$message_file" "$message_stderr_file"',
+    ):
+        assert cleanup in approval, (
+            "every post-allocation approval failure path must remove the private "
+            "stdout and stderr artifacts"
+        )
+
+    private_stdout = tmp_path / "approval-message"
+    private_stderr = tmp_path / "approval-message-stderr"
+    private_stdout.write_text(
+        json.dumps(
+            {
+                "awaiting_approval": True,
+                "finalized": False,
+                "reply": "PRIVATE_REPLY_SENTINEL",
+                "error": "PRIVATE_TOKEN_SENTINEL",
+            }
+        )
+    )
+    private_stderr.write_text("timed out PRIVATE_STDERR_SENTINEL")
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            summary + '\napproval_resume_failure_summary "$1" "$2" 23\n',
+            "bash",
+            str(private_stdout),
+            str(private_stderr),
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "exit_code=23" in result.stdout
+    assert "status=awaiting_approval" in result.stdout
+    assert "finalized=false" in result.stdout
+    assert "error_category=error_field" in result.stdout
+    assert "stderr_category=timed_out" in result.stdout
+    assert "PRIVATE_REPLY_SENTINEL" not in result.stdout + result.stderr
+    assert "PRIVATE_TOKEN_SENTINEL" not in result.stdout + result.stderr
+    assert "PRIVATE_STDERR_SENTINEL" not in result.stdout + result.stderr
+
+    private_stdout.write_text("PRIVATE_PARSE_SENTINEL")
+    private_stderr.write_text("could not parse PRIVATE_PARSE_STDERR_SENTINEL")
+    parse_result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            summary + '\napproval_resume_failure_summary "$1" "$2" 24\n',
+            "bash",
+            str(private_stdout),
+            str(private_stderr),
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert parse_result.returncode == 0, parse_result.stderr
+    assert "status=parse_failure" in parse_result.stdout
+    assert "stderr_category=parse_failure" in parse_result.stdout
+    assert "PRIVATE_PARSE_SENTINEL" not in parse_result.stdout + parse_result.stderr
+    assert "PRIVATE_PARSE_STDERR_SENTINEL" not in parse_result.stdout + parse_result.stderr
 
 
 def test_product_collector_restore_restarts_and_verifies_every_seed_emitter() -> None:

--- a/compose/tests/test_local_observability_ladder.py
+++ b/compose/tests/test_local_observability_ladder.py
@@ -8,6 +8,11 @@ exported signal files, and run both healthy and injected-failure controls.
 
 from __future__ import annotations
 
+import json
+import os
+import re
+import subprocess
+import sys
 from pathlib import Path
 
 import yaml
@@ -34,6 +39,65 @@ def _shell_function(source: str, name: str) -> str:
     start = source.index(start_marker)
     end = source.index("\n}\n", start) + len("\n}\n")
     return source[start:end]
+
+
+def _python_heredoc(function: str) -> str:
+    """Extract the sole quoted Python heredoc from a shell function."""
+
+    start = function.index("<<'PY'\n") + len("<<'PY'\n")
+    end = function.index("\nPY\n", start)
+    return function[start:end]
+
+
+def _run_seed_matcher(
+    tmp_path: Path, matcher: str, marker: str, rows: list[object]
+) -> subprocess.CompletedProcess[str]:
+    private_slice = tmp_path / "bounded-stream.json"
+    private_slice.write_text(json.dumps(rows))
+    return subprocess.run(
+        [sys.executable, "-", str(private_slice), marker],
+        input=matcher,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _run_absent_trace_query(
+    tmp_path: Path, query: str, *, error: str
+) -> tuple[subprocess.CompletedProcess[str], int]:
+    """Run the real shell helper against a deterministic failing candidate CLI."""
+
+    count = tmp_path / "query-count"
+    fake_bin = tmp_path / "curie"
+    fake_bin.write_text(
+        "#!/bin/sh\n"
+        'count="$(cat "$FAKE_COUNT" 2>/dev/null || printf 0)"\n'
+        'count=$((count + 1))\n'
+        'printf "%s" "$count" > "$FAKE_COUNT"\n'
+        'printf \'{"error":"%s","fix":"retry exact id"}\\n\' "$FAKE_ERROR"\n'
+        "exit 1\n"
+    )
+    fake_bin.chmod(0o700)
+    script = f"""set -u
+sanitize_exact_trace_read() {{ return 1; }}
+{query}
+WORKDIR="$1"
+BIN="$2"
+OBSERVABILITY_POLL_ATTEMPTS=3
+OBSERVABILITY_POLL_INTERVAL_SECONDS=0
+CURIE_NAMESPACE=acme-observability
+CURIE_RELEASE=acme-observability
+query_exact_seed_trace local aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa "" "" absent
+"""
+    result = subprocess.run(
+        ["bash", "-c", script, "bash", str(tmp_path), str(fake_bin)],
+        env={**os.environ, "FAKE_COUNT": str(count), "FAKE_ERROR": error},
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    return result, int(count.read_text()) if count.exists() else 0
 
 
 def test_local_ladder_owns_a_real_queryable_otlp_sink() -> None:
@@ -256,14 +320,36 @@ def test_local_otel_controls_distinguish_a_live_sink_from_a_turn() -> None:
     )
 
 
-def test_product_oracle_discovers_only_the_seed_trace_from_bounded_transport() -> None:
+def test_product_oracle_discovers_only_the_seed_trace_from_bounded_transport(
+    tmp_path: Path,
+) -> None:
     """A background/newest trace must be unable to satisfy the turn oracle."""
 
     source = LADDER_PATH.read_text()
-    assert "local observability runs --limit 100" not in source, (
-        "a newest-runs page can select an unrelated background trace; exact discovery "
-        "must start from the seeded stream entry"
+    # The unavailable-API negative may still exercise the public runs verb, but
+    # no helper may select a turn from that list or dump a selected row. Inspect
+    # whole function bodies so `--limit "$limit"` cannot evade this contract.
+    functions = {
+        match.group(1): _shell_function(source, match.group(1))
+        for match in re.finditer(r"(?m)^([A-Za-z0-9_]+)\(\) \{$", source)
+    }
+    forbidden_selectors = {
+        name: body
+        for name, body in functions.items()
+        if "local observability runs" in body
+        and name != "prove_local_observability_queries"
+    }
+    assert not forbidden_selectors, (
+        "a newest-runs selector/raw-dump helper can choose an unrelated background "
+        f"trace regardless of limit interpolation: {sorted(forbidden_selectors)}"
     )
+    for removed_helper in (
+        "discover_local_observability_trace",
+        "assert_local_observability_detail",
+    ):
+        assert removed_helper not in functions, (
+            f"obsolete raw selector/detail helper remains: {removed_helper}"
+        )
 
     discover = _shell_function(source, "discover_trace_id_for_seed")
     for required in (
@@ -281,6 +367,60 @@ def test_product_oracle_discovers_only_the_seed_trace_from_bounded_transport() -
         )
     assert "printf '%s\\n' \"$payload\"" not in discover
     assert "printf '%s\\n' \"$traceparent\"" not in discover
+
+    matcher = _python_heredoc(discover)
+    marker = "curie-seed-ordinary-example"
+    target_trace = "a" * 32
+    background_trace = "b" * 32
+    background = [
+        "1-0",
+        [
+            "payload",
+            json.dumps({"text": "ordinary correlation another-seed"}),
+            "traceparent",
+            f"00-{background_trace}-{'1' * 16}-01",
+        ],
+    ]
+    target = [
+        "2-0",
+        [
+            "payload",
+            json.dumps({"text": f"ordinary correlation {marker}"}),
+            "traceparent",
+            f"00-{target_trace}-{'2' * 16}-01",
+        ],
+    ]
+    matched = _run_seed_matcher(tmp_path, matcher, marker, [background, target])
+    assert matched.returncode == 0, matched.stderr
+    assert matched.stdout.strip() == target_trace, (
+        "the real matcher must recover the carrier adjacent to a marker embedded "
+        "in representative QueuedTurn.text, never the background carrier"
+    )
+
+    mismatch = _run_seed_matcher(tmp_path, matcher, marker, [background])
+    assert mismatch.returncode != 0, (
+        "a background entry without the marker must not satisfy exact discovery"
+    )
+    duplicate = _run_seed_matcher(
+        tmp_path,
+        matcher,
+        marker,
+        [
+            target,
+            [
+                "3-0",
+                [
+                    "payload",
+                    json.dumps({"text": f"ordinary correlation {marker}"}),
+                    "traceparent",
+                    f"00-{'c' * 32}-{'3' * 16}-01",
+                ],
+            ],
+        ],
+    )
+    assert duplicate.returncode != 0, (
+        "more than one matching adjacent carrier must fail closed"
+    )
 
     query = _shell_function(source, "query_exact_seed_trace")
     assert 'observability run "$trace_id"' in query
@@ -302,6 +442,81 @@ def test_product_oracle_discovers_only_the_seed_trace_from_bounded_transport() -
     for private in ("input", "output", "session", "user", "headers"):
         assert private in sanitizer, (
             f"sanitizer must explicitly prevent raw {private!r} from reaching stdout"
+        )
+    assert "if private_fields.intersection(node):\n        pass" not in sanitizer, (
+        "private-field handling must reject or remove data, not be a no-op"
+    )
+
+
+def test_product_evidence_sanitizer_and_failure_paths_never_dump_private_json(
+    tmp_path: Path,
+) -> None:
+    """Raw replies and private Langfuse fields stay in task-owned artifacts."""
+
+    source = LADDER_PATH.read_text()
+    sanitizer = _shell_function(source, "sanitize_exact_trace_read")
+    sanitizer_python = _python_heredoc(sanitizer)
+    trace_id = "d" * 32
+    private_sentinels = {
+        "input": "PRIVATE_PROMPT_SENTINEL",
+        "output": "PRIVATE_REPLY_SENTINEL",
+        "session": "PRIVATE_SESSION_SENTINEL",
+        "user": "PRIVATE_USER_SENTINEL",
+        "headers": {"authorization": "PRIVATE_HEADER_SENTINEL"},
+    }
+    raw = tmp_path / "raw-trace.json"
+    raw.write_text(
+        json.dumps(
+            {
+                "trace": {"id": trace_id},
+                "tree": [
+                    {
+                        "name": "curie.queue.enqueue",
+                        "type": "SPAN",
+                        "children": [],
+                        **private_sentinels,
+                    }
+                ],
+                "approval_decision": None,
+            }
+        )
+    )
+    result = subprocess.run(
+        [sys.executable, "-", trace_id, str(raw), "curie.queue.enqueue", ""],
+        input=sanitizer_python,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    evidence = json.loads(result.stdout)
+    assert set(evidence) == {
+        "trace_id",
+        "service",
+        "operation",
+        "observation_count",
+        "observation_type",
+        "approval_decision",
+    }
+    combined_output = result.stdout + result.stderr
+    for private_value in (
+        "PRIVATE_PROMPT_SENTINEL",
+        "PRIVATE_REPLY_SENTINEL",
+        "PRIVATE_SESSION_SENTINEL",
+        "PRIVATE_USER_SENTINEL",
+        "PRIVATE_HEADER_SENTINEL",
+    ):
+        assert private_value not in combined_output
+
+    finalized = _shell_function(source, "assert_finalized_reply")
+    for raw_dump in (
+        'printf \'%s\\n\' "$payload"',
+        'printf "%s\\n" "$payload"',
+        'echo "$payload"',
+    ):
+        assert raw_dump not in finalized, (
+            "message parse/finalization failures must report a bounded verdict, "
+            "not the private message JSON"
         )
 
 
@@ -325,6 +540,14 @@ def test_ordinary_mcp_and_approval_seeds_have_independent_receipts() -> None:
         assert not missing, f"{name} lacks independent outcome evidence: {missing}"
         assert "discover_trace_id_for_seed" in body
         assert "query_exact_seed_trace" in body
+
+    approval = _shell_function(source, "seed_approval_resume_turn")
+    assert "curie.approval.suspend" in approval, (
+        "the approval oracle must require the worker's real parked-turn span"
+    )
+    assert "curie.approval.wait" not in approval, (
+        "the oracle must not invent a wait span that no current emitter produces"
+    )
 
     assert "seed-invalid" in source
     assert MCP_RECEIPT_FIXTURE.is_dir(), (
@@ -368,11 +591,14 @@ def test_product_collector_restore_restarts_and_verifies_every_seed_emitter() ->
         assert protocol in restore
 
 
-def test_invalid_langfuse_auth_is_temporary_durable_and_recovers_the_same_id() -> None:
+def test_invalid_langfuse_auth_is_temporary_durable_and_recovers_the_same_id(
+    tmp_path: Path,
+) -> None:
     """Pin the real backend negative without redefining exporter semantics."""
 
     source = LADDER_PATH.read_text()
     negative = _shell_function(source, "case_local_langfuse_invalid_auth")
+    query = _shell_function(source, "query_exact_seed_trace")
 
     # Observed shipped behavior, not an assumed external-API contract:
     # otel/collector-config.yaml enables retry_on_failure at 5s/30s/5m and a
@@ -404,6 +630,66 @@ def test_invalid_langfuse_auth_is_temporary_durable_and_recovers_the_same_id() -
         "after the queue-preserving restart"
     )
 
+    invalid_auth = negative.index(
+        'export LANGFUSE_OTLP_AUTH_HEADER="$INVALID_LANGFUSE_OTLP_AUTH_HEADER"'
+    )
+    control = negative.find('query_exact_seed_trace local "$LAST_ORDINARY_TRACE_ID"')
+    assert 0 <= control < invalid_auth, (
+        "a successful exact read under valid auth must discriminate backend/query "
+        "health before the credential is made invalid"
+    )
+
+    # Restart once while auth is still invalid, then re-observe both queued
+    # failure and stable absence. Restoring auth is a later, separate restart.
+    before_restore = negative[: negative.index("restore_local_langfuse_auth")]
+    restart_positions = [
+        match.start()
+        for match in re.finditer("restart_local_product_collector", before_restore)
+    ]
+    assert len(restart_positions) >= 2, (
+        "the file-backed queue must survive a Collector restart while auth remains invalid"
+    )
+    after_invalid_restart = before_restore[restart_positions[1] :]
+    assert "otelcol_exporter_queue_size" in after_invalid_restart
+    assert "otelcol_exporter_send_failed_spans" in after_invalid_restart
+    assert "query_exact_seed_trace" in after_invalid_restart
+
+    # Execute the production query helper: absence is a bounded observation,
+    # not one lucky first poll, and only the stable not-found error is accepted.
+    stable_absence_dir = tmp_path / "stable-absence"
+    stable_absence_dir.mkdir()
+    absent, polls = _run_absent_trace_query(
+        stable_absence_dir, query, error="exact trace not found"
+    )
+    assert absent.returncode == 0, absent.stderr
+    assert polls == 3, (
+        "temporary absence must remain not-found for the full declared poll bound"
+    )
+
+    wrong_failure_dir = tmp_path / "wrong-failure"
+    wrong_failure_dir.mkdir()
+    wrong_failure, _ = _run_absent_trace_query(
+        wrong_failure_dir, query, error="Langfuse authorization failed"
+    )
+    assert wrong_failure.returncode != 0, (
+        "an arbitrary candidate-CLI exit 1 must not masquerade as stable not-found"
+    )
+
+    absent_call = re.search(
+        r'query_exact_seed_trace local "\$same_queued_trace_id"[^\n]*absent',
+        negative,
+    )
+    recovered_call = re.search(
+        r'query_exact_seed_trace local "\$same_queued_trace_id"\s*$',
+        negative,
+        re.MULTILINE,
+    )
+    assert (
+        absent_call
+        and recovered_call
+        and absent_call.start() < recovered_call.start()
+    ), "the same ID must be absent during failure and present after recovery"
+
 
 def test_cluster_product_observability_is_private_preflight_and_query_only() -> None:
     """The ladder may inspect a task release but must never install or remove it."""
@@ -430,10 +716,14 @@ def test_cluster_product_observability_is_private_preflight_and_query_only() -> 
         assert required in preflight, f"cluster preflight omits {required!r}"
 
     mode = _shell_function(source, "run_cluster_product_observability")
+    wrapper = _shell_function(source, "rung_cluster_product")
     assert "preflight_cluster_product_observability" in mode
     assert "seed_ordinary_turn" in mode
     assert "seed_approval_resume_turn" in mode
     assert "cluster observability run" in mode
+    assert "cluster deploy" in wrapper, (
+        "the wrapper must retain the intended agent seed deployment"
+    )
     for mutating in (
         "cluster up",
         "cluster down",
@@ -442,9 +732,22 @@ def test_cluster_product_observability_is_private_preflight_and_query_only() -> 
         "helm uninstall",
         "kubectl delete",
     ):
-        assert mutating not in mode, (
-            f"product-observability mode must be preflight/query-only, found {mutating!r}"
-        )
+        for helper_name, helper in (
+            ("preflight", preflight),
+            ("query", mode),
+            ("product wrapper", wrapper),
+        ):
+            assert mutating not in helper, (
+                "product-observability preflight/query/wrapper must not manage the "
+                f"release; found {mutating!r} in {helper_name}"
+            )
+    assert '-o json > "$inventory"' not in preflight, (
+        "preflight must query Ready/imageID fields directly, not persist full pod "
+        "JSON that may contain private environment values"
+    )
+    assert "cluster-product-pods" not in preflight, (
+        "full pod specifications must not be persisted even in a mode-0600 artifact"
+    )
 
 
 def test_adopted_component_stop_requires_successful_export_on_both_product_surfaces() -> None:

--- a/docs/architecture-atlas/snapshots/v0.8.5.json
+++ b/docs/architecture-atlas/snapshots/v0.8.5.json
@@ -1,0 +1,3636 @@
+{
+  "schemaVersion": "1.4",
+  "asOf": "2026-09-03",
+  "repository": {
+    "name": "curie-eng/curie",
+    "branch": "main",
+    "commit": "69cbe26af299e01d16b2e667e627a0b672238662",
+    "shortCommit": "69cbe26a",
+    "release": "v0.8.5"
+  },
+  "title": "Curie architecture atlas",
+  "subtitle": "The production loop, its swappable seams, and the distance between current state and vision.",
+  "architectureGroups": [
+    {
+      "id": "channel-surface",
+      "label": "Channel surface",
+      "subtitle": "3 current \u00b7 1 planned",
+      "kind": "surface",
+      "state": "implemented",
+      "zone": "surfaces",
+      "x": 0.075,
+      "y": 0.25,
+      "description": "One stable channel role in the architecture. Slack, Discord, and email are shipped implementations of this role; Teams remains planned. Concrete surfaces stay inside this expandable node.",
+      "memberIds": [
+        "slack",
+        "discord",
+        "email",
+        "teams"
+      ]
+    },
+    {
+      "id": "sandbox-substrate",
+      "label": "Sandbox substrate",
+      "mapLabel": "Substrate",
+      "subtitle": "2 proven implementations",
+      "kind": "substrate",
+      "state": "implemented",
+      "zone": "foundation",
+      "x": 0.92,
+      "y": 0.765,
+      "description": "The stable substrate role beneath sandbox lifecycle. Kubernetes and Docker prove that the same boundary has multiple implementations.",
+      "memberIds": [
+        "kubernetes",
+        "docker"
+      ]
+    }
+  ],
+  "overview": {
+    "title": "The request-to-reply loop",
+    "description": "Read left to right. Every colored connector is a seam: green is proven, yellow is clean but unproven, red is intertwined, and blue is planned.",
+    "stages": [
+      {
+        "id": "surfaces",
+        "eyebrow": "1 \u00b7 Enter",
+        "label": "External surfaces",
+        "description": "A person, repository, or operator starts work.",
+        "nodeIds": [
+          "slack",
+          "discord",
+          "email",
+          "cli",
+          "github",
+          "external-hook"
+        ]
+      },
+      {
+        "id": "ingress",
+        "eyebrow": "2 \u00b7 Normalize",
+        "label": "Ingress + API",
+        "description": "Authenticate, bind the agent, and turn the event into work.",
+        "nodeIds": [
+          "dispatcher",
+          "channel-api",
+          "api"
+        ]
+      },
+      {
+        "id": "dispatch",
+        "eyebrow": "3 \u00b7 Route",
+        "label": "Queue + worker",
+        "description": "Claim delivery, lock the conversation, and resolve the run.",
+        "nodeIds": [
+          "queue",
+          "worker"
+        ]
+      },
+      {
+        "id": "runtime",
+        "eyebrow": "4 \u00b7 Isolate",
+        "label": "Sandbox + runner",
+        "description": "Start or resume an isolated, steerable ACI session.",
+        "nodeIds": [
+          "sandbox",
+          "runner"
+        ]
+      },
+      {
+        "id": "execution",
+        "eyebrow": "5 \u00b7 Execute",
+        "label": "Harness + MCP + model",
+        "description": "Run the multi-turn model loop, call hosted MCP tools, and produce side effects.",
+        "nodeIds": [
+          "harness",
+          "model",
+          "connector-host",
+          "oauth-gateway"
+        ]
+      }
+    ],
+    "connections": [
+      {
+        "from": "surfaces",
+        "to": "ingress",
+        "label": "channel ingress",
+        "seamId": "channel-ingress"
+      },
+      {
+        "from": "ingress",
+        "to": "dispatch",
+        "label": "durable work",
+        "seamId": "queue-stream"
+      },
+      {
+        "from": "dispatch",
+        "to": "runtime",
+        "label": "sandbox claim",
+        "seamId": "substrate"
+      },
+      {
+        "from": "runtime",
+        "to": "execution",
+        "label": "model session",
+        "seamId": "harness-modelsession"
+      }
+    ],
+    "return": {
+      "label": "stream result, request approval when needed, then reply to the originating surface",
+      "seamId": "channel-reply"
+    },
+    "rails": [
+      {
+        "id": "approval-loop",
+        "label": "Approval loop",
+        "description": "Pause, authorize, and resume a live turn.",
+        "nodeIds": [
+          "approvals"
+        ],
+        "seamIds": [
+          "approval-authorizer",
+          "approval-principal"
+        ]
+      },
+      {
+        "id": "evidence-plane",
+        "label": "Evidence plane",
+        "description": "Traces, telemetry, eval cases, scores, and results surround every run.",
+        "nodeIds": [
+          "otel",
+          "langfuse",
+          "eval-plane"
+        ],
+        "seamIds": [
+          "telemetry",
+          "eval-scorer"
+        ]
+      },
+      {
+        "id": "substrate",
+        "label": "Substrate",
+        "description": "Kubernetes is the production baseline; Docker proves the same sandbox boundary locally.",
+        "nodeIds": [
+          "kubernetes",
+          "docker"
+        ],
+        "seamIds": [
+          "substrate"
+        ]
+      }
+    ]
+  },
+  "maturityRubric": [
+    {
+      "id": "green",
+      "label": "Proven",
+      "symbol": "\u2713",
+      "definition": "Multiple real implementations have exercised the same boundary."
+    },
+    {
+      "id": "yellow",
+      "label": "Clean, unproven",
+      "symbol": "\u25c7",
+      "definition": "One real implementation sits behind a credible boundary, but a second implementation has not tested the shape."
+    },
+    {
+      "id": "red",
+      "label": "Intertwined",
+      "symbol": "\u00d7",
+      "definition": "A swap still requires coordinated knowledge or changes across implementation owners."
+    },
+    {
+      "id": "planned",
+      "label": "Planned / reserved",
+      "symbol": "\u25cb",
+      "definition": "The intended line is documented, but there is not a real implementation to score."
+    }
+  ],
+  "sources": [
+    {
+      "id": "architecture",
+      "type": "architecture",
+      "title": "Architecture as built",
+      "path": "ARCHITECTURE.md",
+      "href": "https://github.com/curie-eng/curie/blob/69cbe26af299e01d16b2e667e627a0b672238662/ARCHITECTURE.md"
+    },
+    {
+      "id": "vision",
+      "type": "vision",
+      "title": "Product vision",
+      "path": "docs/vision.md",
+      "href": "https://github.com/curie-eng/curie/blob/687322e4be896e2ef1fe63770eac1ed040ccaa5c/docs/vision.md"
+    },
+    {
+      "id": "architecture-vision",
+      "type": "architecture",
+      "title": "Swappable jobs around an opinionated core",
+      "path": "docs/architecture-vision.md",
+      "href": "https://github.com/curie-eng/curie/blob/687322e4be896e2ef1fe63770eac1ed040ccaa5c/docs/architecture-vision.md"
+    },
+    {
+      "id": "interfaces",
+      "type": "catalog",
+      "title": "Interface catalog",
+      "path": "docs/interfaces.md",
+      "href": "https://github.com/curie-eng/curie/blob/617df5bef46864f9abd7d01ac630ac672100afdd/docs/interfaces.md"
+    },
+    {
+      "id": "message-flow",
+      "type": "diagram",
+      "title": "Message flow",
+      "path": "docs/diagrams/message-flow.md",
+      "href": "https://github.com/curie-eng/curie/blob/687322e4be896e2ef1fe63770eac1ed040ccaa5c/docs/diagrams/message-flow.md"
+    },
+    {
+      "id": "kubernetes",
+      "type": "diagram",
+      "title": "Kubernetes architecture",
+      "path": "docs/diagrams/kubernetes.md",
+      "href": "https://github.com/curie-eng/curie/blob/5185e6bf5c153271ec9eb37fd84334c59b3f4a5f/docs/diagrams/kubernetes.md"
+    },
+    {
+      "id": "aci-diagram",
+      "type": "diagram",
+      "title": "Agent Container Interface",
+      "path": "docs/diagrams/aci.md",
+      "href": "https://github.com/curie-eng/curie/blob/5185e6bf5c153271ec9eb37fd84334c59b3f4a5f/docs/diagrams/aci.md"
+    },
+    {
+      "id": "channel-api-code",
+      "type": "code",
+      "title": "Generic channel HTTP ingress",
+      "path": "apps/api/src/curie_api/routers/channels.py",
+      "href": "https://github.com/curie-eng/curie/blob/687322e4be896e2ef1fe63770eac1ed040ccaa5c/apps/api/src/curie_api/routers/channels.py"
+    },
+    {
+      "id": "reply-sink-code",
+      "type": "code",
+      "title": "Neutral reply sink and router",
+      "path": "apps/worker/src/curie_worker/reply_sink.py",
+      "href": "https://github.com/curie-eng/curie/blob/687322e4be896e2ef1fe63770eac1ed040ccaa5c/apps/worker/src/curie_worker/reply_sink.py"
+    },
+    {
+      "id": "binding-code",
+      "type": "code",
+      "title": "Kind/address deployment binding",
+      "path": "apps/worker/src/curie_worker/binding.py",
+      "href": "https://github.com/curie-eng/curie/blob/687322e4be896e2ef1fe63770eac1ed040ccaa5c/apps/worker/src/curie_worker/binding.py"
+    },
+    {
+      "id": "runner-adapter-code",
+      "type": "code",
+      "title": "Claude-shaped ModelSession boundary",
+      "path": "runner/src/curie_runner/adapter.py",
+      "href": "https://github.com/curie-eng/curie/blob/617df5bef46864f9abd7d01ac630ac672100afdd/runner/src/curie_runner/adapter.py"
+    },
+    {
+      "id": "runner-telemetry-code",
+      "type": "code",
+      "title": "Runner phase telemetry",
+      "path": "runner/src/curie_runner/otel.py",
+      "href": "https://github.com/curie-eng/curie/blob/617df5bef46864f9abd7d01ac630ac672100afdd/runner/src/curie_runner/otel.py"
+    },
+    {
+      "id": "approval-principal-code",
+      "type": "code",
+      "title": "Authenticated approval principals",
+      "path": "apps/api/src/curie_api/approval_principal.py",
+      "href": "https://github.com/curie-eng/curie/blob/617df5bef46864f9abd7d01ac630ac672100afdd/apps/api/src/curie_api/approval_principal.py"
+    },
+    {
+      "id": "approval-auth-code",
+      "type": "code",
+      "title": "Approval resolution authentication",
+      "path": "apps/api/src/curie_api/approval_auth.py",
+      "href": "https://github.com/curie-eng/curie/blob/617df5bef46864f9abd7d01ac630ac672100afdd/apps/api/src/curie_api/approval_auth.py"
+    },
+    {
+      "id": "cli-doctor-code",
+      "type": "code",
+      "title": "Doctor API discovery",
+      "path": "cli/src/doctor.rs",
+      "href": "https://github.com/curie-eng/curie/blob/617df5bef46864f9abd7d01ac630ac672100afdd/cli/src/doctor.rs"
+    },
+    {
+      "id": "mail-adapter-code",
+      "type": "code",
+      "title": "First-party email adapter",
+      "path": "apps/mail-adapter/src/curie_mail_adapter/adapter.py",
+      "href": "https://github.com/curie-eng/curie/blob/687322e4be896e2ef1fe63770eac1ed040ccaa5c/apps/mail-adapter/src/curie_mail_adapter/adapter.py"
+    },
+    {
+      "id": "discord-adapter-code",
+      "type": "code",
+      "title": "Discord channel adapter",
+      "path": "adapters/discord/src/curie_discord_adapter/main.py",
+      "href": "https://github.com/curie-eng/curie/blob/687322e4be896e2ef1fe63770eac1ed040ccaa5c/adapters/discord/src/curie_discord_adapter/main.py"
+    },
+    {
+      "id": "hook-code",
+      "type": "code",
+      "title": "Bounded external-hook ingress",
+      "path": "apps/api/src/curie_api/routers/hooks.py",
+      "href": "https://github.com/curie-eng/curie/blob/5185e6bf5c153271ec9eb37fd84334c59b3f4a5f/apps/api/src/curie_api/routers/hooks.py"
+    },
+    {
+      "id": "dispatcher-preflight-code",
+      "type": "code",
+      "title": "Dispatcher startup preflight",
+      "path": "apps/dispatcher/src/curie_dispatcher/preflight.py",
+      "href": "https://github.com/curie-eng/curie/blob/5185e6bf5c153271ec9eb37fd84334c59b3f4a5f/apps/dispatcher/src/curie_dispatcher/preflight.py"
+    },
+    {
+      "id": "approval-actions-code",
+      "type": "code",
+      "title": "Slack approval action ownership",
+      "path": "apps/dispatcher/src/curie_dispatcher/approval_actions.py",
+      "href": "https://github.com/curie-eng/curie/blob/69cbe26af299e01d16b2e667e627a0b672238662/apps/dispatcher/src/curie_dispatcher/approval_actions.py"
+    },
+    {
+      "id": "worker-runner-client-code",
+      "type": "code",
+      "title": "Delivery-bounded runner client",
+      "path": "apps/worker/src/curie_worker/runner_client.py",
+      "href": "https://github.com/curie-eng/curie/blob/5185e6bf5c153271ec9eb37fd84334c59b3f4a5f/apps/worker/src/curie_worker/runner_client.py"
+    },
+    {
+      "id": "chart-values",
+      "type": "code",
+      "title": "Helm runtime values",
+      "path": "charts/curie/values.yaml",
+      "href": "https://github.com/curie-eng/curie/blob/69cbe26af299e01d16b2e667e627a0b672238662/charts/curie/values.yaml"
+    },
+    {
+      "id": "chart-secret-template",
+      "type": "code",
+      "title": "Managed and external Secret rendering",
+      "path": "charts/curie/templates/secrets.yaml",
+      "href": "https://github.com/curie-eng/curie/blob/5185e6bf5c153271ec9eb37fd84334c59b3f4a5f/charts/curie/templates/secrets.yaml"
+    }
+  ],
+  "documentationDrift": [
+    {
+      "id": "drift-channel-catalog-count",
+      "title": "The generated channel catalog still counts one implementation",
+      "claim": "docs/interfaces.md and the Communication grade row still describe Slack plus HttpReplyAdapter as the proof, not a second first-party production channel, and the generated Channel/ingress header still says impls: 1.",
+      "current": "ARCHITECTURE.md, adapters/discord, and apps/mail-adapter ship Slack, Discord, and email as wired channels on the same HTTP ingress and HttpReplyAdapter egress. Discord v1 and email do not implement interactive approvals.",
+      "evidence": [
+        "architecture",
+        "architecture-vision",
+        "interfaces",
+        "discord-adapter-code",
+        "mail-adapter-code"
+      ]
+    }
+  ],
+  "zones": [
+    {
+      "id": "surfaces",
+      "label": "External surfaces",
+      "x": 0.01,
+      "y": 0.04,
+      "w": 0.14,
+      "h": 0.91
+    },
+    {
+      "id": "control",
+      "label": "Control & ingress",
+      "x": 0.17,
+      "y": 0.04,
+      "w": 0.22,
+      "h": 0.91
+    },
+    {
+      "id": "core",
+      "label": "Opinionated core",
+      "x": 0.41,
+      "y": 0.04,
+      "w": 0.21,
+      "h": 0.91
+    },
+    {
+      "id": "runtime",
+      "label": "Isolated runtime",
+      "x": 0.64,
+      "y": 0.04,
+      "w": 0.35,
+      "h": 0.55
+    },
+    {
+      "id": "foundation",
+      "label": "Data \u00b7 evidence \u00b7 substrate",
+      "x": 0.64,
+      "y": 0.62,
+      "w": 0.35,
+      "h": 0.33
+    }
+  ],
+  "nodes": [
+    {
+      "id": "slack",
+      "label": "Slack",
+      "subtitle": "Surface today",
+      "kind": "surface",
+      "state": "implemented",
+      "zone": "surfaces",
+      "x": 0.075,
+      "y": 0.18,
+      "description": "The original production channel. Bolt Socket Mode handles ingress; Slack Web API renders replies, progress cards, and approval cards. It is no longer the only registered production kind.",
+      "technology": [
+        "Slack Bolt",
+        "Socket Mode",
+        "Block Kit"
+      ],
+      "evidence": [
+        "architecture",
+        "message-flow"
+      ],
+      "adrIds": [
+        "ADR-0010",
+        "ADR-0020",
+        "ADR-0096",
+        "ADR-0118",
+        "ADR-0130"
+      ]
+    },
+    {
+      "id": "discord",
+      "label": "Discord",
+      "subtitle": "Shipped surface",
+      "kind": "surface",
+      "state": "implemented",
+      "zone": "surfaces",
+      "x": 0.075,
+      "y": 0.26,
+      "description": "Out-of-process Gateway adapter. Mentions in a bound parent channel create a public thread and placeholder; later thread messages continue the same conversation. v1 supports text, mentions, threads, and streamed edits. It does not implement buttons, DMs, attachments, or interactive approvals, and a Discord failure never falls back to Slack.",
+      "technology": [
+        "Discord Gateway",
+        "Discord REST",
+        "SQLite"
+      ],
+      "evidence": [
+        "discord-adapter-code",
+        "channel-api-code",
+        "architecture"
+      ],
+      "adrIds": [
+        "ADR-0020",
+        "ADR-0096",
+        "ADR-0118"
+      ]
+    },
+    {
+      "id": "email",
+      "label": "Email",
+      "subtitle": "Shipped surface",
+      "kind": "surface",
+      "state": "implemented",
+      "zone": "surfaces",
+      "x": 0.075,
+      "y": 0.34,
+      "description": "First-party AgentMail adapter. It polls an inbox, posts to POST /channels/turns under a scoped channel token, and sends one threaded reply per turn.completed. Delivery state is local SQLite with one serialized writer. Provider, channel, and egress credentials may come from per-field existing Secrets without chart ownership of their values. It does not implement interactive approvals.",
+      "technology": [
+        "AgentMail",
+        "SQLite",
+        "HTTP channel wire"
+      ],
+      "evidence": [
+        "mail-adapter-code",
+        "channel-api-code",
+        "architecture",
+        "chart-secret-template"
+      ],
+      "adrIds": [
+        "ADR-0020",
+        "ADR-0096",
+        "ADR-0120",
+        "ADR-0118"
+      ]
+    },
+    {
+      "id": "teams",
+      "label": "Teams",
+      "subtitle": "Future surface",
+      "kind": "surface",
+      "state": "planned",
+      "zone": "surfaces",
+      "x": 0.075,
+      "y": 0.47,
+      "description": "Named in the vision, but deliberately deferred until a real second channel teaches the adapter interface.",
+      "technology": [
+        "Future adapter"
+      ],
+      "evidence": [
+        "vision",
+        "architecture-vision"
+      ],
+      "adrIds": [
+        "ADR-0016",
+        "ADR-0020"
+      ]
+    },
+    {
+      "id": "cli",
+      "label": "Curie CLI",
+      "subtitle": "Agent-facing control",
+      "kind": "surface",
+      "state": "implemented",
+      "zone": "surfaces",
+      "x": 0.075,
+      "y": 0.61,
+      "description": "Drives skill, local, and cluster loops. The local/cluster message verbs can replace Slack ingress and reply transport without changing the worker path. A bare curie doctor discovers the platform API from cluster state, cluster up --dev preserves recorded comms and sealing values, and release builds embed the exact source commit used to resolve installer artifacts.",
+      "technology": [
+        "Rust",
+        "structured --json"
+      ],
+      "evidence": [
+        "architecture",
+        "interfaces",
+        "cli-doctor-code"
+      ],
+      "adrIds": [
+        "ADR-0021",
+        "ADR-0041",
+        "ADR-0074"
+      ]
+    },
+    {
+      "id": "github",
+      "label": "GitHub",
+      "subtitle": "Push / PR trigger",
+      "kind": "surface",
+      "state": "implemented",
+      "zone": "surfaces",
+      "x": 0.075,
+      "y": 0.76,
+      "description": "Webhook and outbound commit polling converge on the API git-flow engine. Dev pushes build and evaluate; production pushes promote. The platform can also clone a managed workspace and publish through an approval-gated path that does not leave write credentials inside the sandbox.",
+      "technology": [
+        "HMAC webhook",
+        "commit poller",
+        "commit status"
+      ],
+      "evidence": [
+        "architecture"
+      ],
+      "adrIds": [
+        "ADR-0014",
+        "ADR-0091",
+        "ADR-0092",
+        "ADR-0125",
+        "ADR-0126"
+      ]
+    },
+    {
+      "id": "external-hook",
+      "label": "External hook",
+      "subtitle": "HMAC-triggered turn",
+      "kind": "surface",
+      "state": "implemented",
+      "zone": "surfaces",
+      "x": 0.075,
+      "y": 0.53,
+      "description": "A named, HMAC-authenticated API hook creates a quota- and body-bounded webhook-sourced turn whose authenticated payload is escaped and delimited as untrusted prompt content. Bundle-declared hook lifecycle and schedules remain planned.",
+      "technology": [
+        "HTTP",
+        "HMAC",
+        "typed QueuedTurn"
+      ],
+      "evidence": [
+        "interfaces",
+        "architecture",
+        "hook-code"
+      ],
+      "adrIds": [
+        "ADR-0079"
+      ]
+    },
+    {
+      "id": "console",
+      "label": "Console UI",
+      "subtitle": "Operations surface",
+      "kind": "surface",
+      "state": "implemented",
+      "zone": "surfaces",
+      "x": 0.075,
+      "y": 0.89,
+      "description": "A real API-backed console for fleet, runs, metrics, cost, logs, versions, evals, approvals, and memory. Approval resolution uses the authenticated Console session subject rather than a caller-supplied actor. Usage and Settings remain honest stubs.",
+      "technology": [
+        "React",
+        "Vite",
+        "TypeScript"
+      ],
+      "evidence": [
+        "architecture"
+      ],
+      "adrIds": [
+        "ADR-0024",
+        "ADR-0083"
+      ]
+    },
+    {
+      "id": "dispatcher",
+      "label": "Dispatcher",
+      "subtitle": "Ingress \u00b7 dedupe \u00b7 placeholder",
+      "kind": "service",
+      "state": "implemented",
+      "zone": "control",
+      "x": 0.245,
+      "y": 0.2,
+      "description": "Before Socket Mode, a bounded startup preflight waits for API health and verifies configured Slack destination capabilities. The live dispatcher then normalizes Slack events and Block Kit text into QueuedTurn, records adapter-owned refusals, deduplicates ingress, posts the placeholder, and appends to the run stream. Approval clicks become independently signed, approval-bound chat principal attestations; an exact record miss is treated as another release owning that approval, never as authority to mutate it.",
+      "technology": [
+        "Python",
+        "Slack Bolt",
+        "Valkey"
+      ],
+      "evidence": [
+        "message-flow",
+        "architecture",
+        "dispatcher-preflight-code",
+        "approval-actions-code"
+      ],
+      "adrIds": [
+        "ADR-0012",
+        "ADR-0013"
+      ]
+    },
+    {
+      "id": "port-adapter",
+      "label": "Port adapter service",
+      "subtitle": "Third-party channel edge",
+      "kind": "service",
+      "state": "planned",
+      "zone": "surfaces",
+      "x": 0.105,
+      "y": 0.39,
+      "description": "The accepted placement for a generic third-party adapter kit: a deployed service, not a bundle-loaded plugin. Slack, Discord, and email already ship as first-party surfaces. The generic adapter manifest, install flow, service discovery, and conformance kit remain unbuilt.",
+      "technology": [
+        "Deployed service",
+        "future adapter kit"
+      ],
+      "evidence": [
+        "interfaces",
+        "architecture-vision"
+      ],
+      "adrIds": [
+        "ADR-0096"
+      ]
+    },
+    {
+      "id": "channel-api",
+      "label": "Channel HTTP edge",
+      "mapLabel": "Channel edge",
+      "subtitle": "Generic ingress + egress",
+      "kind": "service",
+      "state": "implemented",
+      "zone": "control",
+      "x": 0.285,
+      "y": 0.41,
+      "description": "The API mints row-scoped channel tokens and platform-owned QueuedTurn records. Discord and email already consume this HTTP edge. Worker-side HttpReplyAdapter posts the four versioned reply events to each binding's server-controlled endpoint.",
+      "technology": [
+        "POST /channels/turns",
+        "HttpReplyAdapter",
+        "scoped chn token"
+      ],
+      "evidence": [
+        "channel-api-code",
+        "reply-sink-code",
+        "binding-code",
+        "interfaces",
+        "architecture"
+      ],
+      "adrIds": [
+        "ADR-0096",
+        "ADR-0118"
+      ]
+    },
+    {
+      "id": "api",
+      "label": "API",
+      "subtitle": "Control plane \u00b7 git flow",
+      "kind": "service",
+      "state": "implemented",
+      "zone": "control",
+      "x": 0.275,
+      "y": 0.67,
+      "description": "Owns agents, versions, deployments, multi-surface channel bindings, approvals, state, connector rendering, managed repository workspaces, bundle validation, git-flow deploys, and read proxies. Approval resolution authenticates chat, Console, or operator principals; the platform key alone cannot resolve.",
+      "technology": [
+        "FastAPI",
+        "SQLAlchemy",
+        "Alembic"
+      ],
+      "evidence": [
+        "architecture",
+        "approval-principal-code",
+        "approval-auth-code"
+      ],
+      "adrIds": [
+        "ADR-0014",
+        "ADR-0033",
+        "ADR-0046",
+        "ADR-0118",
+        "ADR-0125",
+        "ADR-0126"
+      ]
+    },
+    {
+      "id": "queue",
+      "label": "Valkey streams",
+      "subtitle": "Runs \u00b7 evals \u00b7 delivery",
+      "kind": "broker",
+      "state": "implemented",
+      "zone": "core",
+      "x": 0.455,
+      "y": 0.31,
+      "description": "At-least-once streams carry run and eval jobs. Shared consumer machinery provides bounded delivery, a renewable fenced owner per delivery, and dead-letter handling.",
+      "technology": [
+        "Valkey",
+        "redis-py",
+        "consumer groups"
+      ],
+      "evidence": [
+        "architecture",
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0013",
+        "ADR-0027",
+        "ADR-0039",
+        "ADR-0131"
+      ]
+    },
+    {
+      "id": "worker",
+      "label": "Worker kernel",
+      "mapLabel": "Worker",
+      "subtitle": "Route \u00b7 claim \u00b7 steer \u00b7 recover",
+      "kind": "service",
+      "state": "implemented",
+      "zone": "core",
+      "x": 0.575,
+      "y": 0.31,
+      "description": "The concurrency hub: resolves the active deployment, emits a typed terminal failure instead of dropping turns when none exists, enforces one live session per conversation, selects steer versus fresh turn, protects side effects, and reclaims crashed delivery only after sustained renewable-lease absence with one recovery owner. Each runner request is capped by both the configured runner ceiling and the delivery's remaining deadline.",
+      "technology": [
+        "Python",
+        "Valkey",
+        "Postgres"
+      ],
+      "evidence": [
+        "architecture",
+        "message-flow",
+        "worker-runner-client-code"
+      ],
+      "adrIds": [
+        "ADR-0013",
+        "ADR-0039",
+        "ADR-0059",
+        "ADR-0130",
+        "ADR-0131"
+      ]
+    },
+    {
+      "id": "approvals",
+      "label": "Approval plane",
+      "subtitle": "Durable human gate",
+      "kind": "capability",
+      "state": "implemented",
+      "zone": "core",
+      "x": 0.485,
+      "y": 0.58,
+      "description": "A gate terminates the turn as AWAITING_APPROVAL, persists a durable record and its validated originating trace context, suspends the sandbox, and later resumes through a new queued resolution turn that continues that trace when available. Legacy or malformed carriers intentionally start a clean root. The resume reconciler's grace is derived from the delivery budget plus shutdown reserve. Resolution accepts only authenticated chat, Console, or operator principals and checks every principal, including the requester, against the captured approver set. When multiple releases share one Slack app, only the API owning the approval record may resolve it. Known read-only tools avoid approval and receipt side effects.",
+      "technology": [
+        "API record",
+        "authorizer sets",
+        "semantic confirm"
+      ],
+      "evidence": [
+        "architecture",
+        "message-flow",
+        "approval-principal-code",
+        "approval-auth-code",
+        "approval-actions-code",
+        "chart-values"
+      ],
+      "adrIds": [
+        "ADR-0010",
+        "ADR-0034",
+        "ADR-0035",
+        "ADR-0046",
+        "ADR-0106",
+        "ADR-0123"
+      ]
+    },
+    {
+      "id": "eval-plane",
+      "label": "Eval plane",
+      "subtitle": "Cases \u00b7 graders \u00b7 report",
+      "kind": "capability",
+      "state": "implemented",
+      "zone": "core",
+      "x": 0.57,
+      "y": 0.72,
+      "description": "The same bundle-carried eval suite runs across skill, local, local-release, and cluster. Worker scores and records cases, then reports a rollup to the API.",
+      "technology": [
+        "frozen case schema",
+        "text graders",
+        "trajectory matcher"
+      ],
+      "evidence": [
+        "architecture",
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0019",
+        "ADR-0022",
+        "ADR-0042",
+        "ADR-0055"
+      ]
+    },
+    {
+      "id": "sandbox",
+      "label": "Sandbox",
+      "subtitle": "One isolated session",
+      "kind": "runtime",
+      "state": "implemented",
+      "zone": "runtime",
+      "x": 0.69,
+      "y": 0.2,
+      "description": "An isolated runtime claimed per conversation. Kubernetes Agent Sandbox is production; Docker runs the same image locally. Session identity can arrive over the ACI so a warm pool sandbox may be pre-bound before the turn. Chart render fails closed if the retired in-path LiteLLM sidecar is re-enabled (ADR-0037).",
+      "technology": [
+        "Agent Sandbox",
+        "Docker",
+        "network policy"
+      ],
+      "evidence": [
+        "architecture",
+        "kubernetes"
+      ],
+      "adrIds": [
+        "ADR-0002",
+        "ADR-0028",
+        "ADR-0054",
+        "ADR-0059",
+        "ADR-0116"
+      ]
+    },
+    {
+      "id": "runner",
+      "label": "Runner / ACI server",
+      "mapLabel": "Runner",
+      "subtitle": "Multi-turn session loop",
+      "kind": "runtime",
+      "state": "implemented",
+      "zone": "runtime",
+      "x": 0.79,
+      "y": 0.2,
+      "description": "Serves event, steer, interrupt, and reset; translates harness events into the frozen NDJSON union; injects memory and history; and probes MCP capabilities conservatively. Telemetry records each observed provider-wait and tool-wait interval as root siblings with bounded phase, terminal, round, TTFT, and outcome attributes.",
+      "technology": [
+        "Python",
+        "FastAPI",
+        "frozen ACI"
+      ],
+      "evidence": [
+        "architecture",
+        "aci-diagram",
+        "runner-adapter-code",
+        "runner-telemetry-code"
+      ],
+      "adrIds": [
+        "ADR-0005",
+        "ADR-0017",
+        "ADR-0036",
+        "ADR-0049",
+        "ADR-0116",
+        "ADR-0117"
+      ]
+    },
+    {
+      "id": "harness",
+      "label": "Claude harness",
+      "mapLabel": "Harness",
+      "subtitle": "Declared package today",
+      "kind": "runtime",
+      "state": "implemented",
+      "zone": "runtime",
+      "x": 0.79,
+      "y": 0.4,
+      "description": "The only production harness contribution. ModelSession exists, but raw SDK messages and the Claude Code plugin format still cross the conceptual boundary.",
+      "technology": [
+        "claude-agent-sdk",
+        "Claude Code plugin format"
+      ],
+      "evidence": [
+        "architecture-vision",
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0005",
+        "ADR-0060",
+        "ADR-0061",
+        "ADR-0062"
+      ]
+    },
+    {
+      "id": "model",
+      "label": "Model endpoint",
+      "mapLabel": "Model",
+      "subtitle": "Provider-selected inference",
+      "kind": "external",
+      "state": "implemented",
+      "zone": "runtime",
+      "x": 0.93,
+      "y": 0.4,
+      "description": "Anthropic is the default; OpenRouter, Zhipu, Moonshot, DeepSeek, and opt-in Ollama routes are also built. Cluster Ollama pulls now require an explicit durable-storage policy or a declaration that weights are pre-provisioned; ephemeral implicit downloads are refused before mutation. Native OpenAI wire format remains absent.",
+      "technology": [
+        "Anthropic",
+        "OpenRouter",
+        "provider-native endpoints",
+        "Ollama"
+      ],
+      "evidence": [
+        "architecture",
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0015",
+        "ADR-0032",
+        "ADR-0048"
+      ]
+    },
+    {
+      "id": "connector-host",
+      "label": "MCP connector hosts",
+      "mapLabel": "MCP hosts",
+      "subtitle": "Collapsed MCP implementations",
+      "kind": "runtime",
+      "state": "implemented",
+      "zone": "runtime",
+      "x": 0.69,
+      "y": 0.48,
+      "description": "The stable MCP role in the architecture. Bundle-declared local and remote MCP servers stay collapsed behind this host boundary, so adding another server does not add another architecture box.",
+      "technology": [
+        "Kubernetes",
+        "MCP",
+        "bundle declaration"
+      ],
+      "evidence": [
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0009",
+        "ADR-0086",
+        "ADR-0087",
+        "ADR-0088",
+        "ADR-0090"
+      ]
+    },
+    {
+      "id": "oauth-gateway",
+      "label": "MCP OAuth gateway",
+      "mapLabel": "OAuth gateway",
+      "subtitle": "Per-person delegated access",
+      "kind": "runtime",
+      "state": "planned",
+      "zone": "runtime",
+      "x": 0.87,
+      "y": 0.52,
+      "description": "The accepted vision boundary for delegated MCP authorization. The control plane owns OAuth discovery, PKCE, encrypted tokens, refresh, revocation, and grants; the gateway applies the active run principal's grant without exposing raw OAuth tokens to the runner.",
+      "technology": [
+        "OAuth 2.1",
+        "PKCE",
+        "MCP authorization",
+        "principal-bound grants"
+      ],
+      "evidence": [
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0088",
+        "ADR-0106"
+      ]
+    },
+    {
+      "id": "agent-proxy",
+      "label": "Agent Proxy",
+      "subtitle": "Credentials + egress boundary",
+      "kind": "runtime",
+      "state": "planned",
+      "zone": "runtime",
+      "x": 0.93,
+      "y": 0.2,
+      "description": "Accepted architecture moves provider credentials and enforceable egress policy out of the sandbox. The direction is decided, but substrate, TLS termination, credential injection, and implementation remain follow-up work.",
+      "technology": [
+        "Accepted proxy boundary"
+      ],
+      "evidence": [
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0075"
+      ]
+    },
+    {
+      "id": "otel",
+      "label": "OTel collector",
+      "subtitle": "Telemetry write port",
+      "kind": "observability",
+      "state": "implemented",
+      "zone": "foundation",
+      "x": 0.735,
+      "y": 0.69,
+      "description": "Receives OTLP from Curie services and the runner and exports to Langfuse over HTTP. Ingress, durable approval resolution, expiry, and reconciliation preserve the originating W3C trace context when valid; missing or malformed legacy carriers start clean roots. The runner emits truthful sibling provider/tool phase intervals with a closed versioned attribute set; the collector boundary remains mostly vendor-neutral.",
+      "technology": [
+        "OpenTelemetry",
+        "OTLP HTTP/gRPC"
+      ],
+      "evidence": [
+        "architecture",
+        "interfaces",
+        "runner-telemetry-code"
+      ],
+      "adrIds": [
+        "ADR-0004",
+        "ADR-0076"
+      ]
+    },
+    {
+      "id": "langfuse",
+      "label": "Langfuse",
+      "subtitle": "Traces \u00b7 metrics \u00b7 eval scores",
+      "kind": "observability",
+      "state": "implemented",
+      "zone": "foundation",
+      "x": 0.865,
+      "y": 0.69,
+      "description": "The current trace and eval store. The shipping Helm surface pins the reviewed Langfuse web and worker migration set together with ClickHouse 25.12; its AVX preflight fails the default installation on AVX-less nodes rather than allowing a migration-incompatible store. Compose retains its separate SSE4.2-safe ClickHouse pin for local evidence. The API reconstructs trees and metrics through a vendor-specific read adapter. Operators can disable the in-chart deployment and point every consumer at an explicit external Langfuse host without rendering a nonexistent in-cluster Service.",
+      "technology": [
+        "Langfuse v3",
+        "ClickHouse"
+      ],
+      "evidence": [
+        "architecture",
+        "architecture-vision",
+        "chart-values"
+      ],
+      "adrIds": [
+        "ADR-0004"
+      ]
+    },
+    {
+      "id": "postgres",
+      "label": "Postgres",
+      "subtitle": "Control-plane state",
+      "kind": "data",
+      "state": "implemented",
+      "zone": "foundation",
+      "x": 0.735,
+      "y": 0.87,
+      "description": "Stores agents, versions, deployments, channel bindings, approvals, memory, history, and other durable control-plane state. Workflow-state identity distinguishes binding-scoped rows from one shared NULL scope, enforced with PostgreSQL 15 NULLS NOT DISTINCT so legacy shared memory cannot fork into duplicates.",
+      "technology": [
+        "Postgres",
+        "SQLAlchemy",
+        "JSONB"
+      ],
+      "evidence": [
+        "architecture-vision",
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0008",
+        "ADR-0025",
+        "ADR-0029"
+      ]
+    },
+    {
+      "id": "object-store",
+      "label": "RustFS / S3",
+      "subtitle": "Immutable bundles",
+      "kind": "data",
+      "state": "implemented",
+      "zone": "foundation",
+      "x": 0.865,
+      "y": 0.87,
+      "description": "Stores immutable agent bundles and eval inputs behind an S3-compatible protocol and ObjectStore port. With a bring-your-own store and egress rail enabled, runner bundle fetch is fail-closed until explicit store CIDRs and ports are supplied; the key-free path also requires separate STS egress and uses projected service-account identity rather than node metadata.",
+      "technology": [
+        "RustFS",
+        "S3 protocol",
+        "boto3"
+      ],
+      "evidence": [
+        "architecture-vision",
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0014",
+        "ADR-0026"
+      ]
+    },
+    {
+      "id": "kubernetes",
+      "label": "Kubernetes",
+      "subtitle": "Production substrate",
+      "kind": "substrate",
+      "state": "implemented",
+      "zone": "foundation",
+      "x": 0.945,
+      "y": 0.72,
+      "description": "Baseline production substrate: platform services, Agent Sandbox CRDs, security rails, connector workloads, and observability dependencies. Helm upgrades preserve external credential references and heal missing or blank legacy chart-managed Secret keys while retaining nonblank persisted values.",
+      "technology": [
+        "Kubernetes",
+        "Helm",
+        "Agent Sandbox"
+      ],
+      "evidence": [
+        "kubernetes",
+        "architecture",
+        "chart-secret-template",
+        "chart-values"
+      ],
+      "adrIds": [
+        "ADR-0002",
+        "ADR-0006",
+        "ADR-0023"
+      ]
+    },
+    {
+      "id": "docker",
+      "label": "Docker",
+      "subtitle": "Local parity substrate",
+      "kind": "substrate",
+      "state": "implemented",
+      "zone": "foundation",
+      "x": 0.945,
+      "y": 0.87,
+      "description": "Runs the same worker and runner image locally behind the same SandboxClient contract.",
+      "technology": [
+        "Docker Compose",
+        "Docker sandbox"
+      ],
+      "evidence": [
+        "architecture",
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0012",
+        "ADR-0028",
+        "ADR-0054"
+      ]
+    }
+  ],
+  "seams": [
+    {
+      "id": "channel-ingress",
+      "label": "Channel ingress + binding",
+      "maturity": "green",
+      "catalogKind": "SOFT",
+      "grade": "B-",
+      "implementations": "3 production channels (Slack Bolt, Discord HTTP adapter, email HTTP adapter) plus the CLI transport stub",
+      "contract": "QueuedTurn + ReplyHandle; neutral {kind, address} deployment binding",
+      "reason": "Slack, Discord, and email all mint or consume the same channel-neutral QueuedTurn and (kind, address) binding. Discord and email prove the HTTP edge that Slack does not use.",
+      "leakage": "The generated interface catalog still says one implementation. Discord v1 and email do not share Slack's in-process dispatcher or approval cards.",
+      "nextStep": "Regenerate the Communication catalog row from the three shipped adapters, then decide whether Teams or Discord approvals is the remaining proof.",
+      "evidence": [
+        "channel-api-code",
+        "binding-code",
+        "discord-adapter-code",
+        "mail-adapter-code",
+        "interfaces",
+        "architecture"
+      ],
+      "adrIds": [
+        "ADR-0012",
+        "ADR-0020",
+        "ADR-0096",
+        "ADR-0118"
+      ],
+      "flowIds": [
+        "slack-turn",
+        "discord-turn",
+        "email-turn",
+        "approval-loop"
+      ]
+    },
+    {
+      "id": "channel-reply",
+      "label": "Reply delivery semantics",
+      "maturity": "yellow",
+      "catalogKind": "SOFT",
+      "grade": "B-",
+      "implementations": "SlackReplyAdapter plus HttpReplyAdapter consumed by Discord and email",
+      "contract": "ReplySink.emit over turn.status, reply.update, reply.post, and turn.completed",
+      "reason": "The four versioned reply events now leave the worker for three surfaces. Slack still owns edit-in-place streaming and approval-card settlement.",
+      "leakage": "Discord v1 falls back to text and does not implement buttons. Email sends one correspondent-visible reply per turn.completed and does not settle approvals. Neither surface may fall back to Slack.",
+      "nextStep": "Keep the HTTP reply wire; add Discord interaction or treat email's one-shot reply as a distinct delivery policy rather than a missing Slack feature.",
+      "evidence": [
+        "reply-sink-code",
+        "channel-api-code",
+        "discord-adapter-code",
+        "mail-adapter-code",
+        "interfaces",
+        "message-flow"
+      ],
+      "adrIds": [
+        "ADR-0020",
+        "ADR-0063",
+        "ADR-0078",
+        "ADR-0096",
+        "ADR-0120",
+        "ADR-0130"
+      ],
+      "flowIds": [
+        "slack-turn",
+        "discord-turn",
+        "email-turn",
+        "approval-loop"
+      ]
+    },
+    {
+      "id": "channel-interaction",
+      "label": "Semantic channel interaction",
+      "maturity": "green",
+      "catalogKind": "CLEAN",
+      "grade": "\u2014",
+      "implementations": "2 real renderers (Slack Block Kit, terminal selector)",
+      "contract": "Versioned OutboundMessage with text fallback, Choice, Confirm, and semantic action values",
+      "reason": "Two distinct surfaces render the same semantic message without putting their widgets in the contract.",
+      "leakage": "The terminal mirror is handwritten and capabilities are modeled but not dynamically negotiated. Discord and email do not render Choice or Confirm.",
+      "nextStep": "Wire capability negotiation when a shipped surface other than Slack needs buttons or cards.",
+      "evidence": [
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0020"
+      ],
+      "flowIds": [
+        "approval-loop",
+        "email-turn",
+        "discord-turn"
+      ]
+    },
+    {
+      "id": "queue-stream",
+      "label": "Queue / stream broker",
+      "maturity": "yellow",
+      "catalogKind": "CLEAN",
+      "grade": "\u2014",
+      "implementations": "1 real broker (Valkey) behind producer and consumer ports",
+      "contract": "StreamPublisher + StreamBroker ports, frozen payload field, shared bounded consumer, and one renewable fenced owner per delivery",
+      "reason": "The port and consumer invariants are explicit, but a second broker has not exercised them.",
+      "leakage": "Some API producers and graveyard readers still bypass the ports; the adjacent consumer-liveness store, set verbs, and redis-py exception types also leak Valkey semantics.",
+      "nextStep": "No speculative adapter; promote only if a real broker demand appears.",
+      "evidence": [
+        "interfaces",
+        "architecture"
+      ],
+      "adrIds": [
+        "ADR-0013",
+        "ADR-0027",
+        "ADR-0039",
+        "ADR-0131"
+      ],
+      "flowIds": [
+        "slack-turn",
+        "discord-turn",
+        "email-turn",
+        "approval-loop",
+        "git-deploy",
+        "eval-loop"
+      ]
+    },
+    {
+      "id": "substrate",
+      "label": "Sandbox substrate",
+      "maturity": "green",
+      "catalogKind": "CLEAN",
+      "grade": "\u2014",
+      "implementations": "2 real implementations (Kubernetes, Docker)",
+      "contract": "Six-method SandboxClient claim lifecycle plus ClaimView and SandboxView outcome types",
+      "reason": "The same kernel and runner operate through two materially different runtime implementations.",
+      "leakage": "SandboxView.port, model-credential forwarding, connector-secret delivery, warm-pool behavior, and production capacity still differ across Kubernetes and Docker.",
+      "nextStep": "Keep parity tests focused on the shared outcomes; do not turn substrate choice into a product axis.",
+      "evidence": [
+        "interfaces",
+        "architecture",
+        "kubernetes"
+      ],
+      "adrIds": [
+        "ADR-0002",
+        "ADR-0028"
+      ],
+      "flowIds": [
+        "slack-turn",
+        "approval-loop",
+        "eval-loop"
+      ]
+    },
+    {
+      "id": "aci",
+      "label": "Frozen ACI protocol",
+      "maturity": "yellow",
+      "catalogKind": "CLEAN, frozen",
+      "grade": "A-",
+      "implementations": "1 production producer + scripted reference/conformance implementation",
+      "contract": "SessionConfig, boot env, HTTP control verbs, and versioned NDJSON events across Python/TS/Rust",
+      "reason": "This is the strongest documented boundary, but only one production harness stack has proven it end to end.",
+      "leakage": "A non-Claude harness must still consume or translate the Claude Code plugin bundle shape.",
+      "nextStep": "Use the conformance guide against a genuinely different production harness.",
+      "evidence": [
+        "aci-diagram",
+        "architecture-vision",
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0005",
+        "ADR-0017",
+        "ADR-0036",
+        "ADR-0062",
+        "ADR-0116"
+      ],
+      "flowIds": [
+        "slack-turn",
+        "approval-loop",
+        "eval-loop"
+      ]
+    },
+    {
+      "id": "harness-modelsession",
+      "label": "Runner \u2194 harness / ModelSession",
+      "maturity": "red",
+      "catalogKind": "CLEAN",
+      "grade": "A-",
+      "implementations": "1 production SDK + fake",
+      "contract": "In-process ModelSession protocol and declared harness contribution",
+      "reason": "The named protocol is real, but its message union is still SDK-shaped and the bundle distribution format is Claude Code verbatim.",
+      "leakage": "A foreign harness must emit Claude SDK-shaped objects or replace the runner adapter while also interpreting the Claude plugin format.",
+      "nextStep": "Prove the out-of-process ACI boundary with a second harness; keep provider-native checkpointing an optional capability.",
+      "evidence": [
+        "runner-adapter-code",
+        "architecture-vision",
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0005",
+        "ADR-0060",
+        "ADR-0061",
+        "ADR-0105"
+      ],
+      "flowIds": [
+        "slack-turn",
+        "approval-loop",
+        "eval-loop"
+      ]
+    },
+    {
+      "id": "harness-package",
+      "label": "Declared harness package",
+      "maturity": "yellow",
+      "catalogKind": "CLEAN",
+      "grade": "\u2014",
+      "implementations": "1 declared contribution (Claude)",
+      "contract": "HarnessContribution manifest; built-ins resolve directly and third-party contributions use curie.harness entry points",
+      "reason": "Selection and declared assets are clean, but there is no second real package and third-party conformance remains unproven.",
+      "leakage": "The registry currently wraps the same built-in adapter rather than demonstrating substitution.",
+      "nextStep": "Publish and run contribution conformance against a non-built-in package.",
+      "evidence": [
+        "architecture-vision",
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0060",
+        "ADR-0062"
+      ],
+      "flowIds": [
+        "slack-turn",
+        "eval-loop"
+      ]
+    },
+    {
+      "id": "model-provider",
+      "label": "Model provider + credentials",
+      "maturity": "yellow",
+      "catalogKind": "SOFT",
+      "grade": "\u2014",
+      "implementations": "Multiple live endpoints through one Claude-SDK / Anthropic-wire strategy",
+      "contract": "Declared wire protocol, provider endpoint, canonical credential keys, and boot-env forwarding",
+      "reason": "Several endpoints exercise routing and credential resolution, but they do not represent multiple independent provider or harness implementations of the boundary.",
+      "leakage": "Native OpenAI wire format is absent; several providers share compatibility routing rather than independent harness implementations.",
+      "nextStep": "Add native OpenAI wire only when its semantics are tested through the live-provider parity tier.",
+      "evidence": [
+        "architecture",
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0015",
+        "ADR-0032",
+        "ADR-0048",
+        "ADR-0049"
+      ],
+      "flowIds": [
+        "slack-turn",
+        "eval-loop"
+      ]
+    },
+    {
+      "id": "telemetry",
+      "label": "Telemetry / OTLP",
+      "maturity": "yellow",
+      "catalogKind": "SOFT",
+      "grade": "B+",
+      "implementations": "1 trace backend (Langfuse) behind an OTel collector",
+      "contract": "OTLP write path + versioned phase semantics + Curie API DTO read path",
+      "reason": "Curie preserves valid W3C parentage from ingress through durable approval resolution, expiry, and reconciliation, the runner records real provider/tool intervals behind a closed attribute contract, and the UI sees Curie DTOs; only Langfuse has exercised both sides.",
+      "leakage": "Vendor attributes and /langfuse URL namespaces still leak into the otherwise neutral boundary; the read adapter spans multiple modules.",
+      "nextStep": "Map vendor span attributes in the collector and neutralize read-route naming.",
+      "evidence": [
+        "architecture",
+        "architecture-vision",
+        "interfaces",
+        "runner-telemetry-code",
+        "approval-actions-code"
+      ],
+      "adrIds": [
+        "ADR-0004",
+        "ADR-0076"
+      ],
+      "flowIds": [
+        "observability",
+        "eval-loop"
+      ]
+    },
+    {
+      "id": "eval-scorer",
+      "label": "Eval case + scorer",
+      "maturity": "green",
+      "catalogKind": "SOFT",
+      "grade": "B",
+      "implementations": "Multiple grader kinds plus a trajectory matcher across Python and Rust",
+      "contract": "Frozen eval-case schema + shared trajectory vectors + tri-state outcomes",
+      "reason": "Distinct scoring implementations and two languages exercise the case boundary, with shared fixtures pinning semantics.",
+      "leakage": "Python and Rust still implement graders separately; cluster answer-quality failure is not yet universally fatal.",
+      "nextStep": "Land semantic provenance verification before making cluster answer-quality promotion fatal.",
+      "evidence": [
+        "architecture",
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0019",
+        "ADR-0022",
+        "ADR-0042",
+        "ADR-0053",
+        "ADR-0055"
+      ],
+      "flowIds": [
+        "git-deploy",
+        "eval-loop"
+      ]
+    },
+    {
+      "id": "eval-store",
+      "label": "Eval result store",
+      "maturity": "yellow",
+      "catalogKind": "SOFT",
+      "grade": "B",
+      "implementations": "1 backend (Langfuse traces + scores)",
+      "contract": "Eval recorder write + EvalMatrix read DTO + version:/suite: tag convention",
+      "reason": "The platform owns the result shape, but only one backend and one unfrozen tag convention have exercised it.",
+      "leakage": "The recorder and matrix reader encode Langfuse tags and API behavior directly.",
+      "nextStep": "Record or freeze the tag convention; wait for a real second store before inventing a generic adapter.",
+      "evidence": [
+        "architecture-vision",
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0004",
+        "ADR-0019"
+      ],
+      "flowIds": [
+        "git-deploy",
+        "eval-loop",
+        "observability"
+      ]
+    },
+    {
+      "id": "blob-storage",
+      "label": "Blob storage",
+      "maturity": "yellow",
+      "catalogKind": "CLEAN",
+      "grade": "B+",
+      "implementations": "1 backend (RustFS) over S3-compatible protocol",
+      "contract": "ObjectStore port + shared S3 client + bundle-fetch init path",
+      "reason": "The port is explicit and S3-compatible services are configuration swaps, but no non-S3 implementation has tested the abstraction.",
+      "leakage": "API and worker use separate async/sync adapters, while bucket bootstrap, init containers, migration, key-free auth, and NetworkPolicy CIDR configuration retain S3-specific obligations.",
+      "nextStep": "Leave it alone until a real non-S3 demand appears; keep the BYO egress and web-identity render assertions as the fail-closed operational boundary.",
+      "evidence": [
+        "architecture-vision",
+        "interfaces",
+        "chart-values"
+      ],
+      "adrIds": [
+        "ADR-0026"
+      ],
+      "flowIds": [
+        "git-deploy",
+        "eval-loop"
+      ]
+    },
+    {
+      "id": "relational-db",
+      "label": "Relational database",
+      "maturity": "yellow",
+      "catalogKind": "SOFT",
+      "grade": "A-",
+      "implementations": "1 engine family (Postgres; self-hosted or managed)",
+      "contract": "SQLAlchemy models + Alembic migrations + DSN",
+      "reason": "Managed Postgres is a clean operational swap, but another SQL engine has not exercised the model boundary.",
+      "leakage": "Postgres UUID, JSONB, schema qualification, native enums, DISTINCT ON SQL, asyncpg-specific JSONB decoding, and PostgreSQL 15 NULLS NOT DISTINCT workflow-state identity remain in application code or migrations.",
+      "nextStep": "Keep Postgres opinionated unless a concrete alternate engine demand emerges.",
+      "evidence": [
+        "architecture-vision",
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0008"
+      ],
+      "flowIds": [
+        "slack-turn",
+        "approval-loop",
+        "git-deploy"
+      ]
+    },
+    {
+      "id": "approval-authorizer",
+      "label": "Approval authorizer",
+      "maturity": "green",
+      "catalogKind": "CLEAN",
+      "grade": "\u2014",
+      "implementations": "3 real approver sets (channel, user group, explicit users)",
+      "contract": "ApproverSet / ApprovalCreator + authenticated ApprovalPrincipal + durable semantic approval record",
+      "reason": "Three distinct membership strategies exercise one API-owned authorization interface after resolver identity is authenticated separately.",
+      "leakage": "Channel membership remains Slack-shaped, while Console and operator principals are intentionally eligible for only the approver sets their credential kind can satisfy.",
+      "nextStep": "Exercise the same authenticated-principal and membership boundary through a second interactive channel before broadening approval authority.",
+      "evidence": [
+        "interfaces",
+        "architecture",
+        "approval-principal-code",
+        "approval-auth-code"
+      ],
+      "adrIds": [
+        "ADR-0010",
+        "ADR-0034",
+        "ADR-0046",
+        "ADR-0106"
+      ],
+      "flowIds": [
+        "approval-loop"
+      ]
+    },
+    {
+      "id": "approval-principal",
+      "label": "Approval principal identity",
+      "maturity": "green",
+      "catalogKind": "SOFT",
+      "grade": "\u2014",
+      "implementations": "3 authenticated principal kinds (chat, Console, operator)",
+      "contract": "Canonical ApprovalPrincipal + credential-kind eligibility + authenticated audit fields",
+      "reason": "Three independent credential paths derive one server-owned principal shape before the common membership decision.",
+      "leakage": "Chat attestations remain Slack-specific, operator principals are limited to explicit-user sets, and Console principals cannot assert channel evidence.",
+      "nextStep": "Add a second adapter-scoped interactive credential without widening any existing principal kind or accepting the platform key as resolver identity.",
+      "evidence": [
+        "architecture",
+        "interfaces",
+        "approval-principal-code",
+        "approval-auth-code"
+      ],
+      "adrIds": [
+        "ADR-0033",
+        "ADR-0034",
+        "ADR-0106"
+      ],
+      "flowIds": [
+        "approval-loop"
+      ]
+    },
+    {
+      "id": "workflow-state",
+      "label": "Workflow state store",
+      "maturity": "red",
+      "catalogKind": "SOFT",
+      "grade": "\u2014",
+      "implementations": "1 state API router over Postgres JSONB",
+      "contract": "Scoped namespace/key document API with size limits, CAS behavior, and singular shared NULL-scope identity",
+      "reason": "The HTTP state router is useful, but not every state consumer stays behind it; operator memory and relational paths can bypass the supposed boundary.",
+      "leakage": "A second state backend would not cover direct model/JSONB access, while memory and transcript loaders still depend on the HTTP shape and capacity limits.",
+      "nextStep": "Inventory and close bypasses before extracting another backend; then treat retention, capacity, and back-pressure as one admission policy.",
+      "evidence": [
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0025",
+        "ADR-0029",
+        "ADR-0109"
+      ],
+      "flowIds": [
+        "slack-turn",
+        "approval-loop"
+      ]
+    },
+    {
+      "id": "memory",
+      "label": "Agent memory",
+      "maturity": "yellow",
+      "catalogKind": "CLEAN",
+      "grade": "\u2014",
+      "implementations": "1 real loader (StateApiMemoryStore)",
+      "contract": "MemoryStore load/append, optional replace, and boot-preamble injection over a scoped state token",
+      "reason": "The loader port and null implementation are clean, but no alternate durable memory backend has exercised them.",
+      "leakage": "The operator inspect/seed/edit/delete plane addresses the Postgres WorkflowStateEntry backing directly instead of going through MemoryStore.",
+      "nextStep": "Keep the operator plane and any future loader consistent before adding another backing; automatic learned-record extraction remains future work.",
+      "evidence": [
+        "interfaces",
+        "architecture"
+      ],
+      "adrIds": [
+        "ADR-0025",
+        "ADR-0030",
+        "ADR-0095",
+        "ADR-0111"
+      ],
+      "flowIds": [
+        "slack-turn"
+      ]
+    },
+    {
+      "id": "conversation-history",
+      "label": "Conversation history",
+      "maturity": "yellow",
+      "catalogKind": "CLEAN",
+      "grade": "\u2014",
+      "implementations": "1 real loader (StateApiTranscriptStore)",
+      "contract": "TranscriptStore load/append + deterministic per-agent/thread reference",
+      "reason": "The harness-neutral replay path is explicit, but only one store and prompt-preamble rehydration have proven it. Append records only a successful model-produced terminal final with DONE status; classified failures, budget/auth halts, awaiting-approval, and synthetic incomplete finals are omitted.",
+      "leakage": "Stored append logs remain unbounded under state-store caps; replay is semantic, not token-exact or native-session restoration.",
+      "nextStep": "Keep portable replay mandatory; add native checkpoints only as an optional harness capability.",
+      "evidence": [
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0003",
+        "ADR-0029",
+        "ADR-0105"
+      ],
+      "flowIds": [
+        "slack-turn",
+        "approval-loop"
+      ]
+    },
+    {
+      "id": "triggers",
+      "label": "Trigger ingestion",
+      "maturity": "red",
+      "catalogKind": "SOFT",
+      "grade": "\u2014",
+      "implementations": "4 hardcoded trigger paths (Slack, GitHub webhook, commit poller, generic HMAC hook)",
+      "contract": "No unified runtime trigger port; API hooks mint bounded webhook-sourced turns while bundle declarations and schedules remain planned",
+      "reason": "Several triggers exist, but they do not implement one shared trigger interface or one event lifecycle.",
+      "leakage": "Slack enters through dispatcher while GitHub, polling, and generic hooks enter through API-specific handlers; bundle-declared hooks and schedules are not consumed.",
+      "nextStep": "Connect declarations and schedules to the shipped bounded hook lifecycle before expanding trigger types.",
+      "evidence": [
+        "interfaces",
+        "architecture"
+      ],
+      "adrIds": [
+        "ADR-0079",
+        "ADR-0099"
+      ],
+      "flowIds": [
+        "slack-turn",
+        "git-deploy",
+        "webhook-turn",
+        "future-hooks"
+      ]
+    },
+    {
+      "id": "cli-output",
+      "label": "Agent-facing CLI output",
+      "maturity": "green",
+      "catalogKind": "CLEAN",
+      "grade": "\u2014",
+      "implementations": "46 typed outputs behind one trait across many verbs",
+      "contract": "CliOutput + Ui.emit + versioned JSON result schemas",
+      "reason": "Many independent command results exercise the same human/JSON emission boundary.",
+      "leakage": "A tracked set of legacy/operator verbs still has inline or unstructured success output.",
+      "nextStep": "Finish migrating the tracked exceptions without widening the output contract.",
+      "evidence": [
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0021",
+        "ADR-0041",
+        "ADR-0074"
+      ],
+      "flowIds": [
+        "slack-turn",
+        "git-deploy"
+      ]
+    },
+    {
+      "id": "connector-host",
+      "label": "MCP connector host",
+      "maturity": "red",
+      "catalogKind": "CLEAN",
+      "grade": "\u2014",
+      "implementations": "1 real Kubernetes host + in-memory fake",
+      "contract": "Bundle declaration \u2192 rendered connector workload \u2192 MCP reachability",
+      "reason": "The typed client exposes raw Kubernetes JSON, rendering is Kubernetes-specific outside the port, and CLI and reconciler paths do not share identical apply/prune semantics.",
+      "leakage": "Build inputs, pinned images, delegated OAuth, runtime injection, reconciliation, and Kubernetes objects cross control-plane and cluster ownership.",
+      "nextStep": "Close runtime injection and converge CLI/reconciler lifecycle before calling the host portable.",
+      "evidence": [
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0086",
+        "ADR-0087",
+        "ADR-0088",
+        "ADR-0090",
+        "ADR-0113",
+        "ADR-0117"
+      ],
+      "flowIds": [
+        "slack-turn",
+        "mcp-service-call",
+        "mcp-delegated-oauth"
+      ]
+    },
+    {
+      "id": "mcp-service-auth",
+      "label": "MCP service-key authentication",
+      "maturity": "yellow",
+      "catalogKind": "SOFT",
+      "grade": "\u2014",
+      "implementations": "1 deployment-owned service identity mode",
+      "contract": "Named connector secret \u2192 platform-hosted MCP environment or authorization header",
+      "reason": "Service credentials already cross a named secret boundary and stay owned by the deployment, but no second production identity mode has proved the abstraction.",
+      "leakage": "Secret rendering and delivery still span bundle declaration, API, Kubernetes, and the incomplete sealed-credential consumer path.",
+      "nextStep": "Keep service authentication explicit and fail closed; prove delegated OAuth as a separate identity mode with no fallback between them.",
+      "evidence": [
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0009",
+        "ADR-0086",
+        "ADR-0094"
+      ],
+      "flowIds": [
+        "mcp-service-call"
+      ]
+    },
+    {
+      "id": "mcp-delegated-oauth",
+      "label": "Per-person MCP OAuth",
+      "maturity": "planned",
+      "catalogKind": "NONE",
+      "grade": "\u2014",
+      "implementations": "0; accepted architecture only",
+      "contract": "Canonical run principal \u2192 principal-scoped grant \u2192 control-plane-owned OAuth gateway \u2192 MCP server",
+      "reason": "ADR-0088 defines the ownership and fail-closed behavior, but the gateway, grant lifecycle, connection action, and resume path are not shipped.",
+      "leakage": "Until implemented, MCP calls cannot safely act with each human's authority; the existing deployment service identity is the only current mode.",
+      "nextStep": "Implement discovery, PKCE, encrypted grant storage, refresh and revocation, then prove missing-auth pause and post-callback resume without giving the runner a raw token.",
+      "evidence": [
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0088",
+        "ADR-0106"
+      ],
+      "flowIds": [
+        "mcp-delegated-oauth"
+      ]
+    },
+    {
+      "id": "sealed-credential",
+      "label": "Sealed connector credential",
+      "maturity": "red",
+      "catalogKind": "SOFT",
+      "grade": "\u2014",
+      "implementations": "1 cross-language wire (Rust sealer, Python opener)",
+      "contract": "Frozen sealed-credential envelope with cluster-side opening",
+      "reason": "The Rust sealer and Python opener interoperate, but the product path is disconnected: validation and delivery do not yet form one working production consumer path.",
+      "leakage": "Security depends on exact agreement between CLI, API rendering, cluster delivery, and the currently uncalled opener.",
+      "nextStep": "Connect and prove the complete sealed-secret path before expanding its wire or consumers.",
+      "evidence": [
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0009",
+        "ADR-0094"
+      ],
+      "flowIds": [
+        "git-deploy"
+      ]
+    },
+    {
+      "id": "bundle-format",
+      "label": "Bundle / plugin format",
+      "maturity": "yellow",
+      "catalogKind": "CLEAN, frozen",
+      "grade": "\u2014",
+      "implementations": "1 deliberately adopted format (Claude Code plugin)",
+      "contract": "Frozen Pydantic models + regenerated committed JSON Schema (no generated Rust/TS) + immutable content-addressed bundle",
+      "reason": "The format is strongly enforced but intentionally has one implementation and one ecosystem shape.",
+      "leakage": "This is the main coupling that a non-Claude harness must interpret or translate.",
+      "nextStep": "Do not invent another format; require alternate harnesses to demonstrate a translation strategy.",
+      "evidence": [
+        "architecture-vision",
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0007",
+        "ADR-0014",
+        "ADR-0017"
+      ],
+      "flowIds": [
+        "git-deploy",
+        "eval-loop"
+      ]
+    },
+    {
+      "id": "port-adapter-service",
+      "label": "Third-party port adapter",
+      "maturity": "planned",
+      "catalogKind": "NONE",
+      "grade": "\u2014",
+      "implementations": "0 generic adapter-kit services; Discord and email are first-party adapters on the shipped HTTP edge",
+      "contract": "Intended deployed-service placement; no runtime implementation",
+      "reason": "ADR-0096 still places a third-party adapter as a deployed service. The generic kit is unbuilt; first-party Discord and email adapters already use the HTTP edge without that kit.",
+      "leakage": "Adapter discovery, routing, credentials, conformance, and lifecycle are still future work.",
+      "nextStep": "Build the adapter kit only if a third-party channel needs install, discovery, and conformance beyond the two shipped first-party adapters.",
+      "evidence": [
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0096"
+      ],
+      "flowIds": []
+    },
+    {
+      "id": "agent-proxy",
+      "label": "Agent Proxy boundary",
+      "maturity": "planned",
+      "catalogKind": "NONE",
+      "grade": "\u2014",
+      "implementations": "0",
+      "contract": "Accepted credential and egress enforcement boundary outside the sandbox",
+      "reason": "The direction is accepted but intentionally unimplemented pending narrower substrate, TLS, and injection decisions.",
+      "leakage": "Provider credentials and web egress still enter the sandbox under current controls.",
+      "nextStep": "Land the follow-up ADRs for substrate, TLS termination, and credential injection before implementation.",
+      "evidence": [
+        "interfaces"
+      ],
+      "adrIds": [
+        "ADR-0075"
+      ],
+      "flowIds": [
+        "slack-turn"
+      ]
+    },
+    {
+      "id": "promotion-gate",
+      "label": "Eval result \u2192 promotion authority",
+      "maturity": "planned",
+      "catalogKind": "NONE",
+      "grade": "\u2014",
+      "implementations": "Commit status exists; internal promotion enforcement does not",
+      "contract": "Reserved policy boundary between graded evidence and production deployment",
+      "reason": "The API reports eval state to GitHub, but process_push does not read that result before creating a production deployment.",
+      "leakage": "Safety depends on external branch protection and release policy rather than a product invariant.",
+      "nextStep": "Land semantic provenance first, then bind promotion to an authoritative graded result without rebuilding the artifact.",
+      "evidence": [
+        "architecture"
+      ],
+      "adrIds": [
+        "ADR-0014",
+        "ADR-0022",
+        "ADR-0042"
+      ],
+      "flowIds": [
+        "git-deploy",
+        "eval-loop"
+      ]
+    }
+  ],
+  "routes": [
+    {
+      "id": "slack-dispatcher",
+      "from": "slack",
+      "to": "dispatcher",
+      "label": "mention / DM",
+      "state": "current",
+      "seamId": "channel-ingress",
+      "bend": 0
+    },
+    {
+      "id": "email-adapter",
+      "from": "email",
+      "to": "channel-api",
+      "label": "POST /channels/turns",
+      "state": "current",
+      "seamId": "channel-ingress",
+      "bend": -8
+    },
+    {
+      "id": "discord-channel-api",
+      "from": "discord",
+      "to": "channel-api",
+      "label": "POST /channels/turns",
+      "state": "current",
+      "seamId": "channel-ingress",
+      "bend": 8
+    },
+    {
+      "id": "teams-adapter",
+      "from": "teams",
+      "to": "port-adapter",
+      "label": "normalized event",
+      "state": "planned",
+      "seamId": "port-adapter-service",
+      "bend": 18
+    },
+    {
+      "id": "adapter-channel-api",
+      "from": "port-adapter",
+      "to": "channel-api",
+      "label": "scoped HTTP",
+      "state": "planned",
+      "seamId": "port-adapter-service",
+      "bend": 0
+    },
+    {
+      "id": "channel-api-adapter",
+      "from": "channel-api",
+      "to": "port-adapter",
+      "label": "reply event callback",
+      "state": "planned",
+      "seamId": "port-adapter-service",
+      "bend": 20
+    },
+    {
+      "id": "adapter-email-reply",
+      "from": "port-adapter",
+      "to": "email",
+      "label": "email reply",
+      "state": "planned",
+      "seamId": "channel-reply",
+      "bend": 18
+    },
+    {
+      "id": "channel-api-queue",
+      "from": "channel-api",
+      "to": "queue",
+      "label": "platform-minted QueuedTurn",
+      "state": "current",
+      "seamId": "channel-ingress",
+      "bend": -12
+    },
+    {
+      "id": "cli-queue",
+      "from": "cli",
+      "to": "queue",
+      "label": "same QueuedTurn",
+      "state": "current",
+      "seamId": "channel-ingress",
+      "bend": -26
+    },
+    {
+      "id": "github-api",
+      "from": "github",
+      "to": "api",
+      "label": "push / poll",
+      "state": "current",
+      "seamId": "triggers",
+      "bend": 0
+    },
+    {
+      "id": "external-hook-api",
+      "from": "external-hook",
+      "to": "api",
+      "label": "named HMAC hook",
+      "state": "current",
+      "seamId": "triggers",
+      "bend": 14
+    },
+    {
+      "id": "console-api",
+      "from": "console",
+      "to": "api",
+      "label": "Curie API DTOs",
+      "state": "current",
+      "seamId": "telemetry",
+      "bend": 16
+    },
+    {
+      "id": "dispatcher-queue",
+      "from": "dispatcher",
+      "to": "queue",
+      "label": "XADD curie:runs",
+      "state": "current",
+      "seamId": "queue-stream",
+      "bend": 0
+    },
+    {
+      "id": "api-queue",
+      "from": "api",
+      "to": "queue",
+      "label": "eval / resume turn",
+      "state": "current",
+      "seamId": "queue-stream",
+      "bend": -18
+    },
+    {
+      "id": "queue-worker",
+      "from": "queue",
+      "to": "worker",
+      "label": "XREADGROUP",
+      "state": "current",
+      "seamId": "queue-stream",
+      "bend": 0
+    },
+    {
+      "id": "worker-sandbox",
+      "from": "worker",
+      "to": "sandbox",
+      "label": "claim / resume",
+      "state": "current",
+      "seamId": "substrate",
+      "bend": 0
+    },
+    {
+      "id": "sandbox-runner",
+      "from": "sandbox",
+      "to": "runner",
+      "label": "start ACI server",
+      "state": "current",
+      "seamId": "aci",
+      "bend": 0
+    },
+    {
+      "id": "worker-runner",
+      "from": "worker",
+      "to": "runner",
+      "label": "event / steer / interrupt",
+      "state": "current",
+      "seamId": "aci",
+      "bend": -12
+    },
+    {
+      "id": "runner-worker",
+      "from": "runner",
+      "to": "worker",
+      "label": "NDJSON events",
+      "state": "current",
+      "seamId": "aci",
+      "bend": 24
+    },
+    {
+      "id": "runner-harness",
+      "from": "runner",
+      "to": "harness",
+      "label": "ModelSession",
+      "state": "current",
+      "seamId": "harness-modelsession",
+      "bend": 0
+    },
+    {
+      "id": "harness-model",
+      "from": "harness",
+      "to": "model",
+      "label": "provider call",
+      "state": "current",
+      "seamId": "model-provider",
+      "bend": 0
+    },
+    {
+      "id": "model-harness",
+      "from": "model",
+      "to": "harness",
+      "label": "streamed result",
+      "state": "current",
+      "seamId": "model-provider",
+      "bend": 19
+    },
+    {
+      "id": "worker-slack",
+      "from": "worker",
+      "to": "slack",
+      "label": "status / post / update",
+      "state": "current",
+      "seamId": "channel-reply",
+      "bend": -92
+    },
+    {
+      "id": "worker-email",
+      "from": "worker",
+      "to": "email",
+      "label": "HttpReplyAdapter /replies",
+      "state": "current",
+      "seamId": "channel-reply",
+      "bend": 16
+    },
+    {
+      "id": "worker-discord",
+      "from": "worker",
+      "to": "discord",
+      "label": "HttpReplyAdapter /replies",
+      "state": "current",
+      "seamId": "channel-reply",
+      "bend": -16
+    },
+    {
+      "id": "worker-channel-api",
+      "from": "worker",
+      "to": "channel-api",
+      "label": "neutral reply events",
+      "state": "current",
+      "seamId": "channel-reply",
+      "bend": 28
+    },
+    {
+      "id": "worker-approvals",
+      "from": "worker",
+      "to": "approvals",
+      "label": "AWAITING_APPROVAL",
+      "state": "current",
+      "seamId": "approval-authorizer",
+      "bend": 0
+    },
+    {
+      "id": "approvals-api",
+      "from": "approvals",
+      "to": "api",
+      "label": "persist / resolve",
+      "state": "current",
+      "seamId": "approval-authorizer",
+      "bend": 0
+    },
+    {
+      "id": "slack-api-approval",
+      "from": "slack",
+      "to": "api",
+      "label": "approve / reject",
+      "state": "current",
+      "seamId": "approval-principal",
+      "bend": 66
+    },
+    {
+      "id": "worker-api-approval",
+      "from": "worker",
+      "to": "api",
+      "label": "approval create",
+      "state": "current",
+      "seamId": "approval-authorizer",
+      "bend": 18
+    },
+    {
+      "id": "worker-api-eval-report",
+      "from": "worker",
+      "to": "api",
+      "label": "eval report",
+      "state": "current",
+      "seamId": "eval-store",
+      "bend": 30
+    },
+    {
+      "id": "runner-api-state",
+      "from": "runner",
+      "to": "api",
+      "label": "state get / put / list / delete / append",
+      "state": "current",
+      "seamId": "workflow-state",
+      "bend": 34
+    },
+    {
+      "id": "runner-api-memory",
+      "from": "runner",
+      "to": "api",
+      "label": "memory load / append / replace",
+      "state": "current",
+      "seamId": "memory",
+      "bend": 46
+    },
+    {
+      "id": "api-postgres",
+      "from": "api",
+      "to": "postgres",
+      "label": "control-plane state",
+      "state": "current",
+      "seamId": "relational-db",
+      "bend": 0
+    },
+    {
+      "id": "worker-postgres",
+      "from": "worker",
+      "to": "postgres",
+      "label": "binding read",
+      "state": "current",
+      "seamId": "relational-db",
+      "bend": 22
+    },
+    {
+      "id": "api-store",
+      "from": "api",
+      "to": "object-store",
+      "label": "store bundle",
+      "state": "current",
+      "seamId": "blob-storage",
+      "bend": -20
+    },
+    {
+      "id": "worker-store",
+      "from": "worker",
+      "to": "object-store",
+      "label": "load eval bundle",
+      "state": "current",
+      "seamId": "blob-storage",
+      "bend": 18
+    },
+    {
+      "id": "sandbox-store",
+      "from": "object-store",
+      "to": "sandbox",
+      "label": "bundle-fetch init",
+      "state": "current",
+      "seamId": "blob-storage",
+      "bend": -18
+    },
+    {
+      "id": "runner-otel",
+      "from": "runner",
+      "to": "otel",
+      "label": "OTLP spans",
+      "state": "current",
+      "seamId": "telemetry",
+      "bend": 0
+    },
+    {
+      "id": "otel-langfuse",
+      "from": "otel",
+      "to": "langfuse",
+      "label": "OTLP HTTP",
+      "state": "current",
+      "seamId": "telemetry",
+      "bend": 0
+    },
+    {
+      "id": "eval-langfuse",
+      "from": "eval-plane",
+      "to": "langfuse",
+      "label": "traces + scores",
+      "state": "current",
+      "seamId": "eval-store",
+      "bend": 0
+    },
+    {
+      "id": "api-langfuse",
+      "from": "langfuse",
+      "to": "api",
+      "label": "trace / matrix read",
+      "state": "current",
+      "seamId": "telemetry",
+      "bend": 32
+    },
+    {
+      "id": "api-github-status",
+      "from": "api",
+      "to": "github",
+      "label": "commit status; gate external",
+      "state": "current",
+      "seamId": "promotion-gate",
+      "bend": -34
+    },
+    {
+      "id": "worker-evals",
+      "from": "worker",
+      "to": "eval-plane",
+      "label": "run + grade cases",
+      "state": "current",
+      "seamId": "eval-scorer",
+      "bend": 0
+    },
+    {
+      "id": "sandbox-kubernetes",
+      "from": "kubernetes",
+      "to": "sandbox",
+      "label": "production claim",
+      "state": "current",
+      "seamId": "substrate",
+      "bend": -20
+    },
+    {
+      "id": "sandbox-docker",
+      "from": "docker",
+      "to": "sandbox",
+      "label": "local container",
+      "state": "current",
+      "seamId": "substrate",
+      "bend": 25
+    },
+    {
+      "id": "api-mcp-service",
+      "from": "api",
+      "to": "connector-host",
+      "label": "service-key binding",
+      "state": "current",
+      "seamId": "mcp-service-auth",
+      "bend": -26
+    },
+    {
+      "id": "runner-connectors",
+      "from": "runner",
+      "to": "connector-host",
+      "label": "MCP request / result",
+      "state": "current",
+      "seamId": "mcp-service-auth",
+      "bend": 0,
+      "bidirectional": true
+    },
+    {
+      "id": "worker-kubernetes-connectors",
+      "from": "worker",
+      "to": "kubernetes",
+      "label": "list / apply / delete connector workloads",
+      "state": "current",
+      "seamId": "connector-host",
+      "bend": 42
+    },
+    {
+      "id": "api-oauth-gateway",
+      "from": "api",
+      "to": "oauth-gateway",
+      "label": "principal + OAuth grant",
+      "state": "planned",
+      "seamId": "mcp-delegated-oauth",
+      "bend": 34
+    },
+    {
+      "id": "runner-oauth-gateway",
+      "from": "runner",
+      "to": "oauth-gateway",
+      "label": "principal-bound MCP",
+      "state": "planned",
+      "seamId": "mcp-delegated-oauth",
+      "bend": -12,
+      "bidirectional": true
+    },
+    {
+      "id": "oauth-gateway-host",
+      "from": "oauth-gateway",
+      "to": "connector-host",
+      "label": "OAuth-applied MCP",
+      "state": "planned",
+      "seamId": "mcp-delegated-oauth",
+      "bend": 0,
+      "bidirectional": true
+    },
+    {
+      "id": "proxy-model",
+      "from": "harness",
+      "to": "agent-proxy",
+      "label": "credential-free request",
+      "state": "planned",
+      "seamId": "agent-proxy",
+      "bend": 0
+    },
+    {
+      "id": "proxy-provider",
+      "from": "agent-proxy",
+      "to": "model",
+      "label": "authorized egress",
+      "state": "planned",
+      "seamId": "agent-proxy",
+      "bend": -18
+    }
+  ],
+  "flows": [
+    {
+      "id": "whole-system",
+      "label": "Whole system",
+      "state": "current",
+      "summary": "Every currently visible component and route in one architecture map. Choose a specific flow to isolate and walk its path.",
+      "showRouteLabels": false,
+      "steps": []
+    },
+    {
+      "id": "slack-turn",
+      "label": "Slack turn",
+      "state": "current",
+      "summary": "A mention becomes one queued, isolated, multi-turn model session and one edited thread reply.",
+      "steps": [
+        {
+          "routeId": "slack-dispatcher",
+          "title": "Receive and deduplicate",
+          "caption": "Bolt receives the mention; the dispatcher claims the event id and posts the placeholder."
+        },
+        {
+          "routeId": "dispatcher-queue",
+          "title": "Normalize ingress",
+          "caption": "The dispatcher serializes a channel-neutral QueuedTurn onto curie:runs."
+        },
+        {
+          "routeId": "queue-worker",
+          "title": "Claim delivery",
+          "caption": "The worker consumer group claims the event and acquires the conversation lock."
+        },
+        {
+          "routeId": "worker-sandbox",
+          "title": "Resolve and isolate",
+          "caption": "The binding selects agent, version, and bundle; SandboxClient claims or resumes the runtime."
+        },
+        {
+          "routeId": "worker-runner",
+          "title": "Start or steer",
+          "caption": "The worker sends event for a fresh turn or steer for a live one."
+        },
+        {
+          "routeId": "runner-api-memory",
+          "title": "Rehydrate durable memory",
+          "caption": "At boot the runner loads the agent memory log over the scoped state token before composing the effective prompt."
+        },
+        {
+          "routeId": "runner-harness",
+          "title": "Enter the harness",
+          "caption": "The runner translates the ACI request into the active ModelSession."
+        },
+        {
+          "routeId": "harness-model",
+          "title": "Run inference",
+          "caption": "The declared Claude harness calls the selected provider and streams its result."
+        },
+        {
+          "routeId": "runner-worker",
+          "title": "Stream outcomes",
+          "caption": "The runner emits text deltas, tool notes, side-effect markers, and a terminal result as NDJSON."
+        },
+        {
+          "routeId": "worker-slack",
+          "title": "Return to the surface",
+          "caption": "ReplySink updates the original placeholder and the worker acknowledges the stream entry."
+        }
+      ]
+    },
+    {
+      "id": "discord-turn",
+      "label": "Discord turn",
+      "state": "current",
+      "summary": "A Discord mention becomes a public thread, a platform-minted QueuedTurn, and streamed text edits on that thread.",
+      "steps": [
+        {
+          "routeId": "discord-channel-api",
+          "title": "Admit the mention",
+          "caption": "adapters/discord creates a public thread and placeholder, then posts to POST /channels/turns under a scoped channel token."
+        },
+        {
+          "routeId": "channel-api-queue",
+          "title": "Enter the same core",
+          "caption": "The API mints a channel-neutral QueuedTurn onto curie:runs."
+        },
+        {
+          "routeId": "queue-worker",
+          "title": "Claim delivery",
+          "caption": "The worker consumer group claims the event under one renewable fenced owner."
+        },
+        {
+          "routeId": "worker-sandbox",
+          "title": "Resolve and isolate",
+          "caption": "Multi-surface binding selects the agent by (kind, address) without cloning the bot identity."
+        },
+        {
+          "routeId": "worker-runner",
+          "title": "Start or steer",
+          "caption": "The worker sends event for a fresh turn or steer for a live one."
+        },
+        {
+          "routeId": "worker-discord",
+          "title": "Return to the thread",
+          "caption": "HttpReplyAdapter streams text edits to the Discord placeholder. Buttons and approvals are not implemented."
+        }
+      ]
+    },
+    {
+      "id": "approval-loop",
+      "label": "Approval + resume",
+      "state": "current",
+      "summary": "A gated tool call ends the turn, persists authority, suspends the sandbox, then resumes through a new queued event.",
+      "steps": [
+        {
+          "routeId": "worker-approvals",
+          "title": "Gate the side effect",
+          "caption": "The runner terminates AWAITING_APPROVAL; the kernel converts it into durable governance work."
+        },
+        {
+          "routeId": "approvals-api",
+          "title": "Persist the decision point",
+      "caption": "The API stores the approval, policy, requester, allowed approver set, and validated originating trace context."
+        },
+        {
+          "routeId": "worker-slack",
+          "title": "Render a semantic confirm",
+          "caption": "The worker posts a channel-neutral confirm intent; Slack renders the approval card."
+        },
+        {
+          "routeId": "slack-api-approval",
+          "title": "Authorize the human",
+          "caption": "Slack signs an approval-bound chat attestation; the API derives the principal and resolves membership without trusting caller-supplied identity or channel. A non-owning release acknowledges an exact record miss without changing the approval or card, leaving the owning release's compare-and-set as the only mutation path."
+        },
+        {
+          "routeId": "api-queue",
+          "title": "Queue a new resolution turn",
+      "caption": "The original event is already acknowledged; resolution enters as its own QueuedTurn under the stored trace context, while legacy or malformed carriers start clean roots."
+        },
+        {
+          "routeId": "queue-worker",
+          "title": "Reclaim the conversation",
+          "caption": "The worker restores the same thread affinity and suspended sandbox."
+        },
+        {
+          "routeId": "worker-runner",
+          "title": "Resume with one-shot allowance",
+          "caption": "The resolution turn tells the runner whether to continue or terminate the rejected action."
+        },
+        {
+          "routeId": "worker-slack",
+          "title": "Settle the surface",
+          "caption": "The card becomes non-interactive and the final reply returns to the same conversation."
+        }
+      ]
+    },
+    {
+      "id": "git-deploy",
+      "label": "PR / git deploy",
+      "state": "current",
+      "summary": "A development branch push becomes an immutable bundle, deployment, and eval fan-out; a production push promotes the stored artifact without cloning or rebuilding it.",
+      "steps": [
+        {
+          "routeId": "github-api",
+          "title": "Ingest a push",
+          "caption": "HMAC webhook or outbound commit poller converges on the same process_push function."
+        },
+        {
+          "routeId": "api-store",
+          "title": "Archive, validate, store",
+          "caption": "The API archives the SHA, validates the frozen plugin shape, and writes an immutable bundle."
+        },
+        {
+          "routeId": "api-postgres",
+          "title": "Create version + deployment",
+          "caption": "Dev branches activate the new version; production branches promote an existing artifact."
+        },
+        {
+          "routeId": "api-queue",
+          "title": "Fan out evals",
+          "caption": "A newly built development bundle appends one deduplicated EvalJob to curie:evals."
+        },
+        {
+          "routeId": "worker-evals",
+          "title": "Grade the exact bundle",
+          "caption": "The eval consumer loads cases from the immutable bundle and drives the runner."
+        },
+        {
+          "routeId": "eval-langfuse",
+          "title": "Record evidence",
+          "caption": "Each case writes a trace and eval score tagged by version and suite."
+        },
+        {
+          "routeId": "worker-api-eval-report",
+          "title": "Report the rollup",
+          "caption": "The worker posts the result to the API."
+        },
+        {
+          "routeId": "api-github-status",
+          "title": "Publish, but do not internally gate",
+          "caption": "GitHub receives a commit status; production promotion still relies on external policy rather than an API invariant."
+        }
+      ]
+    },
+    {
+      "id": "eval-loop",
+      "label": "Eval + parity ladder",
+      "state": "current",
+      "summary": "One bundle and one case file cross skill, local, local-release, and cluster to expose environment drift.",
+      "steps": [
+        {
+          "routeId": "api-store",
+          "title": "Pin the artifact",
+          "caption": "Bundle identity fixes the code, tools, and eval cases under test."
+        },
+        {
+          "routeId": "worker-store",
+          "title": "Load the suite",
+          "caption": "The worker reads evals/cases.json from that exact immutable bundle."
+        },
+        {
+          "routeId": "worker-sandbox",
+          "title": "Choose the required tier",
+          "caption": "Skill, Docker, released Compose, or Kubernetes changes only the substrate rung."
+        },
+        {
+          "routeId": "worker-runner",
+          "title": "Run a fresh case",
+          "caption": "Each case defaults to a fresh conversation and uses the same ACI loop."
+        },
+        {
+          "routeId": "worker-evals",
+          "title": "Score the outcome",
+          "caption": "Text graders and trajectory matching produce pass, fail, or plumbing-only."
+        },
+        {
+          "routeId": "eval-langfuse",
+          "title": "Persist the evidence",
+          "caption": "Traces and scores support the matrix and later diagnosis."
+        }
+      ]
+    },
+    {
+      "id": "observability",
+      "label": "Observability read/write",
+      "state": "current",
+      "summary": "Curie preserves valid ingress and approval trace lineage into OTLP; the API turns vendor reads back into Curie DTOs for agents and humans.",
+      "steps": [
+        {
+          "routeId": "runner-otel",
+          "title": "Emit the run",
+          "caption": "The runner writes an agent.run root plus real sibling provider-wait and tool-wait intervals, with bounded terminal and outcome attributes, over OTLP."
+        },
+        {
+          "routeId": "otel-langfuse",
+          "title": "Export once",
+          "caption": "The collector handles Langfuse authentication and HTTP-only OTLP ingest."
+        },
+        {
+          "routeId": "api-langfuse",
+          "title": "Reconstruct the evidence",
+          "caption": "The API reads traces, builds the tool tree, and proxies metrics and cost."
+        },
+        {
+          "routeId": "console-api",
+          "title": "Expose one read surface",
+          "caption": "Console and CLI use Curie API shapes instead of talking to Langfuse directly."
+        }
+      ]
+    },
+    {
+      "id": "mcp-service-call",
+      "label": "MCP with service key",
+      "state": "current",
+      "summary": "Today an MCP connector acts as a deployment-owned bot or service account: the platform binds its named secret and the runner talks through the collapsed MCP host boundary.",
+      "steps": [
+        {
+          "routeId": "worker-kubernetes-connectors",
+          "title": "Reconcile the hosted workload",
+          "caption": "The worker uses ConnectorClient to list, apply, and delete the Kubernetes connector resources derived from the bundle."
+        },
+        {
+          "routeId": "api-mcp-service",
+          "title": "Bind the service identity",
+          "caption": "The bundle names the connector secret; deployment configuration supplies the value and the platform injects it into the hosted MCP connector."
+        },
+        {
+          "routeId": "runner-connectors",
+          "title": "Call the MCP server",
+          "caption": "The runner exchanges MCP requests and results with the hosted connector. Every human currently shares the deployment's service authority."
+        }
+      ]
+    },
+    {
+      "id": "mcp-delegated-oauth",
+      "label": "Future per-person MCP OAuth",
+      "state": "planned",
+      "summary": "The accepted vision binds each run's canonical human principal to that person's OAuth grant. Curie applies the grant at a gateway, and the runner never receives the raw token.",
+      "steps": [
+        {
+          "routeId": "api-oauth-gateway",
+          "title": "Resolve principal and grant",
+          "caption": "The control plane owns OAuth discovery, PKCE, encrypted token storage, refresh, revocation, and the principal-to-grant binding."
+        },
+        {
+          "routeId": "runner-oauth-gateway",
+          "title": "Call as the run principal",
+          "caption": "The runner sends a principal-bound MCP request to the gateway without receiving a provider token."
+        },
+        {
+          "routeId": "oauth-gateway-host",
+          "title": "Apply delegated authority",
+          "caption": "The gateway applies only that principal's active grant and exchanges MCP traffic with the declared server. Missing auth pauses the run for a connection action, then resumes after callback."
+        }
+      ]
+    },
+    {
+      "id": "email-turn",
+      "label": "Email turn",
+      "state": "current",
+      "summary": "The first-party mail adapter polls AgentMail, the API mints a QueuedTurn, and HttpReplyAdapter returns one threaded email at turn.completed.",
+      "steps": [
+        {
+          "routeId": "email-adapter",
+          "title": "Poll and admit",
+          "caption": "apps/mail-adapter polls AgentMail, applies provider and allow-list filters, and keeps delivery ownership in local SQLite."
+        },
+        {
+          "routeId": "email-adapter",
+          "title": "Use the shipped HTTP edge",
+          "caption": "The adapter authenticates with a row-scoped chn token and posts the provider message id as the delivery id."
+        },
+        {
+          "routeId": "channel-api-queue",
+          "title": "Enter the same core",
+          "caption": "The API, not the adapter, mints the same QueuedTurn used by Slack, Discord, and the CLI stub."
+        },
+        {
+          "routeId": "queue-worker",
+          "title": "Reuse the worker invariants",
+          "caption": "Routing, concurrency, sandboxing, and renewable delivery ownership remain unchanged."
+        },
+        {
+          "routeId": "worker-runner",
+          "title": "Reuse the ACI",
+          "caption": "The agent does not learn which channel started the turn."
+        },
+        {
+          "routeId": "worker-email",
+          "title": "Send one threaded reply",
+          "caption": "HttpReplyAdapter posts the four reply events to the mail adapter; one turn.completed becomes one correspondent-visible email."
+        }
+      ]
+    },
+    {
+      "id": "webhook-turn",
+      "label": "Generic webhook turn",
+      "state": "current",
+      "summary": "A named HMAC-authenticated hook becomes a bounded webhook-sourced turn on the shared run stream.",
+      "steps": [
+        {
+          "routeId": "external-hook-api",
+          "title": "Authenticate the named hook",
+          "caption": "The API verifies the per-hook HMAC and resolves the target agent."
+        },
+        {
+          "routeId": "api-queue",
+          "title": "Mint the platform turn",
+          "caption": "The API creates the typed webhook-sourced QueuedTurn with bounded delivery metadata and an escaped, explicitly delimited untrusted payload."
+        },
+        {
+          "routeId": "queue-worker",
+          "title": "Reuse bounded delivery",
+          "caption": "The shared consumer claims, caps, and dead-letters the hook turn like other run traffic."
+        },
+        {
+          "routeId": "worker-runner",
+          "title": "Run through the same ACI",
+          "caption": "The worker drives the selected bundle without a channel adapter in the path."
+        }
+      ]
+    },
+    {
+      "id": "future-hooks",
+      "label": "Future bundle hooks",
+      "state": "planned",
+      "summary": "Generic webhook consumption ships; bundle-declared hook installation and scheduled turns remain planned.",
+      "steps": [
+        {
+          "routeId": "external-hook-api",
+          "title": "Reuse API-owned ingress",
+          "caption": "A future declaration resolves onto the shipped named-hook endpoint rather than a new dispatcher."
+        },
+        {
+          "routeId": "api-queue",
+          "title": "Create a typed turn",
+          "caption": "A new event kind would carry source, authorization, concurrency, expiry, and delivery policy."
+        },
+        {
+          "routeId": "queue-worker",
+          "title": "Reuse bounded delivery",
+          "caption": "The shared stream consumer must still cap attempts, dead-letter, and expose failure."
+        }
+      ]
+    }
+  ],
+  "adrs": [
+    {
+      "id": "ADR-0002",
+      "number": 2,
+      "title": "Kubernetes Agent Sandbox as the interactive runtime substrate",
+      "status": "accepted",
+      "implementation": "implemented",
+      "summary": "Kubernetes is the production runtime substrate; Docker is the parity implementation behind SandboxClient.",
+      "nodeIds": [
+        "sandbox",
+        "kubernetes",
+        "docker"
+      ],
+      "seamIds": [
+        "substrate"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/687322e4be896e2ef1fe63770eac1ed040ccaa5c/docs/adr/0002-kubernetes-agent-sandbox-as-runtime-substrate.md"
+    },
+    {
+      "id": "ADR-0005",
+      "number": 5,
+      "title": "claude-agent-sdk adapter behind a frozen ACI",
+      "status": "accepted",
+      "implementation": "partial",
+      "summary": "The outer protocol is strong; the in-runner message types and plugin format retain Claude coupling.",
+      "nodeIds": [
+        "runner",
+        "harness"
+      ],
+      "seamIds": [
+        "aci",
+        "harness-modelsession"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/687322e4be896e2ef1fe63770eac1ed040ccaa5c/docs/adr/0005-claude-agent-sdk-adapter-and-frozen-aci.md"
+    },
+    {
+      "id": "ADR-0009",
+      "number": 9,
+      "title": "Per-agent connector auth",
+      "status": "accepted",
+      "implementation": "implemented",
+      "summary": "Connector credentials are named by the bundle and supplied per deployment, giving current MCP servers one service or bot identity rather than a human principal.",
+      "nodeIds": [
+        "api",
+        "connector-host"
+      ],
+      "seamIds": [
+        "mcp-service-auth",
+        "sealed-credential"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/687322e4be896e2ef1fe63770eac1ed040ccaa5c/docs/adr/0009-per-agent-connector-auth.md"
+    },
+    {
+      "id": "ADR-0010",
+      "number": 10,
+      "title": "Approval gates and human-in-the-loop",
+      "status": "accepted",
+      "implementation": "implemented",
+      "summary": "A gated turn persists a durable decision and resumes later through a new event.",
+      "nodeIds": [
+        "approvals",
+        "worker",
+        "slack"
+      ],
+      "seamIds": [
+        "approval-authorizer",
+        "channel-interaction"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/687322e4be896e2ef1fe63770eac1ed040ccaa5c/docs/adr/0010-approval-gates-and-human-in-the-loop.md"
+    },
+    {
+      "id": "ADR-0014",
+      "number": 14,
+      "title": "A git push is the deploy",
+      "status": "accepted",
+      "implementation": "partial",
+      "summary": "Git flow, immutable bundles, and eval fan-out are built; a red eval does not yet universally enforce promotion.",
+      "nodeIds": [
+        "github",
+        "api",
+        "eval-plane",
+        "object-store"
+      ],
+      "seamIds": [
+        "triggers",
+        "bundle-format",
+        "eval-scorer"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/687322e4be896e2ef1fe63770eac1ed040ccaa5c/docs/adr/0014-git-push-is-the-deploy.md"
+    },
+    {
+      "id": "ADR-0016",
+      "number": 16,
+      "title": "Swappable jobs around an opinionated core",
+      "status": "accepted",
+      "implementation": "guiding",
+      "summary": "One curated default per job; a second implementation teaches the interface instead of a speculative registry.",
+      "nodeIds": [
+        "worker",
+        "runner",
+        "api"
+      ],
+      "seamIds": [
+        "aci",
+        "channel-ingress",
+        "telemetry",
+        "blob-storage",
+        "relational-db"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/687322e4be896e2ef1fe63770eac1ed040ccaa5c/docs/adr/0016-swappable-jobs-around-an-opinionated-core.md"
+    },
+    {
+      "id": "ADR-0020",
+      "number": 20,
+      "title": "Rendering-free channel interface",
+      "status": "accepted",
+      "implementation": "partial",
+      "summary": "Semantic Choice and Confirm still render in Slack and terminal. Discord and email are shipped text surfaces; capability negotiation remains open.",
+      "nodeIds": [
+        "slack",
+        "cli",
+        "discord",
+        "email"
+      ],
+      "seamIds": [
+        "channel-ingress",
+        "channel-reply",
+        "channel-interaction"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/687322e4be896e2ef1fe63770eac1ed040ccaa5c/docs/adr/0020-message-port-rendering-free-channel-interface.md"
+    },
+    {
+      "id": "ADR-0025",
+      "number": 25,
+      "title": "Memory port and first loader",
+      "status": "accepted",
+      "implementation": "implemented",
+      "summary": "Scoped state-backed agent memory reaches the runner as a harness-neutral boot preamble.",
+      "nodeIds": [
+        "runner",
+        "postgres",
+        "api"
+      ],
+      "seamIds": [
+        "memory",
+        "workflow-state"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/687322e4be896e2ef1fe63770eac1ed040ccaa5c/docs/adr/0025-memory-port-and-first-loader.md"
+    },
+    {
+      "id": "ADR-0029",
+      "number": 29,
+      "title": "Conversation-history port and first loader",
+      "status": "accepted",
+      "implementation": "implemented",
+      "summary": "A fresh or restarted sandbox rehydrates the same thread from durable transcript state, without SDK-native resume.",
+      "nodeIds": [
+        "runner",
+        "postgres",
+        "api"
+      ],
+      "seamIds": [
+        "conversation-history",
+        "workflow-state"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/687322e4be896e2ef1fe63770eac1ed040ccaa5c/docs/adr/0029-conversation-history-port-and-first-loader.md"
+    },
+    {
+      "id": "ADR-0030",
+      "number": 30,
+      "title": "Proactive within-episode memory agent",
+      "status": "accepted",
+      "implementation": "planned",
+      "summary": "Drafts an injected within-episode memory agent; automatic generation remains absent.",
+      "nodeIds": [
+        "runner"
+      ],
+      "seamIds": [
+        "memory"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/687322e4be896e2ef1fe63770eac1ed040ccaa5c/docs/adr/0030-proactive-within-episode-memory-agent.md"
+    },
+    {
+      "id": "ADR-0042",
+      "number": 42,
+      "title": "LLM-as-a-Verifier grader and progress signal",
+      "status": "accepted",
+      "implementation": "reserved",
+      "summary": "The semantic provenance grader is an accepted slot, but no verifier grader exists in Python or Rust today.",
+      "nodeIds": [
+        "eval-plane"
+      ],
+      "seamIds": [
+        "eval-scorer"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/687322e4be896e2ef1fe63770eac1ed040ccaa5c/docs/adr/0042-llm-as-a-verifier-grader-and-progress-signal.md"
+    },
+    {
+      "id": "ADR-0060",
+      "number": 60,
+      "title": "The harness is a declared package",
+      "status": "accepted",
+      "implementation": "implemented",
+      "summary": "Harness assets and selection are declared; only the built-in Claude contribution exists.",
+      "nodeIds": [
+        "harness",
+        "runner"
+      ],
+      "seamIds": [
+        "harness-package",
+        "harness-modelsession"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/687322e4be896e2ef1fe63770eac1ed040ccaa5c/docs/adr/0060-the-harness-is-a-declared-package.md"
+    },
+    {
+      "id": "ADR-0061",
+      "number": 61,
+      "title": "Out-of-process harness boundary",
+      "status": "draft",
+      "implementation": "planned",
+      "summary": "Would make alternate harness adapters consumable out of process across an Omnigent-compatible wire.",
+      "nodeIds": [
+        "runner",
+        "harness"
+      ],
+      "seamIds": [
+        "aci",
+        "harness-modelsession"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/687322e4be896e2ef1fe63770eac1ed040ccaa5c/docs/adr/0061-out-of-process-harness-boundary.md"
+    },
+    {
+      "id": "ADR-0062",
+      "number": 62,
+      "title": "Harness conformance has teeth",
+      "status": "accepted",
+      "implementation": "partial",
+      "summary": "A reusable conformance suite exists; third-party production contributions have not yet proved it.",
+      "nodeIds": [
+        "runner",
+        "harness"
+      ],
+      "seamIds": [
+        "aci",
+        "harness-package"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/687322e4be896e2ef1fe63770eac1ed040ccaa5c/docs/adr/0062-harness-conformance-has-teeth.md"
+    },
+    {
+      "id": "ADR-0075",
+      "number": 75,
+      "title": "Agent Proxy credential and egress boundary",
+      "status": "accepted",
+      "implementation": "planned",
+      "summary": "Accepts moving credentials and enforceable FQDN egress outside the sandbox; substrate, TLS termination, credential injection, and implementation remain follow-up work.",
+      "nodeIds": [
+        "agent-proxy",
+        "sandbox",
+        "model"
+      ],
+      "seamIds": [
+        "agent-proxy",
+        "model-provider"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/617df5bef46864f9abd7d01ac630ac672100afdd/docs/adr/0075-the-agent-proxy-credential-and-egress-boundary.md"
+    },
+    {
+      "id": "ADR-0079",
+      "number": 79,
+      "title": "Inbound triggers as a new event kind",
+      "status": "accepted",
+      "implementation": "implemented",
+      "summary": "API-owned, HMAC-authenticated generic hooks mint typed webhook-sourced turns; declaration installation and schedules remain future work.",
+      "nodeIds": [
+        "external-hook",
+        "api",
+        "queue",
+        "worker"
+      ],
+      "seamIds": [
+        "triggers",
+        "queue-stream"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/687322e4be896e2ef1fe63770eac1ed040ccaa5c/docs/adr/0079-inbound-triggers-as-a-new-event-kind.md"
+    },
+    {
+      "id": "ADR-0094",
+      "number": 94,
+      "title": "A bundle carries its own sealed connector keys",
+      "status": "accepted",
+      "implementation": "partial",
+      "summary": "Defines the cross-language sealed-box wire and cluster-owned opening key; end-to-end production delivery is not yet fully connected.",
+      "nodeIds": [
+        "api",
+        "connector-host",
+        "kubernetes"
+      ],
+      "seamIds": [
+        "sealed-credential",
+        "mcp-service-auth"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/687322e4be896e2ef1fe63770eac1ed040ccaa5c/docs/adr/0094-a-bundle-carries-its-own-sealed-connector-keys.md"
+    },
+    {
+      "id": "ADR-0086",
+      "number": 86,
+      "title": "Bundles declare connectors; the platform hosts them",
+      "status": "accepted",
+      "implementation": "partial",
+      "summary": "The bundle declares MCP connectors and Curie derives their hosted runtime, secrets, policy, and MCP configuration; lifecycle portability remains intertwined with Kubernetes.",
+      "nodeIds": [
+        "api",
+        "connector-host"
+      ],
+      "seamIds": [
+        "connector-host",
+        "mcp-service-auth"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/687322e4be896e2ef1fe63770eac1ed040ccaa5c/docs/adr/0086-bundles-declare-connectors-the-platform-hosts-them.md"
+    },
+    {
+      "id": "ADR-0088",
+      "number": 88,
+      "title": "Per-user delegated OAuth for MCP",
+      "status": "accepted",
+      "implementation": "planned",
+      "summary": "Defines principal-scoped OAuth, control-plane-owned grants, a token-hiding MCP gateway, and missing-auth pause and resume semantics. The service-key mode remains separate and cannot silently substitute.",
+      "nodeIds": [
+        "api",
+        "runner",
+        "oauth-gateway",
+        "connector-host",
+        "approvals"
+      ],
+      "seamIds": [
+        "mcp-delegated-oauth",
+        "mcp-service-auth",
+        "approval-authorizer"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/687322e4be896e2ef1fe63770eac1ed040ccaa5c/docs/adr/0088-per-user-delegated-oauth-for-mcp.md"
+    },
+    {
+      "id": "ADR-0095",
+      "number": 95,
+      "title": "Tiered memory lifecycle",
+      "status": "draft",
+      "implementation": "planned",
+      "summary": "Defines agent and channel memory tiers, lifecycle turns, trust, and bootstrap/update obligations.",
+      "nodeIds": [
+        "runner",
+        "api",
+        "postgres"
+      ],
+      "seamIds": [
+        "memory",
+        "workflow-state"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/687322e4be896e2ef1fe63770eac1ed040ccaa5c/docs/adr/0095-tiered-memory-lifecycle.md"
+    },
+    {
+      "id": "ADR-0096",
+      "number": 96,
+      "title": "Port adapters are deployed services",
+      "status": "accepted",
+      "implementation": "partial",
+      "summary": "First-party Discord and email adapters are deployed services on the shipped HTTP edge. The generic third-party adapter kit remains unbuilt.",
+      "nodeIds": [
+        "port-adapter",
+        "slack",
+        "discord",
+        "email"
+      ],
+      "seamIds": [
+        "port-adapter-service",
+        "channel-ingress",
+        "channel-reply"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/687322e4be896e2ef1fe63770eac1ed040ccaa5c/docs/adr/0096-port-adapters-are-deployed-services.md"
+    },
+    {
+      "id": "ADR-0099",
+      "number": 99,
+      "title": "Hooks are bundle-declared turns",
+      "status": "draft",
+      "implementation": "planned",
+      "summary": "Drafts scheduled and webhook turns with authorization, silence, concurrency, and test-fire semantics.",
+      "nodeIds": [
+        "api",
+        "queue",
+        "worker"
+      ],
+      "seamIds": [
+        "triggers"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/687322e4be896e2ef1fe63770eac1ed040ccaa5c/docs/adr/0099-hooks-are-bundle-declared-turns-the-system-starts.md"
+    },
+    {
+      "id": "ADR-0100",
+      "number": 100,
+      "title": "Agents search their own surface through the channel port",
+      "status": "draft",
+      "implementation": "planned",
+      "summary": "Proposes a spike before committing channel search verbs; intentionally not current behavior.",
+      "nodeIds": [
+        "slack",
+        "port-adapter"
+      ],
+      "seamIds": [
+        "channel-ingress",
+        "port-adapter-service"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/687322e4be896e2ef1fe63770eac1ed040ccaa5c/docs/adr/0100-agents-search-their-own-surface-through-the-channel-port.md"
+    },
+    {
+      "id": "ADR-0105",
+      "number": 105,
+      "title": "External native session checkpoints",
+      "status": "draft",
+      "implementation": "planned",
+      "summary": "Makes provider-native checkpoints an optional harness capability while retaining portable projection.",
+      "nodeIds": [
+        "harness",
+        "runner",
+        "object-store"
+      ],
+      "seamIds": [
+        "harness-modelsession",
+        "conversation-history"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/687322e4be896e2ef1fe63770eac1ed040ccaa5c/docs/adr/0105-external-native-session-checkpoints.md"
+    },
+    {
+      "id": "ADR-0106",
+      "number": 106,
+      "title": "An approver is an authenticated principal",
+      "status": "accepted",
+      "implementation": "implemented",
+      "summary": "Approval resolution derives authenticated chat, Console, or operator principals from credentials; membership, not requester inequality, decides authority, and the platform key alone cannot resolve.",
+      "nodeIds": [
+        "approvals",
+        "api"
+      ],
+      "seamIds": [
+        "approval-authorizer",
+        "approval-principal"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/617df5bef46864f9abd7d01ac630ac672100afdd/docs/adr/0106-an-approver-is-an-authenticated-principal.md"
+    },
+    {
+      "id": "ADR-0107",
+      "number": 107,
+      "title": "An agent reads its own runs",
+      "status": "draft",
+      "implementation": "planned",
+      "summary": "Proposes a first-party scoped runs MCP surface with structured attribution and fail-closed identity.",
+      "nodeIds": [
+        "runner",
+        "api",
+        "langfuse"
+      ],
+      "seamIds": [
+        "telemetry",
+        "connector-host"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/687322e4be896e2ef1fe63770eac1ed040ccaa5c/docs/adr/0107-an-agent-reads-its-own-runs-through-a-first-party-scoped-surface.md"
+    },
+    {
+      "id": "ADR-0108",
+      "number": 108,
+      "title": "Deploy targets carry environment values",
+      "status": "draft",
+      "implementation": "planned",
+      "summary": "Moves environment-specific non-secret values onto deploy targets while preserving connector declaration shape.",
+      "nodeIds": [
+        "api",
+        "github",
+        "connector-host"
+      ],
+      "seamIds": [
+        "bundle-format",
+        "connector-host"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/687322e4be896e2ef1fe63770eac1ed040ccaa5c/docs/adr/0108-a-deploy-target-carries-its-environments-values.md"
+    },
+    {
+      "id": "ADR-0109",
+      "number": 109,
+      "title": "Retention, capacity, and back pressure are one policy",
+      "status": "draft",
+      "implementation": "planned",
+      "summary": "Would admit claims against a coherent capacity policy instead of discovering overload after launch.",
+      "nodeIds": [
+        "worker",
+        "sandbox",
+        "postgres"
+      ],
+      "seamIds": [
+        "substrate",
+        "workflow-state"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/687322e4be896e2ef1fe63770eac1ed040ccaa5c/docs/adr/0109-retention-capacity-and-back-pressure-are-one-policy.md"
+    },
+    {
+      "id": "ADR-0110",
+      "number": 110,
+      "title": "Deterministic security posture classification",
+      "status": "draft",
+      "implementation": "planned",
+      "summary": "Computes posture from shipped layers and operator gates instead of trusting a configured label.",
+      "nodeIds": [
+        "sandbox",
+        "api",
+        "connector-host"
+      ],
+      "seamIds": [
+        "connector-host",
+        "agent-proxy"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/687322e4be896e2ef1fe63770eac1ed040ccaa5c/docs/adr/0110-deterministic-security-posture-classification.md"
+    },
+    {
+      "id": "ADR-0111",
+      "number": 111,
+      "title": "Default memory compaction algorithm",
+      "status": "draft",
+      "implementation": "planned",
+      "summary": "Drafts opt-in, from-source compaction with validation, scope defaults, and an auditable write path.",
+      "nodeIds": [
+        "runner",
+        "api",
+        "postgres"
+      ],
+      "seamIds": [
+        "memory",
+        "conversation-history"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/687322e4be896e2ef1fe63770eac1ed040ccaa5c/docs/adr/0111-the-default-memory-compaction-algorithm.md"
+    },
+    {
+      "id": "ADR-0116",
+      "number": 116,
+      "title": "Session identity arrives over the ACI so a sandbox can be pre-bound",
+      "status": "accepted",
+      "implementation": "implemented",
+      "summary": "The claim path can bind a warm sandbox before the turn by passing session identity over the ACI, without changing isolation rails.",
+      "nodeIds": [
+        "sandbox",
+        "runner",
+        "worker"
+      ],
+      "seamIds": [
+        "aci",
+        "substrate"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/687322e4be896e2ef1fe63770eac1ed040ccaa5c/docs/adr/0116-session-identity-arrives-over-the-aci-so-a-sandbox-can-be-pre-bound.md"
+    },
+    {
+      "id": "ADR-0117",
+      "number": 117,
+      "title": "A tool that changes the world reports what it changed",
+      "status": "accepted",
+      "implementation": "partial",
+      "summary": "A mutating tool reports the world change so the platform can restore it later. Restore remains a connector-owned verb under a draft follow-up.",
+      "nodeIds": [
+        "runner",
+        "connector-host"
+      ],
+      "seamIds": [
+        "connector-host",
+        "aci"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/687322e4be896e2ef1fe63770eac1ed040ccaa5c/docs/adr/0117-a-tool-that-changes-the-world-reports-what-it-changed.md"
+    },
+    {
+      "id": "ADR-0118",
+      "number": 118,
+      "title": "Binding cardinality is the multi-surface opt-in",
+      "status": "accepted",
+      "implementation": "implemented",
+      "summary": "One agent may bind several (kind, address) surfaces. Adding Discord or email does not clone the bot identity.",
+      "nodeIds": [
+        "api",
+        "worker",
+        "slack",
+        "discord",
+        "email"
+      ],
+      "seamIds": [
+        "channel-ingress",
+        "channel-reply"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/687322e4be896e2ef1fe63770eac1ed040ccaa5c/docs/adr/0118-binding-cardinality-is-the-multi-surface-opt-in.md"
+    },
+    {
+      "id": "ADR-0120",
+      "number": 120,
+      "title": "Durable first-party email state",
+      "status": "accepted",
+      "implementation": "implemented",
+      "summary": "The mail adapter keeps ingress and reply ownership in local SQLite with one serialized writer, not in-process maps.",
+      "nodeIds": [
+        "email",
+        "channel-api"
+      ],
+      "seamIds": [
+        "channel-ingress",
+        "channel-reply"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/687322e4be896e2ef1fe63770eac1ed040ccaa5c/docs/adr/0120-durable-first-party-email-state.md"
+    },
+    {
+      "id": "ADR-0123",
+      "number": 123,
+      "title": "A pending approval's approver set does not follow its route binding",
+      "status": "accepted",
+      "implementation": "implemented",
+      "summary": "The allowed approver set is captured when the approval is created and does not track a later binding change.",
+      "nodeIds": [
+        "approvals",
+        "api"
+      ],
+      "seamIds": [
+        "approval-authorizer"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/687322e4be896e2ef1fe63770eac1ed040ccaa5c/docs/adr/0123-a-pending-approvals-approver-set-does-not-follow-its-route-binding.md"
+    },
+    {
+      "id": "ADR-0125",
+      "number": 125,
+      "title": "Managed repository workspaces and approval-gated publication",
+      "status": "accepted",
+      "implementation": "implemented",
+      "summary": "The platform clones and publishes through its own GitHub identity. Write credentials do not remain inside the sandbox.",
+      "nodeIds": [
+        "github",
+        "api",
+        "sandbox"
+      ],
+      "seamIds": [
+        "triggers",
+        "approval-authorizer"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/687322e4be896e2ef1fe63770eac1ed040ccaa5c/docs/adr/0125-managed-repository-workspaces-and-approval-gated-publication.md"
+    },
+    {
+      "id": "ADR-0126",
+      "number": 126,
+      "title": "Runtime repository selection is sticky authorized thread state",
+      "status": "accepted",
+      "implementation": "implemented",
+      "summary": "The selected repository sticks on the thread as authorized state rather than being re-derived from the prompt.",
+      "nodeIds": [
+        "api",
+        "github",
+        "runner"
+      ],
+      "seamIds": [
+        "workflow-state"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/687322e4be896e2ef1fe63770eac1ed040ccaa5c/docs/adr/0126-runtime-repository-selection-is-sticky-authorized-thread-state.md"
+    },
+    {
+      "id": "ADR-0130",
+      "number": 130,
+      "title": "Deliberate progress is bounded durable channel state",
+      "status": "accepted",
+      "implementation": "implemented",
+      "summary": "Progress is durable channel state with a bound, not a substitute for streaming the final answer.",
+      "nodeIds": [
+        "worker",
+        "slack"
+      ],
+      "seamIds": [
+        "channel-reply",
+        "channel-interaction"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/687322e4be896e2ef1fe63770eac1ed040ccaa5c/docs/adr/0130-deliberate-progress-is-bounded-durable-channel-state.md"
+    },
+    {
+      "id": "ADR-0131",
+      "number": 131,
+      "title": "A delivery has one deadline and one renewable fenced owner",
+      "status": "accepted",
+      "implementation": "implemented",
+      "summary": "Stream delivery ownership is a renewable fence with one deadline. A second replica cannot steal a live delivery.",
+      "nodeIds": [
+        "queue",
+        "worker"
+      ],
+      "seamIds": [
+        "queue-stream"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/687322e4be896e2ef1fe63770eac1ed040ccaa5c/docs/adr/0131-a-delivery-has-one-deadline-and-one-renewable-fenced-owner.md"
+    },
+    {
+      "id": "ADR-0134",
+      "number": 134,
+      "title": "A hook shares one thread per partition",
+      "status": "draft",
+      "implementation": "planned",
+      "summary": "Drafts per-delivery conversation identity for hooks so concurrent firings do not share one thread by default.",
+      "nodeIds": [
+        "external-hook",
+        "api",
+        "queue"
+      ],
+      "seamIds": [
+        "triggers"
+      ],
+      "href": "https://github.com/curie-eng/curie/blob/687322e4be896e2ef1fe63770eac1ed040ccaa5c/docs/adr/0134-a-hook-shares-one-thread-per-partition.md"
+    }
+  ],
+  "investments": [
+    {
+      "rank": 1,
+      "title": "Close remaining channel interaction and the generic adapter kit",
+      "seamIds": [
+        "channel-reply",
+        "channel-interaction",
+        "port-adapter-service",
+        "approval-principal"
+      ],
+      "why": "Slack, Discord, and email now prove ingress and HTTP reply. Approvals, Choice/Confirm, and the generic third-party adapter kit are still Slack-only or unbuilt, and the generated catalog still counts one implementation.",
+      "unlock": "Discord or email approvals, a truthful Communication grade, and a kit only if a third-party channel needs it.",
+      "factors": {
+        "flowImpact": 4,
+        "visionUnlock": 4,
+        "couplingRisk": 3,
+        "evidenceGap": 3,
+        "effort": 4
+      }
+    },
+    {
+      "rank": 2,
+      "title": "Run a genuinely different harness through the ACI",
+      "seamIds": [
+        "harness-modelsession",
+        "aci",
+        "harness-package"
+      ],
+      "why": "The outer contract is strong, but the current in-process path and bundle distribution wedge still hide the real replacement cost.",
+      "unlock": "Credible Codex/ADK/Strands support, truthful harness conformance, optional native checkpoints.",
+      "factors": {
+        "flowImpact": 5,
+        "visionUnlock": 5,
+        "couplingRisk": 5,
+        "evidenceGap": 4,
+        "effort": 5
+      }
+    },
+    {
+      "rank": 3,
+      "title": "Close the semantic eval and promotion gap",
+      "seamIds": [
+        "eval-scorer",
+        "eval-store",
+        "promotion-gate"
+      ],
+      "why": "The parity ladder is the product promise, but provenance quality and red-eval promotion still have reserved or validated-only clauses.",
+      "unlock": "Fatal cluster quality gates, meaningful source verification, stronger PR-to-production trust.",
+      "factors": {
+        "flowImpact": 4,
+        "visionUnlock": 5,
+        "couplingRisk": 3,
+        "evidenceGap": 4,
+        "effort": 4
+      }
+    },
+    {
+      "rank": 4,
+      "title": "Unify generic trigger and hook lifecycle",
+      "seamIds": [
+        "triggers",
+        "queue-stream"
+      ],
+      "why": "Three trigger paths exist, but they are hardcoded lanes rather than one typed, bounded event lifecycle.",
+      "unlock": "Bundle-declared schedules/webhooks, explicit delivery destinations, shared concurrency and failure semantics.",
+      "factors": {
+        "flowImpact": 4,
+        "visionUnlock": 4,
+        "couplingRisk": 4,
+        "evidenceGap": 5,
+        "effort": 4
+      }
+    },
+    {
+      "rank": 5,
+      "title": "Move credentials and enforceable egress out of the sandbox",
+      "seamIds": [
+        "agent-proxy",
+        "connector-host",
+        "mcp-service-auth",
+        "mcp-delegated-oauth",
+        "sealed-credential"
+      ],
+      "why": "The current service-key path and accepted delegated-OAuth design expose the same unresolved security boundary: credentials, principal binding, and enforceable egress still span several owners.",
+      "unlock": "Stronger tenant isolation, explicit service versus delegated identity, per-person MCP authority, centralized credential policy, and auditable outbound access.",
+      "factors": {
+        "flowImpact": 4,
+        "visionUnlock": 4,
+        "couplingRisk": 5,
+        "evidenceGap": 5,
+        "effort": 5
+      }
+    },
+    {
+      "rank": 6,
+      "title": "Neutralize the observability read side",
+      "seamIds": [
+        "telemetry",
+        "eval-store"
+      ],
+      "why": "OTLP is already a good write port; vendor attributes, route names, and read modules are the remaining concentrated leakage.",
+      "unlock": "A practical second trace backend without UI or API contract churn.",
+      "factors": {
+        "flowImpact": 3,
+        "visionUnlock": 3,
+        "couplingRisk": 2,
+        "evidenceGap": 3,
+        "effort": 2
+      }
+    }
+  ]
+}

--- a/docs/architecture-atlas/versions.json
+++ b/docs/architecture-atlas/versions.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.0",
-  "defaultVersion": "v0.8.4",
+  "defaultVersion": "v0.8.5",
   "versions": [
     {
       "id": "v0.7.1",
@@ -65,6 +65,14 @@
       "date": "2026-09-02",
       "branch": "main",
       "commit": "5185e6bf5c153271ec9eb37fd84334c59b3f4a5f"
+    },
+    {
+      "id": "v0.8.5",
+      "label": "v0.8.5",
+      "file": "snapshots/v0.8.5.json",
+      "date": "2026-09-03",
+      "branch": "main",
+      "commit": "69cbe26af299e01d16b2e667e627a0b672238662"
     }
   ]
 }

--- a/docs/guides/deciding-what-belongs-in-a-connector.md
+++ b/docs/guides/deciding-what-belongs-in-a-connector.md
@@ -1,0 +1,181 @@
+# Deciding what belongs in a connector
+
+Connectors are the platform's answer to "the sandbox must not hold this". What
+they are *for* is well covered by [ADR-0075](../adr/0075-the-agent-proxy-credential-and-egress-boundary.md)
+puts the credential on the far side of the sandbox boundary, and
+[ADR-0086](../adr/0086-bundles-declare-connectors-the-platform-hosts-them.md)
+makes a bundle declare one and the platform run it.
+
+What none of them says is what should stay **out**. This guide is that half: a
+test for whether a piece of work belongs in a connector at all, and where to
+spend a boundary when you only get to spend it once.
+
+## 1. The three-way test
+
+For each piece of work, decide which of three things it is.
+
+| It is a… | Example | Where it goes |
+|---|---|---|
+| **Credential** | an API token, a client secret, a kubeconfig | Connector |
+| **Capability** | writing to a storage location, patching a Deployment, sending mail | Connector |
+| **Calculation** | mapping a value into a template, formatting a report, parsing a request | **The sandbox.** A skill and the code it calls |
+
+The first two are what a connector exists for. The third is not, and putting it
+in one is using a security mechanism as a code-organisation mechanism.
+
+**It costs more than it looks.** A connector is a separate image: a build, a
+pushed artifact, a pinned digest ([ADR-0113](../adr/0113-bundles-declare-connector-build-inputs-and-tiers-deliver-pinned-images.md)),
+a redeploy on every change, and a second place to read logs when something goes
+wrong. Configuration that changes weekly becomes a rebuild every week.
+
+**And it buys nothing you did not already have.** The usual argument for moving
+computation into a connector is determinism. The same inputs must produce the
+same output every run. But determinism is a property of the code, not of the
+process it runs in. Same function, same input, same answer, whichever side of the
+boundary it sits on. Moving a calculation across the line does not make it more
+correct; unit tests do that, and they run identically either way.
+
+## 2. When a calculation *does* belong in a connector
+
+One case, and it is the case the SRE bot example is built around: when the
+calculation is the only thing bounding the capability.
+
+`examples/sre-bot/connectors/k8s-write/server.py` builds its patch body itself,
+a constant with a timestamp filled in, and exposes no parameter through which a
+caller reaches an image, a command or a replica count. If that body-building
+moved into the sandbox, a caller could supply the body, and a restart tool would
+become an arbitrary-write tool. The computation *is* the ceiling.
+
+**The test:** if this code moved into the sandbox, could a caller reach the
+capability without it?
+
+- **Yes**: it stays in the connector. It is part of the ceiling, not a helper.
+- **No**: the tool surface already bounds the capability, and the computation
+  can live in the sandbox where it is cheaper to change and easier to debug.
+
+## 3. The four layers
+
+When you do put a boundary in a connector, know which layer is holding it.
+Listed strongest first, because the weakest is the one people assume is doing the
+work. `examples/sre-bot/README.md` develops this at length for one connector.
+
+| # | Layer | What it actually stops |
+|---|---|---|
+| 1 | **The tool surface** | There is no parameter through which a caller reaches the thing. |
+| 2 | **The allowlist inside the connector** | Checked before the request is built. |
+| 3 | **The credential's own permissions** | Bounds a *compromised connector*. |
+| 4 | **The approval gate** | A control on the agent, not on the credential. |
+
+**Scope layers 1 to 3 as if the gate were absent.** If the credential leaked the
+gate would be irrelevant, and a human can approve the wrong thing. A gate is a
+prompt to a person, and people click. Layer 4 is a good control and a bad
+ceiling.
+
+## 4. When the credential cannot express the boundary
+
+This is the case that decides most designs, and it is easy to miss because the
+instinct, *grant the narrowest credential and let the platform enforce it*, is
+right, and then turns out not to be available.
+
+Sometimes the boundary you want cannot be written as a permission. Then layer 3
+is simply not on offer, and the code has to carry it. That is not a workaround.
+It is layer 1, which is stronger anyway.
+
+**The worked example in this repository is Kubernetes RBAC.** `kubectl rollout
+restart` is not a distinct permission; it is a PATCH of the pod template. So
+`patch` on deployments is the *same grant* as `set image`, `set env`, and
+replacing the container command. RBAC grants verbs on resources and cannot say
+"patch only this one field". `examples/sre-bot/manifests/write-role.yaml` says so
+in its own comments, and it is why that connector constructs its patch rather
+than forwarding one.
+
+**The shape generalises.** Object stores and document platforms commonly grant
+per-bucket or per-site, not per-prefix or per-folder. If two locations that must
+be treated differently live under one grant, no credential distinguishes them and
+the connector's own path check is the only thing that does.
+
+**Two rules for that situation:**
+
+1. **Measure before you assume it.** Whether a given provider can express your
+   boundary is a claim about a dependency, and this repository's method is that
+   documentation is not an observation. Probe it against a real account: attempt
+   the operation you believe is forbidden and record what came back. Either answer
+   improves the design. A refusal means the grant can carry the boundary and you
+   should let it, and a success means your code is the only thing there is and the
+   evidence should say so plainly.
+2. **Keep the code layer regardless.** Two layers beat one. If the grant turns out
+   to enforce the boundary too, the code check becomes defence in depth rather
+   than dead weight, and it is what survives a credential being widened by someone
+   who did not read this page.
+
+## 5. Is there a human downstream?
+
+Boundaries are not free, and you rarely get to put one everywhere. This is how to
+choose.
+
+An agent is prompt-injectable by construction: it reads logs, tickets, mail and
+dashboard titles that other people wrote. So assume, for each thing it can do,
+that it can be made to do it wrongly. Then ask: **is there a human between that
+and the consequence?**
+
+- **Yes**: a draft in a review queue, a suggested change, a summary a person
+  reads. The review is the control. A connector boundary here buys little, and
+  the real controls are unit tests and the review itself.
+- **No**: a published document, a cluster change, a sent message, a payment.
+  This is what a boundary is for. Spend it here.
+
+A concrete pattern: a generate-then-review-then-approve workflow, where approval
+is a person moving a file from one location to another. A wrong value in a draft
+is caught by the review. That is what the review is. A write into the *approved*
+location is not caught by anything, because it skipped the step that would have
+caught it. So the boundary goes on the approved location and nowhere else, and
+the code producing the draft can live in the sandbox.
+
+**The corollary matters as much.** If the human step is ever removed, every "yes"
+above becomes a "no" and the calculation changes. An agent that publishes without
+review needs the boundaries an agent that drafts for review does not. Treat "a
+person always reviews this" as a load-bearing assumption, and revisit the design
+when it stops being true rather than after.
+
+## 6. Rules a connector follows
+
+Each of these has cost somebody a day.
+
+**Fail closed on missing configuration.** An empty allowlist means refuse to
+start, never "everything permitted". A connector that comes up with no ceiling
+looks healthy and is wrong.
+
+**Declare the mode, never infer it.** A connector with a fake and a real mode
+reads an explicit variable. Inferring "real" from the presence of credentials
+means a typo'd secret name starts it in fake mode, where it accepts calls,
+reports success and does nothing. A fake does not fail. It answers.
+
+**An empty result is not a success.** A readable-but-empty folder, a query
+matching no rows, a search finding nothing: each is its own status, distinct from
+`ok`. Handed `{"status": "ok", "items": []}`, a model will report "there are none"
+as a fact. A confident "nothing" is worse than an error, because the caller
+believes it and stops looking.
+
+**Keep failures distinguishable.** Not-authenticated (the credential),
+not-authorized (the grant on it), not-found, empty, and refused (your own ceiling
+a request that was never sent) mean five different fixes. Collapsing 401 and 403
+costs an hour every time; an operator widening a permission to fix a *refused* is
+changing the wrong thing entirely.
+
+**State the ceiling in two places on purpose.** The grant, and the connector's own
+allowlist. A ceiling stated once is a ceiling that moves when somebody edits the
+other place.
+
+**Never let a secret reach a returned message.** Error text goes to logs and into
+a model's context. Do not echo values, and think twice about echoing your
+configured scope, which is a map of what this credential can reach.
+
+**Annotate tools honestly.** A gate is armed by exact tool name, so a write tool
+annotated `readOnlyHint` is a write with nothing in front of it. And audit what a
+read tool *returns*, not just its annotation: a tool that hands back a kubeconfig
+is annotated read-only correctly, because reading a credential is a read.
+
+**Do not hand a policy decision back to the caller.** Whether a conflicting write
+is refused or replaces what is there is operator configuration, not a tool
+argument. A per-call `overwrite=true` states the decision and then gives it to a
+model that is reading text a stranger wrote.

--- a/docs/guides/deciding-what-belongs-in-a-connector.md
+++ b/docs/guides/deciding-what-belongs-in-a-connector.md
@@ -40,11 +40,12 @@ correct; unit tests do that, and they run identically either way.
 One case, and it is the case the SRE bot example is built around: when the
 calculation is the only thing bounding the capability.
 
-`examples/sre-bot/connectors/k8s-write/server.py` builds its patch body itself,
-a constant with a timestamp filled in, and exposes no parameter through which a
-caller reaches an image, a command or a replica count. If that body-building
-moved into the sandbox, a caller could supply the body, and a restart tool would
-become an arbitrary-write tool. The computation *is* the ceiling.
+`examples/sre-bot/connectors/self-upgrade/server.py` reads the named CronJob's
+Job template and exposes no parameter through which a caller reaches an image,
+an environment variable, or a command. If that template selection and
+body-building moved into the sandbox, a caller could supply the Job body, and a
+self-upgrade tool would become an arbitrary-Job tool. The computation *is* the
+ceiling.
 
 **The test:** if this code moved into the sandbox, could a caller reach the
 capability without it?
@@ -81,13 +82,12 @@ Sometimes the boundary you want cannot be written as a permission. Then layer 3
 is simply not on offer, and the code has to carry it. That is not a workaround.
 It is layer 1, which is stronger anyway.
 
-**The worked example in this repository is Kubernetes RBAC.** `kubectl rollout
-restart` is not a distinct permission; it is a PATCH of the pod template. So
-`patch` on deployments is the *same grant* as `set image`, `set env`, and
-replacing the container command. RBAC grants verbs on resources and cannot say
-"patch only this one field". `examples/sre-bot/manifests/write-role.yaml` says so
-in its own comments, and it is why that connector constructs its patch rather
-than forwarding one.
+**The worked example in this repository is Kubernetes RBAC.** `create` on Jobs
+is namespace-wide: `resourceNames` cannot restrict a create because the object
+does not exist yet. RBAC therefore cannot say "create only this Job".
+`examples/sre-bot/manifests/upgrade-role.yaml` says so in its own comments, and
+it is why the connector reads the configured CronJob template and posts only
+that template rather than forwarding a caller-supplied Job body.
 
 **The shape generalises.** Object stores and document platforms commonly grant
 per-bucket or per-site, not per-prefix or per-folder. If two locations that must

--- a/packages/telemetry/src/curie_telemetry/__init__.py
+++ b/packages/telemetry/src/curie_telemetry/__init__.py
@@ -8,6 +8,7 @@ from .bootstrap import (
 from .config import resolve_otlp_endpoint, resolve_otlp_protocol
 from .context import (
     TRACEPARENT_STREAM_FIELD,
+    canonicalize_traceparent,
     extract_trace_context,
     inject_trace_context,
 )
@@ -22,6 +23,7 @@ __all__ = [
     "bootstrap_service_telemetry",
     "build_otlp_span_exporter",
     "build_resource",
+    "canonicalize_traceparent",
     "configure_meter_provider",
     "configure_service_logging",
     "deployment_environment",

--- a/packages/telemetry/src/curie_telemetry/context.py
+++ b/packages/telemetry/src/curie_telemetry/context.py
@@ -32,6 +32,31 @@ class _MappingGetter(Getter[Mapping[str, str]]):
 _GETTER = _MappingGetter()
 
 
+def canonicalize_traceparent(value: str | None) -> str | None:
+    """Return a canonical W3C carrier, or ``None`` for unsafe input.
+
+    Validation is delegated to OpenTelemetry's W3C propagator so this helper
+    cannot drift into a second, partial implementation of the standard.  A
+    clean base also keeps invalid input from falling back to ambient context.
+    """
+
+    if value is None:
+        return None
+    candidate = value.strip()
+    if not candidate:
+        return None
+    extracted = _PROPAGATOR.extract(
+        {TRACEPARENT_STREAM_FIELD: candidate},
+        context=Context(),
+        getter=_GETTER,
+    )
+    if not trace.get_current_span(extracted).get_span_context().is_valid:
+        return None
+    canonical: dict[str, str] = {}
+    _PROPAGATOR.inject(canonical, context=_normalize_trace_context(extracted))
+    return canonical.get(TRACEPARENT_STREAM_FIELD)
+
+
 def _normalize_trace_context(context: Context | None = None) -> Context:
     """Normalize trace flags while retaining the active Context and its values."""
 

--- a/packages/telemetry/tests/test_context.py
+++ b/packages/telemetry/tests/test_context.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from curie_telemetry import (
     TRACEPARENT_STREAM_FIELD,
+    canonicalize_traceparent,
     extract_trace_context,
     inject_trace_context,
 )
@@ -44,3 +45,28 @@ def test_missing_or_malformed_traceparent_extracts_a_safe_root_context() -> None
     for carrier in ({}, {TRACEPARENT_STREAM_FIELD: "not-a-traceparent"}):
         extracted = trace.get_current_span(extract_trace_context(carrier)).get_span_context()
         assert not extracted.is_valid
+
+
+def test_canonicalize_traceparent_returns_only_a_valid_w3c_carrier() -> None:
+    carrier = "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01"
+
+    assert canonicalize_traceparent(carrier) == carrier
+    assert canonicalize_traceparent(f"  {carrier}  ") == carrier
+
+
+def test_canonicalize_traceparent_rejects_missing_malformed_and_zero_ids() -> None:
+    assert canonicalize_traceparent(None) is None
+    assert canonicalize_traceparent("") is None
+    assert canonicalize_traceparent("not-a-traceparent") is None
+    assert (
+        canonicalize_traceparent(
+            "00-00000000000000000000000000000000-0123456789abcdef-01"
+        )
+        is None
+    )
+    assert (
+        canonicalize_traceparent(
+            "00-0123456789abcdef0123456789abcdef-0000000000000000-01"
+        )
+        is None
+    )

--- a/packages/test-support/src/curie_test_support/valkey.py
+++ b/packages/test-support/src/curie_test_support/valkey.py
@@ -13,10 +13,28 @@ import os
 
 import pytest
 import redis
+from redis.backoff import NoBackoff
+from redis.retry import Retry
 
 VALKEY_HOST = os.environ.get("TEST_VALKEY_HOST", "localhost")
 VALKEY_PORT = int(os.environ.get("TEST_VALKEY_PORT", "26379"))
 VALKEY_PW = os.environ.get("TEST_VALKEY_PW", "valkeypass")
+
+# How long one connect attempt may block. redis-py leaves socket_connect_timeout
+# at None by default, so a connect to an unreachable Valkey blocks on the OS
+# default rather than on anything this repo chose.
+CONNECT_TIMEOUT_SECONDS = float(os.environ.get("TEST_VALKEY_CONNECT_TIMEOUT", "2"))
+
+# No retries, deliberately. redis-py 8.x defaults to Retry(ExponentialWithJitter,
+# 3), which is a MULTIPLIER on the timeout above and is what actually made an
+# unreachable Valkey cost a minute: measured on redis-py 8.1.0 against a bound
+# but unlistening port, socket_connect_timeout=5 still took 58.74s and the
+# unbounded default took 59.66s, while no-retry with a bounded timeout returns in
+# the timeout. Retrying is wrong for this helper regardless of the cost. Its
+# whole contract is one ping that decides skip-or-raise, the compose Valkey is
+# either up before the suite starts or it is not, and a helper that retries turns
+# "your stack is not running" into a minute of silence per fixture.
+NO_RETRY = Retry(NoBackoff(), 0)
 
 
 def connect_or_skip(*, decode_responses: bool = True) -> redis.Redis:
@@ -27,12 +45,19 @@ def connect_or_skip(*, decode_responses: bool = True) -> redis.Redis:
     ``CI_REQUIRE_VALKEY_TESTS`` is absent. Its presence makes the original
     ``RedisError`` fail the required CI job instead. The caller owns the returned
     client (yield it from a fixture and ``.close()`` on teardown).
+
+    The connect is bounded by ``CONNECT_TIMEOUT_SECONDS`` and does not retry, so
+    an unreachable Valkey costs that timeout once rather than a minute. See the
+    constants above for why; ``TEST_VALKEY_CONNECT_TIMEOUT`` raises the bound for
+    a slow environment.
     """
     client: redis.Redis = redis.Redis(
         host=VALKEY_HOST,
         port=VALKEY_PORT,
         password=VALKEY_PW or None,
         decode_responses=decode_responses,
+        socket_connect_timeout=CONNECT_TIMEOUT_SECONDS,
+        retry=NO_RETRY,
     )
     try:
         client.ping()

--- a/packages/test-support/tests/test_valkey.py
+++ b/packages/test-support/tests/test_valkey.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import socket
+import time
 
 import pytest
 import redis
@@ -29,6 +30,14 @@ def test_connect_or_skip_skips_an_unreachable_valkey_locally(
             valkey.connect_or_skip()
 
 
+# Which error an unreachable port produces is a platform detail, not a contract.
+# A bound but unlistening loopback port refuses on Linux (ConnectionError) and is
+# dropped on macOS (TimeoutError), so pinning ConnectionError alone made this
+# test fail on every Mac. What connect_or_skip promises is that a required run
+# RAISES rather than skips; both classes are that promise kept.
+UNREACHABLE = (redis.exceptions.ConnectionError, redis.exceptions.TimeoutError)
+
+
 def test_connect_or_skip_fails_for_an_unreachable_valkey_when_required(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -36,5 +45,32 @@ def test_connect_or_skip_fails_for_an_unreachable_valkey_when_required(
     listener = _configure_unreachable_valkey(monkeypatch)
 
     with listener:
-        with pytest.raises(redis.exceptions.ConnectionError):
+        with pytest.raises(UNREACHABLE):
             valkey.connect_or_skip()
+
+
+def test_an_unreachable_valkey_costs_the_bounded_timeout_not_a_retry_ladder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The bound must hold end to end, not just be passed to the constructor.
+
+    redis-py 8.x defaults to Retry(ExponentialWithJitterBackoff(), 3), which
+    multiplies socket_connect_timeout rather than capping it: measured on 8.1.0
+    against a bound but unlistening port, socket_connect_timeout=5 still took
+    58.74s and the unbounded default took 59.66s. So asserting the constructor
+    received a timeout would not catch a reintroduced retry policy. Assert the
+    wall clock instead, which is the thing that was wrong.
+    """
+    monkeypatch.delenv("CI_REQUIRE_VALKEY_TESTS", raising=False)
+    monkeypatch.setattr(valkey, "CONNECT_TIMEOUT_SECONDS", 0.25)
+    listener = _configure_unreachable_valkey(monkeypatch)
+
+    with listener:
+        started = time.monotonic()
+        with pytest.raises(pytest.skip.Exception):
+            valkey.connect_or_skip()
+        elapsed = time.monotonic() - started
+
+    # Generous next to a 0.25s bound, and still two orders of magnitude under the
+    # ~59s the retry ladder cost.
+    assert elapsed < 5, f"an unreachable Valkey took {elapsed:.2f}s, so the bound is not holding"

--- a/release/preserve_next.py
+++ b/release/preserve_next.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python3
+"""Refuse an ordinary next-to-main release merge that would delete `next`.
+
+Issue #2090: merging a pull request whose head is the protected `next` branch
+into `main` deleted `next` because the repository keeps
+`delete_branch_on_merge` enabled (so short-lived task branches still clean up)
+and the deletion ruleset that covers `next` lists bypass actors. GitHub then
+auto-deletes the PR head; a bypass-capable merger is not stopped by that
+ruleset.
+
+This script is the fail-closed preflight that must run before that ordinary
+path is merged. It allows:
+
+  * a short-lived `task/release-*` (or any non-`next`) head, which is the
+    repository-owned way to keep task-branch cleanup without deleting `next`;
+  * an active deletion ruleset that covers `next` and has an empty bypass
+    list, which is the durable GitHub configuration (admin-only to apply);
+  * `delete_branch_on_merge` turned off (loses task-branch cleanup);
+  * the documented retirement sequence, once `next` is no longer a release
+    train trigger branch.
+
+Anything else, including a lookup that did not complete, is a refusal. The
+predicate lives in separately-testable functions so the unsafe ordinary path
+is an ordinary pytest assertion against a constructed GitHub fixture, not a
+destructive merge of the live `next` branch. Only `main()` needs the network.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+NEXT_BRANCH = "next"
+DEFAULT_BASE = "main"
+RELEASE_WORKFLOW = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "release.yaml"
+_PUSH_BRANCHES = re.compile(r"^\s+branches:\s*\[([^\]]*)\]", re.MULTILINE)
+
+
+class PreserveNextError(Exception):
+    """An ordinary release merge would delete the protected next branch."""
+
+
+@dataclass(frozen=True)
+class BypassActor:
+    actor_id: object
+    actor_type: str
+    bypass_mode: str
+
+
+@dataclass(frozen=True)
+class Ruleset:
+    id: int
+    name: str
+    enforcement: str
+    include_refs: tuple[str, ...]
+    exclude_refs: tuple[str, ...]
+    rule_types: tuple[str, ...]
+    bypass_actors: tuple[BypassActor, ...] | None
+
+
+@dataclass(frozen=True)
+class RepoSettings:
+    delete_branch_on_merge: bool
+    default_branch: str
+
+
+@dataclass(frozen=True)
+class PullRequestRefs:
+    head_ref: str
+    base_ref: str
+
+
+def parse_repo_settings(payload: dict[str, object]) -> RepoSettings:
+    delete = payload.get("delete_branch_on_merge")
+    if not isinstance(delete, bool):
+        raise PreserveNextError(
+            "repository payload is missing a boolean delete_branch_on_merge"
+        )
+    default_branch = payload.get("default_branch")
+    if not isinstance(default_branch, str) or not default_branch:
+        raise PreserveNextError("repository payload is missing default_branch")
+    return RepoSettings(
+        delete_branch_on_merge=delete, default_branch=default_branch
+    )
+
+
+def parse_ruleset(payload: dict[str, object]) -> Ruleset:
+    conditions = payload.get("conditions")
+    ref_name: dict[str, object] = {}
+    if isinstance(conditions, dict):
+        raw_ref = conditions.get("ref_name")
+        if isinstance(raw_ref, dict):
+            ref_name = raw_ref
+    include = ref_name.get("include")
+    exclude = ref_name.get("exclude")
+    rules = payload.get("rules")
+    rule_types: list[str] = []
+    if isinstance(rules, list):
+        for rule in rules:
+            if isinstance(rule, dict) and isinstance(rule.get("type"), str):
+                rule_types.append(str(rule["type"]))
+    bypass: tuple[BypassActor, ...] | None
+    if "bypass_actors" not in payload:
+        bypass = None
+    else:
+        raw_bypass = payload.get("bypass_actors")
+        actors: list[BypassActor] = []
+        if isinstance(raw_bypass, list):
+            for item in raw_bypass:
+                if not isinstance(item, dict):
+                    continue
+                actors.append(
+                    BypassActor(
+                        actor_id=item.get("actor_id"),
+                        actor_type=str(item.get("actor_type") or ""),
+                        bypass_mode=str(item.get("bypass_mode") or ""),
+                    )
+                )
+        bypass = tuple(actors)
+    return Ruleset(
+        id=int(payload.get("id") or 0),
+        name=str(payload.get("name") or ""),
+        enforcement=str(payload.get("enforcement") or ""),
+        include_refs=tuple(str(item) for item in include) if isinstance(include, list) else (),
+        exclude_refs=tuple(str(item) for item in exclude) if isinstance(exclude, list) else (),
+        rule_types=tuple(rule_types),
+        bypass_actors=bypass,
+    )
+
+
+def _ref_names(branch: str, default_branch: str) -> set[str]:
+    names = {branch, f"refs/heads/{branch}"}
+    if branch == default_branch:
+        names.add("~DEFAULT_BRANCH")
+    return names
+
+
+def ruleset_covers_ref(ruleset: Ruleset, branch: str, default_branch: str) -> bool:
+    names = _ref_names(branch, default_branch)
+    if names.intersection(ruleset.exclude_refs):
+        return False
+    if "~ALL" in ruleset.include_refs:
+        return True
+    return bool(names.intersection(ruleset.include_refs))
+
+
+def deletion_rule_blocks_auto_delete(ruleset: Ruleset) -> bool:
+    if ruleset.enforcement != "active":
+        return False
+    if "deletion" not in ruleset.rule_types:
+        return False
+    if ruleset.bypass_actors is None:
+        # Missing bypass_actors cannot be treated as empty: the list endpoint
+        # omits them, and an omitted list would look like durable protection.
+        return False
+    return len(ruleset.bypass_actors) == 0
+
+
+def head_survives_auto_delete(
+    settings: RepoSettings,
+    rulesets: Sequence[Ruleset],
+    head_ref: str,
+) -> bool:
+    if not settings.delete_branch_on_merge:
+        return True
+    return any(
+        ruleset_covers_ref(ruleset, head_ref, settings.default_branch)
+        and deletion_rule_blocks_auto_delete(ruleset)
+        for ruleset in rulesets
+    )
+
+
+def next_survives_auto_delete_on_merge(
+    settings: RepoSettings,
+    rulesets: Sequence[Ruleset],
+    head_ref: str,
+    next_branch: str = NEXT_BRANCH,
+) -> bool:
+    if head_ref != next_branch:
+        return True
+    return head_survives_auto_delete(settings, rulesets, next_branch)
+
+
+def predict_head_branch_deleted_after_merge(
+    settings: RepoSettings,
+    rulesets: Sequence[Ruleset],
+    head_ref: str,
+) -> bool:
+    """Would GitHub auto-delete `head_ref` after merging this pull request?
+
+    Isolated fixture of GitHub's merge-deletion rule: auto-delete happens when
+    `delete_branch_on_merge` is on, unless an active deletion ruleset covers
+    the head and lists no bypass actors. Documented at
+    https://docs.github.com/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-the-automatic-deletion-of-branches
+    Observed on this repository's PR #2085 (`head_ref_deleted` for `next` six
+    seconds after merge).
+    """
+    return not head_survives_auto_delete(settings, rulesets, head_ref)
+
+
+def next_is_release_train_branch(
+    workflow: dict[str, object], next_branch: str = NEXT_BRANCH
+) -> bool:
+    on = workflow.get("on")
+    if not isinstance(on, dict):
+        return True
+    push = on.get("push")
+    if not isinstance(push, dict):
+        return True
+    branches = push.get("branches")
+    if not isinstance(branches, list):
+        return True
+    return next_branch in [str(item) for item in branches]
+
+
+def pull_request_refs_from_event(event: dict[str, object]) -> PullRequestRefs | None:
+    pull_request = event.get("pull_request")
+    if not isinstance(pull_request, dict):
+        return None
+    head = pull_request.get("head")
+    base = pull_request.get("base")
+    if not isinstance(head, dict) or not isinstance(base, dict):
+        return None
+    head_ref = head.get("ref")
+    base_ref = base.get("ref")
+    if not isinstance(head_ref, str) or not isinstance(base_ref, str):
+        return None
+    if not head_ref or not base_ref:
+        return None
+    return PullRequestRefs(head_ref=head_ref, base_ref=base_ref)
+
+
+def evaluate(
+    *,
+    event: dict[str, object],
+    settings: RepoSettings,
+    rulesets: Sequence[Ruleset],
+    workflow: dict[str, object],
+    next_branch: str = NEXT_BRANCH,
+    default_base: str = DEFAULT_BASE,
+) -> None:
+    refs = pull_request_refs_from_event(event)
+    if refs is None:
+        return
+    if refs.head_ref != next_branch or refs.base_ref != default_base:
+        return
+    if not next_is_release_train_branch(workflow, next_branch):
+        return
+    if next_survives_auto_delete_on_merge(
+        settings, rulesets, refs.head_ref, next_branch
+    ):
+        return
+    raise PreserveNextError(
+        "ordinary next-to-main release merge would delete protected next: "
+        "delete_branch_on_merge is enabled and no active deletion ruleset "
+        "covers next with an empty bypass list. Cut the release PR from a "
+        "short-lived task/release-* branch, or add a next-only deletion "
+        "ruleset with no bypass actors (issue #2090)."
+    )
+
+
+def _gh_env() -> dict[str, str]:
+    """Force plain JSON. `gh api` colorizes when CLICOLOR_FORCE is set."""
+    env = os.environ.copy()
+    env["NO_COLOR"] = "1"
+    env["GH_FORCE_TTY"] = "0"
+    env.pop("CLICOLOR_FORCE", None)
+    return env
+
+
+def _gh_get(endpoint: str) -> object:
+    result = subprocess.run(
+        ["gh", "api", "-X", "GET", endpoint],
+        capture_output=True,
+        text=True,
+        check=True,
+        env=_gh_env(),
+    )
+    return json.loads(result.stdout)
+
+
+def fetch_repo_settings(repo: str) -> RepoSettings:
+    payload = _gh_get(f"repos/{repo}")
+    if not isinstance(payload, dict):
+        raise PreserveNextError(f"repository payload for {repo} was not an object")
+    return parse_repo_settings(payload)
+
+
+def fetch_rulesets(repo: str) -> list[Ruleset]:
+    listing = _gh_get(f"repos/{repo}/rulesets")
+    if not isinstance(listing, list):
+        raise PreserveNextError(f"ruleset list for {repo} was not an array")
+    rulesets: list[Ruleset] = []
+    for item in listing:
+        if not isinstance(item, dict) or item.get("id") is None:
+            raise PreserveNextError(f"ruleset list for {repo} contained an entry without id")
+        detail = _gh_get(f"repos/{repo}/rulesets/{item['id']}")
+        if not isinstance(detail, dict):
+            raise PreserveNextError(
+                f"ruleset {item['id']} for {repo} was not an object"
+            )
+        rulesets.append(parse_ruleset(detail))
+    return rulesets
+
+
+def _push_branches_from_text(text: str) -> list[str]:
+    match = _PUSH_BRANCHES.search(text)
+    if match is None:
+        return [NEXT_BRANCH]
+    names: list[str] = []
+    for item in match.group(1).split(","):
+        token = item.strip()
+        if token:
+            names.append(token.split()[-1])
+    return names
+
+
+def load_release_workflow() -> dict[str, object]:
+    text = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+    return {"on": {"push": {"branches": _push_branches_from_text(text)}}}
+
+
+def _ordinary_release_event() -> dict[str, object]:
+    return {
+        "pull_request": {
+            "head": {"ref": NEXT_BRANCH},
+            "base": {"ref": DEFAULT_BASE},
+        }
+    }
+
+
+def _needs_live_github(
+    event: dict[str, object], workflow: dict[str, object]
+) -> bool:
+    refs = pull_request_refs_from_event(event)
+    return (
+        refs is not None
+        and refs.head_ref == NEXT_BRANCH
+        and refs.base_ref == DEFAULT_BASE
+        and next_is_release_train_branch(workflow)
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--repo", required=True, help="owner/name, e.g. curie-eng/curie"
+    )
+    parser.add_argument(
+        "--event",
+        help="GitHub event JSON path; defaults to GITHUB_EVENT_PATH, or the "
+        "ordinary next-to-main path when neither is set",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        workflow = load_release_workflow()
+        event_path = args.event or os.environ.get("GITHUB_EVENT_PATH")
+        if event_path:
+            event = json.loads(Path(event_path).read_text(encoding="utf-8"))
+            if not isinstance(event, dict):
+                raise PreserveNextError("GitHub event payload was not an object")
+        else:
+            event = _ordinary_release_event()
+        if _needs_live_github(event, workflow):
+            settings = fetch_repo_settings(args.repo)
+            rulesets = fetch_rulesets(args.repo)
+        else:
+            settings = RepoSettings(delete_branch_on_merge=True, default_branch=DEFAULT_BASE)
+            rulesets = []
+        evaluate(
+            event=event,
+            settings=settings,
+            rulesets=rulesets,
+            workflow=workflow,
+        )
+    except PreserveNextError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    except (subprocess.CalledProcessError, json.JSONDecodeError, KeyError, OSError) as exc:
+        detail = getattr(exc, "stderr", None)
+        suffix = f": {str(detail).strip()}" if detail else ""
+        print(
+            f"ERROR: could not retrieve repository settings for {args.repo} "
+            f"-- the lookup failed with {type(exc).__name__}{suffix}. "
+            "Refusing because whether next would be deleted is unknown.",
+            file=sys.stderr,
+        )
+        return 1
+    print("OK: merging this event will not auto-delete next")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/release/tests/test_authorize.py
+++ b/release/tests/test_authorize.py
@@ -989,6 +989,30 @@ class TestReleaseWorkflowContract:
         )
         assert "Build sre-bot-tempo image (no push)" in authorize_module.REQUIRED_CHECK_NAMES
 
+    def test_image_matrix_scopes_its_layer_cache_per_image(self):
+        """Every leg of the images matrix must name its own gha cache scope.
+
+        All ten legs run concurrently and build different Dockerfiles, so an
+        unscoped ``type=gha`` gives them one shared namespace with nothing to
+        share: they only contend for the same reservation. Unscoped, the cache
+        export outgrew the build it was meant to save -- sre-bot-tempo built in
+        80.5s and spent 1057.7s writing one layer, turning a 2 minute image into
+        a 19 minute job on the critical path.
+        """
+        workflow = yaml.load(CI_YAML.read_text(), Loader=yaml.BaseLoader)
+        image_job = workflow["jobs"]["images"]
+        build_step = next(
+            step for step in image_job["steps"] if step.get("name") == "Build (no push)"
+        )
+
+        assert build_step["with"]["cache-from"] == "type=gha,scope=${{ matrix.name }}"
+        assert build_step["with"]["cache-to"] == "type=gha,mode=max,scope=${{ matrix.name }}"
+
+        # The scope is only per image if the key it reads is unique per leg, so
+        # assert the matrix names are distinct rather than trusting the template.
+        names = [row["name"] for row in image_job["strategy"]["matrix"]["include"]]
+        assert len(names) == len(set(names)), f"image matrix names must be unique: {names}"
+
     def test_observability_stack_assertions_run_in_helm_ci(self):
         workflow = yaml.load(HELM_CI_YAML.read_text(), Loader=yaml.BaseLoader)
         chart_steps = workflow["jobs"]["helm"]["steps"]

--- a/release/tests/test_preserve_next.py
+++ b/release/tests/test_preserve_next.py
@@ -1,0 +1,474 @@
+"""Contract tests for the next-branch preservation preflight (issue #2090).
+
+Merging the ordinary `next` -> `main` release PR deleted protected `next`
+because the repository keeps `delete_branch_on_merge` enabled (so short-lived
+task branches still clean up) and the deletion ruleset that covers `next` lists
+bypass actors. GitHub then auto-deletes the PR head, and a bypass-capable
+merger is not stopped by that ruleset.
+
+These tests drive the gate against constructed GitHub payloads, the same split
+`release/authorize.py` uses: the negative case is an ordinary pytest assertion,
+not a destructive merge of the live `next` branch. Live read-only evidence for
+the incident (PR #2085 `head_ref_deleted` six seconds after merge; repository
+`delete_branch_on_merge=true`; ruleset 18711121 covers `refs/heads/next` with a
+`deletion` rule and a bypass actor) is recorded in the issue and the pull
+request, not copied as real identifiers here.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "release" / "preserve_next.py"
+CI_YAML = REPO_ROOT / ".github" / "workflows" / "ci.yaml"
+RELEASE_YAML = REPO_ROOT / ".github" / "workflows" / "release.yaml"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("release_preserve_next", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    # Dataclasses read sys.modules[cls.__module__] while the class body runs.
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+preserve_next = load_module()
+
+
+def ruleset_payload(
+    *,
+    ruleset_id: int = 1,
+    name: str = "Default",
+    enforcement: str = "active",
+    include: list[str] | None = None,
+    exclude: list[str] | None = None,
+    rules: list[dict] | None = None,
+    bypass_actors: list[dict] | None = None,
+    omit_bypass_actors: bool = False,
+) -> dict:
+    payload = {
+        "id": ruleset_id,
+        "name": name,
+        "enforcement": enforcement,
+        "conditions": {
+            "ref_name": {
+                "include": include
+                if include is not None
+                else ["~DEFAULT_BRANCH", "refs/heads/next"],
+                "exclude": exclude if exclude is not None else [],
+            }
+        },
+        "rules": rules if rules is not None else [{"type": "deletion"}],
+    }
+    if not omit_bypass_actors:
+        payload["bypass_actors"] = (
+            bypass_actors
+            if bypass_actors is not None
+            else [
+                {
+                    "actor_id": 1001,
+                    "actor_type": "User",
+                    "bypass_mode": "always",
+                }
+            ]
+        )
+    return payload
+
+
+def repo_payload(*, delete_branch_on_merge: bool = True, default_branch: str = "main") -> dict:
+    return {
+        "delete_branch_on_merge": delete_branch_on_merge,
+        "default_branch": default_branch,
+        "name": "curie",
+    }
+
+
+def pr_event(head: str, base: str = "main") -> dict:
+    return {"action": "opened", "pull_request": {"head": {"ref": head}, "base": {"ref": base}}}
+
+
+def push_event(ref: str = "refs/heads/main") -> dict:
+    return {"ref": ref}
+
+
+def release_train_workflow(branches: list[str] | None = None) -> dict:
+    return {"on": {"push": {"branches": branches if branches is not None else ["main", "next"]}}}
+
+
+def settings_from(payload: dict):
+    return preserve_next.parse_repo_settings(payload)
+
+
+def rulesets_from(*payloads: dict):
+    return [preserve_next.parse_ruleset(payload) for payload in payloads]
+
+
+# Snapshot of the unsafe ordinary release path: auto-delete is on, `next` is
+# the PR head, and the deletion ruleset that covers `next` is bypassable.
+UNSAFE_REPO = repo_payload()
+UNSAFE_RULESET = ruleset_payload()
+UNSAFE_WORKFLOW = release_train_workflow()
+
+
+class TestPredictHeadBranchDeletedAfterMerge:
+    """Isolated GitHub merge/deletion fixture (issue #2090).
+
+    GitHub auto-deletes a merged PR head when `delete_branch_on_merge` is
+    true, unless a ruleset deletion rule covers that head and the merger
+    cannot bypass it. Documented at
+    https://docs.github.com/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-the-automatic-deletion-of-branches
+    Observed on this repository's PR #2085: `merged` at 2026-08-29T22:27:46Z,
+    `head_ref_deleted` for `next` at 2026-08-29T22:27:52Z.
+    """
+
+    def test_ordinary_next_to_main_merge_deletes_next_when_deletion_rule_is_bypassable(
+        self,
+    ):
+        settings = settings_from(UNSAFE_REPO)
+        rulesets = rulesets_from(UNSAFE_RULESET)
+
+        assert preserve_next.predict_head_branch_deleted_after_merge(
+            settings, rulesets, "next"
+        )
+        assert not preserve_next.next_survives_auto_delete_on_merge(
+            settings, rulesets, "next"
+        )
+
+    def test_task_branch_head_is_deleted_and_next_is_preserved(self):
+        settings = settings_from(UNSAFE_REPO)
+        rulesets = rulesets_from(UNSAFE_RULESET)
+
+        assert preserve_next.predict_head_branch_deleted_after_merge(
+            settings, rulesets, "task/release-v0.8.0"
+        )
+        assert preserve_next.next_survives_auto_delete_on_merge(
+            settings, rulesets, "task/release-v0.8.0"
+        )
+
+    def test_empty_bypass_deletion_ruleset_preserves_next(self):
+        settings = settings_from(UNSAFE_REPO)
+        rulesets = rulesets_from(ruleset_payload(bypass_actors=[]))
+
+        assert not preserve_next.predict_head_branch_deleted_after_merge(
+            settings, rulesets, "next"
+        )
+        assert preserve_next.next_survives_auto_delete_on_merge(
+            settings, rulesets, "next"
+        )
+
+    def test_auto_delete_disabled_preserves_next(self):
+        settings = settings_from(repo_payload(delete_branch_on_merge=False))
+        rulesets = rulesets_from(UNSAFE_RULESET)
+
+        assert not preserve_next.predict_head_branch_deleted_after_merge(
+            settings, rulesets, "next"
+        )
+        assert preserve_next.next_survives_auto_delete_on_merge(
+            settings, rulesets, "next"
+        )
+
+    def test_missing_bypass_actors_does_not_count_as_protection(self):
+        settings = settings_from(UNSAFE_REPO)
+        rulesets = rulesets_from(ruleset_payload(omit_bypass_actors=True))
+
+        assert preserve_next.predict_head_branch_deleted_after_merge(
+            settings, rulesets, "next"
+        )
+
+    def test_evaluate_enforcement_does_not_count_as_protection(self):
+        settings = settings_from(UNSAFE_REPO)
+        rulesets = rulesets_from(
+            ruleset_payload(enforcement="evaluate", bypass_actors=[])
+        )
+
+        assert preserve_next.predict_head_branch_deleted_after_merge(
+            settings, rulesets, "next"
+        )
+
+    def test_ruleset_that_does_not_cover_next_does_not_protect_it(self):
+        settings = settings_from(UNSAFE_REPO)
+        rulesets = rulesets_from(
+            ruleset_payload(include=["~DEFAULT_BRANCH"], bypass_actors=[])
+        )
+
+        assert preserve_next.predict_head_branch_deleted_after_merge(
+            settings, rulesets, "next"
+        )
+
+
+class TestEvaluatePreflight:
+    def test_refuses_ordinary_next_to_main_release_merge(self):
+        with pytest.raises(preserve_next.PreserveNextError) as exc_info:
+            preserve_next.evaluate(
+                event=pr_event("next"),
+                settings=settings_from(UNSAFE_REPO),
+                rulesets=rulesets_from(UNSAFE_RULESET),
+                workflow=UNSAFE_WORKFLOW,
+            )
+
+        message = str(exc_info.value)
+        assert "next" in message
+        assert "delete_branch_on_merge" in message
+        assert "bypass" in message
+
+    def test_allows_a_short_lived_release_task_branch(self):
+        preserve_next.evaluate(
+            event=pr_event("task/release-v0.8.0"),
+            settings=settings_from(UNSAFE_REPO),
+            rulesets=rulesets_from(UNSAFE_RULESET),
+            workflow=UNSAFE_WORKFLOW,
+        )
+
+    def test_allows_next_to_main_when_deletion_ruleset_has_no_bypass(self):
+        preserve_next.evaluate(
+            event=pr_event("next"),
+            settings=settings_from(UNSAFE_REPO),
+            rulesets=rulesets_from(ruleset_payload(bypass_actors=[])),
+            workflow=UNSAFE_WORKFLOW,
+        )
+
+    def test_allows_next_to_main_when_auto_delete_is_disabled(self):
+        preserve_next.evaluate(
+            event=pr_event("next"),
+            settings=settings_from(repo_payload(delete_branch_on_merge=False)),
+            rulesets=rulesets_from(UNSAFE_RULESET),
+            workflow=UNSAFE_WORKFLOW,
+        )
+
+    def test_allows_next_to_main_after_the_documented_retirement_sequence(self):
+        preserve_next.evaluate(
+            event=pr_event("next"),
+            settings=settings_from(UNSAFE_REPO),
+            rulesets=rulesets_from(UNSAFE_RULESET),
+            workflow=release_train_workflow(["main"]),
+        )
+
+    def test_push_events_are_not_release_merges(self):
+        preserve_next.evaluate(
+            event=push_event(),
+            settings=settings_from(UNSAFE_REPO),
+            rulesets=rulesets_from(UNSAFE_RULESET),
+            workflow=UNSAFE_WORKFLOW,
+        )
+
+    def test_next_into_next_is_not_the_ordinary_release_merge(self):
+        preserve_next.evaluate(
+            event=pr_event("next", base="next"),
+            settings=settings_from(UNSAFE_REPO),
+            rulesets=rulesets_from(UNSAFE_RULESET),
+            workflow=UNSAFE_WORKFLOW,
+        )
+
+
+class TestReleaseTrainDetection:
+    def test_committed_release_workflow_still_treats_next_as_a_release_train_branch(
+        self,
+    ):
+        workflow = yaml.load(RELEASE_YAML.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+
+        assert preserve_next.next_is_release_train_branch(workflow)
+        assert "next" in workflow["on"]["push"]["branches"]
+
+    def test_a_workflow_without_next_is_the_retirement_state(self):
+        assert not preserve_next.next_is_release_train_branch(
+            release_train_workflow(["main"])
+        )
+
+
+class TestFetchUsesGet:
+    """`gh api` must be pinned to GET, matching issue #732 on authorize.py."""
+
+    @staticmethod
+    def _capture(monkeypatch, responses: dict[str, dict]) -> list:
+        captured: list = []
+
+        def fake_run(argv, **kwargs):
+            captured.append(argv)
+            endpoint = next(
+                arg for arg in argv if isinstance(arg, str) and arg.startswith("repos/")
+            )
+            payload = responses[endpoint]
+            return subprocess.CompletedProcess(
+                argv, 0, stdout=json.dumps(payload), stderr=""
+            )
+
+        monkeypatch.setattr(preserve_next.subprocess, "run", fake_run)
+        return captured
+
+    def test_repo_settings_are_fetched_with_an_explicit_get(self, monkeypatch):
+        captured = self._capture(
+            monkeypatch, {"repos/curie-eng/curie": repo_payload()}
+        )
+
+        settings = preserve_next.fetch_repo_settings("curie-eng/curie")
+
+        argv = captured[0]
+        assert argv[argv.index("-X") + 1] == "GET"
+        assert settings.delete_branch_on_merge is True
+
+    def test_gh_env_disables_color_so_the_payload_stays_json(self, monkeypatch):
+        captured_env: list[dict] = []
+
+        def fake_run(argv, **kwargs):
+            captured_env.append(kwargs.get("env") or {})
+            return subprocess.CompletedProcess(
+                argv, 0, stdout=json.dumps(repo_payload()), stderr=""
+            )
+
+        monkeypatch.setattr(preserve_next.subprocess, "run", fake_run)
+        monkeypatch.setenv("CLICOLOR_FORCE", "1")
+
+        preserve_next.fetch_repo_settings("curie-eng/curie")
+
+        env = captured_env[0]
+        assert env["NO_COLOR"] == "1"
+        assert env["GH_FORCE_TTY"] == "0"
+        assert "CLICOLOR_FORCE" not in env
+
+    def test_rulesets_are_re_fetched_for_bypass_actors(self, monkeypatch):
+        list_payload = [{"id": 1, "name": "Default", "enforcement": "active"}]
+        detail = ruleset_payload()
+        captured = self._capture(
+            monkeypatch,
+            {
+                "repos/curie-eng/curie/rulesets": list_payload,
+                "repos/curie-eng/curie/rulesets/1": detail,
+            },
+        )
+
+        rulesets = preserve_next.fetch_rulesets("curie-eng/curie")
+
+        endpoints = [
+            next(arg for arg in argv if isinstance(arg, str) and arg.startswith("repos/"))
+            for argv in captured
+        ]
+        assert endpoints == [
+            "repos/curie-eng/curie/rulesets",
+            "repos/curie-eng/curie/rulesets/1",
+        ]
+        assert all(argv[argv.index("-X") + 1] == "GET" for argv in captured)
+        assert rulesets[0].bypass_actors is not None
+        assert len(rulesets[0].bypass_actors) == 1
+
+
+class TestMain:
+    @staticmethod
+    def _stub_live(monkeypatch, *, repo: dict, rulesets: list[dict]) -> None:
+        monkeypatch.setattr(
+            preserve_next,
+            "fetch_repo_settings",
+            lambda _repo: preserve_next.parse_repo_settings(repo),
+        )
+        monkeypatch.setattr(
+            preserve_next,
+            "fetch_rulesets",
+            lambda _repo: [preserve_next.parse_ruleset(item) for item in rulesets],
+        )
+        monkeypatch.setattr(
+            preserve_next,
+            "load_release_workflow",
+            lambda: UNSAFE_WORKFLOW,
+        )
+
+    def test_refuses_an_ordinary_next_to_main_pr(self, tmp_path, monkeypatch, capsys):
+        event_path = tmp_path / "event.json"
+        event_path.write_text(json.dumps(pr_event("next")), encoding="utf-8")
+        self._stub_live(monkeypatch, repo=UNSAFE_REPO, rulesets=[UNSAFE_RULESET])
+
+        exit_code = preserve_next.main(
+            ["--repo", "curie-eng/curie", "--event", str(event_path)]
+        )
+
+        assert exit_code == 1
+        err = capsys.readouterr().err
+        assert "ERROR:" in err
+        assert "delete_branch_on_merge" in err
+
+    def test_allows_a_task_branch_pr_without_requiring_the_admin_setting_change(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        event_path = tmp_path / "event.json"
+        event_path.write_text(
+            json.dumps(pr_event("task/2090-preserve-next-branch")), encoding="utf-8"
+        )
+        self._stub_live(monkeypatch, repo=UNSAFE_REPO, rulesets=[UNSAFE_RULESET])
+
+        exit_code = preserve_next.main(
+            ["--repo", "curie-eng/curie", "--event", str(event_path)]
+        )
+
+        assert exit_code == 0
+        assert "OK:" in capsys.readouterr().out
+
+    def test_operator_invocation_without_an_event_checks_the_ordinary_release_path(
+        self, monkeypatch, capsys
+    ):
+        self._stub_live(monkeypatch, repo=UNSAFE_REPO, rulesets=[UNSAFE_RULESET])
+        monkeypatch.delenv("GITHUB_EVENT_PATH", raising=False)
+
+        exit_code = preserve_next.main(["--repo", "curie-eng/curie"])
+
+        assert exit_code == 1
+        assert "delete_branch_on_merge" in capsys.readouterr().err
+
+    def test_lookup_failure_refuses_closed(self, tmp_path, monkeypatch, capsys):
+        event_path = tmp_path / "event.json"
+        event_path.write_text(json.dumps(pr_event("next")), encoding="utf-8")
+        monkeypatch.setattr(
+            preserve_next,
+            "fetch_repo_settings",
+            lambda _repo: (_ for _ in ()).throw(
+                subprocess.CalledProcessError(
+                    1,
+                    ["gh", "api", "-X", "GET", "repos/curie-eng/curie"],
+                    stderr="gh: Not Found (HTTP 404)",
+                )
+            ),
+        )
+        monkeypatch.setattr(
+            preserve_next, "load_release_workflow", lambda: UNSAFE_WORKFLOW
+        )
+
+        exit_code = preserve_next.main(
+            ["--repo", "curie-eng/curie", "--event", str(event_path)]
+        )
+
+        assert exit_code == 1
+        err = capsys.readouterr().err
+        assert "could not retrieve" in err
+        assert "gh: Not Found (HTTP 404)" in err
+
+
+class TestCiWorkflowContract:
+    """The consumer path is the CI job, not the helper sitting unused."""
+
+    def test_preserve_next_job_invokes_the_script_and_never_skips(self):
+        workflow = yaml.safe_load(CI_YAML.read_text(encoding="utf-8"))
+        job = workflow["jobs"]["preserve-next"]
+
+        assert "if" not in job
+        assert job.get("continue-on-error") is not True
+        runs = [step.get("run", "") for step in job["steps"]]
+        assert any("release/preserve_next.py" in run for run in runs)
+        assert any("--repo" in run and "GITHUB_REPOSITORY" in run for run in runs)
+
+    def test_preserve_next_job_supplies_a_token_for_gh_api(self):
+        workflow = yaml.safe_load(CI_YAML.read_text(encoding="utf-8"))
+        job = workflow["jobs"]["preserve-next"]
+        step = next(
+            item
+            for item in job["steps"]
+            if "release/preserve_next.py" in item.get("run", "")
+        )
+        env = step.get("env") or job.get("env") or {}
+        assert env.get("GH_TOKEN") == "${{ secrets.GITHUB_TOKEN }}"

--- a/scripts/check-commit-messages.sh
+++ b/scripts/check-commit-messages.sh
@@ -25,8 +25,15 @@
 #      never trip it.
 #
 # Usage:
-#   scripts/check-commit-messages.sh [<range>]   # default: origin/main..HEAD
-#   scripts/check-commit-messages.sh --self-test # prove the matcher is not vacuous
+#   scripts/check-commit-messages.sh [<range>]        # default: origin/main..HEAD
+#   scripts/check-commit-messages.sh --message-file <path>
+#   scripts/check-commit-messages.sh --self-test      # prove the matcher is not vacuous
+#
+# `--message-file` runs the SAME matcher over one file of message text instead of
+# a commit range. It exists so scripts/check-pr-body.sh can apply this rule to a
+# pull request body without a second copy of the regexes: the vendor lists and
+# the bare-name boundary above are the part most likely to rot, and two copies
+# rot apart. The caller owns the file; this mode only reads it.
 #
 # An unresolvable range is a hard failure, never a silent pass, so `--self-test`
 # re-invokes this script once with a bogus range and must run inside a git repo.
@@ -146,8 +153,54 @@ self_test() {
     echo "commit-message gate self-test: ${#bad[@]} caught, ${#good[@]} correctly ignored"
 }
 
+# Scan one file of message text. Shares offending_reason() with the range mode,
+# so a vendor added to the matcher is covered in both places at once.
+check_message_file() {
+    local message_file="$1"
+    local line reason violations=0
+
+    if [[ ! -f "$message_file" ]]; then
+        echo "message-file check failed: '$message_file' is not a regular file" >&2
+        return 1
+    fi
+    if [[ ! -r "$message_file" ]]; then
+        echo "message-file check failed: '$message_file' is not readable" >&2
+        return 1
+    fi
+
+    # A final line with no trailing newline is still a line: `read` returns
+    # non-zero on it while leaving it in the variable, so the loop body must run
+    # once more for a footer appended without a newline.
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        reason="$(offending_reason "$line")"
+        if [[ -n "$reason" ]]; then
+            if ((violations == 0)); then
+                echo "AGENTS.md forbids AI attribution in commit messages and pull" >&2
+                echo "request bodies (#962). Offending:" >&2
+            fi
+            violations=$((violations + 1))
+            echo "  [$reason] $line" >&2
+        fi
+    done <"$message_file"
+
+    if ((violations)); then
+        echo "Remove the attribution above and try again." >&2
+        return 1
+    fi
+    echo "message text clean: no AI attribution in '$message_file'"
+}
+
 if [[ "${1:-}" == "--self-test" ]]; then
     self_test
+    exit 0
+fi
+
+if [[ "${1:-}" == "--message-file" ]]; then
+    if (($# != 2)); then
+        echo "Usage: scripts/check-commit-messages.sh --message-file <path>" >&2
+        exit 2
+    fi
+    check_message_file "$2"
     exit 0
 fi
 

--- a/scripts/check-pr-body.sh
+++ b/scripts/check-pr-body.sh
@@ -1,14 +1,24 @@
 #!/usr/bin/env bash
-# Reject PR bodies that contain a literal "\\n" escape. GitHub displays that
-# escape as text rather than a line break, so a following `Closes #<issue>` is
-# not parsed as a closing keyword.
+# Two guards on a pull request body.
+#
+# 1. Reject a literal "\\n" escape. GitHub displays that escape as text rather
+#    than a line break, so a following `Closes #<issue>` is not parsed as a
+#    closing keyword.
+# 2. Reject AI attribution, delegating to check-commit-messages.sh
+#    --message-file so both surfaces share ONE matcher. AGENTS.md forbids
+#    attribution in commit messages and pull request bodies alike, but only the
+#    commit half was enforced, so agent-authored bodies kept arriving with the
+#    robot-emoji footer and were merged (#2225). The body is the half a human
+#    reviewer sees first and the half no rebase can rewrite.
 #
 # Usage:
 #   scripts/check-pr-body.sh <body-file>
 #   scripts/check-pr-body.sh --self-test
 set -euo pipefail
 
-SCRIPT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_PATH="$SCRIPT_DIR/$(basename "${BASH_SOURCE[0]}")"
+COMMIT_GATE="$SCRIPT_DIR/check-commit-messages.sh"
 
 usage() {
     echo "Usage: scripts/check-pr-body.sh <body-file>" >&2
@@ -42,19 +52,38 @@ check_body_file() {
         fi
     fi
 
-    echo "PR body check passed: no literal \\n escape sequences"
+    if [[ ! -x "$COMMIT_GATE" && ! -r "$COMMIT_GATE" ]]; then
+        echo "PR body check failed: cannot read '$COMMIT_GATE'" >&2
+        return 1
+    fi
+    if ! bash "$COMMIT_GATE" --message-file "$body_file" >/dev/null; then
+        echo "PR body check failed: the body claims AI authorship." >&2
+        echo "AGENTS.md forbids AI attribution in commit messages and PR bodies alike." >&2
+        return 1
+    fi
+
+    echo "PR body check passed: real newlines, no AI attribution"
 }
 
 self_test() {
-    local temp_dir real_newline_body literal_escape_body
+    local temp_dir real_newline_body literal_escape_body attributed_body footer_no_newline_body
 
     temp_dir="$(mktemp -d "${TMPDIR:-/tmp}/curie-pr-body-check.XXXXXX")"
     trap 'rm -rf -- "$temp_dir"' RETURN
     real_newline_body="$temp_dir/real-newline.md"
     literal_escape_body="$temp_dir/literal-escape.md"
 
+    attributed_body="$temp_dir/attributed.md"
+    footer_no_newline_body="$temp_dir/footer-no-newline.md"
+
     printf 'Describe a fix.\n\nCloses #1713\n' >"$real_newline_body"
     printf 'Describe a fix.\\n\\nCloses #1713\n' >"$literal_escape_body"
+    # The exact footer that reached #2225, and the same footer with no trailing
+    # newline, which is the shape a body pasted from a tool actually has.
+    printf 'Describe a fix.\n\n\xf0\x9f\xa4\x96 Generated with [Claude Code](https://claude.com/claude-code)\n' \
+        >"$attributed_body"
+    printf 'Describe a fix.\n\n\xf0\x9f\xa4\x96 Generated with [Claude Code](https://claude.com/claude-code)' \
+        >"$footer_no_newline_body"
 
     if ! bash "$SCRIPT_PATH" "$real_newline_body" >/dev/null; then
         echo "PR body check self-test failed: real newlines were rejected" >&2
@@ -65,7 +94,16 @@ self_test() {
         return 1
     fi
 
-    echo "PR body check self-test passed: real newlines accepted, literal \\n rejected"
+    if bash "$SCRIPT_PATH" "$attributed_body" >/dev/null 2>&1; then
+        echo "PR body check self-test failed: AI attribution footer was accepted" >&2
+        return 1
+    fi
+    if bash "$SCRIPT_PATH" "$footer_no_newline_body" >/dev/null 2>&1; then
+        echo "PR body check self-test failed: unterminated AI attribution footer was accepted" >&2
+        return 1
+    fi
+
+    echo "PR body check self-test passed: clean body accepted, literal \\n and AI attribution rejected"
 }
 
 if [[ "${1:-}" == "--self-test" ]]; then

--- a/tools/ci-retry-gate/tests/test_pr_body.py
+++ b/tools/ci-retry-gate/tests/test_pr_body.py
@@ -1,4 +1,10 @@
-"""Executable regression for PR bodies that defeat GitHub auto-close (#1713)."""
+"""Executable regressions for the pull request body guards.
+
+Two rules share this checker: bodies that defeat GitHub auto-close (#1713),
+and bodies that claim AI authorship (#962). The second half exists because
+AGENTS.md forbade attribution on both surfaces while only the commit half was
+enforced, so footers kept reaching merged pull requests.
+"""
 
 from __future__ import annotations
 
@@ -53,3 +59,81 @@ def test_pr_body_check_rejects_literal_backslash_n_before_it_inerts_a_closing_ke
     assert completed.returncode != 0, diagnostics
     assert r"\n" in diagnostics, diagnostics
     assert "replace" in diagnostics.lower(), diagnostics
+
+
+FOOTER = "\N{ROBOT FACE} Generated with [Claude Code](https://claude.com/claude-code)"
+
+
+@pytest.mark.parametrize(
+    "body",
+    (
+        # The exact footer that reached merged pull requests.
+        f"Describe a fix.\n\n{FOOTER}\n",
+        # The same footer with no trailing newline, which is the shape a body
+        # pasted straight out of a tool actually has. A `while read` loop drops
+        # that last line unless it is written to handle it.
+        f"Describe a fix.\n\n{FOOTER}",
+        "Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>\n",
+        "This patch was generated with Claude\n",
+    ),
+)
+def test_pr_body_check_rejects_ai_attribution(tmp_path: Path, body: str) -> None:
+    completed = _check_body(tmp_path, body)
+
+    assert completed.returncode != 0, _diagnostics(completed)
+    assert "AI" in completed.stderr, _diagnostics(completed)
+
+
+@pytest.mark.parametrize(
+    "body",
+    (
+        # Attribution, not mention. These are this repo's ordinary vocabulary and
+        # must stay mergeable, or the gate gets switched off.
+        "Update apps/ui/CLAUDE.md and the harness.claude import boundary.\n",
+        "Pin claude-agent-sdk==0.2.110 so claude_agent_sdk spans stay schema-clean.\n",
+        "Describe the Claude harness port and its registry.\n\nCloses #1713\n",
+    ),
+)
+def test_pr_body_check_accepts_technical_references_to_the_harness(
+    tmp_path: Path, body: str
+) -> None:
+    completed = _check_body(tmp_path, body)
+
+    assert completed.returncode == 0, _diagnostics(completed)
+
+
+def test_pr_body_guard_delegates_to_one_matcher() -> None:
+    """Both surfaces must share a matcher, or the vendor lists drift apart."""
+    checker = CHECKER.read_text(encoding="utf-8")
+
+    assert "check-commit-messages.sh" in checker
+    assert "--message-file" in checker
+
+
+def test_pr_body_self_test_covers_the_attribution_half() -> None:
+    """CI trusts --self-test before running the gate, so it must not be vacuous."""
+    completed = subprocess.run(
+        ["bash", str(CHECKER), "--self-test"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, _diagnostics(completed)
+    assert "AI attribution" in completed.stdout, _diagnostics(completed)
+
+
+def test_pr_body_gate_inherits_the_commit_matcher_boundary(tmp_path: Path) -> None:
+    """A bare name followed by `.` is out of scope, by the shared matcher's design.
+
+    BARE_ASSISTANT excludes a trailing `[._-]` so `harness.claude`, `CLAUDE.md`
+    and `claude-sonnet-5` never trip rule C. A sentence that ends "generated with
+    Claude." rides that same exclusion. Widening it belongs to the commit gate
+    and its false-positive budget, not here; this pins the boundary so the next
+    reader knows it is inherited rather than overlooked. The footer forms that
+    actually reach pull requests are caught by rule B regardless.
+    """
+    completed = _check_body(tmp_path, "This patch was generated with Claude.\n")
+
+    assert completed.returncode == 0, _diagnostics(completed)

--- a/tools/fix-pin-ci/check.py
+++ b/tools/fix-pin-ci/check.py
@@ -67,8 +67,13 @@ class Declaration:
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
     parser.add_argument("--event", type=Path, required=True)
-    parser.add_argument("--curie", required=True)
-    parser.add_argument("--ref", required=True)
+    parser.add_argument("--curie")
+    parser.add_argument("--ref")
+    parser.add_argument(
+        "--needs-curie",
+        action="store_true",
+        help="report whether this body would invoke the curie binary",
+    )
     return parser
 
 
@@ -134,6 +139,37 @@ def _declaration(body: str) -> Declaration:
     return Declaration(selector=selector)
 
 
+def _needs_curie(body: str) -> bool:
+    """True iff ``main`` would invoke the curie binary for this body."""
+    try:
+        return _declaration(body).selector is not None
+    except ValueError:
+        return False
+
+
+def _report_needs_curie(event_path: Path) -> int:
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if not output_path:
+        print("Fix pin cargo guard error: GITHUB_OUTPUT is required", file=sys.stderr)
+        return 1
+
+    try:
+        needed = _needs_curie(_body(_event(event_path)))
+    except ValueError as error:
+        print(f"Fix pin declaration error: {error}", file=sys.stderr)
+        return 1
+
+    line = f"needed={'true' if needed else 'false'}\n"
+    try:
+        with Path(output_path).open("a", encoding="utf-8") as stream:
+            stream.write(line)
+    except OSError as error:
+        print(f"Fix pin cargo guard error: could not write GITHUB_OUTPUT: {error}", file=sys.stderr)
+        return 1
+    sys.stdout.write(line)
+    return 0
+
+
 def _closed_issues(body: str) -> list[int]:
     uncommented = COMMENT.sub("", body)
     numbers: list[int] = []
@@ -183,6 +219,11 @@ def _closed_bugs(event: dict[str, object], body: str) -> list[int]:
 
 def main(argv: Sequence[str] | None = None) -> int:
     arguments = _parser().parse_args(argv)
+    if arguments.needs_curie:
+        return _report_needs_curie(arguments.event)
+    if not arguments.curie or not arguments.ref:
+        print("Fix pin invocation error: --curie and --ref are required", file=sys.stderr)
+        return 2
 
     try:
         event = _event(arguments.event)

--- a/tools/fix-pin-ci/tests/test_fix_pin_ci.py
+++ b/tools/fix-pin-ci/tests/test_fix_pin_ci.py
@@ -629,6 +629,63 @@ def test_ci_keeps_the_required_python_status_and_calls_fix_pin_after_pytest() ->
     assert gate_index < diagnostic_index
 
 
+DECLARATION_GUARD = "contains(github.event.pull_request.body, 'Fix pin:')"
+
+
+def test_selector_tooling_builds_only_when_the_body_declares_a_fix_pin() -> None:
+    """The cargo build must be gated on a declaration, and gated the safe way.
+
+    check.py reaches the binary at exactly one place, the `curie dev
+    verify-fix-pin` call, and only once `declaration.selector` is set. `n/a`, no
+    declaration, a near-miss marker and the bug-without-declaration rejection all
+    return first. Building unconditionally therefore spent a cold
+    `cargo build --release` inside the longest job on the graph for a binary that
+    the majority of pull requests never run.
+
+    The guard must stay a strict SUPERSET of the cases that reach the binary.
+    `contains()` is case-insensitive and DECLARATION is the exact-case
+    `Fix pin: <selector>`, so a body that reaches the binary always contains the
+    substring. Skipping a build the gate then needs would be the unsafe
+    direction, and this pins that it cannot happen.
+    """
+    document = _load_ci()
+    _, steps = _python_job(document)
+
+    for description, predicate in (
+        (
+            "direct current release build",
+            lambda step: _string(step, "run").strip()
+            == "cargo build --release --locked --manifest-path cli/Cargo.toml",
+        ),
+        (
+            "pinned Helm setup",
+            lambda step: _string(step, "uses")
+            == "azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310",
+        ),
+    ):
+        step = steps[_single_step_index(steps, predicate, description)]
+        condition = _string(step, "if")
+        assert PR_CONDITION.search(condition), f"{description} must stay pull-request only"
+        assert DECLARATION_GUARD in condition, (
+            f"{description} must build only when the body declares a Fix pin: {condition!r}"
+        )
+
+    # The gate itself must NOT carry the guard. It is the step that decides a
+    # missing declaration is acceptable, and a body-shaped `if` on it would turn
+    # the "closes a bug with no declaration" rejection into a skipped step.
+    gate = steps[
+        _single_step_index(
+            steps,
+            lambda step: "tools/fix-pin-ci/check.py" in _string(step, "run"),
+            "fix pin caller",
+        )
+    ]
+    assert DECLARATION_GUARD not in _string(gate, "if"), (
+        "the gate must still run for a body with no declaration, or the "
+        "bug-without-declaration rejection can never fire"
+    )
+
+
 def test_pull_request_template_documents_the_required_declaration() -> None:
     template = PR_TEMPLATE.read_text(encoding="utf-8")
 

--- a/tools/fix-pin-ci/tests/test_fix_pin_ci.py
+++ b/tools/fix-pin-ci/tests/test_fix_pin_ci.py
@@ -170,6 +170,54 @@ def _gh_call_log(tmp_path: Path) -> Path:
     return tmp_path / "gh-argv.json"
 
 
+def _github_output(tmp_path: Path) -> Path:
+    return tmp_path / "github-output.txt"
+
+
+def _run_needs_curie(
+    tmp_path: Path,
+    body: str | None,
+    *,
+    include_body: bool = True,
+    github_output: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    """Invoke the cargo-guard probe. It must reuse the declaration parser."""
+    event_path = _write_event(tmp_path, body, include_body=include_body)
+    environment = {**os.environ}
+    if github_output:
+        environment["GITHUB_OUTPUT"] = str(_github_output(tmp_path))
+    else:
+        environment.pop("GITHUB_OUTPUT", None)
+    return subprocess.run(
+        [
+            sys.executable,
+            str(CHECKER),
+            "--event",
+            str(event_path),
+            "--needs-curie",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        check=False,
+        env=environment,
+        text=True,
+    )
+
+
+def _needed_output(tmp_path: Path) -> str:
+    return _github_output(tmp_path).read_text(encoding="utf-8")
+
+
+def _is_fix_pin_gate(step: dict[str, Any]) -> bool:
+    run = _string(step, "run")
+    return "tools/fix-pin-ci/check.py" in run and "--needs-curie" not in run
+
+
+def _is_fix_pin_probe(step: dict[str, Any]) -> bool:
+    run = _string(step, "run")
+    return "tools/fix-pin-ci/check.py" in run and "--needs-curie" in run
+
+
 @pytest.mark.parametrize(
     ("body", "include_body"),
     [
@@ -580,11 +628,8 @@ def test_ci_keeps_the_required_python_status_and_calls_fix_pin_after_pytest() ->
         "the Python suite must run unfiltered: only reporting flags may be added "
         f"to `uv run pytest -q`, got {pytest_command!r}"
     )
-    gate_index = _single_step_index(
-        steps,
-        lambda step: "tools/fix-pin-ci/check.py" in _string(step, "run"),
-        "fix pin caller",
-    )
+    probe_index = _single_step_index(steps, _is_fix_pin_probe, "fix pin cargo probe")
+    gate_index = _single_step_index(steps, _is_fix_pin_gate, "fix pin caller")
     gate = steps[gate_index]
     assert _pull_request_only(gate), "the verifier must not run for pushes"
     assert stack_index < migration_index < pytest_index < gate_index
@@ -605,6 +650,21 @@ def test_ci_keeps_the_required_python_status_and_calls_fix_pin_after_pytest() ->
     ]
     assert '--event "$GITHUB_EVENT_PATH"' in _string(gate, "run")
 
+    probe = steps[probe_index]
+    assert _string(probe, "if") == "github.event_name == 'pull_request'", (
+        "the cargo probe must run for every pull request, including bodies with "
+        "no live selector; gating it on its own output would skip the decision"
+    )
+    assert probe.get("id") == "fix-pin-curie"
+    assert shlex.split(_string(probe, "run")) == [
+        "python3",
+        "tools/fix-pin-ci/check.py",
+        "--event",
+        "$GITHUB_EVENT_PATH",
+        "--needs-curie",
+    ]
+    assert '--event "$GITHUB_EVENT_PATH"' in _string(probe, "run")
+
     release_build_index = _single_step_index(
         steps,
         lambda step: _string(step, "run").strip()
@@ -621,7 +681,7 @@ def test_ci_keeps_the_required_python_status_and_calls_fix_pin_after_pytest() ->
     for index in (release_build_index, helm_index):
         assert _pull_request_only(steps[index]), "selector tooling must not affect push runs"
         assert pytest_index < index < gate_index
-    assert release_build_index < helm_index < gate_index
+    assert pytest_index < probe_index < release_build_index < helm_index < gate_index
     assert not any(
         _string(step, "uses") == "Swatinem/rust-cache@v2" for step in steps
     ), "the Python job must build directly without a Cargo cache dependency"
@@ -641,27 +701,30 @@ def test_ci_keeps_the_required_python_status_and_calls_fix_pin_after_pytest() ->
     assert gate_index < diagnostic_index
 
 
-DECLARATION_GUARD = "contains(github.event.pull_request.body, 'Fix pin:')"
+CARGO_NEEDED_GUARD = "steps.fix-pin-curie.outputs.needed == 'true'"
+SUBSTRING_GUARD = "contains(github.event.pull_request.body, 'Fix pin:')"
 
 
-def test_selector_tooling_builds_only_when_the_body_declares_a_fix_pin() -> None:
-    """The cargo build must be gated on a declaration, and gated the safe way.
+def test_selector_tooling_builds_only_when_the_parser_would_invoke_curie() -> None:
+    """The cargo build must be gated on the declaration parser, not a substring.
 
     check.py reaches the binary at exactly one place, the `curie dev
     verify-fix-pin` call, and only once `declaration.selector` is set. `n/a`, no
-    declaration, a near-miss marker and the bug-without-declaration rejection all
-    return first. Building unconditionally therefore spent a cold
-    `cargo build --release` inside the longest job on the graph for a binary that
-    the majority of pull requests never run.
+    declaration, a near-miss marker, HTML-comment examples in the pull request
+    template, and the bug-without-declaration rejection all return first.
 
-    The guard must stay a strict SUPERSET of the cases that reach the binary.
-    `contains()` is case-insensitive and DECLARATION is the exact-case
-    `Fix pin: <selector>`, so a body that reaches the binary always contains the
-    substring. Skipping a build the gate then needs would be the unsafe
-    direction, and this pins that it cannot happen.
+    `#2228` gated cargo with `contains(..., 'Fix pin:')`. The default template
+    embeds those exact bytes inside `<!-- -->`, so the 3.5 min release build
+    still ran on every pull request that kept the template. The probe must
+    reuse `_declaration` so a commented example cannot trigger the build, and
+    a live `Fix pin: <selector>` line still cannot skip it.
     """
     document = _load_ci()
     _, steps = _python_job(document)
+
+    probe = steps[_single_step_index(steps, _is_fix_pin_probe, "fix pin cargo probe")]
+    assert probe.get("id") == "fix-pin-curie"
+    assert "--needs-curie" in shlex.split(_string(probe, "run"))
 
     for description, predicate in (
         (
@@ -678,24 +741,84 @@ def test_selector_tooling_builds_only_when_the_body_declares_a_fix_pin() -> None
         step = steps[_single_step_index(steps, predicate, description)]
         condition = _string(step, "if")
         assert PR_CONDITION.search(condition), f"{description} must stay pull-request only"
-        assert DECLARATION_GUARD in condition, (
-            f"{description} must build only when the body declares a Fix pin: {condition!r}"
+        assert CARGO_NEEDED_GUARD in condition, (
+            f"{description} must build only when the parser says the binary "
+            f"is needed: {condition!r}"
+        )
+        assert SUBSTRING_GUARD not in condition, (
+            f"{description} must not use the template-matching substring: {condition!r}"
         )
 
-    # The gate itself must NOT carry the guard. It is the step that decides a
-    # missing declaration is acceptable, and a body-shaped `if` on it would turn
-    # the "closes a bug with no declaration" rejection into a skipped step.
-    gate = steps[
-        _single_step_index(
-            steps,
-            lambda step: "tools/fix-pin-ci/check.py" in _string(step, "run"),
-            "fix pin caller",
-        )
-    ]
-    assert DECLARATION_GUARD not in _string(gate, "if"), (
+    # The gate itself must NOT carry the cargo guard. It is the step that
+    # decides a missing declaration is acceptable, and a body-shaped `if` on it
+    # would turn the "closes a bug with no declaration" rejection into a
+    # skipped step.
+    gate = steps[_single_step_index(steps, _is_fix_pin_gate, "fix pin caller")]
+    assert CARGO_NEEDED_GUARD not in _string(gate, "if"), (
         "the gate must still run for a body with no declaration, or the "
         "bug-without-declaration rejection can never fire"
     )
+    assert SUBSTRING_GUARD not in _string(gate, "if")
+
+
+def test_default_template_body_does_not_need_curie(tmp_path: Path) -> None:
+    """The template's commented `Fix pin:` examples must not trigger cargo."""
+    completed = _run_needs_curie(tmp_path, PR_TEMPLATE.read_text(encoding="utf-8"))
+
+    assert completed.returncode == 0, completed.stderr
+    assert _needed_output(tmp_path) == "needed=false\n"
+
+
+def test_real_selector_line_needs_curie(tmp_path: Path) -> None:
+    completed = _run_needs_curie(tmp_path, f"Fix pin: {VALID_SELECTOR}\n")
+
+    assert completed.returncode == 0, completed.stderr
+    assert _needed_output(tmp_path) == "needed=true\n"
+
+
+def test_template_plus_real_selector_still_needs_curie(tmp_path: Path) -> None:
+    body = PR_TEMPLATE.read_text(encoding="utf-8") + f"\nFix pin: {VALID_SELECTOR}\n"
+    completed = _run_needs_curie(tmp_path, body)
+
+    assert completed.returncode == 0, completed.stderr
+    assert _needed_output(tmp_path) == "needed=true\n"
+
+
+def test_not_applicable_does_not_need_curie(tmp_path: Path) -> None:
+    """`n/a` skips the verifier today, so cargo is extra work, not a requirement.
+
+    `#2228` documented building on `n/a` as a safe extra because `contains()`
+    could not tell it from a selector. The parser can, and the binary is not
+    invoked, so the probe reports needed=false.
+    """
+    completed = _run_needs_curie(
+        tmp_path, "Fix pin: n/a - the fix is a chart template with no test surface\n"
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert _needed_output(tmp_path) == "needed=false\n"
+
+
+def test_html_comment_selector_does_not_need_curie(tmp_path: Path) -> None:
+    completed = _run_needs_curie(tmp_path, f"<!-- Fix pin: {VALID_SELECTOR} -->\n")
+
+    assert completed.returncode == 0, completed.stderr
+    assert _needed_output(tmp_path) == "needed=false\n"
+
+
+def test_malformed_declaration_does_not_need_curie(tmp_path: Path) -> None:
+    """A declaration error fails the gate without calling curie."""
+    completed = _run_needs_curie(tmp_path, f" Fix pin: {VALID_SELECTOR}\n")
+
+    assert completed.returncode == 0, completed.stderr
+    assert _needed_output(tmp_path) == "needed=false\n"
+
+
+def test_needs_curie_fails_closed_without_github_output(tmp_path: Path) -> None:
+    completed = _run_needs_curie(tmp_path, f"Fix pin: {VALID_SELECTOR}\n", github_output=False)
+
+    assert completed.returncode != 0
+    assert "GITHUB_OUTPUT" in completed.stderr
 
 
 def test_pull_request_template_documents_the_required_declaration() -> None:

--- a/tools/fix-pin-ci/tests/test_fix_pin_ci.py
+++ b/tools/fix-pin-ci/tests/test_fix_pin_ci.py
@@ -563,10 +563,22 @@ def test_ci_keeps_the_required_python_status_and_calls_fix_pin_after_pytest() ->
         lambda step: "uv run alembic upgrade head" in _string(step, "run"),
         "shared database migration",
     )
+    # Matched on the prefix, not on equality. What this assertion is for is that
+    # the normal suite runs, unfiltered, before the gate; reporting flags like
+    # --durations do not bear on that, and pinning the exact string made a
+    # profiling flag look like a contract change.
     pytest_index = _single_step_index(
         steps,
-        lambda step: _string(step, "run").strip() == "uv run pytest -q",
+        lambda step: _string(step, "run").strip().startswith("uv run pytest -q"),
         "normal Python suite",
+    )
+    pytest_command = shlex.split(_string(steps[pytest_index], "run").strip())
+    assert pytest_command[:4] == ["uv", "run", "pytest", "-q"]
+    assert all(
+        argument.startswith("--durations") for argument in pytest_command[4:]
+    ), (
+        "the Python suite must run unfiltered: only reporting flags may be added "
+        f"to `uv run pytest -q`, got {pytest_command!r}"
     )
     gate_index = _single_step_index(
         steps,


### PR DESCRIPTION
## Summary

Forward-merges the stable `v0.8.5` release tag into the `next` release train, retaining the two commits already merged to `next`. The merge was conflict-free. The combined candidate exposed two stale guide citations to an SRE-bot connector and manifest removed on `next`; this PR updates the guide to the current self-upgrade connector and its RBAC manifest.

## Related issue

Release-train forward merge; no issue is closed.

## Fix pin verification

Not applicable: this integration repair closes no bug-tracker issue.

## End-to-end verification

This change does not alter runtime behavior because it integrates already-reviewed `v0.8.5` commits and corrects documentation citations/examples only.

Scoped verification: `git diff --check origin/next...HEAD` — passed with no whitespace errors; `git merge-base --is-ancestor v0.8.5 HEAD` — passed; `git rev-list --left-right --count origin/next...HEAD` — `0 53`, confirming current `next` is an ancestor; `bash scripts/check-docs.sh` at `8c2477c7` — passed with a generated, drift-free catalog and all citations resolving. CI on this PR is the required combined-candidate verification.

## Checklist

- [x] The merge is conflict-free and contains the `v0.8.5` tag.
- [x] Current `next` is retained as an ancestor.
- [x] Documentation citations resolve against the combined candidate.
- [ ] Required PR checks pass on the combined candidate.
- [x] No ADR is needed: this is release-train integration and a documentation repair, not an architectural decision.