### PR TITLE
Honor store existingSecret for the last three curie.langfuse.env refs

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -152,13 +152,13 @@ jobs:
           set -euo pipefail
           bash charts/curie/ci/clickhouse-logging-assertions.sh
 
-      # Prove Langfuse honors valkey.existingSecret on a BYO valkey install
-      # (#2052). A supported BYO install (valkey.deploy=false + host +
-      # existingSecret) had every component read the operator's Secret except
-      # Langfuse, which stayed pinned to the chart-managed Secret -- so trace
-      # ingestion died alone while the rest of the release stayed healthy,
-      # which is why nothing pointed at the cause.
-      - name: helm render assertions (langfuse valkey existingSecret)
+      # Prove Langfuse honors existingSecret for BYO valkey, postgres, and its
+      # own app keys (#2052, #2327). A supported BYO install has every other
+      # component read the operator's Secret except Langfuse: api and worker
+      # authenticate against the real postgres while both Langfuse Deployments
+      # present the chart-generated password and crash-loop at Prisma auth --
+      # so ingestion dies alone while the rest of the release stays healthy.
+      - name: helm render assertions (langfuse store existingSecret)
         run: |
           set -euo pipefail
           bash charts/curie/ci/valkey-existing-secret-assertions.sh

--- a/charts/curie/CLAUDE.md
+++ b/charts/curie/CLAUDE.md
@@ -59,15 +59,6 @@ component and rail detail in `charts/curie/README.md`.
   BYO `host`/`port`/`auth`/`existingSecret` fields on the same block. A new
   backing store must follow this exact pattern -- do not add a store with a
   different enable/disable shape.
-  Known exceptions: in `curie.langfuse.env` (`_helpers.tpl`), `POSTGRES_PASSWORD`
-  (`postgresPassword`) still ignores `postgres.existingSecret`, and `SALT`
-  (`langfuseSalt`) / `ENCRYPTION_KEY` (`langfuseEncryptionKey`) still ignore
-  `langfuse.existingSecret` -- #2052 fixed the valkey and clickhouse half of
-  this idiom and enumerated these three as the remainder, not yet tracked by
-  an issue. Until they're fixed the invariant is aspirational for them: an
-  operator on BYO postgres or a BYO `langfuse.existingSecret` gets the
-  chart-generated value instead of theirs. `ENCRYPTION_KEY` is the sharpest --
-  a mismatched key means previously written encrypted columns stop decrypting.
 - **Values keys are camelCase, not hyphenated.** Go templates cannot
   dot-index a hyphenated key. Keep this consistent across any new values
   additions.

--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -547,6 +547,18 @@ upgrading. Without it the collector pod fails to start with
 `CreateContainerConfigError`, which is the deliberate replacement for a silent
 401 on every trace export.
 
