### PR TITLE
Pin the mail adapter's existingSecret escape in the direct-passthrough parity gate

### DIFF
--- a/charts/curie/ci/direct-passthrough-existing-secret-assertions.sh
+++ b/charts/curie/ci/direct-passthrough-existing-secret-assertions.sh
@@ -2,22 +2,22 @@
 #
 # Render-assertion test for the direct-passthrough credential escape (#1759).
 #
-# templates/secrets.yaml carries nine credential keys read straight from
+# templates/secrets.yaml carries twelve credential keys read straight from
 # .Values with no BYO escape, except githubAppPrivateKey, which already has
 # one (ADR-0092: api.githubAppExistingSecret + api.githubAppExistingSecretKey,
 # see github-app-credential-assertions.sh). This proves the SAME shape lands
-# for the other eight keys, and that two parity-seam gates the new escape
+# for the other eleven keys, and that two parity-seam gates the new escape
 # would otherwise trip are fixed alongside it:
 #
-#   1-2. For each of the eight keys, a default render (no *ExistingSecret set)
+#   1-2. For each of the eleven keys, a default render (no *ExistingSecret set)
 #        still resolves to the chart's own Secret and its published key name,
 #        and setting <field>ExistingSecret makes EVERY consumer of that key
 #        resolve to the named Secret instead -- not just one consumer, for the
 #        two keys with more than one (agentCredentials: agent-sandbox.yaml +
 #        worker.yaml; slackBotToken: dispatcher.yaml + api.yaml + worker.yaml).
 #        Group 2's render also carries a stale inline value on every field, so
-#        it already proves "BYO wins over stale" for all eight, not just the
-#        two multi-consumer ones (mirrors github-app-credential-assertions.sh
+#        it already proves "BYO wins over stale" for all eleven, not just the
+#        multi-consumer ones (mirrors github-app-credential-assertions.sh
 #        assertion (f)).
 #   4.   curie.dispatcher.enabled (_helpers.tpl) must treat an *ExistingSecret
 #        as "token present" too, so a dispatcher wired entirely via BYO
@@ -38,10 +38,32 @@
 #        tier property, verified separately against a real cluster (the same
 #        caveat secrets.yaml already documents for the otlpAuthHeader key).
 #
-# This script is expected to FAIL against the chart as it stands before the
-# *ExistingSecret escape lands (assertions 2, 4a, 5a/5b and 7), and to pass
-# once it does. Accumulates every failure instead of stopping at the first, so
-# a single run reports the complete list.
+#   9.   curie.adapterCredentials (_helpers.tpl) derives the worker's half of
+#        the mail adapter's egress pair from mailAdapter.egressSecret, so both
+#        ends of that shared credential always rotate together. That derivation
+#        has a BYO branch: once mailAdapter.egressSecretExistingSecret is set,
+#        the plain Helm value is unused and the (then required) external worker
+#        map is the independent source of truth. So (9a) the default render
+#        derives the adapter's entry from mailAdapter.egressSecret and the chart
+#        Secret carries all three mail keys; (9b) the BYO render derives NO
+#        entry for the adapter and the chart Secret carries NONE of the three
+#        mail keys -- emitting either would put the very credential the escape
+#        exists to keep out of helm values back into the chart Secret; (9c) the
+#        equality check that normally refuses a worker entry disagreeing with
+#        mailAdapter.egressSecret must NOT fire on that branch, where the plain
+#        value means nothing; and (9d) a negative control with only the
+#        *ExistingSecret removed must still fail the render WITH the equality
+#        check's own diagnostic -- naming both configuration keys and neither
+#        credential value -- proving 9c passes because of the BYO branch, and
+#        not because the check was deleted or some unrelated gate refused first.
+#
+# Assertions 2, 4a, 5a/5b and 7 were written to FAIL against the chart as it
+# stood before the *ExistingSecret escape landed for the original eight keys
+# (#1759), and to pass once it did. The three mail keys and the
+# adapterCredentials BYO branch (1l-1n, 2l-2n and 9) landed their escape later
+# and were added here afterwards, so those are regression pins on shipped
+# behaviour rather than a red-first gate. Accumulates every failure instead of
+# stopping at the first, so a single run reports the complete list.
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -51,7 +73,13 @@ TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
 FAILED=0
