### PR TITLE
Assert Valkey helper pins via client config, not wall-clock

### DIFF
--- a/packages/test-support/src/curie_test_support/valkey.py
+++ b/packages/test-support/src/curie_test_support/valkey.py
@@ -20,20 +20,28 @@ VALKEY_HOST = os.environ.get("TEST_VALKEY_HOST", "localhost")
 VALKEY_PORT = int(os.environ.get("TEST_VALKEY_PORT", "26379"))
 VALKEY_PW = os.environ.get("TEST_VALKEY_PW", "valkeypass")
 
-# How long one connect attempt may block. redis-py leaves socket_connect_timeout
-# at None by default, so a connect to an unreachable Valkey blocks on the OS
-# default rather than on anything this repo chose.
+# How long one connect attempt may block. redis-py 8.1.0 defaults
+# socket_connect_timeout to 5s. A SYN-drop (typical on macOS) waits that bound;
+# a RST (typical on Linux loopback) returns immediately, so this pin is not the
+# Linux cost driver. Keep it anyway: the helper must not inherit a library
+# default, and TEST_VALKEY_CONNECT_TIMEOUT raises the bound for a slow
+# environment.
 CONNECT_TIMEOUT_SECONDS = float(os.environ.get("TEST_VALKEY_CONNECT_TIMEOUT", "2"))
 
-# No retries, deliberately. redis-py 8.x defaults to Retry(ExponentialWithJitter,
-# 3), which is a MULTIPLIER on the timeout above and is what actually made an
-# unreachable Valkey cost a minute: measured on redis-py 8.1.0 against a bound
-# but unlistening port, socket_connect_timeout=5 still took 58.74s and the
-# unbounded default took 59.66s, while no-retry with a bounded timeout returns in
-# the timeout. Retrying is wrong for this helper regardless of the cost. Its
-# whole contract is one ping that decides skip-or-raise, the compose Valkey is
-# either up before the suite starts or it is not, and a helper that retries turns
-# "your stack is not running" into a minute of silence per fixture.
+# No retries, deliberately, including after a successful connect.
+# redis-py 8.1.0 defaults to Retry(ExponentialWithJitterBackoff, 10). That Retry
+# is client-level: redis-py copies it onto each connection, so it governs
+# connect AND command-path ConnectionError/TimeoutError. On Linux a
+# bound-unlistening loopback port answers RST immediately, so the default retry
+# ladder (not the connect timeout) is what costs ~4s; with NO_RETRY the same
+# path returns in ~0s. The ~59s figures are macOS, where the SYN is dropped and
+# each attempt waits the timeout. Retrying is wrong for this helper regardless
+# of the cost. Its whole contract is one ping that decides skip-or-raise, the
+# compose Valkey is either up before the suite starts or it is not, and a helper
+# that retries turns "your stack is not running" into seconds of silence per
+# fixture. Command-path retries are off for the same reason: fixtures should
+# fail loud on a dropped Valkey rather than paper over it. Do not restore the
+# default retry ladder to "fix" command-path transients.
 NO_RETRY = Retry(NoBackoff(), 0)
 
 
@@ -46,10 +54,10 @@ def connect_or_skip(*, decode_responses: bool = True) -> redis.Redis:
     ``RedisError`` fail the required CI job instead. The caller owns the returned
     client (yield it from a fixture and ``.close()`` on teardown).
 
-    The connect is bounded by ``CONNECT_TIMEOUT_SECONDS`` and does not retry, so
-    an unreachable Valkey costs that timeout once rather than a minute. See the
-    constants above for why; ``TEST_VALKEY_CONNECT_TIMEOUT`` raises the bound for
-    a slow environment.
+    The connect is bounded by ``CONNECT_TIMEOUT_SECONDS`` and does not retry
+    (connect or command path), so an unreachable Valkey costs that timeout once
+    rather than a retry ladder. See the constants above for why;
+    ``TEST_VALKEY_CONNECT_TIMEOUT`` raises the bound for a slow environment.
     """
     client: redis.Redis = redis.Redis(
         host=VALKEY_HOST,

--- a/packages/test-support/tests/test_valkey.py
+++ b/packages/test-support/tests/test_valkey.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import socket
-import time
+from collections.abc import Callable
 
 import pytest
 import redis
@@ -17,6 +17,20 @@ def _configure_unreachable_valkey(monkeypatch: pytest.MonkeyPatch) -> socket.soc
     monkeypatch.setattr(valkey, "VALKEY_HOST", "127.0.0.1")
     monkeypatch.setattr(valkey, "VALKEY_PORT", int(listener.getsockname()[1]))
     return listener
+
+
+def _capture_constructed_clients(monkeypatch: pytest.MonkeyPatch) -> list[redis.Redis]:
+    """Wrap redis.Redis so the test can inspect the client connect_or_skip built."""
+    captured: list[redis.Redis] = []
+    original: Callable[..., redis.Redis] = valkey.redis.Redis
+
+    def capture(*args: object, **kwargs: object) -> redis.Redis:
+        client = original(*args, **kwargs)
+        captured.append(client)
+        return client
+
+    monkeypatch.setattr(valkey.redis, "Redis", capture)
+    return captured
 
 
 def test_connect_or_skip_skips_an_unreachable_valkey_locally(
@@ -49,28 +63,38 @@ def test_connect_or_skip_fails_for_an_unreachable_valkey_when_required(
             valkey.connect_or_skip()
 
 
-def test_an_unreachable_valkey_costs_the_bounded_timeout_not_a_retry_ladder(
+def test_connect_or_skip_client_has_no_retry_and_a_connect_timeout(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The bound must hold end to end, not just be passed to the constructor.
+    """Removing either constructor pin must fail this test on Linux.
 
