### PR TITLE
Refuse a verb-widened platform-upgrade Role at install

### DIFF
--- a/cli/src/examples.rs
+++ b/cli/src/examples.rs
@@ -75,7 +75,7 @@ const SELF_UPGRADE_CRONJOB_ENV: &str = "SELF_UPGRADE_CRONJOB";
 // manifest exactly as the write Role's is. The manifest is edited far more often
 // than this file, so a widened grant must stop the install rather than ship in
 // it -- and this is the widest grant the bundle has.
-const PLATFORM_RULE_SHAPE: [(&str, &[&str]); 6] = [
+const PLATFORM_RULE_SHAPE: [(&str, &[&str], &[&str]); 6] = [
     (
         "",
         &[
@@ -85,15 +85,39 @@ const PLATFORM_RULE_SHAPE: [(&str, &[&str]); 6] = [
             "serviceaccounts",
             "persistentvolumeclaims",
         ],
+        &[
+            "get", "list", "watch", "create", "update", "patch", "delete",
+        ],
     ),
     (
         "apps",
         &["deployments", "statefulsets", "daemonsets", "replicasets"],
+        &[
+            "get", "list", "watch", "create", "update", "patch", "delete",
+        ],
     ),
-    ("batch", &["jobs", "cronjobs"]),
-    ("networking.k8s.io", &["networkpolicies", "ingresses"]),
-    ("rbac.authorization.k8s.io", &["roles", "rolebindings"]),
-    ("", &["pods", "events"]),
+    (
+        "batch",
+        &["jobs", "cronjobs"],
+        &[
+            "get", "list", "watch", "create", "update", "patch", "delete",
+        ],
+    ),
+    (
+        "networking.k8s.io",
+        &["networkpolicies", "ingresses"],
+        &[
+            "get", "list", "watch", "create", "update", "patch", "delete",
+        ],
+    ),
+    (
+        "rbac.authorization.k8s.io",
+        &["roles", "rolebindings"],
+        &[
+            "get", "list", "watch", "create", "update", "patch", "delete",
+        ],
+    ),
+    ("", &["pods", "events"], &["get", "list", "watch"]),
 ];
 // The one grant the write path may carry. Read from the shipped manifest and
 // asserted rather than assumed, so editing that file to widen the verb set stops
@@ -524,14 +548,10 @@ pub async fn install_sre_bot(opts: SreBotInstallOpts) -> Result<SreBotInstallRes
                 "kubectl apply -f examples/sre-bot/manifests/upgrade-role.yaml -- the CONNECTOR's \
                  identity ({UPGRADER_IDENTITY}): create on jobs, so it can start an upgrade"
             ));
-            lines.push(format!(
-                "kubectl apply -f examples/sre-bot/manifests/platform-upgrade-role.yaml -- the \
-                 JOB's identity ({PLATFORM_UPGRADER_IDENTITY}) in namespace {}: namespace-admin \
-                 in all but name, because `helm upgrade` rewrites nearly every object the release \
-                 owns. READ THAT FILE. It exists for the ~90s an upgrade runs and the sandbox \
-                 never sees it",
-                identity.namespace
-            ));
+            lines.push(platform_upgrade_role_plan_line(
+                embedded_bundle_file("manifests/platform-upgrade-role.yaml")?,
+                &identity.namespace,
+            )?);
             lines.push(format!(
                 "kubectl apply -f <rendered ConfigMap {PLATFORM_UPGRADE_CONFIGMAP}> -- the upgrade \
                  script the Job runs, from examples/sre-bot/platform-upgrade/upgrade.sh"
@@ -1616,13 +1636,28 @@ fn render_platform_upgrade_configmap(script: &[u8], namespace: &str) -> Result<V
     Ok(rendered.into_bytes())
 }
 
-/// The platform-upgrade identity, rendered into the release's namespace.
+fn embedded_bundle_file(name: &str) -> Result<&'static [u8]> {
+    BUNDLE_FILES
+        .iter()
+        .find(|(candidate, _)| *candidate == name)
+        .map(|(_, contents)| *contents)
+        .ok_or_else(|| anyhow!("embedded SRE bot is missing {name}"))
+}
+
+fn yaml_str_list<'a>(value: &'a serde_json::Value, key: &str) -> Vec<&'a str> {
+    value
+        .get(key)
+        .and_then(serde_json::Value::as_array)
+        .map(|items| items.iter().filter_map(serde_json::Value::as_str).collect())
+        .unwrap_or_default()
+}
+
+/// The shipped Role's rules, asserted against what this build knows how to render.
 ///
