### PR TITLE
fix: preserve runner timeout terminal cause

### DIFF
--- a/apps/worker/src/curie_worker/runner_client.py
+++ b/apps/worker/src/curie_worker/runner_client.py
@@ -50,6 +50,9 @@ _DEFAULT_INTERRUPT_TIMEOUT_S = 5.0
 _MIN_REQUEST_TIMEOUT_S = 0.05
 _POST_FINAL_CLEANUP_TIMEOUT_S = 1.0
 _POST_FINAL_DISCARD_CHUNK_BYTES = 64 * 1024
+_TURN_EPOCH_HEADER = "X-Curie-Turn-Epoch"
+_TURN_EPOCH_MIN_LENGTH = 32
+_TURN_EPOCH_MAX_LENGTH = 256
 _T = TypeVar("_T")
 
 logger = logging.getLogger(__name__)
@@ -74,6 +77,16 @@ def _mark_rpc_failed(span: Any, outcome: str, cause: BaseException) -> None:
     span.add_event(
         "runner.rpc.failed",
         {"outcome": outcome, "error.class": type(cause).__name__},
+    )
+
+
+def _valid_turn_epoch(value: str | None) -> bool:
+    """Accept only the runner's bounded, URL-safe opaque turn capability."""
+    return bool(
+        value
+        and _TURN_EPOCH_MIN_LENGTH <= len(value) <= _TURN_EPOCH_MAX_LENGTH
+        and value.isascii()
+        and all(character.isalnum() or character in "-_" for character in value)
     )
 
 
@@ -111,7 +124,10 @@ class TurnStream:
     """An open ``/v1/event`` response: the turn is active; iterate for frames."""
 
     def __init__(
-        self, response: aiohttp.ClientResponse, budget_s: float | None = None
+        self,
+        response: aiohttp.ClientResponse,
+        budget_s: float | None = None,
+        timeout_callback: Callable[[], Awaitable[None]] | None = None,
     ) -> None:
         self._response = response
         self._saw_final = False
@@ -119,6 +135,10 @@ class TurnStream:
         # client so the stream can NAME the budget it blew (#2011). Optional so
         # a directly-constructed TurnStream (tests, evals) still works.
         self._budget_s = budget_s
+        # A successful /v1/event response may bind its opaque turn epoch to a
+        # separately bounded control call. Consume it before awaiting so a
+        # repeated iterator cannot notify the same turn twice.
+        self._timeout_callback = timeout_callback
 
     async def __aiter__(self) -> AsyncIterator[OutboundEvent]:
         try:
@@ -145,7 +165,24 @@ class TurnStream:
             # subclass TimeoutError, so cooperative cancellation still passes
             # straight through -- do not broaden this clause.
             self._record_stream_timeout(cause)
+            await self._notify_timeout()
             raise RunnerStreamTimeout(self._timeout_reason(cause)) from cause
+
+    async def _notify_timeout(self) -> None:
+        callback = self._timeout_callback
+        self._timeout_callback = None
+        if callback is None:
+            return
+        try:
+            await callback()
+        except Exception as exc:  # noqa: BLE001 - preserve the causal body timeout
+            # The epoch, bearer, and response body are deliberately absent. A
+            # failed notification leaves abandonment as the runner's truthful
+            # best-effort terminal, but must never replace RunnerStreamTimeout.
+            logger.warning(
+                "runner timeout terminal notification failed (%s)",
+                type(exc).__name__,
+            )
 
     def _timeout_reason(self, cause: BaseException) -> str:
         budget = "unbounded" if self._budget_s is None else f"{self._budget_s}s"
@@ -378,9 +415,44 @@ class RunnerClient:
                 body = await resp.text()
                 resp.release()
                 raise RunnerError(f"/v1/event -> {resp.status}: {body}")
-            return TurnStream(resp, stream_timeout_s), "success"
+            turn_epoch = resp.headers.get(_TURN_EPOCH_HEADER)
+            timeout_callback: Callable[[], Awaitable[None]] | None = None
+            if _valid_turn_epoch(turn_epoch):
+                # ``turn_epoch`` is narrowed by the validation above. Keep the
+                # callback response-bound so a retry can never inherit a stale
+                # epoch from an earlier /v1/event.
+                async def notify_timeout() -> None:
+                    assert turn_epoch is not None
+                    await self._notify_timeout(base_url, turn_epoch, token)
+
+                timeout_callback = notify_timeout
+            return TurnStream(resp, stream_timeout_s, timeout_callback), "success"
 
         return await self._rpc("event", token, request)
