### PR TITLE
Bring the mail adapter under shared telemetry and log redaction

### DIFF
--- a/apps/mail-adapter/CLAUDE.md
+++ b/apps/mail-adapter/CLAUDE.md
@@ -52,6 +52,32 @@ the enforceable-rule summary.
   provider message/thread ids, or reply text. Use a one-way correlation token
   and a reason/state label so operators can join retries without copying mail
   content into the cluster log-retention system.
+- **Every log record leaves through the shared service logger, and that filter
+  is a backstop, not a licence.** `main()` calls `bootstrap_service_telemetry`
+  on the *package* logger `curie_mail_adapter`, which installs one redacting
+  single-line-JSON stderr handler and sets `propagate=False` there; `run`,
+  `adapter` and `egress` each hold a `getLogger(__name__)` child, so one
+  bootstrap covers all three and nothing walks past it to a root handler. Do not
+  reintroduce `logging.basicConfig` (it installs a root handler and the same
+  record is then emitted twice, once unformatted), and do not attach a handler
+  that bypasses the service logger -- either move re-opens the unfiltered path
+  this closed. What the filter does **not** do is the load-bearing half:
+  `packages/telemetry/src/curie_telemetry/redact.py`'s `REDACTION_RULES` has no
+  rule for any of this adapter's own credential shapes. A `chn-` channel token,
+  an AgentMail API key and `CURIE_EGRESS_SECRET` all pass through verbatim
+  unless they happen to appear as a URL query parameter (`?token=`,
+  `?api_key=`), as a bare `token=`/`secret=`/`api_key=` assignment, or after
+  `Authorization: Bearer`. `CURIE_CHANNEL_TOKEN=<value>` is specifically **not**
+  redacted -- the `secret_assignment` rule needs a word boundary before `token`,
+  and the preceding `_` denies it -- and neither is an `X-API-Key: <value>`
+  header rendered into a message. The "no raw mail PII" rule above is likewise a
+  code-level obligation the filter cannot enforce: no rule matches an address,
+  subject, body or provider id. Keep credentials and mail content out of the
+  record in the first place; the filter only catches the shapes it knows.
+  Deliberately absent for now: this adapter authors **no spans**. The bootstrap
+  installs the resource and the exporters, so records and any future spans carry
+  `service.name: curie-mail-adapter`, but neither the poll loop nor the egress
+  path is instrumented -- traces will show nothing from it until that lands.
 - **Empty allow-list plus ingress enabled is a boot failure, not deny-all.** The
   inbox is a public mailbox by construction, so fail-open would make every install
   an open trigger for agent turns. Allow-all must be written as `*`.

--- a/apps/mail-adapter/README.md
+++ b/apps/mail-adapter/README.md
@@ -188,6 +188,23 @@ path cannot become an unauthenticated write.
 - **The `chn` token expires.** The adapter cannot re-mint it (that would need a
   platform key it must not hold). It persists the ingress 401 and keeps the mail
   pending; the operator re-mints the scoped token and rolls the pod.
+- **Logs are single-line JSON on stderr, and export is opt-in.** The adapter
+  bootstraps the shared `curie-telemetry` service logger at start, so its output
+  is one JSON object per record on stderr carrying `service.name:
+  curie-mail-adapter`, a severity, the module logger name and a redacted
+  message, rather than the plain text earlier versions printed -- expect a
+  log-shipper or `kubectl logs` grep written against the old format to need
+  updating. With no `OTEL_EXPORTER_OTLP_ENDPOINT` set, nothing is exported
+  anywhere and only that redacting stderr handler runs, which is the supported
+  local and air-gapped mode. With the chart's in-cluster collector deployed
+  (`otelCollector.deploy=true`) the chart both sets the OTLP env and opens the
+  adapter's egress policy to the collector. With `otelCollector.deploy=false`
+  and an external `otelCollector.endpoint`, the env is set but the adapter's own
+  egress policy has no peer for that address, so the operator must apply an
+  additional egress policy selecting the adapter or the exports are silently
+  dropped -- see the mail-adapter section of `charts/curie/README.md`. What is
+  exported is log records: the adapter authors no spans of its own yet, so a
+  trace search for it comes back empty even on a healthy export path.
 
 ### State, privacy, and recovery
 

--- a/apps/mail-adapter/pyproject.toml
+++ b/apps/mail-adapter/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.13"
 dependencies = [
     "aci-protocol",
     "curie-channel-protocol",
+    "curie-telemetry",
     "pydantic>=2.10",
     "pydantic-settings>=2.7",
 ]

--- a/apps/mail-adapter/src/curie_mail_adapter/run.py
+++ b/apps/mail-adapter/src/curie_mail_adapter/run.py
@@ -13,9 +13,13 @@ Run it with ``python -m curie_mail_adapter``.
 from __future__ import annotations
 
 import logging
+import os
 import signal
 import threading
 
+from curie_telemetry import bootstrap_service_telemetry
+
+from . import __version__
 from .adapter import MailAdapter
 from .config import MailAdapterConfig
 from .egress import make_server
@@ -57,45 +61,64 @@ def boot_problems(config: MailAdapterConfig) -> list[str]:
 
 
 def main() -> None:
-    logging.basicConfig(level=logging.INFO)
-    config = MailAdapterConfig()
-
-    problems = boot_problems(config)
-    if problems:
-        for problem in problems:
-            logger.error("%s", problem)
-        raise SystemExit(1)
-
-    adapter = MailAdapter(config)
-    server = make_server(adapter, config.port)
-    threading.Thread(target=server.serve_forever, daemon=True).start()
-    logger.info(
-        "mail adapter starting: kind=email port=%s ingress_enabled=%s",
-        server.server_address[1],
-        config.ingress_enabled,
+    # The *package* logger is handed over, not this module's. `run`, `adapter`
+    # and `egress` each hold their own `getLogger(__name__)` child of it, and
+    # `configure_service_logging` sets `propagate=False` on exactly the logger it
+    # is given — so one bootstrap installs the redacting JSON handler for all
+    # three and nothing walks past it to a root handler. Bootstrapping the three
+    # module loggers instead would leave a fourth module silently unredacted.
+    telemetry = bootstrap_service_telemetry(
+        "curie-mail-adapter",
+        service_version=__version__,
+        logger=logging.getLogger("curie_mail_adapter"),
+        environ=os.environ,
     )
-
-    def _handle_signal(signum: int, _frame: object) -> None:
-        logger.info("received signal %s, shutting down", signum)
-        adapter.shutdown.set()
-
-    signal.signal(signal.SIGINT, _handle_signal)
-    signal.signal(signal.SIGTERM, _handle_signal)
-
     try:
-        if config.ingress_enabled:
-            adapter.poll_loop()
-        else:
-            # The flag gates the poller, never the server: a staged cutover
-            # serves replies before it starts ingesting.
-            logger.info("ingress disabled; serving egress only")
-            adapter.ready.set()
-        adapter.shutdown.wait()
+        config = MailAdapterConfig()
+
+        problems = boot_problems(config)
+        if problems:
+            for problem in problems:
+                logger.error("%s", problem)
+            # Inside the outer try on purpose: the outer `finally` force-flushes
+            # these records before exit, and a crash-looping pod's boot error is
+            # the one log an operator most needs to have been exported.
+            raise SystemExit(1)
+
+        adapter = MailAdapter(config)
+        server = make_server(adapter, config.port)
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        logger.info(
+            "mail adapter starting: kind=email port=%s ingress_enabled=%s",
+            server.server_address[1],
+            config.ingress_enabled,
+        )
+
+        def _handle_signal(signum: int, _frame: object) -> None:
+            logger.info("received signal %s, shutting down", signum)
+            adapter.shutdown.set()
+
+        signal.signal(signal.SIGINT, _handle_signal)
+        signal.signal(signal.SIGTERM, _handle_signal)
+
+        try:
+            if config.ingress_enabled:
+                adapter.poll_loop()
+            else:
+                # The flag gates the poller, never the server: a staged cutover
+                # serves replies before it starts ingesting.
+                logger.info("ingress disabled; serving egress only")
+                adapter.ready.set()
+            adapter.shutdown.wait()
+        finally:
+            server.shutdown()
+            server.server_close()
+            adapter.close()
+        logger.info("mail adapter stopped")
     finally:
-        server.shutdown()
-        server.server_close()
-        adapter.close()
-    logger.info("mail adapter stopped")
+        # After the stop record is emitted, never before: shutdown force-flushes,
+        # so flushing first would drop the last record of every graceful stop.
+        telemetry.shutdown()
 
 
 if __name__ == "__main__":

--- a/apps/mail-adapter/tests/test_telemetry.py
+++ b/apps/mail-adapter/tests/test_telemetry.py
@@ -1,0 +1,265 @@
+"""Shared telemetry: the process's logs are JSON and pass the redaction filter.
+
+The adapter is the first-party service that holds `AGENTMAIL_API_KEY`,
+`CURIE_CHANNEL_TOKEN` and `CURIE_EGRESS_SECRET` and reads whole email bodies, and
+until #2331 it called `logging.basicConfig` and therefore sat outside
+`curie_telemetry.redact.RedactingLogFilter` — the one filter that strips PEM
+keys, JWTs and URL secret params from every other workload's log lines. "The
+process's logs are redacted" is a property of the *process*, so every test here
+drives the real `python -m curie_mail_adapter` entry point through `_support` and
+reads its actual merged stdout+stderr. Calling `configure_service_logging` or
+asserting on a caplog record would prove nothing about the shipped image.
+
+Two things a later author needs to know before adding to this file.
+
+**`REDACTION_RULES` now rewrites home paths.** The `home_path` rule matches
+`/(?:home|Users)/[^/\\s]+`, so any assertion on a `/home/...` path in adapter
+subprocess output will see `[REDACTED:home_path]` rather than the path. No
+existing assertion is at risk: `_support.adapter_env` puts
+`CURIE_MAIL_STATE_PATH` under `tempfile`'s root, which is `/tmp` on this
+project's Linux images and CI, not under `$HOME`. `PLANTED_JWT_BASE_URL` below
+hardcodes `/tmp` for the same reason — resolving the temp root at runtime would
+make the planted JWT redact as a home path on a box whose `TMPDIR` lives under
+`/home`, and the test would pass for the wrong reason.
+
+**The adapter deliberately logs no operator- or provider-supplied string.** Every
+one of its ~40 log call sites passes a status code, a count, a fixed label, or a
+one-way `_correlation` token; that is the "logs carry no raw mail PII" invariant
+in `apps/mail-adapter/CLAUDE.md` doing its job. The single exception is
+`adapter.py`'s `poll: list failed with status=%s cause=%s`, whose cause is
+`_transport_cause`'s rendering of a locally-synthesized `{"error": str(OSError)}`
+— and that helper's own docstring names the redaction filter as its defence in
+depth. So that line is the only real lever for planting a secret, and the first
+test below is built on it.
+
+No test here asserts on adapter-authored spans: this change wires the bootstrap
+and the redacting handler only and adds no `operation_span` instrumentation.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from _support import (
+    IngressState,
+    MailState,
+    adapter_env,
+    exit_of,
+    free_port,
+    post_raw,
+    spawn_adapter,
+    stop,
+    wait_for_healthz,
+    wait_for_readyz,
+    wait_until,
+)
+
+SERVICE_NAME = "curie-mail-adapter"
+
+# Matches `redact.py`'s `jwt` rule (`\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.…`) and
+# is not one of the three credentials `_transport_cause` blanks itself, so it
+# reaches the log line intact and only the shared filter can remove it.
+PLANTED_JWT = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0.c2ln"
+
+# A `file://` base URL whose directory does not exist. `agentmail.request` catches
+# the resulting `OSError` and reports status 0 with `{"error": str(exc)}`, and
+# urllib's message for a missing file — unlike its message for a refused TCP
+# connection or an unresolvable host, both of which were measured and carry no
+# URL at all — embeds the full path. That is what carries the JWT into the log.
+#
+# The `/tmp/<jwt>` shape is load-bearing twice over: `/tmp` keeps `home_path` from
+# firing first, and the short prefix keeps the rendered cause inside
+# `adapter.CAUSE_MAX_CHARS` (120) so the JWT is complete when the filter sees it.
+PLANTED_JWT_BASE_URL = f"file:///tmp/{PLANTED_JWT}"
+
+# The literal prefix of that same log record. Asserting it survives is what stops
+# the redaction assertions passing vacuously when the line is simply absent.
+POLL_FAILURE_PREFIX = "poll: list failed with status=0 cause="
+
+
+def json_records(output: str) -> list[dict[str, object]]:
+    """Every line of process output, parsed as a service log record.
+
+    Strict on purpose: `bootstrap_service_telemetry` is the first statement in
+    `main()`, so nothing in this process may legitimately reach stderr before the
+    JSON handler is installed. A plain-text line here means a logger escaped the
+    `curie_mail_adapter` package — exactly the regression this file exists to
+    catch — so it is a failure, not something to filter out.
+    """
+    records = []
+    for line in output.splitlines():
+        if not line.strip():
+            continue
+        try:
+            record = json.loads(line)
+        except ValueError:  # pragma: no cover - only on a regression
+            raise AssertionError(
+                f"a line of adapter output was not JSON, so it bypassed the "
+                f"service logger:\n{line!r}\n\nfull output:\n{output}"
+            ) from None
+        assert isinstance(record, dict), f"a log line was not a JSON object: {line!r}"
+        records.append(record)
+    return records
+
+
+def test_a_planted_secret_in_an_adapter_log_line_is_redacted_in_process_output(
+    mail: MailState, ingress: IngressState, tmp_path: Path
+) -> None:
+    """The AC: a secret that reaches a log line leaves the process redacted.
+
+    Without the shared filter the adapter writes whatever `str(OSError)` handed
+    it straight into the cluster's log retention. urllib's rendering carries no
+    credential *today*, which is precisely why `_transport_cause` documents the
+    filter as defence in depth rather than relying on that staying true.
+
+    Two phases, because the cause is only rendered on the restart/steady-state
+    path: `prime()` logs a bare status and retries forever on a fresh store, so
+    the first run must complete its prime against the working provider and the
+    second must reuse that store with the poisoned base URL.
+    """
+    state_path = str(tmp_path / "mail-state.sqlite3")
+    assert not os.path.exists(f"/tmp/{PLANTED_JWT}"), (
+        "the planted path must not exist, or the provider call succeeds and the "
+        "log record under test is never emitted"
+    )
+
+    primed_port = free_port()
+    primed = spawn_adapter(
+        adapter_env(
+            agentmail_base_url=mail.base_url,
+            api_url=ingress.url,
+            port=primed_port,
+            CURIE_MAIL_STATE_PATH=state_path,
+        )
+    )
+    try:
+        wait_for_readyz(primed_port, primed)
+    finally:
+        stop(primed)
+
+    port = free_port()
+    proc = spawn_adapter(
+        adapter_env(
+            agentmail_base_url=PLANTED_JWT_BASE_URL,
+            api_url=ingress.url,
+            port=port,
+            CURIE_MAIL_STATE_PATH=state_path,
+        )
+    )
+    try:
+        wait_for_healthz(port, proc)
+        # The restart confirmation's first listing runs synchronously at startup
+        # and fails on a local stat, so the record is emitted almost immediately;
+        # this only bounds the wait. If it were ever missed, the negative control
+        # below fails rather than the test passing on an empty output.
+        wait_until(lambda: proc.poll() is not None, 2.0)
+    finally:
+        output = stop(proc)
+
+    # Negative control first: the same message, minus its secret, must be present,
+    # or the two assertions after it are satisfied by output that never had the
+    # secret in it to begin with.
+    assert POLL_FAILURE_PREFIX in output, (
+        f"the log record carrying the planted secret was never emitted, so the "
+        f"redaction assertions would pass vacuously; output:\n{output}"
+    )
+    assert PLANTED_JWT not in output, f"the planted JWT survived into output:\n{output}"
+    assert "[REDACTED:jwt]" in output, (
+        f"the record was emitted but carries no jwt placeholder, so it did not "
+        f"pass RedactingLogFilter; output:\n{output}"
+    )
+
+
+def test_boot_with_no_otel_env_present_still_serves(mail: MailState, ingress: IngressState) -> None:
+    """No OTLP endpoint is a no-op, not a boot failure.
+
+    The bootstrap runs before `MailAdapterConfig()`, so a raise inside it would
+    replace a precise "AGENTMAIL_INBOX is required" crash with an opaque OTel
+    stack trace — and every local, offline and CI install runs with no endpoint
+    at all. This is also the property the chart's `otelCollector.deploy=false`
+    case leans on: providers come back `None` and only the redacting stderr
+    handler is installed.
+    """
+    port = free_port()
+    env = adapter_env(agentmail_base_url=mail.base_url, api_url=ingress.url, port=port)
+    assert not [name for name in env if name.startswith("OTEL_")], (
+        "adapter_env is a closed world; an OTEL_* key here would mean this test "
+        "is exercising the configured path instead of the unconfigured one"
+    )
+
+    proc = spawn_adapter(env)
+    try:
+        wait_for_healthz(port, proc)
+
+        assert proc.poll() is None
+    finally:
+        stop(proc)
+
+
+def test_a_boot_problem_still_names_its_variable_in_json_output(
+    mail: MailState, ingress: IngressState
+) -> None:
+    """`CrashLoopBackOff` naming the variable is the operator signal.
+
+    The format change from `basicConfig` plain text to single-line JSON must not
+    cost the operator the one thing the boot gates exist to give them. Asserted
+    as the structured property rather than a substring, so a record that merely
+    happens to contain the name somewhere in an unparseable line does not pass.
+    """
+    env = adapter_env(agentmail_base_url=mail.base_url, api_url=ingress.url, port=free_port())
+    del env["CURIE_CHANNEL_TOKEN"]
+
+    code, output = exit_of(spawn_adapter(env))
+
+    assert code != 0
+    records = json_records(output)
+    assert [
+        record
+        for record in records
+        if record.get("severity") == "ERROR"
+        and record.get("service.name") == SERVICE_NAME
+        and "CURIE_CHANNEL_TOKEN" in str(record.get("message", ""))
+    ], f"no ERROR record named the missing variable; records:\n{records}"
+
+
+def test_the_service_logger_owns_the_three_module_loggers(
+    mail: MailState, ingress: IngressState
+) -> None:
+    """Bootstrapping the package logger has to cover every module under it.
+
+    `run`, `adapter` and `egress` each hold their own `logging.getLogger(__name__)`
+    and are only reached because `Logger.callHandlers` walks up to the
+    `curie_mail_adapter` package logger. A future module named outside that
+    package, or a stray `basicConfig` restoring a plain-text root handler, shows
+    up here as a line that is not JSON or a record without the service name.
+    """
+    port = free_port()
+    proc = spawn_adapter(
+        adapter_env(agentmail_base_url=mail.base_url, api_url=ingress.url, port=port)
+    )
+    try:
+        wait_for_readyz(port, proc)
+        # Drive `egress` too: an unauthenticated POST is refused with a warning
+        # from that module, so all three loggers have emitted before shutdown.
+        status, _ = post_raw(f"http://127.0.0.1:{port}/healthz", secret=None)
+        assert status == 401
+    finally:
+        output = stop(proc)
+
+    records = json_records(output)
+    assert records, f"the adapter emitted no log records at all:\n{output}"
+    for record in records:
+        assert record.get("service.name") == SERVICE_NAME, (
+            f"a record escaped the service logger: {record}"
+        )
+    loggers = {str(record.get("logger")) for record in records}
+    assert {
+        "curie_mail_adapter.run",
+        "curie_mail_adapter.adapter",
+        "curie_mail_adapter.egress",
+    } <= loggers, (
+        f"fewer than the three module loggers were observed, so this proves "
+        f"nothing about coverage; saw {sorted(loggers)}"
+    )

--- a/charts/curie/CLAUDE.md
+++ b/charts/curie/CLAUDE.md
@@ -42,12 +42,46 @@ component and rail detail in `charts/curie/README.md`.
     strategy values key**. Pinned by `ci/langfuse-recreate-assertions.sh`.
     Horizontal scale for Langfuse needs an Accepted out-of-band migrator; when
     that lands, this exception is removed rather than extended.
+- **The instrumented set is exactly the workloads whose container `env` block
+  includes the `curie.env.otel` helper.** That include *is* the boundary -- it
+  is not a count and not a list kept in prose, and this rule exists because a
+  written count of "four workloads" went stale the moment a fifth one landed
+  (#2331). The include renders `OTEL_EXPORTER_OTLP_ENDPOINT`, `_PROTOCOL` and
+  `_HEADERS` from the `otelCollector` block and calls `curie.otel.validate`, so
+  adding it is what puts a workload inside chart-owned, validated telemetry, and
+  omitting it is what leaves one outside. `grep -n 'curie.env.otel'
+  charts/curie/templates/` is the authoritative membership answer at any commit;
+  at the time of writing it selects `api.yaml`, `dispatcher.yaml`, `worker.yaml`,
+  `agent-sandbox.yaml` (the runner) and `mail-adapter.yaml`. Adding a workload
+  means adding the include. Configuring the same three variables through that
+  workload's `extraEnv` instead does **not** satisfy the
+  `security.checkDefaultCredentials` production gate: each workload would then
+  carry its own copy of the destination, so any one of them can drift from the
+  rest while the render still looks correct. Two corollaries. The chart half is
+  only half the boundary -- the workload's own entrypoint must call
+  `bootstrap_service_telemetry` (`packages/telemetry`), or the env arrives at a
+  process that reads none of it and whose logs never pass `RedactingLogFilter`.
+  And a workload with an egress NetworkPolicy needs a collector peer in it as
+  well; today the mail adapter is the only such workload (see the next
+  invariant).
 - **Mail-adapter egress is a separate fail-closed rail.** Enabling
   `mailAdapter.deploy` requires at least one
-  `mailAdapter.agentmail.httpsCidrs` entry. Its single egress-only policy allows
-  DNS, this release's API pods, and those CIDRs on TCP 443; with `api.deploy`
-  false, `mailAdapter.apiEgress.httpsCidrs` and `.port` replace the pod selector
-  with an explicit narrow BYO-API peer. It never selects a runner sandbox and
+  `mailAdapter.agentmail.httpsCidrs` entry. One egress-only policy is the
+  complete list of what that pod may reach, and every destination is a rule
+  inside it rather than a second policy object, so one object still shows
+  everything a pod holding three credentials can talk to -- read the rules in
+  `templates/mail-adapter.yaml` for the current set rather than trusting a count
+  here. As written today they are DNS, this release's API pods, those
+  `agentmail.httpsCidrs` on TCP 443, and -- only while `otelCollector.deploy` is
+  true -- this release's OTel Collector on its gRPC and HTTP ports. With
+  `api.deploy` false, `mailAdapter.apiEgress.httpsCidrs` and `.port` replace the
+  API pod selector with an explicit narrow BYO-API peer. Because this is the
+  only first-party service with an egress policy at all, it is also the only one
+  whose OTLP export can be dropped by its own rail: with `otelCollector.deploy`
+  false and an external `otelCollector.endpoint`, this policy has no peer for
+  that address, and the fix is an operator-supplied additional egress policy
+  selecting the adapter (NetworkPolicies union), not a broad allow in the chart
+  for an address the chart cannot know. It never selects a runner sandbox and
   never allows the Kubernetes API. The runtime pod mounts no ServiceAccount
   token and has no RBAC. Prefix-0 and prefix-1 routes fail render, including
   split default routes. Do not turn provider DNS into a broad CIDR or add a

--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -347,7 +347,7 @@ pipeline and environment are applied on `helm upgrade`.
 | ClickHouse | `clickhouse/clickhouse-server:25.12` | Langfuse OLAP store. Coupled to `langfuse.image.tag` 3.225.5; chart default requires AVX (see preflight). |
 | RustFS | `rustfs/rustfs:1.0.0-beta.12` plus `amazon/aws-cli:2.32.6` init | Langfuse object storage; BYO real S3 in prod. |
 | OTel Collector | `otel/opentelemetry-collector-contrib:0.119.0` | Bounded OTLP gateway (gRPC+HTTP), durable queue by default; traces -> Langfuse over HTTP, logs/metrics -> configured exporters. |
-| Mail adapter | `ghcr.io/curie-eng/curie-mail-adapter` | Off by default. One `Recreate` replica with durable SQLite on single-writer storage; no platform key/database credential or ServiceAccount token. |
+| Mail adapter | `ghcr.io/curie-eng/curie-mail-adapter` | Off by default. One `Recreate` replica with durable SQLite on single-writer storage; no platform key/database credential or ServiceAccount token. The only first-party workload with its own egress NetworkPolicy, so its OTLP export needs an explicit peer (see below). |
 
 The mail adapter's `mailAdapter.persistence` block renders a 1 GiB RWO PVC by
 default or mounts a named same-namespace single-writer Filesystem `existingClaim`
@@ -355,11 +355,25 @@ with exactly one `ReadWriteOnce` or `ReadWriteOncePod` access mode. Its
 root filesystem remains read-only; only the state mount and an `emptyDir` at
 `/tmp` are writable. Enabling it also requires an explicit
 `mailAdapter.agentmail.httpsCidrs` list. One egress-only NetworkPolicy then
-allows DNS, this release's API pods, and those provider/proxy CIDRs on TCP 443.
-When `api.deploy=false`, the in-chart API selector is replaced by the required
-`mailAdapter.apiEgress.httpsCidrs` peers on `mailAdapter.apiEgress.port`; the
-chart does not infer IPs from `apiBaseUrl`. The policy has no Kubernetes API
-carve-out and never selects runner sandboxes. See
+allows DNS, this release's API pods, those provider/proxy CIDRs on TCP 443, and
+-- while `otelCollector.deploy=true` -- this release's OTel Collector on its
+gRPC and HTTP ports, so the adapter's OTLP export is not dropped by its own
+rail. When `api.deploy=false`, the in-chart API selector is replaced by the
+required `mailAdapter.apiEgress.httpsCidrs` peers on
+`mailAdapter.apiEgress.port`; the chart does not infer IPs from `apiBaseUrl`.
+The policy has no Kubernetes API carve-out and never selects runner sandboxes.
+
+The adapter is the only first-party workload with an egress-restricting
+NetworkPolicy, which makes one telemetry configuration asymmetric. With
+`otelCollector.deploy=false` and an external `otelCollector.endpoint`, api,
+dispatcher and worker export normally because nothing restricts their egress,
+while the adapter's exports are dropped: its policy has no peer for an address
+the chart cannot know, and the chart deliberately invents no broad allow for
+one. Because NetworkPolicies union rather than intersect, the fix needs no chart
+change -- apply an additional egress policy in the release namespace selecting
+the adapter's labels (`app.kubernetes.io/component: mail-adapter` plus the
+release's instance label) with a `to:` for the external collector. Everything
+else about the rail, including the AgentMail CIDRs, keeps working unchanged. See
 [`docs/operations.md`](../../docs/operations.md#connecting-email) for the
 mode-0600 credential workflow, retention, erase, and recovery procedure.
 

--- a/charts/curie/ci/mail-adapter-wiring-assertions.sh
+++ b/charts/curie/ci/mail-adapter-wiring-assertions.sh
@@ -65,6 +65,15 @@
 #      fixture, rather than merely grepping its shell source.
 #   20 The preflight Job opts out of token mounting and satisfies the Restricted
 #      Pod Security Standard at both pod and container scope.
+#   21 The container carries the SHARED OTLP env -- the same OTEL_EXPORTER_OTLP_*
+#      names and values the other instrumented workloads get -- when the chart
+#      collector is deployed, the external endpoint verbatim when it is not, and
+#      NOTHING when telemetry is explicitly disabled. The adapter joined the
+#      existing telemetry boundary; it did not acquire a private one.
+#   22 The single egress policy gains a collector peer exactly when
+#      otelCollector.deploy is true. The adapter is the ONLY first-party service
+#      with an egress-restricting policy, so OTLP env without this peer exports
+#      into a dropped connection while every render still looks green.
 #
 # NOTE ON `--output-dir`: copied deliberately from
 # dispatcher-api-wiring-assertions.sh. In this environment `helm template` into a
@@ -1133,4 +1142,211 @@ python3 "$MATRIX_PY" \
   mail-adapter \
   || fail "the mail-adapter image is not wired into the standard build path; see the message above"
 
-echo "OK: mail-adapter chart wiring and build-path render assertions passed (20 assertions)"
+# ---------------------------------------------------------------------------
+# 21: the adapter carries the STANDARD OTLP env, and only when the shared
+#     telemetry boundary says so. The two values below are the SAME pair
+#     otel-collector-durability-assertions.sh pins for api/dispatcher/worker/
+#     runner; asserting them here is what makes the adapter a fifth member of
+#     that boundary rather than a workload with its own private wiring.
+# ---------------------------------------------------------------------------
+assert_env_value "$on_dir" OTEL_EXPORTER_OTLP_ENDPOINT "http://curie-otel-collector:4318" \
+  "The in-chart Collector Service must be derived exactly as it is for the other instrumented workloads; an adapter that exports nowhere leaves its records outside the shared, redacted OTLP path."
+assert_env_value "$on_dir" OTEL_EXPORTER_OTLP_PROTOCOL "http/protobuf" \
+  "The protocol must come from the shared helper default, not a per-workload literal."
+
+# A chart-owned EXTERNAL endpoint must reach the adapter verbatim. A template
+# that hardcoded the in-chart Service name would pass the assertion above and
+# silently ignore the operator here.
+otel_external_dir="$(render otel-external "${ON[@]}" "${CREDS[@]}" \
+  --set otelCollector.deploy=false \
+  --set otelCollector.endpoint=https://otel.example.com:4318)"
+assert_env_value "$otel_external_dir" OTEL_EXPORTER_OTLP_ENDPOINT "https://otel.example.com:4318" \
+  "otelCollector.endpoint must render verbatim on the adapter, exactly as it does on the other instrumented workloads."
+assert_env_value "$otel_external_dir" OTEL_EXPORTER_OTLP_PROTOCOL "http/protobuf" \
+  "The external-endpoint path must still carry the protocol; an endpoint with no protocol falls back to the SDK default and can disagree with the collector's receiver."
+
+# The negative direction, and the one that proves membership of the shared
+# boundary: with telemetry explicitly disabled the adapter must render NO
+# OTEL_EXPORTER_OTLP_* env at all, which is what the other four do under the
+# same values.
+otel_disabled_dir="$(render otel-disabled "${ON[@]}" "${CREDS[@]}" \
+  --set otelCollector.deploy=false \
+  --set otelCollector.telemetryDisabled=true)"
+# Non-vacuity floor. An absence check against a render that produced no
+# mail-adapter container passes for the wrong reason; assert a known-present env
+# first, then use the same rc -eq 3 guard assertion 5 uses.
+assert_env_value "$otel_disabled_dir" CURIE_API_URL "http://curie-api:8000" \
+  "The telemetry-disabled render must still be a real mail-adapter container, or the OTLP absence checks below pass vacuously."
+for otel_name in OTEL_EXPORTER_OTLP_ENDPOINT OTEL_EXPORTER_OTLP_PROTOCOL OTEL_EXPORTER_OTLP_HEADERS; do
+  set +e
+  env_field "$otel_disabled_dir" "$DEPLOY_NAME" "$otel_name" name >/dev/null 2>&1
+  rc=$?
+  set -e
+  if [ "$rc" -eq 3 ]; then
+    fail "the telemetry-disabled render produced no mail-adapter container, so the '$otel_name' absence assertion would pass vacuously"
+  fi
+  if [ "$rc" -ne 1 ]; then
+    fail "with otelCollector.telemetryDisabled=true the mail-adapter container still carries '$otel_name'. The adapter must sit inside the shared telemetry boundary: an operator who disabled telemetry for the release must not find one workload still exporting"
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# 22: the collector egress peer exists exactly when otelCollector.deploy is
+#     true. Read structurally, never by grep: this rule is a conditional entry
+#     inside an existing list (Decision 3 keeps ONE policy object for this
+#     credential-bearing pod), so a line reader cannot tell a present rule from
+#     a reordered one, and an accidentally unconditional rule looks identical.
+# ---------------------------------------------------------------------------
+OTEL_EGRESS_PY="$TMP/mail-otel-egress.py"
+cat > "$OTEL_EGRESS_PY" <<'PY'
+"""Assert the mail adapter's collector egress peer in one rendered directory.
+
+argv: <rendered-dir> <expect-collector-rule: yes|no> <expected-total-egress-rules>
+      [<cidr-that-must-still-render>]
+"""
+import pathlib
+import sys
+
+import yaml
+
+rendered, expect, expected_rules = sys.argv[1], sys.argv[2], int(sys.argv[3])
+required_cidr = sys.argv[4] if len(sys.argv) > 4 else ""
+
+# helm template with no -n renders into the `default` namespace, so that is the
+# release namespace the peer must name. A rule that hardcoded another namespace
+# would select nothing at runtime and drop every export.
+NAMESPACE = "default"
+EXPECTED_POD_SELECTOR = {
+    "app.kubernetes.io/name": "curie",
+    "app.kubernetes.io/instance": "curie",
+    "app.kubernetes.io/component": "otel-collector",
+}
+EXPECTED_PORTS = [
+    {"protocol": "TCP", "port": 4317},
+    {"protocol": "TCP", "port": 4318},
+]
+
+docs = [
+    doc
+    for path in pathlib.Path(rendered).rglob("*.yaml")
+    for doc in yaml.safe_load_all(path.read_text())
+    if isinstance(doc, dict)
+]
+
+policies = [
+    doc
+    for doc in docs
+    if doc.get("kind") == "NetworkPolicy"
+    and doc.get("spec", {}).get("podSelector", {}).get("matchLabels", {}).get(
+        "app.kubernetes.io/component"
+    )
+    == "mail-adapter"
+]
+if len(policies) != 1:
+    raise SystemExit(
+        f"expected exactly ONE NetworkPolicy selecting the mail adapter, found "
+        f"{len(policies)} ({[p.get('metadata', {}).get('name') for p in policies]!r}). "
+        "The collector peer is a conditional rule inside the existing egress "
+        "policy, not a second policy object: an auditor must read one object to "
+        "see everything this credential-bearing pod may reach."
+    )
+policy = policies[0]
+egress = policy.get("spec", {}).get("egress") or []
+
+collector_peers = []
+for index, rule in enumerate(egress):
+    for peer in rule.get("to") or []:
+        pod_selector = peer.get("podSelector") or {}
+        labels = pod_selector.get("matchLabels") or {}
+        if labels.get("app.kubernetes.io/component") == "otel-collector":
+            collector_peers.append((index, rule, peer))
+
+if expect == "no":
+    if collector_peers:
+        raise SystemExit(
+            "otelCollector.deploy is false but the mail adapter's egress policy "
+            f"still carries a collector peer: {collector_peers[0][2]!r}. The rule "
+            "must be gated on otelCollector.deploy, or the chart opens a peer for "
+            "pods that do not exist."
+        )
+elif expect == "yes":
+    if len(collector_peers) != 1:
+        raise SystemExit(
+            "otelCollector.deploy is true but the mail adapter's egress policy "
+            f"carries {len(collector_peers)} collector peers, expected exactly 1. "
+            "Without it the adapter's OTLP export is dropped by its own egress "
+            "rail while the rendered env still looks correct. Rendered egress "
+            f"rules: {egress!r}"
+        )
+    _, rule, peer = collector_peers[0]
+    if (rule.get("to") or []).index(peer) != 0:
+        raise SystemExit(f"collector peer is not to[0] of its rule: {rule!r}")
+    namespace_selector = peer.get("namespaceSelector") or {}
+    got_namespace = (namespace_selector.get("matchLabels") or {}).get(
+        "kubernetes.io/metadata.name"
+    )
+    if got_namespace != NAMESPACE:
+        raise SystemExit(
+            f"collector peer namespaceSelector names {got_namespace!r}, expected "
+            f"{NAMESPACE!r}. A podSelector with no namespaceSelector matches pods "
+            "in the adapter's own namespace only by accident of this render, and a "
+            "wrong namespace selects nothing at all."
+        )
+    got_labels = peer.get("podSelector", {}).get("matchLabels") or {}
+    if got_labels != EXPECTED_POD_SELECTOR:
+        raise SystemExit(
+            f"collector peer podSelector is {got_labels!r}, expected "
+            f"{EXPECTED_POD_SELECTOR!r} (curie.selectorLabels for the "
+            "otel-collector component). A partial selector can match a different "
+            "release's collector in the same namespace."
+        )
+    if rule.get("ports") != EXPECTED_PORTS:
+        raise SystemExit(
+            f"collector peer ports are {rule.get('ports')!r}, expected "
+            f"{EXPECTED_PORTS!r} (otelCollector.service.grpcPort and .httpPort). "
+            "The chart's own OTLP endpoint is the HTTP port, so omitting 4318 "
+            "drops every export the default configuration makes."
+        )
+else:
+    raise SystemExit(f"bad expect argument {expect!r}")
+
+if len(egress) != expected_rules:
+    raise SystemExit(
+        f"the mail adapter's egress policy has {len(egress)} rules, expected "
+        f"{expected_rules}. The rule set is DNS, the API peer, the AgentMail "
+        "CIDRs, and -- only under otelCollector.deploy -- the collector. A count "
+        f"drift means a destination was added or lost silently. Rules: {egress!r}"
+    )
+
+if required_cidr:
+    cidrs = {
+        peer.get("ipBlock", {}).get("cidr")
+        for rule in egress
+        for peer in rule.get("to") or []
+        if peer.get("ipBlock")
+    }
+    if required_cidr not in cidrs:
+        raise SystemExit(
+            f"{required_cidr!r} no longer renders alongside the collector peer; "
+            f"rendered CIDRs were {sorted(c for c in cidrs if c)!r}"
+        )
+PY
+
+python3 "$OTEL_EGRESS_PY" "$on_dir" yes 4 203.0.113.0/24 \
+  || fail "with the chart collector deployed, the mail adapter's egress policy does not admit it; see the message above"
+
+# deploy=false: the rule must be GONE, and the policy must be back to exactly
+# its three original destinations. A count assertion, so an accidentally
+# unconditional rule fails here rather than rendering a peer for pods that were
+# never deployed.
+python3 "$OTEL_EGRESS_PY" "$otel_disabled_dir" no 3 203.0.113.0/24 \
+  || fail "with the chart collector not deployed, the mail adapter's egress policy is not back to its three original rules; see the message above"
+python3 "$OTEL_EGRESS_PY" "$otel_external_dir" no 3 203.0.113.0/24 \
+  || fail "an EXTERNAL otelCollector.endpoint must not synthesize an in-cluster collector peer; that destination is an IP the chart cannot know (see the template comment and README)"
+
+# The BYO-API render assertion 17 already exercises: the collector peer must
+# coexist with the explicit BYO API CIDR rule rather than replacing it.
+python3 "$OTEL_EGRESS_PY" "$byo_api_dir" yes 4 198.51.100.0/24 \
+  || fail "with api.deploy=false the collector peer and the BYO API CIDR rule do not coexist; see the message above"
+
+echo "OK: mail-adapter chart wiring and build-path render assertions passed (22 assertions)"

--- a/charts/curie/ci/otel-collector-durability-assertions.sh
+++ b/charts/curie/ci/otel-collector-durability-assertions.sh
@@ -566,7 +566,12 @@ def quantity_is_finite(value):
 
 
 def workload_containers(path):
-    """Return the four first-party Python workload containers by role."""
+    """Return the api/dispatcher/worker Deployments and the runner SandboxTemplate container, by role.
+
+    Not the authoritative instrumented set: the mail adapter also carries the
+    shared OTLP env and is pinned in ci/mail-adapter-wiring-assertions.sh. It
+    cannot appear here because these renders never set mailAdapter.deploy.
+    """
     selected = {}
     for doc in documents(path):
         kind = doc.get("kind")

--- a/charts/curie/templates/_helpers.tpl
+++ b/charts/curie/templates/_helpers.tpl
@@ -509,8 +509,11 @@ http://{{ include "curie.fullname" . }}-otel-collector:{{ .Values.otelCollector.
 
 {{/* Fail closed on contradictory OTEL values always. Fail closed on accidental
      missing only when security.checkDefaultCredentials is on: local/offline
-     no-endpoint remains valid outside that gate. extraEnv-only does not satisfy
-     the production gate because the four workloads can drift. */}}
+     no-endpoint remains valid outside that gate. The instrumented set is
+     exactly the workloads that include curie.env.otel, recorded in
+     charts/curie/CLAUDE.md; extraEnv-only does not satisfy the production gate
+     because it would configure each of them independently and any one can
+     drift. */}}
 {{- define "curie.otel.validate" -}}
 {{- $otel := .Values.otelCollector -}}
 {{- if and $otel.telemetryDisabled $otel.deploy -}}

--- a/charts/curie/templates/mail-adapter.yaml
+++ b/charts/curie/templates/mail-adapter.yaml
@@ -344,11 +344,8 @@ spec:
 # below for the current set rather than trusting a count in prose.
 #
 # With otelCollector.deploy false and an external otelCollector.endpoint set,
-# this policy has no peer for that address and the adapter's OTLP export is
-# dropped here; it is the only first-party service with an egress policy, so
-# api/dispatcher/worker are unaffected. NetworkPolicies union, so the operator
-# applies their own additional egress policy selecting this adapter's labels.
-# The chart deliberately invents no broad allow for an address it cannot know.
+# this policy has no peer for that address and OTLP export is dropped; see
+# charts/curie/README.md for the operator remedy.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/charts/curie/templates/mail-adapter.yaml
+++ b/charts/curie/templates/mail-adapter.yaml
@@ -289,6 +289,18 @@ spec:
             # process fall back to its own default and start.
             - name: CURIE_MAIL_ALLOWED_SENDERS
               value: {{ join "," .Values.mailAdapter.allowedSenders | quote }}
+            # The shared OTLP env, so this adapter's records join the same
+            # redacted telemetry path as every other instrumented workload.
+            # extraEnv is deliberately an empty list, not a new
+            # mailAdapter.extraEnv values key: this pod is the one carrying
+            # three credentials behind a fail-closed egress rail with no
+            # ServiceAccount token, and ci/mail-adapter-wiring-assertions.sh
+            # asserts that NO CURIE_API_KEY env exists on it at all. A
+            # free-form env surface is exactly the hole through which that
+            # property is lost. Accepted cost: an operator cannot point only
+            # the mail adapter at a different collector; otelCollector.endpoint
+            # moves the whole release.
+            {{- include "curie.env.otel" (dict "root" . "extraEnv" list) | nindent 12 }}
           ports:
             - name: http
               containerPort: 8080
@@ -325,6 +337,18 @@ spec:
 # One egress-only policy selects exactly the mail adapter. It deliberately has
 # no ingress policy: kubelet-originated HTTP probes are not reliably labelable
 # as worker traffic, while authenticated POST remains the write gate.
+#
+# Destinations are DNS, the platform API (this release's pods, or the BYO CIDRs
+# when api.deploy is false), the AgentMail CIDRs on 443, and -- only while
+# otelCollector.deploy is true -- this release's collector. Read the rules
+# below for the current set rather than trusting a count in prose.
+#
+# With otelCollector.deploy false and an external otelCollector.endpoint set,
+# this policy has no peer for that address and the adapter's OTLP export is
+# dropped here; it is the only first-party service with an egress policy, so
+# api/dispatcher/worker are unaffected. NetworkPolicies union, so the operator
+# applies their own additional egress policy selecting this adapter's labels.
+# The chart deliberately invents no broad allow for an address it cannot know.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -379,4 +403,23 @@ spec:
         {{- end }}
       ports:
         - { protocol: TCP, port: 443 }
+    {{- if .Values.otelCollector.deploy }}
+    # This release's in-chart OTel Collector. The adapter is the only
+    # first-party service with an egress policy, so unlike api/dispatcher/worker
+    # it needs an explicit peer or every OTLP export is dropped by this rail
+    # while the rendered env still looks correct. Mirrors the peer shape of
+    # security-networkpolicy.yaml's runner-allow-collector, kept as a rule in
+    # this policy rather than a second object so one object still shows
+    # everything this credential-bearing pod may reach.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Release.Namespace }}
+          podSelector:
+            matchLabels:
+              {{- include "curie.selectorLabels" (dict "root" . "component" "otel-collector") | nindent 14 }}
+      ports:
+        - { protocol: TCP, port: {{ .Values.otelCollector.service.grpcPort }} }
+        - { protocol: TCP, port: {{ .Values.otelCollector.service.httpPort }} }
+    {{- end }}
 {{- end }}

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -694,9 +694,18 @@ inference:
 otelCollector:
   deploy: true
   image: otel/opentelemetry-collector-contrib:0.119.0
-  # Chart-owned external OTLP endpoint used when deploy is false. Wired to API,
-  # dispatcher, worker, and runner. Ignored while deploy is true (in-cluster
-  # collector wins). extraEnv remains a per-workload override.
+  # Chart-owned external OTLP endpoint used when deploy is false. Wired to
+  # every workload that includes the curie.env.otel helper; that set is
+  # recorded in charts/curie/CLAUDE.md rather than counted here. Ignored while
+  # deploy is true (in-cluster collector wins). extraEnv remains a per-workload
+  # override where the workload exposes one.
+  #
+  # One asymmetry an operator hits here: the mail adapter is the only
+  # first-party service with its own egress NetworkPolicy, and that policy has
+  # no peer for an external endpoint (an address the chart cannot know). An
+  # install using this key with mailAdapter.deploy true needs an operator-
+  # supplied egress policy selecting the adapter, or its exports are dropped
+  # while every other workload's succeed.
   endpoint: ""
   protocol: http/protobuf
   # Optional OTEL_EXPORTER_OTLP_HEADERS. Prefer headersExistingSecret for

--- a/uv.lock
+++ b/uv.lock
@@ -815,6 +815,7 @@ source = { editable = "apps/mail-adapter" }
 dependencies = [
     { name = "aci-protocol" },
     { name = "curie-channel-protocol" },
+    { name = "curie-telemetry" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
 ]
@@ -823,6 +824,7 @@ dependencies = [
 requires-dist = [
     { name = "aci-protocol", editable = "packages/aci-protocol" },
     { name = "curie-channel-protocol", editable = "packages/channel-protocol" },
+    { name = "curie-telemetry", editable = "packages/telemetry" },
     { name = "pydantic", specifier = ">=2.10" },
     { name = "pydantic-settings", specifier = ">=2.7" },
 ]


### PR DESCRIPTION
Closes #2331

Fix pin: apps/mail-adapter/tests/test_telemetry.py::test_a_planted_secret_in_an_adapter_log_line_is_redacted_in_process_output

`apps/mail-adapter` was the only first-party service depending on neither `curie-telemetry` nor `curie.env.otel`, so the one component holding the mail provider key, the channel token, the egress secret and full email bodies emitted no spans, exported no logs, and sat outside `RedactingLogFilter`.

## What changed

**Python.** `main()` bootstraps `curie-telemetry` on the **package** logger `curie_mail_adapter`. The three module loggers are its children and `configure_service_logging` sets `propagate=False` on exactly the logger it is handed, so one bootstrap covers all three and nothing walks past it to root. `logging.basicConfig` is removed — keeping it leaves a root `StreamHandler` that the redacting root proxy mirrors to, emitting every record twice. `SystemExit(1)` on a boot problem now raises inside the outer `try`, so the `finally` force-flushes those records: a crash-looping pod's boot error is the one log an operator most needs exported.

**Chart.** The container gets `curie.env.otel`, and the adapter's NetworkPolicy gets a fourth egress rule, gated on `otelCollector.deploy`, so it can actually reach the collector. That rule is not optional: this is the only first-party workload with an egress-restricting policy, so without a peer the OTLP env renders green while every export is dropped — AC satisfied in letter, dead in fact.

## Decisions taken on ambiguity, per the conservative default

- **No `mailAdapter.extraEnv` surface**; the helper is called with an empty list. `.Values.mailAdapter` has no such key today, unlike the other four workloads, and this pod is the one with three credentials, no ServiceAccount token, and an assertion pinning that no `CURIE_API_KEY` reaches its container. A free-form env surface is how that would be re-added. Cost: an operator cannot point *only* this adapter at a different collector. Escape hatch filed as #2361.
- **One NetworkPolicy object, not a second named one.** The runner uses separate objects because it sits behind a default-deny base; this file's stated invariant is that one object shows everything the credential-bearing pod may reach. Policies union, so both forms behave identically.
- **`otelCollector.deploy=false` + external `endpoint` is documented, not gated.** The chart cannot invent an allow for an address it cannot know, so the remedy is an operator-supplied additional policy. Filed as #2361, which argues the adjacent BYO-API case fails closed and this arguably should too.
- **Three commits kept, not squashed.** The failing-tests-first commit is the contract and is worth reading separately from the implementation.

## Scope beyond the issue text

Two stale counts the issue does not name were made **false by this change** and are corrected with it: `values.yaml`'s "Wired to API, dispatcher, worker, and runner", and a `workload_containers` docstring. Each is replaced with a rule rather than a number. `charts/curie/CLAUDE.md` gains the boundary record the other comments point at — without it this branch would have replaced a stale count with a dangling pointer, which a review caught.

## Residual gaps, named rather than left implicit

The shared filter is a backstop, not a licence to log a credential. `REDACTION_RULES` matches **no** Curie credential shape: `chn-` channel tokens, AgentMail keys and `CURIE_EGRESS_SECRET` pass through, and `CURIE_CHANNEL_TOKEN=<value>` specifically is not caught because `secret_assignment` needs a word boundary before `token=` that the preceding underscore denies. No current log call site emits any of the three — `_transport_cause` blanks them — so this is defence-in-depth, not an open leak. Filed as #2359. A `MailAdapterConfig()` `ValidationError` also still prints an unredacted traceback, bypassing `logging` entirely; unchanged by this branch, neither better nor worse.

Follow-ups: #2358 (Discord adapter, same defect class), #2359 (redaction rules), #2360 (nothing fails when a workload is omitted from `curie.env.otel` — the root cause), #2361 (external-endpoint egress), #2362 (`shutdown` worst case equals the default grace period).

Image cost: the adapter's locked dependency closure goes 9 → 25 packages (~9 MB → ~34 MB site-packages), dominated by `grpcio` and `protobuf`. Same tree the other four already ship.

## Done-check

- [x] Failing tests committed before implementation — first commit is the contract; 3 of 4 failed for the right reason (planted JWT survived; output not JSON)
- [x] All production edits by delegated executors; no inline driver edits
- [x] Return types broadened: none reported by either implementer
- [x] Code review (agent-router → grok): no blocking findings. Its one claim, that tokens are `chn.`, was checked and is wrong — `channels.py:294` mints `chn-`
- [x] Scope review: PASS, 13 hunks all mapped; fixture scan clean
- [x] Security review (agent-router → grok): no blocking findings; egress peer cannot widen beyond collector pods, OTLP exports strictly less than stderr
- [x] Sibling-path parity: five `curie.env.otel` sites enumerated; Discord adapter routed to #2358
- [x] Guard demonstration: assertion 22 asserts the collector peer is absent when `otelCollector.deploy=false`, by rule count, so an unconditional rule fails
- [x] Consolidation pass ran; one duplication fix applied, revalidated
- [x] Discovery-surface proof (`cluster`): rendered and observed, below
- [x] Train check: milestone v0.8.6 is a patch release → `main`
- [x] Full affected validation green; rebased onto current `main` and re-validated
- [ ] E2E against a live cluster — **not done**, see below

## Verification

Rendered with `mailAdapter.deploy=true`:

```
- name: OTEL_EXPORTER_OTLP_ENDPOINT
  value: "http://curie-otel-collector:4318"
- name: OTEL_EXPORTER_OTLP_PROTOCOL
  value: "http/protobuf"
```

Same render, egress rules: DNS `[53,53]`, api `[8000]`, provider `[443]`, otel-collector `[4317,4318]` — still exactly one NetworkPolicy object. On `main` the same render produced zero `OTEL_*` variables.

`139 passed` (135 pre-existing + 4 new), `helm lint` clean, `mail-adapter-wiring-assertions.sh` 22 assertions, `render-assertions.sh` and `otel-collector-durability-assertions.sh` exit 0, docs gate clean.

**Not verified:** no deployed-cluster run. The render and the assertion suite prove the env and the policy peer; they do not prove packets flow to a live collector. That is the one gap between this PR and the `deployed-surface` bar.
