### PR TITLE
Give the mail adapter and hook Jobs placement classes

### DIFF
--- a/charts/curie/ci/render-assertions.sh
+++ b/charts/curie/ci/render-assertions.sh
@@ -1025,6 +1025,7 @@ expected = {
     ("Deployment", f"{prefix}-otel-collector"): "platform",
     ("Deployment", f"{prefix}-langfuse-web"): "platform",
     ("Deployment", f"{prefix}-langfuse-worker"): "platform",
+    ("Deployment", f"{prefix}-mail-adapter"): "platform",
     ("StatefulSet", f"{prefix}-postgres"): "data",
     ("StatefulSet", f"{prefix}-valkey"): "data",
     ("StatefulSet", f"{prefix}-clickhouse"): "data",
@@ -1041,6 +1042,9 @@ expected = {
     # The pre-upgrade drain gate and its post-upgrade release (issue #2010).
     ("Job", f"{prefix}-upgrade-drain"): "hooks",
     ("Job", f"{prefix}-upgrade-drain-release"): "hooks",
+    ("Job", f"{prefix}-grafana-token-updater"): "hooks",
+    ("Job", f"{prefix}-grafana-token-cleanup"): "hooks",
+    ("Job", f"{prefix}-mail-persistence-preflight"): "hooks",
     ("Pod", f"{prefix}-security-probe-hardening"): "hooks",
     ("Deployment", "agent-sandbox-controller"): "controller",
 }
@@ -1174,12 +1178,19 @@ else:
 PYEOF
 
 # Enable every conditional pod surface so the expected inventory is exhaustive.
+# mailAdapter.deploy also needs a narrow provider CIDR (fail-closed egress) and
+# an existingClaim so the persistence preflight Job actually renders. The Job
+# name is mail-persistence-preflight, not mail-adapter-persistence.
 PLACEMENT_HELM_ARGS=(
   --set dispatcher.slack.appToken=xapp-placement-render
   --set dispatcher.slack.botToken=xoxb-placement-render
   --set inference.deploy=true
   --set inference.persistence.enabled=true
   --set security.gvisor.mode=require
+  --set mailAdapter.deploy=true
+  --set 'mailAdapter.agentmail.httpsCidrs[0]=203.0.113.0/24'
+  --set mailAdapter.persistence.existingClaim=placement-render-mail-state
+  --set grafanaConnector.enabled=true
 )
 
 PLACEMENT_OUT="$(mktemp -d -p "$TMP")"

--- a/charts/curie/templates/grafana-connector-token.yaml
+++ b/charts/curie/templates/grafana-connector-token.yaml
@@ -88,9 +88,19 @@ spec:
   template:
     metadata:
       labels:
+        {{- with (include "curie.placement.labels" (dict "root" $ "class" "hooks")) }}
+        {{- . | nindent 8 }}
+        {{- end }}
         {{- include "curie.labels" . | nindent 8 }}
         {{- include "curie.selectorLabels" (dict "root" . "component" "grafana-token-updater") | nindent 8 }}
+      {{- with (include "curie.placement.annotations" (dict "root" $ "class" "hooks")) }}
+      annotations:
+        {{- . | nindent 8 }}
+      {{- end }}
     spec:
+      {{- with (include "curie.placement.spec" (dict "root" $ "class" "hooks")) }}
+      {{- . | nindent 6 }}
+      {{- end }}
       serviceAccountName: {{ $hookName }}
       restartPolicy: Never
       securityContext:
@@ -447,9 +457,19 @@ spec:
   template:
     metadata:
       labels:
+        {{- with (include "curie.placement.labels" (dict "root" $ "class" "hooks")) }}
+        {{- . | nindent 8 }}
+        {{- end }}
         {{- include "curie.labels" . | nindent 8 }}
         {{- include "curie.selectorLabels" (dict "root" . "component" "grafana-token-cleanup") | nindent 8 }}
+      {{- with (include "curie.placement.annotations" (dict "root" $ "class" "hooks")) }}
+      annotations:
+        {{- . | nindent 8 }}
+      {{- end }}
     spec:
+      {{- with (include "curie.placement.spec" (dict "root" $ "class" "hooks")) }}
+      {{- . | nindent 6 }}
+      {{- end }}
       automountServiceAccountToken: false
       restartPolicy: Never
       securityContext:

--- a/charts/curie/templates/mail-adapter-persistence.yaml
+++ b/charts/curie/templates/mail-adapter-persistence.yaml
@@ -92,8 +92,18 @@ spec:
   template:
     metadata:
       labels:
+        {{- with (include "curie.placement.labels" (dict "root" $ "class" "hooks")) }}
+        {{- . | nindent 8 }}
+        {{- end }}
         {{- include "curie.selectorLabels" (dict "root" . "component" "mail-persistence-preflight") | nindent 8 }}
+      {{- with (include "curie.placement.annotations" (dict "root" $ "class" "hooks")) }}
+      annotations:
+        {{- . | nindent 8 }}
+      {{- end }}
     spec:
+      {{- with (include "curie.placement.spec" (dict "root" $ "class" "hooks")) }}
+      {{- . | nindent 6 }}
+      {{- end }}
       serviceAccountName: {{ include "curie.fullname" . }}-mail-persistence-preflight
       automountServiceAccountToken: false
       restartPolicy: Never

--- a/charts/curie/templates/mail-adapter.yaml
+++ b/charts/curie/templates/mail-adapter.yaml
@@ -203,11 +203,20 @@ spec:
   template:
     metadata:
       annotations:
+        {{- with (include "curie.placement.annotations" (dict "root" $ "class" "platform")) }}
+        {{- . | nindent 8 }}
+        {{- end }}
         checksum/mail-adapter-credentials: {{ $credentialChecksumSources | toJson | sha256sum }}
       labels:
+        {{- with (include "curie.placement.labels" (dict "root" $ "class" "platform")) }}
+        {{- . | nindent 8 }}
+        {{- end }}
         {{- include "curie.labels" . | nindent 8 }}
         {{- include "curie.selectorLabels" (dict "root" . "component" "mail-adapter") | nindent 8 }}
     spec:
+      {{- with (include "curie.placement.spec" (dict "root" $ "class" "platform")) }}
+      {{- . | nindent 6 }}
+      {{- end }}
       automountServiceAccountToken: false
       securityContext:
         {{- toYaml .Values.mailAdapter.podSecurityContext | nindent 8 }}


### PR DESCRIPTION
## Summary

`curie.placement.spec` / `.labels` / `.annotations` now reach the mail-adapter Deployment (class `platform`) and the three hook Jobs that skipped them: grafana token updater, grafana token cleanup, and mail persistence preflight (class `hooks`). The placement render assertion enables those conditional surfaces and lists them in the expected inventory so the unclassified-surface arm covers them.

## Related issue

Closes #2326

## Fix pin verification

Fix pin: charts/curie/ci/render-assertions.sh

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | Does not reach plugin packaging, the runner turn loop, ACI events, or skill eval/check. | | |
| local | n/a | Does not reach compose services, dispatcher, worker, API wiring, or the console UI. | | |
| local-release | n/a | Does not change released binary identity, the install path, version pins, or release compose. | | |
| cluster | required | Chart templates for the mail-adapter Deployment and three hook Jobs, plus the placement render assertion that inventories those surfaces. | fake | Commit `ef3e0b64701d38543e3916d47a5b544a788d81a2`. `bash charts/curie/ci/render-assertions.sh` printed `ok: all 29 pod surfaces carry their exact populated placement class`. A populated `placement.platform`/`placement.hooks` render with `mailAdapter.deploy=true` and `grafanaConnector.enabled=true` showed `nodeSelector={'example.com/node-class': 'platform'}` on `placement-render-curie-mail-adapter` and `hooks` on the three Jobs. `helm lint charts/curie` printed `1 chart(s) linted, 0 chart(s) failed`. `curie dev verify-fix-pin HEAD charts/curie/ci/render-assertions.sh` printed `PINNED`. |
| live provider | n/a | Does not reach model routing, credential resolution, or token accounting. | | |
| external integration | n/a | Does not reach Slack, git webhooks, connector OAuth, or third-party API shape. | | |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

Negatives from the same commit:

- The same helm template without `mailAdapter.deploy` / `grafanaConnector.enabled` renders none of the four surfaces.
- Reversing the three templates while keeping the assertion change fails placement assertion 1 on `placement-render-curie-mail-adapter` (`PINNED`).
- `bash charts/curie/ci/mail-adapter-wiring-assertions.sh` still printed `OK: mail-adapter chart wiring and build-path render assertions passed (20 assertions)`.

`curie dev chart-runtime-e2e` is not the proof for this AC: the criterion is the rendered `nodeSelector` / `tolerations` on those four surfaces, which helm template and `render-assertions.sh` observe. A live cluster with `placement.platform` populated would refuse to schedule on unlabeled nodes.

## Conservative defaults

- The issue named the persistence Job `-mail-adapter-persistence`. The rendered name is `-mail-persistence-preflight`; the expected table uses that name so the check matches the Job.
- The issue did not name `mailAdapter.persistence.existingClaim`. The preflight Job only renders when that claim is set, so the placement args set `existingClaim=placement-render-mail-state` to make the fourth expected row exist.
- The required AgentMail CIDR is `203.0.113.0/24` (TEST-NET-3), the same placeholder `mail-adapter-wiring-assertions.sh` already uses.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [x] An ADR is added under `docs/adr/` if this is an architectural decision.
