### PR TITLE
Label issues fixed on next until they land on main

### DIFF
--- a/.github/workflows/close-on-next.yaml
+++ b/.github/workflows/close-on-next.yaml
@@ -1,0 +1,61 @@
+name: Issues fixed on next
+
+# Choice: label path (`fixed-on-next`), not close-on-merge-to-next.
+#
+# GitHub closing keywords fire only on the default branch (`main`). Closing an
+# issue when its fix lands on `next` would under-count remaining work on the
+# patch train: the issue would be closed while the fix is not yet on `main`.
+# Labeling with `fixed-on-next` keeps the issue open, lets milestone queries
+# exclude already-fixed-on-next work, and closes those issues when `next`
+# merges to `main`.
+#
+# No closer convention exists in this repository today (no `fixed-on-next`
+# label and no existing closer workflow), so this workflow takes the label
+# path.
+
+on:
+  push:
+    branches: [next, main]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Print planned actions without mutating issues
+        type: boolean
+        default: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  reconcile:
+    name: Label or close issues fixed on next
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Fetch next for merge detection
+        if: github.ref == 'refs/heads/main'
+        run: git fetch --no-tags origin next:refs/remotes/origin/next
+      - name: Close-on-next self-test
+        run: python3 tools/close-on-next/close.py --self-test
+      - name: Reconcile issues
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          extra=()
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.dry_run }}" = "true" ]; then
+            extra+=(--dry-run)
+          fi
+          python3 tools/close-on-next/close.py \
+            --event "$GITHUB_EVENT_PATH" \
+            --repo "$GITHUB_REPOSITORY" \
+            "${extra[@]}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,6 +182,7 @@ testpaths = [
     "tools/e2e-ci-selection/tests",
     "tools/sdk-lock-gate/tests",
     "tools/fix-pin-ci/tests",
+    "tools/close-on-next/tests",
 ]
 
 [tool.ruff]

--- a/tools/ci-retry-gate/tests/test_retry_eligibility.py
+++ b/tools/ci-retry-gate/tests/test_retry_eligibility.py
@@ -121,6 +121,8 @@ PROTECTED_STEPS = frozenset(
             "verify-and-publish",
             "Every asset has provenance from this workflow and commit",
         ),
+        ("close-on-next.yaml", "reconcile", "Close-on-next self-test"),
+        ("close-on-next.yaml", "reconcile", "Reconcile issues"),
     }
 )
 

