### PR TITLE
Run live approval proof on named policy and catalog changes

### DIFF
--- a/.github/workflows/sdk-approval-gate.yaml
+++ b/.github/workflows/sdk-approval-gate.yaml
@@ -11,7 +11,11 @@ on:
     paths:
       - "uv.lock"
       - ".github/workflows/sdk-approval-gate.yaml"
-      - "tools/sdk-lock-gate/**"
+      - "tools/sdk-lock-gate/detect.py"
+      - "tools/sdk-lock-gate/run-proof.py"
+      - "tools/sdk-lock-gate/tests/test_approval_paths.py"
+      - "tools/sdk-lock-gate/tests/test_live_proof_consumer.py"
+      - "tools/sdk-lock-gate/tests/test_sdk_lock_gate.py"
       - "runner/src/curie_runner/__main__.py"
       - "runner/src/curie_runner/adapter.py"
       - "runner/src/curie_runner/approval.py"

--- a/.github/workflows/sdk-approval-gate.yaml
+++ b/.github/workflows/sdk-approval-gate.yaml
@@ -1,29 +1,9 @@
 name: SDK approval-gate live proof
 
-# The approval gate has escaped to production three times (#245, #453, #1852).
-# Every automated proof in the tree -- runner/tests/test_approval_gate_enforcement.py,
-# runner/tests/test_gate_shadowing.py, and (as of #2094) the live ladder case
-# case_live_approval_gate_denies -- sits behind FakeModelSession or, for the
-# live case, behind the nightly's cron trigger. None of them re-run on the
-# event that actually produces the regression class #1852 fixed: a bump of
-# `claude-agent-sdk`, the third-party dependency that owns how the real Claude
-# Agent SDK dispatches permission rules against a real model. FakeModelSession
-# cannot exhibit either failure mode (the prose-only-deny hang, or the
-# executed-anyway race) because both are properties of the real SDK's
-# scheduling against a real model, not of anything this repo's code decides.
-#
-# `runner/pyproject.toml` declares `claude-agent-sdk>=0.2.135` -- a floor, not
-# a pin -- and Dependabot groups every Python bump into one weekly PR whose
-# only gate is the offline fake suite above. So today, a `claude-agent-sdk`
-# bump that reintroduces #1852 merges on green CI and is only caught by the
-# next 08:00 UTC nightly, or by a human noticing in production.
-#
-# This workflow closes that gap without paying live-model cost on every PR:
-# `detect` (job below) is a cheap, no-build TOML diff that fires only when the
-# `claude-agent-sdk` entry in `uv.lock` actually changed (tools/sdk-lock-gate);
-# the live job runs the SAME skill-tier ladder case the nightly runs, live,
-# but only when `detect` says so. See the plan at
-# .projects/plans/task-2094-live-approval-gate.md for the full design record.
+# Real SDK scheduling can regress when the SDK lock entry or Curie's named
+# approval/catalog enforcement paths change (#2094, #2308). Keep detection cheap
+# and exact; unrelated runner work and unrelated dependency bumps cost no model
+# run. This workflow is path-triggered, never a globally required PR check.
 
 on:
   pull_request:
@@ -32,19 +12,33 @@ on:
       - "uv.lock"
       - ".github/workflows/sdk-approval-gate.yaml"
       - "tools/sdk-lock-gate/**"
+      - "runner/src/curie_runner/__main__.py"
+      - "runner/src/curie_runner/adapter.py"
+      - "runner/src/curie_runner/approval.py"
+      - "runner/src/curie_runner/config.py"
+      - "runner/src/curie_runner/connectors.py"
+      - "runner/src/curie_runner/hooks.py"
+      - "runner/src/curie_runner/session.py"
+      - "runner/tests/fixtures/mcp_tool_capability_server.py"
+      - "runner/tests/test_approval.py"
+      - "runner/tests/test_approval_gate_enforcement.py"
+      - "runner/tests/test_connectors.py"
+      - "runner/tests/test_gate_e2e.py"
+      - "runner/tests/test_gate_shadowing.py"
+      - "runner/tests/test_hooks.py"
+      - "runner/tests/test_hosted_mcp_approval_catalog.py"
+      - "runner/tests/test_ladder_approval_gate_case.py"
+      - "runner/tests/test_live.py"
+      - "runner/tests/test_mcp_tool_capability.py"
 
 permissions:
   contents: read
 
 jobs:
-  # Cheap and cacheless: no build, no Docker, no credential. Materializes the
-  # base and head uv.lock and asks the pure detector in tools/sdk-lock-gate
-  # whether the resolved claude-agent-sdk entry (or any other line naming it)
-  # actually changed. Fails open (reports changed=true) on anything it cannot
-  # parse -- a missing base file, malformed TOML -- because this gate must
-  # never silently go dark; over-triggering only costs one live run.
+  # The lock fingerprint preserves #2094. Malformed locks demand a live proof;
+  # unreadable git/path detection fails the cheap job and cannot emit a skip.
   detect:
-    name: Detect a claude-agent-sdk lock change
+    name: Detect SDK or approval policy changes
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -54,35 +48,36 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      # fetch-depth: 0 pulls this PR's own ref history; the base branch tip
-      # is not guaranteed to be present locally until fetched explicitly.
-      - name: Fetch the base ref
-        run: git fetch origin "${{ github.base_ref }}"
-      # git show can fail legitimately (uv.lock did not exist on the base --
-      # e.g. it was just added). Do not let that fail the step: leave old.lock
-      # absent and let the detector's own fail-open rule (old_text is None ->
-      # changed=true) decide, per tools/sdk-lock-gate's contract.
-      - name: Materialize the base and head uv.lock
+      - name: Materialize the exact PR change and lock inputs
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
-          if git show "origin/${{ github.base_ref }}:uv.lock" > old.lock 2>/dev/null; then
-            echo "base uv.lock materialized"
-          else
-            rm -f old.lock
-            echo "uv.lock is absent on the base ref; the detector treats this as a change (fail-open)"
-          fi
+          git cat-file -e "$BASE_SHA^{commit}"
+          git cat-file -e "$HEAD_SHA^{commit}"
+          git diff --name-only --no-renames -z "$BASE_SHA...$HEAD_SHA" > changed-paths
+          # Absent locks retain #2094's conservative run-proof decision.
+          for side in old new; do
+            if [[ "$side" == old ]]; then ref="$BASE_SHA"; else ref="$HEAD_SHA"; fi
+            if git cat-file -e "$ref:uv.lock" 2>/dev/null; then
+              git show "$ref:uv.lock" > "$side.lock"
+            else
+              rm -f "$side.lock"
+            fi
+          done
       - id: detect
-        name: Compare the claude-agent-sdk lock entry
-        run: python3 tools/sdk-lock-gate/detect.py --old-file old.lock --new-file uv.lock
+        name: Compare the SDK entry and named enforcement paths
+        run: python3 tools/sdk-lock-gate/detect.py --old-file old.lock --new-file new.lock --changed-paths-file changed-paths
 
   # Runs the SAME skill-tier live case the nightly runs
   # (case_live_approval_gate_denies in cli/scripts/e2e-ladder.sh, #2094), on
-  # demand, only when detect says the claude-agent-sdk entry actually moved.
+  # demand, only when detect says the SDK entry or a named enforcement path moved.
   # Gated on BOTH `needs: [detect]` and the `if:` below -- needs alone still
   # runs this job (skipped or not) on every uv.lock touch; the if: alone,
   # without needs, would evaluate before detect's output exists.
   live-approval-gate:
-    name: Live approval-gate proof (claude-agent-sdk changed)
+    name: Live approval-gate proof (SDK or approval policy changed)
     needs: [detect]
     if: needs.detect.outputs.changed == 'true'
     runs-on: ubuntu-latest
