### PR TITLE
Fix GitHub App sandbox reconciliation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -567,10 +567,12 @@ and the role is what selects your base.
 
 The GitHub milestone-to-train mapping that CI enforces lives in
 [`tools/fix-pin-ci/milestone-trains.json`](tools/fix-pin-ci/milestone-trains.json).
-A patch milestone maps to `main`; a feature milestone maps to `next`. A pull
-request that closes an issue whose milestone belongs to the other train fails,
-and a pull request that closes a `bug` issue with no milestone fails. The check
-reuses the existing fix-pin gate rather than adding a second workflow.
+Each milestone is explicitly classified there: `patch` entries map to `main`
+and `feature` entries map to `next`. The version number's shape does not select
+the branch independently of that mapping. A pull request that closes an issue
+whose milestone belongs to the other train fails, and a pull request that closes
+a `bug` issue with no milestone fails. The check reuses the existing fix-pin gate
+rather than adding a second workflow.
 
 Create a short lived `task/<short-description>` branch from the selected base:
 

--- a/cli/src/github_app.rs
+++ b/cli/src/github_app.rs
@@ -16,11 +16,16 @@
 //! reachable when the operator asks for it; `--set-file` above is still what a
 //! chart-held connect does.
 
-use anyhow::Result;
+use anyhow::{Context, Result};
+use serde::Deserialize;
+use std::collections::{BTreeMap, BTreeSet};
+use std::process::Stdio;
+use std::time::Duration;
+use tokio::io::AsyncWriteExt;
 
 use crate::ops::{
-    fetch_release_values, plain, require_on_path, resolve_existing_secret_ref, run_step,
-    CommonOpts, OpsCommand,
+    helm_history_cmd, parse_helm_history, plain, require_on_path, resolve_existing_secret_ref,
+    run_capture, CommonOpts, OpsCommand,
 };
 
 #[derive(Debug, Clone)]
