### PR TITLE
Let a BYO Valkey that requires TLS reach all four consumers

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -167,6 +167,19 @@ jobs:
           set -euo pipefail
           bash charts/curie/ci/valkey-existing-secret-assertions.sh
 
+      # Prove a BYO Valkey can be reached over TLS, and that the signal reaches
+      # every consumer of that store rather than some of them (#2315). Every
+      # managed Redis-compatible service an operator would bring is TLS-only or
+      # TLS-by-default and redis-py never downgrades, so a half-applied
+      # transport takes down the api, worker, dispatcher and both Langfuse
+      # Deployments at once with a healthy-looking render. Also proves the
+      # guard refuses valkey.tls against the in-chart store, which serves no
+      # TLS listener.
+      - name: helm render assertions (valkey TLS)
+        run: |
+          set -euo pipefail
+          bash charts/curie/ci/valkey-tls-assertions.sh
+
       # Prove the tenant capacity ceiling actually binds the pods it is meant to.
       # The quota is PriorityClass-scoped, so if its scope is not the name the
       # sandbox pods carry it matches nothing and enforces nothing -- silently,

--- a/apps/api/src/curie_api/config.py
+++ b/apps/api/src/curie_api/config.py
@@ -189,10 +189,15 @@ class Settings(BaseSettings):
 
     # Valkey for the kill switch (L1): SET the flag + PUBLISH the kill event.
     # The DSN is built from the parts so the compose VALKEY_PASSWORD override is
-    # honored; set valkey_url to override the whole DSN (e.g. TLS, other host).
+    # honored. valkey_tls is the supported TLS signal -- chart-rendered from
+    # valkey.tls and shared with the worker and dispatcher, so all three agree on
+    # the transport of one store (#2315). valkey_url stays the whole-DSN escape
+    # for anything the parts cannot express (a different host, a non-default db,
+    # credentials embedded differently) and still wins outright.
     valkey_password: str = "valkeypass"
     valkey_host: str = "localhost"
     valkey_port: int = 26379
+    valkey_tls: bool = False
     valkey_url: str | None = None
 
     # The runs stream approval resolutions enqueue resume turns onto (#244).
@@ -399,7 +404,11 @@ class Settings(BaseSettings):
     def valkey_dsn(self) -> str:
         if self.valkey_url:
             return self.valkey_url
-        return f"redis://:{self.valkey_password}@{self.valkey_host}:{self.valkey_port}/0"
+        # The scheme IS the transport: redis-py picks SSLConnection off
+        # `rediss://` alone, so this one character is what carries valkey_tls
+        # through from_url to the pool (#2315).
+        scheme = "rediss" if self.valkey_tls else "redis"
+        return f"{scheme}://:{self.valkey_password}@{self.valkey_host}:{self.valkey_port}/0"
 
     @model_validator(mode="after")
     def _validate_github_repo_allowlist(self) -> "Settings":

--- a/apps/api/tests/test_control_unit.py
+++ b/apps/api/tests/test_control_unit.py
@@ -21,6 +21,48 @@ def test_valkey_dsn_honors_the_password_override() -> None:
     )
 
 
+def test_valkey_dsn_uses_rediss_scheme_when_tls_is_enabled() -> None:
+    # #2315: a BYO TLS-only Valkey/Redis needs rediss://, otherwise redis-py
+    # sends a cleartext connection to a store that never negotiates or
+    # downgrades. Verified on redis-py 8.1.0: redis.from_url("rediss://...")
+    # selects redis.connection.SSLConnection, redis://... selects Connection.
+    assert Settings(valkey_tls=True).valkey_dsn() == (
+        "rediss://:valkeypass@localhost:26379/0"
+    )
+    # Otherwise byte-identical to the plain scheme -- only the scheme changes.
+    assert Settings().valkey_dsn() == "redis://:valkeypass@localhost:26379/0"
+
+
+def test_valkey_url_still_wins_over_valkey_tls() -> None:
+    # The escape hatch stays outright authoritative even when the new signal
+    # is also set.
+    assert (
+        Settings(
+            valkey_tls=True, valkey_url="redis://:x@other:1/2"
+        ).valkey_dsn()
+        == "redis://:x@other:1/2"
+    )
+
+
+# --- VALKEY_TLS env -> Settings.valkey_tls (the seam the chart actually
+# drives; a field that only works via kwargs is not wired) ------------------
+
+
+def test_valkey_tls_env_reaches_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("VALKEY_TLS", "true")
+    assert Settings().valkey_tls is True
+
+
+def test_valkey_tls_defaults_false_on_a_clean_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # VALKEY_TLS may be set in the ambient host/CI env; clear it explicitly so
+    # this default-value assertion cannot be flipped by something outside the
+    # test.
+    monkeypatch.delenv("VALKEY_TLS", raising=False)
+    assert Settings().valkey_tls is False
+
+
 def test_kill_key_matches_the_seam_contract() -> None:
     agent_id = uuid.UUID("00000000-0000-0000-0000-000000000001")
     assert kill_key(agent_id) == "curie:kill:00000000-0000-0000-0000-000000000001"

