### PR TITLE
Point the UI API upstream through curie.api.url

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -375,9 +375,12 @@ jobs:
           bash charts/curie/ci/sandbox-emptydir-sizelimit-assertions.sh
 
       # Prove the dispatcher is told where the platform API is and how to
-      # authenticate to it (issue #442). Unwired, it falls back to its code
-      # default http://localhost:8000 -- itself -- and every Slack Approve click
-      # dead-ends with only a warning.
+      # authenticate to it (issue #442), and that the UI's CURIE_API_TARGET
+      # uses the same helper (issue #2316). Unwired, the dispatcher falls back
+      # to its code default http://localhost:8000 -- itself -- and every Slack
+      # Approve click dead-ends with only a warning. An unwired UI stays Ready
+      # while every /api/ request fails at the proxy, so api.deploy=false with
+      # an empty ui.apiBaseUrl must fail the render closed.
       - name: helm render assertions (dispatcher API wiring)
         run: |
           set -euo pipefail

--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -126,6 +126,7 @@ helm upgrade curie charts/curie -n curie --reuse-values \
 | Value | Default | Meaning |
 | --- | --- | --- |
 | `dispatcher.apiBaseUrl` | `""` | Empty derives the in-chart API Service. A set value is used verbatim (BYO), and is **required** when `api.deploy: false`, where no in-chart Service exists to derive from. |
+| `ui.apiBaseUrl` | `""` | Empty derives the in-chart API Service for the UI's `CURIE_API_TARGET` nginx upstream. A set value is used verbatim (BYO). **Required** when `api.deploy: false` and `ui.deploy` is true: the UI's probes hit nginx `/` rather than the upstream, so an empty override fails the render closed instead of shipping a Ready UI that fails every `/api/` request. |
 | `dispatcher.apiPreflightTimeoutSeconds` | `120` | Bounded time for API `/health`, followed by a fresh same-size discovery-and-Slack budget. The bare dispatcher default remains 30 seconds. |
 | `dispatcher.startupProbe.initialDelaySeconds` | `0` | Delay before Kubernetes begins the dispatcher heartbeat startup probe. |
 | `dispatcher.startupProbe.periodSeconds` | `10` | Interval between dispatcher startup probes. |

--- a/charts/curie/ci/dispatcher-api-wiring-assertions.sh
+++ b/charts/curie/ci/dispatcher-api-wiring-assertions.sh
@@ -1,10 +1,14 @@
 #!/usr/bin/env bash
 #
-# Render-assertion test for the dispatcher's platform-API wiring (#442). Proves,
-# with `helm template` alone (no cluster), that the dispatcher Deployment is told
-# where the API is and how to authenticate to it. Unwired, the dispatcher falls
-# back to its code default http://localhost:8000, which inside its own pod is the
-# dispatcher itself, and every Slack Approve click dead-ends with only a warning.
+# Render-assertion test for the dispatcher's platform-API wiring (#442) and the
+# UI's API upstream (#2316). Proves, with `helm template` alone (no cluster),
+# that the dispatcher Deployment is told where the API is and how to authenticate
+# to it, and that the UI's nginx CURIE_API_TARGET uses the same helper. Unwired,
+# the dispatcher falls back to its code default http://localhost:8000, which
+# inside its own pod is the dispatcher itself, and every Slack Approve click
+# dead-ends with only a warning. The UI's probes hit nginx `/` rather than the
+# upstream, so an unwired BYO install stays Ready while every /api/ request
+# fails at the proxy -- that path must fail the render closed.
 #
 #   1. Default install renders CURIE_API_URL as the in-chart API Service
 #      (http://<fullname>-api:<api.service.port>), asserted as a VALUE.
@@ -20,6 +24,12 @@
 #      The existing readiness/liveness probes remain unchanged, including on the
 #      worker, which must not receive a startup probe.
 #   7. A token-less install still renders no dispatcher at all (unchanged gate).
+#   8. Default install renders the UI's CURIE_API_TARGET as the in-chart API
+#      Service; the port tracks .Values.api.service.port.
+#   9. ui.apiBaseUrl overrides CURIE_API_TARGET verbatim when api.deploy=false
+#      (the BYO path). An empty override with api.deploy=false fails the render
+#      and names ui.apiBaseUrl. ui.deploy=false still renders the rest of the
+#      chart without that override.
 #
 # NOTE ON `--output-dir`: the sibling scripts in this directory capture
 # `helm template` through command substitution. Do NOT copy that here, and do not
