### PR TITLE
Draft: Reserve review revisions against verified PR lineage

### DIFF
--- a/apps/api/alembic/versions/0042_review_lineage_authority.py
+++ b/apps/api/alembic/versions/0042_review_lineage_authority.py
@@ -1,0 +1,142 @@
+"""Add verified publication identity and review revision reservations.
+
+Revision ID: 0042
+Revises: 0041
+Create Date: 2026-09-05
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0042"
+down_revision: str | None = "0041"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+SCHEMA = "curie"
+LINEAGES = "thread_publication_lineages"
+RESERVATIONS = "publication_review_reservations"
+
+
+def upgrade() -> None:
+    # NULL preserves uncertainty: a current name/number cannot authenticate the
+    # original repository after deletion/recreation or an App reinstall.
+    for name, kind in (
+        ("binding_id", postgresql.UUID(as_uuid=True)),
+        ("binding_generation", sa.Integer()),
+        ("reply_conversation_id", sa.String()),
+        ("github_repository_id", sa.BigInteger()),
+        ("github_installation_id", sa.BigInteger()),
+        ("github_pr_node_id", sa.String()),
+        ("base_ref", sa.String()),
+    ):
+        op.add_column(LINEAGES, sa.Column(name, kind, nullable=True), schema=SCHEMA)
+    op.create_foreign_key(
+        "fk_publication_lineage_binding",
+        LINEAGES,
+        "agent_channels",
+        ["binding_id"],
+        ["id"],
+        source_schema=SCHEMA,
+        referent_schema=SCHEMA,
+        ondelete="SET NULL",
+    )
+    op.create_check_constraint(
+        "thread_publication_lineages_github_identity_ck",
+        LINEAGES,
+        "(github_repository_id IS NULL AND github_installation_id IS NULL "
+        "AND github_pr_node_id IS NULL AND base_ref IS NULL) "
+        "OR (github_repository_id IS NOT NULL AND github_repository_id > 0 "
+        "AND github_installation_id IS NOT NULL AND github_installation_id > 0 "
+        "AND github_pr_node_id IS NOT NULL AND length(github_pr_node_id) > 0 "
+        "AND pr_number IS NOT NULL AND base_ref IS NOT NULL AND length(base_ref) > 0)",
+        schema=SCHEMA,
+    )
+    op.create_index(
+        "uq_publication_github_pr_owner",
+        LINEAGES,
+        ["github_repository_id", "pr_number"],
+        unique=True,
+        schema=SCHEMA,
+    )
+    op.create_index(
+        "uq_active_publication_github_conversation",
+        LINEAGES,
+        ["agent_id", "conversation_id", "github_repository_id"],
+        unique=True,
+        schema=SCHEMA,
+        postgresql_where=sa.text("status = 'open'"),
+    )
+    op.create_table(
+        RESERVATIONS,
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("origin_key", sa.String(), nullable=False, unique=True),
+        sa.Column(
+            "lineage_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(f"{SCHEMA}.{LINEAGES}.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("lineage_version", sa.Integer(), nullable=False),
+        sa.Column("expected_head_sha", sa.String(), nullable=False),
+        sa.Column("revision_number", sa.Integer(), nullable=False),
+        sa.Column("binding_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("binding_generation", sa.Integer(), nullable=False),
+        sa.Column("status", sa.String(), nullable=False, server_default="reserved"),
+        sa.Column("version", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.CheckConstraint(
+            "status IN ('reserved', 'consumed', 'cancelled')",
+            name="publication_review_reservations_status_ck",
+        ),
+        sa.CheckConstraint(
+            "version >= 1 AND revision_number >= 1 AND lineage_version >= 1",
+            name="publication_review_reservations_versions_ck",
+        ),
+        schema=SCHEMA,
+    )
+    op.create_index(
+        "ix_publication_review_reservations_lineage_id", RESERVATIONS, ["lineage_id"], schema=SCHEMA
+    )
+    op.create_index(
+        "uq_reserved_review_per_lineage",
+        RESERVATIONS,
+        ["lineage_id"],
+        unique=True,
+        schema=SCHEMA,
+        postgresql_where=sa.text("status = 'reserved'"),
+    )
+
+
+def downgrade() -> None:
+    active = (
+        op.get_bind()
+        .execute(
+            sa.text(
+                "SELECT EXISTS (SELECT 1 FROM curie.publication_review_reservations "
+                "WHERE status='reserved') OR EXISTS (SELECT 1 FROM curie.publications "
+                "WHERE status IN ('pending','approved','launching','running'))"
+            )
+        )
+        .scalar_one()
+    )
+    if active:
+        raise RuntimeError("cannot remove review authority while revisions are active")
+    op.drop_table(RESERVATIONS, schema=SCHEMA)
+    op.drop_index("uq_active_publication_github_conversation", table_name=LINEAGES, schema=SCHEMA)
+    op.drop_index("uq_publication_github_pr_owner", table_name=LINEAGES, schema=SCHEMA)
+    op.drop_constraint("thread_publication_lineages_github_identity_ck", LINEAGES, schema=SCHEMA)
+    op.drop_constraint("fk_publication_lineage_binding", LINEAGES, schema=SCHEMA)
+    for name in (
+        "base_ref",
+        "github_pr_node_id",
+        "github_installation_id",
+        "github_repository_id",
+        "reply_conversation_id",
+        "binding_generation",
+        "binding_id",
+    ):
+        op.drop_column(LINEAGES, name, schema=SCHEMA)

--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -3483,6 +3483,19 @@
             "title": "Repo Full Name",
             "type": "string"
           },
+          "review_origin_key": {
+            "anyOf": [
+              {
+                "maxLength": 180,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Review Origin Key"
+          },
           "summary": {
             "minLength": 1,
             "title": "Summary",
@@ -4046,6 +4059,177 @@
           }
         },
         "title": "ResolvedTarget",
+        "type": "object"
+      },
+      "ReviewRevisionCancel": {
+        "properties": {
+          "expected_version": {
+            "minimum": 1.0,
+            "title": "Expected Version",
+            "type": "integer"
+          },
+          "origin_key": {
+            "maxLength": 180,
+            "minLength": 1,
+            "title": "Origin Key",
+            "type": "string"
+          }
+        },
+        "required": [
+          "origin_key",
+          "expected_version"
+        ],
+        "title": "ReviewRevisionCancel",
+        "type": "object"
+      },
+      "ReviewRevisionOut": {
+        "properties": {
+          "agent_id": {
+            "format": "uuid",
+            "title": "Agent Id",
+            "type": "string"
+          },
+          "base_ref": {
+            "title": "Base Ref",
+            "type": "string"
+          },
+          "base_sha": {
+            "title": "Base Sha",
+            "type": "string"
+          },
+          "binding_generation": {
+            "title": "Binding Generation",
+            "type": "integer"
+          },
+          "binding_id": {
+            "format": "uuid",
+            "title": "Binding Id",
+            "type": "string"
+          },
+          "branch": {
+            "title": "Branch",
+            "type": "string"
+          },
+          "conversation_id": {
+            "title": "Conversation Id",
+            "type": "string"
+          },
+          "expected_head_sha": {
+            "title": "Expected Head Sha",
+            "type": "string"
+          },
+          "installation_id": {
+            "title": "Installation Id",
+            "type": "integer"
+          },
+          "lineage_id": {
+            "format": "uuid",
+            "title": "Lineage Id",
+            "type": "string"
+          },
+          "lineage_version": {
+            "title": "Lineage Version",
+            "type": "integer"
+          },
+          "pr_node_id": {
+            "title": "Pr Node Id",
+            "type": "string"
+          },
+          "pr_number": {
+            "title": "Pr Number",
+            "type": "integer"
+          },
+          "reply_conversation_id": {
+            "title": "Reply Conversation Id",
+            "type": "string"
+          },
+          "repo_full_name": {
+            "title": "Repo Full Name",
+            "type": "string"
+          },
+          "repository_id": {
+            "title": "Repository Id",
+            "type": "integer"
+          },
+          "revision_id": {
+            "format": "uuid",
+            "title": "Revision Id",
+            "type": "string"
+          },
+          "revision_number": {
+            "title": "Revision Number",
+            "type": "integer"
+          },
+          "status": {
+            "enum": [
+              "reserved",
+              "consumed",
+              "cancelled"
+            ],
+            "title": "Status",
+            "type": "string"
+          },
+          "version": {
+            "title": "Version",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "revision_id",
+          "lineage_id",
+          "agent_id",
+          "conversation_id",
+          "reply_conversation_id",
+          "binding_id",
+          "binding_generation",
+          "repository_id",
+          "installation_id",
+          "pr_node_id",
+          "base_ref",
+          "repo_full_name",
+          "pr_number",
+          "branch",
+          "base_sha",
+          "expected_head_sha",
+          "lineage_version",
+          "revision_number",
+          "version",
+          "status"
+        ],
+        "title": "ReviewRevisionOut",
+        "type": "object"
+      },
+      "ReviewRevisionReserve": {
+        "properties": {
+          "expected_lineage_version": {
+            "minimum": 1.0,
+            "title": "Expected Lineage Version",
+            "type": "integer"
+          },
+          "origin_key": {
+            "maxLength": 180,
+            "minLength": 1,
+            "title": "Origin Key",
+            "type": "string"
+          },
+          "pr_number": {
+            "exclusiveMinimum": 0.0,
+            "title": "Pr Number",
+            "type": "integer"
+          },
+          "repository_id": {
+            "exclusiveMinimum": 0.0,
+            "title": "Repository Id",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "repository_id",
+          "pr_number",
+          "expected_lineage_version",
+          "origin_key"
+        ],
+        "title": "ReviewRevisionReserve",
         "type": "object"
       },
       "RoutingCheck": {
@@ -10711,6 +10895,134 @@
           }
         },
         "summary": "Get Publication Lineage",
+        "tags": [
+          "internal-publications"
+        ]
+      }
+    },
+    "/v1/internal/publications/review-reservations": {
+      "post": {
+        "operationId": "reserve_review_revision_v1_internal_publications_review_reservations_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "X-Curie-Worker-Token",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Curie-Worker-Token"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReviewRevisionReserve"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReviewRevisionOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Reserve Review Revision",
+        "tags": [
+          "internal-publications"
+        ]
+      }
+    },
+    "/v1/internal/publications/review-reservations/{reservation_id}/cancel": {
+      "post": {
+        "operationId": "cancel_review_revision_v1_internal_publications_review_reservations__reservation_id__cancel_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "reservation_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Reservation Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Curie-Worker-Token",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Curie-Worker-Token"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReviewRevisionCancel"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReviewRevisionOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Cancel Review Revision",
         "tags": [
           "internal-publications"
         ]

--- a/apps/api/src/curie_api/crud.py
+++ b/apps/api/src/curie_api/crud.py
@@ -2203,7 +2203,9 @@ async def _require_review_binding(
     workspace = await get_thread_workspace(
         session, agent_id=lineage.agent_id, conversation_id=lineage.conversation_id
     )
-    deployment = await get_deployment(session, lineage.deployment_id)
+    deployment = await session.get(
+        Deployment, lineage.deployment_id, with_for_update=True, populate_existing=True
+    )
     if (
         binding is None
         or binding.agent_id != lineage.agent_id

--- a/apps/api/src/curie_api/crud.py
+++ b/apps/api/src/curie_api/crud.py
@@ -29,9 +29,11 @@ from .models import (
     Deployment,
     Environment,
     Publication,
+    PublicationReviewReservation,
     ThreadPublicationLineage,
     ThreadWorkspace,
 )
+from .publication_authority import VerifiedPublicationIdentity
 from .schemas import (
     ActionComplete,
     ActionRecord,
@@ -43,6 +45,7 @@ from .schemas import (
     HookPartitionConfig,
     PublicationCreate,
     PublicationLineageAdvance,
+    ReviewRevisionReserve,
     VersionCreate,
 )
 from .workspace_policy import repository_is_allowed
@@ -81,6 +84,13 @@ async def _adopt_publication_replay(
     deployment = await get_deployment(session, data.deployment_id)
     if deployment is None:
         raise LookupError("deployment not found")
+    review_origin = await session.scalar(
+        select(PublicationReviewReservation.origin_key).where(
+            PublicationReviewReservation.id == publication.id
+        )
+    )
+    if review_origin != data.review_origin_key:
+        raise PublicationReplayConflict("publication replay has a different review origin")
     reply_conversation_id = data.reply_conversation_id or data.conversation_id
     workspace_conversation_id = (
         data.conversation_id
@@ -114,8 +124,7 @@ async def _adopt_publication_replay(
         or publication.lineage is None
         or publication.lineage.agent_id != deployment.agent_id
         or publication.lineage.conversation_id != workspace_conversation_id
-        or publication.lineage.repo_full_name.casefold()
-        != publication.repo_full_name.casefold()
+        or publication.lineage.repo_full_name.casefold() != publication.repo_full_name.casefold()
     ):
         raise PublicationReplayConflict(
             "publication dedupe key was replayed with different snapshot facts"
@@ -124,9 +133,7 @@ async def _adopt_publication_replay(
         # 0041 canonicalizes every genuinely legacy row. A NULL observed after
         # that migration is corruption or an artificial downgrade lane, never
         # authority to fall back to an adapter-native reply id.
-        raise PublicationReplayConflict(
-            "publication replay has no canonical workspace identity"
-        )
+        raise PublicationReplayConflict("publication replay has no canonical workspace identity")
     authorized_conversation_id = publication.workspace_conversation_id
     await _require_current_publication_workspace(
         session,
@@ -783,7 +790,25 @@ async def create_publication(
         repo_full_name=thread_workspace.repo_full_name,
         for_update=True,
     )
+    reservation: PublicationReviewReservation | None = None
     if lineage is None:
+        if data.review_origin_key is not None:
+            raise PublicationLineageConflict(
+                "publication.review_ineligible", "review origin has no existing lineage"
+            )
+        binding = await session.scalar(
+            select(AgentChannel)
+            .where(
+                AgentChannel.agent_id == deployment.agent_id,
+                AgentChannel.kind == data.reply_kind,
+                AgentChannel.address == data.reply_channel,
+            )
+            .with_for_update()
+        )
+        if binding is not None and (
+            binding.endpoint != data.reply_endpoint or binding.adapter != data.reply_adapter
+        ):
+            binding = None
         lineage_id = uuid.uuid4()
         lineage = ThreadPublicationLineage(
             id=lineage_id,
@@ -796,6 +821,9 @@ async def create_publication(
             status="open",
             version=1,
             latest_revision=1,
+            binding_id=binding.id if binding is not None else None,
+            binding_generation=binding.generation if binding is not None else None,
+            reply_conversation_id=data.reply_conversation_id or data.conversation_id,
         )
         session.add(lineage)
         try:
@@ -849,7 +877,46 @@ async def create_publication(
                 "publication.revision_conflict",
                 "another publication revision is still in progress for this thread",
             )
-        revision_number = lineage.latest_revision + 1
+        reservation = await session.scalar(
+            select(PublicationReviewReservation)
+            .where(
+                PublicationReviewReservation.lineage_id == lineage.id,
+                PublicationReviewReservation.status == "reserved",
+            )
+            .with_for_update()
+        )
+        if reservation is not None:
+            if (
+                data.review_origin_key != reservation.origin_key
+                or reservation.lineage_version != lineage.version
+                or reservation.expected_head_sha != expected_prior_head
+            ):
+                raise PublicationLineageConflict(
+                    "publication.revision_conflict",
+                    "a different review origin or stale head owns this revision",
+                )
+            review_binding = await _require_review_binding(session, lineage)
+            if (
+                data.reply_kind != review_binding.kind
+                or data.reply_channel != review_binding.address
+                or data.reply_endpoint != review_binding.endpoint
+                or data.reply_adapter != review_binding.adapter
+                or (data.reply_conversation_id or data.conversation_id)
+                != lineage.reply_conversation_id
+            ):
+                raise PublicationLineageConflict(
+                    "publication.review_ineligible",
+                    "review publication reply differs from its reserved original binding",
+                )
+            revision_number = reservation.revision_number
+            reservation.status = "consumed"
+            reservation.version += 1
+        elif data.review_origin_key is not None:
+            raise PublicationLineageConflict(
+                "publication.review_ineligible", "review origin has no active reservation"
+            )
+        else:
+            revision_number = lineage.latest_revision + 1
         lineage.latest_revision = revision_number
         lineage.updated_at = func.now()
 
@@ -880,6 +947,7 @@ async def create_publication(
     )
     session.add(approval)
     publication = Publication(
+        id=reservation.id if reservation is not None else uuid.uuid4(),
         approval=approval,
         deployment_id=deployment.id,
         workspace_conversation_id=workspace_conversation_id,
@@ -1021,7 +1089,19 @@ async def publication_lineage_has_pending_revision(
         )
         .limit(1)
     )
-    return pending_id is not None
+    if pending_id is not None:
+        return True
+    return (
+        await session.scalar(
+            select(PublicationReviewReservation.id)
+            .where(
+                PublicationReviewReservation.lineage_id == lineage.id,
+                PublicationReviewReservation.status == "reserved",
+            )
+            .limit(1)
+        )
+        is not None
+    )
 
 
 async def publication_lineage_has_pending_outcome(
@@ -1180,6 +1260,8 @@ async def advance_publication_lineage(
     session: AsyncSession,
     publication_id: uuid.UUID,
     data: PublicationLineageAdvance,
+    *,
+    identity: VerifiedPublicationIdentity | None = None,
 ) -> ThreadPublicationLineage:
     """Atomically advance one approved revision and its exact lineage head."""
 
@@ -1236,6 +1318,52 @@ async def advance_publication_lineage(
             "publication revision must be approved before advancing its lineage",
         )
 
+    identity_values: dict[str, Any] = {}
+    if identity is not None:
+        if lineage.github_repository_id is None:
+            if lineage.pr_number is not None or lineage.binding_id is None:
+                raise PublicationLineageConflict(
+                    "publication.review_ineligible",
+                    "historical lineage identity cannot be reconstructed",
+                )
+        elif (
+            lineage.github_repository_id,
+            lineage.github_installation_id,
+            lineage.github_pr_node_id,
+            lineage.base_ref,
+        ) != (
+            identity.repository_id,
+            identity.installation_id,
+            identity.pr_node_id,
+            identity.base_ref,
+        ):
+            raise PublicationLineageConflict(
+                "publication.lineage_stale", "immutable GitHub lineage identity changed"
+            )
+        binding = (
+            await session.get(AgentChannel, lineage.binding_id, with_for_update=True)
+            if lineage.binding_id is not None
+            else None
+        )
+        if (
+            binding is None
+            or binding.agent_id != lineage.agent_id
+            or binding.generation != lineage.binding_generation
+        ):
+            raise PublicationLineageConflict(
+                "publication.lineage_stale", "original publication binding changed"
+            )
+        identity_values = {
+            "github_repository_id": identity.repository_id,
+            "github_installation_id": identity.installation_id,
+            "github_pr_node_id": identity.pr_node_id,
+            "base_ref": identity.base_ref,
+        }
+    elif lineage.github_repository_id is not None:
+        raise PublicationLineageConflict(
+            "publication.lineage_stale", "verified lineage advance requires current GitHub identity"
+        )
+
     head_predicate = (
         ThreadPublicationLineage.head_sha.is_(None)
         if data.expected_head_sha is None
@@ -1250,6 +1378,7 @@ async def advance_publication_lineage(
             head_predicate,
         )
         .values(
+            **identity_values,
             pr_number=data.pr_number,
             pr_url=data.pr_url,
             head_sha=data.head_sha,
@@ -2057,4 +2186,142 @@ async def revoke_console_session(
     row.revoked_at = now or datetime.now(UTC).replace(tzinfo=None)
     await session.commit()
     await session.refresh(row)
+    return row
+
+
+async def _require_review_binding(
+    session: AsyncSession, lineage: ThreadPublicationLineage
+) -> AgentChannel:
+    """Recheck original authority under the same transaction as reservation use."""
+    binding = (
+        await session.get(AgentChannel, lineage.binding_id, with_for_update=True)
+        if lineage.binding_id
+        else None
+    )
+    workspace = await get_thread_workspace(
+        session, agent_id=lineage.agent_id, conversation_id=lineage.conversation_id
+    )
+    deployment = await get_deployment(session, lineage.deployment_id)
+    if (
+        binding is None
+        or binding.agent_id != lineage.agent_id
+        or binding.generation != lineage.binding_generation
+        or not lineage.reply_conversation_id
+        or scoped_conversation_id(binding.kind, binding.address, lineage.reply_conversation_id)
+        != lineage.conversation_id
+        or workspace is None
+        or workspace.repo_full_name.casefold() != lineage.repo_full_name.casefold()
+        or not repository_is_allowed(lineage.repo_full_name, get_settings().github_repo_allowlist)
+        or deployment is None
+        or deployment.agent_id != lineage.agent_id
+        or deployment.status != "active"
+    ):
+        raise PublicationLineageConflict(
+            "publication.review_ineligible",
+            "original review binding or workspace is no longer authorized",
+        )
+    return binding
+
+
+async def reserve_review_revision(
+    session: AsyncSession,
+    data: ReviewRevisionReserve,
+) -> tuple[PublicationReviewReservation, ThreadPublicationLineage, bool]:
+    """Reserve in the caller's transaction, so feedback insertion can be atomic.
+
+    No commit, approval, queue entry, or GitHub write occurs here. A reservation
+    is consumed only by PublicationCreate naming its exact accepted origin.
+    """
+    lineage = await session.scalar(
+        select(ThreadPublicationLineage)
+        .where(
+            ThreadPublicationLineage.github_repository_id == data.repository_id,
+            ThreadPublicationLineage.pr_number == data.pr_number,
+        )
+        .with_for_update()
+    )
+    if (
+        lineage is None
+        or lineage.status != "open"
+        or lineage.head_sha is None
+        or lineage.github_installation_id is None
+        or lineage.github_pr_node_id is None
+    ):
+        raise PublicationLineageConflict(
+            "publication.review_ineligible",
+            "no verified open lineage owns this GitHub pull request",
+        )
+    binding = await _require_review_binding(session, lineage)
+    existing = await session.scalar(
+        select(PublicationReviewReservation)
+        .where(PublicationReviewReservation.origin_key == data.origin_key)
+        .with_for_update()
+    )
+    if existing is not None:
+        if (
+            existing.lineage_id != lineage.id
+            or existing.lineage_version != data.expected_lineage_version
+        ):
+            raise PublicationLineageConflict(
+                "publication.revision_conflict",
+                "review origin was replayed with different lineage facts",
+            )
+        return existing, lineage, False
+    if lineage.version != data.expected_lineage_version:
+        raise PublicationLineageConflict(
+            "publication.lineage_stale", "review expected a stale lineage version"
+        )
+    if await publication_lineage_has_pending_revision(
+        session, lineage
+    ) or await publication_lineage_has_pending_outcome(session, lineage):
+        raise PublicationLineageConflict(
+            "publication.revision_conflict",
+            "a revision or its durable outcome already owns this lineage",
+        )
+    row = PublicationReviewReservation(
+        id=uuid.uuid4(),
+        origin_key=data.origin_key,
+        lineage_id=lineage.id,
+        lineage_version=lineage.version,
+        expected_head_sha=lineage.head_sha,
+        revision_number=lineage.latest_revision + 1,
+        binding_id=binding.id,
+        binding_generation=binding.generation,
+        status="reserved",
+        version=1,
+    )
+    session.add(row)
+    try:
+        await session.flush()
+    except IntegrityError:
+        # Caller owns rollback, including its feedback insertion. A reused origin
+        # on a different PR cannot be adopted by this transaction.
+        raise PublicationLineageConflict(
+            "publication.revision_conflict", "review origin is already reserved"
+        ) from None
+    return row, lineage, True
+
+
+async def cancel_review_revision(
+    session: AsyncSession,
+    reservation_id: uuid.UUID,
+    *,
+    origin_key: str,
+    expected_version: int,
+) -> PublicationReviewReservation:
+    row = await session.scalar(
+        select(PublicationReviewReservation)
+        .where(PublicationReviewReservation.id == reservation_id)
+        .with_for_update()
+    )
+    if row is None:
+        raise LookupError("review reservation not found")
+    if row.origin_key != origin_key or row.version != expected_version or row.status != "reserved":
+        raise PublicationLineageConflict(
+            "publication.revision_conflict", "review reservation changed before cancellation"
+        )
+    row.status = "cancelled"
+    row.version += 1
+    row.updated_at = func.now()
+    await session.flush()
     return row

--- a/apps/api/src/curie_api/crud.py
+++ b/apps/api/src/curie_api/crud.py
@@ -2194,7 +2194,9 @@ async def _require_review_binding(
 ) -> AgentChannel:
     """Recheck original authority under the same transaction as reservation use."""
     binding = (
-        await session.get(AgentChannel, lineage.binding_id, with_for_update=True)
+        await session.get(
+            AgentChannel, lineage.binding_id, with_for_update=True, populate_existing=True
+        )
         if lineage.binding_id
         else None
     )
@@ -2239,6 +2241,7 @@ async def reserve_review_revision(
             ThreadPublicationLineage.pr_number == data.pr_number,
         )
         .with_for_update()
+        .execution_options(populate_existing=True)
     )
     if (
         lineage is None

--- a/apps/api/src/curie_api/github_app.py
+++ b/apps/api/src/curie_api/github_app.py
@@ -102,6 +102,10 @@ class GitHubAppError(RuntimeError):
     """The App is configured but could not produce a token."""
 
 
+class GitHubInstallationRefused(GitHubAppError):
+    """Fresh App installation identity was deterministically refused."""
+
+
 class _GitHubNotFound(GitHubAppError):
     """GitHub answered 404.
 