+Upgrade note for `langfuse.existingSecret` (#2327): the chart now actually reads
+`langfuseSalt` and `langfuseEncryptionKey` from that Secret. `values.yaml`
+already listed both as required keys, but the template ignored them -- an
+install already on this path was salting and encrypting with the chart-managed
+Secret's values instead, because those two keys ignored `existingSecret` while
+`NEXTAUTH_SECRET` and the `LANGFUSE_INIT_*` keys already honored it. Both
+Deployments now read the BYO Secret for real: a missing key fails loud with
+`CreateContainerConfigError`, a differing one fails silently and stops
+decrypting columns already written. Before upgrading, copy the live values out
+of the chart-managed `<release>-secrets` Secret into your BYO Secret, unless no
+encrypted data is worth preserving.
+
 Caveat: generation relies on Helm `lookup`, which is empty under client-side
 rendering. Driving this chart via `helm template | kubectl apply` or ArgoCD's
 client-side Helm (no live API lookup) regenerates these values on every sync and

--- a/charts/curie/ci/valkey-existing-secret-assertions.sh
+++ b/charts/curie/ci/valkey-existing-secret-assertions.sh
@@ -1,14 +1,24 @@
 #!/usr/bin/env bash
 #
-# Render-assertion test for `valkey.existingSecret` reaching Langfuse (#2052).
+# Render-assertion test for `<store>.existingSecret` reaching every Langfuse
+# consumer (#2052 valkey, #2327 postgres + langfuse).
+#
+# The filename is historical: this started as the valkey/REDIS_AUTH gate and
+# was widened in place rather than forked, because every case here is the same
+# split -- one consumer group honouring `<store>.existingSecret` while
+# `curie.langfuse.env` hardcoded the chart Secret -- and the helm-ci wiring
+# already points at this path.
 #
 # The chart's stated invariant (charts/curie/CLAUDE.md, "Every backing store
 # follows the same toggle + BYO idiom") is that flipping `<store>.deploy` to
 # false repoints EVERY consumer at the BYO `host`/`port`/`auth`/`existingSecret`
-# fields on the same block. Valkey had two consumer groups and only one of them
-# honoured it: `curie.env.valkey` (api + worker) read
-# `valkey.existingSecret | default <chart secret>`, while `curie.langfuse.env`
-# hardcoded the chart Secret for REDIS_AUTH.
+# fields on the same block. Three stores had two consumer groups each and only
+# one group honoured it: `curie.env.valkey` (api + worker) read
+# `valkey.existingSecret | default <chart secret>` while `curie.langfuse.env`
+# hardcoded the chart Secret for REDIS_AUTH (#2052), and `curie.env.postgres`
+# read `postgres.existingSecret | default <chart secret>` while the same
+# `curie.langfuse.env` block hardcoded it for POSTGRES_PASSWORD, SALT and
+# ENCRYPTION_KEY (#2327).
 #
 # The consequence is silent and asymmetric, which is why it is worth a gate. On
 # a BYO valkey install (`deploy=false` + `host` + `existingSecret`) the chart
@@ -45,11 +55,26 @@
 #      emitted REDIS_AUTH twice or fell back to the chart Secret, and the gate
 #      would be vacuous.
 #
-# Deliberately NOT asserted: POSTGRES_PASSWORD, SALT and ENCRYPTION_KEY in the
-# same `curie.langfuse.env` block still hardcode the chart Secret even though
-# `postgres.existingSecret` and `langfuse.existingSecret` exist. That is a known
-# gap tracked separately; pinning their current values here would freeze the bug
-# into the gate.
+#   6. `postgres.existingSecret=byo-postgres`: POSTGRES_PASSWORD resolves to
+#      `byo-postgres` on BOTH langfuse containers AND, in the same render, on
+#      the api and worker containers -- the split pair asserted together, so a
+#      future edit cannot "fix" the split by breaking the app services instead.
+#      With a negative control (the chart Secret must not back POSTGRES_PASSWORD
+#      on either langfuse container) and a default-render no-regression case.
+#      Before #2327 the api and worker authenticated against the real BYO
+#      instance while both Langfuse Deployments presented the chart-generated
+#      password and crash-looped at Prisma auth, every other component green.
+#   7. `langfuse.existingSecret=byo-langfuse`: all five Langfuse-owned app keys
+#      resolve to `byo-langfuse` -- SALT (`langfuseSalt`) and ENCRYPTION_KEY
+#      (`langfuseEncryptionKey`) on BOTH containers via the shared env helper,
+#      plus NEXTAUTH_SECRET, LANGFUSE_INIT_PROJECT_SECRET_KEY and
+#      LANGFUSE_INIT_USER_PASSWORD written inline on the web Deployment only.
+#      Two of the five are what #2327 fixed; the other three were already
+#      correct and are asserted so a regression on either half fails the gate.
+#      With the same negative control and no-regression pair for SALT and
+#      ENCRYPTION_KEY. ENCRYPTION_KEY is the sharpest of the set: the operator's
+#      `langfuseEncryptionKey` was silently unused, so a later regeneration of
+#      the chart Secret left previously written encrypted columns undecryptable.
 #
 # Every render goes through `--output-dir`, never a stdout pipe: piping
 # `helm template` in this environment silently truncates a large render at
@@ -93,6 +118,14 @@ render byo-full \
   --set valkey.existingSecret=acme-valkey
 BYO_FULL_DIR="$RENDER_DIR/curie/templates"
 
+echo "=== Rendering Langfuse (postgres.existingSecret=byo-postgres) ==="
+render byo-postgres --set postgres.existingSecret=byo-postgres
+BYO_PG_DIR="$RENDER_DIR/curie/templates"
+
+echo "=== Rendering Langfuse (langfuse.existingSecret=byo-langfuse) ==="
+render byo-langfuse --set langfuse.existingSecret=byo-langfuse
+BYO_LF_DIR="$RENDER_DIR/curie/templates"
+
 # ---------------------------------------------------------------------- 4a
 # A missing manifest file is --output-dir's signal that the whole template
 # rendered nothing (the same check direct-passthrough-existing-secret-
@@ -102,8 +135,9 @@ if [[ -s "$BYO_FULL_DIR/valkey.yaml" ]]; then
 fi
 echo "  [4a] valkey.deploy=false renders no in-chart valkey manifest: OK"
 
-# ------------------------------------------------------------- 1, 2, 3, 4b, 5
+# -------------------------------------------------- 1, 2, 3, 4b, 5, 6, 7
 DEFAULT_DIR="$DEFAULT_DIR" BYO_DIR="$BYO_DIR" BYO_FULL_DIR="$BYO_FULL_DIR" \
+BYO_PG_DIR="$BYO_PG_DIR" BYO_LF_DIR="$BYO_LF_DIR" \
 python3 <<'PY'
 import os
 import sys
@@ -113,12 +147,16 @@ import yaml
 DEFAULT_DIR = os.environ["DEFAULT_DIR"]
 BYO_DIR = os.environ["BYO_DIR"]
 BYO_FULL_DIR = os.environ["BYO_FULL_DIR"]
+BYO_PG_DIR = os.environ["BYO_PG_DIR"]
+BYO_LF_DIR = os.environ["BYO_LF_DIR"]
 
 # `helm template rel <chart>` -> fullname `rel-curie`, so the chart's own
 # Secret is `rel-curie-secrets`. Hardcoded rather than derived: the point of
 # the negative control is that this exact name must NOT appear.
 CHART_SECRET_NAME = "rel-curie-secrets"
 BYO_SECRET_NAME = "acme-valkey"
+BYO_PG_SECRET_NAME = "byo-postgres"
+BYO_LF_SECRET_NAME = "byo-langfuse"
 
 failures = []
 
@@ -229,10 +267,104 @@ for label, d in (("byo", BYO_DIR), ("byo-full", BYO_FULL_DIR)):
                 "wrong password and trace ingestion dies silently with the rest of the "
                 "release healthy.")
 