@@ -60,6 +70,19 @@ render_dispatcher() {
   helm template curie "$CHART" --output-dir "$out" "$@" >/dev/null
   local manifest="$out/curie/templates/dispatcher.yaml"
   [ -f "$manifest" ] || fail "$name: dispatcher.yaml did not render at all"
+  echo "$manifest"
+}
+
+# Same --output-dir convention for the UI Deployment. Do not capture helm
+# template through a pipe; see the header note.
+render_ui() {
+  local name="$1"
+  shift
+  local out="$TMP/$name"
+  mkdir -p "$out"
+  helm template curie "$CHART" --output-dir "$out" "$@" >/dev/null
+  local manifest="$out/curie/templates/ui.yaml"
+  [ -f "$manifest" ] || fail "$name: ui.yaml did not render at all"
   echo "$manifest"
 }
 
@@ -357,4 +380,51 @@ if [ -f "$out/curie/templates/dispatcher.yaml" ]; then
   fail "a token-less default install rendered a dispatcher Deployment; the curie.dispatcher.enabled gate regressed"
 fi
 
-echo "OK: dispatcher platform-API wiring and delayed-readiness render assertions passed"
+# 8: default install renders the UI's CURIE_API_TARGET as the in-chart API
+# Service, and the port comes from .Values.api.service.port. Reuses assertion
+# 1's default render -- the arguments are identical.
+default_ui_manifest="$TMP/default/curie/templates/ui.yaml"
+[ -f "$default_ui_manifest" ] \
+  || fail "default install: ui.yaml did not render"
+actual="$(env_value "$default_ui_manifest" CURIE_API_TARGET)"
+[ -n "$actual" ] \
+  || fail "default install: UI has no CURIE_API_TARGET env value; nginx will proxy /api/ to the image default"
+[ "$actual" = "http://curie-api:8000" ] \
+  || fail "default install: UI CURIE_API_TARGET is '$actual', expected 'http://curie-api:8000' (the in-chart API Service)"
+
+ui_port_manifest="$(render_ui ui-port --set api.service.port=9999)"
+actual="$(env_value "$ui_port_manifest" CURIE_API_TARGET)"
+[ "$actual" = "http://curie-api:9999" ] \
+  || fail "api.service.port=9999: UI CURIE_API_TARGET is '$actual', expected 'http://curie-api:9999' (the port is hardcoded in the template instead of read from .Values.api.service.port)"
+
+# 9: BYO override renders verbatim on the api.deploy=false path, and an empty
+# override fails the render closed naming ui.apiBaseUrl. ui.deploy=false is the
+# gated-off sibling: the rest of the chart still renders without the override.
+ui_byo_manifest="$(render_ui byo-ui \
+  --set api.deploy=false \
+  --set ui.apiBaseUrl=http://byo-api.example:8080)"
+actual="$(env_value "$ui_byo_manifest" CURIE_API_TARGET)"
+[ "$actual" = "http://byo-api.example:8080" ] \
+  || fail "ui.apiBaseUrl override: CURIE_API_TARGET is '$actual', expected the verbatim override 'http://byo-api.example:8080'"
+
+byo_ui_missing="$TMP/byo-ui-missing"
+mkdir -p "$byo_ui_missing"
+if helm template curie "$CHART" --output-dir "$byo_ui_missing" \
+  --set api.deploy=false \
+  >"$TMP/byo-ui-missing.stdout" 2>"$TMP/byo-ui-missing.stderr"; then
+  fail "api.deploy=false with empty ui.apiBaseUrl rendered; the chart must fail closed naming ui.apiBaseUrl"
+fi
+byo_ui_missing_stderr="$(<"$TMP/byo-ui-missing.stderr")"
+[[ "$byo_ui_missing_stderr" == *"ui.apiBaseUrl"* ]] \
+  || fail "api.deploy=false empty-override render failure did not name ui.apiBaseUrl: $byo_ui_missing_stderr"
+
+ui_off="$TMP/ui-off"
+mkdir -p "$ui_off"
+helm template curie "$CHART" --output-dir "$ui_off" \
+  --set api.deploy=false \
+  --set ui.deploy=false >/dev/null
+if [ -f "$ui_off/curie/templates/ui.yaml" ]; then
+  fail "ui.deploy=false still rendered ui.yaml"
+fi
+
+echo "OK: dispatcher platform-API wiring, delayed-readiness, and UI API-target render assertions passed"

