### PR TITLE
feat(cli): version and migrate retained cluster configuration

### DIFF
--- a/charts/curie/values.schema.json
+++ b/charts/curie/values.schema.json
@@ -2,6 +2,20 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
+    "config": {
+      "type": "object",
+      "description": "Installed configuration schema stamp written by the CLI on every install and upgrade (issue #2299).",
+      "properties": {
+        "schemaVersion": {
+          "type": "string",
+          "description": "Configuration schema version persisted with the Helm release."
+        },
+        "migratedFrom": {
+          "type": "string",
+          "description": "Schema or chart version the previous document was migrated from. Empty on a fresh current-schema install."
+        }
+      }
+    },
     "api": {
       "type": "object",
       "properties": {

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -18,6 +18,15 @@
 nameOverride: ""
 fullnameOverride: ""
 
+# Installed configuration schema version (issue #2299). `curie cluster up` and
+# `curie apply` stamp this on every install and upgrade so later upgrades know
+# which migrations to run. Operators should not set this by hand.
+config:
+  schemaVersion: ""
+  # Chart / schema version the previous document was migrated from. Empty on a
+  # fresh install that already uses the current schema.
+  migratedFrom: ""
+
 global:
   imagePullPolicy: IfNotPresent
   # "" uses the cluster default StorageClass. Set to pin a class (e.g. local-path

--- a/cli/src/config_migrate.rs
+++ b/cli/src/config_migrate.rs
@@ -118,24 +118,6 @@ pub fn extra_env_successors() -> &'static [(&'static str, &'static str)] {
     PAIRS
 }
 
-#[cfg(test)]
-mod successor_table_tests {
-    use super::*;
-
-    #[test]
-    fn public_successor_table_matches_promotion_table() {
-        assert_eq!(EXTRA_ENV_SUCCESSORS.len(), extra_env_successors().len());
-        for (env, key, _) in EXTRA_ENV_SUCCESSORS {
-            assert!(
-                extra_env_successors()
-                    .iter()
-                    .any(|(public_env, public_key)| public_env == env && public_key == key),
-                "extra_env_successors() missing {env} -> {key}"
-            );
-        }
-    }
-}
-
 /// Migrate user-supplied Helm values from a supported v0.8.x install to the
 /// v0.9.0 schema. Pure: no cluster I/O.
 pub fn migrate_installed_config(
@@ -444,5 +426,23 @@ fn remove_path(value: &mut Value, dotted: &str) {
     }
     if let Some(obj) = cursor.as_object_mut() {
         obj.remove(last);
+    }
+}
+
+#[cfg(test)]
+mod successor_table_tests {
+    use super::*;
+
+    #[test]
+    fn public_successor_table_matches_promotion_table() {
+        assert_eq!(EXTRA_ENV_SUCCESSORS.len(), extra_env_successors().len());
+        for (env, key, _) in EXTRA_ENV_SUCCESSORS {
+            assert!(
+                extra_env_successors()
+                    .iter()
+                    .any(|(public_env, public_key)| public_env == env && public_key == key),
+                "extra_env_successors() missing {env} -> {key}"
+            );
+        }
     }
 }

--- a/cli/src/config_migrate.rs
+++ b/cli/src/config_migrate.rs
@@ -1,0 +1,448 @@
+//! Versioned installed Helm configuration and pure migrations (issue #2299).
+//!
+//! The supported upgrade command reads user-supplied Helm values, runs these
+//! migrations, and overlays the result. Operators do not choose
+//! `--reuse-values` versus `--reset-then-reuse-values`.
+
+use anyhow::{bail, Context, Result};
+use serde_json::{json, Map, Value};
+
+/// Schema version stamped onto every v0.9.0 install and upgrade.
+pub const TARGET_SCHEMA_VERSION: &str = "0.9.0";
+
+/// Result of migrating one installed configuration document.
+#[derive(Debug, Clone)]
+pub struct MigrationOutcome {
+    pub schema_version: String,
+    pub migrated_from: Option<String>,
+    pub values: Value,
+    pub changes: Vec<String>,
+}
+
+#[derive(Clone, Copy)]
+enum Coerce {
+    String,
+    Number,
+    Integer,
+    Bool,
+}
+
+/// Exact extraEnv name -> first-class Helm key successors.
+const EXTRA_ENV_SUCCESSORS: &[(&str, &str, Coerce)] = &[
+    (
+        "CURIE_RUNNER_TOTAL_TIMEOUT_S",
+        "worker.runnerTotalTimeoutSeconds",
+        Coerce::Number,
+    ),
+    (
+        "SLACK_API_BASE_URL",
+        "worker.slackApiBaseUrl",
+        Coerce::String,
+    ),
+    ("CURIE_SHIMMER", "worker.shimmer", Coerce::Bool),
+    ("CURIE_STATUS_TEXT", "worker.statusText", Coerce::String),
+    (
+        "CURIE_CLAIM_TIMEOUT_SECONDS",
+        "worker.claimTimeoutSeconds",
+        Coerce::Number,
+    ),
+    (
+        "CURIE_ROUTE_TTL_SECONDS",
+        "worker.routeTtlSeconds",
+        Coerce::Integer,
+    ),
+    (
+        "CURIE_SUSPENDED_ROUTE_TTL_SECONDS",
+        "worker.suspendedRouteTtlSeconds",
+        Coerce::Integer,
+    ),
+    (
+        "CURIE_DELIVERY_BUDGET_S",
+        "worker.deliveryBudgetSeconds",
+        Coerce::Integer,
+    ),
+    (
+        "CURIE_SLACK_TRUSTED_ORIGINS",
+        "worker.slackTrustedOrigins",
+        Coerce::String,
+    ),
+];
+
+const EXTRA_ENV_LISTS: &[&str] = &[
+    "worker.extraEnv",
+    "api.extraEnv",
+    "dispatcher.extraEnv",
+    "agentSandbox.runner.extraEnv",
+];
+
+/// Irregular existingSecret -> inline credential paths. The regular case is
+/// `{field}ExistingSecret` -> `{field}` on the same object.
+const INLINE_EXCEPTIONS: &[(&str, &[&str])] = &[
+    ("api.githubAppExistingSecret", &["api.githubAppPrivateKey"]),
+    ("postgres.existingSecret", &["postgres.auth.password"]),
+    ("valkey.existingSecret", &["valkey.password"]),
+    ("clickhouse.existingSecret", &["clickhouse.auth.password"]),
+    (
+        "rustfs.existingSecret",
+        &["rustfs.auth.rootPassword", "rustfs.auth.secretKey"],
+    ),
+    (
+        "langfuse.existingSecret",
+        &[
+            "langfuse.salt",
+            "langfuse.encryptionKey",
+            "langfuse.nextauthSecret",
+        ],
+    ),
+];
+
+/// Exact extraEnv name -> first-class Helm key successors.
+pub fn extra_env_successors() -> &'static [(&'static str, &'static str)] {
+    const PAIRS: &[(&str, &str)] = &[
+        (
+            "CURIE_RUNNER_TOTAL_TIMEOUT_S",
+            "worker.runnerTotalTimeoutSeconds",
+        ),
+        ("SLACK_API_BASE_URL", "worker.slackApiBaseUrl"),
+        ("CURIE_SHIMMER", "worker.shimmer"),
+        ("CURIE_STATUS_TEXT", "worker.statusText"),
+        ("CURIE_CLAIM_TIMEOUT_SECONDS", "worker.claimTimeoutSeconds"),
+        ("CURIE_ROUTE_TTL_SECONDS", "worker.routeTtlSeconds"),
+        (
+            "CURIE_SUSPENDED_ROUTE_TTL_SECONDS",
+            "worker.suspendedRouteTtlSeconds",
+        ),
+        ("CURIE_DELIVERY_BUDGET_S", "worker.deliveryBudgetSeconds"),
+        ("CURIE_SLACK_TRUSTED_ORIGINS", "worker.slackTrustedOrigins"),
+    ];
+    PAIRS
+}
+
+#[cfg(test)]
+mod successor_table_tests {
+    use super::*;
+
+    #[test]
+    fn public_successor_table_matches_promotion_table() {
+        assert_eq!(EXTRA_ENV_SUCCESSORS.len(), extra_env_successors().len());
+        for (env, key, _) in EXTRA_ENV_SUCCESSORS {
+            assert!(
+                extra_env_successors()
+                    .iter()
+                    .any(|(public_env, public_key)| public_env == env && public_key == key),
+                "extra_env_successors() missing {env} -> {key}"
+            );
+        }
+    }
+}
+
+/// Migrate user-supplied Helm values from a supported v0.8.x install to the
+/// v0.9.0 schema. Pure: no cluster I/O.
+pub fn migrate_installed_config(
+    mut values: Value,
+    installed_chart: Option<&str>,
+) -> Result<MigrationOutcome> {
+    if !values.is_object() {
+        if values.is_null() {
+            values = json!({});
+        } else {
+            bail!("installed Helm values must be an object");
+        }
+    }
+
+    let source = infer_schema_version(&values, installed_chart)?;
+    if !is_supported_source(&source) {
+        bail!("installed configuration schema {source} is not a supported v0.8.x upgrade source");
+    }
+
+    let mut changes = Vec::new();
+    promote_extra_env(&mut values, &mut changes)?;
+    strip_inline_secrets(&mut values, &mut changes);
+
+    let migrated_from = if source == TARGET_SCHEMA_VERSION {
+        get_path(&values, "config.migratedFrom")
+            .and_then(Value::as_str)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+    } else {
+        Some(source.clone())
+    };
+
+    set_path(
+        &mut values,
+        "config.schemaVersion",
+        Value::String(TARGET_SCHEMA_VERSION.to_string()),
+    );
+    match &migrated_from {
+        Some(from) => set_path(
+            &mut values,
+            "config.migratedFrom",
+            Value::String(from.clone()),
+        ),
+        None => {
+            if get_path(&values, "config.migratedFrom")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .is_empty()
+            {
+                remove_path(&mut values, "config.migratedFrom");
+            }
+        }
+    }
+
+    Ok(MigrationOutcome {
+        schema_version: TARGET_SCHEMA_VERSION.to_string(),
+        migrated_from,
+        values,
+        changes,
+    })
+}
+
+/// Redacted upgrade-plan lines. Must never include credential values.
+pub fn redacted_upgrade_plan(outcome: &MigrationOutcome) -> Vec<String> {
+    let from = outcome
+        .migrated_from
+        .as_deref()
+        .unwrap_or(&outcome.schema_version);
+    let mut lines = vec![format!(
+        "config schema: {from} -> {}",
+        outcome.schema_version
+    )];
+    lines.extend(outcome.changes.iter().cloned());
+    lines
+}
+
+fn infer_schema_version(values: &Value, installed_chart: Option<&str>) -> Result<String> {
+    if let Some(version) = get_path(values, "config.schemaVersion")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        return Ok(version.to_string());
+    }
+    if let Some(chart) = installed_chart {
+        let name = chart.rsplit('/').next().unwrap_or(chart);
+        let version = name.strip_prefix("curie-").unwrap_or(name).trim();
+        if !version.is_empty() && version != "curie" {
+            return Ok(version.to_string());
+        }
+    }
+    Ok("0.8".to_string())
+}
+
+fn is_supported_source(version: &str) -> bool {
+    version == TARGET_SCHEMA_VERSION || version == "0.8" || version.starts_with("0.8.")
+}
+
+fn promote_extra_env(values: &mut Value, changes: &mut Vec<String>) -> Result<()> {
+    let mut seen: Map<String, Value> = Map::new();
+    for list_path in EXTRA_ENV_LISTS {
+        let Some(Value::Array(items)) = get_path(values, list_path).cloned() else {
+            continue;
+        };
+        let mut kept = Vec::new();
+        for item in items {
+            let Some(name) = item.get("name").and_then(Value::as_str) else {
+                kept.push(item);
+                continue;
+            };
+            let Some((_, helm_key, coerce)) = EXTRA_ENV_SUCCESSORS
+                .iter()
+                .find(|(env, _, _)| *env == name)
+                .copied()
+            else {
+                kept.push(item);
+                continue;
+            };
+            if item.get("valueFrom").is_some() {
+                bail!(
+                    "legacy extraEnv {name} uses valueFrom and cannot migrate to {helm_key}; \
+                     remove the extraEnv entry or set {helm_key} directly"
+                );
+            }
+            let incoming = coerce_extra_env(item.get("value"), coerce)
+                .with_context(|| format!("legacy extraEnv {name} cannot migrate to {helm_key}"))?;
+            if let Some(previous) = seen.get(name) {
+                if !json_equivalent(previous, &incoming) {
+                    bail!(
+                        "legacy extraEnv {name} conflicts with {helm_key}; remove one before upgrading"
+                    );
+                }
+            }
+            if let Some(existing) = get_path(values, helm_key) {
+                if !json_equivalent(existing, &incoming) {
+                    bail!(
+                        "legacy extraEnv {name} conflicts with {helm_key}; remove one before upgrading"
+                    );
+                }
+                changes.push(format!("extraEnv {name} dropped; matches {helm_key}"));
+            } else {
+                set_path(values, helm_key, incoming.clone());
+                changes.push(format!("extraEnv {name} -> {helm_key}"));
+            }
+            seen.insert(name.to_string(), incoming);
+        }
+        if kept.is_empty() {
+            set_path(values, list_path, json!([]));
+        } else {
+            set_path(values, list_path, Value::Array(kept));
+        }
+    }
+    Ok(())
+}
+
+fn coerce_extra_env(value: Option<&Value>, coerce: Coerce) -> Result<Value> {
+    let raw = match value {
+        None | Some(Value::Null) => bail!("missing value"),
+        Some(Value::String(s)) => s.clone(),
+        Some(Value::Number(n)) => n.to_string(),
+        Some(Value::Bool(b)) => b.to_string(),
+        Some(_) => bail!("unsupported extraEnv value shape"),
+    };
+    match coerce {
+        Coerce::String => Ok(Value::String(raw)),
+        Coerce::Number => {
+            let parsed: f64 = raw
+                .parse()
+                .map_err(|_| anyhow::anyhow!("value is not a number"))?;
+            if parsed.fract() == 0.0 && parsed.abs() <= i64::MAX as f64 {
+                Ok(json!(parsed as i64))
+            } else {
+                Ok(json!(parsed))
+            }
+        }
+        Coerce::Integer => {
+            let parsed: i64 = raw
+                .parse()
+                .map_err(|_| anyhow::anyhow!("value is not an integer"))?;
+            Ok(json!(parsed))
+        }
+        Coerce::Bool => match raw.to_ascii_lowercase().as_str() {
+            "true" | "1" => Ok(Value::Bool(true)),
+            "false" | "0" => Ok(Value::Bool(false)),
+            _ => bail!("value is not a boolean"),
+        },
+    }
+}
+
+fn json_equivalent(left: &Value, right: &Value) -> bool {
+    if left == right {
+        return true;
+    }
+    match (left, right) {
+        (Value::String(s), Value::Number(n)) | (Value::Number(n), Value::String(s)) => {
+            s.parse::<f64>().ok() == n.as_f64()
+        }
+        (Value::String(s), Value::Bool(b)) | (Value::Bool(b), Value::String(s)) => {
+            match s.to_ascii_lowercase().as_str() {
+                "true" | "1" => *b,
+                "false" | "0" => !*b,
+                _ => false,
+            }
+        }
+        (Value::Number(a), Value::Number(b)) => a.as_f64() == b.as_f64(),
+        _ => false,
+    }
+}
+
+fn strip_inline_secrets(values: &mut Value, changes: &mut Vec<String>) {
+    let mut refs = Vec::new();
+    collect_existing_secret_refs(values, "", &mut refs);
+    for secret_key in refs {
+        changes.push(format!("preserved external secret {secret_key}"));
+        for inline in inline_keys_for(&secret_key) {
+            if get_path(values, &inline).is_some() {
+                remove_path(values, &inline);
+                changes.push(format!(
+                    "omitted inline {inline} because {secret_key} is set"
+                ));
+            }
+        }
+    }
+}
+
+fn collect_existing_secret_refs(value: &Value, prefix: &str, out: &mut Vec<String>) {
+    let Some(map) = value.as_object() else {
+        return;
+    };
+    for (key, child) in map {
+        let path = if prefix.is_empty() {
+            key.clone()
+        } else {
+            format!("{prefix}.{key}")
+        };
+        let is_ref = key == "existingSecret" || key.ends_with("ExistingSecret");
+        if is_ref {
+            if let Some(name) = child.as_str().map(str::trim).filter(|s| !s.is_empty()) {
+                let _ = name;
+                out.push(path.clone());
+            }
+        }
+        if child.is_object() {
+            collect_existing_secret_refs(child, &path, out);
+        }
+    }
+}
+
+fn inline_keys_for(secret_key: &str) -> Vec<String> {
+    for (key, inlines) in INLINE_EXCEPTIONS {
+        if *key == secret_key {
+            return inlines.iter().map(|s| (*s).to_string()).collect();
+        }
+    }
+    let leaf = secret_key.rsplit('.').next().unwrap_or(secret_key);
+    let Some(field) = leaf.strip_suffix("ExistingSecret") else {
+        return Vec::new();
+    };
+    match secret_key.rsplit_once('.') {
+        Some((parent, _)) => vec![format!("{parent}.{field}")],
+        None => vec![field.to_string()],
+    }
+}
+
+fn get_path<'a>(value: &'a Value, dotted: &str) -> Option<&'a Value> {
+    let mut cursor = value;
+    for part in dotted.split('.') {
+        cursor = cursor.get(part)?;
+    }
+    Some(cursor)
+}
+
+fn set_path(value: &mut Value, dotted: &str, new_val: Value) {
+    let mut parts: Vec<&str> = dotted.split('.').collect();
+    let Some(last) = parts.pop() else {
+        return;
+    };
+    let mut cursor = value;
+    for part in parts {
+        if !cursor.is_object() {
+            *cursor = json!({});
+        }
+        let map = cursor.as_object_mut().expect("object path");
+        cursor = map.entry(part.to_string()).or_insert_with(|| json!({}));
+    }
+    if !cursor.is_object() {
+        *cursor = json!({});
+    }
+    cursor
+        .as_object_mut()
+        .expect("object path")
+        .insert(last.to_string(), new_val);
+}
+
+fn remove_path(value: &mut Value, dotted: &str) {
+    let mut parts: Vec<&str> = dotted.split('.').collect();
+    let Some(last) = parts.pop() else {
+        return;
+    };
+    let mut cursor = value;
+    for part in parts {
+        cursor = match cursor.get_mut(part) {
+            Some(next) => next,
+            None => return,
+        };
+    }
+    if let Some(obj) = cursor.as_object_mut() {
+        obj.remove(last);
+    }
+}

