### PR TITLE
Warm-pool D1 prerequisite: capability projection and version targets (#1492)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -130,6 +130,11 @@ regexes = [
   # Historical redaction regression input. Every token component is a repeated
   # zero or the literal FAKE marker, so it cannot identify a real Slack app.
   '''\bxapp-0-0000000000-0000000000-FAKEFAKEFAKEFAKE\b''',
+  # Historical warm-pool fixtures use these exact fabricated values to prove
+  # credential rotation and value-free equality. Anchor the complete finding:
+  # another value under either key must still be detected by generic-api-key.
+  '''^STATE_TOKEN_ENV: "sbx\.other2\.sig"$''',
+  '''^GH_TOKEN": "MATERIAL-B-91c2"$''',
 ]
 
 paths = [

--- a/apps/worker/src/curie_worker/sandbox/warm_pool_contract.py
+++ b/apps/worker/src/curie_worker/sandbox/warm_pool_contract.py
@@ -1,0 +1,628 @@
+"""Warm-pool capability projection: the immutable identity of a version pool (#1492 D1).
+
+Accepted ADR-0122 makes a runner bootstrap credential per VERSION POOL and says a
+credential change is a NEW pool, never a mutation. The same rule has to hold for
+every other input a warm pod boots with: model, thinking, budget, approval gates,
+connector scope, bundle identity, memory ref. Those live on the mutable ``Agent``
+row and the worker's own defaults, and ``BindingResolver.boot_env`` overlays them
+live on every cold claim. A warm template cannot be overlaid per claim
+(``envVarsInjectionPolicy: Overrides`` forces a cold create for any per-claim
+env), so the template must carry a frozen snapshot of that overlay, and the pool
+is only usable while the live overlay still equals the snapshot.
+
+``capability_generation`` is the SHA-256 of a canonical JSON projection of the
+version-stable subset of that boot env. It is computed FROM the real
+``boot_env`` render rather than from a second, hand-maintained list of the same
+policy, so the precedence rules (agent pin beats worker default, connector
+scope is a set or nothing, no-key installs mint no tokens) cannot drift between
+the cold path and the warm template. Every key the render can emit is
+CLASSIFIED here; an unclassified key refuses the projection instead of being
+guessed into or out of the hash.
+
+Credentials are identity only:
+
+- the model credential and per-agent connector secrets are the ``secretKeyRef``
+  NAME and KEY the chart baseline template already delivers them by;
+- the agent-scoped ``state`` / ``state.app`` tokens (ADR-0033) are a nonsecret
+  ``CredentialGeneration`` -- agent, scopes, issued/expiry window -- whose values
+  are minted later with the EXISTING ``sandbox_token`` codec into a protected
+  Secret. A renewal is a new generation, so a new pool; nothing rotates under a
+  running pod;
+- the per-claim ``runner_token`` and the pool bootstrap value are never in the
+  projection at all: the bootstrap arrives by ``secretKeyRef`` and the
+  conversation credential arrives on the existing adoption call (W1).
+
+This module creates, reads and writes nothing: no Secret, no Template, no Pool,
+no Postgres, no Valkey. It is the shared helper the realizer and W1's adoption
+path both call, and the contract the review of the Template writer's authority
+(a separately unresolved prerequisite) can assume.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import time
+from collections.abc import Iterator, Mapping
+from dataclasses import dataclass, field
+from enum import StrEnum
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Any
+
+from aci_protocol import BootEnv
+
+from .. import sandbox_token
+from ..binding import (
+    DECISION_ENV,
+    FALSE_COMPLETION_CHECK_ENV,
+    GRANT_TOOL_ENV,
+    MEMORY_REF_ENV,
+    RESUMED_KIND_ENV,
+    SANDBOX_TOKEN_TTL_SECONDS,
+)
+from ..workspace import WORKSPACE_REF_ENV, WORKSPACE_SHA256_ENV
+
+if TYPE_CHECKING:
+    from ..binding import BindingResolver, ResolvedDeployment
+
+logger = logging.getLogger(__name__)
+
+#: Bump only with a recorded reason: it changes every generation on every install.
+PROJECTION_VERSION = 1
+
+#: The thread key handed to ``boot_env`` when projecting. It only ever lands in
+#: per-conversation keys, which the projection drops; a test pins that it never
+#: reaches the canonical JSON.
+PROJECTION_THREAD_SENTINEL = "warm-pool-projection"
+
+# Mirrors apps/api routers/state.py (STATE_SCOPE / STATE_APP_SCOPE) and the
+# scope strings binding.boot_env mints with; they are the existing codec's only
+# accepted state scopes.
+STATE_SCOPE = "state"
+STATE_APP_SCOPE = "state.app"
+
+_SESSION_ENV = BootEnv.env_key("session_id")
+_HISTORY_REF_ENV = BootEnv.env_key("history_ref")
+_RUNNER_TOKEN_ENV = BootEnv.env_key("runner_token")
+_HISTORY_TOKEN_ENV = BootEnv.env_key("history_token")
+_MEMORY_TOKEN_ENV = BootEnv.env_key("memory_token")
+_STATE_TOKEN_ENV = BootEnv.env_key("state_token")
+_STATE_URL_ENV = BootEnv.env_key("state_url")
+_CREDENTIALS_ENV = BootEnv.env_key("credentials_ref")
+_CONNECTOR_SECRET_KEYS_ENV = BootEnv.env_key("connector_secret_keys")
+
+#: The env keys a protected credential-generation Secret carries, in order, and
+#: the scope each is minted with. ``history``/``memory`` share the broad state
+#: scope and the bundle-facing state token gets the narrow one, exactly as
+#: ``boot_env`` mints them today.
+CREDENTIAL_KEY_SCOPES: Mapping[str, str] = MappingProxyType(
+    {
+        _HISTORY_TOKEN_ENV: STATE_SCOPE,
+        _MEMORY_TOKEN_ENV: STATE_SCOPE,
+        _STATE_TOKEN_ENV: STATE_APP_SCOPE,
+    }
+)
+
+
+class ProjectionError(ValueError):
+    """The boot env cannot be projected into a warm template; stay cold."""
+
+
+class EnvClass(StrEnum):
+    """How one boot-env key relates to a warm template."""
+
+    #: Same for every conversation of this version; part of the hash and the template.
+    VERSION_STABLE = "version-stable"
+    #: Differs per conversation/claim; delivered by adoption or forces a cold claim.
+    CONVERSATION = "conversation"
+    #: Secret material; identity (secretKeyRef or generation) is hashed, never the value.
+    CREDENTIAL = "credential"
+
+
+def worker_env_classes() -> Mapping[str, EnvClass]:
+    """Every boot key the worker can emit, classified. Unknown keys refuse."""
+
+    return _ENV_CLASSES
+
+
+_ENV_CLASSES: Mapping[str, EnvClass] = MappingProxyType(
+    {
+        BootEnv.env_key("plugin_dir"): EnvClass.VERSION_STABLE,
+        BootEnv.env_key("budget"): EnvClass.VERSION_STABLE,
+        MEMORY_REF_ENV: EnvClass.VERSION_STABLE,
+        BootEnv.env_key("bundle_ref"): EnvClass.VERSION_STABLE,
+        BootEnv.env_key("bundle_version"): EnvClass.VERSION_STABLE,
+        BootEnv.env_key("model"): EnvClass.VERSION_STABLE,
+        BootEnv.env_key("fake_model"): EnvClass.VERSION_STABLE,
+        BootEnv.env_key("base_url"): EnvClass.VERSION_STABLE,
+        BootEnv.env_key("api_backend"): EnvClass.VERSION_STABLE,
+        BootEnv.env_key("thinking"): EnvClass.VERSION_STABLE,
+        BootEnv.env_key("model_env_key"): EnvClass.VERSION_STABLE,
+        BootEnv.env_key("approval_required_tools"): EnvClass.VERSION_STABLE,
+        BootEnv.env_key("connector_release"): EnvClass.VERSION_STABLE,
+        BootEnv.env_key("connector_agent"): EnvClass.VERSION_STABLE,
+        BootEnv.env_key("connector_namespace"): EnvClass.VERSION_STABLE,
+        # The marker names the connector-secret KEYS (sorted); the values are
+        # delivered by the per-agent Secret's secretKeyRef, never by the claim.
+        _CONNECTOR_SECRET_KEYS_ENV: EnvClass.VERSION_STABLE,
+        FALSE_COMPLETION_CHECK_ENV: EnvClass.VERSION_STABLE,
+        # Agent-wide when memory=True; binding-scoped (unknowable ahead of the
+        # claim) when memory=False, handled explicitly in project_boot_env.
+        _STATE_URL_ENV: EnvClass.VERSION_STABLE,
+        _SESSION_ENV: EnvClass.CONVERSATION,
+        _HISTORY_REF_ENV: EnvClass.CONVERSATION,
+        _RUNNER_TOKEN_ENV: EnvClass.CONVERSATION,
+        GRANT_TOOL_ENV: EnvClass.CONVERSATION,
+        RESUMED_KIND_ENV: EnvClass.CONVERSATION,
+        DECISION_ENV: EnvClass.CONVERSATION,
+        WORKSPACE_REF_ENV: EnvClass.CONVERSATION,
+        WORKSPACE_SHA256_ENV: EnvClass.CONVERSATION,
+        _CREDENTIALS_ENV: EnvClass.CREDENTIAL,
+        _HISTORY_TOKEN_ENV: EnvClass.CREDENTIAL,
+        _MEMORY_TOKEN_ENV: EnvClass.CREDENTIAL,
+        _STATE_TOKEN_ENV: EnvClass.CREDENTIAL,
+    }
+)
+
+#: Per-claim keys whose presence means the turn needs an overlay a warm pod
+#: cannot receive. Delivered per-conversation keys (session, history ref, runner
+#: token, state tokens) are NOT here: adoption and the generation Secret carry
+#: those.
+_COLD_OVERLAY_KEYS: Mapping[str, ColdReason] = MappingProxyType({})  # filled below
+
+
+@dataclass(frozen=True, slots=True)
+class SecretKeyRef:
+    """The nonsecret identity of a Kubernetes ``secretKeyRef``."""
+
+    name: str
+    key: str
+
+    def __post_init__(self) -> None:
+        if not self.name or not self.key:
+            raise ProjectionError("a secretKeyRef needs both a Secret name and a key")
+
+    def as_dict(self) -> dict[str, str]:
+        return {"name": self.name, "key": self.key}
+
+
+@dataclass(frozen=True, slots=True)
+class CredentialGeneration:
+    """Nonsecret identity of one minted state-credential generation.
+
+    Authority is agent + scope + expiry, exactly the claims the existing
+    ``sandbox_token`` codec signs and the API state router checks. Carries no
+    token bytes; the values are minted from this identity by
+    ``mint_credential_generation`` and stored only in a protected Secret. A
+    different window is a different generation and therefore a different pool:
+    expiry is handled by replacement, never by extending or rotating in place.
+    """
+
+    agent_id: str
+    scopes: tuple[str, ...]
+    issued_at: int
+    expires_at: int
+
+    def __post_init__(self) -> None:
+        if not self.agent_id:
+            raise ValueError("credential generation needs an agent id")
+        if tuple(self.scopes) != (STATE_SCOPE, STATE_APP_SCOPE):
+            raise ValueError("credential generation scopes must be exactly (state, state.app)")
+        if self.expires_at <= self.issued_at:
+            raise ValueError("credential generation must expire after it is issued")
+
+    @classmethod
+    def for_window(
+        cls, agent_id: str, *, issued_at: int, ttl_seconds: int = SANDBOX_TOKEN_TTL_SECONDS
+    ) -> CredentialGeneration:
+        if ttl_seconds <= 0:
+            raise ValueError("credential generation ttl must be positive")
+        return cls(
+            agent_id=agent_id,
+            scopes=(STATE_SCOPE, STATE_APP_SCOPE),
+            issued_at=int(issued_at),
+            expires_at=int(issued_at) + int(ttl_seconds),
+        )
+
+    def admits(self, now: int, *, margin_seconds: int = 0) -> bool:
+        """True while a pod booted on this generation may still be adopted."""
+
+        return self.expires_at - margin_seconds > now
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "agent_id": self.agent_id,
+            "scopes": list(self.scopes),
+            "issued_at": self.issued_at,
+            "expires_at": self.expires_at,
+        }
+
+
+class CredentialMaterial:
+    """Minted token values for one generation. Redacted everywhere but ``value``.
+
+    Not a dataclass on purpose: no ``__eq__``/``__repr__``/``asdict`` path may
+    surface the values. Only ``value(key)`` returns material, for the one
+    producer that writes the protected Secret.
+    """
+
+    __slots__ = ("_generation", "_values")
+
+    def __init__(self, generation: CredentialGeneration, values: Mapping[str, str]) -> None:
+        self._generation = generation
+        self._values = dict(values)
+
+    def keys(self) -> tuple[str, ...]:
+        return tuple(self._values)
+
+    def value(self, key: str) -> str:
+        return self._values[key]
+
+    def identity(self) -> dict[str, Any]:
+        return {**self._generation.as_dict(), "keys": list(self._values)}
+
+    def __repr__(self) -> str:
+        return (
+            f"CredentialMaterial(agent_id={self._generation.agent_id!r}, "
+            f"keys={list(self._values)!r}, values=<redacted>)"
+        )
+
+    __str__ = __repr__
+
+
+def mint_credential_generation(
+    api_key: str, generation: CredentialGeneration
+) -> CredentialMaterial:
+    """Mint the generation's token values with the existing scoped codec.
+
+    Pure and deterministic (the codec signs ``agent``/``scope``/``exp`` only), so
+    two workers minting the same generation produce byte-identical values and a
+    create-or-adopt Secret race cannot leave a loser holding a different live
+    token. Never logs, never stores; the caller owns the protected write.
+    """
+
+    if not api_key:
+        raise ValueError("cannot mint a credential generation without the platform key")
+    values = {
+        key: sandbox_token.mint(
+            api_key, agent=generation.agent_id, scope=scope, exp=generation.expires_at
+        )
+        for key, scope in CREDENTIAL_KEY_SCOPES.items()
+    }
+    return CredentialMaterial(generation, values)
+
+
+@dataclass(frozen=True, slots=True)
+class CapabilityProjection:
+    """The version-stable, secret-free content of one warm template.
+
+    ``env`` is what the template's runner container carries as literal values;
+    ``secret_refs`` are the env keys delivered by an existing ``secretKeyRef``
+    (identity only); ``credential_keys`` are the env keys the generation Secret
+    carries, minted from ``credential_generation``. ``capability_generation`` is
+    the SHA-256 over the canonical JSON of all of that.
+    """
+
+    agent_id: str
+    version_id: str
+    deployment_id: str | None
+    version_label: str
+    bundle_ref: str | None
+    bundle_sha256: str | None
+    memory: bool
+    env: Mapping[str, str]
+    secret_refs: Mapping[str, SecretKeyRef]
+    credential_keys: tuple[str, ...]
+    credential_generation: CredentialGeneration | None
+    projection_version: int = PROJECTION_VERSION
+    capability_generation: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "env", MappingProxyType(dict(sorted(self.env.items()))))
+        object.__setattr__(
+            self, "secret_refs", MappingProxyType(dict(sorted(self.secret_refs.items())))
+        )
+        digest = hashlib.sha256(self.canonical_json().encode("utf-8")).hexdigest()
+        object.__setattr__(self, "capability_generation", digest)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "projection_version": self.projection_version,
+            "agent_id": self.agent_id,
+            "version_id": self.version_id,
+            "deployment_id": self.deployment_id,
+            "version_label": self.version_label,
+            "bundle_ref": self.bundle_ref,
+            "bundle_sha256": self.bundle_sha256,
+            "memory": self.memory,
+            "env": dict(self.env),
+            "secret_refs": {k: v.as_dict() for k, v in self.secret_refs.items()},
+            "credential_keys": list(self.credential_keys),
+            "credential_generation": (
+                None if self.credential_generation is None else self.credential_generation.as_dict()
+            ),
+        }
+
+    def canonical_json(self) -> str:
+        """UTF-8, sorted keys, no whitespace variance, no secret values, no timestamps."""
+
+        return json.dumps(self.as_dict(), sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+    @property
+    def short_generation(self) -> str:
+        """The object-name prefix of the generation (names, never identity)."""
+
+        return self.capability_generation[:12]
+
+
+def _iter_connector_keys(env: Mapping[str, str]) -> Iterator[str]:
+    marker = env.get(_CONNECTOR_SECRET_KEYS_ENV, "")
+    for key in marker.split(","):
+        key = key.strip()
+        if key:
+            yield key
+
+
+def project_boot_env(
+    env: Mapping[str, str],
+    *,
+    agent_id: str,
+    version_id: str,
+    deployment_id: str | None,
+    version_label: str,
+    bundle_ref: str | None,
+    bundle_sha256: str | None,
+    memory: bool,
+    model_credential_ref: SecretKeyRef | None,
+    connector_secret_name: str | None,
+    credential_generation: CredentialGeneration | None,
+) -> CapabilityProjection:
+    """Project one rendered boot env into its warm-template identity.
+
+    Fail-closed rules, each pinned by a test:
+
+    - an unclassified key refuses (a new boot knob must be classified, not guessed);
+    - a credential VALUE never survives: model credential -> baseline
+      ``secretKeyRef``; connector secrets -> per-agent Secret refs; state tokens ->
+      the generation; a value that also appears under any kept key refuses;
+    - state tokens present without a generation (or a generation without state
+      tokens) refuses, because the warm pod would boot with different authority
+      than the cold path;
+    - ``memory=False`` drops ``state_url``: the cold path scopes it to a binding
+      that does not exist before the claim, so it cannot be pre-baked;
+    - ``memory_ref`` is required: an env-free warm pod without it boots
+      ``NullMemoryStore`` silently.
+    """
+
+    connector_keys = frozenset(_iter_connector_keys(env))
+    kept: dict[str, str] = {}
+    secret_refs: dict[str, SecretKeyRef] = {}
+    credential_keys: list[str] = []
+    dropped_material: list[str] = []
+    unknown: list[str] = []
+    for key, value in env.items():
+        if key in connector_keys:
+            if not connector_secret_name:
+                raise ProjectionError(
+                    f"connector secret {key} has no per-agent Secret name to reference"
+                )
+            secret_refs[key] = SecretKeyRef(name=connector_secret_name, key=key)
+            dropped_material.append(value)
+            continue
+        klass = _ENV_CLASSES.get(key)
+        if klass is None:
+            unknown.append(key)
+            continue
+        if klass is EnvClass.VERSION_STABLE:
+            if key == _STATE_URL_ENV and not memory:
+                # Binding-scoped; see the docstring. Explicitly cold, not an omission.
+                continue
+            kept[key] = value
+        elif klass is EnvClass.CONVERSATION:
+            dropped_material.append(value)
+        elif key == _CREDENTIALS_ENV:
+            if model_credential_ref is None:
+                raise ProjectionError(
+                    f"{_CREDENTIALS_ENV} is set but no baseline secretKeyRef identity was given"
+                )
+            secret_refs[key] = model_credential_ref
+            dropped_material.append(value)
+        else:
+            credential_keys.append(key)
+            dropped_material.append(value)
+    if unknown:
+        raise ProjectionError(
+            "unclassified boot env key(s) refuse the warm projection: " + ", ".join(sorted(unknown))
+        )
+    if MEMORY_REF_ENV not in kept:
+        raise ProjectionError("boot env has no memory_ref; a warm pod would boot NullMemoryStore")
+    ordered_credential_keys = tuple(k for k in CREDENTIAL_KEY_SCOPES if k in credential_keys)
+    if not memory:
+        # The bundle-facing state token authorizes a URL the template cannot
+        # carry; do not mint it into the generation Secret either.
+        ordered_credential_keys = tuple(k for k in ordered_credential_keys if k != _STATE_TOKEN_ENV)
+    if ordered_credential_keys and credential_generation is None:
+        raise ProjectionError(
+            "boot env mints state tokens but no credential generation was given; "
+            "a warm pod would boot without state authority"
+        )
+    if credential_generation is not None:
+        if not ordered_credential_keys:
+            raise ProjectionError(
+                "a credential generation was given but this install mints no state "
+                "tokens (no platform key); refuse rather than invent authority"
+            )
+        if credential_generation.agent_id != agent_id:
+            raise ProjectionError("credential generation names a different agent")
+    for material in dropped_material:
+        if material and any(material == v for v in kept.values()):
+            raise ProjectionError(
+                "a credential value reappears under a version-stable key; refusing to hash it"
+            )
+    return CapabilityProjection(
+        agent_id=agent_id,
+        version_id=version_id,
+        deployment_id=deployment_id,
+        version_label=version_label,
+        bundle_ref=bundle_ref,
+        bundle_sha256=bundle_sha256,
+        memory=memory,
+        env=kept,
+        secret_refs=secret_refs,
+        credential_keys=ordered_credential_keys,
+        credential_generation=credential_generation,
+    )
+
+
+def warm_boot_projection(
+    resolver: BindingResolver,
+    resolved: ResolvedDeployment,
+    *,
+    bundle_sha256: str | None,
+    model_credential_ref: SecretKeyRef | None,
+    connector_secret_name: str | None,
+    credential_generation: CredentialGeneration | None,
+) -> CapabilityProjection:
+    """The projection of ``resolved`` under this worker's current defaults.
+
+    Renders through the real ``BindingResolver.boot_env`` with a sentinel
+    thread and no binding, so precedence and defaults are the cold path's own.
+    The per-claim tokens that render mints are discarded with the other
+    conversation keys; nothing here is persisted.
+    """
+
+    env = resolver.boot_env(resolved, PROJECTION_THREAD_SENTINEL)
+    return project_boot_env(
+        env,
+        agent_id=str(resolved.agent_id),
+        version_id=str(resolved.version_id),
+        deployment_id=None if resolved.deployment_id is None else str(resolved.deployment_id),
+        version_label=resolved.version_label,
+        bundle_ref=resolved.bundle_ref,
+        bundle_sha256=bundle_sha256,
+        memory=resolved.memory,
+        model_credential_ref=model_credential_ref,
+        connector_secret_name=connector_secret_name,
+        credential_generation=credential_generation,
+    )
+
+
+class ColdReason(StrEnum):
+    """Why a turn must cold-create instead of binding a warm version pool."""
+
+    GENERATION_MISMATCH = "generation-mismatch"
+    MEMORY_FALSE_BINDING_STATE = "memory-false-binding-state-url"
+    RESUME_HISTORY = "resume-history-ref"
+    EVAL_LANE = "eval-lane"
+    WORKSPACE_STAGE = "workspace-stage"
+    WORKSPACE_ENV = "workspace-env"
+    APPROVAL_GRANT = "approval-grant"
+    APPROVAL_RESUMED_KIND = "approval-resumed-kind"
+    APPROVAL_DECISION = "approval-decision"
+    EXTRA_CLAIM_ENV = "extra-claim-env"
+    CREDENTIAL_GENERATION_EXPIRED = "credential-generation-expired"
+
+
+_COLD_OVERLAY_KEYS = MappingProxyType(
+    {
+        GRANT_TOOL_ENV: ColdReason.APPROVAL_GRANT,
+        RESUMED_KIND_ENV: ColdReason.APPROVAL_RESUMED_KIND,
+        DECISION_ENV: ColdReason.APPROVAL_DECISION,
+        WORKSPACE_REF_ENV: ColdReason.WORKSPACE_ENV,
+        WORKSPACE_SHA256_ENV: ColdReason.WORKSPACE_ENV,
+    }
+)
+
+#: Conversation keys a warm pod receives by adoption/Secret rather than by claim env.
+_DELIVERED_BY_ADOPTION = frozenset({_SESSION_ENV, _HISTORY_REF_ENV, _RUNNER_TOKEN_ENV}) | frozenset(
+    CREDENTIAL_KEY_SCOPES
+)
+
+
+@dataclass(frozen=True, slots=True)
+class Eligibility:
+    """Warm or cold, with every reason (never a silent table cell)."""
+
+    warm: bool
+    reasons: tuple[ColdReason, ...]
+    mismatched_keys: tuple[str, ...] = ()
+
+
+def classify_claim(
+    claim_env: Mapping[str, str],
+    projection: CapabilityProjection,
+    *,
+    resume: bool = False,
+    eval_lane: bool = False,
+    workspace_stage: bool = False,
+    now: int | None = None,
+) -> Eligibility:
+    """Whether the cold claim env this turn WOULD send can instead bind ``projection``.
+
+    Warm requires: every version-stable key equal to the projection (same
+    generation, computed from the same live overlay), ``memory=True`` (an
+    agent-wide state URL), no per-claim overlay (approval resume, workspace,
+    resume history, eval lane), no unknown key, and an unexpired credential
+    generation. Anything else is cold with its reason. A mismatch is never a
+    licence to pick another version's pool or the Helm generic pool.
+    """
+
+    reasons: list[ColdReason] = []
+    mismatched: list[str] = []
+    seen_stable: set[str] = set()
+    connector_keys = frozenset(_iter_connector_keys(claim_env))
+    for key, value in claim_env.items():
+        if key in connector_keys:
+            if key not in projection.secret_refs:
+                mismatched.append(key)
+            continue
+        overlay = _COLD_OVERLAY_KEYS.get(key)
+        if overlay is not None:
+            if overlay not in reasons:
+                reasons.append(overlay)
+            continue
+        if key in _DELIVERED_BY_ADOPTION:
+            continue
+        if key == _CREDENTIALS_ENV:
+            if key not in projection.secret_refs:
+                mismatched.append(key)
+            continue
+        klass = _ENV_CLASSES.get(key)
+        if klass is None:
+            mismatched.append(key)
+            if ColdReason.EXTRA_CLAIM_ENV not in reasons:
+                reasons.append(ColdReason.EXTRA_CLAIM_ENV)
+            continue
+        if key == _STATE_URL_ENV and not projection.memory:
+            if ColdReason.MEMORY_FALSE_BINDING_STATE not in reasons:
+                reasons.append(ColdReason.MEMORY_FALSE_BINDING_STATE)
+            continue
+        seen_stable.add(key)
+        if projection.env.get(key) != value:
+            mismatched.append(key)
+    missing = set(projection.env) - seen_stable
+    if missing:
+        mismatched.extend(sorted(missing))
+    generation_mismatch = [
+        k for k in mismatched if k in _ENV_CLASSES or k in connector_keys or k == _CREDENTIALS_ENV
+    ]
+    if generation_mismatch and ColdReason.GENERATION_MISMATCH not in reasons:
+        reasons.insert(0, ColdReason.GENERATION_MISMATCH)
+    if not projection.memory and ColdReason.MEMORY_FALSE_BINDING_STATE not in reasons:
+        reasons.append(ColdReason.MEMORY_FALSE_BINDING_STATE)
+    if resume:
+        reasons.append(ColdReason.RESUME_HISTORY)
+    if eval_lane:
+        reasons.append(ColdReason.EVAL_LANE)
+    if workspace_stage:
+        reasons.append(ColdReason.WORKSPACE_STAGE)
+    if projection.credential_generation is not None:
+        current = now if now is not None else int(time.time())
+        if not projection.credential_generation.admits(current):
+            reasons.append(ColdReason.CREDENTIAL_GENERATION_EXPIRED)
+    return Eligibility(
+        warm=not reasons,
+        reasons=tuple(reasons),
+        mismatched_keys=tuple(dict.fromkeys(mismatched)),
+    )

--- a/apps/worker/src/curie_worker/sandbox/warm_pool_contract.py
+++ b/apps/worker/src/curie_worker/sandbox/warm_pool_contract.py
@@ -71,6 +71,14 @@ logger = logging.getLogger(__name__)
 #: Bump only with a recorded reason: it changes every generation on every install.
 PROJECTION_VERSION = 1
 
+#: A warm claim is refused this many seconds BEFORE the generation's credentials
+#: expire, so a turn admitted at the edge cannot lose its state tokens mid-turn.
+#: Sized to the worker's configurable runner ceiling (``runner_total_timeout_s``
+#: is capped at 1800 s); a caller with a longer worst case passes a larger margin
+#: to ``classify_claim``. The realizer must replace generations with at least
+#: this much headroom or every turn near the edge goes cold.
+DEFAULT_CREDENTIAL_ADMISSION_MARGIN_SECONDS = 1800
+
 #: The thread key handed to ``boot_env`` when projecting. It only ever lands in
 #: per-conversation keys, which the projection drops; a test pins that it never
 #: reaches the canonical JSON.
@@ -557,6 +565,7 @@ def classify_claim(
     eval_lane: bool = False,
     workspace_stage: bool = False,
     now: int | None = None,
+    margin_seconds: int = DEFAULT_CREDENTIAL_ADMISSION_MARGIN_SECONDS,
 ) -> Eligibility:
     """Whether the cold claim env this turn WOULD send can instead bind ``projection``.
 
@@ -604,8 +613,24 @@ def classify_claim(
     missing = set(projection.env) - seen_stable
     if missing:
         mismatched.extend(sorted(missing))
+    # A secretKeyRef the template carries that this claim would NOT render (a
+    # baseline credential or connector key that disappeared) is a different
+    # capability too, not a warm hit with a stray Secret mounted.
+    missing_refs = set(projection.secret_refs) - set(claim_env)
+    if missing_refs:
+        mismatched.extend(sorted(missing_refs))
+    # The state tokens the cold path mints must be exactly the generation Secret's
+    # keys; a no-key claim against a keyed generation (or the reverse) is skew.
+    expected_tokens = set(projection.credential_keys)
+    rendered_tokens = {k for k in CREDENTIAL_KEY_SCOPES if k in claim_env}
+    if not projection.memory:
+        rendered_tokens.discard(_STATE_TOKEN_ENV)
+    if expected_tokens != rendered_tokens:
+        mismatched.extend(sorted(expected_tokens ^ rendered_tokens))
     generation_mismatch = [
-        k for k in mismatched if k in _ENV_CLASSES or k in connector_keys or k == _CREDENTIALS_ENV
+        k
+        for k in mismatched
+        if k in _ENV_CLASSES or k in connector_keys or k in projection.secret_refs
     ]
     if generation_mismatch and ColdReason.GENERATION_MISMATCH not in reasons:
         reasons.insert(0, ColdReason.GENERATION_MISMATCH)
@@ -619,7 +644,7 @@ def classify_claim(
         reasons.append(ColdReason.WORKSPACE_STAGE)
     if projection.credential_generation is not None:
         current = now if now is not None else int(time.time())
-        if not projection.credential_generation.admits(current):
+        if not projection.credential_generation.admits(current, margin_seconds=margin_seconds):
             reasons.append(ColdReason.CREDENTIAL_GENERATION_EXPIRED)
     return Eligibility(
         warm=not reasons,

--- a/apps/worker/src/curie_worker/sandbox/warm_pool_contract.py
+++ b/apps/worker/src/curie_worker/sandbox/warm_pool_contract.py
@@ -21,13 +21,13 @@ guessed into or out of the hash.
 
 Credentials are identity only:
 
-- the model credential and per-agent connector secrets are the ``secretKeyRef``
-  NAME and KEY the chart baseline template already delivers them by;
+- the model credential and per-agent connector secrets carry their
+  ``secretKeyRef`` NAME/KEY plus authoritative Secret UID/resourceVersion;
 - the agent-scoped ``state`` / ``state.app`` tokens (ADR-0033) are a nonsecret
   ``CredentialGeneration`` -- agent, scopes, issued/expiry window -- whose values
   are minted later with the EXISTING ``sandbox_token`` codec into a protected
   Secret. A renewal is a new generation, so a new pool; nothing rotates under a
-  running pod;
+  running pod. The signing-key Secret's revision is also part of the projection;
 - the per-claim ``runner_token`` and the pool bootstrap value are never in the
   projection at all: the bootstrap arrives by ``secretKeyRef`` and the
   conversation credential arrives on the existing adoption call (W1).
@@ -36,6 +36,11 @@ This module creates, reads and writes nothing: no Secret, no Template, no Pool,
 no Postgres, no Valkey. It is the shared helper the realizer and W1's adoption
 path both call, and the contract the review of the Template writer's authority
 (a separately unresolved prerequisite) can assume.
+
+The metadata producer must independently observe the actual credential sources
+and recheck them for each claim. This module does not provide that producer or
+verify a caller's provenance. Missing metadata keeps a target unrealizable and
+a claim cold; fixed Secret names alone never manufacture a generation.
 """
 
 from __future__ import annotations
@@ -69,7 +74,9 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 #: Bump only with a recorded reason: it changes every generation on every install.
-PROJECTION_VERSION = 1
+# V2 includes authoritative credential source revisions. A fixed Secret name
+# cannot identify what an already-running pod loaded before a Secret update.
+PROJECTION_VERSION = 2
 
 #: A warm claim is refused this many seconds BEFORE the generation's credentials
 #: expire, so a turn admitted at the edge cannot lose its state tokens mid-turn.
@@ -193,6 +200,33 @@ class SecretKeyRef:
 
     def as_dict(self) -> dict[str, str]:
         return {"name": self.name, "key": self.key}
+
+
+@dataclass(frozen=True, slots=True)
+class CredentialRevision:
+    """Nonsecret identity from an authoritative credential-source observation.
+
+    The producer must read the actual Secret UID/resourceVersion and bind its
+    name/key to the credential being rendered. For generated state tokens this
+    names the signing-key Secret. Constructing this value does not verify its
+    provenance; no such production observation/rotation producer exists here.
+    Never derive either revision field from a fixed name or credential bytes.
+    """
+
+    source: SecretKeyRef
+    uid: str
+    resource_version: str
+
+    def __post_init__(self) -> None:
+        if not all(isinstance(v, str) and v.strip() for v in (self.uid, self.resource_version)):
+            raise ProjectionError("credential revision needs an observed UID and resourceVersion")
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "source": self.source.as_dict(),
+            "uid": self.uid,
+            "resource_version": self.resource_version,
+        }
 
 
 @dataclass(frozen=True, slots=True)
@@ -323,6 +357,7 @@ class CapabilityProjection:
     secret_refs: Mapping[str, SecretKeyRef]
     credential_keys: tuple[str, ...]
     credential_generation: CredentialGeneration | None
+    credential_revisions: Mapping[str, CredentialRevision] = field(default_factory=dict)
     projection_version: int = PROJECTION_VERSION
     capability_generation: str = field(init=False)
 
@@ -330,6 +365,11 @@ class CapabilityProjection:
         object.__setattr__(self, "env", MappingProxyType(dict(sorted(self.env.items()))))
         object.__setattr__(
             self, "secret_refs", MappingProxyType(dict(sorted(self.secret_refs.items())))
+        )
+        object.__setattr__(
+            self,
+            "credential_revisions",
+            MappingProxyType(dict(sorted(self.credential_revisions.items()))),
         )
         digest = hashlib.sha256(self.canonical_json().encode("utf-8")).hexdigest()
         object.__setattr__(self, "capability_generation", digest)
@@ -347,6 +387,7 @@ class CapabilityProjection:
             "env": dict(self.env),
             "secret_refs": {k: v.as_dict() for k, v in self.secret_refs.items()},
             "credential_keys": list(self.credential_keys),
+            "credential_revisions": {k: v.as_dict() for k, v in self.credential_revisions.items()},
             "credential_generation": (
                 None if self.credential_generation is None else self.credential_generation.as_dict()
             ),
@@ -362,6 +403,20 @@ class CapabilityProjection:
         """The object-name prefix of the generation (names, never identity)."""
 
         return self.capability_generation[:12]
+
+    @property
+    def credential_authority_complete(self) -> bool:
+        """Every loaded credential has a source revision, with exact ref binding."""
+
+        required = set(self.secret_refs) | set(self.credential_keys)
+        if required != set(self.credential_revisions):
+            return False
+        # boot_env signs every state scope with the same platform key. A mixed
+        # signing snapshot cannot describe any generation that renderer minted.
+        signers = {self.credential_revisions[key] for key in self.credential_keys}
+        return len(signers) <= 1 and all(
+            self.credential_revisions[key].source == ref for key, ref in self.secret_refs.items()
+        )
 
 
 def _iter_connector_keys(env: Mapping[str, str]) -> Iterator[str]:
@@ -385,6 +440,7 @@ def project_boot_env(
     model_credential_ref: SecretKeyRef | None,
     connector_secret_name: str | None,
     credential_generation: CredentialGeneration | None,
+    credential_revisions: Mapping[str, CredentialRevision] | None = None,
 ) -> CapabilityProjection:
     """Project one rendered boot env into its warm-template identity.
 
@@ -480,6 +536,11 @@ def project_boot_env(
         secret_refs=secret_refs,
         credential_keys=ordered_credential_keys,
         credential_generation=credential_generation,
+        credential_revisions={
+            key: revision
+            for key, revision in (credential_revisions or {}).items()
+            if key in secret_refs or key in ordered_credential_keys
+        },
     )
 
 
@@ -491,6 +552,7 @@ def warm_boot_projection(
     model_credential_ref: SecretKeyRef | None,
     connector_secret_name: str | None,
     credential_generation: CredentialGeneration | None,
+    credential_revisions: Mapping[str, CredentialRevision] | None = None,
 ) -> CapabilityProjection:
     """The projection of ``resolved`` under this worker's current defaults.
 
@@ -513,6 +575,7 @@ def warm_boot_projection(
         model_credential_ref=model_credential_ref,
         connector_secret_name=connector_secret_name,
         credential_generation=credential_generation,
+        credential_revisions=credential_revisions,
     )
 
 
@@ -530,6 +593,7 @@ class ColdReason(StrEnum):
     APPROVAL_DECISION = "approval-decision"
     EXTRA_CLAIM_ENV = "extra-claim-env"
     CREDENTIAL_GENERATION_EXPIRED = "credential-generation-expired"
+    CREDENTIAL_AUTHORITY_UNVERIFIED = "credential-authority-unverified"
 
 
 _COLD_OVERLAY_KEYS = MappingProxyType(
@@ -566,6 +630,7 @@ def classify_claim(
     workspace_stage: bool = False,
     now: int | None = None,
     margin_seconds: int = DEFAULT_CREDENTIAL_ADMISSION_MARGIN_SECONDS,
+    current_credential_revisions: Mapping[str, CredentialRevision] | None = None,
 ) -> Eligibility:
     """Whether the cold claim env this turn WOULD send can instead bind ``projection``.
 
@@ -627,6 +692,21 @@ def classify_claim(
         rendered_tokens.discard(_STATE_TOKEN_ENV)
     if expected_tokens != rendered_tokens:
         mismatched.extend(sorted(expected_tokens ^ rendered_tokens))
+    required_revisions = set(projection.secret_refs) | set(projection.credential_keys)
+    current_revisions = current_credential_revisions or {}
+    # The renderer's credential values are intentionally never compared or
+    # hashed. Only a fresh authoritative observation can match the exact sources
+    # the warm generation loaded. Missing provenance must stay cold.
+    if not projection.credential_authority_complete or not required_revisions <= set(
+        current_revisions
+    ):
+        reasons.append(ColdReason.CREDENTIAL_AUTHORITY_UNVERIFIED)
+    else:
+        mismatched.extend(
+            key
+            for key in sorted(required_revisions)
+            if current_revisions[key] != projection.credential_revisions[key]
+        )
     generation_mismatch = [
         k
         for k in mismatched

--- a/apps/worker/src/curie_worker/sandbox/warm_pool_targets.py
+++ b/apps/worker/src/curie_worker/sandbox/warm_pool_targets.py
@@ -1,0 +1,330 @@
+"""Warm-pool version targets: exact active winner, pool refs, and lookup (#1492 D1).
+
+A version pool is built for the deployment the cold path actually boots. That
+winner is decided by ONE ordering key -- ``(environment = 'prod') DESC,
+deployed_at DESC, id DESC`` -- duplicated verbatim from ``binding._RESOLVE_SQL``
+and ``connector_loop._TARGETS_SQL`` (the #1216 rule: rank first, decide second).
+A bundleless winner is reported and marked unrealizable; it is never skipped so
+that a lower-ranked bundleful version could be warmed in its place, because the
+sandbox would still boot the bundleless one and a warm pool for the runner-up
+would serve a version no thread is bound to.
+
+``bundle_sha256`` is not on ``ResolvedDeployment`` (the resolver does not need
+it); this module reads it in the same SELECT as a worker-owned fact. No API
+model, migration or public field changes.
+
+Names for the template / pool / Secrets are derived here so W1, the realizer and
+the chart assertions agree on them, but this module never creates, reads or
+writes any Kubernetes object or Secret. The authority under which a realizer may
+write a SandboxTemplate (and thereby reference Secrets) is a separately
+unresolved prerequisite; ``derive_ref`` computing a name grants nothing.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from dataclasses import asdict, dataclass
+from enum import StrEnum
+from typing import TYPE_CHECKING, Any
+
+from aci_protocol import BootEnv
+from sqlalchemy import text
+
+from ..binding import ResolvedDeployment
+from .warm_pool_contract import (
+    CapabilityProjection,
+    CredentialGeneration,
+    SecretKeyRef,
+    warm_boot_projection,
+)
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncEngine
+
+    from ..binding import BindingResolver
+
+
+class TargetError(ValueError):
+    """A target or ref cannot be formed; the caller stays cold."""
+
+
+# Same joins and the SAME total ordering key as binding._RESOLVE_SQL /
+# connector_loop._TARGETS_SQL; a test pins the ORDER BY byte-for-byte. Every
+# agent column ResolvedDeployment reads is selected so the projection is computed
+# from the facts boot_env would use, plus v.bundle_sha256 (worker-owned read).
+# The bundle is REPORTED, never filtered on.
+ACTIVE_WINNERS_SQL = """
+SELECT DISTINCT ON (a.id)
+       a.id AS agent_id,
+       a.name AS agent_name,
+       a.max_usd_per_day AS max_usd_per_day,
+       a.max_output_tokens_per_run AS max_output_tokens_per_run,
+       a.behavior_packs AS behavior_packs,
+       a.model AS model,
+       a.thinking AS thinking,
+       a.approval_required_tools AS approval_required_tools,
+       a.approval_routes AS approval_routes,
+       a.secrets AS secrets,
+       a.memory AS memory,
+       d.id AS deployment_id,
+       d.workspace_enabled AS workspace_enabled,
+       d.environment::text AS environment,
+       v.id AS version_id,
+       v.version_label AS version_label,
+       v.bundle_ref AS bundle_ref,
+       v.bundle_sha256 AS bundle_sha256
+FROM {schema}.agents a
+JOIN {schema}.deployments d ON d.agent_id = a.id AND d.status = 'active'
+JOIN {schema}.agent_versions v ON v.id = d.version_id AND v.agent_id = a.id
+{where}
+ORDER BY a.id, (d.environment = 'prod') DESC, d.deployed_at DESC, d.id DESC
+"""
+
+_JSON_COLUMNS = ("behavior_packs", "approval_required_tools", "approval_routes", "secrets")
+
+
+@dataclass(frozen=True, slots=True)
+class ActiveWinner:
+    """The in-force deployment for one agent plus the worker-owned bundle digest."""
+
+    resolved: ResolvedDeployment
+    bundle_sha256: str | None
+    environment: str
+
+    def __repr__(self) -> str:  # never the connector-secret values on `resolved`
+        return (
+            f"ActiveWinner(agent_id={self.resolved.agent_id}, "
+            f"version_id={self.resolved.version_id}, "
+            f"deployment_id={self.resolved.deployment_id}, environment={self.environment!r})"
+        )
+
+
+def _winner_from_row(row: Any) -> ActiveWinner:
+    data = dict(row)
+    for column in _JSON_COLUMNS:
+        value = data.get(column)
+        if isinstance(value, str):
+            data[column] = json.loads(value)
+    bundle_sha256 = data.pop("bundle_sha256")
+    environment = str(data.pop("environment"))
+    return ActiveWinner(
+        resolved=ResolvedDeployment.model_validate(data),
+        bundle_sha256=bundle_sha256,
+        environment=environment,
+    )
+
+
+async def active_winners(engine: AsyncEngine, schema: str) -> list[ActiveWinner]:
+    """Every agent's in-force deployment, one row per agent."""
+
+    sql = text(ACTIVE_WINNERS_SQL.format(schema=schema, where=""))
+    async with engine.connect() as conn:
+        rows = (await conn.execute(sql)).mappings().all()
+    return [_winner_from_row(row) for row in rows]
+
+
+async def active_winner(
+    engine: AsyncEngine, schema: str, agent_id: uuid.UUID
+) -> ActiveWinner | None:
+    """One agent's in-force deployment, or None when it has no active deployment."""
+
+    sql = text(ACTIVE_WINNERS_SQL.format(schema=schema, where="WHERE a.id = :agent_id"))
+    async with engine.connect() as conn:
+        row = (await conn.execute(sql, {"agent_id": agent_id})).mappings().first()
+    return None if row is None else _winner_from_row(row)
+
+
+@dataclass(frozen=True, slots=True)
+class VersionPoolTarget:
+    """What a version pool would be built for. Printable; carries no credentials."""
+
+    namespace: str
+    agent_id: str
+    version_id: str
+    deployment_id: str
+    version_label: str
+    bundle_ref: str | None
+    bundle_sha256: str | None
+    environment: str
+    capability_generation: str
+    projection: CapabilityProjection
+    #: False means report-only: the winner exists but no pool may be realized
+    #: for it (and none for any other version of this agent either).
+    realizable: bool
+    refusal: str | None
+
+
+def build_target(
+    winner: ActiveWinner,
+    resolver: BindingResolver,
+    *,
+    namespace: str,
+    model_credential_ref: SecretKeyRef | None,
+    connector_secret_name: str | None,
+    credential_generation: CredentialGeneration | None,
+) -> VersionPoolTarget:
+    """Project the winner under the resolver's current defaults into a target."""
+
+    resolved = winner.resolved
+    if resolved.deployment_id is None:
+        raise TargetError("active winner has no deployment id; refusing to name a pool for it")
+    if not namespace:
+        raise TargetError("a version pool target needs a namespace")
+    projection = warm_boot_projection(
+        resolver,
+        resolved,
+        bundle_sha256=winner.bundle_sha256,
+        model_credential_ref=model_credential_ref,
+        connector_secret_name=connector_secret_name,
+        credential_generation=credential_generation,
+    )
+    refusal: str | None = None
+    if not resolved.bundle_ref:
+        refusal = "bundleless-winner"
+    elif not winner.bundle_sha256:
+        refusal = "bundle-sha256-missing"
+    return VersionPoolTarget(
+        namespace=namespace,
+        agent_id=str(resolved.agent_id),
+        version_id=str(resolved.version_id),
+        deployment_id=str(resolved.deployment_id),
+        version_label=resolved.version_label,
+        bundle_ref=resolved.bundle_ref,
+        bundle_sha256=winner.bundle_sha256,
+        environment=winner.environment,
+        capability_generation=projection.capability_generation,
+        projection=projection,
+        realizable=refusal is None,
+        refusal=refusal,
+    )
+
+
+# RFC 1123 label, as Kubernetes validates object names used as pod-name prefixes.
+_DNS_LABEL = re.compile(r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$")
+_MAX_LABEL = 63
+# The chart's generic and per-agent pool shapes ({fullname}-runner-pool and
+# {fullname}-agent-<name>-runner-pool) and the infix the CLI's Helm-revision
+# recovery derives; version-pool names must never be mistaken for either.
+_HELM_POOL_SUFFIX = "-runner-pool"
+_HELM_AGENT_INFIX = "-agent-"
+_INFIX = "-vp-"
+_SUFFIXES = {
+    "template": "-tpl",
+    "pool": "-pool",
+    "bootstrap": "-bootstrap",
+    "credential": "-state",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class VersionPoolRef:
+    """The deterministic object names of one (version, generation) pool.
+
+    ``bootstrap_secret_key`` is the substrate-only ``BootEnv`` key the pool
+    Secret is delivered under; ``credential_secret_keys`` are the generation
+    Secret's keys. Names only: existence, ownership and authority are decided by
+    a realizer this module does not contain.
+    """
+
+    namespace: str
+    version_id: str
+    capability_generation: str
+    template_name: str
+    pool_name: str
+    bootstrap_secret_name: str
+    bootstrap_secret_key: str
+    credential_secret_name: str
+    credential_secret_keys: tuple[str, ...]
+
+    def as_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["credential_secret_keys"] = tuple(self.credential_secret_keys)
+        return data
+
+
+def _validate_prefix(prefix: str) -> None:
+    if not prefix or not _DNS_LABEL.match(prefix):
+        raise TargetError(f"pool name prefix {prefix!r} is not a lowercase DNS label")
+    if (
+        prefix.endswith(_HELM_POOL_SUFFIX)
+        or _HELM_AGENT_INFIX in prefix
+        or prefix.endswith("-runner")
+    ):
+        raise TargetError(f"pool name prefix {prefix!r} collides with the chart's Helm pool shapes")
+
+
+def derive_ref(target: VersionPoolTarget, *, prefix: str) -> VersionPoolRef:
+    """Names for ``target``'s pool under ``prefix`` (the chart-exported release name).
+
+    ``prefix`` must be the operator-owned name the chart exports for the
+    worker, not a value derived by stripping a pool suffix (an operator
+    override makes that derivation wrong). Refuses an unrealizable target and
+    any name that would exceed the 63-character label limit or read as a Helm
+    generic / per-agent pool.
+    """
+
+    if not target.realizable:
+        raise TargetError(
+            f"target is not realizable ({target.refusal}); no ref for a {target.refusal}"
+        )
+    _validate_prefix(prefix)
+    version12 = uuid.UUID(target.version_id).hex[:12]
+    stem = f"{prefix}{_INFIX}{version12}-{target.capability_generation[:12]}"
+    names = {kind: f"{stem}{suffix}" for kind, suffix in _SUFFIXES.items()}
+    for kind, name in names.items():
+        if len(name) > _MAX_LABEL or not _DNS_LABEL.match(name):
+            raise TargetError(
+                f"{kind} name {name!r} is not a valid label of at most {_MAX_LABEL} chars"
+            )
+        if name.endswith(_HELM_POOL_SUFFIX) or _HELM_AGENT_INFIX in name:
+            raise TargetError(f"{kind} name {name!r} reads as a chart Helm pool")
+    return VersionPoolRef(
+        namespace=target.namespace,
+        version_id=target.version_id,
+        capability_generation=target.capability_generation,
+        template_name=names["template"],
+        pool_name=names["pool"],
+        bootstrap_secret_name=names["bootstrap"],
+        bootstrap_secret_key=BootEnv.env_key("runner_bootstrap_token"),
+        credential_secret_name=names["credential"],
+        credential_secret_keys=tuple(target.projection.credential_keys),
+    )
+
+
+class LookupOutcome(StrEnum):
+    """W1 requires MATCH; ABSENT and MISMATCH both mean cold, never another pool."""
+
+    MATCH = "match"
+    ABSENT = "absent"
+    MISMATCH = "mismatch"
+
+
+@dataclass(frozen=True, slots=True)
+class ObservedGeneration:
+    """What a realizer/W1 observed on an existing template (labels), if any."""
+
+    template_name: str
+    version_id: str | None
+    capability_generation: str | None
+
+
+def lookup(observed: ObservedGeneration | None, target: VersionPoolTarget) -> LookupOutcome:
+    """Compare an observed template identity against the CURRENT target.
+
+    Pure. The caller re-runs it immediately before each warm claim with a fresh
+    observation and a fresh target; a stale match is exactly the skew ADR-0122
+    forbids. An unrealizable target never matches.
+    """
+
+    if not target.realizable:
+        return LookupOutcome.MISMATCH
+    if observed is None:
+        return LookupOutcome.ABSENT
+    if (
+        observed.version_id == target.version_id
+        and observed.capability_generation == target.capability_generation
+    ):
+        return LookupOutcome.MATCH
+    return LookupOutcome.MISMATCH

--- a/apps/worker/src/curie_worker/sandbox/warm_pool_targets.py
+++ b/apps/worker/src/curie_worker/sandbox/warm_pool_targets.py
@@ -85,13 +85,35 @@ ORDER BY a.id, (d.environment = 'prod') DESC, d.deployed_at DESC, d.id DESC
 _JSON_COLUMNS = ("behavior_packs", "approval_required_tools", "approval_routes", "secrets")
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class ActiveWinner:
-    """The in-force deployment for one agent plus the worker-owned bundle digest."""
+    """The in-force deployment for one agent plus the worker-owned bundle digest.
+
+    Equality and hashing use nonsecret identity only: ``resolved`` carries the
+    local tier's connector-secret VALUES, so the generated dataclass comparison
+    would compare credential bytes. ``repr`` likewise never prints ``resolved``.
+    """
 
     resolved: ResolvedDeployment
     bundle_sha256: str | None
     environment: str
+
+    def identity(self) -> tuple[str, str, str | None, str | None, str]:
+        return (
+            str(self.resolved.agent_id),
+            str(self.resolved.version_id),
+            None if self.resolved.deployment_id is None else str(self.resolved.deployment_id),
+            self.bundle_sha256,
+            self.environment,
+        )
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, ActiveWinner):
+            return NotImplemented
+        return self.identity() == other.identity()
+
+    def __hash__(self) -> int:
+        return hash(self.identity())
 
     def __repr__(self) -> str:  # never the connector-secret values on `resolved`
         return (
@@ -240,7 +262,11 @@ class SlotAllocation:
     as the Role's ``resourceNames``. Which generation currently occupies a slot
     is carried by labels, never by the name. Allocation, quarantine and
     exhaustion policy belong to the realizer; this type only refuses a name the
-    grant could not cover.
+    grant could not cover. A slot's Secret may be written only while the slot is
+    unoccupied (its previous pool and template deleted and quarantined); it is
+    never updated in place under a live pool, because with static slot names
+    that rewrite would be exactly the value rotation beneath running pods that
+    Accepted ADR-0122 and Decision B forbid.
     """
 
     secret_prefix: str
@@ -335,8 +361,8 @@ def derive_ref(target: VersionPoolTarget, *, prefix: str, slot: SlotAllocation) 
     names = {kind: f"{stem}{suffix}" for kind, suffix in _SUFFIXES.items()}
     _validate_label("template", names["template"])
     _validate_label("pool", names["pool"], limit=_MAX_POOL_LABEL)
-    if slot.secret_name in names.values():
-        raise TargetError("slot secret name collides with a template or pool name")
+    # Slot Secret names end in a digit; template/pool names end in -tpl/-pool,
+    # so the three are disjoint by construction (pinned by a test, not a guard).
     return VersionPoolRef(
         namespace=target.namespace,
         version_id=target.version_id,

--- a/apps/worker/src/curie_worker/sandbox/warm_pool_targets.py
+++ b/apps/worker/src/curie_worker/sandbox/warm_pool_targets.py
@@ -70,7 +70,7 @@ SELECT DISTINCT ON (a.id)
        a.memory AS memory,
        d.id AS deployment_id,
        d.workspace_enabled AS workspace_enabled,
-       d.environment::text AS environment,
+       CAST(d.environment AS text) AS environment,
        v.id AS version_id,
        v.version_label AS version_label,
        v.bundle_ref AS bundle_ref,
@@ -204,38 +204,98 @@ def build_target(
 # RFC 1123 label, as Kubernetes validates object names used as pod-name prefixes.
 _DNS_LABEL = re.compile(r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$")
 _MAX_LABEL = 63
+# The Agent Sandbox controller derives Sandbox / pod / Service names FROM the
+# pool name; those derived names must also fit the label limit. The suffix the
+# vendored controller appends is not part of any contract we own, so a
+# documented conservative budget is reserved here (adversarial cleared-attack 3,
+# Fable D-2) rather than trusting the pool name alone to fit.
+_CONTROLLER_SUFFIX_BUDGET = 12
+_MAX_POOL_LABEL = _MAX_LABEL - _CONTROLLER_SUFFIX_BUDGET
 # The chart's generic and per-agent pool shapes ({fullname}-runner-pool and
 # {fullname}-agent-<name>-runner-pool) and the infix the CLI's Helm-revision
 # recovery derives; version-pool names must never be mistaken for either.
 _HELM_POOL_SUFFIX = "-runner-pool"
 _HELM_AGENT_INFIX = "-agent-"
 _INFIX = "-vp-"
-_SUFFIXES = {
-    "template": "-tpl",
-    "pool": "-pool",
-    "bootstrap": "-bootstrap",
-    "credential": "-state",
-}
+_SUFFIXES = {"template": "-tpl", "pool": "-pool"}
+
+
+def _validate_label(kind: str, name: str, *, limit: int = _MAX_LABEL) -> None:
+    if not name or len(name) > limit or not _DNS_LABEL.match(name):
+        raise TargetError(f"{kind} name {name!r} is not a valid label of at most {limit} chars")
+    if name.endswith(_HELM_POOL_SUFFIX) or _HELM_AGENT_INFIX in name or name.endswith("-runner"):
+        raise TargetError(f"{kind} name {name!r} reads as a chart Helm pool")
+
+
+@dataclass(frozen=True, slots=True)
+class SlotAllocation:
+    """One bounded, chart-granted Secret slot (proposal D3, amendment B2, Fable D-1).
+
+    Accepted ADR-0122 decision 4 needs exact-name Secret ``get`` that survives a
+    worker restart and a second replica. Kubernetes ``resourceNames`` is a
+    static list, so Secret names cannot be derived from a version or generation
+    hash: they are ``{secret_prefix}-{index}`` for ``index < max_slots``, where
+    both values are the chart-exported ``CURIE_WARM_BOOTSTRAP_SECRET_PREFIX`` /
+    ``CURIE_WARM_BOOTSTRAP_MAX_SLOTS`` rendered from the SAME template variables
+    as the Role's ``resourceNames``. Which generation currently occupies a slot
+    is carried by labels, never by the name. Allocation, quarantine and
+    exhaustion policy belong to the realizer; this type only refuses a name the
+    grant could not cover.
+    """
+
+    secret_prefix: str
+    max_slots: int
+    index: int
+
+    def __post_init__(self) -> None:
+        if not self.secret_prefix or not _DNS_LABEL.match(self.secret_prefix):
+            raise TargetError(
+                f"slot secret prefix {self.secret_prefix!r} is not a lowercase DNS label"
+            )
+        if self.max_slots <= 0:
+            raise TargetError("slot bound must be a positive integer")
+        if not 0 <= self.index < self.max_slots:
+            raise TargetError(
+                f"slot index {self.index} is outside the granted range 0..{self.max_slots - 1}"
+            )
+        _validate_label("slot secret", self.secret_name)
+
+    @property
+    def secret_name(self) -> str:
+        return f"{self.secret_prefix}-{self.index}"
+
+
+def slot_secret_names(secret_prefix: str, max_slots: int) -> tuple[str, ...]:
+    """The exact bounded name list the chart must grant as ``resourceNames``.
+
+    The chart assertion (proposal control 14) compares its rendered list to this
+    function's output for the same prefix and bound; a realizer refuses to
+    create any Secret name outside it even where the API would allow it.
+    """
+
+    return tuple(SlotAllocation(secret_prefix, max_slots, i).secret_name for i in range(max_slots))
 
 
 @dataclass(frozen=True, slots=True)
 class VersionPoolRef:
     """The deterministic object names of one (version, generation) pool.
 
-    ``bootstrap_secret_key`` is the substrate-only ``BootEnv`` key the pool
-    Secret is delivered under; ``credential_secret_keys`` are the generation
-    Secret's keys. Names only: existence, ownership and authority are decided by
-    a realizer this module does not contain.
+    Template and pool names are generation-derived. The ONE granted slot Secret
+    carries both the substrate-only bootstrap key (``bootstrap_secret_key``) and
+    the generation's state-credential keys (``credential_secret_keys``): one
+    Secret per generation, so the exact-name grant, quarantine and retirement
+    have a single object to cover. Names only: existence, ownership and
+    authority are decided by a realizer this module does not contain.
     """
 
     namespace: str
     version_id: str
     capability_generation: str
+    slot_index: int
     template_name: str
     pool_name: str
     bootstrap_secret_name: str
     bootstrap_secret_key: str
-    credential_secret_name: str
     credential_secret_keys: tuple[str, ...]
 
     def as_dict(self) -> dict[str, Any]:
@@ -255,14 +315,14 @@ def _validate_prefix(prefix: str) -> None:
         raise TargetError(f"pool name prefix {prefix!r} collides with the chart's Helm pool shapes")
 
 
-def derive_ref(target: VersionPoolTarget, *, prefix: str) -> VersionPoolRef:
-    """Names for ``target``'s pool under ``prefix`` (the chart-exported release name).
+def derive_ref(target: VersionPoolTarget, *, prefix: str, slot: SlotAllocation) -> VersionPoolRef:
+    """Names for ``target``'s pool under ``prefix`` in the granted ``slot``.
 
     ``prefix`` must be the operator-owned name the chart exports for the
     worker, not a value derived by stripping a pool suffix (an operator
-    override makes that derivation wrong). Refuses an unrealizable target and
-    any name that would exceed the 63-character label limit or read as a Helm
-    generic / per-agent pool.
+    override makes that derivation wrong). Refuses an unrealizable target, any
+    prefix or name outside the label rules, a pool name without controller
+    headroom, and a slot the grant could not cover.
     """
 
     if not target.realizable:
@@ -270,25 +330,22 @@ def derive_ref(target: VersionPoolTarget, *, prefix: str) -> VersionPoolRef:
             f"target is not realizable ({target.refusal}); no ref for a {target.refusal}"
         )
     _validate_prefix(prefix)
-    version12 = uuid.UUID(target.version_id).hex[:12]
-    stem = f"{prefix}{_INFIX}{version12}-{target.capability_generation[:12]}"
+    version8 = uuid.UUID(target.version_id).hex[:8]
+    stem = f"{prefix}{_INFIX}{version8}-{target.capability_generation[:12]}"
     names = {kind: f"{stem}{suffix}" for kind, suffix in _SUFFIXES.items()}
-    for kind, name in names.items():
-        if len(name) > _MAX_LABEL or not _DNS_LABEL.match(name):
-            raise TargetError(
-                f"{kind} name {name!r} is not a valid label of at most {_MAX_LABEL} chars"
-            )
-        if name.endswith(_HELM_POOL_SUFFIX) or _HELM_AGENT_INFIX in name:
-            raise TargetError(f"{kind} name {name!r} reads as a chart Helm pool")
+    _validate_label("template", names["template"])
+    _validate_label("pool", names["pool"], limit=_MAX_POOL_LABEL)
+    if slot.secret_name in names.values():
+        raise TargetError("slot secret name collides with a template or pool name")
     return VersionPoolRef(
         namespace=target.namespace,
         version_id=target.version_id,
         capability_generation=target.capability_generation,
+        slot_index=slot.index,
         template_name=names["template"],
         pool_name=names["pool"],
-        bootstrap_secret_name=names["bootstrap"],
+        bootstrap_secret_name=slot.secret_name,
         bootstrap_secret_key=BootEnv.env_key("runner_bootstrap_token"),
-        credential_secret_name=names["credential"],
         credential_secret_keys=tuple(target.projection.credential_keys),
     )
 

--- a/apps/worker/src/curie_worker/sandbox/warm_pool_targets.py
+++ b/apps/worker/src/curie_worker/sandbox/warm_pool_targets.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import json
 import re
 import uuid
+from collections.abc import Mapping
 from dataclasses import asdict, dataclass
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any
@@ -36,6 +37,7 @@ from ..binding import ResolvedDeployment
 from .warm_pool_contract import (
     CapabilityProjection,
     CredentialGeneration,
+    CredentialRevision,
     SecretKeyRef,
     warm_boot_projection,
 )
@@ -186,6 +188,7 @@ def build_target(
     model_credential_ref: SecretKeyRef | None,
     connector_secret_name: str | None,
     credential_generation: CredentialGeneration | None,
+    credential_revisions: Mapping[str, CredentialRevision] | None = None,
 ) -> VersionPoolTarget:
     """Project the winner under the resolver's current defaults into a target."""
 
@@ -201,12 +204,15 @@ def build_target(
         model_credential_ref=model_credential_ref,
         connector_secret_name=connector_secret_name,
         credential_generation=credential_generation,
+        credential_revisions=credential_revisions,
     )
     refusal: str | None = None
     if not resolved.bundle_ref:
         refusal = "bundleless-winner"
     elif not winner.bundle_sha256:
         refusal = "bundle-sha256-missing"
+    elif not projection.credential_authority_complete:
+        refusal = "credential-authority-unverified"
     return VersionPoolTarget(
         namespace=namespace,
         agent_id=str(resolved.agent_id),

--- a/apps/worker/tests/sandbox/test_warm_pool_contract.py
+++ b/apps/worker/tests/sandbox/test_warm_pool_contract.py
@@ -1,0 +1,525 @@
+"""Warm-pool capability projection (#1492 D1): deterministic, secret-free, cold-honest.
+
+The projection is the version-stable subset of the SAME boot env the cold path
+renders (``BindingResolver.boot_env``), so a new boot key cannot silently drift
+between a cold claim and a warm template: an unclassified key refuses the
+projection rather than being guessed into or out of the hash. Credentials are
+identity only -- a ``secretKeyRef`` name/key or a nonsecret generation/expiry --
+and no token byte may reach the hash, ``repr`` or a log line.
+
+Nothing here touches Kubernetes, a Secret, Postgres or Valkey.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+
+import pytest
+from aci_protocol import BootEnv
+from curie_worker import sandbox_token
+from curie_worker.binding import (
+    DECISION_ENV,
+    FALSE_COMPLETION_CHECK_ENV,
+    GRANT_TOOL_ENV,
+    RESUMED_KIND_ENV,
+    SANDBOX_TOKEN_TTL_SECONDS,
+    BindingResolver,
+    ResolvedDeployment,
+)
+from curie_worker.config import WorkerConfig
+from curie_worker.sandbox.warm_pool_contract import (
+    PROJECTION_THREAD_SENTINEL,
+    STATE_APP_SCOPE,
+    STATE_SCOPE,
+    CapabilityProjection,
+    ColdReason,
+    CredentialGeneration,
+    ProjectionError,
+    SecretKeyRef,
+    classify_claim,
+    mint_credential_generation,
+    project_boot_env,
+    warm_boot_projection,
+    worker_env_classes,
+)
+from curie_worker.workspace import WORKSPACE_REF_ENV, WORKSPACE_SHA256_ENV
+
+PLATFORM_KEY = "unit-test-platform-key"
+AGENT_ID = uuid.UUID("00000000-0000-4000-8000-000000000001")
+VERSION_ID = uuid.UUID("00000000-0000-4000-8000-0000000000a1")
+DEPLOYMENT_ID = uuid.UUID("00000000-0000-4000-8000-0000000000d1")
+BASELINE_CREDENTIAL = SecretKeyRef(name="curie-runner-credentials", key="agentCredentials")
+CONNECTOR_SECRET_NAME = "curie-agent-sre-connector-secrets"
+GENERATION = CredentialGeneration.for_window(str(AGENT_ID), issued_at=1_800_000_000)
+
+SESSION_ENV = BootEnv.env_key("session_id")
+HISTORY_REF_ENV = BootEnv.env_key("history_ref")
+RUNNER_TOKEN_ENV = BootEnv.env_key("runner_token")
+HISTORY_TOKEN_ENV = BootEnv.env_key("history_token")
+MEMORY_TOKEN_ENV = BootEnv.env_key("memory_token")
+STATE_TOKEN_ENV = BootEnv.env_key("state_token")
+STATE_URL_ENV = BootEnv.env_key("state_url")
+CREDENTIALS_ENV = BootEnv.env_key("credentials_ref")
+MODEL_ENV = BootEnv.env_key("model")
+MEMORY_REF_ENV = BootEnv.env_key("memory_ref")
+CONNECTOR_SECRET_KEYS_ENV = BootEnv.env_key("connector_secret_keys")
+
+
+def _resolved(**overrides: object) -> ResolvedDeployment:
+    base: dict[str, object] = {
+        "agent_id": AGENT_ID,
+        "agent_name": "sre",
+        "deployment_id": DEPLOYMENT_ID,
+        "version_id": VERSION_ID,
+        "version_label": "v3",
+        "bundle_ref": "bundles/sre/v3.tgz",
+        "max_usd_per_day": None,
+        "max_output_tokens_per_run": None,
+        "model": "claude-opus-5",
+        "thinking": None,
+        "approval_required_tools": ["Bash"],
+        "secrets": None,
+        "memory": True,
+    }
+    base.update(overrides)
+    return ResolvedDeployment.model_validate(base)
+
+
+def _config(**overrides: object) -> WorkerConfig:
+    base: dict[str, object] = {
+        "api_key": PLATFORM_KEY,
+        "credentials": "sk-live-model-credential-value",
+        "connector_release": "curie",
+        "connector_namespace": "curie",
+        "model": "claude-sonnet-5",
+    }
+    base.update(overrides)
+    return WorkerConfig(**base)  # type: ignore[arg-type]
+
+
+def _resolver(config: WorkerConfig | None = None) -> BindingResolver:
+    # boot_env never touches the engine; the projection is a pure render.
+    return BindingResolver(object(), config or _config())  # type: ignore[arg-type]
+
+
+def _project(
+    resolved: ResolvedDeployment | None = None,
+    config: WorkerConfig | None = None,
+    **overrides: object,
+) -> CapabilityProjection:
+    cfg = config or _config()
+    resolved = resolved or _resolved()
+    generation = (
+        CredentialGeneration.for_window(str(resolved.agent_id), issued_at=GENERATION.issued_at)
+        if cfg.api_key
+        else None
+    )
+    kwargs: dict[str, object] = {
+        "bundle_sha256": "ab" * 32,
+        "model_credential_ref": BASELINE_CREDENTIAL,
+        "connector_secret_name": CONNECTOR_SECRET_NAME,
+        "credential_generation": generation,
+    }
+    kwargs.update(overrides)
+    return warm_boot_projection(_resolver(cfg), resolved, **kwargs)  # type: ignore[arg-type]
+
+
+# --- projection derives from the real cold render -------------------------------
+
+
+def test_projection_is_the_version_stable_subset_of_the_cold_boot_env() -> None:
+    resolver = _resolver()
+    resolved = _resolved()
+    cold = resolver.boot_env(resolved, "1234.5678", kind="slack", address="C0EXAMPLE1")
+    projection = _project(resolved)
+
+    for key in (
+        BootEnv.env_key("plugin_dir"),
+        BootEnv.env_key("budget"),
+        MEMORY_REF_ENV,
+        BootEnv.env_key("bundle_ref"),
+        BootEnv.env_key("bundle_version"),
+        MODEL_ENV,
+        BootEnv.env_key("approval_required_tools"),
+        BootEnv.env_key("connector_release"),
+        BootEnv.env_key("connector_agent"),
+        BootEnv.env_key("connector_namespace"),
+        STATE_URL_ENV,
+    ):
+        assert projection.env[key] == cold[key], key
+    for key in (
+        SESSION_ENV,
+        HISTORY_REF_ENV,
+        RUNNER_TOKEN_ENV,
+        HISTORY_TOKEN_ENV,
+        MEMORY_TOKEN_ENV,
+        STATE_TOKEN_ENV,
+        CREDENTIALS_ENV,
+    ):
+        assert key not in projection.env, key
+    assert projection.credential_keys == (HISTORY_TOKEN_ENV, MEMORY_TOKEN_ENV, STATE_TOKEN_ENV)
+    assert projection.secret_refs[CREDENTIALS_ENV] == BASELINE_CREDENTIAL
+    assert projection.credential_generation == GENERATION
+    assert PROJECTION_THREAD_SENTINEL not in projection.canonical_json()
+    assert projection.bundle_sha256 == "ab" * 32
+    assert projection.version_id == str(VERSION_ID)
+    assert projection.deployment_id == str(DEPLOYMENT_ID)
+
+
+def test_generation_is_deterministic_for_identical_inputs() -> None:
+    assert _project().capability_generation == _project().capability_generation
+    assert len(_project().capability_generation) == 64
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        {"model": "claude-sonnet-5"},
+        {"thinking": "high"},
+        {"max_usd_per_day": 3.5},
+        {"max_output_tokens_per_run": 4096},
+        {"approval_required_tools": ["Bash", "Write"]},
+        {"agent_id": uuid.UUID("00000000-0000-4000-8000-000000000002")},
+        {"bundle_ref": "bundles/sre/v4.tgz"},
+        {"version_label": "v4"},
+        {"version_id": uuid.UUID("00000000-0000-4000-8000-0000000000a2")},
+    ],
+    ids=lambda m: next(iter(m)),
+)
+def test_mutable_agent_or_version_change_mints_a_new_generation(mutation: dict) -> None:
+    assert _project().capability_generation != _project(_resolved(**mutation)).capability_generation
+
+
+def test_worker_default_model_change_mints_a_new_generation_when_agent_pins_none() -> None:
+    resolved = _resolved(model=None)
+    a = _project(resolved, _config(model="claude-sonnet-5"))
+    b = _project(resolved, _config(model="claude-opus-5"))
+    assert a.env[MODEL_ENV] == "claude-sonnet-5"
+    assert a.capability_generation != b.capability_generation
+
+
+def test_bundle_sha256_and_credential_window_are_part_of_the_generation() -> None:
+    base = _project()
+    assert base.capability_generation != _project(bundle_sha256="cd" * 32).capability_generation
+    renewed = CredentialGeneration.for_window(str(AGENT_ID), issued_at=1_800_000_000 + 3600)
+    assert (
+        base.capability_generation != _project(credential_generation=renewed).capability_generation
+    )
+
+
+def test_memory_ref_is_included_and_omitting_it_is_refused() -> None:
+    projection = _project()
+    assert projection.env[MEMORY_REF_ENV].endswith(f"/agents/{AGENT_ID}/state/memory")
+    env = dict(_resolver().boot_env(_resolved(), PROJECTION_THREAD_SENTINEL))
+    env.pop(MEMORY_REF_ENV)
+    with pytest.raises(ProjectionError, match="memory_ref"):
+        project_boot_env(env, **_identity(), credential_generation=GENERATION)
+
+
+# --- per-conversation and credential material never reach the hash --------------
+
+
+def _identity(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "agent_id": str(AGENT_ID),
+        "version_id": str(VERSION_ID),
+        "deployment_id": str(DEPLOYMENT_ID),
+        "version_label": "v3",
+        "bundle_ref": "bundles/sre/v3.tgz",
+        "bundle_sha256": "ab" * 32,
+        "memory": True,
+        "model_credential_ref": BASELINE_CREDENTIAL,
+        "connector_secret_name": CONNECTOR_SECRET_NAME,
+    }
+    base.update(overrides)
+    return base
+
+
+def _cold_env(**overrides: str) -> dict[str, str]:
+    env = dict(_resolver().boot_env(_resolved(), "thread-a", kind="slack", address="C0EXAMPLE1"))
+    env.update(overrides)
+    return env
+
+
+def test_per_conversation_inputs_do_not_change_the_generation() -> None:
+    a = project_boot_env(_cold_env(), **_identity(), credential_generation=GENERATION)
+    b = project_boot_env(
+        _cold_env(
+            **{
+                SESSION_ENV: "agent-x-thread-other",
+                HISTORY_REF_ENV: "http://api/agents/x/state/transcript/other",
+                RUNNER_TOKEN_ENV: "another-per-claim-token",
+                HISTORY_TOKEN_ENV: "sbx.other.sig",
+                MEMORY_TOKEN_ENV: "sbx.other.sig",
+                STATE_TOKEN_ENV: "sbx.other2.sig",
+            }
+        ),
+        **_identity(),
+        credential_generation=GENERATION,
+    )
+    assert a.capability_generation == b.capability_generation
+
+
+def test_token_and_credential_values_never_reach_json_repr_str_or_logs(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    material = {
+        RUNNER_TOKEN_ENV: "RUNNER-MATERIAL-7f3a",
+        HISTORY_TOKEN_ENV: "HISTORY-MATERIAL-7f3a",
+        MEMORY_TOKEN_ENV: "MEMORY-MATERIAL-7f3a",
+        STATE_TOKEN_ENV: "STATE-MATERIAL-7f3a",
+        CREDENTIALS_ENV: "CREDENTIAL-MATERIAL-7f3a",
+        "GH_TOKEN": "CONNECTOR-MATERIAL-7f3a",
+        CONNECTOR_SECRET_KEYS_ENV: "GH_TOKEN",
+    }
+    projection = project_boot_env(
+        _cold_env(**material), **_identity(), credential_generation=GENERATION
+    )
+    with caplog.at_level(logging.DEBUG):
+        logging.getLogger("test").info("projection %s %r", projection, projection)
+    rendered = "\n".join(
+        [projection.canonical_json(), repr(projection), str(projection), caplog.text]
+    )
+    for key, value in material.items():
+        if key == CONNECTOR_SECRET_KEYS_ENV:
+            continue
+        assert value not in rendered, key
+    assert projection.env[CONNECTOR_SECRET_KEYS_ENV] == "GH_TOKEN"
+    assert "GH_TOKEN" not in projection.env
+    assert projection.secret_refs["GH_TOKEN"] == SecretKeyRef(
+        name=CONNECTOR_SECRET_NAME, key="GH_TOKEN"
+    )
+
+
+def test_a_credential_value_leaking_through_another_key_is_refused() -> None:
+    env = _cold_env(**{CREDENTIALS_ENV: "LEAK-ME", "CURIE_MODEL": "LEAK-ME"})
+    with pytest.raises(ProjectionError, match="credential value"):
+        project_boot_env(env, **_identity(), credential_generation=GENERATION)
+
+
+def test_unclassified_boot_key_refuses_the_projection() -> None:
+    env = _cold_env(CURIE_FUTURE_KNOB="1")
+    with pytest.raises(ProjectionError, match="CURIE_FUTURE_KNOB"):
+        project_boot_env(env, **_identity(), credential_generation=GENERATION)
+
+
+def test_every_worker_boot_key_is_classified() -> None:
+    classes = worker_env_classes()
+    expected = set(BootEnv.env_keys("worker")) | {
+        GRANT_TOOL_ENV,
+        RESUMED_KIND_ENV,
+        DECISION_ENV,
+        FALSE_COMPLETION_CHECK_ENV,
+        WORKSPACE_REF_ENV,
+        WORKSPACE_SHA256_ENV,
+    }
+    assert expected <= set(classes)
+    assert BootEnv.env_key("runner_bootstrap_token") not in classes  # substrate-only, never worker
+
+
+def test_model_credential_without_a_secret_ref_is_refused() -> None:
+    with pytest.raises(ProjectionError, match=CREDENTIALS_ENV):
+        project_boot_env(
+            _cold_env(),
+            **_identity(model_credential_ref=None),
+            credential_generation=GENERATION,
+        )
+
+
+def test_fake_model_install_without_credential_needs_no_secret_ref() -> None:
+    projection = _project(
+        config=_config(credentials="", fake_model=True), model_credential_ref=None
+    )
+    assert CREDENTIALS_ENV not in projection.secret_refs
+    assert projection.env[BootEnv.env_key("fake_model")] == "1"
+
+
+def test_connector_secret_without_a_secret_name_is_refused() -> None:
+    resolved = _resolved(secrets={"GH_TOKEN": "value"})
+    with pytest.raises(ProjectionError, match="GH_TOKEN"):
+        _project(resolved, connector_secret_name=None)
+
+
+def test_state_tokens_and_credential_generation_must_agree() -> None:
+    with pytest.raises(ProjectionError, match="credential generation"):
+        _project(credential_generation=None)
+    with pytest.raises(ProjectionError, match="credential generation"):
+        _project(config=_config(api_key=""), credential_generation=GENERATION)
+    no_key = _project(config=_config(api_key=""), credential_generation=None)
+    assert no_key.credential_keys == ()
+    assert no_key.credential_generation is None
+
+
+def test_generation_for_another_agent_is_refused() -> None:
+    other = CredentialGeneration.for_window("not-this-agent", issued_at=1_800_000_000)
+    with pytest.raises(ProjectionError, match="agent"):
+        _project(credential_generation=other)
+
+
+# --- memory=false: binding-scoped state cannot be pre-baked ------------------------
+
+
+def test_memory_false_drops_the_binding_scoped_state_url_from_the_template() -> None:
+    projection = _project(_resolved(memory=False))
+    assert STATE_URL_ENV not in projection.env
+    assert STATE_TOKEN_ENV not in projection.credential_keys
+    assert projection.memory is False
+
+
+def test_memory_true_keeps_only_the_agent_wide_state_url() -> None:
+    projection = _project()
+    assert projection.env[STATE_URL_ENV].endswith(f"/agents/{AGENT_ID}/state")
+    assert STATE_TOKEN_ENV in projection.credential_keys
+
+
+# --- credential generation identity and the existing codec ------------------------
+
+
+def test_credential_generation_is_nonsecret_identity_only() -> None:
+    gen = CredentialGeneration.for_window(str(AGENT_ID), issued_at=100)
+    assert gen == CredentialGeneration.for_window(str(AGENT_ID), issued_at=100)
+    assert gen.expires_at == 100 + SANDBOX_TOKEN_TTL_SECONDS
+    assert gen.scopes == (STATE_SCOPE, STATE_APP_SCOPE)
+    assert gen.admits(now=gen.expires_at - 1)
+    assert not gen.admits(now=gen.expires_at)
+    assert not gen.admits(now=gen.expires_at - 60, margin_seconds=60)
+    with pytest.raises(ValueError):
+        CredentialGeneration.for_window(str(AGENT_ID), issued_at=100, ttl_seconds=0)
+
+
+def test_minted_material_uses_the_existing_scoped_codec_and_is_redacted() -> None:
+    gen = GENERATION
+    material = mint_credential_generation(PLATFORM_KEY, gen)
+    projection = _project()
+    assert tuple(material.keys()) == projection.credential_keys
+    agent = str(AGENT_ID)
+    now = gen.issued_at + 1
+    assert sandbox_token.verify(
+        material.value(HISTORY_TOKEN_ENV), PLATFORM_KEY, agent=agent, scope=STATE_SCOPE, now=now
+    )
+    assert sandbox_token.verify(
+        material.value(MEMORY_TOKEN_ENV), PLATFORM_KEY, agent=agent, scope=STATE_SCOPE, now=now
+    )
+    assert sandbox_token.verify(
+        material.value(STATE_TOKEN_ENV), PLATFORM_KEY, agent=agent, scope=STATE_APP_SCOPE, now=now
+    )
+    # Causal negatives: wrong agent, wrong scope, expired, wrong key.
+    assert not sandbox_token.verify(
+        material.value(HISTORY_TOKEN_ENV), PLATFORM_KEY, agent="other", scope=STATE_SCOPE, now=now
+    )
+    assert not sandbox_token.verify(
+        material.value(STATE_TOKEN_ENV), PLATFORM_KEY, agent=agent, scope=STATE_SCOPE, now=now
+    )
+    assert not sandbox_token.verify(
+        material.value(HISTORY_TOKEN_ENV),
+        PLATFORM_KEY,
+        agent=agent,
+        scope=STATE_SCOPE,
+        now=gen.expires_at,
+    )
+    assert not sandbox_token.verify(
+        material.value(HISTORY_TOKEN_ENV), "other-key", agent=agent, scope=STATE_SCOPE, now=now
+    )
+    rendered = repr(material) + str(material) + json.dumps(material.identity())
+    for key in material.keys():
+        assert material.value(key) not in rendered
+    assert material.value(HISTORY_TOKEN_ENV) != PLATFORM_KEY
+    assert material.identity()["expires_at"] == gen.expires_at
+
+
+def test_minting_refuses_an_empty_key() -> None:
+    with pytest.raises(ValueError):
+        mint_credential_generation("", GENERATION)
+
+
+# --- cold eligibility --------------------------------------------------------------
+
+
+def _claim_env(resolved: ResolvedDeployment | None = None, **overrides: str) -> dict[str, str]:
+    env = dict(
+        _resolver().boot_env(
+            resolved or _resolved(), "1234.5678", kind="slack", address="C0EXAMPLE1"
+        )
+    )
+    env.update(overrides)
+    return env
+
+
+def test_fresh_matching_turn_is_warm_eligible() -> None:
+    projection = _project()
+    verdict = classify_claim(_claim_env(), projection, now=GENERATION.issued_at + 1)
+    assert verdict.warm, verdict
+    assert verdict.reasons == ()
+
+
+def test_generation_mismatch_is_cold_rather_than_another_pool() -> None:
+    projection = _project()
+    verdict = classify_claim(
+        _claim_env(_resolved(model="claude-sonnet-5")), projection, now=GENERATION.issued_at + 1
+    )
+    assert not verdict.warm
+    assert ColdReason.GENERATION_MISMATCH in verdict.reasons
+    assert MODEL_ENV in verdict.mismatched_keys
+
+
+def test_memory_false_binding_turn_is_cold() -> None:
+    resolved = _resolved(memory=False)
+    projection = _project(resolved)
+    verdict = classify_claim(_claim_env(resolved), projection, now=GENERATION.issued_at + 1)
+    assert not verdict.warm
+    assert verdict.reasons == (ColdReason.MEMORY_FALSE_BINDING_STATE,)
+
+
+@pytest.mark.parametrize(
+    ("key", "reason"),
+    [
+        (GRANT_TOOL_ENV, ColdReason.APPROVAL_GRANT),
+        (RESUMED_KIND_ENV, ColdReason.APPROVAL_RESUMED_KIND),
+        (DECISION_ENV, ColdReason.APPROVAL_DECISION),
+        (WORKSPACE_REF_ENV, ColdReason.WORKSPACE_ENV),
+        (WORKSPACE_SHA256_ENV, ColdReason.WORKSPACE_ENV),
+    ],
+)
+def test_per_claim_overlay_env_is_cold(key: str, reason: ColdReason) -> None:
+    verdict = classify_claim(_claim_env(**{key: "x"}), _project(), now=GENERATION.issued_at + 1)
+    assert not verdict.warm
+    assert verdict.reasons == (reason,)
+
+
+def test_resume_eval_and_workspace_flags_are_cold() -> None:
+    projection = _project()
+    now = GENERATION.issued_at + 1
+    assert classify_claim(_claim_env(), projection, resume=True, now=now).reasons == (
+        ColdReason.RESUME_HISTORY,
+    )
+    assert classify_claim(_claim_env(), projection, eval_lane=True, now=now).reasons == (
+        ColdReason.EVAL_LANE,
+    )
+    assert classify_claim(_claim_env(), projection, workspace_stage=True, now=now).reasons == (
+        ColdReason.WORKSPACE_STAGE,
+    )
+
+
+def test_unknown_extra_claim_env_is_cold_not_guessed() -> None:
+    verdict = classify_claim(
+        _claim_env(CURIE_FUTURE_KNOB="1"), _project(), now=GENERATION.issued_at + 1
+    )
+    assert not verdict.warm
+    assert verdict.reasons == (ColdReason.EXTRA_CLAIM_ENV,)
+    assert verdict.mismatched_keys == ("CURIE_FUTURE_KNOB",)
+
+
+def test_expired_credential_generation_is_cold_until_a_new_generation() -> None:
+    projection = _project()
+    verdict = classify_claim(_claim_env(), projection, now=GENERATION.expires_at)
+    assert not verdict.warm
+    assert verdict.reasons == (ColdReason.CREDENTIAL_GENERATION_EXPIRED,)
+
+
+def test_missing_version_stable_key_on_the_claim_is_a_mismatch() -> None:
+    env = _claim_env()
+    env.pop(BootEnv.env_key("approval_required_tools"))
+    verdict = classify_claim(env, _project(), now=GENERATION.issued_at + 1)
+    assert verdict.reasons == (ColdReason.GENERATION_MISMATCH,)

--- a/apps/worker/tests/sandbox/test_warm_pool_contract.py
+++ b/apps/worker/tests/sandbox/test_warm_pool_contract.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import json
 import logging
 import uuid
+from dataclasses import replace
 
 import pytest
 from aci_protocol import BootEnv
@@ -37,6 +38,7 @@ from curie_worker.sandbox.warm_pool_contract import (
     CapabilityProjection,
     ColdReason,
     CredentialGeneration,
+    CredentialRevision,
     ProjectionError,
     SecretKeyRef,
     classify_claim,
@@ -66,6 +68,24 @@ CREDENTIALS_ENV = BootEnv.env_key("credentials_ref")
 MODEL_ENV = BootEnv.env_key("model")
 MEMORY_REF_ENV = BootEnv.env_key("memory_ref")
 CONNECTOR_SECRET_KEYS_ENV = BootEnv.env_key("connector_secret_keys")
+
+# Explicit synthetic API observations for this pure helper test. They do not
+# claim a production Secret watcher, fresh read, or rotation lifecycle exists.
+OBSERVED_CREDENTIAL_REVISIONS = {
+    CREDENTIALS_ENV: CredentialRevision(BASELINE_CREDENTIAL, "example-model-uid", "11"),
+    "GH_TOKEN": CredentialRevision(
+        SecretKeyRef(CONNECTOR_SECRET_NAME, "GH_TOKEN"), "example-connector-uid", "12"
+    ),
+    "OTHER_TOKEN": CredentialRevision(
+        SecretKeyRef(CONNECTOR_SECRET_NAME, "OTHER_TOKEN"), "example-connector-uid", "12"
+    ),
+    **{
+        key: CredentialRevision(
+            SecretKeyRef("curie-platform-credentials", "apiKey"), "example-signing-uid", "13"
+        )
+        for key in (HISTORY_TOKEN_ENV, MEMORY_TOKEN_ENV, STATE_TOKEN_ENV)
+    },
+}
 
 
 def _resolved(**overrides: object) -> ResolvedDeployment:
@@ -122,6 +142,7 @@ def _project(
         "model_credential_ref": BASELINE_CREDENTIAL,
         "connector_secret_name": CONNECTOR_SECRET_NAME,
         "credential_generation": generation,
+        "credential_revisions": OBSERVED_CREDENTIAL_REVISIONS,
     }
     kwargs.update(overrides)
     return warm_boot_projection(_resolver(cfg), resolved, **kwargs)  # type: ignore[arg-type]
@@ -233,6 +254,7 @@ def _identity(**overrides: object) -> dict[str, object]:
         "memory": True,
         "model_credential_ref": BASELINE_CREDENTIAL,
         "connector_secret_name": CONNECTOR_SECRET_NAME,
+        "credential_revisions": OBSERVED_CREDENTIAL_REVISIONS,
     }
     base.update(overrides)
     return base
@@ -450,15 +472,133 @@ def _claim_env(resolved: ResolvedDeployment | None = None, **overrides: str) -> 
 
 def test_fresh_matching_turn_is_warm_eligible() -> None:
     projection = _project()
-    verdict = classify_claim(_claim_env(), projection, now=GENERATION.issued_at + 1)
+    verdict = classify_claim(
+        _claim_env(),
+        projection,
+        now=GENERATION.issued_at + 1,
+        current_credential_revisions=OBSERVED_CREDENTIAL_REVISIONS,
+    )
     assert verdict.warm, verdict
     assert verdict.reasons == ()
+
+
+@pytest.mark.parametrize("rotated", [False, True])
+def test_unverified_credential_revision_never_reuses_an_existing_pool(rotated: bool) -> None:
+    """Fixed Secret names cannot attest which credential a warm process loaded."""
+
+    resolved = _resolved(secrets={"GH_TOKEN": "example-old-connector"})
+    projection = _project(resolved)
+    claim = _claim_env(resolved)
+    if rotated:
+        claim["GH_TOKEN"] = "example-new-connector"
+        claim[CREDENTIALS_ENV] = "example-new-model"
+    # No fresh authoritative Secret observation is available. Neither equal
+    # material nor a changed value under an unchanged key can prove warm parity.
+    verdict = classify_claim(claim, projection, now=GENERATION.issued_at + 1)
+    assert not verdict.warm
+    assert ColdReason.CREDENTIAL_AUTHORITY_UNVERIFIED in verdict.reasons
+
+
+@pytest.mark.parametrize("key", [CREDENTIALS_ENV, "GH_TOKEN", HISTORY_TOKEN_ENV])
+@pytest.mark.parametrize("field", ["uid", "resource_version"])
+def test_changed_authoritative_revision_refuses_the_old_generation(key: str, field: str) -> None:
+    # Kubernetes ObjectMeta defines UID as object identity and resourceVersion
+    # as opaque: https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/object-meta/
+    # These are synthetic observations, not proof of a production Secret reader.
+    resolved = _resolved(secrets={"GH_TOKEN": "example-connector"})
+    old = _project(resolved)
+    current = dict(OBSERVED_CREDENTIAL_REVISIONS)
+    changed_keys = (
+        (HISTORY_TOKEN_ENV, MEMORY_TOKEN_ENV, STATE_TOKEN_ENV)
+        if key == HISTORY_TOKEN_ENV
+        else (key,)
+    )
+    for changed_key in changed_keys:
+        current[changed_key] = replace(current[changed_key], **{field: "example-new-revision"})
+    new = _project(resolved, credential_revisions=current)
+    assert old.capability_generation != new.capability_generation
+    refused = classify_claim(
+        _claim_env(resolved),
+        old,
+        current_credential_revisions=current,
+        now=GENERATION.issued_at + 1,
+    )
+    assert not refused.warm
+    assert ColdReason.GENERATION_MISMATCH in refused.reasons
+    assert key in refused.mismatched_keys
+    # Same observed source revisions on a newly constructed generation are a
+    # pure healthy control; creating/rotating actual pods remains unproved.
+    assert classify_claim(
+        _claim_env(resolved),
+        new,
+        current_credential_revisions=current,
+        now=GENERATION.issued_at + 1,
+    ).warm
+
+
+@pytest.mark.parametrize("key", [CREDENTIALS_ENV, "GH_TOKEN", HISTORY_TOKEN_ENV])
+def test_missing_current_credential_authority_is_cold(key: str) -> None:
+    resolved = _resolved(secrets={"GH_TOKEN": "example-connector"})
+    current = dict(OBSERVED_CREDENTIAL_REVISIONS)
+    current.pop(key)
+    verdict = classify_claim(
+        _claim_env(resolved),
+        _project(resolved),
+        current_credential_revisions=current,
+        now=GENERATION.issued_at + 1,
+    )
+    assert not verdict.warm
+    assert ColdReason.CREDENTIAL_AUTHORITY_UNVERIFIED in verdict.reasons
+
+
+def test_unknown_projected_authority_cannot_be_replaced_by_a_current_claim() -> None:
+    projection = _project(credential_revisions=None)
+    assert not projection.credential_authority_complete
+    verdict = classify_claim(
+        _claim_env(),
+        projection,
+        current_credential_revisions=OBSERVED_CREDENTIAL_REVISIONS,
+        now=GENERATION.issued_at + 1,
+    )
+    assert not verdict.warm
+    assert ColdReason.CREDENTIAL_AUTHORITY_UNVERIFIED in verdict.reasons
+
+
+def test_revision_of_a_different_secret_does_not_attest_the_projected_ref() -> None:
+    current = dict(OBSERVED_CREDENTIAL_REVISIONS)
+    current[CREDENTIALS_ENV] = replace(
+        current[CREDENTIALS_ENV], source=SecretKeyRef("different-secret", "agentCredentials")
+    )
+    projection = _project(credential_revisions=current)
+    assert not projection.credential_authority_complete
+    assert not classify_claim(
+        _claim_env(),
+        projection,
+        current_credential_revisions=current,
+        now=GENERATION.issued_at + 1,
+    ).warm
+
+
+def test_mixed_state_signer_snapshot_cannot_form_a_warm_generation() -> None:
+    current = dict(OBSERVED_CREDENTIAL_REVISIONS)
+    current[HISTORY_TOKEN_ENV] = replace(current[HISTORY_TOKEN_ENV], resource_version="other")
+    projection = _project(credential_revisions=current)
+    assert not projection.credential_authority_complete
+    assert not classify_claim(
+        _claim_env(),
+        projection,
+        current_credential_revisions=current,
+        now=GENERATION.issued_at + 1,
+    ).warm
 
 
 def test_generation_mismatch_is_cold_rather_than_another_pool() -> None:
     projection = _project()
     verdict = classify_claim(
-        _claim_env(_resolved(model="claude-sonnet-5")), projection, now=GENERATION.issued_at + 1
+        _claim_env(_resolved(model="claude-sonnet-5")),
+        projection,
+        now=GENERATION.issued_at + 1,
+        current_credential_revisions=OBSERVED_CREDENTIAL_REVISIONS,
     )
     assert not verdict.warm
     assert ColdReason.GENERATION_MISMATCH in verdict.reasons
@@ -468,7 +608,12 @@ def test_generation_mismatch_is_cold_rather_than_another_pool() -> None:
 def test_memory_false_binding_turn_is_cold() -> None:
     resolved = _resolved(memory=False)
     projection = _project(resolved)
-    verdict = classify_claim(_claim_env(resolved), projection, now=GENERATION.issued_at + 1)
+    verdict = classify_claim(
+        _claim_env(resolved),
+        projection,
+        now=GENERATION.issued_at + 1,
+        current_credential_revisions=OBSERVED_CREDENTIAL_REVISIONS,
+    )
     assert not verdict.warm
     assert verdict.reasons == (ColdReason.MEMORY_FALSE_BINDING_STATE,)
 
@@ -484,7 +629,12 @@ def test_memory_false_binding_turn_is_cold() -> None:
     ],
 )
 def test_per_claim_overlay_env_is_cold(key: str, reason: ColdReason) -> None:
-    verdict = classify_claim(_claim_env(**{key: "x"}), _project(), now=GENERATION.issued_at + 1)
+    verdict = classify_claim(
+        _claim_env(**{key: "x"}),
+        _project(),
+        now=GENERATION.issued_at + 1,
+        current_credential_revisions=OBSERVED_CREDENTIAL_REVISIONS,
+    )
     assert not verdict.warm
     assert verdict.reasons == (reason,)
 
@@ -492,20 +642,35 @@ def test_per_claim_overlay_env_is_cold(key: str, reason: ColdReason) -> None:
 def test_resume_eval_and_workspace_flags_are_cold() -> None:
     projection = _project()
     now = GENERATION.issued_at + 1
-    assert classify_claim(_claim_env(), projection, resume=True, now=now).reasons == (
-        ColdReason.RESUME_HISTORY,
-    )
-    assert classify_claim(_claim_env(), projection, eval_lane=True, now=now).reasons == (
-        ColdReason.EVAL_LANE,
-    )
-    assert classify_claim(_claim_env(), projection, workspace_stage=True, now=now).reasons == (
-        ColdReason.WORKSPACE_STAGE,
-    )
+    assert classify_claim(
+        _claim_env(),
+        projection,
+        resume=True,
+        now=now,
+        current_credential_revisions=OBSERVED_CREDENTIAL_REVISIONS,
+    ).reasons == (ColdReason.RESUME_HISTORY,)
+    assert classify_claim(
+        _claim_env(),
+        projection,
+        eval_lane=True,
+        now=now,
+        current_credential_revisions=OBSERVED_CREDENTIAL_REVISIONS,
+    ).reasons == (ColdReason.EVAL_LANE,)
+    assert classify_claim(
+        _claim_env(),
+        projection,
+        workspace_stage=True,
+        now=now,
+        current_credential_revisions=OBSERVED_CREDENTIAL_REVISIONS,
+    ).reasons == (ColdReason.WORKSPACE_STAGE,)
 
 
 def test_unknown_extra_claim_env_is_cold_not_guessed() -> None:
     verdict = classify_claim(
-        _claim_env(CURIE_FUTURE_KNOB="1"), _project(), now=GENERATION.issued_at + 1
+        _claim_env(CURIE_FUTURE_KNOB="1"),
+        _project(),
+        now=GENERATION.issued_at + 1,
+        current_credential_revisions=OBSERVED_CREDENTIAL_REVISIONS,
     )
     assert not verdict.warm
     assert verdict.reasons == (ColdReason.EXTRA_CLAIM_ENV,)
@@ -514,7 +679,12 @@ def test_unknown_extra_claim_env_is_cold_not_guessed() -> None:
 
 def test_expired_credential_generation_is_cold_until_a_new_generation() -> None:
     projection = _project()
-    verdict = classify_claim(_claim_env(), projection, now=GENERATION.expires_at)
+    verdict = classify_claim(
+        _claim_env(),
+        projection,
+        now=GENERATION.expires_at,
+        current_credential_revisions=OBSERVED_CREDENTIAL_REVISIONS,
+    )
     assert not verdict.warm
     assert verdict.reasons == (ColdReason.CREDENTIAL_GENERATION_EXPIRED,)
 
@@ -522,16 +692,37 @@ def test_expired_credential_generation_is_cold_until_a_new_generation() -> None:
 def test_a_generation_near_expiry_is_cold_by_the_admission_margin() -> None:
     projection = _project()
     edge = GENERATION.expires_at - DEFAULT_CREDENTIAL_ADMISSION_MARGIN_SECONDS
-    assert not classify_claim(_claim_env(), projection, now=edge).warm
-    assert classify_claim(_claim_env(), projection, now=edge - 1).warm
+    assert not classify_claim(
+        _claim_env(),
+        projection,
+        now=edge,
+        current_credential_revisions=OBSERVED_CREDENTIAL_REVISIONS,
+    ).warm
+    assert classify_claim(
+        _claim_env(),
+        projection,
+        now=edge - 1,
+        current_credential_revisions=OBSERVED_CREDENTIAL_REVISIONS,
+    ).warm
     # A caller with a longer worst-case turn widens the margin.
-    assert not classify_claim(_claim_env(), projection, now=edge - 1, margin_seconds=3600).warm
+    assert not classify_claim(
+        _claim_env(),
+        projection,
+        now=edge - 1,
+        margin_seconds=3600,
+        current_credential_revisions=OBSERVED_CREDENTIAL_REVISIONS,
+    ).warm
 
 
 def test_missing_version_stable_key_on_the_claim_is_a_mismatch() -> None:
     env = _claim_env()
     env.pop(BootEnv.env_key("approval_required_tools"))
-    verdict = classify_claim(env, _project(), now=GENERATION.issued_at + 1)
+    verdict = classify_claim(
+        env,
+        _project(),
+        now=GENERATION.issued_at + 1,
+        current_credential_revisions=OBSERVED_CREDENTIAL_REVISIONS,
+    )
     assert verdict.reasons == (ColdReason.GENERATION_MISMATCH,)
 
 
@@ -539,7 +730,12 @@ def test_a_secret_ref_the_template_carries_but_the_claim_lacks_is_a_mismatch() -
     projection = _project()
     env = _claim_env()
     env.pop(CREDENTIALS_ENV)
-    verdict = classify_claim(env, projection, now=GENERATION.issued_at + 1)
+    verdict = classify_claim(
+        env,
+        projection,
+        now=GENERATION.issued_at + 1,
+        current_credential_revisions=OBSERVED_CREDENTIAL_REVISIONS,
+    )
     assert verdict.reasons == (ColdReason.GENERATION_MISMATCH,)
     assert CREDENTIALS_ENV in verdict.mismatched_keys
 
@@ -549,22 +745,42 @@ def test_connector_secret_set_drift_is_a_mismatch_in_both_directions() -> None:
     projection = _project(with_secret)
     now = GENERATION.issued_at + 1
     # The template references GH_TOKEN; a claim rendered without it is skew.
-    verdict = classify_claim(_claim_env(), projection, now=now)
+    verdict = classify_claim(
+        _claim_env(),
+        projection,
+        now=now,
+        current_credential_revisions=OBSERVED_CREDENTIAL_REVISIONS,
+    )
     assert ColdReason.GENERATION_MISMATCH in verdict.reasons
     assert "GH_TOKEN" in verdict.mismatched_keys
     # The claim renders GH_TOKEN; a template without it is skew.
-    verdict = classify_claim(_claim_env(with_secret), _project(), now=now)
+    verdict = classify_claim(
+        _claim_env(with_secret),
+        _project(),
+        now=now,
+        current_credential_revisions=OBSERVED_CREDENTIAL_REVISIONS,
+    )
     assert ColdReason.GENERATION_MISMATCH in verdict.reasons
     assert "GH_TOKEN" in verdict.mismatched_keys
     # Same secrets on both sides: warm.
-    assert classify_claim(_claim_env(with_secret), projection, now=now).warm
+    assert classify_claim(
+        _claim_env(with_secret),
+        projection,
+        now=now,
+        current_credential_revisions=OBSERVED_CREDENTIAL_REVISIONS,
+    ).warm
 
 
 def test_state_token_presence_must_match_the_generation_keys() -> None:
     projection = _project()
     env = _claim_env()
     env.pop(HISTORY_TOKEN_ENV)
-    verdict = classify_claim(env, projection, now=GENERATION.issued_at + 1)
+    verdict = classify_claim(
+        env,
+        projection,
+        now=GENERATION.issued_at + 1,
+        current_credential_revisions=OBSERVED_CREDENTIAL_REVISIONS,
+    )
     assert verdict.reasons == (ColdReason.GENERATION_MISMATCH,)
     assert HISTORY_TOKEN_ENV in verdict.mismatched_keys
 
@@ -578,14 +794,24 @@ def test_a_no_key_claim_against_a_keyed_generation_is_cold() -> None:
             _resolved(), "1234.5678", kind="slack", address="C0EXAMPLE1"
         )
     )
-    verdict = classify_claim(unkeyed_env, keyed, now=GENERATION.issued_at + 1)
+    verdict = classify_claim(
+        unkeyed_env,
+        keyed,
+        now=GENERATION.issued_at + 1,
+        current_credential_revisions=OBSERVED_CREDENTIAL_REVISIONS,
+    )
     assert verdict.reasons == (ColdReason.GENERATION_MISMATCH,)
     assert set(verdict.mismatched_keys) >= {HISTORY_TOKEN_ENV, MEMORY_TOKEN_ENV, STATE_TOKEN_ENV}
 
 
 def test_a_keyed_claim_against_a_credential_free_projection_is_cold() -> None:
     unkeyed = _project(config=_config(api_key="", credentials=""), model_credential_ref=None)
-    verdict = classify_claim(_claim_env(), unkeyed, now=GENERATION.issued_at + 1)
+    verdict = classify_claim(
+        _claim_env(),
+        unkeyed,
+        now=GENERATION.issued_at + 1,
+        current_credential_revisions=OBSERVED_CREDENTIAL_REVISIONS,
+    )
     assert ColdReason.GENERATION_MISMATCH in verdict.reasons
     assert CREDENTIALS_ENV in verdict.mismatched_keys
     assert HISTORY_TOKEN_ENV in verdict.mismatched_keys
@@ -597,6 +823,11 @@ def test_a_claim_rendered_without_the_model_credential_is_cold() -> None:
             _resolved(), "1234.5678", kind="slack", address="C0EXAMPLE1"
         )
     )
-    verdict = classify_claim(env, _project(), now=GENERATION.issued_at + 1)
+    verdict = classify_claim(
+        env,
+        _project(),
+        now=GENERATION.issued_at + 1,
+        current_credential_revisions=OBSERVED_CREDENTIAL_REVISIONS,
+    )
     assert verdict.reasons == (ColdReason.GENERATION_MISMATCH,)
     assert verdict.mismatched_keys == (CREDENTIALS_ENV,)

--- a/apps/worker/tests/sandbox/test_warm_pool_contract.py
+++ b/apps/worker/tests/sandbox/test_warm_pool_contract.py
@@ -567,3 +567,36 @@ def test_state_token_presence_must_match_the_generation_keys() -> None:
     verdict = classify_claim(env, projection, now=GENERATION.issued_at + 1)
     assert verdict.reasons == (ColdReason.GENERATION_MISMATCH,)
     assert HISTORY_TOKEN_ENV in verdict.mismatched_keys
+
+
+def test_a_no_key_claim_against_a_keyed_generation_is_cold() -> None:
+    """A no-key render mints no state tokens; a keyed template is different authority."""
+
+    keyed = _project()
+    unkeyed_env = dict(
+        _resolver(_config(api_key="")).boot_env(
+            _resolved(), "1234.5678", kind="slack", address="C0EXAMPLE1"
+        )
+    )
+    verdict = classify_claim(unkeyed_env, keyed, now=GENERATION.issued_at + 1)
+    assert verdict.reasons == (ColdReason.GENERATION_MISMATCH,)
+    assert set(verdict.mismatched_keys) >= {HISTORY_TOKEN_ENV, MEMORY_TOKEN_ENV, STATE_TOKEN_ENV}
+
+
+def test_a_keyed_claim_against_a_credential_free_projection_is_cold() -> None:
+    unkeyed = _project(config=_config(api_key="", credentials=""), model_credential_ref=None)
+    verdict = classify_claim(_claim_env(), unkeyed, now=GENERATION.issued_at + 1)
+    assert ColdReason.GENERATION_MISMATCH in verdict.reasons
+    assert CREDENTIALS_ENV in verdict.mismatched_keys
+    assert HISTORY_TOKEN_ENV in verdict.mismatched_keys
+
+
+def test_a_claim_rendered_without_the_model_credential_is_cold() -> None:
+    env = dict(
+        _resolver(_config(credentials="")).boot_env(
+            _resolved(), "1234.5678", kind="slack", address="C0EXAMPLE1"
+        )
+    )
+    verdict = classify_claim(env, _project(), now=GENERATION.issued_at + 1)
+    assert verdict.reasons == (ColdReason.GENERATION_MISMATCH,)
+    assert verdict.mismatched_keys == (CREDENTIALS_ENV,)

--- a/apps/worker/tests/sandbox/test_warm_pool_contract.py
+++ b/apps/worker/tests/sandbox/test_warm_pool_contract.py
@@ -30,6 +30,7 @@ from curie_worker.binding import (
 )
 from curie_worker.config import WorkerConfig
 from curie_worker.sandbox.warm_pool_contract import (
+    DEFAULT_CREDENTIAL_ADMISSION_MARGIN_SECONDS,
     PROJECTION_THREAD_SENTINEL,
     STATE_APP_SCOPE,
     STATE_SCOPE,
@@ -518,8 +519,51 @@ def test_expired_credential_generation_is_cold_until_a_new_generation() -> None:
     assert verdict.reasons == (ColdReason.CREDENTIAL_GENERATION_EXPIRED,)
 
 
+def test_a_generation_near_expiry_is_cold_by_the_admission_margin() -> None:
+    projection = _project()
+    edge = GENERATION.expires_at - DEFAULT_CREDENTIAL_ADMISSION_MARGIN_SECONDS
+    assert not classify_claim(_claim_env(), projection, now=edge).warm
+    assert classify_claim(_claim_env(), projection, now=edge - 1).warm
+    # A caller with a longer worst-case turn widens the margin.
+    assert not classify_claim(_claim_env(), projection, now=edge - 1, margin_seconds=3600).warm
+
+
 def test_missing_version_stable_key_on_the_claim_is_a_mismatch() -> None:
     env = _claim_env()
     env.pop(BootEnv.env_key("approval_required_tools"))
     verdict = classify_claim(env, _project(), now=GENERATION.issued_at + 1)
     assert verdict.reasons == (ColdReason.GENERATION_MISMATCH,)
+
+
+def test_a_secret_ref_the_template_carries_but_the_claim_lacks_is_a_mismatch() -> None:
+    projection = _project()
+    env = _claim_env()
+    env.pop(CREDENTIALS_ENV)
+    verdict = classify_claim(env, projection, now=GENERATION.issued_at + 1)
+    assert verdict.reasons == (ColdReason.GENERATION_MISMATCH,)
+    assert CREDENTIALS_ENV in verdict.mismatched_keys
+
+
+def test_connector_secret_set_drift_is_a_mismatch_in_both_directions() -> None:
+    with_secret = _resolved(secrets={"GH_TOKEN": "value"})
+    projection = _project(with_secret)
+    now = GENERATION.issued_at + 1
+    # The template references GH_TOKEN; a claim rendered without it is skew.
+    verdict = classify_claim(_claim_env(), projection, now=now)
+    assert ColdReason.GENERATION_MISMATCH in verdict.reasons
+    assert "GH_TOKEN" in verdict.mismatched_keys
+    # The claim renders GH_TOKEN; a template without it is skew.
+    verdict = classify_claim(_claim_env(with_secret), _project(), now=now)
+    assert ColdReason.GENERATION_MISMATCH in verdict.reasons
+    assert "GH_TOKEN" in verdict.mismatched_keys
+    # Same secrets on both sides: warm.
+    assert classify_claim(_claim_env(with_secret), projection, now=now).warm
+
+
+def test_state_token_presence_must_match_the_generation_keys() -> None:
+    projection = _project()
+    env = _claim_env()
+    env.pop(HISTORY_TOKEN_ENV)
+    verdict = classify_claim(env, projection, now=GENERATION.issued_at + 1)
+    assert verdict.reasons == (ColdReason.GENERATION_MISMATCH,)
+    assert HISTORY_TOKEN_ENV in verdict.mismatched_keys

--- a/apps/worker/tests/sandbox/test_warm_pool_targets.py
+++ b/apps/worker/tests/sandbox/test_warm_pool_targets.py
@@ -28,6 +28,7 @@ from curie_worker.sandbox.warm_pool_targets import (
     ActiveWinner,
     LookupOutcome,
     ObservedGeneration,
+    SlotAllocation,
     TargetError,
     VersionPoolRef,
     VersionPoolTarget,
@@ -36,6 +37,7 @@ from curie_worker.sandbox.warm_pool_targets import (
     build_target,
     derive_ref,
     lookup,
+    slot_secret_names,
 )
 from sqlalchemy import text
 from sqlalchemy.exc import SQLAlchemyError
@@ -57,6 +59,7 @@ _DB_URL = os.environ.get(
 _SCHEMA = os.environ.get("TEST_DB_SCHEMA", "curie")
 
 _ORDER_KEY = "(d.environment = 'prod') DESC, d.deployed_at DESC, d.id DESC"
+SLOT = SlotAllocation("curie-warm-bootstrap", 4, 1)
 
 
 # --- the winner query is the resolver's winner -------------------------------------
@@ -136,7 +139,7 @@ def test_bundleless_winner_is_reported_unrealizable_not_replaced() -> None:
     assert target.refusal == "bundleless-winner"
     assert target.version_id == str(_resolved().version_id)
     with pytest.raises(TargetError, match="bundleless"):
-        derive_ref(target, prefix="curie")
+        derive_ref(target, prefix="curie", slot=SLOT)
 
 
 def test_target_without_a_deployment_id_is_refused() -> None:
@@ -157,14 +160,9 @@ _DNS_LABEL = re.compile(r"^[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?$")
 
 
 def test_ref_names_are_dns_labels_distinct_from_helm_pools() -> None:
-    ref = derive_ref(_target(), prefix="curie")
-    names = {
-        ref.template_name,
-        ref.pool_name,
-        ref.bootstrap_secret_name,
-        ref.credential_secret_name,
-    }
-    assert len(names) == 4
+    ref = derive_ref(_target(), prefix="curie", slot=SLOT)
+    names = {ref.template_name, ref.pool_name, ref.bootstrap_secret_name}
+    assert len(names) == 3
     for name in names:
         assert _DNS_LABEL.match(name), name
         assert len(name) <= 63
@@ -175,30 +173,91 @@ def test_ref_names_are_dns_labels_distinct_from_helm_pools() -> None:
     assert ref.capability_generation == _target().capability_generation
     assert ref.namespace == "curie"
     assert ref.version_id == _target().version_id
+    assert ref.slot_index == 1
+
+
+def test_secret_name_is_the_granted_slot_not_a_hash_family() -> None:
+    """A static resourceNames grant must cover the Secret after a restart (ADR-0122 d.4)."""
+
+    granted = slot_secret_names("curie-warm-bootstrap", 4)
+    assert granted == (
+        "curie-warm-bootstrap-0",
+        "curie-warm-bootstrap-1",
+        "curie-warm-bootstrap-2",
+        "curie-warm-bootstrap-3",
+    )
+    a = derive_ref(_target(), prefix="curie", slot=SLOT)
+    b = derive_ref(_target(_winner(model="claude-sonnet-5")), prefix="curie", slot=SLOT)
+    assert a.bootstrap_secret_name in granted
+    # Same slot, different generation: the NAME is the slot; identity is labels.
+    assert a.bootstrap_secret_name == b.bootstrap_secret_name
+    assert a.capability_generation != b.capability_generation
+    assert a.template_name != b.template_name
+    assert a.pool_name != b.pool_name
+
+
+@pytest.mark.parametrize(
+    ("prefix", "max_slots", "index"),
+    [
+        ("curie-warm-bootstrap", 4, 4),
+        ("curie-warm-bootstrap", 4, -1),
+        ("curie-warm-bootstrap", 0, 0),
+        ("Curie-Warm", 4, 0),
+        ("", 4, 0),
+        ("curie-agent-x-warm", 4, 0),
+    ],
+)
+def test_slot_outside_the_grant_is_refused(prefix: str, max_slots: int, index: int) -> None:
+    with pytest.raises(TargetError):
+        SlotAllocation(prefix, max_slots, index)
 
 
 def test_ref_names_change_with_the_generation_and_version() -> None:
-    a = derive_ref(_target(), prefix="curie")
-    b = derive_ref(_target(_winner(model="claude-sonnet-5")), prefix="curie")
+    a = derive_ref(_target(), prefix="curie", slot=SLOT)
+    b = derive_ref(_target(_winner(model="claude-sonnet-5")), prefix="curie", slot=SLOT)
     c = derive_ref(
         _target(_winner(version_id=uuid.UUID("00000000-0000-4000-8000-0000000000a2"))),
         prefix="curie",
+        slot=SLOT,
     )
     assert len({a.pool_name, b.pool_name, c.pool_name}) == 3
-    assert a.template_name != b.template_name != c.template_name
+    assert len({a.template_name, b.template_name, c.template_name}) == 3
 
 
 @pytest.mark.parametrize(
     "prefix",
-    ["", "Curie", "cu_rie", "-curie", "x" * 40, "curie-agent-x", "curie-runner-pool"],
+    [
+        "",
+        "Curie",
+        "cu_rie",
+        "-curie",
+        "x" * 40,
+        "curie-agent-x",
+        "curie-runner-pool",
+        "curie-runner",
+    ],
 )
 def test_ref_refuses_bad_prefixes(prefix: str) -> None:
     with pytest.raises(TargetError):
-        derive_ref(_target(), prefix=prefix)
+        derive_ref(_target(), prefix=prefix, slot=SLOT)
+
+
+def test_pool_name_reserves_controller_headroom_under_the_label_limit() -> None:
+    longest_ok = "x" * 21
+    ref = derive_ref(_target(), prefix=longest_ok, slot=SLOT)
+    assert len(ref.pool_name) <= 63 - 12
+    with pytest.raises(TargetError, match="pool"):
+        derive_ref(_target(), prefix="x" * 22, slot=SLOT)
+
+
+def test_slot_secret_name_may_not_collide_with_pool_objects() -> None:
+    ref = derive_ref(_target(), prefix="curie", slot=SLOT)
+    colliding = SlotAllocation(ref.pool_name[: -len("-0")], 1, 0)
+    assert colliding.secret_name == ref.pool_name[: -len("-0")] + "-0"
 
 
 def test_ref_is_a_value_and_serializes_without_material() -> None:
-    ref = derive_ref(_target(), prefix="curie")
+    ref = derive_ref(_target(), prefix="curie", slot=SLOT)
     again = VersionPoolRef(**ref.as_dict())  # type: ignore[arg-type]
     assert again == ref
     # A ref is names and env KEYS only; the same dict is what a log line may carry.
@@ -206,11 +265,11 @@ def test_ref_is_a_value_and_serializes_without_material() -> None:
         "namespace",
         "version_id",
         "capability_generation",
+        "slot_index",
         "template_name",
         "pool_name",
         "bootstrap_secret_name",
         "bootstrap_secret_key",
-        "credential_secret_name",
         "credential_secret_keys",
     }
     assert json.dumps(ref.as_dict())
@@ -221,7 +280,7 @@ def test_ref_is_a_value_and_serializes_without_material() -> None:
 
 def test_lookup_matches_only_the_current_generation() -> None:
     target = _target()
-    ref = derive_ref(target, prefix="curie")
+    ref = derive_ref(target, prefix="curie", slot=SLOT)
     observed = ObservedGeneration(
         template_name=ref.template_name,
         version_id=target.version_id,
@@ -256,13 +315,25 @@ def test_lookup_refuses_an_unrealizable_target() -> None:
 
 
 async def _engine_or_skip() -> AsyncEngine:
+    """A reachable, MIGRATED database, or a skip that says which half is missing.
+
+    A reachable server without the ``curie`` schema (another task's fresh
+    stack on the shared port) is not evidence about this query either way, so
+    it skips with that reason rather than failing on ``UndefinedTableError``.
+    """
+
     engine = create_async_engine(_DB_URL)
     try:
-        async with engine.connect():
-            pass
+        async with engine.connect() as conn:
+            table = (
+                await conn.execute(text("SELECT to_regclass(:name)"), {"name": f"{_SCHEMA}.agents"})
+            ).scalar_one()
     except (SQLAlchemyError, OSError) as exc:  # pragma: no cover - environment dependent
         await engine.dispose()
         pytest.skip(f"Postgres not reachable at {_DB_URL}: {exc}")
+    if table is None:  # pragma: no cover - environment dependent
+        await engine.dispose()
+        pytest.skip(f"Postgres at {_DB_URL} has no migrated {_SCHEMA}.agents table")
     return engine
 
 
@@ -433,7 +504,7 @@ def test_active_winner_query_returns_bundle_sha256_on_real_postgres() -> None:
             )
             assert target.realizable
             assert target.bundle_sha256 == "ab" * 32
-            assert derive_ref(target, prefix="curie").version_id == str(version)
+            assert derive_ref(target, prefix="curie", slot=SLOT).version_id == str(version)
             assert await active_winner(engine, _SCHEMA, uuid.uuid4()) is None
         finally:
             await _cleanup(engine, agent_ids)

--- a/apps/worker/tests/sandbox/test_warm_pool_targets.py
+++ b/apps/worker/tests/sandbox/test_warm_pool_targets.py
@@ -48,6 +48,7 @@ from .test_warm_pool_contract import (
     BASELINE_CREDENTIAL,
     CONNECTOR_SECRET_NAME,
     GENERATION,
+    OBSERVED_CREDENTIAL_REVISIONS,
     _config,
     _project,
     _resolved,
@@ -109,6 +110,7 @@ def _winner(**overrides: object) -> ActiveWinner:
 
 def _target(winner: ActiveWinner | None = None, **kw: object) -> VersionPoolTarget:
     winner = winner or _winner()
+    kw.setdefault("credential_revisions", OBSERVED_CREDENTIAL_REVISIONS)
     return build_target(
         winner,
         _resolver(),
@@ -152,6 +154,14 @@ def test_bundle_ref_without_sha_is_reported_unrealizable() -> None:
     target = _target(_winner(bundle_sha256=None))
     assert not target.realizable
     assert target.refusal == "bundle-sha256-missing"
+
+
+def test_missing_credential_authority_cannot_name_a_realizable_pool() -> None:
+    target = _target(credential_revisions=None)
+    assert not target.realizable
+    assert target.refusal == "credential-authority-unverified"
+    with pytest.raises(TargetError, match="credential-authority-unverified"):
+        derive_ref(target, prefix="curie", slot=SLOT)
 
 
 # --- refs -------------------------------------------------------------------------
@@ -281,6 +291,7 @@ def test_ref_is_a_value_and_serializes_without_material() -> None:
         model_credential_ref=BASELINE_CREDENTIAL,
         connector_secret_name=CONNECTOR_SECRET_NAME,
         credential_generation=GENERATION,
+        credential_revisions=OBSERVED_CREDENTIAL_REVISIONS,
     )
     ref = derive_ref(target, prefix="curie", slot=SLOT)
     again = VersionPoolRef(**ref.as_dict())  # type: ignore[arg-type]
@@ -521,6 +532,7 @@ def test_active_winner_query_agrees_with_the_resolver_on_real_postgres() -> None
                 credential_generation=CredentialGeneration.for_window(
                     str(agent_id), issued_at=1_800_000_000
                 ),
+                credential_revisions=OBSERVED_CREDENTIAL_REVISIONS,
             )
             assert not target.realizable
             assert target.refusal == "bundleless-winner"
@@ -562,6 +574,7 @@ def test_active_winner_query_returns_bundle_sha256_on_real_postgres() -> None:
                 credential_generation=CredentialGeneration.for_window(
                     str(agent_id), issued_at=1_800_000_000
                 ),
+                credential_revisions=OBSERVED_CREDENTIAL_REVISIONS,
             )
             assert target.realizable
             assert target.bundle_sha256 == "ab" * 32

--- a/apps/worker/tests/sandbox/test_warm_pool_targets.py
+++ b/apps/worker/tests/sandbox/test_warm_pool_targets.py
@@ -40,6 +40,7 @@ from curie_worker.sandbox.warm_pool_targets import (
     slot_secret_names,
 )
 from sqlalchemy import text
+from sqlalchemy.engine import make_url
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
@@ -250,14 +251,38 @@ def test_pool_name_reserves_controller_headroom_under_the_label_limit() -> None:
         derive_ref(_target(), prefix="x" * 22, slot=SLOT)
 
 
-def test_slot_secret_name_may_not_collide_with_pool_objects() -> None:
+def test_slot_secret_names_are_structurally_disjoint_from_pool_objects() -> None:
     ref = derive_ref(_target(), prefix="curie", slot=SLOT)
-    colliding = SlotAllocation(ref.pool_name[: -len("-0")], 1, 0)
-    assert colliding.secret_name == ref.pool_name[: -len("-0")] + "-0"
+    assert ref.bootstrap_secret_name[-1].isdigit()
+    assert ref.template_name.endswith("-tpl") and ref.pool_name.endswith("-pool")
+    for name in slot_secret_names("curie-vp-00000000-000000000000", 3):
+        assert name not in {ref.template_name, ref.pool_name}
+
+
+def test_active_winner_equality_and_repr_ignore_secret_values() -> None:
+    a = _winner(secrets={"GH_TOKEN": "MATERIAL-A-91c2"})
+    b = _winner(secrets={"GH_TOKEN": "MATERIAL-B-91c2"})
+    assert a == b and hash(a) == hash(b)
+    assert a != _winner(version_id=uuid.UUID("00000000-0000-4000-8000-0000000000a2"))
+    assert "MATERIAL-A-91c2" not in repr(a) + str(a)
 
 
 def test_ref_is_a_value_and_serializes_without_material() -> None:
-    ref = derive_ref(_target(), prefix="curie", slot=SLOT)
+    material = {
+        "GH_TOKEN": "CONNECTOR-MATERIAL-4d1e",
+        "OTHER_TOKEN": "CONNECTOR-MATERIAL-4d1f",
+    }
+    credential = "MODEL-CREDENTIAL-MATERIAL-4d20"
+    winner = _winner(secrets=material)
+    target = build_target(
+        winner,
+        _resolver(_config(credentials=credential)),
+        namespace="curie",
+        model_credential_ref=BASELINE_CREDENTIAL,
+        connector_secret_name=CONNECTOR_SECRET_NAME,
+        credential_generation=GENERATION,
+    )
+    ref = derive_ref(target, prefix="curie", slot=SLOT)
     again = VersionPoolRef(**ref.as_dict())  # type: ignore[arg-type]
     assert again == ref
     # A ref is names and env KEYS only; the same dict is what a log line may carry.
@@ -272,7 +297,11 @@ def test_ref_is_a_value_and_serializes_without_material() -> None:
         "bootstrap_secret_key",
         "credential_secret_keys",
     }
-    assert json.dumps(ref.as_dict())
+    rendered = json.dumps(ref.as_dict()) + repr(ref) + str(ref) + repr(target) + str(target)
+    rendered += target.projection.canonical_json()
+    for value in (*material.values(), credential):
+        assert value not in rendered
+    assert "GH_TOKEN" in target.projection.secret_refs
 
 
 # --- lookup: current generation or cold, never another pool ------------------------
@@ -314,12 +343,20 @@ def test_lookup_refuses_an_unrealizable_target() -> None:
 # --- real Postgres: the query agrees with the resolver ----------------------------
 
 
+def _db_locator() -> str:
+    """Host and port only: the URL may carry a password and skip reasons reach reports."""
+
+    url = make_url(_DB_URL)
+    return f"{url.host}:{url.port}"
+
+
 async def _engine_or_skip() -> AsyncEngine:
     """A reachable, MIGRATED database, or a skip that says which half is missing.
 
     A reachable server without the ``curie`` schema (another task's fresh
     stack on the shared port) is not evidence about this query either way, so
     it skips with that reason rather than failing on ``UndefinedTableError``.
+    Skip reasons name the host, port and exception TYPE only.
     """
 
     engine = create_async_engine(_DB_URL)
@@ -330,22 +367,42 @@ async def _engine_or_skip() -> AsyncEngine:
             ).scalar_one()
     except (SQLAlchemyError, OSError) as exc:  # pragma: no cover - environment dependent
         await engine.dispose()
-        pytest.skip(f"Postgres not reachable at {_DB_URL}: {exc}")
+        pytest.skip(f"Postgres not reachable at {_db_locator()}: {type(exc).__name__}")
     if table is None:  # pragma: no cover - environment dependent
         await engine.dispose()
-        pytest.skip(f"Postgres at {_DB_URL} has no migrated {_SCHEMA}.agents table")
+        pytest.skip(f"Postgres at {_db_locator()} has no migrated {_SCHEMA}.agents table")
     return engine
 
 
+SEEDED_JSON = {
+    "behavior_packs": {"greeting": {"enabled": True}},
+    "approval_required_tools": ["Bash", "Write"],
+    "approval_routes": {"ops": {"resolve": {"kind": "slack", "address": "C0EXAMPLE9"}}},
+    "secrets": {"GH_TOKEN": "seeded-synthetic-value"},
+}
+
+
 async def _seed_agent(engine: AsyncEngine, *, name: str, address: str, memory: bool) -> uuid.UUID:
+    """One agent with every JSONB column populated, so coercion parity is exercised."""
+
     agent_id = uuid.uuid4()
     async with engine.begin() as conn:
         await conn.execute(
             text(
-                f"INSERT INTO {_SCHEMA}.agents (id, name, model, memory) "
-                "VALUES (:id, :name, 'claude-opus-5', :memory)"
+                f"INSERT INTO {_SCHEMA}.agents (id, name, model, memory, behavior_packs, "
+                "approval_required_tools, approval_routes, secrets) "
+                "VALUES (:id, :name, 'claude-opus-5', :memory, CAST(:packs AS jsonb), "
+                "CAST(:gates AS jsonb), CAST(:routes AS jsonb), CAST(:secrets AS jsonb))"
             ),
-            {"id": agent_id, "name": name, "memory": memory},
+            {
+                "id": agent_id,
+                "name": name,
+                "memory": memory,
+                "packs": json.dumps(SEEDED_JSON["behavior_packs"]),
+                "gates": json.dumps(SEEDED_JSON["approval_required_tools"]),
+                "routes": json.dumps(SEEDED_JSON["approval_routes"]),
+                "secrets": json.dumps(SEEDED_JSON["secrets"]),
+            },
         )
         await conn.execute(
             text(
@@ -445,6 +502,10 @@ def test_active_winner_query_agrees_with_the_resolver_on_real_postgres() -> None
             assert winner is not None
             assert winner.resolved.version_id == prod_version
             assert winner.resolved.model_dump() == resolved.model_dump()
+            assert winner.resolved.behavior_packs == SEEDED_JSON["behavior_packs"]
+            assert winner.resolved.approval_required_tools == SEEDED_JSON["approval_required_tools"]
+            assert winner.resolved.approval_routes == SEEDED_JSON["approval_routes"]
+            assert winner.resolved.secrets == SEEDED_JSON["secrets"]
             assert winner.bundle_sha256 is None
             assert winner.environment == "prod"
 

--- a/apps/worker/tests/sandbox/test_warm_pool_targets.py
+++ b/apps/worker/tests/sandbox/test_warm_pool_targets.py
@@ -1,0 +1,442 @@
+"""Warm-pool version targets (#1492 D1): exact active winner, refs, lookup.
+
+The winner a warm pool is built for must be the SAME deployment the cold path
+boots (`binding._RESOLVE_SQL`) and the connector reconciler serves
+(`connector_loop._TARGETS_SQL`). A bundleless winner is REPORTED and marked
+unrealizable; it is never skipped so that a lower-ranked bundleful version can
+be warmed in its place (#1216 rank-first-decide-second).
+
+Postgres-backed tests skip when no database is reachable and say so; nothing
+here touches Kubernetes or a Secret.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import re
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from aci_protocol import BootEnv
+from curie_worker import binding, connector_loop
+from curie_worker.sandbox.warm_pool_contract import CredentialGeneration
+from curie_worker.sandbox.warm_pool_targets import (
+    ACTIVE_WINNERS_SQL,
+    ActiveWinner,
+    LookupOutcome,
+    ObservedGeneration,
+    TargetError,
+    VersionPoolRef,
+    VersionPoolTarget,
+    active_winner,
+    active_winners,
+    build_target,
+    derive_ref,
+    lookup,
+)
+from sqlalchemy import text
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+
+from .test_warm_pool_contract import (
+    BASELINE_CREDENTIAL,
+    CONNECTOR_SECRET_NAME,
+    GENERATION,
+    _config,
+    _project,
+    _resolved,
+    _resolver,
+)
+
+_DB_URL = os.environ.get(
+    "TEST_DATABASE_URL", "postgresql+asyncpg://postgres:postgres@localhost:25432/postgres"
+)
+_SCHEMA = os.environ.get("TEST_DB_SCHEMA", "curie")
+
+_ORDER_KEY = "(d.environment = 'prod') DESC, d.deployed_at DESC, d.id DESC"
+
+
+# --- the winner query is the resolver's winner -------------------------------------
+
+
+def test_winner_order_key_is_byte_identical_to_binding_and_connector_loop() -> None:
+    def order_clause(sql: str) -> str:
+        match = re.search(r"ORDER BY\s+(.*)$", sql.strip(), flags=re.S)
+        assert match is not None
+        return match.group(1).strip()
+
+    assert order_clause(ACTIVE_WINNERS_SQL) == f"a.id, {_ORDER_KEY}"
+    assert order_clause(binding._RESOLVE_SQL) == _ORDER_KEY
+    assert order_clause(connector_loop._TARGETS_SQL) == f"a.id, {_ORDER_KEY}"
+
+
+def test_winner_query_reports_bundle_identity_and_never_filters_on_it() -> None:
+    assert "DISTINCT ON (a.id)" in ACTIVE_WINNERS_SQL
+    assert "v.bundle_sha256 AS bundle_sha256" in ACTIVE_WINNERS_SQL
+    assert "bundle_ref IS NOT NULL" not in ACTIVE_WINNERS_SQL
+    assert "d.status = 'active'" in ACTIVE_WINNERS_SQL
+    # Every column ResolvedDeployment reads from the resolver query is selected
+    # here too, so the projection is computed from the same facts as boot_env.
+    for column in (
+        "model",
+        "thinking",
+        "approval_required_tools",
+        "secrets",
+        "memory",
+        "max_usd_per_day",
+    ):
+        assert f"a.{column} AS {column}" in ACTIVE_WINNERS_SQL, column
+
+
+# --- targets ----------------------------------------------------------------------
+
+
+def _winner(**overrides: object) -> ActiveWinner:
+    resolved = _resolved(**{k: v for k, v in overrides.items() if k != "bundle_sha256"})
+    return ActiveWinner(
+        resolved=resolved,
+        bundle_sha256=overrides.get("bundle_sha256", "ab" * 32),  # type: ignore[arg-type]
+        environment="prod",
+    )
+
+
+def _target(winner: ActiveWinner | None = None, **kw: object) -> VersionPoolTarget:
+    winner = winner or _winner()
+    return build_target(
+        winner,
+        _resolver(),
+        namespace="curie",
+        model_credential_ref=BASELINE_CREDENTIAL,
+        connector_secret_name=CONNECTOR_SECRET_NAME,
+        credential_generation=GENERATION,
+        **kw,  # type: ignore[arg-type]
+    )
+
+
+def test_target_carries_identity_and_the_projection_generation() -> None:
+    target = _target()
+    assert target.realizable
+    assert target.refusal is None
+    assert target.capability_generation == _project().capability_generation
+    assert (target.agent_id, target.version_id, target.deployment_id) == (
+        str(_resolved().agent_id),
+        str(_resolved().version_id),
+        str(_resolved().deployment_id),
+    )
+    assert target.bundle_sha256 == "ab" * 32
+    assert "sk-live" not in repr(target)
+
+
+def test_bundleless_winner_is_reported_unrealizable_not_replaced() -> None:
+    target = _target(_winner(bundle_ref=None, bundle_sha256=None))
+    assert not target.realizable
+    assert target.refusal == "bundleless-winner"
+    assert target.version_id == str(_resolved().version_id)
+    with pytest.raises(TargetError, match="bundleless"):
+        derive_ref(target, prefix="curie")
+
+
+def test_target_without_a_deployment_id_is_refused() -> None:
+    with pytest.raises(TargetError, match="deployment"):
+        _target(_winner(deployment_id=None))
+
+
+def test_bundle_ref_without_sha_is_reported_unrealizable() -> None:
+    target = _target(_winner(bundle_sha256=None))
+    assert not target.realizable
+    assert target.refusal == "bundle-sha256-missing"
+
+
+# --- refs -------------------------------------------------------------------------
+
+
+_DNS_LABEL = re.compile(r"^[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?$")
+
+
+def test_ref_names_are_dns_labels_distinct_from_helm_pools() -> None:
+    ref = derive_ref(_target(), prefix="curie")
+    names = {
+        ref.template_name,
+        ref.pool_name,
+        ref.bootstrap_secret_name,
+        ref.credential_secret_name,
+    }
+    assert len(names) == 4
+    for name in names:
+        assert _DNS_LABEL.match(name), name
+        assert len(name) <= 63
+        assert not name.endswith("-runner-pool"), name
+        assert "-agent-" not in name, name
+    assert ref.bootstrap_secret_key == BootEnv.env_key("runner_bootstrap_token")
+    assert ref.credential_secret_keys == _project().credential_keys
+    assert ref.capability_generation == _target().capability_generation
+    assert ref.namespace == "curie"
+    assert ref.version_id == _target().version_id
+
+
+def test_ref_names_change_with_the_generation_and_version() -> None:
+    a = derive_ref(_target(), prefix="curie")
+    b = derive_ref(_target(_winner(model="claude-sonnet-5")), prefix="curie")
+    c = derive_ref(
+        _target(_winner(version_id=uuid.UUID("00000000-0000-4000-8000-0000000000a2"))),
+        prefix="curie",
+    )
+    assert len({a.pool_name, b.pool_name, c.pool_name}) == 3
+    assert a.template_name != b.template_name != c.template_name
+
+
+@pytest.mark.parametrize(
+    "prefix",
+    ["", "Curie", "cu_rie", "-curie", "x" * 40, "curie-agent-x", "curie-runner-pool"],
+)
+def test_ref_refuses_bad_prefixes(prefix: str) -> None:
+    with pytest.raises(TargetError):
+        derive_ref(_target(), prefix=prefix)
+
+
+def test_ref_is_a_value_and_serializes_without_material() -> None:
+    ref = derive_ref(_target(), prefix="curie")
+    again = VersionPoolRef(**ref.as_dict())  # type: ignore[arg-type]
+    assert again == ref
+    # A ref is names and env KEYS only; the same dict is what a log line may carry.
+    assert set(ref.as_dict()) == {
+        "namespace",
+        "version_id",
+        "capability_generation",
+        "template_name",
+        "pool_name",
+        "bootstrap_secret_name",
+        "bootstrap_secret_key",
+        "credential_secret_name",
+        "credential_secret_keys",
+    }
+    assert json.dumps(ref.as_dict())
+
+
+# --- lookup: current generation or cold, never another pool ------------------------
+
+
+def test_lookup_matches_only_the_current_generation() -> None:
+    target = _target()
+    ref = derive_ref(target, prefix="curie")
+    observed = ObservedGeneration(
+        template_name=ref.template_name,
+        version_id=target.version_id,
+        capability_generation=target.capability_generation,
+    )
+    assert lookup(observed, target) == LookupOutcome.MATCH
+    assert lookup(None, target) == LookupOutcome.ABSENT
+    stale = ObservedGeneration(
+        template_name=ref.template_name,
+        version_id=target.version_id,
+        capability_generation="0" * 64,
+    )
+    assert lookup(stale, target) == LookupOutcome.MISMATCH
+    other_version = ObservedGeneration(
+        template_name=ref.template_name,
+        version_id="00000000-0000-4000-8000-0000000000a2",
+        capability_generation=target.capability_generation,
+    )
+    assert lookup(other_version, target) == LookupOutcome.MISMATCH
+    helm_generic = ObservedGeneration(
+        template_name="curie-runner", version_id=None, capability_generation=None
+    )
+    assert lookup(helm_generic, target) == LookupOutcome.MISMATCH
+
+
+def test_lookup_refuses_an_unrealizable_target() -> None:
+    target = _target(_winner(bundle_ref=None, bundle_sha256=None))
+    assert lookup(None, target) == LookupOutcome.MISMATCH
+
+
+# --- real Postgres: the query agrees with the resolver ----------------------------
+
+
+async def _engine_or_skip() -> AsyncEngine:
+    engine = create_async_engine(_DB_URL)
+    try:
+        async with engine.connect():
+            pass
+    except (SQLAlchemyError, OSError) as exc:  # pragma: no cover - environment dependent
+        await engine.dispose()
+        pytest.skip(f"Postgres not reachable at {_DB_URL}: {exc}")
+    return engine
+
+
+async def _seed_agent(engine: AsyncEngine, *, name: str, address: str, memory: bool) -> uuid.UUID:
+    agent_id = uuid.uuid4()
+    async with engine.begin() as conn:
+        await conn.execute(
+            text(
+                f"INSERT INTO {_SCHEMA}.agents (id, name, model, memory) "
+                "VALUES (:id, :name, 'claude-opus-5', :memory)"
+            ),
+            {"id": agent_id, "name": name, "memory": memory},
+        )
+        await conn.execute(
+            text(
+                f"INSERT INTO {_SCHEMA}.agent_channels (id, agent_id, kind, address) "
+                "VALUES (:id, :agent_id, 'slack', :address)"
+            ),
+            {"id": uuid.uuid4(), "agent_id": agent_id, "address": address},
+        )
+    return agent_id
+
+
+async def _seed_deployment(
+    engine: AsyncEngine,
+    *,
+    agent_id: uuid.UUID,
+    environment: str,
+    bundle_ref: str | None,
+    bundle_sha256: str | None,
+    deployed_seconds_ago: int,
+) -> uuid.UUID:
+    version_id = uuid.uuid4()
+    async with engine.begin() as conn:
+        await conn.execute(
+            text(
+                f"INSERT INTO {_SCHEMA}.agent_versions "
+                "(id, agent_id, version_label, bundle_ref, bundle_sha256, created_by) "
+                "VALUES (:id, :agent_id, :label, :ref, :sha, 'test')"
+            ),
+            {
+                "id": version_id,
+                "agent_id": agent_id,
+                "label": f"v-{environment}",
+                "ref": bundle_ref,
+                "sha": bundle_sha256,
+            },
+        )
+        await conn.execute(
+            text(
+                f"INSERT INTO {_SCHEMA}.deployments "
+                "(id, agent_id, version_id, environment, status, deployed_at) "
+                f"VALUES (:id, :agent_id, :version_id, CAST(:env AS {_SCHEMA}.environment), "
+                "'active', :deployed_at)"
+            ),
+            {
+                "id": uuid.uuid4(),
+                "agent_id": agent_id,
+                "version_id": version_id,
+                "env": environment,
+                "deployed_at": datetime.now(UTC) - timedelta(seconds=deployed_seconds_ago),
+            },
+        )
+    return version_id
+
+
+async def _cleanup(engine: AsyncEngine, agent_ids: list[uuid.UUID]) -> None:
+    async with engine.begin() as conn:
+        for agent_id in agent_ids:
+            await conn.execute(
+                text(f"DELETE FROM {_SCHEMA}.agents WHERE id = :id"), {"id": agent_id}
+            )
+
+
+def test_active_winner_query_agrees_with_the_resolver_on_real_postgres() -> None:
+    """A bundleless prod winner outranks a newer bundleful dev version in BOTH queries."""
+
+    async def go() -> None:
+        engine = await _engine_or_skip()
+        token = uuid.uuid4().hex[:8]
+        agent_ids: list[uuid.UUID] = []
+        try:
+            agent_id = await _seed_agent(
+                engine, name=f"warm-{token}", address=f"C-warm-{token}", memory=True
+            )
+            agent_ids.append(agent_id)
+            prod_version = await _seed_deployment(
+                engine,
+                agent_id=agent_id,
+                environment="prod",
+                bundle_ref=None,
+                bundle_sha256=None,
+                deployed_seconds_ago=600,
+            )
+            await _seed_deployment(
+                engine,
+                agent_id=agent_id,
+                environment="dev",
+                bundle_ref=f"bundles/{token}/dev.tgz",
+                bundle_sha256="cd" * 32,
+                deployed_seconds_ago=1,
+            )
+            resolver = binding.BindingResolver(engine, _config(db_schema=_SCHEMA))
+            resolved = await resolver.resolve("slack", f"C-warm-{token}")
+            assert resolved is not None
+            assert resolved.version_id == prod_version
+
+            winner = await active_winner(engine, _SCHEMA, agent_id)
+            assert winner is not None
+            assert winner.resolved.version_id == prod_version
+            assert winner.resolved.model_dump() == resolved.model_dump()
+            assert winner.bundle_sha256 is None
+            assert winner.environment == "prod"
+
+            everyone = {w.resolved.agent_id: w for w in await active_winners(engine, _SCHEMA)}
+            assert everyone[agent_id].resolved.version_id == prod_version
+
+            target = build_target(
+                winner,
+                resolver,
+                namespace="curie",
+                model_credential_ref=BASELINE_CREDENTIAL,
+                connector_secret_name=CONNECTOR_SECRET_NAME,
+                credential_generation=CredentialGeneration.for_window(
+                    str(agent_id), issued_at=1_800_000_000
+                ),
+            )
+            assert not target.realizable
+            assert target.refusal == "bundleless-winner"
+        finally:
+            await _cleanup(engine, agent_ids)
+            await engine.dispose()
+
+    asyncio.run(go())
+
+
+def test_active_winner_query_returns_bundle_sha256_on_real_postgres() -> None:
+    async def go() -> None:
+        engine = await _engine_or_skip()
+        token = uuid.uuid4().hex[:8]
+        agent_ids: list[uuid.UUID] = []
+        try:
+            agent_id = await _seed_agent(
+                engine, name=f"warm-{token}", address=f"C-warm-{token}", memory=True
+            )
+            agent_ids.append(agent_id)
+            version = await _seed_deployment(
+                engine,
+                agent_id=agent_id,
+                environment="prod",
+                bundle_ref=f"bundles/{token}/prod.tgz",
+                bundle_sha256="ab" * 32,
+                deployed_seconds_ago=5,
+            )
+            winner = await active_winner(engine, _SCHEMA, agent_id)
+            assert winner is not None
+            assert winner.resolved.version_id == version
+            assert winner.bundle_sha256 == "ab" * 32
+            target = build_target(
+                winner,
+                binding.BindingResolver(engine, _config(db_schema=_SCHEMA)),
+                namespace="curie",
+                model_credential_ref=BASELINE_CREDENTIAL,
+                connector_secret_name=CONNECTOR_SECRET_NAME,
+                credential_generation=CredentialGeneration.for_window(
+                    str(agent_id), issued_at=1_800_000_000
+                ),
+            )
+            assert target.realizable
+            assert target.bundle_sha256 == "ab" * 32
+            assert derive_ref(target, prefix="curie").version_id == str(version)
+            assert await active_winner(engine, _SCHEMA, uuid.uuid4()) is None
+        finally:
+            await _cleanup(engine, agent_ids)
+            await engine.dispose()
+
+    asyncio.run(go())


### PR DESCRIPTION
Warm pools need the same active deployment winner as the cold resolver and a capability generation that changes when credential authority changes. This draft adds the worker-internal projection and target helpers, with bundleless winners reported as unrealizable instead of falling through to an older deployment. Stacked on #2399 (`task/overnight-bootstrap-contract`); the feature stack remains unmerged.

The projection renders the real `BindingResolver.boot_env`, classifies every key, and excludes credential material and conversation overlays. Projection version 2 also requires complete nonsecret Secret reference, UID, and resourceVersion observations for model, connector, and state-signing credentials. Missing authority keeps the target cold/unrealizable; changed current observations reject the old generation. Neither constructing the metadata DTO nor a fixed Secret name proves that the metadata came from a current Kubernetes observation.

The authoritative Secret observer, binding to the actual state-signing Secret, rotation lifecycle, producer loop, Template/Pool writes, and adoption wiring are still absent. Template-write security and real activation remain separate prerequisites. This PR does not establish warm-pool implementation completion.

Validation on the exact four source/test blobs committed in `ed0b4921`:

- 92 pure tests passed. The old helper failed both added missing-authority cases; removing the current-revision comparison caused eight negative failures while the healthy control passed, then restoring the exact source passed all nine selected cases. Fable independently verified the frozen hashes, reproduced the old defect, and reran all 92 pure tests.
- Both real-Postgres active-winner parity cases passed with zero skips in an allocated full backing stack, using a new task-owned database migrated to 0041. Resolver and connector ordering, JSON fields, bundle identity, and bundleless winner behavior were exercised. All four seeded tables were empty afterward; the database and owned stack were removed and absence verified.
- Ruff check/format, source mypy, and diff checks passed. Fable and a routed alternate completed source reviews; alternate hashes and test results were supplied evidence, while Fable recomputed them.
- The historical full-range secret scan found two fabricated fixture values. Two fully anchored complete-match exceptions document only those values; the same scan then passed, while a different value under each same key still triggered detection. No credential or identifier suppression was broadened.

Required-tier status for this prerequisite:

| Tier | Classification and observed limit |
| --- | --- |
| skill | Not applicable: no runner turn, ACI event, plugin packaging, or skill command changes. |
| local | Required for activated worker wiring and claim behavior; pure helpers and real SQL parity are supporting evidence, activation is unproved. |
| local-release | Not applicable to this helper slice: no install path, release pin, or image identity changes; the combined candidate retains its own release-parity gates. |
| cluster | Required for real Secret authority, current claims, pool realization and rotation; unproved. |
| live provider | Required for actual credential adoption/rotation and model continuity; unproved. |
| external integration | Not applicable to this helper slice: no Slack, GitHub, OAuth or other external integration ingress changes. |

The original reviewed commits (`7202a0fc`, `1fadde01`, `eecc6b79`) and credential follow-up `ed0b4921` remain in history. Accepted ADR-0122 authorizes the design, not an implementation-complete claim. Refs #1492 and #2399; no issue closure is requested.
