### PR TITLE
Compress and cache the console UI static assets

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -760,6 +760,308 @@ jobs:
       - name: Entrypoint imports resolve in the built image
         run: docker run --rm --entrypoint python curie-mail-adapter:ci-smoke -c "import curie_mail_adapter; import aci_protocol; import pydantic_settings"
 
+  # The console UI image serves its build through an nginx template that lives
+  # as a heredoc in apps/ui/Dockerfile, not as a checked-in config file, so
+  # nothing reviews it directly. The build-only `images` job above never runs
+  # the image, and the Playwright suite previews the raw Vite build on port
+  # 4273, bypassing nginx entirely. That leaves the built container as the
+  # only place the served response headers, compression and cache behavior
+  # are observable at all. This job builds the real image, boots it, and pins
+  # those headers so a template regression fails CI instead of surfacing as a
+  # production caching or compression bug.
+  ui-image-smoke:
+    name: UI image response headers are correct
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Set up a cache-only buildx builder (named, NOT the default)
+        id: buildcache
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+        with:
+          use: false
+      - name: Build the UI image locally (gha layer cache)
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: apps/ui/Dockerfile
+          builder: ${{ steps.buildcache.outputs.name }}
+          tags: curie-ui:ci-smoke
+          push: false
+          load: true
+          cache-from: type=gha,scope=ui
+      - name: Start the stub API upstream
+        run: |
+          set -euo pipefail
+          docker network create curie-ui-smoke-net
+          docker run -d --name curie-api-smoke \
+            --network curie-ui-smoke-net \
+            --network-alias curie-api \
+            -v "${PWD}/apps/ui/ci/smoke-upstream-api.py:/app/upstream.py:ro" \
+            python:3.13-slim \
+            python -u /app/upstream.py
+          # nginx resolves the proxy_pass upstream at startup, so the alias must
+          # already be resolvable and serving before the UI container starts or
+          # the UI exits 1.
+          for i in $(seq 1 40); do
+            if docker exec curie-api-smoke python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/agents').read()" >/dev/null 2>&1; then
+              exit 0
+            fi
+            sleep 0.5
+          done
+          echo "Stub API upstream never became ready" >&2
+          docker logs curie-api-smoke || true
+          exit 1
+      - name: Start the UI container
+        run: |
+          set -euo pipefail
+          docker run -d --name curie-ui-smoke \
+            --network curie-ui-smoke-net \
+            -e CURIE_API_TARGET=http://curie-api:8000 \
+            -p 18080:8080 \
+            curie-ui:ci-smoke
+          for i in $(seq 1 40); do
+            if curl -sf -o /dev/null http://127.0.0.1:18080/; then
+              exit 0
+            fi
+            sleep 0.5
+          done
+          echo "UI container never became ready" >&2
+          docker logs curie-ui-smoke || true
+          exit 1
+      - name: Assert response headers
+        run: |
+          set -euo pipefail
+
+          # Resolve the hashed asset path from the running container rather
+          # than hardcoding a hash that changes on every build.
+          JS_ASSET_NAME="$(docker exec curie-ui-smoke sh -c 'cd /usr/share/nginx/html/assets && ls *.js' | head -1)"
+          if [ -z "$JS_ASSET_NAME" ]; then
+            echo "No hashed JS asset found in the built image" >&2
+            exit 1
+          fi
+          ASSET_PATH="/assets/${JS_ASSET_NAME}"
+          BASE_URL="http://127.0.0.1:18080"
+
+          gzip_headers="$(curl -sS -D - -o /dev/null -H 'Accept-Encoding: gzip' "${BASE_URL}${ASSET_PATH}" | tr 'A-Z' 'a-z')"
+
+          if ! echo "$gzip_headers" | grep -q '^content-encoding: gzip'; then
+            echo "Missing header: Content-Encoding: gzip on ${ASSET_PATH}" >&2
+            echo "$gzip_headers" >&2
+            exit 1
+          fi
+
+          if ! echo "$gzip_headers" | grep 'cache-control' | grep -q 'public'; then
+            echo "Missing token in Cache-Control: public on ${ASSET_PATH}" >&2
+            echo "$gzip_headers" >&2
+            exit 1
+          fi
+
+          if ! echo "$gzip_headers" | grep 'cache-control' | grep -q 'immutable'; then
+            echo "Missing token in Cache-Control: immutable on ${ASSET_PATH}" >&2
+            echo "$gzip_headers" >&2
+            exit 1
+          fi
+
+          if ! echo "$gzip_headers" | grep 'cache-control' | grep -q 'max-age=31536000'; then
+            echo "Missing token in Cache-Control: max-age=31536000 on ${ASSET_PATH}" >&2
+            echo "$gzip_headers" >&2
+            exit 1
+          fi
+
+          if ! echo "$gzip_headers" | grep -q '^vary: accept-encoding'; then
+            echo "Missing header: Vary: Accept-Encoding on ${ASSET_PATH}" >&2
+            echo "$gzip_headers" >&2
+            exit 1
+          fi
+
+          # Compressed transfer size must be meaningfully smaller than the
+          # identity size, proving gzip actually ran rather than the header
+          # being stamped without real compression behind it.
+          identity_size="$(curl -sS -o /dev/null -H 'Accept-Encoding: identity' -w '%{size_download}' "${BASE_URL}${ASSET_PATH}")"
+          compressed_size="$(curl -sS -o /dev/null -H 'Accept-Encoding: gzip' -w '%{size_download}' "${BASE_URL}${ASSET_PATH}")"
+          if [ "$identity_size" -le 0 ]; then
+            echo "Identity response for ${ASSET_PATH} was empty" >&2
+            exit 1
+          fi
+          half_identity=$((identity_size / 2))
+          if [ "$compressed_size" -ge "$half_identity" ]; then
+            echo "Gzip transfer size not meaningfully smaller than identity for ${ASSET_PATH}" >&2
+            echo "identity_size=${identity_size} compressed_size=${compressed_size}" >&2
+            exit 1
+          fi
+
+          # NEGATIVE case: without gzip in the request, the response must not
+          # claim to be gzip encoded, proving the header tracks the request
+          # rather than being stamped unconditionally.
+          identity_headers="$(curl -sS -D - -o /dev/null -H 'Accept-Encoding: identity' "${BASE_URL}${ASSET_PATH}" | tr 'A-Z' 'a-z')"
+          if echo "$identity_headers" | grep -q '^content-encoding: gzip'; then
+            echo "Content-Encoding: gzip present on an identity request for ${ASSET_PATH}" >&2
+            echo "$identity_headers" >&2
+            exit 1
+          fi
+
+          # index.html must not carry a long-lived cache like the hashed assets do.
+          index_headers="$(curl -sS -D - -o /dev/null "${BASE_URL}/" | tr 'A-Z' 'a-z')"
+          if ! echo "$index_headers" | grep 'cache-control' | grep -q 'no-cache'; then
+            echo "Missing token in Cache-Control: no-cache on / (index.html)" >&2
+            echo "$index_headers" >&2
+            exit 1
+          fi
+          if echo "$index_headers" | grep 'cache-control' | grep -q 'immutable'; then
+            echo "index.html Cache-Control unexpectedly contains immutable" >&2
+            echo "$index_headers" >&2
+            exit 1
+          fi
+          if echo "$index_headers" | grep 'cache-control' | grep -q 'max-age=31536000'; then
+            echo "index.html Cache-Control unexpectedly contains max-age=31536000" >&2
+            echo "$index_headers" >&2
+            exit 1
+          fi
+
+          # GUARD DEMONSTRATION for `try_files $uri =404` in the assets
+          # location. Without it a missing hashed asset falls through to the SPA
+          # fallback and returns an HTML body under a year-long immutable cache
+          # at a URL that will never be requested again with different content.
+          missing_asset_status="$(curl -sS -o /dev/null -w '%{http_code}' "${BASE_URL}/assets/does-not-exist-0000000.js")"
+          if [ "$missing_asset_status" != "404" ]; then
+            echo "A missing hashed asset returned ${missing_asset_status}, expected 404" >&2
+            exit 1
+          fi
+          missing_asset_headers="$(curl -sS -D - -o /dev/null "${BASE_URL}/assets/does-not-exist-0000000.js" | tr 'A-Z' 'a-z')"
+          if echo "$missing_asset_headers" | grep 'cache-control' | grep -q 'immutable'; then
+            echo "A missing hashed asset was served with an immutable Cache-Control" >&2
+            echo "$missing_asset_headers" >&2
+            exit 1
+          fi
+          if echo "$missing_asset_headers" | grep 'cache-control' | grep -q 'max-age=31536000'; then
+            echo "A missing hashed asset was served with a year-long max-age" >&2
+            echo "$missing_asset_headers" >&2
+            exit 1
+          fi
+
+          # API ISOLATION. `gzip off` inside location /api/ is what keeps proxied
+          # responses byte-identical. The subtle pairing: application/json IS in
+          # gzip_types, so this JSON body would be compressed by the server-scope
+          # gzip if the location-scope `gzip off` were removed. A gzipped
+          # response here is therefore a direct failure of that directive.
+          api_headers="$(curl -sS -D - -o /dev/null -H 'Accept-Encoding: gzip' "${BASE_URL}/api/agents" | tr 'A-Z' 'a-z')"
+          if echo "$api_headers" | grep -q '^content-encoding:'; then
+            echo "Proxied API response carries a Content-Encoding header; gzip off in location /api/ is not in effect" >&2
+            echo "$api_headers" >&2
+            exit 1
+          fi
+          api_declared_length="$(echo "$api_headers" | awk '/^content-length:/ {gsub(/[^0-9]/, "", $2); print $2}' | head -1)"
+          if [ -z "$api_declared_length" ]; then
+            echo "Proxied API response has no Content-Length; nginx re-chunked or rewrote the upstream body" >&2
+            echo "$api_headers" >&2
+            exit 1
+          fi
+          api_received_bytes="$(curl -sS -o /dev/null -H 'Accept-Encoding: gzip' -w '%{size_download}' "${BASE_URL}/api/agents")"
+          if [ "$api_declared_length" != "$api_received_bytes" ]; then
+            echo "Proxied API Content-Length ${api_declared_length} does not match the ${api_received_bytes} bytes received; the body was recompressed or re-chunked" >&2
+            exit 1
+          fi
+
+          # STREAMING. The upstream emits five SSE events 0.4s apart, so a
+          # pass-through proxy delivers them over roughly 1.6s. If nginx buffers
+          # the response they all land at once and the elapsed span collapses to
+          # near zero, which fails here.
+          sse_result="$(curl -sN --max-time 30 "${BASE_URL}/api/stream" | python3 -u -c '
+          import sys
+          import time
+
+          first = None
+          last = None
+          count = 0
+          while True:
+              line = sys.stdin.readline()
+              if not line:
+                  break
+              if line.startswith("data:"):
+                  now = time.monotonic()
+                  if first is None:
+                      first = now
+                  last = now
+                  count += 1
+          span_ms = int((last - first) * 1000) if first is not None else 0
+          print("%d %d" % (count, span_ms))
+          ')"
+          sse_count="$(echo "$sse_result" | awk '{print $1}')"
+          sse_span_ms="$(echo "$sse_result" | awk '{print $2}')"
+          if [ "$sse_count" != "5" ]; then
+            echo "Expected 5 SSE events through the /api/ proxy, received ${sse_count}" >&2
+            exit 1
+          fi
+          if [ "$sse_span_ms" -lt 1000 ]; then
+            echo "SSE events arrived within ${sse_span_ms}ms of each other; nginx buffered the stream instead of passing it through" >&2
+            exit 1
+          fi
+
+          # CONFIG-LEVEL PIN for the full gzip_types list. The build emits no
+          # JSON or SVG asset large enough to clear gzip_min_length, so there is
+          # no runtime path that would notice those types being dropped from the
+          # template; this assertion is their pin. The JS asset above already
+          # proves the runtime path end to end for the JavaScript types.
+          # Anchor on the directive line itself: this same config file also has
+          # an nginx comment mentioning gzip_types, and a plain grep would match
+          # that comment too, letting a required type be silently dropped from
+          # the real directive while the check still passes.
+          gzip_types_line="$(docker exec curie-ui-smoke grep -E '^[[:space:]]*gzip_types[[:space:]]' /etc/nginx/conf.d/default.conf)"
+          if [ -z "$gzip_types_line" ]; then
+            echo "nginx config has no gzip_types directive at all" >&2
+            exit 1
+          fi
+          for required_type in application/javascript text/javascript text/css application/json image/svg+xml; do
+            if ! echo "$gzip_types_line" | grep -qF "$required_type"; then
+              echo "nginx gzip_types is missing the required type: ${required_type}" >&2
+              echo "$gzip_types_line" >&2
+              exit 1
+            fi
+          done
+
+          # A CSS asset is gzipped too, if the build emits one and it is large
+          # enough to clear the server's gzip_min_length floor. Below that
+          # floor nginx correctly declines to compress it, so the check falls
+          # back to asserting the config declares text/css as compressible.
+          # Skip gracefully if the build emits no CSS asset at all.
+          GZIP_MIN="$(docker exec curie-ui-smoke sh -c "awk '/gzip_min_length/ {gsub(/[^0-9]/, \"\", \$2); print \$2}' /etc/nginx/conf.d/default.conf" | head -1)"
+          GZIP_MIN="${GZIP_MIN:-1024}"
+          CSS_ASSET_NAME="$(docker exec curie-ui-smoke sh -c 'cd /usr/share/nginx/html/assets && ls *.css 2>/dev/null || true' | head -1)"
+          if [ -n "$CSS_ASSET_NAME" ]; then
+            CSS_ASSET_SIZE="$(docker exec curie-ui-smoke sh -c "wc -c < /usr/share/nginx/html/assets/${CSS_ASSET_NAME}" | tr -d '[:space:]')"
+            css_headers="$(curl -sS -D - -o /dev/null -H 'Accept-Encoding: gzip' "${BASE_URL}/assets/${CSS_ASSET_NAME}" | tr 'A-Z' 'a-z')"
+            if ! echo "$css_headers" | grep 'cache-control' | grep -q 'immutable'; then
+              echo "Missing token in Cache-Control: immutable on /assets/${CSS_ASSET_NAME}" >&2
+              echo "$css_headers" >&2
+              exit 1
+            fi
+            if [ "$CSS_ASSET_SIZE" -ge "$GZIP_MIN" ]; then
+              if ! echo "$css_headers" | grep -q '^content-encoding: gzip'; then
+                echo "Missing header: Content-Encoding: gzip on /assets/${CSS_ASSET_NAME}" >&2
+                echo "$css_headers" >&2
+                exit 1
+              fi
+            else
+              echo "CSS asset ${CSS_ASSET_NAME} is ${CSS_ASSET_SIZE} bytes, below the gzip_min_length floor of ${GZIP_MIN}; asserting gzip_types config instead of runtime encoding"
+              if ! echo "$gzip_types_line" | grep -qF 'text/css'; then
+                echo "nginx config does not declare text/css in gzip_types" >&2
+                exit 1
+              fi
+            fi
+          else
+            echo "No CSS asset found in this build; skipping the CSS gzip assertion"
+          fi
+
+          echo "All UI image header assertions passed"
+      - name: Tear down the UI container and its API upstream
+        if: always()
+        run: |
+          docker rm -f curie-ui-smoke || true
+          docker rm -f curie-api-smoke || true
+          docker network rm curie-ui-smoke-net || true
+
   # FALSIFIABILITY gate for the committed eval suites (issue #619). This is NOT
   # an E2E test: it never runs a real agent or makes a model call. It boots the
   # runner's scripted FAKE model (offline, no credential, no network) -- a

