### PR TITLE
Route BYO Langfuse and ClickHouse URLs through scheme-aware helpers

### DIFF
--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -474,10 +474,22 @@ Flipping any to `false` removes its resources from the render; consumers
 fields on the same block (`host`/`port` for stores, `otelCollector.endpoint`
 for an external collector).
 
+BYO ClickHouse picks its URL scheme the same way: `clickhouse.scheme` governs
+`CLICKHOUSE_URL` for both Langfuse deployments and their readiness gate, derived
+as `https` when `clickhouse.deploy: false` and `httpPort` is 8443 and `http`
+otherwise, with an explicit `http`/`https` winning. `https` additionally enables
+TLS for the Langfuse migration connection on `nativePort`. A TLS ClickHouse
+needs both ports set -- `httpPort: 8443` and `nativePort: 9440` (the migration
+DSN uses `nativePort` and only the flag changes, not the port) -- or an
+explicit `scheme: https` plus both ports.
+
 BYO Langfuse requires a bare external hostname in `langfuse.host`. Consumers
 compose its URL as
-`http://<langfuse.host>:<langfuse.web.service.port>`; do not include a scheme,
-port, or path in `langfuse.host`. With `langfuse.deploy: false`, the chart omits
+`<scheme>://<langfuse.host>:<langfuse.web.service.port>`, where the scheme is
+`langfuse.scheme` when set (`http` or `https` only) and otherwise derived --
+`https` when the port is 443, `http` otherwise. Set `langfuse.scheme: https`
+for a TLS endpoint on any other port. Do not include a scheme, port, or path in
+`langfuse.host`. With `langfuse.deploy: false`, the chart omits
 the Langfuse Service, web and worker Deployments, and model-pricing Job. Helm
 rendering fails with an error naming `langfuse.host` when that value is missing
 or empty, instead of emitting the hostname of a Service the chart did not
@@ -504,10 +516,12 @@ complete `otlpAuthHeader` value. As an alternative for collector
 authentication, set `otelCollector.otlpAuthHeader` explicitly; see the
 credential details below.
 
-This BYO path currently composes HTTP only and has no HTTPS/TLS selector.
-Deploy it only across a trusted private transport or through a proxy that
-provides the required protection: an on-path observer can recover the full
-project credential because the Basic header is encoded, not encrypted.
+The URL scheme is selected by `langfuse.scheme`: derived as `https` when the
+port is 443 and `http` otherwise, with an explicit value winning. On the
+cleartext path (`http`), the Basic header warning still applies -- deploy a
+cleartext BYO Langfuse only across a trusted private transport or behind a
+proxy that provides TLS: an on-path observer can recover the full project
+credential because the Basic header is encoded, not encrypted.
 
 ### Langfuse Postgres startup readiness
 

--- a/charts/curie/ci/langfuse-byo-assertions.sh
+++ b/charts/curie/ci/langfuse-byo-assertions.sh
@@ -6,6 +6,12 @@ set -euo pipefail
 # must require it, route every consumer to it, and leave no dead in-chart
 # Langfuse resources or Service hostname behind.
 
+# Issue #2314: that shared endpoint had its `http://` scheme hardcoded at every
+# consumer, so a BYO Langfuse behind TLS was unreachable. The scheme now comes
+# from the `curie.langfuse.url` helper -- explicit `langfuse.scheme` wins,
+# otherwise it derives (https on port 443, http elsewhere), and an invalid
+# value fails the render rather than silently emitting cleartext.
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CHART="$(cd "$SCRIPT_DIR/.." && pwd)"
 TMP="$(mktemp -d)"
@@ -204,13 +210,50 @@ render "$CHART" internal --set-string langfuse.host=ignored.example.com
 python3 "$CHECKER" internal "$TMP/internal" "http://curie-langfuse-web:3000"
 echo "  ok: API, worker, and collector use the chart-owned Langfuse Service"
 
-echo "=== BYO Langfuse assertion 2: external host and non-default port reach every consumer ==="
+echo "=== BYO Langfuse assertion 2: an external TLS endpoint on 443 reaches every consumer over https ==="
 render "$CHART" external \
   --set langfuse.deploy=false \
   --set-string langfuse.host=langfuse.example.com \
+  --set langfuse.web.service.port=443
+python3 "$CHECKER" external "$TMP/external" "https://langfuse.example.com:443"
+echo "  ok: the derived https endpoint is shared and no chart-owned Langfuse residue remains"
+
+echo "=== BYO Langfuse assertion 2b: an explicit langfuse.scheme=https wins on a non-443 port ==="
+render "$CHART" external-explicit \
+  --set langfuse.deploy=false \
+  --set-string langfuse.host=langfuse.example.com \
+  --set-string langfuse.scheme=https \
   --set langfuse.web.service.port=4319
