### PR TITLE
Fetch runner pod logs with bounded concurrency

### DIFF
--- a/apps/ui/src/views/obs/RealLogs.concurrency.test.tsx
+++ b/apps/ui/src/views/obs/RealLogs.concurrency.test.tsx
@@ -1,0 +1,168 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { RealLogs } from "./RealLogs";
+import { StoreProvider } from "../../state/store";
+import {
+  ApiError,
+  getRunnerLogs,
+  listRunnerPods,
+  type PodLogs,
+  type RunnerPods,
+} from "../../api/client";
+
+// Mock only the data-layer calls; keep the real ApiError so RealLogs' error
+// branching (instanceof ApiError) is preserved.
+vi.mock("../../api/client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../api/client")>();
+  return { ...actual, getRunnerLogs: vi.fn(), listRunnerPods: vi.fn() };
+});
+
+const PODS = Array.from({ length: 12 }, (_, i) => `pod-${String(i + 1).padStart(2, "0")}`);
+
+// One in-flight getRunnerLogs call, parked until the test releases its round.
+type Parked = { pod: string; resolve: (v: PodLogs) => void; reject: (e: unknown) => void };
+
+let parked: Parked[] = [];
+let inFlight = 0;
+let maxInFlight = 0;
+
+function okLogs(pod: string): PodLogs {
+  return { namespace: "curie", pod, container: null, logs: `body of ${pod}` };
+}
+
+// Settle every call parked right now, then drain microtasks with a real timer
+// hop so the worker pool can issue its next batch and React can re-render. The
+// count of release rounds a run needs IS its simulated round-trip count, with
+// no wall-clock or fake-timer dependence.
+async function releaseRound(settle: (p: Parked) => void, order: "asc" | "desc" = "asc") {
+  const round = order === "desc" ? [...parked].reverse() : parked;
+  parked = [];
+  await act(async () => {
+    for (const p of round) settle(p);
+    await new Promise((r) => setTimeout(r, 0));
+  });
+  return round.length;
+}
+
+// Release rounds until `done` holds (or nothing is left parked), returning the
+// number of rounds it took.
+async function drainRounds(
+  settle: (p: Parked) => void,
+  done: () => boolean,
+  order: "asc" | "desc" = "asc",
+) {
+  let rounds = 0;
+  while (!done() && parked.length > 0 && rounds < 20) {
+    rounds++;
+    await releaseRound(settle, order);
+  }
+  return rounds;
+}
+
+async function renderAndFetch(pods: string[] = PODS) {
+  const user = userEvent.setup();
+  vi.mocked(listRunnerPods).mockResolvedValue({ namespace: "curie", pods } as RunnerPods);
+  render(
+    <StoreProvider>
+      <RealLogs />
+    </StoreProvider>,
+  );
+  // The pod list has landed once every pod plus the aggregate sentinel is an
+  // option, which is also when the Fetch button leaves its disabled state.
+  const select = (await screen.findByTestId("logs-pod-select")) as HTMLSelectElement;
+  await waitFor(() => expect(select.options).toHaveLength(pods.length + 1));
+  await user.click(screen.getByRole("button", { name: "Fetch logs" }));
+}
+
+function output() {
+  return screen.queryByTestId("logs-output")?.textContent ?? "";
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  parked = [];
+  inFlight = 0;
+  maxInFlight = 0;
+  vi.mocked(getRunnerLogs).mockImplementation((_ns: string, pod: string) => {
+    inFlight += 1;
+    maxInFlight = Math.max(maxInFlight, inFlight);
+    return new Promise<PodLogs>((resolve, reject) => {
+      parked.push({ pod, resolve, reject });
+    }).finally(() => {
+      inFlight -= 1;
+    });
+  });
+});
+
+describe("RealLogs - aggregate pod fetch concurrency", () => {
+  it("twelve pods finish in fewer than three round trips", async () => {
+    await renderAndFetch();
+
+    // Each release round is one simulated round trip. The serial implementation
+    // this replaced needed 12 rounds for these 12 pods, so this assertion fails
+    // loudly if the fetch ever goes back to one-at-a-time.
+    const rounds = await drainRounds(
+      (p) => p.resolve(okLogs(p.pod)),
+      () => screen.queryByTestId("logs-output") !== null,
+    );
+
+    expect(output()).toContain("=== pod-12 ===");
+    expect(rounds).toBeLessThan(3);
+    // Both halves of the contract: fast enough, and still capped.
+    expect(maxInFlight).toBe(6);
+  });
+
+  it("block order matches the listed pod order", async () => {
+    await renderAndFetch();
+
+    // Settle each round back-to-front so completion order (06..01, 12..07) is
+    // scrambled relative to list order (01..12).
+    await drainRounds(
+      (p) => p.resolve(okLogs(p.pod)),
+      () => screen.queryByTestId("logs-output") !== null,
+      "desc",
+    );
+
+    const text = output();
+    const positions = PODS.map((pod) => text.indexOf(`=== ${pod} ===`));
+    expect(positions.every((i) => i >= 0)).toBe(true);
+    expect(positions).toEqual([...positions].sort((a, b) => a - b));
+    expect(text).toContain(`=== pod-01 ===\nbody of pod-01`);
+  });
+
+  it("one rejected pod yields the inline could-not-fetch fallback and the others still render", async () => {
+    await renderAndFetch();
+
+    await drainRounds(
+      (p) =>
+        p.pod === "pod-03"
+          ? p.reject(new ApiError(404, "pod not found"))
+          : p.resolve(okLogs(p.pod)),
+      () => screen.queryByTestId("logs-output") !== null,
+    );
+
+    const text = output();
+    expect(text).toContain("=== pod-03 ===\n(could not fetch: 404: pod not found)");
+    expect(text).toContain("=== pod-02 ===\nbody of pod-02");
+    expect(text).toContain("=== pod-04 ===\nbody of pod-04");
+    expect(text).toContain("=== pod-12 ===\nbody of pod-12");
+  });
+
+  it("a 503 from any pod yields the no-cluster result", async () => {
+    await renderAndFetch();
+
+    await drainRounds(
+      (p) =>
+        p.pod === "pod-09"
+          ? p.reject(new ApiError(503, "no cluster configured"))
+          : p.resolve(okLogs(p.pod)),
+      () => screen.queryByTestId("logs-state") !== null,
+    );
+
+    const banner = await screen.findByTestId("logs-state");
+    expect(banner).toHaveTextContent("No cluster configured");
+    expect(banner).toHaveTextContent("no cluster configured");
+    expect(screen.queryByTestId("logs-output")).toBeNull();
+  });
+});