@@ -234,6 +238,75 @@ class GitHubCredentials:
             while len(self._tokens) > _REPOSITORY_CACHE_LIMIT:
                 self._tokens.popitem(last=False)
             return token
+
+    def fresh_installation_token(
+        self, repo_full_name: str, expected_installation_id: int | None = None
+    ) -> tuple[int, str]:
+        """Revalidate a review sender's installation with this platform's App.
+
+        A cached token or a user PAT proves neither which App sent an event nor
+        whether its claimed installation still owns this repository. Discovery
+        uses our App JWT on a repository-derived endpoint on every check; the
+        caller must also read the current repository/PR with the returned token.
+        """
+        repo_full_name = normalize_repo_full_name(repo_full_name)
+        if not self.app_configured:
+            raise GitHubInstallationRefused("review feedback requires a configured GitHub App")
+        url = (
+            f"{self.settings.github_api_url.rstrip('/')}"
+            f"/repos/{repo_url_path(repo_full_name)}/installation"
+        )
+        with self._mint_lock_for(repo_full_name):
+            try:
+                with httpx.Client(timeout=self.settings.github_app_timeout_seconds) as client:
+                    response = client.get(url, headers=self._headers(), follow_redirects=False)
+                if response.status_code != 200:
+                    if response.status_code < 500 and response.status_code not in {
+                        401,
+                        403,
+                        404,
+                        429,
+                    }:
+                        raise GitHubInstallationRefused("current review installation was refused")
+                    raise GitHubAppError("current review installation could not be verified")
+                payload = response.json()
+            except (httpx.HTTPError, ValueError):
+                raise GitHubAppError("current review installation could not be verified") from None
+            actual = payload.get("id") if isinstance(payload, dict) else None
+            if (
+                not isinstance(actual, int)
+                or isinstance(actual, bool)
+                or actual <= 0
+                or (expected_installation_id is not None and actual != expected_installation_id)
+            ):
+                raise GitHubInstallationRefused(
+                    "review installation differs from the current App installation"
+                )
+            if self._installations.get(repo_full_name) != actual:
+                # A token is scoped to an installation, not just a repository.
+                # Reinstallation invalidates even an otherwise unexpired cache.
+                self._tokens.pop(repo_full_name, None)
+            self._installations[repo_full_name] = actual
+            self._installations.move_to_end(repo_full_name)
+            while len(self._installations) > _REPOSITORY_CACHE_LIMIT:
+                self._installations.popitem(last=False)
+            cached = self._tokens.get(repo_full_name)
+            if cached is not None and cached.usable(time.time()):
+                self._tokens.move_to_end(repo_full_name)
+                return actual, cached.token
+            token, expires_at = self._mint_for_installation(repo_full_name, actual)
+            self._tokens[repo_full_name] = _CachedToken(token=token, expires_at=expires_at)
+            self._tokens.move_to_end(repo_full_name)
+            while len(self._tokens) > _REPOSITORY_CACHE_LIMIT:
+                self._tokens.popitem(last=False)
+            return actual, token
+
+    def token_for_verified_installation(
+        self, repo_full_name: str, expected_installation_id: int
+    ) -> str:
+        """Return a token only for an independently rediscovered exact installation."""
+        _, token = self.fresh_installation_token(repo_full_name, expected_installation_id)
+        return token
 
     def _mint_lock_for(self, repo_full_name: str) -> threading.Lock:
         with self._mint_locks_guard:

--- a/apps/api/src/curie_api/models.py
+++ b/apps/api/src/curie_api/models.py
@@ -13,6 +13,7 @@ from datetime import datetime
 from typing import Any
 
 from sqlalchemy import (
+    BigInteger,
     CheckConstraint,
     Enum,
     ForeignKey,
@@ -460,6 +461,26 @@ class ThreadPublicationLineage(Base):
             unique=True,
             postgresql_where=text("status = 'open'"),
         ),
+        CheckConstraint(
+            "(github_repository_id IS NULL AND github_installation_id IS NULL "
+            "AND github_pr_node_id IS NULL AND base_ref IS NULL) "
+            "OR (github_repository_id IS NOT NULL "
+            "AND github_repository_id > 0 "
+            "AND github_installation_id IS NOT NULL AND github_installation_id > 0 "
+            "AND github_pr_node_id IS NOT NULL "
+            "AND length(github_pr_node_id) > 0 AND pr_number IS NOT NULL "
+            "AND base_ref IS NOT NULL AND length(base_ref) > 0)",
+            name="thread_publication_lineages_github_identity_ck",
+        ),
+        Index("uq_publication_github_pr_owner", "github_repository_id", "pr_number", unique=True),
+        Index(
+            "uq_active_publication_github_conversation",
+            "agent_id",
+            "conversation_id",
+            "github_repository_id",
+            unique=True,
+            postgresql_where=text("status = 'open'"),
+        ),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
@@ -479,10 +500,59 @@ class ThreadPublicationLineage(Base):
     status: Mapped[str] = mapped_column(server_default="open", default="open")
     version: Mapped[int] = mapped_column(server_default="1", default=1)
     latest_revision: Mapped[int] = mapped_column(server_default="1", default=1)
+    # Only new trusted publication creation captures routing authority. Historical
+    # NULL rows are deliberately never backfilled from a currently reused name.
+    binding_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey(f"{SCHEMA}.agent_channels.id", ondelete="SET NULL"),
+        default=None,
+    )
+    binding_generation: Mapped[int | None] = mapped_column(default=None)
+    reply_conversation_id: Mapped[str | None] = mapped_column(default=None)
+    github_repository_id: Mapped[int | None] = mapped_column(BigInteger, default=None)
+    github_installation_id: Mapped[int | None] = mapped_column(BigInteger, default=None)
+    github_pr_node_id: Mapped[str | None] = mapped_column(default=None)
+    base_ref: Mapped[str | None] = mapped_column(default=None)
     created_at: Mapped[datetime] = mapped_column(server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(server_default=func.now(), onupdate=func.now())
 
     publications: Mapped[list[Publication]] = relationship(back_populates="lineage")
+
+
+class PublicationReviewReservation(Base):
+    """One review origin's claim on the existing publication revision writer."""
+
+    __tablename__ = "publication_review_reservations"
+    __table_args__ = (
+        CheckConstraint(
+            "status IN ('reserved', 'consumed', 'cancelled')",
+            name="publication_review_reservations_status_ck",
+        ),
+        CheckConstraint(
+            "version >= 1 AND revision_number >= 1 AND lineage_version >= 1",
+            name="publication_review_reservations_versions_ck",
+        ),
+        Index(
+            "uq_reserved_review_per_lineage",
+            "lineage_id",
+            unique=True,
+            postgresql_where=text("status = 'reserved'"),
+        ),
+    )
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    origin_key: Mapped[str] = mapped_column(unique=True)
+    lineage_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey(f"{SCHEMA}.thread_publication_lineages.id", ondelete="CASCADE"),
+        index=True,
+    )
+    lineage_version: Mapped[int]
+    expected_head_sha: Mapped[str]
+    revision_number: Mapped[int]
+    binding_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True))
+    binding_generation: Mapped[int]
+    status: Mapped[str] = mapped_column(default="reserved", server_default="reserved")
+    version: Mapped[int] = mapped_column(default=1, server_default="1")
+    created_at: Mapped[datetime] = mapped_column(server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(server_default=func.now(), onupdate=func.now())
 
 
 class Publication(Base):

--- a/apps/api/src/curie_api/publication_authority.py
+++ b/apps/api/src/curie_api/publication_authority.py
@@ -1,0 +1,157 @@
+"""Read immutable GitHub identities during the existing publication advance.
+
+No GitHub writes occur here. Historical NULL lineages cannot acquire authority
+from a repository name that may have been deleted and recreated meanwhile.
+"""
+
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+from starlette.concurrency import run_in_threadpool
+
+from .config import Settings
+from .github_app import GitHubAppError, GitHubInstallationRefused, credentials_for
+from .models import ThreadPublicationLineage
+from .repo_full_name import repo_url_path
+from .schemas import PublicationLineageAdvance
+
+
+class AuthorityRefused(RuntimeError):
+    """Fresh provider identity disagrees with the exact publication outcome."""
+
+
+class AuthorityUnavailable(RuntimeError):
+    """The configured product App could not establish current provider truth."""
+
+
+@dataclass(frozen=True)
+class VerifiedPublicationIdentity:
+    repository_id: int
+    installation_id: int
+    pr_node_id: str
+    base_ref: str
+
+
+def _positive_id(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and 0 < value < 2**63
+
+
+def validated_identity(
+    repository: Any,
+    pull_request: Any,
+    *,
+    installation_id: int,
+    repo_full_name: str,
+    pr_number: int,
+    branch: str,
+    head_sha: str,
+    state: str,
+) -> VerifiedPublicationIdentity:
+    """Validate provider-owned fields, never a webhook's purported authority."""
+    if not isinstance(repository, dict) or not isinstance(pull_request, dict):
+        raise AuthorityRefused("publication GitHub identity was refused")
+    repository_id = repository.get("id")
+    node_id = pull_request.get("node_id")
+    head = pull_request.get("head")
+    base = pull_request.get("base")
+    if (
+        not _positive_id(repository_id)
+        or not _positive_id(installation_id)
+        or str(repository.get("full_name", "")).casefold() != repo_full_name.casefold()
+        or not _positive_id(pull_request.get("number"))
+        or pull_request.get("number") != pr_number
+        or not isinstance(node_id, str)
+        or not node_id
+        or len(node_id) > 256
+        or str(pull_request.get("html_url", "")).casefold()
+        != f"https://github.com/{repo_full_name}/pull/{pr_number}".casefold()
+        or not isinstance(head, dict)
+        or not isinstance(base, dict)
+        or head.get("ref") != branch
+        or not isinstance(head.get("sha"), str)
+        or head["sha"].lower() != head_sha.lower()
+    ):
+        raise AuthorityRefused("publication GitHub identity was refused")
+    for side in (head, base):
+        remote_repo = side.get("repo")
+        if (
+            not isinstance(remote_repo, dict)
+            or not _positive_id(remote_repo.get("id"))
+            or remote_repo.get("id") != repository_id
+            or str(remote_repo.get("full_name", "")).casefold() != repo_full_name.casefold()
+        ):
+            raise AuthorityRefused("publication GitHub repository identity was refused")
+    merged = pull_request.get("merged")
+    remote_state = pull_request.get("state")
+    if not isinstance(merged, bool) or remote_state not in {"open", "closed"}:
+        raise AuthorityRefused("publication GitHub state was refused")
+    actual_state = "merged" if merged else remote_state
+    if actual_state != state or (merged and remote_state != "closed"):
+        raise AuthorityRefused("publication GitHub state was refused")
+    base_ref = base.get("ref")
+    if not isinstance(base_ref, str) or not base_ref or len(base_ref) > 1024:
+        raise AuthorityRefused("publication GitHub base reference was refused")
+    assert isinstance(repository_id, int)
+    return VerifiedPublicationIdentity(repository_id, installation_id, node_id, base_ref)
+
+
+async def verify_publication_identity(
+    lineage: ThreadPublicationLineage,
+    data: PublicationLineageAdvance,
+    settings: Settings,
+    client: httpx.AsyncClient,
+) -> VerifiedPublicationIdentity | None:
+    # A newly captured binding proves this producer created the lineage. Existing
+    # PRs without immutable IDs remain ineligible even if an App is added later.
+    if lineage.binding_id is None or (
+        lineage.pr_number is not None and lineage.github_repository_id is None
+    ):
+        return None
+    resolver = credentials_for(settings)
+    if not resolver.app_configured:
+        if lineage.github_repository_id is not None:
+            raise AuthorityUnavailable("publication App identity is not configured")
+        return None
+    try:
+        installation_id, token = await run_in_threadpool(
+            resolver.fresh_installation_token,
+            lineage.repo_full_name,
+            lineage.github_installation_id,
+        )
+    except GitHubInstallationRefused:
+        raise AuthorityRefused("publication App installation identity was refused") from None
+    except (GitHubAppError, ValueError):
+        raise AuthorityUnavailable("publication App identity could not be verified") from None
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    root = settings.github_api_url.rstrip("/")
+    path = f"/repos/{repo_url_path(lineage.repo_full_name)}"
+    payloads = []
+    try:
+        for suffix in (path, f"{path}/pulls/{data.pr_number}"):
+            response = await client.get(
+                root + suffix,
+                headers=headers,
+                timeout=settings.github_app_timeout_seconds,
+                follow_redirects=False,
+            )
+            if response.status_code in {401, 403, 404, 429} or response.status_code >= 500:
+                raise AuthorityUnavailable("publication GitHub identity could not be verified")
+            if response.status_code != 200:
+                raise AuthorityRefused("publication GitHub identity was refused")
+            payloads.append(response.json())
+    except (httpx.HTTPError, ValueError):
+        raise AuthorityUnavailable("publication GitHub identity could not be verified") from None
+    return validated_identity(
+        *payloads,
+        installation_id=installation_id,
+        repo_full_name=lineage.repo_full_name,
+        pr_number=data.pr_number,
+        branch=lineage.branch,
+        head_sha=data.head_sha,
+        state=data.state,
+    )

--- a/apps/api/src/curie_api/revision_kinds.json
+++ b/apps/api/src/curie_api/revision_kinds.json
@@ -39,5 +39,6 @@
   "0038": "expand",
   "0039": "expand",
   "0040": "expand",
-  "0041": "contract"
+  "0041": "contract",
+  "0042": "expand"
 }

--- a/apps/api/src/curie_api/routers/publications.py
+++ b/apps/api/src/curie_api/routers/publications.py
@@ -6,11 +6,12 @@ GitHub side effects belong to the trusted worker publication reconciler.
 
 import re
 import uuid
-from typing import Any
+from typing import Any, Literal, cast
 
 import httpx
 from curie_telemetry import TRACEPARENT_STREAM_FIELD, canonicalize_traceparent
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from sqlalchemy.exc import IntegrityError
 from starlette.concurrency import run_in_threadpool
 
 from .. import crud
@@ -20,7 +21,12 @@ from ..auth import (
 )
 from ..config import get_settings
 from ..deps import SessionDep
-from ..models import ThreadPublicationLineage
+from ..models import PublicationReviewReservation, ThreadPublicationLineage
+from ..publication_authority import (
+    AuthorityRefused,
+    AuthorityUnavailable,
+    verify_publication_identity,
+)
 from ..repo_full_name import repo_url_path
 from ..repository_auth import resolve_repository_credential
 from ..schemas import (
@@ -29,6 +35,9 @@ from ..schemas import (
     PublicationLineageOut,
     PublicationOut,
     RepositoryCredentialOut,
+    ReviewRevisionCancel,
+    ReviewRevisionOut,
+    ReviewRevisionReserve,
 )
 from ..workspace_policy import credential_mode, repository_is_allowed
 
@@ -37,9 +46,7 @@ router = APIRouter(
     tags=["publications"],
     dependencies=[Depends(require_api_key)],
 )
-internal_router = APIRouter(
-    prefix="/v1/internal/publications", tags=["internal-publications"]
-)
+internal_router = APIRouter(prefix="/v1/internal/publications", tags=["internal-publications"])
 
 _GITHUB_API_VERSION = "2022-11-28"
 _FULL_COMMIT_SHA = re.compile(r"[0-9a-fA-F]{40}")
@@ -336,9 +343,39 @@ async def advance_publication_lineage(
     publication_id: uuid.UUID,
     data: PublicationLineageAdvance,
     session: SessionDep,
+    request: Request,
 ) -> PublicationLineageOut:
     try:
-        lineage = await crud.advance_publication_lineage(session, publication_id, data)
+        publication = await crud.get_publication(session, publication_id)
+        if publication is None or publication.lineage is None:
+            raise LookupError("publication lineage not found")
+        identity = await verify_publication_identity(
+            publication.lineage, data, get_settings(), request.app.state.http_client
+        )
+        lineage = await crud.advance_publication_lineage(
+            session, publication_id, data, identity=identity
+        )
+    except AuthorityUnavailable:
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE, _GITHUB_UNAVAILABLE_DETAIL
+        ) from None
+    except AuthorityRefused:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            {
+                "code": "publication.lineage_stale",
+                "message": "current GitHub publication identity was refused",
+            },
+        ) from None
+    except IntegrityError:
+        await session.rollback()
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            {
+                "code": "publication.revision_conflict",
+                "message": "another lineage already owns this immutable GitHub identity",
+            },
+        ) from None
     except LookupError as exc:
         raise HTTPException(status.HTTP_404_NOT_FOUND, str(exc)) from exc
     except crud.PublicationLineageConflict as exc:
@@ -484,3 +521,86 @@ async def redeem_publication_credential(
         clone_url=clone_url,
         authorization_header=authorization_header,
     )
+
+
+def _review_revision_out(
+    row: PublicationReviewReservation, lineage: ThreadPublicationLineage
+) -> ReviewRevisionOut:
+    assert lineage.reply_conversation_id is not None
+    assert lineage.github_repository_id is not None
+    assert lineage.github_installation_id is not None
+    assert lineage.github_pr_node_id is not None
+    assert lineage.pr_number is not None
+    assert lineage.base_ref is not None
+    return ReviewRevisionOut(
+        revision_id=row.id,
+        lineage_id=lineage.id,
+        agent_id=lineage.agent_id,
+        conversation_id=lineage.conversation_id,
+        reply_conversation_id=lineage.reply_conversation_id,
+        binding_id=row.binding_id,
+        binding_generation=row.binding_generation,
+        repository_id=lineage.github_repository_id,
+        installation_id=lineage.github_installation_id,
+        pr_node_id=lineage.github_pr_node_id,
+        base_ref=lineage.base_ref,
+        repo_full_name=lineage.repo_full_name,
+        pr_number=lineage.pr_number,
+        branch=lineage.branch,
+        base_sha=lineage.base_sha,
+        expected_head_sha=row.expected_head_sha,
+        lineage_version=row.lineage_version,
+        revision_number=row.revision_number,
+        version=row.version,
+        status=cast(Literal["reserved", "consumed", "cancelled"], row.status),
+    )
+
+
+@internal_router.post(
+    "/review-reservations",
+    response_model=ReviewRevisionOut,
+    dependencies=[Depends(require_internal_worker_token)],
+)
+async def reserve_review_revision(
+    data: ReviewRevisionReserve, session: SessionDep, response: Response
+) -> ReviewRevisionOut:
+    response.headers["Cache-Control"] = "no-store"
+    try:
+        row, lineage, created = await crud.reserve_review_revision(session, data)
+        await session.commit()
+    except crud.PublicationLineageConflict as exc:
+        await session.rollback()
+        raise HTTPException(
+            status.HTTP_409_CONFLICT, {"code": exc.code, "message": exc.message}
+        ) from None
+    response.status_code = 201 if created else 200
+    return _review_revision_out(row, lineage)
+
+
+@internal_router.post(
+    "/review-reservations/{reservation_id}/cancel",
+    response_model=ReviewRevisionOut,
+    dependencies=[Depends(require_internal_worker_token)],
+)
+async def cancel_review_revision(
+    reservation_id: uuid.UUID, data: ReviewRevisionCancel, session: SessionDep, response: Response
+) -> ReviewRevisionOut:
+    response.headers["Cache-Control"] = "no-store"
+    try:
+        row = await crud.cancel_review_revision(
+            session,
+            reservation_id,
+            origin_key=data.origin_key,
+            expected_version=data.expected_version,
+        )
+        lineage = await session.get(ThreadPublicationLineage, row.lineage_id)
+        assert lineage is not None
+        await session.commit()
+    except LookupError:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "review reservation not found") from None
+    except crud.PublicationLineageConflict as exc:
+        await session.rollback()
+        raise HTTPException(
+            status.HTTP_409_CONFLICT, {"code": exc.code, "message": exc.message}
+        ) from None
+    return _review_revision_out(row, lineage)

--- a/apps/api/src/curie_api/schemas.py
+++ b/apps/api/src/curie_api/schemas.py
@@ -1405,6 +1405,7 @@ class PublicationCreate(BaseModel):
     reply_endpoint: str | None = None
     reply_adapter: str | None = None
     dedupe_key: str = Field(min_length=1)
+    review_origin_key: str | None = Field(default=None, min_length=1, max_length=180)
     base_sha: str
     patch_b64: str = Field(min_length=1)
     changed_paths: list[str] = Field(min_length=1, max_length=4096)
@@ -1466,6 +1467,41 @@ class PublicationCreate(BaseModel):
             return base64.b64decode(self.patch_b64, validate=True)
         except (binascii.Error, ValueError) as exc:
             raise ValueError("patch_b64 must be canonical base64") from exc
+
+
+class ReviewRevisionReserve(BaseModel):
+    repository_id: int = Field(gt=0, strict=True)
+    pr_number: int = Field(gt=0, strict=True)
+    expected_lineage_version: int = Field(ge=1, strict=True)
+    origin_key: str = Field(min_length=1, max_length=180)
+
+
+class ReviewRevisionOut(BaseModel):
+    revision_id: uuid.UUID
+    lineage_id: uuid.UUID
+    agent_id: uuid.UUID
+    conversation_id: str
+    reply_conversation_id: str
+    binding_id: uuid.UUID
+    binding_generation: int
+    repository_id: int
+    installation_id: int
+    pr_node_id: str
+    base_ref: str
+    repo_full_name: str
+    pr_number: int
+    branch: str
+    base_sha: str
+    expected_head_sha: str
+    lineage_version: int
+    revision_number: int
+    version: int
+    status: Literal["reserved", "consumed", "cancelled"]
+
+
+class ReviewRevisionCancel(BaseModel):
+    origin_key: str = Field(min_length=1, max_length=180)
+    expected_version: int = Field(ge=1, strict=True)
 
 
 class PublicationLineageAdvance(BaseModel):

--- a/apps/api/tests/test_github_app.py
+++ b/apps/api/tests/test_github_app.py
@@ -747,3 +747,28 @@ def test_an_explicit_offset_expiry_is_still_honoured() -> None:
     # The UTC default must apply only when the value carries no zone at all.
     offset = GitHubCredentials._expiry_seconds("2026-01-01T00:00:00+02:00")
     assert offset == GitHubCredentials._expiry_seconds("2025-12-31T22:00:00Z")