+
+    async def _notify_timeout(
+        self,
+        base_url: str,
+        turn_epoch: str,
+        token: str | None,
+    ) -> None:
+        """Best-effort causal timeout notification for one accepted turn."""
+
+        async def request(headers: dict[str, str] | None) -> tuple[None, str]:
+            control_headers = dict(headers or {})
+            control_headers[_TURN_EPOCH_HEADER] = turn_epoch
+            async with self._session.post(
+                f"{base_url}/v1/timeout",
+                headers=control_headers,
+                timeout=self._interrupt_timeout,
+            ) as resp:
+                if resp.status not in (200, 409):
+                    # Do not read or echo an arbitrary response body on this
+                    # sensitive best-effort path.
+                    raise RunnerError(f"/v1/timeout -> {resp.status}")
+                return None, "conflict" if resp.status == 409 else "success"
+
+        await self._rpc("timeout", token, request)
 
     async def steer(
         self,

--- a/apps/worker/tests/kernel/test_runner_client.py
+++ b/apps/worker/tests/kernel/test_runner_client.py
@@ -6,21 +6,32 @@ is what TurnStream.close (called from __aexit__) invokes."""
 
 from __future__ import annotations
 
+import ast
 import asyncio
+import contextlib
 import inspect
 import logging
+import textwrap
 import tracemalloc
 from typing import Any
 
 import pytest
-from aci_protocol import Event, Final, SessionStatus, TextDelta
+from aci_protocol import Event, Final, SessionStatus, SideEffectFlag, TextDelta
 from aiohttp import web
 from aiohttp.test_utils import TestServer
+from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock, ToolUseBlock
 from curie_runner import RunTracer, SideEffectClassifier, create_app
 from curie_runner import server as runner_server
+from curie_runner import session as runner_session_module
 from curie_runner.fake import FakeModelSession
 from curie_runner.session import SessionRunner
+from curie_telemetry.tracing import configure_tracer_provider
+from curie_worker import runner_client as runner_client_module
 from curie_worker.runner_client import RunnerClient, RunnerError, RunnerStreamTimeout
+from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import StatusCode
 
 DONE = SessionStatus.DONE
 
@@ -770,6 +781,31 @@ def test_interrupt_takes_no_remaining_budget_while_the_other_rpcs_do() -> None:
         "control path and keeps its own independent timeout"
     )
 
+    source = textwrap.dedent(inspect.getsource(RunnerClient))
+    tree = ast.parse(source)
+    timeout_posts = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        call_source = ast.get_source_segment(source, node) or ""
+        if (
+            isinstance(node.func, ast.Attribute)
+            and node.func.attr == "post"
+            and "/v1/timeout" in call_source
+        ):
+            timeout_posts.append(node)
+
+    assert len(timeout_posts) == 1, "RunnerClient must own one /v1/timeout POST"
+    timeout_keywords = {
+        keyword.arg: ast.unparse(keyword.value)
+        for keyword in timeout_posts[0].keywords
+        if keyword.arg is not None
+    }
+    assert timeout_keywords.get("timeout") == "self._interrupt_timeout", (
+        "/v1/timeout must use the independent control-plane cap, never the "
+        "expired stream/delivery budget"
+    )
+
 
 def test_interrupt_keeps_its_own_timeout_under_a_huge_streaming_budget() -> None:
     """The behavioral half of the guard above. With a 30s session budget and a
@@ -853,5 +889,438 @@ def test_stream_timeout_raises_a_named_timeout_and_logs_the_expired_budget(
             finally:
                 hold.set()
                 await client.close()
+
+    asyncio.run(go())
+
+
+_PRIVATE_EVENT_TEXT = "private-timeout-event-body-PLACEHOLDER"
+_PRIVATE_TOOL_CALL = "private-timeout-tool-call-PLACEHOLDER"
+_PRIVATE_TOOL_ARGUMENT = "private-timeout-tool-argument-PLACEHOLDER"
+_PRIVATE_POST_TIMEOUT_TEXT = "private-post-timeout-body-PLACEHOLDER"
+_RUNNER_TOKEN = "runner-token-PLACEHOLDER"
+_TURN_EPOCH_HEADER = "X-Curie-Turn-Epoch"
+
+
+class _TimeoutBoundaryFake(FakeModelSession):
+    """Stall after a side-effect prefix, with two real interrupt shapes."""
+
+    def __init__(self, *, release_on_interrupt: bool) -> None:
+        script = [
+            AssistantMessage(
+                content=[
+                    ToolUseBlock(
+                        id=_PRIVATE_TOOL_CALL,
+                        name="Bash",
+                        input={"command": _PRIVATE_TOOL_ARGUMENT},
+                    )
+                ],
+                model="fake-model",
+            ),
+            AssistantMessage(
+                content=[TextBlock(text=_PRIVATE_POST_TIMEOUT_TEXT)],
+                model="fake-model",
+            ),
+        ]
+        super().__init__(
+            lambda: script,
+            truncate_on_interrupt=release_on_interrupt,
+        )
+        self._release_on_interrupt = release_on_interrupt
+        self.entered = asyncio.Event()
+        self.release = asyncio.Event()
+        self.notified = asyncio.Event()
+        self.post_timeout_emitted = asyncio.Event()
+
+    async def receive_turn(self):
+        index = 0
+        async for message in super().receive_turn():
+            if index:
+                self.post_timeout_emitted.set()
+            yield message
+            if index == 0:
+                self.entered.set()
+                await self.release.wait()
+            index += 1
+
+    async def interrupt(self) -> None:
+        await super().interrupt()
+        self.notified.set()
+        if self._release_on_interrupt:
+            self.release.set()
+
+    async def close(self) -> None:
+        self.release.set()
+        await super().close()
+
+
+def _span_material(spans: list[ReadableSpan]) -> str:
+    return repr(
+        [
+            (
+                span.name,
+                dict(span.attributes or {}),
+                [(event.name, dict(event.attributes or {})) for event in span.events],
+                span.status,
+            )
+            for span in spans
+        ]
+    )
+
+
+async def _assert_real_timeout_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    release_on_interrupt: bool,
+) -> list[tuple[str, dict[str, str]]]:
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    fake = _TimeoutBoundaryFake(release_on_interrupt=release_on_interrupt)
+    runner = SessionRunner(
+        session_factory=lambda: fake,
+        ceiling=0,
+        tracer=RunTracer(provider),
+        classifier=SideEffectClassifier(),
+        trace_name="curie-run:test",
+        model="fake-model",
+    )
+    metrics: list[tuple[str, dict[str, str]]] = []
+
+    def capture_metric(
+        name: str,
+        _value: float = 1,
+        *,
+        attributes: dict[str, str],
+    ) -> None:
+        metrics.append((name, dict(attributes)))
+
+    monkeypatch.setattr(runner_session_module, "record_metric", capture_metric)
+    worker_record_metric = runner_client_module.record_metric
+
+    def capture_worker_metric(
+        name: str,
+        value: float = 1,
+        *,
+        attributes: dict[str, str],
+    ) -> None:
+        # Keep the real catalog validator in the path. A capture-only double
+        # would hide the exact closed-domain failure this boundary regressed.
+        worker_record_metric(name, value, attributes=attributes)
+        metrics.append((name, dict(attributes)))
+
+    monkeypatch.setattr(runner_client_module, "record_metric", capture_worker_metric)
+    original_event = runner_server._event
+    handler_done = asyncio.Event()
+    handler_errors: list[BaseException] = []
+
+    async def wrapped_event(request: web.Request) -> web.StreamResponse:
+        try:
+            return await original_event(request)
+        except BaseException as exc:
+            handler_errors.append(exc)
+            raise
+        finally:
+            handler_done.set()
+
+    monkeypatch.setattr(runner_server, "_event", wrapped_event)
+    await runner.start()
+    server = TestServer(create_app(runner, token=_RUNNER_TOKEN))
+    await server.start_server()
+    client = RunnerClient(total_timeout_s=0.25, interrupt_timeout_s=2.0)
+    frames: list[Any] = []
+    epoch = ""
+    parent_trace_id = 0
+    configure_tracer_provider(provider)
+    try:
+        tracer = provider.get_tracer("timeout-boundary-test")
+        with tracer.start_as_current_span("worker.timeout.parent") as parent:
+            parent_trace_id = parent.get_span_context().trace_id
+            turn = await client.start_turn(
+                f"http://127.0.0.1:{server.port}",
+                Event(
+                    type="message",
+                    text=_PRIVATE_EVENT_TEXT,
+                    user="U0EXAMPLE1",
+                    ts="1",
+                ),
+                token=_RUNNER_TOKEN,
+                remaining_s=0.25,
+            )
+            epoch = turn._response.headers[_TURN_EPOCH_HEADER]
+            with pytest.raises(RunnerStreamTimeout):
+                async with turn:
+                    async for frame in turn:
+                        frames.append(frame)
+
+        await asyncio.wait_for(fake.notified.wait(), timeout=2.0)
+        if not release_on_interrupt:
+            # The control response has returned and TurnStream has released the
+            # body. Only now let the SDK emit a non-terminal line: response.write
+            # must fail and aclosing must inject GeneratorExit (or cancellation)
+            # while run_turn is suspended at its yield.
+            fake.release.set()
+            await asyncio.wait_for(fake.post_timeout_emitted.wait(), timeout=2.0)
+        await asyncio.wait_for(handler_done.wait(), timeout=2.0)
+    finally:
+        fake.release.set()
+        await client.close()
+        await server.close()
+        configure_tracer_provider(None)
+
+    assert any(isinstance(frame, SideEffectFlag) for frame in frames)
+    spans = list(exporter.get_finished_spans())
+    roots = [span for span in spans if span.name == "agent.run"]
+    assert len(roots) == 1
+    root = roots[0]
+    assert root.attributes["curie.terminal.cause"] == "runner_timeout"
+    assert root.attributes["curie.terminal.status"] == "failed"
+    assert root.status.status_code is StatusCode.ERROR
+    assert root.context is not None and root.context.trace_id == parent_trace_id
+    assert root.parent is not None
+    parent_rpc = next(
+        span
+        for span in spans
+        if span.context is not None and span.context.span_id == root.parent.span_id
+    )
+    assert parent_rpc.name == "curie.runner.rpc"
+    assert parent_rpc.attributes["curie.operation"] == "event"
+    for phase in (
+        span
+        for span in spans
+        if span.name in {"llm.generation", "execute_tool"}
+    ):
+        assert phase.end_time is not None
+        assert "curie.phase.end_kind" in phase.attributes
+    tool = next(span for span in spans if span.name == "execute_tool")
+    assert tool.attributes["curie.phase.end_kind"] == "terminal_inferred"
+    assert tool.attributes["curie.tool.outcome"] == "cancelled"
+    assert tool.status.status_code is StatusCode.ERROR
+
+    completed = [
+        attributes
+        for name, attributes in metrics
+        if name == "curie.turn.completed"
+    ]
+    assert completed == [
+        {
+            "service.name": "curie-runner",
+            "source": "runner",
+            "outcome": "classified_failure",
+        }
+    ]
+    material = _span_material(spans)
+    for private_value in (
+        epoch,
+        _RUNNER_TOKEN,
+        _PRIVATE_EVENT_TEXT,
+        _PRIVATE_TOOL_CALL,
+        _PRIVATE_TOOL_ARGUMENT,
+        _PRIVATE_POST_TIMEOUT_TEXT,
+    ):
+        assert private_value not in material
+    if not release_on_interrupt:
+        assert handler_errors, "released-body post-timeout write must fail"
+    assert fake.interrupts == 1, "an ACKed timeout stop must not be sent twice"
+    return metrics
+
+
+def test_real_http_timeout_unblocks_live_consumer_with_first_failure_terminal(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    metrics = asyncio.run(
+        _assert_real_timeout_boundary(monkeypatch, release_on_interrupt=True)
+    )
+    timeout_rpc_attributes = {
+        "service.name": "curie-worker",
+        "operation": "timeout",
+        "role": "client",
+        "outcome": "success",
+    }
+    assert (
+        "curie.runner.rpc.request.duration",
+        timeout_rpc_attributes,
+    ) in metrics
+    assert ("curie.runner.rpc.result", timeout_rpc_attributes) in metrics
+    assert not any(
+        "runner timeout terminal notification failed" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+def test_real_http_timeout_terminalizes_before_released_body_write_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    asyncio.run(
+        _assert_real_timeout_boundary(monkeypatch, release_on_interrupt=False)
+    )
+
+
+class _ProductionTimeoutPostureSession:
+    """Ordered wire double for aiohttp's production non-cancelling posture."""
+
+    def __init__(self) -> None:
+        self.wire: list[tuple[str, str | int]] = []
+        self.queries = 0
+        self.interrupts = 0
+        self.first_prefix_emitted = asyncio.Event()
+        self.end_first_receive = asyncio.Event()
+        self.interrupt_entered = asyncio.Event()
+        self.release_ack = asyncio.Event()
+        self.interrupt_returned = asyncio.Event()
+        self.interrupt_cancelled = asyncio.Event()
+        self.second_query_started = asyncio.Event()
+
+    async def connect(self) -> None: ...
+
+    async def query(self, text: str) -> None:
+        self.queries += 1
+        self.wire.append(("query", text))
+        if self.queries == 2:
+            self.second_query_started.set()
+
+    async def receive_turn(self):
+        if self.queries == 1:
+            yield AssistantMessage(
+                content=[
+                    ToolUseBlock(
+                        id="production-timeout-call-PLACEHOLDER",
+                        name="Read",
+                        input={"path": "production-timeout-path-PLACEHOLDER"},
+                    )
+                ],
+                model="fake-model",
+            )
+            self.first_prefix_emitted.set()
+            await self.end_first_receive.wait()
+            # Keep the first turn non-terminal after the ACK. Its attempted
+            # write to the released response drives the GeneratorExit cleanup.
+            yield AssistantMessage(
+                content=[TextBlock(text="post-timeout-PLACEHOLDER")],
+                model="fake-model",
+            )
+            return
+        yield ResultMessage(
+            subtype="success",
+            duration_ms=1,
+            duration_api_ms=1,
+            is_error=False,
+            num_turns=1,
+            session_id="sdk-session-PLACEHOLDER",
+            result="healthy",
+        )
+
+    async def interrupt(self) -> None:
+        self.interrupts += 1
+        self.wire.append(("interrupt", self.interrupts))
+        self.interrupt_entered.set()
+        try:
+            await self.release_ack.wait()
+        except asyncio.CancelledError:
+            self.interrupt_cancelled.set()
+            raise
+        self.end_first_receive.set()
+        self.interrupt_returned.set()
+
+    async def close(self) -> None:
+        self.release_ack.set()
+        self.end_first_receive.set()
+
+
+def test_production_http_timeout_handler_holds_next_query_until_ack(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    async def go() -> None:
+        session = _ProductionTimeoutPostureSession()
+        runner = SessionRunner(
+            session_factory=lambda: session,
+            ceiling=0,
+            tracer=RunTracer(None),
+            classifier=SideEffectClassifier(),
+            trace_name="t",
+        )
+        await runner.start()
+        app_runner = web.AppRunner(
+            create_app(runner, token=_RUNNER_TOKEN), handler_cancellation=False
+        )
+        await app_runner.setup()
+        site = web.TCPSite(app_runner, "127.0.0.1", 0)
+        await site.start()
+        assert site._server is not None  # noqa: SLF001 - ephemeral bound port
+        sockets = site._server.sockets  # noqa: SLF001 - aiohttp exposes no port API
+        assert sockets is not None
+        port = sockets[0].getsockname()[1]
+        base_url = f"http://127.0.0.1:{port}"
+        client = RunnerClient(total_timeout_s=2.0, interrupt_timeout_s=0.05)
+        second_frames: list[Any] = []
+        second_stream_opened = asyncio.Event()
+        second_task: asyncio.Task[None] | None = None
+
+        async def consume_second() -> None:
+            turn = await client.start_turn(
+                base_url,
+                Event(
+                    type="message",
+                    text="second",
+                    user="U0EXAMPLE1",
+                    ts="2",
+                ),
+                token=_RUNNER_TOKEN,
+                remaining_s=2.0,
+            )
+            second_stream_opened.set()
+            async with turn:
+                async for frame in turn:
+                    second_frames.append(frame)
+
+        try:
+            first = await client.start_turn(
+                base_url,
+                Event(
+                    type="message",
+                    text="first",
+                    user="U0EXAMPLE1",
+                    ts="1",
+                ),
+                token=_RUNNER_TOKEN,
+                remaining_s=0.05,
+            )
+            with caplog.at_level(logging.WARNING, logger="curie_worker.runner_client"):
+                with pytest.raises(RunnerStreamTimeout):
+                    async with first:
+                        async for _frame in first:
+                            pass
+
+            await asyncio.wait_for(session.interrupt_entered.wait(), timeout=1.0)
+            second_task = asyncio.create_task(consume_second())
+            await asyncio.wait_for(second_stream_opened.wait(), timeout=1.0)
+            assert not session.interrupt_cancelled.is_set()
+            assert not session.second_query_started.is_set()
+
+            session.release_ack.set()
+            await asyncio.wait_for(session.interrupt_returned.wait(), timeout=1.0)
+            await asyncio.wait_for(session.second_query_started.wait(), timeout=1.0)
+            await asyncio.wait_for(second_task, timeout=1.0)
+
+            assert session.interrupts == 1
+            assert session.wire == [
+                ("query", "first"),
+                ("interrupt", 1),
+                ("query", "second"),
+            ]
+            assert isinstance(second_frames[-1], Final)
+            assert second_frames[-1].status is SessionStatus.DONE
+            assert any(
+                "runner timeout terminal notification failed"
+                in record.getMessage()
+                for record in caplog.records
+            )
+        finally:
+            session.release_ack.set()
+            if second_task is not None and not second_task.done():
+                second_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await second_task
+            await client.close()
+            await app_runner.cleanup()
 
     asyncio.run(go())

--- a/docs/interfaces/aci-producer/INTERFACE.md
+++ b/docs/interfaces/aci-producer/INTERFACE.md
@@ -33,11 +33,14 @@ redefine them.
 ## Current contract
 
 A second implementation is an **ACI server**, an HTTP process serving
-the five POST endpoints (`runner/src/curie_runner/server.py`): `POST /v1/event` opens a
+the six POST endpoints (`runner/src/curie_runner/server.py`): `POST /v1/event` opens a
 turn, `POST /v1/steer` injects into the live turn (409 if none running),
 `POST /v1/interrupt` hard-stops it, `POST /v1/reset` discards the conversation so the
-next turn starts fresh (409 while a turn is active), and `POST /v1/snapshot` captures a
-bounded managed-workspace snapshot for publication. Two GETs sit alongside them and stay
+next turn starts fresh (409 while a turn is active), `POST /v1/snapshot` captures a
+bounded managed-workspace snapshot for publication, and `POST /v1/timeout` stops the
+exact open turn named by the event response epoch. The timeout is a runner-private,
+authenticated control route; a server that omits the epoch response header is simply
+not notified, and worker timeout classification remains unaffected. Two GETs sit alongside them and stay
 unauthenticated, `GET /healthz` and `GET /status`, because the chart's readiness probe
 sends no auth header. `/v1/reset` carries no ACI wire frame (it is a runner control route,
 like the GETs, and takes no body), but it is not optional: it is the per-case isolation

--- a/docs/interfaces/aci-producer/implementing-an-aci-server.md
+++ b/docs/interfaces/aci-producer/implementing-an-aci-server.md
@@ -17,7 +17,7 @@ truth (the committed JSON Schema and generated Rust/TS are derived from them).
 
 ## What "an ACI server" is
 
-An ACI server is an **HTTP process** inside the sandbox that exposes five POST
+An ACI server is an **HTTP process** inside the sandbox that exposes six POST
 routes and streams NDJSON back:
 
 | Route | Purpose |
@@ -27,6 +27,7 @@ routes and streams NDJSON back:
 | `POST /v1/interrupt` | Hard-stop the live turn. Body is an `interrupt` frame; the open turn's `final` is reclassified to idle. |
 | `POST /v1/reset` | Discard the conversation and start a fresh model session, so the next turn cannot answer from earlier history; return `409` while a turn is active. No body, no wire frame (#550). |
 | `POST /v1/snapshot` | Capture a bounded, credential-free snapshot of the managed repository workspace for the authenticated worker; return `409` when the session has no managed workspace. |
+| `POST /v1/timeout` | Stop the exact open turn named by the event response epoch. This runner-private control route is authenticated; a server omitting the epoch response header is simply not notified, and worker timeout classification remains unaffected. |
 
 Plus two unauthenticated GETs the platform relies on: `GET /healthz` (liveness)
 and `GET /status` (session status + readiness). The chart's readiness probe hits
@@ -181,6 +182,10 @@ Route contract to honor:
   turn is active, rather than resetting under an open `/v1/event` stream.
 - **`/v1/snapshot`**: no body. Return the bounded managed-workspace snapshot to
   the authenticated worker, or **409** when no managed workspace is mounted.
+- **`/v1/timeout`**: no body. Require the event response's opaque epoch header and
+  stop only that open turn. This is a runner-private authenticated control route;
+  servers omitting the response header are simply not notified, and worker timeout
+  classification remains unaffected.
 - **`/healthz`**, **`/status`**: always-open GETs; `/status` returns
   `{status, ready, turn_active}`.
 - **Auth (optional):** when a bearer token is configured, require

--- a/packages/telemetry/schema/metrics.json
+++ b/packages/telemetry/schema/metrics.json
@@ -671,7 +671,8 @@
           "steer",
           "interrupt",
           "reset",
-          "status"
+          "status",
+          "timeout"
         ],
         "role": [
           "client"
@@ -683,7 +684,7 @@
           "timeout"
         ]
       },
-      "cardinality_bound": 20
+      "cardinality_bound": 24
     },
     "curie.runner.rpc.result": {
       "type": "counter",
@@ -699,7 +700,8 @@
           "steer",
           "interrupt",
           "reset",
-          "status"
+          "status",
+          "timeout"
         ],
         "role": [
           "client"
@@ -711,7 +713,7 @@
           "timeout"
         ]
       },
-      "cardinality_bound": 20
+      "cardinality_bound": 24
     },
     "curie.approval.lifecycle": {
       "type": "counter",

--- a/packages/telemetry/src/curie_telemetry/metrics.py
+++ b/packages/telemetry/src/curie_telemetry/metrics.py
@@ -108,7 +108,7 @@ _SANDBOX_INVENTORY_ATTRIBUTES = {
 }
 _RUNNER_RPC_ATTRIBUTES = {
     "service.name": ["curie-worker"],
-    "operation": ["event", "steer", "interrupt", "reset", "status"],
+    "operation": ["event", "steer", "interrupt", "reset", "status", "timeout"],
     "role": ["client"],
     "outcome": ["success", "failure", "conflict", "timeout"],
 }

--- a/runner/src/curie_runner/otel.py
+++ b/runner/src/curie_runner/otel.py
@@ -496,12 +496,15 @@ class _GenerationSpan:
         *,
         interrupt_requested: bool,
         classified_failure: bool,
+        timeout_requested: bool = False,
         approval_paused: bool = False,
         completed_without_result: bool = False,
     ) -> None:
         """Apply the closed terminal mapping after the ACI final is decided."""
 