-python3 "$CHECKER" external "$TMP/external" "http://langfuse.example.com:4319"
-echo "  ok: exact BYO endpoint is shared and no chart-owned Langfuse residue remains"
+python3 "$CHECKER" external "$TMP/external-explicit" "https://langfuse.example.com:4319"
+echo "  ok: TLS on an arbitrary port is reachable without touching the port"
+
+echo "=== BYO Langfuse assertion 2c: a cleartext BYO endpoint is unchanged ==="
+render "$CHART" external-cleartext \
+  --set langfuse.deploy=false \
+  --set-string langfuse.host=langfuse.example.com \
+  --set langfuse.web.service.port=4319
+python3 "$CHECKER" external "$TMP/external-cleartext" "http://langfuse.example.com:4319"
+echo "  ok: a non-443 BYO port still derives http, so existing installs do not move"
+
+expect_scheme_failure() {
+  local name="$1"
+  shift
+  local stderr="$TMP/$name.stderr"
+  if helm template curie "$CHART" --output-dir "$TMP/$name" "$@" \
+    >/dev/null 2>"$stderr"; then
+    fail "$name: an invalid langfuse.scheme rendered instead of failing closed"
+  fi
+  if ! grep -qF "langfuse.scheme" "$stderr"; then
+    fail "$name: render failed without naming langfuse.scheme: $(<"$stderr")"
+  fi
+}
+
+echo "=== BYO Langfuse assertion 2d: an unsupported langfuse.scheme fails the render ==="
+expect_scheme_failure bad-scheme \
+  --set langfuse.deploy=false \
+  --set-string langfuse.host=langfuse.example.com \
+  --set-string langfuse.scheme=ftp
+echo "  ok: langfuse.scheme=ftp is rejected by name instead of falling back to cleartext"
 
 echo "=== BYO Langfuse assertion 3: trimmed runtime harness supplies its own Langfuse host ==="
 render "$CHART" harness \

--- a/charts/curie/ci/langfuse-clickhouse-readiness-assertions.sh
+++ b/charts/curie/ci/langfuse-clickhouse-readiness-assertions.sh
@@ -41,6 +41,20 @@
 # securityContext as its application container (the #351 named-image-user class
 # applies to init containers too), and is operator-disableable.
 #
+# Issue #2314 (BYO ClickHouse over TLS) extends the same file. Every consumer
+# used to hardcode `http://` when composing the ClickHouse endpoint, so a BYO
+# ClickHouse reachable only over TLS could not be used at all: the Langfuse app
+# containers and this gate both spoke cleartext to an HTTPS listener. The scheme
+# now comes from the `curie.clickhouse.scheme` helper (explicit
+# `clickhouse.scheme` wins, otherwise https is derived on the conventional HTTPS
+# port 8443 with `deploy: false`), feeding `CLICKHOUSE_URL`,
+# `CLICKHOUSE_MIGRATION_URL`, and the `CLICKHOUSE_MIGRATION_SSL` flag Langfuse's
+# migrator uses for the native port. The assertions below cover the rendered
+# shape AND -- because a rendered `https://` URL proves nothing about whether
+# the probe can speak TLS -- run the rendered gate against a stub ClickHouse
+# serving real TLS, with a cleartext negative control so the pass cannot come
+# from anything but a completed TLS handshake.
+#
 # Runnable locally (from anywhere) and from CI. Fails loudly.
 set -euo pipefail
 
@@ -63,6 +77,8 @@ PATIENT="$TMP/patient.yaml"
 FAST="$TMP/fast.yaml"
 TOLERANT="$TMP/tolerant.yaml"
 DISABLED="$TMP/disabled.yaml"
+SECURE="$TMP/secure.yaml"
+EXPLICIT="$TMP/explicit.yaml"
 
 echo "=== Rendering templates/langfuse.yaml (defaults) ==="
 helm template rel "$CHART" --show-only templates/langfuse.yaml > "$DEFAULT"
@@ -86,6 +102,21 @@ helm template rel "$CHART" --show-only templates/langfuse.yaml \
 echo "=== Rendering templates/langfuse.yaml (gate disabled) ==="
 helm template rel "$CHART" --show-only templates/langfuse.yaml \
   --set langfuse.clickhouseReadiness.enabled=false > "$DISABLED"
+
+echo "=== Rendering templates/langfuse.yaml (BYO ClickHouse on the TLS port) ==="
+helm template rel "$CHART" --show-only templates/langfuse.yaml \
+  --set clickhouse.deploy=false \
+  --set-string clickhouse.host=ch.example.com \
+  --set clickhouse.httpPort=8443 \
+  --set clickhouse.nativePort=9440 \
+  --set langfuse.clickhouseReadiness.maxAttempts=3 \
+  --set langfuse.clickhouseReadiness.intervalSeconds=1 > "$SECURE"
+
+echo "=== Rendering templates/langfuse.yaml (BYO ClickHouse, explicit clickhouse.scheme) ==="
+helm template rel "$CHART" --show-only templates/langfuse.yaml \
+  --set clickhouse.deploy=false \
+  --set-string clickhouse.host=ch.example.com \
+  --set-string clickhouse.scheme=https > "$EXPLICIT"
 
 # ---------------------------------------------------------------- render shape
 
@@ -169,6 +200,138 @@ if ! out="$(python3 "$TMP/shape.py" "$DEFAULT" "$DISABLED" 2>&1)"; then
 fi
 echo "$out"
 