--- a/charts/curie/ci/mail-adapter-wiring-assertions.sh
+++ b/charts/curie/ci/mail-adapter-wiring-assertions.sh
@@ -312,6 +312,7 @@ assert_env_value "$api_port_dir" CURIE_API_URL "http://curie-api:9999" \
   "The port must come from .Values.api.service.port, not a hardcoded 8000."
 byo_api_dir="$(render byo-api "${ON[@]}" "${CREDS[@]}" \
   --set api.deploy=false \
+  --set ui.deploy=false \
   --set mailAdapter.apiBaseUrl=https://byo-api.example:8443 \
   --set 'mailAdapter.apiEgress.httpsCidrs[0]=198.51.100.0/24' \
   --set mailAdapter.apiEgress.port=8443)"
@@ -755,10 +756,12 @@ assert_render_fails_named \
   "mailAdapter.apiEgress.httpsCidrs" \
   "${ON[@]}" "${CREDS[@]}" \
   --set api.deploy=false \
+  --set ui.deploy=false \
   --set mailAdapter.apiBaseUrl=https://byo-api.example:8443
 
 byo_api_default_port_dir="$(render byo-api-default-port "${ON[@]}" "${CREDS[@]}" \
   --set api.deploy=false \
+  --set ui.deploy=false \
   --set mailAdapter.apiBaseUrl=http://byo-api.example:8000 \
   --set 'mailAdapter.apiEgress.httpsCidrs[0]=198.51.100.128/25')"
 
@@ -846,6 +849,7 @@ assert_render_fails_named \
   "mailAdapter.apiEgress.httpsCidrs" \
   "${ON[@]}" "${CREDS[@]}" \
   --set api.deploy=false \
+  --set ui.deploy=false \
   --set mailAdapter.apiBaseUrl=https://byo-api.example:8443 \
   --set-string 'mailAdapter.apiEgress.httpsCidrs[0]=0.0.0.0/1' \
   --set-string 'mailAdapter.apiEgress.httpsCidrs[1]=128.0.0.0/1' \

--- a/charts/curie/ci/render-assertions.sh
+++ b/charts/curie/ci/render-assertions.sh
@@ -819,6 +819,7 @@ python3 "$RUNNER_API_CHECK" "$RUNNER_API_OUT" present \
 RUNNER_API_OFF_OUT="$(mktemp -d -p "$TMP")"
 helm template runner-api-render "$CHART" --namespace runner-api-namespace \
   --set api.deploy=false \
+  --set ui.deploy=false \
   --output-dir "$RUNNER_API_OFF_OUT" > /dev/null
 python3 "$RUNNER_API_CHECK" "$RUNNER_API_OFF_OUT" absent \
   || fail "api.deploy=false did not remove the runner sandbox API egress allowance."
@@ -1476,6 +1477,8 @@ cat > "$WORKER_API_BYO" <<'EOF'
 api:
   deploy: false
 dispatcher:
+  apiBaseUrl: https://byo-api.example
+ui:
   apiBaseUrl: https://byo-api.example
 EOF
 assert_worker_api byo curie https://byo-api.example chart -f "$WORKER_API_BYO"

--- a/charts/curie/ci/worker-ttl-bounds-assertions.sh
+++ b/charts/curie/ci/worker-ttl-bounds-assertions.sh
@@ -431,10 +431,12 @@ assert_env k \
 assert_refused k runnerTotalTimeoutSeconds \
   --set worker.deploy=false \
   --set api.deploy=false \
+  --set ui.deploy=false \
   --set worker.runnerTotalTimeoutSeconds=0
 assert_refused k runnerTotalTimeoutSeconds \
   --set worker.deploy=false \
   --set api.deploy=false \
+  --set ui.deploy=false \
   --set-json worker.runnerTotalTimeoutSeconds=1800.1
 
 # Individually valid scalar values, relationally invalid together. Capture the

--- a/charts/curie/templates/ui.yaml
+++ b/charts/curie/templates/ui.yaml
@@ -1,4 +1,9 @@
 {{- if .Values.ui.deploy }}
