### PR TITLE
Skip compose and pytest on docs-only Python CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,6 +90,28 @@ jobs:
       # cluster-free static gate, so it runs alongside the docs gate.
       - name: Wire tolerance gate (_AciModel model_validate call sites)
         run: bash scripts/check-wire-tolerance.sh
+      # Docs-only diffs still run ruff/mypy/docs/alembic/wire-lock above. Reuse
+      # ignored_prefixes from .github/e2e-selection.yaml so a guides edit does
+      # not boot postgres; packages/, apps/, runner/, examples/tests/, cli,
+      # uv.lock, and pyproject.toml still select pytest. The required check
+      # name stays `Python (ruff + mypy + pytest)` so the ruleset gates the
+      # suite when it is selected.
+      - name: Decide whether compose and pytest are needed
+        id: python-runtime
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "push" ]; then
+            uv run python tools/e2e-ci-selection/select_tiers.py \
+              --registry .github/e2e-selection.yaml \
+              --push
+          else
+            base="${{ github.base_ref || 'main' }}"
+            git fetch --quiet origin "$base"
+            uv run python tools/e2e-ci-selection/select_tiers.py \
+              --registry .github/e2e-selection.yaml \
+              --base "origin/$base" \
+              --head HEAD
+          fi
       # Integration tests dial the real dev stack (Postgres 25432, Valkey 26379,
       # RustFS 29000, Langfuse 23000 + ClickHouse + OTel Collector). Boot it after
       # ruff/mypy so cheap failures stay fast. The first up starts the one-shot
@@ -101,6 +123,8 @@ jobs:
       # DB with alembic below, so their image is never needed here -- and it lives
       # in a private registry, so a bare `up` that pulled it failed the job.
       - name: Start dev stack
+        id: dev-stack
+        if: steps.python-runtime.outputs.pytest == 'true'
         run: |
           docker compose -f compose.dev.yaml up -d \
             postgres valkey clickhouse rustfs rustfs-init \
@@ -113,6 +137,7 @@ jobs:
       # actually serving, so the full-stack readiness gate fails fast with an
       # actionable error before integration tests begin.
       - name: Wait for Langfuse to serve
+        if: steps.python-runtime.outputs.pytest == 'true'
         run: |
           for i in $(seq 1 60); do
             if curl -fsS http://localhost:23000/api/public/health >/dev/null 2>&1; then
@@ -122,6 +147,7 @@ jobs:
           done
           echo "Langfuse did not become ready within 180s"; exit 1
       - name: Released database upgrade gate
+        if: steps.python-runtime.outputs.pytest == 'true'
         run: |
           uv run python scripts/check-released-upgrade.py --self-test
           uv run python scripts/check-released-upgrade.py
@@ -131,6 +157,7 @@ jobs:
       # Apply the real migrations to it so those tests run against a real
       # schema; this also exercises the alembic upgrade path on virgin Postgres.
       - name: Migrate the shared database
+        if: steps.python-runtime.outputs.pytest == 'true'
         working-directory: apps/api
         run: uv run alembic upgrade head
       # The committed-lock test only proves the lock matches the current wire; it
@@ -153,7 +180,32 @@ jobs:
       # Sharding on numbers like those would have split the suite along the wrong
       # seam. This prints the real ones on every run, for the price of 25 lines.
       - name: Pytest
+        id: pytest
+        if: steps.python-runtime.outputs.pytest == 'true'
         run: uv run pytest -q --durations=25