--- a/apps/ui/CLAUDE.md
+++ b/apps/ui/CLAUDE.md
@@ -63,6 +63,19 @@ structure and wiring detail in `apps/ui/README.md`.
   runs when `PW_INTEGRATION=1`). Default `pnpm e2e` runs stackless only, so
   CI stays green without a backend.
 
+## The served response headers are pinned in CI, not in Playwright
+
+The nginx config that serves the console in production lives as a heredoc
+inside `apps/ui/Dockerfile`, not as a checked in config file. It sets gzip
+for the build assets and a one year immutable `Cache-Control` on
+`/assets/`, while `index.html` is `no-cache` so a redeploy is picked up.
+`location /api/` sets `gzip off` so proxied API responses stay
+byte-identical. Playwright cannot cover any of this, because its suite
+previews the Vite build on `4273` and never runs nginx. The pin is the
+`ui-image-smoke` job in `.github/workflows/ci.yaml`, which builds the real
+image, boots it against a stub API upstream, and asserts those headers.
+Change the nginx template and you update that job, not a Playwright spec.
+
 ## Verify
 
 ```bash

--- a/apps/ui/Dockerfile
+++ b/apps/ui/Dockerfile
@@ -44,6 +44,16 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Compress static text payloads. The single Vite JS bundle is about
+    # 567 kB raw and about 155 kB gzipped, and it is render-blocking for the
+    # SPA, so shrinking it on the wire is worth the CPU. text/html is always
+    # gzipped by nginx and cannot be listed here.
+    gzip on;
+    gzip_vary on;
+    gzip_comp_level 6;
+    gzip_min_length 1024;
+    gzip_types application/javascript text/javascript text/css application/json image/svg+xml;
+
     # Internal worker routes are never exposed through the browser-facing
     # reverse proxy, even when a client knows their path.
     location = /api/v1/internal {
@@ -55,6 +65,12 @@ server {
 
     # Reverse-proxy operator API calls, stripping the /api prefix.
     location /api/ {
+        # gzip is on at server scope and application/json is in gzip_types,
+        # so proxied API responses would otherwise get compressed here.
+        # gzip off keeps them byte-identical to what the upstream sent.
+        # Buffering is left at its default on purpose; streaming behavior
+        # is unchanged from before this commit.
+        gzip off;
         proxy_pass ${CURIE_API_TARGET}/;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -62,8 +78,20 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    # Vite emits content-hashed filenames for build assets, so a new build is
+    # a new URL and these can be cached for a year without ever going stale.
+    location ^~ /assets/ {
+        add_header Cache-Control "public, max-age=31536000, immutable";
+        # A missing hashed asset must 404, not fall through to index.html and
+        # get cached for a year as an HTML body.
+        try_files $uri =404;
+    }
+
     # SPA fallback.
     location / {
+        # index.html is the pointer at the hashed assets, so a redeploy is
+        # only picked up if it is revalidated on every request.
+        add_header Cache-Control "no-cache" always;
         try_files $uri $uri/ /index.html;
     }
 }

--- a/apps/ui/ci/smoke-upstream-api.py
+++ b/apps/ui/ci/smoke-upstream-api.py
@@ -1,0 +1,52 @@
+"""Stub upstream API for the `ui-image-smoke` CI job.
+
+The job puts this server behind the console image's `/api/` proxy location so
+the smoke checks can prove that proxied API responses stay uncompressed,
+byte-identical to what the upstream wrote, and incrementally streamed rather
+than buffered. Two behaviors are served: a large JSON body with an explicit
+Content-Length, well over `gzip_min_length` so gzip would certainly fire if the
+`gzip off` in that location were ever deleted, and an SSE stream emitted as
+timed chunked writes so buffering can be measured rather than assumed.
+
+CI only. This file is never copied into the shipped UI image.
+"""
+
+import json
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+PAYLOAD = json.dumps(
+    {"agents": [{"id": i, "name": f"agent-{i}", "status": "ready"} for i in range(2000)]}
+).encode()
+
+
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, fmt, *args):
+        return
+
+    def do_GET(self):
+        if self.path.startswith("/stream"):
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.send_header("Cache-Control", "no-cache")
+            self.send_header("Transfer-Encoding", "chunked")
+            self.end_headers()
+            for n in range(5):
+                body = f"data: tick {n}\n\n".encode()
+                self.wfile.write(f"{len(body):x}\r\n".encode() + body + b"\r\n")
+                self.wfile.flush()
+                time.sleep(0.4)
+            self.wfile.write(b"0\r\n\r\n")
+            self.wfile.flush()
+            return
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(PAYLOAD)))
+        self.end_headers()
+        self.wfile.write(PAYLOAD)
+        self.wfile.flush()
+
+
+ThreadingHTTPServer(("0.0.0.0", 8000), Handler).serve_forever()

--- a/tools/ci-retry-gate/tests/test_retry_eligibility.py
+++ b/tools/ci-retry-gate/tests/test_retry_eligibility.py
@@ -170,6 +170,16 @@ RUN_RETRY_EXEMPT: frozenset[tuple[str, str, str]] = frozenset(
         # The raw CDN is eventually consistent after publication. This poll
         # never reruns repository code or the Pages publication mutation.
         ("chart-index.yaml", "publish-index", "Verify the public Helm consumer path"),
+        # Both are readiness polls for an external process starting up, not
+        # retries. The first waits for the stub upstream container to begin
+        # serving; the second waits for nginx to begin serving, and the two
+        # cannot be collapsed into one because nginx resolves its `proxy_pass`
+        # upstream at startup, so the UI must be started only once the upstream
+        # is already reachable. Neither re invokes repository code, and neither
+        # retries a mutation whose failure would be a defect: if either never
+        # becomes ready the step fails the job rather than papering over it.
+        ("ci.yaml", "ui-image-smoke", "Start the stub API upstream"),
+        ("ci.yaml", "ui-image-smoke", "Start the UI container"),
     }
 )
 


### PR DESCRIPTION
## Summary

The nginx config baked into `apps/ui/Dockerfile` had no gzip and no `Cache-Control`, and the `nginx-unprivileged` base ships `nginx.conf` with gzip commented out, so every console load pulled the render-blocking Vite bundle uncompressed and revalidated it on each visit. This enables gzip for the static text types, marks the content-hashed `/assets/` immutable for a year, and keeps `index.html` at `no-cache` so a redeploy is still picked up. The hashed JS asset drops from 566936 bytes to 153917 on the wire, a 72.9 percent reduction. `location /api/` gets an explicit `gzip off` so proxied API responses are untouched.

## Related issue

None. Opportunistic performance work found by a UI performance review of `origin/main`.

## Measured before and after

Both measured against the real image built from this repository, run as
`docker run -d -e CURIE_API_TARGET=... -p 18080:8080 <image>`.

Baseline, `origin/main` at ce6fef7e:

```
$ curl -sI --compressed http://127.0.0.1:18080/assets/index-CxFuoh_V.js
HTTP/1.1 200 OK
Content-Type: application/javascript
Content-Length: 566936
ETag: "6a9b1d47-8a698"
(no Content-Encoding, no Cache-Control, no Vary)

