### PR TITLE
Adopt a conversation over the ACI Event and retire the pool bootstrap

### DIFF
--- a/apps/worker/src/curie_worker/kernel.py
+++ b/apps/worker/src/curie_worker/kernel.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
+import secrets
 import time
 import uuid
 from collections.abc import Callable, Coroutine
@@ -102,20 +103,23 @@ from .publication_validation import validate_snapshot_against_base
 from .receipt import render_receipt
 from .reply_sink import ObservedReplySink, ReplySink, TargetRoute
 from .runner_client import (
+    AdoptionAttestationMismatch,
     RunnerClient,
     RunnerError,
     RunnerStreamTimeout,
     RunnerWorkspaceSnapshot,
     TurnStream,
 )
-from .sandbox import SandboxSubstrate
+from .sandbox import HISTORY_ENV, SESSION_ENV, SandboxSubstrate
 from .sandbox.types import (
+    AdoptionState,
     CapacityExhaustedError,
     SandboxError,
     SandboxHandle,
     SuspendedThreadError,
 )
 from .threadlock import ThreadLock
+from .warm_bind import ADOPTION_UNCONFIRMED, AdoptionUnconfirmedError, WarmBindPolicy
 from .workspace import (
     WorkspaceClaimCoordinator,
     WorkspacePreparationError,
@@ -329,6 +333,13 @@ _MIN_ATTEMPT_BUDGET_S = 5.0
 # never consume the whole deadline; an interrupt that has not landed inside this
 # window is treated as an unreadable runner, which fails closed.
 _RECLAIM_PREFLIGHT_IDLE_TIMEOUT_S = 5.0
+
+# The bound on the two control-plane reads an adopting start performs UNDER the
+# per-thread route lock (adoption authority, then the recovery attestation).
+# Short on purpose: a hung status route on one pod must not hold the thread's
+# steering hostage for the delivery budget, and reset's lock acquire is 5s, so
+# both reads back to back must fit under it.
+_ADOPTION_PROBE_TIMEOUT_S = 2.0
 _RECLAIM_PREFLIGHT_POLL_S = 0.05
 
 # ``WorkspaceClaimCoordinator`` performs blocking clone/archive/upload work on
@@ -614,6 +625,9 @@ class _RouteResult:
     # route) under the route lock: the canned reply to deliver instead of
     # claiming a sandbox or starting a model turn. None on every other path.
     canned_reply: str | None = None
+    # The turn was opened with an adopting event on a PENDING warm-bind route
+    # (ADR-0116 d2): the caller settles the route after the stream ends.
+    adopting: bool = False
 
 
 @dataclass
@@ -806,6 +820,7 @@ class Kernel:
         card_store: ApprovalCardStore | None = None,
         route_ttl_seconds: int = 3600,
         suspended_route_ttl_seconds: int = 86400,
+        warm_bind: WarmBindPolicy | None = None,
     ) -> None:
         self._substrate = substrate
         self._runner = runner
@@ -827,6 +842,12 @@ class Kernel:
         # directory and giving the appearance of success.
         self._workspace = workspace
         self._killswitch = killswitch
+        # The warm-bind seam (ADR-0116 d2 / ADR-0122): absent, every claim takes
+        # the cold path exactly as before. Present, a non-workspace claim whose
+        # pool the policy knows to be booted in bootstrap mode is claimed
+        # env-free and adopted over the ACI, with authority established before
+        # any event and the route settled after the turn.
+        self._warm_bind = warm_bind
         # The approval-record backend (#244). When absent (unwired tests, a
         # deployment without the API), an awaiting-approval run degrades to an
         # escalation instead of suspending a session nothing could ever resume.
@@ -1729,6 +1750,10 @@ class Kernel:
         """Wire the kill switch after construction (it needs interrupt_agent)."""
         self._killswitch = killswitch
 
+    def attach_warm_bind(self, policy: WarmBindPolicy | None) -> None:
+        """Wire (or clear) the warm-bind policy after construction."""
+        self._warm_bind = policy
+
     async def interrupt_agent(self, agent_id: uuid.UUID) -> int:
         """Interrupt every live turn belonging to an agent (kill switch). Returns
         the number of turns signalled. The kill flag stays set (the API owns it),
@@ -2258,6 +2283,7 @@ class Kernel:
                         agent_name=agent_name,
                         source=qevent.source,
                         remaining_s=remaining_s,
+                        delivery_id=qevent.event_id,
                     )
             except BaseException:
                 # start_turn owns a live response as soon as it returns, which
@@ -2353,6 +2379,14 @@ class Kernel:
                 workspace_deployment_id=workspace_deployment_id,
             )
             return TurnOutcome(terminal_ok=False, classification="workspace-error")
+        except AdoptionUnconfirmedError as exc:
+            # A warm route whose pod already holds the binding from a lost
+            # owner (ADR-0122; root correction 3): no turn was opened here,
+            # but the first turn may have run there, so this is escalated and
+            # never replayed. Deliberately not the retryable clause below.
+            release_order()
+            logger.warning("adoption unconfirmed for %s: %s", qevent.event_id, exc)
+            return TurnOutcome(terminal_ok=False, classification=ADOPTION_UNCONFIRMED)
         except (
             RunnerError,
             aiohttp.ClientError,
@@ -2424,6 +2458,10 @@ class Kernel:
             ):
                 await self.interrupt_thread(thread_key, f"agent {agent_id} killed by operator")
             outcome = await self._consume(qevent, route, turn, nav, agent_id)
+            if routed.adopting:
+                outcome = await self._settle_adoption(
+                    thread_key, routed.handle, turn, outcome, remaining_s=remaining_s
+                )
             if (
                 outcome.status is SessionStatus.AWAITING_APPROVAL
                 and _is_publish_provenance(
@@ -2490,6 +2528,7 @@ class Kernel:
         publication_visible_outcome_revision: int | None = None,
         force_lineage_replacement: bool = False,
         pending_publication_approval: bool = False,
+        delivery_id: str | None = None,
     ) -> _RouteResult:
         # A workspace-enabled thread must establish (or confirm) its repository
         # before any platform response path. This deliberately precedes the
@@ -2630,10 +2669,28 @@ class Kernel:
         # model). This is the only place that can measure claim latency at
         # all -- the runner's own per-turn logging starts only once its
         # process is already up, so it cannot see the wait that got it there.
+        # Warm bind (ADR-0116 d2): only a non-workspace claim with a bound
+        # session identity, and only when the policy knows this claim's pool is
+        # booted in bootstrap mode. Anything else is the cold path, unchanged.
+        # getattr: test doubles build a Kernel without __init__ (the same
+        # tolerance the publication-creator probe above extends).
+        warm_bind: WarmBindPolicy | None = getattr(self, "_warm_bind", None)
+        bootstrap: str | None = None
+        if (
+            warm_bind is not None
+            and workspace_repo is None
+            and boot_env is not None
+            and boot_env.get(SESSION_ENV)
+        ):
+            bootstrap = warm_bind.bootstrap_for(
+                thread_key, boot_env=boot_env, agent_name=agent_name
+            )
         claim_started = time.monotonic()
         handle = await self._claim_or_resume(
             thread_key,
             boot_env,
+            bootstrap=bootstrap,
+            adopting_event_id=delivery_id,
             workspace_deployment_id=(
                 workspace_deployment_id if workspace_repo is not None else None
             ),
@@ -2659,6 +2716,42 @@ class Kernel:
         retained_live_route = existing_handle is not None and handle == existing_handle
         claim_ms = round((time.monotonic() - claim_started) * 1000)
         logger.info("claim latency for %s: %d ms", thread_key, claim_ms)
+        if (
+            handle.adoption_state is AdoptionState.APPLIED
+            and delivery_id is not None
+            and handle.adopting_event_id == delivery_id
+        ):
+            # This very delivery adopted that pod and its turn's fate was lost
+            # (a crash or cancel between the runner's 200 and the settle). The
+            # first turn may have run there: never a plain replay (root
+            # correction 3). The marker stays until a terminal answer clears
+            # it, so every redelivery of this event escalates the same way.
+            raise AdoptionUnconfirmedError(thread_key)
+        if handle.adoption_state is AdoptionState.PENDING:
+            # A warm-bind route whose adoption has not been applied: the pod
+            # is unbound (or a previous attempt lost its response), so it is
+            # never steered and never opened with a plain event. Authority is
+            # established first; the adopting event is the turn.
+            adopting = await self._start_adopting(
+                thread_key,
+                handle,
+                event,
+                bootstrap=bootstrap,
+                delivery_id=delivery_id,
+                remaining_s=remaining_s,
+            )
+            if adopting is not None:
+                return adopting
+            # A lost owner's adoption was just settled APPLIED for a DIFFERENT
+            # event: this message continues on the cold path's steer-or-open
+            # logic against the now-bound pod. Re-read the authoritative route.
+            settled = await asyncio.to_thread(self._substrate.lookup, thread_key)
+            if settled is None or settled.adoption_state is not AdoptionState.APPLIED:
+                raise RunnerError(f"warm route for {thread_key} was lost while settling")
+            handle = settled
+            retained_live_route = existing_handle is not None and (
+                existing_handle.claim_name == handle.claim_name
+            )
         if source.is_job:
             # ADR-0079: a job is an OUTPUT, not a steering input. A cron digest or
             # a webhook must never fold itself into whatever a person is currently
@@ -2732,6 +2825,256 @@ class Kernel:
         _record_route("start")
         _lifecycle_event("runner.turn.started", "start")
         return _RouteResult(steered=False, handle=handle, turn=turn)
+
+    async def _start_adopting(
+        self,
+        thread_key: str,
+        handle: SandboxHandle,
+        event: Event,
+        *,
+        bootstrap: str | None,
+        delivery_id: str | None,
+        remaining_s: float | None,
+    ) -> _RouteResult | None:
+        """Open the adopting turn on a PENDING warm-bind route (ADR-0116 d2).
+
+        Returns ``None`` in exactly one case: the pod already held the binding
+        from a lost owner whose adopting event was a DIFFERENT event; the
+        route is then settled APPLIED and the caller continues on the ordinary
+        steer-or-open path. The same delivery reaching that state raises
+        ``AdoptionUnconfirmedError`` instead.
+
+        Runs under the per-thread route lock like ``start_turn``. Before the
+        event: the runner must prove, by behavior on the existing gated status
+        route, that it is a realizing bootstrap-mode adopter. An old or open
+        runner would serve the event under its boot identity and START A MODEL
+        TURN, so a failed probe releases the claim (the pod is never reused)
+        and raises ``RunnerError``: the delivery retries within its bounded
+        attempt budget and escalates if no capable pod is found. Nothing is
+        inferred from the protocol version.
+
+        Lock hold: the probe is bounded by ``_ADOPTION_PROBE_TIMEOUT_S``; the
+        adopting POST is the same shape as ``start_turn`` under this lock, plus
+        the runner's conversation bind (history load) before its 200. That
+        bind must complete before the lock releases: rule 1 needs the route
+        APPLIED before any follow-up can route, and the route is settled here
+        on the runner's 200. Interrupt: the conversation credential is inert
+        until the runner's ``adopt`` commits, but no model turn is live before
+        that commit (the runner adopts first, then streams), so the window in
+        which ``/v1/interrupt`` would refuse the bearer contains no turn to
+        stop; the kill-switch recheck after registration covers everything
+        after the 200.
+        """
+
+        if not bootstrap:
+            # A pending route reached a worker without the pool credential
+            # (policy absent or changed under a live route): it cannot be
+            # adopted here and must never be opened with a plain event.
+            raise RunnerError(f"pending warm-bind route for {thread_key} has no bootstrap")
+        # Control-plane reads under the route lock get a SHORT bound, never the
+        # delivery budget: a hung status route must not hold steering hostage.
+        probe_s = (
+            _ADOPTION_PROBE_TIMEOUT_S
+            if remaining_s is None
+            else max(0.0, min(_ADOPTION_PROBE_TIMEOUT_S, remaining_s))
+        )
+        established = await self._runner.adoption_authority(
+            handle.base_url, bootstrap_token=bootstrap, remaining_s=probe_s
+        )
+        if not established:
+            # Not a bootstrap adopter NOW. Either it never was (an old or open
+            # pod: release it, nothing ran there) or a lost owner of this very
+            # delivery already adopted it (200 from the runner, then no route
+            # write): the conversation credential attests that pod, the route
+            # is settled APPLIED, and the delivery is unconfirmed, because the
+            # first turn may have run. The attestation decides which.
+            try:
+                applied_on_pod = await self._runner.adoption_applied(
+                    handle.base_url,
+                    conversation_token=handle.token,
+                    session_id=handle.session_id,
+                    remaining_s=probe_s,
+                )
+            except AdoptionAttestationMismatch as exc:
+                # A readable answer that attests NO or ANOTHER conversation:
+                # an open or old runner (200 to any bearer) or a pod bound
+                # elsewhere. Nothing ran here for this thread; end it, fenced.
+                logger.warning(
+                    "warm sandbox %s attested no adoptable identity (%s); releasing it",
+                    handle.sandbox_name,
+                    _exception_reason(exc),
+                )
+                await asyncio.to_thread(
+                    self._substrate.release_claim, thread_key, expected=handle
+                )
+                raise RunnerError("warm sandbox is not a realizing bootstrap adopter") from None
+            except (RunnerError, aiohttp.ClientError, TimeoutError) as exc:
+                # Unreadable or a server fault, not a refusal: keep the claim
+                # (a retry re-probes the same fenced pod) and let the delivery
+                # back off.
+                raise RunnerError(
+                    f"warm sandbox could not be attested: {_exception_reason(exc)}"
+                ) from None
+            if applied_on_pod:
+                # The pod holds the binding a lost owner applied. The route's
+                # marker names the event that adopted it (written at PENDING):
+                # the same delivery is unconfirmed (its turn may have run);
+                # any other event continues on the ordinary path.
+                if (
+                    await asyncio.to_thread(
+                        self._substrate.mark_adoption_applied, thread_key, expected=handle
+                    )
+                    is None
+                ):
+                    logger.warning(
+                        "adoption fence lost for %s on claim %s generation %d",
+                        thread_key,
+                        handle.claim_name,
+                        handle.generation,
+                    )
+                if delivery_id is not None and handle.adopting_event_id == delivery_id:
+                    raise AdoptionUnconfirmedError(thread_key)
+                logger.info(
+                    "warm route for %s settled from a lost owner's adoption; continuing",
+                    thread_key,
+                )
+                return None
+            logger.warning(
+                "warm sandbox %s did not establish adoption authority; releasing it",
+                handle.sandbox_name,
+            )
+            await asyncio.to_thread(self._substrate.release_claim, thread_key, expected=handle)
+            raise RunnerError("warm sandbox is not a realizing bootstrap adopter")
+        turn = await self._runner.start_adopting_turn(
+            handle.base_url,
+            event,
+            bootstrap_token=bootstrap,
+            conversation_token=handle.token,
+            session_id=handle.session_id,
+            history_ref=handle.history_ref,
+            remaining_s=remaining_s,
+        )
+        # The runner commits the adoption BEFORE its 200 (server.py: adopt,
+        # then prepare the stream), so the binding is applied on the pod the
+        # moment start_adopting_turn returns. Settle the route now, still under
+        # the route lock: every later routing decision on this thread (a
+        # follow-up, a job, another replica) then sees an APPLIED route and
+        # steers or opens under the conversation credential exactly as on the
+        # cold path (rules 1 and 2), instead of re-entering this branch. The
+        # per-frame ack is re-checked after the stream as the second proof.
+        if (
+            await asyncio.to_thread(
+                self._substrate.mark_adoption_applied, thread_key, expected=handle
+            )
+            is None
+        ):
+            logger.warning(
+                "adoption fence lost for %s on claim %s generation %d",
+                thread_key,
+                handle.claim_name,
+                handle.generation,
+            )
+        # The metric outcome stays "start" (the allowlisted route outcomes are
+        # a telemetry contract); the lifecycle span event names the adoption.
+        _record_route("start")
+        _lifecycle_event("runner.turn.adopting", "start")
+        return _RouteResult(steered=False, handle=handle, turn=turn, adopting=True)
+
+    async def _settle_adoption(
+        self,
+        thread_key: str,
+        handle: SandboxHandle,
+        turn: TurnStream,
+        outcome: TurnOutcome,
+        *,
+        remaining_s: float | None,
+    ) -> TurnOutcome:
+        """Settle a PENDING route after its adopting turn (ADR-0122 d3).
+
+        Acked on every frame: the binding is APPLIED through the store's fenced
+        predicate; a lost fence (the route was replaced under the turn) is
+        logged and the outcome stands. Lost response (no terminal, or a
+        transport drop): the runner's status attestation under the
+        conversation credential says whether the binding was applied to that
+        pod and ONLY that. Either way the turn is ``adoption-unconfirmed``: it
+        may already have run, so it is escalated, never retried as if the
+        event had not been delivered. A frame stream that ended normally
+        without the ack is a runner that did not adopt; the route is released
+        so nothing routes to it again.
+        """
+
+        # The runner's terminal answer (a final of any status) is the only
+        # thing that makes the adopting turn's fate known. Without it the turn
+        # may already have run, so whatever the binding did, the delivery must
+        # not be replayed as a plain event on the now-bound pod.
+        terminal = outcome.terminal_ok or outcome.status is not None
+        if turn.adoption_acked:
+            # Already APPLIED at the runner's 200 (see _start_adopting); the
+            # per-frame ack is the second proof, and the write is idempotent.
+            applied = await asyncio.to_thread(
+                self._substrate.mark_adoption_applied, thread_key, expected=handle
+            )
+            if applied is None:
+                logger.warning(
+                    "adoption fence lost for %s on claim %s generation %d",
+                    thread_key,
+                    handle.claim_name,
+                    handle.generation,
+                )
+        elif terminal:
+            # A 200 without the per-frame ack contradicts the runner contract
+            # (a realizing adopter stamps every frame of the adopting turn).
+            # The 200 was already taken as the adoption commit and the route
+            # is APPLIED; follow-ups may have steered into this session, so
+            # it is NOT destroyed here. Logged as a contract violation.
+            logger.error(
+                "adopting turn on %s ended without an adoption ack (contract violation)",
+                handle.sandbox_name,
+            )
+        else:
+            try:
+                applied_on_pod = await self._runner.adoption_applied(
+                    handle.base_url,
+                    conversation_token=handle.token,
+                    session_id=handle.session_id,
+                    remaining_s=remaining_s,
+                )
+            except (RunnerError, aiohttp.ClientError, TimeoutError) as exc:
+                logger.warning(
+                    "adoption recovery read failed for %s: %s",
+                    thread_key,
+                    _exception_reason(exc),
+                )
+                applied_on_pod = None
+            if applied_on_pod:
+                if (
+                    await asyncio.to_thread(
+                        self._substrate.mark_adoption_applied, thread_key, expected=handle
+                    )
+                    is None
+                ):
+                    logger.warning(
+                        "adoption fence lost for %s on claim %s generation %d",
+                        thread_key,
+                        handle.claim_name,
+                        handle.generation,
+                    )
+            elif applied_on_pod is False:
+                await asyncio.to_thread(
+                    self._substrate.release_claim, thread_key, expected=handle
+                )
+        if not terminal:
+            outcome.classification = ADOPTION_UNCONFIRMED
+            return outcome
+        # The adopting turn's fate is known: drop the marker so a later retry
+        # of this same event (after a classified failure) opens normally.
+        if not await asyncio.to_thread(
+            self._substrate.clear_adopting_event, thread_key, expected=handle
+        ):
+            logger.warning(
+                "adopting-event marker for %s not cleared (fence lost or absent)", thread_key
+            )
+        return outcome
 
     async def _turn_active(
         self, handle: SandboxHandle, *, remaining_s: float | None = None
@@ -2869,6 +3212,8 @@ class Kernel:
         pending_publication_approval: bool = False,
         agent_name: str | None = None,
         remaining_s: float | None = None,
+        bootstrap: str | None = None,
+        adopting_event_id: str | None = None,
     ) -> SandboxHandle:
         # A live route is an adopt/steer, not a session start. Preparing before
         # this check would clone on every threaded steer and could even replace
@@ -3010,6 +3355,25 @@ class Kernel:
                     "claim", "workspace substrate returned an invalid sandbox handle"
                 )
             return workspace_claim.handle
+        if bootstrap is not None and boot_env is not None and boot_env.get(SESSION_ENV):
+            # Warm bind: an env-free claim binds a pool pod; the identity and a
+            # freshly minted conversation credential are recorded PENDING on
+            # the route before any event leaves this worker. A suspended thread
+            # still resumes cold below: its replacement pod boots from env.
+            try:
+                return await asyncio.to_thread(
+                    self._substrate.claim,
+                    thread_key,
+                    session_id=boot_env[SESSION_ENV],
+                    history_ref=boot_env.get(HISTORY_ENV),
+                    conversation_token=secrets.token_urlsafe(32),
+                    adopting_event_id=adopting_event_id,
+                    agent_name=agent_name,
+                )
+            except SuspendedThreadError:
+                return await asyncio.to_thread(
+                    self._substrate.resume, thread_key, env=boot_env, agent_name=agent_name
+                )
         try:
             return await asyncio.to_thread(
                 self._substrate.claim, thread_key, env=boot_env, agent_name=agent_name

--- a/apps/worker/src/curie_worker/runner_client.py
+++ b/apps/worker/src/curie_worker/runner_client.py
@@ -108,6 +108,10 @@ def _scrub(text: str, *secrets: str) -> str:
 
 
 _REFUSAL_STATUSES = frozenset({400, 401, 403, 409})
+# The runner's fixed refusal for a bootstrap principal on any route but the
+# adopting /v1/event (runner/src/curie_runner/server.py). Its presence on a 403
+# is the only signal that the server is a realizing bootstrap-mode adopter.
+_BOOTSTRAP_ADOPTION_ONLY = "bootstrap credential permits adoption only"
 
 
 def _refusal(message: str, *secrets: str) -> tuple[int | None, str]:
@@ -509,6 +513,51 @@ class RunnerClient:
                     _scrub(str(exc), bootstrap_token, conversation_token)
                 ) from None
             raise AdoptionRefused(status, reason) from None
+
+    async def adoption_authority(
+        self,
+        base_url: str,
+        *,
+        bootstrap_token: str,
+        remaining_s: float | None = None,
+    ) -> bool:
+        """Is this runner a realizing bootstrap-mode adopter for ``bootstrap_token``?
+
+        The pre-activation gate before any adopting event is sent: an older
+        runner that ignores the optional adoption fields (and the bootstrap
+        BootEnv key) would serve the adopting turn under its boot identity and
+        START A MODEL TURN, and its missing ack is only visible afterwards. So
+        the authority is established first, through the existing gated status
+        route rather than the protocol version (a contract-only build carries
+        the same version): a realizing runner in bootstrap mode answers a
+        bootstrap bearer on ``GET /v1/status`` with the fixed 403 refusal and
+        starts nothing; an old open runner answers 200, an old or cold
+        per-claim runner 401, and anything else is a transport or server
+        fault. Only the exact 403 is ``True``; everything else fails closed.
+        """
+
+        if not bootstrap_token:
+            raise RunnerError("adoption authority requires the bootstrap credential")
+
+        async def request(headers: dict[str, str] | None) -> tuple[bool, str]:
+            async with self._session.get(
+                f"{base_url}/v1/status",
+                headers=headers,
+                timeout=self._request_timeout(remaining_s),
+            ) as resp:
+                if resp.status != 403:
+                    await resp.read()
+                    return False, "conflict"
+                try:
+                    body = await resp.json()
+                except Exception:  # noqa: BLE001 - any unreadable body is "not established"
+                    return False, "conflict"
+                error = body.get("error") if isinstance(body, dict) else None
+                return error == _BOOTSTRAP_ADOPTION_ONLY, (
+                    "success" if error == _BOOTSTRAP_ADOPTION_ONLY else "conflict"
+                )
+
+        return await self._rpc("status", bootstrap_token, request)
 
     async def adoption_applied(
         self,

--- a/apps/worker/src/curie_worker/runner_client.py
+++ b/apps/worker/src/curie_worker/runner_client.py
@@ -81,6 +81,15 @@ class RunnerError(Exception):
     """The runner returned an unexpected HTTP status or an unreadable stream."""
 
 
+class AdoptionAttestationMismatch(RunnerError):
+    """A readable ``/v1/status`` attested no conversation, or another one.
+
+    Distinct from a server fault (5xx) or a transport error, which say nothing
+    about the pod's identity: this shape is definitive, the answering runner
+    is not bound to the caller's conversation.
+    """
+
+
 class AdoptionRefused(RunnerError):
     """The runner refused an adopting ``/v1/event`` (ADR-0122).
 
@@ -602,9 +611,11 @@ class RunnerClient:
                 data = await resp.json()
                 attested = data.get("session_id") if isinstance(data, dict) else None
                 if not isinstance(attested, str) or not attested:
-                    raise RunnerError("/v1/status attested no conversation; not adopted")
+                    raise AdoptionAttestationMismatch(
+                        "/v1/status attested no conversation; not adopted"
+                    )
                 if attested != session_id:
-                    raise RunnerError(
+                    raise AdoptionAttestationMismatch(
                         "/v1/status attested a different conversation; refusing this route"
                     )
                 return True, "success"

--- a/apps/worker/src/curie_worker/runner_client.py
+++ b/apps/worker/src/curie_worker/runner_client.py
@@ -81,6 +81,65 @@ class RunnerError(Exception):
     """The runner returned an unexpected HTTP status or an unreadable stream."""
 
 
+class AdoptionRefused(RunnerError):
+    """The runner refused an adopting ``/v1/event`` (ADR-0122).
+
+    ``status`` is the runner's HTTP status: 401 means the bootstrap it was
+    presented with is not the active credential there (wrong pool, or already
+    retired by an earlier adoption), 403/409 that the runner is not adoptable
+    (bound already, or a cold per-claim pod), 400 that the frame was refused
+    before anything was applied. The message never contains the credential:
+    the runner does not echo it, and every failure message raised from
+    ``start_adopting_turn`` (refusal or not) is scrubbed of both credentials so
+    a non-conforming server cannot route one into a log line.
+    """
+
+    def __init__(self, status: int, reason: str) -> None:
+        super().__init__(f"/v1/event -> {status}: adoption refused: {reason}")
+        self.status = status
+        self.reason = reason
+
+
+def _scrub(text: str, *secrets: str) -> str:
+    for secret in secrets:
+        if secret:
+            text = text.replace(secret, "<redacted>")
+    return text
+
+
+_REFUSAL_STATUSES = frozenset({400, 401, 403, 409})
+
+
+def _refusal(message: str, *secrets: str) -> tuple[int | None, str]:
+    """Split a ``start_turn`` failure into (refusal status, scrubbed reason).
+
+    Only the statuses the runner uses to refuse an adoption before applying
+    anything are refusals; everything else (5xx, a lost connection) is left to
+    the caller as the ordinary runner error it always was, because after a
+    503 or a dropped socket the adoption MAY have been applied and only the
+    recovery read can say.
+    """
+
+    prefix = "/v1/event -> "
+    if not message.startswith(prefix):
+        return None, ""
+    status_text, _, body = message[len(prefix):].partition(": ")
+    try:
+        status = int(status_text)
+    except ValueError:
+        return None, ""
+    if status not in _REFUSAL_STATUSES:
+        return None, ""
+    reason = body
+    try:
+        parsed = json.loads(body)
+        if isinstance(parsed, dict) and isinstance(parsed.get("error"), str):
+            reason = parsed["error"]
+    except ValueError:
+        pass
+    return status, _scrub(reason, *secrets)
+
+
 class RunnerStreamTimeout(TimeoutError):
     """The streamed turn body exceeded the client's total/sock-read budget.
 
@@ -119,6 +178,23 @@ class TurnStream:
         # client so the stream can NAME the budget it blew (#2011). Optional so
         # a directly-constructed TurnStream (tests, evals) still works.
         self._budget_s = budget_s
+        # ADR-0122 ack: None until a frame is read; then True only while EVERY
+        # frame of the turn carried ``adoption_applied: true``. A tolerant
+        # consumer that ignored the credential serves the turn with no ack, so
+        # an HTTP 200 alone is never adoption.
+        self._adoption_acked: bool | None = None
+
+    @property
+    def adoption_ack_observed(self) -> bool | None:
+        """``None`` before any frame; otherwise whether every frame so far acked."""
+
+        return self._adoption_acked
+
+    @property
+    def adoption_acked(self) -> bool:
+        """True only once at least one frame was read and all of them acked."""
+
+        return self._adoption_acked is True
 
     async def __aiter__(self) -> AsyncIterator[OutboundEvent]:
         try:
@@ -127,6 +203,10 @@ class TurnStream:
                 if not line:
                     continue
                 frame = parse_ndjson_line(line)
+                acked = frame.adoption_applied is True
+                self._adoption_acked = (
+                    acked if self._adoption_acked is None else (self._adoption_acked and acked)
+                )
                 if isinstance(frame, Final):
                     self._saw_final = True
                 yield frame
@@ -381,6 +461,106 @@ class RunnerClient:
             return TurnStream(resp, stream_timeout_s), "success"
 
         return await self._rpc("event", token, request)
+
+    async def start_adopting_turn(
+        self,
+        base_url: str,
+        event: Event,
+        *,
+        bootstrap_token: str,
+        conversation_token: str,
+        session_id: str,
+        history_ref: str | None,
+        remaining_s: float | None = None,
+    ) -> TurnStream:
+        """Open the one turn a bootstrap credential may authenticate (ADR-0122).
+
+        The existing ``Event`` is the transport: the conversation's identity
+        and its fresh credential ride on the frame, the pool bootstrap is the
+        bearer, and no new route or header exists. The caller has already
+        recorded ``conversation_token`` on the thread's route as pending; this
+        call does not persist anything. Read ``TurnStream.adoption_acked`` after
+        streaming to learn whether the runner applied it, and
+        ``adoption_applied`` to recover when the response was lost. A refusal
+        raises ``AdoptionRefused`` with the status and a credential-free reason.
+        """
+
+        if not bootstrap_token or not conversation_token or not session_id:
+            raise RunnerError("adoption requires a bootstrap credential, a conversation "
+                              "credential, and a session id")
+        adopting = event.model_copy(
+            update={
+                "session_id": session_id,
+                "history_ref": history_ref,
+                "adoption_credential": conversation_token,
+            }
+        )
+        try:
+            return await self.start_turn(
+                base_url, adopting, bootstrap_token, remaining_s=remaining_s
+            )
+        except RunnerError as exc:
+            status, reason = _refusal(str(exc), bootstrap_token, conversation_token)
+            if status is None:
+                # Not a refusal (5xx, unreadable body): the adoption MAY have
+                # been applied and only ``adoption_applied`` can say. Re-raise
+                # as the ordinary runner error, scrubbed the same way.
+                raise RunnerError(
+                    _scrub(str(exc), bootstrap_token, conversation_token)
+                ) from None
+            raise AdoptionRefused(status, reason) from None
+
+    async def adoption_applied(
+        self,
+        base_url: str,
+        *,
+        conversation_token: str,
+        session_id: str,
+        remaining_s: float | None = None,
+    ) -> bool:
+        """Did the runner install ``conversation_token`` for ``session_id``?
+
+        The recovery read for a lost adopting response: ``GET /v1/status``
+        under the conversation credential. ``True`` (200 with an attested
+        ``session_id`` equal to ours) proves the binding was applied to that
+        pod, and ONLY that: it says nothing about whether the lost turn ran to
+        completion or produced side effects, so the caller must not replay the
+        first event as if it had never been delivered. ``False`` (401) means
+        the credential is not active on the pod answering, which is NOT proof
+        that the bootstrap is still adoptable there: a rotated or wrong
+        authority, a replaced pod behind the same route, or lost bound state
+        answer the same way. A retry is permitted only through the original
+        fenced claim and pod, fails closed on any refusal, and is reported as
+        unconfirmed rather than as a fresh adoption. A 200 attesting another
+        conversation, or one attesting none, is refused as ``RunnerError``: it
+        is not a runner this thread may be routed to.
+        """
+
+        if not conversation_token:
+            raise RunnerError("adoption recovery requires the conversation credential")
+
+        async def request(headers: dict[str, str] | None) -> tuple[bool, str]:
+            async with self._session.get(
+                f"{base_url}/v1/status",
+                headers=headers,
+                timeout=self._request_timeout(remaining_s),
+            ) as resp:
+                if resp.status == 401:
+                    return False, "conflict"
+                if resp.status != 200:
+                    await resp.read()
+                    raise RunnerError(f"/v1/status -> {resp.status}: adoption recovery refused")
+                data = await resp.json()
+                attested = data.get("session_id") if isinstance(data, dict) else None
+                if not isinstance(attested, str) or not attested:
+                    raise RunnerError("/v1/status attested no conversation; not adopted")
+                if attested != session_id:
+                    raise RunnerError(
+                        "/v1/status attested a different conversation; refusing this route"
+                    )
+                return True, "success"
+
+        return await self._rpc("status", conversation_token, request)
 
     async def steer(
         self,

--- a/apps/worker/src/curie_worker/sandbox/affinity.py
+++ b/apps/worker/src/curie_worker/sandbox/affinity.py
@@ -40,6 +40,54 @@ redis.call('SET', KEYS[1], ARGV[3], 'EX', ARGV[4])
 return 1
 """
 
+# The ADR-0122 d3 applied transition, fenced INSIDE the store. A warm bind's
+# route is written PENDING with the conversation credential before the first
+# event; the flip to APPLIED must observe, in one atomic predicate, that the
+# route is still LIVE (a concurrent ``mark_suspended`` loses), still names the
+# caller's claim and generation (every replacing writer loses), still carries
+# the same credential, and is still PENDING. A route already APPLIED for that
+# credential answers 2 so a retry that lost its first response is idempotent;
+# every other shape answers 0 and writes nothing. The claim + generation CAS
+# above cannot express the state half, and the kernel's suspend runs after its
+# per-thread lock is released, so no lock closes that window: only this
+# predicate does.
+_MARK_ADOPTION_APPLIED = """
+local raw = redis.call('GET', KEYS[1])
+if not raw then return 0 end
+local ok, current = pcall(cjson.decode, raw)
+if not ok then return 0 end
+if current['state'] ~= 'live' then return 0 end
+local generation = current['generation'] or 0
+if current['claim_name'] ~= ARGV[1] or generation ~= tonumber(ARGV[2]) then
+    return 0
+end
+if current['token'] ~= ARGV[3] then return 0 end
+local adoption = current['adoption_state']
+if adoption == 'applied' then return 2 end
+if adoption ~= 'pending' then return 0 end
+redis.call('SET', KEYS[1], ARGV[4], 'EX', ARGV[5])
+return 1
+"""
+
+# Clear the adopting-event marker once the adopting turn's fate is known. Same
+# fence as the applied transition (live, claim, generation) plus the marker
+# itself, so a stale settler cannot clear a marker a later owner wrote.
+_CLEAR_ADOPTING_EVENT = """
+local raw = redis.call('GET', KEYS[1])
+if not raw then return 0 end
+local ok, current = pcall(cjson.decode, raw)
+if not ok then return 0 end
+if current['state'] ~= 'live' then return 0 end
+local generation = current['generation'] or 0
+if current['claim_name'] ~= ARGV[1] or generation ~= tonumber(ARGV[2]) then
+    return 0
+end
+if current['adoption_state'] ~= 'applied' then return 0 end
+if current['adopting_event_id'] ~= ARGV[3] then return 0 end
+redis.call('SET', KEYS[1], ARGV[4], 'EX', ARGV[5])
+return 1
+"""
+
 
 class AffinityStore:
     """Thread-to-sandbox route records with atomic acquire and guarded delete."""
@@ -49,6 +97,8 @@ class AffinityStore:
         self._prefix = key_prefix
         self._delete_if_claim = client.register_script(_DELETE_IF_CLAIM)
         self._replace_if_generation = client.register_script(_REPLACE_IF_GENERATION)
+        self._mark_adoption_applied = client.register_script(_MARK_ADOPTION_APPLIED)
+        self._clear_adopting_event = client.register_script(_CLEAR_ADOPTING_EVENT)
 
     def _key(self, thread_key: str) -> str:
         return f"{self._prefix}:route:{thread_key}"
@@ -92,6 +142,68 @@ class AffinityStore:
                 args=[
                     expected_claim,
                     expected_generation,
+                    record.to_json(),
+                    ttl_seconds,
+                ],
+            )
+        )
+
+    def mark_adoption_applied(
+        self,
+        thread_key: str,
+        *,
+        expected_claim: str,
+        expected_generation: int,
+        expected_token: str,
+        record: RouteRecord,
+        ttl_seconds: int,
+    ) -> int:
+        """Flip a PENDING warm-bind route to APPLIED under the full predicate.
+
+        Returns 1 when this call wrote ``record``, 2 when the route was already
+        APPLIED for ``expected_token`` on the same claim and generation (no
+        write; the caller's retry is idempotent), and 0 when the fence was
+        lost: the route is missing, not LIVE, names another claim or
+        generation, carries another credential, or is not PENDING. The token
+        comparison happens inside Valkey against the stored copy, so the
+        credential is never compared in worker memory here; it is the same
+        value the route already holds.
+        """
+
+        return int(
+            self._mark_adoption_applied(
+                keys=[self._key(thread_key)],
+                args=[
+                    expected_claim,
+                    expected_generation,
+                    expected_token,
+                    record.to_json(),
+                    ttl_seconds,
+                ],
+            )
+        )
+
+    def clear_adopting_event(
+        self,
+        thread_key: str,
+        *,
+        expected_claim: str,
+        expected_generation: int,
+        expected_event_id: str,
+        record: RouteRecord,
+        ttl_seconds: int,
+    ) -> bool:
+        """Write ``record`` only while the route is LIVE and APPLIED on the same
+        claim and generation and still carries ``expected_event_id`` as its
+        adopting event. False when the fence was lost (nothing written)."""
+
+        return bool(
+            self._clear_adopting_event(
+                keys=[self._key(thread_key)],
+                args=[
+                    expected_claim,
+                    expected_generation,
+                    expected_event_id,
                     record.to_json(),
                     ttl_seconds,
                 ],

--- a/apps/worker/src/curie_worker/sandbox/substrate.py
+++ b/apps/worker/src/curie_worker/sandbox/substrate.py
@@ -142,6 +142,7 @@ class SandboxSubstrate:
         session_id: str | None = None,
         history_ref: str | None = None,
         conversation_token: str | None = None,
+        adopting_event_id: str | None = None,
     ) -> SandboxHandle:
         """Return the thread's live sandbox, claiming a warm one if needed.
 
@@ -196,6 +197,7 @@ class SandboxSubstrate:
                             publication_visible_outcome_revision
                         ),
                         conversation_token=conversation_token,
+                        adopting_event_id=adopting_event_id,
                     )
                     outcome = "claimed"
             except Exception as exc:
@@ -345,48 +347,46 @@ class SandboxSubstrate:
         fence was lost, in which case the caller holds a stale handle and must
         re-resolve the route.
 
-        What is fenced, precisely. The write goes through the existing
-        ``replace_if_generation`` CAS, which atomically requires the route to
-        still name ``expected``'s claim AND generation: every writer that
-        replaces the claim (resume, handoff, release + re-claim) therefore
-        loses to or defeats this call. The remaining conditions (route LIVE,
-        same credential, state PENDING) are checked here between the read and
-        the CAS, so a same-claim, same-generation state flip inside that
-        window (``mark_suspended``) is NOT excluded by the store itself, and
-        no lock closes it today: the kernel's only ``suspend`` call runs after
-        its per-thread lock is released. This method therefore has NO
-        production caller in this slice. Before the kernel-wiring slice wires
-        one, ``AffinityStore`` must gain a CAS whose Lua predicate also
-        requires ``state == live`` and ``adoption_state == pending`` (or this
-        method must switch to it); a claim + generation fence alone does not
-        discharge that requirement.
+        The whole predicate is evaluated atomically inside Valkey
+        (``AffinityStore.mark_adoption_applied``): the route must still be
+        LIVE, name ``expected``'s claim AND generation, carry the same
+        credential, and be PENDING. A same-claim, same-generation state flip
+        between a read here and the write (``mark_suspended`` from the kernel's
+        suspend, which runs after its per-thread lock is released) therefore
+        loses or wins inside the store, never in this process; there is no
+        read-modify-write window left to close with a lock.
         """
 
-        record = self._affinity.get(thread_key)
-        if record is None or record.state is not RouteState.LIVE:
-            return None
-        current = record.handle
-        if (
-            current.claim_name != expected.claim_name
-            or current.generation != expected.generation
-            or not hmac.compare_digest(
-                current.token.encode("utf-8"), expected.token.encode("utf-8")
-            )
-        ):
-            return None
-        if current.adoption_state is AdoptionState.APPLIED:
-            return current
-        if current.adoption_state is not AdoptionState.PENDING:
-            return None
-        applied = replace(current, adoption_state=AdoptionState.APPLIED)
-        if not self._affinity.replace_if_generation(
+        applied = replace(expected, adoption_state=AdoptionState.APPLIED)
+        outcome = self._affinity.mark_adoption_applied(
             thread_key,
             expected_claim=expected.claim_name,
             expected_generation=expected.generation,
+            expected_token=expected.token,
             record=RouteRecord(handle=applied, state=RouteState.LIVE),
             ttl_seconds=self._config.route_ttl_seconds,
-        ):
+        )
+        if outcome == 0:
             return None
+        if outcome == 2:
+            # Already applied for this credential: hand back the stored handle
+            # so a caller that lost its first response sees the same fields the
+            # winner recorded (the route may carry a later touch, never a
+            # different identity, under the predicate above).
+            record = self._affinity.get(thread_key)
+            if record is None or record.state is not RouteState.LIVE:
+                return None
+            current = record.handle
+            if (
+                current.claim_name != expected.claim_name
+                or current.generation != expected.generation
+                or current.adoption_state is not AdoptionState.APPLIED
+                or not hmac.compare_digest(
+                    current.token.encode("utf-8"), expected.token.encode("utf-8")
+                )
+            ):
+                return None
+            return current
         logger.info(
             "adoption applied recorded for %s on claim %s generation %d",
             thread_key,
@@ -394,6 +394,64 @@ class SandboxSubstrate:
             applied.generation,
         )
         return applied
+
+    def clear_adopting_event(self, thread_key: str, *, expected: SandboxHandle) -> bool:
+        """Drop the adopting-event marker once that turn's fate is known.
+
+        Fenced inside the store on LIVE + APPLIED + claim + generation + the
+        marker itself. The caller's ``expected`` is usually the handle it
+        routed with, which still reads PENDING; the written record is the
+        APPLIED form, the only state the predicate admits. False when the
+        fence was lost or ``expected`` carries no marker; nothing is written
+        in either case.
+        """
+
+        if not expected.adopting_event_id:
+            return False
+        return self._affinity.clear_adopting_event(
+            thread_key,
+            expected_claim=expected.claim_name,
+            expected_generation=expected.generation,
+            expected_event_id=expected.adopting_event_id,
+            record=RouteRecord(
+                handle=replace(
+                    expected, adopting_event_id=None, adoption_state=AdoptionState.APPLIED
+                ),
+                state=RouteState.LIVE,
+            ),
+            ttl_seconds=self._config.route_ttl_seconds,
+        )
+
+    def release_claim(self, thread_key: str, *, expected: SandboxHandle) -> bool:
+        """Release the thread's sandbox only while the route still names ``expected``.
+
+        The fenced form of ``release`` for callers that decided to end a
+        session on the strength of a handle they hold (an adopting turn that
+        failed its authority probe, or settled without an ack). ``release``
+        deletes whatever the route names at call time, which after the route
+        lock is gone may be a replacement owner's claim; this one compares the
+        claim name AND generation first and does nothing on a mismatch.
+        Returns whether the sandbox was released.
+        """
+
+        record = self._affinity.get(thread_key)
+        if record is None:
+            return False
+        current = record.handle
+        if (
+            current.claim_name != expected.claim_name
+            or current.generation != expected.generation
+        ):
+            return False
+        self._k8s.delete_claim(expected.claim_name)
+        self._affinity.delete_if_claim(thread_key, expected.claim_name)
+        logger.info(
+            "released %s on claim %s generation %d (fenced)",
+            thread_key,
+            expected.claim_name,
+            expected.generation,
+        )
+        return True
 
     # -- suspend / resume -------------------------------------------------------
 
@@ -712,9 +770,12 @@ class SandboxSubstrate:
         generation: int = 0,
         publish: bool = True,
         conversation_token: str | None = None,
+        adopting_event_id: str | None = None,
     ) -> SandboxHandle:
         config = self._config
         boot_env = env or {}
+        if adopting_event_id and not conversation_token:
+            raise ValueError("an adopting event id belongs to a warm-bind claim only")
         if conversation_token:
             if any(key in boot_env for key in (SESSION_ENV, HISTORY_ENV, RUNNER_TOKEN_ENV)):
                 raise ValueError(
@@ -767,6 +828,7 @@ class SandboxSubstrate:
             publication_visible_outcome_revision=publication_visible_outcome_revision,
             generation=generation,
             adoption_state=adoption_state,
+            adopting_event_id=adopting_event_id if conversation_token else None,
         )
         if not publish:
             return handle

--- a/apps/worker/src/curie_worker/sandbox/substrate.py
+++ b/apps/worker/src/curie_worker/sandbox/substrate.py
@@ -22,11 +22,13 @@ transcript key -- is the caller's job.
 
 from __future__ import annotations
 
+import hmac
 import logging
 import secrets
 import time
 import uuid
 from collections.abc import Callable
+from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 
 from aci_protocol import BootEnv
@@ -40,6 +42,7 @@ from .types import (
     MANAGED_BY_LABEL,
     MANAGED_BY_VALUE,
     THREAD_HASH_LABEL,
+    AdoptionState,
     CapacityExhaustedError,
     ClaimTimeoutError,
     NoRouteError,
@@ -136,6 +139,9 @@ class SandboxSubstrate:
         workspace_repo: str | None = None,
         workspace_materialized_head: str | None = None,
         publication_visible_outcome_revision: int = 0,
+        session_id: str | None = None,
+        history_ref: str | None = None,
+        conversation_token: str | None = None,
     ) -> SandboxHandle:
         """Return the thread's live sandbox, claiming a warm one if needed.
 
@@ -143,6 +149,15 @@ class SandboxSubstrate:
         history ref); the fast path passes none so the claim binds a pre-warmed
         generic sandbox. ``agent_name`` selects the per-agent warm pool when
         connector secrets are marked on ``env`` (#1488).
+
+        A warm bind (ADR-0116 d2 / ADR-0122) passes the conversation's
+        ``session_id``, ``history_ref``, and a freshly minted
+        ``conversation_token`` here instead of as env: the route is recorded
+        with that credential as ``AdoptionState.PENDING`` before the caller
+        sends the adopting ``Event``, so the durable copy exists before the
+        first request that could lose its response. Identity env and a
+        conversation token together are refused: they would describe a cold
+        pod bound at boot to one identity while the ACI adopts another.
         """
 
         started = time.monotonic()
@@ -172,12 +187,15 @@ class SandboxSubstrate:
                         thread_key,
                         env=env,
                         state=RouteState.LIVE,
+                        session_id=session_id,
+                        history_ref=history_ref,
                         agent_name=agent_name,
                         workspace_repo=workspace_repo,
                         workspace_materialized_head=workspace_materialized_head,
                         publication_visible_outcome_revision=(
                             publication_visible_outcome_revision
                         ),
+                        conversation_token=conversation_token,
                     )
                     outcome = "claimed"
             except Exception as exc:
@@ -313,6 +331,69 @@ class SandboxSubstrate:
         except Exception:  # noqa: BLE001 - route already swapped; reaper owns cleanup
             logger.exception("late workspace handoff left old claim for orphan reaping")
         return candidate
+
+    def mark_adoption_applied(
+        self, thread_key: str, *, expected: SandboxHandle
+    ) -> SandboxHandle | None:
+        """Record that the runner installed ``expected.token`` (ADR-0122 d2).
+
+        Called once the adopting turn acked ``adoption_applied: true`` on every
+        frame, or once the ``/v1/status`` attestation under the conversation
+        credential proved the binding after a lost response. Idempotent when
+        the route is already APPLIED for that credential (a retry that lost
+        its first response). Returns the applied handle, or ``None`` when the
+        fence was lost, in which case the caller holds a stale handle and must
+        re-resolve the route.
+
+        What is fenced, precisely. The write goes through the existing
+        ``replace_if_generation`` CAS, which atomically requires the route to
+        still name ``expected``'s claim AND generation: every writer that
+        replaces the claim (resume, handoff, release + re-claim) therefore
+        loses to or defeats this call. The remaining conditions (route LIVE,
+        same credential, state PENDING) are checked here between the read and
+        the CAS, so a same-claim, same-generation state flip inside that
+        window (``mark_suspended``) is NOT excluded by the store itself, and
+        no lock closes it today: the kernel's only ``suspend`` call runs after
+        its per-thread lock is released. This method therefore has NO
+        production caller in this slice. Before the kernel-wiring slice wires
+        one, ``AffinityStore`` must gain a CAS whose Lua predicate also
+        requires ``state == live`` and ``adoption_state == pending`` (or this
+        method must switch to it); a claim + generation fence alone does not
+        discharge that requirement.
+        """
+
+        record = self._affinity.get(thread_key)
+        if record is None or record.state is not RouteState.LIVE:
+            return None
+        current = record.handle
+        if (
+            current.claim_name != expected.claim_name
+            or current.generation != expected.generation
+            or not hmac.compare_digest(
+                current.token.encode("utf-8"), expected.token.encode("utf-8")
+            )
+        ):
+            return None
+        if current.adoption_state is AdoptionState.APPLIED:
+            return current
+        if current.adoption_state is not AdoptionState.PENDING:
+            return None
+        applied = replace(current, adoption_state=AdoptionState.APPLIED)
+        if not self._affinity.replace_if_generation(
+            thread_key,
+            expected_claim=expected.claim_name,
+            expected_generation=expected.generation,
+            record=RouteRecord(handle=applied, state=RouteState.LIVE),
+            ttl_seconds=self._config.route_ttl_seconds,
+        ):
+            return None
+        logger.info(
+            "adoption applied recorded for %s on claim %s generation %d",
+            thread_key,
+            applied.claim_name,
+            applied.generation,
+        )
+        return applied
 
     # -- suspend / resume -------------------------------------------------------
 
@@ -630,8 +711,22 @@ class SandboxSubstrate:
         publication_visible_outcome_revision: int = 0,
         generation: int = 0,
         publish: bool = True,
+        conversation_token: str | None = None,
     ) -> SandboxHandle:
         config = self._config
+        boot_env = env or {}
+        if conversation_token:
+            if any(key in boot_env for key in (SESSION_ENV, HISTORY_ENV, RUNNER_TOKEN_ENV)):
+                raise ValueError(
+                    "a warm-bind claim delivers session identity and its credential over "
+                    "the ACI; per-claim session, history, or runner-token env would boot "
+                    "a cold pod bound to a different identity"
+                )
+            token = conversation_token
+            adoption_state = AdoptionState.PENDING
+        else:
+            token = boot_env.get(RUNNER_TOKEN_ENV, "")
+            adoption_state = AdoptionState.NONE
         nonce = uuid.uuid4().hex[:6]
         name = config.claim_name_for(thread_key, nonce)
         thread_hash = name.rsplit("-", 1)[0].rsplit("-", 1)[-1]
@@ -664,15 +759,14 @@ class SandboxSubstrate:
             # claims receive their authoritative identity in this exact env;
             # the explicit values remain fallbacks for lifecycle callers that
             # preserve identity without carrying those optional env entries.
-            session_id=(env or {}).get(SESSION_ENV)
-            or session_id
-            or f"thread-{thread_hash}",
-            history_ref=(env or {}).get(HISTORY_ENV) or history_ref,
-            token=(env or {}).get(RUNNER_TOKEN_ENV, ""),
+            session_id=boot_env.get(SESSION_ENV) or session_id or f"thread-{thread_hash}",
+            history_ref=boot_env.get(HISTORY_ENV) or history_ref,
+            token=token,
             workspace_repo=workspace_repo,
             workspace_materialized_head=workspace_materialized_head,
             publication_visible_outcome_revision=publication_visible_outcome_revision,
             generation=generation,
+            adoption_state=adoption_state,
         )
         if not publish:
             return handle

--- a/apps/worker/src/curie_worker/sandbox/types.py
+++ b/apps/worker/src/curie_worker/sandbox/types.py
@@ -106,6 +106,30 @@ class RouteState(StrEnum):
     SUSPENDED = "suspended"
 
 