+# ------------------------------------------------- ClickHouse scheme (#2314)
+
+cat > "$TMP/scheme.py" <<'PY'
+import sys, yaml
+
+default_path, secure_path, explicit_path = sys.argv[1:4]
+
+
+def deployments(path):
+    return [
+        doc
+        for doc in yaml.safe_load_all(open(path))
+        if doc and doc.get("kind") == "Deployment"
+    ]
+
+
+def containers(dep):
+    spec = dep["spec"]["template"]["spec"]
+    return (spec.get("initContainers") or []) + (spec.get("containers") or [])
+
+
+def named(dep, name):
+    for container in containers(dep):
+        if container.get("name") == name:
+            return container
+    raise SystemExit(f"{dep['metadata']['name']}: no {name!r} container rendered")
+
+
+def env_of(container, name):
+    for entry in container.get("env") or []:
+        if entry.get("name") == name:
+            return entry.get("value")
+    return None
+
+
+def app_of(dep):
+    name = dep["metadata"]["name"]
+    return named(dep, "langfuse-web" if name.endswith("-langfuse-web") else "langfuse-worker")
+
+
+def check(path, label, url, migration_url, migration_ssl, url_prefix=None):
+    """`url`/`migration_url` of None skip the exact comparison; `url_prefix`
+    asserts a prefix instead, which is how the default render is pinned to
+    cleartext without hardcoding the release name."""
+    deps = deployments(path)
+    if len(deps) != 2:
+        raise SystemExit(f"{label}: expected both Langfuse Deployments, got {len(deps)}")
+    for dep in deps:
+        name = dep["metadata"]["name"]
+        app = app_of(dep)
+        gate = named(dep, "wait-for-clickhouse")
+        for container, label_c in ((app, "app"), (gate, "gate")):
+            actual = env_of(container, "CLICKHOUSE_URL")
+            if url is not None and actual != url:
+                raise SystemExit(
+                    f"{label}: {name} {label_c} CLICKHOUSE_URL is {actual!r}, expected {url!r}"
+                )
+            if url_prefix is not None and not (actual or "").startswith(url_prefix):
+                raise SystemExit(
+                    f"{label}: {name} {label_c} CLICKHOUSE_URL is {actual!r}, "
+                    f"expected it to start with {url_prefix!r}"
+                )
+        actual = env_of(app, "CLICKHOUSE_MIGRATION_URL")
+        if migration_url is not None and actual != migration_url:
+            raise SystemExit(
+                f"{label}: {name} CLICKHOUSE_MIGRATION_URL is {actual!r}, "
+                f"expected {migration_url!r}"
+            )
+        # The migration DSN must stay bare: Langfuse's up.sh appends its own
+        # `?username=...`, so a query string here yields two `?` and the
+        # migration fails.
+        if "?" in (actual or ""):
+            raise SystemExit(
+                f"{label}: {name} CLICKHOUSE_MIGRATION_URL carries a query string "
+                f"({actual!r}); Langfuse's migrator appends its own"
+            )
+        actual = env_of(app, "CLICKHOUSE_MIGRATION_SSL")
+        if migration_ssl is None:
+            if any(
+                entry.get("name") == "CLICKHOUSE_MIGRATION_SSL"
+                for entry in app.get("env") or []
+            ):
+                raise SystemExit(
+                    f"{label}: {name} renders CLICKHOUSE_MIGRATION_SSL on the cleartext "
+                    f"path; the default render must be unchanged"
+                )
+        elif actual != migration_ssl:
+            raise SystemExit(
+                f"{label}: {name} CLICKHOUSE_MIGRATION_SSL is {actual!r}, "
+                f"expected {migration_ssl!r}"
+            )
+
+
+# Default: chart-owned ClickHouse, cleartext, and no TLS migration flag at all.
+check(default_path, "default", None, None, None, url_prefix="http://")
+
+check(
+    secure_path,
+    "byo-8443",
+    "https://ch.example.com:8443",
+    "clickhouse://ch.example.com:9440",
+    "true",
+)
+check(
+    explicit_path,
+    "byo-explicit-https",
+    "https://ch.example.com:8123",
+    "clickhouse://ch.example.com:9000",
+    "true",
+)
+print("  ok: default stays cleartext with no CLICKHOUSE_MIGRATION_SSL")
+print("  ok: httpPort 8443 derives https://ch.example.com:8443 with CLICKHOUSE_MIGRATION_SSL=true")
+print("  ok: an explicit clickhouse.scheme=https wins on the default ports")
+PY
+
+echo
+echo "=== Assertion 1b: the ClickHouse scheme reaches both the app and the gate (#2314) ==="
+if ! out="$(python3 "$TMP/scheme.py" "$DEFAULT" "$SECURE" "$EXPLICIT" 2>&1)"; then
+  fail "$out"
+fi
+echo "$out"
+
+if helm template rel "$CHART" --show-only templates/langfuse.yaml \
+  --set clickhouse.deploy=false \
+  --set-string clickhouse.host=ch.example.com \
+  --set-string clickhouse.scheme=ftp >/dev/null 2>"$TMP/bad-scheme.stderr"; then
+  fail "an unsupported clickhouse.scheme rendered instead of failing closed"
+fi
+grep -qF "clickhouse.scheme" "$TMP/bad-scheme.stderr" \
+  || fail "the rejected render did not name clickhouse.scheme: $(cat "$TMP/bad-scheme.stderr")"
+echo "  ok: clickhouse.scheme=ftp is rejected by name instead of falling back to cleartext"
+
 # ------------------------------------------------------------------ behaviour
 
 # Extract the rendered gate script so the assertions below execute exactly what
