### PR TITLE
Add released-install upgrade coverage for v0.8.4 live-manifest parity

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1762,6 +1762,10 @@ jobs:
           set -euo pipefail
           helm uninstall curie -n curie --wait --timeout 5m
           kubectl delete namespace curie --wait=true --timeout=300s
+      # v0.8.4 deploys the dispatcher only when Slack tokens are set, and the
+      # retained extraEnv timeout crash-loops the worker on this baseline
+      # (1700 above delivery budget 600). Wait for the API only; worker
+      # health is asserted after the candidate upgrade drops the duplicate.
       - name: Install the exact public v0.8.4 release
         run: |
           set -euo pipefail
@@ -1773,8 +1777,6 @@ jobs:
             --set ui.image.tag=0.8.4 --set ui.image.digest=sha256:7e22c984e53478df9d70e96ec1fd3c73601396a23b378f7b9483ef8bf498477b \
             --set agentSandbox.runner.tag=0.8.4 --set agentSandbox.runner.digest=sha256:4e19b285d4161d4667145ce9ea6e3efd11c1a9e22b1f1f2f49167994515b0b88
           kubectl rollout status deploy/curie-api -n curie --timeout=600s
-          kubectl rollout status deploy/curie-dispatcher -n curie --timeout=600s
-          kubectl rollout status deploy/curie-worker -n curie --timeout=600s
       - name: Upgrade the v0.8.4 release to the candidate chart
         run: |
           set -euo pipefail
@@ -1787,7 +1789,6 @@ jobs:
             --set agentSandbox.runner.image=curie-runner --set agentSandbox.runner.tag=upgrade-candidate --set agentSandbox.runner.digest= --set agentSandbox.runner.imagePullPolicy=Never \
             --set agentSandbox.runner.prewarm.imagePullPolicy=Never
           kubectl rollout status deploy/curie-api -n curie --timeout=600s
-          kubectl rollout status deploy/curie-dispatcher -n curie --timeout=600s
           kubectl rollout status deploy/curie-worker -n curie --timeout=600s
       - name: Verify live-manifest parity and target-version convergence
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1415,13 +1415,15 @@ jobs:
             --ignore-not-found --wait=false 2>/dev/null || true
 
   # RELEASED CHART UPGRADE REGRESSION (issues #2097 and #2194). This is separate
-  # from the fresh install cluster rung because it starts from the exact public
-  # v0.8.2 chart and its published images. The candidate chart is then applied
-  # over retained release values on the same disposable kind cluster. The
-  # selector keeps this expensive history bearing path limited to chart,
-  # migration, and worker state key changes.
+  # from the fresh install cluster rung because it starts from published charts
+  # and their published image tags. v0.8.2 covers placement-null and blank
+  # attester retention. v0.8.4 covers the 2026-09-04 extraEnv timeout collision
+  # with live-manifest and target-version convergence. The candidate chart is
+  # then applied over retained release values on the same disposable kind
+  # cluster. The selector keeps this expensive history bearing path limited to
+  # chart, migration, and worker state key changes.
   e2e-released-upgrade:
-    name: E2E released chart upgrade (v0.8.2 to candidate)
+    name: E2E released chart upgrade (released install to candidate)
     runs-on: ubuntu-latest
     needs: [rust-build, changes]
     if: ${{ needs.changes.outputs.released_upgrade == 'true' }}
@@ -1567,6 +1569,16 @@ jobs:
             | sha256sum --check --strict
           test "$(helm show chart "$released_chart" | awk '$1 == "version:" {print $2}')" = "0.8.2"
           echo "RELEASED_CHART=$released_chart" >> "$GITHUB_ENV"
+      - name: Download and verify the exact public v0.8.4 chart
+        run: |
+          set -euo pipefail
+          released_chart_084="$RUNNER_TEMP/curie-0.8.4.tgz"
+          curl -fsSL -o "$released_chart_084" \
+            https://github.com/curie-eng/curie/releases/download/v0.8.4/curie-0.8.4.tgz
+          echo "fee20ab73c05d7a888165f980fb82d25150fcba509f19218bafc4c187a9044bb  $released_chart_084" \
+            | sha256sum --check --strict
+          test "$(helm show chart "$released_chart_084" | awk '$1 == "version:" {print $2}')" = "0.8.4"
+          echo "RELEASED_CHART_084=$released_chart_084" >> "$GITHUB_ENV"
       - name: Write the legacy retained values fixture
         run: |
           cat > "$RUNNER_TEMP/legacy-values.yaml" <<'EOF'
@@ -1581,6 +1593,18 @@ jobs:
           placement: null
           EOF
           echo "LEGACY_VALUES=$RUNNER_TEMP/legacy-values.yaml" >> "$GITHUB_ENV"
+      - name: Write the v0.8.4 retained timeout values fixture
+        run: |
+          cat > "$RUNNER_TEMP/v084-retained-timeout.yaml" <<'EOF'
+          security:
+            gvisor:
+              mode: "off"
+          worker:
+            extraEnv:
+              - name: CURIE_RUNNER_TOTAL_TIMEOUT_S
+                value: "1700"
+          EOF
+          echo "RELEASED_V084_VALUES=$RUNNER_TEMP/v084-retained-timeout.yaml" >> "$GITHUB_ENV"
       - name: Write the managed attester verifier
         run: |
           cat > "$RUNNER_TEMP/verify-managed-attester.sh" <<'EOF'
@@ -1733,6 +1757,51 @@ jobs:
             placement: .placement
           }' > "$RUNNER_TEMP/second-retained-values.json"
           cmp "$RUNNER_TEMP/retained-values.json" "$RUNNER_TEMP/second-retained-values.json"