-        if interrupt_requested:
+        if timeout_requested:
+            self._finish("runner_timeout", "failed", failed=True)
+        elif interrupt_requested:
             self._finish("interrupt_requested", "cancelled", failed=False)
         elif approval_paused:
             self._finish("approval_required", "paused", failed=False)

--- a/runner/src/curie_runner/server.py
+++ b/runner/src/curie_runner/server.py
@@ -13,6 +13,8 @@ Productizes the prototype's aiohttp ``/run`` into the ACI session channel:
                          caller falls back to a fresh ``/v1/event``
 - ``POST /v1/interrupt`` hard-stop the live turn: body is an ACI ``interrupt``
                          frame; the open turn's final is reclassified to idle
+- ``POST /v1/timeout``   mark the exact open turn as timed out and stop it; the
+                         opaque epoch is carried only in a response/request header
 - ``POST /v1/reset``     discard the conversation and start a fresh model
                          session (eval isolation, #550); 409 while a turn is
                          active. Not an ACI wire frame -- a runner control route,
@@ -28,6 +30,7 @@ from __future__ import annotations
 import contextlib
 import hmac
 import inspect
+import secrets
 from collections.abc import Awaitable, Callable
 from typing import cast
 
@@ -40,11 +43,23 @@ from .session import SessionRunner
 from .workspace_snapshot import WorkspaceSnapshot, WorkspaceSnapshotError
 
 _NDJSON = "application/x-ndjson"
+_TURN_EPOCH_HEADER = "X-Curie-Turn-Epoch"
+_TURN_EPOCH_MIN_LENGTH = 32
+_TURN_EPOCH_MAX_LENGTH = 256
 
-# The five runner POST routes; gated when a token is configured.
+# The six runner POST routes; gated when a token is configured.
 # /healthz and /status stay open so the chart readinessProbe (no auth header)
 # keeps working.
-_GATED_PATHS = frozenset({"/v1/event", "/v1/steer", "/v1/interrupt", "/v1/reset", "/v1/snapshot"})
+_GATED_PATHS = frozenset(
+    {
+        "/v1/event",
+        "/v1/steer",
+        "/v1/interrupt",
+        "/v1/timeout",
+        "/v1/reset",
+        "/v1/snapshot",
+    }
+)
 
 # Typed app key so aiohttp resolves the runner without the string-key warning.
 RUNNER: web.AppKey[SessionRunner] = web.AppKey("runner", SessionRunner)
@@ -89,7 +104,7 @@ def create_app(
 ) -> web.Application:
     """Build the aiohttp application bound to a started SessionRunner.
 
-    When ``token`` is set, the five runner POST routes require a matching bearer
+    When ``token`` is set, the six runner POST routes require a matching bearer
     token; when it is ``None`` the app is a pass-through (CLI, fake-model CI, and
     pre-token sandboxes stay unauthenticated).
     """
@@ -108,6 +123,7 @@ def create_app(
             web.post("/v1/event", _event),
             web.post("/v1/steer", _steer),
             web.post("/v1/interrupt", _interrupt),
+            web.post("/v1/timeout", _timeout),
             web.post("/v1/reset", _reset),
             web.post("/v1/snapshot", _snapshot),
         ]
@@ -175,7 +191,11 @@ async def _event(request: web.Request) -> web.StreamResponse:
             status=400,
         )
 