+      # Keep the required Python check honest when compose+pytest are skipped:
+      # a selected skip (or an unselected success) fails this job, so the
+      # ruleset still gates the suite whenever the selector asked for it.
+      - name: Require pytest outcome to match selection
+        if: success()
+        env:
+          PYTEST_SELECTED: ${{ steps.python-runtime.outputs.pytest }}
+          PYTEST_RESULT: ${{ steps.pytest.outcome }}
+          STACK_RESULT: ${{ steps.dev-stack.outcome }}
+        run: |
+          set -euo pipefail
+          expected=skipped
+          if [[ "$PYTEST_SELECTED" == "true" ]]; then
+            expected=success
+          elif [[ "$PYTEST_SELECTED" != "false" ]]; then
+            echo "pytest selection must be true or false, got ${PYTEST_SELECTED:-<empty>}" >&2
+            exit 1
+          fi
+          if [[ "$PYTEST_RESULT" != "$expected" || "$STACK_RESULT" != "$expected" ]]; then
+            echo "compose and pytest selected=$PYTEST_SELECTED pytest=$PYTEST_RESULT stack=$STACK_RESULT" >&2
+            exit 1
+          fi
+          echo "Python pytest selection matched $expected"
       # Build ONLY when the declaration parser would invoke the curie binary.
       # tools/fix-pin-ci/check.py reaches it at exactly one place, the
       # `curie dev verify-fix-pin` call, and only once `declaration.selector` is
@@ -202,7 +254,7 @@ jobs:
           --curie cli/target/release/curie
           --ref HEAD
       - name: Dump dev stack logs on failure
-        if: failure()
+        if: ${{ failure() && steps.python-runtime.outputs.pytest == 'true' }}
         run: docker compose -f compose.dev.yaml logs --no-color --tail=200
 
   rust:

--- a/release/tests/test_authorize.py
+++ b/release/tests/test_authorize.py
@@ -1437,6 +1437,7 @@ class TestLegitimateSkips:
             "cluster=true",
             "released_upgrade=true",
             "skill_local_tiers=skill,local",
