### PR TITLE
fix(cli): stop owned Helm mutation when upgrade owner exits

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -768,6 +768,7 @@ dependencies = [
  "indicatif",
  "jsonschema",
  "keyring",
+ "libc",
  "proc-macro2",
  "quote",
  "ratatui",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -80,6 +80,10 @@ serde_norway = "0.9.42"
 crypto_box = { version = "0.9.1", features = ["seal", "std"] }
 base64 = "0.23.1"
 
+[target.'cfg(target_os = "linux")'.dependencies]
+# Linux parent-death signal and exact owned-process identity checks.
+libc = "0.2"
+
 [dev-dependencies]
 # The frozen ACI types are a normal dependency of the lib, but integration test
 # crates need them by name to build a SessionStatus for the status_json contract.

--- a/cli/README.md
+++ b/cli/README.md
@@ -447,6 +447,8 @@ Wraps the umbrella Helm chart and the deployed release, the way `linkerd` or
 | `curie cluster reset-thread <agent> --thread-key <key> --yes` | Force a stuck thread's sandbox to be released via the platform API (`POST /agents/{id}/threads/{thread_key}/reset`, #737).<br>• The worker's next maintenance tick releases the thread's claim and route, so its next message cold-creates a fresh sandbox; conversation history is not deleted.<br>• Interrupts a live turn on the thread first, so it refuses without `--yes`. |
 | `curie cluster delete <agent> --yes` | End every active deployment, then delete the agent through the platform API. Destructive and irreversible: refuses without `--yes`.<br>• If the final agent deletion fails, the agent remains present but any deployments already ended stay ended. |
 
+On Linux, stopping the transactional upgrade CLI also stops its direct Helm mutation process. Use an ordinary Helm executable for this protection; wrappers, privileged executables, child processes launched by Helm plugins, and Kubernetes hook Jobs are outside it. Other platforms retain their existing process behavior. An interrupted upgrade still requires inspection of the release and hooks before recovery; this process protection does not prove that an in-flight cluster request was cancelled.
+
 ##### `curie local|cluster observability`: API-backed queries
 
 The bare commands above remain URL/surface reports. Queries are read-only and

--- a/cli/src/ops/command.rs
+++ b/cli/src/ops/command.rs
@@ -488,6 +488,38 @@ pub(crate) fn require_on_path(bin: &str) -> Result<()> {
 
 /// Run one command capturing stdout; returns (success, stdout, stderr).
 pub async fn run_capture(cmd: &OpsCommand) -> Result<(bool, String, String)> {
+    capture_process(cmd, false).await
+}
+
+/// Capture the Helm mutation owned by the transactional upgrade. On Linux its
+/// direct child is also stopped when the spawning CLI thread dies. This does
+/// not stop Kubernetes hook Jobs, plugins' descendants, or remote writers.
+pub(super) async fn run_upgrade_capture(cmd: &OpsCommand) -> Result<(bool, String, String)> {
+    capture_process(cmd, true).await
+}
+
+#[cfg(target_os = "linux")]
+fn arm_parent_death(expected_parent: libc::pid_t) -> std::io::Result<()> {
+    // The signal is preserved by ordinary exec, but is cleared by fork and
+    // privileged exec/credential changes. Supported Helm is an ordinary direct
+    // executable, not a wrapper or privilege-changing launcher. The signal is
+    // tied to the spawning thread; that thread awaits this child to completion.
+    // https://man7.org/linux/man-pages/man2/PR_SET_PDEATHSIG.2const.html
+    // SAFETY: pre_exec may not allocate or lock. These libc calls and raw errno
+    // construction perform neither. Capture the expected PID before fork and
+    // recheck after arming so a parent that already died cannot escape the guard.
+    unsafe {
+        if libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGKILL, 0, 0, 0) != 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        if libc::getppid() != expected_parent {
+            return Err(std::io::Error::from_raw_os_error(libc::ESRCH));
+        }
+    }
+    Ok(())
+}
+
+async fn capture_process(cmd: &OpsCommand, owned_upgrade: bool) -> Result<(bool, String, String)> {
     // Materialize any secret values into a private 0600 `-f` file so the secret
     // stays out of the argv/process table. `_secret_files` guards live until the
     // end of this function, so the temp files are removed after `helm` exits
@@ -500,10 +532,25 @@ pub async fn run_capture(cmd: &OpsCommand) -> Result<(bool, String, String)> {
     // reads by a timeout for a wedged daemon, and each timed-out call would
     // otherwise strand another hung `docker` client (#1031). Inert for every
     // caller that awaits to completion: the child has already exited by then.
-    let output = Command::new(&cmd.program)
+    let mut process = Command::new(&cmd.program);
+    process
         .args(cmd.argv())
         .envs(cmd.env.iter().chain(cmd.secret_env.iter()).cloned())
-        .kill_on_drop(true)
+        .kill_on_drop(true);
+    #[cfg(target_os = "linux")]
+    if owned_upgrade {
+        let expected_parent = unsafe { libc::getpid() };
+        // SAFETY: the callback only executes the non-allocating libc/errno
+        // operations documented in arm_parent_death.
+        unsafe {
+            process.pre_exec(move || arm_parent_death(expected_parent));
+        }
+    }
+    // Other platforms retain the existing subprocess behavior; no parent-death
+    // or automatic orphan-recovery guarantee is made for them.
+    #[cfg(not(target_os = "linux"))]
+    let _ = owned_upgrade;
+    let output = process
         .output()
         .await
         .with_context(|| format!("failed to invoke `{}`; is it on PATH?", cmd.program))?;
@@ -738,5 +785,28 @@ mod tests {
             !line.contains("ghp-SENTI"),
             "a ninth token character reached the printed form: {line}"
         );
+    }
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod owned_upgrade_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn parent_changed_before_guard_refuses_before_exec() {
+        let temp = tempfile::tempdir().unwrap();
+        let marker = temp.path().join("must-not-run");
+        let mut command = Command::new("/bin/sh");
+        command.args(["-c", "printf reached > \"$1\"", "sh"]);
+        command.arg(&marker);
+        // An impossible parent PID deterministically exercises the same
+        // post-arm identity check used when the real owner dies before arming.
+        // The consumer is actual spawn/exec, not an internal flag assertion.
+        unsafe {
+            command.pre_exec(|| arm_parent_death(0));
+        }
+        let error = command.output().await.unwrap_err();
+        assert_eq!(error.raw_os_error(), Some(libc::ESRCH));
+        assert!(!marker.exists());
     }
 }

--- a/cli/src/ops/upgrade.rs
+++ b/cli/src/ops/upgrade.rs
@@ -17,7 +17,9 @@ use base64::Engine;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
-use super::command::{mask_secret, plain, require_on_path, run_capture, CommonOpts, OpsCommand};
+use super::command::{
+    mask_secret, plain, require_on_path, run_capture, run_upgrade_capture, CommonOpts, OpsCommand,
+};
 
 /// Durable phases of a cluster upgrade. Order is load-bearing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -2075,7 +2077,9 @@ impl LiveHost {
             args.push(plain("--create-namespace"));
         }
         let cmd = OpsCommand::new("helm", args);
