### PR TITLE
Correct chart docs that undercount preflights, credentials, and footprint

### DIFF
--- a/charts/curie/CLAUDE.md
+++ b/charts/curie/CLAUDE.md
@@ -211,7 +211,7 @@ Cluster verification (a disposable local cluster, `kind` or `k3s`):
 helm install curie-dev charts/curie -n curie-dev --create-namespace \
   -f charts/curie/values-dev.yaml
 kubectl get pods -n curie-dev -w
-helm test curie-dev -n curie-dev                              # re-runs both preflights + the security probe suite
+helm test curie-dev -n curie-dev                              # re-runs the three preflights + the security probe suite
 kubectl logs -n curie-dev job/curie-dev-preflight-avx
 kubectl logs -n curie-dev job/curie-dev-security-probe        # rails 1, 2, 4
 kubectl logs -n curie-dev curie-dev-security-probe-hardening  # rail 3

--- a/charts/curie/Chart.yaml
+++ b/charts/curie/Chart.yaml
@@ -6,6 +6,7 @@ description: >-
   and RustFS backing stores, and the OTel Collector that adapts app traces into
   Langfuse. Every backing store is condition-gated with a bring-your-own block.
   A CPU-AVX / ClickHouse-pin check runs as a blocking pre-install, pre-upgrade
+  hook; a controller-ready check runs as a blocking post-install, post-upgrade
   hook; a NetworkPolicy-enforcement probe ships as a helm test that must be run
   explicitly.
 type: application

--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -3,7 +3,7 @@
 The umbrella Helm chart that installs the whole Curie (Relay) stack on a
 single node. It installs the backing-store stack (Langfuse + Postgres + Valkey +
 ClickHouse + RustFS + OTel Collector, dev profile, BYO (bring-your-own)
-toggles, the two preflights) plus the security rails as chart defaults.
+toggles, the three preflights) plus the security rails as chart defaults.
 
 The chart is a direct port of the proven `compose.dev.yaml` dev stack: same
 images and the same headless-bootstrapped Langfuse dev project. The chart
@@ -513,14 +513,15 @@ authentication and migrations: bad credentials and permanent migration failures
 are terminal there and are not retried by this gate.
 
 Secrets: all credentials are written to one `<release>-secrets` Secret. A sealed
-`helm install` (the default) generates strong random values for all eleven
+`helm install` (the default) generates strong random values for all thirteen
 chart owned credentials: the backing store passwords, Langfuse
-salt/encryptionKey/nextauthSecret, the two Langfuse init credentials, and the
-api/webhook keys. Set `security.allowDevDefaults: true` (values-dev.yaml, i.e.
-`curie cluster up --dev`) to keep the deterministic published defaults for
-dev/CI.
+salt/encryptionKey/nextauthSecret, the two Langfuse init credentials, the
+api/webhook keys, `worker.internalWorkerToken`, and
+`api.approvalChatAttesterSecret`. Set `security.allowDevDefaults: true`
+(values-dev.yaml, i.e. `curie cluster up --dev`) to keep the deterministic
+published defaults for dev/CI.
 
-The nine non init credentials persist through `lookup`, so `helm upgrade`
+The eleven non init credentials persist through `lookup`, so `helm upgrade`
 re-uses them. Their explicit `--set` overrides and per store `existingSecret`
 values take precedence for rotation or recovery. The Langfuse init project
 secret and user password are first boot inputs. A fresh install generates them,
@@ -709,13 +710,17 @@ that is in place, static keys in a Secret remain the supported choice, and they
 are the safer of the two available options rather than a limitation to route
 around.
 
-## The two preflights
+## The three preflights
 
-(a) is a blocking `pre-install,pre-upgrade` hook. (b) is a `helm test` that
-must be run explicitly; it never runs during `helm install`. A green
+The chart ships three default-on preflights under `preflights.*`, plus a
+conditional gVisor RuntimeClass preflight under `security.gvisor` (described
+under the security rails; it is not in this block and does not run on the
+fake-model default). (a) is a blocking `pre-install,pre-upgrade` hook. (b) is
+a `helm test` that must be run explicitly; it never runs during
+`helm install`. (c) is a blocking `post-install,post-upgrade` hook. A green
 `helm install` does not prove NetworkPolicy is enforced, so run
 `helm test <release> -n <ns>` before treating the security rails as live.
