### PR TITLE
Fix streamed coding-tool spans in Langfuse

### DIFF
--- a/docs/interfaces/telemetry-otel/INTERFACE.md
+++ b/docs/interfaces/telemetry-otel/INTERFACE.md
@@ -161,12 +161,16 @@ keys:
   Partial bodies, arguments, provider identifiers, and results never enter telemetry.
 - **Boundary confidence is explicit.** Generation start kinds are `query_observed` or
   `tool_result_inferred`; end kinds are `tool_use_observed`, `result_observed`, or
-  `terminal_inferred`. An `execute_tool` span starts at an SDK tool-use block with
-  `curie.phase.start_kind=tool_use_inferred` and ends on the matching tool result with
-  `curie.phase.end_kind=tool_result_inferred`, or at terminal cleanup with
-  `terminal_inferred`. Matching uses the SDK call id only inside the process. The id is
-  never exported; `curie.tool.call.index` is the bounded numeric correlation value, while
-  `gen_ai.tool.name` and `gen_ai.operation.name=execute_tool` describe the operation.
+  `terminal_inferred`. An `execute_tool` span starts when the adapter observes either a
+  streamed SDK tool-use boundary or an SDK tool-use block, with
+  `curie.phase.start_kind=tool_use_inferred`. A streamed boundary still produces this
+  payload-free observation when no final `AssistantMessage` tool-use block arrives: tool
+  inputs, result bodies, and call IDs are never recorded. The span ends on the matching
+  tool result with `curie.phase.end_kind=tool_result_inferred`, or at terminal cleanup
+  with `terminal_inferred`. Matching uses the SDK call ID only inside the process; the ID
+  is never exported. `curie.tool.call.index` is the bounded numeric correlation value,
+  while `gen_ai.tool.name` and `gen_ai.operation.name=execute_tool` describe the
+  operation.
 - **Terminal state is truthful and bounded.** `curie.phase` marks each interval as
   `provider_wait` or `tool_wait`, and on `agent.run` retains the last active phase.
   The root terminal mapping is closed and ordered:

--- a/runner/src/curie_runner/adapter.py
+++ b/runner/src/curie_runner/adapter.py
@@ -16,8 +16,9 @@ this boundary and nothing above it is. ``aci-protocol`` is never mocked.
 from __future__ import annotations
 
 import contextlib