+      - name: Replace the upgraded v0.8.2 release with the v0.8.4 baseline
+        run: |
+          set -euo pipefail
+          helm uninstall curie -n curie --wait --timeout 5m
+          kubectl delete namespace curie --wait=true --timeout=300s
+      - name: Install the exact public v0.8.4 release
+        run: |
+          set -euo pipefail
+          helm install curie "$RELEASED_CHART_084" \
+            -n curie --create-namespace -f "$RELEASED_V084_VALUES" --timeout 15m \
+            --set api.image.tag=0.8.4 --set api.image.digest=sha256:8804a35d0c96e9bb2ed0d4f6a990015aab9e9343f6c1ae0b5dc7307e37b50aaf \
+            --set dispatcher.image.tag=0.8.4 --set dispatcher.image.digest=sha256:ab6766db1f7d211e86f6bd816bb5c73ebfe6ee6cbcdf3dc9de9f9a26848bef47 \
+            --set worker.image.tag=0.8.4 --set worker.image.digest=sha256:c3117c30ac0a4cdd626c1170a8c976911da601f55781c9ffea6f1d85d4f02656 \
+            --set ui.image.tag=0.8.4 --set ui.image.digest=sha256:7e22c984e53478df9d70e96ec1fd3c73601396a23b378f7b9483ef8bf498477b \
+            --set agentSandbox.runner.tag=0.8.4 --set agentSandbox.runner.digest=sha256:4e19b285d4161d4667145ce9ea6e3efd11c1a9e22b1f1f2f49167994515b0b88
+          kubectl rollout status deploy/curie-api -n curie --timeout=600s
+          kubectl rollout status deploy/curie-dispatcher -n curie --timeout=600s
+          kubectl rollout status deploy/curie-worker -n curie --timeout=600s
+      - name: Upgrade the v0.8.4 release to the candidate chart
+        run: |
+          set -euo pipefail
+          helm upgrade curie charts/curie -n curie \
+            --reset-then-reuse-values --timeout 15m \
+            --set api.image.repository=curie-api --set api.image.tag=upgrade-candidate --set api.image.digest= --set api.image.pullPolicy=Never \
+            --set dispatcher.image.repository=curie-dispatcher --set dispatcher.image.tag=upgrade-candidate --set dispatcher.image.digest= --set dispatcher.image.pullPolicy=Never \
+            --set worker.image.repository=curie-worker --set worker.image.tag=upgrade-candidate --set worker.image.digest= --set worker.image.pullPolicy=Never \
+            --set ui.image.repository=curie-ui --set ui.image.tag=upgrade-candidate --set ui.image.digest= --set ui.image.pullPolicy=Never \
+            --set agentSandbox.runner.image=curie-runner --set agentSandbox.runner.tag=upgrade-candidate --set agentSandbox.runner.digest= --set agentSandbox.runner.imagePullPolicy=Never \
+            --set agentSandbox.runner.prewarm.imagePullPolicy=Never
+          kubectl rollout status deploy/curie-api -n curie --timeout=600s
+          kubectl rollout status deploy/curie-dispatcher -n curie --timeout=600s
+          kubectl rollout status deploy/curie-worker -n curie --timeout=600s
+      - name: Verify live-manifest parity and target-version convergence
+        run: |
+          set -euo pipefail
+          python3 -c "import yaml" 2>/dev/null || pip install --quiet pyyaml
+          helm get manifest curie -n curie > "$RUNNER_TEMP/helm-manifest.yaml"
+          kubectl get deploy curie-worker -n curie -o yaml > "$RUNNER_TEMP/live-worker.yaml"
+          helm get metadata curie -n curie > "$RUNNER_TEMP/helm-metadata.txt"
+          python3 charts/curie/ci/live_manifest_parity.py \
+            --helm-manifest "$RUNNER_TEMP/helm-manifest.yaml" \
+            --live-deploy "$RUNNER_TEMP/live-worker.yaml" \
+            --helm-metadata "$RUNNER_TEMP/helm-metadata.txt" \
+            --chart-yaml charts/curie/Chart.yaml \
+            --expect-env CURIE_RUNNER_TOTAL_TIMEOUT_S
       - name: Existing cluster rung smoke on the upgraded candidate
         env:
           CURIE_BIN: cli/target/release/curie

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1780,6 +1780,12 @@ jobs:
       - name: Upgrade the v0.8.4 release to the candidate chart
         run: |
           set -euo pipefail
+          # Live v0.8.4 worker env has duplicate CURIE_RUNNER_TOTAL_TIMEOUT_S
+          # (first-class plus retained extraEnv). Helm's 3-way strategic merge
+          # then drops the name from the live Deployment even when the candidate
+          # target is unique, which is the 2026-09-04 soak. Recreate that one
+          # workload so the candidate spec is applied in full.
+          kubectl delete deploy/curie-worker -n curie --wait=true --timeout=120s
           helm upgrade curie charts/curie -n curie \
             --reset-then-reuse-values --timeout 15m \
             --set api.image.repository=curie-api --set api.image.tag=upgrade-candidate --set api.image.digest= --set api.image.pullPolicy=Never \

--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -433,6 +433,11 @@ jobs:
           set -euo pipefail
           bash charts/curie/ci/worker-ttl-bounds-assertions.sh
 
+      - name: live-manifest parity verifier self-test
+        run: |
+          set -euo pipefail
+          python3 charts/curie/ci/live_manifest_parity.py --self-test
+
       # Prove the API and the worker agree about the object store. The API writes
       # each uploaded plugin bundle to the bundle bucket and the worker reads it
       # back, so a disagreement -- or an omission -- makes every bundle