+            "pytest=true",
         ], (
             "ci.yaml's push selection no longer emits the complete tier contract: "
             f"{github_output.read_text()!r}"

--- a/tools/e2e-ci-selection/select_tiers.py
+++ b/tools/e2e-ci-selection/select_tiers.py
@@ -100,6 +100,37 @@ def _matches_prefix(path: str, prefix: str) -> bool:
     return path == prefix or path.startswith(f"{prefix}/")
 
 
+# Fail-closed pytest set. ignored_prefixes may skip compose+pytest, but never
+# for these Python or runtime paths even when a more-specific ignore exists
+# (packages/test-support, apps/dispatcher, apps/ui).
+MUST_RUN_PYTEST_EXACT = frozenset({"uv.lock", "pyproject.toml"})
+MUST_RUN_PYTEST_PREFIXES = (
+    "packages",
+    "apps",
+    "runner",
+    "examples/tests",
+    "cli",
+)
+
+
+def _is_must_run_pytest(path: str) -> bool:
+    name = path.rsplit("/", 1)[-1]
+    if path in MUST_RUN_PYTEST_EXACT or name in MUST_RUN_PYTEST_EXACT:
+        return True
+    return any(_matches_prefix(path, prefix) for prefix in MUST_RUN_PYTEST_PREFIXES)
+
+
+def _needs_pytest(registry: Registry, paths: list[str]) -> bool:
+    if not paths:
+        return True
+    for path in paths:
+        if _is_must_run_pytest(path):
+            return True
+        if not any(_matches_prefix(path, prefix) for prefix in registry.ignored_prefixes):
+            return True
+    return False
+
+
 def _load_registry(path: Path) -> Registry:
     with path.open(encoding="utf-8") as stream:
         document = yaml.load(stream, Loader=UniqueKeyLoader)
@@ -163,13 +194,11 @@ def _changed_paths(base: str, head: str) -> list[str]:
     return [line for line in completed.stdout.splitlines() if line]
 
 
-def _render(selected: set[str]) -> str:
-    lines = [
-        f"{OUTPUT_KEYS[tier]}={'true' if tier in selected else 'false'}"
-        for tier in TIERS
-    ]
+def _render(selected: set[str], pytest_needed: bool) -> str:
+    lines = [f"{OUTPUT_KEYS[tier]}={'true' if tier in selected else 'false'}" for tier in TIERS]
     skill_local = ",".join(tier for tier in TIERS[:2] if tier in selected)
     lines.append(f"skill_local_tiers={skill_local}")
+    lines.append(f"pytest={'true' if pytest_needed else 'false'}")
     return "\n".join(lines) + "\n"
 
 
@@ -191,6 +220,7 @@ def _run() -> None:
         if args.path or args.base or args.head:
             raise RegistryError("push cannot be combined with paths or revisions")
         selected = set(TIERS)
+        pytest_needed = True
     else:
         if args.path and (args.base or args.head):
             raise RegistryError("paths cannot be combined with revisions")
@@ -201,12 +231,13 @@ def _run() -> None:
         else:
             raise RegistryError("provide paths, push, or both base and head revisions")
         selected = set().union(*(_select_path(registry, path) for path in paths))
+        pytest_needed = _needs_pytest(registry, paths)
 
     output_path = os.environ.get("GITHUB_OUTPUT")
     if not output_path:
         raise RegistryError("GITHUB_OUTPUT is required")
     with Path(output_path).open("a", encoding="utf-8") as stream:
-        stream.write(_render(selected))
+        stream.write(_render(selected, pytest_needed))
 
 
 def main() -> int:

--- a/tools/e2e-ci-selection/tests/test_e2e_ci_selection.py
+++ b/tools/e2e-ci-selection/tests/test_e2e_ci_selection.py
@@ -81,7 +81,7 @@ def _invoke_selector(
     return completed, output
 
 
-def _expected_output(*selected: str) -> str:
+def _expected_output(*selected: str, pytest_needed: bool = True) -> str:
     selected_tiers = set(selected)
     lines = [
         f"{OUTPUT_KEYS[tier]}={'true' if tier in selected_tiers else 'false'}"
@@ -89,6 +89,7 @@ def _expected_output(*selected: str) -> str:
     ]
     skill_local = ",".join(tier for tier in TIERS[:2] if tier in selected_tiers)
     lines.append(f"skill_local_tiers={skill_local}")
+    lines.append(f"pytest={'true' if pytest_needed else 'false'}")
     return "\n".join(lines) + "\n"
 
 
@@ -96,10 +97,12 @@ def _assert_selection(
     tmp_path: Path,
     path: str,
     selected: tuple[str, ...],
+    *,
+    pytest_needed: bool = True,
 ) -> None:
     completed, output = _invoke_selector(tmp_path, path)
     assert completed.returncode == 0, completed.stderr
-    assert output == _expected_output(*selected)
+    assert output == _expected_output(*selected, pytest_needed=pytest_needed)
 
 
 @pytest.mark.parametrize(
@@ -195,25 +198,29 @@ def test_genuine_documentation_only_selects_no_runtime_e2e_tiers(
     tmp_path: Path,
     path: str,
 ) -> None:
-    _assert_selection(tmp_path, path, ())
+    _assert_selection(tmp_path, path, (), pytest_needed=False)
 
 
 @pytest.mark.parametrize(
-    "path",
+    ("path", "pytest_needed"),
     [
-        "apps/ui/package.json",
-        "apps/ui/pnpm-lock.yaml",
-        "apps/dispatcher/src/curie_dispatcher/app.py",
-        "scripts/README.md",
-        "scripts/check-docs.sh",
-        "scripts/check-pr-body.sh",
-        ".github/workflows/pr-body.yaml",
-        "packages/test-support/src/curie_test_support/valkey.py",
-        "examples/coder/evals/cases.json",
+        ("apps/ui/package.json", True),
+        ("apps/ui/pnpm-lock.yaml", True),
+        ("apps/dispatcher/src/curie_dispatcher/app.py", True),
+        ("scripts/README.md", False),
+        ("scripts/check-docs.sh", False),
+        ("scripts/check-pr-body.sh", False),
+        (".github/workflows/pr-body.yaml", False),
+        ("packages/test-support/src/curie_test_support/valkey.py", True),
+        ("examples/coder/evals/cases.json", False),
     ],
 )
-def test_known_non_runtime_paths_select_no_e2e_tiers(tmp_path: Path, path: str) -> None:
-    _assert_selection(tmp_path, path, ())
+def test_known_non_runtime_paths_select_no_e2e_tiers(
+    tmp_path: Path,
+    path: str,
+    pytest_needed: bool,
+) -> None:
+    _assert_selection(tmp_path, path, (), pytest_needed=pytest_needed)
 
 
 def test_unapproved_markdown_fallback_selects_all_base_tiers(tmp_path: Path) -> None:
@@ -430,7 +437,7 @@ def test_more_specific_ignored_child_of_selected_prefix_is_allowed(tmp_path: Pat
         tmp_path, "charts/ci/probe.sh", registry=registry
     )
     assert ignored.returncode == 0, ignored.stderr
-    assert ignored_output == _expected_output()
+    assert ignored_output == _expected_output(pytest_needed=False)
 
     selected, selected_output = _invoke_selector(
         tmp_path, "charts/curie/values.yaml", registry=registry
@@ -758,7 +765,7 @@ def _run_aggregate(
 def test_e2e_required_validates_docs_only_ladder_skips(tmp_path: Path) -> None:
     selected, output = _invoke_selector(tmp_path, "ARCHITECTURE.md")
     assert selected.returncode == 0, selected.stderr
-    assert output == _expected_output()
+    assert output == _expected_output(pytest_needed=False)
     outputs = dict(line.split("=", maxsplit=1) for line in output.splitlines())
 
     skipped = _run_aggregate(

--- a/tools/e2e-ci-selection/tests/test_python_pytest_selection.py
+++ b/tools/e2e-ci-selection/tests/test_python_pytest_selection.py
@@ -1,0 +1,384 @@
+"""Docs-only Python jobs skip compose+pytest without dropping the required check."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SELECTOR = REPO_ROOT / "tools" / "e2e-ci-selection" / "select_tiers.py"
+REGISTRY = REPO_ROOT / ".github" / "e2e-selection.yaml"
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yaml"
+
+
+def _invoke_selector(
+    tmp_path: Path,
+    *paths: str,
+    push: bool = False,
+    base: str | None = None,
+    head: str | None = None,
+    cwd: Path | None = None,
+) -> tuple[subprocess.CompletedProcess[str], str]:
+    output_path = tmp_path / f"github-output-{len(list(tmp_path.glob('github-output-*')))}"
+    command = [sys.executable, str(SELECTOR), "--registry", str(REGISTRY)]
+    if push:
+        command.append("--push")
+    if base is not None:
+        command.extend(("--base", base))
+    if head is not None:
+        command.extend(("--head", head))
+    for path in paths:
+        command.extend(("--path", path))
+    environment = os.environ.copy()
+    environment["GITHUB_OUTPUT"] = str(output_path)
+    completed = subprocess.run(
+        command,
+        cwd=cwd or tmp_path,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    output = output_path.read_text() if output_path.exists() else ""
+    return completed, output
+
+
+PYTEST_SELECTED = "steps.python-runtime.outputs.pytest == 'true'"
+ALWAYS_RUN_PYTHON_STEPS = (
+    "Alembic revision gate",
+    "Ruff",
+    "Mypy",
+    "Docs gate (catalog drift + agent contract + citations)",
+    "Wire tolerance gate (_AciModel model_validate call sites)",
+    "ACI wire-lock base gate",
+)
+GATED_RUNTIME_STEPS = (
+    "Start dev stack",
+    "Wait for Langfuse to serve",
+    "Released database upgrade gate",
+    "Migrate the shared database",
+    "Pytest",
+)
+PYTEST_AGGREGATE_EXPRESSIONS = {
+    "pytest_selected": "${{ steps.python-runtime.outputs.pytest }}",
+    "pytest_result": "${{ steps.pytest.outcome }}",
+    "stack_result": "${{ steps.dev-stack.outcome }}",
+}
+
+
+def _python_job() -> dict[str, Any]:
+    workflow = yaml.safe_load(WORKFLOW.read_text())
+    job = workflow["jobs"]["python"]
+    assert isinstance(job, dict)
+    return job
+
+
+def _named_steps() -> dict[str, dict[str, Any]]:
+    steps = _python_job()["steps"]
+    return {
+        step["name"]: step
+        for step in steps
+        if isinstance(step, dict) and isinstance(step.get("name"), str)
+    }
+
+
+def _string(step: dict[str, Any], key: str) -> str:
+    value = step.get(key)
+    return value if isinstance(value, str) else ""
+
+
+def _outputs(output: str) -> dict[str, str]:
+    return dict(line.split("=", maxsplit=1) for line in output.splitlines() if line)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "docs/guides/getting-started.md",
+        "docs/example.md",
+        "ARCHITECTURE.md",
+        "README.md",
+        "llms.txt",
+    ],
+)
+def test_docs_only_path_skips_pytest(tmp_path: Path, path: str) -> None:
+    completed, output = _invoke_selector(tmp_path, path)
+    assert completed.returncode == 0, completed.stderr
+    assert _outputs(output)["pytest"] == "false"
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "packages/aci-protocol/src/aci_protocol/wire.py",
+        "apps/api/src/curie_api/main.py",
+        "apps/worker/src/curie_worker/binding.py",
+        "apps/dispatcher/src/curie_dispatcher/app.py",
+        "runner/src/curie_runner/session.py",
+        "examples/tests/test_example.py",
+        "cli/src/main.rs",
+        "uv.lock",
+        "pyproject.toml",
+        "packages/plugin-format/pyproject.toml",
+    ],
+)
+def test_python_or_runtime_path_still_selects_pytest(tmp_path: Path, path: str) -> None:
+    completed, output = _invoke_selector(tmp_path, path)
+    assert completed.returncode == 0, completed.stderr
+    assert _outputs(output)["pytest"] == "true"
+
+
+def test_mixed_docs_and_packages_still_selects_pytest(tmp_path: Path) -> None:
+    completed, output = _invoke_selector(
+        tmp_path,
+        "docs/guides/getting-started.md",
+        "packages/aci-protocol/src/aci_protocol/wire.py",
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert _outputs(output)["pytest"] == "true"
+
+
+def test_push_selects_pytest(tmp_path: Path) -> None:
+    completed, output = _invoke_selector(tmp_path, push=True)
+    assert completed.returncode == 0, completed.stderr
+    outputs = _outputs(output)
+    assert outputs["pytest"] == "true"
+    for tier in ("skill", "local", "local_release", "cluster", "released_upgrade"):
+        assert outputs[tier] == "true"
+
+
+def test_empty_revision_diff_fails_closed_to_pytest(tmp_path: Path) -> None:
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    subprocess.run(
+        ["git", "init", "--initial-branch", "main"],
+        cwd=repository,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repository, check=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=repository, check=True)
+    (repository / "docs").mkdir()
+    (repository / "docs" / "guides.md").write_text("one sentence.\n")
+    subprocess.run(["git", "add", "."], cwd=repository, check=True)
+    subprocess.run(["git", "commit", "-m", "base"], cwd=repository, check=True)
+    head = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repository,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+    completed, output = _invoke_selector(
+        tmp_path,
+        base=head,
+        head=head,
+        cwd=repository,
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert _outputs(output)["pytest"] == "true"
+
+
+def test_deleting_a_docs_guides_sentence_does_not_select_pytest(tmp_path: Path) -> None:
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    subprocess.run(
+        ["git", "init", "--initial-branch", "main"],
+        cwd=repository,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repository, check=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=repository, check=True)
+    guides = repository / "docs" / "guides"
+    guides.mkdir(parents=True)
+    guides.joinpath("getting-started.md").write_text(
+        "First sentence.\nSecond sentence that a docs-only edit can delete.\n"
+    )
+    subprocess.run(["git", "add", "."], cwd=repository, check=True)
+    subprocess.run(["git", "commit", "-m", "base"], cwd=repository, check=True)
+    base = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repository,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+    guides.joinpath("getting-started.md").write_text("First sentence.\n")
+    subprocess.run(["git", "commit", "-am", "delete one sentence"], cwd=repository, check=True)
+    head = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repository,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+    completed, output = _invoke_selector(
+        tmp_path,
+        base=base,
+        head=head,
+        cwd=repository,
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert _outputs(output)["pytest"] == "false"
+
+
+def test_required_python_job_keeps_ruleset_name_and_is_not_skippable() -> None:
+    job = _python_job()
+    assert job["name"] == "Python (ruff + mypy + pytest)"
+    assert "needs" not in job
+    assert "if" not in job
+
+
+def test_python_job_gates_compose_and_pytest_on_selector_output() -> None:
+    named = _named_steps()
+    decision = named["Decide whether compose and pytest are needed"]
+    assert decision["id"] == "python-runtime"
+    assert "tools/e2e-ci-selection/select_tiers.py" in _string(decision, "run")
+    assert "--registry .github/e2e-selection.yaml" in _string(decision, "run")
+
+    for name in GATED_RUNTIME_STEPS:
+        step = named[name]
+        assert _string(step, "if") == PYTEST_SELECTED, name
+
+    stack = named["Start dev stack"]
+    assert stack["id"] == "dev-stack"
+    assert "postgres" in _string(stack, "run")
+
+    pytest_step = named["Pytest"]
+    assert pytest_step["id"] == "pytest"
+    assert _string(pytest_step, "run").strip().startswith("uv run pytest -q")
+
+
+def test_python_static_gates_stay_unconditional() -> None:
+    named = _named_steps()
+    for name in ALWAYS_RUN_PYTHON_STEPS:
+        step = named[name]
+        assert "if" not in step, name
+        assert PYTEST_SELECTED not in _string(step, "run")
+
+    docs = named["Docs gate (catalog drift + agent contract + citations)"]
+    assert "scripts/check-docs.sh" in _string(docs, "run")
+
+
+def test_dump_logs_do_not_run_when_the_stack_never_started() -> None:
+    named = _named_steps()
+    dump = named["Dump dev stack logs on failure"]
+    condition = _string(dump, "if")
+    assert "failure()" in condition
+    assert "steps.python-runtime.outputs.pytest == 'true'" in condition
+
+
+def test_cargo_guard_if_is_unchanged() -> None:
+    named = _named_steps()
+    probe = named["Decide whether the current curie binary is needed"]
+    assert probe["id"] == "fix-pin-curie"
+    assert _string(probe, "if") == "github.event_name == 'pull_request'"
+
+    cargo = named["Build the current curie binary for fix pin verification"]
+    helm = named["Install Helm for fix pin verification"]
+    needed = "steps.fix-pin-curie.outputs.needed == 'true'"
+    for step in (cargo, helm):
+        condition = _string(step, "if")
+        assert "github.event_name == 'pull_request'" in condition
+        assert needed in condition
+        assert "Fix pin:" not in condition
+        assert PYTEST_SELECTED not in condition
+
+    gate = named["Require declared fixes to be pinned by a changed test"]
+    assert _string(gate, "if") == "github.event_name == 'pull_request'"
+    assert needed not in _string(gate, "if")
+
+
+def _pytest_aggregate_contract() -> tuple[str, dict[str, str]]:
+    named = _named_steps()
+    step = named["Require pytest outcome to match selection"]
+    assert _string(step, "if") == "success()"
+    bindings: dict[str, str] = {}
+    environment = step.get("env")
+    assert isinstance(environment, dict)
+    for semantic_name, expression in PYTEST_AGGREGATE_EXPRESSIONS.items():
+        environment_names = [name for name, value in environment.items() if value == expression]
+        assert len(environment_names) == 1, expression
+        bindings[semantic_name] = environment_names[0]
+    return _string(step, "run"), bindings
+
+
+def _run_pytest_aggregate(
+    *,
+    script_transform: Callable[[str], str] | None = None,
+    **overrides: str,
+) -> subprocess.CompletedProcess[str]:
+    script, bindings = _pytest_aggregate_contract()
+    if script_transform is not None:
+        script = script_transform(script)
+    state = {
+        "pytest_selected": "false",
+        "pytest_result": "skipped",
+        "stack_result": "skipped",
+    }
+    state.update(overrides)
+    environment = os.environ.copy()
+    environment.update({bindings[name]: value for name, value in state.items()})
+    return subprocess.run(
+        ["bash", "--noprofile", "--norc", "-e", "-o", "pipefail", "-c", script],
+        cwd=REPO_ROOT,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_pytest_aggregator_accepts_docs_only_skips(tmp_path: Path) -> None:
+    completed, output = _invoke_selector(tmp_path, "docs/guides/getting-started.md")
+    assert completed.returncode == 0, completed.stderr
+    selected = _outputs(output)["pytest"]
+    result = _run_pytest_aggregate(
+        pytest_selected=selected,
+        pytest_result="skipped",
+        stack_result="skipped",
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_pytest_aggregator_accepts_selected_success(tmp_path: Path) -> None:
+    completed, output = _invoke_selector(tmp_path, "packages/aci-protocol/src/aci_protocol/wire.py")
+    assert completed.returncode == 0, completed.stderr
+    selected = _outputs(output)["pytest"]
+    result = _run_pytest_aggregate(
+        pytest_selected=selected,
+        pytest_result="success",
+        stack_result="success",
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_pytest_aggregator_rejects_selected_skip() -> None:
+    result = _run_pytest_aggregate(
+        pytest_selected="true",
+        pytest_result="skipped",
+        stack_result="skipped",
+    )
+    assert result.returncode != 0
+
+
+def test_pytest_aggregator_rejects_unselected_success() -> None:
+    result = _run_pytest_aggregate(
+        pytest_selected="false",
+        pytest_result="success",
+        stack_result="success",
+    )
+    assert result.returncode != 0

--- a/tools/fix-pin-ci/tests/test_fix_pin_ci.py
+++ b/tools/fix-pin-ci/tests/test_fix_pin_ci.py
@@ -694,10 +694,12 @@ def test_ci_keeps_the_required_python_status_and_calls_fix_pin_after_pytest() ->
 
     diagnostic_index = _single_step_index(
         steps,
-        lambda step: "docker compose -f compose.dev.yaml logs" in _string(step, "run")
-        and _string(step, "if") == "failure()",
+        lambda step: "docker compose -f compose.dev.yaml logs" in _string(step, "run"),
         "failure stack diagnostic",
     )
+    diagnostic_if = _string(steps[diagnostic_index], "if")
+    assert "failure()" in diagnostic_if
+    assert "steps.python-runtime.outputs.pytest == 'true'" in diagnostic_if
     assert gate_index < diagnostic_index
 
 


### PR DESCRIPTION
## Summary

Docs-only pull requests keep ruff, mypy, docs, alembic revision, and wire-lock, and skip compose plus pytest. The Python job still reports under the existing required check name `Python (ruff + mypy + pytest)`, with an in-job aggregator that fails if pytest was selected and skipped. Selection reuses `ignored_prefixes` from `.github/e2e-selection.yaml` and still runs pytest for `packages/`, `apps/`, `runner/`, `examples/tests/`, `cli`, `uv.lock`, and `pyproject.toml`.

This is spike 2026-09-03 option 2. It lands after #2242 (cargo-guard); that step's `if:` is unchanged.

## Related issue

No tracker issue. Independent of the cargo-guard task.

## Fix pin verification

Fix pin: n/a - CI path selection only; no bug-labeled issue and no supported product-test selector.

## End-to-end verification

This change does not alter product runtime behavior because it only gates GitHub Actions steps in the Python job. The merge-gate surface is the selector and the workflow wiring.

Scoped verification:

- `uv run pytest -q tools/e2e-ci-selection/tests/test_python_pytest_selection.py tools/e2e-ci-selection/tests/test_e2e_ci_selection.py tools/fix-pin-ci/tests/test_fix_pin_ci.py tools/ci-retry-gate/tests/test_retry_eligibility.py tools/ci-workflow-paths/tests/test_workflow_paths.py` - 227 passed.
- Positive: `docs/guides/getting-started.md` selects `pytest=false`; `packages/aci-protocol/...` and `apps/api/...` select `pytest=true`; docs gate step has no skip `if`.
- Negative: deleting one sentence in `docs/guides` selects `pytest=false`, so `Start dev stack` (`docker compose ... postgres`) does not run.
- Second path: the in-job aggregator accepts selected+success and unselected+skipped, and rejects selected+skipped.

Ruleset-compatible check name: `Python (ruff + mypy + pytest)`.

Cargo-guard behavior from #2242 is preserved: probe stays `github.event_name == 'pull_request'`; cargo and Helm stay gated on `steps.fix-pin-curie.outputs.needed == 'true'`.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [ ] Docs updated if behavior changed.
- [ ] An ADR is added under `docs/adr/` if this is an architectural decision.