+
+
+def test_fresh_installation_cannot_change_during_token_mint(
+    private_key: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A repository installation can disappear between discovery and mint. The
+    # exact-identity review/publication path must not inherit the clone helper's
+    # rediscovery fallback (REST installation/token endpoints documented above).
+    calls: list[str] = []
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        calls.append(request.url.path)
+        if request.url.path.endswith("/installation"):
+            return httpx.Response(200, json={"id": 4242 if len(calls) == 1 else 4343})
+        if request.url.path == "/app/installations/4242/access_tokens":
+            return httpx.Response(404, json={"message": "Not Found"})
+        return httpx.Response(
+            201, json={"token": "fixture-other-installation", "expires_at": "2999-01-01T00:00:00Z"}
+        )
+
+    monkeypatch.setattr("curie_api.github_app.httpx.Client", serve(handle))
+    credentials = GitHubCredentials(settings=app_settings(private_key))
+    with pytest.raises(GitHubAppError):
+        credentials.token_for_verified_installation(REPO, 4242)
+    assert calls == [f"/repos/{REPO}/installation", "/app/installations/4242/access_tokens"]

--- a/apps/api/tests/test_migration_0041_publication_lineages.py
+++ b/apps/api/tests/test_migration_0041_publication_lineages.py
@@ -700,7 +700,8 @@ def test_0041_backfills_active_and_succeeded_pr_publications_and_round_trips(
         result_url="https://github.com/acme-corp/acme-bot/issues/123",
     )
 
-    command.upgrade(config, "head")
+    # This round trip owns 0041; later revisions have independent downgrade guards.
+    command.upgrade(config, "0041")
 
     active = _sql(
         "SELECT p.lineage_id::text, p.revision_number, p.expected_prior_head, "
@@ -798,7 +799,7 @@ def test_0041_backfills_active_and_succeeded_pr_publications_and_round_trips(
         "column_name IN ('lineage_id', 'revision_number', 'expected_prior_head')"
     ) == []
 
-    command.upgrade(config, "head")
+    command.upgrade(config, "0041")
     assert _sql(
         "SELECT l.branch, p.revision_number FROM curie.publications p JOIN "
         "curie.thread_publication_lineages l ON l.id = p.lineage_id "

--- a/apps/api/tests/test_publication_authority.py
+++ b/apps/api/tests/test_publication_authority.py
@@ -1,0 +1,89 @@
+"""GitHub identity response guards; real publication persistence is tested separately.
+
+REST shapes: https://docs.github.com/en/rest/pulls/pulls#get-a-pull-request
+and https://docs.github.com/en/rest/repos/repos#get-a-repository.
+"""
+
+import copy
+
+import pytest
+from curie_api.publication_authority import AuthorityRefused, validated_identity
+
+
+def identity_payloads() -> tuple[dict, dict]:
+    repo = {"id": 9001, "full_name": "acme-corp/acme-bot"}
+    pr = {
+        "number": 123,
+        "node_id": "PR_example_123",
+        "html_url": "https://github.com/acme-corp/acme-bot/pull/123",
+        "state": "open",
+        "merged": False,
+        "head": {"sha": "a" * 40, "ref": "curie/publication-example", "repo": copy.deepcopy(repo)},
+        "base": {"repo": copy.deepcopy(repo), "ref": "main"},
+    }
+    return repo, pr
+
+
+def validate(repo: dict, pr: dict):
+    return validated_identity(
+        repo,
+        pr,
+        installation_id=41,
+        repo_full_name="acme-corp/acme-bot",
+        pr_number=123,
+        branch="curie/publication-example",
+        head_sha="a" * 40,
+        state="open",
+    )
+
+
+def test_verified_identity_requires_matching_repo_and_pr() -> None:
+    repo, pr = identity_payloads()
+    proof = validate(repo, pr)
+    assert (proof.repository_id, proof.installation_id, proof.pr_node_id) == (
+        9001,
+        41,
+        "PR_example_123",
+    )
+
+
+@pytest.mark.parametrize(
+    "path,value",
+    [
+        (("id",), True),
+        (("id",), 0),
+        (("full_name",), "acme-corp/other"),
+        (("pr", "number"), True),
+        (("pr", "node_id"), ""),
+        (("pr", "state"), "closed"),
+        (("pr", "head", "sha"), "b" * 40),
+        (("pr", "head", "ref"), "other"),
+        (("pr", "head", "repo", "id"), 9002),
+        (("pr", "base", "repo", "id"), 9002),
+        (("pr", "html_url"), "https://github.com/acme-corp/other/pull/123"),
+    ],
+)
+def test_identity_guard_refuses_changed_provider_truth(
+    path: tuple[str, ...], value: object
+) -> None:
+    repo, pr = identity_payloads()
+    target = pr if path[0] == "pr" else repo
+    parts = path[1:] if path[0] == "pr" else path
+    for component in parts[:-1]:
+        target = target[component]
+    target[parts[-1]] = value
+    with pytest.raises(AuthorityRefused):
+        validate(repo, pr)
+
+
+def test_same_commit_hex_case_matches_existing_lineage_reader() -> None:
+    repo, pr = identity_payloads()
+    pr["head"]["sha"] = ("a" * 40).upper()
+    assert validate(repo, pr).repository_id == 9001
+
+
+def test_provider_identity_cannot_overflow_bigint_authority() -> None:
+    repo, pr = identity_payloads()
+    repo["id"] = pr["head"]["repo"]["id"] = pr["base"]["repo"]["id"] = 2**63
+    with pytest.raises(AuthorityRefused):
+        validate(repo, pr)

--- a/apps/api/tests/test_publications.py
+++ b/apps/api/tests/test_publications.py
@@ -44,6 +44,7 @@ from fastapi import Response
 from fastapi.testclient import TestClient
 from pydantic import ValidationError
 from sqlalchemy import text, update
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 REPO = "acme-corp/acme-bot"
@@ -4350,3 +4351,523 @@ def test_publication_lineage_route_operations_are_in_every_http_metric_domain(
     complete = {**active, "outcome": "2xx"}
     record_metric("curie.http.server.request", attributes=complete)
     record_metric("curie.http.server.request.duration", 0.001, attributes=complete)
+
+
+# These API integration tests use the actual disposable Postgres/Valkey stack;
+# only GitHub HTTP is fixture-controlled. Provider identity fields are documented
+# at https://docs.github.com/en/rest/pulls/pulls#get-a-pull-request and
+# https://docs.github.com/en/rest/apps/apps#get-a-repository-installation-for-the-authenticated-app.
+
+
+def _reserve_review(
+    client: TestClient, lineage: dict[str, Any], origin: str, *, version: int | None = None
+) -> Any:
+    return client.post(
+        "/v1/internal/publications/review-reservations",
+        headers=WORKER_HEADERS,
+        json={
+            "repository_id": 9001,
+            "pr_number": PR_NUMBER,
+            "expected_lineage_version": version or lineage["version"],
+            "origin_key": origin,
+        },
+    )
+
+
+def test_review_reservation_refuses_legacy_unproved_lineage(
+    clean_db: None, publication_stack: tuple[TestClient, str], auth_headers: dict[str, str]
+) -> None:
+    client, stream = publication_stack
+    _, publication = _open_lineage(
+        client,
+        auth_headers,
+        conversation_id='test-1',
+    )
+    response = _reserve_review(client, {"version": 2}, "review:legacy")
+    assert response.status_code == 409, response.text
+    assert response.json()["detail"]["code"] == "publication.review_ineligible"
+    assert _rows("SELECT count(*) AS n FROM curie.publication_review_reservations")[0]["n"] == 0
+    assert (
+        _rows(
+            "SELECT github_repository_id FROM curie.thread_publication_lineages WHERE id=:id",
+            {"id": publication["lineage_id"]},
+        )[0]["github_repository_id"]
+        is None
+    )
+    valkey = connect_or_skip(decode_responses=True)
+    try:
+        assert valkey.xlen(stream) == 0
+    finally:
+        valkey.close()
+
+
+def test_review_reservation_requires_worker_identity(
+    clean_db: None, publication_stack: tuple[TestClient, str], auth_headers: dict[str, str]
+) -> None:
+    client, _ = publication_stack
+    response = client.post(
+        "/v1/internal/publications/review-reservations",
+        headers=auth_headers,
+        json={
+            "repository_id": 9001,
+            "pr_number": PR_NUMBER,
+            "expected_lineage_version": 1,
+            "origin_key": "review:untrusted",
+        },
+    )
+    assert response.status_code == 401, response.text
+    assert _rows("SELECT count(*) AS n FROM curie.publication_review_reservations")[0]["n"] == 0
+
+
+@pytest.fixture
+def review_lineage_app(
+    clean_db: None, publication_stack: tuple[TestClient, str], monkeypatch: pytest.MonkeyPatch
+) -> Iterator[tuple[TestClient, dict[str, Any], str]]:
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    client, stream = publication_stack
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    monkeypatch.setenv("GITHUB_APP_ID", "51")
+    monkeypatch.setenv(
+        "GITHUB_APP_PRIVATE_KEY",
+        key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        ).decode(),
+    )
+    get_settings.cache_clear()
+    truth: dict[str, Any] = {
+        "repository_id": 9001,
+        "installation_id": 41,
+        "node_id": "PR_example_123",
+        "branch": "pending",
+        "head_sha": FIRST_REVISION_SHA,
+        "status": 200,
+        "calls": [],
+    }
+    real_client = httpx.Client
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        truth["calls"].append((request.method, request.url.path))
+        if request.url.path.endswith("/installation"):
+            return httpx.Response(200, json={"id": truth["installation_id"]})
+        if request.url.path.endswith("/access_tokens"):
+            return httpx.Response(
+                201,
+                json={
+                    "token": "fixture-publication-app-token",
+                    "expires_at": "2999-01-01T00:00:00Z",
+                },
+            )
+        assert request.headers["authorization"] == "Bearer fixture-publication-app-token"
+        if truth["status"] != 200:
+            return httpx.Response(truth["status"], json={"message": "fixture-unavailable"})
+        repo = {"id": truth["repository_id"], "full_name": REPO}
+        if request.url.path == f"/repos/{REPO}":
+            return httpx.Response(200, json=repo)
+        return httpx.Response(
+            200,
+            json={
+                "number": PR_NUMBER,
+                "html_url": PR_URL,
+                "node_id": truth["node_id"],
+                "state": "open",
+                "merged": False,
+                "head": {"sha": truth["head_sha"], "ref": truth["branch"], "repo": repo},
+                "base": {"repo": repo, "ref": "main"},
+            },
+        )
+
+    monkeypatch.setattr(
+        "curie_api.github_app.httpx.Client",
+        lambda *a, **kw: real_client(transport=httpx.MockTransport(handle)),
+    )
+    injected = httpx.AsyncClient(transport=httpx.MockTransport(handle), follow_redirects=True)
+    original = client.app.state.http_client
+    client.app.state.http_client = injected
+    try:
+        yield client, truth, stream
+    finally:
+        client.app.state.http_client = original
+        asyncio.run(injected.aclose())
+        _RESOLVERS.clear()
+        get_settings.cache_clear()
+
+
+def _verified_lineage(
+    client: TestClient,
+    truth: dict[str, Any],
+    auth_headers: dict[str, str],
+    *,
+    conversation: str = "review-original",
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    deployment = _create_deployment(client, auth_headers)
+    _, publication = _create_publication(
+        client, _publication_payload(deployment["id"], conversation_id=conversation)
+    )
+    truth["branch"] = publication["branch"]
+    resolved = _resolve(client, auth_headers, publication["approval_id"])
+    assert resolved.status_code == 200, resolved.text
+    advanced = _advance_lineage(
+        client,
+        publication["id"],
+        expected_version=1,
+        expected_head_sha=None,
+        head_sha=FIRST_REVISION_SHA,
+    )
+    assert advanced.status_code == 200, advanced.text
+    _mark_outcome_history_ready(publication["id"])
+    return deployment, publication, advanced.json()
+
+
+def test_review_reservation_captures_verified_identity_and_exact_replay(
+    review_lineage_app: tuple[TestClient, dict[str, Any], str], auth_headers: dict[str, str]
+) -> None:
+    client, truth, stream = review_lineage_app
+    deployment, publication, lineage = _verified_lineage(client, truth, auth_headers)
+    before_approvals = _rows("SELECT count(*) AS n FROM curie.approvals")[0]["n"]
+    first = _reserve_review(client, lineage, "review:123:71")
+    assert first.status_code == 201, first.text
+    result = first.json()
+    assert first.headers["cache-control"] == "no-store"
+    assert (result["repository_id"], result["installation_id"], result["pr_node_id"]) == (
+        9001,
+        41,
+        "PR_example_123",
+    )
+    assert result["agent_id"] == deployment["agent_id"]
+    assert result["reply_conversation_id"] == "review-original"
+    assert result["conversation_id"] == channel_protocol.scoped_conversation_id(
+        "slack", "C0EXAMPLE1", "review-original"
+    )
+    assert result["revision_number"] == 2 and result["expected_head_sha"] == FIRST_REVISION_SHA
+    replay = _reserve_review(client, lineage, "review:123:71")
+    assert replay.status_code == 200 and replay.json() == result
+    conflict = _reserve_review(client, lineage, "review:123:72")
+    assert (
+        conflict.status_code == 409
+        and conflict.json()["detail"]["code"] == "publication.revision_conflict"
+    )
+    assert _rows("SELECT count(*) AS n FROM curie.publication_review_reservations")[0]["n"] == 1
+    assert _rows("SELECT count(*) AS n FROM curie.approvals")[0]["n"] == before_approvals
+    valkey = connect_or_skip(decode_responses=True)
+    try:
+        assert valkey.xlen(stream) == 0
+    finally:
+        valkey.close()
+
+
+def test_review_reservation_stale_version_and_binding_reassert_are_refused(
+    review_lineage_app: tuple[TestClient, dict[str, Any], str], auth_headers: dict[str, str]
+) -> None:
+    client, truth, _ = review_lineage_app
+    deployment, _, lineage = _verified_lineage(client, truth, auth_headers)
+    stale = _reserve_review(client, lineage, "review:stale", version=1)
+    assert (
+        stale.status_code == 409 and stale.json()["detail"]["code"] == "publication.lineage_stale"
+    )
+    rebind = client.patch(
+        f"/agents/{deployment['agent_id']}/channels",
+        params={"kind": "slack", "address": "C0EXAMPLE1", "expected_generation": 0},
+        json={"kind": "slack", "address": "C0EXAMPLE1"},
+        headers=auth_headers,
+    )
+    assert rebind.status_code == 200, rebind.text
+    denied = _reserve_review(client, lineage, "review:rebound")
+    assert (
+        denied.status_code == 409
+        and denied.json()["detail"]["code"] == "publication.review_ineligible"
+    )
+    assert _rows("SELECT count(*) AS n FROM curie.publication_review_reservations")[0]["n"] == 0
+
+
+def test_review_reservation_concurrency_has_one_winner(
+    review_lineage_app: tuple[TestClient, dict[str, Any], str], auth_headers: dict[str, str]
+) -> None:
+    client, truth, _ = review_lineage_app
+    _, _, lineage = _verified_lineage(client, truth, auth_headers)
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        responses = list(
+            pool.map(lambda n: _reserve_review(client, lineage, f"review:concurrent:{n}"), range(4))
+        )
+    assert sorted(response.status_code for response in responses) == [201, 409, 409, 409]
+    assert (
+        _rows(
+            "SELECT count(*) AS n FROM curie.publication_review_reservations "
+            "WHERE status='reserved'"
+        )[0]["n"]
+        == 1
+    )
+
+
+def test_review_reservation_only_explicit_origin_can_create_fresh_approval(
+    review_lineage_app: tuple[TestClient, dict[str, Any], str], auth_headers: dict[str, str]
+) -> None:
+    client, truth, _ = review_lineage_app
+    deployment, _, lineage = _verified_lineage(client, truth, auth_headers)
+    reservation = _reserve_review(client, lineage, "review:accepted-origin")
+    assert reservation.status_code == 201, reservation.text
+    payload = _publication_payload(
+        deployment["id"], conversation_id="review-original", base_sha=FIRST_REVISION_SHA
+    )
+    for origin in (None, "review:other-origin"):
+        attempted = dict(payload)
+        if origin is not None:
+            attempted["review_origin_key"] = origin
+        refused = client.post("/v1/internal/publications", headers=WORKER_HEADERS, json=attempted)
+        assert refused.status_code == 409, refused.text
+    payload["review_origin_key"] = "review:accepted-origin"
+    created = client.post("/v1/internal/publications", headers=WORKER_HEADERS, json=payload)
+    assert created.status_code == 201, created.text
+    assert created.json()["id"] == reservation.json()["revision_id"]
+    assert created.json()["status"] == "pending" and created.json()["revision_number"] == 2
+    assert created.json()["pr_number"] == PR_NUMBER
+    assert (
+        _rows("SELECT status FROM curie.publication_review_reservations")[0]["status"] == "consumed"
+    )
+    # Replaying an ordinary snapshot cannot strip the review origin from an
+    # already-created approval, even if all patch and dedupe bytes match.
+    payload.pop("review_origin_key")
+    changed = client.post("/v1/internal/publications", headers=WORKER_HEADERS, json=payload)
+    assert changed.status_code == 409, changed.text
+
+
+def test_review_reservation_cancel_is_fenced_and_frees_only_its_own_slot(
+    review_lineage_app: tuple[TestClient, dict[str, Any], str], auth_headers: dict[str, str]
+) -> None:
+    client, truth, _ = review_lineage_app
+    _, _, lineage = _verified_lineage(client, truth, auth_headers)
+    reservation = _reserve_review(client, lineage, "review:cancel-me").json()
+    path = f"/v1/internal/publications/review-reservations/{reservation['revision_id']}/cancel"
+    for origin, version in (("review:other", 1), ("review:cancel-me", 2)):
+        refused = client.post(
+            path, headers=WORKER_HEADERS, json={"origin_key": origin, "expected_version": version}
+        )
+        assert refused.status_code == 409, refused.text
+    cancelled = client.post(
+        path, headers=WORKER_HEADERS, json={"origin_key": "review:cancel-me", "expected_version": 1}
+    )
+    assert cancelled.status_code == 200 and cancelled.json()["status"] == "cancelled"
+    repeated = client.post(
+        path, headers=WORKER_HEADERS, json={"origin_key": "review:cancel-me", "expected_version": 1}
+    )
+    assert repeated.status_code == 409
+    next_origin = _reserve_review(client, lineage, "review:after-cancel")
+    assert next_origin.status_code == 201 and next_origin.json()["revision_number"] == 2
+
+
+@pytest.mark.parametrize(
+    "mutation", ["repository_id", "installation_id", "node_id", "head_sha", "status"]
+)
+def test_review_identity_cannot_change_on_existing_pr_advance(
+    review_lineage_app: tuple[TestClient, dict[str, Any], str],
+    auth_headers: dict[str, str],
+    mutation: str,
+) -> None:
+    client, truth, _ = review_lineage_app
+    deployment, _, lineage = _verified_lineage(client, truth, auth_headers)
+    _, publication = _create_publication(
+        client,
+        _publication_payload(
+            deployment["id"], conversation_id="review-original", base_sha=FIRST_REVISION_SHA
+        ),
+    )
+    assert _resolve(client, auth_headers, publication["approval_id"]).status_code == 200
+    truth["head_sha"] = SECOND_REVISION_SHA
+    truth[mutation] = {
+        "repository_id": 9002,
+        "installation_id": 42,
+        "node_id": "PR_other_123",
+        "head_sha": EXTERNAL_REVISION_SHA,
+        "status": 503,
+    }[mutation]
+    refused = _advance_lineage(
+        client,
+        publication["id"],
+        expected_version=lineage["version"],
+        expected_head_sha=FIRST_REVISION_SHA,
+        head_sha=SECOND_REVISION_SHA,
+    )
+    assert refused.status_code == (503 if mutation == "status" else 409), refused.text
+    stored = _rows(
+        "SELECT github_repository_id, github_installation_id, github_pr_node_id, "
+        "head_sha, version FROM curie.thread_publication_lineages WHERE id=:id",
+        {"id": lineage["id"]},
+    )[0]
+    assert stored == {
+        "github_repository_id": 9001,
+        "github_installation_id": 41,
+        "github_pr_node_id": "PR_example_123",
+        "head_sha": FIRST_REVISION_SHA,
+        "version": lineage["version"],
+    }
+
+
+def test_review_identity_constraints_reject_partial_authority(
+    review_lineage_app: tuple[TestClient, dict[str, Any], str], auth_headers: dict[str, str]
+) -> None:
+    client, truth, _ = review_lineage_app
+    _, _, lineage = _verified_lineage(client, truth, auth_headers)
+    for assignment in (
+        "github_repository_id=NULL",
+        "github_installation_id=NULL",
+        "github_pr_node_id=NULL",
+        "base_ref=NULL",
+    ):
+        with pytest.raises(IntegrityError):
+            _execute(
+                "UPDATE curie.thread_publication_lineages SET " + assignment + " WHERE id=:id",
+                {"id": lineage["id"]},
+            )
+    assert (
+        _rows(
+            "SELECT github_repository_id FROM curie.thread_publication_lineages WHERE id=:id",
+            {"id": lineage["id"]},
+        )[0]["github_repository_id"]
+        == 9001
+    )
+
+
+def test_review_authority_downgrade_refuses_an_active_reservation(
+    review_lineage_app: tuple[TestClient, dict[str, Any], str], auth_headers: dict[str, str]
+) -> None:
+    from alembic import command
+    from alembic.config import Config
+
+    client, truth, _ = review_lineage_app
+    _, _, lineage = _verified_lineage(client, truth, auth_headers)
+    reservation = _reserve_review(client, lineage, "review:retain-on-rollback")
+    assert reservation.status_code == 201, reservation.text
+    api_dir = Path(__file__).resolve().parents[1]
+    config = Config(str(api_dir / "alembic.ini"))
+    config.set_main_option("script_location", str(api_dir / "alembic"))
+    with pytest.raises(RuntimeError, match="revisions are active"):
+        command.downgrade(config, "0041")
+    assert _rows("SELECT version_num FROM curie.alembic_version")[0]["version_num"] == "0042"
+    assert (
+        _rows("SELECT status FROM curie.publication_review_reservations")[0]["status"] == "reserved"
+    )
+
+
+@pytest.mark.parametrize(
+    "changed_route", [{"reply_channel": "C0EXAMPLE2"}, {"reply_conversation_id": "another-thread"}]
+)
+def test_scoped_review_consumption_cannot_redirect_the_fresh_approval(
+    review_lineage_app: tuple[TestClient, dict[str, Any], str],
+    auth_headers: dict[str, str],
+    changed_route: dict[str, str],
+) -> None:
+    client, truth, _ = review_lineage_app
+    deployment, _, lineage = _verified_lineage(client, truth, auth_headers)
+    reservation = _reserve_review(client, lineage, "review:scoped-route")
+    assert reservation.status_code == 201, reservation.text
+    payload = _publication_payload(
+        deployment["id"], conversation_id=lineage["conversation_id"], base_sha=FIRST_REVISION_SHA
+    )
+    payload.update(reply_conversation_id="review-original", review_origin_key="review:scoped-route")
+    payload.update(changed_route)
+    refused = client.post("/v1/internal/publications", headers=WORKER_HEADERS, json=payload)
+    assert refused.status_code == 409, refused.text
+    assert refused.json()["detail"]["code"] == "publication.review_ineligible"
+    assert _rows("SELECT count(*) AS n FROM curie.publications WHERE status='pending'")[0]["n"] == 0
+    assert (
+        _rows("SELECT status FROM curie.publication_review_reservations")[0]["status"] == "reserved"
+    )
+    payload.update(reply_channel="C0EXAMPLE1", reply_conversation_id="review-original")
+    accepted = client.post("/v1/internal/publications", headers=WORKER_HEADERS, json=payload)
+    assert accepted.status_code == 201, accepted.text
+    assert accepted.json()["id"] == reservation.json()["revision_id"]
+    assert accepted.json()["reply_channel"] == "C0EXAMPLE1"
+
+
+def test_cancelled_review_origin_remains_a_non_executing_tombstone(
+    review_lineage_app: tuple[TestClient, dict[str, Any], str], auth_headers: dict[str, str]
+) -> None:
+    client, truth, _ = review_lineage_app
+    deployment, _, lineage = _verified_lineage(client, truth, auth_headers)
+    reserved = _reserve_review(client, lineage, "review:never-rearm").json()
+    response = client.post(
+        f"/v1/internal/publications/review-reservations/{reserved['revision_id']}/cancel",
+        headers=WORKER_HEADERS,
+        json={"origin_key": "review:never-rearm", "expected_version": 1},
+    )
+    assert response.status_code == 200
+    replay = _reserve_review(client, lineage, "review:never-rearm")
+    assert replay.status_code == 200 and replay.json()["status"] == "cancelled"
+    payload = _publication_payload(
+        deployment["id"], conversation_id="review-original", base_sha=FIRST_REVISION_SHA
+    )
+    payload["review_origin_key"] = "review:never-rearm"
+    rejected = client.post("/v1/internal/publications", headers=WORKER_HEADERS, json=payload)
+    assert rejected.status_code == 409
+    assert _rows("SELECT count(*) AS n FROM curie.publications WHERE status='pending'")[0]["n"] == 0
+
+
+def test_verified_github_pr_has_only_one_conversation_owner(
+    review_lineage_app: tuple[TestClient, dict[str, Any], str], auth_headers: dict[str, str]
+) -> None:
+    client, truth, _ = review_lineage_app
+    deployment, _, lineage = _verified_lineage(client, truth, auth_headers)
+    _, other = _create_publication(
+        client, _publication_payload(deployment["id"], conversation_id="other-conversation")
+    )
+    assert _resolve(client, auth_headers, other["approval_id"]).status_code == 200
+    truth["branch"] = other["branch"]
+    conflict = _advance_lineage(
+        client, other["id"], expected_version=1, expected_head_sha=None, head_sha=FIRST_REVISION_SHA
+    )
+    assert (
+        conflict.status_code == 409
+        and conflict.json()["detail"]["code"] == "publication.revision_conflict"
+    )
+    owners = _rows(
+        "SELECT id FROM curie.thread_publication_lineages "
+        "WHERE github_repository_id=9001 AND pr_number=:number",
+        {"number": PR_NUMBER},
+    )
+    assert owners == [{"id": uuid.UUID(lineage["id"])}]
+    assert _rows(
+        "SELECT github_repository_id,head_sha FROM curie.thread_publication_lineages WHERE id=:id",
+        {"id": other["lineage_id"]},
+    ) == [{"github_repository_id": None, "head_sha": None}]
+
+
+def test_adding_app_after_pat_publication_does_not_backfill_legacy_identity(
+    review_lineage_app: tuple[TestClient, dict[str, Any], str],
+    auth_headers: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, truth, _ = review_lineage_app
+    app_id = get_settings().github_app_id
+    monkeypatch.setenv("GITHUB_APP_ID", "")
+    get_settings.cache_clear()
+    deployment, publication = _open_lineage(
+        client,
+        auth_headers,
+        conversation_id='test-2',
+    )
+    monkeypatch.setenv("GITHUB_APP_ID", app_id)
+    get_settings.cache_clear()
+    _, later = _create_publication(
+        client,
+        _publication_payload(
+            deployment["id"], conversation_id="legacy-pat-thread", base_sha=FIRST_REVISION_SHA
+        ),
+    )
+    assert _resolve(client, auth_headers, later["approval_id"]).status_code == 200
+    advanced = _advance_lineage(
+        client,
+        later["id"],
+        expected_version=2,
+        expected_head_sha=FIRST_REVISION_SHA,
+        head_sha=SECOND_REVISION_SHA,
+    )
+    assert advanced.status_code == 200, advanced.text
+    assert truth["calls"] == []
+    assert _rows(
+        "SELECT github_repository_id,head_sha FROM curie.thread_publication_lineages WHERE id=:id",
+        {"id": publication["lineage_id"]},
+    ) == [{"github_repository_id": None, "head_sha": SECOND_REVISION_SHA}]
+    assert _reserve_review(client, advanced.json(), "review:legacy-replay").status_code == 409

--- a/apps/api/tests/test_publications.py
+++ b/apps/api/tests/test_publications.py
@@ -4840,20 +4840,21 @@ def test_adding_app_after_pat_publication_does_not_backfill_legacy_identity(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     client, truth, _ = review_lineage_app
+    conversation_id = "legacy-pat-thread"
     app_id = get_settings().github_app_id
     monkeypatch.setenv("GITHUB_APP_ID", "")
     get_settings.cache_clear()
     deployment, publication = _open_lineage(
         client,
         auth_headers,
-        conversation_id='test-2',
+        conversation_id=conversation_id,
     )
     monkeypatch.setenv("GITHUB_APP_ID", app_id)
     get_settings.cache_clear()
     _, later = _create_publication(
         client,
         _publication_payload(
-            deployment["id"], conversation_id="legacy-pat-thread", base_sha=FIRST_REVISION_SHA
+            deployment["id"], conversation_id=conversation_id, base_sha=FIRST_REVISION_SHA
         ),
     )
     assert _resolve(client, auth_headers, later["approval_id"]).status_code == 200
@@ -4873,14 +4874,14 @@ def test_adding_app_after_pat_publication_does_not_backfill_legacy_identity(
     assert _reserve_review(client, advanced.json(), "review:legacy-replay").status_code == 409
 
 
-@pytest.mark.parametrize("mutation", ["binding", "head"])
+@pytest.mark.parametrize("mutation", ["binding", "head", "deployment"])
 def test_review_reservation_refreshes_authority_already_loaded_by_its_caller(
     review_lineage_app: tuple[TestClient, dict[str, Any], str],
     auth_headers: dict[str, str],
     mutation: str,
 ) -> None:
     """A row lock must refresh objects retained during earlier authority reads."""
-    from curie_api.models import AgentChannel, ThreadPublicationLineage
+    from curie_api.models import AgentChannel, Deployment, ThreadPublicationLineage
     from curie_api.schemas import ReviewRevisionReserve
     from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -4904,6 +4905,8 @@ def test_review_reservation_refreshes_authority_already_loaded_by_its_caller(
                 assert loaded is not None
                 binding = await session.get(AgentChannel, loaded.binding_id)
                 assert binding is not None
+                held_deployment = await session.get(Deployment, loaded.deployment_id)
+                assert held_deployment is not None
                 # Keep both strong references while another real API transaction
                 # changes authority. FOR UPDATE alone does not refresh this map.
                 if mutation == "binding":
@@ -4918,6 +4921,10 @@ def test_review_reservation_refreshes_authority_already_loaded_by_its_caller(
                         json={"kind": "slack", "address": "C0EXAMPLE1"},
                         headers=auth_headers,
                     )
+                elif mutation == "deployment":
+                    response = await asyncio.to_thread(
+                        client.delete, f"/deployments/{deployment['id']}", headers=auth_headers
+                    )
                 else:
                     assert later is not None
                     truth["head_sha"] = EXTERNAL_REVISION_SHA
@@ -4930,7 +4937,9 @@ def test_review_reservation_refreshes_authority_already_loaded_by_its_caller(
                         head_sha=EXTERNAL_REVISION_SHA,
                     )
                     await asyncio.to_thread(_mark_outcome_history_ready, later["id"])
-                assert response.status_code == 200, response.text
+                assert response.status_code == (204 if mutation == "deployment" else 200), (
+                    response.text
+                )
                 with pytest.raises(crud.PublicationLineageConflict) as conflict:
                     await crud.reserve_review_revision(
                         session,
@@ -4942,7 +4951,7 @@ def test_review_reservation_refreshes_authority_already_loaded_by_its_caller(
                         ),
                     )
                 assert conflict.value.code == (
-                    "publication.review_ineligible" if mutation == "binding"
+                    "publication.review_ineligible" if mutation != "head"
                     else "publication.lineage_stale"
                 )
         finally:

--- a/apps/api/tests/test_publications.py
+++ b/apps/api/tests/test_publications.py
@@ -4871,3 +4871,82 @@ def test_adding_app_after_pat_publication_does_not_backfill_legacy_identity(
         {"id": publication["lineage_id"]},
     ) == [{"github_repository_id": None, "head_sha": SECOND_REVISION_SHA}]
     assert _reserve_review(client, advanced.json(), "review:legacy-replay").status_code == 409
+
+
+@pytest.mark.parametrize("mutation", ["binding", "head"])
+def test_review_reservation_refreshes_authority_already_loaded_by_its_caller(
+    review_lineage_app: tuple[TestClient, dict[str, Any], str],
+    auth_headers: dict[str, str],
+    mutation: str,
+) -> None:
+    """A row lock must refresh objects retained during earlier authority reads."""
+    from curie_api.models import AgentChannel, ThreadPublicationLineage
+    from curie_api.schemas import ReviewRevisionReserve
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    client, truth, _ = review_lineage_app
+    deployment, _, lineage = _verified_lineage(client, truth, auth_headers)
+    later = None
+    if mutation == "head":
+        _, later = _create_publication(
+            client,
+            _publication_payload(
+                deployment["id"], conversation_id="review-original", base_sha=FIRST_REVISION_SHA
+            ),
+        )
+        assert _resolve(client, auth_headers, later["approval_id"]).status_code == 200
+
+    async def exercise() -> None:
+        engine = create_async_engine(get_settings().database_url)
+        try:
+            async with AsyncSession(engine) as session:
+                loaded = await session.get(ThreadPublicationLineage, uuid.UUID(lineage["id"]))
+                assert loaded is not None
+                binding = await session.get(AgentChannel, loaded.binding_id)
+                assert binding is not None
+                # Keep both strong references while another real API transaction
+                # changes authority. FOR UPDATE alone does not refresh this map.
+                if mutation == "binding":
+                    response = await asyncio.to_thread(
+                        client.patch,
+                        f"/agents/{deployment['agent_id']}/channels",
+                        params={
+                            "kind": "slack",
+                            "address": "C0EXAMPLE1",
+                            "expected_generation": binding.generation,
+                        },
+                        json={"kind": "slack", "address": "C0EXAMPLE1"},
+                        headers=auth_headers,
+                    )
+                else:
+                    assert later is not None
+                    truth["head_sha"] = EXTERNAL_REVISION_SHA
+                    response = await asyncio.to_thread(
+                        _advance_lineage,
+                        client,
+                        later["id"],
+                        expected_version=lineage["version"],
+                        expected_head_sha=FIRST_REVISION_SHA,
+                        head_sha=EXTERNAL_REVISION_SHA,
+                    )
+                    await asyncio.to_thread(_mark_outcome_history_ready, later["id"])
+                assert response.status_code == 200, response.text
+                with pytest.raises(crud.PublicationLineageConflict) as conflict:
+                    await crud.reserve_review_revision(
+                        session,
+                        ReviewRevisionReserve(
+                            repository_id=9001,
+                            pr_number=PR_NUMBER,
+                            expected_lineage_version=lineage["version"],
+                            origin_key=f"review:cached-{mutation}",
+                        ),
+                    )
+                assert conflict.value.code == (
+                    "publication.review_ineligible" if mutation == "binding"
+                    else "publication.lineage_stale"
+                )
+        finally:
+            await engine.dispose()
+
+    asyncio.run(exercise())
+    assert _rows("SELECT count(*) AS n FROM curie.publication_review_reservations")[0]["n"] == 0

--- a/apps/api/tests/test_schema_compat.py
+++ b/apps/api/tests/test_schema_compat.py
@@ -279,42 +279,43 @@ def test_crash_retry_does_not_double_apply(
         "applied_at timestamptz not null default now())"
     )
 
+    # Synthetic names cannot collide with future production migration numbers.
     alembic_copy = tmp_path / "alembic"
     shutil.copytree(ALEMBIC_DIR, alembic_copy)
     versions = alembic_copy / "versions"
-    (versions / "0042_compat_first.py").write_text(
+    (versions / "compat_probe_first_compat_first.py").write_text(
         '''
-revision = "0042"
+revision = "compat_probe_first"
 down_revision = "0041"
 
 def upgrade():
     from alembic import op
     op.execute(
-        "INSERT INTO curie.compat_probe (rev) VALUES ('0042')"
+        "INSERT INTO curie.compat_probe (rev) VALUES ('compat_probe_first')"
     )
 
 def downgrade():
     from alembic import op
-    op.execute("DELETE FROM curie.compat_probe WHERE rev = '0042'")
+    op.execute("DELETE FROM curie.compat_probe WHERE rev = 'compat_probe_first'")
 '''
     )
-    (versions / "0043_compat_second.py").write_text(
+    (versions / "compat_probe_second_compat_second.py").write_text(
         '''
 import os
-revision = "0043"
-down_revision = "0042"
+revision = "compat_probe_second"
+down_revision = "compat_probe_first"
 
 def upgrade():
     from alembic import op
     if os.environ.get("CURIE_COMPAT_PROBE_CRASH") == "1":
-        raise RuntimeError("injected crash after 0042")
+        raise RuntimeError("injected crash after compat_probe_first")
     op.execute(
-        "INSERT INTO curie.compat_probe (rev) VALUES ('0043')"
+        "INSERT INTO curie.compat_probe (rev) VALUES ('compat_probe_second')"
     )
 
 def downgrade():
     from alembic import op
-    op.execute("DELETE FROM curie.compat_probe WHERE rev = '0043'")
+    op.execute("DELETE FROM curie.compat_probe WHERE rev = 'compat_probe_second'")
 '''
     )
     probe_cfg = Config()
@@ -326,45 +327,45 @@ def downgrade():
             apply_upgrade(
                 forward_only=False,
                 alembic_config=probe_cfg,
-                window=AppWindow(schema_min=HEAD, schema_head="0043"),
+                window=AppWindow(schema_min=HEAD, schema_head="compat_probe_second"),
                 kinds={
                     **load_kinds(),
-                    "0042": KIND_EXPAND,
-                    "0043": KIND_EXPAND,
+                    "compat_probe_first": KIND_EXPAND,
+                    "compat_probe_second": KIND_EXPAND,
                 },
             )
     finally:
         os.environ.pop("CURIE_COMPAT_PROBE_CRASH", None)
 
-    assert current_revision() == "0042"
+    assert current_revision() == "compat_probe_first"
     rows = _sql("SELECT rev FROM curie.compat_probe ORDER BY rev")
-    assert [r[0] for r in rows] == ["0042"]
+    assert [r[0] for r in rows] == ["compat_probe_first"]
 
     outcome = apply_upgrade(
         forward_only=False,
         alembic_config=probe_cfg,
-        window=AppWindow(schema_min=HEAD, schema_head="0043"),
+        window=AppWindow(schema_min=HEAD, schema_head="compat_probe_second"),
         kinds={
             **load_kinds(),
-            "0042": KIND_EXPAND,
-            "0043": KIND_EXPAND,
+            "compat_probe_first": KIND_EXPAND,
+            "compat_probe_second": KIND_EXPAND,
         },
     )
     assert outcome.outcome == "applied"
-    assert current_revision() == "0043"
+    assert current_revision() == "compat_probe_second"
     rows = _sql("SELECT rev FROM curie.compat_probe ORDER BY rev")
-    assert [r[0] for r in rows] == ["0042", "0043"]
+    assert [r[0] for r in rows] == ["compat_probe_first", "compat_probe_second"]
 
     again = apply_upgrade(
         forward_only=False,
         alembic_config=probe_cfg,
-        window=AppWindow(schema_min=HEAD, schema_head="0043"),
+        window=AppWindow(schema_min=HEAD, schema_head="compat_probe_second"),
         kinds={
             **load_kinds(),
-            "0042": KIND_EXPAND,
-            "0043": KIND_EXPAND,
+            "compat_probe_first": KIND_EXPAND,
+            "compat_probe_second": KIND_EXPAND,
         },
     )
     assert again.action == "noop"
     rows = _sql("SELECT rev FROM curie.compat_probe ORDER BY rev")
-    assert [r[0] for r in rows] == ["0042", "0043"]
+    assert [r[0] for r in rows] == ["compat_probe_first", "compat_probe_second"]

--- a/packages/telemetry/schema/metrics.json
+++ b/packages/telemetry/schema/metrics.json
@@ -1,747 +1,7 @@
 {
-  "schema_version": "v1",
   "metrics": {
-    "curie.turn.accepted": {
-      "type": "counter",
-      "unit": "{turn}",
-      "description": "Turns accepted for processing.",
-      "monotonic": true,
-      "attributes": {
-        "service.name": [
-          "curie-api",
-          "curie-dispatcher",
-          "curie-worker",
-          "curie-runner"
-        ],
-        "source": [
-          "api",
-          "dispatcher",
-          "worker",
-          "runner",
-          "local",
-          "eval"
-        ],
-        "outcome": [
-          "accepted"
-        ]
-      },
-      "cardinality_bound": 24
-    },
-    "curie.turn.completed": {
-      "type": "counter",
-      "unit": "{turn}",
-      "description": "Turns reaching a terminal result.",
-      "monotonic": true,
-      "attributes": {
-        "service.name": [
-          "curie-api",
-          "curie-dispatcher",
-          "curie-worker",
-          "curie-runner"
-        ],
-        "source": [
-          "api",
-          "dispatcher",
-          "worker",
-          "runner",
-          "local",
-          "eval"
-        ],
-        "outcome": [
-          "done",
-          "awaiting_approval",
-          "budget_halted",
-          "classified_failure",
-          "side_effect_halted",
-          "idle",
-          "interrupted"
-        ]
-      },
-      "cardinality_bound": 168
-    },
-    "curie.turn.duration": {
-      "type": "histogram",
-      "unit": "s",
-      "description": "End to end turn duration.",
-      "monotonic": false,
-      "attributes": {
-        "service.name": [
-          "curie-api",
-          "curie-dispatcher",
-          "curie-worker",
-          "curie-runner"
-        ],
-        "source": [
-          "api",
-          "dispatcher",
-          "worker",
-          "runner",
-          "local",
-          "eval"
-        ],
-        "outcome": [
-          "done",
-          "awaiting_approval",
-          "budget_halted",
-          "classified_failure",
-          "side_effect_halted",
-          "idle",
-          "interrupted"
-        ]
-      },
-      "cardinality_bound": 168
-    },
-    "curie.history.resume.cache_read": {
-      "type": "histogram",
-      "unit": "{token}",
-      "description": "Provider cache read input tokens on the first turn after structured replay.",
-      "monotonic": false,
-      "attributes": {
-        "service.name": [
-          "curie-runner"
-        ],
-        "source": [
-          "runner"
-        ],
-        "cache_hit": [
-          "true",
-          "false"
-        ]
-      },
-      "cardinality_bound": 2
-    },
-    "curie.queue.enqueue": {
-      "type": "counter",
-      "unit": "{message}",
-      "description": "Messages enqueued.",
-      "monotonic": true,
-      "attributes": {
-        "service.name": [
-          "curie-api",
-          "curie-dispatcher",
-          "curie-worker"
-        ],
-        "source": [
-          "api",
-          "dispatcher",
-          "worker",
-          "local",
-          "eval"
-        ],
-        "outcome": [
-          "success",
-          "failure",
-          "pending",
-          "ack",
-          "retry",
-          "dead-letter"
-        ]
-      },
-      "cardinality_bound": 90
-    },
-    "curie.queue.process": {
-      "type": "counter",
-      "unit": "{message}",
-      "description": "Messages processed.",
-      "monotonic": true,
-      "attributes": {
-        "service.name": [
-          "curie-api",
-          "curie-dispatcher",
-          "curie-worker"
-        ],
-        "source": [
-          "api",
-          "dispatcher",
-          "worker",
-          "local",
-          "eval"
-        ],
-        "outcome": [
-          "success",
-          "failure",
-          "pending",
-          "ack",
-          "retry",
-          "dead-letter"
-        ]
-      },
-      "cardinality_bound": 90
-    },
-    "curie.queue.settle": {
-      "type": "counter",
-      "unit": "{message}",
-      "description": "Message settlement outcomes.",
-      "monotonic": true,
-      "attributes": {
-        "service.name": [
-          "curie-api",
-          "curie-dispatcher",
-          "curie-worker"
-        ],
-        "source": [
-          "api",
-          "dispatcher",
-          "worker",
-          "local",
-          "eval"
-        ],
-        "outcome": [
-          "success",
-          "failure",
-          "pending",
-          "ack",
-          "retry",
-          "dead-letter"
-        ]
-      },
-      "cardinality_bound": 90
-    },
-    "curie.queue.retry": {
-      "type": "counter",
-      "unit": "{retry}",
-      "description": "Bounded queue redelivery and in-process turn retries.",
-      "monotonic": true,
-      "attributes": {
-        "service.name": [
-          "curie-worker"
-        ],
-        "source": [
-          "worker",
-          "eval"
-        ],
-        "retry_class": [
-          "redelivery",
-          "rate-limit",
-          "runner-error",
-          "runner-timeout",
-          "workspace-error"
-        ]
-      },
-      "cardinality_bound": 10
-    },
-    "curie.queue.dead_letter": {
-      "type": "counter",
-      "unit": "{message}",
-      "description": "Messages dead lettered.",
-      "monotonic": true,
-      "attributes": {
-        "service.name": [
-          "curie-api",
-          "curie-dispatcher",
-          "curie-worker"
-        ],
-        "source": [
-          "api",
-          "dispatcher",
-          "worker",
-          "local",
-          "eval"
-        ],
-        "outcome": [
-          "success",
-          "failure",
-          "pending",
-          "ack",
-          "retry",
-          "dead-letter"
-        ]
-      },
-      "cardinality_bound": 90
-    },
-    "curie.queue.wait.duration": {
-      "type": "histogram",
-      "unit": "s",
-      "description": "Queue wait duration.",
-      "monotonic": false,
-      "attributes": {
-        "service.name": [
-          "curie-api",
-          "curie-dispatcher",
-          "curie-worker"
-        ],
-        "source": [
-          "api",
-          "dispatcher",
-          "worker",
-          "local",
-          "eval"
-        ],
-        "outcome": [
-          "success",
-          "failure",
-          "pending",
-          "ack",
-          "retry",
-          "dead-letter"
-        ]
-      },
-      "cardinality_bound": 90
-    },
-    "curie.queue.process.duration": {
-      "type": "histogram",
-      "unit": "s",
-      "description": "Queue processing duration.",
-      "monotonic": false,
-      "attributes": {
-        "service.name": [
-          "curie-api",
-          "curie-dispatcher",
-          "curie-worker"
-        ],
-        "source": [
-          "api",
-          "dispatcher",
-          "worker",
-          "local",
-          "eval"
-        ],
-        "outcome": [
-          "success",
-          "failure",
-          "pending",
-          "ack",
-          "retry",
-          "dead-letter"
-        ]
-      },
-      "cardinality_bound": 90
-    },
-    "curie.queue.message.age": {
-      "type": "histogram",
-      "unit": "s",
-      "description": "Message age at processing.",
-      "monotonic": false,
-      "attributes": {
-        "service.name": [
-          "curie-api",
-          "curie-dispatcher",
-          "curie-worker"
-        ],
-        "source": [
-          "api",
-          "dispatcher",
-          "worker",
-          "local",
-          "eval"
-        ],
-        "outcome": [
-          "success",
-          "failure",
-          "pending",
-          "ack",
-          "retry",
-          "dead-letter"
-        ]
-      },
-      "cardinality_bound": 90
-    },
-    "curie.queue.pending": {
-      "type": "gauge",
-      "unit": "{message}",
-      "description": "Pending consumer group messages.",
-      "monotonic": false,
-      "attributes": {
-        "service.name": [
-          "curie-api",
-          "curie-dispatcher",
-          "curie-worker"
-        ],
-        "source": [
-          "api",
-          "dispatcher",
-          "worker",
-          "local",
-          "eval"
-        ],
-        "outcome": [
-          "success",
-          "failure",
-          "pending",
-          "ack",
-          "retry",
-          "dead-letter"
-        ]
-      },
-      "cardinality_bound": 90
-    },
-    "curie.queue.lag": {
-      "type": "gauge",
-      "unit": "{message}",
-      "description": "Consumer group lag.",
-      "monotonic": false,
-      "attributes": {
-        "service.name": [
-          "curie-api",
-          "curie-dispatcher",
-          "curie-worker"
-        ],
-        "source": [
-          "api",
-          "dispatcher",
-          "worker",
-          "local",
-          "eval"
-        ],
-        "outcome": [
-          "success",
-          "failure",
-          "pending",
-          "ack",
-          "retry",
-          "dead-letter"
-        ]
-      },
-      "cardinality_bound": 90
-    },
-    "curie.queue.depth": {
-      "type": "gauge",
-      "unit": "{message}",
-      "description": "Stream depth.",
-      "monotonic": false,
-      "attributes": {
-        "service.name": [
-          "curie-api",
-          "curie-dispatcher",
-          "curie-worker"
-        ],
-        "source": [
-          "api",
-          "dispatcher",
-          "worker",
-          "local",
-          "eval"
-        ],
-        "outcome": [
-          "success",
-          "failure",
-          "pending",
-          "ack",
-          "retry",
-          "dead-letter"
-        ]
-      },
-      "cardinality_bound": 90
-    },
-    "curie.thread.lock.wait.duration": {
-      "type": "histogram",
-      "unit": "s",
-      "description": "Thread lock acquisition duration.",
-      "monotonic": false,
-      "attributes": {
-        "service.name": [
-          "curie-worker"
-        ],
-        "source": [
-          "worker"
-        ],
-        "outcome": [
-          "acquired",
-          "contended",
-          "timeout",
-          "start",
-          "steer",
-          "finish-race",
-          "observed"
-        ]
-      },
-      "cardinality_bound": 7
-    },
-    "curie.thread.route": {
-      "type": "counter",
-      "unit": "{decision}",
-      "description": "Thread routing decisions.",
-      "monotonic": true,
-      "attributes": {
-        "service.name": [
-          "curie-worker"
-        ],
-        "source": [
-          "worker"
-        ],
-        "outcome": [
-          "acquired",
-          "contended",
-          "timeout",
-          "start",
-          "steer",
-          "finish-race",
-          "observed"
-        ]
-      },
-      "cardinality_bound": 7
-    },
-    "curie.thread.route.active": {
-      "type": "gauge",
-      "unit": "{route}",
-      "description": "Active thread routes.",
-      "monotonic": false,
-      "attributes": {
-        "service.name": [
-          "curie-worker"
-        ],
-        "source": [
-          "worker"
-        ],
-        "outcome": [
-          "acquired",
-          "contended",
-          "timeout",
-          "start",
-          "steer",
-          "finish-race",
-          "observed"
-        ]
-      },
-      "cardinality_bound": 7
-    },
-    "curie.sandbox.lifecycle": {
-      "type": "counter",
-      "unit": "{operation}",
-      "description": "Sandbox lifecycle outcomes.",
-      "monotonic": true,
-      "attributes": {
-        "service.name": [
-          "curie-worker"
-        ],
-        "operation": [
-          "claim",
-          "resume",
-          "release",
-          "suspend",
-          "cleanup"
-        ],
-        "outcome": [
-          "claimed",
-          "reused",
-          "resumed",
-          "released",
-          "suspended",
-          "failed",
-          "orphan-cleaned",
-          "observed"
-        ]
-      },
-      "cardinality_bound": 40
-    },
-    "curie.sandbox.claim.duration": {
-      "type": "histogram",
-      "unit": "s",
-      "description": "Sandbox claim duration.",
-      "monotonic": false,
-      "attributes": {
-        "service.name": [
-          "curie-worker"
-        ],
-        "operation": [
-          "claim",
-          "resume",
-          "release",
-          "suspend",
-          "cleanup"
-        ],
-        "outcome": [
-          "claimed",
-          "reused",
-          "resumed",
-          "released",
-          "suspended",
-          "failed",
-          "orphan-cleaned",
-          "observed"
-        ]
-      },
-      "cardinality_bound": 40
-    },
-    "curie.sandbox.resume.duration": {
-      "type": "histogram",
-      "unit": "s",
-      "description": "Sandbox resume duration.",
-      "monotonic": false,
-      "attributes": {
-        "service.name": [
-          "curie-worker"
-        ],
-        "operation": [
-          "claim",
-          "resume",
-          "release",
-          "suspend",
-          "cleanup"
-        ],
-        "outcome": [
-          "claimed",
-          "reused",
-          "resumed",
-          "released",
-          "suspended",
-          "failed",
-          "orphan-cleaned",
-          "observed"
-        ]
-      },
-      "cardinality_bound": 40
-    },
-    "curie.sandbox.release.duration": {
-      "type": "histogram",
-      "unit": "s",
-      "description": "Sandbox release duration.",
-      "monotonic": false,
-      "attributes": {
-        "service.name": [
-          "curie-worker"
-        ],
-        "operation": [
-          "claim",
-          "resume",
-          "release",
-          "suspend",
-          "cleanup"
-        ],
-        "outcome": [
-          "claimed",
-          "reused",
-          "resumed",
-          "released",
-          "suspended",
-          "failed",
-          "orphan-cleaned",
-          "observed"
-        ]
-      },
-      "cardinality_bound": 40
-    },
-    "curie.sandbox.active": {
-      "type": "gauge",
-      "unit": "{sandbox}",
-      "description": "Active sandboxes.",
-      "monotonic": false,
-      "attributes": {
-        "service.name": [
-          "curie-worker"
-        ],
-        "operation": [
-          "observe"
-        ],
-        "outcome": [
-          "observed"
-        ]
-      },
-      "cardinality_bound": 1
-    },
-    "curie.sandbox.suspended": {
-      "type": "gauge",
-      "unit": "{sandbox}",
-      "description": "Suspended sandboxes.",
-      "monotonic": false,
-      "attributes": {
-        "service.name": [
-          "curie-worker"
-        ],
-        "operation": [
-          "observe"
-        ],
-        "outcome": [
-          "observed"
-        ]
-      },
-      "cardinality_bound": 1
-    },
-    "curie.sandbox.cleanup": {
-      "type": "counter",
-      "unit": "{sandbox}",
-      "description": "Failed and orphan sandbox cleanup.",
-      "monotonic": true,
-      "attributes": {
-        "service.name": [
-          "curie-worker"
-        ],
-        "operation": [
-          "claim",
-          "resume",
-          "release",
-          "suspend",
-          "cleanup"
-        ],
-        "outcome": [
-          "claimed",
-          "reused",
-          "resumed",
-          "released",
-          "suspended",
-          "failed",
-          "orphan-cleaned",
-          "observed"
-        ]
-      },
-      "cardinality_bound": 40
-    },
-    "curie.runner.rpc.request.duration": {
-      "type": "histogram",
-      "unit": "s",
-      "description": "Runner RPC request duration.",
-      "monotonic": false,
-      "attributes": {
-        "service.name": [
-          "curie-worker"
-        ],
-        "operation": [
-          "event",
-          "steer",
-          "interrupt",
-          "reset",
-          "status"
-        ],
-        "role": [
-          "client"
-        ],
-        "outcome": [
-          "success",
-          "failure",
-          "conflict",
-          "timeout"
-        ]
-      },
-      "cardinality_bound": 20
-    },
-    "curie.runner.rpc.result": {
-      "type": "counter",
-      "unit": "{request}",
-      "description": "Runner RPC outcomes.",
-      "monotonic": true,
-      "attributes": {
-        "service.name": [
-          "curie-worker"
-        ],
-        "operation": [
-          "event",
-          "steer",
-          "interrupt",
-          "reset",
-          "status"
-        ],
-        "role": [
-          "client"
-        ],
-        "outcome": [
-          "success",
-          "failure",
-          "conflict",
-          "timeout"
-        ]
-      },
-      "cardinality_bound": 20
-    },
     "curie.approval.lifecycle": {
-      "type": "counter",
-      "unit": "{approval}",
-      "description": "Approval lifecycle outcomes.",
-      "monotonic": true,
       "attributes": {
-        "service.name": [
-          "curie-api",
-          "curie-worker"
-        ],
         "operation": [
           "request",
           "resolve",
@@ -759,469 +19,56 @@
           "pending",
           "observed",
           "failure"
-        ]
-      },
-      "cardinality_bound": 96
-    },
-    "curie.approval.pending": {
-      "type": "gauge",
-      "unit": "{approval}",
-      "description": "Pending approvals.",
-      "monotonic": false,
-      "attributes": {
-        "service.name": [
-          "curie-api"
         ],
-        "operation": [
-          "observe"
-        ],
-        "outcome": [
-          "pending"
-        ]
-      },
-      "cardinality_bound": 1
-    },
-    "curie.approval.pending.age": {
-      "type": "gauge",
-      "unit": "s",
-      "description": "Age of the oldest pending approval.",
-      "monotonic": false,
-      "attributes": {
-        "service.name": [
-          "curie-api"
-        ],
-        "operation": [
-          "observe"
-        ],
-        "outcome": [
-          "pending"
-        ]
-      },
-      "cardinality_bound": 1
-    },
-    "curie.reply.delivery": {
-      "type": "counter",
-      "unit": "{reply}",
-      "description": "Reply delivery outcomes.",
-      "monotonic": true,
-      "attributes": {
-        "service.name": [
-          "curie-worker"
-        ],
-        "operation": [
-          "update",
-          "post"
-        ],
-        "role": [
-          "client"
-        ],
-        "outcome": [
-          "success",
-          "failure",
-          "best-effort",
-          "retry",
-          "rate-limited"
-        ]
-      },
-      "cardinality_bound": 10
-    },
-    "curie.reply.update.duration": {
-      "type": "histogram",
-      "unit": "s",
-      "description": "Reply update duration.",
-      "monotonic": false,
-      "attributes": {
-        "service.name": [
-          "curie-worker"
-        ],
-        "operation": [
-          "update",
-          "post"
-        ],
-        "role": [
-          "client"
-        ],
-        "outcome": [
-          "success",
-          "failure",
-          "best-effort",
-          "retry",
-          "rate-limited"
-        ]
-      },
-      "cardinality_bound": 10
-    },
-    "curie.reply.post.duration": {
-      "type": "histogram",
-      "unit": "s",
-      "description": "Reply post duration.",
-      "monotonic": false,
-      "attributes": {
-        "service.name": [
-          "curie-worker"
-        ],
-        "operation": [
-          "update",
-          "post"
-        ],
-        "role": [
-          "client"
-        ],
-        "outcome": [
-          "success",
-          "failure",
-          "best-effort",
-          "retry",
-          "rate-limited"
-        ]
-      },
-      "cardinality_bound": 10
-    },
-    "curie.reply.retry": {
-      "type": "counter",
-      "unit": "{retry}",
-      "description": "Reply delivery retries.",
-      "monotonic": true,
-      "attributes": {
-        "service.name": [
-          "curie-worker"
-        ],
-        "operation": [
-          "update",
-          "post"
-        ],
-        "role": [
-          "client"
-        ],
-        "retry_class": [
-          "block-fallback",
-          "rate-limit",
-          "transport-fallback"
-        ]
-      },
-      "cardinality_bound": 6
-    },
-    "curie.http.server.request": {
-      "type": "counter",
-      "unit": "{request}",
-      "description": "HTTP server requests.",
-      "monotonic": true,
-      "attributes": {
-        "service.name": [
-          "curie-api"
-        ],
-        "operation": [
-          "/actions",
-          "/actions/{action_id}",
-          "/actions/{action_id}/audit",
-          "/actions/{action_id}/complete",
-          "/actions/{action_id}/undo",
-          "/agents",
-          "/agents/{agent_id}",
-          "/agents/{agent_id}/behavior-packs",
-          "/agents/{agent_id}/budget",
-          "/agents/{agent_id}/channels",
-          "/agents/{agent_id}/cost",
-          "/agents/{agent_id}/kill",
-          "/agents/{agent_id}/memory",
-          "/agents/{agent_id}/memory/{index}",
-          "/agents/{agent_id}/memory/{index}/provenance",
-          "/agents/{agent_id}/resume",
-          "/agents/{agent_id}/state",
-          "/agents/{agent_id}/state/bindings/{kind}/{address}",
-          "/agents/{agent_id}/state/bindings/{kind}/{address}/{namespace}",
-          "/agents/{agent_id}/state/bindings/{kind}/{address}/{namespace}/{key}",
-          "/agents/{agent_id}/state/bindings/{kind}/{address}/{namespace}/{key}/append",
-          "/agents/{agent_id}/state/{namespace}",
-          "/agents/{agent_id}/state/{namespace}/{key}",
-          "/agents/{agent_id}/state/{namespace}/{key}/append",
-          "/agents/{agent_id}/threads/{thread_key}/reset",
-          "/agents/{agent_id}/versions",
-          "/agents/{agent_id}/versions/{version_id}/bundle",
-          "/agents/{agent_id}/versions/{version_id}/connectors",
-          "/agents/{agent_id}/versions/{version_id}/files",
-          "/approvals",
-          "/approvals/principals/operator",
-          "/approvals/{approval_id}",
-          "/approvals/{approval_id}/audit",
-          "/approvals/{approval_id}/resolve",
-          "/channels/token",
-          "/channels/turns",
-          "/cluster-message-replies/{reply_ref}",
-          "/config",
-          "/console/login-codes",
-          "/console/session",
-          "/deploy-targets/list",
-          "/deploy-targets/resolve",
-          "/deployments",
-          "/deployments/{deployment_id}",
-          "/evals/matrix",
-          "/evals/report",
-          "/evals/trigger",
-          "/git-flow/routing-check",
-          "/github/webhook",
-          "/health",
-          "/hooks/{agent_id}/{hook}",
-          "/langfuse/traces",
-          "/langfuse/traces/{trace_id}",
-          "/langfuse/traces/{trace_id}/eval-case",
-          "/openapi.json",
-          "/docs",
-          "/docs/oauth2-redirect",
-          "/redoc",
-          "/observability/metrics/series",
-          "/observability/metrics/summary",
-          "/observability/runners",
-          "/observability/runners/{namespace}/{pod}/logs",
-          "/publications",
-          "/publications/{publication_id}",
-          "/v1/internal/cluster-message-replies/{reply_ref}",
-          "/v1/internal/publications",
-          "/v1/internal/publications/lineage",
-          "/v1/internal/publications/{publication_id}/lineage",
-          "/v1/internal/publications/{publication_id}/credential",
-          "/v1/internal/workspaces/{deployment_id}/credential",
-          "/v1/internal/workspaces/{deployment_id}/selection",
-          "unmatched"
-        ],
-        "role": [
-          "server"
-        ],
-        "source": [
-          "GET",
-          "POST",
-          "PUT",
-          "PATCH",
-          "DELETE",
-          "OPTIONS",
-          "HEAD",
-          "OTHER"
-        ],
-        "outcome": [
-          "1xx",
-          "2xx",
-          "3xx",
-          "4xx",
-          "5xx"
-        ]
-      },
-      "cardinality_bound": 2880
-    },
-    "curie.http.server.request.duration": {
-      "type": "histogram",
-      "unit": "s",
-      "description": "HTTP server request duration.",
-      "monotonic": false,
-      "attributes": {
-        "service.name": [
-          "curie-api"
-        ],
-        "operation": [
-          "/actions",
-          "/actions/{action_id}",
-          "/actions/{action_id}/audit",
-          "/actions/{action_id}/complete",
-          "/actions/{action_id}/undo",
-          "/agents",
-          "/agents/{agent_id}",
-          "/agents/{agent_id}/behavior-packs",
-          "/agents/{agent_id}/budget",
-          "/agents/{agent_id}/channels",
-          "/agents/{agent_id}/cost",
-          "/agents/{agent_id}/kill",
-          "/agents/{agent_id}/memory",
-          "/agents/{agent_id}/memory/{index}",
-          "/agents/{agent_id}/memory/{index}/provenance",
-          "/agents/{agent_id}/resume",
-          "/agents/{agent_id}/state",
-          "/agents/{agent_id}/state/bindings/{kind}/{address}",
-          "/agents/{agent_id}/state/bindings/{kind}/{address}/{namespace}",
-          "/agents/{agent_id}/state/bindings/{kind}/{address}/{namespace}/{key}",
-          "/agents/{agent_id}/state/bindings/{kind}/{address}/{namespace}/{key}/append",
-          "/agents/{agent_id}/state/{namespace}",
-          "/agents/{agent_id}/state/{namespace}/{key}",
-          "/agents/{agent_id}/state/{namespace}/{key}/append",
-          "/agents/{agent_id}/threads/{thread_key}/reset",
-          "/agents/{agent_id}/versions",
-          "/agents/{agent_id}/versions/{version_id}/bundle",
-          "/agents/{agent_id}/versions/{version_id}/connectors",
-          "/agents/{agent_id}/versions/{version_id}/files",
-          "/approvals",
-          "/approvals/principals/operator",
-          "/approvals/{approval_id}",
-          "/approvals/{approval_id}/audit",
-          "/approvals/{approval_id}/resolve",
-          "/channels/token",
-          "/channels/turns",
-          "/cluster-message-replies/{reply_ref}",
-          "/config",
-          "/console/login-codes",
-          "/console/session",
-          "/deploy-targets/list",
-          "/deploy-targets/resolve",
-          "/deployments",
-          "/deployments/{deployment_id}",
-          "/evals/matrix",
-          "/evals/report",
-          "/evals/trigger",
-          "/git-flow/routing-check",
-          "/github/webhook",
-          "/health",
-          "/hooks/{agent_id}/{hook}",
-          "/langfuse/traces",
-          "/langfuse/traces/{trace_id}",
-          "/langfuse/traces/{trace_id}/eval-case",
-          "/openapi.json",
-          "/docs",
-          "/docs/oauth2-redirect",
-          "/redoc",
-          "/observability/metrics/series",
-          "/observability/metrics/summary",
-          "/observability/runners",
-          "/observability/runners/{namespace}/{pod}/logs",
-          "/publications",
-          "/publications/{publication_id}",
-          "/v1/internal/cluster-message-replies/{reply_ref}",
-          "/v1/internal/publications",
-          "/v1/internal/publications/lineage",
-          "/v1/internal/publications/{publication_id}/lineage",
-          "/v1/internal/publications/{publication_id}/credential",
-          "/v1/internal/workspaces/{deployment_id}/credential",
-          "/v1/internal/workspaces/{deployment_id}/selection",
-          "unmatched"
-        ],
-        "role": [
-          "server"
-        ],
-        "source": [
-          "GET",
-          "POST",
-          "PUT",
-          "PATCH",
-          "DELETE",
-          "OPTIONS",
-          "HEAD",
-          "OTHER"
-        ],
-        "outcome": [
-          "1xx",
-          "2xx",
-          "3xx",
-          "4xx",
-          "5xx"
-        ]
-      },
-      "cardinality_bound": 2880
-    },
-    "curie.http.server.active": {
-      "type": "up_down_counter",
-      "unit": "{request}",
-      "description": "Active HTTP server requests.",
-      "monotonic": false,
-      "attributes": {
-        "service.name": [
-          "curie-api"
-        ],
-        "operation": [
-          "/actions",
-          "/actions/{action_id}",
-          "/actions/{action_id}/audit",
-          "/actions/{action_id}/complete",
-          "/actions/{action_id}/undo",
-          "/agents",
-          "/agents/{agent_id}",
-          "/agents/{agent_id}/behavior-packs",
-          "/agents/{agent_id}/budget",
-          "/agents/{agent_id}/channels",
-          "/agents/{agent_id}/cost",
-          "/agents/{agent_id}/kill",
-          "/agents/{agent_id}/memory",
-          "/agents/{agent_id}/memory/{index}",
-          "/agents/{agent_id}/memory/{index}/provenance",
-          "/agents/{agent_id}/resume",
-          "/agents/{agent_id}/state",
-          "/agents/{agent_id}/state/bindings/{kind}/{address}",
-          "/agents/{agent_id}/state/bindings/{kind}/{address}/{namespace}",
-          "/agents/{agent_id}/state/bindings/{kind}/{address}/{namespace}/{key}",
-          "/agents/{agent_id}/state/bindings/{kind}/{address}/{namespace}/{key}/append",
-          "/agents/{agent_id}/state/{namespace}",
-          "/agents/{agent_id}/state/{namespace}/{key}",
-          "/agents/{agent_id}/state/{namespace}/{key}/append",
-          "/agents/{agent_id}/threads/{thread_key}/reset",
-          "/agents/{agent_id}/versions",
-          "/agents/{agent_id}/versions/{version_id}/bundle",
-          "/agents/{agent_id}/versions/{version_id}/connectors",
-          "/agents/{agent_id}/versions/{version_id}/files",
-          "/approvals",
-          "/approvals/principals/operator",
-          "/approvals/{approval_id}",
-          "/approvals/{approval_id}/audit",
-          "/approvals/{approval_id}/resolve",
-          "/channels/token",
-          "/channels/turns",
-          "/cluster-message-replies/{reply_ref}",
-          "/config",
-          "/console/login-codes",
-          "/console/session",
-          "/deploy-targets/list",
-          "/deploy-targets/resolve",
-          "/deployments",
-          "/deployments/{deployment_id}",
-          "/evals/matrix",
-          "/evals/report",
-          "/evals/trigger",
-          "/git-flow/routing-check",
-          "/github/webhook",
-          "/health",
-          "/hooks/{agent_id}/{hook}",
-          "/langfuse/traces",
-          "/langfuse/traces/{trace_id}",
-          "/langfuse/traces/{trace_id}/eval-case",
-          "/openapi.json",
-          "/docs",
-          "/docs/oauth2-redirect",
-          "/redoc",
-          "/observability/metrics/series",
-          "/observability/metrics/summary",
-          "/observability/runners",
-          "/observability/runners/{namespace}/{pod}/logs",
-          "/publications",
-          "/publications/{publication_id}",
-          "/v1/internal/cluster-message-replies/{reply_ref}",
-          "/v1/internal/publications",
-          "/v1/internal/publications/lineage",
-          "/v1/internal/publications/{publication_id}/lineage",
-          "/v1/internal/publications/{publication_id}/credential",
-          "/v1/internal/workspaces/{deployment_id}/credential",
-          "/v1/internal/workspaces/{deployment_id}/selection",
-          "unmatched"
-        ],
-        "role": [
-          "server"
-        ],
-        "source": [
-          "GET",
-          "POST",
-          "PUT",
-          "PATCH",
-          "DELETE",
-          "OPTIONS",
-          "HEAD",
-          "OTHER"
-        ]
-      },
-      "cardinality_bound": 576
-    },
-    "curie.background.loop": {
-      "type": "counter",
-      "unit": "{run}",
-      "description": "Background loop pass outcomes.",
-      "monotonic": true,
-      "attributes": {
         "service.name": [
           "curie-api",
           "curie-worker"
+        ]
+      },
+      "cardinality_bound": 96,
+      "description": "Approval lifecycle outcomes.",
+      "monotonic": true,
+      "type": "counter",
+      "unit": "{approval}"
+    },
+    "curie.approval.pending": {
+      "attributes": {
+        "operation": [
+          "observe"
         ],
+        "outcome": [
+          "pending"
+        ],
+        "service.name": [
+          "curie-api"
+        ]
+      },
+      "cardinality_bound": 1,
+      "description": "Pending approvals.",
+      "monotonic": false,
+      "type": "gauge",
+      "unit": "{approval}"
+    },
+    "curie.approval.pending.age": {
+      "attributes": {
+        "operation": [
+          "observe"
+        ],
+        "outcome": [
+          "pending"
+        ],
+        "service.name": [
+          "curie-api"
+        ]
+      },
+      "cardinality_bound": 1,
+      "description": "Age of the oldest pending approval.",
+      "monotonic": false,
+      "type": "gauge",
+      "unit": "s"
+    },
+    "curie.background.last_success.age": {
+      "attributes": {
         "operation": [
           "resume-reconciler",
           "approval-sweeper",
@@ -1231,57 +78,1216 @@
         ],
         "role": [
           "background"
+        ],
+        "service.name": [
+          "curie-api",
+          "curie-worker"
+        ]
+      },
+      "cardinality_bound": 10,
+      "description": "Age of the last successful background pass.",
+      "monotonic": false,
+      "type": "gauge",
+      "unit": "s"
+    },
+    "curie.background.loop": {
+      "attributes": {
+        "operation": [
+          "resume-reconciler",
+          "approval-sweeper",
+          "graveyard-watcher",
+          "commit-poller",
+          "connector-reconciler"
         ],
         "outcome": [
           "success",
           "failure",
           "observed"
-        ]
-      },
-      "cardinality_bound": 30
-    },
-    "curie.background.last_success.age": {
-      "type": "gauge",
-      "unit": "s",
-      "description": "Age of the last successful background pass.",
-      "monotonic": false,
-      "attributes": {
-        "service.name": [
-          "curie-api",
-          "curie-worker"
-        ],
-        "operation": [
-          "resume-reconciler",
-          "approval-sweeper",
-          "graveyard-watcher",
-          "commit-poller",
-          "connector-reconciler"
         ],
         "role": [
           "background"
+        ],
+        "service.name": [
+          "curie-api",
+          "curie-worker"
         ]
       },
-      "cardinality_bound": 10
+      "cardinality_bound": 30,
+      "description": "Background loop pass outcomes.",
+      "monotonic": true,
+      "type": "counter",
+      "unit": "{run}"
     },
     "curie.eval.process": {
-      "type": "counter",
-      "unit": "{job}",
-      "description": "Eval processing outcomes.",
-      "monotonic": true,
       "attributes": {
+        "outcome": [
+          "success",
+          "failure",
+          "plumbing"
+        ],
         "service.name": [
           "curie-worker"
         ],
         "source": [
           "eval"
+        ]
+      },
+      "cardinality_bound": 3,
+      "description": "Eval processing outcomes.",
+      "monotonic": true,
+      "type": "counter",
+      "unit": "{job}"
+    },
+    "curie.history.resume.cache_read": {
+      "attributes": {
+        "cache_hit": [
+          "true",
+          "false"
+        ],
+        "service.name": [
+          "curie-runner"
+        ],
+        "source": [
+          "runner"
+        ]
+      },
+      "cardinality_bound": 2,
+      "description": "Provider cache read input tokens on the first turn after structured replay.",
+      "monotonic": false,
+      "type": "histogram",
+      "unit": "{token}"
+    },
+    "curie.http.server.active": {
+      "attributes": {
+        "operation": [
+          "/actions",
+          "/actions/{action_id}",
+          "/actions/{action_id}/audit",
+          "/actions/{action_id}/complete",
+          "/actions/{action_id}/undo",
+          "/agents",
+          "/agents/{agent_id}",
+          "/agents/{agent_id}/behavior-packs",
+          "/agents/{agent_id}/budget",
+          "/agents/{agent_id}/channels",
+          "/agents/{agent_id}/cost",
+          "/agents/{agent_id}/kill",
+          "/agents/{agent_id}/memory",
+          "/agents/{agent_id}/memory/{index}",
+          "/agents/{agent_id}/memory/{index}/provenance",
+          "/agents/{agent_id}/resume",
+          "/agents/{agent_id}/state",
+          "/agents/{agent_id}/state/bindings/{kind}/{address}",
+          "/agents/{agent_id}/state/bindings/{kind}/{address}/{namespace}",
+          "/agents/{agent_id}/state/bindings/{kind}/{address}/{namespace}/{key}",
+          "/agents/{agent_id}/state/bindings/{kind}/{address}/{namespace}/{key}/append",
+          "/agents/{agent_id}/state/{namespace}",
+          "/agents/{agent_id}/state/{namespace}/{key}",
+          "/agents/{agent_id}/state/{namespace}/{key}/append",
+          "/agents/{agent_id}/threads/{thread_key}/reset",
+          "/agents/{agent_id}/versions",
+          "/agents/{agent_id}/versions/{version_id}/bundle",
+          "/agents/{agent_id}/versions/{version_id}/connectors",
+          "/agents/{agent_id}/versions/{version_id}/files",
+          "/approvals",
+          "/approvals/principals/operator",
+          "/approvals/{approval_id}",
+          "/approvals/{approval_id}/audit",
+          "/approvals/{approval_id}/resolve",
+          "/channels/token",
+          "/channels/turns",
+          "/cluster-message-replies/{reply_ref}",
+          "/config",
+          "/console/login-codes",
+          "/console/session",
+          "/deploy-targets/list",
+          "/deploy-targets/resolve",
+          "/deployments",
+          "/deployments/{deployment_id}",
+          "/evals/matrix",
+          "/evals/report",
+          "/evals/trigger",
+          "/git-flow/routing-check",
+          "/github/webhook",
+          "/health",
+          "/hooks/{agent_id}/{hook}",
+          "/langfuse/traces",
+          "/langfuse/traces/{trace_id}",
+          "/langfuse/traces/{trace_id}/eval-case",
+          "/openapi.json",
+          "/docs",
+          "/docs/oauth2-redirect",
+          "/redoc",
+          "/observability/metrics/series",
+          "/observability/metrics/summary",
+          "/observability/runners",
+          "/observability/runners/{namespace}/{pod}/logs",
+          "/publications",
+          "/publications/{publication_id}",
+          "/v1/internal/cluster-message-replies/{reply_ref}",
+          "/v1/internal/publications",
+          "/v1/internal/publications/lineage",
+          "/v1/internal/publications/review-reservations",
+          "/v1/internal/publications/review-reservations/{reservation_id}/cancel",
+          "/v1/internal/publications/{publication_id}/lineage",
+          "/v1/internal/publications/{publication_id}/credential",
+          "/v1/internal/workspaces/{deployment_id}/credential",
+          "/v1/internal/workspaces/{deployment_id}/selection",
+          "unmatched"
+        ],
+        "role": [
+          "server"
+        ],
+        "service.name": [
+          "curie-api"
+        ],
+        "source": [
+          "GET",
+          "POST",
+          "PUT",
+          "PATCH",
+          "DELETE",
+          "OPTIONS",
+          "HEAD",
+          "OTHER"
+        ]
+      },
+      "cardinality_bound": 592,
+      "description": "Active HTTP server requests.",
+      "monotonic": false,
+      "type": "up_down_counter",
+      "unit": "{request}"
+    },
+    "curie.http.server.request": {
+      "attributes": {
+        "operation": [
+          "/actions",
+          "/actions/{action_id}",
+          "/actions/{action_id}/audit",
+          "/actions/{action_id}/complete",
+          "/actions/{action_id}/undo",
+          "/agents",
+          "/agents/{agent_id}",
+          "/agents/{agent_id}/behavior-packs",
+          "/agents/{agent_id}/budget",
+          "/agents/{agent_id}/channels",
+          "/agents/{agent_id}/cost",
+          "/agents/{agent_id}/kill",
+          "/agents/{agent_id}/memory",
+          "/agents/{agent_id}/memory/{index}",
+          "/agents/{agent_id}/memory/{index}/provenance",
+          "/agents/{agent_id}/resume",
+          "/agents/{agent_id}/state",
+          "/agents/{agent_id}/state/bindings/{kind}/{address}",
+          "/agents/{agent_id}/state/bindings/{kind}/{address}/{namespace}",
+          "/agents/{agent_id}/state/bindings/{kind}/{address}/{namespace}/{key}",
+          "/agents/{agent_id}/state/bindings/{kind}/{address}/{namespace}/{key}/append",
+          "/agents/{agent_id}/state/{namespace}",
+          "/agents/{agent_id}/state/{namespace}/{key}",
+          "/agents/{agent_id}/state/{namespace}/{key}/append",
+          "/agents/{agent_id}/threads/{thread_key}/reset",
+          "/agents/{agent_id}/versions",
+          "/agents/{agent_id}/versions/{version_id}/bundle",
+          "/agents/{agent_id}/versions/{version_id}/connectors",
+          "/agents/{agent_id}/versions/{version_id}/files",
+          "/approvals",
+          "/approvals/principals/operator",
+          "/approvals/{approval_id}",
+          "/approvals/{approval_id}/audit",
+          "/approvals/{approval_id}/resolve",
+          "/channels/token",
+          "/channels/turns",
+          "/cluster-message-replies/{reply_ref}",
+          "/config",
+          "/console/login-codes",
+          "/console/session",
+          "/deploy-targets/list",
+          "/deploy-targets/resolve",
+          "/deployments",
+          "/deployments/{deployment_id}",
+          "/evals/matrix",
+          "/evals/report",
+          "/evals/trigger",
+          "/git-flow/routing-check",
+          "/github/webhook",
+          "/health",
+          "/hooks/{agent_id}/{hook}",
+          "/langfuse/traces",
+          "/langfuse/traces/{trace_id}",
+          "/langfuse/traces/{trace_id}/eval-case",
+          "/openapi.json",
+          "/docs",
+          "/docs/oauth2-redirect",
+          "/redoc",
+          "/observability/metrics/series",
+          "/observability/metrics/summary",
+          "/observability/runners",
+          "/observability/runners/{namespace}/{pod}/logs",
+          "/publications",
+          "/publications/{publication_id}",
+          "/v1/internal/cluster-message-replies/{reply_ref}",
+          "/v1/internal/publications",
+          "/v1/internal/publications/lineage",
+          "/v1/internal/publications/review-reservations",
+          "/v1/internal/publications/review-reservations/{reservation_id}/cancel",
+          "/v1/internal/publications/{publication_id}/lineage",
+          "/v1/internal/publications/{publication_id}/credential",
+          "/v1/internal/workspaces/{deployment_id}/credential",
+          "/v1/internal/workspaces/{deployment_id}/selection",
+          "unmatched"
+        ],
+        "outcome": [
+          "1xx",
+          "2xx",
+          "3xx",
+          "4xx",
+          "5xx"
+        ],
+        "role": [
+          "server"
+        ],
+        "service.name": [
+          "curie-api"
+        ],
+        "source": [
+          "GET",
+          "POST",
+          "PUT",
+          "PATCH",
+          "DELETE",
+          "OPTIONS",
+          "HEAD",
+          "OTHER"
+        ]
+      },
+      "cardinality_bound": 2960,
+      "description": "HTTP server requests.",
+      "monotonic": true,
+      "type": "counter",
+      "unit": "{request}"
+    },
+    "curie.http.server.request.duration": {
+      "attributes": {
+        "operation": [
+          "/actions",
+          "/actions/{action_id}",
+          "/actions/{action_id}/audit",
+          "/actions/{action_id}/complete",
+          "/actions/{action_id}/undo",
+          "/agents",
+          "/agents/{agent_id}",
+          "/agents/{agent_id}/behavior-packs",
+          "/agents/{agent_id}/budget",
+          "/agents/{agent_id}/channels",
+          "/agents/{agent_id}/cost",
+          "/agents/{agent_id}/kill",
+          "/agents/{agent_id}/memory",
+          "/agents/{agent_id}/memory/{index}",
+          "/agents/{agent_id}/memory/{index}/provenance",
+          "/agents/{agent_id}/resume",
+          "/agents/{agent_id}/state",
+          "/agents/{agent_id}/state/bindings/{kind}/{address}",
+          "/agents/{agent_id}/state/bindings/{kind}/{address}/{namespace}",
+          "/agents/{agent_id}/state/bindings/{kind}/{address}/{namespace}/{key}",
+          "/agents/{agent_id}/state/bindings/{kind}/{address}/{namespace}/{key}/append",
+          "/agents/{agent_id}/state/{namespace}",
+          "/agents/{agent_id}/state/{namespace}/{key}",
+          "/agents/{agent_id}/state/{namespace}/{key}/append",
+          "/agents/{agent_id}/threads/{thread_key}/reset",
+          "/agents/{agent_id}/versions",
+          "/agents/{agent_id}/versions/{version_id}/bundle",
+          "/agents/{agent_id}/versions/{version_id}/connectors",
+          "/agents/{agent_id}/versions/{version_id}/files",
+          "/approvals",
+          "/approvals/principals/operator",
+          "/approvals/{approval_id}",
+          "/approvals/{approval_id}/audit",
+          "/approvals/{approval_id}/resolve",
+          "/channels/token",
+          "/channels/turns",
+          "/cluster-message-replies/{reply_ref}",
+          "/config",
+          "/console/login-codes",
+          "/console/session",
+          "/deploy-targets/list",
+          "/deploy-targets/resolve",
+          "/deployments",
+          "/deployments/{deployment_id}",
+          "/evals/matrix",
+          "/evals/report",
+          "/evals/trigger",
+          "/git-flow/routing-check",
+          "/github/webhook",
+          "/health",
+          "/hooks/{agent_id}/{hook}",
+          "/langfuse/traces",
+          "/langfuse/traces/{trace_id}",
+          "/langfuse/traces/{trace_id}/eval-case",
+          "/openapi.json",
+          "/docs",
+          "/docs/oauth2-redirect",
+          "/redoc",
+          "/observability/metrics/series",
+          "/observability/metrics/summary",
+          "/observability/runners",
+          "/observability/runners/{namespace}/{pod}/logs",
+          "/publications",
+          "/publications/{publication_id}",
+          "/v1/internal/cluster-message-replies/{reply_ref}",
+          "/v1/internal/publications",
+          "/v1/internal/publications/lineage",
+          "/v1/internal/publications/review-reservations",
+          "/v1/internal/publications/review-reservations/{reservation_id}/cancel",
+          "/v1/internal/publications/{publication_id}/lineage",
+          "/v1/internal/publications/{publication_id}/credential",
+          "/v1/internal/workspaces/{deployment_id}/credential",
+          "/v1/internal/workspaces/{deployment_id}/selection",
+          "unmatched"
+        ],
+        "outcome": [
+          "1xx",
+          "2xx",
+          "3xx",
+          "4xx",
+          "5xx"
+        ],
+        "role": [
+          "server"
+        ],
+        "service.name": [
+          "curie-api"
+        ],
+        "source": [
+          "GET",
+          "POST",
+          "PUT",
+          "PATCH",
+          "DELETE",
+          "OPTIONS",
+          "HEAD",
+          "OTHER"
+        ]
+      },
+      "cardinality_bound": 2960,
+      "description": "HTTP server request duration.",
+      "monotonic": false,
+      "type": "histogram",
+      "unit": "s"
+    },
+    "curie.queue.dead_letter": {
+      "attributes": {
+        "outcome": [
+          "success",
+          "failure",
+          "pending",
+          "ack",
+          "retry",
+          "dead-letter"
+        ],
+        "service.name": [
+          "curie-api",
+          "curie-dispatcher",
+          "curie-worker"
+        ],
+        "source": [
+          "api",
+          "dispatcher",
+          "worker",
+          "local",
+          "eval"
+        ]
+      },
+      "cardinality_bound": 90,
+      "description": "Messages dead lettered.",
+      "monotonic": true,
+      "type": "counter",
+      "unit": "{message}"
+    },
+    "curie.queue.depth": {
+      "attributes": {
+        "outcome": [
+          "success",
+          "failure",
+          "pending",
+          "ack",
+          "retry",
+          "dead-letter"
+        ],
+        "service.name": [
+          "curie-api",
+          "curie-dispatcher",
+          "curie-worker"
+        ],
+        "source": [
+          "api",
+          "dispatcher",
+          "worker",
+          "local",
+          "eval"
+        ]
+      },
+      "cardinality_bound": 90,
+      "description": "Stream depth.",
+      "monotonic": false,
+      "type": "gauge",
+      "unit": "{message}"
+    },
+    "curie.queue.enqueue": {
+      "attributes": {
+        "outcome": [
+          "success",
+          "failure",
+          "pending",
+          "ack",
+          "retry",
+          "dead-letter"
+        ],
+        "service.name": [
+          "curie-api",
+          "curie-dispatcher",
+          "curie-worker"
+        ],
+        "source": [
+          "api",
+          "dispatcher",
+          "worker",
+          "local",
+          "eval"
+        ]
+      },
+      "cardinality_bound": 90,
+      "description": "Messages enqueued.",
+      "monotonic": true,
+      "type": "counter",
+      "unit": "{message}"
+    },
+    "curie.queue.lag": {
+      "attributes": {
+        "outcome": [
+          "success",
+          "failure",
+          "pending",
+          "ack",
+          "retry",
+          "dead-letter"
+        ],
+        "service.name": [
+          "curie-api",
+          "curie-dispatcher",
+          "curie-worker"
+        ],
+        "source": [
+          "api",
+          "dispatcher",
+          "worker",
+          "local",
+          "eval"
+        ]
+      },
+      "cardinality_bound": 90,
+      "description": "Consumer group lag.",
+      "monotonic": false,
+      "type": "gauge",
+      "unit": "{message}"
+    },
+    "curie.queue.message.age": {
+      "attributes": {
+        "outcome": [
+          "success",
+          "failure",
+          "pending",
+          "ack",
+          "retry",
+          "dead-letter"
+        ],
+        "service.name": [
+          "curie-api",
+          "curie-dispatcher",
+          "curie-worker"
+        ],
+        "source": [
+          "api",
+          "dispatcher",
+          "worker",
+          "local",
+          "eval"
+        ]
+      },
+      "cardinality_bound": 90,
+      "description": "Message age at processing.",
+      "monotonic": false,
+      "type": "histogram",
+      "unit": "s"
+    },
+    "curie.queue.pending": {
+      "attributes": {
+        "outcome": [
+          "success",
+          "failure",
+          "pending",
+          "ack",
+          "retry",
+          "dead-letter"
+        ],
+        "service.name": [
+          "curie-api",
+          "curie-dispatcher",
+          "curie-worker"
+        ],
+        "source": [
+          "api",
+          "dispatcher",
+          "worker",
+          "local",
+          "eval"
+        ]
+      },
+      "cardinality_bound": 90,
+      "description": "Pending consumer group messages.",
+      "monotonic": false,
+      "type": "gauge",
+      "unit": "{message}"
+    },
+    "curie.queue.process": {
+      "attributes": {
+        "outcome": [
+          "success",
+          "failure",
+          "pending",
+          "ack",
+          "retry",
+          "dead-letter"
+        ],
+        "service.name": [
+          "curie-api",
+          "curie-dispatcher",
+          "curie-worker"
+        ],
+        "source": [
+          "api",
+          "dispatcher",
+          "worker",
+          "local",
+          "eval"
+        ]
+      },
+      "cardinality_bound": 90,
+      "description": "Messages processed.",
+      "monotonic": true,
+      "type": "counter",
+      "unit": "{message}"
+    },
+    "curie.queue.process.duration": {
+      "attributes": {
+        "outcome": [
+          "success",
+          "failure",
+          "pending",
+          "ack",
+          "retry",
+          "dead-letter"
+        ],
+        "service.name": [
+          "curie-api",
+          "curie-dispatcher",
+          "curie-worker"
+        ],
+        "source": [
+          "api",
+          "dispatcher",
+          "worker",
+          "local",
+          "eval"
+        ]
+      },
+      "cardinality_bound": 90,
+      "description": "Queue processing duration.",
+      "monotonic": false,
+      "type": "histogram",
+      "unit": "s"
+    },
+    "curie.queue.retry": {
+      "attributes": {
+        "retry_class": [
+          "redelivery",
+          "rate-limit",
+          "runner-error",
+          "runner-timeout",
+          "workspace-error"
+        ],
+        "service.name": [
+          "curie-worker"
+        ],
+        "source": [
+          "worker",
+          "eval"
+        ]
+      },
+      "cardinality_bound": 10,
+      "description": "Bounded queue redelivery and in-process turn retries.",
+      "monotonic": true,
+      "type": "counter",
+      "unit": "{retry}"
+    },
+    "curie.queue.settle": {
+      "attributes": {
+        "outcome": [
+          "success",
+          "failure",
+          "pending",
+          "ack",
+          "retry",
+          "dead-letter"
+        ],
+        "service.name": [
+          "curie-api",
+          "curie-dispatcher",
+          "curie-worker"
+        ],
+        "source": [
+          "api",
+          "dispatcher",
+          "worker",
+          "local",
+          "eval"
+        ]
+      },
+      "cardinality_bound": 90,
+      "description": "Message settlement outcomes.",
+      "monotonic": true,
+      "type": "counter",
+      "unit": "{message}"
+    },
+    "curie.queue.wait.duration": {
+      "attributes": {
+        "outcome": [
+          "success",
+          "failure",
+          "pending",
+          "ack",
+          "retry",
+          "dead-letter"
+        ],
+        "service.name": [
+          "curie-api",
+          "curie-dispatcher",
+          "curie-worker"
+        ],
+        "source": [
+          "api",
+          "dispatcher",
+          "worker",
+          "local",
+          "eval"
+        ]
+      },
+      "cardinality_bound": 90,
+      "description": "Queue wait duration.",
+      "monotonic": false,
+      "type": "histogram",
+      "unit": "s"
+    },
+    "curie.reply.delivery": {
+      "attributes": {
+        "operation": [
+          "update",
+          "post"
         ],
         "outcome": [
           "success",
           "failure",
-          "plumbing"
+          "best-effort",
+          "retry",
+          "rate-limited"
+        ],
+        "role": [
+          "client"
+        ],
+        "service.name": [
+          "curie-worker"
         ]
       },
-      "cardinality_bound": 3
+      "cardinality_bound": 10,
+      "description": "Reply delivery outcomes.",
+      "monotonic": true,
+      "type": "counter",
+      "unit": "{reply}"
+    },
+    "curie.reply.post.duration": {
+      "attributes": {
+        "operation": [
+          "update",
+          "post"
+        ],
+        "outcome": [
+          "success",
+          "failure",
+          "best-effort",
+          "retry",
+          "rate-limited"
+        ],
+        "role": [
+          "client"
+        ],
+        "service.name": [
+          "curie-worker"
+        ]
+      },
+      "cardinality_bound": 10,
+      "description": "Reply post duration.",
+      "monotonic": false,
+      "type": "histogram",
+      "unit": "s"
+    },
+    "curie.reply.retry": {
+      "attributes": {
+        "operation": [
+          "update",
+          "post"
+        ],
+        "retry_class": [
+          "block-fallback",
+          "rate-limit",
+          "transport-fallback"
+        ],
+        "role": [
+          "client"
+        ],
+        "service.name": [
+          "curie-worker"
+        ]
+      },
+      "cardinality_bound": 6,
+      "description": "Reply delivery retries.",
+      "monotonic": true,
+      "type": "counter",
+      "unit": "{retry}"
+    },
+    "curie.reply.update.duration": {
+      "attributes": {
+        "operation": [
+          "update",
+          "post"
+        ],
+        "outcome": [
+          "success",
+          "failure",
+          "best-effort",
+          "retry",
+          "rate-limited"
+        ],
+        "role": [
+          "client"
+        ],
+        "service.name": [
+          "curie-worker"
+        ]
+      },
+      "cardinality_bound": 10,
+      "description": "Reply update duration.",
+      "monotonic": false,
+      "type": "histogram",
+      "unit": "s"
+    },
+    "curie.runner.rpc.request.duration": {
+      "attributes": {
+        "operation": [
+          "event",
+          "steer",
+          "interrupt",
+          "reset",
+          "status"
+        ],
+        "outcome": [
+          "success",
+          "failure",
+          "conflict",
+          "timeout"
+        ],
+        "role": [
+          "client"
+        ],
+        "service.name": [
+          "curie-worker"
+        ]
+      },
+      "cardinality_bound": 20,
+      "description": "Runner RPC request duration.",
+      "monotonic": false,
+      "type": "histogram",
+      "unit": "s"
+    },
+    "curie.runner.rpc.result": {
+      "attributes": {
+        "operation": [
+          "event",
+          "steer",
+          "interrupt",
+          "reset",
+          "status"
+        ],
+        "outcome": [
+          "success",
+          "failure",
+          "conflict",
+          "timeout"
+        ],
+        "role": [
+          "client"
+        ],
+        "service.name": [
+          "curie-worker"
+        ]
+      },
+      "cardinality_bound": 20,
+      "description": "Runner RPC outcomes.",
+      "monotonic": true,
+      "type": "counter",
+      "unit": "{request}"
+    },
+    "curie.sandbox.active": {
+      "attributes": {
+        "operation": [
+          "observe"
+        ],
+        "outcome": [
+          "observed"
+        ],
+        "service.name": [
+          "curie-worker"
+        ]
+      },
+      "cardinality_bound": 1,
+      "description": "Active sandboxes.",
+      "monotonic": false,
+      "type": "gauge",
+      "unit": "{sandbox}"
+    },
+    "curie.sandbox.claim.duration": {
+      "attributes": {
+        "operation": [
+          "claim",
+          "resume",
+          "release",
+          "suspend",
+          "cleanup"
+        ],
+        "outcome": [
+          "claimed",
+          "reused",
+          "resumed",
+          "released",
+          "suspended",
+          "failed",
+          "orphan-cleaned",
+          "observed"
+        ],
+        "service.name": [
+          "curie-worker"
+        ]
+      },
+      "cardinality_bound": 40,
+      "description": "Sandbox claim duration.",
+      "monotonic": false,
+      "type": "histogram",
+      "unit": "s"
+    },
+    "curie.sandbox.cleanup": {
+      "attributes": {
+        "operation": [
+          "claim",
+          "resume",
+          "release",
+          "suspend",
+          "cleanup"
+        ],
+        "outcome": [
+          "claimed",
+          "reused",
+          "resumed",
+          "released",
+          "suspended",
+          "failed",
+          "orphan-cleaned",
+          "observed"
+        ],
+        "service.name": [
+          "curie-worker"
+        ]
+      },
+      "cardinality_bound": 40,
+      "description": "Failed and orphan sandbox cleanup.",
+      "monotonic": true,
+      "type": "counter",
+      "unit": "{sandbox}"
+    },
+    "curie.sandbox.lifecycle": {
+      "attributes": {
+        "operation": [
+          "claim",
+          "resume",
+          "release",
+          "suspend",
+          "cleanup"
+        ],
+        "outcome": [
+          "claimed",
+          "reused",
+          "resumed",
+          "released",
+          "suspended",
+          "failed",
+          "orphan-cleaned",
+          "observed"
+        ],
+        "service.name": [
+          "curie-worker"
+        ]
+      },
+      "cardinality_bound": 40,
+      "description": "Sandbox lifecycle outcomes.",
+      "monotonic": true,
+      "type": "counter",
+      "unit": "{operation}"
+    },
+    "curie.sandbox.release.duration": {
+      "attributes": {
+        "operation": [
+          "claim",
+          "resume",
+          "release",
+          "suspend",
+          "cleanup"
+        ],
+        "outcome": [
+          "claimed",
+          "reused",
+          "resumed",
+          "released",
+          "suspended",
+          "failed",
+          "orphan-cleaned",
+          "observed"
+        ],
+        "service.name": [
+          "curie-worker"
+        ]
+      },
+      "cardinality_bound": 40,
+      "description": "Sandbox release duration.",
+      "monotonic": false,
+      "type": "histogram",
+      "unit": "s"
+    },
+    "curie.sandbox.resume.duration": {
+      "attributes": {
+        "operation": [
+          "claim",
+          "resume",
+          "release",
+          "suspend",
+          "cleanup"
+        ],
+        "outcome": [
+          "claimed",
+          "reused",
+          "resumed",
+          "released",
+          "suspended",
+          "failed",
+          "orphan-cleaned",
+          "observed"
+        ],
+        "service.name": [
+          "curie-worker"
+        ]
+      },
+      "cardinality_bound": 40,
+      "description": "Sandbox resume duration.",
+      "monotonic": false,
+      "type": "histogram",
+      "unit": "s"
+    },
+    "curie.sandbox.suspended": {
+      "attributes": {
+        "operation": [
+          "observe"
+        ],
+        "outcome": [
+          "observed"
+        ],
+        "service.name": [
+          "curie-worker"
+        ]
+      },
+      "cardinality_bound": 1,
+      "description": "Suspended sandboxes.",
+      "monotonic": false,
+      "type": "gauge",
+      "unit": "{sandbox}"
+    },
+    "curie.thread.lock.wait.duration": {
+      "attributes": {
+        "outcome": [
+          "acquired",
+          "contended",
+          "timeout",
+          "start",
+          "steer",
+          "finish-race",
+          "observed"
+        ],
+        "service.name": [
+          "curie-worker"
+        ],
+        "source": [
+          "worker"
+        ]
+      },
+      "cardinality_bound": 7,
+      "description": "Thread lock acquisition duration.",
+      "monotonic": false,
+      "type": "histogram",
+      "unit": "s"
+    },
+    "curie.thread.route": {
+      "attributes": {
+        "outcome": [
+          "acquired",
+          "contended",
+          "timeout",
+          "start",
+          "steer",
+          "finish-race",
+          "observed"
+        ],
+        "service.name": [
+          "curie-worker"
+        ],
+        "source": [
+          "worker"
+        ]
+      },
+      "cardinality_bound": 7,
+      "description": "Thread routing decisions.",
+      "monotonic": true,
+      "type": "counter",
+      "unit": "{decision}"
+    },
+    "curie.thread.route.active": {
+      "attributes": {
+        "outcome": [
+          "acquired",
+          "contended",
+          "timeout",
+          "start",
+          "steer",
+          "finish-race",
+          "observed"
+        ],
+        "service.name": [
+          "curie-worker"
+        ],
+        "source": [
+          "worker"
+        ]
+      },
+      "cardinality_bound": 7,
+      "description": "Active thread routes.",
+      "monotonic": false,
+      "type": "gauge",
+      "unit": "{route}"
+    },
+    "curie.turn.accepted": {
+      "attributes": {
+        "outcome": [
+          "accepted"
+        ],
+        "service.name": [
+          "curie-api",
+          "curie-dispatcher",
+          "curie-worker",
+          "curie-runner"
+        ],
+        "source": [
+          "api",
+          "dispatcher",
+          "worker",
+          "runner",
+          "local",
+          "eval"
+        ]
+      },
+      "cardinality_bound": 24,
+      "description": "Turns accepted for processing.",
+      "monotonic": true,
+      "type": "counter",
+      "unit": "{turn}"
+    },
+    "curie.turn.completed": {
+      "attributes": {
+        "outcome": [
+          "done",
+          "awaiting_approval",
+          "budget_halted",
+          "classified_failure",
+          "side_effect_halted",
+          "idle",
+          "interrupted"
+        ],
+        "service.name": [
+          "curie-api",
+          "curie-dispatcher",
+          "curie-worker",
+          "curie-runner"
+        ],
+        "source": [
+          "api",
+          "dispatcher",
+          "worker",
+          "runner",
+          "local",
+          "eval"
+        ]
+      },
+      "cardinality_bound": 168,
+      "description": "Turns reaching a terminal result.",
+      "monotonic": true,
+      "type": "counter",
+      "unit": "{turn}"
+    },
+    "curie.turn.duration": {
+      "attributes": {
+        "outcome": [
+          "done",
+          "awaiting_approval",
+          "budget_halted",
+          "classified_failure",
+          "side_effect_halted",
+          "idle",
+          "interrupted"
+        ],
+        "service.name": [
+          "curie-api",
+          "curie-dispatcher",
+          "curie-worker",
+          "curie-runner"
+        ],
+        "source": [
+          "api",
+          "dispatcher",
+          "worker",
+          "runner",
+          "local",
+          "eval"
+        ]
+      },
+      "cardinality_bound": 168,
+      "description": "End to end turn duration.",
+      "monotonic": false,
+      "type": "histogram",
+      "unit": "s"
     }
-  }
+  },
+  "schema_version": "v1"
 }

--- a/packages/telemetry/src/curie_telemetry/metrics.py
+++ b/packages/telemetry/src/curie_telemetry/metrics.py
@@ -216,6 +216,8 @@ _HTTP_OPERATIONS = [
     "/v1/internal/cluster-message-replies/{reply_ref}",
     "/v1/internal/publications",
     "/v1/internal/publications/lineage",
+    "/v1/internal/publications/review-reservations",
+    "/v1/internal/publications/review-reservations/{reservation_id}/cancel",
     "/v1/internal/publications/{publication_id}/lineage",
     "/v1/internal/publications/{publication_id}/credential",
     "/v1/internal/workspaces/{deployment_id}/credential",


### PR DESCRIPTION
A GitHub review must be tied to the product App's immutable repository/installation/PR identity and the original conversation before it can reserve a coding revision. This compatible #2274 prerequisite captures verified identity on new publication lineages and adds explicit origin reservations consumed by the existing approval/publication writer. Historical PAT or unproved lineages stay ineligible; no identity backfill is inferred from repository names.

The reservation uses lineage version/head CAS, pins the original binding generation and reply route, and permits only its exact origin to create a fresh approval. Concurrent reservations, changed routes/heads/identity, cancelled-origin replay and a second conversation claiming the same PR are refused. Locked authority reads refresh retained ORM instances so a committed head, binding or deployment change is observed. App token minting cannot silently change installations after fresh discovery.

Stack: `next` at `26a583ef5cbb4f4241fa20eebf3e5574b45369e0` → this prerequisite (`task/overnight-review-lineage-clean`, current `6811d09f11fc0c473cb9b95a239807bdd4173f26`) → dependent #2395. Migration `0042_review_lineage_authority` follows `0041`; dependent feedback migration is `0043`. Both feature PRs remain unmerged.

Validation is attributed to the source that actually ran:

- Original `09604a12`: 99 actual Postgres/Valkey publication cases, 14 authority cases and 39 App cases passed. This covers concurrency, binding/head CAS, immutable ownership, cancelled-origin and downgrade controls. Required full local/live/external acceptance was not claimed. Its replacement `da707121` preserved production bytes and changed synthetic test identifiers; #2397 was superseded unmerged because of a scanner false positive.
- Actual two-session API tests retained ORM instances while another API transaction changed authority: binding/head both failed on `da707121` and passed on `07ffce4e`. An added deployment-stop case failed on `07ffce4e`; current `6811d09f` adds the same locked-refresh behavior for that leg. Its local positive rerun remains pending.
- `07ffce4e` full Python CI: 6,324 passed, 3 failed, 22 skipped. The three failures were a mismatched synthetic conversation, a 0041 round trip accidentally traversing the later downgrade guard, and synthetic migration IDs colliding with real 0042. Their corrected exact cases passed against a disposable migrated DB; guard and exactly-once assertions remain intact. Fresh full CI on `6811d09f` is pending.
- Read-only code/security reviews and Claude Fable reviews completed on the original implementation and subsequent authority corrections. Final four-file correction hashes matched; Fable and independent scope review found no blocker. Ruff, mypy (250 files), diff checks and the pinned gitleaks PR-range scan passed on the current correction (3 commits scanned). A scanner attempt that read zero commits due to container worktree mounting was rejected as invalid and rerun correctly.
- All task-owned test containers, volumes and networks were removed and absence verified after each run.

Required tiers: **local** (API persistence/auth wiring), **live provider** (product GitHub App credentials), **external integration** (actual GitHub identity/truth). Skill is not applicable because no runner/plugin/ACI behavior changes; local-release is not applicable because no release binary/image/install identity changes; cluster is not applicable because no chart/RBAC/sandbox changes. Scoped real backing integration supports local evidence; the full local ladder and actual App/external path remain unproved.

Draft limits: #2275 ingress-to-model correlation, busy-thread queueing, terminal reservation cleanup, fresh human approval, same-PR continuation and real Slack/GitHub review E2E belong to the dependent stack and are not completed by this prerequisite. Required runtime evidence and full checks remain open. App reinstall or original binding removal fails closed and requires explicit operator recovery.

Refs #2274, #2275. No issue is closed by this draft.