+import time
 from collections.abc import AsyncIterator
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Protocol, cast
 
 from claude_agent_sdk import (
@@ -38,6 +39,15 @@ class PartialMessageBoundary:
     """Payload-free evidence that the provider began returning a message."""
 
     event_type: str
+
+
+@dataclass(frozen=True, slots=True)
+class StreamedToolUseBoundary:
+    """Sanitized evidence that the provider began a tool call."""
+
+    call_id: str = field(repr=False)
+    tool_name: str
+    observed_time_ns: int
 
 
 class ModelSession(Protocol):
@@ -150,11 +160,28 @@ class ClaudeAgentSession:
             async with contextlib.aclosing(response):
                 async for message in response:
                     if isinstance(message, StreamEvent):
+                        event = message.event
                         event_type = (
-                            message.event.get("type")
-                            if isinstance(message.event, dict)
-                            else None
+                            event.get("type") if isinstance(event, dict) else None
                         )
+                        if event_type == "content_block_start":
+                            content_block = event.get("content_block")
+                            if isinstance(content_block, dict):
+                                call_id = content_block.get("id")
+                                tool_name = content_block.get("name")
+                                if (
+                                    content_block.get("type") == "tool_use"
+                                    and isinstance(call_id, str)
+                                    and call_id
+                                    and isinstance(tool_name, str)
+                                    and tool_name
+                                ):
+                                    yield StreamedToolUseBoundary(
+                                        call_id=call_id,
+                                        tool_name=tool_name,
+                                        observed_time_ns=time.time_ns(),
+                                    )
+                                    continue
                         if event_type in _ALLOWED_PARTIAL_BOUNDARY_TYPES:
                             # Do not forward the StreamEvent object: its event body,
                             # uuid, SDK session id, and parent tool id are all

--- a/runner/src/curie_runner/otel.py
+++ b/runner/src/curie_runner/otel.py
@@ -416,6 +416,7 @@ class _GenerationSpan:
         self._root_context = set_span_in_context(root)
         self._configured_model = model
         self._active_generation: Any | None = None
+        self._deferred_generation_end_ns: int | None = None
         self._generation_started_ns = 0
         self._generation_model_recorded = False
         self._generation_ttft_recorded = False
@@ -533,6 +534,7 @@ class _GenerationSpan:
         self._result_observed = True
         if terminal_reason in self._ABORT_CAUSES:
             self._result_abort_cause = terminal_reason
+        self._close_deferred_generation()
         self._close_generation(
             "result_observed",
             failed=failed and not approval_paused,
@@ -562,16 +564,61 @@ class _GenerationSpan:
     def tool_use(self, call_id: str, tool_name: str) -> None:
         """Close provider wait and begin an inferred SDK tool interval."""
 
-        if self._terminal or call_id in self._active_tools:
+        if self._terminal:
+            return
+        self._close_deferred_generation()
+        if call_id in self._active_tools:
             return
         self._close_generation("tool_use_observed", failed=False)
-        self._tool_call_index += 1
-        tool = self._tracer.start_span(
-            "execute_tool",
-            context=self._root_context,
-            record_exception=False,
-            set_status_on_exception=False,
+        self._open_tool(call_id, tool_name)
+
+    def streamed_tool_use(
+        self,
+        call_id: str,
+        tool_name: str,
+        *,
+        observed_time_ns: int,
+    ) -> None:
+        """Begin a streamed tool interval while deferring generation closure."""
+
+        if self._terminal or call_id in self._active_tools:
+            return
+        if self._active_generation is not None:
+            pending_end = self._deferred_generation_end_ns
+            self._deferred_generation_end_ns = (
+                observed_time_ns
+                if pending_end is None
+                else min(pending_end, observed_time_ns)
+            )
+        self._open_tool(
+            call_id,
+            tool_name,
+            start_time_ns=observed_time_ns,
         )
+
+    def _open_tool(
+        self,
+        call_id: str,
+        tool_name: str,
+        *,
+        start_time_ns: int | None = None,
+    ) -> None:
+        self._tool_call_index += 1
+        if start_time_ns is None:
+            tool = self._tracer.start_span(
+                "execute_tool",
+                context=self._root_context,
+                record_exception=False,
+                set_status_on_exception=False,
+            )
+        else:
+            tool = self._tracer.start_span(
+                "execute_tool",
+                context=self._root_context,
+                start_time=start_time_ns,
+                record_exception=False,
+                set_status_on_exception=False,
+            )
         _set(tool, SpanAttributeKey.PHASE, "tool_wait")
         _set(tool, SpanAttributeKey.PHASE_START_KIND, "tool_use_inferred")
         _set(tool, SpanAttributeKey.TOOL_CALL_INDEX, self._tool_call_index)
@@ -585,6 +632,7 @@ class _GenerationSpan:
     def tool_result(self, call_id: str, *, failed: bool) -> None:
         """End a matching tool interval, then infer the next provider wait."""
 
+        self._close_deferred_generation()
         pending = self._active_tools.pop(call_id, None)
         if pending is None:
             return
@@ -666,13 +714,33 @@ class _GenerationSpan:
             self._generation_usage[usage_field] = total
             _set(self._active_generation, attribute_key, total)
 
-    def _close_generation(self, end_kind: str, *, failed: bool) -> None:
+    def _close_deferred_generation(self) -> None:
+        end_time_ns = self._deferred_generation_end_ns
+        if end_time_ns is None:
+            return
+        self._close_generation(
+            "tool_use_observed",
+            failed=False,
+            end_time_ns=end_time_ns,
+        )
+
+    def _close_generation(
+        self,
+        end_kind: str,
+        *,
+        failed: bool,
+        end_time_ns: int | None = None,
+    ) -> None:
         span = self._active_generation
+        self._deferred_generation_end_ns = None
         if span is None:
             return
         _set(span, SpanAttributeKey.PHASE_END_KIND, end_kind)
         span.set_status(StatusCode.ERROR if failed else StatusCode.OK)
-        span.end()
+        if end_time_ns is None:
+            span.end()
+        else:
+            span.end(end_time=end_time_ns)
         self._active_generation = None
 
     def _end_tool(
@@ -691,6 +759,7 @@ class _GenerationSpan:
     def _finish(self, cause: str, status: str, *, failed: bool) -> None:
         if self._terminal:
             return
+        self._close_deferred_generation()
         self._close_generation("terminal_inferred", failed=failed)
         for call_id, (tool, _index) in sorted(
             self._active_tools.items(), key=lambda item: item[1][1]

--- a/runner/src/curie_runner/session.py
+++ b/runner/src/curie_runner/session.py
@@ -40,7 +40,7 @@ from claude_agent_sdk import AssistantMessage, ResultMessage
 from curie_telemetry import record_metric
 from opentelemetry.context import Context
 
-from .adapter import ModelSession, PartialMessageBoundary
+from .adapter import ModelSession, PartialMessageBoundary, StreamedToolUseBoundary
 from .approval import ApprovalGate
 from .budget import BUDGET_CLASSIFICATION, BudgetTracker
 from .history import NullTranscriptStore, TranscriptStore, TurnRecord
@@ -720,6 +720,14 @@ class SessionRunner:
         gen.query_observed()
         await self._session.query(event.text)
         async for message in self._session.receive_turn():
+            if isinstance(message, StreamedToolUseBoundary):
+                gen.record_first_response_boundary()
+                gen.streamed_tool_use(
+                    message.call_id,
+                    message.tool_name,
+                    observed_time_ns=message.observed_time_ns,
+                )
+                continue
             if isinstance(message, PartialMessageBoundary):
                 gen.record_first_response_boundary()
                 continue

--- a/runner/tests/test_otel.py
+++ b/runner/tests/test_otel.py
@@ -1,11 +1,13 @@
 """OTel: the gen_ai span tree is emitted for a turn; exporter wiring is gated."""
 
+import os
 import time
 from collections import defaultdict
 from collections.abc import AsyncIterator, Callable
 from typing import Any
 
 import anyio
+import httpx
 import pytest
 from aci_protocol import (
     ErrorEvent,
@@ -41,6 +43,7 @@ from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
     OTLPSpanExporter as HttpOTLPSpanExporter,
 )
+from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor, SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
@@ -113,10 +116,22 @@ def _export_turn(
     session_factory: Callable[[], Any],
     *,
     model: str | None = "configured-model",
+    collector_endpoint: str | None = None,
 ) -> tuple[list[object], list[ReadableSpan]]:
     exporter = InMemorySpanExporter()
-    provider = TracerProvider()
+    resource = (
+        Resource.create({"service.name": "curie-runner-integration"})
+        if collector_endpoint
+        else None
+    )
+    provider = TracerProvider(resource=resource)
+    if collector_endpoint:
+        provider.add_span_processor(_SchemaValidatingSpanProcessor())
     provider.add_span_processor(SimpleSpanProcessor(exporter))
+    if collector_endpoint:
+        provider.add_span_processor(
+            SimpleSpanProcessor(HttpOTLPSpanExporter(endpoint=collector_endpoint))
+        )
     runner = SessionRunner(
         session_factory=session_factory,
         ceiling=0,
@@ -228,6 +243,33 @@ def _partial_boundary(event_type: str, *, second: bool = False) -> StreamEvent:
     )
 
 
+def _raw_stream_event(event: dict[str, Any]) -> StreamEvent:
+    return StreamEvent(
+        uuid=_STREAM_UUID,
+        session_id=_STREAM_SESSION_ID,
+        parent_tool_use_id=_PARENT_TOOL_ID,
+        event=event,
+    )
+
+
+# Anthropic documents tool starts as ``content_block_start`` events carrying a
+# ``tool_use`` block, exposed by the SDK through ``StreamEvent.event``.
+# https://platform.claude.com/docs/en/build-with-claude/streaming
+def _streamed_tool_start(call_id: str, name: str) -> StreamEvent:
+    return _raw_stream_event(
+        {
+            "type": "content_block_start",
+            "message": {"content": _STREAM_BODY},
+            "content_block": {
+                "type": "tool_use",
+                "id": call_id,
+                "name": name,
+                "input": {"argument": _STREAM_ARGUMENT},
+            },
+        }
+    )
+
+
 def _two_round_script(*, include_boundaries: bool = True) -> list[object]:
     first_usage = {
         "input_tokens": 3,
@@ -296,6 +338,44 @@ def _two_round_script(*, include_boundaries: bool = True) -> list[object]:
         ]
     )
     return script
+
+
+_FIRST_STREAMED_CALL_ID = "streamed-call-one-PLACEHOLDER"
+_SECOND_STREAMED_CALL_ID = "streamed-call-two-PLACEHOLDER"
+_PRIVATE_OTEL_VALUES = (
+    _STREAM_BODY, _STREAM_ARGUMENT, _TOOL_ARGUMENT, _TOOL_RESULT,
+    _STREAM_UUID, _STREAM_SESSION_ID, _PARENT_TOOL_ID, _TOOL_CALL_ID,
+    _FIRST_STREAMED_CALL_ID, _SECOND_STREAMED_CALL_ID,
+    "sdk-result-session-PLACEHOLDER",
+)
+
+
+def _two_streamed_tool_script(*, repeat_final_blocks: bool = False) -> list[object]:
+    repeated: list[object] = []
+    if repeat_final_blocks:
+        repeated = [
+            AssistantMessage(
+                content=[
+                    ToolUseBlock(id=_FIRST_STREAMED_CALL_ID, name="Bash", input={}),
+                    ToolUseBlock(id=_SECOND_STREAMED_CALL_ID, name="Write", input={}),
+                ],
+                model="observed-model",
+                usage={
+                    "input_tokens": 23,
+                    "output_tokens": 29,
+                    "cache_read_input_tokens": 31,
+                    "cache_creation_input_tokens": 37,
+                },
+            )
+        ]
+    return [
+        _streamed_tool_start(_FIRST_STREAMED_CALL_ID, "Bash"),
+        _streamed_tool_start(_SECOND_STREAMED_CALL_ID, "Write"),
+        *repeated,
+        _tool_result(_FIRST_STREAMED_CALL_ID),
+        _tool_result(_SECOND_STREAMED_CALL_ID),
+        _result(),
+    ]
 
 
 def _span_wire_material(spans: list[ReadableSpan]) -> str:
@@ -599,20 +679,232 @@ def test_fake_partial_boundaries_are_opt_in_payload_free_and_precede_each_assist
 
 def test_raw_stream_tool_payloads_and_provider_ids_never_reach_otel() -> None:
     _, finished = _export_turn(_adapter_session_factory(_two_round_script()))
-    material = _span_wire_material(finished)
+    streamed_script = _two_streamed_tool_script(repeat_final_blocks=True)
 
-    for private_value in (
-        _STREAM_BODY,
-        _STREAM_ARGUMENT,
-        _TOOL_ARGUMENT,
-        _TOOL_RESULT,
-        _STREAM_UUID,
-        _STREAM_SESSION_ID,
-        _PARENT_TOOL_ID,
-        _TOOL_CALL_ID,
-        "sdk-result-session-PLACEHOLDER",
-    ):
+    async def adapter_output() -> list[object]:
+        session = _adapter_session_factory([streamed_script[0]])()
+        return [message async for message in session.receive_turn()]
+
+    material = _span_wire_material(finished) + repr(anyio.run(adapter_output))
+
+    for private_value in _PRIVATE_OTEL_VALUES:
         assert private_value not in material
+
+
+@pytest.mark.parametrize("repeat_final_blocks", (False, True), ids=("stream-only", "dedupe"))
+def test_two_streamed_tool_starts_without_final_tool_blocks_emit_two_intervals(
+    repeat_final_blocks: bool,
+) -> None:
+    script = _two_streamed_tool_script(repeat_final_blocks=repeat_final_blocks)
+    events, finished = _export_turn(_adapter_session_factory(script))
+    spans = _spans_by_name(finished)
+    root = spans["agent.run"][0]
+    generations = spans["llm.generation"]
+    tools = spans["execute_tool"]
+
+    assert len(generations) == 2
+    assert len(tools) == 2
+    assert next(
+        span for span in generations if span.attributes["curie.generation.round"] == 1
+    ).end_time == tools[0].start_time
+    assert [span.attributes["gen_ai.tool.name"] for span in tools] == ["Bash", "Write"]
+    assert [span.attributes["curie.tool.call.index"] for span in tools] == [1, 2]
+    assert root.context is not None
+    assert all(
+        span.start_time is not None
+        and span.end_time is not None
+        and span.end_time > span.start_time
+        and span.parent is not None
+        and span.parent.span_id == root.context.span_id
+        and span.context is not None
+        and span.context.trace_id == root.context.trace_id
+        for span in tools
+    )
+    assert sum(getattr(event, "type", None) == "tool_note" for event in events) == (
+        2 if repeat_final_blocks else 0
+    )
+    if repeat_final_blocks:
+        first = next(
+            span for span in generations if span.attributes["curie.generation.round"] == 1
+        )
+        assert first.attributes["gen_ai.usage.input_tokens"] == 23
+        assert first.attributes["gen_ai.usage.output_tokens"] == 29
+        assert first.attributes["gen_ai.usage.cache_read_input_tokens"] == 31
+        assert first.attributes["gen_ai.usage.cache_creation_input_tokens"] == 37
+    material = _span_wire_material(finished)
+    for private_value in _PRIVATE_OTEL_VALUES:
+        assert private_value not in material
+
+
+@pytest.mark.parametrize(
+    ("tool_failed", "outcome", "status", "end_kind"),
+    (
+        pytest.param(False, "success", StatusCode.OK, "tool_result_inferred", id="success"),
+        pytest.param(True, "error", StatusCode.ERROR, "tool_result_inferred", id="failure"),
+        pytest.param(None, "cancelled", StatusCode.OK, "terminal_inferred", id="missing"),
+    ),
+)
+def test_streamed_tool_failure_status_matches_success_and_error_result(
+    tool_failed: bool | None,
+    outcome: str,
+    status: StatusCode,
+    end_kind: str,
+) -> None:
+    tail: list[object] = (
+        [_result()]
+        if tool_failed is None
+        else [_tool_result(_TOOL_CALL_ID, is_error=tool_failed), _result()]
+    )
+    _, finished = _export_turn(
+        _adapter_session_factory(
+            [_streamed_tool_start(_TOOL_CALL_ID, "Read"), *tail]
+        )
+    )
+    tool = _spans_by_name(finished)["execute_tool"][0]
+
+    assert tool.attributes["curie.phase.end_kind"] == end_kind
+    assert tool.attributes["curie.tool.outcome"] == outcome
+    assert tool.status.status_code is status
+    assert tool.start_time is not None
+    assert tool.end_time is not None
+    assert tool.end_time > tool.start_time
+
+
+def test_streamed_tool_malformed_and_no_tool_scripts_emit_no_tool_spans() -> None:
+    malformed_blocks: list[dict[str, object]] = [
+        {"type": "tool_use", "name": "Read"},
+        {"type": "tool_use", "id": 7, "name": "Read"},
+        {"type": "tool_use", "id": "", "name": "Read"},
+        {"type": "tool_use", "id": _TOOL_CALL_ID},
+        {"type": "tool_use", "id": _TOOL_CALL_ID, "name": 7},
+        {"type": "tool_use", "id": _TOOL_CALL_ID, "name": ""},
+        {"type": "text"},
+    ]
+    scripts = [
+        [_raw_stream_event({"type": "content_block_start", "content_block": block})]
+        for block in malformed_blocks
+    ]
+    scripts.extend(([_partial_boundary("message_start")], []))
+
+    for stream_messages in scripts:
+        script = [*stream_messages, _result()]
+        events, finished = _export_turn(_adapter_session_factory(script))
+        assert isinstance(events[-1], Final)
+        assert events[-1].status is SessionStatus.DONE
+        assert "execute_tool" not in _spans_by_name(finished)
+
+
+def _finished_trace_id(spans: list[ReadableSpan]) -> str:
+    roots = [span for span in spans if span.name == "agent.run"]
+    assert len(roots) == 1
+    root = roots[0]
+    assert root.context is not None
+    return format(root.context.trace_id, "032x")
+
+
+def _wait_for_exact_trace_counts(
+    client: httpx.Client,
+    *,
+    langfuse_host: str,
+    auth: tuple[str, str],
+    trace_id: str,
+    expected_generations: int,
+    expected_tool_names: tuple[str, ...],
+) -> tuple[int, int, tuple[str, ...]] | None:
+    deadline = time.monotonic() + 60
+    while time.monotonic() < deadline:
+        try:
+            trace_body = client.get(
+                f"{langfuse_host}/api/public/traces/{trace_id}", auth=auth
+            ).json()
+            observations = client.get(
+                f"{langfuse_host}/api/public/observations",
+                params={"traceId": trace_id, "limit": 100},
+                auth=auth,
+            ).json()["data"]
+        except (KeyError, TypeError, httpx.HTTPError, ValueError):
+            trace_body = observations = None
+        if (
+            isinstance(trace_body, dict)
+            and trace_body.get("id") == trace_id
+            and isinstance(observations, list)
+            and all(isinstance(item, dict) for item in observations)
+            and all(item.get("traceId") == trace_id for item in observations)
+        ):
+            roots = [
+                item
+                for item in observations
+                if item.get("name") == "agent.run" and item.get("endTime")
+            ]
+            names = [item.get("name") for item in observations]
+            counts = (
+                len(roots),
+                names.count("llm.generation"),
+                tuple(
+                    sorted(
+                        item["name"]
+                        for item in observations
+                        if item.get("type") == "TOOL"
+                    )
+                ),
+            )
+            if counts == (1, expected_generations, expected_tool_names):
+                return counts
+        time.sleep(1)
+    return None
+
+
+@pytest.mark.skipif(
+    os.environ.get("CURIE_RUNNER_OTEL_INTEGRATION") != "1",
+    reason="set CURIE_RUNNER_OTEL_INTEGRATION=1 for the local observability stack",
+)
+def test_streamed_tool_starts_reach_langfuse_through_collector() -> None:
+    """Scripted SDK events cross real OTLP/HTTP without a model credential."""
+
+    collector_endpoint = "http://localhost:24318/v1/traces"
+    langfuse_host = "http://localhost:23000"
+    auth = ("pk-lf-curie-dev", "sk-lf-curie-dev")
+
+    with httpx.Client(timeout=2.0) as preflight_client:
+        try:
+            health = preflight_client.get(f"{langfuse_host}/api/public/health")
+            preflight_client.get(collector_endpoint)
+        except (httpx.HTTPError, ValueError):
+            pytest.skip("local Collector and Langfuse are not reachable")
+        if health.status_code != 200:
+            pytest.skip("local Collector and Langfuse are not reachable")
+
+    _, tool_spans = _export_turn(
+        _adapter_session_factory(_two_streamed_tool_script()),
+        collector_endpoint=collector_endpoint,
+    )
+    _, no_tool_spans = _export_turn(
+        _adapter_session_factory([_result()]),
+        collector_endpoint=collector_endpoint,
+    )
+
+    assert len(_spans_by_name(tool_spans)["execute_tool"]) == 2
+    assert "execute_tool" not in _spans_by_name(no_tool_spans)
+
+    with httpx.Client(timeout=5.0) as langfuse_client:
+        tool_counts = _wait_for_exact_trace_counts(
+            langfuse_client,
+            langfuse_host=langfuse_host,
+            auth=auth,
+            trace_id=_finished_trace_id(tool_spans),
+            expected_generations=2,
+            expected_tool_names=("Bash", "Write"),
+        )
+        no_tool_counts = _wait_for_exact_trace_counts(
+            langfuse_client,
+            langfuse_host=langfuse_host,
+            auth=auth,
+            trace_id=_finished_trace_id(no_tool_spans),
+            expected_generations=1,
+            expected_tool_names=(),
+        )
+    assert tool_counts == (1, 2, ("Bash", "Write"))
+    assert no_tool_counts == (1, 1, ())
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

The real SDK can emit a streamed `content_block_start` for a coding tool without later repeating that call as a final `AssistantMessage` `ToolUseBlock`. The runner adapter reduced that start to a generic partial boundary, so the existing telemetry path never opened the tool observation. This change carries only the sanitized call ID, tool name, and observation time across the adapter boundary, opens the existing payload-free tool interval, deduplicates any later final block, and defers generation closure long enough to preserve final model/token usage.

## Related issue

Ref #2204

This PR intentionally does not close the live-found issue. A production-shaped live-provider/Slack confirmation remains required before closure.

## Fix pin verification

Fix pin: runner/tests/test_otel.py::test_two_streamed_tool_starts_without_final_tool_blocks_emit_two_intervals[stream-only]

`curie dev verify-fix-pin HEAD '<selector>' --json` passed on `e22d1016`: the candidate case passed and reversing only the product hunks failed because `execute_tool` was absent.

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | required | Runner turn-loop and tool telemetry changed. | fake | `CURIE_BIN=/home/theconnman/.cargo/shared-targets/agentos/release/curie CURIE_E2E_TIERS=skill cargo run --manifest-path cli/Cargo.toml --quiet -- dev e2e-ladder --json` on the identical production diff at `56ed118a`: `LADDER PASS` with task-owned runners removed. |
| local | required | The regression must cross the real exporter, Collector, and Langfuse ingest/query path. | fake SDK events, real transport | `CURIE_RUNNER_OTEL_INTEGRATION=1 uv run pytest -q -rs runner/tests/test_otel.py::test_streamed_tool_starts_reach_langfuse_through_collector` on `e22d1016`: `1 passed`; exact tool trace contained one terminal root, two generations, and TOOL observations named Bash/Write, while the independently identified no-tool trace contained one terminal root, one generation, and zero TOOL observations. |
| local-release | n/a | No released binary/image identity, install path, version pin, or release Compose changed. | n/a | Not reached. |
| cluster | n/a | No chart, RBAC, security context, NetworkPolicy, sandbox claim, or init-container surface changed; no task-owned candidate cluster was available. | n/a | Not reached. |
| live provider | n/a, remaining blocker | The regression is pinned with real SDK event shapes but no product model credential was available for safe live execution. | n/a | #2204 remains open for production-shaped confirmation. |
| external integration | n/a, remaining blocker | No authorized Slack workspace was available and this task prohibited production or retained-demo mutation. | n/a | #2204 remains open for Slack receipt/reply confirmation. |

Supplemental candidate CI on `e22d1016` passed the fake-model `skill + local`, `local-release`, and disposable kind-cluster parity ladders. The kind result is extra cross-surface evidence; cluster remains n/a in the change classification because no cluster-owned surface changed.

- [x] Every required tier above names its exact command, commit, mode, and literal observed outcome.
- [x] The streamed-tool positive has a separately identified no-tool negative; malformed/non-tool boundaries, error, cancellation, repeated-final-block, usage preservation, and privacy paths are also durable regressions.
- [x] No required tier is left unproved. The broader local ladder stopped before its turn because retained shared data contained two active deployments and its prescribed fix was a destructive wipe; it tore down cleanly and was not rerun around the guard.

## Checklist

- [x] `uv run pytest -q runner/tests` — 809 passed, 5 skipped.
- [x] Ruff, mypy, and `scripts/check-docs.sh` pass.
- [x] All PR checks pass, including Python, the fix-pin gate, fake-model skill/local/local-release/kind-cluster ladders, CodeQL, and secret/dependency scans.
- [x] Telemetry interface documentation describes the streamed fallback and payload-free privacy boundary.
- [x] No ADR is required; this implements the existing telemetry correlation contract without changing a frozen protocol or architecture boundary.
- [x] Adversarial review caught premature generation closure; a red usage regression was added and fixed. The required one-shot fallback oracle accepted the corrected diff after two router review rounds could not complete.
- [x] Consolidation found no smaller behavior-preserving change.
- [x] Task-owned observability containers and volumes were removed; documented ports are free. No production, retained demo, shared infrastructure, merge, release, tag, or deployment was mutated.