-/// The shipped manifest's rules are ASSERTED against what this build knows how to
-/// render before anything is emitted. This is the widest grant in the bundle --
-/// namespace-admin in all but name -- so a manifest that grows a rule must stop
-/// the install rather than have the installer grant it silently.
-fn render_platform_upgrade_role(source: &[u8], curie_namespace: &str) -> Result<Vec<u8>> {
+/// This is the widest grant in the bundle -- namespace-admin in all but name --
+/// so a manifest that grows a rule or a verb must stop the install rather than
+/// have the installer grant it silently.
+fn asserted_platform_rules(source: &[u8]) -> Result<Vec<serde_json::Value>> {
     let source = std::str::from_utf8(source)
         .context("embedded SRE bot platform-upgrade-role.yaml is not UTF-8")?;
     let mut rules: Option<Vec<serde_json::Value>> = None;
@@ -1650,26 +1685,59 @@ fn render_platform_upgrade_role(source: &[u8], curie_namespace: &str) -> Result<
             PLATFORM_RULE_SHAPE.len()
         );
     }
-    for (index, (group, resources)) in PLATFORM_RULE_SHAPE.iter().enumerate() {
+    for (index, (group, resources, verbs)) in PLATFORM_RULE_SHAPE.iter().enumerate() {
         let rule = &rules[index];
-        let groups: Vec<&str> = rule
-            .get("apiGroups")
-            .and_then(serde_json::Value::as_array)
-            .map(|items| items.iter().filter_map(serde_json::Value::as_str).collect())
-            .unwrap_or_default();
-        let actual: Vec<&str> = rule
-            .get("resources")
-            .and_then(serde_json::Value::as_array)
-            .map(|items| items.iter().filter_map(serde_json::Value::as_str).collect())
-            .unwrap_or_default();
-        if groups != [*group] || actual != *resources {
+        let groups = yaml_str_list(rule, "apiGroups");
+        let actual = yaml_str_list(rule, "resources");
+        let actual_verbs = yaml_str_list(rule, "verbs");
+        if groups != [*group] || actual != *resources || actual_verbs != *verbs {
             bail!(
-                "the embedded platform-upgrade Role's rule {index} is {groups:?}/{actual:?}, but \
-                 this build only knows how to render {:?}/{resources:?}",
+                "the embedded platform-upgrade Role's rule {index} is {groups:?}/{actual:?}/{actual_verbs:?}, but \
+                 this build only knows how to render {:?}/{resources:?}/{verbs:?}",
                 [group]
             );
         }
     }
+    Ok(rules)
+}
+
+fn platform_upgrade_grant_summary(rules: &[serde_json::Value]) -> String {
+    rules
+        .iter()
+        .map(|rule| {
+            format!(
+                "{:?}/{:?}/{:?}",
+                yaml_str_list(rule, "apiGroups"),
+                yaml_str_list(rule, "resources"),
+                yaml_str_list(rule, "verbs")
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("; ")
+}
+
+/// `--dry-run` disclosure for the Job identity, derived from the Role this
+/// build would apply. A hand-written summary would keep describing the
+/// unmodified grant after the YAML changed.
+fn platform_upgrade_role_plan_line(source: &[u8], namespace: &str) -> Result<String> {
+    let rules = asserted_platform_rules(source)?;
+    Ok(format!(
+        "kubectl apply -f examples/sre-bot/manifests/platform-upgrade-role.yaml -- the \
+         JOB's identity ({PLATFORM_UPGRADER_IDENTITY}) in namespace {namespace}: {}. \
+         READ THAT FILE. It exists for the ~90s an upgrade runs and the sandbox \
+         never sees it",
+        platform_upgrade_grant_summary(&rules)
+    ))
+}
+
+/// The platform-upgrade identity, rendered into the release's namespace.
+///
+/// The shipped manifest's rules are ASSERTED against what this build knows how to
+/// render before anything is emitted. This is the widest grant in the bundle --
+/// namespace-admin in all but name -- so a manifest that grows a rule must stop
+/// the install rather than have the installer grant it silently.
+fn render_platform_upgrade_role(source: &[u8], curie_namespace: &str) -> Result<Vec<u8>> {
+    let rules = asserted_platform_rules(source)?;
 
     let mut documents: Vec<serde_json::Value> = vec![
         serde_json::json!({
@@ -2407,6 +2475,89 @@ mod tests {
         assert!(
             error.to_string().contains("rules"),
             "a widened Role must be refused by name: {error}"
+        );
+    }
+
+    #[test]
+    fn a_verb_widened_platform_role_stops_the_install() {
+        // Count and apiGroups/resources stay put. The existing appended-rule
+        // test never reaches the per-rule shape check, and that check used to
+        // ignore verbs, so `["*"]` on one rule installed as a
+        // namespace-admin-equivalent grant (#2287).
+        let source = String::from_utf8(platform_role_source().to_vec()).unwrap();
+        let widened = source.replace(
+            "    resources: [\"secrets\", \"configmaps\", \"services\", \"serviceaccounts\", \"persistentvolumeclaims\"]\n    verbs: [\"get\", \"list\", \"watch\", \"create\", \"update\", \"patch\", \"delete\"]",
+            "    resources: [\"secrets\", \"configmaps\", \"services\", \"serviceaccounts\", \"persistentvolumeclaims\"]\n    verbs: [\"*\"]",
+        );
+        assert_ne!(
+            widened, source,
+            "the fixture no longer matches the manifest"
+        );
+        assert_eq!(
+            widened.matches("verbs: [\"*\"]").count(),
+            1,
+            "the mutation must change only one rule's verbs: {widened}"
+        );
+        let resource_widened = source.replace(
+            "resources: [\"pods\", \"events\"]",
+            "resources: [\"pods\", \"events\", \"namespaces\"]",
+        );
+        assert_ne!(resource_widened, source);
+        let resource_error =
+            render_platform_upgrade_role(resource_widened.as_bytes(), "curie-prod")
+                .unwrap_err()
+                .to_string();
+        let error = render_platform_upgrade_role(widened.as_bytes(), "curie-prod")
+            .unwrap_err()
+            .to_string();
+        assert!(
+            resource_error.contains("only knows how to render"),
+            "resource widening is the message class this test pins: {resource_error}"
+        );
+        assert!(
+            error.contains("only knows how to render"),
+            "a verb-widened Role must be refused by the same shape check as a resource widening: {error}"
+        );
+        assert!(
+            error.contains("\"*\""),
+            "the refusal must name the widened verbs: {error}"
+        );
+    }
+
+    #[test]
+    fn the_platform_upgrade_plan_line_is_derived_from_the_asserted_rules() {
+        let line = platform_upgrade_role_plan_line(platform_role_source(), "curie-prod").unwrap();
+        assert!(line.contains("curie-prod"), "{line}");
+        assert!(line.contains(PLATFORM_UPGRADER_IDENTITY), "{line}");
+        assert!(
+            line.contains(
+                r#"["secrets", "configmaps", "services", "serviceaccounts", "persistentvolumeclaims"]"#
+            ),
+            "the plan must name the resources this build would apply: {line}"
+        );
+        assert!(
+            line.contains(r#"["get", "list", "watch", "create", "update", "patch", "delete"]"#),
+            "the plan must name the verbs this build would apply: {line}"
+        );
+        assert!(
+            line.contains(r#"["pods", "events"]"#) && line.contains(r#"["get", "list", "watch"]"#),
+            "the plan must include the read-only pods/events rule: {line}"
+        );
+        assert!(
+            !line.contains("namespace-admin"),
+            "a hand-written characterization would describe a grant the YAML no longer has: {line}"
+        );
+        let source = String::from_utf8(platform_role_source().to_vec()).unwrap();
+        let widened = source.replace(
+            "    resources: [\"secrets\", \"configmaps\", \"services\", \"serviceaccounts\", \"persistentvolumeclaims\"]\n    verbs: [\"get\", \"list\", \"watch\", \"create\", \"update\", \"patch\", \"delete\"]",
+            "    resources: [\"secrets\", \"configmaps\", \"services\", \"serviceaccounts\", \"persistentvolumeclaims\"]\n    verbs: [\"*\"]",
+        );
+        let error = platform_upgrade_role_plan_line(widened.as_bytes(), "curie-prod")
+            .unwrap_err()
+            .to_string();
+        assert!(
+            error.contains("only knows how to render"),
+            "a verb-widened Role must not produce a plan line describing the unmodified grant: {error}"
         );
     }
 

--- a/cli/tests/example_sre_bot_install.rs
+++ b/cli/tests/example_sre_bot_install.rs
@@ -2188,6 +2188,44 @@ fn custom_target_dry_run_reports_and_uses_only_the_selected_identities() {
 }
 
 #[test]
+fn platform_upgrade_dry_run_discloses_the_applied_role_verbs() {
+    let fixture = Fixture::new(nodes(vec![node("node-a", "4Gi", true)]), pods(vec![]));
+    let output = fixture.run(&["--dry-run", "--json", "--platform-upgrade"]);
+    let text = shown(&output);
+    assert!(
+        output.status.success(),
+        "platform-upgrade dry run must succeed: {text}"
+    );
+    let lines = dry_run_plan_lines(&output);
+    let role_line = lines
+        .iter()
+        .find(|line| line.contains("platform-upgrade-role.yaml"))
+        .unwrap_or_else(|| panic!("plan must disclose the Job Role: {lines:?}"));
+    assert!(
+        role_line.contains(r#"["get", "list", "watch", "create", "update", "patch", "delete"]"#),
+        "plan must name the verbs this build would apply: {role_line}"
+    );
+    assert!(
+        !role_line.contains("namespace-admin"),
+        "plan must not describe the grant in canned words: {role_line}"
+    );
+    let without = Fixture::new(nodes(vec![node("node-a", "4Gi", true)]), pods(vec![]));
+    let without_output = without.run(&["--dry-run", "--json"]);
+    assert!(
+        without_output.status.success(),
+        "default dry run must succeed: {}",
+        shown(&without_output)
+    );
+    let without_lines = dry_run_plan_lines(&without_output);
+    assert!(
+        without_lines
+            .iter()
+            .all(|line| !line.contains("platform-upgrade")),
+        "omitting the flag must keep the upgrade path out of the plan: {without_lines:?}"
+    );
+}
+
+#[test]
 fn custom_targets_thread_through_helm_kubectl_manifests_secret_discovery_and_connectors() {
     let fixture = Fixture::with_modes(
         nodes(vec![node("node-a", "4Gi", true)]),


### PR DESCRIPTION
## Summary

The sre-bot platform-upgrade Role's install-time shape check compared apiGroups and resources but never verbs, so widening one rule to `["*"]` installed cleanly. `PLATFORM_RULE_SHAPE` now carries the expected verb list per rule and the installer refuses a mismatch with the same shape-check message as a resource widening. `--dry-run` discloses that grant from the asserted Role rather than a canned phrase, so the plan cannot describe a grant this build would not apply. The shipped Role YAML is unchanged.

## Related issue

Closes #2287

## Trigger

## Live proof

## Fix pin verification

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | Installer Role-shape assertion only; does not reach plugin packaging, the runner turn loop, or ACI events. | | |
| local | required | `curie example sre-bot install --platform-upgrade` is a CLI verb; the assertion runs before apply and the dry-run plan line for that flag now names the applied verbs. | fake | `cargo test --lib` at 2384099e: 1143 passed, including `a_verb_widened_platform_role_stops_the_install`. `cargo test --test example_sre_bot_install platform_upgrade_dry_run_discloses_the_applied_role_verbs` passed: `--dry-run --json --platform-upgrade` names `["get", "list", "watch", "create", "update", "patch", "delete"]`. |
| local-release | n/a | Does not change released binary identity, install path, version pins, or release compose. | | |
| cluster | n/a | Does not change chart templates, Curie-chart RBAC, sandbox claims, or the shipped Role YAML. | | |
| live provider | n/a | Does not reach model routing, credential resolution, or token accounting. | | |
| external integration | n/a | Does not reach Slack, git webhooks, or connector OAuth. | | |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

Positive: shipped YAML still renders (`the_platform_role_lands_in_the_release_namespace_with_no_static_token`) and dry-run names the shipped verbs.

Negative: mutating only the secrets rule's verbs to `["*"]` was red before the fix (`unwrap_err` on an `Ok` Role that contained `verbs: ['*']`) and green after, refused with `only knows how to render`, the same class as a one-rule resource widening. A verb-widened source also cannot produce a dry-run plan line.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [x] An ADR is added under `docs/adr/` if this is an architectural decision.
