### PR TITLE
Reject empty Trigger and Live proof on patch-release PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,23 @@
 
 Closes #
 
+## Trigger
+
+<!-- Required for a patch release PR (title: Prepare the vX.Y.Z release
+     where Z is not 0). List the issue numbers of the defects that
+     triggered this patch, for example #2202. Other pull requests may
+     leave this comment in place.
+
+     If you moved an open issue out of this milestone within 24 hours of
+     the cut, that issue needs a comment naming the release it moved from. -->
+
+## Live proof
+
+<!-- Required for a patch release PR. Name a run URL that re-verified each
+     trigger on a live surface, or an explicit waiver of the form:
+     waiver: <reason>
+     Other pull requests may leave this comment in place. -->
+
 ## Fix pin verification
 
 <!-- Verification is required for declared fixes. For a fix pull request,

--- a/.github/workflows/pr-body.yaml
+++ b/.github/workflows/pr-body.yaml
@@ -26,27 +26,35 @@ jobs:
           persist-credentials: false
       # Keep untrusted PR text out of shell source. github-script reads the
       # payload directly and writes its bytes to a runner-owned temporary file.
-      - name: Write the pull request body to a temporary file
+      - name: Write the pull request body and title to temporary files
         uses: actions/github-script@v9
         env:
           PR_BODY_FILE: ${{ runner.temp }}/curie-pr-body.md
+          PR_TITLE_FILE: ${{ runner.temp }}/curie-pr-title.txt
         with:
           script: |
             const fs = require("node:fs");
             const body = context.payload.pull_request?.body ?? "";
+            const title = context.payload.pull_request?.title ?? "";
             if (typeof body !== "string") {
               core.setFailed("pull request body must be a string or null");
               return;
             }
+            if (typeof title !== "string") {
+              core.setFailed("pull request title must be a string or null");
+              return;
+            }
             fs.writeFileSync(process.env.PR_BODY_FILE, body, { encoding: "utf8", mode: 0o600 });
+            fs.writeFileSync(process.env.PR_TITLE_FILE, title, { encoding: "utf8", mode: 0o600 });
       # Prove both branches of the matcher can still be reached before trusting
       # its verdict against the event payload.
       - name: PR body guard self-test
         run: bash scripts/check-pr-body.sh --self-test
-      - name: Reject literal newline escapes and AI attribution in the pull request body
+      - name: Reject literal newline escapes, AI attribution, and empty patch-release sections
         env:
           PR_BODY_FILE: ${{ runner.temp }}/curie-pr-body.md
+          PR_TITLE_FILE: ${{ runner.temp }}/curie-pr-title.txt
         run: |
           set -euo pipefail
-          trap 'rm -f -- "$PR_BODY_FILE"' EXIT
-          bash scripts/check-pr-body.sh "$PR_BODY_FILE"
+          trap 'rm -f -- "$PR_BODY_FILE" "$PR_TITLE_FILE"' EXIT
+          bash scripts/check-pr-body.sh "$PR_BODY_FILE" --title-file "$PR_TITLE_FILE"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -631,8 +631,12 @@ branch list, restores the `RELEASE_NEXT_BRANCH` environment alias and the
   magic words fire once on the default branch.
 - PR bodies must contain real line breaks. The PR body guard rejects escaped
   newline sequences because GitHub treats them as text, making closing keywords
