### PR TITLE
feat: persist Slack thread pull-request lineage

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1690,6 +1690,7 @@ jobs:
           set -euo pipefail
           helm upgrade curie charts/curie -n curie \
             --reset-then-reuse-values --timeout 15m \
+            --set api.migrate.forwardOnly=true \
             --set api.image.repository=curie-api --set api.image.tag=upgrade-candidate --set api.image.digest= --set api.image.pullPolicy=Never \
             --set dispatcher.image.repository=curie-dispatcher --set dispatcher.image.tag=upgrade-candidate --set dispatcher.image.digest= --set dispatcher.image.pullPolicy=Never \
             --set worker.image.repository=curie-worker --set worker.image.tag=upgrade-candidate --set worker.image.digest= --set worker.image.pullPolicy=Never \
@@ -1735,6 +1736,7 @@ jobs:
           set -euo pipefail
           helm upgrade curie charts/curie -n curie \
             --reset-then-reuse-values --timeout 15m \
+            --set api.migrate.forwardOnly=true \
             --set api.image.repository=curie-api --set api.image.tag=upgrade-candidate --set api.image.digest= --set api.image.pullPolicy=Never \
             --set dispatcher.image.repository=curie-dispatcher --set dispatcher.image.tag=upgrade-candidate --set dispatcher.image.digest= --set dispatcher.image.pullPolicy=Never \
             --set worker.image.repository=curie-worker --set worker.image.tag=upgrade-candidate --set worker.image.digest= --set worker.image.pullPolicy=Never \
@@ -1788,6 +1790,7 @@ jobs:
           kubectl delete deploy/curie-worker -n curie --wait=true --timeout=120s
           helm upgrade curie charts/curie -n curie \
             --reset-then-reuse-values --timeout 15m \
+            --set api.migrate.forwardOnly=true \
             --set api.image.repository=curie-api --set api.image.tag=upgrade-candidate --set api.image.digest= --set api.image.pullPolicy=Never \
             --set dispatcher.image.repository=curie-dispatcher --set dispatcher.image.tag=upgrade-candidate --set dispatcher.image.digest= --set dispatcher.image.pullPolicy=Never \
             --set worker.image.repository=curie-worker --set worker.image.tag=upgrade-candidate --set worker.image.digest= --set worker.image.pullPolicy=Never \
@@ -1817,6 +1820,7 @@ jobs:
           set -euo pipefail
           helm upgrade curie charts/curie -n curie \
             --reset-then-reuse-values --timeout 15m \
+            --set api.migrate.forwardOnly=true \
             --set dispatcher.deploy=false \
             --set dispatcher.image.repository=curie-dispatcher --set dispatcher.image.tag=upgrade-candidate --set dispatcher.image.digest= --set dispatcher.image.pullPolicy=Never \
             --set ui.service.type=NodePort --set ui.service.nodePort=30080 \

--- a/apps/api/alembic/versions/0041_publication_lineages.py
+++ b/apps/api/alembic/versions/0041_publication_lineages.py
@@ -1,0 +1,390 @@
+"""Persist thread-owned pull-request publication lineages.
+
+Revision ID: 0041
+Revises: 0040
+Create Date: 2026-09-03
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0041"
+down_revision: str | None = "0040"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+SCHEMA = "curie"
+
+
+def _publication_identity_cte() -> str:
+    """Prefer the durable workspace identity; scope only the legacy fallback."""
+
+    return f"""
+            publication_identities AS (
+                SELECT p.id, p.approval_id, a.agent_id, p.deployment_id,
+                       COALESCE(
+                           p.workspace_conversation_id,
+                           {SCHEMA}._0041_percent_encode(a.reply_kind) || ':' ||
+                           {SCHEMA}._0041_percent_encode(a.reply_channel) || ':' ||
+                           {SCHEMA}._0041_percent_encode(a.conversation_id)
+                       ) AS conversation_id,
+                       p.repo_full_name, p.base_sha, p.status, p.result_url,
+                       p.created_at
+                  FROM {SCHEMA}.publications AS p
+                  JOIN {SCHEMA}.approvals AS a ON a.id = p.approval_id
+                 WHERE p.status IN ('pending', 'approved', 'launching', 'running')
+                    OR (
+                        p.status = 'succeeded'
+                        AND p.result_url =
+                            'https://github.com/' || p.repo_full_name || '/pull/' ||
+                            substring(p.result_url FROM '/pull/([1-9][0-9]*)$')
+                        AND substring(
+                            p.result_url FROM '/pull/([1-9][0-9]*)$'
+                        )::numeric <= 2147483647
+                    )
+            )
+    """
+
+
+def upgrade() -> None:
+    op.create_table(
+        "thread_publication_lineages",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("agent_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("deployment_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("conversation_id", sa.String(), nullable=False),
+        sa.Column("repo_full_name", sa.String(), nullable=False),
+        sa.Column("base_sha", sa.String(), nullable=False),
+        sa.Column("branch", sa.String(), nullable=False),
+        sa.Column("pr_number", sa.Integer(), nullable=True),
+        sa.Column("pr_url", sa.String(), nullable=True),
+        sa.Column("head_sha", sa.String(), nullable=True),
+        sa.Column("status", sa.String(), server_default="open", nullable=False),
+        sa.Column("version", sa.Integer(), server_default="1", nullable=False),
+        sa.Column("latest_revision", sa.Integer(), server_default="1", nullable=False),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.CheckConstraint(
+            "status IN ('open', 'merged', 'closed')",
+            name="thread_publication_lineages_status_ck",
+        ),
+        sa.CheckConstraint(
+            "version >= 1", name="thread_publication_lineages_version_ck"
+        ),
+        sa.CheckConstraint(
+            "latest_revision >= 1",
+            name="thread_publication_lineages_latest_revision_ck",
+        ),
+        sa.CheckConstraint(
+            "(pr_number IS NULL) = (pr_url IS NULL)",
+            name="thread_publication_lineages_pr_identity_ck",
+        ),
+        sa.ForeignKeyConstraint(
+            ["agent_id"], [f"{SCHEMA}.agents.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(
+            ["deployment_id"], [f"{SCHEMA}.deployments.id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "branch", name="thread_publication_lineages_branch_key"
+        ),
+        schema=SCHEMA,
+    )
+    op.create_index(
+        "ix_thread_publication_lineages_agent_id",
+        "thread_publication_lineages",
+        ["agent_id"],
+        schema=SCHEMA,
+    )
+    op.create_index(
+        "ix_thread_publication_lineages_deployment_id",
+        "thread_publication_lineages",
+        ["deployment_id"],
+        schema=SCHEMA,
+    )
+    op.create_index(
+        "ix_thread_publication_lineages_conversation_id",
+        "thread_publication_lineages",
+        ["conversation_id"],
+        schema=SCHEMA,
+    )
+    op.create_index(
+        "uq_active_thread_publication_lineage",
+        "thread_publication_lineages",
+        ["agent_id", "conversation_id", "repo_full_name"],
+        unique=True,
+        schema=SCHEMA,
+        postgresql_where=sa.text("status = 'open'"),
+    )
+
+    op.add_column(
+        "publications",
+        sa.Column("lineage_id", postgresql.UUID(as_uuid=True), nullable=True),
+        schema=SCHEMA,
+    )
+    op.add_column(
+        "publications",
+        sa.Column("revision_number", sa.Integer(), nullable=True),
+        schema=SCHEMA,
+    )
+    op.add_column(
+        "publications",
+        sa.Column("expected_prior_head", sa.String(), nullable=True),
+        schema=SCHEMA,
+    )
+    op.add_column(
+        "publications",
+        sa.Column("outcome_history_ready_at", sa.DateTime(), nullable=True),
+        schema=SCHEMA,
+    )
+    # Terminal rows from a release predating the outcome-history fence cannot be
+    # replayed into an old transcript honestly. Grandfather only those rows so
+    # the migration does not deadlock established threads. Every terminal state
+    # created after this migration starts NULL and is acknowledged by the worker
+    # only after its marker is present in transcript history.
+    op.execute(
+        sa.text(
+            f"""
+            UPDATE {SCHEMA}.publications
+               SET outcome_history_ready_at =
+                   COALESCE(result_reported_at, terminal_at, updated_at, now())
+             WHERE status IN ('denied', 'expired', 'succeeded', 'failed')
+            """
+        )
+    )
+
+    # ``channel_protocol.scoped_conversation_id`` percent-encodes each UTF-8
+    # segment with only RFC 3986 unreserved bytes left literal. This SQL twin is
+    # only for publications whose 0040 workspace snapshot is NULL. Keep it local
+    # to the data move and drop it below; it is not a new database contract.
+    op.execute(
+        sa.text(
+            f"""
+            CREATE FUNCTION {SCHEMA}._0041_percent_encode(value text)
+            RETURNS text
+            LANGUAGE plpgsql
+            IMMUTABLE STRICT PARALLEL SAFE
+            AS $function$
+            DECLARE
+                source_bytes bytea := convert_to(value, 'UTF8');
+                encoded text := '';
+                byte_offset integer;
+                byte_value integer;
+            BEGIN
+                IF length(source_bytes) = 0 THEN
+                    RETURN encoded;
+                END IF;
+                FOR byte_offset IN 0..length(source_bytes) - 1 LOOP
+                    byte_value := get_byte(source_bytes, byte_offset);
+                    IF (byte_value BETWEEN 48 AND 57)
+                       OR (byte_value BETWEEN 65 AND 90)
+                       OR (byte_value BETWEEN 97 AND 122)
+                       OR byte_value IN (45, 46, 95, 126) THEN
+                        encoded := encoded || chr(byte_value);
+                    ELSE
+                        encoded := encoded || '%' ||
+                            upper(lpad(to_hex(byte_value), 2, '0'));
+                    END IF;
+                END LOOP;
+                RETURN encoded;
+            END;
+            $function$
+            """
+        )
+    )
+
+    # Migration 0040 deliberately left pre-scoping rows NULL because it did not
+    # yet have a durable lineage authority. 0041 does: canonicalize every opaque
+    # legacy adapter-native id exactly once, regardless of whether its bytes
+    # resemble a scoped key. The Approval remains unchanged for reply routing;
+    # credential redemption, transcript delivery, and lineage replay consume
+    # the new workspace snapshot.
+    op.execute(
+        sa.text(
+            f"""
+            UPDATE {SCHEMA}.publications AS p
+               SET workspace_conversation_id =
+                   {SCHEMA}._0041_percent_encode(a.reply_kind) || ':' ||
+                   {SCHEMA}._0041_percent_encode(a.reply_channel) || ':' ||
+                   {SCHEMA}._0041_percent_encode(a.conversation_id)
+              FROM {SCHEMA}.approvals AS a
+             WHERE a.id = p.approval_id
+               AND p.workspace_conversation_id IS NULL
+            """
+        )
+    )
+
+    # Pre-lineage releases allowed several publications for one thread. Select
+    # exactly one lineage owner per agent/thread/repository: active work
+    # outranks succeeded history, then the newest row wins. The winner keeps its
+    # UUID and therefore its byte-for-byte stable deterministic branch.
+    op.execute(
+        sa.text(
+            f"""
+            WITH {_publication_identity_cte()},
+            ranked_publications AS (
+                SELECT p.id, p.agent_id, p.deployment_id, p.conversation_id,
+                       p.repo_full_name, p.base_sha, p.status, p.result_url,
+                       row_number() OVER (
+                           PARTITION BY p.agent_id, p.conversation_id,
+                                        p.repo_full_name
+                           ORDER BY
+                               CASE WHEN p.status IN
+                                   ('pending', 'approved', 'launching', 'running')
+                                   THEN 0 ELSE 1 END,
+                               p.created_at DESC,
+                               p.id DESC
+                       ) AS lineage_rank
+                  FROM publication_identities AS p
+            )
+            INSERT INTO {SCHEMA}.thread_publication_lineages
+                (id, agent_id, deployment_id, conversation_id, repo_full_name,
+                 base_sha, branch, pr_number, pr_url, status, version,
+                 latest_revision)
+            SELECT p.id, p.agent_id, p.deployment_id, p.conversation_id,
+                   p.repo_full_name, p.base_sha,
+                   'curie/publication-' || replace(p.id::text, '-', ''),
+                   CASE WHEN p.status = 'succeeded'
+                        THEN substring(p.result_url FROM '/pull/([1-9][0-9]*)$')::integer
+                        ELSE NULL END,
+                   CASE WHEN p.status = 'succeeded' THEN p.result_url ELSE NULL END,
+                   'open', 1, 1
+              FROM ranked_publications AS p
+             WHERE p.lineage_rank = 1
+            """
+        )
+    )
+
+    # An active loser cannot remain claimable without a lineage. Settle it as a
+    # generic migration conflict, clear its private patch and leases, and close
+    # a still-pending approval so the old card cannot later revive the row.
+    # Succeeded losers are immutable history and intentionally remain unlinked.
+    op.execute(
+        sa.text(
+            f"""
+            WITH {_publication_identity_cte()},
+            ranked_publications AS (
+                SELECT p.id, p.approval_id, p.status,
+                       row_number() OVER (
+                           PARTITION BY p.agent_id, p.conversation_id,
+                                        p.repo_full_name
+                           ORDER BY
+                               CASE WHEN p.status IN
+                                   ('pending', 'approved', 'launching', 'running')
+                                   THEN 0 ELSE 1 END,
+                               p.created_at DESC,
+                               p.id DESC
+                       ) AS lineage_rank
+                  FROM publication_identities AS p
+            ), failed_publications AS (
+                UPDATE {SCHEMA}.publications AS p
+                   SET status = 'failed',
+                       version = p.version + 1,
+                       patch_bytes = NULL,
+                       error = 'superseded by another publication during lineage migration',
+                       lease_owner = NULL,
+                       lease_expires_at = NULL,
+                       updated_at = now(),
+                       terminal_at = COALESCE(p.terminal_at, now())
+                  FROM ranked_publications AS ranked
+                 WHERE p.id = ranked.id
+                   AND ranked.lineage_rank > 1
+                   AND ranked.status IN
+                       ('pending', 'approved', 'launching', 'running')
+             RETURNING p.approval_id
+            )
+            UPDATE {SCHEMA}.approvals AS a
+               SET status = 'expired',
+                   resolved_at = COALESCE(a.resolved_at, now()),
+                   resumed_at = COALESCE(a.resumed_at, now())
+              FROM failed_publications AS failed
+             WHERE a.id = failed.approval_id
+               AND a.status = 'pending'
+            """
+        )
+    )
+
+    op.execute(sa.text(f"DROP FUNCTION {SCHEMA}._0041_percent_encode(text)"))
+
+    # Joining the inserted lineage makes it impossible to assign a losing
+    # publication a foreign-key value for a lineage that was never created.
+    op.execute(
+        sa.text(
+            f"""
+            UPDATE {SCHEMA}.publications AS p
+               SET lineage_id = lineage.id,
+                   revision_number = 1,
+                   expected_prior_head = p.base_sha
+              FROM {SCHEMA}.thread_publication_lineages AS lineage
+             WHERE lineage.id = p.id
+            """
+        )
+    )
+
+    # This is a contract boundary, not a mixed-version expand. A 0040 writer
+    # omits lineage_id and creates pending work; refuse that shape rather than
+    # leave unclaimable work behind. Historical terminal rows remain readable.
+    op.create_check_constraint(
+        "publications_active_lineage_ck",
+        "publications",
+        "status NOT IN ('pending', 'approved', 'launching', 'running') "
+        "OR lineage_id IS NOT NULL",
+        schema=SCHEMA,
+    )
+
+    op.create_foreign_key(
+        "publications_lineage_id_fkey",
+        "publications",
+        "thread_publication_lineages",
+        ["lineage_id"],
+        ["id"],
+        source_schema=SCHEMA,
+        referent_schema=SCHEMA,
+        ondelete="SET NULL",
+    )
+    op.create_index(
+        "uq_publications_lineage_revision",
+        "publications",
+        ["lineage_id", "revision_number"],
+        unique=True,
+        schema=SCHEMA,
+    )
+    op.create_index(
+        "uq_active_publication_per_lineage",
+        "publications",
+        ["lineage_id"],
+        unique=True,
+        schema=SCHEMA,
+        postgresql_where=sa.text(
+            "status IN ('pending', 'approved', 'launching', 'running')"
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "publications_active_lineage_ck",
+        "publications",
+        schema=SCHEMA,
+        type_="check",
+    )
+    op.drop_index(
+        "uq_active_publication_per_lineage", table_name="publications", schema=SCHEMA
+    )
+    op.drop_index(
+        "uq_publications_lineage_revision", table_name="publications", schema=SCHEMA
+    )
+    op.drop_constraint(
+        "publications_lineage_id_fkey", "publications", schema=SCHEMA, type_="foreignkey"
+    )
+    op.drop_column("publications", "expected_prior_head", schema=SCHEMA)
+    op.drop_column("publications", "revision_number", schema=SCHEMA)
+    op.drop_column("publications", "lineage_id", schema=SCHEMA)
+    op.drop_column("publications", "outcome_history_ready_at", schema=SCHEMA)
+    op.drop_table("thread_publication_lineages", schema=SCHEMA)

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -3439,6 +3439,18 @@
             "title": "Reply Channel",
             "type": "string"
           },
+          "reply_conversation_id": {
+            "anyOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reply Conversation Id"
+          },
           "reply_endpoint": {
             "anyOf": [
               {
@@ -3505,6 +3517,174 @@
         "title": "PublicationCreate",
         "type": "object"
       },
+      "PublicationLineageAdvance": {
+        "description": "Exact compare-and-set facts for one publication revision outcome.",
+        "properties": {
+          "expected_head_sha": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expected Head Sha"
+          },
+          "expected_version": {
+            "minimum": 1.0,
+            "title": "Expected Version",
+            "type": "integer"
+          },
+          "head_sha": {
+            "title": "Head Sha",
+            "type": "string"
+          },
+          "pr_number": {
+            "exclusiveMinimum": 0.0,
+            "title": "Pr Number",
+            "type": "integer"
+          },
+          "pr_url": {
+            "maxLength": 2048,
+            "minLength": 1,
+            "title": "Pr Url",
+            "type": "string"
+          },
+          "state": {
+            "default": "open",
+            "enum": [
+              "open",
+              "merged",
+              "closed"
+            ],
+            "title": "State",
+            "type": "string"
+          }
+        },
+        "required": [
+          "expected_version",
+          "expected_head_sha",
+          "pr_number",
+          "pr_url",
+          "head_sha"
+        ],
+        "title": "PublicationLineageAdvance",
+        "type": "object"
+      },
+      "PublicationLineageOut": {
+        "description": "Credential-free pull-request lineage facts safe for the worker.",
+        "properties": {
+          "base_sha": {
+            "title": "Base Sha",
+            "type": "string"
+          },
+          "branch": {
+            "title": "Branch",
+            "type": "string"
+          },
+          "conversation_id": {
+            "title": "Conversation Id",
+            "type": "string"
+          },
+          "deployment_id": {
+            "format": "uuid",
+            "title": "Deployment Id",
+            "type": "string"
+          },
+          "has_pending_outcome": {
+            "default": false,
+            "title": "Has Pending Outcome",
+            "type": "boolean"
+          },
+          "has_pending_revision": {
+            "default": false,
+            "title": "Has Pending Revision",
+            "type": "boolean"
+          },
+          "head_sha": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Head Sha"
+          },
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "latest_revision": {
+            "title": "Latest Revision",
+            "type": "integer"
+          },
+          "pr_number": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pr Number"
+          },
+          "pr_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pr Url"
+          },
+          "repo_full_name": {
+            "title": "Repo Full Name",
+            "type": "string"
+          },
+          "state": {
+            "enum": [
+              "open",
+              "merged",
+              "closed"
+            ],
+            "title": "State",
+            "type": "string"
+          },
+          "version": {
+            "title": "Version",
+            "type": "integer"
+          },
+          "visible_outcome_revision": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Visible Outcome Revision",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "deployment_id",
+          "conversation_id",
+          "repo_full_name",
+          "base_sha",
+          "branch",
+          "pr_number",
+          "pr_url",
+          "head_sha",
+          "state",
+          "version",
+          "latest_revision"
+        ],
+        "title": "PublicationLineageOut",
+        "type": "object"
+      },
       "PublicationOut": {
         "description": "Patch-free publication metadata safe for operator and worker reads.",
         "properties": {
@@ -3520,6 +3700,17 @@
           "body": {
             "title": "Body",
             "type": "string"
+          },
+          "branch": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Branch"
           },
           "changed_paths": {
             "items": {
@@ -3549,10 +3740,104 @@
             ],
             "title": "Error"
           },
+          "expected_prior_head": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expected Prior Head"
+          },
           "id": {
             "format": "uuid",
             "title": "Id",
             "type": "string"
+          },
+          "lineage_base_sha": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Lineage Base Sha"
+          },
+          "lineage_head_sha": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Lineage Head Sha"
+          },
+          "lineage_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Lineage Id"
+          },
+          "lineage_state": {
+            "anyOf": [
+              {
+                "enum": [
+                  "open",
+                  "merged",
+                  "closed"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Lineage State"
+          },
+          "lineage_version": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Lineage Version"
+          },
+          "pr_number": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pr Number"
+          },
+          "pr_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pr Url"
           },
           "reply_adapter": {
             "anyOf": [
@@ -3610,6 +3895,17 @@
             ],
             "title": "Result Url"
           },
+          "revision_number": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Revision Number"
+          },
           "status": {
             "title": "Status",
             "type": "string"
@@ -3644,6 +3940,16 @@
           "id",
           "approval_id",
           "deployment_id",
+          "lineage_id",
+          "revision_number",
+          "expected_prior_head",
+          "lineage_base_sha",
+          "lineage_head_sha",
+          "lineage_state",
+          "lineage_version",
+          "branch",
+          "pr_number",
+          "pr_url",
           "repo_full_name",
           "status",
           "version",
@@ -10333,6 +10639,83 @@
         ]
       }
     },
+    "/v1/internal/publications/lineage": {
+      "get": {
+        "operationId": "get_publication_lineage_v1_internal_publications_lineage_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "deployment_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Deployment Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "conversation_id",
+            "required": true,
+            "schema": {
+              "title": "Conversation Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "repo_full_name",
+            "required": true,
+            "schema": {
+              "title": "Repo Full Name",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Curie-Worker-Token",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Curie-Worker-Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicationLineageOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Publication Lineage",
+        "tags": [
+          "internal-publications"
+        ]
+      }
+    },
     "/v1/internal/publications/{publication_id}/credential": {
       "post": {
         "operationId": "redeem_publication_credential_v1_internal_publications__publication_id__credential_post",
@@ -10387,6 +10770,75 @@
           }
         },
         "summary": "Redeem Publication Credential",
+        "tags": [
+          "internal-publications"
+        ]
+      }
+    },
+    "/v1/internal/publications/{publication_id}/lineage": {
+      "patch": {
+        "operationId": "advance_publication_lineage_v1_internal_publications__publication_id__lineage_patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "publication_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Publication Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Curie-Worker-Token",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Curie-Worker-Token"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PublicationLineageAdvance"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicationLineageOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Advance Publication Lineage",
         "tags": [
           "internal-publications"
         ]

--- a/apps/api/src/curie_api/crud.py
+++ b/apps/api/src/curie_api/crud.py
@@ -29,6 +29,7 @@ from .models import (
     Deployment,
     Environment,
     Publication,
+    ThreadPublicationLineage,
     ThreadWorkspace,
 )
 from .schemas import (
@@ -41,6 +42,7 @@ from .schemas import (
     DeploymentCreate,
     HookPartitionConfig,
     PublicationCreate,
+    PublicationLineageAdvance,
     VersionCreate,
 )
 from .workspace_policy import repository_is_allowed
@@ -50,6 +52,15 @@ _WORKSPACE_UNSET = object()
 
 class PublicationReplayConflict(RuntimeError):
     """A publication dedupe key was replayed with different private facts."""
+
+
+class PublicationLineageConflict(RuntimeError):
+    """A publication revision cannot safely mutate its thread lineage."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
 
 
 async def _adopt_publication_replay(
@@ -70,9 +81,19 @@ async def _adopt_publication_replay(
     deployment = await get_deployment(session, data.deployment_id)
     if deployment is None:
         raise LookupError("deployment not found")
+    reply_conversation_id = data.reply_conversation_id or data.conversation_id
+    workspace_conversation_id = (
+        data.conversation_id
+        if data.reply_conversation_id is not None
+        else scoped_conversation_id(
+            data.reply_kind,
+            data.reply_channel,
+            data.conversation_id,
+        )
+    )
     if (
         approval.agent_id != deployment.agent_id
-        or approval.conversation_id != data.conversation_id
+        or approval.conversation_id != reply_conversation_id
         or approval.reply_kind != data.reply_kind
         or approval.reply_channel != data.reply_channel
         or approval.reply_placeholder != data.reply_placeholder
@@ -90,22 +111,27 @@ async def _adopt_publication_replay(
         or publication.reply_placeholder != data.reply_placeholder
         or publication.reply_endpoint != data.reply_endpoint
         or publication.reply_adapter != data.reply_adapter
+        or publication.lineage is None
+        or publication.lineage.agent_id != deployment.agent_id
+        or publication.lineage.conversation_id != workspace_conversation_id
+        or publication.lineage.repo_full_name.casefold()
+        != publication.repo_full_name.casefold()
     ):
         raise PublicationReplayConflict(
             "publication dedupe key was replayed with different snapshot facts"
         )
-    # A NULL snapshot is an explicit pre-scoping lane. Choose it before any new
-    # derived lookup so a valid historical replay is authorized against the
-    # bare workspace row it originally used.
-    workspace_conversation_id = (
-        publication.workspace_conversation_id
-        if publication.workspace_conversation_id is not None
-        else approval.conversation_id
-    )
+    if publication.workspace_conversation_id is None:
+        # 0041 canonicalizes every genuinely legacy row. A NULL observed after
+        # that migration is corruption or an artificial downgrade lane, never
+        # authority to fall back to an adapter-native reply id.
+        raise PublicationReplayConflict(
+            "publication replay has no canonical workspace identity"
+        )
+    authorized_conversation_id = publication.workspace_conversation_id
     await _require_current_publication_workspace(
         session,
         data,
-        conversation_id=workspace_conversation_id,
+        conversation_id=authorized_conversation_id,
         deployment=deployment,
     )
     return publication
@@ -732,12 +758,17 @@ async def create_publication(
 
     existing = await _adopt_publication_replay(session, data, patch)
     if existing is not None:
+        await session.refresh(existing, ["lineage"])
         return existing, False
 
-    workspace_conversation_id = scoped_conversation_id(
-        data.reply_kind,
-        data.reply_channel,
-        data.conversation_id,
+    workspace_conversation_id = (
+        data.conversation_id
+        if data.reply_conversation_id is not None
+        else scoped_conversation_id(
+            data.reply_kind,
+            data.reply_channel,
+            data.conversation_id,
+        )
     )
     deployment, thread_workspace = await _require_current_publication_workspace(
         session,
@@ -745,6 +776,84 @@ async def create_publication(
         conversation_id=workspace_conversation_id,
     )
 
+    lineage = await _get_thread_publication_lineage(
+        session,
+        agent_id=deployment.agent_id,
+        conversation_id=workspace_conversation_id,
+        repo_full_name=thread_workspace.repo_full_name,
+        for_update=True,
+    )
+    if lineage is None:
+        lineage_id = uuid.uuid4()
+        lineage = ThreadPublicationLineage(
+            id=lineage_id,
+            agent_id=deployment.agent_id,
+            deployment_id=deployment.id,
+            conversation_id=workspace_conversation_id,
+            repo_full_name=thread_workspace.repo_full_name,
+            base_sha=data.base_sha,
+            branch=f"curie/publication-{lineage_id.hex}",
+            status="open",
+            version=1,
+            latest_revision=1,
+        )
+        session.add(lineage)
+        try:
+            await session.flush()
+        except IntegrityError as exc:
+            # A distinct first request can race this INSERT. Its approval and
+            # publication have not been flushed, so the losing transaction can
+            # safely roll back without leaving a second human decision.
+            await session.rollback()
+            existing = await _adopt_publication_replay(session, data, patch)
+            if existing is not None:
+                await session.refresh(existing, ["lineage"])
+                return existing, False
+            raise PublicationLineageConflict(
+                "publication.revision_conflict",
+                "another publication revision already owns this thread lineage",
+            ) from exc
+        revision_number = 1
+    else:
+        if lineage.status != "open":
+            raise PublicationLineageConflict(
+                "publication.lineage_terminal",
+                "the pull request for this thread is merged or closed; start a new thread",
+            )
+        pending_outcome = await session.scalar(
+            select(Publication.id).where(
+                Publication.lineage_id == lineage.id,
+                Publication.status.in_(("denied", "expired", "succeeded", "failed")),
+                Publication.outcome_history_ready_at.is_(None),
+            )
+        )
+        if pending_outcome is not None:
+            raise PublicationLineageConflict(
+                "publication.outcome_pending",
+                "the previous publication outcome is not yet durable in thread history",
+            )
+        expected_prior_head = lineage.head_sha or lineage.base_sha
+        if data.base_sha != expected_prior_head:
+            raise PublicationLineageConflict(
+                "publication.lineage_stale",
+                "the managed checkout is not at the current pull request head",
+            )
+        in_flight = await session.scalar(
+            select(Publication.id).where(
+                Publication.lineage_id == lineage.id,
+                Publication.status.in_(("pending", "approved", "launching", "running")),
+            )
+        )
+        if in_flight is not None:
+            raise PublicationLineageConflict(
+                "publication.revision_conflict",
+                "another publication revision is still in progress for this thread",
+            )
+        revision_number = lineage.latest_revision + 1
+        lineage.latest_revision = revision_number
+        lineage.updated_at = func.now()
+
+    expected_prior_head = lineage.head_sha or lineage.base_sha
     expires_at = None
     if data.expires_in_seconds is not None:
         expires_at = datetime.now(UTC).replace(tzinfo=None) + timedelta(
@@ -752,7 +861,7 @@ async def create_publication(
         )
     approval = Approval(
         agent_id=deployment.agent_id,
-        conversation_id=data.conversation_id,
+        conversation_id=data.reply_conversation_id or data.conversation_id,
         author=data.author,
         summary=data.summary,
         reply_kind=data.reply_kind,
@@ -770,18 +879,13 @@ async def create_publication(
         expires_at=expires_at,
     )
     session.add(approval)
-    try:
-        await session.flush()
-    except IntegrityError:
-        await session.rollback()
-        existing = await _adopt_publication_replay(session, data, patch)
-        if existing is None:
-            raise
-        return existing, False
     publication = Publication(
-        approval_id=approval.id,
+        approval=approval,
         deployment_id=deployment.id,
         workspace_conversation_id=workspace_conversation_id,
+        lineage=lineage,
+        revision_number=revision_number,
+        expected_prior_head=expected_prior_head,
         repo_full_name=thread_workspace.repo_full_name,
         status="pending",
         version=1,
@@ -799,37 +903,404 @@ async def create_publication(
     session.add(publication)
     try:
         await session.commit()
-    except IntegrityError:
-        # Two reclaimed deliveries can both miss the optimistic pre-read. The
-        # unique approval dedupe key is the arbiter; after rolling back the
-        # losing INSERT, re-read and adopt only an exact private-fact replay.
+    except IntegrityError as exc:
+        # The dedupe key and active-revision indexes arbitrate deliveries that
+        # raced after the locked lineage read. Adopt only an exact replay.
         await session.rollback()
         existing = await _adopt_publication_replay(session, data, patch)
         if existing is None:
-            raise
+            raise PublicationLineageConflict(
+                "publication.revision_conflict",
+                "another publication revision already owns this thread lineage",
+            ) from exc
+        await session.refresh(existing, ["lineage"])
         return existing, False
     await session.refresh(publication)
+    await session.refresh(publication, ["lineage"])
     return publication, True
 
 
 async def get_publication(session: AsyncSession, publication_id: uuid.UUID) -> Publication | None:
-    return await session.get(Publication, publication_id)
+    publication: Publication | None = await session.scalar(
+        select(Publication)
+        .options(selectinload(Publication.lineage))
+        .where(Publication.id == publication_id)
+    )
+    return publication
 
 
 async def get_publication_by_approval(
     session: AsyncSession, approval_id: uuid.UUID
 ) -> Publication | None:
     publication: Publication | None = await session.scalar(
-        select(Publication).where(Publication.approval_id == approval_id)
+        select(Publication)
+        .options(selectinload(Publication.lineage))
+        .where(Publication.approval_id == approval_id)
     )
     return publication
 
 
 async def list_publications(session: AsyncSession, *, limit: int = 100) -> list[Publication]:
     result = await session.scalars(
-        select(Publication).order_by(Publication.created_at.desc()).limit(limit)
+        select(Publication)
+        .options(selectinload(Publication.lineage))
+        .order_by(Publication.created_at.desc())
+        .limit(limit)
     )
     return list(result)
+
+
+async def _get_thread_publication_lineage(
+    session: AsyncSession,
+    *,
+    agent_id: uuid.UUID,
+    conversation_id: str,
+    repo_full_name: str,
+    for_update: bool = False,
+) -> ThreadPublicationLineage | None:
+    statement = (
+        select(ThreadPublicationLineage)
+        .where(
+            ThreadPublicationLineage.agent_id == agent_id,
+            ThreadPublicationLineage.conversation_id == conversation_id,
+            ThreadPublicationLineage.repo_full_name == repo_full_name,
+        )
+        .order_by(ThreadPublicationLineage.created_at.desc())
+        .limit(1)
+    )
+    if for_update:
+        statement = statement.with_for_update()
+    lineage: ThreadPublicationLineage | None = await session.scalar(statement)
+    return lineage
+
+
+async def get_thread_publication_lineage(
+    session: AsyncSession,
+    *,
+    deployment_id: uuid.UUID,
+    conversation_id: str,
+    repo_full_name: str,
+) -> ThreadPublicationLineage | None:
+    """Read one authorized thread lineage without exposing credentials."""
+
+    deployment = await get_deployment(session, deployment_id)
+    if deployment is None:
+        raise LookupError("deployment not found")
+    selected = await get_thread_workspace(
+        session,
+        agent_id=deployment.agent_id,
+        conversation_id=conversation_id,
+    )
+    if selected is None:
+        raise ValueError("conversation has no selected repository workspace")
+    if selected.repo_full_name.casefold() != repo_full_name.casefold():
+        raise ValueError("publication repository differs from the thread workspace")
+    if not repository_is_allowed(repo_full_name, get_settings().github_repo_allowlist):
+        raise ValueError("thread workspace repository is no longer allowed")
+    return await _get_thread_publication_lineage(
+        session,
+        agent_id=deployment.agent_id,
+        conversation_id=conversation_id,
+        repo_full_name=selected.repo_full_name,
+    )
+
+
+async def publication_lineage_has_pending_revision(
+    session: AsyncSession,
+    lineage: ThreadPublicationLineage,
+) -> bool:
+    """Return only whether private revision work still owns this lineage."""
+
+    if lineage.status != "open":
+        return False
+    pending_id = await session.scalar(
+        select(Publication.id)
+        .where(
+            Publication.lineage_id == lineage.id,
+            Publication.status.in_(("pending", "approved", "launching", "running")),
+        )
+        .limit(1)
+    )
+    return pending_id is not None
+
+
+async def publication_lineage_has_pending_outcome(
+    session: AsyncSession,
+    lineage: ThreadPublicationLineage,
+) -> bool:
+    """Return whether a terminal result still owes durable thread history."""
+
+    pending_id = await session.scalar(
+        select(Publication.id)
+        .where(
+            Publication.lineage_id == lineage.id,
+            Publication.status.in_(("denied", "expired", "succeeded", "failed")),
+            Publication.outcome_history_ready_at.is_(None),
+        )
+        .limit(1)
+    )
+    return pending_id is not None
+
+
+async def publication_lineage_visible_outcome_revision(
+    session: AsyncSession,
+    lineage: ThreadPublicationLineage,
+) -> int:
+    """Return the newest revision already present in durable thread history."""
+
+    revision = await session.scalar(
+        select(func.max(Publication.revision_number)).where(
+            Publication.lineage_id == lineage.id,
+            Publication.status.in_(("denied", "expired", "succeeded", "failed")),
+            Publication.outcome_history_ready_at.is_not(None),
+        )
+    )
+    return int(revision or 0)
+
+
+async def publication_lineage_has_inflight_push(
+    session: AsyncSession,
+    lineage: ThreadPublicationLineage,
+) -> bool:
+    """Return whether an authorized revision may currently be changing GitHub."""
+
+    if lineage.status != "open":
+        return False
+    inflight_id = await session.scalar(
+        select(Publication.id)
+        .where(
+            Publication.lineage_id == lineage.id,
+            Publication.status.in_(("approved", "launching", "running")),
+        )
+        .limit(1)
+    )
+    return inflight_id is not None
+
+
+async def initialize_publication_lineage_head(
+    session: AsyncSession,
+    lineage: ThreadPublicationLineage,
+    *,
+    expected_version: int,
+    head_sha: str,
+) -> ThreadPublicationLineage:
+    """CAS-initialize the unknown head of a migrated URL-only lineage."""
+
+    changed = await session.execute(
+        update(ThreadPublicationLineage)
+        .where(
+            ThreadPublicationLineage.id == lineage.id,
+            ThreadPublicationLineage.status == "open",
+            ThreadPublicationLineage.version == expected_version,
+            ThreadPublicationLineage.head_sha.is_(None),
+            ThreadPublicationLineage.pr_number == lineage.pr_number,
+            ThreadPublicationLineage.pr_url == lineage.pr_url,
+        )
+        .values(
+            head_sha=head_sha,
+            version=ThreadPublicationLineage.version + 1,
+            updated_at=func.now(),
+        )
+        .returning(ThreadPublicationLineage.id)
+    )
+    if changed.scalar_one_or_none() is None:
+        await session.rollback()
+        current = await session.get(ThreadPublicationLineage, lineage.id)
+        if (
+            current is not None
+            and current.status == "open"
+            and current.head_sha == head_sha
+            and current.pr_number == lineage.pr_number
+            and current.pr_url == lineage.pr_url
+        ):
+            return current
+        raise PublicationLineageConflict(
+            "publication.lineage_stale",
+            "pull request lineage changed while its migrated head was initialized",
+        )
+    await session.commit()
+    refreshed = await session.get(ThreadPublicationLineage, lineage.id)
+    assert refreshed is not None
+    await session.refresh(refreshed)
+    return refreshed
+
+
+async def mark_publication_lineage_terminal(
+    session: AsyncSession,
+    lineage: ThreadPublicationLineage,
+    *,
+    expected_version: int,
+    expected_head_sha: str,
+    state: str,
+) -> ThreadPublicationLineage:
+    """Persist observed terminal GitHub truth without changing the known head."""
+
+    if state not in ("merged", "closed"):
+        raise ValueError("terminal publication lineage state is invalid")
+    changed = await session.execute(
+        update(ThreadPublicationLineage)
+        .where(
+            ThreadPublicationLineage.id == lineage.id,
+            ThreadPublicationLineage.status == "open",
+            ThreadPublicationLineage.version == expected_version,
+            ThreadPublicationLineage.head_sha == expected_head_sha,
+            ThreadPublicationLineage.pr_number == lineage.pr_number,
+            ThreadPublicationLineage.pr_url == lineage.pr_url,
+        )
+        .values(
+            status=state,
+            version=ThreadPublicationLineage.version + 1,
+            updated_at=func.now(),
+        )
+        .returning(ThreadPublicationLineage.id)
+    )
+    if changed.scalar_one_or_none() is None:
+        await session.rollback()
+        current = await session.get(ThreadPublicationLineage, lineage.id)
+        if (
+            current is not None
+            and current.status == state
+            and current.head_sha == expected_head_sha
+            and current.pr_number == lineage.pr_number
+            and current.pr_url == lineage.pr_url
+        ):
+            return current
+        raise PublicationLineageConflict(
+            "publication.lineage_stale",
+            "pull request lineage changed while its terminal state was refreshed",
+        )
+    await session.commit()
+    refreshed = await session.get(ThreadPublicationLineage, lineage.id)
+    assert refreshed is not None
+    await session.refresh(refreshed)
+    return refreshed
+
+
+async def advance_publication_lineage(
+    session: AsyncSession,
+    publication_id: uuid.UUID,
+    data: PublicationLineageAdvance,
+) -> ThreadPublicationLineage:
+    """Atomically advance one approved revision and its exact lineage head."""
+
+    publication = await session.scalar(
+        select(Publication).where(Publication.id == publication_id).with_for_update()
+    )
+    if publication is None:
+        raise LookupError("publication not found")
+    if publication.lineage_id is None:
+        raise PublicationLineageConflict(
+            "publication.lineage_absent",
+            "publication has no thread pull request lineage",
+        )
+    lineage = await session.scalar(
+        select(ThreadPublicationLineage)
+        .where(ThreadPublicationLineage.id == publication.lineage_id)
+        .with_for_update()
+    )
+    if lineage is None:
+        raise PublicationLineageConflict(
+            "publication.lineage_absent",
+            "publication thread pull request lineage is absent",
+        )
+    if lineage.status != "open":
+        raise PublicationLineageConflict(
+            "publication.lineage_terminal",
+            "the pull request for this thread is merged or closed; start a new thread",
+        )
+    if publication.revision_number != lineage.latest_revision:
+        raise PublicationLineageConflict(
+            "publication.lineage_stale",
+            "publication revision is not the current thread lineage revision",
+        )
+    if data.pr_url != f"https://github.com/{lineage.repo_full_name}/pull/{data.pr_number}":
+        raise PublicationLineageConflict(
+            "publication.lineage_stale",
+            "pull request identity does not match the publication repository",
+        )
+    if lineage.pr_number is not None and (
+        lineage.pr_number != data.pr_number or lineage.pr_url != data.pr_url
+    ):
+        raise PublicationLineageConflict(
+            "publication.lineage_stale",
+            "pull request identity no longer matches the stored thread lineage",
+        )
+    if lineage.version != data.expected_version or lineage.head_sha != data.expected_head_sha:
+        raise PublicationLineageConflict(
+            "publication.lineage_stale",
+            "pull request lineage version or expected head is stale",
+        )
+    if publication.status not in ("approved", "launching", "running"):
+        raise PublicationLineageConflict(
+            "publication.revision_not_approved",
+            "publication revision must be approved before advancing its lineage",
+        )
+
+    head_predicate = (
+        ThreadPublicationLineage.head_sha.is_(None)
+        if data.expected_head_sha is None
+        else ThreadPublicationLineage.head_sha == data.expected_head_sha
+    )
+    changed = await session.execute(
+        update(ThreadPublicationLineage)
+        .where(
+            ThreadPublicationLineage.id == lineage.id,
+            ThreadPublicationLineage.status == "open",
+            ThreadPublicationLineage.version == data.expected_version,
+            head_predicate,
+        )
+        .values(
+            pr_number=data.pr_number,
+            pr_url=data.pr_url,
+            head_sha=data.head_sha,
+            status=data.state,
+            version=ThreadPublicationLineage.version + 1,
+            updated_at=func.now(),
+        )
+        .returning(ThreadPublicationLineage.id)
+    )
+    if changed.scalar_one_or_none() is None:
+        await session.rollback()
+        raise PublicationLineageConflict(
+            "publication.lineage_stale",
+            "pull request lineage changed before this revision could advance it",
+        )
+
+    terminal_state = data.state in ("merged", "closed")
+    publication_status = "failed" if terminal_state else "succeeded"
+    publication_values: dict[str, Any] = {
+        "status": publication_status,
+        "version": Publication.version + 1,
+        "patch_bytes": None,
+        "terminal_at": func.now(),
+        "updated_at": func.now(),
+        "result_url": data.pr_url,
+    }
+    if terminal_state:
+        publication_values["error"] = (
+            "the pull request for this thread is merged or closed; start a new thread"
+        )
+    settled = await session.execute(
+        update(Publication)
+        .where(
+            Publication.id == publication.id,
+            Publication.status == publication.status,
+            Publication.version == publication.version,
+        )
+        .values(**publication_values)
+        .returning(Publication.id)
+    )
+    if settled.scalar_one_or_none() is None:
+        await session.rollback()
+        raise PublicationLineageConflict(
+            "publication.lineage_stale",
+            "publication revision changed before its lineage could advance",
+        )
+    await session.commit()
+    refreshed = await session.get(ThreadPublicationLineage, lineage.id)
+    assert refreshed is not None
+    await session.refresh(refreshed)
+    return refreshed
 
 
 async def append_credential_redemption_audit(

--- a/apps/api/src/curie_api/models.py
+++ b/apps/api/src/curie_api/models.py
@@ -22,6 +22,7 @@ from sqlalchemy import (
     Text,
     UniqueConstraint,
     func,
+    text,
 )
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship, validates
@@ -430,13 +431,86 @@ class Approval(Base):
     publication: Mapped[Publication | None] = relationship(back_populates="approval", uselist=False)
 
 
+class ThreadPublicationLineage(Base):
+    """One durable pull-request identity owned by an agent conversation."""
+
+    __tablename__ = "thread_publication_lineages"
+    __table_args__ = (
+        CheckConstraint(
+            "status IN ('open', 'merged', 'closed')",
+            name="thread_publication_lineages_status_ck",
+        ),
+        CheckConstraint(
+            "version >= 1",
+            name="thread_publication_lineages_version_ck",
+        ),
+        CheckConstraint(
+            "latest_revision >= 1",
+            name="thread_publication_lineages_latest_revision_ck",
+        ),
+        CheckConstraint(
+            "(pr_number IS NULL) = (pr_url IS NULL)",
+            name="thread_publication_lineages_pr_identity_ck",
+        ),
+        Index(
+            "uq_active_thread_publication_lineage",
+            "agent_id",
+            "conversation_id",
+            "repo_full_name",
+            unique=True,
+            postgresql_where=text("status = 'open'"),
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    agent_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey(f"{SCHEMA}.agents.id", ondelete="CASCADE"), index=True
+    )
+    deployment_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey(f"{SCHEMA}.deployments.id", ondelete="CASCADE"), index=True
+    )
+    conversation_id: Mapped[str] = mapped_column(index=True)
+    repo_full_name: Mapped[str]
+    base_sha: Mapped[str]
+    branch: Mapped[str] = mapped_column(unique=True)
+    pr_number: Mapped[int | None] = mapped_column(default=None)
+    pr_url: Mapped[str | None] = mapped_column(default=None)
+    head_sha: Mapped[str | None] = mapped_column(default=None)
+    status: Mapped[str] = mapped_column(server_default="open", default="open")
+    version: Mapped[int] = mapped_column(server_default="1", default=1)
+    latest_revision: Mapped[int] = mapped_column(server_default="1", default=1)
+    created_at: Mapped[datetime] = mapped_column(server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(server_default=func.now(), onupdate=func.now())
+
+    publications: Mapped[list[Publication]] = relationship(back_populates="lineage")
+
+
 class Publication(Base):
     """Private patch state settled by the platform publication reconciler."""
 
     __tablename__ = "publications"
     __table_args__ = (
+        CheckConstraint(
+            "status NOT IN ('pending', 'approved', 'launching', 'running') "
+            "OR lineage_id IS NOT NULL",
+            name="publications_active_lineage_ck",
+        ),
         Index("ix_publications_status_lease", "status", "lease_expires_at"),
         Index("ix_publications_deployment_id", "deployment_id"),
+        Index(
+            "uq_publications_lineage_revision",
+            "lineage_id",
+            "revision_number",
+            unique=True,
+        ),
+        Index(
+            "uq_active_publication_per_lineage",
+            "lineage_id",
+            unique=True,
+            postgresql_where=text(
+                "status IN ('pending', 'approved', 'launching', 'running')"
+            ),
+        ),
         Index(
             "ix_publications_approval_card_delivery",
             "approval_card_reported_at",
@@ -468,6 +542,12 @@ class Publication(Base):
     # reply tuple; NULL denotes a successful pre-scoping row whose Approval
     # conversation remains the only honest historical identity.
     workspace_conversation_id: Mapped[str | None] = mapped_column(default=None)
+    lineage_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey(f"{SCHEMA}.thread_publication_lineages.id", ondelete="SET NULL"),
+        default=None,
+    )
+    revision_number: Mapped[int | None] = mapped_column(default=None)
+    expected_prior_head: Mapped[str | None] = mapped_column(default=None)
     repo_full_name: Mapped[str]
     status: Mapped[str] = mapped_column(server_default="pending")
     version: Mapped[int] = mapped_column(server_default="1", default=1)
@@ -510,6 +590,11 @@ class Publication(Base):
     # delivery. These fields form the durable result outbox so a transient
     # adapter failure cannot resurrect publication work or retain patch bytes.
     result_reported_at: Mapped[datetime | None] = mapped_column(default=None)
+    # A terminal publication does not release its thread fence until the
+    # platform-authored outcome is durable in the transcript the next sandbox
+    # rehydrates. Result delivery to Slack is a separate, independently retrying
+    # obligation and must not stand in for this acknowledgement.
+    outcome_history_ready_at: Mapped[datetime | None] = mapped_column(default=None)
     result_delivery_attempts: Mapped[int] = mapped_column(server_default="0", default=0)
     result_delivery_error: Mapped[str | None] = mapped_column(Text, default=None)
     result_delivery_dead_lettered_at: Mapped[datetime | None] = mapped_column(default=None)
@@ -520,6 +605,37 @@ class Publication(Base):
     terminal_at: Mapped[datetime | None] = mapped_column(default=None)
 
     approval: Mapped[Approval] = relationship(back_populates="publication")
+    lineage: Mapped[ThreadPublicationLineage | None] = relationship(
+        back_populates="publications"
+    )
+
+    @property
+    def lineage_base_sha(self) -> str | None:
+        return self.lineage.base_sha if self.lineage is not None else None
+
+    @property
+    def lineage_head_sha(self) -> str | None:
+        return self.lineage.head_sha if self.lineage is not None else None
+
+    @property
+    def lineage_state(self) -> str | None:
+        return self.lineage.status if self.lineage is not None else None
+
+    @property
+    def lineage_version(self) -> int | None:
+        return self.lineage.version if self.lineage is not None else None
+
+    @property
+    def branch(self) -> str | None:
+        return self.lineage.branch if self.lineage is not None else None
+
+    @property
+    def pr_number(self) -> int | None:
+        return self.lineage.pr_number if self.lineage is not None else None
+
+    @property
+    def pr_url(self) -> str | None:
+        return self.lineage.pr_url if self.lineage is not None else None
 
 
 class CredentialRedemptionAuditEntry(Base):

--- a/apps/api/src/curie_api/revision_kinds.json
+++ b/apps/api/src/curie_api/revision_kinds.json
@@ -38,5 +38,6 @@
   "0037": "expand",
   "0038": "expand",
   "0039": "expand",
-  "0040": "expand"
+  "0040": "expand",
+  "0041": "contract"
 }

--- a/apps/api/src/curie_api/routers/publications.py
+++ b/apps/api/src/curie_api/routers/publications.py
@@ -4,8 +4,11 @@ The API stores private patch state and resolves credentials. Kubernetes and
 GitHub side effects belong to the trusted worker publication reconciler.
 """
 
+import re
 import uuid
+from typing import Any
 
+import httpx
 from curie_telemetry import TRACEPARENT_STREAM_FIELD, canonicalize_traceparent
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from starlette.concurrency import run_in_threadpool
@@ -17,8 +20,16 @@ from ..auth import (
 )
 from ..config import get_settings
 from ..deps import SessionDep
+from ..models import ThreadPublicationLineage
+from ..repo_full_name import repo_url_path
 from ..repository_auth import resolve_repository_credential
-from ..schemas import PublicationCreate, PublicationOut, RepositoryCredentialOut
+from ..schemas import (
+    PublicationCreate,
+    PublicationLineageAdvance,
+    PublicationLineageOut,
+    PublicationOut,
+    RepositoryCredentialOut,
+)
 from ..workspace_policy import credential_mode, repository_is_allowed
 
 router = APIRouter(
@@ -29,6 +40,211 @@ router = APIRouter(
 internal_router = APIRouter(
     prefix="/v1/internal/publications", tags=["internal-publications"]
 )
+
+_GITHUB_API_VERSION = "2022-11-28"
+_FULL_COMMIT_SHA = re.compile(r"[0-9a-fA-F]{40}")
+_GITHUB_UNAVAILABLE_DETAIL = {
+    "code": "publication.github_unavailable",
+    "message": (
+        "GitHub could not verify this thread's pull request. Try again later; "
+        "no model turn or publication was started."
+    ),
+}
+
+
+async def _publication_lineage_out(
+    session: SessionDep,
+    lineage: ThreadPublicationLineage,
+) -> PublicationLineageOut:
+    """Render the one safe private-state fact alongside public lineage data."""
+
+    has_pending_revision = await crud.publication_lineage_has_pending_revision(
+        session, lineage
+    )
+    has_pending_outcome = await crud.publication_lineage_has_pending_outcome(
+        session, lineage
+    )
+    visible_outcome_revision = (
+        await crud.publication_lineage_visible_outcome_revision(session, lineage)
+    )
+    return PublicationLineageOut.model_validate(lineage).model_copy(
+        update={
+            "has_pending_revision": has_pending_revision,
+            "has_pending_outcome": has_pending_outcome,
+            "visible_outcome_revision": visible_outcome_revision,
+        }
+    )
+
+
+def _validated_github_pr_truth(
+    payload: Any,
+    *,
+    repo_full_name: str,
+    pr_number: int,
+    pr_url: str,
+    branch: str,
+) -> tuple[str, str]:
+    """Validate identity-bound GitHub fields and return state plus head SHA."""
+
+    if not isinstance(payload, dict):
+        raise ValueError("GitHub returned an invalid pull request body")
+    number = payload.get("number")
+    html_url = payload.get("html_url")
+    remote_state = payload.get("state")
+    merged = payload.get("merged")
+    head = payload.get("head")
+    expected_url = f"https://github.com/{repo_full_name}/pull/{pr_number}"
+    if (
+        not isinstance(number, int)
+        or isinstance(number, bool)
+        or number != pr_number
+        or html_url != pr_url
+        or pr_url != expected_url
+        or not isinstance(head, dict)
+        or head.get("ref") != branch
+    ):
+        raise ValueError("GitHub pull request identity differs from the stored lineage")
+    actual_head_sha = head.get("sha")
+    if not isinstance(actual_head_sha, str) or _FULL_COMMIT_SHA.fullmatch(
+        actual_head_sha
+    ) is None:
+        raise ValueError("GitHub returned an invalid pull request head")
+    if remote_state not in ("open", "closed") or not isinstance(merged, bool):
+        raise ValueError("GitHub returned an invalid pull request state")
+    if merged and remote_state != "closed":
+        raise ValueError("GitHub returned an inconsistent pull request state")
+    state = "merged" if merged else ("closed" if remote_state == "closed" else "open")
+    return state, actual_head_sha.lower()
+
+
+async def _refresh_publication_lineage_from_github(
+    request: Request,
+    session: SessionDep,
+    lineage: ThreadPublicationLineage,
+) -> ThreadPublicationLineage:
+    """Refresh a stored PR by number while keeping credentials API-private."""
+
+    if lineage.pr_number is None and lineage.pr_url is None:
+        return lineage
+    if lineage.pr_number is None or lineage.pr_url is None:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            {
+                "code": "publication.lineage_stale",
+                "message": "stored pull request identity is incomplete",
+            },
+        )
+
+    settings = get_settings()
+    try:
+        _, authorization_header = await run_in_threadpool(
+            resolve_repository_credential, lineage.repo_full_name, settings
+        )
+    except Exception as exc:
+        raise HTTPException(
+            status.HTTP_502_BAD_GATEWAY,
+            {
+                "code": "publication.github_unavailable",
+                "message": "operator repository credential could not be resolved",
+            },
+        ) from exc
+
+    url = (
+        f"{settings.github_api_url.rstrip('/')}"
+        f"/repos/{repo_url_path(lineage.repo_full_name)}/pulls/{lineage.pr_number}"
+    )
+    try:
+        response = await request.app.state.http_client.get(
+            url,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": authorization_header,
+                "X-GitHub-Api-Version": _GITHUB_API_VERSION,
+            },
+            # This request carries operator authority. Refuse every redirect at
+            # this callsite even when the shared client follows redirects for a
+            # different API consumer.
+            follow_redirects=False,
+        )
+    except httpx.HTTPError as exc:
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            _GITHUB_UNAVAILABLE_DETAIL,
+        ) from exc
+    if response.status_code != status.HTTP_200_OK:
+        # A missing PR, rejected credential, rate limit, redirect, or upstream
+        # failure is not verified-open lineage. Keep the durable row unchanged
+        # and make the caller refuse this turn before route adoption/model use.
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            _GITHUB_UNAVAILABLE_DETAIL,
+        )
+    try:
+        remote_state, actual_head_sha = _validated_github_pr_truth(
+            response.json(),
+            repo_full_name=lineage.repo_full_name,
+            pr_number=lineage.pr_number,
+            pr_url=lineage.pr_url,
+            branch=lineage.branch,
+        )
+    except (ValueError, TypeError) as exc:
+        raise HTTPException(
+            status.HTTP_502_BAD_GATEWAY,
+            {
+                "code": "publication.github_invalid_response",
+                "message": "GitHub returned pull request facts that do not match the lineage",
+            },
+        ) from exc
+
+    if actual_head_sha != lineage.head_sha and (
+        await crud.publication_lineage_has_inflight_push(session, lineage)
+    ):
+        # The authorized revision may have pushed its exact commit while its
+        # lineage CAS is still pending. Keep the durable expected head as the
+        # authority until that writer proves and records the new commit.
+        return lineage
+
+    expected_head_sha = lineage.head_sha
+    if expected_head_sha is None:
+        try:
+            lineage = await crud.initialize_publication_lineage_head(
+                session,
+                lineage,
+                expected_version=lineage.version,
+                head_sha=actual_head_sha,
+            )
+        except crud.PublicationLineageConflict as exc:
+            raise HTTPException(
+                status.HTTP_409_CONFLICT,
+                {"code": exc.code, "message": exc.message},
+            ) from exc
+        expected_head_sha = lineage.head_sha
+    assert expected_head_sha is not None
+    if remote_state in ("merged", "closed") and lineage.status == "open":
+        try:
+            lineage = await crud.mark_publication_lineage_terminal(
+                session,
+                lineage,
+                expected_version=lineage.version,
+                expected_head_sha=expected_head_sha,
+                state=remote_state,
+            )
+        except crud.PublicationLineageConflict as exc:
+            raise HTTPException(
+                status.HTTP_409_CONFLICT,
+                {"code": exc.code, "message": exc.message},
+            ) from exc
+    if actual_head_sha != expected_head_sha:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            {
+                "code": "publication.lineage_stale",
+                "message": "GitHub pull request head differs from the stored lineage",
+                "expected_head_sha": expected_head_sha,
+                "actual_head_sha": actual_head_sha,
+            },
+        )
+    return lineage
 
 
 @internal_router.post(
@@ -65,6 +281,11 @@ async def create_publication(
         )
     except crud.PublicationReplayConflict as exc:
         raise HTTPException(status.HTTP_409_CONFLICT, str(exc)) from exc
+    except crud.PublicationLineageConflict as exc:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            {"code": exc.code, "message": exc.message},
+        ) from exc
     except LookupError as exc:
         raise HTTPException(status.HTTP_404_NOT_FOUND, str(exc)) from exc
     except ValueError as exc:
@@ -75,6 +296,57 @@ async def create_publication(
     if not created:
         response.status_code = status.HTTP_200_OK
     return PublicationOut.model_validate(publication)
+
+
+@internal_router.get(
+    "/lineage",
+    response_model=PublicationLineageOut,
+    dependencies=[Depends(require_internal_worker_token)],
+)
+async def get_publication_lineage(
+    deployment_id: uuid.UUID,
+    conversation_id: str,
+    repo_full_name: str,
+    request: Request,
+    session: SessionDep,
+) -> PublicationLineageOut:
+    try:
+        lineage = await crud.get_thread_publication_lineage(
+            session,
+            deployment_id=deployment_id,
+            conversation_id=conversation_id,
+            repo_full_name=repo_full_name,
+        )
+    except LookupError as exc:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status.HTTP_409_CONFLICT, str(exc)) from exc
+    if lineage is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "publication lineage not found")
+    lineage = await _refresh_publication_lineage_from_github(request, session, lineage)
+    return await _publication_lineage_out(session, lineage)
+
+
+@internal_router.patch(
+    "/{publication_id}/lineage",
+    response_model=PublicationLineageOut,
+    dependencies=[Depends(require_internal_worker_token)],
+)
+async def advance_publication_lineage(
+    publication_id: uuid.UUID,
+    data: PublicationLineageAdvance,
+    session: SessionDep,
+) -> PublicationLineageOut:
+    try:
+        lineage = await crud.advance_publication_lineage(session, publication_id, data)
+    except LookupError as exc:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, str(exc)) from exc
+    except crud.PublicationLineageConflict as exc:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            {"code": exc.code, "message": exc.message},
+        ) from exc
+    return await _publication_lineage_out(session, lineage)
 
 
 @router.get("", response_model=list[PublicationOut])
@@ -108,7 +380,8 @@ async def redeem_publication_credential(
     repo = publication.repo_full_name if publication is not None else None
     deployment_id = publication.deployment_id if publication is not None else None
 
-    async def refused(code: int, detail: str) -> None:
+    async def refused(code: int, detail: str | dict[str, str]) -> None:
+        audit_detail = detail if isinstance(detail, str) else detail["message"]
         await crud.append_credential_redemption_audit(
             session,
             purpose="publication_push",
@@ -116,13 +389,23 @@ async def redeem_publication_credential(
             deployment_id=deployment_id,
             publication_id=publication.id if publication is not None else None,
             repo_full_name=repo,
-            detail=detail,
+            detail=audit_detail,
         )
         raise HTTPException(code, detail, headers={"Cache-Control": "no-store"})
 
     if publication is None:
         await refused(status.HTTP_404_NOT_FOUND, "publication not found")
     assert publication is not None and repo is not None
+    if publication.lineage is not None and publication.lineage.status != "open":
+        await refused(
+            status.HTTP_409_CONFLICT,
+            {
+                "code": "publication.lineage_terminal",
+                "message": (
+                    "the pull request for this thread is merged or closed; start a new thread"
+                ),
+            },
+        )
     if publication.status not in ("approved", "launching", "running"):
         await refused(
             status.HTTP_409_CONFLICT,
@@ -133,14 +416,23 @@ async def redeem_publication_credential(
     if deployment is None or approval is None:
         await refused(status.HTTP_409_CONFLICT, "publication workspace binding is absent")
     assert deployment is not None and approval is not None
+    workspace_conversation_id = (
+        publication.workspace_conversation_id
+        if publication.workspace_conversation_id is not None
+        else publication.lineage.conversation_id
+        if publication.lineage is not None
+        else None
+    )
+    if workspace_conversation_id is None:
+        await refused(
+            status.HTTP_409_CONFLICT,
+            "publication canonical workspace identity is absent",
+        )
+    assert workspace_conversation_id is not None
     selected = await crud.get_thread_workspace(
         session,
         agent_id=deployment.agent_id,
-        conversation_id=(
-            publication.workspace_conversation_id
-            if publication.workspace_conversation_id is not None
-            else approval.conversation_id
-        ),
+        conversation_id=workspace_conversation_id,
     )
     settings = get_settings()
     if (

--- a/apps/api/src/curie_api/schema_compat.json
+++ b/apps/api/src/curie_api/schema_compat.json
@@ -1,4 +1,4 @@
 {
-  "schema_min": "0040",
-  "schema_head": "0040"
+  "schema_min": "0041",
+  "schema_head": "0041"
 }

--- a/apps/api/src/curie_api/schemas.py
+++ b/apps/api/src/curie_api/schemas.py
@@ -1395,6 +1395,7 @@ class PublicationCreate(BaseModel):
 
     deployment_id: uuid.UUID
     conversation_id: str = Field(min_length=1)
+    reply_conversation_id: str | None = Field(default=None, min_length=1)
     repo_full_name: str = Field(pattern=REPOSITORY_FULL_NAME_PATTERN)
     author: str = Field(min_length=1)
     summary: str = Field(min_length=1)
@@ -1467,6 +1468,57 @@ class PublicationCreate(BaseModel):
             raise ValueError("patch_b64 must be canonical base64") from exc
 
 
+class PublicationLineageAdvance(BaseModel):
+    """Exact compare-and-set facts for one publication revision outcome."""
+
+    expected_version: int = Field(ge=1)
+    expected_head_sha: str | None
+    state: Literal["open", "merged", "closed"] = "open"
+    pr_number: int = Field(gt=0)
+    pr_url: str = Field(min_length=1, max_length=2048)
+    head_sha: str
+
+    @field_validator("expected_head_sha", "head_sha")
+    @classmethod
+    def _full_commit_sha(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        if not re.fullmatch(r"[0-9a-fA-F]{40}", value):
+            raise ValueError("lineage head must be one full 40-character commit id")
+        return value.lower()
+
+
+class PublicationLineageOut(BaseModel):
+    """Credential-free pull-request lineage facts safe for the worker."""
+
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+
+    id: uuid.UUID
+    deployment_id: uuid.UUID
+    conversation_id: str
+    repo_full_name: str
+    base_sha: str
+    branch: str
+    pr_number: int | None
+    pr_url: str | None
+    head_sha: str | None
+    state: Literal["open", "merged", "closed"] = Field(validation_alias="status")
+    version: int
+    latest_revision: int
+    # This is intentionally only a boolean. The worker needs to know whether a
+    # fenced replacement would race an unresolved revision, but must not learn
+    # that revision's identifier or private patch state.
+    has_pending_revision: bool = False
+    # True while a terminal publication outcome has not yet been acknowledged
+    # by the durable transcript outbox. No private patch or error text crosses
+    # this read seam.
+    has_pending_outcome: bool = False
+    # Monotonic within one lineage. The worker stores this on its route so a
+    # headless denial/failure causes exactly one cold history rehydrate even
+    # though the Git head itself did not move.
+    visible_outcome_revision: int = Field(default=0, ge=0)
+
+
 class PublicationOut(BaseModel):
     """Patch-free publication metadata safe for operator and worker reads."""
 
@@ -1475,6 +1527,16 @@ class PublicationOut(BaseModel):
     id: uuid.UUID
     approval_id: uuid.UUID
     deployment_id: uuid.UUID
+    lineage_id: uuid.UUID | None
+    revision_number: int | None
+    expected_prior_head: str | None
+    lineage_base_sha: str | None
+    lineage_head_sha: str | None
+    lineage_state: Literal["open", "merged", "closed"] | None
+    lineage_version: int | None
+    branch: str | None
+    pr_number: int | None
+    pr_url: str | None
     repo_full_name: str
     status: str
     version: int

--- a/apps/api/tests/test_migration_0041_publication_lineages.py
+++ b/apps/api/tests/test_migration_0041_publication_lineages.py
@@ -1,0 +1,807 @@
+"""Migration 0041 gives resumable publications one durable thread lineage."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from contextlib import contextmanager
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from curie_api.config import get_settings
+from curie_api.deps import get_session
+from curie_api.main import create_app
+from curie_api.models import Publication, ThreadPublicationLineage
+from fastapi.testclient import TestClient
+from sqlalchemy import CheckConstraint, text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import NullPool
+
+ALEMBIC_DIR = Path(__file__).resolve().parents[1] / "alembic"
+BELOW = "0040"
+BASE_SHA = "0123456789abcdef0123456789abcdef01234567"
+REPO = "acme-corp/acme-bot"
+REPLY_KIND = "slack"
+REPLY_CHANNEL = "C0EXAMPLE1"
+
+
+def _config() -> Config:
+    config = Config()
+    config.set_main_option("script_location", str(ALEMBIC_DIR))
+    return config
+
+
+def _sql(statement: str, params: dict[str, Any] | None = None) -> list[dict[str, Any]]:
+    async def run() -> list[dict[str, Any]]:
+        engine = create_async_engine(get_settings().database_url)
+        try:
+            async with engine.begin() as connection:
+                result = await connection.execute(text(statement), params or {})
+                if not result.returns_rows:
+                    return []
+                return [dict(row) for row in result.mappings().all()]
+        finally:
+            await engine.dispose()
+
+    return asyncio.run(run())
+
+
+def _scoped_thread(conversation_id: str) -> str:
+    return ":".join(
+        quote(part, safe="")
+        for part in (REPLY_KIND, REPLY_CHANNEL, conversation_id)
+    )
+
+
+@contextmanager
+def _api_client() -> Iterator[TestClient]:
+    """Drive the real publication router without starting unrelated resources."""
+
+    engine = create_async_engine(get_settings().database_url, poolclass=NullPool)
+    sessions = async_sessionmaker(engine, expire_on_commit=False)
+
+    async def isolated_session() -> AsyncIterator[AsyncSession]:
+        async with sessions() as session:
+            yield session
+
+    app = create_app()
+    app.dependency_overrides[get_session] = isolated_session
+    client = TestClient(app)
+    try:
+        yield client
+    finally:
+        client.close()
+        asyncio.run(engine.dispose())
+
+
+def _seed_deployment() -> tuple[uuid.UUID, uuid.UUID]:
+    agent_id = uuid.uuid4()
+    version_id = uuid.uuid4()
+    deployment_id = uuid.uuid4()
+    _sql(
+        "INSERT INTO curie.agents (id, name) VALUES (:id, :name)",
+        {"id": agent_id, "name": f"lineage-migration-{agent_id.hex[:8]}"},
+    )
+    _sql(
+        "INSERT INTO curie.agent_versions "
+        "(id, agent_id, version_label, bundle_ref, created_by) "
+        "VALUES (:id, :agent_id, 'v1', NULL, 'migration-test')",
+        {"id": version_id, "agent_id": agent_id},
+    )
+    _sql(
+        "INSERT INTO curie.deployments "
+        "(id, agent_id, version_id, environment, status) "
+        "VALUES (:id, :agent_id, :version_id, "
+        "CAST('dev' AS curie.environment), 'active')",
+        {
+            "id": deployment_id,
+            "agent_id": agent_id,
+            "version_id": version_id,
+        },
+    )
+    return agent_id, deployment_id
+
+
+def _seed_redeployment(agent_id: uuid.UUID) -> uuid.UUID:
+    version_id = uuid.uuid4()
+    deployment_id = uuid.uuid4()
+    _sql(
+        "INSERT INTO curie.agent_versions "
+        "(id, agent_id, version_label, bundle_ref, created_by) "
+        "VALUES (:id, :agent_id, 'v2', NULL, 'migration-test')",
+        {"id": version_id, "agent_id": agent_id},
+    )
+    _sql(
+        "INSERT INTO curie.deployments "
+        "(id, agent_id, version_id, environment, status) "
+        "VALUES (:id, :agent_id, :version_id, "
+        "CAST('dev' AS curie.environment), 'active')",
+        {
+            "id": deployment_id,
+            "agent_id": agent_id,
+            "version_id": version_id,
+        },
+    )
+    return deployment_id
+
+
+def _seed_publication(
+    *,
+    agent_id: uuid.UUID,
+    deployment_id: uuid.UUID,
+    conversation_id: str,
+    workspace_conversation_id: str | None = None,
+    status: str,
+    result_url: str | None = None,
+    created_at: datetime | None = None,
+) -> tuple[uuid.UUID, uuid.UUID]:
+    approval_id = uuid.uuid4()
+    publication_id = uuid.uuid4()
+    _sql(
+        "INSERT INTO curie.approvals "
+        "(id, agent_id, conversation_id, author, summary, reply_kind, "
+        "reply_channel, dedupe_key, status, purpose) VALUES "
+        "(:id, :agent_id, :conversation_id, 'U0REQUEST1', "
+        "'Publish repository changes', 'slack', 'C0EXAMPLE1', :dedupe_key, "
+        ":approval_status, 'publication')",
+        {
+            "id": approval_id,
+            "agent_id": agent_id,
+            "conversation_id": conversation_id,
+            "dedupe_key": f"migration-lineage-{publication_id.hex}",
+            "approval_status": "approved" if status != "pending" else "pending",
+        },
+    )
+    _sql(
+        "INSERT INTO curie.publications "
+        "(id, approval_id, deployment_id, workspace_conversation_id, "
+        "repo_full_name, status, base_sha, "
+        "patch_bytes, changed_paths, title, body, reply_kind, reply_channel, "
+        "result_url, created_at, updated_at) VALUES "
+        "(:id, :approval_id, :deployment_id, :workspace_conversation_id, "
+        "'acme-corp/acme-bot', :status, "
+        ":base_sha, :patch_bytes, CAST('[\"README.md\"]' AS jsonb), "
+        "'Update README', 'Approved platform publication.', 'slack', "
+        "'C0EXAMPLE1', :result_url, "
+        "COALESCE(CAST(:created_at AS timestamp), now()), "
+        "COALESCE(CAST(:created_at AS timestamp), now()))",
+        {
+            "id": publication_id,
+            "approval_id": approval_id,
+            "deployment_id": deployment_id,
+            "workspace_conversation_id": workspace_conversation_id,
+            "status": status,
+            "base_sha": BASE_SHA,
+            "patch_bytes": (
+                b"migration-private-patch"
+                if status in ("pending", "approved", "launching", "running")
+                else None
+            ),
+            "result_url": (
+                None
+                if status in ("pending", "approved", "launching", "running")
+                else result_url
+                or "https://github.com/acme-corp/acme-bot/pull/123"
+            ),
+            "created_at": created_at,
+        },
+    )
+    return approval_id, publication_id
+
+
+def _seed_thread_workspace(
+    *,
+    agent_id: uuid.UUID,
+    deployment_id: uuid.UUID,
+    conversation_id: str,
+) -> None:
+    _sql(
+        "INSERT INTO curie.thread_workspaces "
+        "(id, agent_id, selected_by_deployment_id, conversation_id, "
+        "repo_full_name, selected_by) VALUES "
+        "(:id, :agent_id, :deployment_id, :conversation_id, :repo, 'U0REQUEST1')",
+        {
+            "id": uuid.uuid4(),
+            "agent_id": agent_id,
+            "deployment_id": deployment_id,
+            "conversation_id": conversation_id,
+            "repo": REPO,
+        },
+    )
+
+
+def test_thread_publication_lineage_orm_metadata_mirrors_0041_checks() -> None:
+    """Declarative test schemas must enforce the same lineage invariants."""
+
+    checks = {
+        constraint.name: str(constraint.sqltext)
+        for constraint in ThreadPublicationLineage.__table__.constraints
+        if isinstance(constraint, CheckConstraint)
+    }
+
+    assert (
+        checks["thread_publication_lineages_status_ck"]
+        == "status IN ('open', 'merged', 'closed')"
+    )
+    assert checks["thread_publication_lineages_version_ck"] == "version >= 1"
+    assert (
+        checks["thread_publication_lineages_latest_revision_ck"]
+        == "latest_revision >= 1"
+    )
+    assert (
+        checks["thread_publication_lineages_pr_identity_ck"]
+        == "(pr_number IS NULL) = (pr_url IS NULL)"
+    )
+
+
+def test_publication_orm_metadata_requires_lineage_for_active_statuses() -> None:
+    checks = {
+        constraint.name: str(constraint.sqltext)
+        for constraint in Publication.__table__.constraints
+        if isinstance(constraint, CheckConstraint)
+    }
+
+    assert (
+        checks["publications_active_lineage_ck"]
+        == "status NOT IN ('pending', 'approved', 'launching', 'running') "
+        "OR lineage_id IS NOT NULL"
+    )
+
+
+def test_0041_contract_rejects_n_minus_one_active_write_but_keeps_terminal_history(
+    isolated_migration_db: None,
+) -> None:
+    config = _config()
+    command.upgrade(config, BELOW)
+    agent_id, deployment_id = _seed_deployment()
+    _, terminal_id = _seed_publication(
+        agent_id=agent_id,
+        deployment_id=deployment_id,
+        conversation_id="thread-terminal-contract-history",
+        status="failed",
+    )
+
+    command.upgrade(config, "head")
+
+    assert _sql(
+        "SELECT status, lineage_id FROM curie.publications WHERE id = :id",
+        {"id": terminal_id},
+    ) == [{"status": "failed", "lineage_id": None}]
+
+    with pytest.raises(IntegrityError) as excinfo:
+        # This is the 0040 writer shape: it starts pending and knows none of
+        # 0041's lineage columns.
+        _seed_publication(
+            agent_id=agent_id,
+            deployment_id=deployment_id,
+            conversation_id="thread-post-contract-n-minus-one",
+            status="pending",
+        )
+    assert "publications_active_lineage_ck" in str(excinfo.value)
+    assert _sql(
+        "SELECT p.id FROM curie.publications p JOIN curie.approvals a "
+        "ON a.id = p.approval_id WHERE a.conversation_id = :conversation_id",
+        {"conversation_id": "thread-post-contract-n-minus-one"},
+    ) == []
+
+
+def test_0041_collapses_duplicate_preupgrade_thread_publications(
+    isolated_migration_db: None,
+) -> None:
+    config = _config()
+    command.upgrade(config, BELOW)
+    agent_id, deployment_id = _seed_deployment()
+    redeployment_id = _seed_redeployment(agent_id)
+
+    _, older_succeeded_id = _seed_publication(
+        agent_id=agent_id,
+        deployment_id=deployment_id,
+        conversation_id="thread-duplicate-succeeded",
+        status="succeeded",
+        result_url="https://github.com/acme-corp/acme-bot/pull/121",
+        created_at=datetime(2026, 1, 1),
+    )
+    _, newer_succeeded_id = _seed_publication(
+        agent_id=agent_id,
+        deployment_id=deployment_id,
+        conversation_id="thread-duplicate-succeeded",
+        workspace_conversation_id=_scoped_thread("thread-duplicate-succeeded"),
+        status="succeeded",
+        result_url="https://github.com/acme-corp/acme-bot/pull/122",
+        created_at=datetime(2026, 1, 2),
+    )
+
+    older_active_approval_id, older_active_id = _seed_publication(
+        agent_id=agent_id,
+        deployment_id=deployment_id,
+        conversation_id="thread-active-precedence",
+        status="pending",
+        created_at=datetime(2026, 2, 1),
+    )
+    _, newer_active_id = _seed_publication(
+        agent_id=agent_id,
+        deployment_id=redeployment_id,
+        conversation_id="thread-active-precedence",
+        workspace_conversation_id=_scoped_thread("thread-active-precedence"),
+        status="running",
+        created_at=datetime(2026, 2, 2),
+    )
+    _, newest_succeeded_id = _seed_publication(
+        agent_id=agent_id,
+        deployment_id=deployment_id,
+        conversation_id="thread-active-precedence",
+        status="succeeded",
+        result_url="https://github.com/acme-corp/acme-bot/pull/203",
+        created_at=datetime(2026, 2, 3),
+    )
+
+    command.upgrade(config, "head")
+
+    assert _sql(
+        "SELECT p.id::text, p.lineage_id::text, p.revision_number, l.pr_number "
+        "FROM curie.publications p LEFT JOIN curie.thread_publication_lineages l "
+        "ON l.id = p.lineage_id WHERE p.id IN (:older, :newer) ORDER BY p.created_at",
+        {"older": older_succeeded_id, "newer": newer_succeeded_id},
+    ) == [
+        {
+            "id": str(older_succeeded_id),
+            "lineage_id": None,
+            "revision_number": None,
+            "pr_number": None,
+        },
+        {
+            "id": str(newer_succeeded_id),
+            "lineage_id": str(newer_succeeded_id),
+            "revision_number": 1,
+            "pr_number": 122,
+        },
+    ]
+
+    active_rows = _sql(
+        "SELECT p.id::text, p.status, p.lineage_id::text, p.revision_number, p.error, "
+        "p.patch_bytes IS NULL AS patch_cleared, "
+        "p.terminal_at IS NOT NULL AS terminal, a.status AS approval_status "
+        "FROM curie.publications p JOIN curie.approvals a ON a.id = p.approval_id "
+        "WHERE p.id IN (:older_active, :newer_active, :succeeded) ORDER BY p.created_at",
+        {
+            "older_active": older_active_id,
+            "newer_active": newer_active_id,
+            "succeeded": newest_succeeded_id,
+        },
+    )
+    assert active_rows == [
+        {
+            "id": str(older_active_id),
+            "status": "failed",
+            "lineage_id": None,
+            "revision_number": None,
+            "error": "superseded by another publication during lineage migration",
+            "patch_cleared": True,
+            "terminal": True,
+            "approval_status": "expired",
+        },
+        {
+            "id": str(newer_active_id),
+            "status": "running",
+            "lineage_id": str(newer_active_id),
+            "revision_number": 1,
+            "error": None,
+            "patch_cleared": False,
+            "terminal": False,
+            "approval_status": "approved",
+        },
+        {
+            "id": str(newest_succeeded_id),
+            "status": "succeeded",
+            "lineage_id": None,
+            "revision_number": None,
+            "error": None,
+            "patch_cleared": True,
+            "terminal": False,
+            "approval_status": "approved",
+        },
+    ]
+    assert _sql(
+        "SELECT resolved_at IS NOT NULL AS resolved, resumed_at IS NOT NULL AS resumed "
+        "FROM curie.approvals WHERE id = :id",
+        {"id": older_active_approval_id},
+    ) == [{"resolved": True, "resumed": True}]
+
+    assert _sql(
+        "SELECT conversation_id FROM curie.thread_publication_lineages "
+        "ORDER BY conversation_id"
+    ) == [
+        {"conversation_id": _scoped_thread("thread-active-precedence")},
+        {"conversation_id": _scoped_thread("thread-duplicate-succeeded")},
+    ]
+
+
+def test_0041_never_infers_opaque_legacy_reply_id_is_already_scoped(
+    isolated_migration_db: None,
+) -> None:
+    config = _config()
+    command.upgrade(config, BELOW)
+    agent_id, deployment_id = _seed_deployment()
+    native_reply_id = "thread-x"
+    scoped_lookalike_reply_id = _scoped_thread(native_reply_id)
+    _, native_publication_id = _seed_publication(
+        agent_id=agent_id,
+        deployment_id=deployment_id,
+        conversation_id=native_reply_id,
+        status="succeeded",
+        result_url="https://github.com/acme-corp/acme-bot/pull/130",
+    )
+    _, lookalike_publication_id = _seed_publication(
+        agent_id=agent_id,
+        deployment_id=deployment_id,
+        conversation_id=scoped_lookalike_reply_id,
+        status="succeeded",
+        result_url="https://github.com/acme-corp/acme-bot/pull/131",
+    )
+
+    command.upgrade(config, "head")
+
+    expected_identities = {
+        str(native_publication_id): (
+            native_reply_id,
+            _scoped_thread(native_reply_id),
+        ),
+        str(lookalike_publication_id): (
+            scoped_lookalike_reply_id,
+            _scoped_thread(scoped_lookalike_reply_id),
+        ),
+    }
+    rows = _sql(
+        "SELECT p.id::text, p.lineage_id::text, p.workspace_conversation_id, "
+        "a.conversation_id AS reply_conversation_id, l.conversation_id "
+        "FROM curie.publications p "
+        "JOIN curie.approvals a ON a.id = p.approval_id "
+        "JOIN curie.thread_publication_lineages l ON l.id = p.lineage_id "
+        "WHERE p.id IN (:native_id, :lookalike_id) ORDER BY p.id",
+        {
+            "native_id": native_publication_id,
+            "lookalike_id": lookalike_publication_id,
+        },
+    )
+    assert len(rows) == 2
+    for row in rows:
+        reply_id, canonical_id = expected_identities[row["id"]]
+        assert row == {
+            "id": row["id"],
+            "lineage_id": row["id"],
+            "workspace_conversation_id": canonical_id,
+            "reply_conversation_id": reply_id,
+            "conversation_id": canonical_id,
+        }
+
+    _sql(
+        "UPDATE curie.publications SET "
+        "approval_card_delivery_dead_lettered_at = now(), "
+        "resource_cleanup_completed_at = now() "
+        "WHERE id IN (:native_id, :lookalike_id)",
+        {
+            "native_id": native_publication_id,
+            "lookalike_id": lookalike_publication_id,
+        },
+    )
+
+    async def migrated_result(publication_id: uuid.UUID) -> Any:
+        from curie_worker.publication_store import PostgresPublicationStore
+
+        engine = create_async_engine(get_settings().database_url)
+        store = PostgresPublicationStore(
+            engine, schema="curie", lease_owner=f"opaque-{publication_id.hex}"
+        )
+        try:
+            return await store.pending_result(publication_id)
+        finally:
+            await engine.dispose()
+
+    for publication_id in (native_publication_id, lookalike_publication_id):
+        result = asyncio.run(migrated_result(publication_id))
+        assert result is not None
+        reply_id, canonical_id = expected_identities[str(publication_id)]
+        assert result.target.conversation_id == reply_id
+        assert result.workspace_conversation_id == canonical_id
+
+
+def test_0041_scopes_migrated_lineage_but_keeps_reply_identity_bare(
+    isolated_migration_db: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _config()
+    command.upgrade(config, BELOW)
+    agent_id, deployment_id = _seed_deployment()
+    reply_thread = "1700000000.000100"
+    scoped_thread = _scoped_thread(reply_thread)
+    _seed_thread_workspace(
+        agent_id=agent_id,
+        deployment_id=deployment_id,
+        conversation_id=scoped_thread,
+    )
+    approval_id, publication_id = _seed_publication(
+        agent_id=agent_id,
+        deployment_id=deployment_id,
+        conversation_id=reply_thread,
+        workspace_conversation_id=None,
+        status="pending",
+    )
+
+    command.upgrade(config, "head")
+
+    assert _sql(
+        "SELECT l.id::text AS lineage_id, l.conversation_id, "
+        "p.workspace_conversation_id, "
+        "a.conversation_id AS reply_conversation_id "
+        "FROM curie.publications p "
+        "JOIN curie.thread_publication_lineages l ON l.id = p.lineage_id "
+        "JOIN curie.approvals a ON a.id = p.approval_id "
+        "WHERE p.id = :id",
+        {"id": publication_id},
+    ) == [
+        {
+            "lineage_id": str(publication_id),
+            "conversation_id": scoped_thread,
+            "workspace_conversation_id": scoped_thread,
+            "reply_conversation_id": reply_thread,
+        }
+    ]
+
+    # Credential authorization must use the canonical migration snapshot, not
+    # the Approval's intentionally bare Slack reply id.
+    monkeypatch.setenv("GITHUB_REPO_ALLOWLIST", '["acme-corp/*"]')
+    monkeypatch.setenv("GITHUB_TOKEN", "migration-publication-token")
+    get_settings.cache_clear()
+    worker_headers = {
+        "X-Curie-Worker-Token": get_settings().internal_worker_token,
+    }
+    _sql(
+        "UPDATE curie.approvals SET status = 'approved', resolved_at = now() "
+        "WHERE id = :id",
+        {"id": approval_id},
+    )
+    _sql(
+        "UPDATE curie.publications SET status = 'approved' WHERE id = :id",
+        {"id": publication_id},
+    )
+    with _api_client() as client:
+        credential = client.post(
+            f"/v1/internal/publications/{publication_id}/credential",
+            headers=worker_headers,
+        )
+        assert credential.status_code == 200, credential.text
+
+    # Settle the migrated revision without changing either identity. The result
+    # outbox must append to canonical transcript history while still addressing
+    # the adapter reply with its bare Slack thread timestamp.
+    _sql(
+        "UPDATE curie.publications SET status = 'denied', patch_bytes = NULL, "
+        "approval_card_delivery_dead_lettered_at = now(), terminal_at = now() "
+        "WHERE id = :id",
+        {"id": publication_id},
+    )
+    _sql(
+        "UPDATE curie.approvals SET status = 'denied', resolved_at = now() WHERE id = :id",
+        {"id": approval_id},
+    )
+
+    async def migrated_result() -> Any:
+        from curie_worker.publication_store import PostgresPublicationStore
+
+        engine = create_async_engine(get_settings().database_url)
+        store = PostgresPublicationStore(
+            engine, schema="curie", lease_owner="migration-scoped-lineage"
+        )
+        try:
+            return await store.pending_result(publication_id)
+        finally:
+            await engine.dispose()
+
+    result = asyncio.run(migrated_result())
+    assert result is not None
+    assert result.workspace_conversation_id == scoped_thread
+    assert result.target.conversation_id == reply_thread
+    _sql(
+        "UPDATE curie.publications SET outcome_history_ready_at = now(), "
+        "lease_owner = NULL, lease_expires_at = NULL WHERE id = :id",
+        {"id": publication_id},
+    )
+
+    with _api_client() as client:
+        lineage = client.get(
+            "/v1/internal/publications/lineage",
+            params={
+                "deployment_id": str(deployment_id),
+                "conversation_id": scoped_thread,
+                "repo_full_name": REPO,
+            },
+            headers=worker_headers,
+        )
+        assert lineage.status_code == 200, lineage.text
+        assert lineage.json()["id"] == str(publication_id)
+
+        revision = client.post(
+            "/v1/internal/publications",
+            json={
+                "deployment_id": str(deployment_id),
+                "conversation_id": scoped_thread,
+                "reply_conversation_id": reply_thread,
+                "repo_full_name": REPO,
+                "author": "U0REQUEST1",
+                "summary": "Publish the next revision",
+                "reply_kind": REPLY_KIND,
+                "reply_channel": REPLY_CHANNEL,
+                "dedupe_key": "migration-scoped-lineage-next-revision",
+                "base_sha": BASE_SHA,
+                "patch_b64": base64.b64encode(b"next migration patch").decode(),
+                "changed_paths": ["README.md"],
+            },
+            headers=worker_headers,
+        )
+        assert revision.status_code == 201, revision.text
+
+    assert _sql(
+        "SELECT p.lineage_id::text, p.revision_number, "
+        "a.conversation_id AS reply_conversation_id "
+        "FROM curie.publications p "
+        "JOIN curie.approvals a ON a.id = p.approval_id "
+        "WHERE p.id = :id",
+        {"id": uuid.UUID(revision.json()["id"])},
+    ) == [
+        {
+            "lineage_id": str(publication_id),
+            "revision_number": 2,
+            "reply_conversation_id": reply_thread,
+        }
+    ]
+    assert _sql(
+        "SELECT count(*) AS count FROM curie.thread_publication_lineages "
+        "WHERE agent_id = :agent_id AND repo_full_name = :repo",
+        {"agent_id": agent_id, "repo": REPO},
+    ) == [{"count": 1}]
+
+
+def test_0041_backfills_active_and_succeeded_pr_publications_and_round_trips(
+    isolated_migration_db: None,
+) -> None:
+    config = _config()
+    command.upgrade(config, BELOW)
+    agent_id, deployment_id = _seed_deployment()
+    _, active_id = _seed_publication(
+        agent_id=agent_id,
+        deployment_id=deployment_id,
+        conversation_id="thread-active-publication",
+        workspace_conversation_id=_scoped_thread("thread-active-publication"),
+        status="running",
+    )
+    _, terminal_id = _seed_publication(
+        agent_id=agent_id,
+        deployment_id=deployment_id,
+        conversation_id="thread-terminal-publication",
+        status="succeeded",
+    )
+    _, unsafe_terminal_id = _seed_publication(
+        agent_id=agent_id,
+        deployment_id=deployment_id,
+        conversation_id="thread-unsafe-terminal-publication",
+        status="succeeded",
+        result_url="https://github.com/acme-corp/acme-bot/issues/123",
+    )
+
+    command.upgrade(config, "head")
+
+    active = _sql(
+        "SELECT p.lineage_id::text, p.revision_number, p.expected_prior_head, "
+        "l.agent_id::text, l.conversation_id, l.repo_full_name, l.base_sha, "
+        "l.branch, l.pr_number, l.pr_url, l.head_sha, l.status, l.version, "
+        "l.latest_revision FROM curie.publications p JOIN "
+        "curie.thread_publication_lineages l ON l.id = p.lineage_id "
+        "WHERE p.id = :id",
+        {"id": active_id},
+    )
+    assert len(active) == 1
+    assert active[0] == {
+        "lineage_id": active[0]["lineage_id"],
+        "revision_number": 1,
+        "expected_prior_head": BASE_SHA,
+        "agent_id": str(agent_id),
+        "conversation_id": _scoped_thread("thread-active-publication"),
+        "repo_full_name": "acme-corp/acme-bot",
+        "base_sha": BASE_SHA,
+        "branch": f"curie/publication-{active_id.hex}",
+        "pr_number": None,
+        "pr_url": None,
+        "head_sha": None,
+        "status": "open",
+        "version": 1,
+        "latest_revision": 1,
+    }
+    uuid.UUID(active[0]["lineage_id"])
+    terminal = _sql(
+        "SELECT p.lineage_id::text, p.revision_number, p.expected_prior_head, "
+        "p.workspace_conversation_id, a.conversation_id AS reply_conversation_id, "
+        "l.conversation_id, l.branch, l.pr_number, l.pr_url, l.head_sha, l.status "
+        "FROM curie.publications p JOIN curie.thread_publication_lineages l "
+        "ON l.id = p.lineage_id JOIN curie.approvals a ON a.id = p.approval_id "
+        "WHERE p.id = :id",
+        {"id": terminal_id},
+    )
+    assert terminal == [
+        {
+            "lineage_id": str(terminal_id),
+            "revision_number": 1,
+            "expected_prior_head": BASE_SHA,
+            "workspace_conversation_id": _scoped_thread(
+                "thread-terminal-publication"
+            ),
+            "reply_conversation_id": "thread-terminal-publication",
+            "conversation_id": _scoped_thread("thread-terminal-publication"),
+            "branch": f"curie/publication-{terminal_id.hex}",
+            "pr_number": 123,
+            "pr_url": "https://github.com/acme-corp/acme-bot/pull/123",
+            "head_sha": None,
+            "status": "open",
+        }
+    ]
+    assert _sql(
+        "SELECT lineage_id, revision_number, expected_prior_head "
+        "FROM curie.publications WHERE id = :id",
+        {"id": unsafe_terminal_id},
+    ) == [
+        {
+            "lineage_id": None,
+            "revision_number": None,
+            "expected_prior_head": None,
+        }
+    ]
+    assert _sql("SELECT count(*) AS count FROM curie.thread_publication_lineages") == [
+        {"count": 2}
+    ]
+
+    with pytest.raises(IntegrityError):
+        _sql(
+            "INSERT INTO curie.thread_publication_lineages "
+            "(id, agent_id, deployment_id, conversation_id, repo_full_name, base_sha, branch, "
+            "status, version, latest_revision) VALUES "
+            "(:id, :agent_id, :deployment_id, :conversation_id, "
+            "'acme-corp/acme-bot', :base_sha, :branch, 'open', 1, 1)",
+            {
+                "id": uuid.uuid4(),
+                "agent_id": agent_id,
+                "deployment_id": deployment_id,
+                "conversation_id": _scoped_thread("thread-active-publication"),
+                "base_sha": "abcdef0123456789abcdef0123456789abcdef01",
+                "branch": f"curie/publication-{uuid.uuid4().hex}",
+            },
+        )
+
+    command.downgrade(config, BELOW)
+    assert _sql(
+        "SELECT table_name FROM information_schema.tables WHERE "
+        "table_schema = 'curie' AND table_name = 'thread_publication_lineages'"
+    ) == []
+    assert _sql(
+        "SELECT column_name FROM information_schema.columns WHERE "
+        "table_schema = 'curie' AND table_name = 'publications' AND "
+        "column_name IN ('lineage_id', 'revision_number', 'expected_prior_head')"
+    ) == []
+
+    command.upgrade(config, "head")
+    assert _sql(
+        "SELECT l.branch, p.revision_number FROM curie.publications p JOIN "
+        "curie.thread_publication_lineages l ON l.id = p.lineage_id "
+        "WHERE p.id = :id",
+        {"id": active_id},
+    ) == [{"branch": f"curie/publication-{active_id.hex}", "revision_number": 1}]

--- a/apps/api/tests/test_publications.py
+++ b/apps/api/tests/test_publications.py
@@ -38,6 +38,7 @@ from curie_api.main import create_app
 from curie_api.resumequeue import ResumeQueue
 from curie_api.schemas import ChannelBindingWrite, PublicationCreate
 from curie_api.sweeper import sweep_expired_approvals
+from curie_telemetry import record_metric
 from curie_test_support.valkey import connect_or_skip
 from fastapi import Response
 from fastapi.testclient import TestClient
@@ -50,6 +51,11 @@ WORKER_TOKEN = "remote-dev-publication-worker-token"
 WORKER_HEADERS = {"X-Curie-Worker-Token": WORKER_TOKEN}
 PATCH_LIMIT = 900_000
 BASE_SHA = "0123456789abcdef0123456789abcdef01234567"
+FIRST_REVISION_SHA = "1123456789abcdef0123456789abcdef01234567"
+SECOND_REVISION_SHA = "2123456789abcdef0123456789abcdef01234567"
+EXTERNAL_REVISION_SHA = "3123456789abcdef0123456789abcdef01234567"
+PR_NUMBER = 123
+PR_URL = f"https://github.com/{REPO}/pull/{PR_NUMBER}"
 CLUSTER_MESSAGE_ADAPTER = "curie-cluster-message"
 _PUBLICATION_TRACEPARENT = "00-7123456789abcdef0123456789abcdef-7123456789abcdef-01"
 _REPLAY_TRACEPARENT = "00-8123456789abcdef0123456789abcdef-8123456789abcdef-01"
@@ -125,10 +131,12 @@ def _publication_payload(
     dedupe_key: str | None = None,
     author: str = "U0REQUEST1",
     expires_in_seconds: int | None = 600,
+    conversation_id: str | None = None,
+    base_sha: str = BASE_SHA,
 ) -> dict[str, Any]:
     return {
         "deployment_id": deployment_id,
-        "conversation_id": f"thread-{uuid.uuid4().hex[:8]}",
+        "conversation_id": conversation_id or f"thread-{uuid.uuid4().hex[:8]}",
         "repo_full_name": REPO,
         "author": author,
         "summary": "Publish the repository changes",
@@ -136,7 +144,7 @@ def _publication_payload(
         "reply_channel": "C0EXAMPLE1",
         "reply_placeholder": "1700000000.000001",
         "dedupe_key": dedupe_key or f"publish-{uuid.uuid4().hex}",
-        "base_sha": BASE_SHA,
+        "base_sha": base_sha,
         "patch_b64": base64.b64encode(patch).decode(),
         "changed_paths": ["README.md"],
         "expires_in_seconds": expires_in_seconds,
@@ -144,7 +152,10 @@ def _publication_payload(
 
 
 def _workspace_identity(payload: Mapping[str, Any]) -> str:
-    """Derive the authorization key from the unchanged adapter reply tuple."""
+    """Return the canonical authorization key for either worker request shape."""
+
+    if payload.get("reply_conversation_id") is not None:
+        return str(payload["conversation_id"])
 
     return channel_protocol.scoped_conversation_id(
         str(payload["reply_kind"]),
@@ -280,6 +291,129 @@ def _create_publication(
     )
     assert response.status_code in (200, 201), response.text
     return response.status_code, response.json()
+
+
+def _get_lineage(
+    client: TestClient,
+    *,
+    deployment_id: str,
+    conversation_id: str,
+    repo_full_name: str = REPO,
+) -> Any:
+    """Call the current worker endpoint with its canonical scoped identity."""
+
+    return client.get(
+        "/v1/internal/publications/lineage",
+        params={
+            "deployment_id": deployment_id,
+            "conversation_id": channel_protocol.scoped_conversation_id(
+                "slack", "C0EXAMPLE1", conversation_id
+            ),
+            "repo_full_name": repo_full_name,
+        },
+        headers=WORKER_HEADERS,
+    )
+
+
+def _advance_lineage(
+    client: TestClient,
+    publication_id: str,
+    *,
+    expected_version: int,
+    expected_head_sha: str | None,
+    head_sha: str,
+    state: str = "open",
+    pr_number: int = PR_NUMBER,
+    pr_url: str = PR_URL,
+) -> Any:
+    return client.patch(
+        f"/v1/internal/publications/{publication_id}/lineage",
+        json={
+            "expected_version": expected_version,
+            "expected_head_sha": expected_head_sha,
+            "state": state,
+            "pr_number": pr_number,
+            "pr_url": pr_url,
+            "head_sha": head_sha,
+        },
+        headers=WORKER_HEADERS,
+    )
+
+
+def _mark_outcome_history_ready(publication_id: str) -> None:
+    """Stand in for the worker transcript outbox in API-only lineage tests."""
+
+    _execute(
+        "UPDATE curie.publications SET outcome_history_ready_at = now() "
+        "WHERE id = :id",
+        {"id": uuid.UUID(publication_id)},
+    )
+
+
+def _open_lineage(
+    client: TestClient,
+    auth_headers: dict[str, str],
+    *,
+    conversation_id: str,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    deployment = _create_deployment(client, auth_headers)
+    _, publication = _create_publication(
+        client,
+        _publication_payload(
+            deployment["id"],
+            conversation_id=conversation_id,
+            dedupe_key=f"{conversation_id}-revision-one",
+        ),
+    )
+    approved = _resolve(client, auth_headers, publication["approval_id"])
+    assert approved.status_code == 200, approved.text
+    advanced = _advance_lineage(
+        client,
+        publication["id"],
+        expected_version=1,
+        expected_head_sha=None,
+        head_sha=FIRST_REVISION_SHA,
+    )
+    assert advanced.status_code == 200, advanced.text
+    _mark_outcome_history_ready(publication["id"])
+    return deployment, publication
+
+
+def _get_lineage_with_http(
+    client: TestClient,
+    *,
+    deployment_id: str,
+    conversation_id: str,
+    handler: Any,
+) -> Any:
+    injected = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    original = client.app.state.http_client
+    client.app.state.http_client = injected
+    try:
+        return _get_lineage(
+            client,
+            deployment_id=deployment_id,
+            conversation_id=conversation_id,
+        )
+    finally:
+        client.app.state.http_client = original
+        asyncio.run(injected.aclose())
+
+
+def _healthy_github_pr(*, branch: str, head_sha: str) -> httpx.Response:
+    """A verified-open GitHub response for lineage/CAS control reads."""
+
+    return httpx.Response(
+        200,
+        json={
+            "number": PR_NUMBER,
+            "html_url": PR_URL,
+            "state": "open",
+            "merged": False,
+            "base": {"ref": "main", "sha": BASE_SHA},
+            "head": {"ref": branch, "sha": head_sha},
+        },
+    )
 
 
 def _rows(query: str, params: dict[str, Any] | None = None) -> list[dict[str, Any]]:
@@ -572,7 +706,7 @@ def test_publication_replay_refuses_a_changed_conversation_or_agent_identity(
     assert _counts() == (1, 1)
 
 
-def test_legacy_publication_replay_uses_only_its_bare_authorization_lane(
+def test_null_workspace_publication_replay_refuses_bare_authorization_fallback(
     publication_stack: tuple[TestClient, str],
     auth_headers: dict[str, str],
     clean_db: None,
@@ -586,8 +720,7 @@ def test_legacy_publication_replay_uses_only_its_bare_authorization_lane(
     exact = client.post(
         "/v1/internal/publications", json=payload, headers=WORKER_HEADERS
     )
-    assert exact.status_code == 200, exact.text
-    assert exact.json()["id"] == publication["id"]
+    assert exact.status_code == 409
     assert _rows(
         "SELECT workspace_conversation_id FROM curie.publications WHERE id = :id",
         {"id": publication["id"]},
@@ -600,19 +733,6 @@ def test_legacy_publication_replay_uses_only_its_bare_authorization_lane(
     )
     assert crossed.status_code == 409
 
-    _execute(
-        "DELETE FROM curie.thread_workspaces "
-        "WHERE selected_by_deployment_id = :deployment_id "
-        "AND conversation_id = :conversation_id",
-        {
-            "deployment_id": deployment["id"],
-            "conversation_id": payload["conversation_id"],
-        },
-    )
-    revoked = client.post(
-        "/v1/internal/publications", json=payload, headers=WORKER_HEADERS
-    )
-    assert revoked.status_code == 409
     assert _counts() == (1, 1)
 
 
@@ -635,6 +755,146 @@ def test_legacy_publication_replay_rechecks_the_current_allowlist(
     )
     assert replay.status_code == 409
     assert _counts() == (1, 1)
+
+
+def test_publication_splits_scoped_thread_identity_from_slack_reply_identity(
+    publication_stack: tuple[TestClient, str],
+    auth_headers: dict[str, str],
+    clean_db: None,
+) -> None:
+    from curie_worker.publication_store import PostgresPublicationStore
+    from curie_worker.slack_sink import _thread_ts
+
+    client, _ = publication_stack
+    deployment = _create_deployment(client, auth_headers)
+    scoped_thread = "slack:C0EXAMPLE1:1700000000.000100"
+    reply_thread = "1700000000.000100"
+    payload = _publication_payload(
+        deployment["id"],
+        conversation_id=scoped_thread,
+        dedupe_key="scoped-thread-bare-slack-reply",
+    )
+    payload["reply_conversation_id"] = reply_thread
+
+    status_code, publication = _create_publication(client, payload)
+
+    assert status_code == 201
+    assert _rows(
+        "SELECT a.conversation_id AS reply_conversation_id, "
+        "l.conversation_id AS lineage_conversation_id "
+        "FROM curie.publications p "
+        "JOIN curie.approvals a ON a.id = p.approval_id "
+        "JOIN curie.thread_publication_lineages l ON l.id = p.lineage_id "
+        "WHERE p.id = :id",
+        {"id": publication["id"]},
+    ) == [
+        {
+            "reply_conversation_id": reply_thread,
+            "lineage_conversation_id": scoped_thread,
+        }
+    ]
+    assert _thread_ts(reply_thread) == reply_thread
+    assert _thread_ts(scoped_thread) is None
+
+    replay = client.post(
+        "/v1/internal/publications", json=payload, headers=WORKER_HEADERS
+    )
+    assert replay.status_code == 200, replay.text
+    changed_reply = dict(payload, reply_conversation_id="1700000000.000200")
+    conflict = client.post(
+        "/v1/internal/publications", json=changed_reply, headers=WORKER_HEADERS
+    )
+    assert conflict.status_code == 409
+
+    async def claim_outboxes() -> tuple[Any, Any]:
+        engine = create_async_engine(get_settings().database_url)
+        store = PostgresPublicationStore(
+            engine, schema="curie", lease_owner="split-identity-outbox"
+        )
+        try:
+            card = await store.claim_pending_card()
+            assert card is not None
+            await store.mark_card_delivered(card.publication_id)
+            approved = _resolve(client, auth_headers, publication["approval_id"])
+            assert approved.status_code == 200, approved.text
+            work = await store.claim_next()
+            assert work is not None
+            await store.persist_result(
+                work.publication_id,
+                outcome="failed",
+                pr_url=None,
+                error="safe terminal fixture",
+            )
+            cleanup = await store.claim_pending_cleanup()
+            assert cleanup is not None
+            await store.mark_cleanup_completed(cleanup.publication_id)
+            result = await store.pending_result(work.publication_id)
+            assert result is not None
+            return card, result
+        finally:
+            await engine.dispose()
+
+    card, result = asyncio.run(claim_outboxes())
+    assert card.target.conversation_id == reply_thread
+    assert result.target.conversation_id == reply_thread
+    assert result.workspace_conversation_id == scoped_thread
+
+
+def test_old_worker_publication_falls_back_to_one_conversation_identity(
+    publication_stack: tuple[TestClient, str],
+    auth_headers: dict[str, str],
+    clean_db: None,
+) -> None:
+    from curie_worker.publication_store import PostgresPublicationStore
+
+    client, _ = publication_stack
+    deployment = _create_deployment(client, auth_headers)
+    payload = _publication_payload(
+        deployment["id"],
+        conversation_id="legacy-worker-conversation",
+        dedupe_key="legacy-worker-without-reply-conversation",
+    )
+
+    _, publication = _create_publication(client, payload)
+
+    stored = _rows(
+        "SELECT a.conversation_id AS reply_conversation_id, "
+        "l.conversation_id AS lineage_conversation_id "
+        "FROM curie.publications p "
+        "JOIN curie.approvals a ON a.id = p.approval_id "
+        "JOIN curie.thread_publication_lineages l ON l.id = p.lineage_id "
+        "WHERE p.id = :id",
+        {"id": publication["id"]},
+    )
+    assert stored == [
+        {
+            "reply_conversation_id": payload["conversation_id"],
+            "lineage_conversation_id": _workspace_identity(payload),
+        }
+    ]
+
+    _execute(
+        "UPDATE curie.publications "
+        "SET lineage_id = NULL, status = 'denied', patch_bytes = NULL, "
+        "approval_card_delivery_dead_lettered_at = now(), terminal_at = now() "
+        "WHERE id = :id",
+        {"id": publication["id"]},
+    )
+
+    async def claim_legacy_result() -> Any:
+        engine = create_async_engine(get_settings().database_url)
+        store = PostgresPublicationStore(
+            engine, schema="curie", lease_owner="legacy-lineageless-result"
+        )
+        try:
+            return await store.pending_result(uuid.UUID(publication["id"]))
+        finally:
+            await engine.dispose()
+
+    result = asyncio.run(claim_legacy_result())
+    assert result is not None
+    assert result.target.conversation_id == payload["conversation_id"]
+    assert result.workspace_conversation_id == _workspace_identity(payload)
 
 
 def test_exact_publication_replay_rechecks_the_current_thread_selection(
@@ -981,9 +1241,7 @@ def test_publication_result_store_separates_history_identity_from_bare_reply_rou
 
     result = asyncio.run(claim())
     assert result is not None
-    assert result.workspace_conversation_id == (
-        payload["conversation_id"] if legacy else _workspace_identity(payload)
-    )
+    assert result.workspace_conversation_id == _workspace_identity(payload)
     assert result.target.kind == payload["reply_kind"]
     assert result.target.address == payload["reply_channel"]
     assert result.target.conversation_id == payload["conversation_id"]
@@ -996,7 +1254,10 @@ def test_publication_card_and_result_claims_survive_process_replacement(
 ) -> None:
     """Expired leases reclaim, while failed result delivery observes backoff."""
 
-    from curie_worker.publication_store import PostgresPublicationStore
+    from curie_worker.publication_store import (
+        PostgresPublicationStore,
+        PublicationStoreError,
+    )
 
     client, _ = publication_stack
     deployment = _create_deployment(client, auth_headers)
@@ -1089,6 +1350,11 @@ def test_publication_card_and_result_claims_survive_process_replacement(
                 )
             retried_result = await first.pending_result(job.publication_id)
             assert retried_result is not None
+            with pytest.raises(
+                PublicationStoreError, match="publication result delivery CAS was lost"
+            ):
+                await first.mark_result_delivered(retried_result.publication_id)
+            await first.mark_outcome_history_ready(retried_result.publication_id)
             await first.mark_result_delivered(retried_result.publication_id)
             return (
                 abandoned_card.attempt,
@@ -1515,6 +1781,7 @@ class _LocalWorkspacePreparer:
             clean_clone_url=credential.clone_url,
             repo_full_name=credential.repo_full_name,
             base_sha=base_sha,
+            materialized_head=base_sha,
             checkout_mode=0o700,
             reference=self._workspace.WorkspaceRef(
                 url=f"https://objects.example.test/{object_key}",
@@ -1580,9 +1847,10 @@ class _RecordingWorkspaceCoordinator:
 def _testclient_transport(client: TestClient) -> Any:
     def transport(**request: Any) -> Any:
         parsed = urlsplit(str(request["url"]))
+        target = parsed.path + (f"?{parsed.query}" if parsed.query else "")
         response = client.request(
             str(request["method"]),
-            parsed.path,
+            target,
             headers=dict(request["headers"]),
             content=request.get("body"),
             follow_redirects=bool(request.get("allow_redirects", False)),
@@ -1662,7 +1930,6 @@ def test_coder_path_reaches_the_publication_boundary_through_real_runner_and_api
     runner_token = "coder-publication-runner-token"
     deployment = _create_deployment(client, auth_headers)
     conversation_id = "1700000000.000100"
-
     # A real, credential-free checkout supplies both the runner snapshot and
     # the worker's independently rehashed retained base.
     repo, base_sha, base_archive = _local_publication_repository(tmp_path, REPO)
@@ -1780,9 +2047,12 @@ def test_coder_path_reaches_the_publication_boundary_through_real_runner_and_api
         requests: list[dict[str, Any]] = []
 
         def approval_transport(request: httpx.Request) -> httpx.Response:
+            target = request.url.path
+            if request.url.query:
+                target += f"?{request.url.query.decode()}"
             response = client.request(
                 request.method,
-                request.url.path,
+                target,
                 headers=dict(request.headers),
                 content=request.content,
             )
@@ -1942,7 +2212,8 @@ def test_coder_path_reaches_the_publication_boundary_through_real_runner_and_api
     assert statuses == [201]
     assert len(requests) == 1
     assert "workspace_conversation_id" not in requests[0]
-    assert requests[0]["conversation_id"] == conversation_id
+    assert requests[0]["conversation_id"] == scoped
+    assert requests[0]["reply_conversation_id"] == conversation_id
     assert release_keys == [scoped]
     assert len(claims) == 1
     assert claims[0][0] == scoped
@@ -2130,9 +2401,12 @@ def test_kernel_publications_isolate_same_timestamp_across_slack_channels(
         requests: list[dict[str, Any]] = []
 
         def approval_transport(request: httpx.Request) -> httpx.Response:
+            target = request.url.path
+            if request.url.query:
+                target += f"?{request.url.query.decode()}"
             response = client.request(
                 request.method,
-                request.url.path,
+                target,
                 headers=dict(request.headers),
                 content=request.content,
             )
@@ -2718,7 +2992,7 @@ def test_publication_credential_is_approved_only_server_derived_and_audited(
 
 
 @pytest.mark.parametrize("legacy", [False, True])
-def test_publication_credential_rechecks_the_current_scoped_or_legacy_selection(
+def test_publication_credential_rechecks_canonical_selection_and_refuses_bare_fallback(
     publication_stack: tuple[TestClient, str],
     auth_headers: dict[str, str],
     clean_db: None,
@@ -2738,6 +3012,16 @@ def test_publication_credential_rechecks_the_current_scoped_or_legacy_selection(
     url = f"/v1/internal/publications/{publication['id']}/credential"
 
     issued = client.post(url, headers=WORKER_HEADERS)
+    if legacy:
+        assert issued.status_code == 403
+        audit = _rows(
+            "SELECT outcome, detail FROM curie.credential_redemption_audit_entries "
+            "WHERE publication_id = :id ORDER BY created_at, id",
+            {"id": publication["id"]},
+        )
+        assert [row["outcome"] for row in audit] == ["refused"]
+        assert "ghp_publication_operator" not in json.dumps(audit, default=str)
+        return
     assert issued.status_code == 200, issued.text
 
     _execute(
@@ -2746,9 +3030,7 @@ def test_publication_credential_rechecks_the_current_scoped_or_legacy_selection(
         "AND conversation_id = :conversation_id",
         {
             "deployment_id": deployment["id"],
-            "conversation_id": (
-                payload["conversation_id"] if legacy else _workspace_identity(payload)
-            ),
+            "conversation_id": _workspace_identity(payload),
         },
     )
     refused = client.post(url, headers=WORKER_HEADERS)
@@ -2762,6 +3044,51 @@ def test_publication_credential_rechecks_the_current_scoped_or_legacy_selection(
     )
     assert [row["outcome"] for row in audit] == ["issued", "refused"]
     assert "ghp_publication_operator" not in json.dumps(audit, default=str)
+
+
+def test_publication_credential_authorization_uses_scoped_lineage_identity(
+    publication_stack: tuple[TestClient, str],
+    auth_headers: dict[str, str],
+    clean_db: None,
+) -> None:
+    client, _ = publication_stack
+    deployment = _create_deployment(client, auth_headers)
+    scoped_thread = "slack:C0EXAMPLE1:1700000000.000100"
+    reply_thread = "1700000000.000100"
+    payload = _publication_payload(
+        deployment["id"],
+        conversation_id=scoped_thread,
+        dedupe_key="scoped-workspace-credential-authorization",
+    )
+    payload["reply_conversation_id"] = reply_thread
+    _, publication = _create_publication(client, payload)
+    approved = _resolve(client, auth_headers, publication["approval_id"])
+    assert approved.status_code == 200, approved.text
+    url = f"/v1/internal/publications/{publication['id']}/credential"
+
+    issued = client.post(url, headers=WORKER_HEADERS)
+    assert issued.status_code == 200, issued.text
+
+    _execute(
+        "DELETE FROM curie.thread_workspaces "
+        "WHERE selected_by_deployment_id = :deployment_id "
+        "AND conversation_id = :conversation_id",
+        {"deployment_id": deployment["id"], "conversation_id": scoped_thread},
+    )
+    bare_selection = client.post(
+        f"/v1/internal/workspaces/{deployment['id']}/selection",
+        json={
+            "conversation_id": reply_thread,
+            "author": payload["author"],
+            "repo_full_name": REPO,
+        },
+        headers=WORKER_HEADERS,
+    )
+    assert bare_selection.status_code == 200, bare_selection.text
+
+    refused = client.post(url, headers=WORKER_HEADERS)
+    assert refused.status_code == 403
+    assert "authorized" in refused.json()["detail"]
 
 
 def test_disabled_deployment_flag_still_allows_authorized_publication(
@@ -2903,3 +3230,1123 @@ def test_terminal_patch_retention_reaps_bytes_but_keeps_public_metadata(
     assert read.json()["status"] == "succeeded"
     assert read.json()["result_url"].endswith("/pull/123")
     _assert_patch_private(read.json(), "terminal-private-patch")
+
+
+def test_two_publication_revisions_advance_one_durable_thread_lineage(
+    publication_stack: tuple[TestClient, str],
+    auth_headers: dict[str, str],
+    clean_db: None,
+) -> None:
+    """Each approved snapshot advances one branch and one PR by an exact head."""
+
+    client, _ = publication_stack
+    deployment = _create_deployment(client, auth_headers)
+    conversation_id = "thread-two-revisions"
+    first_payload = _publication_payload(
+        deployment["id"],
+        conversation_id=conversation_id,
+        dedupe_key="lineage-revision-one",
+    )
+
+    first_status, first = _create_publication(client, first_payload)
+
+    assert first_status == 201
+    lineage_id = first["lineage_id"]
+    uuid.UUID(lineage_id)
+    assert first["revision_number"] == 1
+    assert first["expected_prior_head"] == BASE_SHA
+    assert first["lineage_base_sha"] == BASE_SHA
+    assert first["lineage_head_sha"] is None
+    assert first["lineage_state"] == "open"
+    assert first["lineage_version"] == 1
+    assert first["pr_number"] is None
+    assert first["pr_url"] is None
+    assert first["branch"].startswith("curie/publication-")
+
+    approved = _resolve(client, auth_headers, first["approval_id"])
+    assert approved.status_code == 200, approved.text
+    advanced = _advance_lineage(
+        client,
+        first["id"],
+        expected_version=1,
+        expected_head_sha=None,
+        head_sha=FIRST_REVISION_SHA,
+    )
+    assert advanced.status_code == 200, advanced.text
+    assert {
+        key: advanced.json()[key]
+        for key in (
+            "id",
+            "deployment_id",
+            "conversation_id",
+            "repo_full_name",
+            "base_sha",
+            "branch",
+            "pr_number",
+            "pr_url",
+            "head_sha",
+            "state",
+            "version",
+            "latest_revision",
+        )
+    } == {
+        "id": lineage_id,
+        "deployment_id": deployment["id"],
+        "conversation_id": _workspace_identity(first_payload),
+        "repo_full_name": REPO,
+        "base_sha": BASE_SHA,
+        "branch": first["branch"],
+        "pr_number": PR_NUMBER,
+        "pr_url": PR_URL,
+        "head_sha": FIRST_REVISION_SHA,
+        "state": "open",
+        "version": 2,
+        "latest_revision": 1,
+    }
+    assert (
+        client.get(f"/publications/{first['id']}", headers=auth_headers).json()[
+            "status"
+        ]
+        == "succeeded"
+    )
+    assert advanced.json()["has_pending_outcome"] is True
+    assert advanced.json()["visible_outcome_revision"] == 0
+    _mark_outcome_history_ready(first["id"])
+
+    second_payload = _publication_payload(
+        deployment["id"],
+        conversation_id=conversation_id,
+        base_sha=FIRST_REVISION_SHA,
+        dedupe_key="lineage-revision-two",
+    )
+    second_status, second = _create_publication(client, second_payload)
+
+    assert second_status == 201
+    assert second["lineage_id"] == lineage_id
+    assert second["revision_number"] == 2
+    assert second["expected_prior_head"] == FIRST_REVISION_SHA
+    assert second["branch"] == first["branch"]
+    assert second["pr_number"] == PR_NUMBER
+    assert second["pr_url"] == PR_URL
+    assert second["lineage_head_sha"] == FIRST_REVISION_SHA
+    assert second["lineage_version"] == 2
+
+    approved = _resolve(client, auth_headers, second["approval_id"])
+    assert approved.status_code == 200, approved.text
+    advanced = _advance_lineage(
+        client,
+        second["id"],
+        expected_version=2,
+        expected_head_sha=FIRST_REVISION_SHA,
+        head_sha=SECOND_REVISION_SHA,
+    )
+    assert advanced.status_code == 200, advanced.text
+    assert advanced.json()["id"] == lineage_id
+    assert advanced.json()["head_sha"] == SECOND_REVISION_SHA
+    assert advanced.json()["version"] == 3
+    assert advanced.json()["latest_revision"] == 2
+    assert advanced.json()["has_pending_outcome"] is True
+    assert advanced.json()["visible_outcome_revision"] == 1
+
+    current = _get_lineage_with_http(
+        client,
+        deployment_id=deployment["id"],
+        conversation_id=conversation_id,
+        handler=lambda _request: _healthy_github_pr(
+            branch=first["branch"], head_sha=SECOND_REVISION_SHA
+        ),
+    )
+    assert current.status_code == 200, current.text
+    assert current.json() == advanced.json()
+    assert _counts() == (2, 2)
+    assert _rows("SELECT count(*) AS count FROM curie.thread_publication_lineages") == [
+        {"count": 1}
+    ]
+
+
+def test_concurrent_first_revisions_create_one_lineage_and_one_approval(
+    publication_stack: tuple[TestClient, str],
+    auth_headers: dict[str, str],
+    clean_db: None,
+) -> None:
+    client, _ = publication_stack
+    deployment = _create_deployment(client, auth_headers)
+    conversation_id = "thread-concurrent-first-revision"
+    selected = client.post(
+        f"/v1/internal/workspaces/{deployment['id']}/selection",
+        json={
+            "conversation_id": channel_protocol.scoped_conversation_id(
+                "slack", "C0EXAMPLE1", conversation_id
+            ),
+            "author": "U0REQUEST1",
+            "repo_full_name": REPO,
+        },
+        headers=WORKER_HEADERS,
+    )
+    assert selected.status_code == 200, selected.text
+    payloads = [
+        _publication_payload(
+            deployment["id"],
+            conversation_id=conversation_id,
+            dedupe_key=f"concurrent-lineage-{index}",
+        )
+        for index in range(2)
+    ]
+
+    def attempt(payload: dict[str, Any]) -> Any:
+        return client.post(
+            "/v1/internal/publications", json=payload, headers=WORKER_HEADERS
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        responses = list(pool.map(attempt, payloads))
+
+    assert sorted(response.status_code for response in responses) == [201, 409]
+    conflict = next(response for response in responses if response.status_code == 409)
+    assert conflict.json()["detail"]["code"] == "publication.revision_conflict"
+    winner = next(response.json() for response in responses if response.status_code == 201)
+    assert winner["revision_number"] == 1
+    assert winner["pr_number"] is None
+    assert winner["lineage_head_sha"] is None
+    assert _counts() == (1, 1)
+    assert _rows("SELECT count(*) AS count FROM curie.thread_publication_lineages") == [
+        {"count": 1}
+    ]
+
+
+def test_denied_first_revision_leaves_absent_pr_create_path_available(
+    publication_stack: tuple[TestClient, str],
+    auth_headers: dict[str, str],
+    clean_db: None,
+) -> None:
+    client, _ = publication_stack
+    deployment = _create_deployment(client, auth_headers)
+    conversation_id = "thread-denied-first-revision"
+    _, first = _create_publication(
+        client,
+        _publication_payload(
+            deployment["id"],
+            conversation_id=conversation_id,
+            dedupe_key="denied-lineage-one",
+        ),
+    )
+    denied = _resolve(
+        client,
+        auth_headers,
+        first["approval_id"],
+        decision="rejected",
+    )
+    assert denied.status_code == 200, denied.text
+
+    after_denial = _get_lineage(
+        client,
+        deployment_id=deployment["id"],
+        conversation_id=conversation_id,
+    )
+    assert after_denial.status_code == 200, after_denial.text
+    assert after_denial.json()["pr_number"] is None
+    assert after_denial.json()["pr_url"] is None
+    assert after_denial.json()["head_sha"] is None
+    assert after_denial.json()["version"] == 1
+    assert after_denial.json()["has_pending_outcome"] is True
+    assert after_denial.json()["visible_outcome_revision"] == 0
+
+    blocked = client.post(
+        "/v1/internal/publications",
+        json=_publication_payload(
+            deployment["id"],
+            conversation_id=conversation_id,
+            dedupe_key="denied-lineage-two",
+        ),
+        headers=WORKER_HEADERS,
+    )
+    assert blocked.status_code == 409
+    assert blocked.json()["detail"]["code"] == "publication.outcome_pending"
+
+    _mark_outcome_history_ready(first["id"])
+    visible = _get_lineage(
+        client,
+        deployment_id=deployment["id"],
+        conversation_id=conversation_id,
+    )
+    assert visible.status_code == 200, visible.text
+    assert visible.json()["has_pending_outcome"] is False
+    assert visible.json()["visible_outcome_revision"] == 1
+    status_code, retry = _create_publication(
+        client,
+        _publication_payload(
+            deployment["id"],
+            conversation_id=conversation_id,
+            dedupe_key="denied-lineage-two-ready",
+        ),
+    )
+    assert status_code == 201
+    assert retry["lineage_id"] == first["lineage_id"]
+    assert retry["revision_number"] == 2
+    assert retry["branch"] == first["branch"]
+    assert retry["expected_prior_head"] == BASE_SHA
+    assert retry["pr_number"] is None
+    assert retry["pr_url"] is None
+    assert retry["lineage_head_sha"] is None
+    assert _counts() == (2, 2)
+
+
+def test_redeployment_reuses_agent_owned_thread_lineage(
+    publication_stack: tuple[TestClient, str],
+    auth_headers: dict[str, str],
+    clean_db: None,
+) -> None:
+    client, _ = publication_stack
+    first_deployment = _create_deployment(client, auth_headers)
+    conversation_id = "thread-same-agent-redeployment"
+    _, first = _create_publication(
+        client,
+        _publication_payload(
+            first_deployment["id"],
+            conversation_id=conversation_id,
+            dedupe_key="same-agent-redeployment-one",
+        ),
+    )
+    assert _resolve(client, auth_headers, first["approval_id"]).status_code == 200
+    advanced = _advance_lineage(
+        client,
+        first["id"],
+        expected_version=1,
+        expected_head_sha=None,
+        head_sha=FIRST_REVISION_SHA,
+    )
+    assert advanced.status_code == 200, advanced.text
+    _mark_outcome_history_ready(first["id"])
+
+    agent_id = first_deployment["agent_id"]
+    version = client.post(
+        f"/agents/{agent_id}/versions",
+        json={"version_label": "v2", "created_by": "operator"},
+        headers=auth_headers,
+    )
+    assert version.status_code == 201, version.text
+    redeployment = client.post(
+        "/deployments",
+        json={
+            "agent_id": agent_id,
+            "version_id": version.json()["id"],
+            "environment": "dev",
+            "workspace_enabled": True,
+        },
+        headers=auth_headers,
+    )
+    assert redeployment.status_code == 201, redeployment.text
+
+    _, second = _create_publication(
+        client,
+        _publication_payload(
+            redeployment.json()["id"],
+            conversation_id=conversation_id,
+            base_sha=FIRST_REVISION_SHA,
+            dedupe_key="same-agent-redeployment-two",
+        ),
+    )
+    assert second["lineage_id"] == first["lineage_id"]
+    assert second["branch"] == first["branch"]
+    assert second["pr_number"] == PR_NUMBER
+    assert second["revision_number"] == 2
+    assert _rows("SELECT count(*) AS count FROM curie.thread_publication_lineages") == [
+        {"count": 1}
+    ]
+
+
+def test_same_thread_and_repo_are_isolated_between_agents(
+    publication_stack: tuple[TestClient, str],
+    auth_headers: dict[str, str],
+    clean_db: None,
+) -> None:
+    client, _ = publication_stack
+    first_deployment = _create_deployment(client, auth_headers, channel="C0EXAMPLE1")
+    second_deployment = _create_deployment(client, auth_headers, channel="C0EXAMPLE2")
+    conversation_id = "thread-agent-isolation"
+
+    _, first = _create_publication(
+        client,
+        _publication_payload(
+            first_deployment["id"],
+            conversation_id=conversation_id,
+            dedupe_key="agent-isolation-one",
+        ),
+    )
+    _, second = _create_publication(
+        client,
+        _publication_payload(
+            second_deployment["id"],
+            conversation_id=conversation_id,
+            dedupe_key="agent-isolation-two",
+        ),
+    )
+
+    assert first["lineage_id"] != second["lineage_id"]
+    assert first["branch"] != second["branch"]
+    assert _rows("SELECT count(*) AS count FROM curie.thread_publication_lineages") == [
+        {"count": 2}
+    ]
+
+
+@pytest.mark.parametrize("terminal_state", ["merged", "closed"])
+def test_terminal_lineage_refuses_revision_and_credential_before_resolution(
+    publication_stack: tuple[TestClient, str],
+    auth_headers: dict[str, str],
+    clean_db: None,
+    monkeypatch: pytest.MonkeyPatch,
+    terminal_state: str,
+) -> None:
+    client, _ = publication_stack
+    deployment = _create_deployment(client, auth_headers)
+    conversation_id = f"thread-{terminal_state}-lineage"
+    _, first = _create_publication(
+        client,
+        _publication_payload(
+            deployment["id"],
+            conversation_id=conversation_id,
+            dedupe_key=f"{terminal_state}-lineage-one",
+        ),
+    )
+    assert _resolve(client, auth_headers, first["approval_id"]).status_code == 200
+    opened = _advance_lineage(
+        client,
+        first["id"],
+        expected_version=1,
+        expected_head_sha=None,
+        head_sha=FIRST_REVISION_SHA,
+    )
+    assert opened.status_code == 200, opened.text
+    _mark_outcome_history_ready(first["id"])
+    _, pending = _create_publication(
+        client,
+        _publication_payload(
+            deployment["id"],
+            conversation_id=conversation_id,
+            base_sha=FIRST_REVISION_SHA,
+            dedupe_key=f"{terminal_state}-lineage-two",
+        ),
+    )
+    assert _resolve(client, auth_headers, pending["approval_id"]).status_code == 200
+    terminal = _advance_lineage(
+        client,
+        pending["id"],
+        expected_version=2,
+        expected_head_sha=FIRST_REVISION_SHA,
+        head_sha=FIRST_REVISION_SHA,
+        state=terminal_state,
+    )
+    assert terminal.status_code == 200, terminal.text
+    assert terminal.json()["state"] == terminal_state
+
+    def forbidden_resolver(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("terminal lineage reached credential resolution")
+
+    monkeypatch.setattr(
+        "curie_api.routers.publications.resolve_repository_credential",
+        forbidden_resolver,
+    )
+    credential = client.post(
+        f"/v1/internal/publications/{pending['id']}/credential",
+        headers=WORKER_HEADERS,
+    )
+    assert credential.status_code == 409
+    assert credential.headers["cache-control"] == "no-store"
+    assert credential.json()["detail"]["code"] == "publication.lineage_terminal"
+
+    refused = client.post(
+        "/v1/internal/publications",
+        json=_publication_payload(
+            deployment["id"],
+            conversation_id=conversation_id,
+            base_sha=FIRST_REVISION_SHA,
+            dedupe_key=f"{terminal_state}-lineage-three",
+        ),
+        headers=WORKER_HEADERS,
+    )
+    assert refused.status_code == 409
+    assert refused.json()["detail"]["code"] == "publication.lineage_terminal"
+    assert _counts() == (2, 2)
+    assert _rows(
+        "SELECT outcome FROM curie.credential_redemption_audit_entries "
+        "WHERE publication_id = :id ORDER BY created_at, id",
+        {"id": pending["id"]},
+    ) == [{"outcome": "refused"}]
+
+
+def test_publication_revision_refuses_a_checkout_not_at_the_lineage_head(
+    publication_stack: tuple[TestClient, str],
+    auth_headers: dict[str, str],
+    clean_db: None,
+) -> None:
+    client, _ = publication_stack
+    deployment = _create_deployment(client, auth_headers)
+    conversation_id = "thread-stale-checkout-head"
+    _, first = _create_publication(
+        client,
+        _publication_payload(
+            deployment["id"],
+            conversation_id=conversation_id,
+            dedupe_key="stale-checkout-one",
+        ),
+    )
+    assert _resolve(client, auth_headers, first["approval_id"]).status_code == 200
+    advanced = _advance_lineage(
+        client,
+        first["id"],
+        expected_version=1,
+        expected_head_sha=None,
+        head_sha=FIRST_REVISION_SHA,
+    )
+    assert advanced.status_code == 200, advanced.text
+    _mark_outcome_history_ready(first["id"])
+
+    stale = client.post(
+        "/v1/internal/publications",
+        json=_publication_payload(
+            deployment["id"],
+            conversation_id=conversation_id,
+            base_sha=EXTERNAL_REVISION_SHA,
+            dedupe_key="stale-checkout-two",
+        ),
+        headers=WORKER_HEADERS,
+    )
+
+    assert stale.status_code == 409
+    assert stale.json()["detail"]["code"] == "publication.lineage_stale"
+    assert _counts() == (1, 1)
+    current = _get_lineage_with_http(
+        client,
+        deployment_id=deployment["id"],
+        conversation_id=conversation_id,
+        handler=lambda _request: _healthy_github_pr(
+            branch=first["branch"], head_sha=FIRST_REVISION_SHA
+        ),
+    ).json()
+    assert current["head_sha"] == FIRST_REVISION_SHA
+    assert current["version"] == 2
+
+
+def test_lineage_advance_cas_refuses_stale_version_and_expected_head(
+    publication_stack: tuple[TestClient, str],
+    auth_headers: dict[str, str],
+    clean_db: None,
+) -> None:
+    client, _ = publication_stack
+    deployment = _create_deployment(client, auth_headers)
+    conversation_id = "thread-lineage-cas"
+    _, first = _create_publication(
+        client,
+        _publication_payload(
+            deployment["id"],
+            conversation_id=conversation_id,
+            dedupe_key="lineage-cas-one",
+        ),
+    )
+    assert _resolve(client, auth_headers, first["approval_id"]).status_code == 200
+    assert (
+        _advance_lineage(
+            client,
+            first["id"],
+            expected_version=1,
+            expected_head_sha=None,
+            head_sha=FIRST_REVISION_SHA,
+        ).status_code
+        == 200
+    )
+    _mark_outcome_history_ready(first["id"])
+    _, second = _create_publication(
+        client,
+        _publication_payload(
+            deployment["id"],
+            conversation_id=conversation_id,
+            base_sha=FIRST_REVISION_SHA,
+            dedupe_key="lineage-cas-two",
+        ),
+    )
+    assert _resolve(client, auth_headers, second["approval_id"]).status_code == 200
+
+    stale_version = _advance_lineage(
+        client,
+        second["id"],
+        expected_version=1,
+        expected_head_sha=FIRST_REVISION_SHA,
+        head_sha=SECOND_REVISION_SHA,
+    )
+    assert stale_version.status_code == 409
+    assert stale_version.json()["detail"]["code"] == "publication.lineage_stale"
+    stale_head = _advance_lineage(
+        client,
+        second["id"],
+        expected_version=2,
+        expected_head_sha=EXTERNAL_REVISION_SHA,
+        head_sha=SECOND_REVISION_SHA,
+    )
+    assert stale_head.status_code == 409
+    assert stale_head.json()["detail"]["code"] == "publication.lineage_stale"
+
+    current = _get_lineage_with_http(
+        client,
+        deployment_id=deployment["id"],
+        conversation_id=conversation_id,
+        handler=lambda _request: _healthy_github_pr(
+            branch=first["branch"], head_sha=FIRST_REVISION_SHA
+        ),
+    ).json()
+    assert current["head_sha"] == FIRST_REVISION_SHA
+    assert current["version"] == 2
+    assert (
+        client.get(f"/publications/{second['id']}", headers=auth_headers).json()[
+            "status"
+        ]
+        == "approved"
+    )
+
+
+def test_concurrent_lineage_advances_have_one_exact_cas_winner(
+    publication_stack: tuple[TestClient, str],
+    auth_headers: dict[str, str],
+    clean_db: None,
+) -> None:
+    client, _ = publication_stack
+    deployment = _create_deployment(client, auth_headers)
+    conversation_id = "thread-concurrent-lineage-cas"
+    _, first = _create_publication(
+        client,
+        _publication_payload(
+            deployment["id"],
+            conversation_id=conversation_id,
+            dedupe_key="concurrent-cas-one",
+        ),
+    )
+    assert _resolve(client, auth_headers, first["approval_id"]).status_code == 200
+    assert (
+        _advance_lineage(
+            client,
+            first["id"],
+            expected_version=1,
+            expected_head_sha=None,
+            head_sha=FIRST_REVISION_SHA,
+        ).status_code
+        == 200
+    )
+    _mark_outcome_history_ready(first["id"])
+    _, second = _create_publication(
+        client,
+        _publication_payload(
+            deployment["id"],
+            conversation_id=conversation_id,
+            base_sha=FIRST_REVISION_SHA,
+            dedupe_key="concurrent-cas-two",
+        ),
+    )
+    assert _resolve(client, auth_headers, second["approval_id"]).status_code == 200
+
+    def attempt(head_sha: str) -> Any:
+        return _advance_lineage(
+            client,
+            second["id"],
+            expected_version=2,
+            expected_head_sha=FIRST_REVISION_SHA,
+            head_sha=head_sha,
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        responses = list(pool.map(attempt, [SECOND_REVISION_SHA, EXTERNAL_REVISION_SHA]))
+
+    assert sorted(response.status_code for response in responses) == [200, 409]
+    loser = next(response for response in responses if response.status_code == 409)
+    assert loser.json()["detail"]["code"] == "publication.lineage_stale"
+    winner = next(response.json() for response in responses if response.status_code == 200)
+    current = _get_lineage_with_http(
+        client,
+        deployment_id=deployment["id"],
+        conversation_id=conversation_id,
+        handler=lambda _request: _healthy_github_pr(
+            branch=first["branch"], head_sha=winner["head_sha"]
+        ),
+    ).json()
+    assert current["head_sha"] == winner["head_sha"]
+    assert current["version"] == 3
+    assert current["latest_revision"] == 2
+
+
+def test_lineage_get_refreshes_stored_pr_truth_and_reports_pending_revision_safely(
+    publication_stack: tuple[TestClient, str],
+    auth_headers: dict[str, str],
+    clean_db: None,
+) -> None:
+    client, _ = publication_stack
+    conversation_id = "thread-refresh-open-lineage"
+    deployment, first = _open_lineage(
+        client,
+        auth_headers,
+        conversation_id=conversation_id,
+    )
+    _, pending = _create_publication(
+        client,
+        _publication_payload(
+            deployment["id"],
+            conversation_id=conversation_id,
+            base_sha=FIRST_REVISION_SHA,
+            dedupe_key="refresh-open-lineage-revision-two",
+        ),
+    )
+    calls: list[httpx.Request] = []
+
+    def github(request: httpx.Request) -> httpx.Response:
+        calls.append(request)
+        # GitHub's Get a pull request response owns ``state``, ``merged``,
+        # ``html_url``, and base/head refs and SHAs:
+        # https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#get-a-pull-request
+        return httpx.Response(
+            200,
+            json={
+                "number": PR_NUMBER,
+                "html_url": PR_URL,
+                "state": "open",
+                "merged": False,
+                "base": {"ref": "main", "sha": BASE_SHA},
+                "head": {
+                    "ref": first["branch"],
+                    "sha": FIRST_REVISION_SHA,
+                },
+            },
+        )
+
+    refreshed = _get_lineage_with_http(
+        client,
+        deployment_id=deployment["id"],
+        conversation_id=conversation_id,
+        handler=github,
+    )
+
+    assert refreshed.status_code == 200, refreshed.text
+    body = refreshed.json()
+    assert set(body) == {
+        "id",
+        "deployment_id",
+        "conversation_id",
+        "repo_full_name",
+        "base_sha",
+        "branch",
+        "pr_number",
+        "pr_url",
+        "head_sha",
+        "state",
+        "version",
+        "latest_revision",
+        "has_pending_revision",
+        "has_pending_outcome",
+        "visible_outcome_revision",
+    }
+    assert body["id"] == first["lineage_id"]
+    assert body["pr_number"] == PR_NUMBER
+    assert body["pr_url"] == PR_URL
+    assert body["head_sha"] == FIRST_REVISION_SHA
+    assert body["state"] == "open"
+    assert body["latest_revision"] == 2
+    assert body["has_pending_revision"] is True
+    assert body["has_pending_outcome"] is False
+    assert body["visible_outcome_revision"] == 1
+    assert len(calls) == 1
+    assert calls[0].method == "GET"
+    assert calls[0].url.path == f"/repos/{REPO}/pulls/{PR_NUMBER}"
+    assert calls[0].headers["accept"] == "application/vnd.github+json"
+    assert calls[0].headers["x-github-api-version"] == "2022-11-28"
+    assert calls[0].headers["authorization"].startswith("Basic ")
+    rendered = json.dumps(body, sort_keys=True)
+    assert pending["id"] not in rendered
+    assert "authorization" not in rendered.casefold()
+    assert "credential" not in rendered.casefold()
+    assert "token" not in rendered.casefold()
+    assert _rows("SELECT * FROM curie.credential_redemption_audit_entries") == []
+
+
+def test_lineage_get_refuses_redirect_without_forwarding_authorization(
+    publication_stack: tuple[TestClient, str],
+    auth_headers: dict[str, str],
+    clean_db: None,
+) -> None:
+    """An authorization-bearing GitHub read stops at the first origin."""
+
+    client, _ = publication_stack
+    conversation_id = "thread-refresh-redirect-lineage"
+    deployment, publication = _open_lineage(
+        client,
+        auth_headers,
+        conversation_id=conversation_id,
+    )
+    calls: list[httpx.Request] = []
+
+    def github(request: httpx.Request) -> httpx.Response:
+        calls.append(request)
+        if len(calls) == 1:
+            return httpx.Response(
+                302,
+                headers={"Location": "https://capture.example.test/pull"},
+            )
+        raise AssertionError("the redirect target received the GitHub request")
+
+    # The app-wide client may follow redirects for unrelated consumers. The
+    # credentialed lineage operation must override that behavior at its callsite.
+    injected = httpx.AsyncClient(
+        transport=httpx.MockTransport(github),
+        follow_redirects=True,
+    )
+    original = client.app.state.http_client
+    client.app.state.http_client = injected
+    try:
+        refused = _get_lineage(
+            client,
+            deployment_id=deployment["id"],
+            conversation_id=conversation_id,
+        )
+    finally:
+        client.app.state.http_client = original
+        asyncio.run(injected.aclose())
+
+    assert refused.status_code == 503
+    assert refused.json()["detail"]["code"] == "publication.github_unavailable"
+    assert len(calls) == 1
+    assert calls[0].url.path == f"/repos/{REPO}/pulls/{PR_NUMBER}"
+    assert "Authorization" in calls[0].headers
+    assert _rows(
+        "SELECT status, head_sha, version FROM curie.thread_publication_lineages "
+        "WHERE id = :id",
+        {"id": uuid.UUID(publication["lineage_id"])},
+    ) == [{"status": "open", "head_sha": FIRST_REVISION_SHA, "version": 2}]
+
+
+@pytest.mark.parametrize("upstream_status", [403, 404, 429, 500, 502])
+def test_lineage_get_refuses_non_200_github_truth_without_mutating_lineage(
+    publication_stack: tuple[TestClient, str],
+    auth_headers: dict[str, str],
+    clean_db: None,
+    upstream_status: int,
+) -> None:
+    client, _ = publication_stack
+    conversation_id = f"thread-refresh-http-{upstream_status}-lineage"
+    deployment, publication = _open_lineage(
+        client,
+        auth_headers,
+        conversation_id=conversation_id,
+    )
+
+    refused = _get_lineage_with_http(
+        client,
+        deployment_id=deployment["id"],
+        conversation_id=conversation_id,
+        handler=lambda _request: httpx.Response(upstream_status),
+    )
+
+    assert refused.status_code == 503
+    detail = refused.json()["detail"]
+    assert detail["code"] == "publication.github_unavailable"
+    assert "Try again later" in detail["message"]
+    assert _rows(
+        "SELECT status, head_sha, version FROM curie.thread_publication_lineages "
+        "WHERE id = :id",
+        {"id": uuid.UUID(publication["lineage_id"])},
+    ) == [{"status": "open", "head_sha": FIRST_REVISION_SHA, "version": 2}]
+    assert _rows("SELECT * FROM curie.credential_redemption_audit_entries") == []
+
+
+def test_lineage_get_refuses_github_transport_failure_without_mutating_lineage(
+    publication_stack: tuple[TestClient, str],
+    auth_headers: dict[str, str],
+    clean_db: None,
+) -> None:
+    client, _ = publication_stack
+    conversation_id = "thread-refresh-transport-lineage"
+    deployment, publication = _open_lineage(
+        client,
+        auth_headers,
+        conversation_id=conversation_id,
+    )
+
+    def unavailable(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("upstream unavailable", request=request)
+
+    refused = _get_lineage_with_http(
+        client,
+        deployment_id=deployment["id"],
+        conversation_id=conversation_id,
+        handler=unavailable,
+    )
+
+    assert refused.status_code == 503
+    assert refused.json()["detail"]["code"] == "publication.github_unavailable"
+    assert _rows(
+        "SELECT status, head_sha, version FROM curie.thread_publication_lineages "
+        "WHERE id = :id",
+        {"id": uuid.UUID(publication["lineage_id"])},
+    ) == [{"status": "open", "head_sha": FIRST_REVISION_SHA, "version": 2}]
+    assert _rows("SELECT * FROM curie.credential_redemption_audit_entries") == []
+
+
+def test_lineage_get_adopts_head_for_migrated_succeeded_publication(
+    publication_stack: tuple[TestClient, str],
+    auth_headers: dict[str, str],
+    clean_db: None,
+) -> None:
+    """A legacy URL-only lineage learns its existing PR head exactly once."""
+
+    client, _ = publication_stack
+    conversation_id = "thread-migrated-succeeded-lineage"
+    deployment, publication = _open_lineage(
+        client,
+        auth_headers,
+        conversation_id=conversation_id,
+    )
+
+    async def clear_migration_unknown_head() -> None:
+        from curie_api.models import ThreadPublicationLineage
+
+        engine = create_async_engine(get_settings().database_url)
+        sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
+        try:
+            async with sessionmaker() as session:
+                await session.execute(
+                    update(ThreadPublicationLineage)
+                    .where(
+                        ThreadPublicationLineage.id
+                        == uuid.UUID(publication["lineage_id"])
+                    )
+                    .values(head_sha=None, version=1)
+                )
+                await session.commit()
+        finally:
+            await engine.dispose()
+
+    asyncio.run(clear_migration_unknown_head())
+
+    def github(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "number": PR_NUMBER,
+                "html_url": PR_URL,
+                "state": "open",
+                "merged": False,
+                "base": {"ref": "main", "sha": BASE_SHA},
+                "head": {
+                    "ref": publication["branch"],
+                    "sha": FIRST_REVISION_SHA,
+                },
+            },
+        )
+
+    refreshed = _get_lineage_with_http(
+        client,
+        deployment_id=deployment["id"],
+        conversation_id=conversation_id,
+        handler=github,
+    )
+
+    assert refreshed.status_code == 200, refreshed.text
+    assert refreshed.json()["head_sha"] == FIRST_REVISION_SHA
+    assert refreshed.json()["version"] == 2
+    assert _rows(
+        "SELECT head_sha, version FROM curie.thread_publication_lineages "
+        "WHERE id = :id",
+        {"id": uuid.UUID(publication["lineage_id"])},
+    ) == [{"head_sha": FIRST_REVISION_SHA, "version": 2}]
+
+
+@pytest.mark.parametrize(
+    ("merged", "expected_state"),
+    [(True, "merged"), (False, "closed")],
+)
+def test_lineage_get_persists_terminal_github_truth_without_credential_redemption(
+    publication_stack: tuple[TestClient, str],
+    auth_headers: dict[str, str],
+    clean_db: None,
+    merged: bool,
+    expected_state: str,
+) -> None:
+    client, _ = publication_stack
+    conversation_id = f"thread-refresh-{expected_state}-lineage"
+    deployment, publication = _open_lineage(
+        client,
+        auth_headers,
+        conversation_id=conversation_id,
+    )
+    calls: list[httpx.Request] = []
+
+    def github(request: httpx.Request) -> httpx.Response:
+        calls.append(request)
+        return httpx.Response(
+            200,
+            json={
+                "number": PR_NUMBER,
+                "html_url": PR_URL,
+                "state": "closed",
+                "merged": merged,
+                "base": {"ref": "main", "sha": BASE_SHA},
+                "head": {
+                    "ref": publication["branch"],
+                    "sha": FIRST_REVISION_SHA,
+                },
+            },
+        )
+
+    refreshed = _get_lineage_with_http(
+        client,
+        deployment_id=deployment["id"],
+        conversation_id=conversation_id,
+        handler=github,
+    )
+
+    assert refreshed.status_code == 200, refreshed.text
+    assert refreshed.json()["state"] == expected_state
+    assert refreshed.json()["head_sha"] == FIRST_REVISION_SHA
+    assert refreshed.json()["has_pending_revision"] is False
+    assert refreshed.json()["version"] == 3
+    assert len(calls) == 1
+    stored = client.get(
+        f"/publications/{publication['id']}", headers=auth_headers
+    )
+    assert stored.status_code == 200, stored.text
+    assert stored.json()["lineage_state"] == expected_state
+    assert _rows("SELECT * FROM curie.credential_redemption_audit_entries") == []
+
+
+@pytest.mark.parametrize("revision_status", ["approved", "launching", "running"])
+def test_lineage_get_reports_pending_revision_while_its_push_is_in_flight(
+    publication_stack: tuple[TestClient, str],
+    auth_headers: dict[str, str],
+    clean_db: None,
+    revision_status: str,
+) -> None:
+    client, _ = publication_stack
+    conversation_id = f"thread-refresh-in-flight-{revision_status}"
+    deployment, first = _open_lineage(
+        client,
+        auth_headers,
+        conversation_id=conversation_id,
+    )
+    _, revision = _create_publication(
+        client,
+        _publication_payload(
+            deployment["id"],
+            conversation_id=conversation_id,
+            base_sha=FIRST_REVISION_SHA,
+            dedupe_key=f"refresh-in-flight-{revision_status}",
+        ),
+    )
+    approved = _resolve(client, auth_headers, revision["approval_id"])
+    assert approved.status_code == 200, approved.text
+    if revision_status != "approved":
+        _execute(
+            "UPDATE curie.publications SET status = :status WHERE id = :id",
+            {"status": revision_status, "id": uuid.UUID(revision["id"])},
+        )
+
+    def github(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "number": PR_NUMBER,
+                "html_url": PR_URL,
+                "state": "open",
+                "merged": False,
+                "base": {"ref": "main", "sha": BASE_SHA},
+                "head": {
+                    "ref": first["branch"],
+                    "sha": SECOND_REVISION_SHA,
+                },
+            },
+        )
+
+    refreshed = _get_lineage_with_http(
+        client,
+        deployment_id=deployment["id"],
+        conversation_id=conversation_id,
+        handler=github,
+    )
+
+    assert refreshed.status_code == 200, refreshed.text
+    body = refreshed.json()
+    assert body["head_sha"] == FIRST_REVISION_SHA
+    assert body["version"] == 2
+    assert body["latest_revision"] == 2
+    assert body["has_pending_revision"] is True
+    assert _rows(
+        "SELECT head_sha, version FROM curie.thread_publication_lineages WHERE id = :id",
+        {"id": uuid.UUID(first["lineage_id"])},
+    ) == [{"head_sha": FIRST_REVISION_SHA, "version": 2}]
+
+
+def test_lineage_get_reports_external_head_without_pending_revision_or_overwrite(
+    publication_stack: tuple[TestClient, str],
+    auth_headers: dict[str, str],
+    clean_db: None,
+) -> None:
+    client, _ = publication_stack
+    conversation_id = "thread-refresh-stale-lineage"
+    deployment, publication = _open_lineage(
+        client,
+        auth_headers,
+        conversation_id=conversation_id,
+    )
+
+    def github(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "number": PR_NUMBER,
+                "html_url": PR_URL,
+                "state": "open",
+                "merged": False,
+                "base": {"ref": "main", "sha": BASE_SHA},
+                "head": {
+                    "ref": publication["branch"],
+                    "sha": EXTERNAL_REVISION_SHA,
+                },
+            },
+        )
+
+    stale = _get_lineage_with_http(
+        client,
+        deployment_id=deployment["id"],
+        conversation_id=conversation_id,
+        handler=github,
+    )
+
+    assert stale.status_code == 409
+    detail = stale.json()["detail"]
+    assert detail["code"] == "publication.lineage_stale"
+    assert detail["expected_head_sha"] == FIRST_REVISION_SHA
+    assert detail["actual_head_sha"] == EXTERNAL_REVISION_SHA
+    assert "credential" not in json.dumps(detail, sort_keys=True).casefold()
+    stored = client.get(
+        f"/publications/{publication['id']}", headers=auth_headers
+    )
+    assert stored.status_code == 200, stored.text
+    assert stored.json()["lineage_head_sha"] == FIRST_REVISION_SHA
+    assert stored.json()["lineage_state"] == "open"
+    assert _rows("SELECT * FROM curie.credential_redemption_audit_entries") == []
+
+
+@pytest.mark.parametrize(
+    ("operation", "method"),
+    [
+        ("/v1/internal/publications/lineage", "GET"),
+        ("/v1/internal/publications/{publication_id}/lineage", "PATCH"),
+    ],
+)
+def test_publication_lineage_route_operations_are_in_every_http_metric_domain(
+    operation: str,
+    method: str,
+) -> None:
+    active = {
+        "service.name": "curie-api",
+        "operation": operation,
+        "role": "server",
+        "source": method,
+    }
+    record_metric("curie.http.server.active", 1, attributes=active)
+    complete = {**active, "outcome": "2xx"}
+    record_metric("curie.http.server.request", attributes=complete)
+    record_metric("curie.http.server.request.duration", 0.001, attributes=complete)

--- a/apps/api/tests/test_schema_compat.py
+++ b/apps/api/tests/test_schema_compat.py
@@ -20,6 +20,7 @@ from alembic import command
 from alembic.config import Config
 from curie_api.config import get_settings
 from curie_api.schema_compat import (
+    KIND_CONTRACT,
     KIND_EXPAND,
     KIND_IRREVERSIBLE,
     AppWindow,
@@ -36,8 +37,8 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import create_async_engine
 
 ALEMBIC_DIR = Path(__file__).resolve().parents[1] / "alembic"
-HEAD = "0040"
-PREV = "0039"
+HEAD = "0041"
+PREV = "0040"
 
 
 def _alembic_config() -> Config:
@@ -80,14 +81,14 @@ def test_released_application_declares_a_machine_readable_window() -> None:
     assert window.schema_min == HEAD
     assert window.schema_head == HEAD
     kinds = load_kinds()
-    assert kinds[HEAD] == KIND_EXPAND
+    assert kinds[HEAD] == KIND_CONTRACT
     assert kinds[PREV] == KIND_EXPAND
     assert kinds["0016"] == KIND_IRREVERSIBLE
 
 
-def test_planner_applies_an_expand_and_marks_rollback_compatible() -> None:
+def test_planner_refuses_0041_contract_without_forward_only() -> None:
     window = AppWindow(schema_min=HEAD, schema_head=HEAD)
-    kinds = {PREV: KIND_EXPAND, HEAD: KIND_EXPAND}
+    kinds = {PREV: KIND_EXPAND, HEAD: KIND_CONTRACT}
     decision = plan_upgrade(
         current_revision=PREV,
         window=window,
@@ -95,10 +96,11 @@ def test_planner_applies_an_expand_and_marks_rollback_compatible() -> None:
         pending=(HEAD,),
         forward_only=False,
     )
-    assert decision.action == "apply"
-    assert decision.rollback_compatible is True
+    assert decision.action == "refuse"
+    assert decision.rollback_compatible is False
     assert decision.pending[0].revision == HEAD
-    assert decision.pending[0].kind == KIND_EXPAND
+    assert decision.pending[0].kind == KIND_CONTRACT
+    assert "forward-only" in decision.reason.lower()
 
 
 def test_planner_refuses_irreversible_before_mutation() -> None:
@@ -151,7 +153,7 @@ def test_already_at_head_is_noop() -> None:
     decision = plan_upgrade(
         current_revision=HEAD,
         window=window,
-        kinds={HEAD: KIND_EXPAND},
+        kinds={HEAD: KIND_CONTRACT},
         pending=(),
         forward_only=False,
     )
@@ -170,11 +172,12 @@ def test_assert_servable_refuses_below_min(isolated_migration_db: None) -> None:
 
 
 def test_n_minus_one_can_serve_an_unknown_newer_expand() -> None:
-    window = AppWindow(schema_min=PREV, schema_head=PREV)
-    known = {PREV, "0038"}
+    future_expand = "0042"
+    window = AppWindow(schema_min=HEAD, schema_head=HEAD)
+    known = {HEAD, PREV}
+    assert can_serve(future_expand, window, known) is True
     assert can_serve(HEAD, window, known) is True
-    assert can_serve(PREV, window, known) is True
-    assert can_serve("0038", window, known) is False
+    assert can_serve(PREV, window, known) is False
     assert can_serve(None, window, known) is False
 
 
@@ -183,9 +186,9 @@ def test_decision_json_is_redacted() -> None:
     decision = plan_upgrade(
         current_revision=PREV,
         window=window,
-        kinds={HEAD: KIND_EXPAND},
+        kinds={HEAD: KIND_CONTRACT},
         pending=(HEAD,),
-        forward_only=False,
+        forward_only=True,
     )
     payload = json.dumps(render_decision(decision))
     lowered = payload.lower()
@@ -196,14 +199,10 @@ def test_decision_json_is_redacted() -> None:
     assert HEAD in payload
 
 
-def test_upgrade_then_n_minus_one_serve_same_nonempty_database(
+def test_0041_contract_requires_forward_only_and_closes_n_minus_one_window(
     isolated_migration_db: None,
 ) -> None:
-    """Upgrade 0039 -> 0040 on one seeded database, then serve as N-1.
-
-    0040 is an expand (nullable column). The N-1 application does not know
-    revision 0040; after the upgrade it must still read the seeded row.
-    """
+    """0041 cannot run while N-1 remains eligible to serve the database."""
     cfg = _alembic_config()
     command.upgrade(cfg, PREV)
     assert current_revision() == PREV
@@ -218,7 +217,7 @@ def test_upgrade_then_n_minus_one_serve_same_nonempty_database(
             "id": approval_id,
             "conversation_id": "th-compat-2300",
             "author": "U1",
-            "summary": "seeded before expand",
+            "summary": "seeded before contract",
             "reply_kind": "slack",
             "reply_channel": "C0EXAMPLE1",
             "reply_placeholder": None,
@@ -226,38 +225,40 @@ def test_upgrade_then_n_minus_one_serve_same_nonempty_database(
         },
     )
 
-    outcome = apply_upgrade(forward_only=False, alembic_config=cfg)
+    refused = apply_upgrade(forward_only=False, alembic_config=cfg)
+    assert refused.action == "refuse"
+    assert refused.outcome == "refused"
+    assert refused.rollback_compatible is False
+    assert refused.pending[0].kind == KIND_CONTRACT
+    assert current_revision() == PREV
+
+    outcome = apply_upgrade(forward_only=True, alembic_config=cfg)
     assert outcome.action == "apply"
     assert outcome.outcome == "applied"
-    assert outcome.rollback_compatible is True
+    assert outcome.rollback_compatible is False
+    assert outcome.forward_only is True
     assert current_revision() == HEAD
 
     rows = _sql(
         "SELECT summary FROM curie.approvals WHERE id = :id",
         {"id": approval_id},
     )
-    assert rows == [("seeded before expand",)]
+    assert rows == [("seeded before contract",)]
 
-    # The expand column exists and is null on the preserved row.
-    col = _sql(
-        "SELECT workspace_conversation_id FROM curie.publications LIMIT 0"
-    )
+    # The contract migration preserves rows, but its new schema is N-only.
+    col = _sql("SELECT outcome_history_ready_at FROM curie.publications LIMIT 0")
     assert col == []
     pubs = _sql(
         "SELECT column_name FROM information_schema.columns "
         "WHERE table_schema = 'curie' AND table_name = 'publications' "
-        "AND column_name = 'workspace_conversation_id'"
+        "AND column_name = 'outcome_history_ready_at'"
     )
-    assert pubs, "0040 expand column must exist after upgrade"
+    assert pubs, "0041 contract column must exist after upgrade"
 
-    n1 = AppWindow(schema_min=PREV, schema_head=PREV)
-    assert can_serve(current_revision(), n1, {PREV}) is True
-
-    # Red-on-revert: the N application (min=0040) refuses a database that
-    # is still at 0039. Expand rollback is application rollback, not schema
-    # downgrade; serving N against the pre-expand revision is the unsupported
-    # direction.
+    # Red-on-revert: min=head=0041 closes the application rollback window.
     n = load_window()
+    assert n.schema_min == HEAD
+    assert n.schema_head == HEAD
     assert can_serve(PREV, n, {PREV, HEAD}) is False
 
 
@@ -281,32 +282,13 @@ def test_crash_retry_does_not_double_apply(
     alembic_copy = tmp_path / "alembic"
     shutil.copytree(ALEMBIC_DIR, alembic_copy)
     versions = alembic_copy / "versions"
-    (versions / "0041_compat_first.py").write_text(
+    (versions / "0042_compat_first.py").write_text(
         '''
-revision = "0041"
-down_revision = "0040"
-
-def upgrade():
-    from alembic import op
-    op.execute(
-        "INSERT INTO curie.compat_probe (rev) VALUES ('0041')"
-    )
-
-def downgrade():
-    from alembic import op
-    op.execute("DELETE FROM curie.compat_probe WHERE rev = '0041'")
-'''
-    )
-    (versions / "0042_compat_second.py").write_text(
-        '''
-import os
 revision = "0042"
 down_revision = "0041"
 
 def upgrade():
     from alembic import op
-    if os.environ.get("CURIE_COMPAT_PROBE_CRASH") == "1":
-        raise RuntimeError("injected crash after 0041")
     op.execute(
         "INSERT INTO curie.compat_probe (rev) VALUES ('0042')"
     )
@@ -314,6 +296,25 @@ def upgrade():
 def downgrade():
     from alembic import op
     op.execute("DELETE FROM curie.compat_probe WHERE rev = '0042'")
+'''
+    )
+    (versions / "0043_compat_second.py").write_text(
+        '''
+import os
+revision = "0043"
+down_revision = "0042"
+
+def upgrade():
+    from alembic import op
+    if os.environ.get("CURIE_COMPAT_PROBE_CRASH") == "1":
+        raise RuntimeError("injected crash after 0042")
+    op.execute(
+        "INSERT INTO curie.compat_probe (rev) VALUES ('0043')"
+    )
+
+def downgrade():
+    from alembic import op
+    op.execute("DELETE FROM curie.compat_probe WHERE rev = '0043'")
 '''
     )
     probe_cfg = Config()
@@ -325,45 +326,45 @@ def downgrade():
             apply_upgrade(
                 forward_only=False,
                 alembic_config=probe_cfg,
-                window=AppWindow(schema_min=HEAD, schema_head="0042"),
+                window=AppWindow(schema_min=HEAD, schema_head="0043"),
                 kinds={
                     **load_kinds(),
-                    "0041": KIND_EXPAND,
                     "0042": KIND_EXPAND,
+                    "0043": KIND_EXPAND,
                 },
             )
     finally:
         os.environ.pop("CURIE_COMPAT_PROBE_CRASH", None)
 
-    assert current_revision() == "0041"
+    assert current_revision() == "0042"
     rows = _sql("SELECT rev FROM curie.compat_probe ORDER BY rev")
-    assert [r[0] for r in rows] == ["0041"]
+    assert [r[0] for r in rows] == ["0042"]
 
     outcome = apply_upgrade(
         forward_only=False,
         alembic_config=probe_cfg,
-        window=AppWindow(schema_min=HEAD, schema_head="0042"),
+        window=AppWindow(schema_min=HEAD, schema_head="0043"),
         kinds={
             **load_kinds(),
-            "0041": KIND_EXPAND,
             "0042": KIND_EXPAND,
+            "0043": KIND_EXPAND,
         },
     )
     assert outcome.outcome == "applied"
-    assert current_revision() == "0042"
+    assert current_revision() == "0043"
     rows = _sql("SELECT rev FROM curie.compat_probe ORDER BY rev")
-    assert [r[0] for r in rows] == ["0041", "0042"]
+    assert [r[0] for r in rows] == ["0042", "0043"]
 
     again = apply_upgrade(
         forward_only=False,
         alembic_config=probe_cfg,
-        window=AppWindow(schema_min=HEAD, schema_head="0042"),
+        window=AppWindow(schema_min=HEAD, schema_head="0043"),
         kinds={
             **load_kinds(),
-            "0041": KIND_EXPAND,
             "0042": KIND_EXPAND,
+            "0043": KIND_EXPAND,
         },
     )
     assert again.action == "noop"
     rows = _sql("SELECT rev FROM curie.compat_probe ORDER BY rev")
-    assert [r[0] for r in rows] == ["0041", "0042"]
+    assert [r[0] for r in rows] == ["0042", "0043"]

--- a/apps/worker/src/curie_worker/approvals.py
+++ b/apps/worker/src/curie_worker/approvals.py
@@ -25,10 +25,48 @@ import httpx
 from aci_protocol import ApprovalRequest
 from curie_telemetry import inject_trace_context
 
+from .workspace import WorkspaceSelectionRefused
+
 # Re-exported so this module stays the kernel-facing seam for the approval
 # payload: ``ApprovalRequest`` is now the shared wire model (#492), not a
 # lane-local mirror of the API's schema.
 logger = logging.getLogger(__name__)
+
+_PUBLICATION_REFUSAL_CODES = {
+    "publication.github_unavailable",
+    "publication.lineage_stale",
+    "publication.lineage_terminal",
+}
+_TERMINAL_WORKSPACE_CONFLICT_DETAILS = {
+    "conversation has no selected repository workspace",
+    "publication repository differs from the thread workspace",
+    "thread workspace repository is no longer allowed",
+}
+
+
+def _publication_refusal(response: httpx.Response) -> str | None:
+    """Return a safe API-classified refusal instead of making it retryable."""
+
+    if response.status_code not in (409, 502, 503):
+        return None
+    try:
+        detail = response.json()["detail"]
+    except (KeyError, TypeError, ValueError):
+        return None
+    if isinstance(detail, dict):
+        code = detail.get("code")
+        message = detail.get("message")
+        if (
+            isinstance(code, str)
+            and code in _PUBLICATION_REFUSAL_CODES
+            and isinstance(message, str)
+            and message.strip()
+        ):
+            return message
+        return None
+    if isinstance(detail, str) and detail in _TERMINAL_WORKSPACE_CONFLICT_DETAILS:
+        return detail
+    return None
 
 __all__ = [
     "ApprovalBackendError",
@@ -41,6 +79,7 @@ __all__ = [
     "CreatedPublication",
     "PublicationCreateRequest",
     "PublicationCreator",
+    "PublicationLineage",
 ]
 
 
@@ -73,6 +112,7 @@ class PublicationCreateRequest:
     expires_in_seconds: int
     title: str
     body: str
+    reply_conversation_id: str | None = None
     max_patch_bytes: int = 900_000
 
     def to_json(self) -> dict[str, Any]:
@@ -80,7 +120,7 @@ class PublicationCreateRequest:
             raise ApprovalBackendError(
                 f"publication patch exceeds {self.max_patch_bytes} raw bytes"
             )
-        return {
+        payload: dict[str, Any] = {
             "deployment_id": str(self.deployment_id),
             "conversation_id": self.conversation_id,
             "repo_full_name": self.repo_full_name,
@@ -99,6 +139,9 @@ class PublicationCreateRequest:
             "title": self.title,
             "body": self.body,
         }
+        if self.reply_conversation_id is not None:
+            payload["reply_conversation_id"] = self.reply_conversation_id
+        return payload
 
 
 @dataclass(frozen=True)
@@ -106,6 +149,25 @@ class CreatedPublication:
     id: str
     approval_id: str
     status: str
+
+
+@dataclass(frozen=True)
+class PublicationLineage:
+    id: uuid.UUID
+    deployment_id: uuid.UUID
+    conversation_id: str
+    repo_full_name: str
+    base_sha: str
+    branch: str
+    pr_number: int | None
+    pr_url: str | None
+    head_sha: str | None
+    state: str
+    version: int
+    latest_revision: int
+    has_pending_revision: bool
+    has_pending_outcome: bool
+    visible_outcome_revision: int
 
 
 class ApprovalBackendError(Exception):
@@ -140,6 +202,13 @@ class PublicationCreator(Protocol):
     """Atomic trusted write seam used only for exact publish provenance."""
 
     async def create_publication(self, request: PublicationCreateRequest) -> CreatedPublication: ...
+
+    async def get_publication_lineage(
+        self,
+        deployment_id: uuid.UUID,
+        conversation_id: str,
+        repo_full_name: str,
+    ) -> PublicationLineage | None: ...
 
 
 class ApprovalReader(Protocol):
@@ -246,6 +315,9 @@ class ApprovalClient:
             )
         except httpx.HTTPError as exc:
             raise ApprovalBackendError(f"publication create failed: {exc}") from exc
+        refusal = _publication_refusal(response)
+        if refusal is not None:
+            raise WorkspaceSelectionRefused(refusal)
         if response.status_code not in (200, 201):
             raise ApprovalBackendError(
                 f"publication create failed: HTTP {response.status_code}: {response.text}"
@@ -259,3 +331,59 @@ class ApprovalClient:
             )
         except (ValueError, KeyError) as exc:
             raise ApprovalBackendError("publication create returned an unusable body") from exc
+
+    async def get_publication_lineage(
+        self,
+        deployment_id: uuid.UUID,
+        conversation_id: str,
+        repo_full_name: str,
+    ) -> PublicationLineage | None:
+        """Read credential-free lineage before choosing a runner route."""
+
+        if not self._worker_headers:
+            return None
+        try:
+            response = await self._client.get(
+                f"{self._publication_url}/lineage",
+                params={
+                    "deployment_id": str(deployment_id),
+                    "conversation_id": conversation_id,
+                    "repo_full_name": repo_full_name,
+                },
+                headers=self._worker_headers,
+                follow_redirects=False,
+            )
+        except httpx.HTTPError as exc:
+            raise ApprovalBackendError(f"publication lineage read failed: {exc}") from exc
+        if response.status_code == 404:
+            return None
+        refusal = _publication_refusal(response)
+        if refusal is not None:
+            raise WorkspaceSelectionRefused(refusal)
+        if response.status_code != 200:
+            raise ApprovalBackendError(
+                f"publication lineage read failed: HTTP {response.status_code}: {response.text}"
+            )
+        try:
+            body = response.json()
+            return PublicationLineage(
+                id=uuid.UUID(str(body["id"])),
+                deployment_id=uuid.UUID(str(body["deployment_id"])),
+                conversation_id=str(body["conversation_id"]),
+                repo_full_name=str(body["repo_full_name"]),
+                base_sha=str(body["base_sha"]),
+                branch=str(body["branch"]),
+                pr_number=int(body["pr_number"]) if body.get("pr_number") is not None else None,
+                pr_url=str(body["pr_url"]) if body.get("pr_url") is not None else None,
+                head_sha=str(body["head_sha"]) if body.get("head_sha") is not None else None,
+                state=str(body["state"]),
+                version=int(body["version"]),
+                latest_revision=int(body["latest_revision"]),
+                has_pending_revision=bool(body["has_pending_revision"]),
+                has_pending_outcome=bool(body["has_pending_outcome"]),
+                visible_outcome_revision=int(body["visible_outcome_revision"]),
+            )
+        except (ValueError, KeyError, TypeError) as exc:
+            raise ApprovalBackendError(
+                "publication lineage read returned an unusable body"
+            ) from exc

--- a/apps/worker/src/curie_worker/kernel.py
+++ b/apps/worker/src/curie_worker/kernel.py
@@ -83,6 +83,7 @@ from .approvals import (
     CreatedApproval,
     PublicationCreateRequest,
     PublicationCreator,
+    PublicationLineage,
 )
 from .behaviorpacks import (
     BehaviorPacks,
@@ -590,6 +591,18 @@ class ThreadBusyError(RuntimeError):
     bounded outcome rather than a silent one, and issue #268 owns replacing it
     with a real idle-aware policy when cron schedules land.
     """
+
+
+class PendingPublicationError(ThreadBusyError):
+    """A thread-owned publication must settle before another turn can start."""
+
+    public_detail = (
+        "This thread already has a publication awaiting approval or completion. "
+        "Resolve it before continuing."
+    )
+
+    def __init__(self, thread_key: str) -> None:
+        super().__init__(f"thread {thread_key} has a pending publication revision")
 
 
 @dataclass
@@ -2280,6 +2293,17 @@ class Kernel:
                 ),
             )
             return TurnOutcome(terminal_ok=True)
+        except PendingPublicationError as exc:
+            release_order()
+            logger.info(
+                "pending publication refused a new turn for agent=%s deployment=%s "
+                "thread=%s",
+                agent_name,
+                workspace_deployment_id,
+                thread_key,
+            )
+            await self._reply_for(qevent, route, exc.public_detail)
+            return TurnOutcome(terminal_ok=True)
         except WorkspaceSelectionRefused as exc:
             release_order()
             # LOG it, not only reply (#2004). This was the one turn-ending branch
@@ -2460,6 +2484,12 @@ class Kernel:
         agent_name: str | None = None,
         source: TurnSource = TurnSource.SLACK,
         remaining_s: float | None = None,
+        lineage_branch: str | None = None,
+        lineage_head: str | None = None,
+        lineage_base_sha: str | None = None,
+        publication_visible_outcome_revision: int | None = None,
+        force_lineage_replacement: bool = False,
+        pending_publication_approval: bool = False,
     ) -> _RouteResult:
         # A workspace-enabled thread must establish (or confirm) its repository
         # before any platform response path. This deliberately precedes the
@@ -2480,6 +2510,44 @@ class Kernel:
                 author=event.user,
                 repo_full_name=repo_fact,
             )
+            if (
+                lineage_branch is None
+                and workspace_repo is not None
+                and getattr(self, "_publication_creator", None) is not None
+            ):
+                reader = getattr(
+                    self._publication_creator, "get_publication_lineage", None
+                )
+                if reader is not None:
+                    lineage: PublicationLineage | None = await reader(
+                        workspace_deployment_id, thread_key, workspace_repo
+                    )
+                    if lineage is not None and lineage.state != "open":
+                        raise WorkspaceSelectionRefused(
+                            "This pull request is already terminal. Start a new thread."
+                        )
+                    if lineage is not None and (
+                        lineage.has_pending_revision or lineage.has_pending_outcome
+                    ):
+                        # A first revision has no accepted head yet, but it still
+                        # owns the thread's publication boundary. Its terminal
+                        # outcome must also reach durable history before a later
+                        # turn can observe it. Refuse before lookup/adopt so a
+                        # failed suspend cannot reuse the dirty runner across
+                        # either boundary.
+                        raise PendingPublicationError(thread_key)
+                    if lineage is not None and lineage.head_sha is not None:
+                        lineage_branch = lineage.branch
+                        lineage_head = lineage.head_sha
+                    if lineage is not None:
+                        publication_visible_outcome_revision = (
+                            lineage.visible_outcome_revision
+                        )
+                        if (
+                            lineage.head_sha is None
+                            and lineage.visible_outcome_revision > 0
+                        ):
+                            lineage_base_sha = lineage.base_sha
         # Greeting/help pre-model short-circuit (ADR-0018): under the per-thread
         # route lock, if an enabled greeting/help pack matches the message text AND
         # the thread has no existing route, it is provably a NEW turn (it cannot be
@@ -2494,8 +2562,37 @@ class Kernel:
         # mere presence of an affinity record as proof that a live route was
         # retained.
         existing_handle = await asyncio.to_thread(self._substrate.lookup, thread_key)
+        materialized_lineage_head = lineage_head or lineage_base_sha
         if (
-            workspace_repo is not None
+            materialized_lineage_head is not None
+            or publication_visible_outcome_revision is not None
+        ):
+            force_lineage_replacement = force_lineage_replacement or (
+                existing_handle is None
+                or (
+                    materialized_lineage_head is not None
+                    and existing_handle.workspace_materialized_head
+                    != materialized_lineage_head
+                )
+                or existing_handle.publication_visible_outcome_revision
+                != publication_visible_outcome_revision
+            )
+        if (
+            force_lineage_replacement
+            and existing_handle is not None
+            and not await self._workspace_handoff_ready(
+                existing_handle,
+                remaining_s=remaining_s,
+                lineage_reconciliation=True,
+                pending_publication_approval=pending_publication_approval,
+            )
+        ):
+            raise ThreadBusyError(
+                f"thread {thread_key} has not reached a durable lineage handoff boundary"
+            )
+        if (
+            not force_lineage_replacement
+            and workspace_repo is not None
             and existing_handle is not None
             and existing_handle.workspace_repo is not None
             and existing_handle.workspace_repo != workspace_repo
@@ -2504,7 +2601,8 @@ class Kernel:
                 "route-fence", "live workspace route does not match sticky repository"
             )
         if (
-            workspace_repo is not None
+            not force_lineage_replacement
+            and workspace_repo is not None
             and existing_handle is not None
             and existing_handle.workspace_repo is None
             and not await self._workspace_handoff_ready(
@@ -2542,11 +2640,19 @@ class Kernel:
             workspace_repo=workspace_repo,
             replace_handle=(
                 existing_handle
-                if workspace_repo is not None
-                and existing_handle is not None
-                and existing_handle.workspace_repo is None
+                if workspace_repo is not None and existing_handle is not None and (
+                    force_lineage_replacement or existing_handle.workspace_repo is None
+                )
                 else None
             ),
+            lineage_branch=lineage_branch,
+            lineage_head=lineage_head,
+            lineage_base_sha=lineage_base_sha,
+            publication_visible_outcome_revision=(
+                publication_visible_outcome_revision or 0
+            ),
+            force_lineage_replacement=force_lineage_replacement,
+            pending_publication_approval=pending_publication_approval,
             agent_name=agent_name,
             remaining_s=remaining_s,
         )
@@ -2671,7 +2777,12 @@ class Kernel:
         return active
 
     async def _workspace_handoff_ready(
-        self, handle: SandboxHandle, *, remaining_s: float | None = None
+        self,
+        handle: SandboxHandle,
+        *,
+        remaining_s: float | None = None,
+        lineage_reconciliation: bool = False,
+        pending_publication_approval: bool = False,
     ) -> bool:
         """Fail closed unless the old runner is idle with durable replay state."""
 
@@ -2693,11 +2804,18 @@ class Kernel:
         return (
             status.get("turn_active") is False
             and status.get("history_durable") is True
-            and status.get("status")
-            in {
-                SessionStatus.DONE.value,
-                SessionStatus.IDLE_AWAITING_INPUT.value,
-            }
+            and not pending_publication_approval
+            and (
+                status.get("status")
+                in {
+                    SessionStatus.DONE.value,
+                    SessionStatus.IDLE_AWAITING_INPUT.value,
+                }
+                or (
+                    lineage_reconciliation
+                    and status.get("status") == SessionStatus.AWAITING_APPROVAL.value
+                )
+            )
         )
 
     async def _workspace_candidate_ready(
@@ -2743,6 +2861,12 @@ class Kernel:
         workspace_deployment_id: uuid.UUID | None = None,
         workspace_repo: str | None = None,
         replace_handle: SandboxHandle | None = None,
+        lineage_branch: str | None = None,
+        lineage_head: str | None = None,
+        lineage_base_sha: str | None = None,
+        publication_visible_outcome_revision: int = 0,
+        force_lineage_replacement: bool = False,
+        pending_publication_approval: bool = False,
         agent_name: str | None = None,
         remaining_s: float | None = None,
     ) -> SandboxHandle:
@@ -2768,7 +2892,9 @@ class Kernel:
                 raise WorkspacePreparationError(
                     "wiring", "selected workspace has no trusted claim-time preparer"
                 )
-            existing = await asyncio.to_thread(self._substrate.adopt, thread_key)
+            existing = None
+            if not force_lineage_replacement:
+                existing = await asyncio.to_thread(self._substrate.adopt, thread_key)
             if existing is not None and existing.workspace_repo == workspace_repo:
                 await asyncio.to_thread(
                     self._workspace.touch,
@@ -2822,7 +2948,10 @@ class Kernel:
 
                     ready = run_status_probe(
                         lambda probe_remaining_s: self._workspace_handoff_ready(
-                            replace_handle, remaining_s=probe_remaining_s
+                            replace_handle,
+                            remaining_s=probe_remaining_s,
+                            lineage_reconciliation=force_lineage_replacement,
+                            pending_publication_approval=pending_publication_approval,
                         ),
                         failure=(
                             f"thread {thread_key} workspace handoff fence "
@@ -2869,6 +2998,12 @@ class Kernel:
                 replace_handle=replace_handle,
                 revalidate_before_handoff=handoff_revalidation,
                 validate_candidate=candidate_validation,
+                lineage_branch=lineage_branch,
+                lineage_head=lineage_head,
+                lineage_base_sha=lineage_base_sha,
+                publication_visible_outcome_revision=(
+                    publication_visible_outcome_revision
+                ),
             )
             if not isinstance(workspace_claim.handle, SandboxHandle):
                 raise WorkspacePreparationError(
@@ -3069,10 +3204,9 @@ class Kernel:
         """
 
         # Both identities are live in this function and they are not
-        # interchangeable: ``thread`` is the BARE adapter conversation id, which
-        # the durable record persists and the resume turn carries back onto the
-        # wire; ``thread_key`` is the worker's scoped key, which names the
-        # sandbox this suspends and the card slot it remembers.
+        # interchangeable: ``thread`` is the BARE adapter conversation id used
+        # only for replies; ``thread_key`` is the canonical server identity that
+        # owns the workspace, publication lineage, sandbox, and card slot.
         thread = qevent.conversation_id
         thread_key = _thread_key_for(qevent)
         summary = outcome.approval_summary or outcome.text or "Approval requested"
@@ -3168,7 +3302,8 @@ class Kernel:
                 published = await publication_creator.create_publication(
                     PublicationCreateRequest(
                         deployment_id=deployment_id,
-                        conversation_id=thread,
+                        conversation_id=thread_key,
+                        reply_conversation_id=thread,
                         repo_full_name=snapshot.repo_full_name,
                         author=qevent.author,
                         summary=summary,
@@ -3231,6 +3366,16 @@ class Kernel:
                         granted_tool=outcome.approval_granted_tool,
                     )
                 )
+        except WorkspaceSelectionRefused as exc:
+            logger.info(
+                "publication refused for agent=%s deployment=%s thread=%s: %s",
+                agent_id,
+                deployment_id,
+                thread_key,
+                exc.public_detail,
+            )
+            await self._reply_for(qevent, route, exc.public_detail)
+            return
         except (ApprovalBackendError, ValidationError) as exc:
             # ValidationError: the shared model rejected the payload at
             # construction (#492) -- an unknown gate_kind, or an empty

--- a/apps/worker/src/curie_worker/publication_clients.py
+++ b/apps/worker/src/curie_worker/publication_clients.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 import re
 import uuid
 from datetime import UTC, datetime
+from typing import Literal, cast
 from urllib.parse import quote, urlsplit
 
 import httpx
 
 from .publication_loop import (
     PublicationCredential,
+    PublicationPullState,
     PublicationReconcileError,
     PublicationTranscriptPermanentError,
 )
@@ -181,7 +183,7 @@ class PublicationCredentialClient:
 
 
 class GitHubPublicationLookup:
-    """Adopt an existing pull request by its deterministic head branch."""
+    """Read stored pull request identity and verify revision ancestry."""
 
     def __init__(
         self,
@@ -192,19 +194,149 @@ class GitHubPublicationLookup:
         self._client = client
         self._api_base = api_base_url.rstrip("/")
 
+    async def read_pr_by_number(
+        self,
+        repo_full_name: str,
+        pr_number: int,
+        authorization_header: str,
+    ) -> PublicationPullState:
+        if not authorization_header:
+            raise PublicationReconcileError(
+                "stored pull request lookup requires authorization"
+            )
+        if pr_number <= 0:
+            raise PublicationReconcileError("stored pull request lookup is invalid")
+        try:
+            response = await self._client.get(
+                f"{self._api_base}/repos/{repo_full_name}/pulls/{pr_number}",
+                headers=self._headers(authorization_header),
+                follow_redirects=False,
+            )
+        except httpx.HTTPError as exc:
+            raise PublicationReconcileError("stored pull request lookup was unreachable") from exc
+        if response.status_code != 200:
+            raise PublicationReconcileError(
+                f"stored pull request lookup returned HTTP {response.status_code}"
+            )
+        try:
+            row = response.json()
+            number = int(row["number"])
+            url = str(row["html_url"])
+            head = row["head"]
+            head_ref = str(head["ref"])
+            head_sha = str(head["sha"])
+            raw_state = str(row["state"])
+            merged_at = row.get("merged_at")
+        except (KeyError, TypeError, ValueError) as exc:
+            raise PublicationReconcileError("GitHub returned an invalid pull request") from exc
+        if number != pr_number or re.fullmatch(
+            rf"https://github\.com/{re.escape(repo_full_name)}/pull/{pr_number}",
+            url,
+            re.IGNORECASE,
+        ) is None:
+            raise PublicationReconcileError("GitHub returned the wrong stored pull request")
+        if re.fullmatch(r"[0-9a-f]{40,64}", head_sha) is None or not head_ref:
+            raise PublicationReconcileError("GitHub pull request head is invalid")
+        state = "merged" if merged_at is not None else raw_state
+        if state not in {"open", "closed", "merged"}:
+            raise PublicationReconcileError("GitHub pull request state is invalid")
+        return PublicationPullState(
+            number=number,
+            url=url,
+            state=cast(Literal["open", "closed", "merged"], state),
+            head_sha=head_sha,
+            head_ref=head_ref,
+        )
+
+    async def verify_revision_commit(
+        self,
+        repo_full_name: str,
+        commit_sha: str,
+        *,
+        revision_id: uuid.UUID,
+        expected_parent: str,
+        authorization_header: str,
+    ) -> str:
+        if not authorization_header:
+            raise PublicationReconcileError("revision verification requires authorization")
+        try:
+            response = await self._client.get(
+                f"{self._api_base}/repos/{repo_full_name}/git/commits/{commit_sha}",
+                headers=self._headers(authorization_header),
+                follow_redirects=False,
+            )
+        except httpx.HTTPError as exc:
+            raise PublicationReconcileError("revision commit lookup was unreachable") from exc
+        if response.status_code != 200:
+            raise PublicationReconcileError(
+                f"revision commit lookup returned HTTP {response.status_code}"
+            )
+        try:
+            row = response.json()
+            observed_sha = str(row["sha"])
+            message = str(row["message"])
+            parents = row["parents"]
+            parent = str(parents[0]["sha"])
+        except (KeyError, IndexError, TypeError, ValueError) as exc:
+            raise PublicationReconcileError("GitHub returned an invalid revision commit") from exc
+        marker = f"Curie-Revision: {revision_id}"
+        if observed_sha != commit_sha or marker not in message.splitlines():
+            raise PublicationReconcileError("remote commit has no matching revision marker")
+        if len(parents) != 1 or parent != expected_parent:
+            raise PublicationReconcileError("remote revision has the wrong expected parent")
+        return observed_sha
+
+    async def read_branch_head(
+        self,
+        repo_full_name: str,
+        branch: str,
+        authorization_header: str,
+    ) -> str | None:
+        """Return the deterministic branch head without creating any GitHub object."""
+
+        if not authorization_header:
+            raise PublicationReconcileError("GitHub branch lookup requires authorization")
+        try:
+            response = await self._client.get(
+                f"{self._api_base}/repos/{repo_full_name}/git/ref/heads/{quote(branch, safe='')}",
+                headers=self._headers(authorization_header),
+                follow_redirects=False,
+            )
+        except httpx.HTTPError as exc:
+            raise PublicationReconcileError("GitHub branch lookup was unreachable") from exc
+        if response.status_code == 404:
+            return None
+        if response.status_code != 200:
+            raise PublicationReconcileError(
+                f"GitHub branch lookup returned HTTP {response.status_code}"
+            )
+        try:
+            head_sha = str(response.json()["object"]["sha"])
+        except (KeyError, TypeError, ValueError) as exc:
+            raise PublicationReconcileError("GitHub returned an invalid branch ref") from exc
+        if re.fullmatch(r"[0-9a-f]{40,64}", head_sha) is None:
+            raise PublicationReconcileError("GitHub returned an invalid branch head")
+        return head_sha
+
     async def recover_pr_by_head(
         self,
         repo_full_name: str,
         branch: str,
         title: str,
         body: str,
+        *,
+        expected_head_sha: str,
         authorization_header: str,
-    ) -> str | None:
+    ) -> PublicationPullState | None:
         """Adopt a PR, or create it only when its deterministic branch exists."""
 
         if not authorization_header:
             raise PublicationReconcileError(
                 "GitHub deterministic-head recovery requires authorization"
+            )
+        if re.fullmatch(r"[0-9a-f]{40,64}", expected_head_sha) is None:
+            raise PublicationReconcileError(
+                "GitHub deterministic-head recovery expected commit is invalid"
             )
         default_branch = await self._default_branch(
             repo_full_name,
@@ -216,6 +348,7 @@ class GitHubPublicationLookup:
             title=title,
             body=body,
             base=default_branch,
+            expected_head_sha=expected_head_sha,
             authorization_header=authorization_header,
         )
         if existing is not None:
@@ -241,6 +374,16 @@ class GitHubPublicationLookup:
                 "GitHub deterministic branch lookup returned HTTP "
                 f"{ref_response.status_code}"
             )
+        try:
+            ref_head_sha = str(ref_response.json()["object"]["sha"])
+        except (KeyError, TypeError, ValueError) as exc:
+            raise PublicationReconcileError(
+                "GitHub returned an invalid deterministic branch ref"
+            ) from exc
+        if ref_head_sha != expected_head_sha:
+            raise PublicationReconcileError(
+                "GitHub deterministic branch no longer matches the expected commit"
+            )
 
         pulls_url = f"{repo_api}/pulls"
         try:
@@ -258,13 +401,14 @@ class GitHubPublicationLookup:
         except httpx.HTTPError:
             created = None
         if created is not None and created.status_code == 201:
-            return self._pull_url(
+            return self._pull_state(
                 created,
                 repo_full_name,
                 branch=branch,
                 title=title,
                 body=body,
                 base=default_branch,
+                expected_head_sha=expected_head_sha,
             )
 
         # A lost POST response or a concurrent reconciler is ambiguous. Query
@@ -275,6 +419,7 @@ class GitHubPublicationLookup:
             title=title,
             body=body,
             base=default_branch,
+            expected_head_sha=expected_head_sha,
             authorization_header=authorization_header,
         )
         if recovered is not None:
@@ -322,7 +467,7 @@ class GitHubPublicationLookup:
         return default_branch
 
     @staticmethod
-    def _pull_url(
+    def _pull_state(
         response: httpx.Response,
         repo_full_name: str,
         *,
@@ -330,7 +475,8 @@ class GitHubPublicationLookup:
         title: str,
         body: str,
         base: str,
-    ) -> str:
+        expected_head_sha: str,
+    ) -> PublicationPullState:
         try:
             payload = response.json()
         except ValueError as exc:
@@ -357,6 +503,7 @@ class GitHubPublicationLookup:
                 if isinstance(head, dict) and isinstance(head.get("repo"), dict)
                 else None
             ),
+            "head_sha": head.get("sha") if isinstance(head, dict) else None,
             "base_ref": (
                 base_payload.get("ref") if isinstance(base_payload, dict) else None
             ),
@@ -385,13 +532,45 @@ class GitHubPublicationLookup:
             raise PublicationReconcileError(
                 "GitHub pull request does not match the approved publication contract"
             )
+        head_sha = actual["head_sha"]
+        if (
+            not isinstance(head_sha, str)
+            or re.fullmatch(r"[0-9a-f]{40,64}", head_sha) is None
+            or head_sha != expected_head_sha
+        ):
+            raise PublicationReconcileError(
+                "GitHub pull request head does not match the expected commit"
+            )
         if not isinstance(url, str) or re.fullmatch(
             rf"https://github\.com/{re.escape(repo_full_name)}/pull/[1-9][0-9]*",
             url,
             re.IGNORECASE,
         ) is None:
             raise PublicationReconcileError("GitHub returned an invalid pull request URL")
-        return url
+        number = payload.get("number")
+        if (
+            isinstance(number, bool)
+            or not isinstance(number, int)
+            or number <= 0
+            or not url.casefold().endswith(f"/pull/{number}".casefold())
+        ):
+            raise PublicationReconcileError("GitHub returned an invalid pull request URL")
+        raw_state = payload.get("state")
+        if payload.get("merged_at") is not None or payload.get("merged") is True:
+            state = "merged"
+        elif isinstance(raw_state, str):
+            state = raw_state
+        else:
+            state = ""
+        if state not in {"open", "closed", "merged"}:
+            raise PublicationReconcileError("GitHub pull request state is invalid")
+        return PublicationPullState(
+            number=number,
+            url=url,
+            state=cast(Literal["open", "closed", "merged"], state),
+            head_sha=head_sha,
+            head_ref=branch,
+        )
 
     async def _find(
         self,
@@ -401,13 +580,14 @@ class GitHubPublicationLookup:
         title: str,
         body: str,
         base: str,
+        expected_head_sha: str,
         authorization_header: str,
-    ) -> str | None:
+    ) -> PublicationPullState | None:
         owner = repo_full_name.split("/", 1)[0]
         try:
             response = await self._client.get(
                 f"{self._api_base}/repos/{repo_full_name}/pulls",
-                params={"state": "open", "head": f"{owner}:{branch}"},
+                params={"state": "all", "head": f"{owner}:{branch}"},
                 headers=self._headers(authorization_header),
                 follow_redirects=False,
             )
@@ -427,11 +607,16 @@ class GitHubPublicationLookup:
             ) from exc
         if not isinstance(rows, list) or not rows:
             return None
-        return self._pull_url(
+        if len(rows) != 1:
+            raise PublicationReconcileError(
+                "GitHub deterministic-head lookup returned multiple pull requests"
+            )
+        return self._pull_state(
             httpx.Response(200, json=rows[0]),
             repo_full_name,
             branch=branch,
             title=title,
             body=body,
             base=base,
+            expected_head_sha=expected_head_sha,
         )

--- a/apps/worker/src/curie_worker/publication_k8s.py
+++ b/apps/worker/src/curie_worker/publication_k8s.py
@@ -16,7 +16,7 @@ import json
 import re
 import uuid
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 from kubernetes import client as k8s_client
 from kubernetes import config as k8s_config
@@ -61,11 +61,17 @@ class PublicationJobSettings:
 @dataclass(frozen=True)
 class PublicationPayload:
     publication_id: uuid.UUID
+    revision_id: uuid.UUID
+    revision_number: int
     repo_full_name: str
     clean_clone_url: str
     base_sha: str
+    expected_prior_head: str
+    expected_remote_head: str | None
     patch: bytes
     branch: str
+    pr_number: int | None
+    pr_url: str | None
     title: str
     body: str
 
@@ -121,15 +127,22 @@ git_with_timeout() {
 }
 
 cleanup_auth() {
-  rm -f /tmp/curie-git-user /tmp/curie-git-pass /tmp/curie-askpass
+  rm -f /tmp/curie-git-user /tmp/curie-git-pass /tmp/curie-askpass \
+    /tmp/curie-github.py /tmp/curie-pr-facts.json
 }
 trap cleanup_auth EXIT
 
+credential_path="${CURIE_CREDENTIAL_PATH:-/credentials/credential}"
+patch_path="${CURIE_PATCH_PATH:-/publication/changes.patch}"
+work_dir="${CURIE_WORK_DIR:-/work}"
+export CURIE_CREDENTIAL_PATH="$credential_path"
+
 python - <<'PY'
 import base64
+import os
 from pathlib import Path
 
-value = Path("/credentials/credential").read_text().strip()
+value = Path(os.environ["CURIE_CREDENTIAL_PATH"]).read_text().strip()
 user, password = "x-access-token", value
 if value.lower().startswith("basic "):
     try:
@@ -154,8 +167,8 @@ chmod 0700 /tmp/curie-askpass
 export GIT_ASKPASS=/tmp/curie-askpass
 export GIT_TERMINAL_PROMPT=0
 
-mkdir -p /work
-cd /work
+mkdir -p "$work_dir"
+cd "$work_dir"
 git_with_timeout clone "$CLEAN_CLONE_URL" repo 2> >(redact >&2)
 cd repo
 git_with_timeout remote set-url origin "$CLEAN_CLONE_URL"
@@ -165,17 +178,24 @@ if ! git_with_timeout cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
 fi
 git_with_timeout checkout --detach "$BASE_SHA" 2> >(redact >&2)
 git_with_timeout switch -c "$BRANCH" 2> >(redact >&2)
-git_with_timeout apply --check --binary /publication/changes.patch
-git_with_timeout apply --binary /publication/changes.patch
+remote_head=$(git_with_timeout ls-remote origin "refs/heads/$BRANCH" \
+  2> >(redact >&2) | awk '{print $1}')
+if [[ "$remote_head" != "$EXPECTED_REMOTE_HEAD" ]]; then
+  echo "publication branch head conflict" >&2
+  exit 1
+fi
+git_with_timeout apply --check --binary "$patch_path"
+git_with_timeout apply --binary "$patch_path"
 git_with_timeout add --all
 if git_with_timeout diff --cached --quiet; then
   echo "publication patch produced no changes" >&2
   exit 1
 fi
-git_with_timeout -c user.name="$GIT_USER_NAME" -c user.email="$GIT_USER_EMAIL" commit -m "$PR_TITLE"
-git_with_timeout push origin "HEAD:refs/heads/$BRANCH" 2> >(redact >&2)
+git_with_timeout -c user.name="$GIT_USER_NAME" -c user.email="$GIT_USER_EMAIL" commit \
+  -m "$PR_TITLE" -m "Curie-Revision: $REVISION_ID"
+commit_sha=$(git_with_timeout rev-parse HEAD)
 
-python - <<'PY'
+cat >/tmp/curie-github.py <<'PY'
 import base64
 import json
 import os
@@ -190,7 +210,17 @@ owner = repo.split("/", 1)[0]
 github_api = os.environ["GITHUB_API_URL"].rstrip("/")
 repo_api = f"{github_api}/repos/{repo}"
 api = f"{repo_api}/pulls"
-raw = Path("/credentials/credential").read_text().strip()
+credential_path = Path(os.environ.get("CURIE_CREDENTIAL_PATH", "/credentials/credential"))
+facts_path = Path(os.environ.get("CURIE_PR_FACTS_PATH", "/tmp/curie-pr-facts.json"))
+phase = os.environ["CURIE_GITHUB_PHASE"]
+if phase not in {"pre-push", "post-push"}:
+    raise SystemExit("invalid publication GitHub validation phase")
+expected_head = os.environ.get("CURIE_EXPECTED_HEAD", "")
+if len(expected_head) not in range(40, 65) or any(
+    char not in "0123456789abcdef" for char in expected_head
+):
+    raise SystemExit("expected publication commit is invalid")
+raw = credential_path.read_text().strip()
 if raw.lower().startswith(("basic ", "bearer ", "token ")):
     authorization = raw
 else:
@@ -213,28 +243,33 @@ def request(method, url, payload=None):
     with opener.open(req, timeout=int(os.environ["GITHUB_TIMEOUT_SECONDS"])) as response:
         return json.load(response)
 
-def validate_pull(row, expected_base):
+def validate_pull(
+    row,
+    expected_base,
+    *,
+    require_metadata,
+    expected_number=None,
+    expected_url=None,
+    require_merged=False,
+):
     if not isinstance(row, dict):
         raise SystemExit("GitHub returned an invalid pull request")
     head = row.get("head")
     base = row.get("base")
     expected = {
-        "title": os.environ["PR_TITLE"],
-        "body": os.environ["PR_BODY"],
         "head_ref": branch,
         "head_repo": repo,
         "base_ref": expected_base,
         "base_repo": repo,
     }
     actual = {
-        "title": row.get("title"),
-        "body": row.get("body"),
         "head_ref": head.get("ref") if isinstance(head, dict) else None,
         "head_repo": (
             (head.get("repo") or {}).get("full_name")
             if isinstance(head, dict) and isinstance(head.get("repo"), dict)
             else None
         ),
+        "head_sha": head.get("sha") if isinstance(head, dict) else None,
         "base_ref": base.get("ref") if isinstance(base, dict) else None,
         "base_repo": (
             (base.get("repo") or {}).get("full_name")
@@ -243,6 +278,13 @@ def validate_pull(row, expected_base):
         ),
     }
     repo_fields = ("head_repo", "base_repo")
+    if require_metadata and (
+        row.get("title") != os.environ["PR_TITLE"]
+        or row.get("body") != os.environ["PR_BODY"]
+    ):
+        raise SystemExit(
+            "GitHub pull request does not match the approved publication contract"
+        )
     if any(
         not isinstance(actual[field], str)
         or actual[field].casefold() != expected[field].casefold()
@@ -255,42 +297,142 @@ def validate_pull(row, expected_base):
         raise SystemExit(
             "GitHub pull request does not match the approved publication contract"
         )
+    if actual["head_sha"] != expected_head:
+        raise SystemExit(
+            "GitHub pull request head does not match the expected publication commit"
+        )
     url = row.get("html_url")
     prefix = f"https://github.com/{repo}/pull/"
     if not isinstance(url, str) or not url.casefold().startswith(prefix.casefold()):
         raise SystemExit("GitHub did not return a usable pull request URL")
-    number = url[len(prefix):]
-    if not number.isdigit() or int(number) <= 0:
+    url_number = url[len(prefix):]
+    number = row.get("number")
+    if (
+        not url_number.isdigit()
+        or isinstance(number, bool)
+        or not isinstance(number, int)
+        or number <= 0
+        or number != int(url_number)
+        or (expected_number is not None and number != expected_number)
+        or (
+            expected_url is not None
+            and url.casefold() != expected_url.casefold()
+        )
+    ):
         raise SystemExit("GitHub did not return a usable pull request URL")
-    return url
+    state = row.get("state")
+    merged = row.get("merged")
+    merged_at = row.get("merged_at")
+    if require_merged and not isinstance(merged, bool):
+        raise SystemExit("GitHub returned an invalid pull request state")
+    if merged is True or merged_at is not None:
+        print(f"CURIE_PR_URL={url}")
+        print(f"CURIE_PR_NUMBER={number}")
+        print(f"CURIE_COMMIT_SHA={actual['head_sha']}")
+        print("CURIE_PR_STATE=merged", flush=True)
+        raise SystemExit("stored pull request is merged")
+    if state != "open":
+        if state == "closed":
+            print(f"CURIE_PR_URL={url}")
+            print(f"CURIE_PR_NUMBER={number}")
+            print(f"CURIE_COMMIT_SHA={actual['head_sha']}")
+            print("CURIE_PR_STATE=closed", flush=True)
+            raise SystemExit("stored pull request is closed")
+        raise SystemExit("GitHub returned an invalid pull request state")
+    return url, number
 
 def existing(expected_base):
     head=quote(f"{owner}:{branch}", safe="")
-    rows = request("GET", f"{api}?state=open&head={head}")
-    return validate_pull(rows[0], expected_base) if rows else None
+    rows = request("GET", f"{api}?state=all&head={head}")
+    if not isinstance(rows, list):
+        raise SystemExit("GitHub deterministic-head lookup returned an invalid response")
+    if len(rows) > 1:
+        raise SystemExit("GitHub deterministic-head lookup returned multiple pull requests")
+    return validate_pull(rows[0], expected_base, require_metadata=True) if rows else None
 
-# Query the deterministic head before POST, and again after an ambiguous REST
-# failure. This is the idempotency boundary for a lost response.
-repository = request("GET", repo_api)
-default_base = repository.get("default_branch")
-if not isinstance(default_base, str) or not default_base:
-    raise SystemExit("GitHub repository has no default branch")
-url = existing(default_base)
-if not url:
+pr_number = os.environ.get("PR_NUMBER")
+if pr_number:
     try:
-        created = request("POST", api, {
-            "title": os.environ["PR_TITLE"],
-            "head": branch,
-            "base": default_base,
-            "body": os.environ["PR_BODY"],
-        })
-        url = validate_pull(created, default_base)
-    except (HTTPError, URLError):
-        url = existing(default_base)
-        if not url:
-            raise
+        expected_number = int(pr_number)
+    except ValueError:
+        raise SystemExit("stored pull request number is invalid") from None
+    expected_url = os.environ.get("PR_URL")
+    if not expected_url:
+        raise SystemExit("stored pull request URL is missing")
+    if phase == "pre-push":
+        repository = request("GET", repo_api)
+        default_base = repository.get("default_branch")
+        if not isinstance(default_base, str) or not default_base:
+            raise SystemExit("GitHub repository has no default branch")
+        url, number = validate_pull(
+            request("GET", f"{api}/{pr_number}"),
+            default_base,
+            require_metadata=False,
+            expected_number=expected_number,
+            expected_url=expected_url,
+            require_merged=True,
+        )
+        facts_path.write_text(json.dumps({"base": default_base, "url": url, "number": number}))
+        raise SystemExit(0)
+    try:
+        facts = json.loads(facts_path.read_text())
+    except (OSError, ValueError):
+        raise SystemExit("stored pull request validation facts are missing") from None
+    if not isinstance(facts, dict):
+        raise SystemExit("stored pull request validation facts are invalid")
+    default_base = facts.get("base")
+    if (
+        not isinstance(default_base, str)
+        or facts.get("url") != expected_url
+        or facts.get("number") != expected_number
+    ):
+        raise SystemExit("stored pull request validation facts are invalid")
+    url, number = validate_pull(
+        request("GET", f"{api}/{pr_number}"),
+        default_base,
+        require_metadata=False,
+        expected_number=expected_number,
+        expected_url=expected_url,
+        require_merged=True,
+    )
+else:
+    if phase != "post-push":
+        raise SystemExit("new pull request cannot be validated before push")
+    # Query the deterministic head before POST, and again after an ambiguous
+    # REST failure. This is the idempotency boundary for a lost response.
+    repository = request("GET", repo_api)
+    default_base = repository.get("default_branch")
+    if not isinstance(default_base, str) or not default_base:
+        raise SystemExit("GitHub repository has no default branch")
+    pull = existing(default_base)
+    if not pull:
+        try:
+            created = request("POST", api, {
+                "title": os.environ["PR_TITLE"],
+                "head": branch,
+                "base": default_base,
+                "body": os.environ["PR_BODY"],
+            })
+            pull = validate_pull(created, default_base, require_metadata=True)
+        except (HTTPError, URLError):
+            pull = existing(default_base)
+            if not pull:
+                raise
+    url, number = pull
 print(f"CURIE_PR_URL={url}")
+print(f"CURIE_PR_NUMBER={number}")
 PY
+
+if [[ -n "$PR_NUMBER" ]]; then
+  CURIE_EXPECTED_HEAD="$EXPECTED_PRIOR_HEAD" \
+    CURIE_GITHUB_PHASE=pre-push python /tmp/curie-github.py
+fi
+git_with_timeout push \
+  --force-with-lease=refs/heads/$BRANCH:$EXPECTED_REMOTE_HEAD \
+  origin "HEAD:refs/heads/$BRANCH" 2> >(redact >&2)
+CURIE_EXPECTED_HEAD="$commit_sha" \
+  CURIE_GITHUB_PHASE=post-push python /tmp/curie-github.py
+echo "CURIE_COMMIT_SHA=$commit_sha"
 """
 
 
@@ -317,12 +459,31 @@ def build_publication_resources(
         raise PublicationResourceError(
             f"publication patch exceeds the {MAX_PATCH_BYTES} raw-byte limit"
         )
-    if payload.branch != deterministic_publication_branch(payload.publication_id):
-        raise PublicationResourceError("publication branch is not deterministic")
+    if not re.fullmatch(r"curie/[A-Za-z0-9._/-]+", payload.branch):
+        raise PublicationResourceError("publication branch is not a valid stored lineage branch")
     if re.fullmatch(r"[0-9a-f]{40,64}", payload.base_sha) is None:
         raise PublicationResourceError(
             "publication base SHA must be 40-64 lowercase hexadecimal characters"
         )
+    if re.fullmatch(r"[0-9a-f]{40,64}", payload.expected_prior_head) is None:
+        raise PublicationResourceError(
+            "publication expected prior head must be 40-64 lowercase hexadecimal characters"
+        )
+    if payload.base_sha != payload.expected_prior_head:
+        raise PublicationResourceError(
+            "publication base SHA does not match expected prior head"
+        )
+    if payload.expected_remote_head is not None and (
+        re.fullmatch(r"[0-9a-f]{40,64}", payload.expected_remote_head) is None
+        or payload.expected_remote_head != payload.expected_prior_head
+    ):
+        raise PublicationResourceError("publication expected remote head is invalid")
+    if payload.revision_number <= 0:
+        raise PublicationResourceError("publication revision number must be positive")
+    if (payload.pr_number is None) != (payload.pr_url is None):
+        raise PublicationResourceError("publication pull request identity is incomplete")
+    if payload.pr_number is not None and payload.pr_number <= 0:
+        raise PublicationResourceError("publication pull request number must be positive")
     if payload.clean_clone_url.casefold() != (
         f"https://github.com/{payload.repo_full_name}.git".casefold()
     ):
@@ -350,11 +511,17 @@ def build_publication_resources(
     }
     contract = {
         "publication_id": str(payload.publication_id),
+        "revision_id": str(payload.revision_id),
+        "revision_number": payload.revision_number,
         "repo_full_name": payload.repo_full_name,
         "clean_clone_url": payload.clean_clone_url,
         "base_sha": payload.base_sha,
+        "expected_prior_head": payload.expected_prior_head,
+        "expected_remote_head": payload.expected_remote_head,
         "patch_sha256": hashlib.sha256(payload.patch).hexdigest(),
         "branch": payload.branch,
+        "pr_number": payload.pr_number,
+        "pr_url": payload.pr_url,
         "title": payload.title,
         "body": payload.body,
         "runner_image": settings.runner_image,
@@ -398,6 +565,12 @@ def build_publication_resources(
         {"name": "CLEAN_CLONE_URL", "value": payload.clean_clone_url},
         {"name": "BASE_SHA", "value": payload.base_sha},
         {"name": "BRANCH", "value": payload.branch},
+        {"name": "REVISION_ID", "value": str(payload.revision_id)},
+        {"name": "REVISION_NUMBER", "value": str(payload.revision_number)},
+        {"name": "EXPECTED_PRIOR_HEAD", "value": payload.expected_prior_head},
+        {"name": "EXPECTED_REMOTE_HEAD", "value": payload.expected_remote_head or ""},
+        {"name": "PR_NUMBER", "value": str(payload.pr_number or "")},
+        {"name": "PR_URL", "value": payload.pr_url or ""},
         {"name": "PR_TITLE", "value": payload.title},
         {"name": "PR_BODY", "value": payload.body},
         {"name": "GIT_USER_NAME", "value": settings.git_user_name},
@@ -742,7 +915,13 @@ class KubernetesPublicationCluster:
         except k8s_client.ApiException as exc:
             if self._is_not_found(exc):
                 return PublicationJobObservation(
-                    phase="pending", pr_url=None, logs="", error=None, exists=False
+                    phase="pending",
+                    pr_url=None,
+                    pr_number=None,
+                    commit_sha=None,
+                    logs="",
+                    error=None,
+                    exists=False,
                 )
             raise
         metadata = job.get("metadata") if isinstance(job, dict) else getattr(job, "metadata", None)
@@ -865,9 +1044,23 @@ class KubernetesPublicationCluster:
             logs,
             re.MULTILINE,
         )
+        number_match = re.search(r"^CURIE_PR_NUMBER=([1-9][0-9]*)$", logs, re.MULTILINE)
+        commit_match = re.search(
+            r"^CURIE_COMMIT_SHA=([0-9a-f]{40,64})$", logs, re.MULTILINE
+        )
+        state_match = re.search(
+            r"^CURIE_PR_STATE=(closed|merged)$", logs, re.MULTILINE
+        )
         return PublicationJobObservation(
             phase=phase,
             pr_url=match.group(1) if match else None,
+            pr_number=int(number_match.group(1)) if number_match else None,
+            commit_sha=commit_match.group(1) if commit_match else None,
+            pr_state=(
+                cast(Literal["closed", "merged"], state_match.group(1))
+                if state_match
+                else None
+            ),
             logs=logs,
             error=error,
         )

--- a/apps/worker/src/curie_worker/publication_loop.py
+++ b/apps/worker/src/curie_worker/publication_loop.py
@@ -33,6 +33,9 @@ from .publication_k8s import (
 from .reply_sink import ReplySink, TargetRoute
 
 _PR_MARKER = re.compile(r"^CURIE_PR_URL=(https://github\.com/[^\s]+/pull/\d+)$", re.MULTILINE)
+_PR_NUMBER_MARKER = re.compile(r"^CURIE_PR_NUMBER=([1-9][0-9]*)$", re.MULTILINE)
+_COMMIT_MARKER = re.compile(r"^CURIE_COMMIT_SHA=([0-9a-f]{40,64})$", re.MULTILINE)
+_PR_STATE_MARKER = re.compile(r"^CURIE_PR_STATE=(closed|merged)$", re.MULTILINE)
 logger = logging.getLogger(__name__)
 
 
@@ -51,10 +54,22 @@ class PublicationCredential:
 
 
 @dataclass(frozen=True)
+class PublicationPullState:
+    number: int
+    url: str
+    state: Literal["open", "closed", "merged"]
+    head_sha: str
+    head_ref: str
+
+
+@dataclass(frozen=True)
 class PublicationJobObservation:
     phase: str
     pr_url: str | None
     logs: str
+    pr_number: int | None = None
+    commit_sha: str | None = None
+    pr_state: Literal["closed", "merged"] | None = None
     error: str | None = None
     exists: bool = True
 
@@ -64,7 +79,16 @@ class PublicationWork:
     publication_id: uuid.UUID
     approval_id: uuid.UUID
     decision: str
+    lineage_id: uuid.UUID
+    lineage_version: int
+    revision_id: uuid.UUID
+    revision_number: int
     repo_full_name: str
+    branch: str
+    pr_number: int | None
+    pr_url: str | None
+    expected_prior_head: str
+    expected_remote_head: str | None
     base_sha: str
     patch: bytes
     changed_paths: tuple[str, ...]
@@ -105,11 +129,16 @@ class PublicationStore(Protocol):
         outcome: str,
         pr_url: str | None,
         error: str | None,
+        **lineage: Any,
     ) -> None | Awaitable[None]: ...
 
     def pending_result(self, publication_id: uuid.UUID | None = None) -> Any: ...
 
     def mark_result_delivered(
+        self, publication_id: uuid.UUID
+    ) -> None | Awaitable[None]: ...
+
+    def mark_outcome_history_ready(
         self, publication_id: uuid.UUID
     ) -> None | Awaitable[None]: ...
 
@@ -119,6 +148,18 @@ class PublicationStore(Protocol):
 
     def retry(
         self, publication_id: uuid.UUID, *, error: str
+    ) -> None | Awaitable[None]: ...
+
+    def mark_lineage_terminal(
+        self,
+        lineage_id: uuid.UUID,
+        *,
+        expected_version: int,
+        expected_stored_head: str | None,
+        state: str,
+        pr_number: int,
+        pr_url: str,
+        head_sha: str,
     ) -> None | Awaitable[None]: ...
 
 
@@ -147,14 +188,40 @@ class PublicationCluster(Protocol):
 
 
 class PublicationGitHub(Protocol):
+    def read_pr_by_number(
+        self,
+        repo_full_name: str,
+        pr_number: int,
+        authorization_header: str,
+    ) -> PublicationPullState | Awaitable[PublicationPullState]: ...
+
+    def verify_revision_commit(
+        self,
+        repo_full_name: str,
+        commit_sha: str,
+        *,
+        revision_id: uuid.UUID,
+        expected_parent: str,
+        authorization_header: str,
+    ) -> str | Awaitable[str]: ...
+
+    def read_branch_head(
+        self,
+        repo_full_name: str,
+        branch: str,
+        authorization_header: str,
+    ) -> str | None | Awaitable[str | None]: ...
+
     def recover_pr_by_head(
         self,
         repo_full_name: str,
         branch: str,
         title: str,
         body: str,
+        *,
+        expected_head_sha: str,
         authorization_header: str,
-    ) -> str | None | Awaitable[str | None]: ...
+    ) -> PublicationPullState | None | Awaitable[PublicationPullState | None]: ...
 
 
 class PublicationTranscript(Protocol):
@@ -186,6 +253,21 @@ async def _cluster_call[T](
 def _marker_url(logs: str) -> str | None:
     match = _PR_MARKER.search(logs)
     return match.group(1) if match else None
+
+
+def _marker_number(logs: str) -> int | None:
+    match = _PR_NUMBER_MARKER.search(logs)
+    return int(match.group(1)) if match else None
+
+
+def _marker_commit(logs: str) -> str | None:
+    match = _COMMIT_MARKER.search(logs)
+    return match.group(1) if match else None
+
+
+def _marker_state(logs: str) -> Literal["closed", "merged"] | None:
+    match = _PR_STATE_MARKER.search(logs)
+    return cast(Literal["closed", "merged"], match.group(1)) if match else None
 
 
 def _validated_pr_url(work: PublicationWork, url: str | None) -> str | None:
@@ -338,6 +420,8 @@ class PublicationReconciler:
         outcome: str,
         pr_url: str | None = None,
         error: str | None = None,
+        pr_number: int | None = None,
+        new_head: str | None = None,
     ) -> None:
         await _resolve(
             self._store.persist_result(
@@ -345,6 +429,12 @@ class PublicationReconciler:
                 outcome=outcome,
                 pr_url=pr_url,
                 error=error,
+                lineage_id=work.lineage_id,
+                lineage_version=work.lineage_version,
+                revision_id=work.revision_id,
+                expected_prior_head=work.expected_prior_head,
+                pr_number=pr_number,
+                new_head=new_head,
             )
         )
 
@@ -435,11 +525,32 @@ class PublicationReconciler:
                         )
                     )
                 except PublicationTranscriptPermanentError:
-                    logger.exception(
-                        "publication transcript permanently refused result "
-                        "publication_id=%s; continuing with routed delivery",
-                        result.publication_id,
+                    # A full transcript may reject the detailed result (most
+                    # commonly a long failure string or URL). Preserve the
+                    # semantic outcome with the smallest useful marker before
+                    # releasing the next-turn fence. The same publication id
+                    # keeps this retry idempotent.
+                    compact_text = (
+                        f"Publication outcome: {result.outcome}. Details omitted "
+                        "because thread history is at capacity."
                     )
+                    try:
+                        await _resolve(
+                            self._transcript.record_result(
+                                result.agent_id,
+                                result.workspace_conversation_id,
+                                result.publication_id,
+                                compact_text,
+                            )
+                        )
+                    except Exception as exc:
+                        transcript_retry_error = exc
+                        logger.warning(
+                            "publication compact transcript outcome failed "
+                            "publication_id=%s; retaining the durable fence",
+                            result.publication_id,
+                            exc_info=True,
+                        )
                 except Exception as exc:
                     transcript_retry_error = exc
                     logger.warning(
@@ -448,6 +559,14 @@ class PublicationReconciler:
                         result.publication_id,
                         exc_info=True,
                     )
+                if transcript_retry_error is None:
+                    await _resolve(
+                        self._store.mark_outcome_history_ready(result.publication_id)
+                    )
+            else:
+                transcript_retry_error = PublicationReconcileError(
+                    "publication transcript recording is not configured"
+                )
             await self._report(result.target, result.route, text)
             if card_ref is not None:
                 await self._settle_card(result, card_ref)
@@ -504,14 +623,44 @@ class PublicationReconciler:
         outcome: str,
         pr_url: str | None = None,
         error: str | None = None,
+        pr_number: int | None = None,
+        new_head: str | None = None,
         names: PublicationResourceNames,
     ) -> None:
         # The durable outcome is the source of truth. Resource cleanup and reply
         # delivery are independent outboxes; result claims remain gated until
         # cleanup has durably completed.
-        await self._persist_result(work, outcome=outcome, pr_url=pr_url, error=error)
+        await self._persist_result(
+            work,
+            outcome=outcome,
+            pr_url=pr_url,
+            error=error,
+            pr_number=pr_number,
+            new_head=new_head,
+        )
         await self.deliver_pending_cleanup()
         await self.deliver_pending_result(work.publication_id)
+
+    async def _mark_lineage_terminal(
+        self,
+        work: PublicationWork,
+        state: Literal["closed", "merged"],
+        *,
+        pr_number: int,
+        pr_url: str,
+        head_sha: str,
+    ) -> None:
+        await _resolve(
+            self._store.mark_lineage_terminal(
+                work.lineage_id,
+                expected_version=work.lineage_version,
+                expected_stored_head=work.expected_remote_head,
+                state=state,
+                pr_number=pr_number,
+                pr_url=pr_url,
+                head_sha=head_sha,
+            )
+        )
 
     async def _bounded_setup_failure(
         self,
@@ -525,22 +674,131 @@ class PublicationReconciler:
         await self.deliver_pending_cleanup()
         await self.deliver_pending_result(work.publication_id)
 
-    async def _recover_remote(
+    @staticmethod
+    def _payload(work: PublicationWork, *, clean_clone_url: str) -> PublicationPayload:
+        return PublicationPayload(
+            publication_id=work.publication_id,
+            revision_id=work.revision_id,
+            revision_number=work.revision_number,
+            repo_full_name=work.repo_full_name,
+            clean_clone_url=clean_clone_url,
+            base_sha=work.base_sha,
+            expected_prior_head=work.expected_prior_head,
+            expected_remote_head=work.expected_remote_head,
+            patch=work.patch,
+            branch=work.branch,
+            pr_number=work.pr_number,
+            pr_url=work.pr_url,
+            title=work.title,
+            body=work.body,
+        )
+
+    async def _read_stored_pull(
         self,
         work: PublicationWork,
-        branch: str,
-        credential: PublicationCredential,
-    ) -> str | None:
-        recovered = await _resolve(
-            self._github.recover_pr_by_head(
+        authorization_header: str,
+    ) -> PublicationPullState | None:
+        if work.pr_number is None:
+            return None
+        pull = await _resolve(
+            self._github.read_pr_by_number(
                 work.repo_full_name,
-                branch,
-                work.title,
-                work.body,
-                credential.authorization_header,
+                work.pr_number,
+                authorization_header,
             )
         )
-        return _validated_pr_url(work, recovered)
+        if pull.head_ref != work.branch:
+            raise PublicationReconcileError(
+                "pull request head branch no longer matches the stored lineage branch"
+            )
+        validated_url = _validated_pr_url(work, pull.url)
+        if (
+            validated_url is None
+            or work.pr_url is None
+            or validated_url.casefold() != work.pr_url.casefold()
+        ):
+            raise PublicationReconcileError(
+                "pull request URL no longer matches the stored lineage identity"
+            )
+        return pull
+
+    async def _finish_observation(
+        self,
+        work: PublicationWork,
+        observation: PublicationJobObservation,
+        names: PublicationResourceNames,
+    ) -> bool:
+        if observation.phase in {"pending", "running"}:
+            return False
+        pr_url = _validated_pr_url(
+            work, observation.pr_url or _marker_url(observation.logs)
+        )
+        pr_number = observation.pr_number or _marker_number(observation.logs)
+        commit_sha = observation.commit_sha or _marker_commit(observation.logs)
+        pr_state = observation.pr_state or _marker_state(observation.logs)
+        if pr_state is not None:
+            if pr_url is None or pr_number is None or commit_sha is None:
+                raise PublicationReconcileError(
+                    "publication Job terminal state omitted exact pull request facts"
+                )
+            if pr_number != int(pr_url.rsplit("/", 1)[1]):
+                raise PublicationReconcileError(
+                    "publication Job terminal pull request facts are inconsistent"
+                )
+            if work.pr_number is not None and pr_number != work.pr_number:
+                raise PublicationReconcileError(
+                    "publication Job returned a different stored pull request"
+                )
+            if (
+                work.pr_url is not None
+                and pr_url.casefold() != work.pr_url.casefold()
+            ):
+                raise PublicationReconcileError(
+                    "publication Job returned a different stored pull request"
+                )
+            await self._mark_lineage_terminal(
+                work,
+                pr_state,
+                pr_number=pr_number,
+                pr_url=pr_url,
+                head_sha=commit_sha,
+            )
+            raise PublicationReconcileError(
+                f"pull request lineage is {pr_state}; start a new thread"
+            )
+        if pr_url is not None and pr_number is not None and commit_sha is not None:
+            if work.pr_number is not None and pr_number != work.pr_number:
+                raise PublicationReconcileError(
+                    "publication Job returned a different stored pull request"
+                )
+            await self._terminalize(
+                work,
+                outcome="published",
+                pr_url=pr_url,
+                pr_number=pr_number,
+                new_head=commit_sha,
+                names=names,
+            )
+            return True
+        # Jobs created by the immediately preceding release emitted only the
+        # URL marker. Preserve their terminal outbox behavior without claiming
+        # a lineage head that they did not prove. New lineage Jobs always emit
+        # all three markers and therefore take the CAS path above.
+        if pr_url is not None and pr_number is None and commit_sha is None:
+            await self._terminalize(
+                work,
+                outcome="published",
+                pr_url=pr_url,
+                names=names,
+            )
+            return True
+        if observation.phase == "failed":
+            raise PublicationReconcileError(
+                observation.error or "publication Job failed without lineage markers"
+            )
+        raise PublicationReconcileError(
+            "publication Job succeeded without complete lineage markers"
+        )
 
     async def reconcile(self, work: PublicationWork) -> None:
         names = publication_resource_names(work.publication_id)
@@ -553,28 +811,24 @@ class PublicationReconciler:
         if work.decision != "approved":
             return
 
-        branch = deterministic_publication_branch(work.publication_id)
         try:
             observation = await _cluster_call(self._cluster.observe, names.job)
         except Exception as exc:
             await self._bounded_setup_failure(work, exc)
             return
 
-        if observation.exists and observation.phase in {"pending", "running"}:
-            # Validate deterministic collisions without minting another write
-            # credential or calling GitHub on every poll. The placeholder is
-            # used only to construct the expected immutable Secret shape.
+        if observation.exists:
+            # Validate deterministic collisions before trusting either an
+            # in-flight state or terminal Job markers. The placeholder is used
+            # only to construct the expected immutable Secret shape;
+            # validate_existing deliberately does not compare Secret bytes, so
+            # a rotated installation token is never needed merely to adopt the
+            # already-created Job.
             try:
                 probe_resources = build_publication_resources(
-                    PublicationPayload(
-                        publication_id=work.publication_id,
-                        repo_full_name=work.repo_full_name,
+                    self._payload(
+                        work,
                         clean_clone_url=f"https://github.com/{work.repo_full_name}.git",
-                        base_sha=work.base_sha,
-                        patch=work.patch,
-                        branch=branch,
-                        title=work.title,
-                        body=work.body,
                     ),
                     credential="validation-placeholder",
                     settings=self._job_settings,
@@ -582,47 +836,204 @@ class PublicationReconciler:
                 await _cluster_call(self._cluster.validate_existing, probe_resources)
             except Exception as exc:
                 await self._bounded_setup_failure(work, exc)
-            return
+                return
+            if observation.phase in {"pending", "running"}:
+                return
+            marker_url = observation.pr_url or _marker_url(observation.logs)
+            marker_number = observation.pr_number or _marker_number(observation.logs)
+            marker_commit = observation.commit_sha or _marker_commit(observation.logs)
+            marker_state = observation.pr_state or _marker_state(observation.logs)
+            if marker_state is not None or (
+                marker_url is not None
+                and marker_number is not None
+                and marker_commit is not None
+            ) or (
+                marker_url is not None
+                and marker_number is None
+                and marker_commit is None
+            ):
+                try:
+                    await self._finish_observation(
+                        work, observation, probe_resources.names
+                    )
+                except Exception as exc:
+                    if await _resolve(self._store.is_terminal(work.publication_id)):
+                        raise
+                    await self._bounded_setup_failure(work, exc)
+                return
 
         credential: PublicationCredential
-        recovered: str | None
-        resources: Any | None = None
         try:
+            # The approved decision is the only authority to redeem. Redeem
+            # exactly once, then use this authorization for every private
+            # GitHub observation and for the one immutable Job Secret.
             credential = await _resolve(self._credentials.redeem(work.publication_id))
-            recovered = await self._recover_remote(work, branch, credential)
-            if recovered is None:
-                resources = build_publication_resources(
-                    PublicationPayload(
-                        publication_id=work.publication_id,
-                        repo_full_name=work.repo_full_name,
-                        clean_clone_url=credential.clean_clone_url,
-                        base_sha=work.base_sha,
-                        patch=work.patch,
-                        branch=branch,
-                        title=work.title,
-                        body=work.body,
-                    ),
-                    credential=credential.authorization_header,
-                    settings=self._job_settings,
+            pull = await self._read_stored_pull(
+                work,
+                credential.authorization_header,
+            )
+            if pull is None:
+                branch_head = await _resolve(
+                    self._github.read_branch_head(
+                        work.repo_full_name,
+                        work.branch,
+                        credential.authorization_header,
+                    )
                 )
+                if branch_head is not None:
+                    await _resolve(
+                        self._github.verify_revision_commit(
+                            work.repo_full_name,
+                            branch_head,
+                            revision_id=work.revision_id,
+                            expected_parent=work.expected_prior_head,
+                            authorization_header=credential.authorization_header,
+                        )
+                    )
+                    recovered = await _resolve(
+                        self._github.recover_pr_by_head(
+                            work.repo_full_name,
+                            work.branch,
+                            work.title,
+                            work.body,
+                            expected_head_sha=branch_head,
+                            authorization_header=credential.authorization_header,
+                        )
+                    )
+                    if recovered is None:
+                        raise PublicationReconcileError(
+                            "verified publication branch has no recoverable pull request"
+                        )
+                    validated_url = _validated_pr_url(work, recovered.url)
+                    if (
+                        validated_url is None
+                        or recovered.number != int(validated_url.rsplit("/", 1)[1])
+                        or recovered.head_ref != work.branch
+                        or recovered.head_sha != branch_head
+                    ):
+                        raise PublicationReconcileError(
+                            "recovered pull request does not match the verified publication"
+                        )
+                    if recovered.state == "closed" or recovered.state == "merged":
+                        await self._mark_lineage_terminal(
+                            work,
+                            recovered.state,
+                            pr_number=recovered.number,
+                            pr_url=validated_url,
+                            head_sha=recovered.head_sha,
+                        )
+                        raise PublicationReconcileError(
+                            "pull request lineage is "
+                            f"{recovered.state}; start a new thread"
+                        )
+                    if recovered.state != "open":
+                        raise PublicationReconcileError(
+                            "GitHub pull request state is invalid"
+                        )
+                    await self._terminalize(
+                        work,
+                        outcome="published",
+                        pr_url=validated_url,
+                        pr_number=recovered.number,
+                        new_head=recovered.head_sha,
+                        names=names,
+                    )
+                    return
+            if pull is not None and pull.state != "open":
+                trusted_head = work.expected_remote_head
+                if pull.head_sha != trusted_head:
+                    try:
+                        verified_head = await _resolve(
+                            self._github.verify_revision_commit(
+                                work.repo_full_name,
+                                pull.head_sha,
+                                revision_id=work.revision_id,
+                                expected_parent=work.expected_prior_head,
+                                authorization_header=credential.authorization_header,
+                            )
+                        )
+                        if verified_head != pull.head_sha:
+                            raise PublicationReconcileError(
+                                "revision verification returned a different commit"
+                            )
+                    except PublicationReconcileError:
+                        if trusted_head is None:
+                            raise PublicationReconcileError(
+                                "terminal pull request head has no trusted lineage commit"
+                            ) from None
+                    else:
+                        trusted_head = verified_head
+                if trusted_head is None:
+                    raise PublicationReconcileError(
+                        "terminal pull request head has no trusted lineage commit"
+                    )
+                await self._mark_lineage_terminal(
+                    work,
+                    pull.state,
+                    pr_number=pull.number,
+                    pr_url=pull.url,
+                    head_sha=trusted_head,
+                )
+                raise PublicationReconcileError(
+                    f"pull request lineage is {pull.state}; start a new thread"
+                )
+            if pull is not None and pull.head_sha != work.expected_prior_head:
+                try:
+                    await _resolve(
+                        self._github.verify_revision_commit(
+                            work.repo_full_name,
+                            pull.head_sha,
+                            revision_id=work.revision_id,
+                            expected_parent=work.expected_prior_head,
+                            authorization_header=credential.authorization_header,
+                        )
+                    )
+                except Exception as exc:
+                    raise PublicationReconcileError(
+                        "pull request head no longer matches the stored lineage head"
+                    ) from exc
         except Exception as exc:
-            # Resource construction has not reached Kubernetes. Remote recovery
-            # may have adopted/created the deterministic-head PR, but its own
-            # query-before-POST/lost-response query makes the next attempt safe.
-            # Release every setup failure through the durable bounded counter.
             await self._bounded_setup_failure(work, exc)
             return
 
-        if recovered is not None:
+        if pull is not None and pull.head_sha != work.expected_prior_head:
+            # Verification above proved the remote head is this revision's
+            # exact marked commit with the expected parent. Persisting the
+            # lineage CAS may expose cleanup or reply-outbox failures; those
+            # must escape as outbox work, never be charged as another attempt
+            # at the already completed publication mutation.
             await self._terminalize(
                 work,
                 outcome="published",
-                pr_url=recovered,
+                pr_url=pull.url,
+                pr_number=pull.number,
+                new_head=pull.head_sha,
                 names=names,
             )
             return
-        if resources is None:
-            raise PublicationReconcileError("publication resources were not constructed")
+
+        if observation.exists:
+            # A validated terminal Job without usable markers may still be
+            # recoverable from GitHub above (the immediately preceding release
+            # emitted only a URL, and a crash can also lose pod logs). If GitHub
+            # still names the expected prior head or no branch exists, preserve
+            # the Job's terminal failure instead of attempting to mutate or
+            # replace deterministic resources.
+            try:
+                await self._finish_observation(work, observation, names)
+            except Exception as exc:
+                await self._bounded_setup_failure(work, exc)
+            return
+
+        try:
+            resources = build_publication_resources(
+                self._payload(work, clean_clone_url=credential.clean_clone_url),
+                credential=credential.authorization_header,
+                settings=self._job_settings,
+            )
+        except Exception as exc:
+            await self._bounded_setup_failure(work, exc)
+            return
 
         # Server-side apply/create-or-adopt validates every deterministic
         # resource before any Job log marker is trusted. This includes a Job
@@ -644,28 +1055,18 @@ class PublicationReconciler:
                 )
                 if observation.exists and observation.phase in {"pending", "running"}:
                     return
-                pr_url = _validated_pr_url(
-                    work,
-                    observation.pr_url or _marker_url(observation.logs)
-                    if observation.exists
-                    else None,
-                )
-                if pr_url is None:
-                    pr_url = await self._recover_remote(work, branch, credential)
+                if observation.exists and await self._finish_observation(
+                    work, observation, resources.names
+                ):
+                    return
             except Exception as recovery_exc:
+                if await _resolve(self._store.is_terminal(work.publication_id)):
+                    raise
                 await self._bounded_setup_failure(
                     work,
                     PublicationReconcileError(
                         f"ambiguous publication apply could not be recovered: {recovery_exc}"
                     ),
-                )
-                return
-            if pr_url is not None:
-                await self._terminalize(
-                    work,
-                    outcome="published",
-                    pr_url=pr_url,
-                    names=resources.names,
                 )
                 return
             await self._bounded_setup_failure(work, apply_exc)
@@ -675,33 +1076,12 @@ class PublicationReconciler:
             observation = await _cluster_call(
                 self._cluster.observe, resources.names.job
             )
-            if observation.exists and observation.phase in {"pending", "running"}:
-                return
-            pr_url = _validated_pr_url(
-                work,
-                observation.pr_url or _marker_url(observation.logs)
-                if observation.exists
-                else None,
-            )
-            if pr_url is None:
-                # Covers both crash-after-push and crash-after-REST-POST: the
-                # authenticated recovery client adopts an existing PR or opens
-                # one for the deterministic remote branch.
-                pr_url = await self._recover_remote(work, branch, credential)
-            if pr_url is None:
-                raise PublicationReconcileError(
-                    observation.error
-                    or "publication Job finished but no pull request was found for its branch"
-                )
+            await self._finish_observation(work, observation, resources.names)
         except Exception as exc:
+            if await _resolve(self._store.is_terminal(work.publication_id)):
+                raise
             await self._bounded_setup_failure(work, exc)
             return
-        await self._terminalize(
-            work,
-            outcome="published",
-            pr_url=pr_url,
-            names=resources.names,
-        )
 
 
 class PublicationReconcileLoop:
@@ -760,6 +1140,7 @@ class PublicationReconcileLoop:
 __all__ = [
     "PublicationCredential",
     "PublicationJobObservation",
+    "PublicationPullState",
     "PublicationReconcileError",
     "PublicationReconciler",
     "PublicationReconcileLoop",

--- a/apps/worker/src/curie_worker/publication_store.py
+++ b/apps/worker/src/curie_worker/publication_store.py
@@ -86,6 +86,7 @@ class PostgresPublicationStore:
         self._engine = engine
         self._table = f'"{schema}".publications'
         self._approvals = f'"{schema}".approvals'
+        self._lineages = f'"{schema}".thread_publication_lineages'
         self._lease_owner = lease_owner
         self._lease_seconds = lease_seconds
         self._result_max_attempts = result_max_attempts
@@ -321,12 +322,16 @@ class PostgresPublicationStore:
         statement = text(
             f"""
             SELECT p.id, p.approval_id, p.repo_full_name, p.status, p.version,
+                   p.lineage_id, p.revision_number, p.expected_prior_head,
                    p.base_sha, p.patch_bytes, p.changed_paths, p.title, p.body,
                    p.reply_kind, p.reply_channel, p.reply_placeholder,
                    p.reply_endpoint, p.reply_adapter,
+                   l.version AS lineage_version, l.branch, l.pr_number,
+                   l.pr_url, l.head_sha,
                    a.conversation_id
               FROM {self._table} p
               JOIN {self._approvals} a ON a.id = p.approval_id
+              JOIN {self._lineages} l ON l.id = p.lineage_id
              WHERE p.patch_bytes IS NOT NULL
                AND p.status IN ('approved', 'launching', 'running')
                AND p.approval_card_reported_at IS NOT NULL
@@ -386,7 +391,20 @@ class PostgresPublicationStore:
             publication_id=publication_id,
             approval_id=uuid.UUID(str(row["approval_id"])),
             decision="approved",
+            lineage_id=uuid.UUID(str(row["lineage_id"])),
+            lineage_version=int(row["lineage_version"]),
+            revision_id=publication_id,
+            revision_number=int(row["revision_number"]),
             repo_full_name=str(row["repo_full_name"]),
+            branch=str(row["branch"]),
+            pr_number=int(row["pr_number"]) if row["pr_number"] is not None else None,
+            pr_url=str(row["pr_url"]) if row["pr_url"] is not None else None,
+            expected_prior_head=str(row["expected_prior_head"]),
+            expected_remote_head=(
+                str(row["head_sha"])
+                if row["pr_number"] is not None and row["head_sha"] is not None
+                else None
+            ),
             base_sha=str(row["base_sha"]),
             patch=patch,
             changed_paths=tuple(str(path) for path in paths),
@@ -426,6 +444,103 @@ class PostgresPublicationStore:
             status == "denied" and bool(row["patch_cleared"])
         )
 
+    async def mark_lineage_terminal(
+        self,
+        lineage_id: uuid.UUID,
+        *,
+        expected_version: int,
+        expected_stored_head: str | None,
+        state: str,
+        pr_number: int,
+        pr_url: str,
+        head_sha: str,
+    ) -> None:
+        """Persist exact terminal GitHub facts, accepting an identical replay."""
+
+        if state not in {"merged", "closed"}:
+            raise ValueError("publication lineage terminal state is invalid")
+        if expected_stored_head is not None and (
+            not isinstance(expected_stored_head, str)
+            or re.fullmatch(r"[0-9a-f]{40,64}", expected_stored_head) is None
+        ):
+            raise ValueError("publication lineage expected head is invalid")
+        if (
+            isinstance(pr_number, bool)
+            or not isinstance(pr_number, int)
+            or pr_number <= 0
+        ):
+            raise ValueError("publication lineage pull request number is invalid")
+        if (
+            not isinstance(pr_url, str)
+            or re.fullmatch(
+                r"https://github\.com/[^/\s]+/[^/\s]+/pull/[1-9][0-9]*",
+                pr_url,
+                re.IGNORECASE,
+            )
+            is None
+            or not pr_url.casefold().endswith(f"/pull/{pr_number}".casefold())
+        ):
+            raise ValueError("publication lineage pull request URL is invalid")
+        if (
+            not isinstance(head_sha, str)
+            or re.fullmatch(r"[0-9a-f]{40,64}", head_sha) is None
+        ):
+            raise ValueError("publication lineage head is invalid")
+        async with self._engine.begin() as connection:
+            updated = (
+                await connection.execute(
+                    text(
+                        f"""
+                        UPDATE {self._lineages}
+                           SET status = :state,
+                               pr_number = :pr_number,
+                               pr_url = :pr_url,
+                               head_sha = :head_sha,
+                               version = version + 1,
+                               updated_at = now()
+                         WHERE id = :lineage_id
+                           AND status = 'open'
+                           AND version = :expected_version
+                           AND head_sha IS NOT DISTINCT FROM :expected_stored_head
+                           AND (pr_number IS NULL OR pr_number = :pr_number)
+                           AND (pr_url IS NULL OR pr_url = :pr_url)
+                     RETURNING version
+                        """
+                    ),
+                    {
+                        "lineage_id": lineage_id,
+                        "expected_version": expected_version,
+                        "expected_stored_head": expected_stored_head,
+                        "state": state,
+                        "pr_number": pr_number,
+                        "pr_url": pr_url,
+                        "head_sha": head_sha,
+                    },
+                )
+            ).scalar_one_or_none()
+            if updated is not None:
+                return
+            current = (
+                await connection.execute(
+                    text(
+                        f"""
+                        SELECT status, pr_number, pr_url, head_sha
+                          FROM {self._lineages}
+                         WHERE id = :lineage_id
+                        """
+                    ),
+                    {"lineage_id": lineage_id},
+                )
+            ).mappings().one_or_none()
+            if current is not None and (
+                str(current["status"]) == state
+                and current["pr_number"] == pr_number
+                and current["pr_url"] == pr_url
+                and current["head_sha"] == head_sha
+            ):
+                return
+        raise PublicationStoreError("publication lineage terminal CAS was lost")
+
     async def complete(
         self, publication_id: uuid.UUID, *, outcome: str, pr_url: str | None
     ) -> None:
@@ -445,6 +560,7 @@ class PostgresPublicationStore:
         outcome: str,
         pr_url: str | None,
         error: str | None,
+        **lineage: object,
     ) -> None:
         """Persist the outcome and clear private work before any reply attempt."""
 
@@ -457,11 +573,35 @@ class PostgresPublicationStore:
         }.get(outcome)
         if status is None:
             raise ValueError(f"unsupported publication outcome {outcome!r}")
+        lineage_id_value = lineage.get("lineage_id")
+        lineage_version_value = lineage.get("lineage_version")
+        pr_number_value = lineage.get("pr_number")
         await self._terminal_cas(
             publication_id,
             status=status,
             result_url=pr_url,
             error=error[:2000] if error else None,
+            lineage_id=lineage_id_value if isinstance(lineage_id_value, uuid.UUID) else None,
+            lineage_version=(
+                lineage_version_value
+                if isinstance(lineage_version_value, int)
+                else None
+            ),
+            pr_number=(
+                pr_number_value
+                if isinstance(pr_number_value, int)
+                else None
+            ),
+            new_head=(
+                str(lineage["new_head"])
+                if lineage.get("new_head") is not None
+                else None
+            ),
+            expected_prior_head=(
+                str(lineage["expected_prior_head"])
+                if lineage.get("expected_prior_head") is not None
+                else None
+            ),
         )
 
     async def pending_result(
@@ -476,11 +616,12 @@ class PostgresPublicationStore:
             SELECT p.id, p.approval_id, p.status, p.result_url, p.error, p.version,
                    p.result_delivery_attempts, p.reply_kind, p.reply_channel,
                    p.reply_placeholder, p.reply_endpoint, p.reply_adapter,
-                   COALESCE(p.workspace_conversation_id, a.conversation_id)
+                   COALESCE(p.workspace_conversation_id, l.conversation_id)
                        AS workspace_conversation_id,
                    a.agent_id, a.conversation_id, a.resolved_by, a.resolution_note
               FROM {self._table} p
               JOIN {self._approvals} a ON a.id = p.approval_id
+              LEFT JOIN {self._lineages} l ON l.id = p.lineage_id
              WHERE p.status IN ('denied', 'expired', 'succeeded', 'failed')
                AND p.patch_bytes IS NULL
                AND (
@@ -594,6 +735,42 @@ class PostgresPublicationStore:
 
         await self._result_delivery_cas(publication_id, delivered=True, error=None)
 
+    async def mark_outcome_history_ready(self, publication_id: uuid.UUID) -> None:
+        """Release the thread fence only after transcript append succeeded."""
+
+        version = self._result_versions.get(publication_id)
+        if version is None:
+            raise PublicationStoreError("publication result has no owned lease version")
+        async with self._engine.begin() as connection:
+            updated = (
+                await connection.execute(
+                    text(
+                        f"""
+                        UPDATE {self._table}
+                           SET outcome_history_ready_at =
+                                   COALESCE(outcome_history_ready_at, now()),
+                               version = version + 1,
+                               updated_at = now()
+                         WHERE id = :id
+                           AND status IN ('denied', 'expired', 'succeeded', 'failed')
+                           AND lease_owner = :owner
+                           AND version = :version
+                     RETURNING version
+                        """
+                    ),
+                    {
+                        "id": publication_id,
+                        "owner": self._lease_owner,
+                        "version": version,
+                    },
+                )
+            ).scalar_one_or_none()
+        if updated is None:
+            raise PublicationStoreError(
+                "publication outcome history acknowledgement CAS was lost"
+            )
+        self._result_versions[publication_id] = int(updated)
+
     async def retry_result_delivery(
         self, publication_id: uuid.UUID, *, error: str
     ) -> None:
@@ -642,6 +819,7 @@ class PostgresPublicationStore:
                                version = version + 1,
                                updated_at = now()
                          WHERE id = :id AND version = :version AND lease_owner = :owner
+                           AND (NOT :delivered OR outcome_history_ready_at IS NOT NULL)
                      RETURNING version
                         """
                     ),
@@ -822,11 +1000,61 @@ class PostgresPublicationStore:
         status: str,
         result_url: str | None,
         error: str | None,
+        lineage_id: uuid.UUID | None = None,
+        lineage_version: int | None = None,
+        pr_number: int | None = None,
+        new_head: str | None = None,
+        expected_prior_head: str | None = None,
     ) -> None:
         version = self._versions.get(publication_id)
         if version is None:
             raise PublicationStoreError("publication has no owned lease version")
         async with self._engine.begin() as connection:
+            if new_head is not None:
+                if (
+                    lineage_id is None
+                    or lineage_version is None
+                    or pr_number is None
+                    or result_url is None
+                    or expected_prior_head is None
+                ):
+                    raise PublicationStoreError(
+                        "publication success omitted lineage CAS identity"
+                    )
+                lineage_updated = (
+                    await connection.execute(
+                        text(
+                            f"""
+                            UPDATE {self._lineages}
+                               SET pr_number = COALESCE(pr_number, :pr_number),
+                                   pr_url = COALESCE(pr_url, :pr_url),
+                                   head_sha = :new_head,
+                                   version = version + 1,
+                                   updated_at = now()
+                             WHERE id = :lineage_id
+                               AND status = 'open'
+                               AND version = :lineage_version
+                               AND (pr_number IS NULL OR pr_number = :pr_number)
+                               AND (pr_url IS NULL OR pr_url = :pr_url)
+                               AND (
+                                    (head_sha IS NULL AND base_sha = :expected_prior)
+                                    OR head_sha = :expected_prior
+                               )
+                         RETURNING version
+                            """
+                        ),
+                        {
+                            "lineage_id": lineage_id,
+                            "lineage_version": lineage_version,
+                            "pr_number": pr_number,
+                            "pr_url": result_url,
+                            "new_head": new_head,
+                            "expected_prior": expected_prior_head,
+                        },
+                    )
+                ).scalar_one_or_none()
+                if lineage_updated is None:
+                    raise PublicationStoreError("publication lineage advance CAS was lost")
             updated = (
                 await connection.execute(
                     text(
@@ -857,6 +1085,12 @@ class PostgresPublicationStore:
                     },
                 )
             ).scalar_one_or_none()
+            # A successful lineage advance and a lost publication lease must
+            # roll back together. Otherwise a stale worker could move the
+            # shared PR head while leaving its revision nonterminal and make
+            # the retry appear to be a foreign concurrent commit.
+            if updated is None and new_head is not None:
+                raise PublicationStoreError("publication terminal CAS was lost")
         if updated is None:
             if await self.is_terminal(publication_id):
                 self._versions.pop(publication_id, None)

--- a/apps/worker/src/curie_worker/sandbox/substrate.py
+++ b/apps/worker/src/curie_worker/sandbox/substrate.py
@@ -134,6 +134,8 @@ class SandboxSubstrate:
         env: dict[str, str] | None = None,
         agent_name: str | None = None,
         workspace_repo: str | None = None,
+        workspace_materialized_head: str | None = None,
+        publication_visible_outcome_revision: int = 0,
     ) -> SandboxHandle:
         """Return the thread's live sandbox, claiming a warm one if needed.
 
@@ -172,6 +174,10 @@ class SandboxSubstrate:
                         state=RouteState.LIVE,
                         agent_name=agent_name,
                         workspace_repo=workspace_repo,
+                        workspace_materialized_head=workspace_materialized_head,
+                        publication_visible_outcome_revision=(
+                            publication_visible_outcome_revision
+                        ),
                     )
                     outcome = "claimed"
             except Exception as exc:
@@ -253,6 +259,8 @@ class SandboxSubstrate:
         expected: SandboxHandle,
         env: dict[str, str],
         workspace_repo: str,
+        workspace_materialized_head: str | None = None,
+        publication_visible_outcome_revision: int = 0,
         agent_name: str | None = None,
         validate_candidate: Callable[[SandboxHandle], None] | None = None,
     ) -> SandboxHandle:
@@ -276,6 +284,8 @@ class SandboxSubstrate:
             history_ref=expected.history_ref,
             agent_name=agent_name,
             workspace_repo=workspace_repo,
+            workspace_materialized_head=workspace_materialized_head,
+            publication_visible_outcome_revision=publication_visible_outcome_revision,
             generation=expected.generation + 1,
             publish=False,
         )
@@ -354,6 +364,9 @@ class SandboxSubstrate:
         *,
         env: dict[str, str] | None = None,
         agent_name: str | None = None,
+        workspace_repo: str | None = None,
+        workspace_materialized_head: str | None = None,
+        publication_visible_outcome_revision: int | None = None,
     ) -> SandboxHandle:
         """Rehydrate a suspended thread into a fresh claim.
 
@@ -400,7 +413,15 @@ class SandboxSubstrate:
                     session_id=old.session_id,
                     history_ref=old.history_ref,
                     agent_name=agent_name,
-                    workspace_repo=old.workspace_repo,
+                    workspace_repo=workspace_repo or old.workspace_repo,
+                    workspace_materialized_head=(
+                        workspace_materialized_head or old.workspace_materialized_head
+                    ),
+                    publication_visible_outcome_revision=(
+                        publication_visible_outcome_revision
+                        if publication_visible_outcome_revision is not None
+                        else old.publication_visible_outcome_revision
+                    ),
                     generation=old.generation + 1,
                 )
             except Exception as exc:
@@ -605,6 +626,8 @@ class SandboxSubstrate:
         history_ref: str | None = None,
         agent_name: str | None = None,
         workspace_repo: str | None = None,
+        workspace_materialized_head: str | None = None,
+        publication_visible_outcome_revision: int = 0,
         generation: int = 0,
         publish: bool = True,
     ) -> SandboxHandle:
@@ -647,6 +670,8 @@ class SandboxSubstrate:
             history_ref=(env or {}).get(HISTORY_ENV) or history_ref,
             token=(env or {}).get(RUNNER_TOKEN_ENV, ""),
             workspace_repo=workspace_repo,
+            workspace_materialized_head=workspace_materialized_head,
+            publication_visible_outcome_revision=publication_visible_outcome_revision,
             generation=generation,
         )
         if not publish:

--- a/apps/worker/src/curie_worker/sandbox/types.py
+++ b/apps/worker/src/curie_worker/sandbox/types.py
@@ -130,6 +130,13 @@ class SandboxHandle:
     token: str = ""
     # Worker-internal late-acquisition fence. These facts never cross ACI.
     workspace_repo: str | None = None
+    # Exact commit extracted into /workspace for this runner. A verified PR
+    # lineage can reuse the route only while this still matches its remote head.
+    workspace_materialized_head: str | None = None
+    # Highest publication result already present in durable transcript history
+    # when this runner booted. Advancing it requires one cold rehydrate even
+    # when a denied/failed revision leaves the git head unchanged.
+    publication_visible_outcome_revision: int = 0
     generation: int = 0
 
     @property

--- a/apps/worker/src/curie_worker/workspace.py
+++ b/apps/worker/src/curie_worker/workspace.py
@@ -630,6 +630,7 @@ class PreparedWorkspace:
     clean_clone_url: str
     repo_full_name: str
     base_sha: str
+    materialized_head: str
     checkout_mode: int
     reference: WorkspaceRef
 
@@ -666,6 +667,7 @@ class _WorkspaceOwnership:
                     "clean_clone_url": prepared.clean_clone_url,
                     "repo_full_name": prepared.repo_full_name,
                     "base_sha": prepared.base_sha,
+                    "materialized_head": prepared.materialized_head,
                     "checkout_mode": prepared.checkout_mode,
                     "reference": prepared.reference.encode(),
                 },
@@ -695,6 +697,9 @@ class _WorkspaceOwnership:
                 clean_clone_url=str(prepared_raw["clean_clone_url"]),
                 repo_full_name=str(prepared_raw["repo_full_name"]),
                 base_sha=str(prepared_raw["base_sha"]),
+                materialized_head=str(
+                    prepared_raw.get("materialized_head", prepared_raw["base_sha"])
+                ),
                 checkout_mode=int(prepared_raw["checkout_mode"]),
                 reference=WorkspaceRef.decode(str(prepared_raw["reference"])),
             )
@@ -883,7 +888,14 @@ class WorkspacePreparer:
         self.limiter = limiter or WorkspaceCloneLimiter(max_concurrent=limits.max_concurrent_clones)
 
     def prepare(
-        self, *, deployment_id: uuid.UUID, thread_key: str, generation: str
+        self,
+        *,
+        deployment_id: uuid.UUID,
+        thread_key: str,
+        generation: str,
+        branch: str | None = None,
+        expected_head: str | None = None,
+        detached_head: str | None = None,
     ) -> PreparedWorkspace:
         started = self.clock()
         real_started = time.monotonic()
@@ -919,22 +931,49 @@ class WorkspacePreparer:
                     "GIT_CONFIG_VALUE_1": f"Authorization: {credential.authorization_header}",
                 }
                 try:
+                    clone_argv = [
+                        "git",
+                        "clone",
+                        "--depth=1",
+                        "--single-branch",
+                        "--no-tags",
+                    ]
+                    if branch is not None:
+                        clone_argv.extend(["--branch", branch])
+                    clone_argv.extend([credential.clone_url, str(checkout)])
                     self.commands.run(
-                        [
-                            "git",
-                            "clone",
-                            "--depth=1",
-                            "--single-branch",
-                            "--no-tags",
-                            credential.clone_url,
-                            str(checkout),
-                        ],
+                        clone_argv,
                         env=clone_env,
                         timeout_seconds=min(
                             self.limits.clone_timeout_seconds,
                             self._real_remaining(real_started),
                         ),
                     )
+                    if detached_head is not None:
+                        self.commands.run(
+                            [
+                                "git",
+                                "fetch",
+                                "--depth=1",
+                                "--no-tags",
+                                "origin",
+                                detached_head,
+                            ],
+                            cwd=checkout,
+                            env=clone_env,
+                            timeout_seconds=min(
+                                self.limits.clone_timeout_seconds,
+                                self._real_remaining(real_started),
+                            ),
+                        )
+                        self.commands.run(
+                            ["git", "checkout", "--detach", detached_head],
+                            cwd=checkout,
+                            timeout_seconds=min(
+                                self.limits.clone_timeout_seconds,
+                                self._real_remaining(real_started),
+                            ),
+                        )
                 except TimeoutError as exc:
                     raise WorkspaceStageTimeout("clone", self.limits.clone_timeout_seconds) from exc
                 except WorkspacePreparationError as exc:
@@ -963,6 +1002,11 @@ class WorkspacePreparer:
                     cwd=checkout,
                     timeout_seconds=self.limits.archive_timeout_seconds,
                 ).stdout.strip()
+                if expected_head is not None and base_sha != expected_head:
+                    raise WorkspacePreparationError(
+                        "lineage-checkout",
+                        "checkout does not match the expected lineage head",
+                    )
 
                 checkout_bytes = self._checkout_size(checkout)
                 if checkout_bytes > self.limits.max_checkout_bytes:
@@ -1030,6 +1074,7 @@ class WorkspacePreparer:
                 clean_clone_url=credential.clone_url,
                 repo_full_name=credential.repo_full_name,
                 base_sha=base_sha,
+                materialized_head=base_sha,
                 checkout_mode=checkout.stat().st_mode,
                 reference=reference,
             )
@@ -1042,6 +1087,51 @@ class WorkspacePreparer:
             raise
         finally:
             shutil.rmtree(scratch, ignore_errors=True)
+
+    def prepare_lineage(
+        self,
+        *,
+        deployment_id: uuid.UUID,
+        thread_key: str,
+        generation: str,
+        branch: str,
+        expected_head: str,
+    ) -> PreparedWorkspace:
+        """Materialize one stored lineage branch at its exact fenced head."""
+
+        if not branch or re.fullmatch(r"[0-9a-f]{40}", expected_head) is None:
+            raise WorkspacePreparationError(
+                "lineage-checkout", "lineage branch or expected head is invalid"
+            )
+        return self.prepare(
+            deployment_id=deployment_id,
+            thread_key=thread_key,
+            generation=generation,
+            branch=branch,
+            expected_head=expected_head,
+        )
+
+    def prepare_lineage_base(
+        self,
+        *,
+        deployment_id: uuid.UUID,
+        thread_key: str,
+        generation: str,
+        expected_base: str,
+    ) -> PreparedWorkspace:
+        """Materialize a headless lineage at its proposal base without a branch."""
+
+        if re.fullmatch(r"[0-9a-f]{40}", expected_base) is None:
+            raise WorkspacePreparationError(
+                "lineage-checkout", "lineage base is invalid"
+            )
+        return self.prepare(
+            deployment_id=deployment_id,
+            thread_key=thread_key,
+            generation=generation,
+            expected_head=expected_base,
+            detached_head=expected_base,
+        )
 
     def _check_total(self, started: float) -> None:
         if self.clock() - started > self.limits.total_timeout_seconds:
@@ -1220,6 +1310,10 @@ class WorkspaceClaimCoordinator:
         replace_handle: Any | None = None,
         revalidate_before_handoff: Callable[[], None] | None = None,
         validate_candidate: Callable[[Any], None] | None = None,
+        lineage_branch: str | None = None,
+        lineage_head: str | None = None,
+        lineage_base_sha: str | None = None,
+        publication_visible_outcome_revision: int = 0,
     ) -> WorkspaceClaimResult:
         """Prepare once, then cold-claim or resume a suspended route.
 
@@ -1232,11 +1326,36 @@ class WorkspaceClaimCoordinator:
         ready but before its route CAS; refusal follows the same rollback path.
         """
 
-        prepared = self.preparer.prepare(
-            deployment_id=deployment_id,
-            thread_key=thread_key,
-            generation=uuid.uuid4().hex,
-        )
+        generation = uuid.uuid4().hex
+        if (lineage_branch is None) != (lineage_head is None):
+            raise WorkspacePreparationError(
+                "lineage-checkout", "lineage branch and head must be supplied together"
+            )
+        if lineage_base_sha is not None and lineage_head is not None:
+            raise WorkspacePreparationError(
+                "lineage-checkout", "lineage head and base are mutually exclusive"
+            )
+        if lineage_branch is not None and lineage_head is not None:
+            prepared = self.preparer.prepare_lineage(
+                deployment_id=deployment_id,
+                thread_key=thread_key,
+                generation=generation,
+                branch=lineage_branch,
+                expected_head=lineage_head,
+            )
+        elif lineage_base_sha is not None:
+            prepared = self.preparer.prepare_lineage_base(
+                deployment_id=deployment_id,
+                thread_key=thread_key,
+                generation=generation,
+                expected_base=lineage_base_sha,
+            )
+        else:
+            prepared = self.preparer.prepare(
+                deployment_id=deployment_id,
+                thread_key=thread_key,
+                generation=generation,
+            )
         previous_ownership: _WorkspaceOwnership | None = None
         ownership_staged = False
         sandbox_exposed = False
@@ -1267,6 +1386,10 @@ class WorkspaceClaimCoordinator:
                     expected=replace_handle,
                     env=claim_env,
                     workspace_repo=repo_full_name,
+                    workspace_materialized_head=prepared.materialized_head,
+                    publication_visible_outcome_revision=(
+                        publication_visible_outcome_revision
+                    ),
                     agent_name=agent_name,
                     **candidate_guard,
                 )
@@ -1277,6 +1400,10 @@ class WorkspaceClaimCoordinator:
                         env=claim_env,
                         agent_name=agent_name,
                         workspace_repo=repo_full_name,
+                        workspace_materialized_head=prepared.materialized_head,
+                        publication_visible_outcome_revision=(
+                            publication_visible_outcome_revision
+                        ),
                     )
                 except Exception as exc:
                     # The substrate signal is injected to keep this worker-local
@@ -1284,7 +1411,14 @@ class WorkspaceClaimCoordinator:
                     if not isinstance(exc, self._suspended_errors):
                         raise
                     handle = self.substrate.resume(
-                        thread_key, env=claim_env, agent_name=agent_name
+                        thread_key,
+                        env=claim_env,
+                        agent_name=agent_name,
+                        workspace_repo=repo_full_name,
+                        workspace_materialized_head=prepared.materialized_head,
+                        publication_visible_outcome_revision=(
+                            publication_visible_outcome_revision
+                        ),
                     )
             sandbox_exposed = True
             self._commit_ownership(thread_key, prepared)

--- a/apps/worker/tests/kernel/test_approval_lifecycle.py
+++ b/apps/worker/tests/kernel/test_approval_lifecycle.py
@@ -14,6 +14,7 @@ import json
 import uuid
 from collections.abc import Iterator
 from contextlib import contextmanager
+from types import SimpleNamespace
 
 import aiohttp
 import httpx
@@ -148,6 +149,1288 @@ def _awaiting_script(summary: str) -> list:
     ]
 
 
+class _LineageFenceRunner:
+    def __init__(self, status: dict[str, object]) -> None:
+        self._status = status
+        self.reads = 0
+
+    async def status(self, *_args: object, **_kwargs: object) -> dict[str, object]:
+        self.reads += 1
+        return dict(self._status)
+
+
+def _lineage_route() -> object:
+    return SimpleNamespace(
+        base_url="http://runner.example.test",
+        token="route-token",
+    )
+
+
+def test_completed_lineage_can_replace_an_idle_durable_awaiting_runner() -> None:
+    """A failed publication suspend must not strand the dirty pre-publish route."""
+
+    async def go() -> None:
+        from curie_worker.kernel import Kernel
+
+        kernel = object.__new__(Kernel)
+        kernel._runner = _LineageFenceRunner(  # type: ignore[attr-defined]
+            {
+                "status": SessionStatus.AWAITING_APPROVAL.value,
+                "turn_active": False,
+                "history_durable": True,
+            }
+        )
+
+        assert await kernel._workspace_handoff_ready(
+            _lineage_route(),
+            lineage_reconciliation=True,
+            pending_publication_approval=False,
+        )
+
+    asyncio.run(go())
+
+
+@pytest.mark.parametrize(
+    ("status", "pending", "reason"),
+    [
+        (
+            {
+                "status": SessionStatus.AWAITING_APPROVAL.value,
+                "turn_active": True,
+                "history_durable": True,
+            },
+            False,
+            "active-turn",
+        ),
+        (
+            {
+                "status": SessionStatus.AWAITING_APPROVAL.value,
+                "turn_active": False,
+                "history_durable": False,
+            },
+            False,
+            "non-durable-history",
+        ),
+        (
+            {
+                "status": SessionStatus.AWAITING_APPROVAL.value,
+                "turn_active": False,
+                "history_durable": True,
+            },
+            True,
+            "pending-approval",
+        ),
+    ],
+)
+def test_lineage_handoff_keeps_busy_and_durability_fences(
+    status: dict[str, object], pending: bool, reason: str
+) -> None:
+    async def go() -> None:
+        from curie_worker.kernel import Kernel
+
+        kernel = object.__new__(Kernel)
+        kernel._runner = _LineageFenceRunner(status)  # type: ignore[attr-defined]
+
+        assert not await kernel._workspace_handoff_ready(
+            _lineage_route(),
+            lineage_reconciliation=True,
+            pending_publication_approval=pending,
+        ), reason
+
+    asyncio.run(go())
+
+
+def test_non_lineage_handoff_still_refuses_awaiting_approval() -> None:
+    """The AWAITING_APPROVAL waiver belongs only to completed publication lineage."""
+
+    async def go() -> None:
+        from curie_worker.kernel import Kernel
+
+        kernel = object.__new__(Kernel)
+        kernel._runner = _LineageFenceRunner(  # type: ignore[attr-defined]
+            {
+                "status": SessionStatus.AWAITING_APPROVAL.value,
+                "turn_active": False,
+                "history_durable": True,
+            }
+        )
+
+        assert not await kernel._workspace_handoff_ready(
+            _lineage_route(),
+            lineage_reconciliation=False,
+            pending_publication_approval=False,
+        )
+
+    asyncio.run(go())
+
+
+def test_open_lineage_bypasses_same_repo_adoption_and_surfaces_route_cas_loss() -> None:
+    async def go() -> None:
+        from curie_worker.kernel import Kernel
+
+        old_route = object()
+
+        class Substrate:
+            def adopt(self, _thread_key: str) -> object:
+                raise AssertionError("open lineage must not adopt the dirty live route")
+
+        class Workspace:
+            def claim_or_resume_with_handle(self, **kwargs: object) -> object:
+                assert kwargs["replace_handle"] is old_route
+                assert kwargs["lineage_branch"] == "curie/thread-lineage-example"
+                assert kwargs["lineage_head"] == "a" * 40
+                raise RuntimeError("late workspace handoff lost its route fence")
+
+        kernel = object.__new__(Kernel)
+        kernel._substrate = Substrate()  # type: ignore[attr-defined]
+        kernel._workspace = Workspace()  # type: ignore[attr-defined]
+
+        with pytest.raises(RuntimeError, match="lost its route fence"):
+            await kernel._claim_or_resume(
+                "slack:C0EXAMPLE1:1700000000.000100",
+                {},
+                workspace_deployment_id=uuid.UUID(
+                    "11111111-1111-4111-8111-111111111111"
+                ),
+                workspace_repo="acme-corp/acme-bot",
+                replace_handle=old_route,
+                lineage_branch="curie/thread-lineage-example",
+                lineage_head="a" * 40,
+                force_lineage_replacement=True,
+                agent_name="acme-bot",
+            )
+
+    asyncio.run(go())
+
+
+def test_route_cas_loss_never_steers_or_starts_the_old_lineage_runner() -> None:
+    async def go() -> None:
+        from curie_worker.kernel import Kernel
+        from curie_worker.sandbox.types import SandboxHandle
+
+        thread_key = "slack:C0EXAMPLE1:1700000000.000100"
+        old_route = SandboxHandle(
+            thread_key=thread_key,
+            claim_name="claim-old",
+            sandbox_name="sandbox-old",
+            namespace="test-ns",
+            service_fqdn="old-runner.example.test",
+            port=8080,
+            session_id="session-old",
+            token="route-token",
+            workspace_repo="acme-corp/acme-bot",
+        )
+
+        class Substrate:
+            adopt_calls = 0
+
+            def lookup(self, _thread_key: str) -> SandboxHandle:
+                return old_route
+
+            def adopt(self, _thread_key: str) -> object:
+                self.adopt_calls += 1
+                raise AssertionError("open lineage must bypass same-repo adoption")
+
+        class Workspace:
+            handoffs = 0
+
+            def select_repository(self, **_kwargs: object) -> str:
+                return "acme-corp/acme-bot"
+
+            def claim_or_resume_with_handle(self, **kwargs: object) -> object:
+                self.handoffs += 1
+                assert kwargs["replace_handle"] == old_route
+                raise RuntimeError("late workspace handoff lost its route fence")
+
+        class Runner(_LineageFenceRunner):
+            def __init__(self) -> None:
+                super().__init__(
+                    {
+                        "status": SessionStatus.AWAITING_APPROVAL.value,
+                        "turn_active": False,
+                        "history_durable": True,
+                    }
+                )
+                self.steers: list[object] = []
+                self.starts: list[object] = []
+
+            async def steer(self, *args: object, **kwargs: object) -> bool:
+                self.steers.append((args, kwargs))
+                return False
+
+            async def start_turn(self, *args: object, **kwargs: object) -> object:
+                self.starts.append((args, kwargs))
+                raise AssertionError("model start crossed a lost route fence")
+
+        substrate = Substrate()
+        workspace = Workspace()
+        runner = Runner()
+        kernel = object.__new__(Kernel)
+        kernel._substrate = substrate  # type: ignore[attr-defined]
+        kernel._workspace = workspace  # type: ignore[attr-defined]
+        kernel._runner = runner  # type: ignore[attr-defined]
+
+        with pytest.raises(RuntimeError, match="lost its route fence"):
+            await kernel._route_and_start(
+                thread_key,
+                SimpleNamespace(
+                    text="Continue https://github.com/acme-corp/acme-bot",
+                    user="U0REQUEST1",
+                ),
+                {},
+                workspace_deployment_id=uuid.UUID(
+                    "11111111-1111-4111-8111-111111111111"
+                ),
+                agent_name="acme-bot",
+                lineage_branch="curie/thread-lineage-example",
+                lineage_head="a" * 40,
+                force_lineage_replacement=True,
+                pending_publication_approval=False,
+            )
+
+        assert substrate.adopt_calls == 0
+        assert workspace.handoffs == 1
+        assert runner.steers == []
+        assert runner.starts == []
+
+    asyncio.run(go())
+
+
+@pytest.mark.parametrize(
+    ("route_head", "lineage_head", "route_outcome_revision"),
+    [
+        (None, "b" * 40, 1),
+        ("c" * 40, "b" * 40, 1),
+        ("b" * 40, "b" * 40, 0),
+        ("a" * 40, None, 0),
+    ],
+)
+def test_verified_lineage_with_mismatched_route_state_cold_reconciles(
+    route_head: str | None,
+    lineage_head: str | None,
+    route_outcome_revision: int,
+) -> None:
+    async def go() -> None:
+        from curie_worker.approvals import PublicationLineage
+        from curie_worker.kernel import Kernel
+        from curie_worker.sandbox.types import SandboxHandle
+
+        thread_key = "slack:C0EXAMPLE1:1700000000.000100"
+        deployment_id = uuid.UUID("11111111-1111-4111-8111-111111111111")
+        old_route = SandboxHandle(
+            thread_key=thread_key,
+            claim_name="claim-old",
+            sandbox_name="sandbox-old",
+            namespace="test-ns",
+            service_fqdn="old-runner.example.test",
+            port=8080,
+            session_id="session-old",
+            token="route-token",
+            workspace_repo="acme-corp/acme-bot",
+            workspace_materialized_head=route_head,
+            publication_visible_outcome_revision=route_outcome_revision,
+        )
+
+        class PublicationApi:
+            async def get_publication_lineage(
+                self, requested_deployment: uuid.UUID, conversation: str, repo: str
+            ) -> PublicationLineage:
+                assert (requested_deployment, conversation, repo) == (
+                    deployment_id,
+                    thread_key,
+                    "acme-corp/acme-bot",
+                )
+                return PublicationLineage(
+                    id=uuid.UUID("55555555-5555-4555-8555-555555555555"),
+                    deployment_id=deployment_id,
+                    conversation_id=conversation,
+                    repo_full_name=repo,
+                    base_sha="1" * 40,
+                    branch="curie/thread-lineage-example",
+                    pr_number=42 if lineage_head is not None else None,
+                    pr_url=(
+                        "https://github.com/acme-corp/acme-bot/pull/42"
+                        if lineage_head is not None
+                        else None
+                    ),
+                    head_sha=lineage_head,
+                    state="open",
+                    version=2,
+                    latest_revision=1,
+                    has_pending_revision=False,
+                    has_pending_outcome=False,
+                    visible_outcome_revision=1,
+                )
+
+        class Substrate:
+            def lookup(self, _thread_key: str) -> SandboxHandle:
+                return old_route
+
+            def adopt(self, _thread_key: str) -> object:
+                raise AssertionError("mismatched lineage head must not reuse the route")
+
+        class Workspace:
+            def select_repository(self, **_kwargs: object) -> str:
+                return "acme-corp/acme-bot"
+
+            def claim_or_resume_with_handle(self, **kwargs: object) -> object:
+                assert kwargs["replace_handle"] == old_route
+                assert kwargs["lineage_branch"] == (
+                    "curie/thread-lineage-example" if lineage_head is not None else None
+                )
+                assert kwargs["lineage_head"] == lineage_head
+                assert kwargs["lineage_base_sha"] == (
+                    "1" * 40 if lineage_head is None else None
+                )
+                assert kwargs["publication_visible_outcome_revision"] == 1
+                raise RuntimeError("captured cold lineage reconciliation")
+
+        kernel = object.__new__(Kernel)
+        kernel._substrate = Substrate()  # type: ignore[attr-defined]
+        kernel._workspace = Workspace()  # type: ignore[attr-defined]
+        kernel._publication_creator = PublicationApi()  # type: ignore[attr-defined]
+        kernel._runner = _LineageFenceRunner(  # type: ignore[attr-defined]
+            {
+                "status": SessionStatus.DONE.value,
+                "turn_active": False,
+                "history_durable": True,
+            }
+        )
+
+        with pytest.raises(RuntimeError, match="captured cold lineage reconciliation"):
+            await kernel._route_and_start(
+                thread_key,
+                SimpleNamespace(
+                    text="Continue https://github.com/acme-corp/acme-bot",
+                    user="U0REQUEST1",
+                ),
+                {},
+                workspace_deployment_id=deployment_id,
+                agent_name="acme-bot",
+            )
+
+    asyncio.run(go())
+
+
+@pytest.mark.parametrize("turn_active", [False, True])
+@pytest.mark.parametrize("lineage_head", ["b" * 40, None])
+def test_verified_lineage_at_materialized_route_head_reuses_existing_session(
+    turn_active: bool,
+    lineage_head: str | None,
+) -> None:
+    async def go() -> None:
+        from curie_worker.approvals import PublicationLineage
+        from curie_worker.kernel import Kernel
+        from curie_worker.sandbox.types import SandboxHandle
+
+        thread_key = "slack:C0EXAMPLE1:1700000000.000100"
+        deployment_id = uuid.UUID("11111111-1111-4111-8111-111111111111")
+        route = SandboxHandle(
+            thread_key=thread_key,
+            claim_name="claim-lineage",
+            sandbox_name="sandbox-lineage",
+            namespace="test-ns",
+            service_fqdn="lineage-runner.example.test",
+            port=8080,
+            session_id="session-lineage",
+            token="route-token",
+            workspace_repo="acme-corp/acme-bot",
+            workspace_materialized_head=lineage_head or "1" * 40,
+            publication_visible_outcome_revision=1,
+        )
+
+        class PublicationApi:
+            async def get_publication_lineage(
+                self, requested_deployment: uuid.UUID, conversation: str, repo: str
+            ) -> PublicationLineage:
+                return PublicationLineage(
+                    id=uuid.UUID("55555555-5555-4555-8555-555555555555"),
+                    deployment_id=requested_deployment,
+                    conversation_id=conversation,
+                    repo_full_name=repo,
+                    base_sha="1" * 40,
+                    branch="curie/thread-lineage-example",
+                    pr_number=42 if lineage_head is not None else None,
+                    pr_url=(
+                        "https://github.com/acme-corp/acme-bot/pull/42"
+                        if lineage_head is not None
+                        else None
+                    ),
+                    head_sha=lineage_head,
+                    state="open",
+                    version=2,
+                    latest_revision=1,
+                    has_pending_revision=False,
+                    has_pending_outcome=False,
+                    visible_outcome_revision=1,
+                )
+
+        class Substrate:
+            adopt_calls = 0
+
+            def lookup(self, _thread_key: str) -> SandboxHandle:
+                return route
+
+            def adopt(self, _thread_key: str) -> SandboxHandle:
+                self.adopt_calls += 1
+                return route
+
+        class Workspace:
+            touches: list[tuple[str, int]] = []
+
+            def select_repository(self, **_kwargs: object) -> str:
+                return "acme-corp/acme-bot"
+
+            def touch(self, requested_thread: str, *, ttl_seconds: int) -> bool:
+                self.touches.append((requested_thread, ttl_seconds))
+                return True
+
+            def claim_or_resume_with_handle(self, **_kwargs: object) -> object:
+                raise AssertionError("matching lineage head must reuse the live route")
+
+        class Runner:
+            status_reads = 0
+            steers = 0
+            starts = 0
+
+            async def status(self, *_args: object, **_kwargs: object) -> dict[str, object]:
+                self.status_reads += 1
+                return {"turn_active": turn_active}
+
+            async def steer(self, *_args: object, **_kwargs: object) -> bool:
+                self.steers += 1
+                return turn_active
+
+            async def start_turn(self, *_args: object, **_kwargs: object) -> object:
+                self.starts += 1
+                return SimpleNamespace()
+
+        substrate = Substrate()
+        workspace = Workspace()
+        runner = Runner()
+        kernel = object.__new__(Kernel)
+        kernel._substrate = substrate  # type: ignore[attr-defined]
+        kernel._workspace = workspace  # type: ignore[attr-defined]
+        kernel._publication_creator = PublicationApi()  # type: ignore[attr-defined]
+        kernel._runner = runner  # type: ignore[attr-defined]
+        kernel._route_ttl_seconds = 60  # type: ignore[attr-defined]
+
+        result = await kernel._route_and_start(
+            thread_key,
+            SimpleNamespace(
+                text="Continue https://github.com/acme-corp/acme-bot",
+                user="U0REQUEST1",
+            ),
+            {},
+            workspace_deployment_id=deployment_id,
+            agent_name="acme-bot",
+        )
+
+        assert substrate.adopt_calls == 1
+        assert workspace.touches == [(thread_key, 60)]
+        assert runner.steers == 1
+        assert result.steered is turn_active
+        assert runner.starts == (0 if turn_active else 1)
+
+    asyncio.run(go())
+
+
+def test_headless_visible_outcome_cold_reconciles_once_then_live_followup_steers() -> None:
+    async def go() -> None:
+        from curie_worker.approvals import PublicationLineage
+        from curie_worker.kernel import Kernel
+        from curie_worker.sandbox.types import SandboxHandle
+
+        thread_key = "slack:C0EXAMPLE1:1700000000.000100"
+        deployment_id = uuid.UUID("11111111-1111-4111-8111-111111111111")
+        base_sha = "1" * 40
+        dirty_route = SandboxHandle(
+            thread_key=thread_key,
+            claim_name="claim-dirty",
+            sandbox_name="sandbox-dirty",
+            namespace="test-ns",
+            service_fqdn="dirty-runner.example.test",
+            port=8080,
+            session_id="session-lineage",
+            token="route-token",
+            workspace_repo="acme-corp/acme-bot",
+            workspace_materialized_head="d" * 40,
+        )
+        reconciled_route = SandboxHandle(
+            thread_key=thread_key,
+            claim_name="claim-reconciled",
+            sandbox_name="sandbox-reconciled",
+            namespace="test-ns",
+            service_fqdn="reconciled-runner.example.test",
+            port=8080,
+            session_id="session-lineage",
+            token="route-token",
+            workspace_repo="acme-corp/acme-bot",
+            workspace_materialized_head=base_sha,
+            publication_visible_outcome_revision=1,
+            generation=1,
+        )
+
+        class PublicationApi:
+            async def get_publication_lineage(
+                self, requested_deployment: uuid.UUID, conversation: str, repo: str
+            ) -> PublicationLineage:
+                return PublicationLineage(
+                    id=uuid.UUID("55555555-5555-4555-8555-555555555555"),
+                    deployment_id=requested_deployment,
+                    conversation_id=conversation,
+                    repo_full_name=repo,
+                    base_sha=base_sha,
+                    branch="curie/thread-lineage-example",
+                    pr_number=None,
+                    pr_url=None,
+                    head_sha=None,
+                    state="open",
+                    version=1,
+                    latest_revision=1,
+                    has_pending_revision=False,
+                    has_pending_outcome=False,
+                    visible_outcome_revision=1,
+                )
+
+        class Substrate:
+            current = dirty_route
+            adopts = 0
+
+            def lookup(self, _thread_key: str) -> SandboxHandle:
+                return self.current
+
+            def adopt(self, _thread_key: str) -> SandboxHandle:
+                self.adopts += 1
+                return self.current
+
+        class Workspace:
+            replacements = 0
+            touches = 0
+
+            def select_repository(self, **_kwargs: object) -> str:
+                return "acme-corp/acme-bot"
+
+            def claim_or_resume_with_handle(self, **kwargs: object) -> object:
+                self.replacements += 1
+                assert kwargs["replace_handle"] == dirty_route
+                assert kwargs["lineage_branch"] is None
+                assert kwargs["lineage_head"] is None
+                assert kwargs["lineage_base_sha"] == base_sha
+                substrate.current = reconciled_route
+                return SimpleNamespace(handle=reconciled_route)
+
+            def touch(self, _thread_key: str, *, ttl_seconds: int) -> bool:
+                assert ttl_seconds == 60
+                self.touches += 1
+                return True
+
+        class Runner:
+            live = False
+            starts = 0
+            steers = 0
+
+            async def status(
+                self, handle_url: str, **_kwargs: object
+            ) -> dict[str, object]:
+                if handle_url == dirty_route.base_url:
+                    return {
+                        "status": SessionStatus.DONE.value,
+                        "turn_active": False,
+                        "history_durable": True,
+                    }
+                return {"turn_active": self.live}
+
+            async def steer(self, *_args: object, **_kwargs: object) -> bool:
+                self.steers += 1
+                return self.live
+
+            async def start_turn(self, *_args: object, **_kwargs: object) -> object:
+                self.starts += 1
+                return SimpleNamespace()
+
+        substrate = Substrate()
+        workspace = Workspace()
+        runner = Runner()
+        kernel = object.__new__(Kernel)
+        kernel._substrate = substrate  # type: ignore[attr-defined]
+        kernel._workspace = workspace  # type: ignore[attr-defined]
+        kernel._publication_creator = PublicationApi()  # type: ignore[attr-defined]
+        kernel._runner = runner  # type: ignore[attr-defined]
+        kernel._route_ttl_seconds = 60  # type: ignore[attr-defined]
+        event = SimpleNamespace(
+            text="Continue https://github.com/acme-corp/acme-bot",
+            user="U0REQUEST1",
+        )
+
+        first = await kernel._route_and_start(
+            thread_key,
+            event,
+            {},
+            workspace_deployment_id=deployment_id,
+            agent_name="acme-bot",
+        )
+        runner.live = True
+        second = await kernel._route_and_start(
+            thread_key,
+            event,
+            {},
+            workspace_deployment_id=deployment_id,
+            agent_name="acme-bot",
+        )
+
+        assert first.steered is False
+        assert second.steered is True
+        assert workspace.replacements == 1
+        assert workspace.touches == 1
+        assert substrate.adopts == 1
+        assert runner.starts == 1
+        assert runner.steers == 2
+
+    asyncio.run(go())
+
+
+@pytest.mark.parametrize(
+    ("has_pending_revision", "has_pending_outcome", "lineage_head"),
+    [(True, False, "b" * 40), (False, True, None)],
+)
+def test_api_pending_publication_work_is_fenced_before_lineage_handoff_probe(
+    has_pending_revision: bool,
+    has_pending_outcome: bool,
+    lineage_head: str | None,
+) -> None:
+    async def go() -> None:
+        from curie_worker.approvals import PublicationLineage
+        from curie_worker.kernel import Kernel, ThreadBusyError
+        from curie_worker.sandbox.types import SandboxHandle
+
+        thread_key = "slack:C0EXAMPLE1:1700000000.000100"
+        deployment_id = uuid.UUID("11111111-1111-4111-8111-111111111111")
+        old_route = SandboxHandle(
+            thread_key=thread_key,
+            claim_name="claim-old",
+            sandbox_name="sandbox-old",
+            namespace="test-ns",
+            service_fqdn="old-runner.example.test",
+            port=8080,
+            session_id="session-old",
+            token="route-token",
+            workspace_repo="acme-corp/acme-private",
+        )
+
+        class PublicationApi:
+            reads: list[tuple[uuid.UUID, str, str]] = []
+
+            async def get_publication_lineage(
+                self, requested_deployment: uuid.UUID, conversation: str, repo: str
+            ) -> PublicationLineage:
+                self.reads.append((requested_deployment, conversation, repo))
+                return PublicationLineage(
+                    id=uuid.UUID("55555555-5555-4555-8555-555555555555"),
+                    deployment_id=deployment_id,
+                    conversation_id=conversation,
+                    repo_full_name=repo,
+                    base_sha="a" * 40,
+                    branch="curie/thread-lineage-example",
+                    pr_number=123 if lineage_head is not None else None,
+                    pr_url=(
+                        "https://github.com/acme-corp/acme-private/pull/123"
+                        if lineage_head is not None
+                        else None
+                    ),
+                    head_sha=lineage_head,
+                    state="open",
+                    version=3,
+                    latest_revision=2,
+                    has_pending_revision=has_pending_revision,
+                    has_pending_outcome=has_pending_outcome,
+                    visible_outcome_revision=0,
+                )
+
+        class Workspace:
+            handoffs = 0
+
+            def select_repository(self, **_kwargs: object) -> str:
+                return "acme-corp/acme-private"
+
+            def claim_or_resume_with_handle(self, **_kwargs: object) -> object:
+                self.handoffs += 1
+                raise AssertionError("pending revision crossed the lineage fence")
+
+        class Substrate:
+            def lookup(self, _thread_key: str) -> SandboxHandle:
+                return old_route
+
+        publication_api = PublicationApi()
+        workspace = Workspace()
+        runner = _LineageFenceRunner(
+            {
+                "status": SessionStatus.AWAITING_APPROVAL.value,
+                "turn_active": False,
+                "history_durable": True,
+            }
+        )
+        kernel = object.__new__(Kernel)
+        kernel._workspace = workspace  # type: ignore[attr-defined]
+        kernel._substrate = Substrate()  # type: ignore[attr-defined]
+        kernel._runner = runner  # type: ignore[attr-defined]
+        kernel._publication_creator = publication_api  # type: ignore[attr-defined]
+
+        with pytest.raises(ThreadBusyError, match="pending publication revision"):
+            await kernel._route_and_start(
+                thread_key,
+                SimpleNamespace(
+                    text="Continue https://github.com/acme-corp/acme-private",
+                    user="U0REQUEST1",
+                    ts="1700000000.000100",
+                ),
+                {"CURIE_RUNNER_TOKEN": "runner-token"},
+                workspace_deployment_id=deployment_id,
+                agent_name="acme-bot",
+            )
+
+        assert publication_api.reads == [
+            (
+                deployment_id,
+                "slack:C0EXAMPLE1:1700000000.000100",
+                "acme-corp/acme-private",
+            )
+        ]
+        assert workspace.handoffs == 0
+        assert runner.reads == 0
+
+    asyncio.run(go())
+
+
+def test_pending_first_revision_is_a_terminal_reply_before_dirty_route_adoption(
+    make_harness,
+) -> None:
+    """A headless first revision fences the failed-suspend runner immediately."""
+
+    from curie_worker.approvals import PublicationLineage
+    from curie_worker.sandbox.types import SandboxHandle
+
+    deployment_id = uuid.UUID("11111111-1111-4111-8111-111111111111")
+    thread = "1700000000.000100"
+    thread_key = f"slack:C1:{thread}"
+    old_route = SandboxHandle(
+        thread_key=thread_key,
+        claim_name="claim-old",
+        sandbox_name="sandbox-old",
+        namespace="test-ns",
+        service_fqdn="old-runner.example.test",
+        port=8080,
+        session_id="session-old",
+        token="route-token",
+        workspace_repo="acme-corp/acme-private",
+    )
+
+    class Binding(GrantBinding):
+        async def resolve(self, kind: str, channel: str):  # noqa: ANN201
+            from curie_worker.binding import ResolvedDeployment
+
+            return ResolvedDeployment(
+                agent_id=self.agent_id,
+                agent_name="acme-bot",
+                deployment_id=deployment_id,
+                workspace_enabled=True,
+                version_id=uuid.uuid4(),
+                version_label="v1",
+                bundle_ref=None,
+                max_usd_per_day=None,
+                max_output_tokens_per_run=None,
+            )
+
+    class PublicationApi:
+        reads: list[tuple[uuid.UUID, str, str]] = []
+
+        async def get_publication_lineage(
+            self, requested_deployment: uuid.UUID, conversation: str, repo: str
+        ) -> PublicationLineage:
+            self.reads.append((requested_deployment, conversation, repo))
+            return PublicationLineage(
+                id=uuid.UUID("55555555-5555-4555-8555-555555555555"),
+                deployment_id=deployment_id,
+                conversation_id=conversation,
+                repo_full_name=repo,
+                base_sha="a" * 40,
+                branch="curie/thread-lineage-example",
+                pr_number=None,
+                pr_url=None,
+                head_sha=None,
+                state="open",
+                version=1,
+                latest_revision=1,
+                has_pending_revision=True,
+                has_pending_outcome=False,
+                visible_outcome_revision=0,
+            )
+
+    class Workspace:
+        def select_repository(self, **_kwargs: object) -> str:
+            return "acme-corp/acme-private"
+
+        def claim_or_resume_with_handle(self, **_kwargs: object) -> object:
+            raise AssertionError("pending first revision reached workspace preparation")
+
+    class Substrate:
+        lookup_calls = 0
+        adopt_calls = 0
+
+        def lookup(self, _thread_key: str) -> SandboxHandle:
+            self.lookup_calls += 1
+            return old_route
+
+        def adopt(self, _thread_key: str) -> object:
+            self.adopt_calls += 1
+            raise AssertionError("pending first revision adopted the dirty live route")
+
+    async def go() -> None:
+        publication_api = PublicationApi()
+        substrate = Substrate()
+        binding = Binding(grant_event_id="unused", grant_tool="unused")
+        async with make_harness(
+            binding=binding, publication_creator=publication_api
+        ) as h:
+            h.runner.session_status = SessionStatus.AWAITING_APPROVAL.value
+            h.kernel._workspace = Workspace()  # type: ignore[assignment]
+            h.kernel._substrate = substrate  # type: ignore[assignment]
+
+            await h.kernel.process_event(
+                _qevent(
+                    "Continue https://github.com/acme-corp/acme-private",
+                    thread=thread,
+                )
+            )
+
+            assert publication_api.reads == [
+                (deployment_id, thread_key, "acme-corp/acme-private")
+            ]
+            assert substrate.lookup_calls == 0
+            assert substrate.adopt_calls == 0
+            assert h.runner.opened == []
+            assert h.sink.last_text == (
+                "This thread already has a publication awaiting approval or completion. "
+                "Resolve it before continuing."
+            )
+            assert len(h.sink.completions) == 1
+
+    asyncio.run(go())
+
+
+def test_api_stale_head_conflict_stops_before_workspace_or_model_for_private_repo() -> None:
+    async def go() -> None:
+        from curie_worker.kernel import Kernel
+
+        deployment_id = uuid.UUID("11111111-1111-4111-8111-111111111111")
+
+        class PublicationApi:
+            async def get_publication_lineage(self, *_args: object) -> object:
+                raise ApprovalBackendError(
+                    "publication lineage remote head conflicts with the stored head"
+                )
+
+        class Workspace:
+            def select_repository(self, **_kwargs: object) -> str:
+                return "acme-corp/acme-private"
+
+            def claim_or_resume_with_handle(self, **_kwargs: object) -> object:
+                raise AssertionError("stale API truth reached workspace preparation")
+
+        class Substrate:
+            def lookup(self, _thread_key: str) -> object:
+                raise AssertionError("stale API truth reached sandbox routing")
+
+        kernel = object.__new__(Kernel)
+        kernel._workspace = Workspace()  # type: ignore[attr-defined]
+        kernel._substrate = Substrate()  # type: ignore[attr-defined]
+        kernel._runner = _LineageFenceRunner({})  # type: ignore[attr-defined]
+        kernel._publication_creator = PublicationApi()  # type: ignore[attr-defined]
+
+        with pytest.raises(ApprovalBackendError, match="remote head conflicts"):
+            await kernel._route_and_start(
+                "slack:C0EXAMPLE1:1700000000.000100",
+                SimpleNamespace(
+                    text="Continue https://github.com/acme-corp/acme-private",
+                    user="U0REQUEST1",
+                    ts="1700000000.000100",
+                ),
+                {},
+                workspace_deployment_id=deployment_id,
+                agent_name="acme-bot",
+            )
+
+    asyncio.run(go())
+
+
+@pytest.mark.parametrize(
+    ("response_status", "detail", "message"),
+    [
+        (
+            409,
+            {
+                "code": "publication.lineage_stale",
+                "message": "GitHub pull request head differs from the stored lineage; "
+                "restore the expected head or start a new thread.",
+            },
+            "GitHub pull request head differs from the stored lineage; restore the "
+            "expected head or start a new thread.",
+        ),
+        (
+            409,
+            {
+                "code": "publication.lineage_terminal",
+                "message": "The pull request for this thread is merged or closed; "
+                "start a new thread.",
+            },
+            "The pull request for this thread is merged or closed; start a new thread.",
+        ),
+        (
+            503,
+            {
+                "code": "publication.github_unavailable",
+                "message": "GitHub could not verify this thread's pull request. "
+                "Try again later; no model turn or publication was started.",
+            },
+            "GitHub could not verify this thread's pull request. Try again later; "
+            "no model turn or publication was started.",
+        ),
+        (
+            409,
+            "conversation has no selected repository workspace",
+            "conversation has no selected repository workspace",
+        ),
+        (
+            409,
+            "publication repository differs from the thread workspace",
+            "publication repository differs from the thread workspace",
+        ),
+        (
+            409,
+            "thread workspace repository is no longer allowed",
+            "thread workspace repository is no longer allowed",
+        ),
+    ],
+)
+def test_lineage_api_refusal_is_a_user_visible_terminal_process_event(
+    make_harness,
+    response_status: int,
+    detail: object,
+    message: str,
+) -> None:
+    """A safe API refusal answers the requester instead of retrying to dead-letter."""
+
+    deployment_id = uuid.UUID("11111111-1111-4111-8111-111111111111")
+
+    class Binding(GrantBinding):
+        async def resolve(self, kind: str, channel: str):  # noqa: ANN201
+            from curie_worker.binding import ResolvedDeployment
+
+            return ResolvedDeployment(
+                agent_id=self.agent_id,
+                agent_name="acme-bot",
+                deployment_id=deployment_id,
+                workspace_enabled=True,
+                version_id=uuid.uuid4(),
+                version_label="v1",
+                bundle_ref=None,
+                max_usd_per_day=None,
+                max_output_tokens_per_run=None,
+            )
+
+    async def go() -> None:
+        thread = "1700000000.000100"
+        thread_key = f"slack:C1:{thread}"
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == "/v1/internal/publications/lineage"
+            assert request.url.params["conversation_id"] == thread_key
+            return httpx.Response(response_status, json={"detail": detail})
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            publication_api = ApprovalClient(
+                api_base_url="https://api.example.com",
+                api_key="",
+                worker_token="worker-token",
+                client=client,
+                read_timeout_s=1,
+            )
+            binding = Binding(grant_event_id="unused", grant_tool="unused")
+            async with make_harness(
+                binding=binding, publication_creator=publication_api
+            ) as h:
+                class Substrate:
+                    lookup_calls = 0
+                    adopt_calls = 0
+
+                    def lookup(self, _thread_key: str) -> object:
+                        self.lookup_calls += 1
+                        raise AssertionError("lineage refusal reached route lookup")
+
+                    def adopt(self, _thread_key: str) -> object:
+                        self.adopt_calls += 1
+                        raise AssertionError("lineage refusal reached route adoption")
+
+                class Workspace:
+                    def select_repository(self, **kwargs: object) -> str:
+                        assert kwargs["thread_key"] == thread_key
+                        return "acme-corp/acme-private"
+
+                    def claim_or_resume_with_handle(self, **_kwargs: object) -> object:
+                        raise AssertionError("lineage refusal reached workspace preparation")
+
+                substrate = Substrate()
+                h.kernel._workspace = Workspace()  # type: ignore[assignment]
+                h.kernel._substrate = substrate  # type: ignore[assignment]
+                await h.kernel.process_event(
+                    _qevent(
+                        "Continue https://github.com/acme-corp/acme-private",
+                        thread=thread,
+                    )
+                )
+
+                assert h.runner.opened == []
+                assert h.fake_k8s.claim_envs == []
+                assert substrate.lookup_calls == 0
+                assert substrate.adopt_calls == 0
+                assert h.sink.last_text == message
+                assert h.sink.completions[0].target.conversation_id == thread
+
+    asyncio.run(go())
+
+
+def test_slack_publication_ownership_uses_scoped_key_but_replies_use_bare_thread(
+    make_harness,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Lineage ownership is canonical; the adapter thread id remains Slack-shaped."""
+
+    from curie_worker.approvals import CreatedPublication
+    from curie_worker.runner_client import RunnerWorkspaceSnapshot
+
+    deployment_id = uuid.UUID("11111111-1111-4111-8111-111111111111")
+    thread = "1700000000.000100"
+    thread_key = f"slack:C0EXAMPLE1:{thread}"
+
+    class Binding(GrantBinding):
+        async def resolve(self, kind: str, channel: str):  # noqa: ANN201
+            from curie_worker.binding import ResolvedDeployment
+
+            return ResolvedDeployment(
+                agent_id=self.agent_id,
+                agent_name="acme-bot",
+                deployment_id=deployment_id,
+                workspace_enabled=True,
+                version_id=uuid.uuid4(),
+                version_label="v1",
+                bundle_ref=None,
+                max_usd_per_day=None,
+                max_output_tokens_per_run=None,
+            )
+
+    class PublicationApi:
+        reads: list[tuple[uuid.UUID, str, str]] = []
+        creates: list[PublicationCreateRequest] = []
+
+        async def get_publication_lineage(
+            self, requested_deployment: uuid.UUID, conversation: str, repo: str
+        ) -> None:
+            self.reads.append((requested_deployment, conversation, repo))
+            return None
+
+        async def create_publication(
+            self, request: PublicationCreateRequest
+        ) -> CreatedPublication:
+            self.creates.append(request)
+            return CreatedPublication(
+                id="publication-example",
+                approval_id="approval-example",
+                status="pending",
+            )
+
+    class Workspace:
+        def __init__(self) -> None:
+            self.substrate = None
+            self.selected: list[str] = []
+            self.released: list[str] = []
+
+        def select_repository(self, **kwargs: object) -> str:
+            self.selected.append(str(kwargs["thread_key"]))
+            return "acme-corp/acme-private"
+
+        def claim_or_resume_with_handle(self, **kwargs: object) -> object:
+            assert self.substrate is not None
+            return SimpleNamespace(
+                handle=self.substrate.claim(
+                    str(kwargs["thread_key"]),
+                    env=kwargs["env"],
+                    agent_name=kwargs["agent_name"],
+                    workspace_repo=kwargs["repo_full_name"],
+                )
+            )
+
+        def release(self, thread_identity: str) -> None:
+            self.released.append(thread_identity)
+
+        def touch(self, _thread_identity: str, *, ttl_seconds: int) -> None:
+            del ttl_seconds
+
+    async def go() -> None:
+        publication_api = PublicationApi()
+        workspace = Workspace()
+        binding = Binding(grant_event_id="unused", grant_tool="unused")
+        async with make_harness(
+            binding=binding, publication_creator=publication_api
+        ) as h:
+            workspace.substrate = h.substrate
+            h.kernel._workspace = workspace  # type: ignore[assignment]
+            h.runner.default_script = [
+                Final(
+                    text="Ready to publish",
+                    status=AWAITING,
+                    approval_summary="Publish the prepared changes",
+                    approval_gate_kind="permission",
+                    approval_granted_tool="mcp__curie__publish_changes",
+                )
+            ]
+
+            async def snapshot(*_args: object, **_kwargs: object) -> RunnerWorkspaceSnapshot:
+                return RunnerWorkspaceSnapshot(
+                    repo_full_name="acme-corp/acme-private",
+                    base_sha="a" * 40,
+                    patch=b"diff --git a/README.md b/README.md\n",
+                    changed_paths=("README.md",),
+                    contains_workflow_files=False,
+                    publication_title="Update README",
+                    publication_body="Prepared by acme-bot.",
+                )
+
+            monkeypatch.setattr(h.kernel._runner, "snapshot", snapshot)
+            monkeypatch.setattr(
+                "curie_worker.kernel.validate_snapshot_against_base",
+                lambda *_args, **_kwargs: None,
+            )
+            await h.kernel.process_event(
+                _qevent(
+                    "Publish https://github.com/acme-corp/acme-private",
+                    thread=thread,
+                    channel="C0EXAMPLE1",
+                )
+            )
+
+            assert workspace.selected == [thread_key]
+            assert publication_api.reads == [
+                (deployment_id, thread_key, "acme-corp/acme-private")
+            ]
+            assert [request.conversation_id for request in publication_api.creates] == [
+                thread_key
+            ]
+            assert [request.reply_conversation_id for request in publication_api.creates] == [
+                thread
+            ]
+            assert workspace.released == [thread_key]
+            assert h.sink.completions[0].target.conversation_id == thread
+
+    asyncio.run(go())
+
+
+def test_private_lineage_head_reaches_handoff_without_a_publication_credential() -> None:
+    async def go() -> None:
+        from curie_worker.approvals import PublicationLineage
+        from curie_worker.kernel import Kernel
+        from curie_worker.sandbox.types import SandboxHandle
+
+        thread_key = "slack:C0EXAMPLE1:1700000000.000100"
+        deployment_id = uuid.UUID("11111111-1111-4111-8111-111111111111")
+        old_route = SandboxHandle(
+            thread_key=thread_key,
+            claim_name="claim-old",
+            sandbox_name="sandbox-old",
+            namespace="test-ns",
+            service_fqdn="old-runner.example.test",
+            port=8080,
+            session_id="session-old",
+            token="route-token",
+            workspace_repo="acme-corp/acme-private",
+        )
+
+        class PublicationApi:
+            async def get_publication_lineage(
+                self, _deployment: uuid.UUID, conversation: str, repo: str
+            ) -> PublicationLineage:
+                return PublicationLineage(
+                    id=uuid.UUID("55555555-5555-4555-8555-555555555555"),
+                    deployment_id=deployment_id,
+                    conversation_id=conversation,
+                    repo_full_name=repo,
+                    base_sha="a" * 40,
+                    branch="curie/thread-lineage-example",
+                    pr_number=123,
+                    pr_url="https://github.com/acme-corp/acme-private/pull/123",
+                    head_sha="b" * 40,
+                    state="open",
+                    version=3,
+                    latest_revision=2,
+                    has_pending_revision=False,
+                    has_pending_outcome=False,
+                    visible_outcome_revision=2,
+                )
+
+        class Workspace:
+            claim: dict[str, object] | None = None
+
+            def select_repository(self, **_kwargs: object) -> str:
+                return "acme-corp/acme-private"
+
+            def claim_or_resume_with_handle(self, **kwargs: object) -> object:
+                self.claim = dict(kwargs)
+                raise RuntimeError("captured safe lineage handoff")
+
+        class Substrate:
+            def lookup(self, _thread_key: str) -> SandboxHandle:
+                return old_route
+
+            def adopt(self, _thread_key: str) -> object:
+                raise AssertionError("open lineage reused the dirty same-repo route")
+
+        workspace = Workspace()
+        kernel = object.__new__(Kernel)
+        kernel._workspace = workspace  # type: ignore[attr-defined]
+        kernel._substrate = Substrate()  # type: ignore[attr-defined]
+        kernel._runner = _LineageFenceRunner(  # type: ignore[attr-defined]
+            {
+                "status": SessionStatus.AWAITING_APPROVAL.value,
+                "turn_active": False,
+                "history_durable": True,
+            }
+        )
+        kernel._publication_creator = PublicationApi()  # type: ignore[attr-defined]
+
+        with pytest.raises(RuntimeError, match="captured safe lineage handoff"):
+            await kernel._route_and_start(
+                thread_key,
+                SimpleNamespace(
+                    text="Continue https://github.com/acme-corp/acme-private",
+                    user="U0REQUEST1",
+                    ts="1700000000.000100",
+                ),
+                {"CURIE_RUNNER_TOKEN": "runner-token"},
+                workspace_deployment_id=deployment_id,
+                agent_name="acme-bot",
+            )
+
+        assert workspace.claim is not None
+        assert workspace.claim["lineage_branch"] == "curie/thread-lineage-example"
+        assert workspace.claim["lineage_head"] == "b" * 40
+        assert workspace.claim["replace_handle"] == old_route
+        serialized = json.dumps(workspace.claim, default=str).casefold()
+        assert "authorization" not in serialized
+        assert "publication-write" not in serialized
+        assert "github_pat" not in serialized
+
+    asyncio.run(go())
+
+
 # The settled record a resolved approval reads back as: the one verdict the
 # card-stamping tests below all pin their assertions to.
 _APPROVED = SettledApproval(
@@ -254,6 +1537,157 @@ def test_worker_approval_http_requests_carry_the_active_turn_parent() -> None:
             request.headers.get("traceparent") == _HTTP_TRACEPARENT
             for request in requests
         )
+
+    asyncio.run(go())
+
+
+def test_private_lineage_truth_is_read_from_api_without_publication_credentials() -> None:
+    """Routing gets refreshed PR truth from the trusted API, never GitHub directly."""
+
+    async def go() -> None:
+        seen: list[httpx.Request] = []
+        deployment_id = uuid.UUID("11111111-1111-4111-8111-111111111111")
+
+        def handle(request: httpx.Request) -> httpx.Response:
+            seen.append(request)
+            assert request.url.path == "/v1/internal/publications/lineage"
+            return httpx.Response(
+                200,
+                json={
+                    "id": "55555555-5555-4555-8555-555555555555",
+                    "deployment_id": str(deployment_id),
+                    "conversation_id": "1700000000.000100",
+                    "repo_full_name": "acme-corp/acme-private",
+                    "base_sha": "a" * 40,
+                    "branch": "curie/thread-lineage-example",
+                    "pr_number": 123,
+                    "pr_url": "https://github.com/acme-corp/acme-private/pull/123",
+                    "head_sha": "b" * 40,
+                    "state": "open",
+                    "version": 3,
+                    "latest_revision": 2,
+                    "has_pending_revision": True,
+                    "has_pending_outcome": True,
+                    "visible_outcome_revision": 1,
+                },
+            )
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handle)) as http:
+            client = ApprovalClient(
+                api_base_url="https://api.example.test",
+                api_key="platform-test-key",
+                client=http,
+                read_timeout_s=1.0,
+                worker_token="worker-test-token",
+            )
+            lineage = await client.get_publication_lineage(
+                deployment_id,
+                "1700000000.000100",
+                "acme-corp/acme-private",
+            )
+
+        assert lineage is not None
+        assert lineage.state == "open"
+        assert lineage.head_sha == "b" * 40
+        assert lineage.has_pending_revision is True
+        assert lineage.has_pending_outcome is True
+        assert lineage.visible_outcome_revision == 1
+        assert not hasattr(lineage, "authorization_header")
+        assert len(seen) == 1
+        request = seen[0]
+        assert request.headers["X-Curie-Worker-Token"] == "worker-test-token"
+        assert "Authorization" not in request.headers
+        assert "credential" not in request.url.query.decode().casefold()
+
+    asyncio.run(go())
+
+
+@pytest.mark.parametrize(
+    "code",
+    ["publication.lineage_stale", "publication.lineage_terminal"],
+)
+def test_private_lineage_conflict_is_translated_to_a_user_actionable_refusal(
+    code: str,
+) -> None:
+    async def go() -> None:
+        from curie_worker.workspace import WorkspaceSelectionRefused
+
+        message = "Restore the expected head or start a new thread."
+
+        def handle(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                409,
+                json={"detail": {"code": code, "message": message}},
+            )
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handle)) as http:
+            client = ApprovalClient(
+                api_base_url="https://api.example.test",
+                api_key="",
+                client=http,
+                read_timeout_s=1.0,
+                worker_token="worker-test-token",
+            )
+            with pytest.raises(WorkspaceSelectionRefused) as excinfo:
+                await client.get_publication_lineage(
+                    uuid.UUID("11111111-1111-4111-8111-111111111111"),
+                    "1700000000.000100",
+                    "acme-corp/acme-private",
+                )
+
+        assert excinfo.value.public_detail == message
+
+    asyncio.run(go())
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "conversation has no selected repository workspace",
+        "publication repository differs from the thread workspace",
+        "thread workspace repository is no longer allowed",
+    ],
+)
+def test_publication_create_workspace_409_is_a_terminal_refusal(message: str) -> None:
+    """Workspace authorization failures must not retry an already-run model turn."""
+
+    async def go() -> None:
+        from curie_worker.workspace import WorkspaceSelectionRefused
+
+        def handle(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(409, json={"detail": message})
+
+        request = PublicationCreateRequest(
+            deployment_id=uuid.UUID("11111111-1111-4111-8111-111111111111"),
+            conversation_id="slack:C0EXAMPLE1:1700000000.000100",
+            repo_full_name="acme-corp/acme-private",
+            author="U0REQUEST1",
+            summary="Publish the bounded change",
+            reply_kind="slack",
+            reply_channel="C0EXAMPLE1",
+            reply_placeholder="1700000000.000001",
+            reply_endpoint=None,
+            reply_adapter=None,
+            dedupe_key="publication-example",
+            base_sha="a" * 40,
+            patch=b"diff --git a/README.md b/README.md\n",
+            changed_paths=("README.md",),
+            expires_in_seconds=600,
+            title="Update README",
+            body="Approved platform publication.",
+        )
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handle)) as http:
+            client = ApprovalClient(
+                api_base_url="https://api.example.test",
+                api_key="",
+                client=http,
+                read_timeout_s=1.0,
+                worker_token="worker-test-token",
+            )
+            with pytest.raises(WorkspaceSelectionRefused) as excinfo:
+                await client.create_publication(request)
+
+        assert excinfo.value.public_detail == message
 
     asyncio.run(go())
 

--- a/apps/worker/tests/sandbox/test_substrate.py
+++ b/apps/worker/tests/sandbox/test_substrate.py
@@ -108,6 +108,8 @@ def test_handoff_cold_claims_then_atomically_replaces_and_retires_old_route(
             "CURIE_WORKSPACE_SHA256": "a" * 64,
         },
         workspace_repo="acme-corp/acme-bot",
+        workspace_materialized_head="a" * 40,
+        publication_visible_outcome_revision=1,
     )
 
     # The route is the continuity record used to construct a later replacement.
@@ -116,6 +118,8 @@ def test_handoff_cold_claims_then_atomically_replaces_and_retires_old_route(
     assert claimed.session_id == "logical-session"
     assert claimed.history_ref == history_ref
     assert claimed.workspace_repo == "acme-corp/acme-bot"
+    assert claimed.workspace_materialized_head == "a" * 40
+    assert claimed.publication_visible_outcome_revision == 1
     claim_env = fake_k8s.claims[claimed.claim_name].env
     assert claim_env[SESSION_ENV] == "logical-session"
     assert claim_env[HISTORY_ENV] == history_ref
@@ -132,12 +136,16 @@ def test_handoff_cold_claims_then_atomically_replaces_and_retires_old_route(
             "CURIE_WORKSPACE_SHA256": "b" * 64,
         },
         workspace_repo="acme-corp/acme-bot",
+        workspace_materialized_head="b" * 40,
+        publication_visible_outcome_revision=2,
     )
 
     assert replacement.claim_name != claimed.claim_name
     assert replacement.session_id == claimed.session_id == "logical-session"
     assert replacement.history_ref == claimed.history_ref == history_ref
     assert replacement.workspace_repo == "acme-corp/acme-bot"
+    assert replacement.workspace_materialized_head == "b" * 40
+    assert replacement.publication_visible_outcome_revision == 2
     assert replacement.generation == 1
     assert affinity.get("T1") == RouteRecord(handle=replacement)
     candidate_env = fake_k8s.claims[replacement.claim_name].env
@@ -497,7 +505,12 @@ def test_lost_race_adopts_winner_and_retires_loser(
 def test_suspend_resume_rehydrates_from_history(
     substrate: SandboxSubstrate, fake_k8s: FakeSandboxClient, affinity: AffinityStore
 ) -> None:
-    first = substrate.claim("T1")
+    first = substrate.claim(
+        "T1",
+        workspace_repo="acme-corp/acme-bot",
+        workspace_materialized_head="a" * 40,
+        publication_visible_outcome_revision=1,
+    )
     substrate.suspend("T1", history_ref="sdk-session-abc")
 
     # Suspended: mode flipped, route no longer live.
@@ -508,10 +521,18 @@ def test_suspend_resume_rehydrates_from_history(
     # A claim() while suspended must not silently fork a second live session
     # for the thread without the history; the kernel resumes explicitly.
 
-    resumed = substrate.resume("T1")
+    resumed = substrate.resume(
+        "T1",
+        workspace_repo="acme-corp/acme-bot",
+        workspace_materialized_head="b" * 40,
+        publication_visible_outcome_revision=2,
+    )
     assert resumed.claim_name != first.claim_name
     assert resumed.session_id == first.session_id
     assert resumed.history_ref == "sdk-session-abc"
+    assert resumed.workspace_repo == "acme-corp/acme-bot"
+    assert resumed.workspace_materialized_head == "b" * 40
+    assert resumed.publication_visible_outcome_revision == 2
     # The new claim injects the rehydrate env for the replacement runner.
     env = fake_k8s.claims[resumed.claim_name].env
     assert env[HISTORY_ENV] == "sdk-session-abc"

--- a/apps/worker/tests/sandbox/test_types.py
+++ b/apps/worker/tests/sandbox/test_types.py
@@ -1,10 +1,10 @@
-"""RouteRecord wire-format contract for the per-sandbox runner token (issue #63).
+"""Upgrade-safe RouteRecord contract for worker-internal route metadata.
 
 The token is carried on the SandboxHandle from claim-time to call-time, and the
 affinity store serializes the handle to Valkey, so the token must survive the
-JSON round-trip. Upgrade safety: a route written by a pre-token worker has no
-``token`` key, and must rehydrate to ``token == ""`` (that sandbox's runner has
-no token configured, so the client sends no header and it keeps working).
+JSON round-trip. Workspace head and visible publication outcome revision are
+the corresponding cold-reconciliation fences. Upgrade safety: a legacy route
+has none of these keys and must still rehydrate with conservative defaults.
 """
 
 from __future__ import annotations
@@ -29,10 +29,18 @@ def _handle(**overrides: object) -> SandboxHandle:
 
 
 def test_route_record_round_trips_token() -> None:
-    record = RouteRecord(handle=_handle(token="tok-20"))
+    record = RouteRecord(
+        handle=_handle(
+            token="tok-20",
+            workspace_materialized_head="a" * 40,
+            publication_visible_outcome_revision=2,
+        )
+    )
     restored = RouteRecord.from_json(record.to_json())
 
     assert restored.handle.token == "tok-20"
+    assert restored.handle.workspace_materialized_head == "a" * 40
+    assert restored.handle.publication_visible_outcome_revision == 2
     assert restored.handle == record.handle
 
 
@@ -52,3 +60,5 @@ def test_route_record_legacy_payload_without_token_defaults_empty() -> None:
     }
     record = RouteRecord.from_json(json.dumps(legacy))
     assert record.handle.token == ""
+    assert record.handle.workspace_materialized_head is None
+    assert record.handle.publication_visible_outcome_revision == 0

--- a/apps/worker/tests/test_publication_clients.py
+++ b/apps/worker/tests/test_publication_clients.py
@@ -1,10 +1,9 @@
-"""GitHub publication recovery adopts only the exact approved pull request."""
+"""GitHub lineage recovery uses stored PR identity and marked commit ancestry."""
 
 from __future__ import annotations
 
 import json
 import uuid
-from collections.abc import Callable
 from urllib.parse import quote
 
 import httpx
@@ -20,10 +19,11 @@ from curie_worker.publication_loop import (
 )
 
 REPO = "acme-corp/acme-bot"
-BRANCH = "curie/publication-22222222222242228222222222222222"
-TITLE = "Update repository"
-BODY = "Approved platform publication."
+BRANCH = "curie/thread-lineage-example"
 PR_URL = f"https://github.com/{REPO}/pull/123"
+REVISION_ID = uuid.UUID("44444444-4444-4444-8444-444444444444")
+PRIOR_HEAD = "a" * 40
+REVISION_HEAD = "b" * 40
 
 pytestmark = pytest.mark.anyio
 
@@ -33,42 +33,412 @@ def anyio_backend() -> str:
     return "asyncio"
 
 
-def _pull(**overrides: object) -> dict[str, object]:
-    row: dict[str, object] = {
-        "html_url": PR_URL,
-        "title": TITLE,
-        "body": BODY,
-        "head": {"ref": BRANCH, "repo": {"full_name": REPO}},
-        "base": {"ref": "main", "repo": {"full_name": REPO}},
-    }
-    row.update(overrides)
-    return row
+async def test_stored_pull_number_is_the_only_identity_used_for_lineage_truth() -> None:
+    requests: list[httpx.Request] = []
 
-
-def _transport(pull: dict[str, object]) -> httpx.MockTransport:
     def handler(request: httpx.Request) -> httpx.Response:
-        if request.url.path == f"/repos/{REPO}":
-            return httpx.Response(200, json={"default_branch": "main"})
-        if request.url.path == f"/repos/{REPO}/pulls":
-            return httpx.Response(200, json=[pull])
-        raise AssertionError(f"unexpected GitHub request: {request.method} {request.url}")
+        requests.append(request)
+        assert request.url.path == f"/repos/{REPO}/pulls/123"
+        return httpx.Response(
+            200,
+            json={
+                "number": 123,
+                "html_url": PR_URL,
+                "state": "open",
+                "merged_at": None,
+                "title": "A human may edit this without changing identity",
+                "body": "Mutable prose is not a recovery key.",
+                "head": {"ref": BRANCH, "sha": REVISION_HEAD},
+                "base": {"ref": "main"},
+            },
+        )
 
-    return httpx.MockTransport(handler)
-
-
-async def test_recovery_adopts_exact_approved_pull_request() -> None:
-    async with httpx.AsyncClient(transport=_transport(_pull())) as client:
-        lookup = GitHubPublicationLookup(client)
-
-        recovered = await lookup.recover_pr_by_head(
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        observed = await GitHubPublicationLookup(client).read_pr_by_number(
             REPO,
-            BRANCH,
-            TITLE,
-            BODY,
+            123,
             "Bearer operator-token",
         )
 
-    assert recovered == PR_URL
+    assert len(requests) == 1
+    assert observed.number == 123
+    assert observed.url == PR_URL
+    assert observed.state == "open"
+    assert observed.head_sha == REVISION_HEAD
+    assert observed.head_ref == BRANCH
+
+
+async def test_github_lineage_reads_refuse_empty_auth_before_network_access() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        raise AssertionError("unauthenticated GitHub request escaped")
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        lookup = GitHubPublicationLookup(client)
+        with pytest.raises(PublicationReconcileError, match="requires authorization"):
+            await lookup.read_pr_by_number(REPO, 123, "")
+        with pytest.raises(PublicationReconcileError, match="requires authorization"):
+            await lookup.verify_revision_commit(
+                REPO,
+                REVISION_HEAD,
+                revision_id=REVISION_ID,
+                expected_parent=PRIOR_HEAD,
+                authorization_header="",
+            )
+
+    assert requests == []
+
+
+@pytest.mark.parametrize(
+    ("state", "merged_at", "expected"),
+    [("closed", None, "closed"), ("closed", "2026-09-03T00:00:00Z", "merged")],
+)
+async def test_stored_pull_number_reports_terminal_state_without_title_matching(
+    state: str,
+    merged_at: str | None,
+    expected: str,
+) -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "number": 123,
+                "html_url": PR_URL,
+                "state": state,
+                "merged_at": merged_at,
+                "title": "Edited title",
+                "body": "Edited body",
+                "head": {"ref": BRANCH, "sha": REVISION_HEAD},
+                "base": {"ref": "main"},
+            },
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        observed = await GitHubPublicationLookup(client).read_pr_by_number(
+            REPO, 123, "Bearer operator-token"
+        )
+
+    assert observed.state == expected
+
+
+@pytest.mark.parametrize(
+    ("message", "parent", "error"),
+    [
+        ("Approved revision without a trailer", PRIOR_HEAD, "revision marker"),
+        (
+            f"Approved revision\n\nCurie-Revision: {REVISION_ID}",
+            "c" * 40,
+            "expected parent",
+        ),
+    ],
+    ids=("missing-marker", "wrong-parent"),
+)
+async def test_lost_response_adopts_only_the_marked_revision_with_expected_parent(
+    message: str,
+    parent: str,
+    error: str,
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == f"/repos/{REPO}/git/commits/{REVISION_HEAD}"
+        return httpx.Response(
+            200,
+            json={
+                "sha": REVISION_HEAD,
+                "message": message,
+                "parents": [{"sha": parent}],
+            },
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(PublicationReconcileError, match=error):
+            await GitHubPublicationLookup(client).verify_revision_commit(
+                REPO,
+                REVISION_HEAD,
+                revision_id=REVISION_ID,
+                expected_parent=PRIOR_HEAD,
+                authorization_header="Bearer operator-token",
+            )
+
+
+async def test_lost_response_adopts_the_exact_marked_revision_commit() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "sha": REVISION_HEAD,
+                "message": f"Approved revision\n\nCurie-Revision: {REVISION_ID}",
+                "parents": [{"sha": PRIOR_HEAD}],
+            },
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        verified = await GitHubPublicationLookup(client).verify_revision_commit(
+            REPO,
+            REVISION_HEAD,
+            revision_id=REVISION_ID,
+            expected_parent=PRIOR_HEAD,
+            authorization_header="Bearer operator-token",
+        )
+
+    assert verified == REVISION_HEAD
+
+
+async def test_missing_job_recovery_reads_the_exact_lineage_branch_head() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, json={"object": {"sha": REVISION_HEAD}})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        head = await GitHubPublicationLookup(client).read_branch_head(
+            REPO,
+            BRANCH,
+            "Bearer rotated-installation-token",
+        )
+
+    assert head == REVISION_HEAD
+    assert len(requests) == 1
+    assert requests[0].url.raw_path.decode() == (
+        f"/repos/{REPO}/git/ref/heads/curie%2Fthread-lineage-example"
+    )
+    assert requests[0].headers["Authorization"] == "Bearer rotated-installation-token"
+
+
+@pytest.mark.parametrize(
+    ("state", "merged_at", "terminal"),
+    [
+        ("closed", None, "closed"),
+        ("closed", "2026-09-03T00:00:00Z", "merged"),
+    ],
+)
+async def test_first_pr_recovery_recognizes_exact_terminal_pull_without_posting(
+    state: str,
+    merged_at: str | None,
+    terminal: str,
+) -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.url.path == f"/repos/{REPO}":
+            return httpx.Response(200, json={"default_branch": "main"})
+        assert request.url.path == f"/repos/{REPO}/pulls"
+        assert request.url.params["state"] == "all"
+        assert request.url.params["head"] == f"acme-corp:{BRANCH}"
+        return httpx.Response(
+            200,
+            json=[
+                {
+                    "number": 123,
+                    "html_url": PR_URL,
+                    "state": state,
+                    "merged_at": merged_at,
+                    "title": "Update repository",
+                    "body": "Approved platform publication.",
+                    "head": {
+                        "ref": BRANCH,
+                        "sha": REVISION_HEAD,
+                        "repo": {"full_name": REPO},
+                    },
+                    "base": {"ref": "main", "repo": {"full_name": REPO}},
+                }
+            ],
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        recovered = await GitHubPublicationLookup(client).recover_pr_by_head(
+            REPO,
+            BRANCH,
+            "Update repository",
+            "Approved platform publication.",
+            expected_head_sha=REVISION_HEAD,
+            authorization_header="Bearer rotated-installation-token",
+        )
+
+    assert recovered is not None
+    assert (
+        recovered.number,
+        recovered.url,
+        recovered.state,
+        recovered.head_sha,
+        recovered.head_ref,
+    ) == (
+        123,
+        PR_URL,
+        terminal,
+        REVISION_HEAD,
+        BRANCH,
+    )
+    assert [request.method for request in requests] == ["GET", "GET"]
+
+
+async def test_first_pr_recovery_rejects_pull_whose_head_was_replaced() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.url.path == f"/repos/{REPO}":
+            return httpx.Response(200, json={"default_branch": "main"})
+        assert request.url.path == f"/repos/{REPO}/pulls"
+        return httpx.Response(
+            200,
+            json=[
+                {
+                    "number": 123,
+                    "html_url": PR_URL,
+                    "state": "open",
+                    "merged_at": None,
+                    "title": "Update repository",
+                    "body": "Approved platform publication.",
+                    "head": {
+                        "ref": BRANCH,
+                        "sha": "c" * 40,
+                        "repo": {"full_name": REPO},
+                    },
+                    "base": {"ref": "main", "repo": {"full_name": REPO}},
+                }
+            ],
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(PublicationReconcileError, match="expected commit"):
+            await GitHubPublicationLookup(client).recover_pr_by_head(
+                REPO,
+                BRANCH,
+                "Update repository",
+                "Approved platform publication.",
+                expected_head_sha=REVISION_HEAD,
+                authorization_header="Bearer rotated-installation-token",
+            )
+
+    assert [request.method for request in requests] == ["GET", "GET"]
+
+
+async def test_lost_create_response_recognizes_terminal_pull_without_second_post() -> None:
+    requests: list[httpx.Request] = []
+    pull_queries = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal pull_queries
+        requests.append(request)
+        if request.url.path == f"/repos/{REPO}":
+            return httpx.Response(200, json={"default_branch": "main"})
+        if request.url.raw_path.decode().endswith(
+            "/git/ref/heads/curie%2Fthread-lineage-example"
+        ):
+            return httpx.Response(200, json={"object": {"sha": REVISION_HEAD}})
+        if request.method == "POST":
+            raise httpx.ReadError("create response was lost", request=request)
+        assert request.url.path == f"/repos/{REPO}/pulls"
+        pull_queries += 1
+        if pull_queries == 1:
+            return httpx.Response(200, json=[])
+        return httpx.Response(
+            200,
+            json=[
+                {
+                    "number": 123,
+                    "html_url": PR_URL,
+                    "state": "closed",
+                    "merged_at": None,
+                    "title": "Update repository",
+                    "body": "Approved platform publication.",
+                    "head": {
+                        "ref": BRANCH,
+                        "sha": REVISION_HEAD,
+                        "repo": {"full_name": REPO},
+                    },
+                    "base": {"ref": "main", "repo": {"full_name": REPO}},
+                }
+            ],
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        recovered = await GitHubPublicationLookup(client).recover_pr_by_head(
+            REPO,
+            BRANCH,
+            "Update repository",
+            "Approved platform publication.",
+            expected_head_sha=REVISION_HEAD,
+            authorization_header="Bearer rotated-installation-token",
+        )
+
+    assert recovered is not None
+    assert recovered.state == "closed"
+    assert recovered.head_sha == REVISION_HEAD
+    assert [request.method for request in requests].count("POST") == 1
+    assert pull_queries == 2
+
+
+async def test_lost_create_response_adopts_exact_open_pull_once() -> None:
+    requests: list[httpx.Request] = []
+    pull_queries = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal pull_queries
+        requests.append(request)
+        if request.url.path == f"/repos/{REPO}":
+            return httpx.Response(200, json={"default_branch": "main"})
+        if request.url.raw_path.decode().endswith(
+            "/git/ref/heads/curie%2Fthread-lineage-example"
+        ):
+            return httpx.Response(200, json={"object": {"sha": REVISION_HEAD}})
+        if request.method == "POST":
+            raise httpx.ReadError("create response was lost", request=request)
+        assert request.url.path == f"/repos/{REPO}/pulls"
+        assert request.url.params["state"] == "all"
+        pull_queries += 1
+        if pull_queries == 1:
+            return httpx.Response(200, json=[])
+        return httpx.Response(
+            200,
+            json=[
+                {
+                    "number": 123,
+                    "html_url": PR_URL,
+                    "state": "open",
+                    "merged_at": None,
+                    "title": "Update repository",
+                    "body": "Approved platform publication.",
+                    "head": {
+                        "ref": BRANCH,
+                        "sha": REVISION_HEAD,
+                        "repo": {"full_name": REPO},
+                    },
+                    "base": {"ref": "main", "repo": {"full_name": REPO}},
+                }
+            ],
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        recovered = await GitHubPublicationLookup(client).recover_pr_by_head(
+            REPO,
+            BRANCH,
+            "Update repository",
+            "Approved platform publication.",
+            expected_head_sha=REVISION_HEAD,
+            authorization_header="Bearer rotated-installation-token",
+        )
+
+    assert recovered is not None
+    assert (
+        recovered.number,
+        recovered.url,
+        recovered.state,
+        recovered.head_sha,
+        recovered.head_ref,
+    ) == (
+        123,
+        PR_URL,
+        "open",
+        REVISION_HEAD,
+        BRANCH,
+    )
+    assert [request.method for request in requests].count("POST") == 1
+    assert pull_queries == 2
 
 
 async def test_publication_result_is_appended_once_to_the_durable_transcript() -> None:
@@ -272,73 +642,3 @@ async def test_transcript_capacity_refusal_is_classified_as_permanent() -> None:
                 uuid.UUID("22222222-2222-4222-8222-222222222222"),
                 f"Published the approved changes: {PR_URL}",
             )
-
-
-@pytest.mark.parametrize(
-    "mutate",
-    [
-        lambda row: row.update(title="Different title"),
-        lambda row: row.update(body="Different body"),
-        lambda row: row.update(head={"ref": "other", "repo": {"full_name": REPO}}),
-        lambda row: row.update(
-            head={"ref": BRANCH, "repo": {"full_name": "acme-corp/other"}}
-        ),
-        lambda row: row.update(base={"ref": "other", "repo": {"full_name": REPO}}),
-        lambda row: row.update(
-            base={"ref": "main", "repo": {"full_name": "acme-corp/other"}}
-        ),
-    ],
-    ids=("title", "body", "head-ref", "head-repo", "base-ref", "base-repo"),
-)
-async def test_recovery_rejects_mutated_pull_request_contract(
-    mutate: Callable[[dict[str, object]], None],
-) -> None:
-    row = _pull()
-    mutate(row)
-    async with httpx.AsyncClient(transport=_transport(row)) as client:
-        lookup = GitHubPublicationLookup(client)
-
-        with pytest.raises(PublicationReconcileError, match="contract"):
-            await lookup.recover_pr_by_head(
-                REPO,
-                BRANCH,
-                TITLE,
-                BODY,
-                "Bearer operator-token",
-            )
-
-
-async def test_create_response_is_validated_before_reporting_success() -> None:
-    calls = 0
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        nonlocal calls
-        if request.url.path == f"/repos/{REPO}":
-            return httpx.Response(200, json={"default_branch": "main"})
-        if request.url.path.endswith(f"/git/ref/heads/{BRANCH}"):
-            return httpx.Response(200, json={"ref": f"refs/heads/{BRANCH}"})
-        if request.url.path == f"/repos/{REPO}/pulls" and request.method == "GET":
-            calls += 1
-            return httpx.Response(200, json=[])
-        if request.url.path == f"/repos/{REPO}/pulls" and request.method == "POST":
-            assert json.loads(request.content) == {
-                "title": TITLE,
-                "head": BRANCH,
-                "base": "main",
-                "body": BODY,
-            }
-            return httpx.Response(201, json=_pull(title="Mutated after creation"))
-        raise AssertionError(f"unexpected GitHub request: {request.method} {request.url}")
-
-    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
-        lookup = GitHubPublicationLookup(client)
-        with pytest.raises(PublicationReconcileError, match="contract"):
-            await lookup.recover_pr_by_head(
-                REPO,
-                BRANCH,
-                TITLE,
-                BODY,
-                "Bearer operator-token",
-            )
-
-    assert calls == 1

--- a/apps/worker/tests/test_publication_k8s.py
+++ b/apps/worker/tests/test_publication_k8s.py
@@ -5,13 +5,18 @@ from __future__ import annotations
 import base64
 import importlib
 import json
+import os
+import shutil
 import subprocess
-import sys
+import threading
 import uuid
 from copy import deepcopy
 from dataclasses import replace
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
+from urllib.parse import parse_qs, urlsplit
 
 import pytest
 from kubernetes.client import ApiException
@@ -20,6 +25,10 @@ PUBLICATION_ID = uuid.UUID("22222222-2222-4222-8222-222222222222")
 WRITE_CREDENTIAL = "publication-write-credential-value"
 CLEAN_URL = "https://github.com/acme-corp/acme-bot.git"
 PR_API_URL = "https://api.github.com/repos/acme-corp/acme-bot/pulls"
+REVISION_ID = uuid.UUID("44444444-4444-4444-8444-444444444444")
+LINEAGE_BRANCH = "curie/thread-lineage-example"
+PRIOR_HEAD = "b" * 40
+REVISION_HEAD = "d" * 40
 
 
 @pytest.fixture
@@ -50,11 +59,17 @@ def _settings(module: Any) -> Any:
 def _payload(module: Any, patch: bytes = b"diff --git a/a b/a\n") -> Any:
     return module.PublicationPayload(
         publication_id=PUBLICATION_ID,
+        revision_id=REVISION_ID,
+        revision_number=1,
         repo_full_name="acme-corp/acme-bot",
         clean_clone_url=CLEAN_URL,
         base_sha="a" * 40,
+        expected_prior_head="a" * 40,
+        expected_remote_head=None,
         patch=patch,
-        branch=module.deterministic_publication_branch(PUBLICATION_ID),
+        branch=LINEAGE_BRANCH,
+        pr_number=None,
+        pr_url=None,
         title="Update repository",
         body="Approved platform publication.",
     )
@@ -63,6 +78,35 @@ def _payload(module: Any, patch: bytes = b"diff --git a/a b/a\n") -> Any:
 def _resources(module: Any, patch: bytes = b"diff --git a/a b/a\n") -> Any:
     return module.build_publication_resources(
         _payload(module, patch),
+        credential=WRITE_CREDENTIAL,
+        settings=_settings(module),
+    )
+
+
+def _job_env(resources: Any) -> dict[str, str]:
+    container = resources.job["spec"]["template"]["spec"]["containers"][0]
+    return {item["name"]: item["value"] for item in container["env"]}
+
+
+def _lineage_resources(module: Any) -> Any:
+    payload = module.PublicationPayload(
+        publication_id=PUBLICATION_ID,
+        revision_id=REVISION_ID,
+        revision_number=2,
+        repo_full_name="acme-corp/acme-bot",
+        clean_clone_url=CLEAN_URL,
+        base_sha=PRIOR_HEAD,
+        expected_prior_head=PRIOR_HEAD,
+        expected_remote_head=PRIOR_HEAD,
+        patch=b"diff --git a/a b/a\n",
+        branch=LINEAGE_BRANCH,
+        pr_number=123,
+        pr_url="https://github.com/acme-corp/acme-bot/pull/123",
+        title="Update repository",
+        body="Approved platform publication.",
+    )
+    return module.build_publication_resources(
+        payload,
         credential=WRITE_CREDENTIAL,
         settings=_settings(module),
     )
@@ -102,7 +146,7 @@ def test_publication_base_sha_is_revalidated_before_entering_job_argv(
         )
 
 
-def test_publication_resource_names_and_branch_are_deterministic(
+def test_publication_resource_names_and_stored_lineage_branch_are_deterministic(
     publication_k8s: Any,
 ) -> None:
     first = _resources(publication_k8s)
@@ -112,9 +156,7 @@ def test_publication_resource_names_and_branch_are_deterministic(
     assert first.job == second.job
     assert first.config_map == second.config_map
     assert first.secret["metadata"]["name"] == first.names.secret
-    assert publication_k8s.deterministic_publication_branch(PUBLICATION_ID) == (
-        "curie/publication-22222222222242228222222222222222"
-    )
+    assert _job_env(first)["BRANCH"] == LINEAGE_BRANCH
 
 
 def test_built_job_is_bounded_secret_free_and_outside_sandbox_selectors(
@@ -189,6 +231,78 @@ def test_publish_script_uses_clean_remote_file_askpass_rest_and_redacted_marker(
     assert WRITE_CREDENTIAL not in serialized_job
 
 
+def test_lineage_revision_job_marks_one_commit_and_uses_exact_head_occupancy_cas(
+    publication_k8s: Any,
+) -> None:
+    """Revision two may advance only the stored head of the stable lineage branch."""
+
+    resources = _lineage_resources(publication_k8s)
+    script = resources.config_map["data"]["publish.sh"]
+    container = resources.job["spec"]["template"]["spec"]["containers"][0]
+    env = {item["name"]: item["value"] for item in container["env"]}
+
+    assert env["BRANCH"] == LINEAGE_BRANCH
+    assert env["EXPECTED_PRIOR_HEAD"] == PRIOR_HEAD
+    assert env["EXPECTED_REMOTE_HEAD"] == PRIOR_HEAD
+    assert env["REVISION_ID"] == str(REVISION_ID)
+    assert env["PR_NUMBER"] == "123"
+    assert env["PR_URL"] == "https://github.com/acme-corp/acme-bot/pull/123"
+    assert "Curie-Revision: $REVISION_ID" in script
+    assert (
+        '--force-with-lease=refs/heads/$BRANCH:$EXPECTED_REMOTE_HEAD' in script
+    )
+    assert "CURIE_COMMIT_SHA=" in script
+    assert "CURIE_PR_NUMBER=" in script
+    assert "git push --force " not in script
+    assert f"publication-{PUBLICATION_ID.hex}" not in LINEAGE_BRANCH
+    preflight = script.index("CURIE_GITHUB_PHASE=pre-push python")
+    push = script.index("git_with_timeout push")
+    postflight = script.index("CURIE_GITHUB_PHASE=post-push python")
+    success = script.index('echo "CURIE_COMMIT_SHA=$commit_sha"')
+    assert preflight < push < postflight < success
+
+
+def test_lineage_job_refuses_every_remote_head_except_prior_or_own_marked_commit(
+    publication_k8s: Any,
+) -> None:
+    script = _lineage_resources(publication_k8s).config_map["data"]["publish.sh"]
+
+    assert "ls-remote" in script
+    assert "EXPECTED_REMOTE_HEAD" in script
+    assert "REVISION_ID" in script
+    assert "Curie-Revision:" in script
+    assert "publication branch head conflict" in script
+    assert "force-with-lease=refs/heads/$BRANCH:$EXPECTED_REMOTE_HEAD" in script
+
+
+def test_lineage_revision_payload_rejects_checkout_and_expected_head_disagreement(
+    publication_k8s: Any,
+) -> None:
+    payload = publication_k8s.PublicationPayload(
+        publication_id=PUBLICATION_ID,
+        revision_id=REVISION_ID,
+        revision_number=2,
+        repo_full_name="acme-corp/acme-bot",
+        clean_clone_url=CLEAN_URL,
+        base_sha="c" * 40,
+        expected_prior_head=PRIOR_HEAD,
+        expected_remote_head=PRIOR_HEAD,
+        patch=b"diff --git a/a b/a\n",
+        branch=LINEAGE_BRANCH,
+        pr_number=123,
+        pr_url="https://github.com/acme-corp/acme-bot/pull/123",
+        title="Update repository",
+        body="Approved platform publication.",
+    )
+
+    with pytest.raises(publication_k8s.PublicationResourceError, match="expected prior head"):
+        publication_k8s.build_publication_resources(
+            payload,
+            credential=WRITE_CREDENTIAL,
+            settings=_settings(publication_k8s),
+        )
+
+
 def test_publish_job_refuses_redirects_for_git_and_github_rest(
     publication_k8s: Any,
 ) -> None:
@@ -202,6 +316,885 @@ def test_publish_job_refuses_redirects_for_git_and_github_rest(
     assert "opener = build_opener(_NoRedirect())" in script
     assert "opener.open(req, timeout=int(os.environ[\"GITHUB_TIMEOUT_SECONDS\"]))" in script
     assert "urlopen(req" not in script
+
+
+def _pull_response(
+    *,
+    state: str = "open",
+    merged: bool = False,
+    number: int = 123,
+    url: str = "https://github.com/acme-corp/acme-bot/pull/123",
+    head: str = LINEAGE_BRANCH,
+    head_sha: str | None = None,
+    base: str = "main",
+) -> dict[str, Any]:
+    head_payload: dict[str, Any] = {
+        "ref": head,
+        "repo": {"full_name": "acme-corp/acme-bot"},
+    }
+    if head_sha is not None:
+        head_payload["sha"] = head_sha
+    return {
+        "number": number,
+        "html_url": url,
+        "state": state,
+        "merged": merged,
+        "title": "Update repository",
+        "body": "Approved platform publication.",
+        "head": head_payload,
+        "base": {"ref": base, "repo": {"full_name": "acme-corp/acme-bot"}},
+    }
+
+
+def _terminal_markers(state: str, head_sha: str) -> str:
+    return (
+        "CURIE_PR_URL=https://github.com/acme-corp/acme-bot/pull/123\n"
+        "CURIE_PR_NUMBER=123\n"
+        f"CURIE_COMMIT_SHA={head_sha}\n"
+        f"CURIE_PR_STATE={state}\n"
+    )
+
+
+class _GitHubApiHandler(BaseHTTPRequestHandler):
+    queued_responses: list[tuple[int, dict[str, str], Any]] = []
+    requests: list[tuple[str, str | None]] = []
+    post_count = 0
+
+    def _respond(self) -> None:
+        type(self).requests.append((self.path, self.headers.get("Authorization")))
+        status, headers, payload = type(self).queued_responses.pop(0)
+        self.send_response(status)
+        for name, value in headers.items():
+            self.send_header(name, value)
+        if payload is not None:
+            body = json.dumps(payload).encode()
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+        else:
+            body = b""
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self) -> None:
+        self._respond()
+
+    def do_POST(self) -> None:
+        type(self).post_count += 1
+        content_length = int(self.headers.get("Content-Length", "0"))
+        self.rfile.read(content_length)
+        self._respond()
+
+    def log_message(self, _format: str, *args: object) -> None:
+        return
+
+
+def _embedded_github_script(resources: Any) -> str:
+    script = resources.config_map["data"]["publish.sh"]
+    marker = "cat >/tmp/curie-github.py <<'PY'\n"
+    return cast(str, script.split(marker, 1)[1].split("\nPY\n", 1)[0])
+
+
+def _run_github_guard(
+    tmp_path: Path,
+    resources: Any,
+    *,
+    mode: str,
+    responses: list[tuple[int, dict[str, str], Any]],
+    expected_head: str | None = None,
+) -> tuple[subprocess.CompletedProcess[str], list[tuple[str, str | None]]]:
+    credential = tmp_path / "credential"
+    credential.write_text(WRITE_CREDENTIAL)
+    facts = tmp_path / "pr-facts.json"
+    expected_head = expected_head or (
+        PRIOR_HEAD if mode == "pre-push" else REVISION_HEAD
+    )
+    prepared = deepcopy(responses)
+    for _status, _headers, payload in prepared:
+        rows = payload if isinstance(payload, list) else [payload]
+        for row in rows:
+            if isinstance(row, dict) and isinstance(row.get("head"), dict):
+                row["head"].setdefault("sha", expected_head)
+    _GitHubApiHandler.queued_responses = prepared
+    _GitHubApiHandler.requests = []
+    _GitHubApiHandler.post_count = 0
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _GitHubApiHandler)
+    thread = threading.Thread(target=server.serve_forever)
+    thread.start()
+    try:
+        completed = subprocess.run(
+            ["python", "-c", _embedded_github_script(resources)],
+            env={
+                **os.environ,
+                **_job_env(resources),
+                "GITHUB_API_URL": f"http://127.0.0.1:{server.server_port}",
+                "CURIE_GITHUB_PHASE": mode,
+                "CURIE_EXPECTED_HEAD": expected_head,
+                "CURIE_CREDENTIAL_PATH": str(credential),
+                "CURIE_PR_FACTS_PATH": str(facts),
+            },
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+    finally:
+        server.shutdown()
+        thread.join()
+        server.server_close()
+    return completed, list(_GitHubApiHandler.requests)
+
+
+@pytest.mark.parametrize(
+    ("state", "merged", "marker"),
+    [("closed", False, "closed"), ("closed", True, "merged")],
+)
+def test_revision_guard_refuses_closed_or_merged_pull_before_push(
+    publication_k8s: Any,
+    tmp_path: Path,
+    state: str,
+    merged: bool,
+    marker: str,
+) -> None:
+    resources = _lineage_resources(publication_k8s)
+    completed, requests = _run_github_guard(
+        tmp_path,
+        resources,
+        mode="pre-push",
+        responses=[
+            (200, {}, {"default_branch": "main"}),
+            (200, {}, _pull_response(state=state, merged=merged)),
+        ],
+    )
+
+    assert completed.returncode != 0
+    assert completed.stdout == _terminal_markers(marker, PRIOR_HEAD)
+    assert requests == [
+        ("/repos/acme-corp/acme-bot", f"Bearer {WRITE_CREDENTIAL}"),
+        ("/repos/acme-corp/acme-bot/pulls/123", f"Bearer {WRITE_CREDENTIAL}"),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("state", "merged", "marker"),
+    [("closed", False, "closed"), ("closed", True, "merged")],
+)
+def test_revision_guard_refuses_closed_or_merged_pull_after_push_without_success(
+    publication_k8s: Any,
+    tmp_path: Path,
+    state: str,
+    merged: bool,
+    marker: str,
+) -> None:
+    resources = _lineage_resources(publication_k8s)
+    before, _ = _run_github_guard(
+        tmp_path,
+        resources,
+        mode="pre-push",
+        responses=[
+            (200, {}, {"default_branch": "main"}),
+            (200, {}, _pull_response()),
+        ],
+    )
+    assert before.returncode == 0
+
+    after, requests = _run_github_guard(
+        tmp_path,
+        resources,
+        mode="post-push",
+        responses=[(200, {}, _pull_response(state=state, merged=merged))],
+    )
+
+    assert after.returncode != 0
+    assert after.stdout == _terminal_markers(marker, REVISION_HEAD)
+    assert requests == [
+        ("/repos/acme-corp/acme-bot/pulls/123", f"Bearer {WRITE_CREDENTIAL}")
+    ]
+
+
+@pytest.mark.parametrize("mode", ["pre-push", "post-push"])
+@pytest.mark.parametrize(
+    "mismatch",
+    [
+        {"number": 124},
+        {"url": "https://github.com/acme-corp/acme-bot/pull/124"},
+        {"head": "curie/different-lineage"},
+        {"base": "different-base"},
+    ],
+)
+def test_revision_guard_refuses_pull_identity_mismatch_at_both_boundaries(
+    publication_k8s: Any,
+    tmp_path: Path,
+    mode: str,
+    mismatch: dict[str, Any],
+) -> None:
+    resources = _lineage_resources(publication_k8s)
+    if mode == "post-push":
+        healthy, _ = _run_github_guard(
+            tmp_path,
+            resources,
+            mode="pre-push",
+            responses=[
+                (200, {}, {"default_branch": "main"}),
+                (200, {}, _pull_response()),
+            ],
+        )
+        assert healthy.returncode == 0
+        responses: list[tuple[int, dict[str, str], Any]] = [
+            (200, {}, _pull_response(**mismatch))
+        ]
+    else:
+        responses = [
+            (200, {}, {"default_branch": "main"}),
+            (200, {}, _pull_response(**mismatch)),
+        ]
+
+    completed, _ = _run_github_guard(
+        tmp_path, resources, mode=mode, responses=responses
+    )
+
+    assert completed.returncode != 0
+    assert completed.stdout == ""
+    assert "CURIE_PR_URL=" not in completed.stdout
+
+
+def test_revision_guard_does_not_follow_or_forward_auth_on_redirect(
+    publication_k8s: Any,
+    tmp_path: Path,
+) -> None:
+    resources = _lineage_resources(publication_k8s)
+    target_requests: list[str | None] = []
+
+    class TargetHandler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            target_requests.append(self.headers.get("Authorization"))
+            self.send_response(200)
+            self.end_headers()
+
+        def log_message(self, _format: str, *args: object) -> None:
+            return
+
+    target = ThreadingHTTPServer(("127.0.0.1", 0), TargetHandler)
+    target_thread = threading.Thread(target=target.serve_forever)
+    target_thread.start()
+    try:
+        completed, requests = _run_github_guard(
+            tmp_path,
+            resources,
+            mode="pre-push",
+            responses=[
+                (200, {}, {"default_branch": "main"}),
+                (
+                    302,
+                    {"Location": f"http://127.0.0.1:{target.server_port}/capture"},
+                    None,
+                ),
+            ],
+        )
+    finally:
+        target.shutdown()
+        target_thread.join()
+        target.server_close()
+
+    assert completed.returncode != 0
+    assert target_requests == []
+    assert requests[-1][0] == "/repos/acme-corp/acme-bot/pulls/123"
+
+
+def test_revision_guard_revalidates_healthy_stable_pull_before_and_after_push(
+    publication_k8s: Any,
+    tmp_path: Path,
+) -> None:
+    resources = _lineage_resources(publication_k8s)
+    before, _ = _run_github_guard(
+        tmp_path,
+        resources,
+        mode="pre-push",
+        responses=[
+            (200, {}, {"default_branch": "main"}),
+            (200, {}, _pull_response()),
+        ],
+    )
+    assert before.returncode == 0
+    assert before.stdout == ""
+
+    after, requests = _run_github_guard(
+        tmp_path,
+        resources,
+        mode="post-push",
+        responses=[(200, {}, _pull_response())],
+    )
+
+    assert after.returncode == 0
+    assert after.stdout == (
+        "CURIE_PR_URL=https://github.com/acme-corp/acme-bot/pull/123\n"
+        "CURIE_PR_NUMBER=123\n"
+    )
+    assert requests == [
+        ("/repos/acme-corp/acme-bot/pulls/123", f"Bearer {WRITE_CREDENTIAL}")
+    ]
+
+
+def test_post_push_guard_rejects_concurrent_branch_replacement_before_markers(
+    publication_k8s: Any,
+    tmp_path: Path,
+) -> None:
+    resources = _lineage_resources(publication_k8s)
+    before, _ = _run_github_guard(
+        tmp_path,
+        resources,
+        mode="pre-push",
+        responses=[
+            (200, {}, {"default_branch": "main"}),
+            (200, {}, _pull_response()),
+        ],
+    )
+    assert before.returncode == 0
+
+    completed, requests = _run_github_guard(
+        tmp_path,
+        resources,
+        mode="post-push",
+        responses=[(200, {}, _pull_response(head_sha="c" * 40))],
+        expected_head=REVISION_HEAD,
+    )
+
+    assert completed.returncode != 0
+    assert completed.stdout == ""
+    assert "expected publication commit" in completed.stderr
+    assert requests == [
+        ("/repos/acme-corp/acme-bot/pulls/123", f"Bearer {WRITE_CREDENTIAL}")
+    ]
+
+
+def test_embedded_github_client_executes_healthy_two_revision_path(
+    publication_k8s: Any,
+    tmp_path: Path,
+) -> None:
+    first_revision = _resources(publication_k8s)
+    first, first_requests = _run_github_guard(
+        tmp_path,
+        first_revision,
+        mode="post-push",
+        responses=[
+            (200, {}, {"default_branch": "main"}),
+            (200, {}, []),
+            (201, {}, _pull_response()),
+        ],
+    )
+    assert first.returncode == 0
+    assert first.stdout == (
+        "CURIE_PR_URL=https://github.com/acme-corp/acme-bot/pull/123\n"
+        "CURIE_PR_NUMBER=123\n"
+    )
+    assert [path.split("?", 1)[0] for path, _auth in first_requests] == [
+        "/repos/acme-corp/acme-bot",
+        "/repos/acme-corp/acme-bot/pulls",
+        "/repos/acme-corp/acme-bot/pulls",
+    ]
+
+    second_revision = _lineage_resources(publication_k8s)
+    before, _ = _run_github_guard(
+        tmp_path,
+        second_revision,
+        mode="pre-push",
+        responses=[
+            (200, {}, {"default_branch": "main"}),
+            (200, {}, _pull_response()),
+        ],
+    )
+    after, _ = _run_github_guard(
+        tmp_path,
+        second_revision,
+        mode="post-push",
+        responses=[(200, {}, _pull_response())],
+    )
+
+    assert before.returncode == 0
+    assert after.returncode == 0
+    assert after.stdout.endswith("CURIE_PR_NUMBER=123\n")
+
+
+def test_first_revision_recovers_pull_after_ambiguous_create_failure(
+    publication_k8s: Any,
+    tmp_path: Path,
+) -> None:
+    completed, requests = _run_github_guard(
+        tmp_path,
+        _resources(publication_k8s),
+        mode="post-push",
+        responses=[
+            (200, {}, {"default_branch": "main"}),
+            (200, {}, []),
+            (500, {}, {"message": "ambiguous failure"}),
+            (200, {}, [_pull_response()]),
+        ],
+    )
+
+    assert completed.returncode == 0
+    assert completed.stdout.endswith("CURIE_PR_NUMBER=123\n")
+    assert len(requests) == 4
+
+
+@pytest.mark.parametrize(
+    ("state", "merged", "marker"),
+    [("closed", False, "closed"), ("closed", True, "merged")],
+)
+def test_first_revision_recognizes_terminal_pull_without_posting(
+    publication_k8s: Any,
+    tmp_path: Path,
+    state: str,
+    merged: bool,
+    marker: str,
+) -> None:
+    completed, requests = _run_github_guard(
+        tmp_path,
+        _resources(publication_k8s),
+        mode="post-push",
+        responses=[
+            (200, {}, {"default_branch": "main"}),
+            (200, {}, [_pull_response(state=state, merged=merged)]),
+        ],
+    )
+
+    assert completed.returncode != 0
+    assert completed.stdout == _terminal_markers(marker, REVISION_HEAD)
+    assert [path.split("?", 1)[0] for path, _auth in requests] == [
+        "/repos/acme-corp/acme-bot",
+        "/repos/acme-corp/acme-bot/pulls",
+    ]
+    assert "state=all" in requests[-1][0]
+
+
+def test_first_revision_lost_create_response_recognizes_terminal_without_repost(
+    publication_k8s: Any,
+    tmp_path: Path,
+) -> None:
+    completed, requests = _run_github_guard(
+        tmp_path,
+        _resources(publication_k8s),
+        mode="post-push",
+        responses=[
+            (200, {}, {"default_branch": "main"}),
+            (200, {}, []),
+            (500, {}, {"message": "response lost after create"}),
+            (200, {}, [_pull_response(state="closed")]),
+        ],
+    )
+
+    assert completed.returncode != 0
+    assert completed.stdout == _terminal_markers("closed", REVISION_HEAD)
+    assert [method_path.split("?", 1)[0] for method_path, _auth in requests].count(
+        "/repos/acme-corp/acme-bot/pulls"
+    ) == 3
+    assert _GitHubApiHandler.post_count == 1
+
+
+class _LocalGitHubState:
+    def __init__(self, *, git: str, remote: Path) -> None:
+        self.git = git
+        self.remote = remote
+        self.pr_number: int | None = None
+        self.requests: list[tuple[str, str, dict[str, list[str]]]] = []
+        self.post_payloads: list[dict[str, Any]] = []
+
+    def branch_head(self) -> str:
+        return subprocess.run(
+            [
+                self.git,
+                "--git-dir",
+                str(self.remote),
+                "rev-parse",
+                f"refs/heads/{LINEAGE_BRANCH}",
+            ],
+            text=True,
+            capture_output=True,
+            check=True,
+        ).stdout.strip()
+
+    def pull(self) -> dict[str, Any]:
+        assert self.pr_number is not None
+        return _pull_response(
+            number=self.pr_number,
+            url=f"https://github.com/acme-corp/acme-bot/pull/{self.pr_number}",
+            head_sha=self.branch_head(),
+        )
+
+
+def _local_github_handler(state: _LocalGitHubState) -> type[BaseHTTPRequestHandler]:
+    class Handler(BaseHTTPRequestHandler):
+        def _send(self, status: int, payload: Any) -> None:
+            body = json.dumps(payload).encode()
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_GET(self) -> None:
+            parsed = urlsplit(self.path)
+            query = parse_qs(parsed.query)
+            state.requests.append(("GET", parsed.path, query))
+            if parsed.path == "/repos/acme-corp/acme-bot":
+                self._send(200, {"default_branch": "main"})
+                return
+            if parsed.path == "/repos/acme-corp/acme-bot/pulls":
+                self._send(200, [] if state.pr_number is None else [state.pull()])
+                return
+            if parsed.path == "/repos/acme-corp/acme-bot/pulls/123":
+                self._send(200, state.pull())
+                return
+            self._send(404, {"message": "not found"})
+
+        def do_POST(self) -> None:
+            parsed = urlsplit(self.path)
+            state.requests.append(("POST", parsed.path, {}))
+            length = int(self.headers.get("Content-Length", "0"))
+            payload = json.loads(self.rfile.read(length))
+            assert isinstance(payload, dict)
+            state.post_payloads.append(payload)
+            if parsed.path != "/repos/acme-corp/acme-bot/pulls":
+                self._send(404, {"message": "not found"})
+                return
+            if state.pr_number is not None:
+                self._send(422, {"message": "pull request already exists"})
+                return
+            state.pr_number = 123
+            self._send(201, state.pull())
+
+        def log_message(self, _format: str, *args: object) -> None:
+            return
+
+    return Handler
+
+
+def _run_generated_publish_script(
+    tmp_path: Path,
+    resources: Any,
+    *,
+    remote: Path,
+    api_url: str,
+    ordinal: str,
+    path_prefix: Path | None = None,
+    extra_env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    root = tmp_path / f"run-{ordinal}"
+    root.mkdir()
+    credential = root / "credential"
+    credential.write_text("Bearer local-test-token")
+    patch = root / "changes.patch"
+    patch.write_bytes(
+        base64.b64decode(resources.config_map["binaryData"]["changes.patch"])
+    )
+    script = root / "publish.sh"
+    script.write_text(resources.config_map["data"]["publish.sh"])
+    remote_url = remote.resolve().as_uri()
+    env = {
+        **os.environ,
+        **_job_env(resources),
+        "GITHUB_API_URL": api_url,
+        "CURIE_CREDENTIAL_PATH": str(credential),
+        "CURIE_PATCH_PATH": str(patch),
+        "CURIE_WORK_DIR": str(root / "work"),
+        "GIT_ALLOW_PROTOCOL": "file",
+        "GIT_CONFIG_COUNT": "1",
+        "GIT_CONFIG_KEY_0": f"url.{remote_url}.insteadOf",
+        "GIT_CONFIG_VALUE_0": CLEAN_URL,
+    }
+    if path_prefix is not None:
+        env["PATH"] = f"{path_prefix}{os.pathsep}{env['PATH']}"
+    if extra_env is not None:
+        env.update(extra_env)
+    return subprocess.run(
+        ["/bin/bash", str(script)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _publication_resources_for_commit(
+    module: Any,
+    *,
+    publication_id: uuid.UUID,
+    revision_id: uuid.UUID,
+    revision_number: int,
+    base_sha: str,
+    expected_remote_head: str | None,
+    pr_number: int | None,
+    patch: bytes,
+) -> Any:
+    return module.build_publication_resources(
+        module.PublicationPayload(
+            publication_id=publication_id,
+            revision_id=revision_id,
+            revision_number=revision_number,
+            repo_full_name="acme-corp/acme-bot",
+            clean_clone_url=CLEAN_URL,
+            base_sha=base_sha,
+            expected_prior_head=base_sha,
+            expected_remote_head=expected_remote_head,
+            patch=patch,
+            branch=LINEAGE_BRANCH,
+            pr_number=pr_number,
+            pr_url=(
+                "https://github.com/acme-corp/acme-bot/pull/123"
+                if pr_number is not None
+                else None
+            ),
+            title="Update repository",
+            body="Approved platform publication.",
+        ),
+        credential="Bearer local-test-token",
+        settings=_settings(module),
+    )
+
+
+def test_generated_publish_script_keeps_one_pr_lineage_and_refuses_lease_race(
+    publication_k8s: Any,
+    tmp_path: Path,
+) -> None:
+    git = shutil.which("git")
+    assert git is not None
+    remote = tmp_path / "remote.git"
+    seed = tmp_path / "seed"
+    subprocess.run([git, "init", "--bare", str(remote)], check=True, capture_output=True)
+    subprocess.run([git, "init", "-b", "main", str(seed)], check=True, capture_output=True)
+    subprocess.run([git, "-C", str(seed), "config", "user.name", "Test Publisher"], check=True)
+    subprocess.run(
+        [git, "-C", str(seed), "config", "user.email", "publisher@example.com"],
+        check=True,
+    )
+    (seed / "README.md").write_text("base\n")
+    subprocess.run([git, "-C", str(seed), "add", "README.md"], check=True)
+    subprocess.run([git, "-C", str(seed), "commit", "-m", "Base"], check=True)
+    base_sha = subprocess.run(
+        [git, "-C", str(seed), "rev-parse", "HEAD"],
+        text=True,
+        capture_output=True,
+        check=True,
+    ).stdout.strip()
+    subprocess.run(
+        [git, "-C", str(seed), "remote", "add", "origin", remote.resolve().as_uri()],
+        check=True,
+    )
+    subprocess.run([git, "-C", str(seed), "push", "origin", "main"], check=True)
+    subprocess.run(
+        [git, "--git-dir", str(remote), "symbolic-ref", "HEAD", "refs/heads/main"],
+        check=True,
+    )
+
+    state = _LocalGitHubState(git=git, remote=remote)
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _local_github_handler(state))
+    thread = threading.Thread(target=server.serve_forever)
+    thread.start()
+    api_url = f"http://127.0.0.1:{server.server_port}"
+    try:
+        first_resources = _publication_resources_for_commit(
+            publication_k8s,
+            publication_id=PUBLICATION_ID,
+            revision_id=REVISION_ID,
+            revision_number=1,
+            base_sha=base_sha,
+            expected_remote_head=None,
+            pr_number=None,
+            patch=(
+                b"diff --git a/README.md b/README.md\n"
+                b"--- a/README.md\n+++ b/README.md\n"
+                b"@@ -1 +1,2 @@\n base\n+first\n"
+            ),
+        )
+        first = _run_generated_publish_script(
+            tmp_path,
+            first_resources,
+            remote=remote,
+            api_url=api_url,
+            ordinal="one",
+        )
+        assert first.returncode == 0, first.stderr
+        first_head = state.branch_head()
+        assert f"CURIE_COMMIT_SHA={first_head}" in first.stdout
+        assert "CURIE_PR_URL=https://github.com/acme-corp/acme-bot/pull/123" in first.stdout
+        assert "CURIE_PR_NUMBER=123" in first.stdout
+        first_parents = subprocess.run(
+            [git, "--git-dir", str(remote), "rev-list", "--parents", "-n", "1", first_head],
+            text=True,
+            capture_output=True,
+            check=True,
+        ).stdout.split()
+        assert first_parents == [first_head, base_sha]
+
+        second_revision = uuid.UUID("77777777-7777-4777-8777-777777777777")
+        second_resources = _publication_resources_for_commit(
+            publication_k8s,
+            publication_id=uuid.UUID("66666666-6666-4666-8666-666666666666"),
+            revision_id=second_revision,
+            revision_number=2,
+            base_sha=first_head,
+            expected_remote_head=first_head,
+            pr_number=123,
+            patch=(
+                b"diff --git a/README.md b/README.md\n"
+                b"--- a/README.md\n+++ b/README.md\n"
+                b"@@ -1,2 +1,3 @@\n base\n first\n+second\n"
+            ),
+        )
+        second = _run_generated_publish_script(
+            tmp_path,
+            second_resources,
+            remote=remote,
+            api_url=api_url,
+            ordinal="two",
+        )
+        assert second.returncode == 0, second.stderr
+        second_head = state.branch_head()
+        assert f"CURIE_COMMIT_SHA={second_head}" in second.stdout
+        assert "CURIE_PR_URL=https://github.com/acme-corp/acme-bot/pull/123" in second.stdout
+        assert "CURIE_PR_NUMBER=123" in second.stdout
+        second_parents = subprocess.run(
+            [git, "--git-dir", str(remote), "rev-list", "--parents", "-n", "1", second_head],
+            text=True,
+            capture_output=True,
+            check=True,
+        ).stdout.split()
+        assert second_parents == [second_head, first_head]
+        commit_count = subprocess.run(
+            [
+                git,
+                "--git-dir",
+                str(remote),
+                "rev-list",
+                "--count",
+                f"{base_sha}..{second_head}",
+            ],
+            text=True,
+            capture_output=True,
+            check=True,
+        ).stdout.strip()
+        assert commit_count == "2"
+        assert len(state.post_payloads) == 1
+        assert state.post_payloads[0]["head"] == LINEAGE_BRANCH
+        assert all(
+            query.get("state") == ["all"]
+            for method, path, query in state.requests
+            if method == "GET" and path.endswith("/pulls")
+        )
+
+        contender = tmp_path / "contender"
+        subprocess.run(
+            [git, "clone", remote.resolve().as_uri(), str(contender)],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            [git, "-C", str(contender), "fetch", "origin", LINEAGE_BRANCH],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            [git, "-C", str(contender), "checkout", "--detach", second_head],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            [git, "-C", str(contender), "config", "user.name", "Race Writer"],
+            check=True,
+        )
+        subprocess.run(
+            [git, "-C", str(contender), "config", "user.email", "race@example.com"],
+            check=True,
+        )
+        (contender / "race.txt").write_text("replacement\n")
+        subprocess.run([git, "-C", str(contender), "add", "race.txt"], check=True)
+        subprocess.run([git, "-C", str(contender), "commit", "-m", "Race"], check=True)
+        replacement_head = subprocess.run(
+            [git, "-C", str(contender), "rev-parse", "HEAD"],
+            text=True,
+            capture_output=True,
+            check=True,
+        ).stdout.strip()
+        subprocess.run(
+            [
+                git,
+                "-C",
+                str(contender),
+                "push",
+                "origin",
+                f"{replacement_head}:refs/curie-test/race-candidate",
+            ],
+            check=True,
+            capture_output=True,
+        )
+
+        wrapper_dir = tmp_path / "git-wrapper"
+        wrapper_dir.mkdir()
+        wrapper = wrapper_dir / "git"
+        wrapper.write_text(
+            """#!/usr/bin/env python3
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+args = sys.argv[1:]
+real_git = os.environ["CURIE_TEST_REAL_GIT"]
+marker = Path(os.environ["CURIE_TEST_RACE_MARKER"])
+if "push" in args and not marker.exists():
+    marker.touch()
+    subprocess.run(
+        [
+            real_git,
+            "--git-dir",
+            os.environ["CURIE_TEST_REMOTE"],
+            "update-ref",
+            os.environ["CURIE_TEST_RACE_REF"],
+            os.environ["CURIE_TEST_RACE_SHA"],
+        ],
+        check=True,
+    )
+os.execv(real_git, [real_git, *args])
+"""
+        )
+        wrapper.chmod(0o700)
+        third_resources = _publication_resources_for_commit(
+            publication_k8s,
+            publication_id=uuid.UUID("88888888-8888-4888-8888-888888888888"),
+            revision_id=uuid.UUID("99999999-9999-4999-8999-999999999999"),
+            revision_number=3,
+            base_sha=second_head,
+            expected_remote_head=second_head,
+            pr_number=123,
+            patch=(
+                b"diff --git a/README.md b/README.md\n"
+                b"--- a/README.md\n+++ b/README.md\n"
+                b"@@ -1,3 +1,4 @@\n base\n first\n second\n+third\n"
+            ),
+        )
+        raced = _run_generated_publish_script(
+            tmp_path,
+            third_resources,
+            remote=remote,
+            api_url=api_url,
+            ordinal="race",
+            path_prefix=wrapper_dir,
+            extra_env={
+                "CURIE_TEST_REAL_GIT": git,
+                "CURIE_TEST_REMOTE": str(remote),
+                "CURIE_TEST_RACE_REF": f"refs/heads/{LINEAGE_BRANCH}",
+                "CURIE_TEST_RACE_SHA": replacement_head,
+                "CURIE_TEST_RACE_MARKER": str(tmp_path / "race-fired"),
+            },
+        )
+        assert raced.returncode != 0
+        assert "CURIE_PR_URL=" not in raced.stdout
+        assert "CURIE_PR_NUMBER=" not in raced.stdout
+        assert "CURIE_COMMIT_SHA=" not in raced.stdout
+        assert (tmp_path / "race-fired").is_file()
+        assert state.branch_head() == replacement_head
+        assert len(state.post_payloads) == 1
+    finally:
+        server.shutdown()
+        thread.join()
+        server.server_close()
 
 
 def test_job_injects_a_non_default_github_api_base_without_baking_it_into_script(
@@ -255,7 +1248,7 @@ def test_publish_script_executes_redaction_and_the_assertion_catches_a_mutation(
         _assert_script_redacts_authorization(mutation)
 
 
-def test_job_retries_rest_by_querying_deterministic_head_before_posting_again(
+def test_absent_pull_job_queries_stored_lineage_head_before_posting_once(
     publication_k8s: Any,
 ) -> None:
     script = _resources(publication_k8s).config_map["data"]["publish.sh"]
@@ -265,86 +1258,6 @@ def test_job_retries_rest_by_querying_deterministic_head_before_posting_again(
     assert lookup < post
     assert "CURIE_PR_URL=" in script
     assert "urllib" in script or "http.client" in script
-
-
-def _run_job_pull_validator(
-    script: str, row: dict[str, object]
-) -> subprocess.CompletedProcess[str]:
-    start = script.index("def validate_pull(")
-    end = script.index("\ndef existing(", start)
-    validator = script[start:end]
-    program = f"""
-import json
-import os
-import sys
-repo = {json.dumps('acme-corp/acme-bot')}
-branch = {json.dumps('curie/publication-22222222222242228222222222222222')}
-{validator}
-print(validate_pull(json.loads(sys.stdin.read()), "main"))
-"""
-    return subprocess.run(
-        [sys.executable, "-c", program],
-        input=json.dumps(row),
-        text=True,
-        capture_output=True,
-        env={
-            "PR_TITLE": "Update repository",
-            "PR_BODY": "Approved platform publication.",
-        },
-        check=False,
-    )
-
-
-def _job_pull_row() -> dict[str, object]:
-    return {
-        "html_url": "https://github.com/acme-corp/acme-bot/pull/123",
-        "title": "Update repository",
-        "body": "Approved platform publication.",
-        "head": {
-            "ref": "curie/publication-22222222222242228222222222222222",
-            "repo": {"full_name": "acme-corp/acme-bot"},
-        },
-        "base": {"ref": "main", "repo": {"full_name": "acme-corp/acme-bot"}},
-    }
-
-
-@pytest.mark.parametrize(
-    ("field", "value"),
-    (("title", "Mutated title"), ("body", "Mutated body")),
-)
-def test_job_rejects_mutated_pull_request_metadata(
-    publication_k8s: Any,
-    field: str,
-    value: str,
-) -> None:
-    script = _resources(publication_k8s).config_map["data"]["publish.sh"]
-    valid = _run_job_pull_validator(script, _job_pull_row())
-    assert valid.returncode == 0, valid.stderr
-
-    mutated = _job_pull_row()
-    mutated[field] = value
-    rejected = _run_job_pull_validator(script, mutated)
-
-    assert rejected.returncode != 0
-    assert "approved publication contract" in rejected.stderr
-
-
-def test_job_accepts_github_canonical_repository_casing(publication_k8s: Any) -> None:
-    script = _resources(publication_k8s).config_map["data"]["publish.sh"]
-    row = _job_pull_row()
-    row["html_url"] = "https://github.com/Acme-Corp/Acme-Bot/pull/123"
-    row["head"] = {
-        "ref": "curie/publication-22222222222242228222222222222222",
-        "repo": {"full_name": "Acme-Corp/Acme-Bot"},
-    }
-    row["base"] = {
-        "ref": "main",
-        "repo": {"full_name": "Acme-Corp/Acme-Bot"},
-    }
-
-    accepted = _run_job_pull_validator(script, row)
-
-    assert accepted.returncode == 0, accepted.stderr
 
 
 def test_every_dynamic_resource_has_the_helm_owner_reference(
@@ -522,7 +1435,7 @@ def test_observe_reads_logs_only_from_a_pod_owned_by_the_exact_job(
         log_reads.append(name)
         if name == "hostile-pod":
             return "CURIE_PR_URL=https://github.com/attacker/repo/pull/1"
-        return "CURIE_PR_URL=https://github.com/acme-corp/acme-bot/pull/123"
+        return _terminal_markers("closed", REVISION_HEAD)
 
     cluster._core = SimpleNamespace(
         list_namespaced_pod=lambda *_args, **_kwargs: SimpleNamespace(
@@ -535,6 +1448,9 @@ def test_observe_reads_logs_only_from_a_pod_owned_by_the_exact_job(
 
     assert log_reads == ["owned-pod"]
     assert observed.pr_url == "https://github.com/acme-corp/acme-bot/pull/123"
+    assert observed.pr_number == 123
+    assert observed.commit_sha == REVISION_HEAD
+    assert observed.pr_state == "closed"
 
 
 def test_observe_reads_terminal_status_from_dict_shaped_kubernetes_objects(

--- a/apps/worker/tests/test_publication_loop.py
+++ b/apps/worker/tests/test_publication_loop.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import importlib
 import logging
+import os
 import threading
 import uuid
 from types import SimpleNamespace
@@ -14,7 +15,15 @@ import pytest
 from channel_protocol import scoped_conversation_id
 from channel_protocol.reply import ReplyAck, ReplyTarget
 from curie_worker.approval_cards import ApprovalCardRef
+from curie_worker.publication_loop import PublicationReconcileError
+from curie_worker.publication_store import (
+    PostgresPublicationStore,
+    PublicationStoreError,
+)
 from curie_worker.reply_sink import TargetRoute
+from sqlalchemy import text
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
 PUBLICATION_ID = uuid.UUID("22222222-2222-4222-8222-222222222222")
 APPROVAL_ID = uuid.UUID("33333333-3333-4333-8333-333333333333")
@@ -25,6 +34,15 @@ RESOLUTION_NOTE = "Ready to publish."
 CONVERSATION_ID = "1700000000.000100"
 WORKSPACE_CONVERSATION_ID = scoped_conversation_id(
     "slack", "C0EXAMPLE1", CONVERSATION_ID
+)
+LINEAGE_ID = uuid.UUID("55555555-5555-4555-8555-555555555555")
+REVISION_ID = uuid.UUID("44444444-4444-4444-8444-444444444444")
+LINEAGE_BRANCH = "curie/thread-lineage-example"
+PRIOR_HEAD = "a" * 40
+REVISION_HEAD = "b" * 40
+_DB_URL = os.environ.get(
+    "TEST_DATABASE_URL",
+    "postgresql+asyncpg://postgres:postgres@localhost:25432/postgres",
 )
 
 pytestmark = pytest.mark.anyio
@@ -60,6 +78,9 @@ class _Store:
         self.cleanup_claimed: set[uuid.UUID] = set()
         self.cleanup_completed: set[uuid.UUID] = set()
         self.cleanup_retries: list[tuple[uuid.UUID, str]] = []
+        self.lineage_advances: list[dict[str, Any]] = []
+        self.lineage_terminals: list[dict[str, Any]] = []
+        self.history_ready: set[uuid.UUID] = set()
 
     def claim_pending_card(self) -> Any | None:
         return self.card_pending
@@ -142,6 +163,7 @@ class _Store:
         outcome: str,
         pr_url: str | None,
         error: str | None,
+        **lineage: Any,
     ) -> None:
         self.completed[publication_id] = (outcome, pr_url)
         if outcome == "failed" and error is not None:
@@ -155,10 +177,15 @@ class _Store:
         }
         if outcome in {"published", "failed"}:
             self.cleanup_pending.add(publication_id)
+        if lineage:
+            self.lineage_advances.append(dict(lineage))
 
     def mark_result_delivered(self, publication_id: uuid.UUID) -> None:
         self.delivered.add(publication_id)
         self.pending.pop(publication_id, None)
+
+    def mark_outcome_history_ready(self, publication_id: uuid.UUID) -> None:
+        self.history_ready.add(publication_id)
 
     def retry_result_delivery(self, publication_id: uuid.UUID, *, error: str) -> None:
         self.delivery_retries.append((publication_id, error))
@@ -174,6 +201,29 @@ class _Store:
                 "error": error,
             }
             self.cleanup_pending.add(publication_id)
+
+    def mark_lineage_terminal(
+        self,
+        lineage_id: uuid.UUID,
+        *,
+        expected_version: int,
+        expected_stored_head: str | None,
+        state: str,
+        pr_number: int,
+        pr_url: str,
+        head_sha: str,
+    ) -> None:
+        self.lineage_terminals.append(
+            {
+                "lineage_id": lineage_id,
+                "expected_version": expected_version,
+                "expected_stored_head": expected_stored_head,
+                "state": state,
+                "pr_number": pr_number,
+                "pr_url": pr_url,
+                "head_sha": head_sha,
+            }
+        )
 
     async def claim_next(self) -> None:
         return None
@@ -202,7 +252,14 @@ class _Cluster:
         self.credentials_cleaned: list[Any] = []
         self.terminals_cleaned: list[Any] = []
         self.observation = module.PublicationJobObservation(
-            phase="succeeded", pr_url=PR_URL, logs=f"CURIE_PR_URL={PR_URL}\n"
+            phase="succeeded",
+            pr_url=PR_URL,
+            pr_number=123,
+            commit_sha=REVISION_HEAD,
+            logs=(
+                f"CURIE_PR_URL={PR_URL}\n"
+                f"CURIE_PR_NUMBER=123\nCURIE_COMMIT_SHA={REVISION_HEAD}\n"
+            ),
         )
         self.preexisting_observation: Any | None = None
         self.raise_after_apply = False
@@ -211,6 +268,7 @@ class _Cluster:
         self.terminal_cleanup_fail_once = False
         self.terminal_cleanup_failures_remaining = 0
         self.validated_existing: list[Any] = []
+        self.active_jobs: set[str] = set()
         self.observe_release: threading.Event | None = None
         self.observe_timed_out = False
 
@@ -218,12 +276,15 @@ class _Cluster:
         self.applied.append(resources)
         if self.apply_error is not None:
             raise self.apply_error
+        self.active_jobs.add(resources.names.job)
         if self.raise_after_apply:
             self.raise_after_apply = False
             raise RuntimeError("worker stopped after apiserver accepted resources")
 
     def validate_existing(self, resources: Any) -> None:
         self.validated_existing.append(resources)
+        if self.apply_error is not None:
+            raise self.apply_error
 
     def observe(self, job_name: str) -> Any:
         if self.observe_release is not None and not self.observe_release.wait(
@@ -232,7 +293,7 @@ class _Cluster:
             self.observe_timed_out = True
         if self.applied and self.observe_after_apply_error is not None:
             raise self.observe_after_apply_error
-        if not self.applied:
+        if job_name not in self.active_jobs:
             return self.preexisting_observation or self.module.PublicationJobObservation(
                 phase="pending", pr_url=None, logs="", exists=False
             )
@@ -253,12 +314,82 @@ class _Cluster:
             )
             raise RuntimeError("publication resource cleanup unavailable")
         self.terminals_cleaned.append(names)
+        self.active_jobs.discard(names.job)
 
 
 class _GitHub:
-    def __init__(self, recovered: str | None = None) -> None:
-        self.recovered = recovered
-        self.calls: list[tuple[str, str, str, str, str]] = []
+    def __init__(self) -> None:
+        self.number_calls: list[tuple[str, int]] = []
+        self.branch_calls: list[tuple[str, str]] = []
+        self.recover_calls: list[tuple[str, str, str]] = []
+        self.verify_calls: list[tuple[str, str, uuid.UUID, str]] = []
+        self.authorization_headers: list[str] = []
+        self.state = "open"
+        self.head_sha = PRIOR_HEAD
+        self.branch_head: str | None = None
+        self.recovered_pr_url = PR_URL
+        self.recovered_head_sha = REVISION_HEAD
+        self.recovered_pr_state = "open"
+        self.verified_revision_head: str | None = None
+        self.verified_revision_id: uuid.UUID | None = None
+        self.verified_expected_parent: str | None = None
+
+    def read_pr_by_number(
+        self,
+        repo_full_name: str,
+        pr_number: int,
+        authorization_header: str,
+    ) -> Any:
+        self.authorization_headers.append(authorization_header)
+        if not authorization_header:
+            raise AssertionError(
+                "GitHub lineage lookup happened before publication credential redemption"
+            )
+        self.number_calls.append((repo_full_name, pr_number))
+        return SimpleNamespace(
+            number=pr_number,
+            url=PR_URL,
+            state=self.state,
+            head_sha=self.head_sha,
+            head_ref=LINEAGE_BRANCH,
+        )
+
+    def verify_revision_commit(
+        self,
+        repo_full_name: str,
+        commit_sha: str,
+        *,
+        revision_id: uuid.UUID,
+        expected_parent: str,
+        authorization_header: str,
+    ) -> str:
+        self.authorization_headers.append(authorization_header)
+        if not authorization_header:
+            raise AssertionError(
+                "GitHub revision verification happened before credential redemption"
+            )
+        self.verify_calls.append(
+            (repo_full_name, commit_sha, revision_id, expected_parent)
+        )
+        if (
+            commit_sha != self.verified_revision_head
+            or revision_id != self.verified_revision_id
+            or expected_parent != self.verified_expected_parent
+        ):
+            raise PublicationReconcileError(
+                "remote head is not this revision's marked commit with expected parent"
+            )
+        return commit_sha
+
+    def read_branch_head(
+        self,
+        repo_full_name: str,
+        branch: str,
+        authorization_header: str,
+    ) -> str | None:
+        self.authorization_headers.append(authorization_header)
+        self.branch_calls.append((repo_full_name, branch))
+        return self.branch_head
 
     def recover_pr_by_head(
         self,
@@ -266,10 +397,32 @@ class _GitHub:
         branch: str,
         title: str,
         body: str,
+        *,
+        expected_head_sha: str,
         authorization_header: str,
-    ) -> str | None:
-        self.calls.append((repo_full_name, branch, title, body, authorization_header))
-        return self.recovered
+    ) -> Any | None:
+        self.authorization_headers.append(authorization_header)
+        self.recover_calls.append((repo_full_name, branch, expected_head_sha))
+        if expected_head_sha != self.recovered_head_sha:
+            raise PublicationReconcileError(
+                "recoverable pull request head does not match the expected commit"
+            )
+        if self.recovered_pr_url is None:
+            return None
+        return SimpleNamespace(
+            number=123,
+            url=self.recovered_pr_url,
+            state=self.recovered_pr_state,
+            head_sha=self.recovered_head_sha,
+            head_ref=LINEAGE_BRANCH,
+        )
+
+    def allow_exact_revision(
+        self, commit_sha: str, revision_id: uuid.UUID, expected_parent: str
+    ) -> None:
+        self.verified_revision_head = commit_sha
+        self.verified_revision_id = revision_id
+        self.verified_expected_parent = expected_parent
 
 
 class _Replies:
@@ -367,6 +520,9 @@ class _Transcript:
         self.records.append((agent_id, conversation_id, publication_id, text))
 
 
+_DEFAULT_TRANSCRIPT = object()
+
+
 def _card() -> ApprovalCardRef:
     return ApprovalCardRef(
         channel="C0EXAMPLE1",
@@ -391,7 +547,16 @@ def _work(module: Any, *, decision: str = "approved", kind: str = "slack") -> An
         publication_id=PUBLICATION_ID,
         approval_id=APPROVAL_ID,
         decision=decision,
+        lineage_id=LINEAGE_ID,
+        lineage_version=1,
+        revision_id=REVISION_ID,
+        revision_number=1,
         repo_full_name="acme-corp/acme-bot",
+        branch=LINEAGE_BRANCH,
+        pr_number=None,
+        pr_url=None,
+        expected_prior_head=PRIOR_HEAD,
+        expected_remote_head=None,
         base_sha="a" * 40,
         patch=b"diff --git a/README.md b/README.md\n",
         changed_paths=("README.md",),
@@ -402,6 +567,42 @@ def _work(module: Any, *, decision: str = "approved", kind: str = "slack") -> An
             endpoint=None if kind == "slack" else "https://adapter.example.com/replies",
             adapter=None if kind == "slack" else "agentmail-sandbox",
         ),
+        version=1,
+    )
+
+
+def _lineage_work(
+    module: Any,
+    *,
+    publication_id: uuid.UUID = PUBLICATION_ID,
+    revision_id: uuid.UUID = REVISION_ID,
+    revision_number: int = 2,
+    decision: str = "approved",
+    pr_number: int | None = 123,
+    pr_url: str | None = PR_URL,
+    expected_prior_head: str | None = PRIOR_HEAD,
+) -> Any:
+    return module.PublicationWork(
+        publication_id=publication_id,
+        approval_id=APPROVAL_ID,
+        decision=decision,
+        lineage_id=LINEAGE_ID,
+        lineage_version=2,
+        revision_id=revision_id,
+        revision_number=revision_number,
+        repo_full_name="acme-corp/acme-bot",
+        branch=LINEAGE_BRANCH,
+        pr_number=pr_number,
+        pr_url=pr_url,
+        expected_prior_head=expected_prior_head,
+        expected_remote_head=(expected_prior_head if pr_number is not None else None),
+        base_sha=expected_prior_head or PRIOR_HEAD,
+        patch=b"diff --git a/README.md b/README.md\n",
+        changed_paths=("README.md",),
+        title="Update repository",
+        body="Approved platform publication.",
+        target=_target(),
+        route=TargetRoute(endpoint=None, adapter=None),
         version=1,
     )
 
@@ -427,7 +628,7 @@ def _card_work() -> Any:
 def _loop(
     module: Any,
     cards: _Cards | None = None,
-    transcript: _Transcript | None = None,
+    transcript: _Transcript | None | object = _DEFAULT_TRANSCRIPT,
 ) -> tuple[Any, _Store, _Credentials, _Cluster, _GitHub, _Replies]:
     k8s = importlib.import_module("curie_worker.publication_k8s")
     store = _Store()
@@ -436,6 +637,8 @@ def _loop(
     github = _GitHub()
     replies = _Replies()
     cards = cards or _Cards()
+    if transcript is _DEFAULT_TRANSCRIPT:
+        transcript = _Transcript()
     loop = module.PublicationReconciler(
         store=store,
         credentials=credentials,
@@ -443,7 +646,7 @@ def _loop(
         github=github,
         replies=replies,
         card_store=cards,
-        transcript=transcript,
+        transcript=transcript if isinstance(transcript, _Transcript) else None,
         job_settings=k8s.PublicationJobSettings(
             namespace="curie",
             runner_image="ghcr.io/curie-eng/curie-runner:v0.7.0",
@@ -463,6 +666,11 @@ def _loop(
         ),
     )
     return loop, store, credentials, cluster, github, replies
+
+
+def _job_env(resources: Any) -> dict[str, str]:
+    container = resources.job["spec"]["template"]["spec"]["containers"][0]
+    return {item["name"]: item["value"] for item in container["env"]}
 
 
 async def test_publication_card_outbox_posts_and_remembers_before_ack(
@@ -511,9 +719,11 @@ async def test_terminal_result_is_recorded_for_the_next_model_turn(
             f"Published the approved changes: {PR_URL}",
         )
     ]
-    assert PR_URL in replies.events[0][0].text
-    assert replies.events[0][0].target.address == "C0EXAMPLE1"
-    assert replies.events[0][0].target.conversation_id == CONVERSATION_ID
+    assert store.history_ready == {PUBLICATION_ID}
+    event = replies.events[0][0]
+    assert PR_URL in event.text
+    assert event.target.address == "C0EXAMPLE1"
+    assert event.target.conversation_id == CONVERSATION_ID
 
 
 async def test_transient_transcript_failure_delivers_and_settles_before_retry(
@@ -545,6 +755,7 @@ async def test_transient_transcript_failure_delivers_and_settles_before_retry(
     assert replies.events[1][0].settled.decision == "approved"
     assert cards.ref is None
     assert PUBLICATION_ID not in store.delivered
+    assert PUBLICATION_ID not in store.history_ready
     assert store.delivery_retries == [
         (
             PUBLICATION_ID,
@@ -555,12 +766,13 @@ async def test_transient_transcript_failure_delivers_and_settles_before_retry(
     assert await loop.deliver_pending_result(PUBLICATION_ID) is True
 
     assert PUBLICATION_ID in store.delivered
+    assert store.history_ready == {PUBLICATION_ID}
     assert len(transcript.records) == 1
     assert len(replies.events) == 3
     assert replies.events[2][0].settled is None
 
 
-async def test_transcript_capacity_refusal_cannot_veto_result_or_card(
+async def test_transcript_capacity_refusal_uses_compact_durable_outcome_before_ready(
     publication: Any,
 ) -> None:
     cards = _Cards()
@@ -586,7 +798,17 @@ async def test_transcript_capacity_refusal_cannot_veto_result_or_card(
     assert await loop.deliver_pending_result(PUBLICATION_ID) is True
 
     assert PUBLICATION_ID in store.delivered
+    assert store.history_ready == {PUBLICATION_ID}
     assert store.delivery_retries == []
+    assert transcript.records == [
+        (
+            AGENT_ID,
+            WORKSPACE_CONVERSATION_ID,
+            PUBLICATION_ID,
+            "Publication outcome: published. Details omitted because thread "
+            "history is at capacity.",
+        )
+    ]
     assert PR_URL in replies.events[0][0].text
     assert replies.events[1][0].settled.decision == "approved"
     assert cards.ref is None
@@ -597,7 +819,7 @@ async def test_missing_transcript_wiring_is_logged_loudly(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     with caplog.at_level(logging.ERROR, logger="curie_worker.publication_loop"):
-        _loop(publication)
+        _loop(publication, transcript=None)
 
     assert "publication transcript recording is not configured" in caplog.text
 
@@ -660,7 +882,8 @@ async def test_approved_publication_launches_job_and_reports_pr_url(
     resources = cluster.applied[0]
     assert resources.job["kind"] == "Job"
     assert PR_URL not in str(resources.secret), "the result is learned from the Job"
-    assert len(github.calls) == 1
+    assert github.number_calls == []
+    assert github.verify_calls == []
     assert store.completed == {PUBLICATION_ID: ("published", PR_URL)}
     assert cluster.credentials_cleaned == [resources.names]
     assert cluster.terminals_cleaned == [resources.names]
@@ -670,6 +893,141 @@ async def test_approved_publication_launches_job_and_reports_pr_url(
     assert PR_URL in event.text
     assert route == work.route
     assert not hasattr(loop, "runner") and not hasattr(loop, "model")
+
+
+async def test_two_approved_revisions_keep_one_lineage_branch_and_pull_number(
+    publication: Any,
+) -> None:
+    loop, store, credentials, cluster, github, _ = _loop(publication)
+    second_publication_id = uuid.UUID("66666666-6666-4666-8666-666666666666")
+    second_revision_id = uuid.UUID("77777777-7777-4777-8777-777777777777")
+    first = _lineage_work(publication)
+    cluster.observation = publication.PublicationJobObservation(
+        phase="succeeded",
+        pr_url=PR_URL,
+        pr_number=123,
+        commit_sha=REVISION_HEAD,
+        logs=(
+            f"CURIE_PR_URL={PR_URL}\n"
+            f"CURIE_PR_NUMBER=123\nCURIE_COMMIT_SHA={REVISION_HEAD}\n"
+        ),
+    )
+
+    await loop.reconcile(first)
+
+    github.head_sha = REVISION_HEAD
+    second_head = "c" * 40
+    cluster.observation = publication.PublicationJobObservation(
+        phase="succeeded",
+        pr_url=PR_URL,
+        pr_number=123,
+        commit_sha=second_head,
+        logs=(
+            f"CURIE_PR_URL={PR_URL}\n"
+            f"CURIE_PR_NUMBER=123\nCURIE_COMMIT_SHA={second_head}\n"
+        ),
+    )
+    second = _lineage_work(
+        publication,
+        publication_id=second_publication_id,
+        revision_id=second_revision_id,
+        revision_number=3,
+        expected_prior_head=REVISION_HEAD,
+    )
+
+    await loop.reconcile(second)
+
+    assert credentials.calls == [PUBLICATION_ID, second_publication_id]
+    assert github.number_calls == [
+        ("acme-corp/acme-bot", 123),
+        ("acme-corp/acme-bot", 123),
+    ]
+    assert github.authorization_headers == [
+        "Basic publication-write-credential-value",
+        "Basic publication-write-credential-value",
+    ]
+    assert len(cluster.applied) == 2
+    job_envs = [_job_env(resource) for resource in cluster.applied]
+    assert {env["BRANCH"] for env in job_envs} == {LINEAGE_BRANCH}
+    assert {env["PR_NUMBER"] for env in job_envs} == {"123"}
+    assert [env["REVISION_ID"] for env in job_envs] == [
+        str(REVISION_ID),
+        str(second_revision_id),
+    ]
+    assert [advance["new_head"] for advance in store.lineage_advances] == [
+        REVISION_HEAD,
+        second_head,
+    ]
+    assert store.completed == {
+        PUBLICATION_ID: ("published", PR_URL),
+        second_publication_id: ("published", PR_URL),
+    }
+
+
+async def test_denied_first_revision_leaves_absent_identity_for_later_create_path(
+    publication: Any,
+) -> None:
+    loop, store, credentials, cluster, github, _ = _loop(publication)
+    denied = _lineage_work(
+        publication,
+        decision="denied",
+        revision_number=1,
+        pr_number=None,
+        pr_url=None,
+    )
+
+    await loop.reconcile(denied)
+
+    assert credentials.calls == []
+    assert cluster.applied == []
+    assert github.number_calls == []
+
+    later = _lineage_work(
+        publication,
+        publication_id=uuid.UUID("66666666-6666-4666-8666-666666666666"),
+        revision_id=uuid.UUID("77777777-7777-4777-8777-777777777777"),
+        revision_number=2,
+        pr_number=None,
+        pr_url=None,
+    )
+    cluster.observation = publication.PublicationJobObservation(
+        phase="pending", pr_url=None, pr_number=None, commit_sha=None, logs=""
+    )
+
+    await loop.reconcile(later)
+
+    assert credentials.calls == [later.publication_id]
+    assert len(cluster.applied) == 1
+    env = _job_env(cluster.applied[0])
+    assert env["REVISION_NUMBER"] == "2"
+    assert env["PR_NUMBER"] == ""
+    assert env["EXPECTED_REMOTE_HEAD"] == ""
+
+
+async def test_foreign_remote_head_is_never_adopted_as_the_approved_revision(
+    publication: Any,
+) -> None:
+    loop, store, credentials, cluster, github, replies = _loop(publication)
+    github.head_sha = "d" * 40
+
+    await loop.reconcile(_lineage_work(publication))
+
+    assert credentials.calls == [PUBLICATION_ID]
+    assert github.number_calls == [("acme-corp/acme-bot", 123)]
+    assert github.verify_calls == [
+        ("acme-corp/acme-bot", "d" * 40, REVISION_ID, PRIOR_HEAD)
+    ]
+    assert github.authorization_headers == [
+        "Basic publication-write-credential-value",
+        "Basic publication-write-credential-value",
+    ]
+    assert cluster.applied == []
+    assert store.completed == {}
+    assert store.lineage_advances == []
+    assert replies.events == []
+    assert store.retries == [
+        (PUBLICATION_ID, "pull request head no longer matches the stored lineage head")
+    ]
 
 
 async def test_nonapproved_work_is_inert_in_the_job_reconciler(publication: Any) -> None:
@@ -682,7 +1040,7 @@ async def test_nonapproved_work_is_inert_in_the_job_reconciler(publication: Any)
     assert cluster.applied == []
     assert cluster.credentials_cleaned == []
     assert cluster.terminals_cleaned == []
-    assert github.calls == []
+    assert github.number_calls == []
     assert store.completed == {}
     assert replies.events == []
 
@@ -701,30 +1059,540 @@ async def test_worker_crash_reuses_the_same_job_and_cannot_duplicate_publication
     assert len(set(job_names)) == 1
     assert store.completed == {PUBLICATION_ID: ("published", PR_URL)}
     assert len(replies.events) == 1
-    assert len(github.calls) == 1
+    assert github.number_calls == []
 
 
-async def test_existing_remote_pr_is_adopted_before_recreating_a_missing_job(
+async def test_succeeded_job_retry_uses_validated_markers_without_a_second_credential(
     publication: Any,
 ) -> None:
-    loop, store, credentials, cluster, github, replies = _loop(publication)
-    github.recovered = PR_URL
+    """A rotated installation token cannot make a completed Job unadoptable."""
+
+    loop, store, credentials, cluster, _, replies = _loop(publication)
     work = _work(publication)
+    cluster.observation = publication.PublicationJobObservation(
+        phase="pending", pr_url=None, pr_number=None, commit_sha=None, logs=""
+    )
 
     await loop.reconcile(work)
 
-    branch = publication.deterministic_publication_branch(PUBLICATION_ID)
-    assert github.calls == [
+    cluster.observation = publication.PublicationJobObservation(
+        phase="succeeded",
+        pr_url=PR_URL,
+        pr_number=123,
+        commit_sha=REVISION_HEAD,
+        logs=(
+            f"CURIE_PR_URL={PR_URL}\n"
+            f"CURIE_PR_NUMBER=123\nCURIE_COMMIT_SHA={REVISION_HEAD}\n"
+        ),
+    )
+    await loop.reconcile(work)
+
+    assert credentials.calls == [PUBLICATION_ID]
+    assert len(cluster.applied) == 1
+    assert len(cluster.validated_existing) == 1
+    assert store.completed == {PUBLICATION_ID: ("published", PR_URL)}
+    assert len(replies.events) == 1
+
+
+async def test_ttl_deleted_first_revision_job_recovers_exact_marked_commit_and_pr(
+    publication: Any,
+) -> None:
+    """A distinct retry credential adopts GitHub truth after Job TTL deletion."""
+
+    class TtlCluster(_Cluster):
+        def __init__(self, module: Any) -> None:
+            super().__init__(module)
+            self.job_exists = False
+
+        def apply(self, resources: Any) -> None:
+            super().apply(resources)
+            self.job_exists = True
+
+        def observe(self, job_name: str) -> Any:
+            if not self.job_exists:
+                return self.module.PublicationJobObservation(
+                    phase="pending", pr_url=None, logs="", exists=False
+                )
+            return self.observation
+
+    class RotatingCredentials(_Credentials):
+        def redeem(self, publication_id: uuid.UUID) -> Any:
+            self.calls.append(publication_id)
+            ordinal = len(self.calls)
+            return self.module.PublicationCredential(
+                clean_clone_url="https://github.com/acme-corp/acme-bot.git",
+                authorization_header=f"Bearer rotated-installation-token-{ordinal}",
+            )
+
+    loop, store, _, _, github, replies = _loop(publication)
+    cluster = TtlCluster(publication)
+    credentials = RotatingCredentials(publication)
+    loop._cluster = cluster
+    loop._credentials = credentials
+    work = _work(publication)
+    cluster.observation = publication.PublicationJobObservation(
+        phase="pending", pr_url=None, pr_number=None, commit_sha=None, logs=""
+    )
+
+    await loop.reconcile(work)
+    assert len(cluster.applied) == 1
+
+    cluster.job_exists = False
+    github.branch_head = REVISION_HEAD
+    github.allow_exact_revision(REVISION_HEAD, REVISION_ID, PRIOR_HEAD)
+    await loop.reconcile(work)
+
+    assert credentials.calls == [PUBLICATION_ID, PUBLICATION_ID]
+    assert len(cluster.applied) == 1, "recovery must not recreate the publication Job"
+    assert github.branch_calls == [
+        ("acme-corp/acme-bot", LINEAGE_BRANCH),
+        ("acme-corp/acme-bot", LINEAGE_BRANCH),
+    ]
+    assert github.verify_calls == [
+        ("acme-corp/acme-bot", REVISION_HEAD, REVISION_ID, PRIOR_HEAD)
+    ]
+    assert github.recover_calls == [
+        ("acme-corp/acme-bot", LINEAGE_BRANCH, REVISION_HEAD)
+    ]
+    assert github.authorization_headers == [
+        "Bearer rotated-installation-token-1",
+        "Bearer rotated-installation-token-2",
+        "Bearer rotated-installation-token-2",
+        "Bearer rotated-installation-token-2",
+    ]
+    assert store.completed == {PUBLICATION_ID: ("published", PR_URL)}
+    assert store.lineage_advances[0]["pr_number"] == 123
+    assert store.lineage_advances[0]["new_head"] == REVISION_HEAD
+    assert len(replies.events) == 1
+
+
+async def test_first_revision_recovery_refuses_pr_head_replaced_after_commit_proof(
+    publication: Any,
+) -> None:
+    loop, store, credentials, cluster, github, replies = _loop(publication)
+    github.branch_head = REVISION_HEAD
+    github.allow_exact_revision(REVISION_HEAD, REVISION_ID, PRIOR_HEAD)
+    github.recovered_head_sha = "c" * 40
+
+    await loop.reconcile(_work(publication))
+
+    assert credentials.calls == [PUBLICATION_ID]
+    assert github.verify_calls == [
+        ("acme-corp/acme-bot", REVISION_HEAD, REVISION_ID, PRIOR_HEAD)
+    ]
+    assert github.recover_calls == [
+        ("acme-corp/acme-bot", LINEAGE_BRANCH, REVISION_HEAD)
+    ]
+    assert cluster.applied == []
+    assert store.completed == {}
+    assert store.lineage_advances == []
+    assert store.retries == [
         (
-            "acme-corp/acme-bot",
-            branch,
-            "Update repository",
-            "Approved platform publication.",
-            "Basic publication-write-credential-value",
+            PUBLICATION_ID,
+            "recoverable pull request head does not match the expected commit",
         )
+    ]
+    assert replies.events == []
+
+
+@pytest.mark.parametrize("terminal_state", ["closed", "merged"])
+async def test_first_revision_recovery_persists_terminal_pull_without_repost(
+    publication: Any,
+    terminal_state: str,
+) -> None:
+    loop, store, credentials, cluster, github, replies = _loop(publication)
+    github.branch_head = REVISION_HEAD
+    github.allow_exact_revision(REVISION_HEAD, REVISION_ID, PRIOR_HEAD)
+    github.recovered_pr_state = terminal_state
+
+    await loop.reconcile(_work(publication))
+
+    assert credentials.calls == [PUBLICATION_ID]
+    assert github.recover_calls == [
+        ("acme-corp/acme-bot", LINEAGE_BRANCH, REVISION_HEAD)
+    ]
+    assert store.lineage_terminals == [
+        {
+            "lineage_id": LINEAGE_ID,
+            "expected_version": 1,
+            "expected_stored_head": None,
+            "state": terminal_state,
+            "pr_number": 123,
+            "pr_url": PR_URL,
+            "head_sha": REVISION_HEAD,
+        }
+    ]
+    assert store.retries == [
+        (
+            PUBLICATION_ID,
+            f"pull request lineage is {terminal_state}; start a new thread",
+        )
+    ]
+    assert cluster.applied == []
+    assert store.completed == {}
+    assert store.lineage_advances == []
+    assert replies.events == []
+
+
+@pytest.mark.parametrize("terminal_state", ["closed", "merged"])
+async def test_stored_terminal_pull_never_adopts_a_foreign_replacement_head(
+    publication: Any,
+    terminal_state: str,
+) -> None:
+    loop, store, credentials, cluster, github, replies = _loop(publication)
+    foreign_head = "c" * 40
+    github.state = terminal_state
+    github.head_sha = foreign_head
+
+    await loop.reconcile(_lineage_work(publication))
+
+    assert credentials.calls == [PUBLICATION_ID]
+    assert github.verify_calls == [
+        ("acme-corp/acme-bot", foreign_head, REVISION_ID, PRIOR_HEAD)
+    ]
+    assert store.lineage_terminals == [
+        {
+            "lineage_id": LINEAGE_ID,
+            "expected_version": 2,
+            "expected_stored_head": PRIOR_HEAD,
+            "state": terminal_state,
+            "pr_number": 123,
+            "pr_url": PR_URL,
+            "head_sha": PRIOR_HEAD,
+        }
+    ]
+    assert store.retries == [
+        (
+            PUBLICATION_ID,
+            f"pull request lineage is {terminal_state}; start a new thread",
+        )
+    ]
+    assert cluster.applied == []
+    assert store.completed == {}
+    assert store.lineage_advances == []
+    assert replies.events == []
+
+
+async def test_stored_terminal_pull_accepts_an_exact_verified_revision_head(
+    publication: Any,
+) -> None:
+    loop, store, _, cluster, github, replies = _loop(publication)
+    github.state = "merged"
+    github.head_sha = REVISION_HEAD
+    github.allow_exact_revision(REVISION_HEAD, REVISION_ID, PRIOR_HEAD)
+
+    await loop.reconcile(_lineage_work(publication))
+
+    assert github.verify_calls == [
+        ("acme-corp/acme-bot", REVISION_HEAD, REVISION_ID, PRIOR_HEAD)
+    ]
+    assert store.lineage_terminals == [
+        {
+            "lineage_id": LINEAGE_ID,
+            "expected_version": 2,
+            "expected_stored_head": PRIOR_HEAD,
+            "state": "merged",
+            "pr_number": 123,
+            "pr_url": PR_URL,
+            "head_sha": REVISION_HEAD,
+        }
+    ]
+    assert cluster.applied == []
+    assert store.completed == {}
+    assert store.lineage_advances == []
+    assert replies.events == []
+
+
+@pytest.mark.parametrize("terminal_state", ["closed", "merged"])
+async def test_terminal_first_pr_job_marker_persists_lineage_without_recovery(
+    publication: Any,
+    terminal_state: str,
+) -> None:
+    loop, store, credentials, cluster, github, replies = _loop(publication)
+    cluster.preexisting_observation = publication.PublicationJobObservation(
+        phase="failed",
+        pr_url=PR_URL,
+        pr_number=123,
+        commit_sha=REVISION_HEAD,
+        pr_state=terminal_state,
+        logs=(
+            f"CURIE_PR_URL={PR_URL}\n"
+            "CURIE_PR_NUMBER=123\n"
+            f"CURIE_COMMIT_SHA={REVISION_HEAD}\n"
+            f"CURIE_PR_STATE={terminal_state}\n"
+        ),
+        error=f"stored pull request is {terminal_state}",
+    )
+
+    await loop.reconcile(_work(publication))
+
+    assert len(cluster.validated_existing) == 1
+    assert credentials.calls == []
+    assert github.branch_calls == []
+    assert github.recover_calls == []
+    assert store.lineage_terminals == [
+        {
+            "lineage_id": LINEAGE_ID,
+            "expected_version": 1,
+            "expected_stored_head": None,
+            "state": terminal_state,
+            "pr_number": 123,
+            "pr_url": PR_URL,
+            "head_sha": REVISION_HEAD,
+        }
+    ]
+    assert store.retries == [
+        (
+            PUBLICATION_ID,
+            f"pull request lineage is {terminal_state}; start a new thread",
+        )
+    ]
+    assert cluster.applied == []
+    assert store.completed == {}
+    assert store.lineage_advances == []
+    assert replies.events == []
+
+
+async def test_terminal_job_state_without_exact_facts_cannot_close_lineage(
+    publication: Any,
+) -> None:
+    loop, store, credentials, cluster, github, replies = _loop(publication)
+    cluster.preexisting_observation = publication.PublicationJobObservation(
+        phase="failed",
+        pr_url=None,
+        pr_number=None,
+        commit_sha=None,
+        pr_state="closed",
+        logs="CURIE_PR_STATE=closed\n",
+        error="stored pull request is closed",
+    )
+
+    await loop.reconcile(_work(publication))
+
+    assert store.lineage_terminals == []
+    assert store.retries == [
+        (
+            PUBLICATION_ID,
+            "publication Job terminal state omitted exact pull request facts",
+        )
+    ]
+    assert credentials.calls == []
+    assert github.recover_calls == []
+    assert store.completed == {}
+    assert store.lineage_advances == []
+    assert replies.events == []
+
+
+async def test_terminal_job_reconcile_replay_is_idempotent_in_real_store(
+    publication: Any,
+) -> None:
+    engine: AsyncEngine = create_async_engine(_DB_URL)
+    schema: str | None = None
+    try:
+        try:
+            async with engine.connect():
+                pass
+        except SQLAlchemyError as exc:
+            pytest.skip(f"Postgres not reachable at {_DB_URL}: {exc}")
+
+        schema = f"test_publication_{uuid.uuid4().hex}"
+        durable = PostgresPublicationStore(
+            engine,
+            schema=schema,
+            lease_owner="terminal-replay-test",
+        )
+        async with engine.begin() as connection:
+            await connection.execute(text(f'CREATE SCHEMA "{schema}"'))
+            await connection.execute(
+                text(
+                    f'CREATE TABLE "{schema}".thread_publication_lineages ('
+                    "id uuid PRIMARY KEY, pr_number integer, pr_url text, "
+                    "head_sha text, status text NOT NULL, version integer NOT NULL, "
+                    "updated_at timestamp NOT NULL DEFAULT now())"
+                )
+            )
+            await connection.execute(
+                text(
+                    f'INSERT INTO "{schema}".thread_publication_lineages '
+                    "(id, pr_number, pr_url, head_sha, status, version) "
+                    "VALUES (:id, 123, :pr_url, :head_sha, 'open', 2)"
+                ),
+                {"id": LINEAGE_ID, "pr_url": PR_URL, "head_sha": PRIOR_HEAD},
+            )
+
+        class RealTerminalStore(_Store):
+            async def mark_lineage_terminal(
+                self,
+                lineage_id: uuid.UUID,
+                *,
+                expected_version: int,
+                expected_stored_head: str | None,
+                state: str,
+                pr_number: int,
+                pr_url: str,
+                head_sha: str,
+            ) -> None:
+                await durable.mark_lineage_terminal(
+                    lineage_id,
+                    expected_version=expected_version,
+                    expected_stored_head=expected_stored_head,
+                    state=state,
+                    pr_number=pr_number,
+                    pr_url=pr_url,
+                    head_sha=head_sha,
+                )
+
+        loop, _, credentials, cluster, github, replies = _loop(publication)
+        store = RealTerminalStore()
+        loop._store = store
+        cluster.preexisting_observation = publication.PublicationJobObservation(
+            phase="failed",
+            pr_url=PR_URL,
+            pr_number=123,
+            commit_sha=REVISION_HEAD,
+            pr_state="merged",
+            logs=(
+                f"CURIE_PR_URL={PR_URL}\n"
+                "CURIE_PR_NUMBER=123\n"
+                f"CURIE_COMMIT_SHA={REVISION_HEAD}\n"
+                "CURIE_PR_STATE=merged\n"
+            ),
+            error="stored pull request is merged",
+        )
+        work = _lineage_work(publication)
+
+        await loop.reconcile(work)
+        await loop.reconcile(work)
+
+        async with engine.connect() as connection:
+            row = (
+                await connection.execute(
+                    text(
+                        f'SELECT status, pr_number, pr_url, head_sha, version '
+                        f'FROM "{schema}".thread_publication_lineages WHERE id = :id'
+                    ),
+                    {"id": LINEAGE_ID},
+                )
+            ).mappings().one()
+        assert dict(row) == {
+            "status": "merged",
+            "pr_number": 123,
+            "pr_url": PR_URL,
+            "head_sha": REVISION_HEAD,
+            "version": 3,
+        }
+        assert len(store.retries) == 2
+        assert credentials.calls == []
+        assert github.recover_calls == []
+        assert store.completed == {}
+        assert store.lineage_advances == []
+        assert replies.events == []
+
+        for conflict_state, conflict_head in (
+            ("closed", REVISION_HEAD),
+            ("merged", "c" * 40),
+        ):
+            with pytest.raises(PublicationStoreError, match="terminal CAS was lost"):
+                await durable.mark_lineage_terminal(
+                    LINEAGE_ID,
+                    expected_version=2,
+                    expected_stored_head=PRIOR_HEAD,
+                    state=conflict_state,
+                    pr_number=123,
+                    pr_url=PR_URL,
+                    head_sha=conflict_head,
+                )
+
+        concurrent_id = uuid.uuid4()
+        foreign_head = "d" * 40
+        async with engine.begin() as connection:
+            await connection.execute(
+                text(
+                    f'INSERT INTO "{schema}".thread_publication_lineages '
+                    "(id, pr_number, pr_url, head_sha, status, version) "
+                    "VALUES (:id, 123, :pr_url, :head_sha, 'open', 2)"
+                ),
+                {"id": concurrent_id, "pr_url": PR_URL, "head_sha": foreign_head},
+            )
+        with pytest.raises(PublicationStoreError, match="terminal CAS was lost"):
+            await durable.mark_lineage_terminal(
+                concurrent_id,
+                expected_version=2,
+                expected_stored_head=PRIOR_HEAD,
+                state="closed",
+                pr_number=123,
+                pr_url=PR_URL,
+                head_sha=PRIOR_HEAD,
+            )
+        async with engine.connect() as connection:
+            concurrent = (
+                await connection.execute(
+                    text(
+                        f'SELECT status, head_sha, version FROM "{schema}".'
+                        "thread_publication_lineages WHERE id = :id"
+                    ),
+                    {"id": concurrent_id},
+                )
+            ).mappings().one()
+        assert dict(concurrent) == {
+            "status": "open",
+            "head_sha": foreign_head,
+            "version": 2,
+        }
+    finally:
+        if schema is not None:
+            async with engine.begin() as connection:
+                await connection.execute(text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
+        await engine.dispose()
+
+
+async def test_missing_job_never_overwrites_an_unmarked_lineage_branch_head(
+    publication: Any,
+) -> None:
+    loop, store, credentials, cluster, github, replies = _loop(publication)
+    github.branch_head = "d" * 40
+
+    await loop.reconcile(_work(publication))
+
+    assert credentials.calls == [PUBLICATION_ID]
+    assert github.verify_calls == [
+        ("acme-corp/acme-bot", "d" * 40, REVISION_ID, PRIOR_HEAD)
+    ]
+    assert github.recover_calls == []
+    assert cluster.applied == []
+    assert store.completed == {}
+    assert store.lineage_advances == []
+    assert store.retries == [
+        (
+            PUBLICATION_ID,
+            "remote head is not this revision's marked commit with expected parent",
+        )
+    ]
+    assert replies.events == []
+
+
+async def test_exact_marked_remote_revision_is_adopted_before_recreating_a_missing_job(
+    publication: Any,
+) -> None:
+    loop, store, credentials, cluster, github, replies = _loop(publication)
+    github.head_sha = REVISION_HEAD
+    github.allow_exact_revision(REVISION_HEAD, REVISION_ID, PRIOR_HEAD)
+    work = _lineage_work(publication)
+
+    await loop.reconcile(work)
+
+    assert credentials.calls == [PUBLICATION_ID]
+    assert github.number_calls == [("acme-corp/acme-bot", 123)]
+    assert github.verify_calls == [
+        ("acme-corp/acme-bot", REVISION_HEAD, REVISION_ID, PRIOR_HEAD)
+    ]
+    assert github.authorization_headers == [
+        "Basic publication-write-credential-value",
+        "Basic publication-write-credential-value",
     ]
     assert cluster.applied == [], "remote adoption must happen before a replacement Job"
     assert store.completed == {PUBLICATION_ID: ("published", PR_URL)}
+    assert store.lineage_advances[0]["new_head"] == REVISION_HEAD
     assert PR_URL in replies.events[0][0].text
 
 
@@ -843,7 +1711,7 @@ async def test_only_exact_approved_decision_can_redeem_write_credential(
         await loop.reconcile(_work(publication, decision=decision))
         assert credentials.calls == [], decision
         assert cluster.applied == [], decision
-        assert github.calls == [], decision
+        assert github.number_calls == [], decision
 
 
 async def test_terminal_result_is_persisted_and_credentials_removed_before_reply_retry(
@@ -938,23 +1806,33 @@ async def test_supervisor_drains_terminal_result_outbox_without_job_work(
 
 
 @pytest.mark.parametrize("phase", ["failed", "succeeded"])
-async def test_terminal_job_recovers_remote_branch_or_lost_rest_response_before_failure(
+async def test_terminal_job_recovers_exact_marked_revision_after_lost_response(
     publication: Any,
     phase: str,
 ) -> None:
     loop, store, credentials, cluster, github, replies = _loop(publication)
-    github.recovered = PR_URL
+    github.head_sha = REVISION_HEAD
+    github.allow_exact_revision(REVISION_HEAD, REVISION_ID, PRIOR_HEAD)
     cluster.preexisting_observation = publication.PublicationJobObservation(
         phase=phase,
         pr_url=None,
+        pr_number=None,
+        commit_sha=None,
         logs="publication process exited without a marker\n",
         error="job process exited" if phase == "failed" else None,
     )
 
-    await loop.reconcile(_work(publication))
+    await loop.reconcile(_lineage_work(publication))
 
     assert credentials.calls == [PUBLICATION_ID]
-    assert len(github.calls) == 1
+    assert github.number_calls == [("acme-corp/acme-bot", 123)]
+    assert github.verify_calls == [
+        ("acme-corp/acme-bot", REVISION_HEAD, REVISION_ID, PRIOR_HEAD)
+    ]
+    assert github.authorization_headers == [
+        "Basic publication-write-credential-value",
+        "Basic publication-write-credential-value",
+    ]
     assert cluster.applied == []
     assert store.completed == {PUBLICATION_ID: ("published", PR_URL)}
     assert PR_URL in replies.events[0][0].text
@@ -972,7 +1850,7 @@ async def test_running_job_is_validated_without_redeeming_another_credential(
 
     assert len(cluster.validated_existing) == 1
     assert credentials.calls == []
-    assert github.calls == []
+    assert github.number_calls == []
     assert cluster.applied == []
     assert store.completed == {}
     assert replies.events == []
@@ -1019,7 +1897,7 @@ async def test_credential_setup_failure_is_bounded_and_terminalized(publication:
         (PUBLICATION_ID, "publication credential endpoint is unreachable")
     ]
     assert cluster.applied == []
-    assert github.calls == []
+    assert github.number_calls == []
     assert "failed safely" in replies.events[0][0].text.lower()
 
 
@@ -1059,7 +1937,8 @@ async def test_unvalidated_terminal_marker_cannot_bypass_resource_adoption(
 
     await loop.reconcile(_work(publication))
 
-    assert len(cluster.applied) == 1
+    assert len(cluster.validated_existing) == 1
+    assert cluster.applied == []
     assert store.completed == {}
     assert len(store.retries) == 1
     assert replies.events == []

--- a/apps/worker/tests/test_workspace.py
+++ b/apps/worker/tests/test_workspace.py
@@ -57,6 +57,7 @@ class _FakeCommands:
         self.events: list[str] = []
         self.available = True
         self.fail_stage: str | None = None
+        self.head_sha = "a" * 40
 
     def require(self, executable: str) -> None:
         self.calls.append({"require": executable})
@@ -96,6 +97,15 @@ class _FakeCommands:
             (checkout / "README.md").write_text("workspace ready\n")
             return _CommandResult()
 
+        if "fetch" in args:
+            self.events.append("fetch-exact")
+            return _CommandResult()
+
+        if "checkout" in args and "--detach" in args:
+            self.events.append("checkout-detached")
+            self.head_sha = args[-1]
+            return _CommandResult()
+
         if "remote" in args and "set-url" in args:
             self.events.append("set-url")
             assert cwd is not None
@@ -111,7 +121,7 @@ class _FakeCommands:
             return _CommandResult(stdout=f"{value}\n")
 
         if "rev-parse" in args:
-            return _CommandResult(stdout=f"{'a' * 40}\n")
+            return _CommandResult(stdout=f"{self.head_sha}\n")
 
         raise AssertionError(f"unexpected command: {args}")
 
@@ -304,6 +314,89 @@ def test_clone_is_private_full_blob_shallow_and_refuses_redirects(
     assert "http.followRedirects=false" in config_entries
     assert GIT_CREDENTIAL in config_entries
     assert stat.S_IMODE(prepared.checkout_mode) == 0o700
+
+
+def test_lineage_prepare_clones_the_stored_branch_at_the_exact_expected_head(
+    workspace: Any, tmp_path: Path
+) -> None:
+    """A revision starts from the PR head, not the repository default branch."""
+
+    expected_head = "a" * 40
+    branch = "curie/thread-lineage-example"
+    preparer, commands, objects = _preparer(workspace, tmp_path)
+
+    prepared = preparer.prepare_lineage(
+        deployment_id=DEPLOYMENT_ID,
+        thread_key="1700000000.000100",
+        generation="lineage-claim-2",
+        branch=branch,
+        expected_head=expected_head,
+    )
+
+    clone_call = next(call for call in commands.calls if "clone" in call.get("argv", []))
+    assert clone_call["argv"][:2] == ["git", "clone"]
+    assert "--depth=1" in clone_call["argv"]
+    assert "--single-branch" in clone_call["argv"]
+    assert clone_call["argv"][clone_call["argv"].index("--branch") + 1] == branch
+    assert prepared.materialized_head == expected_head
+    assert objects.objects[prepared.object_key]
+    assert GIT_CREDENTIAL.encode() not in objects.objects[prepared.object_key]
+
+
+def test_lineage_prepare_refuses_a_checkout_head_mismatch_before_upload(
+    workspace: Any, tmp_path: Path
+) -> None:
+    commands = _FakeCommands()
+    commands.head_sha = "b" * 40
+    preparer, _, objects = _preparer(workspace, tmp_path, commands=commands)
+
+    with pytest.raises(workspace.WorkspacePreparationError, match="expected lineage head"):
+        preparer.prepare_lineage(
+            deployment_id=DEPLOYMENT_ID,
+            thread_key="1700000000.000100",
+            generation="lineage-claim-stale",
+            branch="curie/thread-lineage-example",
+            expected_head="a" * 40,
+        )
+
+    assert objects.objects == {}
+
+
+def test_headless_lineage_prepare_fetches_exact_base_not_advanced_default(
+    workspace: Any, tmp_path: Path
+) -> None:
+    """A denied first revision rehydrates at its proposal base without a PR branch."""
+
+    expected_base = "a" * 40
+    commands = _FakeCommands()
+    commands.head_sha = "d" * 40
+    preparer, _, objects = _preparer(workspace, tmp_path, commands=commands)
+
+    prepared = preparer.prepare_lineage_base(
+        deployment_id=DEPLOYMENT_ID,
+        thread_key="1700000000.000100",
+        generation="headless-lineage-outcome-1",
+        expected_base=expected_base,
+    )
+
+    clone_call = next(call for call in commands.calls if "clone" in call.get("argv", []))
+    fetch_call = next(call for call in commands.calls if "fetch" in call.get("argv", []))
+    checkout_call = next(call for call in commands.calls if "checkout" in call.get("argv", []))
+    assert "--branch" not in clone_call["argv"]
+    assert fetch_call["argv"] == [
+        "git",
+        "fetch",
+        "--depth=1",
+        "--no-tags",
+        "origin",
+        expected_base,
+    ]
+    assert checkout_call["argv"] == ["git", "checkout", "--detach", expected_base]
+    assert GIT_CREDENTIAL in fetch_call["env"]["GIT_CONFIG_VALUE_1"]
+    assert GIT_CREDENTIAL not in " ".join(fetch_call["argv"])
+    assert prepared.base_sha == expected_base
+    assert prepared.materialized_head == expected_base
+    assert objects.objects[prepared.object_key]
 
 
 def test_internal_workspace_redemption_uses_only_worker_auth_and_deployment_id(
@@ -786,6 +879,8 @@ class _RecordingSubstrate:
         expected: object,
         env: dict[str, str] | None = None,
         workspace_repo: str,
+        workspace_materialized_head: str | None = None,
+        publication_visible_outcome_revision: int = 0,
         agent_name: str | None = None,
         validate_candidate: Callable[[object], None] | None = None,
     ) -> object:
@@ -798,6 +893,8 @@ class _RecordingSubstrate:
                 "expected": expected,
                 "env": payload,
                 "workspace_repo": workspace_repo,
+                "workspace_materialized_head": workspace_materialized_head,
+                "publication_visible_outcome_revision": publication_visible_outcome_revision,
                 "agent_name": agent_name,
                 "candidate": candidate,
             }
@@ -957,6 +1054,7 @@ def test_late_handoff_uses_substrate_handoff_and_keeps_credentials_out_of_claim_
         agent_name="acme-bot",
         repo_full_name="acme-corp/acme-bot",
         replace_handle=old_handle,
+        publication_visible_outcome_revision=2,
         revalidate_before_handoff=lambda: ordering.append("revalidated"),
     )
 
@@ -966,6 +1064,8 @@ def test_late_handoff_uses_substrate_handoff_and_keeps_credentials_out_of_claim_
     handoff = substrate.handoff_calls[0]
     assert handoff["expected"] is old_handle
     assert handoff["workspace_repo"] == "acme-corp/acme-bot"
+    assert handoff["workspace_materialized_head"] == result.prepared.materialized_head
+    assert handoff["publication_visible_outcome_revision"] == 2
     assert handoff["agent_name"] == "acme-bot"
     workspace_env = result.prepared.claim_env()
     assert handoff["env"]["CURIE_WORKSPACE_REF"] == workspace_env["CURIE_WORKSPACE_REF"]
@@ -992,6 +1092,41 @@ def test_late_handoff_uses_substrate_handoff_and_keeps_credentials_out_of_claim_
         for marker in ("AUTHORIZATION", "PASSWORD", "SECRET")
         if name != "CURIE_RUNNER_TOKEN"
     )
+
+
+def test_headless_lineage_claim_owns_original_base_for_later_publication(
+    workspace: Any, tmp_path: Path
+) -> None:
+    expected_base = "a" * 40
+    commands = _FakeCommands()
+    commands.head_sha = "d" * 40
+    preparer, _, _objects = _preparer(workspace, tmp_path, commands=commands)
+    observed: list[dict[str, object]] = []
+
+    class Substrate(_RecordingSubstrate):
+        def claim(self, thread_key: str, **kwargs: object) -> object:
+            observed.append({"thread_key": thread_key, **kwargs})
+            return super().claim(thread_key, **kwargs)
+
+    substrate = Substrate()
+    coordinator = workspace.WorkspaceClaimCoordinator(
+        preparer=preparer,
+        substrate=substrate,
+    )
+
+    result = coordinator.claim_or_resume_with_handle(
+        thread_key="1700000000.000100",
+        deployment_id=DEPLOYMENT_ID,
+        repo_full_name="acme-corp/acme-bot",
+        lineage_base_sha=expected_base,
+        publication_visible_outcome_revision=1,
+    )
+
+    assert result.prepared.base_sha == expected_base
+    assert result.prepared.materialized_head == expected_base
+    assert coordinator.current("1700000000.000100") == result.prepared
+    assert observed[0]["workspace_materialized_head"] == expected_base
+    assert observed[0]["publication_visible_outcome_revision"] == 1
     assert "clone" in commands.events
 
 
@@ -1186,9 +1321,20 @@ def test_late_handoff_fence_loss_restores_prior_durable_ownership(
             expected: object,
             env: dict[str, str] | None = None,
             workspace_repo: str,
+            workspace_materialized_head: str | None = None,
+            publication_visible_outcome_revision: int = 0,
             agent_name: str | None = None,
+            validate_candidate: Callable[[object], None] | None = None,
         ) -> object:
-            del expected, env, workspace_repo, agent_name
+            del (
+                expected,
+                env,
+                workspace_repo,
+                workspace_materialized_head,
+                publication_visible_outcome_revision,
+                agent_name,
+                validate_candidate,
+            )
             self.calls.append(("handoff", thread_key, {}))
             raise RuntimeError("late workspace handoff lost its route fence")
 

--- a/docs/adr/0143-thread-owned-pull-request-lineage.md
+++ b/docs/adr/0143-thread-owned-pull-request-lineage.md
@@ -1,0 +1,218 @@
+# 143. A coding thread owns one fenced pull request lineage
+
+Date: 2026-09-03
+
+Status: Accepted
+
+Brian's explicit implementation request on 2026-09-03 authorizes this ADR to
+land Accepted alongside its realizing implementation under
+[ADR 0102](0102-accepted-alongside-implementation-with-explicit-approval.md).
+The tracked work is [issue #2274](https://github.com/curie-eng/curie/issues/2274).
+
+## Context
+
+[ADR 0125](0125-managed-repository-workspaces-and-approval-gated-publication.md)
+made publication one deterministic, approval-gated transition. Its first
+version gives every Publication a branch and can recover that branch's pull
+request, but it does not connect a later approved revision to the pull request
+already owned by the Slack thread. Live testing exposed both sides of that gap:
+the later turn can see stale denial state, and its managed checkout can still
+contain the original dirty base rather than the accepted pull request head.
+
+[ADR 0136](0136-a-late-workspace-handoff-replaces-the-sandbox-at-a-fenced-turn-boundary.md)
+defines how a conversation acquires a workspace without allowing two runners
+to become authoritative. The same fencing principle is required after
+publication. Merely appending the publication outcome to durable history does
+not reconcile the filesystem from which the next revision is produced.
+
+The lineage owner must be the canonical server thread identity. Adapter scope
+and a bare Slack reply conversation id are not interchangeable identities.
+Issue #2272 remains the separate prerequisite which supplies that distinction;
+this decision neither absorbs nor weakens it.
+
+## Decision
+
+**One agent's canonical server thread identity owns at most one active,
+repository-compatible pull request lineage. Each approved revision advances
+that lineage with one fenced commit, then replaces the managed checkout at a
+fenced turn boundary before another model turn may begin.**
+
+### Lineage is durable compare-and-set state
+
+The API persists the canonical repository, stable publication branch, pull
+request number, accepted head commit, lineage version, and current revision
+state. One open lineage may be reused only for the same canonical thread and
+repository. The first publication request creates the stable lineage and a
+revision proposal before approval; subsequent publication requests propose a
+revision against its recorded head and version. This pre-approval reservation
+is the concurrency fence, not authority to publish.
+
+The durable ownership key is the agent, canonical conversation identity, and
+repository. A deployment records the execution context but does not own the
+lineage. Replacing a deployment for the same agent therefore continues the
+same lineage, while another agent using the same conversation string and
+repository remains isolated from it.
+
+Reservation and completion are compare-and-set transitions. Concurrent
+revisions cannot both claim the same expected parent, and stale workers cannot
+advance or clear a newer reservation. Approval denial grants no GitHub
+credential and produces no GitHub side effect. When the first proposal is
+denied, its stable lineage retains no pull request number, URL, or accepted
+head. A later approved revision reuses that lineage and follows the absent-pull
+request creation path rather than inferring GitHub state from a revision
+ordinal.
+
+Migration 0041 is a contract migration, not a mixed-version expand. After its
+backfill, a database CHECK rejects active N-1-shaped publications without a
+lineage while allowing immutable terminal legacy history to remain readable.
+Old API writers therefore must not remain in service through this migration.
+
+A merged or closed pull request is terminal for its thread lineage. The
+platform reports that state and refuses another revision. Continuing after
+merge or close requires a new thread, which receives a new lineage.
+
+### GitHub truth stays behind the API boundary
+
+The worker asks a private, worker-authenticated API operation to reconcile the
+stored pull request number, branch, and head against GitHub. The API resolves
+the operator-owned GitHub credential and returns only normalized repository and
+pull request facts. It never returns a credential, authenticated URL, or
+authorization header.
+
+GitHub remains authoritative for whether the pull request is open and for its
+current head. A head not equal to the lineage's recorded head, the expected
+revision commit, or another explicitly recoverable state is a visible stale
+conflict. It is never overwritten or silently adopted.
+
+Terminal GitHub state is persisted with pull request identity under the lineage
+compare-and-set. A foreign moved head is never adopted: the stored accepted
+head is retained unless an exact revision marker and parent proof authorize an
+advance. Replaying identical terminal facts is idempotent.
+
+### One approval means one exact commit
+
+Every approved revision has a deterministic commit identity marked with its
+server-owned publication identity and expected parent. The publication Job
+constructs exactly that commit from the validated patch. Retry may adopt the
+commit only when the remote head is that exact expected commit. This closes the
+lost-response interval after a successful push without creating a duplicate
+commit or pull request.
+
+The normal push is permitted only while the remote branch still names the
+recorded expected parent. An exact-SHA force-with-lease is the compare-and-set
+operation for that transition. It may never overwrite an unexpected head, use
+an unfenced force push, or silently rebase another writer's work. After GitHub
+accepts the expected commit, the API advances the lineage head and version by
+compare-and-set. A loser reports a stale or concurrent outcome and cannot
+declare success.
+
+For an existing pull request, the trusted publication Job validates the stored
+pull request identity and open state immediately before the fenced push and
+again after it. A pull request that closes or merges at either boundary cannot
+produce a success marker or advance the lineage as though it remained open.
+
+### Publication completion is a checkout fence
+
+A completed revision is appended to durable thread history. Only after that
+append is acknowledged does the API expose the revision as visible history.
+The worker carries the highest visible revision in route metadata, so a change
+in either the accepted head or visible outcome revision forces the next
+delivery through a replacement boundary. Until the append is acknowledged, a
+later turn remains fenced out rather than observing an incomplete result.
+
+When an accepted head exists, the trusted worker obtains a depth-one checkout
+of that exact head, removes authenticated remote state, verifies the clean
+remote and requested commit, archives that sanitized checkout, and cold-claims
+a replacement workspace runner. When a terminal outcome exists before any
+pull request head was accepted, the worker instead fetches the lineage's exact
+recorded base and checks it out detached. It does not follow an advanced
+default branch or reuse the retained dirty runner merely because no pull
+request branch exists yet.
+
+The route handoff follows ADR 0136's compare-and-swap. An inactive runner in
+`AWAITING_APPROVAL` may be replaced only when the completed turn's history is
+durable and no publication revision remains pending. This is the sole waiver
+of ADR 0136's ordinary approval-boundary refusal, because the completed
+publication is itself the durable resolution of that boundary. A live turn,
+missing history, another pending revision, unreadable status, or incompatible
+repository still fails closed.
+
+The old route remains authoritative until the replacement is ready and wins
+the affinity compare-and-swap. A losing replacement is deleted and must not
+start model execution on either its candidate claim or the stale claim. Only
+the fenced winner may run the later instruction, with durable publication
+outcomes in history and the accepted pull request head on disk.
+
+Local publication remains unsupported. This decision changes no ACI protocol
+or plugin-format contract. If realizing it requires either frozen contract to
+change, implementation stops and raises that prerequisite separately.
+
+The realizing paths are:
+
+- lineage persistence, versioned transitions, private GitHub reconciliation,
+  and publication approval state in `apps/api/src/curie_api/models.py`,
+  `crud.py`, and `routers/publications.py`;
+- turn-boundary fencing, exact-head workspace preparation, and no-start
+  behavior after a lost fence in `apps/worker/src/curie_worker/kernel.py` and
+  `workspace.py`; and
+- deterministic revision commits, exact-head recovery, fenced pushes, and
+  lineage completion in `apps/worker/src/curie_worker/publication_loop.py` and
+  `publication_k8s.py`.
+
+## Consequences
+
+Two approved changes in one Slack thread produce two commits on one open pull
+request. The later model turn observes the first publication result in durable
+history and edits the exact head that GitHub accepted.
+
+Lineage state becomes both concurrency control and user-visible recovery
+state. API and worker retries must preserve publication identity, expected
+parent, accepted head, and version together. A stale database view, external
+branch mutation, concurrent approval, lost Job marker, or lost API response now
+ends in an explicit recoverable conflict rather than a duplicate pull request
+or hidden overwrite. A lineage may exist before any pull request does, allowing
+proposal concurrency to be fenced while denied work remains side-effect free.
+
+Replacing the workspace after each completed revision costs a sanitized clone
+and cold claim. That cost preserves the credential boundary, makes GitHub's
+accepted commit the next turn's filesystem truth, and avoids mutating a live
+sandbox in place.
+
+The thread cannot continue its lineage after the pull request is merged or
+closed. Starting a new thread makes the new branch and review history explicit
+instead of reviving a terminal review object.
+
+## Alternatives considered
+
+### Create one pull request per approved revision
+
+Rejected. It loses thread ownership, fragments review history, and recreates
+the duplicate pull request behavior this decision closes.
+
+### Reuse a branch name without persisted lineage state
+
+Rejected. A name alone cannot distinguish a retry from a concurrent writer,
+prove the expected parent, or fence a lost response.
+
+### Force push the latest generated tree
+
+Rejected. An unfenced force push can silently erase external or concurrent
+work. Only an exact expected-parent lease is an authorized transition.
+
+### Keep the existing sandbox after publication
+
+Rejected. Durable history can report the accepted result while the filesystem
+still reflects the pre-publication base. Editing that checkout would make the
+next revision depend on stale or dirty state.
+
+### Resume any runner waiting for approval
+
+Rejected. `AWAITING_APPROVAL` normally marks an unresolved side-effect
+boundary. Replacement is safe only for the inactive, durably completed
+publication case with no pending revision, and it still requires the route
+compare-and-swap.
+
+### Put GitHub reconciliation in the sandbox
+
+Rejected. It would expose operator authority to model-controlled code and undo
+ADR 0125's credential boundary.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -170,4 +170,5 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0138 | [Provider-side web search is a default-on bundle capability](0138-provider-side-web-search-is-a-default-on-bundle-capability.md) | Proposed |
 | 0139 | [Bundle owners classify every vanilla MCP tool](0139-bundle-owners-classify-every-vanilla-mcp-tool.md) | Draft |
 | 0142 | [Database compatibility is a release contract; migrations run in one upgrade phase](0142-database-compatibility-windows-and-a-single-upgrade-phase.md) | Accepted |
+| 0143 | [A coding thread owns one fenced pull request lineage](0143-thread-owned-pull-request-lineage.md) | Accepted |
 <!-- END GENERATED: adr-index -->

--- a/packages/telemetry/schema/metrics.json
+++ b/packages/telemetry/schema/metrics.json
@@ -977,6 +977,8 @@
           "/publications/{publication_id}",
           "/v1/internal/cluster-message-replies/{reply_ref}",
           "/v1/internal/publications",
+          "/v1/internal/publications/lineage",
+          "/v1/internal/publications/{publication_id}/lineage",
           "/v1/internal/publications/{publication_id}/credential",
           "/v1/internal/workspaces/{deployment_id}/credential",
           "/v1/internal/workspaces/{deployment_id}/selection",
@@ -1003,7 +1005,7 @@
           "5xx"
         ]
       },
-      "cardinality_bound": 2800
+      "cardinality_bound": 2880
     },
     "curie.http.server.request.duration": {
       "type": "histogram",
@@ -1081,6 +1083,8 @@
           "/publications/{publication_id}",
           "/v1/internal/cluster-message-replies/{reply_ref}",
           "/v1/internal/publications",
+          "/v1/internal/publications/lineage",
+          "/v1/internal/publications/{publication_id}/lineage",
           "/v1/internal/publications/{publication_id}/credential",
           "/v1/internal/workspaces/{deployment_id}/credential",
           "/v1/internal/workspaces/{deployment_id}/selection",
@@ -1107,7 +1111,7 @@
           "5xx"
         ]
       },
-      "cardinality_bound": 2800
+      "cardinality_bound": 2880
     },
     "curie.http.server.active": {
       "type": "up_down_counter",
@@ -1185,6 +1189,8 @@
           "/publications/{publication_id}",
           "/v1/internal/cluster-message-replies/{reply_ref}",
           "/v1/internal/publications",
+          "/v1/internal/publications/lineage",
+          "/v1/internal/publications/{publication_id}/lineage",
           "/v1/internal/publications/{publication_id}/credential",
           "/v1/internal/workspaces/{deployment_id}/credential",
           "/v1/internal/workspaces/{deployment_id}/selection",
@@ -1204,7 +1210,7 @@
           "OTHER"
         ]
       },
-      "cardinality_bound": 560
+      "cardinality_bound": 576
     },
     "curie.background.loop": {
       "type": "counter",

--- a/packages/telemetry/src/curie_telemetry/metrics.py
+++ b/packages/telemetry/src/curie_telemetry/metrics.py
@@ -215,6 +215,8 @@ _HTTP_OPERATIONS = [
     "/publications/{publication_id}",
     "/v1/internal/cluster-message-replies/{reply_ref}",
     "/v1/internal/publications",
+    "/v1/internal/publications/lineage",
+    "/v1/internal/publications/{publication_id}/lineage",
     "/v1/internal/publications/{publication_id}/credential",
     "/v1/internal/workspaces/{deployment_id}/credential",
     "/v1/internal/workspaces/{deployment_id}/selection",

--- a/tools/e2e-ci-selection/tests/test_e2e_ci_selection.py
+++ b/tools/e2e-ci-selection/tests/test_e2e_ci_selection.py
@@ -641,6 +641,26 @@ fi'''
     assert named_steps["Tear down the disposable upgrade cluster"]["if"] == "always()"
 
 
+def test_released_upgrade_candidate_images_opt_into_forward_only_migrations() -> None:
+    workflow = yaml.safe_load(WORKFLOW.read_text())
+    steps = workflow["jobs"]["e2e-released-upgrade"]["steps"]
+    named_steps = {
+        step["name"]: step for step in steps if isinstance(step.get("name"), str)
+    }
+
+    candidate_upgrade_steps = (
+        "Upgrade the legacy release to the candidate chart",
+        "Upgrade a second time and preserve the generated attester",
+        "Upgrade the v0.8.4 release to the candidate chart",
+        "Existing cluster rung smoke on the upgraded candidate",
+    )
+    for name in candidate_upgrade_steps:
+        run = named_steps[name]["run"]
+        assert "helm upgrade curie charts/curie -n curie" in run
+        assert "--set api.image.tag=upgrade-candidate" in run
+        assert "--set api.migrate.forwardOnly=true" in run
+
+
 def test_released_upgrade_workflow_pins_issue_2097_live_manifest_parity() -> None:
     workflow = yaml.safe_load(WORKFLOW.read_text())
     job = workflow["jobs"]["e2e-released-upgrade"]


### PR DESCRIPTION
## Summary

Persist one pull-request lineage per agent-owned coding thread and repository, expose publication outcomes to later turns, and reconcile the managed checkout to the accepted pull-request head at a fenced turn boundary. Each approved revision now advances the same open PR by one exact commit; stale, concurrent, denied, merged, closed, and lost-response paths fail visibly without duplicate PRs or unfenced force pushes.

## Related issue

Closes #2274

## Architecture

- ADR 0143 succeeds ADR 0125 for iterative publication while preserving its approval and credential boundary.
- Migration 0041 adds durable lineage/revision identity and CAS state. It is a contract migration: after backfill, the database rejects active legacy publications without a lineage while retaining terminal legacy history.
- Adapter reply identity remains bare while transcript/lineage identity remains canonically scoped.
- GitHub reconciliation binds repository, PR number/URL, branch, state, and exact head SHA. Terminal state never adopts a foreign moved head; an advance requires the exact revision marker and expected parent.
- Publication completion becomes a history-readiness and route-replacement fence. The replacement checkout is a clean depth-one checkout of the exact accepted head, or the exact recorded base when no PR head exists.

## Fix pin verification

Fix pin: apps/api/tests/test_publications.py::test_two_publication_revisions_advance_one_durable_thread_lineage

`curie dev verify-fix-pin HEAD 'apps/api/tests/test_publications.py::test_two_publication_revisions_advance_one_durable_thread_lineage' --json` on product commit `a26628fd`: candidate `1 passed`; reversed product hunks failed with missing lineage state; verdict `PINNED`. The follow-up CI-only commit `dba5cda5` does not change the pinned product path.

## Verification

- Full affected matrix on the final content: `292 passed, 178 skipped` across API publication/migration/schema-compatibility tests and worker approval, sandbox, publication, and workspace tests.
- Focused publication integrity matrix: `113 passed`, including a generated-script execution against a local bare Git remote and fake local GitHub REST service. It proves two one-parent commits on one branch/PR identity and refuses a lease race.
- Migration/compatibility matrix: `18 passed`, including execution of the database rejection for an active 0040-shaped lineage-less insert.
- Released-upgrade regression pin: `91 passed` in `tools/e2e-ci-selection/tests/test_e2e_ci_selection.py`; the chart migration assertions and `helm lint charts/curie` also pass. Code re-review `APPROVE`; Scope re-review `CLEAN`.
- GitHub CI on `dba5cda5`: all `35` checks pass. The released-upgrade job completed v0.8.2 -> candidate, its idempotent second upgrade, v0.8.4 -> candidate, live-manifest convergence, and the final cluster smoke. The first Rust run hit the existing ClickHouse-readiness timing flake; the exact script passed locally unchanged and the job-only rerun passed.
- `uv lock --check`, Alembic revision gate, Ruff, mypy, import contracts, docs lint, wire tolerance, and `git diff --check` all pass.
- Final reviews: Code `APPROVE`, Scope `CLEAN`, Security `SECURE`.

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | No plugin, runner turn-loop, ACI, or skill packaging change. | n/a | Frozen ACI and plugin-format paths are unchanged. |
| local | n/a | Publication remains cluster-only under ADR 0125; local refusal is preserved. | fake | Local bare-Git/fake-REST execution is integration proof, not a supported local publication tier. |
| local-release | n/a | No released binary/image identity, installer, or release-compose change. | n/a | Not reached. |
| cluster | required - partial | Worker/API publication is cluster-owned; the available harness proves the deployment substrate but cannot exercise Slack/GitHub publication without task-owned credentials. | fake | `bash scripts/chart-runtime-e2e.sh --force --namespace curie-2274-pr-e2e --release curie-2274-pr-e2e` on `a26628fd`: `PASS: API Service NodePort and runtime security assertions`; real sandbox bundle, credential non-persistence, telemetry outage/restart/exact-once recovery, and bounded overflow all passed; teardown completed. |
| live provider | required - blocked | A real model must perform the two revision turns against this candidate. | live | The overnight coordinator has separate provider-access proof, but this PR has not run the task-specific two-revision candidate journey. No retained/shared environment was borrowed by this implementation run. |
| external integration | required - blocked | A real Slack thread and GitHub App must prove one PR receives two commits and terminal/stale controls refuse. | live | The overnight coordinator reports a dedicated bot sender and task-owned local stack, but no Slack human card-click access yet. That is access/preflight evidence, not the required candidate card-click -> GitHub revision loop. |

- [x] Every exercised required tier above names its exact command, commit, mode, and literal observed outcome; blocked tiers name their capability check.
- [x] Each code-level acceptance criterion has positive proof plus a falsifiable negative or independent path: same-PR two-revision, denied, merged/closed, stale head, concurrent CAS/lease, lost response, and contract-migration refusal.
- [ ] No required tier is left unproved. Real Slack + GitHub App + live-model proof remains blocked by absent task-owned credentials; cluster proof is therefore substrate-only.

## `/implement` done-check

- [x] Failing tests preceded implementation in the build pipeline; the validated history was then squashed to one feature commit.
- [x] Production edits were performed by delegated Codex workers; the driver owned git and validation.
- [x] Broadened recovery/terminal return types were checked at every protocol, implementation, caller, and test site.
- [x] Code Reviewer completed and converged to `APPROVE` after all findings were fixed.
- [x] Scope Reviewer mapped the final diff to #2274 or mechanical schema/docs generation and returned `CLEAN`.
- [x] Sibling paths are covered: API/worker state, direct/Job recovery, first/subsequent revisions, scoped transcript/bare reply identity, and stored/no-head checkout replacement.
- [x] Guards were executed against violating inputs: stale CAS/head, terminal PR, concurrent lease, denied publication, invalid active legacy write, incomplete markers, and reversed fix-pin product hunks.
- [x] Consolidation was skipped because `/simplify` is unavailable in this runtime; targeted review fixes removed the identified passenger and mixed-version dead end, followed by full validation/re-review.
- [x] Security Reviewer reconciled all identity, credential, CAS, migration, and GitHub race findings and returned `SECURE`.
- [x] Observable local integration ran the generated publication script against real local Git and fake REST, including the negative lease race.
- [ ] Deployed feature E2E remains blocked: the disposable cluster substrate passed, but task-owned Slack/GitHub App/model credentials are absent.
- [x] Train check: milestone v0.9.0 maps to `next`; after unrelated merges advanced `next`, the branch is two commits ahead of its merge base and two behind current `origin/next`. GitHub reports `MERGEABLE` / `CLEAN` with no conflict.
- [x] Discovery-surface proof is n/a because #2274 is an enhancement; the live-origin limitation is nevertheless recorded above.
- [x] Re-fix mechanism is n/a; this extends ADR 0125 rather than repeating a claimed fix.
- [x] Full affected suite, typecheck, lint, import contracts, docs, and wire gates pass.

## Checklist

- [x] Tests pass for the area touched.
- [x] Docs updated for the behavior change.
- [x] ADR 0143 records the architectural decision and migration boundary.

This PR must remain open and unmerged until the blocked live-provider and external-integration evidence is supplied.