-ASSERTION_COUNT=29
+ASSERTION_COUNT=39
+
+# mailAdapter.deploy=true fails closed without at least one AgentMail HTTPS
+# CIDR (see the chart-level invariant in charts/curie/CLAUDE.md), so this flag
+# rides along with every render below that turns the adapter on -- it is not
+# an incidental value.
+MAIL_HTTPS_CIDR="203.0.113.0/24"
 
 # Render the whole chart (never `-s`/--show-only for a template that can
 # render to nothing: under this environment's helm, `-s` on a template whose
@@ -79,9 +107,15 @@ render() {
 }
 
 # ------------------------------------------------------------------------
-# Render 1: the "default" path for all eight keys -- no *ExistingSecret set,
+# Render 1: the "default" path for all eleven keys -- no *ExistingSecret set,
 # every underlying field given a throwaway value (including both Slack tokens,
 # so the dispatcher deploys at all).
+#
+# The two mail flags that are not credentials are load-bearing, not noise:
+# mail-adapter.yaml only renders when mailAdapter.deploy is true, and the
+# mail-adapter egress rail fails CLOSED unless deploy=true is paired with at
+# least one mailAdapter.agentmail.httpsCidrs entry. Drop either and this render
+# stops producing the manifest assertions 1l-1n read.
 # ------------------------------------------------------------------------
 render default \
   --set agentSandbox.runner.credentials=default-agentcreds \
@@ -91,12 +125,26 @@ render default \
   --set sealing.previousPrivateKey=default-prevsealingkey \
   --set dispatcher.slack.appToken=default-apptoken \
   --set dispatcher.slack.botToken=default-bottoken \
-  --set dispatcher.slack.signingSecret=default-signingsecret
+  --set dispatcher.slack.signingSecret=default-signingsecret \
+  --set mailAdapter.deploy=true \
+  --set-string "mailAdapter.agentmail.httpsCidrs[0]=${MAIL_HTTPS_CIDR}" \
+  --set mailAdapter.channelToken=default-channeltoken \
+  --set mailAdapter.egressSecret=default-egresssecret \
+  --set mailAdapter.agentmail.apiKey=default-apikey
 
 # ------------------------------------------------------------------------
-# Render 2: the BYO path for all eight keys. Each field ALSO carries a stale
+# Render 2: the BYO path for all eleven keys. Each field ALSO carries a stale
 # inline value, so this render doubles as assertions 2 (BYO resolves
-# correctly, every consumer) and 3 (BYO wins over a stale inline value).
+# correctly, every consumer) and 3 (BYO wins over a stale inline value); the
+# mail fields are set the same way so that "stale inline value on every field"
+# property stays uniform across all eleven keys.
+#
+# Two couplings, both deliberate: the same fail-closed mail rail as render 1
+# (deploy=true needs an mailAdapter.agentmail.httpsCidrs entry), and
+# mailAdapter.egressSecretExistingSecret requires
+# worker.adapterCredentialsExistingSecret -- which this render already sets for
+# assertion 2c, so neither of those two --set flags is removable even though
+# they read as belonging to unrelated keys.
 # ------------------------------------------------------------------------
 render byo \
   --set agentSandbox.runner.credentials=STALE-agentcreds \
@@ -114,7 +162,15 @@ render byo \
   --set dispatcher.slack.botToken=STALE-bottoken \
   --set dispatcher.slack.botTokenExistingSecret=byo-bottoken \
   --set dispatcher.slack.signingSecret=STALE-signingsecret \
-  --set dispatcher.slack.signingSecretExistingSecret=byo-signingsecret
+  --set dispatcher.slack.signingSecretExistingSecret=byo-signingsecret \
+  --set mailAdapter.deploy=true \
+  --set-string "mailAdapter.agentmail.httpsCidrs[0]=${MAIL_HTTPS_CIDR}" \
+  --set mailAdapter.channelToken=STALE-channeltoken \
+  --set mailAdapter.channelTokenExistingSecret=byo-channeltoken \
+  --set mailAdapter.egressSecret=STALE-egresssecret \
+  --set mailAdapter.egressSecretExistingSecret=byo-egresssecret \
+  --set mailAdapter.agentmail.apiKey=STALE-apikey \
+  --set mailAdapter.agentmail.apiKeyExistingSecret=byo-apikey
 
 # ------------------------------------------------------------------------
 # Renders for assertion 5 (agentCredentials gate): credentialsExistingSecret
@@ -126,9 +182,10 @@ render agentcred-pos \
 render bare
 
 # ------------------------------------------------------------------------
