### PR TITLE
Refuse cluster github-app when the private key is not that App

### DIFF
--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -1268,7 +1268,9 @@ curie cluster github-app --app-id 1234567 --existing-secret my-github-app
 
 `--existing-secret-key` defaults to `privateKey`, the same default as the
 chart — pass it explicitly if your Secret uses a different key, since the CLI
-always sets this field. The command also rolls the API deployment onto the
+always sets this field. The command signs a JWT and calls GitHub `GET /app`
+before the helm upgrade; a 401 or App-id mismatch leaves the last known-good
+credential in place. The command also rolls the API deployment onto the
 referenced Secret, so there is nothing further to restart.
 
 **Quick trial — let the chart hold it.** `curie cluster github-app --app-id …

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -332,6 +332,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -342,6 +348,12 @@ name = "base64"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bit-set"
@@ -608,6 +620,12 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
@@ -698,6 +716,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -767,6 +797,7 @@ dependencies = [
  "getrandom 0.4.3",
  "indicatif",
  "jsonschema",
+ "jsonwebtoken",
  "keyring",
  "proc-macro2",
  "quote",
@@ -807,6 +838,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -865,6 +897,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid 0.9.6",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -899,6 +942,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid 0.9.6",
  "crypto-common 0.1.7",
  "subtle",
 ]
@@ -910,7 +954,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.1",
- "const-oid",
+ "const-oid 0.10.2",
  "crypto-common 0.2.2",
 ]
 
@@ -941,10 +985,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "email_address"
@@ -1047,6 +1150,16 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
 
 [[package]]
 name = "fiat-crypto"
@@ -1239,6 +1352,17 @@ dependencies = [
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -1668,6 +1792,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "11.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "881733cbc631fc9e472e24447ce32a64bedf2da498d6d8570b08edc87de71f65"
+dependencies = [
+ "base64 0.22.1",
+ "ed25519-dalek",
+ "getrandom 0.2.17",
+ "hmac",
+ "js-sys",
+ "p256",
+ "p384",
+ "pem",
+ "rand 0.8.8",
+ "rsa",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "signature",
+ "simple_asn1",
+ "zeroize",
+]
+
+[[package]]
 name = "kasuari"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1697,6 +1845,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb1e621458ca9c51aa110bd0339d4751a056b9576bf1253aee1aa560dda0fc9d"
 dependencies = [
  "log",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
 ]
 
 [[package]]
@@ -1858,6 +2015,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.8",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-cmp"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1915,6 +2088,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1959,6 +2133,30 @@ name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
 
 [[package]]
 name = "palette"
@@ -2014,6 +2212,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2034,6 +2251,27 @@ dependencies = [
  "atomic-waker",
  "fastrand",
  "futures-io",
+]
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
 ]
 
 [[package]]
@@ -2083,6 +2321,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2129,7 +2385,7 @@ dependencies = [
  "bytes",
  "getrandom 0.4.3",
  "lru-slab",
- "rand",
+ "rand 0.10.2",
  "rand_pcg",
  "ring",
  "rustc-hash",
@@ -2179,6 +2435,17 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
@@ -2186,6 +2453,16 @@ dependencies = [
  "chacha20",
  "getrandom 0.4.3",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2419,6 +2696,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2441,6 +2728,26 @@ dependencies = [
  "libc",
  "rtoolbox",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid 0.9.6",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2542,6 +2849,20 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "secret-service"
@@ -2751,10 +3072,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror",
+ "time",
+]
 
 [[package]]
 name = "slab"
@@ -2776,6 +3119,22 @@ checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -3703,6 +4062,20 @@ name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "zerotrie"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -79,6 +79,7 @@ jsonschema = { version = "0.51", default-features = false }
 serde_norway = "0.9.42"
 crypto_box = { version = "0.9.1", features = ["seal", "std"] }
 base64 = "0.23.1"
+jsonwebtoken = { version = "11.0.0", default-features = false, features = ["use_pem", "rust_crypto"] }
 
 [dev-dependencies]
 # The frozen ACI types are a normal dependency of the lib, but integration test

--- a/cli/src/github_app.rs
+++ b/cli/src/github_app.rs
@@ -16,11 +16,14 @@
 //! reachable when the operator asks for it; `--set-file` above is still what a
 //! chart-held connect does.
 
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
 use anyhow::Result;
+use serde::Serialize;
 
 use crate::ops::{
-    fetch_release_values, plain, require_on_path, resolve_existing_secret_ref, run_step,
-    CommonOpts, OpsCommand,
+    fetch_release_values, plain, require_on_path, resolve_existing_secret_ref, run_capture,
+    run_step, CommonOpts, OpsCommand,
 };
 
 #[derive(Debug, Clone)]
@@ -49,6 +52,17 @@ pub struct GithubAppOpts {
 /// is rejected as a configuration error. An operator wiring up the App has
 /// exactly the wrong context to debug that, so we set both together.
 pub const DEFAULT_CLONE_BASE: &str = "https://github.com";
+
+/// Default GitHub REST API for github.com. GHE is `{host}/api/v3`. Overridable
+/// by `CURIE_GITHUB_API_URL` (tests) or `GITHUB_API_URL` (same env the API
+/// process already reads).
+pub const DEFAULT_GITHUB_API_URL: &str = "https://api.github.com";
+
+/// Match `apps/api/src/curie_api/github_app.py`: GitHub rejects a JWT whose
+/// `iat` is in its future, so backdate by a minute. `exp` stays inside the
+/// documented 10-minute ceiling.
+const JWT_BACKDATE_SECONDS: i64 = 60;
+const JWT_LIFETIME_SECONDS: i64 = 480;
 
 /// The data key the chart defaults to inside a BYO Secret
 /// (`charts/curie/values.yaml`: `api.githubAppExistingSecretKey: privateKey`,
@@ -439,6 +453,278 @@ impl crate::ui::CliOutput for GithubAppOutput {
     }
 }
 
+/// The GitHub REST API this probe should call.
+///
+/// Precedence: `CURIE_GITHUB_API_URL` (tests and an explicit CLI override),
+/// then `GITHUB_API_URL` (the same env the API already reads), then github.com
+/// vs GHE derived from `--clone-base`. No new clap flag: a command-surface
+/// change would force a manifest regen this ticket does not need.
+pub(crate) fn github_api_url(clone_base: &str) -> String {
+    for var in ["CURIE_GITHUB_API_URL", "GITHUB_API_URL"] {
+        if let Ok(url) = std::env::var(var) {
+            let trimmed = url.trim().trim_end_matches('/');
+            if !trimmed.is_empty() {
+                return trimmed.to_string();
+            }
+        }
+    }
+    let base = clone_base.trim().trim_end_matches('/');
+    if base.is_empty() || base == DEFAULT_CLONE_BASE || base == "http://github.com" {
+        return DEFAULT_GITHUB_API_URL.to_string();
+    }
+    format!("{base}/api/v3")
+}
+
+#[derive(Serialize)]
+struct GitHubAppJwtClaims {
+    iat: i64,
+    exp: i64,
+    iss: String,
+}
+
+/// Sign a GitHub App JWT the same way the API does (`_app_jwt` in
+/// `apps/api/src/curie_api/github_app.py`): RS256, `iss` = App id, `iat`
+/// backdated 60s, `exp` 480s. The two cannot share code across Python/Rust;
+/// the constants and claim names are the sibling.
+fn sign_app_jwt(app_id: &str, pem: &str) -> Result<String> {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|err| {
+            crate::exit::CliError::failure(format!("system clock is before Unix epoch: {err}"))
+        })?
+        .as_secs() as i64;
+    let claims = GitHubAppJwtClaims {
+        iat: now - JWT_BACKDATE_SECONDS,
+        exp: now + JWT_LIFETIME_SECONDS,
+        iss: app_id.to_string(),
+    };
+    let key = jsonwebtoken::EncodingKey::from_rsa_pem(pem.as_bytes()).map_err(|_| {
+        crate::exit::CliError::failure(
+            "could not sign a GitHub App JWT from the supplied private key; it is PEM-shaped \
+             but is not a usable RSA key",
+        )
+        .with_fix(
+            "re-download the App's private key (its settings page, under 'Private keys') and \
+             rerun; the last known-good credential was left unchanged",
+        )
+    })?;
+    jsonwebtoken::encode(
+        &jsonwebtoken::Header::new(jsonwebtoken::Algorithm::RS256),
+        &claims,
+        &key,
+    )
+    .map_err(|_| {
+        crate::exit::CliError::failure(
+            "could not sign a GitHub App JWT from the supplied private key",
+        )
+        .with_fix(
+            "re-download the App's private key (its settings page, under 'Private keys') \
+                 and rerun; the last known-good credential was left unchanged",
+        )
+        .into()
+    })
+}
+
+fn pem_from_secret_json(body: &str, secret: &str, key: &str) -> Result<String> {
+    let value: serde_json::Value = serde_json::from_str(body).map_err(|_| {
+        crate::exit::CliError::failure(format!(
+            "kubectl get secret {secret} did not return JSON; cannot read the GitHub App private key"
+        ))
+        .with_fix(format!(
+            "inspect the Secret with kubectl -n <namespace> get secret {secret} -o json and \
+             rerun; the last known-good credential was left unchanged"
+        ))
+    })?;
+    if let Some(encoded) = value
+        .get("data")
+        .and_then(|d| d.get(key))
+        .and_then(|v| v.as_str())
+    {
+        let bytes =
+            base64::Engine::decode(&base64::engine::general_purpose::STANDARD, encoded.trim())
+                .map_err(|_| {
+                    crate::exit::CliError::failure(format!(
+                "Secret {secret} key {key} is not standard base64; cannot read the GitHub App \
+                 private key"
+            ))
+            .with_fix(
+                "store the PEM as a normal Secret data value (kubectl create secret generic \
+                 --from-file) and rerun; the last known-good credential was left unchanged",
+            )
+                })?;
+        return String::from_utf8(bytes).map_err(|_| {
+            crate::exit::CliError::failure(format!(
+                "Secret {secret} key {key} is not UTF-8; a PEM private key is ASCII"
+            ))
+            .with_fix(
+                "store the PEM as UTF-8 text in that Secret data key and rerun; the last \
+                 known-good credential was left unchanged",
+            )
+            .into()
+        });
+    }
+    if let Some(plain_pem) = value
+        .get("stringData")
+        .and_then(|d| d.get(key))
+        .and_then(|v| v.as_str())
+    {
+        return Ok(plain_pem.to_string());
+    }
+    Err(crate::exit::CliError::failure(format!(
+        "Secret {secret} has no data key {key}; cannot probe GitHub App identity"
+    ))
+    .with_fix(format!(
+        "put the App PEM in Secret {secret} under key {key} and rerun; the last known-good \
+         credential was left unchanged"
+    ))
+    .into())
+}
+
+async fn load_existing_secret_pem(opts: &GithubAppOpts) -> Result<String> {
+    let args = crate::connectors::get_secret_args(&opts.common.namespace, &opts.existing_secret);
+    let cmd = OpsCommand::new(
+        "kubectl",
+        args.iter().skip(1).map(|a| plain(a.clone())).collect(),
+    );
+    let (ok, out, err) = run_capture(&cmd).await?;
+    if !ok {
+        return Err(crate::exit::CliError::failure(format!(
+            "could not read Secret {} in namespace {}: {err}",
+            opts.existing_secret, opts.common.namespace
+        ))
+        .with_fix(format!(
+            "create Secret {} (key {}) in namespace {} and rerun; the last known-good \
+             credential was left unchanged",
+            opts.existing_secret, opts.existing_secret_key, opts.common.namespace
+        ))
+        .into());
+    }
+    pem_from_secret_json(&out, &opts.existing_secret, &opts.existing_secret_key)
+}
+
+async fn load_connect_pem(opts: &GithubAppOpts) -> Result<String> {
+    if !opts.existing_secret.trim().is_empty() {
+        return load_existing_secret_pem(opts).await;
+    }
+    std::fs::read_to_string(&opts.private_key_path).map_err(|err| {
+        crate::exit::CliError::failure(format!(
+            "--private-key: cannot re-read {} for the GitHub identity probe: {err}",
+            opts.private_key_path
+        ))
+        .with_fix(
+            "rerun with --private-key pointing at a readable PEM file; the last known-good \
+             credential was left unchanged",
+        )
+        .into()
+    })
+}
+
+fn github_id_matches(body: &serde_json::Value, app_id: &str) -> bool {
+    match body.get("id") {
+        Some(serde_json::Value::Number(n)) => {
+            n.to_string() == app_id
+                || n.as_u64().is_some_and(|u| u.to_string() == app_id)
+                || n.as_i64().is_some_and(|i| i.to_string() == app_id)
+        }
+        Some(serde_json::Value::String(s)) => s == app_id,
+        _ => false,
+    }
+}
+
+fn reported_github_id(body: &serde_json::Value) -> String {
+    match body.get("id") {
+        Some(serde_json::Value::Number(n)) => n.to_string(),
+        Some(serde_json::Value::String(s)) => s.clone(),
+        _ => "<missing>".into(),
+    }
+}
+
+/// Sign a JWT and `GET /app` before any helm mutation. A 401 or an App id
+/// that does not match `--app-id` is a configuration error (exit 1) with a
+/// fix; the last known-good credential is preserved because helm is never
+/// run. Network failures stay transient (exit 3) via reqwest classification.
+///
+/// Skipped on `--dry-run` (offline) and `--disconnect` by the caller.
+pub(crate) async fn guard_app_identity(opts: &GithubAppOpts, clone_base: &str) -> Result<()> {
+    let app_id = opts.app_id.trim();
+    let pem = load_connect_pem(opts).await?;
+    if !is_pem_private_key(&pem) {
+        return Err(crate::exit::CliError::failure(
+            "the GitHub App private key is not a PEM private key; refusing to change credentials",
+        )
+        .with_fix(
+            "put a PEM downloaded from the App's settings page under 'Private keys' and rerun; \
+             the last known-good credential was left unchanged",
+        )
+        .into());
+    }
+    let jwt = sign_app_jwt(app_id, &pem)?;
+    let api = github_api_url(clone_base);
+    let url = format!("{}/app", api.trim_end_matches('/'));
+    let client = reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(5))
+        .timeout(Duration::from_secs(15))
+        .build()
+        .map_err(|err| {
+            crate::exit::CliError::failure(format!("could not build an HTTP client: {err}"))
+        })?;
+    let response = client
+        .get(&url)
+        .header("Authorization", format!("Bearer {jwt}"))
+        .header("Accept", "application/vnd.github+json")
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        .header("User-Agent", format!("curie/{}", env!("CARGO_PKG_VERSION")))
+        .send()
+        .await?;
+    let status = response.status();
+    let body = response.text().await.unwrap_or_default();
+    if status.as_u16() == 401 || status.as_u16() == 403 {
+        return Err(crate::exit::CliError::failure(format!(
+            "the GitHub App private key does not authenticate as App {app_id}. GitHub \
+             returned HTTP {} for GET /app",
+            status.as_u16()
+        ))
+        .with_fix(format!(
+            "download the private key that belongs to App {app_id} (Settings -> Developer \
+             settings -> GitHub Apps -> your app -> Private keys) and rerun; the last \
+             known-good credential was left unchanged"
+        ))
+        .into());
+    }
+    if status.is_server_error() {
+        return Err(crate::exit::CliError::transient(format!(
+            "GitHub returned HTTP {} probing GET /app; the last known-good credential was \
+             left unchanged",
+            status.as_u16()
+        ))
+        .into());
+    }
+    if !status.is_success() {
+        return Err(crate::exit::CliError::failure(format!(
+            "GitHub returned HTTP {} probing GET /app for App {app_id}",
+            status.as_u16()
+        ))
+        .with_fix(
+            "check the App id and private key, then rerun; the last known-good credential \
+             was left unchanged",
+        )
+        .into());
+    }
+    let parsed: serde_json::Value = serde_json::from_str(&body).unwrap_or(serde_json::Value::Null);
+    if !github_id_matches(&parsed, app_id) {
+        let got = reported_github_id(&parsed);
+        return Err(crate::exit::CliError::failure(format!(
+            "GitHub authenticated the key as App {got}, not the requested --app-id {app_id}"
+        ))
+        .with_fix(format!(
+            "pass --app-id {got} for this key, or supply the private key that belongs to \
+             App {app_id}; the last known-good credential was left unchanged"
+        ))
+        .into());
+    }
+    Ok(())
+}
+
 pub async fn github_app(opts: GithubAppOpts, clone_base: &str) -> Result<GithubAppOutput> {
     let ui = crate::ui::ui();
     require_connect_inputs(&opts)?;
@@ -487,6 +773,12 @@ pub async fn github_app(opts: GithubAppOpts, clone_base: &str) -> Result<GithubA
     }
 
     require_on_path("kubectl")?;
+    // Probe GitHub BEFORE helm upgrade so a 401 cannot replace the last
+    // known-good credential mode (#2269). `--disconnect` has nothing to
+    // authenticate; `--dry-run` returned above and stays offline.
+    if !opts.disconnect {
+        guard_app_identity(&opts, clone_base).await?;
+    }
     let cl = ui.checklist();
     let label = if opts.disconnect {
         format!(

--- a/cli/tests/github_app_clap_wiring.rs
+++ b/cli/tests/github_app_clap_wiring.rs
@@ -26,6 +26,8 @@
 //! `charts/curie` relative to the test process's cwd, which is the `cli`
 //! package root.
 
+mod support;
+
 use std::process::Command;
 
 fn bin() -> &'static str {
@@ -212,6 +214,10 @@ if [ "$tool" = "helm" ] && [ "$1" = "get" ] && [ "$2" = "values" ]; then
   echo "$FAKE_VALUES"
   exit 0
 fi
+if [ "$tool" = "kubectl" ] && echo "$*" | grep -q " get secret "; then
+  echo "$FAKE_SECRET_JSON"
+  exit 0
+fi
 echo "shim: refusing to execute: $tool $*" >&2
 exit 1
 "#;
@@ -240,16 +246,7 @@ exit 1
     /// `Command::env`.
     struct FakeRelease {
         dir: tempfile::TempDir,
-    }
-
-    /// One PEM marker line, composed from its boundary word rather than
-    /// written out whole. This fixture carries no key material -- the
-    /// placeholder bytes between the markers are never read as a key -- but
-    /// spelling the markers out contiguously reads as a pasted credential to
-    /// a secret scanner, a false positive that would otherwise have to be
-    /// allowlisted in every repo that vendors this test.
-    fn pem_marker(boundary: &str) -> String {
-        format!("-----{boundary} RSA PRIVATE KEY-----")
+        github: super::support::MockServer,
     }
 
     impl FakeRelease {
@@ -264,24 +261,25 @@ exit 1
                 perms.set_mode(0o755);
                 std::fs::set_permissions(&path, perms).expect("chmod shim");
             }
-            // Must be PEM-SHAPED: since #1260, `require_connect_inputs`
-            // validates the file's shape (a BEGIN/END PRIVATE KEY pair), not
-            // just `Path::is_file`, so a non-PEM body would be refused before
-            // ever reaching the BYO-conflict guard these tests exercise. The
-            // contents are still never parsed as an actual key -- the
-            // chart-held branch only hands helm the PATH (never the
-            // contents) via `--set-file` -- so an inert placeholder between
-            // the markers is enough; no credential-shaped body is needed.
-            std::fs::write(
-                dir.path().join("app.pem"),
-                format!(
-                    "{}\nplaceholder; these bytes are never read as a key\n{}\n",
-                    pem_marker("BEGIN"),
-                    pem_marker("END"),
-                ),
-            )
-            .expect("write pem fixture");
-            Self { dir }
+            // A real RSA key: since #2269 the live path signs a JWT and
+            // probes GitHub before helm upgrade, so a PEM-shaped placeholder
+            // would be refused at signing and never reach the BYO-conflict
+            // call site these tests exist to pin. Generated at runtime so
+            // this file never carries key material.
+            let pem = std::process::Command::new("openssl")
+                .args(["genrsa", "2048"])
+                .output()
+                .unwrap_or_else(|e| panic!("openssl genrsa: {e}"));
+            assert!(
+                pem.status.success(),
+                "openssl genrsa failed: {}",
+                String::from_utf8_lossy(&pem.stderr)
+            );
+            std::fs::write(dir.path().join("app.pem"), &pem.stdout).expect("write pem fixture");
+            let github = super::support::serve(|_req: &super::support::Request| {
+                super::support::Response::json(200, r#"{"id":1234567,"name":"acme-bot"}"#)
+            });
+            Self { dir, github }
         }
 
         /// A real file, because `require_connect_inputs` stats the path long
@@ -309,6 +307,18 @@ exit 1
         /// Run the binary with the shim dir PREPENDED to the child's PATH.
         /// Prepended rather than replacing: the shims must win over a real helm
         /// or kubectl, and the binary still needs the rest of PATH.
+        fn secret_json(&self) -> String {
+            let pem = std::fs::read(self.dir.path().join("app.pem")).expect("read pem");
+            let encoded = base64::Engine::encode(&base64::engine::general_purpose::STANDARD, pem);
+            serde_json::json!({
+                "apiVersion": "v1",
+                "kind": "Secret",
+                "metadata": {"name": "my-github-app"},
+                "data": {"app-pem": encoded, "privateKey": encoded}
+            })
+            .to_string()
+        }
+
         fn run(&self, values: &str, argv: &[&str]) -> Output {
             let mut dirs = vec![self.dir.path().join("bin")];
             if let Some(existing) = std::env::var_os("PATH") {
@@ -319,6 +329,8 @@ exit 1
                 .args(argv)
                 .env("PATH", path)
                 .env("FAKE_VALUES", values)
+                .env("FAKE_SECRET_JSON", self.secret_json())
+                .env("CURIE_GITHUB_API_URL", &self.github.base_url)
                 .env("SHIM_LOG", self.log_path())
                 .output()
                 .unwrap_or_else(|e| panic!("run curie {}: {e}", argv.join(" ")))

--- a/cli/tests/github_app_identity.rs
+++ b/cli/tests/github_app_identity.rs
@@ -1,0 +1,466 @@
+//! Integration: `cluster github-app` authenticates the supplied private key
+//! as the requested GitHub App before mutating the release (issue #2269).
+//!
+//! The SRE demo saw exit 0 and "GitHub App configured" for a syntactically
+//! valid PEM that belonged to a different App; an independent `GET /app`
+//! probe with the same pair returned 401. Shape checks in
+//! `require_connect_inputs` cannot see that: they never sign a JWT and never
+//! talk to GitHub. These tests drive the built binary on a real (non
+//! `--dry-run`) invocation against a fake helm/kubectl and a local HTTP
+//! stand-in of GitHub's documented App API
+//! (https://docs.github.com/en/rest/apps/apps#get-the-authenticated-app).
+//!
+//! `--dry-run` stays offline (`cli/CLAUDE.md`): it is deliberately not used
+//! here. The identity probe is the call site under test, and it must run
+//! before `helm upgrade` so a 401 cannot replace the last known-good
+//! credential mode.
+//!
+//! No live GitHub and no cluster. The PEM is generated at runtime with
+//! openssl so this file never carries key material.
+
+#![cfg(unix)]
+
+mod support;
+
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use support::{serve, MockServer, Request, Response};
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_curie")
+}
+
+/// GitHub's documented App JWT probe. Cited so a future reader does not
+/// treat the path as an invention of this test.
+const APP_PATH: &str = "/app";
+
+const MATCHING_APP_ID: &str = "1234567";
+const OTHER_APP_ID: &str = "7654321";
+
+/// Logs every helm/kubectl invocation. Answers only the reads this verb
+/// needs before it mutates (values, Secret, fullname discovery) plus, when
+/// `ALLOW_MUTATION=1`, the upgrade and rollout. Everything else is refused
+/// so a test cannot pass by running some other command that happened to
+/// succeed.
+const TOOL_SHIM: &str = r#"#!/usr/bin/env bash
+tool=$(basename "$0")
+echo "$tool $*" >> "$SHIM_LOG"
+if [ "$tool" = "helm" ] && [ "$1" = "get" ] && [ "$2" = "values" ]; then
+  echo "$FAKE_VALUES"
+  exit 0
+fi
+if [ "$tool" = "kubectl" ] && echo "$*" | grep -q " get secret "; then
+  echo "$FAKE_SECRET_JSON"
+  exit 0
+fi
+if [ "$ALLOW_MUTATION" = "1" ]; then
+  if [ "$tool" = "helm" ] && [ "$1" = "upgrade" ]; then
+    exit 0
+  fi
+  if [ "$tool" = "kubectl" ]; then
+    exit 0
+  fi
+fi
+echo "shim: refusing to execute: $tool $*" >&2
+exit 1
+"#;
+
+fn generate_rsa_pem(path: &Path) {
+    let output = Command::new("openssl")
+        .args(["genrsa", "2048"])
+        .output()
+        .unwrap_or_else(|e| panic!("openssl genrsa: {e}"));
+    assert!(
+        output.status.success(),
+        "openssl genrsa failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    std::fs::write(path, output.stdout).expect("write generated PEM");
+}
+
+fn b64(bytes: &[u8]) -> String {
+    base64::Engine::encode(&base64::engine::general_purpose::STANDARD, bytes)
+}
+
+fn jwt_payload(authorization: &str) -> serde_json::Value {
+    let token = authorization
+        .strip_prefix("Bearer ")
+        .unwrap_or_else(|| panic!("Authorization is not a Bearer token: {authorization}"));
+    let payload = token
+        .split('.')
+        .nth(1)
+        .unwrap_or_else(|| panic!("JWT has no payload: {token}"));
+    let decoded =
+        base64::Engine::decode(&base64::engine::general_purpose::URL_SAFE_NO_PAD, payload)
+            .or_else(|_| {
+                base64::Engine::decode(&base64::engine::general_purpose::URL_SAFE, payload)
+            })
+            .unwrap_or_else(|e| panic!("JWT payload is not base64url: {e}"));
+    serde_json::from_slice(&decoded).unwrap_or_else(|e| panic!("JWT payload is not JSON: {e}"))
+}
+
+struct Probe {
+    dir: tempfile::TempDir,
+    github: MockServer,
+}
+
+impl Probe {
+    fn matching() -> Self {
+        Self::with_github(|_req: &Request| {
+            Response::json(
+                200,
+                &format!(r#"{{"id":{MATCHING_APP_ID},"name":"acme-bot"}}"#),
+            )
+        })
+    }
+
+    fn unauthorized() -> Self {
+        Self::with_github(|_req: &Request| {
+            Response::json(
+                401,
+                r#"{"message":"A JSON web token could not be decoded","status":"401"}"#,
+            )
+        })
+    }
+
+    fn mismatched_id() -> Self {
+        Self::with_github(|_req: &Request| {
+            Response::json(
+                200,
+                &format!(r#"{{"id":{OTHER_APP_ID},"name":"acme-other"}}"#),
+            )
+        })
+    }
+
+    fn with_github(handler: impl Fn(&Request) -> Response + Send + Sync + 'static) -> Self {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let shim_dir = dir.path().join("bin");
+        std::fs::create_dir(&shim_dir).expect("create shim dir");
+        for tool in ["helm", "kubectl"] {
+            let path = shim_dir.join(tool);
+            std::fs::write(&path, TOOL_SHIM).expect("write shim");
+            let mut perms = std::fs::metadata(&path).expect("stat shim").permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&path, perms).expect("chmod shim");
+        }
+        generate_rsa_pem(&dir.path().join("app.pem"));
+        let github = serve(handler);
+        Self { dir, github }
+    }
+
+    fn private_key(&self) -> String {
+        self.dir
+            .path()
+            .join("app.pem")
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    fn secret_json(&self) -> String {
+        let pem = std::fs::read(self.dir.path().join("app.pem")).expect("read pem");
+        serde_json::json!({
+            "apiVersion": "v1",
+            "kind": "Secret",
+            "metadata": {"name": "my-github-app"},
+            "data": {"app-pem": b64(&pem)}
+        })
+        .to_string()
+    }
+
+    fn log_path(&self) -> PathBuf {
+        self.dir.path().join("invocations.log")
+    }
+
+    fn invocations(&self) -> Vec<String> {
+        match std::fs::read_to_string(self.log_path()) {
+            Ok(body) => body.lines().map(str::to_string).collect(),
+            Err(_) => Vec::new(),
+        }
+    }
+
+    fn run(&self, argv: &[&str], allow_mutation: bool) -> Output {
+        let mut dirs = vec![self.dir.path().join("bin")];
+        if let Some(existing) = std::env::var_os("PATH") {
+            dirs.extend(std::env::split_paths(&existing));
+        }
+        let path = std::env::join_paths(dirs).expect("join PATH");
+        let mut cmd = Command::new(bin());
+        cmd.args(argv)
+            .env("PATH", path)
+            .env("CURIE_GITHUB_API_URL", &self.github.base_url)
+            .env(
+                "FAKE_VALUES",
+                r#"{"api":{"githubApiUrl":"https://api.github.com"}}"#,
+            )
+            .env("FAKE_SECRET_JSON", self.secret_json())
+            .env("SHIM_LOG", self.log_path());
+        if allow_mutation {
+            cmd.env("ALLOW_MUTATION", "1");
+        }
+        cmd.output()
+            .unwrap_or_else(|e| panic!("run curie {}: {e}", argv.join(" ")))
+    }
+}
+
+fn combined(output: &Output) -> String {
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn stdout_json(output: &Output) -> serde_json::Value {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("stdout must be one JSON object: {e}; stdout: {stdout}"))
+}
+
+fn text_at(value: &serde_json::Value, key: &str) -> String {
+    value
+        .get(key)
+        .and_then(|v| v.as_str())
+        .unwrap_or_else(|| panic!("the payload must carry `{key}`: {value}"))
+        .to_string()
+}
+
+fn connect_argv<'a>(app_id: &'a str, key: &'a str) -> Vec<&'a str> {
+    vec![
+        "cluster",
+        "github-app",
+        "--app-id",
+        app_id,
+        "--private-key",
+        key,
+        "--chart",
+        "charts/curie",
+        "--json",
+    ]
+}
+
+fn byo_argv(app_id: &str) -> Vec<&str> {
+    vec![
+        "cluster",
+        "github-app",
+        "--app-id",
+        app_id,
+        "--existing-secret",
+        "my-github-app",
+        "--existing-secret-key",
+        "app-pem",
+        "--chart",
+        "charts/curie",
+        "--json",
+    ]
+}
+
+fn assert_probed_matching_app(probe: &Probe) {
+    let recorded = probe.github.recorded();
+    let app = recorded
+        .iter()
+        .find(|r| r.method == "GET" && r.path == APP_PATH)
+        .unwrap_or_else(|| panic!("CLI never called GET {APP_PATH}: {recorded:?}"));
+    let auth = app
+        .header("authorization")
+        .unwrap_or_else(|| panic!("GET {APP_PATH} had no Authorization header"));
+    let claims = jwt_payload(auth);
+    assert_eq!(
+        claims.get("iss").and_then(|v| v.as_str()),
+        Some(MATCHING_APP_ID),
+        "JWT iss must be the requested App id: {claims}"
+    );
+}
+
+#[test]
+fn a_matching_key_configures_the_app_after_github_confirms_identity() {
+    // Positive AC: a key that authenticates as --app-id is allowed to mutate
+    // the release and report success. GitHub's GET /app is the oracle, not
+    // the PEM shape check.
+    let probe = Probe::matching();
+    let key = probe.private_key();
+    let output = probe.run(&connect_argv(MATCHING_APP_ID, &key), true);
+    assert!(
+        output.status.success(),
+        "matching App identity must exit 0; output: {}",
+        combined(&output)
+    );
+    let value = stdout_json(&output);
+    assert_eq!(
+        value.get("github_app_configured"),
+        Some(&serde_json::json!(true)),
+        "matching identity must report configured: {value}"
+    );
+    assert_probed_matching_app(&probe);
+    let log = probe.invocations();
+    assert!(
+        log.iter().any(|line| line.starts_with("helm upgrade")),
+        "a confirmed identity must still run the helm upgrade: {log:?}"
+    );
+}
+
+#[test]
+fn a_mismatched_private_key_is_refused_before_helm_upgrade() {
+    // THIS IS THE TICKET. GitHub 401 on GET /app means the PEM does not
+    // authenticate as --app-id. Before #2269 the CLI never asked, helm
+    // upgraded, and the operator was told the App was configured.
+    let probe = Probe::unauthorized();
+    let key = probe.private_key();
+    let output = probe.run(&connect_argv(MATCHING_APP_ID, &key), true);
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "a GitHub 401 must exit 1 (Failure); output: {}",
+        combined(&output)
+    );
+    let value = stdout_json(&output);
+    let error = text_at(&value, "error");
+    assert!(
+        error.contains("401") || error.to_lowercase().contains("does not authenticate"),
+        "the refusal must say GitHub rejected the key: {error}"
+    );
+    let fix = text_at(&value, "fix");
+    assert!(
+        !fix.is_empty(),
+        "the refusal must carry a non-null fix: {value}"
+    );
+    assert!(
+        value.get("github_app_configured").is_none(),
+        "the refused run reported the App as configured: {value}"
+    );
+    let recorded = probe.github.recorded();
+    assert!(
+        recorded
+            .iter()
+            .any(|r| r.method == "GET" && r.path == APP_PATH),
+        "the refusal must come from GET {APP_PATH}, not a skipped probe: {recorded:?}"
+    );
+    let log = probe.invocations();
+    assert!(
+        log.iter().all(|line| !line.starts_with("helm upgrade")),
+        "a failed identity probe must not replace last known-good credentials: {log:?}"
+    );
+    assert!(
+        log.iter().all(|line| !line.contains("rollout restart")),
+        "a failed identity probe must not roll the API onto the rejected key: {log:?}"
+    );
+}
+
+#[test]
+fn a_github_app_id_mismatch_is_refused_before_helm_upgrade() {
+    // Defense in depth on the same AC: GET /app 200 with a different `id`
+    // than --app-id is still a false success if we only check HTTP status.
+    let probe = Probe::mismatched_id();
+    let key = probe.private_key();
+    let output = probe.run(&connect_argv(MATCHING_APP_ID, &key), true);
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "an authenticated-but-wrong App id must exit 1; output: {}",
+        combined(&output)
+    );
+    let value = stdout_json(&output);
+    let error = text_at(&value, "error");
+    assert!(
+        error.contains(OTHER_APP_ID) || error.contains(MATCHING_APP_ID),
+        "the refusal must name the identity mismatch: {error}"
+    );
+    assert!(
+        value.get("github_app_configured").is_none(),
+        "the refused run reported the App as configured: {value}"
+    );
+    let log = probe.invocations();
+    assert!(
+        log.iter().all(|line| !line.starts_with("helm upgrade")),
+        "an id mismatch must not replace last known-good credentials: {log:?}"
+    );
+}
+
+#[test]
+fn an_existing_secret_mismatched_key_is_refused_before_helm_upgrade() {
+    // The SRE demo used --existing-secret. The CLI must read the Secret,
+    // probe GitHub, and refuse before helm upgrade — not skip the probe
+    // because it never had a --private-key path.
+    let probe = Probe::unauthorized();
+    let output = probe.run(&byo_argv(MATCHING_APP_ID), true);
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "a BYO Secret whose PEM 401s must exit 1; output: {}",
+        combined(&output)
+    );
+    let value = stdout_json(&output);
+    assert!(
+        value.get("github_app_configured").is_none(),
+        "the refused BYO run reported the App as configured: {value}"
+    );
+    let log = probe.invocations();
+    assert!(
+        log.iter().any(|line| line.contains("get secret")),
+        "the BYO path must read the Secret in order to probe it: {log:?}"
+    );
+    assert!(
+        log.iter().all(|line| !line.starts_with("helm upgrade")),
+        "a failed BYO identity probe must not replace last known-good credentials: {log:?}"
+    );
+}
+
+#[test]
+fn dry_run_does_not_call_github() {
+    // `--dry-run` never touches the network (`cli/CLAUDE.md`). The identity
+    // probe is a GitHub call, so it must not run on a dry-run even when a
+    // mock is listening.
+    let probe = Probe::unauthorized();
+    let key = probe.private_key();
+    let argv = [
+        "cluster",
+        "github-app",
+        "--app-id",
+        MATCHING_APP_ID,
+        "--private-key",
+        key.as_str(),
+        "--chart",
+        "charts/curie",
+        "--dry-run",
+        "--json",
+    ];
+    let output = probe.run(&argv, false);
+    assert!(
+        output.status.success(),
+        "dry-run must stay offline and succeed; output: {}",
+        combined(&output)
+    );
+    assert!(
+        probe.github.recorded().is_empty(),
+        "dry-run called GitHub: {:?}",
+        probe.github.recorded()
+    );
+}
+
+#[test]
+fn disconnect_does_not_call_github() {
+    let probe = Probe::unauthorized();
+    let output = probe.run(
+        &[
+            "cluster",
+            "github-app",
+            "--disconnect",
+            "--chart",
+            "charts/curie",
+            "--json",
+        ],
+        true,
+    );
+    assert!(
+        probe.github.recorded().is_empty(),
+        "disconnect called GitHub: {:?}",
+        probe.github.recorded()
+    );
+    let log = probe.invocations();
+    assert!(
+        log.iter().any(|line| line.starts_with("helm upgrade")),
+        "disconnect must still clear the release: {log:?}; output: {}",
+        combined(&output)
+    );
+}


### PR DESCRIPTION
## Summary

`curie cluster github-app` now signs a JWT and calls GitHub `GET /app` before any helm upgrade. A syntactically valid private key that does not authenticate as `--app-id` exits 1 with a recovery instruction and leaves the last known-good credential in place, instead of printing success and rolling the API.

## Related issue

Closes #2269

## Fix pin verification

Fix pin: cli/tests/github_app_identity.rs::a_mismatched_private_key_is_refused_before_helm_upgrade

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | Does not reach plugin packaging, the runner turn loop, or skill eval/check | | |
| local | required | CLI verb exit code, success/failure payload, and mutation gating | fake | `cd cli && cargo test --offline --test github_app_identity` against `75560969`: 6 passed. Matching key reports `github_app_configured: true` after GET /app and helm upgrade. GitHub 401 / id mismatch exit 1, `github_app_configured` absent, no `helm upgrade`. |
| local-release | n/a | Does not change released binary identity, install path, version pins, or release compose | | |
| cluster | n/a | Does not change chart templates, RBAC, securityContext, NetworkPolicy, sandbox claims, or init containers | | |
| live provider | n/a | Does not change model routing, provider auth, or token/cost accounting | | |
| external integration | n/a | Does not change Slack, git webhooks, or connector OAuth. GET /app is proven against a local stand-in of the documented GitHub App API; live App credentials are forbidden in this public-repo run | | |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [x] No ADR: this is a CLI validation fix on an existing verb, not a new architectural decision.