--- a/apps/ui/src/views/obs/RealLogs.tsx
+++ b/apps/ui/src/views/obs/RealLogs.tsx
@@ -64,6 +64,38 @@ function resultFromError(e: unknown): Result {
   return { kind: "error", message: e instanceof Error ? e.message : String(e) };
 }
 
+// Cap on pod-log reads in flight at once. The cap exists to protect the API's
+// Kubernetes proxy from a burst of concurrent reads, not because the client
+// could not issue more.
+const LOG_FETCH_CONCURRENCY = 6;
+
+// Run `fn` over `items` with at most `limit` calls in flight. Results are
+// returned in ITEM order regardless of completion order, and a rejection is
+// captured as a settled result so one failing item never rejects the batch.
+async function mapWithLimit<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T) => Promise<R>,
+): Promise<PromiseSettledResult<R>[]> {
+  if (items.length === 0) return [];
+  const results = new Array<PromiseSettledResult<R>>(items.length);
+  let cursor = 0;
+  // A shared index cursor hands each worker the next unclaimed item, so a slow
+  // item parks one worker instead of stalling the whole batch behind it.
+  const worker = async () => {
+    while (cursor < items.length) {
+      const i = cursor++;
+      try {
+        results[i] = { status: "fulfilled", value: await fn(items[i]) };
+      } catch (reason) {
+        results[i] = { status: "rejected", reason };
+      }
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, () => worker()));
+  return results;
+}
+
 // Wired Logs tab: pick a runner pod (or all of them) and tail its logs, proxying
 // the K8s pod-logs API. The pod list comes from the runner-pods endpoint; the
 // distinct cluster states are designed (503 no cluster, 404 pod not found, 502
@@ -102,26 +134,36 @@ export function RealLogs() {
     void loadPods("curie", prefill ?? ALL);
   }, [loadPods, prefill]);
 
