### PR TITLE
fix: read prod deployments and honor env narrowing in self-upgrade

### DIFF
--- a/examples/sre-bot/connectors/self-upgrade/server.py
+++ b/examples/sre-bot/connectors/self-upgrade/server.py
@@ -1,4 +1,11 @@
-"""A write connector that can do exactly one thing: start this bot's upgrade.
+"""Two gated upgrade buttons and one read. None of them takes an argument.
+
+`upgrade_self` redeploys this bot's own bundle. `upgrade_platform` moves the
+Curie release underneath it. `latest_release` says what version is available.
+
+The two writes are the same mechanism pointed at different operator-written
+CronJob templates, which is why they share `_start_job_from` rather than being
+two files kept in step.
 
 Why the bot cannot just do the upgrade itself
 ---------------------------------------------
@@ -16,12 +23,28 @@ start that one Job and learn its name. It cannot say what the Job runs.
 
 Why a separate server, and why zero arguments
 ----------------------------------------------
-This connector exposes one zero-argument tool, so there is no second action for
-a gate to miss and no parameter through which a caller could reach an image, an
+There is no parameter through which a caller could reach an image, an
 environment variable, or a command. The repository, the branch, the agent
 name, the image and the command all come from the CronJob's own `jobTemplate`,
 read from the cluster at call time. There is no field a caller can influence, so
 there is nothing to validate and nothing to escape.
+
+There are three tools here now, and the "nothing for a gate to miss" argument
+holds differently than it did with one. Both writes are gated, and both are
+zero-argument buttons that copy a template verbatim -- so the property that
+matters is not the COUNT of tools but that no tool takes caller input. A gate
+cannot be missed here because there is no unclassified verb: two writes, two
+gates, one read that changes nothing and holds no credential.
+
+What would break it is a tool growing a parameter. That is the line, and it is
+worth restating because the obvious next request -- "let me name the version" --
+is exactly that.
+
+It lives here rather than in its own connector because it answers the same
+question from the other side. "What version is available" is what a person asks
+immediately before "can we upgrade", and splitting them across two images, two
+publish jobs and two declarations buys separation between a read and a write
+that share a repository, a domain, and no credential at all.
 
 The grant RBAC cannot narrow, and what stands in for it
 --------------------------------------------------------
@@ -35,7 +58,7 @@ template verbatim, and the CronJob is named by operator configuration
 Read that grant honestly when reviewing this: a leaked credential from this pod
 could create an arbitrary Job in this namespace. It is bounded by the same thing
 every other connector's credential is bounded by -- it never leaves the pod, and
-the pod exposes one no-argument tool.
+no tool takes caller input.
 
 NOT REVERSIBLE, and it says so
 -------------------------------

--- a/examples/sre-bot/self-upgrade/redeploy.py
+++ b/examples/sre-bot/self-upgrade/redeploy.py
@@ -81,6 +81,11 @@ BUNDLE_MEMBERS = (
 )
 BUNDLE_TREES = ("skills/", "manifests/")
 
+# deploy() always posts this environment. deployed_commit must read the same
+# one: git-flow leaves a previous environment's active row in place, so the
+# newest active deployment across environments is not what prod is serving.
+DEPLOY_ENVIRONMENT = "prod"
+
 
 class SelfUpgradeError(RuntimeError):
     """Something the operator has to fix, phrased for the operator."""
