### PR TITLE
fix: accept deadline_halted as a terminal turn metric

### DIFF
--- a/apps/worker/tests/kernel/test_delivery_ownership.py
+++ b/apps/worker/tests/kernel/test_delivery_ownership.py
@@ -38,6 +38,7 @@ from typing import Any
 
 from aci_protocol import Final, QueuedTurn, ReplyHandle, SessionStatus, TextDelta
 from curie_dispatcher.queue import to_stream_fields
+from curie_worker import kernel as kernel_module
 from curie_worker.consumer import Consumer
 from curie_worker.delivery_lease import DeliveryLeaseStore
 
@@ -673,3 +674,114 @@ def test_a_transferred_delivery_inherits_the_remaining_budget_not_a_fresh_one(
             assert fresh.budget.deadline_ms > lease_1.budget.deadline_ms
 
     asyncio.run(go())
+
+
+def test_an_already_expired_delivery_escalates_once_records_deadline_halted_and_acks(
+    make_harness,
+    monkeypatch,
+) -> None:
+    """#2278: recovering an already-expired delivery must escalate once, emit
+    one terminal completion, record both turn metrics through the REAL shared
+    ``record_metric`` validator, and ACK so the entry does not remain pending.
+
+    Red on omitting ``deadline_halted`` from ``_TURN_OUTCOMES``: ``record_metric``
+    raises after settlement, the consumer leaves the entry pending, and a turn
+    that already completed stays visibly stuck.
+
+    The sibling entry is the failure-negative: a first delivery with a live
+    budget still completes as ``done`` and ACKs, so the halt is the expired
+    deadline and not a consumer that stopped settling.
+    """
+
+    recorded: list[tuple[str, dict[str, str]]] = []
+    real_record_metric = kernel_module.record_metric
+
+    def spy(
+        name: str, value: float = 1, *, attributes: dict[str, str] | None = None
+    ) -> None:
+        recorded.append((name, dict(attributes or {})))
+        real_record_metric(name, value, attributes=attributes)
+
+    monkeypatch.setattr(kernel_module, "record_metric", spy)
+
+    async def go() -> None:
+        async with make_harness(**_LEASE_KNOBS, reclaim_min_idle_ms=900000) as h:
+            store = DeliveryLeaseStore(h.async_redis, h.config)
+            consumer = Consumer(
+                redis=h.async_redis, kernel=h.kernel, config=h.config, leases=store
+            )
+            await consumer.ensure_group()
+            h.runner.default_script = [Final(text="should-not-run", status=DONE)]
+
+            await h.async_redis.xadd(
+                h.config.stream,
+                to_stream_fields(
+                    _qevent("expired", thread="deadline-1", event_id="deadline-1")
+                ),
+            )
+            entry_id, fields = await _read_one(h, h.config.consumer_name)
+            seconds, microseconds = await h.async_redis.time()
+            now_ms = int(seconds) * 1000 + int(microseconds) // 1000
+            await h.async_redis.hset(
+                h.config.delivery_state_key(
+                    h.config.stream, h.config.consumer_group, entry_id
+                ),
+                mapping={"deadline_ms": str(now_ms - 1000)},
+            )
+
+            await consumer._dispatch(entry_id, fields)
+            await _settle(consumer)
+
+            assert h.runner.opened == [], (
+                "an already-expired delivery must not start a runner attempt"
+            )
+            assert h.sink.last_text is not None
+            assert "delivery deadline" in h.sink.last_text.lower()
+            assert "human" in h.sink.last_text.lower()
+            assert [event.event for event, _route, _best in h.sink.events].count(
+                "turn.completed"
+            ) == 1
+            assert [completion.outcome for completion in h.sink.completions] == [
+                "escalated"
+            ]
+            assert await h.async_redis.exists(h.config.done_key("deadline-1"))
+            assert entry_id not in await _pending_rows(h), (
+                "an expired delivery that already completed was left pending"
+            )
+
+            completed = [
+                attrs
+                for name, attrs in recorded
+                if name == "curie.turn.completed"
+            ]
+            durations = [
+                attrs for name, attrs in recorded if name == "curie.turn.duration"
+            ]
+            assert [attrs["outcome"] for attrs in completed] == ["deadline_halted"]
+            assert [attrs["outcome"] for attrs in durations] == ["deadline_halted"]
+
+            recorded.clear()
+            h.runner.default_script = [Final(text="fresh-ok", status=DONE)]
+            await h.async_redis.xadd(
+                h.config.stream,
+                to_stream_fields(
+                    _qevent("fresh", thread="deadline-2", event_id="deadline-2")
+                ),
+            )
+            fresh_id, fresh_fields = await _read_one(h, h.config.consumer_name)
+            await consumer._dispatch(fresh_id, fresh_fields)
+            await _settle(consumer)
+
+            assert h.sink.last_text == "fresh-ok"
+            assert [completion.outcome for completion in h.sink.completions][-1] == (
+                "delivered"
+            )
+            assert fresh_id not in await _pending_rows(h)
+            assert [
+                attrs["outcome"]
+                for name, attrs in recorded
+                if name == "curie.turn.completed"
+            ] == ["done"]
+
+    asyncio.run(go())
+

--- a/packages/telemetry/schema/metrics.json
+++ b/packages/telemetry/schema/metrics.json
@@ -54,10 +54,11 @@
           "classified_failure",
           "side_effect_halted",
           "idle",
-          "interrupted"
+          "interrupted",
+          "deadline_halted"
         ]
       },
