### PR TITLE
Draft: Route verified GitHub reviews to coding conversations

### DIFF
--- a/apps/api/alembic/versions/0043_github_review_feedback.py
+++ b/apps/api/alembic/versions/0043_github_review_feedback.py
@@ -27,6 +27,7 @@ def upgrade() -> None:
         sa.Column("binding_generation", sa.Integer(), nullable=False),
         sa.Column("agent_id", postgresql.UUID(as_uuid=True), nullable=False),
         sa.Column("lineage_version", sa.Integer(), nullable=False),
+        sa.Column("reservation_id", postgresql.UUID(as_uuid=True), nullable=True),
         sa.Column("feedback", postgresql.JSONB(), nullable=False),
         sa.Column("turn", postgresql.JSONB(), nullable=False),
         sa.Column("traceparent", sa.String(), nullable=True),
@@ -39,8 +40,9 @@ def upgrade() -> None:
         sa.Column("stream_id", sa.String(), nullable=True),
         sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
         sa.Column("queued_at", sa.DateTime(), nullable=True),
+        sa.Column("terminal_scan_cursor", sa.String(), nullable=True),
         sa.CheckConstraint(
-            "status IN ('waiting', 'queued', 'refused', 'dead_lettered')",
+            "status IN ('waiting', 'queued', 'reserved', 'settled', 'refused', 'dead_lettered')",
             name="github_review_feedback_status_ck",
         ),
         sa.CheckConstraint("version >= 1", name="github_review_feedback_version_ck"),
@@ -51,6 +53,9 @@ def upgrade() -> None:
             ondelete="SET NULL",
         ),
         sa.ForeignKeyConstraint(["binding_id"], ["curie.agent_channels.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(
+            ["reservation_id"], ["curie.publication_review_reservations.id"], ondelete="SET NULL"
+        ),
         schema="curie",
     )
     op.create_index(
@@ -60,6 +65,62 @@ def upgrade() -> None:
         schema="curie",
     )
 
+    op.create_table(
+        "github_review_deliveries",
+        sa.Column("delivery_id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("event_kind", sa.String(), nullable=False),
+        sa.Column("action", sa.String(), nullable=False),
+        sa.Column("body_sha256", sa.String(), nullable=False),
+        sa.Column("repository_id", sa.BigInteger(), nullable=True),
+        sa.Column("installation_id", sa.BigInteger(), nullable=True),
+        sa.Column("pr_number", sa.Integer(), nullable=True),
+        sa.Column("source_object_id", sa.BigInteger(), nullable=True),
+        sa.Column("sender_id", sa.BigInteger(), nullable=True),
+        sa.Column("sender_type", sa.String(), nullable=False),
+        sa.Column("sender_login", sa.String(), nullable=True),
+        sa.Column("author_association", sa.String(), nullable=False),
+        sa.Column(
+            "event_id",
+            sa.String(),
+            sa.ForeignKey("curie.github_review_feedback.event_id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("status", sa.String(), nullable=False, server_default="pending"),
+        sa.Column("reason", sa.String(), nullable=True),
+        sa.Column("version", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("replay_conflicts", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.CheckConstraint(
+            "status IN ('pending','accepted','ignored','rejected','retryable')",
+            name="github_review_deliveries_status_ck",
+        ),
+        sa.CheckConstraint(
+            "version >= 1 AND replay_conflicts >= 0", name="github_review_deliveries_version_ck"
+        ),
+        sa.CheckConstraint("length(body_sha256) = 64", name="github_review_deliveries_digest_ck"),
+        sa.CheckConstraint(
+            "status IN ('pending','accepted') OR reason IS NOT NULL",
+            name="github_review_deliveries_reason_ck",
+        ),
+        schema="curie",
+    )
+
 
 def downgrade() -> None:
+    active = (
+        op.get_bind()
+        .execute(
+            sa.text(
+                "SELECT EXISTS (SELECT 1 FROM curie.github_review_feedback "
+                "WHERE status IN ('waiting','queued','reserved')) "
+                "OR EXISTS (SELECT 1 FROM curie.github_review_deliveries "
+                "WHERE status IN ('pending','retryable'))"
+            )
+        )
+        .scalar_one()
+    )
+    if active:
+        raise RuntimeError("cannot remove GitHub review audit while deliveries are active")
+    op.drop_table("github_review_deliveries", schema="curie")
     op.drop_table("github_review_feedback", schema="curie")

--- a/apps/api/alembic/versions/0043_github_review_feedback.py
+++ b/apps/api/alembic/versions/0043_github_review_feedback.py
@@ -1,0 +1,65 @@
+"""Persist GitHub review feedback and its runs-stream outbox.
+
+Revision ID: 0043
+Revises: 0042
+Create Date: 2026-09-05
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0043"
+down_revision: str | None = "0042"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "github_review_feedback",
+        sa.Column("event_id", sa.String(), primary_key=True),
+        sa.Column("delivery_id", postgresql.UUID(as_uuid=True), nullable=False, unique=True),
+        sa.Column("lineage_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("binding_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("binding_generation", sa.Integer(), nullable=False),
+        sa.Column("agent_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("lineage_version", sa.Integer(), nullable=False),
+        sa.Column("feedback", postgresql.JSONB(), nullable=False),
+        sa.Column("turn", postgresql.JSONB(), nullable=False),
+        sa.Column("traceparent", sa.String(), nullable=True),
+        sa.Column("status", sa.String(), nullable=False, server_default="waiting"),
+        sa.Column("version", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("enqueue_attempts", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("quota_taken", sa.Boolean(), nullable=False, server_default="false"),
+        sa.Column("next_attempt_at", sa.DateTime(), nullable=True),
+        sa.Column("error_code", sa.String(), nullable=True),
+        sa.Column("stream_id", sa.String(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column("queued_at", sa.DateTime(), nullable=True),
+        sa.CheckConstraint(
+            "status IN ('waiting', 'queued', 'refused', 'dead_lettered')",
+            name="github_review_feedback_status_ck",
+        ),
+        sa.CheckConstraint("version >= 1", name="github_review_feedback_version_ck"),
+        sa.CheckConstraint("enqueue_attempts >= 0", name="github_review_feedback_attempts_ck"),
+        sa.ForeignKeyConstraint(
+            ["lineage_id"],
+            ["curie.thread_publication_lineages.id"],
+            ondelete="SET NULL",
+        ),
+        sa.ForeignKeyConstraint(["binding_id"], ["curie.agent_channels.id"], ondelete="SET NULL"),
+        schema="curie",
+    )
+    op.create_index(
+        "ix_github_review_feedback_pending",
+        "github_review_feedback",
+        ["status", "created_at"],
+        schema="curie",
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("github_review_feedback", schema="curie")

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -4156,6 +4156,56 @@
         "title": "ResolvedTarget",
         "type": "object"
       },
+      "ReviewReservationOut": {
+        "properties": {
+          "origin_key": {
+            "title": "Origin Key",
+            "type": "string"
+          },
+          "reservation_id": {
+            "format": "uuid",
+            "title": "Reservation Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "origin_key",
+          "reservation_id"
+        ],
+        "title": "ReviewReservationOut",
+        "type": "object"
+      },
+      "ReviewReservationRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "deployment_id": {
+            "format": "uuid",
+            "title": "Deployment Id",
+            "type": "string"
+          },
+          "expected_head_sha": {
+            "pattern": "^[0-9a-f]{40}$",
+            "title": "Expected Head Sha",
+            "type": "string"
+          },
+          "expected_lineage_version": {
+            "minimum": 1.0,
+            "title": "Expected Lineage Version",
+            "type": "integer"
+          },
+          "turn": {
+            "$ref": "#/components/schemas/QueuedTurn"
+          }
+        },
+        "required": [
+          "turn",
+          "deployment_id",
+          "expected_lineage_version",
+          "expected_head_sha"
+        ],
+        "title": "ReviewReservationRequest",
+        "type": "object"
+      },
       "ReviewRevisionCancel": {
         "properties": {
           "expected_version": {
@@ -4338,9 +4388,29 @@
             "title": "Head Sha",
             "type": "string"
           },
+          "lineage_version": {
+            "title": "Lineage Version",
+            "type": "integer"
+          },
+          "origin_key": {
+            "title": "Origin Key",
+            "type": "string"
+          },
           "receipt": {
             "title": "Receipt",
             "type": "string"
+          },
+          "reservation_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reservation Id"
           },
           "sender": {
             "title": "Sender",
@@ -4351,7 +4421,10 @@
           "head_sha",
           "agent_id",
           "sender",
-          "receipt"
+          "receipt",
+          "origin_key",
+          "lineage_version",
+          "reservation_id"
         ],
         "title": "ReviewVerificationOut",
         "type": "object"
@@ -10924,6 +10997,74 @@
         "summary": "Append Cluster Message Reply",
         "tags": [
           "internal-cluster-message-replies"
+        ]
+      }
+    },
+    "/v1/internal/github/reviews/{event_id}/reserve": {
+      "post": {
+        "operationId": "reserve_review_v1_internal_github_reviews__event_id__reserve_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "event_id",
+            "required": true,
+            "schema": {
+              "title": "Event Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Curie-Worker-Token",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Curie-Worker-Token"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReviewReservationRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReviewReservationOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Reserve Review",
+        "tags": [
+          "internal-github-reviews"
         ]
       }
     },

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -3984,6 +3984,101 @@
         "title": "PublicationOut",
         "type": "object"
       },
+      "QueuedTurn": {
+        "description": "A normalized inbound turn ready for the worker to route and run.\n\nThe channel-neutral promotion of the dispatcher's former ``QueuedSlackEvent``.\nThe Valkey Stream carries this model as a single ``payload`` JSON field; the\nstream-encoding helpers live with the producer (the dispatcher), not on this\nfrozen model, so the contract stays transport-agnostic.\n\n``source`` defaults to ``SLACK`` so a pre-upgrade producer that does not set\nit still decodes, which is what makes this addition a PATCH under this\npackage's change-class table rather than a breaking minor. The default is a\ncompatibility affordance and not a licence to omit it: every first-party mint\nsite sets it explicitly, exactly as ``ReplyHandle.adapter`` does. Defaulting\nto the non-job value is also the safe direction -- an unset ``source`` reads\nas a person's message, so a job can never be created by omission.",
+        "properties": {
+          "author": {
+            "title": "Author",
+            "type": "string"
+          },
+          "conversation_id": {
+            "title": "Conversation Id",
+            "type": "string"
+          },
+          "event_id": {
+            "title": "Event Id",
+            "type": "string"
+          },
+          "received_at": {
+            "title": "Received At",
+            "type": "string"
+          },
+          "reply_handle": {
+            "$ref": "#/components/schemas/ReplyHandle"
+          },
+          "source": {
+            "$ref": "#/components/schemas/TurnSource",
+            "default": "slack"
+          },
+          "text": {
+            "title": "Text",
+            "type": "string"
+          }
+        },
+        "required": [
+          "event_id",
+          "conversation_id",
+          "author",
+          "text",
+          "reply_handle",
+          "received_at"
+        ],
+        "title": "QueuedTurn",
+        "type": "object"
+      },
+      "ReplyHandle": {
+        "description": "Channel-neutral coordinates for where a turn's reply is delivered.\n\n``kind`` and ``channel`` are the **routing pair** (ADR-0096): the channel kind\n(``slack``, ``email``, ...) plus the address within that kind. Both halves are\nneeded to resolve the binding, because one address can legitimately exist under\ntwo kinds. ``kind`` is REQUIRED and deliberately has no default: an optional\nkind forces the resolver to invent one, and every honest answer there is an\naddress-only fallback or a ``\"slack\"`` guess -- the silent misroute this field\nexists to close.\n\nThe reply model supports editing an existing reply or carrying no existing\nreply reference. ``placeholder`` is a required, nullable, opaque correlation\nhandle minted by the adapter. The worker never parses it and only ever hands\nit back to the adapter that minted it. For the Slack adapter it happens to be\nthe ts of the preposted placeholder message. For another kind it is whatever\nthat adapter needs to find the same message again. ``None`` means this turn\nhas no existing reply to edit.\n\n``endpoint`` is the per-turn reply target: the base URL of the channel API the\nworker delivers this turn's reply through. It routes the reply back to the\ningress that enqueued the turn instead of a worker-global setting, so two\ningress paths (a real Slack workspace and a no-Slack CLI stub) can coexist on\none worker (issue #19). ``None`` means \"use the worker's configured default\"\n(its ``slack_api_base_url``, i.e. real Slack), so a producer that does not set\nit keeps the pre-#19 behavior.\n\n``adapter`` names the egress adapter identity whose credential authenticates\nthe reply, so a sink call made *before* binding resolution can still select the\nright credential. For non-Slack kinds ``endpoint`` and ``adapter`` are both\n**platform-set from the binding row** (never accepted from an ingress request\nbody); ``slack`` legitimately carries neither, because its route is the\nworker's configured Slack origin. ``adapter`` is optional at the schema so a\nthird-party or pre-upgrade producer is not rejected outright, but every\nfirst-party mint site sets it explicitly.",
+        "properties": {
+          "adapter": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Adapter"
+          },
+          "channel": {
+            "title": "Channel",
+            "type": "string"
+          },
+          "endpoint": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Endpoint"
+          },
+          "kind": {
+            "title": "Kind",
+            "type": "string"
+          },
+          "placeholder": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Placeholder"
+          }
+        },
+        "required": [
+          "kind",
+          "channel",
+          "placeholder"
+        ],
+        "title": "ReplyHandle",
+        "type": "object"
+      },
       "RepositoryCredentialOut": {
         "description": "One server-derived Git credential returned only to the trusted worker.",
         "properties": {
@@ -4230,6 +4325,54 @@
           "origin_key"
         ],
         "title": "ReviewRevisionReserve",
+        "type": "object"
+      },
+      "ReviewVerificationOut": {
+        "properties": {
+          "agent_id": {
+            "format": "uuid",
+            "title": "Agent Id",
+            "type": "string"
+          },
+          "head_sha": {
+            "title": "Head Sha",
+            "type": "string"
+          },
+          "receipt": {
+            "title": "Receipt",
+            "type": "string"
+          },
+          "sender": {
+            "title": "Sender",
+            "type": "string"
+          }
+        },
+        "required": [
+          "head_sha",
+          "agent_id",
+          "sender",
+          "receipt"
+        ],
+        "title": "ReviewVerificationOut",
+        "type": "object"
+      },
+      "ReviewVerificationRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "deployment_id": {
+            "format": "uuid",
+            "title": "Deployment Id",
+            "type": "string"
+          },
+          "turn": {
+            "$ref": "#/components/schemas/QueuedTurn"
+          }
+        },
+        "required": [
+          "turn",
+          "deployment_id"
+        ],
+        "title": "ReviewVerificationRequest",
         "type": "object"
       },
       "RoutingCheck": {
@@ -4632,6 +4775,16 @@
         ],
         "title": "TurnAccepted",
         "type": "object"
+      },
+      "TurnSource": {
+        "description": "What started this turn: a person speaking, or the system doing a job.\n\nADR-0079's new event kind. The values are the three the ADR names, and the\ndistinction the kernel actually acts on is binary: ``SLACK`` is a person's\nmessage and may steer a live turn; ``WEBHOOK`` and ``CRON`` are jobs, and a\njob is an OUTPUT, never a steering input. ``is_job`` is that predicate, kept\nhere rather than re-derived at each call site so a fourth value cannot be\nadded without deciding which side of the line it falls on.\n\n**This is a different axis from ``ReplyHandle.kind`` and the two do not\ncollapse.** ``kind`` answers *where the reply goes* (slack, email); ``source``\nanswers *what caused the turn*. A nightly digest posted into a Slack channel\nis ``kind=\"slack\"`` with ``source=CRON``: same transport as a mention, and it\nmust not steer whatever conversation is live in that thread. Reading either\nfield off the other is the silent misroute both exist to close.\n\n``SLACK`` is the ADR's spelling for \"a person's chat message\", which was the\nonly such ingress when ADR-0079 was accepted. A channel port turn from a\nhuman on another transport (an email that a person actually sent) is that\nsame category on a different ``kind``, and giving it its own value is a NEW\nENUM VALUE -- breaking under this package's rules, so it is a deliberate,\nseparately-decided bump rather than something this change assumes.",
+        "enum": [
+          "slack",
+          "webhook",
+          "cron"
+        ],
+        "title": "TurnSource",
+        "type": "string"
       },
       "ValidationError": {
         "properties": {
@@ -9771,6 +9924,16 @@
           },
           {
             "in": "header",
+            "name": "x-github-delivery",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "X-Github-Delivery",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
             "name": "x-hub-signature-256",
             "required": false,
             "schema": {
@@ -10761,6 +10924,74 @@
         "summary": "Append Cluster Message Reply",
         "tags": [
           "internal-cluster-message-replies"
+        ]
+      }
+    },
+    "/v1/internal/github/reviews/{event_id}/verify": {
+      "post": {
+        "operationId": "verify_review_v1_internal_github_reviews__event_id__verify_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "event_id",
+            "required": true,
+            "schema": {
+              "title": "Event Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Curie-Worker-Token",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Curie-Worker-Token"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReviewVerificationRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReviewVerificationOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Verify Review",
+        "tags": [
+          "internal-github-reviews"
         ]
       }
     },

--- a/apps/api/src/curie_api/config.py
+++ b/apps/api/src/curie_api/config.py
@@ -126,6 +126,7 @@ class Settings(BaseSettings):
     # Git flow (J1). The webhook secret authenticates inbound GitHub events; the
     # two bot identities are the routing targets recorded on each deployment.
     github_webhook_secret: str = "dev-webhook-secret"
+    github_review_ingress_enabled: bool = False
     dev_branch: str = "dev"
     prod_branch: str = "main"
     # Outbound GitHub credential. Used for the eval PR check's commit-status
@@ -150,6 +151,9 @@ class Settings(BaseSettings):
     # never place it in argv.
     github_app_private_key: str = ""
     github_app_timeout_seconds: float = 15.0
+    # Durable human-review outbox. Zero disables only the periodic backstop;
+    # authenticated ingress still attempts an immediate enqueue.
+    github_review_reconciler_interval_s: float = Field(default=5.0, ge=0)
     # Repositories the runtime workspace selector may bind to a thread. Exact
     # owner/repository entries and owner-wide owner/* entries are supported.
     # Empty is fail-closed: enabling workspace capability alone grants no
@@ -400,6 +404,18 @@ class Settings(BaseSettings):
         if self.valkey_url:
             return self.valkey_url
         return f"redis://:{self.valkey_password}@{self.valkey_host}:{self.valkey_port}/0"
+
+    @model_validator(mode="after")
+    def _validate_review_ingress(self) -> "Settings":
+        if self.github_review_ingress_enabled and (
+            not self.github_app_id.strip()
+            or not self.github_app_private_key.strip()
+            or self.github_webhook_secret.strip() in ("", _DEV_DEFAULT_WEBHOOK_SECRET)
+        ):
+            raise ValueError(
+                "GitHub review ingress requires a configured App and non-default webhook secret"
+            )
+        return self
 
     @model_validator(mode="after")
     def _validate_github_repo_allowlist(self) -> "Settings":

--- a/apps/api/src/curie_api/config.py
+++ b/apps/api/src/curie_api/config.py
@@ -199,6 +199,10 @@ class Settings(BaseSettings):
     valkey_port: int = 26379
     valkey_url: str | None = None
 
+    # Read-only observer of worker terminal markers. WorkerConfig consumes the
+    # unprefixed KEY_PREFIX variable; CURIE_KEY_PREFIX is not its configuration.
+    worker_key_prefix: str = Field(default="curie:worker", validation_alias="KEY_PREFIX")
+
     # The runs stream approval resolutions enqueue resume turns onto (#244).
     # Must match the worker's CURIE_STREAM (its consumer side) -- which is why
     # the default is the shared declaration both lanes import (#492) rather than

--- a/apps/api/src/curie_api/github_review_audit.py
+++ b/apps/api/src/curie_api/github_review_audit.py
@@ -1,0 +1,108 @@
+"""Durable authenticated delivery receipts without webhook bodies or credentials."""
+
+import hashlib
+import re
+import uuid
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .models import GitHubReviewDelivery
+
+
+def _object(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _id(value: Any, maximum: int = 2**63 - 1) -> int | None:
+    return (
+        value
+        if isinstance(value, int) and not isinstance(value, bool) and 0 < value <= maximum
+        else None
+    )
+
+
+def _enum(value: Any, choices: set[str]) -> str:
+    return value if isinstance(value, str) and value in choices else "other"
+
+
+async def claim_review_delivery(
+    session: AsyncSession,
+    *,
+    delivery_id: uuid.UUID,
+    event: str,
+    body: bytes,
+    payload: Any,
+) -> tuple[GitHubReviewDelivery, bool]:
+    """Serialize a delivery header and bind every alias to its original bytes.
+
+    HMAC verification belongs to the caller and must precede this function.
+    The body is hashed in memory and never persisted. Holding this row lock
+    until admission commits makes same-header races adopt one canonical result.
+    """
+    data = _object(payload)
+    source = _object(data.get("review") if event == "pull_request_review" else data.get("comment"))
+    pr = _object(data.get("issue") if event == "issue_comment" else data.get("pull_request"))
+    sender = _object(data.get("sender"))
+    digest = hashlib.sha256(body).hexdigest()
+    login = sender.get("login")
+    if not isinstance(login, str) or re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9-]{0,38}", login) is None:
+        login = None
+    await session.execute(
+        insert(GitHubReviewDelivery)
+        .values(
+            delivery_id=delivery_id,
+            event_kind=event,
+            body_sha256=digest,
+            action=_enum(
+                data.get("action"), {"created", "edited", "deleted", "submitted", "dismissed"}
+            ),
+            repository_id=_id(_object(data.get("repository")).get("id")),
+            installation_id=_id(_object(data.get("installation")).get("id")),
+            pr_number=_id(pr.get("number"), 2**31 - 1),
+            source_object_id=_id(source.get("id")),
+            sender_id=_id(sender.get("id")),
+            sender_login=login,
+            sender_type=_enum(sender.get("type"), {"User", "Bot", "Organization"}),
+            author_association=_enum(
+                source.get("author_association"),
+                {
+                    "OWNER",
+                    "MEMBER",
+                    "COLLABORATOR",
+                    "CONTRIBUTOR",
+                    "FIRST_TIMER",
+                    "FIRST_TIME_CONTRIBUTOR",
+                    "NONE",
+                    "MANNEQUIN",
+                },
+            ),
+        )
+        .on_conflict_do_nothing(index_elements=["delivery_id"])
+    )
+    row = await session.scalar(
+        select(GitHubReviewDelivery)
+        .where(GitHubReviewDelivery.delivery_id == delivery_id)
+        .with_for_update()
+    )
+    assert row is not None
+    conflict = row.event_kind != event or row.body_sha256 != digest
+    if conflict:
+        row.replay_conflicts += 1
+        row.version += 1
+    return row, conflict
+
+
+def settle_review_delivery(
+    row: GitHubReviewDelivery,
+    status: str,
+    reason: str | None = None,
+    *,
+    event_id: str | None = None,
+) -> None:
+    row.status = status
+    row.reason = reason
+    row.event_id = event_id
+    row.version += 1

--- a/apps/api/src/curie_api/github_review_events.py
+++ b/apps/api/src/curie_api/github_review_events.py
@@ -1,0 +1,229 @@
+"""Normalize untrusted review events without granting authority to their contents.
+
+Only the authenticated ingress may call the later GitHub/lineage verifier. A
+parsed event is not proof that its installation, author or PR is authorized.
+URLs are reconstructed from validated identity, never used as fetch targets.
+"""
+
+import re
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from .repo_full_name import InvalidRepoFullName, normalize_repo_full_name
+
+_REVIEW_EVENTS = {
+    "issue_comment": ("created", "comment", "issuecomment"),
+    "pull_request_review_comment": ("created", "comment", "discussion_r"),
+    "pull_request_review": ("submitted", "review", "pullrequestreview"),
+}
+_SHA = re.compile(r"[0-9a-fA-F]{40}")
+_LOGIN = re.compile(r"[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*")
+_MAX_FEEDBACK_LENGTH = 65536
+
+
+class FeedbackIgnored(ValueError):
+    """An observable refusal code that never includes webhook/model contents."""
+
+    def __init__(self, code: str) -> None:
+        self.code = code
+        super().__init__(code)
+
+
+class FeedbackUnavailable(FeedbackIgnored):
+    """Current authority could not be read; retry without executing a turn."""
+
+
+@dataclass(frozen=True)
+class UnverifiedFeedback:
+    """Parsed sender claims; current GitHub truth and lineage still must agree."""
+
+    delivery_id: uuid.UUID
+    event: str
+    installation_id: int
+    repository_id: int
+    repo_full_name: str
+    pr_number: int
+    feedback_id: int
+    sender_id: int
+    sender_login: str
+    body: str
+    url: str
+    created_at: datetime
+    head_sha: str | None
+    commit_sha: str | None
+    author_association: str
+    path: str | None = None
+    line: int | None = None
+    review_id: int | None = None
+
+    @property
+    def event_id(self) -> str:
+        # GitHub's delivery header is not covered by its body HMAC. A new
+        # delivery ID for the same comment/review cannot create a second turn.
+        # Installation identity is authorization provenance, not comment
+        # identity: reinstalling the same App must not replay an old comment.
+        identity = f"{self.repository_id}:{self.event}:{self.feedback_id}"
+        return f"github-feedback-{uuid.uuid5(uuid.NAMESPACE_URL, identity)}"
+
+
+def _object(value: Any, code: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise FeedbackIgnored(code)
+    return value
+
+
+def _positive(value: Any, code: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        raise FeedbackIgnored(code)
+    return value
+
+
+def _instant(value: Any, code: str) -> datetime:
+    if not isinstance(value, str):
+        raise FeedbackIgnored(code)
+    try:
+        result = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        raise FeedbackIgnored(code) from None
+    if result.tzinfo is None:
+        raise FeedbackIgnored(code)
+    return result.astimezone(UTC)
+
+
+def _human(value: Any) -> tuple[int, str]:
+    user = _object(value, "non_human_sender")
+    login = user.get("login")
+    if (
+        user.get("type") != "User"
+        or not isinstance(login, str)
+        or not 1 <= len(login) <= 39
+        or _LOGIN.fullmatch(login) is None
+        or login.casefold() == "ghost"
+    ):
+        raise FeedbackIgnored("non_human_sender")
+    return _positive(user.get("id"), "non_human_sender"), login
+
+
+def parse_feedback(event: str, payload: Any, delivery_id: str) -> UnverifiedFeedback:
+    """Retain actionable human feedback claims or return an explicit refusal.
+
+    Actions/fields follow the provider's webhook-event documentation:
+    https://docs.github.com/en/webhooks/webhook-events-and-payloads
+    ``issue_comment`` also covers ordinary issues, which cannot own a PR lineage.
+    """
+
+    definition = _REVIEW_EVENTS.get(event)
+    if definition is None:
+        raise FeedbackIgnored("unsupported_event")
+    data = _object(payload, "invalid_payload")
+    action, feedback_key, fragment_kind = definition
+    if data.get("action") != action:
+        raise FeedbackIgnored("unsupported_action")
+    try:
+        delivery = uuid.UUID(delivery_id)
+    except (ValueError, TypeError, AttributeError):
+        raise FeedbackIgnored("invalid_delivery") from None
+    if str(delivery) != delivery_id.lower():
+        raise FeedbackIgnored("invalid_delivery")
+    installation = _object(data.get("installation"), "invalid_installation")
+    installation_id = _positive(installation.get("id"), "invalid_installation")
+    repository = _object(data.get("repository"), "invalid_repository")
+    repository_id = _positive(repository.get("id"), "invalid_repository")
+    repository_name = repository.get("full_name")
+    if not isinstance(repository_name, str):
+        raise FeedbackIgnored("invalid_repository")
+    try:
+        repo = normalize_repo_full_name(repository_name)
+    except InvalidRepoFullName:
+        raise FeedbackIgnored("invalid_repository") from None
+    sender_id, sender_login = _human(data.get("sender"))
+    feedback = _object(data.get(feedback_key), "invalid_feedback")
+    author_id, author_login = _human(feedback.get("user"))
+    if author_id != sender_id or author_login.casefold() != sender_login.casefold():
+        raise FeedbackIgnored("sender_mismatch")
+    if feedback.get("performed_via_github_app") is not None:
+        raise FeedbackIgnored("app_authored")
+    association = feedback.get("author_association")
+    if not isinstance(association, str) or association not in {"OWNER", "MEMBER", "COLLABORATOR"}:
+        raise FeedbackIgnored("unauthorized_association")
+    feedback_id = _positive(feedback.get("id"), "invalid_feedback")
+    body = feedback.get("body")
+    if not isinstance(body, str) or not body.strip():
+        raise FeedbackIgnored("empty_feedback")
+    if len(body) > _MAX_FEEDBACK_LENGTH:
+        raise FeedbackIgnored("feedback_too_large")
+
+    head_sha = None
+    commit_sha = None
+    path = None
+    line = None
+    review_id = None
+    if event == "issue_comment":
+        pr = _object(data.get("issue"), "not_pull_request")
+        _object(pr.get("pull_request"), "not_pull_request")
+    else:
+        pr = _object(data.get("pull_request"), "not_pull_request")
+        head = _object(pr.get("head"), "invalid_head")
+        head_sha = head.get("sha")
+        commit_sha = feedback.get("commit_id")
+        if (
+            not isinstance(head_sha, str)
+            or _SHA.fullmatch(head_sha) is None
+            or not isinstance(commit_sha, str)
+            or _SHA.fullmatch(commit_sha) is None
+        ):
+            raise FeedbackIgnored("invalid_head")
+        head_sha, commit_sha = head_sha.lower(), commit_sha.lower()
+        if commit_sha != head_sha:
+            raise FeedbackIgnored("stale_feedback_head")
+    pr_number = _positive(pr.get("number"), "not_pull_request")
+    if pr.get("state") != "open" or pr.get("merged") is True:
+        raise FeedbackIgnored("terminal_pull_request")
+    if event == "pull_request_review":
+        review_state = feedback.get("state")
+        if not isinstance(review_state, str) or review_state.lower() not in {
+            "commented",
+            "changes_requested",
+        }:
+            raise FeedbackIgnored("non_actionable_review")
+        created = _instant(feedback.get("submitted_at"), "invalid_feedback_time")
+    else:
+        created = _instant(feedback.get("created_at"), "invalid_feedback_time")
+        updated = _instant(feedback.get("updated_at"), "invalid_feedback_time")
+        if updated != created:
+            raise FeedbackIgnored("edited_feedback")
+    if event == "pull_request_review_comment":
+        path = feedback.get("path")
+        if not isinstance(path, str) or not path or len(path) > 4096:
+            raise FeedbackIgnored("invalid_review_context")
+        raw_line = feedback.get("line")
+        if raw_line is not None:
+            line = _positive(raw_line, "invalid_review_context")
+        review_id = _positive(feedback.get("pull_request_review_id"), "invalid_review_context")
+    separator = "" if fragment_kind == "discussion_r" else "-"
+    url = f"https://github.com/{repo}/pull/{pr_number}#{fragment_kind}{separator}{feedback_id}"
+    claimed_url = feedback.get("html_url")
+    if not isinstance(claimed_url, str) or claimed_url.casefold() != url.casefold():
+        raise FeedbackIgnored("invalid_feedback_url")
+    return UnverifiedFeedback(
+        delivery,
+        event,
+        installation_id,
+        repository_id,
+        repo,
+        pr_number,
+        feedback_id,
+        sender_id,
+        sender_login,
+        body,
+        url,
+        created,
+        head_sha,
+        commit_sha,
+        association,
+        path,
+        line,
+        review_id,
+    )

--- a/apps/api/src/curie_api/github_review_events.py
+++ b/apps/api/src/curie_api/github_review_events.py
@@ -146,7 +146,11 @@ def parse_feedback(event: str, payload: Any, delivery_id: str) -> UnverifiedFeed
     if feedback.get("performed_via_github_app") is not None:
         raise FeedbackIgnored("app_authored")
     association = feedback.get("author_association")
-    if not isinstance(association, str) or association not in {"OWNER", "MEMBER", "COLLABORATOR"}:
+    # CONTRIBUTOR is only a claim here. The shared truth verifier additionally
+    # requires current App-proven write/admin permission before admitting it.
+    if not isinstance(association, str) or association not in {
+        "OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"
+    }:
         raise FeedbackIgnored("unauthorized_association")
     feedback_id = _positive(feedback.get("id"), "invalid_feedback")
     body = feedback.get("body")

--- a/apps/api/src/curie_api/github_review_events.py
+++ b/apps/api/src/curie_api/github_review_events.py
@@ -74,8 +74,8 @@ def _object(value: Any, code: str) -> dict[str, Any]:
     return value
 
 
-def _positive(value: Any, code: str) -> int:
-    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+def _positive(value: Any, code: str, maximum: int = 2**63 - 1) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or not 0 < value <= maximum:
         raise FeedbackIgnored(code)
     return value
 
@@ -178,7 +178,7 @@ def parse_feedback(event: str, payload: Any, delivery_id: str) -> UnverifiedFeed
         head_sha, commit_sha = head_sha.lower(), commit_sha.lower()
         if commit_sha != head_sha:
             raise FeedbackIgnored("stale_feedback_head")
-    pr_number = _positive(pr.get("number"), "not_pull_request")
+    pr_number = _positive(pr.get("number"), "not_pull_request", 2**31 - 1)
     if pr.get("state") != "open" or pr.get("merged") is True:
         raise FeedbackIgnored("terminal_pull_request")
     if event == "pull_request_review":

--- a/apps/api/src/curie_api/github_review_store.py
+++ b/apps/api/src/curie_api/github_review_store.py
@@ -276,7 +276,10 @@ class GitHubReviewReconciler:
                             <= datetime.now(UTC).replace(tzinfo=None),
                         ),
                     )
-                    .with_for_update(skip_locked=True)
+                    # NO KEY UPDATE still excludes competing mutators while
+                    # allowing concurrent delivery-audit FK references. FOR
+                    # UPDATE would skip an eligible row held only by KEY SHARE.
+                    .with_for_update(skip_locked=True, key_share=True)
                 )
                 if row is None:
                     continue

--- a/apps/api/src/curie_api/github_review_store.py
+++ b/apps/api/src/curie_api/github_review_store.py
@@ -13,23 +13,26 @@ import redis.asyncio as redis
 from aci_protocol import STREAM_PAYLOAD_FIELD, QueuedTurn, ReplyHandle, TurnSource
 from channel_protocol import scoped_conversation_id
 from curie_telemetry import TRACEPARENT_STREAM_FIELD, canonicalize_traceparent
-from sqlalchemy import func, or_, select
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy import or_, select
+from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
+from . import crud
 from .config import Settings
 from .delivery import enqueue_owned, take_backlog_slot
-from .github_review_events import FeedbackIgnored, UnverifiedFeedback
+from .github_review_events import FeedbackIgnored, FeedbackUnavailable, UnverifiedFeedback
+from .github_review_terminal import read_review_dead_letter, worker_event_is_terminal
 from .github_review_truth import BoundReviewLineage, verify_feedback_truth
 from .models import (
     AgentChannel,
-    Approval,
     Deployment,
     GitHubReviewFeedback,
     Publication,
+    PublicationReviewReservation,
     ThreadPublicationLineage,
     ThreadWorkspace,
 )
+from .schemas import ReviewRevisionReserve
 from .workspace_policy import repository_is_allowed
 
 logger = logging.getLogger(__name__)
@@ -45,11 +48,18 @@ class ReviewContext:
     @property
     def truth(self) -> BoundReviewLineage:
         assert self.lineage.pr_number is not None and self.lineage.head_sha is not None
+        assert self.lineage.github_repository_id is not None
+        assert self.lineage.github_installation_id is not None
+        assert self.lineage.github_pr_node_id is not None and self.lineage.base_ref is not None
         return BoundReviewLineage(
             self.lineage.repo_full_name,
             self.lineage.pr_number,
             self.lineage.branch,
             self.lineage.head_sha,
+            self.lineage.github_repository_id,
+            self.lineage.github_installation_id,
+            self.lineage.github_pr_node_id,
+            self.lineage.base_ref,
         )
 
 
@@ -63,8 +73,7 @@ async def review_context(
         await session.scalars(
             select(ThreadPublicationLineage)
             .where(
-                func.lower(ThreadPublicationLineage.repo_full_name)
-                == feedback.repo_full_name.lower(),
+                ThreadPublicationLineage.github_repository_id == feedback.repository_id,
                 ThreadPublicationLineage.pr_number == feedback.pr_number,
                 ThreadPublicationLineage.status == "open",
             )
@@ -74,8 +83,17 @@ async def review_context(
     if len(candidates) != 1:
         raise FeedbackIgnored("lineage_absent_or_ambiguous")
     lineage = candidates[0]
-    if lineage.head_sha is None:
-        raise FeedbackIgnored("lineage_head_unproved")
+    if (
+        lineage.head_sha is None
+        or lineage.github_installation_id != feedback.installation_id
+        or lineage.github_pr_node_id is None
+        or lineage.base_ref is None
+        or lineage.binding_id is None
+        or lineage.binding_generation is None
+        or lineage.reply_conversation_id is None
+        or lineage.repo_full_name.casefold() != feedback.repo_full_name.casefold()
+    ):
+        raise FeedbackIgnored("lineage_authority_unproved")
     workspace = await session.scalar(
         select(ThreadWorkspace).where(
             ThreadWorkspace.agent_id == lineage.agent_id,
@@ -88,43 +106,19 @@ async def review_context(
         or not repository_is_allowed(lineage.repo_full_name, settings.github_repo_allowlist)
     ):
         raise FeedbackIgnored("workspace_no_longer_authorized")
-    # The scoped workspace identity cannot be decoded into a Slack thread_ts.
-    # The last successful publication retains the actual original routing pair.
-    publication = await session.scalar(
-        select(Publication)
-        .where(
-            Publication.lineage_id == lineage.id,
-            Publication.status == "succeeded",
-        )
-        .order_by(Publication.revision_number.desc())
-        .limit(1)
-    )
-    if publication is None:
-        raise FeedbackIgnored("publication_route_absent")
-    approval = await session.get(Approval, publication.approval_id)
+    # The producer captured this exact binding and bare reply route. A current
+    # channel with the same name is not historical authority after a rebind.
+    binding = await session.get(AgentChannel, lineage.binding_id)
     if (
-        approval is None
+        binding is None
+        or binding.agent_id != lineage.agent_id
+        or binding.generation != lineage.binding_generation
         or scoped_conversation_id(
-            publication.reply_kind,
-            publication.reply_channel,
-            approval.conversation_id,
-        )
-        != lineage.conversation_id
-    ):
-        raise FeedbackIgnored("publication_route_mismatch")
-    binding = await session.scalar(
-        select(AgentChannel).where(
-            AgentChannel.agent_id == lineage.agent_id,
-            AgentChannel.kind == publication.reply_kind,
-            AgentChannel.address == publication.reply_channel,
-        )
-    )
-    if binding is None or (
-        binding.endpoint != publication.reply_endpoint
-        or binding.adapter != publication.reply_adapter
+            binding.kind, binding.address, lineage.reply_conversation_id
+        ) != lineage.conversation_id
     ):
         raise FeedbackIgnored("binding_no_longer_authorized")
-    return ReviewContext(lineage, binding, approval.conversation_id)
+    return ReviewContext(lineage, binding, lineage.reply_conversation_id)
 
 
 def feedback_from_row(row: GitHubReviewFeedback) -> UnverifiedFeedback:
@@ -192,28 +186,30 @@ async def admit_feedback(
     context = await review_context(session, feedback, settings)
     await verify_feedback_truth(feedback, context.truth, settings=settings, client=client)
     turn = review_turn(feedback, context)
-    row = GitHubReviewFeedback(
-        event_id=feedback.event_id,
-        delivery_id=feedback.delivery_id,
-        lineage_id=context.lineage.id,
-        lineage_version=context.lineage.version,
-        binding_id=context.binding.id,
-        binding_generation=context.binding.generation,
-        agent_id=context.lineage.agent_id,
-        feedback=json.loads(json.dumps(asdict(feedback), default=str)),
-        turn=turn.model_dump(mode="json"),
-        traceparent=canonicalize_traceparent(traceparent),
+    inserted = await session.execute(
+        insert(GitHubReviewFeedback)
+        .values(
+            event_id=feedback.event_id,
+            delivery_id=feedback.delivery_id,
+            lineage_id=context.lineage.id,
+            lineage_version=context.lineage.version,
+            binding_id=context.binding.id,
+            binding_generation=context.binding.generation,
+            agent_id=context.lineage.agent_id,
+            feedback=json.loads(json.dumps(asdict(feedback), default=str)),
+            turn=turn.model_dump(mode="json"),
+            traceparent=canonicalize_traceparent(traceparent),
+        )
+        .on_conflict_do_nothing()
+        .returning(GitHubReviewFeedback.event_id)
     )
-    session.add(row)
-    try:
-        await session.commit()
-    except IntegrityError:
-        await session.rollback()
-        duplicate = await session.get(GitHubReviewFeedback, feedback.event_id)
-        if duplicate is None:
-            raise FeedbackIgnored("delivery_identity_conflict") from None
-        return duplicate, False
-    return row, True
+    created = inserted.scalar_one_or_none() is not None
+    row = await session.get(GitHubReviewFeedback, feedback.event_id)
+    if row is None:
+        raise FeedbackIgnored("delivery_identity_conflict")
+    # Caller commits its delivery receipt and this outbox together. All distinct
+    # comments remain durable; the later per-lineage reservation serializes work.
+    return row, created
 
 
 async def validate_stored_context(
@@ -248,6 +244,7 @@ class GitHubReviewReconciler:
         self._settings = settings
 
     async def reconcile_once(self, event_id: str | None = None) -> int:
+        await self.reconcile_terminal(event_id)
         async with self._sessionmaker() as session:
             statement = (
                 select(GitHubReviewFeedback.event_id)
@@ -336,6 +333,76 @@ class GitHubReviewReconciler:
                 row.version += 1
         return enqueued
 
+    async def reconcile_terminal(self, event_id: str | None = None) -> int:
+        """Release only an exact event's reservation after worker settlement.
+
+        A disappeared/trimmed stream entry or expired lease is never terminal.
+        The marker is produced by the existing fenced worker path; this lane
+        only mirrors its outcome into SQL and preserves the origin tombstone.
+        """
+        async with self._sessionmaker() as session:
+            statement = select(GitHubReviewFeedback.event_id).where(
+                GitHubReviewFeedback.status.in_(("queued", "reserved"))
+            ).order_by(GitHubReviewFeedback.created_at).limit(100)
+            if event_id is not None:
+                statement = statement.where(GitHubReviewFeedback.event_id == event_id)
+            candidates = list(await session.scalars(statement))
+        settled = 0
+        for candidate in candidates:
+            terminal = await worker_event_is_terminal(self._valkey, self._settings, candidate)
+            async with self._sessionmaker() as session, session.begin():
+                row = await session.scalar(
+                    select(GitHubReviewFeedback).where(
+                        GitHubReviewFeedback.event_id == candidate,
+                        GitHubReviewFeedback.status.in_(("queued", "reserved")),
+                    ).with_for_update(skip_locked=True)
+                )
+                if row is None:
+                    continue
+                dead_lettered = False
+                if not terminal and row.stream_id is not None:
+                    dead_lettered, cursor = await read_review_dead_letter(
+                        self._valkey, self._settings, stream_id=row.stream_id,
+                        turn=row.turn, cursor=row.terminal_scan_cursor,
+                    )
+                    if cursor != row.terminal_scan_cursor:
+                        row.terminal_scan_cursor = cursor
+                        row.version += 1
+                if not terminal and not dead_lettered:
+                    continue
+                consumed = False
+                if row.reservation_id is not None:
+                    reservation = await session.get(
+                        PublicationReviewReservation, row.reservation_id, with_for_update=True
+                    )
+                    if reservation is None or reservation.origin_key != row.event_id:
+                        row.error_code = "feedback_reservation_identity_lost"
+                        row.version += 1
+                        continue
+                    if reservation.status == "reserved":
+                        if await session.get(Publication, reservation.id) is not None:
+                            row.error_code = "feedback_reservation_publication_conflict"
+                            row.version += 1
+                            continue
+                        await crud.cancel_review_revision(
+                            session, reservation.id, origin_key=row.event_id,
+                            expected_version=reservation.version,
+                        )
+                    consumed = reservation.status == "consumed"
+                    # A consumed reservation is owned by the sole publication
+                    # writer and must never be cancelled by this observer.
+                if dead_lettered:
+                    row.status, row.error_code = "dead_lettered", "delivery_dead_lettered"
+                else:
+                    row.status = "settled" if consumed or not row.error_code else "refused"
+                    if consumed:
+                        # A late verifier may refuse re-execution after the sole
+                        # writer consumed this origin. That is not failed work.
+                        row.error_code = None
+                row.version += 1
+                settled += 1
+        return settled
+
     async def run_forever(self) -> None:
         while True:
             try:
@@ -354,21 +421,119 @@ async def verify_queued_feedback(
     *,
     settings: Settings,
     client: httpx.AsyncClient,
-) -> dict[str, str]:
+) -> dict[str, Any]:
     """Recheck canonical input and current authority immediately before model use."""
     row = await session.get(GitHubReviewFeedback, turn.event_id)
-    if row is None or row.status not in {"waiting", "queued"}:
+    if row is None or row.status not in {"waiting", "queued", "reserved"}:
         raise FeedbackIgnored("feedback_not_executable")
     if turn.model_dump(mode="json") != row.turn:
         raise FeedbackIgnored("feedback_turn_mismatch")
+    if row.status == "waiting":
+        # XADD may be durable while its SQL queued mark is still retrying.
+        # This turn must retain retry semantics until the outbox is repaired.
+        raise FeedbackUnavailable("feedback_outbox_pending")
     feedback, context = await validate_stored_context(session, row, settings)
     deployment = await session.get(Deployment, deployment_id)
     if deployment is None or deployment.agent_id != row.agent_id or deployment.status != "active":
         raise FeedbackIgnored("deployment_no_longer_authorized")
     head = await verify_feedback_truth(feedback, context.truth, settings=settings, client=client)
+    if row.reservation_id is not None:
+        reservation = await session.get(PublicationReviewReservation, row.reservation_id)
+        if (
+            reservation is None
+            or reservation.origin_key != row.event_id
+            or reservation.status != "reserved"
+            or reservation.lineage_version != row.lineage_version
+            or reservation.expected_head_sha != head
+        ):
+            raise FeedbackIgnored("feedback_revision_not_executable")
     return {
         "head_sha": head,
         "agent_id": str(row.agent_id),
         "sender": turn.author,
         "receipt": f"Received GitHub feedback from {feedback.sender_login}: {feedback.url}",
+        "origin_key": row.event_id,
+        "lineage_version": row.lineage_version,
+        "reservation_id": str(row.reservation_id) if row.reservation_id is not None else None,
     }
+
+
+async def reserve_queued_feedback(
+    session: AsyncSession,
+    turn: QueuedTurn,
+    deployment_id: uuid.UUID,
+    *,
+    expected_lineage_version: int,
+    expected_head_sha: str,
+    settings: Settings,
+) -> uuid.UUID:
+    """Short DB-only CAS after the worker observes an idle durable runner.
+
+    GitHub verification precedes this call outside the worker route lock. This
+    transaction binds its exact verified head/version to the still-current DB
+    authority and the sole publication writer. No network request occurs here.
+    """
+    row = await session.scalar(
+        select(GitHubReviewFeedback)
+        .where(GitHubReviewFeedback.event_id == turn.event_id)
+        .with_for_update()
+    )
+    if row is None or row.status not in {"waiting", "queued", "reserved"}:
+        raise FeedbackIgnored("feedback_not_executable")
+    if turn.model_dump(mode="json") != row.turn:
+        raise FeedbackIgnored("feedback_turn_mismatch")
+    if row.status == "waiting":
+        # XADD may be durable while its SQL queued mark is still retrying.
+        # This turn must retain retry semantics until the outbox is repaired.
+        raise FeedbackUnavailable("feedback_outbox_pending")
+    _, context = await validate_stored_context(session, row, settings)
+    deployment = await session.get(Deployment, deployment_id)
+    if deployment is None or deployment.agent_id != row.agent_id or deployment.status != "active":
+        raise FeedbackIgnored("deployment_no_longer_authorized")
+    if (
+        row.lineage_version != expected_lineage_version
+        or context.lineage.head_sha != expected_head_sha
+    ):
+        raise FeedbackIgnored("binding_or_lineage_changed")
+    try:
+        reservation, _, _ = await crud.reserve_review_revision(
+            session,
+            ReviewRevisionReserve(
+                repository_id=context.truth.repository_id,
+                pr_number=context.truth.pr_number,
+                expected_lineage_version=expected_lineage_version,
+                origin_key=row.event_id,
+            ),
+        )
+    except crud.PublicationLineageConflict:
+        raise FeedbackIgnored("feedback_revision_conflict") from None
+    if reservation.status != "reserved":
+        raise FeedbackIgnored("feedback_revision_not_executable")
+    if row.reservation_id is not None and row.reservation_id != reservation.id:
+        raise FeedbackIgnored("feedback_revision_conflict")
+    if row.status != "reserved":
+        row.reservation_id = reservation.id
+        row.status = "reserved"
+        row.version += 1
+    await session.flush()
+    return reservation.id
+
+
+async def record_feedback_refusal(
+    session: AsyncSession, turn: QueuedTurn, reason: str
+) -> None:
+    """Retain a canonical worker refusal; only terminal evidence releases it."""
+    row = await session.scalar(
+        select(GitHubReviewFeedback)
+        .where(GitHubReviewFeedback.event_id == turn.event_id)
+        .with_for_update()
+    )
+    if (
+        row is not None
+        and row.status in {"queued", "reserved"}
+        and turn.model_dump(mode="json") == row.turn
+        and row.error_code != reason
+    ):
+        row.error_code = reason
+        row.version += 1
+        await session.flush()

--- a/apps/api/src/curie_api/github_review_store.py
+++ b/apps/api/src/curie_api/github_review_store.py
@@ -1,0 +1,374 @@
+"""Bind normalized feedback to durable publication state and enqueue its outbox."""
+
+import asyncio
+import json
+import logging
+import uuid
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import httpx
+import redis.asyncio as redis
+from aci_protocol import STREAM_PAYLOAD_FIELD, QueuedTurn, ReplyHandle, TurnSource
+from channel_protocol import scoped_conversation_id
+from curie_telemetry import TRACEPARENT_STREAM_FIELD, canonicalize_traceparent
+from sqlalchemy import func, or_, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from .config import Settings
+from .delivery import enqueue_owned, take_backlog_slot
+from .github_review_events import FeedbackIgnored, UnverifiedFeedback
+from .github_review_truth import BoundReviewLineage, verify_feedback_truth
+from .models import (
+    AgentChannel,
+    Approval,
+    Deployment,
+    GitHubReviewFeedback,
+    Publication,
+    ThreadPublicationLineage,
+    ThreadWorkspace,
+)
+from .workspace_policy import repository_is_allowed
+
+logger = logging.getLogger(__name__)
+_MAX_ENQUEUE_ATTEMPTS = 8
+
+
+@dataclass(frozen=True)
+class ReviewContext:
+    lineage: ThreadPublicationLineage
+    binding: AgentChannel
+    conversation_id: str
+
+    @property
+    def truth(self) -> BoundReviewLineage:
+        assert self.lineage.pr_number is not None and self.lineage.head_sha is not None
+        return BoundReviewLineage(
+            self.lineage.repo_full_name,
+            self.lineage.pr_number,
+            self.lineage.branch,
+            self.lineage.head_sha,
+        )
+
+
+async def review_context(
+    session: AsyncSession,
+    feedback: UnverifiedFeedback,
+    settings: Settings,
+) -> ReviewContext:
+    """Resolve one original conversation; a webhook never supplies its route."""
+    candidates = list(
+        await session.scalars(
+            select(ThreadPublicationLineage)
+            .where(
+                func.lower(ThreadPublicationLineage.repo_full_name)
+                == feedback.repo_full_name.lower(),
+                ThreadPublicationLineage.pr_number == feedback.pr_number,
+                ThreadPublicationLineage.status == "open",
+            )
+            .limit(2)
+        )
+    )
+    if len(candidates) != 1:
+        raise FeedbackIgnored("lineage_absent_or_ambiguous")
+    lineage = candidates[0]
+    if lineage.head_sha is None:
+        raise FeedbackIgnored("lineage_head_unproved")
+    workspace = await session.scalar(
+        select(ThreadWorkspace).where(
+            ThreadWorkspace.agent_id == lineage.agent_id,
+            ThreadWorkspace.conversation_id == lineage.conversation_id,
+        )
+    )
+    if (
+        workspace is None
+        or workspace.repo_full_name.casefold() != lineage.repo_full_name.casefold()
+        or not repository_is_allowed(lineage.repo_full_name, settings.github_repo_allowlist)
+    ):
+        raise FeedbackIgnored("workspace_no_longer_authorized")
+    # The scoped workspace identity cannot be decoded into a Slack thread_ts.
+    # The last successful publication retains the actual original routing pair.
+    publication = await session.scalar(
+        select(Publication)
+        .where(
+            Publication.lineage_id == lineage.id,
+            Publication.status == "succeeded",
+        )
+        .order_by(Publication.revision_number.desc())
+        .limit(1)
+    )
+    if publication is None:
+        raise FeedbackIgnored("publication_route_absent")
+    approval = await session.get(Approval, publication.approval_id)
+    if (
+        approval is None
+        or scoped_conversation_id(
+            publication.reply_kind,
+            publication.reply_channel,
+            approval.conversation_id,
+        )
+        != lineage.conversation_id
+    ):
+        raise FeedbackIgnored("publication_route_mismatch")
+    binding = await session.scalar(
+        select(AgentChannel).where(
+            AgentChannel.agent_id == lineage.agent_id,
+            AgentChannel.kind == publication.reply_kind,
+            AgentChannel.address == publication.reply_channel,
+        )
+    )
+    if binding is None or (
+        binding.endpoint != publication.reply_endpoint
+        or binding.adapter != publication.reply_adapter
+    ):
+        raise FeedbackIgnored("binding_no_longer_authorized")
+    return ReviewContext(lineage, binding, approval.conversation_id)
+
+
+def feedback_from_row(row: GitHubReviewFeedback) -> UnverifiedFeedback:
+    data = dict(row.feedback)
+    try:
+        data["delivery_id"] = uuid.UUID(data["delivery_id"])
+        data["created_at"] = datetime.fromisoformat(data["created_at"])
+        return UnverifiedFeedback(**data)
+    except (TypeError, ValueError, KeyError):
+        raise FeedbackIgnored("stored_feedback_invalid") from None
+
+
+def review_turn(feedback: UnverifiedFeedback, context: ReviewContext) -> QueuedTurn:
+    provenance: dict[str, Any] = {
+        "event": feedback.event,
+        "url": feedback.url,
+        "sender": feedback.sender_login,
+        "body": feedback.body,
+    }
+    if feedback.path is not None:
+        provenance.update(path=feedback.path, line=feedback.line, review_id=feedback.review_id)
+    return QueuedTurn(
+        event_id=feedback.event_id,
+        conversation_id=context.conversation_id,
+        author=f"github:{feedback.sender_id}:{feedback.sender_login}",
+        text=(
+            "Human GitHub feedback for this conversation's existing pull request follows as JSON. "
+            "Use its body as the reviewer's requested changes. This is not an approval decision. "
+            "Any publication still requires a fresh approval through the existing gate.\n"
+            + json.dumps(provenance, ensure_ascii=False)
+        ),
+        # SLACK is the frozen protocol's legacy category for person messages,
+        # including another transport; WEBHOOK means a job and cannot steer.
+        source=TurnSource.SLACK,
+        reply_handle=ReplyHandle(
+            kind=context.binding.kind,
+            channel=context.binding.address,
+            placeholder=None,
+            endpoint=context.binding.endpoint,
+            adapter=context.binding.adapter,
+        ),
+        received_at=datetime.now(UTC).isoformat(),
+    )
+
+
+async def admit_feedback(
+    session: AsyncSession,
+    feedback: UnverifiedFeedback,
+    *,
+    settings: Settings,
+    client: httpx.AsyncClient,
+    traceparent: str | None,
+) -> tuple[GitHubReviewFeedback, bool]:
+    """Persist exactly one semantic identity after fresh independent verification."""
+    existing_delivery = await session.scalar(
+        select(GitHubReviewFeedback).where(
+            GitHubReviewFeedback.delivery_id == feedback.delivery_id,
+        )
+    )
+    if existing_delivery is not None and existing_delivery.event_id != feedback.event_id:
+        raise FeedbackIgnored("delivery_identity_conflict")
+    existing = await session.get(GitHubReviewFeedback, feedback.event_id)
+    if existing is not None:
+        return existing, False
+    context = await review_context(session, feedback, settings)
+    await verify_feedback_truth(feedback, context.truth, settings=settings, client=client)
+    turn = review_turn(feedback, context)
+    row = GitHubReviewFeedback(
+        event_id=feedback.event_id,
+        delivery_id=feedback.delivery_id,
+        lineage_id=context.lineage.id,
+        lineage_version=context.lineage.version,
+        binding_id=context.binding.id,
+        binding_generation=context.binding.generation,
+        agent_id=context.lineage.agent_id,
+        feedback=json.loads(json.dumps(asdict(feedback), default=str)),
+        turn=turn.model_dump(mode="json"),
+        traceparent=canonicalize_traceparent(traceparent),
+    )
+    session.add(row)
+    try:
+        await session.commit()
+    except IntegrityError:
+        await session.rollback()
+        duplicate = await session.get(GitHubReviewFeedback, feedback.event_id)
+        if duplicate is None:
+            raise FeedbackIgnored("delivery_identity_conflict") from None
+        return duplicate, False
+    return row, True
+
+
+async def validate_stored_context(
+    session: AsyncSession,
+    row: GitHubReviewFeedback,
+    settings: Settings,
+) -> tuple[UnverifiedFeedback, ReviewContext]:
+    feedback = feedback_from_row(row)
+    context = await review_context(session, feedback, settings)
+    if (
+        row.lineage_id != context.lineage.id
+        or row.lineage_version != context.lineage.version
+        or row.agent_id != context.lineage.agent_id
+        or row.binding_id != context.binding.id
+        or row.binding_generation != context.binding.generation
+    ):
+        raise FeedbackIgnored("binding_or_lineage_changed")
+    return feedback, context
+
+
+class GitHubReviewReconciler:
+    """SQL outbox to the existing atomic receipt + bounded runs consumer."""
+
+    def __init__(
+        self,
+        sessionmaker: async_sessionmaker[AsyncSession],
+        valkey: redis.Redis,
+        settings: Settings,
+    ) -> None:
+        self._sessionmaker = sessionmaker
+        self._valkey = valkey
+        self._settings = settings
+
+    async def reconcile_once(self, event_id: str | None = None) -> int:
+        async with self._sessionmaker() as session:
+            statement = (
+                select(GitHubReviewFeedback.event_id)
+                .where(
+                    GitHubReviewFeedback.status == "waiting",
+                    or_(
+                        GitHubReviewFeedback.next_attempt_at.is_(None),
+                        GitHubReviewFeedback.next_attempt_at
+                        <= datetime.now(UTC).replace(tzinfo=None),
+                    ),
+                )
+                .order_by(GitHubReviewFeedback.created_at)
+                .limit(100)
+            )
+            if event_id is not None:
+                statement = statement.where(GitHubReviewFeedback.event_id == event_id)
+            candidates = list(await session.scalars(statement))
+        enqueued = 0
+        for candidate in candidates:
+            async with self._sessionmaker() as session, session.begin():
+                row = await session.scalar(
+                    select(GitHubReviewFeedback)
+                    .where(
+                        GitHubReviewFeedback.event_id == candidate,
+                        GitHubReviewFeedback.status == "waiting",
+                        or_(
+                            GitHubReviewFeedback.next_attempt_at.is_(None),
+                            GitHubReviewFeedback.next_attempt_at
+                            <= datetime.now(UTC).replace(tzinfo=None),
+                        ),
+                    )
+                    .with_for_update(skip_locked=True)
+                )
+                if row is None:
+                    continue
+                try:
+                    await validate_stored_context(session, row, self._settings)
+                except FeedbackIgnored as exc:
+                    row.status, row.error_code = "refused", exc.code
+                    row.version += 1
+                    continue
+                row.enqueue_attempts += 1
+                try:
+                    async with asyncio.timeout(10):
+                        if not row.quota_taken:
+                            if not await take_backlog_slot(
+                                self._valkey,
+                                key_prefix=f"curie:github-review:backlog:{row.binding_id}",
+                                limit=self._settings.channel_binding_backlog_limit,
+                                window_s=self._settings.channel_binding_backlog_window_s,
+                            ):
+                                row.status, row.error_code = "refused", "binding_backlog_quota"
+                                row.version += 1
+                                continue
+                            row.quota_taken = True
+                        _, receipt = await enqueue_owned(
+                            self._valkey,
+                            key=f"curie:github-review:{row.event_id}",
+                            stream=self._settings.runs_stream,
+                            # Lua preserves its preceding SET if XADD fails.
+                            # Reuse this row's owner so a retry can finish that
+                            # partial operation without waiting for lease expiry.
+                            owner=f"pending:{row.event_id}",
+                            payload=json.dumps(row.turn),
+                            payload_field=STREAM_PAYLOAD_FIELD,
+                            lease_s=30,
+                            transport_field=TRACEPARENT_STREAM_FIELD,
+                            transport_value=row.traceparent,
+                        )
+                    if "-" not in receipt or not all(p.isdigit() for p in receipt.split("-")):
+                        raise RuntimeError("enqueue receipt unavailable")
+                except Exception:
+                    row.error_code = "enqueue_unavailable"
+                    row.next_attempt_at = datetime.now(UTC).replace(tzinfo=None) + timedelta(
+                        seconds=min(300, 5 * 2 ** (row.enqueue_attempts - 1))
+                    )
+                    if row.enqueue_attempts >= _MAX_ENQUEUE_ATTEMPTS:
+                        row.status = "dead_lettered"
+                else:
+                    row.status = "queued"
+                    row.stream_id = receipt
+                    row.queued_at = datetime.now(UTC).replace(tzinfo=None)
+                    row.error_code = None
+                    row.next_attempt_at = None
+                    enqueued += 1
+                row.version += 1
+        return enqueued
+
+    async def run_forever(self) -> None:
+        while True:
+            try:
+                await self.reconcile_once()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.warning("GitHub feedback outbox pass failed; durable rows retained")
+            await asyncio.sleep(self._settings.github_review_reconciler_interval_s)
+
+
+async def verify_queued_feedback(
+    session: AsyncSession,
+    turn: QueuedTurn,
+    deployment_id: uuid.UUID,
+    *,
+    settings: Settings,
+    client: httpx.AsyncClient,
+) -> dict[str, str]:
+    """Recheck canonical input and current authority immediately before model use."""
+    row = await session.get(GitHubReviewFeedback, turn.event_id)
+    if row is None or row.status not in {"waiting", "queued"}:
+        raise FeedbackIgnored("feedback_not_executable")
+    if turn.model_dump(mode="json") != row.turn:
+        raise FeedbackIgnored("feedback_turn_mismatch")
+    feedback, context = await validate_stored_context(session, row, settings)
+    deployment = await session.get(Deployment, deployment_id)
+    if deployment is None or deployment.agent_id != row.agent_id or deployment.status != "active":
+        raise FeedbackIgnored("deployment_no_longer_authorized")
+    head = await verify_feedback_truth(feedback, context.truth, settings=settings, client=client)
+    return {
+        "head_sha": head,
+        "agent_id": str(row.agent_id),
+        "sender": turn.author,
+        "receipt": f"Received GitHub feedback from {feedback.sender_login}: {feedback.url}",
+    }

--- a/apps/api/src/curie_api/github_review_terminal.py
+++ b/apps/api/src/curie_api/github_review_terminal.py
@@ -1,0 +1,60 @@
+"""Read exact worker terminal evidence; absence never means completion."""
+
+import json
+from typing import Any
+
+import redis.asyncio as redis
+
+from .config import Settings
+
+
+async def worker_event_is_terminal(
+    valkey: redis.Redis, settings: Settings, event_id: str
+) -> bool:
+    """Mirror Markers.is_terminal without becoming another terminal writer.
+
+    The worker alone records terminal completion under its delivery fence. A
+    missing queue entry or an expired lease supplies no terminal evidence.
+    Executable parity tests cover default/custom prefixes, the current/stale
+    fence, and the independently retained completion-outbox flag.
+    """
+    async with valkey.pipeline(transaction=False) as pipe:
+        pipe.exists(f"{settings.worker_key_prefix}:done:{event_id}")
+        pipe.hget(f"{settings.worker_key_prefix}:completion:{event_id}", "done")
+        marker, flag = await pipe.execute()
+    return bool(marker) or flag in ("1", b"1")
+
+
+async def read_review_dead_letter(
+    valkey: redis.Redis,
+    settings: Settings,
+    *,
+    stream_id: str,
+    turn: dict[str, Any],
+    cursor: str | None,
+) -> tuple[bool, str | None]:
+    """Observe at most 128 existing graveyard rows; the caller owns SQL cursor CAS.
+
+    Missing or trimmed records remain unknown. Malformed data naming the exact
+    original delivery raises before returning a cursor, so the caller cannot
+    commit progress past a matching record it failed to process.
+    """
+    entries = await valkey.xrange(
+        settings.dead_letter_stream_name(), min=f"({cursor}" if cursor else "-", count=128
+    ) or []
+    observed = cursor
+    for entry_id, fields in entries:
+        if entry_id is None or fields is None:
+            raise ValueError("review dead-letter record is unreadable")
+        record_id = entry_id.decode() if isinstance(entry_id, bytes) else entry_id
+        # The API uses byte responses; worker test clients may decode them.
+        original_id = fields.get("dl_original_id", fields.get(b"dl_original_id"))
+        if original_id in (stream_id, stream_id.encode()):
+            try:
+                candidate = json.loads(fields.get("payload", fields.get(b"payload", "")))
+            except (ValueError, TypeError):
+                raise ValueError("matching review dead-letter payload is unreadable") from None
+            if candidate == turn:
+                return True, record_id
+        observed = record_id
+    return False, observed

--- a/apps/api/src/curie_api/github_review_truth.py
+++ b/apps/api/src/curie_api/github_review_truth.py
@@ -180,4 +180,25 @@ async def verify_feedback_truth(
     expected = replace(feedback, repo_full_name=observed.repo_full_name, url=observed.url)
     if observed != expected:
         raise FeedbackIgnored("feedback_changed")
+    if observed.author_association == "CONTRIBUTOR":
+        # Association does not establish effective repository permission. Keep
+        # the existing OWNER/MEMBER/COLLABORATOR policy, and authorize this
+        # fallback only through the current, installation-verified App token.
+        # Permission results are read again on every pre-model verification.
+        # https://docs.github.com/en/rest/collaborators/collaborators#get-repository-permissions-for-a-user
+        permission = await read(
+            f"{repo_path}/collaborators/{observed.sender_login}/permission",
+            "sender_permission_unavailable",
+        )
+        user = permission.get("user")
+        if (
+            not isinstance(user, dict)
+            or type(user.get("id")) is not int
+            or user["id"] != observed.sender_id
+        ):
+            raise FeedbackIgnored("sender_permission_identity_mismatch")
+        # The documented legacy field folds maintain into write. Descriptive
+        # role_name and unexpected values cannot grant authority.
+        if permission.get("permission") not in ("write", "admin"):
+            raise FeedbackIgnored("sender_permission_refused")
     return lineage.head_sha

--- a/apps/api/src/curie_api/github_review_truth.py
+++ b/apps/api/src/curie_api/github_review_truth.py
@@ -1,0 +1,175 @@
+"""Fresh GitHub authority checks for thread-bound human review feedback.
+
+The HTTP ingress and the before-model recheck use the same verifier. It only
+reads provider state; publication still belongs to the existing trusted writer.
+"""
+
+from dataclasses import dataclass, replace
+from typing import Any
+
+import httpx
+from starlette.concurrency import run_in_threadpool
+
+from .config import Settings
+from .github_app import GitHubAppError, GitHubInstallationRefused, credentials_for
+from .github_review_events import (
+    FeedbackIgnored,
+    FeedbackUnavailable,
+    UnverifiedFeedback,
+    parse_feedback,
+)
+from .repo_full_name import repo_url_path
+
+
+@dataclass(frozen=True)
+class BoundReviewLineage:
+    """Identity read from one unambiguous persisted publication lineage."""
+
+    repo_full_name: str
+    pr_number: int
+    branch: str
+    head_sha: str
+
+
+async def verify_feedback_truth(
+    feedback: UnverifiedFeedback,
+    lineage: BoundReviewLineage,
+    *,
+    settings: Settings,
+    client: httpx.AsyncClient,
+) -> str:
+    """Return the exact current bound PR head, or a payload-free refusal.
+
+    Resource URLs are derived from persisted identity. No claimed webhook or
+    REST response URL is fetched, and redirects cannot carry the App token to
+    another endpoint. All credential-bearing requests stay inside the API.
+    """
+    if (
+        feedback.repo_full_name.casefold() != lineage.repo_full_name.casefold()
+        or feedback.pr_number != lineage.pr_number
+    ):
+        raise FeedbackIgnored("lineage_mismatch")
+    try:
+        token = await run_in_threadpool(
+            credentials_for(settings).token_for_verified_installation,
+            lineage.repo_full_name,
+            feedback.installation_id,
+        )
+    except (GitHubInstallationRefused, ValueError):
+        raise FeedbackIgnored("installation_unverified") from None
+    except GitHubAppError:
+        raise FeedbackUnavailable("installation_unavailable") from None
+
+    api = settings.github_api_url.rstrip("/")
+    repo_path = f"/repos/{repo_url_path(lineage.repo_full_name)}"
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {token}",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+    async def read(path: str, refusal: str) -> dict[str, Any]:
+        try:
+            response = await client.get(
+                f"{api}{path}",
+                headers=headers,
+                follow_redirects=False,
+            )
+        except httpx.HTTPError:
+            raise FeedbackUnavailable(refusal) from None
+        # A 404 can conceal missing App permissions; it cannot distinguish a
+        # deleted comment from a temporary inability to prove current authority.
+        # Neither case may execute. Operators can redeliver after correcting
+        # setup; GitHub does not automatically retry failed webhook deliveries.
+        if response.status_code in {401, 403, 404, 429} or response.status_code >= 500:
+            raise FeedbackUnavailable(refusal)
+        if response.status_code != 200:
+            raise FeedbackIgnored(refusal)
+        try:
+            result = response.json()
+        except ValueError:
+            raise FeedbackIgnored(refusal) from None
+        if not isinstance(result, dict):
+            raise FeedbackIgnored(refusal)
+        return result
+
+    repository = await read(repo_path, "repository_unavailable")
+
+    def same_repository(value: Any) -> bool:
+        return (
+            isinstance(value, dict)
+            and type(value.get("id")) is int
+            and value["id"] == feedback.repository_id
+            and isinstance(value.get("full_name"), str)
+            and value["full_name"].casefold() == lineage.repo_full_name.casefold()
+        )
+
+    if not same_repository(repository):
+        raise FeedbackIgnored("repository_mismatch")
+    pr = await read(f"{repo_path}/pulls/{lineage.pr_number}", "pull_request_unavailable")
+    head, base = pr.get("head"), pr.get("base")
+    if (
+        not isinstance(head, dict)
+        or not isinstance(base, dict)
+        or type(pr.get("number")) is not int
+        or pr["number"] != lineage.pr_number
+        or not isinstance(pr.get("html_url"), str)
+        or pr["html_url"].casefold()
+        != f"https://github.com/{lineage.repo_full_name}/pull/{lineage.pr_number}".casefold()
+        or head.get("ref") != lineage.branch
+    ):
+        raise FeedbackIgnored("pull_request_mismatch")
+    if not same_repository(head.get("repo")) or not same_repository(base.get("repo")):
+        raise FeedbackIgnored("repository_mismatch")
+    if pr.get("state") != "open" or pr.get("merged") is not False:
+        raise FeedbackIgnored("terminal_pull_request")
+    if head.get("sha") != lineage.head_sha or (
+        feedback.head_sha is not None and feedback.head_sha != lineage.head_sha
+    ):
+        raise FeedbackIgnored("stale_feedback_head")
+
+    if feedback.event == "issue_comment":
+        path = f"{repo_path}/issues/comments/{feedback.feedback_id}"
+    elif feedback.event == "pull_request_review_comment":
+        path = f"{repo_path}/pulls/comments/{feedback.feedback_id}"
+    else:
+        path = f"{repo_path}/pulls/{lineage.pr_number}/reviews/{feedback.feedback_id}"
+    current = await read(path, "feedback_unavailable")
+    if feedback.event == "issue_comment" and current.get("issue_url") != (
+        f"{api}{repo_path}/issues/{lineage.pr_number}"
+    ):
+        raise FeedbackIgnored("feedback_target_mismatch")
+    if feedback.event == "pull_request_review_comment" and current.get("pull_request_url") != (
+        f"{api}{repo_path}/pulls/{lineage.pr_number}"
+    ):
+        raise FeedbackIgnored("feedback_target_mismatch")
+
+    # Reuse the strict body/author/time/URL/context checks on the freshly read
+    # provider object. The wrapper supplies only independently verified facts.
+    canonical: dict[str, Any] = {
+        "installation": {"id": feedback.installation_id},
+        "repository": repository,
+        "sender": current.get("user"),
+        "action": "submitted" if feedback.event == "pull_request_review" else "created",
+    }
+    if feedback.event == "issue_comment":
+        canonical.update(
+            {
+                "comment": current,
+                "issue": {
+                    "number": lineage.pr_number,
+                    "state": "open",
+                    "pull_request": {},
+                },
+            }
+        )
+    else:
+        canonical["pull_request"] = pr
+        canonical["review" if feedback.event == "pull_request_review" else "comment"] = current
+    observed = parse_feedback(feedback.event, canonical, str(feedback.delivery_id))
+    # Repository spelling may differ in a signed payload; it is case-insensitive
+    # identity. The canonical URL retained for the model comes from our lineage.
+    expected = replace(feedback, repo_full_name=observed.repo_full_name, url=observed.url)
+    if observed != expected:
+        raise FeedbackIgnored("feedback_changed")
+    return lineage.head_sha

--- a/apps/api/src/curie_api/github_review_truth.py
+++ b/apps/api/src/curie_api/github_review_truth.py
@@ -29,6 +29,10 @@ class BoundReviewLineage:
     pr_number: int
     branch: str
     head_sha: str
+    repository_id: int
+    installation_id: int
+    pr_node_id: str
+    base_ref: str
 
 
 async def verify_feedback_truth(
@@ -47,13 +51,15 @@ async def verify_feedback_truth(
     if (
         feedback.repo_full_name.casefold() != lineage.repo_full_name.casefold()
         or feedback.pr_number != lineage.pr_number
+        or feedback.repository_id != lineage.repository_id
+        or feedback.installation_id != lineage.installation_id
     ):
         raise FeedbackIgnored("lineage_mismatch")
     try:
         token = await run_in_threadpool(
             credentials_for(settings).token_for_verified_installation,
             lineage.repo_full_name,
-            feedback.installation_id,
+            lineage.installation_id,
         )
     except (GitHubInstallationRefused, ValueError):
         raise FeedbackIgnored("installation_unverified") from None
@@ -99,7 +105,7 @@ async def verify_feedback_truth(
         return (
             isinstance(value, dict)
             and type(value.get("id")) is int
-            and value["id"] == feedback.repository_id
+            and value["id"] == lineage.repository_id
             and isinstance(value.get("full_name"), str)
             and value["full_name"].casefold() == lineage.repo_full_name.casefold()
         )
@@ -113,6 +119,8 @@ async def verify_feedback_truth(
         or not isinstance(base, dict)
         or type(pr.get("number")) is not int
         or pr["number"] != lineage.pr_number
+        or pr.get("node_id") != lineage.pr_node_id
+        or base.get("ref") != lineage.base_ref
         or not isinstance(pr.get("html_url"), str)
         or pr["html_url"].casefold()
         != f"https://github.com/{lineage.repo_full_name}/pull/{lineage.pr_number}".casefold()

--- a/apps/api/src/curie_api/main.py
+++ b/apps/api/src/curie_api/main.py
@@ -33,6 +33,7 @@ from .db import create_engine, create_sessionmaker
 from .evalqueue import EvalQueue
 from .github_app import credentials_for, log_credential_path
 from .github_checks import GitHubStatusReporter
+from .github_review_store import GitHubReviewReconciler
 from .graveyardwatcher import GraveyardWatcher
 from .k8s import build_lazy_pod_lister, build_lazy_pod_log_reader
 from .killswitch import KillSwitch
@@ -54,6 +55,7 @@ from .routers import (
     evals,
     gitflow_routing,
     github,
+    github_reviews,
     hooks,
     memory,
     observability,
@@ -106,6 +108,16 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         valkey,
         stream=settings.runs_stream,
         dead_letter_stream=settings.resume_dead_letter_stream or settings.dead_letter_stream_name(),
+    )
+    app.state.github_review_reconciler = GitHubReviewReconciler(
+        app.state.sessionmaker,
+        valkey,
+        settings,
+    )
+    app.state.github_review_reconciler_task = (
+        asyncio.create_task(app.state.github_review_reconciler.run_forever())
+        if settings.github_review_reconciler_interval_s > 0
+        else None
     )
     # The composition root for approvals (#420, ADR-0034): the only place that
     # names Slack to build the approver-set selector, so the authorizer and the
@@ -210,6 +222,13 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     try:
         yield
     finally:
+        review_task = app.state.github_review_reconciler_task
+        if review_task is not None:
+            review_task.cancel()
+            try:
+                await review_task
+            except asyncio.CancelledError:
+                pass
         # Both background loops enqueue via resume_queue (which uses the valkey
         # client) and read via the sessionmaker, so both are stopped BEFORE
         # valkey.aclose()/engine.dispose() below.
@@ -335,6 +354,7 @@ def create_app() -> FastAPI:
     app.include_router(bundles.router)
     app.include_router(deploy_targets.router)
     app.include_router(github.router)
+    app.include_router(github_reviews.router)
     app.include_router(gitflow_routing.router)
     app.include_router(observability.router)
     app.include_router(control.router)

--- a/apps/api/src/curie_api/models.py
+++ b/apps/api/src/curie_api/models.py
@@ -555,13 +555,55 @@ class PublicationReviewReservation(Base):
     updated_at: Mapped[datetime] = mapped_column(server_default=func.now(), onupdate=func.now())
 
 
+class GitHubReviewDelivery(Base):
+    """One authenticated webhook receipt, including ignored actions and aliases."""
+
+    __tablename__ = "github_review_deliveries"
+    __table_args__ = (
+        CheckConstraint(
+            "status IN ('pending','accepted','ignored','rejected','retryable')",
+            name="github_review_deliveries_status_ck",
+        ),
+        CheckConstraint(
+            "version >= 1 AND replay_conflicts >= 0", name="github_review_deliveries_version_ck"
+        ),
+        CheckConstraint("length(body_sha256) = 64", name="github_review_deliveries_digest_ck"),
+        CheckConstraint(
+            "status IN ('pending','accepted') OR reason IS NOT NULL",
+            name="github_review_deliveries_reason_ck",
+        ),
+    )
+    delivery_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True)
+    event_kind: Mapped[str]
+    action: Mapped[str]
+    body_sha256: Mapped[str]
+    repository_id: Mapped[int | None] = mapped_column(BigInteger, default=None)
+    installation_id: Mapped[int | None] = mapped_column(BigInteger, default=None)
+    pr_number: Mapped[int | None] = mapped_column(default=None)
+    source_object_id: Mapped[int | None] = mapped_column(BigInteger, default=None)
+    sender_id: Mapped[int | None] = mapped_column(BigInteger, default=None)
+    sender_type: Mapped[str]
+    sender_login: Mapped[str | None] = mapped_column(default=None)
+    author_association: Mapped[str]
+    event_id: Mapped[str | None] = mapped_column(
+        ForeignKey(f"{SCHEMA}.github_review_feedback.event_id", ondelete="SET NULL"),
+        default=None,
+    )
+    status: Mapped[str] = mapped_column(default="pending", server_default="pending")
+    reason: Mapped[str | None] = mapped_column(default=None)
+    version: Mapped[int] = mapped_column(default=1, server_default="1")
+    replay_conflicts: Mapped[int] = mapped_column(default=0, server_default="0")
+    created_at: Mapped[datetime] = mapped_column(server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(server_default=func.now(), onupdate=func.now())
+
+
 class GitHubReviewFeedback(Base):
     """One immutable human feedback identity and its durable enqueue receipt."""
 
     __tablename__ = "github_review_feedback"
     __table_args__ = (
         CheckConstraint(
-            "status IN ('waiting', 'queued', 'refused', 'dead_lettered')",
+            "status IN ('waiting', 'queued', 'reserved', 'settled', 'refused', 'dead_lettered')",
             name="github_review_feedback_status_ck",
         ),
         CheckConstraint("version >= 1", name="github_review_feedback_version_ck"),
@@ -582,6 +624,10 @@ class GitHubReviewFeedback(Base):
     binding_generation: Mapped[int]
     agent_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True))
     lineage_version: Mapped[int]
+    reservation_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey(f"{SCHEMA}.publication_review_reservations.id", ondelete="SET NULL"),
+        default=None,
+    )
     # Only normalized, bounded feedback and a credential-free QueuedTurn; never
     # the unfiltered webhook body, headers or a GitHub credential.
     feedback: Mapped[dict[str, Any]] = mapped_column(JSONB)
@@ -596,6 +642,7 @@ class GitHubReviewFeedback(Base):
     stream_id: Mapped[str | None] = mapped_column(default=None)
     created_at: Mapped[datetime] = mapped_column(server_default=func.now())
     queued_at: Mapped[datetime | None] = mapped_column(default=None)
+    terminal_scan_cursor: Mapped[str | None] = mapped_column(default=None)
 
 
 class Publication(Base):

--- a/apps/api/src/curie_api/models.py
+++ b/apps/api/src/curie_api/models.py
@@ -555,6 +555,49 @@ class PublicationReviewReservation(Base):
     updated_at: Mapped[datetime] = mapped_column(server_default=func.now(), onupdate=func.now())
 
 
+class GitHubReviewFeedback(Base):
+    """One immutable human feedback identity and its durable enqueue receipt."""
+
+    __tablename__ = "github_review_feedback"
+    __table_args__ = (
+        CheckConstraint(
+            "status IN ('waiting', 'queued', 'refused', 'dead_lettered')",
+            name="github_review_feedback_status_ck",
+        ),
+        CheckConstraint("version >= 1", name="github_review_feedback_version_ck"),
+        CheckConstraint("enqueue_attempts >= 0", name="github_review_feedback_attempts_ck"),
+        Index("ix_github_review_feedback_pending", "status", "created_at"),
+    )
+
+    event_id: Mapped[str] = mapped_column(primary_key=True)
+    delivery_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), unique=True)
+    # Keep the semantic tombstone if an operator deletes the old binding or
+    # lineage. Recreating one cannot make an old comment executable again.
+    lineage_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey(f"{SCHEMA}.thread_publication_lineages.id", ondelete="SET NULL")
+    )
+    binding_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey(f"{SCHEMA}.agent_channels.id", ondelete="SET NULL")
+    )
+    binding_generation: Mapped[int]
+    agent_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True))
+    lineage_version: Mapped[int]
+    # Only normalized, bounded feedback and a credential-free QueuedTurn; never
+    # the unfiltered webhook body, headers or a GitHub credential.
+    feedback: Mapped[dict[str, Any]] = mapped_column(JSONB)
+    turn: Mapped[dict[str, Any]] = mapped_column(JSONB)
+    traceparent: Mapped[str | None] = mapped_column(default=None)
+    status: Mapped[str] = mapped_column(default="waiting", server_default="waiting")
+    version: Mapped[int] = mapped_column(default=1, server_default="1")
+    enqueue_attempts: Mapped[int] = mapped_column(default=0, server_default="0")
+    quota_taken: Mapped[bool] = mapped_column(default=False, server_default="false")
+    next_attempt_at: Mapped[datetime | None] = mapped_column(default=None)
+    error_code: Mapped[str | None] = mapped_column(default=None)
+    stream_id: Mapped[str | None] = mapped_column(default=None)
+    created_at: Mapped[datetime] = mapped_column(server_default=func.now())
+    queued_at: Mapped[datetime | None] = mapped_column(default=None)
+
+
 class Publication(Base):
     """Private patch state settled by the platform publication reconciler."""
 

--- a/apps/api/src/curie_api/revision_kinds.json
+++ b/apps/api/src/curie_api/revision_kinds.json
@@ -40,5 +40,6 @@
   "0039": "expand",
   "0040": "expand",
   "0041": "contract",
-  "0042": "expand"
+  "0042": "expand",
+  "0043": "expand"
 }

--- a/apps/api/src/curie_api/routers/github.py
+++ b/apps/api/src/curie_api/routers/github.py
@@ -13,6 +13,8 @@ from fastapi import APIRouter, Header, HTTPException, Request, status
 from ..config import get_settings
 from ..deps import EvalQueueDep, SessionDep, StoreDep
 from ..gitflow import log_push_outcome, process_push, verify_signature
+from ..github_review_events import FeedbackIgnored, FeedbackUnavailable, parse_feedback
+from ..github_review_store import admit_feedback
 from ..schemas import WebhookResult
 from ..wirebody import read_bounded_body
 
@@ -28,28 +30,56 @@ async def github_webhook(
     store: StoreDep,
     eval_queue: EvalQueueDep,
     x_github_event: str = Header(default=""),
+    x_github_delivery: str = Header(default=""),
     x_hub_signature_256: str | None = Header(default=None),
 ) -> WebhookResult:
     settings = get_settings()
     body = await read_bounded_body(
         request, settings.github_webhook_max_body_bytes, subject="webhook body"
     )
-    if not verify_signature(
-        settings.github_webhook_secret, body, x_hub_signature_256
-    ):
+    if not verify_signature(settings.github_webhook_secret, body, x_hub_signature_256):
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, "invalid signature")
 
     if x_github_event == "ping":
         return WebhookResult(status="pong")
-    if x_github_event != "push":
+    is_review = x_github_event in {
+        "issue_comment",
+        "pull_request_review_comment",
+        "pull_request_review",
+    }
+    if x_github_event != "push" and not is_review:
         return WebhookResult(status="ignored")
 
     try:
         payload = json.loads(body)
     except json.JSONDecodeError as exc:
-        raise HTTPException(
-            status.HTTP_400_BAD_REQUEST, "webhook body is not valid JSON"
-        ) from exc
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, "webhook body is not valid JSON") from exc
+
+    if is_review:
+        if not settings.github_review_ingress_enabled:
+            return WebhookResult(status="feedback_disabled")
+        try:
+            feedback = parse_feedback(x_github_event, payload, x_github_delivery)
+            row, created = await admit_feedback(
+                session,
+                feedback,
+                settings=settings,
+                client=request.app.state.http_client,
+                traceparent=request.headers.get("traceparent"),
+            )
+        except FeedbackUnavailable as exc:
+            raise HTTPException(503, {"code": exc.code}, headers={"Retry-After": "10"}) from None
+        except FeedbackIgnored as exc:
+            if exc.code == "invalid_delivery":
+                raise HTTPException(400, {"code": exc.code}) from None
+            return WebhookResult(status="feedback_ignored", errors=[{"code": exc.code}])
+        if not created:
+            return WebhookResult(status="feedback_duplicate")
+        # The committed row is the recovery authority if Valkey or this API
+        # process fails between persistence, XADD and the response.
+        await request.app.state.github_review_reconciler.reconcile_once(row.event_id)
+        await session.refresh(row)
+        return WebhookResult(status=f"feedback_{row.status}")
 
     result = await process_push(session, store, settings, eval_queue, payload)
     log_push_outcome(result, payload, source="github webhook")

--- a/apps/api/src/curie_api/routers/github.py
+++ b/apps/api/src/curie_api/routers/github.py
@@ -7,12 +7,14 @@ push to the prod branch promotes; other events are acknowledged and ignored.
 
 import json
 import logging
+import uuid
 
 from fastapi import APIRouter, Header, HTTPException, Request, status
 
 from ..config import get_settings
 from ..deps import EvalQueueDep, SessionDep, StoreDep
 from ..gitflow import log_push_outcome, process_push, verify_signature
+from ..github_review_audit import claim_review_delivery, settle_review_delivery
 from ..github_review_events import FeedbackIgnored, FeedbackUnavailable, parse_feedback
 from ..github_review_store import admit_feedback
 from ..schemas import WebhookResult
@@ -59,6 +61,31 @@ async def github_webhook(
         if not settings.github_review_ingress_enabled:
             return WebhookResult(status="feedback_disabled")
         try:
+            delivery_id = uuid.UUID(x_github_delivery)
+            if str(delivery_id) != x_github_delivery.lower():
+                raise ValueError("noncanonical delivery")
+        except (ValueError, AttributeError):
+            raise HTTPException(400, {"code": "invalid_delivery"}) from None
+        audit, conflict = await claim_review_delivery(
+            session,
+            delivery_id=delivery_id,
+            event=x_github_event,
+            body=body,
+            payload=payload,
+        )
+        if conflict:
+            await session.commit()
+            return WebhookResult(
+                status="feedback_ignored", errors=[{"code": "delivery_identity_conflict"}]
+            )
+        if audit.status in {"ignored", "rejected"}:
+            assert audit.reason is not None
+            await session.commit()
+            return WebhookResult(status="feedback_ignored", errors=[{"code": audit.reason}])
+        if audit.status == "accepted":
+            await session.commit()
+            return WebhookResult(status="feedback_duplicate")
+        try:
             feedback = parse_feedback(x_github_event, payload, x_github_delivery)
             row, created = await admit_feedback(
                 session,
@@ -68,11 +95,31 @@ async def github_webhook(
                 traceparent=request.headers.get("traceparent"),
             )
         except FeedbackUnavailable as exc:
+            settle_review_delivery(audit, "retryable", exc.code)
+            await session.commit()
             raise HTTPException(503, {"code": exc.code}, headers={"Retry-After": "10"}) from None
         except FeedbackIgnored as exc:
             if exc.code == "invalid_delivery":
                 raise HTTPException(400, {"code": exc.code}) from None
+            disposition = (
+                "ignored"
+                if exc.code
+                in {
+                    "unsupported_action",
+                    "non_actionable_review",
+                    "empty_feedback",
+                    "edited_feedback",
+                    "not_pull_request",
+                    "non_human_sender",
+                    "app_authored",
+                }
+                else "rejected"
+            )
+            settle_review_delivery(audit, disposition, exc.code)
+            await session.commit()
             return WebhookResult(status="feedback_ignored", errors=[{"code": exc.code}])
+        settle_review_delivery(audit, "accepted", event_id=row.event_id)
+        await session.commit()
         if not created:
             return WebhookResult(status="feedback_duplicate")
         # The committed row is the recovery authority if Valkey or this API

--- a/apps/api/src/curie_api/routers/github_reviews.py
+++ b/apps/api/src/curie_api/routers/github_reviews.py
@@ -1,0 +1,64 @@
+"""Worker-only current-authority check for durable human GitHub feedback."""
+
+import uuid
+
+from aci_protocol import QueuedTurn
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
+from pydantic import BaseModel, ConfigDict
+
+from ..auth import require_internal_worker_token
+from ..config import get_settings
+from ..deps import SessionDep
+from ..github_review_events import FeedbackIgnored, FeedbackUnavailable
+from ..github_review_store import verify_queued_feedback
+
+router = APIRouter(
+    prefix="/v1/internal/github/reviews",
+    tags=["internal-github-reviews"],
+    dependencies=[Depends(require_internal_worker_token)],
+)
+
+
+class ReviewVerificationRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    turn: QueuedTurn
+    deployment_id: uuid.UUID
+
+
+class ReviewVerificationOut(BaseModel):
+    head_sha: str
+    agent_id: uuid.UUID
+    sender: str
+    receipt: str
+
+
+@router.post("/{event_id}/verify", response_model=ReviewVerificationOut)
+async def verify_review(
+    event_id: str,
+    payload: ReviewVerificationRequest,
+    request: Request,
+    response: Response,
+    session: SessionDep,
+) -> ReviewVerificationOut:
+    response.headers["Cache-Control"] = "no-store"
+    if event_id != payload.turn.event_id:
+        raise HTTPException(
+            409, {"code": "feedback_turn_mismatch"}, headers={"Cache-Control": "no-store"}
+        )
+    try:
+        result = await verify_queued_feedback(
+            session,
+            payload.turn,
+            payload.deployment_id,
+            settings=get_settings(),
+            client=request.app.state.http_client,
+        )
+    except FeedbackUnavailable as exc:
+        raise HTTPException(
+            503, {"code": exc.code}, headers={"Cache-Control": "no-store"}
+        ) from None
+    except FeedbackIgnored as exc:
+        raise HTTPException(
+            409, {"code": exc.code}, headers={"Cache-Control": "no-store"}
+        ) from None
+    return ReviewVerificationOut.model_validate(result)

--- a/apps/api/src/curie_api/routers/github_reviews.py
+++ b/apps/api/src/curie_api/routers/github_reviews.py
@@ -4,13 +4,17 @@ import uuid
 
 from aci_protocol import QueuedTurn
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 from ..auth import require_internal_worker_token
 from ..config import get_settings
 from ..deps import SessionDep
 from ..github_review_events import FeedbackIgnored, FeedbackUnavailable
-from ..github_review_store import verify_queued_feedback
+from ..github_review_store import (
+    record_feedback_refusal,
+    reserve_queued_feedback,
+    verify_queued_feedback,
+)
 
 router = APIRouter(
     prefix="/v1/internal/github/reviews",
@@ -30,6 +34,19 @@ class ReviewVerificationOut(BaseModel):
     agent_id: uuid.UUID
     sender: str
     receipt: str
+    origin_key: str
+    lineage_version: int
+    reservation_id: uuid.UUID | None
+
+
+class ReviewReservationRequest(ReviewVerificationRequest):
+    expected_lineage_version: int = Field(ge=1, strict=True)
+    expected_head_sha: str = Field(pattern=r"^[0-9a-f]{40}$")
+
+
+class ReviewReservationOut(BaseModel):
+    origin_key: str
+    reservation_id: uuid.UUID
 
 
 @router.post("/{event_id}/verify", response_model=ReviewVerificationOut)
@@ -58,7 +75,44 @@ async def verify_review(
             503, {"code": exc.code}, headers={"Cache-Control": "no-store"}
         ) from None
     except FeedbackIgnored as exc:
+        await session.rollback()
+        await record_feedback_refusal(session, payload.turn, exc.code)
+        await session.commit()
         raise HTTPException(
             409, {"code": exc.code}, headers={"Cache-Control": "no-store"}
         ) from None
     return ReviewVerificationOut.model_validate(result)
+
+
+@router.post("/{event_id}/reserve", response_model=ReviewReservationOut)
+async def reserve_review(
+    event_id: str,
+    payload: ReviewReservationRequest,
+    response: Response,
+    session: SessionDep,
+) -> ReviewReservationOut:
+    response.headers["Cache-Control"] = "no-store"
+    if event_id != payload.turn.event_id:
+        raise HTTPException(409, {"code": "feedback_turn_mismatch"})
+    try:
+        reservation_id = await reserve_queued_feedback(
+            session,
+            payload.turn,
+            payload.deployment_id,
+            expected_lineage_version=payload.expected_lineage_version,
+            expected_head_sha=payload.expected_head_sha,
+            settings=get_settings(),
+        )
+        await session.commit()
+    except FeedbackUnavailable as exc:
+        raise HTTPException(
+            503, {"code": exc.code}, headers={"Cache-Control": "no-store"}
+        ) from None
+    except FeedbackIgnored as exc:
+        await session.rollback()
+        await record_feedback_refusal(session, payload.turn, exc.code)
+        await session.commit()
+        raise HTTPException(
+            409, {"code": exc.code}, headers={"Cache-Control": "no-store"}
+        ) from None
+    return ReviewReservationOut(origin_key=event_id, reservation_id=reservation_id)

--- a/apps/api/tests/test_github_review_binding_scope.py
+++ b/apps/api/tests/test_github_review_binding_scope.py
@@ -1,0 +1,132 @@
+"""A Slack channel binding must not serialize independent review conversations."""
+
+import base64
+import copy
+import time
+import uuid
+
+import httpx
+import pytest
+from channel_protocol import scoped_conversation_id
+from curie_api import approval_principal
+from curie_api.config import get_settings
+from curie_api.github_review_events import parse_feedback
+
+from apps.api.tests.test_github_review_events import (
+    HEAD,
+    REPO,
+    post_review,
+    review_rows,
+)
+from apps.api.tests.test_github_review_events import review_app_key as review_app_key
+from apps.api.tests.test_github_review_events import review_stack as review_stack
+
+
+def _other_verified_lineage(client, truth, auth_headers):
+    """Actual producer APIs; fixed fixture attestation is not a human click."""
+    deployment = review_rows("SELECT deployment_id FROM curie.thread_publication_lineages")[0][
+        "deployment_id"
+    ]
+    conversation = "1700000000.000051"
+    worker_headers = {"X-Curie-Worker-Token": "fixture-review-worker-token"}
+    selected = client.post(
+        f"/v1/internal/workspaces/{deployment}/selection",
+        headers=worker_headers,
+        json={"conversation_id": scoped_conversation_id("slack", "C0EXAMPLE1", conversation),
+              "author": "U0REQUEST1", "repo_full_name": REPO},
+    )
+    assert selected.status_code == 200, selected.text
+    created = client.post("/v1/internal/publications", headers=worker_headers, json={
+        "deployment_id": str(deployment), "conversation_id": conversation,
+        "repo_full_name": REPO, "author": "U0REQUEST1", "summary": "Second thread fixture",
+        "reply_kind": "slack", "reply_channel": "C0EXAMPLE1",
+        "reply_placeholder": "1700000000.000052", "dedupe_key": str(uuid.uuid4()),
+        "base_sha": HEAD, "patch_b64": base64.b64encode(b"diff --git a/a b/a\n").decode(),
+        "changed_paths": ["a"], "expires_in_seconds": 600,
+    })
+    assert created.status_code == 201, created.text
+    publication = created.json()
+    truth.pr.update(number=18, node_id="PR_example_18", html_url=f"https://github.com/{REPO}/pull/18")
+    truth.pr["head"]["ref"] = publication["branch"]
+    principal = approval_principal.mint(
+        get_settings().approval_chat_attester_secret,
+        subject="U0REQUEST1", kind="chat", actor_channel="C0EXAMPLE1",
+        approval_id=publication["approval_id"], scope=approval_principal.APPROVE_SCOPE,
+        exp=int(time.time()) + 60,
+    )
+    resolved = client.post(
+        f"/approvals/{publication['approval_id']}/resolve", json={"decision": "approved"},
+        headers={**auth_headers, "X-Curie-Approval-Principal": principal},
+    )
+    assert resolved.status_code == 200, resolved.text
+    advanced = client.patch(
+        f"/v1/internal/publications/{publication['id']}/lineage",
+        headers=worker_headers,
+        json={"expected_version": 1, "expected_head_sha": None, "state": "open",
+              "pr_number": 18, "pr_url": f"https://github.com/{REPO}/pull/18", "head_sha": HEAD},
+    )
+    assert advanced.status_code == 200, advanced.text
+    review_rows("UPDATE curie.publications SET outcome_history_ready_at=now(), "
+                "result_reported_at=now() WHERE id=:id", {"id": publication["id"]})
+    return conversation
+
+
+@pytest.mark.parametrize("other_conversation", [False, True])
+def test_concurrent_feedback_is_durable_for_same_and_independent_thread_lineages(
+    review_stack, auth_headers, other_conversation,
+):
+    client, truth, valkey, stream = review_stack
+    assert post_review(client, truth).json()["status"] == "feedback_queued"
+    original_http = client.app.state.http_client
+
+    def handle(request):
+        # Both response shapes are documented by GitHub REST Pull requests/Get.
+        if request.url.path == f"/repos/{REPO}/pulls/18":
+            truth.calls.append(request.url.path)
+            return httpx.Response(200, json=truth.pr)
+        return truth.handle(request)
+
+    injected = httpx.AsyncClient(transport=httpx.MockTransport(handle))
+    client.app.state.http_client = injected
+    delivery = str(uuid.uuid4())
+    second_id = None
+    try:
+        if other_conversation:
+            expected_conversation = _other_verified_lineage(client, truth, auth_headers)
+            assert valkey.xlen(stream) == 1  # Producer setup never erases or wakes the queue.
+            truth.payload["issue"]["number"] = 18
+            truth.payload["issue"]["pull_request"].update(
+                html_url=f"https://github.com/{REPO}/pull/18",
+                url=f"https://api.github.com/repos/{REPO}/pulls/18",
+            )
+        else:
+            expected_conversation = "1700000000.000001"
+        number = 18 if other_conversation else 17
+        truth.payload["comment"].update(
+            id=72, html_url=f"https://github.com/{REPO}/pull/{number}#issuecomment-72"
+        )
+        truth.comment = copy.deepcopy(truth.payload["comment"])
+        truth.comment["issue_url"] = f"https://api.github.com/repos/{REPO}/issues/{number}"
+        truth.comment["pull_request_url"] = f"https://api.github.com/repos/{REPO}/pulls/{number}"
+        second_id = parse_feedback("issue_comment", truth.payload, delivery).event_id
+        result = post_review(client, truth, delivery=delivery)
+        assert result.status_code == 200, result.text
+        assert result.json()["status"] == "feedback_queued", result.text
+        rows = review_rows(
+            "SELECT lineage_id,binding_id,status,turn FROM curie.github_review_feedback"
+        )
+        assert len(rows) == 2 and all(row["status"] == "queued" for row in rows)
+        assert len({row["binding_id"] for row in rows}) == 1
+        assert len({row["lineage_id"] for row in rows}) == (2 if other_conversation else 1)
+        assert {row["turn"]["conversation_id"] for row in rows} == {
+            "1700000000.000001", expected_conversation
+        }
+        assert valkey.xlen(stream) == 2
+        assert review_rows("SELECT id FROM curie.publication_review_reservations") == []
+    finally:
+        client.app.state.http_client = original_http
+        try:
+            client.portal.call(injected.aclose)
+        finally:
+            if second_id is not None:
+                valkey.delete(f"curie:github-review:{second_id}")

--- a/apps/api/tests/test_github_review_events.py
+++ b/apps/api/tests/test_github_review_events.py
@@ -1401,6 +1401,105 @@ def test_before_model_recheck_refuses_stale_binding_or_lineage_version(
     assert valkey.xlen(stream) == 1
 
 
+@pytest.mark.parametrize(
+    ("holder_kind", "mutation", "refusal"),
+    [
+        ("delivery", None, None),
+        ("mutator", None, None),
+        ("delivery", "UPDATE curie.agent_channels SET generation=generation+1",
+         "binding_no_longer_authorized"),
+        ("delivery", "UPDATE curie.thread_publication_lineages SET version=version+1",
+         "binding_or_lineage_changed"),
+    ],
+    ids=["audit-reference", "competing-mutator", "stale-binding", "stale-lineage"],
+)
+def test_review_outbox_recovers_under_delivery_reference_without_racing_mutators(
+    review_stack, holder_kind, mutation, refusal
+) -> None:
+    client, truth, valkey, stream = review_stack
+    # Admit through the real signed HTTP route while the fixture stream has
+    # the wrong type. Actual XADD fails, leaving the committed outbox eligible
+    # for recovery after removing this task-owned fault; neither store is mocked.
+    valkey.set(stream, "fixture-wrong-stream-type")
+    response = post_review(client, truth)
+    assert response.status_code == 200, response.text
+    assert response.json()["status"] == "feedback_waiting"
+    assert review_rows("SELECT status,error_code FROM curie.github_review_feedback") == [
+        {"status": "waiting", "error_code": "enqueue_unavailable"}
+    ]
+    assert valkey.get(stream) == "fixture-wrong-stream-type"
+    valkey.delete(stream)
+    review_rows("UPDATE curie.github_review_feedback SET next_attempt_at=NULL")
+    if mutation is not None:
+        review_rows(mutation)
+    event_id = truth.feedback.event_id
+    reconciler = client.app.state.github_review_reconciler
+
+    async def recover_with_holder() -> None:
+        engine = create_async_engine(get_settings().database_url)
+        try:
+            async with engine.connect() as holder, holder.begin() as transaction:
+                if holder_kind == "delivery":
+                    # A real child FK reference holds KEY SHARE on its parent
+                    # until commit, just like settling a concurrent audit row.
+                    # It must not prevent the outbox's non-key state update.
+                    await holder.execute(text("""
+                        INSERT INTO curie.github_review_deliveries (
+                          delivery_id,event_kind,action,body_sha256,sender_type,
+                          author_association,status,event_id
+                        ) SELECT :delivery,event_kind,action,body_sha256,sender_type,
+                          author_association,status,event_id
+                          FROM curie.github_review_deliveries WHERE delivery_id=:original
+                    """), {"delivery": uuid.uuid4(), "original": uuid.UUID(DELIVERY)})
+                    assert await holder.scalar(text(
+                        "SELECT count(*) FROM curie.github_review_deliveries WHERE event_id=:event"
+                    ), {"event": event_id}) == 2
+                else:
+                    assert await holder.scalar(text(
+                        "SELECT event_id FROM curie.github_review_feedback "
+                        "WHERE event_id=:event FOR NO KEY UPDATE"
+                    ), {"event": event_id}) == event_id
+                async with asyncio.timeout(5):
+                    enqueued = await reconciler.reconcile_once(event_id)
+                if holder_kind == "mutator":
+                    assert enqueued == 0
+                    assert valkey.xlen(stream) == 0
+                    assert await holder.scalar(text(
+                        "SELECT status FROM curie.github_review_feedback WHERE event_id=:event"
+                    ), {"event": event_id}) == "waiting"
+                else:
+                    assert enqueued == (0 if refusal else 1)
+                    assert await holder.scalar(text(
+                        "SELECT status FROM curie.github_review_feedback WHERE event_id=:event"
+                    ), {"event": event_id}) == ("refused" if refusal else "queued")
+                # Explicit release is part of the control: a real competing
+                # mutator must block this pass, then allow the next one through.
+                await transaction.rollback()
+            assert await reconciler.reconcile_once(event_id) == (
+                1 if holder_kind == "mutator" else 0
+            )
+        finally:
+            await engine.dispose()
+
+    client.portal.call(recover_with_holder)
+    rows = review_rows(
+        "SELECT event_id,status,error_code,stream_id FROM curie.github_review_feedback"
+    )
+    assert len(rows) == 1
+    assert rows[0]["event_id"] == event_id
+    assert rows[0]["status"] == ("refused" if refusal else "queued")
+    assert rows[0]["error_code"] == refusal
+    assert valkey.xlen(stream) == (0 if refusal else 1)
+    if refusal:
+        assert rows[0]["stream_id"] is None
+    else:
+        receipt, fields = valkey.xrange(stream)[0]
+        assert rows[0]["stream_id"] == receipt
+        assert json.loads(fields["payload"])["event_id"] == event_id
+        assert post_review(client, truth).json()["status"] == "feedback_duplicate"
+        assert valkey.xlen(stream) == 1
+
+
 def test_concurrent_distinct_delivery_headers_for_one_feedback_enqueue_once(review_stack) -> None:
     client, truth, valkey, stream = review_stack
     barrier = threading.Barrier(4)

--- a/apps/api/tests/test_github_review_events.py
+++ b/apps/api/tests/test_github_review_events.py
@@ -1,0 +1,998 @@
+"""GitHub sender fixtures through the feedback-normalization boundary.
+
+Payload families and action names are documented at
+https://docs.github.com/en/webhooks/webhook-events-and-payloads#issue_comment
+and the pull_request_review / pull_request_review_comment sections. These
+fixtures prove parsing and refusal only; HMAC, current GitHub truth and durable
+lineage authorization are exercised separately through the actual HTTP ingress.
+"""
+
+import asyncio
+import base64
+import copy
+import hashlib
+import hmac
+import json
+import socket
+import threading
+import uuid
+from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import ExitStack
+from dataclasses import replace
+
+import httpx
+import pytest
+from channel_protocol import scoped_conversation_id
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from curie_api.config import Settings, get_settings
+from curie_api.github_app import _RESOLVERS
+from curie_api.github_review_events import FeedbackIgnored, parse_feedback
+from curie_api.github_review_truth import BoundReviewLineage, verify_feedback_truth
+from curie_api.main import create_app
+from curie_test_support.valkey import connect_or_skip
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+DELIVERY = str(uuid.UUID(int=1))
+REPO = "acme-corp/acme-bot"
+HEAD = "a" * 40
+
+
+def feedback_payload(event: str = "issue_comment") -> dict:
+    user = {"id": 41, "login": "example-reviewer", "type": "User"}
+    feedback = {
+        "id": 71,
+        "body": "Please add a regression test before updating this PR.",
+        "user": user,
+        "created_at": "2026-09-05T01:00:00Z",
+        "updated_at": "2026-09-05T01:00:00Z",
+        "performed_via_github_app": None,
+        "author_association": "MEMBER",
+    }
+    result = {
+        "action": "created",
+        "installation": {"id": 11},
+        "repository": {"id": 21, "full_name": REPO},
+        "sender": copy.deepcopy(user),
+    }
+    pr = {
+        "number": 17,
+        "state": "open",
+        "html_url": f"https://github.com/{REPO}/pull/17",
+        "head": {"sha": HEAD, "ref": "curie/example", "repo": {"id": 21, "full_name": REPO}},
+        "base": {"repo": {"id": 21, "full_name": REPO}},
+    }
+    if event == "issue_comment":
+        result["issue"] = {
+            "number": 17,
+            "state": "open",
+            "pull_request": {
+                "html_url": pr["html_url"],
+                "url": f"https://api.github.com/repos/{REPO}/pulls/17",
+            },
+        }
+        feedback["html_url"] = f"{pr['html_url']}#issuecomment-71"
+        result["comment"] = feedback
+    elif event == "pull_request_review_comment":
+        feedback.update(
+            {
+                "html_url": f"{pr['html_url']}#discussion_r71",
+                "commit_id": HEAD,
+                "path": "src/example.py",
+                "line": 12,
+                "pull_request_review_id": 81,
+            }
+        )
+        result.update({"pull_request": pr, "comment": feedback})
+    else:
+        feedback.update(
+            {
+                "html_url": f"{pr['html_url']}#pullrequestreview-71",
+                "commit_id": HEAD,
+                "state": "changes_requested",
+                "submitted_at": "2026-09-05T01:00:00Z",
+            }
+        )
+        result.update({"action": "submitted", "pull_request": pr, "review": feedback})
+    return result
+
+
+@pytest.mark.parametrize(
+    "event", ["issue_comment", "pull_request_review_comment", "pull_request_review"]
+)
+def test_each_human_review_family_retains_canonical_identity_and_provenance(event: str) -> None:
+    result = parse_feedback(event, feedback_payload(event), DELIVERY)
+    assert result.repo_full_name == REPO
+    assert result.pr_number == 17
+    assert result.sender_id == 41 and result.sender_login == "example-reviewer"
+    assert result.feedback_id == 71 and result.installation_id == 11
+    assert result.body == "Please add a regression test before updating this PR."
+    assert result.url.startswith(f"https://github.com/{REPO}/pull/17#")
+    assert (
+        result.event_id
+        == parse_feedback(event, feedback_payload(event), str(uuid.UUID(int=2))).event_id
+    )
+    if event == "pull_request_review_comment":
+        assert result.path == "src/example.py" and result.line == 12 and result.review_id == 81
+
+
+@pytest.mark.parametrize("action", ["edited", "deleted", "dismissed"])
+def test_non_creation_actions_are_observably_ignored(action: str) -> None:
+    payload = feedback_payload()
+    payload["action"] = action
+    with pytest.raises(FeedbackIgnored, match="unsupported_action"):
+        parse_feedback("issue_comment", payload, DELIVERY)
+
+
+@pytest.mark.parametrize(
+    "mutation,reason",
+    [
+        (lambda p: p.pop("installation"), "invalid_installation"),
+        (lambda p: p["installation"].update(id=True), "invalid_installation"),
+        (lambda p: p["repository"].update(full_name="acme-corp/../other"), "invalid_repository"),
+        (lambda p: p["sender"].update(id=42), "sender_mismatch"),
+        (lambda p: p["sender"].update(type="Bot"), "non_human_sender"),
+        (lambda p: p["sender"].update(login="ghost"), "non_human_sender"),
+        (lambda p: p["comment"]["user"].update(type="Bot"), "non_human_sender"),
+        (lambda p: p["comment"].update(performed_via_github_app={"id": 51}), "app_authored"),
+        (lambda p: p["issue"].pop("pull_request"), "not_pull_request"),
+        (lambda p: p["issue"].update(state="closed"), "terminal_pull_request"),
+        (lambda p: p["comment"].update(body="  "), "empty_feedback"),
+        (
+            lambda p: p["comment"].update(html_url="https://evil.example.com/private-sentinel"),
+            "invalid_feedback_url",
+        ),
+        (lambda p: p["comment"].update(updated_at="2026-09-05T01:00:01Z"), "edited_feedback"),
+    ],
+)
+def test_invalid_or_non_human_feedback_cannot_be_normalized(mutation, reason: str) -> None:
+    payload = feedback_payload()
+    mutation(payload)
+    with pytest.raises(FeedbackIgnored, match=reason) as caught:
+        parse_feedback("issue_comment", payload, DELIVERY)
+    assert "private-sentinel" not in str(caught.value)
+
+
+def test_delivery_header_must_be_a_real_uuid() -> None:
+    with pytest.raises(FeedbackIgnored, match="invalid_delivery"):
+        parse_feedback("issue_comment", feedback_payload(), "not-a-delivery-private-sentinel")
+
+
+def test_app_reinstallation_does_not_change_feedback_execution_identity() -> None:
+    payload = feedback_payload()
+    original = parse_feedback("issue_comment", payload, DELIVERY)
+    payload["installation"]["id"] = 12
+    replacement = parse_feedback("issue_comment", payload, str(uuid.UUID(int=3)))
+    assert replacement.event_id == original.event_id
+    assert replacement.installation_id != original.installation_id
+
+
+@pytest.mark.parametrize("association", [None, "NONE", "CONTRIBUTOR", "FIRST_TIMER", [], "member"])
+def test_drive_by_or_malformed_sender_association_cannot_authorize_feedback(association) -> None:
+    payload = feedback_payload()
+    payload["comment"]["author_association"] = association
+    with pytest.raises(FeedbackIgnored, match="unauthorized_association"):
+        parse_feedback("issue_comment", payload, DELIVERY)
+
+
+@pytest.mark.parametrize("association", ["OWNER", "MEMBER", "COLLABORATOR"])
+def test_signed_member_associations_are_retained_and_verified(association: str) -> None:
+    payload = feedback_payload()
+    payload["comment"]["author_association"] = association
+    assert parse_feedback("issue_comment", payload, DELIVERY).author_association == association
+
+
+def test_review_ingress_is_disabled_by_default_and_refuses_incomplete_enablement() -> None:
+    from pydantic import ValidationError
+
+    assert Settings().github_review_ingress_enabled is False
+    with pytest.raises(ValidationError, match="GitHub review ingress"):
+        Settings(github_review_ingress_enabled=True)
+
+
+@pytest.mark.parametrize("state", [None, 1, {}, [], "approved", "dismissed"])
+def test_non_actionable_or_malformed_review_state_has_a_redacted_refusal(state) -> None:
+    payload = feedback_payload("pull_request_review")
+    payload["review"]["state"] = state
+    with pytest.raises(FeedbackIgnored, match="non_actionable_review"):
+        parse_feedback("pull_request_review", payload, DELIVERY)
+
+
+class GitHubTruth:
+    """Only GitHub HTTP is replaced; signer/resolver/verifier execute normally.
+
+    REST comment identities, issue_url and pull_request_url follow:
+    https://docs.github.com/en/rest/issues/comments#get-an-issue-comment
+    https://docs.github.com/en/rest/pulls/comments#get-a-review-comment-for-a-pull-request
+    https://docs.github.com/en/rest/pulls/reviews#get-a-review-for-a-pull-request
+    """
+
+    def __init__(self, event: str, key: str):
+        self.payload = feedback_payload(event)
+        self.feedback = parse_feedback(event, self.payload, DELIVERY)
+        self.settings = Settings(
+            github_app_id="51",
+            github_app_private_key=key,
+            github_token="fixture-pat-must-not-be-used",
+        )
+        self.lineage = BoundReviewLineage(REPO, 17, "curie/example", HEAD)
+        self.calls: list[str] = []
+        self.installation = {"id": 11}
+        self.installation_status = 200
+        self.repo = {"id": 21, "full_name": REPO}
+        self.pr = copy.deepcopy(feedback_payload("pull_request_review")["pull_request"])
+        self.pr["merged"] = False
+        self.comment = copy.deepcopy(self.payload.get("comment", self.payload.get("review")))
+        self.comment["issue_url"] = f"https://api.github.com/repos/{REPO}/issues/17"
+        self.comment["pull_request_url"] = f"https://api.github.com/repos/{REPO}/pulls/17"
+        self.feedback_status = 200
+
+    def handle(self, request: httpx.Request) -> httpx.Response:
+        self.calls.append(request.url.path)
+        assert "fixture-pat" not in request.headers.get("Authorization", "")
+        if request.url.path.endswith("/installation"):
+            return httpx.Response(self.installation_status, json=self.installation)
+        if request.url.path.endswith("/access_tokens"):
+            return httpx.Response(
+                201,
+                json={
+                    "token": "fixture-app-token-private-sentinel",
+                    "expires_at": "2999-01-01T00:00:00Z",
+                },
+            )
+        assert request.headers["Authorization"] == "Bearer fixture-app-token-private-sentinel"
+        if request.url.path == f"/repos/{REPO}":
+            return httpx.Response(200, json=self.repo)
+        if request.url.path == f"/repos/{REPO}/pulls/17":
+            return httpx.Response(200, json=self.pr)
+        return httpx.Response(
+            self.feedback_status,
+            json=self.comment,
+            headers={"Location": "https://evil.example.com/private-sentinel"},
+        )
+
+
+@pytest.fixture(scope="module")
+def review_app_key() -> str:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+
+
+async def verify_truth(truth: GitHubTruth, monkeypatch: pytest.MonkeyPatch) -> str:
+    real_client = httpx.Client
+    monkeypatch.setattr(
+        "curie_api.github_app.httpx.Client",
+        lambda *a, **kw: real_client(transport=httpx.MockTransport(truth.handle)),
+    )
+    _RESOLVERS.clear()
+    try:
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(truth.handle), follow_redirects=True
+        ) as client:
+            return await verify_feedback_truth(
+                truth.feedback,
+                truth.lineage,
+                settings=truth.settings,
+                client=client,
+            )
+    finally:
+        _RESOLVERS.clear()
+
+
+@pytest.mark.parametrize(
+    "event", ["issue_comment", "pull_request_review_comment", "pull_request_review"]
+)
+def test_current_app_repo_pr_and_human_feedback_must_independently_agree(
+    event: str,
+    review_app_key: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    truth = GitHubTruth(event, review_app_key)
+    assert asyncio.run(verify_truth(truth, monkeypatch)) == HEAD
+    assert truth.calls[0] == f"/repos/{REPO}/installation"
+    assert f"/repos/{REPO}" in truth.calls
+    assert f"/repos/{REPO}/pulls/17" in truth.calls
+
+
+@pytest.mark.parametrize(
+    "mutation,reason",
+    [
+        (lambda t: t.installation.update(id=12), "installation_unverified"),
+        (lambda t: setattr(t, "installation_status", 302), "installation_unverified"),
+        (lambda t: t.repo.update(id=22), "repository_mismatch"),
+        (lambda t: t.pr["head"].update(ref="other-branch"), "pull_request_mismatch"),
+        (lambda t: t.pr["head"].update(sha="b" * 40), "stale_feedback_head"),
+        (lambda t: t.pr["base"]["repo"].update(id=22), "repository_mismatch"),
+        (lambda t: t.pr.update(state="closed", merged=True), "terminal_pull_request"),
+        (
+            lambda t: t.comment.update(body="forged-current-body-private-sentinel"),
+            "feedback_changed",
+        ),
+        (lambda t: t.comment["user"].update(id=42), "feedback_changed"),
+        (lambda t: t.comment.update(updated_at="2026-09-05T01:00:01Z"), "edited_feedback"),
+        (
+            lambda t: t.comment.update(issue_url=f"https://api.github.com/repos/{REPO}/issues/18"),
+            "feedback_target_mismatch",
+        ),
+        (lambda t: setattr(t, "feedback_status", 404), "feedback_unavailable"),
+        (lambda t: setattr(t, "feedback_status", 401), "feedback_unavailable"),
+        (lambda t: setattr(t, "feedback_status", 302), "feedback_unavailable"),
+    ],
+)
+def test_signed_claims_cannot_override_current_github_authority(
+    mutation,
+    reason: str,
+    review_app_key: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    truth = GitHubTruth("issue_comment", review_app_key)
+    mutation(truth)
+    with pytest.raises(FeedbackIgnored, match=reason) as caught:
+        asyncio.run(verify_truth(truth, monkeypatch))
+    assert "private-sentinel" not in str(caught.value)
+    assert not any("private-sentinel" in path for path in truth.calls)
+
+
+def test_a_user_pat_is_not_product_app_installation_proof(
+    review_app_key: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    truth = GitHubTruth("issue_comment", review_app_key)
+    truth.settings = Settings(github_token="fixture-pat-must-not-be-used")
+    with pytest.raises(FeedbackIgnored, match="installation_unverified"):
+        asyncio.run(verify_truth(truth, monkeypatch))
+    assert truth.calls == []
+
+
+def test_webhook_repo_cannot_select_a_different_persisted_lineage(
+    review_app_key: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    truth = GitHubTruth("issue_comment", review_app_key)
+    truth.lineage = replace(truth.lineage, repo_full_name="acme-corp/other-bot")
+    with pytest.raises(FeedbackIgnored, match="lineage_mismatch"):
+        asyncio.run(verify_truth(truth, monkeypatch))
+    assert truth.calls == []
+
+
+@pytest.mark.parametrize("surface", ["installation", "feedback"])
+@pytest.mark.parametrize("status", [401, 403, 404, 429, 503])
+def test_current_authority_outage_is_retryable_and_recovers(
+    surface: str,
+    status: int,
+    review_app_key: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from curie_api.github_review_events import FeedbackUnavailable
+
+    truth = GitHubTruth("issue_comment", review_app_key)
+    # GitHub hides private resources behind 404 and uses 403 for rate limits.
+    # https://docs.github.com/en/rest/using-the-rest-api/troubleshooting-the-rest-api
+    setattr(truth, f"{surface}_status", status)
+    with pytest.raises(FeedbackUnavailable):
+        asyncio.run(verify_truth(truth, monkeypatch))
+    setattr(truth, f"{surface}_status", 200)
+    assert asyncio.run(verify_truth(truth, monkeypatch)) == HEAD
+
+
+def test_verified_reinstallation_retires_old_cached_token_before_any_repo_read(
+    review_app_key: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from curie_api.github_app import GitHubCredentials
+
+    truth = GitHubTruth("issue_comment", review_app_key)
+    requests: list[httpx.Request] = []
+
+    def github(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.url.path.endswith("/access_tokens"):
+            installation = request.url.path.split("/")[-2]
+            return httpx.Response(
+                201,
+                json={
+                    "token": f"fixture-installation-{installation}",
+                    "expires_at": "2999-01-01T00:00:00Z",
+                },
+            )
+        return truth.handle(request)
+
+    real_client = httpx.Client
+    monkeypatch.setattr(
+        "curie_api.github_app.httpx.Client",
+        lambda *a, **kw: real_client(transport=httpx.MockTransport(github)),
+    )
+    credentials = GitHubCredentials(truth.settings)
+    assert credentials.token_for_verified_installation(REPO, 11) == "fixture-installation-11"
+    # An unchanged installation may reuse its cache; a different installation
+    # must mint a new token even when the previous token has not yet expired.
+    assert credentials.token_for_verified_installation(REPO, 11) == "fixture-installation-11"
+    truth.installation["id"] = 12
+    assert credentials.token_for_verified_installation(REPO, 12) == "fixture-installation-12"
+    assert [r.url.path for r in requests if r.method == "POST"] == [
+        "/app/installations/11/access_tokens",
+        "/app/installations/12/access_tokens",
+    ]
+
+
+def review_rows(statement: str, parameters: dict | None = None) -> list[dict]:
+    async def execute() -> list[dict]:
+        engine = create_async_engine(get_settings().database_url)
+        try:
+            async with engine.begin() as connection:
+                result = await connection.execute(text(statement), parameters or {})
+                return [dict(row) for row in result.mappings()] if result.returns_rows else []
+        finally:
+            await engine.dispose()
+
+    return asyncio.run(execute())
+
+
+@pytest.fixture
+def review_stack(
+    clean_db: None,
+    request: pytest.FixtureRequest,
+    monkeypatch: pytest.MonkeyPatch,
+    review_app_key: str,
+) -> Iterator[tuple[TestClient, GitHubTruth, object, str]]:
+    """Real migrated Postgres/Valkey/API, with only GitHub HTTP replaced.
+
+    The database seed represents a PR already published by #2274. Setting that
+    historical fixture is not an exercised approval or GitHub publication.
+    """
+    event = getattr(request, "param", "issue_comment")
+    truth = GitHubTruth(event, review_app_key)
+    stream = f"test:curie:github-review:{uuid.uuid4().hex}"
+    for key, value in {
+        "RUNS_STREAM": stream,
+        "INTERNAL_WORKER_TOKEN": "fixture-review-worker-token",
+        "GITHUB_WEBHOOK_SECRET": "fixture-review-webhook-secret",
+        "GITHUB_REVIEW_INGRESS_ENABLED": "true",
+        "GITHUB_APP_ID": "51",
+        "GITHUB_APP_PRIVATE_KEY": review_app_key,
+        "GITHUB_TOKEN": "",
+        "GITHUB_REPO_ALLOWLIST": '["acme-corp/*"]',
+        "GITHUB_REVIEW_RECONCILER_INTERVAL_S": "0",
+        "APPROVAL_SWEEP_INTERVAL_S": "0",
+        "RESUME_RECONCILER_ENABLED": "false",
+        "DEAD_LETTER_WATCH_INTERVAL_S": "0",
+    }.items():
+        monkeypatch.setenv(key, value)
+    get_settings.cache_clear()
+    _RESOLVERS.clear()
+    valkey = connect_or_skip(decode_responses=True)
+    with ExitStack() as owned:
+        owned.callback(get_settings.cache_clear)
+        owned.callback(_RESOLVERS.clear)
+        owned.callback(valkey.close)
+        owned.callback(
+            valkey.delete,
+            stream,
+            f"{stream}:dead",
+            f"curie:github-review:{truth.feedback.event_id}",
+        )
+        client = owned.enter_context(TestClient(create_app()))
+        real_client = httpx.Client
+        monkeypatch.setattr(
+            "curie_api.github_app.httpx.Client",
+            lambda *a, **kw: real_client(transport=httpx.MockTransport(truth.handle)),
+        )
+        external = httpx.AsyncClient(transport=httpx.MockTransport(truth.handle))
+        owned.callback(client.portal.call, external.aclose)
+        client.app.state.http_client = external
+        auth = {"X-API-Key": get_settings().api_key}
+        agent = client.post(
+            "/agents",
+            headers=auth,
+            json={
+                "name": f"acme-review-{uuid.uuid4().hex[:8]}",
+                "repo_full_name": REPO,
+                "channel": {"kind": "slack", "address": "C0EXAMPLE1"},
+            },
+        )
+        assert agent.status_code == 201, agent.text
+        agent_id = agent.json()["id"]
+        version = client.post(
+            f"/agents/{agent_id}/versions",
+            headers=auth,
+            json={"version_label": "fixture", "created_by": "operator"},
+        )
+        assert version.status_code == 201, version.text
+        deployment = client.post(
+            "/deployments",
+            headers=auth,
+            json={
+                "agent_id": agent_id,
+                "version_id": version.json()["id"],
+                "environment": "dev",
+            },
+        )
+        assert deployment.status_code == 201, deployment.text
+        selected = client.post(
+            f"/v1/internal/workspaces/{deployment.json()['id']}/selection",
+            headers={"X-Curie-Worker-Token": "fixture-review-worker-token"},
+            json={
+                "conversation_id": scoped_conversation_id(
+                    "slack", "C0EXAMPLE1", "1700000000.000001"
+                ),
+                "author": "U0REQUEST1",
+                "repo_full_name": REPO,
+            },
+        )
+        assert selected.status_code == 200, selected.text
+        publication = client.post(
+            "/v1/internal/publications",
+            headers={
+                "X-Curie-Worker-Token": "fixture-review-worker-token",
+            },
+            json={
+                "deployment_id": deployment.json()["id"],
+                "conversation_id": "1700000000.000001",
+                "repo_full_name": REPO,
+                "author": "U0REQUEST1",
+                "summary": "Fixture publication",
+                "reply_kind": "slack",
+                "reply_channel": "C0EXAMPLE1",
+                "reply_placeholder": "1700000000.000002",
+                "dedupe_key": f"fixture-{uuid.uuid4()}",
+                "base_sha": HEAD,
+                "patch_b64": base64.b64encode(b"diff --git a/a b/a\n").decode(),
+                "changed_paths": ["a"],
+                "expires_in_seconds": 600,
+            },
+        )
+        assert publication.status_code == 201, publication.text
+        lineage_id = publication.json()["lineage_id"]
+        branch = publication.json()["branch"]
+        truth.pr["head"]["ref"] = branch
+        review_rows(
+            "UPDATE curie.thread_publication_lineages SET head_sha=:head, pr_number=17, "
+            "pr_url=:url, version=2 WHERE id=:id",
+            {"head": HEAD, "url": f"https://github.com/{REPO}/pull/17", "id": lineage_id},
+        )
+        review_rows(
+            "UPDATE curie.publications SET status='succeeded', outcome_history_ready_at=now(), "
+            "result_reported_at=now(), terminal_at=now() WHERE id=:id",
+            {"id": publication.json()["id"]},
+        )
+        yield client, truth, valkey, stream
+
+
+def post_review(
+    client: TestClient,
+    truth: GitHubTruth,
+    *,
+    delivery: str = DELIVERY,
+    signature: str | None = None,
+) -> httpx.Response:
+    body = json.dumps(truth.payload).encode()
+    signature = (
+        signature
+        or "sha256="
+        + hmac.new(
+            b"fixture-review-webhook-secret",
+            body,
+            hashlib.sha256,
+        ).hexdigest()
+    )
+    return client.post(
+        "/github/webhook",
+        content=body,
+        headers={
+            "X-GitHub-Event": truth.feedback.event,
+            "X-GitHub-Delivery": delivery,
+            "X-Hub-Signature-256": signature,
+            "Content-Type": "application/json",
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    "review_stack",
+    [
+        "issue_comment",
+        "pull_request_review_comment",
+        "pull_request_review",
+    ],
+    indirect=True,
+)
+def test_real_ingress_persists_and_enqueues_exactly_one_honest_bound_turn(review_stack) -> None:
+    from aci_protocol import parse_queued_turn
+
+    client, truth, valkey, stream = review_stack
+    first = post_review(client, truth)
+    assert first.status_code == 200, first.text
+    assert first.json()["status"] == "feedback_queued"
+    for delivery in (DELIVERY, str(uuid.UUID(int=2))):
+        duplicate = post_review(client, truth, delivery=delivery)
+        assert duplicate.status_code == 200, duplicate.text
+        assert duplicate.json()["status"] == "feedback_duplicate"
+    entries = valkey.xrange(stream)
+    assert len(entries) == 1
+    turn = parse_queued_turn(entries[0][1]["payload"])
+    assert turn.event_id == truth.feedback.event_id
+    assert turn.conversation_id == "1700000000.000001"
+    assert turn.reply_handle.kind == "slack" and turn.reply_handle.channel == "C0EXAMPLE1"
+    assert turn.reply_handle.placeholder is None
+    assert turn.author == "github:41:example-reviewer"
+    assert not turn.source.is_job
+    assert truth.feedback.body in turn.text and truth.feedback.url in turn.text
+    assert "fixture-review-worker-token" not in entries[0][1]["payload"]
+    assert "fixture-app-token" not in entries[0][1]["payload"]
+    rows = review_rows("SELECT status, stream_id, version FROM curie.github_review_feedback")
+    assert rows == [{"status": "queued", "stream_id": entries[0][0], "version": 2}]
+
+
+def test_invalid_hmac_cannot_read_github_persist_or_enqueue(review_stack) -> None:
+    client, truth, valkey, stream = review_stack
+    response = post_review(client, truth, signature="sha256=invalid")
+    assert response.status_code == 401
+    assert truth.calls == []
+    assert valkey.xlen(stream) == 0
+    assert review_rows("SELECT event_id FROM curie.github_review_feedback") == []
+
+
+def test_disabled_review_ingress_does_not_read_authority_or_enqueue(
+    review_stack, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    client, truth, valkey, stream = review_stack
+    monkeypatch.setenv("GITHUB_REVIEW_INGRESS_ENABLED", "false")
+    get_settings.cache_clear()
+    response = post_review(client, truth)
+    assert response.status_code == 200 and response.json()["status"] == "feedback_disabled"
+    assert truth.calls == []
+    assert review_rows("SELECT event_id FROM curie.github_review_feedback") == []
+    assert valkey.xlen(stream) == 0
+
+
+def test_binding_quota_refuses_new_feedback_and_keeps_an_observable_row(review_stack) -> None:
+    client, truth, valkey, stream = review_stack
+    client.app.state.github_review_reconciler._settings.channel_binding_backlog_limit = 0
+    response = post_review(client, truth)
+    assert response.status_code == 200 and response.json()["status"] == "feedback_refused"
+    assert valkey.xlen(stream) == 0
+    rows = review_rows("SELECT status,error_code FROM curie.github_review_feedback")
+    assert rows == [{"status": "refused", "error_code": "binding_backlog_quota"}]
+    assert post_review(client, truth).json()["status"] == "feedback_duplicate"
+    assert valkey.xlen(stream) == 0
+
+
+def test_real_enqueue_refusal_backs_off_then_recovers_without_second_quota(review_stack) -> None:
+    import redis.asyncio as redis
+
+    client, truth, valkey, stream = review_stack
+    username = f"review-test-{uuid.uuid4().hex}"
+    password = "fixture-owned-valkey-acl-token"
+    # Only this task-created ACL identity loses XADD. The backing server and
+    # other clients remain healthy; no Postgres/Valkey service is mocked.
+    valkey.execute_command("ACL", "SETUSER", username, "on", f">{password}", "~*", "+@all", "-xadd")
+    restricted = redis.Redis.from_url(
+        str(httpx.URL(get_settings().valkey_dsn()).copy_with(username=username, password=password)),
+        decode_responses=True,
+    )
+    reconciler = client.app.state.github_review_reconciler
+    original = reconciler._valkey
+    reconciler._valkey = restricted
+    try:
+        assert client.portal.call(restricted.ping) is True
+        response = post_review(client, truth)
+        assert response.json()["status"] == "feedback_waiting"
+        row = review_rows(
+            "SELECT enqueue_attempts,quota_taken,next_attempt_at FROM curie.github_review_feedback"
+        )[0]
+        assert row["enqueue_attempts"] == 1 and row["quota_taken"] is True
+        assert row["next_attempt_at"] is not None and valkey.xlen(stream) == 0
+        assert client.portal.call(reconciler.reconcile_once) == 0
+        assert (
+            review_rows("SELECT enqueue_attempts FROM curie.github_review_feedback")[0][
+                "enqueue_attempts"
+            ]
+            == 1
+        )
+        # Queue several real scans behind one DB connection. They can all read
+        # the due candidate before the first locked attempt updates its retry
+        # deadline; later locks must recheck that deadline rather than burn it.
+        review_rows("UPDATE curie.github_review_feedback SET next_attempt_at=NULL")
+
+        async def competing_passes() -> list[int]:
+            from curie_api.github_review_store import GitHubReviewReconciler
+            from sqlalchemy.ext.asyncio import async_sessionmaker
+
+            engine = create_async_engine(get_settings().database_url, pool_size=1, max_overflow=0)
+            try:
+                contender = GitHubReviewReconciler(
+                    async_sessionmaker(engine, expire_on_commit=False), restricted, get_settings()
+                )
+                return await asyncio.gather(*(contender.reconcile_once() for _ in range(4)))
+            finally:
+                await engine.dispose()
+
+        assert client.portal.call(competing_passes) == [0, 0, 0, 0]
+        assert (
+            review_rows("SELECT enqueue_attempts FROM curie.github_review_feedback")[0][
+                "enqueue_attempts"
+            ]
+            == 2
+        )
+        valkey.execute_command("ACL", "SETUSER", username, "+xadd")
+        review_rows(
+            "UPDATE curie.github_review_feedback SET next_attempt_at=now()-interval '1 second'"
+        )
+        assert client.portal.call(reconciler.reconcile_once) == 1
+        assert valkey.xlen(stream) == 1
+        assert post_review(client, truth).json()["status"] == "feedback_duplicate"
+        assert valkey.xlen(stream) == 1
+    finally:
+        reconciler._valkey = original
+        client.portal.call(restricted.aclose)
+        valkey.execute_command("ACL", "DELUSER", username)
+
+
+def test_signed_feedback_with_wrong_current_head_cannot_create_a_turn(review_stack) -> None:
+    client, truth, valkey, stream = review_stack
+    truth.pr["head"]["sha"] = "b" * 40
+    response = post_review(client, truth)
+    assert response.status_code == 200, response.text
+    assert response.json()["status"] == "feedback_ignored"
+    assert response.json()["errors"] == [{"code": "stale_feedback_head"}]
+    assert valkey.xlen(stream) == 0
+    assert review_rows("SELECT event_id FROM curie.github_review_feedback") == []
+
+
+def test_before_model_revalidation_rejects_edit_and_never_accepts_platform_key(
+    review_stack,
+) -> None:
+    client, truth, valkey, stream = review_stack
+    assert post_review(client, truth).json()["status"] == "feedback_queued"
+    turn = json.loads(valkey.xrange(stream)[0][1]["payload"])
+    deployment = review_rows("SELECT deployment_id FROM curie.thread_publication_lineages")[0]
+    payload = {"turn": turn, "deployment_id": str(deployment["deployment_id"])}
+    path = f"/v1/internal/github/reviews/{truth.feedback.event_id}/verify"
+    unauthenticated = client.post(path, json=payload, headers={"X-API-Key": get_settings().api_key})
+    assert unauthenticated.status_code == 401
+    headers = {"X-Curie-Worker-Token": "fixture-review-worker-token"}
+    verified = client.post(path, json=payload, headers=headers)
+    assert verified.status_code == 200, verified.text
+    assert verified.json()["head_sha"] == HEAD
+    assert verified.json()["sender"] == "github:41:example-reviewer"
+    truth.comment["body"] = "edited-private-sentinel"
+    rejected = client.post(path, json=payload, headers=headers)
+    assert rejected.status_code == 409
+    assert "private-sentinel" not in rejected.text
+    assert valkey.xlen(stream) == 1
+
+
+def test_production_worker_client_uses_actual_api_without_github_or_slack_authority(
+    review_stack,
+) -> None:
+    from aci_protocol import parse_queued_turn
+    from curie_worker.approvals import ApprovalBackendError, ApprovalClient
+
+    client, truth, valkey, stream = review_stack
+    assert post_review(client, truth).json()["status"] == "feedback_queued"
+    turn = parse_queued_turn(valkey.xrange(stream)[0][1]["payload"])
+    deployment_id = review_rows("SELECT deployment_id FROM curie.thread_publication_lineages")[0][
+        "deployment_id"
+    ]
+
+    async def exercise() -> None:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=client.app),
+            base_url="http://api.example.test",
+        ) as http:
+            worker = ApprovalClient(
+                api_base_url="http://api.example.test",
+                api_key="",
+                client=http,
+                read_timeout_s=2,
+                worker_token="fixture-review-worker-token",
+            )
+            verified = await worker.verify_review_feedback(turn, deployment_id)
+            assert verified.head_sha == HEAD
+            assert verified.sender == "github:41:example-reviewer"
+            assert truth.feedback.url in verified.receipt
+            truth.feedback_status = 404
+            with pytest.raises(ApprovalBackendError):
+                await worker.verify_review_feedback(turn, deployment_id)
+
+    client.portal.call(exercise)
+
+
+def test_review_verification_uses_its_own_budget_over_actual_api_http(review_stack) -> None:
+    """The production card-read budget is too short for fresh GitHub reads.
+
+    Uvicorn serves the actual API with real Postgres/Valkey; only external GitHub
+    responses are controlled. ASGITransport does not enforce HTTP timeouts, so
+    this regression deliberately uses a loopback socket and a delayed provider.
+    """
+    import uvicorn
+    from aci_protocol import parse_queued_turn
+    from curie_worker.approvals import ApprovalBackendError, ApprovalClient
+
+    client, truth, valkey, stream = review_stack
+    assert post_review(client, truth).json()["status"] == "feedback_queued"
+    turn = parse_queued_turn(valkey.xrange(stream)[0][1]["payload"])
+    deployment_id = review_rows("SELECT deployment_id FROM curie.thread_publication_lineages")[0][
+        "deployment_id"
+    ]
+
+    async def exercise() -> None:
+        async def delayed_github(request: httpx.Request) -> httpx.Response:
+            if request.url.path.endswith("/comments/71"):
+                await asyncio.sleep(2.2)
+            return truth.handle(request)
+
+        sock = socket.socket()
+        sock.bind(("127.0.0.1", 0))
+        sock.listen(16)
+        server = uvicorn.Server(
+            uvicorn.Config(client.app, lifespan="off", log_level="critical", access_log=False)
+        )
+        task = asyncio.create_task(server.serve(sockets=[sock]))
+        previous = client.app.state.http_client
+        try:
+            async with asyncio.timeout(5):
+                while not server.started:
+                    await asyncio.sleep(0.01)
+            async with (
+                httpx.AsyncClient(transport=httpx.MockTransport(delayed_github)) as github,
+                httpx.AsyncClient() as http,
+            ):
+                client.app.state.http_client = github
+                worker = ApprovalClient(
+                    api_base_url=f"http://127.0.0.1:{sock.getsockname()[1]}",
+                    api_key="",
+                    client=http,
+                    read_timeout_s=2.0,
+                    worker_token="fixture-review-worker-token",
+                )
+                assert (await worker.verify_review_feedback(turn, deployment_id)).head_sha == HEAD
+                # A mixed-token rollout is infrastructure unavailability and
+                # cannot become a terminal policy refusal that ACKs the turn.
+                wrong_token = ApprovalClient(
+                    api_base_url=f"http://127.0.0.1:{sock.getsockname()[1]}",
+                    api_key="",
+                    client=http,
+                    read_timeout_s=2.0,
+                    worker_token="fixture-old-worker-token",
+                )
+                with pytest.raises(ApprovalBackendError):
+                    await wrong_token.verify_review_feedback(turn, deployment_id)
+        finally:
+            client.app.state.http_client = previous
+            server.should_exit = True
+            try:
+                await asyncio.wait_for(task, 5)
+            finally:
+                sock.close()
+
+    client.portal.call(exercise)
+
+
+def test_real_queue_receipt_survives_database_commit_failure_without_second_turn(
+    review_stack,
+) -> None:
+    from sqlalchemy.exc import DBAPIError
+
+    client, truth, valkey, stream = review_stack
+    # Task-owned disposable DB fault: the real outbox XADD succeeds, then the
+    # real transaction fails while flushing its queued mark. No service mocked.
+    review_rows("""
+        CREATE FUNCTION curie.review_test_reject_queued() RETURNS trigger LANGUAGE plpgsql AS $$
+        BEGIN
+          IF NEW.status = 'queued' THEN RAISE EXCEPTION 'task-owned queued-mark failure'; END IF;
+          RETURN NEW;
+        END $$
+    """)
+    review_rows("""
+        CREATE TRIGGER review_test_reject_queued BEFORE UPDATE ON curie.github_review_feedback
+        FOR EACH ROW EXECUTE FUNCTION curie.review_test_reject_queued()
+    """)
+    try:
+        with pytest.raises(DBAPIError):
+            post_review(client, truth)
+        assert valkey.xlen(stream) == 1
+        assert review_rows("SELECT status, version FROM curie.github_review_feedback") == [
+            {"status": "waiting", "version": 1}
+        ]
+    finally:
+        review_rows("DROP TRIGGER review_test_reject_queued ON curie.github_review_feedback")
+        review_rows("DROP FUNCTION curie.review_test_reject_queued()")
+    assert client.portal.call(client.app.state.github_review_reconciler.reconcile_once) == 1
+    assert client.portal.call(client.app.state.github_review_reconciler.reconcile_once) == 0
+    assert valkey.xlen(stream) == 1
+    assert review_rows("SELECT status, version FROM curie.github_review_feedback") == [
+        {"status": "queued", "version": 2}
+    ]
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "UPDATE curie.agent_channels SET generation=generation+1",
+        "UPDATE curie.thread_publication_lineages SET version=version+1",
+    ],
+)
+def test_before_model_recheck_refuses_stale_binding_or_lineage_version(
+    review_stack, mutation
+) -> None:
+    client, truth, valkey, stream = review_stack
+    assert post_review(client, truth).json()["status"] == "feedback_queued"
+    turn = json.loads(valkey.xrange(stream)[0][1]["payload"])
+    deployment_id = review_rows("SELECT deployment_id FROM curie.thread_publication_lineages")[0][
+        "deployment_id"
+    ]
+    review_rows(mutation)
+    response = client.post(
+        f"/v1/internal/github/reviews/{truth.feedback.event_id}/verify",
+        json={"turn": turn, "deployment_id": str(deployment_id)},
+        headers={"X-Curie-Worker-Token": "fixture-review-worker-token"},
+    )
+    assert response.status_code == 409, response.text
+    assert response.json()["detail"]["code"] == "binding_or_lineage_changed"
+    assert valkey.xlen(stream) == 1
+
+
+def test_concurrent_distinct_delivery_headers_for_one_feedback_enqueue_once(review_stack) -> None:
+    client, truth, valkey, stream = review_stack
+    barrier = threading.Barrier(4)
+
+    def deliver(index: int) -> tuple[int, str]:
+        barrier.wait(timeout=10)
+        response = post_review(client, truth, delivery=str(uuid.UUID(int=100 + index)))
+        return response.status_code, response.json()["status"]
+
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        results = list(pool.map(deliver, range(4)))
+    assert sorted(results) == [(200, "feedback_duplicate")] * 3 + [(200, "feedback_queued")]
+    assert valkey.xlen(stream) == 1
+    assert len(review_rows("SELECT event_id FROM curie.github_review_feedback")) == 1
+
+
+def test_ambiguous_persisted_pr_cannot_choose_a_conversation_from_webhook_contents(
+    review_stack,
+) -> None:
+    client, truth, valkey, stream = review_stack
+    review_rows(
+        """
+        INSERT INTO curie.thread_publication_lineages (
+          id,agent_id,deployment_id,conversation_id,repo_full_name,base_sha,branch,
+          pr_number,pr_url,head_sha,status,version,latest_revision
+        ) SELECT :id,agent_id,deployment_id,'other-conversation',repo_full_name,base_sha,
+          'curie/other-conversation',pr_number,pr_url,head_sha,status,version,latest_revision
+          FROM curie.thread_publication_lineages
+    """,
+        {"id": uuid.uuid4()},
+    )
+    response = post_review(client, truth)
+    assert response.status_code == 200, response.text
+    assert response.json()["errors"] == [{"code": "lineage_absent_or_ambiguous"}]
+    assert truth.calls == []
+    assert valkey.xlen(stream) == 0
+
+
+def test_forged_slack_principal_on_queued_github_feedback_is_refused_by_actual_api(
+    review_stack,
+) -> None:
+    client, truth, valkey, stream = review_stack
+    assert post_review(client, truth).json()["status"] == "feedback_queued"
+    turn = json.loads(valkey.xrange(stream)[0][1]["payload"])
+    turn["author"] = "U0REQUEST1"
+    deployment_id = review_rows("SELECT deployment_id FROM curie.thread_publication_lineages")[0][
+        "deployment_id"
+    ]
+    response = client.post(
+        f"/v1/internal/github/reviews/{truth.feedback.event_id}/verify",
+        json={"turn": turn, "deployment_id": str(deployment_id)},
+        headers={"X-Curie-Worker-Token": "fixture-review-worker-token"},
+    )
+    assert response.status_code == 409, response.text
+    assert response.json()["detail"]["code"] == "feedback_turn_mismatch"
+    assert valkey.xlen(stream) == 1

--- a/apps/api/tests/test_github_review_events.py
+++ b/apps/api/tests/test_github_review_events.py
@@ -15,6 +15,7 @@ import hmac
 import json
 import socket
 import threading
+import time
 import uuid
 from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor
@@ -26,6 +27,7 @@ import pytest
 from channel_protocol import scoped_conversation_id
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
+from curie_api import approval_principal
 from curie_api.config import Settings, get_settings
 from curie_api.github_app import _RESOLVERS
 from curie_api.github_review_events import FeedbackIgnored, parse_feedback
@@ -218,13 +220,17 @@ class GitHubTruth:
             github_app_private_key=key,
             github_token="fixture-pat-must-not-be-used",
         )
-        self.lineage = BoundReviewLineage(REPO, 17, "curie/example", HEAD)
+        self.lineage = BoundReviewLineage(
+            REPO, 17, "curie/example", HEAD, 21, 11, "PR_example_17", "main"
+        )
         self.calls: list[str] = []
         self.installation = {"id": 11}
         self.installation_status = 200
         self.repo = {"id": 21, "full_name": REPO}
         self.pr = copy.deepcopy(feedback_payload("pull_request_review")["pull_request"])
         self.pr["merged"] = False
+        self.pr["node_id"] = "PR_example_17"
+        self.pr["base"]["ref"] = "main"
         self.comment = copy.deepcopy(self.payload.get("comment", self.payload.get("review")))
         self.comment["issue_url"] = f"https://api.github.com/repos/{REPO}/issues/17"
         self.comment["pull_request_url"] = f"https://api.github.com/repos/{REPO}/pulls/17"
@@ -284,6 +290,24 @@ async def verify_truth(truth: GitHubTruth, monkeypatch: pytest.MonkeyPatch) -> s
             )
     finally:
         _RESOLVERS.clear()
+
+
+@pytest.mark.parametrize(
+    "changed",
+    [
+        {"repository_id": 999},
+        {"installation_id": 999},
+        {"pr_node_id": "PR_other_identity"},
+        {"base_ref": "another-base"},
+    ],
+)
+def test_review_truth_must_match_immutable_persisted_authority(
+    changed: dict, review_app_key: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    truth = GitHubTruth("issue_comment", review_app_key)
+    truth.lineage = replace(truth.lineage, **changed)
+    with pytest.raises(FeedbackIgnored):
+        asyncio.run(verify_truth(truth, monkeypatch))
 
 
 @pytest.mark.parametrize(
@@ -444,14 +468,16 @@ def review_stack(
 ) -> Iterator[tuple[TestClient, GitHubTruth, object, str]]:
     """Real migrated Postgres/Valkey/API, with only GitHub HTTP replaced.
 
-    The database seed represents a PR already published by #2274. Setting that
-    historical fixture is not an exercised approval or GitHub publication.
+    The producer captures App identity through its actual approval/advance API.
+    The fixed example attestation is test setup, not a real human Slack click;
+    publication GitHub HTTP and worker outcome-history delivery remain fixtures.
     """
     event = getattr(request, "param", "issue_comment")
     truth = GitHubTruth(event, review_app_key)
     stream = f"test:curie:github-review:{uuid.uuid4().hex}"
     for key, value in {
         "RUNS_STREAM": stream,
+        "KEY_PREFIX": f"{stream}:worker",
         "INTERNAL_WORKER_TOKEN": "fixture-review-worker-token",
         "GITHUB_WEBHOOK_SECRET": "fixture-review-webhook-secret",
         "GITHUB_REVIEW_INGRESS_ENABLED": "true",
@@ -472,6 +498,12 @@ def review_stack(
         owned.callback(get_settings.cache_clear)
         owned.callback(_RESOLVERS.clear)
         owned.callback(valkey.close)
+        def cleanup_worker_markers() -> None:
+            keys = list(valkey.scan_iter(match=f"{stream}:worker:*"))
+            if keys:
+                valkey.delete(*keys)
+
+        owned.callback(cleanup_worker_markers)
         owned.callback(
             valkey.delete,
             stream,
@@ -549,19 +581,54 @@ def review_stack(
             },
         )
         assert publication.status_code == 201, publication.text
-        lineage_id = publication.json()["lineage_id"]
         branch = publication.json()["branch"]
         truth.pr["head"]["ref"] = branch
-        review_rows(
-            "UPDATE curie.thread_publication_lineages SET head_sha=:head, pr_number=17, "
-            "pr_url=:url, version=2 WHERE id=:id",
-            {"head": HEAD, "url": f"https://github.com/{REPO}/pull/17", "id": lineage_id},
+        principal = approval_principal.mint(
+            get_settings().approval_chat_attester_secret,
+            subject="U0REQUEST1",
+            kind="chat",
+            actor_channel="C0EXAMPLE1",
+            approval_id=publication.json()["approval_id"],
+            scope=approval_principal.APPROVE_SCOPE,
+            exp=int(time.time()) + 60,
         )
+        resolved = client.post(
+            f"/approvals/{publication.json()['approval_id']}/resolve",
+            json={"decision": "approved"},
+            headers={**auth, "X-Curie-Approval-Principal": principal},
+        )
+        assert resolved.status_code == 200, resolved.text
+        advanced = client.patch(
+            f"/v1/internal/publications/{publication.json()['id']}/lineage",
+            headers={"X-Curie-Worker-Token": "fixture-review-worker-token"},
+            json={
+                "expected_version": 1,
+                "expected_head_sha": None,
+                "state": "open",
+                "pr_number": 17,
+                "pr_url": f"https://github.com/{REPO}/pull/17",
+                "head_sha": HEAD,
+            },
+        )
+        assert advanced.status_code == 200, advanced.text
         review_rows(
-            "UPDATE curie.publications SET status='succeeded', outcome_history_ready_at=now(), "
+            "UPDATE curie.publications SET outcome_history_ready_at=now(), "
             "result_reported_at=now(), terminal_at=now() WHERE id=:id",
             {"id": publication.json()["id"]},
         )
+        # Remove only this fixture's synthetic approval-resume input, before
+        # admitting any review. This test does not execute that earlier turn.
+        valkey.delete(stream)
+        assert review_rows(
+            "SELECT github_repository_id, github_installation_id, github_pr_node_id, base_ref "
+            "FROM curie.thread_publication_lineages"
+        ) == [{
+            "github_repository_id": 21,
+            "github_installation_id": 11,
+            "github_pr_node_id": "PR_example_17",
+            "base_ref": "main",
+        }]
+        truth.calls.clear()  # Attribute subsequent reads to the ingress under test.
         yield client, truth, valkey, stream
 
 
@@ -662,6 +729,200 @@ def test_binding_quota_refuses_new_feedback_and_keeps_an_observable_row(review_s
     assert rows == [{"status": "refused", "error_code": "binding_backlog_quota"}]
     assert post_review(client, truth).json()["status"] == "feedback_duplicate"
     assert valkey.xlen(stream) == 0
+
+
+def test_real_review_consumer_waits_for_active_turn_and_revalidates_before_new_turn(
+    review_stack, tmp_path
+) -> None:
+    """Actual API/DB/Valkey/consumer/RunnerClient; GitHub and ACI peer are fixtures.
+
+    An existing managed route is a fixture premise, not a claim of a real
+    checkout or Kubernetes recovery. This asserts durable review deferral and
+    exact reservation origin; GitHub publication and approval remain separate.
+    """
+    import uvicorn
+    from aci_protocol import Final, QueuedTurn, ReplyHandle, SessionStatus, TextDelta
+    from aci_protocol.s3 import build_s3_client
+    from curie_dispatcher.queue import to_stream_fields
+    from curie_worker.approvals import ApprovalClient
+    from curie_worker.binding import BindingResolver
+    from curie_worker.consumer import Consumer
+    from curie_worker.delivery_lease import DeliveryLeaseStore
+    from curie_worker.workspace import (
+        SubprocessCommands,
+        WorkspaceClaimCoordinator,
+        WorkspaceCredentialClient,
+        WorkspaceLimits,
+        WorkspaceObjectStore,
+        WorkspacePreparer,
+    )
+
+    from apps.worker.tests.kernel.conftest import kernel_harness, make_config
+
+    client, truth, valkey, stream = review_stack
+    settings = get_settings()
+    names = {"stream": stream, "group": f"{stream}:group",
+             "prefix": settings.worker_key_prefix, "sandbox_prefix": f"{stream}:sandbox"}
+    original = QueuedTurn(
+        event_id=f"ordinary-{uuid.uuid4()}", conversation_id="1700000000.000001",
+        author="U0REQUEST1", text="Continue the existing work.",
+        reply_handle=ReplyHandle(kind="slack", channel="C0EXAMPLE1", placeholder=None),
+        received_at="2026-09-05T01:00:00+00:00",
+    )
+    thread_key = scoped_conversation_id("slack", "C0EXAMPLE1", original.conversation_id)
+    bucket = f"review-consumer-{uuid.uuid4().hex}"
+    objects_client = build_s3_client(
+        endpoint_url=settings.s3_endpoint_url, access_key=settings.s3_access_key,
+        secret_key=settings.s3_secret_key, region=settings.s3_region,
+    )
+    objects_client.create_bucket(Bucket=bucket)
+
+    async def exercise() -> None:
+        sock = socket.socket()
+        sock.bind(("127.0.0.1", 0))
+        sock.listen(16)
+        api_url = f"http://127.0.0.1:{sock.getsockname()[1]}"
+        server = uvicorn.Server(
+            uvicorn.Config(client.app, lifespan="off", log_level="critical", access_log=False)
+        )
+        server_task = asyncio.create_task(server.serve(sockets=[sock]))
+        engine = create_async_engine(settings.database_url)
+        try:
+            async with asyncio.timeout(5):
+                while not server.started:
+                    await asyncio.sleep(0.01)
+            async with httpx.AsyncClient() as http:
+                publication_client = ApprovalClient(
+                    api_base_url=api_url, api_key="", client=http,
+                    worker_token="fixture-review-worker-token", read_timeout_s=2.0,
+                )
+
+                def workspace(substrate):
+                    return WorkspaceClaimCoordinator(
+                        preparer=WorkspacePreparer(
+                            credentials=WorkspaceCredentialClient(
+                                api_url=api_url, worker_token="fixture-review-worker-token"
+                            ),
+                            commands=SubprocessCommands(),
+                            objects=WorkspaceObjectStore(client=objects_client, bucket=bucket),
+                            scratch_root=tmp_path, limits=WorkspaceLimits(),
+                        ),
+                        substrate=substrate,
+                    )
+
+                async with kernel_harness(
+                    names, valkey, binding=BindingResolver(engine, make_config(names)),
+                    publication_creator=publication_client, workspace_factory=workspace,
+                ) as h:
+                    await asyncio.to_thread(
+                        h.substrate.claim, thread_key,
+                        env={"CURIE_RUNNER_TOKEN": "example-review-route-token"},
+                        workspace_repo=REPO, workspace_materialized_head=HEAD,
+                        publication_visible_outcome_revision=1,
+                    )
+                    consumer = Consumer(
+                        redis=h.async_redis, kernel=h.kernel, config=h.config,
+                        leases=DeliveryLeaseStore(h.async_redis, h.config),
+                    )
+                    await consumer.ensure_group()
+                    hold = asyncio.Event()
+                    h.runner.hold = hold
+                    h.runner.default_script = [TextDelta(text="working")]
+                    h.runner.tail = [Final(text="original complete", status=SessionStatus.DONE)]
+
+                    async def dispatch_new():
+                        rows = await h.async_redis.xreadgroup(
+                            h.config.consumer_group, h.config.consumer_name,
+                            {stream: ">"}, count=1,
+                        )
+                        assert rows
+                        entry_id, fields = rows[0][1][0]
+                        await consumer._dispatch(entry_id, fields)
+                        return entry_id, fields
+
+                    async def handler_done(entry_id):
+                        async with asyncio.timeout(10):
+                            while entry_id in consumer._inflight_ids:
+                                await asyncio.sleep(0.01)
+
+                    try:
+                        await h.async_redis.xadd(stream, to_stream_fields(original))
+                        first_id, _ = await dispatch_new()
+                        async with asyncio.timeout(10):
+                            while not h.runner.turn_active:
+                                await asyncio.sleep(0.01)
+                        ordinary_steer = original.model_copy(update={
+                            "event_id": f"ordinary-{uuid.uuid4()}", "text": "Also cover the edge."
+                        })
+                        await h.async_redis.xadd(stream, to_stream_fields(ordinary_steer))
+                        steer_id, _ = await dispatch_new()
+                        await handler_done(steer_id)
+                        assert h.runner.steers == [ordinary_steer.text]
+                        admitted = await asyncio.to_thread(post_review, client, truth)
+                        assert admitted.json()["status"] == "feedback_queued", admitted.text
+                        review_id, review_fields = await dispatch_new()
+                        await handler_done(review_id)
+                        assert h.runner.opened == [original.text]
+                        assert h.runner.steers == [ordinary_steer.text]
+                        assert await asyncio.to_thread(
+                            review_rows, "SELECT id FROM curie.publication_review_reservations"
+                        ) == []
+                        pending = await h.async_redis.xpending_range(
+                            stream, h.config.consumer_group, review_id, review_id, 1
+                        )
+                        assert len(pending) == 1
+                        hold.set()
+                        await handler_done(first_id)
+                        h.runner.hold = None
+                        h.runner.tail = []
+                        h.runner.default_script = [
+                            Final(text="review complete", status=SessionStatus.DONE)
+                        ]
+                        truth.calls.clear()
+                        await consumer._dispatch(review_id, review_fields)
+                        await handler_done(review_id)
+                        assert len(h.runner.opened) == 2
+                        assert h.runner.opened[1] == json.loads(review_fields["payload"])["text"]
+                        assert h.runner.steers == [ordinary_steer.text]
+                        assert f"/repos/{REPO}/pulls/17" in truth.calls
+                        assert await h.async_redis.xpending_range(
+                            stream, h.config.consumer_group, review_id, review_id, 1
+                        ) == []
+                        assert await asyncio.to_thread(
+                            review_rows,
+                            "SELECT origin_key,status FROM curie.publication_review_reservations",
+                        ) == [{"origin_key": truth.feedback.event_id, "status": "reserved"}]
+                        reconciler = client.app.state.github_review_reconciler
+                        assert await reconciler.reconcile_terminal() == 1
+                    finally:
+                        hold.set()
+                        await asyncio.gather(*list(consumer._inflight), return_exceptions=True)
+        finally:
+            await engine.dispose()
+            server.should_exit = True
+            try:
+                await asyncio.wait_for(server_task, 5)
+            finally:
+                if not server_task.done():
+                    server_task.cancel()
+                    await asyncio.gather(server_task, return_exceptions=True)
+                sock.close()
+
+    try:
+        client.portal.call(exercise)
+    finally:
+        def cleanup_sandbox_keys():
+            keys = list(valkey.scan_iter(match=f"{stream}:sandbox*"))
+            if keys:
+                valkey.delete(*keys)
+
+        with ExitStack() as cleanup:
+            cleanup.callback(cleanup_sandbox_keys)
+            cleanup.callback(objects_client.close)
+            cleanup.callback(objects_client.delete_bucket, Bucket=bucket)
+            contents = objects_client.list_objects_v2(Bucket=bucket).get("Contents", [])
+            for obj in contents:
+                cleanup.callback(objects_client.delete_object, Bucket=bucket, Key=obj["Key"])
 
 
 def test_real_enqueue_refusal_backs_off_then_recovers_without_second_quota(review_stack) -> None:
@@ -798,6 +1059,15 @@ def test_production_worker_client_uses_actual_api_without_github_or_slack_author
             assert verified.head_sha == HEAD
             assert verified.sender == "github:41:example-reviewer"
             assert truth.feedback.url in verified.receipt
+            assert verified.origin_key == turn.event_id
+            assert verified.reservation_id is None
+            reserved = await worker.reserve_review_feedback(turn, deployment_id, verified)
+            assert reserved == await worker.reserve_review_feedback(turn, deployment_id, verified)
+            assert await asyncio.to_thread(
+                review_rows, "SELECT origin_key FROM curie.publication_review_reservations"
+            ) == [
+                {"origin_key": turn.event_id}
+            ]
             truth.feedback_status = 404
             with pytest.raises(ApprovalBackendError):
                 await worker.verify_review_feedback(turn, deployment_id)
@@ -914,14 +1184,16 @@ def test_real_queue_receipt_survives_database_commit_failure_without_second_turn
 
 
 @pytest.mark.parametrize(
-    "mutation",
+    ("mutation", "code"),
     [
-        "UPDATE curie.agent_channels SET generation=generation+1",
-        "UPDATE curie.thread_publication_lineages SET version=version+1",
+        ("UPDATE curie.agent_channels SET generation=generation+1",
+         "binding_no_longer_authorized"),
+        ("UPDATE curie.thread_publication_lineages SET version=version+1",
+         "binding_or_lineage_changed"),
     ],
 )
 def test_before_model_recheck_refuses_stale_binding_or_lineage_version(
-    review_stack, mutation
+    review_stack, mutation, code
 ) -> None:
     client, truth, valkey, stream = review_stack
     assert post_review(client, truth).json()["status"] == "feedback_queued"
@@ -936,7 +1208,7 @@ def test_before_model_recheck_refuses_stale_binding_or_lineage_version(
         headers={"X-Curie-Worker-Token": "fixture-review-worker-token"},
     )
     assert response.status_code == 409, response.text
-    assert response.json()["detail"]["code"] == "binding_or_lineage_changed"
+    assert response.json()["detail"]["code"] == code
     assert valkey.xlen(stream) == 1
 
 
@@ -956,7 +1228,7 @@ def test_concurrent_distinct_delivery_headers_for_one_feedback_enqueue_once(revi
     assert len(review_rows("SELECT event_id FROM curie.github_review_feedback")) == 1
 
 
-def test_ambiguous_persisted_pr_cannot_choose_a_conversation_from_webhook_contents(
+def test_legacy_name_only_lineage_cannot_override_verified_github_owner(
     review_stack,
 ) -> None:
     client, truth, valkey, stream = review_stack
@@ -973,9 +1245,23 @@ def test_ambiguous_persisted_pr_cannot_choose_a_conversation_from_webhook_conten
     )
     response = post_review(client, truth)
     assert response.status_code == 200, response.text
-    assert response.json()["errors"] == [{"code": "lineage_absent_or_ambiguous"}]
+    assert response.json()["status"] == "feedback_queued", response.text
+    queued = json.loads(valkey.xrange(stream)[0][1]["payload"])
+    assert queued["conversation_id"] == "1700000000.000001"
+    assert valkey.xlen(stream) == 1
+    # A name/number-only historical row cannot become review authority when the
+    # verified owner is no longer open. Keep the valid queued receipt untouched.
+    review_rows("UPDATE curie.thread_publication_lineages SET status='closed' "
+                "WHERE github_repository_id IS NOT NULL")
+    truth.payload["comment"].update(
+        id=72, html_url=f"https://github.com/{REPO}/pull/17#issuecomment-72"
+    )
+    truth.comment.update(truth.payload["comment"])
+    truth.calls.clear()
+    refused = post_review(client, truth, delivery=str(uuid.uuid4()))
+    assert refused.json()["errors"] == [{"code": "lineage_absent_or_ambiguous"}]
     assert truth.calls == []
-    assert valkey.xlen(stream) == 0
+    assert valkey.xlen(stream) == 1
 
 
 def test_forged_slack_principal_on_queued_github_feedback_is_refused_by_actual_api(
@@ -996,3 +1282,485 @@ def test_forged_slack_principal_on_queued_github_feedback_is_refused_by_actual_a
     assert response.status_code == 409, response.text
     assert response.json()["detail"]["code"] == "feedback_turn_mismatch"
     assert valkey.xlen(stream) == 1
+
+
+@pytest.mark.parametrize("action", ["edited", "deleted"])
+def test_signed_unactionable_review_is_durably_audited_without_effects(
+    review_stack, action
+) -> None:
+    client, truth, valkey, stream = review_stack
+    truth.payload["action"] = action
+    truth.payload["comment"]["body"] = "AUDIT_PRIVATE_BODY_SENTINEL"
+    first = post_review(client, truth)
+    assert first.status_code == 200 and first.json()["status"] == "feedback_ignored"
+    assert post_review(client, truth).json() == first.json()
+    audits = review_rows(
+        "SELECT delivery_id,event_kind,action,status,reason,body_sha256,version "
+        "FROM curie.github_review_deliveries"
+    )
+    assert len(audits) == 1 and audits[0]["status"] == "ignored"
+    assert audits[0]["event_kind"] == "issue_comment" and audits[0]["action"] == action
+    assert (
+        audits[0]["body_sha256"] == hashlib.sha256(json.dumps(truth.payload).encode()).hexdigest()
+    )
+    assert "AUDIT_PRIVATE_BODY_SENTINEL" not in str(audits)
+    assert truth.calls == [] and valkey.xlen(stream) == 0
+    assert review_rows("SELECT event_id FROM curie.github_review_feedback") == []
+
+
+def test_reused_delivery_bytes_conflict_even_after_semantic_alias(review_stack) -> None:
+    client, truth, valkey, stream = review_stack
+    first = post_review(client, truth)
+    assert first.json()["status"] == "feedback_queued"
+    alias = str(uuid.uuid4())
+    assert post_review(client, truth, delivery=alias).json()["status"] == "feedback_duplicate"
+    truth.payload["comment"]["body"] = "Changed bytes under a previously adopted delivery alias"
+    for delivery in (DELIVERY, alias):
+        refused = post_review(client, truth, delivery=delivery)
+        assert refused.status_code == 200
+        assert refused.json()["errors"] == [{"code": "delivery_identity_conflict"}]
+    assert valkey.xlen(stream) == 1
+    audits = review_rows(
+        "SELECT status,replay_conflicts,version FROM curie.github_review_deliveries "
+        "ORDER BY delivery_id"
+    )
+    assert len(audits) == 2
+    assert all(row == {"status": "accepted", "replay_conflicts": 1, "version": 3} for row in audits)
+
+
+def test_ignored_delivery_cannot_be_promoted_by_changed_signed_bytes(review_stack) -> None:
+    client, truth, valkey, stream = review_stack
+    truth.payload["action"] = "edited"
+    assert post_review(client, truth).json()["status"] == "feedback_ignored"
+    truth.payload["action"] = "created"
+    refused = post_review(client, truth)
+    assert refused.json()["errors"] == [{"code": "delivery_identity_conflict"}]
+    assert truth.calls == [] and valkey.xlen(stream) == 0
+    assert review_rows("SELECT status,replay_conflicts FROM curie.github_review_deliveries") == [
+        {"status": "ignored", "replay_conflicts": 1}
+    ]
+
+
+def test_invalid_hmac_and_missing_delivery_header_create_no_audit(review_stack) -> None:
+    client, truth, valkey, stream = review_stack
+    assert post_review(client, truth, signature="sha256=invalid").status_code == 401
+    assert post_review(client, truth, delivery="").status_code == 400
+    assert truth.calls == [] and valkey.xlen(stream) == 0
+    assert review_rows("SELECT delivery_id FROM curie.github_review_deliveries") == []
+
+
+def test_repository_id_cannot_overflow_a_durable_receipt() -> None:
+    payload = feedback_payload()
+    payload["repository"]["id"] = 2**63
+    with pytest.raises(FeedbackIgnored):
+        parse_feedback("issue_comment", payload, DELIVERY)
+
+
+def test_concurrent_conflicting_delivery_replays_preserve_canonical_receipt(review_stack) -> None:
+    client, truth, valkey, stream = review_stack
+    assert post_review(client, truth).json()["status"] == "feedback_queued"
+    original = review_rows("SELECT body_sha256 FROM curie.github_review_deliveries")[0][
+        "body_sha256"
+    ]
+    truth.payload["comment"]["body"] = "Changed signed replay, never another instruction"
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        replies = list(pool.map(lambda _: post_review(client, truth), range(4)))
+    assert all(
+        reply.json()["errors"] == [{"code": "delivery_identity_conflict"}] for reply in replies
+    )
+    assert review_rows(
+        "SELECT body_sha256,replay_conflicts,version FROM curie.github_review_deliveries"
+    ) == [{"body_sha256": original, "replay_conflicts": 4, "version": 6}]
+    assert valkey.xlen(stream) == 1
+
+
+def test_retryable_github_read_is_audited_and_explicit_redelivery_recovers(review_stack) -> None:
+    client, truth, valkey, stream = review_stack
+    truth.feedback_status = 503
+    unavailable = post_review(client, truth)
+    assert unavailable.status_code == 503
+    assert review_rows("SELECT status,reason FROM curie.github_review_deliveries") == [
+        {"status": "retryable", "reason": "feedback_unavailable"}
+    ]
+    assert valkey.xlen(stream) == 0
+    assert review_rows("SELECT event_id FROM curie.github_review_feedback") == []
+    # GitHub does not automatically redeliver failed webhooks. This explicitly
+    # drives the authenticated redelivery surface, not an assumed background retry.
+    # https://docs.github.com/en/webhooks/using-webhooks/handling-failed-webhook-deliveries
+    truth.feedback_status = 200
+    assert post_review(client, truth).json()["status"] == "feedback_queued"
+    assert post_review(client, truth).json()["status"] == "feedback_duplicate"
+    assert valkey.xlen(stream) == 1
+    assert review_rows("SELECT status,reason,version FROM curie.github_review_deliveries") == [
+        {"status": "accepted", "reason": None, "version": 3}
+    ]
+
+
+def test_receipt_and_feedback_admission_commit_atomically(review_stack) -> None:
+    from sqlalchemy.exc import DBAPIError
+
+    client, truth, valkey, stream = review_stack
+    review_rows("""
+        CREATE FUNCTION curie.review_test_reject_admission() RETURNS trigger LANGUAGE plpgsql AS $$
+        BEGIN
+          IF NEW.status = 'accepted' THEN
+            RAISE EXCEPTION 'task-owned admission-mark failure';
+          END IF;
+          RETURN NEW;
+        END $$
+    """)
+    review_rows("""
+        CREATE TRIGGER review_test_reject_admission BEFORE UPDATE ON curie.github_review_deliveries
+        FOR EACH ROW EXECUTE FUNCTION curie.review_test_reject_admission()
+    """)
+    try:
+        with pytest.raises(DBAPIError):
+            post_review(client, truth)
+        assert review_rows("SELECT event_id FROM curie.github_review_feedback") == []
+        assert review_rows("SELECT delivery_id FROM curie.github_review_deliveries") == []
+        assert valkey.xlen(stream) == 0
+    finally:
+        review_rows("DROP TRIGGER review_test_reject_admission ON curie.github_review_deliveries")
+        review_rows("DROP FUNCTION curie.review_test_reject_admission()")
+    assert post_review(client, truth).json()["status"] == "feedback_queued"
+    assert valkey.xlen(stream) == 1
+
+
+def _review_reserve_request(review_stack) -> tuple[str, dict, dict]:
+    client, truth, valkey, stream = review_stack
+    assert post_review(client, truth).json()["status"] == "feedback_queued"
+    turn = json.loads(valkey.xrange(stream)[0][1]["payload"])
+    lineage = review_rows("SELECT deployment_id,version FROM curie.thread_publication_lineages")[0]
+    headers = {"X-Curie-Worker-Token": "fixture-review-worker-token"}
+    payload = {"turn": turn, "deployment_id": str(lineage["deployment_id"])}
+    base = f"/v1/internal/github/reviews/{turn['event_id']}"
+    verified = client.post(base + "/verify", json=payload, headers=headers)
+    assert verified.status_code == 200, verified.text
+    assert review_rows("SELECT id FROM curie.publication_review_reservations") == []
+    payload.update(expected_lineage_version=lineage["version"], expected_head_sha=HEAD)
+    return base, payload, headers
+
+
+@pytest.mark.parametrize("mutation", ["author", "head", "version", "token"])
+def test_review_reservation_rejects_unverified_origin_without_effects(review_stack, mutation):
+    client, _, valkey, stream = review_stack
+    base, payload, headers = _review_reserve_request(review_stack)
+    if mutation == "author":
+        payload["turn"]["author"] = "U0REQUEST1"
+    elif mutation == "head":
+        payload["expected_head_sha"] = "d" * 40
+    elif mutation == "version":
+        payload["expected_lineage_version"] += 1
+    else:
+        headers = {"X-Curie-Worker-Token": "example-wrong-worker-token"}
+    result = client.post(base + "/reserve", json=payload, headers=headers)
+    assert result.status_code == (401 if mutation == "token" else 409), result.text
+    assert review_rows("SELECT id FROM curie.publication_review_reservations") == []
+    assert review_rows("SELECT status FROM curie.github_review_feedback") == [{"status": "queued"}]
+    assert valkey.xlen(stream) == 1
+
+
+def test_review_reservation_is_one_atomic_origin_after_concurrent_replays(review_stack):
+    client, _, valkey, stream = review_stack
+    base, payload, headers = _review_reserve_request(review_stack)
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        responses = list(pool.map(
+            lambda _: client.post(base + "/reserve", json=payload, headers=headers), range(4)
+        ))
+    assert all(response.status_code == 200 for response in responses)
+    ids = {response.json()["reservation_id"] for response in responses}
+    assert len(ids) == 1
+    rows = review_rows("SELECT origin_key,status FROM curie.publication_review_reservations")
+    assert rows == [{"origin_key": payload["turn"]["event_id"], "status": "reserved"}]
+    assert review_rows("SELECT status,version FROM curie.github_review_feedback") == [
+        {"status": "reserved", "version": 3}
+    ]
+    assert valkey.xlen(stream) == 1
+
+
+def _write_actual_fenced_review_terminal(client, event_id: str, stream: str) -> None:
+    from channel_protocol.reply import REPLY_WIRE_VERSION, ReplyTarget, TurnCompleted
+    from curie_worker.config import WorkerConfig
+    from curie_worker.delivery_lease import DeliveryLeaseStore
+    from curie_worker.markers import CompletionRecord, Markers
+    from curie_worker.reply_sink import TargetRoute
+    from redis.exceptions import ResponseError
+
+    async def settle() -> None:
+        valkey = client.app.state.github_review_reconciler._valkey
+        config = WorkerConfig(key_prefix=get_settings().worker_key_prefix)
+        group = "review-observer-test"
+        try:
+            await valkey.xgroup_create(stream, group, id="0")
+        except ResponseError as error:
+            if not str(error).startswith("BUSYGROUP"):
+                raise
+        pending = await valkey.xreadgroup(group, "fixture", {stream: "0"}, count=1)
+        if not pending or not pending[0][1]:
+            pending = await valkey.xreadgroup(group, "fixture", {stream: ">"}, count=1)
+        assert len(pending[0][1]) == 1
+        entry_id = pending[0][1][0][0]
+        store = DeliveryLeaseStore(valkey, config)
+        lease = await store.acquire(stream, group, entry_id, consumer="fixture")
+        try:
+            assert await Markers(valkey, config).settle_fenced(
+                event_id,
+                CompletionRecord(
+                    event_id=event_id,
+                    event=TurnCompleted(
+                        version=REPLY_WIRE_VERSION,
+                        event="turn.completed",
+                        target=ReplyTarget(
+                            kind="slack", address="C0EXAMPLE1",
+                            conversation_id="1700000000.000001",
+                            reply_ref=None,
+                        ),
+                        event_id=event_id,
+                        outcome="delivered",
+                    ),
+                    route=TargetRoute(),
+                    created_at=time.time(),
+                ),
+                stream=stream,
+                group=lease.group,
+                entry_id=entry_id,
+                owner=lease.owner,
+                generation=lease.generation,
+            ) is not None
+        finally:
+            await store.release(stream, lease.group, entry_id, owner=lease.owner)
+
+    client.portal.call(settle)
+
+
+@pytest.mark.parametrize("reserve", [False, True])
+def test_review_cleanup_requires_own_fenced_terminal_and_keeps_origin_tombstone(
+    review_stack, reserve
+) -> None:
+    client, truth, _, stream = review_stack
+    base, payload, headers = _review_reserve_request(review_stack)
+    if reserve:
+        response = client.post(base + "/reserve", json=payload, headers=headers)
+        assert response.status_code == 200, response.text
+    reconciler = client.app.state.github_review_reconciler
+    assert client.portal.call(reconciler.reconcile_terminal) == 0
+    assert review_rows("SELECT status FROM curie.github_review_feedback") == [
+        {"status": "reserved" if reserve else "queued"}
+    ]
+    # A different event's real fenced marker cannot settle this origin.
+    _write_actual_fenced_review_terminal(client, truth.feedback.event_id + "-other", stream)
+    assert client.portal.call(reconciler.reconcile_terminal) == 0
+    _write_actual_fenced_review_terminal(client, truth.feedback.event_id, stream)
+    assert client.portal.call(reconciler.reconcile_terminal) == 1
+    assert client.portal.call(reconciler.reconcile_terminal) == 0
+    assert review_rows("SELECT status FROM curie.github_review_feedback") == [{"status": "settled"}]
+    if reserve:
+        assert review_rows("SELECT status FROM curie.publication_review_reservations") == [
+            {"status": "cancelled"}
+        ]
+    replay = client.post(base + "/reserve", json=payload, headers=headers)
+    assert replay.status_code == 409
+    assert replay.json()["detail"]["code"] == "feedback_not_executable"
+    assert post_review(client, truth).json()["status"] == "feedback_duplicate"
+
+
+@pytest.mark.parametrize("trim", [False, True])
+def test_review_graveyard_cursor_survives_restart_and_never_treats_absence_as_terminal(
+    review_stack, trim,
+) -> None:
+    from curie_api.github_review_store import GitHubReviewReconciler
+
+    client, truth, valkey, stream = review_stack
+    base, payload, headers = _review_reserve_request(review_stack)
+    assert client.post(base + "/reserve", json=payload, headers=headers).status_code == 200
+    reconciler = client.app.state.github_review_reconciler
+    dead = get_settings().dead_letter_stream_name()
+    original_id = valkey.xrange(stream)[0][0]
+    # Every irrelevant row is valid but names another original delivery; a
+    # later matching original ID with a different canonical turn also refuses.
+    for _ in range(129):
+        valkey.xadd(dead, {"dl_original_id": "1-0", "payload": json.dumps(payload["turn"])})
+    wrong_turn = dict(payload["turn"], author="U0REQUEST1")
+    valkey.xadd(dead, {"dl_original_id": original_id, "payload": json.dumps(wrong_turn)})
+    valkey.xadd(dead, {"dl_original_id": original_id, "payload": json.dumps(payload["turn"])})
+    assert client.portal.call(reconciler.reconcile_terminal) == 0
+    cursor = review_rows("SELECT terminal_scan_cursor FROM curie.github_review_feedback")[0][
+        "terminal_scan_cursor"
+    ]
+    assert cursor == valkey.xrange(dead, count=128)[-1][0]
+    restarted = GitHubReviewReconciler(
+        reconciler._sessionmaker, reconciler._valkey, reconciler._settings
+    )
+    if not trim:
+        assert client.portal.call(restarted.reconcile_terminal) == 1
+        assert review_rows("SELECT status FROM curie.github_review_feedback") == [
+            {"status": "dead_lettered"}
+        ]
+        return
+    # A trimmed graveyard or missing original stream entry is unknown; neither
+    # permits cancelling the one reserved revision.
+    valkey.xtrim(dead, maxlen=0, approximate=False)
+    valkey.xdel(stream, original_id)
+    assert client.portal.call(restarted.reconcile_terminal) == 0
+    assert review_rows("SELECT status FROM curie.github_review_feedback") == [
+        {"status": "reserved"}
+    ]
+    assert review_rows("SELECT status FROM curie.publication_review_reservations") == [
+        {"status": "reserved"}
+    ]
+
+
+def test_actual_consumer_dead_letter_settles_only_the_matching_review_origin(review_stack):
+    from curie_worker.consumer import Consumer
+    from curie_worker.delivery_lease import DeliveryLeaseStore
+
+    from apps.worker.tests.kernel.conftest import kernel_harness
+
+    client, truth, valkey, stream = review_stack
+    base, payload, headers = _review_reserve_request(review_stack)
+    assert client.post(base + "/reserve", json=payload, headers=headers).status_code == 200
+    names = {"stream": stream, "group": f"{stream}:dead-group",
+             "prefix": get_settings().worker_key_prefix, "sandbox_prefix": f"{stream}:sandbox"}
+
+    async def exercise():
+        async with kernel_harness(
+            names, valkey, max_delivery=2, reclaim_min_idle_ms=1,
+            delivery_lease_ttl_s=1.0, delivery_lease_heartbeat_s=0.3,
+        ) as h:
+            leases = DeliveryLeaseStore(h.async_redis, h.config)
+            consumer = Consumer(
+                redis=h.async_redis, kernel=h.kernel, config=h.config, leases=leases
+            )
+            # The running consumer group predates this queued event. Production
+            # ensure_group intentionally skips historical backlog on first boot.
+            await h.async_redis.xgroup_create(stream, h.config.consumer_group, id="0")
+            await consumer.ensure_group()
+            rows = await h.async_redis.xreadgroup(
+                h.config.consumer_group, h.config.consumer_name, {stream: ">"}, count=1
+            )
+            entry_id, fields = rows[0][1][0]
+            await h.async_redis.xclaim(
+                stream, h.config.consumer_group, h.config.consumer_name,
+                min_idle_time=0, message_ids=[entry_id], idle=1000,
+            )
+            async with consumer._delivery_lease(entry_id, fields) as stale:
+                assert stale is not None
+                assert await leases.release(
+                    stream, h.config.consumer_group, entry_id, owner=stale.owner
+                )
+                await h.async_redis.xclaim(
+                    stream, h.config.consumer_group, "replacement",
+                    min_idle_time=0, message_ids=[entry_id],
+                )
+                current = await leases.acquire(
+                    stream, h.config.consumer_group, entry_id, consumer="replacement"
+                )
+                try:
+                    assert current.generation == stale.generation + 1
+                    await asyncio.wait_for(stale.lost.wait(), 2)
+                    await consumer._dead_letter(
+                        entry_id, fields, reason="max-delivery", delivery_count=2
+                    )
+                    assert await h.async_redis.xlen(h.config.dead_letter_stream_name()) == 0
+                    assert await client.app.state.github_review_reconciler.reconcile_terminal() == 0
+                finally:
+                    await leases.release(
+                        stream, h.config.consumer_group, entry_id, owner=current.owner
+                    )
+            await h.async_redis.xclaim(
+                stream, h.config.consumer_group, h.config.consumer_name,
+                min_idle_time=0, message_ids=[entry_id], idle=1000,
+            )
+            assert await consumer._dead_letter_over_cap() == {entry_id}
+            assert await h.async_redis.xpending_range(
+                stream, h.config.consumer_group, entry_id, entry_id, 1
+            ) == []
+            assert await client.app.state.github_review_reconciler.reconcile_terminal() == 1
+            assert h.runner.opened == []
+
+    client.portal.call(exercise)
+    assert review_rows("SELECT status,error_code FROM curie.github_review_feedback") == [
+        {"status": "dead_lettered", "error_code": "delivery_dead_lettered"}
+    ]
+    assert review_rows("SELECT origin_key,status FROM curie.publication_review_reservations") == [
+        {"origin_key": truth.feedback.event_id, "status": "cancelled"}
+    ]
+
+
+def test_concurrent_review_observers_settle_once_and_malformed_match_keeps_cursor(review_stack):
+    from curie_api.github_review_store import GitHubReviewReconciler
+
+    client, _, valkey, stream = review_stack
+    _, payload, _ = _review_reserve_request(review_stack)
+    reconciler = client.app.state.github_review_reconciler
+    dead = get_settings().dead_letter_stream_name()
+    original_id = valkey.xrange(stream)[0][0]
+    valkey.xadd(dead, {"dl_original_id": "1-0", "payload": "irrelevant"})
+    malformed = valkey.xadd(dead, {"dl_original_id": original_id, "payload": "broken-json"})
+    with pytest.raises(ValueError, match="unreadable"):
+        client.portal.call(reconciler.reconcile_terminal)
+    assert review_rows("SELECT terminal_scan_cursor,status FROM curie.github_review_feedback") == [
+        {"terminal_scan_cursor": None, "status": "queued"}
+    ]
+    valkey.xdel(dead, malformed)
+    valkey.xadd(dead, {"dl_original_id": original_id, "payload": json.dumps(payload["turn"])})
+
+    async def competing():
+        observers = [GitHubReviewReconciler(
+            reconciler._sessionmaker, reconciler._valkey, reconciler._settings
+        ) for _ in range(4)]
+        return await asyncio.gather(*(observer.reconcile_terminal() for observer in observers))
+
+    assert sum(client.portal.call(competing)) == 1
+    assert review_rows("SELECT status FROM curie.github_review_feedback") == [
+        {"status": "dead_lettered"}
+    ]
+
+
+@pytest.mark.parametrize("stale_verifier", [False, True])
+def test_review_terminal_observer_never_cancels_consumed_publication_or_reuses_approval(
+    review_stack, stale_verifier,
+):
+    client, truth, _, stream = review_stack
+    base, payload, headers = _review_reserve_request(review_stack)
+    reserved = client.post(base + "/reserve", json=payload, headers=headers)
+    assert reserved.status_code == 200, reserved.text
+    original_approvals = review_rows("SELECT id FROM curie.approvals")
+    publication = client.post("/v1/internal/publications", headers=headers, json={
+        "deployment_id": payload["deployment_id"],
+        "conversation_id": scoped_conversation_id(
+            "slack", "C0EXAMPLE1", payload["turn"]["conversation_id"]
+        ),
+        "repo_full_name": REPO, "author": payload["turn"]["author"],
+        "summary": "Review revision fixture", "reply_kind": "slack",
+        "reply_channel": "C0EXAMPLE1",
+        "reply_conversation_id": payload["turn"]["conversation_id"],
+        "reply_placeholder": "1700000000.000003",
+        "dedupe_key": f"review-publication-{uuid.uuid4()}",
+        "review_origin_key": truth.feedback.event_id,
+        "base_sha": HEAD, "patch_b64": base64.b64encode(b"diff --git a/a b/a\n").decode(),
+        "changed_paths": ["a"], "expires_in_seconds": 600,
+    })
+    assert publication.status_code == 201, publication.text
+    assert publication.json()["id"] == reserved.json()["reservation_id"]
+    assert publication.json()["approval_id"] not in {str(row["id"]) for row in original_approvals}
+    if stale_verifier:
+        refused = client.post(base + "/verify", json={
+            "turn": payload["turn"], "deployment_id": payload["deployment_id"],
+        }, headers=headers)
+        assert refused.status_code == 409
+        assert refused.json()["detail"]["code"] == "feedback_revision_not_executable"
+    _write_actual_fenced_review_terminal(client, truth.feedback.event_id, stream)
+    assert client.portal.call(client.app.state.github_review_reconciler.reconcile_terminal) == 1
+    assert review_rows("SELECT status FROM curie.github_review_feedback") == [
+        {"status": "settled"}
+    ]
+    assert review_rows("SELECT status FROM curie.publication_review_reservations") == [
+        {"status": "consumed"}
+    ]
+    assert review_rows("SELECT status FROM curie.publications WHERE id=:id", {
+        "id": publication.json()["id"]
+    }) == [{"status": "pending"}]
+    assert review_rows("SELECT status FROM curie.approvals WHERE id=:id", {
+        "id": publication.json()["approval_id"]
+    }) == [{"status": "pending"}]

--- a/apps/api/tests/test_github_review_events.py
+++ b/apps/api/tests/test_github_review_events.py
@@ -768,6 +768,10 @@ def test_real_review_consumer_waits_for_active_turn_and_revalidates_before_new_t
     permission = {"permission": "write", "role_name": "write", "user": {"id": 41}}
     permission_status = 200
     permission_timeout = False
+    permission_path = f"/repos/{REPO}/collaborators/example-reviewer/permission"
+    lineage_authorization = "Basic " + base64.b64encode(
+        b"x-access-token:fixture-app-token-private-sentinel"
+    ).decode()
     if permission_case != "legacy":
         from dataclasses import replace
 
@@ -776,7 +780,17 @@ def test_real_review_consumer_waits_for_active_turn_and_revalidates_before_new_t
         truth.feedback = replace(truth.feedback, author_association="CONTRIBUTOR")
 
     def github_permission(request):
-        if request.url.path != f"/repos/{REPO}/collaborators/example-reviewer/permission":
+        # Observed with a scoped App installation token on GitHub REST,
+        # 2026-09-05: Basic x-access-token and Bearer both read the same private
+        # PR (200); an invalid Basic credential is refused (404). The existing
+        # lineage reader uses Basic; review verification still requires Bearer.
+        if (
+            request.url.path == f"/repos/{REPO}/pulls/17"
+            and request.headers.get("Authorization") == lineage_authorization
+        ):
+            truth.calls.append(request.url.path)
+            return httpx.Response(200, json=truth.pr)
+        if request.url.path != permission_path:
             return truth.handle(request)
         truth.calls.append(request.url.path)
         assert request.headers["Authorization"] == "Bearer fixture-app-token-private-sentinel"
@@ -821,6 +835,21 @@ def test_real_review_consumer_waits_for_active_turn_and_revalidates_before_new_t
                     api_base_url=api_url, api_key="", client=http,
                     worker_token="fixture-review-worker-token", read_timeout_s=2.0,
                 )
+                lineage = (await asyncio.to_thread(
+                    review_rows, "SELECT deployment_id FROM curie.thread_publication_lineages"
+                ))[0]
+                lineage_response = await http.get(
+                    f"{api_url}/v1/internal/publications/lineage",
+                    params={
+                        "deployment_id": str(lineage["deployment_id"]),
+                        "conversation_id": thread_key,
+                        "repo_full_name": REPO,
+                    },
+                    headers={"X-Curie-Worker-Token": "fixture-review-worker-token"},
+                )
+                assert lineage_response.status_code == 200, lineage_response.text
+                assert lineage_response.json()["head_sha"] == HEAD
+                assert lineage_response.json()["conversation_id"] == thread_key
 
                 def workspace(substrate):
                     return WorkspaceClaimCoordinator(
@@ -875,6 +904,9 @@ def test_real_review_consumer_waits_for_active_turn_and_revalidates_before_new_t
                         first_id, _ = await dispatch_new()
                         async with asyncio.timeout(10):
                             while not h.runner.turn_active:
+                                assert first_id in consumer._inflight_ids, (
+                                    "initial ordinary delivery ended before a model turn opened"
+                                )
                                 await asyncio.sleep(0.01)
                         ordinary_steer = original.model_copy(update={
                             "event_id": f"ordinary-{uuid.uuid4()}", "text": "Also cover the edge."
@@ -956,6 +988,10 @@ def test_real_review_consumer_waits_for_active_turn_and_revalidates_before_new_t
                         assert h.runner.opened[1] == json.loads(review_fields["payload"])["text"]
                         assert h.runner.steers == [ordinary_steer.text]
                         assert f"/repos/{REPO}/pulls/17" in truth.calls
+                        if permission_case == "legacy":
+                            assert permission_path not in truth.calls
+                        else:
+                            assert permission_path in truth.calls
                         assert await h.async_redis.xpending_range(
                             stream, h.config.consumer_group, review_id, review_id, 1
                         ) == []

--- a/apps/api/tests/test_github_review_events.py
+++ b/apps/api/tests/test_github_review_events.py
@@ -35,7 +35,7 @@ from curie_api.github_review_truth import BoundReviewLineage, verify_feedback_tr
 from curie_api.main import create_app
 from curie_test_support.valkey import connect_or_skip
 from fastapi.testclient import TestClient
-from sqlalchemy import text
+from sqlalchemy import literal, text
 from sqlalchemy.ext.asyncio import create_async_engine
 
 DELIVERY = str(uuid.UUID(int=1))
@@ -735,6 +735,7 @@ def test_binding_quota_refuses_new_feedback_and_keeps_an_observable_row(review_s
 
 @pytest.mark.parametrize("permission_case", [
     "legacy", "allowed", "revoked", "wrong_id", "bad_login", "http404", "http403", "timeout",
+    "reserve_unavailable", "http403_cap", "reserve_cap",
 ])
 def test_real_review_consumer_waits_for_active_turn_and_revalidates_before_new_turn(
     review_stack, tmp_path, permission_case,
@@ -768,6 +769,8 @@ def test_real_review_consumer_waits_for_active_turn_and_revalidates_before_new_t
     permission = {"permission": "write", "role_name": "write", "user": {"id": 41}}
     permission_status = 200
     permission_timeout = False
+    reservation_fault_installed = False
+    reservation_fault_name = f"review_reservation_{uuid.uuid4().hex}"
     permission_path = f"/repos/{REPO}/collaborators/example-reviewer/permission"
     lineage_authorization = "Basic " + base64.b64encode(
         b"x-access-token:fixture-app-token-private-sentinel"
@@ -814,6 +817,39 @@ def test_real_review_consumer_waits_for_active_turn_and_revalidates_before_new_t
         secret_key=settings.s3_secret_key, region=settings.s3_region,
     )
     objects_client.create_bucket(Bucket=bucket)
+
+    def install_reservation_fault() -> None:
+        nonlocal reservation_fault_installed
+        # Real task-owned database fault at the reserve sibling, after the live
+        # API verifier succeeds. The API/DB/Valkey are never replaced by doubles.
+        # clean_db depends on _disposable_db: this function exists only in that
+        # run's freshly created DB. The runtime owner also drops its own volume
+        # after a killed pytest. Names and the origin predicate are task scoped.
+        reservation_fault_installed = True
+        review_rows(f"""
+            CREATE FUNCTION curie.{reservation_fault_name}()
+            RETURNS trigger LANGUAGE plpgsql AS $$
+            BEGIN RAISE EXCEPTION 'task-owned reservation failure'; END $$
+        """)
+        origin = str(literal(truth.feedback.event_id).compile(
+            compile_kwargs={"literal_binds": True}
+        ))
+        review_rows(f"""
+            CREATE TRIGGER {reservation_fault_name}
+            BEFORE INSERT ON curie.publication_review_reservations
+            FOR EACH ROW WHEN (NEW.origin_key = {origin})
+            EXECUTE FUNCTION curie.{reservation_fault_name}()
+        """)
+
+    def remove_reservation_fault() -> None:
+        nonlocal reservation_fault_installed
+        if reservation_fault_installed:
+            review_rows(
+                f"DROP TRIGGER IF EXISTS {reservation_fault_name} "
+                "ON curie.publication_review_reservations"
+            )
+            review_rows(f"DROP FUNCTION IF EXISTS curie.{reservation_fault_name}()")
+            reservation_fault_installed = False
 
     async def exercise() -> None:
         nonlocal permission_status, permission_timeout
@@ -867,6 +903,7 @@ def test_real_review_consumer_waits_for_active_turn_and_revalidates_before_new_t
                 async with kernel_harness(
                     names, valkey, binding=BindingResolver(engine, make_config(names)),
                     publication_creator=publication_client, workspace_factory=workspace,
+                    max_delivery=2, reclaim_min_idle_ms=1,
                 ) as h:
                     await asyncio.to_thread(
                         h.substrate.claim, thread_key,
@@ -942,9 +979,11 @@ def test_real_review_consumer_waits_for_active_turn_and_revalidates_before_new_t
                         elif permission_case == "bad_login":
                             truth.comment["user"]["login"] = "wrong/path"
                         elif permission_case.startswith("http"):
-                            permission_status = int(permission_case[4:])
+                            permission_status = int(permission_case[4:].removesuffix("_cap"))
                         elif permission_case == "timeout":
                             permission_timeout = True
+                        elif permission_case.startswith("reserve"):
+                            await asyncio.to_thread(install_reservation_fault)
                         truth.calls.clear()
                         await consumer._dispatch(review_id, review_fields)
                         await handler_done(review_id)
@@ -969,7 +1008,10 @@ def test_real_review_consumer_waits_for_active_turn_and_revalidates_before_new_t
                                 "SELECT status,error_code FROM curie.github_review_feedback",
                             ) == [{"status": "refused", "error_code": code}]
                             return
-                        if permission_case in {"http404", "http403", "timeout"}:
+                        if permission_case in {
+                            "http404", "http403", "timeout", "reserve_unavailable",
+                            "http403_cap", "reserve_cap",
+                        }:
                             assert h.runner.opened == [original.text]
                             assert len(await h.async_redis.xpending_range(
                                 stream, h.config.consumer_group, review_id, review_id, 1
@@ -981,7 +1023,40 @@ def test_real_review_consumer_waits_for_active_turn_and_revalidates_before_new_t
                                 review_rows,
                                 "SELECT status,error_code FROM curie.github_review_feedback",
                             ) == [{"status": "queued", "error_code": None}]
+                            # A transient authority read is not terminal. It is
+                            # still bounded by the existing real PEL delivery cap.
+                            assert await consumer._dead_letter_over_cap() == set()
+                            if permission_case.endswith("_cap"):
+                                await h.async_redis.xclaim(
+                                    stream, h.config.consumer_group, h.config.consumer_name,
+                                    min_idle_time=0, message_ids=[review_id], idle=1000,
+                                )
+                                assert await consumer._dead_letter_over_cap() == {review_id}
+                                assert await h.async_redis.xpending_range(
+                                    stream, h.config.consumer_group, review_id, review_id, 1
+                                ) == []
+                                dead = await h.async_redis.xrange(
+                                    h.config.dead_letter_stream_name()
+                                )
+                                assert len(dead) == 1
+                                assert dead[0][1]["dl_original_id"] == review_id
+                                assert json.loads(dead[0][1]["payload"]) == json.loads(
+                                    review_fields["payload"]
+                                )
+                                reconciler = client.app.state.github_review_reconciler
+                                assert await reconciler.reconcile_terminal() == 1
+                                assert await asyncio.to_thread(
+                                    review_rows,
+                                    "SELECT status,error_code FROM curie.github_review_feedback",
+                                ) == [{
+                                    "status": "dead_lettered",
+                                    "error_code": "delivery_dead_lettered",
+                                }]
+                                assert h.runner.opened == [original.text]
+                                return
                             permission_status, permission_timeout = 200, False
+                            await asyncio.to_thread(remove_reservation_fault)
+                            truth.calls.clear()
                             await consumer._dispatch(review_id, review_fields)
                             await handler_done(review_id)
                         assert len(h.runner.opened) == 2
@@ -1004,6 +1079,7 @@ def test_real_review_consumer_waits_for_active_turn_and_revalidates_before_new_t
                     finally:
                         hold.set()
                         await asyncio.gather(*list(consumer._inflight), return_exceptions=True)
+                        await asyncio.to_thread(remove_reservation_fault)
         finally:
             await engine.dispose()
             server.should_exit = True

--- a/apps/api/tests/test_github_review_events.py
+++ b/apps/api/tests/test_github_review_events.py
@@ -172,7 +172,9 @@ def test_app_reinstallation_does_not_change_feedback_execution_identity() -> Non
     assert replacement.installation_id != original.installation_id
 
 
-@pytest.mark.parametrize("association", [None, "NONE", "CONTRIBUTOR", "FIRST_TIMER", [], "member"])
+@pytest.mark.parametrize(
+    "association", [None, "NONE", "FIRST_TIME_CONTRIBUTOR", "FIRST_TIMER", [], "member"]
+)
 def test_drive_by_or_malformed_sender_association_cannot_authorize_feedback(association) -> None:
     payload = feedback_payload()
     payload["comment"]["author_association"] = association
@@ -731,8 +733,11 @@ def test_binding_quota_refuses_new_feedback_and_keeps_an_observable_row(review_s
     assert valkey.xlen(stream) == 0
 
 
+@pytest.mark.parametrize("permission_case", [
+    "legacy", "allowed", "revoked", "wrong_id", "bad_login", "http404", "http403", "timeout",
+])
 def test_real_review_consumer_waits_for_active_turn_and_revalidates_before_new_turn(
-    review_stack, tmp_path
+    review_stack, tmp_path, permission_case,
 ) -> None:
     """Actual API/DB/Valkey/consumer/RunnerClient; GitHub and ACI peer are fixtures.
 
@@ -760,6 +765,25 @@ def test_real_review_consumer_waits_for_active_turn_and_revalidates_before_new_t
     from apps.worker.tests.kernel.conftest import kernel_harness, make_config
 
     client, truth, valkey, stream = review_stack
+    permission = {"permission": "write", "role_name": "write", "user": {"id": 41}}
+    permission_status = 200
+    permission_timeout = False
+    if permission_case != "legacy":
+        from dataclasses import replace
+
+        truth.payload["comment"]["author_association"] = "CONTRIBUTOR"
+        truth.comment["author_association"] = "CONTRIBUTOR"
+        truth.feedback = replace(truth.feedback, author_association="CONTRIBUTOR")
+
+    def github_permission(request):
+        if request.url.path != f"/repos/{REPO}/collaborators/example-reviewer/permission":
+            return truth.handle(request)
+        truth.calls.append(request.url.path)
+        assert request.headers["Authorization"] == "Bearer fixture-app-token-private-sentinel"
+        if permission_timeout:
+            raise httpx.ReadTimeout("synthetic permission timeout", request=request)
+        return httpx.Response(permission_status, json=permission)
+
     settings = get_settings()
     names = {"stream": stream, "group": f"{stream}:group",
              "prefix": settings.worker_key_prefix, "sandbox_prefix": f"{stream}:sandbox"}
@@ -778,6 +802,7 @@ def test_real_review_consumer_waits_for_active_turn_and_revalidates_before_new_t
     objects_client.create_bucket(Bucket=bucket)
 
     async def exercise() -> None:
+        nonlocal permission_status, permission_timeout
         sock = socket.socket()
         sock.bind(("127.0.0.1", 0))
         sock.listen(16)
@@ -878,9 +903,55 @@ def test_real_review_consumer_waits_for_active_turn_and_revalidates_before_new_t
                         h.runner.default_script = [
                             Final(text="review complete", status=SessionStatus.DONE)
                         ]
+                        if permission_case == "revoked":
+                            permission["permission"] = "read"
+                        elif permission_case == "wrong_id":
+                            permission["user"] = {"id": 42}
+                        elif permission_case == "bad_login":
+                            truth.comment["user"]["login"] = "wrong/path"
+                        elif permission_case.startswith("http"):
+                            permission_status = int(permission_case[4:])
+                        elif permission_case == "timeout":
+                            permission_timeout = True
                         truth.calls.clear()
                         await consumer._dispatch(review_id, review_fields)
                         await handler_done(review_id)
+                        if permission_case in {"revoked", "wrong_id", "bad_login"}:
+                            assert h.runner.opened == [original.text]
+                            assert h.runner.steers == [ordinary_steer.text]
+                            assert await asyncio.to_thread(
+                                review_rows, "SELECT id FROM curie.publication_review_reservations"
+                            ) == []
+                            assert await h.async_redis.xpending_range(
+                                stream, h.config.consumer_group, review_id, review_id, 1
+                            ) == []
+                            reconciler = client.app.state.github_review_reconciler
+                            assert await reconciler.reconcile_terminal() == 1
+                            code = {
+                                "revoked": "sender_permission_refused",
+                                "wrong_id": "sender_permission_identity_mismatch",
+                                "bad_login": "non_human_sender",
+                            }[permission_case]
+                            assert await asyncio.to_thread(
+                                review_rows,
+                                "SELECT status,error_code FROM curie.github_review_feedback",
+                            ) == [{"status": "refused", "error_code": code}]
+                            return
+                        if permission_case in {"http404", "http403", "timeout"}:
+                            assert h.runner.opened == [original.text]
+                            assert len(await h.async_redis.xpending_range(
+                                stream, h.config.consumer_group, review_id, review_id, 1
+                            )) == 1
+                            assert await asyncio.to_thread(
+                                review_rows, "SELECT id FROM curie.publication_review_reservations"
+                            ) == []
+                            assert await asyncio.to_thread(
+                                review_rows,
+                                "SELECT status,error_code FROM curie.github_review_feedback",
+                            ) == [{"status": "queued", "error_code": None}]
+                            permission_status, permission_timeout = 200, False
+                            await consumer._dispatch(review_id, review_fields)
+                            await handler_done(review_id)
                         assert len(h.runner.opened) == 2
                         assert h.runner.opened[1] == json.loads(review_fields["payload"])["text"]
                         assert h.runner.steers == [ordinary_steer.text]
@@ -908,15 +979,21 @@ def test_real_review_consumer_waits_for_active_turn_and_revalidates_before_new_t
                     await asyncio.gather(server_task, return_exceptions=True)
                 sock.close()
 
+    original_github = client.app.state.http_client
+    injected = httpx.AsyncClient(transport=httpx.MockTransport(github_permission))
+    client.app.state.http_client = injected
     try:
         client.portal.call(exercise)
     finally:
+        client.app.state.http_client = original_github
+
         def cleanup_sandbox_keys():
             keys = list(valkey.scan_iter(match=f"{stream}:sandbox*"))
             if keys:
                 valkey.delete(*keys)
 
         with ExitStack() as cleanup:
+            cleanup.callback(client.portal.call, injected.aclose)
             cleanup.callback(cleanup_sandbox_keys)
             cleanup.callback(objects_client.close)
             cleanup.callback(objects_client.delete_bucket, Bucket=bucket)

--- a/apps/api/tests/test_github_review_pending_outbox.py
+++ b/apps/api/tests/test_github_review_pending_outbox.py
@@ -1,0 +1,80 @@
+"""A queued transport receipt can precede its durable SQL queued mark."""
+
+import copy
+import json
+
+import pytest
+from sqlalchemy.exc import DBAPIError
+
+from apps.api.tests.test_github_review_events import HEAD, post_review, review_rows
+from apps.api.tests.test_github_review_events import review_app_key as review_app_key
+from apps.api.tests.test_github_review_events import review_stack as review_stack
+
+
+@pytest.mark.parametrize("operation", ["verify", "reserve"])
+def test_waiting_outbox_is_retryable_until_exact_queue_receipt_is_reconciled(
+    review_stack, operation,
+):
+    client, truth, valkey, stream = review_stack
+    review_rows("""
+        CREATE FUNCTION curie.review_pending_reject() RETURNS trigger LANGUAGE plpgsql AS $$
+        BEGIN
+          IF NEW.status = 'queued' THEN RAISE EXCEPTION 'task-owned queued-mark failure'; END IF;
+          RETURN NEW;
+        END $$
+    """)
+    review_rows("""
+        CREATE TRIGGER review_pending_reject BEFORE UPDATE ON curie.github_review_feedback
+        FOR EACH ROW EXECUTE FUNCTION curie.review_pending_reject()
+    """)
+    try:
+        with pytest.raises(DBAPIError):
+            post_review(client, truth)
+        rows = valkey.xrange(stream)
+        assert len(rows) == 1
+        stream_id, fields = rows[0]
+        turn = json.loads(fields["payload"])
+        lineage = review_rows(
+            "SELECT deployment_id,version FROM curie.thread_publication_lineages"
+        )[0]
+        payload = {"turn": turn, "deployment_id": str(lineage["deployment_id"])}
+        if operation == "reserve":
+            payload.update(expected_lineage_version=lineage["version"], expected_head_sha=HEAD)
+        headers = {"X-Curie-Worker-Token": "fixture-review-worker-token"}
+        path = f"/v1/internal/github/reviews/{turn['event_id']}/{operation}"
+        forged = copy.deepcopy(payload)
+        forged["turn"]["author"] = "U0REQUEST1"
+        rejected = client.post(path, json=forged, headers=headers)
+        assert rejected.status_code == 409
+        assert rejected.json()["detail"]["code"] == "feedback_turn_mismatch"
+        calls = len(truth.calls)
+        waiting = client.post(path, json=payload, headers=headers)
+        assert waiting.status_code == 503, waiting.text
+        assert waiting.json()["detail"]["code"] == "feedback_outbox_pending"
+        assert waiting.headers["cache-control"] == "no-store"
+        assert len(truth.calls) == calls  # No provider read or model authority while pending.
+        assert review_rows(
+            "SELECT status,version,error_code FROM curie.github_review_feedback"
+        ) == [
+            {"status": "waiting", "version": 1, "error_code": None}
+        ]
+        assert review_rows("SELECT id FROM curie.publication_review_reservations") == []
+    finally:
+        review_rows("DROP TRIGGER review_pending_reject ON curie.github_review_feedback")
+        review_rows("DROP FUNCTION curie.review_pending_reject()")
+    reconciler = client.app.state.github_review_reconciler
+    assert client.portal.call(reconciler.reconcile_once) == 1
+    assert valkey.xrange(stream) == [(stream_id, fields)]
+    ready = client.post(path, json=payload, headers=headers)
+    assert ready.status_code == 200, ready.text
+    assert ready.json()["origin_key"] == turn["event_id"]
+    assert review_rows("SELECT status FROM curie.github_review_feedback") == [
+        {"status": "reserved" if operation == "reserve" else "queued"}
+    ]
+    reservations = review_rows(
+        "SELECT origin_key,status FROM curie.publication_review_reservations"
+    )
+    assert reservations == (
+        [{"origin_key": turn["event_id"], "status": "reserved"}]
+        if operation == "reserve" else []
+    )

--- a/apps/api/tests/test_github_review_sender_authority.py
+++ b/apps/api/tests/test_github_review_sender_authority.py
@@ -1,0 +1,172 @@
+"""App-retrieved effective permission is independent of comment association."""
+
+import asyncio
+from dataclasses import replace
+
+import httpx
+import pytest
+from curie_api.github_app import _RESOLVERS
+from curie_api.github_review_events import FeedbackIgnored, FeedbackUnavailable, parse_feedback
+from curie_api.github_review_truth import verify_feedback_truth
+
+from apps.api.tests.test_github_review_events import (
+    DELIVERY,
+    HEAD,
+    REPO,
+    GitHubTruth,
+    feedback_payload,
+    verify_truth,
+)
+from apps.api.tests.test_github_review_events import review_app_key as review_app_key
+
+PERMISSION_PATH = f"/repos/{REPO}/collaborators/example-reviewer/permission"
+
+
+class PermissionTruth(GitHubTruth):
+    def __init__(self, event, key, association="CONTRIBUTOR"):
+        super().__init__(event, key)
+        source = "review" if event == "pull_request_review" else "comment"
+        self.payload[source]["author_association"] = association
+        self.comment["author_association"] = association
+        self.feedback = replace(self.feedback, author_association=association)
+        # GitHub's documented permission endpoint returns effective legacy
+        # permission separately from role_name; maintain maps to write.
+        # https://docs.github.com/en/rest/collaborators/collaborators#get-repository-permissions-for-a-user
+        self.permission = {
+            "permission": "admin", "role_name": "admin",
+            "user": {"id": 41, "login": "example-reviewer", "type": "User"},
+        }
+        self.permission_status = 200
+        self.permission_timeout = False
+
+    def handle(self, request):
+        if request.url.path != PERMISSION_PATH:
+            return super().handle(request)
+        self.calls.append(request.url.path)
+        assert request.headers["Authorization"] == "Bearer fixture-app-token-private-sentinel"
+        if self.permission_timeout:
+            raise httpx.ReadTimeout("synthetic permission timeout", request=request)
+        return httpx.Response(self.permission_status, json=self.permission)
+
+
+def test_contributor_parsing_retains_a_claim_without_granting_permission():
+    payload = feedback_payload()
+    payload["comment"]["author_association"] = "CONTRIBUTOR"
+    assert parse_feedback("issue_comment", payload, DELIVERY).author_association == "CONTRIBUTOR"
+
+
+@pytest.mark.parametrize("event", [
+    "issue_comment", "pull_request_review_comment", "pull_request_review",
+])
+@pytest.mark.parametrize("permission", ["write", "admin"])
+def test_contributor_requires_effective_app_permission_for_each_feedback_family(
+    review_app_key, monkeypatch, event, permission,
+):
+    truth = PermissionTruth(event, review_app_key)
+    truth.permission.update(permission=permission, role_name="custom-example-role")
+    assert asyncio.run(verify_truth(truth, monkeypatch)) == HEAD
+    assert truth.calls.count(PERMISSION_PATH) == 1
+    assert truth.calls.index(f"/repos/{REPO}") < truth.calls.index(PERMISSION_PATH)
+
+
+@pytest.mark.parametrize("association", ["OWNER", "MEMBER", "COLLABORATOR"])
+def test_existing_association_policy_keeps_its_independent_positive_path(
+    review_app_key, monkeypatch, association,
+):
+    truth = PermissionTruth("issue_comment", review_app_key, association)
+    truth.permission_status = 403
+    assert asyncio.run(verify_truth(truth, monkeypatch)) == HEAD
+    assert PERMISSION_PATH not in truth.calls
+
+
+@pytest.mark.parametrize("permission", ["read", "none", "maintain", None, True, [], {}])
+def test_contributor_cannot_gain_authority_from_role_name_or_unproved_permission(
+    review_app_key, monkeypatch, permission,
+):
+    truth = PermissionTruth("issue_comment", review_app_key)
+    truth.permission.update(permission=permission, role_name="admin")
+    with pytest.raises(FeedbackIgnored, match="sender_permission_refused"):
+        asyncio.run(verify_truth(truth, monkeypatch))
+    assert truth.calls.count(PERMISSION_PATH) == 1
+
+
+@pytest.mark.parametrize("user", [None, [], {}, {"id": 42}, {"id": True}])
+def test_permission_response_must_name_the_exact_fetched_immutable_user(
+    review_app_key, monkeypatch, user,
+):
+    truth = PermissionTruth("issue_comment", review_app_key)
+    truth.permission["user"] = user
+    with pytest.raises(FeedbackIgnored, match="sender_permission_identity_mismatch"):
+        asyncio.run(verify_truth(truth, monkeypatch))
+
+
+@pytest.mark.parametrize("status", [401, 403, 404, 429, 500])
+def test_unknown_permission_is_retryable_even_after_repository_access_was_proven(
+    review_app_key, monkeypatch, status,
+):
+    truth = PermissionTruth("issue_comment", review_app_key)
+    truth.permission_status = status
+    with pytest.raises(FeedbackUnavailable, match="sender_permission_unavailable"):
+        asyncio.run(verify_truth(truth, monkeypatch))
+    assert f"/repos/{REPO}" in truth.calls and PERMISSION_PATH in truth.calls
+
+
+def test_permission_timeout_never_grants_contributor_authority(review_app_key, monkeypatch):
+    truth = PermissionTruth("issue_comment", review_app_key)
+    truth.permission_timeout = True
+    with pytest.raises(FeedbackUnavailable, match="sender_permission_unavailable"):
+        asyncio.run(verify_truth(truth, monkeypatch))
+
+
+@pytest.mark.parametrize("signed,fetched", [
+    ("CONTRIBUTOR", "MEMBER"), ("MEMBER", "CONTRIBUTOR"),
+])
+def test_association_drift_never_selects_an_easier_authorization_path(
+    review_app_key, monkeypatch, signed, fetched,
+):
+    truth = PermissionTruth("issue_comment", review_app_key, signed)
+    truth.comment["author_association"] = fetched
+    with pytest.raises(FeedbackIgnored, match="feedback_changed"):
+        asyncio.run(verify_truth(truth, monkeypatch))
+    assert PERMISSION_PATH not in truth.calls
+
+
+def test_fetched_login_is_validated_before_it_can_address_permission_endpoint(
+    review_app_key, monkeypatch,
+):
+    truth = PermissionTruth("issue_comment", review_app_key)
+    truth.comment["user"]["login"] = "wrong/path"
+    with pytest.raises(FeedbackIgnored, match="non_human_sender"):
+        asyncio.run(verify_truth(truth, monkeypatch))
+    assert PERMISSION_PATH not in truth.calls
+
+
+def test_permission_revocation_is_observed_within_the_same_verifier_client(
+    review_app_key, monkeypatch,
+):
+    truth = PermissionTruth("issue_comment", review_app_key)
+    real_client = httpx.Client
+    monkeypatch.setattr(
+        "curie_api.github_app.httpx.Client",
+        lambda *a, **kw: real_client(transport=httpx.MockTransport(truth.handle)),
+    )
+
+    async def exercise():
+        async with httpx.AsyncClient(transport=httpx.MockTransport(truth.handle)) as client:
+            async def verify():
+                return await verify_feedback_truth(
+                    truth.feedback, truth.lineage, settings=truth.settings, client=client
+                )
+            assert await verify() == HEAD
+            truth.permission["permission"] = "read"
+            with pytest.raises(FeedbackIgnored, match="sender_permission_refused"):
+                await verify()
+            truth.permission["permission"] = "write"
+            assert await verify() == HEAD
+            assert truth.calls.count(PERMISSION_PATH) == 3
+
+    _RESOLVERS.clear()
+    try:
+        asyncio.run(exercise())
+    finally:
+        _RESOLVERS.clear()

--- a/apps/api/tests/test_github_review_terminal.py
+++ b/apps/api/tests/test_github_review_terminal.py
@@ -1,0 +1,76 @@
+"""The API observer reads the real worker's terminal key configuration."""
+
+import asyncio
+import json
+import uuid
+
+import pytest
+import redis.asyncio as redis
+from curie_api.config import Settings
+from curie_worker.config import WorkerConfig
+
+
+@pytest.mark.parametrize("override", [None, "KEY_PREFIX", "CURIE_KEY_PREFIX"])
+def test_review_terminal_prefix_matches_actual_worker_environment(
+    monkeypatch: pytest.MonkeyPatch, override: str | None
+) -> None:
+    monkeypatch.delenv("KEY_PREFIX", raising=False)
+    monkeypatch.delenv("CURIE_KEY_PREFIX", raising=False)
+    if override:
+        monkeypatch.setenv(override, "test:review-terminal")
+    expected = "test:review-terminal" if override == "KEY_PREFIX" else "curie:worker"
+    assert WorkerConfig().key_prefix == expected
+    assert Settings(_env_file=None).worker_key_prefix == expected
+
+
+@pytest.mark.parametrize("decode_responses", [False, True])
+def test_graveyard_observer_reads_actual_client_bytes_and_decoded_fields(
+    decode_responses: bool,
+) -> None:
+    from curie_api.github_review_terminal import read_review_dead_letter
+    from curie_test_support.valkey import (
+        VALKEY_HOST,
+        VALKEY_PORT,
+        VALKEY_PW,
+        connect_or_skip,
+    )
+
+    probe = connect_or_skip()
+    probe.close()
+
+    async def exercise() -> None:
+        settings = Settings(runs_stream=f"test:review-bytes:{uuid.uuid4()}")
+        stream = settings.dead_letter_stream_name()
+        valkey = redis.Redis(
+            host=VALKEY_HOST, port=VALKEY_PORT, password=VALKEY_PW or None,
+            decode_responses=decode_responses, socket_connect_timeout=2,
+        )
+        turn = {"event_id": "github-feedback-example", "conversation_id": "review-original"}
+        try:
+            assert await read_review_dead_letter(
+                valkey, settings, stream_id="1-0", turn=turn, cursor=None,
+            ) == (False, None)
+            unrelated = await valkey.xadd(stream, {
+                "dl_original_id": "2-0", "payload": json.dumps(turn),
+            })
+            unrelated_id = unrelated.decode() if isinstance(unrelated, bytes) else unrelated
+            assert await read_review_dead_letter(
+                valkey, settings, stream_id="1-0", turn=turn, cursor=None,
+            ) == (False, unrelated_id)
+            matched = await valkey.xadd(stream, {
+                "dl_original_id": "1-0", "payload": json.dumps(turn),
+            })
+            matched_id = matched.decode() if isinstance(matched, bytes) else matched
+            assert await read_review_dead_letter(
+                valkey, settings, stream_id="1-0", turn=turn, cursor=unrelated_id,
+            ) == (True, matched_id)
+            # Removing real evidence must restore unknown, never infer completion.
+            await valkey.delete(stream)
+            assert await read_review_dead_letter(
+                valkey, settings, stream_id="1-0", turn=turn, cursor=unrelated_id,
+            ) == (False, unrelated_id)
+        finally:
+            await valkey.delete(stream)
+            await valkey.aclose()
+
+    asyncio.run(exercise())

--- a/apps/api/tests/test_migration_0043_github_reviews.py
+++ b/apps/api/tests/test_migration_0043_github_reviews.py
@@ -1,0 +1,70 @@
+"""An upgrade rollback must not erase admitted or retryable review work."""
+
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+
+from apps.api.tests.test_github_review_events import (
+    _write_actual_fenced_review_terminal,
+    post_review,
+    review_rows,
+)
+from apps.api.tests.test_github_review_events import review_app_key as review_app_key
+from apps.api.tests.test_github_review_events import review_stack as review_stack
+
+
+@pytest.mark.parametrize("retryable", [False, True])
+def test_0043_refuses_active_work_and_allows_rollback_after_real_settlement(
+    review_stack, retryable,
+):
+    client, truth, valkey, stream = review_stack
+    if retryable:
+        truth.feedback_status = 503
+    admitted = post_review(client, truth)
+    assert admitted.status_code == (503 if retryable else 200)
+    before_feedback = review_rows("SELECT event_id,status FROM curie.github_review_feedback")
+    before_delivery = review_rows("SELECT delivery_id,status FROM curie.github_review_deliveries")
+    assert [row["status"] for row in before_delivery] == [
+        "retryable" if retryable else "accepted"
+    ]
+    assert [row["status"] for row in before_feedback] == ([] if retryable else ["queued"])
+    assert valkey.xlen(stream) == (0 if retryable else 1)
+    before_revision = review_rows("SELECT version_num FROM curie.alembic_version")
+    api_dir = Path(__file__).resolve().parents[1]
+    config = Config(str(api_dir / "alembic.ini"))
+    config.set_main_option("script_location", str(api_dir / "alembic"))
+    try:
+        with pytest.raises(RuntimeError, match="deliveries are active"):
+            command.downgrade(config, "0042")
+        assert review_rows("SELECT version_num FROM curie.alembic_version") == before_revision
+        assert review_rows("SELECT event_id,status FROM curie.github_review_feedback") == (
+            before_feedback
+        )
+        assert review_rows("SELECT delivery_id,status FROM curie.github_review_deliveries") == (
+            before_delivery
+        )
+        if retryable:
+            # Recovery is explicit signed redelivery, not assumed GitHub retry.
+            truth.feedback_status = 200
+            assert post_review(client, truth).json()["status"] == "feedback_queued"
+        _write_actual_fenced_review_terminal(client, truth.feedback.event_id, stream)
+        assert client.portal.call(client.app.state.github_review_reconciler.reconcile_terminal) == 1
+        assert review_rows("SELECT status FROM curie.github_review_feedback") == [
+            {"status": "settled"}
+        ]
+        assert review_rows("SELECT status FROM curie.github_review_deliveries") == [
+            {"status": "accepted"}
+        ]
+        command.downgrade(config, "0042")
+        assert review_rows("SELECT version_num FROM curie.alembic_version") == [
+            {"version_num": "0042"}
+        ]
+        assert review_rows(
+            "SELECT to_regclass('curie.github_review_feedback') AS feedback, "
+            "to_regclass('curie.github_review_deliveries') AS delivery"
+        ) == [{"feedback": None, "delivery": None}]
+    finally:
+        command.upgrade(config, before_revision[0]["version_num"])
+    assert review_rows("SELECT version_num FROM curie.alembic_version") == before_revision

--- a/apps/api/tests/test_publications.py
+++ b/apps/api/tests/test_publications.py
@@ -4743,9 +4743,10 @@ def test_review_authority_downgrade_refuses_an_active_reservation(
     api_dir = Path(__file__).resolve().parents[1]
     config = Config(str(api_dir / "alembic.ini"))
     config.set_main_option("script_location", str(api_dir / "alembic"))
+    before_revision = _rows("SELECT version_num FROM curie.alembic_version")
     with pytest.raises(RuntimeError, match="revisions are active"):
         command.downgrade(config, "0041")
-    assert _rows("SELECT version_num FROM curie.alembic_version")[0]["version_num"] == "0042"
+    assert _rows("SELECT version_num FROM curie.alembic_version") == before_revision
     assert (
         _rows("SELECT status FROM curie.publication_review_reservations")[0]["status"] == "reserved"
     )

--- a/apps/api/tests/test_publications.py
+++ b/apps/api/tests/test_publications.py
@@ -4738,18 +4738,27 @@ def test_review_authority_downgrade_refuses_an_active_reservation(
 
     client, truth, _ = review_lineage_app
     _, _, lineage = _verified_lineage(client, truth, auth_headers)
-    reservation = _reserve_review(client, lineage, "review:retain-on-rollback")
-    assert reservation.status_code == 201, reservation.text
     api_dir = Path(__file__).resolve().parents[1]
     config = Config(str(api_dir / "alembic.ini"))
     config.set_main_option("script_location", str(api_dir / "alembic"))
-    before_revision = _rows("SELECT version_num FROM curie.alembic_version")
-    with pytest.raises(RuntimeError, match="revisions are active"):
-        command.downgrade(config, "0041")
-    assert _rows("SELECT version_num FROM curie.alembic_version") == before_revision
-    assert (
-        _rows("SELECT status FROM curie.publication_review_reservations")[0]["status"] == "reserved"
-    )
+    original_revision = _rows("SELECT version_num FROM curie.alembic_version")
+    try:
+        # #2300 commits each migration independently. Exercise the authority
+        # guard at its own boundary, after higher revisions have safely retired.
+        command.downgrade(config, "0042")
+        before_revision = _rows("SELECT version_num FROM curie.alembic_version")
+        assert before_revision == [{"version_num": "0042"}]
+        reservation = _reserve_review(client, lineage, "review:retain-on-rollback")
+        assert reservation.status_code == 201, reservation.text
+        before_reservation = _rows("SELECT * FROM curie.publication_review_reservations")
+        assert [row["status"] for row in before_reservation] == ["reserved"]
+        with pytest.raises(RuntimeError, match="revisions are active"):
+            command.downgrade(config, "0041")
+        assert _rows("SELECT version_num FROM curie.alembic_version") == before_revision
+        assert _rows("SELECT * FROM curie.publication_review_reservations") == before_reservation
+    finally:
+        command.upgrade(config, original_revision[0]["version_num"])
+    assert _rows("SELECT version_num FROM curie.alembic_version") == original_revision
 
 
 @pytest.mark.parametrize(

--- a/apps/worker/src/curie_worker/approvals.py
+++ b/apps/worker/src/curie_worker/approvals.py
@@ -17,12 +17,13 @@ from __future__ import annotations
 
 import base64
 import logging
+import re
 import uuid
 from dataclasses import dataclass
 from typing import Any, Protocol
 
 import httpx
-from aci_protocol import ApprovalRequest
+from aci_protocol import ApprovalRequest, QueuedTurn
 from curie_telemetry import inject_trace_context
 
 from .workspace import WorkspaceSelectionRefused
@@ -67,6 +68,7 @@ def _publication_refusal(response: httpx.Response) -> str | None:
     if isinstance(detail, str) and detail in _TERMINAL_WORKSPACE_CONFLICT_DETAILS:
         return detail
     return None
+
 
 __all__ = [
     "ApprovalBackendError",
@@ -198,6 +200,14 @@ class ApprovalCreator(Protocol):
     async def create(self, request: ApprovalRequest) -> CreatedApproval: ...
 
 
+@dataclass(frozen=True)
+class VerifiedReviewFeedback:
+    head_sha: str
+    agent_id: uuid.UUID
+    sender: str
+    receipt: str
+
+
 class PublicationCreator(Protocol):
     """Atomic trusted write seam used only for exact publish provenance."""
 
@@ -209,6 +219,12 @@ class PublicationCreator(Protocol):
         conversation_id: str,
         repo_full_name: str,
     ) -> PublicationLineage | None: ...
+
+    async def verify_review_feedback(
+        self,
+        turn: QueuedTurn,
+        deployment_id: uuid.UUID,
+    ) -> VerifiedReviewFeedback: ...
 
 
 class ApprovalReader(Protocol):
@@ -230,13 +246,69 @@ class ApprovalClient:
         client: httpx.AsyncClient,
         read_timeout_s: float,
         worker_token: str = "",
+        review_timeout_s: float = 30.0,
     ) -> None:
         self._url = f"{api_base_url.rstrip('/')}/approvals"
         self._publication_url = f"{api_base_url.rstrip('/')}/v1/internal/publications"
+        self._review_url = f"{api_base_url.rstrip('/')}/v1/internal/github/reviews"
         self._headers = {"X-API-Key": api_key} if api_key else {}
         self._worker_headers = {"X-Curie-Worker-Token": worker_token} if worker_token else {}
         self._client = client
         self._read_timeout_s = read_timeout_s
+        self._review_timeout_s = review_timeout_s
+
+    async def verify_review_feedback(
+        self,
+        turn: QueuedTurn,
+        deployment_id: uuid.UUID,
+    ) -> VerifiedReviewFeedback:
+        """Read the API's current App/binding/head authority, never a credential."""
+        refusal = (
+            "GitHub feedback could not be verified for this conversation; no model turn started."
+        )
+        if (
+            not self._worker_headers
+            or re.fullmatch(
+                r"github-feedback-[0-9a-f-]{36}",
+                turn.event_id,
+            )
+            is None
+        ):
+            raise WorkspaceSelectionRefused(refusal)
+        try:
+            response = await self._client.post(
+                f"{self._review_url}/{turn.event_id}/verify",
+                json={"turn": turn.model_dump(mode="json"), "deployment_id": str(deployment_id)},
+                headers=self._worker_headers,
+                follow_redirects=False,
+                timeout=self._review_timeout_s,
+            )
+        except httpx.HTTPError:
+            raise ApprovalBackendError(
+                "GitHub feedback verification transport unavailable"
+            ) from None
+        if response.status_code in {401, 403, 404, 429} or response.status_code >= 500:
+            raise ApprovalBackendError("GitHub feedback verification temporarily unavailable")
+        if response.status_code != 200:
+            # Response bodies may contain upstream/model text; expose only our
+            # fixed policy refusal. Infrastructure/auth/rollout failures above
+            # remain retryable and cannot silently ACK an unexecuted turn.
+            raise WorkspaceSelectionRefused(refusal)
+        try:
+            body = response.json()
+            head, sender, receipt = body["head_sha"], body["sender"], body["receipt"]
+            if (
+                not isinstance(head, str)
+                or re.fullmatch(r"[0-9a-f]{40}", head) is None
+                or sender != turn.author
+                or not isinstance(receipt, str)
+                or not receipt
+                or len(receipt) > 1024
+            ):
+                raise ValueError("invalid verified feedback")
+            return VerifiedReviewFeedback(head, uuid.UUID(body["agent_id"]), sender, receipt)
+        except (ValueError, TypeError, KeyError):
+            raise WorkspaceSelectionRefused(refusal) from None
 
     async def create(self, request: ApprovalRequest) -> CreatedApproval:
         headers = {**self._headers, "Content-Type": "application/json"}

--- a/apps/worker/src/curie_worker/approvals.py
+++ b/apps/worker/src/curie_worker/approvals.py
@@ -180,6 +180,14 @@ class ApprovalBackendError(Exception):
     than suspending a session no resolution could ever wake."""
 
 
+class ReviewAuthorityUnavailable(Exception):
+    """Review authority is unavailable before any model turn was accepted.
+
+    Keep the delivery pending for the shared bounded reclaim/dead-letter lane;
+    spending the model attempt budget would settle feedback that never ran.
+    """
+
+
 @dataclass(frozen=True)
 class SettledApproval:
     """A resolved record's outcome, for stamping its card (#1084).

--- a/apps/worker/src/curie_worker/approvals.py
+++ b/apps/worker/src/curie_worker/approvals.py
@@ -116,6 +116,7 @@ class PublicationCreateRequest:
     body: str
     reply_conversation_id: str | None = None
     max_patch_bytes: int = 900_000
+    review_origin_key: str | None = None
 
     def to_json(self) -> dict[str, Any]:
         if len(self.patch) > self.max_patch_bytes:
@@ -143,6 +144,8 @@ class PublicationCreateRequest:
         }
         if self.reply_conversation_id is not None:
             payload["reply_conversation_id"] = self.reply_conversation_id
+        if self.review_origin_key is not None:
+            payload["review_origin_key"] = self.review_origin_key
         return payload
 
 
@@ -206,6 +209,9 @@ class VerifiedReviewFeedback:
     agent_id: uuid.UUID
     sender: str
     receipt: str
+    origin_key: str
+    lineage_version: int
+    reservation_id: uuid.UUID | None
 
 
 class PublicationCreator(Protocol):
@@ -225,6 +231,13 @@ class PublicationCreator(Protocol):
         turn: QueuedTurn,
         deployment_id: uuid.UUID,
     ) -> VerifiedReviewFeedback: ...
+
+    async def reserve_review_feedback(
+        self,
+        turn: QueuedTurn,
+        deployment_id: uuid.UUID,
+        verified: VerifiedReviewFeedback,
+    ) -> uuid.UUID: ...
 
 
 class ApprovalReader(Protocol):
@@ -304,11 +317,62 @@ class ApprovalClient:
                 or not isinstance(receipt, str)
                 or not receipt
                 or len(receipt) > 1024
+                or body["origin_key"] != turn.event_id
+                or type(body["lineage_version"]) is not int
+                or body["lineage_version"] < 1
             ):
                 raise ValueError("invalid verified feedback")
-            return VerifiedReviewFeedback(head, uuid.UUID(body["agent_id"]), sender, receipt)
+            return VerifiedReviewFeedback(
+                head,
+                uuid.UUID(body["agent_id"]),
+                sender,
+                receipt,
+                body["origin_key"],
+                body["lineage_version"],
+                uuid.UUID(body["reservation_id"]) if body["reservation_id"] is not None else None,
+            )
         except (ValueError, TypeError, KeyError):
             raise WorkspaceSelectionRefused(refusal) from None
+
+    async def reserve_review_feedback(
+        self,
+        turn: QueuedTurn,
+        deployment_id: uuid.UUID,
+        verified: VerifiedReviewFeedback,
+    ) -> uuid.UUID:
+        """Bind a verified origin to its own revision after the idle fence."""
+        if not self._worker_headers or verified.origin_key != turn.event_id:
+            raise WorkspaceSelectionRefused("GitHub feedback revision identity was refused.")
+        try:
+            response = await self._client.post(
+                f"{self._review_url}/{turn.event_id}/reserve",
+                json={
+                    "turn": turn.model_dump(mode="json"),
+                    "deployment_id": str(deployment_id),
+                    "expected_lineage_version": verified.lineage_version,
+                    "expected_head_sha": verified.head_sha,
+                },
+                headers=self._worker_headers,
+                follow_redirects=False,
+                # This endpoint performs only SQL CAS and must remain short
+                # while the worker holds the idle thread's route lock.
+                timeout=self._read_timeout_s,
+            )
+        except httpx.HTTPError:
+            raise ApprovalBackendError("GitHub review reservation transport unavailable") from None
+        if response.status_code in {401, 403, 404, 429} or response.status_code >= 500:
+            raise ApprovalBackendError("GitHub review reservation temporarily unavailable")
+        if response.status_code != 200:
+            raise WorkspaceSelectionRefused("GitHub feedback revision is no longer executable.")
+        try:
+            body = response.json()
+            if body["origin_key"] != turn.event_id:
+                raise ValueError("wrong review origin")
+            return uuid.UUID(body["reservation_id"])
+        except (ValueError, TypeError, KeyError):
+            raise WorkspaceSelectionRefused(
+                "GitHub feedback revision identity was refused."
+            ) from None
 
     async def create(self, request: ApprovalRequest) -> CreatedApproval:
         headers = {**self._headers, "Content-Type": "application/json"}

--- a/apps/worker/src/curie_worker/kernel.py
+++ b/apps/worker/src/curie_worker/kernel.py
@@ -84,6 +84,7 @@ from .approvals import (
     PublicationCreateRequest,
     PublicationCreator,
     PublicationLineage,
+    VerifiedReviewFeedback,
 )
 from .behaviorpacks import (
     BehaviorPacks,
@@ -572,6 +573,7 @@ class TurnOutcome:
     approval_granted_tool: str | None = None
     publication_snapshot: RunnerWorkspaceSnapshot | None = None
     publication_snapshot_error: str | None = None
+    review_origin_key: str | None = None
 
 
 class ThreadBusyError(RuntimeError):
@@ -2243,6 +2245,7 @@ class Kernel:
         routed: _RouteResult | None = None
         review_head: str | None = None
         review_receipt: str | None = None
+        verified_review: VerifiedReviewFeedback | None = None
 
         def close_routed_turn() -> None:
             if routed is not None and routed.turn is not None:
@@ -2277,6 +2280,7 @@ class Kernel:
                             "GitHub feedback no longer belongs to this conversation."
                         )
                     review_head, review_receipt = verified.head_sha, verified.receipt
+                    verified_review = verified
                 async with self._lock.hold(self._config.lock_key(thread_key)):
                     routed = await self._route_and_start(
                         thread_key,
@@ -2288,6 +2292,8 @@ class Kernel:
                         source=qevent.source,
                         remaining_s=remaining_s,
                         required_review_head=review_head,
+                        verified_review=verified_review,
+                        review_turn=qevent if verified_review is not None else None,
                     )
             except BaseException:
                 # start_turn owns a live response as soon as it returns, which
@@ -2464,6 +2470,8 @@ class Kernel:
             ):
                 await self.interrupt_thread(thread_key, f"agent {agent_id} killed by operator")
             outcome = await self._consume(qevent, route, turn, nav, agent_id)
+            if verified_review is not None:
+                outcome.review_origin_key = verified_review.origin_key
             if (
                 outcome.status is SessionStatus.AWAITING_APPROVAL
                 and _is_publish_provenance(
@@ -2531,6 +2539,8 @@ class Kernel:
         force_lineage_replacement: bool = False,
         pending_publication_approval: bool = False,
         required_review_head: str | None = None,
+        verified_review: VerifiedReviewFeedback | None = None,
+        review_turn: QueuedTurn | None = None,
     ) -> _RouteResult:
         # A workspace-enabled thread must establish (or confirm) its repository
         # before any platform response path. This deliberately precedes the
@@ -2581,7 +2591,18 @@ class Kernel:
                         # turn can observe it. Refuse before lookup/adopt so a
                         # failed suspend cannot reuse the dirty runner across
                         # either boundary.
-                        raise PendingPublicationError(thread_key)
+                        if verified_review is None:
+                            raise PendingPublicationError(thread_key)
+                        if (
+                            lineage.has_pending_outcome
+                            or verified_review.reservation_id is None
+                        ):
+                            raise ThreadBusyError(
+                                f"thread {thread_key} is waiting for its earlier publication"
+                            )
+                        # Only the API-verified origin may reuse its own reserved
+                        # boundary. The DB-only reserve CAS below rechecks this
+                        # again before any model input, including on reclaim.
                     if lineage is not None and lineage.head_sha is not None:
                         lineage_branch = lineage.branch
                         lineage_head = lineage.head_sha
@@ -2613,6 +2634,21 @@ class Kernel:
         # mere presence of an affinity record as proof that a live route was
         # retained.
         existing_handle = await asyncio.to_thread(self._substrate.lookup, thread_key)
+        if (
+            required_review_head is not None
+            and existing_handle is not None
+            and not await self._workspace_handoff_ready(
+                existing_handle, remaining_s=remaining_s
+            )
+        ):
+            # The API-verified review owns a later publication revision. A steer
+            # cannot attribute an earlier turn's publication gate to this event,
+            # so retain this delivery in the existing bounded queue until the
+            # active turn has reached an idle, durable boundary. Ordinary Slack
+            # still follows its immediate steering path below.
+            raise ThreadBusyError(
+                f"thread {thread_key} is not ready for its queued review revision"
+            )
         materialized_lineage_head = lineage_head or lineage_base_sha
         if (
             materialized_lineage_head is not None
@@ -2663,7 +2699,7 @@ class Kernel:
             raise ThreadBusyError(
                 f"thread {thread_key} has not reached a durable workspace handoff boundary"
             )
-        if packs is not None:
+        if packs is not None and required_review_head is None:
             reply = match_greeting(packs, event.text) or match_help(packs, event.text)
             if reply is not None and existing_handle is None:
                 return _RouteResult(steered=False, canned_reply=reply)
@@ -2710,7 +2746,7 @@ class Kernel:
         retained_live_route = existing_handle is not None and handle == existing_handle
         claim_ms = round((time.monotonic() - claim_started) * 1000)
         logger.info("claim latency for %s: %d ms", thread_key, claim_ms)
-        if source.is_job:
+        if source.is_job or required_review_head is not None:
             # ADR-0079: a job is an OUTPUT, not a steering input. A cron digest or
             # a webhook must never fold itself into whatever a person is currently
             # saying, so this path does not attempt a steer at all.
@@ -2774,6 +2810,22 @@ class Kernel:
             if retained_live_route and active_before_steer:
                 _record_route("finish-race")
                 _lifecycle_event("runner.finish_race", "finish-race")
+        if verified_review is not None:
+            if (
+                review_turn is None
+                or workspace_deployment_id is None
+                or verified_review.origin_key != review_turn.event_id
+                or self._publication_creator is None
+            ):
+                raise WorkspaceSelectionRefused("GitHub feedback revision identity was refused.")
+            try:
+                await self._publication_creator.reserve_review_feedback(
+                    review_turn, workspace_deployment_id, verified_review
+                )
+            except ApprovalBackendError:
+                raise WorkspacePreparationError(
+                    "github-review-reservation", "GitHub review reservation is unavailable"
+                ) from None
         # The per-request timeout is min(runner_total_timeout_s, remaining
         # delivery budget): the budget can only ever SHORTEN a request, never
         # grant one more time than the delivery has left (ADR-0131).
@@ -3371,6 +3423,7 @@ class Kernel:
                         title=snapshot.publication_title,
                         body=snapshot.publication_body,
                         max_patch_bytes=self._config.publication_patch_max_bytes,
+                        review_origin_key=outcome.review_origin_key,
                     )
                 )
                 created = CreatedApproval(

--- a/apps/worker/src/curie_worker/kernel.py
+++ b/apps/worker/src/curie_worker/kernel.py
@@ -84,6 +84,7 @@ from .approvals import (
     PublicationCreateRequest,
     PublicationCreator,
     PublicationLineage,
+    ReviewAuthorityUnavailable,
     VerifiedReviewFeedback,
 )
 from .behaviorpacks import (
@@ -2271,9 +2272,11 @@ class Kernel:
                             if remaining_s is not None:
                                 remaining_s = max(0.0, remaining_s - (time.monotonic() - started))
                     except (ApprovalBackendError, TimeoutError):
-                        raise WorkspacePreparationError(
-                            "github-review-verification",
-                            "GitHub feedback verification is temporarily unavailable",
+                        # No model turn has started. Preserve the same delivery
+                        # for bounded reclaim, rather than exhausting the model
+                        # attempt budget and ACKing feedback that never ran.
+                        raise ReviewAuthorityUnavailable(
+                            "GitHub feedback verification is temporarily unavailable"
                         ) from None
                     if verified.agent_id != agent_id or verified.sender != qevent.author:
                         raise WorkspaceSelectionRefused(
@@ -2823,8 +2826,11 @@ class Kernel:
                     review_turn, workspace_deployment_id, verified_review
                 )
             except ApprovalBackendError:
-                raise WorkspacePreparationError(
-                    "github-review-reservation", "GitHub review reservation is unavailable"
+                # The reserve sibling has the same pre-model transport policy.
+                # A transport failure must revalidate the exact origin
+                # on reclaim; the existing SQL reservation CAS remains sole writer.
+                raise ReviewAuthorityUnavailable(
+                    "GitHub review reservation is temporarily unavailable"
                 ) from None
         # The per-request timeout is min(runner_total_timeout_s, remaining
         # delivery budget): the budget can only ever SHORTEN a request, never

--- a/apps/worker/src/curie_worker/kernel.py
+++ b/apps/worker/src/curie_worker/kernel.py
@@ -2241,6 +2241,8 @@ class Kernel:
         # next same-thread event can route, and release the Valkey lock before
         # streaming so a follow-up can steer.
         routed: _RouteResult | None = None
+        review_head: str | None = None
+        review_receipt: str | None = None
 
         def close_routed_turn() -> None:
             if routed is not None and routed.turn is not None:
@@ -2248,6 +2250,33 @@ class Kernel:
 
         try:
             try:
+                if qevent.event_id.startswith("github-feedback-"):
+                    verifier = getattr(
+                        self._publication_creator, "verify_review_feedback", None
+                    )
+                    if verifier is None or workspace_deployment_id is None:
+                        raise WorkspaceSelectionRefused(
+                            "GitHub feedback requires a configured trusted workspace verifier; "
+                            "no model turn started."
+                        )
+                    try:
+                        started = time.monotonic()
+                        try:
+                            async with asyncio.timeout(remaining_s):
+                                verified = await verifier(qevent, workspace_deployment_id)
+                        finally:
+                            if remaining_s is not None:
+                                remaining_s = max(0.0, remaining_s - (time.monotonic() - started))
+                    except (ApprovalBackendError, TimeoutError):
+                        raise WorkspacePreparationError(
+                            "github-review-verification",
+                            "GitHub feedback verification is temporarily unavailable",
+                        ) from None
+                    if verified.agent_id != agent_id or verified.sender != qevent.author:
+                        raise WorkspaceSelectionRefused(
+                            "GitHub feedback no longer belongs to this conversation."
+                        )
+                    review_head, review_receipt = verified.head_sha, verified.receipt
                 async with self._lock.hold(self._config.lock_key(thread_key)):
                     routed = await self._route_and_start(
                         thread_key,
@@ -2258,6 +2287,7 @@ class Kernel:
                         agent_name=agent_name,
                         source=qevent.source,
                         remaining_s=remaining_s,
+                        required_review_head=review_head,
                     )
             except BaseException:
                 # start_turn owns a live response as soon as it returns, which
@@ -2369,6 +2399,16 @@ class Kernel:
             logger.warning("turn start failed for %s: %r", qevent.event_id, exc)
             return TurnOutcome(terminal_ok=False, classification="runner-error")
         assert routed is not None
+        if review_receipt is not None:
+            try:
+                await self._reply_for(qevent, route, review_receipt)
+            except asyncio.CancelledError:
+                close_routed_turn()
+                raise
+            except Exception:
+                # The turn's result uses the existing durable completion path;
+                # a receipt delivery outage cannot start a second model turn.
+                logger.warning("GitHub feedback receipt delivery unavailable")
         try:
             release_order()
         except BaseException:
@@ -2490,6 +2530,7 @@ class Kernel:
         publication_visible_outcome_revision: int | None = None,
         force_lineage_replacement: bool = False,
         pending_publication_approval: bool = False,
+        required_review_head: str | None = None,
     ) -> _RouteResult:
         # A workspace-enabled thread must establish (or confirm) its repository
         # before any platform response path. This deliberately precedes the
@@ -2502,7 +2543,12 @@ class Kernel:
                 raise WorkspacePreparationError(
                     "wiring", "workspace-enabled deployment has no trusted coordinator"
                 )
-            repo_fact = parse_github_repo_fact(event.text)
+            # A verified review already belongs to the persisted workspace. Its
+            # untrusted body may link other repositories; those are context,
+            # never a request to select a different workspace.
+            repo_fact = (
+                None if required_review_head is not None else parse_github_repo_fact(event.text)
+            )
             workspace_repo = await asyncio.to_thread(
                 self._workspace.select_repository,
                 thread_key=thread_key,
@@ -2548,6 +2594,11 @@ class Kernel:
                             and lineage.visible_outcome_revision > 0
                         ):
                             lineage_base_sha = lineage.base_sha
+        if required_review_head is not None and lineage_head != required_review_head:
+            raise WorkspaceSelectionRefused(
+                "The pull request changed after GitHub feedback verification; "
+                "no model turn started."
+            )
         # Greeting/help pre-model short-circuit (ADR-0018): under the per-thread
         # route lock, if an enabled greeting/help pack matches the message text AND
         # the thread has no existing route, it is provably a NEW turn (it cannot be

--- a/apps/worker/tests/kernel/conftest.py
+++ b/apps/worker/tests/kernel/conftest.py
@@ -665,6 +665,7 @@ async def kernel_harness(
     approval_reader: object | None = None,
     actions: object | None = None,
     publication_creator: object | None = None,
+    workspace_factory: Callable[[SandboxSubstrate], object] | None = None,
     sink: object | None = None,
     runner_app: web.Application | None = None,
     claim_timeout_seconds: float = 3.0,
@@ -749,6 +750,7 @@ async def kernel_harness(
         approval_reader=approval_reader,  # type: ignore[arg-type]
         actions=actions,  # type: ignore[arg-type]
         publication_creator=publication_creator,  # type: ignore[arg-type]
+        workspace=workspace_factory(substrate) if workspace_factory else None,  # type: ignore[arg-type]
         card_store=card_store,
     )
     killswitch = None

--- a/apps/worker/tests/kernel/test_github_review_queue.py
+++ b/apps/worker/tests/kernel/test_github_review_queue.py
@@ -1,0 +1,202 @@
+"""Bounded route proof; real API provenance and durable ingress are separate.
+
+The verified-head argument is supplied at the kernel boundary in this test.
+It proves that a verified review cannot disappear into an unrelated active
+turn; it does not claim that a forged webhook acquired that authority.
+"""
+
+import asyncio
+import uuid
+
+import pytest
+from aci_protocol import Final, QueuedTurn, ReplyHandle, SessionStatus, TextDelta
+from channel_protocol import scoped_conversation_id
+from curie_worker.kernel import ThreadBusyError
+
+
+def test_verified_review_defers_while_ordinary_slack_still_steers(make_harness) -> None:
+    async def exercise() -> None:
+        async with make_harness() as h:
+            first = QueuedTurn(
+                event_id=f"Ev-{uuid.uuid4()}",
+                conversation_id="1700000000.000051",
+                author="U0REQUEST1",
+                text="Continue the existing task.",
+                reply_handle=ReplyHandle(kind="slack", channel="C0EXAMPLE1", placeholder=None),
+                received_at="2026-09-05T00:00:00+00:00",
+            )
+            thread_key = scoped_conversation_id(
+                first.reply_handle.kind, first.reply_handle.channel, first.conversation_id
+            )
+            # Exercise a materialized route at the SAME accepted head. Without
+            # this premise, the old workspace-handoff guard already defers and
+            # would conceal the review-steering bug this regression must catch.
+            head = "a" * 40
+            handle = await asyncio.to_thread(
+                h.substrate.claim,
+                thread_key,
+                env={"CURIE_RUNNER_TOKEN": "example-review-route-token"},
+                workspace_materialized_head=head,
+                publication_visible_outcome_revision=0,
+            )
+            assert handle.workspace_materialized_head == head
+            hold = asyncio.Event()
+            h.runner.hold = hold
+            h.runner.default_script = [TextDelta(text="working")]
+            h.runner.tail = [Final(text="finished", status=SessionStatus.DONE)]
+            active = asyncio.create_task(h.kernel.process_event(first))
+            try:
+                async with asyncio.timeout(3):
+                    while not h.runner.turn_active:
+                        await asyncio.sleep(0.01)
+                ordinary = first.model_copy(
+                    update={"event_id": f"Ev-{uuid.uuid4()}", "text": "Also cover the edge case."}
+                )
+                await h.kernel.process_event(ordinary)
+                assert h.runner.steers == [ordinary.text]
+                assert h.runner.opened == [first.text]
+                assert h.runner.turn_active
+                review = first.model_copy(
+                    update={
+                        "event_id": f"github-feedback-{uuid.uuid4()}",
+                        "author": "github:41:example-reviewer",
+                        "text": "Please address this review in its own revision.",
+                    }
+                )
+                async with h.kernel._lock.hold(h.config.lock_key(thread_key)):
+                    with pytest.raises(ThreadBusyError):
+                        await h.kernel._route_and_start(
+                            thread_key,
+                            h.kernel._to_event(review),
+                            None,
+                            source=review.source,
+                            lineage_head=head,
+                            required_review_head=head,
+                            publication_visible_outcome_revision=0,
+                        )
+                assert h.runner.steers == [ordinary.text]
+                assert h.runner.opened == [first.text]
+            finally:
+                hold.set()
+                await active
+
+    asyncio.run(exercise())
+
+
+def test_review_terminal_observer_requires_exact_current_fenced_completion(make_harness) -> None:
+    from channel_protocol.reply import REPLY_WIRE_VERSION, ReplyTarget, TurnCompleted
+    from curie_api.config import Settings
+    from curie_api.github_review_terminal import worker_event_is_terminal
+    from curie_worker.delivery_lease import DeliveryLeaseStore
+    from curie_worker.markers import CompletionRecord, Markers
+    from curie_worker.reply_sink import TargetRoute
+
+    async def exercise() -> None:
+        async with make_harness() as h:
+            settings = Settings(KEY_PREFIX=h.config.key_prefix)
+            markers = Markers(h.async_redis, h.config)
+            leases = DeliveryLeaseStore(h.async_redis, h.config)
+            event_id = f"github-feedback-{uuid.uuid4()}"
+            await h.async_redis.xgroup_create(
+                h.config.stream, h.config.consumer_group, id="0", mkstream=True
+            )
+            entry_id = await h.async_redis.xadd(
+                h.config.stream,
+                {"payload": QueuedTurn(
+                    event_id=event_id, conversation_id="review-terminal",
+                    author="github:41:example-reviewer", text="Review fixture",
+                    reply_handle=ReplyHandle(kind="slack", channel="C0EXAMPLE1", placeholder=None),
+                    received_at="2026-09-05T00:00:00+00:00",
+                ).model_dump_json()},
+            )
+            pending = await h.async_redis.xreadgroup(
+                h.config.consumer_group, "old", {h.config.stream: ">"}, count=1
+            )
+            assert pending[0][1][0][0] == entry_id
+            stale = await leases.acquire(
+                h.config.stream, h.config.consumer_group, entry_id, consumer="old"
+            )
+            assert await leases.release(
+                h.config.stream, h.config.consumer_group, entry_id, owner=stale.owner
+            )
+            await h.async_redis.xclaim(
+                h.config.stream, h.config.consumer_group, "current",
+                min_idle_time=0, message_ids=[entry_id],
+            )
+            current = await leases.acquire(
+                h.config.stream, h.config.consumer_group, entry_id, consumer="current"
+            )
+            assert current.generation == stale.generation + 1
+            record = CompletionRecord(
+                event_id=event_id,
+                event=TurnCompleted(
+                    version=REPLY_WIRE_VERSION,
+                    event="turn.completed",
+                    target=ReplyTarget(
+                        kind="slack", address="C0EXAMPLE1", conversation_id="review-terminal",
+                        reply_ref=None,
+                    ),
+                    event_id=event_id,
+                    outcome="delivered",
+                ),
+                route=TargetRoute(),
+                created_at=1.0,
+            )
+
+            async def settle(lease):
+                return await markers.settle_fenced(
+                    event_id,
+                    record,
+                    stream=lease.stream,
+                    group=lease.group,
+                    entry_id=lease.entry_id,
+                    owner=lease.owner,
+                    generation=lease.generation,
+                )
+
+            assert await settle(stale) is None
+            assert not await worker_event_is_terminal(h.async_redis, settings, event_id)
+            assert await settle(current) is not None
+            assert await worker_event_is_terminal(h.async_redis, settings, event_id)
+            assert not await worker_event_is_terminal(h.async_redis, settings, event_id + "-other")
+            # The production completion outbox remains independently terminal
+            # after the shorter ordinary done marker is absent.
+            await h.async_redis.delete(h.config.done_key(event_id))
+            assert await worker_event_is_terminal(h.async_redis, settings, event_id)
+            await h.async_redis.hset(h.config.completion_key(event_id), "done", "0")
+            assert not await worker_event_is_terminal(h.async_redis, settings, event_id)
+
+    asyncio.run(exercise())
+
+
+def test_review_refuses_idle_runner_until_its_history_is_durable(make_harness) -> None:
+    async def exercise() -> None:
+        async with make_harness() as h:
+            turn = QueuedTurn(
+                event_id=f"github-feedback-{uuid.uuid4()}",
+                conversation_id="1700000000.000061", author="github:41:example-reviewer",
+                text="Review the completed turn only after its history is durable.",
+                reply_handle=ReplyHandle(kind="slack", channel="C0EXAMPLE1", placeholder=None),
+                received_at="2026-09-05T00:00:00+00:00",
+            )
+            thread_key = scoped_conversation_id(
+                turn.reply_handle.kind, turn.reply_handle.channel, turn.conversation_id
+            )
+            head = "a" * 40
+            await asyncio.to_thread(
+                h.substrate.claim, thread_key,
+                env={"CURIE_RUNNER_TOKEN": "example-review-route-token"},
+                workspace_materialized_head=head, publication_visible_outcome_revision=0,
+            )
+            assert h.runner.turn_active is False
+            h.runner.history_durable = False
+            async with h.kernel._lock.hold(h.config.lock_key(thread_key)):
+                with pytest.raises(ThreadBusyError, match="queued review revision"):
+                    await h.kernel._route_and_start(
+                        thread_key, h.kernel._to_event(turn), None,
+                        source=turn.source, lineage_head=head, required_review_head=head,
+                        publication_visible_outcome_revision=0,
+                    )
+            assert h.runner.opened == [] and h.runner.steers == []
+
+    asyncio.run(exercise())

--- a/apps/worker/tests/kernel/test_github_reviews.py
+++ b/apps/worker/tests/kernel/test_github_reviews.py
@@ -1,0 +1,44 @@
+"""Run the missing-authority guard through the actual kernel and Valkey.
+
+This is a bounded negative plus ordinary-turn control. It does not substitute
+for the full real API/GitHub/cluster continuation acceptance journey.
+"""
+
+import asyncio
+import uuid
+from datetime import UTC, datetime
+
+from aci_protocol import Final, QueuedTurn, ReplyHandle, SessionStatus, TextDelta
+
+
+def test_review_event_without_trusted_before_model_verifier_never_reaches_runner(
+    make_harness,
+) -> None:
+    async def exercise() -> None:
+        async with make_harness() as h:
+            turn = QueuedTurn(
+                event_id=f"github-feedback-{uuid.uuid4()}",
+                conversation_id="1700000000.000001",
+                author="github:41:example-reviewer",
+                text="Please add the missing regression test.",
+                reply_handle=ReplyHandle(kind="slack", channel="C0EXAMPLE1", placeholder=None),
+                received_at=datetime.now(UTC).isoformat(),
+            )
+            h.runner.turn_scripts.append(
+                [
+                    TextDelta(text="MODEL_MUST_NOT_RUN"),
+                    Final(text="done", status=SessionStatus.DONE),
+                ]
+            )
+            await h.kernel.process_event(turn)
+            assert len(h.runner.opened) == 0
+            assert any(
+                "GitHub feedback" in update[2] for update in h.sink.updates + h.sink.text_posts
+            )
+            healthy = turn.model_copy(
+                update={"event_id": f"Ev-{uuid.uuid4()}", "author": "U0REQUEST1"}
+            )
+            await h.kernel.process_event(healthy)
+            assert len(h.runner.opened) == 1
+
+    asyncio.run(exercise())

--- a/docs/interfaces/relational-db/INTERFACE.md
+++ b/docs/interfaces/relational-db/INTERFACE.md
@@ -67,10 +67,10 @@ is a judgement call, not something derivable from the tree.
    column is a native Postgres `Enum(Environment, name="environment", schema=SCHEMA)`
    (`apps/api/src/curie_api/models.py::Deployment`), which materializes as a `CREATE TYPE` in the `curie` schema.
 3. **`JSONB` column type** — `apps/api/src/curie_api/models.py::JSONB` is imported from
-   `sqlalchemy.dialects.postgresql` on the same line as `UUID` and used on **fourteen** columns:
+   `sqlalchemy.dialects.postgresql` on the same line as `UUID` and used on **sixteen** columns:
    `behavior_packs`, `approval_required_tools`, `approval_routes`, `secrets`,
    `hook_partitions`, `changed_paths`, `evidence`, `arguments`, `result`, `prior_state`,
-   `target`, `post_state`, and `value`. The last one is
+   `target`, `post_state`, `feedback`, `turn`, and `value`. The last one is
    `apps/api/src/curie_api/models.py::WorkflowStateEntry.value`; `evidence` is used
    by both approval and action audit rows. Three of them are
    load-bearing rather than incidental: the workflow-state store exists precisely because

--- a/packages/telemetry/schema/metrics.json
+++ b/packages/telemetry/schema/metrics.json
@@ -226,6 +226,7 @@
           "/publications/{publication_id}",
           "/v1/internal/cluster-message-replies/{reply_ref}",
           "/v1/internal/publications",
+          "/v1/internal/github/reviews/{event_id}/verify",
           "/v1/internal/publications/lineage",
           "/v1/internal/publications/review-reservations",
           "/v1/internal/publications/review-reservations/{reservation_id}/cancel",
@@ -252,7 +253,7 @@
           "OTHER"
         ]
       },
-      "cardinality_bound": 592,
+      "cardinality_bound": 600,
       "description": "Active HTTP server requests.",
       "monotonic": false,
       "type": "up_down_counter",
@@ -327,6 +328,7 @@
           "/publications/{publication_id}",
           "/v1/internal/cluster-message-replies/{reply_ref}",
           "/v1/internal/publications",
+          "/v1/internal/github/reviews/{event_id}/verify",
           "/v1/internal/publications/lineage",
           "/v1/internal/publications/review-reservations",
           "/v1/internal/publications/review-reservations/{reservation_id}/cancel",
@@ -360,7 +362,7 @@
           "OTHER"
         ]
       },
-      "cardinality_bound": 2960,
+      "cardinality_bound": 3000,
       "description": "HTTP server requests.",
       "monotonic": true,
       "type": "counter",
@@ -435,6 +437,7 @@
           "/publications/{publication_id}",
           "/v1/internal/cluster-message-replies/{reply_ref}",
           "/v1/internal/publications",
+          "/v1/internal/github/reviews/{event_id}/verify",
           "/v1/internal/publications/lineage",
           "/v1/internal/publications/review-reservations",
           "/v1/internal/publications/review-reservations/{reservation_id}/cancel",
@@ -468,7 +471,7 @@
           "OTHER"
         ]
       },
-      "cardinality_bound": 2960,
+      "cardinality_bound": 3000,
       "description": "HTTP server request duration.",
       "monotonic": false,
       "type": "histogram",

--- a/packages/telemetry/schema/metrics.json
+++ b/packages/telemetry/schema/metrics.json
@@ -1,7 +1,747 @@
 {
+  "schema_version": "v1",
   "metrics": {
-    "curie.approval.lifecycle": {
+    "curie.turn.accepted": {
+      "type": "counter",
+      "unit": "{turn}",
+      "description": "Turns accepted for processing.",
+      "monotonic": true,
       "attributes": {
+        "service.name": [
+          "curie-api",
+          "curie-dispatcher",
+          "curie-worker",
+          "curie-runner"
+        ],
+        "source": [
+          "api",
+          "dispatcher",
+          "worker",
+          "runner",
+          "local",
+          "eval"
+        ],
+        "outcome": [
+          "accepted"
+        ]
+      },
+      "cardinality_bound": 24
+    },
+    "curie.turn.completed": {
+      "type": "counter",
+      "unit": "{turn}",
+      "description": "Turns reaching a terminal result.",
+      "monotonic": true,
+      "attributes": {
+        "service.name": [
+          "curie-api",
+          "curie-dispatcher",
+          "curie-worker",
+          "curie-runner"
+        ],
+        "source": [
+          "api",
+          "dispatcher",
+          "worker",
+          "runner",
+          "local",
+          "eval"
+        ],
+        "outcome": [
+          "done",
+          "awaiting_approval",
+          "budget_halted",
+          "classified_failure",
+          "side_effect_halted",
+          "idle",
+          "interrupted"
+        ]
+      },
+      "cardinality_bound": 168
+    },
+    "curie.turn.duration": {
+      "type": "histogram",
+      "unit": "s",
+      "description": "End to end turn duration.",
+      "monotonic": false,
+      "attributes": {
+        "service.name": [
+          "curie-api",
+          "curie-dispatcher",
+          "curie-worker",
+          "curie-runner"
+        ],
+        "source": [
+          "api",
+          "dispatcher",
+          "worker",
+          "runner",
+          "local",
+          "eval"
+        ],
+        "outcome": [
+          "done",
+          "awaiting_approval",
+          "budget_halted",
+          "classified_failure",
+          "side_effect_halted",
+          "idle",
+          "interrupted"
+        ]
+      },
+      "cardinality_bound": 168
+    },
+    "curie.history.resume.cache_read": {
+      "type": "histogram",
+      "unit": "{token}",
+      "description": "Provider cache read input tokens on the first turn after structured replay.",
+      "monotonic": false,
+      "attributes": {
+        "service.name": [
+          "curie-runner"
+        ],
+        "source": [
+          "runner"
+        ],
+        "cache_hit": [
+          "true",
+          "false"
+        ]
+      },
+      "cardinality_bound": 2
+    },
+    "curie.queue.enqueue": {
+      "type": "counter",
+      "unit": "{message}",
+      "description": "Messages enqueued.",
+      "monotonic": true,
+      "attributes": {
+        "service.name": [
+          "curie-api",
+          "curie-dispatcher",
+          "curie-worker"
+        ],
+        "source": [
+          "api",
+          "dispatcher",
+          "worker",
+          "local",
+          "eval"
+        ],
+        "outcome": [
+          "success",
+          "failure",
+          "pending",
+          "ack",
+          "retry",
+          "dead-letter"
+        ]
+      },
+      "cardinality_bound": 90
+    },
+    "curie.queue.process": {
+      "type": "counter",
+      "unit": "{message}",
+      "description": "Messages processed.",
+      "monotonic": true,
+      "attributes": {
+        "service.name": [
+          "curie-api",
+          "curie-dispatcher",
+          "curie-worker"
+        ],
+        "source": [
+          "api",
+          "dispatcher",
+          "worker",
+          "local",
+          "eval"
+        ],
+        "outcome": [
+          "success",
+          "failure",
+          "pending",
+          "ack",
+          "retry",
+          "dead-letter"
+        ]
+      },
+      "cardinality_bound": 90
+    },
+    "curie.queue.settle": {
+      "type": "counter",
+      "unit": "{message}",
+      "description": "Message settlement outcomes.",
+      "monotonic": true,
+      "attributes": {
+        "service.name": [
+          "curie-api",
+          "curie-dispatcher",
+          "curie-worker"
+        ],
+        "source": [
+          "api",
+          "dispatcher",
+          "worker",
+          "local",
+          "eval"
+        ],
+        "outcome": [
+          "success",
+          "failure",
+          "pending",
+          "ack",
+          "retry",
+          "dead-letter"
+        ]
+      },
+      "cardinality_bound": 90
+    },
+    "curie.queue.retry": {
+      "type": "counter",
+      "unit": "{retry}",
+      "description": "Bounded queue redelivery and in-process turn retries.",
+      "monotonic": true,
+      "attributes": {
+        "service.name": [
+          "curie-worker"
+        ],
+        "source": [
+          "worker",
+          "eval"
+        ],
+        "retry_class": [
+          "redelivery",
+          "rate-limit",
+          "runner-error",
+          "runner-timeout",
+          "workspace-error"
+        ]
+      },
+      "cardinality_bound": 10
+    },
+    "curie.queue.dead_letter": {
+      "type": "counter",
+      "unit": "{message}",
+      "description": "Messages dead lettered.",
+      "monotonic": true,
+      "attributes": {
+        "service.name": [
+          "curie-api",
+          "curie-dispatcher",
+          "curie-worker"
+        ],
+        "source": [
+          "api",
+          "dispatcher",
+          "worker",
+          "local",
+          "eval"
+        ],
+        "outcome": [
+          "success",
+          "failure",
+          "pending",
+          "ack",
+          "retry",
+          "dead-letter"
+        ]
+      },
+      "cardinality_bound": 90
+    },
+    "curie.queue.wait.duration": {
+      "type": "histogram",
+      "unit": "s",
+      "description": "Queue wait duration.",
+      "monotonic": false,
+      "attributes": {
+        "service.name": [
+          "curie-api",
+          "curie-dispatcher",
+          "curie-worker"
+        ],
+        "source": [
+          "api",
+          "dispatcher",
+          "worker",
+          "local",
+          "eval"
+        ],
+        "outcome": [
+          "success",
+          "failure",
+          "pending",
+          "ack",
+          "retry",
+          "dead-letter"
+        ]
+      },
+      "cardinality_bound": 90
+    },
+    "curie.queue.process.duration": {
+      "type": "histogram",
+      "unit": "s",
+      "description": "Queue processing duration.",
+      "monotonic": false,
+      "attributes": {
+        "service.name": [
+          "curie-api",
+          "curie-dispatcher",
+          "curie-worker"
+        ],
+        "source": [
+          "api",
+          "dispatcher",
+          "worker",
+          "local",
+          "eval"
+        ],
+        "outcome": [
+          "success",
+          "failure",
+          "pending",
+          "ack",
+          "retry",
+          "dead-letter"
+        ]
+      },
+      "cardinality_bound": 90
+    },
+    "curie.queue.message.age": {
+      "type": "histogram",
+      "unit": "s",
+      "description": "Message age at processing.",
+      "monotonic": false,
+      "attributes": {
+        "service.name": [
+          "curie-api",
+          "curie-dispatcher",
+          "curie-worker"
+        ],
+        "source": [
+          "api",
+          "dispatcher",
+          "worker",
+          "local",
+          "eval"
+        ],
+        "outcome": [
+          "success",
+          "failure",
+          "pending",
+          "ack",
+          "retry",
+          "dead-letter"
+        ]
+      },
+      "cardinality_bound": 90
+    },
+    "curie.queue.pending": {
+      "type": "gauge",
+      "unit": "{message}",
+      "description": "Pending consumer group messages.",
+      "monotonic": false,
+      "attributes": {
+        "service.name": [
+          "curie-api",
+          "curie-dispatcher",
+          "curie-worker"
+        ],
+        "source": [
+          "api",
+          "dispatcher",
+          "worker",
+          "local",
+          "eval"
+        ],
+        "outcome": [
+          "success",
+          "failure",
+          "pending",
+          "ack",
+          "retry",
+          "dead-letter"
+        ]
+      },
+      "cardinality_bound": 90
+    },
+    "curie.queue.lag": {
+      "type": "gauge",
+      "unit": "{message}",
+      "description": "Consumer group lag.",
+      "monotonic": false,
+      "attributes": {
+        "service.name": [
+          "curie-api",
+          "curie-dispatcher",
+          "curie-worker"
+        ],
+        "source": [
+          "api",
+          "dispatcher",
+          "worker",
+          "local",
+          "eval"
+        ],
+        "outcome": [
+          "success",
+          "failure",
+          "pending",
+          "ack",
+          "retry",
+          "dead-letter"
+        ]
+      },
+      "cardinality_bound": 90
+    },
+    "curie.queue.depth": {
+      "type": "gauge",
+      "unit": "{message}",
+      "description": "Stream depth.",
+      "monotonic": false,
+      "attributes": {
+        "service.name": [
+          "curie-api",
+          "curie-dispatcher",
+          "curie-worker"
+        ],
+        "source": [
+          "api",
+          "dispatcher",
+          "worker",
+          "local",
+          "eval"
+        ],
+        "outcome": [
+          "success",
+          "failure",
+          "pending",
+          "ack",
+          "retry",
+          "dead-letter"
+        ]
+      },
+      "cardinality_bound": 90
+    },
+    "curie.thread.lock.wait.duration": {
+      "type": "histogram",
+      "unit": "s",
+      "description": "Thread lock acquisition duration.",
+      "monotonic": false,
+      "attributes": {
+        "service.name": [
+          "curie-worker"
+        ],
+        "source": [
+          "worker"
+        ],
+        "outcome": [
+          "acquired",
+          "contended",
+          "timeout",
+          "start",
+          "steer",
+          "finish-race",
+          "observed"
+        ]
+      },
+      "cardinality_bound": 7
+    },
+    "curie.thread.route": {
+      "type": "counter",
+      "unit": "{decision}",
+      "description": "Thread routing decisions.",
+      "monotonic": true,
+      "attributes": {
+        "service.name": [
+          "curie-worker"
+        ],
+        "source": [
+          "worker"
+        ],
+        "outcome": [
+          "acquired",
+          "contended",
+          "timeout",
+          "start",
+          "steer",
+          "finish-race",
+          "observed"
+        ]
+      },
+      "cardinality_bound": 7
+    },
+    "curie.thread.route.active": {
+      "type": "gauge",
+      "unit": "{route}",
+      "description": "Active thread routes.",
+      "monotonic": false,
+      "attributes": {
+        "service.name": [
+          "curie-worker"
+        ],
+        "source": [
+          "worker"
+        ],
+        "outcome": [
+          "acquired",
+          "contended",
+          "timeout",
+          "start",
+          "steer",
+          "finish-race",
+          "observed"
+        ]
+      },
+      "cardinality_bound": 7
+    },
+    "curie.sandbox.lifecycle": {
+      "type": "counter",
+      "unit": "{operation}",
+      "description": "Sandbox lifecycle outcomes.",
+      "monotonic": true,
+      "attributes": {
+        "service.name": [
+          "curie-worker"
+        ],
+        "operation": [
+          "claim",
+          "resume",
+          "release",
+          "suspend",
+          "cleanup"
+        ],
+        "outcome": [
+          "claimed",
+          "reused",
+          "resumed",
+          "released",
+          "suspended",
+          "failed",
+          "orphan-cleaned",
+          "observed"
+        ]
+      },
+      "cardinality_bound": 40
+    },
+    "curie.sandbox.claim.duration": {
+      "type": "histogram",
+      "unit": "s",
+      "description": "Sandbox claim duration.",
+      "monotonic": false,
+      "attributes": {
+        "service.name": [
+          "curie-worker"
+        ],
+        "operation": [
+          "claim",
+          "resume",
+          "release",
+          "suspend",
+          "cleanup"
+        ],
+        "outcome": [
+          "claimed",
+          "reused",
+          "resumed",
+          "released",
+          "suspended",
+          "failed",
+          "orphan-cleaned",
+          "observed"
+        ]
+      },
+      "cardinality_bound": 40
+    },
+    "curie.sandbox.resume.duration": {
+      "type": "histogram",
+      "unit": "s",
+      "description": "Sandbox resume duration.",
+      "monotonic": false,
+      "attributes": {
+        "service.name": [
+          "curie-worker"
+        ],
+        "operation": [
+          "claim",
+          "resume",
+          "release",
+          "suspend",
+          "cleanup"
+        ],
+        "outcome": [
+          "claimed",
+          "reused",
+          "resumed",
+          "released",
+          "suspended",
+          "failed",
+          "orphan-cleaned",
+          "observed"
+        ]
+      },
+      "cardinality_bound": 40
+    },
+    "curie.sandbox.release.duration": {
+      "type": "histogram",
+      "unit": "s",
+      "description": "Sandbox release duration.",
+      "monotonic": false,
+      "attributes": {
+        "service.name": [
+          "curie-worker"
+        ],
+        "operation": [
+          "claim",
+          "resume",
+          "release",
+          "suspend",
+          "cleanup"
+        ],
+        "outcome": [
+          "claimed",
+          "reused",
+          "resumed",
+          "released",
+          "suspended",
+          "failed",
+          "orphan-cleaned",
+          "observed"
+        ]
+      },
+      "cardinality_bound": 40
+    },
+    "curie.sandbox.active": {
+      "type": "gauge",
+      "unit": "{sandbox}",
+      "description": "Active sandboxes.",
+      "monotonic": false,
+      "attributes": {
+        "service.name": [
+          "curie-worker"
+        ],
+        "operation": [
+          "observe"
+        ],
+        "outcome": [
+          "observed"
+        ]
+      },
+      "cardinality_bound": 1
+    },
+    "curie.sandbox.suspended": {
+      "type": "gauge",
+      "unit": "{sandbox}",
+      "description": "Suspended sandboxes.",
+      "monotonic": false,
+      "attributes": {
+        "service.name": [
+          "curie-worker"
+        ],
+        "operation": [
+          "observe"
+        ],
+        "outcome": [
+          "observed"
+        ]
+      },
+      "cardinality_bound": 1
+    },
+    "curie.sandbox.cleanup": {
+      "type": "counter",
+      "unit": "{sandbox}",
+      "description": "Failed and orphan sandbox cleanup.",
+      "monotonic": true,
+      "attributes": {
+        "service.name": [
+          "curie-worker"
+        ],
+        "operation": [
+          "claim",
+          "resume",
+          "release",
+          "suspend",
+          "cleanup"
+        ],
+        "outcome": [
+          "claimed",
+          "reused",
+          "resumed",
+          "released",
+          "suspended",
+          "failed",
+          "orphan-cleaned",
+          "observed"
+        ]
+      },
+      "cardinality_bound": 40
+    },
+    "curie.runner.rpc.request.duration": {
+      "type": "histogram",
+      "unit": "s",
+      "description": "Runner RPC request duration.",
+      "monotonic": false,
+      "attributes": {
+        "service.name": [
+          "curie-worker"
+        ],
+        "operation": [
+          "event",
+          "steer",
+          "interrupt",
+          "reset",
+          "status"
+        ],
+        "role": [
+          "client"
+        ],
+        "outcome": [
+          "success",
+          "failure",
+          "conflict",
+          "timeout"
+        ]
+      },
+      "cardinality_bound": 20
+    },
+    "curie.runner.rpc.result": {
+      "type": "counter",
+      "unit": "{request}",
+      "description": "Runner RPC outcomes.",
+      "monotonic": true,
+      "attributes": {
+        "service.name": [
+          "curie-worker"
+        ],
+        "operation": [
+          "event",
+          "steer",
+          "interrupt",
+          "reset",
+          "status"
+        ],
+        "role": [
+          "client"
+        ],
+        "outcome": [
+          "success",
+          "failure",
+          "conflict",
+          "timeout"
+        ]
+      },
+      "cardinality_bound": 20
+    },
+    "curie.approval.lifecycle": {
+      "type": "counter",
+      "unit": "{approval}",
+      "description": "Approval lifecycle outcomes.",
+      "monotonic": true,
+      "attributes": {
+        "service.name": [
+          "curie-api",
+          "curie-worker"
+        ],
         "operation": [
           "request",
           "resolve",
@@ -19,808 +759,61 @@
           "pending",
           "observed",
           "failure"
-        ],
-        "service.name": [
-          "curie-api",
-          "curie-worker"
         ]
       },
-      "cardinality_bound": 96,
-      "description": "Approval lifecycle outcomes.",
-      "monotonic": true,
-      "type": "counter",
-      "unit": "{approval}"
+      "cardinality_bound": 96
     },
     "curie.approval.pending": {
-      "attributes": {
-        "operation": [
-          "observe"
-        ],
-        "outcome": [
-          "pending"
-        ],
-        "service.name": [
-          "curie-api"
-        ]
-      },
-      "cardinality_bound": 1,
+      "type": "gauge",
+      "unit": "{approval}",
       "description": "Pending approvals.",
       "monotonic": false,
-      "type": "gauge",
-      "unit": "{approval}"
-    },
-    "curie.approval.pending.age": {
       "attributes": {
+        "service.name": [
+          "curie-api"
+        ],
         "operation": [
           "observe"
         ],
         "outcome": [
           "pending"
-        ],
-        "service.name": [
-          "curie-api"
         ]
       },
-      "cardinality_bound": 1,
+      "cardinality_bound": 1
+    },
+    "curie.approval.pending.age": {
+      "type": "gauge",
+      "unit": "s",
       "description": "Age of the oldest pending approval.",
       "monotonic": false,
-      "type": "gauge",
-      "unit": "s"
-    },
-    "curie.background.last_success.age": {
       "attributes": {
-        "operation": [
-          "resume-reconciler",
-          "approval-sweeper",
-          "graveyard-watcher",
-          "commit-poller",
-          "connector-reconciler"
-        ],
-        "role": [
-          "background"
-        ],
-        "service.name": [
-          "curie-api",
-          "curie-worker"
-        ]
-      },
-      "cardinality_bound": 10,
-      "description": "Age of the last successful background pass.",
-      "monotonic": false,
-      "type": "gauge",
-      "unit": "s"
-    },
-    "curie.background.loop": {
-      "attributes": {
-        "operation": [
-          "resume-reconciler",
-          "approval-sweeper",
-          "graveyard-watcher",
-          "commit-poller",
-          "connector-reconciler"
-        ],
-        "outcome": [
-          "success",
-          "failure",
-          "observed"
-        ],
-        "role": [
-          "background"
-        ],
-        "service.name": [
-          "curie-api",
-          "curie-worker"
-        ]
-      },
-      "cardinality_bound": 30,
-      "description": "Background loop pass outcomes.",
-      "monotonic": true,
-      "type": "counter",
-      "unit": "{run}"
-    },
-    "curie.eval.process": {
-      "attributes": {
-        "outcome": [
-          "success",
-          "failure",
-          "plumbing"
-        ],
-        "service.name": [
-          "curie-worker"
-        ],
-        "source": [
-          "eval"
-        ]
-      },
-      "cardinality_bound": 3,
-      "description": "Eval processing outcomes.",
-      "monotonic": true,
-      "type": "counter",
-      "unit": "{job}"
-    },
-    "curie.history.resume.cache_read": {
-      "attributes": {
-        "cache_hit": [
-          "true",
-          "false"
-        ],
-        "service.name": [
-          "curie-runner"
-        ],
-        "source": [
-          "runner"
-        ]
-      },
-      "cardinality_bound": 2,
-      "description": "Provider cache read input tokens on the first turn after structured replay.",
-      "monotonic": false,
-      "type": "histogram",
-      "unit": "{token}"
-    },
-    "curie.http.server.active": {
-      "attributes": {
-        "operation": [
-          "/actions",
-          "/actions/{action_id}",
-          "/actions/{action_id}/audit",
-          "/actions/{action_id}/complete",
-          "/actions/{action_id}/undo",
-          "/agents",
-          "/agents/{agent_id}",
-          "/agents/{agent_id}/behavior-packs",
-          "/agents/{agent_id}/budget",
-          "/agents/{agent_id}/channels",
-          "/agents/{agent_id}/cost",
-          "/agents/{agent_id}/kill",
-          "/agents/{agent_id}/memory",
-          "/agents/{agent_id}/memory/{index}",
-          "/agents/{agent_id}/memory/{index}/provenance",
-          "/agents/{agent_id}/resume",
-          "/agents/{agent_id}/state",
-          "/agents/{agent_id}/state/bindings/{kind}/{address}",
-          "/agents/{agent_id}/state/bindings/{kind}/{address}/{namespace}",
-          "/agents/{agent_id}/state/bindings/{kind}/{address}/{namespace}/{key}",
-          "/agents/{agent_id}/state/bindings/{kind}/{address}/{namespace}/{key}/append",
-          "/agents/{agent_id}/state/{namespace}",
-          "/agents/{agent_id}/state/{namespace}/{key}",
-          "/agents/{agent_id}/state/{namespace}/{key}/append",
-          "/agents/{agent_id}/threads/{thread_key}/reset",
-          "/agents/{agent_id}/versions",
-          "/agents/{agent_id}/versions/{version_id}/bundle",
-          "/agents/{agent_id}/versions/{version_id}/connectors",
-          "/agents/{agent_id}/versions/{version_id}/files",
-          "/approvals",
-          "/approvals/principals/operator",
-          "/approvals/{approval_id}",
-          "/approvals/{approval_id}/audit",
-          "/approvals/{approval_id}/resolve",
-          "/channels/token",
-          "/channels/turns",
-          "/cluster-message-replies/{reply_ref}",
-          "/config",
-          "/console/login-codes",
-          "/console/session",
-          "/deploy-targets/list",
-          "/deploy-targets/resolve",
-          "/deployments",
-          "/deployments/{deployment_id}",
-          "/evals/matrix",
-          "/evals/report",
-          "/evals/trigger",
-          "/git-flow/routing-check",
-          "/github/webhook",
-          "/health",
-          "/hooks/{agent_id}/{hook}",
-          "/langfuse/traces",
-          "/langfuse/traces/{trace_id}",
-          "/langfuse/traces/{trace_id}/eval-case",
-          "/openapi.json",
-          "/docs",
-          "/docs/oauth2-redirect",
-          "/redoc",
-          "/observability/metrics/series",
-          "/observability/metrics/summary",
-          "/observability/runners",
-          "/observability/runners/{namespace}/{pod}/logs",
-          "/publications",
-          "/publications/{publication_id}",
-          "/v1/internal/cluster-message-replies/{reply_ref}",
-          "/v1/internal/publications",
-          "/v1/internal/github/reviews/{event_id}/verify",
-          "/v1/internal/publications/lineage",
-          "/v1/internal/publications/review-reservations",
-          "/v1/internal/publications/review-reservations/{reservation_id}/cancel",
-          "/v1/internal/publications/{publication_id}/lineage",
-          "/v1/internal/publications/{publication_id}/credential",
-          "/v1/internal/workspaces/{deployment_id}/credential",
-          "/v1/internal/workspaces/{deployment_id}/selection",
-          "unmatched"
-        ],
-        "role": [
-          "server"
-        ],
         "service.name": [
           "curie-api"
         ],
-        "source": [
-          "GET",
-          "POST",
-          "PUT",
-          "PATCH",
-          "DELETE",
-          "OPTIONS",
-          "HEAD",
-          "OTHER"
-        ]
-      },
-      "cardinality_bound": 600,
-      "description": "Active HTTP server requests.",
-      "monotonic": false,
-      "type": "up_down_counter",
-      "unit": "{request}"
-    },
-    "curie.http.server.request": {
-      "attributes": {
         "operation": [
-          "/actions",
-          "/actions/{action_id}",
-          "/actions/{action_id}/audit",
-          "/actions/{action_id}/complete",
-          "/actions/{action_id}/undo",
-          "/agents",
-          "/agents/{agent_id}",
-          "/agents/{agent_id}/behavior-packs",
-          "/agents/{agent_id}/budget",
-          "/agents/{agent_id}/channels",
-          "/agents/{agent_id}/cost",
-          "/agents/{agent_id}/kill",
-          "/agents/{agent_id}/memory",
-          "/agents/{agent_id}/memory/{index}",
-          "/agents/{agent_id}/memory/{index}/provenance",
-          "/agents/{agent_id}/resume",
-          "/agents/{agent_id}/state",
-          "/agents/{agent_id}/state/bindings/{kind}/{address}",
-          "/agents/{agent_id}/state/bindings/{kind}/{address}/{namespace}",
-          "/agents/{agent_id}/state/bindings/{kind}/{address}/{namespace}/{key}",
-          "/agents/{agent_id}/state/bindings/{kind}/{address}/{namespace}/{key}/append",
-          "/agents/{agent_id}/state/{namespace}",
-          "/agents/{agent_id}/state/{namespace}/{key}",
-          "/agents/{agent_id}/state/{namespace}/{key}/append",
-          "/agents/{agent_id}/threads/{thread_key}/reset",
-          "/agents/{agent_id}/versions",
-          "/agents/{agent_id}/versions/{version_id}/bundle",
-          "/agents/{agent_id}/versions/{version_id}/connectors",
-          "/agents/{agent_id}/versions/{version_id}/files",
-          "/approvals",
-          "/approvals/principals/operator",
-          "/approvals/{approval_id}",
-          "/approvals/{approval_id}/audit",
-          "/approvals/{approval_id}/resolve",
-          "/channels/token",
-          "/channels/turns",
-          "/cluster-message-replies/{reply_ref}",
-          "/config",
-          "/console/login-codes",
-          "/console/session",
-          "/deploy-targets/list",
-          "/deploy-targets/resolve",
-          "/deployments",
-          "/deployments/{deployment_id}",
-          "/evals/matrix",
-          "/evals/report",
-          "/evals/trigger",
-          "/git-flow/routing-check",
-          "/github/webhook",
-          "/health",
-          "/hooks/{agent_id}/{hook}",
-          "/langfuse/traces",
-          "/langfuse/traces/{trace_id}",
-          "/langfuse/traces/{trace_id}/eval-case",
-          "/openapi.json",
-          "/docs",
-          "/docs/oauth2-redirect",
-          "/redoc",
-          "/observability/metrics/series",
-          "/observability/metrics/summary",
-          "/observability/runners",
-          "/observability/runners/{namespace}/{pod}/logs",
-          "/publications",
-          "/publications/{publication_id}",
-          "/v1/internal/cluster-message-replies/{reply_ref}",
-          "/v1/internal/publications",
-          "/v1/internal/github/reviews/{event_id}/verify",
-          "/v1/internal/publications/lineage",
-          "/v1/internal/publications/review-reservations",
-          "/v1/internal/publications/review-reservations/{reservation_id}/cancel",
-          "/v1/internal/publications/{publication_id}/lineage",
-          "/v1/internal/publications/{publication_id}/credential",
-          "/v1/internal/workspaces/{deployment_id}/credential",
-          "/v1/internal/workspaces/{deployment_id}/selection",
-          "unmatched"
+          "observe"
         ],
         "outcome": [
-          "1xx",
-          "2xx",
-          "3xx",
-          "4xx",
-          "5xx"
-        ],
-        "role": [
-          "server"
-        ],
-        "service.name": [
-          "curie-api"
-        ],
-        "source": [
-          "GET",
-          "POST",
-          "PUT",
-          "PATCH",
-          "DELETE",
-          "OPTIONS",
-          "HEAD",
-          "OTHER"
+          "pending"
         ]
       },
-      "cardinality_bound": 3000,
-      "description": "HTTP server requests.",
-      "monotonic": true,
-      "type": "counter",
-      "unit": "{request}"
-    },
-    "curie.http.server.request.duration": {
-      "attributes": {
-        "operation": [
-          "/actions",
-          "/actions/{action_id}",
-          "/actions/{action_id}/audit",
-          "/actions/{action_id}/complete",
-          "/actions/{action_id}/undo",
-          "/agents",
-          "/agents/{agent_id}",
-          "/agents/{agent_id}/behavior-packs",
-          "/agents/{agent_id}/budget",
-          "/agents/{agent_id}/channels",
-          "/agents/{agent_id}/cost",
-          "/agents/{agent_id}/kill",
-          "/agents/{agent_id}/memory",
-          "/agents/{agent_id}/memory/{index}",
-          "/agents/{agent_id}/memory/{index}/provenance",
-          "/agents/{agent_id}/resume",
-          "/agents/{agent_id}/state",
-          "/agents/{agent_id}/state/bindings/{kind}/{address}",
-          "/agents/{agent_id}/state/bindings/{kind}/{address}/{namespace}",
-          "/agents/{agent_id}/state/bindings/{kind}/{address}/{namespace}/{key}",
-          "/agents/{agent_id}/state/bindings/{kind}/{address}/{namespace}/{key}/append",
-          "/agents/{agent_id}/state/{namespace}",
-          "/agents/{agent_id}/state/{namespace}/{key}",
-          "/agents/{agent_id}/state/{namespace}/{key}/append",
-          "/agents/{agent_id}/threads/{thread_key}/reset",
-          "/agents/{agent_id}/versions",
-          "/agents/{agent_id}/versions/{version_id}/bundle",
-          "/agents/{agent_id}/versions/{version_id}/connectors",
-          "/agents/{agent_id}/versions/{version_id}/files",
-          "/approvals",
-          "/approvals/principals/operator",
-          "/approvals/{approval_id}",
-          "/approvals/{approval_id}/audit",
-          "/approvals/{approval_id}/resolve",
-          "/channels/token",
-          "/channels/turns",
-          "/cluster-message-replies/{reply_ref}",
-          "/config",
-          "/console/login-codes",
-          "/console/session",
-          "/deploy-targets/list",
-          "/deploy-targets/resolve",
-          "/deployments",
-          "/deployments/{deployment_id}",
-          "/evals/matrix",
-          "/evals/report",
-          "/evals/trigger",
-          "/git-flow/routing-check",
-          "/github/webhook",
-          "/health",
-          "/hooks/{agent_id}/{hook}",
-          "/langfuse/traces",
-          "/langfuse/traces/{trace_id}",
-          "/langfuse/traces/{trace_id}/eval-case",
-          "/openapi.json",
-          "/docs",
-          "/docs/oauth2-redirect",
-          "/redoc",
-          "/observability/metrics/series",
-          "/observability/metrics/summary",
-          "/observability/runners",
-          "/observability/runners/{namespace}/{pod}/logs",
-          "/publications",
-          "/publications/{publication_id}",
-          "/v1/internal/cluster-message-replies/{reply_ref}",
-          "/v1/internal/publications",
-          "/v1/internal/github/reviews/{event_id}/verify",
-          "/v1/internal/publications/lineage",
-          "/v1/internal/publications/review-reservations",
-          "/v1/internal/publications/review-reservations/{reservation_id}/cancel",
-          "/v1/internal/publications/{publication_id}/lineage",
-          "/v1/internal/publications/{publication_id}/credential",
-          "/v1/internal/workspaces/{deployment_id}/credential",
-          "/v1/internal/workspaces/{deployment_id}/selection",
-          "unmatched"
-        ],
-        "outcome": [
-          "1xx",
-          "2xx",
-          "3xx",
-          "4xx",
-          "5xx"
-        ],
-        "role": [
-          "server"
-        ],
-        "service.name": [
-          "curie-api"
-        ],
-        "source": [
-          "GET",
-          "POST",
-          "PUT",
-          "PATCH",
-          "DELETE",
-          "OPTIONS",
-          "HEAD",
-          "OTHER"
-        ]
-      },
-      "cardinality_bound": 3000,
-      "description": "HTTP server request duration.",
-      "monotonic": false,
-      "type": "histogram",
-      "unit": "s"
-    },
-    "curie.queue.dead_letter": {
-      "attributes": {
-        "outcome": [
-          "success",
-          "failure",
-          "pending",
-          "ack",
-          "retry",
-          "dead-letter"
-        ],
-        "service.name": [
-          "curie-api",
-          "curie-dispatcher",
-          "curie-worker"
-        ],
-        "source": [
-          "api",
-          "dispatcher",
-          "worker",
-          "local",
-          "eval"
-        ]
-      },
-      "cardinality_bound": 90,
-      "description": "Messages dead lettered.",
-      "monotonic": true,
-      "type": "counter",
-      "unit": "{message}"
-    },
-    "curie.queue.depth": {
-      "attributes": {
-        "outcome": [
-          "success",
-          "failure",
-          "pending",
-          "ack",
-          "retry",
-          "dead-letter"
-        ],
-        "service.name": [
-          "curie-api",
-          "curie-dispatcher",
-          "curie-worker"
-        ],
-        "source": [
-          "api",
-          "dispatcher",
-          "worker",
-          "local",
-          "eval"
-        ]
-      },
-      "cardinality_bound": 90,
-      "description": "Stream depth.",
-      "monotonic": false,
-      "type": "gauge",
-      "unit": "{message}"
-    },
-    "curie.queue.enqueue": {
-      "attributes": {
-        "outcome": [
-          "success",
-          "failure",
-          "pending",
-          "ack",
-          "retry",
-          "dead-letter"
-        ],
-        "service.name": [
-          "curie-api",
-          "curie-dispatcher",
-          "curie-worker"
-        ],
-        "source": [
-          "api",
-          "dispatcher",
-          "worker",
-          "local",
-          "eval"
-        ]
-      },
-      "cardinality_bound": 90,
-      "description": "Messages enqueued.",
-      "monotonic": true,
-      "type": "counter",
-      "unit": "{message}"
-    },
-    "curie.queue.lag": {
-      "attributes": {
-        "outcome": [
-          "success",
-          "failure",
-          "pending",
-          "ack",
-          "retry",
-          "dead-letter"
-        ],
-        "service.name": [
-          "curie-api",
-          "curie-dispatcher",
-          "curie-worker"
-        ],
-        "source": [
-          "api",
-          "dispatcher",
-          "worker",
-          "local",
-          "eval"
-        ]
-      },
-      "cardinality_bound": 90,
-      "description": "Consumer group lag.",
-      "monotonic": false,
-      "type": "gauge",
-      "unit": "{message}"
-    },
-    "curie.queue.message.age": {
-      "attributes": {
-        "outcome": [
-          "success",
-          "failure",
-          "pending",
-          "ack",
-          "retry",
-          "dead-letter"
-        ],
-        "service.name": [
-          "curie-api",
-          "curie-dispatcher",
-          "curie-worker"
-        ],
-        "source": [
-          "api",
-          "dispatcher",
-          "worker",
-          "local",
-          "eval"
-        ]
-      },
-      "cardinality_bound": 90,
-      "description": "Message age at processing.",
-      "monotonic": false,
-      "type": "histogram",
-      "unit": "s"
-    },
-    "curie.queue.pending": {
-      "attributes": {
-        "outcome": [
-          "success",
-          "failure",
-          "pending",
-          "ack",
-          "retry",
-          "dead-letter"
-        ],
-        "service.name": [
-          "curie-api",
-          "curie-dispatcher",
-          "curie-worker"
-        ],
-        "source": [
-          "api",
-          "dispatcher",
-          "worker",
-          "local",
-          "eval"
-        ]
-      },
-      "cardinality_bound": 90,
-      "description": "Pending consumer group messages.",
-      "monotonic": false,
-      "type": "gauge",
-      "unit": "{message}"
-    },
-    "curie.queue.process": {
-      "attributes": {
-        "outcome": [
-          "success",
-          "failure",
-          "pending",
-          "ack",
-          "retry",
-          "dead-letter"
-        ],
-        "service.name": [
-          "curie-api",
-          "curie-dispatcher",
-          "curie-worker"
-        ],
-        "source": [
-          "api",
-          "dispatcher",
-          "worker",
-          "local",
-          "eval"
-        ]
-      },
-      "cardinality_bound": 90,
-      "description": "Messages processed.",
-      "monotonic": true,
-      "type": "counter",
-      "unit": "{message}"
-    },
-    "curie.queue.process.duration": {
-      "attributes": {
-        "outcome": [
-          "success",
-          "failure",
-          "pending",
-          "ack",
-          "retry",
-          "dead-letter"
-        ],
-        "service.name": [
-          "curie-api",
-          "curie-dispatcher",
-          "curie-worker"
-        ],
-        "source": [
-          "api",
-          "dispatcher",
-          "worker",
-          "local",
-          "eval"
-        ]
-      },
-      "cardinality_bound": 90,
-      "description": "Queue processing duration.",
-      "monotonic": false,
-      "type": "histogram",
-      "unit": "s"
-    },
-    "curie.queue.retry": {
-      "attributes": {
-        "retry_class": [
-          "redelivery",
-          "rate-limit",
-          "runner-error",
-          "runner-timeout",
-          "workspace-error"
-        ],
-        "service.name": [
-          "curie-worker"
-        ],
-        "source": [
-          "worker",
-          "eval"
-        ]
-      },
-      "cardinality_bound": 10,
-      "description": "Bounded queue redelivery and in-process turn retries.",
-      "monotonic": true,
-      "type": "counter",
-      "unit": "{retry}"
-    },
-    "curie.queue.settle": {
-      "attributes": {
-        "outcome": [
-          "success",
-          "failure",
-          "pending",
-          "ack",
-          "retry",
-          "dead-letter"
-        ],
-        "service.name": [
-          "curie-api",
-          "curie-dispatcher",
-          "curie-worker"
-        ],
-        "source": [
-          "api",
-          "dispatcher",
-          "worker",
-          "local",
-          "eval"
-        ]
-      },
-      "cardinality_bound": 90,
-      "description": "Message settlement outcomes.",
-      "monotonic": true,
-      "type": "counter",
-      "unit": "{message}"
-    },
-    "curie.queue.wait.duration": {
-      "attributes": {
-        "outcome": [
-          "success",
-          "failure",
-          "pending",
-          "ack",
-          "retry",
-          "dead-letter"
-        ],
-        "service.name": [
-          "curie-api",
-          "curie-dispatcher",
-          "curie-worker"
-        ],
-        "source": [
-          "api",
-          "dispatcher",
-          "worker",
-          "local",
-          "eval"
-        ]
-      },
-      "cardinality_bound": 90,
-      "description": "Queue wait duration.",
-      "monotonic": false,
-      "type": "histogram",
-      "unit": "s"
+      "cardinality_bound": 1
     },
     "curie.reply.delivery": {
-      "attributes": {
-        "operation": [
-          "update",
-          "post"
-        ],
-        "outcome": [
-          "success",
-          "failure",
-          "best-effort",
-          "retry",
-          "rate-limited"
-        ],
-        "role": [
-          "client"
-        ],
-        "service.name": [
-          "curie-worker"
-        ]
-      },
-      "cardinality_bound": 10,
+      "type": "counter",
+      "unit": "{reply}",
       "description": "Reply delivery outcomes.",
       "monotonic": true,
-      "type": "counter",
-      "unit": "{reply}"
-    },
-    "curie.reply.post.duration": {
       "attributes": {
+        "service.name": [
+          "curie-worker"
+        ],
         "operation": [
           "update",
           "post"
+        ],
+        "role": [
+          "client"
         ],
         "outcome": [
           "success",
@@ -828,469 +821,479 @@
           "best-effort",
           "retry",
           "rate-limited"
+        ]
+      },
+      "cardinality_bound": 10
+    },
+    "curie.reply.update.duration": {
+      "type": "histogram",
+      "unit": "s",
+      "description": "Reply update duration.",
+      "monotonic": false,
+      "attributes": {
+        "service.name": [
+          "curie-worker"
+        ],
+        "operation": [
+          "update",
+          "post"
         ],
         "role": [
           "client"
         ],
-        "service.name": [
-          "curie-worker"
+        "outcome": [
+          "success",
+          "failure",
+          "best-effort",
+          "retry",
+          "rate-limited"
         ]
       },
-      "cardinality_bound": 10,
+      "cardinality_bound": 10
+    },
+    "curie.reply.post.duration": {
+      "type": "histogram",
+      "unit": "s",
       "description": "Reply post duration.",
       "monotonic": false,
-      "type": "histogram",
-      "unit": "s"
-    },
-    "curie.reply.retry": {
       "attributes": {
+        "service.name": [
+          "curie-worker"
+        ],
         "operation": [
           "update",
           "post"
+        ],
+        "role": [
+          "client"
+        ],
+        "outcome": [
+          "success",
+          "failure",
+          "best-effort",
+          "retry",
+          "rate-limited"
+        ]
+      },
+      "cardinality_bound": 10
+    },
+    "curie.reply.retry": {
+      "type": "counter",
+      "unit": "{retry}",
+      "description": "Reply delivery retries.",
+      "monotonic": true,
+      "attributes": {
+        "service.name": [
+          "curie-worker"
+        ],
+        "operation": [
+          "update",
+          "post"
+        ],
+        "role": [
+          "client"
         ],
         "retry_class": [
           "block-fallback",
           "rate-limit",
           "transport-fallback"
-        ],
-        "role": [
-          "client"
-        ],
-        "service.name": [
-          "curie-worker"
         ]
       },
-      "cardinality_bound": 6,
-      "description": "Reply delivery retries.",
-      "monotonic": true,
-      "type": "counter",
-      "unit": "{retry}"
+      "cardinality_bound": 6
     },
-    "curie.reply.update.duration": {
+    "curie.http.server.request": {
+      "type": "counter",
+      "unit": "{request}",
+      "description": "HTTP server requests.",
+      "monotonic": true,
       "attributes": {
+        "service.name": [
+          "curie-api"
+        ],
         "operation": [
-          "update",
-          "post"
+          "/actions",
+          "/actions/{action_id}",
+          "/actions/{action_id}/audit",
+          "/actions/{action_id}/complete",
+          "/actions/{action_id}/undo",
+          "/agents",
+          "/agents/{agent_id}",
+          "/agents/{agent_id}/behavior-packs",
+          "/agents/{agent_id}/budget",
+          "/agents/{agent_id}/channels",
+          "/agents/{agent_id}/cost",
+          "/agents/{agent_id}/kill",
+          "/agents/{agent_id}/memory",
+          "/agents/{agent_id}/memory/{index}",
+          "/agents/{agent_id}/memory/{index}/provenance",
+          "/agents/{agent_id}/resume",
+          "/agents/{agent_id}/state",
+          "/agents/{agent_id}/state/bindings/{kind}/{address}",
+          "/agents/{agent_id}/state/bindings/{kind}/{address}/{namespace}",
+          "/agents/{agent_id}/state/bindings/{kind}/{address}/{namespace}/{key}",
+          "/agents/{agent_id}/state/bindings/{kind}/{address}/{namespace}/{key}/append",
+          "/agents/{agent_id}/state/{namespace}",
+          "/agents/{agent_id}/state/{namespace}/{key}",
+          "/agents/{agent_id}/state/{namespace}/{key}/append",
+          "/agents/{agent_id}/threads/{thread_key}/reset",
+          "/agents/{agent_id}/versions",
+          "/agents/{agent_id}/versions/{version_id}/bundle",
+          "/agents/{agent_id}/versions/{version_id}/connectors",
+          "/agents/{agent_id}/versions/{version_id}/files",
+          "/approvals",
+          "/approvals/principals/operator",
+          "/approvals/{approval_id}",
+          "/approvals/{approval_id}/audit",
+          "/approvals/{approval_id}/resolve",
+          "/channels/token",
+          "/channels/turns",
+          "/cluster-message-replies/{reply_ref}",
+          "/config",
+          "/console/login-codes",
+          "/console/session",
+          "/deploy-targets/list",
+          "/deploy-targets/resolve",
+          "/deployments",
+          "/deployments/{deployment_id}",
+          "/evals/matrix",
+          "/evals/report",
+          "/evals/trigger",
+          "/git-flow/routing-check",
+          "/github/webhook",
+          "/health",
+          "/hooks/{agent_id}/{hook}",
+          "/langfuse/traces",
+          "/langfuse/traces/{trace_id}",
+          "/langfuse/traces/{trace_id}/eval-case",
+          "/openapi.json",
+          "/docs",
+          "/docs/oauth2-redirect",
+          "/redoc",
+          "/observability/metrics/series",
+          "/observability/metrics/summary",
+          "/observability/runners",
+          "/observability/runners/{namespace}/{pod}/logs",
+          "/publications",
+          "/publications/{publication_id}",
+          "/v1/internal/cluster-message-replies/{reply_ref}",
+          "/v1/internal/publications",
+          "/v1/internal/github/reviews/{event_id}/reserve",
+          "/v1/internal/github/reviews/{event_id}/verify",
+          "/v1/internal/publications/lineage",
+          "/v1/internal/publications/review-reservations",
+          "/v1/internal/publications/review-reservations/{reservation_id}/cancel",
+          "/v1/internal/publications/{publication_id}/lineage",
+          "/v1/internal/publications/{publication_id}/credential",
+          "/v1/internal/workspaces/{deployment_id}/credential",
+          "/v1/internal/workspaces/{deployment_id}/selection",
+          "unmatched"
+        ],
+        "role": [
+          "server"
+        ],
+        "source": [
+          "GET",
+          "POST",
+          "PUT",
+          "PATCH",
+          "DELETE",
+          "OPTIONS",
+          "HEAD",
+          "OTHER"
+        ],
+        "outcome": [
+          "1xx",
+          "2xx",
+          "3xx",
+          "4xx",
+          "5xx"
+        ]
+      },
+      "cardinality_bound": 3040
+    },
+    "curie.http.server.request.duration": {
+      "type": "histogram",
+      "unit": "s",
+      "description": "HTTP server request duration.",
+      "monotonic": false,
+      "attributes": {
+        "service.name": [
+          "curie-api"
+        ],
+        "operation": [
+          "/actions",
+          "/actions/{action_id}",
+          "/actions/{action_id}/audit",
+          "/actions/{action_id}/complete",
+          "/actions/{action_id}/undo",
+          "/agents",
+          "/agents/{agent_id}",
+          "/agents/{agent_id}/behavior-packs",
+          "/agents/{agent_id}/budget",
+          "/agents/{agent_id}/channels",
+          "/agents/{agent_id}/cost",
+          "/agents/{agent_id}/kill",
+          "/agents/{agent_id}/memory",
+          "/agents/{agent_id}/memory/{index}",
+          "/agents/{agent_id}/memory/{index}/provenance",
+          "/agents/{agent_id}/resume",
+          "/agents/{agent_id}/state",
+          "/agents/{agent_id}/state/bindings/{kind}/{address}",
+          "/agents/{agent_id}/state/bindings/{kind}/{address}/{namespace}",
+          "/agents/{agent_id}/state/bindings/{kind}/{address}/{namespace}/{key}",
+          "/agents/{agent_id}/state/bindings/{kind}/{address}/{namespace}/{key}/append",
+          "/agents/{agent_id}/state/{namespace}",
+          "/agents/{agent_id}/state/{namespace}/{key}",
+          "/agents/{agent_id}/state/{namespace}/{key}/append",
+          "/agents/{agent_id}/threads/{thread_key}/reset",
+          "/agents/{agent_id}/versions",
+          "/agents/{agent_id}/versions/{version_id}/bundle",
+          "/agents/{agent_id}/versions/{version_id}/connectors",
+          "/agents/{agent_id}/versions/{version_id}/files",
+          "/approvals",
+          "/approvals/principals/operator",
+          "/approvals/{approval_id}",
+          "/approvals/{approval_id}/audit",
+          "/approvals/{approval_id}/resolve",
+          "/channels/token",
+          "/channels/turns",
+          "/cluster-message-replies/{reply_ref}",
+          "/config",
+          "/console/login-codes",
+          "/console/session",
+          "/deploy-targets/list",
+          "/deploy-targets/resolve",
+          "/deployments",
+          "/deployments/{deployment_id}",
+          "/evals/matrix",
+          "/evals/report",
+          "/evals/trigger",
+          "/git-flow/routing-check",
+          "/github/webhook",
+          "/health",
+          "/hooks/{agent_id}/{hook}",
+          "/langfuse/traces",
+          "/langfuse/traces/{trace_id}",
+          "/langfuse/traces/{trace_id}/eval-case",
+          "/openapi.json",
+          "/docs",
+          "/docs/oauth2-redirect",
+          "/redoc",
+          "/observability/metrics/series",
+          "/observability/metrics/summary",
+          "/observability/runners",
+          "/observability/runners/{namespace}/{pod}/logs",
+          "/publications",
+          "/publications/{publication_id}",
+          "/v1/internal/cluster-message-replies/{reply_ref}",
+          "/v1/internal/publications",
+          "/v1/internal/github/reviews/{event_id}/reserve",
+          "/v1/internal/github/reviews/{event_id}/verify",
+          "/v1/internal/publications/lineage",
+          "/v1/internal/publications/review-reservations",
+          "/v1/internal/publications/review-reservations/{reservation_id}/cancel",
+          "/v1/internal/publications/{publication_id}/lineage",
+          "/v1/internal/publications/{publication_id}/credential",
+          "/v1/internal/workspaces/{deployment_id}/credential",
+          "/v1/internal/workspaces/{deployment_id}/selection",
+          "unmatched"
+        ],
+        "role": [
+          "server"
+        ],
+        "source": [
+          "GET",
+          "POST",
+          "PUT",
+          "PATCH",
+          "DELETE",
+          "OPTIONS",
+          "HEAD",
+          "OTHER"
+        ],
+        "outcome": [
+          "1xx",
+          "2xx",
+          "3xx",
+          "4xx",
+          "5xx"
+        ]
+      },
+      "cardinality_bound": 3040
+    },
+    "curie.http.server.active": {
+      "type": "up_down_counter",
+      "unit": "{request}",
+      "description": "Active HTTP server requests.",
+      "monotonic": false,
+      "attributes": {
+        "service.name": [
+          "curie-api"
+        ],
+        "operation": [
+          "/actions",
+          "/actions/{action_id}",
+          "/actions/{action_id}/audit",
+          "/actions/{action_id}/complete",
+          "/actions/{action_id}/undo",
+          "/agents",
+          "/agents/{agent_id}",
+          "/agents/{agent_id}/behavior-packs",
+          "/agents/{agent_id}/budget",
+          "/agents/{agent_id}/channels",
+          "/agents/{agent_id}/cost",
+          "/agents/{agent_id}/kill",
+          "/agents/{agent_id}/memory",
+          "/agents/{agent_id}/memory/{index}",
+          "/agents/{agent_id}/memory/{index}/provenance",
+          "/agents/{agent_id}/resume",
+          "/agents/{agent_id}/state",
+          "/agents/{agent_id}/state/bindings/{kind}/{address}",
+          "/agents/{agent_id}/state/bindings/{kind}/{address}/{namespace}",
+          "/agents/{agent_id}/state/bindings/{kind}/{address}/{namespace}/{key}",
+          "/agents/{agent_id}/state/bindings/{kind}/{address}/{namespace}/{key}/append",
+          "/agents/{agent_id}/state/{namespace}",
+          "/agents/{agent_id}/state/{namespace}/{key}",
+          "/agents/{agent_id}/state/{namespace}/{key}/append",
+          "/agents/{agent_id}/threads/{thread_key}/reset",
+          "/agents/{agent_id}/versions",
+          "/agents/{agent_id}/versions/{version_id}/bundle",
+          "/agents/{agent_id}/versions/{version_id}/connectors",
+          "/agents/{agent_id}/versions/{version_id}/files",
+          "/approvals",
+          "/approvals/principals/operator",
+          "/approvals/{approval_id}",
+          "/approvals/{approval_id}/audit",
+          "/approvals/{approval_id}/resolve",
+          "/channels/token",
+          "/channels/turns",
+          "/cluster-message-replies/{reply_ref}",
+          "/config",
+          "/console/login-codes",
+          "/console/session",
+          "/deploy-targets/list",
+          "/deploy-targets/resolve",
+          "/deployments",
+          "/deployments/{deployment_id}",
+          "/evals/matrix",
+          "/evals/report",
+          "/evals/trigger",
+          "/git-flow/routing-check",
+          "/github/webhook",
+          "/health",
+          "/hooks/{agent_id}/{hook}",
+          "/langfuse/traces",
+          "/langfuse/traces/{trace_id}",
+          "/langfuse/traces/{trace_id}/eval-case",
+          "/openapi.json",
+          "/docs",
+          "/docs/oauth2-redirect",
+          "/redoc",
+          "/observability/metrics/series",
+          "/observability/metrics/summary",
+          "/observability/runners",
+          "/observability/runners/{namespace}/{pod}/logs",
+          "/publications",
+          "/publications/{publication_id}",
+          "/v1/internal/cluster-message-replies/{reply_ref}",
+          "/v1/internal/publications",
+          "/v1/internal/github/reviews/{event_id}/reserve",
+          "/v1/internal/github/reviews/{event_id}/verify",
+          "/v1/internal/publications/lineage",
+          "/v1/internal/publications/review-reservations",
+          "/v1/internal/publications/review-reservations/{reservation_id}/cancel",
+          "/v1/internal/publications/{publication_id}/lineage",
+          "/v1/internal/publications/{publication_id}/credential",
+          "/v1/internal/workspaces/{deployment_id}/credential",
+          "/v1/internal/workspaces/{deployment_id}/selection",
+          "unmatched"
+        ],
+        "role": [
+          "server"
+        ],
+        "source": [
+          "GET",
+          "POST",
+          "PUT",
+          "PATCH",
+          "DELETE",
+          "OPTIONS",
+          "HEAD",
+          "OTHER"
+        ]
+      },
+      "cardinality_bound": 608
+    },
+    "curie.background.loop": {
+      "type": "counter",
+      "unit": "{run}",
+      "description": "Background loop pass outcomes.",
+      "monotonic": true,
+      "attributes": {
+        "service.name": [
+          "curie-api",
+          "curie-worker"
+        ],
+        "operation": [
+          "resume-reconciler",
+          "approval-sweeper",
+          "graveyard-watcher",
+          "commit-poller",
+          "connector-reconciler"
+        ],
+        "role": [
+          "background"
         ],
         "outcome": [
           "success",
           "failure",
-          "best-effort",
-          "retry",
-          "rate-limited"
-        ],
-        "role": [
-          "client"
-        ],
-        "service.name": [
-          "curie-worker"
+          "observed"
         ]
       },
-      "cardinality_bound": 10,
-      "description": "Reply update duration.",
-      "monotonic": false,
-      "type": "histogram",
-      "unit": "s"
+      "cardinality_bound": 30
     },
-    "curie.runner.rpc.request.duration": {
+    "curie.background.last_success.age": {
+      "type": "gauge",
+      "unit": "s",
+      "description": "Age of the last successful background pass.",
+      "monotonic": false,
       "attributes": {
+        "service.name": [
+          "curie-api",
+          "curie-worker"
+        ],
         "operation": [
-          "event",
-          "steer",
-          "interrupt",
-          "reset",
-          "status"
+          "resume-reconciler",
+          "approval-sweeper",
+          "graveyard-watcher",
+          "commit-poller",
+          "connector-reconciler"
+        ],
+        "role": [
+          "background"
+        ]
+      },
+      "cardinality_bound": 10
+    },
+    "curie.eval.process": {
+      "type": "counter",
+      "unit": "{job}",
+      "description": "Eval processing outcomes.",
+      "monotonic": true,
+      "attributes": {
+        "service.name": [
+          "curie-worker"
+        ],
+        "source": [
+          "eval"
         ],
         "outcome": [
           "success",
           "failure",
-          "conflict",
-          "timeout"
-        ],
-        "role": [
-          "client"
-        ],
-        "service.name": [
-          "curie-worker"
+          "plumbing"
         ]
       },
-      "cardinality_bound": 20,
-      "description": "Runner RPC request duration.",
-      "monotonic": false,
-      "type": "histogram",
-      "unit": "s"
-    },
-    "curie.runner.rpc.result": {
-      "attributes": {
-        "operation": [
-          "event",
-          "steer",
-          "interrupt",
-          "reset",
-          "status"
-        ],
-        "outcome": [
-          "success",
-          "failure",
-          "conflict",
-          "timeout"
-        ],
-        "role": [
-          "client"
-        ],
-        "service.name": [
-          "curie-worker"
-        ]
-      },
-      "cardinality_bound": 20,
-      "description": "Runner RPC outcomes.",
-      "monotonic": true,
-      "type": "counter",
-      "unit": "{request}"
-    },
-    "curie.sandbox.active": {
-      "attributes": {
-        "operation": [
-          "observe"
-        ],
-        "outcome": [
-          "observed"
-        ],
-        "service.name": [
-          "curie-worker"
-        ]
-      },
-      "cardinality_bound": 1,
-      "description": "Active sandboxes.",
-      "monotonic": false,
-      "type": "gauge",
-      "unit": "{sandbox}"
-    },
-    "curie.sandbox.claim.duration": {
-      "attributes": {
-        "operation": [
-          "claim",
-          "resume",
-          "release",
-          "suspend",
-          "cleanup"
-        ],
-        "outcome": [
-          "claimed",
-          "reused",
-          "resumed",
-          "released",
-          "suspended",
-          "failed",
-          "orphan-cleaned",
-          "observed"
-        ],
-        "service.name": [
-          "curie-worker"
-        ]
-      },
-      "cardinality_bound": 40,
-      "description": "Sandbox claim duration.",
-      "monotonic": false,
-      "type": "histogram",
-      "unit": "s"
-    },
-    "curie.sandbox.cleanup": {
-      "attributes": {
-        "operation": [
-          "claim",
-          "resume",
-          "release",
-          "suspend",
-          "cleanup"
-        ],
-        "outcome": [
-          "claimed",
-          "reused",
-          "resumed",
-          "released",
-          "suspended",
-          "failed",
-          "orphan-cleaned",
-          "observed"
-        ],
-        "service.name": [
-          "curie-worker"
-        ]
-      },
-      "cardinality_bound": 40,
-      "description": "Failed and orphan sandbox cleanup.",
-      "monotonic": true,
-      "type": "counter",
-      "unit": "{sandbox}"
-    },
-    "curie.sandbox.lifecycle": {
-      "attributes": {
-        "operation": [
-          "claim",
-          "resume",
-          "release",
-          "suspend",
-          "cleanup"
-        ],
-        "outcome": [
-          "claimed",
-          "reused",
-          "resumed",
-          "released",
-          "suspended",
-          "failed",
-          "orphan-cleaned",
-          "observed"
-        ],
-        "service.name": [
-          "curie-worker"
-        ]
-      },
-      "cardinality_bound": 40,
-      "description": "Sandbox lifecycle outcomes.",
-      "monotonic": true,
-      "type": "counter",
-      "unit": "{operation}"
-    },
-    "curie.sandbox.release.duration": {
-      "attributes": {
-        "operation": [
-          "claim",
-          "resume",
-          "release",
-          "suspend",
-          "cleanup"
-        ],
-        "outcome": [
-          "claimed",
-          "reused",
-          "resumed",
-          "released",
-          "suspended",
-          "failed",
-          "orphan-cleaned",
-          "observed"
-        ],
-        "service.name": [
-          "curie-worker"
-        ]
-      },
-      "cardinality_bound": 40,
-      "description": "Sandbox release duration.",
-      "monotonic": false,
-      "type": "histogram",
-      "unit": "s"
-    },
-    "curie.sandbox.resume.duration": {
-      "attributes": {
-        "operation": [
-          "claim",
-          "resume",
-          "release",
-          "suspend",
-          "cleanup"
-        ],
-        "outcome": [
-          "claimed",
-          "reused",
-          "resumed",
-          "released",
-          "suspended",
-          "failed",
-          "orphan-cleaned",
-          "observed"
-        ],
-        "service.name": [
-          "curie-worker"
-        ]
-      },
-      "cardinality_bound": 40,
-      "description": "Sandbox resume duration.",
-      "monotonic": false,
-      "type": "histogram",
-      "unit": "s"
-    },
-    "curie.sandbox.suspended": {
-      "attributes": {
-        "operation": [
-          "observe"
-        ],
-        "outcome": [
-          "observed"
-        ],
-        "service.name": [
-          "curie-worker"
-        ]
-      },
-      "cardinality_bound": 1,
-      "description": "Suspended sandboxes.",
-      "monotonic": false,
-      "type": "gauge",
-      "unit": "{sandbox}"
-    },
-    "curie.thread.lock.wait.duration": {
-      "attributes": {
-        "outcome": [
-          "acquired",
-          "contended",
-          "timeout",
-          "start",
-          "steer",
-          "finish-race",
-          "observed"
-        ],
-        "service.name": [
-          "curie-worker"
-        ],
-        "source": [
-          "worker"
-        ]
-      },
-      "cardinality_bound": 7,
-      "description": "Thread lock acquisition duration.",
-      "monotonic": false,
-      "type": "histogram",
-      "unit": "s"
-    },
-    "curie.thread.route": {
-      "attributes": {
-        "outcome": [
-          "acquired",
-          "contended",
-          "timeout",
-          "start",
-          "steer",
-          "finish-race",
-          "observed"
-        ],
-        "service.name": [
-          "curie-worker"
-        ],
-        "source": [
-          "worker"
-        ]
-      },
-      "cardinality_bound": 7,
-      "description": "Thread routing decisions.",
-      "monotonic": true,
-      "type": "counter",
-      "unit": "{decision}"
-    },
-    "curie.thread.route.active": {
-      "attributes": {
-        "outcome": [
-          "acquired",
-          "contended",
-          "timeout",
-          "start",
-          "steer",
-          "finish-race",
-          "observed"
-        ],
-        "service.name": [
-          "curie-worker"
-        ],
-        "source": [
-          "worker"
-        ]
-      },
-      "cardinality_bound": 7,
-      "description": "Active thread routes.",
-      "monotonic": false,
-      "type": "gauge",
-      "unit": "{route}"
-    },
-    "curie.turn.accepted": {
-      "attributes": {
-        "outcome": [
-          "accepted"
-        ],
-        "service.name": [
-          "curie-api",
-          "curie-dispatcher",
-          "curie-worker",
-          "curie-runner"
-        ],
-        "source": [
-          "api",
-          "dispatcher",
-          "worker",
-          "runner",
-          "local",
-          "eval"
-        ]
-      },
-      "cardinality_bound": 24,
-      "description": "Turns accepted for processing.",
-      "monotonic": true,
-      "type": "counter",
-      "unit": "{turn}"
-    },
-    "curie.turn.completed": {
-      "attributes": {
-        "outcome": [
-          "done",
-          "awaiting_approval",
-          "budget_halted",
-          "classified_failure",
-          "side_effect_halted",
-          "idle",
-          "interrupted"
-        ],
-        "service.name": [
-          "curie-api",
-          "curie-dispatcher",
-          "curie-worker",
-          "curie-runner"
-        ],
-        "source": [
-          "api",
-          "dispatcher",
-          "worker",
-          "runner",
-          "local",
-          "eval"
-        ]
-      },
-      "cardinality_bound": 168,
-      "description": "Turns reaching a terminal result.",
-      "monotonic": true,
-      "type": "counter",
-      "unit": "{turn}"
-    },
-    "curie.turn.duration": {
-      "attributes": {
-        "outcome": [
-          "done",
-          "awaiting_approval",
-          "budget_halted",
-          "classified_failure",
-          "side_effect_halted",
-          "idle",
-          "interrupted"
-        ],
-        "service.name": [
-          "curie-api",
-          "curie-dispatcher",
-          "curie-worker",
-          "curie-runner"
-        ],
-        "source": [
-          "api",
-          "dispatcher",
-          "worker",
-          "runner",
-          "local",
-          "eval"
-        ]
-      },
-      "cardinality_bound": 168,
-      "description": "End to end turn duration.",
-      "monotonic": false,
-      "type": "histogram",
-      "unit": "s"
+      "cardinality_bound": 3
     }
-  },
-  "schema_version": "v1"
+  }
 }

--- a/packages/telemetry/src/curie_telemetry/metrics.py
+++ b/packages/telemetry/src/curie_telemetry/metrics.py
@@ -215,6 +215,7 @@ _HTTP_OPERATIONS = [
     "/publications/{publication_id}",
     "/v1/internal/cluster-message-replies/{reply_ref}",
     "/v1/internal/publications",
+    "/v1/internal/github/reviews/{event_id}/verify",
     "/v1/internal/publications/lineage",
     "/v1/internal/publications/review-reservations",
     "/v1/internal/publications/review-reservations/{reservation_id}/cancel",

--- a/packages/telemetry/src/curie_telemetry/metrics.py
+++ b/packages/telemetry/src/curie_telemetry/metrics.py
@@ -215,6 +215,7 @@ _HTTP_OPERATIONS = [
     "/publications/{publication_id}",
     "/v1/internal/cluster-message-replies/{reply_ref}",
     "/v1/internal/publications",
+    "/v1/internal/github/reviews/{event_id}/reserve",
     "/v1/internal/github/reviews/{event_id}/verify",
     "/v1/internal/publications/lineage",
     "/v1/internal/publications/review-reservations",


### PR DESCRIPTION
Draft for #2275. Signed GitHub feedback retains its immutable App/repository/PR lineage and original conversation, waits behind an active turn, and revalidates the current head and sender before reserving its revision. Ordinary Slack instructions retain their steering path. The existing publication writer consumes the exact reservation origin and still requires a fresh approval.

Durable delivery audits bind signed delivery identity to the payload digest. The SQL outbox reuses the existing bounded queue and enqueue receipt. Exact fenced completion or matching bounded dead-letter evidence settles the review; absent evidence never counts as completion. CONTRIBUTOR feedback additionally requires a fresh product-App repository permission response of write/admin for the exact immutable user; other accepted associations keep their approved behavior. No PAT or permission cache is introduced.

Stack: #2398, `task/overnight-review-lineage-clean` at `6811d09f11fc0c473cb9b95a239807bdd4173f26` → this draft at `eff0d3ff5c6696904fa1c0bbe4c9b9a262c141d2`. Schema graph0041→0042 lineage/reservation authority→0043 review outbox/audit. The feature stack remains unmerged.

Historical validation checkpoints:

- Actual full backing selection at c57f7d83:411 passed/9 failed of420, with independent API/publication/kernel/App suite exits. All100 kernel and39 App cases passed. These are bounded integration tests with real Postgres/Valkey/Langfuse backing, controlled GitHub/ACI peers.
- This follow-up repairs two proven fixtures: the migration guard is exercised at its own0042 transaction boundary, preserving the entire reservation row; the existing lineage reader's exact App Basic authorization is accepted only on its PR-read fixture. Review/permission Bearer and PAT refusal checks remain strict. A real scoped product-App probe independently observed Basic200/Bearer200 on the same PR/head and invalidBasic404.
- Exact affected rerun:8 passed/3 failed of11. Authority1, allowed/legacy/refusal consumer5, independent0043 rollback2 passed. HTTP404/403/timeout cases now reach the real consumer and reveal a remaining defect: authority unavailability spends inline workspace retries and acknowledges an unexecuted review. The bounded review-authority recovery follow-up below fixes that defect. This draft is not complete.
- Full Fable, alternate Grok and coordinator source/security/scope reviews cleared the committed fixture correction. The alternate wrapper timed out; its completed backend result was recovered separately. Ruff/diff checks and pinned, checksum-verified Gitleaks8.30.1 task-history scan pass. This stacked task-branch base does not trigger the normal main/next CI filter; required remote CI is unrun.

| Tier | Classification and evidence |
|---|---|
| skill | Required: final combined runner continuation unproved. |
| local | Required: partial real backing evidence above; authority recovery and enqueue concurrency tests now pass; final combined journey pending. |
| local-release | Required for the coordinated journey candidate; pending. |
| cluster | Required for original workspace/sandbox behavior; pending. |
| live provider | Required: final model-driven continuation unproved. |
| external integration | Required: actual App item/permission reads proven; webhook-driven publication and human approval unproved. |

The disposable external probe fetched exact conversation-comment, review-COMMENT and inline-comment items under the real product App, retained honest gh author provenance and returned invalid-token401 controls. The owned PR was closed unmerged and its branch removed. Product webhook subscriptions and real approval interaction remain setup/evidence gaps. The quota counter can consume another slot when repairing a failed SQL queued mark; that margin remains an explicit residual. No issue closure or full journey acceptance is claimed.


### Bounded review-authority recovery follow-up

Commit `106c30f4` preserves pre-model verification and reservation transport failures in the existing bounded pending/reclaim path. The same delivery freshly revalidates before recovery; the normal delivery cap still dead-letters it visibly. It no longer spends three model attempts and ACKs feedback that never reached the model. Definitive sender refusals and ordinary Slack steering retain their existing paths.

Fresh allocated full-backing verification on the exact committed source bytes: authority downgrade 1 PASS, real API/Consumer/Postgres/Valkey verification/reservation/recovery/cap cases 11 PASS, independent migration rollback 2 PASS; all 14 cases passed with zero skips. This closes the three product failures exposed by the prior eight-pass/three-fail fixture retry. Earlier full selection 411-pass/nine-fail remains historical evidence and is not relabeled as a fresh full-suite pass.

The two review siblings, healthy sender path, revoked/incorrect identity refusals, active-turn queueing plus ordinary Slack steering, fresh recovery permission read, and actual over-cap dead-letter reconciliation were observed. Source/security/scope reviews include full and delta Claude Fable plus routed alternate adjudication. Pinned Gitleaks 8.30.1 task history scan passed. Required external webhook ingress and live publication journeys remain unproved; draft status and the required-tier ledger remain unchanged.


### Audit-reference enqueue correction

Commit `eff0d3ff` lets eligible feedback enqueue while another delivery audit holds a foreign-key reference to the same feedback row. The waiting-row transaction uses `FOR NO KEY UPDATE SKIP LOCKED`; competing writers still exclude one another, and current binding/lineage checks remain mandatory. No authentication, provider, schema or terminal-state behavior changes.

A deterministic regression drives the signed API and real Postgres/Valkey outbox under an uncommitted audit reference. Before the fix, three cases failed and two controls passed. On the repaired source, all five focused cases and all **125 GitHub review module tests** passed with zero skips. Controls cover competing-writer exclusion and release, stale binding/lineage refusal with no XADD, exact SQL/stream receipt identity, duplicate ingress, and the unchanged four-delivery assertions.

The ordinary commit-level verification command `curie dev verify-fix-pin eff0d3ff 'apps/api/tests/test_github_review_events.py::test_review_outbox_recovers_under_delivery_reference_without_racing_mutators[audit-reference]'` returned `PINNED`: the selected case passes on the candidate and fails when only that commit's product change is reversed. This is evidence for the incremental fix, not a claim that reversing this whole feature PR preserves its prerequisite modules.

Native code/security review and explicit Claude Fable review approved the exact two-file delta; Ruff, scoped mypy, diff checks and Gitleaks 8.30.1 task-commit scan passed. The owned full backing stack was removed and its containers, volumes, networks, fixed ports and lock were checked after cleanup. No new live GitHub delivery, model continuation or human approval proof is claimed; this PR remains a draft with the required journey tiers above still open.