-# Assertions 1, 2, 3, 5a-5d: structural checks on the rendered env/secretKeyRef
-# shape, via PyYAML rather than grep/awk -- a line-oriented reader silently
-# mis-reads a requoted value or a reordered key (see the same reasoning in
+# Assertions 1, 2, 3, 5a-5d and 9a-9b: structural checks on the rendered
+# env/secretKeyRef shape and on the chart Secret's own stringData, via PyYAML
+# rather than grep/awk -- a line-oriented reader silently mis-reads a requoted
+# value or a reordered key (see the same reasoning in
 # dispatcher-api-wiring-assertions.sh).
 # ------------------------------------------------------------------------
 DEFAULT_DIR="$TMP/default/curie/templates" \
@@ -136,6 +193,7 @@ BYO_DIR="$TMP/byo/curie/templates" \
 AGENTCRED_POS_DIR="$TMP/agentcred-pos/curie/templates" \
 BARE_DIR="$TMP/bare/curie/templates" \
 python3 <<'PY'
+import json
 import os
 import sys
 
@@ -169,8 +227,8 @@ def find_containers(obj, acc):
             find_containers(item, acc)
 
 
-def find_env(manifest, container_name, env_name):
-    """Return (secretKeyRef-or-None, match-count) for one env entry.
+def find_env_entry(manifest, container_name, env_name):
+    """Return (whole-env-entry-or-None, match-count) for one env entry.
 
     Searches every container across every document in the file, regardless of
     the owning object's kind (Deployment for api/worker/dispatcher,
@@ -185,12 +243,19 @@ def find_env(manifest, container_name, env_name):
     entries = [e for c in matched for e in (c.get("env") or []) if e.get("name") == env_name]
     if len(entries) != 1:
         return None, len(entries)
-    ref = (entries[0].get("valueFrom") or {}).get("secretKeyRef")
-    return ref, 1
+    return entries[0], 1
+
+
+def find_env(manifest, container_name, env_name):
+    """Return (secretKeyRef-or-None, match-count) for one env entry."""
+    entry, n = find_env_entry(manifest, container_name, env_name)
+    if entry is None:
+        return None, n
+    return (entry.get("valueFrom") or {}).get("secretKeyRef"), n
 
 
 def check_ref(assertion_id, manifest, container_name, env_name, expected_secret, expected_key, ctx):
-    ref, n = find_env(manifest, container_name, env_name)
+    entry, n = find_env_entry(manifest, container_name, env_name)
     if n == 0:
         failures.append(f"[{assertion_id}] {ctx}: {env_name} did not render on container "
                          f"{container_name!r} in {manifest}")