-Both are re-runnable via that same `helm test` command.
+All three are re-runnable via that same `helm test` command.
 
 **(a) CPU-AVX / ClickHouse-pin check** (`preflights.avxCheck`). A pre-install /
 pre-upgrade hook Job.
@@ -741,6 +746,26 @@ does a before/after egress check -- reach an external target with no policy
 private ranges stay allowed so the control path survives; the public target is
 denied), retry (expect blocked). It reports `enforcement=true` only if the after
 egress is actually blocked, and `enforcement=false` (fails loudly) otherwise.
+
+**(c) Controller-ready gate** (`preflights.controllerReady`). A post-install /
+post-upgrade hook Job, also re-runnable via `helm test`. Default `enabled:
+true`, gated also on `agentSandbox.controller.deploy` (also default true).
+
+- The vendored agent-sandbox controller runs a cluster-scope NetworkPolicy
+  informer. If its RBAC cannot satisfy that cluster LIST, the manager
+  crash-loops and no SandboxClaim ever binds. The Deployment has no
+  readiness probe, so `rollout status` can pass while the manager still
+  blocks on cache sync. The load-bearing signal is the "Starting workers"
+  log line.
+- The Job fails the Helm operation unless the controller becomes Available
+  and logs "Starting workers" within
+  `preflights.controllerReady.timeoutSeconds` (default 180).
+- An upgrade over a crash-looping controller may need a manual pod delete
+  plus `helm test`, because the hook waits for a healthy controller that
+  never arrives.
+- Skipped when `agentSandbox.controller.deploy: false` (BYO controller) or
+  `preflights.controllerReady.enabled: false`.
+- Read the verdict: `kubectl logs -n <ns> job/<release>-preflight-controller`.
 
 ## Single-node footprint (measured on a disposable single-node k3s cluster, 4 GB / 4 core)
 
@@ -908,12 +933,16 @@ a reachability boundary (namespace-per-tenant compute); the `ResourceQuota` and
 `LimitRange` complete it with a bound on consumption, since nodes are shared
 beneath the namespace and one tenant's sandboxes can otherwise exhaust node
 capacity another tenant's sandboxes depend on. The `ResourceQuota` is scoped