-    redis-py 8.x defaults to Retry(ExponentialWithJitterBackoff(), 3), which
-    multiplies socket_connect_timeout rather than capping it: measured on 8.1.0
-    against a bound but unlistening port, socket_connect_timeout=5 still took
-    58.74s and the unbounded default took 59.66s. So asserting the constructor
-    received a timeout would not catch a reintroduced retry policy. Assert the
-    wall clock instead, which is the thing that was wrong.
+    The previous control asserted elapsed < 5 against a bound-unlistening
+    loopback port. On Linux that port answers RST immediately, so redis-py
+    8.1.0 without these pins already returned in ~4.3s and both mutations
+    stayed green. The ~59s figures are macOS, where the SYN is dropped.
+    Inspect the client's effective configuration instead: that is what the
+    two pins change, and it does not depend on SYN-drop vs RST.
+
+    redis-py 8.1.0 defaults socket_connect_timeout to 5s, so asserting the
+    timeout is merely set would not catch deleting the kwarg. The bound must
+    equal CONNECT_TIMEOUT_SECONDS. Default retry.get_retries() is 10, so
+    retries == 0 catches deleting retry=NO_RETRY.
     """
     monkeypatch.delenv("CI_REQUIRE_VALKEY_TESTS", raising=False)
-    monkeypatch.setattr(valkey, "CONNECT_TIMEOUT_SECONDS", 0.25)
+    captured = _capture_constructed_clients(monkeypatch)
     listener = _configure_unreachable_valkey(monkeypatch)
 
     with listener:
-        started = time.monotonic()
-        with pytest.raises(pytest.skip.Exception):
+        with pytest.raises(pytest.skip.Exception, match="Valkey not reachable"):
             valkey.connect_or_skip()
-        elapsed = time.monotonic() - started
 
-    # Generous next to a 0.25s bound, and still two orders of magnitude under the
-    # ~59s the retry ladder cost.
-    assert elapsed < 5, f"an unreachable Valkey took {elapsed:.2f}s, so the bound is not holding"
+    assert captured, "connect_or_skip never constructed a Redis client"
+    client = captured[0]
+    try:
+        retry = client.get_retry()
+        assert retry is not None
+        assert retry.get_retries() == 0
+        timeout = client.connection_pool.connection_kwargs.get("socket_connect_timeout")
+        assert timeout == valkey.CONNECT_TIMEOUT_SECONDS
+    finally:
+        client.close()


### PR DESCRIPTION
## Summary

#2233 bounded the shared Valkey test helper with `socket_connect_timeout` and `retry=NO_RETRY`, and shipped a control that asserted `elapsed < 5` against a bound-unlistening loopback port. On Linux that port answers RST immediately, so the unfixed redis-py 8.1.0 default already returns in ~4s and deleting either pin stays green. The ~59s figures in that PR are macOS, where the SYN is dropped.

This replaces the wall-clock control with assertions on the constructed client's effective configuration: `retry.get_retries() == 0` and `socket_connect_timeout == CONNECT_TIMEOUT_SECONDS`. redis-py 8.1.0 defaults those to 10 retries and 5s, so omitting either kwarg fails on Linux.

`retry=NO_RETRY` is a client-level redis-py setting, so it also disables command-path retries after a successful connect. That is deliberate: fixtures should fail loud on a dropped Valkey rather than paper over it. The helper comments now say so. The `CI_REQUIRE_VALKEY_TESTS` re-raise is unchanged.

## Related issue

Closes #2290

## Fix pin verification

## End-to-end verification

This change does not alter runtime behavior because `connect_or_skip` already passed both constructor pins; the constructor is unchanged. The change is the control that defends those pins, plus comments documenting Linux vs macOS cost and that command-path retry is off on purpose.

Scoped verification: `uv run pytest packages/test-support -q` - `3 passed in 0.07s` on `task/2290-valkey-control`.

Linux timings against a bound-unlistening loopback port, redis-py 8.1.0, n=3 min/avg/max:

| config | elapsed |
| --- | --- |
| pre-fix (no timeout, default retry) | 4.06 / 4.18 / 4.28 s |
| post-fix (timeout=2, NO_RETRY) | 0.0001 / 0.0001 / 0.0002 s |
| delete `retry=NO_RETRY` | 3.20 / 3.46 / 3.97 s |
| delete `socket_connect_timeout` | 0.0002 / 0.0002 / 0.0004 s |

Both delete-one-pin rows stay under 5s, which is why the old control could not fail.

Mutations of the new control on Linux (`uv run pytest packages/test-support -q`):

- unmutated: `3 passed in 0.07s`
- delete `retry=NO_RETRY`: `FAILED ... assert 10 == 0` (`1 failed, 2 passed in 11.71s`)
- delete `socket_connect_timeout`: `FAILED ... assert 5 == 2.0` (`1 failed, 2 passed in 0.11s`)
- restored: `3 passed in 0.07s`

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [ ] An ADR is added under `docs/adr/` if this is an architectural decision.
