### PR TITLE
Accept the warm-pool bootstrap credential decision

### DIFF
--- a/docs/adr/0116-session-identity-arrives-over-the-aci-so-a-sandbox-can-be-pre-bound.md
+++ b/docs/adr/0116-session-identity-arrives-over-the-aci-so-a-sandbox-can-be-pre-bound.md
@@ -4,6 +4,10 @@ Date: 2026-08-20
 
 Status: Accepted
 
+Decision 2's per-pod pool-token minting clause is superseded by
+[ADR-0122](0122-a-warm-pools-runner-token-is-per-version-not-per-pod.md).
+The rest of this decision remains Accepted.
+
 Extends [ADR-0059](0059-sandbox-is-a-bounded-resource-envelope.md) into the
 dimension it deliberately left out of scope -- **throughput and the wall-clock
 deadline on the claim path** -- and revisits the resume framing of

--- a/docs/adr/0122-a-warm-pools-runner-token-is-per-version-not-per-pod.md
+++ b/docs/adr/0122-a-warm-pools-runner-token-is-per-version-not-per-pod.md
@@ -2,15 +2,26 @@
 
 Date: 2026-08-25
 
-Status: Draft
+Status: Accepted
 
-**Supersedes in part, when accepted,
+**Supersedes in part
 [ADR-0116](0116-session-identity-arrives-over-the-aci-so-a-sandbox-can-be-pre-bound.md)**,
-whose decision 2 says the pool "mints one per pod at creation". It cannot. While
-this record is Draft it replaces nothing; ADR-0116's clause stands until this one
-is Accepted. Everything else in ADR-0116 is unaffected either way, including the
+whose decision 2 says the pool "mints one per pod at creation". It cannot.
+Only the per-pod minting clause is replaced. Everything else in ADR-0116 is
+unaffected, including the
 half of decision 2 that moves session identity onto the ACI `Event` frame, and
 including the ordering that puts the token before decision 3's warm pool.
+
+## Acceptance and realization
+
+The maintainer explicitly approved acceptance on 2026-09-04. The realizing
+implementation and its live isolation proofs are tracked in
+[#1492](https://github.com/curie-eng/curie/issues/1492). Acceptance authorizes
+that work; it does not claim the mechanism is implemented or permit enabling
+warm replicas before adoption, bootstrap retirement, and conversation isolation
+are proven. The optional ACI session metadata prerequisite in
+[#2309](https://github.com/curie-eng/curie/pull/2309) does not implement those
+requirements.
 
 ## Context
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -151,7 +151,7 @@ read verbatim from its `Status:` line. **Do not hand-edit it.** Run
 | 0119 | [A resumed thread rebuilds its prefix so the prompt cache still hits](0119-a-resumed-thread-rebuilds-its-prefix-so-the-prompt-cache-still-hits.md) | Accepted |
 | 0120 | [First-party email delivery state is local durable single-writer state](0120-durable-first-party-email-state.md) | Accepted |
 | 0121 | [A restore is the connector's own verb, run under the same pinned connector](0121-a-restore-is-the-connectors-own-verb-run-under-the-same-pinned-connector.md) | Draft |
-| 0122 | [A warm pool's runner token is per version, not per pod](0122-a-warm-pools-runner-token-is-per-version-not-per-pod.md) | Draft |
+| 0122 | [A warm pool's runner token is per version, not per pod](0122-a-warm-pools-runner-token-is-per-version-not-per-pod.md) | Accepted |
 | 0123 | [A pending approval's approver set does not follow its route binding](0123-a-pending-approvals-approver-set-does-not-follow-its-route-binding.md) | Accepted |
 | 0124 | [A snapshot is sealed to the connector that wrote it](0124-a-snapshot-is-sealed-to-the-connector-that-wrote-it.md) | Draft |
 | 0125 | [Managed repository workspaces and approval-gated publication are platform capabilities](0125-managed-repository-workspaces-and-approval-gated-publication.md) | Accepted |


### PR DESCRIPTION
## Summary

Accept ADR-0122 with explicit maintainer approval and record its partial supersession of ADR-0116's per-pod pool-token minting clause. The adoption-only bootstrap, credential retirement, and conversation-isolation decisions remain unchanged; #1492 still owns implementation and live proof.

## Related issue

Ref #1492

Milestone: v0.9.0

## End-to-end verification

This change does not alter runtime behavior: it publishes maintainer acceptance, the permitted partial-supersession backlink, and the generated ADR index. No warm replicas or runtime features are enabled.

Scoped verification at 879aa422:
- `bash scripts/check-docs.sh` passed.
- `uv run python -m curie_doclint --repo-root "$PWD"` passed.
- `git diff --cached --check` passed before commit.
- Mechanical comparison confirmed both ADRs' existing decision and evidence bodies are unchanged.
- Independent ADR-procedure and scope review found no blockers.

## Checklist

- [x] Appropriate documentation checks pass.
- [x] The generated ADR index is committed.
- [x] Explicit maintainer approval is recorded.
- [x] The realizing feature remains tracked and unclaimed as complete.