-    response = web.StreamResponse(status=200, headers={"Content-Type": _NDJSON})
+    turn_epoch = secrets.token_urlsafe(32)
+    response = web.StreamResponse(
+        status=200,
+        headers={"Content-Type": _NDJSON, _TURN_EPOCH_HEADER: turn_epoch},
+    )
     await response.prepare(request)
     # aclosing guarantees the generator is finalized on THIS driving task. On a
     # client disconnect, response.write() raises from this frame; without
@@ -188,7 +208,9 @@ async def _event(request: web.Request) -> web.StreamResponse:
     if traceparent is not None:
         carrier[TRACEPARENT_STREAM_FIELD] = traceparent
     parent = extract_trace_context(carrier)
-    async with contextlib.aclosing(runner.run_turn(frame, parent=parent)) as stream:
+    async with contextlib.aclosing(
+        runner.run_turn(frame, parent=parent, turn_epoch=turn_epoch)
+    ) as stream:
         async for line in stream:
             await response.write(line.encode("utf-8"))
     await response.write_eof()
@@ -222,6 +244,30 @@ async def _interrupt(request: web.Request) -> web.Response:
         return web.json_response({"error": "expected an interrupt frame"}, status=400)
 
     await runner.interrupt(frame.reason)
+    return web.json_response({"ok": True})
+
+
+def _valid_turn_epoch(epoch: str | None) -> bool:
+    """Whether an epoch header has the bounded opaque token shape we mint."""
+
+    return (
+        epoch is not None
+        and _TURN_EPOCH_MIN_LENGTH <= len(epoch) <= _TURN_EPOCH_MAX_LENGTH
+        and epoch.isascii()
+        and all(character.isalnum() or character in "-_" for character in epoch)
+    )
+
+
+async def _timeout(request: web.Request) -> web.Response:
+    """Stop only the currently open turn named by its private response epoch."""
+
+    runner: SessionRunner = request.app[RUNNER]
+    turn_epoch = request.headers.get(_TURN_EPOCH_HEADER)
+    if not _valid_turn_epoch(turn_epoch):
+        return web.json_response({"error": "invalid turn epoch"}, status=400)
+    assert turn_epoch is not None
+    if not await runner.timeout(turn_epoch):
+        return web.json_response({"error": "turn epoch is not active"}, status=409)
     return web.json_response({"ok": True})
 
 

--- a/runner/src/curie_runner/session.py
+++ b/runner/src/curie_runner/session.py
@@ -20,6 +20,7 @@ Responsibilities layered on the translation:
 from __future__ import annotations
 
 import contextlib
+import hmac
 import logging
 import time
 from collections.abc import AsyncGenerator, AsyncIterator, Callable
@@ -238,6 +239,19 @@ class SessionRunner:
         # over-permitting two concurrent turns on the single SDK generator.
         self._turn_lock = anyio.Semaphore(1, max_value=1)
         self._interrupt_requested = False
+        # Timeout is deliberately distinct from an ACI/operator interrupt: the
+        # former is a failed delivery boundary while the latter is an intentional
+        # cancellation. The opaque epoch binds the side-channel request to exactly
+        # this handler-owned turn without becoming an ACI field or trace attribute.
+        self._timeout_requested = False
+        # Set only for an accepted timeout control request. The SDK serializes
+        # control and query lines onto its stdin, and the CLI interrupt applies
+        # only to the query live when that line is read. The run-turn owner waits
+        # for this event before deciding whether the ordered stop was delivered
+        # or needs the abandonment safety-net below.
+        self._timeout_interrupt_settled: anyio.Event | None = None
+        self._timeout_interrupt_delivered = False
+        self._turn_epoch: str | None = None
         self._status = SessionStatus.IDLE_AWAITING_INPUT
         self._started = False
         # True only while a turn can still accept a steer: from turn start until
@@ -374,6 +388,10 @@ class SessionRunner:
             self._session = self._factory()
             await self._session.connect()
             self._interrupt_requested = False
+            self._timeout_requested = False
+            self._timeout_interrupt_settled = None
+            self._timeout_interrupt_delivered = False
+            self._turn_epoch = None
             self._turn_open = False
             self._status = SessionStatus.IDLE_AWAITING_INPUT
 
@@ -397,6 +415,40 @@ class SessionRunner:
         if self._session is not None:
             await self._session.interrupt()
 
+    async def timeout(self, turn_epoch: str) -> bool:
+        """Stop the exact current turn and mark its terminal as a timeout failure.
+
+        The accepted flag is stored before the SDK await so every completion race
+        sees timeout precedence. A replay, stale epoch, or call outside an open
+        turn is a no-op; in particular it cannot poison the next lock owner.
+        """
+
+        current_epoch = self._turn_epoch
+        if (
+            self._session is None
+            or not self._turn_open
+            or self._timeout_requested
+            or current_epoch is None
+            or not hmac.compare_digest(
+                turn_epoch.encode("utf-8"), current_epoch.encode("utf-8")
+            )
+        ):
+            return False
+        timeout_interrupt_settled = anyio.Event()
+        self._timeout_requested = True
+        self._timeout_interrupt_settled = timeout_interrupt_settled
+        try:
+            await self._session.interrupt()
+            # A delayed SDK acknowledgement can return after this turn has
+            # released ownership and a later turn has installed fresh timeout
+            # state. Only the turn that still owns this completion event may
+            # suppress its abandonment safety-net interrupt.
+            if self._timeout_interrupt_settled is timeout_interrupt_settled:
+                self._timeout_interrupt_delivered = True
+        finally:
+            timeout_interrupt_settled.set()
+        return True
+
     async def run_inbound(self, message: Event | Interrupt) -> AsyncIterator[str]:
         """Produce the NDJSON a compliant runner emits for one inbound frame.
 
@@ -415,7 +467,11 @@ class SessionRunner:
             yield line
 
     async def run_turn(
-        self, event: Event, *, parent: Context | None = None
+        self,
+        event: Event,
+        *,
+        parent: Context | None = None,
+        turn_epoch: str | None = None,
     ) -> AsyncGenerator[str]:
         """Run one turn, streaming ACI NDJSON lines and enforcing the budget.
 
@@ -431,6 +487,10 @@ class SessionRunner:
             start = time.monotonic()
             logger.info("turn start session=%s user=%s", self._session_id, event.user)
             self._interrupt_requested = False
+            self._timeout_requested = False
+            self._timeout_interrupt_settled = None
+            self._timeout_interrupt_delivered = False
+            self._turn_epoch = turn_epoch
             self._turn_open = True
             state = TurnState()
             # A permission-gate block belongs to exactly one turn: clear any
@@ -445,6 +505,25 @@ class SessionRunner:
                 "outcome": "accepted",
             }
             record_metric("curie.turn.accepted", attributes=metric_attributes)
+            metrics_emitted = False
+
+            def emit_completed_metrics() -> None:
+                """Emit the terminal metric pair once, synchronously."""
+
+                nonlocal metrics_emitted
+                if metrics_emitted:
+                    return
+                metrics_emitted = True
+                completed_attributes = {
+                    "service.name": "curie-runner",
+                    "source": "runner",
+                    "outcome": metric_outcome,
+                }
+                elapsed = time.monotonic() - start
+                record_metric("curie.turn.completed", attributes=completed_attributes)
+                record_metric(
+                    "curie.turn.duration", elapsed, attributes=completed_attributes
+                )
 
             try:
                 with self._tracer.run_span(
@@ -481,7 +560,25 @@ class SessionRunner:
                         # is intentionally not caught here -- the finally handles
                         # that abandonment case.
                         self._turn_open = False
-                        if self._interrupt_requested:
+                        if self._timeout_requested:
+                            # The body-boundary timeout is a failure even when the
+                            # SDK reports its interrupt as an iterator exception.
+                            # The caller may still be reading this direct session
+                            # path, so retain a terminal final when it is deliverable.
+                            self._status = SessionStatus.CLASSIFIED_FAILURE
+                            metric_outcome = self._metric_outcome(tracker)
+                            gen.finish_turn(
+                                timeout_requested=True,
+                                interrupt_requested=self._interrupt_requested,
+                                classified_failure=True,
+                            )
+                            yield to_ndjson_line(
+                                Final(
+                                    text="run timed out",
+                                    status=SessionStatus.CLASSIFIED_FAILURE,
+                                )
+                            )
+                        elif self._interrupt_requested:
                             # Some SDK iterators surface the runner-requested
                             # interrupt as an exception instead of a terminal
                             # ResultMessage. The interrupt remains authoritative:
@@ -510,7 +607,7 @@ class SessionRunner:
                             )
                             self._status = SessionStatus.CLASSIFIED_FAILURE
                             metric_outcome = self._metric_outcome(tracker)
-                            gen.set_failed()
+                            self._set_failed(gen)
                             yield to_ndjson_line(
                                 ErrorEvent(
                                     message=f"runner error: {exc}",
@@ -524,28 +621,70 @@ class SessionRunner:
                                 )
                             )
                     finally:
