### PR TITLE
Strengthen sandbox resilience outcome and recovery evidence

### DIFF
--- a/apps/worker/tests/sandbox/resilience_fixtures.py
+++ b/apps/worker/tests/sandbox/resilience_fixtures.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import json
 import sys
 import time
+import uuid
 from collections.abc import Iterator
 from pathlib import Path
 
@@ -52,7 +53,7 @@ def resilience_substrate(cfg: ResilienceConfig) -> Iterator[object]:
         password=cfg.valkey_password,
     )
     client.ping()
-    prefix = "soak:curie:sandbox"
+    prefix = f"test:resilience:curie:sandbox:{uuid.uuid4().hex}"
     config = SubstrateConfig(
         namespace=cfg.namespace,
         warm_pool=cfg.pool,

--- a/apps/worker/tests/sandbox/resilience_harness.py
+++ b/apps/worker/tests/sandbox/resilience_harness.py
@@ -16,6 +16,7 @@ The substrate seam is synchronous, so the scenario drives concurrency with a
 
 from __future__ import annotations
 
+import base64
 import contextlib
 import hashlib
 import json
@@ -23,8 +24,11 @@ import os
 import socket
 import subprocess
 import urllib.request
+import uuid
 from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
+
+from aci_protocol import Final, SessionStatus, parse_ndjson
 
 
 @dataclass(frozen=True)
@@ -43,13 +47,18 @@ class ResilienceConfig:
     concurrency: int
     batch: int
     runs: int
-    live_creds: bool
+    live_model: bool
 
     @classmethod
     def from_env(cls) -> ResilienceConfig:
         password = os.environ.get("TEST_VALKEY_PW", "valkeypass") or None
-        live = bool(
-            os.environ.get("CLAUDE_CODE_OAUTH_TOKEN") or os.environ.get("ANTHROPIC_API_KEY")
+        # Credentials belong to the selected cluster pool, not necessarily to
+        # this pytest process (CURIE_CREDENTIALS may come from a pod Secret).
+        # An explicitly required live run must execute and fail on missing
+        # prerequisites, never turn green through a host-credential skip.
+        live = (
+            os.environ.get("CURIE_SANDBOX_E2E_LIVE") == "1"
+            or os.environ.get("CURIE_E2E_LIVE") == "1"
         )
         return cls(
             namespace=os.environ.get("CURIE_SANDBOX_E2E_NAMESPACE", "curie-g1"),
@@ -60,7 +69,7 @@ class ResilienceConfig:
             concurrency=int(os.environ.get("CURIE_SANDBOX_E2E_CONCURRENCY", "5")),
             batch=int(os.environ.get("CURIE_SANDBOX_E2E_BATCH", "3")),
             runs=int(os.environ.get("CURIE_SANDBOX_E2E_RUNS", "1")),
-            live_creds=live,
+            live_model=live,
         )
 
 
@@ -194,18 +203,82 @@ def get_json(base: str, path: str) -> dict[str, object]:
 
 
 def post_event(
-    base: str, text: str, *, user: str = "U-soak", ts: str = "1.0"
+    base: str,
+    text: str,
+    *,
+    user: str = "U-soak",
+    ts: str = "1.0",
+    token: str = "",
+    trace_id: str | None = None,
 ) -> list[dict[str, object]]:
-    """POST an ACI ``message`` event and return the parsed NDJSON frames."""
+    """Drive an authenticated ACI turn and require a successful terminal frame.
+
+    HTTP 200 only means the stream opened. A classified failure, approval wait,
+    missing final or malformed wire response must fail the scenario. Error
+    diagnostics name types/status only; model text and bearer tokens stay out.
+    """
 
     body = json.dumps(
         {"kind": "event", "type": "message", "text": text, "user": user, "ts": ts}
     ).encode()
-    request = urllib.request.Request(
-        f"{base}/v1/event", data=body, headers={"Content-Type": "application/json"}
-    )
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    if trace_id:
+        headers["traceparent"] = f"00-{trace_id}-{uuid.uuid4().hex[:16]}-01"
+    request = urllib.request.Request(f"{base}/v1/event", data=body, headers=headers)
     with urllib.request.urlopen(request, timeout=90) as resp:
-        return [json.loads(line) for line in resp.read().splitlines() if line.strip()]
+        raw = resp.read()
+    try:
+        frames = parse_ndjson(raw.decode())
+    except Exception:
+        # Decoder exceptions can include input_value and wire version reprs.
+        # Neither model output nor hostile frame contents belong in diagnostics.
+        raise AssertionError("runner emitted invalid NDJSON") from None
+    assert frames and isinstance(frames[-1], Final), "turn did not end in a final frame"
+    final = frames[-1]
+    assert final.status == SessionStatus.DONE, f"runner terminal status was {final.status.value}"
+    assert sum(isinstance(frame, Final) for frame in frames) == 1, "turn emitted multiple finals"
+    assert not any(frame.type == "error" for frame in frames), "turn emitted an error frame"
+    return [frame.model_dump(mode="json") for frame in frames]
+
+
+def cache_reads_for_trace(observations: Sequence[dict[str, object]], trace_id: str) -> int:
+    """Count only this turn's generation usage, never a global cached request.
+
+    Langfuse documents flat usageDetails and normalized OTel cache buckets:
+    https://langfuse.com/docs/observability/features/token-and-cost-tracking
+    """
+
+    total = 0
+    for observation in observations:
+        if observation.get("traceId") != trace_id or observation.get("type") != "GENERATION":
+            continue
+        usage = observation.get("usageDetails")
+        if isinstance(usage, dict):
+            count = usage.get("cache_read_input_tokens", usage.get("input_cached_tokens", 0))
+            assert isinstance(count, int) and not isinstance(count, bool) and count >= 0, (
+                "generation cache usage must be a nonnegative integer"
+            )
+            total += count
+    return total
+
+
+def trace_cache_reads(trace_id: str) -> int:
+    """Read one exact trace from the real Langfuse v3 public API."""
+
+    host = os.environ.get("LANGFUSE_HOST", "http://localhost:23000").rstrip("/")
+    public_key = os.environ.get("LANGFUSE_PUBLIC_KEY", "pk-lf-curie-dev")
+    secret_key = os.environ.get("LANGFUSE_SECRET_KEY", "sk-lf-curie-dev")
+    bearer = base64.b64encode(f"{public_key}:{secret_key}".encode()).decode()
+    # Same supported v3 query as curie_api.langfuse.LangfuseClient.observations.
+    request = urllib.request.Request(
+        f"{host}/api/public/observations?traceId={trace_id}&limit=100",
+        headers={"Authorization": f"Basic {bearer}"},
+    )
+    with urllib.request.urlopen(request, timeout=10) as response:
+        payload = json.loads(response.read())
+    return cache_reads_for_trace(payload["data"], trace_id)
 
 
 def live_sandboxclaims(

--- a/apps/worker/tests/sandbox/resilience_harness.py
+++ b/apps/worker/tests/sandbox/resilience_harness.py
@@ -21,12 +21,15 @@ import contextlib
 import hashlib
 import json
 import os
+import re
 import socket
 import subprocess
+import time
 import urllib.request
 import uuid
-from collections.abc import Iterator, Sequence
+from collections.abc import Callable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
+from urllib.parse import urlparse
 
 from aci_protocol import Final, SessionStatus, parse_ndjson
 
@@ -119,6 +122,58 @@ def collected_text(frames: Sequence[dict[str, object]]) -> str:
         if isinstance(value, str) and value:
             parts.append(value)
     return " ".join(parts)
+
+
+def assert_exact_recall(frames: Sequence[dict[str, object]], expected: str) -> None:
+    """A substring in a UUID, tool note, or echoed context is not final recall."""
+    final = final_frame(frames)
+    assert final is not None and final.get("status") == "done", "successful final absent"
+    text = final.get("text")
+    assert isinstance(text, str) and text.strip() == expected, (
+        "final did not recall the exact value"
+    )
+
+
+def required_history_fixture(env: Mapping[str, str]) -> tuple[str, str, str]:
+    """Validate fixture shape, never claim authentication or a fetch from this check.
+
+    Only a real authenticated runner recall can prove durable history. The fake
+    lane remains environment-only. Decoding the scoped token prevents passing a
+    raw platform key into a sandbox; the real state API still verifies its HMAC.
+    """
+    ref = env.get("CURIE_SANDBOX_E2E_HISTORY_REF", "")
+    marker = env.get("CURIE_SANDBOX_E2E_HISTORY_MARKER", "")
+    token = env.get("CURIE_SANDBOX_E2E_HISTORY_TOKEN", "")
+    valid = False
+    try:
+        url = urlparse(ref)
+        match = re.search(r"/agents/([^/]+)/state/transcript/[^/]+/?$", url.path)
+        prefix, payload, signature = token.split(".")
+        claims = json.loads(base64.urlsafe_b64decode(payload + "=" * (-len(payload) % 4)))
+        valid = bool(
+            url.scheme in {"http", "https"} and url.hostname
+            and not url.username and not url.password and not url.query and not url.fragment
+            and match and str(uuid.UUID(match.group(1))) == match.group(1)
+            and marker and prefix == "sbx" and signature
+            and isinstance(claims, dict) and claims.get("agent") == match.group(1)
+            and claims.get("scope") == "state" and type(claims.get("exp")) is int
+            and claims["exp"] > time.time()
+        )
+    except (ValueError, TypeError):
+        pass
+    assert valid, "configure a transcript-key URL, matching scoped state token and expected marker"
+    return ref, token, marker
+
+
+def release_claims(release: Callable[[str], None], keys: Sequence[str]) -> None:
+    """Attempt every task-owned release, then fail if any cleanup failed."""
+    failures: list[str] = []
+    for key in keys:
+        try:
+            release(key)
+        except Exception as exc:
+            failures.append(type(exc).__name__)
+    assert not failures, f"task-owned claim cleanup failed ({len(failures)} failures)"
 
 
 def detect_cross_talk(marker: str, other_markers: Sequence[str], text: str) -> bool:

--- a/apps/worker/tests/sandbox/test_delivery_resilience.py
+++ b/apps/worker/tests/sandbox/test_delivery_resilience.py
@@ -1,0 +1,173 @@
+"""Real stream recovery and side effects, below the cluster fault-injection tier.
+
+The production Kernel, substrate, RunnerClient, SessionRunner and Valkey run
+unchanged. The external model fixture executes one actual subprocess file append
+between its SDK tool-use/result messages. Replacement constructs new worker and
+runner objects, then consumes the abandoned PEL entry through real XAUTOCLAIM.
+Kubernetes and Slack are test doubles. This does not claim a pod/process kill or
+live-provider evidence; those require the disposable cluster scenario.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import sys
+import uuid
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+import redis
+from aci_protocol import QueuedTurn, ReplyHandle
+from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock, ToolUseBlock
+from curie_dispatcher.queue import to_stream_fields
+from curie_runner import RunTracer, SideEffectClassifier, create_app
+from curie_runner.fake import FakeModelSession
+from curie_runner.session import SessionRunner
+from curie_worker.consumer import Consumer
+
+from apps.worker.tests.kernel.conftest import kernel_harness
+
+
+class ReceiptModel(FakeModelSession):
+    """A scripted provider whose tool really appends a durable receipt."""
+
+    def __init__(self, receipt: Path, fault: str | None) -> None:
+        super().__init__()
+        self.receipt = receipt
+        self.fault = fault
+        self.reached = asyncio.Event()
+
+    async def receive_turn(self) -> AsyncIterator[Any]:
+        yield AssistantMessage(content=[TextBlock(text="starting")], model="fake-model")
+        if self.fault == "before-effect":
+            self.reached.set()
+            await asyncio.Event().wait()
+        yield AssistantMessage(
+            content=[ToolUseBlock(id="receipt", name="Bash", input={"command": "append receipt"})],
+            model="fake-model",
+        )
+        # The receipt is an actual child-process side effect, not a claim count,
+        # an emitted frame count or an in-memory call recorder.
+        process = await asyncio.create_subprocess_exec(
+            sys.executable,
+            "-c",
+            "import os,sys; "
+            "fd=os.open(sys.argv[1],os.O_WRONLY|os.O_CREAT|os.O_APPEND,0o600); "
+            "os.write(fd,b'committed\\n'); os.fsync(fd); os.close(fd)",
+            str(self.receipt),
+        )
+        assert await process.wait() == 0
+        self.reached.set()
+        if self.fault == "after-effect":
+            await asyncio.Event().wait()
+        yield ResultMessage(
+            subtype="success", duration_ms=1, duration_api_ms=1, is_error=False,
+            num_turns=1, session_id="resilience-session", result="receipt committed",
+        )
+
+
+def _runner(model: ReceiptModel) -> SessionRunner:
+    return SessionRunner(
+        session_factory=lambda: model,
+        ceiling=0,
+        tracer=RunTracer(None),
+        classifier=SideEffectClassifier(),
+        trace_name="delivery-resilience",
+    )
+
+
+@pytest.mark.parametrize("fault", ["before-effect", "after-effect"])
+def test_reclaimed_delivery_commits_exactly_one_receipt(
+    fault: str, names: dict[str, str], sync_redis: redis.Redis, tmp_path: Path,
+) -> None:
+    async def run() -> None:
+        receipt = tmp_path / "effect-receipts"
+        event = QueuedTurn(
+            event_id=uuid.uuid4().hex,
+            conversation_id="resilience-thread",
+            author="U0EXAMPLE1",
+            text="commit one receipt",
+            reply_handle=ReplyHandle(kind="slack", channel="C0EXAMPLE1", placeholder="1.0"),
+            received_at="2026-09-05T00:00:00+00:00",
+        )
+        first_model = ReceiptModel(receipt, fault)
+        first_runner = _runner(first_model)
+        await first_runner.start()
+        async with kernel_harness(
+            names, sync_redis, runner_app=create_app(first_runner), reclaim_min_idle_ms=0,
+        ) as first:
+            consumer = Consumer(redis=first.async_redis, kernel=first.kernel, config=first.config)
+            await consumer.ensure_group()
+            entry_id = await first.async_redis.xadd(first.config.stream, to_stream_fields(event))
+            deliveries = await first.async_redis.xreadgroup(
+                first.config.consumer_group, "departed-worker", {first.config.stream: ">"}, count=1,
+            )
+            assert deliveries
+            task = asyncio.create_task(first.kernel.process_event(event))
+            try:
+                await asyncio.wait_for(first_model.reached.wait(), timeout=5)
+                if fault == "after-effect":
+                    async with asyncio.timeout(5):
+                        while not await first.async_redis.exists(
+                            first.config.side_effect_key(event.event_id)
+                        ):
+                            await asyncio.sleep(0.01)
+                    assert receipt.read_text() == "committed\n"
+                else:
+                    assert not receipt.exists()
+                    assert not await first.async_redis.exists(
+                        first.config.side_effect_key(event.event_id)
+                    )
+                assert not await first.async_redis.exists(first.config.done_key(event.event_id))
+            finally:
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await task
+
+        # All worker/kernel/runner clients are fresh. Only the real Valkey
+        # route, pending entry and side-effect marker survive the replacement.
+        second_model = ReceiptModel(receipt, None)
+        second_runner = _runner(second_model)
+        await second_runner.start()
+        async with kernel_harness(
+            names, sync_redis, runner_app=create_app(second_runner), reclaim_min_idle_ms=0,
+        ) as second:
+            consumer = Consumer(
+                redis=second.async_redis, kernel=second.kernel, config=second.config
+            )
+            await consumer.ensure_group()
+            assert await consumer._reclaim_once() == 1
+            await asyncio.wait_for(asyncio.gather(*list(consumer._inflight)), timeout=10)
+            assert receipt.read_text() == "committed\n"
+            expected_queries = [] if fault == "after-effect" else [event.text]
+            assert second_model.queries == expected_queries
+            assert second.sink.completions[-1].outcome == (
+                "escalated" if fault == "after-effect" else "delivered"
+            )
+            pending = await second.async_redis.xpending(
+                second.config.stream, second.config.consumer_group
+            )
+            assert pending["pending"] == 0
+            assert await second.async_redis.exists(second.config.done_key(event.event_id))
+
+            # A second independently delivered duplicate cannot append again.
+            duplicate_id = await second.async_redis.xadd(
+                second.config.stream, to_stream_fields(event)
+            )
+            duplicate = await second.async_redis.xreadgroup(
+                second.config.consumer_group,
+                second.config.consumer_name,
+                {second.config.stream: ">"},
+                count=1,
+            )
+            assert duplicate[0][1][0][0] == duplicate_id
+            await consumer._dispatch(*duplicate[0][1][0])
+            await asyncio.wait_for(asyncio.gather(*list(consumer._inflight)), timeout=10)
+            assert receipt.read_text() == "committed\n"
+            assert second_model.queries == expected_queries
+            assert entry_id
+
+    asyncio.run(run())

--- a/apps/worker/tests/sandbox/test_delivery_resilience.py
+++ b/apps/worker/tests/sandbox/test_delivery_resilience.py
@@ -27,8 +27,9 @@ from curie_runner import RunTracer, SideEffectClassifier, create_app
 from curie_runner.fake import FakeModelSession
 from curie_runner.session import SessionRunner
 from curie_worker.consumer import Consumer
+from curie_worker.delivery_lease import DeliveryLeaseStore
 
-from apps.worker.tests.kernel.conftest import kernel_harness
+from apps.worker.tests.kernel.conftest import _ProcessEventSpy, kernel_harness
 
 
 class ReceiptModel(FakeModelSession):
@@ -80,8 +81,9 @@ def _runner(model: ReceiptModel) -> SessionRunner:
 
 
 @pytest.mark.parametrize("fault", ["before-effect", "after-effect"])
+@pytest.mark.parametrize("fenced", [False, True], ids=["legacy-unfenced", "current-fenced"])
 def test_reclaimed_delivery_commits_exactly_one_receipt(
-    fault: str, names: dict[str, str], sync_redis: redis.Redis, tmp_path: Path,
+    fault: str, fenced: bool, names: dict[str, str], sync_redis: redis.Redis, tmp_path: Path,
 ) -> None:
     async def run() -> None:
         receipt = tmp_path / "effect-receipts"
@@ -99,16 +101,28 @@ def test_reclaimed_delivery_commits_exactly_one_receipt(
         async with kernel_harness(
             names, sync_redis, runner_app=create_app(first_runner), reclaim_min_idle_ms=0,
         ) as first:
-            consumer = Consumer(redis=first.async_redis, kernel=first.kernel, config=first.config)
+            first_calls = _ProcessEventSpy(first.kernel)
+            first_config = first.config.model_copy(update={"consumer_name": "departed-worker"})
+            consumer = Consumer(
+                redis=first.async_redis, kernel=first.kernel, config=first_config,
+                leases=DeliveryLeaseStore(first.async_redis, first_config) if fenced else None,
+            )
             await consumer.ensure_group()
             entry_id = await first.async_redis.xadd(first.config.stream, to_stream_fields(event))
             deliveries = await first.async_redis.xreadgroup(
                 first.config.consumer_group, "departed-worker", {first.config.stream: ">"}, count=1,
             )
-            assert deliveries
-            task = asyncio.create_task(first.kernel.process_event(event))
+            assert deliveries[0][1][0][0] == entry_id
+            if fenced:
+                await consumer._dispatch(*deliveries[0][1][0])
+                task = next(iter(consumer._inflight))
+            else:
+                task = asyncio.create_task(first.kernel.process_event(event))
             try:
                 await asyncio.wait_for(first_model.reached.wait(), timeout=5)
+                if fenced:
+                    lease = first_calls.leases_for(event.event_id)[0]
+                    assert lease is not None and lease.generation == 1
                 if fault == "after-effect":
                     async with asyncio.timeout(5):
                         while not await first.async_redis.exists(
@@ -135,12 +149,17 @@ def test_reclaimed_delivery_commits_exactly_one_receipt(
         async with kernel_harness(
             names, sync_redis, runner_app=create_app(second_runner), reclaim_min_idle_ms=0,
         ) as second:
+            second_calls = _ProcessEventSpy(second.kernel)
+            second_config = second.config.model_copy(update={"consumer_name": "replacement-worker"})
             consumer = Consumer(
-                redis=second.async_redis, kernel=second.kernel, config=second.config
+                redis=second.async_redis, kernel=second.kernel, config=second_config,
+                leases=DeliveryLeaseStore(second.async_redis, second_config) if fenced else None,
             )
             await consumer.ensure_group()
             assert await consumer._reclaim_once() == 1
             await asyncio.wait_for(asyncio.gather(*list(consumer._inflight)), timeout=10)
+            if fenced:
+                assert second_calls.leases_for(event.event_id)[0].generation == 2
             assert receipt.read_text() == "committed\n"
             expected_queries = [] if fault == "after-effect" else [event.text]
             assert second_model.queries == expected_queries
@@ -159,7 +178,7 @@ def test_reclaimed_delivery_commits_exactly_one_receipt(
             )
             duplicate = await second.async_redis.xreadgroup(
                 second.config.consumer_group,
-                second.config.consumer_name,
+                second_config.consumer_name,
                 {second.config.stream: ">"},
                 count=1,
             )
@@ -168,6 +187,5 @@ def test_reclaimed_delivery_commits_exactly_one_receipt(
             await asyncio.wait_for(asyncio.gather(*list(consumer._inflight)), timeout=10)
             assert receipt.read_text() == "committed\n"
             assert second_model.queries == expected_queries
-            assert entry_id
 
     asyncio.run(run())

--- a/apps/worker/tests/sandbox/test_e2e_resilience.py
+++ b/apps/worker/tests/sandbox/test_e2e_resilience.py
@@ -1,100 +1,34 @@
-"""Sandbox-substrate resilience E2E against a standing Curie cluster.
+"""Sandbox-substrate resilience E2E on a disposable, task-owned cluster.
 
-The scenario drives the worker's ``SandboxSubstrate`` plus Valkey plus
-``kubectl`` directly, mirroring ``apps/worker/tests/sandbox/test_e2e_k8scratch.py``.
-There is no REST thread or message API to drive: a turn is a ``kubectl
-port-forward`` to the sandbox pod followed by ``POST /v1/event`` (NDJSON frames
-ending in a ``final``).
+The scenario drives the production SandboxSubstrate, real Valkey and runner ACI.
+Run three repetitions with ``CURIE_SANDBOX_E2E=1 CURIE_SANDBOX_E2E_RUNS=3 uv run
+pytest apps/worker/tests/sandbox/test_e2e_resilience.py -q``. The ordinary
+collector excludes this file unless the gate is enabled. Namespace, pool and
+capacity are selected by the CURIE_SANDBOX_E2E environment family; provision at
+least concurrency + batch ready replicas. Never target the permanent mail soak.
 
-It is opt-in: the sandbox collector excludes this module unless
-``CURIE_SANDBOX_E2E=1`` and the module retains the same guard for direct
-collection. The offline helpers in ``test_resilience_harness_unit.py`` remain in
-the normal ``apps/worker/tests`` collection and need neither a cluster nor a dev
-stack. To run the scenario three consecutive times against a standing cluster
-and dev-stack Valkey:
+Phases A/B assert distinct sandboxes, conversation affinity and a concurrent
+burst. Phase C replaces an idle sandbox and proves one surviving claim. Phase D
+asserts cold suspend/resume environment and a successful authenticated turn.
+Every ACI turn must end successfully: an HTTP 200 stream or a failed final does
+not pass. Set CURIE_SANDBOX_E2E_LIVE=1 (or CURIE_E2E_LIVE=1) to require a live
+pool, content isolation, durable recall and cache evidence. Credentials may live
+only in the pool's Secret; missing prerequisites fail the live run, never skip it.
+Phase D requires CURIE_SANDBOX_E2E_HISTORY_REF to name a task-owned real state
+API transcript, CURIE_SANDBOX_E2E_HISTORY_TOKEN for its scoped credential and
+CURIE_SANDBOX_E2E_HISTORY_MARKER for the synthetic token seeded in that transcript.
 
-``CURIE_SANDBOX_E2E=1 CURIE_SANDBOX_E2E_RUNS=3 uv run pytest
-apps/worker/tests/sandbox/test_e2e_resilience.py -q``
+These phases do not claim a worker process kill, a mid-tool pod kill, actual
+side-effect idempotency, eval-stream delivery or cache reuse merely from pod
+identity. The companion test_delivery_resilience.py counts durable subprocess
+receipts across fresh kernel/runner instances and real PEL reclaim, with fake
+Kubernetes and provider seams. Actual pod/worker crash and eval-fanout acceptance
+still needs separate disposable-cluster execution.
 
-Size the warm pool to at least ``CURIE_SANDBOX_E2E_CONCURRENCY +
-CURIE_SANDBOX_E2E_BATCH`` ready replicas. ``pool_ready`` blocks until the pool
-reports that capacity, so the concurrent claims and batch burst do not starve.
-``CURIE_SANDBOX_E2E_NAMESPACE`` and ``CURIE_SANDBOX_E2E_POOL`` select the
-standing-cluster resources; the namespace/pool and Valkey defaults match the
-sandbox E2E template. With a live Claude credential, reply-content isolation
-assertions and the cache-token probe are also enabled. Without one, the
-fake-model runner still proves every structural property but does not echo
-markers, so content-level cross-talk assertions do not run.
-
-Four phases share the module-scoped substrate and a set of held claims:
-
-- Phase A: concurrent threads are isolated (distinct sandboxes) and affined
-  (re-claim returns the same sandbox); with live creds, no content cross-talk.
-- Phase B: a mid-thread batch burst runs while Phase-A threads are held, and
-  leaves them undisturbed (same pod UIDs).
-- Phase C: a sandbox is killed mid-run (unclean pod delete); the thread
-  re-claims a fresh sandbox and exactly one live claim survives (no orphan or
-  duplicate side effect at the substrate level).
-- Phase D: one thread is suspended and resumed under sustained load on the
-  others; the resumed pod carries the injected history ref and the loaded
-  threads keep their pods.
-
-A cache-warmth proxy asserts pod-UID affinity across consecutive turns (the
-ADR-0003 "same pod across turns" property that enables prompt-cache reuse); see
-the documented assumptions below for why the direct
-``cache_read_input_tokens`` signal is not cluster-observable today.
-
-Documented assumptions and gaps:
-
-1. **"Batch job" is interpreted as a concurrent burst under sustained load.**
-   The batch phase launches ``CURIE_SANDBOX_E2E_BATCH`` additional threads while
-   the Phase-A threads are still held claimed, and asserts the batch turns
-   complete without disturbing the held threads. An alternative reading of
-   "batch job" is an eval fan-out (an ``XADD`` to the ``curie:evals`` stream
-   consumed by a separate consumer group). That path is not part of the sandbox
-   substrate this scenario drives, so it is noted here as an alternative rather
-   than exercised.
-
-2. **"No duplicate side effects" is asserted at the substrate level (one live
-   claim survives a kill), not as end-to-end side-effect idempotency.** The
-   semantic invariant, a failed run that emitted a side effect escalates to a
-   human instead of auto-retrying, is the kernel's fourth rule in
-   ``apps/worker/CLAUDE.md`` and already has a provoking integration test in
-   ``apps/worker/tests/kernel``. This scenario drives the ``SandboxSubstrate``
-   seam directly, mirroring ``test_e2e_k8scratch.py``, and therefore asserts the
-   observable substrate-level proxy: after an unclean kill and re-claim, exactly
-   one live ``SandboxClaim`` remains for the thread hash (no orphaned or
-   duplicated claim). Re-driving turns through the kernel path (a Valkey
-   ``curie:runs`` producer plus a fake Slack sink plus the in-cluster consumer)
-   to count actual side-effect executions is deliberately outside this
-   footprint: it would duplicate the kernel suite's existing coverage and pull
-   this scenario away from the substrate seam it is meant to stress.
-
-3. **``cache_read_input_tokens`` is not observable at the cluster level, so the
-   scenario asserts pod-UID affinity as the cache-warmth proxy.** The runner's
-   OTel export (``runner/src/curie_runner/otel.py``,
-   ``_GenerationSpan.record_usage``) exports only
-   ``gen_ai.usage.input_tokens`` and ``output_tokens`` and drops the cache-token
-   fields, so Langfuse never records ``cache_read_input_tokens``. It is asserted
-   only at the SDK layer in ``runner/tests/test_live.py``. The scenario therefore
-   asserts the cluster-observable property that enables cache reuse: the same
-   pod (same pod UID) serves consecutive turns on a thread (ADR-0003 "same pod
-   across turns"). The single ``xfail`` probe, ``test_cache_read_tokens_probe``,
-   reads per-trace usage from Langfuse and would turn green if the OTel export is
-   later extended.
-
-Follow-ups outside this footprint:
-
-- Extend ``runner/src/curie_runner/otel.py`` to export
-  ``cache_read_input_tokens`` and ``cache_creation_input_tokens``; the ``xfail``
-  probe becomes a real assertion then.
-- Add an end-to-end side-effect-idempotency resilience scenario that drives
-  turns through the kernel path (a Valkey ``curie:runs`` producer plus a fake
-  Slack sink plus the in-cluster consumer), kills a sandbox after a
-  side-effecting tool call fires, re-drives, and asserts the effect executed
-  exactly once.
-- If an eval-fanout batch interpretation is wanted, add a phase that drives the
-  ``curie:evals`` stream and its consumer group.
+The live cache probe drives two successful turns and queries their explicit
+trace identity in Langfuse. A missing endpoint, missing usage or unrelated cached
+observation cannot qualify. The runner already exports cache-token OTel fields;
+a stale xfail on that export would mask a regression.
 """
 
 from __future__ import annotations
@@ -103,11 +37,11 @@ import os
 import subprocess
 import sys
 import time
-import urllib.error
-import urllib.request
+import uuid
 from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from urllib.parse import urlparse
 
 import pytest
 
@@ -132,6 +66,7 @@ from resilience_harness import (  # noqa: E402
     port_forward,
     post_event,
     thread_hash,
+    trace_cache_reads,
     unique_marker,
 )
 
@@ -156,12 +91,22 @@ def _drive_turn(
     *,
     user: str,
     ts: str,
+    token: str = "",
+    trace_id: str | None = None,
 ) -> list[dict[str, object]]:
     """Port-forward to a sandbox, assert health, post one ACI turn, return frames."""
 
+    if cfg.live_model:
+        # Read only the model-mode bit. Never dump the pod's credential env.
+        fake = kubectl(
+            cfg, "get", "pod", sandbox_name,
+            "-o", 'jsonpath={.spec.containers[?(@.name=="runner")]'
+            '.env[?(@.name=="CURIE_FAKE_MODEL")].value}',
+        ).strip().lower()
+        assert fake not in {"1", "true", "yes"}, "required live run reached a fake-model pod"
     with port_forward(cfg, sandbox_name, port) as base:
         assert get_json(base, "/healthz") == {"ok": True}
-        return post_event(base, text, user=user, ts=ts)
+        return post_event(base, text, user=user, ts=ts, token=token, trace_id=trace_id)
 
 
 def _assert_final(frames: Sequence[dict[str, object]]) -> None:
@@ -185,13 +130,23 @@ def _wait_pod_gone(cfg: ResilienceConfig, sandbox_name: str, timeout: float = 90
 def test_e2e_resilience(
     run: int, substrate: object, cfg: ResilienceConfig, pool_ready: None
 ) -> None:
+    from aci_protocol import BootEnv
     from curie_worker.sandbox import HISTORY_ENV, SandboxHandle, SandboxSubstrate
 
     assert isinstance(substrate, SandboxSubstrate)
+    # The operator prepares an isolated transcript through the real state API.
+    # An arbitrary marker is not a valid history ref: runner boot rejects it.
+    history_ref = os.environ.get("CURIE_SANDBOX_E2E_HISTORY_REF", "")
+    history_marker = os.environ.get("CURIE_SANDBOX_E2E_HISTORY_MARKER", "")
+    assert urlparse(history_ref).scheme in {"http", "https"} and history_marker, (
+        "configure a task-owned state API transcript URL and its synthetic expected marker "
+        "using CURIE_SANDBOX_E2E_HISTORY_REF and CURIE_SANDBOX_E2E_HISTORY_MARKER"
+    )
     print(f"\nEVIDENCE resilience_run={run} concurrency={cfg.concurrency} batch={cfg.batch}")
 
-    a_keys = [f"soak-a-{run}-{i}" for i in range(cfg.concurrency)]
-    batch_keys = [f"soak-batch-{run}-{j}" for j in range(cfg.batch)]
+    scope = uuid.uuid4().hex
+    a_keys = [f"resilience-{scope}-a-{run}-{i}" for i in range(cfg.concurrency)]
+    batch_keys = [f"resilience-{scope}-batch-{run}-{j}" for j in range(cfg.batch)]
     claimed: dict[str, SandboxHandle] = {}
     markers: dict[str, str] = {}
     uids: dict[str, str] = {}
@@ -214,7 +169,10 @@ def test_e2e_resilience(
         def _turn(key: str) -> tuple[str, list[dict[str, object]]]:
             handle = claimed[key]
             text = f"Please remember this token exactly: {markers[key]}"
-            frames = _drive_turn(cfg, handle.sandbox_name, handle.port, text, user=key, ts="1.0")
+            frames = _drive_turn(
+                cfg, handle.sandbox_name, handle.port, text,
+                user=key, ts="1.0", token=handle.token,
+            )
             return key, frames
 
         replies: dict[str, list[dict[str, object]]] = {}
@@ -231,7 +189,7 @@ def test_e2e_resilience(
         print("EVIDENCE phase_a_affinity_stable=true")
 
         # Content-level no-cross-talk only when a real model is behind the runner.
-        if cfg.live_creds:
+        if cfg.live_model:
             all_markers = list(markers.values())
             for key in a_keys:
                 text = collected_text(replies[key])
@@ -250,7 +208,8 @@ def test_e2e_resilience(
             handle = substrate.claim(key)
             claimed[key] = handle
             frames = _drive_turn(
-                cfg, handle.sandbox_name, handle.port, "batch turn under load", user=key, ts="1.0"
+                cfg, handle.sandbox_name, handle.port, "batch turn under load",
+                user=key, ts="1.0", token=handle.token,
             )
             return key, frames
 
@@ -270,10 +229,9 @@ def test_e2e_resilience(
         assert pod_uid(pod_of_sandbox(cfg, claimed[probe].sandbox_name)) == uids[probe]
         print("EVIDENCE phase_b_phase_a_undisturbed=true")
 
-        # -- Phase C: sandbox killed mid-run ---------------------------------
-        # The kernel's no-auto-retry-after-side-effects escalation is unit-tested
-        # in apps/worker/tests/kernel; here we assert the substrate-level proxy
-        # for "no duplicate side effect": exactly one live claim survives a kill.
+        # -- Phase C: idle sandbox replacement -------------------------------
+        # One live claim proves substrate cleanup only. It does not count tool
+        # side effects or claim to interrupt an active turn.
         victim = a_keys[-1]
         victim_hash = thread_hash(victim)
         victim_sandbox = claimed[victim].sandbox_name
@@ -287,7 +245,8 @@ def test_e2e_resilience(
         new_uid = pod_uid(pod_of_sandbox(cfg, fresh.sandbox_name))
         assert new_uid != old_uid, "re-claim returned the killed pod UID"
         frames = _drive_turn(
-            cfg, fresh.sandbox_name, fresh.port, "back after a kill", user=victim, ts="2.0"
+            cfg, fresh.sandbox_name, fresh.port, "back after a kill",
+            user=victim, ts="2.0", token=fresh.token,
         )
         _assert_final(frames)
         uids[victim] = new_uid
@@ -308,12 +267,12 @@ def test_e2e_resilience(
         loaded = [k for k in a_keys if k != victim][: max(cfg.concurrency - 1, 1)]
         target = loaded[0]
         others = loaded[1:]
-        target_marker = markers[target]
 
         def _sustained(key: str) -> str:
             handle = claimed[key]
             frames = _drive_turn(
-                cfg, handle.sandbox_name, handle.port, "sustained follow-up", user=key, ts="3.0"
+                cfg, handle.sandbox_name, handle.port, "sustained follow-up",
+                user=key, ts="3.0", token=handle.token,
             )
             _assert_final(frames)
             return key
@@ -321,9 +280,12 @@ def test_e2e_resilience(
         original_claim = claimed[target].claim_name
         with ThreadPoolExecutor(max_workers=max(len(others), 1)) as pool:
             load = pool.map(_sustained, others) if others else iter(())
-            substrate.suspend(target, history_ref=target_marker)
+            substrate.suspend(target, history_ref=history_ref)
             _wait_pod_gone(cfg, claimed[target].sandbox_name)
-            resumed = substrate.resume(target)
+            history_token = os.environ.get("CURIE_SANDBOX_E2E_HISTORY_TOKEN", "")
+            resumed = substrate.resume(
+                target, env={BootEnv.env_key("history_token"): history_token},
+            )
             claimed[target] = resumed
             list(load)
 
@@ -336,11 +298,18 @@ def test_e2e_resilience(
             for c in containers
             for e in c.get("env", [])
         }
-        assert env.get(HISTORY_ENV) == target_marker, "resumed pod missing injected history ref"
+        actual_history_ref = env.get(HISTORY_ENV)
+        del env
+        assert actual_history_ref == history_ref, "resumed pod missing injected history ref"
         frames = _drive_turn(
-            cfg, resumed.sandbox_name, resumed.port, "resumed and rehydrated", user=target, ts="4.0"
+            cfg, resumed.sandbox_name, resumed.port,
+            "What exact verification token was recorded in the durable transcript? "
+            "Reply only that token.",
+            user=target, ts="4.0", token=resumed.token,
         )
         _assert_final(frames)
+        if cfg.live_model:
+            assert history_marker in collected_text(frames), "resumed runner lost durable history"
         for key in others:
             assert pod_uid(pod_of_sandbox(cfg, claimed[key].sandbox_name)) == uids[key], (
                 f"suspend/resume disturbed concurrently loaded thread {key}"
@@ -352,12 +321,12 @@ def test_e2e_resilience(
         first_uid = pod_uid(pod_of_sandbox(cfg, claimed[stable].sandbox_name))
         frames = _drive_turn(
             cfg, claimed[stable].sandbox_name, claimed[stable].port, "warmth turn one",
-            user=stable, ts="5.0",
+            user=stable, ts="5.0", token=claimed[stable].token,
         )
         _assert_final(frames)
         frames = _drive_turn(
             cfg, claimed[stable].sandbox_name, claimed[stable].port, "warmth turn two",
-            user=stable, ts="6.0",
+            user=stable, ts="6.0", token=claimed[stable].token,
         )
         _assert_final(frames)
         second_uid = pod_uid(pod_of_sandbox(cfg, claimed[stable].sandbox_name))
@@ -372,50 +341,44 @@ def test_e2e_resilience(
                 pass
 
 
-@pytest.mark.xfail(
-    strict=False,
-    reason=(
-        "otel.py does not export cache_read_input_tokens; "
-        "see runner/src/curie_runner/otel.py -- tracked follow-up"
-    ),
-)
 @pytest.mark.skipif(
-    not (os.environ.get("CLAUDE_CODE_OAUTH_TOKEN") or os.environ.get("ANTHROPIC_API_KEY")),
-    reason="cache-token probe needs live creds so a real model reports usage",
+    not ResilienceConfig.from_env().live_model,
+    reason="cache is outside the fake tier; select CURIE_SANDBOX_E2E_LIVE=1 for the live probe",
 )
-def test_cache_read_tokens_probe(cfg: ResilienceConfig) -> None:
-    """Probe: assert a per-trace ``cache_read_input_tokens`` is observable.
+def test_cache_read_tokens_probe(
+    substrate: object, cfg: ResilienceConfig, pool_ready: None,
+) -> None:
+    """Attribute cache reads to an actual follow-up, with an absent-trace control."""
 
-    This lights up green only if the runner's OTel export is later extended to
-    carry the cache-token fields (today ``_GenerationSpan.record_usage`` drops
-    them, so Langfuse never sees them). Reading is via the Langfuse public API
-    using the dev-stack keys; if Langfuse is not reachable the probe skips.
-    """
+    from curie_worker.sandbox import SandboxSubstrate
 
-    host = os.environ.get("LANGFUSE_HOST", "http://localhost:23000")
-    public_key = os.environ.get("LANGFUSE_PUBLIC_KEY", "pk-lf-curie-dev")
-    secret_key = os.environ.get("LANGFUSE_SECRET_KEY", "sk-lf-curie-dev")
-
-    import base64
-
-    token = base64.b64encode(f"{public_key}:{secret_key}".encode()).decode()
-    request = urllib.request.Request(
-        f"{host}/api/public/observations?limit=50",
-        headers={"Authorization": f"Basic {token}"},
-    )
+    assert isinstance(substrate, SandboxSubstrate)
+    key = f"cache-{uuid.uuid4().hex}"
     try:
-        with urllib.request.urlopen(request, timeout=10) as resp:
-            import json
-
-            payload = json.loads(resp.read())
-    except (urllib.error.URLError, TimeoutError) as exc:
-        pytest.skip(f"Langfuse not reachable for the cache-token probe: {exc}")
-
-    observations = payload.get("data", [])
-    cache_reads = [
-        (o.get("usage") or {}).get("cache_read_input_tokens", 0) for o in observations
-    ]
-    assert any((count or 0) > 0 for count in cache_reads), (
-        "no observation reported cache_read_input_tokens > 0 "
-        "(otel.py drops the cache-token fields today)"
-    )
+        handle = substrate.claim(key)
+        # A unique, substantial prompt makes the continuation useful for a
+        # real cache probe. Two tiny replies alone may never reach a provider's
+        # minimum cacheable prefix size.
+        context = "\n".join(f"Record {i}: {key} item {i * 17}" for i in range(500))
+        _drive_turn(
+            cfg, handle.sandbox_name, handle.port,
+            f"Remember these records for the next turn. Reply only READY.\n{context}",
+            user=key, ts="1.0", token=handle.token,
+        )
+        trace_id = uuid.uuid4().hex
+        followup = _drive_turn(
+            cfg, handle.sandbox_name, handle.port, "What is the item value in Record 17?",
+            user=key, ts="2.0", token=handle.token, trace_id=trace_id,
+        )
+        assert "289" in collected_text(followup), "follow-up did not retain the primed records"
+        deadline = time.monotonic() + 120
+        while True:
+            reads = trace_cache_reads(trace_id)
+            if reads > 0:
+                break
+            assert time.monotonic() < deadline, "follow-up trace has no observed cache reads"
+            time.sleep(2)
+        assert trace_cache_reads(uuid.uuid4().hex) == 0, "unobserved trace reported cached tokens"
+        print(f"EVIDENCE cache_followup_trace={trace_id} cache_read_input_tokens={reads}")
+    finally:
+        substrate.release(key)

--- a/apps/worker/tests/sandbox/test_e2e_resilience.py
+++ b/apps/worker/tests/sandbox/test_e2e_resilience.py
@@ -14,8 +14,9 @@ Every ACI turn must end successfully: an HTTP 200 stream or a failed final does
 not pass. Set CURIE_SANDBOX_E2E_LIVE=1 (or CURIE_E2E_LIVE=1) to require a live
 pool, content isolation, durable recall and cache evidence. Credentials may live
 only in the pool's Secret; missing prerequisites fail the live run, never skip it.
-Phase D requires CURIE_SANDBOX_E2E_HISTORY_REF to name a task-owned real state
-API transcript, CURIE_SANDBOX_E2E_HISTORY_TOKEN for its scoped credential and
+The whole scenario preflights its phase-D fixture before creating any claims:
+CURIE_SANDBOX_E2E_HISTORY_REF must name a task-owned real state API transcript,
+CURIE_SANDBOX_E2E_HISTORY_TOKEN supplies its scoped credential and
 CURIE_SANDBOX_E2E_HISTORY_MARKER for the synthetic token seeded in that transcript.
 
 These phases do not claim a worker process kill, a mid-tool pod kill, actual
@@ -41,7 +42,6 @@ import uuid
 from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from urllib.parse import urlparse
 
 import pytest
 
@@ -55,6 +55,7 @@ from resilience_fixtures import (  # noqa: E402, F401
 )
 from resilience_harness import (  # noqa: E402
     ResilienceConfig,
+    assert_exact_recall,
     collected_text,
     detect_cross_talk,
     final_frame,
@@ -65,6 +66,8 @@ from resilience_harness import (  # noqa: E402
     pod_uid,
     port_forward,
     post_event,
+    release_claims,
+    required_history_fixture,
     thread_hash,
     trace_cache_reads,
     unique_marker,
@@ -98,12 +101,12 @@ def _drive_turn(
 
     if cfg.live_model:
         # Read only the model-mode bit. Never dump the pod's credential env.
-        fake = kubectl(
-            cfg, "get", "pod", sandbox_name,
-            "-o", 'jsonpath={.spec.containers[?(@.name=="runner")]'
-            '.env[?(@.name=="CURIE_FAKE_MODEL")].value}',
-        ).strip().lower()
-        assert fake not in {"1", "true", "yes"}, "required live run reached a fake-model pod"
+        mode = kubectl(
+            cfg, "exec", sandbox_name, "-c", "runner", "--", "python", "-c",
+            "import os; print('fake' if os.environ.get('CURIE_FAKE_MODEL','').lower() "
+            "in {'1','true','yes'} else 'live')",
+        ).strip()
+        assert mode == "live", "required live run reached a fake-model or unverified pod"
     with port_forward(cfg, sandbox_name, port) as base:
         assert get_json(base, "/healthz") == {"ok": True}
         return post_event(base, text, user=user, ts=ts, token=token, trace_id=trace_id)
@@ -136,12 +139,7 @@ def test_e2e_resilience(
     assert isinstance(substrate, SandboxSubstrate)
     # The operator prepares an isolated transcript through the real state API.
     # An arbitrary marker is not a valid history ref: runner boot rejects it.
-    history_ref = os.environ.get("CURIE_SANDBOX_E2E_HISTORY_REF", "")
-    history_marker = os.environ.get("CURIE_SANDBOX_E2E_HISTORY_MARKER", "")
-    assert urlparse(history_ref).scheme in {"http", "https"} and history_marker, (
-        "configure a task-owned state API transcript URL and its synthetic expected marker "
-        "using CURIE_SANDBOX_E2E_HISTORY_REF and CURIE_SANDBOX_E2E_HISTORY_MARKER"
-    )
+    history_ref, history_token, history_marker = required_history_fixture(os.environ)
     print(f"\nEVIDENCE resilience_run={run} concurrency={cfg.concurrency} batch={cfg.batch}")
 
     scope = uuid.uuid4().hex
@@ -282,7 +280,6 @@ def test_e2e_resilience(
             load = pool.map(_sustained, others) if others else iter(())
             substrate.suspend(target, history_ref=history_ref)
             _wait_pod_gone(cfg, claimed[target].sandbox_name)
-            history_token = os.environ.get("CURIE_SANDBOX_E2E_HISTORY_TOKEN", "")
             resumed = substrate.resume(
                 target, env={BootEnv.env_key("history_token"): history_token},
             )
@@ -299,8 +296,10 @@ def test_e2e_resilience(
             for e in c.get("env", [])
         }
         actual_history_ref = env.get(HISTORY_ENV)
-        del env
+        history_token_matches = env.get(BootEnv.env_key("history_token")) == history_token
+        del env, containers, resumed_pod, history_token
         assert actual_history_ref == history_ref, "resumed pod missing injected history ref"
+        assert history_token_matches, "resumed pod missing matching scoped history credential"
         frames = _drive_turn(
             cfg, resumed.sandbox_name, resumed.port,
             "What exact verification token was recorded in the durable transcript? "
@@ -309,12 +308,13 @@ def test_e2e_resilience(
         )
         _assert_final(frames)
         if cfg.live_model:
-            assert history_marker in collected_text(frames), "resumed runner lost durable history"
+            assert_exact_recall(frames, history_marker)
         for key in others:
             assert pod_uid(pod_of_sandbox(cfg, claimed[key].sandbox_name)) == uids[key], (
                 f"suspend/resume disturbed concurrently loaded thread {key}"
             )
-        print(f"EVIDENCE phase_d_resume_injected_history_ref pod={resumed.sandbox_name}")
+        proof = "authenticated_runner_recall" if cfg.live_model else "UNPROVED_environment_only"
+        print(f"EVIDENCE phase_d_history={proof}")
 
         # -- Cache-warmth proxy: same pod across consecutive turns ------------
         stable = loaded[-1] if len(loaded) > 1 else target
@@ -334,11 +334,7 @@ def test_e2e_resilience(
         print(f"EVIDENCE same_pod_across_turns uid={first_uid}")
 
     finally:
-        for key in list(claimed):
-            try:
-                substrate.release(key)
-            except Exception:
-                pass
+        release_claims(substrate.release, list(claimed))
 
 
 @pytest.mark.skipif(
@@ -354,12 +350,13 @@ def test_cache_read_tokens_probe(
 
     assert isinstance(substrate, SandboxSubstrate)
     key = f"cache-{uuid.uuid4().hex}"
+    handle = substrate.claim(key)
     try:
-        handle = substrate.claim(key)
         # A unique, substantial prompt makes the continuation useful for a
         # real cache probe. Two tiny replies alone may never reach a provider's
         # minimum cacheable prefix size.
-        context = "\n".join(f"Record {i}: {key} item {i * 17}" for i in range(500))
+        values = [unique_marker(key, i) for i in range(500)]
+        context = "\n".join(f"Record {i}: {value}" for i, value in enumerate(values))
         _drive_turn(
             cfg, handle.sandbox_name, handle.port,
             f"Remember these records for the next turn. Reply only READY.\n{context}",
@@ -367,10 +364,11 @@ def test_cache_read_tokens_probe(
         )
         trace_id = uuid.uuid4().hex
         followup = _drive_turn(
-            cfg, handle.sandbox_name, handle.port, "What is the item value in Record 17?",
+            cfg, handle.sandbox_name, handle.port,
+            "What is the exact value in Record 17? Reply only that value.",
             user=key, ts="2.0", token=handle.token, trace_id=trace_id,
         )
-        assert "289" in collected_text(followup), "follow-up did not retain the primed records"
+        assert_exact_recall(followup, values[17])
         deadline = time.monotonic() + 120
         while True:
             reads = trace_cache_reads(trace_id)
@@ -381,4 +379,4 @@ def test_cache_read_tokens_probe(
         assert trace_cache_reads(uuid.uuid4().hex) == 0, "unobserved trace reported cached tokens"
         print(f"EVIDENCE cache_followup_trace={trace_id} cache_read_input_tokens={reads}")
     finally:
-        substrate.release(key)
+        release_claims(substrate.release, [key])

--- a/apps/worker/tests/sandbox/test_resilience_harness_unit.py
+++ b/apps/worker/tests/sandbox/test_resilience_harness_unit.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import hashlib
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -18,13 +19,86 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parent))
 
 from resilience_harness import (  # noqa: E402
+    assert_exact_recall,
     cache_reads_for_trace,
     collected_text,
     detect_cross_talk,
     final_frame,
+    release_claims,
+    required_history_fixture,
     thread_hash,
     unique_marker,
 )
+
+
+def test_recall_requires_exact_successful_final_not_substring_or_tool_note() -> None:
+    expected = "soakmark-cache-example-17-f00"
+    assert_exact_recall([{"type": "final", "status": "done", "text": expected}], expected)
+    for frames in (
+        [{"type": "final", "status": "done", "text": "prefix " + expected}],
+        [{"type": "tool_note", "text": expected}, {"type": "final", "text": "unrelated"}],
+        [{"type": "final", "status": "classified-failure", "text": expected}],
+        [{"type": "final", "status": "done", "text": "a-key-with-289-inside"}],
+    ):
+        with pytest.raises(AssertionError):
+            assert_exact_recall(frames, expected)
+
+
+def _history_env() -> dict[str, str]:
+    from curie_worker.sandbox_token import mint
+
+    agent = "00000000-0000-0000-0000-000000000001"
+    return {
+        "CURIE_SANDBOX_E2E_HISTORY_REF":
+            f"https://api.example.com/agents/{agent}/state/transcript/example-thread",
+        "CURIE_SANDBOX_E2E_HISTORY_MARKER": "synthetic-history-example-marker",
+        "CURIE_SANDBOX_E2E_HISTORY_TOKEN": mint(
+            "test-signing-key", agent=agent, scope="state", exp=int(time.time()) + 300,
+        ),
+    }
+
+
+def test_history_fixture_requires_transcript_key_and_scoped_token_shape() -> None:
+    env = _history_env()
+    ref, token, marker = required_history_fixture(env)
+    assert ref == env["CURIE_SANDBOX_E2E_HISTORY_REF"]
+    assert token == env["CURIE_SANDBOX_E2E_HISTORY_TOKEN"]
+    assert marker == env["CURIE_SANDBOX_E2E_HISTORY_MARKER"]
+
+
+@pytest.mark.parametrize("key,value", [
+    ("CURIE_SANDBOX_E2E_HISTORY_REF", "https://example.com/"),
+    ("CURIE_SANDBOX_E2E_HISTORY_REF", "not-a-url"),
+    ("CURIE_SANDBOX_E2E_HISTORY_REF",
+     "https://api.example.com/agents/00000000-0000-0000-0000-000000000002/state/transcript/key"),
+    ("CURIE_SANDBOX_E2E_HISTORY_TOKEN", ""),
+    ("CURIE_SANDBOX_E2E_HISTORY_TOKEN", "platform-key-sentinel"),
+    ("CURIE_SANDBOX_E2E_HISTORY_TOKEN", "sbx.not-json.signature"),
+    ("CURIE_SANDBOX_E2E_HISTORY_MARKER", ""),
+])
+def test_invalid_history_fixture_is_refused_without_echo(key: str, value: str) -> None:
+    env = _history_env()
+    env[key] = value
+    with pytest.raises(AssertionError) as caught:
+        required_history_fixture(env)
+    assert "platform-key-sentinel" not in str(caught.value)
+
+
+def test_cleanup_attempts_every_owned_release_and_reports_failure_without_payload() -> None:
+    calls: list[str] = []
+
+    def release(key: str) -> None:
+        calls.append(key)
+        if key == "broken":
+            raise RuntimeError("private-response-sentinel")
+
+    with pytest.raises(AssertionError) as caught:
+        release_claims(release, ["broken", "healthy"])
+    assert calls == ["broken", "healthy"]
+    assert "private-response-sentinel" not in str(caught.value)
+    calls.clear()
+    release_claims(release, ["healthy", "another"])
+    assert calls == ["healthy", "another"]
 
 
 def test_thread_hash_matches_sha256_prefix() -> None:
@@ -128,4 +202,48 @@ def test_cache_probe_rejects_malformed_usage(count: object) -> None:
                 "usageDetails": {"input_cached_tokens": count},
             }],
             "ours",
+        )
+
+
+@pytest.mark.parametrize("runtime_mode", ["1", "true", "YES", "false", "0", ""])
+def test_live_requirement_checks_effective_container_mode_before_forwarding(
+    monkeypatch: pytest.MonkeyPatch, runtime_mode: str,
+) -> None:
+    import importlib.util
+    import os
+    import subprocess
+    from dataclasses import replace
+
+    from resilience_harness import ResilienceConfig
+
+    spec = importlib.util.spec_from_file_location(
+        "resilience_scenario_mode_test", Path(__file__).with_name("test_e2e_resilience.py"),
+    )
+    assert spec is not None and spec.loader is not None
+    scenario = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(scenario)
+
+    def external_kubectl(_cfg: object, *args: str) -> str:
+        if args[0] == "get":
+            # A Secret/envFrom-supplied bit has no direct pod .env[].value.
+            return ""
+        assert args[0] == "exec" and args[-2] == "-c"
+        env = {**os.environ, "CURIE_FAKE_MODEL": runtime_mode,
+               "PROVIDER_TOKEN": "test-private-sentinel"}
+        result = subprocess.run(
+            [sys.executable, "-c", args[-1]], env=env, capture_output=True, text=True, check=True,
+        )
+        assert "test-private-sentinel" not in result.stdout + result.stderr
+        return result.stdout
+
+    def external_forward(*_args: object) -> None:
+        raise AssertionError("port-forward reached")
+
+    monkeypatch.setattr(scenario, "kubectl", external_kubectl)
+    monkeypatch.setattr(scenario, "port_forward", external_forward)
+    expected = "fake-model" if runtime_mode.lower() in {"1", "true", "yes"} else "port-forward"
+    with pytest.raises(AssertionError, match=expected):
+        scenario._drive_turn(
+            replace(ResilienceConfig.from_env(), live_model=True),
+            "example-runner", 8000, "example", user="example", ts="1.0",
         )

--- a/apps/worker/tests/sandbox/test_resilience_harness_unit.py
+++ b/apps/worker/tests/sandbox/test_resilience_harness_unit.py
@@ -13,9 +13,12 @@ import hashlib
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).parent))
 
 from resilience_harness import (  # noqa: E402
+    cache_reads_for_trace,
     collected_text,
     detect_cross_talk,
     final_frame,
@@ -103,3 +106,26 @@ def test_detect_cross_talk_false_when_no_markers_present() -> None:
     own = "soakmark-a-0-aaaa"
     others = [own, "soakmark-b-1-bbbb"]
     assert detect_cross_talk(own, others, "no markers at all") is False
+
+
+def test_cache_reads_are_attributed_only_to_the_requested_generation_trace() -> None:
+    observations: list[dict[str, object]] = [
+        {"traceId": "ours", "type": "GENERATION", "usageDetails": {"input_cached_tokens": 27}},
+        {"traceId": "ours", "type": "GENERATION", "usageDetails": {"cache_read_input_tokens": 3}},
+        {"traceId": "foreign", "type": "GENERATION", "usageDetails": {"input_cached_tokens": 999}},
+        {"traceId": "ours", "type": "SPAN", "usageDetails": {"input_cached_tokens": 999}},
+    ]
+    assert cache_reads_for_trace(observations, "ours") == 30
+    assert cache_reads_for_trace(observations, "unobserved") == 0
+
+
+@pytest.mark.parametrize("count", [-1, True, "27"])
+def test_cache_probe_rejects_malformed_usage(count: object) -> None:
+    with pytest.raises(AssertionError, match="nonnegative integer"):
+        cache_reads_for_trace(
+            [{
+                "traceId": "ours", "type": "GENERATION",
+                "usageDetails": {"input_cached_tokens": count},
+            }],
+            "ours",
+        )

--- a/apps/worker/tests/sandbox/test_resilience_runner_outcomes.py
+++ b/apps/worker/tests/sandbox/test_resilience_runner_outcomes.py
@@ -1,0 +1,139 @@
+"""Exercise the resilience oracle through the real runner HTTP surface.
+
+Only the external model is scripted. A classified failure is a real runner
+terminal, and must never qualify as a successful resilience turn.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+from aci_protocol import PROTOCOL_VERSION
+from aiohttp import web
+from aiohttp.test_utils import TestServer
+from claude_agent_sdk import ResultMessage
+from curie_runner import RunTracer, SideEffectClassifier, create_app
+from curie_runner.fake import FakeModelSession
+from curie_runner.session import SessionRunner
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from resilience_harness import post_event  # noqa: E402
+
+
+@pytest.mark.parametrize("failed", [False, True])
+def test_resilience_requires_success_from_the_actual_runner(failed: bool) -> None:
+    async def run() -> None:
+        model = FakeModelSession(
+            lambda: [
+                ResultMessage(
+                    subtype="error_during_execution" if failed else "success",
+                    duration_ms=1,
+                    duration_api_ms=1,
+                    is_error=failed,
+                    num_turns=1,
+                    session_id="resilience-session",
+                    result="provider refused" if failed else "completed",
+                )
+            ]
+        )
+        runner = SessionRunner(
+            session_factory=lambda: model,
+            ceiling=0,
+            tracer=RunTracer(None),
+            classifier=SideEffectClassifier(),
+            trace_name="resilience-oracle",
+        )
+        await runner.start()
+        async with TestServer(create_app(runner)) as server:
+            base = str(server.make_url("/")).rstrip("/")
+            if failed:
+                with pytest.raises(AssertionError, match="classified-failure"):
+                    await asyncio.to_thread(post_event, base, "run the task")
+            else:
+                frames = await asyncio.to_thread(post_event, base, "run the task")
+                assert frames[-1]["status"] == "done"
+
+    asyncio.run(run())
+
+
+def test_resilience_can_drive_the_cold_resumed_runner_token() -> None:
+    async def run() -> None:
+        runner = SessionRunner(
+            session_factory=FakeModelSession,
+            ceiling=0,
+            tracer=RunTracer(None),
+            classifier=SideEffectClassifier(),
+            trace_name="resilience-token",
+        )
+        await runner.start()
+        async with TestServer(create_app(runner, token="example-conversation-token")) as server:
+            base = str(server.make_url("/")).rstrip("/")
+            from urllib.error import HTTPError
+
+            with pytest.raises(HTTPError) as refused:
+                await asyncio.to_thread(post_event, base, "unauthorized")
+            assert refused.value.code == 401
+            frames = await asyncio.to_thread(
+                post_event, base, "authorized", token="example-conversation-token"
+            )
+            assert frames[-1]["status"] == "done"
+
+    asyncio.run(run())
+
+
+def test_resilience_turn_trace_is_the_runner_trace() -> None:
+    async def run() -> None:
+        exporter = InMemorySpanExporter()
+        provider = TracerProvider()
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        runner = SessionRunner(
+            session_factory=FakeModelSession,
+            ceiling=0,
+            tracer=RunTracer(provider),
+            classifier=SideEffectClassifier(),
+            trace_name="resilience-trace",
+        )
+        await runner.start()
+        async with TestServer(create_app(runner)) as server:
+            base = str(server.make_url("/")).rstrip("/")
+            trace_id = "1234567890abcdef1234567890abcdef"
+            await asyncio.to_thread(post_event, base, "trace the turn", trace_id=trace_id)
+            spans = exporter.get_finished_spans()
+            roots = [span for span in spans if span.name == "agent.run"]
+            assert len(roots) == 1
+            assert f"{roots[0].context.trace_id:032x}" == trace_id
+            await asyncio.to_thread(post_event, base, "independent turn")
+            roots = [span for span in exporter.get_finished_spans() if span.name == "agent.run"]
+            assert len(roots) == 2
+            assert f"{roots[1].context.trace_id:032x}" != trace_id
+        provider.shutdown()
+
+    asyncio.run(run())
+
+
+@pytest.mark.parametrize("wire", [
+    '{"type":"final","version":"private-wire-sentinel","status":"done","text":"private-output-sentinel"}',
+    '{"type":"final","version":"' + PROTOCOL_VERSION + '",'
+    '"status":"private-output-sentinel","text":"private-output-sentinel"}',
+])
+def test_resilience_malformed_wire_diagnostics_are_redacted(wire: str) -> None:
+    async def run() -> None:
+        async def malformed(_request: web.Request) -> web.Response:
+            return web.Response(text=wire, content_type="application/x-ndjson")
+
+        producer = web.Application()
+        producer.router.add_post("/v1/event", malformed)
+        async with TestServer(producer) as server:
+            with pytest.raises(AssertionError) as failed:
+                await asyncio.to_thread(post_event, str(server.make_url("/")).rstrip("/"), "run")
+            assert str(failed.value) == "runner emitted invalid NDJSON"
+            assert failed.value.__suppress_context__
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary

The sandbox resilience driver previously accepted a classified-failure final as success, omitted the bearer on a cold resume, and queried global cache observations under a stale xfail. This change requires a successful real ACI terminal, sends the persisted conversation token, requires a supported scoped transcript fixture and live exact recall, and attributes cache reads to a successful follow-up trace. Separate recovery tests execute one durable subprocess receipt across fresh worker/runner objects, real Valkey PEL reclaim, current delivery fencing generations 1 then 2, legacy controls and an independently delivered duplicate.

This is a draft verification slice. It does not implement warm adoption or claim the complete cluster journey passes. The model and Kubernetes remain test doubles in the bounded recovery test; replacing objects is not a process or pod kill. No runtime product source, chart, frozen contract or release identity changes.

Ref #1492. The missing frozen adoption-credential prerequisite is recorded in #2385. No issue closes from this PR.

## Evidence

Candidate: `509f3eb45f8f903b5a679f645ea4702ebdc830ca`, based on `06d6179d742c73ac6e4c58593a6437225edf8857` on next.

- `TEST_VALKEY_HOST=127.0.0.1 TEST_VALKEY_PORT=32786 TEST_VALKEY_PW='' CI_REQUIRE_VALKEY_TESTS=1 uv run pytest apps/worker/tests/sandbox -q`: 150 passed, 1 existing cluster-gated skip, against task-owned Valkey.
- Before the helper change, the actual production runner HTTP tests failed on classified-failure acceptance and missing bearer support; the successful-turn control passed. Trace propagation also failed before its implementation. Final focused tests cover the positive/negative status paths, actual 401 without auth, authorized success, exact trace propagation and malformed-wire redaction.
- Before-effect interruption leaves no receipt and the replacement executes once. After-effect interruption leaves one fsync'd receipt and the replacement escalates without executing. A separate duplicate delivery leaves the receipt count unchanged in both cases. These use the production Kernel, RunnerClient, SessionRunner and real Valkey; only Kubernetes, Slack and provider behavior are simulated.
- Ruff, `git diff --check` and `bash scripts/check-docs.sh` pass.
- Bare full pytest collection includes the offline resilience and delivery tests and excludes the cluster scenario. `CURIE_SANDBOX_E2E=1 CURIE_SANDBOX_E2E_RUNS=3 uv run pytest apps/worker/tests/sandbox/test_e2e_resilience.py --collect-only -q` collects repetitions 0, 1, 2 and the cache probe. Collection is not execution.
- Explicit `CURIE_SANDBOX_E2E_LIVE=1` keeps the live probe enabled when host credentials are absent. The pool may receive its provider credential through a Secret. A required live run cannot silently skip because the pytest host lacks a particular provider variable.

## Remaining journey gates

| Tier | Status and scope |
| --- | --- |
| skill | Not reached by product source changes; real runner HTTP fixture exercised locally. |
| local | Bounded queue/runner integration above passes; deployed service and process-crash evidence remains open. |
| local-release | Not reached: no published binary, image or install behavior changes. |
| cluster | Required for W2, not yet executed on this candidate. A disposable task-owned namespace, ready capacity and actual pod/worker faults are needed. |
| live provider | Required for real conversation isolation, durable recall and cache. Not yet executed. Set CURIE_SANDBOX_E2E_LIVE=1 and prepare the pool's real provider credential. |
| external integration | Required for actual Langfuse cache readback, not yet executed. The probe filters the exact trace and checks an absent trace control; global sums cannot pass it. Slack/GitHub product paths are outside this diff. |

The whole scenario preflights its phase-D resume fixture before creating claims. It needs a task-owned real state API transcript URL, its scoped token and a synthetic expected marker through `CURIE_SANDBOX_E2E_HISTORY_REF`, `CURIE_SANDBOX_E2E_HISTORY_TOKEN` and `CURIE_SANDBOX_E2E_HISTORY_MARKER`. Fake mode reports history recall as UNPROVED; a scoped-token shape check is not authenticated fetch evidence. The live cache probe requires the exact unique primed record value in the successful final, but does not claim all observed cache reads came exclusively from the conversation prefix. Eval-stream fan-out and real process/pod crash proof remain separate acceptance work.

## Review and cleanup

Release cleanup attempts every owned claim and fails the suite on any release error. Independent alternative-provider and explicit Claude Fable reviews addressed current fencing, cache substring false positives and scoped history prerequisites. Final re-review completed without remaining source blockers after the corrections (Claude Fable; the earlier alternative-provider review findings were reproduced and fixed). Required runtime evidence remains unproved.. Earlier code/security review addressed malformed response diagnostics and the invalid history-reference fixture. Scope review confirmed the six test files map to the sandbox outcome gaps. The task-owned Valkey container and its anonymous volume are removed after local validation. No permanent soak or another task's stack was changed.

## Existing CI failure

Original head `484755950ff8881481c80caea0688f8b85e40eb9` had a failed required cluster gate in [run33932641298](https://github.com/curie-eng/curie/actions/runs/33932641298): the pre-existing rollout-recovery harness included an already-terminating predecessor in its baseline; its normal disappearance failed the full identity comparison while the ready worker and generation stayed unchanged. The lead owns a separate main-first prerequisite. Required checks are not waived; this head needs a fresh passing run or remains blocked. Actual W2 pod/process crashes, eval fanout and three live repetitions are still unproved.
