### PR TITLE
Allow exact trusted bot channel pairs in Slack threads

### DIFF
--- a/apps/dispatcher/README.md
+++ b/apps/dispatcher/README.md
@@ -47,8 +47,8 @@ bot-authored `app_mention` posted at the root of a channel is ingested, so an al
 `IgnoringSelfEvents` middleware drops the bot's own posts before any listener runs).
 
 Still refused: a bot-authored `app_mention` that carries a `thread_ts`, as a loop guard
-between two Curie installations in one workspace — the cost is that an alert bot replying
-*inside* a thread is not ingested; a `message` event outside the DM lane, which the app
+between two Curie installations in one workspace, unless its exact sender/channel pair
+is explicitly trusted as described below; a `message` event outside the DM lane, which the app
 never subscribed to; a redelivery whose dedupe key is already claimed; and a button click
 with nowhere to reply — an App Home or modal click, which carries no channel and no
 message.
@@ -63,6 +63,34 @@ currently deliver, so they are not dispositions to expect in production logs —
 kept on purpose, and `docs/interfaces/channel-ingress/INTERFACE.md` says why. If the grep
 finds nothing, the refusal was Bolt's, above these handlers — that same document is the
 system of record for this contract.
+
+### Trusted bot continuations
+
+`CURIE_SLACK_THREADED_BOT_ALLOWLIST` is a JSON array of exact channel/bot pairs:
+
+```bash
+export CURIE_SLACK_THREADED_BOT_ALLOWLIST='[{"channel_id":"C0EXAMPLE1","bot_id":"B0EXAMPLE1"}]'
+```
+
+It defaults to `[]`. Malformed JSON, missing or extra keys, blank identifiers,
+non-channel or non-bot identifiers, and wildcards prevent dispatcher startup.
+A pair admits only that bot's threaded channel mentions; pairs never form a
+cross product. Use the event's `bot_id`, not the bot's user ID or display name.
+The authenticated Slack event supplies both identifiers. Deduplication, content
+filters, and Bolt's self-event suppression still run. This grants no approval
+rights and does not create a human principal.
+
+Trust only a dedicated sender that does not automatically reply to Curie.
+The dispatcher cannot tell whether another bot identity is another Curie
+installation: allowlisting such a bot removes the cross-installation loop guard
+for that pair. All unlisted bot/channel pairs retain the default refusal.
+Remove the pair and restart the dispatcher to revoke threaded admission.
+
+Compose forwards this variable in both dev and generated release stacks. Helm
+operators can set the same variable with `dispatcher.extraEnv`; no new chart
+value is required. Runtime Slack proof requires an installed sender app and
+live delivery; the Bolt/Valkey tests alone do not establish that Slack delivered
+or that the worker answered.
 
 ## The queue seam (what the worker consumes)
 
