### PR TITLE
Add spec-vs-impl trigger for P0 and sre-bot-e2e-demo Closes

### DIFF
--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -293,6 +293,27 @@ Before completion, run the full affected test suite plus the relevant type check
 lint. Check sibling paths when the change touches a known seam or guard. Demonstrate
 that a new or modified guard rejects violating input through its real consumer path.
 
+### P0, release-blocker, and sre-bot-e2e-demo Closes
+
+When the pull request this run will open uses a GitHub closing keyword
+(`Closes`, `Fixes`, `Resolves`, and their past-tense forms) on an issue labeled
+`P0`, `release-blocker`, or `sre-bot-e2e-demo`, the review stage adds one extra
+read-only spec-vs-impl pass. That pass's only job is: each issue acceptance
+criterion is visible in the product diff, not only in the e2e table or the Fix
+pin selector. Scope review already asks whether each hunk traces to an AC; this
+pass asks the converse, whether each AC is in the diff.
+
+A string or refusal-text test cannot be the sole pin for a routing, catalog, or
+live-trace AC. The documented insufficient pin is #2209, which closed #2202 with
+a message-only Fix pin on the record-miss copy; #2248 reopened the routing AC.
+
+If the diff does not implement an AC, the PR uses `Ref` and leaves the issue
+open.
+
+Ordinary bugfixes that close neither of those labels are unchanged: the existing
+code review, scope review, and Fix pin rules still apply, and this extra pass
+does not run.
+
 ## Stop and escalate
 
 Hand the decision back rather than pressing on when reviews cannot converge after
@@ -334,6 +355,10 @@ an item nobody had to answer for is an item nobody checked.
       falsifiable negative or a second independent path
 - [ ] The change does not undo an earlier deliberate decision, per Prior intent
 - [ ] Full affected test suite, type check, and lint pass on the final code
+- [ ] If this PR closes a `P0`, `release-blocker`, or `sre-bot-e2e-demo` issue,
+      spec-vs-impl confirmed each issue AC against the diff, not only the e2e
+      table or the Fix pin selector. Ordinary bugfixes that close neither label
+      mark this n/a.
 
 A quick path change marks the failing tests, separate contexts, and prior intent
 items not applicable. A direct path change applies only the suite and lint items.

--- a/.github/workflows/p0-closes.yaml
+++ b/.github/workflows/p0-closes.yaml
@@ -1,0 +1,99 @@
+name: P0 Closes spec-vs-impl reminder
+
+# Advisory only. A PR that Closes a P0, release-blocker, or sre-bot-e2e-demo
+# issue gets a comment asking for spec-vs-impl of each issue AC against the
+# diff (#2306). This workflow must not fail that pull request and must not
+# raise GitHub required reviews. Keep it out of ci.yaml so it cannot join the
+# required Python check.
+on:
+  pull_request:
+    branches: [main, next]
+    # A closing keyword can appear or disappear in a body-only edit. Re-run so
+    # the reminder tracks the body GitHub will actually close from.
+    types: [opened, synchronize, reopened, edited]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  remind:
+    name: Comment when a Closes targets P0 / release-blocker / sre-bot-e2e-demo
+    runs-on: ubuntu-latest
+    # A job-level block REPLACES the workflow-level one, so `contents: read` is
+    # repeated here. `issues: read` is the label lookup; `pull-requests: write`
+    # is the comment. Neither is a required review.
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Decide whether this Closes a trigger-labeled issue
+        env:
+          COMMENT_FILE: ${{ runner.temp }}/curie-p0-closes-comment.md
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >-
+          python3 tools/p0-closes-ci/check.py
+          --event "$GITHUB_EVENT_PATH"
+          --comment-file "$COMMENT_FILE"
+      - name: Upsert or remove the spec-vs-impl reminder comment
+        uses: actions/github-script@v9
+        env:
+          COMMENT_FILE: ${{ runner.temp }}/curie-p0-closes-comment.md
+        with:
+          script: |
+            const fs = require("node:fs");
+            const marker = "<!-- curie-p0-closes-spec-vs-impl -->";
+            const commentPath = process.env.COMMENT_FILE;
+            try {
+              if (!commentPath) {
+                core.warning("COMMENT_FILE is not set");
+                return;
+              }
+              const body = fs.existsSync(commentPath)
+                ? fs.readFileSync(commentPath, { encoding: "utf8" })
+                : "";
+              const { data: comments } = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                per_page: 100,
+              });
+              const existing = comments.find(
+                (comment) =>
+                  typeof comment.body === "string" && comment.body.includes(marker)
+              );
+              if (!body.trim()) {
+                if (existing) {
+                  await github.rest.issues.deleteComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    comment_id: existing.id,
+                  });
+                }
+                return;
+              }
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                  body,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  body,
+                });
+              }
+            } catch (error) {
+              core.warning(`P0 Closes reminder comment was not posted: ${error.message}`);
+            }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,6 +181,7 @@ testpaths = [
     "tools/ci-workflow-paths/tests",
     "tools/e2e-ci-selection/tests",
     "tools/sdk-lock-gate/tests",
+    "tools/p0-closes-ci/tests",
 ]
 
 [tool.ruff]