@@ -199,6 +264,18 @@ def check_ref(assertion_id, manifest, container_name, env_name, expected_secret,
         failures.append(f"[{assertion_id}] {ctx}: {env_name} rendered {n} times on container "
                          f"{container_name!r}, expected exactly 1")
         return
+    # An inline `value:` sitting ALONGSIDE the secretKeyRef is the half-landed
+    # escape (#2328): the ref looks right while the credential is still written
+    # into the rendered manifest, `helm get manifest` and release history.
+    # Kubernetes refuses both fields on one env entry at admission, but `helm
+    # template` renders them happily -- so this script is the only gate that
+    # sees it. The value itself is never printed.
+    if "value" in entry:
+        failures.append(f"[{assertion_id}] {ctx}: {env_name} carries an inline value alongside its "
+                         "secretKeyRef, which puts the credential into the rendered manifest "
+                         "(value not printed). Kubernetes rejects both fields at admission; "
+                         "`helm template` does not, so only this assertion catches it.")
+    ref = (entry.get("valueFrom") or {}).get("secretKeyRef")
     if not ref:
         failures.append(f"[{assertion_id}] {ctx}: {env_name} has no valueFrom.secretKeyRef "
                          "(an inline value would put this credential in the rendered manifest)")
@@ -223,6 +300,20 @@ def check_absent(assertion_id, manifest, container_name, env_name, ctx):
     if n != 0:
         failures.append(f"[{assertion_id}] {ctx}: {env_name} rendered on container "
                          f"{container_name!r} in {manifest} (expected ABSENT)")
+
+
+def secret_string_data(render_dir):
+    """stringData of the chart's OWN Secret in one render's secrets.yaml.
+
+    Assertion 9 reads the emitted Secret rather than a consumer's env, because
+    what it is proving is what the chart WRITES (a derived adapter entry, and
+    which mail keys exist at all), not where a container reads it from. Both
+    lookups go through here so the two branches cannot drift apart.
+    """
+    for doc in load_docs(f"{render_dir}/secrets.yaml"):
+        if doc.get("kind") == "Secret" and (doc.get("metadata") or {}).get("name") == SECRET:
+            return doc.get("stringData") or {}
+    return {}
 
 
 # ---- 1: default render (no *ExistingSecret set) resolves to the chart's own
@@ -250,11 +341,20 @@ check_ref("1j", f"{d}/worker.yaml", "worker", "SLACK_BOT_TOKEN",
           SECRET, "slackBotToken", "slackBotToken via worker.yaml")
 check_ref("1k", f"{d}/dispatcher.yaml", "dispatcher", "SLACK_SIGNING_SECRET",
           SECRET, "slackSigningSecret", "slackSigningSecret via dispatcher.yaml")
+# The mail adapter is the third multi-key consumer template (after worker.yaml
+# and dispatcher.yaml): all three mail keys resolve on its single container, so
+# a per-key escape that only half-landed shows up as one of these three.
+check_ref("1l", f"{d}/mail-adapter.yaml", "mail-adapter", "CURIE_CHANNEL_TOKEN",
+          SECRET, "mailChannelToken", "mailChannelToken via mail-adapter.yaml")
+check_ref("1m", f"{d}/mail-adapter.yaml", "mail-adapter", "CURIE_EGRESS_SECRET",
+          SECRET, "mailEgressSecret", "mailEgressSecret via mail-adapter.yaml")
+check_ref("1n", f"{d}/mail-adapter.yaml", "mail-adapter", "AGENTMAIL_API_KEY",
+          SECRET, "mailAgentmailApiKey", "mailAgentmailApiKey via mail-adapter.yaml")
 
 # ---- 2: *ExistingSecret makes every consumer resolve to the named Secret
 #         instead, winning over the stale inline value the same render also
 #         carries for every field -- so this group already IS the "wins over
-#         stale" proof for all eight keys, not just the two multi-consumer
+#         stale" proof for all eleven keys, not just the multi-consumer
 #         ones; a separate assertion 3 repeating 2b/2h byte-for-byte would add
 #         no coverage of its own. ----
 b = BYO_DIR
@@ -280,6 +380,14 @@ check_ref("2j", f"{b}/worker.yaml", "worker", "SLACK_BOT_TOKEN",
           "byo-bottoken", "slackBotToken", "slackBotToken via worker.yaml")
 check_ref("2k", f"{b}/dispatcher.yaml", "dispatcher", "SLACK_SIGNING_SECRET",
           "byo-signingsecret", "slackSigningSecret", "slackSigningSecret via dispatcher.yaml")
+# Same three mail keys on the third multi-key consumer template, each pointed at
+# its own BYO Secret over the stale inline value this render also carries.
+check_ref("2l", f"{b}/mail-adapter.yaml", "mail-adapter", "CURIE_CHANNEL_TOKEN",
+          "byo-channeltoken", "mailChannelToken", "mailChannelToken via mail-adapter.yaml")
+check_ref("2m", f"{b}/mail-adapter.yaml", "mail-adapter", "CURIE_EGRESS_SECRET",
+          "byo-egresssecret", "mailEgressSecret", "mailEgressSecret via mail-adapter.yaml")
+check_ref("2n", f"{b}/mail-adapter.yaml", "mail-adapter", "AGENTMAIL_API_KEY",
+          "byo-apikey", "mailAgentmailApiKey", "mailAgentmailApiKey via mail-adapter.yaml")
 
 # ---- 5: the agentCredentials gate (agent-sandbox.yaml AND worker.yaml) must
 #         also open on credentialsExistingSecret alone. ----
@@ -297,13 +405,80 @@ check_absent("5c", f"{n}/agent-sandbox.yaml", "runner", "CURIE_CREDENTIALS",
 check_absent("5d", f"{n}/worker.yaml", "worker", "CURIE_CREDENTIALS",
              "negative control: both empty, via worker.yaml")
 
+# ---- 9a-9b: the curie.adapterCredentials derivation (_helpers.tpl) and its BYO
+#      branch, read off the chart's own Secret. adapterCredentials is a
+#      JSON-encoded string, so it is parsed rather than substring-matched.
+#      Failure messages name the credential and never print its value. ----
+MAIL_SLUG = "mail-adapter"          # .Values.mailAdapter.adapterSlug
+MAIL_KEYS = ("mailChannelToken", "mailEgressSecret", "mailAgentmailApiKey")
+
+# Parsed once per render directory -- both the 9a and 9b branches below read
+# these same stringData dicts rather than each re-opening and re-parsing
+# secrets.yaml a second time.
+default_sd = secret_string_data(DEFAULT_DIR)
+byo_sd = secret_string_data(BYO_DIR)
+
+
+def adapter_credentials(assertion_id, string_data, ctx):
+    """Parsed adapterCredentials map, or None with a failure already recorded."""
+    raw = string_data.get("adapterCredentials")
+    if raw is None:
+        failures.append(f"[{assertion_id}] {ctx}: the chart Secret has no adapterCredentials key")
+        return None
+    try:
+        parsed = json.loads(raw)
+    except ValueError:
+        failures.append(f"[{assertion_id}] {ctx}: adapterCredentials is not valid JSON "
+                        "(curie.adapterCredentials must emit a toJson map)")
+        return None
+    if not isinstance(parsed, dict):
+        failures.append(f"[{assertion_id}] {ctx}: adapterCredentials parsed to "
+                        f"{type(parsed).__name__}, expected an object")
+        return None
+    return parsed
+
+
+# Default (non-BYO) branch: the chart derives the worker's half of the egress
+# pair from mailAdapter.egressSecret, so both ends rotate together, and the
+# Secret carries all three mail credentials the adapter reads.
+creds = adapter_credentials("9a", default_sd, "default render")
+if creds is not None and creds.get(MAIL_SLUG) != "default-egresssecret":
+    failures.append(f"[9a] default render: adapterCredentials[{MAIL_SLUG!r}] is missing or does "
+                    "not equal mailAdapter.egressSecret (value not printed -- it is a live "
+                    "egress credential). The worker's half must be derived from it, or the two "
+                    "ends of the pair rotate independently and egress 401s.")
+for key in MAIL_KEYS:
+    if key not in default_sd:
+        failures.append(f"[9a] default render: chart Secret is missing {key}, which the mail "
+                        "adapter reads from it when no *ExistingSecret is set")
+
+# BYO branch: with the adapter's egress credential externally sourced, the plain
+# mailAdapter.egressSecret is unused and the required external worker map is the
+# independent source of truth -- so the chart must neither derive the adapter's
+# entry from that value nor emit any of the three mail keys. Emitting them would
+# put the very credential this escape exists to keep OUT of helm values straight
+# back into the chart Secret.
+byo_creds = adapter_credentials("9b", byo_sd, "BYO render")
+if byo_creds is not None and MAIL_SLUG in byo_creds:
+    failures.append(f"[9b] BYO render: adapterCredentials still carries an entry for "
+                    f"{MAIL_SLUG!r} with mailAdapter.egressSecretExistingSecret set. On the BYO "
+                    "branch the plain mailAdapter.egressSecret is unused, and the external "
+                    "worker map is the only source of truth.")
+for key in MAIL_KEYS:
+    if key in byo_sd:
+        failures.append(f"[9b] BYO render: chart Secret still emits {key} even though its own "
+                        "*ExistingSecret is set. That writes the externally managed credential "
+                        "back into helm values-sourced chart state, which is exactly what the "
+                        "escape exists to prevent.")
+
 if failures:
     for msg in failures:
         print(f"FAIL {msg}", file=sys.stderr)
-    print(f"{len(failures)} of 26 python-side assertions failed "
-          "(assertions 1, 2 and 5a-5d; 4a-4b and 7 run separately in bash)", file=sys.stderr)
+    print(f"{len(failures)} of 34 python-side assertions failed "
+          "(assertions 1, 2, 5a-5d and 9a-9b; 4a-4b, 7 and 9c-9d run separately in bash)",
+          file=sys.stderr)
     sys.exit(1)
-print("OK: all 26 python-side assertions passed (1a-1k, 2a-2k, 5a-5d)")
+print("OK: all 34 python-side assertions passed (1a-1n, 2a-2n, 5a-5d, 9a-9b)")
 PY
 [ $? -eq 0 ] || FAILED=1
 
@@ -364,6 +539,106 @@ elif [ "$CHECKSUM_BASE" = "$CHECKSUM_WITH_SECRET" ]; then
   FAILED=1
 else
   echo "OK [7] checksum/adapter-credentials changes when adapterCredentialsExistingSecret changes"
+fi
+
+# 9c and 9d differ by exactly the two *ExistingSecret flags 9c appends below
+# and nothing else -- that is precisely what makes 9d a control for 9c, so
+# these two argument lists must not be allowed to drift apart.
+EQUALITY_ARGS=(
+  --set mailAdapter.deploy=true
+  --set-string "mailAdapter.agentmail.httpsCidrs[0]=${MAIL_HTTPS_CIDR}"
+  --set mailAdapter.channelToken=t
+  --set mailAdapter.egressSecret=PLAIN-DIFFERENT
+  --set mailAdapter.agentmail.apiKey=k
+  --set worker.adapterCredentials.mail-adapter=SOMETHING-ELSE
+)
+
+# ------------------------------------------------------------------------
+# Assertion 9c/9d: the curie.adapterCredentials equality check has a BYO
+# branch. Normally the chart REFUSES a render where worker.adapterCredentials
+# already carries an entry for the mail adapter's slug that disagrees with
+# mailAdapter.egressSecret -- the two are one credential and a silent
+# disagreement is a 401 at egress time that reads like a code bug. But once
+# mailAdapter.egressSecretExistingSecret is set, the plain
+# mailAdapter.egressSecret is unused: the external worker map is the
+# independent source of truth, so there is nothing left to disagree WITH and
+# the check must not fire. 9c proves the render succeeds on that branch; 9d is
+# the negative control that the check itself still exists, and it pins the
+# check's OWN diagnostic rather than "the render failed somehow" -- a bare
+# non-zero exit would keep 9d green if helm were missing, a new fail-closed gate
+# fired first, or a replacement fail() no longer implemented this check at all,
+# which is exactly the false pass that would hollow out 9c.
+# mail-adapter-wiring-assertions.sh assertion 13c is the sibling control of the
+# same shape.
+# ------------------------------------------------------------------------
+# 9c invokes `helm template` directly rather than through render(): 9c's argv
+# carries the two sentinel values (PLAIN-DIFFERENT and SOMETHING-ELSE) that 9d
+# asserts must never appear in the chart's own refusal, so routing 9c through
+# a helper that echoes its argv ("$*") on an unexpected failure would have this
+# file print the very strings its sibling assertion exists to prove are never
+# printed -- the pre-existing default and byo renders above also pass
+# synthetic credential values through render(), so "this invocation's argv is
+# nothing but credential values" was never what set 9c apart. Hardening
+# render() itself never to echo raw argv is the deeper fix, deliberately left
+# out of scope here: that helper is shared with eight assertions this ticket
+# does not touch.
+rm -rf "$TMP/adaptercreds-byo-branch"
+helm template curie "$CHART" -n curie --output-dir "$TMP/adaptercreds-byo-branch" \
+  "${EQUALITY_ARGS[@]}" \
+  --set mailAdapter.egressSecretExistingSecret=byo-egresssecret \
+  --set worker.adapterCredentialsExistingSecret=byo-adaptercreds \
+  >/dev/null 2>"$TMP/adaptercreds-byo-branch.stderr"
+BYO_BRANCH_RC=$?
+if [ "$BYO_BRANCH_RC" -eq 0 ]; then
+  echo "OK [9c] adapterCredentials equality check does not fire when the adapter's egress credential is externally sourced"
+else
+  echo "FAIL [9c] render was refused (rc=$BYO_BRANCH_RC) even though" \
+       "mailAdapter.egressSecretExistingSecret is set. On the BYO branch the plain" \
+       "mailAdapter.egressSecret is unused, so the equality check against" \
+       "worker.adapterCredentials must not fire -- otherwise an operator who moved this" \
+       "credential out of helm values can never render the chart again." \
+       "(Neither the argv nor the captured stderr is echoed: both carry credential values.)" >&2
+  FAILED=1
+fi
+
+# Negative control: the SAME disagreement with ONLY egressSecretExistingSecret
+# removed must still FAIL the render, AND fail with this check's own diagnostic.
+# Without that, 9c would also pass if the equality check had simply been deleted
+# and something else refused the render. `helm template` is invoked directly
+# rather than through render(), which reports any non-zero exit as a failure --
+# here a non-zero exit is the expected result. The captured stderr is written
+# under "$TMP" and never echoed: it is matched only for the two configuration
+# key names the check's own fail() prints, and asserted NOT to contain either
+# sentinel -- that absence is what pins fail()'s refusal to print either half of
+# a live egress credential. Matching the key names rather than the whole
+# sentence keeps ordinary rewording of the message out of CI's way.
+NEG_STDERR="$TMP/adaptercreds-equality-neg.stderr"
+helm template curie "$CHART" -n curie \
+  "${EQUALITY_ARGS[@]}" \
+  >/dev/null 2>"$NEG_STDERR"
+NEG_RC=$?
+if [ "$NEG_RC" -eq 0 ]; then
+  echo "FAIL [9d] render SUCCEEDED with worker.adapterCredentials.mail-adapter disagreeing with" \
+       "mailAdapter.egressSecret and no *ExistingSecret set. The equality check must still refuse" \
+       "that combination -- otherwise 9c passes because the check is gone, not because the BYO" \
+       "branch skips it." >&2
+  FAILED=1
+elif ! grep -qF 'worker.adapterCredentials.mail-adapter' "$NEG_STDERR" \
+  || ! grep -qF 'mailAdapter.egressSecret' "$NEG_STDERR"; then
+  echo "FAIL [9d] the render failed (rc=$NEG_RC) but its stderr does not name BOTH" \
+       "worker.adapterCredentials.mail-adapter and mailAdapter.egressSecret, so this control" \
+       "cannot tell the equality check's own refusal apart from an unrelated failure (a new" \
+       "fail-closed gate, a schema rejection, a missing helm). Re-point the match at the" \
+       "check's current diagnostic, or restore the check." >&2
+  FAILED=1
+elif grep -qF 'PLAIN-DIFFERENT' "$NEG_STDERR" || grep -qF 'SOMETHING-ELSE' "$NEG_STDERR"; then
+  echo "FAIL [9d] the equality check's refusal printed one of the two disagreeing values." \
+       "Both halves of the mail adapter's egress pair are live credentials and the chart's fail()" \
+       "must name the configuration keys only -- an error string lands in CI logs, terminal" \
+       "scrollback and helm's own output." >&2
+  FAILED=1
+else
+  echo "OK [9d] negative control: the equality check still refuses a disagreement off the BYO branch, naming both keys and neither value"
 fi
 
 # ---- 8 (note, not an assertion): a BYO Secret missing the referenced key


### PR DESCRIPTION
## What this changes

`charts/curie/ci/direct-passthrough-existing-secret-assertions.sh` is the parity
gate for the #1759 direct-passthrough credential escape, wired into
`.github/workflows/helm-ci.yaml`. It covered eight of the eleven keys consumed
through `curie.secretRef`. The three mail-adapter keys landed their
`existingSecret` / `existingSecretKey` pair afterwards and were never added, so
nothing in CI held the escape in place for the one credential that authorizes a
third-party mail provider.

This adds that coverage: 29 assertions to 39.

- **1l-1n / 2l-2n** — `mailChannelToken`, `mailEgressSecret` and
  `mailAgentmailApiKey` resolve to the chart Secret and their published key names
  by default, and to the named external Secret when each key's own
  `*ExistingSecret` is set, winning over the stale inline value the same render
  carries for every field.
- **9a / 9b** — the `curie.adapterCredentials` derivation: on the default path
  the chart derives the worker's half of the egress pair from
  `mailAdapter.egressSecret` and emits all three mail keys; on the BYO path it
  derives no entry and emits none of the three, so the escape cannot write the
  externally managed credential back into chart state.
- **9c / 9d** — the equality check does not fire when the adapter's egress
  credential is externally sourced, with a negative control proving it still
  refuses a split pair off that branch, names both configuration keys, and prints
  neither half of the credential.

`check_ref` now also refuses an inline `value:` beside a `secretKeyRef`. A
half-landed escape that adds `curie.secretRef` but leaves the literal in place
puts the credential straight back into `helm get manifest`; Kubernetes rejects
both fields at admission but `helm template` does not, so only this assertion
catches it.

## Note on the rest of the issue

The chart wiring #2328 asks for already landed on `main` in 878d1a6d and
426c9340 — the three values pairs, the `secrets.yaml` BYO guards and its
twelve-key comment, the three `curie.secretRef` sites in `mail-adapter.yaml`, the
README table, and the `curie.adapterCredentials` BYO branch. Each was re-verified
against this branch's base rather than assumed. The CI clause was the only one
still outstanding, so this PR is that clause alone.

## Out-of-scope annotations

Three deliberate calls, flagged by review and kept:

1. **`check_ref`'s inline-`value` refusal applies to all 22 ref assertions**, not
   only the six new mail ones, so it also strengthens the sixteen #1759
   assertions this ticket did not ask about. Gating it to the mail keys would
   mean a flag whose only purpose is keeping the other sixteen weaker; an inline
   `value:` beside a `secretKeyRef` is invalid in every one of the 22 cases.
2. **`render()` still echoes its argv on an unexpected failure.** Assertion 9c
   bypasses that helper rather than hardening it, because 9c's argv carries the
   two sentinel values 9d asserts are never printed. Hardening `render()` itself
   is the deeper fix and would change behaviour for eight assertions outside this
   ticket, so it is left for a follow-up.
3. **9a-9d overlap `mail-adapter-wiring-assertions.sh` assertions 7 and 13c.**
   The two scripts have different mandates: that one is the mail adapter's own
   wiring gate, this one is the cross-key parity gate that has to show the mail
   keys land the *same shape* as the other eight. 9d matches only the two
   configuration key names, not the sentence, so ordinary rewording of the chart's
   message does not break CI.

## Verification

- `helm lint charts/curie` — 0 failed
- `bash charts/curie/ci/direct-passthrough-existing-secret-assertions.sh` — 39 assertions pass
- `charts/curie/ci/mail-adapter-wiring-assertions.sh` (20) and
  `github-app-credential-assertions.sh` (6) still pass
- `shellcheck -S warning` — clean
- **Mutation-tested against throwaway chart copies**, so the new assertions are
  not vacuous. Each mutation was caught:
  | Mutation | Caught by |
  | --- | --- |
  | `mail-adapter.yaml` reverted to hardcode `curie.secretName` | 2l, 2m, 2n |
  | inline `value:` added beside a mail `secretKeyRef` | 1l, 2l |
  | the three `secrets.yaml` BYO guards forced open and the derivation's BYO branch removed | 9b, 9c |
  | the derived `adapterCredentials` value corrupted | 9a |
  | the equality check deleted outright | 9d |
  | the refusal reworded to name neither configuration key | 9d |
  | the refusal changed to print both disagreeing values | 9d |

## Done-check

- [x] Tests present and green — 39 assertions, mutation-verified above
- [x] Adversarial code review (agent-router, reviewer `grok`) — 3 findings, all fixed: 9d strengthened from "any non-zero exit" to the check's own diagnostic plus sentinel absence; 9c moved off `render()`; `check_ref` inline-`value` refusal added
- [x] Adversarial scope review (agent-router, reviewer `grok`) — 2 findings: the header multi-consumer clause was miscategorising the mail keys and is fixed; the `check_ref` widening is annotated above rather than reverted
- [x] Spec-vs-impl review — all six acceptance criteria met against `origin/main` plus this commit
- [x] Consolidation pass — reuse / simplification / efficiency / altitude; applied the repeated-CIDR constant, the shared 9c/9d argument array, the single `secrets.yaml` parse per render, and an accurate rationale comment on 9c. Skipped the cross-file duplication findings, annotated above
- [x] Lint clean — `helm lint`, `shellcheck`
- [x] Guard demonstration — every new assertion executed against a mutated chart and observed failing, output in the table above
- [x] Train check — milestone v0.8.6 is a patch milestone, base is `main`
- [x] Sibling-path parity — `githubAppPrivateKey` is the twelfth key and keeps its own ADR-0092 escape (`api.githubAppExistingSecret`), pinned separately by `github-app-credential-assertions.sh`; unifying it on `curie.secretRef` would be its own ticket
- [ ] Discovery-surface proof — N/A. `helm template` cannot exercise admission-time behaviour, so the "BYO Secret missing the referenced key fails the pod loudly" property stays a cluster-tier property. The file already documents that as note 8, unchanged by this PR

## Fix pin verification

The selector this change would otherwise declare is
`charts/curie/ci/direct-passthrough-existing-secret-assertions.sh`, which this pull
request does change. The gate cannot use it: `cli/scripts/verify-fix-pin.sh` proves a
pin by reversing the product hunk and watching the selector go red, and this pull
request has no product hunk to reverse — the chart fix landed on `main` in 878d1a6d,
and only the CI pin was still missing. It fails with `change contains no product
files to reverse`. The equivalent red-first evidence is the mutation table above:
seven separate reversals of the chart behaviour, each caught by the named assertion.

Fix pin: n/a - no product hunk in this pull request to reverse; the chart fix landed on main in 878d1a6d and this adds only the CI pin, whose red-first proof is the mutation table above

Closes #2328