-                        # If the turn never reached a terminal final (_turn_open still
-                        # set), the consumer abandoned the stream mid-run (client
-                        # disconnect -> GeneratorExit, or cancellation). Stop the SDK
-                        # so it does not keep executing tools past the released turn
-                        # lock and bleed into the next turn. Best-effort.
-                        if self._turn_open and self._session is not None:
-                            with contextlib.suppress(Exception):
-                                await self._session.interrupt()
-                        self._turn_open = False
+                        try:
+                            # A timeout accepted while the stream was suspended at
+                            # a yield reaches this no-yield block via GeneratorExit
+                            # (or cancellation). Store its root terminal and metric
+                            # pair synchronously, before cleanup can await or be
+                            # cancelled; RunTracer's later abandonment fallback is
+                            # idempotent.
+                            if self._timeout_requested:
+                                self._status = SessionStatus.CLASSIFIED_FAILURE
+                                gen.finish_turn(
+                                    timeout_requested=True,
+                                    interrupt_requested=self._interrupt_requested,
+                                    classified_failure=True,
+                                )
+                                metric_outcome = self._metric_outcome(tracker)
+                                emit_completed_metrics()
+                        finally:
+                            # The SDK serializes this turn's stop and any later
+                            # query onto one locked stdin stream. Wait until the
+                            # timeout attempt settles before cleanup: a normally
+                            # returned stop is already ordered ahead of the next
+                            # query and the CLI cannot latch it for that later
+                            # turn. If the timeout call does not return normally,
+                            # the cleanup path below supplies the safety-net while
+                            # this turn still owns the lock; cancellation before
+                            # the write sends nothing for a later turn to observe.
+                            timeout_settled = self._timeout_interrupt_settled
+                            if timeout_settled is not None:
+                                with anyio.CancelScope(shield=True):
+                                    await timeout_settled.wait()
+                            # Retire this turn's control token before cleanup can
+                            # await the session-global interrupt. A timeout that
+                            # arrives during that await is stale and must not
+                            # queue a stop that could be consumed by the next
+                            # turn after this owner releases the lock.
+                            self._turn_epoch = None
+                            # If the turn never reached a terminal final (_turn_open
+                            # still set), the consumer abandoned the stream mid-run
+                            # (client disconnect -> GeneratorExit, or cancellation).
+                            # Stop the SDK so it cannot keep executing tools past the
+                            # released turn lock and bleed into the next turn.
+                            try:
+                                if (
+                                    self._turn_open
+                                    and not self._timeout_interrupt_delivered
+                                    and self._session is not None
+                                ):
+                                    with contextlib.suppress(Exception):
+                                        await self._session.interrupt()
+                            finally:
+                                self._turn_open = False
+                                self._turn_epoch = None
             finally:
-                completed_attributes = {
-                    "service.name": "curie-runner",
-                    "source": "runner",
-                    "outcome": metric_outcome,
-                }
-                elapsed = time.monotonic() - start
-                record_metric("curie.turn.completed", attributes=completed_attributes)
-                record_metric(
-                    "curie.turn.duration", elapsed, attributes=completed_attributes
-                )
+                try:
+                    emit_completed_metrics()
+                finally:
+                    self._turn_open = False
+                    self._turn_epoch = None
+                    self._timeout_interrupt_settled = None
+                    self._timeout_interrupt_delivered = False
 
     def _metric_outcome(self, tracker: BudgetTracker) -> str:
+        if self._timeout_requested:
+            return "classified_failure"
         if self._status is SessionStatus.DONE:
             return "done"
         if self._status is SessionStatus.AWAITING_APPROVAL:
@@ -555,6 +694,18 @@ class SessionRunner:
         if self._interrupt_requested:
             return "interrupted"
         return "idle"
