### PR TITLE
Fix retained mail configuration during cluster upgrades

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -322,6 +322,10 @@ jobs:
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           python-version: "3.13"
+      - name: Install Helm for CLI consumer render tests
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5
+        with:
+          version: v3.16.4
       - name: Test
         run: cargo test --locked
       - name: Generated ACI protocol crate compiles

--- a/cli/src/installation.rs
+++ b/cli/src/installation.rs
@@ -760,6 +760,7 @@ fn plan_installation_inner(
         .as_ref()
         .and_then(|name| resolved.get(name).cloned());
     let up = crate::ops::UpOpts {
+        retained_mail_values: None,
         common: crate::ops::CommonOpts {
             namespace: cfg.install.namespace.clone(),
             release: cfg.install.release.clone(),

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -3648,6 +3648,7 @@ async fn run(command: Option<Command>) -> Result<()> {
                 emit(
                     ops::up(
                         UpOpts {
+                            retained_mail_values: None,
                             common: CommonOpts {
                                 namespace,
                                 release,

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -52,6 +52,7 @@ pub enum CmdArg {
     HelmSetExpression(String),
     SecretSet { key: String, value: String },
     SecretValuesFile(Vec<(String, String)>),
+    PrivateJsonValuesFile(PrivateHelmValues),
 }
 
 impl CmdArg {
@@ -65,7 +66,7 @@ impl CmdArg {
             CmdArg::Plain(s) => vec![s.clone()],
             CmdArg::HelmSetExpression(expression) => vec![expression.clone()],
             CmdArg::SecretSet { key, value } => vec![format!("{key}={value}")],
-            CmdArg::SecretValuesFile(_) => {
+            CmdArg::SecretValuesFile(_) | CmdArg::PrivateJsonValuesFile(_) => {
                 debug_assert!(
                     false,
                     "SecretValuesFile must be materialized before argv(); \
@@ -86,6 +87,13 @@ impl CmdArg {
                 vec![mask_helm_set_expression(expression)]
             }
             CmdArg::SecretSet { key, value } => vec![format!("{key}={}", mask_secret(value))],
+            CmdArg::PrivateJsonValuesFile(values) => vec![
+                "-f".to_string(),
+                format!(
+                    "<private retained mail values: {}>",
+                    values.keys().join(", ")
+                ),
+            ],
             CmdArg::SecretValuesFile(pairs) => {
                 let masked: Vec<String> = pairs
                     .iter()
@@ -168,6 +176,12 @@ impl OpsCommand {
             match a {
                 CmdArg::SecretValuesFile(pairs) => {
                     let guard = SecretValuesFileGuard::write(pairs)?;
+                    new_args.push(plain("-f"));
+                    new_args.push(plain(guard.path.to_string_lossy().into_owned()));
+                    guards.push(guard);
+                }
+                CmdArg::PrivateJsonValuesFile(values) => {
+                    let guard = SecretValuesFileGuard::write_document(&values.0)?;
                     new_args.push(plain("-f"));
                     new_args.push(plain(guard.path.to_string_lossy().into_owned()));
                     guards.push(guard);
@@ -315,10 +329,12 @@ impl SecretValuesFileGuard {
     /// with restrictive permissions atomically so the secret is never briefly
     /// world-readable.
     fn write(pairs: &[(String, String)]) -> Result<Self> {
-        ensure_secret_signal_cleanup()?;
+        Self::write_document(&nest_dotted_keys(pairs))
+    }
 
-        let doc = nest_dotted_keys(pairs);
-        let body = serde_json::to_vec(&doc).context("serializing secret helm values")?;
+    fn write_document(doc: &serde_json::Value) -> Result<Self> {
+        ensure_secret_signal_cleanup()?;
+        let body = serde_json::to_vec(doc).context("serializing secret helm values")?;
 
         let mut path = std::env::temp_dir();
         path.push(format!("curie-helm-values-{}.yaml", uuid::Uuid::new_v4()));
@@ -472,7 +488,42 @@ pub struct CommonOpts {
     pub dry_run: bool,
 }
 
+/// Typed retained values use the same protected file lifecycle as credentials.
+/// Debug and command rendering expose field names only.
+#[derive(Clone, PartialEq, Eq)]
+pub struct PrivateHelmValues(serde_json::Value, BTreeMap<String, String>);
+
+impl PrivateHelmValues {
+    fn keys(&self) -> Vec<String> {
+        [
+            "mailAdapter",
+            "worker.adapterCredentials",
+            "worker.adapterCredentialsExistingSecret",
+            "worker.adapterCredentialsExistingSecretKey",
+        ]
+        .into_iter()
+        .filter(|key| {
+            self.0
+                .pointer(&format!("/{}", key.replace('.', "/")))
+                .is_some()
+        })
+        .map(str::to_string)
+        .collect()
+    }
+}
+
+impl std::fmt::Debug for PrivateHelmValues {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PrivateHelmValues")
+            .field("keys", &self.keys())
+            .finish()
+    }
+}
+
 pub struct UpOpts {
+    /// Existing mail lifecycle and paired worker credentials, with explicit
+    /// operator overrides removed. Populated by the one release-values read.
+    pub retained_mail_values: Option<PrivateHelmValues>,
     pub common: CommonOpts,
     pub chart: String,
     pub no_expose: bool,
@@ -1618,6 +1669,114 @@ fn resolve_sealing_values(
     resolved
 }
 
+/// Preserve the installed mail surface as typed values: booleans, arrays and
+/// credential maps must not become strings when delivered through Helm -f.
+/// This family includes the paired worker credential source, because preserving
+/// only the adapter side can leave the channel unable to receive replies.
+fn resolve_retained_mail_values(
+    existing: Option<&serde_json::Value>,
+    operator_sets: &[String],
+) -> Option<PrivateHelmValues> {
+    let existing = existing?;
+    let mut retained = serde_json::json!({});
+    if let Some(mail) = existing.get("mailAdapter") {
+        retained["mailAdapter"] = mail.clone();
+    }
+    for key in [
+        "adapterCredentials",
+        "adapterCredentialsExistingSecret",
+        "adapterCredentialsExistingSecretKey",
+    ] {
+        if let Some(value) = existing.get("worker").and_then(|worker| worker.get(key)) {
+            retained["worker"][key] = value.clone();
+        }
+    }
+    let overridden = operator_set_keys(operator_sets);
+    let mut cleared = BTreeMap::new();
+    for inline in [
+        "mailAdapter.agentmail.apiKey",
+        "mailAdapter.channelToken",
+        "mailAdapter.egressSecret",
+        "worker.adapterCredentials",
+    ] {
+        let reference = format!("{inline}ExistingSecret");
+        // An explicit inline value replaces the external source. Conversely,
+        // an active or explicitly changed reference must not replay an old
+        // inline copy, even if Helm still recorded it before token rotation.
+        let remove = if overridden
+            .iter()
+            .any(|key| key_is_or_descends_from(key, inline))
+        {
+            vec![reference.clone()]
+        } else if overridden.contains(&reference)
+            || lookup_dotted(&retained, &reference).is_some_and(|value| !value.is_empty())
+        {
+            vec![inline.to_string()]
+        } else {
+            vec![]
+        };
+        for path in remove {
+            let (parent, leaf) = path.rsplit_once('.').expect("credential path");
+            let pointer = format!("/{}", parent.replace('.', "/"));
+            if let Some(object) = retained
+                .pointer_mut(&pointer)
+                .and_then(serde_json::Value::as_object_mut)
+            {
+                object.remove(leaf);
+                cleared.insert(
+                    path.clone(),
+                    if path == "worker.adapterCredentials" {
+                        "{}".to_string()
+                    } else {
+                        String::new()
+                    },
+                );
+            }
+        }
+    }
+    fn without_overrides(
+        value: &serde_json::Value,
+        path: &str,
+        overridden: &std::collections::HashSet<String>,
+    ) -> Option<serde_json::Value> {
+        if overridden
+            .iter()
+            .any(|key| key_is_or_descends_from(path, key))
+        {
+            return None;
+        }
+        match value {
+            serde_json::Value::Object(object) => {
+                let remaining: serde_json::Map<String, serde_json::Value> = object
+                    .iter()
+                    .filter_map(|(key, value)| {
+                        let child = if path.is_empty() {
+                            key.clone()
+                        } else {
+                            format!("{path}.{key}")
+                        };
+                        without_overrides(value, &child, overridden)
+                            .map(|value| (key.clone(), value))
+                    })
+                    .collect();
+                (!remaining.is_empty() || object.is_empty())
+                    .then_some(serde_json::Value::Object(remaining))
+            }
+            serde_json::Value::Array(_)
+                if overridden
+                    .iter()
+                    .any(|key| key_is_or_descends_from(key, path)) =>
+            {
+                None
+            }
+            _ => Some(value.clone()),
+        }
+    }
+    without_overrides(&retained, "", &overridden)
+        .filter(|value| value.as_object().is_some_and(|object| !object.is_empty()))
+        .map(|document| PrivateHelmValues(document, cleared))
+}
+
 /// Every value a plain `cluster up` must carry forward, in one place.
 ///
 /// `up` does a FULL upgrade and drops anything it does not re-pass, so each
@@ -1968,7 +2127,11 @@ fn reindex_inferred_provider_egress(
 /// says it carries names and never secrets. `sealing_test` below asserts the
 /// two lists agree by construction rather than by a hand-kept fixture.
 pub fn is_preserved_by_up(key: &str) -> bool {
-    COMMS_MANAGED_KEYS.contains(&key)
+    key_is_or_descends_from(key, "mailAdapter")
+        || key_is_or_descends_from(key, "worker.adapterCredentials")
+        || key == "worker.adapterCredentialsExistingSecret"
+        || key == "worker.adapterCredentialsExistingSecretKey"
+        || COMMS_MANAGED_KEYS.contains(&key)
         || GITHUB_APP_MANAGED_KEYS.contains(&key)
         || REQUIRED_SECRETS.iter().any(|(k, _)| *k == key)
         || crate::sealing::SEALING_MANAGED_KEYS.contains(&key)
@@ -3681,6 +3844,7 @@ fn complete_up_opts_without_runner_egress(
     clear_github_token: bool,
 ) -> Result<UpOpts> {
     let operator_sets = opts.operator_sets();
+    opts.retained_mail_values = resolve_retained_mail_values(existing, &operator_sets);
     resolve_preserved_runner_identity_values(&mut opts, existing, &operator_sets);
     resolve_preserved_gvisor_mode_value(&mut opts, existing, &operator_sets);
     resolve_preserved_worker_extra_env_values(&mut opts, existing, &operator_sets);
@@ -3890,6 +4054,7 @@ enum DiffParticipation {
 
 #[derive(Clone, PartialEq, Eq)]
 enum PlannedHelmValues {
+    RetainedMail(PrivateHelmValues),
     Set {
         flag: HelmSetFlag,
         expression: String,
@@ -3964,6 +4129,9 @@ impl UpValuePlan {
     fn append_command_args(&self, args: &mut Vec<CmdArg>) {
         for entry in &self.entries {
             match entry {
+                PlannedHelmValues::RetainedMail(values) => {
+                    args.push(CmdArg::PrivateJsonValuesFile(values.clone()));
+                }
                 PlannedHelmValues::Set {
                     flag, expression, ..
                 } => {
@@ -3984,6 +4152,14 @@ impl UpValuePlan {
         let mut values = BTreeMap::new();
         for entry in &self.entries {
             match entry {
+                PlannedHelmValues::RetainedMail(retained) => {
+                    values.extend(
+                        retained
+                            .1
+                            .iter()
+                            .map(|(key, value)| (key.clone(), value.clone())),
+                    );
+                }
                 PlannedHelmValues::Set { effective, .. } => {
                     values.extend(effective.iter().cloned());
                 }
@@ -4058,6 +4234,10 @@ pub(crate) fn up_value_plan(o: &UpOpts) -> UpValuePlan {
         );
     }
     plan.secret_file(o.secrets.clone(), DiffParticipation::Preserve);
+    if let Some(values) = &o.retained_mail_values {
+        plan.entries
+            .push(PlannedHelmValues::RetainedMail(values.clone()));
+    }
     if let Some(model) = &o.model {
         if explicit_runner_model(&o.operator_sets()).is_none() {
             plan.set(RUNNER_MODEL_KEY, model);
@@ -6080,6 +6260,12 @@ async fn run_prepared_up(
         inference.render(ui);
     }
     let operator_sets = opts.operator_sets();
+    if let Some(values) = &opts.retained_mail_values {
+        ui.note(&format!(
+            "preserving {} mail value(s) recorded by the release",
+            values.keys().len()
+        ));
+    }
     let preserved = resolve_preserved_values(existing.as_ref(), &operator_sets);
     if !preserved.is_empty() {
         let sealing_values = preserved
@@ -8915,9 +9101,199 @@ mod tests {
         }
     }
 
+    fn mail_upgrade_opts(existing: &serde_json::Value, set: Vec<String>) -> UpOpts {
+        complete_up_opts_without_runner_egress(
+            UpOpts {
+                retained_mail_values: None,
+                common: common(),
+                chart: "charts/curie".into(),
+                no_expose: true,
+                set,
+                set_string: vec![],
+                allow_egress_host: vec![],
+                resolved_egress_cidrs: vec![],
+                allow_web_egress: vec![],
+                fake_model: false,
+                credentials: None,
+                local_model: None,
+                model: None,
+                secrets: vec![],
+                github_token: GithubTokenPlan::Untouched,
+                dev: true,
+            },
+            Some(existing),
+            None,
+            false,
+        )
+        .unwrap()
+    }
+
+    fn retained_mail_fixture() -> serde_json::Value {
+        serde_json::json!({
+            "mailAdapter": {
+                "deploy": true,
+                "inbox": "mail@example.com",
+                "allowedSenders": ["operator@example.com"],
+                "pollIntervalSeconds": 37,
+                "persistence": {"existingClaim": "acme-mail-state"},
+                "agentmail": {
+                    "apiKeyExistingSecret": "acme-mail-credentials",
+                    "apiKeyExistingSecretKey": "provider-key",
+                    "httpsCidrs": ["203.0.113.8/32"]
+                },
+                "channelTokenExistingSecret": "acme-mail-credentials",
+                "channelTokenExistingSecretKey": "channel-key",
+                "egressSecretExistingSecret": "acme-mail-credentials",
+                "egressSecretExistingSecretKey": "egress-key"
+            },
+            "worker": {
+                "adapterCredentialsExistingSecret": "acme-mail-credentials",
+                "adapterCredentialsExistingSecretKey": "worker-map"
+            }
+        })
+    }
+
+    fn materialized_mail_values(opts: &UpOpts) -> serde_json::Value {
+        let commands = up_commands(opts);
+        let command = &commands[0];
+        let (materialized, _guards) = command.materialize_secret_files().unwrap();
+        let argv = materialized.argv();
+        for pair in argv.windows(2).filter(|pair| pair[0] == "-f") {
+            let value: serde_json::Value =
+                serde_json::from_slice(&std::fs::read(&pair[1]).unwrap()).unwrap();
+            if value.get("mailAdapter").is_some() {
+                return value;
+            }
+        }
+        panic!("plain cluster up dropped the installed mail values");
+    }
+
+    #[test]
+    fn plain_up_preserves_mail_lifecycle_and_external_secret_pairs() {
+        let existing = retained_mail_fixture();
+        let opts = mail_upgrade_opts(&existing, vec![]);
+        let actual = materialized_mail_values(&opts);
+        assert_eq!(
+            actual, existing,
+            "mail and worker credential state must survive unchanged"
+        );
+        let mut leaves = BTreeMap::new();
+        crate::installation::flatten_values(&actual, "", &mut leaves);
+        for key in leaves.keys() {
+            assert!(is_preserved_by_up(key), "diff disagrees with up for {key}");
+        }
+        let shown = up_commands(&opts)[0].display();
+        for private in ["mail@example.com", "acme-mail-credentials", "provider-key"] {
+            assert!(
+                !shown.contains(private),
+                "private retained mail values leaked"
+            );
+        }
+    }
+
+    #[test]
+    fn retained_mail_command_and_debug_hide_dynamic_keys_and_inline_secrets() {
+        let mut existing = retained_mail_fixture();
+        existing["worker"]["adapterCredentials"] = serde_json::json!({
+            "private-adapter-identity": "private-inline-credential"
+        });
+        existing["worker"]
+            .as_object_mut()
+            .unwrap()
+            .remove("adapterCredentialsExistingSecret");
+        existing["worker"]
+            .as_object_mut()
+            .unwrap()
+            .remove("adapterCredentialsExistingSecretKey");
+        existing["mailAdapter"]["podAnnotations"] = serde_json::json!({
+            "private.example.com/identity": "private-annotation-value"
+        });
+        let opts = mail_upgrade_opts(&existing, vec![]);
+        let command = &up_commands(&opts)[0];
+        let display = command.display();
+        let debug = format!("{command:?}");
+        let (materialized, _guards) = command.materialize_secret_files().unwrap();
+        let argv = materialized.argv().join(" ");
+        for private in [
+            "private-adapter-identity",
+            "private-inline-credential",
+            "private.example.com/identity",
+            "private-annotation-value",
+        ] {
+            for surface in [&display, &debug, &argv] {
+                assert!(!surface.contains(private), "retained mail metadata leaked");
+            }
+        }
+        assert_eq!(materialized_mail_values(&opts), existing);
+    }
+
+    #[test]
+    fn plain_mail_upgrade_never_replays_inline_copies_behind_external_sources() {
+        let expected = retained_mail_fixture();
+        let mut existing = expected.clone();
+        existing["mailAdapter"]["channelToken"] = "stale-channel-token".into();
+        existing["mailAdapter"]["egressSecret"] = "stale-egress-secret".into();
+        existing["mailAdapter"]["agentmail"]["apiKey"] = "stale-provider-key".into();
+        existing["worker"]["adapterCredentials"] =
+            serde_json::json!({"mail-adapter": "stale-egress-secret"});
+        let opts = mail_upgrade_opts(&existing, vec![]);
+        assert_eq!(materialized_mail_values(&opts), expected);
+    }
+
+    #[test]
+    fn explicit_mail_disable_and_secret_clear_override_retained_values() {
+        let mut existing = retained_mail_fixture();
+        existing["mailAdapter"]["channelToken"] = "obsolete-inline-token".into();
+        let opts = mail_upgrade_opts(
+            &existing,
+            vec![
+                "mailAdapter.deploy=false".into(),
+                "mailAdapter.channelTokenExistingSecret=".into(),
+                "mailAdapter.allowedSenders={}".into(),
+            ],
+        );
+        let actual = materialized_mail_values(&opts);
+        assert!(actual["mailAdapter"].get("deploy").is_none());
+        assert!(actual["mailAdapter"].get("allowedSenders").is_none());
+        assert!(
+            actual["mailAdapter"].get("channelToken").is_none(),
+            "clearing an external reference cannot resurrect an obsolete inline token"
+        );
+        assert!(actual["mailAdapter"]
+            .get("channelTokenExistingSecret")
+            .is_none());
+        assert_eq!(actual["mailAdapter"]["pollIntervalSeconds"], 37);
+        let effective = up_value_plan(&opts).effective_values();
+        assert_eq!(
+            effective.get("mailAdapter.deploy").map(String::as_str),
+            Some("false")
+        );
+    }
+
+    #[test]
+    fn explicit_inline_mail_credential_replaces_the_external_reference() {
+        let opts = mail_upgrade_opts(
+            &retained_mail_fixture(),
+            vec!["mailAdapter.channelToken=new-inline-token".into()],
+        );
+        let actual = materialized_mail_values(&opts);
+        assert!(actual["mailAdapter"]
+            .get("channelTokenExistingSecret")
+            .is_none());
+        assert_eq!(
+            actual["mailAdapter"]["channelTokenExistingSecretKey"],
+            "channel-key"
+        );
+        assert_eq!(
+            actual["worker"]["adapterCredentialsExistingSecretKey"],
+            "worker-map"
+        );
+    }
+
     #[test]
     fn up_defaults_expose_ui_and_langfuse() {
         let cmds = up_commands(&UpOpts {
+            retained_mail_values: None,
             common: common(),
             github_token: GithubTokenPlan::Untouched,
             allow_egress_host: vec![],
@@ -8961,6 +9337,7 @@ mod tests {
         });
         let opts = complete_up_opts_without_runner_egress(
             UpOpts {
+                retained_mail_values: None,
                 common: common(),
                 github_token: GithubTokenPlan::Untouched,
                 allow_egress_host: vec![],
@@ -9014,6 +9391,7 @@ mod tests {
         });
         let opts = complete_up_opts_without_runner_egress(
             UpOpts {
+                retained_mail_values: None,
                 common: common(),
                 github_token: GithubTokenPlan::Untouched,
                 allow_egress_host: vec![],
@@ -9068,6 +9446,7 @@ mod tests {
         });
         let opts = complete_up_opts_without_runner_egress(
             UpOpts {
+                retained_mail_values: None,
                 common: common(),
                 github_token: GithubTokenPlan::Untouched,
                 allow_egress_host: vec![],
@@ -9116,6 +9495,7 @@ mod tests {
         });
         let opts = complete_up_opts_without_runner_egress(
             UpOpts {
+                retained_mail_values: None,
                 common: common(),
                 github_token: GithubTokenPlan::Untouched,
                 allow_egress_host: vec![],
@@ -9160,6 +9540,7 @@ mod tests {
         });
         let opts = complete_up_opts_without_runner_egress(
             UpOpts {
+                retained_mail_values: None,
                 common: common(),
                 github_token: GithubTokenPlan::Untouched,
                 allow_egress_host: vec![],
@@ -9204,6 +9585,7 @@ mod tests {
         });
         let opts = complete_up_opts_without_runner_egress(
             UpOpts {
+                retained_mail_values: None,
                 common: common(),
                 github_token: GithubTokenPlan::Untouched,
                 allow_egress_host: vec![],
@@ -9249,6 +9631,7 @@ mod tests {
         });
         let opts = complete_up_opts_without_runner_egress(
             UpOpts {
+                retained_mail_values: None,
                 common: common(),
                 github_token: GithubTokenPlan::Untouched,
                 allow_egress_host: vec![],
@@ -9303,6 +9686,7 @@ mod tests {
         ] {
             let opts = complete_up_opts_without_runner_egress(
                 UpOpts {
+                    retained_mail_values: None,
                     common: common(),
                     github_token: GithubTokenPlan::Untouched,
                     allow_egress_host: vec![],
@@ -9354,6 +9738,7 @@ mod tests {
     #[test]
     fn up_no_expose_drops_the_nodeport_sets() {
         let cmds = up_commands(&UpOpts {
+            retained_mail_values: None,
             common: common(),
             github_token: GithubTokenPlan::Untouched,
             set_string: vec![],
@@ -9378,6 +9763,7 @@ mod tests {
     #[test]
     fn up_passthrough_set_is_appended_verbatim() {
         let cmds = up_commands(&UpOpts {
+            retained_mail_values: None,
             common: common(),
             github_token: GithubTokenPlan::Untouched,
             allow_egress_host: vec![],
@@ -9406,6 +9792,7 @@ mod tests {
         // No credential and not --fake-model: a plain install with no real-model
         // or egress sets (the fake model stays on, egress stays fail-closed).
         let cmds = up_commands(&UpOpts {
+            retained_mail_values: None,
             common: common(),
             github_token: GithubTokenPlan::Untouched,
             set_string: vec![],
@@ -9433,6 +9820,7 @@ mod tests {
         // --fake-model resolves to no credential, so the argv is the sealed
         // install even when the caller had a credential in the environment.
         let cmds = up_commands(&UpOpts {
+            retained_mail_values: None,
             common: common(),
             github_token: GithubTokenPlan::Untouched,
             allow_egress_host: vec![],
@@ -9457,6 +9845,7 @@ mod tests {
     #[test]
     fn up_with_credentials_enables_real_model_and_masks() {
         let cmds = up_commands(&UpOpts {
+            retained_mail_values: None,
             common: common(),
             github_token: GithubTokenPlan::Untouched,
             set_string: vec![],
@@ -9592,6 +9981,7 @@ mod tests {
     #[test]
     fn up_local_model_adds_inference_sets() {
         let cmds = up_commands(&UpOpts {
+            retained_mail_values: None,
             common: common(),
             github_token: GithubTokenPlan::Untouched,
             allow_egress_host: vec![],
@@ -9616,6 +10006,7 @@ mod tests {
     #[test]
     fn up_without_local_model_omits_inference_sets() {
         let cmds = up_commands(&UpOpts {
+            retained_mail_values: None,
             common: common(),
             github_token: GithubTokenPlan::Untouched,
             set_string: vec![],
@@ -9641,6 +10032,7 @@ mod tests {
     fn up_defaults_runner_model_from_env() {
         // CURIE_MODEL set, no explicit --set: inject the runner model (#361).
         let cmds = up_commands(&UpOpts {
+            retained_mail_values: None,
             common: common(),
             github_token: GithubTokenPlan::Untouched,
             allow_egress_host: vec![],
@@ -9668,6 +10060,7 @@ mod tests {
     fn up_without_env_model_omits_runner_model_set() {
         // No CURIE_MODEL: inject nothing, the chart default stands (#361).
         let cmds = up_commands(&UpOpts {
+            retained_mail_values: None,
             common: common(),
             github_token: GithubTokenPlan::Untouched,
             set_string: vec![],
@@ -9693,6 +10086,7 @@ mod tests {
         // CURIE_MODEL set AND an explicit matching --set: the operator's set
         // already carries it, so no duplicate injection (#361).
         let cmds = up_commands(&UpOpts {
+            retained_mail_values: None,
             common: common(),
             github_token: GithubTokenPlan::Untouched,
             allow_egress_host: vec![],
@@ -9724,6 +10118,7 @@ mod tests {
         // `--set` must be detected so `up` does not inject a redundant
         // `--set agentSandbox.runner.model=<model>` on top of it (#361).
         let cmds = up_commands(&UpOpts {
+            retained_mail_values: None,
             common: common(),
             github_token: GithubTokenPlan::Untouched,
             set_string: vec![],
@@ -9799,6 +10194,7 @@ mod tests {
     #[test]
     fn up_opens_web_egress_after_model() {
         let cmds = up_commands(&UpOpts {
+            retained_mail_values: None,
             common: common(),
             github_token: GithubTokenPlan::Untouched,
             allow_egress_host: vec!["anthropic".into()],
@@ -9837,6 +10233,7 @@ mod tests {
     #[test]
     fn up_web_egress_without_model_uses_index_zero() {
         let cmds = up_commands(&UpOpts {
+            retained_mail_values: None,
             common: common(),
             github_token: GithubTokenPlan::Untouched,
             set_string: vec![],
@@ -9872,6 +10269,7 @@ mod tests {
     #[test]
     fn up_web_egress_multiple_cidrs_contiguous() {
         let cmds = up_commands(&UpOpts {
+            retained_mail_values: None,
             common: common(),
             github_token: GithubTokenPlan::Untouched,
             allow_egress_host: vec!["anthropic".into()],
@@ -9906,6 +10304,7 @@ mod tests {
     #[test]
     fn up_no_web_egress_stays_sealed() {
         let sealed_cmds = up_commands(&UpOpts {
+            retained_mail_values: None,
             common: common(),
             github_token: GithubTokenPlan::Untouched,
             set_string: vec![],
@@ -9926,6 +10325,7 @@ mod tests {
         assert!(!sealed_line.contains("allowedEgress"), "{sealed_line}");
 
         let model_cmds = up_commands(&UpOpts {
+            retained_mail_values: None,
             common: common(),
             github_token: GithubTokenPlan::Untouched,
             allow_egress_host: vec![],
@@ -11271,6 +11671,7 @@ mod tests {
         // live credential, so it must land in the private -f file like any other
         // secret and never appear in argv or the printed line.
         let cmds = up_commands(&UpOpts {
+            retained_mail_values: None,
             common: common(),
             github_token: GithubTokenPlan::Untouched,
             set_string: vec![],
@@ -11454,6 +11855,7 @@ mod tests {
     fn completed_dev_up(existing: Option<&serde_json::Value>, set: Vec<String>) -> UpOpts {
         complete_up_opts_without_runner_egress(
             UpOpts {
+                retained_mail_values: None,
                 common: common(),
                 github_token: GithubTokenPlan::Untouched,
                 allow_egress_host: vec![],
@@ -11613,6 +12015,7 @@ mod tests {
         // Success criterion: a missing secret's generated value lands in the
         // private -f values file, never in the executed argv / process table.
         let cmds = up_commands(&UpOpts {
+            retained_mail_values: None,
             common: common(),
             github_token: GithubTokenPlan::Untouched,
             allow_egress_host: vec![],
@@ -11669,6 +12072,7 @@ mod tests {
         // The pure builder with no supplied secrets (the --dev path, and every
         // pre-#196 argv test) emits no secret values file.
         let cmds = up_commands(&UpOpts {
+            retained_mail_values: None,
             common: common(),
             github_token: GithubTokenPlan::Untouched,
             set_string: vec![],
@@ -11695,6 +12099,7 @@ mod tests {
         // to helm (issue #195). Without it the sealed chart generates strong
         // random values and the dev/e2e stack would not match compose.
         let cmds = up_commands(&UpOpts {
+            retained_mail_values: None,
             common: common(),
             github_token: GithubTokenPlan::Untouched,
             allow_egress_host: vec![],
@@ -11723,6 +12128,7 @@ mod tests {
         // The default (non-dev) path must NOT opt into the published defaults;
         // the sealed chart generates strong per-release credentials there.
         let cmds = up_commands(&UpOpts {
+            retained_mail_values: None,
             common: common(),
             github_token: GithubTokenPlan::Untouched,
             set_string: vec![],
@@ -12828,6 +13234,7 @@ mod tests {
         // Resolved provider CIDRs take the first slots (in order), then declared
         // web destinations continue contiguously -- one array, no gaps.
         let cmds = up_commands(&UpOpts {
+            retained_mail_values: None,
             common: common(),
             github_token: GithubTokenPlan::Untouched,
             model: None,
@@ -12878,6 +13285,7 @@ mod tests {
         // unconditional Anthropic carve-out is removed entirely (#362). The
         // sandbox stays sealed and the model is unreachable by design.
         let cmds = up_commands(&UpOpts {
+            retained_mail_values: None,
             common: common(),
             github_token: GithubTokenPlan::Untouched,
             model: None,
@@ -12911,6 +13319,7 @@ mod tests {
         // Existing behavior preserved: with no credential and no provider host,
         // a declared web destination still occupies index [0].
         let cmds = up_commands(&UpOpts {
+            retained_mail_values: None,
             common: common(),
             github_token: GithubTokenPlan::Untouched,
             model: None,
@@ -12958,6 +13367,7 @@ mod tests {
     /// assertion below reads exactly one variable.
     fn up_with_github_token(plan: GithubTokenPlan) -> Vec<OpsCommand> {
         up_commands(&UpOpts {
+            retained_mail_values: None,
             common: common(),
             github_token: plan,
             set_string: vec![],
@@ -13336,6 +13746,7 @@ mod tests {
         // Between them these two pin the read DECISION and the argv it feeds; the
         // live evidence is the E2E's `--dev` arm.
         let cmds = up_commands(&UpOpts {
+            retained_mail_values: None,
             common: common(),
             github_token: GithubTokenPlan::Set(GH_SENTINEL.into()),
             allow_egress_host: vec![],
@@ -13587,6 +13998,7 @@ mod tests {
         // `operator_sets` chains `--set` THEN `--set-string`, and a key the
         // operator supplied only through the latter must exempt the run too.
         let opts = UpOpts {
+            retained_mail_values: None,
             common: common(),
             github_token: GithubTokenPlan::Untouched,
             allow_egress_host: vec![],
@@ -13722,6 +14134,7 @@ mod tests {
         // credential, so both keys must survive to their own file and neither
         // may reach argv.
         let cmds = up_commands(&UpOpts {
+            retained_mail_values: None,
             common: common(),
             github_token: GithubTokenPlan::Set(GH_SENTINEL.into()),
             set_string: vec![],

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -1676,8 +1676,10 @@ fn resolve_sealing_values(
 fn resolve_retained_mail_values(
     existing: Option<&serde_json::Value>,
     operator_sets: &[String],
-) -> Option<PrivateHelmValues> {
-    let existing = existing?;
+) -> Result<Option<PrivateHelmValues>> {
+    let Some(existing) = existing else {
+        return Ok(None);
+    };
     let mut retained = serde_json::json!({});
     if let Some(mail) = existing.get("mailAdapter") {
         retained["mailAdapter"] = mail.clone();
@@ -1692,6 +1694,55 @@ fn resolve_retained_mail_values(
         }
     }
     let overridden = operator_set_keys(operator_sets);
+    let operator_values: BTreeMap<_, _> = operator_set_entries(operator_sets)
+        .into_iter()
+        .map(|(key, value)| (key.trim(), value))
+        .collect();
+    let replaces_inline = |inline: &str| {
+        operator_values.iter().any(|(key, value)| {
+            key_is_or_descends_from(key, inline)
+                && !value.is_empty()
+                && !(*key == inline
+                    && inline == "worker.adapterCredentials"
+                    && serde_json::from_str::<serde_json::Value>(value)
+                        .is_ok_and(|value| value.as_object().is_some_and(|map| map.is_empty())))
+        })
+    };
+    // An externally managed worker map is opaque: changing only the adapter's
+    // source cannot safely derive or replace its paired worker credential.
+    // Require an explicit paired decision instead of creating a silent 401.
+    let changes_adapter_source = replaces_inline("mailAdapter.egressSecret")
+        || operator_values
+            .get("mailAdapter.egressSecretExistingSecret")
+            .is_some_and(|value| {
+                Some(*value)
+                    != lookup_dotted(existing, "mailAdapter.egressSecretExistingSecret").as_deref()
+            })
+        || (lookup_dotted(existing, "mailAdapter.egressSecretExistingSecret")
+            .is_some_and(|value| !value.is_empty())
+            && operator_values
+                .get("mailAdapter.egressSecretExistingSecretKey")
+                .is_some_and(|value| {
+                    *value
+                        != lookup_dotted(existing, "mailAdapter.egressSecretExistingSecretKey")
+                            .as_deref()
+                            .unwrap_or("mailEgressSecret")
+                }));
+    let changes_worker_source = replaces_inline("worker.adapterCredentials")
+        || overridden.contains("worker.adapterCredentialsExistingSecret")
+        || overridden.contains("worker.adapterCredentialsExistingSecretKey");
+    if changes_adapter_source
+        && !changes_worker_source
+        && lookup_dotted(existing, "worker.adapterCredentialsExistingSecret")
+            .is_some_and(|value| !value.is_empty())
+    {
+        bail!(
+            "changing the mail egress credential source requires an explicit paired worker \
+             source decision: also set worker.adapterCredentialsExistingSecret (clear it \
+             to use the chart-derived inline pair), its ExistingSecretKey, or supply \
+             worker.adapterCredentials"
+        );
+    }
     let mut cleared = BTreeMap::new();
     for inline in [
         "mailAdapter.agentmail.apiKey",
@@ -1700,13 +1751,11 @@ fn resolve_retained_mail_values(
         "worker.adapterCredentials",
     ] {
         let reference = format!("{inline}ExistingSecret");
-        // An explicit inline value replaces the external source. Conversely,
-        // an active or explicitly changed reference must not replay an old
-        // inline copy, even if Helm still recorded it before token rotation.
-        let remove = if overridden
-            .iter()
-            .any(|key| key_is_or_descends_from(key, inline))
-        {
+        // A nonempty inline value replaces the external source. An empty inline
+        // clear leaves that source active; its explicit reference clear remains
+        // the operator's way to remove it. Active sources never replay stale
+        // inline copies left in Helm before token rotation.
+        let remove = if replaces_inline(inline) {
             vec![reference.clone()]
         } else if overridden.contains(&reference)
             || lookup_dotted(&retained, &reference).is_some_and(|value| !value.is_empty())
@@ -1722,15 +1771,11 @@ fn resolve_retained_mail_values(
                 .pointer_mut(&pointer)
                 .and_then(serde_json::Value::as_object_mut)
             {
-                object.remove(leaf);
-                cleared.insert(
-                    path.clone(),
-                    if path == "worker.adapterCredentials" {
-                        "{}".to_string()
-                    } else {
-                        String::new()
-                    },
-                );
+                if let Some(removed) = object.remove(leaf) {
+                    let mut removed_leaves = BTreeMap::new();
+                    crate::installation::flatten_values(&removed, &path, &mut removed_leaves);
+                    cleared.extend(removed_leaves.into_keys().map(|key| (key, String::new())));
+                }
             }
         }
     }
@@ -1772,9 +1817,9 @@ fn resolve_retained_mail_values(
             _ => Some(value.clone()),
         }
     }
-    without_overrides(&retained, "", &overridden)
+    Ok(without_overrides(&retained, "", &overridden)
         .filter(|value| value.as_object().is_some_and(|object| !object.is_empty()))
-        .map(|document| PrivateHelmValues(document, cleared))
+        .map(|document| PrivateHelmValues(document, cleared)))
 }
 
 /// Every value a plain `cluster up` must carry forward, in one place.
@@ -3844,7 +3889,7 @@ fn complete_up_opts_without_runner_egress(
     clear_github_token: bool,
 ) -> Result<UpOpts> {
     let operator_sets = opts.operator_sets();
-    opts.retained_mail_values = resolve_retained_mail_values(existing, &operator_sets);
+    opts.retained_mail_values = resolve_retained_mail_values(existing, &operator_sets)?;
     resolve_preserved_runner_identity_values(&mut opts, existing, &operator_sets);
     resolve_preserved_gvisor_mode_value(&mut opts, existing, &operator_sets);
     resolve_preserved_worker_extra_env_values(&mut opts, existing, &operator_sets);

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -4115,6 +4115,16 @@ enum PlannedHelmValues {
 enum HelmSetFlag {
     Set,
     SetString,
+    SetJson,
+}
+
+fn typed_empty_worker_map_override(expression: &str) -> Option<String> {
+    let (key, value) = expression.split_once('=')?;
+    (key.trim() == "worker.adapterCredentials"
+        && (value.is_empty()
+            || serde_json::from_str::<serde_json::Value>(value)
+                .is_ok_and(|value| value.as_object().is_some_and(|map| map.is_empty()))))
+    .then(|| "worker.adapterCredentials={}".to_string())
 }
 
 #[derive(Clone, Default, PartialEq, Eq)]
@@ -4138,9 +4148,14 @@ impl UpValuePlan {
             .into_iter()
             .map(|(key, value)| (key.trim().to_string(), value.to_string()))
             .collect();
+        let typed = typed_empty_worker_map_override(&expression);
         self.entries.push(PlannedHelmValues::Set {
-            flag: HelmSetFlag::Set,
-            expression,
+            flag: if typed.is_some() {
+                HelmSetFlag::SetJson
+            } else {
+                HelmSetFlag::Set
+            },
+            expression: typed.unwrap_or(expression),
             effective,
         });
     }
@@ -4157,9 +4172,14 @@ impl UpValuePlan {
                 .map(|(key, value)| (key.trim().to_string(), value.to_string()))
                 .collect()
         };
+        let typed = typed_empty_worker_map_override(&expression);
         self.entries.push(PlannedHelmValues::Set {
-            flag: HelmSetFlag::SetString,
-            expression,
+            flag: if typed.is_some() {
+                HelmSetFlag::SetJson
+            } else {
+                HelmSetFlag::SetString
+            },
+            expression: typed.unwrap_or(expression),
             effective,
         });
     }
@@ -4183,6 +4203,7 @@ impl UpValuePlan {
                     args.push(plain(match flag {
                         HelmSetFlag::Set => "--set",
                         HelmSetFlag::SetString => "--set-string",
+                        HelmSetFlag::SetJson => "--set-json",
                     }));
                     args.push(CmdArg::HelmSetExpression(expression.clone()));
                 }

--- a/cli/tests/cluster_secret_hardening.rs
+++ b/cli/tests/cluster_secret_hardening.rs
@@ -406,6 +406,7 @@ fn assert_parser_edge_cases_are_masked(rendered: &str, surface: &str) {
 
 fn pure_up() -> UpOpts {
     UpOpts {
+        retained_mail_values: None,
         common: CommonOpts {
             namespace: TARGET_NAMESPACE.to_string(),
             release: TARGET_RELEASE.to_string(),

--- a/cli/tests/installation_plan_parity.rs
+++ b/cli/tests/installation_plan_parity.rs
@@ -269,6 +269,9 @@ if [ "$1" = upgrade ]; then
     runner_real_mode_preserved='no'
     runner_egress_preserved='no'
     for argument in "$@"; do
+        if [ "$previous" = '-f' ] && [ -n "${CURIE_TEST_CAPTURE_MAIL_VALUES:-}" ] && grep -Fq '"mailAdapter"' "$argument"; then
+            cp "$argument" "$CURIE_TEST_CAPTURE_MAIL_VALUES"
+        fi
         if [ "$previous" = '-f' ] && grep -q '"sealing"' "$argument" && grep -q '"privateKey"' "$argument"; then
             sealing_key_present='yes'
         fi
@@ -1558,6 +1561,83 @@ fn cluster_up_dry_run_defers_sealing_resolution_without_inventing_a_key() {
             && visible.contains("generat"),
         "the preview must explain that live release discovery decides preservation or generation:\n{visible}"
     );
+}
+
+#[test]
+fn apply_and_plain_up_preserve_omitted_mail_but_honor_explicit_source_clear() {
+    let existing = json!({
+        "mailAdapter": {
+            "deploy": true,
+            "inbox": "mail@example.com",
+            "channelToken": "obsolete-inline-token",
+            "channelTokenExistingSecret": "acme-mail-credentials",
+            "channelTokenExistingSecretKey": "channel-key",
+            "allowedSenders": ["operator@example.com"],
+            "pollIntervalSeconds": 37
+        },
+        "worker": {
+            "adapterCredentialsExistingSecret": "acme-mail-credentials",
+            "adapterCredentialsExistingSecretKey": "worker-map"
+        }
+    });
+    for surface in ["up", "apply", "apply-clear"] {
+        let config = if surface == "apply-clear" {
+            format!(
+                "{}set:\n  mailAdapter.channelTokenExistingSecret: \"\"\n",
+                installation_for_the_stateful_guard()
+            )
+        } else {
+            installation_for_the_stateful_guard().to_string()
+        };
+        let fixture = HelmFixture::new(&config, HelmValuesResponse::Object(existing.clone()));
+        let captured = fixture.temp.path().join("mail-values.json");
+        let env = [("CURIE_TEST_CAPTURE_MAIL_VALUES", captured.to_str().unwrap())];
+        let output = if surface == "up" {
+            fixture.cluster_up_with(&["--fake-model"], &env)
+        } else {
+            fixture.apply(&[], &env)
+        };
+        json_output(output, surface);
+        let actual: Value =
+            serde_json::from_slice(&fs::read(captured).expect("Helm received mail values"))
+                .unwrap();
+        assert_eq!(actual["mailAdapter"]["deploy"], true);
+        assert_eq!(actual["mailAdapter"]["pollIntervalSeconds"], 37);
+        assert_eq!(
+            actual["mailAdapter"]["allowedSenders"],
+            json!(["operator@example.com"])
+        );
+        assert!(actual["mailAdapter"].get("channelToken").is_none());
+        if surface == "apply-clear" {
+            assert!(actual["mailAdapter"]
+                .get("channelTokenExistingSecret")
+                .is_none());
+            assert!(fixture
+                .calls()
+                .contains("--set-string mailAdapter.channelTokenExistingSecret="));
+        } else {
+            assert_eq!(
+                actual["mailAdapter"]["channelTokenExistingSecret"],
+                "acme-mail-credentials"
+            );
+        }
+        let diff = json_output(fixture.diff(&[]), "diff retained mail");
+        let entries = diff["entries"].as_array().unwrap();
+        let deploy = entries
+            .iter()
+            .find(|entry| entry["key"] == "mailAdapter.deploy")
+            .unwrap();
+        assert_eq!(deploy["kind"], "preserved");
+        let stale = entries
+            .iter()
+            .find(|entry| entry["key"] == "mailAdapter.channelToken")
+            .unwrap();
+        assert_eq!(
+            stale["kind"], "change",
+            "diff must disclose stripping the stale inline copy"
+        );
+        assert!(!fixture.calls().contains("obsolete-inline-token"));
+    }
 }
 
 #[test]

--- a/cli/tests/installation_plan_parity.rs
+++ b/cli/tests/installation_plan_parity.rs
@@ -152,6 +152,9 @@ if [ "$1" = show ] && [ "$2" = chart ]; then
     exit 0
 fi
 if [ "$1" = template ]; then
+    if [ -n "${CURIE_TEST_REAL_HELM:-}" ]; then
+        exec "$CURIE_TEST_REAL_HELM" "$@"
+    fi
     case " $* " in
         *" --show-only templates/preflight-gvisor.yaml "*)
             printf '%s\n' 'Error: could not find template templates/preflight-gvisor.yaml in chart' >&2
@@ -1682,6 +1685,56 @@ fn empty_inline_mail_clears_preserve_external_sources_through_up_and_apply() {
                     "{surface}: empty {inline}={value:?} must not switch credential sources"
                 );
             }
+        }
+    }
+}
+
+#[test]
+fn empty_worker_map_clear_reaches_real_helm_with_its_map_type_intact() {
+    let helm = Command::new("sh")
+        .args(["-c", "command -v helm"])
+        .output()
+        .unwrap();
+    assert!(
+        helm.status.success(),
+        "real Helm is required for the CLI consumer render"
+    );
+    let helm = String::from_utf8(helm.stdout).unwrap();
+    for value in ["", "{}"] {
+        for surface in ["up", "apply"] {
+            let config = format!(
+                "{}set:\n  security.gvisor.mode: off\n  worker.adapterCredentials: {value:?}\n",
+                installation_for_the_stateful_guard()
+            );
+            let mut existing = external_mail_sources();
+            existing["mailAdapter"]["ingressEnabled"] = json!(false);
+            existing["mailAdapter"]["agentmail"]["httpsCidrs"] = json!(["203.0.113.10/32"]);
+            let fixture = HelmFixture::new(&config, HelmValuesResponse::Object(existing));
+            let env = [("CURIE_TEST_REAL_HELM", helm.trim())];
+            let output = if surface == "up" {
+                fixture.cluster_up_with(
+                    &[
+                        "--fake-model",
+                        "--set",
+                        "security.gvisor.mode=off",
+                        "--set",
+                        &format!("worker.adapterCredentials={value}"),
+                    ],
+                    &env,
+                )
+            } else {
+                fixture.apply(
+                    &[
+                        "--chart",
+                        concat!(env!("CARGO_MANIFEST_DIR"), "/../charts/curie"),
+                    ],
+                    &env,
+                )
+            };
+            json_output(
+                output,
+                &format!("{surface}: real Helm accepts empty map {value:?}"),
+            );
         }
     }
 }

--- a/cli/tests/installation_plan_parity.rs
+++ b/cli/tests/installation_plan_parity.rs
@@ -1564,6 +1564,236 @@ fn cluster_up_dry_run_defers_sealing_resolution_without_inventing_a_key() {
 }
 
 #[test]
+fn clean_external_mail_diff_has_no_phantom_inline_additions() {
+    let existing = external_mail_sources();
+    let fixture = HelmFixture::new(
+        installation_for_the_stateful_guard(),
+        HelmValuesResponse::Object(existing),
+    );
+    let diff = json_output(fixture.diff(&[]), "clean external mail diff");
+    for entry in diff["entries"].as_array().unwrap() {
+        assert!(
+            ![
+                "mailAdapter.agentmail.apiKey",
+                "mailAdapter.channelToken",
+                "mailAdapter.egressSecret",
+                "worker.adapterCredentials"
+            ]
+            .contains(&entry["key"].as_str().unwrap()),
+            "an absent inline credential must stay absent from a clean diff: {entry}"
+        );
+    }
+}
+
+fn external_mail_sources() -> Value {
+    json!({
+        "mailAdapter": {
+            "deploy": true,
+            "agentmail": {"apiKeyExistingSecret": "acme-provider", "apiKeyExistingSecretKey": "provider-key"},
+            "channelTokenExistingSecret": "acme-channel", "channelTokenExistingSecretKey": "channel-key",
+            "egressSecretExistingSecret": "acme-egress", "egressSecretExistingSecretKey": "egress-key"
+        },
+        "worker": {"adapterCredentialsExistingSecret": "acme-worker", "adapterCredentialsExistingSecretKey": "worker-map"}
+    })
+}
+
+#[test]
+fn typed_worker_mail_credential_map_removal_has_no_phantom_parent_diff() {
+    for inline_map in [json!({}), json!({"mail-adapter": "obsolete-inline"})] {
+        let mut existing = external_mail_sources();
+        existing["worker"]["adapterCredentials"] = inline_map.clone();
+        let fixture = HelmFixture::new(
+            installation_for_the_stateful_guard(),
+            HelmValuesResponse::Object(existing),
+        );
+        let diff = json_output(fixture.diff(&[]), "typed worker map diff");
+        let entries = diff["entries"].as_array().unwrap();
+        assert!(
+            !entries
+                .iter()
+                .any(|entry| entry["key"] == "worker.adapterCredentials"),
+            "an object is not a new scalar Helm value"
+        );
+        if !inline_map.as_object().unwrap().is_empty() {
+            let leaf = entries
+                .iter()
+                .find(|entry| entry["key"] == "worker.adapterCredentials.mail-adapter")
+                .unwrap();
+            assert_eq!(
+                leaf["kind"], "change",
+                "the stale inline map must not claim preservation"
+            );
+        }
+        let captured = fixture.temp.path().join("mail-values.json");
+        json_output(
+            fixture.cluster_up_with(
+                &["--fake-model"],
+                &[("CURIE_TEST_CAPTURE_MAIL_VALUES", captured.to_str().unwrap())],
+            ),
+            "typed worker map up",
+        );
+        let actual: Value = serde_json::from_slice(&fs::read(captured).unwrap()).unwrap();
+        assert!(actual["worker"].get("adapterCredentials").is_none());
+        assert_eq!(
+            actual["worker"]["adapterCredentialsExistingSecret"],
+            "acme-worker"
+        );
+    }
+}
+
+#[test]
+fn empty_inline_mail_clears_preserve_external_sources_through_up_and_apply() {
+    for (inline, value) in [
+        ("mailAdapter.agentmail.apiKey", ""),
+        ("mailAdapter.channelToken", ""),
+        ("mailAdapter.egressSecret", ""),
+        ("worker.adapterCredentials", ""),
+        ("worker.adapterCredentials", "{}"),
+    ] {
+        for surface in ["up", "apply"] {
+            let config = format!(
+                "{}set:\n  {inline}: {value:?}\n",
+                installation_for_the_stateful_guard()
+            );
+            let fixture =
+                HelmFixture::new(&config, HelmValuesResponse::Object(external_mail_sources()));
+            let captured = fixture.temp.path().join("mail-values.json");
+            let env = [("CURIE_TEST_CAPTURE_MAIL_VALUES", captured.to_str().unwrap())];
+            let set = format!("{inline}={value}");
+            let output = if surface == "up" {
+                fixture.cluster_up_with(&["--fake-model", "--set", &set], &env)
+            } else {
+                fixture.apply(&[], &env)
+            };
+            json_output(output, surface);
+            let actual: Value = serde_json::from_slice(&fs::read(captured).unwrap()).unwrap();
+            for (pointer, expected) in [
+                (
+                    "/mailAdapter/agentmail/apiKeyExistingSecret",
+                    "acme-provider",
+                ),
+                ("/mailAdapter/channelTokenExistingSecret", "acme-channel"),
+                ("/mailAdapter/egressSecretExistingSecret", "acme-egress"),
+                ("/worker/adapterCredentialsExistingSecret", "acme-worker"),
+            ] {
+                assert_eq!(
+                    actual.pointer(pointer).and_then(Value::as_str),
+                    Some(expected),
+                    "{surface}: empty {inline}={value:?} must not switch credential sources"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn changing_mail_egress_source_requires_an_explicit_worker_pair_decision() {
+    for set in [
+        "mailAdapter.egressSecret=new-inline",
+        "mailAdapter.egressSecretExistingSecret=",
+        "mailAdapter.egressSecretExistingSecretKey=new-egress-key",
+    ] {
+        let (key, value) = set.split_once('=').unwrap();
+        let config = format!(
+            "{}set:\n  {key}: {value:?}\n",
+            installation_for_the_stateful_guard()
+        );
+        for surface in ["up", "apply", "diff"] {
+            let fixture =
+                HelmFixture::new(&config, HelmValuesResponse::Object(external_mail_sources()));
+            let output = match surface {
+                "up" => fixture.cluster_up_with(&["--fake-model", "--set", set], &[]),
+                "apply" => fixture.apply(&[], &[]),
+                _ => fixture.diff(&[]),
+            };
+            assert!(
+                !output.status.success(),
+                "{surface}: unpaired egress source change must be refused before Helm"
+            );
+            assert!(
+                !fixture.calls().contains("upgrade --install"),
+                "refusal must precede mutation"
+            );
+            let visible = format!(
+                "{}{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            assert!(
+                visible.contains("paired worker"),
+                "actionable paired-source refusal: {visible}"
+            );
+        }
+    }
+    // A paired switch can use the chart's derived worker credential map.
+    let fixture = HelmFixture::new(
+        installation_for_the_stateful_guard(),
+        HelmValuesResponse::Object(external_mail_sources()),
+    );
+    json_output(
+        fixture.cluster_up_with(
+            &[
+                "--fake-model",
+                "--set",
+                "mailAdapter.egressSecret=new-inline",
+                "--set",
+                "worker.adapterCredentialsExistingSecret=",
+            ],
+            &[],
+        ),
+        "paired inline switch",
+    );
+    // Repeating an existing source is not a source change.
+    let fixture = HelmFixture::new(
+        installation_for_the_stateful_guard(),
+        HelmValuesResponse::Object(external_mail_sources()),
+    );
+    json_output(
+        fixture.cluster_up_with(
+            &[
+                "--fake-model",
+                "--set",
+                "mailAdapter.egressSecretExistingSecret=acme-egress",
+            ],
+            &[],
+        ),
+        "reassert unchanged source",
+    );
+    let fixture = HelmFixture::new(
+        installation_for_the_stateful_guard(),
+        HelmValuesResponse::Object(external_mail_sources()),
+    );
+    json_output(
+        fixture.cluster_up_with(
+            &[
+                "--fake-model",
+                "--set",
+                "mailAdapter.egressSecretExistingSecretKey=egress-key",
+            ],
+            &[],
+        ),
+        "reassert unchanged source key",
+    );
+    let fixture = HelmFixture::new(
+        installation_for_the_stateful_guard(),
+        HelmValuesResponse::Object(external_mail_sources()),
+    );
+    json_output(
+        fixture.cluster_up_with(
+            &[
+                "--fake-model",
+                "--set",
+                "mailAdapter.egressSecretExistingSecretKey=new-egress-key",
+                "--set",
+                "worker.adapterCredentialsExistingSecretKey=new-worker-key",
+            ],
+            &[],
+        ),
+        "paired source key rotation",
+    );
+}
+
+#[test]
 fn apply_and_plain_up_preserve_omitted_mail_but_honor_explicit_source_clear() {
     let existing = json!({
         "mailAdapter": {

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -472,8 +472,14 @@ settings, PVC configuration, and all three credential references together with
 `worker.adapterCredentialsExistingSecret` and its key. Inline credentials on
 older installs are also retained through the protected values-file path. An
 explicit `--set mailAdapter.deploy=false` disables it; clearing an external
-credential reference does not restore a stale inline credential. Replacing a
-credential with an explicit inline value drops its retained external reference.
+credential reference does not restore a stale inline credential. A nonempty
+inline credential replaces its retained external reference; an empty inline
+clear leaves the external source active. An empty worker credential map also
+leaves its external source active. Changing the adapter's egress source while
+the worker uses an external credential map requires an explicit paired worker
+source decision; the CLI refuses an unpaired change before Helm runs. Restating
+the worker's Secret name or key acknowledges a pairing updated inside that
+Secret. The CLI checks this explicit decision, not equality of opaque credentials.
 
 Two platform-side steps come first, in this order:
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -133,6 +133,16 @@ Installs (or upgrades) Curie's Helm chart onto the cluster you're pointed at:
 curie cluster up
 ```
 
+This is a full Helm upgrade. It carries forward the recorded generated secrets,
+sealing keys, Slack tokens, GitHub App and token, runner model and credential,
+gVisor mode, worker extra environment, trusted Slack origins, runner egress,
+and the installed `mailAdapter.*` values with the worker's paired adapter
+credential map or external Secret reference. Other values must be supplied again.
+Explicit `--set` and `--set-string` inputs override retained values. Retained mail
+values use a private temporary values file; the command shows field names only.
+The offline `--dry-run` does not read an installed release, so it cannot display
+that release's retained values.
+
 | Flag / env var | What it does |
 |---|---|
 | `--chart <path-or-tgz>` | Install from a local chart instead of the pinned release asset (for chart development). |
@@ -456,6 +466,14 @@ For the `local`-target equivalent (`curie local comms --slack`), see
 There is no `curie cluster comms --email` yet, so email is wired with a private
 Helm values file. The mail adapter ships off by default
 ([`apps/mail-adapter`](../apps/mail-adapter)).
+
+After email is configured, a plain `curie cluster up` preserves its recorded
+settings, PVC configuration, and all three credential references together with
+`worker.adapterCredentialsExistingSecret` and its key. Inline credentials on
+older installs are also retained through the protected values-file path. An
+explicit `--set mailAdapter.deploy=false` disables it; clearing an external
+credential reference does not restore a stale inline credential. Replacing a
+credential with an explicit inline value drops its retained external reference.
 
 Two platform-side steps come first, in this order:
 


### PR DESCRIPTION
## Summary

A plain `curie cluster up` currently discards an installed mail adapter's values, disabling the adapter and removing its PVC while dropping its external credential references. Preserve the typed mail configuration and paired worker adapter credential source through the existing private temporary Helm values-file lifecycle. Explicit overrides win; an active external Secret never replays an obsolete inline credential. Empty inline clears preserve active external sources, and empty worker maps retain their map type. Changing the adapter egress source requires an explicit paired worker decision while an opaque external worker map is active; this is an acknowledgement, not a comparison of Secret contents. The shared `apply` and `diff` consumers follow the same retained-family behavior.

This is the narrow mail prerequisite for a retained-configuration patch upgrade. It does not claim completion of all external Secret preservation work in #1801.

## Related issue

Ref #2373. Ref #1801 (only the three mail credential pairs and paired worker adapter source).

## Fix pin verification

Fix pin: cli/tests/installation_plan_parity.rs::apply_and_plain_up_preserve_omitted_mail_but_honor_explicit_source_clear

## Verification

Candidate: `a1c1db147d735df3790affe8ead5884772f2f1cc`.

- Test-first retention, stale-inline, empty-clear, typed-map, phantom-diff, and paired-source controls failed before their fixes. The binary `up` / `apply` / `diff` consumer tests now cover the primary and sibling paths.
- A real-Helm consumer test reproduces the old map-to-scalar warning through the CLI preflight, then passes all four `up` / `apply` × empty / empty-object paths. Verified with Helm 3.16.4 and 3.20.0; Rust CI explicitly installs the pinned 3.16.4 tool, and the test never silently skips.
- The final candidate passed 2,174 Rust tests across 84 suites with mandatory real Valkey, plus formatting and all-target Clippy. Documentation checks passed on the preceding reviewed candidate; the final delta changes code, a consumer test and its pinned CI tool dependency.
- Independent code, security, scope and adversarial reviews passed after correcting the source-pair issues. Final reviewed snapshots included independent red-on-revert and green execution.
- The final candidate's full PR fix-pin check reported `PINNED`.
- Final actual-cluster checks preserved all six PVC UIDs, four external Secret sources, typed mail configuration and a persisted marker through released v0.8.5 → candidate CLI `cluster up`. Actual plain-up, all-four empty-inline, typed-empty-map and unchanged-reference/key paths passed; repeated `diff` reads are idempotent without phantom additions. Three unpaired egress source changes refused before any Helm revision changed.
- The final installed worker completed a real model task and delivered exactly one response bearing the new event marker through the external mail provider. Its matching conversation/admission-time runner trace contains one real generation, 16 observations, no errors and completed/succeeded terminal status. Admission was fixture-owned with inbox polling disabled; this proves real egress, not inbox ingestion.
- An intentionally stale worker credential produced a correlated processing exception with adapter HTTP 401, no external negative-event message and unchanged provider message count. The worker was stopped before restoring the original disposable Secret.
- Actual `cluster up --set mailAdapter.deploy=false --set worker.replicas=0` removed the mail Deployment/PVC while preserving the other five PVC UIDs. The task cluster and synthetic provider thread were deleted after verification.
- A first final external attempt failed because provider DNS rotated outside the fixture's narrow CIDRs. Its duplicate oracle then caught an observer bug: constructing production state for polling reset the live writer's lease. Failed evidence remains recorded. After refreshing only the task-owned CIDRs and using read-only SQLite observation, one fresh event passed the exact single-reply assertion. This is not a product duplicate-delivery acceptance claim.
- Final candidate `CURIE_E2E_TIERS=local CURIE_E2E_LIVE=0 curie dev e2e-ladder` passed with source-built images, real turns, injected failure/recovery, trace/metric controls and invalid Langfuse auth/exact absence/fresh recovery. `CURIE_E2E_TIERS=local-release CURIE_E2E_LIVE=0 curie dev e2e-ladder` then passed with the generated artifact and the same image IDs under its required tags. Both runs used the copied immutable candidate binary. All task containers, volumes and runner containers were removed between/after rungs.
- Required remote CI still controls merge readiness. The initial Python failure was the existing authenticated chunked-body race tracked in #1922; the coordinator requested one failed-job rerun after the exact local selector passed. No assertions, required checks or audit policy were weakened.

| Tier | Required / n/a | Reason | Mode | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | No runner loop or bundle packaging change | n/a | n/a |
| local | required | Operator command plan/output changes | fake | Exact candidate local ladder passed, including failure/auth negative and fresh recovery |
| local-release | required | Selected journey upgrades a released installation | fake | Exact candidate local-release ladder passed using generated Compose and recorded source image IDs |
| cluster | required | Retained mail Deployment/PVC/config across actual upgrade | live install | Final exact-candidate positive, three source-refusal controls and actual explicit disable passed |
| live provider | required | Product integration credential resolution crosses retained Secret and worker boundaries | live | Fresh installed worker: one real model generation, succeeded terminal trace and one external event-marked reply; stale worker credential refused HTTP401 before external send |
| external integration | required | Real mail roundtrip after retained-config upgrade | live | Final installed-worker real-provider egress and stale-credential HTTP401 negative passed |

- [x] Every required tier names an exact command, candidate and observed result.
- [x] Source/consumer checks include positive and falsifiable negative or independent paths.
- [x] No required runtime tier is left unproved.

Coordinator inspection of the final source and evidence is complete; required remote CI must pass before normal merge. The offline dry-run still does not read the installed release; documentation states this limitation rather than inventing retained values.