--- a/apps/dispatcher/README.md
+++ b/apps/dispatcher/README.md
@@ -124,6 +124,7 @@ Read from the environment by `DispatcherConfig()` (a `pydantic_settings.BaseSett
 | `VALKEY_PORT` | `6379` | Valkey port (compose maps it to `26379` on the host) |
 | `VALKEY_PASSWORD` | "" | Valkey password (compose dev: `valkeypass`) |
 | `VALKEY_DB` | `0` | Valkey db index |
+| `VALKEY_TLS` | `false` | when `true`, the client connects over TLS and verifies against the system CA bundle; the chart sets this from `valkey.tls` |
 | `CURIE_STREAM` | `curie:runs` | Stream the jobs land on |
 | `CURIE_DEDUPE_PREFIX` | `curie:dedupe:` | dedupe key prefix |
 | `CURIE_DEDUPE_TTL_SECONDS` | `3600` | dedupe guard TTL |

--- a/apps/dispatcher/src/curie_dispatcher/app.py
+++ b/apps/dispatcher/src/curie_dispatcher/app.py
@@ -52,6 +52,7 @@ def build_redis(config: DispatcherConfig) -> redis.Redis:
         password=config.valkey_password or None,
         db=config.valkey_db,
         decode_responses=True,
+        ssl=config.valkey_tls,
     )
 
 

--- a/apps/dispatcher/src/curie_dispatcher/config.py
+++ b/apps/dispatcher/src/curie_dispatcher/config.py
@@ -15,6 +15,7 @@ Env mapping:
     VALKEY_PORT                -> valkey_port
     VALKEY_PASSWORD            -> valkey_password
     VALKEY_DB                  -> valkey_db
+    VALKEY_TLS                 -> valkey_tls
     CURIE_STREAM             -> stream
     CURIE_DEDUPE_PREFIX      -> dedupe_prefix
     CURIE_DEDUPE_TTL_SECONDS -> dedupe_ttl_seconds
@@ -81,6 +82,10 @@ class DispatcherConfig(BaseSettings):
     valkey_port: int = 6379
     valkey_password: str = ""
     valkey_db: int = 0
+    # TLS transport for a BYO Valkey, rendered by the chart from valkey.tls.
+    # Off by default: the in-chart store and the compose lane are both cleartext
+    # by design (#2315).
+    valkey_tls: bool = False
 
     stream: str = Field(default=RUNS_STREAM_DEFAULT, validation_alias=STREAM_ENV)
     dedupe_prefix: str = Field(

--- a/apps/dispatcher/tests/test_app_redis.py
+++ b/apps/dispatcher/tests/test_app_redis.py
@@ -1,0 +1,59 @@
+"""build_redis TLS selection (#2315).
+
+A BYO TLS-only Valkey/Redis (in-transit-encrypted ElastiCache, Azure Cache for
+Redis, Redis Cloud, Upstash, ...) must produce an SSL-wrapped connection pool,
+mirroring the worker's `_valkey_kwargs` seam and the API's `valkey_dsn` scheme
+switch (#2315). Construction performs no I/O -- no Valkey is contacted here --
+so these assertions read redis-py's own connection-class selection rather than
+mocking the thing under test.
+"""
+
+from __future__ import annotations
+
+import pytest
+import redis
+from curie_dispatcher.app import build_redis
+from curie_dispatcher.config import DispatcherConfig
+
+# An independent, non-secret placeholder credential -- unrelated to any real
+# deployment. DispatcherConfig requires it non-blank and distinct from
+# api_key (ADR-0106); the tests here don't touch that boundary, they just need
+# a valid config to build a client from.
+_ATTESTER_PLACEHOLDER = "dispatcher-redis-test-value"
+
+
+def _config(**overrides: object) -> DispatcherConfig:
+    return DispatcherConfig(
+        approval_chat_attester_secret=_ATTESTER_PLACEHOLDER, **overrides
+    )
+
+
+def test_build_redis_selects_the_plain_connection_by_default() -> None:
+    client = build_redis(_config())
+    assert client.connection_pool.connection_class is redis.connection.Connection
+
+
+def test_build_redis_selects_ssl_connection_when_tls_is_set() -> None:
+    client = build_redis(_config(valkey_tls=True))
+    assert client.connection_pool.connection_class is redis.connection.SSLConnection
+
+
+# --- VALKEY_TLS env -> DispatcherConfig.valkey_tls (the seam the chart
+# actually drives; a field that only works via kwargs is not wired) ---------
+
+
+def test_valkey_tls_env_reaches_the_dispatcher_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VALKEY_TLS", "true")
+    assert _config().valkey_tls is True
+
+
+def test_valkey_tls_defaults_false_on_a_clean_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # VALKEY_TLS may be set in the ambient host/CI env; clear it explicitly so
+    # this default-value assertion cannot be flipped by something outside the
+    # test.
+    monkeypatch.delenv("VALKEY_TLS", raising=False)
+    assert _config().valkey_tls is False

--- a/apps/worker/src/curie_worker/config.py
+++ b/apps/worker/src/curie_worker/config.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import json
 import os
 import socket
-from typing import Annotated
+from typing import Annotated, Any
 
 from aci_protocol.service_config import (
     API_KEY_ENV,
@@ -158,6 +158,10 @@ class WorkerConfig(BaseSettings):
     valkey_port: int = 6379
     valkey_password: str = ""
     valkey_db: int = 0
+    # TLS transport for a BYO Valkey (VALKEY_TLS, rendered by the chart from
+    # valkey.tls). Off by default: the in-chart store and the compose lane are
+    # both cleartext by design (#2315).
+    valkey_tls: bool = False
 
     # Slack
     slack_bot_token: str = ""
@@ -994,6 +998,26 @@ class WorkerConfig(BaseSettings):
         never api_base_url directly (#678).
         """
         return self.runner_api_base_url or self.api_base_url
+
+    def valkey_client_kwargs(self) -> dict[str, Any]:
+        """The connection parts every Valkey client in the worker is built from.
+
+        One place -- the three clients in ``run.build`` and the upgrade-drain
+        hook's own client -- so they cannot drift on the transport: ``ssl``
+        reaching some of them and not the rest is a lane that goes silently
+        cleartext against a TLS-only BYO store (#2315), and for the drain hook
+        that failure blocks every ``helm upgrade`` on the install (#2010).
+        ``socket_timeout`` stays at the call sites: the drain hook deliberately
+        does not set one.
+        """
+        return {
+            "host": self.valkey_host,
+            "port": self.valkey_port,
+            "password": self.valkey_password or None,
+            "db": self.valkey_db,
+            "decode_responses": True,
+            "ssl": self.valkey_tls,
+        }
 
     @property
     def valkey_socket_timeout_s(self) -> float:

--- a/apps/worker/src/curie_worker/run.py
+++ b/apps/worker/src/curie_worker/run.py
@@ -300,19 +300,11 @@ def _sandbox_client(
 
 def build(config: WorkerConfig, env: Mapping[str, str]) -> Runtime:
     async_redis: AsyncRedis = AsyncRedis(
-        host=config.valkey_host,
-        port=config.valkey_port,
-        password=config.valkey_password or None,
-        db=config.valkey_db,
-        decode_responses=True,
+        **config.valkey_client_kwargs(),
         socket_timeout=config.valkey_socket_timeout_s,
     )
     sync_redis = redis.Redis(
-        host=config.valkey_host,
-        port=config.valkey_port,
-        password=config.valkey_password or None,
-        db=config.valkey_db,
-        decode_responses=True,
+        **config.valkey_client_kwargs(),
         socket_timeout=config.valkey_socket_timeout_s,
     )
     sub_config = _substrate_config(env)
@@ -434,11 +426,7 @@ def build(config: WorkerConfig, env: Mapping[str, str]) -> Runtime:
     # reuses the same substrate (eval runs provision from the same warm pool) and
     # the binding resolver as its repo lookup for the /evals/report payload.
     eval_redis: AsyncRedis = AsyncRedis(
-        host=config.valkey_host,
-        port=config.valkey_port,
-        password=config.valkey_password or None,
-        db=config.valkey_db,
-        decode_responses=True,
+        **config.valkey_client_kwargs(),
         socket_timeout=config.valkey_socket_timeout_s,
     )
     eval_consumer = EvalStreamConsumer(

--- a/apps/worker/src/curie_worker/upgrade_drain.py
+++ b/apps/worker/src/curie_worker/upgrade_drain.py
@@ -245,13 +245,7 @@ class UpgradeDrainGate:
 
 
 def _client(config: WorkerConfig) -> Redis:
-    return Redis(
-        host=config.valkey_host,
-        port=config.valkey_port,
-        password=config.valkey_password or None,
-        db=config.valkey_db,
-        decode_responses=True,
-    )
+    return Redis(**config.valkey_client_kwargs())
 
 
 async def run_gate(config: WorkerConfig, *, mode: str) -> int:

--- a/apps/worker/tests/test_run.py
+++ b/apps/worker/tests/test_run.py
@@ -14,6 +14,8 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+import redis
+import redis.asyncio
 from curie_worker import run
 from curie_worker.config import WorkerConfig
 from curie_worker.run import (
@@ -770,3 +772,79 @@ def test_run_boots_the_consumers_when_the_migration_exceeds_its_budget(
     ]
     assert len(cut_short) == 1
     assert cut_short[0].levelno == logging.WARNING
+
+
+# --- WorkerConfig.valkey_client_kwargs: the seam shared by all three Valkey client
+# constructions in build() (#2315) ------------------------------------------
+#
+# build() itself is not driven directly here: it constructs
+# KubernetesSandboxClient, which loads a kubeconfig at __init__
+# (sandbox/k8s.py:226-229), and the sync affinity client it builds is not
+# reachable from Runtime anyway. valkey_client_kwargs is the seam precisely because
+# all three call sites go through it, so testing it once covers all three.
+#
+# Assertions read redis-py's own connection-class selection (never a mock of
+# the thing under test): ssl=True selects SSLConnection in both the sync and
+# async namespaces, which are distinct classes sharing a name -- both are
+# checked so a test cannot pass by importing the wrong one.
+
+
+def test_valkey_kwargs_selects_the_plain_connection_by_default() -> None:
+    kwargs = WorkerConfig().valkey_client_kwargs()
+    sync_client = redis.Redis(**kwargs)
+    assert sync_client.connection_pool.connection_class is redis.connection.Connection
+    async_client = redis.asyncio.Redis(**kwargs)
+    assert (
+        async_client.connection_pool.connection_class
+        is redis.asyncio.connection.Connection
+    )
+
+
+def test_valkey_kwargs_selects_ssl_connection_when_tls_is_set() -> None:
+    kwargs = WorkerConfig(valkey_tls=True).valkey_client_kwargs()
+    sync_client = redis.Redis(**kwargs)
+    assert sync_client.connection_pool.connection_class is redis.connection.SSLConnection
+    async_client = redis.asyncio.Redis(**kwargs)
+    assert (
+        async_client.connection_pool.connection_class
+        is redis.asyncio.connection.SSLConnection
+    )
+
+
+def test_valkey_kwargs_carries_host_port_password_db_unchanged() -> None:
+    # So a future edit cannot satisfy the TLS assertions above by dropping a
+    # field: every part of the connection identity must still be present.
+    config = WorkerConfig(
+        valkey_host="valkey.acme.internal",
+        valkey_port=6380,
+        valkey_password="s3cret",
+        valkey_db=2,
+        valkey_tls=True,
+    )
+    kwargs = config.valkey_client_kwargs()
+    assert kwargs["host"] == "valkey.acme.internal"
+    assert kwargs["port"] == 6380
+    assert kwargs["password"] == "s3cret"
+    assert kwargs["db"] == 2
+    assert kwargs["ssl"] is True
+
+
+# --- VALKEY_TLS env -> WorkerConfig.valkey_tls (the seam the chart actually
+# drives; a field that only works via kwargs is not wired) ------------------
+
+
+def test_valkey_tls_env_reaches_the_worker_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VALKEY_TLS", "true")
+    assert WorkerConfig().valkey_tls is True
+
+
+def test_valkey_tls_defaults_false_on_a_clean_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # VALKEY_TLS may be set in the ambient host/CI env; clear it explicitly so
+    # this default-value assertion cannot be flipped by something outside the
+    # test.
+    monkeypatch.delenv("VALKEY_TLS", raising=False)
+    assert WorkerConfig().valkey_tls is False

--- a/apps/worker/tests/test_upgrade_drain.py
+++ b/apps/worker/tests/test_upgrade_drain.py
@@ -35,6 +35,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+import redis.asyncio
 from curie_test_support.valkey import (
     VALKEY_HOST as _VALKEY_HOST,
 )
@@ -46,7 +47,7 @@ from curie_test_support.valkey import (
 )
 from curie_worker.config import WorkerConfig
 from curie_worker.delivery_lease import DeliveryLeaseStore
-from curie_worker.upgrade_drain import UpgradeDrainGate, main, run_gate
+from curie_worker.upgrade_drain import UpgradeDrainGate, _client, main, run_gate
 from redis.asyncio import Redis as AsyncRedis
 from redis.exceptions import ResponseError
 
@@ -497,3 +498,35 @@ def test_an_unknown_mode_is_refused_rather_than_silently_draining() -> None:
         assert exit_code.code == 2
     else:
         raise AssertionError("an unknown --mode was accepted")
+
+
+# --- _client TLS selection (#2315) -------------------------------------------
+#
+# Construction performs no I/O (no assertion here touches real Valkey), so
+# this is hermetic: the seam under test is redis-py's own pool selection, the
+# same shape run.py's _valkey_kwargs tests use.
+
+
+def _drain_config(**overrides: object) -> WorkerConfig:
+    base: dict[str, object] = {
+        "valkey_host": _VALKEY_HOST,
+        "valkey_port": _VALKEY_PORT,
+        "valkey_password": _VALKEY_PW,
+    }
+    base.update(overrides)
+    return WorkerConfig(**base)
+
+
+def test_client_selects_the_plain_connection_by_default() -> None:
+    client = _client(_drain_config())
+    assert (
+        client.connection_pool.connection_class is redis.asyncio.connection.Connection
+    )
+
+
+def test_client_selects_ssl_connection_when_tls_is_set() -> None:
+    client = _client(_drain_config(valkey_tls=True))
+    assert (
+        client.connection_pool.connection_class
+        is redis.asyncio.connection.SSLConnection
+    )

--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -497,6 +497,17 @@ needs both ports set -- `httpPort: 8443` and `nativePort: 9440` (the migration
 DSN uses `nativePort` and only the flag changes, not the port) -- or an
 explicit `scheme: https` plus both ports.
 
+A BYO Valkey that only accepts TLS -- in-transit-encrypted ElastiCache, Azure
+Cache for Redis, Redis Cloud, Upstash -- also needs `valkey.tls: true` alongside
+`valkey.deploy: false` and `valkey.host`. It reaches every consumer of that
+store at once: the api, worker and dispatcher, both `worker-upgrade-drain` hook
+Jobs, and both Langfuse Deployments. It requires `valkey.deploy: false` --
+`valkey.tls: true` against the in-chart Valkey fails the render, because that
+StatefulSet serves no TLS listener. Verification uses the system CA bundle, so a
+store fronted by a private CA (or one requiring mutual TLS) is not supported by
+this knob; that needs CA material distributed to all seven containers, which is
+a separate decision.
+
 BYO Langfuse requires a bare external hostname in `langfuse.host`. Consumers
 compose its URL as
 `<scheme>://<langfuse.host>:<langfuse.web.service.port>`, where the scheme is

--- a/charts/curie/ci/valkey-tls-assertions.sh
+++ b/charts/curie/ci/valkey-tls-assertions.sh
@@ -1,0 +1,397 @@
+#!/usr/bin/env bash
+#
+# Render-assertion test for BYO Valkey over TLS (#2315).
+#
+# The chart's stated invariant (`charts/curie/CLAUDE.md`, "Every backing store
+# follows the same toggle + BYO idiom") is that flipping `<store>.deploy` to
+# false repoints EVERY consumer at the BYO `host`/`port`/`auth` fields on the
+# same block. Valkey's block carried no TRANSPORT field at all, so the BYO
+# branch could only ever produce a cleartext connection -- and every managed
+# Redis-compatible service an operator would realistically bring is TLS-only or
+# TLS-by-default. redis-py does not negotiate or downgrade, so the connection
+# fails outright, taking down the api, worker, dispatcher, and both Langfuse
+# Deployments at once.
+#
+# `valkey.tls` is threaded to all of it through ONE shared helper
+# (`curie.valkey.tls`), included from both `curie.env.valkey` (api, worker,
+# dispatcher, both upgrade-hook Jobs) and `curie.langfuse.env` (both Langfuse
+# Deployments). The bug class this repo has hit twice (#2052, #2327) is exactly
+# "two consumer groups read the same `valkey.*` field and only one of them was
+# updated" -- silent and asymmetric: the render stays healthy, some consumers
+# connect fine, and the rest fail closed with no failing manifest and no
+# failing preflight to point at the cause.
+#
+# Asserts:
+#
+#   1. `byo-tls` (deploy=false + host + tls=true): VALKEY_TLS == "true" on the
+#      api, worker and dispatcher containers, AND on both worker-upgrade-drain
+#      hook Job containers (drain and release -- resolved by their `--mode`
+#      arg, the way `upgrade-drain-assertions.sh` does, not by container name
+#      alone); REDIS_TLS_ENABLED == "true" on both Langfuse Deployment
+#      containers. All seven checked in ONE render, so a fix applied to one
+#      include site and not its sibling fails this gate.
+#   2. `byo-tls` transport/identity parity, in the SAME render: VALKEY_HOST /
+#      REDIS_HOST still resolve to the BYO host, and VALKEY_PASSWORD /
+#      REDIS_AUTH still resolve to their `secretKeyRef`. Prevents "fixing" TLS
+#      by breaking the BYO host or credential path.
+#   3. `byo-plain` (the same BYO shape, `valkey.tls` left at its default):
+#      every one of the seven containers carries the var with the LITERAL
+#      value "false" -- present, and false. This is what makes assertion 1
+#      non-vacuous: without it, a template that emitted "true" unconditionally
+#      would pass.
+#   4. `default` no-regression: same as 3 on the default render, plus the
+#      in-chart `templates/valkey.yaml` still renders. A BYO knob must not
+#      disturb an install that never set it.
+#   5. NEGATIVE CONTROL -- the guard: `helm template --set valkey.tls=true`
+#      with `valkey.deploy` left at its default `true` exits non-zero, and its
+#      stderr names BOTH `valkey.tls` and `valkey.deploy`. Asserting only the
+#      exit code would pass against any unrelated template error. The in-chart
+#      `valkey/valkey:8-alpine` StatefulSet serves no TLS listener, so
+#      rendering TLS against it would break all seven consumers at once with a
+#      perfectly healthy-looking manifest.
+#   6. NEGATIVE CONTROL -- string coercion: `--set-string valkey.tls=false` on
+#      a BYO render still yields "false" everywhere and does not trip the
+#      guard. Go templates read a quoted `"false"` as truthy; this is the same
+#      scar `security.allowDevDefaults` already carries (`_helpers.tpl:748`).
+#   7. `byo-tls` renders NO in-chart valkey manifest (`[[ -s
+#      "$DIR/valkey.yaml" ]]` is the `--output-dir` signal a template rendered
+#      nothing, per the sibling scripts).
+#
+# Every render goes through `--output-dir`, never a stdout pipe: piping `helm
+# template` in this environment silently truncates a large render at exit 0
+# with empty stderr, which reads as a passing assertion against manifests that
+# were never examined. Structural checks go through PyYAML rather than grep,
+# for the reason `valkey-existing-secret-assertions.sh` gives -- a
+# line-oriented reader mis-reads a requoted value or a reordered key.
+#
+# Runnable locally (from anywhere) and from CI. Fails loudly.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+render() {
+  local name="$1"
+  shift
+  RENDER_DIR="$TMP/$name"
+  rm -rf "$RENDER_DIR"
+  helm template rel "$CHART" --output-dir "$RENDER_DIR" "$@" >/dev/null \
+    || fail "helm template failed for render '$name'"
+}
+
+BYO_HOST="redis.acme.internal"
+
+# The dispatcher Deployment (curie.dispatcher.enabled) renders only when BOTH
+# Slack tokens are present (issue #1759) -- a token-less default install skips
+# it entirely rather than crash-looping. Every render below sets a placeholder
+# pair so the dispatcher container is present to assert against; the values
+# are inert (Socket Mode dials out, nothing in this script connects to Slack).
+DISPATCHER_SLACK_ARGS=(
+  --set-string dispatcher.slack.appToken=xapp-tls-assertions-placeholder
+  --set-string dispatcher.slack.botToken=xoxb-assert
+)
+
+echo "=== Rendering (defaults) ==="
+render default "${DISPATCHER_SLACK_ARGS[@]}"
+DEFAULT_DIR="$RENDER_DIR/curie/templates"
+
+echo "=== Rendering (byo-tls: deploy=false + host + tls=true) ==="
+render byo-tls \
+  "${DISPATCHER_SLACK_ARGS[@]}" \
+  --set valkey.deploy=false \
+  --set-string valkey.host="$BYO_HOST" \
+  --set valkey.tls=true
+BYO_TLS_DIR="$RENDER_DIR/curie/templates"
+
+echo "=== Rendering (byo-plain: deploy=false + host, tls left default) ==="
+render byo-plain \
+  "${DISPATCHER_SLACK_ARGS[@]}" \
+  --set valkey.deploy=false \
+  --set-string valkey.host="$BYO_HOST"
+BYO_PLAIN_DIR="$RENDER_DIR/curie/templates"
+
+echo "=== Rendering (byo-string-false: --set-string valkey.tls=false) ==="
+render byo-string-false \
+  "${DISPATCHER_SLACK_ARGS[@]}" \
+  --set valkey.deploy=false \
+  --set-string valkey.host="$BYO_HOST" \
+  --set-string valkey.tls=false
+BYO_STRING_FALSE_DIR="$RENDER_DIR/curie/templates"
+
+# ---------------------------------------------------------------------- 7
+# A missing manifest file is --output-dir's signal that the whole template
+# rendered nothing (the same check valkey-existing-secret-assertions.sh uses);
+# an empty document would not be distinguishable.
+if [[ -s "$BYO_TLS_DIR/valkey.yaml" ]]; then
+  fail "[7] byo-tls (valkey.deploy=false + valkey.tls=true) still rendered templates/valkey.yaml"
+fi
+echo "  [7] byo-tls renders no in-chart valkey manifest: OK"
+
+# -------------------------------------------------------------- 1, 2, 3, 4, 6
+DEFAULT_DIR="$DEFAULT_DIR" BYO_TLS_DIR="$BYO_TLS_DIR" BYO_PLAIN_DIR="$BYO_PLAIN_DIR" \
+BYO_STRING_FALSE_DIR="$BYO_STRING_FALSE_DIR" BYO_HOST="$BYO_HOST" \
+python3 <<'PY'
+import os
+import sys
+
+import yaml
+
+DEFAULT_DIR = os.environ["DEFAULT_DIR"]
+BYO_TLS_DIR = os.environ["BYO_TLS_DIR"]
+BYO_PLAIN_DIR = os.environ["BYO_PLAIN_DIR"]
+BYO_STRING_FALSE_DIR = os.environ["BYO_STRING_FALSE_DIR"]
+BYO_HOST = os.environ["BYO_HOST"]
+
+# `helm template rel <chart>` -> fullname `rel-curie`, so the chart's own
+# Secret is `rel-curie-secrets` (same convention as
+# valkey-existing-secret-assertions.sh). Hardcoded rather than derived: the
+# BYO renders below never set valkey.existingSecret, so the password path must
+# still fall back to this exact chart-managed Secret.
+CHART_SECRET_NAME = "rel-curie-secrets"
+
+failures = []
+
+
+_docs_cache = {}
+
+
+def load_docs(path):
+    # Each manifest is queried several times per render (both hook modes,
+    # both Langfuse containers, every assertion); parse it once.
+    if path not in _docs_cache:
+        if not os.path.isfile(path):
+            _docs_cache[path] = []
+        else:
+            with open(path) as f:
+                _docs_cache[path] = [d for d in yaml.safe_load_all(f) if d]
+    return _docs_cache[path]
+
+
+def find_containers(obj, acc):
+    if isinstance(obj, dict):
+        containers = obj.get("containers")
+        if isinstance(containers, list):
+            acc.extend(containers)
+        for v in obj.values():
+            find_containers(v, acc)
+    elif isinstance(obj, list):
+        for item in obj:
+            find_containers(item, acc)
+
+
+def all_containers(manifest_path):
+    containers = []
+    for d in load_docs(manifest_path):
+        find_containers(d, containers)
+    return [c for c in containers if isinstance(c, dict)]
+
+
+def mode_of(container):
+    """The value following `--mode` in a container's command, or None.
+
+    Both worker-upgrade-drain hook Job containers live in the SAME manifest
+    file and are told apart by which mode they run, not by container identity
+    alone -- the same signal upgrade-drain-assertions.sh checks.
+    """
+    command = container.get("command") or []
+    for i, arg in enumerate(command):
+        if arg == "--mode" and i + 1 < len(command):
+            return command[i + 1]
+    return None
+
+
+def by_name(manifest_path, name):
+    return [c for c in all_containers(manifest_path) if c.get("name") == name]
+
+
+def by_mode(manifest_path, mode):
+    return [c for c in all_containers(manifest_path) if mode_of(c) == mode]
+
+
+def resolve_env_entry(aid, containers, label, env_name, ctx):
+    """The single env entry `env_name` on the single container matching `label`.
+
+    Records a failure and returns None when either is not exactly one: a
+    missing var and a var rendered twice are both drift, and a label matching
+    zero or two containers means the manifest shape moved under the gate.
+    """
+    if len(containers) != 1:
+        failures.append(
+            f"[{aid}] {ctx}: found {len(containers)} container(s) matching "
+            f"{label!r}, expected exactly 1"
+        )
+        return None
+    entries = [e for e in (containers[0].get("env") or []) if e.get("name") == env_name]
+    if len(entries) != 1:
+        failures.append(
+            f"[{aid}] {ctx}: {env_name} rendered {len(entries)} time(s) on "
+            f"{label!r}, expected exactly 1"
+        )
+        return None
+    return entries[0]
+
+
+def check_literal(aid, containers, label, env_name, expected, ctx):
+    entry = resolve_env_entry(aid, containers, label, env_name, ctx)
+    if entry is None:
+        return
+    value = entry.get("value")
+    if value != expected:
+        failures.append(
+            f"[{aid}] {ctx}: {env_name} on {label!r} = {value!r}, expected {expected!r}"
+        )
+
+
+def check_secret_ref(aid, containers, label, env_name, expected_name, expected_key, ctx):
+    entry = resolve_env_entry(aid, containers, label, env_name, ctx)
+    if entry is None:
+        return
+    ref = (entry.get("valueFrom") or {}).get("secretKeyRef") or {}
+    if ref.get("name") != expected_name:
+        failures.append(
+            f"[{aid}] {ctx}: {env_name} secretKeyRef.name on {label!r} = "
+            f"{ref.get('name')!r}, expected {expected_name!r}"
+        )
+    if ref.get("key") != expected_key:
+        failures.append(
+            f"[{aid}] {ctx}: {env_name} secretKeyRef.key on {label!r} = "
+            f"{ref.get('key')!r}, expected {expected_key!r}"
+        )
+
+
+# The full TLS-carrying consumer set: every container the chart's two shared
+# env helpers (curie.env.valkey, curie.langfuse.env) reach. Reused for
+# assertions 1, 3, and 4 so a fix applied to one include site and not its
+# sibling fails every one of them, not just the render it happened to touch.
+def tls_consumers(templates_dir):
+    return [
+        ("api", "VALKEY_TLS", by_name(f"{templates_dir}/api.yaml", "api")),
+        ("worker", "VALKEY_TLS", by_name(f"{templates_dir}/worker.yaml", "worker")),
+        ("dispatcher", "VALKEY_TLS", by_name(f"{templates_dir}/dispatcher.yaml", "dispatcher")),
+        (
+            "upgrade-drain (drain)",
+            "VALKEY_TLS",
+            by_mode(f"{templates_dir}/worker-upgrade-drain.yaml", "drain"),
+        ),
+        (
+            "upgrade-drain (release)",
+            "VALKEY_TLS",
+            by_mode(f"{templates_dir}/worker-upgrade-drain.yaml", "release"),
+        ),
+        (
+            "langfuse-web",
+            "REDIS_TLS_ENABLED",
+            by_name(f"{templates_dir}/langfuse.yaml", "langfuse-web"),
+        ),
+        (
+            "langfuse-worker",
+            "REDIS_TLS_ENABLED",
+            by_name(f"{templates_dir}/langfuse.yaml", "langfuse-worker"),
+        ),
+    ]
+
+
+# ---- 1: byo-tls, all seven consumer containers carry TLS == "true". --------
+for label, env_name, containers in tls_consumers(BYO_TLS_DIR):
+    check_literal("1", containers, label, env_name, "true", "byo-tls render")
+
+# ---- 2: byo-tls transport/identity parity, in the SAME render. ------------
+check_literal("2", by_name(f"{BYO_TLS_DIR}/api.yaml", "api"), "api", "VALKEY_HOST", BYO_HOST, "byo-tls render")
+check_literal("2", by_name(f"{BYO_TLS_DIR}/worker.yaml", "worker"), "worker", "VALKEY_HOST", BYO_HOST, "byo-tls render")
+check_literal(
+    "2", by_name(f"{BYO_TLS_DIR}/dispatcher.yaml", "dispatcher"), "dispatcher",
+    "VALKEY_HOST", BYO_HOST, "byo-tls render",
+)
+check_literal(
+    "2", by_name(f"{BYO_TLS_DIR}/langfuse.yaml", "langfuse-web"), "langfuse-web",
+    "REDIS_HOST", BYO_HOST, "byo-tls render",
+)
+check_literal(
+    "2", by_name(f"{BYO_TLS_DIR}/langfuse.yaml", "langfuse-worker"), "langfuse-worker",
+    "REDIS_HOST", BYO_HOST, "byo-tls render",
+)
+check_secret_ref(
+    "2", by_name(f"{BYO_TLS_DIR}/api.yaml", "api"), "api",
+    "VALKEY_PASSWORD", CHART_SECRET_NAME, "valkeyPassword", "byo-tls render",
+)
+check_secret_ref(
+    "2", by_name(f"{BYO_TLS_DIR}/worker.yaml", "worker"), "worker",
+    "VALKEY_PASSWORD", CHART_SECRET_NAME, "valkeyPassword", "byo-tls render",
+)
+check_secret_ref(
+    "2", by_name(f"{BYO_TLS_DIR}/dispatcher.yaml", "dispatcher"), "dispatcher",
+    "VALKEY_PASSWORD", CHART_SECRET_NAME, "valkeyPassword", "byo-tls render",
+)
+check_secret_ref(
+    "2", by_name(f"{BYO_TLS_DIR}/langfuse.yaml", "langfuse-web"), "langfuse-web",
+    "REDIS_AUTH", CHART_SECRET_NAME, "valkeyPassword", "byo-tls render",
+)
+check_secret_ref(
+    "2", by_name(f"{BYO_TLS_DIR}/langfuse.yaml", "langfuse-worker"), "langfuse-worker",
+    "REDIS_AUTH", CHART_SECRET_NAME, "valkeyPassword", "byo-tls render",
+)
+
+# ---- 3: byo-plain no-regression: every container carries the LITERAL
+#         "false" -- this is what makes assertion 1 non-vacuous. -----------
+for label, env_name, containers in tls_consumers(BYO_PLAIN_DIR):
+    check_literal("3", containers, label, env_name, "false", "byo-plain render")
+
+# ---- 4: default no-regression, same shape as 3. ---------------------------
+for label, env_name, containers in tls_consumers(DEFAULT_DIR):
+    check_literal("4", containers, label, env_name, "false", "default render")
+_default_valkey_manifest = f"{DEFAULT_DIR}/valkey.yaml"
+if not (os.path.isfile(_default_valkey_manifest) and os.path.getsize(_default_valkey_manifest) > 0):
+    failures.append("[4] default render: templates/valkey.yaml did not render (or is empty)")
+
+# ---- 6: NEGATIVE CONTROL -- a quoted "false" from --set-string must not
+#         read as truthy (the security.allowDevDefaults trap). -------------
+for label, env_name, containers in tls_consumers(BYO_STRING_FALSE_DIR):
+    check_literal(
+        "6", containers, label, env_name, "false",
+        "byo render with --set-string valkey.tls=false",
+    )
+
+if failures:
+    for msg in failures:
+        print(f"FAIL {msg}", file=sys.stderr)
+    print(f"{len(failures)} python-side assertion(s) failed", file=sys.stderr)
+    sys.exit(1)
+
+print("  [1] byo-tls: VALKEY_TLS/REDIS_TLS_ENABLED == true on all seven consumer containers: OK")
+print("  [2] byo-tls: VALKEY_HOST/REDIS_HOST and VALKEY_PASSWORD/REDIS_AUTH parity preserved: OK")
+print("  [3] byo-plain: every consumer carries the literal \"false\": OK")
+print("  [4] default: every consumer carries \"false\" and templates/valkey.yaml still renders: OK")
+print("  [6] negative control: --set-string valkey.tls=false does not read as truthy: OK")
+PY
+
+echo
+echo "=== Rendering (guard: valkey.tls=true with valkey.deploy left at its default) ==="
+# ---------------------------------------------------------------------- 5
+# NEGATIVE CONTROL, asserted by EXECUTING the rejected configuration, not by
+# reading the helper: a guard that has never been seen refusing is a guard
+# nobody has tested. The in-chart valkey/valkey:8-alpine StatefulSet serves no
+# TLS listener, so rendering TLS against it would break all seven consumers at
+# once with a perfectly healthy-looking manifest and no failing preflight.
+GUARD_OUT="$(helm template rel "$CHART" --set valkey.tls=true 2>&1)" && {
+  fail "[5] valkey.tls=true with valkey.deploy left true rendered successfully; expected a render-time refusal"
+}
+for needle in "valkey.tls" "valkey.deploy"; do
+  if ! printf '%s' "$GUARD_OUT" | grep -qF "$needle"; then
+    echo "FAIL: [5] the guard's refusal did not name '$needle'" >&2
+    echo "  actual output:" >&2
+    printf '%s\n' "$GUARD_OUT" | sed 's/^/    /' >&2
+    exit 1
+  fi
+done
+echo "  [5] negative control: valkey.tls=true + valkey.deploy=true is refused at render time, naming both keys: OK"
+
+echo
+echo "PASS: valkey.tls reaches every consumer (api, worker, dispatcher, both"
+echo "      upgrade-hook Jobs, both Langfuse Deployments), the default and"
+echo "      BYO-plain renders stay cleartext, and the deploy+tls guard refuses"
+echo "      the one configuration that would break all of it silently."