--- a/cli/src/installation.rs
+++ b/cli/src/installation.rs
@@ -2499,7 +2499,26 @@ mod diff_tests {
             github_entry.unresolved_credential.as_deref(),
             Some("CURIE_1426_GITHUB_CREDENTIAL")
         );
-        assert_eq!(out.changes(), 1);
+        let extra: Vec<&str> = out
+            .entries
+            .iter()
+            .filter(|entry| entry.kind != DiffKind::Same && entry.kind != DiffKind::Preserved)
+            .map(|entry| entry.key.as_str())
+            .collect();
+        assert!(
+            extra.contains(&"api.githubToken"),
+            "unresolved github must remain a change: {extra:?}"
+        );
+        assert!(
+            extra
+                .iter()
+                .all(|key| *key == "api.githubToken" || key.starts_with("config.")),
+            "unresolved github must not grow unrelated non-config changes: {extra:?}"
+        );
+        assert!(
+            out.changes() >= 1,
+            "an unresolved declared GitHub change must never report zero changes"
+        );
     }
 
     /// Values from the shared effective plan carry their literal desired value

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -12,6 +12,7 @@ pub mod chat;
 pub mod cluster_secrets;
 pub mod commands;
 pub mod comms;
+pub mod config_migrate;
 pub mod connector_build;
 pub mod connectors;
 pub mod credcheck;

