### PR TITLE
feat: add ACI event session context

### DIFF
--- a/cli/src/runner.rs
+++ b/cli/src/runner.rs
@@ -110,6 +110,8 @@ impl RunnerClient {
             text: text.to_string(),
             user: user.to_string(),
             ts: slack_ts(),
+            session_id: None,
+            history_ref: None,
         };
         let resp = self
             .http

--- a/docs/diagrams/aci.md
+++ b/docs/diagrams/aci.md
@@ -30,6 +30,12 @@ The reply is a stream of NDJSON events defined in
 - `final` — the turn is done (carries the final text + status)
 - `error`
 
+An inbound `event` frame carries `{kind, type, text, user, ts}` plus optional,
+nullable `session_id` and `history_ref` strings for conversation-scoped identity.
+Older producers may omit either field independently. Startup configuration is a
+separate, environment-only `SessionConfig`; the per-event fields do not replace
+it.
+
 ## Inside the box
 
 ```mermaid
@@ -107,7 +113,7 @@ regenerated and committed together it **always goes green**. It pins artifact
 *sync*; it never pinned *compatibility*. Three things carry the contract
 instead:
 
-- **Semver, not a freeze.** `PROTOCOL_VERSION` is `0.4.3`
+- **Semver, not a freeze.** `PROTOCOL_VERSION` is `0.4.4`
   ([`packages/aci-protocol/src/aci_protocol/version.py`](../../packages/aci-protocol/src/aci_protocol/version.py)),
   versioned independently of the Curie release. Under 0.x a consumer accepts
   the same `major.minor`; only a new optional field is compatible (patch), and

--- a/docs/interfaces/aci-producer/implementing-an-aci-server.md
+++ b/docs/interfaces/aci-producer/implementing-an-aci-server.md
@@ -43,10 +43,12 @@ reported as a failed case, so a server without this route fails every eval case
 that has not opted into shared history. The reference implementation is
 `runner/src/curie_runner/server.py`.
 
-Session setup is **not** on the wire — it comes from the environment. Read it once
-at startup with `SessionConfig.from_env()` (the `CURIE_*` mapping: `plugin_dir`,
-`session_id`, `sandbox_id`, `budget`, optional `memory_ref`, `credentials_ref`,
-`otel`).
+Startup configuration remains **environment-only**. Read it once with
+`SessionConfig.from_env()` (the `CURIE_*` mapping: `plugin_dir`, `session_id`,
+`sandbox_id`, `budget`, optional `memory_ref`, `credentials_ref`, `otel`). The
+inbound `Event` separately has optional `session_id` and `history_ref` fields for
+conversation-scoped identity after a sandbox is bound. They are wire metadata,
+not a replacement for `SessionConfig`, and older producers may omit either one.
 
 ## The wire contract in one screen
 
@@ -54,7 +56,9 @@ Import everything from `aci_protocol`; do not hand-roll JSON.
 
 **Inbound** — a discriminated union on `kind` (`parse_inbound` decodes it):
 
-- `Event` = `{kind: "event", type: "message"|"job"|"eval_case", text, user, ts}`
+- `Event` = `{kind: "event", type: "message"|"job"|"eval_case", text, user, ts,
+  session_id?, history_ref?}`. The optional fields are nullable strings; either
+  may be omitted independently.
 - `Interrupt` = `{kind: "interrupt", reason}`
 
 **Outbound** — a discriminated union on `type`, each carrying `version`
@@ -70,7 +74,7 @@ Import everything from `aci_protocol`; do not hand-roll JSON.
   made and once when its result arrives, joined on `call_id` (ADR-0117)
 
 **Version gate (strict producer, tolerant consumer).** Your producer emits its
-**exact build `PROTOCOL_VERSION`** (currently `0.4.3`) on every outbound event and
+**exact build `PROTOCOL_VERSION`** (currently `0.4.4`) on every outbound event and
 constructs strictly -- an unknown field is an error at construction, catching your
 mistakes at the source. A **consumer** decoding the wire is tolerant the other way:
 it accepts any version compatible with its own build (`major.minor` match under

--- a/packages/aci-protocol/README.md
+++ b/packages/aci-protocol/README.md
@@ -24,9 +24,9 @@ string rather than a `const`. Artifact sync is enforced by the
 schema-compat gate (`tests/test_schema_compat.py`); an unbumped wire change is
 caught by the wire-lock gate (`tests/test_wire_lock.py`).
 
-## Contract surface (v0.4.3)
+## Contract surface (v0.4.4)
 
-`PROTOCOL_VERSION = "0.4.3"` is embedded in the schema and in every outbound
+`PROTOCOL_VERSION = "0.4.4"` is embedded in the schema and in every outbound
 event.
 
 **Session setup** (`SessionConfig`, with `to_env()` / `from_env()`):
@@ -45,7 +45,9 @@ event.
 
 **Inbound channel messages** (discriminated union on `kind`):
 
-- `Event` = `{kind: "event", type: message|job|eval_case, text, user, ts}`
+- `Event` = `{kind: "event", type: message|job|eval_case, text, user, ts, session_id?, history_ref?}`.
+  `session_id` and `history_ref` are nullable strings carrying conversation-scoped
+  identity after a sandbox is bound; older producers may omit either field.
 - `Interrupt` = `{kind: "interrupt", reason}`
 
 **Outbound NDJSON response events** (discriminated union on `type`, each carries

--- a/packages/aci-protocol/generated/rust/src/lib.rs
+++ b/packages/aci-protocol/generated/rust/src/lib.rs
@@ -6,7 +6,7 @@
 
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: &str = "0.4.3";
+pub const PROTOCOL_VERSION: &str = "0.4.4";
 
 pub const RUNS_STREAM_DEFAULT: &str = "curie:runs";
 
@@ -329,6 +329,10 @@ pub enum InboundMessage {
         text: String,
         user: String,
         ts: String,
+        #[serde(default)]
+        session_id: Option<String>,
+        #[serde(default)]
+        history_ref: Option<String>,
     },
     #[serde(rename = "interrupt")]
     Interrupt {
@@ -447,6 +451,8 @@ mod tests {
             text: "hello".to_string(),
             user: "U1".to_string(),
             ts: "1.0".to_string(),
+            session_id: None,
+            history_ref: None,
         };
         let encoded = serde_json::to_string(&message).unwrap();
         let decoded: InboundMessage = serde_json::from_str(&encoded).unwrap();
@@ -485,13 +491,13 @@ mod tests {
 
     #[test]
     fn accepts_compatible_patch() {
-        let raw = r#"{"type":"final","version":"0.4.4","text":"x","status":"done"}"#;
+        let raw = r#"{"type":"final","version":"0.4.5","text":"x","status":"done"}"#;
         assert!(serde_json::from_str::<OutboundEvent>(raw).is_ok());
     }
 
     #[test]
     fn accepts_unknown_fields() {
-        let raw = r#"{"type":"final","version":"0.4.3","text":"x","status":"done","extra":1}"#;
+        let raw = r#"{"type":"final","version":"0.4.4","text":"x","status":"done","extra":1}"#;
         assert!(serde_json::from_str::<OutboundEvent>(raw).is_ok());
     }
 }

--- a/packages/aci-protocol/generated/ts/aci-protocol.ts
+++ b/packages/aci-protocol/generated/ts/aci-protocol.ts
@@ -20,7 +20,7 @@ export type ExpiresInSeconds = number | null;
  * authority-bearing per #544/ADR-0046, so the value domain is a named, exported
  * part of the contract rather than an inline annotation.
  *
- * This interface was referenced by `ACIProtocolV043`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
  * via the `definition` "GateKind".
  */
 export type GateKind = "permission" | "policy";
@@ -86,7 +86,9 @@ export type RepoFullName = string;
 export type Sha1 = string;
 export type TargetUrl1 = string | null;
 export type Total = number;
+export type HistoryRef1 = string | null;
 export type Kind = "event";
+export type SessionId1 = string | null;
 export type Text = string;
 export type Ts = string;
 export type Type1 = "message" | "job" | "eval_case";
@@ -108,14 +110,14 @@ export type Text1 = string;
 export type Type2 = "final";
 export type Version1 = string;
 /**
- * This interface was referenced by `ACIProtocolV043`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
  * via the `definition` "InboundMessage".
  */
 export type InboundMessage = Event | Interrupt;
 export type Kind1 = "interrupt";
 export type Reason = string;
 /**
- * This interface was referenced by `ACIProtocolV043`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
  * via the `definition` "OutboundEvent".
  */
 export type OutboundEvent = TextDelta | ToolNote | Final | ErrorEvent | SideEffectFlag;
@@ -179,7 +181,7 @@ export type Text4 = string;
  * Wire tokens follow the section 0 spelling; ``classified failure`` in prose
  * becomes the token ``classified-failure`` on the wire.
  *
- * This interface was referenced by `ACIProtocolV043`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
  * via the `definition` "SessionStatus".
  */
 export type SessionStatus1 = "done" | "idle-awaiting-input" | "classified-failure" | "awaiting-approval";
@@ -207,12 +209,12 @@ export type SessionStatus1 = "done" | "idle-awaiting-input" | "classified-failur
  * ENUM VALUE -- breaking under this package's rules, so it is a deliberate,
  * separately-decided bump rather than something this change assumes.
  *
- * This interface was referenced by `ACIProtocolV043`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
  * via the `definition` "TurnSource".
  */
 export type TurnSource1 = "slack" | "webhook" | "cron";
 
-export interface ACIProtocolV043 {
+export interface ACIProtocolV044 {
   [k: string]: unknown;
 }
 /**
@@ -236,7 +238,7 @@ export interface ACIProtocolV043 {
  * nullable because ``slack`` legitimately has no adapter -- its route is the
  * worker's configured Slack origin.
  *
- * This interface was referenced by `ACIProtocolV043`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
  * via the `definition` "ApprovalRequest".
  */
 export interface ApprovalRequest {
@@ -283,7 +285,7 @@ export interface ApprovalRequest {
  * baked template default, the worker's value is per-agent model routing. Do not
  * collapse either producer list to a single value.
  *
- * This interface was referenced by `ACIProtocolV043`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
  * via the `definition` "BootEnv".
  */
 export interface BootEnv {
@@ -323,7 +325,7 @@ export interface BootEnv {
  * section 0 describes these as per-tool secrets via K8s Secret refs, so the
  * contract carries the reference, not the secret material itself.
  *
- * This interface was referenced by `ACIProtocolV043`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
  * via the `definition` "SessionConfig".
  */
 export interface SessionConfig {
@@ -342,7 +344,7 @@ export interface SessionConfig {
  * ``task_budget_hint`` is the optional hint passed through to the model so it
  * self paces (section 6b); it is not a hard ceiling.
  *
- * This interface was referenced by `ACIProtocolV043`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
  * via the `definition` "Budget".
  */
 export interface Budget {
@@ -358,7 +360,7 @@ export interface Budget {
  * fields the prototype used (endpoint, headers, protocol); any others pass
  * through as raw env vars untouched and are out of scope for this typed view.
  *
- * This interface was referenced by `ACIProtocolV043`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
  * via the `definition` "OtelConfig".
  */
 export interface OtelConfig {
@@ -370,7 +372,7 @@ export interface OtelConfig {
 /**
  * A classified failure surfaced to the platform.
  *
- * This interface was referenced by `ACIProtocolV043`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
  * via the `definition` "ErrorEvent".
  */
 export interface ErrorEvent {
@@ -387,7 +389,7 @@ export interface ErrorEvent {
  * worker consumes off it (formerly the API's ``EvalJobRequest`` and the
  * worker's ``EvalWorkItem``, which had drifted on ``bundle_ref``).
  *
- * This interface was referenced by `ACIProtocolV043`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
  * via the `definition` "EvalJob".
  */
 export interface EvalJob {
@@ -407,7 +409,7 @@ export interface EvalJob {
  * Byte-identical across both lanes before this promotion, so it carries no
  * semantic decisions.
  *
- * This interface was referenced by `ACIProtocolV043`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
  * via the `definition` "EvalReport".
  */
 export interface EvalReport {
@@ -421,11 +423,17 @@ export interface EvalReport {
 /**
  * An inbound event delivered into a live session (initial or follow-up).
  *
- * This interface was referenced by `ACIProtocolV043`'s JSON-Schema
+ * ``session_id`` and ``history_ref`` carry conversation-scoped identity to a
+ * runner after its sandbox is bound. Both remain optional so older producers
+ * can omit them and tolerant consumers can adopt the additive wire shape.
+ *
+ * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
  * via the `definition` "Event".
  */
 export interface Event {
+  history_ref?: HistoryRef1;
   kind: Kind;
+  session_id?: SessionId1;
   text: Text;
   ts: Ts;
   type: Type1;
@@ -466,7 +474,7 @@ export interface Event {
  * scalars: a tolerant consumer decoding an older producer's ``final`` simply
  * sees them absent.
  *
- * This interface was referenced by `ACIProtocolV043`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
  * via the `definition` "Final".
  */
 export interface Final {
@@ -485,7 +493,7 @@ export interface Final {
 /**
  * A hard stop delivered on the control channel, distinct from a steer.
  *
- * This interface was referenced by `ACIProtocolV043`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
  * via the `definition` "Interrupt".
  */
 export interface Interrupt {
@@ -496,7 +504,7 @@ export interface Interrupt {
 /**
  * A streamed chunk of assistant text.
  *
- * This interface was referenced by `ACIProtocolV043`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
  * via the `definition` "TextDelta".
  */
 export interface TextDelta {
@@ -508,7 +516,7 @@ export interface TextDelta {
 /**
  * A human readable note about a tool call the harness is making.
  *
- * This interface was referenced by `ACIProtocolV043`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
  * via the `definition` "ToolNote".
  */
 export interface ToolNote {
@@ -537,7 +545,7 @@ export interface ToolNote {
  * turn that calls the same tool twice is otherwise indistinguishable from one
  * that called it once.
  *
- * This interface was referenced by `ACIProtocolV043`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
  * via the `definition` "SideEffectFlag".
  */
 export interface SideEffectFlag {
@@ -567,7 +575,7 @@ export interface SideEffectFlag {
  * to the non-job value is also the safe direction -- an unset ``source`` reads
  * as a person's message, so a job can never be created by omission.
  *
- * This interface was referenced by `ACIProtocolV043`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
  * via the `definition` "QueuedTurn".
  */
 export interface QueuedTurn {
@@ -616,7 +624,7 @@ export interface QueuedTurn {
  * third-party or pre-upgrade producer is not rejected outright, but every
  * first-party mint site sets it explicitly.
  *
- * This interface was referenced by `ACIProtocolV043`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
  * via the `definition` "ReplyHandle".
  */
 export interface ReplyHandle {

--- a/packages/aci-protocol/schema/aci-protocol.schema.json
+++ b/packages/aci-protocol/schema/aci-protocol.schema.json
@@ -776,12 +776,36 @@
       "type": "object"
     },
     "Event": {
-      "description": "An inbound event delivered into a live session (initial or follow-up).",
+      "description": "An inbound event delivered into a live session (initial or follow-up).\n\n``session_id`` and ``history_ref`` carry conversation-scoped identity to a\nrunner after its sandbox is bound. Both remain optional so older producers\ncan omit them and tolerant consumers can adopt the additive wire shape.",
       "properties": {
+        "history_ref": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "History Ref"
+        },
         "kind": {
           "const": "event",
           "title": "Kind",
           "type": "string"
+        },
+        "session_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Session Id"
         },
         "text": {
           "title": "Text",
@@ -1372,6 +1396,6 @@
   },
   "$id": "https://curietech.ai/schemas/aci-protocol.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "protocolVersion": "0.4.3",
-  "title": "ACI Protocol v0.4.3"
+  "protocolVersion": "0.4.4",
+  "title": "ACI Protocol v0.4.4"
 }

--- a/packages/aci-protocol/schema/wire.lock
+++ b/packages/aci-protocol/schema/wire.lock
@@ -1,4 +1,4 @@
 {
-  "protocol_version": "0.4.3",
-  "wire_sha256": "95750642b79c70c1ffb45b68425c73a9abb141897673bc61000d6ca4f6c24bea"
+  "protocol_version": "0.4.4",
+  "wire_sha256": "df4e3a1360567a04f15ba5261dc0418e80b50a3bf26dc26c2476833d47eb49b1"
 }

--- a/packages/aci-protocol/src/aci_protocol/events.py
+++ b/packages/aci-protocol/src/aci_protocol/events.py
@@ -88,13 +88,20 @@ class SessionStatus(StrEnum):
 
 
 class Event(_AciModel):
-    """An inbound event delivered into a live session (initial or follow-up)."""
+    """An inbound event delivered into a live session (initial or follow-up).
+
+    ``session_id`` and ``history_ref`` carry conversation-scoped identity to a
+    runner after its sandbox is bound. Both remain optional so older producers
+    can omit them and tolerant consumers can adopt the additive wire shape.
+    """
 
     kind: Literal["event"] = "event"
     type: Literal["message", "job", "eval_case"]
     text: str
     user: str
     ts: str
+    session_id: str | None = None
+    history_ref: str | None = None
 
 
 class Interrupt(_AciModel):

--- a/packages/aci-protocol/src/aci_protocol/rust_export.py
+++ b/packages/aci-protocol/src/aci_protocol/rust_export.py
@@ -343,6 +343,8 @@ mod tests {
             text: "hello".to_string(),
             user: "U1".to_string(),
             ts: "1.0".to_string(),
+            session_id: None,
+            history_ref: None,
         };
         let encoded = serde_json::to_string(&message).unwrap();
         let decoded: InboundMessage = serde_json::from_str(&encoded).unwrap();

--- a/packages/aci-protocol/src/aci_protocol/version.py
+++ b/packages/aci-protocol/src/aci_protocol/version.py
@@ -20,7 +20,7 @@ the guard.
 import re
 from typing import Final
 
-PROTOCOL_VERSION: Final = "0.4.3"
+PROTOCOL_VERSION: Final = "0.4.4"
 
 # The wire field carrying the protocol version on every outbound event. Both
 # exporters special-case this field by name; do not rename without updating them.

--- a/packages/aci-protocol/tests/test_events.py
+++ b/packages/aci-protocol/tests/test_events.py
@@ -76,6 +76,48 @@ def test_models_reject_unknown_fields() -> None:
         Final(text="ok", nonsense=1)  # type: ignore[call-arg]
 
 
+def test_event_rejects_unknown_fields_on_direct_construction() -> None:
+    with pytest.raises(ValidationError):
+        Event(  # type: ignore[call-arg]
+            type="message",
+            text="hi",
+            user="U0EXAMPLE1",
+            ts="1.0",
+            nonsense=1,
+        )
+
+
+@pytest.mark.parametrize("field", ("session_id", "history_ref"))
+def test_interrupt_rejects_event_session_context_fields(field: str) -> None:
+    with pytest.raises(ValidationError):
+        Interrupt.model_validate({"reason": "stop", field: "context-example"})
+
+
+@pytest.mark.parametrize("field", ("session_id", "history_ref"))
+@pytest.mark.parametrize(
+    "value",
+    (
+        1,
+        False,
+        ["not-a-string"],
+        {"not": "a string"},
+    ),
+)
+def test_event_session_context_rejects_non_string_non_null_values(
+    field: str, value: object
+) -> None:
+    payload = {
+        "type": "message",
+        "text": "hi",
+        "user": "U0EXAMPLE1",
+        "ts": "1.0",
+        field: value,
+    }
+
+    with pytest.raises(ValidationError):
+        Event.model_validate(payload)
+
+
 def test_session_status_wire_values() -> None:
     assert SessionStatus.IDLE_AWAITING_INPUT.value == "idle-awaiting-input"
     assert SessionStatus.CLASSIFIED_FAILURE.value == "classified-failure"

--- a/packages/aci-protocol/tests/test_exporters.py
+++ b/packages/aci-protocol/tests/test_exporters.py
@@ -23,6 +23,15 @@ def test_version_field_is_required_in_the_exported_schema() -> None:
     assert "const" not in final["properties"]["version"]
 
 
+def test_event_session_context_fields_are_optional_nullable_strings() -> None:
+    event = build_schema()["$defs"]["Event"]
+    for field in ("session_id", "history_ref"):
+        assert field not in event["required"]
+        prop = event["properties"][field]
+        assert "anyOf" in prop
+        assert {variant["type"] for variant in prop["anyOf"]} == {"string", "null"}
+
+
 def test_generated_rust_guards_the_version() -> None:
     rust = render_rust()
     lines = rust.splitlines()

--- a/packages/aci-protocol/tests/test_ndjson.py
+++ b/packages/aci-protocol/tests/test_ndjson.py
@@ -67,6 +67,65 @@ def test_inbound_roundtrip() -> None:
         assert parse_inbound(to_inbound_json(message)) == message
 
 
+def test_legacy_inbound_event_without_session_context_defaults_to_none() -> None:
+    raw = json.dumps(
+        {
+            "kind": "event",
+            "type": "message",
+            "text": "hi",
+            "user": "U0EXAMPLE1",
+            "ts": "1.0",
+        }
+    )
+
+    message = parse_inbound(raw)
+
+    assert isinstance(message, Event)
+    assert message.session_id is None
+    assert message.history_ref is None
+
+
+def test_inbound_event_accepts_explicit_null_session_context() -> None:
+    raw = json.dumps(
+        {
+            "kind": "event",
+            "type": "message",
+            "text": "hi",
+            "user": "U0EXAMPLE1",
+            "ts": "1.0",
+            "session_id": None,
+            "history_ref": None,
+        }
+    )
+
+    message = parse_inbound(raw)
+
+    assert isinstance(message, Event)
+    assert message.session_id is None
+    assert message.history_ref is None
+
+
+def test_inbound_event_session_context_survives_json_roundtrip() -> None:
+    message = Event(
+        type="message",
+        text="hi",
+        user="U0EXAMPLE1",
+        ts="1.0",
+        session_id="session-example",
+        history_ref="history-example",
+    )
+
+    encoded = to_inbound_json(message)
+    wire = json.loads(encoded)
+    decoded = parse_inbound(encoded)
+
+    assert wire["session_id"] == "session-example"
+    assert wire["history_ref"] == "history-example"
+    assert isinstance(decoded, Event)
+    assert decoded.session_id == "session-example"
+    assert decoded.history_ref == "history-example"
+
+
 # --- Reader policy: tolerant consumers, strict producers ----------------------
 
 

--- a/packages/aci-protocol/tests/test_wire_lock.py
+++ b/packages/aci-protocol/tests/test_wire_lock.py
@@ -173,3 +173,11 @@ def test_committed_lock_matches_the_current_wire() -> None:
     lock = json.loads(lock_path.read_text(encoding="utf-8"))
     assert lock["protocol_version"] == PROTOCOL_VERSION
     assert lock["wire_sha256"] == wire_fingerprint()
+
+
+def test_event_session_context_contract_uses_patch_version_0_4_4() -> None:
+    lock_path = schema_export.schema_path().parent / "wire.lock"
+    lock = json.loads(lock_path.read_text(encoding="utf-8"))
+
+    assert PROTOCOL_VERSION == "0.4.4"
+    assert lock["protocol_version"] == "0.4.4"


### PR DESCRIPTION
## Summary

Adds the standalone ACI 0.4.4 prerequisite for #1492: inbound `Event` frames can carry optional nullable `session_id` and `history_ref` metadata without breaking 0.4.3 producers. The schema, wire lock, generated TypeScript/Rust, exhaustive Rust constructors, tests, and live ACI docs move together. This does not consume or populate the fields, alter isolation, enable warm replicas, accept ADR-0122, or close #1492.

## Related issue

Ref #1492

Milestone: v0.9.0 feature train.

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | required | Changes the ACI event contract used by the runner turn surface. | fake | Local `CURIE_E2E_TIERS=skill curie dev e2e-ladder` and CI `CURIE_E2E_TIERS=skill,local curie dev e2e-ladder` at `bcdefc2e`: `LADDER PASS (tiers: skill)` and `LADDER PASS (tiers: skill,local)`. |
| local | required | The repository selector promotes ACI changes across the worker/runner service boundary. | fake | `CURIE_E2E_TIERS=skill,local curie dev e2e-ladder` at `bcdefc2e`: `LADDER PASS (tiers: skill,local)`. |
| local-release | required | The repository selector requires release-compose compatibility for this shared wire change. | fake | `CURIE_E2E_TIERS=local-release curie dev e2e-ladder` at `bcdefc2e`: `LADDER PASS (tiers: local-release)`. |
| cluster | required | The repository selector promotes the shared ACI contract across deployed cluster consumers. | fake | `CURIE_E2E_TIERS=cluster curie dev e2e-ladder` on disposable kind at `bcdefc2e`: `LADDER PASS (tiers: cluster)`; the cluster was torn down. |
| live provider | n/a | No model routing, provider credential/auth, token, or cost behavior changes; fields are inert metadata. | n/a | Deferred to the realizing #1492 PR. |
| external integration | n/a | No Slack, webhook, connector OAuth, or third-party API boundary changes. | n/a | Not reached. |

- [x] Every required tier above names its exact command, candidate commit, mode, and literal outcome.
- [x] Positive: omitted, explicit-null, and populated session context parses/round-trips and generated artifacts agree. Negative/independent paths: Event rejects unknown and malformed values; Interrupt rejects both new fields; schema proves the fields are not required.
- [x] No required tier is left unproved.

Affected checks: contract regeneration/drift check passed; 195 ACI protocol tests passed; generated Rust passed 9 tests; docs, Ruff, and mypy passed; the current squashed commit passed the commit-SHA-sensitive CLI test. Full CLI fmt/clippy/test passed before the content-preserving squash. The local full Python compose baseline could not start because another checkout owns the fixed dev-stack ports; that owner was preserved. CI then passed the full Python stack/test gate plus Rust, UI, secret scan, dependency audits, image builds, and every selected E2E rung.

## Rollout and rollback

Roll out in compatibility order: merge this optional 0.4.4 contract first; then land the reviewed runner consumer and worker producer; accept ADR-0122 with that realizing implementation; only then enable per-agent warm replicas after cluster and real-model evidence. Roll back the realizing feature by setting warm-pool replicas to zero first, stopping producers from populating session context, then reverting consumers. This prerequisite alone is safe to revert after downstream producers stop sending the fields; 0.4.x readers remain tolerant across the additive patch.

## Implementation checklist

- [x] Failing contract tests were committed before implementation.
- [x] Production edits were made by delegated Codex workers; the driver only performed generation, state bookkeeping, validation, and squash.
- [x] No function return type was broadened; the additive wire-model fields are covered across Python, JSON Schema, TypeScript, Rust, and exhaustive constructors.
- [x] Adversarial code, scope, and security reviews completed with no unresolved findings.
- [x] Sibling parity covers the source model, schema, generated languages, wire lock, CLI constructor, Interrupt negative path, and live ACI docs.
- [x] Guard behavior was executed: strict unknown/malformed Event values and Interrupt misuse fail.
- [x] Consolidation was skipped because the required `/simplify` capability is unavailable in this session; no consolidation edits were made.
- [x] User-facing contract docs passed the repository docs gate.
- [x] `next` is protected by the active repository ruleset and matches the v0.9.0 milestone train.
- [x] Discovery waiver: this frozen-contract prerequisite cannot prove the later live cluster behavior; #1492 remains open for that implementation and evidence.
- [x] Tests pass for the affected area; docs are updated; no new architecture decision is introduced in this prerequisite.