@@ -188,19 +351,23 @@ PY
 python3 "$TMP/extract.py" "$PATIENT" > "$TMP/gate-patient.sh"
 python3 "$TMP/extract.py" "$FAST" > "$TMP/gate-fast.sh"
 python3 "$TMP/extract.py" "$TOLERANT" > "$TMP/gate-tolerant.sh"
-[[ -s "$TMP/gate-patient.sh" && -s "$TMP/gate-fast.sh" && -s "$TMP/gate-tolerant.sh" ]] || fail "an extracted gate script is empty"
+python3 "$TMP/extract.py" "$SECURE" > "$TMP/gate-secure.sh"
+[[ -s "$TMP/gate-patient.sh" && -s "$TMP/gate-fast.sh" && -s "$TMP/gate-tolerant.sh" && -s "$TMP/gate-secure.sh" ]] || fail "an extracted gate script is empty"
 
 # A free port that nothing is listening on: the delayed/absent ClickHouse.
 PORT="$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')"
 
 # Stub ClickHouse. $1 = seconds to stay down before binding, $2 = /ping status,
 # $3 = port, $4 = seconds each /ping response is held back (slow but healthy).
+# Set STUB_TLS_CERT/STUB_TLS_KEY to serve real TLS instead of cleartext (#2314).
 cat > "$TMP/stub.py" <<'PY'
-import sys, time
+import os, ssl, sys, time
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
 delay, status, port = float(sys.argv[1]), int(sys.argv[2]), int(sys.argv[3])
 response_delay = float(sys.argv[4]) if len(sys.argv) > 4 else 0.0
+tls_cert = os.environ.get("STUB_TLS_CERT")
+tls_key = os.environ.get("STUB_TLS_KEY")
 
 
 class Handler(BaseHTTPRequestHandler):
@@ -226,15 +393,27 @@ class Handler(BaseHTTPRequestHandler):
 
 
 time.sleep(delay)
-HTTPServer(("127.0.0.1", port), Handler).serve_forever()
+server = HTTPServer(("127.0.0.1", port), Handler)
+if tls_cert:
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    context.load_cert_chain(tls_cert, tls_key)
+    # Wrapping the LISTENING socket makes the handshake part of accept(), so a
+    # cleartext client (the negative control below) is dropped as an OSError
+    # before any handler runs rather than printing a traceback.
+    server.socket = context.wrap_socket(server.socket, server_side=True)
+server.serve_forever()
 PY
 