@@ -302,10 +307,9 @@ pub(crate) fn configured_existing_secret(
 /// chart-held connect (`--private-key`, no `--existing-secret`) that we have
 /// not yet checked against the release.
 ///
-/// Cheap predicate so a `--disconnect` or an explicit BYO connect never pays
-/// for a `helm get values` round trip -- neither needs anything from the
-/// release, and on a real run the read would add a hard failure when the
-/// cluster is unreachable to two paths that never had one.
+/// This predicate scopes only the credential-conflict decision. Every real
+/// invocation now reads one exact revision's values to derive the sandbox
+/// inventory, including disconnect and explicit BYO paths.
 pub(crate) fn needs_byo_conflict_check(opts: &GithubAppOpts) -> bool {
     !opts.disconnect
         && opts.existing_secret.trim().is_empty()
@@ -314,15 +318,11 @@ pub(crate) fn needs_byo_conflict_check(opts: &GithubAppOpts) -> bool {
 
 /// True when THIS invocation must read the release's values before it acts.
 ///
-/// A `--dry-run` answers false unconditionally. `cli/CLAUDE.md` makes it a
-/// load-bearing invariant that pure argv builders never fetch and that
-/// `--dry-run` never touches the network, and that invariant outranks the
-/// convenience of refusing a plan: a best-effort read that silently degrades to
-/// "no conflict" the moment `helm get values` fails is worse than no read at
-/// all, because automation cannot tell a conflict-checked plan from a plan
-/// whose check was skipped. Nothing is lost -- [`guard_byo_key_conflict`] runs
-/// on the real invocation BEFORE any mutation, so a misconfigured release is
-/// never written to either way.
+/// The chart-held credential-conflict check needs a values read on a real run.
+/// The caller also reads values for every real invocation's sandbox inventory;
+/// this predicate remains scoped to the older conflict guard so its sibling
+/// policy can be tested independently. A `--dry-run` is always offline.
+#[cfg(test)]
 pub(crate) fn needs_release_read(opts: &GithubAppOpts) -> bool {
     !opts.common.dry_run && needs_byo_conflict_check(opts)
 }
@@ -349,7 +349,7 @@ pub(crate) fn needs_release_read(opts: &GithubAppOpts) -> bool {
 /// but not a string is refused without a name rather than read as "nothing
 /// configured", which is the same false success one layer down.
 ///
-/// Called with `existing = None` under `--dry-run` (see [`needs_release_read`]),
+/// Called with `existing = None` under `--dry-run`,
 /// where it is a no-op: the plan is offline, and the refusal comes on the real
 /// invocation before helm is ever run.
 pub(crate) fn guard_byo_key_conflict(
@@ -417,6 +417,1026 @@ fn opaque_byo_field_error(
     .into()
 }
 
+const SANDBOX_API_VERSION: &str = "extensions.agents.x-k8s.io/v1beta1";
+const SANDBOX_TEMPLATE_KIND: &str = "SandboxTemplate";
+const SANDBOX_POOL_KIND: &str = "SandboxWarmPool";
+const SANDBOX_RECOVERY_ATTEMPTS: usize = 3;
+const KUBECTL_REQUEST_TIMEOUT: &str = "5s";
+const KUBECTL_WALL_TIMEOUT: Duration = Duration::from_secs(7);
+const SANDBOX_RECONCILE_WALL_TIMEOUT: Duration = Duration::from_secs(30);
+const HELM_READ_WALL_TIMEOUT: Duration = Duration::from_secs(15);
+const HELM_MUTATION_WALL_TIMEOUT: Duration = Duration::from_secs(200);
+const KUBECTL_ROLLOUT_WALL_TIMEOUT: Duration = Duration::from_secs(200);
+const HELM_MANAGED_BY_LABEL: &str = "app.kubernetes.io/managed-by";
+const HELM_RELEASE_NAME_ANNOTATION: &str = "meta.helm.sh/release-name";
+const HELM_RELEASE_NAMESPACE_ANNOTATION: &str = "meta.helm.sh/release-namespace";
+const RECOVERY_OPERATION_ANNOTATION: &str = "curietech.ai/github-app-recovery";
+
+#[derive(Clone, Copy)]
+struct HelmOwnership<'a> {
+    release: &'a str,
+    namespace: &'a str,
+}
+
+#[derive(Debug)]
+struct RecoverySandboxMarker {
+    kind: String,
+    name: String,
+    operation: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct HelmHistorySnapshot {
+    active_revision: u32,
+    head_revision: u32,
+    head_status: String,
+}
+
+impl HelmHistorySnapshot {
+    fn is_normal_failed_successor_of(&self, prior: &Self) -> bool {
+        self.active_revision == prior.active_revision
+            && prior
+                .head_revision
+                .checked_add(1)
+                .is_some_and(|successor| self.head_revision == successor)
+            && self.head_status == "failed"
+    }
+}
+
+#[derive(Debug)]
+enum SandboxReconcileFailure {
+    RevisionDrift {
+        expected: Box<HelmHistorySnapshot>,
+        observed: Box<HelmHistorySnapshot>,
+        phase: String,
+        recovery_object: Option<RecoverySandboxMarker>,
+    },
+    RevisionIndeterminate {
+        expected: Box<HelmHistorySnapshot>,
+        phase: String,
+        recovery_object: Option<RecoverySandboxMarker>,
+    },
+    StableRevisionFailure {
+        proven_snapshot: Box<HelmHistorySnapshot>,
+        error: anyhow::Error,
+    },
+    Other(anyhow::Error),
+}
+
+impl From<anyhow::Error> for SandboxReconcileFailure {
+    fn from(error: anyhow::Error) -> Self {
+        Self::Other(error)
+    }
+}
+
+fn helm_mutation_wall_timeout() -> Duration {
+    #[cfg(debug_assertions)]
+    if let Ok(raw) = std::env::var("CURIE_TEST_GITHUB_APP_HELM_TIMEOUT_MS") {
+        if let Ok(milliseconds) = raw.parse::<u64>() {
+            if (1..=HELM_MUTATION_WALL_TIMEOUT.as_millis() as u64).contains(&milliseconds) {
+                return Duration::from_millis(milliseconds);
+            }
+        }
+    }
+    HELM_MUTATION_WALL_TIMEOUT
+}
+
+#[derive(Debug, Clone)]
+struct ExpectedSandboxInventory {
+    deploy: bool,
+    agents: Vec<String>,
+}
+
+impl ExpectedSandboxInventory {
+    fn from_values(values: Option<&serde_json::Value>) -> Result<Self> {
+        let sandbox = values.and_then(|value| value.get("agentSandbox"));
+        let deploy = match sandbox.and_then(|value| value.get("deploy")) {
+            None | Some(serde_json::Value::Null) => true,
+            Some(serde_json::Value::Bool(value)) => *value,
+            Some(_) => anyhow::bail!("agentSandbox.deploy in Helm values is not a boolean"),
+        };
+        let mut agents = match sandbox.and_then(|value| value.get("connectorSecrets")) {
+            None | Some(serde_json::Value::Null) => Vec::new(),
+            Some(serde_json::Value::Object(values)) => values.keys().cloned().collect(),
+            Some(_) => anyhow::bail!("agentSandbox.connectorSecrets in Helm values is not a map"),
+        };
+        agents.sort();
+        Ok(Self { deploy, agents })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct DesiredSandboxObject {
+    kind: String,
+    name: String,
+    template_ref: Option<String>,
+    manifest: serde_json::Value,
+}
+
+impl DesiredSandboxObject {
+    fn key(&self) -> (String, String) {
+        (self.kind.clone(), self.name.clone())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct DesiredSandboxSet {
+    objects: Vec<DesiredSandboxObject>,
+}
+
+impl DesiredSandboxSet {
+    fn parse(manifest: &str) -> Result<Self> {
+        let mut objects = Vec::new();
+        for document in serde_norway::Deserializer::from_str(manifest) {
+            let value = serde_json::Value::deserialize(document)
+                .map_err(|_| anyhow::anyhow!("could not parse the deployed Helm manifest"))?;
+            let Some(kind) = value.get("kind").and_then(serde_json::Value::as_str) else {
+                continue;
+            };
+            if kind != SANDBOX_TEMPLATE_KIND && kind != SANDBOX_POOL_KIND {
+                continue;
+            }
+            if value.get("apiVersion").and_then(serde_json::Value::as_str)
+                != Some(SANDBOX_API_VERSION)
+            {
+                continue;
+            }
+            let name = value
+                .pointer("/metadata/name")
+                .and_then(serde_json::Value::as_str)
+                .filter(|name| !name.is_empty())
+                .context("a sandbox object in the deployed Helm manifest has no metadata.name")?
+                .to_string();
+            let template_ref = if kind == SANDBOX_POOL_KIND {
+                Some(
+                    value
+                        .pointer("/spec/sandboxTemplateRef/name")
+                        .and_then(serde_json::Value::as_str)
+                        .filter(|name| !name.is_empty())
+                        .context(
+                            "a SandboxWarmPool in the deployed Helm manifest has no sandboxTemplateRef.name",
+                        )?
+                        .to_string(),
+                )
+            } else {
+                None
+            };
+            objects.push(DesiredSandboxObject {
+                kind: kind.to_string(),
+                name,
+                template_ref,
+                manifest: value,
+            });
+        }
+        objects.sort_by_key(|object| {
+            (
+                if object.kind == SANDBOX_TEMPLATE_KIND {
+                    0
+                } else {
+                    1
+                },
+                object.name.clone(),
+            )
+        });
+        let set = Self { objects };
+        set.validate_pairs()?;
+        Ok(set)
+    }
+
+    fn validate_pairs(&self) -> Result<()> {
+        let mut keys = BTreeSet::new();
+        let templates: BTreeSet<&str> = self
+            .objects
+            .iter()
+            .filter(|object| object.kind == SANDBOX_TEMPLATE_KIND)
+            .map(|object| object.name.as_str())
+            .collect();
+        let mut referenced = BTreeSet::new();
+        for object in &self.objects {
+            if !keys.insert(object.key()) {
+                anyhow::bail!(
+                    "the deployed Helm manifest contains duplicate {} {}",
+                    object.kind,
+                    object.name
+                );
+            }
+            if let Some(template_ref) = object.template_ref.as_deref() {
+                if !templates.contains(template_ref) {
+                    anyhow::bail!(
+                        "SandboxWarmPool {} references missing SandboxTemplate {}",
+                        object.name,
+                        template_ref
+                    );
+                }
+                referenced.insert(template_ref);
+            }
+        }
+        if let Some(unpaired) = templates.difference(&referenced).next() {
+            anyhow::bail!("SandboxTemplate {unpaired} has no SandboxWarmPool pair");
+        }
+        Ok(())
+    }
+
+    fn validate_inventory(&self, expected: &ExpectedSandboxInventory) -> Result<()> {
+        if !expected.deploy {
+            if self.objects.is_empty() {
+                return Ok(());
+            }
+            anyhow::bail!(
+                "agentSandbox.deploy=false but the deployed manifest still owns sandbox objects"
+            );
+        }
+        if self.objects.is_empty() {
+            anyhow::bail!(
+                "the deployed Helm manifest contains no SandboxTemplate/SandboxWarmPool pairs"
+            );
+        }
+
+        let templates: BTreeSet<&str> = self
+            .objects
+            .iter()
+            .filter(|object| object.kind == SANDBOX_TEMPLATE_KIND)
+            .map(|object| object.name.as_str())
+            .collect();
+        let pools: BTreeMap<&str, &DesiredSandboxObject> = self
+            .objects
+            .iter()
+            .filter(|object| object.kind == SANDBOX_POOL_KIND)
+            .map(|object| (object.name.as_str(), object))
+            .collect();
+        let generic = templates
+            .iter()
+            .filter(|name| {
+                name.strip_suffix("-runner").is_some_and(|prefix| {
+                    pools
+                        .get(format!("{prefix}-runner-pool").as_str())
+                        .is_some_and(|pool| pool.template_ref.as_deref() == Some(**name))
+                })
+            })
+            .min_by_key(|name| name.len())
+            .copied()
+            .context("the deployed manifest has no generic SandboxTemplate/SandboxWarmPool pair")?;
+        let prefix = generic
+            .strip_suffix("-runner")
+            .expect("generic candidate has runner suffix");
+        for agent in &expected.agents {
+            let template = format!("{prefix}-agent-{agent}-runner");
+            let pool = format!("{template}-pool");
+            if !templates.contains(template.as_str())
+                || pools
+                    .get(pool.as_str())
+                    .is_none_or(|object| object.template_ref.as_deref() != Some(template.as_str()))
+            {
+                anyhow::bail!(
+                    "agent {agent} is missing expected SandboxTemplate/SandboxWarmPool pair {template} / {pool}"
+                );
+            }
+        }
+        Ok(())
+    }
+
+    fn by_key(&self) -> BTreeMap<(String, String), &serde_json::Value> {
+        self.objects
+            .iter()
+            .map(|object| (object.key(), &object.manifest))
+            .collect()
+    }
+
+    fn preserves(&self, prior: &Self) -> bool {
+        let current = self.by_key();
+        prior
+            .objects
+            .iter()
+            .all(|object| current.get(&object.key()) == Some(&&object.manifest))
+    }
+}
+
+fn helm_manifest_command(opts: &GithubAppOpts, revision: Option<u32>) -> OpsCommand {
+    let mut args = vec![
+        plain("get"),
+        plain("manifest"),
+        plain(&opts.common.release),
+        plain("-n"),
+        plain(&opts.common.namespace),
+    ];
+    if let Some(revision) = revision {
+        args.push(plain("--revision"));
+        args.push(plain(revision.to_string()));
+    }
+    OpsCommand::new("helm", args)
+}
+
+fn helm_values_command(opts: &GithubAppOpts, revision: u32) -> OpsCommand {
+    OpsCommand::new(
+        "helm",
+        vec![
+            plain("get"),
+            plain("values"),
+            plain(&opts.common.release),
+            plain("-n"),
+            plain(&opts.common.namespace),
+            plain("--revision"),
+            plain(revision.to_string()),
+            plain("-o"),
+            plain("json"),
+        ],
+    )
+}
+
+fn sandbox_list_command(namespace: &str) -> OpsCommand {
+    OpsCommand::new(
+        "kubectl",
+        vec![
+            plain("get"),
+            plain(
+                "sandboxtemplates.extensions.agents.x-k8s.io,sandboxwarmpools.extensions.agents.x-k8s.io",
+            ),
+            plain("-n"),
+            plain(namespace),
+            plain("-o"),
+            plain("json"),
+            plain(format!("--request-timeout={KUBECTL_REQUEST_TIMEOUT}")),
+        ],
+    )
+}
+
+fn rollback_command(opts: &GithubAppOpts, revision: u32) -> OpsCommand {
+    OpsCommand::new(
+        "helm",
+        vec![
+            plain("rollback"),
+            plain(&opts.common.release),
+            plain(revision.to_string()),
+            plain("-n"),
+            plain(&opts.common.namespace),
+            plain("--wait"),
+            plain("--timeout"),
+            plain("180s"),
+        ],
+    )
+}
+
+fn rollback_recovery_command(opts: &GithubAppOpts, revision: u32) -> String {
+    rollback_command(opts, revision).display()
+}
+
+async fn run_helm_bounded(
+    command: &OpsCommand,
+    timeout: Duration,
+    operation: &str,
+) -> Result<(bool, String, String)> {
+    tokio::time::timeout(timeout, run_capture(command))
+        .await
+        .map_err(|_| anyhow::anyhow!("{operation} timed out at its wall-clock deadline"))?
+}
+
+async fn current_history_snapshot(opts: &GithubAppOpts) -> Result<HelmHistorySnapshot> {
+    let command = helm_history_cmd(&opts.common);
+    let recovery = command.display();
+    let (ok, out, _) = run_helm_bounded(
+        &command,
+        HELM_READ_WALL_TIMEOUT,
+        "reading Helm release history",
+    )
+    .await?;
+    if !ok {
+        return Err(crate::exit::CliError::failure(format!(
+            "could not capture the deployed Helm revision for release {}",
+            opts.common.release
+        ))
+        .with_fix(format!("inspect it with `{recovery}`"))
+        .into());
+    }
+    let history = parse_helm_history(&out)?;
+    let active_revision = history
+        .iter()
+        .filter(|row| row.status.trim().eq_ignore_ascii_case("deployed"))
+        .map(|row| row.revision)
+        .max()
+        .ok_or_else(|| {
+            crate::exit::CliError::failure(format!(
+                "release {} has no revision Helm marks deployed",
+                opts.common.release
+            ))
+            .with_fix(format!("inspect it with `{recovery}`"))
+        })?;
+    let head = history
+        .iter()
+        .max_by_key(|row| row.revision)
+        .ok_or_else(|| {
+            crate::exit::CliError::failure(format!(
+                "release {} has no revisions in Helm history",
+                opts.common.release
+            ))
+            .with_fix(format!("inspect it with `{recovery}`"))
+        })?;
+    Ok(HelmHistorySnapshot {
+        active_revision,
+        head_revision: head.revision,
+        head_status: head.status.trim().to_ascii_lowercase(),
+    })
+}
+
+async fn read_desired_sandboxes(
+    opts: &GithubAppOpts,
+    revision: Option<u32>,
+) -> Result<DesiredSandboxSet> {
+    let command = helm_manifest_command(opts, revision);
+    let (ok, out, _) = run_helm_bounded(
+        &command,
+        HELM_READ_WALL_TIMEOUT,
+        "reading the Helm release manifest",
+    )
+    .await?;
+    if !ok {
+        anyhow::bail!("helm could not read the deployed manifest")
+    }
+    DesiredSandboxSet::parse(&out)
+}
+
+async fn read_release_values_at_revision(
+    opts: &GithubAppOpts,
+    revision: u32,
+) -> Result<Option<serde_json::Value>> {
+    let command = helm_values_command(opts, revision);
+    let (ok, out, _) = run_helm_bounded(
+        &command,
+        HELM_READ_WALL_TIMEOUT,
+        "reading the Helm release values",
+    )
+    .await?;
+    if !ok {
+        anyhow::bail!("helm could not read the captured revision's values")
+    }
+    let value: serde_json::Value = serde_json::from_str(&out)
+        .map_err(|_| anyhow::anyhow!("helm returned malformed values JSON"))?;
+    match value {
+        serde_json::Value::Null => Ok(None),
+        serde_json::Value::Object(_) => Ok(Some(value)),
+        _ => anyhow::bail!("helm returned values JSON that is neither an object nor null"),
+    }
+}
+
+async fn live_sandboxes(namespace: &str) -> Result<BTreeMap<String, serde_json::Value>> {
+    let command = sandbox_list_command(namespace);
+    let (ok, out, err) = tokio::time::timeout(KUBECTL_WALL_TIMEOUT, run_capture(&command))
+        .await
+        .map_err(|_| {
+            anyhow::anyhow!("kubectl sandbox read timed out at its wall-clock deadline")
+        })??;
+    if !ok {
+        if err.to_ascii_lowercase().contains("deadline")
+            || err.to_ascii_lowercase().contains("timed out")
+        {
+            anyhow::bail!("kubectl sandbox read timed out at its request deadline")
+        }
+        anyhow::bail!("kubectl could not list SandboxTemplate and SandboxWarmPool objects")
+    }
+    let value: serde_json::Value =
+        serde_json::from_str(&out).context("kubectl returned malformed sandbox JSON")?;
+    let items = value
+        .get("items")
+        .and_then(serde_json::Value::as_array)
+        .context("kubectl sandbox JSON has no items array")?;
+    let mut live = BTreeMap::new();
+    for item in items {
+        let Some(kind) = item.get("kind").and_then(serde_json::Value::as_str) else {
+            continue;
+        };
+        if kind != SANDBOX_TEMPLATE_KIND && kind != SANDBOX_POOL_KIND {
+            continue;
+        }
+        let name = item
+            .pointer("/metadata/name")
+            .and_then(serde_json::Value::as_str)
+            .filter(|name| !name.is_empty())
+            .context("a live sandbox object has no metadata.name")?;
+        if live.insert(name.to_string(), item.clone()).is_some() {
+            anyhow::bail!("multiple live sandbox objects share the name {name}");
+        }
+    }
+    Ok(live)
+}
+
+fn value_is_required_subset(desired: &serde_json::Value, live: &serde_json::Value) -> bool {
+    match (desired, live) {
+        (serde_json::Value::Object(desired), serde_json::Value::Object(live)) => {
+            desired.iter().all(|(key, value)| {
+                live.get(key)
+                    .is_some_and(|item| value_is_required_subset(value, item))
+            })
+        }
+        (serde_json::Value::Array(desired), serde_json::Value::Array(live)) => {
+            desired.len() == live.len()
+                && desired
+                    .iter()
+                    .zip(live)
+                    .all(|(desired, live)| value_is_required_subset(desired, live))
+        }
+        _ => desired == live,
+    }
+}
+
+fn validate_live_object(
+    desired: &DesiredSandboxObject,
+    live: &serde_json::Value,
+    ownership: HelmOwnership<'_>,
+) -> Result<()> {
+    if live.get("apiVersion") != desired.manifest.get("apiVersion")
+        || live.get("kind") != desired.manifest.get("kind")
+        || live.pointer("/metadata/name") != desired.manifest.pointer("/metadata/name")
+    {
+        anyhow::bail!("apiVersion, kind, or metadata.name diverges");
+    }
+    if live
+        .pointer("/metadata/labels/app.kubernetes.io~1managed-by")
+        .and_then(serde_json::Value::as_str)
+        != Some("Helm")
+        || live
+            .pointer("/metadata/annotations/meta.helm.sh~1release-name")
+            .and_then(serde_json::Value::as_str)
+            != Some(ownership.release)
+        || live
+            .pointer("/metadata/annotations/meta.helm.sh~1release-namespace")
+            .and_then(serde_json::Value::as_str)
+            != Some(ownership.namespace)
+    {
+        anyhow::bail!("Helm ownership metadata is missing or does not match this release");
+    }
+    let empty = serde_json::Value::Object(serde_json::Map::new());
+    let desired_labels = desired
+        .manifest
+        .pointer("/metadata/labels")
+        .unwrap_or(&empty);
+    let live_labels = live.pointer("/metadata/labels").unwrap_or(&empty);
+    let desired_spec = desired
+        .manifest
+        .get("spec")
+        .unwrap_or(&serde_json::Value::Null);
+    let live_spec = live.get("spec").unwrap_or(&serde_json::Value::Null);
+    if !value_is_required_subset(desired_labels, live_labels) {
+        anyhow::bail!("Helm-desired labels diverge");
+    }
+    if !value_is_required_subset(desired_spec, live_spec) {
+        anyhow::bail!("Helm-desired spec diverges");
+    }
+    Ok(())
+}
+
+fn missing_from_live<'a>(
+    desired: &'a DesiredSandboxSet,
+    live: &BTreeMap<String, serde_json::Value>,
+    ownership: HelmOwnership<'_>,
+) -> Result<Vec<&'a DesiredSandboxObject>> {
+    let mut missing = Vec::new();
+    for object in &desired.objects {
+        match live.get(&object.name) {
+            Some(value) => {
+                if let Err(error) = validate_live_object(object, value, ownership) {
+                    anyhow::bail!(
+                        "live sandbox object {} diverges from its Helm-desired state: {error}",
+                        object.name
+                    );
+                }
+            }
+            None => missing.push(object),
+        }
+    }
+    Ok(missing)
+}
+
+async fn create_sandbox(
+    ownership: HelmOwnership<'_>,
+    object: &DesiredSandboxObject,
+    recovery_operation: &str,
+) -> Result<()> {
+    tokio::time::timeout(
+        KUBECTL_WALL_TIMEOUT,
+        create_sandbox_inner(ownership, object, recovery_operation),
+    )
+    .await
+    .map_err(|_| anyhow::anyhow!("kubectl sandbox create timed out at its wall-clock deadline"))?
+}
+
+async fn create_sandbox_inner(
+    ownership: HelmOwnership<'_>,
+    object: &DesiredSandboxObject,
+    recovery_operation: &str,
+) -> Result<()> {
+    let mut recovery_manifest = object.manifest.clone();
+    let metadata = recovery_manifest
+        .get_mut("metadata")
+        .and_then(serde_json::Value::as_object_mut)
+        .context("a sandbox recovery object has no metadata map")?;
+    let labels = metadata
+        .entry("labels")
+        .or_insert_with(|| serde_json::json!({}))
+        .as_object_mut()
+        .context("a sandbox recovery object's metadata.labels is not a map")?;
+    labels.insert(
+        HELM_MANAGED_BY_LABEL.to_string(),
+        serde_json::Value::String("Helm".to_string()),
+    );
+    let annotations = metadata
+        .entry("annotations")
+        .or_insert_with(|| serde_json::json!({}))
+        .as_object_mut()
+        .context("a sandbox recovery object's metadata.annotations is not a map")?;
+    annotations.insert(
+        HELM_RELEASE_NAME_ANNOTATION.to_string(),
+        serde_json::Value::String(ownership.release.to_string()),
+    );
+    annotations.insert(
+        HELM_RELEASE_NAMESPACE_ANNOTATION.to_string(),
+        serde_json::Value::String(ownership.namespace.to_string()),
+    );
+    annotations.insert(
+        RECOVERY_OPERATION_ANNOTATION.to_string(),
+        serde_json::Value::String(recovery_operation.to_string()),
+    );
+    let body = serde_norway::to_string(&recovery_manifest)
+        .context("could not serialize a sandbox recovery object")?;
+    let mut child = tokio::process::Command::new("kubectl")
+        .args([
+            "create",
+            "-n",
+            ownership.namespace,
+            "-f",
+            "-",
+            &format!("--request-timeout={KUBECTL_REQUEST_TIMEOUT}"),
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
+        .context("failed to invoke `kubectl`; is it on PATH?")?;
+    let mut stdin = child
+        .stdin
+        .take()
+        .context("could not open kubectl stdin for sandbox recovery")?;
+    stdin
+        .write_all(body.as_bytes())
+        .await
+        .context("could not send a sandbox recovery object to kubectl")?;
+    drop(stdin);
+    let output = child
+        .wait_with_output()
+        .await
+        .context("could not wait for kubectl sandbox recovery")?;
+    if !output.status.success() {
+        anyhow::bail!("kubectl could not recreate {} {}", object.kind, object.name);
+    }
+    Ok(())
+}
+
+async fn ensure_reconcile_revision(
+    opts: &GithubAppOpts,
+    expected: &HelmHistorySnapshot,
+    phase: &'static str,
+) -> std::result::Result<(), SandboxReconcileFailure> {
+    let observed = match current_history_snapshot(opts).await {
+        Ok(observed) => observed,
+        Err(_) => {
+            return Err(SandboxReconcileFailure::RevisionIndeterminate {
+                expected: Box::new(expected.clone()),
+                phase: phase.to_string(),
+                recovery_object: None,
+            });
+        }
+    };
+    if &observed == expected {
+        Ok(())
+    } else {
+        Err(SandboxReconcileFailure::RevisionDrift {
+            expected: Box::new(expected.clone()),
+            observed: Box::new(observed),
+            phase: phase.to_string(),
+            recovery_object: None,
+        })
+    }
+}
+
+async fn reconcile_live_sandboxes(
+    opts: &GithubAppOpts,
+    ownership: HelmOwnership<'_>,
+    expected_snapshot: &HelmHistorySnapshot,
+    desired: &DesiredSandboxSet,
+) -> std::result::Result<(), SandboxReconcileFailure> {
+    tokio::time::timeout(
+        SANDBOX_RECONCILE_WALL_TIMEOUT,
+        reconcile_live_sandboxes_inner(opts, ownership, expected_snapshot, desired),
+    )
+    .await
+    .map_err(|_| {
+        SandboxReconcileFailure::Other(anyhow::anyhow!(
+            "sandbox reconciliation timed out at its overall deadline"
+        ))
+    })?
+}
+
+async fn reconcile_live_sandboxes_inner(
+    opts: &GithubAppOpts,
+    ownership: HelmOwnership<'_>,
+    expected_snapshot: &HelmHistorySnapshot,
+    desired: &DesiredSandboxSet,
+) -> std::result::Result<(), SandboxReconcileFailure> {
+    for _ in 0..SANDBOX_RECOVERY_ATTEMPTS {
+        let live = live_sandboxes(ownership.namespace).await?;
+        let missing = missing_from_live(desired, &live, ownership)?;
+        if missing.is_empty() {
+            return ensure_reconcile_revision(
+                opts,
+                expected_snapshot,
+                "after the sandbox reconciliation barrier",
+            )
+            .await;
+        }
+        ensure_reconcile_revision(opts, expected_snapshot, "before a sandbox recovery attempt")
+            .await?;
+        for object in missing {
+            ensure_reconcile_revision(opts, expected_snapshot, "before a sandbox recovery write")
+                .await?;
+            let recovery_operation = uuid::Uuid::new_v4().to_string();
+            let create = create_sandbox(ownership, object, &recovery_operation).await;
+            let recovery_object = || RecoverySandboxMarker {
+                kind: object.kind.clone(),
+                name: object.name.clone(),
+                operation: recovery_operation.clone(),
+            };
+            let observed = match current_history_snapshot(opts).await {
+                Ok(observed) => observed,
+                Err(_) => {
+                    return Err(SandboxReconcileFailure::RevisionIndeterminate {
+                        expected: Box::new(expected_snapshot.clone()),
+                        phase: "after a sandbox recovery write".to_string(),
+                        recovery_object: Some(recovery_object()),
+                    });
+                }
+            };
+            if &observed != expected_snapshot {
+                return Err(SandboxReconcileFailure::RevisionDrift {
+                    expected: Box::new(expected_snapshot.clone()),
+                    observed: Box::new(observed),
+                    phase: "during a sandbox recovery write".to_string(),
+                    recovery_object: Some(recovery_object()),
+                });
+            }
+            if create.is_err() {
+                // A concurrent controller or operator may have won the create
+                // race. Relist immediately and accept that outcome only when
+                // the object now contains every Helm-desired field.
+                let live = live_sandboxes(ownership.namespace).await?;
+                let still_missing = missing_from_live(desired, &live, ownership)?;
+                if !still_missing
+                    .iter()
+                    .any(|candidate| candidate.name == object.name)
+                {
+                    continue;
+                }
+            }
+        }
+    }
+    let live = live_sandboxes(ownership.namespace).await?;
+    let missing = missing_from_live(desired, &live, ownership)?
+        .into_iter()
+        .map(|object| object.name.as_str())
+        .collect::<Vec<_>>();
+    ensure_reconcile_revision(
+        opts,
+        expected_snapshot,
+        "after the sandbox reconciliation barrier",
+    )
+    .await?;
+    if missing.is_empty() {
+        Ok(())
+    } else {
+        Err(SandboxReconcileFailure::StableRevisionFailure {
+            proven_snapshot: Box::new(expected_snapshot.clone()),
+            error: anyhow::anyhow!("unreconciled sandbox object(s): {}", missing.join(", ")),
+        })
+    }
+}
+
+fn recovery_failure(
+    opts: &GithubAppOpts,
+    revision: u32,
+    message: impl Into<String>,
+) -> anyhow::Error {
+    crate::exit::CliError::failure(message.into())
+        .with_fix(format!(
+            "run `{}` and inspect every SandboxTemplate/SandboxWarmPool pair before retrying",
+            rollback_recovery_command(opts, revision)
+        ))
+        .into()
+}
+
+fn manifest_preflight_failure(
+    opts: &GithubAppOpts,
+    revision: u32,
+    error: &anyhow::Error,
+) -> anyhow::Error {
+    let command = helm_manifest_command(opts, Some(revision)).display();
+    crate::exit::CliError::failure(format!(
+        "release {} revision {} has no complete, usable SandboxTemplate/SandboxWarmPool set: {error}",
+        opts.common.release, revision
+    ))
+    .with_fix(format!(
+        "inspect it with `{command}` and restore every complete template/pool pair before retrying"
+    ))
+    .into()
+}
+
+fn revision_stability_failure(
+    opts: &GithubAppOpts,
+    captured: &HelmHistorySnapshot,
+    observed: &HelmHistorySnapshot,
+    phase: &str,
+) -> anyhow::Error {
+    revision_stability_failure_with_recovery(opts, captured, observed, phase, None)
+}
+
+fn snapshot_description(snapshot: &HelmHistorySnapshot) -> String {
+    format!(
+        "active revision {}, history head revision {} ({})",
+        snapshot.active_revision, snapshot.head_revision, snapshot.head_status
+    )
+}
+
+fn pending_head_failure(opts: &GithubAppOpts, snapshot: &HelmHistorySnapshot) -> anyhow::Error {
+    let command = helm_history_cmd(&opts.common).display();
+    crate::exit::CliError::failure(format!(
+        "release {} has Helm history head revision {} in {}; refusing all mutation while that operation is pending",
+        opts.common.release, snapshot.head_revision, snapshot.head_status
+    ))
+    .with_fix(format!(
+        "inspect current release history with `{command}` and resolve the pending Helm operation before retrying; no automatic rollback was attempted"
+    ))
+    .into()
+}
+
+fn sandbox_inspection_command(
+    opts: &GithubAppOpts,
+    recovery_object: &RecoverySandboxMarker,
+) -> OpsCommand {
+    let resource = if recovery_object.kind == SANDBOX_TEMPLATE_KIND {
+        "sandboxtemplates.extensions.agents.x-k8s.io"
+    } else {
+        "sandboxwarmpools.extensions.agents.x-k8s.io"
+    };
+    OpsCommand::new(
+        "kubectl",
+        vec![
+            plain("get"),
+            plain(format!("{resource}/{}", recovery_object.name)),
+            plain("-n"),
+            plain(&opts.common.namespace),
+            plain("-o"),
+            plain("yaml"),
+            plain(format!("--request-timeout={KUBECTL_REQUEST_TIMEOUT}")),
+        ],
+    )
+}
+
+fn revision_stability_failure_with_recovery(
+    opts: &GithubAppOpts,
+    captured: &HelmHistorySnapshot,
+    observed: &HelmHistorySnapshot,
+    phase: &str,
+    recovery_object: Option<&RecoverySandboxMarker>,
+) -> anyhow::Error {
+    let history_command = helm_history_cmd(&opts.common).display();
+    let recovery_detail = recovery_object.map_or_else(String::new, |object| {
+        format!(
+            "; the create attempt for {} {} used recovery marker {}={} and was left untouched for operator inspection",
+            object.kind, object.name, RECOVERY_OPERATION_ANNOTATION, object.operation
+        )
+    });
+    let fix = recovery_object.map_or_else(
+        || {
+            format!(
+                "inspect concurrent release history with `{history_command}` and reconcile the active revision; no automatic rollback was attempted"
+            )
+        },
+        |object| {
+            let inspect_command = sandbox_inspection_command(opts, object).display();
+            format!(
+                "inspect the operation-marked object with `{inspect_command}` and verify {}={}; inspect concurrent release history with `{history_command}`, then reconcile only against the active revision; no automatic deletion or rollback was attempted",
+                RECOVERY_OPERATION_ANNOTATION, object.operation
+            )
+        },
+    );
+    crate::exit::CliError::failure(
+        format!(
+            "release {} moved from captured Helm history snapshot ({}) to ({}) {phase}; refusing stale state",
+            opts.common.release,
+            snapshot_description(captured),
+            snapshot_description(observed)
+        ) + &recovery_detail,
+    )
+    .with_fix(fix)
+    .into()
+}
+
+fn revision_indeterminate_failure_with_recovery(
+    opts: &GithubAppOpts,
+    expected: &HelmHistorySnapshot,
+    phase: &str,
+    recovery_object: Option<&RecoverySandboxMarker>,
+) -> anyhow::Error {
+    let history_command = helm_history_cmd(&opts.common).display();
+    let recovery_detail = recovery_object.map_or_else(String::new, |object| {
+        format!(
+            "; the create attempt for {} {} used recovery marker {}={} and was left untouched for operator inspection",
+            object.kind, object.name, RECOVERY_OPERATION_ANNOTATION, object.operation
+        )
+    });
+    let fix = recovery_object.map_or_else(
+        || {
+            format!(
+                "inspect current release history with `{history_command}` before reconciling the expected snapshot ({}); no automatic rollback was attempted",
+                snapshot_description(expected)
+            )
+        },
+        |object| {
+            let inspect_command = sandbox_inspection_command(opts, object).display();
+            format!(
+                "inspect the operation-marked object with `{inspect_command}` and verify {}={}; inspect current release history with `{history_command}`, then reconcile only against the active revision; no automatic deletion or rollback was attempted",
+                RECOVERY_OPERATION_ANNOTATION, object.operation
+            )
+        },
+    );
+    crate::exit::CliError::failure(
+        format!(
+            "could not establish whether release {} still has expected Helm history snapshot ({}) {phase}; refusing stale state",
+            opts.common.release,
+            snapshot_description(expected)
+        ) + &recovery_detail,
+    )
+    .with_fix(fix)
+    .into()
+}
+
+fn map_reconcile_failure(
+    opts: &GithubAppOpts,
+    recovery_revision: u32,
+    expected_snapshot: &HelmHistorySnapshot,
+    context: impl FnOnce(anyhow::Error) -> String,
+    failure: SandboxReconcileFailure,
+) -> anyhow::Error {
+    match failure {
+        SandboxReconcileFailure::RevisionDrift {
+            expected,
+            observed,
+            phase,
+            recovery_object,
+        } => revision_stability_failure_with_recovery(
+            opts,
+            &expected,
+            &observed,
+            &phase,
+            recovery_object.as_ref(),
+        ),
+        SandboxReconcileFailure::RevisionIndeterminate {
+            expected,
+            phase,
+            recovery_object,
+        } => revision_indeterminate_failure_with_recovery(
+            opts,
+            &expected,
+            &phase,
+            recovery_object.as_ref(),
+        ),
+        SandboxReconcileFailure::StableRevisionFailure {
+            proven_snapshot,
+            error,
+        } => recovery_failure(
+            opts,
+            recovery_revision,
+            format!(
+                "{}; Helm history snapshot ({}) was rechecked immediately before this failure",
+                context(error),
+                snapshot_description(&proven_snapshot)
+            ),
+        ),
+        SandboxReconcileFailure::Other(error) => revision_indeterminate_failure_with_recovery(
+            opts,
+            expected_snapshot,
+            &format!("while reconciling sandbox state: {}", context(error)),
+            None,
+        ),
+    }
+}
+
+async fn restore_captured_sandboxes(
+    opts: &GithubAppOpts,
+    ownership: HelmOwnership<'_>,
+    expected_snapshot: &HelmHistorySnapshot,
+    prior: &DesiredSandboxSet,
+) -> std::result::Result<(), SandboxReconcileFailure> {
+    reconcile_live_sandboxes(opts, ownership, expected_snapshot, prior).await
+}
+
 pub enum GithubAppOutput {
     DryRun(crate::ui::DryRunPlan),
     Done { configured: bool },
@@ -449,20 +1469,10 @@ pub async fn github_app(opts: GithubAppOpts, clone_base: &str) -> Result<GithubA
     if !opts.common.dry_run {
         require_on_path("helm")?;
     }
-    let existing = if needs_release_read(&opts) {
-        // The typed error propagates: the `helm upgrade` two steps later would
-        // fail identically, and failing before any mutation is strictly better
-        // than failing part-way through one.
-        fetch_release_values(&opts.common).await?
-    } else {
-        None
-    };
-    // Under `--dry-run` this is a no-op by construction: `needs_release_read`
-    // answered false, so `existing` is None and the guard has nothing to judge.
-    // The plan therefore stays offline, and the guard still runs on the REAL
-    // invocation above -- before any mutation -- so nothing is ever written to
-    // a release whose key the API would ignore.
-    guard_byo_key_conflict(&opts, existing.as_ref())?;
+    // The dry-run guard has no release state to judge and remains a no-op. A
+    // real run evaluates the guard below against the exact captured revision,
+    // so inventory and credential decisions cannot come from different reads.
+    guard_byo_key_conflict(&opts, None)?;
 
     let cmds = if opts.disconnect {
         disconnect_commands(&opts)
@@ -487,6 +1497,41 @@ pub async fn github_app(opts: GithubAppOpts, clone_base: &str) -> Result<GithubA
     }
 
     require_on_path("kubectl")?;
+    let ownership = HelmOwnership {
+        release: &opts.common.release,
+        namespace: &opts.common.namespace,
+    };
+    let prior_snapshot = current_history_snapshot(&opts).await?;
+    if prior_snapshot.head_status.starts_with("pending-") {
+        return Err(pending_head_failure(&opts, &prior_snapshot));
+    }
+    let prior_revision = prior_snapshot.active_revision;
+    let revision_values = read_release_values_at_revision(&opts, prior_revision)
+        .await
+        .map_err(|error| manifest_preflight_failure(&opts, prior_revision, &error))?;
+    guard_byo_key_conflict(&opts, revision_values.as_ref())?;
+    let expected_inventory = ExpectedSandboxInventory::from_values(revision_values.as_ref())?;
+    let prior_sandboxes = read_desired_sandboxes(&opts, Some(prior_revision))
+        .await
+        .map_err(|error| manifest_preflight_failure(&opts, prior_revision, &error))?;
+    prior_sandboxes
+        .validate_inventory(&expected_inventory)
+        .map_err(|error| manifest_preflight_failure(&opts, prior_revision, &error))?;
+    reconcile_live_sandboxes(&opts, ownership, &prior_snapshot, &prior_sandboxes)
+        .await
+        .map_err(|failure| {
+            map_reconcile_failure(
+                &opts,
+                prior_revision,
+                &prior_snapshot,
+                |error| format!(
+                    "release {} is unsafe to mutate because its pre-existing sandbox set could not be reconciled: {error}",
+                    opts.common.release
+                ),
+                failure,
+            )
+        })?;
+
     let cl = ui.checklist();
     let label = if opts.disconnect {
         format!(
@@ -504,8 +1549,132 @@ pub async fn github_app(opts: GithubAppOpts, clone_base: &str) -> Result<GithubA
     } else {
         "configured"
     };
+    let mut helm_failure = None;
     for cmd in &cmds {
-        run_step(&cl, &label, ok_detail, cmd).await?;
+        ui.plumbing(&format!("+ {}", cmd.display()));
+        let step = cl.step(&label);
+        match run_helm_bounded(
+            cmd,
+            helm_mutation_wall_timeout(),
+            "the GitHub App Helm mutation",
+        )
+        .await
+        {
+            Ok((true, _, _)) => step.done(ok_detail),
+            Ok((false, _, _)) | Err(_) => {
+                step.fail("failed; recovering sandbox resources");
+                helm_failure = Some(());
+                break;
+            }
+        }
+    }
+
+    let post_snapshot = current_history_snapshot(&opts).await.map_err(|_| {
+        revision_indeterminate_failure_with_recovery(
+            &opts,
+            &prior_snapshot,
+            "immediately after the Helm mutation",
+            None,
+        )
+    })?;
+    if helm_failure.is_some() {
+        if post_snapshot != prior_snapshot
+            && !post_snapshot.is_normal_failed_successor_of(&prior_snapshot)
+        {
+            return Err(revision_stability_failure(
+                &opts,
+                &prior_snapshot,
+                &post_snapshot,
+                "after the Helm mutation failed or became indeterminate",
+            ));
+        }
+    } else {
+        let expected_revision = prior_snapshot.head_revision.checked_add(1).ok_or_else(|| {
+            crate::exit::CliError::failure(
+                "the captured Helm history head cannot have a representable successor",
+            )
+            .with_fix(format!(
+                "inspect release history with `{}`",
+                helm_history_cmd(&opts.common).display()
+            ))
+        })?;
+        let expected_post_snapshot = HelmHistorySnapshot {
+            active_revision: expected_revision,
+            head_revision: expected_revision,
+            head_status: "deployed".to_string(),
+        };
+        if post_snapshot != expected_post_snapshot {
+            return Err(revision_stability_failure(
+                &opts,
+                &expected_post_snapshot,
+                &post_snapshot,
+                &format!(
+                    "after the credential mutation from active prior revision {prior_revision}"
+                ),
+            ));
+        }
+    }
+    let post_revision = post_snapshot.active_revision;
+    let post_sandboxes = read_desired_sandboxes(&opts, Some(post_revision)).await;
+    let manifest_is_safe = post_sandboxes.as_ref().is_ok_and(|current| {
+        if helm_failure.is_some() {
+            current == &prior_sandboxes
+        } else {
+            current.preserves(&prior_sandboxes)
+        }
+    });
+    if !manifest_is_safe {
+        let reason = match &post_sandboxes {
+            Ok(_) => "the credential Helm attempt removed or changed a previously deployed sandbox object".to_string(),
+            Err(error) => format!("the post-attempt Helm manifest could not prove sandbox ownership: {error}"),
+        };
+        let restoration =
+            restore_captured_sandboxes(&opts, ownership, &post_snapshot, &prior_sandboxes).await;
+        let message = match restoration {
+            Ok(()) => format!(
+                "{reason}; the captured pre-mutation sandbox objects were restored and verified, but Helm ownership is still unsafe"
+            ),
+            Err(failure) => {
+                return Err(map_reconcile_failure(
+                    &opts,
+                    prior_revision,
+                    &post_snapshot,
+                    |error| {
+                        format!(
+                            "{reason}; captured sandbox restoration failed within the bounded recovery barrier: {error}"
+                        )
+                    },
+                    failure,
+                ));
+            }
+        };
+        return Err(recovery_failure(&opts, prior_revision, message));
+    }
+
+    let post_sandboxes = post_sandboxes.expect("manifest_is_safe requires a parsed manifest");
+    reconcile_live_sandboxes(&opts, ownership, &post_snapshot, &post_sandboxes)
+        .await
+        .map_err(|failure| {
+            map_reconcile_failure(
+                &opts,
+                prior_revision,
+                &post_snapshot,
+                |error| {
+                    format!(
+                        "release {} still has {error} after {} bounded recovery attempts",
+                        opts.common.release, SANDBOX_RECOVERY_ATTEMPTS
+                    )
+                },
+                failure,
+            )
+        })?;
+
+    if helm_failure.is_some() {
+        return Err(recovery_failure(
+            &opts,
+            prior_revision,
+            "Helm mutation failed after the sandbox recovery barrier restored and verified the captured release-owned set; no API rollout was started",
+        ));
     }
     // A secretKeyRef env var is resolved once at pod start, so the Secret
     // change alone leaves the running API on the old credential.
@@ -517,8 +1686,89 @@ pub async fn github_app(opts: GithubAppOpts, clone_base: &str) -> Result<GithubA
     let fullname = crate::ops::release_fullname(&opts.common.namespace, &opts.common.release).await;
     let rollout = rollout_commands(&opts.common.namespace, &fullname);
     let roll_label = format!("rolling {} to pick up the credential", opts.common.release);
+    let mut rollout_failure = None;
     for cmd in &rollout {
-        run_step(&cl, &roll_label, "rolled", cmd).await?;
+        ui.plumbing(&format!("+ {}", cmd.display()));
+        let step = cl.step(&roll_label);
+        match tokio::time::timeout(KUBECTL_ROLLOUT_WALL_TIMEOUT, run_capture(cmd)).await {
+            Ok(Ok((true, _, _))) => step.done("rolled"),
+            Ok(Ok((false, _, _))) | Ok(Err(_)) | Err(_) => {
+                step.fail("failed; verifying sandbox recovery");
+                rollout_failure = Some(());
+                break;
+            }
+        }
+    }
+
+    let final_snapshot = current_history_snapshot(&opts).await.map_err(|_| {
+        revision_indeterminate_failure_with_recovery(
+            &opts,
+            &post_snapshot,
+            "after API rollout",
+            None,
+        )
+    })?;
+    if final_snapshot != post_snapshot {
+        return Err(revision_stability_failure(
+            &opts,
+            &post_snapshot,
+            &final_snapshot,
+            "during API rollout",
+        ));
+    }
+    let final_revision = final_snapshot.active_revision;
+    let final_sandboxes = read_desired_sandboxes(&opts, Some(final_revision)).await;
+    let final_sandboxes = match final_sandboxes {
+        Ok(current) if current == post_sandboxes => current,
+        Ok(_) | Err(_) => {
+            let restoration =
+                restore_captured_sandboxes(&opts, ownership, &final_snapshot, &prior_sandboxes)
+                    .await;
+            let detail = match restoration {
+                Ok(()) => String::new(),
+                Err(failure) => {
+                    return Err(map_reconcile_failure(
+                        &opts,
+                        prior_revision,
+                        &final_snapshot,
+                        |error| format!("captured sandbox restoration failed: {error}"),
+                        failure,
+                    ));
+                }
+            };
+            let command = helm_manifest_command(&opts, Some(final_revision)).display();
+            return Err(crate::exit::CliError::failure(format!(
+                "release {} revision {} manifest was not stable through API rollout{detail}",
+                opts.common.release, final_revision
+            ))
+            .with_fix(format!(
+                "inspect the immutable revision with `{command}` and reconcile its SandboxTemplate/SandboxWarmPool ownership; no automatic rollback was attempted"
+            ))
+            .into());
+        }
+    };
+    reconcile_live_sandboxes(&opts, ownership, &final_snapshot, &final_sandboxes)
+        .await
+        .map_err(|failure| {
+            map_reconcile_failure(
+                &opts,
+                prior_revision,
+                &final_snapshot,
+                |error| {
+                    format!(
+                        "release {} lost sandbox state during API rollout: {error}",
+                        opts.common.release
+                    )
+                },
+                failure,
+            )
+        })?;
+    if rollout_failure.is_some() {
+        return Err(recovery_failure(
+            &opts,
+            prior_revision,
+            "API rollout failed; the bounded sandbox recovery barrier restored and verified the release-owned sandbox set before returning",
+        ));
     }
     if opts.disconnect {
         ui.note("GitHub App cleared; the platform falls back to api.githubToken");

--- a/cli/tests/github_app_clap_wiring.rs
+++ b/cli/tests/github_app_clap_wiring.rs
@@ -180,11 +180,11 @@ fn the_wired_byo_connect_still_rolls_the_api() {
 /// execution through the real consumer path, and the real consumer path is the
 /// binary.
 ///
-/// Real invocation, and still no cluster. `github_app()` orders itself
-/// `require_connect_inputs` -> `require_on_path("helm")` -> `fetch_release_values`
-/// -> `guard_byo_key_conflict` -> `helm upgrade`, and the CLI reads the release
-/// with `helm get values -o json`. A `helm` shim earlier on the CHILD's PATH
-/// answers that read; the refusal then happens before anything is executed.
+/// Real invocation, and still no cluster. `github_app()` validates the inputs
+/// and tools, captures the deployed Helm revision, then reads that revision's
+/// values before applying `guard_byo_key_conflict` and entering any sandbox or
+/// Helm mutation path. A `helm` shim earlier on the CHILD's PATH answers those
+/// exact-revision reads; the refusal then happens before anything is mutated.
 /// `--dry-run` is deliberately NOT used here: it must never touch the network
 /// (`cli/CLAUDE.md`), so it makes no values read and reaches no guard at all --
 /// a dry run could not exercise this call site.
@@ -199,9 +199,10 @@ mod byo_conflict_guard_through_the_binary {
     use std::path::PathBuf;
     use std::process::{Command, Output};
 
-    /// Logs every invocation, answers only the values read this verb makes, and
-    /// refuses everything else -- so no test can pass because the CLI ran some
-    /// other command that happened to succeed, and no test can mutate anything.
+    /// Logs every invocation, answers the read-only release and sandbox reads
+    /// required before a credential mutation, and refuses everything else --
+    /// so no test can pass because the CLI ran some other command that happened
+    /// to succeed, and no test can mutate anything.
     /// Installed under both names: the real path calls `require_on_path`
     /// ("kubectl") before running the upgrade, so a missing kubectl would abort
     /// the sibling paths one step early and for the wrong reason.
@@ -210,6 +211,44 @@ tool=$(basename "$0")
 echo "$tool $*" >> "$SHIM_LOG"
 if [ "$tool" = "helm" ] && [ "$1" = "get" ] && [ "$2" = "values" ]; then
   echo "$FAKE_VALUES"
+  exit 0
+fi
+if [ "$tool" = "helm" ] && [ "$1" = "history" ]; then
+  echo '[{"revision":12,"status":"deployed","chart":"curie-0.8.6"}]'
+  exit 0
+fi
+if [ "$tool" = "helm" ] && [ "$1" = "get" ] && [ "$2" = "manifest" ]; then
+  cat <<'MANIFEST'
+---
+apiVersion: extensions.agents.x-k8s.io/v1beta1
+kind: SandboxTemplate
+metadata:
+  name: curie-runner
+  labels:
+    app.kubernetes.io/component: agent-sandbox
+    app.kubernetes.io/instance: curie
+    app.kubernetes.io/managed-by: Helm
+spec:
+  service: true
+---
+apiVersion: extensions.agents.x-k8s.io/v1beta1
+kind: SandboxWarmPool
+metadata:
+  name: curie-runner-pool
+  labels:
+    app.kubernetes.io/component: agent-sandbox
+    app.kubernetes.io/instance: curie
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 0
+  sandboxTemplateRef:
+    name: curie-runner
+MANIFEST
+  exit 0
+fi
+if [ "$tool" = "kubectl" ] && [ "$1" = "get" ] \
+  && [[ "$2" == sandboxtemplates.extensions.agents.x-k8s.io,* ]]; then
+  echo '{"items":[{"apiVersion":"extensions.agents.x-k8s.io/v1beta1","kind":"SandboxTemplate","metadata":{"name":"curie-runner","labels":{"app.kubernetes.io/component":"agent-sandbox","app.kubernetes.io/instance":"curie","app.kubernetes.io/managed-by":"Helm"},"annotations":{"meta.helm.sh/release-name":"curie","meta.helm.sh/release-namespace":"curie"}},"spec":{"service":true}},{"apiVersion":"extensions.agents.x-k8s.io/v1beta1","kind":"SandboxWarmPool","metadata":{"name":"curie-runner-pool","labels":{"app.kubernetes.io/component":"agent-sandbox","app.kubernetes.io/instance":"curie","app.kubernetes.io/managed-by":"Helm"},"annotations":{"meta.helm.sh/release-name":"curie","meta.helm.sh/release-namespace":"curie"}},"spec":{"replicas":0,"sandboxTemplateRef":{"name":"curie-runner"}}}]}'
   exit 0
 fi
 echo "shim: refusing to execute: $tool $*" >&2
@@ -429,16 +468,20 @@ exit 1
             "the refused run reported the App as configured: {value}"
         );
 
-        // And the refusal must land before any mutation: the values read is the
-        // only thing the CLI was allowed to run.
+        // And the refusal must land before any mutation. The exact-revision
+        // guard first identifies Helm revision 12, then reads values from that
+        // revision so the credential decision and sandbox inventory cannot
+        // observe different release states. Those are the only two commands
+        // allowed before this refusal; in particular no helm upgrade and no
+        // kubectl mutation may run.
         let log = release.invocations();
-        assert!(
-            log.iter().all(|line| line.starts_with("helm get values")),
-            "the guard let something run before refusing: {log:?}"
-        );
-        assert!(
-            log.iter().any(|line| line.starts_with("helm get values")),
-            "the release was never read, so the refusal proves nothing: {log:?}"
+        assert_eq!(
+            log,
+            vec![
+                "helm history curie -n curie -o json --max 256",
+                "helm get values curie -n curie --revision 12 -o json",
+            ],
+            "the guard must perform only the exact-revision read before refusing"
         );
     }
 

--- a/cli/tests/github_app_sandbox_reconciliation.rs
+++ b/cli/tests/github_app_sandbox_reconciliation.rs
@@ -1,0 +1,2179 @@
+//! Real-binary regression coverage for #2270.
+//!
+//! `cluster github-app` mutates a Helm release. SandboxTemplate and
+//! SandboxWarmPool objects are Helm-owned runtime dependencies, so success is
+//! truthful only when every complete pair from the pre-mutation deployed
+//! manifest still exists after the credential change. These tests put
+//! deterministic `helm` and `kubectl` shims on the child process's PATH. The
+//! shims model Helm revision 12, multiple sandbox pairs, live deletion, and
+//! recovery while the real CLI owns parsing, ordering, bounded retries, JSON
+//! errors, and the success decision.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::time::{Duration, Instant};
+
+const RELEASE: &str = "acme-platform";
+const NAMESPACE: &str = "acme-system";
+const REVISION: &str = "12";
+
+const PRE_MANIFEST: &str = r#"---
+apiVersion: extensions.agents.x-k8s.io/v1beta1
+kind: SandboxTemplate
+metadata:
+  name: acme-platform-runner
+  labels:
+    app.kubernetes.io/component: agent-sandbox
+    app.kubernetes.io/instance: acme-platform
+    app.kubernetes.io/managed-by: Helm
+spec:
+  service: true
+---
+apiVersion: extensions.agents.x-k8s.io/v1beta1
+kind: SandboxWarmPool
+metadata:
+  name: acme-platform-runner-pool
+  labels:
+    app.kubernetes.io/component: agent-sandbox
+    app.kubernetes.io/instance: acme-platform
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 0
+  sandboxTemplateRef:
+    name: acme-platform-runner
+---
+apiVersion: extensions.agents.x-k8s.io/v1beta1
+kind: SandboxTemplate
+metadata:
+  name: acme-platform-agent-red-runner
+  labels:
+    app.kubernetes.io/component: agent-sandbox
+    app.kubernetes.io/instance: acme-platform
+    app.kubernetes.io/managed-by: Helm
+spec:
+  service: true
+---
+apiVersion: extensions.agents.x-k8s.io/v1beta1
+kind: SandboxWarmPool
+metadata:
+  name: acme-platform-agent-red-runner-pool
+  labels:
+    app.kubernetes.io/component: agent-sandbox
+    app.kubernetes.io/instance: acme-platform
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 0
+  sandboxTemplateRef:
+    name: acme-platform-agent-red-runner
+"#;
+
+const DROPPED_MANIFEST: &str = r#"---
+apiVersion: extensions.agents.x-k8s.io/v1beta1
+kind: SandboxTemplate
+metadata:
+  name: acme-platform-runner
+  labels:
+    app.kubernetes.io/component: agent-sandbox
+    app.kubernetes.io/instance: acme-platform
+    app.kubernetes.io/managed-by: Helm
+spec:
+  service: true
+---
+apiVersion: extensions.agents.x-k8s.io/v1beta1
+kind: SandboxWarmPool
+metadata:
+  name: acme-platform-runner-pool
+  labels:
+    app.kubernetes.io/component: agent-sandbox
+    app.kubernetes.io/instance: acme-platform
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 0
+  sandboxTemplateRef:
+    name: acme-platform-runner
+"#;
+
+const INCOMPLETE_MANIFEST: &str = r#"---
+apiVersion: extensions.agents.x-k8s.io/v1beta1
+kind: SandboxTemplate
+metadata:
+  name: acme-platform-runner
+spec:
+  service: true
+---
+apiVersion: extensions.agents.x-k8s.io/v1beta1
+kind: SandboxWarmPool
+metadata:
+  name: acme-platform-runner-pool
+spec:
+  replicas: 0
+  sandboxTemplateRef:
+    name: acme-platform-does-not-exist
+"#;
+
+// One script is installed under both tool names. Python keeps the fake
+// cluster's state machine readable without depending on PyYAML or a shell YAML
+// parser. It never receives credential material.
+const TOOL_SHIM: &str = r#"#!/usr/bin/env python3
+import json
+import os
+import re
+import sys
+import time
+from pathlib import Path
+
+tool = Path(sys.argv[0]).name
+args = sys.argv[1:]
+root = Path(os.environ["FAKE_CLUSTER_STATE"])
+scenario = os.environ["FAKE_CLUSTER_SCENARIO"]
+raw = root / "raw.log"
+events = root / "events.log"
+
+with raw.open("a") as stream:
+    stream.write(tool + " " + " ".join(args) + "\n")
+
+def event(value):
+    with events.open("a") as stream:
+        stream.write(value + "\n")
+
+def marker(name):
+    return root / ("live__" + name)
+
+def set_live(name, present=True):
+    path = marker(name)
+    if present:
+        path.touch()
+    elif path.exists():
+        path.unlink()
+
+def metadata(name):
+    return {
+        "name": name,
+        "labels": {
+            "app.kubernetes.io/component": "agent-sandbox",
+            "app.kubernetes.io/instance": "acme-platform",
+            "app.kubernetes.io/managed-by": "Helm",
+        },
+        "annotations": {
+            "meta.helm.sh/release-name": "acme-platform",
+            "meta.helm.sh/release-namespace": "acme-system",
+        },
+    }
+
+objects = {
+    "acme-platform-runner": {
+        "apiVersion": "extensions.agents.x-k8s.io/v1beta1",
+        "kind": "SandboxTemplate",
+        "metadata": metadata("acme-platform-runner"),
+        "spec": {"service": True},
+    },
+    "acme-platform-runner-pool": {
+        "apiVersion": "extensions.agents.x-k8s.io/v1beta1",
+        "kind": "SandboxWarmPool",
+        "metadata": metadata("acme-platform-runner-pool"),
+        "spec": {"replicas": 0, "sandboxTemplateRef": {"name": "acme-platform-runner"}},
+    },
+    "acme-platform-agent-red-runner": {
+        "apiVersion": "extensions.agents.x-k8s.io/v1beta1",
+        "kind": "SandboxTemplate",
+        "metadata": metadata("acme-platform-agent-red-runner"),
+        "spec": {"service": True},
+    },
+    "acme-platform-agent-red-runner-pool": {
+        "apiVersion": "extensions.agents.x-k8s.io/v1beta1",
+        "kind": "SandboxWarmPool",
+        "metadata": metadata("acme-platform-agent-red-runner-pool"),
+        "spec": {"replicas": 0, "sandboxTemplateRef": {"name": "acme-platform-agent-red-runner"}},
+    },
+}
+
+if scenario == "divergent-live":
+    objects["acme-platform-agent-red-runner"]["metadata"]["labels"]["app.kubernetes.io/managed-by"] = "external-controller"
+    objects["acme-platform-agent-red-runner"]["spec"]["service"] = False
+if scenario == "wrong-live-ownership":
+    del objects["acme-platform-agent-red-runner"]["metadata"]["annotations"]["meta.helm.sh/release-namespace"]
+def sandbox_list():
+    items = []
+    for name, value in objects.items():
+        if not marker(name).exists():
+            continue
+        persisted = root / ("created-json__" + name)
+        items.append(json.loads(persisted.read_text()) if persisted.exists() else value)
+    return {"apiVersion": "v1", "items": items}
+
+if tool == "helm":
+    verb = args[0] if args else ""
+    if verb == "history":
+        event("helm:history")
+        if scenario == "history-failure":
+            print("history unavailable", file=sys.stderr)
+            raise SystemExit(1)
+        counter = root / "history-count"
+        count = int(counter.read_text()) if counter.exists() else 0
+        counter.write_text(str(count + 1))
+        if scenario == "history-failure-before-write" and count >= 2:
+            print("history unavailable at the recovery write fence", file=sys.stderr)
+            raise SystemExit(1)
+        if scenario == "history-failure-after-create" and (root / "create-succeeded").exists():
+            print("history unavailable after sandbox create", file=sys.stderr)
+            raise SystemExit(1)
+        if scenario == "history-failure-after-helm" and (root / "upgraded").exists():
+            print("history unavailable after credential mutation", file=sys.stderr)
+            raise SystemExit(1)
+        if scenario == "history-failure-after-rollout" and (root / "rollout-finished").exists():
+            print("history unavailable after API rollout", file=sys.stderr)
+            raise SystemExit(1)
+        if scenario == "pending-head-initial" or (scenario == "pending-head-write-fence" and count > 0):
+            rows = [
+                {"revision": 12, "updated": "2026-01-01T00:00:00Z", "status": "deployed", "chart": "curie-0.8.6", "app_version": "0.8.6", "description": "Upgrade complete"},
+                {"revision": 13, "updated": "2026-01-01T00:01:00Z", "status": "pending-upgrade", "chart": "curie-0.8.6", "app_version": "0.8.6", "description": "Preparing upgrade"},
+            ]
+        elif scenario == "helm-failed-successor-with-loss" and (root / "upgraded").exists():
+            rows = [
+                {"revision": 12, "updated": "2026-01-01T00:00:00Z", "status": "deployed", "chart": "curie-0.8.6", "app_version": "0.8.6", "description": "Upgrade complete"},
+                {"revision": 13, "updated": "2026-01-01T00:01:00Z", "status": "failed", "chart": "curie-0.8.6", "app_version": "0.8.6", "description": "Credential upgrade failed"},
+            ]
+        elif scenario == "failed-head-then-success" and (root / "upgraded").exists():
+            rows = [
+                {"revision": 12, "updated": "2026-01-01T00:00:00Z", "status": "superseded", "chart": "curie-0.8.6", "app_version": "0.8.6", "description": "Upgrade complete"},
+                {"revision": 13, "updated": "2026-01-01T00:01:00Z", "status": "failed", "chart": "curie-0.8.6", "app_version": "0.8.6", "description": "Upgrade failed"},
+                {"revision": 14, "updated": "2026-01-01T00:02:00Z", "status": "deployed", "chart": "curie-0.8.6", "app_version": "0.8.6", "description": "Upgrade complete"},
+            ]
+        elif scenario == "failed-head-then-success":
+            rows = [
+                {"revision": 12, "updated": "2026-01-01T00:00:00Z", "status": "deployed", "chart": "curie-0.8.6", "app_version": "0.8.6", "description": "Upgrade complete"},
+                {"revision": 13, "updated": "2026-01-01T00:01:00Z", "status": "failed", "chart": "curie-0.8.6", "app_version": "0.8.6", "description": "Upgrade failed"},
+            ]
+        elif scenario == "restore-create-then-drift" and (root / "create-succeeded").exists():
+            rows = [
+                {"revision": 12, "status": "superseded", "chart": "curie-0.8.6", "description": "Upgrade complete"},
+                {"revision": 13, "status": "superseded", "chart": "curie-0.8.6", "description": "credential upgrade completed"},
+                {"revision": 14, "status": "deployed", "chart": "curie-0.8.6", "description": "external upgrade completed"},
+            ]
+        elif scenario == "create-then-drift" and (root / "create-succeeded").exists():
+            rows = [
+                {"revision": 12, "status": "superseded", "chart": "curie-0.8.6", "description": "Upgrade complete"},
+                {"revision": 13, "status": "deployed", "chart": "curie-0.8.6", "description": "external upgrade completed"},
+            ]
+        elif scenario in ("revision-drift", "pre-missing-write-fence-drift") and count > 0:
+            rows = [
+                {"revision": 12, "status": "superseded", "chart": "curie-0.8.6", "description": "Upgrade complete"},
+                {"revision": 13, "status": "deployed", "chart": "curie-0.8.6", "description": "Upgrade complete"},
+            ]
+        elif scenario == "post-missing-write-fence-drift" and (root / "upgraded").exists() and count >= 3:
+            rows = [
+                {"revision": 12, "status": "superseded", "chart": "curie-0.8.6", "description": "Upgrade complete"},
+                {"revision": 13, "status": "superseded", "chart": "curie-0.8.6", "description": "credential upgrade completed"},
+                {"revision": 14, "status": "deployed", "chart": "curie-0.8.6", "description": "external upgrade completed"},
+            ]
+        elif scenario == "post-upgrade-interleaving" and (root / "upgraded").exists():
+            rows = [
+                {"revision": 12, "status": "superseded", "chart": "curie-0.8.6", "description": "Upgrade complete"},
+                {"revision": 13, "status": "superseded", "chart": "curie-0.8.6", "description": "external upgrade completed"},
+                {"revision": 14, "status": "deployed", "chart": "curie-0.8.6", "description": "credential upgrade completed"},
+            ]
+        elif scenario == "rollout-revision-drift" and (root / "rollout-started").exists():
+            rows = [
+                {"revision": 12, "status": "superseded", "chart": "curie-0.8.6", "description": "Upgrade complete"},
+                {"revision": 13, "status": "superseded", "chart": "curie-0.8.6", "description": "credential upgrade completed"},
+                {"revision": 14, "status": "deployed", "chart": "curie-0.8.6", "description": "external upgrade completed"},
+            ]
+        elif scenario == "helm-upgrade-hang" and (root / "upgraded").exists():
+            rows = [
+                {"revision": 12, "status": "deployed", "chart": "curie-0.8.6", "description": "Upgrade complete"},
+            ]
+        elif (root / "upgraded").exists():
+            rows = [
+                {"revision": 12, "status": "superseded", "chart": "curie-0.8.6", "description": "Upgrade complete"},
+                {"revision": 13, "status": "deployed", "chart": "curie-0.8.6", "description": "Upgrade complete"},
+            ]
+        else:
+            rows = [
+                {"revision": 12, "status": "deployed", "chart": "curie-0.8.6", "description": "Upgrade complete"},
+            ]
+        head = max(rows, key=lambda row: row["revision"])
+        event("helm:head:" + str(head["revision"]) + ":" + head["status"])
+        deployed = next(row["revision"] for row in rows if row["status"] == "deployed")
+        event("helm:deployed:" + str(deployed))
+        print(json.dumps(rows))
+        raise SystemExit(0)
+    if verb == "get" and len(args) > 1 and args[1] == "values":
+        event("helm:get-values")
+        if scenario == "sandbox-disabled":
+            print(json.dumps({"agentSandbox": {"deploy": False}}))
+        elif scenario == "active-agent-omitted":
+            print(json.dumps({"agentSandbox": {"deploy": True, "connectorSecrets": {"red": {"EXAMPLE_SETTING": "placeholder"}}}}))
+        else:
+            print("{}")
+        raise SystemExit(0)
+    if verb == "get" and len(args) > 1 and args[1] == "manifest":
+        phase = "recovered" if (root / "rolled-back").exists() else ("post" if (root / "upgraded").exists() else "pre")
+        event("helm:get-manifest:" + phase)
+        if scenario in ("empty", "sandbox-disabled"):
+            body = ""
+        elif scenario == "incomplete":
+            body = (root / "incomplete.yaml").read_text()
+        elif scenario == "active-agent-omitted" or (scenario in ("ownership-loss", "restore-create-then-drift") and phase == "post") or (scenario == "create-then-drift" and (root / "create-succeeded").exists()):
+            body = (root / "dropped.yaml").read_text()
+        else:
+            body = (root / "pre.yaml").read_text()
+        sys.stdout.write(body)
+        raise SystemExit(0)
+    if verb == "upgrade":
+        event("helm:upgrade")
+        (root / "upgraded").touch()
+        if scenario in ("ownership-loss", "unreconciled", "helm-upgrade-hang", "post-missing-write-fence-drift", "restore-create-then-drift", "helm-failed-successor-with-loss"):
+            set_live("acme-platform-agent-red-runner", False)
+            set_live("acme-platform-agent-red-runner-pool", False)
+        if scenario == "helm-upgrade-hang":
+            (root / "hung-helm.pid").write_text(str(os.getpid()))
+            print("helm-hang-stdout-placeholder", flush=True)
+            print("helm-hang-stderr-placeholder", file=sys.stderr, flush=True)
+            time.sleep(3)
+            raise SystemExit(124)
+        if scenario == "helm-sensitive-stderr":
+            print(os.environ["FAKE_SENSITIVE_SENTINEL"], file=sys.stderr)
+            raise SystemExit(1)
+        if scenario == "helm-failed-successor-with-loss":
+            print("placeholder credential upgrade failure", file=sys.stderr)
+            raise SystemExit(1)
+        raise SystemExit(0)
+    if verb == "rollback":
+        target = args[2] if len(args) > 2 else "missing"
+        event("helm:rollback:" + target)
+        (root / "rolled-back").touch()
+        for name in objects:
+            set_live(name)
+        raise SystemExit(0)
+    print("unsupported fake helm invocation: " + " ".join(args), file=sys.stderr)
+    raise SystemExit(1)
+
+if tool == "kubectl":
+    joined = " ".join(args)
+    if args and args[0] == "proxy":
+        event("kubectl:proxy")
+        print("placeholder proxy is forbidden", file=sys.stderr)
+        raise SystemExit(1)
+    if " delete " in " " + joined + " ":
+        event("kubectl:delete")
+        print("placeholder delete is forbidden", file=sys.stderr)
+        raise SystemExit(1)
+    if " rollout restart " in " " + joined + " ":
+        event("kubectl:rollout-restart")
+        (root / "rollout-started").touch()
+        if scenario in ("rollout-loss", "rollout-revision-drift", "rollout-restart-failure"):
+            set_live("acme-platform-agent-red-runner", False)
+            set_live("acme-platform-agent-red-runner-pool", False)
+        if scenario == "rollout-restart-failure":
+            print("placeholder rollout restart failure", file=sys.stderr)
+            raise SystemExit(1)
+        raise SystemExit(0)
+    if " rollout status " in " " + joined + " ":
+        event("kubectl:rollout-status")
+        if scenario == "rollout-status-failure":
+            set_live("acme-platform-agent-red-runner", False)
+            set_live("acme-platform-agent-red-runner-pool", False)
+            print("placeholder rollout status failure", file=sys.stderr)
+            raise SystemExit(1)
+        (root / "rollout-finished").touch()
+        raise SystemExit(0)
+    if " get svc " in " " + joined + " ":
+        event("kubectl:get-api-fullname")
+        print("acme-platform-api")
+        raise SystemExit(0)
+    if " get " in " " + joined + " " and ("sandboxtemplate" in joined.lower() or "sandboxwarmpool" in joined.lower()):
+        event("kubectl:get-sandboxes:" + ("post" if (root / "upgraded").exists() else "pre"))
+        if scenario == "kubectl-timeout":
+            print("request deadline exceeded", file=sys.stderr)
+            raise SystemExit(124)
+        if scenario == "kubectl-hang":
+            (root / "hung-kubectl.pid").write_text(str(os.getpid()))
+            time.sleep(30)
+        print(json.dumps(sandbox_list()))
+        raise SystemExit(0)
+    if " create " in " " + joined + " " or " apply " in " " + joined + " ":
+        verb = "apply" if " apply " in " " + joined + " " else "create"
+        source = None
+        for index, value in enumerate(args[:-1]):
+            if value in ("-f", "--filename"):
+                source = args[index + 1]
+                break
+        if source is None:
+            print("fake kubectl expected -f", file=sys.stderr)
+            raise SystemExit(1)
+        body = sys.stdin.read() if source == "-" else Path(source).read_text()
+        kind = re.search(r"(?m)^kind:\s*(\S+)\s*$", body)
+        metadata_block = re.search(r"(?m)^metadata:\s*\n((?:^[ \t]+[^\n]*\n?)*)", body)
+        name = re.search(r"(?m)^[ \t]+name:\s*(\S+)\s*$", metadata_block.group(1)) if metadata_block else None
+        if not kind or not name:
+            print("fake kubectl could not identify created sandbox", file=sys.stderr)
+            raise SystemExit(1)
+        kind = kind.group(1)
+        name = name.group(1)
+        event("kubectl:" + verb + ":" + kind + ":" + name)
+        if verb == "create":
+            (root / ("created__" + name + ".yaml")).write_text(body)
+        if scenario == "concurrent-create" and not (root / "concurrent-create-seen").exists():
+            (root / "concurrent-create-seen").touch()
+            set_live(name)
+            print("already exists", file=sys.stderr)
+            raise SystemExit(1)
+        if scenario != "unreconciled":
+            set_live(name)
+        if verb == "create":
+            operation = re.search(r"(?m)^[ \t]+curietech\.ai/github-app-recovery:\s*(\S+)\s*$", body)
+            objects[name]["metadata"]["uid"] = "00000000-0000-4000-8000-000000000001"
+            objects[name]["metadata"]["resourceVersion"] = "101"
+            if operation:
+                objects[name]["metadata"]["annotations"]["curietech.ai/github-app-recovery"] = operation.group(1)
+            (root / ("created-json__" + name)).write_text(json.dumps(objects[name]))
+            print(json.dumps(objects[name]))
+            if scenario in ("create-then-drift", "history-failure-after-create", "restore-create-then-drift"):
+                (root / "create-succeeded").touch()
+        raise SystemExit(0)
+    print("unsupported fake kubectl invocation: " + joined, file=sys.stderr)
+    raise SystemExit(1)
+
+raise SystemExit(1)
+"#;
+
+struct FakeCluster {
+    dir: tempfile::TempDir,
+}
+
+impl FakeCluster {
+    fn new(scenario: &str) -> Self {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let bin_dir = dir.path().join("bin");
+        fs::create_dir(&bin_dir).expect("create shim dir");
+        for tool in ["helm", "kubectl"] {
+            let path = bin_dir.join(tool);
+            fs::write(&path, TOOL_SHIM).expect("write tool shim");
+            let mut permissions = fs::metadata(&path).expect("stat shim").permissions();
+            permissions.set_mode(0o755);
+            fs::set_permissions(&path, permissions).expect("chmod shim");
+        }
+        fs::write(dir.path().join("pre.yaml"), PRE_MANIFEST).expect("write pre manifest");
+        fs::write(dir.path().join("dropped.yaml"), DROPPED_MANIFEST)
+            .expect("write dropped manifest");
+        fs::write(dir.path().join("incomplete.yaml"), INCOMPLETE_MANIFEST)
+            .expect("write incomplete manifest");
+
+        for name in [
+            "acme-platform-runner",
+            "acme-platform-runner-pool",
+            "acme-platform-agent-red-runner",
+            "acme-platform-agent-red-runner-pool",
+        ] {
+            if scenario != "sandbox-disabled"
+                && (scenario != "pre-missing"
+                    && scenario != "concurrent-create"
+                    && scenario != "pre-missing-write-fence-drift"
+                    && scenario != "create-then-drift"
+                    && scenario != "history-failure-before-write"
+                    && scenario != "history-failure-after-create"
+                    || !name.contains("agent-red"))
+            {
+                fs::write(dir.path().join(format!("live__{name}")), "").expect("seed live object");
+            }
+        }
+        Self { dir }
+    }
+
+    fn state(&self) -> &Path {
+        self.dir.path()
+    }
+
+    fn child_path(&self) -> std::ffi::OsString {
+        let mut dirs = vec![self.state().join("bin")];
+        if let Some(existing) = std::env::var_os("PATH") {
+            dirs.extend(std::env::split_paths(&existing));
+        }
+        std::env::join_paths(dirs).expect("join PATH")
+    }
+
+    fn run(&self, scenario: &str, disconnect: bool) -> Output {
+        self.run_target(scenario, disconnect, RELEASE, NAMESPACE)
+    }
+
+    fn run_target(
+        &self,
+        scenario: &str,
+        disconnect: bool,
+        release: &str,
+        namespace: &str,
+    ) -> Output {
+        let mut args = vec![
+            "cluster",
+            "github-app",
+            "--namespace",
+            namespace,
+            "--release",
+            release,
+            "--chart",
+            "charts/curie",
+            "--json",
+        ];
+        if disconnect {
+            args.push("--disconnect");
+        } else {
+            args.extend([
+                "--app-id",
+                "1234567",
+                "--existing-secret",
+                "acme-github-app",
+                "--existing-secret-key",
+                "app-pem",
+            ]);
+        }
+        let mut command = Command::new(env!("CARGO_BIN_EXE_curie"));
+        command
+            .args(&args)
+            .env("PATH", self.child_path())
+            .env("FAKE_CLUSTER_STATE", self.state())
+            .env("FAKE_CLUSTER_SCENARIO", scenario)
+            .env("FAKE_SENSITIVE_SENTINEL", sensitive_stderr_sentinel());
+        if scenario == "helm-upgrade-hang" {
+            command.env("CURIE_TEST_GITHUB_APP_HELM_TIMEOUT_MS", "150");
+        }
+        command
+            .output()
+            .unwrap_or_else(|error| panic!("run curie {}: {error}", args.join(" ")))
+    }
+
+    fn events(&self) -> Vec<String> {
+        read_lines(self.state().join("events.log"))
+    }
+
+    fn raw(&self) -> Vec<String> {
+        read_lines(self.state().join("raw.log"))
+    }
+}
+
+fn sensitive_stderr_sentinel() -> String {
+    format!(
+        "-----{} PRIVATE KEY----- placeholder-only-sensitive-stderr",
+        "BEGIN"
+    )
+}
+
+fn read_lines(path: PathBuf) -> Vec<String> {
+    fs::read_to_string(path)
+        .unwrap_or_default()
+        .lines()
+        .map(str::to_string)
+        .collect()
+}
+
+fn combined(output: &Output) -> String {
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn process_exited(pid: u32) -> bool {
+    let process = PathBuf::from("/proc").join(pid.to_string());
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while process.exists() && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    !process.exists()
+}
+
+fn stdout_json(output: &Output) -> serde_json::Value {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|error| panic!("stdout must be one JSON object: {error}; stdout: {stdout}"))
+}
+
+fn position(events: &[String], expected: &str) -> usize {
+    events
+        .iter()
+        .position(|event| event == expected)
+        .unwrap_or_else(|| panic!("missing event `{expected}`: {events:?}"))
+}
+
+fn assert_revisioned_pre_manifest_read(raw: &[String]) {
+    assert!(
+        raw.iter().any(|line| {
+            line.starts_with(&format!("helm get manifest {RELEASE} "))
+                && (line.contains(&format!("--revision {REVISION}"))
+                    || line.contains(&format!("--revision={REVISION}")))
+        }),
+        "the pre-mutation desired set was not read from exact Helm revision {REVISION}: {raw:?}"
+    );
+}
+
+fn assert_recreated_as_helm_owned(cluster: &FakeCluster, names: &[&str]) {
+    for name in names {
+        let path = cluster.state().join(format!("created__{name}.yaml"));
+        let body = fs::read_to_string(&path).unwrap_or_else(|error| {
+            panic!("read recreated object body {}: {error}", path.display())
+        });
+        for expected in [
+            "app.kubernetes.io/managed-by: Helm",
+            "meta.helm.sh/release-name: acme-platform",
+            "meta.helm.sh/release-namespace: acme-system",
+        ] {
+            assert!(
+                body.lines().any(|line| line.trim() == expected),
+                "recreated {name} must preserve Helm ownership `{expected}`: {body}"
+            );
+        }
+    }
+}
+
+fn recovery_operation_from_created(cluster: &FakeCluster, name: &str) -> String {
+    let path = cluster.state().join(format!("created__{name}.yaml"));
+    let body = fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("read recovery body {}: {error}", path.display()));
+    let operation = body
+        .lines()
+        .find_map(|line| {
+            line.trim()
+                .strip_prefix("curietech.ai/github-app-recovery:")
+                .map(str::trim)
+        })
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| panic!("created {name} lacks a recovery-operation annotation: {body}"));
+    assert!(
+        uuid::Uuid::parse_str(operation).is_ok(),
+        "the recovery-operation annotation must be a unique operation identifier: {body}"
+    );
+    operation.to_string()
+}
+
+fn assert_history_inspection_without_rollback(value: &serde_json::Value) {
+    let fix = value
+        .get("fix")
+        .and_then(|fix| fix.as_str())
+        .unwrap_or_default();
+    let lower = fix.to_lowercase();
+    assert!(
+        fix.contains("helm history acme-platform -n acme-system")
+            && lower.contains("no automatic")
+            && lower.contains("rollback")
+            && !fix.contains("helm rollback"),
+        "the failure must direct history inspection and explicitly refuse rollback: {value}"
+    );
+}
+
+fn has_request_timeout(command: &str) -> bool {
+    command
+        .split_whitespace()
+        .any(|arg| arg == "--request-timeout" || arg.starts_with("--request-timeout="))
+}
+
+fn assert_no_success(output: &Output, events: &[String]) {
+    let value = stdout_json(output);
+    assert!(
+        value.get("github_app_configured").is_none(),
+        "a failed reconciliation reported success: {value}"
+    );
+    assert!(
+        !combined(output).contains("GitHub App configured"),
+        "a failed reconciliation printed the success note: {}",
+        combined(output)
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|event| event == "kubectl:rollout-restart"),
+        "the API rolled before the sandbox recovery gate passed: {events:?}"
+    );
+}
+
+fn assert_rollout_failure_recovers_sandbox_loss(scenario: &str, failure_event: &str) {
+    let cluster = FakeCluster::new(scenario);
+    let output = cluster.run(scenario, false);
+    let events = cluster.events();
+    assert!(
+        !output.status.success(),
+        "a failed API rollout must return nonzero: {}",
+        combined(&output)
+    );
+    let failure = position(&events, failure_event);
+    let template = position(
+        &events,
+        "kubectl:create:SandboxTemplate:acme-platform-agent-red-runner",
+    );
+    let pool = position(
+        &events,
+        "kubectl:create:SandboxWarmPool:acme-platform-agent-red-runner-pool",
+    );
+    let verified = events
+        .iter()
+        .rposition(|event| event == "kubectl:get-sandboxes:post")
+        .unwrap_or_else(|| panic!("missing post-rollout-failure verification: {events:?}"));
+    assert!(
+        failure < template && template < pool && pool < verified,
+        "rollout failure must still restore template-before-pool and verify: {events:?}"
+    );
+    let recovery_reads = events[failure + 1..]
+        .iter()
+        .filter(|event| event.as_str() == "kubectl:get-sandboxes:post")
+        .count();
+    assert!(
+        (2..=4).contains(&recovery_reads),
+        "rollout-failure reconciliation must verify within its bounded retry budget: {events:?}"
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|event| event.starts_with("helm:rollback:")),
+        "the CLI must not automatically roll back after rollout failure: {events:?}"
+    );
+    let value = stdout_json(&output);
+    let error = value
+        .get("error")
+        .and_then(|error| error.as_str())
+        .unwrap_or_default()
+        .to_lowercase();
+    assert!(
+        error.contains("rollout") && error.contains("sandbox"),
+        "the typed failure must report both rollout failure and sandbox recovery: {value}"
+    );
+    let recovery =
+        format!("helm rollback {RELEASE} {REVISION} -n {NAMESPACE} --wait --timeout 180s");
+    assert!(
+        value
+            .get("fix")
+            .and_then(|fix| fix.as_str())
+            .is_some_and(|fix| fix.contains(&recovery)),
+        "rollout failure must provide deterministic operator recovery: {value}"
+    );
+    assert!(
+        value.get("github_app_configured").is_none()
+            && !combined(&output).contains("GitHub App configured"),
+        "rollout failure emitted success: {value}"
+    );
+}
+
+fn assert_pending_helm_head_blocks_all_mutation(scenario: &str) {
+    let cluster = FakeCluster::new(scenario);
+    let output = cluster.run(scenario, false);
+    let events = cluster.events();
+    assert!(
+        !output.status.success(),
+        "a higher pending Helm head must return nonzero"
+    );
+    assert!(
+        events
+            .iter()
+            .any(|event| event == "helm:head:13:pending-upgrade"),
+        "the fixture did not expose pending-upgrade revision 13: {events:?}"
+    );
+    assert!(
+        !events.iter().any(|event| {
+            event.starts_with("kubectl:create:")
+                || event.starts_with("kubectl:apply:")
+                || event == "helm:upgrade"
+                || event == "kubectl:rollout-restart"
+        }),
+        "the pending Helm operation did not block every mutation path: {events:?}"
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|event| event.starts_with("helm:rollback:")),
+        "a pending Helm operation must never trigger rollback: {events:?}"
+    );
+    let value = stdout_json(&output);
+    let error = value
+        .get("error")
+        .and_then(|error| error.as_str())
+        .unwrap_or_default()
+        .to_lowercase();
+    assert!(
+        error.contains("pending-upgrade") && error.contains("13"),
+        "the refusal must identify the pending head revision and status: {value}"
+    );
+    assert_history_inspection_without_rollback(&value);
+    assert!(
+        value.get("github_app_configured").is_none()
+            && !combined(&output).contains("GitHub App configured"),
+        "pending Helm state emitted false success: {value}"
+    );
+}
+
+#[test]
+fn connect_preserves_every_manifest_pair_and_gates_api_rollout_on_post_upgrade_verification() {
+    let cluster = FakeCluster::new("healthy");
+    let output = cluster.run("healthy", false);
+    let events = cluster.events();
+    assert!(
+        output.status.success(),
+        "healthy connect must succeed: {}; events: {events:?}",
+        combined(&output)
+    );
+    assert_eq!(
+        stdout_json(&output),
+        serde_json::json!({"github_app_configured": true})
+    );
+    assert_revisioned_pre_manifest_read(&cluster.raw());
+
+    let pre_manifest = position(&events, "helm:get-manifest:pre");
+    let upgrade = position(&events, "helm:upgrade");
+    let post_manifest = position(&events, "helm:get-manifest:post");
+    let post_verify = events
+        .iter()
+        .enumerate()
+        .skip(post_manifest + 1)
+        .find_map(|(index, event)| (event == "kubectl:get-sandboxes:post").then_some(index))
+        .unwrap_or_else(|| panic!("missing post-upgrade live verification: {events:?}"));
+    let rollout = position(&events, "kubectl:rollout-restart");
+    assert!(
+        pre_manifest < upgrade && upgrade < post_manifest && post_manifest < post_verify && post_verify < rollout,
+        "required order is snapshot -> Helm mutation -> reconcile/verify -> API rollout: {events:?}"
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|event| event.starts_with("kubectl:create:")),
+        "already-live objects must not be overwritten: {events:?}"
+    );
+}
+
+#[test]
+fn a_pair_deleted_during_api_rollout_is_recreated_and_verified_before_success() {
+    let cluster = FakeCluster::new("rollout-loss");
+    let output = cluster.run("rollout-loss", false);
+    let events = cluster.events();
+    assert!(
+        output.status.success(),
+        "rollout-time loss must be repaired before success: {}; events: {events:?}",
+        combined(&output)
+    );
+    let rollout = position(&events, "kubectl:rollout-restart");
+    let template = position(
+        &events,
+        "kubectl:create:SandboxTemplate:acme-platform-agent-red-runner",
+    );
+    let pool = position(
+        &events,
+        "kubectl:create:SandboxWarmPool:acme-platform-agent-red-runner-pool",
+    );
+    let final_verify = events
+        .iter()
+        .rposition(|event| event == "kubectl:get-sandboxes:post")
+        .unwrap_or_else(|| panic!("missing final live verification: {events:?}"));
+    assert!(
+        rollout < template && template < pool && pool < final_verify,
+        "the post-rollout barrier must repair template-before-pool and verify before success: {events:?}"
+    );
+    assert_eq!(
+        stdout_json(&output),
+        serde_json::json!({"github_app_configured": true})
+    );
+}
+
+#[test]
+fn rollout_restart_failure_still_runs_bounded_sandbox_recovery_before_returning_error() {
+    assert_rollout_failure_recovers_sandbox_loss(
+        "rollout-restart-failure",
+        "kubectl:rollout-restart",
+    );
+}
+
+#[test]
+fn rollout_status_failure_still_runs_bounded_sandbox_recovery_before_returning_error() {
+    assert_rollout_failure_recovers_sandbox_loss(
+        "rollout-status-failure",
+        "kubectl:rollout-status",
+    );
+}
+
+#[test]
+fn a_pending_helm_head_at_initial_snapshot_blocks_every_mutation() {
+    assert_pending_helm_head_blocks_all_mutation("pending-head-initial");
+}
+
+#[test]
+fn a_pending_helm_head_appearing_at_the_write_fence_blocks_every_mutation() {
+    assert_pending_helm_head_blocks_all_mutation("pending-head-write-fence");
+}
+
+#[test]
+fn a_failed_higher_head_allows_the_next_successful_revision_and_normal_rollout() {
+    let cluster = FakeCluster::new("failed-head-then-success");
+    let output = cluster.run("failed-head-then-success", false);
+    let events = cluster.events();
+    assert!(
+        output.status.success(),
+        "a stable failed head must not block the next Helm revision: {}; events: {events:?}",
+        combined(&output)
+    );
+    let failed_head = position(&events, "helm:head:13:failed");
+    let upgrade = position(&events, "helm:upgrade");
+    let deployed = position(&events, "helm:head:14:deployed");
+    let rollout = position(&events, "kubectl:rollout-restart");
+    assert!(
+        failed_head < upgrade && upgrade < deployed && deployed < rollout,
+        "the failed head must remain stable through preflight, then Helm revision 14 must precede rollout: {events:?}"
+    );
+    assert!(
+        !events.iter().any(|event| {
+            event.starts_with("kubectl:create:")
+                || event.starts_with("kubectl:apply:")
+                || event.starts_with("helm:rollback:")
+        }),
+        "the healthy failed-head path unexpectedly rewrote or rolled back sandbox state: {events:?}"
+    );
+    let raw = cluster.raw();
+    assert_revisioned_pre_manifest_read(&raw);
+    assert!(
+        raw.iter().any(|line| {
+            line.starts_with(&format!("helm get manifest {RELEASE} "))
+                && (line.contains("--revision 14") || line.contains("--revision=14"))
+        }),
+        "the post-upgrade sandbox inventory was not read from successful revision 14: {raw:?}"
+    );
+    assert_eq!(
+        stdout_json(&output),
+        serde_json::json!({"github_app_configured": true})
+    );
+}
+
+#[test]
+fn a_revision_drift_before_mutation_refuses_without_upgrading_or_rolling_back_stale_state() {
+    let cluster = FakeCluster::new("revision-drift");
+    let output = cluster.run("revision-drift", false);
+    let events = cluster.events();
+    assert!(
+        !output.status.success(),
+        "a revision that moved after snapshot must not report success: {}",
+        combined(&output)
+    );
+    assert!(
+        events
+            .iter()
+            .filter(|event| *event == "helm:history")
+            .count()
+            >= 2,
+        "the release revision was never rechecked immediately before mutation: {events:?}"
+    );
+    assert!(
+        !events.iter().any(|event| event == "helm:upgrade"),
+        "credential mutation ran against a stale revision snapshot: {events:?}"
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|event| event.starts_with("helm:rollback:")),
+        "the drift path must not roll back revision 12 after another actor deployed 13: {events:?}"
+    );
+    let value = stdout_json(&output);
+    let error = value
+        .get("error")
+        .and_then(|value| value.as_str())
+        .unwrap_or_default();
+    assert!(
+        error.contains("12") && error.contains("13"),
+        "the refusal must name the captured and current revisions: {value}"
+    );
+    assert!(
+        value.get("github_app_configured").is_none(),
+        "revision drift emitted success JSON: {value}"
+    );
+}
+
+#[test]
+fn preflight_repair_refuses_to_create_when_the_release_drifts_at_its_write_fence() {
+    let cluster = FakeCluster::new("pre-missing-write-fence-drift");
+    let output = cluster.run("pre-missing-write-fence-drift", false);
+    let events = cluster.events();
+    assert!(
+        !output.status.success(),
+        "a preflight repair must not write objects from a stale manifest: {}",
+        combined(&output)
+    );
+    position(&events, "helm:deployed:13");
+    assert!(
+        !events.iter().any(|event| {
+            event.starts_with("kubectl:create:") || event.starts_with("kubectl:apply:")
+        }),
+        "preflight revision drift must prevent every stale sandbox write: {events:?}"
+    );
+    assert!(
+        !events.iter().any(|event| event == "helm:upgrade"),
+        "credential mutation ran after preflight revision drift: {events:?}"
+    );
+    let value = stdout_json(&output);
+    let error = value
+        .get("error")
+        .and_then(|error| error.as_str())
+        .unwrap_or_default();
+    assert!(
+        error.contains("12") && error.contains("13") && error.to_lowercase().contains("revision"),
+        "the write-fence refusal must identify captured revision 12 and current revision 13: {value}"
+    );
+    assert!(
+        value.get("github_app_configured").is_none(),
+        "preflight write-fence drift emitted success: {value}"
+    );
+}
+
+#[test]
+fn history_failure_before_recovery_write_refuses_without_writing_or_rollback_guidance() {
+    let cluster = FakeCluster::new("history-failure-before-write");
+    let output = cluster.run("history-failure-before-write", false);
+    let events = cluster.events();
+    assert!(
+        !output.status.success(),
+        "a failed pre-write history fence must return nonzero"
+    );
+    assert!(
+        !events.iter().any(|event| {
+            event.starts_with("kubectl:create:") || event.starts_with("kubectl:apply:")
+        }),
+        "a sandbox was written after the history fence became unreadable: {events:?}"
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|event| event.starts_with("helm:rollback:")),
+        "an unreadable write fence must never trigger automatic rollback: {events:?}"
+    );
+    let value = stdout_json(&output);
+    assert_history_inspection_without_rollback(&value);
+    assert!(
+        value.get("github_app_configured").is_none()
+            && !events.iter().any(|event| event == "helm:upgrade")
+            && !events
+                .iter()
+                .any(|event| event == "kubectl:rollout-restart"),
+        "the failed history fence continued toward mutation or success: {events:?}; {value}"
+    );
+}
+
+#[test]
+fn history_failure_after_create_preserves_operation_marker_guidance_and_stops() {
+    let cluster = FakeCluster::new("history-failure-after-create");
+    let output = cluster.run("history-failure-after-create", false);
+    let events = cluster.events();
+    assert!(
+        !output.status.success(),
+        "an unreadable post-create history fence must return nonzero"
+    );
+    let creates = events
+        .iter()
+        .filter(|event| event.starts_with("kubectl:create:"))
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        creates,
+        vec!["kubectl:create:SandboxTemplate:acme-platform-agent-red-runner"],
+        "post-create history failure must stop after the single identifiable write: {events:?}"
+    );
+    let operation = recovery_operation_from_created(&cluster, "acme-platform-agent-red-runner");
+    let value = stdout_json(&output);
+    let guidance = format!(
+        "{} {}",
+        value
+            .get("error")
+            .and_then(|error| error.as_str())
+            .unwrap_or_default(),
+        value
+            .get("fix")
+            .and_then(|fix| fix.as_str())
+            .unwrap_or_default()
+    );
+    assert!(
+        guidance.contains("acme-platform-agent-red-runner")
+            && guidance.contains("curietech.ai/github-app-recovery")
+            && guidance.contains(&operation)
+            && guidance.contains("helm history acme-platform -n acme-system"),
+        "the failure must retain exact object, operation marker, and history inspection guidance: {value}"
+    );
+    assert!(
+        !guidance.contains("helm rollback")
+            && !events
+                .iter()
+                .any(|event| event.starts_with("helm:rollback:")),
+        "post-create uncertainty must not advertise or perform rollback: {value}; {events:?}"
+    );
+    assert!(
+        value.get("github_app_configured").is_none()
+            && !events.iter().any(|event| event == "helm:upgrade")
+            && !events
+                .iter()
+                .any(|event| event == "kubectl:rollout-restart"),
+        "post-create history failure continued toward mutation, rollout, or success: {events:?}; {value}"
+    );
+}
+
+#[test]
+fn drift_immediately_after_create_never_proxies_deletes_or_continues_stale_recovery() {
+    let cluster = FakeCluster::new("create-then-drift");
+    let output = cluster.run("create-then-drift", false);
+    let events = cluster.events();
+    assert!(
+        !output.status.success(),
+        "revision drift immediately after create must return nonzero: {}",
+        combined(&output)
+    );
+    let create = position(
+        &events,
+        "kubectl:create:SandboxTemplate:acme-platform-agent-red-runner",
+    );
+    let drift = position(&events, "helm:deployed:13");
+    assert!(
+        create < drift,
+        "the fixture must advance Helm only after kubectl reports a successful create: {events:?}"
+    );
+    let creates = events
+        .iter()
+        .filter(|event| event.starts_with("kubectl:create:"))
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        creates,
+        vec!["kubectl:create:SandboxTemplate:acme-platform-agent-red-runner"],
+        "the command continued stale recovery writes after post-create drift: {events:?}"
+    );
+    recovery_operation_from_created(&cluster, "acme-platform-agent-red-runner");
+    assert!(
+        !events.iter().any(|event| event == "kubectl:proxy")
+            && !cluster
+                .raw()
+                .iter()
+                .any(|line| line.starts_with("kubectl proxy ")),
+        "post-create drift must never start a Kubernetes API proxy: {events:?}"
+    );
+    assert!(
+        !events.iter().any(|event| event == "kubectl:delete")
+            && !cluster
+                .raw()
+                .iter()
+                .any(|line| line.starts_with("kubectl delete ")),
+        "post-create drift must preserve the identifiable object for operator recovery: {events:?}"
+    );
+    assert!(
+        !events.iter().any(|event| event == "helm:upgrade")
+            && !events
+                .iter()
+                .any(|event| event == "kubectl:rollout-restart"),
+        "credential mutation or rollout continued after post-create drift: {events:?}"
+    );
+    let value = stdout_json(&output);
+    let error = value
+        .get("error")
+        .and_then(|error| error.as_str())
+        .unwrap_or_default();
+    assert!(
+        error.contains("12") && error.contains("13") && error.to_lowercase().contains("revision"),
+        "the loud failure must identify the post-create revision drift: {value}"
+    );
+    assert!(
+        value.get("github_app_configured").is_none()
+            && !combined(&output).contains("GitHub App configured"),
+        "post-create drift emitted success: {value}"
+    );
+}
+
+#[test]
+fn history_failure_immediately_after_helm_mutation_stops_without_rollback_guidance() {
+    let cluster = FakeCluster::new("history-failure-after-helm");
+    let output = cluster.run("history-failure-after-helm", false);
+    let events = cluster.events();
+    assert!(
+        !output.status.success(),
+        "an unreadable post-mutation revision must return nonzero"
+    );
+    let upgrade = position(&events, "helm:upgrade");
+    let failed_history = events
+        .iter()
+        .rposition(|event| event == "helm:history")
+        .unwrap_or_else(|| panic!("missing post-mutation history read: {events:?}"));
+    assert!(
+        upgrade < failed_history,
+        "the fixture did not fail history after the credential mutation: {events:?}"
+    );
+    assert!(
+        !events[upgrade + 1..].iter().any(|event| {
+            event.starts_with("kubectl:create:")
+                || event.starts_with("kubectl:apply:")
+                || event == "kubectl:rollout-restart"
+        }),
+        "the command continued unsafe writes or rollout without a post-mutation revision: {events:?}"
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|event| event.starts_with("helm:rollback:")),
+        "post-mutation uncertainty must not trigger rollback: {events:?}"
+    );
+    let value = stdout_json(&output);
+    assert_history_inspection_without_rollback(&value);
+    assert!(
+        value.get("github_app_configured").is_none()
+            && !combined(&output).contains("GitHub App configured"),
+        "post-mutation history failure emitted success: {value}"
+    );
+}
+
+#[test]
+fn post_upgrade_revision_interleaving_fails_without_rolling_back_stale_state() {
+    let cluster = FakeCluster::new("post-upgrade-interleaving");
+    let output = cluster.run("post-upgrade-interleaving", false);
+    let events = cluster.events();
+    assert!(
+        !output.status.success(),
+        "an intervening revision after the final preflight must not report success: {}",
+        combined(&output)
+    );
+    assert!(
+        events.iter().any(|event| event == "helm:upgrade"),
+        "the scenario never reached the credential Helm attempt: {events:?}"
+    );
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| *event == "helm:history")
+            .count(),
+        3,
+        "snapshot, immediate pre-mutation recheck, and post-attempt read must all occur: {events:?}"
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|event| event.starts_with("helm:rollback:")),
+        "revision 12 is stale once the release reaches 14 and must never be rolled back automatically: {events:?}"
+    );
+    let drift = position(&events, "helm:deployed:14");
+    assert!(
+        !events[drift + 1..].iter().any(|event| {
+            event.starts_with("kubectl:create:") || event.starts_with("kubectl:apply:")
+        }),
+        "no stale revision-12 sandbox object may be written after revision 14 is observed: {events:?}"
+    );
+    let value = stdout_json(&output);
+    let error = value
+        .get("error")
+        .and_then(|error| error.as_str())
+        .unwrap_or_default();
+    assert!(
+        error.contains("12") && error.contains("14"),
+        "the failure must name captured revision 12 and observed revision 14: {value}"
+    );
+    assert!(
+        value
+            .get("fix")
+            .and_then(|fix| fix.as_str())
+            .is_some_and(|fix| fix.contains("inspect") && !fix.contains("helm rollback")),
+        "interleaved state needs an inspection action, never a stale rollback command: {value}"
+    );
+    assert_no_success(&output, &events);
+}
+
+#[test]
+fn post_upgrade_repair_refuses_to_create_when_the_release_drifts_at_its_write_fence() {
+    let cluster = FakeCluster::new("post-missing-write-fence-drift");
+    let output = cluster.run("post-missing-write-fence-drift", false);
+    let events = cluster.events();
+    assert!(
+        !output.status.success(),
+        "post-upgrade repair must not write revision-13 objects after revision 14 deploys: {}",
+        combined(&output)
+    );
+    position(&events, "helm:deployed:14");
+    assert!(
+        !events.iter().any(|event| {
+            event.starts_with("kubectl:create:") || event.starts_with("kubectl:apply:")
+        }),
+        "post-upgrade revision drift must prevent every stale sandbox write: {events:?}"
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|event| event == "kubectl:rollout-restart"),
+        "the API rollout started after the post-upgrade write fence failed: {events:?}"
+    );
+    let value = stdout_json(&output);
+    let error = value
+        .get("error")
+        .and_then(|error| error.as_str())
+        .unwrap_or_default();
+    assert!(
+        error.contains("13") && error.contains("14") && error.to_lowercase().contains("revision"),
+        "the refusal must identify post-upgrade revision 13 and current revision 14: {value}"
+    );
+    assert!(
+        value.get("github_app_configured").is_none(),
+        "post-upgrade write-fence drift emitted success: {value}"
+    );
+}
+
+#[test]
+fn final_revision_drift_during_api_rollout_fails_without_stale_reconcile_or_rollback() {
+    let cluster = FakeCluster::new("rollout-revision-drift");
+    let output = cluster.run("rollout-revision-drift", false);
+    let events = cluster.events();
+    assert!(
+        !output.status.success(),
+        "release revision 14 appearing during API rollout must prevent success: {}",
+        combined(&output)
+    );
+    let rollout = position(&events, "kubectl:rollout-restart");
+    let drift = position(&events, "helm:deployed:14");
+    assert!(
+        rollout < drift,
+        "the simulated revision drift must occur during the API rollout window: {events:?}"
+    );
+    assert!(
+        !events[drift + 1..].iter().any(|event| {
+            event.starts_with("kubectl:create:") || event.starts_with("kubectl:apply:")
+        }),
+        "captured revision-13 objects were written after current revision 14 was observed: {events:?}"
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|event| event.starts_with("helm:rollback:")),
+        "rollout-time drift must never roll back another actor's revision: {events:?}"
+    );
+    let value = stdout_json(&output);
+    let error = value
+        .get("error")
+        .and_then(|error| error.as_str())
+        .unwrap_or_default();
+    assert!(
+        error.contains("14") && error.to_lowercase().contains("revision"),
+        "the failure must name the newly observed revision 14: {value}"
+    );
+    assert!(
+        value
+            .get("fix")
+            .and_then(|fix| fix.as_str())
+            .is_some_and(|fix| !fix.contains("helm rollback")),
+        "rollout-time drift requires inspection, never stale rollback guidance: {value}"
+    );
+    assert!(
+        value.get("github_app_configured").is_none()
+            && !combined(&output).contains("GitHub App configured"),
+        "rollout-time revision drift emitted success: {value}"
+    );
+}
+
+#[test]
+fn history_failure_after_completed_rollout_stops_without_rollback_or_false_success() {
+    let cluster = FakeCluster::new("history-failure-after-rollout");
+    let output = cluster.run("history-failure-after-rollout", false);
+    let events = cluster.events();
+    assert!(
+        !output.status.success(),
+        "an unreadable post-rollout revision must return nonzero"
+    );
+    let status = position(&events, "kubectl:rollout-status");
+    let failed_history = events
+        .iter()
+        .rposition(|event| event == "helm:history")
+        .unwrap_or_else(|| panic!("missing history read after rollout: {events:?}"));
+    assert!(
+        status < failed_history,
+        "the fixture did not fail history after rollout status completed: {events:?}"
+    );
+    assert!(
+        !events[status + 1..].iter().any(|event| {
+            event.starts_with("kubectl:create:") || event.starts_with("kubectl:apply:")
+        }),
+        "the command wrote sandbox state after losing the post-rollout revision fence: {events:?}"
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|event| event.starts_with("helm:rollback:")),
+        "post-rollout uncertainty must not trigger rollback: {events:?}"
+    );
+    let value = stdout_json(&output);
+    assert_history_inspection_without_rollback(&value);
+    assert!(
+        value.get("github_app_configured").is_none()
+            && !combined(&output).contains("GitHub App configured"),
+        "post-rollout history failure emitted false success: {value}"
+    );
+}
+
+#[test]
+fn a_divergent_live_object_is_refused_without_overwrite_or_credential_mutation() {
+    let cluster = FakeCluster::new("divergent-live");
+    let output = cluster.run("divergent-live", false);
+    let events = cluster.events();
+    assert!(
+        !output.status.success(),
+        "same-name live state with divergent desired content must fail closed"
+    );
+    assert!(
+        !events.iter().any(|event| event == "helm:upgrade"),
+        "a divergent live sandbox reached the credential mutation: {events:?}"
+    );
+    assert!(
+        !events.iter().any(|event| {
+            event.starts_with("kubectl:create:") || event.starts_with("kubectl:apply:")
+        }),
+        "the command overwrote a divergent live object: {events:?}"
+    );
+    let value = stdout_json(&output);
+    assert!(
+        value
+            .get("error")
+            .and_then(|value| value.as_str())
+            .is_some_and(|error| error.contains("acme-platform-agent-red-runner")),
+        "the refusal must name the divergent placeholder object: {value}"
+    );
+}
+
+#[test]
+fn a_live_object_missing_helm_ownership_is_refused_before_mutation_without_overwrite() {
+    let cluster = FakeCluster::new("wrong-live-ownership");
+    let output = cluster.run("wrong-live-ownership", false);
+    let events = cluster.events();
+    assert!(
+        !output.status.success(),
+        "an expected live sandbox without exact Helm ownership must fail closed"
+    );
+    assert!(
+        !events.iter().any(|event| event == "helm:upgrade"),
+        "invalid Helm ownership reached the credential mutation: {events:?}"
+    );
+    assert!(
+        !events.iter().any(|event| {
+            event.starts_with("kubectl:create:") || event.starts_with("kubectl:apply:")
+        }),
+        "invalid Helm ownership was overwritten during preflight: {events:?}"
+    );
+    let value = stdout_json(&output);
+    assert!(
+        value
+            .get("error")
+            .and_then(|value| value.as_str())
+            .is_some_and(|error| {
+                error.contains("acme-platform-agent-red-runner")
+                    && error.to_lowercase().contains("ownership")
+            }),
+        "the refusal must name the object and explain its invalid ownership: {value}"
+    );
+}
+
+#[test]
+fn manifest_ownership_loss_restores_live_state_without_automatic_rollback_and_returns_recovery() {
+    let cluster = FakeCluster::new("ownership-loss");
+    let output = cluster.run("ownership-loss", false);
+    let events = cluster.events();
+    assert!(
+        !output.status.success(),
+        "dropping an active pair from Helm ownership must fail: {}",
+        combined(&output)
+    );
+    let raw = cluster.raw();
+    assert_revisioned_pre_manifest_read(&raw);
+    assert!(
+        !events
+            .iter()
+            .any(|event| event.starts_with("helm:rollback:")),
+        "the command must not roll back release state another actor may have changed: {events:?}"
+    );
+    let post_manifest = position(&events, "helm:get-manifest:post");
+    let template = position(
+        &events,
+        "kubectl:create:SandboxTemplate:acme-platform-agent-red-runner",
+    );
+    let pool = position(
+        &events,
+        "kubectl:create:SandboxWarmPool:acme-platform-agent-red-runner-pool",
+    );
+    let final_live = events
+        .iter()
+        .rposition(|event| event == "kubectl:get-sandboxes:post")
+        .unwrap_or_else(|| panic!("missing restoration verification: {events:?}"));
+    assert!(
+        post_manifest < template && template < pool && pool < final_live,
+        "lost ownership must restore the captured live objects template-before-pool and verify them: {events:?}"
+    );
+    let value = stdout_json(&output);
+    let error = value
+        .get("error")
+        .and_then(|value| value.as_str())
+        .unwrap_or_default()
+        .to_lowercase();
+    assert!(
+        error.contains("ownership") || error.contains("removed"),
+        "the failure must explain the Helm ownership loss: {value}"
+    );
+    let recovery =
+        format!("helm rollback {RELEASE} {REVISION} -n {NAMESPACE} --wait --timeout 180s");
+    assert!(
+        value
+            .get("fix")
+            .and_then(|fix| fix.as_str())
+            .is_some_and(|fix| fix.contains(&recovery)),
+        "the nonzero result must provide the exact operator-controlled rollback: {value}"
+    );
+    for name in [
+        "acme-platform-agent-red-runner",
+        "acme-platform-agent-red-runner-pool",
+    ] {
+        assert!(
+            cluster.state().join(format!("live__{name}")).exists(),
+            "live restoration did not recreate {name}"
+        );
+    }
+    assert_recreated_as_helm_owned(
+        &cluster,
+        &[
+            "acme-platform-agent-red-runner",
+            "acme-platform-agent-red-runner-pool",
+        ],
+    );
+    assert!(
+        !error.contains("rolled back"),
+        "the error falsely claims an automatic rollback occurred: {value}"
+    );
+    assert_no_success(&output, &events);
+}
+
+#[test]
+fn restore_create_then_drift_retains_operation_marker_guidance_without_more_writes() {
+    let cluster = FakeCluster::new("restore-create-then-drift");
+    let output = cluster.run("restore-create-then-drift", false);
+    let events = cluster.events();
+    assert!(
+        !output.status.success(),
+        "revision drift during ownership-loss restoration must return nonzero"
+    );
+    let post_manifest = position(&events, "helm:get-manifest:post");
+    let create = position(
+        &events,
+        "kubectl:create:SandboxTemplate:acme-platform-agent-red-runner",
+    );
+    let drift = position(&events, "helm:deployed:14");
+    assert!(
+        post_manifest < create && create < drift,
+        "the fixture must drift only after the restore-path create succeeds: {events:?}"
+    );
+    let creates = events
+        .iter()
+        .filter(|event| event.starts_with("kubectl:create:"))
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        creates,
+        vec!["kubectl:create:SandboxTemplate:acme-platform-agent-red-runner"],
+        "restore-path drift must stop before a second stale sandbox write: {events:?}"
+    );
+    let operation = recovery_operation_from_created(&cluster, "acme-platform-agent-red-runner");
+    let value = stdout_json(&output);
+    let guidance = format!(
+        "{} {}",
+        value
+            .get("error")
+            .and_then(|error| error.as_str())
+            .unwrap_or_default(),
+        value
+            .get("fix")
+            .and_then(|fix| fix.as_str())
+            .unwrap_or_default()
+    );
+    assert!(
+        guidance.contains("acme-platform-agent-red-runner")
+            && guidance.contains("curietech.ai/github-app-recovery")
+            && guidance.contains(&operation)
+            && guidance.contains("kubectl get sandboxtemplates.extensions.agents.x-k8s.io/acme-platform-agent-red-runner"),
+        "restore-path drift must retain exact operation-marked object inspection guidance: {value}"
+    );
+    assert!(
+        !guidance.contains("helm rollback")
+            && !events
+                .iter()
+                .any(|event| event.starts_with("helm:rollback:")),
+        "restore-path drift must not advertise or perform rollback: {value}; {events:?}"
+    );
+    assert!(
+        value.get("github_app_configured").is_none()
+            && !events
+                .iter()
+                .any(|event| event == "kubectl:rollout-restart")
+            && !combined(&output).contains("GitHub App configured"),
+        "restore-path drift continued to rollout or success: {events:?}; {value}"
+    );
+}
+
+#[test]
+fn a_live_only_missing_pair_is_recreated_template_before_pool_then_verified() {
+    let cluster = FakeCluster::new("pre-missing");
+    let output = cluster.run("pre-missing", false);
+    let events = cluster.events();
+    assert!(
+        output.status.success(),
+        "manifest-backed live repair must allow the connect to continue: {}; events: {events:?}",
+        combined(&output)
+    );
+    let template = position(
+        &events,
+        "kubectl:create:SandboxTemplate:acme-platform-agent-red-runner",
+    );
+    let pool = position(
+        &events,
+        "kubectl:create:SandboxWarmPool:acme-platform-agent-red-runner-pool",
+    );
+    let upgrade = position(&events, "helm:upgrade");
+    assert!(
+        template < pool && pool < upgrade,
+        "pre-existing loss must be repaired template-before-pool and verified before mutation: {events:?}"
+    );
+    assert!(
+        events[..upgrade]
+            .iter()
+            .filter(|event| event.as_str() == "kubectl:get-sandboxes:pre")
+            .count()
+            >= 2,
+        "the pre-mutation repair was not verified before Helm ran: {events:?}"
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|event| event.starts_with("kubectl:apply:")),
+        "recovery must create only absent objects, never apply over live objects: {events:?}"
+    );
+    let raw = cluster.raw();
+    let sandbox_gets: Vec<&String> = raw
+        .iter()
+        .filter(|line| line.starts_with("kubectl get sandboxtemplates.extensions.agents.x-k8s.io,"))
+        .collect();
+    assert!(
+        !sandbox_gets.is_empty()
+            && sandbox_gets
+                .iter()
+                .all(|command| has_request_timeout(command)),
+        "every sandbox list must have an explicit request timeout: {raw:?}"
+    );
+    let sandbox_creates: Vec<&String> = raw
+        .iter()
+        .filter(|line| line.starts_with("kubectl create "))
+        .collect();
+    assert!(
+        !sandbox_creates.is_empty()
+            && sandbox_creates
+                .iter()
+                .all(|command| has_request_timeout(command)),
+        "every sandbox create must have an explicit request timeout: {raw:?}"
+    );
+}
+
+#[test]
+fn a_concurrent_creator_wins_the_race_and_a_relist_allows_recovery_to_continue() {
+    let cluster = FakeCluster::new("concurrent-create");
+    let output = cluster.run("concurrent-create", false);
+    let events = cluster.events();
+    assert!(
+        output.status.success(),
+        "create nonzero is recoverable when a relist proves the object now exists: {}; events: {events:?}",
+        combined(&output)
+    );
+    let first_create = position(
+        &events,
+        "kubectl:create:SandboxTemplate:acme-platform-agent-red-runner",
+    );
+    let pool_create = position(
+        &events,
+        "kubectl:create:SandboxWarmPool:acme-platform-agent-red-runner-pool",
+    );
+    assert!(
+        events[first_create + 1..pool_create]
+            .iter()
+            .any(|event| event == "kubectl:get-sandboxes:pre"),
+        "a failed create was not relisted before continuing: {events:?}"
+    );
+}
+
+#[test]
+fn unreconciled_post_upgrade_loss_is_bounded_actionable_and_blocks_success() {
+    let cluster = FakeCluster::new("unreconciled");
+    let output = cluster.run("unreconciled", false);
+    let events = cluster.events();
+    assert!(
+        !output.status.success(),
+        "a create that never becomes observable must fail: {}",
+        combined(&output)
+    );
+    let creates = events
+        .iter()
+        .filter(|event| event.starts_with("kubectl:create:"))
+        .count();
+    assert_eq!(
+        creates, 6,
+        "three exact recovery rounds over two absent objects must issue six creates: {events:?}"
+    );
+    let value = stdout_json(&output);
+    let fix = value
+        .get("fix")
+        .and_then(|value| value.as_str())
+        .unwrap_or_default();
+    let recovery =
+        format!("helm rollback {RELEASE} {REVISION} -n {NAMESPACE} --wait --timeout 180s");
+    assert!(
+        fix.contains(&recovery),
+        "the bounded failure must carry the deterministic recovery command `{recovery}`: {value}"
+    );
+    let error = value
+        .get("error")
+        .and_then(|value| value.as_str())
+        .unwrap_or_default();
+    assert!(
+        error.contains("acme-platform-agent-red-runner")
+            || error.contains("acme-platform-agent-red-runner-pool"),
+        "the failure must name an unreconciled placeholder object: {value}"
+    );
+    assert_no_success(&output, &events);
+}
+
+#[test]
+fn a_kubectl_deadline_is_explicit_and_returns_an_actionable_nonzero_result() {
+    let cluster = FakeCluster::new("kubectl-timeout");
+    let output = cluster.run("kubectl-timeout", false);
+    let events = cluster.events();
+    assert!(
+        !output.status.success(),
+        "a sandbox read deadline must return nonzero rather than report success"
+    );
+    let raw = cluster.raw();
+    let command = raw
+        .iter()
+        .find(|line| line.starts_with("kubectl get sandboxtemplates.extensions.agents.x-k8s.io,"))
+        .unwrap_or_else(|| panic!("sandbox list was never attempted: {raw:?}"));
+    assert!(
+        has_request_timeout(command),
+        "the kubectl request had no explicit request-timeout: {command}"
+    );
+    let value = stdout_json(&output);
+    let error = value
+        .get("error")
+        .and_then(|value| value.as_str())
+        .unwrap_or_default()
+        .to_lowercase();
+    assert!(
+        error.contains("timed out") || error.contains("deadline"),
+        "the bounded wall-clock/request deadline must be visible: {value}"
+    );
+    assert_history_inspection_without_rollback(&value);
+    assert_no_success(&output, &events);
+}
+
+#[test]
+fn a_hung_kubectl_is_killed_by_the_wall_clock_deadline_and_returns_actionable_failure() {
+    let cluster = FakeCluster::new("kubectl-hang");
+    let started = Instant::now();
+    let output = cluster.run("kubectl-hang", false);
+    let elapsed = started.elapsed();
+    let events = cluster.events();
+    assert!(
+        elapsed >= Duration::from_secs(6) && elapsed < Duration::from_secs(12),
+        "the CLI must enforce its approximately seven-second process deadline; elapsed={elapsed:?}"
+    );
+    assert!(
+        !output.status.success(),
+        "a hung kubectl must return actionable nonzero"
+    );
+    let value = stdout_json(&output);
+    assert!(
+        value
+            .get("error")
+            .and_then(|error| error.as_str())
+            .is_some_and(|error| error.contains("wall-clock") || error.contains("timed out")),
+        "the outer process deadline must be visible in the error: {value}"
+    );
+    assert_history_inspection_without_rollback(&value);
+
+    let pid: u32 = fs::read_to_string(cluster.state().join("hung-kubectl.pid"))
+        .expect("hanging kubectl wrote its pid")
+        .trim()
+        .parse()
+        .expect("kubectl pid is numeric");
+    assert!(
+        process_exited(pid),
+        "timed-out kubectl child {pid} remained alive after the CLI returned"
+    );
+    assert_no_success(&output, &events);
+}
+
+#[test]
+fn agent_sandbox_disabled_with_no_resources_preserves_the_sibling_credential_path() {
+    let cluster = FakeCluster::new("sandbox-disabled");
+    let output = cluster.run("sandbox-disabled", false);
+    let events = cluster.events();
+    assert!(
+        output.status.success(),
+        "agentSandbox.deploy=false has no sandbox set to preserve: {}; events: {events:?}",
+        combined(&output)
+    );
+    assert!(
+        events.iter().any(|event| event == "helm:get-values"),
+        "the zero-resource path did not prove agentSandbox.deploy=false from Helm values: {events:?}"
+    );
+    assert!(
+        position(&events, "helm:upgrade") < position(&events, "kubectl:rollout-restart"),
+        "the disabled sibling path did not retain Helm-before-rollout ordering: {events:?}"
+    );
+    assert_eq!(
+        stdout_json(&output),
+        serde_json::json!({"github_app_configured": true})
+    );
+}
+
+#[test]
+fn active_connector_agent_missing_from_the_captured_manifest_refuses_before_mutation() {
+    let cluster = FakeCluster::new("active-agent-omitted");
+    let output = cluster.run("active-agent-omitted", false);
+    let events = cluster.events();
+    assert!(
+        !output.status.success(),
+        "an active connector agent absent from revision 12's manifest must fail"
+    );
+    assert!(
+        events.iter().any(|event| event == "helm:get-values"),
+        "active per-agent inventory was not derived independently from Helm values: {events:?}"
+    );
+    assert!(
+        !events.iter().any(|event| event == "helm:upgrade"),
+        "credential mutation ran without the active agent's sandbox pair: {events:?}"
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|event| event.starts_with("helm:rollback:")),
+        "a pre-mutation inventory refusal must not roll back unrelated state: {events:?}"
+    );
+    let value = stdout_json(&output);
+    let error = value
+        .get("error")
+        .and_then(|value| value.as_str())
+        .unwrap_or_default();
+    assert!(
+        error.contains("red")
+            && (error.contains("acme-platform-agent-red-runner")
+                || error.contains("SandboxTemplate/SandboxWarmPool")),
+        "the refusal must name the missing placeholder agent or pair: {value}"
+    );
+    assert!(
+        value.get("github_app_configured").is_none(),
+        "the refused inventory emitted success JSON: {value}"
+    );
+}
+
+#[test]
+fn failed_helm_successor_restores_the_stable_active_revision_before_returning_error() {
+    let cluster = FakeCluster::new("helm-failed-successor-with-loss");
+    let output = cluster.run("helm-failed-successor-with-loss", false);
+    let events = cluster.events();
+    assert!(
+        !output.status.success(),
+        "a failed credential Helm revision must return nonzero"
+    );
+    let upgrade = position(&events, "helm:upgrade");
+    let failed_head = events
+        .iter()
+        .enumerate()
+        .skip(upgrade + 1)
+        .find_map(|(index, event)| (event == "helm:head:13:failed").then_some(index))
+        .unwrap_or_else(|| panic!("missing failed Helm successor after mutation: {events:?}"));
+    let post_manifest = events
+        .iter()
+        .enumerate()
+        .skip(failed_head + 1)
+        .find_map(|(index, event)| (event == "helm:get-manifest:post").then_some(index))
+        .unwrap_or_else(|| panic!("active revision manifest was not reread: {events:?}"));
+    let template = position(
+        &events,
+        "kubectl:create:SandboxTemplate:acme-platform-agent-red-runner",
+    );
+    let pool = position(
+        &events,
+        "kubectl:create:SandboxWarmPool:acme-platform-agent-red-runner-pool",
+    );
+    let verified = events
+        .iter()
+        .rposition(|event| event == "kubectl:get-sandboxes:post")
+        .unwrap_or_else(|| panic!("missing final failed-successor verification: {events:?}"));
+    assert!(
+        upgrade < failed_head
+            && failed_head < post_manifest
+            && post_manifest < template
+            && template < pool
+            && pool < verified,
+        "stable failed successor recovery must reread active revision 12, restore template-before-pool, and verify: {events:?}"
+    );
+    assert!(
+        events[upgrade + 1..=verified]
+            .iter()
+            .filter(|event| event.as_str() == "helm:head:13:failed")
+            .count()
+            >= 5,
+        "failed head 13 was not repeatedly fenced as stable during recovery: {events:?}"
+    );
+    let revision_12_manifests = cluster
+        .raw()
+        .into_iter()
+        .filter(|line| {
+            line.starts_with(&format!("helm get manifest {RELEASE} "))
+                && (line.contains("--revision 12") || line.contains("--revision=12"))
+        })
+        .count();
+    assert!(
+        revision_12_manifests >= 2,
+        "recovery must use the immutable active revision 12 manifest before and after the failed successor"
+    );
+    assert_recreated_as_helm_owned(
+        &cluster,
+        &[
+            "acme-platform-agent-red-runner",
+            "acme-platform-agent-red-runner-pool",
+        ],
+    );
+    recovery_operation_from_created(&cluster, "acme-platform-agent-red-runner");
+    recovery_operation_from_created(&cluster, "acme-platform-agent-red-runner-pool");
+    assert!(
+        !events
+            .iter()
+            .any(|event| event.starts_with("helm:rollback:")),
+        "the stable failed successor must not be rolled back automatically: {events:?}"
+    );
+    let value = stdout_json(&output);
+    let error = value
+        .get("error")
+        .and_then(|error| error.as_str())
+        .unwrap_or_default()
+        .to_lowercase();
+    assert!(
+        error.contains("helm mutation failed")
+            && error.contains("sandbox")
+            && (error.contains("restored") || error.contains("reconciled")),
+        "the typed failure must report failed Helm mutation and completed sandbox recovery: {value}"
+    );
+    let recovery =
+        format!("helm rollback {RELEASE} {REVISION} -n {NAMESPACE} --wait --timeout 180s");
+    assert!(
+        value
+            .get("fix")
+            .and_then(|fix| fix.as_str())
+            .is_some_and(|fix| fix.contains(&recovery)),
+        "the stable failed successor must provide exact prior-revision rollback guidance: {value}"
+    );
+    assert!(
+        value.get("github_app_configured").is_none()
+            && !events
+                .iter()
+                .any(|event| event == "kubectl:rollout-restart")
+            && !combined(&output).contains("GitHub App configured"),
+        "failed Helm successor recovery rolled the API or emitted success: {events:?}; {value}"
+    );
+}
+
+#[test]
+fn helm_failure_output_cannot_echo_sensitive_stderr_into_the_json_error() {
+    let cluster = FakeCluster::new("helm-sensitive-stderr");
+    let output = cluster.run("helm-sensitive-stderr", false);
+    let events = cluster.events();
+    assert!(
+        !output.status.success(),
+        "the injected Helm failure must return nonzero"
+    );
+    let sentinel = sensitive_stderr_sentinel();
+    assert!(
+        !combined(&output).contains(&sentinel),
+        "the CLI echoed sensitive-looking Helm stderr into its user-visible error"
+    );
+    let value = stdout_json(&output);
+    assert!(
+        value
+            .get("error")
+            .and_then(|value| value.as_str())
+            .is_some_and(|error| error.contains("Helm mutation failed")),
+        "the scrubbed error must still identify the failing operation: {value}"
+    );
+    assert_no_success(&output, &events);
+}
+
+#[test]
+fn a_hung_helm_upgrade_times_out_restores_live_pairs_and_returns_recovery() {
+    let cluster = FakeCluster::new("helm-upgrade-hang");
+    let started = Instant::now();
+    let output = cluster.run("helm-upgrade-hang", false);
+    let elapsed = started.elapsed();
+    let events = cluster.events();
+    assert!(
+        elapsed < Duration::from_secs(2),
+        "debug timeout override must bound the hanging Helm child near 150ms; elapsed={elapsed:?}"
+    );
+    assert!(
+        !output.status.success(),
+        "a timed-out Helm upgrade must return nonzero"
+    );
+    let pid: u32 = fs::read_to_string(cluster.state().join("hung-helm.pid"))
+        .expect("hanging Helm shim wrote its pid")
+        .trim()
+        .parse()
+        .expect("Helm pid is numeric");
+    assert!(
+        process_exited(pid),
+        "timed-out Helm child {pid} remained alive after the CLI returned"
+    );
+    assert!(
+        events
+            .iter()
+            .filter(|event| event.as_str() == "helm:deployed:12")
+            .count()
+            >= 3
+            && !events.iter().any(|event| event == "helm:deployed:13"),
+        "post-timeout history must still identify captured revision 12: {events:?}"
+    );
+    let template = position(
+        &events,
+        "kubectl:create:SandboxTemplate:acme-platform-agent-red-runner",
+    );
+    let pool = position(
+        &events,
+        "kubectl:create:SandboxWarmPool:acme-platform-agent-red-runner-pool",
+    );
+    let verified = events
+        .iter()
+        .rposition(|event| event == "kubectl:get-sandboxes:post")
+        .unwrap_or_else(|| panic!("missing post-timeout live verification: {events:?}"));
+    assert!(
+        position(&events, "helm:upgrade") < template && template < pool && pool < verified,
+        "timeout recovery must restore template-before-pool and verify: {events:?}"
+    );
+    assert_recreated_as_helm_owned(
+        &cluster,
+        &[
+            "acme-platform-agent-red-runner",
+            "acme-platform-agent-red-runner-pool",
+        ],
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|event| event.starts_with("helm:rollback:")),
+        "the CLI must not automatically roll back an uncertain Helm attempt: {events:?}"
+    );
+    let value = stdout_json(&output);
+    let recovery =
+        format!("helm rollback {RELEASE} {REVISION} -n {NAMESPACE} --wait --timeout 180s");
+    assert!(
+        value
+            .get("fix")
+            .and_then(|fix| fix.as_str())
+            .is_some_and(|fix| fix.contains(&recovery)),
+        "the timed-out mutation must provide exact deterministic recovery: {value}"
+    );
+    let text = combined(&output);
+    assert!(
+        !text.contains("helm-hang-stdout-placeholder")
+            && !text.contains("helm-hang-stderr-placeholder"),
+        "raw Helm output escaped into the structured failure"
+    );
+    assert_no_success(&output, &events);
+}
+
+#[test]
+fn an_empty_deployed_manifest_refuses_before_the_credential_mutation() {
+    let cluster = FakeCluster::new("empty");
+    let output = cluster.run("empty", false);
+    let events = cluster.events();
+    assert!(!output.status.success(), "empty expected set must fail");
+    assert_no_success(&output, &events);
+    assert!(
+        !events.iter().any(|event| event == "helm:upgrade"),
+        "an empty expected sandbox set reached the credential mutation: {events:?}"
+    );
+    let value = stdout_json(&output);
+    assert!(
+        value
+            .get("fix")
+            .and_then(|value| value.as_str())
+            .is_some_and(|fix| fix.contains("helm get manifest")),
+        "empty-manifest refusal must say how to inspect the release: {value}"
+    );
+}
+
+#[test]
+fn copy_paste_history_hint_shell_quotes_crafted_target_arguments() {
+    let release = "acme release;false";
+    let namespace = "acme-system;false";
+
+    let history_cluster = FakeCluster::new("history-failure");
+    let history_output = history_cluster.run_target("history-failure", false, release, namespace);
+    assert!(!history_output.status.success());
+    let history_fix = stdout_json(&history_output)
+        .get("fix")
+        .and_then(|fix| fix.as_str())
+        .unwrap_or_default()
+        .to_string();
+    assert!(
+        history_fix.contains("helm history 'acme release;false' -n 'acme-system;false' -o json"),
+        "the history recovery hint is not safe to copy into a shell: {history_fix}"
+    );
+}
+
+#[test]
+fn copy_paste_manifest_hint_shell_quotes_crafted_target_arguments() {
+    let release = "acme release;false";
+    let namespace = "acme-system;false";
+    let manifest_cluster = FakeCluster::new("empty");
+    let manifest_output = manifest_cluster.run_target("empty", false, release, namespace);
+    assert!(!manifest_output.status.success());
+    let manifest_fix = stdout_json(&manifest_output)
+        .get("fix")
+        .and_then(|fix| fix.as_str())
+        .unwrap_or_default()
+        .to_string();
+    assert!(
+        manifest_fix.contains(
+            "helm get manifest 'acme release;false' -n 'acme-system;false' --revision 12"
+        ),
+        "the manifest recovery hint is not safe to copy into a shell: {manifest_fix}"
+    );
+}
+
+#[test]
+fn an_incomplete_template_pool_reference_refuses_before_mutation() {
+    let cluster = FakeCluster::new("incomplete");
+    let output = cluster.run("incomplete", false);
+    let events = cluster.events();
+    assert!(
+        !output.status.success(),
+        "incomplete expected set must fail"
+    );
+    assert_no_success(&output, &events);
+    assert!(
+        !events.iter().any(|event| event == "helm:upgrade"),
+        "an invalid template/pool pair reached the credential mutation: {events:?}"
+    );
+}
+
+#[test]
+fn disconnect_uses_the_same_sandbox_barrier_and_retains_its_sibling_output() {
+    let cluster = FakeCluster::new("healthy");
+    let output = cluster.run("healthy", true);
+    let events = cluster.events();
+    assert!(
+        output.status.success(),
+        "healthy disconnect must succeed through the same barrier: {}; events: {events:?}",
+        combined(&output)
+    );
+    assert_eq!(
+        stdout_json(&output),
+        serde_json::json!({"github_app_configured": false})
+    );
+    assert!(
+        position(&events, "helm:get-manifest:pre") < position(&events, "helm:upgrade")
+            && position(&events, "helm:get-manifest:post")
+                < position(&events, "kubectl:rollout-restart"),
+        "disconnect bypassed the shared sandbox recovery barrier: {events:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- snapshot the active Helm revision plus history head/status before changing GitHub App credentials
- validate and preserve every release-owned generic and per-agent SandboxTemplate/SandboxWarmPool pair
- reconcile live-only loss in bounded template-before-pool order, while refusing divergent ownership, pending/concurrent Helm state, and stale writes
- run the same final sandbox barrier after Helm and API rollout failures, and return typed recovery guidance without false success

Closes #2270

Fix pin: cli/tests/github_app_sandbox_reconciliation.rs::connect_preserves_every_manifest_pair_and_gates_api_rollout_on_post_upgrade_verification

## Verification

Behavioral candidate and PR head: `8bf9800e` (rebased onto `next`; mechanical Rust 1.98 boxing is folded into the behavior commit so the fix-pin reversal stays independently verifiable)

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo +1.98.0 clippy --locked --all-targets -- -D warnings`
- `cargo test` (includes 36 focused reconciliation cases, 8 sibling GitHub App wiring cases, and chart assertions)
- `uv run pytest -q tools/fix-pin-ci/tests/test_fix_pin_ci.py` (106 passed; new `v0.8.6` test observed failing before the mapping was added)
- `bash scripts/check-docs.sh`
- `curie dev verify-fix-pin 8bf9800e cli/tests/github_app_sandbox_reconciliation.rs::connect_preserves_every_manifest_pair_and_gates_api_rollout_on_post_upgrade_verification` -> `PINNED`
- blocking reviews for both the behavioral implementation and the Rust 1.98 follow-up: code `APPROVE`, scope `CLEAN`, security `SECURE`

## E2E tiers

| Tier | Decision | Evidence |
| --- | --- | --- |
| skill | N/A | No plugin packaging, runner loop, ACI event, skill eval, or skill check changes. |
| local | Required / PASS | `CURIE_E2E_TIERS=local curie dev e2e-ladder --json` passed with the candidate binary, fake model, and a task-isolated Compose project; containers and volumes were removed afterward. |
| local-release | N/A | No released image identity, install asset, version pin, or release Compose change. |
| cluster | Required / PASS | Fresh disposable kind cluster exercised the real candidate CLI, Helm upgrade, sandbox CRDs/controller, and API rollout; cluster was deleted afterward. |
| live provider | N/A | No model routing, provider credential, auth, token, or cost behavior changed. |
| external integration | N/A | The change does not call or alter the GitHub API; it changes Kubernetes reconciliation around the credential Helm operation. |

Cluster positive: a release containing the generic pair and one placeholder per-agent pair advanced from revision 1 to deployed revision 2, rolled the API, and retained all four live objects with exact Helm ownership.

Cluster failure-negative: a throwaway chart variant omitted the per-agent pair and advanced to revision 3. The command restored both missing live objects with recovery markers, returned one nonzero `{error, fix}` result naming the exact prior-revision rollback, and did not roll the API or report success. The release manifest still omitted the pair, proving the check discriminates the regression rather than merely counting existing objects.