--- a/charts/curie/templates/_helpers.tpl
+++ b/charts/curie/templates/_helpers.tpl
@@ -170,6 +170,33 @@ ANTHROPIC_BASE_URL ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN ANTHROPIC_AUTH_TOKE
 {{- end -}}
 {{- end -}}
 
+{{/* Whether consumers reach Valkey over TLS, as the literal string "true" or
+     "false" (#2315). ONE helper, included from BOTH curie.env.valkey and
+     curie.langfuse.env: the bug class this chart has hit twice (#2052, #2327)
+     is "two consumer groups read the same valkey.* field and only one of them
+     was updated", and a shared helper makes that divergence structurally
+     impossible rather than merely tested against.
+
+     Why the guard. The in-chart valkey/valkey:8-alpine StatefulSet is started
+     with --requirepass and serves no TLS listener, so rendering TLS against it
+     would break every consumer at once behind a perfectly healthy-looking
+     manifest and no failing preflight -- silent and total. Refuse at render
+     time instead, naming both keys and both ways out.
+
+     Why toString. Go templates read any non-empty string as truthy, so a
+     quoted "false" arriving from --set-string would otherwise turn TLS on
+     against a cleartext store; this is the same scar curie.managedSecret
+     carries for security.allowDevDefaults. A nil -- a --reuse-values upgrade
+     of a release created before this key existed coalesces it away -- is not
+     "true" either, and renders the pre-change "false". */}}
+{{- define "curie.valkey.tls" -}}
+{{- $tls := eq (toString .Values.valkey.tls) "true" -}}
+{{- if and $tls .Values.valkey.deploy -}}
+{{- fail "valkey.tls is true but valkey.deploy is also true: the in-chart Valkey serves no TLS listener, so every consumer would fail to connect. Set valkey.deploy=false and point valkey.host at your external TLS store, or leave valkey.tls=false." -}}
+{{- end -}}
+{{- $tls -}}
+{{- end -}}
+
 {{- define "curie.clickhouse.host" -}}
 {{- if .Values.clickhouse.deploy -}}
 {{- printf "%s-clickhouse" (include "curie.fullname" .) -}}
