### PR TITLE
Require live-provider and Slack tiers for MCP and workspace changes

### DIFF
--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -156,6 +156,16 @@ required tier, and a change that bears no runtime behavior records that reason
 once instead. A direct path change makes no behavior change and classifies
 nothing.
 
+The path set is runner MCP catalog projection, unscoped PreToolUse,
+in-process platform MCP tools, workspace publication, and
+built-in coding-tool session capability. A behavior-bearing change that
+reaches any of those reaches both live-provider and Slack external-integration.
+Those two rows are required on that path. "No model routing change" is not a valid n/a reason.
+Fake-model kind, skill ladder, and helper-only tests remain useful and are
+not sufficient for those acceptance criteria. Leave the required-tier item
+open when the evidence is missing; do not close it by marking the row n/a.
+This rule does not pull the live e2e ladder onto unrelated pull requests.
+
 ## Build rules
 
 For a behavior change, write or update the test first and confirm it fails for the

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -51,7 +51,14 @@ Fix pin: n/a - <reason>
 
      Documentation and ADR changes are not automatically exempt. If they alter
      runtime behavior, use the behavior-bearing path. See "E2E verification is
-     mandatory" in AGENTS.md. -->
+     mandatory" in AGENTS.md.
+
+     A change that reaches runner MCP catalog projection, unscoped PreToolUse,
+     in-process platform MCP tools, workspace publication, or
+     built-in coding-tool session capability must record live-provider plus
+     Slack external-integration evidence, or leave those required-tier rows open.
+     "No model routing change" is not a valid n/a reason. Fake-model kind,
+     skill ladder, and helper-only tests are not sufficient. -->
 
 | Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
 | --- | --- | --- | --- | --- |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -480,8 +480,18 @@ required and proved, not carried on the original classification.
 | local | compose services, dispatcher, worker, or API wiring, boot env crossing a service boundary, the console UI, or any `curie` verb whose output, exit code, or `--json` shape changed | `CURIE_E2E_TIERS=local curie dev e2e-ladder` |
 | local-release | released binary or image identity, the install path, version pins, release compose | `CURIE_E2E_TIERS=local-release curie dev e2e-ladder` |
 | cluster | chart templates, RBAC, securityContext, NetworkPolicy, sandbox claims, init containers | `CURIE_E2E_TIERS=cluster curie dev e2e-ladder`, or `curie dev chart-runtime-e2e` for a chart, sandbox, or bundle slice |
-| live provider | model routing, credential resolution, provider auth, token or cost accounting, meaning the product's own model and integration credentials, never the agent tooling that runs this workflow | the required rungs with `CURIE_E2E_LIVE=1`, since a fake-tier pass proves wiring and nothing about a real model |
-| external integration | Slack, git push webhooks, connector OAuth, or any third-party API shape | drive the real integration; a replayed fixture or a fake does not close this tier |
+| live provider | model routing, credential resolution, provider auth, token or cost accounting, meaning the product's own model and integration credentials, never the agent tooling that runs this workflow; also the MCP/workspace/coding-tool path set below | the required rungs with `CURIE_E2E_LIVE=1`, since a fake-tier pass proves wiring and nothing about a real model |
+| external integration | Slack, git push webhooks, connector OAuth, or any third-party API shape; Slack is required on the MCP/workspace/coding-tool path set below | drive the real integration; a replayed fixture or a fake does not close this tier |
+
+The path set is runner MCP catalog projection, unscoped PreToolUse,
+in-process platform MCP tools, workspace publication, and
+built-in coding-tool session capability. A behavior-bearing change that
+reaches any of those reaches both live-provider and Slack external-integration.
+Those two rows are required on that path. "No model routing change" is not a valid n/a reason.
+Fake-model kind, skill ladder, and helper-only tests remain useful and are
+not sufficient for those acceptance criteria. Leave the required-tier item
+open when the evidence is missing; do not close it by marking the row n/a.
+This rule does not pull the live e2e ladder onto unrelated pull requests.
 
 ### Evidence per acceptance criterion
 

--- a/tools/doclint/src/curie_doclint/__init__.py
+++ b/tools/doclint/src/curie_doclint/__init__.py
@@ -56,6 +56,7 @@ from .generate import (
     replace_region,
     seam_link,
 )