+class AdoptionState(StrEnum):
+    """Whether the route's runner credential has been installed on its pod.
+
+    ADR-0122 delivers a warm bind's per-conversation credential over the first
+    authenticated ACI ``Event`` and keeps the durable copy on the route, so a
+    lost response, a crash, or a second replica recovers it from the store
+    rather than from a worker's memory.
+
+    - ``NONE``: cold path. The token reached the runner as per-claim boot env
+      (``CURIE_RUNNER_TOKEN``); nothing is adoptable. Also what every route
+      written before this field existed rehydrates as.
+    - ``PENDING``: warm bind. The worker minted the credential and recorded it
+      here BEFORE sending the adopting event; the runner still holds only the
+      pool bootstrap, so the adopting request may be retried.
+    - ``APPLIED``: the runner acked ``adoption_applied: true`` for this
+      credential, or its ``/v1/status`` attestation proved the binding. The
+      bootstrap is retired on that pod; only this credential reaches it.
+    """
+
+    NONE = "none"
+    PENDING = "pending"
+    APPLIED = "applied"
+
+
 @dataclass(frozen=True)
 class SandboxHandle:
     """A claimed sandbox bound to a thread: identity plus the ACI dial target.
@@ -138,6 +162,9 @@ class SandboxHandle:
     # when a denied/failed revision leaves the git head unchanged.
     publication_visible_outcome_revision: int = 0
     generation: int = 0
+    # ADR-0122: whether ``token`` has been installed on the runner. Defaulted so
+    # every route written before the field existed rehydrates as the cold path.
+    adoption_state: AdoptionState = AdoptionState.NONE
 
     @property
     def sandbox_id(self) -> str:
@@ -160,12 +187,26 @@ class RouteRecord:
     def to_json(self) -> str:
         payload = asdict(self.handle)
         payload["state"] = self.state.value
+        # Mixed-fleet safety: a worker built before this field rehydrates a
+        # record with ``SandboxHandle(**payload)`` and would raise on an
+        # unknown key, then evict or reap the live claim. The cold path is the
+        # default, so it is written in the legacy shape; only a route that is
+        # actually pending or applied carries the key, and those are written
+        # only once every replica understands it (rollout order: worker last).
+        if payload["adoption_state"] == AdoptionState.NONE.value:
+            del payload["adoption_state"]
         return json.dumps(payload, sort_keys=True)
 
     @classmethod
     def from_json(cls, raw: str) -> RouteRecord:
         payload = json.loads(raw)
         state = RouteState(payload.pop("state", RouteState.LIVE.value))
+        # An unknown value raises rather than being guessed: a route that
+        # claims a state this build does not know must not be treated as
+        # either adoptable or applied.
+        payload["adoption_state"] = AdoptionState(
+            payload.get("adoption_state", AdoptionState.NONE.value)
+        )
         return cls(handle=SandboxHandle(**payload), state=state)
 
 

--- a/apps/worker/src/curie_worker/sandbox/types.py
+++ b/apps/worker/src/curie_worker/sandbox/types.py
@@ -165,6 +165,12 @@ class SandboxHandle:
     # ADR-0122: whether ``token`` has been installed on the runner. Defaulted so
     # every route written before the field existed rehydrates as the cold path.
     adoption_state: AdoptionState = AdoptionState.NONE
+    # ADR-0122 / root correction 3: the id of the event whose adopting turn
+    # this route's pod was (or is being) bound with, recorded at the PENDING
+    # write and cleared only once that turn's terminal answer is known. A
+    # redelivery of that same event that finds the route APPLIED with its own
+    # id here must not open a plain turn: the first turn may already have run.
+    adopting_event_id: str | None = None
 
     @property
     def sandbox_id(self) -> str:
@@ -195,6 +201,8 @@ class RouteRecord:
         # only once every replica understands it (rollout order: worker last).
         if payload["adoption_state"] == AdoptionState.NONE.value:
             del payload["adoption_state"]
+        if payload["adopting_event_id"] is None:
+            del payload["adopting_event_id"]
         return json.dumps(payload, sort_keys=True)
 
     @classmethod

--- a/apps/worker/src/curie_worker/warm_bind.py
+++ b/apps/worker/src/curie_worker/warm_bind.py
@@ -1,0 +1,68 @@
+"""The warm-bind seam: which claims may adopt a pre-booted pool pod (ADR-0116 d2).
+
+The kernel's cold path binds a sandbox at boot through per-claim env. A warm
+bind instead claims an env-free pool pod whose runner booted in bootstrap mode
+(ADR-0122) and adopts the conversation over the ACI ``Event``. Whether a given
+claim MAY do that, and with which pool bootstrap credential, is a decision that
+belongs to the version-scoped template and pool owner (#1492 decisions 1 and
+3), not to the kernel. The kernel therefore asks this policy and does nothing
+warm when it is absent: production wires ``None`` today, so every claim keeps
+the cold path byte for byte.
+
+``ADOPTION_UNCONFIRMED`` is the outcome classification for an adopting turn
+whose response was lost after the adopting event left the worker. It is
+deliberately NOT retryable: the runner may already have run the model for that
+event, and a retry would replay the first turn's side effects. The kernel
+escalates it to a human instead.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+ADOPTION_UNCONFIRMED = "adoption-unconfirmed"
+
+
+class AdoptionUnconfirmedError(RuntimeError):
+    """A pending route's pod already holds the binding, but no turn ran here.
+
+    Raised from the routing critical section when a delivery finds its warm
+    route still PENDING while the pod attests the conversation credential: a
+    previous owner of this delivery adopted the pod and was lost between the
+    runner's 200 and the route write. The first turn may already have run on
+    that pod, so the kernel converts this into the ``adoption-unconfirmed``
+    outcome (escalated, never replayed) rather than into a retryable error.
+    """
+
+    def __init__(self, thread_key: str) -> None:
+        super().__init__(f"thread {thread_key}: adoption applied by a lost owner; unconfirmed")
+
+
+class WarmBindPolicy(Protocol):
+    """Answer the pool bootstrap credential for a claim that may warm-bind."""
+
+    def bootstrap_for(
+        self, thread_key: str, *, boot_env: dict[str, str], agent_name: str | None
+    ) -> str | None:
+        """Return the pool's bootstrap credential, or ``None`` for the cold path.
+
+        The credential is the pool's, never the conversation's: the kernel
+        mints the per-conversation credential itself and records it on the
+        route before any event. Return ``None`` whenever the pool that would
+        serve this claim is not known to be booted in bootstrap mode.
+
+        Two invariants the policy owner carries, because a warm claim injects
+        NO env: only the session id, the history ref, and the conversation
+        credential travel over the ACI. (1) The pool template that serves this
+        claim must already carry everything ``boot_env`` would have injected
+        for the cold path (the agent's bundle ref, plugin dir, budget, memory
+        and state refs and tokens); a bootstrap returned for a pool whose
+        template lacks the agent's bundle binds a runner to the wrong agent.
+        (2) The pool must be image-homogeneous and the pod's runner process
+        stable between the kernel's authority probe and its adopting event:
+        the probe establishes authority on the process that answers it, and a
+        mixed-image pool could pass the probe on one process and serve the
+        event on an older one. The actual old-server negative is an activation
+        gate for the pool owner, not something the kernel can infer.
+        """
+        ...

--- a/apps/worker/tests/kernel/test_runner_client_adoption.py
+++ b/apps/worker/tests/kernel/test_runner_client_adoption.py
@@ -492,6 +492,78 @@ def test_non_refusal_failure_is_scrubbed_and_not_an_adoption_refusal() -> None:
     asyncio.run(go())
 
 
+def test_adoption_authority_is_established_only_by_a_realizing_bootstrap_runner() -> None:
+    """Root correction 6: authority first, through the status route, never by version."""
+
+    async def go() -> None:
+        client = RunnerClient(total_timeout_s=30.0)
+        try:
+            async with _real_runner() as warm:
+                assert await client.adoption_authority(warm.base_url, bootstrap_token=_BOOT) is True
+                # Establishing authority started no turn and bound nothing.
+                assert warm.sessions[0].queries == [] and warm.runner.session_id == "warm-unbound"
+                # The wrong pool credential establishes nothing (401 -> False).
+                assert (
+                    await client.adoption_authority(warm.base_url, bootstrap_token="other-pool")
+                    is False
+                )
+                # After adoption the bootstrap is retired: authority is gone too.
+                turn = await client.start_adopting_turn(
+                    warm.base_url,
+                    _event(),
+                    bootstrap_token=_BOOT,
+                    conversation_token=_CONV,
+                    session_id=_SESSION,
+                    history_ref=None,
+                )
+                await _drain(turn)
+                assert (
+                    await client.adoption_authority(warm.base_url, bootstrap_token=_BOOT) is False
+                )
+            async with _real_runner(token="per-claim-token-0123456789", bootstrap=None) as cold:
+                # A cold per-claim runner (even presented with its own token) is not an adopter.
+                assert (
+                    await client.adoption_authority(
+                        cold.base_url, bootstrap_token="per-claim-token-0123456789"
+                    )
+                    is False
+                )
+            async with _real_runner(token=None, bootstrap=None) as open_runner:
+                # An OLD or open runner answers 200 on the probe: refused, so no
+                # adopting event (and no model turn) is ever sent to it.
+                assert (
+                    await client.adoption_authority(open_runner.base_url, bootstrap_token=_BOOT)
+                    is False
+                )
+                assert open_runner.sessions[0].queries == []
+        finally:
+            await client.close()
+
+    asyncio.run(go())
+
+
+def test_adoption_authority_rejects_a_forged_403_without_the_fixed_reason() -> None:
+    app = web.Application()
+
+    async def status(_: web.Request) -> web.Response:
+        return web.json_response({"error": "forbidden"}, status=403)
+
+    app.add_routes([web.get("/v1/status", status)])
+
+    async def go() -> None:
+        server = TestServer(app)
+        await server.start_server()
+        client = RunnerClient(total_timeout_s=30.0)
+        try:
+            base = str(server.make_url("")).rstrip("/")
+            assert await client.adoption_authority(base, bootstrap_token=_BOOT) is False
+        finally:
+            await client.close()
+            await server.close()
+
+    asyncio.run(go())
+
+
 def test_recovery_probe_refuses_a_legacy_attestation_without_session_id() -> None:
     """A runner that answers 200 without attesting a session cannot be trusted as bound."""
 

--- a/apps/worker/tests/kernel/test_runner_client_adoption.py
+++ b/apps/worker/tests/kernel/test_runner_client_adoption.py
@@ -1,0 +1,517 @@
+"""Worker-side adoption over the existing ACI Event (ADR-0116 d2, ADR-0122).
+
+The worker never learns success from an HTTP 200: a tolerant consumer that
+ignores ``adoption_credential`` serves the turn anyway. Success is the runner's
+``adoption_applied: true`` ack on every frame of the adopting turn, and the
+recovery path for a lost response is ``GET /v1/status`` with the conversation
+credential, whose attested ``session_id`` is what proves the binding (identity
+only: never that the lost turn completed or is safe to repeat).
+
+Pure HTTP: the server is the REAL runner app in bootstrap mode over a fake
+model session (no Valkey, no cluster). Legacy and malformed consumers are the
+only doubles, and they exist to prove a missing or non-boolean ack is never
+counted as adoption.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+from aci_protocol import Event, Final, SessionStatus, TextDelta
+from aiohttp import web
+from aiohttp.test_utils import TestServer
+from curie_runner import RunTracer, SideEffectClassifier, create_app
+from curie_runner.fake import FakeModelSession
+from curie_runner.history import ConversationReplay, NullTranscriptStore
+from curie_runner.server import bind_status_attestation
+from curie_runner.session import SessionRunner
+from curie_worker.runner_client import AdoptionRefused, RunnerClient, RunnerError
+
+_BOOT = "pool-bootstrap-credential-0123456789"
+_CONV = "conversation-credential-A-0123456789"
+_CONV_B = "conversation-credential-B-0123456789"
+_SESSION = "agent-acme-thread-C0EXAMPLE1-1700000000.000100"
+_SESSION_B = "agent-acme-thread-C0EXAMPLE1-1700000000.000200"
+_HISTORY = "http://api.example.com/agents/acme/state/transcript/thread-1"
+_SECRETS = (_BOOT, _CONV, _CONV_B)
+
+
+def _event(text: str = "hello") -> Event:
+    return Event(type="message", text=text, user="U1", ts="1700000000.000100")
+
+
+class _Binder:
+    """The runner's ConversationBinder: records what was bound, loads nothing."""
+
+    def __init__(self) -> None:
+        self.loads: list[tuple[str, str | None]] = []
+
+    async def load(
+        self, session_id: str, history_ref: str | None
+    ) -> tuple[Any, ConversationReplay, Any]:
+        self.loads.append((session_id, history_ref))
+        return NullTranscriptStore(), ConversationReplay(), None
+
+    def rebind(self, session_id: str, replay: ConversationReplay) -> None:
+        return None
+
+
+@dataclass
+class _Runner:
+    server: TestServer
+    runner: SessionRunner
+    binder: _Binder
+    sessions: list[FakeModelSession]
+
+    @property
+    def base_url(self) -> str:
+        return str(self.server.make_url("")).rstrip("/")
+
+
+@asynccontextmanager
+async def _real_runner(
+    *, token: str | None = None, bootstrap: str | None = _BOOT
+) -> AsyncIterator[_Runner]:
+    """The real runner app: bootstrap mode by default, per-claim when ``token`` is set."""
+
+    sessions: list[FakeModelSession] = []
+
+    def factory() -> FakeModelSession:
+        fake = FakeModelSession()
+        sessions.append(fake)
+        return fake
+
+    binder = _Binder()
+    runner = SessionRunner(
+        session_factory=factory,
+        ceiling=0,
+        tracer=RunTracer(None),
+        classifier=SideEffectClassifier(),
+        trace_name="curie-run:warm-unbound",
+        session_id="warm-unbound",
+        conversation_binder=binder,
+    )
+    await runner.start()
+    # What ``__main__`` binds at boot: the attestation ``/v1/status`` reports.
+    bind_status_attestation(runner, session_id="warm-unbound", sandbox_id="sbx-pool-1", cwd=None)
+    app = create_app(runner, token=token, bootstrap_token=bootstrap)
+    server = TestServer(app)
+    await server.start_server()
+    try:
+        yield _Runner(server=server, runner=runner, binder=binder, sessions=sessions)
+    finally:
+        await server.close()
+
+
+class _LegacyRunner:
+    """A tolerant pre-adoption consumer: ignores the field, serves the turn, no ack."""
+
+    def __init__(self, *, ack_value: object = None) -> None:
+        self.app = web.Application()
+        self.app.add_routes([web.post("/v1/event", self._event)])
+        self.bodies: list[dict[str, Any]] = []
+        self.ack_value = ack_value
+
+    async def _event(self, request: web.Request) -> web.StreamResponse:
+        self.bodies.append(await request.json())
+        resp = web.StreamResponse(status=200, headers={"Content-Type": "application/x-ndjson"})
+        await resp.prepare(request)
+        for frame in (TextDelta(text="x"), Final(text="ok", status=SessionStatus.DONE)):
+            payload = frame.model_dump()
+            if self.ack_value is not None:
+                payload["adoption_applied"] = self.ack_value
+            resp_line = __import__("json").dumps(payload) + "\n"
+            await resp.write(resp_line.encode("utf-8"))
+        await resp.write_eof()
+        return resp
+
+
+async def _drain(turn: Any) -> list[Any]:
+    frames = []
+    async with turn:
+        async for frame in turn:
+            frames.append(frame)
+    return frames
+
+
+def _assert_no_secret(*payloads: str) -> None:
+    for payload in payloads:
+        for secret in _SECRETS:
+            assert secret not in payload
+
+
+# --- the happy path against the real runner ------------------------------------
+
+
+def test_adopting_turn_is_acked_then_the_conversation_credential_gates(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.DEBUG)
+
+    async def go() -> None:
+        async with _real_runner() as rt:
+            client = RunnerClient(total_timeout_s=30.0)
+            try:
+                turn = await client.start_adopting_turn(
+                    rt.base_url,
+                    _event(),
+                    bootstrap_token=_BOOT,
+                    conversation_token=_CONV,
+                    session_id=_SESSION,
+                    history_ref=_HISTORY,
+                )
+                # Before any frame is read the ack is unknown, never assumed.
+                assert turn.adoption_ack_observed is None
+                assert turn.adoption_acked is False
+                frames = await _drain(turn)
+                assert frames and isinstance(frames[-1], Final)
+                assert turn.adoption_acked is True
+                assert all(frame.adoption_applied is True for frame in frames)
+                # The runner really bound the conversation named on the frame.
+                assert rt.binder.loads == [(_SESSION, _HISTORY)]
+                assert rt.runner.session_id == _SESSION
+                assert rt.sessions[-1].queries == ["hello"]
+
+                # The bootstrap is retired: refused as a plain wrong token.
+                with pytest.raises(AdoptionRefused) as refused:
+                    await client.start_adopting_turn(
+                        rt.base_url,
+                        _event(),
+                        bootstrap_token=_BOOT,
+                        conversation_token=_CONV_B,
+                        session_id=_SESSION_B,
+                        history_ref=_HISTORY,
+                    )
+                assert refused.value.status == 401
+                # The conversation credential now gates the ordinary routes.
+                status = await client.status(rt.base_url, token=_CONV)
+                assert status["session_id"] == _SESSION
+                follow = await client.start_turn(
+                    rt.base_url,
+                    _event("again").model_copy(update={"session_id": _SESSION}),
+                    token=_CONV,
+                )
+                later = await _drain(follow)
+                # A later turn is not an adoption and claims no ack.
+                assert follow.adoption_acked is False
+                assert all(frame.adoption_applied is None for frame in later)
+                assert await client.adoption_applied(
+                    rt.base_url, conversation_token=_CONV, session_id=_SESSION
+                )
+            finally:
+                await client.close()
+
+    asyncio.run(go())
+    _assert_no_secret(*(record.getMessage() for record in caplog.records))
+
+
+def test_adopting_event_carries_identity_and_credential_on_the_wire() -> None:
+    """The existing Event is the transport: no header, no new route."""
+
+    legacy = _LegacyRunner()
+
+    async def go() -> None:
+        server = TestServer(legacy.app)
+        await server.start_server()
+        client = RunnerClient(total_timeout_s=30.0)
+        try:
+            base = str(server.make_url("")).rstrip("/")
+            turn = await client.start_adopting_turn(
+                base,
+                _event(),
+                bootstrap_token=_BOOT,
+                conversation_token=_CONV,
+                session_id=_SESSION,
+                history_ref=_HISTORY,
+            )
+            await _drain(turn)
+        finally:
+            await client.close()
+            await server.close()
+
+    asyncio.run(go())
+    body = legacy.bodies[0]
+    assert body["adoption_credential"] == _CONV
+    assert body["session_id"] == _SESSION
+    assert body["history_ref"] == _HISTORY
+    assert body["kind"] == "event" and body["text"] == "hello"
+
+
+# --- a 200 is never proof: legacy and malformed acks ----------------------------
+
+
+def test_legacy_consumer_without_ack_is_not_adopted() -> None:
+    legacy = _LegacyRunner()
+
+    async def go() -> None:
+        server = TestServer(legacy.app)
+        await server.start_server()
+        client = RunnerClient(total_timeout_s=30.0)
+        try:
+            base = str(server.make_url("")).rstrip("/")
+            turn = await client.start_adopting_turn(
+                base,
+                _event(),
+                bootstrap_token=_BOOT,
+                conversation_token=_CONV,
+                session_id=_SESSION,
+                history_ref=None,
+            )
+            frames = await _drain(turn)
+            assert isinstance(frames[-1], Final)  # the turn itself succeeded
+            assert turn.adoption_ack_observed is False
+            assert turn.adoption_acked is False  # ...and that is not adoption
+        finally:
+            await client.close()
+            await server.close()
+
+    asyncio.run(go())
+
+
+def test_explicit_false_ack_is_not_adopted() -> None:
+    declined = _LegacyRunner(ack_value=False)
+
+    async def go() -> None:
+        server = TestServer(declined.app)
+        await server.start_server()
+        client = RunnerClient(total_timeout_s=30.0)
+        try:
+            base = str(server.make_url("")).rstrip("/")
+            turn = await client.start_adopting_turn(
+                base,
+                _event(),
+                bootstrap_token=_BOOT,
+                conversation_token=_CONV,
+                session_id=_SESSION,
+                history_ref=None,
+            )
+            await _drain(turn)
+            assert turn.adoption_acked is False
+        finally:
+            await client.close()
+            await server.close()
+
+    asyncio.run(go())
+
+
+@pytest.mark.parametrize("ack_value", ["true", 1])
+def test_non_boolean_ack_is_a_stream_error_not_adoption(ack_value: object) -> None:
+    malformed = _LegacyRunner(ack_value=ack_value)
+
+    async def go() -> None:
+        server = TestServer(malformed.app)
+        await server.start_server()
+        client = RunnerClient(total_timeout_s=30.0)
+        try:
+            base = str(server.make_url("")).rstrip("/")
+            turn = await client.start_adopting_turn(
+                base,
+                _event(),
+                bootstrap_token=_BOOT,
+                conversation_token=_CONV,
+                session_id=_SESSION,
+                history_ref=None,
+            )
+            with pytest.raises(ValueError):
+                await _drain(turn)
+            assert turn.adoption_acked is False
+        finally:
+            await client.close()
+            await server.close()
+
+    asyncio.run(go())
+
+
+# --- refusals never leak the credential -----------------------------------------
+
+
+def test_refusals_carry_status_and_no_credential(caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.DEBUG)
+
+    async def go() -> None:
+        async with _real_runner() as rt:
+            client = RunnerClient(total_timeout_s=30.0)
+            try:
+                # Wrong bootstrap.
+                with pytest.raises(AdoptionRefused) as wrong:
+                    await client.start_adopting_turn(
+                        rt.base_url,
+                        _event(),
+                        bootstrap_token="not-the-pool-bootstrap",
+                        conversation_token=_CONV,
+                        session_id=_SESSION,
+                        history_ref=None,
+                    )
+                assert wrong.value.status == 401
+                _assert_no_secret(str(wrong.value))
+                # Bootstrap presented as the new credential.
+                with pytest.raises(AdoptionRefused) as same:
+                    await client.start_adopting_turn(
+                        rt.base_url,
+                        _event(),
+                        bootstrap_token=_BOOT,
+                        conversation_token=_BOOT,
+                        session_id=_SESSION,
+                        history_ref=None,
+                    )
+                assert same.value.status == 400
+                _assert_no_secret(str(same.value))
+                # Nothing was bound by either refusal.
+                assert rt.binder.loads == []
+                assert rt.runner.session_id == "warm-unbound"
+                assert not await client.adoption_applied(
+                    rt.base_url, conversation_token=_CONV, session_id=_SESSION
+                )
+            finally:
+                await client.close()
+        async with _real_runner(token="per-claim-token-0123456789", bootstrap=None) as cold:
+            client = RunnerClient(total_timeout_s=30.0)
+            try:
+                # A cold (per-claim) runner is never adoptable, whoever asks.
+                with pytest.raises(AdoptionRefused) as not_adoptable:
+                    await client.start_adopting_turn(
+                        cold.base_url,
+                        _event(),
+                        bootstrap_token="per-claim-token-0123456789",
+                        conversation_token=_CONV,
+                        session_id=_SESSION,
+                        history_ref=None,
+                    )
+                assert not_adoptable.value.status == 409
+                assert cold.sessions[0].queries == []
+            finally:
+                await client.close()
+
+    asyncio.run(go())
+    _assert_no_secret(*(record.getMessage() for record in caplog.records))
+
+
+# --- lost-response recovery through the runner's attestation --------------------
+
+
+def test_recovery_probe_distinguishes_applied_from_still_adoptable() -> None:
+    async def go() -> None:
+        async with _real_runner() as rt:
+            client = RunnerClient(total_timeout_s=30.0)
+            try:
+                # Not applied yet: the conversation credential is a wrong token
+                # (401). That is "not confirmed on this pod", not proof the
+                # bootstrap is adoptable; here the same pod really is unbound.
+                assert (
+                    await client.adoption_applied(
+                        rt.base_url, conversation_token=_CONV, session_id=_SESSION
+                    )
+                    is False
+                )
+                # Apply, simulating the lost response by never reading the body.
+                turn = await client.start_adopting_turn(
+                    rt.base_url,
+                    _event(),
+                    bootstrap_token=_BOOT,
+                    conversation_token=_CONV,
+                    session_id=_SESSION,
+                    history_ref=_HISTORY,
+                )
+                turn.close()
+                # Let the runner finish the turn we abandoned.
+                for _ in range(200):
+                    if rt.runner.session_id == _SESSION and not rt.runner._turn_open:  # noqa: SLF001
+                        break
+                    await asyncio.sleep(0.01)
+                # The attestation proves the binding without reopening the
+                # bootstrap or sending a second adopting event.
+                assert (
+                    await client.adoption_applied(
+                        rt.base_url, conversation_token=_CONV, session_id=_SESSION
+                    )
+                    is True
+                )
+                # A retry of the adopting request after recovery is refused, so a
+                # duplicate first turn cannot be started under the bootstrap.
+                with pytest.raises(AdoptionRefused) as again:
+                    await client.start_adopting_turn(
+                        rt.base_url,
+                        _event(),
+                        bootstrap_token=_BOOT,
+                        conversation_token=_CONV,
+                        session_id=_SESSION,
+                        history_ref=_HISTORY,
+                    )
+                assert again.value.status == 401
+                # The credential attesting a DIFFERENT conversation is a refusal,
+                # never "applied": the worker must not route this thread there.
+                with pytest.raises(RunnerError):
+                    await client.adoption_applied(
+                        rt.base_url, conversation_token=_CONV, session_id=_SESSION_B
+                    )
+            finally:
+                await client.close()
+
+    asyncio.run(go())
+
+
+def test_non_refusal_failure_is_scrubbed_and_not_an_adoption_refusal() -> None:
+    """A 5xx that echoes the body is neither a refusal nor a credential leak."""
+
+    app = web.Application()
+
+    async def broken(request: web.Request) -> web.Response:
+        # A non-conforming server that echoes the request back on failure.
+        return web.Response(status=503, text=await request.text())
+
+    app.add_routes([web.post("/v1/event", broken)])
+
+    async def go() -> None:
+        server = TestServer(app)
+        await server.start_server()
+        client = RunnerClient(total_timeout_s=30.0)
+        try:
+            base = str(server.make_url("")).rstrip("/")
+            with pytest.raises(RunnerError) as failure:
+                await client.start_adopting_turn(
+                    base,
+                    _event(),
+                    bootstrap_token=_BOOT,
+                    conversation_token=_CONV,
+                    session_id=_SESSION,
+                    history_ref=None,
+                )
+            assert not isinstance(failure.value, AdoptionRefused)
+            assert "503" in str(failure.value)
+            _assert_no_secret(str(failure.value))
+        finally:
+            await client.close()
+            await server.close()
+
+    asyncio.run(go())
+
+
+def test_recovery_probe_refuses_a_legacy_attestation_without_session_id() -> None:
+    """A runner that answers 200 without attesting a session cannot be trusted as bound."""
+
+    app = web.Application()
+
+    async def status(_: web.Request) -> web.Response:
+        return web.json_response({"status": "idle-awaiting-input", "turn_active": False})
+
+    app.add_routes([web.get("/v1/status", status)])
+
+    async def go() -> None:
+        server = TestServer(app)
+        await server.start_server()
+        client = RunnerClient(total_timeout_s=30.0)
+        try:
+            base = str(server.make_url("")).rstrip("/")
+            with pytest.raises(RunnerError):
+                await client.adoption_applied(base, conversation_token=_CONV, session_id=_SESSION)
+        finally:
+            await client.close()
+            await server.close()
+
+    asyncio.run(go())

