### PR TITLE
fix(cli): bind upgrade metadata to the observed Helm revision

### DIFF
--- a/cli/src/ops/upgrade.rs
+++ b/cli/src/ops/upgrade.rs
@@ -515,6 +515,43 @@ fn remaining_after(completed: &[UpgradePhase]) -> Vec<UpgradePhase> {
         .collect()
 }
 
+fn source_status_command(opts: &CommonOpts) -> OpsCommand {
+    OpsCommand::new(
+        "helm",
+        vec![
+            plain("status"),
+            plain(&opts.release),
+            plain("-n"),
+            plain(&opts.namespace),
+            plain("-o"),
+            plain("json"),
+        ],
+    )
+}
+
+fn source_metadata_command(opts: &CommonOpts, revision: &str) -> OpsCommand {
+    OpsCommand::new(
+        "helm",
+        vec![
+            plain("get"),
+            plain("metadata"),
+            plain(&opts.release),
+            plain("-n"),
+            plain(&opts.namespace),
+            plain("--revision"),
+            plain(revision),
+            plain("-o"),
+            plain("json"),
+        ],
+    )
+}
+
+fn source_metadata_error(message: &str) -> anyhow::Error {
+    crate::exit::CliError::failure(message)
+        .with_fix("inspect the selected release with helm status and helm get metadata --revision for that same revision; restore read access and resolve any release mismatch before rerunning this upgrade")
+        .into()
+}
+
 fn plan_lines(opts: &UpgradeOpts, from: Option<&str>, secret: Option<&str>) -> Vec<String> {
     let from = from.unwrap_or(if opts.common.dry_run {
         "source not inspected"
@@ -528,6 +565,8 @@ fn plan_lines(opts: &UpgradeOpts, from: Option<&str>, secret: Option<&str>) -> V
     let mut lines = vec![
         super::upgrade_owner::capture_command().display(),
         super::upgrade_owner::namespace_command(&opts.common.namespace).display(),
+        source_status_command(&opts.common).display(),
+        format!("Command template (revision resolved from source Helm status at execution): {}", source_metadata_command(&opts.common, "<observed-revision>").display()),
         "Reject nonempty HELM_KUBE target/authentication overrides; use the selected kubeconfig".into(),
         "Bind all Helm/Kubernetes commands to one private captured kubeconfig; acquire same-host ownership by namespace UID and release before checkpoint mutation".into(),
         format!("phase plan: {from} -> {}", opts.to),
@@ -1816,39 +1855,74 @@ impl LiveHost {
     }
 
     fn inspect_known_good(&self) -> Result<Option<String>> {
-        let (ok, raw, _) = self.run(&OpsCommand::new(
-            "helm",
-            vec![
-                plain("status"),
-                plain(&self.opts.common.release),
-                plain("-n"),
-                plain(&self.opts.common.namespace),
-                plain("-o"),
-                plain("json"),
-            ],
-        ))?;
+        let (ok, raw, _) = self.run(&source_status_command(&self.opts.common))?;
         if !ok {
-            bail!("could not inspect source Helm operation state before mutation");
+            return Err(source_metadata_error(
+                "could not inspect source Helm operation state before mutation",
+            ));
         }
-        let status: serde_json::Value =
-            serde_json::from_str(&raw).context("source Helm status is malformed")?;
+        let status: serde_json::Value = serde_json::from_str(&raw)
+            .map_err(|_| source_metadata_error("source Helm status is malformed"))?;
         let state = status
             .pointer("/info/status")
             .and_then(|value| value.as_str())
-            .context("source Helm status has no operation state")?;
+            .ok_or_else(|| source_metadata_error("source Helm status has no operation state"))?;
         if state.starts_with("pending-") {
             bail!("another Helm operation is pending; wait for its owner before resuming this upgrade");
         }
-        if state == "deployed"
-            && status
-                .pointer("/chart/metadata/version")
-                .and_then(|value| value.as_str())
-                == self.current.as_deref()
-        {
-            Ok(self.current.clone())
-        } else {
-            Ok(None)
+        if state != "deployed" {
+            return Ok(None);
         }
+        let revision = status
+            .get("version")
+            .and_then(|value| value.as_u64())
+            .filter(|revision| *revision > 0)
+            .ok_or_else(|| {
+                source_metadata_error("source Helm status has no valid release revision")
+            })?;
+        if status.get("name").and_then(|value| value.as_str()) != Some(&self.opts.common.release)
+            || status.get("namespace").and_then(|value| value.as_str())
+                != Some(&self.opts.common.namespace)
+        {
+            return Err(source_metadata_error(
+                "source Helm status does not identify the selected release",
+            ));
+        }
+        // Helm status deliberately removes Chart from its JSON output; obtain the
+        // metadata from the exact observed revision instead of guessing its version.
+        // https://github.com/helm/helm/blob/v3.16.4/cmd/helm/status.go
+        // https://github.com/helm/helm/blob/v3.16.4/pkg/action/get_metadata.go
+        let command = source_metadata_command(&self.opts.common, &revision.to_string());
+        let command = self
+            .owner
+            .as_ref()
+            .map_or_else(|| command.clone(), |owner| owner.bind(&command));
+        let (ok, raw, _) = tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(tokio::time::timeout(
+                std::time::Duration::from_secs(10),
+                run_capture(&command),
+            ))
+        })
+        .map_err(|_| source_metadata_error("source Helm metadata read timed out"))?
+        .map_err(|_| source_metadata_error("source Helm metadata read failed"))?;
+        if !ok {
+            return Err(source_metadata_error("source Helm metadata read failed"));
+        }
+        let metadata: serde_json::Value = serde_json::from_str(&raw)
+            .map_err(|_| source_metadata_error("source Helm metadata is malformed"))?;
+        if metadata.get("name").and_then(|value| value.as_str()) != Some(&self.opts.common.release)
+            || metadata.get("namespace").and_then(|value| value.as_str())
+                != Some(&self.opts.common.namespace)
+            || metadata.get("revision").and_then(|value| value.as_u64()) != Some(revision)
+            || metadata.get("status").and_then(|value| value.as_str()) != Some(state)
+            || metadata.get("chart").and_then(|value| value.as_str()) != Some("curie")
+            || metadata.get("version").and_then(|value| value.as_str()) != self.current.as_deref()
+        {
+            return Err(source_metadata_error(
+                "source Helm metadata does not match the observed release revision and version",
+            ));
+        }
+        Ok(self.current.clone())
     }
 
     fn prepare_retained_data(&mut self) -> Result<()> {

--- a/cli/tests/cluster_upgrade_live_driver.rs
+++ b/cli/tests/cluster_upgrade_live_driver.rs
@@ -456,6 +456,12 @@ fn offline_dry_run_does_not_claim_to_have_inspected_the_source() {
     assert!(output.status.success());
     assert!(fixture.calls().is_empty());
     assert!(String::from_utf8_lossy(&output.stdout).contains("not inspected"));
+    let text = String::from_utf8_lossy(&output.stdout);
+    assert!(text.contains("helm status acme-bot -n upgrade-test -o json"));
+    assert!(text.contains("helm get metadata acme-bot -n upgrade-test --revision"));
+    assert!(
+        text.contains("Command template (revision resolved from source Helm status at execution)")
+    );
 }
 
 #[test]
@@ -1032,4 +1038,97 @@ fn helm_target_overrides_refuse_before_upgrade_target_discovery_without_leaking_
             String::from_utf8_lossy(&empty.stdout)
         );
     }
+}
+
+#[test]
+fn source_known_good_uses_exact_revision_metadata_when_status_omits_chart() {
+    let fixture = Fixture::new();
+    let output = fixture.run("canary-fails");
+    assert_eq!(output.status.code(), Some(1));
+    let result: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(result["known_good_version"], "0.8.5");
+    let calls = fixture.calls();
+    assert!(calls.contains("\"helm\", \"get\", \"metadata\""));
+    assert!(calls.contains("\"--revision\", \"1\""));
+}
+
+#[test]
+fn mismatched_source_metadata_refuses_before_checkpoint_or_upgrade() {
+    for scenario in [
+        "source-metadata-denied",
+        "source-metadata-malformed",
+        "source-metadata-wrong-name",
+        "source-metadata-wrong-namespace",
+        "source-metadata-wrong-revision",
+        "source-metadata-wrong-chart",
+        "source-metadata-wrong-version",
+        "source-metadata-failed",
+        "source-metadata-missing-revision",
+    ] {
+        let fixture = Fixture::new();
+        let output = fixture.run(scenario);
+        fixture.assert_refused_without_upgrade(&output);
+        assert_eq!(output.status.code(), Some(1), "{scenario}");
+        let result: Value = serde_json::from_slice(&output.stdout).unwrap();
+        assert!(
+            result["fix"]
+                .as_str()
+                .is_some_and(|value| !value.is_empty()),
+            "{scenario}"
+        );
+        assert!(!fixture.path("record.json").exists(), "{scenario}");
+        for stream in [&output.stdout, &output.stderr] {
+            assert!(!String::from_utf8_lossy(stream)
+                .contains("synthetic-source-metadata-secret-sentinel"));
+        }
+    }
+}
+
+#[test]
+fn invalid_source_status_identity_refuses_before_metadata_and_checkpoint() {
+    for scenario in [
+        "source-status-wrong-name",
+        "source-status-wrong-namespace",
+        "source-status-missing-revision",
+        "source-status-zero-revision",
+        "source-status-string-revision",
+    ] {
+        let fixture = Fixture::new();
+        let output = fixture.run(scenario);
+        fixture.assert_refused_without_upgrade(&output);
+        assert_eq!(output.status.code(), Some(1));
+        let result: Value = serde_json::from_slice(&output.stdout).unwrap();
+        assert!(result["fix"]
+            .as_str()
+            .is_some_and(|value| !value.is_empty()));
+        assert!(!fixture.calls().contains("\"helm\", \"get\", \"metadata\""));
+        assert!(!fixture.path("record.json").exists());
+    }
+}
+
+#[test]
+fn bounded_source_metadata_read_stops_its_child_and_preserves_recovery() {
+    let fixture = Fixture::new();
+    let started = std::time::Instant::now();
+    let output = fixture.run("source-metadata-hung");
+    assert!(started.elapsed() < std::time::Duration::from_secs(20));
+    fixture.assert_refused_without_upgrade(&output);
+    assert_eq!(output.status.code(), Some(1));
+    let result: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert!(result["error"]
+        .as_str()
+        .unwrap()
+        .contains("metadata read timed out"));
+    assert!(result["fix"]
+        .as_str()
+        .is_some_and(|value| !value.is_empty()));
+    assert!(!fixture.path("record.json").exists());
+    for stream in [&output.stdout, &output.stderr] {
+        assert!(
+            !String::from_utf8_lossy(stream).contains("synthetic-source-metadata-secret-sentinel")
+        );
+    }
+    let pid = fs::read_to_string(fixture.path("metadata-pid")).unwrap();
+    let absent = Command::new("/usr/bin/python3").args(["-c", "import os,sys; p=int(sys.argv[1]);\ntry: os.kill(p,0)\nexcept ProcessLookupError: sys.exit(0)\nsys.exit(1)", &pid]).status().unwrap();
+    assert!(absent.success(), "timed-out metadata child must be absent");
 }

--- a/cli/tests/data/upgrade-driver.py
+++ b/cli/tests/data/upgrade-driver.py
@@ -208,10 +208,26 @@ if program == "helm":
                 )
             )
         else:
+            if scenario.startswith("source-status-"):
+                status = {"name": "acme-bot", "namespace": "upgrade-test", "version": 1, "info": {"status": "deployed"}}
+                if scenario == "source-status-wrong-name":
+                    status["name"] = "acme-other"
+                elif scenario == "source-status-wrong-namespace":
+                    status["namespace"] = "other-test"
+                elif scenario == "source-status-missing-revision":
+                    status.pop("version")
+                elif scenario == "source-status-zero-revision":
+                    status["version"] = 0
+                elif scenario == "source-status-string-revision":
+                    status["version"] = "1"
+                print(json.dumps(status))
+                sys.exit(0)
             print(
                 json.dumps(
                     {
-                        "chart": {"metadata": {"version": installed}},
+                        "name": "acme-bot",
+                        "namespace": "upgrade-test",
+                        "version": 2 if (root / "installed-version").exists() else 1,
                         "info": {"status": "failed" if scenario == "helm-failed" else "deployed"},
                         "hooks": []
                         if scenario == "missing-hooks"
@@ -236,6 +252,29 @@ if program == "helm":
                     }
                 )
             )
+    elif args[:2] == ["get", "metadata"]:
+        # Helm3.16.4 status deliberately strips Chart; get metadata is separate.
+        # https://github.com/helm/helm/blob/v3.16.4/cmd/helm/status.go
+        # https://github.com/helm/helm/blob/v3.16.4/pkg/action/get_metadata.go
+        if scenario == "source-metadata-hung":
+            (root / "metadata-pid").write_text(str(os.getpid()))
+            print("synthetic-source-metadata-secret-sentinel", file=sys.stderr, flush=True)
+            time.sleep(60)
+        if scenario == "source-metadata-denied":
+            print("synthetic-source-metadata-secret-sentinel", file=sys.stderr)
+            sys.exit(1)
+        if scenario == "source-metadata-malformed":
+            print("synthetic-source-metadata-secret-sentinel")
+            sys.exit(0)
+        installed = (root / "installed-version").read_text() if (root / "installed-version").exists() else "0.8.5"
+        metadata = {"name": "acme-bot", "namespace": "upgrade-test", "revision": int(args[args.index("--revision") + 1]), "chart": "curie", "version": installed, "appVersion": installed, "status": "deployed"}
+        changes = {"source-metadata-wrong-name": ("name", "acme-other"), "source-metadata-wrong-namespace": ("namespace", "other-test"), "source-metadata-wrong-revision": ("revision", 99), "source-metadata-wrong-chart": ("chart", "other-chart"), "source-metadata-wrong-version": ("version", "0.7.0"), "source-metadata-failed": ("status", "failed")}
+        if scenario in changes:
+            key, value = changes[scenario]
+            metadata[key] = value
+        if scenario == "source-metadata-missing-revision":
+            metadata.pop("revision")
+        print(json.dumps(metadata))
     elif args[:2] == ["show", "chart"]:
         version = "0.8.5" if scenario == "wrong-chart" else "0.9.0"
         print(f"name: curie\nversion: {version}\nappVersion: {version}")