+{{- if not .Values.api.deploy }}
+  {{- if not .Values.ui.apiBaseUrl }}
+  {{- fail "api.deploy is false: set ui.apiBaseUrl to the bring-your-own API URL" }}
+  {{- end }}
+{{- end }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -61,9 +66,12 @@ spec:
           {{- end }}
           env:
             # nginx reverse-proxies /api/ to this upstream (the /api prefix is
-            # stripped). Points at the in-chart API Service.
+            # stripped). Empty ui.apiBaseUrl (the default) derives the in-chart
+            # API Service; a set value renders verbatim and is the BYO answer,
+            # and the only correct one when api.deploy is false. Include
+            # curie.api.url, never a copy of its expression.
             - name: CURIE_API_TARGET
-              value: http://{{ include "curie.fullname" . }}-api:{{ .Values.api.service.port }}
+              value: {{ include "curie.api.url" (dict "root" . "baseUrl" .Values.ui.apiBaseUrl) | quote }}
           ports:
             - name: http
               containerPort: 8080

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -1579,6 +1579,14 @@ worker:
 ui:
   deploy: true
   replicas: 1
+  # Platform API the UI's nginx reverse-proxies /api/ to. Empty (the default)
+  # derives the in-chart API Service, http://<fullname>-api:<api.service.port>.
+  # Set it to a full base URL to point at an API this chart did not deploy; that
+  # BYO value renders verbatim as CURIE_API_TARGET. Required when api.deploy is
+  # false: unlike the dispatcher, the UI stays Ready while every /api/ request
+  # fails at the proxy, so the render fails closed rather than shipping a
+  # stranded UI.
+  apiBaseUrl: ""
   image:
     repository: ghcr.io/curie-eng/curie-ui
     # Empty -> chart appVersion (immutable). Set to pin an explicit version tag.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -537,6 +537,8 @@ independently; the chart cannot safely infer IP ranges from a hostname:
 ```yaml
 api:
   deploy: false
+ui:
+  apiBaseUrl: https://api.example.com:8443
 mailAdapter:
   apiBaseUrl: https://api.example.com:8443
   apiEgress:


### PR DESCRIPTION
## Summary

`api.deploy=false` is a supported BYO toggle, but `ui.yaml` still inlined the in-chart API Service for `CURIE_API_TARGET`. The UI pod stayed Ready (probes hit nginx `/`) while every `/api/` request failed at the proxy. Dispatcher and mail-adapter already resolve through `curie.api.url`; this change adds `ui.apiBaseUrl` and uses that same helper.

The conservative default is the mail-adapter shape: when `ui.deploy` is true, `api.deploy` is false, and `ui.apiBaseUrl` is empty, the render fails closed naming `ui.apiBaseUrl`. Silently omitting the UI would hide a misconfigured install. Existing `api.deploy=false` assertion renders that do not exercise the UI now set `ui.deploy=false` or `ui.apiBaseUrl` so they keep isolating their own guards.

## Related issue

Closes #2316

## Fix pin verification

Fix pin: charts/curie/ci/dispatcher-api-wiring-assertions.sh

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | Does not reach plugin or skill packaging, the runner turn loop, ACI events, or skill eval/check. | | |
| local | n/a | Does not reach compose services, dispatcher/worker/API wiring, the console UI, or a `curie` verb whose output, exit code, or `--json` shape changed. | | |
| local-release | n/a | Does not reach released binary or image identity, the install path, version pins, or release compose. | | |
| cluster | required | Chart templates and values: `CURIE_API_TARGET`, `ui.apiBaseUrl`, and the `api.deploy=false` fail-closed render. Ticket AC is `helm template`, not a live cluster exec. | fake | Commit `2c2a8c5a9e57e81d65cd058dbd729620397a21cc`. `helm template curie charts/curie --output-dir <dir> --set api.deploy=false --set ui.apiBaseUrl=https://api.example.net --set dispatcher.apiBaseUrl=https://api.example.net --set mailAdapter.apiBaseUrl=https://api.example.net` rendered `CURIE_API_TARGET=https://api.example.net`. `helm template curie charts/curie --set api.deploy=false` exited 1 with `api.deploy is false: set ui.apiBaseUrl to the bring-your-own API URL`. `bash charts/curie/ci/dispatcher-api-wiring-assertions.sh` passed. `helm lint charts/curie` passed. `curie dev verify-fix-pin HEAD charts/curie/ci/dispatcher-api-wiring-assertions.sh` printed `PINNED`. |
| live provider | n/a | Does not reach model routing, credential resolution, provider auth, or token/cost accounting. | | |
| external integration | n/a | Does not reach Slack, git push webhooks, connector OAuth, or any third-party API shape. | | |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [ ] An ADR is added under `docs/adr/` if this is an architectural decision.
