### PR TITLE
Add the frozen ACI adoption-credential prerequisite

### DIFF
--- a/cli/src/evals.rs
+++ b/cli/src/evals.rs
@@ -755,6 +755,7 @@ mod tests {
         OutboundEvent::TextDelta {
             version: PROTOCOL_VERSION.into(),
             text: text.into(),
+            adoption_applied: None,
         }
     }
 
@@ -769,6 +770,7 @@ mod tests {
             approval_granted_tool: None,
             input_tokens: None,
             output_tokens: None,
+            adoption_applied: None,
         }
     }
 
@@ -777,6 +779,7 @@ mod tests {
             version: PROTOCOL_VERSION.into(),
             text: format!("calling {tool}"),
             tool: Some(tool.into()),
+            adoption_applied: None,
         }
     }
 

--- a/cli/src/ndjson.rs
+++ b/cli/src/ndjson.rs
@@ -86,6 +86,7 @@ mod tests {
                 approval_granted_tool: None,
                 input_tokens: None,
                 output_tokens: None,
+                adoption_applied: None,
             }
         );
     }

--- a/cli/src/render.rs
+++ b/cli/src/render.rs
@@ -147,6 +147,7 @@ mod tests {
         let delta = OutboundEvent::TextDelta {
             version: v(),
             text: "all done".into(),
+            adoption_applied: None,
         };
         let final_frame = OutboundEvent::Final {
             version: v(),
@@ -158,6 +159,7 @@ mod tests {
             approval_granted_tool: None,
             input_tokens: None,
             output_tokens: None,
+            adoption_applied: None,
         };
         // A delta routes to stdout as a raw token.
         assert!(matches!(printer.part_for(&delta), Some(TurnPart::Token(t)) if t == "all done"));
@@ -180,6 +182,7 @@ mod tests {
             approval_granted_tool: None,
             input_tokens: None,
             output_tokens: None,
+            adoption_applied: None,
         };
         // The caller prints this token to stdout, then appends the status trailer.
         assert!(
@@ -200,6 +203,7 @@ mod tests {
             approval_granted_tool: None,
             input_tokens: None,
             output_tokens: None,
+            adoption_applied: None,
         };
         assert!(
             matches!(printer.part_for(&final_frame), Some(TurnPart::Status(s)) if s == "-- final (done)")
@@ -213,6 +217,7 @@ mod tests {
             version: v(),
             text: "running echo hi".into(),
             tool: Some("Bash".into()),
+            adoption_applied: None,
         };
         let flag = OutboundEvent::SideEffectFlag {
             version: v(),
@@ -225,11 +230,13 @@ mod tests {
             arguments: None,
             result: None,
             failed: None,
+            adoption_applied: None,
         };
         let error = OutboundEvent::ErrorEvent {
             version: v(),
             message: "boom".into(),
             classification: Some("budget".into()),
+            adoption_applied: None,
         };
         // Tool note and side-effect flag are diagnostics -> Note (stderr).
         assert!(matches!(printer.part_for(&note), Some(TurnPart::Note(_))));

--- a/cli/src/runner.rs
+++ b/cli/src/runner.rs
@@ -112,6 +112,7 @@ impl RunnerClient {
             ts: slack_ts(),
             session_id: None,
             history_ref: None,
+            adoption_credential: None,
         };
         let resp = self
             .http

--- a/cli/tests/eval_falsifiability.rs
+++ b/cli/tests/eval_falsifiability.rs
@@ -110,6 +110,7 @@ fn done_turn(text: &str) -> Vec<OutboundEvent> {
         approval_granted_tool: None,
         input_tokens: None,
         output_tokens: None,
+        adoption_applied: None,
     }]
 }
 

--- a/cli/tests/fake_tier_plumbing.rs
+++ b/cli/tests/fake_tier_plumbing.rs
@@ -290,6 +290,7 @@ fn final_event(text: &str, status: SessionStatus) -> OutboundEvent {
         approval_granted_tool: None,
         input_tokens: None,
         output_tokens: None,
+        adoption_applied: None,
     }
 }
 
@@ -343,6 +344,7 @@ fn a_fake_turn_that_did_not_complete_is_still_a_fail() {
     let unfinished: Vec<OutboundEvent> = vec![OutboundEvent::TextDelta {
         version: PROTOCOL_VERSION.into(),
         text: "all done".into(),
+        adoption_applied: None,
     }];
     assert_eq!(
         turn_outcome(&case, &unfinished, true),

--- a/cli/tests/json_contract.rs
+++ b/cli/tests/json_contract.rs
@@ -1167,6 +1167,7 @@ fn skill_message_awaiting_approval_output_preserves_final_approval_fields() {
         approval_granted_tool: Some("ExampleTool".to_string()),
         input_tokens: Some(10),
         output_tokens: Some(5),
+        adoption_applied: None,
     };
     let out = SkillMessageOutput::from_final("the answer is 42".to_string(), &final_frame)
         .expect("a final frame produces skill message output");
@@ -1199,6 +1200,7 @@ fn skill_message_awaiting_approval_output_is_not_finalized() {
         approval_granted_tool: None,
         input_tokens: None,
         output_tokens: None,
+        adoption_applied: None,
     };
     let out = SkillMessageOutput::from_final(
         "I need approval before continuing".to_string(),
@@ -1235,6 +1237,7 @@ fn skill_message_only_marks_awaiting_approval_as_not_finalized() {
             approval_granted_tool: None,
             input_tokens: None,
             output_tokens: None,
+            adoption_applied: None,
         };
         let out = SkillMessageOutput::from_final(String::new(), &final_frame)
             .expect("a final frame produces skill message output");

--- a/docs/diagrams/aci.md
+++ b/docs/diagrams/aci.md
@@ -31,10 +31,14 @@ The reply is a stream of NDJSON events defined in
 - `error`
 
 An inbound `event` frame carries `{kind, type, text, user, ts}` plus optional,
-nullable `session_id` and `history_ref` strings for conversation-scoped identity.
-Older producers may omit either field independently. Startup configuration is a
-separate, environment-only `SessionConfig`; the per-event fields do not replace
-it.
+nullable `session_id`, `history_ref`, and `adoption_credential` strings.
+`session_id` and `history_ref` are conversation-scoped identity.
+`adoption_credential` is the optional per-conversation runner credential on this
+same authenticated event; omitted or null is the legacy cold path. Older
+producers may omit any of these independently. A successful turn without
+`adoption_applied: true` on the outbound stream is not adoption. Startup
+configuration is a separate, environment-only `SessionConfig`; the per-event
+fields do not replace it.
 
 ## Inside the box
 
@@ -113,7 +117,7 @@ regenerated and committed together it **always goes green**. It pins artifact
 *sync*; it never pinned *compatibility*. Three things carry the contract
 instead:
 
-- **Semver, not a freeze.** `PROTOCOL_VERSION` is `0.4.4`
+- **Semver, not a freeze.** `PROTOCOL_VERSION` is `0.4.5`
   ([`packages/aci-protocol/src/aci_protocol/version.py`](../../packages/aci-protocol/src/aci_protocol/version.py)),
   versioned independently of the Curie release. Under 0.x a consumer accepts
   the same `major.minor`; only a new optional field is compatible (patch), and

--- a/docs/interfaces/aci-producer/implementing-an-aci-server.md
+++ b/docs/interfaces/aci-producer/implementing-an-aci-server.md
@@ -46,9 +46,13 @@ that has not opted into shared history. The reference implementation is
 Startup configuration remains **environment-only**. Read it once with
 `SessionConfig.from_env()` (the `CURIE_*` mapping: `plugin_dir`, `session_id`,
 `sandbox_id`, `budget`, optional `memory_ref`, `credentials_ref`, `otel`). The
-inbound `Event` separately has optional `session_id` and `history_ref` fields for
-conversation-scoped identity after a sandbox is bound. They are wire metadata,
-not a replacement for `SessionConfig`, and older producers may omit either one.
+inbound `Event` separately has optional `session_id`, `history_ref`, and
+`adoption_credential` fields. The first two are conversation-scoped identity
+after a sandbox is bound. `adoption_credential` is the optional per-conversation
+runner credential delivered on this same authenticated event (ADR-0122); omitted
+or null means no adoption. They are wire metadata, not a replacement for
+`SessionConfig`, and older producers may omit any of them. A schema field is
+not bootstrap retirement or warm-pool activation.
 
 ## The wire contract in one screen
 
@@ -57,24 +61,28 @@ Import everything from `aci_protocol`; do not hand-roll JSON.
 **Inbound** — a discriminated union on `kind` (`parse_inbound` decodes it):
 
 - `Event` = `{kind: "event", type: "message"|"job"|"eval_case", text, user, ts,
-  session_id?, history_ref?}`. The optional fields are nullable strings; either
-  may be omitted independently.
+  session_id?, history_ref?, adoption_credential?}`. The optional fields are
+  nullable strings and may be omitted independently. `adoption_credential` is
+  secret material: omit/null is the legacy cold path, a malformed value is a
+  hard decode error, and the value must not appear in `repr`, errors, model
+  prompts, or evidence.
 - `Interrupt` = `{kind: "interrupt", reason}`
 
 **Outbound** — a discriminated union on `type`, each carrying `version`
 (`to_ndjson_line` encodes, `parse_ndjson_line` decodes one line):
 
-- `TextDelta` → `text_delta` `{version, text}`
-- `ToolNote` → `tool_note` `{version, text, tool?}`
-- `Final` → `final` `{version, text, status}` where `status ∈ {done,
+- `TextDelta` → `text_delta` `{version, text, adoption_applied?}`
+- `ToolNote` → `tool_note` `{version, text, tool?, adoption_applied?}`
+- `Final` → `final` `{version, text, status, adoption_applied?}` where `status ∈ {done,
   idle-awaiting-input, classified-failure}`
-- `ErrorEvent` → `error` `{version, message, classification?}`
+- `ErrorEvent` → `error` `{version, message, classification?, adoption_applied?}`
 - `SideEffectFlag` → `side_effect_flag` `{version, tool?, detail?, call_id?,
-  arguments?, result?, failed?}`, emitted once when a side-effecting call is
-  made and once when its result arrives, joined on `call_id` (ADR-0117)
+  arguments?, result?, failed?, adoption_applied?}`, emitted once when a
+  side-effecting call is made and once when its result arrives, joined on
+  `call_id` (ADR-0117)
 
 **Version gate (strict producer, tolerant consumer).** Your producer emits its
-**exact build `PROTOCOL_VERSION`** (currently `0.4.4`) on every outbound event and
+**exact build `PROTOCOL_VERSION`** (currently `0.4.5`) on every outbound event and
 constructs strictly -- an unknown field is an error at construction, catching your
 mistakes at the source. A **consumer** decoding the wire is tolerant the other way:
 it accepts any version compatible with its own build (`major.minor` match under

--- a/packages/aci-protocol/README.md
+++ b/packages/aci-protocol/README.md
@@ -24,9 +24,9 @@ string rather than a `const`. Artifact sync is enforced by the
 schema-compat gate (`tests/test_schema_compat.py`); an unbumped wire change is
 caught by the wire-lock gate (`tests/test_wire_lock.py`).
 
-## Contract surface (v0.4.4)
+## Contract surface (v0.4.5)
 
-`PROTOCOL_VERSION = "0.4.4"` is embedded in the schema and in every outbound
+`PROTOCOL_VERSION = "0.4.5"` is embedded in the schema and in every outbound
 event.
 
 **Session setup** (`SessionConfig`, with `to_env()` / `from_env()`):
@@ -45,19 +45,45 @@ event.
 
 **Inbound channel messages** (discriminated union on `kind`):
 
-- `Event` = `{kind: "event", type: message|job|eval_case, text, user, ts, session_id?, history_ref?}`.
+- `Event` = `{kind: "event", type: message|job|eval_case, text, user, ts, session_id?, history_ref?, adoption_credential?}`.
   `session_id` and `history_ref` are nullable strings carrying conversation-scoped
   identity after a sandbox is bound; older producers may omit either field.
+  `adoption_credential` is a nullable string carrying a per-conversation runner
+  credential on the existing authenticated event (ADR-0122). Omitted or JSON
+  `null` is the legacy cold path (no adoption requested). A malformed value is
+  a hard decode error with no partial Event. The field is secret material: it
+  is omitted from `repr`/`str` and must not appear in errors, model prompts, or
+  evidence. It is not a substitute for `text`, `user`, `ts`, or `history_ref`.
 - `Interrupt` = `{kind: "interrupt", reason}`
 
 **Outbound NDJSON response events** (discriminated union on `type`, each carries
 `version`):
 
-- `text_delta` = `{version, text}`
-- `tool_note` = `{version, text, tool?}`
-- `final` = `{version, text, status}` where `status` is `SessionStatus`
-- `error` = `{version, message, classification?}`
-- `side_effect_flag` = `{version, tool?, detail?}`
+- `text_delta` = `{version, text, adoption_applied?}`
+- `tool_note` = `{version, text, tool?, adoption_applied?}`
+- `final` = `{version, text, status, adoption_applied?}` where `status` is `SessionStatus`
+- `error` = `{version, message, classification?, adoption_applied?}`
+- `side_effect_flag` = `{version, tool?, detail?, adoption_applied?}`
+
+`adoption_applied` is the optional ack that the consumer applied
+`adoption_credential` for that turn. `null`/omitted is the pre-ack shape. `true`
+means the credential was installed. A producer that sent a credential must
+require `true`; a successful turn without that ack is not adoption, because a
+tolerant 0.4.4 consumer ignores the inbound field.
+
+These fields define delivery and admission on the frozen Event. They do not
+retire a bootstrap token, recover a route, or enable warm-pool replicas. That
+realizing work stays in a later runner/worker change.
+
+**Producer/consumer rollout.** Inbound `Event` has no `version`, so an old
+tolerant consumer can ignore `adoption_credential` and still emit a `final`.
+Order: (1) land this contract; (2) ship a consumer that validates, applies only
+after a well-formed value, fails malformed frames atomically, redacts the
+secret, and emits `adoption_applied=true` when it applied; (3) only then may a
+producer send `adoption_credential`, and only on authenticated `POST /v1/event`.
+A steer that carries a credential must be rejected by the realizing server
+rather than swapping mid-turn. Do not treat HTTP 200 or a `final` as
+retirement.
 
 **Session status** (`SessionStatus`): `done`, `idle-awaiting-input`,
 `classified-failure`.

--- a/packages/aci-protocol/generated/rust/src/lib.rs
+++ b/packages/aci-protocol/generated/rust/src/lib.rs
@@ -6,7 +6,7 @@
 
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: &str = "0.4.4";
+pub const PROTOCOL_VERSION: &str = "0.4.5";
 
 pub const RUNS_STREAM_DEFAULT: &str = "curie:runs";
 
@@ -69,6 +69,22 @@ where
     T: Deserialize<'de>,
 {
     Option::<T>::deserialize(deserializer)
+}
+
+fn deserialize_adoption_credential<'de, D>(
+    deserializer: D,
+) -> Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<String>::deserialize(deserializer)?;
+    match &value {
+        None => Ok(None),
+        Some(s) if s.trim().is_empty() || s.chars().count() > 4096 => {
+            Err(serde::de::Error::custom("malformed adoption credential"))
+        }
+        Some(_) => Ok(value),
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
@@ -320,7 +336,7 @@ pub struct ApprovalRequest {
     pub expires_in_seconds: Option<i64>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "kind")]
 pub enum InboundMessage {
     #[serde(rename = "event")]
@@ -333,11 +349,44 @@ pub enum InboundMessage {
         session_id: Option<String>,
         #[serde(default)]
         history_ref: Option<String>,
+        #[serde(default, deserialize_with = "deserialize_adoption_credential")]
+        adoption_credential: Option<String>,
     },
     #[serde(rename = "interrupt")]
     Interrupt {
         reason: String,
     },
+}
+
+impl std::fmt::Debug for InboundMessage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Event {
+                r#type,
+                text,
+                user,
+                ts,
+                session_id,
+                history_ref,
+                adoption_credential,
+            } => f
+                .debug_struct("Event")
+                .field("type", r#type)
+                .field("text", text)
+                .field("user", user)
+                .field("ts", ts)
+                .field("session_id", session_id)
+                .field("history_ref", history_ref)
+                .field(
+                    "adoption_credential",
+                    &adoption_credential.as_ref().map(|_| "<redacted>"),
+                )
+                .finish(),
+            Self::Interrupt { reason } => {
+                f.debug_struct("Interrupt").field("reason", reason).finish()
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -347,12 +396,16 @@ pub enum OutboundEvent {
     TextDelta {
         #[serde(deserialize_with = "require_compatible_protocol_version")]
         version: String,
+        #[serde(default)]
+        adoption_applied: Option<bool>,
         text: String,
     },
     #[serde(rename = "tool_note")]
     ToolNote {
         #[serde(deserialize_with = "require_compatible_protocol_version")]
         version: String,
+        #[serde(default)]
+        adoption_applied: Option<bool>,
         text: String,
         #[serde(default)]
         tool: Option<String>,
@@ -361,6 +414,8 @@ pub enum OutboundEvent {
     Final {
         #[serde(deserialize_with = "require_compatible_protocol_version")]
         version: String,
+        #[serde(default)]
+        adoption_applied: Option<bool>,
         text: String,
         #[serde(default)]
         status: SessionStatus,
@@ -381,6 +436,8 @@ pub enum OutboundEvent {
     ErrorEvent {
         #[serde(deserialize_with = "require_compatible_protocol_version")]
         version: String,
+        #[serde(default)]
+        adoption_applied: Option<bool>,
         message: String,
         #[serde(default)]
         classification: Option<String>,
@@ -389,6 +446,8 @@ pub enum OutboundEvent {
     SideEffectFlag {
         #[serde(deserialize_with = "require_compatible_protocol_version")]
         version: String,
+        #[serde(default)]
+        adoption_applied: Option<bool>,
         #[serde(default)]
         tool: Option<String>,
         #[serde(default)]
@@ -420,6 +479,7 @@ mod tests {
             approval_granted_tool: None,
             input_tokens: None,
             output_tokens: None,
+            adoption_applied: None,
         };
         let encoded = serde_json::to_string(&event).unwrap();
         let decoded: OutboundEvent = serde_json::from_str(&encoded).unwrap();
@@ -438,6 +498,7 @@ mod tests {
             approval_granted_tool: None,
             input_tokens: None,
             output_tokens: None,
+            adoption_applied: None,
         };
         let encoded = serde_json::to_string(&event).unwrap();
         let decoded: OutboundEvent = serde_json::from_str(&encoded).unwrap();
@@ -453,10 +514,38 @@ mod tests {
             ts: "1.0".to_string(),
             session_id: None,
             history_ref: None,
+            adoption_credential: None,
         };
         let encoded = serde_json::to_string(&message).unwrap();
         let decoded: InboundMessage = serde_json::from_str(&encoded).unwrap();
         assert_eq!(message, decoded);
+    }
+
+    #[test]
+    fn inbound_event_debug_redacts_adoption_credential() {
+        let message = InboundMessage::Event {
+            r#type: EventType::Message,
+            text: "hello".to_string(),
+            user: "U1".to_string(),
+            ts: "1.0".to_string(),
+            session_id: None,
+            history_ref: None,
+            adoption_credential: Some("adoption-credential-fixture-PLACEHOLDER".to_string()),
+        };
+        let rendered = format!("{message:?}");
+        assert!(!rendered.contains("adoption-credential-fixture-PLACEHOLDER"));
+        assert!(rendered.contains("<redacted>"));
+    }
+
+    #[test]
+    fn inbound_event_rejects_empty_adoption_credential() {
+        let raw = concat!(
+            r#"{"kind":"event","type":"message","text":"hi","user":"U1","ts":"1.0","#,
+            r#""adoption_credential":""}"#
+        );
+        let error = serde_json::from_str::<InboundMessage>(raw).unwrap_err();
+        assert!(error.to_string().contains("malformed adoption credential"));
+        assert!(!error.to_string().contains("adoption-credential-fixture-PLACEHOLDER"));
     }
 
     #[test]
@@ -491,13 +580,13 @@ mod tests {
 
     #[test]
     fn accepts_compatible_patch() {
-        let raw = r#"{"type":"final","version":"0.4.5","text":"x","status":"done"}"#;
+        let raw = r#"{"type":"final","version":"0.4.6","text":"x","status":"done"}"#;
         assert!(serde_json::from_str::<OutboundEvent>(raw).is_ok());
     }
 
     #[test]
     fn accepts_unknown_fields() {
-        let raw = r#"{"type":"final","version":"0.4.4","text":"x","status":"done","extra":1}"#;
+        let raw = r#"{"type":"final","version":"0.4.5","text":"x","status":"done","extra":1}"#;
         assert!(serde_json::from_str::<OutboundEvent>(raw).is_ok());
     }
 }

--- a/packages/aci-protocol/generated/ts/aci-protocol.ts
+++ b/packages/aci-protocol/generated/ts/aci-protocol.ts
@@ -20,7 +20,7 @@ export type ExpiresInSeconds = number | null;
  * authority-bearing per #544/ADR-0046, so the value domain is a named, exported
  * part of the contract rather than an inline annotation.
  *
- * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
  * via the `definition` "GateKind".
  */
 export type GateKind = "permission" | "policy";
@@ -69,6 +69,7 @@ export type SessionId = string;
 export type StateToken = string | null;
 export type StateUrl = string | null;
 export type Thinking = string | null;
+export type AdoptionApplied = boolean | null;
 export type Classification = string | null;
 export type Message = string;
 export type Type = "error";
@@ -86,6 +87,7 @@ export type RepoFullName = string;
 export type Sha1 = string;
 export type TargetUrl1 = string | null;
 export type Total = number;
+export type AdoptionCredential = string | null;
 export type HistoryRef1 = string | null;
 export type Kind = "event";
 export type SessionId1 = string | null;
@@ -93,6 +95,7 @@ export type Text = string;
 export type Ts = string;
 export type Type1 = "message" | "job" | "eval_case";
 export type User = string;
+export type AdoptionApplied1 = boolean | null;
 export type ApprovalGateKind = string | null;
 export type ApprovalGrantedTool = string | null;
 export type ApprovalRoute = string | null;
@@ -110,24 +113,27 @@ export type Text1 = string;
 export type Type2 = "final";
 export type Version1 = string;
 /**
- * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
  * via the `definition` "InboundMessage".
  */
 export type InboundMessage = Event | Interrupt;
 export type Kind1 = "interrupt";
 export type Reason = string;
 /**
- * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
  * via the `definition` "OutboundEvent".
  */
 export type OutboundEvent = TextDelta | ToolNote | Final | ErrorEvent | SideEffectFlag;
+export type AdoptionApplied2 = boolean | null;
 export type Text2 = string;
 export type Type3 = "text_delta";
 export type Version2 = string;
+export type AdoptionApplied3 = boolean | null;
 export type Text3 = string;
 export type Tool = string | null;
 export type Type4 = "tool_note";
 export type Version3 = string;
+export type AdoptionApplied4 = boolean | null;
 export type Arguments = {
   [k: string]: unknown;
 } | null;
@@ -181,7 +187,7 @@ export type Text4 = string;
  * Wire tokens follow the section 0 spelling; ``classified failure`` in prose
  * becomes the token ``classified-failure`` on the wire.
  *
- * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
  * via the `definition` "SessionStatus".
  */
 export type SessionStatus1 = "done" | "idle-awaiting-input" | "classified-failure" | "awaiting-approval";
@@ -209,12 +215,12 @@ export type SessionStatus1 = "done" | "idle-awaiting-input" | "classified-failur
  * ENUM VALUE -- breaking under this package's rules, so it is a deliberate,
  * separately-decided bump rather than something this change assumes.
  *
- * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
  * via the `definition` "TurnSource".
  */
 export type TurnSource1 = "slack" | "webhook" | "cron";
 
-export interface ACIProtocolV044 {
+export interface ACIProtocolV045 {
   [k: string]: unknown;
 }
 /**
@@ -238,7 +244,7 @@ export interface ACIProtocolV044 {
  * nullable because ``slack`` legitimately has no adapter -- its route is the
  * worker's configured Slack origin.
  *
- * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
  * via the `definition` "ApprovalRequest".
  */
 export interface ApprovalRequest {
@@ -285,7 +291,7 @@ export interface ApprovalRequest {
  * baked template default, the worker's value is per-agent model routing. Do not
  * collapse either producer list to a single value.
  *
- * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
  * via the `definition` "BootEnv".
  */
 export interface BootEnv {
@@ -325,7 +331,7 @@ export interface BootEnv {
  * section 0 describes these as per-tool secrets via K8s Secret refs, so the
  * contract carries the reference, not the secret material itself.
  *
- * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
  * via the `definition` "SessionConfig".
  */
 export interface SessionConfig {
@@ -344,7 +350,7 @@ export interface SessionConfig {
  * ``task_budget_hint`` is the optional hint passed through to the model so it
  * self paces (section 6b); it is not a hard ceiling.
  *
- * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
  * via the `definition` "Budget".
  */
 export interface Budget {
@@ -360,7 +366,7 @@ export interface Budget {
  * fields the prototype used (endpoint, headers, protocol); any others pass
  * through as raw env vars untouched and are out of scope for this typed view.
  *
- * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
  * via the `definition` "OtelConfig".
  */
 export interface OtelConfig {
@@ -372,10 +378,11 @@ export interface OtelConfig {
 /**
  * A classified failure surfaced to the platform.
  *
- * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
  * via the `definition` "ErrorEvent".
  */
 export interface ErrorEvent {
+  adoption_applied?: AdoptionApplied;
   classification?: Classification;
   message: Message;
   type: Type;
@@ -389,7 +396,7 @@ export interface ErrorEvent {
  * worker consumes off it (formerly the API's ``EvalJobRequest`` and the
  * worker's ``EvalWorkItem``, which had drifted on ``bundle_ref``).
  *
- * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
  * via the `definition` "EvalJob".
  */
 export interface EvalJob {
@@ -409,7 +416,7 @@ export interface EvalJob {
  * Byte-identical across both lanes before this promotion, so it carries no
  * semantic decisions.
  *
- * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
  * via the `definition` "EvalReport".
  */
 export interface EvalReport {
@@ -427,10 +434,29 @@ export interface EvalReport {
  * runner after its sandbox is bound. Both remain optional so older producers
  * can omit them and tolerant consumers can adopt the additive wire shape.
  *
- * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
+ * ``adoption_credential`` is the optional per-conversation runner credential
+ * ADR-0122 delivers on this same authenticated ``Event`` (never a new
+ * lifecycle route, and never by overloading ``text`` / ``user`` / ``ts`` /
+ * ``history_ref``). Omitted or JSON ``null`` is the legacy cold path: no
+ * adoption is requested and a current credential must stay in force. A
+ * malformed value is a hard decode error; the model is not constructed, so
+ * there is no partial adoption at the wire layer. The field is secret
+ * material: it is omitted from ``repr`` / ``str``, and decode errors must
+ * not echo it.
+ *
+ * This field does not retire a bootstrap token, persist a route, or enable a
+ * warm pool. Those are realizing-runner/worker behaviors. Because inbound
+ * ``Event`` carries no ``version`` and a tolerant consumer ignores unknown
+ * keys, a successful turn is not proof of adoption. A consumer that applies
+ * the credential MUST set ``adoption_applied=True`` on the outbound frames of
+ * that turn; a producer that sent a credential MUST treat a missing or
+ * non-true ack as "not adopted".
+ *
+ * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
  * via the `definition` "Event".
  */
 export interface Event {
+  adoption_credential?: AdoptionCredential;
   history_ref?: HistoryRef1;
   kind: Kind;
   session_id?: SessionId1;
@@ -474,10 +500,11 @@ export interface Event {
  * scalars: a tolerant consumer decoding an older producer's ``final`` simply
  * sees them absent.
  *
- * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
  * via the `definition` "Final".
  */
 export interface Final {
+  adoption_applied?: AdoptionApplied1;
   approval_gate_kind?: ApprovalGateKind;
   approval_granted_tool?: ApprovalGrantedTool;
   approval_route?: ApprovalRoute;
@@ -493,7 +520,7 @@ export interface Final {
 /**
  * A hard stop delivered on the control channel, distinct from a steer.
  *
- * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
  * via the `definition` "Interrupt".
  */
 export interface Interrupt {
@@ -504,10 +531,11 @@ export interface Interrupt {
 /**
  * A streamed chunk of assistant text.
  *
- * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
  * via the `definition` "TextDelta".
  */
 export interface TextDelta {
+  adoption_applied?: AdoptionApplied2;
   text: Text2;
   type: Type3;
   version: Version2;
@@ -516,10 +544,11 @@ export interface TextDelta {
 /**
  * A human readable note about a tool call the harness is making.
  *
- * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
  * via the `definition` "ToolNote".
  */
 export interface ToolNote {
+  adoption_applied?: AdoptionApplied3;
   text: Text3;
   tool?: Tool;
   type: Type4;
@@ -545,10 +574,11 @@ export interface ToolNote {
  * turn that calls the same tool twice is otherwise indistinguishable from one
  * that called it once.
  *
- * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
  * via the `definition` "SideEffectFlag".
  */
 export interface SideEffectFlag {
+  adoption_applied?: AdoptionApplied4;
   arguments?: Arguments;
   call_id?: CallId;
   detail?: Detail;
@@ -575,7 +605,7 @@ export interface SideEffectFlag {
  * to the non-job value is also the safe direction -- an unset ``source`` reads
  * as a person's message, so a job can never be created by omission.
  *
- * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
  * via the `definition` "QueuedTurn".
  */
 export interface QueuedTurn {
@@ -624,7 +654,7 @@ export interface QueuedTurn {
  * third-party or pre-upgrade producer is not rejected outright, but every
  * first-party mint site sets it explicitly.
  *
- * This interface was referenced by `ACIProtocolV044`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
  * via the `definition` "ReplyHandle".
  */
 export interface ReplyHandle {

--- a/packages/aci-protocol/schema/aci-protocol.schema.json
+++ b/packages/aci-protocol/schema/aci-protocol.schema.json
@@ -627,6 +627,18 @@
     "ErrorEvent": {
       "description": "A classified failure surfaced to the platform.",
       "properties": {
+        "adoption_applied": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Adoption Applied"
+        },
         "classification": {
           "anyOf": [
             {
@@ -776,8 +788,23 @@
       "type": "object"
     },
     "Event": {
-      "description": "An inbound event delivered into a live session (initial or follow-up).\n\n``session_id`` and ``history_ref`` carry conversation-scoped identity to a\nrunner after its sandbox is bound. Both remain optional so older producers\ncan omit them and tolerant consumers can adopt the additive wire shape.",
+      "description": "An inbound event delivered into a live session (initial or follow-up).\n\n``session_id`` and ``history_ref`` carry conversation-scoped identity to a\nrunner after its sandbox is bound. Both remain optional so older producers\ncan omit them and tolerant consumers can adopt the additive wire shape.\n\n``adoption_credential`` is the optional per-conversation runner credential\nADR-0122 delivers on this same authenticated ``Event`` (never a new\nlifecycle route, and never by overloading ``text`` / ``user`` / ``ts`` /\n``history_ref``). Omitted or JSON ``null`` is the legacy cold path: no\nadoption is requested and a current credential must stay in force. A\nmalformed value is a hard decode error; the model is not constructed, so\nthere is no partial adoption at the wire layer. The field is secret\nmaterial: it is omitted from ``repr`` / ``str``, and decode errors must\nnot echo it.\n\nThis field does not retire a bootstrap token, persist a route, or enable a\nwarm pool. Those are realizing-runner/worker behaviors. Because inbound\n``Event`` carries no ``version`` and a tolerant consumer ignores unknown\nkeys, a successful turn is not proof of adoption. A consumer that applies\nthe credential MUST set ``adoption_applied=True`` on the outbound frames of\nthat turn; a producer that sent a credential MUST treat a missing or\nnon-true ack as \"not adopted\".",
       "properties": {
+        "adoption_credential": {
+          "anyOf": [
+            {
+              "maxLength": 4096,
+              "minLength": 1,
+              "pattern": ".*\\S.*",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Adoption Credential"
+        },
         "history_ref": {
           "anyOf": [
             {
@@ -842,6 +869,18 @@
     "Final": {
       "description": "The terminal response event, carrying the session status.\n\n``approval_summary`` accompanies an ``awaiting-approval`` status (ADR-0010):\nthe human-readable statement of what needs approval, captured from the\nrun's approval request so the platform can persist it on the durable\n``Approval`` record and show it to the approver. ``approval_route`` names\nthe approval route the request targets (#247): declared in the bundle\nmanifest's ``approvalPolicy`` (versioned with the agent), bound to a\nworkspace channel per deployment by the worker. Both ``None`` on every\nother status; ``approval_route`` also ``None`` when the request named no\nroute (the platform falls back to the requesting channel).\n\n``approval_gate_kind`` records which gate produced the request (#544):\n``'permission'`` when the runner's tool-permission gate denied a real tool\ncall, ``'policy'`` when the model asked for a business-decision approval.\nIt is the durable provenance the worker branches on instead of sniffing the\nsummary prefix. ``approval_granted_tool`` carries the tool name the\npermission gate denied -- the trusted ``can_use_tool`` value the resume-turn\ngrant is bound to -- and is only ever set for ``approval_gate_kind =\n'permission'``; a policy gate never authorizes a tool, so it stays ``None``.\nBoth ``None`` on every other status, and ``None`` from an older runner that\npredates these fields (the worker falls back to the prefix parse then).\n\n``input_tokens``/``output_tokens`` carry the turn's model token usage when\nthe harness reported it (#390): the runner stamps them from the SDK result's\n``usage`` so a consumer can attribute a dollar cost to the turn (model\npricing lives with the consumer, not on the wire). Both ``None`` when usage\nwas unavailable -- the fake-model path, a provider that reports no usage, or\nan older runner that predates these fields -- so a consumer computing cost\nleaves it unknown rather than counting the turn as free. Additive optional\nscalars: a tolerant consumer decoding an older producer's ``final`` simply\nsees them absent.",
       "properties": {
+        "adoption_applied": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Adoption Applied"
+        },
         "approval_gate_kind": {
           "anyOf": [
             {
@@ -1227,6 +1266,18 @@
     "SideEffectFlag": {
       "description": "Marks that a non-idempotent tool call executed during the run.\n\nIts presence gates the no-retry-after-side-effects rule (section 2b): a\nfailed run carrying this flag escalates to a human instead of retrying.\n\nIt also reports WHAT the call did (ADR-0117). The information was already in\nhand where the frame is built and was being replaced by a constant ``detail``\nstring, so a consumer could know that something mutated and never what. Every\nfield below is optional with a ``None`` default, which is why carrying them\nis a patch under ADR-0036: a reader that predates them decodes the frame\nunchanged.\n\nOne CALL produces two frames -- an opening one when the call is made, so the\nno-retry rule latches even if the turn dies mid-call, and a closing one\ncarrying what came back. ``call_id`` is what joins them into one record; a\nturn that calls the same tool twice is otherwise indistinguishable from one\nthat called it once.",
       "properties": {
+        "adoption_applied": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Adoption Applied"
+        },
         "arguments": {
           "anyOf": [
             {
@@ -1322,6 +1373,18 @@
     "TextDelta": {
       "description": "A streamed chunk of assistant text.",
       "properties": {
+        "adoption_applied": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Adoption Applied"
+        },
         "text": {
           "title": "Text",
           "type": "string"
@@ -1348,6 +1411,18 @@
     "ToolNote": {
       "description": "A human readable note about a tool call the harness is making.",
       "properties": {
+        "adoption_applied": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Adoption Applied"
+        },
         "text": {
           "title": "Text",
           "type": "string"
@@ -1396,6 +1471,6 @@
   },
   "$id": "https://curietech.ai/schemas/aci-protocol.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "protocolVersion": "0.4.4",
-  "title": "ACI Protocol v0.4.4"
+  "protocolVersion": "0.4.5",
+  "title": "ACI Protocol v0.4.5"
 }

--- a/packages/aci-protocol/schema/wire.lock
+++ b/packages/aci-protocol/schema/wire.lock
@@ -1,4 +1,4 @@
 {
-  "protocol_version": "0.4.4",
-  "wire_sha256": "df4e3a1360567a04f15ba5261dc0418e80b50a3bf26dc26c2476833d47eb49b1"
+  "protocol_version": "0.4.5",
+  "wire_sha256": "b1e13f7ba8da30ac758a65bdfe7cc4c83ffe8ceb9d3995f3e095d2bcc8c37f93"
 }

--- a/packages/aci-protocol/src/aci_protocol/__init__.py
+++ b/packages/aci-protocol/src/aci_protocol/__init__.py
@@ -13,6 +13,7 @@ class and regenerates the committed schema and types.
 
 from .conformance import ConformanceReport, Producer, run_conformance
 from .events import (
+    ADOPTION_CREDENTIAL_MAX_CHARS,
     OUTBOUND_EVENT_TYPES,
     READER_CONTEXT,
     ErrorEvent,
@@ -25,6 +26,7 @@ from .events import (
     SideEffectFlag,
     TextDelta,
     ToolNote,
+    parse_adoption_credential,
 )
 from .ndjson import (
     ProtocolVersionError,
@@ -91,6 +93,8 @@ __all__ = [
     "Event",
     "Interrupt",
     "InboundMessage",
+    "ADOPTION_CREDENTIAL_MAX_CHARS",
+    "parse_adoption_credential",
     # outbound
     "TextDelta",
     "ToolNote",

--- a/packages/aci-protocol/src/aci_protocol/events.py
+++ b/packages/aci-protocol/src/aci_protocol/events.py
@@ -167,7 +167,9 @@ def redact_adoption_credential_error(exc: ValidationError) -> ValidationError:
 
     Errors whose loc is the credential field stay a closed malformed-credential
     failure. Unrelated failures (a missing ``text``, for example) keep their
-    diagnosis; only the credential material is scrubbed from their inputs.
+    diagnosis; only the credential material is scrubbed from their inputs. A
+    ``json_invalid`` error keeps its parser diagnosis but loses its input
+    entirely, because unparsed raw JSON cannot be scrubbed by field name.
     """
 
     errors = exc.errors()
@@ -184,9 +186,18 @@ def redact_adoption_credential_error(exc: ValidationError) -> ValidationError:
     scrubbed: list[Any] = []
     for err in errors:
         input_value = err.get("input")
+        item = dict(err)
+        if err.get("type") == "json_invalid":
+            # Raw JSON that never parsed: pydantic attaches the WHOLE input, and
+            # no field-name match can locate a credential inside it (an escaped
+            # key such as ``"adoption_credenti\u0061l"`` defeats a literal
+            # scrub). Drop the raw input outright; the parser's position-only
+            # message keeps the invalid-JSON diagnosis truthful.
+            item["input"] = "<redacted>"
+            scrubbed.append(item)
+            continue
         if isinstance(input_value, str) and "adoption_credential" in input_value:
             return _malformed_event_error()
-        item = dict(err)
         item["input"] = _scrub_credential_input(input_value)
         scrubbed.append(item)
     try:

--- a/packages/aci-protocol/src/aci_protocol/events.py
+++ b/packages/aci-protocol/src/aci_protocol/events.py
@@ -13,12 +13,21 @@ describingly. Outbound events are a discriminated union on ``type``; every
 outbound event carries a ``version`` equal to PROTOCOL_VERSION.
 """
 
+import json
 from collections.abc import Mapping
 from enum import StrEnum
 from types import MappingProxyType
 from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationError,
+    ValidationInfo,
+    field_validator,
+    model_validator,
+)
 
 from .version import PROTOCOL_VERSION, SEMVER_PATTERN
 
@@ -87,12 +96,129 @@ class SessionStatus(StrEnum):
 # --- Inbound channel messages -------------------------------------------------
 
 
+# Opaque per-conversation runner credential. Character cap, not a product
+# secret format: long enough for a typical bearer, short enough to reject a
+# dump. Realizing servers must not echo this value in errors, traces, or prompts.
+ADOPTION_CREDENTIAL_MAX_CHARS = 4096
+
+
+def _malformed_adoption_credential() -> ValueError:
+    """Reject without attaching the presented material to the exception."""
+
+    return ValueError("malformed adoption credential")
+
+
+def parse_adoption_credential(value: Any) -> str | None:
+    """Admit an optional adoption credential, or raise without echoing it.
+
+    ``None`` is the legacy cold path (omit or JSON null). Any other well-formed
+    value is a non-empty string no longer than ``ADOPTION_CREDENTIAL_MAX_CHARS``
+    that is not whitespace-only. The presented material is never copied onto
+    the raised error; a realizing server that interpolates the exception into
+    an HTTP body therefore cannot leak it from this helper.
+    """
+
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise _malformed_adoption_credential()
+    if not value or value.strip() == "" or len(value) > ADOPTION_CREDENTIAL_MAX_CHARS:
+        raise _malformed_adoption_credential()
+    return value
+
+
+def _malformed_event_error() -> ValidationError:
+    """A credential-free ValidationError for a bad adoption_credential."""
+
+    return ValidationError.from_exception_data(
+        "Event",
+        [
+            {
+                "type": "value_error",
+                "loc": ("adoption_credential",),
+                "input": None,
+                "ctx": {"error": "malformed adoption credential"},
+            }
+        ],
+    )
+
+
+def _scrub_credential_input(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            key: None if key == "adoption_credential" else _scrub_credential_input(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_scrub_credential_input(item) for item in value]
+    if isinstance(value, (bytes, bytearray)):
+        try:
+            text = bytes(value).decode("utf-8")
+        except UnicodeDecodeError:
+            return "<redacted>"
+        return "<redacted>" if "adoption_credential" in text else value
+    if isinstance(value, str) and "adoption_credential" in value:
+        return "<redacted>"
+    return value
+
+
+def redact_adoption_credential_error(exc: ValidationError) -> ValidationError:
+    """Return a ValidationError whose inputs cannot contain credential material.
+
+    Errors whose loc is the credential field stay a closed malformed-credential
+    failure. Unrelated failures (a missing ``text``, for example) keep their
+    diagnosis; only the credential material is scrubbed from their inputs.
+    """
+
+    errors = exc.errors()
+    credential_failed = False
+    for err in errors:
+        loc = err.get("loc", ())
+        loc_text = ".".join(str(part) for part in loc) if isinstance(loc, tuple) else ""
+        msg = str(err.get("msg", ""))
+        if "adoption_credential" in loc_text or msg == "malformed adoption credential":
+            credential_failed = True
+            break
+    if credential_failed:
+        return _malformed_event_error()
+    scrubbed: list[Any] = []
+    for err in errors:
+        input_value = err.get("input")
+        if isinstance(input_value, str) and "adoption_credential" in input_value:
+            return _malformed_event_error()
+        item = dict(err)
+        item["input"] = _scrub_credential_input(input_value)
+        scrubbed.append(item)
+    try:
+        return ValidationError.from_exception_data(exc.title, scrubbed)
+    except (TypeError, ValueError):
+        return _malformed_event_error()
+
+
 class Event(_AciModel):
     """An inbound event delivered into a live session (initial or follow-up).
 
     ``session_id`` and ``history_ref`` carry conversation-scoped identity to a
     runner after its sandbox is bound. Both remain optional so older producers
     can omit them and tolerant consumers can adopt the additive wire shape.
+
+    ``adoption_credential`` is the optional per-conversation runner credential
+    ADR-0122 delivers on this same authenticated ``Event`` (never a new
+    lifecycle route, and never by overloading ``text`` / ``user`` / ``ts`` /
+    ``history_ref``). Omitted or JSON ``null`` is the legacy cold path: no
+    adoption is requested and a current credential must stay in force. A
+    malformed value is a hard decode error; the model is not constructed, so
+    there is no partial adoption at the wire layer. The field is secret
+    material: it is omitted from ``repr`` / ``str``, and decode errors must
+    not echo it.
+
+    This field does not retire a bootstrap token, persist a route, or enable a
+    warm pool. Those are realizing-runner/worker behaviors. Because inbound
+    ``Event`` carries no ``version`` and a tolerant consumer ignores unknown
+    keys, a successful turn is not proof of adoption. A consumer that applies
+    the credential MUST set ``adoption_applied=True`` on the outbound frames of
+    that turn; a producer that sent a credential MUST treat a missing or
+    non-true ack as "not adopted".
     """
 
     kind: Literal["event"] = "event"
@@ -102,6 +228,45 @@ class Event(_AciModel):
     ts: str
     session_id: str | None = None
     history_ref: str | None = None
+    adoption_credential: str | None = Field(
+        default=None,
+        repr=False,
+        min_length=1,
+        max_length=ADOPTION_CREDENTIAL_MAX_CHARS,
+        pattern=r".*\S.*",
+    )
+
+    @classmethod
+    def model_validate_json(
+        cls,
+        json_data: str | bytes | bytearray,
+        **kwargs: Any,
+    ) -> "Event":
+        try:
+            return super().model_validate_json(json_data, **kwargs)
+        except ValidationError as exc:
+            raise redact_adoption_credential_error(exc) from None
+        except json.JSONDecodeError:
+            raise _malformed_event_error() from None
+
+    @model_validator(mode="wrap")
+    @classmethod
+    def _admit_adoption_credential(cls, data: Any, handler: Any) -> Any:
+        # Validate and (on failure) drop the presented value before pydantic
+        # records ``input_value``. The wrap path is what keeps HTTP 400 bodies
+        # that interpolate ``ValidationError`` from echoing the credential.
+        if isinstance(data, Mapping) and "adoption_credential" in data:
+            incoming = dict(data)
+            raw = incoming.pop("adoption_credential")
+            try:
+                incoming["adoption_credential"] = parse_adoption_credential(raw)
+            except ValueError:
+                raise _malformed_event_error() from None
+            data = incoming
+        try:
+            return handler(data)
+        except ValidationError as exc:
+            raise redact_adoption_credential_error(exc) from None
 
 
 class Interrupt(_AciModel):
@@ -123,6 +288,25 @@ class _OutboundBase(_AciModel):
     # compatibility range. The NDJSON decoder enforces compatibility; the pattern
     # here rejects a structurally malformed value on construction.
     version: str = Field(default=PROTOCOL_VERSION, pattern=SEMVER_PATTERN)
+    # Ack that the consumer applied ``Event.adoption_credential`` for this turn.
+    # ``None`` (omitted or JSON null) is the pre-ack shape: either the consumer
+    # predates the field, or no adoption was requested. ``True`` means the
+    # credential was installed and the bootstrap must no longer be accepted
+    # against that pod. ``False`` means the consumer understood the field and
+    # did not apply it. A producer that sent a credential must require
+    # ``True``; a missing ack is not successful adoption.
+    adoption_applied: bool | None = None
+
+    @field_validator("adoption_applied", mode="before")
+    @classmethod
+    def _strict_adoption_applied(cls, value: Any) -> bool | None:
+        # JSON true/false only. Coercing "true"/1 to True would let a malformed
+        # ack look like successful adoption.
+        if value is None:
+            return None
+        if value is True or value is False:
+            return value
+        raise ValueError("adoption_applied must be a JSON boolean")
 
 
 class TextDelta(_OutboundBase):

--- a/packages/aci-protocol/src/aci_protocol/ndjson.py
+++ b/packages/aci-protocol/src/aci_protocol/ndjson.py
@@ -20,7 +20,7 @@ import json
 from collections.abc import Iterable, Iterator
 from typing import Any
 
-from pydantic import TypeAdapter
+from pydantic import TypeAdapter, ValidationError
 
 from .events import (
     READER_CONTEXT,
@@ -31,6 +31,7 @@ from .events import (
     SideEffectFlag,
     TextDelta,
     ToolNote,
+    redact_adoption_credential_error,
 )
 from .turn import QueuedTurn
 from .version import PROTOCOL_VERSION, is_compatible
@@ -96,8 +97,14 @@ def iter_ndjson(text: str) -> Iterator[OutboundEventModel]:
 def parse_inbound(raw: str | dict[str, Any]) -> Any:
     """Decode an inbound channel message (event or interrupt) from JSON."""
 
-    data = json.loads(raw) if isinstance(raw, str) else raw
-    return _INBOUND_ADAPTER.validate_python(data, context=READER_CONTEXT)
+    try:
+        data = json.loads(raw) if isinstance(raw, str) else raw
+    except json.JSONDecodeError as exc:
+        raise json.JSONDecodeError("malformed inbound JSON", "<redacted>", exc.pos) from None
+    try:
+        return _INBOUND_ADAPTER.validate_python(data, context=READER_CONTEXT)
+    except ValidationError as exc:
+        raise redact_adoption_credential_error(exc) from None
 
 
 def to_inbound_json(message: Any) -> str:

--- a/packages/aci-protocol/src/aci_protocol/rust_export.py
+++ b/packages/aci-protocol/src/aci_protocol/rust_export.py
@@ -180,6 +180,10 @@ def _struct_fields(model: type[BaseModel], skip: set[str], public: bool) -> list
             # not by type, so dropping the old Literal does not silently remove
             # the guard and let #[serde(default)] make version optional.
             out.append('    #[serde(deserialize_with = "require_compatible_protocol_version")]')
+        elif field_name == "adoption_credential":
+            out.append(
+                '    #[serde(default, deserialize_with = "deserialize_adoption_credential")]'
+            )
         elif field.is_required() and nullable:
             out.append('    #[serde(deserialize_with = "deserialize_required_nullable")]')
         elif not field.is_required():
@@ -225,8 +229,13 @@ def _env_keys_module() -> str:
 
 
 def _tagged_enum(name: str, tag: str, variants: tuple[type[BaseModel], ...]) -> str:
+    derives = (
+        "#[derive(Clone, PartialEq, Serialize, Deserialize)]"
+        if name == "InboundMessage"
+        else _ENUM_DERIVES
+    )
     lines = [
-        _ENUM_DERIVES,
+        derives,
         f'#[serde(tag = "{tag}")]',
         f"pub enum {name} {{",
     ]
@@ -238,6 +247,9 @@ def _tagged_enum(name: str, tag: str, variants: tuple[type[BaseModel], ...]) -> 
             lines.append(f"    {field_line}")
         lines.append("    },")
     lines.append("}")
+    if name == "InboundMessage":
+        lines.append("")
+        lines.append(_INBOUND_DEBUG_IMPL.rstrip("\n"))
     return "\n".join(lines)
 
 
@@ -296,6 +308,55 @@ where
 }"""
 
 
+_ADOPTION_CREDENTIAL_DESERIALIZER = """fn deserialize_adoption_credential<'de, D>(
+    deserializer: D,
+) -> Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<String>::deserialize(deserializer)?;
+    match &value {
+        None => Ok(None),
+        Some(s) if s.trim().is_empty() || s.chars().count() > 4096 => {
+            Err(serde::de::Error::custom("malformed adoption credential"))
+        }
+        Some(_) => Ok(value),
+    }
+}"""
+
+
+_INBOUND_DEBUG_IMPL = """impl std::fmt::Debug for InboundMessage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Event {
+                r#type,
+                text,
+                user,
+                ts,
+                session_id,
+                history_ref,
+                adoption_credential,
+            } => f
+                .debug_struct("Event")
+                .field("type", r#type)
+                .field("text", text)
+                .field("user", user)
+                .field("ts", ts)
+                .field("session_id", session_id)
+                .field("history_ref", history_ref)
+                .field(
+                    "adoption_credential",
+                    &adoption_credential.as_ref().map(|_| "<redacted>"),
+                )
+                .finish(),
+            Self::Interrupt { reason } => {
+                f.debug_struct("Interrupt").field("reason", reason).finish()
+            }
+        }
+    }
+}"""
+
+
 _TESTS = """#[cfg(test)]
 mod tests {
     use super::*;
@@ -312,6 +373,7 @@ mod tests {
             approval_granted_tool: None,
             input_tokens: None,
             output_tokens: None,
+            adoption_applied: None,
         };
         let encoded = serde_json::to_string(&event).unwrap();
         let decoded: OutboundEvent = serde_json::from_str(&encoded).unwrap();
@@ -330,6 +392,7 @@ mod tests {
             approval_granted_tool: None,
             input_tokens: None,
             output_tokens: None,
+            adoption_applied: None,
         };
         let encoded = serde_json::to_string(&event).unwrap();
         let decoded: OutboundEvent = serde_json::from_str(&encoded).unwrap();
@@ -345,10 +408,38 @@ mod tests {
             ts: "1.0".to_string(),
             session_id: None,
             history_ref: None,
+            adoption_credential: None,
         };
         let encoded = serde_json::to_string(&message).unwrap();
         let decoded: InboundMessage = serde_json::from_str(&encoded).unwrap();
         assert_eq!(message, decoded);
+    }
+
+    #[test]
+    fn inbound_event_debug_redacts_adoption_credential() {
+        let message = InboundMessage::Event {
+            r#type: EventType::Message,
+            text: "hello".to_string(),
+            user: "U1".to_string(),
+            ts: "1.0".to_string(),
+            session_id: None,
+            history_ref: None,
+            adoption_credential: Some("adoption-credential-fixture-PLACEHOLDER".to_string()),
+        };
+        let rendered = format!("{message:?}");
+        assert!(!rendered.contains("adoption-credential-fixture-PLACEHOLDER"));
+        assert!(rendered.contains("<redacted>"));
+    }
+
+    #[test]
+    fn inbound_event_rejects_empty_adoption_credential() {
+        let raw = concat!(
+            r#"{"kind":"event","type":"message","text":"hi","user":"U1","ts":"1.0","#,
+            r#""adoption_credential":""}"#
+        );
+        let error = serde_json::from_str::<InboundMessage>(raw).unwrap_err();
+        assert!(error.to_string().contains("malformed adoption credential"));
+        assert!(!error.to_string().contains("adoption-credential-fixture-PLACEHOLDER"));
     }
 
     #[test]
@@ -445,6 +536,7 @@ def render_rust() -> str:
         f'pub const STREAM_PAYLOAD_FIELD: &str = "{STREAM_PAYLOAD_FIELD}";',
         _VERSION_GUARD,
         _REQUIRED_NULLABLE_DESERIALIZER,
+        _ADOPTION_CREDENTIAL_DESERIALIZER,
         _string_enum(
             "SessionStatus",
             tuple(m.value for m in SessionStatus),

--- a/packages/aci-protocol/src/aci_protocol/version.py
+++ b/packages/aci-protocol/src/aci_protocol/version.py
@@ -20,7 +20,7 @@ the guard.
 import re
 from typing import Final
 
-PROTOCOL_VERSION: Final = "0.4.4"
+PROTOCOL_VERSION: Final = "0.4.5"
 
 # The wire field carrying the protocol version on every outbound event. Both
 # exporters special-case this field by name; do not rename without updating them.

--- a/packages/aci-protocol/tests/test_adoption_credential.py
+++ b/packages/aci-protocol/tests/test_adoption_credential.py
@@ -245,6 +245,55 @@ def test_malformed_json_errors_do_not_echo_secret_material() -> None:
     assert _CREDENTIAL not in f"invalid event frame: {json_exc.value}"
 
 
+_ESCAPED_KEY = "adoption_credenti\\u0061l"  # JSON-escaped spelling of the field name
+
+
+def _malformed_json_specimens() -> list[tuple[str, str | bytes | bytearray]]:
+    # Raw JSON that never parses, so pydantic reports ``json_invalid`` and would
+    # otherwise attach the WHOLE raw input. The escaped key defeats a literal
+    # field-name scrub; the keyless specimen has no field name to match at all.
+    escaped = (
+        '{"kind":"event","type":"message","text":"hi","user":"U0EXAMPLE1",'
+        f'"ts":"1.0","{_ESCAPED_KEY}":"{_CREDENTIAL}", bad}}'
+    )
+    keyless = f'{{"text":"{_CREDENTIAL}", bad}}'
+    return [
+        ("escaped-str", escaped),
+        ("escaped-bytes", escaped.encode()),
+        ("escaped-bytearray", bytearray(escaped.encode())),
+        ("keyless-str", keyless),
+        ("keyless-bytes", keyless.encode()),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("label", "raw"),
+    _malformed_json_specimens(),
+    ids=[label for label, _ in _malformed_json_specimens()],
+)
+def test_invalid_json_errors_redact_the_whole_raw_input(
+    label: str, raw: str | bytes | bytearray
+) -> None:
+    with pytest.raises(ValidationError) as exc:
+        Event.model_validate_json(raw)
+    error = exc.value
+    # ``str(exc)`` truncating a long input is not a protection; ``errors()`` is
+    # what a structured 400 body or a log formatter serializes.
+    surfaces = {
+        "str": str(error),
+        "repr": repr(error),
+        "errors": json.dumps(error.errors(), default=str),
+        "interpolated": f"invalid event frame: {error}",
+    }
+    leaked = [name for name, text in surfaces.items() if _CREDENTIAL in text]
+    assert not leaked, f"{label}: credential material in {leaked}"
+    # The diagnosis stays truthful: malformed JSON is reported as invalid JSON,
+    # not misdiagnosed as a malformed credential, and no raw input survives.
+    types = {err["type"] for err in error.errors()}
+    assert types == {"json_invalid"}, types
+    assert all(err["input"] == "<redacted>" for err in error.errors())
+
+
 def test_mapping_inputs_cannot_bypass_malformed_admission() -> None:
     from collections import UserDict
 

--- a/packages/aci-protocol/tests/test_adoption_credential.py
+++ b/packages/aci-protocol/tests/test_adoption_credential.py
@@ -1,0 +1,280 @@
+"""Adoption-credential wire contract (#2385, ADR-0116, ADR-0122).
+
+This package defines delivery and admission semantics. It does not implement
+runner token swap, bootstrap retirement, route recovery, or warm-pool replicas.
+A schema field is not those behaviors.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from aci_protocol import (
+    PROTOCOL_VERSION,
+    ErrorEvent,
+    Event,
+    Final,
+    Interrupt,
+    TextDelta,
+    parse_inbound,
+    parse_ndjson_line,
+    to_inbound_json,
+    to_ndjson_line,
+)
+from pydantic import ValidationError
+
+# Distinctive fixture material, not a live credential. Tests assert this exact
+# string never appears in repr or validation errors.
+_CREDENTIAL = "adoption-credential-fixture-PLACEHOLDER"
+_BASE = {
+    "kind": "event",
+    "type": "message",
+    "text": "hi",
+    "user": "U0EXAMPLE1",
+    "ts": "1.0",
+}
+
+
+def _payload(**fields: object) -> dict[str, object]:
+    body: dict[str, object] = dict(_BASE)
+    body.update(fields)
+    return body
+
+
+def test_legacy_omission_is_compatible() -> None:
+    event = parse_inbound(_payload())
+    assert isinstance(event, Event)
+    assert event.adoption_credential is None
+    assert event.session_id is None
+    assert event.history_ref is None
+
+
+def test_explicit_null_is_compatible() -> None:
+    event = parse_inbound(_payload(adoption_credential=None))
+    assert isinstance(event, Event)
+    assert event.adoption_credential is None
+
+
+def test_well_formed_credential_roundtrips_on_the_wire() -> None:
+    event = Event(
+        type="message",
+        text="hi",
+        user="U0EXAMPLE1",
+        ts="1.0",
+        adoption_credential=_CREDENTIAL,
+    )
+    encoded = to_inbound_json(event)
+    wire = json.loads(encoded)
+    decoded = parse_inbound(encoded)
+
+    assert wire["adoption_credential"] == _CREDENTIAL
+    assert isinstance(decoded, Event)
+    assert decoded.adoption_credential == _CREDENTIAL
+
+
+@pytest.mark.parametrize(
+    "value",
+    (
+        1,
+        False,
+        ["not-a-string"],
+        {"not": "a string"},
+        "",
+        "   ",
+        "\n",
+        "\t",
+        "x" * 4097,
+    ),
+)
+def test_malformed_credential_is_rejected(value: object) -> None:
+    with pytest.raises(ValidationError):
+        Event.model_validate(_payload(adoption_credential=value))
+    with pytest.raises(ValidationError):
+        parse_inbound(_payload(adoption_credential=value))
+
+
+def test_malformed_rejection_is_atomic_and_does_not_construct_a_partial_event() -> None:
+    with pytest.raises(ValidationError):
+        Event.model_validate(_payload(text="turn-text", adoption_credential=""))
+    # A sibling Event without the field still constructs; the failed validate
+    # must not have been a half-applied mutation of a shared model.
+    ok = Event.model_validate(_payload(text="turn-text"))
+    assert ok.text == "turn-text"
+    assert ok.adoption_credential is None
+
+
+def test_interrupt_rejects_adoption_credential() -> None:
+    with pytest.raises(ValidationError):
+        Interrupt.model_validate({"reason": "stop", "adoption_credential": _CREDENTIAL})
+
+
+def test_credential_is_absent_from_repr_and_str() -> None:
+    event = Event(
+        type="message",
+        text="hi",
+        user="U0EXAMPLE1",
+        ts="1.0",
+        adoption_credential=_CREDENTIAL,
+    )
+    assert _CREDENTIAL not in repr(event)
+    assert _CREDENTIAL not in str(event)
+
+
+def test_malformed_credential_errors_do_not_echo_secret_material() -> None:
+    secret = _CREDENTIAL + ("x" * 4097)
+    with pytest.raises(ValidationError) as direct:
+        Event.model_validate(_payload(adoption_credential=secret))
+    with pytest.raises(ValidationError) as inbound:
+        parse_inbound(_payload(adoption_credential=secret))
+
+    for exc in (direct.value, inbound.value):
+        rendered = f"invalid event frame: {exc}"
+        assert secret not in str(exc)
+        assert secret not in repr(exc)
+        assert secret not in rendered
+        assert secret not in json.dumps(exc.errors(), default=str)
+
+
+def test_error_event_message_is_not_a_credential_channel() -> None:
+    error = ErrorEvent(message="malformed adoption credential")
+    assert _CREDENTIAL not in error.message
+    assert "adoption_credential" not in error.model_dump(mode="json")
+
+
+def test_adoption_applied_omission_and_null_are_compatible() -> None:
+    omitted = parse_ndjson_line(
+        json.dumps({"type": "final", "version": PROTOCOL_VERSION, "text": "ok", "status": "done"})
+    )
+    assert isinstance(omitted, Final)
+    assert omitted.adoption_applied is None
+
+    explicit_null = parse_ndjson_line(
+        json.dumps(
+            {
+                "type": "final",
+                "version": PROTOCOL_VERSION,
+                "text": "ok",
+                "status": "done",
+                "adoption_applied": None,
+            }
+        )
+    )
+    assert isinstance(explicit_null, Final)
+    assert explicit_null.adoption_applied is None
+
+
+@pytest.mark.parametrize("applied", (True, False))
+def test_adoption_applied_roundtrips(applied: bool) -> None:
+    final = Final(text="ok", adoption_applied=applied)
+    wire = json.loads(to_ndjson_line(final))
+    decoded = parse_ndjson_line(json.dumps(wire))
+    assert wire["adoption_applied"] is applied
+    assert isinstance(decoded, Final)
+    assert decoded.adoption_applied is applied
+
+
+def test_missing_adoption_applied_is_not_successful_adoption() -> None:
+    """An old tolerant consumer ignores adoption_credential and emits no ack.
+
+    A successful final without adoption_applied is the pre-0.4.5 shape. The
+    producer must treat that as "not adopted", not as bootstrap retirement.
+    """
+
+    legacy = TextDelta(text="working")
+    assert legacy.adoption_applied is None
+    final = Final(text="done")
+    assert final.adoption_applied is None
+
+
+def test_container_and_bytes_errors_do_not_echo_secret_material() -> None:
+    raw = json.dumps([_payload(adoption_credential=_CREDENTIAL)])
+    with pytest.raises(ValidationError) as list_exc:
+        parse_inbound(raw)
+    assert _CREDENTIAL not in str(list_exc.value)
+    assert _CREDENTIAL not in f"invalid event frame: {list_exc.value}"
+
+    json_raw = (
+        b'{"type":"message","text":"hi","user":"U0EXAMPLE1","ts":"1.0",'
+        + f'"adoption_credential":"{_CREDENTIAL}", bad}}'.encode()
+    )
+    with pytest.raises(ValidationError) as bytes_exc:
+        Event.model_validate_json(json_raw)
+    assert _CREDENTIAL not in str(bytes_exc.value)
+    assert _CREDENTIAL not in f"invalid event frame: {bytes_exc.value}"
+
+
+def test_unrelated_missing_field_is_not_reported_as_malformed_credential() -> None:
+    with pytest.raises(ValidationError) as exc:
+        Event.model_validate(
+            {
+                "kind": "event",
+                "type": "message",
+                "user": "U0EXAMPLE1",
+                "ts": "1.0",
+                "adoption_credential": _CREDENTIAL,
+            }
+        )
+    rendered = str(exc.value)
+    assert "malformed adoption credential" not in rendered
+    assert _CREDENTIAL not in rendered
+
+
+def test_protocol_version_is_the_compatible_patch() -> None:
+    assert PROTOCOL_VERSION == "0.4.5"
+
+
+def test_malformed_json_errors_do_not_echo_secret_material() -> None:
+    raw = (
+        '{"kind":"event","type":"message","text":"hi","user":"U0EXAMPLE1",'
+        f'"ts":"1.0","adoption_credential":"{_CREDENTIAL}", bad}}'
+    )
+    with pytest.raises(Exception) as exc:
+        parse_inbound(raw)
+    rendered = f"invalid event frame: {exc.value}"
+    assert _CREDENTIAL not in str(exc.value)
+    assert _CREDENTIAL not in rendered
+
+    json_raw = (
+        '{"type":"message","text":"hi","user":"U0EXAMPLE1","ts":"1.0",'
+        f'"adoption_credential":"{_CREDENTIAL}", bad}}'
+    )
+    with pytest.raises(ValidationError) as json_exc:
+        Event.model_validate_json(json_raw)
+    assert _CREDENTIAL not in str(json_exc.value)
+    assert _CREDENTIAL not in f"invalid event frame: {json_exc.value}"
+
+
+def test_mapping_inputs_cannot_bypass_malformed_admission() -> None:
+    from collections import UserDict
+
+    payload = UserDict(_payload(adoption_credential=""))
+    with pytest.raises(ValidationError):
+        Event.model_validate(payload)
+
+
+def test_string_true_is_not_an_adoption_ack() -> None:
+    with pytest.raises(ValidationError):
+        parse_ndjson_line(
+            json.dumps(
+                {
+                    "type": "final",
+                    "version": PROTOCOL_VERSION,
+                    "text": "ok",
+                    "status": "done",
+                    "adoption_applied": "true",
+                }
+            )
+        )
+    with pytest.raises(ValidationError):
+        parse_ndjson_line(
+            json.dumps(
+                {
+                    "type": "final",
+                    "version": PROTOCOL_VERSION,
+                    "text": "ok",
+                    "status": "done",
+                    "adoption_applied": 1,
+                }
+            )
+        )

--- a/packages/aci-protocol/tests/test_events.py
+++ b/packages/aci-protocol/tests/test_events.py
@@ -87,7 +87,7 @@ def test_event_rejects_unknown_fields_on_direct_construction() -> None:
         )
 
 
-@pytest.mark.parametrize("field", ("session_id", "history_ref"))
+@pytest.mark.parametrize("field", ("session_id", "history_ref", "adoption_credential"))
 def test_interrupt_rejects_event_session_context_fields(field: str) -> None:
     with pytest.raises(ValidationError):
         Interrupt.model_validate({"reason": "stop", field: "context-example"})

--- a/packages/aci-protocol/tests/test_exporters.py
+++ b/packages/aci-protocol/tests/test_exporters.py
@@ -10,7 +10,7 @@ the private helpers, because the rendered artifact is the real contract.
 
 import re
 
-from aci_protocol import BootEnv
+from aci_protocol import ADOPTION_CREDENTIAL_MAX_CHARS, BootEnv
 from aci_protocol.rust_export import render_rust
 from aci_protocol.schema_export import build_schema
 
@@ -30,6 +30,26 @@ def test_event_session_context_fields_are_optional_nullable_strings() -> None:
         prop = event["properties"][field]
         assert "anyOf" in prop
         assert {variant["type"] for variant in prop["anyOf"]} == {"string", "null"}
+
+
+def test_event_adoption_credential_is_optional_nullable_string() -> None:
+    event = build_schema()["$defs"]["Event"]
+    assert "adoption_credential" not in event["required"]
+    prop = event["properties"]["adoption_credential"]
+    assert "anyOf" in prop
+    assert {variant["type"] for variant in prop["anyOf"]} == {"string", "null"}
+    string_variant = next(variant for variant in prop["anyOf"] if variant["type"] == "string")
+    assert string_variant["minLength"] == 1
+    assert string_variant["maxLength"] == ADOPTION_CREDENTIAL_MAX_CHARS
+    assert string_variant["pattern"] == r".*\S.*"
+
+
+def test_outbound_adoption_applied_is_optional_nullable_bool() -> None:
+    final = build_schema()["$defs"]["Final"]
+    assert "adoption_applied" not in final["required"]
+    prop = final["properties"]["adoption_applied"]
+    assert "anyOf" in prop
+    assert {variant["type"] for variant in prop["anyOf"]} == {"boolean", "null"}
 
 
 def test_generated_rust_guards_the_version() -> None:

--- a/packages/aci-protocol/tests/test_ndjson.py
+++ b/packages/aci-protocol/tests/test_ndjson.py
@@ -124,6 +124,44 @@ def test_inbound_event_session_context_survives_json_roundtrip() -> None:
     assert isinstance(decoded, Event)
     assert decoded.session_id == "session-example"
     assert decoded.history_ref == "history-example"
+    assert decoded.adoption_credential is None
+
+
+def test_legacy_inbound_event_without_adoption_credential_defaults_to_none() -> None:
+    raw = json.dumps(
+        {
+            "kind": "event",
+            "type": "message",
+            "text": "hi",
+            "user": "U0EXAMPLE1",
+            "ts": "1.0",
+            "session_id": "session-example",
+            "history_ref": "history-example",
+        }
+    )
+
+    message = parse_inbound(raw)
+
+    assert isinstance(message, Event)
+    assert message.adoption_credential is None
+
+
+def test_inbound_event_accepts_explicit_null_adoption_credential() -> None:
+    raw = json.dumps(
+        {
+            "kind": "event",
+            "type": "message",
+            "text": "hi",
+            "user": "U0EXAMPLE1",
+            "ts": "1.0",
+            "adoption_credential": None,
+        }
+    )
+
+    message = parse_inbound(raw)
+
+    assert isinstance(message, Event)
+    assert message.adoption_credential is None
 
 
 # --- Reader policy: tolerant consumers, strict producers ----------------------

--- a/packages/aci-protocol/tests/test_wire_lock.py
+++ b/packages/aci-protocol/tests/test_wire_lock.py
@@ -175,9 +175,11 @@ def test_committed_lock_matches_the_current_wire() -> None:
     assert lock["wire_sha256"] == wire_fingerprint()
 
 
-def test_event_session_context_contract_uses_patch_version_0_4_4() -> None:
+def test_adoption_credential_contract_uses_patch_version_0_4_5() -> None:
+    # Session identity landed as 0.4.4 (optional session_id/history_ref). This
+    # patch adds optional adoption_credential plus the adoption_applied ack.
     lock_path = schema_export.schema_path().parent / "wire.lock"
     lock = json.loads(lock_path.read_text(encoding="utf-8"))
 
-    assert PROTOCOL_VERSION == "0.4.4"
-    assert lock["protocol_version"] == "0.4.4"
+    assert PROTOCOL_VERSION == "0.4.5"
+    assert lock["protocol_version"] == "0.4.5"


### PR DESCRIPTION
## Summary

Standalone compatible ACI prerequisite for per-conversation warm-pool adoption (#2385). Optional `adoption_credential` on the existing authenticated `Event` delivers a runner credential. Optional `adoption_applied` on outbound frames is the ack so a tolerant 0.4.4 consumer ignoring the inbound field cannot be mistaken for successful adoption.

Omitted or JSON null remains the legacy cold path. A malformed credential is a hard decode error and does not construct an Event. The value is omitted from Python `repr`/`str` and scrubbed from validation errors. Generated Rust Debug redacts it. JSON Schema and the Rust decoder enforce the same non-empty, non-whitespace, 4096-character bound.

This does not retire bootstrap tokens, recover routes, enable warm replicas, add `POST /v1/adopt`, or overload `text` / `user` / `ts` / `history_ref`. Realizing runner/worker work stays on #1492.

`PROTOCOL_VERSION` is `0.4.5` (0.x patch for new optional fields). Schema, TypeScript, Rust, and `wire.lock` are regenerated from the Pydantic source.

## Rollout

1. Land this contract.
2. Ship a consumer that validates, applies only a well-formed value, fails malformed frames atomically, redacts the secret, and emits `adoption_applied: true` when it applied.
3. Only then may a producer send `adoption_credential`, and only on authenticated `POST /v1/event`. A steer that carries a credential must be rejected rather than swapping mid-turn.

A successful `final` without `adoption_applied: true` is not adoption.

## Evidence

Protocol tests: `uv run pytest packages/aci-protocol/tests -q` (232 passed on the candidate, including five new specimens that were red before the follow-up commit). Generated Rust `cargo test`. CLI `cargo check --tests --all-targets`. `uv run ruff check packages/aci-protocol` and `uv run mypy` on the package source.

Follow-up commit: a pydantic `json_invalid` error attaches the whole unparsed input, so malformed raw JSON with a JSON-escaped field name leaked credential material through `ValidationError.errors()` for str, bytes and bytearray. Every `json_invalid` error now carries `<redacted>` as its input while keeping the parser's position-only diagnosis. One visible diagnosis change: malformed JSON whose text contains the literal field name is now reported as invalid JSON with a redacted input instead of as a malformed credential. Schema, `wire.lock`, generated Rust and TypeScript are unchanged by that commit.

## Tiers

| Tier | Status |
| --- | --- |
| skill | Required: ACI event contract. Protocol positive/negative tests pass. Runner turn-loop e2e remains pending. |
| local | Not applicable: no compose service or CLI verb output change. Mechanical CLI initializers only. |
| local-release | Not applicable: no published binary or image identity change. |
| cluster | Not applicable: no chart or sandbox change. |
| live provider | Not applicable: no model credential path. |
| external integration | Not applicable: no Slack/git/OAuth path. |

Draft only. Do not merge as a v0.9 release. Does not close #2385 or #1492.

Ref #2385.