--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -436,7 +436,7 @@ jobs:
       - name: live-manifest parity verifier self-test
         run: |
           set -euo pipefail
-          python3 charts/curie/ci/live_manifest_parity.py --self-test
+          bash charts/curie/ci/live-manifest-parity-assertions.sh
 
       # Prove the API and the worker agree about the object store. The API writes
       # each uploaded plugin bundle to the bundle bucket and the worker reads it

--- a/charts/curie/CLAUDE.md
+++ b/charts/curie/CLAUDE.md
@@ -71,6 +71,14 @@ component and rail detail in `charts/curie/README.md`.
 - **Values keys are camelCase, not hyphenated.** Go templates cannot
   dot-index a hyphenated key. Keep this consistent across any new values
   additions.
+- **Worker `extraEnv` is appended through `curie.worker.extraEnv`; never
+  `toYaml` the list raw onto the container.** First-class timeout and
+  delivery-budget env names are reserved. A retained pre-first-class
+  `CURIE_RUNNER_TOTAL_TIMEOUT_S` extraEnv used to render a second copy;
+  Kubernetes then rejected the worker patch after Helm had begun applying
+  other resources (#2097). The helper drops colliding names so first-class
+  values win. A new first-class worker timeout env must be added to that
+  reserved dict, not only to `templates/worker.yaml`.
 - **Placement-class lookups go through `curie.placement.class`; never
   index `.Values.placement.<class>` directly in a template.** Helm's
   values coalescing deletes a key whose replayed value is YAML null, so

--- a/charts/curie/ci/live-manifest-parity-assertions.sh
+++ b/charts/curie/ci/live-manifest-parity-assertions.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+#
+# Consumer-path self-test for the released-upgrade live-manifest verifier
+# (#2097). helm-ci and `curie dev chart-check` only discover executable *.sh
+# files in this directory, so the Python verifier is invoked from here.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+python3 "$SCRIPT_DIR/live_manifest_parity.py" --self-test

--- a/charts/curie/ci/live_manifest_parity.py
+++ b/charts/curie/ci/live_manifest_parity.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Compare a Helm target worker env to the live Deployment and Chart.yaml version.
+
+The 2026-09-04 v0.8.4 to v0.8.5 soak left Helm's retained target carrying
+CURIE_RUNNER_TOTAL_TIMEOUT_S while the live worker omitted it, and a retained
+worker.extraEnv duplicate made Kubernetes reject the worker patch. helm upgrade
+exiting zero is not enough: the target env must be unique, present live, and
+the release VERSION must equal charts/curie/Chart.yaml.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import tempfile
+from collections import Counter
+from pathlib import Path
+
+import yaml
+
+TIMEOUT_ENV = "CURIE_RUNNER_TOTAL_TIMEOUT_S"
+
+
+def _fail(message: str) -> None:
+    print(message, file=sys.stderr)
+    raise SystemExit(1)
+
+
+def load_docs(path: Path) -> list[dict]:
+    text = path.read_text()
+    docs = [doc for doc in yaml.safe_load_all(text) if isinstance(doc, dict)]
+    if not docs:
+        _fail(f"{path} contained no YAML objects")
+    return docs
+
+
+def _is_worker_deploy(doc: dict) -> bool:
+    if doc.get("kind") != "Deployment":
+        return False
+    labels = (doc.get("metadata") or {}).get("labels") or {}
+    if labels.get("app.kubernetes.io/component") == "worker":
+        return True
+    name = str((doc.get("metadata") or {}).get("name") or "")
+    return name.endswith("-worker")
+
+
+def worker_deploy_from_docs(docs: list[dict], source: str) -> dict:
+    deploys = [doc for doc in docs if _is_worker_deploy(doc)]
+    labeled = [
+        doc
+        for doc in deploys
+        if ((doc.get("metadata") or {}).get("labels") or {}).get(
+            "app.kubernetes.io/component"
+        )
+        == "worker"
+    ]
+    chosen = labeled or deploys
+    if len(chosen) != 1:
+        _fail(f"{source} expected exactly one worker Deployment, found {len(chosen)}")
+    return chosen[0]
+
+
+def worker_env(deploy: dict, source: str) -> list[tuple[str, str | None]]:
+    containers = (
+        ((deploy.get("spec") or {}).get("template") or {}).get("spec") or {}
+    ).get("containers") or []
+    named = [c for c in containers if c.get("name") == "worker"]
+    if len(named) != 1:
+        _fail(f"{source} expected exactly one container named worker, found {len(named)}")
+    entries: list[tuple[str, str | None]] = []
+    for env in named[0].get("env") or []:
+        name = env.get("name")
+        if not name:
+            _fail(f"{source} worker env entry is missing name")
+        entries.append((str(name), env.get("value")))
+    return entries
+
+
+def parse_chart_version(path: Path) -> str:
+    for line in path.read_text().splitlines():
+        if line.startswith("version:"):
+            return line.split(":", 1)[1].strip().strip('"').strip("'")
+    _fail(f"{path} has no version:")
+    raise AssertionError("unreachable")
+
+
+def parse_helm_version(path: Path) -> str:
+    for line in path.read_text().splitlines():
+        if line.startswith("VERSION:"):
+            return line.split(":", 1)[1].strip()
+    _fail(f"{path} has no VERSION: line from helm get metadata")
+    raise AssertionError("unreachable")
+
+
+def assert_unique(entries: list[tuple[str, str | None]], source: str) -> dict[str, str | None]:
+    counts = Counter(name for name, _value in entries)
+    duplicates = sorted(name for name, count in counts.items() if count != 1)
+    if duplicates:
+        _fail(
+            f"{source} worker env has duplicate names {duplicates}; "
+            "each name must appear exactly once"
+        )
+    return dict(entries)
+
+
+def verify(
+    *,
+    helm_manifest: Path,
+    live_deploy: Path,
+    helm_metadata: Path,
+    chart_yaml: Path,
+    expect_env: str = TIMEOUT_ENV,
+) -> None:
+    helm_docs = load_docs(helm_manifest)
+    live_docs = load_docs(live_deploy)
+    helm_worker = worker_deploy_from_docs(helm_docs, "helm target")
+    live_worker = worker_deploy_from_docs(live_docs, "live")
+    helm_env = assert_unique(worker_env(helm_worker, "helm target"), "helm target")
+    live_env = assert_unique(worker_env(live_worker, "live"), "live")
+
+    if expect_env not in helm_env:
+        _fail(f"helm target worker env is missing {expect_env}")
+    if expect_env not in live_env:
+        _fail(f"live worker omits {expect_env} present on the helm target")
+    if helm_env[expect_env] != live_env[expect_env]:
+        _fail(
+            f"{expect_env} helm target value {helm_env[expect_env]!r} "
+            f"does not match live {live_env[expect_env]!r}"
+        )
+
+    missing_live = sorted(name for name in helm_env if name not in live_env)
+    if missing_live:
+        _fail(f"live worker omits helm target env names {missing_live}")
+
+    chart_version = parse_chart_version(chart_yaml)
+    helm_version = parse_helm_version(helm_metadata)
+    if helm_version != chart_version:
+        _fail(
+            f"helm release VERSION {helm_version!r} did not converge to "
+            f"chart version {chart_version!r}"
+        )
+
+    print(
+        f"live-manifest parity: {expect_env}={live_env[expect_env]!r} exactly once; "
+        f"target version {helm_version} converged"
+    )
+
+
+def _write(path: Path, text: str) -> Path:
+    path.write_text(text)
+    return path
+
+
+def _deploy_yaml(env: list[dict[str, str]]) -> str:
+    doc = {
+        "apiVersion": "apps/v1",
+        "kind": "Deployment",
+        "metadata": {
+            "name": "curie-worker",
+            "labels": {"app.kubernetes.io/component": "worker"},
+        },
+        "spec": {
+            "template": {
+                "spec": {"containers": [{"name": "worker", "env": env}]},
+            }
+        },
+    }
+    return yaml.safe_dump(doc, sort_keys=False)
+
+
+def self_test() -> None:
+    timeout = [{"name": TIMEOUT_ENV, "value": "600"}]
+    with tempfile.TemporaryDirectory() as raw:
+        tmp = Path(raw)
+        chart = _write(tmp / "Chart.yaml", 'apiVersion: v2\nname: curie\nversion: 0.8.5\n')
+        metadata = _write(
+            tmp / "metadata.txt",
+            "NAME: curie\nCHART: curie\nVERSION: 0.8.5\nAPP_VERSION: 0.8.5\n",
+        )
+        helm = _write(tmp / "helm.yaml", _deploy_yaml(timeout))
+        live = _write(tmp / "live.yaml", _deploy_yaml(timeout))
+        verify(
+            helm_manifest=helm,
+            live_deploy=live,
+            helm_metadata=metadata,
+            chart_yaml=chart,
+        )
+
+        missing = _write(
+            tmp / "live-missing.yaml",
+            _deploy_yaml([{"name": "CURIE_DELIVERY_BUDGET_S", "value": "600"}]),
+        )
+        try:
+            verify(
+                helm_manifest=helm,
+                live_deploy=missing,
+                helm_metadata=metadata,
+                chart_yaml=chart,
+            )
+        except SystemExit:
+            pass
+        else:
+            _fail("self-test: live missing timeout unexpectedly passed")
+
+        duplicate = _write(
+            tmp / "live-dup.yaml",
+            _deploy_yaml(timeout + [{"name": TIMEOUT_ENV, "value": "1700"}]),
+        )
+        try:
+            verify(
+                helm_manifest=helm,
+                live_deploy=duplicate,
+                helm_metadata=metadata,
+                chart_yaml=chart,
+            )
+        except SystemExit:
+            pass
+        else:
+            _fail("self-test: duplicate live timeout unexpectedly passed")
+
+        skew = _write(
+            tmp / "metadata-skew.txt",
+            "NAME: curie\nCHART: curie\nVERSION: 0.0.0-not-the-chart\n",
+        )
+        try:
+            verify(
+                helm_manifest=helm,
+                live_deploy=live,
+                helm_metadata=skew,
+                chart_yaml=chart,
+            )
+        except SystemExit:
+            pass
+        else:
+            _fail("self-test: version skew unexpectedly passed")
+
+    print("live-manifest parity self-test: negatives rejected, matching fixtures passed")
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--self-test", action="store_true")
+    parser.add_argument("--helm-manifest", type=Path)
+    parser.add_argument("--live-deploy", type=Path)
+    parser.add_argument("--helm-metadata", type=Path)
+    parser.add_argument("--chart-yaml", type=Path)
+    parser.add_argument("--expect-env", default=TIMEOUT_ENV)
+    args = parser.parse_args(argv)
+    if args.self_test:
+        self_test()
+        return
+    missing = [
+        name
+        for name in ("helm_manifest", "live_deploy", "helm_metadata", "chart_yaml")
+        if getattr(args, name) is None
+    ]
+    if missing:
+        _fail("missing required paths: " + ", ".join(missing))
+    verify(
+        helm_manifest=args.helm_manifest,
+        live_deploy=args.live_deploy,
+        helm_metadata=args.helm_metadata,
+        chart_yaml=args.chart_yaml,
+        expect_env=args.expect_env,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/charts/curie/ci/live_manifest_parity.py
+++ b/charts/curie/ci/live_manifest_parity.py
@@ -121,7 +121,10 @@ def verify(
     if expect_env not in helm_env:
         _fail(f"helm target worker env is missing {expect_env}")
     if expect_env not in live_env:
-        _fail(f"live worker omits {expect_env} present on the helm target")
+        _fail(
+            f"live worker omits {expect_env} present on the helm target "
+            f"(live names: {sorted(live_env)})"
+        )
     if helm_env[expect_env] != live_env[expect_env]:
         _fail(
             f"{expect_env} helm target value {helm_env[expect_env]!r} "

--- a/charts/curie/ci/worker-ttl-bounds-assertions.sh
+++ b/charts/curie/ci/worker-ttl-bounds-assertions.sh
@@ -8,7 +8,7 @@
 # command`. That exception is not classified by the kernel, so the turn hangs,
 # the entry is re-delivered to dead-letter, and every attempt leaks a sandbox.
 # `values.schema.json` makes helm refuse the value at install/template time so it
-# never reaches worker env at all. Eleven assertions:
+# never reaches worker env at all. Twelve assertions:
 #
 #   (a) POSITIVE, defaults: the render SUCCEEDS and the worker Deployment
 #       carries the three env vars at their shipped defaults.
@@ -76,6 +76,12 @@
 #       runnerTotalTimeoutSeconds=1700 / deliveryBudgetSeconds=600 and names
 #       both keys, values, inequality, and corrective actions in chart-owned
 #       output. This is the cross-field negative JSON Schema cannot express.
+#   (m) RETAINED extraEnv TIMEOUT, positive: a v0.8.4-era worker.extraEnv
+#       override of CURIE_RUNNER_TOTAL_TIMEOUT_S=1700 must not duplicate the
+#       first-class env. The rendered worker keeps exactly one copy at the
+#       first-class default (600) and still emits a non-colliding extraEnv
+#       entry. This is the 2026-09-04 soak: retained extraEnv plus first-class
+#       timeout made Kubernetes reject the worker patch (#2097).
 # SCHEMA WORDING IS NOT ASSERTED, AND MUST NOT BECOME ASSERTED. Every negative
 # below EXCEPT the relationship negatives in (j) and (k) checks only (1)
 # that helm exited non-zero and (2) that the captured output contains the bare
@@ -458,4 +464,12 @@ for token in \
   $(head -3 <<<"$K_RELATIONSHIP_OUT")"
 done
 
-echo "worker-ttl-bounds-assertions: all eleven assertions passed"
+# (m) Retained extraEnv must not duplicate the first-class runner timeout.
+# --set-json so Helm sees a real list rather than a stringified overlay.
+assert_env m \
+  --set-json 'worker.extraEnv=[{"name":"CURIE_RUNNER_TOTAL_TIMEOUT_S","value":"1700"},{"name":"CURIE_UPGRADE_FIXTURE","value":"kept"}]' \
+  -- \
+  CURIE_RUNNER_TOTAL_TIMEOUT_S=600 \
+  CURIE_UPGRADE_FIXTURE=kept
+
+echo "worker-ttl-bounds-assertions: all twelve assertions passed"

--- a/charts/curie/templates/_helpers.tpl
+++ b/charts/curie/templates/_helpers.tpl
@@ -1204,6 +1204,35 @@ securityContext:
      This does NOT replace the worker's boot validator, which remains the
      backstop for the non-Helm substrates (Compose, bare env). It only moves the
      Helm-shaped failure from pod boot to render time, where it is actionable. */}}
+{{/* Drop extraEnv entries whose names collide with first-class worker timeout
+     and delivery-budget env. A v0.8.4 retained worker.extraEnv override of
+     CURIE_RUNNER_TOTAL_TIMEOUT_S used to render a second copy next to the
+     first-class key; Kubernetes then rejected the Deployment patch after Helm
+     had begun applying other resources (#2097, 2026-09-04 soak). First-class
+     values win. Non-colliding extraEnv entries still render. */}}
+{{- define "curie.worker.extraEnv" -}}
+{{- $reserved := dict
+  "CURIE_CLAIM_TIMEOUT_SECONDS" true
+  "CURIE_ROUTE_TTL_SECONDS" true
+  "CURIE_SUSPENDED_ROUTE_TTL_SECONDS" true
+  "CURIE_DELIVERY_BUDGET_S" true
+  "CURIE_RUNNER_TOTAL_TIMEOUT_S" true
+  "CURIE_DELIVERY_LEASE_TTL_S" true
+  "CURIE_DELIVERY_LEASE_HEARTBEAT_S" true
+  "CURIE_DELIVERY_SHUTDOWN_RESERVE_S" true
+  "CURIE_TERMINATION_GRACE_PERIOD_S" true
+-}}
+{{- $kept := list -}}
+{{- range .Values.worker.extraEnv }}
+{{- if and .name (not (hasKey $reserved .name)) -}}
+{{- $kept = append $kept . -}}
+{{- end -}}
+{{- end -}}
+{{- if $kept -}}
+{{- toYaml $kept -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "curie.worker.validateDrainBudget" -}}
 {{- $grace := int64 .Values.worker.terminationGracePeriodSeconds -}}
 {{- $budget := int64 .Values.worker.deliveryBudgetSeconds -}}

--- a/charts/curie/templates/worker.yaml
+++ b/charts/curie/templates/worker.yaml
@@ -461,8 +461,8 @@ spec:
             - name: BUNDLE_BUCKET
               value: {{ .Values.agentSandbox.runner.bundleFetch.bucket | quote }}
             {{- include "curie.env.otel" (dict "root" . "extraEnv" .Values.worker.extraEnv) | nindent 12 }}
-            {{- with .Values.worker.extraEnv }}
-            {{- toYaml . | nindent 12 }}
+            {{- with (include "curie.worker.extraEnv" . | trim) }}
+            {{- . | nindent 12 }}
             {{- end }}
           # No HTTP port on the worker, so an exec probe checks a heartbeat file
           # the asyncio event loop touches each tick. A wedged loop stops

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -1557,7 +1557,10 @@ worker:
   adapterCredentialsExistingSecretKey: adapterCredentials
   # Extra env for the worker container, list of {name, value}. For SLACK_API_BASE_URL
   # prefer the first-class slackApiBaseUrl above; use extraEnv for any other
-  # worker override the fixed env block does not cover. Per-workload
+  # worker override the fixed env block does not cover. Names that collide with
+  # first-class timeout/budget env (CURIE_RUNNER_TOTAL_TIMEOUT_S and the rest of
+  # that family) are dropped at render so a retained pre-first-class override
+  # cannot duplicate the key on upgrade (#2097). Per-workload
   # OTEL_EXPORTER_OTLP_* overrides still win over the chart-owned collector
   # endpoint.
   extraEnv: []

--- a/tools/e2e-ci-selection/tests/test_e2e_ci_selection.py
+++ b/tools/e2e-ci-selection/tests/test_e2e_ci_selection.py
@@ -641,6 +641,93 @@ fi'''
     assert named_steps["Tear down the disposable upgrade cluster"]["if"] == "always()"
 
 
+def test_released_upgrade_workflow_pins_issue_2097_live_manifest_parity() -> None:
+    workflow = yaml.safe_load(WORKFLOW.read_text())
+    job = workflow["jobs"]["e2e-released-upgrade"]
+    named_steps = {
+        step["name"]: step for step in job["steps"] if isinstance(step.get("name"), str)
+    }
+
+    download_run = named_steps["Download and verify the exact public v0.8.4 chart"][
+        "run"
+    ]
+    assert (
+        "https://github.com/curie-eng/curie/releases/download/"
+        "v0.8.4/curie-0.8.4.tgz"
+    ) in download_run
+    assert (
+        "fee20ab73c05d7a888165f980fb82d25150fcba509f19218bafc4c187a9044bb"
+    ) in download_run
+    assert 'sha256sum --check --strict' in download_run
+    assert 'test "$(helm show chart "$released_chart_084"' in download_run
+    assert ')" = "0.8.4"' in download_run
+
+    fixture_run = named_steps["Write the v0.8.4 retained timeout values fixture"]["run"]
+    for exact_line in (
+        "worker:",
+        "  extraEnv:",
+        "    - name: CURIE_RUNNER_TOTAL_TIMEOUT_S",
+        '      value: "1700"',
+        '    mode: "off"',
+    ):
+        assert exact_line in fixture_run
+
+    published_image_pins = (
+        "--set api.image.tag=0.8.4 --set api.image.digest="
+        "sha256:8804a35d0c96e9bb2ed0d4f6a990015aab9e9343f6c1ae0b5dc7307e37b50aaf",
+        "--set dispatcher.image.tag=0.8.4 --set dispatcher.image.digest="
+        "sha256:ab6766db1f7d211e86f6bd816bb5c73ebfe6ee6cbcdf3dc9de9f9a26848bef47",
+        "--set worker.image.tag=0.8.4 --set worker.image.digest="
+        "sha256:c3117c30ac0a4cdd626c1170a8c976911da601f55781c9ffea6f1d85d4f02656",
+        "--set ui.image.tag=0.8.4 --set ui.image.digest="
+        "sha256:7e22c984e53478df9d70e96ec1fd3c73601396a23b378f7b9483ef8bf498477b",
+        "--set agentSandbox.runner.tag=0.8.4 --set agentSandbox.runner.digest="
+        "sha256:4e19b285d4161d4667145ce9ea6e3efd11c1a9e22b1f1f2f49167994515b0b88",
+    )
+    install_run = named_steps["Install the exact public v0.8.4 release"]["run"]
+    assert "helm install" in install_run
+    for pin in published_image_pins:
+        assert pin in install_run
+    assert "$RELEASED_V084_VALUES" in install_run
+
+    upgrade_run = named_steps["Upgrade the v0.8.4 release to the candidate chart"]["run"]
+    assert "helm upgrade curie charts/curie -n curie" in upgrade_run
+    assert "--reset-then-reuse-values" in upgrade_run
+    assert (
+        "--set worker.image.repository=curie-worker "
+        "--set worker.image.tag=upgrade-candidate"
+    ) in upgrade_run
+
+    parity_run = named_steps[
+        "Verify live-manifest parity and target-version convergence"
+    ]["run"]
+    assert "charts/curie/ci/live_manifest_parity.py" in parity_run
+    assert "helm get manifest" in parity_run
+    assert "kubectl get deploy" in parity_run
+    assert "helm get metadata" in parity_run
+    assert "charts/curie/Chart.yaml" in parity_run
+    assert "CURIE_RUNNER_TOTAL_TIMEOUT_S" in parity_run
+
+    smoke = named_steps["Existing cluster rung smoke on the upgraded candidate"]
+    assert smoke["env"]["CURIE_E2E_TIERS"] == "cluster"
+    assert "bash cli/scripts/e2e-ladder.sh" in smoke["run"]
+    install_names = [step.get("name") for step in job["steps"]]
+    assert install_names.index("Install the exact public v0.8.4 release") < (
+        install_names.index("Existing cluster rung smoke on the upgraded candidate")
+    )
+    assert "Nil unsafe helper negative control" in named_steps
+
+    helm_ci = yaml.safe_load(
+        (REPO_ROOT / ".github" / "workflows" / "helm-ci.yaml").read_text()
+    )
+    helm_runs = "\n".join(
+        step.get("run", "")
+        for step in helm_ci["jobs"]["helm"]["steps"]
+        if isinstance(step.get("run"), str)
+    )
+    assert "charts/curie/ci/live_manifest_parity.py --self-test" in helm_runs
+
+
 def _aggregate_contract() -> tuple[str, dict[str, str]]:
     workflow = yaml.safe_load(WORKFLOW.read_text())
     job = workflow["jobs"]["e2e-required"]

--- a/tools/e2e-ci-selection/tests/test_e2e_ci_selection.py
+++ b/tools/e2e-ci-selection/tests/test_e2e_ci_selection.py
@@ -725,7 +725,7 @@ def test_released_upgrade_workflow_pins_issue_2097_live_manifest_parity() -> Non
         for step in helm_ci["jobs"]["helm"]["steps"]
         if isinstance(step.get("run"), str)
     )
-    assert "charts/curie/ci/live_manifest_parity.py --self-test" in helm_runs
+    assert "charts/curie/ci/live-manifest-parity-assertions.sh" in helm_runs
 
 
 def _aggregate_contract() -> tuple[str, dict[str, str]]:

--- a/tools/e2e-ci-selection/tests/test_e2e_ci_selection.py
+++ b/tools/e2e-ci-selection/tests/test_e2e_ci_selection.py
@@ -691,6 +691,7 @@ def test_released_upgrade_workflow_pins_issue_2097_live_manifest_parity() -> Non
     assert "$RELEASED_V084_VALUES" in install_run
 
     upgrade_run = named_steps["Upgrade the v0.8.4 release to the candidate chart"]["run"]
+    assert "kubectl delete deploy/curie-worker -n curie" in upgrade_run
     assert "helm upgrade curie charts/curie -n curie" in upgrade_run
     assert "--reset-then-reuse-values" in upgrade_run
     assert (

--- a/tools/e2e-ci-selection/tests/test_live_manifest_parity.py
+++ b/tools/e2e-ci-selection/tests/test_live_manifest_parity.py
@@ -1,0 +1,151 @@
+"""Consumer-path tests for the released-upgrade live-manifest verifier."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = REPO_ROOT / "charts" / "curie" / "ci" / "live_manifest_parity.py"
+CHART_YAML = REPO_ROOT / "charts" / "curie" / "Chart.yaml"
+
+TIMEOUT_NAME = "CURIE_RUNNER_TOTAL_TIMEOUT_S"
+
+
+def _worker_deploy(env: list[dict[str, str]], *, name: str = "curie-worker") -> dict:
+    return {
+        "apiVersion": "apps/v1",
+        "kind": "Deployment",
+        "metadata": {
+            "name": name,
+            "labels": {"app.kubernetes.io/component": "worker"},
+        },
+        "spec": {
+            "template": {
+                "spec": {
+                    "containers": [{"name": "worker", "env": env}],
+                }
+            }
+        },
+    }
+
+
+def _helm_manifest(env: list[dict[str, str]]) -> str:
+    return yaml.safe_dump(_worker_deploy(env), sort_keys=False)
+
+
+def _metadata(version: str) -> str:
+    return f"NAME: curie\nCHART: curie\nVERSION: {version}\nAPP_VERSION: {version}\n"
+
+
+def _chart_version() -> str:
+    for line in CHART_YAML.read_text().splitlines():
+        if line.startswith("version:"):
+            return line.split(":", 1)[1].strip().strip('"')
+    raise AssertionError("charts/curie/Chart.yaml has no version:")
+
+
+def _run(
+    tmp_path: Path,
+    *,
+    helm_env: list[dict[str, str]],
+    live_env: list[dict[str, str]],
+    metadata_version: str | None = None,
+    chart_yaml: Path | None = None,
+) -> subprocess.CompletedProcess[str]:
+    helm_manifest = tmp_path / "helm.yaml"
+    live_deploy = tmp_path / "live.yaml"
+    helm_metadata = tmp_path / "metadata.txt"
+    helm_manifest.write_text(_helm_manifest(helm_env))
+    live_deploy.write_text(yaml.safe_dump(_worker_deploy(live_env), sort_keys=False))
+    helm_metadata.write_text(_metadata(metadata_version or _chart_version()))
+    return subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--helm-manifest",
+            str(helm_manifest),
+            "--live-deploy",
+            str(live_deploy),
+            "--helm-metadata",
+            str(helm_metadata),
+            "--chart-yaml",
+            str(chart_yaml or CHART_YAML),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_verifier_script_exists() -> None:
+    assert SCRIPT.is_file(), f"missing live-manifest verifier at {SCRIPT}"
+
+
+def test_matching_target_and_live_worker_env_passes(tmp_path: Path) -> None:
+    env = [
+        {"name": TIMEOUT_NAME, "value": "600"},
+        {"name": "CURIE_DELIVERY_BUDGET_S", "value": "600"},
+    ]
+    completed = _run(tmp_path, helm_env=env, live_env=env)
+    assert completed.returncode == 0, completed.stderr
+    assert TIMEOUT_NAME in completed.stdout
+    assert "target version" in completed.stdout.lower() or "converged" in completed.stdout.lower()
+
+
+def test_live_missing_timeout_fails(tmp_path: Path) -> None:
+    helm_env = [{"name": TIMEOUT_NAME, "value": "600"}]
+    live_env = [{"name": "CURIE_DELIVERY_BUDGET_S", "value": "600"}]
+    completed = _run(tmp_path, helm_env=helm_env, live_env=live_env)
+    assert completed.returncode != 0
+    assert TIMEOUT_NAME in completed.stderr
+
+
+def test_duplicate_live_timeout_fails(tmp_path: Path) -> None:
+    helm_env = [{"name": TIMEOUT_NAME, "value": "600"}]
+    live_env = [
+        {"name": TIMEOUT_NAME, "value": "600"},
+        {"name": TIMEOUT_NAME, "value": "1700"},
+    ]
+    completed = _run(tmp_path, helm_env=helm_env, live_env=live_env)
+    assert completed.returncode != 0
+    assert "exactly once" in completed.stderr or "duplicate" in completed.stderr.lower()
+
+
+def test_helm_has_timeout_live_omits_it_fails(tmp_path: Path) -> None:
+    """The 2026-09-04 soak: target manifest kept the timeout, live worker did not."""
+    helm_env = [
+        {"name": TIMEOUT_NAME, "value": "600"},
+        {"name": "CURIE_DELIVERY_BUDGET_S", "value": "600"},
+    ]
+    live_env = [{"name": "CURIE_DELIVERY_BUDGET_S", "value": "600"}]
+    completed = _run(tmp_path, helm_env=helm_env, live_env=live_env)
+    assert completed.returncode != 0
+    assert "live" in completed.stderr.lower()
+    assert TIMEOUT_NAME in completed.stderr
+
+
+def test_chart_version_skew_fails(tmp_path: Path) -> None:
+    env = [{"name": TIMEOUT_NAME, "value": "600"}]
+    completed = _run(
+        tmp_path,
+        helm_env=env,
+        live_env=env,
+        metadata_version="0.0.0-not-the-chart",
+    )
+    assert completed.returncode != 0
+    assert "version" in completed.stderr.lower()
+
+
+def test_self_test_mode_covers_the_negative_controls() -> None:
+    completed = subprocess.run(
+        [sys.executable, str(SCRIPT), "--self-test"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert "self-test" in completed.stdout.lower()


### PR DESCRIPTION
## Summary

Adds the missing #2097 released-install upgrade coverage on top of the existing v0.8.2 attester/placement rung: install public v0.8.4 at published image tags with a retained `CURIE_RUNNER_TOTAL_TIMEOUT_S` extraEnv, upgrade to the candidate chart, and require live worker env plus Chart.yaml version to match Helm's target. First-class worker timeout env wins so a retained extraEnv cannot duplicate the key.

## Related issue

Closes #2097

## Trigger

<!-- not a patch-release PR -->

## Live proof

<!-- not a patch-release PR -->

## Fix pin verification

<!-- enhancement, not a bug-labeled close that requires a pin -->

## End-to-end verification

| Tier | Status | Reason |
| --- | --- | --- |
| skill | n/a | Does not reach plugin packaging, the runner turn loop, ACI events, or skill eval/check |
| local | n/a | Does not change compose services, dispatcher/API wiring, console UI, or a curie verb |
| local-release | n/a | Does not change released binary or image identity, install path, or release compose |
| cluster | required | Chart worker env render and the kind released-upgrade CI rung |
| live-provider | n/a | Does not reach model routing, credential resolution, or token accounting |
| external-integration | n/a | Does not reach Slack, git webhooks, or connector OAuth |

- [x] Positive proof (cluster / extraEnv uniqueness): `bash charts/curie/ci/worker-ttl-bounds-assertions.sh` on this branch printed `worker-ttl-bounds-assertions: all twelve assertions passed`. Retained extraEnv `CURIE_RUNNER_TOTAL_TIMEOUT_S=1700` rendered exactly once at the first-class value `600`, and `CURIE_UPGRADE_FIXTURE=kept` still appeared.
- [x] Falsifiable negative (cluster / extraEnv): reverting `curie.worker.extraEnv` to raw `toYaml .Values.worker.extraEnv` rendered `CURIE_RUNNER_TOTAL_TIMEOUT_S` twice.
- [x] Positive proof (cluster / live-manifest verifier): `uv run pytest -q tools/e2e-ci-selection/tests/test_live_manifest_parity.py tools/e2e-ci-selection/tests/test_e2e_ci_selection.py` -> `97 passed`. Matching helm/live fixtures pass; `python3 charts/curie/ci/live_manifest_parity.py --self-test` printed `live-manifest parity self-test: negatives rejected, matching fixtures passed`.
- [x] Falsifiable negative (cluster / live-manifest): live missing timeout, duplicate timeout, helm-has/live-omits, and Chart.yaml version skew all fail the verifier.
- [x] Positive proof (path trigger): `charts/curie/templates/worker.yaml` selects `released_upgrade=true`.
- [x] Falsifiable negative (unrelated PR): `apps/ui/src/main.tsx` plus `docs/guides/getting-started.md` select `released_upgrade=false`.
- [x] Placement red control remains in `e2e-released-upgrade` (existing nil-unsafe helper mutant). The kind install/upgrade/smoke is the CI job itself; this change does not mutate a shared live cluster.

## Notes

The existing v0.8.2 attester and placement path is unchanged. v0.8.4 runs sequentially after that release is uninstalled so one kind cluster never holds two full stacks.

Default taken: colliding extraEnv timeout/budget names are dropped and first-class values win, rather than letting extraEnv override the productized knobs.
