### PR TITLE
Add the optional BootEnv runner_bootstrap_token prerequisite

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -111,6 +111,7 @@ S3_SECRET_KEY=rustfssecret
 # CURIE_MODEL_API_BACKEND        producers: worker
 # CURIE_MODEL_ENV_KEY            producers: worker
 # CURIE_PLUGIN_DIR               producers: worker, substrate
+# CURIE_RUNNER_BOOTSTRAP_TOKEN   producers: substrate
 # CURIE_RUNNER_PORT              producers: substrate
 # CURIE_RUNNER_TOKEN             producers: worker
 # CURIE_SANDBOX_ID               producers: substrate

--- a/docs/diagrams/aci.md
+++ b/docs/diagrams/aci.md
@@ -117,7 +117,7 @@ regenerated and committed together it **always goes green**. It pins artifact
 *sync*; it never pinned *compatibility*. Three things carry the contract
 instead:
 
-- **Semver, not a freeze.** `PROTOCOL_VERSION` is `0.4.5`
+- **Semver, not a freeze.** `PROTOCOL_VERSION` is `0.4.6`
   ([`packages/aci-protocol/src/aci_protocol/version.py`](../../packages/aci-protocol/src/aci_protocol/version.py)),
   versioned independently of the Curie release. Under 0.x a consumer accepts
   the same `major.minor`; only a new optional field is compatible (patch), and

--- a/docs/interfaces/aci-producer/implementing-an-aci-server.md
+++ b/docs/interfaces/aci-producer/implementing-an-aci-server.md
@@ -82,7 +82,7 @@ Import everything from `aci_protocol`; do not hand-roll JSON.
   `call_id` (ADR-0117)
 
 **Version gate (strict producer, tolerant consumer).** Your producer emits its
-**exact build `PROTOCOL_VERSION`** (currently `0.4.5`) on every outbound event and
+**exact build `PROTOCOL_VERSION`** (currently `0.4.6`) on every outbound event and
 constructs strictly -- an unknown field is an error at construction, catching your
 mistakes at the source. A **consumer** decoding the wire is tolerant the other way:
 it accepts any version compatible with its own build (`major.minor` match under

--- a/packages/aci-protocol/README.md
+++ b/packages/aci-protocol/README.md
@@ -24,9 +24,9 @@ string rather than a `const`. Artifact sync is enforced by the
 schema-compat gate (`tests/test_schema_compat.py`); an unbumped wire change is
 caught by the wire-lock gate (`tests/test_wire_lock.py`).
 
-## Contract surface (v0.4.5)
+## Contract surface (v0.4.6)
 
-`PROTOCOL_VERSION = "0.4.5"` is embedded in the schema and in every outbound
+`PROTOCOL_VERSION = "0.4.6"` is embedded in the schema and in every outbound
 event.
 
 **Session setup** (`SessionConfig`, with `to_env()` / `from_env()`):
@@ -42,6 +42,28 @@ event.
 | `otel` | `OTEL_EXPORTER_OTLP_ENDPOINT` / `_HEADERS` / `_PROTOCOL` | optional |
 
 `Budget` = `{max_output_tokens_per_run: int, task_budget_hint: int | None, max_usd_per_day: float}`.
+
+**Boot env** (`BootEnv`, ADR-0049) composes `SessionConfig` with the platform
+boot keys; the full key list with its producers is the generated block in the
+repo's `.env.example`. As of 0.4.6 it carries two runner credential keys with
+different authority, so an unbound warm runner can tell them apart at boot
+(#1492, ADR-0116 decision 2, ADR-0122):
+
+| Field | Env var | Producer | Authority |
+|---|---|---|---|
+| `runner_token` | `CURIE_RUNNER_TOKEN` | worker, per claim | bound per-conversation credential, enforced on every gated ACI route |
+| `runner_bootstrap_token` | `CURIE_RUNNER_BOOTSTRAP_TOKEN` | substrate, per-pool `Secret` | may authorize one atomic adoption (an `Event` carrying `adoption_credential`), then is retired for that pod |
+
+Consumer authority policy, realized by the runner and not by this package:
+`runner_token` present wins and the bootstrap is never admitted (the cold path
+is unchanged); only `runner_bootstrap_token` present is bootstrap mode, where
+any gated request other than the adopting event is refused before a model turn
+starts; neither present is today's tokenless legacy boot, unchanged. Both are
+secret material: omitted from `repr`/`str`, never echoed by a validation error,
+and redacted by the generated Rust `Debug`. A present but blank or oversize
+value fails the boot parse closed; a declared-but-empty var is "unset", the
+rule every boot var already follows. Declaring the key is not bootstrap mode,
+adoption, retirement, or a pool.
 
 **Inbound channel messages** (discriminated union on `kind`):
 

--- a/packages/aci-protocol/README.md
+++ b/packages/aci-protocol/README.md
@@ -58,12 +58,21 @@ Consumer authority policy, realized by the runner and not by this package:
 `runner_token` present wins and the bootstrap is never admitted (the cold path
 is unchanged); only `runner_bootstrap_token` present is bootstrap mode, where
 any gated request other than the adopting event is refused before a model turn
-starts; neither present is today's tokenless legacy boot, unchanged. Both are
-secret material: omitted from `repr`/`str`, never echoed by a validation error,
-and redacted by the generated Rust `Debug`. A present but blank or oversize
-value fails the boot parse closed; a declared-but-empty var is "unset", the
-rule every boot var already follows. Declaring the key is not bootstrap mode,
-adoption, retirement, or a pool.
+starts; neither present is today's tokenless legacy boot, unchanged.
+
+`runner_bootstrap_token` is handled as secret material: omitted from
+`repr`/`str`, never echoed by a validation error, and redacted by the generated
+Rust `Debug`. A present value that is empty, blank, oversize or not a string
+fails the boot parse closed. Unlike every other optional boot var, a
+declared-but-empty `CURIE_RUNNER_BOOTSTRAP_TOKEN` is not "unset": its only
+producer is a pool `Secret`, so an empty value is a mis-render, and only an
+absent key is the compatible legacy case. `runner_token` keeps its current
+handling, which predates this patch and is not changed by it: a
+declared-but-empty `CURIE_RUNNER_TOKEN` is unset, a blank value passes through
+verbatim with no size cap, and the value still appears in `repr` and in the
+Rust `Debug` output. Extending the redaction to it and the other token fields
+is a separate change. Declaring the key is not bootstrap mode, adoption,
+retirement, or a pool.
 
 **Inbound channel messages** (discriminated union on `kind`):
 

--- a/packages/aci-protocol/generated/rust/src/lib.rs
+++ b/packages/aci-protocol/generated/rust/src/lib.rs
@@ -6,7 +6,7 @@
 
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: &str = "0.4.5";
+pub const PROTOCOL_VERSION: &str = "0.4.6";
 
 pub const RUNS_STREAM_DEFAULT: &str = "curie:runs";
 
@@ -71,8 +71,10 @@ where
     Option::<T>::deserialize(deserializer)
 }
 
-fn deserialize_adoption_credential<'de, D>(
+fn deserialize_bounded_credential<'de, D>(
     deserializer: D,
+    what: &'static str,
+    max_chars: usize,
 ) -> Result<Option<String>, D::Error>
 where
     D: serde::Deserializer<'de>,
@@ -80,11 +82,37 @@ where
     let value = Option::<String>::deserialize(deserializer)?;
     match &value {
         None => Ok(None),
-        Some(s) if s.trim().is_empty() || s.chars().count() > 4096 => {
-            Err(serde::de::Error::custom("malformed adoption credential"))
+        Some(s) if s.trim().is_empty() || s.chars().count() > max_chars => {
+            Err(serde::de::Error::custom(format!("malformed {what}")))
         }
         Some(_) => Ok(value),
     }
+}
+
+fn deserialize_adoption_credential<'de, D>(
+    deserializer: D,
+) -> Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    deserialize_bounded_credential(
+        deserializer,
+        "adoption credential",
+        4096,
+    )
+}
+
+fn deserialize_runner_bootstrap_token<'de, D>(
+    deserializer: D,
+) -> Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    deserialize_bounded_credential(
+        deserializer,
+        "runner bootstrap token",
+        4096,
+    )
 }
 
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
@@ -161,7 +189,7 @@ pub struct SessionConfig {
     pub otel: OtelConfig,
 }
 
-#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct BootEnv {
     pub session: SessionConfig,
     #[serde(default)]
@@ -170,6 +198,8 @@ pub struct BootEnv {
     pub bundle_version: Option<String>,
     #[serde(default)]
     pub runner_token: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_runner_bootstrap_token")]
+    pub runner_bootstrap_token: Option<String>,
     #[serde(default)]
     pub model: Option<String>,
     #[serde(default)]
@@ -218,6 +248,44 @@ pub struct BootEnv {
     pub history_max_bytes: Option<i64>,
 }
 
+impl std::fmt::Debug for BootEnv {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BootEnv")
+            .field("session", &self.session)
+            .field("bundle_ref", &self.bundle_ref)
+            .field("bundle_version", &self.bundle_version)
+            .field("runner_token", &self.runner_token)
+            .field(
+                "runner_bootstrap_token",
+                &self.runner_bootstrap_token.as_ref().map(|_| "<redacted>"),
+            )
+            .field("model", &self.model)
+            .field("fake_model", &self.fake_model)
+            .field("history_ref", &self.history_ref)
+            .field("history_token", &self.history_token)
+            .field("memory_token", &self.memory_token)
+            .field("state_url", &self.state_url)
+            .field("state_token", &self.state_token)
+            .field("approval_required_tools", &self.approval_required_tools)
+            .field("approval_grant_tool", &self.approval_grant_tool)
+            .field("approval_resumed_kind", &self.approval_resumed_kind)
+            .field("approval_decision", &self.approval_decision)
+            .field("connector_secret_keys", &self.connector_secret_keys)
+            .field("connector_release", &self.connector_release)
+            .field("connector_agent", &self.connector_agent)
+            .field("connector_namespace", &self.connector_namespace)
+            .field("port", &self.port)
+            .field("base_url", &self.base_url)
+            .field("api_backend", &self.api_backend)
+            .field("thinking", &self.thinking)
+            .field("model_env_key", &self.model_env_key)
+            .field("max_turns", &self.max_turns)
+            .field("history_max_turns", &self.history_max_turns)
+            .field("history_max_bytes", &self.history_max_bytes)
+            .finish()
+    }
+}
+
 /// Boot-env variable names, generated from aci_protocol.session.BootEnv.
 /// The env key is the contract; the Rust CLI and the chart render-assert
 /// pin against these instead of retyping the literals.