@@ -124,6 +152,7 @@ Read from the environment by `DispatcherConfig()` (a `pydantic_settings.BaseSett
 | `VALKEY_PORT` | `6379` | Valkey port (compose maps it to `26379` on the host) |
 | `VALKEY_PASSWORD` | "" | Valkey password (compose dev: `valkeypass`) |
 | `VALKEY_DB` | `0` | Valkey db index |
+| `CURIE_SLACK_THREADED_BOT_ALLOWLIST` | `[]` | exact `{channel_id, bot_id}` pairs allowed to mention the agent inside channel threads |
 | `CURIE_STREAM` | `curie:runs` | Stream the jobs land on |
 | `CURIE_DEDUPE_PREFIX` | `curie:dedupe:` | dedupe key prefix |
 | `CURIE_DEDUPE_TTL_SECONDS` | `3600` | dedupe guard TTL |

--- a/apps/dispatcher/src/curie_dispatcher/config.py
+++ b/apps/dispatcher/src/curie_dispatcher/config.py
@@ -30,6 +30,9 @@ Env mapping:
     CURIE_HEARTBEAT_INTERVAL_SECONDS -> heartbeat_interval_s
 """
 
+import json
+from typing import Annotated
+
 from aci_protocol.service_config import (
     API_KEY_ENV,
     HEARTBEAT_FILE_ENV,
@@ -40,11 +43,20 @@ from aci_protocol.service_config import (
     api_url_validation_alias,
     warn_if_deprecated_api_url_env,
 )
-from pydantic import Field, model_validator
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 from pydantic_settings.sources import (
     PydanticBaseSettingsSource,
 )
+
+
+class ThreadedBotAdmission(BaseModel):
+    """One explicitly trusted bot in one channel; no wildcard or cross product."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    channel_id: str = Field(strict=True, pattern=r"^[CG][A-Z0-9]+$")
+    bot_id: str = Field(strict=True, pattern=r"^B[A-Z0-9]+$")
 
 
 class DispatcherConfig(BaseSettings):
@@ -76,6 +88,9 @@ class DispatcherConfig(BaseSettings):
     slack_app_token: str = ""
     slack_bot_token: str = ""
     slack_signing_secret: str = ""
+    slack_threaded_bot_allowlist: Annotated[tuple[ThreadedBotAdmission, ...], NoDecode] = Field(
+        default=(), validation_alias="CURIE_SLACK_THREADED_BOT_ALLOWLIST"
+    )
 
     valkey_host: str = "localhost"
     valkey_port: int = 6379
@@ -156,6 +171,13 @@ class DispatcherConfig(BaseSettings):
     heartbeat_interval_s: float = Field(
         default=10.0, validation_alias=HEARTBEAT_INTERVAL_ENV
     )
+
+    @field_validator("slack_threaded_bot_allowlist", mode="before")
+    @classmethod
+    def _decode_threaded_bot_allowlist(cls, value: object) -> object:
+        # Decode here so JSON null is rejected instead of being discarded by
+        # the settings env source and silently replaced by the empty default.
+        return json.loads(value) if isinstance(value, str) else value
 
     @model_validator(mode="after")
     def _require_independent_chat_attester(self) -> "DispatcherConfig":

--- a/apps/dispatcher/src/curie_dispatcher/handlers.py
+++ b/apps/dispatcher/src/curie_dispatcher/handlers.py
@@ -12,7 +12,8 @@ silent, which is the defect that ticket closes.
 
   - ``app_mention``: the bot was @-mentioned. A human mention is always
     processed, at root or in a thread. A *bot*-authored mention is processed
-    only as a ROOT post: one carrying ``thread_ts`` is refused as
+    at root; one carrying ``thread_ts`` requires an exact sender/channel pair
+    in ``CURIE_SLACK_THREADED_BOT_ALLOWLIST`` or is refused as
     ``BOT_AUTHORED_THREAD_REPLY``, because Curie's own replies are always
     threaded and two installations in one workspace could otherwise mention-loop
     each other -- a case Bolt's self filter cannot see, since the two bot
@@ -320,7 +321,9 @@ def process_event(
         )
         return None
 
-    reason = classify(event, lane=lane)
+    reason = classify(
+        event, lane=lane, threaded_bot_allowlist=config.slack_threaded_bot_allowlist
+    )
     if reason is not None:
         drop(log, reason, event_id=slack_event_id, lane=lane)
         return None

--- a/apps/dispatcher/src/curie_dispatcher/relevance.py
+++ b/apps/dispatcher/src/curie_dispatcher/relevance.py
@@ -39,6 +39,8 @@ from enum import StrEnum
 from types import MappingProxyType
 from typing import Any, Literal
 
+from .config import ThreadedBotAdmission
+
 #: Which subscribed lane a delivery arrived on. The manifest
 #: (``apps/dispatcher/slack-app-manifest.yaml``) subscribes to exactly two bot
 #: events, so this is the complete set of lanes -- not an open string.
@@ -88,7 +90,8 @@ DROP_RATIONALES: Mapping[DropReason, str] = MappingProxyType(
             "are always threaded, so admitting a bot-authored mention that carries "
             "a thread timestamp would let two Curie installations in one workspace "
             "mention-loop each other indefinitely, which Bolt's self filter cannot "
-            "stop because the two bot identities differ."
+            "stop because the two bot identities differ. Only an explicitly trusted "
+            "sender/channel pair may bypass this refusal."
         ),
         DropReason.NON_CONTENT_SUBTYPE: (
             "The subtype marks something other than new user content: an edit, a "
@@ -191,7 +194,12 @@ def missing_envelope_fields(required: Mapping[str, object]) -> tuple[str, ...]:
     )
 
 
-def classify(event: dict[str, Any], *, lane: Lane) -> DropReason | None:
+def classify(
+    event: dict[str, Any],
+    *,
+    lane: Lane,
+    threaded_bot_allowlist: tuple[ThreadedBotAdmission, ...] = (),
+) -> DropReason | None:
     """The reason this event must not become a turn, or None to admit it.
 
     Args:
@@ -214,11 +222,14 @@ def classify(event: dict[str, Any], *, lane: Lane) -> DropReason | None:
     # own posts are already gone -- Bolt's IgnoringSelfEvents dropped them
     # before this listener ran.
     #
-    # Accepted cost, stated rather than discovered later: an alert bot that
-    # replies INSIDE a thread with a mention is not ingested. Root-only
-    # admission is what separates the ticket's case from the cross-installation
-    # loop without a new schema field or a bot allowlist.
+    # Only an exact pair from operator configuration may bypass this refusal.
+    # These identities come from the Slack event, never message text or a user
+    # field. Bolt's self-event middleware has already run and remains mandatory.
     if lane == "mention" and event.get("bot_id") and event.get("thread_ts"):
-        return DropReason.BOT_AUTHORED_THREAD_REPLY
+        if not any(
+            pair.channel_id == event.get("channel") and pair.bot_id == event.get("bot_id")
+            for pair in threaded_bot_allowlist
+        ):
+            return DropReason.BOT_AUTHORED_THREAD_REPLY
 
     return None

--- a/apps/dispatcher/tests/test_threaded_bot_allowlist.py
+++ b/apps/dispatcher/tests/test_threaded_bot_allowlist.py
@@ -1,0 +1,220 @@
+"""Exact sender/channel exceptions through real Bolt and Valkey.
+
+Slack supplies bot_id for bot messages and channel/thread_ts for replies:
+https://docs.slack.dev/reference/events/message/bot_message/
+https://docs.slack.dev/reference/events/app_mention/
+Only Slack's transport and Web API are faked; own-event suppression is Bolt's
+installed IgnoringSelfEvents middleware, exercised by the self-bot row.
+"""
+
+import json
+from typing import Any
+
+import pytest
+import redis
+from curie_dispatcher.config import DispatcherConfig
+from curie_dispatcher.queue import from_stream_fields
+from curie_dispatcher.relevance import DropReason
+from pydantic import ValidationError
+from pydantic_settings.exceptions import SettingsError
+
+from .test_dispatch import BOT_TS, _drain, _events_api_request
+from .test_inbound_relevance import (
+    _build_harness,
+    _dm,
+    _drop_reasons_logged,
+    _mention,
+    _stream_entries,
+)
+
+_PAIRS = [
+    {"channel_id": "C123", "bot_id": "B2"},
+    {"channel_id": "C456", "bot_id": "B3"},
+    {"channel_id": "C123", "bot_id": "B1"},  # own bot must still be suppressed
+]
+
+
+def _configured(config: DispatcherConfig, monkeypatch: pytest.MonkeyPatch) -> DispatcherConfig:
+    monkeypatch.setenv("CURIE_SLACK_THREADED_BOT_ALLOWLIST", json.dumps(_PAIRS))
+    return DispatcherConfig(**config.model_dump(exclude={"slack_threaded_bot_allowlist"}))
+
+
+@pytest.mark.parametrize(
+    ("bot_id", "channel", "expected"),
+    [
+        ("B2", "C123", None),
+        ("B3", "C456", None),
+        ("B2", "C456", DropReason.BOT_AUTHORED_THREAD_REPLY),
+        ("B3", "C123", DropReason.BOT_AUTHORED_THREAD_REPLY),
+        ("B2", "C789", DropReason.BOT_AUTHORED_THREAD_REPLY),
+        ("B4", "C123", DropReason.BOT_AUTHORED_THREAD_REPLY),
+        ("B1", "C123", "bolt_self"),
+    ],
+)
+def test_exact_pair_reaches_queue_and_retains_loop_guards(
+    redis_client: redis.Redis,
+    config: DispatcherConfig,
+    monkeypatch: pytest.MonkeyPatch,
+    bot_id: str,
+    channel: str,
+    expected: DropReason | str | None,
+) -> None:
+    config = _configured(config, monkeypatch)
+    harness = _build_harness(config, redis_client)
+    event = _mention(text="<@U0BOT> revise the same PR", bot_id=bot_id, thread_ts="1700.0000")
+    event["channel"] = channel
+    harness.handler.handle(harness.sock, _events_api_request("env-bot", "Ev-bot", event))
+    _drain(harness.app)
+    assert harness.errors == []
+    assert harness.sock.acked_envelope_ids == ["env-bot"]
+    entries = _stream_entries(redis_client, config)
+    if expected is None:
+        assert len(entries) == 1
+        turn = from_stream_fields(entries[0][1])
+        assert turn.text == "revise the same PR"
+        assert turn.conversation_id == "1700.0000"
+        assert turn.author == ""  # admitting a bot does not invent a human principal
+        assert harness.web_client.chat_postMessage.call_count == 1  # type: ignore[attr-defined]
+        assert _drop_reasons_logged(harness.records) == []
+    else:
+        assert entries == []
+        assert harness.web_client.chat_postMessage.call_count == 0  # type: ignore[attr-defined]
+        assert redis_client.exists(config.dedupe_key("Ev-bot")) == 0
+        assert _drop_reasons_logged(harness.records) == (
+            [] if expected == "bolt_self" else [expected]
+        )
+
+
+def test_allowlisted_bot_duplicate_posts_and_enqueues_only_once(
+    redis_client: redis.Redis, config: DispatcherConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config = _configured(config, monkeypatch)
+    request = _events_api_request(
+        "env-dup", "Ev-dup", _mention(text="continue", bot_id="B2", thread_ts="1700.0000")
+    )
+    for expected in ([], [DropReason.DUPLICATE_DELIVERY]):
+        harness = _build_harness(config, redis_client)
+        harness.handler.handle(harness.sock, request)
+        _drain(harness.app)
+        assert harness.errors == []
+        assert _drop_reasons_logged(harness.records) == expected
+        assert harness.web_client.chat_postMessage.call_count == (0 if expected else 1)  # type: ignore[attr-defined]
+    assert len(_stream_entries(redis_client, config)) == 1
+
+
+@pytest.mark.parametrize("raw", [None, "[]"])
+def test_absent_or_empty_allowlist_refuses_threaded_bot(
+    redis_client: redis.Redis,
+    config: DispatcherConfig,
+    monkeypatch: pytest.MonkeyPatch,
+    raw: str | None,
+) -> None:
+    monkeypatch.delenv("CURIE_SLACK_THREADED_BOT_ALLOWLIST", raising=False)
+    if raw is not None:
+        monkeypatch.setenv("CURIE_SLACK_THREADED_BOT_ALLOWLIST", raw)
+    config = DispatcherConfig(**config.model_dump(exclude={"slack_threaded_bot_allowlist"}))
+    harness = _build_harness(config, redis_client)
+    harness.handler.handle(
+        harness.sock,
+        _events_api_request(
+            "env-empty", "Ev-empty", _mention(text="continue", bot_id="B2", thread_ts="1700.0000")
+        ),
+    )
+    _drain(harness.app)
+    assert harness.errors == []
+    assert _stream_entries(redis_client, config) == []
+    assert _drop_reasons_logged(harness.records) == [DropReason.BOT_AUTHORED_THREAD_REPLY]
+
+
+@pytest.mark.parametrize(
+    "event",
+    [
+        _mention(text="human continuation", thread_ts="1700.0000"),
+        _mention(text="root bot", bot_id="B4"),
+        _dm(text="bot DM", bot_id="B4"),
+    ],
+)
+def test_allowlist_preserves_human_root_and_dm_admission(
+    redis_client: redis.Redis,
+    config: DispatcherConfig,
+    monkeypatch: pytest.MonkeyPatch,
+    event: dict[str, Any],
+) -> None:
+    config = _configured(config, monkeypatch)
+    harness = _build_harness(config, redis_client)
+    harness.handler.handle(harness.sock, _events_api_request("env-control", "Ev-control", event))
+    _drain(harness.app)
+    assert harness.errors == []
+    assert len(_stream_entries(redis_client, config)) == 1
+    assert _drop_reasons_logged(harness.records) == []
+
+
+def test_allowlisted_bot_still_refuses_non_content(
+    redis_client: redis.Redis, config: DispatcherConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config = _configured(config, monkeypatch)
+    event = _mention(text="edited", bot_id="B2", thread_ts="1700.0000")
+    event["subtype"] = "message_changed"
+    harness = _build_harness(config, redis_client)
+    harness.handler.handle(harness.sock, _events_api_request("env-edit", "Ev-edit", event))
+    _drain(harness.app)
+    assert harness.errors == []
+    assert _stream_entries(redis_client, config) == []
+    assert _drop_reasons_logged(harness.records) == [DropReason.NON_CONTENT_SUBTYPE]
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "",
+        "not json",
+        "null",
+        "{}",
+        '["B2"]',
+        '[{"channel_id":"*","bot_id":"B2"}]',
+        '[{"channel_id":"C123","bot_id":"*"}]',
+        '[{"channel_id":"C123","bot_id":""}]',
+        '[{"channel_id":"C123","bot_id":"U123"}]',
+        '[{"channel_id":"D123","bot_id":"B2"}]',
+        '[{"channel_id":" C123","bot_id":"B2"}]',
+        '[{"channel_id":"C123"}]',
+        '[{"channel_id":"C123","bot_id":"B2","allow_all":true}]',
+        '[{"channel_id":"C123","bot_id":"B2"},{"channel_id":"*","bot_id":"B3"}]',
+    ],
+)
+def test_malformed_allowlist_refuses_dispatcher_configuration(
+    monkeypatch: pytest.MonkeyPatch, raw: str
+) -> None:
+    monkeypatch.setenv("CURIE_SLACK_THREADED_BOT_ALLOWLIST", raw)
+    with pytest.raises((ValidationError, SettingsError)):
+        DispatcherConfig(approval_chat_attester_secret="test-independent-attester")
+
+
+def test_modern_allowlisted_bot_preserves_authenticated_event_provenance(
+    redis_client: redis.Redis, config: DispatcherConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Modern apps can include a bot user alongside bot_id (Slack bot_message docs).
+
+    The bot's user ID is retained as provenance, not converted into an approval
+    principal. Admission must still key off bot_id, never this user field.
+    """
+    config = _configured(config, monkeypatch)
+    harness = _build_harness(config, redis_client)
+    event = _mention(text="continue", bot_id="B2", thread_ts="1700.0000")
+    event["user"] = "U0EXAMPLE1"
+    event["bot_profile"] = {"id": "B2", "name": "acme-test-sender"}
+    harness.handler.handle(
+        harness.sock, _events_api_request("env-modern", "Ev-modern", event)
+    )
+    _drain(harness.app)
+    assert harness.errors == []
+    entries = _stream_entries(redis_client, config)
+    assert len(entries) == 1
+    turn = from_stream_fields(entries[0][1])
+    assert turn.author == "U0EXAMPLE1"
+    assert turn.source == "slack"
+    assert turn.conversation_id == "1700.0000"
+    assert turn.reply_handle.channel == "C123"
+    assert turn.reply_handle.placeholder == BOT_TS
+    assert turn.reply_handle.kind == "slack"
+    assert _drop_reasons_logged(harness.records) == []

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -693,6 +693,7 @@ services:
       SLACK_APP_TOKEN: ${SLACK_APP_TOKEN:-}
       SLACK_BOT_TOKEN: ${SLACK_BOT_TOKEN:-}
       SLACK_SIGNING_SECRET: ${SLACK_SIGNING_SECRET:-}
+      CURIE_SLACK_THREADED_BOT_ALLOWLIST: ${CURIE_SLACK_THREADED_BOT_ALLOWLIST:-[]}
       # In-network form, matching the UI's CURIE_API_TARGET above. The
       # published host port is unreachable from this bridge-network container.
       CURIE_API_URL: http://curie-api:8000

--- a/compose/tests/test_generate_release_compose.py
+++ b/compose/tests/test_generate_release_compose.py
@@ -929,3 +929,26 @@ def test_generated_compose_validates_with_docker(tmp_path):
         text=True,
     )
     assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.parametrize("raw", [None, '[{"channel_id":"C123","bot_id":"B2"}]'])
+def test_threaded_bot_allowlist_reaches_dev_and_generated_release_compose(raw, tmp_path):
+    """Exercise Compose interpolation on both delivery paths, including opt-out."""
+    generate = load_generate()
+    env = os.environ.copy()
+    env.pop("CURIE_SLACK_THREADED_BOT_ALLOWLIST", None)
+    if raw is not None:
+        env["CURIE_SLACK_THREADED_BOT_ALLOWLIST"] = raw
+    for name, content in [("dev", DEV_TEXT), ("release", generate(DEV_TEXT, OTEL_TEXT, "9.9.9"))]:
+        path = tmp_path / f"{name}.yaml"
+        path.write_text(content)
+        result = subprocess.run(
+            [
+                "docker", "compose", "--env-file", "/dev/null",
+                "--project-directory", str(REPO_ROOT), "-f", str(path),
+                "--profile", "slack", "--profile", "full", "config", "--format", "json",
+            ],
+            env=env, capture_output=True, text=True, check=True, timeout=30,
+        )
+        dispatcher = json.loads(result.stdout)["services"]["curie-dispatcher"]
+        assert dispatcher["environment"]["CURIE_SLACK_THREADED_BOT_ALLOWLIST"] == (raw or "[]")

--- a/docs/interfaces/channel-ingress/INTERFACE.md
+++ b/docs/interfaces/channel-ingress/INTERFACE.md
@@ -142,7 +142,7 @@ tests assert the two sets equal in both directions.
 | `DropReason` | Documented rationale |
 |---|---|
 | `UNSUBSCRIBED_LANE` | The delivered envelope is outside the adapter's declared subscription surface — `apps/dispatcher/slack-app-manifest.yaml` subscribes to `app_mention` and `message.im` only, so a message event on any other channel type cannot legitimately arrive, and refusing it is envelope validation rather than a relevance judgement. |
-| `BOT_AUTHORED_THREAD_REPLY` | Loop guard across installations: Curie's own replies and placeholders are always threaded, so admitting a bot-authored mention that carries a thread timestamp would let two Curie installations in one workspace mention-loop each other indefinitely, which Bolt's self filter cannot stop because the two bot identities differ. |
+| `BOT_AUTHORED_THREAD_REPLY` | Loop guard across installations: Curie's own replies and placeholders are always threaded, so admitting a bot-authored mention that carries a thread timestamp would let two Curie installations in one workspace mention-loop each other indefinitely, which Bolt's self filter cannot stop because the two bot identities differ. An exact operator-trusted sender/channel pair may bypass this refusal; self-event suppression remains mandatory. |
 | `NON_CONTENT_SUBTYPE` | The subtype marks something other than new user content: an edit, a delete, a tombstone, a body redacted by Enterprise Key Management, or an assistant thread-start marker. |
 | `DUPLICATE_DELIVERY` | Slack redelivered a delivery whose idempotency key was already claimed, so processing it again would post a second placeholder and mint a second turn for one message. |
 | `NO_ACTION_IN_PAYLOAD` | A block-action payload carrying no actions names no command and addresses nothing, so there is no turn to mint from it. |
@@ -207,11 +207,15 @@ absent — it is *handled* by the dedicated approval listener, not dropped.
   typically arrives as Block Kit and is normalized by
   `apps/dispatcher/src/curie_dispatcher/inbound_text.py::derive_text` rather than read off
   an empty top-level `text`. A bot-authored mention carrying `thread_ts` is refused as
-  `BOT_AUTHORED_THREAD_REPLY` for the cross-installation loop above; on the DM lane bot
-  authorship is not consulted at all. The accepted cost, stated rather than discovered
-  later: an alert bot that replies *inside* a thread with a mention is not ingested.
-  Root-only admission is what separates the ticket's case from the loop without a new
-  `QueuedTurn` field or a bot allowlist.
+  `BOT_AUTHORED_THREAD_REPLY` for the cross-installation loop above, unless the event's
+  exact channel/bot pair is in `CURIE_SLACK_THREADED_BOT_ALLOWLIST`; on the DM lane bot
+  authorship is not consulted at all. The allowlist defaults to empty and malformed
+  entries fail dispatcher configuration. Only trust a dedicated sender that does not
+  automatically respond to Curie: an allowlisted second Curie installation could loop.
+  Bolt still drops this installation's own bot even when it is listed. Exact-pair,
+  cross-product, self-bot, content-filter and duplicate outcomes are exercised through
+  Bolt and real Valkey in `apps/dispatcher/tests/test_threaded_bot_allowlist.py`.
+  See `apps/dispatcher/README.md` for configuration and the live-proof boundary.
 
   Its known consequence, stated here rather than left to be found: a bot-authored event
   normally carries no human `user`, so the turn is queued with an empty `author` while its


### PR DESCRIPTION
## Summary

Allow an operator to admit a dedicated bot's threaded mentions by exact channel/bot pairs. The default remains empty; malformed entries refuse startup. Existing Bolt self-event suppression, non-content filtering, author provenance, deduplication and queue ordering remain enforced. Dev and generated release Compose pass the same setting to the dispatcher.

This change provides the narrow integration prerequisite for testing continuous conversations. It grants no approval authority. The exact sender restriction and existing self-event suppression prevent an autonomous response loop.

## Verification

Candidate: `4571bdba4c16df31858d9318b981ef85f212ef7d`.

- Test-first: the permitted pair failed through the real Socket Mode handler before implementation; generated Compose lacked the setting before its change.
- Focused real Bolt/Valkey tests cover permitted pairs and forbidden cross products, wrong channel/sender, own bot, default/empty configuration, malformed entries, duplicate delivery, human thread, root bot and DM controls.
- Canonical repository Python baseline: `6203 passed, 19 skipped, 837 warnings in 1218.51s`. Lock, Ruff, mypy, import boundaries, docs, wire compatibility, migrations and released-upgrade checks passed. Task-owned backing services and test-created observability containers were removed afterward.
- Scope/security and independent adversarial reviews completed. Real Slack enabled/disabled paths passed on both local source and generated local-release Compose, followed by both generic product rungs. This narrow policy proof does not complete the broader coding journey or real human approval acceptance.

## End-to-end verification

| Tier | Required / n/a | Reason | Mode | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | No runner loop, ACI or plugin change | n/a | n/a |
| local | required | Dispatcher policy and Compose environment wiring | fake/live Slack | PASS: `CURIE_E2E_TIERS=local CURIE_E2E_LIVE=0 <candidate-cli> dev e2e-ladder`; actual `local up --minimal --slack --build` enabled/disabled policy driver also passed. Empty policy: zero matching queue events/replies plus healthy root control. Exact pair: one event, exact reply, worker done, same author/thread and 30-second stability. |
| local-release | required | Generated release Compose carries the setting | fake/live Slack | PASS: `CURIE_E2E_TIERS=local-release CURIE_E2E_LIVE=0 <candidate-cli> dev e2e-ladder`; generated Compose pinned to `overnight-4571bdba` also passed the same real Slack disabled/enabled controls. Running images matched the source build before sends and after policy recreation. |
| cluster | n/a | No chart or Kubernetes runtime change; existing extraEnv carries the same setting | n/a | n/a |
| live provider | n/a | No model routing, credential resolution or accounting change | n/a | n/a |
| external integration | required | Threaded Slack app mentions from a dedicated sender | live | PASS: private task-local `slack-live-policy.py` against image built from exact tracked candidate. Empty allowlist: zero matching queue events and zero target replies over a complete cursor range, plus a healthy exact root response. Exact pair: one queue event, preserved sender/thread provenance, exact target reply, worker done, stable after 30 seconds. Original dispatcher spec restored exactly. Independent local and local-release policy runs additionally verified dispatcher image ID `sha256:a7f51da64116a485f2c089e16c1b11a8c4bef9f1c46b6eed9bcde1221a97657a` across both policy states. Earlier cluster-supporting imported image manifest `sha256:036b93bc91df4fec9ffe7797a4006ee9dc0924afb86efa099f255ae30dc34a25`; runtime pod imageID not captured, so no independent pod-digest claim. |

- [x] Every required tier names the exact command, candidate and observed outcome.
- [x] Policy controls have positive and falsifiable negative coverage through the actual consumer.
- [x] No required tier is left unproved.

Exact copied CLI SHA256: `423adff9dc7b5e72247c9d4c9cc9db7dc8dcd2db77b9882e3a2eeb2dd4d69e5c`. Generated policy Compose SHA256: `edaa2fc28af243d91a1c8034f84e0da527edcb8722bac8c2d1af9e1b5f140020`. All task containers, volumes, runners and sender processes were removed; the original dedicated dispatcher was restored and ready. The first local-release preflight refused a socket bind before any send or remote mutation; the unchanged driver passed after a fresh free-port check.

Feature PR remains unmerged for maintainer review.

## Checklist

- [x] Scoped tests and canonical Python baseline pass.
- [x] Runtime behavior and trust limits are documented.
- [x] Required live acceptance for this restricted admission policy is complete.