-  inert. Run `scripts/check-pr-body.sh <body-file>` before opening or editing a
-  PR.
+  inert. A patch release PR (title `Prepare the vX.Y.Z release` with Z not 0)
+  must also fill Trigger (issue numbers) and Live proof (a run URL or
+  `waiver: <reason>`); the same guard rejects either section left empty. Run
+  `scripts/check-pr-body.sh <body-file>` before opening or editing a PR
+  (`--title-file` for a release PR). See
+  [`docs/release-verification.md`](docs/release-verification.md#patch-releases-name-their-trigger-and-live-proof).
 - **Never mention any AI assistant (Claude, Codex, GPT, etc.) or AI in general in
   commit messages OR pull request bodies, and never add `Co-Authored-By` lines
   referencing AI.** This applies to the PR body as much as to the commits: many

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -232,8 +232,11 @@ branch list, restores the `RELEASE_NEXT_BRANCH` environment alias and the
   title.
 - **Use real line breaks in the PR body**. The PR body guard rejects escaped
   newline sequences because GitHub treats them as text, which makes closing
-  keywords inert. Before opening or editing a PR, run
-  `scripts/check-pr-body.sh <body-file>`.
+  keywords inert. A patch release PR (title `Prepare the vX.Y.Z release` with
+  Z not 0) must also fill **Trigger** (issue numbers) and **Live proof** (a
+  run URL or `waiver: <reason>`). Before opening or editing a PR, run
+  `scripts/check-pr-body.sh <body-file>` (pass `--title-file` for a release
+  PR).
 - **No dashes or emdashes in prose; no emojis** in code or docs.
 - **Never mention any AI assistant** (or AI in general) in commit messages, and
   never add `Co-Authored-By` lines referencing an AI.

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,7 +52,8 @@ git history (`git log -- docs/`).
   operator-facing findings from early installs.
 - [`release-verification.md`](release-verification.md): what every release asset
   carries (checksums, signature, provenance, SBOM) and how to verify one before
-  you run it.
+  you run it, plus the patch-release rule that the cut names its defect trigger
+  and a live proof.
 - [`design/multi-dev-shared-cluster.md`](design/multi-dev-shared-cluster.md): the
   design pass for many developers iterating against one shared cluster (isolation,
   targeting, ambient context), answering epic #44's deferred open questions.

--- a/docs/release-verification.md
+++ b/docs/release-verification.md
@@ -12,6 +12,34 @@ These artifacts are produced by the release workflow, so they exist on every
 release published *after* v0.4.0. Nothing below works against v0.4.0 or earlier,
 which shipped bare binaries.
 
+## Patch releases name their trigger and live proof
+
+A patch release (`vX.Y.Z` where Z is not 0) names the defects that triggered it
+and the live surface each defect was re-verified on. The four v0.8.x patch PRs
+(#2117, #2157, #2181, #2218) are the negative examples: they described release
+mechanics, marked every product end-to-end tier n/a, and moved unfinished
+issues out of the milestone so it read as empty. Only v0.8.4 had a real
+trigger, and even that cut did not record live proof on the PR.
+
+The release pull request therefore carries two required sections, which the
+default [PR template](../.github/PULL_REQUEST_TEMPLATE.md) includes:
+
+- **Trigger** lists the issue numbers of the defects that caused the cut.
+- **Live proof** names a CI or ladder run URL that re-verified each trigger on
+  a live surface, or an explicit `waiver:` line with the reason no live run
+  was possible.
+
+`scripts/check-pr-body.sh` (the PR-body gate in
+[`.github/workflows/pr-body.yaml`](../.github/workflows/pr-body.yaml)) rejects a
+patch release PR whose title matches `Prepare the vX.Y.Z release` when either
+section is missing, comment-only, or empty of those contents. Feature releases
+(`vX.Y.0`) are not this gate.
+
+When an open issue is moved out of the milestone within 24 hours of the cut,
+comment on that issue naming the release it moved from. That is a process
+rule: the PR-body gate does not observe milestone moves. A milestone that
+reads "zero open issues" is not itself a reason to cut.
+
 ## What each release publishes
 
 | Asset | What it is |

--- a/scripts/check-pr-body.sh
+++ b/scripts/check-pr-body.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Two guards on a pull request body.
+# Three guards on a pull request body.
 #
 # 1. Reject a literal "\\n" escape. GitHub displays that escape as text rather
 #    than a line break, so a following `Closes #<issue>` is not parsed as a
@@ -10,9 +10,13 @@
 #    commit half was enforced, so agent-authored bodies kept arriving with the
 #    robot-emoji footer and were merged (#2225). The body is the half a human
 #    reviewer sees first and the half no rebase can rewrite.
+# 3. Reject a patch-release PR (title `Prepare the vX.Y.Z release` with Z not
+#    0) whose Trigger or Live proof section is missing, comment-only, or empty
+#    of issue numbers / a run URL or explicit waiver (#2251). The v0.8.x patch
+#    PRs shipped as release mechanics with every product tier marked n/a.
 #
 # Usage:
-#   scripts/check-pr-body.sh <body-file>
+#   scripts/check-pr-body.sh <body-file> [--title-file <title-file>]
 #   scripts/check-pr-body.sh --self-test
 set -euo pipefail
 
@@ -21,13 +25,125 @@ SCRIPT_PATH="$SCRIPT_DIR/$(basename "${BASH_SOURCE[0]}")"
 COMMIT_GATE="$SCRIPT_DIR/check-commit-messages.sh"
 
 usage() {
-    echo "Usage: scripts/check-pr-body.sh <body-file>" >&2
+    echo "Usage: scripts/check-pr-body.sh <body-file> [--title-file <title-file>]" >&2
     echo "       scripts/check-pr-body.sh --self-test" >&2
+}
+
+# True when the title is a patch release: "Prepare the vX.Y.Z release" and Z is
+# not 0. Feature and major cuts (Z == 0) are not this gate.
+is_patch_release_title() {
+    local title="$1"
+    title="${title//$'\r'/}"
+    title="${title#"${title%%[![:space:]]*}"}"
+    title="${title%"${title##*[![:space:]]}"}"
+    if [[ "$title" =~ ^Prepare\ the\ v([0-9]+)\.([0-9]+)\.([0-9]+)\ release$ ]]; then
+        [[ "${BASH_REMATCH[3]}" != "0" ]]
+        return
+    fi
+    return 1
+}
+
+# Strip HTML comments, including ones that span lines, then drop blank lines.
+visible_text() {
+    awk '
+        BEGIN { in_comment = 0 }
+        {
+            line = $0
+            out = ""
+            while (length(line) > 0) {
+                if (in_comment) {
+                    idx = index(line, "-->")
+                    if (idx == 0) { line = ""; break }
+                    line = substr(line, idx + 3)
+                    in_comment = 0
+                } else {
+                    idx = index(line, "<!--")
+                    if (idx == 0) { out = out line; break }
+                    out = out substr(line, 1, idx - 1)
+                    line = substr(line, idx + 4)
+                    in_comment = 1
+                }
+            }
+            print out
+        }
+    ' | sed 's/\r$//;s/^[[:space:]]*//;s/[[:space:]]*$//' | sed '/^$/d'
+}
+
+# Print the body of `## <heading>` until the next ATX H2. Exact heading match
+# after collapsing space, case-insensitive.
+extract_section() {
+    local heading="$1"
+    awk -v heading="$heading" '
+        {
+            line = $0
+            sub(/\r$/, "", line)
+        }
+        /^##[[:space:]]+/ {
+            title = line
+            sub(/^##[[:space:]]+/, "", title)
+            gsub(/[[:space:]]+/, " ", title)
+            sub(/[[:space:]]+$/, "", title)
+            if (capturing) {
+                exit
+            }
+            heading_l = heading
+            title_l = title
+            # tolower is POSIX; Ubuntu awk (mawk) has no IGNORECASE.
+            if (tolower(title_l) == tolower(heading_l)) {
+                capturing = 1
+                next
+            }
+        }
+        capturing { print line }
+    '
+}
+
+section_visible() {
+    local heading="$1"
+    local body_file="$2"
+    extract_section "$heading" <"$body_file" | visible_text
+}
+
+trigger_lists_issue_numbers() {
+    grep -qE '#[0-9]+' <<<"$1"
+}
+
+live_proof_names_url_or_waiver() {
+    local text="$1"
+    if grep -qiE 'https?://' <<<"$text"; then
+        return 0
+    fi
+    grep -qiE '(^|[[:space:]])waiver:[[:space:]]*[^[:space:]]' <<<"$text"
+}
+
+check_patch_release_sections() {
+    local body_file="$1"
+    local title="$2"
+    local trigger_text proof_text
+
+    if ! is_patch_release_title "$title"; then
+        return 0
+    fi
+
+    trigger_text="$(section_visible "Trigger" "$body_file" || true)"
+    if [[ -z "$trigger_text" ]] || ! trigger_lists_issue_numbers "$trigger_text"; then
+        echo "PR body check failed: patch release PRs must have a non-empty Trigger section listing issue numbers." >&2
+        return 1
+    fi
+
+    proof_text="$(section_visible "Live proof" "$body_file" || true)"
+    if [[ -z "$proof_text" ]] || ! live_proof_names_url_or_waiver "$proof_text"; then
+        echo "PR body check failed: patch release PRs must have a non-empty Live proof section naming a run URL or an explicit waiver." >&2
+        return 1
+    fi
+    return 0
 }
 
 check_body_file() {
     local body_file="$1"
-    local grep_status
+    local title_file="${2:-}"
+    local grep_status title=""
+    local patch_release=0
 
     if [[ ! -f "$body_file" ]]; then
         echo "PR body check failed: '$body_file' is not a regular file" >&2
@@ -62,19 +178,49 @@ check_body_file() {
         return 1
     fi
 
-    echo "PR body check passed: real newlines, no AI attribution"
+    if [[ -n "$title_file" ]]; then
+        if [[ ! -f "$title_file" ]]; then
+            echo "PR body check failed: '$title_file' is not a regular file" >&2
+            return 1
+        fi
+        if [[ ! -r "$title_file" ]]; then
+            echo "PR body check failed: '$title_file' is not readable" >&2
+            return 1
+        fi
+        title="$(head -n 1 -- "$title_file")"
+        if ! check_patch_release_sections "$body_file" "$title"; then
+            return 1
+        fi
+        if is_patch_release_title "$title"; then
+            patch_release=1
+        fi
+    fi
+
+    if ((patch_release)); then
+        echo "PR body check passed: real newlines, no AI attribution, patch release Trigger and Live proof are present"
+    else
+        echo "PR body check passed: real newlines, no AI attribution"
+    fi
 }
 
 self_test() {
     local temp_dir real_newline_body literal_escape_body attributed_body footer_no_newline_body
+    local empty_patch_body filled_patch_body comment_trigger_body empty_proof_body
+    local patch_title feature_title patch10_title
 
     temp_dir="$(mktemp -d "${TMPDIR:-/tmp}/curie-pr-body-check.XXXXXX")"
     trap 'rm -rf -- "$temp_dir"' RETURN
     real_newline_body="$temp_dir/real-newline.md"
     literal_escape_body="$temp_dir/literal-escape.md"
-
     attributed_body="$temp_dir/attributed.md"
     footer_no_newline_body="$temp_dir/footer-no-newline.md"
+    empty_patch_body="$temp_dir/empty-patch.md"
+    filled_patch_body="$temp_dir/filled-patch.md"
+    comment_trigger_body="$temp_dir/comment-trigger.md"
+    empty_proof_body="$temp_dir/empty-proof.md"
+    patch_title="$temp_dir/patch-title.txt"
+    feature_title="$temp_dir/feature-title.txt"
+    patch10_title="$temp_dir/patch-10-title.txt"
 
     printf 'Describe a fix.\n\nCloses #1713\n' >"$real_newline_body"
     printf 'Describe a fix.\\n\\nCloses #1713\n' >"$literal_escape_body"
@@ -84,6 +230,54 @@ self_test() {
         >"$attributed_body"
     printf 'Describe a fix.\n\n\xf0\x9f\xa4\x96 Generated with [Claude Code](https://claude.com/claude-code)' \
         >"$footer_no_newline_body"
+
+    printf 'Prepare the v0.8.4 release\n' >"$patch_title"
+    printf 'Prepare the v0.9.0 release\n' >"$feature_title"
+    printf 'Prepare the v0.8.10 release\n' >"$patch10_title"
+
+    printf '%s\n' \
+        '## Summary' \
+        '' \
+        'Prepare the frozen v0.8.4 patch release.' \
+        '' \
+        '## Related issue' \
+        '' \
+        'Milestone: v0.8.4' \
+        >"$empty_patch_body"
+
+    printf '%s\n' \
+        '## Summary' \
+        '' \
+        'Prepare the frozen v0.8.4 patch release.' \
+        '' \
+        '## Trigger' \
+        '' \
+        '#2202, #2203, #2205, #2194' \
+        '' \
+        '## Live proof' \
+        '' \
+        'https://github.com/curie-eng/curie/actions/runs/1' \
+        >"$filled_patch_body"
+
+    printf '%s\n' \
+        '## Trigger' \
+        '' \
+        '<!-- List the issue numbers of the defects that triggered this patch. -->' \
+        '' \
+        '## Live proof' \
+        '' \
+        'https://github.com/curie-eng/curie/actions/runs/1' \
+        >"$comment_trigger_body"
+
+    printf '%s\n' \
+        '## Trigger' \
+        '' \
+        '#2202' \
+        '' \
+        '## Live proof' \
+        '' \
+        '<!-- Name a run URL or an explicit waiver. -->' \
+        >"$empty_proof_body"
 
     if ! bash "$SCRIPT_PATH" "$real_newline_body" >/dev/null; then
         echo "PR body check self-test failed: real newlines were rejected" >&2
@@ -103,7 +297,32 @@ self_test() {
         return 1
     fi
 
-    echo "PR body check self-test passed: clean body accepted, literal \\n and AI attribution rejected"
+    if bash "$SCRIPT_PATH" "$empty_patch_body" --title-file "$patch_title" >/dev/null 2>&1; then
+        echo "PR body check self-test failed: empty patch-release Trigger/Live proof were accepted" >&2
+        return 1
+    fi
+    if bash "$SCRIPT_PATH" "$comment_trigger_body" --title-file "$patch_title" >/dev/null 2>&1; then
+        echo "PR body check self-test failed: comment-only Trigger was accepted" >&2
+        return 1
+    fi
+    if bash "$SCRIPT_PATH" "$empty_proof_body" --title-file "$patch_title" >/dev/null 2>&1; then
+        echo "PR body check self-test failed: empty Live proof was accepted" >&2
+        return 1
+    fi
+    if ! bash "$SCRIPT_PATH" "$filled_patch_body" --title-file "$patch_title" >/dev/null; then
+        echo "PR body check self-test failed: filled Trigger and Live proof were rejected" >&2
+        return 1
+    fi
+    if ! bash "$SCRIPT_PATH" "$empty_patch_body" --title-file "$feature_title" >/dev/null; then
+        echo "PR body check self-test failed: a feature-release title was gated as a patch" >&2
+        return 1
+    fi
+    if bash "$SCRIPT_PATH" "$empty_patch_body" --title-file "$patch10_title" >/dev/null 2>&1; then
+        echo "PR body check self-test failed: two-digit patch version skipped the gate" >&2
+        return 1
+    fi
+
+    echo "PR body check self-test passed: clean body accepted, literal \\n and AI attribution rejected, empty patch-release Trigger and Live proof rejected"
 }
 
 if [[ "${1:-}" == "--self-test" ]]; then
@@ -115,9 +334,36 @@ if [[ "${1:-}" == "--self-test" ]]; then
     exit 0
 fi
 
-if (($# != 1)); then
+body_file=""
+title_file=""
+while (($#)); do
+    case "$1" in
+        --title-file)
+            if (($# < 2)); then
+                usage
+                exit 2
+            fi
+            title_file="$2"
+            shift 2
+            ;;
+        --*)
+            usage
+            exit 2
+            ;;
+        *)
+            if [[ -n "$body_file" ]]; then
+                usage
+                exit 2
+            fi
+            body_file="$1"
+            shift
+            ;;
+    esac
+done
+
+if [[ -z "$body_file" ]]; then
     usage
     exit 2
 fi
 
-check_body_file "$1"
+check_body_file "$body_file" "$title_file"

--- a/tools/ci-retry-gate/tests/test_pr_body.py
+++ b/tools/ci-retry-gate/tests/test_pr_body.py
@@ -1,9 +1,11 @@
 """Executable regressions for the pull request body guards.
 
-Two rules share this checker: bodies that defeat GitHub auto-close (#1713),
-and bodies that claim AI authorship (#962). The second half exists because
+Three rules share this checker: bodies that defeat GitHub auto-close (#1713),
+bodies that claim AI authorship (#962), and patch-release bodies that leave
+Trigger or Live proof empty (#2251). The attribution half exists because
 AGENTS.md forbade attribution on both surfaces while only the commit half was
-enforced, so footers kept reaching merged pull requests.
+enforced, so footers kept reaching merged pull requests. The release half exists
+because the v0.8.x patch PRs named no defect trigger and no live re-verification.
 """
 
 from __future__ import annotations
@@ -17,11 +19,18 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 CHECKER = REPO_ROOT / "scripts" / "check-pr-body.sh"
 
 
-def _check_body(tmp_path: Path, body: str) -> subprocess.CompletedProcess[str]:
+def _check_body(
+    tmp_path: Path, body: str, *, title: str | None = None
+) -> subprocess.CompletedProcess[str]:
     body_path = tmp_path / "pull-request-body.md"
     body_path.write_text(body, encoding="utf-8")
+    command = ["bash", str(CHECKER), str(body_path)]
+    if title is not None:
+        title_path = tmp_path / "pull-request-title.txt"
+        title_path.write_text(title, encoding="utf-8")
+        command.extend(["--title-file", str(title_path)])
     return subprocess.run(
-        ["bash", str(CHECKER), str(body_path)],
+        command,
         cwd=REPO_ROOT,
         capture_output=True,
         text=True,
@@ -137,3 +146,152 @@ def test_pr_body_gate_inherits_the_commit_matcher_boundary(tmp_path: Path) -> No
     completed = _check_body(tmp_path, "This patch was generated with Claude.\n")
 
     assert completed.returncode == 0, _diagnostics(completed)
+
+
+PATCH_RELEASE_TITLE = "Prepare the v0.8.4 release"
+FEATURE_RELEASE_TITLE = "Prepare the v0.9.0 release"
+
+# Shape of #2218: release mechanics, no Trigger, no Live proof, every product
+# tier marked n/a. The gate must refuse this on a patch-release title.
+EMPTY_PATCH_RELEASE_BODY = """## Summary
+
+Prepare the frozen v0.8.4 patch release on `main`. This registers the
+immutable architecture-atlas snapshot and aligns CLI and chart versions.
+
+## Related issue
+
+Milestone: v0.8.4
+
+## Fix pin verification
+
+This is release preparation, not a behavior fix, and it closes no bug.
+
+## End-to-end verification
+
+This change updates release identity. Product behavior is unchanged.
+
+| Tier | Required / n/a | Reason |
+| --- | --- | --- |
+| skill | n/a | unchanged |
+| local | n/a | unchanged |
+| local-release | required | released identity changes |
+| cluster | n/a | unchanged |
+| live provider | n/a | unchanged |
+| external integration | n/a | unchanged |
+
+## Checklist
+
+- [x] Tests pass for the area touched.
+"""
+
+FILLED_TRIGGER = "## Trigger\n\n#2202, #2203, #2205, #2194\n"
+FILLED_LIVE_PROOF_URL = (
+    "## Live proof\n\n"
+    "https://github.com/curie-eng/curie/actions/runs/1\n"
+)
+FILLED_LIVE_PROOF_WAIVER = "## Live proof\n\nwaiver: no live cluster in this cut\n"
+COMMENT_ONLY_TRIGGER = (
+    "## Trigger\n\n"
+    "<!-- List the issue numbers of the defects that triggered this patch. -->\n"
+)
+
+
+def test_pr_body_rejects_patch_release_without_trigger_or_live_proof(tmp_path: Path) -> None:
+    """#2251: the v0.8.x patch PRs are the negative examples this gate exists for."""
+    completed = _check_body(
+        tmp_path, EMPTY_PATCH_RELEASE_BODY, title=PATCH_RELEASE_TITLE
+    )
+    diagnostics = _diagnostics(completed)
+
+    assert completed.returncode != 0, diagnostics
+    assert "Trigger" in completed.stderr, diagnostics
+
+
+def test_pr_body_rejects_patch_release_with_empty_trigger(tmp_path: Path) -> None:
+    body = EMPTY_PATCH_RELEASE_BODY + "\n" + COMMENT_ONLY_TRIGGER + FILLED_LIVE_PROOF_URL
+    completed = _check_body(tmp_path, body, title=PATCH_RELEASE_TITLE)
+    diagnostics = _diagnostics(completed)
+
+    assert completed.returncode != 0, diagnostics
+    assert "Trigger" in completed.stderr, diagnostics
+
+
+def test_pr_body_rejects_patch_release_with_empty_live_proof(tmp_path: Path) -> None:
+    body = (
+        EMPTY_PATCH_RELEASE_BODY
+        + "\n"
+        + FILLED_TRIGGER
+        + "## Live proof\n\n<!-- Name a run URL or an explicit waiver. -->\n"
+    )
+    completed = _check_body(tmp_path, body, title=PATCH_RELEASE_TITLE)
+    diagnostics = _diagnostics(completed)
+
+    assert completed.returncode != 0, diagnostics
+    assert "Live proof" in completed.stderr, diagnostics
+
+
+@pytest.mark.parametrize(
+    "live_proof",
+    (FILLED_LIVE_PROOF_URL, FILLED_LIVE_PROOF_WAIVER),
+)
+def test_pr_body_accepts_patch_release_with_trigger_and_live_proof(
+    tmp_path: Path, live_proof: str
+) -> None:
+    body = EMPTY_PATCH_RELEASE_BODY + "\n" + FILLED_TRIGGER + live_proof
+    completed = _check_body(tmp_path, body, title=PATCH_RELEASE_TITLE)
+
+    assert completed.returncode == 0, _diagnostics(completed)
+    assert "Trigger" in completed.stdout or "Live proof" in completed.stdout, _diagnostics(
+        completed
+    )
+
+
+@pytest.mark.parametrize(
+    "title",
+    (
+        FEATURE_RELEASE_TITLE,
+        "Prepare the v1.0.0 release",
+        "Fix the dispatcher readiness probe",
+    ),
+)
+def test_pr_body_skips_release_sections_unless_title_is_a_patch_release(
+    tmp_path: Path, title: str
+) -> None:
+    completed = _check_body(tmp_path, EMPTY_PATCH_RELEASE_BODY, title=title)
+
+    assert completed.returncode == 0, _diagnostics(completed)
+
+
+def test_pr_body_gates_two_digit_patch_versions(tmp_path: Path) -> None:
+    completed = _check_body(
+        tmp_path, EMPTY_PATCH_RELEASE_BODY, title="Prepare the v0.8.10 release"
+    )
+    diagnostics = _diagnostics(completed)
+
+    assert completed.returncode != 0, diagnostics
+    assert "Trigger" in completed.stderr, diagnostics
+
+
+def test_pr_template_has_required_patch_release_sections() -> None:
+    """#2251: the template the release PRs actually use must carry both sections."""
+    template = (REPO_ROOT / ".github" / "PULL_REQUEST_TEMPLATE.md").read_text(encoding="utf-8")
+
+    assert "## Trigger" in template
+    assert "## Live proof" in template
+    assert "waiver:" in template
+
+
+def test_pr_body_self_test_covers_the_patch_release_half() -> None:
+    """CI trusts --self-test before running the gate, so the #2251 cases must be in it."""
+    completed = subprocess.run(
+        ["bash", str(CHECKER), "--self-test"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, _diagnostics(completed)
+    combined = f"{completed.stdout}\n{completed.stderr}"
+    assert "Trigger" in combined, _diagnostics(completed)
+    assert "Live proof" in combined, _diagnostics(completed)

--- a/tools/ci-workflow-paths/tests/test_workflow_paths.py
+++ b/tools/ci-workflow-paths/tests/test_workflow_paths.py
@@ -623,12 +623,20 @@ def test_pr_body_guard_workflow_handles_body_only_pull_request_edits() -> None:
     assert script_step.get("env", {}).get("PR_BODY_FILE") == (
         "${{ runner.temp }}/curie-pr-body.md"
     ), "github-script must write only to a runner-owned temporary file"
+    assert script_step.get("env", {}).get("PR_TITLE_FILE") == (
+        "${{ runner.temp }}/curie-pr-title.txt"
+    ), "github-script must write the untrusted title to a runner-owned temporary file"
     script = script_step.get("with", {}).get("script")
     assert isinstance(script, str), "github-script must contain the payload serialization script"
     assert "context.payload.pull_request?.body ?? \"\"" in script
+    assert "context.payload.pull_request?.title ?? \"\"" in script
     assert "fs.writeFileSync(process.env.PR_BODY_FILE, body" in script
+    assert "fs.writeFileSync(process.env.PR_TITLE_FILE, title" in script
     assert "github.event.pull_request.body" not in script, (
         "untrusted PR text must be read from context.payload, not interpolated into script source"
+    )
+    assert "github.event.pull_request.title" not in script, (
+        "untrusted PR title must be read from context.payload, not interpolated into script source"
     )
 
     run_bodies = [step.get("run") for step in steps if isinstance(step.get("run"), str)]
@@ -641,8 +649,14 @@ def test_pr_body_guard_workflow_handles_body_only_pull_request_edits() -> None:
         if isinstance(body, str) and 'bash scripts/check-pr-body.sh "$PR_BODY_FILE"' in body
     ]
     assert len(guard_runs) == 1, "the event check must pass the runner temp file to the guard"
+    assert "--title-file \"$PR_TITLE_FILE\"" in guard_runs[0], (
+        "the event check must pass the title file so patch-release Trigger/Live proof can be gated"
+    )
     assert "${{ github.event.pull_request.body }}" not in guard_runs[0], (
         "the guard must receive the temporary file, never an interpolated PR body"
+    )
+    assert "${{ github.event.pull_request.title }}" not in guard_runs[0], (
+        "the guard must receive the title file, never an interpolated PR title"
     )
 
 


### PR DESCRIPTION
## Summary

Patch-release pull requests must name the defects that triggered the cut and the live surface each was re-verified on. The v0.8.x patch PRs (#2117, #2157, #2181, #2218) are the negative examples: they described release mechanics, marked every product tier n/a, and left no trigger or live proof on the PR.

This change documents that rule, adds Trigger and Live proof sections to the default PR template, and extends the PR-body gate so a title matching `Prepare the vX.Y.Z release` with Z not 0 is rejected when either section is missing, comment-only, or empty of issue numbers / a run URL or `waiver:` line. Feature releases (`vX.Y.0`) are not this gate.

Moving an open issue out of the milestone within 24 hours of the cut is a process rule (comment on the issue naming the release it moved from). The PR-body gate does not observe milestone moves.

## Related issue

Closes #2251

## Fix pin verification

This pull request does not close a `bug`-labeled issue.

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | Plugin packaging, the runner turn loop, ACI events, and skill eval/check are unchanged. | n/a | n/a |
| local | required | The consumer path is `scripts/check-pr-body.sh` as invoked by `.github/workflows/pr-body.yaml`. | fake | `bash scripts/check-pr-body.sh --self-test` and `uv run pytest -q tools/ci-retry-gate/tests/test_pr_body.py tools/ci-workflow-paths/tests/test_workflow_paths.py -k pr_body` on `8cf319bf` - self-test passed (empty patch-release Trigger and Live proof rejected); 25 passed. |
| local-release | n/a | Released binary and image identity are unchanged. | n/a | n/a |
| cluster | n/a | Chart templates, RBAC, sandbox claims, and init containers are unchanged. | n/a | n/a |
| live provider | n/a | Model routing, credentials, and provider auth are unchanged. | n/a | n/a |
| external integration | n/a | Does not drive Slack, git webhooks, connector OAuth, or a third-party API shape. | n/a | n/a |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

Positive: a patch-release title with Trigger issue numbers and a Live proof URL (or `waiver:`) exits 0.
Negative: the #2218-shaped body with title `Prepare the v0.8.4 release` and empty Trigger/Live proof exits non-zero; comment-only sections exit non-zero; a feature-release title `Prepare the v0.9.0 release` with those sections empty exits 0.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [ ] An ADR is added under `docs/adr/` if this is an architectural decision.