@@ -130,7 +125,7 @@ jobs:
             {
               echo "### SDK approval-gate live proof DID NOT RUN -- this check is red on purpose"
               echo ""
-              echo "This PR changes the \`claude-agent-sdk\` entry in \`uv.lock\`. That dependency owns how the real Claude Agent SDK dispatches permission rules against a real model, so it is the one change that can reintroduce the approval-gate escapes of #245, #453 and #1852 -- and no offline fake-model test in this repo can detect either failure mode."
+              echo "This PR changes the SDK lock entry or a named approval/catalog enforcement path. Those changes can regress real SDK permission dispatch; offline fake-model tests cannot establish the live proof."
               echo ""
               echo "The live approval-gate proof could not run: **no model credential was available to this run**. \`OPENROUTER_API_KEY\` is empty here, which happens for a fork PR (a \`pull_request\` run from a fork is never issued repository secrets) and for a Dependabot PR (those runs read the separate Dependabot secret store). Re-running this same workflow will not change that."
               echo ""
@@ -195,4 +190,4 @@ jobs:
           CURIE_E2E_LIVE: "1"
           CURIE_CREDENTIALS: ${{ secrets.OPENROUTER_API_KEY }}
           CURIE_MODEL: z-ai/glm-5.2
-        run: bash cli/scripts/e2e-ladder.sh
+        run: python3 tools/sdk-lock-gate/run-proof.py

--- a/tools/sdk-lock-gate/detect.py
+++ b/tools/sdk-lock-gate/detect.py
@@ -17,6 +17,10 @@ mean different bytes execute the permission dispatch, and all of them return ``T
 For the same reason the detector fails **open**: a missing side or a lock that is not valid
 TOML returns ``True``. A corrupt lock is somebody else's CI failure and must never silently
 disarm this gate.
+
+The workflow also supplies git changed paths (#2308). Named approval and MCP
+enforcement paths force the proof with an unchanged lock; unrelated paths do not.
+Malformed path input fails detection, never a successful changed=false skip.
 """
 
 from __future__ import annotations
@@ -30,6 +34,53 @@ from typing import Any
 
 SDK_NAME = "claude-agent-sdk"
 PACKAGE_HEADER = "[[package]]"
+
+# Exact enforcement and catalog observation paths, not all runner changes (#2308).
+# The workflow's outer paths mirror these; consumer tests pin both boundaries.
+APPROVAL_PATHS = frozenset(
+    {
+        "runner/src/curie_runner/approval.py",
+        "runner/src/curie_runner/adapter.py",
+        "runner/src/curie_runner/__main__.py",
+        "runner/src/curie_runner/connectors.py",
+        "runner/src/curie_runner/hooks.py",
+        "runner/src/curie_runner/config.py",
+        "runner/src/curie_runner/session.py",
+        "runner/tests/test_approval.py",
+        "runner/tests/test_approval_gate_enforcement.py",
+        "runner/tests/test_gate_shadowing.py",
+        "runner/tests/test_gate_e2e.py",
+        "runner/tests/test_hooks.py",
+        "runner/tests/test_connectors.py",
+        "runner/tests/test_mcp_tool_capability.py",
+        "runner/tests/test_hosted_mcp_approval_catalog.py",
+        "runner/tests/test_live.py",
+        "runner/tests/test_ladder_approval_gate_case.py",
+        "runner/tests/fixtures/mcp_tool_capability_server.py",
+        ".github/workflows/sdk-approval-gate.yaml",
+    }
+)
+
+
+def approval_paths_changed(path: Path) -> bool:
+    """Consume git's NUL terminated path stream, including deleted/renamed paths.
+
+    Invalid or unreadable input raises, making detect fail instead of emitting a
+    successful skip. Empty is git's valid representation of no changed files.
+    """
+    raw = path.read_bytes()
+    if raw and not raw.endswith(b"\0"):
+        raise ValueError("changed paths must be NUL terminated")
+    paths = raw[:-1].decode("utf-8").split("\0") if raw else []
+    for name in paths:
+        if (
+            not name
+            or name.startswith("/")
+            or any(part in {".", "..", ""} for part in name.split("/"))
+        ):
+            raise ValueError("changed paths contain an invalid repository path")
+    return any(name in APPROVAL_PATHS or name.startswith("tools/sdk-lock-gate/") for name in paths)
+
 
 # (parsed SDK tables, sorted other lines naming the SDK). Comparable, not hashable:
 # the tables stay nested dicts and are compared with ``==``, never hashed.
@@ -144,12 +195,17 @@ def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--old-file", required=True, type=Path)
     parser.add_argument("--new-file", required=True, type=Path)
+    parser.add_argument("--changed-paths-file", type=Path)
     return parser
 
 
 def _run() -> None:
     args = _parser().parse_args()
     changed = sdk_entry_changed(_read(args.old_file), _read(args.new_file))
+    if args.changed_paths_file is not None:
+        # Always parse even if the SDK moved: malformed detect input is a failure.
+        policy_changed = approval_paths_changed(args.changed_paths_file)
+        changed = changed or policy_changed
 
     output_path = os.environ.get("GITHUB_OUTPUT")
     if not output_path:
@@ -159,7 +215,7 @@ def _run() -> None:
 
 
 def main() -> int:
-    """Write the verdict and always exit 0; the workflow reads the output, not the code."""
+    """Write the verdict; unreadable detection input fails the workflow job."""
     _run()
     return 0
 

--- a/tools/sdk-lock-gate/detect.py
+++ b/tools/sdk-lock-gate/detect.py
@@ -58,6 +58,11 @@ APPROVAL_PATHS = frozenset(
         "runner/tests/test_ladder_approval_gate_case.py",
         "runner/tests/fixtures/mcp_tool_capability_server.py",
         ".github/workflows/sdk-approval-gate.yaml",
+        "tools/sdk-lock-gate/detect.py",
+        "tools/sdk-lock-gate/run-proof.py",
+        "tools/sdk-lock-gate/tests/test_approval_paths.py",
+        "tools/sdk-lock-gate/tests/test_live_proof_consumer.py",
+        "tools/sdk-lock-gate/tests/test_sdk_lock_gate.py",
     }
 )
 
@@ -79,7 +84,7 @@ def approval_paths_changed(path: Path) -> bool:
             or any(part in {".", "..", ""} for part in name.split("/"))
         ):
             raise ValueError("changed paths contain an invalid repository path")
-    return any(name in APPROVAL_PATHS or name.startswith("tools/sdk-lock-gate/") for name in paths)
+    return any(name in APPROVAL_PATHS for name in paths)
 
 
 # (parsed SDK tables, sorted other lines naming the SDK). Comparable, not hashable:

--- a/tools/sdk-lock-gate/run-proof.py
+++ b/tools/sdk-lock-gate/run-proof.py
@@ -1,0 +1,60 @@
+"""Run the existing live skill ladder and require its approval case observations.
+
+A zero exit without reaching the case is not proof. In particular, a reset/setup
+failure before the case must remain a named failure (#2221, #2308). These markers
+come from the actual ladder assertions, not model response prose. This does not
+replace those assertions or certify a replay as live provider evidence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+START = "=== case: a live gated tool call is denied and the turn parks (#2094) ==="
+PARK = "the gated turn parked: status=awaiting-approval finalized=false approval_summary=present"
+ABSENT = "the gated command did not run: /tmp/curie-2094-canary is absent"
+
+
+def fail(message: str) -> int:
+    print(f"::error title=SDK approval-gate proof incomplete::{message}", file=sys.stderr)
+    return 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--ladder", type=Path, default=Path("cli/scripts/e2e-ladder.sh"))
+    args = parser.parse_args()
+    if os.environ.get("CURIE_E2E_LIVE") != "1" or os.environ.get("CURIE_E2E_TIERS") != "skill":
+        return fail("CURIE_E2E_LIVE=1 and CURIE_E2E_TIERS=skill are required")
+    observed: set[str] = set()
+    with subprocess.Popen(
+        ["bash", str(args.ladder)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+    ) as process:
+        assert process.stdout is not None
+        for line in process.stdout:
+            print(line, end="", flush=True)
+            marker = line.rstrip("\r\n")
+            if marker in {START, PARK, ABSENT}:
+                observed.add(marker)
+        code = process.wait()
+    if START not in observed:
+        return fail(f"runner setup/reset failed before approval-gate case; ladder exit {code}")
+    if code != 0:
+        return fail(f"ladder failed with exit {code}; the live proof did not pass")
+    if PARK not in observed or ABSENT not in observed:
+        return fail(
+            "approval-gate case did not observe both a parked turn and an absent side effect"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/sdk-lock-gate/tests/test_approval_paths.py
+++ b/tools/sdk-lock-gate/tests/test_approval_paths.py
@@ -76,6 +76,9 @@ def test_each_enforcement_path_runs_live_with_unchanged_lock(tmp_path: Path, pat
     "path",
     [
         "README.md",
+        "tools/sdk-lock-gate/README.md",
+        "tools/sdk-lock-gate/tests/README.md",
+        "tools/sdk-lock-gate/detect.py.bak",
         "runner/src/curie_runner/otel.py",
         "runner/tests/test_otel.py",
         "runner/src/curie_runner/approval.py.bak",
@@ -92,6 +95,9 @@ def test_unrelated_paths_do_not_run_live(tmp_path: Path, path: str) -> None:
         ".github/workflows/sdk-approval-gate.yaml",
         "tools/sdk-lock-gate/detect.py",
         "tools/sdk-lock-gate/tests/test_approval_paths.py",
+        "tools/sdk-lock-gate/run-proof.py",
+        "tools/sdk-lock-gate/tests/test_live_proof_consumer.py",
+        "tools/sdk-lock-gate/tests/test_sdk_lock_gate.py",
     ],
 )
 def test_gate_changes_reprove_the_guard(tmp_path: Path, path: str) -> None:
@@ -155,7 +161,11 @@ def test_workflow_outer_filter_is_only_named_policy_and_gate_paths() -> None:
     assert set(workflow[True]["pull_request"]["paths"]) == set(POLICY_PATHS) | {
         "uv.lock",
         ".github/workflows/sdk-approval-gate.yaml",
-        "tools/sdk-lock-gate/**",
+        "tools/sdk-lock-gate/detect.py",
+        "tools/sdk-lock-gate/run-proof.py",
+        "tools/sdk-lock-gate/tests/test_approval_paths.py",
+        "tools/sdk-lock-gate/tests/test_live_proof_consumer.py",
+        "tools/sdk-lock-gate/tests/test_sdk_lock_gate.py",
     }
 
 

--- a/tools/sdk-lock-gate/tests/test_approval_paths.py
+++ b/tools/sdk-lock-gate/tests/test_approval_paths.py
@@ -1,0 +1,209 @@
+"""Execute the workflow detector with real git changes and its output consumer."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[3]
+DETECTOR = ROOT / "tools/sdk-lock-gate/detect.py"
+WORKFLOW = ROOT / ".github/workflows/sdk-approval-gate.yaml"
+LOCK = 'version = 1\n[[package]]\nname = "claude-agent-sdk"\nversion = "0.2.135"\n'
+
+# Deliberately independent of the detector: removing one production path must red.
+POLICY_PATHS = (
+    "runner/src/curie_runner/approval.py",
+    "runner/src/curie_runner/adapter.py",
+    "runner/src/curie_runner/__main__.py",
+    "runner/src/curie_runner/connectors.py",
+    "runner/src/curie_runner/hooks.py",
+    "runner/src/curie_runner/config.py",
+    "runner/src/curie_runner/session.py",
+    "runner/tests/test_approval.py",
+    "runner/tests/test_approval_gate_enforcement.py",
+    "runner/tests/test_gate_shadowing.py",
+    "runner/tests/test_gate_e2e.py",
+    "runner/tests/test_hooks.py",
+    "runner/tests/test_connectors.py",
+    "runner/tests/test_mcp_tool_capability.py",
+    "runner/tests/test_hosted_mcp_approval_catalog.py",
+    "runner/tests/test_live.py",
+    "runner/tests/test_ladder_approval_gate_case.py",
+    "runner/tests/fixtures/mcp_tool_capability_server.py",
+)
+
+
+def detect(tmp_path: Path, paths: bytes, *, new_lock: str = LOCK) -> tuple[int, str, str]:
+    (tmp_path / "old.lock").write_text(LOCK)
+    (tmp_path / "uv.lock").write_text(new_lock)
+    (tmp_path / "paths").write_bytes(paths)
+    output = tmp_path / "output"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(DETECTOR),
+            "--old-file",
+            str(tmp_path / "old.lock"),
+            "--new-file",
+            str(tmp_path / "uv.lock"),
+            "--changed-paths-file",
+            str(tmp_path / "paths"),
+        ],
+        env=dict(os.environ, GITHUB_OUTPUT=str(output)),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.returncode, output.read_text() if output.exists() else "", result.stderr
+
+
+@pytest.mark.parametrize("path", POLICY_PATHS)
+def test_each_enforcement_path_runs_live_with_unchanged_lock(tmp_path: Path, path: str) -> None:
+    code, output, error = detect(tmp_path, path.encode() + b"\0")
+    assert code == 0, error
+    assert output == "changed=true\n"
+    workflow = yaml.safe_load(WORKFLOW.read_text())
+    assert path in workflow[True]["pull_request"]["paths"]
+    assert (ROOT / path).is_file()
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "README.md",
+        "runner/src/curie_runner/otel.py",
+        "runner/tests/test_otel.py",
+        "runner/src/curie_runner/approval.py.bak",
+        "apps/ui/src/App.tsx",
+    ],
+)
+def test_unrelated_paths_do_not_run_live(tmp_path: Path, path: str) -> None:
+    assert detect(tmp_path, path.encode() + b"\0")[:2] == (0, "changed=false\n")
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        ".github/workflows/sdk-approval-gate.yaml",
+        "tools/sdk-lock-gate/detect.py",
+        "tools/sdk-lock-gate/tests/test_approval_paths.py",
+    ],
+)
+def test_gate_changes_reprove_the_guard(tmp_path: Path, path: str) -> None:
+    assert detect(tmp_path, path.encode() + b"\0")[:2] == (0, "changed=true\n")
+
+
+@pytest.mark.parametrize("paths", [b"unterminated", b"\xff\0", b"\0", b"../outside\0"])
+def test_malformed_path_input_cannot_false_green_skip(tmp_path: Path, paths: bytes) -> None:
+    code, output, _ = detect(tmp_path, paths)
+    assert code != 0 or output == "changed=true\n"
+    assert output != "changed=false\n"
+
+
+def test_lock_semantics_remain_in_the_workflow_consumer(tmp_path: Path) -> None:
+    assert detect(tmp_path, b"uv.lock\0", new_lock=LOCK.replace("0.2.135", "0.2.140"))[:2] == (
+        0,
+        "changed=true\n",
+    )
+    (tmp_path / "output").unlink()
+    assert detect(tmp_path, b"uv.lock\0", new_lock=LOCK + "\n# other package changed\n")[:2] == (
+        0,
+        "changed=false\n",
+    )
+
+
+def test_deleted_enforcement_file_is_in_real_git_path_stream(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    def git(*args: str) -> bytes:
+        return subprocess.check_output(["git", "-C", str(repo), *args])
+
+    git("init", "-q")
+    file = repo / POLICY_PATHS[0]
+    file.parent.mkdir(parents=True)
+    file.write_text("old policy\n")
+    git("add", ".")
+    git("-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-qm", "base")
+    file.unlink()
+    paths = git("diff", "--name-only", "--no-renames", "-z", "HEAD")
+    assert detect(tmp_path, paths)[:2] == (0, "changed=true\n")
+
+
+def test_workflow_materializes_immutable_pr_range_and_uses_proof_consumer() -> None:
+    workflow = yaml.safe_load(WORKFLOW.read_text())
+    detect_job = workflow["jobs"]["detect"]
+    runs = "\n".join(step.get("run", "") for step in detect_job["steps"])
+    assert "--no-renames -z" in runs
+    assert "github.event.pull_request.base.sha" in str(detect_job)
+    assert "github.event.pull_request.head.sha" in str(detect_job)
+    assert "--changed-paths-file" in runs
+    live = workflow["jobs"]["live-approval-gate"]
+    assert live["if"] == "needs.detect.outputs.changed == 'true'"
+    proof = next(step for step in live["steps"] if "run-proof.py" in step.get("run", ""))
+    assert proof["env"]["CURIE_E2E_LIVE"] == "1"
+    assert proof["env"]["CURIE_E2E_TIERS"] == "skill"
+
+
+def test_workflow_outer_filter_is_only_named_policy_and_gate_paths() -> None:
+    workflow = yaml.safe_load(WORKFLOW.read_text())
+    assert set(workflow[True]["pull_request"]["paths"]) == set(POLICY_PATHS) | {
+        "uv.lock",
+        ".github/workflows/sdk-approval-gate.yaml",
+        "tools/sdk-lock-gate/**",
+    }
+
+
+def test_workflow_materialization_executes_against_exact_git_commits(tmp_path: Path) -> None:
+    workflow = yaml.safe_load(WORKFLOW.read_text())
+    step = next(
+        step
+        for step in workflow["jobs"]["detect"]["steps"]
+        if step.get("name") == "Materialize the exact PR change and lock inputs"
+    )
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    def git(*args: str) -> str:
+        return subprocess.check_output(["git", "-C", str(repo), *args], text=True).strip()
+
+    git("init", "-q")
+    file = repo / POLICY_PATHS[0]
+    file.parent.mkdir(parents=True)
+    file.write_text("old policy\n")
+    (repo / "uv.lock").write_text(LOCK)
+    git("add", ".")
+    git("-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-qm", "base")
+    base = git("rev-parse", "HEAD")
+    file.unlink()
+    git("add", ".")
+    git("-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-qm", "head")
+    head = git("rev-parse", "HEAD")
+    # A dirty working lock must not substitute for the PR head's lock.
+    (repo / "uv.lock").write_text("broken working file")
+    result = subprocess.run(
+        ["bash", "-c", step["run"]],
+        cwd=repo,
+        env=dict(os.environ, BASE_SHA=base, HEAD_SHA=head),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert (repo / "old.lock").read_text() == LOCK
+    assert (repo / "new.lock").read_text() == LOCK
+    assert detect(tmp_path, (repo / "changed-paths").read_bytes())[:2] == (0, "changed=true\n")
+    result = subprocess.run(
+        ["bash", "-c", step["run"]],
+        cwd=repo,
+        env=dict(os.environ, BASE_SHA="missing-ref", HEAD_SHA=head),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode != 0

--- a/tools/sdk-lock-gate/tests/test_live_proof_consumer.py
+++ b/tools/sdk-lock-gate/tests/test_live_proof_consumer.py
@@ -1,0 +1,61 @@
+"""Fixture-controlled guard executions; these never claim a live SDK proof."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+CONSUMER = ROOT / "tools/sdk-lock-gate/run-proof.py"
+START = "=== case: a live gated tool call is denied and the turn parks (#2094) ==="
+PARK = "the gated turn parked: status=awaiting-approval finalized=false approval_summary=present"
+ABSENT = "the gated command did not run: /tmp/curie-2094-canary is absent"
+
+
+def run(
+    tmp_path: Path, lines: list[str], exit_code: int = 0, live: str = "1"
+) -> subprocess.CompletedProcess[str]:
+    ladder = tmp_path / "ladder.sh"
+    ladder.write_text(
+        "#!/bin/bash\ncat <<'OUTPUT'\n" + "\n".join(lines) + f"\nOUTPUT\nexit {exit_code}\n"
+    )
+    return subprocess.run(
+        [sys.executable, str(CONSUMER), "--ladder", str(ladder)],
+        env=dict(os.environ, CURIE_E2E_LIVE=live, CURIE_E2E_TIERS="skill"),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_observed_park_and_no_effect_with_success_are_accepted(tmp_path: Path) -> None:
+    result = run(tmp_path, [START, PARK, ABSENT])
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.parametrize("missing", [START, PARK, ABSENT])
+def test_missing_case_or_assertion_cannot_succeed(tmp_path: Path, missing: str) -> None:
+    result = run(tmp_path, [line for line in [START, PARK, ABSENT] if line != missing])
+    assert result.returncode != 0
+    assert "::error title=" in result.stderr
+
+
+@pytest.mark.parametrize("exit_code", [0, 1])
+def test_reset_failure_before_case_is_named_failure(tmp_path: Path, exit_code: int) -> None:
+    result = run(tmp_path, ["runner reset returned HTTP 500"], exit_code)
+    assert result.returncode != 0
+    assert "setup/reset failed before approval-gate case" in result.stderr
+
+
+def test_a_later_ladder_failure_is_not_hidden_by_successful_case(tmp_path: Path) -> None:
+    assert run(tmp_path, [START, PARK, ABSENT], 1).returncode != 0
+
+
+def test_non_live_mode_refuses_before_launching_ladder(tmp_path: Path) -> None:
+    result = run(tmp_path, [START, PARK, ABSENT], live="0")
+    assert result.returncode != 0
+    assert START not in result.stdout


### PR DESCRIPTION
## Summary

Run the existing live SDK approval proof when named approval, MCP policy, or catalog enforcement files change, even when the SDK lock entry is unchanged. Keep the semantic lock comparison from #2094 and the cheap detector so unrelated changes do not incur model cost. Detection uses the exact PR base/head commits and rejects malformed path input.

Require the live ladder to reach its approval case and observe both a parked turn and an absent side effect. A setup/reset failure before that case is an explicit failure, including an accidental successful ladder exit. No global required check is added.

## Related issue

Ref #2308. This draft carries reviewed source and fresh live SDK approval proof for the final exact-file boundary correction.

## Candidate

Base: `next` at `26a583ef5cbb4f4241fa20eebf3e5574b45369e0`.
Head: `134bab277552277b613b9617aedfd70eeb145c8e`.

## Verification

`python -m pytest -q tools/sdk-lock-gate/tests runner/tests/test_ladder_approval_gate_case.py tools/ci-workflow-paths/tests/test_workflow_paths.py`: 81 passed.

`ruff check tools/sdk-lock-gate`, `ruff format --check tools/sdk-lock-gate`, and `git diff --cached --check`: passed.

The new consumer tests failed before implementation. Four deliberate mutations each failed their focused test, then passed after byte-for-byte restoration: removing policy-path detection, accepting malformed path input as unchanged, accepting reset/setup failure before the case, and accepting missing case assertions. Git history tests exercise exact immutable inputs and deleted enforcement files. Fixture-controlled proof transcripts test the result guard only; they do not establish live SDK runtime behavior.

## End-to-end verification

| Tier | Required / n/a | Reason | Mode | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | required | This workflow drives the existing runner approval case. | live | `CURIE_E2E_LIVE=1 CURIE_E2E_TIERS=skill python3 tools/sdk-lock-gate/run-proof.py`; PASS in [run33953975111](https://github.com/curie-eng/curie/actions/runs/33953975111) on merge `f2b28750ed05e72ddd68da1cd88ca52e2a5e425a` of exact head `134bab277552277b613b9617aedfd70eeb145c8e` into the stated base. |
| local | n/a | No compose services, worker/API wiring, console, or product CLI output changes. | | |
| local-release | n/a | No published binary/image identity, installer, pins, or release compose changes. | | |
| cluster | n/a | No chart, RBAC, sandbox claim, or init-container changes. | | |
| live provider | required | Real SDK permission scheduling is the purpose of the triggered proof. | live | Same command as skill: PASS. At08:01:17UTC, the real SDK turn parked `awaiting-approval`, `finalized=false`, approval summary present; direct canary check confirmed no tool side effect. Existing protected credentials and candidate runner/CLI builds used. |
| external integration | n/a | No Slack, webhook, OAuth, or other third-party API shape changes. Provider proof is recorded above. | | |

- [x] Every required tier has passing evidence on the final candidate/base merge.
- [x] Source acceptance checks have positive and causal negative evidence.
- [x] No required tier remains unproved for this CI source slice.

Existing #2221, #2201, and #2294 production implementations are outside this change. A live failure in those dependencies remains a failure and must be recorded, not converted to a skip.

This is the selected workflow result, not a claim that every PR check passed. No live reset fault was injected; named reset/setup refusal is established by the separate causal consumer tests. Hosted-MCP catalog and Slack acceptance are outside this proof.

The workflow and detector name exactly 18 runner enforcement/observation files, the workflow, and five gate implementation/test files. No directory glob remains. Three new consumer cases proved that documentation and backup files under the gate directory incorrectly forced live proof before the correction. All 81 scoped tests pass; deliberately restoring the broad prefix fails those tests and byte-exact restoration passes. Final frozen code, scope and security reviews are complete.
