### PR TITLE
Make the Langfuse and ClickHouse images digest-pinnable

### DIFF
--- a/charts/curie/ci/langfuse-image-pin-assertions.sh
+++ b/charts/curie/ci/langfuse-image-pin-assertions.sh
@@ -7,6 +7,14 @@
 # chart consumer and made the Compose observability query return 500. This gate
 # renders both user-facing consumers, requires one exact version, and proves a
 # floating-tag mutation is rejected.
+#
+# Issue #2332: the same three images must also be pinnable by digest. The
+# templates used to concatenate `repo` and `tag` with a colon, so an operator
+# who set `repo@sha256:...` got `repo@sha256:...:tag` and the kubelet refused it
+# with InvalidImageName. The second half of this file renders the chart with
+# digests set and proves every one of those images -- including the
+# wait-for-clickhouse init container that gates them -- resolves to a bare
+# `repo@sha256:...` and never to the `@sha256:...:tag` shape.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -96,4 +104,193 @@ if [[ "$negative_output" != *"floating Langfuse tags are forbidden"* ]]; then
 fi
 
 echo "negative: replacing the reviewed version with :3 is rejected"
-echo "PASS: chart and Compose share one reviewed Langfuse version and reject floating tags"
+
+# ---------------------------------------------------------------------------
+# Issue #2332: digest-pinnability. Chart render only -- no Compose -- so this
+# section stays runnable wherever `docker compose` is unavailable.
+# ---------------------------------------------------------------------------
+WEB_DIGEST="sha256:$(printf 'aa%.0s' $(seq 32))"
+WORKER_DIGEST="sha256:$(printf 'bb%.0s' $(seq 32))"
+CLICKHOUSE_DIGEST="sha256:$(printf 'cc%.0s' $(seq 32))"
+CLICKHOUSE_TAG="25.12"  # charts/curie/values.yaml clickhouse.image.tag
+
+DIGEST_RENDER="$TMP/chart-digest.yaml"
+DIGEST_CHECKER="$TMP/check-digest.py"
+
+helm template curie "$CHART" \
+  --set-string "langfuse.image.webDigest=$WEB_DIGEST" \
+  --set-string "langfuse.image.workerDigest=$WORKER_DIGEST" \
+  --set-string "clickhouse.image.digest=$CLICKHOUSE_DIGEST" \
+  >"$DIGEST_RENDER"
+
+cat >"$DIGEST_CHECKER" <<'PY'
+import pathlib
+import re
+import sys
+
+import yaml
+
+render_path, web_digest, worker_digest, clickhouse_digest = sys.argv[1:]
+
+expected = {
+    "langfuse-web": f"langfuse/langfuse@{web_digest}",
+    "langfuse-worker": f"langfuse/langfuse-worker@{worker_digest}",
+    "clickhouse": f"clickhouse/clickhouse-server@{clickhouse_digest}",
+}
+
+documents = [
+    document
+    for document in yaml.safe_load_all(pathlib.Path(render_path).read_text())
+    if document
+]
+
+app_images = {}
+# Workload container name -> (app container image, wait-for-clickhouse image).
+gate_pairs = {}
+all_images = []
+preflight_env = None  # {"CLICKHOUSE_IMAGE": ..., "CLICKHOUSE_TAG": ...} from the AVX preflight Job.
+for document in documents:
+    spec = document.get("spec")
+    pod_spec = spec.get("template", {}).get("spec", {}) if isinstance(spec, dict) else {}
+    containers = pod_spec.get("containers") or []
+    init_containers = pod_spec.get("initContainers") or []
+    for container in containers + init_containers:
+        all_images.append(container.get("image"))
+    gate = next((c for c in init_containers if c.get("name") == "wait-for-clickhouse"), None)
+    for container in containers:
+        name = container.get("name")
+        if name in expected:
+            app_images[name] = container.get("image")
+            if gate is not None:
+                gate_pairs[name] = (container.get("image"), gate.get("image"))
+        env_pairs = {e.get("name"): e.get("value") for e in (container.get("env") or [])}
+        if "CLICKHOUSE_IMAGE" in env_pairs:
+            preflight_env = env_pairs
+
+problems = []
+for name, wanted in expected.items():
+    actual = app_images.get(name)
+    if actual != wanted:
+        problems.append(
+            f"{name} must render digest reference {wanted}; found {actual!r} "
+            "(digest pinning is broken)"
+        )
+
+for name in ("langfuse-web", "langfuse-worker"):
+    if name not in gate_pairs:
+        problems.append(
+            f"{name} has no wait-for-clickhouse init container to compare "
+            "(digest pinning is broken)"
+        )
+        continue
+    app_image, gate_image = gate_pairs[name]
+    if gate_image != app_image:
+        problems.append(
+            f"{name} wait-for-clickhouse init container must use the same bytes as the "
+            f"app container {app_image!r}; found {gate_image!r} (digest pinning is broken)"
+        )
+
+if preflight_env is None:
+    problems.append(
+        "no Job container env carries CLICKHOUSE_IMAGE to compare against the AVX "
+        "preflight (digest pinning is broken)"
+    )
+else:
+    clickhouse_app_image = app_images.get("clickhouse")
+    if preflight_env.get("CLICKHOUSE_IMAGE") != clickhouse_app_image:
+        problems.append(
+            "AVX preflight Job env CLICKHOUSE_IMAGE must use the same bytes as the "
+            f"ClickHouse container {clickhouse_app_image!r}; found "
+            f"{preflight_env.get('CLICKHOUSE_IMAGE')!r} (digest pinning is broken)"
+        )
+    if "@sha256:" in (preflight_env.get("CLICKHOUSE_TAG") or ""):
+        problems.append(
+            "AVX preflight Job env CLICKHOUSE_TAG must stay a plain version string "
+            f"for the SSE4.2 prefix match, not a digest; found "
+            f"{preflight_env.get('CLICKHOUSE_TAG')!r} (digest pinning is broken)"
+        )
+
+invalid = sorted(
+    {image for image in all_images if image and re.search(r"@sha256:[0-9a-f]+:", image)}
+)
+if invalid:
+    problems.append(
+        "rendered images use the InvalidImageName shape @sha256:...:tag: "
+        + ", ".join(invalid)
+        + " (digest pinning is broken)"
+    )
+
+if problems:
+    raise SystemExit("\n".join(problems))
+
+print("chart renders every pinnable image as a bare repo@sha256 reference")
+PY
+
+python3 "$DIGEST_CHECKER" "$DIGEST_RENDER" "$WEB_DIGEST" "$WORKER_DIGEST" "$CLICKHOUSE_DIGEST"
+echo "digest: langfuse web/worker, clickhouse and the clickhouse gate all pin by digest"
+echo "digest: AVX preflight Job CLICKHOUSE_IMAGE matches the ClickHouse digest while CLICKHOUSE_TAG stays a plain version string"
+
+MUTANT_DIGEST_RENDER="$TMP/chart-digest-suffixed.yaml"
+python3 - "$DIGEST_RENDER" "$MUTANT_DIGEST_RENDER" "$EXPECTED_VERSION" "$CLICKHOUSE_TAG" <<'PY'
+import pathlib
+import re
+import sys
+
+render, mutant, langfuse_version, clickhouse_tag = sys.argv[1:]
+
+# Reproduce exactly what the broken templates rendered: repository, digest, then
+# a concatenated `:tag` the kubelet rejects as InvalidImageName.
+text = pathlib.Path(render).read_text()
+text = re.sub(
+    r"(langfuse/langfuse(?:-worker)?@sha256:[0-9a-f]+)",
+    lambda match: f"{match.group(1)}:{langfuse_version}",
+    text,
+)
+text = re.sub(
+    r"(clickhouse/clickhouse-server@sha256:[0-9a-f]+)",
+    lambda match: f"{match.group(1)}:{clickhouse_tag}",
+    text,
+)
+pathlib.Path(mutant).write_text(text)
+PY
+
+digest_negative_output=""
+if digest_negative_output="$(python3 "$DIGEST_CHECKER" "$MUTANT_DIGEST_RENDER" "$WEB_DIGEST" "$WORKER_DIGEST" "$CLICKHOUSE_DIGEST" 2>&1)"; then
+  echo "FAIL: an @sha256:...:tag render passed the digest-pin contract" >&2
+  exit 1
+fi
+if [[ "$digest_negative_output" != *"digest pinning is broken"* ]]; then
+  echo "FAIL: digest mutation failed unexpectedly: $digest_negative_output" >&2
+  exit 1
+fi
+
+echo "negative: appending :<tag> after a digest is rejected"
+
+python3 - "$RENDER" "$CLICKHOUSE_TAG" <<'PY'
+import pathlib
+import sys
+
+import yaml
+
+render_path, clickhouse_tag = sys.argv[1:]
+wanted = f"clickhouse/clickhouse-server:{clickhouse_tag}"
+
+actual = None
+for document in yaml.safe_load_all(pathlib.Path(render_path).read_text()):
+    if not document or not isinstance(document.get("spec"), dict):
+        continue
+    containers = document["spec"].get("template", {}).get("spec", {}).get("containers", [])
+    for container in containers:
+        if container.get("name") == "clickhouse":
+            actual = container.get("image")
+
+if actual != wanted:
+    raise SystemExit(
+        f"with no digest set the clickhouse container must stay on {wanted}; found {actual!r}"
+    )
+
+print(f"default render keeps ClickHouse on {wanted}")
+PY
+
+echo "default: no digest set leaves the reviewed ClickHouse tag path unchanged"
+echo "PASS: chart and Compose share one reviewed Langfuse version, reject floating tags, and every pinnable image renders a valid digest reference"