-      "cardinality_bound": 168
+      "cardinality_bound": 192
     },
     "curie.turn.duration": {
       "type": "histogram",
@@ -86,10 +87,11 @@
           "classified_failure",
           "side_effect_halted",
           "idle",
-          "interrupted"
+          "interrupted",
+          "deadline_halted"
         ]
       },
-      "cardinality_bound": 168
+      "cardinality_bound": 192
     },
     "curie.queue.enqueue": {
       "type": "counter",

--- a/packages/telemetry/src/curie_telemetry/metrics.py
+++ b/packages/telemetry/src/curie_telemetry/metrics.py
@@ -26,6 +26,12 @@ _TURN_OUTCOMES: Final = [
     "side_effect_halted",
     "idle",
     "interrupted",
+    # "deadline_halted" (#2278): the worker lifecycle's wall-clock delivery
+    # deadline (ADR-0131), distinct from model-spend ``budget_halted``.
+    # ``record_metric`` raises on an out-of-domain outcome, so omitting this
+    # value crashes terminal completion after the turn has already settled
+    # and leaves the stream entry pending.
+    "deadline_halted",
 ]
 
 

--- a/packages/telemetry/tests/test_metrics.py
+++ b/packages/telemetry/tests/test_metrics.py
@@ -160,6 +160,51 @@ def test_side_effect_halt_is_a_distinct_terminal_turn_class() -> None:
         assert "side_effect_halted" in manifest[name]["attributes"]["outcome"]
 
 
+def test_deadline_halted_is_a_declared_terminal_turn_outcome(
+    metrics: tuple[MeterProvider, InMemoryMetricReader],
+) -> None:
+    """#2278: the worker lifecycle emits deadline_halted; the shared validator
+    must accept it on both turn-completion instruments.
+
+    Mocking telemetry is not enough: this calls the real ``record_metric``
+    allowlist. Red on omitting the value from ``_TURN_OUTCOMES``.
+    """
+    del metrics
+    attributes = {
+        "service.name": "curie-worker",
+        "source": "worker",
+        "outcome": "deadline_halted",
+    }
+    record_metric("curie.turn.completed", attributes=attributes)
+    record_metric("curie.turn.duration", 1.5, attributes=attributes)
+    manifest = _read(_MANIFEST)["metrics"]
+    for name in ("curie.turn.completed", "curie.turn.duration"):
+        outcomes = manifest[name]["attributes"]["outcome"]
+        assert "deadline_halted" in outcomes
+        for sibling in ("budget_halted", "interrupted", "side_effect_halted"):
+            assert sibling in outcomes
+        assert "fenced_out" not in outcomes
+        assert manifest[name]["cardinality_bound"] == 192
+
+
+def test_record_metric_still_rejects_unknown_turn_outcome(
+    metrics: tuple[MeterProvider, InMemoryMetricReader],
+) -> None:
+    """#2278 negative control: extending the domain for deadline_halted must
+    not disable the bounded validator. An undeclared outcome still raises.
+    """
+    del metrics
+    with pytest.raises(ValueError, match="outside its declared domain"):
+        record_metric(
+            "curie.turn.completed",
+            attributes={
+                "service.name": "curie-worker",
+                "source": "worker",
+                "outcome": "deadline_halted_unknown",
+            },
+        )
+
+
 def test_record_metric_rejects_undeclared_instrument_by_execution(
     metrics: tuple[MeterProvider, InMemoryMetricReader],
 ) -> None:


### PR DESCRIPTION
## Summary

The worker already classifies an exhausted delivery deadline as `deadline_halted` and records `curie.turn.completed` plus `curie.turn.duration`. The shared metric domain omitted that value, so `record_metric` raised after settlement and the consumer left the stream entry pending. This adds `deadline_halted` to the bounded turn-outcome domain and the committed manifest so an expired delivery escalates once, records both metrics, and ACKs.

## Related issue

Closes #2278

## Fix pin verification

Fix pin: packages/telemetry/tests/test_metrics.py::test_deadline_halted_is_a_declared_terminal_turn_outcome

Verified with `bash cli/scripts/verify-fix-pin.sh HEAD packages/telemetry/tests/test_metrics.py::test_deadline_halted_is_a_declared_terminal_turn_outcome` against `7005a5a2313e129a4b84721eedd44f01eaf2a14d`. Baseline green, reversed product files red with `ValueError: attribute 'outcome' value 'deadline_halted' is outside its declared domain`, printed `PINNED`.

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | Does not reach plugin packaging, the runner turn loop, ACI events, or skill eval/check. | | |
| local | required | Worker consumer and kernel settle an expired delivery against real Valkey and emit shared turn metrics. | fake | Against `7005a5a2313e129a4b84721eedd44f01eaf2a14d`, with a throwaway local Valkey for the worker harness (not the retained SRE demo stack): `uv run pytest -q packages/telemetry/tests/test_metrics.py::test_deadline_halted_is_a_declared_terminal_turn_outcome packages/telemetry/tests/test_metrics.py::test_record_metric_still_rejects_unknown_turn_outcome apps/worker/tests/kernel/test_delivery_ownership.py::test_an_already_expired_delivery_escalates_once_records_deadline_halted_and_acks` observed `3 passed in 1.13s`. The expired path asserted one `turn.completed` with outcome `escalated`, both metrics with `deadline_halted`, `runner.opened == []`, and the entry absent from `XPENDING`. The unknown-value control raised `outside its declared domain` for `deadline_halted_unknown`. |
| local-release | n/a | Does not change released binary, image identity, install path, version pins, or release compose. | | |
| cluster | n/a | Does not reach chart templates, RBAC, securityContext, NetworkPolicy, sandbox claims, or init containers. | | |
| live provider | n/a | Does not reach model routing, credential resolution, provider auth, or token/cost accounting. | | |
| external integration | n/a | Does not reach Slack, git push webhooks, connector OAuth, or any third-party API shape. | | |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

Positive: real `record_metric` accepts `deadline_halted` on both turn instruments; an already-expired delivery through `Consumer._dispatch` emits one escalation and one `turn.completed`, records both metrics, and ACKs (`entry_id not in XPENDING`).

Negative / second path: `deadline_halted_unknown` still raises through the real validator; a sibling live-budget delivery on the same consumer completes as `done` and ACKs.

Red-before-green on this base: the same two new tests failed with `attribute 'outcome' value 'deadline_halted' is outside its declared domain` and `an expired delivery that already completed was left pending`.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [ ] An ADR is added under `docs/adr/` if this is an architectural decision.