+# ---- 6: postgres.existingSecret reaches Langfuse as well as the app services
+#         (#2327). POSTGRES_PASSWORD/postgresPassword is the same env name and
+#         key on all four containers -- `curie.env.postgres` (api + worker) and
+#         `curie.langfuse.env` (web + worker) -- so the split is visible only by
+#         asserting both groups in one render. ----
+for suffix, c in LANGFUSE_CONTAINERS:
+    check_ref(f"6{suffix}", f"{BYO_PG_DIR}/langfuse.yaml", c,
+              "POSTGRES_PASSWORD", BYO_PG_SECRET_NAME, "postgresPassword",
+              f"postgres.existingSecret set, {c}")
+
+# ---- 6c/6d: the app-service half of that same render. Asserted alongside 6a/6b
+#             so a future edit cannot "fix" the split by breaking these instead.
+check_ref("6c", f"{BYO_PG_DIR}/api.yaml", "api", "POSTGRES_PASSWORD",
+          BYO_PG_SECRET_NAME, "postgresPassword", "postgres.existingSecret set, api")
+check_ref("6d", f"{BYO_PG_DIR}/worker.yaml", "worker", "POSTGRES_PASSWORD",
+          BYO_PG_SECRET_NAME, "postgresPassword", "postgres.existingSecret set, worker")
+
+# ---- 6e: NEGATIVE CONTROL for 6. Without it 6a/6b would still pass against a
+#          template that emitted POSTGRES_PASSWORD twice or fell back to the
+#          chart Secret, and the gate would be vacuous. ----
+for _suffix, c in LANGFUSE_CONTAINERS:
+    ref, n = find_env(f"{BYO_PG_DIR}/langfuse.yaml", c, "POSTGRES_PASSWORD")
+    if n == 1 and ref and ref.get("name") == CHART_SECRET_NAME:
+        failures.append(
+            f"[6e] negative control ({c}): POSTGRES_PASSWORD still resolves to the "
+            f"chart-managed Secret {CHART_SECRET_NAME!r} with postgres.existingSecret="
+            f"{BYO_PG_SECRET_NAME!r} set. This is issue #2327: the api and worker "
+            "authenticate against the real BYO instance while both Langfuse Deployments "
+            "present the chart-generated password and crash-loop at Prisma auth, with "
+            "every other component green.")
+
+# ---- 6f: no-regression. An install that never set postgres.existingSecret must
+#          still resolve to the chart's own Secret. ----
+for suffix, c in LANGFUSE_CONTAINERS:
+    check_ref(f"6f{suffix}", f"{DEFAULT_DIR}/langfuse.yaml", c,
+              "POSTGRES_PASSWORD", CHART_SECRET_NAME, "postgresPassword",
+              f"default render, {c}")
+
+# ---- 7: langfuse.existingSecret backs all five Langfuse-owned app keys.
+#         SALT and ENCRYPTION_KEY come from the shared `curie.langfuse.env`
+#         include, so they must land on BOTH Deployments; the other three are
+#         written inline in langfuse.yaml's web Deployment only. Verified
+#         against templates/langfuse.yaml, not assumed. ----
+LANGFUSE_SHARED_KEYS = [
+    ({"langfuse-web": "7a", "langfuse-worker": "7b"}, "SALT", "langfuseSalt"),
+    ({"langfuse-web": "7c", "langfuse-worker": "7d"}, "ENCRYPTION_KEY", "langfuseEncryptionKey"),
+]
+for aid_by_container, env_name, secret_key in LANGFUSE_SHARED_KEYS:
+    for _suffix, c in LANGFUSE_CONTAINERS:
+        check_ref(aid_by_container[c], f"{BYO_LF_DIR}/langfuse.yaml", c,
+                  env_name, BYO_LF_SECRET_NAME, secret_key,
+                  f"langfuse.existingSecret set, {c}")
+
+# ---- 7e/7f/7g: the three web-only keys. These already honoured
+#                langfuse.existingSecret before #2327 and are asserted so a
+#                regression on either half of the block fails the gate. ----
+LANGFUSE_WEB_ONLY_KEYS = [
+    ("7e", "NEXTAUTH_SECRET", "langfuseNextauthSecret"),
+    ("7f", "LANGFUSE_INIT_PROJECT_SECRET_KEY", "langfuseInitProjectSecretKey"),
+    ("7g", "LANGFUSE_INIT_USER_PASSWORD", "langfuseInitUserPassword"),
+]
+for aid, env_name, secret_key in LANGFUSE_WEB_ONLY_KEYS:
+    check_ref(aid, f"{BYO_LF_DIR}/langfuse.yaml", "langfuse-web",
+              env_name, BYO_LF_SECRET_NAME, secret_key,
+              "langfuse.existingSecret set, langfuse-web")
+
+# ---- 7h: NEGATIVE CONTROL for the two keys #2327 fixed. ----
+for env_name in ("SALT", "ENCRYPTION_KEY"):
+    for _suffix, c in LANGFUSE_CONTAINERS:
+        ref, n = find_env(f"{BYO_LF_DIR}/langfuse.yaml", c, env_name)
+        if n == 1 and ref and ref.get("name") == CHART_SECRET_NAME:
+            failures.append(
+                f"[7h] negative control ({c}): {env_name} still resolves to the "
+                f"chart-managed Secret {CHART_SECRET_NAME!r} with langfuse.existingSecret="
+                f"{BYO_LF_SECRET_NAME!r} set. This is issue #2327: the operator's key is "
+                "silently unused, and for ENCRYPTION_KEY a later regeneration of the chart "
+                "Secret leaves previously written encrypted columns undecryptable.")
+
+# ---- 7i/7j: no-regression for the same two keys on a default install. ----
+LANGFUSE_SHARED_DEFAULTS = [
+    ("7i", "SALT", "langfuseSalt"),
+    ("7j", "ENCRYPTION_KEY", "langfuseEncryptionKey"),
+]
+for prefix, env_name, secret_key in LANGFUSE_SHARED_DEFAULTS:
+    for suffix, c in LANGFUSE_CONTAINERS:
+        check_ref(f"{prefix}{suffix}", f"{DEFAULT_DIR}/langfuse.yaml", c,
+                  env_name, CHART_SECRET_NAME, secret_key,
+                  f"default render, {c}")
+
 if failures:
     for msg in failures:
         print(f"FAIL {msg}", file=sys.stderr)