@@ -847,7 +874,11 @@ http://{{ include "curie.fullname" . }}-otel-collector:{{ .Values.otelCollector.
 {{- end -}}
 
 {{/* Valkey connection env for the app services (host/port + password from the
-     Secret). The apps build their own redis DSN from these parts. */}}
+     Secret, plus the transport). The apps build their own redis DSN from these
+     parts, and TLS is one of the parts -- rendered always, both values, so an
+     install that never set valkey.tls cannot be confused with a broken
+     template and a --reuse-values upgrade cannot leave a stale "true" behind
+     (#2315). */}}
 {{- define "curie.env.valkey" -}}
 - name: VALKEY_HOST
   value: {{ include "curie.valkey.host" . | quote }}
@@ -858,6 +889,8 @@ http://{{ include "curie.fullname" . }}-otel-collector:{{ .Values.otelCollector.
     secretKeyRef:
       name: {{ .Values.valkey.existingSecret | default (include "curie.secretName" .) }}
       key: valkeyPassword
+- name: VALKEY_TLS
+  value: {{ include "curie.valkey.tls" . | quote }}
 {{- end -}}
 
 {{/* Platform API connection env for first party services that call the API.
@@ -1052,6 +1085,14 @@ livenessProbe:
     secretKeyRef:
       name: {{ .Values.valkey.existingSecret | default (include "curie.secretName" .) }}
       key: valkeyPassword
+{{- /* Same helper as curie.env.valkey, so the two Langfuse Deployments and the
+       first-party apps cannot disagree about the transport of the one store
+       they share (#2315). Langfuse's REDIS_TLS_CA/_CERT/_KEY siblings are
+       deliberately NOT rendered: system-CA verification is the boundary for
+       every consumer here, and giving Langfuse alone a private-CA capability
+       is the asymmetry this helper exists to prevent. */}}
+- name: REDIS_TLS_ENABLED
+  value: {{ include "curie.valkey.tls" . | quote }}
 - name: LANGFUSE_S3_EVENT_UPLOAD_BUCKET
   value: {{ .Values.rustfs.bucket | quote }}
 {{- /* Both upload regions come from rustfs.region, never the literal

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -353,7 +353,8 @@ postgres:
 
 # ---------------------------------------------------------------------------
 # Valkey (Redis-compatible). Langfuse cache/queue AND the dispatcher's Streams
-# queue. BYO: deploy=false + host/port (existingSecret key valkeyPassword).
+# queue. BYO: deploy=false + host/port (existingSecret key valkeyPassword), plus
+# tls=true for a managed store that only accepts TLS.
 # ---------------------------------------------------------------------------
 valkey:
   deploy: true
@@ -366,6 +367,11 @@ valkey:
   port: 6379
   password: valkeypass
   existingSecret: ""
+  # Connect over TLS (#2315). For a BYO store ONLY: the in-chart StatefulSet
+  # serves no TLS listener, so tls=true with deploy=true fails the render rather
+  # than shipping six consumers that cannot connect. Verification uses the
+  # system CA bundle -- a private CA or mutual TLS is not supported by this knob.
+  tls: false
   persistence:
     enabled: true
     size: 1Gi


### PR DESCRIPTION
Closes #2315

Fix pin: charts/curie/ci/valkey-tls-assertions.sh

A BYO Valkey that requires TLS was unusable: the chart rendered only host, port and password, and every consumer built a cleartext connection. This adds `valkey.tls` (default `false`) on the chart's `valkey` block and threads it to all four consumers.

**Chart.** One shared `curie.valkey.tls` helper renders `VALKEY_TLS` for the api, worker, dispatcher and both upgrade-drain hook containers, and `REDIS_TLS_ENABLED` for both Langfuse Deployments, so the consumer set cannot split the way #2052/#2327 did. It refuses `valkey.tls=true` while `valkey.deploy=true`, because the in-chart Valkey serves no TLS listener and every consumer would fail at once behind a healthy-looking render.

**Apps.** `valkey_tls: bool = False` on WorkerConfig, DispatcherConfig and the API Settings, read from `VALKEY_TLS`. The worker's three clients and the upgrade-drain hook client build from one `WorkerConfig.valkey_client_kwargs()` carrying `ssl=`; the dispatcher's `build_redis` passes `ssl=`; the API DSN switches to `rediss://`, with the existing `valkey_url` full-DSN override still winning.

**Gate.** `charts/curie/ci/valkey-tls-assertions.sh`, wired into helm-ci: BYO+TLS across all seven consumer containers in one render, BYO-plain and default renders pinned to a literal `"false"`, the guard's failure text naming both keys, `--set-string valkey.tls=false` staying false, and no in-chart Valkey manifest on the BYO render.

**Conservative defaults chosen on ambiguity (noted per the run contract):**
- `valkey.tls` is a bare bool that trusts the system CA bundle (redis-py 8.1 builds its context with `ssl.create_default_context`), which is what managed TLS stores present. A CA-file or skip-verify knob is deferred; no follow-up issue was filed because this run is authorized only to push a branch and open a PR.
- `VALKEY_TLS` and `REDIS_TLS_ENABLED` render always, as quoted `"true"`/`"false"`, so the default render is assertable rather than absent.
- The compose lane (`compose.dev.yaml`) and `packages/test-support` stay cleartext by design; they point at the in-chart/dev Valkey.

**Verification beyond unit tests.** Against a Docker `valkey/valkey:8-alpine` started with `--tls-port` only and a throwaway CA: with `VALKEY_TLS=true` every builder (worker sync and async, upgrade-drain `_client`, dispatcher `build_redis`, API `from_url(valkey_dsn())`) gets `PONG`; with `VALKEY_TLS` unset all five get `Connection closed by server`. Not reachable from this run: a full cluster install against a managed TLS store (needs a TLS-terminating BYO store plus CA trust in the app pods); the render gate and the Docker proof are the closest tiers.

**Review.** Cross-engine Code, Scope and consolidation reviews (agent-router, primary claude excluded) all returned ACCEPT with no blocking findings. One advisory left open: the worker tests pin `valkey_client_kwargs`, not the three `build()` call sites (`build()` is not hermetic); the Docker proof above exercises the sites.

## Done-check

- [x] Failing tests committed before implementation (contract commit first, then the implementation; squashed for the PR)
- [x] All production edits by delegated executors (Implementer, Fixer); the consolidation pass applied its own edits by design
- [x] No public return type broadened (Implementer: "none broadened"; `valkey_client_kwargs` is new)
- [x] Router Code Reviewer: ACCEPT, 0 blocking, 5 advisory (2 fixed)
- [x] Router Scope Reviewer: ACCEPT, every hunk mapped to an AC or mechanical exception, 0 orphans
- [x] Sibling-path parity: all seven env include sites go through the two shared fragments; compose lane and test-support recorded out of scope
- [x] Guard demonstration: `helm template --set valkey.tls=true` exited 1 naming both keys; a hardcoded `"false"` mutant made the gate fail on api/worker/dispatcher
- [x] Consolidation: `/simplify` applied 3 of 6 findings; revalidated; router re-check ACCEPT
- [ ] N/A Security reviewer (not flagged)
- [ ] N/A Observable verification for user-facing change (no user-facing flow)
- [x] E2E (deployed-surface): Docker TLS-only Valkey proof, positive and negative
- [x] Train check: v0.8.6 patch milestone cut from `main`
- [x] Discovery-surface proof: live-tier Docker TLS proof; cluster tier waived as above
- [ ] N/A Re-fix mechanism (no prior fix of this symptom)
- [x] Full affected suites green locally (api 1647 passed, worker+dispatcher 1517 passed), ruff, mypy, helm lint clean