$ curl -sI --compressed http://127.0.0.1:18080/
HTTP/1.1 200 OK
Content-Type: text/html
Content-Length: 453
(no Cache-Control)
```

After, this branch:

```
$ curl -sI --compressed http://127.0.0.1:18080/assets/index-CxFuoh_V.js
HTTP/1.1 200 OK
Content-Type: application/javascript
Vary: Accept-Encoding
ETag: W/"6a9b1d47-8a698"
Cache-Control: public, max-age=31536000, immutable
Content-Encoding: gzip

$ curl -sI --compressed http://127.0.0.1:18080/
HTTP/1.1 200 OK
Content-Type: text/html
Content-Length: 453
Cache-Control: no-cache
```

Bytes actually transferred for the hashed JS asset:

```
$ curl -s -o /dev/null -H 'Accept-Encoding: identity' -w '%{size_download}' .../index-CxFuoh_V.js
566936
$ curl -s -o /dev/null -H 'Accept-Encoding: gzip' -w '%{size_download}' .../index-CxFuoh_V.js
153917
```

nginx switches to a weak ETag when it compresses, which is expected and still revalidates correctly.

## The API proxy is unchanged

Verified by running both images against the same upstream, one serving a large JSON body and one serving a chunked SSE stream:

| | baseline | this branch |
| --- | --- | --- |
| `GET /api/agents` Content-Length | 69791 | 69791 |
| response body sha256 | c0158e0b53f5... | c0158e0b53f5... |
| Content-Encoding | absent | absent |
| SSE tick arrival | 400 ms apart, 5 ticks | 400 ms apart, 5 ticks |

Buffering is deliberately left at its default, so streaming behavior is unchanged from before this commit.

## Every new assertion was mutation tested

The `ui-image-smoke` job passes against this branch and fails against `origin/main`. Each guard was then removed one at a time and the job re-run, to prove no assertion is vacuous:

| Mutation applied to the nginx template | Result |
| --- | --- |
| delete `gzip off;` from `location /api/` | KILLED: proxied API response carries a Content-Encoding header |
| `try_files $uri =404` back to the SPA fallback | KILLED: a missing hashed asset returned 200, expected 404 |
| drop the `public` token from Cache-Control | KILLED: missing token in Cache-Control: public |
| drop `application/json` from `gzip_types` | KILLED: gzip_types is missing the required type |
| drop `add_header Cache-Control "no-cache"` on index.html | KILLED: missing token in Cache-Control: no-cache |

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | reaches no plugin or skill packaging, no runner turn loop, no ACI event, and no skill eval or check | | |
| local | Required | the console UI is a compose service and its served response headers change | fake | `COMPOSE_PROJECT_NAME=curie-perfui-<pid> CURIE_UI_IMAGE=curie-ui:perf-after docker compose -f compose.dev.yaml --profile full up -d --no-deps curie-ui`, against be5ecb07. Observed: the compose healthcheck reached `healthy`, and through the published port 28080 the hashed asset returned `Content-Encoding: gzip`, `Vary: Accept-Encoding`, `Cache-Control: public, max-age=31536000, immutable` at 153917 wire bytes, while `/` returned `Cache-Control: no-cache`. Stack torn down with `down -v --remove-orphans`. |
| local-release | n/a | no released binary or image identity, install path, version pin, or release compose content changes; the ui image tag, entrypoint, base image, non-root user and port 8080 are all untouched | | |
| cluster | n/a | no chart template, RBAC, securityContext, NetworkPolicy, sandbox claim, or init container is touched; `charts/curie/templates/ui.yaml` consumes the image unchanged and adds no server config of its own | | |
| live provider | n/a | reaches no model routing, credential resolution, provider auth, or token and cost accounting | | |
| external integration | n/a | reaches no Slack, git push webhook, connector OAuth, or third-party API shape | | |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path. Positive: the smoke job passes on this branch. Negative: the same job fails on `origin/main`, and each individual guard was mutation tested as tabled above.
- [x] No required tier is left unproved.

## Decisions taken on bounded ambiguity

- A missing `/assets/` path now returns 404 instead of falling through to the SPA. Falling through would serve an HTML body under a hashed URL carrying a one year immutable cache, which is the more dangerous option. The console only ever requests assets its own build emitted, so this is not reachable in normal product use.
- `gzip_min_length` is left at the conservative 1024. The current CSS asset is 825 bytes and so is not compressed at runtime; `text/css` is therefore pinned at the config level in the smoke job, with the JS asset proving the runtime path end to end.
- `application/json` and `image/svg+xml` have no build asset large enough to exercise them, so they are pinned at the config level too. The proxied JSON staying uncompressed despite `application/json` being in `gzip_types` is exactly what the `gzip off` in the API location guarantees, and that pairing is asserted at runtime.
- The stub upstream the smoke job uses is written into the workspace rather than the runner temp dir. The temp dir variant could not be verified on the development box, whose Docker daemon cannot mount host `/tmp`, and shipping an unverified CI change was the worse trade.

## Checklist

- [x] Tests pass for the area I touched. `pnpm lint`, `pnpm typecheck`, `pnpm test` (24 files, 157 tests) and `pnpm e2e` all pass in `apps/ui`, and the ui image builds.
- [x] Docs updated if behavior changed. `apps/ui/CLAUDE.md` gains a section recording that these headers are pinned by the CI job rather than by Playwright, which cannot reach nginx.
- [x] An ADR is added under `docs/adr/` if this is an architectural decision. Not an architectural decision: this configures the existing serving path and changes no seam or contract.

## Notes on the CI job itself

- The stub upstream lives in `apps/ui/ci/smoke-upstream-api.py` rather than a heredoc. The repository's retry gate reads a `run:` body as shell, and the Python `return` statements inside a heredoc read as a repeated command invocation.
- The job's two readiness polls are registered in `RUN_RETRY_EXEMPT` in `tools/ci-retry-gate/tests/test_retry_eligibility.py`. Both wait for an external process to begin serving rather than retrying anything, and they cannot be collapsed into one because nginx resolves its `proxy_pass` upstream at startup, so the UI container can only start once the upstream is already reachable.
- The image build follows the convention `main` established in 0f0ea6f5 for the other four smoke and gate jobs: a named cache-only buildx builder with `cache-from: type=gha,scope=ui` and no `cache-to`, since the `images` matrix already refreshes that scope.

## Known unrelated red check

`cargo audit` fails on this pull request. It also fails on `main` itself, including at ce6fef7e, the exact commit this branch was cut from, before this branch existed. It runs in `dependency-audit.yaml`, which fetches the live RustSec advisory database on every run, and `cli/Cargo.lock` here is the identical git blob to the one on `main` (this branch changes no Rust or Cargo file at all). The advisory is RUSTSEC-2023-0071 against the `rsa` crate. That is a pre-existing repository-wide failure and is out of scope for this pull request.