--- a/apps/worker/tests/kernel/test_warm_adoption.py
+++ b/apps/worker/tests/kernel/test_warm_adoption.py
@@ -1,0 +1,537 @@
+"""Warm bind through the kernel: claim env-free, establish authority, adopt, settle.
+
+ADR-0116 d2 / ADR-0122 realized end to end inside the worker: with a warm-bind
+policy wired, a non-workspace claim binds a pool pod with NO identity env, the
+per-conversation credential is on the route as PENDING before the first event,
+the runner must prove by behavior that it is a bootstrap-mode adopter before
+that event is sent, the adopting turn is acked on every frame, and the route is
+settled through the store's fenced predicate. Real Valkey, the real substrate
+over the fake control plane, and either the REAL runner app (its model seam
+faked) or a scriptable adopting fake for the failure shapes.
+
+Without a policy the kernel is byte-for-byte the cold path, proven here too.
+
+The "old or open runner" negative uses the suite's ordinary ``FakeRunner``,
+which ignores adoption entirely and answers 200 to any status bearer. That is an
+open-mode SURROGATE on current code, not an execution of a pre-adoption runner
+image; the actual old-server negative remains an activation obligation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from typing import Any
+
+import pytest
+from aci_protocol import Final, QueuedTurn, ReplyHandle, SessionStatus, TextDelta
+from aiohttp import web
+from curie_runner import RunTracer, SideEffectClassifier
+from curie_runner.fake import FakeModelSession
+from curie_runner.history import ConversationReplay, NullTranscriptStore
+from curie_runner.server import bind_status_attestation, create_app
+from curie_runner.session import SessionRunner
+from curie_worker.behaviorpacks import BehaviorPacks
+from curie_worker.binding import BUDGET_ENV, PLUGIN_DIR_ENV, ResolvedDeployment
+from curie_worker.runner_client import RunnerClient
+from curie_worker.sandbox import HISTORY_ENV, SESSION_ENV
+from curie_worker.sandbox.types import AdoptionState, RouteRecord, RouteState
+from curie_worker.warm_bind import ADOPTION_UNCONFIRMED
+
+from .conftest import FakeRunner
+
+DONE = SessionStatus.DONE
+_BOOT = "pool-bootstrap-credential-0123456789"
+_BOOTSTRAP_ONLY = "bootstrap credential permits adoption only"
+_CHANNEL = "C1"
+_THREAD = "th-warm"
+_THREAD_KEY = f"slack:{_CHANNEL}:{_THREAD}"
+_SESSION = f"agent-test-{_THREAD_KEY}"
+_HISTORY = "http://api.example.com/agents/acme/state/transcript/th-warm"
+
+
+def _qevent(text: str, *, thread: str = _THREAD) -> QueuedTurn:
+    return QueuedTurn(
+        event_id=uuid.uuid4().hex,
+        conversation_id=thread,
+        author="U1",
+        text=text,
+        reply_handle=ReplyHandle(kind="slack", channel=_CHANNEL, placeholder="p-1"),
+        received_at="2026-07-05T00:00:00+00:00",
+    )
+
+
+class _Binding:
+    """A resolver whose boot env carries the bound identity the cold path injects."""
+
+    def __init__(self) -> None:
+        self.agent_id = uuid.uuid4()
+
+    async def resolve(self, kind: str, address: str) -> ResolvedDeployment | None:
+        return ResolvedDeployment(
+            agent_id=self.agent_id,
+            agent_name="test-agent",
+            version_id=uuid.uuid4(),
+            version_label="v1",
+            bundle_ref="bundles/x.zip",
+            max_usd_per_day=None,
+            max_output_tokens_per_run=None,
+        )
+
+    async def undeployed_binding(self, kind: str, address: str) -> Any | None:
+        return None
+
+    def packs_for(self, resolved: ResolvedDeployment) -> BehaviorPacks:
+        return BehaviorPacks.from_config(resolved.behavior_packs)
+
+    def boot_env(self, resolved: ResolvedDeployment, thread_key: str, **_: Any) -> dict[str, str]:
+        return {
+            BUDGET_ENV: '{"max_output_tokens_per_run":100000,"max_usd_per_day":10.0}',
+            PLUGIN_DIR_ENV: "/bundles/current",
+            SESSION_ENV: f"agent-test-{thread_key}",
+            HISTORY_ENV: _HISTORY,
+        }
+
+
+class _Pool:
+    """The warm-bind policy: this pool is booted in bootstrap mode."""
+
+    def __init__(self, bootstrap: str | None = _BOOT) -> None:
+        self.bootstrap = bootstrap
+        self.asked: list[str] = []
+
+    def bootstrap_for(
+        self, thread_key: str, *, boot_env: dict[str, str], agent_name: str | None
+    ) -> str | None:
+        self.asked.append(thread_key)
+        return self.bootstrap
+
+
+async def _wait_applied(h: Any, *, thread_key: str = _THREAD_KEY) -> None:
+    """Wait until the route reads APPLIED: the kernel writes it after the runner's
+    200, on a worker thread, so ``turn_active`` on the fake can lead it."""
+
+    for _ in range(300):
+        live = h.substrate.lookup(thread_key)
+        if live is not None and live.adoption_state is AdoptionState.APPLIED:
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError("route never read APPLIED")
+
+
+class _RealRunnerApp:
+    """The real runner app in bootstrap mode over the fake model seam."""
+
+    def __init__(self) -> None:
+        self.sessions: list[FakeModelSession] = []
+        self.loads: list[tuple[str, str | None]] = []
+        app_self = self
+
+        class Binder:
+            async def load(self, session_id: str, history_ref: str | None) -> tuple[Any, Any, Any]:
+                app_self.loads.append((session_id, history_ref))
+                return NullTranscriptStore(), ConversationReplay(), None
+
+            def rebind(self, session_id: str, replay: ConversationReplay) -> None:
+                return None
+
+        def factory() -> FakeModelSession:
+            fake = FakeModelSession()
+            self.sessions.append(fake)
+            return fake
+
+        self.runner = SessionRunner(
+            session_factory=factory,
+            ceiling=0,
+            tracer=RunTracer(None),
+            classifier=SideEffectClassifier(),
+            trace_name="curie-run:warm-unbound",
+            session_id="warm-unbound",
+            conversation_binder=Binder(),
+        )
+        bind_status_attestation(self.runner, session_id="warm-unbound", sandbox_id="sbx", cwd=None)
+        self.app = create_app(self.runner, token=None, bootstrap_token=_BOOT)
+
+
+class _AdoptingFake(FakeRunner):
+    """A scriptable bootstrap-mode adopter for the failure shapes.
+
+    ``apply`` controls whether the adopting event actually binds: when True the
+    frames carry ``adoption_applied: true`` and the status route attests the
+    adopted session under the conversation credential; when False the frames
+    carry no ack and the conversation credential is refused (401), the shape of
+    a pod whose binding never became active.
+    """
+
+    def __init__(self, *, apply: bool = True, stamp: bool = True) -> None:
+        super().__init__()
+        self.apply = apply
+        self.stamp = stamp
+        self.conversation: str | None = None
+        self.adopted: str | None = None
+        self.adopting_bodies: list[dict[str, Any]] = []
+
+    @staticmethod
+    def _bearer(request: web.Request) -> str | None:
+        auth = request.headers.get("Authorization", "")
+        return auth.removeprefix("Bearer ").strip() or None
+
+    async def _status(self, request: web.Request) -> web.Response:
+        bearer = self._bearer(request)
+        if self.adopted is None and bearer == _BOOT:
+            return web.json_response({"error": _BOOTSTRAP_ONLY}, status=403)
+        if self.adopted is not None and bearer == self.conversation:
+            return web.json_response(
+                {"status": "idle-awaiting-input", "turn_active": False, "session_id": self.adopted}
+            )
+        return web.json_response({"error": "unauthorized"}, status=401)
+
+    async def _event(self, request: web.Request) -> web.StreamResponse:
+        body = await request.json()
+        if body.get("adoption_credential") is not None:
+            self.adopting_bodies.append(body)
+            if self.apply:
+                self.conversation = body["adoption_credential"]
+                self.adopted = body["session_id"]
+            if self.apply and self.stamp:
+                self.default_script = [
+                    frame.model_copy(update={"adoption_applied": True})
+                    for frame in self.default_script
+                ]
+                self.tail = [
+                    frame.model_copy(update={"adoption_applied": True}) for frame in self.tail
+                ]
+        return await super()._event(request)
+
+
+def test_warm_bind_adopts_over_the_aci_and_settles_the_route(make_harness) -> None:
+    """Positive path against the REAL runner app in bootstrap mode."""
+
+    real = _RealRunnerApp()
+    pool = _Pool()
+
+    async def go() -> None:
+        await real.runner.start()
+        async with make_harness(binding=_Binding(), runner_app=real.app) as h:
+            h.kernel.attach_warm_bind(pool)
+            await h.kernel.process_event(_qevent("hello warm"))
+
+            # The claim carried no identity env; the identity travelled over the ACI.
+            assert h.fake_k8s.claim_envs == [None]
+            assert real.loads == [(_SESSION, _HISTORY)]
+            assert real.runner.session_id == _SESSION
+            # The route settled through the fenced predicate with the minted credential.
+            handle = h.substrate.lookup(_THREAD_KEY)
+            assert handle is not None
+            assert handle.adoption_state is AdoptionState.APPLIED
+            assert handle.session_id == _SESSION and handle.token
+            # The adopting-event marker was written at PENDING and cleared by
+            # the terminal answer: a later retry of this event opens normally.
+            assert handle.adopting_event_id is None
+            assert h.sink.last_text
+            # The bootstrap is retired on the pod; the conversation credential is live.
+            client = RunnerClient(total_timeout_s=10.0)
+            try:
+                base = handle.base_url
+                assert await client.adoption_authority(base, bootstrap_token=_BOOT) is False
+                assert (
+                    await client.adoption_applied(
+                        base, conversation_token=handle.token, session_id=_SESSION
+                    )
+                    is True
+                )
+            finally:
+                await client.close()
+            # A second message on the thread is an ordinary turn under the
+            # conversation credential on the same, now-bound, pod.
+            await h.kernel.process_event(_qevent("and again"))
+            assert h.fake_k8s.claim_envs == [None]
+            assert len(real.sessions) >= 1 and sum(len(s.queries) for s in real.sessions) == 2
+            assert h.substrate.lookup(_THREAD_KEY) == handle or (
+                h.substrate.lookup(_THREAD_KEY).adoption_state is AdoptionState.APPLIED  # type: ignore[union-attr]
+            )
+
+    asyncio.run(go())
+
+
+def test_without_a_policy_the_cold_path_is_unchanged(make_harness) -> None:
+    async def go() -> None:
+        async with make_harness(binding=_Binding()) as h:
+            await h.kernel.process_event(_qevent("hello cold"))
+            assert len(h.fake_k8s.claim_envs) == 1
+            env = h.fake_k8s.claim_envs[0]
+            assert env is not None and env[SESSION_ENV] == _SESSION
+            handle = h.substrate.lookup(_THREAD_KEY)
+            assert handle is not None and handle.adoption_state is AdoptionState.NONE
+            assert h.runner.opened == ["hello cold"]
+
+    asyncio.run(go())
+
+
+def test_a_non_adopting_runner_is_refused_before_any_event(make_harness) -> None:
+    """Open-mode surrogate (see the module docstring): 200 to the bootstrap bearer."""
+
+    pool = _Pool()
+
+    async def go() -> None:
+        async with make_harness(binding=_Binding(), max_attempts=2) as h:
+            h.kernel.attach_warm_bind(pool)
+            await h.kernel.process_event(_qevent("hello old"))
+            # No adopting event, no plain event, no model turn: the pod never
+            # established authority, so nothing was ever sent to /v1/event.
+            assert h.runner.opened == []
+            # Each attempt claimed env-free, failed the probe, and released the
+            # pod; the bounded attempt budget then escalated to a human.
+            assert h.fake_k8s.claim_envs == [None, None]
+            assert h.fake_k8s.claims == {}
+            assert h.substrate.lookup(_THREAD_KEY) is None
+            assert "Flagging for a human" in (h.sink.last_text or "")
+            assert "runner-error" in (h.sink.last_text or "")
+
+    asyncio.run(go())
+
+
+def test_lost_response_after_an_applied_adoption_is_unconfirmed_not_retried(
+    make_harness,
+) -> None:
+    fake = _AdoptingFake(apply=True)
+    # The stream ends without a Final: a dropped response after the event landed.
+    fake.default_script = [TextDelta(text="partial")]
+    pool = _Pool()
+
+    async def go() -> None:
+        async with make_harness(binding=_Binding(), runner_app=fake.app, max_attempts=3) as h:
+            h.kernel.attach_warm_bind(pool)
+            await h.kernel.process_event(_qevent("hello lost"))
+            # Exactly one adopting event; the lost turn was NOT replayed.
+            assert len(fake.adopting_bodies) == 1 and fake.opened == ["hello lost"]
+            body = fake.adopting_bodies[0]
+            assert body["session_id"] == _SESSION and body["history_ref"] == _HISTORY
+            # The attestation proved the binding: the route is APPLIED and kept...
+            handle = h.substrate.lookup(_THREAD_KEY)
+            assert handle is not None
+            assert handle.adoption_state is AdoptionState.APPLIED
+            assert handle.token == fake.conversation
+            # ...and the turn is escalated as unconfirmed rather than retried.
+            assert ADOPTION_UNCONFIRMED in (h.sink.last_text or "")
+            assert "1 attempt(s)" in (h.sink.last_text or "")
+
+    asyncio.run(go())
+
+
+def test_lost_response_with_no_active_binding_releases_and_escalates(make_harness) -> None:
+    fake = _AdoptingFake(apply=False)
+    fake.default_script = [TextDelta(text="partial")]
+    pool = _Pool()
+
+    async def go() -> None:
+        async with make_harness(binding=_Binding(), runner_app=fake.app, max_attempts=3) as h:
+            h.kernel.attach_warm_bind(pool)
+            await h.kernel.process_event(_qevent("hello gone"))
+            assert len(fake.adopting_bodies) == 1 and fake.opened == ["hello gone"]
+            # The credential is not active on the answering pod: fail closed,
+            # the route is released, nothing is re-adopted, a human is flagged.
+            assert h.substrate.lookup(_THREAD_KEY) is None
+            assert h.fake_k8s.claims == {}
+            assert ADOPTION_UNCONFIRMED in (h.sink.last_text or "")
+            assert "1 attempt(s)" in (h.sink.last_text or "")
+
+    asyncio.run(go())
+
+
+def test_acked_turn_whose_route_was_replaced_logs_a_lost_fence(make_harness, caplog) -> None:
+    fake = _AdoptingFake(apply=True)
+    hold = asyncio.Event()
+    fake.default_script = []
+    fake.tail = [Final(text="done late", status=DONE)]
+    pool = _Pool()
+
+    async def go() -> None:
+        fake.hold = hold
+        async with make_harness(binding=_Binding(), runner_app=fake.app) as h:
+            h.kernel.attach_warm_bind(pool)
+            task = asyncio.create_task(h.kernel.process_event(_qevent("hello fence")))
+            await _wait_applied(h)
+            assert fake.turn_active
+            # Settled APPLIED at the runner's 200, while the turn still streams.
+            live = h.substrate.lookup(_THREAD_KEY)
+            assert live is not None and live.adoption_state is AdoptionState.APPLIED
+            # Another owner ends the session while the adopting turn streams:
+            # the post-stream settle finds no route to re-affirm and says so.
+            await asyncio.to_thread(h.substrate.release, _THREAD_KEY)
+            hold.set()
+            await task
+            assert "adoption fence lost" in caplog.text
+            assert h.sink.last_text == "done late"
+
+    asyncio.run(go())
+
+
+def test_follow_up_during_the_adopting_turn_steers_instead_of_releasing(make_harness) -> None:
+    """Router finding 1: the route is APPLIED at the runner's 200, under the lock.
+
+    A second message arriving while the adopting turn streams must take the
+    cold path's steer (rule 1), never the PENDING branch, and must never
+    release the live pod.
+    """
+
+    fake = _AdoptingFake(apply=True)
+    hold = asyncio.Event()
+    fake.default_script = [TextDelta(text="working")]
+    fake.tail = [Final(text="first done", status=DONE)]
+    pool = _Pool()
+
+    async def go() -> None:
+        fake.hold = hold
+        async with make_harness(binding=_Binding(), runner_app=fake.app) as h:
+            h.kernel.attach_warm_bind(pool)
+            first = asyncio.create_task(h.kernel.process_event(_qevent("first")))
+            await _wait_applied(h)
+            assert fake.turn_active
+            # Settled before the route lock was released: APPLIED while streaming.
+            live = h.substrate.lookup(_THREAD_KEY)
+            assert live is not None and live.adoption_state is AdoptionState.APPLIED
+            claim_before = live.claim_name
+            # The follow-up steers under the conversation credential.
+            await h.kernel.process_event(_qevent("second"))
+            assert fake.steers == ["second"]
+            assert len(fake.adopting_bodies) == 1 and fake.opened == ["first"]
+            after = h.substrate.lookup(_THREAD_KEY)
+            assert after is not None and after.claim_name == claim_before
+            hold.set()
+            await first
+            assert h.sink.last_text == "first done" or "Folded" in (h.sink.last_text or "")
+            assert pool.asked.count(_THREAD_KEY) >= 1
+
+    asyncio.run(go())
+
+
+def test_lost_owner_binding_continues_a_new_message_and_escalates_the_original(
+    make_harness,
+) -> None:
+    """Router findings 2/3 and Fable's retry-vs-new: the marker tells them apart.
+
+    A lost owner adopted the pod (runner 200) but died before the route write.
+    The route is PENDING and names the ORIGINAL adopting event. A NEW message
+    settles the route and continues on the ordinary steer-or-open path (rule
+    1); a redelivery of the ORIGINAL event sends nothing and is escalated as
+    unconfirmed, because its turn may have run.
+    """
+
+    fake = _AdoptingFake(apply=True)
+    fake.default_script = [Final(text="answer", status=DONE)]
+    pool = _Pool()
+
+    async def go() -> None:
+        async with make_harness(binding=_Binding(), runner_app=fake.app, max_attempts=3) as h:
+            h.kernel.attach_warm_bind(pool)
+            await h.kernel.process_event(_qevent("first"))
+            applied = h.substrate.lookup(_THREAD_KEY)
+            assert applied is not None and applied.adoption_state is AdoptionState.APPLIED
+            # Rewind the ROUTE to the lost-owner shape; the pod stays bound.
+            from dataclasses import replace
+
+            h.substrate._affinity.replace(  # noqa: SLF001 - shaping the store for the test
+                _THREAD_KEY,
+                RouteRecord(
+                    handle=replace(
+                        applied,
+                        adoption_state=AdoptionState.PENDING,
+                        adopting_event_id="original-adopting-event",
+                    ),
+                    state=RouteState.LIVE,
+                ),
+                600,
+            )
+            # A NEW message: no adopting event, the route settles APPLIED, and
+            # the message opens an ordinary turn on the bound pod.
+            await h.kernel.process_event(_qevent("new message"))
+            assert len(fake.adopting_bodies) == 1
+            assert fake.opened == ["first", "new message"]
+            assert h.sink.last_text == "answer"
+            settled = h.substrate.lookup(_THREAD_KEY)
+            assert settled is not None
+            assert settled.adoption_state is AdoptionState.APPLIED
+            assert settled.claim_name == applied.claim_name
+            assert settled.adopting_event_id == "original-adopting-event"
+            # The ORIGINAL event, redelivered: nothing is sent, it is escalated
+            # as unconfirmed on one attempt, the pod is kept.
+            original = _qevent("first")
+            original = original.model_copy(update={"event_id": "original-adopting-event"})
+            await h.kernel.process_event(original)
+            assert fake.opened == ["first", "new message"]
+            assert ADOPTION_UNCONFIRMED in (h.sink.last_text or "")
+            assert "1 attempt(s)" in (h.sink.last_text or "")
+            assert list(h.fake_k8s.claims) == [applied.claim_name]
+            kept = h.substrate.lookup(_THREAD_KEY)
+            assert kept is not None and kept.adopting_event_id == "original-adopting-event"
+
+    asyncio.run(go())
+
+
+def test_crash_after_the_runner_200_makes_the_redelivery_unconfirmed(make_harness) -> None:
+    """Router 8's blocking finding: cancel between the 200 and the settle.
+
+    The route is APPLIED with this event's marker; the redelivered SAME event
+    must not open a plain turn on the bound pod.
+    """
+
+    fake = _AdoptingFake(apply=True)
+    hold = asyncio.Event()
+    fake.default_script = [TextDelta(text="working")]
+    fake.tail = [Final(text="late", status=DONE)]
+    pool = _Pool()
+
+    async def go() -> None:
+        fake.hold = hold
+        async with make_harness(binding=_Binding(), runner_app=fake.app, max_attempts=3) as h:
+            h.kernel.attach_warm_bind(pool)
+            event = _qevent("first")
+            task = asyncio.create_task(h.kernel.process_event(event))
+            await _wait_applied(h)
+            assert fake.turn_active
+            live = h.substrate.lookup(_THREAD_KEY)
+            assert live is not None
+            assert live.adoption_state is AdoptionState.APPLIED
+            assert live.adopting_event_id == event.event_id
+            # The worker dies mid-stream.
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+            hold.set()
+            for _ in range(200):
+                if not fake.turn_active:
+                    break
+                await asyncio.sleep(0.01)
+            # Redelivery of the SAME event: no event is sent, the delivery is
+            # escalated unconfirmed, the pod and the marker are kept.
+            await h.kernel.process_event(event)
+            assert fake.opened == ["first"] and len(fake.adopting_bodies) == 1
+            assert ADOPTION_UNCONFIRMED in (h.sink.last_text or "")
+            kept = h.substrate.lookup(_THREAD_KEY)
+            assert kept is not None and kept.adopting_event_id == event.event_id
+            assert list(h.fake_k8s.claims) == [live.claim_name]
+            # A different message on the thread routes normally.
+            await h.kernel.process_event(_qevent("second"))
+            assert fake.opened == ["first", "second"]
+
+    asyncio.run(go())
+
+
+def test_terminal_answer_without_the_per_frame_ack_keeps_the_session(make_harness) -> None:
+    """Router 8's should-fix: after settle-at-200 a missing ack is a contract log, not a release."""
+
+    fake = _AdoptingFake(apply=True, stamp=False)
+    fake.default_script = [Final(text="unstamped answer", status=DONE)]
+    pool = _Pool()
+
+    async def go() -> None:
+        async with make_harness(binding=_Binding(), runner_app=fake.app) as h:
+            h.kernel.attach_warm_bind(pool)
+            await h.kernel.process_event(_qevent("first"))
+            assert h.sink.last_text == "unstamped answer"
+            kept = h.substrate.lookup(_THREAD_KEY)
+            assert kept is not None and kept.adoption_state is AdoptionState.APPLIED
+            assert list(h.fake_k8s.claims) == [kept.claim_name]
+
+    asyncio.run(go())

