### PR TITLE
Cache the four smoke and gate image builds off the images matrix scopes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -643,6 +643,20 @@ jobs:
   # (docker driver), whose FROM lookup consults the local image store -- so the
   # overlay resolves the just-built base with no GHCR pull, no registry auth,
   # and works on any branch (including forks). Build only, never pushed.
+  #
+  # The base build is GHA-layer-cached off the SAME scope the `images` matrix
+  # writes for the worker image (`scope=worker`), via a named buildx builder
+  # that is NOT made the default (`use: false`) -- the mechanism the e2e-ladder
+  # job below documents at length (#697/#791/#803). `use: false` is load-bearing
+  # here: the overlay step is a plain `docker build` whose `FROM
+  # ...curie-worker:ci-local` must resolve out of the local daemon image store,
+  # which only the default `docker` driver consults. `load: true` puts the
+  # freshly built base into that store. Read-only cache (`cache-from` with no
+  # `cache-to`): the `images` matrix already refreshes `scope=worker` with
+  # `mode=max` on every run, and a second concurrent writer on one scope only
+  # contends for the reservation -- the exact failure the matrix comment above
+  # records. The overlay itself stays a plain `docker build`: it has no entry in
+  # the `images` matrix, so there is no scope for it to share.
   worker-local-image:
     name: Build worker-local overlay image (no push)
     runs-on: ubuntu-latest
