### PR TITLE
Run the metrics summary Langfuse queries concurrently

### DIFF
--- a/apps/api/src/curie_api/metrics.py
+++ b/apps/api/src/curie_api/metrics.py
@@ -12,7 +12,9 @@ traces whose name contains `agent-<agent_id>`. `agent_trace_filter` builds that
 token; callers pass it as the `agent` argument below.
 """
 
+import asyncio
 import uuid
+from collections.abc import Coroutine
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
@@ -148,6 +150,73 @@ def _error_rate(rows: list[dict[str, Any]]) -> float:
     return errors / total
 
 
+async def _gather_ordered(*coros: Coroutine[Any, Any, Any]) -> list[Any]:
+    """Run independent units of work concurrently, failing in argument order.
+
+    The summary and cost_known queries share no state and the Langfuse client is
+    an httpx.AsyncClient, so running them together makes the wall time the
+    slowest round trip instead of the sum of all of them.
+
+    The re-raise is deliberately ordered rather than first-to-fail. These calls
+    used to be a sequence of awaits, so the caller saw the failure of the
+    EARLIEST unit in the list, and a later unit's failure was invisible
+    whenever an earlier one had already raised. A bare ``asyncio.gather`` would
+    instead surface whichever unit lost the race, which turns one Langfuse
+    outage into a nondeterministic error surface. ``return_exceptions=True``
+    lets every unit finish (the queries are read-only GETs, so completing them
+    is harmless and leaves no cancelled httpx connections), and the scan below
+    then raises the first exception in argument order, reproducing the old
+    behavior exactly.
+
+    What counts as one unit differs per caller, and inside ``summary`` it
+    differs per argument, because the sequential code each one replaces
+    differed. ``summary`` ran query-then-convert per scalar metric, so a bad
+    value in an earlier response raised before the next query was even issued;
+    its four scalar units are therefore "query plus its own conversion"
+    (``_scalar_value``), each returning a float. Its fifth unit, the level
+    query, is the query ALONE: the original reduced those rows to an error
+    rate inside the ``MetricsSummary(...)`` call, and constructor arguments
+    evaluate left to right, so the ``int()`` conversions of runs and tokens ran
+    before that reduction. Folding the reduction into this unit would let a bad
+    level row preempt them. ``cost_known`` awaited BOTH of its queries before
+    either conversion, so there a later query's failure legitimately beat an
+    earlier response's conversion failure; both of its units are "query only"
+    and it converts afterwards.
+
+    There is no type parameter, because the units are heterogeneous even within
+    one ``summary`` call: four floats and one list of rows. The elements are
+    typed as ``Any``; every caller destructures the result positionally and
+    knows what each of its own units returns.
+    """
+
+    results = await asyncio.gather(*coros, return_exceptions=True)
+    ordered: list[Any] = []
+    for result in results:
+        if isinstance(result, BaseException):
+            raise result
+        ordered.append(result)
+    return ordered
+
+
+async def _scalar_value(
+    lf: LangfuseClient,
+    metric: str,
+    start: str,
+    end: str,
+    environment: str | None,
+    agent: str | None,
+) -> float:
+    """One scalar metric: issue its query, then convert its own response.
+
+    Query and conversion stay in the same unit so that _gather_ordered's ordered
+    re-raise covers a conversion failure at the position the metric occupies,
+    exactly as the sequential awaits did.
+    """
+
+    rows = await lf.query_metrics(_scalar_query(metric, start, end, environment, agent))
+    return _num(rows[0], _SPEC[metric][3]) if rows else 0.0
+
+
 async def summary(
     lf: LangfuseClient,
     start: str,
@@ -155,15 +224,19 @@ async def summary(
     environment: str | None,
     agent: str | None,
 ) -> MetricsSummary:
-    scalars: dict[str, float] = {}
-    for metric in SCALAR_METRICS:
-        rows = await lf.query_metrics(
-            _scalar_query(metric, start, end, environment, agent)
-        )
-        key = _SPEC[metric][3]
-        scalars[metric] = _num(rows[0], key) if rows else 0.0
-
-    level_rows = await lf.query_metrics(_level_query(start, end, environment, agent))
+    # Scalars in SCALAR_METRICS order, each unit converting its own response,
+    # then the level query -- the same sequential order as before. The level
+    # rows come back unreduced on purpose: _error_rate runs where it originally
+    # did, as the last MetricsSummary argument, after the int() conversions
+    # above it. See _gather_ordered for why.
+    *scalar_values, level_rows = await _gather_ordered(
+        *(
+            _scalar_value(lf, metric, start, end, environment, agent)
+            for metric in SCALAR_METRICS
+        ),
+        lf.query_metrics(_level_query(start, end, environment, agent)),
+    )
+    scalars: dict[str, float] = dict(zip(SCALAR_METRICS, scalar_values, strict=True))
 
     return MetricsSummary(
         start=start,
@@ -200,8 +273,14 @@ async def cost_known(
     """The `cost_known` flag for a window, for callers (get_cost) that fetch cost
     without the token total. Runs the one extra tokens query summary already has."""
 
-    cost_rows = await lf.query_metrics(_scalar_query("cost_usd", start, end, environment, agent))
-    token_rows = await lf.query_metrics(_scalar_query("tokens", start, end, environment, agent))
+    # Cost first, tokens second. Unlike summary(), the unit here is the query
+    # ALONE, and both conversions run after both queries -- deliberately, so a
+    # later tokens-query failure beats an earlier cost-conversion failure. Do
+    # not "consistency-fix" this to match summary(); see _gather_ordered.
+    cost_rows, token_rows = await _gather_ordered(
+        lf.query_metrics(_scalar_query("cost_usd", start, end, environment, agent)),
+        lf.query_metrics(_scalar_query("tokens", start, end, environment, agent)),
+    )
     cost = _num(cost_rows[0], _SPEC["cost_usd"][3]) if cost_rows else 0.0
     tokens = _num(token_rows[0], _SPEC["tokens"][3]) if token_rows else 0.0
     return _cost_known(tokens, cost)

--- a/apps/api/tests/test_metrics_unit.py
+++ b/apps/api/tests/test_metrics_unit.py
@@ -1,7 +1,13 @@
 """Unit tests for the Langfuse metrics query builders (no I/O)."""
 
+import asyncio
+import time
 import uuid
+from collections.abc import Callable, Coroutine
+from typing import Any
 
+import pytest
+from curie_api import metrics
 from curie_api.metrics import (
     _cost_known,
     _error_rate,
@@ -102,3 +108,271 @@ def test_error_rate_from_level_rows() -> None:
     ]
     assert _error_rate(rows) == 0.2
     assert _error_rate([]) == 0.0
+
+
+# --- concurrent query dispatch (no I/O; the Langfuse client is faked) --------
+#
+# summary() issues five independent Langfuse queries and cost_known() issues
+# two. They share no state and the real client is an httpx.AsyncClient, so they
+# are dispatched together: the wall time is the slowest round trip rather than
+# the sum. The tests below pin both halves of that change, the speedup AND the
+# fact that the caller still sees the same values and the same failure.
+
+
+_Handler = Callable[[dict[str, Any]], Coroutine[Any, Any, list[dict[str, Any]]]]
+
+
+class _FakeLangfuse:
+    """A no-I/O stand-in for LangfuseClient with a per-query delay.
+
+    Records every query it is handed, sleeps `delay` seconds, then awaits
+    `handler(query)` for the rows -- or lets it raise. The delay is what lets a
+    test tell concurrent dispatch from sequential dispatch by wall time alone;
+    a handler may add its own extra sleep where a test needs one.
+    """
+
+    def __init__(
+        self,
+        delay: float = 0.0,
+        handler: _Handler | None = None,
+    ) -> None:
+        self.delay = delay
+        self.handler = handler
+        self.queries: list[dict[str, Any]] = []
+
+    async def query_metrics(self, query: dict[str, Any]) -> list[dict[str, Any]]:
+        self.queries.append(query)
+        if self.delay:
+            await asyncio.sleep(self.delay)
+        return await self.handler(query) if self.handler else []
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+# 0.2s per query: sequential summary() would floor at 5 * 0.2 = 1.0s, and the
+# assertion allows 2 * 0.2 = 400ms. That leaves ~200ms of scheduling headroom
+# above the concurrent time (one delay) and a 600ms margin below the sequential
+# floor, so a loaded CI box cannot flip the verdict either way. 0.05s left only
+# ~50ms of headroom, which a busy runner can eat. cost_known() keeps the same
+# ratio: two queries, a 400ms sequential floor against the same 400ms bound, and
+# the same one-delay concurrent time.
+_DELAY = 0.2
+
+
+@pytest.mark.anyio
+async def test_summary_runs_its_queries_concurrently() -> None:
+    lf = _FakeLangfuse(delay=_DELAY)
+
+    started = time.perf_counter()
+    await metrics.summary(lf, "s", "e", None, None)
+    elapsed = time.perf_counter() - started
+
+    assert len(lf.queries) == 5, "four scalars plus the level query"
+    assert elapsed < 2 * _DELAY, (
+        f"summary() took {elapsed:.3f}s; the old sequential shape takes about "
+        f"{5 * _DELAY:.3f}s, so this is the query dispatch going serial again"
+    )
+
+
+@pytest.mark.anyio
+async def test_cost_known_runs_its_two_queries_concurrently() -> None:
+    lf = _FakeLangfuse(delay=_DELAY)
+
+    started = time.perf_counter()
+    await metrics.cost_known(lf, "s", "e", None, None)
+    elapsed = time.perf_counter() - started
+
+    assert len(lf.queries) == 2, "the cost query plus the tokens query"
+    assert elapsed < 2 * _DELAY, (
+        f"cost_known() took {elapsed:.3f}s; sequentially it takes about "
+        f"{2 * _DELAY:.3f}s"
+    )
+
+
+async def _distinct_rows(query: dict[str, Any]) -> list[dict[str, Any]]:
+    """A different canned row per query, so a mis-assignment cannot pass.
+
+    Dispatches on the query shape the builders produce: the level query is the
+    only one carrying `dimensions`, and the four scalars are told apart by their
+    measure.
+    """
+
+    if "dimensions" in query:
+        return [
+            {"level": "DEFAULT", "count_count": 8},
+            {"level": "ERROR", "count_count": 2},
+        ]
+    measure = query["metrics"][0]["measure"]
+    return {
+        "count": [{"count_count": 7}],
+        "latency": [{"p95_latency": 123.5}],
+        "totalTokens": [{"sum_totalTokens": 4242}],
+        "totalCost": [{"sum_totalCost": 0.0506}],
+    }[measure]
+
+
+@pytest.mark.anyio
+async def test_summary_returns_the_same_values_as_the_sequential_shape() -> None:
+    # Concurrency must not scramble which row lands in which field. Every scalar
+    # is a distinct value, so any cross-wiring changes the assertion below.
+    lf = _FakeLangfuse(handler=_distinct_rows)
+
+    result = await metrics.summary(
+        lf, "2026-01-01T00:00:00+00:00", "2026-01-02T00:00:00+00:00", None, None
+    )
+
+    assert result.runs == 7
+    assert result.latency_p95_ms == 123.5
+    assert result.tokens == 4242
+    assert result.cost_usd == 0.0506
+    assert result.cost_known is True
+    assert result.error_rate == 0.2
+    assert result.start == "2026-01-01T00:00:00+00:00"
+    assert result.end == "2026-01-02T00:00:00+00:00"
+
+
+class _RunsQueryFailed(RuntimeError):
+    pass
+
+
+class _CostQueryFailed(ValueError):
+    pass
+
+
+class _LevelQueryFailed(RuntimeError):
+    pass
+
+
+@pytest.mark.anyio
+async def test_summary_raises_the_first_failing_query_in_order() -> None:
+    # Sequentially, the caller saw the failure of the earliest query in
+    # SCALAR_METRICS order; a later query's failure was invisible behind it.
+    # Here `runs` (first) fails slowly and `cost_usd` (fourth) fails instantly,
+    # so completion order and list order disagree. A bare asyncio.gather would
+    # surface _CostQueryFailed, which is the race this pins against.
+    finished: list[str] = []
+
+    async def handler(query: dict[str, Any]) -> list[dict[str, Any]]:
+        measure = query["metrics"][0]["measure"]
+        if "dimensions" not in query:
+            if measure == "count":
+                await asyncio.sleep(_DELAY)
+                raise _RunsQueryFailed("runs query failed")
+            if measure == "totalCost":
+                raise _CostQueryFailed("cost query failed")
+        # The survivors outlive the runs failure, so a cancellation of the
+        # in-flight siblings would drop them off `finished`.
+        await asyncio.sleep(_DELAY * 2)
+        finished.append(measure)
+        return []
+
+    lf = _FakeLangfuse(handler=handler)
+
+    with pytest.raises(_RunsQueryFailed):
+        await metrics.summary(lf, "s", "e", None, None)
+
+    assert len(lf.queries) == 5, "four scalars plus the level query are all dispatched"
+    assert sorted(finished) == ["count", "latency", "totalTokens"], (
+        "the queries that did not fail must run to completion, not be cancelled "
+        f"mid-flight; finished={finished}"
+    )
+
+
+@pytest.mark.anyio
+async def test_summary_still_fails_when_a_query_fails() -> None:
+    # return_exceptions=True collects failures instead of raising them, so the
+    # ordered re-raise is the only thing keeping a single broken query from
+    # being silently swallowed into a zero-valued summary.
+    async def handler(query: dict[str, Any]) -> list[dict[str, Any]]:
+        if "dimensions" in query:
+            raise _LevelQueryFailed("level query failed")
+        return []
+
+    with pytest.raises(_LevelQueryFailed):
+        await metrics.summary(_FakeLangfuse(handler=handler), "s", "e", None, None)
+
+
+class _LatencyQueryFailed(RuntimeError):
+    pass
+
+
+class _TokensQueryFailed(RuntimeError):
+    pass
+
+
+@pytest.mark.anyio
+async def test_summary_prefers_an_earlier_conversion_failure_over_a_later_query_failure() -> None:
+    # The old sequential code converted each scalar before issuing the next
+    # query: runs-query, runs-convert, latency-query, latency-convert, and so
+    # on. A nonnumeric value in the `runs` response therefore raised ValueError
+    # before the latency query was ever sent, and the latency failure could not
+    # be seen. Gathering the five raw queries first and converting afterwards
+    # inverts that and surfaces the latency failure instead, so the unit of work
+    # has to be the query plus its own conversion.
+    async def handler(query: dict[str, Any]) -> list[dict[str, Any]]:
+        if "dimensions" in query:
+            return []
+        measure = query["metrics"][0]["measure"]
+        if measure == "count":
+            return [{"count_count": "not-a-number"}]
+        if measure == "latency":
+            raise _LatencyQueryFailed("latency query failed")
+        return []
+
+    with pytest.raises(ValueError) as excinfo:
+        await metrics.summary(_FakeLangfuse(handler=handler), "s", "e", None, None)
+
+    assert not isinstance(excinfo.value, _LatencyQueryFailed), (
+        "the later latency query's failure must not preempt the earlier runs "
+        f"conversion failure; got {excinfo.value!r}"
+    )
+    assert "not-a-number" in str(excinfo.value)
+
+
+@pytest.mark.anyio
+async def test_cost_known_prefers_a_later_query_failure_over_a_conversion_failure() -> None:
+    # Deliberate asymmetry with summary(), not an oversight. The old
+    # cost_known() awaited BOTH queries before calling _num on either, so a
+    # failure of the LATER tokens query beat a conversion failure in the EARLIER
+    # cost response. Query-plus-convert units here would flip that precedence,
+    # so this pins the equivalent direction against a "consistency fix".
+    async def handler(query: dict[str, Any]) -> list[dict[str, Any]]:
+        measure = query["metrics"][0]["measure"]
+        if measure == "totalCost":
+            return [{"sum_totalCost": "not-a-number"}]
+        if measure == "totalTokens":
+            raise _TokensQueryFailed("tokens query failed")
+        return []
+
+    with pytest.raises(_TokensQueryFailed):
+        await metrics.cost_known(_FakeLangfuse(handler=handler), "s", "e", None, None)
+
+
+@pytest.mark.anyio
+async def test_summary_prefers_an_int_conversion_failure_over_a_bad_level_row() -> None:
+    # The original built MetricsSummary(..., runs=int(...), ..., tokens=int(...),
+    # ..., error_rate=_error_rate(level_rows)). Constructor arguments are
+    # evaluated left to right, so int(runs) ran BEFORE the error-rate reduction,
+    # and a level row that _num could not convert was invisible behind an
+    # infinite runs count. Folding the reduction into the level gather unit
+    # inverts that, so this pins the level unit staying query-only.
+    #
+    # "Infinity" is what a Langfuse response can carry through json and float()
+    # alike, and it is int() that then refuses it with OverflowError.
+    async def handler(query: dict[str, Any]) -> list[dict[str, Any]]:
+        if "dimensions" in query:
+            return [{"level": "ERROR", "count_count": "not-a-number"}]
+        if query["metrics"][0]["measure"] == "count":
+            return [{"count_count": "Infinity"}]
+        return []
+
+    with pytest.raises(OverflowError) as excinfo:
+        await metrics.summary(_FakeLangfuse(handler=handler), "s", "e", None, None)
+
+    assert not isinstance(excinfo.value, ValueError), (
+        "the level row's conversion failure must not preempt int(runs); "
+        f"got {excinfo.value!r}"
+    )


### PR DESCRIPTION
## Summary

`GET /observability/metrics/summary` is the console Overview landing call
(`useMetricsSummary`). It issued five independent Langfuse Metrics API queries
strictly one after another: a loop over `SCALAR_METRICS` awaiting four scalar
aggregates, then the level query for the error rate. `cost_known()` did the same
with its two queries. The queries share no state and the Langfuse client is an
`httpx.AsyncClient`, so the wall time was the sum of every round trip where the
slowest one would do.

This runs them under `asyncio.gather`. Measured against the `compose.dev.yaml`
stack, the p50 of 20 curl samples fell from 77.3 ms to 33.5 ms, and the response
bodies are byte identical.

The re-raise is deliberately ordered rather than first to fail. The sequential
code surfaced the failure of the earliest query in the list and hid any later
one, so a bare `asyncio.gather` would have turned a Langfuse outage into a
nondeterministic error surface depending on which query lost the race.
`_gather_ordered` uses `return_exceptions=True` and then raises the first
exception in argument order.

`summary()` and `cost_known()` deliberately use different units of work.
`summary()` ran query-then-convert per metric, so a bad value in an earlier
response raised before the next query was issued; its units are therefore
"query plus its own conversion". `cost_known()` awaited both queries before
either conversion, so there a later query failure legitimately beat an earlier
conversion failure; its units are "query only". The asymmetry is documented in
the code so it is not consistency-fixed into a bug.

## Related issue

No issue. Found by a performance review of `origin/main`.

## Fix pin verification

Fix pin: n/a - this pull request closes no bug-labeled issue.

## Measurements

Both runs were taken back to back against the same seeded Langfuse instance, so
they see identical data (`runs` 141, `tokens` 915384, `cost_usd`
13.350641399978 in both bodies) and the same machine load.

Stack, from the worktree with an isolated project name:

```
COMPOSE_PROJECT_NAME=curie-perfgather docker compose -f compose.dev.yaml up -d \
  postgres valkey clickhouse rustfs rustfs-init langfuse-web langfuse-worker otel-collector
(cd apps/api && uv run alembic upgrade head)
```

The API was run from this worktree's source against that stack, so the two
implementations could be swapped without rebuilding an image:

```
VALKEY_PASSWORD=valkeypass S3_ACCESS_KEY=rustfs S3_SECRET_KEY=rustfssecret \
S3_ENDPOINT_URL=http://localhost:29000 BUNDLE_BUCKET=curie-bundles \
uv run uvicorn curie_api.main:app --host 127.0.0.1 --port 28100
```

Sampling command, 3 unmeasured warm-up requests then 20 measured:

```
for i in $(seq 1 20); do
  curl -sS -o /dev/null -w '%{time_total}' -H 'X-API-Key: <dev key>' \
    'http://127.0.0.1:28100/observability/metrics/summary'
  echo
done
```

| | p50 | mean | min | max |
| --- | --- | --- | --- | --- |
| before (sequential, `origin/main`) | 77.3 ms | 77.9 ms | 69.6 ms | 92.0 ms |
| after (concurrent, this branch) | 33.5 ms | 35.6 ms | 25.3 ms | 88.1 ms |

The remaining 33 ms is roughly one Langfuse round trip plus FastAPI overhead,
which is the intended floor. The seeded instance answers an aggregate in about
15 ms; against a production instance answering in 150 to 400 ms the same change
turns roughly 1 to 2 s into roughly one round trip.

**Byte identity.** Over a fixed window, so the body is deterministic, the
unfiltered and the agent-filtered responses are byte identical before and after
(`cmp` exit 0 on both):

```
curl -sS -H 'X-API-Key: <dev key>' \
  'http://127.0.0.1:28101/observability/metrics/summary?start=2026-06-01T00:00:00%2B00:00&end=2026-09-04T00:00:00%2B00:00'
{"start":"2026-06-01T00:00:00+00:00","end":"2026-09-04T00:00:00+00:00","runs":379,"latency_p95_ms":0.0,"tokens":2527279,"cost_usd":36.398105999947,"cost_known":true,"error_rate":0.0846233230134159}
```

## Error semantics

Two independent adversarial reviewers checked the failure paths against the
original sequential code. Both found the same divergence in an intermediate
revision of this branch, and it is fixed rather than carried:

- Scalar units are query plus their own conversion, so a bad value in an earlier
  response still beats a later query's failure, as it did when each `_num` ran
  before the next query was issued.
- The level unit is query only, and `_error_rate` is still the last
  `MetricsSummary` argument, because constructor arguments evaluate left to
  right and the original therefore ran `int(runs)` and `int(tokens)` before the
  error-rate reduction.
- `cost_known()` converts after both queries, because its sequential form did.

All three orderings are pinned by tests.

## Other decisions taken on bounded ambiguity

- `return_exceptions=True` lets every query finish rather than cancelling
  siblings. On a failure path `summary()` therefore always issues all five
  Langfuse requests where the sequential code could stop after one. That is the
  cost of a deterministic error surface, and these are read-only GETs.
- `series()` and `_error_rate_series()` were left alone: each issues exactly one
  query per invocation, so there is nothing to run concurrently.
- `langfuse.py` `_get_all` pagination is untouched, and issue #1948 (capping
  observability series after the query) is a separate concern.

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | No plugin or skill packaging, runner turn loop, ACI event, or skill eval is reached; the diff is confined to the API's Langfuse read path. | | |
| local | Required | The change alters how the API serves an HTTP request, and the console reads it. | fake | See Measurements above: 20 curl samples of `GET /observability/metrics/summary` against the `compose.dev.yaml` stack, p50 77.3 ms before and 33.5 ms after, with byte identical bodies over a fixed window. |
| local-release | n/a | No released binary or image identity, install path, version pin, or release compose is touched. | | |
| cluster | n/a | No chart template, RBAC, securityContext, NetworkPolicy, sandbox claim, or init container is touched. | | |
| live provider | n/a | No model routing, credential resolution, or provider auth changes. The cost and token arithmetic (`_num`, `_cost_known`) and every query dict are byte for byte unchanged; only the order in which the queries are issued differs. | | |
| external integration | Required | Langfuse is a third-party API and its query shape must still be accepted. | live | `uv run pytest -q apps/api/tests/test_metrics_integration.py` against the real dev Langfuse: 6 passed. These compare each endpoint number to the same aggregate queried directly from Langfuse, so they exercise the real API rather than a fixture. |

- [x] Every required tier above names its exact command, the commit it ran
      against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable
      negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in
      the table.

**Falsifiable negatives.** The three new timing and ordering tests were run
against the unmodified `metrics.py` and fail there: `summary()` took 0.252 s
with a 0.05 s per-query delay, which is the five sequential round trips, and the
ordering test saw only 1 of 5 queries dispatched. The per-query delay is now
0.2 s so the bound has more scheduling headroom on a loaded runner.

## Checklist

- [x] Tests pass for the area I touched: `uv run pytest -q apps/api/tests`,
      1650 passed, 3 skipped. `uv run ruff check .`, `uv run mypy` (247 files),
      and `uv run lint-imports` (4 contracts kept) are all clean.
- [x] Docs updated if behavior changed. No user-facing documentation describes
      the dispatch order; the rationale lives in `_gather_ordered`'s docstring.
- [x] An ADR is added under `docs/adr/` if this is an architectural decision.
      Not an architectural decision: no wire shape, route signature, CLI `--json`
      schema, or command manifest changes.
