### PR TITLE
Fix durable workspace replacement continuity

### DIFF
--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -457,7 +457,7 @@ substrate = SandboxSubstrate(
 
 handle = substrate.claim(thread_ts)   # existing live route, or warm-pool claim
 # handle.base_url -> http://<serviceFQDN>:8080  (dial from inside the cluster)
-substrate.suspend(thread_ts, history_ref=sdk_session_id)
+substrate.suspend(thread_ts, history_ref=thread_history_ref)
 handle = substrate.resume(thread_ts)  # new claim, CURIE_HISTORY_REF injected
 substrate.release(thread_ts)          # delete claim -> sandbox+pod reaped
 substrate.reap_orphans()              # periodic tick: claims with no live route
@@ -487,6 +487,16 @@ Contract notes the kernel must know:
   state-store URL (`.../state/transcript/<thread_key>`), so there is nothing to
   capture off the ACI `final` frame and no frozen-contract change (ADR-0029); do
   not reintroduce a frame-captured resume id.
+- **Late workspace acquisition is a fenced cold replacement.** A repository URL
+  on an existing generic route proceeds only when the bearer-authenticated old
+  runner is idle, its complete structured history is durable, and it is not
+  suspended on an approval or unresolved side-effect boundary. The worker
+  revalidates that status after workspace preparation, then cold-creates a
+  candidate carrying the same logical session and history reference. Before the
+  affinity compare-and-swap, the candidate must attest its exact session and
+  sandbox identities, a ready idle state, durable history, and cwd `/workspace`.
+  Any unreadable or mismatched status deletes only the unexposed candidate and
+  leaves the generic route authoritative (ADR-0136).
 - **Reaping.** `release()` deletes the claim (the claim owns its sandbox and
   pod). Routes that expire in Valkey leave orphaned claims; `reap_orphans()`
   lists claims labeled `curietech.ai/managed-by=curie-sandbox-substrate` and

--- a/apps/worker/src/curie_worker/kernel.py
+++ b/apps/worker/src/curie_worker/kernel.py
@@ -2691,6 +2691,45 @@ class Kernel:
         return (
             status.get("turn_active") is False
             and status.get("history_durable") is True
+            and status.get("status")
+            in {
+                SessionStatus.DONE.value,
+                SessionStatus.IDLE_AWAITING_INPUT.value,
+            }
+        )
+
+    async def _workspace_candidate_ready(
+        self, handle: SandboxHandle, *, remaining_s: float | None = None
+    ) -> bool:
+        """Fail closed unless this exact candidate booted the managed checkout."""
+
+        if not handle.token:
+            logger.warning(
+                "workspace handoff refused an unauthenticated candidate runner at %s",
+                handle.base_url,
+            )
+            return False
+        try:
+            status = await self._runner.status(
+                handle.base_url,
+                token=handle.token,
+                remaining_s=remaining_s,
+            )
+        except Exception as exc:  # noqa: BLE001 - unreadable is never safe to expose
+            logger.warning(
+                "could not attest workspace handoff candidate at %s: %r",
+                handle.base_url,
+                exc,
+            )
+            return False
+        return (
+            status.get("session_id") == handle.session_id
+            and status.get("sandbox_id") == handle.sandbox_id
+            and status.get("managed_workspace") is True
+            and status.get("cwd") == "/workspace"
+            and status.get("ready") is True
+            and status.get("turn_active") is False
+            and status.get("history_durable") is True
             and status.get("status") == SessionStatus.IDLE_AWAITING_INPUT.value
         )
 
@@ -2736,6 +2775,7 @@ class Kernel:
                 )
                 return existing
             handoff_revalidation: Callable[[], None] | None = None
+            candidate_validation: Callable[[SandboxHandle], None] | None = None
             if replace_handle is not None:
                 loop = asyncio.get_running_loop()
 
@@ -2775,6 +2815,42 @@ class Kernel:
                         )
 
                 handoff_revalidation = revalidate_before_handoff
+
+                def validate_candidate(candidate: SandboxHandle) -> None:
+                    """Attest the newly ready runner before the substrate route CAS."""
+
+                    probe_remaining_s = handoff_remaining()
+                    probe = asyncio.run_coroutine_threadsafe(
+                        self._workspace_candidate_ready(
+                            candidate, remaining_s=probe_remaining_s
+                        ),
+                        loop,
+                    )
+                    request_ceiling = self._config.runner_total_timeout_s
+                    if probe_remaining_s is not None:
+                        request_ceiling = max(
+                            0.0, min(request_ceiling, probe_remaining_s)
+                        )
+                    try:
+                        ready = probe.result(
+                            timeout=(
+                                request_ceiling
+                                + _HANDOFF_REVALIDATION_BRIDGE_GRACE_S
+                            )
+                        )
+                    except Exception as exc:
+                        probe.cancel()
+                        raise ThreadBusyError(
+                            f"thread {thread_key} workspace handoff candidate "
+                            "could not be attested"
+                        ) from exc
+                    if not ready:
+                        raise ThreadBusyError(
+                            f"thread {thread_key} workspace handoff candidate "
+                            "did not attest the expected managed checkout"
+                        )
+
+                candidate_validation = validate_candidate
             # Prepare once, then let the substrate decide cold claim versus
             # suspended-route resume. Either branch materializes the same fresh,
             # verified archive before the runner can start.
@@ -2787,6 +2863,7 @@ class Kernel:
                 repo_full_name=workspace_repo,
                 replace_handle=replace_handle,
                 revalidate_before_handoff=handoff_revalidation,