--- a/tools/p0-closes-ci/check.py
+++ b/tools/p0-closes-ci/check.py
@@ -1,0 +1,190 @@
+"""Comment when a pull request Closes a P0, release-blocker, or sre-bot-e2e-demo issue.
+
+Advisory only: never fails a pull request because it Closes one of those
+labels. The implement skill owns the spec-vs-impl AC-vs-diff pass; this helper
+only reminds. Do not raise GitHub required reviews.
+
+Closing-keyword parsing is a sibling of ``tools/fix-pin-ci/check.py``. That
+helper asks for a Fix pin when a ``bug`` closes; this one comments when a
+``P0``, ``release-blocker``, or ``sre-bot-e2e-demo`` issue closes. The regex is
+duplicated because changing Fix pin parsing is out of scope for #2306.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+
+COMMENT = re.compile(r"<!--.*?-->", re.DOTALL)
+# Sibling of tools/fix-pin-ci/check.py::CLOSING. GitHub closes an issue in the
+# same repository only for a bare `#N` reference that follows a closing
+# keyword. A `#` glued to a word character or a slash is a cross repository or
+# URL reference and closes nothing here. The single optional colon covers
+# GitHub's documented `Closes: #N` form.
+CLOSING = re.compile(
+    r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b\s*:?"
+    r"(?P<references>(?:\s*(?:,|and)?\s*(?<![\w/])#\d+)+)",
+    re.IGNORECASE,
+)
+REFERENCE = re.compile(r"(?<![\w/])#(?P<number>\d+)")
+TRIGGER_LABELS = frozenset({"P0", "release-blocker", "sre-bot-e2e-demo"})
+COMMENT_MARKER = "<!-- curie-p0-closes-spec-vs-impl -->"
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--event", type=Path, required=True)
+    parser.add_argument("--comment-file", type=Path, required=True)
+    return parser
+
+
+def _event(event_path: Path) -> dict[str, object]:
+    try:
+        event = json.loads(event_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValueError(f"could not read pull request event: {error}") from error
+
+    if not isinstance(event, dict):
+        raise ValueError("pull request event must be an object")
+    return event
+
+
+def _body(event: dict[str, object]) -> str:
+    pull_request = event.get("pull_request")
+    if not isinstance(pull_request, dict):
+        return ""
+
+    body = pull_request.get("body")
+    if body is None:
+        return ""
+    if not isinstance(body, str):
+        raise ValueError("pull request body must be a string or null")
+    return body
+
+
+def _repository(event: dict[str, object]) -> str | None:
+    repository = event.get("repository")
+    if isinstance(repository, dict):
+        full_name = repository.get("full_name")
+        if isinstance(full_name, str) and full_name:
+            return full_name
+    return os.environ.get("GITHUB_REPOSITORY") or None
+
+
+def _closed_issues(body: str) -> list[int]:
+    uncommented = COMMENT.sub("", body)
+    numbers: list[int] = []
+    for closure in CLOSING.finditer(uncommented):
+        for reference in REFERENCE.finditer(closure.group("references")):
+            number = int(reference.group("number"))
+            if number not in numbers:
+                numbers.append(number)
+    return numbers
+
+
+def _labels(repository: str | None, issue: int) -> list[str]:
+    gh = shutil.which("gh")
+    if gh is None:
+        raise ValueError(f"gh is not on PATH, so the labels of issue #{issue} cannot be read")
+    if repository is None:
+        raise ValueError(
+            f"no repository slug is available, so the labels of issue #{issue} cannot be read"
+        )
+
+    completed = subprocess.run(
+        [gh, "api", f"repos/{repository}/issues/{issue}", "--jq", "[.labels[].name]"],
+        capture_output=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        detail = completed.stderr.decode("utf-8", errors="replace").strip()
+        raise ValueError(f"could not read the labels of issue #{issue}: {detail}")
+
+    try:
+        labels = json.loads(completed.stdout.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValueError(f"could not parse the labels of issue #{issue}: {error}") from error
+
+    if not isinstance(labels, list) or not all(isinstance(label, str) for label in labels):
+        raise ValueError(f"could not parse the labels of issue #{issue}: not a list of names")
+    return labels
+
+
+def _trigger_issues(event: dict[str, object], body: str) -> list[int]:
+    issues = _closed_issues(body)
+    if not issues:
+        return []
+    repository = _repository(event)
+    matched: list[int] = []
+    for issue in issues:
+        labels = _labels(repository, issue)
+        if TRIGGER_LABELS.intersection(labels):
+            matched.append(issue)
+    return matched
+
+
+def _comment_body(issues: Sequence[int]) -> str:
+    listed = ", ".join(f"#{issue}" for issue in issues)
+    return (
+        f"{COMMENT_MARKER}\n"
+        "This pull request uses a GitHub closing keyword on issue(s) labeled "
+        f"`P0`, `release-blocker`, or `sre-bot-e2e-demo`: {listed}.\n"
+        "\n"
+        "Confirm each issue acceptance criterion is visible in the diff, not "
+        "only in the e2e table or the Fix pin selector. A string or "
+        "refusal-text test cannot be the sole pin for a routing, catalog, or "
+        "live-trace AC. If the diff does not implement an AC, switch the "
+        "keyword to `Ref` and leave the issue open.\n"
+        "\n"
+        "Documented insufficient pin: #2209 closed #2202 with a message-only "
+        "Fix pin; #2248 reopened the routing AC.\n"
+    )
+
+
+def _write_comment_file(path: Path, body: str) -> None:
+    path.write_text(body, encoding="utf-8")
+
+
+def _skip(comment_file: Path, reason: str) -> int:
+    _write_comment_file(comment_file, "")
+    print(f"SKIPPED: {reason}")
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    arguments = _parser().parse_args(argv)
+
+    try:
+        event = _event(arguments.event)
+        body = _body(event)
+    except ValueError as error:
+        print(f"P0 Closes reminder error: {error}", file=sys.stderr)
+        return 1
+
+    issues = _closed_issues(body)
+    if not issues:
+        return _skip(arguments.comment_file, "no P0, release-blocker, or sre-bot-e2e-demo Closes")
+
+    try:
+        matched = _trigger_issues(event, body)
+    except ValueError as error:
+        return _skip(arguments.comment_file, f"could not read issue labels ({error})")
+
+    if not matched:
+        return _skip(arguments.comment_file, "no P0, release-blocker, or sre-bot-e2e-demo Closes")
+
+    listed = ", ".join(f"#{issue}" for issue in matched)
+    _write_comment_file(arguments.comment_file, _comment_body(matched))
+    print(f"COMMENT: this Closes a P0, release-blocker, or sre-bot-e2e-demo issue ({listed})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/p0-closes-ci/tests/test_p0_closes_ci.py
+++ b/tools/p0-closes-ci/tests/test_p0_closes_ci.py
@@ -1,0 +1,380 @@
+"""Executable contract for the P0 / release-blocker / sre-bot-e2e-demo Closes reminder.
+
+Issue #2306: a PR that closes one of those labels must spec-vs-impl each issue
+AC against the diff. The implement skill is the trigger. The optional CI helper
+comments; it must not fail the pull request and must not raise GitHub required
+reviews. Ordinary bugfixes that close neither label stay skipped.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CHECKER = REPO_ROOT / "tools" / "p0-closes-ci" / "check.py"
+SKILL = REPO_ROOT / ".claude" / "skills" / "implement" / "SKILL.md"
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "p0-closes.yaml"
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yaml"
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+
+TRIGGER_LABELS = ("P0", "release-blocker", "sre-bot-e2e-demo")
+COMMENT_MARKER = "<!-- curie-p0-closes-spec-vs-impl -->"
+
+
+def _write_event(
+    tmp_path: Path,
+    body: str | None,
+    *,
+    include_body: bool = True,
+    repository: str = "curie-eng/curie",
+) -> Path:
+    pull_request: dict[str, object] = {}
+    if include_body:
+        pull_request["body"] = body
+    event_path = tmp_path / "event.json"
+    event_path.write_text(
+        json.dumps(
+            {
+                "action": "opened",
+                "pull_request": pull_request,
+                "repository": {"full_name": repository},
+            }
+        ),
+        encoding="utf-8",
+    )
+    return event_path
+
+
+def _write_fake_gh(tmp_path: Path) -> Path:
+    directory = tmp_path / "gh-bin"
+    directory.mkdir()
+    fake_binary = directory / "gh"
+    fake_binary.write_text(
+        "\n".join(
+            [
+                f"#!{sys.executable}",
+                "import json",
+                "import os",
+                "import sys",
+                "from pathlib import Path",
+                "log = Path(os.environ['P0_CLOSES_GH_CALLS'])",
+                "calls = json.loads(log.read_text()) if log.exists() else []",
+                "calls.append(sys.argv[1:])",
+                "log.write_text(json.dumps(calls))",
+                "code = int(os.environ.get('P0_CLOSES_GH_EXIT', '0'))",
+                "if code != 0:",
+                "    raise SystemExit(code)",
+                "path = sys.argv[2]",
+                "number = path.rsplit('/', 1)[-1]",
+                "by_issue = json.loads(os.environ.get('P0_CLOSES_GH_LABELS_BY_ISSUE', '{}'))",
+                "if number in by_issue:",
+                "    print(json.dumps(by_issue[number]))",
+                "else:",
+                "    print(os.environ.get('P0_CLOSES_GH_LABELS', '[]'))",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    fake_binary.chmod(0o755)
+    return directory
+
+
+def _run_checker(
+    tmp_path: Path,
+    body: str | None,
+    *,
+    include_body: bool = True,
+    gh_labels: str = "[]",
+    gh_labels_by_issue: dict[str, list[str]] | None = None,
+    gh_exit: int = 0,
+    gh_on_path: bool = True,
+) -> tuple[subprocess.CompletedProcess[str], Path, Path]:
+    event_path = _write_event(tmp_path, body, include_body=include_body)
+    comment_file = tmp_path / "comment.md"
+    gh_calls = tmp_path / "gh-calls.json"
+    binaries = _write_fake_gh(tmp_path)
+    environment = {
+        **os.environ,
+        "P0_CLOSES_GH_CALLS": str(gh_calls),
+        "P0_CLOSES_GH_LABELS": gh_labels,
+        "P0_CLOSES_GH_LABELS_BY_ISSUE": json.dumps(gh_labels_by_issue or {}),
+        "P0_CLOSES_GH_EXIT": str(gh_exit),
+        "GITHUB_REPOSITORY": "curie-eng/curie",
+        "PATH": f"{binaries}{os.pathsep}{os.environ.get('PATH', '')}" if gh_on_path else "",
+    }
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(CHECKER),
+            "--event",
+            str(event_path),
+            "--comment-file",
+            str(comment_file),
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        check=False,
+        env=environment,
+        text=True,
+    )
+    return completed, comment_file, gh_calls
+
+
+def _load_workflow(path: Path) -> dict[str, Any]:
+    document = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert isinstance(document, dict), f"{path.name} must be a YAML mapping"
+    return document
+
+
+def _string(step: dict[str, Any], key: str) -> str:
+    value = step.get(key)
+    return value if isinstance(value, str) else ""
+
+
+def _single_step(
+    steps: list[dict[str, Any]], predicate: Callable[[dict[str, Any]], bool], description: str
+) -> dict[str, Any]:
+    matches = [step for step in steps if predicate(step)]
+    assert len(matches) == 1, f"expected exactly one {description}, found {len(matches)}"
+    return matches[0]
+
+
+def test_implement_skill_states_the_p0_closes_trigger_and_ac_vs_diff_rule() -> None:
+    text = SKILL.read_text(encoding="utf-8")
+    for label in TRIGGER_LABELS:
+        assert f"`{label}`" in text, f"implement skill must name the `{label}` Closes trigger"
+    assert "Closes" in text
+    assert "spec-vs-impl" in text
+    assert "acceptance criterion" in text.lower() or "acceptance criteria" in text.lower()
+    assert "diff" in text
+    assert "Fix pin" in text
+    assert "e2e" in text.lower()
+
+
+def test_implement_skill_documents_the_2209_message_only_pin_as_insufficient() -> None:
+    text = SKILL.read_text(encoding="utf-8")
+    assert "#2209" in text
+    assert "#2248" in text
+    combined = text.lower()
+    assert "routing" in combined
+    assert "message-only" in combined or "refusal-text" in combined or "string" in combined
+
+
+def test_implement_skill_leaves_ordinary_bugfixes_unchanged() -> None:
+    text = SKILL.read_text(encoding="utf-8")
+    lowered = text.lower()
+    assert "ordinary" in lowered
+    assert "unchanged" in lowered
+
+
+def test_pytest_collects_this_suite_from_committed_testpaths() -> None:
+    assert '    "tools/p0-closes-ci/tests",' in PYPROJECT.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("label", TRIGGER_LABELS)
+def test_closing_a_trigger_label_writes_the_advisory_comment_and_exits_zero(
+    tmp_path: Path, label: str
+) -> None:
+    completed, comment_file, gh_calls = _run_checker(
+        tmp_path, "Closes #12\n", gh_labels=json.dumps([label, "bug"])
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.strip().startswith("COMMENT:")
+    assert "#12" in completed.stdout
+    body = comment_file.read_text(encoding="utf-8")
+    assert COMMENT_MARKER in body
+    assert "#12" in body
+    assert "confirm each" in body.lower() or "each issue" in body.lower()
+    assert "diff" in body
+    assert "#2209" in body
+    assert "#2248" in body
+    calls = json.loads(gh_calls.read_text(encoding="utf-8"))
+    assert calls == [["api", "repos/curie-eng/curie/issues/12", "--jq", "[.labels[].name]"]]
+
+
+def test_ordinary_bug_close_skips_without_commenting(tmp_path: Path) -> None:
+    completed, comment_file, gh_calls = _run_checker(
+        tmp_path, "Closes #12\n", gh_labels=json.dumps(["bug"])
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.strip().startswith("SKIPPED:")
+    assert comment_file.read_text(encoding="utf-8") == ""
+    assert json.loads(gh_calls.read_text(encoding="utf-8"))
+
+
+def test_no_closing_keyword_skips_without_calling_gh(tmp_path: Path) -> None:
+    completed, comment_file, gh_calls = _run_checker(
+        tmp_path, "Ref #12\nThis is an ordinary bugfix.\n"
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.strip().startswith("SKIPPED:")
+    assert comment_file.read_text(encoding="utf-8") == ""
+    assert not gh_calls.exists()
+
+
+def test_html_comment_closes_does_not_trigger(tmp_path: Path) -> None:
+    completed, comment_file, gh_calls = _run_checker(
+        tmp_path, "<!-- Closes #12 -->\n", gh_labels=json.dumps(["P0"])
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.strip().startswith("SKIPPED:")
+    assert comment_file.read_text(encoding="utf-8") == ""
+    assert not gh_calls.exists()
+
+
+def test_fixes_colon_form_triggers(tmp_path: Path) -> None:
+    completed, comment_file, _gh_calls = _run_checker(
+        tmp_path, "Fixes: #12\n", gh_labels=json.dumps(["sre-bot-e2e-demo"])
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.strip().startswith("COMMENT:")
+    assert "#12" in comment_file.read_text(encoding="utf-8")
+
+
+def test_mixed_closes_comments_only_the_trigger_issues(tmp_path: Path) -> None:
+    completed, comment_file, _gh_calls = _run_checker(
+        tmp_path,
+        "Closes #12 and #13\n",
+        gh_labels_by_issue={"12": ["bug"], "13": ["P0"]},
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.strip().startswith("COMMENT:")
+    body = comment_file.read_text(encoding="utf-8")
+    assert "#13" in body
+    assert "#12" not in body
+    assert "#13" in completed.stdout
+    assert "#12" not in completed.stdout
+
+
+def test_gh_api_error_fails_open_without_blocking(tmp_path: Path) -> None:
+    completed, comment_file, _gh_calls = _run_checker(
+        tmp_path, "Closes #12\n", gh_labels=json.dumps(["P0"]), gh_exit=1
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.strip().startswith("SKIPPED:")
+    assert comment_file.read_text(encoding="utf-8") == ""
+
+
+def test_missing_gh_with_closed_issues_fails_open(tmp_path: Path) -> None:
+    completed, comment_file, _gh_calls = _run_checker(tmp_path, "Closes #12\n", gh_on_path=False)
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.strip().startswith("SKIPPED:")
+    assert comment_file.read_text(encoding="utf-8") == ""
+
+
+def test_malformed_event_exits_nonzero(tmp_path: Path) -> None:
+    event_path = tmp_path / "event.json"
+    event_path.write_text("{", encoding="utf-8")
+    comment_file = tmp_path / "comment.md"
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(CHECKER),
+            "--event",
+            str(event_path),
+            "--comment-file",
+            str(comment_file),
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    assert completed.returncode != 0
+    assert "event" in completed.stderr.lower() or "json" in completed.stderr.lower()
+
+
+def test_commenter_is_not_wired_into_the_required_python_job() -> None:
+    ci = CI_WORKFLOW.read_text(encoding="utf-8")
+    assert "p0-closes" not in ci
+    assert "tools/p0-closes-ci/check.py" not in ci
+
+
+def test_workflow_comments_on_body_edits_and_never_requires_a_review() -> None:
+    workflow = _load_workflow(WORKFLOW)
+    trigger = workflow.get("on", workflow.get(True))
+    assert isinstance(trigger, dict)
+    pull_request = trigger.get("pull_request")
+    assert isinstance(pull_request, dict)
+    assert set(pull_request.get("types") or []) == {
+        "opened",
+        "reopened",
+        "synchronize",
+        "edited",
+    }
+    assert set(pull_request.get("branches") or []) == {"main", "next"}
+
+    workflow_permissions = workflow.get("permissions")
+    assert workflow_permissions == {"contents": "read"} or (
+        isinstance(workflow_permissions, dict) and workflow_permissions.get("contents") == "read"
+    )
+
+    jobs = workflow.get("jobs")
+    assert isinstance(jobs, dict)
+    assert len(jobs) == 1
+    job = next(iter(jobs.values()))
+    assert isinstance(job, dict)
+    permissions = job.get("permissions")
+    assert isinstance(permissions, dict)
+    assert permissions.get("contents") == "read"
+    assert permissions.get("issues") == "read"
+    assert permissions.get("pull-requests") == "write"
+    assert "reviews" not in permissions
+    assert job.get("continue-on-error") is not True
+
+    steps = [step for step in job.get("steps") or [] if isinstance(step, dict)]
+    checkout = _single_step(
+        steps,
+        lambda step: _string(step, "uses").startswith("actions/checkout@"),
+        "checkout",
+    )
+    assert checkout.get("with", {}).get("persist-credentials") is False
+
+    checker = _single_step(
+        steps,
+        lambda step: "tools/p0-closes-ci/check.py" in _string(step, "run"),
+        "commenter caller",
+    )
+    assert "python3" in _string(checker, "run") or "python" in _string(checker, "run")
+    assert "--event" in _string(checker, "run")
+    assert "$GITHUB_EVENT_PATH" in _string(checker, "run")
+    assert "${{ github.event.pull_request.body }}" not in _string(checker, "run")
+    checker_env = checker.get("env")
+    assert isinstance(checker_env, dict)
+    assert checker_env.get("GH_TOKEN")
+
+    poster = _single_step(
+        steps,
+        lambda step: (
+            isinstance(step.get("uses"), str)
+            and str(step.get("uses")).startswith("actions/github-script@")
+            and "createComment" in str(step.get("with", {}).get("script", ""))
+        ),
+        "comment poster",
+    )
+    script = str(poster.get("with", {}).get("script", ""))
+    assert COMMENT_MARKER in script or "curie-p0-closes-spec-vs-impl" in script
+    assert "github.event.pull_request.body" not in script
+    assert "createComment" in script
+    assert "updateComment" in script
+    assert poster.get("continue-on-error") is not True
+    assert "catch" in script
+    assert "core.warning" in script


### PR DESCRIPTION
## Summary

A pull request that closes a `P0`, `release-blocker`, or `sre-bot-e2e-demo`
issue must spec-vs-impl each issue acceptance criterion against the product
diff. A Fix pin string, a filled e2e table, or a retry-shaped live write-up is
not enough. That is the miss behind #2209 (message-only pin on #2202; follow-up
#2248) and the P0s that live retest reopened.

The implement skill now states the trigger, the AC-vs-diff rule, and the
#2209 / #2248 example. Ordinary bugfixes that close neither label are
unchanged. An optional CI workflow comments on matching PRs; it does not fail
the check and does not raise GitHub required reviews.

Closing-keyword parsing is a sibling of `tools/fix-pin-ci/check.py` and is
duplicated on purpose: changing Fix pin parsing is out of scope.

## Related issue

Closes #2306

## Fix pin verification

Fix pin: n/a - tools/ paths are not a supported Fix pin selector. Proof is
`uv run pytest -q tools/p0-closes-ci/tests/test_p0_closes_ci.py` (17 passed).
Mutations that drop the skill section, empty TRIGGER_LABELS, or make the
comment path exit 1 each redden the suite.

## End-to-end verification

This change does not alter product runtime behavior because it is implement-skill
process plus an advisory GitHub comment, not skill/local/cluster/live surfaces.

Scoped verification: `uv run pytest -q tools/p0-closes-ci/tests/test_p0_closes_ci.py`
- 17 passed, including the ordinary `bug` Closes skip (negative) and the P0 /
release-blocker / sre-bot-e2e-demo comment path (positive).

| Tier | Required / n/a | Reason |
| --- | --- | --- |
| skill | n/a | Contributor implement skill, not plugin packaging or skill eval |
| local | n/a | No compose, API, worker, dispatcher, UI, or curie verb change |
| local-release | n/a | No released binary, image, or compose pin |
| cluster | n/a | No chart, RBAC, or sandbox change |
| live provider | n/a | No model routing or credentials |
| external integration | n/a | GitHub comment is CI process; proof is the subprocess checker, not a live product integration |

- [x] Every required tier above names its exact command, the commit it ran
      against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable
      negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in
      the table.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [ ] An ADR is added under `docs/adr/` if this is an architectural decision.