--- a/apps/worker/tests/sandbox/test_adoption_route.py
+++ b/apps/worker/tests/sandbox/test_adoption_route.py
@@ -274,3 +274,209 @@ def test_resume_of_a_pending_route_cold_creates_with_a_fresh_per_claim_token(
     env = fake_k8s.claims[resumed.claim_name].env
     assert env[SESSION_ENV] == _SESSION and env[HISTORY_ENV] == _HISTORY
     assert env[RUNNER_TOKEN_ENV] == resumed.token
+
+
+# --- the applied transition is decided INSIDE Valkey (ADR-0122 d3 Lua predicate) --
+
+
+def test_mark_applied_loses_to_a_concurrent_suspend_of_the_same_claim(
+    fake_k8s: FakeSandboxClient, affinity: AffinityStore, config: SubstrateConfig
+) -> None:
+    """The window the claim + generation CAS could not close.
+
+    A suspend flips the route's state without changing claim or generation.
+    The caller of ``mark_adoption_applied`` holds a handle read BEFORE that
+    flip; the predicate must refuse it, and it must do so in the store, not in
+    a Python check that a concurrent writer can interleave with.
+    """
+
+    substrate = SandboxSubstrate(fake_k8s, affinity, config)
+    pending = substrate.claim("T-lua-susp", session_id=_SESSION, conversation_token=_CONV)
+    # The competing transition lands between the caller's read and its CAS.
+    affinity.mark_suspended("T-lua-susp", _HISTORY, config.suspended_route_ttl_seconds)
+    assert (
+        affinity.mark_adoption_applied(
+            "T-lua-susp",
+            expected_claim=pending.claim_name,
+            expected_generation=pending.generation,
+            expected_token=_CONV,
+            record=RouteRecord(handle=replace(pending, adoption_state=AdoptionState.APPLIED)),
+            ttl_seconds=config.route_ttl_seconds,
+        )
+        == 0
+    )
+    stored = affinity.get("T-lua-susp")
+    assert stored is not None
+    assert stored.state is RouteState.SUSPENDED
+    assert stored.handle.adoption_state is AdoptionState.PENDING
+
+
+def test_mark_applied_predicate_answers_write_idempotent_or_lost(
+    fake_k8s: FakeSandboxClient, affinity: AffinityStore, config: SubstrateConfig
+) -> None:
+    substrate = SandboxSubstrate(fake_k8s, affinity, config)
+    pending = substrate.claim("T-lua", session_id=_SESSION, conversation_token=_CONV)
+    applied = RouteRecord(handle=replace(pending, adoption_state=AdoptionState.APPLIED))
+
+    def cas(**overrides: object) -> int:
+        args: dict[str, object] = {
+            "expected_claim": pending.claim_name,
+            "expected_generation": pending.generation,
+            "expected_token": _CONV,
+            "record": applied,
+            "ttl_seconds": config.route_ttl_seconds,
+        }
+        args.update(overrides)
+        return affinity.mark_adoption_applied("T-lua", **args)  # type: ignore[arg-type]
+
+    # Every wrong shape is 0 and writes nothing.
+    assert cas(expected_token=_CONV_B) == 0
+    assert cas(expected_generation=pending.generation + 1) == 0
+    assert cas(expected_claim="claim-stale") == 0
+    assert (
+        affinity.mark_adoption_applied(
+            "T-missing",
+            expected_claim=pending.claim_name,
+            expected_generation=pending.generation,
+            expected_token=_CONV,
+            record=applied,
+            ttl_seconds=config.route_ttl_seconds,
+        )
+        == 0
+    )
+    stored = affinity.get("T-lua")
+    assert stored is not None and stored.handle.adoption_state is AdoptionState.PENDING
+    # The one matching write is 1; a repeat is 2 (already applied, no write).
+    assert cas() == 1
+    assert cas() == 2
+    stored = affinity.get("T-lua")
+    assert stored is not None and stored.handle == applied.handle
+    # Already applied for ANOTHER credential is still lost, never idempotent.
+    assert cas(expected_token=_CONV_B) == 0
+    # A cold (never pending) route can never be marked applied.
+    cold = substrate.claim("T-lua-cold", env={SESSION_ENV: _SESSION, RUNNER_TOKEN_ENV: "tok"})
+    assert (
+        affinity.mark_adoption_applied(
+            "T-lua-cold",
+            expected_claim=cold.claim_name,
+            expected_generation=cold.generation,
+            expected_token="tok",
+            record=RouteRecord(handle=replace(cold, adoption_state=AdoptionState.APPLIED)),
+            ttl_seconds=config.route_ttl_seconds,
+        )
+        == 0
+    )
+
+
+def test_racing_appliers_produce_exactly_one_write(
+    fake_k8s: FakeSandboxClient, affinity: AffinityStore, config: SubstrateConfig
+) -> None:
+    """Two replicas settling the same lost-response adoption: one writes, one is idempotent."""
+
+    import threading
+
+    substrate = SandboxSubstrate(fake_k8s, affinity, config)
+    pending = substrate.claim("T-lua-race", session_id=_SESSION, conversation_token=_CONV)
+    results: list[SandboxHandle | None] = []
+    barrier = threading.Barrier(2)
+
+    def settle() -> None:
+        barrier.wait()
+        results.append(substrate.mark_adoption_applied("T-lua-race", expected=pending))
+
+    workers = [threading.Thread(target=settle) for _ in range(2)]
+    for w in workers:
+        w.start()
+    for w in workers:
+        w.join()
+    assert len(results) == 2
+    assert all(r is not None and r.adoption_state is AdoptionState.APPLIED for r in results)
+    assert results[0] == results[1]
+    stored = affinity.get("T-lua-race")
+    assert stored is not None and stored.handle.adoption_state is AdoptionState.APPLIED
+
+
+# --- a fenced release never deletes a replacement owner's claim -------------------
+
+
+def test_release_claim_is_fenced_on_claim_and_generation(
+    fake_k8s: FakeSandboxClient, affinity: AffinityStore, config: SubstrateConfig
+) -> None:
+    substrate = SandboxSubstrate(fake_k8s, affinity, config)
+    pending = substrate.claim("T-rel", session_id=_SESSION, conversation_token=_CONV)
+    # A replacement owner re-claimed the thread under a new claim name.
+    substrate.release("T-rel")
+    fresh = substrate.claim("T-rel", session_id=_SESSION, conversation_token=_CONV_B)
+    assert fresh.claim_name != pending.claim_name
+    # The stale holder's fenced release is a no-op for the replacement...
+    assert substrate.release_claim("T-rel", expected=pending) is False
+    stored = affinity.get("T-rel")
+    assert stored is not None and stored.handle == fresh
+    assert fresh.claim_name in fake_k8s.claims
+    # ...a wrong generation is refused too...
+    assert (
+        substrate.release_claim("T-rel", expected=replace(fresh, generation=fresh.generation + 1))
+        is False
+    )
+    # ...and the matching holder releases exactly its own claim.
+    assert substrate.release_claim("T-rel", expected=fresh) is True
+    assert affinity.get("T-rel") is None
+    assert fresh.claim_name not in fake_k8s.claims
+    assert substrate.release_claim("T-rel", expected=fresh) is False
+
+
+# --- the adopting-event marker rides the route and clears under a fence -----------
+
+
+def test_adopting_event_marker_is_written_at_pending_and_cleared_under_a_fence(
+    fake_k8s: FakeSandboxClient, affinity: AffinityStore, config: SubstrateConfig
+) -> None:
+    substrate = SandboxSubstrate(fake_k8s, affinity, config)
+    pending = substrate.claim(
+        "T-mark", session_id=_SESSION, conversation_token=_CONV, adopting_event_id="evt-1"
+    )
+    assert pending.adopting_event_id == "evt-1"
+    stored = affinity.get("T-mark")
+    assert stored is not None and stored.handle.adopting_event_id == "evt-1"
+    # The marker survives the applied transition (same record, same fence).
+    applied = substrate.mark_adoption_applied("T-mark", expected=pending)
+    assert applied is not None and applied.adopting_event_id == "evt-1"
+    # A stale handle (wrong marker / generation / suspended) cannot clear it...
+    assert (
+        substrate.clear_adopting_event(
+            "T-mark", expected=replace(applied, adopting_event_id="evt-9")
+        )
+        is False
+    )
+    assert (
+        substrate.clear_adopting_event(
+            "T-mark", expected=replace(applied, generation=applied.generation + 1)
+        )
+        is False
+    )
+    assert (
+        substrate.clear_adopting_event("T-mark", expected=replace(applied, adopting_event_id=None))
+        is False
+    )
+    affinity.mark_suspended("T-mark", _HISTORY, config.suspended_route_ttl_seconds)
+    assert substrate.clear_adopting_event("T-mark", expected=applied) is False
+    suspended = affinity.get("T-mark")
+    assert suspended is not None and suspended.state is RouteState.SUSPENDED
+    assert suspended.handle.adopting_event_id == "evt-1"
+    # ...the live holder clears it exactly once.
+    affinity.replace(
+        "T-mark", RouteRecord(handle=applied, state=RouteState.LIVE), config.route_ttl_seconds
+    )
+    # Even from the PENDING-shaped handle the kernel routed with: the written
+    # record is the APPLIED form.
+    assert substrate.clear_adopting_event("T-mark", expected=pending) is True
+    cleared = affinity.get("T-mark")
+    assert cleared is not None and cleared.handle.adopting_event_id is None
+    assert cleared.handle.adoption_state is AdoptionState.APPLIED
+    assert substrate.clear_adopting_event("T-mark", expected=applied) is False
+    # A cold route never carries the key on the wire, and a marker without a
+    # conversation token is refused.
+    cold = substrate.claim("T-mark-cold", env={SESSION_ENV: _SESSION, RUNNER_TOKEN_ENV: "tok"})
+    assert "adopting_event_id" not in json.loads(RouteRecord(handle=cold).to_json())
+    with pytest.raises(ValueError):
+        substrate.claim("T-mark-bad", session_id=_SESSION, adopting_event_id="evt-2")

--- a/apps/worker/tests/sandbox/test_adoption_route.py
+++ b/apps/worker/tests/sandbox/test_adoption_route.py
@@ -1,0 +1,276 @@
+"""The route is the authority for a warm bind's conversation credential.
+
+ADR-0122 d3: the per-conversation token lives where the route lives, on the
+``RouteRecord`` in Valkey, never only in a worker's memory. A warm-bind claim
+records the freshly minted credential as PENDING before any first event leaves
+the worker, so a crash, a lost response, or a second replica recovers it from
+the store; the transition to APPLIED is a fenced CAS on the existing claim +
+generation authority, and a stale owner cannot win it.
+
+The Valkey-backed cases run against the real store (never mocked) and skip
+when it is unreachable; the pure record-shape cases always run.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+
+import pytest
+from curie_worker.binding import RUNNER_TOKEN_ENV
+from curie_worker.sandbox import HISTORY_ENV, SESSION_ENV, SandboxSubstrate, SubstrateConfig
+from curie_worker.sandbox.affinity import AffinityStore
+from curie_worker.sandbox.types import (
+    AdoptionState,
+    RouteRecord,
+    RouteState,
+    SandboxHandle,
+)
+
+from .conftest import FakeSandboxClient
+
+_CONV = "conversation-credential-A-0123456789"
+_CONV_B = "conversation-credential-B-0123456789"
+_SESSION = "agent-acme-thread-C0EXAMPLE1-1700000000.000100"
+_HISTORY = "http://api.example.com/agents/acme/state/transcript/thread-1"
+
+
+def _handle(**overrides: object) -> SandboxHandle:
+    base = SandboxHandle(
+        thread_key="T1",
+        claim_name="claim-a",
+        sandbox_name="sbx-claim-a",
+        namespace="ns",
+        service_fqdn="sbx-claim-a.ns.svc.cluster.local",
+        port=8080,
+        session_id=_SESSION,
+    )
+    return replace(base, **overrides)  # type: ignore[arg-type]
+
+
+# --- record shape: compatible with every route already in Valkey ------------------
+
+
+def test_legacy_route_records_rehydrate_as_not_adoptable() -> None:
+    raw = json.dumps(
+        {
+            "thread_key": "T1",
+            "claim_name": "claim-a",
+            "sandbox_name": "sbx-claim-a",
+            "namespace": "ns",
+            "service_fqdn": "sbx-claim-a.ns.svc.cluster.local",
+            "port": 8080,
+            "session_id": _SESSION,
+            "token": "per-claim-token",
+            "state": "live",
+        }
+    )
+    record = RouteRecord.from_json(raw)
+    assert record.handle.adoption_state is AdoptionState.NONE
+    assert record.handle.token == "per-claim-token"
+
+
+def test_cold_route_records_keep_the_legacy_wire_shape() -> None:
+    """A worker built before the field must still rehydrate every cold route.
+
+    ``SandboxHandle(**payload)`` on that build raises on an unknown key, and an
+    unreadable route is evicted or its claim reaped; so the default state is
+    written in the pre-field shape and only pending/applied routes carry it.
+    """
+
+    payload = json.loads(RouteRecord(handle=_handle(token="per-claim-token")).to_json())
+    assert "adoption_state" not in payload
+    legacy_shape = {key: value for key, value in payload.items() if key != "state"}
+    # Exactly the constructor signature the 628feac worker has (no extra key).
+    assert set(legacy_shape) == {
+        "thread_key",
+        "claim_name",
+        "sandbox_name",
+        "namespace",
+        "service_fqdn",
+        "port",
+        "session_id",
+        "history_ref",
+        "token",
+        "workspace_repo",
+        "workspace_materialized_head",
+        "publication_visible_outcome_revision",
+        "generation",
+    }
+    for state in (AdoptionState.PENDING, AdoptionState.APPLIED):
+        carried = json.loads(RouteRecord(handle=_handle(adoption_state=state)).to_json())
+        assert carried["adoption_state"] == state.value
+
+
+def test_adoption_state_round_trips_as_a_plain_string() -> None:
+    record = RouteRecord(handle=_handle(token=_CONV, adoption_state=AdoptionState.PENDING))
+    payload = json.loads(record.to_json())
+    assert payload["adoption_state"] == "pending"
+    loaded = RouteRecord.from_json(record.to_json())
+    assert loaded.handle.adoption_state is AdoptionState.PENDING
+    assert loaded.handle == record.handle
+
+
+def test_unknown_adoption_state_is_rejected_not_guessed() -> None:
+    payload = json.loads(RouteRecord(handle=_handle()).to_json())
+    payload["adoption_state"] = "maybe"
+    with pytest.raises(ValueError):
+        RouteRecord.from_json(json.dumps(payload))
+
+
+# --- the pending route is written before any first event ---------------------------
+
+
+def test_warm_bind_claim_records_pending_credential_before_any_event(
+    fake_k8s: FakeSandboxClient, affinity: AffinityStore, config: SubstrateConfig
+) -> None:
+    substrate = SandboxSubstrate(fake_k8s, affinity, config)
+    handle = substrate.claim(
+        "T-warm",
+        session_id=_SESSION,
+        history_ref=_HISTORY,
+        conversation_token=_CONV,
+    )
+    # The claim carried no identity env: identity travels over the ACI.
+    assert fake_k8s.claims[handle.claim_name].env == {}
+    assert handle.adoption_state is AdoptionState.PENDING
+    assert handle.token == _CONV
+    assert handle.session_id == _SESSION
+    assert handle.history_ref == _HISTORY
+    # ...and the route in the store already carries all of it.
+    stored = affinity.get("T-warm")
+    assert stored is not None
+    assert stored.state is RouteState.LIVE
+    assert stored.handle == handle
+
+
+def test_warm_bind_refuses_identity_env(
+    fake_k8s: FakeSandboxClient, affinity: AffinityStore, config: SubstrateConfig
+) -> None:
+    substrate = SandboxSubstrate(fake_k8s, affinity, config)
+    for env in (
+        {SESSION_ENV: "other-session"},
+        {HISTORY_ENV: _HISTORY},
+        {RUNNER_TOKEN_ENV: "per-claim-token"},
+    ):
+        with pytest.raises(ValueError):
+            substrate.claim("T-mixed", env=env, session_id=_SESSION, conversation_token=_CONV)
+    assert fake_k8s.created == []
+    assert affinity.get("T-mixed") is None
+
+
+def test_cold_claim_is_unchanged_and_never_pending(
+    fake_k8s: FakeSandboxClient, affinity: AffinityStore, config: SubstrateConfig
+) -> None:
+    substrate = SandboxSubstrate(fake_k8s, affinity, config)
+    handle = substrate.claim(
+        "T-cold", env={SESSION_ENV: _SESSION, RUNNER_TOKEN_ENV: "per-claim-token"}
+    )
+    assert handle.adoption_state is AdoptionState.NONE
+    assert handle.token == "per-claim-token"
+    assert substrate.mark_adoption_applied("T-cold", expected=handle) is None
+
+
+# --- the applied transition is fenced -----------------------------------------------
+
+
+def test_mark_applied_is_fenced_on_claim_generation_token_and_state(
+    fake_k8s: FakeSandboxClient, affinity: AffinityStore, config: SubstrateConfig
+) -> None:
+    substrate = SandboxSubstrate(fake_k8s, affinity, config)
+    pending = substrate.claim("T-fence", session_id=_SESSION, conversation_token=_CONV)
+
+    # A stale owner: wrong generation, wrong claim, or a different credential.
+    assert (
+        substrate.mark_adoption_applied(
+            "T-fence", expected=replace(pending, generation=pending.generation + 1)
+        )
+        is None
+    )
+    assert (
+        substrate.mark_adoption_applied(
+            "T-fence", expected=replace(pending, claim_name="claim-stale")
+        )
+        is None
+    )
+    assert (
+        substrate.mark_adoption_applied("T-fence", expected=replace(pending, token=_CONV_B)) is None
+    )
+    untouched = affinity.get("T-fence")
+    assert untouched is not None
+    assert untouched.handle.adoption_state is AdoptionState.PENDING
+
+    applied = substrate.mark_adoption_applied("T-fence", expected=pending)
+    assert applied is not None
+    assert applied.adoption_state is AdoptionState.APPLIED
+    assert applied == replace(pending, adoption_state=AdoptionState.APPLIED)
+    stored = affinity.get("T-fence")
+    assert stored is not None and stored.handle == applied
+
+    # Applying twice (a retry that lost its first response) is idempotent.
+    assert substrate.mark_adoption_applied("T-fence", expected=pending) == applied
+    assert substrate.mark_adoption_applied("T-fence", expected=applied) == applied
+    # ...but a stale pending holder with another credential still loses.
+    assert (
+        substrate.mark_adoption_applied("T-fence", expected=replace(pending, token=_CONV_B)) is None
+    )
+
+
+def test_mark_applied_refuses_a_suspended_or_missing_route(
+    fake_k8s: FakeSandboxClient, affinity: AffinityStore, config: SubstrateConfig
+) -> None:
+    substrate = SandboxSubstrate(fake_k8s, affinity, config)
+    pending = substrate.claim("T-susp", session_id=_SESSION, conversation_token=_CONV)
+    substrate.suspend("T-susp", history_ref=_HISTORY)
+    assert substrate.mark_adoption_applied("T-susp", expected=pending) is None
+    stored = affinity.get("T-susp")
+    assert stored is not None and stored.state is RouteState.SUSPENDED
+    assert substrate.mark_adoption_applied("T-none", expected=pending) is None
+
+
+def test_route_replaced_under_a_pending_owner_loses_the_fence(
+    fake_k8s: FakeSandboxClient, affinity: AffinityStore, config: SubstrateConfig
+) -> None:
+    substrate = SandboxSubstrate(fake_k8s, affinity, config)
+    pending = substrate.claim("T-race", session_id=_SESSION, conversation_token=_CONV)
+    # Another owner evicted and re-claimed the thread (a new claim name).
+    substrate.release("T-race")
+    fresh = substrate.claim("T-race", session_id=_SESSION, conversation_token=_CONV_B)
+    assert fresh.claim_name != pending.claim_name
+    assert substrate.mark_adoption_applied("T-race", expected=pending) is None
+    stored = affinity.get("T-race")
+    assert stored is not None
+    assert stored.handle == fresh
+    assert stored.handle.adoption_state is AdoptionState.PENDING
+
+
+def test_creation_race_loser_adopts_the_winners_pending_route(
+    fake_k8s: FakeSandboxClient, affinity: AffinityStore, config: SubstrateConfig
+) -> None:
+    substrate = SandboxSubstrate(fake_k8s, affinity, config)
+    winner = substrate.claim("T-dup", session_id=_SESSION, conversation_token=_CONV)
+    # A second replica racing the same first message: it must converge on the
+    # winner's credential rather than minting a second live one.
+    loser_view = SandboxSubstrate(fake_k8s, affinity, config)
+    adopted = loser_view.claim("T-dup", session_id=_SESSION, conversation_token=_CONV_B)
+    assert adopted == winner
+    assert adopted.token == _CONV
+    assert adopted.adoption_state is AdoptionState.PENDING
+
+
+def test_resume_of_a_pending_route_cold_creates_with_a_fresh_per_claim_token(
+    fake_k8s: FakeSandboxClient, affinity: AffinityStore, config: SubstrateConfig
+) -> None:
+    substrate = SandboxSubstrate(fake_k8s, affinity, config)
+    pending = substrate.claim("T-res", session_id=_SESSION, conversation_token=_CONV)
+    substrate.suspend("T-res", history_ref=_HISTORY)
+    resumed = substrate.resume("T-res", env={"CURIE_BUDGET": "{}"})
+    # The replacement is a cold pod bound at boot: per-claim mode, never pending.
+    assert resumed.adoption_state is AdoptionState.NONE
+    assert resumed.token and resumed.token != _CONV
+    assert resumed.session_id == pending.session_id
+    assert resumed.history_ref == _HISTORY
+    assert resumed.generation == pending.generation + 1
+    env = fake_k8s.claims[resumed.claim_name].env
+    assert env[SESSION_ENV] == _SESSION and env[HISTORY_ENV] == _HISTORY
+    assert env[RUNNER_TOKEN_ENV] == resumed.token

--- a/runner/src/curie_runner/__main__.py
+++ b/runner/src/curie_runner/__main__.py
@@ -10,7 +10,8 @@ from __future__ import annotations
 
 import logging
 import os
-from dataclasses import replace
+from collections.abc import Mapping
+from dataclasses import dataclass, replace
 from pathlib import Path
 
 import anyio
@@ -52,6 +53,7 @@ from .history import (
     DEFAULT_REPLAY_MAX_TURNS,
     ConversationReplay,
     HistoryError,
+    HistoryRecord,
     StructuredReplayUnsupported,
     TranscriptStore,
     build_conversation_replay,
@@ -65,9 +67,14 @@ from .plugin import load_bundle_web_search_enabled
 from .redact import install_stdout_redaction
 from .sdk_auth import UnsupportedCredentialError
 from .server import bind_status_attestation, create_app
-from .session import SessionRunner
+from .session import ConversationBinder, SessionRunner
 from .side_effects import SideEffectClassifier
-from .state import STATE_SERVER_NAME, build_state_server, resolve_state_client
+from .state import (
+    STATE_SERVER_NAME,
+    STATE_URL_ENV,
+    build_state_server,
+    resolve_state_client,
+)
 from .workspace_snapshot import WorkspaceSnapshot, capture_workspace_snapshot
 
 logger = logging.getLogger("curie_runner")
@@ -148,6 +155,61 @@ def _merge_pre_tool_use_hooks(
     return merged or None
 
 
+def _replay_window(config: RunnerConfig) -> tuple[int, int]:
+    """The structured-replay bounds: operator knobs, else the loader defaults."""
+
+    max_turns = (
+        config.history_max_turns
+        if config.history_max_turns is not None
+        else DEFAULT_REPLAY_MAX_TURNS
+    )
+    max_bytes = (
+        config.history_max_bytes
+        if config.history_max_bytes is not None
+        else DEFAULT_REPLAY_MAX_BYTES
+    )
+    return max_turns, max_bytes
+
+
+def adoptable_history_ref(history_ref: str | None, env: Mapping[str, str]) -> str | None:
+    """Admit a caller-chosen ``history_ref`` only inside this pod's state authority.
+
+    The adopting Event names the transcript to load, and the runner fetches it
+    with the pod's agent-scoped ``CURIE_HISTORY_TOKEN``. Unlike the boot ref,
+    which the worker set in the same env as the token, this ref arrives from
+    whoever holds the bootstrap credential, so it is bound to the state
+    namespace the pod was booted for: it must sit under ``CURIE_STATE_URL``
+    (``.../agents/<id>/state``). A pod booted with no state authority admits
+    no ref at all. An absent ref is the history-less adoption and passes.
+    """
+
+    if not history_ref:
+        return None
+    base = (env.get(STATE_URL_ENV) or "").rstrip("/")
+    if not base:
+        raise HistoryError(
+            "adoption named a history_ref but this runner has no configured state authority"
+        )
+    if not history_ref.startswith(base + "/"):
+        raise HistoryError("adoption history_ref is outside this runner's state authority")
+    return history_ref
+
+
+@dataclass
+class _BoundIdentity:
+    """The conversation the session factory currently builds sessions for.
+
+    Fixed at boot for a per-claim runner. A bootstrap-mode runner boots on the
+    template's placeholder identity and is repointed here at adoption
+    (ADR-0116 decision 2), so the replacement model session, and every later
+    reset generation, carries the adopted conversation's replay and id.
+    """
+
+    session_id: str
+    replay: ConversationReplay
+    options: ClaudeAgentOptions | None
+
+
 def build_runner(
     config: RunnerConfig,
     *,
@@ -177,6 +239,9 @@ def build_runner(
     # compiles into session inputs, replacing the direct module imports these
     # used to be. Defaults to the built-in Claude harness.
     harness = harness or _resolve_harness()
+    # A non-optional alias for the nested binder below: mypy does not carry the
+    # narrowing above into a closure.
+    active_harness: HarnessContribution = harness
     conversation_replay = conversation_replay or ConversationReplay()
     if conversation_replay.present and not harness.supports_structured_replay and not fake_model:
         raise StructuredReplayUnsupported(
@@ -383,6 +448,11 @@ def build_runner(
         )
 
     sdk_generation = 0
+    identity = _BoundIdentity(
+        session_id=config.session.session_id,
+        replay=conversation_replay,
+        options=real_options,
+    )
 
     def factory() -> ModelSession:
         if fake_model:
@@ -399,9 +469,9 @@ def build_runner(
                 # Share the same gate so a scripted request_approval resolves its
                 # route through the real decision table on the offline tier (#561).
                 approval_gate=approval_gate,
-                replay_messages=conversation_replay.messages,
+                replay_messages=identity.replay.messages,
             )
-        assert real_options is not None
+        assert identity.options is not None
         nonlocal sdk_generation
         generation = sdk_generation
         sdk_generation += 1
@@ -413,22 +483,86 @@ def build_runner(
         # (#2221). Native checkpoint entries carry the previous id, so later
         # generations rematerialize portable messages only.
         if generation == 0:
-            return ClaudeAgentSession(real_options)
+            return ClaudeAgentSession(identity.options)
         envelope = build_structured_resume(
-            conversation_replay.messages,
-            curie_session_id=f"{config.session.session_id}:reset:{generation}",
+            identity.replay.messages,
+            curie_session_id=f"{identity.session_id}:reset:{generation}",
             cwd=workspace_cwd,
             harness_replay=None,
         )
         return ClaudeAgentSession(
             replace(
-                real_options,
+                identity.options,
                 resume=envelope.resume,
                 session_id=envelope.session_id if envelope.resume is None else None,
                 session_store=envelope.session_store,
                 session_store_flush="eager" if envelope.session_store is not None else "batched",
             )
         )
+
+    class _Binder:
+        """Adoption binder (ADR-0116 d2): load the conversation, repoint the factory."""
+
+        async def load(
+            self, session_id: str, history_ref: str | None
+        ) -> tuple[TranscriptStore, ConversationReplay, HistoryRecord | None]:
+            # Same loader, same window, same fail-closed posture as the boot
+            # path (_load_history): a configured ref that cannot be loaded is
+            # continuity-critical and refuses rather than answering blind. The
+            # ref itself is caller-chosen here, so it is first bound to the
+            # pod's own state authority.
+            store = resolve_history(adoptable_history_ref(history_ref, os.environ), os.environ)
+            max_turns, max_bytes = _replay_window(config)
+            records = await store.load()
+            replay, summary = build_conversation_replay(
+                records, max_turns=max_turns, max_bytes=max_bytes
+            )
+            if (
+                replay.present
+                and not active_harness.supports_structured_replay
+                and not fake_model
+            ):
+                raise StructuredReplayUnsupported(
+                    f"harness {active_harness.name!r} declares structured replay absent; "
+                    "refusing recovered history instead of rendering a prompt preamble"
+                )
+            logger.info(
+                "history loaded at adoption session=%s records=%d messages=%d compacted=%s",
+                session_id,
+                len(records),
+                len(replay.messages),
+                summary is not None,
+            )
+            # The summary is handed back, not appended: the runner writes it
+            # only once the binding is applied.
+            return store, replay, summary
+
+        def rebind(self, session_id: str, replay: ConversationReplay) -> None:
+            nonlocal sdk_generation
+            if not fake_model:
+                assert real_options is not None
+                structured = build_structured_resume(
+                    replay.messages,
+                    curie_session_id=session_id,
+                    cwd=workspace_cwd,
+                    harness_replay=replay.harness_replay,
+                )
+                identity.options = replace(
+                    real_options,
+                    resume=structured.resume,
+                    session_id=structured.session_id if structured.resume is None else None,
+                    session_store=structured.session_store,
+                    session_store_flush=(
+                        "eager" if structured.session_store is not None else "batched"
+                    ),
+                )
+            identity.session_id = session_id
+            identity.replay = replay
+            # The bound conversation's first SDK session is its generation 0;
+            # later resets mint ids under the bound session id.
+            sdk_generation = 0
+
+    binder: ConversationBinder = _Binder()
 
     provider = build_tracer_provider(
         config.session.otel,
@@ -458,6 +592,8 @@ def build_runner(
             approval_decision=config.approval_decision,
             false_completion_check=config.false_completion_check,
             history_resumed=conversation_replay.present,
+            conversation_binder=binder,
+            boot_replay=conversation_replay,
         ),
         session_id=config.session.session_id,
         sandbox_id=config.session.sandbox_id,
@@ -507,16 +643,7 @@ def _load_history(config: RunnerConfig) -> tuple[TranscriptStore, ConversationRe
     """
 
     store = resolve_history(config.history_ref, os.environ)
-    max_turns = (
-        config.history_max_turns
-        if config.history_max_turns is not None
-        else DEFAULT_REPLAY_MAX_TURNS
-    )
-    max_bytes = (
-        config.history_max_bytes
-        if config.history_max_bytes is not None
-        else DEFAULT_REPLAY_MAX_BYTES
-    )
+    max_turns, max_bytes = _replay_window(config)
 
     async def _load() -> tuple[ConversationReplay, int, bool]:
         records = await store.load()

--- a/runner/src/curie_runner/__main__.py
+++ b/runner/src/curie_runner/__main__.py
@@ -10,15 +10,17 @@ from __future__ import annotations
 
 import logging
 import os
-from collections.abc import Mapping
+from collections.abc import Mapping, MutableMapping
 from dataclasses import dataclass, replace
 from pathlib import Path
+from urllib.parse import unquote
 
 import anyio
 from aci_protocol import BootEnv
 from aiohttp import web
 from claude_agent_sdk import ClaudeAgentOptions, HookMatcher
 from curie_telemetry import bootstrap_service_telemetry
+from yarl import URL
 
 from . import __version__
 from .adapter import (
@@ -66,7 +68,7 @@ from .otel import RunTracer, build_tracer_provider
 from .plugin import load_bundle_web_search_enabled
 from .redact import install_stdout_redaction
 from .sdk_auth import UnsupportedCredentialError
-from .server import bind_status_attestation, create_app
+from .server import Snapshotter, bind_status_attestation, create_app
 from .session import ConversationBinder, SessionRunner
 from .side_effects import SideEffectClassifier
 from .state import (
@@ -181,18 +183,76 @@ def adoptable_history_ref(history_ref: str | None, env: Mapping[str, str]) -> st
     namespace the pod was booted for: it must sit under ``CURIE_STATE_URL``
     (``.../agents/<id>/state``). A pod booted with no state authority admits
     no ref at all. An absent ref is the history-less adoption and passes.
+
+    The comparison is on PARSED URLs, not on the string: the scheme, host
+    and port must match exactly; userinfo, a query, or a fragment is refused;
+    and every path segment below the base is checked for the dot forms
+    (``.``, ``..``, and their percent-encodings) that would walk out of the
+    namespace once a server normalizes them. The ref is parsed in its encoded
+    form so the worker's percent-encoded thread key (``binding.py`` quotes the
+    key with ``safe=""``, so a Slack ``:`` arrives as ``%3A``) is compared as
+    sent rather than requoted, and any ref the parser would rewrite is
+    refused outright rather than "helpfully" normalized.
     """
 
     if not history_ref:
         return None
-    base = (env.get(STATE_URL_ENV) or "").rstrip("/")
-    if not base:
+    raw_base = (env.get(STATE_URL_ENV) or "").rstrip("/")
+    if not raw_base:
         raise HistoryError(
             "adoption named a history_ref but this runner has no configured state authority"
         )
-    if not history_ref.startswith(base + "/"):
-        raise HistoryError("adoption history_ref is outside this runner's state authority")
+    outside = HistoryError("adoption history_ref is outside this runner's state authority")
+    try:
+        base = URL(raw_base, encoded=True)
+        ref = URL(history_ref, encoded=True)
+    except ValueError as exc:
+        raise outside from exc
+    if str(ref) != history_ref or ref.user is not None or ref.query_string or ref.fragment:
+        raise outside
+    if (ref.scheme, ref.host, ref.port) != (base.scheme, base.host, base.port):
+        raise outside
+    prefix = base.raw_path.rstrip("/") + "/"
+    if not ref.raw_path.startswith(prefix):
+        raise outside
+    for segment in ref.raw_path[len(prefix) :].split("/"):
+        if unquote(segment) in ("", ".", ".."):
+            raise outside
     return history_ref
+
+
+def retire_bootstrap_from_process_env(environ: MutableMapping[str, str]) -> bool:
+    """Drop the pool bootstrap credential from the process environment.
+
+    The runner keeps the bootstrap in ``CredentialAuthority`` (private memory)
+    and nowhere else. It must not be inheritable by any child: the harness
+    SDK builds its subprocess environment from ``os.environ`` and the MCP tool
+    capability probe merges ``os.environ`` too, so leaving the key in place
+    would hand a credential that can adopt EVERY unbound pod of the pool to
+    prompt-driven code. Called once, immediately after ``RunnerConfig`` has
+    read it and before any spawn. Returns whether a value was present.
+    """
+
+    return environ.pop(BootEnv.env_key("runner_bootstrap_token"), None) is not None
+
+
+def build_app_for(
+    config: RunnerConfig, runner: SessionRunner, snapshotter: Snapshotter | None
+) -> web.Application:
+    """The one boot-time app construction: per-claim, bootstrap, or open.
+
+    ``CredentialAuthority`` decides the mode from the two BootEnv credentials
+    exactly as the contract documents: a present ``runner_token`` wins and the
+    bootstrap is never admitted; only a bootstrap present means bootstrap mode;
+    neither means the tokenless legacy boot.
+    """
+
+    return create_app(
+        runner,
+        token=config.runner_token,
+        bootstrap_token=config.runner_bootstrap_token,
+        snapshotter=snapshotter,
+    )
 
 
 @dataclass
@@ -687,6 +747,10 @@ def _serve() -> None:
     )
     logger.info("runner starting fake_model=%s", fake_model)
     config = RunnerConfig.from_env(os.environ)
+    # First thing after the parse and before ANY child can be spawned: the
+    # bootstrap lives in the authority only, never in a child's environment.
+    if retire_bootstrap_from_process_env(os.environ):
+        logger.info("pool bootstrap credential read and removed from the process environment")
     logger.info(
         "runner configured session=%s model=%s port=%d harness=%s",
         config.session.session_id,
@@ -746,7 +810,7 @@ def _serve() -> None:
 
     snapshot_callback = capture_mounted_workspace if workspace_path is not None else None
 
-    app = create_app(runner, token=config.runner_token, snapshotter=snapshot_callback)
+    app = build_app_for(config, runner, snapshot_callback)
 
     async def _startup(_app: web.Application) -> None:
         try:

--- a/runner/src/curie_runner/adoption.py
+++ b/runner/src/curie_runner/adoption.py
@@ -1,0 +1,206 @@
+"""Per-conversation credential authority for the runner's ACI control routes.
+
+ADR-0116 decision 2 moves session identity onto the authenticated ``Event``
+frame so a pre-booted runner can be bound to a conversation after its pod
+exists; ADR-0122 bounds a warm pool's pre-baked token to *adoption and nothing
+else*: the first authenticated ``Event`` that carries ``adoption_credential``
+installs a fresh per-conversation credential and retires the bootstrap for that
+pod. This module is the runner-side state machine for that rule.
+
+Three credential modes, decided once at app construction:
+
+- ``OPEN``: no token configured. The legacy pass-through (CLI, fake-model CI).
+  Nothing is adoptable, nothing is gated.
+- ``PER_CLAIM``: a token the worker minted per claim and injected as pod env.
+  The runner was bound to its conversation at boot; the token is a conversation
+  credential from the first request on and nothing is adoptable.
+- ``BOOTSTRAP``: a pool bootstrap credential. Until adoption it authenticates
+  exactly one thing, an adopting ``Event`` on ``/v1/event``; every other gated
+  route refuses it. Adoption is atomic: exactly one concurrent request wins,
+  the conversation binding is applied to the session first, and only then is
+  the bootstrap replaced outright by the presented credential. A failed
+  binding leaves the runner unbound and the bootstrap still adoptable, so a
+  retry can succeed and no partial state is ever observable.
+
+The presented credential material never appears in an exception message, a log
+line, or a response body: refusals carry a fixed reason and an HTTP status.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hmac
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from enum import StrEnum
+
+logger = logging.getLogger("curie_runner.adoption")
+
+BindConversation = Callable[[str, str | None], Awaitable[None]]
+
+
+class CredentialMode(StrEnum):
+    OPEN = "open"
+    PER_CLAIM = "per-claim"
+    BOOTSTRAP = "bootstrap"
+
+
+class Principal(StrEnum):
+    """What a presented bearer proves, at the moment it is checked."""
+
+    NONE = "none"
+    BOOTSTRAP = "bootstrap"
+    CONVERSATION = "conversation"
+
+
+@dataclass(frozen=True)
+class ConversationBinding:
+    """The conversation an adopted runner is bound to (identity, never secret)."""
+
+    session_id: str
+    history_ref: str | None
+
+
+class AdoptionRefused(Exception):
+    """An adoption request was refused; ``status``/``error`` are safe to return."""
+
+    def __init__(self, status: int, error: str) -> None:
+        super().__init__(error)
+        self.status = status
+        self.error = error
+
+
+def _compare(presented: str | None, active: bytes | None) -> bool:
+    if presented is None or active is None:
+        return False
+    # Compare UTF-8 bytes: hmac.compare_digest raises TypeError on a non-ASCII
+    # str, which aiohttp would surface as a 500 instead of a 401.
+    return hmac.compare_digest(presented.encode("utf-8"), active)
+
+
+class CredentialAuthority:
+    """The one active credential for this runner process, and how it changes.
+
+    ``token`` is the per-claim conversation credential (``CURIE_RUNNER_TOKEN``);
+    ``bootstrap_token`` is a pool bootstrap credential. A per-claim token wins
+    when both are supplied: the pod was bound at boot, so the bootstrap must not
+    be accepted at all. Neither configured is the legacy open mode.
+    """
+
+    def __init__(self, *, token: str | None = None, bootstrap_token: str | None = None) -> None:
+        # A falsy value means "not configured": an empty token would make
+        # ``Bearer `` with an empty value compare-equal.
+        if token:
+            self._mode = CredentialMode.PER_CLAIM
+            self._active: bytes | None = token.encode("utf-8")
+        elif bootstrap_token:
+            self._mode = CredentialMode.BOOTSTRAP
+            self._active = bootstrap_token.encode("utf-8")
+        else:
+            self._mode = CredentialMode.OPEN
+            self._active = None
+        self._binding: ConversationBinding | None = None
+        self._lock = asyncio.Lock()
+
+    @property
+    def mode(self) -> CredentialMode:
+        return self._mode
+
+    @property
+    def gated(self) -> bool:
+        """Whether the control routes require a bearer at all."""
+
+        return self._mode is not CredentialMode.OPEN
+
+    @property
+    def binding(self) -> ConversationBinding | None:
+        """The adopted conversation, or None before adoption / outside bootstrap mode."""
+
+        return self._binding
+
+    @property
+    def adoptable(self) -> bool:
+        return self._mode is CredentialMode.BOOTSTRAP and self._binding is None
+
+    def authenticate(self, presented: str | None) -> Principal:
+        """Classify a presented bearer against the credential active right now.
+
+        After adoption the bootstrap is simply no longer the active credential,
+        so it classifies as ``NONE`` exactly like any other wrong token; nothing
+        distinguishes a retired bootstrap from a guess.
+        """
+
+        if not self.gated or not _compare(presented, self._active):
+            return Principal.NONE
+        if self._mode is CredentialMode.BOOTSTRAP and self._binding is None:
+            return Principal.BOOTSTRAP
+        return Principal.CONVERSATION
+
+    async def adopt(
+        self,
+        credential: str,
+        session_id: str,
+        history_ref: str | None,
+        *,
+        bind: BindConversation,
+    ) -> ConversationBinding:
+        """Bind this runner to one conversation and retire the bootstrap, atomically.
+
+        ``bind`` applies the conversation to the live session (history load,
+        session rebuild, attestation) and may raise; when it does, nothing here
+        has changed and the bootstrap remains adoptable. The credential swap is
+        the LAST step, after the binding is applied, so an observer can never
+        see the new credential accepted before the conversation is bound, nor
+        the bootstrap accepted after it is.
+
+        The locked transition runs shielded from the caller's cancellation: a
+        client that disconnects (or a request task cancelled) mid-bind must
+        not be able to leave the session half-adopted with the bootstrap still
+        active. The caller still observes ``CancelledError``; the transition
+        itself runs to one of its two consistent ends, bound-and-swapped or
+        rolled-back-and-adoptable.
+        """
+
+        return await asyncio.shield(
+            self._adopt_locked(credential, session_id, history_ref, bind=bind)
+        )
+
+    async def _adopt_locked(
+        self,
+        credential: str,
+        session_id: str,
+        history_ref: str | None,
+        *,
+        bind: BindConversation,
+    ) -> ConversationBinding:
+        async with self._lock:
+            if self._mode is not CredentialMode.BOOTSTRAP:
+                raise AdoptionRefused(409, "runner is not adoptable")
+            if self._binding is not None:
+                raise AdoptionRefused(409, "runner is already bound to a conversation")
+            if not session_id:
+                raise AdoptionRefused(400, "adoption requires a session_id")
+            if not credential or not credential.strip():
+                # The wire layer already rejects an empty or whitespace
+                # credential; this guard keeps the authority itself from ever
+                # installing one, which would make an empty bearer authenticate.
+                raise AdoptionRefused(400, "adoption credential must not be empty")
+            if _compare(credential, self._active):
+                # Installing the bootstrap as the conversation credential would
+                # leave the shared secret in force for a bound conversation.
+                raise AdoptionRefused(400, "adoption credential must differ from the bootstrap")
+            try:
+                await bind(session_id, history_ref)
+            except Exception as exc:  # noqa: BLE001 - any binding failure is inert
+                logger.error(
+                    "adoption binding failed session=%s error_class=%s",
+                    session_id,
+                    type(exc).__name__,
+                )
+                raise AdoptionRefused(503, "conversation could not be bound") from exc
+            binding = ConversationBinding(session_id=session_id, history_ref=history_ref)
+            self._binding = binding
+            self._active = credential.encode("utf-8")
+            logger.info("adoption applied session=%s; bootstrap credential retired", session_id)
+            return binding

--- a/runner/src/curie_runner/config.py
+++ b/runner/src/curie_runner/config.py
@@ -15,7 +15,7 @@ their default. Each var keeps the behavior it has.
 from __future__ import annotations
 
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 from aci_protocol import BootEnv, SessionConfig
@@ -83,6 +83,11 @@ class RunnerConfig:
     false_completion_check: bool
     port: int
     runner_token: str | None
+    # Pool bootstrap credential (ADR-0122), delivered by the substrate's pool
+    # template only; ``None`` when absent. ``CredentialAuthority`` gives a
+    # present ``runner_token`` precedence, so a pod bound at boot never enters
+    # bootstrap mode. Never repr'd: it is secret material.
+    runner_bootstrap_token: str | None = field(repr=False)
     # Operator bounds on the rehydrated structured history, reachable through
     # the chart's runner.extraEnv. None hands the consumer its own default, so
     # the defaults live at the call site rather than here.
@@ -148,6 +153,7 @@ class RunnerConfig:
             false_completion_check=false_completion_check,
             port=boot.port if boot.port is not None else 8080,
             runner_token=boot.runner_token,
+            runner_bootstrap_token=boot.runner_bootstrap_token,
             history_max_turns=boot.history_max_turns,
             history_max_bytes=boot.history_max_bytes,
         )

--- a/runner/src/curie_runner/server.py
+++ b/runner/src/curie_runner/server.py
@@ -26,7 +26,6 @@ the open ``/v1/event`` stream, exactly as the PT-2 steering proof showed.
 from __future__ import annotations
 
 import contextlib
-import hmac
 import inspect
 from collections.abc import Awaitable, Callable, Mapping
 from types import MappingProxyType
@@ -37,6 +36,7 @@ from aiohttp import web
 from aiohttp.typedefs import Handler, Middleware
 from curie_telemetry import TRACEPARENT_STREAM_FIELD, extract_trace_context
 
+from .adoption import AdoptionRefused, CredentialAuthority, Principal
 from .session import SessionRunner
 from .workspace_snapshot import WorkspaceSnapshot, WorkspaceSnapshotError
 
@@ -54,6 +54,9 @@ RUNNER: web.AppKey[SessionRunner] = web.AppKey("runner", SessionRunner)
 Snapshotter = Callable[[], WorkspaceSnapshot | Awaitable[WorkspaceSnapshot]]
 SNAPSHOTTER: web.AppKey[object] = web.AppKey("snapshotter", object)
 STATUS_ATTESTATION: web.AppKey[object] = web.AppKey("status_attestation", object)
+AUTHORITY: web.AppKey[CredentialAuthority] = web.AppKey("authority", CredentialAuthority)
+# Per-request principal the auth middleware resolved (absent on the open app).
+_PRINCIPAL_KEY: web.RequestKey[Principal] = web.RequestKey("curie_principal", Principal)
 
 
 class _StatusAttestation(TypedDict):
@@ -90,17 +93,17 @@ def _bound_status_attestation(runner: SessionRunner) -> Mapping[str, object] | N
     return cast("Mapping[str, object]", value) if isinstance(value, Mapping) else None
 
 
-def _auth_middleware(token: str) -> Middleware:
-    """Require ``Authorization: Bearer <token>`` on the gated control routes.
+def _auth_middleware(authority: CredentialAuthority) -> Middleware:
+    """Require a bearer the live credential authority accepts on the gated routes.
 
     Runs before body parsing so an authenticated call keeps the route's existing
-    400/409 semantics unchanged. The presented token is compared with the
-    configured one via ``hmac.compare_digest`` (no timing oracle).
+    400/409 semantics unchanged. The authority is read PER REQUEST rather than
+    captured once: in bootstrap mode the active credential changes at adoption
+    (ADR-0122), and a bootstrap principal is admitted to ``/v1/event`` only --
+    the one route that can carry an adoption -- and refused everywhere else, so
+    the shared pool secret never reads status, steers, interrupts, resets, or
+    snapshots any pod. Comparison is constant-time inside the authority.
     """
-
-    # The configured token is invariant for the process, so encode it once here
-    # rather than on every gated request.
-    token_bytes = token.encode("utf-8")
 
     @web.middleware
     async def middleware(request: web.Request, handler: Handler) -> web.StreamResponse:
@@ -109,12 +112,14 @@ def _auth_middleware(token: str) -> Middleware:
             scheme = "Bearer "
             if not header.startswith(scheme):
                 return web.json_response({"error": "missing bearer token"}, status=401)
-            presented = header[len(scheme) :]
-            # Compare UTF-8 bytes: hmac.compare_digest raises TypeError on a
-            # non-ASCII str, which aiohttp would surface as a 500 instead of a
-            # 401. Bytes keep a crafted non-ASCII token a clean 401.
-            if not hmac.compare_digest(presented.encode("utf-8"), token_bytes):
+            principal = authority.authenticate(header[len(scheme) :])
+            if principal is Principal.NONE:
                 return web.json_response({"error": "invalid token"}, status=401)
+            if principal is Principal.BOOTSTRAP and request.path != "/v1/event":
+                return web.json_response(
+                    {"error": "bootstrap credential permits adoption only"}, status=403
+                )
+            request[_PRINCIPAL_KEY] = principal
         return await handler(request)
 
     return middleware
@@ -124,24 +129,31 @@ def create_app(
     runner: SessionRunner,
     token: str | None = None,
     snapshotter: Snapshotter | None = None,
+    *,
+    bootstrap_token: str | None = None,
 ) -> web.Application:
     """Build the aiohttp application bound to a started SessionRunner.
 
-    When ``token`` is set, the runner control routes require a matching bearer
-    token; when it is ``None`` the app is a pass-through (CLI, fake-model CI,
-    and pre-token sandboxes stay unauthenticated).
+    When ``token`` is set, the runner control routes require that per-claim
+    bearer and nothing is adoptable. When only ``bootstrap_token`` is set, the
+    runner is in bootstrap mode: the bearer authenticates exactly one adopting
+    ``/v1/event`` that installs a per-conversation credential and retires the
+    bootstrap (ADR-0122). When neither is set the app is a pass-through (CLI,
+    fake-model CI, and pre-token sandboxes stay unauthenticated).
     """
 
     # A falsy token (None or empty string) means no enforcement: an empty token
     # would make ``Bearer `` with an empty value compare-equal, so treat it as
     # pass-through rather than an unusable enforce-on state.
-    middlewares = [_auth_middleware(token)] if token else []
+    authority = CredentialAuthority(token=token, bootstrap_token=bootstrap_token)
+    middlewares = [_auth_middleware(authority)] if authority.gated else []
     app = web.Application(middlewares=middlewares)
     app[RUNNER] = runner
+    app[AUTHORITY] = authority
     app[SNAPSHOTTER] = snapshotter
     # An identity-bearing response exists only when middleware above enforces a
     # non-empty bearer. Legacy/tokenless apps keep both status routes probe-only.
-    app[STATUS_ATTESTATION] = _bound_status_attestation(runner) if token else None
+    app[STATUS_ATTESTATION] = _bound_status_attestation(runner) if authority.gated else None
     app.add_routes(
         [
             web.get("/healthz", _healthz),
@@ -178,6 +190,11 @@ async def _status(request: web.Request) -> web.Response:
         attestation = cast("Mapping[str, object] | None", request.app[STATUS_ATTESTATION])
         if attestation is not None:
             body.update(attestation)
+            # The conversation actually served, not the boot placeholder: an
+            # adopted runner attests the session it was bound to, which is how
+            # a worker that lost the adoption response learns it was applied.
+            if runner.session_id is not None:
+                body["session_id"] = runner.session_id
     return web.json_response(body)
 
 
@@ -211,15 +228,57 @@ def _parse(body: object) -> Event | Interrupt:
 
 async def _event(request: web.Request) -> web.StreamResponse:
     runner: SessionRunner = request.app[RUNNER]
+    authority: CredentialAuthority = request.app[AUTHORITY]
+    principal = request.get(_PRINCIPAL_KEY, Principal.NONE)
     try:
         frame = _parse(await request.json())
     except Exception as exc:  # noqa: BLE001 - map any decode/validation error to 400
+        # aci_protocol scrubs adoption-credential material from its validation
+        # errors, so interpolating the exception cannot echo the secret.
         return web.json_response({"error": f"invalid event frame: {exc}"}, status=400)
     if not isinstance(frame, Event):
         return web.json_response(
             {"error": "expected an event frame; use /v1/interrupt for interrupts"},
             status=400,
         )
+
+    adoption_applied = False
+    if frame.adoption_credential is not None:
+        # Adoption (ADR-0122): the authority refuses every case that is not a
+        # bootstrap-authenticated first binding -- an open or per-claim runner,
+        # an already-bound pod, a bootstrap presented as the new credential --
+        # and applies the conversation to the session BEFORE swapping the
+        # credential. No model turn starts unless the binding was applied.
+        try:
+            await authority.adopt(
+                frame.adoption_credential,
+                frame.session_id or "",
+                frame.history_ref,
+                bind=runner.bind_conversation,
+            )
+        except AdoptionRefused as refusal:
+            return web.json_response({"error": refusal.error}, status=refusal.status)
+        adoption_applied = True
+    else:
+        if principal is Principal.BOOTSTRAP:
+            # The shared pool secret may adopt and nothing else: an ordinary
+            # turn under it would expose a live conversation to every holder.
+            return web.json_response(
+                {"error": "bootstrap credential permits adoption only"}, status=403
+            )
+        if (
+            authority.gated
+            and frame.session_id is not None
+            and runner.session_id is not None
+            and frame.session_id != runner.session_id
+        ):
+            # A credential admits exactly one conversation; a frame naming
+            # another one is a cross-conversation request, refused before any
+            # model call.
+            return web.json_response(
+                {"error": "event names a conversation this runner is not bound to"},
+                status=409,
+            )
 
     response = web.StreamResponse(status=200, headers={"Content-Type": _NDJSON})
     await response.prepare(request)
@@ -234,7 +293,9 @@ async def _event(request: web.Request) -> web.StreamResponse:
     if traceparent is not None:
         carrier[TRACEPARENT_STREAM_FIELD] = traceparent
     parent = extract_trace_context(carrier)
-    async with contextlib.aclosing(runner.run_turn(frame, parent=parent)) as stream:
+    async with contextlib.aclosing(
+        runner.run_turn(frame, parent=parent, adoption_applied=adoption_applied)
+    ) as stream:
         async for line in stream:
             await response.write(line.encode("utf-8"))
     await response.write_eof()
@@ -249,6 +310,11 @@ async def _steer(request: web.Request) -> web.Response:
         return web.json_response({"error": f"invalid steer frame: {exc}"}, status=400)
     if not isinstance(frame, Event):
         return web.json_response({"error": "expected an event frame"}, status=400)
+    if frame.adoption_credential is not None:
+        # A credential swaps only on the adopting /v1/event, never mid-turn.
+        return web.json_response(
+            {"error": "steer must not carry an adoption credential"}, status=400
+        )
 
     delivered = await runner.steer(frame.text)
     if not delivered:

--- a/runner/src/curie_runner/session.py
+++ b/runner/src/curie_runner/session.py
@@ -23,6 +23,7 @@ import contextlib
 import logging
 import time
 from collections.abc import AsyncGenerator, AsyncIterator, Callable
+from typing import Protocol
 
 import anyio
 from aci_protocol import (
@@ -30,6 +31,7 @@ from aci_protocol import (
     Event,
     Final,
     Interrupt,
+    OutboundEvent,
     SessionStatus,
     ToolNote,
     parse_ndjson_line,
@@ -45,7 +47,9 @@ from .budget import BUDGET_CLASSIFICATION, BudgetTracker
 from .history import (
     ApprovalContext,
     ConversationMessage,
+    ConversationReplay,
     HarnessReplayState,
+    HistoryRecord,
     NullTranscriptStore,
     TranscriptStore,
     TurnRecord,
@@ -177,6 +181,31 @@ def _apply_approval_override(final: Final, state: TurnState) -> Final:
     return final
 
 
+class ConversationBinder(Protocol):
+    """How a runner booted without a conversation acquires one at adoption.
+
+    ``load`` resolves the conversation's durable transcript for ``history_ref``
+    and returns the store, the replay prefix a fresh model session must
+    reconstruct, and the compaction summary record to append once the binding
+    is applied (``None`` when the load did not compact); it raises when the
+    history cannot be loaded, and the caller then leaves the runner exactly as
+    it was. It must write nothing durable itself, so a failed adoption is
+    inert on the transcript too. ``rebind`` repoints the session factory at
+    the bound identity so the next session it produces carries the
+    conversation's replay and session id (ADR-0116 decision 2, ADR-0122).
+    """
+
+    async def load(
+        self, session_id: str, history_ref: str | None
+    ) -> tuple[TranscriptStore, ConversationReplay, HistoryRecord | None]: ...
+
+    def rebind(self, session_id: str, replay: ConversationReplay) -> None: ...
+
+
+class ConversationBindingError(RuntimeError):
+    """The runner cannot bind a conversation in its current state."""
+
+
 class SessionRunner:
     """Drives one model session, streaming ACI NDJSON for each inbound frame."""
 
@@ -197,8 +226,19 @@ class SessionRunner:
         approval_decision: str | None = None,
         false_completion_check: bool = False,
         history_resumed: bool = False,
+        conversation_binder: ConversationBinder | None = None,
+        boot_replay: ConversationReplay | None = None,
     ) -> None:
         self._factory = session_factory
+        # Adoption support (ADR-0116 d2 / ADR-0122): None means this runner was
+        # bound at boot (per-claim env) and cannot be re-bound; a binder lets a
+        # bootstrap-mode runner take its conversation from the adopting Event.
+        self._binder = conversation_binder
+        # Set only for the adopting turn: every outbound frame of that turn
+        # carries ``adoption_applied: true`` so the producer can distinguish a
+        # runner that applied the credential from a tolerant consumer that
+        # ignored the field and served the turn anyway.
+        self._ack_adoption = False
         self._ceiling = ceiling
         self._tracer = tracer
         self._classifier = classifier
@@ -232,6 +272,10 @@ class SessionRunner:
         self._false_completion_check = false_completion_check
         self._history_resumed = history_resumed
         self._resume_cache_metric_recorded = False
+        # The replay the factory was actually built with at boot; restored if a
+        # rebind's connect fails so an aborted adoption leaves the boot factory
+        # intact rather than repointed at an empty replay.
+        self._boot_replay = boot_replay if boot_replay is not None else ConversationReplay()
 
         self._session: ModelSession | None = None
         # One turn consumes the SDK generator at a time. This MUST be a
@@ -286,6 +330,86 @@ class SessionRunner:
         """Whether every completed logical turn is present in durable replay."""
 
         return self._history_durable
+
+    @property
+    def session_id(self) -> str | None:
+        """The conversation this runner currently serves (boot-bound or adopted)."""
+
+        return self._session_id
+
+    async def bind_conversation(self, session_id: str, history_ref: str | None) -> None:
+        """Bind an unbound (bootstrap-mode) runner to one conversation, atomically.
+
+        Order is load-bearing. The transcript is loaded FIRST, while nothing
+        about this runner has changed, so a failed or unauthorized history load
+        leaves the boot identity, store, and live session untouched. Only then
+        is the factory repointed and a replacement model session connected with
+        the conversation's replay; if that connect fails the factory is
+        restored to the boot identity before the error propagates. The runner's
+        own identity (session id, trace name, transcript store, attestation
+        source) changes last, after the replacement session is live. Taken
+        under the turn lock so it can never overlap a turn.
+        """
+
+        if self._binder is None:
+            raise ConversationBindingError("this runner was bound at boot and cannot adopt")
+        async with self._turn_lock:
+            store, replay, summary = await self._binder.load(session_id, history_ref)
+            previous_id = self._session_id
+            previous_replay = self._boot_replay
+            self._binder.rebind(session_id, replay)
+            replacement: ModelSession | None = None
+            try:
+                replacement = self._factory()
+                await replacement.connect()
+            except BaseException:
+                # BaseException on purpose: a cancellation arriving here must
+                # roll the factory back exactly like a connect failure, and a
+                # replacement that already spawned a harness child is closed
+                # rather than leaked.
+                if previous_id is not None:
+                    self._binder.rebind(previous_id, previous_replay)
+                if replacement is not None:
+                    with contextlib.suppress(Exception):
+                        await replacement.close()
+                raise
+            # From here the swap is synchronous: no await sits between the
+            # first identity assignment and the last, so no observer (and no
+            # cancellation) can see a half-adopted runner.
+            old = self._session
+            self._session = replacement
+            self._session_id = session_id
+            self._trace_name = f"curie-run:{session_id}"
+            self._history = store
+            self._history_resumed = replay.present
+            self._resume_cache_metric_recorded = False
+            self._boot_replay = replay
+            self._interrupt_requested = False
+            self._turn_open = False
+            self._active_state = None
+            self._status = SessionStatus.IDLE_AWAITING_INPUT
+            self._started = True
+            if old is not None:
+                with contextlib.suppress(Exception):
+                    await old.close()
+            if summary is not None:
+                # The compaction record is written only now, after the binding
+                # is applied, so a refused adoption leaves the transcript as it
+                # found it. Same best-effort posture as the boot path's append.
+                try:
+                    await store.append(summary)
+                except Exception:  # noqa: BLE001 - durable summary is best-effort
+                    logger.warning(
+                        "compaction summary append failed after adoption session=%s",
+                        session_id,
+                    )
+
+    def _line(self, model: OutboundEvent) -> str:
+        """Encode one outbound frame, stamping the adoption ack on the adopting turn."""
+
+        if self._ack_adoption:
+            model = model.model_copy(update={"adoption_applied": True})
+        return to_ndjson_line(model)
 
     async def remember(
         self,
@@ -484,7 +608,7 @@ class SessionRunner:
         """
 
         if isinstance(message, Interrupt):
-            yield to_ndjson_line(
+            yield self._line(
                 Final(text="run interrupted", status=SessionStatus.IDLE_AWAITING_INPUT)
             )
             self._status = SessionStatus.IDLE_AWAITING_INPUT
@@ -493,7 +617,11 @@ class SessionRunner:
             yield line
 
     async def run_turn(
-        self, event: Event, *, parent: Context | None = None
+        self,
+        event: Event,
+        *,
+        parent: Context | None = None,
+        adoption_applied: bool = False,
     ) -> AsyncGenerator[str]:
         """Run one turn, streaming ACI NDJSON lines and enforcing the budget.
 
@@ -509,6 +637,7 @@ class SessionRunner:
             start = time.monotonic()
             logger.info("turn start session=%s user=%s", self._session_id, event.user)
             self._interrupt_requested = False
+            self._ack_adoption = adoption_applied
             self._turn_open = True
             self._history_durable = False
             state = TurnState()
@@ -574,7 +703,7 @@ class SessionRunner:
                                 interrupt_requested=True,
                                 classified_failure=False,
                             )
-                            yield to_ndjson_line(
+                            yield self._line(
                                 Final(
                                     text="run interrupted",
                                     status=SessionStatus.IDLE_AWAITING_INPUT,
@@ -591,13 +720,13 @@ class SessionRunner:
                             self._status = SessionStatus.CLASSIFIED_FAILURE
                             metric_outcome = self._metric_outcome(tracker)
                             gen.set_failed()
-                            yield to_ndjson_line(
+                            yield self._line(
                                 ErrorEvent(
                                     message=f"runner error: {exc}",
                                     classification="runner-error",
                                 )
                             )
-                            yield to_ndjson_line(
+                            yield self._line(
                                 Final(
                                     text="run failed",
                                     status=SessionStatus.CLASSIFIED_FAILURE,
@@ -615,6 +744,7 @@ class SessionRunner:
                         self._turn_open = False
             finally:
                 self._active_state = None
+                self._ack_adoption = False
                 completed_attributes = {
                     "service.name": "curie-runner",
                     "source": "runner",
@@ -779,9 +909,9 @@ class SessionRunner:
                         SessionStatus.AWAITING_APPROVAL,
                     }:
                         state.final_text = final.text
-                    yield to_ndjson_line(final)
+                    yield self._line(final)
                     return
-                yield to_ndjson_line(outbound)
+                yield self._line(outbound)
 
             if budget_hit:
                 # Budget crossed on a non-terminal message: stop the live run,
@@ -819,7 +949,7 @@ class SessionRunner:
         # halt: its structured tool call and gate context must cross runners.
         if final.status is SessionStatus.AWAITING_APPROVAL:
             state.final_text = final.text or state.assistant_text
-        yield to_ndjson_line(final)
+        yield self._line(final)
 
     def _approval_not_acted_lines(self, state: TurnState, final: Final) -> list[str]:
         """The OBSERVE-ONLY reconciliation warning (#544, Decision A2).
@@ -852,7 +982,7 @@ class SessionRunner:
                 self._session_id,
             )
             return [
-                to_ndjson_line(
+                self._line(
                     ErrorEvent(
                         message=(
                             "resumed policy approval was not acted on this turn: "
@@ -898,7 +1028,7 @@ class SessionRunner:
                 self._session_id,
             )
             return [
-                to_ndjson_line(
+                self._line(
                     ErrorEvent(
                         message=(
                             "turn declared done with a substantive answer but made "
@@ -974,13 +1104,13 @@ class SessionRunner:
         self._turn_open = False
         self._status = SessionStatus.CLASSIFIED_FAILURE
         return [
-            to_ndjson_line(
+            self._line(
                 ErrorEvent(
                     message="output token budget exceeded",
                     classification=BUDGET_CLASSIFICATION,
                 )
             ),
-            to_ndjson_line(
+            self._line(
                 Final(
                     text="run halted: output token budget exceeded",
                     status=SessionStatus.CLASSIFIED_FAILURE,
@@ -1003,13 +1133,13 @@ class SessionRunner:
         self._turn_open = False
         self._status = SessionStatus.CLASSIFIED_FAILURE
         return [
-            to_ndjson_line(
+            self._line(
                 ErrorEvent(
                     message="model credential rejected by provider (check CURIE_CREDENTIALS)",
                     classification=AUTH_REJECTED_CLASSIFICATION,
                 )
             ),
-            to_ndjson_line(
+            self._line(
                 Final(
                     text="run failed: model credential rejected by provider",
                     status=SessionStatus.CLASSIFIED_FAILURE,

--- a/runner/tests/test_adoption.py
+++ b/runner/tests/test_adoption.py
@@ -1,0 +1,831 @@
+"""Warm-pool adoption over the authenticated ACI Event (ADR-0116 d2, ADR-0122).
+
+A bootstrap-mode runner accepts its pool credential for exactly one thing: an
+adopting ``POST /v1/event`` carrying ``adoption_credential`` and ``session_id``.
+That call binds the conversation (history, session, attestation) BEFORE the
+credential swaps, acks with ``adoption_applied: true`` on every frame of that
+turn, and retires the bootstrap. Everything else under the bootstrap refuses,
+a failed or malformed adoption is inert, concurrent adoptions have exactly one
+winner, and the per-claim (cold) and open (CLI/fake) modes are unchanged.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+import anyio
+import pytest
+from aci_protocol import SessionStatus, parse_ndjson
+from aiohttp.test_utils import TestClient, TestServer
+from curie_runner import RunTracer, SideEffectClassifier, create_app
+from curie_runner.__main__ import adoptable_history_ref
+from curie_runner.adoption import AdoptionRefused, CredentialAuthority, CredentialMode, Principal
+from curie_runner.fake import FakeModelSession
+from curie_runner.history import (
+    ConversationMessage,
+    ConversationReplay,
+    HistoryError,
+    NullTranscriptStore,
+)
+from curie_runner.server import AUTHORITY, bind_status_attestation
+from curie_runner.session import ConversationBindingError, SessionRunner
+
+_BOOT = "pool-bootstrap-credential-0123456789"
+_CONV = "conversation-credential-A-0123456789"
+_CONV_B = "conversation-credential-B-0123456789"
+_SESSION = "agent-acme-thread-C0EXAMPLE1-1700000000.000100"
+_SESSION_B = "agent-acme-thread-C0EXAMPLE1-1700000000.000200"
+_HISTORY = "http://api.example.com/agents/acme/state/transcript/thread-1"
+_SECRETS = (_BOOT, _CONV, _CONV_B)
+
+
+def _bearer(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _frame(**overrides: Any) -> dict[str, Any]:
+    frame: dict[str, Any] = {
+        "kind": "event",
+        "type": "message",
+        "text": "hello",
+        "user": "U1",
+        "ts": "1700000000.000100",
+    }
+    frame.update(overrides)
+    return frame
+
+
+def _adopting(
+    credential: str = _CONV, session_id: str | None = _SESSION, **extra: Any
+) -> dict[str, Any]:
+    frame = _frame(adoption_credential=credential, history_ref=_HISTORY, **extra)
+    if session_id is not None:
+        frame["session_id"] = session_id
+    return frame
+
+
+class RecordingBinder:
+    """A ConversationBinder double: records calls, optionally fails or dawdles."""
+
+    def __init__(
+        self,
+        *,
+        fail: bool = False,
+        delay_s: float = 0.0,
+        replay: ConversationReplay | None = None,
+    ) -> None:
+        self.loads: list[tuple[str, str | None]] = []
+        self.rebinds: list[tuple[str, ConversationReplay]] = []
+        self.fail = fail
+        self.delay_s = delay_s
+        self.replay = replay or ConversationReplay()
+        self.store: Any = NullTranscriptStore()
+        self.summary: Any = None
+
+    async def load(
+        self, session_id: str, history_ref: str | None
+    ) -> tuple[Any, ConversationReplay, Any]:
+        self.loads.append((session_id, history_ref))
+        if self.delay_s:
+            await anyio.sleep(self.delay_s)
+        if self.fail:
+            raise HistoryError("configured structured history could not be loaded")
+        return self.store, self.replay, self.summary
+
+    def rebind(self, session_id: str, replay: ConversationReplay) -> None:
+        self.rebinds.append((session_id, replay))
+
+
+class _RefusingSession(FakeModelSession):
+    """A replacement session whose connect fails after the object exists."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.closed = False
+
+    async def connect(self) -> None:
+        raise RuntimeError("model session refused to connect")
+
+    async def close(self) -> None:
+        self.closed = True
+        await super().close()
+
+
+def _runner(
+    binder: RecordingBinder | None,
+    *,
+    factory_fail_after: int | None = None,
+    connect_fail_after: int | None = None,
+    boot_replay: ConversationReplay | None = None,
+) -> tuple[SessionRunner, list[FakeModelSession]]:
+    sessions: list[FakeModelSession] = []
+
+    def factory() -> FakeModelSession:
+        if factory_fail_after is not None and len(sessions) >= factory_fail_after:
+            raise RuntimeError("model session refused to connect")
+        fake: FakeModelSession = (
+            _RefusingSession()
+            if connect_fail_after is not None and len(sessions) >= connect_fail_after
+            else FakeModelSession()
+        )
+        sessions.append(fake)
+        return fake
+
+    runner = SessionRunner(
+        session_factory=factory,
+        ceiling=0,
+        tracer=RunTracer(None),
+        classifier=SideEffectClassifier(),
+        trace_name="curie-run:warm-unbound",
+        session_id="warm-unbound",
+        conversation_binder=binder,
+        boot_replay=boot_replay,
+    )
+    bind_status_attestation(runner, session_id="warm-unbound", sandbox_id="sbx-pool-1", cwd=None)
+    return runner, sessions
+
+
+def _events(text: str) -> list[Any]:
+    return parse_ndjson(text)
+
+
+def _assert_no_secret(*payloads: str) -> None:
+    for payload in payloads:
+        for secret in _SECRETS:
+            assert secret not in payload
+
+
+# --- the authority on its own ------------------------------------------------
+
+
+def test_authority_modes_and_principals() -> None:
+    open_mode = CredentialAuthority()
+    assert open_mode.mode is CredentialMode.OPEN
+    assert open_mode.gated is False
+    assert open_mode.authenticate("anything") is Principal.NONE
+
+    per_claim = CredentialAuthority(token="per-claim-token", bootstrap_token=_BOOT)
+    assert per_claim.mode is CredentialMode.PER_CLAIM
+    assert per_claim.adoptable is False
+    assert per_claim.authenticate("per-claim-token") is Principal.CONVERSATION
+    # A per-claim pod was bound at boot; the bootstrap is never accepted there.
+    assert per_claim.authenticate(_BOOT) is Principal.NONE
+
+    bootstrap = CredentialAuthority(bootstrap_token=_BOOT)
+    assert bootstrap.mode is CredentialMode.BOOTSTRAP
+    assert bootstrap.adoptable is True
+    assert bootstrap.authenticate(_BOOT) is Principal.BOOTSTRAP
+    assert bootstrap.authenticate(_CONV) is Principal.NONE
+    assert bootstrap.authenticate(None) is Principal.NONE
+    # Empty strings are "not configured", never an enforce-on-empty state.
+    assert CredentialAuthority(token="", bootstrap_token="").gated is False
+
+
+# --- bootstrap mode: refusals before adoption --------------------------------
+
+
+def test_bootstrap_without_credential_is_refused_and_starts_no_turn() -> None:
+    binder = RecordingBinder()
+    runner, sessions = _runner(binder)
+
+    async def go() -> None:
+        await runner.start()
+        app = create_app(runner, bootstrap_token=_BOOT)
+        async with TestClient(TestServer(app)) as client:
+            unauth = await client.post("/v1/event", json=_frame())
+            assert unauth.status == 401
+            wrong = await client.post("/v1/event", json=_frame(), headers=_bearer(_CONV))
+            assert wrong.status == 401
+            plain = await client.post("/v1/event", json=_frame(), headers=_bearer(_BOOT))
+            assert plain.status == 403
+            body = await plain.json()
+            assert body["error"] == "bootstrap credential permits adoption only"
+            # Even a frame that names the conversation is refused without the credential.
+            named = await client.post(
+                "/v1/event", json=_frame(session_id=_SESSION), headers=_bearer(_BOOT)
+            )
+            assert named.status == 403
+        assert sessions[0].queries == []
+        assert binder.loads == []
+        assert runner.session_id == "warm-unbound"
+
+    anyio.run(go)
+
+
+def test_bootstrap_is_refused_on_every_other_gated_route() -> None:
+    runner, _ = _runner(RecordingBinder())
+
+    async def go() -> None:
+        await runner.start()
+        async with TestClient(TestServer(create_app(runner, bootstrap_token=_BOOT))) as client:
+            for method, path, payload in (
+                ("get", "/v1/status", None),
+                ("post", "/v1/steer", _frame()),
+                ("post", "/v1/interrupt", {"kind": "interrupt", "reason": "x"}),
+                ("post", "/v1/reset", None),
+                ("post", "/v1/snapshot", None),
+            ):
+                resp = await client.request(
+                    method.upper(), path, json=payload, headers=_bearer(_BOOT)
+                )
+                assert resp.status == 403, path
+                assert (await resp.json())["error"] == "bootstrap credential permits adoption only"
+            # The probe routes stay open for the chart's probes.
+            assert (await client.get("/healthz")).status == 200
+            assert (await client.get("/status")).status == 200
+
+    anyio.run(go)
+
+
+# --- bootstrap mode: adoption --------------------------------------------------
+
+
+def test_adoption_binds_acks_and_retires_the_bootstrap(caplog: pytest.LogCaptureFixture) -> None:
+    replay = ConversationReplay(
+        messages=(ConversationMessage(role="user", content="earlier question"),),
+        source_turns=1,
+    )
+    binder = RecordingBinder(replay=replay)
+    runner, sessions = _runner(binder)
+    caplog.set_level(logging.DEBUG)
+
+    async def go() -> None:
+        await runner.start()
+        boot_session = sessions[0]
+        async with TestClient(TestServer(create_app(runner, bootstrap_token=_BOOT))) as client:
+            resp = await client.post("/v1/event", json=_adopting(), headers=_bearer(_BOOT))
+            text = await resp.text()
+            assert resp.status == 200, text
+            events = _events(text)
+            assert events[-1].type == "final"
+            assert events[-1].status == SessionStatus.DONE
+            # Every frame of the adopting turn carries the ack, the final included.
+            assert events and all(event.adoption_applied is True for event in events)
+
+            # The conversation was actually bound, not merely accepted:
+            assert binder.loads == [(_SESSION, _HISTORY)]
+            assert binder.rebinds == [(_SESSION, replay)]
+            assert runner.session_id == _SESSION
+            # ...on a replacement model session; the boot session is closed and
+            # the turn ran against the bound one.
+            assert len(sessions) == 2
+            assert boot_session.connected is False
+            assert boot_session.queries == []
+            assert sessions[1].queries == ["hello"]
+
+            # The bootstrap is retired: it is now just a wrong token everywhere.
+            stale = await client.post("/v1/event", json=_frame(), headers=_bearer(_BOOT))
+            assert stale.status == 401
+            stale_status = await client.get("/v1/status", headers=_bearer(_BOOT))
+            assert stale_status.status == 401
+            readopt = await client.post(
+                "/v1/event", json=_adopting(_CONV_B), headers=_bearer(_BOOT)
+            )
+            assert readopt.status == 401
+
+            # The conversation credential gates every control route and the
+            # attestation reports the ADOPTED conversation.
+            status = await client.get("/v1/status", headers=_bearer(_CONV))
+            assert status.status == 200
+            attested = await status.json()
+            assert attested["session_id"] == _SESSION
+            assert attested["sandbox_id"] == "sbx-pool-1"
+            follow_up = await client.post(
+                "/v1/event", json=_frame(text="again", session_id=_SESSION), headers=_bearer(_CONV)
+            )
+            follow_text = await follow_up.text()
+            assert follow_up.status == 200
+            # A later turn is not an adoption: no ack is claimed for it.
+            assert all(event.adoption_applied is None for event in _events(follow_text))
+            reset = await client.post("/v1/reset", headers=_bearer(_CONV))
+            assert reset.status == 200
+            # A reset after adoption still serves the bound conversation.
+            assert runner.session_id == _SESSION
+            _assert_no_secret(text, follow_text, await status.text())
+        _assert_no_secret(*(record.getMessage() for record in caplog.records))
+
+    anyio.run(go)
+
+
+def test_adoption_credential_is_required_on_every_route_after_binding() -> None:
+    runner, _ = _runner(RecordingBinder())
+
+    async def go() -> None:
+        await runner.start()
+        async with TestClient(TestServer(create_app(runner, bootstrap_token=_BOOT))) as client:
+            assert (
+                await client.post("/v1/event", json=_adopting(), headers=_bearer(_BOOT))
+            ).status == 200
+            for method, path, payload in (
+                ("get", "/v1/status", None),
+                ("post", "/v1/steer", _frame()),
+                ("post", "/v1/interrupt", {"kind": "interrupt", "reason": "x"}),
+                ("post", "/v1/reset", None),
+                ("post", "/v1/snapshot", None),
+                ("post", "/v1/event", _frame()),
+            ):
+                missing = await client.request(method.upper(), path, json=payload)
+                assert missing.status == 401, path
+                wrong = await client.request(
+                    method.upper(), path, json=payload, headers=_bearer(_CONV_B)
+                )
+                assert wrong.status == 401, path
+            # Positive control: the bound credential reaches the route logic.
+            steer = await client.post("/v1/steer", json=_frame(), headers=_bearer(_CONV))
+            assert steer.status == 409  # no live turn, the ordinary finish-race answer
+            snapshot = await client.post("/v1/snapshot", headers=_bearer(_CONV))
+            assert snapshot.status == 409  # no managed workspace on this fake runner
+
+    anyio.run(go)
+
+
+def test_cross_conversation_and_re_adoption_are_refused_after_binding() -> None:
+    binder = RecordingBinder()
+    runner, sessions = _runner(binder)
+
+    async def go() -> None:
+        await runner.start()
+        async with TestClient(TestServer(create_app(runner, bootstrap_token=_BOOT))) as client:
+            assert (
+                await client.post("/v1/event", json=_adopting(), headers=_bearer(_BOOT))
+            ).status == 200
+            queries_after_adoption = list(sessions[-1].queries)
+            # The bound credential presented with another conversation's identity.
+            other = await client.post(
+                "/v1/event", json=_frame(session_id=_SESSION_B), headers=_bearer(_CONV)
+            )
+            assert other.status == 409
+            assert (await other.json())["error"] == (
+                "event names a conversation this runner is not bound to"
+            )
+            # The bound credential trying to adopt again (same or other session).
+            again = await client.post(
+                "/v1/event", json=_adopting(_CONV_B, _SESSION_B), headers=_bearer(_CONV)
+            )
+            assert again.status == 409
+            assert (await again.json())["error"] == "runner is already bound to a conversation"
+            same = await client.post(
+                "/v1/event", json=_adopting(_CONV, _SESSION), headers=_bearer(_CONV)
+            )
+            assert same.status == 409
+            # None of those reached the model, and the binding did not move.
+            assert sessions[-1].queries == queries_after_adoption
+            assert binder.loads == [(_SESSION, _HISTORY)]
+            assert runner.session_id == _SESSION
+            # The bound conversation still works with its own credential.
+            ok = await client.post(
+                "/v1/event", json=_frame(session_id=_SESSION), headers=_bearer(_CONV)
+            )
+            assert ok.status == 200
+
+    anyio.run(go)
+
+
+@pytest.mark.parametrize(
+    ("frame", "status", "error"),
+    [
+        (_adopting(session_id=None), 400, "adoption requires a session_id"),
+        (_adopting(session_id=""), 400, "adoption requires a session_id"),
+        (_adopting(credential=_BOOT), 400, "adoption credential must differ from the bootstrap"),
+        (_adopting(credential=""), 400, None),
+        (_adopting(credential="   "), 400, None),
+        (_adopting(credential="x" * 4097), 400, None),
+        ({**_adopting(), "adoption_credential": 12345}, 400, None),
+        ({**_adopting(), "adoption_credential": {"token": _CONV}}, 400, None),
+    ],
+)
+def test_malformed_or_partial_adoption_is_inert(
+    frame: dict[str, Any], status: int, error: str | None
+) -> None:
+    binder = RecordingBinder()
+    runner, sessions = _runner(binder)
+
+    async def go() -> None:
+        await runner.start()
+        async with TestClient(TestServer(create_app(runner, bootstrap_token=_BOOT))) as client:
+            resp = await client.post("/v1/event", json=frame, headers=_bearer(_BOOT))
+            body = await resp.text()
+            assert resp.status == status, body
+            if error is not None:
+                assert (await resp.json())["error"] == error
+            _assert_no_secret(body)
+            # Nothing was applied: no history load, no session swap, no model
+            # call, no credential change, and the boot identity still stands.
+            assert binder.loads == []
+            assert binder.rebinds == []
+            assert len(sessions) == 1
+            assert sessions[0].queries == []
+            assert runner.session_id == "warm-unbound"
+            assert (
+                await client.post("/v1/event", json=_frame(), headers=_bearer(_CONV))
+            ).status == 401
+            # The bootstrap remains adoptable afterwards: a well-formed retry wins.
+            retry = await client.post("/v1/event", json=_adopting(), headers=_bearer(_BOOT))
+            assert retry.status == 200, await retry.text()
+            assert runner.session_id == _SESSION
+
+    anyio.run(go)
+
+
+def test_failed_history_load_leaves_runner_unbound_and_bootstrap_adoptable() -> None:
+    binder = RecordingBinder(fail=True)
+    runner, sessions = _runner(binder)
+
+    async def go() -> None:
+        await runner.start()
+        async with TestClient(TestServer(create_app(runner, bootstrap_token=_BOOT))) as client:
+            resp = await client.post("/v1/event", json=_adopting(), headers=_bearer(_BOOT))
+            assert resp.status == 503
+            body = await resp.text()
+            assert (await resp.json())["error"] == "conversation could not be bound"
+            _assert_no_secret(body)
+            assert binder.loads == [(_SESSION, _HISTORY)]
+            assert binder.rebinds == []
+            assert len(sessions) == 1 and sessions[0].queries == []
+            assert runner.session_id == "warm-unbound"
+            # The presented credential was NOT installed...
+            assert (await client.get("/v1/status", headers=_bearer(_CONV))).status == 401
+            # ...and the bootstrap still adopts once the store recovers.
+            binder.fail = False
+            retry = await client.post("/v1/event", json=_adopting(), headers=_bearer(_BOOT))
+            assert retry.status == 200, await retry.text()
+            assert runner.session_id == _SESSION
+            assert (await client.get("/v1/status", headers=_bearer(_CONV))).status == 200
+
+    anyio.run(go)
+
+
+def test_failed_session_connect_restores_boot_factory_and_stays_unbound() -> None:
+    binder = RecordingBinder()
+    # The boot session is the first factory call; the adoption's replacement
+    # session (second call) refuses to connect.
+    runner, sessions = _runner(binder, factory_fail_after=1)
+
+    async def go() -> None:
+        await runner.start()
+        async with TestClient(TestServer(create_app(runner, bootstrap_token=_BOOT))) as client:
+            resp = await client.post("/v1/event", json=_adopting(), headers=_bearer(_BOOT))
+            assert resp.status == 503
+            # rebind was applied then rolled back to the boot identity.
+            assert [session_id for session_id, _ in binder.rebinds] == [_SESSION, "warm-unbound"]
+            assert runner.session_id == "warm-unbound"
+            assert sessions[0].connected is True
+            assert (await client.get("/v1/status", headers=_bearer(_CONV))).status == 401
+            # Still adoptable.
+            assert (
+                await client.post("/v1/event", json=_frame(), headers=_bearer(_BOOT))
+            ).status == 403
+
+    anyio.run(go)
+
+
+def test_failed_connect_restores_the_real_boot_replay_and_closes_the_replacement() -> None:
+    boot = ConversationReplay(
+        messages=(ConversationMessage(role="user", content="boot history"),), source_turns=1
+    )
+    binder = RecordingBinder()
+    # The boot session is the first factory call; the replacement (second)
+    # exists but refuses to connect.
+    runner, sessions = _runner(binder, connect_fail_after=1, boot_replay=boot)
+
+    async def go() -> None:
+        await runner.start()
+        async with TestClient(TestServer(create_app(runner, bootstrap_token=_BOOT))) as client:
+            resp = await client.post("/v1/event", json=_adopting(), headers=_bearer(_BOOT))
+            assert resp.status == 503
+            # Rolled back to the ACTUAL boot replay, not an empty one.
+            assert binder.rebinds[-1] == ("warm-unbound", boot)
+            refused = sessions[1]
+            assert isinstance(refused, _RefusingSession) and refused.closed is True
+            assert sessions[0].connected is True
+            assert runner.session_id == "warm-unbound"
+            assert (await client.get("/v1/status", headers=_bearer(_CONV))).status == 401
+
+    anyio.run(go)
+
+
+def test_compaction_summary_is_appended_only_after_the_binding_is_applied() -> None:
+    class RecordingStore(NullTranscriptStore):
+        def __init__(self) -> None:
+            self.appended: list[Any] = []
+
+        async def append(self, record: Any) -> None:
+            self.appended.append(record)
+
+    failing = RecordingBinder()
+    failing.store, failing.summary = RecordingStore(), object()
+    runner, _ = _runner(failing, connect_fail_after=1)
+
+    async def go_failed() -> None:
+        await runner.start()
+        async with TestClient(TestServer(create_app(runner, bootstrap_token=_BOOT))) as client:
+            assert (
+                await client.post("/v1/event", json=_adopting(), headers=_bearer(_BOOT))
+            ).status == 503
+        # A refused adoption wrote nothing durable.
+        assert failing.store.appended == []
+
+    anyio.run(go_failed)
+
+    ok = RecordingBinder()
+    marker = object()
+    ok.store, ok.summary = RecordingStore(), marker
+    runner_ok, _ = _runner(ok)
+
+    async def go_ok() -> None:
+        await runner_ok.start()
+        async with TestClient(TestServer(create_app(runner_ok, bootstrap_token=_BOOT))) as client:
+            assert (
+                await client.post("/v1/event", json=_adopting(), headers=_bearer(_BOOT))
+            ).status == 200
+        # The summary is the first durable write, ahead of the adopting turn's own record.
+        assert ok.store.appended[0] is marker
+        assert len(ok.store.appended) == 2
+
+    anyio.run(go_ok)
+
+
+def test_cancelled_adoption_completes_atomically_instead_of_splitting() -> None:
+    """A request cancelled mid-bind ends bound-and-swapped, never half-adopted."""
+
+    binder = RecordingBinder(delay_s=0.1)
+    runner, sessions = _runner(binder)
+
+    async def go() -> None:
+        await runner.start()
+        app = create_app(runner, bootstrap_token=_BOOT)
+        authority = app[AUTHORITY]
+        adopting = asyncio.create_task(
+            authority.adopt(_CONV, _SESSION, _HISTORY, bind=runner.bind_conversation)
+        )
+        await asyncio.sleep(0.02)  # inside the binder's history load
+        adopting.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await adopting
+        # The shielded transition still ran to its consistent end.
+        for _ in range(100):
+            if authority.binding is not None:
+                break
+            await asyncio.sleep(0.01)
+        assert authority.binding is not None
+        assert authority.binding.session_id == _SESSION
+        assert runner.session_id == _SESSION
+        assert authority.authenticate(_CONV) is Principal.CONVERSATION
+        assert authority.authenticate(_BOOT) is Principal.NONE
+        assert len(sessions) == 2 and sessions[0].connected is False
+        async with TestClient(TestServer(app)) as client:
+            assert (await client.get("/v1/status", headers=_bearer(_CONV))).status == 200
+            assert (await client.get("/v1/status", headers=_bearer(_BOOT))).status == 401
+            again = await client.post(
+                "/v1/event", json=_adopting(_CONV_B, _SESSION_B), headers=_bearer(_BOOT)
+            )
+            assert again.status == 401
+
+    asyncio.run(go())
+
+
+def test_bind_conversation_rolls_back_on_cancellation_during_connect() -> None:
+    """Below the authority, a cancelled connect leaves the boot factory intact."""
+
+    class HangingSession(FakeModelSession):
+        def __init__(self) -> None:
+            super().__init__()
+            self.closed = False
+
+        async def connect(self) -> None:
+            await asyncio.sleep(10)
+
+        async def close(self) -> None:
+            self.closed = True
+
+    hanging: list[HangingSession] = []
+    binder = RecordingBinder()
+    sessions: list[FakeModelSession] = []
+
+    def factory() -> FakeModelSession:
+        if sessions:
+            session = HangingSession()
+            hanging.append(session)
+            sessions.append(session)
+            return session
+        boot = FakeModelSession()
+        sessions.append(boot)
+        return boot
+
+    runner = SessionRunner(
+        session_factory=factory,
+        ceiling=0,
+        tracer=RunTracer(None),
+        classifier=SideEffectClassifier(),
+        trace_name="curie-run:warm-unbound",
+        session_id="warm-unbound",
+        conversation_binder=binder,
+    )
+
+    async def go() -> None:
+        await runner.start()
+        task = asyncio.create_task(runner.bind_conversation(_SESSION, _HISTORY))
+        await asyncio.sleep(0.02)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert [session_id for session_id, _ in binder.rebinds] == [_SESSION, "warm-unbound"]
+        assert hanging and hanging[0].closed is True
+        assert runner.session_id == "warm-unbound"
+        assert sessions[0].connected is True
+
+    asyncio.run(go())
+
+
+def test_adoptable_history_ref_is_bound_to_the_pods_state_authority() -> None:
+    base = "http://api.example.com/agents/acme/state"
+    env = {"CURIE_STATE_URL": base}
+    assert adoptable_history_ref(None, env) is None
+    assert adoptable_history_ref("", env) is None
+    assert (
+        adoptable_history_ref(f"{base}/transcript/thread-1", env) == f"{base}/transcript/thread-1"
+    )
+    for outside in (
+        "http://api.example.com/agents/other/state/transcript/thread-1",
+        "http://evil.example.com/agents/acme/state/transcript/thread-1",
+        "https://api.example.com/agents/acme/state/transcript/thread-1",
+        f"{base}x/transcript/thread-1",
+        base,
+    ):
+        with pytest.raises(HistoryError):
+            adoptable_history_ref(outside, env)
+    # No state authority configured: no caller-chosen ref is admitted at all.
+    with pytest.raises(HistoryError):
+        adoptable_history_ref(f"{base}/transcript/thread-1", {})
+
+
+def test_concurrent_adoptions_have_exactly_one_winner() -> None:
+    binder = RecordingBinder(delay_s=0.05)
+    runner, sessions = _runner(binder)
+
+    async def go() -> None:
+        await runner.start()
+        async with TestClient(TestServer(create_app(runner, bootstrap_token=_BOOT))) as client:
+            results: dict[str, tuple[int, str]] = {}
+
+            async def attempt(name: str, credential: str, session_id: str) -> None:
+                resp = await client.post(
+                    "/v1/event", json=_adopting(credential, session_id), headers=_bearer(_BOOT)
+                )
+                results[name] = (resp.status, await resp.text())
+
+            async with anyio.create_task_group() as tg:
+                tg.start_soon(attempt, "a", _CONV, _SESSION)
+                tg.start_soon(attempt, "b", _CONV_B, _SESSION_B)
+
+            statuses = sorted(status for status, _ in results.values())
+            assert statuses == [200, 409], results
+            winner = next(name for name, (status, _) in results.items() if status == 200)
+            loser = "b" if winner == "a" else "a"
+            assert "already bound" in results[loser][1]
+            won_credential, won_session = (
+                (_CONV, _SESSION) if winner == "a" else (_CONV_B, _SESSION_B)
+            )
+            lost_credential = _CONV_B if winner == "a" else _CONV
+            # Exactly one binding was applied, to the winner.
+            assert binder.loads == [(won_session, _HISTORY)]
+            assert runner.session_id == won_session
+            assert all(event.adoption_applied is True for event in _events(results[winner][1]))
+            # Only the winner's credential works; the loser's and the bootstrap do not.
+            assert (await client.get("/v1/status", headers=_bearer(won_credential))).status == 200
+            assert (await client.get("/v1/status", headers=_bearer(lost_credential))).status == 401
+            assert (await client.get("/v1/status", headers=_bearer(_BOOT))).status == 401
+            # Exactly one model turn ran.
+            assert sum(len(session.queries) for session in sessions) == 1
+
+    anyio.run(go)
+
+
+# --- per-claim (cold) and open modes are unchanged -----------------------------
+
+
+def test_per_claim_runner_refuses_adoption_and_keeps_serving_legacy_frames() -> None:
+    binder = RecordingBinder()
+    runner, sessions = _runner(binder)
+    token = "per-claim-token-0123456789"
+
+    async def go() -> None:
+        await runner.start()
+        async with TestClient(TestServer(create_app(runner, token=token))) as client:
+            # A per-claim pod was bound at boot: it is not adoptable, whoever asks.
+            adopt = await client.post("/v1/event", json=_adopting(), headers=_bearer(token))
+            assert adopt.status == 409
+            assert (await adopt.json())["error"] == "runner is not adoptable"
+            assert binder.loads == [] and binder.rebinds == []
+            assert sessions[0].queries == []
+            # The bootstrap is never a credential here.
+            assert (
+                await client.post("/v1/event", json=_adopting(), headers=_bearer(_BOOT))
+            ).status == 401
+            # Legacy omission of session identity still serves the turn, without an ack.
+            legacy = await client.post("/v1/event", json=_frame(), headers=_bearer(token))
+            legacy_text = await legacy.text()
+            assert legacy.status == 200
+            assert all(event.adoption_applied is None for event in _events(legacy_text))
+            # An explicit matching session id serves; a different one refuses.
+            assert (
+                await client.post(
+                    "/v1/event", json=_frame(session_id="warm-unbound"), headers=_bearer(token)
+                )
+            ).status == 200
+            mismatch = await client.post(
+                "/v1/event", json=_frame(session_id=_SESSION_B), headers=_bearer(token)
+            )
+            assert mismatch.status == 409
+            assert runner.session_id == "warm-unbound"
+
+    anyio.run(go)
+
+
+def test_open_runner_refuses_adoption_and_stays_pass_through() -> None:
+    binder = RecordingBinder()
+    runner, sessions = _runner(binder)
+
+    async def go() -> None:
+        await runner.start()
+        async with TestClient(TestServer(create_app(runner))) as client:
+            adopt = await client.post("/v1/event", json=_adopting())
+            assert adopt.status == 409
+            assert binder.loads == [] and sessions[0].queries == []
+            plain = await client.post("/v1/event", json=_frame())
+            assert plain.status == 200
+            assert all(event.adoption_applied is None for event in _events(await plain.text()))
+            # Open mode never enforced identity; a session id on the frame is inert.
+            assert (
+                await client.post("/v1/event", json=_frame(session_id=_SESSION_B))
+            ).status == 200
+
+    anyio.run(go)
+
+
+@pytest.mark.parametrize("mode", ["open", "per-claim", "bootstrap-bound"])
+def test_steer_never_carries_a_credential(mode: str) -> None:
+    runner, _ = _runner(RecordingBinder())
+    token = "per-claim-token-0123456789"
+
+    async def go() -> None:
+        await runner.start()
+        if mode == "open":
+            app, headers = create_app(runner), {}
+        elif mode == "per-claim":
+            app, headers = create_app(runner, token=token), _bearer(token)
+        else:
+            app, headers = create_app(runner, bootstrap_token=_BOOT), _bearer(_CONV)
+        async with TestClient(TestServer(app)) as client:
+            if mode == "bootstrap-bound":
+                assert (
+                    await client.post("/v1/event", json=_adopting(), headers=_bearer(_BOOT))
+                ).status == 200
+            # Hold a live turn open so the refusal is provably not the 409 finish race.
+            runner._turn_open = True  # noqa: SLF001 - simulate a live turn
+            resp = await client.post(
+                "/v1/steer", json=_frame(adoption_credential=_CONV_B), headers=headers
+            )
+            assert resp.status == 400
+            assert (await resp.json())["error"] == "steer must not carry an adoption credential"
+            runner._turn_open = False  # noqa: SLF001
+
+    anyio.run(go)
+
+
+def test_authority_never_installs_an_empty_credential() -> None:
+    """Defense in depth below the wire layer: an empty bearer must never authenticate."""
+
+    async def go() -> None:
+        authority = CredentialAuthority(bootstrap_token=_BOOT)
+        calls: list[str] = []
+
+        async def bind(session_id: str, history_ref: str | None) -> None:
+            calls.append(session_id)
+
+        for empty in ("", "   "):
+            with pytest.raises(AdoptionRefused) as refused:
+                await authority.adopt(empty, _SESSION, None, bind=bind)
+            assert refused.value.status == 400
+        assert calls == []
+        assert authority.adoptable is True
+        assert authority.authenticate("") is Principal.NONE
+
+    anyio.run(go)
+
+
+def test_runner_without_binder_cannot_bind() -> None:
+    runner, _ = _runner(None)
+
+    async def go() -> None:
+        await runner.start()
+        with pytest.raises(ConversationBindingError):
+            await runner.bind_conversation(_SESSION, _HISTORY)
+        async with TestClient(TestServer(create_app(runner, bootstrap_token=_BOOT))) as client:
+            resp = await client.post("/v1/event", json=_adopting(), headers=_bearer(_BOOT))
+            assert resp.status == 503
+            assert runner.session_id == "warm-unbound"
+
+    anyio.run(go)

--- a/runner/tests/test_adoption.py
+++ b/runner/tests/test_adoption.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from typing import Any
+from urllib.parse import quote
 
 import anyio
 import pytest
@@ -647,12 +648,32 @@ def test_adoptable_history_ref_is_bound_to_the_pods_state_authority() -> None:
     assert (
         adoptable_history_ref(f"{base}/transcript/thread-1", env) == f"{base}/transcript/thread-1"
     )
+    # The worker quotes the thread key with safe="" (binding.py), so a Slack
+    # key's ":" and a nested "/" arrive percent-encoded and must pass AS SENT.
+    for key in ("C0EXAMPLE1:1700000000.000100", "slack/C0EXAMPLE1/1700000000.000100"):
+        quoted = f"{base}/transcript/{quote(key, safe='')}"
+        assert adoptable_history_ref(quoted, env) == quoted
+    assert adoptable_history_ref(f"{base}/transcript/thread-1", {"CURIE_STATE_URL": base + "/"})
     for outside in (
         "http://api.example.com/agents/other/state/transcript/thread-1",
         "http://evil.example.com/agents/acme/state/transcript/thread-1",
         "https://api.example.com/agents/acme/state/transcript/thread-1",
+        "http://api.example.com:8080/agents/acme/state/transcript/thread-1",
         f"{base}x/transcript/thread-1",
         base,
+        # Same host, prefix intact as a string, but dot segments escape the
+        # namespace once normalized: refused on the PARSED form.
+        f"{base}/../other/state/transcript/thread-1",
+        f"{base}/transcript/%2e%2e/%2e%2e/other/state/transcript/thread-1",
+        f"{base}/transcript/.%2E/../other/state/transcript/thread-1",
+        f"{base}/transcript/./thread-1",
+        f"{base}//transcript/thread-1",
+        f"{base}/transcript/",
+        # Userinfo, query and fragment are never part of a transcript key.
+        "http://user:pw@api.example.com/agents/acme/state/transcript/thread-1",
+        f"{base}/transcript/thread-1?x=1",
+        f"{base}/transcript/thread-1#frag",
+        "not a url",
     ):
         with pytest.raises(HistoryError):
             adoptable_history_ref(outside, env)

--- a/runner/tests/test_bootstrap_boot.py
+++ b/runner/tests/test_bootstrap_boot.py
@@ -1,0 +1,123 @@
+"""Bootstrap mode at boot (ADR-0122 via the BootEnv ``runner_bootstrap_token``).
+
+Two activation gates, both proven by execution rather than by reading:
+
+- the boot path selects the credential mode from the two BootEnv credentials
+  exactly as the contract documents (per-claim wins; bootstrap alone is
+  bootstrap mode; neither is the open legacy boot);
+- the bootstrap credential is removed from the process environment before any
+  child can be spawned, proven with an EXECUTING child: a real subprocess that
+  reports whether it can see the key, with a positive control (a needed token
+  stays visible) and a negative control (without the scrub the child does see
+  the bootstrap, so the assertion is not vacuous).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+import pytest
+from aci_protocol import BootEnv
+from curie_runner import RunTracer, SideEffectClassifier
+from curie_runner.__main__ import build_app_for, retire_bootstrap_from_process_env
+from curie_runner.adoption import CredentialMode
+from curie_runner.config import RunnerConfig
+from curie_runner.fake import FakeModelSession
+from curie_runner.server import AUTHORITY
+from curie_runner.session import SessionRunner
+
+BOOTSTRAP_ENV = BootEnv.env_key("runner_bootstrap_token")
+HISTORY_TOKEN_ENV = BootEnv.env_key("history_token")
+_BOOT = "pool-bootstrap-credential-0123456789"
+
+_BASE = {
+    "CURIE_PLUGIN_DIR": "/unused",
+    "CURIE_SESSION_ID": "warm-unbound",
+    "CURIE_SANDBOX_ID": "sbx-pool-1",
+    "CURIE_BUDGET": '{"max_output_tokens_per_run": 1000, "max_usd_per_day": 5.0}',
+}
+
+
+def _runner() -> SessionRunner:
+    return SessionRunner(
+        session_factory=FakeModelSession,
+        ceiling=0,
+        tracer=RunTracer(None),
+        classifier=SideEffectClassifier(),
+        trace_name="curie-run:warm-unbound",
+        session_id="warm-unbound",
+    )
+
+
+def test_config_reads_the_bootstrap_token_and_keeps_it_out_of_repr() -> None:
+    config = RunnerConfig.from_env(dict(_BASE, **{BOOTSTRAP_ENV: _BOOT}))
+    assert config.runner_bootstrap_token == _BOOT
+    assert _BOOT not in repr(config)
+    assert RunnerConfig.from_env(dict(_BASE)).runner_bootstrap_token is None
+    # A declared-but-empty value is a mis-rendered Secret and fails closed.
+    with pytest.raises(Exception, match="runner_bootstrap_token"):
+        RunnerConfig.from_env(dict(_BASE, **{BOOTSTRAP_ENV: ""}))
+
+
+@pytest.mark.parametrize(
+    ("env", "mode"),
+    [
+        ({BOOTSTRAP_ENV: _BOOT}, CredentialMode.BOOTSTRAP),
+        ({BOOTSTRAP_ENV: _BOOT, "CURIE_RUNNER_TOKEN": "per-claim-token"}, CredentialMode.PER_CLAIM),
+        ({"CURIE_RUNNER_TOKEN": "per-claim-token"}, CredentialMode.PER_CLAIM),
+        ({}, CredentialMode.OPEN),
+    ],
+)
+def test_boot_selects_the_credential_mode_from_boot_env(
+    env: dict[str, str], mode: CredentialMode
+) -> None:
+    config = RunnerConfig.from_env(dict(_BASE, **env))
+    app = build_app_for(config, _runner(), None)
+    assert app[AUTHORITY].mode is mode
+    assert app[AUTHORITY].adoptable is (mode is CredentialMode.BOOTSTRAP)
+
+
+def _child_sees(key: str) -> bool:
+    """Run a REAL child process and report whether ``key`` is in its environment."""
+
+    completed = subprocess.run(
+        [sys.executable, "-c", f"import os, sys; sys.exit(0 if {key!r} in os.environ else 7)"],
+        check=False,
+    )
+    assert completed.returncode in (0, 7), completed.returncode
+    return completed.returncode == 0
+
+
+def test_bootstrap_is_removed_from_the_executing_child_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(BOOTSTRAP_ENV, _BOOT)
+    monkeypatch.setenv(HISTORY_TOKEN_ENV, "history-token-stays")
+    # Negative control: before the scrub, a child DOES inherit the bootstrap,
+    # so the assertion below cannot pass by accident.
+    assert _child_sees(BOOTSTRAP_ENV) is True
+
+    assert retire_bootstrap_from_process_env(os.environ) is True
+
+    # The bootstrap is gone from every child spawned from now on...
+    assert _child_sees(BOOTSTRAP_ENV) is False
+    assert BOOTSTRAP_ENV not in os.environ
+    # ...while a credential the runner legitimately needs (positive control)
+    # is still inherited.
+    assert _child_sees(HISTORY_TOKEN_ENV) is True
+    # Idempotent and honest about absence.
+    assert retire_bootstrap_from_process_env(os.environ) is False
+
+
+def test_mcp_capability_probe_env_cannot_see_the_bootstrap_after_the_scrub(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The probe merges ``os.environ`` at call time; after the scrub it is clean."""
+
+    monkeypatch.setenv(BOOTSTRAP_ENV, _BOOT)
+    retire_bootstrap_from_process_env(os.environ)
+    merged = {**os.environ, **{}}
+    assert BOOTSTRAP_ENV not in merged
+    assert _BOOT not in "".join(merged.values())

--- a/runner/tests/test_signal_bootstrap.py
+++ b/runner/tests/test_signal_bootstrap.py
@@ -39,6 +39,7 @@ def _wire_process_dependencies(monkeypatch: pytest.MonkeyPatch) -> None:
         port=8080,
         harness="claude",
         runner_token=None,
+        runner_bootstrap_token=None,
     )
     monkeypatch.setenv("CURIE_FAKE_MODEL", "1")
     monkeypatch.setattr(RunnerConfig, "from_env", lambda _env: config)


### PR DESCRIPTION
## Summary

First realizing source slice for #1492, stacked on the reviewed ACI adoption-credential prerequisite (#2396, `task/overnight-adoption-contract`). It implements ADR-0116 decision 2's consumer half in the runner and the route-authority half of ADR-0122 in the worker: a pool bootstrap credential authenticates exactly one adopting `POST /v1/event` that carries `session_id`, `history_ref`, and `adoption_credential` on the existing frame; the runner binds the conversation (history load, model session replacement, attestation) BEFORE swapping the credential, retires the bootstrap outright, gates every control route on the per-conversation credential afterwards, and acks `adoption_applied: true` only on the frames of the adopting turn. The worker records the freshly minted credential on the thread's `RouteRecord` in Valkey as `pending` before the first event, moves it to `applied` through the existing claim + generation CAS, treats a missing or non-true ack as not adopted, and recovers a lost response through the runner's `/v1/status` attestation, which proves the binding's identity only, never that the lost turn completed. Adoption is cancellation-safe (a disconnected client cannot leave a half-adopted runner), a refused adoption writes nothing durable, and a caller-chosen `history_ref` is admitted only under the pod's own state authority. Cold (per-claim) and open runners are unchanged; cold route records keep their pre-field JSON shape so an older worker replica still rehydrates them.

Implemented subset of the six #1492 decisions: decision 2 (runner consumer half + worker route authority). Not in this PR: decision 1 (version-scoped templates), decision 3 (per-version pools, bootstrap Secret, RBAC `get`, the worker's Secret read), decision 4 (node bundle cache), decision 5 (residency), decision 6 (resource share), and the kernel wiring that decides which claims warm-bind. The second commit consumes the reviewed `BootEnv.runner_bootstrap_token` (#2399, protocol 0.4.6): the runner reads it into config (never repr'd), the single boot-time `create_app` call passes both credentials so the authority selects per-claim, bootstrap, or open exactly as the contract documents, and the bootstrap is popped from the process environment right after the parse and before any spawn, proven with an executing child plus negative and positive controls (the SDK builds child environments from `os.environ`; the MCP capability probe merges it). The worker gains `RunnerClient.adoption_authority`, which establishes adoption authority through the existing gated `/v1/status` route under the bootstrap bearer before any adopting event: only the runner's fixed 403 refusal is authority; an old or open runner, a per-claim runner, a forged refusal, or a transport fault fail closed and no turn starts. `adoptable_history_ref` compares parsed URLs in encoded form so the worker's percent-encoded thread key passes as sent while dot segments, userinfo, query, fragment, and any other scheme, host or port are refused. No deployed runner changes mode until a pool template actually carries the Secret (decision 3) and a warm-bind policy is wired.

The third commit wires the kernel behind that policy seam (`curie_worker.warm_bind.WarmBindPolicy`, absent in production so every claim keeps the cold path byte for byte): a non-workspace claim with a bound session identity is claimed env-free, the minted conversation credential is recorded `pending` on the route before any event, `adoption_authority` must be established by behavior before the adopting event (a failing pod is released before any event and the delivery retries within its bounded budget), the route is settled applied at the runner's 200 while the route lock is still held (a follow-up during the adopting turn steers as on the cold path), releases in the new paths are fenced on claim and generation, and the applied transition goes through a new affinity Lua predicate (live, same claim and generation, same stored credential, still pending; idempotent when already applied) so the suspend-between-read-and-write window closes inside Valkey. The route also carries the adopting delivery's event id from the pending write until the turn's terminal answer clears it (a second fenced Lua predicate), so a redelivery of that event after a crash is escalated as `adoption-unconfirmed` instead of replaying on the bound pod, while a new message on the thread continues on the ordinary path. That marker is route-lifetime, not exactly-once: a resumed cold pod after suspend/resume carries no marker, so a crashed adopting event redelivered across that cycle degrades to the cold path's existing crash-retry semantics. Any adopting turn without a terminal answer is `adoption-unconfirmed` and escalated, never replayed on the bound pod. Kernel tests run the positive path against the REAL runner app in bootstrap mode and the failure shapes against a scriptable adopting fake; the non-adopting-runner negative remains an open-mode surrogate. Review record for this sacred-module commit: two independent cross-engine rounds (REVISE on its v6 and v7 freezes) whose findings are all incorporated, and a Fable sacred-module review that verified the final v8 freeze closes them; the cross-engine delta on v8 itself timed out on the provider and was not re-run, so the last completed cross-engine verdict is the REVISE on v7 with every finding addressed, not an ACCEPT on v8. No frozen package is modified. No warm replicas are raised.

Draft, stacked, and unmerged by design: base is `task/overnight-bootstrap-contract` (#2399, which carries #2396), never `main` or `next`. the child-environment scrub is proven in-tree with an executing child (`runner/tests/test_bootstrap_boot.py`), and the kernel caller must use `adoption_authority` before `start_adopting_turn`. The probe's "old or open runner" arm in `apps/worker/tests/kernel/test_runner_client_adoption.py` is an open-mode surrogate on the NEW server code, not an execution of an actual pre-adoption runner; the real old-server negative (frozen old runner source, reachable app or subprocess, no model query observed after the refusal) is owed at kernel activation. The Lua predicate now exists and is the only writer of the applied transition; the actual old-server negative remains a recorded activation gate, not a claim of this PR.

## Related issue

Ref #1492

## Trigger

## Live proof

## Fix pin verification

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | required | runner turn loop and ACI event admission changed | fake | BLOCKED: needs a heavy slot; the boot-env producer is now consumed, so a runner booted with `CURIE_RUNNER_BOOTSTRAP_TOKEN` enters bootstrap mode. Positive: adopting event under the bootstrap returns 200 with `adoption_applied: true` on every frame and a later plain event under the bootstrap returns 401. Negative: same pod, no credential on the frame, returns 403 and starts no model turn. Source proof today: `runner/tests/test_adoption.py` (29 passed) and `runner/tests/test_bootstrap_boot.py` (7 passed, mode selection through the real boot path and the executing-child scrub) against the real app in-process. |
| local | required | worker route record crosses the Valkey boundary; worker/runner ACI wiring changed | fake | BLOCKED: dev stack not available in this run. Positive: a cold `curie local message` turn round-trips and its route rehydrates with `adoption_state: none`. Negative: a route JSON carrying `adoption_state: maybe` is refused by `RouteRecord.from_json`. Source proof today: `apps/worker/tests/sandbox/test_adoption_route.py` (12 passed on a task-owned ephemeral Valkey) and `apps/worker/tests/kernel/test_runner_client_adoption.py` (12 passed, including the authority probe against bootstrap, per-claim, retired and forged servers, plus an open-mode surrogate for an old runner; not an actual old binary). |
| local-release | n/a | no released binary, image identity, install path, version pin, or release compose changed | | |
| cluster | required (deferred) | the substrate claim path reaches sandbox claims; the chart Secret/RBAC producer lands in the decision-3 slice | fake | BLOCKED until the pool template carries a bootstrap Secret: `curie dev chart-runtime-e2e`. Positive: an env-free claim binds a warm pod and the adopting event is acked. Negative: the same pod refuses a second adoption with 401. |
| live provider | n/a | adoption swaps the runner control credential, not a model credential; no routing or provider auth changed | | |
| external integration | n/a | no Slack, GitHub, webhook, or third-party API shape touched | | |

- [ ] Every required tier above names its exact command, the commit it ran
      against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable
      negative or a second independent path.
- [ ] No required tier is left unproved; any blocked tier names its blocker in
      the table.

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands).
- [ ] Docs updated if behavior changed.
- [ ] An ADR is added under `docs/adr/` if this is an architectural decision.