-  // Aggregate logs across every listed pod, one labeled block per pod. A single
-  // pod short-circuits to the plain per-pod result so its distinct error states
-  // (404/502/503) are preserved; only the multi-pod "All" view concatenates.
+  // Aggregate logs across every listed pod, one labeled block per pod, reading
+  // up to LOG_FETCH_CONCURRENCY pods at a time. A single pod short-circuits to
+  // the plain per-pod result so its distinct error states (404/502/503) are
+  // preserved; only the multi-pod "All" view concatenates.
   const fetchAll = async (ns: string, list: string[]) => {
-    const blocks: string[] = [];
-    for (const pod of list) {
-      try {
-        const data = await getRunnerLogs(ns, pod, { tail_lines: 200 });
-        blocks.push(`=== ${pod} ===\n${data.logs.trim() === "" ? "(no log lines)" : data.logs}`);
-      } catch (e) {
-        // A cluster-wide failure (503) aborts the whole aggregate; per-pod 404s
-        // are noted inline so one missing pod does not blank the others.
-        if (e instanceof ApiError && e.status === 503) {
-          setResult({ kind: "no-cluster", message: e.message });
-          return;
-        }
-        const msg = e instanceof ApiError ? `${e.status}: ${e.message}` : e instanceof Error ? e.message : String(e);
-        blocks.push(`=== ${pod} ===\n(could not fetch: ${msg})`);
+    const settled = await mapWithLimit(list, LOG_FETCH_CONCURRENCY, (pod) =>
+      getRunnerLogs(ns, pod, { tail_lines: 200 }),
+    );
+    // A cluster-wide failure (503) still aborts the whole aggregate, but because
+    // the reads now overlap it is detected in the results rather than mid-loop:
+    // the earliest 503 in list order stands in for the one the serial read would
+    // have hit first.
+    for (const outcome of settled) {
+      if (outcome.status === "rejected" && outcome.reason instanceof ApiError && outcome.reason.status === 503) {
+        setResult({ kind: "no-cluster", message: outcome.reason.message });
+        return;
       }
     }
+    // Per-pod failures (a 404 for a pod that has since gone) are noted inline so
+    // one missing pod does not blank the others.
+    const blocks = list.map((pod, i) => {
+      const outcome = settled[i];
+      if (outcome.status === "fulfilled") {
+        const data = outcome.value;
+        return `=== ${pod} ===\n${data.logs.trim() === "" ? "(no log lines)" : data.logs}`;
+      }
+      const e = outcome.reason;
+      const msg = e instanceof ApiError ? `${e.status}: ${e.message}` : e instanceof Error ? e.message : String(e);
+      return `=== ${pod} ===\n(could not fetch: ${msg})`;
+    });
     setResult({
       kind: "ok",
       data: { namespace: ns, pod: `all runner pods (${list.length})`, container: null, logs: blocks.join("\n\n") },


### PR DESCRIPTION
## Summary

The console Logs view's "All runner pods" aggregate read one pod at a time (`for (const pod of list) { await getRunnerLogs(...) }`), so wall time was pod count times the API proxied Kubernetes pod-logs round trip. That is the default selection, so the common case paid the worst price. This replaces the serial loop with a bounded worker pool capped at six reads in flight, which turns the aggregate into roughly one round trip regardless of pod count. Rendered output, block ordering, the inline could-not-fetch fallback, and the cluster wide 503 short circuit are all preserved exactly; no API, wire shape, OpenAPI signature, CLI schema, or command manifest is touched.

Found by an internal performance review of the console UI.

## Related issue

No tracking issue. Opportunistic performance work; this closes nothing.

## Measured baseline and after

Twelve pods, `getRunnerLogs` mocked at a fixed 50 ms latency, measured from the "Fetch logs" click to the aggregate rendering, via a throwaway vitest bench (not committed) rendering the real `RealLogs` component:

| | Wall time to render the 12 pod aggregate | Simulated round trips |
| --- | --- | --- |
| Before (serial `for await`) | 782 ms | 12 |
| After (bounded pool, cap 6) | 226 ms | 2 |

The 556 ms saved is the latency portion: 12 x 50 ms of serial waiting becomes 2 x 50 ms, and the residual ~126 ms is React and Testing Library overhead that both runs pay. The round trip count is the load bearing number, and it is pinned by a committed test rather than by wall clock.

The committed round count is reproducible without any timing dependence:

```
cd apps/ui
pnpm exec vitest run src/views/obs/RealLogs.concurrency.test.tsx
```

and the falsifiable negative, which restores the serial implementation under the new test:

```
cd apps/ui
git show origin/main:apps/ui/src/views/obs/RealLogs.tsx > src/views/obs/RealLogs.tsx
pnpm exec vitest run src/views/obs/RealLogs.concurrency.test.tsx
# AssertionError: expected 12 to be less than 3
git checkout src/views/obs/RealLogs.tsx
```

## Approach and the one behavior that could not be preserved

`mapWithLimit` is an ordered worker pool: a shared index cursor hands each of `min(limit, n)` workers the next unclaimed item, and each result is written into a pre sized array at its own index, so the returned array is in item order no matter what order the reads complete in. A rejection is captured as a settled result, so one bad pod never rejects the batch.

The one deviation, taken as the conservative default and called out here:

- **The 503 is now detected in the settled results rather than mid loop.** The serial loop aborted the instant a pod returned 503, so later pods were never requested. Overlapping reads cannot do that, so the aggregate now scans the settled results in list order and takes the first 503, which is the one the serial read would have hit first. The user visible result is identical. What differs is that up to five other reads may already be in flight when the 503 lands, so a cluster wide outage costs a few extra requests before the aggregate gives up. Early cancellation was deliberately not added: it would need an abort flag threaded through the pool for a saving that only applies on the path where the cluster is already gone.

The cap of six is a deliberate ceiling on the API's Kubernetes proxy, not a limit of the client.

The single pod short circuit in `fetchLogs`, `resultFromError`, `loadPods`, and every piece of JSX are untouched.

## Fix pin verification

Not a fix pull request and it closes no `bug` labeled issue, so no selector is declared.

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | No plugin or skill packaging, runner turn loop, ACI event, or skill eval is reached; the diff is one console UI view component and its test. | | |
| local | Required | The diff changes the console UI. | fake | `cd apps/ui && PW_PORT=4291 pnpm exec playwright test` at ca662d2f: **40 passed**, including the three Logs tab specs that pin the preserved behavior in a real browser against the built UI: "Logs tab aggregates logs across all runner pods by default", "Logs tab renders a single pod's logs from the dropdown", and "Logs tab shows the 503 no-cluster degraded state". Also `pnpm lint` clean, `pnpm typecheck` clean, `pnpm test` **25 files / 161 tests passed** (up from 24 / 157). |
| local-release | n/a | No released binary or image identity, install path, version pin, or release compose file is reached. | | |
| cluster | n/a | No chart template, RBAC, securityContext, NetworkPolicy, sandbox claim, or init container is reached. | | |
| live provider | n/a | No model routing, credential resolution, provider auth, or token and cost accounting is reached. | | |
| external integration | n/a | No Slack, git push webhook, connector OAuth, or third party API shape is reached. The only endpoint called is Curie's own observability runner-logs route, which is unchanged. | | |

Deviation on the `local` tier, recorded rather than glossed: `CURIE_E2E_TIERS=local curie dev e2e-ladder` was **not** run. This box was already hosting another job's compose stack, and standing up a second full stack alongside it risked disturbing that run. The ladder's extra surface is not reachable by this diff in any case: nothing in compose, the dispatcher, the worker, the API, or boot env is touched, and the changed code is client side only. The `local` tier is instead evidenced by the committed stackless Playwright suite, which drives the real built console UI through a real browser across all three preserved paths.

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.

  - *Bounded concurrency, same output*: positive is the 12 pod test draining in 2 rounds with `maxInFlight` pinned at exactly 6; negative is the same test reporting 12 rounds against the restored serial implementation (command above).
  - *Block order follows list order*: positive is the ordering test settling each round back to front and asserting the `=== pod-NN ===` headers still ascend; second independent path is the Playwright aggregate spec asserting both pod blocks render.
  - *Inline fallback survives*: positive asserts the `=== pod-03 ===` header followed by `(could not fetch: 404: pod not found)` renders beside its neighbours' bodies; the negative is that the neighbouring pods' logs are asserted present in the same output, so a fallback that swallowed the batch would fail.
  - *503 short circuits the aggregate*: positive asserts the no-cluster banner renders; the negative is the paired assertion that `logs-output` is absent, so a 503 degraded into an inline fallback would fail. Second independent path is the Playwright 503 spec.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

## Checklist

- [x] Tests pass for the area I touched.
- [x] Docs updated if behavior changed. No user facing behavior changed, so no doc references this; the rationale for the concurrency cap and the 503 detection change lives in comments at the code.
- [x] An ADR is added under `docs/adr/` if this is an architectural decision. Not an architectural decision: a local scheduling change inside one view component, with no seam, contract, or cross cutting pattern introduced.