+from .mcp_workspace_live_tiers import check_mcp_workspace_live_tiers
 from .symbols import SymbolCache, SymbolSyntaxError, dataclass_fields, resolve_symbol
 from .vision import VISION_REL, read_swap_readiness
 
@@ -117,6 +118,9 @@ def _lint_and_count(repo_root: Path) -> tuple[list[Finding], int]:
     # machine-readable ground truth, never rewritten, so `--write` leaves it
     # alone.
     findings.extend(check_agent_contract(repo_root))
+    # Implement-workflow live-tier rule (#2305). Same class as check_counts:
+    # required sentences asserted against the workflow docs, never rewritten.
+    findings.extend(check_mcp_workspace_live_tiers(repo_root))
     doc_findings, ignored = _check_docs(repo_root, cache)
     findings.extend(doc_findings)
     return findings, ignored

--- a/tools/doclint/src/curie_doclint/mcp_workspace_live_tiers.py
+++ b/tools/doclint/src/curie_doclint/mcp_workspace_live_tiers.py
@@ -1,0 +1,80 @@
+"""The #2305 live-tier rule in the implement workflow docs.
+
+A pull request can change how the runner advertises MCP tools, how PreToolUse
+classifies them, or how a mounted workspace exposes coding and publication
+tools, then mark live-provider and Slack external-integration n/a because
+"model routing did not change." The implement skill and AGENTS.md now forbid
+that classification. This check pins the contiguous rule sentences so a
+reword cannot keep the nouns and drop the prohibition.
+
+The files are optional in the miniature fixture tree. When a file is present,
+every required sentence must appear after whitespace is squashed. The real
+repo carries all three files, and the docs gate always runs, including on
+docs-only diffs that skip pytest.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .finding import Finding
+
+WORKFLOW_DOCS = (
+    "AGENTS.md",
+    ".claude/skills/implement/SKILL.md",
+)
+
+# Contiguous claims, not a bag of nouns. A document that names the path set
+# and then re-allows "No model routing change" as n/a must fail.
+WORKFLOW_SENTENCES = (
+    "runner MCP catalog projection, unscoped PreToolUse, "
+    "in-process platform MCP tools, workspace publication, and "
+    "built-in coding-tool session capability",
+    "A behavior-bearing change that reaches any of those reaches both "
+    "live-provider and Slack external-integration",
+    '"No model routing change" is not a valid n/a reason',
+    "Fake-model kind, skill ladder, and helper-only tests remain useful "
+    "and are not sufficient",
+    "Leave the required-tier item open when the evidence is missing",
+)
+
+TEMPLATE_REL = ".github/PULL_REQUEST_TEMPLATE.md"
+TEMPLATE_SENTENCES = (
+    "runner MCP catalog projection, unscoped PreToolUse, "
+    "in-process platform MCP tools, workspace publication",
+    "built-in coding-tool session capability must record live-provider plus "
+    "Slack external-integration evidence, or leave those required-tier "
+    "rows open",
+    '"No model routing change" is not a valid n/a reason',
+)
+
+
+def _squashed(text: str) -> str:
+    return " ".join(text.split())
+
+
+def _missing_sentences(text: str, sentences: tuple[str, ...]) -> list[str]:
+    haystack = _squashed(text)
+    return [sentence for sentence in sentences if sentence not in haystack]
+
+
+def check_mcp_workspace_live_tiers(repo_root: Path) -> list[Finding]:
+    """Return a finding for each required sentence a present workflow doc dropped."""
+
+    findings: list[Finding] = []
+    targets: tuple[tuple[str, tuple[str, ...]], ...] = tuple(
+        (rel, WORKFLOW_SENTENCES) for rel in WORKFLOW_DOCS
+    ) + ((TEMPLATE_REL, TEMPLATE_SENTENCES),)
+    for rel, sentences in targets:
+        path = repo_root / rel
+        if not path.is_file():
+            continue
+        for sentence in _missing_sentences(path.read_text(encoding="utf-8"), sentences):
+            findings.append(
+                Finding(
+                    rel,
+                    sentence,
+                    "MCP/workspace live-tier rule is missing this required sentence",
+                )
+            )
+    return findings

--- a/tools/doclint/tests/CONTRACT.md
+++ b/tools/doclint/tests/CONTRACT.md
@@ -20,10 +20,10 @@ private module/function names are free to change.
 ## Findings API (documented, not asserted directly)
 
 `curie_doclint.lint(repo_root: Path) -> list[Finding]` runs the generate,
-counts, agent-contract command, and citation lint phases in memory and
-returns the findings `main` prints. A `Finding` carries at least the
-repo-relative doc path, the offending citation/field, and a human reason.
-Tests exercise this through `main`.
+counts, agent-contract command, MCP/workspace live-tier, and citation lint
+phases in memory and returns the findings `main` prints. A `Finding` carries
+at least the repo-relative doc path, the offending citation/field, and a
+human reason. Tests exercise this through `main`.
 
 ## Generator surface
 
@@ -75,6 +75,9 @@ resolve is a finding (deletion, not a skip).
   subcommand`.
 - Agent-contract names no command at all (vacuity guard): contains `no
   \`curie\` command appears`.
+- MCP/workspace live-tier rule missing a required sentence: names the doc,
+  names the missing sentence, and contains `MCP/workspace live-tier rule is
+  missing this required sentence`.
 
 ## Front-matter schema (per `INTERFACE.md`)
 

--- a/tools/doclint/tests/test_mcp_workspace_live_tiers.py
+++ b/tools/doclint/tests/test_mcp_workspace_live_tiers.py
@@ -1,0 +1,116 @@
+"""The #2305 live-tier rule is pinned through the docs gate.
+
+A docs-only AGENTS.md edit skips pytest, so the pin has to live in
+``curie_doclint``: the docs step always runs. Tests drive ``main`` and
+assert on exit code and message text only.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .conftest import RunLint, write
+
+_AGENTS = "AGENTS.md"
+_SKILL = ".claude/skills/implement/SKILL.md"
+_TEMPLATE = ".github/PULL_REQUEST_TEMPLATE.md"
+_REASON = "MCP/workspace live-tier rule is missing this required sentence"
+
+_WORKFLOW_RULE = """
+The path set is runner MCP catalog projection, unscoped PreToolUse,
+in-process platform MCP tools, workspace publication, and
+built-in coding-tool session capability. A behavior-bearing change that
+reaches any of those reaches both live-provider and Slack external-integration.
+Those two rows are required on that path. "No model routing change" is not a valid n/a reason.
+Fake-model kind, skill ladder, and helper-only tests remain useful and are
+not sufficient for those acceptance criteria. Leave the required-tier item
+open when the evidence is missing; do not close it by marking the row n/a.
+"""
+
+_TEMPLATE_RULE = """
+A change that reaches runner MCP catalog projection, unscoped PreToolUse,
+in-process platform MCP tools, workspace publication, or
+built-in coding-tool session capability must record live-provider plus
+Slack external-integration evidence, or leave those required-tier rows open.
+"No model routing change" is not a valid n/a reason.
+"""
+
+_FORBIDDEN_NA = '"No model routing change" is not a valid n/a reason'
+_LIVE_SLACK = (
+    "A behavior-bearing change that reaches any of those reaches both "
+    "live-provider and Slack external-integration"
+)
+
+
+def test_fixture_without_workflow_docs_still_passes(
+    clean_repo: Path, run_lint: RunLint
+) -> None:
+    # The miniature tree has no AGENTS.md / implement skill / PR template.
+    # Absence is a skip, not a finding: those files are not fixture artifacts.
+    code, out = run_lint(clean_repo)
+    assert code == 0, out
+    assert _REASON not in out
+
+
+def test_complete_workflow_docs_pass(clean_repo: Path, run_lint: RunLint) -> None:
+    write(clean_repo, _AGENTS, _WORKFLOW_RULE)
+    write(clean_repo, _SKILL, _WORKFLOW_RULE)
+    write(clean_repo, _TEMPLATE, _TEMPLATE_RULE)
+    code, out = run_lint(clean_repo)
+    assert code == 0, out
+
+
+def test_agents_md_missing_the_forbidden_na_sentence_fails(
+    clean_repo: Path, run_lint: RunLint
+) -> None:
+    # THE ticket's own defect: the path set is named, live-provider and Slack
+    # are named, but "No model routing change" is no longer forbidden.
+    write(clean_repo, _AGENTS, _WORKFLOW_RULE.replace(_FORBIDDEN_NA, "", 1))
+    code, out = run_lint(clean_repo)
+    assert code != 0
+    assert _AGENTS in out
+    assert _FORBIDDEN_NA in out
+    assert _REASON in out
+
+
+def test_scattered_nouns_without_the_contiguous_rule_fail(
+    clean_repo: Path, run_lint: RunLint
+) -> None:
+    # Independent substrings are not enough. A doc that keeps every noun and
+    # re-allows the n/a reason must fail the contiguous live-provider sentence.
+    write(
+        clean_repo,
+        _AGENTS,
+        "The path set is runner MCP catalog projection, unscoped PreToolUse, "
+        "in-process platform MCP tools, workspace publication, and "
+        "built-in coding-tool session capability. "
+        "No model routing change is a valid n/a reason for live-provider "
+        "and Slack external-integration. Fake-model kind, skill ladder, and "
+        "helper-only tests remain useful and are not sufficient. Leave the "
+        "required-tier item open when the evidence is missing.\n",
+    )
+    code, out = run_lint(clean_repo)
+    assert code != 0
+    assert _AGENTS in out
+    assert _LIVE_SLACK in out
+    assert _REASON in out
+
+
+def test_implement_skill_missing_the_rule_fails(
+    clean_repo: Path, run_lint: RunLint
+) -> None:
+    write(clean_repo, _SKILL, "Classify the end-to-end tiers before the first edit.\n")
+    code, out = run_lint(clean_repo)
+    assert code != 0
+    assert _SKILL in out
+    assert _REASON in out
+
+
+def test_pr_template_missing_the_reminder_fails(
+    clean_repo: Path, run_lint: RunLint
+) -> None:
+    write(clean_repo, _TEMPLATE, "## End-to-end verification\n")
+    code, out = run_lint(clean_repo)
+    assert code != 0
+    assert _TEMPLATE in out
+    assert _REASON in out