--- a/tools/close-on-next/close.py
+++ b/tools/close-on-next/close.py
@@ -1,0 +1,631 @@
+"""Label issues whose fix merged to next; close them when next reaches main.
+
+GitHub closing keywords fire only on the default branch. This helper is the
+non-default-branch half of that contract: parse merged pull request bodies the
+way GitHub would, apply `fixed-on-next`, and close those issues when `next`
+merges to `main`.
+
+Choice: the label path, not close-on-merge-to-next. Closing on `next` would
+under-count remaining work on the patch train. See the workflow header.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+LABEL = "fixed-on-next"
+LABEL_COLOR = "1D76DB"
+LABEL_DESCRIPTION = "Fix merged to next; closes when next merges to main"
+COMMENT = re.compile(r"<!--.*?-->", re.DOTALL)
+MERGE_FROM_NEXT = re.compile(
+    r"(?i)"
+    r"(?:^Merge (?:remote-tracking )?branch '(?:origin/)?next'(?: into \S+)?$)"
+    r"|(?:^Merge pull request #\d+ from \S+/next(?:\s|$))"
+)
+ZERO_SHA = "0" * 40
+
+
+@dataclass(frozen=True)
+class PullRequest:
+    """A merged pull request whose body may name issues to close."""
+
+    number: int
+    body: str
+    url: str
+    merged: bool
+    base: str
+    head: str
+
+
+@dataclass(frozen=True)
+class Issue:
+    """Enough of a GitHub issue to decide label vs skip vs close."""
+
+    number: int
+    state: str
+    labels: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class Action:
+    """One GitHub mutation, or the plan of one in dry-run."""
+
+    kind: str
+    issue: int | None = None
+    body: str | None = None
+    reason: str = ""
+
+
+def parse_closing_issues(body: str, repository: str) -> tuple[int, ...]:
+    """Return same-repo issue numbers GitHub would close from this body.
+
+    GitHub requires a closing keyword immediately before each reference, so
+    `Closes #12, #13` yields only 12. HTML comments are stripped first. A `#`
+    glued to a word character or a slash is a cross-repo reference and is
+    ignored, matching GitHub's same-repository rule.
+    """
+    owner, _, name = repository.partition("/")
+    if not owner or not name:
+        raise ValueError(f"invalid repository slug: {repository}")
+    repo_url = re.escape(f"https://github.com/{owner}/{name}/issues/")
+    pattern = re.compile(
+        r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b\s*:?\s*"
+        rf"(?:{repo_url}|(?<![\w/])#)"
+        r"(?P<number>\d+)",
+        re.IGNORECASE,
+    )
+    uncommented = COMMENT.sub("", body)
+    numbers: list[int] = []
+    for match in pattern.finditer(uncommented):
+        number = int(match.group("number"))
+        if number == 0 or number in numbers:
+            continue
+        numbers.append(number)
+    return tuple(numbers)
+
+
+def label_comment(pr: PullRequest) -> str:
+    return (
+        f"Fixed on `next` by {pr.url} (#{pr.number}). "
+        "This issue stays open until `next` merges into `main`; "
+        f"the `{LABEL}` label tracks that."
+    )
+
+
+def close_comment() -> str:
+    return (
+        f"Closed because `next` merged into `main`. "
+        f"Tracked as `{LABEL}` since the fix landed on the feature train."
+    )
+
+
+def plan_next_actions(
+    prs: Sequence[PullRequest],
+    open_issues: Mapping[int, Issue],
+    *,
+    repository: str,
+) -> list[Action]:
+    """Label open issues named by merged-to-next PR bodies; skip the rest."""
+    actions: list[Action] = []
+    seen: set[int] = set()
+    for pr in prs:
+        if not pr.merged or pr.base != "next":
+            continue
+        for number in parse_closing_issues(pr.body, repository):
+            if number in seen:
+                continue
+            seen.add(number)
+            issue = open_issues.get(number)
+            if issue is None:
+                continue
+            if LABEL in issue.labels:
+                continue
+            actions.append(
+                Action(kind="add_label", issue=number, reason=f"PR #{pr.number}")
+            )
+            actions.append(
+                Action(
+                    kind="comment",
+                    issue=number,
+                    body=label_comment(pr),
+                    reason=f"PR #{pr.number}",
+                )
+            )
+    if not actions:
+        return []
+    return [Action(kind="ensure_label", reason=f"create `{LABEL}` if missing")] + actions
+
+
+def plan_main_actions(
+    *, should_close: bool, labeled_open: Sequence[Issue]
+) -> list[Action]:
+    """Close open `fixed-on-next` issues only when next just merged to main."""
+    if not should_close:
+        return []
+    actions: list[Action] = []
+    for issue in labeled_open:
+        actions.append(
+            Action(kind="comment", issue=issue.number, body=close_comment(), reason=LABEL)
+        )
+        actions.append(Action(kind="close", issue=issue.number, reason=LABEL))
+    return actions
+
+
+def should_close_labeled_issues(
+    *,
+    ref: str,
+    event_name: str,
+    head_message: str,
+    associated_is_next_merge: bool,
+    next_is_ancestor_of_after: bool | None,
+    next_is_ancestor_of_before: bool | None,
+) -> bool:
+    """True when this event is a `next` into `main` merge (or dispatch recovery)."""
+    short = ref.rsplit("/", 1)[-1]
+    if short != "main":
+        return False
+    if associated_is_next_merge:
+        return True
+    if MERGE_FROM_NEXT.search(head_message.strip()):
+        return True
+    if next_is_ancestor_of_after is True:
+        if event_name == "workflow_dispatch":
+            return True
+        if next_is_ancestor_of_before is False:
+            return True
+    return False
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--self-test", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--event", type=Path)
+    parser.add_argument("--repo")
+    parser.add_argument("--ref")
+    return parser
+
+
+def _load_event(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValueError(f"could not read event: {error}") from error
+    if not isinstance(payload, dict):
+        raise ValueError("event must be an object")
+    return payload
+
+
+def _repo(event: dict[str, Any] | None, explicit: str | None) -> str:
+    if explicit:
+        return explicit
+    if event is not None:
+        repository = event.get("repository")
+        if isinstance(repository, dict):
+            full_name = repository.get("full_name")
+            if isinstance(full_name, str) and full_name:
+                return full_name
+    env = os.environ.get("GITHUB_REPOSITORY")
+    if env:
+        return env
+    raise ValueError("no repository slug is available")
+
+
+def _ref(event: dict[str, Any] | None, explicit: str | None) -> str:
+    if explicit:
+        return explicit
+    if event is not None:
+        value = event.get("ref")
+        if isinstance(value, str) and value:
+            return value
+    env = os.environ.get("GITHUB_REF")
+    if env:
+        return env
+    raise ValueError("no git ref is available")
+
+
+def _event_name(event: dict[str, Any] | None) -> str:
+    env = os.environ.get("GITHUB_EVENT_NAME")
+    if env:
+        return env
+    if event is not None and "inputs" in event:
+        return "workflow_dispatch"
+    return "push"
+
+
+def _head_message(event: dict[str, Any] | None) -> str:
+    if event is None:
+        return ""
+    commit = event.get("head_commit")
+    if isinstance(commit, dict):
+        message = commit.get("message")
+        if isinstance(message, str):
+            return message
+    return ""
+
+
+def _sha(event: dict[str, Any] | None, field: str, fallback: str | None) -> str | None:
+    if event is not None:
+        value = event.get(field)
+        if isinstance(value, str) and value and value != ZERO_SHA:
+            return value
+    if fallback:
+        return fallback
+    return None
+
+
+def _gh(*args: str) -> str:
+    gh = shutil.which("gh")
+    if gh is None:
+        raise ValueError("gh is not on PATH")
+    env = os.environ.copy()
+    # gh colorizes JSON when stdout is captured unless color is forced off,
+    # and a pager can swallow the payload. Both make json.loads fail closed.
+    env["NO_COLOR"] = "1"
+    env["CLICOLOR"] = "0"
+    env["GH_PAGER"] = "cat"
+    env.pop("FORCE_COLOR", None)
+    env.pop("CLICOLOR_FORCE", None)
+    completed = subprocess.run(
+        [gh, *args], capture_output=True, check=False, text=True, env=env
+    )
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout).strip()
+        raise ValueError(f"gh {' '.join(args)} failed: {detail}")
+    return completed.stdout
+
+
+def _json_list(text: str, what: str) -> list[Any]:
+    try:
+        payload = json.loads(text) if text.strip() else []
+    except json.JSONDecodeError as error:
+        raise ValueError(f"could not parse {what}: {error}") from error
+    if not isinstance(payload, list):
+        raise ValueError(f"{what} must be a JSON array")
+    return payload
+
+
+def _labels_of(raw: Any) -> tuple[str, ...]:
+    if not isinstance(raw, list):
+        return ()
+    names: list[str] = []
+    for item in raw:
+        if isinstance(item, str):
+            names.append(item)
+        elif isinstance(item, dict):
+            name = item.get("name")
+            if isinstance(name, str):
+                names.append(name)
+    return tuple(names)
+
+
+def _issue_from(raw: Any) -> Issue | None:
+    if not isinstance(raw, dict):
+        return None
+    number = raw.get("number")
+    if not isinstance(number, int):
+        return None
+    state = raw.get("state")
+    state_text = state.lower() if isinstance(state, str) else "open"
+    return Issue(number=number, state=state_text, labels=_labels_of(raw.get("labels")))
+
+
+def _pr_from(raw: Any) -> PullRequest | None:
+    if not isinstance(raw, dict):
+        return None
+    number = raw.get("number")
+    if not isinstance(number, int):
+        return None
+    body = raw.get("body")
+    body_text = body if isinstance(body, str) else ""
+    url = raw.get("url") or raw.get("html_url") or ""
+    url_text = url if isinstance(url, str) else ""
+    base = raw.get("baseRefName")
+    head = raw.get("headRefName")
+    if isinstance(raw.get("base"), dict):
+        base = raw["base"].get("ref", base)
+    if isinstance(raw.get("head"), dict):
+        head = raw["head"].get("ref", head)
+    merged = bool(raw.get("mergedAt") or raw.get("merged_at") or raw.get("merged"))
+    return PullRequest(
+        number=number,
+        body=body_text,
+        url=url_text,
+        merged=merged,
+        base=base if isinstance(base, str) else "",
+        head=head if isinstance(head, str) else "",
+    )
+
+
+def _list_merged_next_prs(repo: str) -> list[PullRequest]:
+    text = _gh(
+        "pr",
+        "list",
+        "--repo",
+        repo,
+        "--base",
+        "next",
+        "--state",
+        "merged",
+        "--limit",
+        "1000",
+        "--json",
+        "number,url,body,title,mergedAt,headRefName,baseRefName",
+    )
+    prs: list[PullRequest] = []
+    for item in _json_list(text, "merged pull requests"):
+        parsed = _pr_from(item)
+        if parsed is not None:
+            prs.append(parsed)
+    return prs
+
+
+def _list_open_issues(repo: str) -> dict[int, Issue]:
+    text = _gh(
+        "issue",
+        "list",
+        "--repo",
+        repo,
+        "--state",
+        "open",
+        "--limit",
+        "1000",
+        "--json",
+        "number,state,labels",
+    )
+    issues: dict[int, Issue] = {}
+    for item in _json_list(text, "open issues"):
+        parsed = _issue_from(item)
+        if parsed is not None:
+            issues[parsed.number] = parsed
+    return issues
+
+
+def _list_labeled_open(repo: str) -> list[Issue]:
+    text = _gh(
+        "issue",
+        "list",
+        "--repo",
+        repo,
+        "--label",
+        LABEL,
+        "--state",
+        "open",
+        "--limit",
+        "1000",
+        "--json",
+        "number,state,labels,title,url",
+    )
+    issues: list[Issue] = []
+    for item in _json_list(text, "labeled issues"):
+        parsed = _issue_from(item)
+        if parsed is not None:
+            issues.append(parsed)
+    return issues
+
+
+def _associated_is_next_merge(repo: str, sha: str | None) -> bool:
+    if not sha:
+        return False
+    try:
+        text = _gh("api", f"repos/{repo}/commits/{sha}/pulls")
+    except ValueError:
+        return False
+    for item in _json_list(text, "associated pull requests"):
+        parsed = _pr_from(item)
+        if (
+            parsed is not None
+            and parsed.base == "main"
+            and parsed.head == "next"
+            and parsed.merged
+        ):
+            return True
+    return False
+
+
+def _is_ancestor(ancestor: str, descendant: str) -> bool | None:
+    completed = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", ancestor, descendant],
+        capture_output=True,
+        check=False,
+    )
+    if completed.returncode == 0:
+        return True
+    if completed.returncode == 1:
+        return False
+    return None
+
+
+def _ensure_origin_next() -> None:
+    subprocess.run(
+        ["git", "fetch", "--no-tags", "origin", "next:refs/remotes/origin/next"],
+        capture_output=True,
+        check=False,
+    )
+
+
+def _print_plan(actions: Sequence[Action]) -> None:
+    payload = [
+        {
+            "kind": action.kind,
+            "issue": action.issue,
+            "reason": action.reason,
+            "body": action.body,
+        }
+        for action in actions
+    ]
+    print(json.dumps({"actions": payload}, indent=2))
+    if not actions:
+        print("no actions")
+
+
+def _apply(repo: str, actions: Sequence[Action]) -> None:
+    for action in actions:
+        if action.kind == "ensure_label":
+            _gh(
+                "label",
+                "create",
+                LABEL,
+                "--repo",
+                repo,
+                "--color",
+                LABEL_COLOR,
+                "--description",
+                LABEL_DESCRIPTION,
+                "--force",
+            )
+        elif action.kind == "add_label":
+            _gh(
+                "issue",
+                "edit",
+                str(action.issue),
+                "--repo",
+                repo,
+                "--add-label",
+                LABEL,
+            )
+        elif action.kind == "comment":
+            _gh(
+                "issue",
+                "comment",
+                str(action.issue),
+                "--repo",
+                repo,
+                "--body",
+                action.body or "",
+            )
+        elif action.kind == "close":
+            _gh(
+                "issue",
+                "close",
+                str(action.issue),
+                "--repo",
+                repo,
+                "--reason",
+                "completed",
+            )
+        else:
+            raise ValueError(f"unknown action {action.kind}")
+
+
+def _self_test() -> None:
+    repo = "curie-eng/curie"
+    assert parse_closing_issues("Fixes #2201\n", repo) == (2201,)
+    assert parse_closing_issues("Closes #12, #13\n", repo) == (12,)
+    assert parse_closing_issues("Closes #12, closes #13\n", repo) == (12, 13)
+    assert parse_closing_issues("<!-- Closes #12 -->\n", repo) == ()
+    assert parse_closing_issues("This mentions #12 without a keyword.\n", repo) == ()
+    pr = PullRequest(
+        number=2217,
+        body="Fixes #2201\n",
+        url="https://github.com/curie-eng/curie/pull/2217",
+        merged=True,
+        base="next",
+        head="task/example",
+    )
+    labeled = plan_next_actions(
+        [pr],
+        {2201: Issue(number=2201, state="open", labels=())},
+        repository=repo,
+    )
+    assert any(action.kind == "add_label" and action.issue == 2201 for action in labeled)
+    skipped = plan_next_actions(
+        [pr],
+        {2201: Issue(number=2201, state="open", labels=(LABEL,))},
+        repository=repo,
+    )
+    assert skipped == []
+    closed = plan_main_actions(
+        should_close=True,
+        labeled_open=[Issue(number=12, state="open", labels=(LABEL,))],
+    )
+    assert [action.kind for action in closed] == ["comment", "close"]
+    assert (
+        plan_main_actions(
+            should_close=False,
+            labeled_open=[Issue(number=12, state="open", labels=(LABEL,))],
+        )
+        == []
+    )
+    assert should_close_labeled_issues(
+        ref="refs/heads/main",
+        event_name="push",
+        head_message="Merge pull request #99 from example/next",
+        associated_is_next_merge=False,
+        next_is_ancestor_of_after=None,
+        next_is_ancestor_of_before=None,
+    )
+    assert not should_close_labeled_issues(
+        ref="refs/heads/main",
+        event_name="push",
+        head_message="Merge pull request #50 from example/task/hotfix",
+        associated_is_next_merge=False,
+        next_is_ancestor_of_after=None,
+        next_is_ancestor_of_before=None,
+    )
+    print("close-on-next self-test passed: parser, planner, and merge detection")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    arguments = _parser().parse_args(argv)
+    if arguments.self_test:
+        try:
+            _self_test()
+        except AssertionError as error:
+            print(f"self-test failed: {error}", file=sys.stderr)
+            return 1
+        return 0
+
+    try:
+        event = _load_event(arguments.event) if arguments.event is not None else None
+        repo = _repo(event, arguments.repo)
+        ref = _ref(event, arguments.ref)
+        event_name = _event_name(event)
+        short = ref.rsplit("/", 1)[-1]
+        if short == "next":
+            prs = _list_merged_next_prs(repo)
+            open_issues = _list_open_issues(repo)
+            actions = plan_next_actions(prs, open_issues, repository=repo)
+        elif short == "main":
+            after = _sha(event, "after", os.environ.get("GITHUB_SHA"))
+            before = _sha(event, "before", None)
+            associated = _associated_is_next_merge(repo, after)
+            _ensure_origin_next()
+            after_has = _is_ancestor("origin/next", after) if after else None
+            before_has = _is_ancestor("origin/next", before) if before else None
+            should_close = should_close_labeled_issues(
+                ref=ref,
+                event_name=event_name,
+                head_message=_head_message(event),
+                associated_is_next_merge=associated,
+                next_is_ancestor_of_after=after_has,
+                next_is_ancestor_of_before=before_has,
+            )
+            labeled = _list_labeled_open(repo) if should_close else []
+            actions = plan_main_actions(should_close=should_close, labeled_open=labeled)
+        else:
+            print(f"skip: ref {ref} is not next or main")
+            return 0
+        _print_plan(actions)
+        if arguments.dry_run:
+            print("dry-run: no GitHub mutations")
+            return 0
+        _apply(repo, actions)
+    except ValueError as error:
+        print(error, file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/close-on-next/tests/test_close_on_next.py
+++ b/tools/close-on-next/tests/test_close_on_next.py
@@ -1,0 +1,552 @@
+"""Executable contract for labeling issues fixed on next (issue #2250).
+
+GitHub closing keywords fire only on the default branch. This helper is what
+the push-to-next workflow runs: parse merged PR bodies, apply `fixed-on-next`,
+and close those issues when `next` merges to `main`. Tests drive the script as
+a subprocess with a fake `gh`, matching tools/fix-pin-ci.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+HELPER = REPO_ROOT / "tools" / "close-on-next" / "close.py"
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "close-on-next.yaml"
+REPO = "curie-eng/curie"
+LABEL = "fixed-on-next"
+
+
+def _helper() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("curie_close_on_next", HELPER)
+    assert spec is not None and spec.loader is not None, f"cannot load {HELPER}"
+    module = importlib.util.module_from_spec(spec)
+    # Dataclasses on 3.14 look up the module in sys.modules while the class
+    # body runs; spec_from_file_location does not register it on its own.
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _parse(body: str, repository: str = REPO) -> tuple[int, ...]:
+    return _helper().parse_closing_issues(body, repository)
+
+
+def _write_event(tmp_path: Path, payload: dict[str, Any]) -> Path:
+    path = tmp_path / "event.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _write_fake_gh(tmp_path: Path, fixture: Mapping[str, Any]) -> tuple[Path, Path]:
+    """Install a fake ``gh`` that logs argv and serves scripted list/view JSON."""
+    gh_bin = tmp_path / "gh-bin"
+    gh_bin.mkdir()
+    log_path = tmp_path / "gh-argv.json"
+    fixture_path = tmp_path / "gh-fixture.json"
+    fixture_path.write_text(json.dumps(fixture), encoding="utf-8")
+    fake = gh_bin / "gh"
+    fake.write_text(
+        "\n".join(
+            [
+                f"#!{sys.executable}",
+                "import json, os, sys",
+                "from pathlib import Path",
+                f"log = Path({str(log_path)!r})",
+                f"fixture = json.loads(Path({str(fixture_path)!r}).read_text())",
+                "calls = json.loads(log.read_text()) if log.exists() else []",
+                "calls.append(sys.argv[1:])",
+                "log.write_text(json.dumps(calls))",
+                "argv = sys.argv[1:]",
+                "joined = ' '.join(argv)",
+                "if os.environ.get('CLOSE_ON_NEXT_GH_EXIT', '0') != '0':",
+                "    sys.stderr.write(os.environ.get('CLOSE_ON_NEXT_GH_ERR', 'gh failed'))",
+                "    raise SystemExit(int(os.environ['CLOSE_ON_NEXT_GH_EXIT']))",
+                "if argv[:1] == ['pr'] and 'list' in argv:",
+                "    print(json.dumps(fixture.get('prs', [])))",
+                "    raise SystemExit(0)",
+                "if argv[:1] == ['issue'] and 'list' in argv:",
+                "    if '--label' in argv:",
+                "        print(json.dumps(fixture.get('labeled', [])))",
+                "    else:",
+                "        print(json.dumps(fixture.get('open_issues', [])))",
+                "    raise SystemExit(0)",
+                "if 'commits' in joined and joined.rstrip('/').endswith('pulls'):",
+                "    print(json.dumps(fixture.get('associated', [])))",
+                "    raise SystemExit(0)",
+                "mutating = (",
+                "    '--method' in argv or '-X' in argv",
+                "    or (argv[:1] == ['label'] and 'create' in argv)",
+                "    or 'issue' in argv and ("
+                "'comment' in argv or 'edit' in argv or 'close' in argv)",
+                ")",
+                "if mutating:",
+                "    print('{}')",
+                "    raise SystemExit(0)",
+                "sys.stderr.write('unexpected gh invocation: ' + joined)",
+                "raise SystemExit(2)",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    fake.chmod(0o755)
+    return gh_bin, log_path
+
+
+def _run(
+    tmp_path: Path,
+    *,
+    event: dict[str, Any] | None = None,
+    extra: list[str] | None = None,
+    fixture: Mapping[str, Any] | None = None,
+    gh_on_path: bool = True,
+    dry_run: bool = False,
+) -> tuple[subprocess.CompletedProcess[str], Path]:
+    args = [sys.executable, str(HELPER), "--repo", REPO]
+    if event is not None:
+        args.extend(["--event", str(_write_event(tmp_path, event))])
+    if dry_run:
+        args.append("--dry-run")
+    if extra:
+        args.extend(extra)
+    environment = {**os.environ, "GITHUB_REPOSITORY": REPO}
+    log_path = tmp_path / "gh-argv.json"
+    if gh_on_path:
+        gh_bin, log_path = _write_fake_gh(tmp_path, fixture or {})
+        environment["PATH"] = f"{gh_bin}{os.pathsep}{os.environ.get('PATH', '')}"
+    else:
+        environment["PATH"] = ""
+    completed = subprocess.run(
+        args,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=environment,
+    )
+    return completed, log_path
+
+
+def _calls(log_path: Path) -> list[list[str]]:
+    if not log_path.exists():
+        return []
+    return json.loads(log_path.read_text(encoding="utf-8"))
+
+
+def _mutating_calls(log_path: Path) -> list[list[str]]:
+    mutating: list[list[str]] = []
+    for argv in _calls(log_path):
+        joined = " ".join(argv)
+        if (
+            "--method" in argv
+            or "-X" in argv
+            or argv[:1] == ["label"]
+            or "comment" in argv
+            or "close" in argv
+            or (argv[:1] == ["issue"] and "edit" in argv)
+        ):
+            mutating.append(argv)
+        elif "unexpected" in joined:
+            mutating.append(argv)
+    return mutating
+
+
+# GitHub merge messages are `from <owner>/<branch>`. Naming this org as the
+# owner makes a branch look like a downstream repository slug to gitleaks.
+NEXT_HEAD_MESSAGE = "Merge pull request #2217 from example/task/example"
+NEXT_MERGE_MESSAGE = "Merge pull request #99 from example/next"
+HOTFIX_MERGE_MESSAGE = "Merge pull request #50 from example/task/hotfix"
+
+NEXT_EVENT = {
+    "ref": "refs/heads/next",
+    "before": "a" * 40,
+    "after": "b" * 40,
+    "head_commit": {"message": NEXT_HEAD_MESSAGE},
+    "repository": {"full_name": REPO},
+}
+
+MAIN_NEXT_MERGE_EVENT = {
+    "ref": "refs/heads/main",
+    "before": "c" * 40,
+    "after": "d" * 40,
+    "head_commit": {"message": NEXT_MERGE_MESSAGE},
+    "repository": {"full_name": REPO},
+}
+
+MAIN_HOTFIX_EVENT = {
+    "ref": "refs/heads/main",
+    "before": "c" * 40,
+    "after": "d" * 40,
+    "head_commit": {"message": HOTFIX_MERGE_MESSAGE},
+    "repository": {"full_name": REPO},
+}
+
+
+# --- parser -----------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("body", "expected"),
+    [
+        ("Fixes #2201\n", (2201,)),
+        ("Closes #2123.\n", (2123,)),
+        ("Closes #2173\n", (2173,)),
+        ("Closes: #12\n", (12,)),
+        ("Resolved #12\n", (12,)),
+        ("This mentions #12 without a keyword.\n", ()),
+        ("Closes #12, #13\n", (12,)),
+        ("Closes #12 and #13\n", (12,)),
+        ("Closes #12, closes #13\n", (12, 13)),
+        ("Fixes #12\nFixes #13\n", (12, 13)),
+        ("<!-- Closes #12 -->\n", ()),
+        ("Closes another-owner" + "/some-repo#12\n", ()),
+        (f"Closes https://github.com/{REPO}/issues/12\n", (12,)),
+        ("Closes https://github.com/other/other/issues/12\n", ()),
+        ("", ()),
+    ],
+)
+def test_parse_closing_issues_matches_github_same_repo_semantics(
+    body: str, expected: tuple[int, ...]
+) -> None:
+    assert _parse(body) == expected
+
+
+def test_parse_strips_html_comments_before_scanning() -> None:
+    body = "Summary\n\n<!-- Closes #99 -->\n\nCloses #12\n"
+    assert _parse(body) == (12,)
+
+
+# --- planner ----------------------------------------------------------------
+
+
+def test_plan_next_labels_open_unlabeled_issues_and_skips_the_rest() -> None:
+    module = _helper()
+    prs = [
+        module.PullRequest(
+            number=2217,
+            body="Fixes #2201\n",
+            url=f"https://github.com/{REPO}/pull/2217",
+            merged=True,
+            base="next",
+            head="task/example",
+        ),
+        module.PullRequest(
+            number=9,
+            body="Closes #12, closes #13\n",
+            url=f"https://github.com/{REPO}/pull/9",
+            merged=True,
+            base="next",
+            head="task/other",
+        ),
+    ]
+    open_issues = {
+        2201: module.Issue(number=2201, state="open", labels=()),
+        12: module.Issue(number=12, state="open", labels=(LABEL,)),
+        # 13 is closed / missing from the open map
+    }
+    actions = module.plan_next_actions(prs, open_issues, repository=REPO)
+    kinds = [(action.kind, action.issue) for action in actions]
+    assert ("ensure_label", None) in kinds
+    assert ("add_label", 2201) in kinds
+    assert ("comment", 2201) in kinds
+    assert ("add_label", 12) not in kinds
+    assert ("add_label", 13) not in kinds
+    comment = next(action for action in actions if action.kind == "comment")
+    assert "#2217" in (comment.body or "")
+    assert "next" in (comment.body or "")
+
+
+def test_plan_next_is_empty_when_nothing_is_open_and_unlabeled() -> None:
+    module = _helper()
+    prs = [
+        module.PullRequest(
+            number=1,
+            body="Closes #12\n",
+            url=f"https://github.com/{REPO}/pull/1",
+            merged=True,
+            base="next",
+            head="task/x",
+        )
+    ]
+    actions = module.plan_next_actions(prs, {}, repository=REPO)
+    assert actions == []
+
+
+def test_plan_main_closes_labeled_issues_only_on_next_merge() -> None:
+    module = _helper()
+    labeled = [module.Issue(number=12, state="open", labels=(LABEL,))]
+    close_actions = module.plan_main_actions(should_close=True, labeled_open=labeled)
+    assert [(action.kind, action.issue) for action in close_actions] == [
+        ("comment", 12),
+        ("close", 12),
+    ]
+    assert module.plan_main_actions(should_close=False, labeled_open=labeled) == []
+
+
+@pytest.mark.parametrize(
+    ("ref", "event_name", "message", "associated", "after_has", "before_has", "expected"),
+    [
+        (
+            "refs/heads/main",
+            "push",
+            NEXT_MERGE_MESSAGE,
+            False,
+            None,
+            None,
+            True,
+        ),
+        ("refs/heads/main", "push", "Merge branch 'next'", False, None, None, True),
+        (
+            "refs/heads/main",
+            "push",
+            HOTFIX_MERGE_MESSAGE,
+            False,
+            None,
+            None,
+            False,
+        ),
+        ("refs/heads/main", "push", "hotfix", True, None, None, True),
+        ("refs/heads/main", "push", "hotfix", False, True, False, True),
+        ("refs/heads/main", "push", "hotfix", False, True, True, False),
+        ("refs/heads/main", "workflow_dispatch", "n/a", False, True, True, True),
+        (
+            "refs/heads/next",
+            "push",
+            NEXT_MERGE_MESSAGE,
+            False,
+            None,
+            None,
+            False,
+        ),
+    ],
+)
+def test_should_close_labeled_issues_detects_next_to_main_merge(
+    ref: str,
+    event_name: str,
+    message: str,
+    associated: bool,
+    after_has: bool | None,
+    before_has: bool | None,
+    expected: bool,
+) -> None:
+    assert (
+        _helper().should_close_labeled_issues(
+            ref=ref,
+            event_name=event_name,
+            head_message=message,
+            associated_is_next_merge=associated,
+            next_is_ancestor_of_after=after_has,
+            next_is_ancestor_of_before=before_has,
+        )
+        is expected
+    )
+
+
+# --- CLI / gh ---------------------------------------------------------------
+
+
+def test_self_test_passes_without_gh() -> None:
+    completed = subprocess.run(
+        [sys.executable, str(HELPER), "--self-test"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        env={**os.environ, "PATH": ""},
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert "self-test passed" in completed.stdout
+
+
+def test_dry_run_on_next_prints_label_plan_and_does_not_mutate(tmp_path: Path) -> None:
+    fixture = {
+        "prs": [
+            {
+                "number": 2217,
+                "url": f"https://github.com/{REPO}/pull/2217",
+                "body": "Fixes #2201\n",
+                "title": "fix mcp",
+                "mergedAt": "2026-09-02T16:52:01Z",
+                "headRefName": "task/example",
+                "baseRefName": "next",
+            }
+        ],
+        "open_issues": [{"number": 2201, "state": "OPEN", "labels": []}],
+        "labeled": [],
+        "associated": [],
+    }
+    completed, log_path = _run(
+        tmp_path, event=NEXT_EVENT, fixture=fixture, dry_run=True
+    )
+    shown = f"{completed.stdout}\n{completed.stderr}"
+    assert completed.returncode == 0, shown
+    assert "2201" in completed.stdout
+    assert "add_label" in completed.stdout
+    assert _mutating_calls(log_path) == []
+    assert any("pr" in argv and "list" in argv for argv in _calls(log_path))
+
+
+def test_apply_on_next_adds_label_and_comments(tmp_path: Path) -> None:
+    fixture = {
+        "prs": [
+            {
+                "number": 2217,
+                "url": f"https://github.com/{REPO}/pull/2217",
+                "body": "Fixes #2201\n",
+                "title": "fix mcp",
+                "mergedAt": "2026-09-02T16:52:01Z",
+                "headRefName": "task/example",
+                "baseRefName": "next",
+            }
+        ],
+        "open_issues": [{"number": 2201, "state": "OPEN", "labels": []}],
+        "labeled": [],
+        "associated": [],
+    }
+    completed, log_path = _run(tmp_path, event=NEXT_EVENT, fixture=fixture)
+    shown = f"{completed.stdout}\n{completed.stderr}"
+    assert completed.returncode == 0, shown
+    mutating = _mutating_calls(log_path)
+    assert mutating, shown
+    joined = " ".join(" ".join(argv) for argv in mutating)
+    assert "2201" in joined
+    assert "label" in joined or "labels" in joined
+
+
+def test_dry_run_on_main_next_merge_plans_close_without_mutating(tmp_path: Path) -> None:
+    fixture = {
+        "prs": [],
+        "open_issues": [],
+        "labeled": [
+            {
+                "number": 2201,
+                "state": "OPEN",
+                "labels": [{"name": LABEL}],
+                "title": "mcp",
+                "url": f"https://github.com/{REPO}/issues/2201",
+            }
+        ],
+        "associated": [],
+    }
+    completed, log_path = _run(
+        tmp_path, event=MAIN_NEXT_MERGE_EVENT, fixture=fixture, dry_run=True
+    )
+    shown = f"{completed.stdout}\n{completed.stderr}"
+    assert completed.returncode == 0, shown
+    assert "close" in completed.stdout
+    assert "2201" in completed.stdout
+    assert _mutating_calls(log_path) == []
+
+
+def test_main_hotfix_does_not_close_labeled_issues(tmp_path: Path) -> None:
+    fixture = {
+        "prs": [],
+        "open_issues": [],
+        "labeled": [
+            {
+                "number": 2201,
+                "state": "OPEN",
+                "labels": [{"name": LABEL}],
+                "title": "mcp",
+                "url": f"https://github.com/{REPO}/issues/2201",
+            }
+        ],
+        "associated": [],
+    }
+    completed, log_path = _run(tmp_path, event=MAIN_HOTFIX_EVENT, fixture=fixture)
+    shown = f"{completed.stdout}\n{completed.stderr}"
+    assert completed.returncode == 0, shown
+    assert "close" not in completed.stdout.splitlines() or "no actions" in completed.stdout
+    assert _mutating_calls(log_path) == []
+
+
+def test_missing_gh_fails_closed(tmp_path: Path) -> None:
+    completed, _log = _run(tmp_path, event=NEXT_EVENT, gh_on_path=False)
+    assert completed.returncode != 0
+    assert "gh" in f"{completed.stdout}\n{completed.stderr}".lower()
+
+
+# --- workflow wiring --------------------------------------------------------
+
+
+def _workflow() -> dict[str, Any]:
+    loaded = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    assert isinstance(loaded, dict)
+    return loaded
+
+
+def test_workflow_documents_the_label_path_and_triggers_on_next_and_main() -> None:
+    header = WORKFLOW.read_text(encoding="utf-8")
+    assert "label path" in header.lower()
+    assert LABEL in header
+    assert "close-on-merge-to-next" in header or "not close" in header.lower()
+
+    workflow = _workflow()
+    trigger = workflow.get(True, workflow.get("on"))
+    assert isinstance(trigger, dict)
+    push = trigger.get("push")
+    assert isinstance(push, dict)
+    assert set(push.get("branches") or []) == {"next", "main"}
+    dispatch = trigger.get("workflow_dispatch")
+    assert isinstance(dispatch, dict)
+    inputs = dispatch.get("inputs")
+    assert isinstance(inputs, dict)
+    dry_run = inputs.get("dry_run")
+    assert isinstance(dry_run, dict)
+    assert dry_run.get("type") == "boolean"
+    assert dry_run.get("default") is True
+
+    permissions = workflow.get("permissions")
+    assert isinstance(permissions, dict)
+    assert permissions.get("contents") == "read"
+    assert permissions.get("issues") == "write"
+    assert permissions.get("pull-requests") == "read"
+
+
+def test_workflow_runs_self_test_before_reconcile_and_supports_dry_run() -> None:
+    workflow = _workflow()
+    jobs = workflow.get("jobs")
+    assert isinstance(jobs, dict)
+    job = jobs.get("reconcile")
+    assert isinstance(job, dict)
+    steps = job.get("steps")
+    assert isinstance(steps, list)
+    run_bodies = [step.get("run") for step in steps if isinstance(step.get("run"), str)]
+    assert any(
+        isinstance(body, str) and "close.py --self-test" in body for body in run_bodies
+    ), "the workflow must run --self-test before mutating GitHub"
+    reconcile_runs = [
+        body
+        for body in run_bodies
+        if isinstance(body, str) and "close.py" in body and "--self-test" not in body
+    ]
+    assert len(reconcile_runs) == 1
+    assert "--event" in reconcile_runs[0]
+    assert "--dry-run" in reconcile_runs[0]
+    checkout = [
+        step
+        for step in steps
+        if isinstance(step, dict)
+        and isinstance(step.get("uses"), str)
+        and step["uses"].split("@", 1)[0] == "actions/checkout"
+    ]
+    assert checkout
+    persist = checkout[0].get("with", {}).get("persist-credentials")
+    assert persist is False
+    assert all(
+        step.get("continue-on-error") is not True
+        for step in steps
+        if isinstance(step, dict)
+    )


### PR DESCRIPTION
## Summary

GitHub closing keywords fire only on `main`, so fixes merged to `next` leave their issues open. This adds a workflow on push to `next` and `main` that parses merged PR bodies for those keywords, applies a `fixed-on-next` label with a comment naming the PR, and closes those issues when `next` merges to `main`.

The label path is a documented choice: no closer convention existed in the repo, and closing on `next` would under-count remaining work on the patch train. The workflow runs `--self-test` before mutating and supports `--dry-run` (default on `workflow_dispatch`).

The seven issues named in #2250 were already closed by hand before this change. First run labels still-open issues whose merged-to-next PRs carry closing keywords; it does not reopen.

## Related issue

Closes #2250

## Fix pin verification

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | Does not reach plugin packaging, the runner turn loop, or skill eval | | |
| local | n/a | Does not reach compose services, dispatcher, worker, API, console UI, or a curie verb | | |
| local-release | n/a | Does not change released binary or image identity | | |
| cluster | n/a | Does not reach chart templates, RBAC, or sandbox claims | | |
| live provider | n/a | Does not reach model routing or credential resolution | | |
| external integration | required | GitHub Issues and Pull Requests API | live | `python3 tools/close-on-next/close.py --repo curie-eng/curie --ref refs/heads/next --dry-run` on 0ad2392d planned 27 `add_label` actions and printed `dry-run: no GitHub mutations`. Issue #2250 `updatedAt` stayed `2026-09-03T10:56:58Z`. Second path: `--ref refs/heads/main --dry-run` printed `no actions`. |

- [x] Every required tier above names its exact command, the commit it ran
      against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable
      negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in
      the table.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [ ] An ADR is added under `docs/adr/` if this is an architectural decision.
