### PR TITLE
Share the Langfuse Postgres readiness gate with langfuse-worker and give it probes

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -291,13 +291,30 @@ jobs:
           set -euo pipefail
           bash charts/curie/ci/langfuse-runasuser-assertions.sh
 
-      # Prove the web-only Postgres readiness gate is ordered before Langfuse,
-      # credential-free, bounded/tunable, hardened like the web container, and
-      # removable through its explicit values switch. Includes a red mutation.
+      # Prove the Postgres readiness gate is rendered on BOTH Langfuse
+      # Deployments (#2330: it was web-only, so langfuse-worker crash-looped on
+      # the same Prisma P1001 that #1853 fixed for web), ordered before the
+      # ClickHouse gate on each, credential-free, bounded/tunable, hardened from
+      # each Deployment's OWN containerSecurityContext, and removable through its
+      # values switch. `langfuse.web.postgresReadiness` stays honoured as a
+      # deprecated alias applied to both Deployments -- not refused, because a
+      # render fail would abort `helm upgrade --reuse-values` on exactly the
+      # releases that need the gate. Includes red mutations, armed per Deployment.
       - name: helm render assertions (langfuse postgres readiness)
         run: |
           set -euo pipefail
           bash charts/curie/ci/langfuse-postgres-readiness-assertions.sh
+
+      # Prove langfuse-worker carries both probes on its :3030 endpoint -- #71's
+      # criterion is that every Deployment with a persistent process has both a
+      # readiness and a liveness probe, and the worker was the last violation.
+      # Readiness is the SIGTERM-aware /api/ready so a terminating pod drains;
+      # liveness is tcpSocket so a Postgres or Valkey blip cannot restart the
+      # single replica into its boot migrations (#71, #2330).
+      - name: helm render assertions (langfuse worker probes)
+        run: |
+          set -euo pipefail
+          bash charts/curie/ci/langfuse-worker-probe-assertions.sh
 
       # Prove the controller NetworkPolicy RBAC split (issue #350): exactly one
       # read-only cluster grant (get/list/watch) so the informer syncs, no

--- a/charts/curie/CLAUDE.md
+++ b/charts/curie/CLAUDE.md
@@ -42,6 +42,34 @@ component and rail detail in `charts/curie/README.md`.
     strategy values key**. Pinned by `ci/langfuse-recreate-assertions.sh`.
     Horizontal scale for Langfuse needs an Accepted out-of-band migrator; when
     that lands, this exception is removed rather than extended.