### PR DESCRIPTION
## Summary

A pull request can change how the runner advertises MCP tools, how PreToolUse classifies them, or how a mounted workspace exposes coding and publication tools, then mark live-provider and Slack external-integration as not applicable because model routing did not change. Fake-model kind and skill-ladder proof then merge, and the production-shaped Slack plus real-model demo is the first place the catalog is seen.

This change names that path set in the implement skill and the AGENTS.md tier table, forbids "No model routing change" as an n/a reason, reminds reviewers in the PR template, and pins the contiguous rule sentences in the docs gate so a docs-only revert still fails.

## Related issue

Closes #2305

## Fix pin verification

Fix pin: n/a - the pin lives in tools/doclint/tests/test_mcp_workspace_live_tiers.py, which is outside the supported selector prefixes (apps, packages, runner, cli, charts). The docs gate always runs it, including on docs-only diffs that skip pytest.

## End-to-end verification

This change does not alter runtime behavior because it only updates implementer triage docs and the docs-gate pin of that wording. Product runtime, model routing, Slack, and the runner are unchanged.

Scoped verification: `uv run pytest -q tools/doclint/tests/test_mcp_workspace_live_tiers.py` - 6 passed on commit 82714b8b.

Scoped verification: `bash scripts/check-docs.sh` - OK, the interface catalog is generated and drift-free.

Negative: `test_scattered_nouns_without_the_contiguous_rule_fail` feeds a document that names the path set and re-allows "No model routing change" as n/a; the docs gate exits non-zero and names the missing live-provider plus Slack sentence.

Second path: `test_real_repo_docs_are_clean` runs the same docs gate over the real tree and passes only while AGENTS.md, the implement skill, and the PR template still carry the required sentences.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [x] An ADR is added under `docs/adr/` if this is an architectural decision. Not applicable: this is implementer process coverage, not a product architecture decision.

Sibling: CONTRIBUTING.md restates the generic E2E exemption and already points at AGENTS.md. Left unchanged on purpose.

Out of scope, not in this PR: #2201, #2294, #2271, #2272, sdk-approval-gate path filters, blanket live e2e.