@@ -156,11 +161,12 @@ def _api(
 def deployed_commit(api_url: str, api_key: str, agent: str) -> tuple[str, str | None, str | None]:
     """``(agent_id, commit_sha, version_id)`` for the version this agent is SERVING.
 
-    The active deployment, not the newest version row. Those are different facts
-    and confusing them is how this job read a version that was created and never
-    deployed -- then tried to read a connector surface out of it and got "no
-    bundle stored for this version", which reads like a broken agent rather than
-    like a question asked about the wrong row.
+    The active deployment in ``DEPLOY_ENVIRONMENT``, not the newest version row
+    and not the newest active row across environments. Those are different
+    facts: git-flow never stops the previous environment's row, so an old
+    active prod deployment and a newer active dev deployment coexist, and
+    taking the newest ``deployed_at`` reports the dev commit as what prod is
+    serving.
 
     ``None`` for the sha when the deployed version records none: a version
     deployed by hand from a working copy has no commit, and that must read as
@@ -186,8 +192,10 @@ def deployed_commit(api_url: str, api_key: str, agent: str) -> tuple[str, str | 
 
     active = [
         d
-        for d in get("/deployments")
-        if d.get("agent_id") == agent_id and d.get("status") == "active"
+        for d in get(f"/deployments?agent_id={agent_id}")
+        if d.get("agent_id") == agent_id
+        and d.get("status") == "active"
+        and d.get("environment") == DEPLOY_ENVIRONMENT
     ]
     if not active:
         return agent_id, None, None
@@ -307,6 +315,30 @@ def resolve_digest(connector: str, commit: str) -> str:
     return str(digest)
 
 
+_MISSING = object()
+
+
+def _carried_overrides_declaration(key: str, declared: object, carried: str) -> bool:
+    """Whether a running env value may replace the incoming declaration.
+
+    Operator customizations of a still-granted value survive. An incoming empty
+    string is how connectors.yaml revokes a grant, and a narrower ``*_ALLOWLIST``
+    is a lowered ceiling: neither may be overwritten by the value currently
+    running.
+    """
+
+    if declared is _MISSING:
+        return True
+    if declared is None or (isinstance(declared, str) and declared.strip() == ""):
+        return False
+    if key.endswith("_ALLOWLIST"):
+        incoming = {part.strip() for part in str(declared).split(",") if part.strip()}
+        running = {part.strip() for part in carried.split(",") if part.strip()}
+        if incoming < running:
+            return False
+    return True
+
+
 def pin_build_connectors(
     declaration: bytes, commit: str, carried: dict[str, dict[str, str]]
 ) -> bytes:
@@ -315,7 +347,8 @@ def pin_build_connectors(
     Two substitutions: a `build:` block records a LOCAL image id, which the
     cluster tier refuses, and runtime connector environment may differ from the
     repository defaults. Resolve the image and carry the running environment
-    across the immutable rebuild.
+    across the immutable rebuild, except where the incoming declaration
+    narrows or revokes it.
     """
 
     import yaml
@@ -325,8 +358,13 @@ def pin_build_connectors(
         if "build" in spec:
             spec.pop("build")
             spec["image"] = f"ghcr.io/curie-eng/curie-sre-bot-{name}@{resolve_digest(name, commit)}"
+        env = spec.setdefault("env", {})
+        if not isinstance(env, dict):
+            env = {}
+            spec["env"] = env
         for key, value in (carried.get(name) or {}).items():
-            spec.setdefault("env", {})[key] = value
+            if _carried_overrides_declaration(key, env.get(key, _MISSING), value):
+                env[key] = value
     return yaml.safe_dump(parsed, sort_keys=False).encode()
 
 
@@ -452,7 +490,7 @@ def deploy(
             {
                 "agent_id": agent_id,
                 "version_id": version_id,
-                "environment": "prod",
+                "environment": DEPLOY_ENVIRONMENT,
                 "commit_sha": commit,
             }
         ).encode(),

--- a/examples/tests/test_self_upgrade_detection.py
+++ b/examples/tests/test_self_upgrade_detection.py
@@ -188,6 +188,50 @@ def test_the_running_connector_environment_survives_the_upgrade(
     )
 
 
+REVOKE = b"""connectors:
+  self-upgrade:
+    build:
+      context: connectors/self-upgrade
+    env:
+      SELF_UPGRADE_CRONJOB: sre-bot-self-upgrade
+      PLATFORM_UPGRADE_CRONJOB: ""
+      K8S_WRITE_ALLOWLIST: ns-a/deploy-a
+"""
+
+
+def test_a_carried_env_cannot_override_an_incoming_empty_value(
+    offline_registry: None,
+) -> None:
+    """A commit that revokes a grant by resetting env to empty must land.
+
+    connectors.yaml expresses "not granted" as an empty string. Carrying the
+    running value over that unconditionally made upgrade_self unable to
+    narrow a ceiling (curie#2292).
+    """
+
+    parsed = yaml.safe_load(
+        pin_build_connectors(
+            REVOKE,
+            "c" * 40,
+            {
+                "self-upgrade": {
+                    "PLATFORM_UPGRADE_CRONJOB": "sre-bot-platform-upgrade",
+                    "K8S_WRITE_ALLOWLIST": "ns-a/deploy-a,ns-b/deploy-b",
+                }
+            },
+        )
+    )
+    env = parsed["connectors"]["self-upgrade"]["env"]
+    assert env["PLATFORM_UPGRADE_CRONJOB"] == "", (
+        "a carried grant must not override an incoming empty value; empty is "
+        "how the declaration revokes the capability"
+    )
+    assert env["K8S_WRITE_ALLOWLIST"] == "ns-a/deploy-a", (
+        "a carried allowlist must not override a narrower incoming ceiling"
+    )
+    assert env["SELF_UPGRADE_CRONJOB"] == "sre-bot-self-upgrade"
+
+
 def test_replacing_one_member_leaves_the_others_byte_for_byte() -> None:
     original = _bundle({"connectors.yaml": b"old", "skills/sre-bot/SKILL.md": b"the skill"})
     swapped = _read(replace_member(original, "connectors.yaml", b"new"))
@@ -219,7 +263,7 @@ class _FakeApi:
         }
 
     def __call__(self, request, timeout=0):  # noqa: ANN001 - urlopen's shape
-        path = request.full_url.replace("http://api", "")
+        path = request.full_url.replace("http://api", "").split("?", 1)[0]
         import io as _io
 
         return _io.BytesIO(json.dumps(self.routes[path]).encode())
@@ -250,6 +294,7 @@ def test_the_served_version_wins_over_a_newer_undeployed_one(
                 "agent_id": "agent-1",
                 "version_id": "served",
                 "status": "active",
+                "environment": "prod",
                 "deployed_at": "2026-01-01T00:00:00",
                 "commit_sha": None,
             }
@@ -271,6 +316,73 @@ def test_the_served_version_wins_over_a_newer_undeployed_one(
 def test_no_active_deployment_reads_as_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
     # Never "up to date". A job that cannot tell must not report success.
     api = _FakeApi(deployments=[], versions=[{"id": "v", "commit_sha": "c" * 40}])
+    _patched(monkeypatch, api)
+    _agent, commit, version_id = deployed_commit("http://api", "k", "sre-bot")
+    assert commit is None and version_id is None
+
+
+def test_the_prod_deployment_wins_over_a_newer_active_dev_one(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Multiple active rows are normal; newest-across-environments is not prod.
+
+    create_deployment_row never stops the previous row, so an old active prod
+    row and a newer active dev row coexist. deployed_commit must match what
+    deploy() posts to (environment=prod), not the newest active row
+    (curie#2292).
+    """
+
+    api = _FakeApi(
+        deployments=[
+            {
+                "agent_id": "agent-1",
+                "version_id": "prod-v",
+                "status": "active",
+                "environment": "prod",
+                "deployed_at": "2026-01-01T00:00:00",
+                "commit_sha": "a" * 40,
+            },
+            {
+                "agent_id": "agent-1",
+                "version_id": "dev-v",
+                "status": "active",
+                "environment": "dev",
+                "deployed_at": "2026-09-01T00:00:00",
+                "commit_sha": "b" * 40,
+            },
+        ],
+        versions=[
+            {"id": "prod-v", "commit_sha": "a" * 40},
+            {"id": "dev-v", "commit_sha": "b" * 40},
+        ],
+    )
+    _patched(monkeypatch, api)
+
+    agent_id, commit, version_id = deployed_commit("http://api", "k", "sre-bot")
+
+    assert agent_id == "agent-1"
+    assert version_id == "prod-v"
+    assert commit == "a" * 40
+
+
+def test_an_active_dev_deployment_is_not_read_as_prod(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The falsifiable negative: no prod row must not report the dev commit."""
+
+    api = _FakeApi(
+        deployments=[
+            {
+                "agent_id": "agent-1",
+                "version_id": "dev-v",
+                "status": "active",
+                "environment": "dev",
+                "deployed_at": "2026-09-01T00:00:00",
+                "commit_sha": "b" * 40,
+            }
+        ],
+        versions=[{"id": "dev-v", "commit_sha": "b" * 40}],
+    )
     _patched(monkeypatch, api)
     _agent, commit, version_id = deployed_commit("http://api", "k", "sre-bot")
     assert commit is None and version_id is None

--- a/examples/tests/test_sre_bot_hygiene.py
+++ b/examples/tests/test_sre_bot_hygiene.py
@@ -129,6 +129,34 @@ def test_deploy_yaml_placeholder_channels_cannot_silently_rebind() -> None:
     )
 
 
+def test_self_upgrade_connector_docstring_names_the_tools_it_ships() -> None:
+    """The module docstring is this connector's blast-radius argument.
+
+    After the #2126 forward merge it claimed one zero-argument tool on a
+    three-tool file. A reviewer reading the header would stop. The invariant
+    that actually guards the connector is that no tool takes caller input
+    (curie#2292).
+    """
+
+    text = (BUNDLE / "connectors" / "self-upgrade" / "server.py").read_text(encoding="utf-8")
+    docstring = text[text.index('"""') + 3 : text.index('"""', 3)]
+    for tool in ("upgrade_self", "upgrade_platform", "latest_release"):
+        assert tool in docstring, (
+            f"self-upgrade module docstring must name {tool}; the file ships "
+            "three tools and the header is the security argument a reviewer reads"
+        )
+    assert "no tool takes caller input" in docstring, (
+        "self-upgrade module docstring must state the no-caller-input invariant; "
+        "that is the line, not the count of tools"
+    )
+    assert "one zero-argument tool" not in docstring, (
+        "self-upgrade module docstring still claims one zero-argument tool"
+    )
+    assert "exactly one thing" not in docstring, (
+        "self-upgrade module docstring still claims the connector does exactly one thing"
+    )
+
+
 def test_permission_map_matches_the_vanilla_kubernetes_connector() -> None:
     """Retiring the bespoke writers must retire their documentation too."""
 


### PR DESCRIPTION
## Summary

The sre-bot self-upgrade job treated every active deployment as equivalent and treated every running connector env value as authoritative. Combined with git-flow leaving previous environment rows active, that made a newer dev deployment look like prod, and it made a commit that revoked a grant by setting env to empty a no-op. The connector module docstring still described a one-tool surface after the #2126 forward merge dropped the three-tool text.

`deployed_commit` now filters to the same environment `deploy()` posts (`prod`), and lists deployments with `agent_id` rather than the whole collection. Carried env still survives when the incoming declaration keeps a non-empty value; an incoming empty string or a narrower `*_ALLOWLIST` wins. The module docstring names `upgrade_self`, `upgrade_platform`, and `latest_release`, and restores the invariant that no tool takes caller input.

What `upgrade_self` deploys is unchanged.

## Related issue

Closes #2292

## Trigger

<!-- not a patch-release PR -->

## Live proof

<!-- not a patch-release PR -->

## Fix pin verification

Fix pin: n/a - issue is unlabeled; the ticket's named proof is examples/tests, which is not a supported pin selector

## End-to-end verification

| Tier | Decision | Reason |
| --- | --- | --- |
| skill | n/a | No change to plugin packaging, the runner turn loop, ACI events, or skill eval/check. Connector signatures stay zero-argument. |
| local | required | The example self-upgrade job and connector are the changed surface; the ticket names `uv run pytest examples/tests -q`. |
| local-release | n/a | No released binary, image identity, install path, version pin, or release compose change. |
| cluster | n/a | No chart templates, RBAC, securityContext, NetworkPolicy, sandbox claims, or init containers. |
| live provider | n/a | No model routing, credential resolution, or token accounting. |
| external integration | n/a | No Slack, git webhook, or third-party API shape change. |

- [x] Required tier evidence (local): `uv run pytest examples/tests -q` on `16aa92aa` observed `111 passed in 165.21s`. Focused re-run on that commit: `uv run pytest examples/tests/test_self_upgrade_detection.py examples/tests/test_sre_bot_hygiene.py::test_self_upgrade_connector_docstring_names_the_tools_it_ships -q` observed `19 passed in 0.12s`.
- [x] Falsifiable negative: `test_an_active_dev_deployment_is_not_read_as_prod` returns unknown when only a dev row is active; `test_a_carried_env_cannot_override_an_incoming_empty_value` fails if carried env overwrites an incoming empty grant or a narrower allowlist; the docstring test fails if the header claims one tool or omits the no-caller-input line.
- [x] Teardown: none; unit tests against `_FakeApi`, no stack.

## Notes

- Default chosen on the merge rule: empty incoming values and proper-subset `*_ALLOWLIST` entries are revocations; other non-empty carried values still survive, which keeps the existing TEMPO_URL test.
- `examples/sre-bot/connectors.yaml` still comments that this connector is one tool. Left alone as out of ticket scope.
- Review was single-provider (grok): code and scope findings files recorded zero findings.