-        let (ok, _, _) = self.run(&cmd)?;
+        let (ok, _, _) = tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(run_upgrade_capture(&cmd))
+        })?;
         if !ok {
             bail!("helm upgrade to {to} failed; inspect the release and resume the same upgrade command");
         }

--- a/cli/tests/cluster_upgrade_live_driver.rs
+++ b/cli/tests/cluster_upgrade_live_driver.rs
@@ -46,8 +46,9 @@ impl Fixture {
         self.run_args(scenario, &[])
     }
 
-    fn run_args(&self, scenario: &str, extra: &[&str]) -> Output {
-        Command::new(env!("CARGO_BIN_EXE_curie"))
+    fn command(&self, scenario: &str, extra: &[&str]) -> Command {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_curie"));
+        command
             .args([
                 "--json",
                 "cluster",
@@ -68,9 +69,12 @@ impl Fixture {
                 format!("{}:/usr/bin:/bin", self.temp.path().display()),
             )
             .env("UPGRADE_DRIVER_ROOT", self.temp.path())
-            .env("UPGRADE_DRIVER_SCENARIO", scenario)
-            .output()
-            .unwrap()
+            .env("UPGRADE_DRIVER_SCENARIO", scenario);
+        command
+    }
+
+    fn run_args(&self, scenario: &str, extra: &[&str]) -> Output {
+        self.command(scenario, extra).output().unwrap()
     }
 
     fn run_status(&self) -> Output {
@@ -751,4 +755,122 @@ fn retained_repository_override_cannot_self_authorize_schema_compatibility() {
         "{}",
         String::from_utf8_lossy(&output.stdout)
     );
+}
+
+// Kernel semantics: https://man7.org/linux/man-pages/man2/PR_SET_PDEATHSIG.2const.html
+// Linux parent-death handling is an owned-process capability, not a claim about
+// remote Helm writers or the Kubernetes hook Jobs that outlive a Helm client.
+#[cfg(target_os = "linux")]
+mod owner_death {
+    use super::*;
+    use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+    use std::process::{Child, Stdio};
+    use std::time::{Duration, Instant};
+
+    struct OwnedProcesses {
+        cli: Child,
+        helm: Option<OwnedFd>,
+    }
+
+    impl Drop for OwnedProcesses {
+        fn drop(&mut self) {
+            let _ = self.cli.kill();
+            let _ = self.cli.wait();
+            if let Some(helm) = &self.helm {
+                // A pidfd targets this exact owned child even if its numeric PID
+                // has been reused by the time a failed assertion unwinds.
+                unsafe {
+                    libc::syscall(
+                        libc::SYS_pidfd_send_signal,
+                        helm.as_raw_fd(),
+                        libc::SIGKILL,
+                        std::ptr::null::<libc::siginfo_t>(),
+                        0,
+                    );
+                }
+            }
+        }
+    }
+
+    fn stopped(fd: &OwnedFd) -> bool {
+        let mut event = libc::pollfd {
+            fd: fd.as_raw_fd(),
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        // pidfd readiness means the process exited, including an unreaped
+        // zombie. It does not depend on the host PID 1 reaping promptly.
+        unsafe { libc::poll(&mut event, 1, 0) == 1 }
+    }
+
+    fn killed_owner_stops_helm(signal: i32) {
+        let fixture = Fixture::new();
+        let stdout = fs::File::create(fixture.path("cli.stdout")).unwrap();
+        let stderr = fs::File::create(fixture.path("cli.stderr")).unwrap();
+        let cli = fixture
+            .command("owner-death", &[])
+            .env("TMPDIR", fixture.temp.path())
+            .stdin(Stdio::null())
+            .stdout(stdout)
+            .stderr(stderr)
+            .spawn()
+            .unwrap();
+        let mut processes = OwnedProcesses { cli, helm: None };
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while !fixture.path("helm-owner.json").exists() {
+            assert!(
+                processes.cli.try_wait().unwrap().is_none(),
+                "CLI ended before Helm: {}",
+                fs::read_to_string(fixture.path("cli.stdout")).unwrap()
+            );
+            assert!(Instant::now() < deadline, "owned Helm did not start");
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        let owner: Value =
+            serde_json::from_slice(&fs::read(fixture.path("helm-owner.json")).unwrap()).unwrap();
+        assert_eq!(
+            owner["parent"].as_u64(),
+            Some(u64::from(processes.cli.id()))
+        );
+        let helm_pid = owner["pid"].as_i64().unwrap() as libc::pid_t;
+        let fd = unsafe { libc::syscall(libc::SYS_pidfd_open, helm_pid, 0) } as i32;
+        assert!(
+            fd >= 0,
+            "opening owned Helm pidfd: {}",
+            std::io::Error::last_os_error()
+        );
+        processes.helm = Some(unsafe { OwnedFd::from_raw_fd(fd) });
+        assert!(!stopped(processes.helm.as_ref().unwrap()));
+        // This is the actual CLI process, not a dropped future or a stand-in
+        // parent. SIGTERM additionally crosses its installed cleanup handler.
+        assert_eq!(
+            unsafe { libc::kill(processes.cli.id() as libc::pid_t, signal) },
+            0
+        );
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while processes.cli.try_wait().unwrap().is_none() {
+            assert!(Instant::now() < deadline, "CLI did not stop after signal");
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        fs::write(fixture.path("release-helm"), b"owner stopped").unwrap();
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while !stopped(processes.helm.as_ref().unwrap()) {
+            assert!(Instant::now() < deadline, "Helm survived its owning CLI");
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(
+            !fixture.path("after-owner-mutation").exists(),
+            "Helm continued to mutate after its actual CLI owner died"
+        );
+    }
+
+    #[test]
+    fn sigkill_of_upgrade_cli_stops_owned_helm_before_later_mutation() {
+        killed_owner_stops_helm(libc::SIGKILL);
+    }
+
+    #[test]
+    fn sigterm_of_upgrade_cli_stops_owned_helm_before_later_mutation() {
+        killed_owner_stops_helm(libc::SIGTERM);
+    }
 }

--- a/cli/tests/cluster_upgrade_live_driver.rs
+++ b/cli/tests/cluster_upgrade_live_driver.rs
@@ -758,119 +758,47 @@ fn retained_repository_override_cannot_self_authorize_schema_compatibility() {
 }
 
 // Kernel semantics: https://man7.org/linux/man-pages/man2/PR_SET_PDEATHSIG.2const.html
-// Linux parent-death handling is an owned-process capability, not a claim about
-// remote Helm writers or the Kubernetes hook Jobs that outlive a Helm client.
+// Keep the process supervisor test-only so reversing the product's new libc
+// dependency still compiles and fails on the actual unguarded behavior.
 #[cfg(target_os = "linux")]
-mod owner_death {
-    use super::*;
-    use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
-    use std::process::{Child, Stdio};
-    use std::time::{Duration, Instant};
+fn assert_upgrade_owner_death(signal: &str) {
+    let fixture = Fixture::new();
+    fs::write(
+        fixture.path("owner-supervisor.py"),
+        include_str!("data/upgrade-owner-supervisor.py"),
+    )
+    .unwrap();
+    let command = fixture.command("owner-death", &[]);
+    let output = Command::new("/usr/bin/python3")
+        .arg(fixture.path("owner-supervisor.py"))
+        .arg(signal)
+        .arg(env!("CARGO_BIN_EXE_curie"))
+        .args(command.get_args())
+        .envs(command.get_envs().map(|(key, value)| (key, value.unwrap())))
+        .env("TMPDIR", fixture.temp.path())
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "owned process proof failed: {} / {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let proof: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(proof["owner_exited"], true);
+    assert_eq!(proof["direct_child_exited"], true);
+    assert_eq!(proof["after_owner_mutation"], false);
+    assert_eq!(proof["cleanup_complete"], true);
+}
 
-    struct OwnedProcesses {
-        cli: Child,
-        helm: Option<OwnedFd>,
-    }
+#[cfg(target_os = "linux")]
+#[test]
+fn sigkill_of_upgrade_cli_stops_owned_helm_before_later_mutation() {
+    assert_upgrade_owner_death("SIGKILL");
+}
 
-    impl Drop for OwnedProcesses {
-        fn drop(&mut self) {
-            let _ = self.cli.kill();
-            let _ = self.cli.wait();
-            if let Some(helm) = &self.helm {
-                // A pidfd targets this exact owned child even if its numeric PID
-                // has been reused by the time a failed assertion unwinds.
-                unsafe {
-                    libc::syscall(
-                        libc::SYS_pidfd_send_signal,
-                        helm.as_raw_fd(),
-                        libc::SIGKILL,
-                        std::ptr::null::<libc::siginfo_t>(),
-                        0,
-                    );
-                }
-            }
-        }
-    }
-
-    fn stopped(fd: &OwnedFd) -> bool {
-        let mut event = libc::pollfd {
-            fd: fd.as_raw_fd(),
-            events: libc::POLLIN,
-            revents: 0,
-        };
-        // pidfd readiness means the process exited, including an unreaped
-        // zombie. It does not depend on the host PID 1 reaping promptly.
-        unsafe { libc::poll(&mut event, 1, 0) == 1 }
-    }
-
-    fn killed_owner_stops_helm(signal: i32) {
-        let fixture = Fixture::new();
-        let stdout = fs::File::create(fixture.path("cli.stdout")).unwrap();
-        let stderr = fs::File::create(fixture.path("cli.stderr")).unwrap();
-        let cli = fixture
-            .command("owner-death", &[])
-            .env("TMPDIR", fixture.temp.path())
-            .stdin(Stdio::null())
-            .stdout(stdout)
-            .stderr(stderr)
-            .spawn()
-            .unwrap();
-        let mut processes = OwnedProcesses { cli, helm: None };
-        let deadline = Instant::now() + Duration::from_secs(10);
-        while !fixture.path("helm-owner.json").exists() {
-            assert!(
-                processes.cli.try_wait().unwrap().is_none(),
-                "CLI ended before Helm: {}",
-                fs::read_to_string(fixture.path("cli.stdout")).unwrap()
-            );
-            assert!(Instant::now() < deadline, "owned Helm did not start");
-            std::thread::sleep(Duration::from_millis(10));
-        }
-        let owner: Value =
-            serde_json::from_slice(&fs::read(fixture.path("helm-owner.json")).unwrap()).unwrap();
-        assert_eq!(
-            owner["parent"].as_u64(),
-            Some(u64::from(processes.cli.id()))
-        );
-        let helm_pid = owner["pid"].as_i64().unwrap() as libc::pid_t;
-        let fd = unsafe { libc::syscall(libc::SYS_pidfd_open, helm_pid, 0) } as i32;
-        assert!(
-            fd >= 0,
-            "opening owned Helm pidfd: {}",
-            std::io::Error::last_os_error()
-        );
-        processes.helm = Some(unsafe { OwnedFd::from_raw_fd(fd) });
-        assert!(!stopped(processes.helm.as_ref().unwrap()));
-        // This is the actual CLI process, not a dropped future or a stand-in
-        // parent. SIGTERM additionally crosses its installed cleanup handler.
-        assert_eq!(
-            unsafe { libc::kill(processes.cli.id() as libc::pid_t, signal) },
-            0
-        );
-        let deadline = Instant::now() + Duration::from_secs(5);
-        while processes.cli.try_wait().unwrap().is_none() {
-            assert!(Instant::now() < deadline, "CLI did not stop after signal");
-            std::thread::sleep(Duration::from_millis(10));
-        }
-        fs::write(fixture.path("release-helm"), b"owner stopped").unwrap();
-        let deadline = Instant::now() + Duration::from_secs(5);
-        while !stopped(processes.helm.as_ref().unwrap()) {
-            assert!(Instant::now() < deadline, "Helm survived its owning CLI");
-            std::thread::sleep(Duration::from_millis(10));
-        }
-        assert!(
-            !fixture.path("after-owner-mutation").exists(),
-            "Helm continued to mutate after its actual CLI owner died"
-        );
-    }
-
-    #[test]
-    fn sigkill_of_upgrade_cli_stops_owned_helm_before_later_mutation() {
-        killed_owner_stops_helm(libc::SIGKILL);
-    }
-
-    #[test]
-    fn sigterm_of_upgrade_cli_stops_owned_helm_before_later_mutation() {
-        killed_owner_stops_helm(libc::SIGTERM);
-    }
+#[cfg(target_os = "linux")]
+#[test]
+fn sigterm_of_upgrade_cli_stops_owned_helm_before_later_mutation() {
+    assert_upgrade_owner_death("SIGTERM");
 }

--- a/cli/tests/data/upgrade-driver.py
+++ b/cli/tests/data/upgrade-driver.py
@@ -8,6 +8,7 @@ import json
 import os
 import pathlib
 import sys
+import time
 
 root = pathlib.Path(os.environ["UPGRADE_DRIVER_ROOT"])
 scenario = os.environ["UPGRADE_DRIVER_SCENARIO"]
@@ -250,6 +251,16 @@ if program == "helm":
                 )
             )
     elif args[0] == "upgrade":
+        if scenario == "owner-death":
+            witness = root / "helm-owner.pending"
+            witness.write_text(json.dumps({"pid": os.getpid(), "parent": os.getppid()}))
+            witness.rename(root / "helm-owner.json")
+            deadline = time.monotonic() + 15
+            while not (root / "release-helm").exists():
+                if time.monotonic() > deadline:
+                    sys.exit(70)
+                time.sleep(0.01)
+            (root / "after-owner-mutation").write_text("mutation after owner termination")
         if scenario == "helm-hook-fails":
             sys.exit(1)
         if "-f" in args:

--- a/cli/tests/data/upgrade-owner-supervisor.py
+++ b/cli/tests/data/upgrade-owner-supervisor.py
@@ -1,0 +1,93 @@
+#!/usr/bin/python3
+"""Own the actual CLI and its exact Helm child across an owner-death test."""
+
+import json
+import os
+import select
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+def exited(fd):
+    poll = select.poll()
+    poll.register(fd, select.POLLIN)
+    return bool(poll.poll(0))
+
+
+def terminate(fd):
+    if fd is not None:
+        try:
+            signal.pidfd_send_signal(fd, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+
+
+def interrupted(signum, frame):
+    raise KeyboardInterrupt("owned process test interrupted")
+
+
+def main():
+    # pidfds keep both observation and cleanup bound to the exact processes,
+    # even if a numeric PID is reused while an assertion unwinds.
+    root = Path(os.environ["UPGRADE_DRIVER_ROOT"])
+    assert Path(os.environ["TMPDIR"]) == root
+    assert sys.argv[1] in ("SIGKILL", "SIGTERM")
+    cli = None
+    cli_fd = None
+    helm_fd = None
+    proof = {}
+    signal.signal(signal.SIGTERM, interrupted)
+    signal.signal(signal.SIGINT, interrupted)
+    try:
+        with (root / "cli.stdout").open("w") as stdout, (root / "cli.stderr").open("w") as stderr:
+            cli = subprocess.Popen(
+                sys.argv[2:], stdin=subprocess.DEVNULL, stdout=stdout, stderr=stderr
+            )
+            cli_fd = os.pidfd_open(cli.pid)
+            deadline = time.monotonic() + 10
+            while not (root / "helm-owner.json").exists():
+                assert cli.poll() is None, "CLI ended before its owned Helm started"
+                assert time.monotonic() < deadline, "owned Helm did not start"
+                time.sleep(0.01)
+            owner = json.loads((root / "helm-owner.json").read_text())
+            assert owner["parent"] == cli.pid, "Helm must be the direct CLI child"
+            helm_fd = os.pidfd_open(owner["pid"])
+            assert not exited(helm_fd)
+            signal.pidfd_send_signal(cli_fd, getattr(signal, sys.argv[1]))
+            cli.wait(timeout=5)
+            proof["owner_exited"] = True
+            (root / "release-helm").write_text("owner stopped")
+            deadline = time.monotonic() + 5
+            while not exited(helm_fd):
+                assert time.monotonic() < deadline, "Helm survived its owning CLI"
+                time.sleep(0.01)
+            proof["direct_child_exited"] = True
+            proof["after_owner_mutation"] = (root / "after-owner-mutation").exists()
+            assert not proof["after_owner_mutation"], (
+                "Helm continued to mutate after its actual CLI owner died"
+            )
+    finally:
+        signal.signal(signal.SIGTERM, signal.SIG_IGN)
+        signal.signal(signal.SIGINT, signal.SIG_IGN)
+        terminate(cli_fd)
+        if cli is not None:
+            if cli_fd is None:
+                cli.kill()
+            cli.wait(timeout=5)
+        terminate(helm_fd)
+        deadline = time.monotonic() + 5
+        while helm_fd is not None and not exited(helm_fd):
+            assert time.monotonic() < deadline, "owned Helm cleanup failed"
+            time.sleep(0.01)
+        for fd in (cli_fd, helm_fd):
+            if fd is not None:
+                os.close(fd)
+        proof["cleanup_complete"] = True
+    print(json.dumps(proof))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Killing the transactional upgrade CLI could leave its direct Helm mutation running. On Linux, that child now receives a kernel parent-death signal, with a parent identity check before exec to cover an owner that already exited. Ordinary subprocess callers keep their existing behavior.

This is a prerequisite in the upgrade stack, based on #2391 at `7b9a145fd3f89005208120eeb2b06319efc33613`; candidate `b6fef384f9ce314c100e8ce3be206a9a7f759c25`. It remains a draft. It does not establish automatic rollback, remote ownership, Kubernetes hook cancellation, cancellation of in-flight requests, or complete transactional upgrade acceptance. Wrappers, privileged executables, plugin descendants and other operating systems are outside this protection.

## Related issue

Ref #2301. Follows the accepted upgrade boundary in ADR 0142; no frozen protocol change.

## Fix pin verification

Fix pin: cli/tests/cluster_upgrade_live_driver.rs::sigkill_of_upgrade_cli_stops_owned_helm_before_later_mutation

## Verification

Actual CLI SIGKILL and SIGTERM cases both failed before the change because the owned Helm process performed a later mutation. Both now pass; all 42 external-process upgrade-driver tests pass. A separate execution test rejects a changed parent identity before the shell command can run. Test cleanup uses exact process handles and an owned temporary directory.

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, fixture Ruff and docs checks pass. The complete Rust suite with mandatory Valkey passes 2,302 tests across 89 test targets against the reviewed source; the final README changes only move its paragraph after the command table and clarify “mutation process.” Independent code, scope and security reviews are complete.

## End-to-end verification

| Tier | Required / n/a | Reason | Mode | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | No plugin packaging, runner turn loop or ACI change. | — | — |
| local | required | Transactional CLI process lifecycle. | fake | Actual CLI external-process controls pass; `CURIE_E2E_TIERS=local curie dev e2e-ladder` remains pending for the combined upgrade candidate. |
| local-release | required | Retained upgrade stack reaches installation and version identity. | fake | `CURIE_E2E_TIERS=local-release curie dev e2e-ladder` remains pending for the combined candidate. |
| cluster | required | The guarded command performs a real Helm upgrade. | fake | Exact real Helm interruption and `CURIE_E2E_TIERS=cluster curie dev e2e-ladder` remain pending; process fixtures do not prove hook or database recovery. |
| live provider | n/a | This prerequisite does not change model routing, provider credentials or accounting. | — | — |
| external integration | n/a | No Slack, webhook, OAuth or third-party API shape changes. | — | — |

- [ ] Every required tier has exact-candidate evidence.
- [x] The source behavior has a positive plus actual owner-death and before-exec refusal controls.
- [ ] No required tier remains unproved. The pending rows above block completion; this draft does not close the issue.

## Checklist

- [x] Scoped source tests and full mandatory Rust suite pass.
- [x] Documentation describes the implemented scope and limits.
- [x] Existing accepted architecture is preserved.