+                validate_candidate=candidate_validation,
             )
             if not isinstance(workspace_claim.handle, SandboxHandle):
                 raise WorkspacePreparationError(

--- a/apps/worker/src/curie_worker/kernel.py
+++ b/apps/worker/src/curie_worker/kernel.py
@@ -29,7 +29,7 @@ import logging
 import re
 import time
 import uuid
-from collections.abc import Callable
+from collections.abc import Callable, Coroutine
 from contextvars import ContextVar
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -2779,6 +2779,35 @@ class Kernel:
             if replace_handle is not None:
                 loop = asyncio.get_running_loop()
 
+                def run_status_probe(
+                    probe_factory: Callable[
+                        [float | None], Coroutine[Any, Any, bool]
+                    ],
+                    *,
+                    failure: str,
+                ) -> bool:
+                    """Run one bounded runner probe from the coordinator thread."""
+
+                    probe_remaining_s = handoff_remaining()
+                    probe = asyncio.run_coroutine_threadsafe(
+                        probe_factory(probe_remaining_s), loop
+                    )
+                    request_ceiling = self._config.runner_total_timeout_s
+                    if probe_remaining_s is not None:
+                        request_ceiling = max(
+                            0.0, min(request_ceiling, probe_remaining_s)
+                        )
+                    try:
+                        return probe.result(
+                            timeout=(
+                                request_ceiling
+                                + _HANDOFF_REVALIDATION_BRIDGE_GRACE_S
+                            )
+                        )
+                    except Exception as exc:
+                        probe.cancel()
+                        raise ThreadBusyError(failure) from exc
+
                 def revalidate_before_handoff() -> None:
                     """Bridge the coordinator thread back to the runner's loop.
 
@@ -2789,25 +2818,15 @@ class Kernel:
                     free to service the authenticated status request.
                     """
 
-                    probe_remaining_s = handoff_remaining()
-                    probe = asyncio.run_coroutine_threadsafe(
-                        self._workspace_handoff_ready(
+                    ready = run_status_probe(
+                        lambda probe_remaining_s: self._workspace_handoff_ready(
                             replace_handle, remaining_s=probe_remaining_s
                         ),
-                        loop,
+                        failure=(
+                            f"thread {thread_key} workspace handoff fence "
+                            "could not be revalidated"
+                        ),
                     )
-                    request_ceiling = self._config.runner_total_timeout_s
-                    if probe_remaining_s is not None:
-                        request_ceiling = max(0.0, min(request_ceiling, probe_remaining_s))
-                    try:
-                        ready = probe.result(
-                            timeout=(request_ceiling + _HANDOFF_REVALIDATION_BRIDGE_GRACE_S)
-                        )
-                    except Exception as exc:
-                        probe.cancel()
-                        raise ThreadBusyError(
-                            f"thread {thread_key} workspace handoff fence could not be revalidated"
-                        ) from exc
                     if not ready:
                         raise ThreadBusyError(
                             f"thread {thread_key} lost its durable workspace "
@@ -2819,31 +2838,15 @@ class Kernel:
                 def validate_candidate(candidate: SandboxHandle) -> None:
                     """Attest the newly ready runner before the substrate route CAS."""
 
-                    probe_remaining_s = handoff_remaining()
-                    probe = asyncio.run_coroutine_threadsafe(
-                        self._workspace_candidate_ready(
+                    ready = run_status_probe(
+                        lambda probe_remaining_s: self._workspace_candidate_ready(
                             candidate, remaining_s=probe_remaining_s
                         ),
-                        loop,
-                    )
-                    request_ceiling = self._config.runner_total_timeout_s
-                    if probe_remaining_s is not None:
-                        request_ceiling = max(
-                            0.0, min(request_ceiling, probe_remaining_s)
-                        )
-                    try:
-                        ready = probe.result(
-                            timeout=(
-                                request_ceiling
-                                + _HANDOFF_REVALIDATION_BRIDGE_GRACE_S
-                            )
-                        )
-                    except Exception as exc:
-                        probe.cancel()
-                        raise ThreadBusyError(
+                        failure=(
                             f"thread {thread_key} workspace handoff candidate "
                             "could not be attested"
-                        ) from exc
+                        ),
+                    )
                     if not ready:
                         raise ThreadBusyError(
                             f"thread {thread_key} workspace handoff candidate "

--- a/apps/worker/src/curie_worker/kernel.py
+++ b/apps/worker/src/curie_worker/kernel.py
@@ -328,6 +328,14 @@ _MIN_ATTEMPT_BUDGET_S = 5.0
 _RECLAIM_PREFLIGHT_IDLE_TIMEOUT_S = 5.0
 _RECLAIM_PREFLIGHT_POLL_S = 0.05
 
+# ``WorkspaceClaimCoordinator`` performs blocking clone/archive/upload work on
+# a worker thread. Its final handoff guard schedules one bounded runner-status
+# read back onto the owning asyncio loop, then waits on that thread. The HTTP
+# request already has the runner client's delivery-clamped timeout; this small
+# grace covers scheduling and returning its result without leaving a worker
+# thread blocked forever if the loop stops servicing callbacks.
+_HANDOFF_REVALIDATION_BRIDGE_GRACE_S = 1.0
+
 
 class ReclaimPreflightUnsafe(RuntimeError):
     """A transferred delivery could not be proven safe to re-execute.
@@ -2538,6 +2546,7 @@ class Kernel:
                 else None
             ),
             agent_name=agent_name,
+            remaining_s=remaining_s,
         )
         retained_live_route = existing_handle is not None and handle == existing_handle
         claim_ms = round((time.monotonic() - claim_started) * 1000)
@@ -2682,7 +2691,7 @@ class Kernel:
         return (
             status.get("turn_active") is False
             and status.get("history_durable") is True
-            and status.get("status") != SessionStatus.AWAITING_APPROVAL.value
+            and status.get("status") == SessionStatus.IDLE_AWAITING_INPUT.value
         )
 
     async def _claim_or_resume(
@@ -2694,6 +2703,7 @@ class Kernel:
         workspace_repo: str | None = None,
         replace_handle: SandboxHandle | None = None,
         agent_name: str | None = None,
+        remaining_s: float | None = None,
     ) -> SandboxHandle:
         # A live route is an adopt/steer, not a session start. Preparing before
         # this check would clone on every threaded steer and could even replace
@@ -2703,6 +2713,16 @@ class Kernel:
         # lookup-then-claim gap, where the route could disappear and ``claim``
         # would create a sandbox without a freshly prepared workspace ref.
         if workspace_deployment_id is not None:
+            handoff_budget_started = time.monotonic()
+
+            def handoff_remaining() -> float | None:
+                if remaining_s is None:
+                    return None
+                return max(
+                    0.0,
+                    remaining_s - (time.monotonic() - handoff_budget_started),
+                )
+
             if self._workspace is None:
                 raise WorkspacePreparationError(
                     "wiring", "selected workspace has no trusted claim-time preparer"
@@ -2715,6 +2735,46 @@ class Kernel:
                     ttl_seconds=self._route_ttl_seconds,
                 )
                 return existing
+            handoff_revalidation: Callable[[], None] | None = None
+            if replace_handle is not None:
+                loop = asyncio.get_running_loop()
+
+                def revalidate_before_handoff() -> None:
+                    """Bridge the coordinator thread back to the runner's loop.
+
+                    The coordinator invokes this after preparation and durable
+                    ownership staging, immediately before ``substrate.handoff``.
+                    Blocking here is safe: ``_claim_or_resume`` is awaiting the
+                    coordinator via ``to_thread``, so the owning event loop is
+                    free to service the authenticated status request.
+                    """
+
+                    probe_remaining_s = handoff_remaining()
+                    probe = asyncio.run_coroutine_threadsafe(
+                        self._workspace_handoff_ready(
+                            replace_handle, remaining_s=probe_remaining_s
+                        ),
+                        loop,
+                    )
+                    request_ceiling = self._config.runner_total_timeout_s
+                    if probe_remaining_s is not None:
+                        request_ceiling = max(0.0, min(request_ceiling, probe_remaining_s))
+                    try:
+                        ready = probe.result(
+                            timeout=(request_ceiling + _HANDOFF_REVALIDATION_BRIDGE_GRACE_S)
+                        )
+                    except Exception as exc:
+                        probe.cancel()
+                        raise ThreadBusyError(
+                            f"thread {thread_key} workspace handoff fence could not be revalidated"
+                        ) from exc
+                    if not ready:
+                        raise ThreadBusyError(
+                            f"thread {thread_key} lost its durable workspace "
+                            "handoff boundary during preparation"
+                        )
+
+                handoff_revalidation = revalidate_before_handoff
             # Prepare once, then let the substrate decide cold claim versus
             # suspended-route resume. Either branch materializes the same fresh,
             # verified archive before the runner can start.
@@ -2726,6 +2786,7 @@ class Kernel:
                 agent_name=agent_name,
                 repo_full_name=workspace_repo,
                 replace_handle=replace_handle,
+                revalidate_before_handoff=handoff_revalidation,
             )
             if not isinstance(workspace_claim.handle, SandboxHandle):
                 raise WorkspacePreparationError(

--- a/apps/worker/src/curie_worker/sandbox/docker.py
+++ b/apps/worker/src/curie_worker/sandbox/docker.py
@@ -120,11 +120,21 @@ _SDK_PASSTHROUGH_ENV = (
 _OAUTH_TOKEN_PREFIX = "sk-ant-oat"
 # Env keys the worker sets explicitly or forwards specially, so the generic
 # value loop must not also emit them: the plugin dir and sandbox id are set
-# explicitly, the bundle ref named a RustFS object the worker already fetched
-# (the runner never fetches), and the credential is forwarded by name (never as
-# a value in the argv). CURIE_BUNDLE_VERSION is deliberately not in this set:
-# it is the agent-readable version_label and must reach the child env (#2174).
-_WORKER_OWNED_ENV = frozenset({BUNDLE_REF_ENV, PLUGIN_DIR_ENV, "CURIE_SANDBOX_ID", CREDENTIALS_ENV})
+# explicitly, the bundle ref names a RustFS object the worker already fetched,
+# workspace ref/digest name the archive the worker already fetched and mounted,
+# and the credential is forwarded by name (never as a value in the argv).
+# CURIE_BUNDLE_VERSION is deliberately not in this set: it is the agent-readable
+# version_label and must reach the child env (#2174).
+_WORKER_OWNED_ENV = frozenset(
+    {
+        BUNDLE_REF_ENV,
+        PLUGIN_DIR_ENV,
+        "CURIE_SANDBOX_ID",
+        CREDENTIALS_ENV,
+        WORKSPACE_REF_ENV,
+        WORKSPACE_SHA256_ENV,
+    }
+)
 
 
 def _parse_created(raw: str) -> datetime | None:

--- a/apps/worker/src/curie_worker/sandbox/substrate.py
+++ b/apps/worker/src/curie_worker/sandbox/substrate.py
@@ -26,6 +26,7 @@ import logging
 import secrets
 import time
 import uuid
+from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
 
 from aci_protocol import BootEnv
@@ -253,6 +254,7 @@ class SandboxSubstrate:
         env: dict[str, str],
         workspace_repo: str,
         agent_name: str | None = None,
+        validate_candidate: Callable[[SandboxHandle], None] | None = None,
     ) -> SandboxHandle:
         """Cold-create a workspace runner, then CAS it over one generic route.
 
@@ -277,6 +279,15 @@ class SandboxSubstrate:
             generation=expected.generation + 1,
             publish=False,
         )
+        try:
+            if validate_candidate is not None:
+                validate_candidate(candidate)
+        except Exception:
+            # The candidate is ready but still unrouted. Refusal retires only
+            # that unexposed claim; the old route remains authoritative until
+            # the generation CAS below succeeds.
+            self._k8s.delete_claim(candidate.claim_name)
+            raise
         record = RouteRecord(handle=candidate, state=RouteState.LIVE)
         if not self._affinity.replace_if_generation(
             thread_key,

--- a/apps/worker/src/curie_worker/sandbox/substrate.py
+++ b/apps/worker/src/curie_worker/sandbox/substrate.py
@@ -626,8 +626,14 @@ class SandboxSubstrate:
             namespace=config.namespace,
             service_fqdn=bound.service_fqdn or "",
             port=bound.port if bound.port is not None else config.runner_port,
-            session_id=session_id or f"thread-{thread_hash}",
-            history_ref=history_ref,
+            # The route must describe the runner that actually booted.  Bound
+            # claims receive their authoritative identity in this exact env;
+            # the explicit values remain fallbacks for lifecycle callers that
+            # preserve identity without carrying those optional env entries.
+            session_id=(env or {}).get(SESSION_ENV)
+            or session_id
+            or f"thread-{thread_hash}",
+            history_ref=(env or {}).get(HISTORY_ENV) or history_ref,
             token=(env or {}).get(RUNNER_TOKEN_ENV, ""),
             workspace_repo=workspace_repo,
             generation=generation,

--- a/apps/worker/src/curie_worker/workspace.py
+++ b/apps/worker/src/curie_worker/workspace.py
@@ -1218,8 +1218,17 @@ class WorkspaceClaimCoordinator:
         agent_name: str | None = None,
         repo_full_name: str | None = None,
         replace_handle: Any | None = None,
+        revalidate_before_handoff: Callable[[], None] | None = None,
     ) -> WorkspaceClaimResult:
-        """Prepare once, then cold-claim or resume a suspended route."""
+        """Prepare once, then cold-claim or resume a suspended route.
+
+        ``revalidate_before_handoff`` is the late-replacement linearization
+        guard. It runs after the archive is verified and durably staged,
+        immediately before the substrate begins replacing the old route. A
+        refusal raises through the ordinary pre-exposure rollback path, so the
+        old route stays authoritative and the newly staged archive is not
+        orphaned.
+        """
 
         prepared = self.preparer.prepare(
             deployment_id=deployment_id,
@@ -1244,6 +1253,8 @@ class WorkspaceClaimCoordinator:
                     raise WorkspacePreparationError(
                         "claim", "late workspace handoff requires a selected repository"
                     )
+                if revalidate_before_handoff is not None:
+                    revalidate_before_handoff()
                 handle = self.substrate.handoff(
                     thread_key,
                     expected=replace_handle,

--- a/apps/worker/src/curie_worker/workspace.py
+++ b/apps/worker/src/curie_worker/workspace.py
@@ -1219,6 +1219,7 @@ class WorkspaceClaimCoordinator:
         repo_full_name: str | None = None,
         replace_handle: Any | None = None,
         revalidate_before_handoff: Callable[[], None] | None = None,
+        validate_candidate: Callable[[Any], None] | None = None,
     ) -> WorkspaceClaimResult:
         """Prepare once, then cold-claim or resume a suspended route.
 
@@ -1227,7 +1228,8 @@ class WorkspaceClaimCoordinator:
         immediately before the substrate begins replacing the old route. A
         refusal raises through the ordinary pre-exposure rollback path, so the
         old route stays authoritative and the newly staged archive is not
-        orphaned.
+        orphaned. ``validate_candidate`` runs after the replacement runner is
+        ready but before its route CAS; refusal follows the same rollback path.
         """
 
         prepared = self.preparer.prepare(
@@ -1255,12 +1257,18 @@ class WorkspaceClaimCoordinator:
                     )
                 if revalidate_before_handoff is not None:
                     revalidate_before_handoff()
+                candidate_guard = (
+                    {"validate_candidate": validate_candidate}
+                    if validate_candidate is not None
+                    else {}
+                )
                 handle = self.substrate.handoff(
                     thread_key,
                     expected=replace_handle,
                     env=claim_env,
                     workspace_repo=repo_full_name,
                     agent_name=agent_name,
+                    **candidate_guard,
                 )
             else:
                 try:

--- a/apps/worker/tests/kernel/test_kernel.py
+++ b/apps/worker/tests/kernel/test_kernel.py
@@ -779,6 +779,141 @@ def test_late_workspace_selection_defers_without_steering_until_boundary_is_safe
     asyncio.run(go())
 
 
+@pytest.mark.parametrize(
+    "status_payload",
+    [
+        pytest.param(
+            {"turn_active": False, "history_durable": True},
+            id="missing-status",
+        ),
+        pytest.param(
+            {
+                "status": "newer-runner-status",
+                "turn_active": False,
+                "history_durable": True,
+            },
+            id="unrecognized-status",
+        ),
+    ],
+)
+def test_workspace_handoff_boundary_rejects_missing_or_unrecognized_status(
+    make_harness,
+    status_payload: dict[str, object],
+) -> None:
+    """A shape-drifted status is not evidence that replacement is safe."""
+
+    async def go() -> None:
+        async with make_harness() as h:
+            old = h.substrate.claim(
+                _thread_key("tUnknownHandoffStatus"),
+                env={"CURIE_RUNNER_TOKEN": "workspace-test-token"},
+            )
+
+            async def status(*_args: object, **_kwargs: object) -> dict[str, object]:
+                return dict(status_payload)
+
+            h.kernel._runner.status = status  # type: ignore[method-assign]
+
+            assert not await h.kernel._workspace_handoff_ready(old)
+
+    asyncio.run(go())
+
+
+@pytest.mark.parametrize(
+    "unsafe_status",
+    [
+        pytest.param(
+            {
+                "status": "idle-awaiting-input",
+                "turn_active": True,
+                "history_durable": True,
+            },
+            id="became-busy",
+        ),
+        pytest.param(
+            {
+                "status": "idle-awaiting-input",
+                "turn_active": False,
+                "history_durable": False,
+            },
+            id="became-undurable",
+        ),
+    ],
+)
+def test_late_workspace_handoff_revalidates_boundary_before_route_replacement(
+    make_harness,
+    unsafe_status: dict[str, object],
+) -> None:
+    """Preparation latency cannot spend a one-shot safe-boundary observation."""
+
+    deployment_id = uuid.uuid4()
+
+    async def go() -> None:
+        async with make_harness(binding=_workspace_binding(deployment_id)) as h:
+            thread_key = _thread_key("tBoundaryChangedDuringPreparation")
+            old = h.substrate.claim(
+                thread_key,
+                env={"CURIE_RUNNER_TOKEN": "workspace-test-token"},
+            )
+            status_payloads = [
+                {
+                    "status": "idle-awaiting-input",
+                    "turn_active": False,
+                    "history_durable": True,
+                },
+                unsafe_status,
+            ]
+            status_reads = 0
+            ordering: list[str] = []
+
+            async def status(*_args: object, **_kwargs: object) -> dict[str, object]:
+                nonlocal status_reads
+                status_reads += 1
+                ordering.append(f"status-{status_reads}")
+                return dict(status_payloads[min(status_reads - 1, 1)])
+
+            h.kernel._runner.status = status  # type: ignore[method-assign]
+
+            class WorkspaceProbe:
+                replacements = 0
+
+                def select_repository(self, **_kwargs: object) -> str:
+                    return "acme-corp/acme-bot"
+
+                def claim_or_resume_with_handle(self, **_kwargs: object) -> object:
+                    self.replacements += 1
+                    ordering.append("prepared-and-verified")
+                    revalidate = _kwargs.get("revalidate_before_handoff")
+                    assert callable(revalidate), (
+                        "late handoff must pass a post-preparation revalidation callback"
+                    )
+                    revalidate()
+                    ordering.append("handoff")
+                    raise AssertionError(
+                        "a refused revalidation must prevent route replacement"
+                    )
+
+            probe = WorkspaceProbe()
+            h.kernel._workspace = probe  # type: ignore[assignment]
+
+            with pytest.raises(ThreadBusyError):
+                await h.kernel.process_event(
+                    _qevent(
+                        "Use https://github.com/acme-corp/acme-bot",
+                        thread="tBoundaryChangedDuringPreparation",
+                    )
+                )
+
+            assert status_reads == 2
+            assert probe.replacements == 1
+            assert ordering == ["status-1", "prepared-and-verified", "status-2"]
+            assert h.substrate.lookup(thread_key) == old
+            assert len(h.fake_k8s.claim_envs) == 1
+            assert h.runner.opened == []
+
+    asyncio.run(go())
+
+
 def test_workspace_route_metadata_mismatch_fails_closed_without_claim_or_model(
     make_harness,
 ) -> None:

--- a/apps/worker/tests/kernel/test_kernel.py
+++ b/apps/worker/tests/kernel/test_kernel.py
@@ -34,7 +34,7 @@ from curie_worker.behaviorpacks import BehaviorPacks
 from curie_worker.kernel import ThreadBusyError
 from curie_worker.reply_sink import TargetRoute
 from curie_worker.runner_client import RunnerError, TurnStream
-from curie_worker.sandbox import QuotaRejection
+from curie_worker.sandbox import QuotaRejection, SandboxHandle
 from curie_worker.workspace import (
     WorkspacePreparationError,
     WorkspaceSelectionRefused,
@@ -74,6 +74,19 @@ def _qevent(
 
 def _thread_key(thread: str) -> str:
     return f"slack:C1:{thread}"
+
+
+def _safe_candidate_status(candidate: SandboxHandle) -> dict[str, object]:
+    return {
+        "status": SessionStatus.IDLE_AWAITING_INPUT.value,
+        "ready": True,
+        "turn_active": False,
+        "history_durable": True,
+        "session_id": candidate.session_id,
+        "sandbox_id": candidate.sandbox_id,
+        "managed_workspace": True,
+        "cwd": "/workspace",
+    }
 
 
 async def _wait_until(pred: Callable[[], bool], timeout: float = 5.0) -> None:
@@ -780,6 +793,40 @@ def test_late_workspace_selection_defers_without_steering_until_boundary_is_safe
 
 
 @pytest.mark.parametrize(
+    "session_status",
+    [
+        pytest.param(SessionStatus.DONE, id="done"),
+        pytest.param(SessionStatus.IDLE_AWAITING_INPUT, id="idle-awaiting-input"),
+    ],
+)
+def test_workspace_handoff_boundary_accepts_completed_durable_status(
+    make_harness,
+    session_status: SessionStatus,
+) -> None:
+    """Both real post-turn terminal statuses are safe when replay is durable."""
+
+    async def go() -> None:
+        async with make_harness() as h:
+            old = h.substrate.claim(
+                _thread_key("tCompletedHandoffStatus"),
+                env={"CURIE_RUNNER_TOKEN": "workspace-test-token"},
+            )
+
+            async def status(*_args: object, **_kwargs: object) -> dict[str, object]:
+                return {
+                    "status": session_status.value,
+                    "turn_active": False,
+                    "history_durable": True,
+                }
+
+            h.kernel._runner.status = status  # type: ignore[method-assign]
+
+            assert await h.kernel._workspace_handoff_ready(old)
+
+    asyncio.run(go())
+
+
+@pytest.mark.parametrize(
     "status_payload",
     [
         pytest.param(
@@ -794,9 +841,17 @@ def test_late_workspace_selection_defers_without_steering_until_boundary_is_safe
             },
             id="unrecognized-status",
         ),
+        pytest.param(
+            {
+                "status": SessionStatus.AWAITING_APPROVAL.value,
+                "turn_active": False,
+                "history_durable": True,
+            },
+            id="awaiting-approval",
+        ),
     ],
 )
-def test_workspace_handoff_boundary_rejects_missing_or_unrecognized_status(
+def test_workspace_handoff_boundary_rejects_unsafe_or_unrecognized_status(
     make_harness,
     status_payload: dict[str, object],
 ) -> None:
@@ -857,7 +912,7 @@ def test_late_workspace_handoff_revalidates_boundary_before_route_replacement(
             )
             status_payloads = [
                 {
-                    "status": "idle-awaiting-input",
+                    "status": SessionStatus.DONE.value,
                     "turn_active": False,
                     "history_durable": True,
                 },
@@ -910,6 +965,196 @@ def test_late_workspace_handoff_revalidates_boundary_before_route_replacement(
             assert h.substrate.lookup(thread_key) == old
             assert len(h.fake_k8s.claim_envs) == 1
             assert h.runner.opened == []
+
+    asyncio.run(go())
+
+
+def test_late_workspace_candidate_attestation_uses_exact_authenticated_handle(
+    make_harness,
+) -> None:
+    deployment_id = uuid.uuid4()
+
+    async def go() -> None:
+        async with make_harness(binding=_workspace_binding(deployment_id)) as h:
+            thread_key = _thread_key("tCandidateAttestation")
+            old = h.substrate.claim(
+                thread_key,
+                env={
+                    "CURIE_RUNNER_TOKEN": "old-runner-token",
+                    "CURIE_SESSION_ID": "logical-session",
+                    "CURIE_HISTORY_REF": "history/tCandidateAttestation",
+                },
+            )
+            candidate = SandboxHandle(
+                thread_key=thread_key,
+                claim_name="candidate-claim",
+                sandbox_name="candidate-sandbox",
+                namespace=old.namespace,
+                service_fqdn="candidate.test-ns.svc.cluster.local",
+                port=old.port,
+                session_id=old.session_id,
+                history_ref=old.history_ref,
+                token="candidate-runner-token",
+                workspace_repo="acme-corp/acme-bot",
+                generation=old.generation + 1,
+            )
+            ordering: list[str] = []
+            status_calls: list[tuple[str, str | None]] = []
+
+            async def status(
+                base_url: str,
+                *,
+                token: str | None = None,
+                remaining_s: float | None = None,
+            ) -> dict[str, object]:
+                del remaining_s
+                status_calls.append((base_url, token))
+                if base_url == old.base_url:
+                    ordering.append("old-runner-revalidated")
+                    return {
+                        "status": SessionStatus.DONE.value,
+                        "turn_active": False,
+                        "history_durable": True,
+                    }
+                assert base_url == candidate.base_url
+                assert token == candidate.token
+                ordering.append("candidate-attested")
+                return _safe_candidate_status(candidate)
+
+            h.kernel._runner.status = status  # type: ignore[method-assign]
+
+            class WorkspaceProbe:
+                def claim_or_resume_with_handle(self, **kwargs: object) -> object:
+                    ordering.append("prepared-and-verified")
+                    revalidate = kwargs.get("revalidate_before_handoff")
+                    assert callable(revalidate)
+                    revalidate()
+                    validate_candidate = kwargs.get("validate_candidate")
+                    assert callable(validate_candidate), (
+                        "kernel must bridge candidate attestation into the coordinator"
+                    )
+                    validate_candidate(candidate)
+                    return SimpleNamespace(handle=candidate, prepared=None)
+
+            h.kernel._workspace = WorkspaceProbe()  # type: ignore[assignment]
+
+            result = await h.kernel._claim_or_resume(
+                thread_key,
+                {
+                    "CURIE_SESSION_ID": old.session_id,
+                    "CURIE_HISTORY_REF": old.history_ref or "",
+                },
+                workspace_deployment_id=deployment_id,
+                workspace_repo="acme-corp/acme-bot",
+                replace_handle=old,
+            )
+
+            assert result is candidate
+            assert ordering == [
+                "prepared-and-verified",
+                "old-runner-revalidated",
+                "candidate-attested",
+            ]
+            assert status_calls == [
+                (old.base_url, old.token),
+                (candidate.base_url, candidate.token),
+            ]
+
+    asyncio.run(go())
+
+
+@pytest.mark.parametrize(
+    ("field", "invalid_value"),
+    [
+        pytest.param("session_id", "other-session", id="session-id"),
+        pytest.param("sandbox_id", "other-sandbox", id="sandbox-id"),
+        pytest.param("managed_workspace", False, id="managed-workspace"),
+        pytest.param("cwd", "/tmp", id="cwd"),
+        pytest.param("ready", False, id="ready"),
+        pytest.param("status", SessionStatus.DONE.value, id="status"),
+        pytest.param("turn_active", True, id="turn-active"),
+        pytest.param("history_durable", False, id="history-durable"),
+    ],
+)
+def test_late_workspace_candidate_attestation_mismatch_refuses_handoff(
+    make_harness,
+    field: str,
+    invalid_value: object,
+) -> None:
+    deployment_id = uuid.uuid4()
+
+    async def go() -> None:
+        async with make_harness(binding=_workspace_binding(deployment_id)) as h:
+            thread_key = _thread_key("tCandidateMismatch")
+            old = h.substrate.claim(
+                thread_key,
+                env={
+                    "CURIE_RUNNER_TOKEN": "old-runner-token",
+                    "CURIE_SESSION_ID": "logical-session",
+                    "CURIE_HISTORY_REF": "history/tCandidateMismatch",
+                },
+            )
+            candidate = SandboxHandle(
+                thread_key=thread_key,
+                claim_name="candidate-claim",
+                sandbox_name="candidate-sandbox",
+                namespace=old.namespace,
+                service_fqdn="candidate.test-ns.svc.cluster.local",
+                port=old.port,
+                session_id=old.session_id,
+                history_ref=old.history_ref,
+                token="candidate-runner-token",
+                workspace_repo="acme-corp/acme-bot",
+                generation=old.generation + 1,
+            )
+
+            async def status(
+                base_url: str,
+                *,
+                token: str | None = None,
+                remaining_s: float | None = None,
+            ) -> dict[str, object]:
+                del remaining_s
+                if base_url == old.base_url:
+                    assert token == old.token
+                    return {
+                        "status": SessionStatus.DONE.value,
+                        "turn_active": False,
+                        "history_durable": True,
+                    }
+                assert base_url == candidate.base_url
+                assert token == candidate.token
+                payload = _safe_candidate_status(candidate)
+                payload[field] = invalid_value
+                return payload
+
+            h.kernel._runner.status = status  # type: ignore[method-assign]
+
+            class WorkspaceProbe:
+                def claim_or_resume_with_handle(self, **kwargs: object) -> object:
+                    revalidate = kwargs.get("revalidate_before_handoff")
+                    assert callable(revalidate)
+                    revalidate()
+                    validate_candidate = kwargs.get("validate_candidate")
+                    assert callable(validate_candidate), (
+                        "kernel must bridge candidate attestation into the coordinator"
+                    )
+                    validate_candidate(candidate)
+                    raise AssertionError("a mismatched candidate must never be returned")
+
+            h.kernel._workspace = WorkspaceProbe()  # type: ignore[assignment]
+
+            with pytest.raises(ThreadBusyError):
+                await h.kernel._claim_or_resume(
+                    thread_key,
+                    {
+                        "CURIE_SESSION_ID": old.session_id,
+                        "CURIE_HISTORY_REF": old.history_ref or "",
+                    },
+                    workspace_deployment_id=deployment_id,
+                    workspace_repo="acme-corp/acme-bot",
+                    replace_handle=old,
+                )
 
     asyncio.run(go())
 

--- a/apps/worker/tests/kernel/test_kernel.py
+++ b/apps/worker/tests/kernel/test_kernel.py
@@ -603,9 +603,20 @@ def test_late_workspace_selection_replaces_generic_sandbox_and_stays_sticky(
     make_harness,
 ) -> None:
     deployment_id = uuid.uuid4()
+    session_id = "agent-session-tLateWorkspace"
+    history_ref = "https://api.example.com/state/transcript/tLateWorkspace"
 
     async def go() -> None:
-        async with make_harness(binding=_workspace_binding(deployment_id)) as h:
+        async with make_harness(
+            binding=_workspace_binding(
+                deployment_id,
+                boot_env_override={
+                    "CURIE_RUNNER_TOKEN": "workspace-test-token",
+                    "CURIE_SESSION_ID": session_id,
+                    "CURIE_HISTORY_REF": history_ref,
+                },
+            )
+        ) as h:
             class WorkspaceProbe:
                 selected: str | None = None
                 handoffs = 0
@@ -621,10 +632,16 @@ def test_late_workspace_selection_replaces_generic_sandbox_and_stays_sticky(
                     self.handoffs += 1
                     old = kwargs["replace_handle"]
                     assert old is not None
+                    raw_env = kwargs["env"]
+                    assert isinstance(raw_env, dict)
                     handle = h.substrate.handoff(
                         _thread_key("tLateWorkspace"),
                         expected=old,
-                        env={"CURIE_WORKSPACE_REF": "workspace/private-base"},
+                        env={
+                            **raw_env,
+                            "CURIE_WORKSPACE_REF": "workspace/private-base",
+                            "CURIE_WORKSPACE_SHA256": "d" * 64,
+                        },
                         workspace_repo=str(kwargs["repo_full_name"]),
                     )
                     return SimpleNamespace(handle=handle, prepared=None)
@@ -639,6 +656,10 @@ def test_late_workspace_selection_replaces_generic_sandbox_and_stays_sticky(
             await h.kernel.process_event(_qevent("hello", thread="tLateWorkspace"))
             generic = h.substrate.lookup(_thread_key("tLateWorkspace"))
             assert generic is not None and generic.workspace_repo is None
+            # The durable pointer and logical session on the route must match
+            # the runner boot. A late replacement is built from this handle.
+            assert generic.session_id == session_id
+            assert generic.history_ref == history_ref
 
             await h.kernel.process_event(
                 _qevent(
@@ -649,7 +670,8 @@ def test_late_workspace_selection_replaces_generic_sandbox_and_stays_sticky(
             workspace = h.substrate.lookup(_thread_key("tLateWorkspace"))
             assert workspace is not None
             assert workspace.claim_name != generic.claim_name
-            assert workspace.session_id == generic.session_id
+            assert workspace.session_id == generic.session_id == session_id
+            assert workspace.history_ref == generic.history_ref == history_ref
             assert workspace.workspace_repo == "acme-corp/acme-bot"
             assert workspace.generation == generic.generation + 1
 
@@ -666,10 +688,31 @@ def test_late_workspace_selection_replaces_generic_sandbox_and_stays_sticky(
             ]
             claim_env = h.fake_k8s.claim_envs[-1] or {}
             assert claim_env["CURIE_WORKSPACE_REF"] == "workspace/private-base"
+            assert claim_env["CURIE_WORKSPACE_SHA256"] == "d" * 64
+            assert claim_env["CURIE_SESSION_ID"] == session_id
+            assert claim_env["CURIE_HISTORY_REF"] == history_ref
+            # This durable pointer is the worker-side proof that the first
+            # model turn remains available to the cold replacement. Replay is
+            # asserted at the runner store consumer, not simulated here.
+            assert h.runner.opened[:2] == [
+                "hello",
+                "Use https://github.com/acme-corp/acme-bot",
+            ]
+            forbidden_names = {
+                "CURIE_INTERNAL_WORKER_TOKEN",
+                "CURIE_API_KEY",
+                "S3_ACCESS_KEY",
+                "S3_SECRET_KEY",
+                "AWS_ACCESS_KEY_ID",
+                "AWS_SECRET_ACCESS_KEY",
+                "GITHUB_TOKEN",
+            }
+            assert forbidden_names.isdisjoint(claim_env)
             assert not any(
                 marker in f"{name}={value}".upper()
                 for name, value in claim_env.items()
                 for marker in ("AUTHORIZATION", "PASSWORD", "TOKEN", "SECRET")
+                if name != "CURIE_RUNNER_TOKEN"
             )
 
     asyncio.run(go())
@@ -856,7 +899,11 @@ def test_a_selection_refusal_is_logged_so_an_operator_can_find_it(
 # the missing half.
 
 
-def _workspace_binding(deployment_id: uuid.UUID | None) -> object:
+def _workspace_binding(
+    deployment_id: uuid.UUID | None,
+    *,
+    boot_env_override: dict[str, str] | None = None,
+) -> object:
     """A binding carrying a fixed deployment id and the legacy flag.
 
     Fixed on purpose: the id is what an operator greps for, so the tests assert
@@ -882,7 +929,10 @@ def _workspace_binding(deployment_id: uuid.UUID | None) -> object:
             kind: str | None = None,
             address: str | None = None,
         ) -> dict[str, str]:
-            return {"CURIE_RUNNER_TOKEN": "workspace-test-token"}
+            return dict(
+                boot_env_override
+                or {"CURIE_RUNNER_TOKEN": "workspace-test-token"}
+            )
 
         def packs_for(self, _resolved: object) -> BehaviorPacks:
             return BehaviorPacks()

--- a/apps/worker/tests/kernel/test_runner_client.py
+++ b/apps/worker/tests/kernel/test_runner_client.py
@@ -95,7 +95,7 @@ def test_turn_stream_released_when_consumer_raises(make_harness) -> None:
 class _HeaderRecordingRunner:
     """Records the request headers seen on each ACI route."""
 
-    def __init__(self) -> None:
+    def __init__(self, *, status_body: dict[str, object] | None = None) -> None:
         self.app = web.Application()
         self.app.add_routes(
             [
@@ -107,6 +107,11 @@ class _HeaderRecordingRunner:
             ]
         )
         self.headers: dict[str, dict[str, str]] = {}
+        self.status_body = status_body or {
+            "status": "idle-awaiting-input",
+            "turn_active": False,
+            "history_durable": True,
+        }
 
     async def _event(self, request: web.Request) -> web.StreamResponse:
         self.headers["event"] = dict(request.headers)
@@ -126,9 +131,7 @@ class _HeaderRecordingRunner:
 
     async def _status(self, request: web.Request) -> web.Response:
         self.headers[request.path] = dict(request.headers)
-        return web.json_response(
-            {"status": "idle-awaiting-input", "turn_active": False, "history_durable": True}
-        )
+        return web.json_response(self.status_body)
 
 
 async def _drain(turn: Any) -> None:
@@ -154,6 +157,35 @@ def test_runner_client_sends_bearer_token_on_every_call() -> None:
             assert runner.headers["event"].get("Authorization") == "Bearer tok-1"
             assert runner.headers["steer"].get("Authorization") == "Bearer tok-1"
             assert runner.headers["interrupt"].get("Authorization") == "Bearer tok-1"
+            assert runner.headers["/v1/status"].get("Authorization") == "Bearer tok-1"
+        finally:
+            await client.close()
+            await server.close()
+
+    asyncio.run(go())
+
+
+def test_runner_client_preserves_authenticated_boot_attestation() -> None:
+    async def go() -> None:
+        attested = {
+            "status": "idle-awaiting-input",
+            "ready": True,
+            "turn_active": False,
+            "history_durable": True,
+            "session_id": "session-acme-workspace",
+            "sandbox_id": "sandbox-acme-workspace",
+            "managed_workspace": True,
+            "cwd": "/workspace",
+        }
+        runner = _HeaderRecordingRunner(status_body=attested)
+        server = TestServer(runner.app)
+        await server.start_server()
+        base_url = f"http://127.0.0.1:{server.port}"
+        client = RunnerClient(total_timeout_s=30.0)
+        try:
+            status = await client.status(base_url, token="tok-1")
+
+            assert status == attested
             assert runner.headers["/v1/status"].get("Authorization") == "Bearer tok-1"
         finally:
             await client.close()

--- a/apps/worker/tests/sandbox/test_docker.py
+++ b/apps/worker/tests/sandbox/test_docker.py
@@ -174,6 +174,60 @@ def test_create_claim_fetches_and_unwraps_bundle() -> None:
     assert "CURIE_BUNDLE_VERSION=abc123def456" in child_env
 
 
+def test_create_claim_prefetches_workspace_without_forwarding_capability_env(
+    tmp_path: Path,
+) -> None:
+    """Docker consumes workspace capabilities at the trusted worker boundary.
+
+    Kubernetes gives these values only to its trusted init containers
+    (``test_workspace_capability_targets_only_workspace_init_containers``).
+    Docker has no init container, so its worker performs the equivalent fetch
+    before mounting the checkout. Neither opaque capability may survive in the
+    untrusted runner's environment.
+    """
+
+    checkout = tmp_path / "trusted-checkout"
+    checkout.mkdir()
+    workspace_ref = "opaque-presigned-workspace-reference"
+    workspace_sha256 = "a" * 64
+
+    class _WorkspacePreparingDocker(_RecordingDocker):
+        def __init__(self, **kwargs: object) -> None:
+            super().__init__(**kwargs)
+            self.prepared: list[tuple[str, str, str]] = []
+
+        def _prepare_workspace(
+            self, name: str, encoded_ref: str, expected_sha256: str
+        ) -> str:
+            self.prepared.append((name, encoded_ref, expected_sha256))
+            return str(checkout)
+
+    client = _WorkspacePreparingDocker(
+        image="curie-runner", bundle_store=_FakeBundleStore()
+    )
+    client.create_claim(
+        "thread-workspace",
+        pool="pool",
+        env={
+            "CURIE_BUDGET": "{}",
+            "CURIE_WORKSPACE_REF": workspace_ref,
+            "CURIE_WORKSPACE_SHA256": workspace_sha256,
+        },
+    )
+
+    assert client.prepared == [
+        ("thread-workspace", workspace_ref, workspace_sha256)
+    ]
+    argv = client.calls[0]
+    assert f"{checkout}:/workspace:rw" in _flag_values(argv, "-v")
+    child_env = _flag_values(argv, "-e")
+    child_env_names = {entry.partition("=")[0] for entry in child_env}
+    assert "CURIE_WORKSPACE_REF" not in child_env_names
+    assert "CURIE_WORKSPACE_SHA256" not in child_env_names
+    assert all(workspace_ref not in entry for entry in child_env)
+    assert all(workspace_sha256 not in entry for entry in child_env)
+
+
 def test_create_claim_without_bundle_ref_mounts_nothing() -> None:
     client = _RecordingDocker(image="curie-runner", bundle_store=_FakeBundleStore())
     client.create_claim("t1", pool="pool", env={"CURIE_FAKE_MODEL": "1"})

--- a/apps/worker/tests/sandbox/test_substrate.py
+++ b/apps/worker/tests/sandbox/test_substrate.py
@@ -149,6 +149,101 @@ def test_handoff_cold_claims_then_atomically_replaces_and_retires_old_route(
     assert replacement.claim_name not in fake_k8s.deleted
 
 
+def test_handoff_validates_the_ready_candidate_before_route_cas(
+    substrate: SandboxSubstrate,
+    fake_k8s: FakeSandboxClient,
+    affinity: AffinityStore,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    old = substrate.claim(
+        "T1",
+        env={SESSION_ENV: "logical-session", HISTORY_ENV: "history/T1"},
+    )
+    ordering: list[str] = []
+    observed: list[SandboxHandle] = []
+    real_replace = affinity.replace_if_generation
+
+    def replace_if_generation(
+        thread_key: str,
+        *,
+        expected_claim: str,
+        expected_generation: int,
+        record: RouteRecord,
+        ttl_seconds: int,
+    ) -> bool:
+        ordering.append("route-cas")
+        return real_replace(
+            thread_key,
+            expected_claim=expected_claim,
+            expected_generation=expected_generation,
+            record=record,
+            ttl_seconds=ttl_seconds,
+        )
+
+    monkeypatch.setattr(affinity, "replace_if_generation", replace_if_generation)
+
+    def validate_candidate(candidate: SandboxHandle) -> None:
+        ordering.append("candidate-validated")
+        observed.append(candidate)
+        assert affinity.get("T1") == RouteRecord(handle=old)
+        assert fake_k8s.claims[candidate.claim_name].ready is True
+        sandbox = fake_k8s.sandboxes[candidate.sandbox_name]
+        assert sandbox.ready is True
+        assert sandbox.operating_mode == "Running"
+
+    replacement = substrate.handoff(
+        "T1",
+        expected=old,
+        env={
+            "CURIE_WORKSPACE_REF": "workspace/candidate",
+            "CURIE_WORKSPACE_SHA256": "c" * 64,
+        },
+        workspace_repo="acme-corp/acme-bot",
+        validate_candidate=validate_candidate,
+    )
+
+    assert observed == [replacement]
+    assert ordering == ["candidate-validated", "route-cas"]
+    assert affinity.get("T1") == RouteRecord(handle=replacement)
+
+
+def test_handoff_candidate_validation_refusal_deletes_only_the_candidate(
+    substrate: SandboxSubstrate,
+    fake_k8s: FakeSandboxClient,
+    affinity: AffinityStore,
+) -> None:
+    old = substrate.claim(
+        "T1",
+        env={SESSION_ENV: "logical-session", HISTORY_ENV: "history/T1"},
+    )
+    claims_before = set(fake_k8s.claims)
+    observed: list[SandboxHandle] = []
+
+    def refuse_candidate(candidate: SandboxHandle) -> None:
+        observed.append(candidate)
+        raise RuntimeError("candidate runner attestation mismatch")
+
+    with pytest.raises(RuntimeError, match="candidate runner attestation mismatch"):
+        substrate.handoff(
+            "T1",
+            expected=old,
+            env={
+                "CURIE_WORKSPACE_REF": "workspace/candidate",
+                "CURIE_WORKSPACE_SHA256": "c" * 64,
+            },
+            workspace_repo="acme-corp/acme-bot",
+            validate_candidate=refuse_candidate,
+        )
+
+    assert len(observed) == 1
+    rejected = observed[0]
+    assert rejected.claim_name in fake_k8s.deleted
+    assert rejected.claim_name not in fake_k8s.claims
+    assert set(fake_k8s.claims) == claims_before
+    assert affinity.get("T1") == RouteRecord(handle=old)
+    assert old.claim_name not in fake_k8s.deleted
+
+
 def test_handoff_route_cas_loss_keeps_old_route_and_deletes_unexposed_candidate(
     substrate: SandboxSubstrate,
     fake_k8s: FakeSandboxClient,

--- a/apps/worker/tests/sandbox/test_substrate.py
+++ b/apps/worker/tests/sandbox/test_substrate.py
@@ -98,27 +98,88 @@ def test_handoff_cold_claims_then_atomically_replaces_and_retires_old_route(
     fake_k8s: FakeSandboxClient,
     affinity: AffinityStore,
 ) -> None:
-    claimed = substrate.claim("T1", env={SESSION_ENV: "logical-session"})
-    old = replace(claimed, history_ref="history/private-base")
-    affinity.replace("T1", RouteRecord(handle=old), ttl_seconds=60)
-
-    replacement = substrate.handoff(
+    history_ref = "https://api.example.com/state/transcript/T1"
+    claimed = substrate.claim(
         "T1",
-        expected=old,
-        env={SESSION_ENV: old.session_id, "CURIE_WORKSPACE_REF": "private/ref"},
+        env={
+            SESSION_ENV: "logical-session",
+            HISTORY_ENV: history_ref,
+            "CURIE_WORKSPACE_REF": "workspace/claim-time",
+            "CURIE_WORKSPACE_SHA256": "a" * 64,
+        },
         workspace_repo="acme-corp/acme-bot",
     )
 
-    assert replacement.claim_name != old.claim_name
-    assert replacement.session_id == old.session_id
-    assert replacement.history_ref == old.history_ref == "history/private-base"
+    # The route is the continuity record used to construct a later replacement.
+    # It must describe the runner that actually booted, rather than synthesizing
+    # a different session id and dropping the durable transcript identity.
+    assert claimed.session_id == "logical-session"
+    assert claimed.history_ref == history_ref
+    assert claimed.workspace_repo == "acme-corp/acme-bot"
+    claim_env = fake_k8s.claims[claimed.claim_name].env
+    assert claim_env[SESSION_ENV] == "logical-session"
+    assert claim_env[HISTORY_ENV] == history_ref
+    assert claim_env["CURIE_WORKSPACE_REF"] == "workspace/claim-time"
+    assert claim_env["CURIE_WORKSPACE_SHA256"] == "a" * 64
+
+    replacement = substrate.handoff(
+        "T1",
+        expected=claimed,
+        env={
+            SESSION_ENV: claimed.session_id,
+            HISTORY_ENV: history_ref,
+            "CURIE_WORKSPACE_REF": "workspace/late-handoff",
+            "CURIE_WORKSPACE_SHA256": "b" * 64,
+        },
+        workspace_repo="acme-corp/acme-bot",
+    )
+
+    assert replacement.claim_name != claimed.claim_name
+    assert replacement.session_id == claimed.session_id == "logical-session"
+    assert replacement.history_ref == claimed.history_ref == history_ref
     assert replacement.workspace_repo == "acme-corp/acme-bot"
     assert replacement.generation == 1
     assert affinity.get("T1") == RouteRecord(handle=replacement)
-    assert fake_k8s.claims[replacement.claim_name].env[SESSION_ENV] == old.session_id
-    assert fake_k8s.claims[replacement.claim_name].env[HISTORY_ENV] == "history/private-base"
-    assert old.claim_name in fake_k8s.deleted
+    candidate_env = fake_k8s.claims[replacement.claim_name].env
+    assert candidate_env[SESSION_ENV] == "logical-session"
+    assert candidate_env[HISTORY_ENV] == history_ref
+    assert candidate_env["CURIE_WORKSPACE_REF"] == "workspace/late-handoff"
+    assert candidate_env["CURIE_WORKSPACE_SHA256"] == "b" * 64
+    assert claimed.claim_name in fake_k8s.deleted
     assert replacement.claim_name not in fake_k8s.deleted
+
+
+def test_handoff_route_cas_loss_keeps_old_route_and_deletes_unexposed_candidate(
+    substrate: SandboxSubstrate,
+    fake_k8s: FakeSandboxClient,
+    affinity: AffinityStore,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    old = substrate.claim(
+        "T1",
+        env={SESSION_ENV: "logical-session", HISTORY_ENV: "history/T1"},
+    )
+    created_before = set(fake_k8s.claims)
+    monkeypatch.setattr(
+        affinity,
+        "replace_if_generation",
+        lambda *_args, **_kwargs: False,
+    )
+
+    with pytest.raises(NoRouteError, match="lost its route fence"):
+        substrate.handoff(
+            "T1",
+            expected=old,
+            env={
+                "CURIE_WORKSPACE_REF": "workspace/candidate",
+                "CURIE_WORKSPACE_SHA256": "c" * 64,
+            },
+            workspace_repo="acme-corp/acme-bot",
+        )
+
+    assert affinity.get("T1") == RouteRecord(handle=old)
+    assert set(fake_k8s.claims) == created_before
+    assert old.claim_name not in fake_k8s.deleted
 
 
 def test_handoff_route_survives_old_claim_delete_failure_and_reaper_finishes_cleanup(

--- a/apps/worker/tests/test_workspace.py
+++ b/apps/worker/tests/test_workspace.py
@@ -918,7 +918,21 @@ def test_late_handoff_uses_substrate_handoff_and_keeps_credentials_out_of_claim_
     workspace: Any, tmp_path: Path
 ) -> None:
     preparer, commands, _objects = _preparer(workspace, tmp_path)
-    substrate = _RecordingSubstrate()
+    ordering: list[str] = []
+    real_verify = preparer.verify
+
+    def verify(prepared: Any) -> None:
+        real_verify(prepared)
+        ordering.append("verified")
+
+    preparer.verify = verify
+
+    class OrderingSubstrate(_RecordingSubstrate):
+        def handoff(self, *args: Any, **kwargs: Any) -> object:
+            ordering.append("handoff")
+            return super().handoff(*args, **kwargs)
+
+    substrate = OrderingSubstrate()
     coordinator = workspace.WorkspaceClaimCoordinator(
         preparer=preparer,
         substrate=substrate,
@@ -938,8 +952,10 @@ def test_late_handoff_uses_substrate_handoff_and_keeps_credentials_out_of_claim_
         agent_name="acme-bot",
         repo_full_name="acme-corp/acme-bot",
         replace_handle=old_handle,
+        revalidate_before_handoff=lambda: ordering.append("revalidated"),
     )
 
+    assert ordering == ["verified", "revalidated", "handoff"]
     assert substrate.calls[0][0] == "handoff"
     assert [kind for kind, _thread, _env in substrate.calls] == ["handoff"]
     handoff = substrate.handoff_calls[0]
@@ -972,6 +988,79 @@ def test_late_handoff_uses_substrate_handoff_and_keeps_credentials_out_of_claim_
         if name != "CURIE_RUNNER_TOKEN"
     )
     assert "clone" in commands.events
+
+
+def test_late_handoff_revalidation_refusal_restores_ownership_and_old_route(
+    workspace: Any, tmp_path: Path
+) -> None:
+    preparer, _, objects = _preparer(workspace, tmp_path)
+    thread_key = "1700000000.000100"
+    old_route = object()
+    ordering: list[str] = []
+
+    class RouteSubstrate(_RecordingSubstrate):
+        current_route = old_route
+
+        def handoff(self, *args: Any, **kwargs: Any) -> object:
+            ordering.append("handoff")
+            self.current_route = object()
+            return super().handoff(*args, **kwargs)
+
+    substrate = RouteSubstrate()
+    coordinator = workspace.WorkspaceClaimCoordinator(
+        preparer=preparer,
+        substrate=substrate,
+        ownership_ttl_seconds=60,
+        wall_clock=lambda: 1000.0,
+    )
+    previous = coordinator.claim_or_resume_with_handle(
+        thread_key=thread_key,
+        deployment_id=DEPLOYMENT_ID,
+    ).prepared
+    substrate.calls.clear()
+    substrate.handoff_calls.clear()
+
+    real_verify = preparer.verify
+
+    def verify(prepared: Any) -> None:
+        real_verify(prepared)
+        ordering.append("verified")
+
+    preparer.verify = verify
+
+    def refuse_revalidation() -> None:
+        staged = coordinator.current(thread_key)
+        assert staged is not None and staged != previous
+        ordering.append("revalidated-refused")
+        raise RuntimeError("workspace handoff boundary changed")
+
+    with pytest.raises(RuntimeError, match="handoff boundary changed"):
+        coordinator.claim_or_resume_with_handle(
+            thread_key=thread_key,
+            deployment_id=DEPLOYMENT_ID,
+            repo_full_name="acme-corp/acme-bot",
+            replace_handle=old_route,
+            revalidate_before_handoff=refuse_revalidation,
+        )
+
+    assert ordering == ["verified", "revalidated-refused"]
+    assert substrate.handoff_calls == []
+    assert substrate.current_route is old_route
+
+    restarted = workspace.WorkspaceClaimCoordinator(
+        preparer=preparer,
+        substrate=_RecordingSubstrate(),
+        ownership_ttl_seconds=60,
+        wall_clock=lambda: 1001.0,
+    )
+    assert restarted.current(thread_key) == previous
+    assert previous.object_key in objects.objects
+    archive_keys = [key for key in objects.objects if not key.startswith("_ownership/")]
+    assert archive_keys == [previous.object_key]
+    assert any(
+        key != previous.object_key and not key.startswith("_ownership/")
+        for key in objects.deleted
+    )
 
 
 def test_late_handoff_without_a_selected_repository_never_touches_the_substrate(

--- a/apps/worker/tests/test_workspace.py
+++ b/apps/worker/tests/test_workspace.py
@@ -22,7 +22,7 @@ import stat
 import tarfile
 import threading
 import uuid
-from collections.abc import Iterable, Iterator, Sequence
+from collections.abc import Callable, Iterable, Iterator, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from types import SimpleNamespace
@@ -787,8 +787,10 @@ class _RecordingSubstrate:
         env: dict[str, str] | None = None,
         workspace_repo: str,
         agent_name: str | None = None,
+        validate_candidate: Callable[[object], None] | None = None,
     ) -> object:
         payload = dict(env or {})
+        candidate = object()
         self.calls.append(("handoff", thread_key, payload))
         self.handoff_calls.append(
             {
@@ -797,9 +799,12 @@ class _RecordingSubstrate:
                 "env": payload,
                 "workspace_repo": workspace_repo,
                 "agent_name": agent_name,
+                "candidate": candidate,
             }
         )
-        return object()
+        if validate_candidate is not None:
+            validate_candidate(candidate)
+        return candidate
 
 
 def test_workspace_ownership_is_durable_before_the_sandbox_claim_is_exposed(
@@ -1045,6 +1050,83 @@ def test_late_handoff_revalidation_refusal_restores_ownership_and_old_route(
 
     assert ordering == ["verified", "revalidated-refused"]
     assert substrate.handoff_calls == []
+    assert substrate.current_route is old_route
+
+    restarted = workspace.WorkspaceClaimCoordinator(
+        preparer=preparer,
+        substrate=_RecordingSubstrate(),
+        ownership_ttl_seconds=60,
+        wall_clock=lambda: 1001.0,
+    )
+    assert restarted.current(thread_key) == previous
+    assert previous.object_key in objects.objects
+    archive_keys = [key for key in objects.objects if not key.startswith("_ownership/")]
+    assert archive_keys == [previous.object_key]
+    assert any(
+        key != previous.object_key and not key.startswith("_ownership/")
+        for key in objects.deleted
+    )
+
+
+def test_late_handoff_candidate_refusal_restores_prior_durable_ownership(
+    workspace: Any, tmp_path: Path
+) -> None:
+    preparer, _, objects = _preparer(workspace, tmp_path)
+    thread_key = "1700000000.000100"
+    old_route = object()
+    ordering: list[str] = []
+    observed_candidates: list[object] = []
+
+    class CandidateSubstrate(_RecordingSubstrate):
+        current_route = old_route
+
+        def handoff(self, *args: Any, **kwargs: Any) -> object:
+            candidate = super().handoff(*args, **kwargs)
+            self.current_route = candidate
+            return candidate
+
+    substrate = CandidateSubstrate()
+    coordinator = workspace.WorkspaceClaimCoordinator(
+        preparer=preparer,
+        substrate=substrate,
+        ownership_ttl_seconds=60,
+        wall_clock=lambda: 1000.0,
+    )
+    previous = coordinator.claim_or_resume_with_handle(
+        thread_key=thread_key,
+        deployment_id=DEPLOYMENT_ID,
+    ).prepared
+    substrate.calls.clear()
+    substrate.handoff_calls.clear()
+
+    real_verify = preparer.verify
+
+    def verify(prepared: Any) -> None:
+        real_verify(prepared)
+        ordering.append("verified")
+
+    preparer.verify = verify
+
+    def refuse_candidate(candidate: object) -> None:
+        staged = coordinator.current(thread_key)
+        assert staged is not None and staged != previous
+        observed_candidates.append(candidate)
+        ordering.append("candidate-refused")
+        raise RuntimeError("candidate runner attestation mismatch")
+
+    with pytest.raises(RuntimeError, match="candidate runner attestation mismatch"):
+        coordinator.claim_or_resume_with_handle(
+            thread_key=thread_key,
+            deployment_id=DEPLOYMENT_ID,
+            repo_full_name="acme-corp/acme-bot",
+            replace_handle=old_route,
+            revalidate_before_handoff=lambda: ordering.append("old-revalidated"),
+            validate_candidate=refuse_candidate,
+        )
+
+    assert ordering == ["verified", "old-revalidated", "candidate-refused"]
+    assert len(substrate.handoff_calls) == 1
+    assert observed_candidates == [substrate.handoff_calls[0]["candidate"]]
     assert substrate.current_route is old_route
 
     restarted = workspace.WorkspaceClaimCoordinator(

--- a/apps/worker/tests/test_workspace.py
+++ b/apps/worker/tests/test_workspace.py
@@ -930,7 +930,11 @@ def test_late_handoff_uses_substrate_handoff_and_keeps_credentials_out_of_claim_
     result = coordinator.claim_or_resume_with_handle(
         thread_key="1700000000.000100",
         deployment_id=DEPLOYMENT_ID,
-        env={"CURIE_RUNNER_TOKEN": "workspace-test-token"},
+        env={
+            "CURIE_RUNNER_TOKEN": "workspace-test-token",
+            "CURIE_SESSION_ID": "logical-session",
+            "CURIE_HISTORY_REF": "https://api.example.com/state/transcript/thread-1",
+        },
         agent_name="acme-bot",
         repo_full_name="acme-corp/acme-bot",
         replace_handle=old_handle,
@@ -946,6 +950,19 @@ def test_late_handoff_uses_substrate_handoff_and_keeps_credentials_out_of_claim_
     assert handoff["env"]["CURIE_WORKSPACE_REF"] == workspace_env["CURIE_WORKSPACE_REF"]
     assert handoff["env"]["CURIE_WORKSPACE_SHA256"] == workspace_env["CURIE_WORKSPACE_SHA256"]
     assert handoff["env"]["CURIE_RUNNER_TOKEN"] == "workspace-test-token"
+    assert handoff["env"]["CURIE_SESSION_ID"] == "logical-session"
+    assert handoff["env"]["CURIE_HISTORY_REF"] == (
+        "https://api.example.com/state/transcript/thread-1"
+    )
+    assert {
+        "CURIE_INTERNAL_WORKER_TOKEN",
+        "CURIE_API_KEY",
+        "S3_ACCESS_KEY",
+        "S3_SECRET_KEY",
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "GITHUB_TOKEN",
+    }.isdisjoint(handoff["env"])
     assert GIT_CREDENTIAL not in json.dumps(handoff["env"])
     assert "redeemed-credential-value" not in json.dumps(handoff["env"])
     assert not any(
@@ -1288,13 +1305,25 @@ def test_workspace_claim_env_never_carries_worker_auth_object_store_or_git_crede
     workspace: Any, tmp_path: Path
 ) -> None:
     preparer, _, _ = _preparer(workspace, tmp_path)
-    prepared = _prepare(preparer)
-    env = {
-        **prepared.claim_env(),
-        "CURIE_BUNDLE_REF": "bundles/first",
-    }
+    substrate = _RecordingSubstrate()
+    coordinator = workspace.WorkspaceClaimCoordinator(
+        preparer=preparer,
+        substrate=substrate,
+    )
+    result = coordinator.claim_or_resume_with_handle(
+        thread_key="1700000000.000100",
+        deployment_id=DEPLOYMENT_ID,
+        env={
+            "CURIE_BUNDLE_REF": "bundles/first",
+            "CURIE_SESSION_ID": "logical-session",
+            "CURIE_HISTORY_REF": "https://api.example.com/state/transcript/thread-1",
+        },
+        repo_full_name="acme-corp/acme-bot",
+    )
+    env = substrate.calls[0][2]
     forbidden = {
         "CURIE_INTERNAL_WORKER_TOKEN",
+        "CURIE_API_KEY",
         "S3_ACCESS_KEY",
         "S3_SECRET_KEY",
         "AWS_ACCESS_KEY_ID",
@@ -1305,6 +1334,14 @@ def test_workspace_claim_env_never_carries_worker_auth_object_store_or_git_crede
     assert forbidden.isdisjoint(env)
     assert WORKER_AUTH not in env.values()
     assert GIT_CREDENTIAL not in env.values()
+    assert env["CURIE_SESSION_ID"] == "logical-session"
+    assert env["CURIE_HISTORY_REF"] == (
+        "https://api.example.com/state/transcript/thread-1"
+    )
+    assert env["CURIE_WORKSPACE_REF"] == result.prepared.claim_env()[
+        "CURIE_WORKSPACE_REF"
+    ]
+    assert env["CURIE_WORKSPACE_SHA256"] == result.prepared.sha256
 
 
 def test_two_clone_slots_bound_concurrency_and_a_third_waits(workspace: Any) -> None:

--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -1233,12 +1233,17 @@ One allowed root `https://github.com/owner/repository` URL in the initial
 message establishes the thread's selection and causes the worker to acquire its
 managed workspace at claim time. An initial message without a repository URL
 uses a generic sandbox and does not redeem a repository credential. If a root
-URL arrives after that generic route is already running, Curie refuses it
-before selection, credential redemption, or a second claim; the fenced
-same-thread replacement described by Draft
-[ADR 0136](../../docs/adr/0136-a-late-workspace-handoff-replaces-the-sandbox-at-a-fenced-turn-boundary.md)
-is not yet available. The first established selection remains pinned to the
-agent and thread, and choosing another repository requires a new thread.
+URL arrives after that generic route is already running, Curie may acquire the
+workspace only at an authenticated idle boundary where no turn can accept a
+steer, the latest structured history is durable, and no approval suspension or
+unresolved side-effect boundary is active. It prepares and verifies the
+workspace, cold-claims a replacement with the same logical session and history
+reference, and only then atomically fences the old route. If that safe
+boundary cannot be verified, Curie refuses the handoff and keeps the old route
+authoritative, as required by Accepted
+[ADR 0136](../../docs/adr/0136-a-late-workspace-handoff-replaces-the-sandbox-at-a-fenced-turn-boundary.md).
+The first established selection remains pinned to the agent and thread, and
+choosing another repository requires a new thread.
 
 Set `api.githubRepoAllowlist` to exact `owner/repository` entries or explicit
 owner-wide `owner/*` entries. Empty is deny-all. Curie checks this policy before

--- a/runner/README.md
+++ b/runner/README.md
@@ -20,6 +20,10 @@ locally in Docker.
 - Emits `side_effect_flag` when a non-idempotent tool executes (read-only
   allowlist, deny-by-default; see `side_effects.py`).
 - Loads and validates the mounted plugin bundle via `plugin_format.validate_bundle`.
+- Always exposes the Claude Code file tools and Curie's
+  `mcp__curie__publish_changes` tool, independent of bundle skills and bundle
+  MCP policy. Publication remains unusable without a managed `/workspace` and
+  only records an approval request; the trusted worker publishes after approval.
 - Offers Anthropic's provider-side `WebSearch` tool by default. A bundle can
   suppress it with a root `curie.bundle.json` containing
   `{"webSearch": false}`; the provider connection remains the only network
@@ -29,14 +33,19 @@ locally in Docker.
   OTLP-HTTP (the OpenTelemetry Protocol over HTTP) to the collector, which
   forwards to Langfuse.
 - Rehydrates from a history ref on start (`resume`), stateless-first
-  (ADR-0003, an Architecture Decision Record).
+  (ADR-0003, an Architecture Decision Record). Completed turns are stored as
+  structured replay; oversized text payloads are replaced with stable digest
+  markers before the state API's 64 KiB value boundary while tool-call
+  structure remains intact. An append failure makes the runner's
+  `history_durable` status fail closed for the rest of that process.
 
 ## HTTP surface (ACI channel)
 
 | Method | Path | Purpose |
 |---|---|---|
 | GET | `/healthz` | Liveness. |
-| GET | `/status` | Session status (done / idle-awaiting-input / classified-failure), readiness, turn state. |
+| GET | `/status` | Probe-safe session status, readiness, turn state, and transcript durability. |
+| GET | `/v1/status` | Bearer-authenticated handoff status, including session/sandbox identity and managed-workspace cwd attestation. |
 | POST | `/v1/event` | Open a turn: body is an ACI `event` frame; streams outbound NDJSON, ending in a `final`. |
 | POST | `/v1/steer` | Inject a follow-up into the live turn (`{"text": ...}`); 409 when no turn is active. |
 | POST | `/v1/interrupt` | Hard-stop the live turn: body is an ACI `interrupt` frame. |
@@ -46,14 +55,16 @@ side-channel injections whose output surfaces on the open `/v1/event` stream (th
 proven steering pattern). The finish race (a steer arriving as a turn ends,
 409) is owned by the worker.
 
-The three POST routes (`/v1/event`, `/v1/steer`, `/v1/interrupt`) require an
-`Authorization: Bearer <token>` header matching `CURIE_RUNNER_TOKEN` when that
-env var is set, returning 401 otherwise. This is per-sandbox transport auth
-(defense-in-depth on the ACI ingress alongside the NetworkPolicy), not part of
-the frozen ACI wire contract. Enforcement is only-when-configured: with the var
-unset the app is pass-through (CLI, fake-model CI, and pre-token sandboxes stay
-unauthenticated). `GET /healthz` and `GET /status` are never gated (the chart
-readinessProbe hits `/healthz`).
+The control routes (`/v1/event`, `/v1/steer`, `/v1/interrupt`, `/v1/reset`,
+`/v1/snapshot`, and `/v1/status`) require an `Authorization: Bearer <token>`
+header matching `CURIE_RUNNER_TOKEN` when that env var is set, returning 401
+otherwise. This is per-sandbox transport auth (defense-in-depth on the ACI
+ingress alongside the NetworkPolicy), not part of the frozen ACI wire contract.
+Enforcement is only-when-configured: with the var unset the app is pass-through
+(CLI, fake-model CI, and pre-token sandboxes stay unauthenticated). `GET
+/healthz` and probe-only `GET /status` are never gated (the chart readinessProbe
+hits `/healthz`); replacement authority comes only from authenticated
+`GET /v1/status`.
 
 ## Environment
 

--- a/runner/src/curie_runner/__main__.py
+++ b/runner/src/curie_runner/__main__.py
@@ -64,7 +64,7 @@ from .otel import RunTracer, build_tracer_provider
 from .plugin import load_bundle_web_search_enabled
 from .redact import install_stdout_redaction
 from .sdk_auth import UnsupportedCredentialError
-from .server import create_app
+from .server import bind_status_attestation, create_app
 from .session import SessionRunner
 from .side_effects import SideEffectClassifier
 from .state import STATE_SERVER_NAME, build_state_server, resolve_state_client
@@ -435,28 +435,33 @@ def build_runner(
         config.session.session_id,
         config.session.sandbox_id,
     )
-    return SessionRunner(
-        session_factory=factory,
-        ceiling=config.ceiling,
-        tracer=RunTracer(provider),
-        classifier=SideEffectClassifier(
-            readonly_tools=harness.readonly_tools
-            | (
-                observed_readonly_tools - approval_gate.required
-                if approval_gate is not None
-                else observed_readonly_tools
-            )
+    return bind_status_attestation(
+        SessionRunner(
+            session_factory=factory,
+            ceiling=config.ceiling,
+            tracer=RunTracer(provider),
+            classifier=SideEffectClassifier(
+                readonly_tools=harness.readonly_tools
+                | (
+                    observed_readonly_tools - approval_gate.required
+                    if approval_gate is not None
+                    else observed_readonly_tools
+                )
+            ),
+            trace_name=f"curie-run:{config.session.session_id}",
+            session_id=config.session.session_id,
+            model=config.model,
+            memory_store=memory_store,
+            history_store=history_store,
+            approval_gate=approval_gate,
+            approval_resumed_kind=config.approval_resumed_kind,
+            approval_decision=config.approval_decision,
+            false_completion_check=config.false_completion_check,
+            history_resumed=conversation_replay.present,
         ),
-        trace_name=f"curie-run:{config.session.session_id}",
         session_id=config.session.session_id,
-        model=config.model,
-        memory_store=memory_store,
-        history_store=history_store,
-        approval_gate=approval_gate,
-        approval_resumed_kind=config.approval_resumed_kind,
-        approval_decision=config.approval_decision,
-        false_completion_check=config.false_completion_check,
-        history_resumed=conversation_replay.present,
+        sandbox_id=config.session.sandbox_id,
+        cwd=workspace_cwd,
     )
 
 

--- a/runner/src/curie_runner/approval.py
+++ b/runner/src/curie_runner/approval.py
@@ -741,6 +741,11 @@ def _tool_policy_outcome(gate: ApprovalGate, tool_name: str) -> ToolPolicyDecisi
 
     if gate.tool_policy is None or not is_mcp_tool(tool_name):
         return None
+    # These exact tools belong to the platform-owned approval server, not to
+    # the bundle or one of its connectors.  Leave them to their existing
+    # permission/in-process gates; every other MCP name remains fail-closed.
+    if tool_name == APPROVAL_TOOL_NAME or tool_name == PUBLISH_TOOL_NAME:
+        return None
     canonical = canonical_tool_name(
         tool_name,
         bundle_name=gate.bundle_name,

--- a/runner/src/curie_runner/history.py
+++ b/runner/src/curie_runner/history.py
@@ -63,6 +63,21 @@ class StructuredReplayUnsupported(HistoryError):
 
 JsonContent = str | list[dict[str, Any]]
 
+# The state API caps one JSON value at 64 KiB. Transcript appends store a JSON
+# array, so a turn must fit with that array's brackets rather than merely fit as
+# a standalone object. Accumulated-log compaction is a separate concern: this
+# bound prevents a single large first turn from being rejected before any
+# durable conversation exists.
+HISTORY_VALUE_MAX_BYTES = 65_536
+
+_STRUCTURAL_BLOCK_FIELDS = {
+    "type",
+    "id",
+    "tool_use_id",
+    "name",
+    "is_error",
+}
+
 
 def _json_copy(value: JsonContent) -> JsonContent:
     """Return a detached JSON-safe copy of message content."""
@@ -263,6 +278,208 @@ class TurnRecord:
                 else None
             ),
         )
+
+
+def _state_value_size(record: Mapping[str, Any]) -> int:
+    """Return the state API's encoded size for a one-record transcript."""
+
+    return len(json.dumps([record], separators=(",", ":")).encode("utf-8"))
+
+
+def _digest_marker(value: str) -> str:
+    encoded = value.encode("utf-8")
+    digest = hashlib.sha256(encoded).hexdigest()
+    return (
+        "[history payload omitted; "
+        f"sha256={digest}; original_bytes={len(encoded)}]"
+    )
+
+
+def _collect_text_payloads(
+    value: Any,
+    *,
+    path: tuple[str | int, ...],
+    priority: int,
+    candidates: dict[str, tuple[int, list[tuple[str | int, ...]]]],
+) -> None:
+    """Collect replaceable string leaves without touching structural fields."""
+
+    if isinstance(value, str):
+        existing = candidates.get(value)
+        if existing is None:
+            candidates[value] = (priority, [path])
+        else:
+            existing_priority, paths = existing
+            paths.append(path)
+            candidates[value] = (min(existing_priority, priority), paths)
+        return
+    if isinstance(value, list):
+        for index, item in enumerate(value):
+            _collect_text_payloads(
+                item,
+                path=(*path, index),
+                priority=priority,
+                candidates=candidates,
+            )
+        return
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            _collect_text_payloads(
+                item,
+                path=(*path, str(key)),
+                priority=priority,
+                candidates=candidates,
+            )
+
+
+def _turn_text_payloads(
+    record: dict[str, Any],
+) -> dict[str, tuple[int, list[tuple[str | int, ...]]]]:
+    """Index portable text by reduction priority and stable object path."""
+
+    candidates: dict[str, tuple[int, list[tuple[str | int, ...]]]] = {}
+
+    # The legacy pair mirrors the structured messages. Grouping by value means
+    # both projections receive the same marker if either copy must be bounded.
+    for field in ("user", "assistant"):
+        value = record.get(field)
+        if isinstance(value, str):
+            _collect_text_payloads(
+                value,
+                path=(field,),
+                priority=3,
+                candidates=candidates,
+            )
+
+    approval = record.get("approval")
+    if isinstance(approval, Mapping) and isinstance(approval.get("summary"), str):
+        _collect_text_payloads(
+            approval["summary"],
+            path=("approval", "summary"),
+            priority=2,
+            candidates=candidates,
+        )
+
+    messages = record.get("messages")
+    if not isinstance(messages, list):
+        return candidates
+    for message_index, message in enumerate(messages):
+        if not isinstance(message, Mapping):
+            continue
+        content = message.get("content")
+        content_path: tuple[str | int, ...] = (
+            "messages",
+            message_index,
+            "content",
+        )
+        if isinstance(content, str):
+            _collect_text_payloads(
+                content,
+                path=content_path,
+                priority=3,
+                candidates=candidates,
+            )
+            continue
+        if not isinstance(content, list):
+            continue
+        for block_index, block in enumerate(content):
+            if not isinstance(block, Mapping):
+                continue
+            block_path = (*content_path, block_index)
+            block_type = block.get("type")
+            if block_type == "tool_result" and "content" in block:
+                _collect_text_payloads(
+                    block["content"],
+                    path=(*block_path, "content"),
+                    priority=0,
+                    candidates=candidates,
+                )
+            elif block_type == "text" and "text" in block:
+                _collect_text_payloads(
+                    block["text"],
+                    path=(*block_path, "text"),
+                    priority=1,
+                    candidates=candidates,
+                )
+
+            for key, item in block.items():
+                if key in _STRUCTURAL_BLOCK_FIELDS:
+                    continue
+                if block_type == "tool_result" and key == "content":
+                    continue
+                if block_type == "text" and key == "text":
+                    continue
+                _collect_text_payloads(
+                    item,
+                    path=(*block_path, str(key)),
+                    priority=2,
+                    candidates=candidates,
+                )
+    return candidates
+
+
+def _replace_path(
+    root: dict[str, Any], path: tuple[str | int, ...], replacement: str
+) -> None:
+    target: Any = root
+    for part in path[:-1]:
+        target = target[part]
+    target[path[-1]] = replacement
+
+
+def bound_turn_record(
+    record: TurnRecord, *, max_value_bytes: int = HISTORY_VALUE_MAX_BYTES
+) -> TurnRecord:
+    """Bound one turn for a whole state value without losing message order.
+
+    Native harness replay is discarded first because portable messages are the
+    authority across sandbox replacement. If that is insufficient, textual
+    payloads are replaced with deterministic digest and byte-count markers:
+    tool results first, then assistant text and other content, while role,
+    message, and block order remain intact. If that irreducible structure alone
+    exceeds the cap, fail before the transcript store sees an append.
+    """
+
+    if max_value_bytes <= 0:
+        raise HistoryError("history value byte cap must be positive")
+
+    raw = record.to_dict()
+    if _state_value_size(raw) <= max_value_bytes:
+        return record
+
+    raw["harness_replay"] = None
+    if _state_value_size(raw) <= max_value_bytes:
+        return TurnRecord.from_dict(raw)
+
+    candidates = _turn_text_payloads(raw)
+    ordered: list[tuple[int, int, str, str, list[tuple[str | int, ...]]]] = []
+    for original, (priority, paths) in candidates.items():
+        marker = _digest_marker(original)
+        original_size = len(json.dumps(original).encode("utf-8"))
+        marker_size = len(json.dumps(marker).encode("utf-8"))
+        savings = (original_size - marker_size) * len(paths)
+        if savings > 0:
+            ordered.append(
+                (
+                    priority,
+                    -savings,
+                    hashlib.sha256(original.encode("utf-8")).hexdigest(),
+                    marker,
+                    paths,
+                )
+            )
+
+    for _priority, _negative_savings, _digest, marker, paths in sorted(ordered):
+        for path in paths:
+            _replace_path(raw, path, marker)
+        if _state_value_size(raw) <= max_value_bytes:
+            return TurnRecord.from_dict(raw)
+
+    irreducible_size = _state_value_size(raw)
+    raise HistoryError(
+        "history turn cannot fit without dropping portable message roles or order: "
+        f"minimum value is {irreducible_size} bytes, cap is {max_value_bytes} bytes"
+    )
 
 
 @dataclass(frozen=True)

--- a/runner/src/curie_runner/server.py
+++ b/runner/src/curie_runner/server.py
@@ -28,8 +28,9 @@ from __future__ import annotations
 import contextlib
 import hmac
 import inspect
-from collections.abc import Awaitable, Callable
-from typing import cast
+from collections.abc import Awaitable, Callable, Mapping
+from types import MappingProxyType
+from typing import TypedDict, cast
 
 from aci_protocol import Event, Interrupt, parse_inbound
 from aiohttp import web
@@ -52,6 +53,41 @@ _GATED_PATHS = frozenset(
 RUNNER: web.AppKey[SessionRunner] = web.AppKey("runner", SessionRunner)
 Snapshotter = Callable[[], WorkspaceSnapshot | Awaitable[WorkspaceSnapshot]]
 SNAPSHOTTER: web.AppKey[object] = web.AppKey("snapshotter", object)
+STATUS_ATTESTATION: web.AppKey[object] = web.AppKey("status_attestation", object)
+
+
+class _StatusAttestation(TypedDict):
+    session_id: str
+    sandbox_id: str
+    managed_workspace: bool
+    cwd: str | None
+
+
+_STATUS_ATTESTATION_ATTR = "_curie_control_status_attestation"
+
+
+def bind_status_attestation(
+    runner: SessionRunner,
+    *,
+    session_id: str,
+    sandbox_id: str,
+    cwd: str | None,
+) -> SessionRunner:
+    """Bind credential-free boot facts for the authenticated worker status."""
+
+    attestation: _StatusAttestation = {
+        "session_id": session_id,
+        "sandbox_id": sandbox_id,
+        "managed_workspace": cwd is not None,
+        "cwd": cwd,
+    }
+    setattr(runner, _STATUS_ATTESTATION_ATTR, MappingProxyType(attestation))
+    return runner
+
+
+def _bound_status_attestation(runner: SessionRunner) -> Mapping[str, object] | None:
+    value = getattr(runner, _STATUS_ATTESTATION_ATTR, None)
+    return cast("Mapping[str, object]", value) if isinstance(value, Mapping) else None
 
 
 def _auth_middleware(token: str) -> Middleware:
@@ -103,6 +139,9 @@ def create_app(
     app = web.Application(middlewares=middlewares)
     app[RUNNER] = runner
     app[SNAPSHOTTER] = snapshotter
+    # An identity-bearing response exists only when middleware above enforces a
+    # non-empty bearer. Legacy/tokenless apps keep both status routes probe-only.
+    app[STATUS_ATTESTATION] = _bound_status_attestation(runner) if token else None
     app.add_routes(
         [
             web.get("/healthz", _healthz),
@@ -129,14 +168,17 @@ async def _healthz(_request: web.Request) -> web.Response:
 
 async def _status(request: web.Request) -> web.Response:
     runner: SessionRunner = request.app[RUNNER]
-    return web.json_response(
-        {
-            "status": runner.status.value,
-            "ready": runner.ready,
-            "turn_active": runner.turn_active,
-            "history_durable": runner.history_durable,
-        }
-    )
+    body: dict[str, object] = {
+        "status": runner.status.value,
+        "ready": runner.ready,
+        "turn_active": runner.turn_active,
+        "history_durable": runner.history_durable,
+    }
+    if request.path == "/v1/status":
+        attestation = cast("Mapping[str, object] | None", request.app[STATUS_ATTESTATION])
+        if attestation is not None:
+            body.update(attestation)
+    return web.json_response(body)
 
 
 async def _snapshot(request: web.Request) -> web.Response:

--- a/runner/src/curie_runner/session.py
+++ b/runner/src/curie_runner/session.py
@@ -49,6 +49,7 @@ from .history import (
     NullTranscriptStore,
     TranscriptStore,
     TurnRecord,
+    bound_turn_record,
     close_suspended_tool_calls,
 )
 from .memory import (
@@ -343,7 +344,7 @@ class SessionRunner:
                     exc,
                 )
         try:
-            await self._history.append(
+            record = bound_turn_record(
                 TurnRecord(
                     user=event.text,
                     assistant=state.final_text,
@@ -372,6 +373,7 @@ class SessionRunner:
                     harness_replay=harness_replay,
                 )
             )
+            await self._history.append(record)
             self._history_durable = True
         except Exception as exc:  # noqa: BLE001 - best-effort; never fail a completed turn
             self._history_durable = False

--- a/runner/src/curie_runner/session.py
+++ b/runner/src/curie_runner/session.py
@@ -260,8 +260,11 @@ class SessionRunner:
         self._turn_open = False
         # Safe-boundary fence for replacing a runner. A fresh runner has no
         # completed turn to lose. Once a turn begins, only a successful durable
-        # transcript append re-authorizes replacement.
+        # transcript append re-authorizes replacement, unless an earlier turn
+        # was already lost by this process. Later appends cannot repair that
+        # missing prefix, so the loss remains sticky for this runner's lifetime.
         self._history_durable = True
+        self._history_loss_observed = False
         self._active_state: TurnState | None = None
 
     @property
@@ -374,8 +377,9 @@ class SessionRunner:
                 )
             )
             await self._history.append(record)
-            self._history_durable = True
+            self._history_durable = not self._history_loss_observed
         except Exception as exc:  # noqa: BLE001 - best-effort; never fail a completed turn
+            self._history_loss_observed = True
             self._history_durable = False
             logger.warning(
                 "history append failed session=%s error_class=%s: %s",

--- a/runner/tests/test_history.py
+++ b/runner/tests/test_history.py
@@ -698,6 +698,94 @@ def test_irreducibly_large_turn_fails_durability_before_store_append(caplog) -> 
     )
 
 
+def test_history_durability_failure_is_sticky_after_later_successful_append() -> None:
+    """A later turn cannot make an earlier dropped turn safe to hand off."""
+
+    from aci_protocol import Event, Final, SessionStatus, parse_ndjson_line
+    from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock
+
+    class CountingStore(_RecordingStore):
+        def __init__(self) -> None:
+            super().__init__()
+            self.append_attempts = 0
+
+        async def append(self, record: TurnRecord) -> None:
+            self.append_attempts += 1
+            await super().append(record)
+
+    oversized_messages = 3_000
+    scripts = iter(
+        (
+            [
+                *(
+                    AssistantMessage(content=[], model="fake-model")
+                    for _ in range(oversized_messages)
+                ),
+                ResultMessage(
+                    subtype="success",
+                    duration_ms=1,
+                    duration_api_ms=1,
+                    is_error=False,
+                    num_turns=1,
+                    session_id="fake-session",
+                    result="first answer",
+                    usage={"input_tokens": 1, "output_tokens": 1},
+                ),
+            ],
+            [
+                AssistantMessage(
+                    content=[TextBlock(text="small answer")], model="fake-model"
+                ),
+                ResultMessage(
+                    subtype="success",
+                    duration_ms=1,
+                    duration_api_ms=1,
+                    is_error=False,
+                    num_turns=1,
+                    session_id="fake-session",
+                    result="small answer",
+                    usage={"input_tokens": 1, "output_tokens": 1},
+                ),
+            ],
+        )
+    )
+    store = CountingStore()
+    runner = _recording_runner(store, script=lambda: next(scripts))
+
+    async def go() -> None:
+        await runner.start()
+        first_lines = [
+            line
+            async for line in runner.run_inbound(
+                Event(type="message", text="oversized turn", user="U", ts="1")
+            )
+        ]
+        first_final = parse_ndjson_line(first_lines[-1])
+        assert isinstance(first_final, Final)
+        assert first_final.status is SessionStatus.DONE
+        assert runner.history_durable is False
+        assert store.append_attempts == 0
+
+        second_lines = [
+            line
+            async for line in runner.run_inbound(
+                Event(type="message", text="small turn", user="U", ts="2")
+            )
+        ]
+        second_final = parse_ndjson_line(second_lines[-1])
+        assert isinstance(second_final, Final)
+        assert second_final.status is SessionStatus.DONE
+        assert store.append_attempts == 1
+        assert len(store.turns) == 1
+        assert store.turns[0].assistant == "small answer"
+
+        # The earlier missing turn still makes replacement unsafe even though
+        # this append succeeded.
+        assert runner.history_durable is False
+
+    anyio.run(go)
+
+
 def test_state_store_load_rejects_non_array() -> None:
     app = web.Application()
 

--- a/runner/tests/test_history.py
+++ b/runner/tests/test_history.py
@@ -7,6 +7,9 @@ round-trip over real HTTP without the API. The write side is exercised by drivin
 a real turn through the SessionRunner with the fake model.
 """
 
+import hashlib
+import json
+
 import anyio
 import pytest
 from aiohttp import web
@@ -49,6 +52,58 @@ def _fake_state_app() -> tuple[web.Application, list]:
     app.router.add_get(key, get_key)
     app.router.add_post(f"{key}/append", append_key)
     return app, log
+
+
+_STATE_VALUE_MAX_BYTES = 65_536
+
+
+def _capped_state_app() -> tuple[web.Application, list, list[int]]:
+    """A state-key fake that enforces the API's whole-value JSON byte cap."""
+
+    log: list = []
+    rejected_sizes: list[int] = []
+    app = web.Application()
+    key = "/agents/A/state/transcript/t1"
+
+    async def get_key(_request: web.Request) -> web.Response:
+        if not log:
+            return web.json_response({"detail": "not found"}, status=404)
+        return web.json_response(
+            {"namespace": "transcript", "key": "t1", "value": list(log), "version": 1}
+        )
+
+    async def append_key(request: web.Request) -> web.Response:
+        body = await request.json()
+        candidate = [*log, body["item"]]
+        encoded_size = len(
+            json.dumps(candidate, separators=(",", ":")).encode("utf-8")
+        )
+        if encoded_size > _STATE_VALUE_MAX_BYTES:
+            rejected_sizes.append(encoded_size)
+            return web.json_response(
+                {
+                    "detail": (
+                        f"value is {encoded_size} bytes, over the "
+                        f"{_STATE_VALUE_MAX_BYTES}-byte per-value cap"
+                    )
+                },
+                status=413,
+            )
+        log.append(body["item"])
+        return web.json_response(
+            {"namespace": "transcript", "key": "t1", "value": list(log), "version": 1}
+        )
+
+    app.router.add_get(key, get_key)
+    app.router.add_post(f"{key}/append", append_key)
+    return app, log, rejected_sizes
+
+
+def _assert_digest_marker(value: object, original: str) -> None:
+    assert isinstance(value, str)
+    assert original not in value
+    assert hashlib.sha256(original.encode("utf-8")).hexdigest() in value
+    assert str(len(original.encode("utf-8"))) in value
 
 
 def test_turn_record_round_trip() -> None:
@@ -394,6 +449,253 @@ def test_state_store_append_then_load_round_trip() -> None:
             assert len(log) == 2
 
     anyio.run(go)
+
+
+def test_oversized_first_turn_is_bounded_before_append_and_cold_replays_in_order() -> None:
+    """The live-sized first record must fit before the state API sees it (#2271)."""
+
+    from aci_protocol import Event, Final, SessionStatus, parse_ndjson_line
+    from claude_agent_sdk import (
+        AssistantMessage,
+        ResultMessage,
+        TextBlock,
+        ToolResultBlock,
+        ToolUseBlock,
+        UserMessage,
+    )
+    from curie_runner import RunTracer, SideEffectClassifier
+    from curie_runner.fake import FakeModelSession
+    from curie_runner.session import SessionRunner
+
+    tool_payload = "tool-output-" + ("x" * 42_000)
+    assistant_payload = "assistant-output-" + ("y" * 42_000)
+    native_payload = "native-checkpoint-" + ("z" * 42_000)
+    harness_replay = HarnessReplayState(
+        harness="claude",
+        kind="checkpoint",
+        entries=({"type": "assistant", "payload": native_payload},),
+    )
+    raw_record = TurnRecord(
+        user="inspect the example workspace",
+        assistant=assistant_payload,
+        messages=(
+            ConversationMessage(role="user", content="inspect the example workspace"),
+            ConversationMessage(
+                role="assistant",
+                content=[
+                    {
+                        "type": "tool_use",
+                        "id": "call-example",
+                        "name": "Read",
+                        "input": {"path": "example.txt"},
+                    }
+                ],
+            ),
+            ConversationMessage(
+                role="user",
+                content=[
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "call-example",
+                        "content": tool_payload,
+                    }
+                ],
+            ),
+            ConversationMessage(
+                role="assistant",
+                content=[{"type": "text", "text": assistant_payload}],
+            ),
+        ),
+        harness_replay=harness_replay,
+    )
+    raw_value_size = len(
+        json.dumps([raw_record.to_dict()], separators=(",", ":")).encode("utf-8")
+    )
+    raw_without_native = TurnRecord(
+        user=raw_record.user,
+        assistant=raw_record.assistant,
+        messages=raw_record.messages,
+    )
+    assert raw_value_size > 84 * 1024
+    assert (
+        len(
+            json.dumps(
+                [raw_without_native.to_dict()], separators=(",", ":")
+            ).encode("utf-8")
+        )
+        > _STATE_VALUE_MAX_BYTES
+    )
+
+    class ReplayExportingFake(FakeModelSession):
+        async def export_replay_state(self) -> HarnessReplayState:
+            return harness_replay
+
+    script = lambda: [  # noqa: E731 - compact fixed SDK transcript fixture
+        AssistantMessage(
+            content=[
+                ToolUseBlock(
+                    id="call-example",
+                    name="Read",
+                    input={"path": "example.txt"},
+                )
+            ],
+            model="fake-model",
+        ),
+        UserMessage(
+            content=[
+                ToolResultBlock(
+                    tool_use_id="call-example",
+                    content=tool_payload,
+                    is_error=False,
+                )
+            ]
+        ),
+        AssistantMessage(
+            content=[TextBlock(text=assistant_payload)], model="fake-model"
+        ),
+        ResultMessage(
+            subtype="success",
+            duration_ms=1,
+            duration_api_ms=1,
+            is_error=False,
+            num_turns=1,
+            session_id="fake-session",
+            result=assistant_payload,
+            usage={"input_tokens": 1, "output_tokens": 1},
+        ),
+    ]
+    app, log, rejected_sizes = _capped_state_app()
+
+    async def go() -> None:
+        async with TestServer(app) as server:
+            key_url = str(server.make_url("/agents/A/state/transcript/t1"))
+            session = ReplayExportingFake(script)
+            runner = SessionRunner(
+                session_factory=lambda: session,
+                ceiling=0,
+                tracer=RunTracer(None),
+                classifier=SideEffectClassifier(),
+                trace_name="bounded-history",
+                session_id="session-example",
+                history_store=StateApiTranscriptStore(key_url, token=None),
+            )
+            await runner.start()
+            lines = [
+                line
+                async for line in runner.run_inbound(
+                    Event(
+                        type="message",
+                        text="inspect the example workspace",
+                        user="U",
+                        ts="1",
+                    )
+                )
+            ]
+            final = parse_ndjson_line(lines[-1])
+            assert isinstance(final, Final)
+            assert final.status is SessionStatus.DONE
+            assert runner.history_durable is True
+
+            # Bounding is pre-append: the API must never reject a raw attempt.
+            assert rejected_sizes == []
+            assert len(log) == 1
+            assert (
+                len(json.dumps(log, separators=(",", ":")).encode("utf-8"))
+                <= _STATE_VALUE_MAX_BYTES
+            )
+
+            cold_store = StateApiTranscriptStore(key_url, token=None)
+            cold_records = await cold_store.load()
+            replay, summary = build_conversation_replay(
+                cold_records, max_turns=None, max_bytes=None
+            )
+            assert summary is None
+            assert replay.present is True
+            assert [message.role for message in replay.messages] == [
+                "user",
+                "assistant",
+                "user",
+                "assistant",
+            ]
+
+            bounded = cold_records[0]
+            assert isinstance(bounded, TurnRecord)
+            assert bounded.harness_replay is None
+            assert bounded.user == "inspect the example workspace"
+            _assert_digest_marker(bounded.assistant, assistant_payload)
+            tool_result = bounded.messages[2].content
+            assert isinstance(tool_result, list)
+            _assert_digest_marker(tool_result[0]["content"], tool_payload)
+            assistant_text = bounded.messages[3].content
+            assert isinstance(assistant_text, list)
+            _assert_digest_marker(assistant_text[0]["text"], assistant_payload)
+
+    anyio.run(go)
+
+
+def test_irreducibly_large_turn_fails_durability_before_store_append(caplog) -> None:
+    """Role/order overhead cannot be dropped merely to manufacture a small record."""
+
+    from aci_protocol import Event, SessionStatus
+    from claude_agent_sdk import AssistantMessage, ResultMessage
+
+    class CountingStore(_RecordingStore):
+        def __init__(self) -> None:
+            super().__init__()
+            self.append_attempts = 0
+
+        async def append(self, record: TurnRecord) -> None:
+            self.append_attempts += 1
+            await super().append(record)
+
+    empty_assistant_messages = 3_000
+    script = lambda: [  # noqa: E731 - compact fixed SDK transcript fixture
+        *(
+            AssistantMessage(content=[], model="fake-model")
+            for _ in range(empty_assistant_messages)
+        ),
+        ResultMessage(
+            subtype="success",
+            duration_ms=1,
+            duration_api_ms=1,
+            is_error=False,
+            num_turns=1,
+            session_id="fake-session",
+            result="answer",
+            usage={"input_tokens": 1, "output_tokens": 1},
+        ),
+    ]
+    irreducible = TurnRecord(
+        user="q",
+        assistant="answer",
+        messages=(
+            ConversationMessage(role="user", content="q"),
+            *(
+                ConversationMessage(role="assistant", content=[])
+                for _ in range(empty_assistant_messages)
+            ),
+        ),
+    )
+    assert (
+        len(json.dumps([irreducible.to_dict()], separators=(",", ":")).encode("utf-8"))
+        > _STATE_VALUE_MAX_BYTES
+    )
+
+    store = CountingStore()
+    runner = _recording_runner(store, script=script)
+    final = _run_recording_turn(
+        runner, Event(type="message", text="q", user="U", ts="1")
+    )
+
+    assert final.status is SessionStatus.DONE
+    assert runner.history_durable is False
+    assert store.append_attempts == 0
+    assert store.turns == []
+    assert any(
+        "history append failed" in record.getMessage()
+        and "HistoryError" in record.getMessage()
+        for record in caplog.records
+    )
 
 
 def test_state_store_load_rejects_non_array() -> None:

--- a/runner/tests/test_live.py
+++ b/runner/tests/test_live.py
@@ -26,6 +26,7 @@ from curie_runner.adapter import (
     build_structured_resume,
     model_message_to_conversation,
 )
+from curie_runner.approval import PUBLISH_TOOL_NAME
 from curie_runner.history import (
     ConversationMessage,
     ConversationReplay,
@@ -196,6 +197,43 @@ def _drive_live_catalog(
     return anyio.run(go)
 
 
+def _structured_tool_history(
+    record: TurnRecord,
+) -> tuple[dict[str, list[dict[str, Any]]], dict[str, list[dict[str, Any]]]]:
+    """Index persisted SDK tool calls and their results without trusting prose."""
+
+    uses: dict[str, list[dict[str, Any]]] = {}
+    results: dict[str, list[dict[str, Any]]] = {}
+    for message in record.messages:
+        if not isinstance(message.content, list):
+            continue
+        for block in message.content:
+            if block.get("type") == "tool_use":
+                name = block.get("name")
+                if isinstance(name, str):
+                    uses.setdefault(name, []).append(block)
+            elif block.get("type") == "tool_result":
+                tool_use_id = block.get("tool_use_id")
+                if isinstance(tool_use_id, str):
+                    results.setdefault(tool_use_id, []).append(block)
+    return uses, results
+
+
+def _successful_tool_result_text(
+    use: dict[str, Any], results: dict[str, list[dict[str, Any]]]
+) -> str:
+    tool_use_id = use.get("id")
+    assert isinstance(tool_use_id, str), f"tool use carried no id: {use!r}"
+    matches = results.get(tool_use_id)
+    assert matches, f"tool use {tool_use_id!r} carried no structured result"
+    assert all(result.get("is_error") is not True for result in matches), matches
+    return json.dumps(
+        [result.get("content") for result in matches],
+        sort_keys=True,
+        default=str,
+    )
+
+
 def test_workspace_catalog_assertion_rejects_missing_and_pluginless_init(
     tmp_path: Path,
 ) -> None:
@@ -231,16 +269,43 @@ def test_live_claim_time_workspace_init_catalogue(
     )
     bundle = _production_sre_bundle(tmp_path)
     init_messages = _install_init_observer(monkeypatch)
-    runner = boot.build_runner(
-        _catalog_config(bundle, f"claim-{uuid4()}"),
-        workspace_path=workspace,
-    )
+    store = _LiveTranscriptStore()
+    nonce = uuid4().hex
+    sentinel_path = workspace / f".curie-2271-claim-tool-{nonce}.txt"
+    sentinel_text = f"claim-workspace-sentinel-{nonce}"
+    sentinel_path.write_text(f"{sentinel_text}\n", encoding="utf-8")
+    try:
+        runner = boot.build_runner(
+            _catalog_config(bundle, f"claim-{uuid4()}"),
+            history_store=store,
+            workspace_path=workspace,
+        )
 
-    final = _drive_live_catalog(runner)
+        final = _drive_live_catalog(
+            runner,
+            prompt=(
+                "This is a bounded workspace tool check. Perform exactly these "
+                "steps before answering: call Bash with the command `pwd`; then "
+                f"call Read with the absolute file path `{sentinel_path}`. "
+                "Do not call Skill or any other tool. After both results arrive, "
+                "reply with only: workspace-tool-check-complete"
+            ),
+        )
 
-    assert final.status is SessionStatus.DONE
-    assert init_messages, "real SDK claim-time boot emitted no init frame"
-    _assert_production_workspace_init(init_messages[-1], bundle=bundle)
+        assert final.status is SessionStatus.DONE
+        assert init_messages, "real SDK claim-time boot emitted no init frame"
+        _assert_production_workspace_init(init_messages[-1], bundle=bundle)
+        assert len(store.records) == 1
+        uses, results = _structured_tool_history(store.records[0])
+        assert {"Bash", "Read"} <= set(uses), (
+            f"claim-time turn did not execute required coding tools: {sorted(uses)}"
+        )
+        bash_text = _successful_tool_result_text(uses["Bash"][0], results)
+        read_text = _successful_tool_result_text(uses["Read"][0], results)
+        assert "/workspace" in bash_text, bash_text
+        assert sentinel_text in read_text, read_text
+    finally:
+        sentinel_path.unlink(missing_ok=True)
 
 
 @pytest.mark.skipif(
@@ -284,7 +349,24 @@ def test_live_late_workspace_replacement_init_catalogue(
     assert config.session.session_id == logical_session_id
     assert config.history_ref == history_ref
 
-    history_marker = f"prior-workspace-context-{uuid4().hex}"
+    nonce = uuid4().hex
+    history_marker = f"prior-workspace-context-{nonce}"
+    fixture_dir = workspace / f".curie-2271-late-tool-{nonce}"
+    instruction_path = fixture_dir / "AGENTS.md"
+    sentinel_path = fixture_dir / "sentinel.txt"
+    old_sentinel = f"late-workspace-before-{nonce}"
+    new_sentinel = f"late-workspace-after-{nonce}"
+    verification_command = (
+        f"grep -Fx -- {shlex.quote(new_sentinel)} {shlex.quote(str(sentinel_path))}"
+    )
+    scoped_instructions = (
+        "# Scoped verification instructions\n\n"
+        "For changes to files in this directory, the required applicable check is "
+        "exactly:\n\n"
+        f"```sh\n{verification_command}\n```\n\n"
+        "Run that bounded check after editing `sentinel.txt` and before requesting "
+        "publication. A successful result verifies the complete sentinel content.\n"
+    )
     prior_turn = TurnRecord(
         user=f"Retain this exact marker for the next turn: {history_marker}",
         assistant="I will retain that exact marker for the next turn.",
@@ -320,27 +402,99 @@ def test_live_late_workspace_replacement_init_catalogue(
     assert replay.present
 
     init_messages = _install_init_observer(monkeypatch)
-    replacement = boot.build_runner(
-        config,
-        history_store=store,
-        conversation_replay=replay,
-        workspace_path=workspace,
-    )
+    fixture_dir.mkdir()
+    instruction_path.write_text(scoped_instructions, encoding="utf-8")
+    sentinel_path.write_text(f"{old_sentinel}\n", encoding="utf-8")
+    try:
+        replacement = boot.build_runner(
+            config,
+            history_store=store,
+            conversation_replay=replay,
+            workspace_path=workspace,
+        )
 
-    final = _drive_live_catalog(
-        replacement,
-        prompt=(
-            "Reply with only the exact marker I asked you to retain in the "
-            "immediately prior turn. Do not call any tool."
-        ),
-    )
+        final = _drive_live_catalog(
+            replacement,
+            prompt=(
+                "Complete every step in this bounded late-handoff check using tools; "
+                "do not merely describe the steps and do not stop after editing. "
+                "Recover the exact marker from the immediately prior turn. First call "
+                f"Read on the scoped instruction file `{instruction_path}` and follow "
+                f"it. Second call Read on `{sentinel_path}`. Third call Edit on that same file "
+                f"and replace the exact text `{old_sentinel}` with `{new_sentinel}`. "
+                "Do not edit the instruction file or touch any other file. Fourth call "
+                "Bash with exactly the check documented by the scoped instruction: "
+                f"verification command: `{verification_command}`. Wait for its "
+                "successful result. Fifth, you MUST call "
+                "mcp__curie__publish_changes with title `Workspace tool check` and "
+                "body set to exactly the recovered marker. Calling that tool requests "
+                "approval; make the call now even though it will pause the turn. Do "
+                "not call Skill."
+            ),
+        )
 
-    assert final.status is SessionStatus.DONE
-    assert history_marker in final.text, (
-        "late workspace replacement did not use its durable prior-turn context"
-    )
-    assert init_messages, "fresh late workspace runner emitted no SDK init frame"
-    _assert_production_workspace_init(init_messages[-1], bundle=bundle)
+        assert init_messages, "fresh late workspace runner emitted no SDK init frame"
+        _assert_production_workspace_init(init_messages[-1], bundle=bundle)
+        assert len(store.records) == 2
+        uses, results = _structured_tool_history(store.records[-1])
+        assert {"Read", "Edit", "Bash", PUBLISH_TOOL_NAME} <= set(uses), (
+            "late replacement did not execute required coding surface; "
+            f"persisted tool names={sorted(uses)}, final_status={final.status.value!r}, "
+            f"final_text={final.text!r}"
+        )
+        read_by_path = {
+            use.get("input", {}).get("file_path"): use
+            for use in uses["Read"]
+            if isinstance(use.get("input"), dict)
+        }
+        instruction_read = read_by_path.get(str(instruction_path))
+        sentinel_read = read_by_path.get(str(sentinel_path))
+        assert instruction_read is not None, read_by_path
+        assert sentinel_read is not None, read_by_path
+        assert verification_command in _successful_tool_result_text(
+            instruction_read, results
+        )
+        assert old_sentinel in _successful_tool_result_text(sentinel_read, results)
+        assert sentinel_path.read_text(encoding="utf-8") == f"{new_sentinel}\n"
+        edit_text = _successful_tool_result_text(uses["Edit"][0], results)
+        assert edit_text
+        bash_use = next(
+            (
+                use
+                for use in uses["Bash"]
+                if isinstance(use.get("input"), dict)
+                and use["input"].get("command") == verification_command
+            ),
+            None,
+        )
+        assert bash_use is not None, uses["Bash"]
+        bash_text = _successful_tool_result_text(bash_use, results)
+        assert new_sentinel in bash_text, bash_text
+        publish_use = uses[PUBLISH_TOOL_NAME][0]
+        publish_input = publish_use.get("input")
+        assert isinstance(publish_input, dict)
+        assert publish_input.get("body") == history_marker, (
+            "late workspace replacement did not recall durable prior-turn context"
+        )
+        publish_id = publish_use.get("id")
+        assert isinstance(publish_id, str)
+        publish_results = results.get(publish_id)
+        assert publish_results
+        assert any(result.get("is_error") is True for result in publish_results)
+        publish_result_text = json.dumps(
+            [result.get("content") for result in publish_results],
+            sort_keys=True,
+            default=str,
+        ).lower()
+        assert "requires human approval" in publish_result_text
+        assert "an approval request has been recorded" in publish_result_text
+        assert final.status is SessionStatus.AWAITING_APPROVAL
+        assert final.approval_gate_kind == "permission"
+        assert final.approval_granted_tool == PUBLISH_TOOL_NAME
+    finally:
+        sentinel_path.unlink(missing_ok=True)
+        instruction_path.unlink(missing_ok=True)
+        fixture_dir.rmdir()
 
 
 @pytest.mark.skipif(

--- a/runner/tests/test_live.py
+++ b/runner/tests/test_live.py
@@ -28,6 +28,7 @@ from curie_runner.adapter import (
 )
 from curie_runner.history import (
     ConversationMessage,
+    ConversationReplay,
     HarnessReplayState,
     TurnRecord,
     build_conversation_replay,
@@ -37,6 +38,10 @@ from curie_runner.session import SessionRunner
 _HAS_CRED = bool(os.environ.get("CLAUDE_CODE_OAUTH_TOKEN") or os.environ.get("ANTHROPIC_API_KEY"))
 _OPENROUTER_KEY = os.environ.get("OPENROUTER_API_KEY", "")
 _LIVE_REQUESTED = os.environ.get("CURIE_E2E_LIVE") == "1"
+
+_WORKSPACE_REQUIRED_TOOLS = frozenset(
+    {"Read", "Edit", "Bash", "mcp__curie__publish_changes"}
+)
 
 
 class _LiveTranscriptStore:
@@ -48,6 +53,231 @@ class _LiveTranscriptStore:
 
     async def append(self, record: TurnRecord) -> None:
         self.records.append(record)
+
+
+def _production_sre_source() -> Path:
+    return Path(__file__).parents[2] / "examples" / "sre-bot"
+
+
+def _production_sre_bundle(tmp_path: Path) -> Path:
+    source = _production_sre_source()
+    bundle = tmp_path / "sre-bot"
+    (bundle / ".claude-plugin").mkdir(parents=True)
+    (bundle / "skills" / "sre-bot").mkdir(parents=True)
+    (bundle / ".claude-plugin" / "plugin.json").write_text(
+        (source / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    (bundle / "skills" / "sre-bot" / "SKILL.md").write_text(
+        (source / "skills" / "sre-bot" / "SKILL.md").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    # The checked-in example's connector build declarations require the
+    # deploy-generated connectors.lock.yaml. This runner fixture preserves the
+    # exact SRE manifest, skill, toolPolicy, and approvalPolicy while keeping
+    # the policy's direct connector namespace. Non-build URL connectors need no
+    # generated lock file. Loopback port 9 refuses promptly if probed.
+    (bundle / "connectors.yaml").write_text(
+        "connectors:\n"
+        "  kubernetes:\n"
+        "    url: http://127.0.0.1:9/kubernetes\n"
+        "  self-upgrade:\n"
+        "    url: http://127.0.0.1:9/self-upgrade\n",
+        encoding="utf-8",
+    )
+    manifest = json.loads(
+        (bundle / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8")
+    )
+    assert manifest["name"] == "sre-bot"
+    assert manifest["toolPolicy"]["enforcement"] == "curie/mcp-tool-policy@1"
+    assert manifest["approvalPolicy"]["gates"]
+    return bundle
+
+
+def _assert_production_workspace_init(
+    init: dict[str, Any], *, bundle: Path
+) -> None:
+    """Require the real mounted catalogue, not an options-only substitute."""
+
+    source = _production_sre_source()
+    manifest = bundle / ".claude-plugin" / "plugin.json"
+    skill = bundle / "skills" / "sre-bot" / "SKILL.md"
+    assert (
+        manifest.is_file()
+        and skill.is_file()
+        and manifest.read_text(encoding="utf-8")
+        == (source / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8")
+        and skill.read_text(encoding="utf-8")
+        == (source / "skills" / "sre-bot" / "SKILL.md").read_text(encoding="utf-8")
+        and (bundle / "connectors.yaml").is_file()
+        and not (bundle / ".mcp.json").exists()
+    ), (
+        "generic or plugin-less bundle cannot satisfy SRE workspace acceptance"
+    )
+    raw_tools = init.get("tools")
+    assert isinstance(raw_tools, list), "SDK init carried no concrete tools catalogue"
+    tools = {str(tool) for tool in raw_tools}
+    missing = sorted(_WORKSPACE_REQUIRED_TOOLS - tools)
+    assert not missing, f"mounted SDK init catalogue missing required tools: {missing}"
+    assert init.get("cwd") == "/workspace", (
+        f"mounted SDK init cwd was {init.get('cwd')!r}, expected '/workspace'"
+    )
+
+
+def _catalog_config(bundle: Path, session_id: str):
+    from curie_runner.config import RunnerConfig
+
+    env = {
+        "CURIE_PLUGIN_DIR": str(bundle),
+        "CURIE_SESSION_ID": session_id,
+        "CURIE_SANDBOX_ID": f"sandbox-{session_id}",
+        "CURIE_BUDGET": (
+            '{"max_output_tokens_per_run": 10000, "max_usd_per_day": 1.0}'
+        ),
+    }
+    if model := os.environ.get("CURIE_MODEL"):
+        env["CURIE_MODEL"] = model
+    return RunnerConfig.from_env(env)
+
+
+def _install_init_observer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> list[dict[str, Any]]:
+    from claude_agent_sdk import SystemMessage
+    from curie_runner import __main__ as boot
+
+    init_messages: list[dict[str, Any]] = []
+
+    class InitObservingSession(ClaudeAgentSession):
+        def receive_turn(self):
+            upstream = super().receive_turn()
+
+            async def observe():
+                async for message in upstream:
+                    # claude-agent-sdk 0.2.135 message_parser.py preserves the
+                    # CLI init frame as SystemMessage(subtype="init"). The
+                    # catalogue and cwd are observed SDK output, not inferred
+                    # from ClaudeAgentOptions.
+                    if isinstance(message, SystemMessage) and message.subtype == "init":
+                        init_messages.append(dict(message.data))
+                    yield message
+
+            return observe()
+
+    monkeypatch.setattr(boot, "ClaudeAgentSession", InitObservingSession)
+    return init_messages
+
+
+def _drive_live_catalog(runner: SessionRunner) -> Final:
+    async def go() -> Final:
+        await runner.start()
+        final: Final | None = None
+        try:
+            async for line in runner.run_turn(
+                Event(
+                    type="message",
+                    text="Reply with only: workspace-ready. Do not call any tool.",
+                    user="U0EXAMPLE",
+                    ts="1",
+                )
+            ):
+                parsed = parse_ndjson_line(line)
+                if isinstance(parsed, Final):
+                    final = parsed
+        finally:
+            await runner.close()
+        assert final is not None, "real SDK turn emitted no terminal Final"
+        return final
+
+    return anyio.run(go)
+
+
+def test_workspace_catalog_assertion_rejects_missing_and_pluginless_init(
+    tmp_path: Path,
+) -> None:
+    bundle = _production_sre_bundle(tmp_path / "production")
+    complete = list(_WORKSPACE_REQUIRED_TOOLS)
+    without_bash = [tool for tool in complete if tool != "Bash"]
+    with pytest.raises(AssertionError, match="missing required tools.*Bash"):
+        _assert_production_workspace_init(
+            {"tools": without_bash, "cwd": "/workspace"}, bundle=bundle
+        )
+
+    generic = tmp_path / "generic-plugin"
+    generic.mkdir()
+    with pytest.raises(AssertionError, match="generic or plugin-less bundle"):
+        _assert_production_workspace_init(
+            {"tools": complete, "cwd": "/workspace"}, bundle=generic
+        )
+
+
+@pytest.mark.skipif(
+    not _LIVE_REQUESTED,
+    reason="set CURIE_E2E_LIVE=1 for real SDK mounted workspace catalogue evidence",
+)
+def test_live_claim_time_workspace_init_catalogue(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from curie_runner import __main__ as boot
+
+    workspace = Path("/workspace")
+    assert workspace.is_dir() and (workspace / ".git").exists(), (
+        "CURIE_E2E_LIVE=1 workspace catalogue proof requires a mounted "
+        "/workspace checkout"
+    )
+    bundle = _production_sre_bundle(tmp_path)
+    init_messages = _install_init_observer(monkeypatch)
+    runner = boot.build_runner(
+        _catalog_config(bundle, f"claim-{uuid4()}"),
+        workspace_path=workspace,
+    )
+
+    final = _drive_live_catalog(runner)
+
+    assert final.status is SessionStatus.DONE
+    assert init_messages, "real SDK claim-time boot emitted no init frame"
+    _assert_production_workspace_init(init_messages[-1], bundle=bundle)
+
+
+@pytest.mark.skipif(
+    not _LIVE_REQUESTED,
+    reason="set CURIE_E2E_LIVE=1 for real SDK late workspace catalogue evidence",
+)
+def test_live_late_workspace_replacement_init_catalogue(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from curie_runner import __main__ as boot
+
+    workspace = Path("/workspace")
+    assert workspace.is_dir() and (workspace / ".git").exists(), (
+        "CURIE_E2E_LIVE=1 workspace catalogue proof requires a mounted "
+        "/workspace checkout"
+    )
+    bundle = _production_sre_bundle(tmp_path)
+    session_id = f"late-{uuid4()}"
+    config = _catalog_config(bundle, session_id)
+
+    # The first claim is the idle, unmounted standing-by session. It has the
+    # same thread identity and production bundle, but its options-only shape is
+    # deliberately not accepted as catalogue evidence. The fresh replacement
+    # below is the only runner driven through a real SDK init frame.
+    boot.build_runner(
+        config,
+        conversation_replay=ConversationReplay(),
+        workspace_path=None,
+    )
+    init_messages = _install_init_observer(monkeypatch)
+    replacement = boot.build_runner(
+        config,
+        conversation_replay=ConversationReplay(),
+        workspace_path=workspace,
+    )
+
+    final = _drive_live_catalog(replacement)
+
+    assert final.status is SessionStatus.DONE
+    assert init_messages, "fresh late workspace runner emitted no SDK init frame"
+    _assert_production_workspace_init(init_messages[-1], bundle=bundle)
 
 
 @pytest.mark.skipif(

--- a/runner/tests/test_live.py
+++ b/runner/tests/test_live.py
@@ -168,7 +168,11 @@ def _install_init_observer(
     return init_messages
 
 
-def _drive_live_catalog(runner: SessionRunner) -> Final:
+def _drive_live_catalog(
+    runner: SessionRunner,
+    *,
+    prompt: str = "Reply with only: workspace-ready. Do not call any tool.",
+) -> Final:
     async def go() -> Final:
         await runner.start()
         final: Final | None = None
@@ -176,7 +180,7 @@ def _drive_live_catalog(runner: SessionRunner) -> Final:
             async for line in runner.run_turn(
                 Event(
                     type="message",
-                    text="Reply with only: workspace-ready. Do not call any tool.",
+                    text=prompt,
                     user="U0EXAMPLE",
                     ts="1",
                 )
@@ -246,7 +250,9 @@ def test_live_claim_time_workspace_init_catalogue(
 def test_live_late_workspace_replacement_init_catalogue(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    from aci_protocol import BootEnv
     from curie_runner import __main__ as boot
+    from curie_runner.config import RunnerConfig
 
     workspace = Path("/workspace")
     assert workspace.is_dir() and (workspace / ".git").exists(), (
@@ -254,28 +260,85 @@ def test_live_late_workspace_replacement_init_catalogue(
         "/workspace checkout"
     )
     bundle = _production_sre_bundle(tmp_path)
-    session_id = f"late-{uuid4()}"
-    config = _catalog_config(bundle, session_id)
-
-    # The first claim is the idle, unmounted standing-by session. It has the
-    # same thread identity and production bundle, but its options-only shape is
-    # deliberately not accepted as catalogue evidence. The fresh replacement
-    # below is the only runner driven through a real SDK init frame.
-    boot.build_runner(
-        config,
-        conversation_replay=ConversationReplay(),
-        workspace_path=None,
+    logical_session_id = f"agent-acme-thread-{uuid4()}"
+    history_ref = (
+        "http://api.example.com/agents/acme-agent/state/transcript/"
+        f"thread-{uuid4()}"
     )
+    base_config = _catalog_config(bundle, logical_session_id)
+
+    # SandboxSubstrate.handoff carries the standing claim's exact logical
+    # session and history identities into the replacement boot env. Render the
+    # same worker-owned shape rather than constructing runner options directly;
+    # the substrate adds only its fresh sandbox identity.
+    handoff_env = BootEnv.render_worker(
+        plugin_dir=str(bundle),
+        session_id=logical_session_id,
+        budget=base_config.session.budget,
+        memory_ref="http://api.example.com/agents/acme-agent/state/memory",
+        history_ref=history_ref,
+        model=os.environ.get("CURIE_MODEL"),
+    )
+    handoff_env[BootEnv.env_key("sandbox_id")] = "sandbox-acme-workspace-replacement"
+    config = RunnerConfig.from_env(handoff_env)
+    assert config.session.session_id == logical_session_id
+    assert config.history_ref == history_ref
+
+    history_marker = f"prior-workspace-context-{uuid4().hex}"
+    prior_turn = TurnRecord(
+        user=f"Retain this exact marker for the next turn: {history_marker}",
+        assistant="I will retain that exact marker for the next turn.",
+        ts="2026-09-03T00:00:00Z",
+        messages=(
+            ConversationMessage(
+                role="user",
+                content=f"Retain this exact marker for the next turn: {history_marker}",
+            ),
+            ConversationMessage(
+                role="assistant",
+                content=[
+                    {
+                        "type": "text",
+                        "text": "I will retain that exact marker for the next turn.",
+                    }
+                ],
+            ),
+        ),
+    )
+    store = _LiveTranscriptStore()
+
+    async def seed_durable_replay() -> ConversationReplay:
+        await store.append(prior_turn)
+        records = await store.load()
+        replay, summary = build_conversation_replay(
+            records, max_turns=None, max_bytes=None
+        )
+        assert summary is None
+        return replay
+
+    replay = anyio.run(seed_durable_replay)
+    assert replay.present
+
     init_messages = _install_init_observer(monkeypatch)
     replacement = boot.build_runner(
         config,
-        conversation_replay=ConversationReplay(),
+        history_store=store,
+        conversation_replay=replay,
         workspace_path=workspace,
     )
 
-    final = _drive_live_catalog(replacement)
+    final = _drive_live_catalog(
+        replacement,
+        prompt=(
+            "Reply with only the exact marker I asked you to retain in the "
+            "immediately prior turn. Do not call any tool."
+        ),
+    )
 
     assert final.status is SessionStatus.DONE
+    assert history_marker in final.text, (
+        "late workspace replacement did not use its durable prior-turn context"
+    )
     assert init_messages, "fresh late workspace runner emitted no SDK init frame"
     _assert_production_workspace_init(init_messages[-1], bundle=bundle)
 

--- a/runner/tests/test_server.py
+++ b/runner/tests/test_server.py
@@ -1,9 +1,14 @@
 """The aiohttp ACI channel: health, status, event stream, interrupt, steer."""
 
+import json
+from pathlib import Path
+
 import anyio
 from aci_protocol import SessionStatus, parse_ndjson
 from aiohttp.test_utils import TestClient, TestServer
 from curie_runner import RunTracer, SideEffectClassifier, create_app
+from curie_runner.__main__ import build_runner
+from curie_runner.config import RunnerConfig
 from curie_runner.fake import FakeModelSession
 from curie_runner.session import SessionRunner
 from opentelemetry.sdk.trace import TracerProvider
@@ -21,6 +26,41 @@ def _runner() -> tuple[SessionRunner, FakeModelSession]:
         trace_name="t",
     )
     return runner, fake
+
+
+def _boot_runner(
+    tmp_path: Path, *, managed_workspace: bool
+) -> tuple[SessionRunner, Path | None]:
+    """Build the actual fake-model boot path with claim identity and workspace state."""
+
+    plugin_dir = tmp_path / "bundle"
+    manifest_dir = plugin_dir / ".claude-plugin"
+    manifest_dir.mkdir(parents=True)
+    (manifest_dir / "plugin.json").write_text(
+        json.dumps({"name": "acme-bot"}), encoding="utf-8"
+    )
+    workspace_path: Path | None = None
+    if managed_workspace:
+        workspace_path = tmp_path / "workspace"
+        (workspace_path / ".git").mkdir(parents=True)
+    config = RunnerConfig.from_env(
+        {
+            "CURIE_PLUGIN_DIR": str(plugin_dir),
+            "CURIE_SESSION_ID": "session-acme-workspace",
+            "CURIE_SANDBOX_ID": "sandbox-acme-workspace",
+            "CURIE_BUDGET": (
+                '{"max_output_tokens_per_run": 10000, "max_usd_per_day": 1.0}'
+            ),
+        }
+    )
+    return (
+        build_runner(
+            config,
+            fake_model=True,
+            workspace_path=workspace_path,
+        ),
+        workspace_path,
+    )
 
 
 def test_healthz_status_and_event_round_trip() -> None:
@@ -228,6 +268,68 @@ def test_control_status_requires_auth_while_probe_status_remains_open() -> None:
             authenticated = await client.get("/v1/status", headers=_AUTH)
             assert authenticated.status == 200
             assert (await authenticated.json())["history_durable"] is True
+
+    anyio.run(go)
+
+
+def test_authenticated_status_attests_actual_mounted_workspace_boot(tmp_path: Path) -> None:
+    runner, workspace_path = _boot_runner(tmp_path, managed_workspace=True)
+    assert workspace_path is not None
+
+    async def go() -> None:
+        await runner.start()
+        async with TestClient(TestServer(create_app(runner, token=_TOKEN))) as client:
+            # Boot identity and filesystem placement are control-plane facts. The
+            # unauthenticated probe remains useful without disclosing either.
+            probe = await client.get("/status")
+            probe_body = await probe.json()
+            assert probe.status == 200
+            assert "session_id" not in probe_body
+            assert "sandbox_id" not in probe_body
+            assert "managed_workspace" not in probe_body
+            assert "cwd" not in probe_body
+
+            unauthenticated = await client.get("/v1/status")
+            assert unauthenticated.status == 401
+            authenticated = await client.get("/v1/status", headers=_AUTH)
+            body = await authenticated.json()
+            assert authenticated.status == 200
+            # Preserve the pre-attestation status DTO while adding enough
+            # runner-observed state for a worker to reject a wrong replacement.
+            assert body["status"] == SessionStatus.IDLE_AWAITING_INPUT.value
+            assert body["ready"] is True
+            assert body["turn_active"] is False
+            assert body["history_durable"] is True
+            assert {
+                "session_id": "session-acme-workspace",
+                "sandbox_id": "sandbox-acme-workspace",
+                "managed_workspace": True,
+                "cwd": str(workspace_path),
+            }.items() <= body.items()
+
+    anyio.run(go)
+
+
+def test_authenticated_status_attests_unmounted_boot_without_cwd(tmp_path: Path) -> None:
+    runner, workspace_path = _boot_runner(tmp_path, managed_workspace=False)
+    assert workspace_path is None
+
+    async def go() -> None:
+        await runner.start()
+        async with TestClient(TestServer(create_app(runner, token=_TOKEN))) as client:
+            authenticated = await client.get("/v1/status", headers=_AUTH)
+            body = await authenticated.json()
+            assert authenticated.status == 200
+            assert body["status"] == SessionStatus.IDLE_AWAITING_INPUT.value
+            assert body["ready"] is True
+            assert body["turn_active"] is False
+            assert body["history_durable"] is True
+            assert {
+                "session_id": "session-acme-workspace",
+                "sandbox_id": "sandbox-acme-workspace",
+                "managed_workspace": False,
+                "cwd": None,
+            }.items() <= body.items()
 
     anyio.run(go)
 

--- a/runner/tests/test_tool_policy_enforcement.py
+++ b/runner/tests/test_tool_policy_enforcement.py
@@ -13,18 +13,23 @@ permissions, and every other test here would still pass.
 
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
 import anyio
 import pytest
-from claude_agent_sdk.types import PermissionResultDeny
+from claude_agent_sdk.types import PermissionResultAllow, PermissionResultDeny
 from curie_runner import mcp_tool_capability
 from curie_runner.approval import (
+    APPROVAL_TOOL_NAME,
+    PUBLISH_TOOL_NAME,
     ApprovalGate,
+    build_approval_gate,
     build_approval_hook,
     build_can_use_tool,
     policy_disallowed_tools,
+    resolve_approval_policy,
 )
 from mcp import Tool
 from mcp.types import ToolAnnotations
@@ -50,12 +55,16 @@ def _gate(policy: ToolPolicy | None, **kwargs: Any) -> ApprovalGate:
     )
 
 
-def _hook_call(gate: ApprovalGate, tool_name: str) -> dict[str, Any]:
+def _hook_call(
+    gate: ApprovalGate,
+    tool_name: str,
+    tool_input: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     hooks = build_approval_hook(gate)
     matcher = hooks["PreToolUse"][0]
     callback = matcher.hooks[0]
     return anyio.run(
-        callback, {"tool_name": tool_name, "tool_input": {}}, None, None
+        callback, {"tool_name": tool_name, "tool_input": tool_input or {}}, None, None
     )
 
 
@@ -79,6 +88,26 @@ def _catalog_gate() -> ApprovalGate:
         mcp_servers={"operations", "failed"},
         connector_servers={"operations"},
     )
+
+
+def _production_sre_gate(*, managed_workspace: bool) -> ApprovalGate:
+    """Build the gate from the exact production SRE bundle policy and skill."""
+
+    bundle = Path(__file__).parents[2] / "examples" / "sre-bot"
+    assert (bundle / "skills" / "sre-bot" / "SKILL.md").is_file()
+    resolution = resolve_approval_policy(str(bundle))
+    gate = build_approval_gate(
+        operator_tools=None,
+        policy_routes=resolution.route_by_tool,
+        grantable_by_route=resolution.grantable_by_route,
+        bundle_name=resolution.bundle_name,
+        mcp_servers=resolution.mcp_servers,
+        connector_servers=resolution.connector_servers,
+        managed_workspace=managed_workspace,
+        tool_policy=resolution.tool_policy,
+    )
+    assert gate is not None
+    return gate
 
 
 def _assert_no_approval_was_recorded(gate: ApprovalGate) -> None:
@@ -275,6 +304,48 @@ def test_a_builtin_is_untouched_by_a_policy_about_connectors() -> None:
     ships a policy."""
     gate = _gate(_policy(deny=["k8s-write/*"]))
     assert _hook_call(gate, "Bash") == {}
+
+
+@pytest.mark.parametrize("interceptor", ["hook", "callback"])
+def test_platform_publish_reaches_approval_gate_under_production_sre_tool_policy(
+    interceptor: str,
+) -> None:
+    """Bundle MCP policy must not swallow Curie's platform-owned publish gate."""
+
+    gate = _production_sre_gate(managed_workspace=True)
+    tool_input = {"title": "Workspace tool check", "body": "prior-turn marker"}
+    if interceptor == "hook":
+        result = _hook_call(gate, PUBLISH_TOOL_NAME, tool_input)
+        assert _denied(result)
+        reason = _reason(result)
+    else:
+        result = anyio.run(
+            build_can_use_tool(gate), PUBLISH_TOOL_NAME, tool_input, None
+        )
+        assert isinstance(result, PermissionResultDeny)
+        reason = result.message
+
+    assert gate.pending_gate_kind == "permission"
+    assert gate.pending_granted_tool == PUBLISH_TOOL_NAME
+    assert gate.publication_title == "Workspace tool check"
+    assert gate.publication_body == "prior-turn marker"
+    assert "denied by this agent's tool policy" not in reason
+
+
+@pytest.mark.parametrize("interceptor", ["hook", "callback"])
+def test_platform_request_approval_is_outside_production_sre_tool_policy(
+    interceptor: str,
+) -> None:
+    """The sibling Curie MCP tool remains governed by its in-process route logic."""
+
+    gate = _production_sre_gate(managed_workspace=True)
+    if interceptor == "hook":
+        assert _hook_call(gate, APPROVAL_TOOL_NAME) == {}
+    else:
+        result = anyio.run(build_can_use_tool(gate), APPROVAL_TOOL_NAME, {}, None)
+        assert isinstance(result, PermissionResultAllow)
+
+    _assert_no_approval_was_recorded(gate)
 
 
 def test_an_allowed_tool_falls_through_to_the_existing_gate() -> None:

--- a/tools/fix-pin-ci/milestone-trains.json
+++ b/tools/fix-pin-ci/milestone-trains.json
@@ -17,6 +17,7 @@
     "v0.8.3": "patch",
     "v0.8.4": "patch",
     "v0.8.5": "patch",
+    "v0.8.6": "feature",
     "v0.9.0": "feature"
   }
 }

--- a/tools/fix-pin-ci/tests/test_fix_pin_ci.py
+++ b/tools/fix-pin-ci/tests/test_fix_pin_ci.py
@@ -1273,7 +1273,7 @@ def test_pull_request_template_documents_the_tier_waiver() -> None:
     assert "found:live" in template
 
 
-FEATURE_MILESTONE = "v0.9.0"
+FEATURE_MILESTONE = "v0.8.6"
 PATCH_MILESTONE = "v0.8.5"
 MAPPING_PATH = REPO_ROOT / "tools" / "fix-pin-ci" / "milestone-trains.json"
 NA_BODY = "Closes #12\n\nFix pin: n/a - the fix is a chart template with no test surface\n"


### PR DESCRIPTION
## Summary

Preserve the standing thread and history identities when a generic sandbox is replaced by a managed workspace, attest the replacement before its route becomes authoritative, and make the replacement fence depend on an inactive durable runner. Mounted production-policy SDK sessions now retain usable `Read`, `Edit`, `Bash`, and approval-gated `mcp__curie__publish_changes`. Durable turns are bounded before append so an oversized first record cannot become a silent empty replay; an irreducible or later append failure stays sticky and blocks replacement.

## Related issue

Fixes #2271

## Fix pin verification

Fix pin: runner/tests/test_history.py::test_oversized_first_turn_is_bounded_before_append_and_cold_replays_in_order
Fix pin waiver: The real-SDK acceptance test requires provider credentials and a mounted workspace; this deterministic state-boundary selector is the CI-safe red-on-revert pin, while live tool coverage is reported separately below.

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | Required | Runner turn loop and mounted tool surface changed. | fake | At `aa601b21`: `PATH="$PWD/.projects/curie-2271-bin:$PATH" CURIE_BIN=/home/theconnman/.cargo/shared-targets/agentos/release/curie CURIE_E2E_TIERS=skill CURIE_E2E_IMAGE=curie-runner-2271 curie dev e2e-ladder` — `LADDER PASS (tiers: skill)`; status reported durable/ready and the Bash tool completed. |
| local | Required | Worker claim, replacement, and runner wiring changed. | fake | At `aa601b21`: `COMPOSE_PROJECT_NAME=curie-2271-e2e PATH="$PWD/.projects/curie-2271-bin:$PATH" CURIE_BIN=/home/theconnman/.cargo/shared-targets/agentos/release/curie CURIE_E2E_TIERS=local CURIE_E2E_IMAGE=curie-runner-2271 curie dev e2e-ladder` — `LADDER PASS (tiers: local)` in a task-only Compose project; ordinary turn, injected failure/recovery, approval resume, connector, and observability checks passed. Task containers and volumes were removed. |
| local-release | n/a | No released binary/image identity, install path, version pin, or release Compose changed. | n/a | n/a |
| cluster | Required | Sandbox claims and late route replacement changed. | fake | At `ccc76996`: `PATH="$PWD/.projects/curie-2271-bin:$PATH" CURIE_BIN=/home/theconnman/.cargo/shared-targets/agentos/release/curie CURIE_E2E_TIERS=cluster CURIE_E2E_IMAGE=curie-runner-2271 curie dev e2e-ladder` — `LADDER PASS (tiers: cluster)` on a disposable task-owned kind cluster; two worker messages completed and bundle identity matched. The cluster was deleted. The later changes are reviewed behavior-neutral probe consolidation, docs, and rebase; final-source unit/local/skill/live checks were rerun. |
| live provider | Required | The reported miss was in the real SDK catalogue and policy callback. | live | At `aa601b21`: `docker run --rm -e CURIE_E2E_LIVE=1 -e CURIE_MODEL=claude-sonnet-4-6 -e HOME=/home/runner -e UV_PROJECT_ENVIRONMENT=/tmp/curie-test-venv -v "$HOME/.claude:/home/runner/.claude:ro" -v "$PWD:/workspace" -w /workspace ghcr.io/astral-sh/uv:python3.12-bookworm-slim uv run pytest -q runner/tests/test_live.py::test_live_claim_time_workspace_init_catalogue runner/tests/test_live.py::test_live_late_workspace_replacement_init_catalogue` — `2 passed in 33.89s`. Claim-time executed Bash+Read; late replacement executed Read+Edit+Bash, recalled the durable prior-turn marker, and called `publish_changes`, which parked at human approval. |
| external integration | n/a | No Slack, webhook, OAuth, GitHub API, or publication execution behavior changed; publication remains approval-only. | n/a | n/a |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

Acceptance evidence:

- The two real-SDK selectors assert the concrete init catalogue and actual tool results. The unmounted status/publication controls remain negative, and a missing tool or plugin-less fixture is rejected.
- `test_oversized_first_turn_is_bounded_before_append_and_cold_replays_in_order` starts above the observed boundary, stores at or below 65,536 bytes, and cold-replays ordered non-empty messages. `test_irreducibly_large_turn_fails_durability_before_store_append` proves no write is attempted, while `test_history_durability_failure_is_sticky_after_later_successful_append` proves a later small success cannot silently reauthorize replacement.
- Replacement accepts both real inactive durable post-turn statuses, revalidates immediately before handoff, and requires authenticated candidate identity/cwd/workspace attestation before route CAS. Mismatch and CAS-loss tests keep the old route authoritative and delete only the unexposed candidate.
- The exact production policy exemption is limited to Curie's two platform approval tools; the arbitrary-MCP deny sibling remains fail-closed. `publish_changes` still records approval and never publishes directly.
- Red-on-revert was observed for the reported policy failure: before the exact platform exemption the live publication call was denied by bundle policy and recorded no permission grant; after the fix the same surface reached `awaiting-approval`.
- `curie dev verify-fix-pin 2280 runner/tests/test_history.py::test_oversized_first_turn_is_bounded_before_append_and_cold_replays_in_order --json` returned `PINNED`: the head selector passed, then reversing the product hunks reproduced the 65,536-byte rejection and failed the selected test.

Repository baseline at `aa601b21`: `uv lock --check`, `uv sync`, Alembic revision gate, Ruff, mypy (247 files), import-linter, docs, wire-tolerance, released-upgrade self-test and v0.8.5-to-candidate gate, `next` wire-lock comparison, and `uv run pytest -q` — 6,060 passed, 19 skipped. No `aci-protocol` or `plugin-format` files changed.

Final head `0a4e1293` additionally registers the issue's existing `v0.8.6` milestone as a `next`-train milestone so the fix-pin gate can evaluate this PR; all 105 fix-pin gate tests pass, and the checker accepts PR #2280's real metadata.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [x] No new ADR is needed: this enforces Accepted ADR 0136 and the existing durable-history policy rather than introducing a new architectural decision.
