### PR TITLE
Restore explicitly supported SRE observability reads

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -49,8 +49,8 @@ The [bundle schema](../examples/sre-bot/supported-surface.schema.json) governs
 the combined manifest, connectors and supported surface. The consumer compares
 the [permission map](../examples/sre-bot/docs/PERMISSION-MAP.md) and uses the
 product's policy classifier. A static pass proves declaration consistency only.
-The shipped policy defect in #2285 currently makes that command fail; fixing its
-prerequisite must precede a supported bundle pass.
+The supported reads are classified explicitly. The complete image catalog and
+eight starter-prompt observations in #2285 remain separate acceptance evidence.
 
 For catalog verification, place every connector's real MCP URL in a protected
 JSON object keyed by connector name. Run the following with that file path:

--- a/examples/sre-bot/.claude-plugin/plugin.json
+++ b/examples/sre-bot/.claude-plugin/plugin.json
@@ -58,7 +58,14 @@
       "kubernetes/resources_list",
       "kubernetes/resources_get",
       "self-upgrade/upgrade_self",
-      "self-upgrade/upgrade_platform"
+      "self-upgrade/upgrade_platform",
+      "grafana/query_loki_logs",
+      "grafana/list_alert_rules",
+      "tempo/search_traces",
+      "tempo/get_trace",
+      "tempo/list_trace_tags",
+      "tempo/list_trace_tag_values",
+      "self-upgrade/latest_release"
     ],
     "approvalRequired": [
       "kubernetes/pods_delete",

--- a/examples/sre-bot/docs/PERMISSION-MAP.md
+++ b/examples/sre-bot/docs/PERMISSION-MAP.md
@@ -130,6 +130,6 @@ returned tool, including image-only tools absent from repository source.
 | `grafana/query_loki_logs` | `allow` |
 | `grafana/list_alert_rules` | `allow` |
 
-This table states the supported surface obligation. The current manifest
-still violates the observability read rows tracked in #2285. A failing
-consistency check is a dependency failure, never permission to skip it.
+This table states the supported surface obligation and matches the explicit
+manifest grants. The complete image catalog and live starter-prompt evidence
+remain tracked in #2285. A failing consistency check must never be skipped.

--- a/tools/sre-contract/tests/test_shipped_policy.py
+++ b/tools/sre-contract/tests/test_shipped_policy.py
@@ -1,0 +1,46 @@
+"""Execute the shipped bundle guard, then remove each restored supported read."""
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+READS = (
+    "grafana/query_loki_logs",
+    "grafana/list_alert_rules",
+    "tempo/search_traces",
+    "tempo/get_trace",
+    "tempo/list_trace_tags",
+    "tempo/list_trace_tag_values",
+    "self-upgrade/latest_release",
+)
+
+
+def test_shipped_supported_reads_and_each_missing_grant(tmp_path):
+    bundle = tmp_path / "sre-bot"
+    shutil.copytree(ROOT / "examples/sre-bot", bundle)
+    manifest = bundle / ".claude-plugin/plugin.json"
+    healthy = manifest.read_text()
+
+    def check():
+        return subprocess.run(
+            [sys.executable, str(ROOT / "tools/sre-contract/check.py"), "--bundle", str(bundle)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+    baseline = check()
+    assert baseline.returncode == 0, baseline.stderr
+    for canonical in READS:
+        broken = json.loads(healthy)
+        broken["toolPolicy"]["allow"].remove(canonical)
+        manifest.write_text(json.dumps(broken))
+        result = check()
+        assert result.returncode == 1
+        assert f"{canonical}: expected allow, got deny" in result.stderr
+        manifest.write_text(healthy)
+        restored = check()
+        assert restored.returncode == 0, restored.stderr


### PR DESCRIPTION
## Summary

Restore seven explicitly supported read tools that the example's enforcing policy currently denies: the two documented Grafana reads, four Tempo reads and `self-upgrade/latest_release`. Keep exact tool names so additional image catalog tools must be classified deliberately through the live consistency guard.

The regression test runs the shipped bundle consumer, removes each grant independently, observes its named denial, and restores a passing bundle. This narrow prerequisite does not complete #2285. The actual image-catalog check now runs and fails: the expected Grafana catalog differs from the pinned image, and 47 advertised Grafana tools remain uncovered. The full catalog must be classified from actual tool metadata, and all eight live starter prompts remain unproved.

## Related issue and stack

Ref #2285. Corrective prerequisite for the supported bundle guard in #2404. No issue is closed.

Base branch: `task/overnight-sre-contract` at `26606e2f0bdb9b446059891f6d1cb1a1d9753eee` (itself targets `next`).
Head branch: `task/overnight-sre-policy` at `086e2adfb67b2222fc87eab8dac8d9300f857c63`.
The plugin manifest, one consumer regression test, and two mechanically updated documentation statements differ from that exact base. Do not merge this draft before the parent contract and remaining acceptance evidence are reviewed together.

## Verification

`python -m pytest -q tools/sre-contract/tests examples/tests/test_permission_map_names_every_gate.py examples/tests/test_sre_bot_hygiene.py tools/ci-workflow-paths/tests/test_workflow_paths.py`: 47 passed.

The new shipped-consumer test failed before the manifest change, naming all seven denied reads. Each individual grant removal now exits 1 with the exact affected tool; restoring the unchanged manifest exits 0. Ruff, formatting, diff and identifier/credential checks pass. Frozen code, scope and security reviews are recorded against the exact final files.

## End-to-end verification

| Tier | Required / n/a | Reason | Mode | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | required | Policy controls the supported runner catalog. | live | Actual SRE skill observation: UNRUN; real connectors and protected model credentials required. |
| local | required | Same bundle is consumed through the local worker/API path. | live | Actual local SRE eval: UNRUN; serialized stack grant required. |
| local-release | required | Published supported bundle must preserve the same reads. | live | Published artifact SRE eval: UNRUN; released artifact setup required. |
| cluster | required | Supported installed connector catalog and effects. | live | SRE install and all eight starter prompts: UNRUN; isolated cluster setup required. |
| live provider | required | The model must see and use the restored tools. | live | Credentialed SRE observations: UNRUN; static classifier output is insufficient. |
| external integration | required | Real Grafana/Tempo catalog, read results and Slack journey. | live | `python tools/sre-contract/catalog_ci.py` and actual upstream/Slack observations: FAIL in [run33953138551](https://github.com/curie-eng/curie/actions/runs/33953138551) on exact head `086e2adfb67b2222fc87eab8dac8d9300f857c63`. First failure: `grafana: live catalog differs from supported surface`, followed by 47 uncovered tools. Image catalog discovery alone does not prove upstream effects. |

- [x] Positive shipped-consumer and causal negative evidence.
- [ ] All required runtime tiers proved on this candidate.
- [ ] Full declared image catalog deliberately classified and all eight starter prompts answered.

Remote source checks passed: 21 consumer tests and the actual shipped checker returned `{"status":"pass","mode":"static","runtime_tiers_proven":[]}`. The subsequent actual-image command exited 1. At least one expected Grafana tool is absent; these diagnostics do not identify the complete missing-name set or classify the uncovered tools as safe reads. No wildcard grant/denial or capability removal is used to turn this failure green.
