### PR TITLE
Pin first-party image bases to a version plus digest

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,4 @@
-# Dependabot keeps the four dependency ecosystems in this repo current. Grouped
+# Dependabot keeps the five dependency ecosystems in this repo current. Grouped
 # into one PR per ecosystem per week to keep the update volume reviewable.
 version: 2
 updates:
@@ -47,3 +47,23 @@ updates:
     ignore:
       - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]
+
+  # First-party image bases. Each FROM is pinned to a version plus digest
+  # (#2320); this ecosystem raises the bumps as reviewable PRs so a nightly
+  # ladder rebuild does not silently pick up a new base. Directories are the
+  # product Dockerfiles only; `/` would also scan compose and chart image
+  # refs that #2319 tracks separately.
+  - package-ecosystem: docker
+    directories:
+      - /apps/api
+      - /apps/dispatcher
+      - /apps/mail-adapter
+      - /apps/ui
+      - /apps/worker
+      - /adapters/discord
+      - /runner
+    schedule:
+      interval: weekly
+    groups:
+      docker:
+        patterns: ["*"]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -141,8 +141,8 @@ admins maintain (issue #632).
   workflow runs `cargo audit` (Rust), `pip-audit` (the uv/Python workspace), and
   `pnpm audit` (the `apps/ui` JavaScript workspace) as advisory checks.
 - **CodeQL** static analysis over the Python and JavaScript/TypeScript code.
-- **Dependabot** keeps the four ecosystems (GitHub Actions, Cargo, uv, npm)
-  current through grouped weekly PRs (`.github/dependabot.yml`).
+- **Dependabot** keeps the five ecosystems (GitHub Actions, Cargo, uv, npm,
+  Docker) current through grouped weekly PRs (`.github/dependabot.yml`).
 - **Third-party actions and scanner images on sensitive workflows are pinned to
   immutable revisions** — a commit SHA for actions, a digest for images;
   first-party `actions/*` are referenced by major-version tag.

--- a/adapters/discord/Dockerfile
+++ b/adapters/discord/Dockerfile
@@ -1,13 +1,13 @@
 # Build from the repository root:
 # docker build -f adapters/discord/Dockerfile -t curie-discord-adapter .
-FROM python:3.13-slim AS builder
+FROM python:3.13.15-slim@sha256:9d2e5553305c7c7b0097999bb17187c69b921ccd6bc9d40e4bb5ebe652c00285 AS builder
 RUN pip install --no-cache-dir uv==0.10.7
 WORKDIR /app
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy UV_PYTHON_DOWNLOADS=never
 COPY . .
 RUN uv sync --frozen --no-dev --no-editable --package curie-discord-adapter
 
-FROM python:3.13-slim
+FROM python:3.13.15-slim@sha256:9d2e5553305c7c7b0097999bb17187c69b921ccd6bc9d40e4bb5ebe652c00285
 RUN groupadd -g 1000 app && useradd -u 1000 -g app -m -d /home/app app
 WORKDIR /app
 COPY --from=builder --chown=app:app /app/.venv /app/.venv

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -12,7 +12,7 @@
 # `curie-api` member (and only its deps) as non-editable wheels into /app/.venv;
 # the runtime carries just that venv plus the Alembic migration tree so the chart
 # can run `alembic upgrade head` from the same image.
-FROM python:3.13-slim AS builder
+FROM python:3.13.15-slim@sha256:9d2e5553305c7c7b0097999bb17187c69b921ccd6bc9d40e4bb5ebe652c00285 AS builder
 RUN pip install --no-cache-dir uv==0.10.7
 WORKDIR /app
 ENV UV_COMPILE_BYTECODE=1 \
@@ -21,7 +21,7 @@ ENV UV_COMPILE_BYTECODE=1 \
 COPY . .
 RUN uv sync --frozen --no-dev --no-editable --package curie-api
 
-FROM python:3.13-slim
+FROM python:3.13.15-slim@sha256:9d2e5553305c7c7b0097999bb17187c69b921ccd6bc9d40e4bb5ebe652c00285
 # git is a RUNTIME dependency: the git-flow engine (gitflow.py) shells out to
 # `git clone --mirror` / `git archive` to build a bundle from a pushed sha. The
 # slim base does not ship it, so without this a push webhook fails

--- a/apps/dispatcher/Dockerfile
+++ b/apps/dispatcher/Dockerfile
@@ -8,7 +8,7 @@
 # Socket Mode means no inbound HTTP: the process dials Slack out, so there is no
 # server port. The chart uses a heartbeat-file exec liveness probe (a daemon
 # thread touches a file the probe checks for freshness), not an HTTP probe.
-FROM python:3.13-slim AS builder
+FROM python:3.13.15-slim@sha256:9d2e5553305c7c7b0097999bb17187c69b921ccd6bc9d40e4bb5ebe652c00285 AS builder
 RUN pip install --no-cache-dir uv==0.10.7
 WORKDIR /app
 ENV UV_COMPILE_BYTECODE=1 \
@@ -17,7 +17,7 @@ ENV UV_COMPILE_BYTECODE=1 \
 COPY . .
 RUN uv sync --frozen --no-dev --no-editable --package curie-dispatcher
 
-FROM python:3.13-slim
+FROM python:3.13.15-slim@sha256:9d2e5553305c7c7b0097999bb17187c69b921ccd6bc9d40e4bb5ebe652c00285
 RUN groupadd -g 1000 app && useradd -u 1000 -g app -m -d /home/app app
 WORKDIR /app
 COPY --from=builder --chown=app:app /app/.venv /app/.venv

--- a/apps/mail-adapter/Dockerfile
+++ b/apps/mail-adapter/Dockerfile
@@ -8,7 +8,7 @@
 # Unlike the dispatcher this process serves inbound HTTP (the neutral reply wire
 # plus /healthz on CURIE_MAIL_PORT), so the chart gives it an HTTP liveness probe
 # rather than a heartbeat-file exec probe.
-FROM python:3.13-slim AS builder
+FROM python:3.13.15-slim@sha256:9d2e5553305c7c7b0097999bb17187c69b921ccd6bc9d40e4bb5ebe652c00285 AS builder
 RUN pip install --no-cache-dir uv==0.10.7
 WORKDIR /app
 ENV UV_COMPILE_BYTECODE=1 \
@@ -17,7 +17,7 @@ ENV UV_COMPILE_BYTECODE=1 \
 COPY . .
 RUN uv sync --frozen --no-dev --no-editable --package curie-mail-adapter
 
-FROM python:3.13-slim
+FROM python:3.13.15-slim@sha256:9d2e5553305c7c7b0097999bb17187c69b921ccd6bc9d40e4bb5ebe652c00285
 RUN groupadd -g 1000 app && useradd -u 1000 -g app -m -d /home/app app
 WORKDIR /app
 COPY --from=builder --chown=app:app /app/.venv /app/.venv

--- a/apps/ui/Dockerfile
+++ b/apps/ui/Dockerfile
@@ -11,7 +11,7 @@
 # apps/ui/Dockerfile.dockerignore (BuildKit honors <dockerfile>.dockerignore over
 # the context-root one) trims the root context to the UI plus that one
 # cross-package tree.
-FROM node:22-slim AS build
+FROM node:22.23.2-slim@sha256:83f487e0a63425e5b4d146fb5e5be574bcbe1b7b843d3ebafdd95eaf7767a7e5 AS build
 WORKDIR /app
 # Pin pnpm explicitly: package.json has no packageManager field, so corepack
 # would otherwise pull whatever pnpm is latest. pnpm 10+ turns a dependency with
@@ -32,7 +32,7 @@ COPY apps/ui ./apps/ui
 WORKDIR /app/apps/ui
 RUN pnpm build
 
-FROM nginxinc/nginx-unprivileged:1.27-alpine
+FROM nginxinc/nginx-unprivileged:1.27.5-alpine@sha256:65e3e85dbaed8ba248841d9d58a899b6197106c23cb0ff1a132b7bfe0547e4c0
 # Only CURIE_API_TARGET is substituted; nginx's own $vars are left intact.
 ENV CURIE_API_TARGET=http://curie-api:8000 \
     NGINX_ENVSUBST_FILTER=CURIE_API_TARGET

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -7,7 +7,7 @@
 #
 # The worker drives the Kubernetes API to claim/manage sandboxes, so its
 # Deployment carries a ServiceAccount + RBAC (see the chart). No inbound HTTP.
-FROM python:3.13-slim AS builder
+FROM python:3.13.15-slim@sha256:9d2e5553305c7c7b0097999bb17187c69b921ccd6bc9d40e4bb5ebe652c00285 AS builder
 RUN pip install --no-cache-dir uv==0.10.7
 WORKDIR /app
 ENV UV_COMPILE_BYTECODE=1 \
@@ -16,7 +16,7 @@ ENV UV_COMPILE_BYTECODE=1 \
 COPY . .
 RUN uv sync --frozen --no-dev --no-editable --package curie-worker
 
-FROM python:3.13-slim
+FROM python:3.13.15-slim@sha256:9d2e5553305c7c7b0097999bb17187c69b921ccd6bc9d40e4bb5ebe652c00285
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git ca-certificates \
     && rm -rf /var/lib/apt/lists/* \

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -17,12 +17,15 @@
 # everyone on 2026-07-27, which broke every runner-image build repo-wide: curl
 # failed, nodejs never installed, and the next line died with `npm: not found`.
 # Copying from the official image removes the third-party apt repo from the build
-# path entirely, pins the version by tag, and is architecture-correct by
-# construction (Docker resolves the matching platform, so an arm64 dev box and an
-# amd64 CI runner both work -- a hardcoded tarball URL would not).
-FROM node:22-bookworm-slim AS node
+# path entirely, pins the version by tag plus digest so a rebuild at this commit
+# is the same image (#2320), and is architecture-correct by construction (Docker
+# resolves the matching platform from the multi-arch index, so an arm64 dev box
+# and an amd64 CI runner both work -- a hardcoded tarball URL would not).
+# Floating tags would still pick up upstream OS security patches without a
+# commit; Dependabot's docker ecosystem raises those base moves as PRs instead.
+FROM node:22.23.2-bookworm-slim@sha256:83f487e0a63425e5b4d146fb5e5be574bcbe1b7b843d3ebafdd95eaf7767a7e5 AS node
 
-FROM python:3.13-slim-bookworm
+FROM python:3.13.15-slim-bookworm@sha256:ed86c82274b3c69b52fb5820f358f0bd7df0b603332063cb5c6e32bd220c3e6e
 
 # Only the Node bits, never all of /usr/local: the python base keeps its own
 # interpreter there, so a blanket copy would clobber it.

--- a/runner/tests/test_dockerfile_base_pins.py
+++ b/runner/tests/test_dockerfile_base_pins.py
@@ -1,0 +1,150 @@
+"""First-party image bases must be a full version plus digest (#2320).
+
+A floating tag (`python:3.13-slim`, `node:22-slim`) moves under a rebuild
+with no commit, so a nightly ladder grade change or a contributor
+`curie build` can disagree with CI at the same sha. The pin is the FROM
+line itself; Dependabot's docker ecosystem is how a base move becomes a
+reviewable PR instead of a silent rebuild.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Shipped first-party images plus the other first-party product Dockerfiles
+# that share the same floating-tag shape. Examples, prototypes, and test
+# fixtures are out of scope: they are not in the release matrix.
+FIRST_PARTY_DOCKERFILES = (
+    "apps/api/Dockerfile",
+    "apps/dispatcher/Dockerfile",
+    "apps/mail-adapter/Dockerfile",
+    "apps/ui/Dockerfile",
+    "apps/worker/Dockerfile",
+    "adapters/discord/Dockerfile",
+    "runner/Dockerfile",
+)
+
+_FROM = re.compile(
+    r"^FROM\s+(?:--platform=\S+\s+)?(?P<image>\S+)(?:\s+AS\s+\S+)?\s*$",
+    re.IGNORECASE,
+)
+_PINNED = re.compile(
+    r"^[^:@\s]+(?::[^@\s]*\d+\.\d+\.\d+[^@\s]*)?@sha256:[0-9a-f]{64}$",
+    re.IGNORECASE,
+)
+_FULL_VERSION = re.compile(r"\d+\.\d+\.\d+")
+_DIGEST = re.compile(r"@sha256:[0-9a-f]{64}$", re.IGNORECASE)
+
+
+def _logical_instructions(dockerfile_text: str) -> list[str]:
+    instructions: list[str] = []
+    pending: list[str] = []
+    for raw_line in dockerfile_text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        continues = line.endswith("\\")
+        pending.append(line[:-1].rstrip() if continues else line)
+        if not continues:
+            instructions.append(" ".join(pending))
+            pending = []
+    assert not pending, "Dockerfile ends with an unfinished continuation"
+    return instructions
+
+
+def _from_images(dockerfile_text: str) -> list[str]:
+    images: list[str] = []
+    for instruction in _logical_instructions(dockerfile_text):
+        match = _FROM.fullmatch(instruction)
+        if match is None:
+            continue
+        image = match.group("image")
+        if image == "scratch" or image.startswith("$") or "${" in image:
+            continue
+        images.append(image)
+    return images
+
+
+def _pin_error(image: str) -> str | None:
+    """Return a reason the FROM ref is not a full version plus digest."""
+    if _PINNED.fullmatch(image) and _FULL_VERSION.search(image.split("@", 1)[0]):
+        return None
+    if _DIGEST.search(image) is None:
+        return "missing sha256 digest"
+    if _FULL_VERSION.search(image.split("@", 1)[0]) is None:
+        return "tag is not a full x.y.z version"
+    return "FROM is not pinned to a version plus digest"
+
+
+def test_pin_parser_accepts_version_plus_digest() -> None:
+    assert (
+        _pin_error(
+            "python:3.13.15-slim@sha256:"
+            "9d2e5553305c7c7b0097999bb17187c69b921ccd6bc9d40e4bb5ebe652c00285"
+        )
+        is None
+    )
+
+
+def test_pin_parser_rejects_floating_tag() -> None:
+    assert _pin_error("python:3.13-slim") == "missing sha256 digest"
+
+
+def test_pin_parser_rejects_version_without_digest() -> None:
+    assert _pin_error("python:3.13.15-slim") == "missing sha256 digest"
+
+
+def test_pin_parser_rejects_digest_on_floating_minor() -> None:
+    digest = "sha256:9d2e5553305c7c7b0097999bb17187c69b921ccd6bc9d40e4bb5ebe652c00285"
+    assert _pin_error(f"python:3.13-slim@{digest}") == "tag is not a full x.y.z version"
+
+
+def test_first_party_dockerfiles_pin_from_to_version_and_digest() -> None:
+    failures: list[str] = []
+    for relative in FIRST_PARTY_DOCKERFILES:
+        path = _REPO_ROOT / relative
+        images = _from_images(path.read_text(encoding="utf-8"))
+        assert images, f"{relative} has no FROM images to pin"
+        for image in images:
+            error = _pin_error(image)
+            if error is not None:
+                failures.append(f"{relative}: FROM {image}: {error}")
+    assert failures == []
+
+
+def test_floating_from_in_a_first_party_dockerfile_is_rejected() -> None:
+    dockerfile = (_REPO_ROOT / "runner" / "Dockerfile").read_text(encoding="utf-8")
+    mutated = "FROM python:3.13-slim AS node\n" + dockerfile
+    errors = [_pin_error(image) for image in _from_images(mutated)]
+    assert "missing sha256 digest" in errors
+
+
+def _dependabot_ecosystem_blocks(text: str) -> dict[str, str]:
+    parts = re.split(r"(?m)^  - package-ecosystem:\s*", text)
+    blocks: dict[str, str] = {}
+    for part in parts[1:]:
+        first, _, rest = part.partition("\n")
+        name = first.strip()
+        assert name not in blocks, f"duplicate dependabot ecosystem {name}"
+        blocks[name] = rest
+    return blocks
+
+
+def test_dependabot_watches_first_party_docker_directories() -> None:
+    text = (_REPO_ROOT / ".github" / "dependabot.yml").read_text(encoding="utf-8")
+    blocks = _dependabot_ecosystem_blocks(text)
+    assert "docker" in blocks, (
+        "dependabot.yml must configure the docker ecosystem so base bumps arrive as reviewable PRs"
+    )
+    docker_block = blocks["docker"]
+    missing = [
+        directory
+        for directory in sorted(
+            {f"/{Path(relative).parent.as_posix()}" for relative in FIRST_PARTY_DOCKERFILES}
+        )
+        if directory not in docker_block
+    ]
+    assert missing == []


### PR DESCRIPTION
## Summary

Pin every first-party product image `FROM` to a full x.y.z tag plus its multi-arch index digest, and add Dependabot's docker ecosystem so base moves arrive as weekly reviewable PRs instead of silent nightly-ladder or contributor rebuilds.

`python:3.13-slim` currently resolves to Debian trixie (`3.13.15-slim`). This PR pins that current target rather than retargeting those images to bookworm. The runner already names bookworm explicitly and stays on `python:3.13.15-slim-bookworm`.

## Related issue

Closes #2320

## Fix pin verification

Fix pin: runner/tests/test_dockerfile_base_pins.py::test_first_party_dockerfiles_pin_from_to_version_and_digest

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | Does not reach plugin packaging, the runner turn loop, ACI events, or skill eval | | |
| local | required | First-party Dockerfiles are what `curie build` and `curie local up --build` produce; the acceptance criterion is that those images still build | fake | `docker build -f apps/api/Dockerfile -t curie-2320-api .` (and dispatcher, mail-adapter, worker, discord, ui, runner) at 7f0926e8. Observed `ALL_OK 2026-09-04T16:27:35Z`. API resolve line: `FROM docker.io/library/python:3.13.15-slim@sha256:9d2e5553305c7c7b0097999bb17187c69b921ccd6bc9d40e4bb5ebe652c00285`. Negative: `uv run pytest runner/tests/test_dockerfile_base_pins.py` rejects `FROM python:3.13-slim`; `bash cli/scripts/verify-fix-pin.sh HEAD runner/tests/test_dockerfile_base_pins.py::test_first_party_dockerfiles_pin_from_to_version_and_digest` printed `PINNED` after the reversed Dockerfiles went red. Images were `docker rmi`'d after the builds. |
| local-release | n/a | Does not change released binary identity, the install path, or the release compose | | |
| cluster | n/a | Chart templates, RBAC, sandbox claims, and init containers are unchanged | | |
| live provider | n/a | Does not reach model routing, credential resolution, or token accounting | | |
| external integration | n/a | Does not reach Slack, git webhooks, or third-party API shapes | | |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

## Conservative defaults

- Also pinned `apps/mail-adapter` and `adapters/discord` (first-party product Dockerfiles listed in the issue evidence). Discord is not in the release matrix; leaving it floating would keep the same defect on a sibling path.
- Left examples, prototypes, and test-fixture Dockerfiles floating. They are not first-party shipped images.
- Dependabot docker watches only those Dockerfile directories. A root `/` entry would also scan compose and chart image refs, which #2319 tracks separately.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [ ] An ADR is added under `docs/adr/` if this is an architectural decision.