--- a/cli/src/ops/up.rs
+++ b/cli/src/ops/up.rs
@@ -227,7 +227,10 @@ pub(super) fn operator_set_entries(sets: &[String]) -> Vec<(&str, &str)> {
 /// byte except credential values, which are replaced by their standard mask.
 pub(super) fn mask_helm_set_expression(expression: &str) -> String {
     let render_part = |part: &str| match operator_set_entry(part) {
-        Some((key, value)) if !value.is_empty() && is_secret_value_key(key.trim()) => {
+        Some((key, value))
+            if !value.is_empty()
+                && (is_secret_value_key(key.trim()) || is_extra_env_value_key(key.trim())) =>
+        {
             format!("{key}={}", mask_secret(value))
         }
         _ => part.to_string(),
@@ -1606,8 +1609,23 @@ fn complete_up_opts_without_runner_egress(
     existing: Option<&serde_json::Value>,
     github_token: Option<&str>,
     clear_github_token: bool,
+    overlay_live: bool,
 ) -> Result<UpOpts> {
     let operator_sets = opts.operator_sets();
+    let migrated_owned;
+    let existing = if let Some(values) = existing {
+        let outcome = crate::config_migrate::migrate_installed_config(values.clone(), None)?;
+        stamp_config_schema(&mut opts, &outcome);
+        overlay_migration_results(&mut opts, &outcome.values, &operator_sets);
+        if overlay_live {
+            overlay_live_operator_values(&mut opts, &outcome.values, &operator_sets);
+        }
+        migrated_owned = Some(outcome.values);
+        migrated_owned.as_ref()
+    } else {
+        stamp_target_schema(&mut opts);
+        existing
+    };
     resolve_preserved_runner_identity_values(&mut opts, existing, &operator_sets);
     resolve_preserved_gvisor_mode_value(&mut opts, existing, &operator_sets);
     resolve_preserved_worker_extra_env_values(&mut opts, existing, &operator_sets);
@@ -1632,6 +1650,210 @@ fn complete_up_opts_without_runner_egress(
     Ok(opts)
 }
 
+fn stamp_target_schema(opts: &mut UpOpts) {
+    if operator_set_keys(&opts.operator_sets()).contains("config.schemaVersion") {
+        return;
+    }
+    opts.set_string.push(format!(
+        "config.schemaVersion={}",
+        crate::config_migrate::TARGET_SCHEMA_VERSION
+    ));
+}
+
+fn stamp_config_schema(opts: &mut UpOpts, outcome: &crate::config_migrate::MigrationOutcome) {
+    stamp_target_schema(opts);
+    if let Some(from) = &outcome.migrated_from {
+        if !operator_set_keys(&opts.operator_sets()).contains("config.migratedFrom") {
+            opts.set_string.push(format!("config.migratedFrom={from}"));
+        }
+    }
+}
+
+fn is_external_secret_ref_key(key: &str) -> bool {
+    let leaf = key.rsplit('.').next().unwrap_or(key);
+    leaf == "existingSecret"
+        || leaf.ends_with("ExistingSecret")
+        || leaf.ends_with("ExistingSecretKey")
+        || leaf == "headersSecretKey"
+}
+
+fn is_extra_env_value_key(key: &str) -> bool {
+    key.contains(".extraEnv[") && (key.ends_with(".value") || key.contains(".valueFrom"))
+}
+
+/// Stamp first-class extraEnv successors and external Secret references from
+/// the migrated document. Shared by `cluster up` and `apply` so a legacy
+/// extraEnv entry is promoted even when `curie.yaml` does not mention it.
+fn overlay_migration_results(
+    opts: &mut UpOpts,
+    values: &serde_json::Value,
+    operator_sets: &[String],
+) {
+    let overridden = operator_set_keys(operator_sets);
+    for (_, helm_key) in crate::config_migrate::extra_env_successors() {
+        if overridden.contains(*helm_key)
+            || overridden
+                .iter()
+                .any(|key| key_is_or_descends_from(key, helm_key))
+        {
+            continue;
+        }
+        overlay_leaf(opts, values, helm_key, &overridden);
+    }
+    overlay_secret_refs(opts, values, "", &overridden);
+}
+
+/// Overlay remaining live operator values on `cluster up` only. `apply`/`diff`
+/// keep `curie.yaml` as whole intent (ADR-0097) and must not copy undeclared
+/// live keys into the desired plan.
+fn overlay_live_operator_values(
+    opts: &mut UpOpts,
+    values: &serde_json::Value,
+    operator_sets: &[String],
+) {
+    let overridden = operator_set_keys(operator_sets);
+    overlay_json(opts, values, "", &overridden);
+}
+
+fn overlay_family_is_managed(key: &str) -> bool {
+    key_is_or_descends_from(key, MODEL_CREDENTIAL_KEY)
+        || key_is_or_descends_from(key, RUNNER_MODEL_KEY)
+        || key_is_or_descends_from(key, FAKE_MODEL_KEY)
+        || key_is_or_descends_from(key, GVISOR_MODE_KEY)
+        || key_is_or_descends_from(key, ALLOWED_EGRESS_KEY)
+        || key_is_or_descends_from(key, SLACK_TRUSTED_ORIGINS_KEY)
+        || key_is_or_descends_from(key, WORKER_EXTRA_ENV_KEY)
+        || key_is_or_descends_from(key, "api.extraEnv")
+        || key_is_or_descends_from(key, "dispatcher.extraEnv")
+        || key_is_or_descends_from(key, "agentSandbox.runner.extraEnv")
+        || COMMS_MANAGED_KEYS
+            .iter()
+            .any(|managed| key_is_or_descends_from(key, managed))
+        || GITHUB_APP_MANAGED_KEYS
+            .iter()
+            .any(|managed| key_is_or_descends_from(key, managed))
+        || REQUIRED_SECRETS
+            .iter()
+            .any(|(managed, _)| key_is_or_descends_from(key, managed))
+        || crate::sealing::SEALING_MANAGED_KEYS
+            .iter()
+            .any(|managed| key_is_or_descends_from(key, managed))
+        || key_is_or_descends_from(key, GITHUB_TOKEN_KEY)
+}
+
+fn overlay_secret_refs(
+    opts: &mut UpOpts,
+    value: &serde_json::Value,
+    prefix: &str,
+    overridden: &std::collections::HashSet<String>,
+) {
+    let Some(map) = value.as_object() else {
+        return;
+    };
+    for (key, child) in map {
+        let path = if prefix.is_empty() {
+            key.clone()
+        } else {
+            format!("{prefix}.{key}")
+        };
+        if is_external_secret_ref_key(&path) && !overridden.contains(&path) {
+            match child {
+                serde_json::Value::String(raw) if raw.is_empty() => {}
+                serde_json::Value::String(raw) => opts
+                    .set_string
+                    .push(format!("{path}={}", escape_helm_set_string_value(raw))),
+                _ => {}
+            }
+        }
+        if child.is_object() {
+            overlay_secret_refs(opts, child, &path, overridden);
+        }
+    }
+}
+
+fn overlay_leaf(
+    opts: &mut UpOpts,
+    root: &serde_json::Value,
+    path: &str,
+    overridden: &std::collections::HashSet<String>,
+) {
+    if overridden.contains(path) {
+        return;
+    }
+    let mut cursor = root;
+    for part in path.split('.') {
+        let Some(next) = cursor.get(part) else {
+            return;
+        };
+        cursor = next;
+    }
+    match cursor {
+        serde_json::Value::String(raw) if raw.is_empty() => {}
+        serde_json::Value::String(raw) => opts
+            .set_string
+            .push(format!("{path}={}", escape_helm_set_string_value(raw))),
+        serde_json::Value::Bool(flag) => opts.set.push(format!("{path}={flag}")),
+        serde_json::Value::Number(number) => opts.set.push(format!("{path}={number}")),
+        _ => {}
+    }
+}
+
+fn overlay_json(
+    opts: &mut UpOpts,
+    value: &serde_json::Value,
+    prefix: &str,
+    overridden: &std::collections::HashSet<String>,
+) {
+    match value {
+        serde_json::Value::Object(map) => {
+            for (key, child) in map {
+                let path = if prefix.is_empty() {
+                    key.clone()
+                } else {
+                    format!("{prefix}.{key}")
+                };
+                overlay_json(opts, child, &path, overridden);
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for (index, child) in items.iter().enumerate() {
+                overlay_json(opts, child, &format!("{prefix}[{index}]"), overridden);
+            }
+        }
+        serde_json::Value::Null => {}
+        other => {
+            if prefix.is_empty() {
+                return;
+            }
+            if prefix == "config.schemaVersion" || prefix == "config.migratedFrom" {
+                return;
+            }
+            if overridden.contains(prefix)
+                || overridden.iter().any(|key| {
+                    key_is_or_descends_from(prefix, key) || key_is_or_descends_from(key, prefix)
+                })
+            {
+                return;
+            }
+            if overlay_family_is_managed(prefix) && !is_external_secret_ref_key(prefix) {
+                return;
+            }
+            if is_secret_value_key(prefix) && !is_external_secret_ref_key(prefix) {
+                return;
+            }
+            match other {
+                serde_json::Value::String(raw) if raw.is_empty() => {}
+                serde_json::Value::String(raw) => opts
+                    .set_string
+                    .push(format!("{prefix}={}", escape_helm_set_string_value(raw))),
+                serde_json::Value::Bool(flag) => opts.set.push(format!("{prefix}={flag}")),
+                serde_json::Value::Number(number) => opts.set.push(format!("{prefix}={number}")),
+                _ => {}
+            }
+        }
+    }
+}
+
 /// Finish an already validated up plan with the one live values read and, when
 /// requested, resolved provider addresses. This is kept separate from command
 /// execution so apply and diff can compare the same completed values.
@@ -1642,8 +1864,13 @@ pub(crate) fn complete_up_opts(
     clear_github_token: bool,
     resolve_provider_egress: bool,
 ) -> Result<UpOpts> {
-    let mut opts =
-        complete_up_opts_without_runner_egress(opts, existing, github_token, clear_github_token)?;
+    let mut opts = complete_up_opts_without_runner_egress(
+        opts,
+        existing,
+        github_token,
+        clear_github_token,
+        false,
+    )?;
     let operator_sets = opts.operator_sets();
     resolve_preserved_runner_egress_values(&mut opts, existing, &operator_sets, false);
     resolve_provider_egress_for_up(&mut opts, resolve_provider_egress)?;
@@ -3313,6 +3540,7 @@ pub async fn up(
         existing.as_ref(),
         github_token.as_deref(),
         clear_github_token,
+        true,
     )?;
     validate_credential_egress_consistency(&opts)?;
     let completed_identity_plan = up_value_plan(&opts);
@@ -3796,6 +4024,7 @@ mod tests {
             Some(&existing),
             None,
             false,
+            true,
         )
         .unwrap();
 
@@ -3852,6 +4081,7 @@ mod tests {
             Some(&existing),
             None,
             false,
+            true,
         )
         .unwrap();
 
@@ -3903,6 +4133,7 @@ mod tests {
             Some(&existing),
             None,
             false,
+            true,
         )
         .unwrap();
 
@@ -3919,6 +4150,100 @@ mod tests {
         assert!(
             argv.contains(&"worker.extraEnv[0].value=10.0.0.0/8\\,localhost".into()),
             "recorded worker extraEnv values must escape commas for Helm: {argv:?}"
+        );
+    }
+
+    /// Issue #2299: a released v0.8.x user-values overlay is migrated and
+    /// re-supplied without `--reuse-values`, with schema version visible and
+    /// inline credentials omitted when an external Secret is the source.
+    #[test]
+    fn upgrade_overlay_promotes_timeout_stamps_schema_and_keeps_secret_refs() {
+        let existing = serde_json::json!({
+            "ui": {"deploy": false},
+            "worker": {
+                "extraEnv": [
+                    {"name": "CURIE_RUNNER_TOTAL_TIMEOUT_S", "value": "120"},
+                    {"name": "PROVIDER_BASE_URL", "value": "https://provider.example.com/v1"}
+                ]
+            },
+            "dispatcher": {
+                "slack": {
+                    "botTokenExistingSecret": "acme-slack",
+                    "botTokenExistingSecretKey": "botToken",
+                    "botToken": "xoxb-test-token-must-not-leak"
+                }
+            }
+        });
+        let opts = complete_up_opts_without_runner_egress(
+            UpOpts {
+                common: common(),
+                github_token: GithubTokenPlan::Untouched,
+                allow_egress_host: vec![],
+                resolved_egress_cidrs: vec![],
+                chart: "charts/curie".into(),
+                secrets: vec![],
+                dev: false,
+                no_expose: true,
+                set: vec![],
+                set_string: vec![],
+                allow_web_egress: vec![],
+                fake_model: false,
+                credentials: None,
+                local_model: None,
+                model: None,
+            },
+            Some(&existing),
+            None,
+            false,
+            true,
+        )
+        .unwrap();
+
+        let effective = up_value_plan(&opts).effective_values();
+        assert_eq!(
+            effective.get("config.schemaVersion").map(String::as_str),
+            Some("0.9.0")
+        );
+        assert_eq!(
+            effective
+                .get("worker.runnerTotalTimeoutSeconds")
+                .map(String::as_str),
+            Some("120")
+        );
+        assert_eq!(
+            effective
+                .get("dispatcher.slack.botTokenExistingSecret")
+                .map(String::as_str),
+            Some("acme-slack")
+        );
+        assert_eq!(
+            effective
+                .get("dispatcher.slack.botTokenExistingSecretKey")
+                .map(String::as_str),
+            Some("botToken")
+        );
+        assert!(
+            effective
+                .keys()
+                .all(|key| !key.contains("botToken") || key.contains("Existing")),
+            "inline botToken must not return on the overlay: {effective:?}"
+        );
+
+        let (materialized, _guards) = up_commands(&opts)[0].materialize_secret_files().unwrap();
+        let argv = materialized.argv().join(" ");
+        let display = up_commands(&opts)[0].display();
+        assert!(
+            !argv.contains("--reuse-values") && !display.contains("--reuse-values"),
+            "upgrade must remain a full Helm upgrade: {display}"
+        );
+        assert!(
+            display.contains("config.schemaVersion=0.9.0"),
+            "redacted plan must expose the schema version: {display}"
+        );
+        assert!(
+            !display.contains("xoxb-test-token-must-not-leak")
+                && !argv.contains("xoxb-test-token-must-not-leak"),
+            "inline token must not appear in plan or argv: {display}"
         );
     }
 
@@ -3951,6 +4276,7 @@ mod tests {
             Some(&existing),
             None,
             false,
+            true,
         )
         .unwrap();
 
@@ -3995,6 +4321,7 @@ mod tests {
             Some(&existing),
             None,
             false,
+            true,
         )
         .unwrap();
 
@@ -4039,6 +4366,7 @@ mod tests {
             Some(&existing),
             None,
             false,
+            true,
         )
         .unwrap();
 
@@ -4084,6 +4412,7 @@ mod tests {
             Some(&existing),
             None,
             false,
+            true,
         )
         .unwrap();
 
@@ -4138,6 +4467,7 @@ mod tests {
                 existing.as_ref(),
                 None,
                 false,
+                true,
             )
             .unwrap();
 
@@ -5087,6 +5417,7 @@ mod tests {
             existing,
             None,
             false,
+            true,
         )
         .unwrap()
     }

--- a/cli/tests/config_migrate.rs
+++ b/cli/tests/config_migrate.rs
@@ -1,0 +1,340 @@
+//! Versioned installed-configuration migrations (issue #2299).
+//!
+//! Fixtures under `data/upgrade-config/` are user-supplied Helm values from
+//! released v0.8.x charts, not current-chart defaults.
+
+use curie::config_migrate::{
+    extra_env_successors, migrate_installed_config, redacted_upgrade_plan, MigrationOutcome,
+    TARGET_SCHEMA_VERSION,
+};
+use serde_json::{json, Value};
+
+fn load_fixture(name: &str) -> (String, Value) {
+    let raw = match name {
+        "v0.8.0" => include_str!("data/upgrade-config/v0.8.0-user-values.json"),
+        "v0.8.1" => include_str!("data/upgrade-config/v0.8.1-user-values.json"),
+        "v0.8.2" => include_str!("data/upgrade-config/v0.8.2-user-values.json"),
+        "v0.8.3" => include_str!("data/upgrade-config/v0.8.3-user-values.json"),
+        "v0.8.4" => include_str!("data/upgrade-config/v0.8.4-user-values.json"),
+        "v0.8.5" => include_str!("data/upgrade-config/v0.8.5-user-values.json"),
+        other => panic!("unknown fixture {other}"),
+    };
+    let mut value: Value = serde_json::from_str(raw).expect("fixture json");
+    let released = value
+        .get("_fixture")
+        .and_then(|f| f.get("releasedChart"))
+        .and_then(|v| v.as_str())
+        .unwrap_or(name)
+        .trim_start_matches('v')
+        .to_string();
+    if let Some(obj) = value.as_object_mut() {
+        obj.remove("_fixture");
+    }
+    (released, value)
+}
+
+fn extra_env_names(values: &Value, path: &[&str]) -> Vec<String> {
+    let mut cursor = values;
+    for part in path {
+        cursor = match cursor.get(*part) {
+            Some(next) => next,
+            None => return Vec::new(),
+        };
+    }
+    cursor
+        .as_array()
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| {
+                    item.get("name")
+                        .and_then(|n| n.as_str())
+                        .map(str::to_string)
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn number_at(values: &Value, path: &[&str]) -> Option<f64> {
+    let mut cursor = values;
+    for part in path {
+        cursor = cursor.get(*part)?;
+    }
+    cursor.as_f64().or_else(|| cursor.as_str()?.parse().ok())
+}
+
+fn string_at(values: &Value, path: &[&str]) -> Option<String> {
+    let mut cursor = values;
+    for part in path {
+        cursor = cursor.get(*part)?;
+    }
+    match cursor {
+        Value::String(s) => Some(s.clone()),
+        Value::Null => None,
+        other => Some(other.to_string()),
+    }
+}
+
+fn assert_redacted(outcome: &MigrationOutcome, forbidden: &[&str]) {
+    let plan = redacted_upgrade_plan(outcome).join("\n");
+    let err_debug = format!("{outcome:?}");
+    for secret in forbidden {
+        assert!(
+            !plan.contains(secret),
+            "redacted plan leaked {secret:?}: {plan}"
+        );
+        assert!(
+            !err_debug.contains(secret),
+            "debug output leaked {secret:?}: {err_debug}"
+        );
+    }
+}
+
+#[test]
+fn successor_table_names_runner_timeout_red_on_revert() {
+    assert!(
+        extra_env_successors()
+            .iter()
+            .any(|(env, key)| *env == "CURIE_RUNNER_TOTAL_TIMEOUT_S"
+                && *key == "worker.runnerTotalTimeoutSeconds"),
+        "red-on-revert: CURIE_RUNNER_TOTAL_TIMEOUT_S must map to worker.runnerTotalTimeoutSeconds"
+    );
+    assert!(
+        extra_env_successors()
+            .iter()
+            .any(|(env, key)| *env == "SLACK_API_BASE_URL" && *key == "worker.slackApiBaseUrl"),
+        "red-on-revert: SLACK_API_BASE_URL must map to worker.slackApiBaseUrl"
+    );
+}
+
+#[test]
+fn every_released_v0_8_fixture_migrates_to_v0_9() {
+    for name in ["v0.8.0", "v0.8.1", "v0.8.2", "v0.8.3", "v0.8.4", "v0.8.5"] {
+        let (released, values) = load_fixture(name);
+        let chart = format!("curie-{released}");
+        let outcome = migrate_installed_config(values, Some(&chart)).unwrap_or_else(|err| {
+            panic!("{name} migration failed: {err:#}");
+        });
+        assert_eq!(
+            outcome.schema_version, TARGET_SCHEMA_VERSION,
+            "{name} must stamp the v0.9.0 schema"
+        );
+        assert_eq!(
+            string_at(&outcome.values, &["config", "schemaVersion"]).as_deref(),
+            Some(TARGET_SCHEMA_VERSION),
+            "{name} must persist config.schemaVersion"
+        );
+        assert_eq!(
+            string_at(&outcome.values, &["config", "migratedFrom"]).as_deref(),
+            Some(released.as_str()),
+            "{name} must record migratedFrom"
+        );
+        assert!(
+            !extra_env_names(&outcome.values, &["worker", "extraEnv"])
+                .iter()
+                .any(|n| n == "CURIE_RUNNER_TOTAL_TIMEOUT_S"),
+            "{name} must drop promoted extraEnv CURIE_RUNNER_TOTAL_TIMEOUT_S"
+        );
+        assert!(
+            number_at(&outcome.values, &["worker", "runnerTotalTimeoutSeconds"]).is_some(),
+            "{name} must set worker.runnerTotalTimeoutSeconds"
+        );
+        assert_eq!(
+            string_at(&outcome.values, &["ui", "deploy"]).as_deref(),
+            Some("false"),
+            "{name} must keep the operator ui.deploy override"
+        );
+        let plan = redacted_upgrade_plan(&outcome).join("\n");
+        assert!(
+            plan.contains(&format!(
+                "config schema: {released} -> {TARGET_SCHEMA_VERSION}"
+            )),
+            "{name} plan must expose schema versions: {plan}"
+        );
+        assert_redacted(
+            &outcome,
+            &[
+                "xoxb-test-token-must-not-leak",
+                "sk-ant-test-must-not-leak",
+                "ghp_test-token-must-not-leak",
+                "adapter-secret-must-not-leak",
+                "MII-test",
+                "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+            ],
+        );
+    }
+}
+
+#[test]
+fn v0_8_0_promotes_slack_base_url_and_keeps_generic_extra_env() {
+    let (_, values) = load_fixture("v0.8.0");
+    let outcome = migrate_installed_config(values, Some("curie-0.8.0")).unwrap();
+    assert_eq!(
+        string_at(&outcome.values, &["worker", "slackApiBaseUrl"]).as_deref(),
+        Some("https://slack.example.com")
+    );
+    let names = extra_env_names(&outcome.values, &["worker", "extraEnv"]);
+    assert!(names.contains(&"PROVIDER_BASE_URL".to_string()));
+    assert!(!names.contains(&"SLACK_API_BASE_URL".to_string()));
+}
+
+#[test]
+fn v0_8_4_preserves_external_secret_refs_and_drops_inline() {
+    let (_, values) = load_fixture("v0.8.4");
+    let outcome = migrate_installed_config(values, Some("curie-0.8.4")).unwrap();
+    assert_eq!(
+        string_at(
+            &outcome.values,
+            &["dispatcher", "slack", "botTokenExistingSecret"]
+        )
+        .as_deref(),
+        Some("acme-slack")
+    );
+    assert_eq!(
+        string_at(
+            &outcome.values,
+            &["dispatcher", "slack", "botTokenExistingSecretKey"]
+        )
+        .as_deref(),
+        Some("botToken")
+    );
+    assert!(
+        string_at(&outcome.values, &["dispatcher", "slack", "botToken"]).is_none(),
+        "inline botToken must not be restored when existingSecret is set"
+    );
+    assert_eq!(
+        string_at(
+            &outcome.values,
+            &["agentSandbox", "runner", "credentialsExistingSecret"]
+        )
+        .as_deref(),
+        Some("acme-model")
+    );
+    assert!(
+        string_at(&outcome.values, &["agentSandbox", "runner", "credentials"]).is_none(),
+        "inline model credentials must not be restored when existingSecret is set"
+    );
+}
+
+#[test]
+fn extra_env_conflict_with_first_class_is_rejected_before_mutation() {
+    let values = json!({
+        "worker": {
+            "runnerTotalTimeoutSeconds": 600,
+            "extraEnv": [
+                {"name": "CURIE_RUNNER_TOTAL_TIMEOUT_S", "value": "120"}
+            ]
+        }
+    });
+    let err = migrate_installed_config(values, Some("curie-0.8.4")).unwrap_err();
+    let message = format!("{err:#}");
+    assert!(
+        message.contains("CURIE_RUNNER_TOTAL_TIMEOUT_S"),
+        "conflict must name the extraEnv entry: {message}"
+    );
+    assert!(
+        message.contains("worker.runnerTotalTimeoutSeconds"),
+        "conflict must name the first-class successor: {message}"
+    );
+    assert!(
+        !message.contains("120") && !message.contains("600"),
+        "conflict must not print the colliding values: {message}"
+    );
+}
+
+#[test]
+fn extra_env_value_from_successor_is_rejected() {
+    let values = json!({
+        "worker": {
+            "extraEnv": [{
+                "name": "CURIE_RUNNER_TOTAL_TIMEOUT_S",
+                "valueFrom": {"secretKeyRef": {"name": "acme-timeout", "key": "seconds"}}
+            }]
+        }
+    });
+    let err = migrate_installed_config(values, Some("curie-0.8.4")).unwrap_err();
+    let message = format!("{err:#}");
+    assert!(message.contains("valueFrom"), "{message}");
+    assert!(
+        message.contains("CURIE_RUNNER_TOTAL_TIMEOUT_S"),
+        "{message}"
+    );
+    assert!(!message.contains("acme-timeout"), "{message}");
+}
+
+#[test]
+fn matching_extra_env_and_first_class_drops_extra_env() {
+    let values = json!({
+        "worker": {
+            "runnerTotalTimeoutSeconds": 120,
+            "extraEnv": [
+                {"name": "CURIE_RUNNER_TOTAL_TIMEOUT_S", "value": "120"},
+                {"name": "PROVIDER_BASE_URL", "value": "https://provider.example.com/v1"}
+            ]
+        }
+    });
+    let outcome = migrate_installed_config(values, Some("curie-0.8.4")).unwrap();
+    assert_eq!(
+        number_at(&outcome.values, &["worker", "runnerTotalTimeoutSeconds"]),
+        Some(120.0)
+    );
+    let names = extra_env_names(&outcome.values, &["worker", "extraEnv"]);
+    assert_eq!(names, vec!["PROVIDER_BASE_URL".to_string()]);
+}
+
+#[test]
+fn migration_is_idempotent() {
+    let (_, values) = load_fixture("v0.8.4");
+    let first = migrate_installed_config(values, Some("curie-0.8.4")).unwrap();
+    let second = migrate_installed_config(first.values.clone(), Some("curie-0.9.0")).unwrap();
+    assert_eq!(first.values, second.values);
+    assert_eq!(second.schema_version, TARGET_SCHEMA_VERSION);
+}
+
+#[test]
+fn new_defaults_are_not_frozen_as_operator_intent() {
+    let values = json!({
+        "ui": {"deploy": false},
+        "worker": {
+            "extraEnv": [{"name": "PROVIDER_BASE_URL", "value": "https://provider.example.com/v1"}]
+        }
+    });
+    let outcome = migrate_installed_config(values, Some("curie-0.8.5")).unwrap();
+    assert!(
+        outcome.values.pointer("/worker/upgradeDrain").is_none(),
+        "absent chart defaults must stay absent so helm applies the target default"
+    );
+    assert_eq!(
+        string_at(&outcome.values, &["ui", "deploy"]).as_deref(),
+        Some("false")
+    );
+}
+
+#[test]
+fn unsupported_schema_is_rejected() {
+    let values = json!({"config": {"schemaVersion": "0.7.3"}, "ui": {"deploy": false}});
+    let err = migrate_installed_config(values, Some("curie-0.7.3")).unwrap_err();
+    let message = format!("{err:#}");
+    assert!(message.contains("0.7.3"), "{message}");
+    assert!(message.contains("v0.8"), "{message}");
+}
+
+#[test]
+fn already_versioned_v0_9_is_a_no_op_stamp() {
+    let values = json!({
+        "config": {"schemaVersion": "0.9.0"},
+        "ui": {"deploy": false},
+        "worker": {"runnerTotalTimeoutSeconds": 180}
+    });
+    let outcome = migrate_installed_config(values.clone(), None).unwrap();
+    assert_eq!(outcome.values["ui"], values["ui"]);
+    assert_eq!(
+        outcome.values["worker"]["runnerTotalTimeoutSeconds"],
+        values["worker"]["runnerTotalTimeoutSeconds"]
+    );
+    assert_eq!(
+        string_at(&outcome.values, &["config", "schemaVersion"]).as_deref(),
+        Some(TARGET_SCHEMA_VERSION)
+    );
+}

--- a/cli/tests/data/upgrade-config/v0.8.0-user-values.json
+++ b/cli/tests/data/upgrade-config/v0.8.0-user-values.json
@@ -1,0 +1,24 @@
+{
+  "_fixture": {
+    "releasedChart": "v0.8.0",
+    "source": "user-supplied helm values overlay from a released v0.8.0 chart, not current-chart defaults"
+  },
+  "ui": { "deploy": false },
+  "worker": {
+    "extraEnv": [
+      { "name": "CURIE_RUNNER_TOTAL_TIMEOUT_S", "value": "90" },
+      { "name": "PROVIDER_BASE_URL", "value": "https://provider.example.com/v1" },
+      { "name": "SLACK_API_BASE_URL", "value": "https://slack.example.com" }
+    ]
+  },
+  "dispatcher": {
+    "slack": {
+      "botTokenExistingSecret": "acme-slack",
+      "botTokenExistingSecretKey": "botToken",
+      "botToken": "xoxb-test-token-must-not-leak"
+    }
+  },
+  "api": {
+    "githubRepoAllowlist": ["acme-corp/acme-bot"]
+  }
+}

--- a/cli/tests/data/upgrade-config/v0.8.1-user-values.json
+++ b/cli/tests/data/upgrade-config/v0.8.1-user-values.json
@@ -1,0 +1,18 @@
+{
+  "_fixture": {
+    "releasedChart": "v0.8.1",
+    "source": "user-supplied helm values overlay from a released v0.8.1 chart, not current-chart defaults"
+  },
+  "ui": { "deploy": false },
+  "worker": {
+    "extraEnv": [
+      { "name": "CURIE_RUNNER_TOTAL_TIMEOUT_S", "value": "91" },
+      { "name": "PROVIDER_BASE_URL", "value": "https://provider.example.com/v1" }
+    ]
+  },
+  "sealing": {
+    "privateKeyExistingSecret": "acme-sealing",
+    "privateKeyExistingSecretKey": "sealingPrivateKey",
+    "privateKey": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+  }
+}

--- a/cli/tests/data/upgrade-config/v0.8.2-user-values.json
+++ b/cli/tests/data/upgrade-config/v0.8.2-user-values.json
@@ -1,0 +1,18 @@
+{
+  "_fixture": {
+    "releasedChart": "v0.8.2",
+    "source": "user-supplied helm values overlay from a released v0.8.2 chart, not current-chart defaults"
+  },
+  "ui": { "deploy": false },
+  "worker": {
+    "extraEnv": [
+      { "name": "CURIE_RUNNER_TOTAL_TIMEOUT_S", "value": "92" },
+      { "name": "CURIE_SHIMMER", "value": "false" }
+    ]
+  },
+  "api": {
+    "githubAppExistingSecret": "acme-github-app",
+    "githubAppExistingSecretKey": "privateKey",
+    "githubAppPrivateKey": "-----BEGIN PRIVATE KEY-----\nMII-test\n-----END PRIVATE KEY-----"
+  }
+}

--- a/cli/tests/data/upgrade-config/v0.8.3-user-values.json
+++ b/cli/tests/data/upgrade-config/v0.8.3-user-values.json
@@ -1,0 +1,16 @@
+{
+  "_fixture": {
+    "releasedChart": "v0.8.3",
+    "source": "user-supplied helm values overlay from a released v0.8.3 chart, not current-chart defaults"
+  },
+  "ui": { "deploy": false },
+  "worker": {
+    "extraEnv": [
+      { "name": "CURIE_RUNNER_TOTAL_TIMEOUT_S", "value": "93" },
+      { "name": "CURIE_DELIVERY_BUDGET_S", "value": "900" }
+    ],
+    "adapterCredentialsExistingSecret": "acme-adapters",
+    "adapterCredentialsExistingSecretKey": "adapterCredentials",
+    "adapterCredentials": { "slack": "adapter-secret-must-not-leak" }
+  }
+}

--- a/cli/tests/data/upgrade-config/v0.8.4-user-values.json
+++ b/cli/tests/data/upgrade-config/v0.8.4-user-values.json
@@ -1,0 +1,27 @@
+{
+  "_fixture": {
+    "releasedChart": "v0.8.4",
+    "source": "user-supplied helm values overlay from a released v0.8.4 chart, not current-chart defaults. extraEnv CURIE_RUNNER_TOTAL_TIMEOUT_S is the #2297 class: the first-class field exists on this chart but the operator still carried the legacy extraEnv."
+  },
+  "ui": { "deploy": false },
+  "worker": {
+    "extraEnv": [
+      { "name": "CURIE_RUNNER_TOTAL_TIMEOUT_S", "value": "120" },
+      { "name": "PROVIDER_BASE_URL", "value": "https://provider.example.com/v1" }
+    ]
+  },
+  "dispatcher": {
+    "slack": {
+      "botTokenExistingSecret": "acme-slack",
+      "botTokenExistingSecretKey": "botToken",
+      "botToken": "xoxb-test-token-must-not-leak"
+    }
+  },
+  "agentSandbox": {
+    "runner": {
+      "credentialsExistingSecret": "acme-model",
+      "credentialsExistingSecretKey": "agentCredentials",
+      "credentials": "sk-ant-test-must-not-leak"
+    }
+  }
+}

--- a/cli/tests/data/upgrade-config/v0.8.5-user-values.json
+++ b/cli/tests/data/upgrade-config/v0.8.5-user-values.json
@@ -1,0 +1,19 @@
+{
+  "_fixture": {
+    "releasedChart": "v0.8.5",
+    "source": "user-supplied helm values overlay from a released v0.8.5 chart, not current-chart defaults"
+  },
+  "ui": { "deploy": false },
+  "worker": {
+    "extraEnv": [
+      { "name": "CURIE_RUNNER_TOTAL_TIMEOUT_S", "value": "150" },
+      { "name": "PROVIDER_BASE_URL", "value": "https://provider.example.com/v1" }
+    ],
+    "slackTrustedOrigins": "http://host.docker.internal"
+  },
+  "api": {
+    "githubTokenExistingSecret": "acme-github",
+    "githubTokenExistingSecretKey": "githubToken",
+    "githubToken": "ghp_test-token-must-not-leak"
+  }
+}

--- a/cli/tests/installation_plan_parity.rs
+++ b/cli/tests/installation_plan_parity.rs
@@ -2477,10 +2477,12 @@ fn empty_github_token_clear_is_shared_by_apply_and_diff() {
         &diff,
         &[
             "api.githubToken",
+            "config.schemaVersion",
             "langfuse.web.service.type",
             "ui.service.type",
         ],
     );
+    assert_added(&diff, "config.schemaVersion", "0.9.0");
 }
 
 #[test]

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -752,6 +752,14 @@ helm get values <release> -n <ns> -o yaml > values.yaml
 helm upgrade <release> <chart> -n <ns> -f values.yaml
 ```
 
+`curie cluster up` and `curie apply` do this without asking the operator to
+choose `--reuse-values` versus `--reset-then-reuse-values`. They persist
+`config.schemaVersion` on the release, run pure migrations from supported
+v0.8.x user values onto the v0.9.0 schema (legacy extraEnv entries with a
+first-class successor, external Secret references), and overlay the result so
+new chart defaults still apply. A second upgrade with no input change is a
+no-op. Plan and diff output stay redacted.
+
 ### Migrating the bundle store (0.5.x → 0.6.0, `minio` → `rustfs`)
 
 0.6.0 renamed the in-cluster object store. The chart cannot migrate it for you,


### PR DESCRIPTION
## Summary

Cluster upgrades currently depend on per-family Helm preserve lists and
operators choosing `--reuse-values` versus a full upgrade. This adds a
versioned installed configuration document and pure migrations from supported
v0.8.x user values to the v0.9.0 schema.

`curie cluster up` overlays migrated operator intent without `--reuse-values`.
`curie apply` still treats `curie.yaml` as whole intent (ADR-0097) while
running the same migrations so extraEnv successors and external Secret
references are handled before any cluster mutation.

Closes #2299

## Acceptance criteria

- Persist `config.schemaVersion` with each release and expose it in the
  redacted upgrade plan (`--set-string config.schemaVersion=0.9.0`).
- Pure, unit-tested migrations from released v0.8.0 through v0.8.5 user-value
  fixtures to the v0.9.0 schema.
- Migrate legacy extraEnv entries with an exact first-class successor
  (`CURIE_RUNNER_TOTAL_TIMEOUT_S` -> `worker.runnerTotalTimeoutSeconds`,
  `SLACK_API_BASE_URL` -> `worker.slackApiBaseUrl`, and the other named
  successors). Ambiguous conflicts and `valueFrom` successors are refused
  before Helm runs, without printing the colliding values.
- Preserve external Secret names and keys byte-for-byte.
- Omit the inline credential when `existingSecret` is the active source.
- New target defaults stay absent from the user overlay so Helm applies them.
- A second migrate with no input change is a no-op.
- Plan, diff, error, and test output stay free of fixture credential values.
- Red-on-revert: emptying `extra_env_successors()` fails
  `successor_table_names_runner_timeout_red_on_revert`.

## Tests

```
cd cli && cargo test --offline --test config_migrate
cd cli && cargo test --offline --lib ops::up
cd cli && cargo test --offline --lib installation::
cd cli && cargo test --offline --test installation_plan_parity
cd cli && cargo clippy --all-targets --offline -- -D warnings
```

Red-on-revert observed: `extra_env_successors()` returning `&[]` panics
`successor_table_names_runner_timeout_red_on_revert` with
`CURIE_RUNNER_TOTAL_TIMEOUT_S must map to worker.runnerTotalTimeoutSeconds`.

## Notes

- No new ADR: issue #2299 plus ADR-0097 already close `--reuse-values`.
- No clap or command-manifest change.
- No live cluster mutation, merge, tag, or release.