-via `scopeSelector` to the sandbox `PriorityClass` name
-(`resourceQuota.sandboxPriorityClassName`, default `curie-sandbox` -- the
-name ADR-0059 decision 5's `PriorityClass` is expected to define), so it binds
-only sandbox pods and not the control plane or data tier that, in the N=1
-self-host topology, share this same release namespace. The `LimitRange` has no
-scope (Kubernetes does not support one on `LimitRange`) and so applies
+via `scopeSelector` to the sandbox `PriorityClass` name. That name derives
+from `priorityClasses.sandbox.name` when
+`resourceQuota.sandboxPriorityClassName` is empty (the default -- empty
+means derive). Set the override only for a PriorityClass managed outside
+this chart whose name differs from `priorityClasses.sandbox.name`; pinning
+it is what lets a later rename leave the quota scoped to a class nothing
+carries. The quota then binds only sandbox pods and not the control plane
+or data tier that, in the N=1 self-host topology, share this same release
+namespace. The `LimitRange` has no scope (Kubernetes does not support one
+on `LimitRange`) and so applies
 namespace-wide, but ships `default`/`defaultRequest` only -- never `min`/`max`
 -- so it only ever fills a resource dimension a container leaves undeclared
 (today, `ephemeral-storage` everywhere in the chart) and can never reject an
@@ -1314,7 +1343,7 @@ restarts.
 
 The GitHub App key was the first of twelve credential keys read straight from
 `.Values` with no in-chart generation (`charts/curie/templates/secrets.yaml`
-calls these direct passthrough, as opposed to the eleven keys
+calls these direct passthrough, as opposed to the thirteen keys
 `curie.managedSecret` generates and persists). Issue #1759 gave the other
 eleven the same `existingSecret` / `existingSecretKey` escape, one pair per
 key, all winning over their plain value when set:

--- a/charts/curie/templates/NOTES.txt
+++ b/charts/curie/templates/NOTES.txt
@@ -99,6 +99,10 @@ Preflights:
       helm test {{ .Release.Name }} -n {{ .Release.Namespace }}
       kubectl logs -n {{ .Release.Namespace }} job/{{ include "curie.fullname" . }}-netpol-probe
 {{- end }}
+{{- if and .Values.agentSandbox.controller.deploy .Values.preflights.controllerReady.enabled }}
+  - Controller-ready check ran as a post-install hook. Read its verdict:
+      kubectl logs -n {{ .Release.Namespace }} job/{{ include "curie.fullname" . }}-preflight-controller
+{{- end }}
 
 Check rollout:
   kubectl get pods -n {{ .Release.Namespace }} -w

--- a/charts/curie/templates/_helpers.tpl
+++ b/charts/curie/templates/_helpers.tpl
@@ -710,7 +710,7 @@ http://{{ include "curie.fullname" . }}-otel-collector:{{ .Values.otelCollector.
           truthy and ship the published default -- a fail-OPEN regression.
        2. Explicit override: if the operator/CLI supplied a value that differs from
           the published default (`ne value default`), it wins even on `helm
-          upgrade`. For the nine non init credentials, this supports rotation or
+          upgrade`. For the eleven non init credentials, this supports rotation or
           recovery. The Langfuse init credentials are first boot inputs, so an
           upgrade only changes the Secret; it does not rotate Langfuse records.
           The override must sit ahead of the persist branch or an explicit value

--- a/charts/curie/templates/priorityclass.yaml
+++ b/charts/curie/templates/priorityclass.yaml
@@ -40,6 +40,7 @@ globalDefault: false
 description: >-
   ADR-0059 decision 5: Curie sandbox runner pods. Ranked below
   {{ .Values.priorityClasses.platform.name }} for node-pressure eviction; also
-  the scopeSelector handle for the sandbox-namespace ResourceQuota (issue
-  #758) -- keep the two in sync if renamed.
+  the derived scopeSelector handle for the sandbox-namespace ResourceQuota
+  (issue #758). The quota follows this name unless an explicit
+  resourceQuota.sandboxPriorityClassName override is set.
 {{- end }}

--- a/charts/curie/templates/secrets.yaml
+++ b/charts/curie/templates/secrets.yaml
@@ -21,12 +21,12 @@ loudly with CreateContainerConfigError rather than the chart silently emitting
 an empty credential -- the same fail-loud property `otlpAuthHeader` below gets
 from never rendering a value the operator's own Secret would not be read for.
 
-The twelve chart owned credentials (the four backing store passwords, the three
+The thirteen chart owned credentials (the four backing store passwords, the three
 Langfuse app secrets, both init credentials, the API key, approval chat
-attester secret, and webhook key) are
+attester secret, internal worker token, and webhook key) are
 resolved through `curie.managedSecret` (issue #195). A sealed fresh install
 generates a strong random per release; `security.allowDevDefaults=true`
-(values-dev.yaml) instead keeps deterministic published values. The ten
+(values-dev.yaml) instead keeps deterministic published values. The eleven
 non-init credentials re-use persisted values on upgrade, and an explicit
 override supports their rotation and recovery. The Langfuse init credentials
 are first boot inputs: changing them during an upgrade does not rotate records

--- a/charts/curie/values-dev.yaml
+++ b/charts/curie/values-dev.yaml
@@ -3,13 +3,15 @@
 #   helm install curie-dev charts/curie -n curie-dev --create-namespace \
 #     -f charts/curie/values-dev.yaml
 #
-# Sized to fit a ~4 GB / 4-core scratch cluster. Sum of memory
-# requests here is ~1.7 GB, leaving headroom for the kubelet/system and for
-# ClickHouse/Langfuse to burst toward their limits. Everything is single-replica
-# and ClickHouse cluster mode is off. This mirrors compose.dev.yaml (same
-# Langfuse pin; chart ClickHouse default is 25.12 / AVX-required, compose stays
-# 24.8 for SSE4.2-only local hosts) so V1 (compose) and V3 (chart) verify the
-# same application stack.
+# Sized to fit a ~4 GB / 4-core scratch cluster, tightly. Sum of memory
+# requests here is 2496 Mi (~2.44 GiB). That plus a distribution's kubelet
+# and system pods leaves little request headroom on a 4 GB node; ClickHouse
+# and Langfuse bursting toward their limits is the remaining squeeze, which
+# is why the README's measured steady state is ~3.3 GB / ~82% node memory.
+# Everything is single-replica and ClickHouse cluster mode is off. This
+# mirrors compose.dev.yaml (same Langfuse pin; chart ClickHouse default is
+# 25.12 / AVX-required, compose stays 24.8 for SSE4.2-only local hosts) so
+# V1 (compose) and V3 (chart) verify the same application stack.
 
 langfuse:
   web:

--- a/charts/curie/values-e2e-harness.yaml
+++ b/charts/curie/values-e2e-harness.yaml
@@ -10,9 +10,10 @@
 # the #56 credential-isolation fix lives in. It disables every backing store and
 # app service that the bundle-fetch/runner path does not need (langfuse,
 # postgres, valkey, clickhouse, inference, otel collector, api, dispatcher,
-# worker, ui) and both install-time preflights, keeping only RustFS (the bundle
-# store) and the agent-sandbox substrate (the SandboxTemplate whose podTemplate
-# the harness renders into a bound Pod).
+# worker, ui) and the avx and networkpolicy preflights (controllerReady is
+# already gated off by controller.deploy false below), keeping only RustFS
+# (the bundle store) and the agent-sandbox substrate (the SandboxTemplate
+# whose podTemplate the harness renders into a bound Pod).
 #
 # The vendored controller is OFF: the harness builds the bound sandbox Pod
 # directly from the SandboxTemplate.spec.podTemplate, so it never needs the

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -7,10 +7,11 @@
 #     bring-your-own block on the SAME object: to use an external instance, set
 #     `deploy: false` and fill `host` / `port` / `auth` (or `existingSecret`).
 #
-# SIZING: the defaults below carry a modest single-node footprint (sum of memory
-# requests ~1.7 GB) so a bare `helm install` schedules on an 8-16 GB node without
-# any overlay. This is NOT sized for production load -- for production raise every
-# `resources` block and persistence size, supply real secrets (or `existingSecret`),
+# SIZING: the defaults below carry a modest single-node footprint (sum of
+# steady-state memory requests 2512 Mi, ~2.45 GiB) so a bare `helm install`
+# schedules on an 8-16 GB node without any overlay. This is NOT sized for
+# production load -- for production raise every `resources` block and
+# persistence size, supply real secrets (or `existingSecret`),
 # and point the stores at managed services via the BYO blocks. For a laptop / fully
 # offline cluster use `-f values-dev.yaml`, which additionally swaps every image for
 # a locally-built, cluster-imported tag.
@@ -77,9 +78,12 @@ placement:
 #
 # Both names are cluster-scoped (PriorityClass has no namespace), so installing
 # a second curie release into the SAME cluster must override one release's
-# names to avoid an ownership conflict. `sandbox.name` is also the intended
-# `scopeSelector` handle for the sandbox-namespace ResourceQuota (issue #758) --
-# keep the two in sync if you rename it.
+# names to avoid an ownership conflict. The sandbox-namespace ResourceQuota
+# scope derives from `sandbox.name` when `resourceQuota.sandboxPriorityClassName`
+# is empty (the default). Do not pin that override to "keep them in sync" --
+# pinning it is what lets a later rename leave the quota scoped to a class
+# nothing carries. Set the override only for a PriorityClass managed outside
+# this chart.
 # ---------------------------------------------------------------------------
 priorityClasses:
   platform:
@@ -1616,8 +1620,10 @@ ui:
       type: RuntimeDefault
 
 # ---------------------------------------------------------------------------
-# Install-time preflights. Both are Helm hooks that block a broken install, and
-# both are re-runnable via `helm test`.
+# Install-time preflights. (a) AVX is a pre-install/pre-upgrade hook, (b)
+# NetworkPolicy is a helm test that never runs during helm install, and (c)
+# controllerReady is a post-install/post-upgrade hook. All three are
+# re-runnable via `helm test`.
 # ---------------------------------------------------------------------------
 preflights:
   # (a) CPU-AVX / ClickHouse-pin check. Runs as a pre-install/pre-upgrade hook
@@ -2091,13 +2097,15 @@ security:
   # chart credentials once its design pass lands.)
   checkDefaultCredentials: false
   # Auto-generate per-release chart credentials (issue #195). Default false: a
-  # no-override `helm install` generates strong random values for the eleven
+  # no-override `helm install` generates strong random values for the thirteen
   # chart owned credentials: the backing store passwords, Langfuse
-  # salt/encryptionKey/nextauthSecret, the two init credentials, and the
-  # api/webhook keys. Set true (values-dev.yaml does) for a deterministic dev/CI
-  # render that keeps the published defaults byte-for-byte. The nine non init
-  # credentials persist via `lookup`, so `helm upgrade` re-uses them. Their
-  # explicit `--set` overrides and per store `existingSecret` values support
+  # salt/encryptionKey/nextauthSecret, the two init credentials, the
+  # api/webhook keys, worker.internalWorkerToken, and
+  # api.approvalChatAttesterSecret. Set true (values-dev.yaml does) for a
+  # deterministic dev/CI render that keeps the published defaults
+  # byte-for-byte. The eleven non init credentials persist via `lookup`, so
+  # `helm upgrade` re-uses them. Their explicit `--set` overrides and per
+  # store `existingSecret` values support
   # rotation and recovery. The two Langfuse init credentials are first boot
   # inputs: changing them during an upgrade does not rotate initialized records.
   # Caveat: generation relies on Helm `lookup`, which is empty under client-side


### PR DESCRIPTION
## Summary

Four operator-facing claims in the chart docs were falsified by the templates: the preflight sections named two gates while `preflights.controllerReady` ships default-on as a post-install hook; managed-credential counts said eleven/nine (README) and twelve/ten (`secrets.yaml`) while the template makes thirteen `curie.managedSecret` calls (eleven non-init) and the README list omitted `worker.internalWorkerToken` and `api.approvalChatAttesterSecret`; `resourceQuota.sandboxPriorityClassName` was documented as defaulting to `curie-sandbox` when empty means derive; and both sizing comments said ~1.7 GB when a default render requests 2512 Mi.

This change makes those sentences match a `helm template` of the chart. No values keys, hook annotations, or credential-generation logic changed.

## Related issue

Closes #2322

## Fix pin verification

## End-to-end verification

This change does not alter runtime behavior because it only rewrites operator-facing prose and comments. Templates, values keys, and hook annotations are untouched.

Scoped verification:

- `helm lint charts/curie` - 1 chart linted, 0 failed.
- Default `helm template` steady-state container memory requests: 2512 Mi (~2.45 GiB) across api, clickhouse, langfuse-web, langfuse-worker, otel-collector, postgres, runner-prewarm, rustfs, ui, valkey, worker. `values-dev.yaml` render: 2496 Mi (~2.44 GiB); the overlay turns the sandbox off so prewarm is absent.
- NOTES.txt rendered through `tpl` (helm template does not emit notes) lists the controller-ready check as a post-install hook and `job/<release>-preflight-controller`. Negative: `--set agentSandbox.controller.deploy=false` omits that line while AVX and NetworkPolicy remain.
- `secrets.yaml` still has thirteen `curie.managedSecret` includes, including `internalWorkerToken` and `approvalChatAttesterSecret`.
- `bash scripts/check-docs.sh` - OK, catalog drift-free.
- `bash charts/curie/ci/render-assertions.sh` - PASS, including Assertion 15 (NOTES image refs).

## Conservative defaults

- Also corrected the same false counts and "two preflights" / "keep the two in sync" wording in `values.yaml` (`allowDevDefaults` comment), `_helpers.tpl`, the Chart.yaml description, `CLAUDE.md`'s `helm test` comment, the `values-e2e-harness.yaml` overlay comment, and the sandbox PriorityClass description. The ticket named README, secrets.yaml, values.yaml:82, NOTES, and the two sizing comments; these are the same defect class on adjacent operator-facing surfaces.
- Left `charts/curie/ci/render-assertions.sh` `KEYS` at twelve, still omitting `internalWorkerToken`. That is a test-coverage gap, not an operator-facing claim. Adding the thirteenth key would be a new assertion, outside this docs ticket.
- `values-dev.yaml` uses 2496 Mi, not 2512 Mi, because that overlay disables the sandbox substrate (no runner-prewarm). Each sizing comment matches its own render.
- Did not bump the chart version.

## Checklist

- [x] Tests pass for the area I touched (`helm lint charts/curie`, `charts/curie/ci/render-assertions.sh`, `scripts/check-docs.sh`).
- [x] Docs updated if behavior changed (this change is the docs).
- [ ] An ADR is added under `docs/adr/` if this is an architectural decision.