@@ -247,6 +315,7 @@ pub mod env_keys {
     pub const CURIE_MODEL_API_BACKEND: &str = "CURIE_MODEL_API_BACKEND";
     pub const CURIE_MODEL_ENV_KEY: &str = "CURIE_MODEL_ENV_KEY";
     pub const CURIE_PLUGIN_DIR: &str = "CURIE_PLUGIN_DIR";
+    pub const CURIE_RUNNER_BOOTSTRAP_TOKEN: &str = "CURIE_RUNNER_BOOTSTRAP_TOKEN";
     pub const CURIE_RUNNER_PORT: &str = "CURIE_RUNNER_PORT";
     pub const CURIE_RUNNER_TOKEN: &str = "CURIE_RUNNER_TOKEN";
     pub const CURIE_SANDBOX_ID: &str = "CURIE_SANDBOX_ID";
@@ -548,6 +617,60 @@ mod tests {
         assert!(!error.to_string().contains("adoption-credential-fixture-PLACEHOLDER"));
     }
 
+    const BOOT_ENV_MINIMAL: &str = concat!(
+        r#"{"session":{"plugin_dir":"/plugins/bundle","session_id":"sess-abc","#,
+        r#""sandbox_id":"curie-sandbox-abc123","#,
+        r#""budget":{"max_output_tokens_per_run":4096,"max_usd_per_day":5.0}}"#
+    );
+
+    #[test]
+    fn boot_env_omitted_bootstrap_token_is_none() {
+        let raw = format!("{BOOT_ENV_MINIMAL}}}");
+        let decoded: BootEnv = serde_json::from_str(&raw).unwrap();
+        assert_eq!(decoded.runner_bootstrap_token, None);
+        assert_eq!(decoded.runner_token, None);
+    }
+
+    #[test]
+    fn boot_env_bootstrap_token_roundtrips() {
+        let boot = BootEnv {
+            runner_bootstrap_token: Some("runner-bootstrap-token-fixture-PLACEHOLDER".to_string()),
+            ..BootEnv::default()
+        };
+        let encoded = serde_json::to_string(&boot).unwrap();
+        let decoded: BootEnv = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(boot, decoded);
+    }
+
+    #[test]
+    fn boot_env_debug_redacts_bootstrap_token() {
+        let boot = BootEnv {
+            runner_bootstrap_token: Some("runner-bootstrap-token-fixture-PLACEHOLDER".to_string()),
+            ..BootEnv::default()
+        };
+        let rendered = format!("{boot:?}");
+        assert!(!rendered.contains("runner-bootstrap-token-fixture-PLACEHOLDER"));
+        assert!(rendered.contains("runner_bootstrap_token: Some(\"<redacted>\")"));
+        let unset = format!("{:?}", BootEnv::default());
+        assert!(unset.contains("runner_bootstrap_token: None"));
+    }
+
+    #[test]
+    fn boot_env_rejects_blank_bootstrap_token() {
+        let raw = format!("{BOOT_ENV_MINIMAL},\"runner_bootstrap_token\":\"   \"}}");
+        let error = serde_json::from_str::<BootEnv>(&raw).unwrap_err();
+        assert!(error.to_string().contains("malformed runner bootstrap token"));
+    }
+
+    #[test]
+    fn boot_env_rejects_oversize_bootstrap_token_without_echo() {
+        let material = format!("runner-bootstrap-token-fixture-PLACEHOLDER{}", "x".repeat(4096));
+        let raw = format!("{BOOT_ENV_MINIMAL},\"runner_bootstrap_token\":\"{material}\"}}");
+        let error = serde_json::from_str::<BootEnv>(&raw).unwrap_err();
+        assert!(error.to_string().contains("malformed runner bootstrap token"));
+        assert!(!error.to_string().contains("runner-bootstrap-token-fixture-PLACEHOLDER"));
+    }
+
     #[test]
     fn reply_handle_accepts_explicit_null_placeholder() {
         let raw = r#"{"kind":"email","channel":"agent@example.test","placeholder":null,"endpoint":"https://adapter.example/hook","adapter":"agentmail_sandbox"}"#;
@@ -580,13 +703,13 @@ mod tests {
 
     #[test]
     fn accepts_compatible_patch() {
-        let raw = r#"{"type":"final","version":"0.4.6","text":"x","status":"done"}"#;
+        let raw = r#"{"type":"final","version":"0.4.7","text":"x","status":"done"}"#;
         assert!(serde_json::from_str::<OutboundEvent>(raw).is_ok());
     }
 
     #[test]
     fn accepts_unknown_fields() {
-        let raw = r#"{"type":"final","version":"0.4.5","text":"x","status":"done","extra":1}"#;
+        let raw = r#"{"type":"final","version":"0.4.6","text":"x","status":"done","extra":1}"#;
         assert!(serde_json::from_str::<OutboundEvent>(raw).is_ok());
     }
 }

--- a/packages/aci-protocol/generated/rust/src/lib.rs
+++ b/packages/aci-protocol/generated/rust/src/lib.rs
@@ -79,13 +79,15 @@ fn deserialize_bounded_credential<'de, D>(
 where
     D: serde::Deserializer<'de>,
 {
-    let value = Option::<String>::deserialize(deserializer)?;
-    match &value {
-        None => Ok(None),
-        Some(s) if s.trim().is_empty() || s.chars().count() > max_chars => {
-            Err(serde::de::Error::custom(format!("malformed {what}")))
+    let value = Option::<serde_json::Value>::deserialize(deserializer)?;
+    match value {
+        None | Some(serde_json::Value::Null) => Ok(None),
+        Some(serde_json::Value::String(s))
+            if !s.trim().is_empty() && s.chars().count() <= max_chars =>
+        {
+            Ok(Some(s))
         }
-        Some(_) => Ok(value),
+        Some(_) => Err(serde::de::Error::custom(format!("malformed {what}"))),
     }
 }
 
@@ -660,6 +662,41 @@ mod tests {
         let raw = format!("{BOOT_ENV_MINIMAL},\"runner_bootstrap_token\":\"   \"}}");
         let error = serde_json::from_str::<BootEnv>(&raw).unwrap_err();
         assert!(error.to_string().contains("malformed runner bootstrap token"));
+    }
+
+    #[test]
+    fn boot_env_rejects_non_string_bootstrap_token_without_echo() {
+        let specimens = [
+            "4711",
+            "true",
+            r#"["runner-bootstrap-token-fixture-PLACEHOLDER"]"#,
+            r#"{"v":"runner-bootstrap-token-fixture-PLACEHOLDER"}"#,
+        ];
+        for specimen in specimens {
+            let raw = format!("{BOOT_ENV_MINIMAL},\"runner_bootstrap_token\":{specimen}}}");
+            let rendered = serde_json::from_str::<BootEnv>(&raw).unwrap_err().to_string();
+            assert!(rendered.contains("malformed runner bootstrap token"), "{rendered}");
+            assert!(!rendered.contains("4711"), "{rendered}");
+            assert!(!rendered.contains("runner-bootstrap-token-fixture-PLACEHOLDER"), "{rendered}");
+        }
+    }
+
+    #[test]
+    fn boot_env_explicit_null_bootstrap_token_is_none() {
+        let raw = format!("{BOOT_ENV_MINIMAL},\"runner_bootstrap_token\":null}}");
+        let decoded: BootEnv = serde_json::from_str(&raw).unwrap();
+        assert_eq!(decoded.runner_bootstrap_token, None);
+    }
+
+    #[test]
+    fn inbound_event_rejects_non_string_adoption_credential_without_echo() {
+        let raw = concat!(
+            r#"{"kind":"event","type":"message","text":"hi","user":"U1","ts":"1.0","#,
+            r#""adoption_credential":4711}"#
+        );
+        let rendered = serde_json::from_str::<InboundMessage>(raw).unwrap_err().to_string();
+        assert!(rendered.contains("malformed adoption credential"), "{rendered}");
+        assert!(!rendered.contains("4711"), "{rendered}");
     }
 
     #[test]

--- a/packages/aci-protocol/generated/ts/aci-protocol.ts
+++ b/packages/aci-protocol/generated/ts/aci-protocol.ts
@@ -20,7 +20,7 @@ export type ExpiresInSeconds = number | null;
  * authority-bearing per #544/ADR-0046, so the value domain is a named, exported
  * part of the contract rather than an inline annotation.
  *
- * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV046`'s JSON-Schema
  * via the `definition` "GateKind".
  */
 export type GateKind = "permission" | "policy";
@@ -54,6 +54,7 @@ export type MemoryToken = string | null;
 export type Model = string | null;
 export type ModelEnvKey = string | null;
 export type Port = number | null;
+export type RunnerBootstrapToken = string | null;
 export type RunnerToken = string | null;
 export type MaxOutputTokensPerRun = number;
 export type MaxUsdPerDay = number;
@@ -113,14 +114,14 @@ export type Text1 = string;
 export type Type2 = "final";
 export type Version1 = string;
 /**
- * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV046`'s JSON-Schema
  * via the `definition` "InboundMessage".
  */
 export type InboundMessage = Event | Interrupt;
 export type Kind1 = "interrupt";
 export type Reason = string;
 /**
- * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV046`'s JSON-Schema
  * via the `definition` "OutboundEvent".
  */
 export type OutboundEvent = TextDelta | ToolNote | Final | ErrorEvent | SideEffectFlag;
@@ -187,7 +188,7 @@ export type Text4 = string;
  * Wire tokens follow the section 0 spelling; ``classified failure`` in prose
  * becomes the token ``classified-failure`` on the wire.
  *
- * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV046`'s JSON-Schema
  * via the `definition` "SessionStatus".
  */
 export type SessionStatus1 = "done" | "idle-awaiting-input" | "classified-failure" | "awaiting-approval";
@@ -215,12 +216,12 @@ export type SessionStatus1 = "done" | "idle-awaiting-input" | "classified-failur
  * ENUM VALUE -- breaking under this package's rules, so it is a deliberate,
  * separately-decided bump rather than something this change assumes.
  *
- * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV046`'s JSON-Schema
  * via the `definition` "TurnSource".
  */
 export type TurnSource1 = "slack" | "webhook" | "cron";
 
-export interface ACIProtocolV045 {
+export interface ACIProtocolV046 {
   [k: string]: unknown;
 }
 /**
@@ -244,7 +245,7 @@ export interface ACIProtocolV045 {
  * nullable because ``slack`` legitimately has no adapter -- its route is the
  * worker's configured Slack origin.
  *
- * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV046`'s JSON-Schema
  * via the `definition` "ApprovalRequest".
  */
 export interface ApprovalRequest {
@@ -291,7 +292,7 @@ export interface ApprovalRequest {
  * baked template default, the worker's value is per-agent model routing. Do not
  * collapse either producer list to a single value.
  *
- * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV046`'s JSON-Schema
  * via the `definition` "BootEnv".
  */
 export interface BootEnv {
@@ -317,6 +318,7 @@ export interface BootEnv {
   model?: Model;
   model_env_key?: ModelEnvKey;
   port?: Port;
+  runner_bootstrap_token?: RunnerBootstrapToken;
   runner_token?: RunnerToken;
   session: SessionConfig;
   state_token?: StateToken;
@@ -331,7 +333,7 @@ export interface BootEnv {
  * section 0 describes these as per-tool secrets via K8s Secret refs, so the
  * contract carries the reference, not the secret material itself.
  *
- * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV046`'s JSON-Schema
  * via the `definition` "SessionConfig".
  */
 export interface SessionConfig {
@@ -350,7 +352,7 @@ export interface SessionConfig {
  * ``task_budget_hint`` is the optional hint passed through to the model so it
  * self paces (section 6b); it is not a hard ceiling.
  *
- * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV046`'s JSON-Schema
  * via the `definition` "Budget".
  */
 export interface Budget {
@@ -366,7 +368,7 @@ export interface Budget {
  * fields the prototype used (endpoint, headers, protocol); any others pass
  * through as raw env vars untouched and are out of scope for this typed view.
  *
- * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV046`'s JSON-Schema
  * via the `definition` "OtelConfig".
  */
 export interface OtelConfig {
@@ -378,7 +380,7 @@ export interface OtelConfig {
 /**
  * A classified failure surfaced to the platform.
  *
- * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV046`'s JSON-Schema
  * via the `definition` "ErrorEvent".
  */
 export interface ErrorEvent {
@@ -396,7 +398,7 @@ export interface ErrorEvent {
  * worker consumes off it (formerly the API's ``EvalJobRequest`` and the
  * worker's ``EvalWorkItem``, which had drifted on ``bundle_ref``).
  *
- * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV046`'s JSON-Schema
  * via the `definition` "EvalJob".
  */
 export interface EvalJob {
@@ -416,7 +418,7 @@ export interface EvalJob {
  * Byte-identical across both lanes before this promotion, so it carries no
  * semantic decisions.
  *
- * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV046`'s JSON-Schema
  * via the `definition` "EvalReport".
  */
 export interface EvalReport {
@@ -452,7 +454,7 @@ export interface EvalReport {
  * that turn; a producer that sent a credential MUST treat a missing or
  * non-true ack as "not adopted".
  *
- * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV046`'s JSON-Schema
  * via the `definition` "Event".
  */
 export interface Event {
@@ -500,7 +502,7 @@ export interface Event {
  * scalars: a tolerant consumer decoding an older producer's ``final`` simply
  * sees them absent.
  *
- * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV046`'s JSON-Schema
  * via the `definition` "Final".
  */
 export interface Final {
@@ -520,7 +522,7 @@ export interface Final {
 /**
  * A hard stop delivered on the control channel, distinct from a steer.
  *
- * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV046`'s JSON-Schema
  * via the `definition` "Interrupt".
  */
 export interface Interrupt {
@@ -531,7 +533,7 @@ export interface Interrupt {
 /**
  * A streamed chunk of assistant text.
  *
- * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV046`'s JSON-Schema
  * via the `definition` "TextDelta".
  */
 export interface TextDelta {
@@ -544,7 +546,7 @@ export interface TextDelta {
 /**
  * A human readable note about a tool call the harness is making.
  *
- * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV046`'s JSON-Schema
  * via the `definition` "ToolNote".
  */
 export interface ToolNote {
@@ -574,7 +576,7 @@ export interface ToolNote {
  * turn that calls the same tool twice is otherwise indistinguishable from one
  * that called it once.
  *
- * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV046`'s JSON-Schema
  * via the `definition` "SideEffectFlag".
  */
 export interface SideEffectFlag {
@@ -605,7 +607,7 @@ export interface SideEffectFlag {
  * to the non-job value is also the safe direction -- an unset ``source`` reads
  * as a person's message, so a job can never be created by omission.
  *
- * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV046`'s JSON-Schema
  * via the `definition` "QueuedTurn".
  */
 export interface QueuedTurn {
@@ -654,7 +656,7 @@ export interface QueuedTurn {
  * third-party or pre-upgrade producer is not rejected outright, but every
  * first-party mint site sets it explicitly.
  *
- * This interface was referenced by `ACIProtocolV045`'s JSON-Schema
+ * This interface was referenced by `ACIProtocolV046`'s JSON-Schema
  * via the `definition` "ReplyHandle".
  */
 export interface ReplyHandle {

--- a/packages/aci-protocol/schema/aci-protocol.schema.json
+++ b/packages/aci-protocol/schema/aci-protocol.schema.json
@@ -519,6 +519,25 @@
           ],
           "title": "Port"
         },
+        "runner_bootstrap_token": {
+          "anyOf": [
+            {
+              "maxLength": 4096,
+              "minLength": 1,
+              "pattern": ".*\\S.*",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "env": "CURIE_RUNNER_BOOTSTRAP_TOKEN",
+          "producer": [
+            "substrate"
+          ],
+          "title": "Runner Bootstrap Token"
+        },
         "runner_token": {
           "anyOf": [
             {
@@ -1471,6 +1490,6 @@
   },
   "$id": "https://curietech.ai/schemas/aci-protocol.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "protocolVersion": "0.4.5",
-  "title": "ACI Protocol v0.4.5"
+  "protocolVersion": "0.4.6",
+  "title": "ACI Protocol v0.4.6"
 }

--- a/packages/aci-protocol/schema/wire.lock
+++ b/packages/aci-protocol/schema/wire.lock
@@ -1,4 +1,4 @@
 {
-  "protocol_version": "0.4.5",
-  "wire_sha256": "b1e13f7ba8da30ac758a65bdfe7cc4c83ffe8ceb9d3995f3e095d2bcc8c37f93"
+  "protocol_version": "0.4.6",
+  "wire_sha256": "85ab097d3902585aa1c30f917a1525680bd89edd6156128012fd400641c2d2d4"
 }

--- a/packages/aci-protocol/src/aci_protocol/__init__.py
+++ b/packages/aci-protocol/src/aci_protocol/__init__.py
@@ -51,7 +51,14 @@ from .service_config import (
     WORKER_GROUP_DEFAULT,
     derive_dead_letter_stream_name,
 )
-from .session import BootEnv, Budget, OtelConfig, SessionConfig
+from .session import (
+    RUNNER_BOOTSTRAP_TOKEN_MAX_CHARS,
+    BootEnv,
+    Budget,
+    OtelConfig,
+    SessionConfig,
+    parse_runner_bootstrap_token,
+)
 from .session import Producer as EnvProducer
 from .turn import QueuedTurn, ReplyHandle, TurnSource
 from .version import PROTOCOL_VERSION, is_compatible
@@ -95,6 +102,8 @@ __all__ = [
     "InboundMessage",
     "ADOPTION_CREDENTIAL_MAX_CHARS",
     "parse_adoption_credential",
+    "RUNNER_BOOTSTRAP_TOKEN_MAX_CHARS",
+    "parse_runner_bootstrap_token",
     # outbound
     "TextDelta",
     "ToolNote",

--- a/packages/aci-protocol/src/aci_protocol/events.py
+++ b/packages/aci-protocol/src/aci_protocol/events.py
@@ -14,7 +14,7 @@ outbound event carries a ``version`` equal to PROTOCOL_VERSION.
 """
 
 import json
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from enum import StrEnum
 from types import MappingProxyType
 from typing import Annotated, Any, Literal
@@ -108,6 +108,30 @@ def _malformed_adoption_credential() -> ValueError:
     return ValueError("malformed adoption credential")
 
 
+def admit_bounded_credential(
+    value: Any, *, max_chars: int, error: Callable[[], ValueError]
+) -> str | None:
+    """Admit an optional opaque credential, or raise ``error()`` without echoing it.
+
+    The one admission rule every credential-bearing ACI field shares
+    (``Event.adoption_credential``, ``BootEnv.runner_bootstrap_token``):
+    ``None`` is "not presented"; any other well-formed value is a non-empty
+    string no longer than ``max_chars`` that is not whitespace-only. The
+    presented material is never copied onto the raised error, so a caller that
+    interpolates the exception into an HTTP body or a log line cannot leak it
+    from here. Control characters are deliberately not policed at this layer;
+    a realizing consumer compares the value and fails closed on a mismatch.
+    """
+
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise error()
+    if not value or value.strip() == "" or len(value) > max_chars:
+        raise error()
+    return value
+
+
 def parse_adoption_credential(value: Any) -> str | None:
     """Admit an optional adoption credential, or raise without echoing it.
 
@@ -118,58 +142,65 @@ def parse_adoption_credential(value: Any) -> str | None:
     an HTTP body therefore cannot leak it from this helper.
     """
 
-    if value is None:
-        return None
-    if not isinstance(value, str):
-        raise _malformed_adoption_credential()
-    if not value or value.strip() == "" or len(value) > ADOPTION_CREDENTIAL_MAX_CHARS:
-        raise _malformed_adoption_credential()
-    return value
+    return admit_bounded_credential(
+        value, max_chars=ADOPTION_CREDENTIAL_MAX_CHARS, error=_malformed_adoption_credential
+    )
 
 
-def _malformed_event_error() -> ValidationError:
-    """A credential-free ValidationError for a bad adoption_credential."""
+def _malformed_credential_error(title: str, field: str, message: str) -> ValidationError:
+    """A material-free ValidationError naming only the field and a fixed message."""
 
     return ValidationError.from_exception_data(
-        "Event",
+        title,
         [
             {
                 "type": "value_error",
-                "loc": ("adoption_credential",),
+                "loc": (field,),
                 "input": None,
-                "ctx": {"error": "malformed adoption credential"},
+                "ctx": {"error": message},
             }
         ],
     )
 
 
-def _scrub_credential_input(value: Any) -> Any:
+def _malformed_event_error() -> ValidationError:
+    """A credential-free ValidationError for a bad adoption_credential."""
+
+    return _malformed_credential_error(
+        "Event", "adoption_credential", "malformed adoption credential"
+    )
+
+
+def _scrub_credential_input(value: Any, field: str) -> Any:
     if isinstance(value, dict):
         return {
-            key: None if key == "adoption_credential" else _scrub_credential_input(item)
+            key: None if key == field else _scrub_credential_input(item, field)
             for key, item in value.items()
         }
     if isinstance(value, list):
-        return [_scrub_credential_input(item) for item in value]
+        return [_scrub_credential_input(item, field) for item in value]
     if isinstance(value, (bytes, bytearray)):
         try:
             text = bytes(value).decode("utf-8")
         except UnicodeDecodeError:
             return "<redacted>"
-        return "<redacted>" if "adoption_credential" in text else value
-    if isinstance(value, str) and "adoption_credential" in value:
+        return "<redacted>" if field in text else value
+    if isinstance(value, str) and field in value:
         return "<redacted>"
     return value
 
 
-def redact_adoption_credential_error(exc: ValidationError) -> ValidationError:
-    """Return a ValidationError whose inputs cannot contain credential material.
+def redact_credential_error(
+    exc: ValidationError, *, title: str, field: str, message: str
+) -> ValidationError:
+    """Return a ValidationError whose inputs cannot contain ``field``'s material.
 
-    Errors whose loc is the credential field stay a closed malformed-credential
-    failure. Unrelated failures (a missing ``text``, for example) keep their
-    diagnosis; only the credential material is scrubbed from their inputs. A
-    ``json_invalid`` error keeps its parser diagnosis but loses its input
-    entirely, because unparsed raw JSON cannot be scrubbed by field name.
+    Errors whose loc is the credential field collapse to a closed
+    malformed-credential failure (``title``/``field``/``message``). Unrelated
+    failures (a missing ``text``, for example) keep their diagnosis; only the
+    credential material is scrubbed from their inputs. A ``json_invalid`` error
+    keeps its parser diagnosis but loses its input entirely, because unparsed
+    raw JSON cannot be scrubbed by field name.
     """
 
     errors = exc.errors()
@@ -178,11 +209,11 @@ def redact_adoption_credential_error(exc: ValidationError) -> ValidationError:
         loc = err.get("loc", ())
         loc_text = ".".join(str(part) for part in loc) if isinstance(loc, tuple) else ""
         msg = str(err.get("msg", ""))
-        if "adoption_credential" in loc_text or msg == "malformed adoption credential":
+        if field in loc_text or msg == message:
             credential_failed = True
             break
     if credential_failed:
-        return _malformed_event_error()
+        return _malformed_credential_error(title, field, message)
     scrubbed: list[Any] = []
     for err in errors:
         input_value = err.get("input")
@@ -196,14 +227,25 @@ def redact_adoption_credential_error(exc: ValidationError) -> ValidationError:
             item["input"] = "<redacted>"
             scrubbed.append(item)
             continue
-        if isinstance(input_value, str) and "adoption_credential" in input_value:
-            return _malformed_event_error()
-        item["input"] = _scrub_credential_input(input_value)
+        if isinstance(input_value, str) and field in input_value:
+            return _malformed_credential_error(title, field, message)
+        item["input"] = _scrub_credential_input(input_value, field)
         scrubbed.append(item)
     try:
         return ValidationError.from_exception_data(exc.title, scrubbed)
     except (TypeError, ValueError):
-        return _malformed_event_error()
+        return _malformed_credential_error(title, field, message)
+
+
+def redact_adoption_credential_error(exc: ValidationError) -> ValidationError:
+    """``redact_credential_error`` bound to ``Event.adoption_credential``."""
+
+    return redact_credential_error(
+        exc,
+        title="Event",
+        field="adoption_credential",
+        message="malformed adoption credential",
+    )
 
 
 class Event(_AciModel):

--- a/packages/aci-protocol/src/aci_protocol/events.py
+++ b/packages/aci-protocol/src/aci_protocol/events.py
@@ -295,12 +295,16 @@ class Event(_AciModel):
         json_data: str | bytes | bytearray,
         **kwargs: Any,
     ) -> "Event":
+        # Raise outside the handler: ``from None`` hides traceback display but
+        # leaves the original raw-input error reachable through ``__context__``.
+        redacted: ValidationError | None = None
         try:
             return super().model_validate_json(json_data, **kwargs)
         except ValidationError as exc:
-            raise redact_adoption_credential_error(exc) from None
+            redacted = redact_adoption_credential_error(exc)
         except json.JSONDecodeError:
-            raise _malformed_event_error() from None
+            redacted = _malformed_event_error()
+        raise redacted
 
     @model_validator(mode="wrap")
     @classmethod

--- a/packages/aci-protocol/src/aci_protocol/rust_export.py
+++ b/packages/aci-protocol/src/aci_protocol/rust_export.py
@@ -360,8 +360,11 @@ where
 
 
 # One admission rule for every credential-bearing field, mirroring the Python
-# ``admit_bounded_credential``: absent/null is None; a present value must be
-# non-blank and within the cap, and the error names the field, never the value.
+# ``admit_bounded_credential``: absent/null is None; a present value must be a
+# non-blank string within the cap, and the error names the field, never the
+# value. Decoded as a ``serde_json::Value`` first so a non-string (a number, a
+# bool, an array) also lands in the fixed-message arm: serde's own type error
+# for ``Option<String>`` would echo a scalar ("invalid type: integer `4711`").
 # The caps are interpolated from the Python constants so the two lanes cannot
 # drift on the bound.
 _BOUNDED_CREDENTIAL_DESERIALIZER = """fn deserialize_bounded_credential<'de, D>(
@@ -372,13 +375,15 @@ _BOUNDED_CREDENTIAL_DESERIALIZER = """fn deserialize_bounded_credential<'de, D>(
 where
     D: serde::Deserializer<'de>,
 {
-    let value = Option::<String>::deserialize(deserializer)?;
-    match &value {
-        None => Ok(None),
-        Some(s) if s.trim().is_empty() || s.chars().count() > max_chars => {
-            Err(serde::de::Error::custom(format!("malformed {what}")))
+    let value = Option::<serde_json::Value>::deserialize(deserializer)?;
+    match value {
+        None | Some(serde_json::Value::Null) => Ok(None),
+        Some(serde_json::Value::String(s))
+            if !s.trim().is_empty() && s.chars().count() <= max_chars =>
+        {
+            Ok(Some(s))
         }
-        Some(_) => Ok(value),
+        Some(_) => Err(serde::de::Error::custom(format!("malformed {what}"))),
     }
 }"""
 
@@ -569,6 +574,41 @@ mod tests {
         let raw = format!("{BOOT_ENV_MINIMAL},\\"runner_bootstrap_token\\":\\"   \\"}}");
         let error = serde_json::from_str::<BootEnv>(&raw).unwrap_err();
         assert!(error.to_string().contains("malformed runner bootstrap token"));
+    }
+
+    #[test]
+    fn boot_env_rejects_non_string_bootstrap_token_without_echo() {
+        let specimens = [
+            "4711",
+            "true",
+            r#"["runner-bootstrap-token-fixture-PLACEHOLDER"]"#,
+            r#"{"v":"runner-bootstrap-token-fixture-PLACEHOLDER"}"#,
+        ];
+        for specimen in specimens {
+            let raw = format!("{BOOT_ENV_MINIMAL},\\"runner_bootstrap_token\\":{specimen}}}");
+            let rendered = serde_json::from_str::<BootEnv>(&raw).unwrap_err().to_string();
+            assert!(rendered.contains("malformed runner bootstrap token"), "{rendered}");
+            assert!(!rendered.contains("4711"), "{rendered}");
+            assert!(!rendered.contains("runner-bootstrap-token-fixture-PLACEHOLDER"), "{rendered}");
+        }
+    }
+
+    #[test]
+    fn boot_env_explicit_null_bootstrap_token_is_none() {
+        let raw = format!("{BOOT_ENV_MINIMAL},\\"runner_bootstrap_token\\":null}}");
+        let decoded: BootEnv = serde_json::from_str(&raw).unwrap();
+        assert_eq!(decoded.runner_bootstrap_token, None);
+    }
+
+    #[test]
+    fn inbound_event_rejects_non_string_adoption_credential_without_echo() {
+        let raw = concat!(
+            r#"{"kind":"event","type":"message","text":"hi","user":"U1","ts":"1.0","#,
+            r#""adoption_credential":4711}"#
+        );
+        let rendered = serde_json::from_str::<InboundMessage>(raw).unwrap_err().to_string();
+        assert!(rendered.contains("malformed adoption credential"), "{rendered}");
+        assert!(!rendered.contains("4711"), "{rendered}");
     }
 
     #[test]

--- a/packages/aci-protocol/src/aci_protocol/rust_export.py
+++ b/packages/aci-protocol/src/aci_protocol/rust_export.py
@@ -19,6 +19,7 @@ from typing import Any, Literal, Union, get_args, get_origin
 from pydantic import BaseModel
 
 from .events import (
+    ADOPTION_CREDENTIAL_MAX_CHARS,
     ErrorEvent,
     Event,
     Final,
@@ -35,7 +36,13 @@ from .service_config import (
     STREAM_PAYLOAD_FIELD,
     WORKER_GROUP_DEFAULT,
 )
-from .session import BootEnv, Budget, OtelConfig, SessionConfig
+from .session import (
+    RUNNER_BOOTSTRAP_TOKEN_MAX_CHARS,
+    BootEnv,
+    Budget,
+    OtelConfig,
+    SessionConfig,
+)
 from .turn import QueuedTurn, ReplyHandle, TurnSource
 from .version import PROTOCOL_VERSION, WIRE_VERSION_FIELD
 from .wire import ApprovalRequest, EvalJob, EvalReport, GateKind
@@ -184,6 +191,10 @@ def _struct_fields(model: type[BaseModel], skip: set[str], public: bool) -> list
             out.append(
                 '    #[serde(default, deserialize_with = "deserialize_adoption_credential")]'
             )
+        elif field_name == "runner_bootstrap_token":
+            out.append(
+                '    #[serde(default, deserialize_with = "deserialize_runner_bootstrap_token")]'
+            )
         elif field.is_required() and nullable:
             out.append('    #[serde(deserialize_with = "deserialize_required_nullable")]')
         elif not field.is_required():
@@ -194,13 +205,53 @@ def _struct_fields(model: type[BaseModel], skip: set[str], public: bool) -> list
     return out
 
 
-def _struct(model: type[BaseModel]) -> str:
+def _struct(model: type[BaseModel], redact: frozenset[str] = frozenset()) -> str:
     # No deny_unknown_fields: the reader path is deliberately tolerant of unknown
     # fields (strict producers, tolerant consumers). A Rust producer stays strict
     # by construction -- a struct cannot serialize a field it does not have -- so
     # dropping it only loosens the read path we mean to loosen.
-    lines = [_STRUCT_DERIVES, f"pub struct {model.__name__} {{"]
+    #
+    # ``redact`` names secret-bearing fields: the struct then gets a hand-rolled
+    # Debug (generated below, not written by hand) that prints ``<redacted>``
+    # in their place, so a ``{:?}`` of the boot env cannot echo a credential.
+    derives = _STRUCT_DERIVES.replace("Debug, ", "") if redact else _STRUCT_DERIVES
+    lines = [derives, f"pub struct {model.__name__} {{"]
     lines.extend(_struct_fields(model, skip=set(), public=True))
+    lines.append("}")
+    if redact:
+        unknown = redact - set(model.model_fields)
+        if unknown:
+            raise TypeError(f"{model.__name__} has no field(s) {sorted(unknown)} to redact")
+        lines.append("")
+        lines.append(_debug_impl(model, redact))
+    return "\n".join(lines)
+
+
+def _debug_impl(model: type[BaseModel], redact: frozenset[str]) -> str:
+    """A field-complete Debug impl that redacts the named fields.
+
+    Every field is listed (a derived Debug would print all of them), and the
+    redacted ones print ``<redacted>`` when set and ``None`` when unset, so a
+    debug line still says whether a credential was configured.
+    """
+
+    name = model.__name__
+    lines = [
+        f"impl std::fmt::Debug for {name} {{",
+        "    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {",
+        f'        f.debug_struct("{name}")',
+    ]
+    for field_name in model.model_fields:
+        rust_name = _rust_field(field_name)
+        if field_name in redact:
+            lines.append("            .field(")
+            lines.append(f'                "{field_name}",')
+            lines.append(f'                &self.{rust_name}.as_ref().map(|_| "<redacted>"),')
+            lines.append("            )")
+        else:
+            lines.append(f'            .field("{field_name}", &self.{rust_name})')
+    lines.append("            .finish()")
+    lines.append("    }")
     lines.append("}")
     return "\n".join(lines)
 
@@ -308,8 +359,15 @@ where
 }"""
 
 
-_ADOPTION_CREDENTIAL_DESERIALIZER = """fn deserialize_adoption_credential<'de, D>(
+# One admission rule for every credential-bearing field, mirroring the Python
+# ``admit_bounded_credential``: absent/null is None; a present value must be
+# non-blank and within the cap, and the error names the field, never the value.
+# The caps are interpolated from the Python constants so the two lanes cannot
+# drift on the bound.
+_BOUNDED_CREDENTIAL_DESERIALIZER = """fn deserialize_bounded_credential<'de, D>(
     deserializer: D,
+    what: &'static str,
+    max_chars: usize,
 ) -> Result<Option<String>, D::Error>
 where
     D: serde::Deserializer<'de>,
@@ -317,12 +375,38 @@ where
     let value = Option::<String>::deserialize(deserializer)?;
     match &value {
         None => Ok(None),
-        Some(s) if s.trim().is_empty() || s.chars().count() > 4096 => {
-            Err(serde::de::Error::custom("malformed adoption credential"))
+        Some(s) if s.trim().is_empty() || s.chars().count() > max_chars => {
+            Err(serde::de::Error::custom(format!("malformed {what}")))
         }
         Some(_) => Ok(value),
     }
 }"""
+
+_ADOPTION_CREDENTIAL_DESERIALIZER = f"""fn deserialize_adoption_credential<'de, D>(
+    deserializer: D,
+) -> Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{{
+    deserialize_bounded_credential(
+        deserializer,
+        "adoption credential",
+        {ADOPTION_CREDENTIAL_MAX_CHARS},
+    )
+}}"""
+
+_RUNNER_BOOTSTRAP_TOKEN_DESERIALIZER = f"""fn deserialize_runner_bootstrap_token<'de, D>(
+    deserializer: D,
+) -> Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{{
+    deserialize_bounded_credential(
+        deserializer,
+        "runner bootstrap token",
+        {RUNNER_BOOTSTRAP_TOKEN_MAX_CHARS},
+    )
+}}"""
 
 
 _INBOUND_DEBUG_IMPL = """impl std::fmt::Debug for InboundMessage {
@@ -442,6 +526,60 @@ mod tests {
         assert!(!error.to_string().contains("adoption-credential-fixture-PLACEHOLDER"));
     }
 
+    const BOOT_ENV_MINIMAL: &str = concat!(
+        r#"{"session":{"plugin_dir":"/plugins/bundle","session_id":"sess-abc","#,
+        r#""sandbox_id":"curie-sandbox-abc123","#,
+        r#""budget":{"max_output_tokens_per_run":4096,"max_usd_per_day":5.0}}"#
+    );
+
+    #[test]
+    fn boot_env_omitted_bootstrap_token_is_none() {
+        let raw = format!("{BOOT_ENV_MINIMAL}}}");
+        let decoded: BootEnv = serde_json::from_str(&raw).unwrap();
+        assert_eq!(decoded.runner_bootstrap_token, None);
+        assert_eq!(decoded.runner_token, None);
+    }
+
+    #[test]
+    fn boot_env_bootstrap_token_roundtrips() {
+        let boot = BootEnv {
+            runner_bootstrap_token: Some("runner-bootstrap-token-fixture-PLACEHOLDER".to_string()),
+            ..BootEnv::default()
+        };
+        let encoded = serde_json::to_string(&boot).unwrap();
+        let decoded: BootEnv = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(boot, decoded);
+    }
+
+    #[test]
+    fn boot_env_debug_redacts_bootstrap_token() {
+        let boot = BootEnv {
+            runner_bootstrap_token: Some("runner-bootstrap-token-fixture-PLACEHOLDER".to_string()),
+            ..BootEnv::default()
+        };
+        let rendered = format!("{boot:?}");
+        assert!(!rendered.contains("runner-bootstrap-token-fixture-PLACEHOLDER"));
+        assert!(rendered.contains("runner_bootstrap_token: Some(\\"<redacted>\\")"));
+        let unset = format!("{:?}", BootEnv::default());
+        assert!(unset.contains("runner_bootstrap_token: None"));
+    }
+
+    #[test]
+    fn boot_env_rejects_blank_bootstrap_token() {
+        let raw = format!("{BOOT_ENV_MINIMAL},\\"runner_bootstrap_token\\":\\"   \\"}}");
+        let error = serde_json::from_str::<BootEnv>(&raw).unwrap_err();
+        assert!(error.to_string().contains("malformed runner bootstrap token"));
+    }
+
+    #[test]
+    fn boot_env_rejects_oversize_bootstrap_token_without_echo() {
+        let material = format!("runner-bootstrap-token-fixture-PLACEHOLDER{}", "x".repeat(4096));
+        let raw = format!("{BOOT_ENV_MINIMAL},\\"runner_bootstrap_token\\":\\"{material}\\"}}");
+        let error = serde_json::from_str::<BootEnv>(&raw).unwrap_err();
+        assert!(error.to_string().contains("malformed runner bootstrap token"));
+        assert!(!error.to_string().contains("runner-bootstrap-token-fixture-PLACEHOLDER"));
+    }
+
     #[test]
     fn reply_handle_accepts_explicit_null_placeholder() {
         let raw = r#"{"kind":"email","channel":"agent@example.test","placeholder":null,"endpoint":"https://adapter.example/hook","adapter":"agentmail_sandbox"}"#;
@@ -536,7 +674,9 @@ def render_rust() -> str:
         f'pub const STREAM_PAYLOAD_FIELD: &str = "{STREAM_PAYLOAD_FIELD}";',
         _VERSION_GUARD,
         _REQUIRED_NULLABLE_DESERIALIZER,
+        _BOUNDED_CREDENTIAL_DESERIALIZER,
         _ADOPTION_CREDENTIAL_DESERIALIZER,
+        _RUNNER_BOOTSTRAP_TOKEN_DESERIALIZER,
         _string_enum(
             "SessionStatus",
             tuple(m.value for m in SessionStatus),
@@ -558,7 +698,7 @@ def render_rust() -> str:
         _struct(Budget),
         _struct(OtelConfig),
         _struct(SessionConfig),
-        _struct(BootEnv),
+        _struct(BootEnv, redact=frozenset({"runner_bootstrap_token"})),
         _env_keys_module(),
         _struct(ReplyHandle),
         _struct(QueuedTurn),

--- a/packages/aci-protocol/src/aci_protocol/session.py
+++ b/packages/aci-protocol/src/aci_protocol/session.py
@@ -188,35 +188,17 @@ def _malformed_boot_env_error() -> ValidationError:
 def parse_runner_bootstrap_token(value: Any) -> str | None:
     """Admit an optional bootstrap token, or raise without echoing it.
 
-    ``None`` is "no bootstrap presented". Any other well-formed value is a
-    non-empty string no longer than ``RUNNER_BOOTSTRAP_TOKEN_MAX_CHARS`` that is
-    not whitespace-only. Same admission rule and same no-echo guarantee as
-    ``parse_adoption_credential``; the two are one helper bound twice.
+    ``None`` is "no bootstrap presented" (the key is absent). Any other
+    well-formed value is a non-empty string no longer than
+    ``RUNNER_BOOTSTRAP_TOKEN_MAX_CHARS`` that is not whitespace-only; an empty
+    string is malformed, not unset. Same admission rule and same no-echo
+    guarantee as ``parse_adoption_credential``; the two are one helper bound
+    twice.
     """
 
     return admit_bounded_credential(
         value, max_chars=RUNNER_BOOTSTRAP_TOKEN_MAX_CHARS, error=_malformed_bootstrap_token
     )
-
-
-def _bootstrap_token_or_none(raw: str | None) -> str | None:
-    """Env parse: empty is unset; a present malformed value fails the boot closed.
-
-    The first half is the BootEnv-wide rule (exactly ``_str_or_none``): a
-    declared-but-empty var is "unset", so an empty key yields the same legacy
-    tokenless boot a pod without the key gets. The second half deliberately
-    differs from ``_str_or_none``: a present value that is blank or oversize
-    is NOT passed through verbatim and NOT degraded to ``None``, because
-    degrading would turn a mis-rendered pool Secret into a warm pod that
-    enforces nothing. The raised error never carries the material.
-    """
-
-    if not raw:
-        return None
-    try:
-        return parse_runner_bootstrap_token(raw)
-    except ValueError:
-        raise _malformed_boot_env_error() from None
 
 
 def _env(key: str, *producers: Producer) -> dict[str, Any]:
@@ -386,11 +368,16 @@ class BootEnv(_AciModel):
     #   - neither present: today's tokenless legacy boot, unchanged. Nothing
     #     is relaxed and nothing new is enforced by this field's existence.
     #
-    # Secret material: omitted from ``repr``/``str``; a malformed value fails
-    # the parse closed with an error that never carries the material (see
-    # ``_bootstrap_token_or_none`` for the env rule and ``_admit_runner_bootstrap_token``
-    # for the model path). Declaring the key is not bootstrap mode, adoption,
-    # retirement, or a pool; those remain #1492 realizing work.
+    # Secret material: omitted from ``repr``/``str``; a present value that is
+    # empty, blank, oversize or not a string fails the parse closed with an
+    # error that never carries the material (``_admit_runner_bootstrap_token``,
+    # on every construction path including ``from_env``). Unlike every other
+    # optional boot var, a declared-but-EMPTY value is NOT "unset": the only
+    # producer is a pool Secret, an empty ``secretKeyRef`` is a mis-render, and
+    # decoding it as "neither token present" would boot a warm pod that
+    # enforces nothing. Only an ABSENT key is the compatible legacy case.
+    # Declaring the key is not bootstrap mode, adoption, retirement, or a
+    # pool; those remain #1492 realizing work.
     runner_bootstrap_token: str | None = Field(
         default=None,
         repr=False,
@@ -536,14 +523,20 @@ class BootEnv(_AciModel):
         json_data: str | bytes | bytearray,
         **kwargs: Any,
     ) -> "BootEnv":
+        # The redacted error is raised OUTSIDE the except block on purpose:
+        # ``raise ... from None`` only suppresses display, and the original
+        # error (whose ``json_invalid`` input is the raw material) would stay
+        # reachable through ``__context__``. Leaving the block first drops it.
+        redacted: ValidationError | None = None
         try:
             return super().model_validate_json(json_data, **kwargs)
         except ValidationError as exc:
-            raise redact_credential_error(
+            redacted = redact_credential_error(
                 exc, title="BootEnv", field=_BOOTSTRAP_FIELD, message=_BOOTSTRAP_MALFORMED
-            ) from None
+            )
         except json.JSONDecodeError:
-            raise _malformed_boot_env_error() from None
+            redacted = _malformed_boot_env_error()
+        raise redacted
 
     @model_validator(mode="wrap")
     @classmethod
@@ -552,20 +545,26 @@ class BootEnv(_AciModel):
         # records ``input_value``, exactly as ``Event._admit_adoption_credential``
         # does: the wrap path is what keeps a boot-time log line or an HTTP body
         # that interpolates ``ValidationError`` from echoing the credential.
+        # Redacted errors are raised outside their except blocks (see
+        # ``model_validate_json``) so no ``__context__`` retains the material.
+        redacted: ValidationError | None = None
         if isinstance(data, Mapping) and _BOOTSTRAP_FIELD in data:
             incoming = dict(data)
             raw = incoming.pop(_BOOTSTRAP_FIELD)
             try:
                 incoming[_BOOTSTRAP_FIELD] = parse_runner_bootstrap_token(raw)
             except ValueError:
-                raise _malformed_boot_env_error() from None
+                redacted = _malformed_boot_env_error()
+            if redacted is not None:
+                raise redacted
             data = incoming
         try:
             return handler(data)
         except ValidationError as exc:
-            raise redact_credential_error(
+            redacted = redact_credential_error(
                 exc, title="BootEnv", field=_BOOTSTRAP_FIELD, message=_BOOTSTRAP_MALFORMED
-            ) from None
+            )
+        raise redacted
 
     @classmethod
     def _declared(cls) -> dict[str, tuple[str, tuple[Producer, ...]]]:
@@ -829,7 +828,13 @@ class BootEnv(_AciModel):
             bundle_ref=_str_or_none(env.get("CURIE_BUNDLE_REF")),
             bundle_version=_str_or_none(env.get("CURIE_BUNDLE_VERSION")),
             runner_token=_str_or_none(env.get("CURIE_RUNNER_TOKEN")),
-            runner_bootstrap_token=_bootstrap_token_or_none(env.get("CURIE_RUNNER_BOOTSTRAP_TOKEN")),
+            # Passed through RAW, not via ``_str_or_none``: for this key a
+            # declared-but-empty value is a mis-rendered pool Secret, not
+            # "unset", and must fail the boot closed rather than decode as the
+            # tokenless legacy boot. ``_admit_runner_bootstrap_token`` is the
+            # single admission point for absent (None), empty, blank, oversize
+            # and non-string values, on every construction path.
+            runner_bootstrap_token=env.get("CURIE_RUNNER_BOOTSTRAP_TOKEN"),
             model=_str_or_none(env.get("CURIE_MODEL")),
             fake_model=_fake_model_or_none(env.get("CURIE_FAKE_MODEL")),
             history_ref=_str_or_none(env.get("CURIE_HISTORY_REF")),

--- a/packages/aci-protocol/src/aci_protocol/session.py
+++ b/packages/aci-protocol/src/aci_protocol/session.py
@@ -17,17 +17,24 @@ Env mapping:
 
 ``BootEnv`` (#488, ADR-0049) is the Curie-platform superset: SessionConfig
 COMPOSED as a field plus the platform-operational boot vars (runner token,
-bundle ref, approval plumbing, history port, model routing, the operator knobs).
+pool bootstrap token, bundle ref, approval plumbing, history port, model
+routing, the operator knobs).
 It is deliberately not an extension of SessionConfig -- see ADR-0049 and the
 class docstring.
 """
 
+import json
 from collections.abc import Mapping, Sequence
 from typing import Any, Literal, cast
 
-from pydantic import Field
+from pydantic import Field, ValidationError, model_validator
 
-from .events import _AciModel
+from .events import (
+    _AciModel,
+    _malformed_credential_error,
+    admit_bounded_credential,
+    redact_credential_error,
+)
 
 
 class Budget(_AciModel):
@@ -155,6 +162,61 @@ _SESSION_ENV: dict[str, tuple[str, tuple[Producer, ...]]] = {
     "otel_headers": ("OTEL_EXPORTER_OTLP_HEADERS", ("operator",)),
     "otel_protocol": ("OTEL_EXPORTER_OTLP_PROTOCOL", ("substrate",)),
 }
+
+
+# Opaque pool bootstrap credential (#1492, ADR-0122). Same character cap as
+# ``ADOPTION_CREDENTIAL_MAX_CHARS`` and for the same reason: long enough for a
+# typical bearer, short enough to reject a dump. Not a product secret format.
+RUNNER_BOOTSTRAP_TOKEN_MAX_CHARS = 4096
+
+_BOOTSTRAP_FIELD = "runner_bootstrap_token"
+_BOOTSTRAP_MALFORMED = "malformed runner bootstrap token"
+
+
+def _malformed_bootstrap_token() -> ValueError:
+    """Reject without attaching the presented material to the exception."""
+
+    return ValueError(_BOOTSTRAP_MALFORMED)
+
+
+def _malformed_boot_env_error() -> ValidationError:
+    """A material-free ValidationError for a bad runner_bootstrap_token."""
+
+    return _malformed_credential_error("BootEnv", _BOOTSTRAP_FIELD, _BOOTSTRAP_MALFORMED)
+
+
+def parse_runner_bootstrap_token(value: Any) -> str | None:
+    """Admit an optional bootstrap token, or raise without echoing it.
+
+    ``None`` is "no bootstrap presented". Any other well-formed value is a
+    non-empty string no longer than ``RUNNER_BOOTSTRAP_TOKEN_MAX_CHARS`` that is
+    not whitespace-only. Same admission rule and same no-echo guarantee as
+    ``parse_adoption_credential``; the two are one helper bound twice.
+    """
+
+    return admit_bounded_credential(
+        value, max_chars=RUNNER_BOOTSTRAP_TOKEN_MAX_CHARS, error=_malformed_bootstrap_token
+    )
+
+
+def _bootstrap_token_or_none(raw: str | None) -> str | None:
+    """Env parse: empty is unset; a present malformed value fails the boot closed.
+
+    The first half is the BootEnv-wide rule (exactly ``_str_or_none``): a
+    declared-but-empty var is "unset", so an empty key yields the same legacy
+    tokenless boot a pod without the key gets. The second half deliberately
+    differs from ``_str_or_none``: a present value that is blank or oversize
+    is NOT passed through verbatim and NOT degraded to ``None``, because
+    degrading would turn a mis-rendered pool Secret into a warm pod that
+    enforces nothing. The raised error never carries the material.
+    """
+
+    if not raw:
+        return None
+    try:
+        return parse_runner_bootstrap_token(raw)
+    except ValueError:
+        raise _malformed_boot_env_error() from None
 
 
 def _env(key: str, *producers: Producer) -> dict[str, Any]:
@@ -298,6 +360,45 @@ class BootEnv(_AciModel):
     runner_token: str | None = Field(
         default=None, json_schema_extra=_env("CURIE_RUNNER_TOKEN", "worker")
     )
+    # Pool bootstrap credential (#1492; ADR-0116 decision 2, ADR-0122). Written
+    # by the SUBSTRATE only: one Secret per warm pool, delivered through the
+    # pool template's ``secretKeyRef``. The worker's per-claim render never
+    # writes it, and ``render_worker`` has no parameter for it by design.
+    #
+    # It is a distinct key rather than a reuse of ``runner_token`` because the
+    # two credentials carry different AUTHORITY, and an unbound warm runner has
+    # to tell them apart at boot: ``CURIE_RUNNER_TOKEN`` means "bound,
+    # per-conversation, enforced on every gated ACI route", while a bootstrap
+    # may authorize exactly one atomic adoption (an ``Event`` carrying
+    # ``adoption_credential``) and is retired for that pod once applied. The
+    # chart's ``CURIE_SESSION_ID=warm-unbound`` placeholder is a template value,
+    # not a contract signal, and must not be used as the mode switch.
+    #
+    # Consumer authority policy (documented here; realized by the runner, not
+    # by this package):
+    #   - ``runner_token`` present: bound per-conversation mode. The bootstrap
+    #     value is ignored and never admitted, so the cold path is unchanged
+    #     even if a pool template and a per-claim render both wrote a key.
+    #   - only ``runner_bootstrap_token`` present: bootstrap mode. The
+    #     credential authorizes one adoption; any other gated request that
+    #     presents it is refused before a model turn starts, and after the
+    #     adoption is applied it authenticates nothing against that pod.
+    #   - neither present: today's tokenless legacy boot, unchanged. Nothing
+    #     is relaxed and nothing new is enforced by this field's existence.
+    #
+    # Secret material: omitted from ``repr``/``str``; a malformed value fails
+    # the parse closed with an error that never carries the material (see
+    # ``_bootstrap_token_or_none`` for the env rule and ``_admit_runner_bootstrap_token``
+    # for the model path). Declaring the key is not bootstrap mode, adoption,
+    # retirement, or a pool; those remain #1492 realizing work.
+    runner_bootstrap_token: str | None = Field(
+        default=None,
+        repr=False,
+        min_length=1,
+        max_length=RUNNER_BOOTSTRAP_TOKEN_MAX_CHARS,
+        pattern=r".*\S.*",
+        json_schema_extra=_env("CURIE_RUNNER_BOOTSTRAP_TOKEN", "substrate"),
+    )
     # The agent's pinned model (#254), overriding the worker default. The chart
     # also bakes a template default (inference.model, or runner.model) so a warm
     # pod boots resolvable; the per-claim value wins under Overrides.
@@ -428,6 +529,43 @@ class BootEnv(_AciModel):
     history_max_bytes: int | None = Field(
         default=None, json_schema_extra=_env("CURIE_HISTORY_MAX_BYTES", "operator")
     )
+
+    @classmethod
+    def model_validate_json(
+        cls,
+        json_data: str | bytes | bytearray,
+        **kwargs: Any,
+    ) -> "BootEnv":
+        try:
+            return super().model_validate_json(json_data, **kwargs)
+        except ValidationError as exc:
+            raise redact_credential_error(
+                exc, title="BootEnv", field=_BOOTSTRAP_FIELD, message=_BOOTSTRAP_MALFORMED
+            ) from None
+        except json.JSONDecodeError:
+            raise _malformed_boot_env_error() from None
+
+    @model_validator(mode="wrap")
+    @classmethod
+    def _admit_runner_bootstrap_token(cls, data: Any, handler: Any) -> Any:
+        # Validate and (on failure) drop the presented value before pydantic
+        # records ``input_value``, exactly as ``Event._admit_adoption_credential``
+        # does: the wrap path is what keeps a boot-time log line or an HTTP body
+        # that interpolates ``ValidationError`` from echoing the credential.
+        if isinstance(data, Mapping) and _BOOTSTRAP_FIELD in data:
+            incoming = dict(data)
+            raw = incoming.pop(_BOOTSTRAP_FIELD)
+            try:
+                incoming[_BOOTSTRAP_FIELD] = parse_runner_bootstrap_token(raw)
+            except ValueError:
+                raise _malformed_boot_env_error() from None
+            data = incoming
+        try:
+            return handler(data)
+        except ValidationError as exc:
+            raise redact_credential_error(
+                exc, title="BootEnv", field=_BOOTSTRAP_FIELD, message=_BOOTSTRAP_MALFORMED
+            ) from None
 
     @classmethod
     def _declared(cls) -> dict[str, tuple[str, tuple[Producer, ...]]]:
@@ -621,6 +759,8 @@ class BootEnv(_AciModel):
             env[self.env_key("bundle_version")] = self.bundle_version
         if self.runner_token is not None:
             env[self.env_key("runner_token")] = self.runner_token
+        if self.runner_bootstrap_token is not None:
+            env[self.env_key("runner_bootstrap_token")] = self.runner_bootstrap_token
         if self.model is not None:
             env[self.env_key("model")] = self.model
         if self.fake_model is not None:
@@ -689,6 +829,7 @@ class BootEnv(_AciModel):
             bundle_ref=_str_or_none(env.get("CURIE_BUNDLE_REF")),
             bundle_version=_str_or_none(env.get("CURIE_BUNDLE_VERSION")),
             runner_token=_str_or_none(env.get("CURIE_RUNNER_TOKEN")),
+            runner_bootstrap_token=_bootstrap_token_or_none(env.get("CURIE_RUNNER_BOOTSTRAP_TOKEN")),
             model=_str_or_none(env.get("CURIE_MODEL")),
             fake_model=_fake_model_or_none(env.get("CURIE_FAKE_MODEL")),
             history_ref=_str_or_none(env.get("CURIE_HISTORY_REF")),

--- a/packages/aci-protocol/src/aci_protocol/version.py
+++ b/packages/aci-protocol/src/aci_protocol/version.py
@@ -20,7 +20,7 @@ the guard.
 import re
 from typing import Final
 
-PROTOCOL_VERSION: Final = "0.4.5"
+PROTOCOL_VERSION: Final = "0.4.6"
 
 # The wire field carrying the protocol version on every outbound event. Both
 # exporters special-case this field by name; do not rename without updating them.

--- a/packages/aci-protocol/tests/test_adoption_credential.py
+++ b/packages/aci-protocol/tests/test_adoption_credential.py
@@ -221,7 +221,11 @@ def test_unrelated_missing_field_is_not_reported_as_malformed_credential() -> No
 
 
 def test_protocol_version_is_the_compatible_patch() -> None:
-    assert PROTOCOL_VERSION == "0.4.5"
+    # 0.4.5 introduced this contract; later optional-field patches on the same
+    # 0.4 line stay wire compatible with it.
+    from aci_protocol import is_compatible
+
+    assert is_compatible("0.4.5", PROTOCOL_VERSION)
 
 
 def test_malformed_json_errors_do_not_echo_secret_material() -> None:

--- a/packages/aci-protocol/tests/test_adoption_credential.py
+++ b/packages/aci-protocol/tests/test_adoption_credential.py
@@ -267,7 +267,28 @@ def _malformed_json_specimens() -> list[tuple[str, str | bytes | bytearray]]:
         ("escaped-bytearray", bytearray(escaped.encode())),
         ("keyless-str", keyless),
         ("keyless-bytes", keyless.encode()),
+        ("keyless-bytearray", bytearray(keyless.encode())),
     ]
+
+
+def _assert_no_credential_in_exception_chain(error: BaseException) -> None:
+    pending = [error]
+    seen: set[int] = set()
+    while pending:
+        current = pending.pop()
+        if id(current) in seen:
+            continue
+        seen.add(id(current))
+        surfaces = [str(current), repr(current)]
+        if isinstance(current, ValidationError):
+            surfaces.extend((json.dumps(current.errors(), default=str), current.json()))
+        assert all(_CREDENTIAL not in surface for surface in surfaces)
+        # Follow both links even when traceback display suppresses the context.
+        pending.extend(
+            linked for linked in (current.__cause__, current.__context__) if linked is not None
+        )
+    assert error.__cause__ is None
+    assert error.__context__ is None
 
 
 @pytest.mark.parametrize(
@@ -296,6 +317,22 @@ def test_invalid_json_errors_redact_the_whole_raw_input(
     types = {err["type"] for err in error.errors()}
     assert types == {"json_invalid"}, types
     assert all(err["input"] == "<redacted>" for err in error.errors())
+    _assert_no_credential_in_exception_chain(error)
+
+
+@pytest.mark.parametrize("encoding", (str, bytes, bytearray))
+def test_json_unrelated_error_keeps_diagnosis_without_credential_chain(
+    encoding: type[str] | type[bytes] | type[bytearray],
+) -> None:
+    body = _payload(adoption_credential=_CREDENTIAL)
+    del body["text"]
+    raw = json.dumps(body)
+    encoded = raw if encoding is str else encoding(raw.encode())
+    with pytest.raises(ValidationError) as exc:
+        Event.model_validate_json(encoded)
+    assert [(err["type"], err["loc"]) for err in exc.value.errors()] == [("missing", ("text",))]
+    assert "malformed adoption credential" not in str(exc.value)
+    _assert_no_credential_in_exception_chain(exc.value)
 
 
 def test_mapping_inputs_cannot_bypass_malformed_admission() -> None:

--- a/packages/aci-protocol/tests/test_bootstrap_token.py
+++ b/packages/aci-protocol/tests/test_bootstrap_token.py
@@ -1,0 +1,296 @@
+"""Bootstrap boot-env contract (#1492, ADR-0116 decision 2, ADR-0122).
+
+This package declares the key and its admission bounds. It does not implement
+bootstrap mode, adoption, retirement, pools, or any runtime authority check; a
+declared boot field is not those behaviors (see the field's docstring for the
+consumer authority policy the realizing runner enforces).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+
+import pytest
+from aci_protocol import (
+    PROTOCOL_VERSION,
+    READER_CONTEXT,
+    RUNNER_BOOTSTRAP_TOKEN_MAX_CHARS,
+    BootEnv,
+    Budget,
+    SessionConfig,
+    is_compatible,
+)
+from aci_protocol.env_example_export import render_block
+from aci_protocol.rust_export import render_rust
+from aci_protocol.schema_export import build_schema
+from pydantic import ValidationError
+
+# Distinctive fixture material, not a live credential. Every redaction test
+# asserts this exact string never reaches a repr, str, or error surface.
+_TOKEN = "runner-bootstrap-token-fixture-PLACEHOLDER"
+_KEY = "CURIE_RUNNER_BOOTSTRAP_TOKEN"
+_FIELD = "runner_bootstrap_token"
+
+_BUDGET = Budget(max_output_tokens_per_run=4096, max_usd_per_day=5.0)
+
+# A cold, bound pod's env as the worker + substrate write it today: a
+# per-conversation CURIE_RUNNER_TOKEN and no bootstrap key at all.
+_COLD_ENV: dict[str, str] = {
+    "CURIE_PLUGIN_DIR": "/plugins/bundle",
+    "CURIE_SESSION_ID": "sess-abc",
+    "CURIE_SANDBOX_ID": "curie-sandbox-abc123",
+    "CURIE_BUDGET": _BUDGET.model_dump_json(),
+    "CURIE_RUNNER_PORT": "8080",
+    "CURIE_RUNNER_TOKEN": "rt-per-conversation-fixture",
+}
+
+
+def _session() -> SessionConfig:
+    return SessionConfig(
+        plugin_dir="/plugins/bundle",
+        session_id="sess-abc",
+        sandbox_id="curie-sandbox-abc123",
+        budget=_BUDGET,
+    )
+
+
+def _warm_env(**overrides: str) -> dict[str, str]:
+    """A warm pool pod's env: substrate keys only, no per-conversation token."""
+    env = {k: v for k, v in _COLD_ENV.items() if k != "CURIE_RUNNER_TOKEN"}
+    env[_KEY] = _TOKEN
+    env.update(overrides)
+    return env
+
+
+def _surfaces(exc: BaseException) -> str:
+    """Every text a caller could log or interpolate from a raised error."""
+    parts = [str(exc), repr(exc), f"{exc}"]
+    if isinstance(exc, ValidationError):
+        parts.append(repr(exc.errors()))
+        parts.append(exc.json())
+    return "\n".join(parts)
+
+
+# --- Compatibility: omitted, empty, and the cold path are byte-identical -----
+
+
+def test_omitted_key_parses_to_none_and_renders_nothing() -> None:
+    boot = BootEnv.from_env(_COLD_ENV)
+    assert boot.runner_bootstrap_token is None
+    assert boot.runner_token == "rt-per-conversation-fixture"
+    assert _KEY not in boot.to_env()
+
+
+def test_declared_but_empty_is_unset_like_every_other_boot_var() -> None:
+    """The BootEnv-wide rule: a declared-but-empty var is "unset", never a value.
+
+    Mirrors ``runner_token`` (``env.get(...) or None``). An empty bootstrap key
+    therefore yields the same legacy, tokenless boot a pod without the key gets;
+    nothing is relaxed relative to today, because the key did not exist.
+    """
+    boot = BootEnv.from_env(_warm_env(**{_KEY: ""}))
+    assert boot.runner_bootstrap_token is None
+
+
+def test_cold_path_with_both_keys_parses_both_verbatim() -> None:
+    """The contract carries both; precedence is the consumer's policy.
+
+    ``runner_token`` present means the bound per-conversation mode and the
+    bootstrap is never admitted. That policy is documented on the field and
+    realized by the runner, not by this parse, which must not silently drop
+    either value (dropping the bootstrap here would hide a misconfigured pool
+    from the consumer that has to refuse it).
+    """
+    boot = BootEnv.from_env(_COLD_ENV | {_KEY: _TOKEN})
+    assert boot.runner_token == "rt-per-conversation-fixture"
+    assert boot.runner_bootstrap_token == _TOKEN
+
+
+def test_default_construction_is_none() -> None:
+    assert BootEnv(session=_session()).runner_bootstrap_token is None
+
+
+# --- The new env round trip ---------------------------------------------------
+
+
+def test_warm_env_roundtrips_through_from_env_and_to_env() -> None:
+    boot = BootEnv.from_env(_warm_env())
+    assert boot.runner_bootstrap_token == _TOKEN
+    assert boot.runner_token is None
+    rendered = boot.to_env()
+    assert rendered[_KEY] == _TOKEN
+    assert "CURIE_RUNNER_TOKEN" not in rendered
+    assert BootEnv.from_env(rendered) == boot
+
+
+def test_env_key_accessor_names_the_key() -> None:
+    assert BootEnv.env_key(_FIELD) == _KEY
+    assert _KEY in BootEnv.env_keys()
+
+
+def test_the_worker_render_surface_never_emits_the_bootstrap_key() -> None:
+    """Producer is the substrate (per-pool Secret), never the per-claim render."""
+    env = BootEnv.render_worker(
+        plugin_dir="/plugins/bundle",
+        session_id="sess-abc",
+        budget=_BUDGET,
+        memory_ref="s3://memory/agent",
+        history_ref="s3://history/thread",
+        runner_token="rt-per-conversation-fixture",
+    )
+    assert _KEY not in env
+    assert _KEY not in BootEnv.env_keys(producer="worker")
+    assert _KEY not in BootEnv.env_keys(producer="kernel")
+    assert _KEY not in BootEnv.env_keys(producer="operator")
+    assert _KEY in BootEnv.env_keys(producer="substrate")
+
+
+# --- Secrecy: repr, str, and every validation-error surface -------------------
+
+
+def test_repr_and_str_omit_the_token() -> None:
+    boot = BootEnv.from_env(_warm_env())
+    assert _TOKEN not in repr(boot)
+    assert _TOKEN not in str(boot)
+    assert _FIELD not in repr(boot)
+
+
+@pytest.mark.parametrize(
+    "raw",
+    (
+        " ",
+        "   ",
+        "\t\n",
+        " ",
+        _TOKEN + "x" * (RUNNER_BOOTSTRAP_TOKEN_MAX_CHARS - len(_TOKEN) + 1),
+    ),
+    ids=("space", "spaces", "tab-newline", "nbsp", "oversize"),
+)
+def test_present_but_malformed_env_value_fails_closed_without_echo(raw: str) -> None:
+    """A malformed present value must refuse the boot, not degrade to tokenless.
+
+    Degrading would turn a mis-rendered pool Secret into an unauthenticated
+    warm pod. The material is never attached to the error.
+    """
+    with pytest.raises(ValidationError) as exc:
+        BootEnv.from_env(_warm_env(**{_KEY: raw}))
+    rendered = _surfaces(exc.value)
+    assert _TOKEN not in rendered
+    assert raw.strip() == "" or raw not in rendered
+    assert "malformed runner bootstrap token" in rendered
+    assert [err["loc"] for err in exc.value.errors()] == [(_FIELD,)]
+
+
+def test_oversize_by_one_is_rejected_and_at_the_bound_is_admitted() -> None:
+    at_bound = "b" * RUNNER_BOOTSTRAP_TOKEN_MAX_CHARS
+    assert BootEnv.from_env(_warm_env(**{_KEY: at_bound})).runner_bootstrap_token == at_bound
+    with pytest.raises(ValidationError):
+        BootEnv.from_env(_warm_env(**{_KEY: at_bound + "b"}))
+
+
+@pytest.mark.parametrize(
+    "value",
+    (
+        1,
+        True,
+        b"bytes",
+        [_TOKEN],
+        {"nested": _TOKEN},
+        "",
+        "   ",
+        "x" * (RUNNER_BOOTSTRAP_TOKEN_MAX_CHARS + 1),
+    ),
+    ids=("int", "bool", "bytes", "list", "dict", "empty", "blank", "oversize"),
+)
+def test_direct_construction_rejects_malformed_values_without_echo(value: object) -> None:
+    """The model path (a producer building the union, or a JSON decode)."""
+    with pytest.raises(ValidationError) as exc:
+        BootEnv(session=_session(), runner_bootstrap_token=value)  # type: ignore[arg-type]
+    rendered = _surfaces(exc.value)
+    assert _TOKEN not in rendered
+    assert "malformed runner bootstrap token" in rendered
+    assert [err["loc"] for err in exc.value.errors()] == [(_FIELD,)]
+
+
+def test_model_validate_json_redacts_a_malformed_token() -> None:
+    raw = json.dumps({"session": _session().model_dump(), _FIELD: "   " + _TOKEN[:0]})
+    with pytest.raises(ValidationError) as exc:
+        BootEnv.model_validate_json(raw)
+    assert _TOKEN not in _surfaces(exc.value)
+
+
+def test_invalid_json_never_echoes_the_raw_input() -> None:
+    raw = '{"session": {}, "' + _FIELD + '": "' + _TOKEN + '", bad}'
+    with pytest.raises(ValidationError) as exc:
+        BootEnv.model_validate_json(raw)
+    assert _TOKEN not in _surfaces(exc.value)
+
+
+def test_unrelated_errors_keep_their_diagnosis_but_lose_the_material() -> None:
+    """A missing session field is still reported as such; the token is scrubbed."""
+    with pytest.raises(ValidationError) as exc:
+        BootEnv.model_validate({"session": {"plugin_dir": "/p"}, _FIELD: _TOKEN})
+    rendered = _surfaces(exc.value)
+    assert "session_id" in rendered
+    assert _TOKEN not in rendered
+
+
+def test_a_well_formed_token_with_an_unrelated_error_is_not_misdiagnosed() -> None:
+    with pytest.raises(ValidationError) as exc:
+        BootEnv.model_validate({"session": {"plugin_dir": "/p"}, _FIELD: _TOKEN})
+    assert "malformed runner bootstrap token" not in str(exc.value)
+
+
+# --- Old-consumer compatibility and the version class --------------------------
+
+
+def test_reader_context_tolerates_fields_a_consumer_does_not_model() -> None:
+    """The strict-producer/tolerant-consumer rule that makes an optional field a patch."""
+    payload = {"session": _session().model_dump(), "field_from_the_future": 1}
+    assert BootEnv.model_validate(payload, context=READER_CONTEXT).runner_bootstrap_token is None
+    with pytest.raises(ValidationError):
+        BootEnv.model_validate(payload)
+
+
+def test_protocol_version_is_the_compatible_patch_over_0_4_5() -> None:
+    assert PROTOCOL_VERSION == "0.4.6"
+    assert is_compatible("0.4.5", PROTOCOL_VERSION)
+    assert is_compatible(PROTOCOL_VERSION, "0.4.5")
+    assert not is_compatible("0.5.0", PROTOCOL_VERSION)
+
+
+def test_schema_declares_an_optional_bounded_nullable_string() -> None:
+    boot = build_schema()["$defs"]["BootEnv"]
+    prop = boot["properties"][_FIELD]
+    assert _FIELD not in boot.get("required", [])
+    assert prop["default"] is None
+    assert prop["env"] == _KEY
+    assert prop["producer"] == ["substrate"]
+    string_branch = next(b for b in prop["anyOf"] if b.get("type") == "string")
+    assert string_branch["minLength"] == 1
+    assert string_branch["maxLength"] == RUNNER_BOOTSTRAP_TOKEN_MAX_CHARS
+    assert re.compile(string_branch["pattern"]).search("a")
+    assert not re.compile(string_branch["pattern"]).search("   ")
+    assert {"type": "null"} in prop["anyOf"]
+
+
+# --- Exporter completeness ----------------------------------------------------
+
+
+def test_env_example_block_documents_the_key_as_substrate_owned() -> None:
+    line = next(line for line in render_block().splitlines() if _KEY in line)
+    assert line.endswith("producers: substrate")
+
+
+def test_generated_rust_carries_the_constant_and_redacts_the_field() -> None:
+    rust = render_rust()
+    assert f'pub const {_KEY}: &str = "{_KEY}";' in rust
+    assert 'deserialize_with = "deserialize_runner_bootstrap_token"' in rust
+    assert "impl std::fmt::Debug for BootEnv" in rust
+    assert (
+        '"runner_bootstrap_token",\n                &self.runner_bootstrap_token'
+        '.as_ref().map(|_| "<redacted>")'
+    ) in rust
+    assert "malformed runner bootstrap token" in rust
+    assert f"{RUNNER_BOOTSTRAP_TOKEN_MAX_CHARS}" in rust

--- a/packages/aci-protocol/tests/test_bootstrap_token.py
+++ b/packages/aci-protocol/tests/test_bootstrap_token.py
@@ -82,15 +82,20 @@ def test_omitted_key_parses_to_none_and_renders_nothing() -> None:
     assert _KEY not in boot.to_env()
 
 
-def test_declared_but_empty_is_unset_like_every_other_boot_var() -> None:
-    """The BootEnv-wide rule: a declared-but-empty var is "unset", never a value.
+def test_declared_but_empty_fails_closed_unlike_every_other_boot_var() -> None:
+    """Deliberately NOT the ``_str_or_none`` rule ``runner_token`` follows.
 
-    Mirrors ``runner_token`` (``env.get(...) or None``). An empty bootstrap key
-    therefore yields the same legacy, tokenless boot a pod without the key gets;
-    nothing is relaxed relative to today, because the key did not exist.
+    ``CURIE_RUNNER_TOKEN`` treats empty as unset so a local/fake sandbox never
+    presents an empty bearer. The bootstrap key has no such producer: it comes
+    only from a pool Secret, so an empty value is a mis-rendered ``secretKeyRef``,
+    and decoding it as "neither token present" would boot a warm pod whose
+    gated routes pass through. Absent stays the compatible legacy case.
     """
-    boot = BootEnv.from_env(_warm_env(**{_KEY: ""}))
-    assert boot.runner_bootstrap_token is None
+    with pytest.raises(ValidationError) as exc:
+        BootEnv.from_env(_warm_env(**{_KEY: ""}))
+    assert [err["loc"] for err in exc.value.errors()] == [(_FIELD,)]
+    assert "malformed runner bootstrap token" in str(exc.value)
+    assert BootEnv.from_env(_COLD_ENV | {"CURIE_RUNNER_TOKEN": ""}).runner_token is None
 
 
 def test_cold_path_with_both_keys_parses_both_verbatim() -> None:
@@ -199,7 +204,7 @@ def test_oversize_by_one_is_rejected_and_at_the_bound_is_admitted() -> None:
         {"nested": _TOKEN},
         "",
         "   ",
-        "x" * (RUNNER_BOOTSTRAP_TOKEN_MAX_CHARS + 1),
+        _TOKEN + "x" * (RUNNER_BOOTSTRAP_TOKEN_MAX_CHARS - len(_TOKEN) + 1),
     ),
     ids=("int", "bool", "bytes", "list", "dict", "empty", "blank", "oversize"),
 )
@@ -213,11 +218,69 @@ def test_direct_construction_rejects_malformed_values_without_echo(value: object
     assert [err["loc"] for err in exc.value.errors()] == [(_FIELD,)]
 
 
-def test_model_validate_json_redacts_a_malformed_token() -> None:
-    raw = json.dumps({"session": _session().model_dump(), _FIELD: "   " + _TOKEN[:0]})
+@pytest.mark.parametrize(
+    "value",
+    (
+        _TOKEN + "x" * (RUNNER_BOOTSTRAP_TOKEN_MAX_CHARS - len(_TOKEN) + 1),
+        [_TOKEN],
+        {"nested": _TOKEN},
+        4711,
+        "",
+        "   ",
+    ),
+    ids=("oversize", "list", "dict", "int", "empty", "blank"),
+)
+def test_model_validate_json_redacts_a_malformed_token(value: object) -> None:
+    raw = json.dumps({"session": _session().model_dump(), _FIELD: value})
     with pytest.raises(ValidationError) as exc:
         BootEnv.model_validate_json(raw)
-    assert _TOKEN not in _surfaces(exc.value)
+    rendered = _surfaces(exc.value)
+    assert _TOKEN not in rendered
+    assert "4711" not in rendered
+    assert "malformed runner bootstrap token" in rendered
+    assert [err["loc"] for err in exc.value.errors()] == [(_FIELD,)]
+
+
+def test_model_validate_json_explicit_null_is_none() -> None:
+    raw = json.dumps({"session": _session().model_dump(), _FIELD: None})
+    assert BootEnv.model_validate_json(raw).runner_bootstrap_token is None
+
+
+def _context_chain(exc: BaseException) -> list[BaseException]:
+    out: list[BaseException] = []
+    cur: BaseException | None = exc
+    while cur is not None:
+        out.append(cur)
+        cur = cur.__context__ or cur.__cause__
+    return out[1:]
+
+
+@pytest.mark.parametrize(
+    "build",
+    (
+        lambda: BootEnv.model_validate_json(
+            '{"session": {}, "' + _FIELD + '": "' + _TOKEN + '", bad}'
+        ),
+        lambda: BootEnv.model_validate_json(
+            json.dumps({"session": {"plugin_dir": "/p"}, _FIELD: _TOKEN})
+        ),
+        lambda: BootEnv(session=_session(), runner_bootstrap_token=[_TOKEN]),  # type: ignore[arg-type]
+        lambda: BootEnv.from_env(
+            _warm_env(**{_KEY: _TOKEN + "x" * RUNNER_BOOTSTRAP_TOKEN_MAX_CHARS})
+        ),
+    ),
+    ids=("invalid-json", "unrelated-error", "ctor-list", "env-oversize"),
+)
+def test_no_chained_exception_retains_the_material(build: object) -> None:
+    """``raise ... from None`` only hides the chain; the original error would
+    still hang off ``__context__``. The redacted error is raised outside the
+    except block so an introspector that ignores ``__suppress_context__``
+    finds nothing behind it."""
+    with pytest.raises(ValidationError) as exc:
+        build()  # type: ignore[operator]
+    for chained in _context_chain(exc.value):
+        assert _TOKEN not in _surfaces(chained)
+    assert _context_chain(exc.value) == []
 
 
 def test_invalid_json_never_echoes_the_raw_input() -> None:
@@ -294,3 +357,6 @@ def test_generated_rust_carries_the_constant_and_redacts_the_field() -> None:
     ) in rust
     assert "malformed runner bootstrap token" in rust
     assert f"{RUNNER_BOOTSTRAP_TOKEN_MAX_CHARS}" in rust
+    # Non-strings are decoded through serde_json::Value so a scalar cannot be
+    # echoed by serde's own "invalid type: integer `...`" error.
+    assert "Option::<serde_json::Value>::deserialize(deserializer)" in rust

--- a/packages/aci-protocol/tests/test_session.py
+++ b/packages/aci-protocol/tests/test_session.py
@@ -885,7 +885,9 @@ def test_the_substrate_writes_identity_otel_and_the_warm_pool_defaults() -> None
         "CURIE_SESSION_ID",  # agent-sandbox.yaml:420 ("warm-unbound")
         "CURIE_BUDGET",  # agent-sandbox.yaml:428
         # Substrate-only by contract (#1492, ADR-0122): a per-pool bootstrap
-        # credential arrives via secretKeyRef on the pool template. The worker's
+        # credential arrives via secretKeyRef on the pool template. Declared
+        # here as the PRODUCER TAG; the chart does not render it yet, so unlike
+        # the keys above it has no agent-sandbox.yaml citation. The worker's
         # per-claim render never writes it; a worker write would turn a bound
         # pod back into one that admits the pool's shared bootstrap.
         "CURIE_RUNNER_BOOTSTRAP_TOKEN",

--- a/packages/aci-protocol/tests/test_session.py
+++ b/packages/aci-protocol/tests/test_session.py
@@ -167,6 +167,7 @@ def _full_boot_env() -> BootEnv:
         bundle_ref="bundles/demo/abc123.tar.gz",
         bundle_version="abc123def456",
         runner_token="rt-full-token",
+        runner_bootstrap_token="rt-bootstrap-full-token",
         model="claude-opus-4-6",
         fake_model=True,
         history_ref=_HISTORY_REF,
@@ -769,6 +770,7 @@ def test_env_keys_declares_the_whole_flattened_boot_surface() -> None:
         "CURIE_BUNDLE_REF",
         "CURIE_BUNDLE_VERSION",
         "CURIE_RUNNER_TOKEN",
+        "CURIE_RUNNER_BOOTSTRAP_TOKEN",
         "CURIE_MODEL",
         "CURIE_FAKE_MODEL",
         "CURIE_HISTORY_REF",
@@ -882,6 +884,11 @@ def test_the_substrate_writes_identity_otel_and_the_warm_pool_defaults() -> None
         "CURIE_PLUGIN_DIR",  # agent-sandbox.yaml:416
         "CURIE_SESSION_ID",  # agent-sandbox.yaml:420 ("warm-unbound")
         "CURIE_BUDGET",  # agent-sandbox.yaml:428
+        # Substrate-only by contract (#1492, ADR-0122): a per-pool bootstrap
+        # credential arrives via secretKeyRef on the pool template. The worker's
+        # per-claim render never writes it; a worker write would turn a bound
+        # pod back into one that admits the pool's shared bootstrap.
+        "CURIE_RUNNER_BOOTSTRAP_TOKEN",
     }
 
 

--- a/packages/aci-protocol/tests/test_wire_lock.py
+++ b/packages/aci-protocol/tests/test_wire_lock.py
@@ -175,11 +175,12 @@ def test_committed_lock_matches_the_current_wire() -> None:
     assert lock["wire_sha256"] == wire_fingerprint()
 
 
-def test_adoption_credential_contract_uses_patch_version_0_4_5() -> None:
-    # Session identity landed as 0.4.4 (optional session_id/history_ref). This
-    # patch adds optional adoption_credential plus the adoption_applied ack.
+def test_bootstrap_token_contract_uses_patch_version_0_4_6() -> None:
+    # Session identity landed as 0.4.4 (optional session_id/history_ref), the
+    # adoption credential and its ack as 0.4.5. This patch adds the optional
+    # BootEnv.runner_bootstrap_token key and nothing on the event wire.
     lock_path = schema_export.schema_path().parent / "wire.lock"
     lock = json.loads(lock_path.read_text(encoding="utf-8"))
 
-    assert PROTOCOL_VERSION == "0.4.5"
-    assert lock["protocol_version"] == "0.4.5"
+    assert PROTOCOL_VERSION == "0.4.6"
+    assert lock["protocol_version"] == "0.4.6"


### PR DESCRIPTION
## Summary

Frozen-contract prerequisite for warm-pool adoption (#1492, ADR-0116 decision 2, ADR-0122), stacked on #2396. One optional `BootEnv` string field, `runner_bootstrap_token` mapped to `CURIE_RUNNER_BOOTSTRAP_TOKEN` with the substrate as its only producer, so an unbound warm runner can tell a pool bootstrap credential (authority: one atomic adoption, then retired) from the bound per-conversation `CURIE_RUNNER_TOKEN`. The chart's `CURIE_SESSION_ID=warm-unbound` placeholder is a template value, not a contract signal, and is not a mode switch. Raised first on the issue: https://github.com/curie-eng/curie/issues/1492#issuecomment-5549397585

Consumer authority policy, documented on the field and in the package README and realized by the runner in a later change, not here: `runner_token` present wins and the bootstrap is never admitted (cold path unchanged); only `runner_bootstrap_token` present is bootstrap mode; neither present is today's tokenless legacy boot, unchanged. Nothing is relaxed and nothing new is enforced by this field's existence.

Admission and secrecy: non-empty, not whitespace-only, at most 4096 characters, a string. A present value that fails any of those fails the boot parse closed, with an error that never carries the material and no chained exception retaining it. Deliberately unlike every other optional boot var, a declared-but-empty `CURIE_RUNNER_BOOTSTRAP_TOKEN` is not "unset": the key's only producer is a pool `Secret`, an empty `secretKeyRef` is the most plausible mis-render, no producer renders the key today so no existing stack can break, and a refused boot is a visible signal where a tokenless warm pod is a silent one. Only an absent key is the compatible legacy case; `runner_token` keeps its empty-is-unset rule. The two reviews split on this point (the adversarial review argued fail-closed, the Fable review argued empty-is-unset because compose templating produces `KEY=` lines); fail-closed was adopted and the delta review was asked to rule on it. The field is omitted from `repr`/`str`; validation errors are scrubbed through the same redaction helper as `adoption_credential`, now parameterized by field name; the generated Rust `BootEnv` gets a generated `Debug` impl that redacts the field, and the shared bounded deserializer decodes through `serde_json::Value` so a non-string value cannot reach serde's echoing type error (this also covers `adoption_credential`).

Protocol semver class: `0.4.5` to `0.4.6`, a 0.x patch for a new optional field (tolerant consumers ignore it). No new endpoint, no new enum value, no change to the `Event` wire shape or the outbound frames. A compatible two-file follow-up also removes retained raw-input exceptions from `Event.model_validate_json` without another protocol bump. Schema, `wire.lock`, generated Rust, generated TypeScript and the `.env.example` block are regenerated from the Pydantic source with the repository tools.

Not in this PR: pool `Secret`, RBAC read grant, chart templates, runner or worker behavior, any cryptographic claim about the bootstrap, and `plugin-format` (the `CURIE_` prefix rule already reserves the key). A pre-existing gap is left as is and named here: the older token fields (`runner_token`, `history_token`, `memory_token`, `state_token`) still print in Python `repr` and Rust `Debug`; only the new field is redacted.

## Acceptance criteria

| AC | Positive | Negative |
| --- | --- | --- |
| Single optional field, `CURIE_RUNNER_BOOTSTRAP_TOKEN` mapping | `test_env_key_accessor_names_the_key`, `test_warm_env_roundtrips_through_from_env_and_to_env` | `test_schema_declares_an_optional_bounded_nullable_string` (not required, nullable, default null) |
| Omitted/default behavior compatible | `test_omitted_key_parses_to_none_and_renders_nothing`, `test_default_construction_is_none`, `test_boot_env_roundtrips_with_every_optional_omitted`, `test_model_validate_json_explicit_null_is_none` | `test_declared_but_empty_fails_closed_unlike_every_other_boot_var` |
| Cold path: explicit `runner_token` presence is preserved verbatim | `test_cold_path_with_both_keys_parses_both_verbatim` | the policy is documented, not implemented (no runner code in the diff) |
| Non-empty, non-whitespace, bounded credential | `test_oversize_by_one_is_rejected_and_at_the_bound_is_admitted` | `test_present_but_malformed_env_value_fails_closed_without_echo` (5 specimens), `test_direct_construction_rejects_malformed_values_without_echo` (8 specimens) |
| repr/errors redacted wherever the field can appear | `test_repr_and_str_omit_the_token`, Rust `boot_env_debug_redacts_bootstrap_token` | `test_model_validate_json_redacts_a_malformed_token` (6 specimens), `test_invalid_json_never_echoes_the_raw_input`, `test_unrelated_errors_keep_their_diagnosis_but_lose_the_material`, `test_no_chained_exception_retains_the_material` (4 paths), Rust `boot_env_rejects_oversize_bootstrap_token_without_echo`, `boot_env_rejects_non_string_bootstrap_token_without_echo` |
| Producer is substrate only; worker render never emits it | `test_the_worker_render_surface_never_emits_the_bootstrap_key`, `test_the_substrate_writes_identity_otel_and_the_warm_pool_defaults` | worker/kernel/operator producer pins unchanged |
| Old consumer compatibility, version class patch | `test_reader_context_tolerates_fields_a_consumer_does_not_model`, `test_protocol_version_is_the_compatible_patch_over_0_4_5`, `test_bootstrap_token_contract_uses_patch_version_0_4_6` | `is_compatible("0.5.0", ...)` is false |
| Exporter completeness; Rust and TS compile | `test_env_example_block_documents_the_key_as_substrate_owned`, `test_generated_rust_carries_the_constant_and_redacts_the_field`, `scripts/check-contracts.sh` OK | drift gate red before regeneration |
| `adoption_credential` unchanged after helper parameterization | all 232 prior protocol tests pass unchanged; the Fable review fingerprinted 20 cases byte-identical to base | Rust `inbound_event_rejects_empty_adoption_credential` message unchanged; `inbound_event_rejects_non_string_adoption_credential_without_echo` added |

## Evidence

- `uv run pytest packages/aci-protocol/tests -q`: 273 passed (41 new; the new module and three moved pins were red on 628feacf).
- Generated Rust `cargo test`: 19 passed (8 new). `tsc --noEmit` clean. `./scripts/check-contracts.sh` and `scripts/check-docs.sh` OK on each commit.
- Reviews: independent `agent-router adversarial-review` (routed to Grok) and a read-only Claude Fable review of the first commit, both incorporated in the second commit (empty fails closed, single admission point, no `__context__` retention, Rust non-string echo, README rescoped, non-vacuous specimens); a delta re-review by both was run on the final head. Reports live in the private evidence directory, not linked here.
- `uv run ruff check packages/aci-protocol` and root `uv run mypy` (249 files) clean.
- Consumer-side pins: `apps/worker/tests/binding/test_reserved_boot_env_pin.py`, `test_boot_env_golden.py`, `runner/tests/test_config_boot_env.py`: 37 passed.
- Not run: the full CLI `cargo` build (no CLI source changed; the CLI does not construct the Rust `BootEnv` struct).

Remaining follow-ups outside this PR: `parse_inbound` in #2396 still retains the raw-input decoder error through `JSONDecodeError.__context__.doc` (a separate reader path, outside this Event-only follow-up); the older token fields' redaction; the `plugin-format` greppability list lags by this one key (policy-neutral, prefix rule enforces); the README `runner_token` sentence could also name validation-error inputs as a surface that carries the value.

## Exception-context source follow-up

The original Event JSON validation error remained reachable through `__context__` despite `raise ... from None`. The compatible follow-up in this PR raises the sanitized error after leaving the exception handler, matching BootEnv. Both handled exception types use this path. This fixes parent #2396 behavior within this stack without rewriting that parent or changing the protocol version.

- Exactly `events.py` and `test_adoption_credential.py` change. Wire lock, schemas, generated TypeScript/Rust, protocol version, and optional-field semantics retain their exact bytes.
- Six escaped/keyless invalid-JSON cases exercise str/bytes/bytearray. Three valid-credential cases preserve the unrelated missing-text diagnosis. Assertions walk both cause and context links and require no retained chain.
- Test-first and implementation-only causal reversal each produce 9 failures and 27 passes. The fixed focused suite passes 36 tests, the full protocol suite passes 277, and plugin-format passes 781. Scoped lint, format, type checks and whitespace checks pass.
- Final exact-delta adversarial and independent reviews both returned CLEAR. Commit: `ed141058961beb19a64de531fa6214b467111589`; the committed patch is byte-identical to the reviewed snapshot. Skill runtime remains pending; this is not merge or runtime acceptance.

## Tiers

| Tier | Status |
| --- | --- |
| skill | Required: boot-env contract. Protocol positive/negative tests pass. Runner consumption and the e2e ladder are not in this PR. |
| local | Not applicable: no compose service or CLI verb output change. |
| local-release | Not applicable: no published binary or image identity change. |
| cluster | Not applicable: no chart or sandbox change; the chart does not yet render the key. |
| live provider | Not applicable: no model credential path. |
| external integration | Not applicable: no Slack/git/OAuth path. |

Draft only. Stacked on #2396; retarget after it merges. Does not close #1492.

Ref #1492.