+
+    def _set_failed(self, gen: _GenerationSpan) -> None:
+        """Store timeout first when a generic failure site wins the race."""
+
+        if self._timeout_requested:
+            gen.finish_turn(
+                timeout_requested=True,
+                interrupt_requested=self._interrupt_requested,
+                classified_failure=True,
+            )
+        else:
+            gen.set_failed()
 
     async def _drive_turn(
         self,
@@ -582,7 +733,7 @@ class SessionRunner:
                 # terminal ``model-credential-rejected`` error is emitted regardless.
                 with contextlib.suppress(Exception):
                     await self._session.interrupt()
-                gen.set_failed()
+                self._set_failed(gen)
                 for line in self._auth_halt_lines():
                     yield line
                 return
@@ -599,9 +750,9 @@ class SessionRunner:
             decided_result_final: Final | None = None
             if isinstance(message, ResultMessage):
                 terminal_reason = getattr(message, "terminal_reason", None)
-                cancelled = self._interrupt_requested
+                cancelled = self._interrupt_requested and not self._timeout_requested
                 subtype = message.subtype or ""
-                result_failed = budget_hit or (
+                result_failed = self._timeout_requested or budget_hit or (
                     not cancelled and (message.is_error or subtype.startswith("error"))
                 )
                 if not budget_hit:
@@ -633,7 +784,7 @@ class SessionRunner:
                     )
                 if isinstance(outbound, Final):
                     if budget_hit:
-                        gen.set_failed()
+                        self._set_failed(gen)
                         for line in self._budget_halt_lines():
                             yield line
                         return
@@ -648,9 +799,14 @@ class SessionRunner:
                         yield line
                     for line in self._false_completion_lines(state, final):
                         yield line
+                    # A timeout can land while one of the warning lines above is
+                    # suspended at its yield. Re-apply its precedence immediately
+                    # before publishing the terminal final.
+                    final = self._reclassify(final)
                     self._status = final.status
                     self._turn_open = False
                     gen.finish_turn(
+                        timeout_requested=self._timeout_requested,
                         interrupt_requested=self._interrupt_requested,
                         classified_failure=final.status
                         is SessionStatus.CLASSIFIED_FAILURE,
@@ -672,7 +828,7 @@ class SessionRunner:
                 # Budget crossed on a non-terminal message: stop the live run,
                 # then emit the same error+final pair.
                 await self._session.interrupt()
-                gen.set_failed()
+                self._set_failed(gen)
                 for line in self._budget_halt_lines():
                     yield line
                 return
@@ -680,20 +836,23 @@ class SessionRunner:
         # The turn iterator ended without a terminal result (e.g. an interrupt
         # aborted before the model produced one). Emit a final so the stream
         # always terminates in a final event.
-        status = (
-            SessionStatus.IDLE_AWAITING_INPUT
-            if self._interrupt_requested
-            else SessionStatus.DONE
-        )
+        if self._timeout_requested:
+            status = SessionStatus.CLASSIFIED_FAILURE
+        elif self._interrupt_requested:
+            status = SessionStatus.IDLE_AWAITING_INPUT
+        else:
+            status = SessionStatus.DONE
         self._merge_gate_block(state)
         final = _apply_approval_override(Final(text="", status=status), state)
         for line in self._approval_not_acted_lines(state, final):
             yield line
         for line in self._false_completion_lines(state, final):
             yield line
+        final = self._reclassify(final)
         self._status = final.status
         self._turn_open = False
         gen.finish_turn(
+            timeout_requested=self._timeout_requested,
             interrupt_requested=self._interrupt_requested,
             classified_failure=final.status is SessionStatus.CLASSIFIED_FAILURE,
             approval_paused=final.status is SessionStatus.AWAITING_APPROVAL,
@@ -840,7 +999,11 @@ class SessionRunner:
 
         # See the "Approval halt" bullet above: an operator interrupt outranks a
         # runner-requested one, so the marker is copied only in its absence.
-        if gate.pending_halt and not self._interrupt_requested:
+        if (
+            gate.pending_halt
+            and not self._interrupt_requested
+            and not self._timeout_requested
+        ):
             state.approval_halt_requested = True
 
     def _budget_halt_lines(self) -> list[str]:
@@ -906,6 +1069,11 @@ class SessionRunner:
         would look like a failure and could trip F1's escalation path.
         """
 
+        if self._timeout_requested:
+            return Final(
+                text=final.text or "run timed out",
+                status=SessionStatus.CLASSIFIED_FAILURE,
+            )
         if self._interrupt_requested:
             return Final(
                 text=final.text or "run interrupted",

--- a/runner/tests/test_otel.py
+++ b/runner/tests/test_otel.py
@@ -1355,6 +1355,37 @@ def test_interrupt_requested_wins_over_error_result_and_sdk_abort_reason() -> No
     assert root.attributes["curie.terminal.status"] == "cancelled"
 
 
+def test_runner_timeout_is_a_closed_error_terminal_and_is_first_store_stable() -> None:
+    """The private timeout control is a failure, never an ACI cancellation.
+
+    Timeout has higher precedence than an ordinary interrupt when both race, and
+    the existing idempotent terminal guard must keep a later abandonment fallback
+    from replacing the first stored cause.
+    """
+
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    with RunTracer(provider).run_span("curie-run:test", "fake-model") as gen:
+        gen.query_observed()
+        gen.finish_turn(
+            timeout_requested=True,
+            interrupt_requested=True,
+            classified_failure=True,
+        )
+        gen.set_abandoned()
+
+    spans = _spans_by_name(list(exporter.get_finished_spans()))
+    root = spans["agent.run"][0]
+    generation = spans["llm.generation"][0]
+    assert root.attributes["curie.terminal.cause"] == "runner_timeout"
+    assert root.attributes["curie.terminal.status"] == "failed"
+    assert root.status.status_code is StatusCode.ERROR
+    assert generation.status.status_code is StatusCode.ERROR
+    assert generation.attributes["curie.phase.end_kind"] == "terminal_inferred"
+
+
 def test_exhausted_stream_is_abandoned_not_a_false_success() -> None:
     _, spans = _run_and_export(lambda: FakeModelSession(lambda: []))
     root = spans["agent.run"][0]

--- a/runner/tests/test_runner_otel_shape.py
+++ b/runner/tests/test_runner_otel_shape.py
@@ -28,6 +28,7 @@ _TERMINAL_OUTCOMES = (
     ("aborted_streaming", "failed", 2),
     ("aborted_tools", "failed", 2),
     ("classified_failure", "failed", 2),
+    ("runner_timeout", "failed", 2),
     ("abandoned", "abandoned", 2),
 )
 
@@ -290,6 +291,7 @@ def test_root_terminal_closed_mapping_is_accepted(
         ("aborted_streaming", "abandoned"),
         ("aborted_tools", "succeeded"),
         ("classified_failure", "paused"),
+        ("runner_timeout", "abandoned"),
         ("abandoned", "failed"),
         ("unknown_terminal", "succeeded"),
         ("completed", "unknown_status"),

--- a/runner/tests/test_server.py
+++ b/runner/tests/test_server.py
@@ -10,6 +10,38 @@ from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
+_TURN_EPOCH_HEADER = "X-Curie-Turn-Epoch"
+
+
+class _EpochControlledSession:
+    """Two no-result turns whose SDK wait is released only by interrupt."""
+
+    def __init__(self) -> None:
+        self.entered = [anyio.Event(), anyio.Event()]
+        self.release = [anyio.Event(), anyio.Event()]
+        self.turn = -1
+        self.interrupts = 0
+
+    async def connect(self) -> None: ...
+
+    async def query(self, _text: str) -> None:
+        self.turn += 1
+
+    async def receive_turn(self):
+        turn = self.turn
+        self.entered[turn].set()
+        await self.release[turn].wait()
+        if False:  # pragma: no cover - retain the async-generator shape
+            yield None
+
+    async def interrupt(self) -> None:
+        self.interrupts += 1
+        self.release[self.turn].set()
+
+    async def close(self) -> None:
+        for release in self.release:
+            release.set()
+
 
 def _runner() -> tuple[SessionRunner, FakeModelSession]:
     fake = FakeModelSession()
@@ -305,6 +337,118 @@ def test_interrupt_requires_auth_and_proceeds_with_token() -> None:
             assert resp.status == 200
             assert (await resp.json())["ok"] is True
             assert fake.interrupts >= 1
+
+    anyio.run(go)
+
+
+def test_timeout_route_auth_epoch_validation_and_turn_isolation() -> None:
+    """Only the authenticated current epoch may label and stop its own turn."""
+
+    async def go() -> None:
+        session = _EpochControlledSession()
+        runner = SessionRunner(
+            session_factory=lambda: session,
+            ceiling=0,
+            tracer=RunTracer(None),
+            classifier=SideEffectClassifier(),
+            trace_name="t",
+        )
+        await runner.start()
+        async with TestClient(TestServer(create_app(runner, token=_TOKEN))) as client:
+            first = await client.post("/v1/event", json=_EVENT_FRAME, headers=_AUTH)
+            first_epoch = first.headers[_TURN_EPOCH_HEADER]
+            assert 32 <= len(first_epoch) <= 256
+            assert all(
+                character.isalnum() or character in "-_"
+                for character in first_epoch
+            )
+            await session.entered[0].wait()
+
+            unauthenticated = await client.post(
+                "/v1/timeout", headers={_TURN_EPOCH_HEADER: first_epoch}
+            )
+            assert unauthenticated.status == 401
+            wrong_bearer = await client.post(
+                "/v1/timeout",
+                headers={
+                    "Authorization": "Bearer wrong-token-PLACEHOLDER",
+                    _TURN_EPOCH_HEADER: first_epoch,
+                },
+            )
+            assert wrong_bearer.status == 401
+            assert session.interrupts == 0
+
+            missing = await client.post("/v1/timeout", headers=_AUTH)
+            malformed = await client.post(
+                "/v1/timeout",
+                headers={**_AUTH, _TURN_EPOCH_HEADER: "not*an*epoch"},
+            )
+            oversized = await client.post(
+                "/v1/timeout",
+                headers={**_AUTH, _TURN_EPOCH_HEADER: "A" * 1025},
+            )
+            assert missing.status == 400
+            assert malformed.status == 400
+            assert oversized.status == 400
+
+            guessed_epoch = (
+                ("A" if first_epoch[0] != "A" else "B") + first_epoch[1:]
+            )
+            spoofed = await client.post(
+                "/v1/timeout",
+                headers={**_AUTH, _TURN_EPOCH_HEADER: guessed_epoch},
+            )
+            assert spoofed.status == 409
+            assert session.interrupts == 0
+
+            accepted = await client.post(
+                "/v1/timeout",
+                headers={**_AUTH, _TURN_EPOCH_HEADER: first_epoch},
+            )
+            assert accepted.status == 200
+            assert (await accepted.json())["ok"] is True
+            assert session.interrupts == 1
+            first_body = await first.text()
+            assert first_epoch not in first_body
+
+            replayed = await client.post(
+                "/v1/timeout",
+                headers={**_AUTH, _TURN_EPOCH_HEADER: first_epoch},
+            )
+            assert replayed.status == 409
+            assert session.interrupts == 1
+
+            second = await client.post("/v1/event", json=_EVENT_FRAME, headers=_AUTH)
+            second_epoch = second.headers[_TURN_EPOCH_HEADER]
+            assert second_epoch != first_epoch
+            await session.entered[1].wait()
+
+            stale = await client.post(
+                "/v1/timeout",
+                headers={**_AUTH, _TURN_EPOCH_HEADER: first_epoch},
+            )
+            spoofed_retry = await client.post(
+                "/v1/timeout",
+                headers={**_AUTH, _TURN_EPOCH_HEADER: guessed_epoch},
+            )
+            assert stale.status == 409
+            assert spoofed_retry.status == 409
+            assert session.interrupts == 1
+
+            accepted_retry = await client.post(
+                "/v1/timeout",
+                headers={**_AUTH, _TURN_EPOCH_HEADER: second_epoch},
+            )
+            assert accepted_retry.status == 200
+            await second.text()
+            assert session.interrupts == 2
+
+            delayed_replay = await client.post(
+                "/v1/timeout",
+                headers={**_AUTH, _TURN_EPOCH_HEADER: second_epoch},
+            )
+            assert delayed_replay.status == 409
+            assert session.interrupts == 2
 
     anyio.run(go)
 

--- a/runner/tests/test_session.py
+++ b/runner/tests/test_session.py
@@ -1,5 +1,6 @@
 """SessionRunner: turn streaming, interrupt reclassification, rehydrate options."""
 
+import asyncio
 import logging
 
 import anyio
@@ -7,6 +8,7 @@ import pytest
 from aci_protocol import ErrorEvent, Event, Interrupt, SessionStatus, parse_ndjson
 from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock, ToolUseBlock
 from curie_runner import RunTracer, SideEffectClassifier, build_options
+from curie_runner import session as session_module
 from curie_runner.fake import FakeModelSession, default_turn
 from curie_runner.session import SessionRunner
 from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
@@ -253,6 +255,627 @@ def test_interrupt_precedes_iterator_exception_and_preserves_cancelled_terminal(
         assert "internal-interrupt-error-call-PLACEHOLDER" not in repr(
             tools[0].attributes
         )
+
+
+def test_timeout_terminalizes_before_generator_close_and_emits_one_metric(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Closing at a suspended yield must not let abandonment store first."""
+
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    fake = FakeModelSession()
+    runner = SessionRunner(
+        session_factory=lambda: fake,
+        ceiling=0,
+        tracer=RunTracer(provider),
+        classifier=SideEffectClassifier(),
+        trace_name="t",
+    )
+    metrics: list[tuple[str, dict[str, str]]] = []
+
+    def capture_metric(
+        name: str,
+        _value: float = 1,
+        *,
+        attributes: dict[str, str],
+    ) -> None:
+        metrics.append((name, dict(attributes)))
+
+    monkeypatch.setattr(session_module, "record_metric", capture_metric)
+    epoch = "A" * 43
+
+    async def go() -> None:
+        await runner.start()
+        turn = runner.run_turn(
+            Event(type="message", text="go", user="U0EXAMPLE1", ts="1"),
+            turn_epoch=epoch,
+        )
+        await anext(turn)
+        assert await runner.timeout(epoch) is True
+        # No further yield is requested. GeneratorExit reaches run_turn's
+        # no-yield finally, which must store timeout before RunTracer can infer
+        # generic abandonment.
+        await turn.aclose()
+        await runner.close()
+
+    anyio.run(go)
+    spans = list(exporter.get_finished_spans())
+    root = _span_named(spans, "agent.run")[0]
+    assert root.attributes["curie.terminal.cause"] == "runner_timeout"
+    assert root.attributes["curie.terminal.status"] == "failed"
+    assert root.status.status_code is StatusCode.ERROR
+    completed = [
+        attributes
+        for name, attributes in metrics
+        if name == "curie.turn.completed"
+    ]
+    assert completed == [
+        {
+            "service.name": "curie-runner",
+            "source": "runner",
+            "outcome": "classified_failure",
+        }
+    ]
+
+
+def test_timeout_epoch_is_isolated_from_stale_spoofed_and_replayed_turns() -> None:
+    runner, fake = _runner()
+    first_epoch = "B" * 43
+    second_epoch = "C" * 43
+    spoofed_epoch = "D" * 43
+
+    async def go() -> None:
+        await runner.start()
+        first = runner.run_turn(
+            Event(type="message", text="first", user="U0EXAMPLE1", ts="1"),
+            turn_epoch=first_epoch,
+        )
+        async for _ in first:
+            pass
+
+        interrupts_after_first = fake.interrupts
+        assert await runner.timeout(first_epoch) is False
+        assert fake.interrupts == interrupts_after_first
+
+        second = runner.run_turn(
+            Event(type="message", text="second", user="U0EXAMPLE1", ts="2"),
+            turn_epoch=second_epoch,
+        )
+        await anext(second)
+        assert await runner.timeout(first_epoch) is False
+        assert await runner.timeout(spoofed_epoch) is False
+        assert fake.interrupts == interrupts_after_first
+
+        assert await runner.timeout(second_epoch) is True
+        async for _ in second:
+            pass
+        interrupts_after_timeout = fake.interrupts
+        assert await runner.timeout(second_epoch) is False
+        assert fake.interrupts == interrupts_after_timeout
+        await runner.close()
+
+    anyio.run(go)
+
+
+def test_timeout_during_abandonment_cleanup_cannot_own_next_turn_stop() -> None:
+    class CleanupRaceSession:
+        def __init__(self) -> None:
+            self.queries: list[str] = []
+            self.interrupt_lock = anyio.Lock()
+            self.interrupt_roles: list[str] = []
+            self.first_interrupt_entered = anyio.Event()
+            self.release_first_interrupt = anyio.Event()
+            self.second_interrupt_entered = anyio.Event()
+            self.release_second_interrupt = anyio.Event()
+            self.turn_b_cleanup_started = False
+
+        async def connect(self) -> None: ...
+
+        async def query(self, text: str) -> None:
+            self.queries.append(text)
+
+        async def receive_turn(self):
+            yield AssistantMessage(
+                content=[TextBlock(text=f"working-{len(self.queries)}")],
+                model="fake-model",
+            )
+
+        async def interrupt(self) -> None:
+            async with self.interrupt_lock:
+                self.interrupt_roles.append(
+                    "turn_b_cleanup"
+                    if self.turn_b_cleanup_started
+                    else "before_turn_b_cleanup"
+                )
+                attempt = len(self.interrupt_roles)
+                if attempt == 1:
+                    self.first_interrupt_entered.set()
+                    await self.release_first_interrupt.wait()
+                elif attempt == 2:
+                    self.second_interrupt_entered.set()
+                    await self.release_second_interrupt.wait()
+
+        async def close(self) -> None:
+            self.release_first_interrupt.set()
+            self.release_second_interrupt.set()
+
+    session = CleanupRaceSession()
+    runner = SessionRunner(
+        session_factory=lambda: session,
+        ceiling=0,
+        tracer=RunTracer(None),
+        classifier=SideEffectClassifier(),
+        trace_name="t",
+    )
+    first_epoch = "J" * 43
+    second_epoch = "K" * 43
+
+    async def go() -> None:
+        first_close_done = anyio.Event()
+        timeout_started = anyio.Event()
+        timeout_done = anyio.Event()
+        timeout_accepted: list[bool] = []
+
+        async def close_first() -> None:
+            await first.aclose()
+            first_close_done.set()
+
+        async def request_late_timeout() -> None:
+            timeout_started.set()
+            timeout_accepted.append(await runner.timeout(first_epoch))
+            timeout_done.set()
+
+        await runner.start()
+        first = runner.run_turn(
+            Event(type="message", text="first", user="U0EXAMPLE1", ts="1"),
+            turn_epoch=first_epoch,
+        )
+        await anext(first)
+
+        async with anyio.create_task_group() as tasks:
+            tasks.start_soon(close_first)
+            await session.first_interrupt_entered.wait()
+            tasks.start_soon(request_late_timeout)
+            await timeout_started.wait()
+            # Let the control request either reject the retired epoch or queue
+            # behind turn A's cleanup stop. No wall-clock timing is involved.
+            await anyio.lowlevel.checkpoint()
+            await anyio.lowlevel.checkpoint()
+            session.release_first_interrupt.set()
+            await first_close_done.wait()
+
+            second = runner.run_turn(
+                Event(type="message", text="second", user="U0EXAMPLE1", ts="2"),
+                turn_epoch=second_epoch,
+            )
+            await anext(second)
+
+            if not timeout_done.is_set():
+                # Current buggy behavior reaches here: the timeout stop was
+                # accepted for A but its acknowledgement lands during B.
+                await session.second_interrupt_entered.wait()
+                session.release_second_interrupt.set()
+                await timeout_done.wait()
+
+            session.turn_b_cleanup_started = True
+            second_close_done = anyio.Event()
+
+            async def close_second() -> None:
+                await second.aclose()
+                second_close_done.set()
+
+            tasks.start_soon(close_second)
+            if not second_close_done.is_set():
+                await session.second_interrupt_entered.wait()
+                session.release_second_interrupt.set()
+            await second_close_done.wait()
+
+        assert timeout_accepted == [False]
+        assert session.interrupt_roles == [
+            "before_turn_b_cleanup",
+            "turn_b_cleanup",
+        ]
+        await runner.close()
+
+    anyio.run(go)
+
+
+def test_next_turn_waits_for_timeout_interrupt_to_settle() -> None:
+    class SlowTimeoutInterruptSession:
+        def __init__(self) -> None:
+            self.queries: list[str] = []
+            self.interrupts = 0
+            self.first_receive_entered = anyio.Event()
+            self.end_first_receive = anyio.Event()
+            self.interrupt_entered = anyio.Event()
+            self.release_interrupt = anyio.Event()
+            self.interrupt_settled = anyio.Event()
+            self.second_query_started = anyio.Event()
+            self.second_query_started_early = False
+
+        async def connect(self) -> None: ...
+
+        async def query(self, text: str) -> None:
+            self.queries.append(text)
+            if len(self.queries) == 2:
+                self.second_query_started_early = not self.interrupt_settled.is_set()
+                self.second_query_started.set()
+
+        async def receive_turn(self):
+            if len(self.queries) == 1:
+                self.first_receive_entered.set()
+                await self.end_first_receive.wait()
+                return
+            yield ResultMessage(
+                subtype="success",
+                duration_ms=1,
+                duration_api_ms=1,
+                is_error=False,
+                num_turns=1,
+                session_id="sdk-session-PLACEHOLDER",
+                result="healthy",
+            )
+
+        async def interrupt(self) -> None:
+            self.interrupts += 1
+            self.end_first_receive.set()
+            self.interrupt_entered.set()
+            await self.release_interrupt.wait()
+            self.interrupt_settled.set()
+
+        async def close(self) -> None: ...
+
+    session = SlowTimeoutInterruptSession()
+    runner = SessionRunner(
+        session_factory=lambda: session,
+        ceiling=0,
+        tracer=RunTracer(None),
+        classifier=SideEffectClassifier(),
+        trace_name="t",
+    )
+    first_epoch = "F" * 43
+    second_epoch = "G" * 43
+    first_lines: list[str] = []
+    second_lines: list[str] = []
+
+    async def go() -> None:
+        first_done = anyio.Event()
+        second_attempted = anyio.Event()
+        second_done = anyio.Event()
+        timeout_done = anyio.Event()
+        timeout_accepted: list[bool] = []
+
+        async def consume_first() -> None:
+            async for line in runner.run_turn(
+                Event(type="message", text="first", user="U0EXAMPLE1", ts="1"),
+                turn_epoch=first_epoch,
+            ):
+                first_lines.append(line)
+            first_done.set()
+
+        async def request_timeout() -> None:
+            timeout_accepted.append(await runner.timeout(first_epoch))
+            timeout_done.set()
+
+        async def consume_second() -> None:
+            second_attempted.set()
+            async for line in runner.run_turn(
+                Event(type="message", text="second", user="U0EXAMPLE1", ts="2"),
+                turn_epoch=second_epoch,
+            ):
+                second_lines.append(line)
+            second_done.set()
+
+        await runner.start()
+        async with anyio.create_task_group() as tasks:
+            tasks.start_soon(consume_first)
+            await session.first_receive_entered.wait()
+            tasks.start_soon(request_timeout)
+            await session.interrupt_entered.wait()
+            tasks.start_soon(consume_second)
+            await second_attempted.wait()
+            # Let the timeout, first consumer, and already-queued second
+            # consumer advance to their ownership barriers. No clock delay is
+            # involved: checkpoints only give each runnable task a turn.
+            await anyio.lowlevel.checkpoint()
+            await anyio.lowlevel.checkpoint()
+
+            assert not first_done.is_set()
+            assert not session.second_query_started.is_set()
+            assert not timeout_done.is_set()
+
+            session.release_interrupt.set()
+            await timeout_done.wait()
+            await first_done.wait()
+            await session.second_query_started.wait()
+            await second_done.wait()
+
+        assert timeout_accepted == [True]
+        await runner.close()
+
+    anyio.run(go)
+
+    first_events = parse_ndjson("".join(first_lines))
+    second_events = parse_ndjson("".join(second_lines))
+    assert first_events[-1].status is SessionStatus.CLASSIFIED_FAILURE
+    assert second_events[-1].status is SessionStatus.DONE
+    assert session.queries == ["first", "second"]
+    assert session.interrupts == 1
+    assert session.interrupt_settled.is_set()
+    assert not session.second_query_started_early
+
+
+class _OrderedTimeoutWireSession:
+    """Event-gated SDK double exposing stop/query order without clock sleeps."""
+
+    def __init__(self, failure: str) -> None:
+        self.failure = failure
+        self.wire: list[tuple[str, str | int]] = []
+        self.queries = 0
+        self.interrupts = 0
+        self.first_receive_entered = anyio.Event()
+        self.end_first_receive = anyio.Event()
+        self.first_interrupt_entered = anyio.Event()
+        self.cleanup_interrupt_written = anyio.Event()
+        self.release_ack = anyio.Event()
+        self.second_query_started = anyio.Event()
+
+    async def connect(self) -> None: ...
+
+    async def query(self, text: str) -> None:
+        self.queries += 1
+        self.wire.append(("query", text))
+        if self.queries == 2:
+            self.second_query_started.set()
+
+    async def receive_turn(self):
+        if self.queries == 1:
+            self.first_receive_entered.set()
+            await self.end_first_receive.wait()
+            return
+        yield ResultMessage(
+            subtype="success",
+            duration_ms=1,
+            duration_api_ms=1,
+            is_error=False,
+            num_turns=1,
+            session_id="sdk-session-PLACEHOLDER",
+            result="healthy",
+        )
+
+    async def interrupt(self) -> None:
+        self.interrupts += 1
+        attempt = self.interrupts
+        self.first_interrupt_entered.set()
+        if self.failure == "cancel-before-write" and attempt == 1:
+            await self.release_ack.wait()
+            return
+        self.wire.append(("interrupt", attempt))
+        if attempt > 1:
+            self.cleanup_interrupt_written.set()
+        if self.failure == "ack-failure" and attempt == 1:
+            self.end_first_receive.set()
+            raise RuntimeError("Control request timeout: interrupt")
+        await self.release_ack.wait()
+        self.end_first_receive.set()
+
+    async def close(self) -> None:
+        self.release_ack.set()
+        self.end_first_receive.set()
+
+
+def _exercise_timeout_interrupt_failure(
+    failure: str,
+) -> tuple[
+    _OrderedTimeoutWireSession,
+    list[str],
+    list[str],
+    list[BaseException],
+    list[ReadableSpan],
+]:
+    session = _OrderedTimeoutWireSession(failure)
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    runner = SessionRunner(
+        session_factory=lambda: session,
+        ceiling=0,
+        tracer=RunTracer(provider),
+        classifier=SideEffectClassifier(),
+        trace_name="t",
+    )
+    first_epoch = "H" * 43
+    second_epoch = "I" * 43
+    first_lines: list[str] = []
+    second_lines: list[str] = []
+    timeout_errors: list[BaseException] = []
+
+    async def go() -> None:
+        first_done = anyio.Event()
+        second_done = anyio.Event()
+        timeout_done = anyio.Event()
+        first_scope = anyio.CancelScope()
+        timeout_scope = anyio.CancelScope()
+
+        async def consume_first() -> None:
+            with first_scope:
+                try:
+                    async for line in runner.run_turn(
+                        Event(
+                            type="message",
+                            text="first",
+                            user="U0EXAMPLE1",
+                            ts="1",
+                        ),
+                        turn_epoch=first_epoch,
+                    ):
+                        first_lines.append(line)
+                except anyio.get_cancelled_exc_class():
+                    pass
+            first_done.set()
+
+        async def request_timeout() -> None:
+            with timeout_scope:
+                try:
+                    await runner.timeout(first_epoch)
+                except BaseException as exc:
+                    timeout_errors.append(exc)
+            timeout_done.set()
+
+        async def consume_second() -> None:
+            async for line in runner.run_turn(
+                Event(type="message", text="second", user="U0EXAMPLE1", ts="2"),
+                turn_epoch=second_epoch,
+            ):
+                second_lines.append(line)
+            second_done.set()
+
+        await runner.start()
+        async with anyio.create_task_group() as tasks:
+            tasks.start_soon(consume_first)
+            await session.first_receive_entered.wait()
+            tasks.start_soon(request_timeout)
+            await session.first_interrupt_entered.wait()
+
+            if failure.startswith("cancel-"):
+                timeout_scope.cancel()
+                await timeout_done.wait()
+                # Abandon the blocked consumer. Its run_turn finalizer must see
+                # the still-open turn and send the safety-net stop; ending the
+                # fake iterator normally would set _turn_open=False first and
+                # would not exercise this cancellation shape.
+                first_scope.cancel()
+                await session.cleanup_interrupt_written.wait()
+                session.release_ack.set()
+                await first_done.wait()
+                tasks.start_soon(consume_second)
+            else:
+                await timeout_done.wait()
+                tasks.start_soon(consume_second)
+
+            await first_done.wait()
+            await session.second_query_started.wait()
+            await second_done.wait()
+
+        await runner.close()
+
+    anyio.run(go)
+    return session, first_lines, second_lines, timeout_errors, list(
+        exporter.get_finished_spans()
+    )
+
+
+def _assert_timeout_then_healthy(
+    first_lines: list[str],
+    second_lines: list[str],
+    spans: list[ReadableSpan],
+    *,
+    first_was_abandoned: bool = False,
+) -> None:
+    second_events = parse_ndjson("".join(second_lines))
+    if first_was_abandoned:
+        assert not first_lines
+    else:
+        first_events = parse_ndjson("".join(first_lines))
+        assert first_events[-1].status is SessionStatus.CLASSIFIED_FAILURE
+    assert second_events[-1].status is SessionStatus.DONE
+    first_root = _span_named(spans, "agent.run")[0]
+    assert first_root.attributes["curie.terminal.cause"] == "runner_timeout"
+    assert first_root.attributes["curie.terminal.status"] == "failed"
+    assert first_root.status.status_code is StatusCode.ERROR
+
+
+def test_timeout_cancelled_after_stop_write_cleans_up_before_next_query() -> None:
+    session, first, second, errors, spans = _exercise_timeout_interrupt_failure(
+        "cancel-after-write"
+    )
+    assert len(errors) == 1
+    assert isinstance(errors[0], asyncio.CancelledError)
+    assert session.wire == [
+        ("query", "first"),
+        ("interrupt", 1),
+        ("interrupt", 2),
+        ("query", "second"),
+    ]
+    _assert_timeout_then_healthy(first, second, spans, first_was_abandoned=True)
+
+
+def test_timeout_ack_failure_releases_only_after_recorded_stop() -> None:
+    session, first, second, errors, spans = _exercise_timeout_interrupt_failure(
+        "ack-failure"
+    )
+    assert [type(error) for error in errors] == [RuntimeError]
+    assert session.wire == [
+        ("query", "first"),
+        ("interrupt", 1),
+        ("query", "second"),
+    ]
+    _assert_timeout_then_healthy(first, second, spans)
+
+
+def test_timeout_cancelled_before_stop_write_uses_cleanup_before_next_query() -> None:
+    session, first, second, errors, spans = _exercise_timeout_interrupt_failure(
+        "cancel-before-write"
+    )
+    assert len(errors) == 1
+    assert isinstance(errors[0], asyncio.CancelledError)
+    assert session.wire == [
+        ("query", "first"),
+        ("interrupt", 2),
+        ("query", "second"),
+    ]
+    _assert_timeout_then_healthy(first, second, spans, first_was_abandoned=True)
+
+
+def test_timeout_precedes_an_operator_interrupt_on_the_same_turn() -> None:
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    script = [
+        AssistantMessage(content=[TextBlock(text="working")], model="fake-model"),
+        ResultMessage(
+            subtype="error_during_execution",
+            duration_ms=1,
+            duration_api_ms=1,
+            is_error=True,
+            num_turns=1,
+            session_id="sdk-session-PLACEHOLDER",
+            result="stopped",
+        ),
+    ]
+    fake = FakeModelSession(lambda: script, truncate_on_interrupt=False)
+    runner = SessionRunner(
+        session_factory=lambda: fake,
+        ceiling=0,
+        tracer=RunTracer(provider),
+        classifier=SideEffectClassifier(),
+        trace_name="t",
+    )
+    epoch = "E" * 43
+    lines: list[str] = []
+
+    async def go() -> None:
+        await runner.start()
+        turn = runner.run_turn(
+            Event(type="message", text="go", user="U0EXAMPLE1", ts="1"),
+            turn_epoch=epoch,
+        )
+        lines.append(await anext(turn))
+        await runner.interrupt("operator stop")
+        assert await runner.timeout(epoch) is True
+        async for line in turn:
+            lines.append(line)
+        await runner.close()
+
+    anyio.run(go)
+    events = parse_ndjson("".join(lines))
+    assert events[-1].status is SessionStatus.CLASSIFIED_FAILURE
+    root = _span_named(list(exporter.get_finished_spans()), "agent.run")[0]
+    assert root.attributes["curie.terminal.cause"] == "runner_timeout"
+    assert root.attributes["curie.terminal.status"] == "failed"
+    assert root.status.status_code is StatusCode.ERROR
 
 
 @pytest.mark.parametrize(

--- a/scripts/runner_otel_shape.py
+++ b/scripts/runner_otel_shape.py
@@ -46,6 +46,7 @@ _TERMINAL_OUTCOMES = {
     ("aborted_streaming", "failed"): _OTEL_STATUS_ERROR,
     ("aborted_tools", "failed"): _OTEL_STATUS_ERROR,
     ("classified_failure", "failed"): _OTEL_STATUS_ERROR,
+    ("runner_timeout", "failed"): _OTEL_STATUS_ERROR,
     ("completed", "succeeded"): _OTEL_STATUS_OK,
     ("abandoned", "abandoned"): _OTEL_STATUS_ERROR,
 }


### PR DESCRIPTION
## Summary

- add an authenticated, per-turn timeout control from the worker to the runner
- store `runner_timeout` / `failed` / ERROR as the first correlated runner terminal and emit once-only failure metrics
- preserve ordered session ownership across cancellation, failed ACKs, cleanup, and healthy retries without changing the kernel or frozen contracts

## Done-check

- [x] Failing tests committed before implementation; pre-squash history recorded each test contract ahead of its source fix.
- [x] All production edits were made by scoped native Codex workers; reviewers and the driver did not author production code.
- [x] No return type was broadened.
- [x] Code review converged through the required Fable oracle after repeated router timeouts; its late-ACK race finding was fixed and the narrow follow-up returned PASS / UNBLOCKED.
- [x] Scope review passed with every hunk mapped to #2011, a required control, or a mechanical telemetry/docs update.
- [x] Sibling paths were checked against the plan: worker/runner HTTP, terminal storage sites, metrics, and healthy/cancellation paths are covered; CLI direct-runner behavior remains explicitly outside this worker-RPC issue.
- [x] Guard demonstrations passed for missing/malformed/stale/spoofed epochs and unauthenticated timeout controls.
- [x] Consolidation was skipped because the built-in `/simplify` capability is unavailable in this session; no consolidation diff exists.
- [x] Security review passed after authenticated capability, replay, cancellation, cleanup, and cross-turn ordering review.
- [x] Observable behavior was verified at the real worker-runner HTTP boundary.
- [x] Deployed E2E passed: `LADDER PASS (tiers: skill,local)` on freshly built candidate artifacts, followed by clean teardown.
- [x] Full affected validation passed: worker 337 passed / 2 skipped; runner 803 passed / 4 skipped; telemetry 109 passed; Ruff, MyPy, import contracts, docs, and wire tolerance clean.

## Verification

- `curie dev verify-fix-pin de1309a0 apps/worker/tests/kernel/test_runner_client.py::test_real_http_timeout_unblocks_live_consumer_with_first_failure_terminal` returned `PINNED`.
- No Curie, plugin, chart, protocol, or runtime version was changed.
- The live soak release, cluster, systemd units, and credentials were not touched.

Fixes #2011

Fix pin: apps/worker/tests/kernel/test_runner_client.py::test_real_http_timeout_unblocks_live_consumer_with_first_failure_terminal