### PR DESCRIPTION
## Summary

Helm status JSON omits the chart. Transactional upgrades previously treated that omission as an unknown last known-good version. Read the supported metadata command at the exact observed release revision, and require its release, namespace, revision, state, chart and version to match before checkpoint mutation. Invalid or inaccessible metadata returns one structured error with recovery instructions; the new read has a ten-second bound.

This prerequisite is stacked on #2402 for #2301. It adds no automatic pending-Helm recovery or distributed ownership guarantee. The feature remains a draft until its required runtime evidence is complete.

## Fix pin verification

Fix pin: cli/tests/cluster_upgrade_live_driver.rs::source_known_good_uses_exact_revision_metadata_when_status_omits_chart

## Verification

- Actual Helm 3.16.4 status output from the disposable capability probe omits chart; the upstream status and metadata implementations confirm the supported fields.
- The actual CLI regression failed on the previous implementation with a null known-good version instead of 0.8.5.
- 54 external-process upgrade-driver tests and 22 command-surface tests pass, including wrong release/namespace/revision/state/chart/version, missing or malformed fields, denied reads, and a hung read whose child is stopped. Refusals preserve the checkpoint boundary and omit synthetic private sentinels.
- Offline dry-run prints the shared read commands with an explicitly unresolved revision template and executes no subprocess.
- Independent code/security and scope reviews completed. Final formatting, lint and exact fix-pin verification remain pending; this PR stays draft.

## End-to-end verification

| Tier | Required / n/a | Reason | Mode | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | No runner turn loop, ACI or plugin packaging change. | — | — |
| local | required | Transactional CLI failure and recovery output changes. | fake | Pending; external-process tests do not replace this rung. |
| local-release | required | Upgrade reads installed release identity. | fake | Pending on the exact combined candidate. |
| cluster | required | Real Helm revision metadata and checkpoint behavior must be exercised. | fake | Pending full transactional candidate; the earlier capability probe proves only Helm's metadata shape. |
| live provider | n/a | No product model routing, provider auth or accounting change. | — | — |
| external integration | n/a | No Slack, GitHub, OAuth or third-party product integration changes. | — | — |

- [x] Positive and negative consumer regressions are present.
- [ ] Every required runtime tier passes on the exact candidate.
- [ ] Full transactional resume, retained data/thread/approval and interruption matrix complete.