-run_gate() {  # run_gate <gate-script> <outfile>; returns the gate's exit status
+run_gate_url() {  # run_gate_url <url> <gate-script> <outfile>; returns the gate's exit status
   set +e
-  CLICKHOUSE_URL="http://127.0.0.1:$PORT" sh "$1" > "$2" 2>&1
+  CLICKHOUSE_URL="$1" sh "$2" > "$3" 2>&1
   local status=$?
   set -e
   return $status
+}
+
+run_gate() {  # run_gate <gate-script> <outfile>; returns the gate's exit status
+  run_gate_url "http://127.0.0.1:$PORT" "$1" "$2"
 }
 
 echo
@@ -292,4 +471,32 @@ kill "$STUB_PID" 2>/dev/null || true; wait "$STUB_PID" 2>/dev/null || true; STUB
 echo "  ok: a 3s /ping fails at timeoutSeconds=2 and passes at timeoutSeconds=10"
 
 echo
-echo "PASS: both Langfuse deployments gate startup on ClickHouse's HTTP /ping; the rendered gate waits out a delayed dependency and exits 0 once, fails bounded when ClickHouse never appears, and stays closed while ClickHouse answers non-200, and honours the operator's probe timeout (issue #2009)."
+echo "=== Assertion 6: the rendered gate actually speaks TLS to an https endpoint (#2314) ==="
+openssl req -x509 -newkey rsa:2048 -nodes \
+  -keyout "$TMP/key.pem" -out "$TMP/cert.pem" -days 1 \
+  -subj '/CN=localhost' -addext 'subjectAltName=IP:127.0.0.1' >/dev/null 2>&1 \
+  || fail "could not generate the self-signed certificate the TLS stub serves"
+
+STUB_TLS_CERT="$TMP/cert.pem" STUB_TLS_KEY="$TMP/key.pem" \
+  python3 "$TMP/stub.py" 0 200 "$PORT" & STUB_PID=$!
+sleep 1
+if ! NODE_EXTRA_CA_CERTS="$TMP/cert.pem" \
+  run_gate_url "https://127.0.0.1:$PORT" "$TMP/gate-secure.sh" "$TMP/tls.log"; then
+  echo "--- gate output ---"; cat "$TMP/tls.log"
+  fail "the gate failed against a ClickHouse serving TLS on an https:// CLICKHOUSE_URL; a BYO ClickHouse behind TLS can never start Langfuse (#2314)"
+fi
+grep -q "ClickHouse ready" "$TMP/tls.log" \
+  || fail "the gate exited 0 without reporting readiness over TLS (output: $(cat "$TMP/tls.log"))"
+echo "  ok: the rendered probe completes a TLS handshake and reads a 200 /ping"
+
+echo
+echo "=== Assertion 7: cleartext against that same TLS listener does NOT pass ==="
+if run_gate_url "http://127.0.0.1:$PORT" "$TMP/gate-secure.sh" "$TMP/tls-negative.log"; then
+  echo "--- gate output ---"; cat "$TMP/tls-negative.log"
+  fail "the gate passed while speaking cleartext to a TLS-only listener; assertion 6 cannot have proved TLS support"
+fi
+kill "$STUB_PID" 2>/dev/null || true; wait "$STUB_PID" 2>/dev/null || true; STUB_PID=""
+echo "  ok: the same gate fails on http:// against the TLS stub, so assertion 6's pass came from real TLS"
+
+echo
+echo "PASS: both Langfuse deployments gate startup on ClickHouse's HTTP /ping; the rendered gate waits out a delayed dependency and exits 0 once, fails bounded when ClickHouse never appears, and stays closed while ClickHouse answers non-200, and honours the operator's probe timeout (issue #2009); the ClickHouse scheme is operator-selectable and the rendered gate really speaks TLS when it is https (issue #2314)."

--- a/charts/curie/templates/NOTES.txt
+++ b/charts/curie/templates/NOTES.txt
@@ -4,7 +4,7 @@ Components deployed:
 {{- if .Values.langfuse.deploy }}
   - Langfuse web + worker (v{{ .Values.langfuse.image.tag }})
 {{- else }}
-  - Langfuse: BYO at http://{{ include "curie.langfuse.webHost" . }}:{{ .Values.langfuse.web.service.port }}
+  - Langfuse: BYO at {{ include "curie.langfuse.url" . }}
 {{- end }}
 {{- if .Values.postgres.deploy }}
   - Postgres ({{ .Values.postgres.image }})

--- a/charts/curie/templates/_helpers.tpl
+++ b/charts/curie/templates/_helpers.tpl
@@ -178,6 +178,51 @@ ANTHROPIC_BASE_URL ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN ANTHROPIC_AUTH_TOKE
 {{- end -}}
 {{- end -}}
 
+{{/* URL scheme for the ClickHouse endpoint Langfuse connects to (#2314).
+     Same shape as curie.rustfs.scheme (#1447): an explicit clickhouse.scheme
+     wins, otherwise a BYO server on the conventional ClickHouse HTTPS port
+     (8443) is assumed to speak TLS and everything else stays cleartext. The
+     chart-owned server is always http. */}}
+{{- define "curie.clickhouse.scheme" -}}
+{{- $scheme := .Values.clickhouse.scheme | default "" -}}
+{{- if $scheme -}}
+{{- if not (has $scheme (list "http" "https")) -}}
+{{- fail (printf "clickhouse.scheme must be either \"http\" or \"https\", got %q" $scheme) -}}
+{{- end -}}
+{{- $scheme -}}
+{{- else if and (not .Values.clickhouse.deploy) (eq (printf "%v" .Values.clickhouse.httpPort) "8443") -}}
+https
+{{- else -}}
+http
+{{- end -}}
+{{- end -}}
+
+{{/* The one HTTP endpoint every ClickHouse consumer uses. Call sites include
+     this helper rather than re-composing scheme://host:port (#2314). */}}
+{{- define "curie.clickhouse.httpUrl" -}}
+{{- include "curie.clickhouse.scheme" . }}://{{ include "curie.clickhouse.host" . }}:{{ .Values.clickhouse.httpPort }}
+{{- end -}}
+
+{{/* Langfuse's ClickHouse migration DSN, on the native port. Deliberately
+     bare: Langfuse's `up.sh` appends its own query string
+     (`${CLICKHOUSE_MIGRATION_URL}?username=...`), so anything added here would
+     produce two `?` and break the migration. TLS is selected out of band by
+     CLICKHOUSE_MIGRATION_SSL (curie.clickhouse.migrationSsl). */}}
+{{- define "curie.clickhouse.migrationUrl" -}}
+clickhouse://{{ include "curie.clickhouse.host" . }}:{{ .Values.clickhouse.nativePort }}
+{{- end -}}
+
+{{/* Whether the Langfuse migration connection on the native port uses TLS
+     (#2314). Tracks the HTTP scheme: a TLS ClickHouse endpoint terminates TLS
+     on both ports. */}}
+{{- define "curie.clickhouse.migrationSsl" -}}
+{{- if eq (include "curie.clickhouse.scheme" .) "https" -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}
+
 {{- define "curie.clickhouse.loggingConfig" -}}
 <clickhouse>
   <logger>
@@ -284,6 +329,31 @@ true
 {{- else -}}
 {{- required "langfuse.deploy is false: set langfuse.host to your external Langfuse hostname" .Values.langfuse.host -}}
 {{- end -}}
+{{- end -}}
+
+{{/* URL scheme for the Langfuse endpoint every consumer talks to (#2314).
+     Same shape as curie.rustfs.scheme (#1447): an explicit langfuse.scheme
+     wins, otherwise a BYO endpoint on 443 is assumed to speak TLS and
+     everything else stays cleartext. The chart-owned Service is always http. */}}
+{{- define "curie.langfuse.scheme" -}}
+{{- $scheme := .Values.langfuse.scheme | default "" -}}
+{{- if $scheme -}}
+{{- if not (has $scheme (list "http" "https")) -}}
+{{- fail (printf "langfuse.scheme must be either \"http\" or \"https\", got %q" $scheme) -}}
+{{- end -}}
+{{- $scheme -}}
+{{- else if and (not .Values.langfuse.deploy) (eq (printf "%v" .Values.langfuse.web.service.port) "443") -}}
+https
+{{- else -}}
+http
+{{- end -}}
+{{- end -}}
+
+{{/* The one Langfuse base URL. Call sites include this helper rather than
+     re-composing scheme://host:port, which is how the hardcoded `http://`
+     reached five consumers at once (#2314). */}}
+{{- define "curie.langfuse.url" -}}
+{{- include "curie.langfuse.scheme" . }}://{{ include "curie.langfuse.webHost" . }}:{{ .Values.langfuse.web.service.port }}
 {{- end -}}
 
 {{/* Shared ServiceAccount name for both Langfuse Deployments. Empty
@@ -439,7 +509,7 @@ processors:
   batch: {}
 exporters:
   otlphttp/langfuse:
-    endpoint: http://{{ include "curie.langfuse.webHost" . }}:{{ .Values.langfuse.web.service.port }}/api/public/otel
+    endpoint: {{ include "curie.langfuse.url" . }}/api/public/otel
     headers:
       Authorization: ${env:LANGFUSE_OTLP_AUTH_HEADER}
     retry_on_failure:
@@ -945,9 +1015,17 @@ livenessProbe:
 - name: LANGFUSE_ENABLE_EXPERIMENTAL_FEATURES
   value: {{ .Values.langfuse.enableExperimentalFeatures | quote }}
 - name: CLICKHOUSE_MIGRATION_URL
-  value: clickhouse://{{ include "curie.clickhouse.host" . }}:{{ .Values.clickhouse.nativePort }}
+  value: {{ include "curie.clickhouse.migrationUrl" . }}
 - name: CLICKHOUSE_URL
-  value: http://{{ include "curie.clickhouse.host" . }}:{{ .Values.clickhouse.httpPort }}
+  value: {{ include "curie.clickhouse.httpUrl" . }}
+{{- if eq (include "curie.clickhouse.migrationSsl" .) "true" }}
+{{- /* Langfuse's documented switch for a TLS migration connection on the
+       native port; its migrator appends `secure=true` to the DSN itself, which
+       is why CLICKHOUSE_MIGRATION_URL above stays bare. Rendered only on the
+       https path so a cleartext install is byte-identical (#2314). */}}
+- name: CLICKHOUSE_MIGRATION_SSL
+  value: "true"
+{{- end }}
 - name: CLICKHOUSE_USER
   value: {{ .Values.clickhouse.auth.username | quote }}
 {{- /* Both of these honour the store's own existingSecret, the same escape
@@ -1350,8 +1428,8 @@ securityContext:
       probe_timeout_ms={{ mulf $root.Values.langfuse.clickhouseReadiness.timeoutSeconds 1000 | int }}
       while [ "$attempt" -le "$max_attempts" ]; do
         if PROBE_TIMEOUT_MS="$probe_timeout_ms" node -e '
-      const http = require("http");
-      const request = http.get(process.env.CLICKHOUSE_URL + "/ping", { timeout: Number(process.env.PROBE_TIMEOUT_MS) }, (response) => {
+      const client = require(process.env.CLICKHOUSE_URL.startsWith("https:") ? "https" : "http");
+      const request = client.get(process.env.CLICKHOUSE_URL + "/ping", { timeout: Number(process.env.PROBE_TIMEOUT_MS) }, (response) => {
         response.resume();
         process.exit(response.statusCode === 200 ? 0 : 1);
       });
@@ -1373,7 +1451,7 @@ securityContext:
       exit 1
   env:
     - name: CLICKHOUSE_URL
-      value: http://{{ include "curie.clickhouse.host" $root }}:{{ $root.Values.clickhouse.httpPort }}
+      value: {{ include "curie.clickhouse.httpUrl" $root }}
   resources:
     {{- toYaml .resources | nindent 4 }}
 {{- end -}}

--- a/charts/curie/templates/api.yaml
+++ b/charts/curie/templates/api.yaml
@@ -192,7 +192,7 @@ spec:
             - name: GITHUB_CLONE_BASE
               value: {{ .Values.api.githubCloneBase | quote }}
             - name: LANGFUSE_HOST
-              value: http://{{ include "curie.langfuse.webHost" . }}:{{ .Values.langfuse.web.service.port }}
+              value: {{ include "curie.langfuse.url" . }}
             - name: LANGFUSE_PUBLIC_KEY
               value: {{ .Values.langfuse.init.projectPublicKey | quote }}
             - name: LANGFUSE_SECRET_KEY

--- a/charts/curie/templates/langfuse-model-pricing.yaml
+++ b/charts/curie/templates/langfuse-model-pricing.yaml
@@ -46,7 +46,7 @@ spec:
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           env:
             - name: LANGFUSE_BASE
-              value: http://{{ include "curie.langfuse.webHost" . }}:{{ .Values.langfuse.web.service.port }}
+              value: {{ include "curie.langfuse.url" . }}
             - name: LANGFUSE_PUBLIC_KEY
               value: {{ .Values.langfuse.init.projectPublicKey | quote }}
             - name: LANGFUSE_SECRET_KEY

--- a/charts/curie/templates/worker.yaml
+++ b/charts/curie/templates/worker.yaml
@@ -318,7 +318,7 @@ spec:
               value: {{ .Values.worker.connectorReconciler.intervalSeconds | quote }}
 {{- end }}
             - name: LANGFUSE_HOST
-              value: http://{{ include "curie.langfuse.webHost" . }}:{{ .Values.langfuse.web.service.port }}
+              value: {{ include "curie.langfuse.url" . }}
             - name: LANGFUSE_PUBLIC_KEY
               value: {{ .Values.langfuse.init.projectPublicKey | quote }}
             - name: LANGFUSE_SECRET_KEY

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -107,9 +107,18 @@ priorityClasses:
 # ---------------------------------------------------------------------------
 langfuse:
   deploy: true
-  # Bare external hostname required only when deploy is false. Consumers append
-  # langfuse.web.service.port; do not include a scheme or port here.
+  # Bare external hostname required only when deploy is false. Consumers build
+  # the URL as <langfuse.scheme>://<host>:<langfuse.web.service.port>, with the
+  # scheme coming from `langfuse.scheme` below; do not include a scheme or port
+  # here.
   host: ""
+  # URL scheme every Langfuse consumer uses (#2314). Empty derives it: `http`
+  # for the chart-owned Service, and with `deploy: false`, `https` when
+  # `langfuse.web.service.port` is 443 and `http` otherwise -- the same
+  # derivation `rustfs.scheme` uses (#1447). Set `https` explicitly for a TLS
+  # endpoint on any other port, or `http` to force cleartext on 443. Only
+  # `http` and `https` are accepted.
+  scheme: ""
   image:
     web: langfuse/langfuse
     worker: langfuse/langfuse-worker
@@ -399,6 +408,18 @@ clickhouse:
   host: ""
   httpPort: 8123
   nativePort: 9000
+  # URL scheme Langfuse uses to reach ClickHouse (#2314). Empty derives it:
+  # `http` for the chart-owned server, and with `deploy: false`, `https` when
+  # `httpPort` is 8443 and `http` otherwise -- the same derivation
+  # `rustfs.scheme` uses (#1447). `https` also switches the Langfuse migration
+  # connection on `nativePort` to TLS (rendered as CLICKHOUSE_MIGRATION_SSL=true;
+  # Langfuse's migrator builds its own query string from that flag, so the URL
+  # stays bare). Set `https` explicitly for TLS on any other port, or `http` to
+  # force cleartext on 8443. Only `http` and `https` are accepted. A TLS
+  # ClickHouse needs both ports set: `httpPort: 8443` and `nativePort: 9440`
+  # (the migration DSN uses `nativePort` and only the flag changes, not the
+  # port), or an explicit `scheme: https` plus both ports.
+  scheme: ""
   auth:
     username: default
     password: clickhouse


### PR DESCRIPTION
## Summary

BYO Langfuse (`langfuse.deploy: false`) and BYO ClickHouse (`clickhouse.deploy: false`) could not be reached over TLS: every consumer composed the endpoint with a literal `http://` (or a bare `clickhouse://` migration DSN) and neither values block had a scheme knob, so a managed, TLS-only instance was unreachable and the readiness gate reported "ClickHouse unreachable" instead of the real cause. This follows the `curie.rustfs.scheme` precedent from #1447: each store gets a `scheme` value (`""` derives it, explicit `http`/`https` wins, anything else fails the render by name) and one shared helper per store, and every call site includes the helper instead of re-composing the URL.

- `langfuse.scheme` + `curie.langfuse.scheme` / `curie.langfuse.url`. Derivation: `http` for the chart-owned Service; with `deploy: false`, `https` when `langfuse.web.service.port` is 443, else `http`. All five composers now include `curie.langfuse.url`: api, worker, the collector's `otlphttp/langfuse` exporter, the model-pricing Job, and NOTES.txt (the last two were not named in the issue; they are the same expression, so they moved with it).
- `clickhouse.scheme` + `curie.clickhouse.scheme` / `curie.clickhouse.httpUrl` / `curie.clickhouse.migrationUrl` / `curie.clickhouse.migrationSsl`. Derivation: `http` for the chart-owned server; with `deploy: false`, `https` when `httpPort` is 8443, else `http`. `CLICKHOUSE_URL` (app and readiness gate) reads `httpUrl`; the gate's node probe now picks `https`/`http` by URL scheme, which is the only change to the default render.
- The secure native form is `CLICKHOUSE_MIGRATION_URL=clickhouse://<host>:<nativePort>` (bare) plus `CLICKHOUSE_MIGRATION_SSL=true`, rendered only on the https path. Langfuse's migrator appends its own `?username=...&secure=true` query string to the DSN (`packages/shared/clickhouse/scripts/up.sh`), so a query string in the URL itself would break the migration. Cleartext installs render byte-identically.

Conservative defaults chosen without asking, noted here:
- One `clickhouse.scheme` knob governs both the HTTP endpoint and the native migration connection; a TLS-terminated ClickHouse terminates both ports, and a split would need a second knob nobody has asked for.
- Derivation from the conventional TLS port (443 / 8443) mirrors #1447 rather than requiring the explicit value; an operator with a cleartext BYO store on those ports sets `scheme: http`.
- Langfuse's `CLICKHOUSE_MIGRATION_SSL` implies `skip_verify=true` upstream; that is Langfuse's contract, not something the chart can tighten.
- A TLS ClickHouse needs both ports set (`httpPort: 8443` and `nativePort: 9440`): the migration DSN keeps whatever `nativePort` says and only the TLS flag follows the scheme. Documented in values.yaml and the README rather than derived, so a wrong native port stays visible instead of being guessed.
- The readiness gate's probe verifies the server certificate the same way the Langfuse application does; a private CA needs the certificate in the Langfuse image trust store, which is outside this chart. The CI script's `NODE_EXTRA_CA_CERTS` is test-only.

Out of scope for the issue but included deliberately: the README gained a short BYO ClickHouse paragraph documenting `clickhouse.scheme`, because the repo checklist requires docs for a new values key and there was no existing sentence to correct. The reviewer also suggested printing the composed ClickHouse URL in NOTES.txt; that was tried and reverted because the trimmed e2e harness values set `clickhouse.deploy: false` without a host, and routing NOTES through the `required` host guard broke that render (caught by `charts/curie/ci/langfuse-byo-assertions.sh` assertion 3).

Adversarial review (agent-router, Grok): Code review returned one blocking finding, a README paragraph that still said the BYO Langfuse path had no TLS selector, fixed; four advisories (the two above, the NOTES line noted above, and the silent http-to-https flip on the conventional port, which mirrors #1447 and is documented). Scope review mapped every hunk to an acceptance criterion except the README ClickHouse paragraph justified above.

## Related issue

Closes #2314

## Fix pin verification

Fix pin: charts/curie/ci/langfuse-byo-assertions.sh

Verified locally with `cli/scripts/verify-fix-pin.sh <commit> charts/curie/ci/langfuse-byo-assertions.sh`: the script fails on the pre-fix tree at assertion 2 (`http://langfuse.example.com:443` where `https://` is expected) and passes on this branch. `charts/curie/ci/langfuse-clickhouse-readiness-assertions.sh` is the second changed gate: its new assertion 1b pins the rendered BYO secure shape (`https://ch.example.com:8443`, bare `clickhouse://ch.example.com:9440`, `CLICKHOUSE_MIGRATION_SSL=true`, none of it on the default path, `clickhouse.scheme=ftp` refused by name), and assertions 6 and 7 execute the rendered gate script against a stub ClickHouse serving real TLS, with a cleartext negative control against the same listener.

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | chart-only change; no runner or skill surface | | |
| local | n/a | compose does not consume these values | | |
| local-release | n/a | same | | |
| cluster | n/a | the chart renders are the surface the issue was found on; a cluster with a TLS-only Langfuse or ClickHouse is not available to this run, and the rendered gate script is executed against a real TLS listener by the CI script instead | | `bash charts/curie/ci/langfuse-clickhouse-readiness-assertions.sh` on this branch: assertions 6 and 7 pass (TLS handshake + 200 `/ping`, cleartext against the same listener fails) |
| live provider | n/a | no model provider involved | | |
| external integration | n/a | no external service call at render time | | |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

Render evidence on this branch (`helm template ... --output-dir`):
- `--set langfuse.deploy=false --set-string langfuse.host=langfuse.example.com --set langfuse.web.service.port=443`: `LANGFUSE_HOST=https://langfuse.example.com:443` on api and worker, collector endpoint `https://langfuse.example.com:443/api/public/otel`.
- `--set clickhouse.deploy=false --set-string clickhouse.host=ch.example.com --set clickhouse.httpPort=8443 --set clickhouse.nativePort=9440`: both Langfuse Deployments and both readiness gates render `CLICKHOUSE_URL=https://ch.example.com:8443`, `CLICKHOUSE_MIGRATION_URL=clickhouse://ch.example.com:9440`, `CLICKHOUSE_MIGRATION_SSL=true`.
- Default values: the rendered manifests differ from `main` only in the gate's two probe lines (and the per-render random Secret values).
- `helm lint charts/curie`: 0 failed. `charts/curie/ci/langfuse-byo-assertions.sh` and `charts/curie/ci/langfuse-clickhouse-readiness-assertions.sh` pass; the other chart CI scripts that read these env vars (`render-assertions.sh`, `observability-stack-assertions.sh`, `otel-collector-checksum-assertions.sh`, `otel-collector-durability-assertions.sh`, `worker-eval-wiring-assertions.sh`, `langfuse-image-pin-assertions.sh`, `langfuse-postgres-readiness-assertions.sh`, `langfuse-runasuser-assertions.sh`) still pass.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [ ] An ADR is added under `docs/adr/` if this is an architectural decision.