-    print(f"{len(failures)} of 10 python-side assertions failed", file=sys.stderr)
+    # 35 = 25 check_ref call sites + 10 negative-control loop iterations
+    # ([5] 2 dirs x 2 containers = 4, [6e] 2 containers = 2, [7h] 2 env names x
+    # 2 containers = 4). Bash-side [4a] is outside this count, hence "python-
+    # side"; a single check_ref site can emit 2 failures (name and key both
+    # wrong), so len(failures) is not capped at 35.
+    print(f"{len(failures)} of 35 python-side assertions failed", file=sys.stderr)
     sys.exit(1)
 
 print("  [1] default render: REDIS_AUTH -> chart Secret on web + worker: OK")
@@ -240,7 +372,13 @@ print("  [2] valkey.existingSecret: REDIS_AUTH -> BYO Secret on web + worker: OK
 print("  [3] same render: VALKEY_PASSWORD -> BYO Secret on api + worker: OK")
 print("  [4b] deploy=false + host + existingSecret: langfuse -> BYO Secret: OK")
 print("  [5] negative control: chart Secret never backs REDIS_AUTH under BYO: OK")
+print("  [6] postgres.existingSecret: POSTGRES_PASSWORD -> BYO Secret on langfuse "
+      "web + worker AND api + worker, with negative control and default no-regression: OK")
+print("  [7] langfuse.existingSecret: SALT + ENCRYPTION_KEY (web + worker) and "
+      "NEXTAUTH_SECRET + the two LANGFUSE_INIT_* keys (web) -> BYO Secret, with "
+      "negative control and default no-regression: OK")
 PY
 
 echo
-echo "PASS: valkey.existingSecret reaches every consumer, Langfuse included (#2052)."
+echo "PASS: valkey, postgres and langfuse existingSecret each reach every consumer,"
+echo "      Langfuse included (#2052, #2327)."

--- a/charts/curie/templates/_helpers.tpl
+++ b/charts/curie/templates/_helpers.tpl
@@ -910,22 +910,32 @@ livenessProbe:
 {{/* ---- Langfuse shared environment (mirrors compose.dev.yaml's
         x-langfuse-env anchor). Rendered into both web and worker. ---- */}}
 {{- define "curie.langfuse.env" -}}
+{{- /* These three honour their store's own existingSecret, the same escape
+       curie.env.postgres and the CLICKHOUSE_PASSWORD/REDIS_AUTH refs below
+       already use. They were pinned to the chart Secret while every sibling
+       read the BYO one. On a BYO-Postgres install the api and worker
+       authenticated against the real instance while both Langfuse Deployments
+       presented the chart-generated password and crash-looped at Prisma auth,
+       with every other component green. On a BYO langfuse.existingSecret
+       install the operator's langfuseEncryptionKey was silently unused, and a
+       later regeneration of the chart Secret left previously written encrypted
+       columns undecryptable. See #2327. */}}
 - name: POSTGRES_PASSWORD
   valueFrom:
     secretKeyRef:
-      name: {{ include "curie.secretName" . }}
+      name: {{ .Values.postgres.existingSecret | default (include "curie.secretName" .) }}
       key: postgresPassword
 - name: DATABASE_URL
   value: postgresql://{{ .Values.postgres.auth.username }}:$(POSTGRES_PASSWORD)@{{ include "curie.postgres.host" . }}:{{ .Values.postgres.port }}/{{ .Values.postgres.auth.database }}
 - name: SALT
   valueFrom:
     secretKeyRef:
-      name: {{ include "curie.secretName" . }}
+      name: {{ .Values.langfuse.existingSecret | default (include "curie.secretName" .) }}
       key: langfuseSalt
 - name: ENCRYPTION_KEY
   valueFrom:
     secretKeyRef:
-      name: {{ include "curie.secretName" . }}
+      name: {{ .Values.langfuse.existingSecret | default (include "curie.secretName" .) }}
       key: langfuseEncryptionKey
 - name: TELEMETRY_ENABLED
   value: {{ .Values.langfuse.telemetryEnabled | quote }}


### PR DESCRIPTION
Closes #2327.

Fix pin: charts/curie/ci/valkey-existing-secret-assertions.sh

`POSTGRES_PASSWORD`, `SALT` and `ENCRYPTION_KEY` in the `curie.langfuse.env` helper resolved to the hardcoded chart Secret while their four siblings in the same block already honoured the store's `existingSecret`. All three now use the same `<store>.existingSecret | default (include "curie.secretName" .)` idiom — `postgres.existingSecret` for the first, `langfuse.existingSecret` for the other two.

### Render proof

Same command both ways: `helm template rel charts/curie --set postgres.existingSecret=byo-postgres --set langfuse.existingSecret=byo-langfuse`.

| env | container | before | after |
|---|---|---|---|
| `POSTGRES_PASSWORD` | langfuse-web, langfuse-worker | `rel-curie-secrets` | `byo-postgres` |
| `SALT` | langfuse-web, langfuse-worker | `rel-curie-secrets` | `byo-langfuse` |
| `ENCRYPTION_KEY` | langfuse-web, langfuse-worker | `rel-curie-secrets` | `byo-langfuse` |
| `POSTGRES_PASSWORD` | api, worker | `byo-postgres` | `byo-postgres` (unchanged) |
| `NEXTAUTH_SECRET`, both `LANGFUSE_INIT_*` | langfuse-web | `byo-langfuse` | `byo-langfuse` (unchanged) |

### Gate

`ci/valkey-existing-secret-assertions.sh` was widened in place rather than forked, because the helm-ci wiring already points at that path and its old header explicitly declared these three keys "deliberately NOT asserted" — text that would otherwise have frozen the bug into the gate. New cases:

- **postgres sibling** — `POSTGRES_PASSWORD` on both Langfuse containers *and* on api/worker in the same render, so a future edit cannot "fix" the split by breaking the app services instead.
- **`langfuse.existingSecret`** — all five Langfuse app keys: `SALT` and `ENCRYPTION_KEY` on both Deployments (shared env helper), `NEXTAUTH_SECRET` and the two `LANGFUSE_INIT_*` keys on web (written inline). Three of the five were already correct and are asserted so a regression on either half fails.

Both carry a negative control and a default-render no-regression pair. **Demonstrated non-vacuous:** with `_helpers.tpl` reverted to `origin/main` the script exits 1 with `12 of 35 python-side assertions failed` (`6a 6b 6e×2 7a 7b 7c 7d 7h×4`); with the fix, 35/35 pass.

The helm-ci step was retitled — its `name:` and comment described only the valkey/#2052 half of a gate that now covers three stores. The `run:` block is byte-identical.

### Upgrade note (please read)

The scope review surfaced a hazard worth flagging: an install **already** on `langfuse.existingSecret` has been salting and encrypting with the *chart* Secret's `langfuseSalt`/`langfuseEncryptionKey`, because those two refs ignored the BYO Secret. `values.yaml` had listed both as required BYO keys all along — the template just never read them. After this upgrade it does. A missing key fails loud (`CreateContainerConfigError`); a *differing* key fails silently and stops decrypting columns already written.

Operators must copy the live values out of the chart-managed `<release>-secrets` Secret into their BYO Secret before upgrading. Documented in `charts/curie/README.md` alongside the existing `otlpAuthHeader` note (#1563). `POSTGRES_PASSWORD` carries no equivalent hazard — Langfuse was crash-looping on that path, so switching it only heals.

### Decisions taken (conservative defaults, per the ambiguity instruction)

- **Widened the existing script instead of adding a new one**, per the issue's own suggested fix. Cost: the filename now under-describes its contents. A rename was skipped deliberately — it would mean editing CI wiring for no behavioural gain. Called out in the file's header.
- **No `values.yaml` change** — it already documented the intended contract; the template is what contradicted it.
- **Kept five separate renders** rather than combining the two new `--set` cases into one. Costs ~160ms against a minutes-scale job and preserves one-variable-per-render attribution on failure.

### Not in this PR

The altitude review flagged that both #2052 and #2327 were fixed the same way — patch the specific lines, enumerate the specific assertions — and neither makes the next instance impossible. The idiom is inlined at ~9 sites in `_helpers.tpl` and the gate hand-enumerates keys, so a tenth ref nobody lists would survive exactly as these three survived #2052. Filed as **#2354** (a named template for the idiom, plus a generic walk-every-`secretKeyRef` assertion). Deliberately out of scope here — it touches every existing site and wants its own render diff.

### Validation

- `helm lint charts/curie` — 0 failed.
- Widened gate — 35/35 pass; 12/35 fail against the unfixed template.
- Neighbouring chart gates green: `render-assertions`, `langfuse-byo`, `direct-passthrough-existing-secret`, `otel-collector-langfuse-secret`, `clickhouse-logging`, `object-store-web-identity`, `langfuse-postgres-readiness`, `connector-secrets`.
- Adversarial code + scope review via agent-router (reviewer: grok, primary excluded). Code review found no correctness defects and independently confirmed no other consumer of either `existingSecret` is newly inconsistent. Scope review found no passengers; its one finding is the upgrade note above, now addressed.

### Done-check

- [x] Delegated executor made every production edit; driver ran only git/validation — build-tier plan-doc and failing-tests-first items N/A (quick tier)
- [x] Adversarial Code Reviewer completed, file:line evidence
- [x] Adversarial Scope Reviewer completed, every hunk mapped to an AC
- [x] Guard demonstration: gate executed against a violating input (12/35 fail), not read
- [x] Sibling-path parity: api/worker postgres half asserted in the same render; residual class filed as #2354
- [x] Consolidation pass ran (4 angles); 2 cleanups applied, validation re-run and guard re-demonstrated after
- [x] Train check: v0.8.6 is a patch milestone, cut from `main`
- [x] `helm lint` clean, full affected gate suite green
- N/A Security reviewer (not flagged), E2E tester, observable UI verification

**Discovery surface:** #2327 was filed from a fresh cluster install. The defect is entirely render-level — which Secret name lands in the manifest — so a `helm template` render is the definitive observation for it, not a proxy for one. No live-cluster waiver needed.