--- a/charts/curie/templates/NOTES.txt
+++ b/charts/curie/templates/NOTES.txt
@@ -24,7 +24,7 @@ Components deployed:
 {{- $sse42 = true }}
 {{- end }}
 {{- end }}
-  - ClickHouse ({{ .Values.clickhouse.image.repository }}:{{ $chTag }}){{ if $sse42 }}  [SSE4.2-safe override]{{ else }}  [AVX required]{{ end }}
+  - ClickHouse ({{ include "curie.image" (dict "repository" .Values.clickhouse.image.repository "tag" .Values.clickhouse.image.tag "digest" .Values.clickhouse.image.digest) }}){{ if $sse42 }}  [SSE4.2-safe override]{{ else }}  [AVX required]{{ end }}
 {{- else }}
   - ClickHouse: BYO at {{ .Values.clickhouse.host }}
 {{- end }}

--- a/charts/curie/templates/_helpers.tpl
+++ b/charts/curie/templates/_helpers.tpl
@@ -1314,14 +1314,15 @@ securityContext:
      ClickHouse that answers slowly needs a longer timeout, not a patched chart.
 
      Call with a dict: `root` (the chart context), `image` (the component's
-     image repository), `containerSecurityContext` and `resources` (the
+     fully-rendered image reference, built by curie.image so a digest pin
+     reaches the gate too), `containerSecurityContext` and `resources` (the
      component's, so the gate inherits the same posture and the pod's effective
      request is unchanged -- init and app container requests are maxed, not
      summed). */}}
 {{- define "curie.langfuse.clickhouseGate" -}}
 {{- $root := .root -}}
 - name: wait-for-clickhouse