+  - **Third named exception: `langfuse-worker`'s probe cadences, also in
+    `templates/langfuse.yaml`.** Its `readinessProbe`/`livenessProbe` cadence
+    numbers (#2330) -- `initialDelaySeconds`, `periodSeconds`,
+    `timeoutSeconds`, `failureThreshold` -- are hardcoded to match
+    `langfuse-web`'s, three blocks above in the same file, instead of reading
+    from new `langfuse.worker.readinessProbe.*` / `.livenessProbe.*` values
+    keys. The probe types and endpoints deliberately differ from web's
+    (worker readiness is `httpGet /api/ready`, liveness is `tcpSocket`; web
+    uses `httpGet /api/public/health` for both -- see the liveness rationale
+    below) -- only the cadence numbers follow web. This is a knowing
+    deviation, not a claim that the invariant does not apply: this ticket
+    exists *because* `langfuse-web` and `langfuse-worker` had diverged (web
+    alone had the Postgres readiness gate), and adding values-driven probe
+    keys for the worker while `langfuse-web`'s probes stay hardcoded in the
+    same file would create a new asymmetry in the very file the ticket is
+    about. It is also not a new hole in the chart: every other long-running
+    Deployment already
+    hardcodes its probe numbers -- `api.yaml`, `ui.yaml`, `postgres.yaml`,
+    `clickhouse.yaml`, `valkey.yaml`, `rustfs.yaml`, `otel-collector.yaml`,
+    `mail-adapter.yaml`, `inference.yaml`, and the `curie.heartbeatProbes`
+    helper (used by `worker.yaml` and `dispatcher.yaml`) -- so `langfuse-web`
+    itself was already inside this exception before #2330. The only K8s Probes
+    genuinely driven by values in this chart are
+    `agentSandbox.runner.readinessProbe`, because its cadence couples to the
+    worker's claim-timeout budget, and `dispatcher.startupProbe`; nothing here
+    couples the same way. The correct end state is lifting `langfuse-web` and
+    `langfuse-worker` onto values-driven probes together, tracked as a separate
+    follow-up -- not extended piecemeal from this ticket.
 - **The instrumented set is exactly the workloads whose container `env` block
   includes the `curie.env.otel` helper.** That include *is* the boundary -- it
   is not a count and not a list kept in prose, and this rule exists because a
@@ -64,6 +92,28 @@ component and rail detail in `charts/curie/README.md`.
   And a workload with an egress NetworkPolicy needs a collector peer in it as
   well; today the mail adapter is the only such workload (see the next
   invariant).
+- **`langfuse-worker`'s liveness probe is `tcpSocket`, not HTTP.** Both
+  `/api/health` and `/api/ready` in the worker image run a Prisma `SELECT 1`
+  plus a Redis ping and differ only in SIGTERM handling, so an HTTP liveness
+  probe would poke the same stores the HTTP readiness probe already pokes.
+  `langfuse-worker` is `replicas: 1` and runs Prisma and ClickHouse migrations
+  at container boot, and init containers do NOT re-run on a liveness restart --
+  so an HTTP liveness probe would restart the only replica straight into those
+  boot migrations against a Postgres or Valkey that may still be recovering,
+  which is exactly the crash-loop class
+  this chart's readiness gates exist to prevent (#2330). Accepted trade-off:
+  `tcpSocket` will not catch a wedged Node event loop -- the kernel still
+  accepts on the listen backlog against a process doing nothing -- so
+  detection of that rides on the **readiness** probe instead, which does
+  exercise the event loop and the stores, and flips `Deployment.Available`.
+  The chart's other first-party liveness probes are likewise process-local
+  rather than store-probing: `api.yaml`'s `/health` does no store I/O,
+  `mail-adapter.yaml` documents `/healthz` as a static liveness signal while
+  `/readyz` alone waits on SQLite, `inference.yaml` uses `tcpSocket`, and
+  `worker.yaml`/`dispatcher.yaml` use the heartbeat-file check
+  (`curie.heartbeatProbes`). `langfuse-web` probing `/api/public/health` for
+  *both* readiness and liveness is the exception, not the pattern -- do not
+  copy its liveness shape onto the worker.
 - **Mail-adapter egress is a separate fail-closed rail.** Enabling
   `mailAdapter.deploy` requires at least one
   `mailAdapter.agentmail.httpsCidrs` entry. One egress-only policy is the

--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -550,21 +550,48 @@ credential because the Basic header is encoded, not encrypted.
 
 ### Langfuse Postgres startup readiness
 
-`langfuse.web.postgresReadiness` is enabled by default. Before Langfuse web
-starts, its `wait-for-postgres` init container makes a credential-free
-`pg_isready` protocol-readiness check only; it does not validate authentication
-or run migrations. Its `image` is empty by default and falls back to
-`postgres.image`; override it for a BYO Postgres/private registry when the
-default image is unavailable there.
+`langfuse.postgresReadiness` is enabled by default. Both `langfuse-web` and
+`langfuse-worker` render a `wait-for-postgres` init container from it, because
+both run Prisma schema migrations against Postgres at boot (#2330). The check
+is a credential-free `pg_isready` protocol-readiness check only; it does not
+validate authentication or run migrations. Its `image` is empty by default and
+falls back to `postgres.image`; override it for a BYO Postgres/private
+registry when the default image is unavailable there.
 
 Defaults are `attempts: 60`, `intervalSeconds: 2`, and
 `probeTimeoutSeconds: 2`: the wait is bounded to approximately 2--4 minutes,
-depending on how quickly each probe fails. While the Pod remains in `Init`, use
-`kubectl logs <langfuse-web-pod> -c wait-for-postgres` and check the Postgres
-endpoint, DNS, and network path. Exhaustion fails the init container so
-Kubernetes restarts it. After a successful protocol check, Langfuse web owns
-authentication and migrations: bad credentials and permanent migration failures
-are terminal there and are not retried by this gate.
+depending on how quickly each probe fails. While a Pod remains in `Init`, use
+`kubectl logs <langfuse-web-pod> -c wait-for-postgres` or
+`kubectl logs <langfuse-worker-pod> -c wait-for-postgres` (whichever Pod is
+stuck) and check the Postgres endpoint, DNS, and network path. Exhaustion
+fails the init container so Kubernetes restarts it. After a successful
+protocol check, the Langfuse container itself owns authentication and
+migrations: bad credentials and permanent migration failures are terminal
+there and are not retried by this gate.
+
+**Upgrading from a release that set `langfuse.web.postgresReadiness`:** that
+path is deprecated but still honoured — values supplied there are merged over
+the `langfuse.postgresReadiness` defaults and now apply to **both**
+Deployments, not web only, for consistency: whatever an operator configured
+under the old key -- a disable, a BYO `image`, a tuned attempt budget -- must
+take effect uniformly across both Deployments rather than silently applying to
+web only and letting the two diverge. The render does not refuse the old key:
+`helm upgrade --reuse-values` replays a release's stored
+user-supplied values, so a key set on an earlier version comes back on every
+upgrade, and failing the render on it would break the upgrade path for exactly
+the operators who customized the gate. Move any `--set`s or overlay files from
+`langfuse.web.postgresReadiness.*` to `langfuse.postgresReadiness.*`; the
+alias is removed in a future minor. `helm install`/`upgrade` prints a NOTES.txt
+reminder whenever the deprecated key is still set.
+
+`langfuse-worker` also carries its own `readinessProbe` (`httpGet /api/ready`)
+and `livenessProbe` (`tcpSocket` on the same port 3030) once the container is
+running. Liveness is deliberately a TCP check rather than an HTTP path: the
+worker is `replicas: 1` and runs the same boot migrations as web, and init
+containers do not re-run on a liveness restart, so an HTTP liveness probe
+hitting a Postgres/Valkey blip would restart the only replica straight into
+those migrations against a store that is still recovering — the crash-loop
+class this gate exists to prevent.
 
 Secrets: all credentials are written to one `<release>-secrets` Secret. A sealed
 `helm install` (the default) generates strong random values for all thirteen

--- a/charts/curie/ci/langfuse-postgres-readiness-assertions.sh
+++ b/charts/curie/ci/langfuse-postgres-readiness-assertions.sh
@@ -1,5 +1,40 @@
 #!/usr/bin/env bash
-# Fast render contract for the Langfuse web Postgres readiness gate (#1853).
+#
+# Fast render contract for the Langfuse Postgres readiness gate on BOTH
+# Langfuse Deployments (#1853, #2330).
+#
+# #1853 filed the crash-loop against the Langfuse *web* pod and its fix keyed
+# the gate under `langfuse.web.postgresReadiness` -- a per-Deployment values
+# path. `langfuse-worker` runs the same Prisma boot migrations against the same
+# Postgres, so it reproduced the identical symptom (Prisma `P1001`,
+# `reason: Error`, namespace `BackOff`) with no gate to hold it back: that is
+# #2330. The gate is now chart-level (`langfuse.postgresReadiness`, the shape
+# `langfuse.clickhouseReadiness` already had for #2009) and rendered from the
+# shared `curie.langfuse.postgresGate` helper on both Deployments, ordered
+# before the ClickHouse gate on both.
+#
+# `langfuse.web.postgresReadiness` survives as a DEPRECATED ALIAS, honoured on
+# BOTH Deployments. It is deliberately not refused: `helm upgrade
+# --reuse-values` replays an operator's stored user-supplied values blob, so a
+# render `fail` would abort upgrades (including `curie cluster comms`) on
+# exactly the 0.8.5 releases that need the gate. The safety property asserted
+# here is that a stored legacy `enabled: false` or a legacy tuning value does
+# not silently become web-only.
+#
+# Every render assertion below iterates both `-langfuse-web` and
+# `-langfuse-worker`, and both red negative controls are armed once PER
+# Deployment: a mutant that only strips the web init stays green against a
+# worker-only regression, which is the exact hole #2330 fell through.
+#
+# Two renders exist solely to catch worker-specific defects that the default
+# render cannot, because `langfuse.web.containerSecurityContext` and
+# `langfuse.worker.containerSecurityContext` are byte-identical in values.yaml:
+# `worker-uid` proves the helper reads the WORKER's context rather than web's,
+# and `root-worker-security` proves the 1001 non-root floor (#351: both Langfuse
+# images declare a NAMED user, so `runAsNonRoot` needs a numeric uid) still
+# applies on the worker. `langfuse-runasuser-assertions.sh` stays web-only; these
+# two renders are what makes that deferral safe.
+#
 # The executable live delayed-start regression is nested under ci/runtime so
 # chart-check keeps discovering only the fast top-level assertion scripts.
 set -euo pipefail
@@ -35,16 +70,30 @@ render() {
 }
 
 render default
-render disabled --set langfuse.web.postgresReadiness.enabled=false
-render blank-security --set-json 'langfuse.web.containerSecurityContext=null'
+render disabled --set langfuse.postgresReadiness.enabled=false
+render both-disabled \
+  --set langfuse.postgresReadiness.enabled=false \
+  --set langfuse.clickhouseReadiness.enabled=false
+render blank-web-security --set-json 'langfuse.web.containerSecurityContext=null'
 render root-web-security \
   --set langfuse.web.containerSecurityContext.runAsNonRoot=false \
   --set langfuse.web.containerSecurityContext.runAsUser=0
+# Worker-only securityContext renders. The two defaults are byte-identical, so
+# these are the ONLY renders that can catch a helper wired to web's context.
+render worker-uid --set langfuse.worker.containerSecurityContext.runAsUser=1002
+render root-worker-security \
+  --set langfuse.worker.containerSecurityContext.runAsNonRoot=false \
+  --set langfuse.worker.containerSecurityContext.runAsUser=0
 render tuned \
-  --set-string langfuse.web.postgresReadiness.image=registry.example.com/postgres-readiness:test \
-  --set langfuse.web.postgresReadiness.attempts=7 \
-  --set langfuse.web.postgresReadiness.intervalSeconds=3 \
-  --set langfuse.web.postgresReadiness.probeTimeoutSeconds=4
+  --set-string langfuse.postgresReadiness.image=registry.example.com/postgres-readiness:test \
+  --set langfuse.postgresReadiness.attempts=7 \
+  --set langfuse.postgresReadiness.intervalSeconds=3 \
+  --set langfuse.postgresReadiness.probeTimeoutSeconds=4
+render canonical-tuned --set langfuse.postgresReadiness.attempts=7
+# Deprecated-alias renders (#2330 AC4). Both must SUCCEED -- there is no
+# legacy-refusal control, by design.
+render legacy-disabled --set langfuse.web.postgresReadiness.enabled=false
+render legacy-tuned --set langfuse.web.postgresReadiness.attempts=7
 
 cat >"$TMP/assert.py" <<'PY'
 import sys
@@ -53,176 +102,316 @@ import yaml
 path, mode, expected_image, attempts, interval, timeout = sys.argv[1:]
 docs = [doc for doc in yaml.safe_load_all(open(path)) if doc]
 
-def deployment_with_container(name):
+# (Deployment name suffix, application container name, short key used by the
+# per-mode tables below). Every assertion runs for BOTH.
+DEPLOYMENTS = (
+    ("-langfuse-web", "langfuse-web", "web"),
+    ("-langfuse-worker", "langfuse-worker", "worker"),
+)
+
+# How the init container's securityContext is expected to relate to its OWN
+# application container's, per render mode:
+#   match       -- identical to the app container's (the #351 class)
+#   floor-blank -- app container has no securityContext; the init still floors
+#   floor-root  -- app container was overridden to root; the init still floors
+SC_POLICY = {
+    "default": {"web": "match", "worker": "match"},
+    "tuned": {"web": "match", "worker": "match"},
+    "canonical-tuned": {"web": "match", "worker": "match"},
+    "legacy-tuned": {"web": "match", "worker": "match"},
+    "worker-uid": {"web": "match", "worker": "match"},
+    "blank-web-security": {"web": "floor-blank", "worker": "match"},
+    "root-web-security": {"web": "floor-root", "worker": "match"},
+    "root-worker-security": {"web": "match", "worker": "floor-root"},
+}
+
+# Exact uid expectations. `worker-uid` is the render that proves the gate reads
+# the per-Deployment context: web must stay 1001 while the worker moves to 1002.
+EXACT_UID = {
+    ("worker-uid", "web"): 1001,
+    ("worker-uid", "worker"): 1002,
+    ("blank-web-security", "web"): 1001,
+    ("root-web-security", "web"): 1001,
+    ("root-worker-security", "worker"): 1001,
+}
+
+NO_GATE_MODES = ("disabled", "legacy-disabled")
+
+
+def deployment_with_container(suffix, container_name):
     matches = []
     for doc in docs:
         if doc.get("kind") != "Deployment":
             continue
+        if not doc.get("metadata", {}).get("name", "").endswith(suffix):
+            continue
         containers = doc.get("spec", {}).get("template", {}).get("spec", {}).get("containers", [])
-        if any(container.get("name") == name for container in containers):
+        if any(container.get("name") == container_name for container in containers):
             matches.append(doc)
     if len(matches) != 1:
-        raise SystemExit(f"expected one Deployment containing {name}, got {len(matches)}")
+        raise SystemExit(
+            f"expected one Deployment ending in {suffix!r} containing {container_name!r}, got {len(matches)}"
+        )
     return matches[0]
 
-web = deployment_with_container("langfuse-web")
-worker = deployment_with_container("langfuse-worker")
-web_spec = web["spec"]["template"]["spec"]
-worker_spec = worker["spec"]["template"]["spec"]
-web_inits = web_spec.get("initContainers", [])
-worker_waits = [item for item in worker_spec.get("initContainers", []) if item.get("name") == "wait-for-postgres"]
-if worker_waits:
-    raise SystemExit("wait-for-postgres must be absent from the Langfuse worker Deployment")
 
-waits = [item for item in web_inits if item.get("name") == "wait-for-postgres"]
-if mode == "disabled":
+def check_absent(suffix, container_name):
+    spec = deployment_with_container(suffix, container_name)["spec"]["template"]["spec"]
+    inits = spec.get("initContainers", [])
+    waits = [item for item in inits if item.get("name") == "wait-for-postgres"]
     if waits:
-        raise SystemExit("wait-for-postgres rendered while postgresReadiness.enabled=false")
-    print("  ok: enabled=false removes the web readiness init and worker remains unchanged")
+        raise SystemExit(
+            f"{suffix}: wait-for-postgres rendered while the Postgres readiness gate is disabled "
+            f"(got initContainers {[item.get('name') for item in inits]})"
+        )
+    if mode == "both-disabled" and "initContainers" in spec:
+        raise SystemExit(
+            f"{suffix}: initContainers key still rendered with BOTH readiness gates disabled "
+            f"(got {[item.get('name') for item in inits]})"
+        )
+
+
+def check_gate(suffix, container_name, key):
+    dep = deployment_with_container(suffix, container_name)
+    spec = dep["spec"]["template"]["spec"]
+    inits = spec.get("initContainers", [])
+    names = [item.get("name") for item in inits]
+    waits = [item for item in inits if item.get("name") == "wait-for-postgres"]
+    if len(waits) != 1:
+        raise SystemExit(
+            f"{suffix}: expected exactly one wait-for-postgres init container, got {len(waits)} "
+            f"(initContainers {names}). The worker runs the same Prisma boot migrations against the "
+            f"same Postgres as the web pod, so it needs the same gate (#2330)"
+        )
+    wait = waits[0]
+    if not names or names[0] != "wait-for-postgres":
+        raise SystemExit(f"{suffix}: wait-for-postgres must be the FIRST init container, got {names}")
+    if "wait-for-clickhouse" in names and names.index("wait-for-postgres") > names.index("wait-for-clickhouse"):
+        raise SystemExit(
+            f"{suffix}: wait-for-postgres must precede wait-for-clickhouse, got {names}"
+        )
+    if wait.get("image") != expected_image:
+        raise SystemExit(
+            f"{suffix}: wait-for-postgres image is {wait.get('image')!r}, expected {expected_image!r}"
+        )
+
+    app = next(item for item in spec["containers"] if item.get("name") == container_name)
+    wait_sc = wait.get("securityContext") or {}
+    app_sc = app.get("securityContext") or {}
+    policy = SC_POLICY[mode][key]
+    if policy == "match" and wait_sc != app_sc:
+        raise SystemExit(
+            f"{suffix}: wait-for-postgres securityContext differs from {container_name}: "
+            f"{wait_sc!r} != {app_sc!r}"
+        )
+    uid = wait_sc.get("runAsUser")
+    if type(uid) is not int or uid < 1:
+        raise SystemExit(
+            f"{suffix}: wait-for-postgres runAsUser must be a numeric non-root uid, got {uid!r} (#351)"
+        )
+    if wait_sc.get("runAsNonRoot") is not True:
+        raise SystemExit(f"{suffix}: wait-for-postgres must retain runAsNonRoot=true")
+    expected_uid = EXACT_UID.get((mode, key))
+    if expected_uid is not None and uid != expected_uid:
+        raise SystemExit(
+            f"{suffix}: wait-for-postgres runAsUser is {uid!r}, expected {expected_uid!r} -- the gate "
+            f"must derive its securityContext from the {key} Deployment's own containerSecurityContext"
+        )
+    if policy == "floor-blank" and app_sc:
+        raise SystemExit(
+            f"{suffix}: expected a blank {container_name} securityContext in this render, got {app_sc!r}"
+        )
+    if policy == "floor-root" and (
+        app_sc.get("runAsUser") != 0 or app_sc.get("runAsNonRoot") is not False
+    ):
+        raise SystemExit(
+            f"{suffix}: expected a root {container_name} override in this render, got {app_sc!r}"
+        )
+
+    env_items = wait.get("env", [])
+    env = {item.get("name"): item for item in env_items}
+    expected_names = {
+        "POSTGRES_HOST",
+        "POSTGRES_PORT",
+        "POSTGRES_USER",
+        "POSTGRES_DATABASE",
+        "POSTGRES_READINESS_ATTEMPTS",
+        "POSTGRES_READINESS_INTERVAL_SECONDS",
+        "POSTGRES_READINESS_PROBE_TIMEOUT_SECONDS",
+    }
+    if set(env) != expected_names:
+        raise SystemExit(
+            f"{suffix}: wait-for-postgres env names are {sorted(env)}, expected {sorted(expected_names)}"
+        )
+    for name, item in env.items():
+        if "valueFrom" in item:
+            raise SystemExit(
+                f"{suffix}: credential-free readiness env {name} unexpectedly uses valueFrom"
+            )
+        upper = name.upper()
+        if any(token in upper for token in ("PASSWORD", "TOKEN", "SECRET", "CREDENTIAL")):
+            raise SystemExit(f"{suffix}: credential-like env {name} reached wait-for-postgres")
+
+    expected_tuning = {
+        "POSTGRES_READINESS_ATTEMPTS": attempts,
+        "POSTGRES_READINESS_INTERVAL_SECONDS": interval,
+        "POSTGRES_READINESS_PROBE_TIMEOUT_SECONDS": timeout,
+    }
+    for name, expected in expected_tuning.items():
+        actual = str(env[name].get("value"))
+        if actual != expected:
+            raise SystemExit(f"{suffix}: {name} rendered {actual!r}, expected {expected!r}")
+
+    command = "\n".join(str(part) for part in wait.get("command", []))
+    for needle in (
+        "pg_isready",
+        'while [ "$attempt" -le "$POSTGRES_READINESS_ATTEMPTS" ]',
+        "Postgres readiness exhausted",
+        "exit 1",
+    ):
+        if needle not in command:
+            raise SystemExit(
+                f"{suffix}: wait-for-postgres command is missing bounded-gate contract {needle!r}"
+            )
+
+
+if mode in NO_GATE_MODES or mode == "both-disabled":
+    for suffix, container_name, _key in DEPLOYMENTS:
+        check_absent(suffix, container_name)
+    print(f"  ok: {mode} removes the readiness init from BOTH Langfuse Deployments")
     raise SystemExit(0)
 
-if len(waits) != 1:
-    raise SystemExit(f"web must render exactly one wait-for-postgres init, got {len(waits)}")
-wait = waits[0]
-if not web_inits or web_inits[0].get("name") != "wait-for-postgres":
-    raise SystemExit("wait-for-postgres must be the first web init container")
-if wait.get("image") != expected_image:
-    raise SystemExit(f"wait-for-postgres image is {wait.get('image')!r}, expected {expected_image!r}")
-
-web_main = next(item for item in web_spec["containers"] if item.get("name") == "langfuse-web")
-wait_sc = wait.get("securityContext") or {}
-web_sc = web_main.get("securityContext") or {}
-if mode not in ("blank-security", "root-web-security") and wait_sc != web_sc:
-    raise SystemExit(f"wait-for-postgres securityContext differs from langfuse-web: {wait_sc!r} != {web_sc!r}")
-uid = wait_sc.get("runAsUser")
-if type(uid) is not int or uid < 1:
-    raise SystemExit(f"wait-for-postgres runAsUser must be a numeric non-root uid, got {uid!r}")
-if wait_sc.get("runAsNonRoot") is not True:
-    raise SystemExit("wait-for-postgres must retain runAsNonRoot=true")
-if mode == "blank-security" and (uid != 1001 or web_sc):
-    raise SystemExit(f"blank web securityContext must leave the init at its 1001 non-root floor, got wait={wait_sc!r} web={web_sc!r}")
-if mode == "root-web-security":
-    if uid != 1001 or web_sc.get("runAsUser") != 0 or web_sc.get("runAsNonRoot") is not False:
-        raise SystemExit(f"root web override must leave the readiness init at its 1001 non-root floor, got wait={wait_sc!r} web={web_sc!r}")
-
-env_items = wait.get("env", [])
-env = {item.get("name"): item for item in env_items}
-expected_names = {
-    "POSTGRES_HOST",
-    "POSTGRES_PORT",
-    "POSTGRES_USER",
-    "POSTGRES_DATABASE",
-    "POSTGRES_READINESS_ATTEMPTS",
-    "POSTGRES_READINESS_INTERVAL_SECONDS",
-    "POSTGRES_READINESS_PROBE_TIMEOUT_SECONDS",
-}
-if set(env) != expected_names:
-    raise SystemExit(f"wait-for-postgres env names are {sorted(env)}, expected {sorted(expected_names)}")
-for name, item in env.items():
-    if "valueFrom" in item:
-        raise SystemExit(f"credential-free readiness env {name} unexpectedly uses valueFrom")
-    upper = name.upper()
-    if any(token in upper for token in ("PASSWORD", "TOKEN", "SECRET", "CREDENTIAL")):
-        raise SystemExit(f"credential-like env {name} reached wait-for-postgres")
-
-expected_tuning = {
-    "POSTGRES_READINESS_ATTEMPTS": attempts,
-    "POSTGRES_READINESS_INTERVAL_SECONDS": interval,
-    "POSTGRES_READINESS_PROBE_TIMEOUT_SECONDS": timeout,
-}
-for name, expected in expected_tuning.items():
-    actual = str(env[name].get("value"))
-    if actual != expected:
-        raise SystemExit(f"{name} rendered {actual!r}, expected {expected!r}")
-
-command = "\n".join(str(part) for part in wait.get("command", []))
-for needle in ("pg_isready", 'while [ "$attempt" -le "$POSTGRES_READINESS_ATTEMPTS" ]', "Postgres readiness exhausted", "exit 1"):
-    if needle not in command:
-        raise SystemExit(f"wait-for-postgres command is missing bounded-gate contract {needle!r}")
-
-print(f"  ok: {mode} web init is first, credential-free, hardened, image={expected_image}, tuning={attempts}/{interval}/{timeout}")
+for suffix, container_name, key in DEPLOYMENTS:
+    check_gate(suffix, container_name, key)
+print(
+    f"  ok: {mode} both Deployments gate first on wait-for-postgres (before wait-for-clickhouse), "
+    f"credential-free, hardened per-Deployment, image={expected_image}, tuning={attempts}/{interval}/{timeout}"
+)
 PY
 
 python3 "$TMP/assert.py" "$TMP/default.yaml" default "$POSTGRES_IMAGE" 60 2 2
 python3 "$TMP/assert.py" "$TMP/tuned.yaml" tuned registry.example.com/postgres-readiness:test 7 3 4
-python3 "$TMP/assert.py" "$TMP/blank-security.yaml" blank-security "$POSTGRES_IMAGE" 60 2 2
+python3 "$TMP/assert.py" "$TMP/blank-web-security.yaml" blank-web-security "$POSTGRES_IMAGE" 60 2 2
 python3 "$TMP/assert.py" "$TMP/root-web-security.yaml" root-web-security "$POSTGRES_IMAGE" 60 2 2
+python3 "$TMP/assert.py" "$TMP/worker-uid.yaml" worker-uid "$POSTGRES_IMAGE" 60 2 2
+python3 "$TMP/assert.py" "$TMP/root-worker-security.yaml" root-worker-security "$POSTGRES_IMAGE" 60 2 2
 python3 "$TMP/assert.py" "$TMP/disabled.yaml" disabled ignored 0 0 0
+python3 "$TMP/assert.py" "$TMP/both-disabled.yaml" both-disabled ignored 0 0 0
 
+# AC4 -- the deprecated `langfuse.web.postgresReadiness` alias. Both of these
+# renders must SUCCEED and must reach BOTH Deployments; a legacy value that
+# silently stayed web-only would leave the worker ungated (or, worse, gated
+# after an operator had explicitly turned the gate off).
+python3 "$TMP/assert.py" "$TMP/legacy-disabled.yaml" legacy-disabled ignored 0 0 0
+python3 "$TMP/assert.py" "$TMP/legacy-tuned.yaml" legacy-tuned "$POSTGRES_IMAGE" 7 2 2
+python3 "$TMP/assert.py" "$TMP/canonical-tuned.yaml" canonical-tuned "$POSTGRES_IMAGE" 7 2 2
+echo "  ok: the deprecated langfuse.web.postgresReadiness alias reaches BOTH Deployments and merges over the canonical defaults"
+
+# The validation `fail` names the key path the OPERATOR used, so the grep has to
+# move with it: a single hardcoded string would silently pass against the wrong
+# message for one of the two paths.
 assert_refused() {
-  local field="$1" flag="$2" value="$3" output rc
+  local keypath="$1" field="$2" flag="$3" value="$4" output rc
   set +e
   output="$(helm template curie "$CHART" --show-only templates/langfuse.yaml \
-    "$flag" "langfuse.web.postgresReadiness.${field}=${value}" 2>&1)"
+    "$flag" "${keypath}.${field}=${value}" 2>&1)"
   rc=$?
   set -e
-  [[ "$rc" -ne 0 ]] || fail "invalid ${field}=${value} rendered successfully"
-  [[ "$output" == *"langfuse.web.postgresReadiness.${field}"* ]] || \
-    fail "invalid ${field}=${value} failed without naming the knob: $output"
+  [[ "$rc" -ne 0 ]] || fail "invalid ${keypath}.${field}=${value} rendered successfully"
+  [[ "$output" == *"${keypath}.${field}"* ]] || \
+    fail "invalid ${keypath}.${field}=${value} failed without naming the knob the operator set: $output"
 }
 
 for field in attempts intervalSeconds probeTimeoutSeconds; do
-  assert_refused "$field" --set 0
-  assert_refused "$field" --set -1
-  assert_refused "$field" --set-json 2.5
+  assert_refused langfuse.postgresReadiness "$field" --set 0
+  assert_refused langfuse.postgresReadiness "$field" --set -1
+  assert_refused langfuse.postgresReadiness "$field" --set-json 2.5
 done
 echo "  ok: every bounded tuning knob rejects zero, negative, and fractional values"
 
-# Red-on-revert control: remove the init from a real default render, then prove
-# the same consumer assertion rejects it for the intended reason.
-python3 - "$TMP/default.yaml" "$TMP/missing-init.yaml" <<'PY'
+for field in attempts intervalSeconds probeTimeoutSeconds; do
+  assert_refused langfuse.web.postgresReadiness "$field" --set 0
+  assert_refused langfuse.web.postgresReadiness "$field" --set -1
+  assert_refused langfuse.web.postgresReadiness "$field" --set-json 2.5
+done
+echo "  ok: an invalid value supplied through the deprecated alias is refused, naming the alias path"
+
+# Red-on-revert controls: remove the init from a real default render, then prove
+# the same consumer assertion rejects it for the intended reason. Each control
+# is armed ONCE PER DEPLOYMENT -- a mutant that only strips the web init stays
+# green against a worker-only regression, which is #2330 itself.
+cat >"$TMP/strip-init.py" <<'PY'
 import sys
 import yaml
 
-source, target = sys.argv[1:]
+source, target, container_name = sys.argv[1:]
 docs = [doc for doc in yaml.safe_load_all(open(source)) if doc]
+mutated = False
 for doc in docs:
     if doc.get("kind") != "Deployment":
         continue
     spec = doc.get("spec", {}).get("template", {}).get("spec", {})
-    if any(item.get("name") == "langfuse-web" for item in spec.get("containers", [])):
+    if any(item.get("name") == container_name for item in spec.get("containers", [])):
         spec["initContainers"] = [
             item for item in spec.get("initContainers", [])
             if item.get("name") != "wait-for-postgres"
         ]
+        mutated = True
+if not mutated:
+    raise SystemExit(f"no Deployment containing {container_name!r} to mutate")
 with open(target, "w") as output:
     yaml.safe_dump_all(docs, output)
 PY
 
-set +e
-negative_output="$(python3 "$TMP/assert.py" "$TMP/missing-init.yaml" negative "$POSTGRES_IMAGE" 60 2 2 2>&1)"
-negative_rc=$?
-set -e
-[[ "$negative_rc" -ne 0 ]] || fail "negative control passed after wait-for-postgres was removed"
-[[ "$negative_output" == *"wait-for-postgres"* ]] || fail "negative control failed for an unrelated reason: $negative_output"
-echo "  ok: removing the rendered web readiness init is rejected"
-
-python3 - "$TMP/default.yaml" "$TMP/unbounded-init.yaml" <<'PY'
+cat >"$TMP/unbound-init.py" <<'PY'
 import sys
 import yaml
 
-source, target = sys.argv[1:]
+source, target, container_name = sys.argv[1:]
 docs = [doc for doc in yaml.safe_load_all(open(source)) if doc]
+mutated = False
 for doc in docs:
     if doc.get("kind") != "Deployment":
         continue
     spec = doc.get("spec", {}).get("template", {}).get("spec", {})
+    if not any(item.get("name") == container_name for item in spec.get("containers", [])):
+        continue
     for item in spec.get("initContainers", []):
         if item.get("name") == "wait-for-postgres":
             item["command"][-1] = item["command"][-1].replace(
                 'while [ "$attempt" -le "$POSTGRES_READINESS_ATTEMPTS" ]; do',
                 "while true; do",
             )
+            mutated = True
+if not mutated:
+    raise SystemExit(f"no wait-for-postgres under {container_name!r} to mutate")
 with open(target, "w") as output:
     yaml.safe_dump_all(docs, output)
 PY
 
-set +e
-negative_output="$(python3 "$TMP/assert.py" "$TMP/unbounded-init.yaml" negative "$POSTGRES_IMAGE" 60 2 2 2>&1)"
-negative_rc=$?
-set -e
-[[ "$negative_rc" -ne 0 ]] || fail "negative control passed after the readiness loop was made unbounded"
-[[ "$negative_output" == *"bounded-gate contract"* ]] || fail "unbounded-loop control failed for an unrelated reason: $negative_output"
-echo "  ok: stripping the loop bound from the rendered init is rejected"
+assert_mutant_rejected() {
+  local label="$1" mutant="$2" suffix="$3" needle="$4" output rc
+  set +e
+  output="$(python3 "$TMP/assert.py" "$mutant" default "$POSTGRES_IMAGE" 60 2 2 2>&1)"
+  rc=$?
+  set -e
+  [[ "$rc" -ne 0 ]] || fail "negative control passed: $label"
+  [[ "$output" == *"$needle"* ]] || fail "$label was rejected for an unrelated reason: $output"
+  [[ "$output" == *"$suffix"* ]] || fail "$label was rejected without naming $suffix: $output"
+}
 
-echo "PASS: Langfuse web Postgres readiness render contract and red negative control"
+for target in "langfuse-web:-langfuse-web" "langfuse-worker:-langfuse-worker"; do
+  container_name="${target%%:*}"
+  suffix="${target##*:}"
+  python3 "$TMP/strip-init.py" "$TMP/default.yaml" "$TMP/missing-init-$container_name.yaml" "$container_name"
+  assert_mutant_rejected "removing wait-for-postgres from $container_name" \
+    "$TMP/missing-init-$container_name.yaml" "$suffix" "wait-for-postgres"
+  echo "  ok: removing the rendered readiness init from $suffix is rejected"
+
+  python3 "$TMP/unbound-init.py" "$TMP/default.yaml" "$TMP/unbounded-init-$container_name.yaml" "$container_name"
+  assert_mutant_rejected "unbounding the readiness loop on $container_name" \
+    "$TMP/unbounded-init-$container_name.yaml" "$suffix" "bounded-gate contract"
+  echo "  ok: stripping the loop bound from the rendered init on $suffix is rejected"
+done
+
+echo "PASS: Langfuse web AND worker Postgres readiness render contract, the deprecated langfuse.web.postgresReadiness alias, and per-Deployment red negative controls (#1853, #2330)"

--- a/charts/curie/ci/langfuse-worker-probe-assertions.sh
+++ b/charts/curie/ci/langfuse-worker-probe-assertions.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+#
+# Render contract for the langfuse-worker Deployment's probes (#71, #2330).
+#
+# #71 ("K8s: add liveness probes -- worker and dispatcher have none at all")
+# closed on the criterion that *every* Deployment with a persistent process
+# carries both a readiness and a liveness probe. `langfuse-worker` was the
+# remaining violation: its container block ended at `resources:` with no probe
+# key at all, so Kubernetes reported `ready: true` the instant the process
+# started, `Deployment.Available` stayed true against a wedged worker, and
+# `kubectl rollout status` / `helm --wait` succeeded immediately. That is the
+# second, independent defect #2330 names (the first -- the missing
+# `wait-for-postgres` gate, sibling of #1853/#2009 -- is pinned by
+# langfuse-postgres-readiness-assertions.sh).
+#
+# The probes' proof surface is the RENDER, not a cluster. With no readinessProbe
+# the runtime `WORKER_READY == true` check passes identically before and after
+# the change (`minReadySeconds` defaults to 0), so only these assertions can
+# falsify the probe contract.
+#
+# WHY readiness is `/api/ready` and liveness is `tcpSocket`, not an HTTP path:
+#
+#   From the pinned image `langfuse/langfuse-worker:3.225.5`, both `GET
+#   /api/health` and `GET /api/ready` call `checkContainerHealth`, which runs a
+#   Prisma `SELECT 1` AND a Redis ping; they differ ONLY in `failOnSigterm`.
+#
+#   * Readiness -> `/api/ready` (failOnSigterm: true). It exercises the event
+#     loop and the stores, and it returns 500 during shutdown so a terminating
+#     pod drains. `/api/health` as readiness would keep a terminating pod in
+#     service.
+#   * Liveness -> `tcpSocket:3030`. An HTTP liveness probe on either endpoint
+#     couples the worker's LIFE to Postgres and Valkey. The worker is
+#     `replicas: 1` with `strategy: Recreate` and runs Prisma/ClickHouse boot
+#     migrations at container start, and init containers do NOT re-run on a
+#     liveness restart. So a store blip of roughly two minutes
+#     (`failureThreshold: 6` x `periodSeconds: 20`) would kill the only replica
+#     and restart it straight into boot migrations against a sick Postgres --
+#     reproducing the exact Prisma `P1001` / `BackOff` class this ticket exists
+#     to stop, with the readiness gate powerless to help. Chart precedent is
+#     against dependency-coupled liveness (`mail-adapter.yaml` splits a static
+#     `/healthz` from a store-waiting `/readyz`; the API's `/health` touches no
+#     DB; `inference.yaml` uses `tcpSocket`); `langfuse-web` probing
+#     `/api/public/health` for both is the exception, not the pattern.
+#
+#   ACCEPTED TRADE-OFF: `tcpSocket` will not catch a fully wedged Node event
+#   loop -- the kernel still accepts on the listen backlog. Detection of that
+#   rides on the READINESS probe, which does exercise the event loop and flips
+#   `Deployment.Available`. Restart-on-hard-hang (process alive, not listening)
+#   is liveness's only job here, deliberately.
+#
+# `timeoutSeconds` is asserted BY NAME on both probes: the kubelet default is
+# 1s, and `langfuse-web`'s block (the obvious thing to copy) omits the key. A
+# 1s timeout against an endpoint that runs a Prisma query plus a Redis ping is
+# a restart loop waiting to happen.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART="$(cd "$SCRIPT_DIR/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+if ! helm template curie "$CHART" --show-only templates/langfuse.yaml >"$TMP/default.yaml"; then
+  fail "default render failed"
+fi
+
+cat >"$TMP/assert.py" <<'PY'
+import sys
+import yaml
+
+path = sys.argv[1]
+docs = [doc for doc in yaml.safe_load_all(open(path)) if doc]
+
+CONTAINER = "langfuse-worker"
+SUFFIX = "-langfuse-worker"
+
+matches = [
+    doc
+    for doc in docs
+    if doc.get("kind") == "Deployment"
+    and doc.get("metadata", {}).get("name", "").endswith(SUFFIX)
+]
+if len(matches) != 1:
+    raise SystemExit(f"expected exactly one Deployment ending in {SUFFIX!r}, got {len(matches)}")
+spec = matches[0]["spec"]["template"]["spec"]
+worker = next((c for c in spec.get("containers", []) if c.get("name") == CONTAINER), None)
+if worker is None:
+    raise SystemExit(f"no {CONTAINER!r} container in the {SUFFIX} Deployment")
+
+ports = worker.get("ports") or []
+declared = [p.get("containerPort") for p in ports]
+if 3030 not in declared:
+    raise SystemExit(f"{CONTAINER} must declare containerPort 3030, got {declared}")
+print("  ok: langfuse-worker declares containerPort 3030")
+
+readiness = worker.get("readinessProbe")
+liveness = worker.get("livenessProbe")
+if readiness is None:
+    raise SystemExit(
+        f"{CONTAINER} has NO readinessProbe. Without one Kubernetes reports ready:true as soon as "
+        f"the process starts, so Deployment.Available and `kubectl rollout status` report a wedged "
+        f"worker as healthy -- the #71 criterion this Deployment was the last to violate (#2330)"
+    )
+if liveness is None:
+    raise SystemExit(
+        f"{CONTAINER} has NO livenessProbe. A worker whose process is alive but no longer listening "
+        f"is never restarted; #71 requires both a readiness AND a liveness probe on every Deployment "
+        f"running a persistent process (#2330)"
+    )
+print("  ok: langfuse-worker carries BOTH a readinessProbe and a livenessProbe (#71)")
+
+# ------------------------------------------------------------------- readiness
+http = readiness.get("httpGet")
+if not http:
+    raise SystemExit(
+        f"readinessProbe must be an httpGet on /api/ready: it is the endpoint that actually "
+        f"exercises the event loop and the stores, got {sorted(readiness)}"
+    )
+if http.get("path") != "/api/ready":
+    raise SystemExit(
+        f"readinessProbe httpGet.path is {http.get('path')!r}, expected '/api/ready'. Only "
+        f"/api/ready sets failOnSigterm, so it is the endpoint that returns 500 during shutdown and "
+        f"lets a terminating pod drain; /api/health as readiness would keep a terminating pod in "
+        f"service"
+    )
+if http.get("port") != 3030:
+    raise SystemExit(
+        f"readinessProbe httpGet.port is {http.get('port')!r}, expected the declared containerPort 3030"
+    )
+print("  ok: readinessProbe is httpGet /api/ready on port 3030 (SIGTERM-aware, so a terminating pod drains)")
+
+# -------------------------------------------------------------------- liveness
+if "httpGet" in liveness:
+    raise SystemExit(
+        f"livenessProbe must NOT use httpGet (got {liveness['httpGet']!r}). Both /api/health and "
+        f"/api/ready run a Prisma SELECT 1 and a Redis ping, so an HTTP liveness probe couples the "
+        f"worker's LIFE to Postgres and Valkey. The worker is replicas:1 + Recreate and runs boot "
+        f"migrations at container start, and init containers do NOT re-run on a liveness restart -- "
+        f"so a ~2 minute store blip would restart the single replica straight into boot migrations "
+        f"against a sick Postgres, which is the exact P1001/BackOff class #2330 exists to stop. Use "
+        f"tcpSocket:3030"
+    )
+tcp = liveness.get("tcpSocket")
+if not tcp:
+    raise SystemExit(
+        f"livenessProbe must be tcpSocket:3030 -- the only liveness signal the worker image offers "
+        f"that does not couple to Postgres and Valkey (got {sorted(liveness)})"
+    )
+if tcp.get("port") != 3030:
+    raise SystemExit(
+        f"livenessProbe tcpSocket.port is {tcp.get('port')!r}, expected the declared containerPort 3030"
+    )
+print("  ok: livenessProbe is tcpSocket:3030 with no httpGet -- a store blip cannot restart the single replica")
+
+# --------------------------------------------------------------------- cadence
+EXPECTED = {
+    "readinessProbe": (readiness, {
+        "initialDelaySeconds": 20,
+        "periodSeconds": 10,
+        "timeoutSeconds": 5,
+        "failureThreshold": 30,
+    }),
+    "livenessProbe": (liveness, {
+        "initialDelaySeconds": 90,
+        "periodSeconds": 20,
+        "timeoutSeconds": 5,
+        "failureThreshold": 6,
+    }),
+}
+for probe_name, (probe, expected) in EXPECTED.items():
+    for field, value in expected.items():
+        if field not in probe:
+            reason = ""
+            if field == "timeoutSeconds":
+                reason = (
+                    " -- the kubelet default is 1s, and langfuse-web's block (the obvious thing to "
+                    "copy) omits the key; 1s against an endpoint running a Prisma query plus a Redis "
+                    "ping is a restart loop"
+                )
+            raise SystemExit(
+                f"{probe_name} does not declare {field} explicitly{reason}"
+            )
+        if probe[field] != value:
+            raise SystemExit(
+                f"{probe_name}.{field} is {probe[field]!r}, expected {value!r}"
+            )
+print("  ok: readiness cadence 20/10/5/30 and liveness cadence 90/20/5/6, both with an explicit timeoutSeconds")
+PY
+
+python3 "$TMP/assert.py" "$TMP/default.yaml"
+
+# --------------------------------------------------------------- red controls
+# Each control mutates a REAL default render and proves the assertion rejects it
+# for the INTENDED reason, not an incidental KeyError.
+cat >"$TMP/mutate.py" <<'PY'
+import sys
+import yaml
+
+source, target, mutation = sys.argv[1:]
+docs = [doc for doc in yaml.safe_load_all(open(source)) if doc]
+worker = None
+for doc in docs:
+    if doc.get("kind") != "Deployment":
+        continue
+    for container in doc.get("spec", {}).get("template", {}).get("spec", {}).get("containers", []):
+        if container.get("name") == "langfuse-worker":
+            worker = container
+if worker is None:
+    raise SystemExit("no langfuse-worker container to mutate")
+
+if mutation == "drop-readiness":
+    worker.pop("readinessProbe", None)
+elif mutation == "drop-liveness":
+    worker.pop("livenessProbe", None)
+elif mutation == "liveness-http-health":
+    worker["livenessProbe"] = {
+        "httpGet": {"path": "/api/health", "port": 3030},
+        "initialDelaySeconds": 90,
+        "periodSeconds": 20,
+        "timeoutSeconds": 5,
+        "failureThreshold": 6,
+    }
+elif mutation == "readiness-health":
+    worker.setdefault("readinessProbe", {}).setdefault("httpGet", {})["path"] = "/api/health"
+elif mutation == "drop-liveness-timeout":
+    worker.get("livenessProbe", {}).pop("timeoutSeconds", None)
+else:
+    raise SystemExit(f"unknown mutation {mutation!r}")
+
+with open(target, "w") as output:
+    yaml.safe_dump_all(docs, output)
+PY
+
+assert_rejected() {
+  local mutation="$1" needle="$2" label="$3" output rc
+  python3 "$TMP/mutate.py" "$TMP/default.yaml" "$TMP/$mutation.yaml" "$mutation"
+  set +e
+  output="$(python3 "$TMP/assert.py" "$TMP/$mutation.yaml" 2>&1)"
+  rc=$?
+  set -e
+  [[ "$rc" -ne 0 ]] || fail "negative control passed: $label"
+  [[ "$output" == *"$needle"* ]] || fail "$label was rejected for an unrelated reason: $output"
+  echo "  ok: $label is rejected"
+}
+
+assert_rejected drop-readiness "NO readinessProbe" "removing the readinessProbe"
+assert_rejected drop-liveness "NO livenessProbe" "removing the livenessProbe"
+assert_rejected liveness-http-health "must NOT use httpGet" \
+  "swapping liveness to httpGet /api/health (a store-coupled probe that restarts the single replica on a Postgres or Valkey blip)"
+assert_rejected readiness-health "keep a terminating pod in service" \
+  "swapping readiness to /api/health"
+assert_rejected drop-liveness-timeout "livenessProbe does not declare timeoutSeconds explicitly" \
+  "dropping the explicit livenessProbe timeoutSeconds (kubelet would default it to 1s)"
+
+echo "PASS: langfuse-worker carries a readiness AND a liveness probe on its :3030 endpoint -- httpGet /api/ready for readiness so a terminating pod drains, tcpSocket for liveness so a store blip cannot restart the single replica into its boot migrations (#71, #2330)"

--- a/charts/curie/ci/runtime/langfuse-postgres-readiness-runtime.sh
+++ b/charts/curie/ci/runtime/langfuse-postgres-readiness-runtime.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
-# Runtime regression for #1853. It lives below charts/curie/ci/runtime because
+# Runtime regression for #1853 and #2330. It proves on a live cluster that BOTH
+# Langfuse Deployments -- langfuse-web (#1853) and langfuse-worker (#2330) --
+# hold behind the shared wait-for-postgres gate while Postgres is unavailable,
+# and that both recover cleanly once it is ready. It lives below
+# charts/curie/ci/runtime because
 # chart-check discovers only top-level assertion scripts, while this script
 # creates and removes a real Helm release. Its nested chart-CI path still lets
 # curie dev verify-fix-pin route it as a chart runtime selector.
@@ -152,16 +156,20 @@ component_deployment() {
   fi
 }
 
+# pod_snapshot <pod> <app-container-name>
+# The application container name is a parameter so the same reader serves both
+# Langfuse Deployments: langfuse-web (#1853) and langfuse-worker (#2330).
 pod_snapshot() {
-  local pod="$1" pod_json
+  local pod="$1" app_container="$2" pod_json
   if ! pod_json="$(kubectl get pod "$pod" -n "$NAMESPACE" -o json)"; then
     echo "kubectl failed fetching pod snapshot for $NAMESPACE/$pod" >&2
     return 2
   fi
-  printf '%s' "$pod_json" | python3 /dev/fd/3 3<<'PY'
+  printf '%s' "$pod_json" | python3 /dev/fd/3 "$app_container" 3<<'PY'
 import json
 import sys
 
+app_container = sys.argv[1]
 pod = json.load(sys.stdin)
 spec = pod.get("spec", {})
 status = pod.get("status", {})
@@ -178,18 +186,18 @@ init_names = {item.get("name") for item in spec.get("initContainers", [])}
 init_restart, init_state, init_exit, _ = container_status(
     status.get("initContainerStatuses"), "wait-for-postgres"
 )
-web_restart, web_state, web_exit, web_ready = container_status(
-    status.get("containerStatuses"), "langfuse-web"
+app_restart, app_state, app_exit, app_ready = container_status(
+    status.get("containerStatuses"), app_container
 )
 fields = [
     "yes" if "wait-for-postgres" in init_names else "no",
     init_restart,
     init_state,
     init_exit,
-    web_restart,
-    web_state,
-    web_exit,
-    web_ready,
+    app_restart,
+    app_state,
+    app_exit,
+    app_ready,
 ]
 print("|".join(fields))
 PY
@@ -197,11 +205,21 @@ PY
 
 read_snapshot() {
   local pod="$1" snapshot
-  if ! snapshot="$(pod_snapshot "$pod")"; then
+  if ! snapshot="$(pod_snapshot "$pod" langfuse-web)"; then
     fail "could not read pod status for $NAMESPACE/$pod"
   fi
   IFS='|' read -r INIT_PRESENT INIT_RESTART INIT_STATE INIT_EXIT \
     WEB_RESTART WEB_STATE WEB_EXIT WEB_READY <<<"$snapshot"
+}
+
+read_worker_snapshot() {
+  local pod="$1" snapshot
+  if ! snapshot="$(pod_snapshot "$pod" langfuse-worker)"; then
+    fail "could not read Langfuse worker pod status for $NAMESPACE/$pod"
+  fi
+  # shellcheck disable=SC2034  # WORKER_EXIT mirrors read_snapshot's field list and is read by diagnostics/debugging
+  IFS='|' read -r WORKER_INIT_PRESENT WORKER_INIT_RESTART WORKER_INIT_STATE WORKER_INIT_EXIT \
+    WORKER_RESTART WORKER_STATE WORKER_EXIT WORKER_READY <<<"$snapshot"
 }
 
 pod_ready() {
@@ -261,7 +279,11 @@ diagnostics() {
     safe_pod_logs "$pod" wait-for-postgres
   }
   pod="$(component_pod langfuse-worker | cut -d'|' -f1 || true)"
-  [[ -z "$pod" ]] || safe_pod_logs "$pod" langfuse-worker
+  [[ -z "$pod" ]] || {
+    kubectl describe pod "$pod" -n "$NAMESPACE" 2>&1 | sanitize || true
+    safe_pod_logs "$pod" langfuse-worker
+    safe_pod_logs "$pod" wait-for-postgres
+  }
 }
 
 cleanup() {
@@ -354,49 +376,86 @@ HELM_INSTALL_PID=$!
 WEB_REF="$(wait_for_component_pod langfuse-web "" 300)" || fail "Langfuse web pod was not created"
 WEB_POD="${WEB_REF%%|*}"
 WEB_UID="${WEB_REF#*|}"
+# The worker gets its OWN warm-up rather than a share of the web pod's, so a
+# worker Deployment that is scheduled late does not eat the pre-ready sampling
+# budget below and turn a healthy run red as a flake.
+WORKER_POD_WAIT_SECONDS=300
+WORKER_REF="$(wait_for_component_pod langfuse-worker "" "$WORKER_POD_WAIT_SECONDS")" || \
+  fail "Langfuse worker pod never appeared within ${WORKER_POD_WAIT_SECONDS}s (pod was never created; this is infrastructure, not the #2330 gate regression)"
+WORKER_POD="${WORKER_REF%%|*}"
+WORKER_UID="${WORKER_REF#*|}"
 POSTGRES_REF="$(wait_for_component_pod postgres "" 180)" || fail "Postgres pod was not created"
 POSTGRES_POD="${POSTGRES_REF%%|*}"
 
-banner "ASSERT bounded gate is running while Postgres is unavailable"
+banner "ASSERT bounded gate is running on BOTH Langfuse Deployments while Postgres is unavailable"
 waited=0
 while (( waited < 180 )); do
   read_snapshot "$WEB_POD"
+  read_worker_snapshot "$WORKER_POD"
   if [[ "$INIT_PRESENT" == "no" ]]; then
     fail "live Langfuse web pod has no wait-for-postgres init container"
   fi
-  if [[ "$INIT_STATE" == "running" && "$(pod_ready "$POSTGRES_POD")" != "True" ]]; then
+  if [[ "$WORKER_INIT_PRESENT" == "no" ]]; then
+    fail "live Langfuse worker pod has no wait-for-postgres init container -- #2330 regression"
+  fi
+  if [[ "$INIT_STATE" == "running" && "$WORKER_INIT_STATE" == "running" && \
+        "$(pod_ready "$POSTGRES_POD")" != "True" ]]; then
     break
   fi
   sleep "$POLL_SECONDS"
   waited=$((waited + POLL_SECONDS))
 done
-[[ "$INIT_STATE" == "running" ]] || fail "wait-for-postgres never reached Running before Postgres readiness"
+[[ "$INIT_STATE" == "running" ]] || fail "wait-for-postgres never reached Running on the Langfuse web pod before Postgres readiness"
+[[ "$WORKER_INIT_STATE" == "running" ]] || \
+  fail "Langfuse worker did not hold behind the wait-for-postgres gate: its init container never reached Running before Postgres readiness (state=$WORKER_INIT_STATE) -- #2330 regression"
 [[ "$(pod_ready "$POSTGRES_POD")" != "True" ]] || fail "delayed fixture became ready before the observation window"
 
 MIN_PRE_READY_SAMPLES=3
 PRE_READY_SAMPLES=0
+WORKER_PRE_READY_SAMPLES=0
+# Two counters and two deadlines: the worker's sampling budget is tracked
+# independently of the web pod's so that a slow start on either Deployment is
+# reported as its own failure instead of silently consuming the other's window.
 OBSERVE_STARTED=$SECONDS
-while (( PRE_READY_SAMPLES < MIN_PRE_READY_SAMPLES )); do
-  (( SECONDS - OBSERVE_STARTED < OBSERVE_SECONDS )) || \
-    fail "pre-ready sampling exceeded ${OBSERVE_SECONDS}s after $PRE_READY_SAMPLES samples"
+WORKER_OBSERVE_STARTED=$SECONDS
+while (( PRE_READY_SAMPLES < MIN_PRE_READY_SAMPLES || WORKER_PRE_READY_SAMPLES < MIN_PRE_READY_SAMPLES )); do
+  (( PRE_READY_SAMPLES >= MIN_PRE_READY_SAMPLES || SECONDS - OBSERVE_STARTED < OBSERVE_SECONDS )) || \
+    fail "Langfuse web pre-ready sampling exceeded ${OBSERVE_SECONDS}s after $PRE_READY_SAMPLES samples"
+  (( WORKER_PRE_READY_SAMPLES >= MIN_PRE_READY_SAMPLES || SECONDS - WORKER_OBSERVE_STARTED < OBSERVE_SECONDS )) || \
+    fail "Langfuse worker pre-ready sampling exceeded ${OBSERVE_SECONDS}s after $WORKER_PRE_READY_SAMPLES samples"
   current_ref="$(component_pod langfuse-web)"
   [[ "${current_ref#*|}" == "$WEB_UID" ]] || fail "Langfuse web pod was replaced before Postgres readiness"
+  current_ref="$(component_pod langfuse-worker)"
+  [[ "${current_ref#*|}" == "$WORKER_UID" ]] || fail "Langfuse worker pod was replaced before Postgres readiness"
   if [[ "$(pod_ready "$POSTGRES_POD")" == "True" ]]; then
-    fail "delayed fixture became ready after only $PRE_READY_SAMPLES pre-ready samples"
+    fail "delayed fixture became ready after only $PRE_READY_SAMPLES web / $WORKER_PRE_READY_SAMPLES worker pre-ready samples"
   fi
   read_snapshot "$WEB_POD"
   [[ "$INIT_PRESENT" == "yes" && "$INIT_STATE" == "running" ]] || fail "readiness init stopped waiting before Postgres was ready"
   [[ "${INIT_RESTART:-0}" == "0" ]] || fail "readiness init restarted before Postgres readiness"
   [[ "${WEB_RESTART:-0}" == "0" ]] || fail "Langfuse web restarted before Postgres readiness"
   [[ "$WEB_STATE" == "waiting" || "$WEB_STATE" == "missing" ]] || fail "Langfuse web started before its readiness init completed"
-  PRE_READY_SAMPLES=$((PRE_READY_SAMPLES + 1))
-  echo "pre-ready sample $PRE_READY_SAMPLES: init=running initRestarts=0 web=${WEB_STATE} webRestarts=0"
+  read_worker_snapshot "$WORKER_POD"
+  [[ "$WORKER_INIT_PRESENT" == "yes" && "$WORKER_INIT_STATE" == "running" ]] || \
+    fail "Langfuse worker did not hold behind the wait-for-postgres gate: init present=$WORKER_INIT_PRESENT state=$WORKER_INIT_STATE before Postgres was ready -- #2330 regression"
+  [[ "${WORKER_INIT_RESTART:-0}" == "0" ]] || fail "Langfuse worker readiness init restarted before Postgres readiness"
+  [[ "${WORKER_RESTART:-0}" == "0" ]] || fail "langfuse-worker restarted before Postgres readiness"
+  [[ "$WORKER_STATE" == "waiting" || "$WORKER_STATE" == "missing" ]] || \
+    fail "langfuse-worker started before its readiness init completed (state=$WORKER_STATE) -- #2330 regression"
   if (( PRE_READY_SAMPLES < MIN_PRE_READY_SAMPLES )); then
+    PRE_READY_SAMPLES=$((PRE_READY_SAMPLES + 1))
+  fi
+  if (( WORKER_PRE_READY_SAMPLES < MIN_PRE_READY_SAMPLES )); then
+    WORKER_PRE_READY_SAMPLES=$((WORKER_PRE_READY_SAMPLES + 1))
+  fi
+  echo "pre-ready sample web=$PRE_READY_SAMPLES worker=$WORKER_PRE_READY_SAMPLES: webInit=${INIT_STATE} webInitRestarts=${INIT_RESTART:-0} web=${WEB_STATE} webRestarts=${WEB_RESTART:-0} workerInit=${WORKER_INIT_STATE} workerInitRestarts=${WORKER_INIT_RESTART:-0} worker=${WORKER_STATE} workerRestarts=${WORKER_RESTART:-0}"
+  if (( PRE_READY_SAMPLES < MIN_PRE_READY_SAMPLES || WORKER_PRE_READY_SAMPLES < MIN_PRE_READY_SAMPLES )); then
     sleep "$POLL_SECONDS"
   fi
 done
 assert_no_backoff "$WEB_POD"
-echo "pre-ready observation: samples=$PRE_READY_SAMPLES BackOff=0"
+assert_no_backoff "$WORKER_POD"
+echo "pre-ready observation: webSamples=$PRE_READY_SAMPLES workerSamples=$WORKER_PRE_READY_SAMPLES BackOff=0 on both pods"
 
 if ! wait "$HELM_INSTALL_PID"; then
   tail -120 "$HELM_INSTALL_LOG" | sanitize >&2
@@ -425,13 +484,85 @@ read_snapshot "$WEB_POD"
 assert_no_backoff "$WEB_POD"
 echo "positive: postgres=Ready postgresRestarts=0 initExit=0 initRestarts=0 web=Ready webRestarts=0 BackOff=0"
 
-WORKER_REF="$(component_pod langfuse-worker || true)"
-if [[ "$WORKER_REF" == *"|"* ]]; then
-  WORKER_POD="${WORKER_REF%%|*}"
-  WORKER_RESTART="$(kubectl get pod "$WORKER_POD" -n "$NAMESPACE" -o jsonpath='{.status.containerStatuses[?(@.name=="langfuse-worker")].restartCount}' 2>/dev/null || true)"
-  WORKER_REASON="$(kubectl get pod "$WORKER_POD" -n "$NAMESPACE" -o jsonpath='{.status.containerStatuses[?(@.name=="langfuse-worker")].state.waiting.reason}' 2>/dev/null || true)"
-  echo "informational sibling: langfuse-worker restarts=${WORKER_RESTART:-unknown} waitingReason=${WORKER_REASON:-none}"
-fi
+banner "WAIT for Langfuse worker readiness"
+WORKER_DEPLOYMENT="$(component_deployment "$WORKER_POD")"
+[[ -n "$WORKER_DEPLOYMENT" ]] || fail "Langfuse worker Deployment not found"
+kubectl rollout status deployment/"$WORKER_DEPLOYMENT" -n "$NAMESPACE" --timeout=360s
+current_ref="$(component_pod langfuse-worker)"
+[[ "${current_ref#*|}" == "$WORKER_UID" ]] || fail "Langfuse worker pod was replaced while recovering"
+read_worker_snapshot "$WORKER_POD"
+[[ "$WORKER_INIT_STATE" == "terminated" && "$WORKER_INIT_EXIT" == "0" && "${WORKER_INIT_RESTART:-0}" == "0" ]] || \
+  fail "Langfuse worker readiness init did not complete once with exit 0 (state=$WORKER_INIT_STATE exit=$WORKER_INIT_EXIT restarts=${WORKER_INIT_RESTART:-0})"
+# WORKER_READY is a gate-completed-cleanly assertion, NOT a proof of the probes.
+# With no readinessProbe at all Kubernetes reports ready: true the instant the
+# process starts and `kubectl rollout status` succeeds (minReadySeconds defaults
+# to 0), so this check passes identically before and after #2330's probe change
+# and falsifies nothing about the probes. The discriminating runtime assertion
+# is the Deployment read-back below; the probes' semantic contract is pinned at
+# the render surface by ci/langfuse-worker-probe-assertions.sh.
+[[ "$WORKER_READY" == "true" && "${WORKER_RESTART:-0}" == "0" ]] || \
+  fail "langfuse-worker did not become Ready with zero restarts (ready=$WORKER_READY restarts=${WORKER_RESTART:-0})"
+assert_no_backoff "$WORKER_POD"
+echo "positive worker: initExit=0 initRestarts=0 worker=Ready workerRestarts=0 BackOff=0"
+
+banner "ASSERT the worker's probes reached the API server"
+# Read the LIVE Deployment back rather than trusting the render: this is the one
+# runtime assertion sensitive to the probe change, and it catches a probe that
+# was dropped by an admission controller, a values override, or a stale chart in
+# the release. Pod-level readiness (above) cannot discriminate here.
+WORKER_DEPLOYMENT_JSON="$(kubectl get deployment "$WORKER_DEPLOYMENT" -n "$NAMESPACE" -o json)" || \
+  fail "kubectl failed reading the live Deployment $NAMESPACE/$WORKER_DEPLOYMENT"
+printf '%s' "$WORKER_DEPLOYMENT_JSON" | python3 /dev/fd/3 3<<'PY' || \
+  fail "live $WORKER_DEPLOYMENT Deployment did not carry the expected langfuse-worker probes"
+import json
+import sys
+
+deployment = json.load(sys.stdin)
+containers = deployment.get("spec", {}).get("template", {}).get("spec", {}).get("containers", [])
+worker = next((item for item in containers if item.get("name") == "langfuse-worker"), None)
+if worker is None:
+    print("live worker Deployment has no langfuse-worker container", file=sys.stderr)
+    sys.exit(1)
+
+problems = []
+
+readiness = worker.get("readinessProbe") or {}
+if not readiness:
+    problems.append("readinessProbe is absent (#71: a persistent-process Deployment needs one)")
+else:
+    http_get = readiness.get("httpGet") or {}
+    if http_get.get("path") != "/api/ready":
+        problems.append(f"readinessProbe.httpGet.path is {http_get.get('path')!r}, expected '/api/ready'")
+    if http_get.get("port") != 3030:
+        problems.append(f"readinessProbe.httpGet.port is {http_get.get('port')!r}, expected the integer 3030")
+    if not isinstance(readiness.get("timeoutSeconds"), int):
+        problems.append("readinessProbe.timeoutSeconds is not set explicitly")
+
+liveness = worker.get("livenessProbe") or {}
+if not liveness:
+    problems.append("livenessProbe is absent (#71: a persistent-process Deployment needs one)")
+else:
+    if "httpGet" in liveness:
+        problems.append(
+            "livenessProbe carries an httpGet; liveness must stay tcpSocket-only so a "
+            "Postgres/Valkey blip cannot restart the single Recreate replica into its boot migrations"
+        )
+    tcp_socket = liveness.get("tcpSocket") or {}
+    if tcp_socket.get("port") != 3030:
+        problems.append(f"livenessProbe.tcpSocket.port is {tcp_socket.get('port')!r}, expected the integer 3030")
+    if not isinstance(liveness.get("timeoutSeconds"), int):
+        problems.append("livenessProbe.timeoutSeconds is not set explicitly")
+
+if problems:
+    for problem in problems:
+        print(f"langfuse-worker probe mismatch: {problem}", file=sys.stderr)
+    sys.exit(1)
+
+print(
+    "worker probes on the live Deployment: readiness=httpGet /api/ready:3030 "
+    "liveness=tcpSocket:3030 (no httpGet), both with an explicit timeoutSeconds"
+)
+PY
 
 banner "NEGATIVE invalid credentials pass readiness and fail in real Langfuse web"
 SECRET_NAME="$(kubectl get deployment "$WEB_DEPLOYMENT" -n "$NAMESPACE" -o json |
@@ -507,12 +638,18 @@ echo "negative: initExit=0 initRestarts=0 webExit=$WEB_EXIT webRestarts=$WEB_RES
 
 banner "NEGATIVE unreachable Postgres exhausts the bounded readiness gate"
 EXHAUSTION_OLD_UID="${NEGATIVE_REF#*|}"
+# langfuse.postgresReadiness is the canonical chart-level key (it replaces the
+# deprecated langfuse.web.postgresReadiness alias), so it shortens the WORKER's
+# gate here too. That is intended: this stage deliberately points Postgres at an
+# unresolvable host, so the worker crash-looping its own init container is the
+# expected consequence and is NOT asserted. The assertions below stay web-scoped
+# and assert_no_backoff is pod-scoped, so the worker cannot contaminate them.
 helm upgrade "$RELEASE" "$CHART" -n "$NAMESPACE" --reuse-values \
   --set postgres.deploy=false \
   --set-string postgres.host=postgres-readiness.invalid \
-  --set langfuse.web.postgresReadiness.attempts=2 \
-  --set langfuse.web.postgresReadiness.intervalSeconds=1 \
-  --set langfuse.web.postgresReadiness.probeTimeoutSeconds=1
+  --set langfuse.postgresReadiness.attempts=2 \
+  --set langfuse.postgresReadiness.intervalSeconds=1 \
+  --set langfuse.postgresReadiness.probeTimeoutSeconds=1
 
 EXHAUSTION_REF="$(wait_for_component_pod langfuse-web "$EXHAUSTION_OLD_UID" 30 || true)"
 if [[ "$EXHAUSTION_REF" != *"|"* ]]; then
@@ -553,4 +690,4 @@ fi
 grep -E '^Postgres readiness exhausted for .+ after 2 attempts: pg_isready=[0-3] ' "$EXHAUSTION_LOG" | tail -1 | sanitize
 echo "exhaustion negative: initExit=$INIT_EXIT webState=$WEB_STATE webRestarts=0 webStarted=false"
 
-banner "PASS delayed Postgres caused no Langfuse web restart/BackOff; readiness recovered; invalid credentials remained terminal; unreachable Postgres exhausted the bounded gate"
+banner "PASS delayed Postgres caused no restart/BackOff on EITHER Langfuse Deployment (web #1853, worker #2330); both readiness gates recovered; the worker Deployment carries both probes; invalid credentials remained terminal; unreachable Postgres exhausted the bounded gate"

--- a/charts/curie/templates/NOTES.txt
+++ b/charts/curie/templates/NOTES.txt
@@ -187,6 +187,14 @@ The nodePort is pinned in values (langfuse.web.service.nodePort) so it survives 
 
 App services send OTLP traces to the collector, NOT directly to Langfuse:
   {{ include "curie.fullname" . }}-otel-collector:{{ .Values.otelCollector.service.grpcPort }} (gRPC) / :{{ .Values.otelCollector.service.httpPort }} (HTTP)
+{{- $legacyPostgresReadiness := get (.Values.langfuse.web | default dict) "postgresReadiness" }}
+{{- if and $legacyPostgresReadiness (kindIs "map" $legacyPostgresReadiness) (gt (len $legacyPostgresReadiness) 0) }}
+
+!! langfuse.web.postgresReadiness is DEPRECATED. The value you supplied is
+   still being honoured, and now applies to BOTH the Langfuse web and worker
+   Deployments (#2330), not web only. Move it to langfuse.postgresReadiness;
+   the alias is removed in a future minor.
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/curie/templates/_helpers.tpl
+++ b/charts/curie/templates/_helpers.tpl
@@ -1427,6 +1427,132 @@ securityContext:
 {{- end -}}
 {{- end -}}
 
+{{/* ---- Langfuse Postgres startup gate (issues #1853, #2330) ----
+     Shared by BOTH Langfuse Deployments because both run their Prisma boot
+     migrations against the same Postgres. #1853 filed the crash-loop against
+     the web pod and keyed the gate under `langfuse.web.postgresReadiness`, a
+     per-Deployment path that was structurally unreachable from the worker; the
+     worker then reproduced the identical symptom (Prisma `P1001`,
+     `reason: Error`, namespace `BackOff`), which is #2330. The gate is now
+     chart-level (`langfuse.postgresReadiness`, the shape
+     `langfuse.clickhouseReadiness` already had) and rendered from one define on
+     both Deployments, ordered before the ClickHouse gate on both.
+
+     The probe is credential-free: `pg_isready` speaks the startup protocol
+     only, so no password or Secret reaches this container. It is bounded on
+     purpose -- after `attempts` polls it exits non-zero and hands the decision
+     back to the kubelet, which keeps a genuinely-down Postgres visible instead
+     of hanging forever.
+
+     `securityContext` is the CALLER's own container securityContext, floored to
+     non-root: the gate runs the POSTGRES image, not the Langfuse image, so
+     runAsUser 1001 (#351) is a floor rather than an inheritance. It is always
+     emitted, even for a blank caller context.
+
+     `langfuse.web.postgresReadiness` survives as a DEPRECATED ALIAS resolved by
+     `curie.langfuse.postgresReadinessValues`, and it is honoured for BOTH
+     Deployments -- a stored `enabled: false` or a BYO `image` must never
+     silently become web-only.
+
+     Call with a dict: `root` (the chart context) and `containerSecurityContext`
+     (the component's own). */}}
+{{- define "curie.langfuse.postgresReadinessValues" -}}
+{{/* Resolves the EFFECTIVE Postgres readiness config for both Deployments.
+
+     Starts from a deepCopy of the canonical `langfuse.postgresReadiness` block
+     and merges any operator-supplied `langfuse.web.postgresReadiness` over it,
+     so a PARTIAL legacy override (`--set langfuse.web.postgresReadiness.attempts=30`)
+     still inherits every other canonical field instead of blanking them.
+
+     Detection is sound only because `values.yaml` no longer ships a default at
+     the legacy path: anything present there came from an operator. A null or
+     empty legacy value falls through to the canonical block rather than
+     merging a null over it, and `langfuse.web` itself is guarded so a
+     `langfuse.web: null` release cannot crash the render. Neither path fails --
+     `helm upgrade --reuse-values` replays an operator's stored user-supplied
+     blob, so a `fail` here would abort upgrades on exactly the releases that
+     need the gate.
+
+     `keyPath` rides along solely so the validation `fail` in
+     `curie.langfuse.postgresGate` can name the path the operator actually set.
+     It is never rendered into a manifest. */}}
+{{- $root := . -}}
+{{- $effective := deepCopy $root.Values.langfuse.postgresReadiness -}}
+{{- $keyPath := "langfuse.postgresReadiness" -}}
+{{- $legacy := get ($root.Values.langfuse.web | default dict) "postgresReadiness" -}}
+{{- if and $legacy (kindIs "map" $legacy) (gt (len $legacy) 0) -}}
+{{- $effective = mergeOverwrite $effective (deepCopy $legacy) -}}
+{{- $keyPath = "langfuse.web.postgresReadiness" -}}
+{{- end -}}
+{{- $_ := set $effective "keyPath" $keyPath -}}
+{{- toYaml $effective -}}
+{{- end -}}
+
+{{- define "curie.langfuse.postgresGate" -}}
+{{- $root := .root -}}
+{{- $postgresReadiness := fromYaml (include "curie.langfuse.postgresReadinessValues" $root) -}}
+{{- $readinessSecurityContext := deepCopy (.containerSecurityContext | default dict) -}}
+{{- $_ := set $readinessSecurityContext "runAsNonRoot" true -}}
+{{- if not (hasKey $readinessSecurityContext "runAsUser") -}}
+{{- $_ := set $readinessSecurityContext "runAsUser" 1001 -}}
+{{- else if eq (int64 (get $readinessSecurityContext "runAsUser")) 0 -}}
+{{- $_ := set $readinessSecurityContext "runAsUser" 1001 -}}
+{{- end -}}
+{{- range $field := list "attempts" "intervalSeconds" "probeTimeoutSeconds" -}}
+{{- $value := index $postgresReadiness $field -}}
+{{- $integerKind := or (kindIs "int" $value) (kindIs "int64" $value) (kindIs "float64" $value) -}}
+{{- if or (not $integerKind) (not (regexMatch "^[0-9]+$" (printf "%v" $value))) (lt (int64 $value) 1) -}}
+{{- fail (printf "%s.%s must be an integer >= 1" $postgresReadiness.keyPath $field) -}}
+{{- end -}}
+{{- end -}}
+- name: wait-for-postgres
+  image: {{ $postgresReadiness.image | default $root.Values.postgres.image | quote }}
+  imagePullPolicy: {{ $root.Values.global.imagePullPolicy }}
+  securityContext:
+    {{- toYaml $readinessSecurityContext | nindent 4 }}
+  command:
+    - sh
+    - -ec
+    - |
+      echo "waiting for Postgres readiness"
+      attempt=1
+      last_exit_code=1
+      while [ "$attempt" -le "$POSTGRES_READINESS_ATTEMPTS" ]; do
+        if pg_isready \
+          -h "$POSTGRES_HOST" \
+          -p "$POSTGRES_PORT" \
+          -U "$POSTGRES_USER" \
+          -d "$POSTGRES_DATABASE" \
+          -t "$POSTGRES_READINESS_PROBE_TIMEOUT_SECONDS" \
+          >/dev/null 2>&1; then
+          exit 0
+        else
+          last_exit_code=$?
+        fi
+        if [ "$attempt" -lt "$POSTGRES_READINESS_ATTEMPTS" ]; then
+          sleep "$POSTGRES_READINESS_INTERVAL_SECONDS"
+        fi
+        attempt=$((attempt + 1))
+      done
+      echo "Postgres readiness exhausted for ${POSTGRES_HOST}:${POSTGRES_PORT} after ${POSTGRES_READINESS_ATTEMPTS} attempts: pg_isready=${last_exit_code} (0=accepting, 1=rejecting, 2=no-response, 3=no-attempt)" >&2
+      exit 1
+  env:
+    - name: POSTGRES_HOST
+      value: {{ include "curie.postgres.host" $root | quote }}
+    - name: POSTGRES_PORT
+      value: {{ $root.Values.postgres.port | quote }}
+    - name: POSTGRES_USER
+      value: {{ $root.Values.postgres.auth.username | quote }}
+    - name: POSTGRES_DATABASE
+      value: {{ $root.Values.postgres.auth.database | quote }}
+    - name: POSTGRES_READINESS_ATTEMPTS
+      value: {{ $postgresReadiness.attempts | quote }}
+    - name: POSTGRES_READINESS_INTERVAL_SECONDS
+      value: {{ $postgresReadiness.intervalSeconds | quote }}
+    - name: POSTGRES_READINESS_PROBE_TIMEOUT_SECONDS
+      value: {{ $postgresReadiness.probeTimeoutSeconds | quote }}
+{{- end -}}
+
 {{/* ---- Langfuse ClickHouse startup gate (issue #2009) ----
      Both Langfuse deployments run their ClickHouse migrations during boot, so a
      Helm upgrade that recreates the ClickHouse Service can start them before the

--- a/charts/curie/templates/langfuse.yaml
+++ b/charts/curie/templates/langfuse.yaml
@@ -1,3 +1,4 @@
+{{- $pgReadiness := fromYaml (include "curie.langfuse.postgresReadinessValues" .) -}}
 {{- if .Values.langfuse.deploy }}
 {{- if .Values.langfuse.serviceAccount.create }}
 apiVersion: v1
@@ -73,70 +74,12 @@ spec:
       {{- . | nindent 6 }}
       {{- end }}
       serviceAccountName: {{ include "curie.langfuse.serviceAccountName" . }}
-      {{- if or .Values.langfuse.clickhouseReadiness.enabled .Values.langfuse.web.postgresReadiness.enabled }}
+      {{- if or .Values.langfuse.clickhouseReadiness.enabled $pgReadiness.enabled }}
       initContainers:
-      {{- if .Values.langfuse.web.postgresReadiness.enabled }}
-      {{- $postgresReadiness := .Values.langfuse.web.postgresReadiness }}
-      {{- $readinessSecurityContext := deepCopy (.Values.langfuse.web.containerSecurityContext | default dict) }}
-      {{- $_ := set $readinessSecurityContext "runAsNonRoot" true }}
-      {{- if not (hasKey $readinessSecurityContext "runAsUser") }}
-      {{- $_ := set $readinessSecurityContext "runAsUser" 1001 }}
-      {{- else if eq (int64 (get $readinessSecurityContext "runAsUser")) 0 }}
-      {{- $_ := set $readinessSecurityContext "runAsUser" 1001 }}
-      {{- end }}
-      {{- range $field := list "attempts" "intervalSeconds" "probeTimeoutSeconds" }}
-      {{- $value := index $postgresReadiness $field }}
-      {{- $integerKind := or (kindIs "int" $value) (kindIs "int64" $value) (kindIs "float64" $value) }}
-      {{- if or (not $integerKind) (not (regexMatch "^[0-9]+$" (printf "%v" $value))) (lt (int64 $value) 1) }}
-      {{- fail (printf "langfuse.web.postgresReadiness.%s must be an integer >= 1" $field) }}
-      {{- end }}
-      {{- end }}
-        - name: wait-for-postgres
-          image: {{ $postgresReadiness.image | default .Values.postgres.image | quote }}
-          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
-          securityContext:
-            {{- toYaml $readinessSecurityContext | nindent 12 }}
-          command:
-            - sh
-            - -ec
-            - |
-              echo "waiting for Postgres readiness"
-              attempt=1
-              last_exit_code=1
-              while [ "$attempt" -le "$POSTGRES_READINESS_ATTEMPTS" ]; do
-                if pg_isready \
-                  -h "$POSTGRES_HOST" \
-                  -p "$POSTGRES_PORT" \
-                  -U "$POSTGRES_USER" \
-                  -d "$POSTGRES_DATABASE" \
-                  -t "$POSTGRES_READINESS_PROBE_TIMEOUT_SECONDS" \
-                  >/dev/null 2>&1; then
-                  exit 0
-                else
-                  last_exit_code=$?
-                fi
-                if [ "$attempt" -lt "$POSTGRES_READINESS_ATTEMPTS" ]; then
-                  sleep "$POSTGRES_READINESS_INTERVAL_SECONDS"
-                fi
-                attempt=$((attempt + 1))
-              done
-              echo "Postgres readiness exhausted for ${POSTGRES_HOST}:${POSTGRES_PORT} after ${POSTGRES_READINESS_ATTEMPTS} attempts: pg_isready=${last_exit_code} (0=accepting, 1=rejecting, 2=no-response, 3=no-attempt)" >&2
-              exit 1
-          env:
-            - name: POSTGRES_HOST
-              value: {{ include "curie.postgres.host" . | quote }}
-            - name: POSTGRES_PORT
-              value: {{ .Values.postgres.port | quote }}
-            - name: POSTGRES_USER
-              value: {{ .Values.postgres.auth.username | quote }}
-            - name: POSTGRES_DATABASE
-              value: {{ .Values.postgres.auth.database | quote }}
-            - name: POSTGRES_READINESS_ATTEMPTS
-              value: {{ .Values.langfuse.web.postgresReadiness.attempts | quote }}
-            - name: POSTGRES_READINESS_INTERVAL_SECONDS
-              value: {{ .Values.langfuse.web.postgresReadiness.intervalSeconds | quote }}
-            - name: POSTGRES_READINESS_PROBE_TIMEOUT_SECONDS
-              value: {{ .Values.langfuse.web.postgresReadiness.probeTimeoutSeconds | quote }}
+      {{- if $pgReadiness.enabled }}
+        {{- include "curie.langfuse.postgresGate" (dict
+             "root" .
+             "containerSecurityContext" .Values.langfuse.web.containerSecurityContext) | nindent 8 }}
       {{- end }}
       {{- if .Values.langfuse.clickhouseReadiness.enabled }}
         {{- include "curie.langfuse.clickhouseGate" (dict
@@ -246,13 +189,20 @@ spec:
       {{- . | nindent 6 }}
       {{- end }}
       serviceAccountName: {{ include "curie.langfuse.serviceAccountName" . }}
-      {{- if .Values.langfuse.clickhouseReadiness.enabled }}
+      {{- if or .Values.langfuse.clickhouseReadiness.enabled $pgReadiness.enabled }}
       initContainers:
+      {{- if $pgReadiness.enabled }}
+        {{- include "curie.langfuse.postgresGate" (dict
+             "root" .
+             "containerSecurityContext" .Values.langfuse.worker.containerSecurityContext) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.langfuse.clickhouseReadiness.enabled }}
         {{- include "curie.langfuse.clickhouseGate" (dict
              "root" .
              "image" (include "curie.image" (dict "repository" .Values.langfuse.image.worker "tag" .Values.langfuse.image.tag "digest" .Values.langfuse.image.workerDigest))
              "containerSecurityContext" .Values.langfuse.worker.containerSecurityContext
              "resources" .Values.langfuse.worker.resources) | nindent 8 }}
+      {{- end }}
       {{- end }}
       containers:
         - name: langfuse-worker
@@ -271,6 +221,32 @@ spec:
           ports:
             - name: http
               containerPort: 3030
+          # Readiness is the SIGTERM-aware /api/ready (the worker image's only
+          # endpoint that fails during shutdown, so a terminating pod drains).
+          # Liveness is deliberately tcpSocket, NOT an HTTP path: both
+          # /api/health and /api/ready run a Prisma `SELECT 1` and a Redis ping,
+          # and this Deployment is replicas:1 + Recreate with Prisma/ClickHouse
+          # migrations at container boot. Init containers do NOT re-run on a
+          # liveness restart, so a store blip would restart the only replica
+          # straight into those boot migrations against a sick Postgres -- the
+          # exact P1001/BackOff class the wait-for-postgres gate exists to stop
+          # (#71, #2330). timeoutSeconds is explicit on both: the kubelet
+          # default is 1s, which langfuse-web's block above silently takes.
+          readinessProbe:
+            httpGet:
+              path: /api/ready
+              port: 3030
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30
+          livenessProbe:
+            tcpSocket:
+              port: 3030
+            initialDelaySeconds: 90
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 6
           resources:
             {{- toYaml .Values.langfuse.worker.resources | nindent 12 }}
 {{- end }}

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -158,6 +158,25 @@ langfuse:
     maxAttempts: 60
     intervalSeconds: 2
     timeoutSeconds: 2
+  # Credential-free protocol readiness gate before either Langfuse Deployment
+  # starts its own migrations (#1853, #2330). Both Langfuse deployments run
+  # their schema migrations at boot against the same Postgres, so both are held
+  # behind this gate -- web reproduced Prisma `P1001` first (#1853) and the
+  # worker reproduced it identically once the web gate landed (#2330).
+  # Authentication and migration failures remain owned by the unmodified
+  # Langfuse entrypoint after this bounded wait succeeds.
+  # `langfuse.web.postgresReadiness` is a DEPRECATED alias: values supplied
+  # there are still honoured and are merged over these defaults for BOTH
+  # Deployments.
+  postgresReadiness:
+    enabled: true
+    # Empty reuses postgres.image; override for BYO Postgres when needed.
+    # This probe always runs as non-root, independently of a Langfuse image's
+    # containerSecurityContext override, because it uses the Postgres image.
+    image: ""
+    attempts: 60
+    intervalSeconds: 2
+    probeTimeoutSeconds: 2
   # NEXTAUTH_URL the browser reaches the web UI at. Override for a real ingress.
   nextauthUrl: http://localhost:23000
   # Dev-only secret material. Override in prod or set `existingSecret` to a
@@ -241,18 +260,11 @@ langfuse:
     # cap (~512Mi) OOM-crashes under a tight container limit; raise it in step
     # with the memory limit. Empty = leave the image default.
     nodeOptions: "--max-old-space-size=1024"
-    # Credential-free protocol readiness gate before Langfuse web starts its
-    # own migrations. Authentication and migration failures remain owned by
-    # the unmodified Langfuse entrypoint after this bounded wait succeeds.
-    postgresReadiness:
-      enabled: true
-      # Empty reuses postgres.image; override for BYO Postgres when needed.
-      # This probe always runs as non-root, independently of a web image's
-      # containerSecurityContext override, because it uses the Postgres image.
-      image: ""
-      attempts: 60
-      intervalSeconds: 2
-      probeTimeoutSeconds: 2
+    # DEPRECATED: langfuse.web.postgresReadiness moved to langfuse.postgresReadiness
+    # (#2330), which gates BOTH Langfuse Deployments. Values supplied at the old
+    # path are still honoured and are applied to BOTH; the chart no longer sets
+    # any default here. Move your overrides -- the alias is removed in a future
+    # minor.
     resources:
       requests: { cpu: 150m, memory: 384Mi }
       limits: { cpu: "1", memory: 1536Mi }


### PR DESCRIPTION
## Summary

`langfuse-worker` carried neither the Postgres readiness gate nor any probe,
while `langfuse-web` had both — even though the chart runs Prisma and ClickHouse
migrations at container boot on *both* Deployments. The worker therefore hit the
same Prisma `P1001` crash-loop that #1853 fixed for web, and, with no
readinessProbe and `minReadySeconds` defaulting to 0, Kubernetes reported it
`Ready` the instant the process started.

This shares the Postgres gate across both Deployments the way the ClickHouse
gate already is, and gives the worker both probes.

- New `curie.langfuse.postgresGate` helper renders the `wait-for-postgres` init
  container for either Deployment, hardened from that Deployment's **own**
  `containerSecurityContext`, ordered before the ClickHouse gate on each.
- New canonical `langfuse.postgresReadiness.*` values block.
  `langfuse.web.postgresReadiness.*` stays honoured as a deprecated alias and is
  merged over the canonical defaults, applied to **both** Deployments.
- `langfuse-worker` gains a `readinessProbe` (`httpGet /api/ready`) and a
  `livenessProbe` (`tcpSocket` on :3030).

`curie-langfuse-web` renders **byte-identically** to `main`; every changed
render line is inside `curie-langfuse-worker`.

### Conservative defaults chosen, and why

- **The deprecated alias now applies to both Deployments, and the render does
  not refuse it.** `helm upgrade --reuse-values` replays a release's stored
  user-supplied values, so failing the render on the old key would break the
  upgrade path for exactly the operators who customized the gate. A NOTES.txt
  stanza prints the deprecation whenever the key is still set.
- **Worker liveness is `tcpSocket`, not HTTP.** Both `/api/health` and
  `/api/ready` run a Prisma `SELECT 1` plus a Redis ping, and init containers do
  **not** re-run on a liveness restart — so an HTTP liveness probe would restart
  the single replica straight into its boot migrations against a store that is
  still recovering, which is the crash-loop class this gate exists to prevent.
  Accepted trade-off: `tcpSocket` will not catch a wedged Node event loop, so
  detection of that rides on the readiness probe, which does exercise the event
  loop and the stores.
- **The worker's probe cadence numbers are hardcoded to match web's** rather
  than introducing `langfuse.worker.*Probe.*` values keys, because
  `langfuse-web`'s probes are hardcoded in the same file and adding keys for
  only one of the pair would create a new asymmetry in the very file this ticket
  is about. Recorded as a named exception in `charts/curie/CLAUDE.md` with the
  follow-up (lift both onto values-driven probes together).

### Known cosmetic gap

The bounds-validation `fail` message reports a block-level `keyPath`. When the
deprecated alias is set, a bad value inherited from the canonical block is
attributed to `langfuse.web.postgresReadiness`. The value is still rejected and
the bound named; only the key in the message can point at the wrong block.

## Related issue

Closes #2330

## Fix pin verification

Fix pin: charts/curie/ci/langfuse-worker-probe-assertions.sh

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | The skill tier runs the runner container only; it never renders or installs this Helm chart, so it cannot reach a Langfuse Deployment's initContainers or probes. | | |
| local | n/a | The local tier is the Compose stack, which does not render the Helm chart; Langfuse there is a Compose service with no initContainers and no Kubernetes Probe fields. | | |
| local-release | n/a | Same substrate as local (Compose, release-pinned images); no Helm render, so the changed templates are unreachable. | | |
| cluster | Required | This change is entirely a Helm render plus live pod-ordering behavior, both of which exist only on a Kubernetes cluster. | live cluster (kind), fake model | `bash charts/curie/ci/runtime/langfuse-postgres-readiness-runtime.sh --namespace curie-2330-r2 --release curie-2330-r2 --postgres-image curie-postgres-readiness:2330r2` on a kind cluster at commit 7fc0cb9e0093. Observed, while Postgres was deliberately delayed: 3 samples of each pod showed `webInit=running web=waiting workerInit=running worker=waiting` with 0 restarts and `BackOff=0` on both. After Postgres came up: `positive: postgres=Ready initExit=0 web=Ready webRestarts=0 BackOff=0` and `positive worker: initExit=0 worker=Ready workerRestarts=0 BackOff=0`. Probes read back from the live API server as `readiness=httpGet /api/ready:3030 liveness=tcpSocket:3030 (no httpGet)`, both with an explicit timeoutSeconds. Both negative controls armed: invalid credentials stayed terminal inside Langfuse, and an unreachable Postgres exhausted the bounded gate (`initExit=1 webStarted=false`). Namespace teardown confirmed absent. |
| live provider | n/a | No model routing, provider credential, or inference path is touched; the diff is Helm templates, chart values, chart CI scripts, and chart docs. | | |
| external integration | n/a | No Slack, mail, or other external-integration surface is touched. | | |

- [x] Every required tier above names its exact command, the commit it ran
      against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable
      negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in
      the table.

Render contracts (both scripts verified red-before / green-after):

- `bash charts/curie/ci/langfuse-postgres-readiness-assertions.sh` — asserts the
  gate on **both** Deployments, its ordering before the ClickHouse gate, the
  per-Deployment securityContext, the alias merge, and the bounds; includes red
  mutations armed per Deployment.
- `bash charts/curie/ci/langfuse-worker-probe-assertions.sh` — new; pins the
  worker's readiness and liveness probe shape, endpoints, and port.

## CI note

`cargo audit` is red on this pull request and was already red on `main` before it (RUSTSEC-2023-0071 plus two 2026 advisories against the CLI crate's dependencies). This branch changes no Rust and no Cargo manifest or lockfile — `git diff --name-only origin/main...HEAD` matches no `.rs`, `Cargo.toml`, or `Cargo.lock` path — so it is a pre-existing dependency advisory, not a regression from this work.

The `E2E parity ladder (cluster rung)` failed once on `cli/scripts/e2e-cluster-rollout-recovery.sh` ("first invocation in flight mutated worker identity", an old `curie-worker` ReplicaSet still terminating) and passed on re-run. That gate is about the product worker's rollout identity, which this branch does not touch. The same ladder run also executed this ticket's own runtime regression and passed it.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [x] Docs updated if behavior changed.
- [ ] An ADR is added under `docs/adr/` if this is an architectural decision.
