### PR TITLE
Settle rollout setup before recording worker identity

### DIFF
--- a/cli/scripts/e2e-cluster-rollout-recovery.sh
+++ b/cli/scripts/e2e-cluster-rollout-recovery.sh
@@ -575,6 +575,10 @@ PY
 )" >/dev/null
 DEPLOYMENT_PATCHED=1
 kubectl -n "$NAMESPACE" rollout status "deployment/$WORKER_DEPLOYMENT" --timeout=300s
+# A completed rollout can still have a terminating predecessor. Settle that
+# setup transition before choosing the consumer and freezing the full identity
+# invariant for the first message; keep every pod in the later comparisons.
+assert_release_healthy
 OLD_POD="$(ready_worker)"
 [[ -n "$OLD_POD" ]] || { echo "error: no Ready baseline worker" >&2; exit 1; }
 OLD_CONSUMER="$(wait_consumer_for_pod "$OLD_POD" 60)"


### PR DESCRIPTION
## Summary

Wait for the test setup rollout to settle before recording worker identity for the first-message regression check. Kubernetes can report the rollout complete while its predecessor is still terminating; when that predecessor disappears, the current test incorrectly reports that the message replaced a worker. Reuse the existing bounded release-health check before selecting the consumer and baseline. Keep the complete pod/generation identity comparison and deliberate-kill recovery checks unchanged.

## Related issue

Ref #2096. The setup race was observed in [required cluster CI](https://github.com/curie-eng/curie/actions/runs/33932641298/job/101214452403), with unchanged generation and Ready-worker identity and only the already-terminating predecessor disappearing. This PR closes no issue.

## Verification

Candidate `65b32194ea27f6aa5066b39fe537aa4d8b151e06`, base `d9f5c3f98f6e8fdfdc67e8acc0a397a0fe6b73bd`. Bash syntax and diff checks pass. Independent code/scope review found the original identity invariant preserved; acceptance remains open pending fresh real-cluster execution. This draft is reviewable work, not a completed gate.

## End-to-end verification

| Tier | Required / n/a | Reason | Mode | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | No runner or skill loop change | n/a | n/a |
| local | n/a | Only cluster E2E setup sequence changes | n/a | n/a |
| local-release | n/a | No released Compose or artifact identity change | n/a | n/a |
| cluster | required | Real rollout/recovery harness behavior | fake model, real Kubernetes | `bash cli/scripts/e2e-cluster-rollout-recovery.sh` with exact candidate CLI and disposable release: pending; unchanged old setup already failed in linked CI |
| live provider | n/a | This harness uses the credential-free fake model | n/a | n/a |
| external integration | n/a | No Slack, GitHub or model-provider integration change | n/a | n/a |

- [ ] Exact candidate passes the real cluster harness.
- [ ] Positive stable baseline and negative replacement/recovery assertions are observed.
- [ ] All required tiers have passing evidence.