-  image: "{{ .image }}:{{ $root.Values.langfuse.image.tag }}"
+  image: {{ .image | quote }}
   imagePullPolicy: {{ $root.Values.global.imagePullPolicy }}
   {{- with .containerSecurityContext }}
   securityContext:

--- a/charts/curie/templates/clickhouse.yaml
+++ b/charts/curie/templates/clickhouse.yaml
@@ -86,8 +86,9 @@ spec:
       containers:
         - name: clickhouse
           # Pinned tag (coupled to langfuse.image.tag); the AVX preflight
-          # validates it against the node's CPU.
-          image: "{{ .Values.clickhouse.image.repository }}:{{ .Values.clickhouse.image.tag }}"
+          # validates it against the node's CPU. clickhouse.image.digest wins
+          # over the tag when set (#2332).
+          image: {{ include "curie.image" (dict "repository" .Values.clickhouse.image.repository "tag" .Values.clickhouse.image.tag "digest" .Values.clickhouse.image.digest) | quote }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           {{- with .Values.clickhouse.containerSecurityContext }}
           securityContext:

--- a/charts/curie/templates/langfuse.yaml
+++ b/charts/curie/templates/langfuse.yaml
@@ -141,14 +141,14 @@ spec:
       {{- if .Values.langfuse.clickhouseReadiness.enabled }}
         {{- include "curie.langfuse.clickhouseGate" (dict
              "root" .
-             "image" .Values.langfuse.image.web
+             "image" (include "curie.image" (dict "repository" .Values.langfuse.image.web "tag" .Values.langfuse.image.tag "digest" .Values.langfuse.image.webDigest))
              "containerSecurityContext" .Values.langfuse.web.containerSecurityContext
              "resources" .Values.langfuse.web.resources) | nindent 8 }}
       {{- end }}
       {{- end }}
       containers:
         - name: langfuse-web
-          image: "{{ .Values.langfuse.image.web }}:{{ .Values.langfuse.image.tag }}"
+          image: {{ include "curie.image" (dict "repository" .Values.langfuse.image.web "tag" .Values.langfuse.image.tag "digest" .Values.langfuse.image.webDigest) | quote }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           {{- with .Values.langfuse.web.containerSecurityContext }}
           securityContext:
@@ -250,13 +250,13 @@ spec:
       initContainers:
         {{- include "curie.langfuse.clickhouseGate" (dict
              "root" .
-             "image" .Values.langfuse.image.worker
+             "image" (include "curie.image" (dict "repository" .Values.langfuse.image.worker "tag" .Values.langfuse.image.tag "digest" .Values.langfuse.image.workerDigest))
              "containerSecurityContext" .Values.langfuse.worker.containerSecurityContext
              "resources" .Values.langfuse.worker.resources) | nindent 8 }}
       {{- end }}
       containers:
         - name: langfuse-worker
-          image: "{{ .Values.langfuse.image.worker }}:{{ .Values.langfuse.image.tag }}"
+          image: {{ include "curie.image" (dict "repository" .Values.langfuse.image.worker "tag" .Values.langfuse.image.tag "digest" .Values.langfuse.image.workerDigest) | quote }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           {{- with .Values.langfuse.worker.containerSecurityContext }}
           securityContext:

--- a/charts/curie/templates/preflight-avx.yaml
+++ b/charts/curie/templates/preflight-avx.yaml
@@ -51,7 +51,7 @@ spec:
             - name: CLICKHOUSE_TAG
               value: {{ .Values.clickhouse.image.tag | quote }}
             - name: CLICKHOUSE_IMAGE
-              value: "{{ .Values.clickhouse.image.repository }}:{{ .Values.clickhouse.image.tag }}"
+              value: {{ include "curie.image" (dict "repository" .Values.clickhouse.image.repository "tag" .Values.clickhouse.image.tag "digest" .Values.clickhouse.image.digest) | quote }}
             - name: SSE42_SAFE_TAGS
               value: {{ join " " .Values.clickhouse.sse42SafeTags | quote }}
             - name: FORCE_NO_AVX

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -119,6 +119,14 @@ langfuse:
     # 39 onward need that ClickHouse version. Do not advance this pin without
     # it, and do not move ClickHouse off 25.12 while this pin stays (#2210).
     tag: "3.225.5"
+    # Optional immutable content digest per image (#2332). Set one and it wins
+    # over `tag` for that image, rendering `repo@sha256:...`; empty (the
+    # default) keeps the reviewed tag path above byte-for-byte. Give the bare
+    # `sha256:<64 hex>` form only -- a full `repo@sha256:...` here renders
+    # `repo@sha256:...@sha256:...` and the kubelet rejects it as
+    # InvalidImageName, which is the failure this key exists to end.
+    webDigest: ""
+    workerDigest: ""
   telemetryEnabled: false
   enableExperimentalFeatures: true
   # Startup gate on the ClickHouse endpoint Langfuse boots against (issue
@@ -371,6 +379,14 @@ clickhouse:
   image:
     repository: clickhouse/clickhouse-server
     tag: "25.12"
+    # Optional immutable content digest (#2332). Set it and it wins over `tag`,
+    # rendering `repo@sha256:...`; empty (the default) keeps the pinned tag
+    # path byte-for-byte. Bare `sha256:<64 hex>` only -- a full
+    # `repo@sha256:...` renders an InvalidImageName reference. The AVX
+    # preflight still evaluates `clickhouse.image.tag` against `sse42SafeTags`,
+    # so keep `tag` set to the version these bytes correspond to when pinning
+    # by digest, or the preflight judges the wrong build.
+    digest: ""
   # Tags whose upstream binaries still ship an SSE4.2 build (no AVX required).
   # The AVX preflight passes an AVX-less node only if the configured tag begins
   # with one of these. Not a supported default: 25.12 is required by the


### PR DESCRIPTION
## What

`langfuse.yaml` (web and worker), `clickhouse.yaml` and the `wait-for-clickhouse` gate concatenated repository and tag with a colon, so writing a digest into those values keys rendered `repo@sha256:...:tag` and the kubelet failed the pod with `InvalidImageName`. Those were the only chart images with no immutable pin available — and they are exactly the components whose tag mutation caused #2190.

They now have the `repository` / `tag` / `digest` shape every other chart image already has, and render through the `curie.image` helper (#62).

- New values keys, all defaulting to `""`: `langfuse.image.webDigest`, `langfuse.image.workerDigest`, `clickhouse.image.digest` (bare `sha256:<64 hex>` form; the comments say so, because a full `repo@sha256:...` here would reintroduce the same invalid reference).
- The `wait-for-clickhouse` init container no longer appends the tag itself. Both call sites pass the fully-rendered reference, so the gate is guaranteed the same bytes as the app container it gates — the site that would otherwise have silently stayed on a mutable tag.
- The AVX preflight's display-only `CLICKHOUSE_IMAGE` env and the ClickHouse line in `NOTES.txt` render through the same helper, so operator-facing output names the bytes actually deployed. `CLICKHOUSE_TAG` deliberately stays the raw version string — the `sse42SafeTags` prefix match depends on it.

## Test

`charts/curie/ci/langfuse-image-pin-assertions.sh` gains a chart-render-only section (no Compose, so it stays runnable where `docker compose` is unavailable) proving:

- all three images plus both gates render bare `repo@sha256:...` references with no trailing tag;
- no rendered image anywhere in the chart matches the invalid `@sha256:...:tag` shape;
- the preflight env agrees with the StatefulSet while `CLICKHOUSE_TAG` stays a plain version;
- **negative control**: re-appending `:<tag>` after each digest — exactly what the old templates rendered — is rejected;
- **default path**: with no digest set, ClickHouse stays on the reviewed tag.

Verified locally: `helm lint` clean; a full default render diffed against `origin/main` differs only in the chart's per-render generated secrets, so the tag path is unchanged; `langfuse-image-pin-assertions.sh`, `clickhouse-langfuse-pin-assertions.sh`, `render-assertions.sh`, `unpinned-image-assertions.sh`, `statefulset-metadata-rollout-assertions.sh` and the langfuse readiness/byo/recreate/runasuser/postgres-readiness gates all pass.

## Conservative defaults chosen

- **Additive keys, no rename.** `langfuse.image.web` / `.worker` keep their existing names rather than moving to a `repository` key, so no operator values file breaks. The digest keys sit beside them.
- **Per-image digests for Langfuse.** Web and worker share one `tag` but are different repositories, so they get separate digest keys rather than one shared value.
- **The AVX preflight still judges `clickhouse.image.tag`.** An operator pinning ClickHouse by digest must keep `tag` set to the version those bytes correspond to, or the preflight evaluates the wrong build; that is documented on the new key. Making the preflight derive a version from a digest is out of scope here.
- **The default-render assertion hardcodes the ClickHouse tag** with a comment, matching the file's existing `EXPECTED_VERSION` convention. It fails loudly if the pin moves without it.

This is the immutability half of the story; the remaining floating major/minor aliases are #2319.

Fix pin: charts/curie/ci/langfuse-image-pin-assertions.sh

Closes #2332