@@ -650,8 +664,21 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - name: Build the base worker image locally
-        run: docker build -t ghcr.io/curie-eng/curie-worker:ci-local -f apps/worker/Dockerfile .
+      - name: Set up a cache-only buildx builder (named, NOT the default -- preserves the overlay's FROM)
+        id: buildcache
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+        with:
+          use: false
+      - name: Build the base worker image locally (gha layer cache)
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: apps/worker/Dockerfile
+          builder: ${{ steps.buildcache.outputs.name }}
+          tags: ghcr.io/curie-eng/curie-worker:ci-local
+          push: false
+          load: true
+          cache-from: type=gha,scope=worker
       - name: Build the worker-local overlay (no push)
         run: docker build --build-arg BASE_TAG=ci-local -f compose/worker-local.Dockerfile compose
 
@@ -663,6 +690,13 @@ jobs:
   # startup (issue #428). The build-only `images` job above cannot catch this
   # (it never runs the image). Build the real image and assert the entrypoint's
   # imports resolve inside it -- the one place that gap is observable.
+  #
+  # GHA-layer-cached off the same scope the `images` matrix writes for this
+  # image (`scope=dispatcher`), read-only: the matrix refreshes it with
+  # `mode=max` every run, so a second writer would only contend. `load: true`
+  # is required -- the assertion step runs the built image. The builder is
+  # created with `use: false` so the default `docker` driver stays current,
+  # matching the ladder jobs and keeping any local-tag lookup working.
   dispatcher-image-smoke:
     name: Dispatcher image imports resolve
     runs-on: ubuntu-latest
@@ -670,8 +704,21 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - name: Build the dispatcher image locally
-        run: docker build -t curie-dispatcher:ci-smoke -f apps/dispatcher/Dockerfile .
+      - name: Set up a cache-only buildx builder (named, NOT the default)
+        id: buildcache
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+        with:
+          use: false
+      - name: Build the dispatcher image locally (gha layer cache)
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: apps/dispatcher/Dockerfile
+          builder: ${{ steps.buildcache.outputs.name }}
+          tags: curie-dispatcher:ci-smoke
+          push: false
+          load: true
+          cache-from: type=gha,scope=dispatcher
       - name: Entrypoint imports resolve in the built image
         run: docker run --rm --entrypoint python curie-dispatcher:ci-smoke -c "import curie_dispatcher; import aci_protocol"
 
@@ -681,6 +728,13 @@ jobs:
   # stay importable from a source checkout while being absent from the isolated
   # image venv, and the process crash-loops on startup. The build-only `images`
   # job above never runs the image, so this is the one place that is observable.
+  #
+  # GHA-layer-cached off `scope=mail-adapter`, the scope the `images` matrix
+  # writes for this image, read-only for the same reason as the dispatcher job.
+  # `context: .` is kept explicit here (it is what the plain `docker build` this
+  # replaces used); the matrix entry for mail-adapter omits `context`, so the
+  # two builds may not share every layer -- that pre-existing asymmetry is left
+  # alone rather than widened by this change.
   mail-adapter-image-smoke:
     name: Mail adapter image imports resolve
     runs-on: ubuntu-latest
@@ -688,8 +742,21 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - name: Build the mail adapter image locally
-        run: docker build -t curie-mail-adapter:ci-smoke -f apps/mail-adapter/Dockerfile .
+      - name: Set up a cache-only buildx builder (named, NOT the default)
+        id: buildcache
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+        with:
+          use: false
+      - name: Build the mail adapter image locally (gha layer cache)
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: apps/mail-adapter/Dockerfile
+          builder: ${{ steps.buildcache.outputs.name }}
+          tags: curie-mail-adapter:ci-smoke
+          push: false
+          load: true
+          cache-from: type=gha,scope=mail-adapter
       - name: Entrypoint imports resolve in the built image
         run: docker run --rm --entrypoint python curie-mail-adapter:ci-smoke -c "import curie_mail_adapter; import aci_protocol; import pydantic_settings"
 
@@ -708,7 +775,10 @@ jobs:
   # ride the Rust job (cli/tests/eval_falsifiability.rs) -- the fake model can
   # only ever say "all done", so those cannot be expressed through this path.
   # Reuses the release binary the Rust job already built and uploaded, and builds
-  # the runner image locally (plain `docker build`, no registry auth).
+  # the runner image locally (no registry auth), GHA-layer-cached off
+  # `scope=runner` -- the same scope the `images` matrix writes for the runner.
+  # Read-only cache for the same reason as the smoke jobs above; `load: true`
+  # because the gate script runs a container from the tag.
   eval-falsifiability:
     name: Eval falsifiability gate (fake model, offline)
     runs-on: ubuntu-latest
@@ -724,8 +794,21 @@ jobs:
           path: cli/target/release
       - name: Make the binary executable
         run: chmod +x cli/target/release/curie
-      - name: Build the runner image locally
-        run: docker build -t curie-runner -f runner/Dockerfile .
+      - name: Set up a cache-only buildx builder (named, NOT the default)
+        id: buildcache
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+        with:
+          use: false
+      - name: Build the runner image locally (gha layer cache)
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: runner/Dockerfile
+          builder: ${{ steps.buildcache.outputs.name }}
+          tags: curie-runner
+          push: false
+          load: true
+          cache-from: type=gha,scope=runner
       - name: Falsifiability gate (every committed case must go RED against the fake model)
         env:
           CURIE_BIN: cli/target/release/curie


### PR DESCRIPTION
## What

Four CI jobs rebuilt a first-party image with a bare `docker build` and no layer
cache, paying a cold rebuild on every push and pull request:

| Job | Step | Image |
| --- | --- | --- |
| `worker-local-image` | Build the base worker image locally | `apps/worker/Dockerfile` |
| `dispatcher-image-smoke` | Build the dispatcher image locally | `apps/dispatcher/Dockerfile` |
| `mail-adapter-image-smoke` | Build the mail adapter image locally | `apps/mail-adapter/Dockerfile` |
| `eval-falsifiability` | Build the runner image locally | `runner/Dockerfile` |

The `images` matrix directly above them was already writing a `mode=max` GitHub
Actions layer cache for those same four Dockerfiles, scoped per image
(`cache-to: type=gha,mode=max,scope=${{ matrix.name }}`, added by #2226). These
jobs cannot be folded into that matrix -- the matrix is build-only (`load:
false`) and each of these jobs needs a runnable local image -- but they can read
from the same scope.

Each of the four now builds through `docker/build-push-action` with
`cache-from: type=gha,scope=<image>`, using the exact scope the matrix writes
for that image (`worker`, `dispatcher`, `mail-adapter`, `runner`), plus
`load: true` so the image lands in the local daemon store the assertion steps
run against.

## Deliberate choices

- **Read-only cache: `cache-from` with no `cache-to`.** The `images` matrix
  already refreshes every one of these scopes with `mode=max` on each run, so
  nothing here needs to write. A second concurrent writer on a single scope only
  contends for the reservation -- the exact failure the matrix's own comment
  records (`Unable to reserve cache with key ... another job may be creating
  this cache`, run 33690551116, where a 2-minute image spent 1057.7s on the
  export). These jobs run concurrently with the matrix, so writing would have
  reintroduced that.
- **`use: false` on the buildx builder, with `builder:` passed explicitly.**
  This is the mechanism the `e2e-ladder` job below already documents at length
  (#697/#791/#803). It is load-bearing in `worker-local-image`: the overlay step
  is a plain `docker build` whose `FROM ghcr.io/curie-eng/curie-worker:ci-local`
  only resolves through the default `docker` driver's local image store. #697
  added a bare `setup-buildx-action` whose default `use: true` repointed the
  default builder and reddened every run; `use: false` is the one line it
  lacked. The same shape is applied uniformly to the other three jobs so no
  future local-tag lookup in them can hit the same trap.
- **The worker-local overlay build stays a plain `docker build`.** It has no
  entry in the `images` matrix, so there is no scope for it to share, and its
  own layers are trivial (a pinned static docker CLI on top of the base). It
  keeps resolving its `FROM` from the local store, which is what `use: false`
  above preserves. Conservative default on a bounded ambiguity.
- **`context: .` kept explicit on the mail adapter build**, matching the
  `docker build ... .` it replaces. The `mail-adapter` entry in the `images`
  matrix omits `context` entirely, so the two builds may not share every layer.
  That pre-existing asymmetry is noted rather than widened; fixing it would mean
  editing the matrix, which is outside this change.
- **Ladder cache scopes untouched.** `scope=ladder-*` is left exactly as it was.

Nothing about what any job asserts, or which image it runs, changes -- only how
the image is built. The `docker run --entrypoint python ...` import assertions
and `cli/scripts/eval-falsifiability.sh` are byte-identical.

## Baseline (before)

Per-build-step wall time, from the four most recent green `main` CI runs on
2026-09-04. Every one of these steps was an uncached `docker build`.

```
gh api repos/curie-eng/agentos/actions/runs/<run-id>/jobs --paginate \
  -q '.jobs[] | select(.name|test("imports resolve|worker-local|falsifiability"))
      | .name as $n | .steps[] | select(.name|test("^Build"))
      | "\($n)|\(.name)|\(.started_at)|\(.completed_at)"'
```

| Build step | 33898634566 | 33893909416 | 33889433309 | 33885281466 | median |
| --- | --- | --- | --- | --- | --- |
| worker base | 21s | 18s | 19s | 24s | **20s** |
| dispatcher | 16s | 15s | 12s | 10s | **13.5s** |
| mail adapter | 16s | 19s | 8s | 11s | **13.5s** |
| runner (eval gate) | 38s | 36s | 34s | 38s | **37s** |
| **cacheable total** | 91s | 88s | 73s | 83s | **~84s** |

The worker-local overlay step (7-8s across all four runs) is excluded: it is not
being cached, for the reason given above.

One correction to the figure this change was scoped from: the ~155s estimate
came from whole-*job* durations on run 33883242497 (a push to `next`), which
include checkout, artifact download and the assertion step. The build steps
themselves are ~84s median on `main`, and that is the number this change can
actually move. The same run measured at step level: worker base 48s, dispatcher
12s, mail adapter 11s, runner 36s (107s total) -- `next` ran hotter than the
`main` median, so `main` is used as the honest baseline.

For the size of the win to expect, this repo has already measured the same
runner image against a warm `type=gha` scope: the `e2e-ladder` job's comment
records 58s -> 15s (9 layers restored) after wiping the builder.

## Local verification

Structural check that each build reuses a scope the matrix actually writes, that
the read-only/`load`/`use: false` shape is right, that tags and Dockerfiles are
unchanged, and that every assertion step survived:

```
uv run --no-project --with pyyaml==6.0.3 python <check script, see below>
```

```
matrix cache-to template: type=gha,mode=max,scope=${{ matrix.name }}
matrix names: ['api', 'dispatcher', 'mail-adapter', 'runner', 'sre-bot-k8s-scale',
               'sre-bot-k8s-write', 'sre-bot-self-upgrade', 'sre-bot-tempo', 'ui', 'worker']
PASS worker-local-image
PASS dispatcher-image-smoke
PASS mail-adapter-image-smoke
PASS eval-falsifiability
PASS overlay still plain docker build
PASS dispatcher-image-smoke assertion intact
PASS mail-adapter-image-smoke assertion intact
PASS eval-falsifiability assertion intact

ALL_STRUCTURAL_CHECKS OK
```

Workflow-shape gates, run against this diff:

```
uv run pytest tools/ci-workflow-paths/tests tools/ci-retry-gate/tests tools/e2e-ci-selection/tests -q
6 failed, 169 passed
```

The 6 failures are all `tools/ci-retry-gate/tests/test_gitleaks_scope.py` and
are environmental -- `gitleaks` is not installed on the machine this was
prepared on. Confirmed identical on the unmodified tree (`git stash` and re-run:
same 6 failed, 8 passed). The `ci-workflow-paths` gate (#1350) passes; this
change only removes `run:` steps, which is the surface that gate parses.

`.github/workflows/ci.yaml` is registered `exact` in `.github/e2e-selection.yaml`
for all five tiers, so this PR runs the full ladder including the cluster and
released-upgrade rungs.

## After

Filled in from the CI run on this PR once it completes; see the follow-up edit
to this body.

Ref #2230 -- this is one specific avoidable build-time driver on the PR critical
path, not the reorganization that issue tracks.
