### PR TITLE
Install app image dependencies in a layer that survives a source edit

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -12,12 +12,38 @@
 # `curie-api` member (and only its deps) as non-editable wheels into /app/.venv;
 # the runtime carries just that venv plus the Alembic migration tree so the chart
 # can run `alembic upgrade head` from the same image.
+#
+# Third-party dependencies install in their own layer ahead of the sources; see
+# the dependency-layer comment in the builder.
 FROM python:3.13.15-slim@sha256:9d2e5553305c7c7b0097999bb17187c69b921ccd6bc9d40e4bb5ebe652c00285 AS builder
 RUN pip install --no-cache-dir uv==0.10.7
 WORKDIR /app
 ENV UV_COMPILE_BYTECODE=1 \
     UV_LINK_MODE=copy \
     UV_PYTHON_DOWNLOADS=never
+# Dependency layer: the lockfile plus every workspace member's pyproject.toml
+# (uv needs all of them to resolve --frozen), and nothing else, so this layer
+# is invalidated only by a lockfile or manifest change -- never by a source
+# edit. --no-install-workspace installs the member's locked third-party
+# dependencies without building any workspace member.
+COPY pyproject.toml uv.lock ./
+COPY packages/aci-protocol/pyproject.toml packages/aci-protocol/
+COPY packages/channel-protocol/pyproject.toml packages/channel-protocol/
+COPY packages/plugin-format/pyproject.toml packages/plugin-format/
+COPY packages/telemetry-schema/pyproject.toml packages/telemetry-schema/
+COPY packages/test-support/pyproject.toml packages/test-support/
+COPY packages/telemetry/pyproject.toml packages/telemetry/
+COPY apps/api/pyproject.toml apps/api/
+COPY apps/dispatcher/pyproject.toml apps/dispatcher/
+COPY adapters/discord/pyproject.toml adapters/discord/
+COPY apps/mail-adapter/pyproject.toml apps/mail-adapter/
+COPY apps/worker/pyproject.toml apps/worker/
+COPY runner/pyproject.toml runner/
+COPY tools/doclint/pyproject.toml tools/doclint/
+COPY tools/wire-tolerance-gate/pyproject.toml tools/wire-tolerance-gate/
+RUN uv sync --frozen --no-dev --no-editable --no-install-workspace --package curie-api
+# Sources last: this sync only builds and installs the workspace members the
+# package depends on; the third-party wheels above are already in the venv.
 COPY . .
 RUN uv sync --frozen --no-dev --no-editable --package curie-api
 

--- a/apps/dispatcher/Dockerfile
+++ b/apps/dispatcher/Dockerfile
@@ -8,12 +8,38 @@
 # Socket Mode means no inbound HTTP: the process dials Slack out, so there is no
 # server port. The chart uses a heartbeat-file exec liveness probe (a daemon
 # thread touches a file the probe checks for freshness), not an HTTP probe.
+#
+# Third-party dependencies install in their own layer ahead of the sources; see
+# the dependency-layer comment in the builder.
 FROM python:3.13.15-slim@sha256:9d2e5553305c7c7b0097999bb17187c69b921ccd6bc9d40e4bb5ebe652c00285 AS builder
 RUN pip install --no-cache-dir uv==0.10.7
 WORKDIR /app
 ENV UV_COMPILE_BYTECODE=1 \
     UV_LINK_MODE=copy \
     UV_PYTHON_DOWNLOADS=never
+# Dependency layer: the lockfile plus every workspace member's pyproject.toml
+# (uv needs all of them to resolve --frozen), and nothing else, so this layer
+# is invalidated only by a lockfile or manifest change -- never by a source
+# edit. --no-install-workspace installs the member's locked third-party
+# dependencies without building any workspace member.
+COPY pyproject.toml uv.lock ./
+COPY packages/aci-protocol/pyproject.toml packages/aci-protocol/
+COPY packages/channel-protocol/pyproject.toml packages/channel-protocol/
+COPY packages/plugin-format/pyproject.toml packages/plugin-format/
+COPY packages/telemetry-schema/pyproject.toml packages/telemetry-schema/
+COPY packages/test-support/pyproject.toml packages/test-support/
+COPY packages/telemetry/pyproject.toml packages/telemetry/
+COPY apps/api/pyproject.toml apps/api/
+COPY apps/dispatcher/pyproject.toml apps/dispatcher/
+COPY adapters/discord/pyproject.toml adapters/discord/
+COPY apps/mail-adapter/pyproject.toml apps/mail-adapter/
+COPY apps/worker/pyproject.toml apps/worker/
+COPY runner/pyproject.toml runner/
+COPY tools/doclint/pyproject.toml tools/doclint/
+COPY tools/wire-tolerance-gate/pyproject.toml tools/wire-tolerance-gate/
+RUN uv sync --frozen --no-dev --no-editable --no-install-workspace --package curie-dispatcher
+# Sources last: this sync only builds and installs the workspace members the
+# package depends on; the third-party wheels above are already in the venv.
 COPY . .
 RUN uv sync --frozen --no-dev --no-editable --package curie-dispatcher
 

--- a/apps/mail-adapter/Dockerfile
+++ b/apps/mail-adapter/Dockerfile
@@ -8,12 +8,38 @@
 # Unlike the dispatcher this process serves inbound HTTP (the neutral reply wire
 # plus /healthz on CURIE_MAIL_PORT), so the chart gives it an HTTP liveness probe
 # rather than a heartbeat-file exec probe.
+#
+# Third-party dependencies install in their own layer ahead of the sources; see
+# the dependency-layer comment in the builder.
 FROM python:3.13.15-slim@sha256:9d2e5553305c7c7b0097999bb17187c69b921ccd6bc9d40e4bb5ebe652c00285 AS builder
 RUN pip install --no-cache-dir uv==0.10.7
 WORKDIR /app
 ENV UV_COMPILE_BYTECODE=1 \
     UV_LINK_MODE=copy \
     UV_PYTHON_DOWNLOADS=never
+# Dependency layer: the lockfile plus every workspace member's pyproject.toml
+# (uv needs all of them to resolve --frozen), and nothing else, so this layer
+# is invalidated only by a lockfile or manifest change -- never by a source
+# edit. --no-install-workspace installs the member's locked third-party
+# dependencies without building any workspace member.
+COPY pyproject.toml uv.lock ./
+COPY packages/aci-protocol/pyproject.toml packages/aci-protocol/
+COPY packages/channel-protocol/pyproject.toml packages/channel-protocol/
+COPY packages/plugin-format/pyproject.toml packages/plugin-format/
+COPY packages/telemetry-schema/pyproject.toml packages/telemetry-schema/
+COPY packages/test-support/pyproject.toml packages/test-support/
+COPY packages/telemetry/pyproject.toml packages/telemetry/
+COPY apps/api/pyproject.toml apps/api/
+COPY apps/dispatcher/pyproject.toml apps/dispatcher/
+COPY adapters/discord/pyproject.toml adapters/discord/
+COPY apps/mail-adapter/pyproject.toml apps/mail-adapter/
+COPY apps/worker/pyproject.toml apps/worker/
+COPY runner/pyproject.toml runner/
+COPY tools/doclint/pyproject.toml tools/doclint/
+COPY tools/wire-tolerance-gate/pyproject.toml tools/wire-tolerance-gate/
+RUN uv sync --frozen --no-dev --no-editable --no-install-workspace --package curie-mail-adapter
+# Sources last: this sync only builds and installs the workspace members the
+# package depends on; the third-party wheels above are already in the venv.
 COPY . .
 RUN uv sync --frozen --no-dev --no-editable --package curie-mail-adapter
 

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -7,12 +7,38 @@
 #
 # The worker drives the Kubernetes API to claim/manage sandboxes, so its
 # Deployment carries a ServiceAccount + RBAC (see the chart). No inbound HTTP.
+#
+# Third-party dependencies install in their own layer ahead of the sources; see
+# the dependency-layer comment in the builder.
 FROM python:3.13.15-slim@sha256:9d2e5553305c7c7b0097999bb17187c69b921ccd6bc9d40e4bb5ebe652c00285 AS builder
 RUN pip install --no-cache-dir uv==0.10.7
 WORKDIR /app
 ENV UV_COMPILE_BYTECODE=1 \
     UV_LINK_MODE=copy \
     UV_PYTHON_DOWNLOADS=never
+# Dependency layer: the lockfile plus every workspace member's pyproject.toml
+# (uv needs all of them to resolve --frozen), and nothing else, so this layer
+# is invalidated only by a lockfile or manifest change -- never by a source
+# edit. --no-install-workspace installs the member's locked third-party
+# dependencies without building any workspace member.
+COPY pyproject.toml uv.lock ./
+COPY packages/aci-protocol/pyproject.toml packages/aci-protocol/
+COPY packages/channel-protocol/pyproject.toml packages/channel-protocol/
+COPY packages/plugin-format/pyproject.toml packages/plugin-format/
+COPY packages/telemetry-schema/pyproject.toml packages/telemetry-schema/
+COPY packages/test-support/pyproject.toml packages/test-support/
+COPY packages/telemetry/pyproject.toml packages/telemetry/
+COPY apps/api/pyproject.toml apps/api/
+COPY apps/dispatcher/pyproject.toml apps/dispatcher/
+COPY adapters/discord/pyproject.toml adapters/discord/
+COPY apps/mail-adapter/pyproject.toml apps/mail-adapter/
+COPY apps/worker/pyproject.toml apps/worker/
+COPY runner/pyproject.toml runner/
+COPY tools/doclint/pyproject.toml tools/doclint/
+COPY tools/wire-tolerance-gate/pyproject.toml tools/wire-tolerance-gate/
+RUN uv sync --frozen --no-dev --no-editable --no-install-workspace --package curie-worker
+# Sources last: this sync only builds and installs the workspace members the
+# package depends on; the third-party wheels above are already in the venv.
 COPY . .
 RUN uv sync --frozen --no-dev --no-editable --package curie-worker
 

--- a/runner/tests/test_dockerfile_dependency_layer.py
+++ b/runner/tests/test_dockerfile_dependency_layer.py
@@ -1,0 +1,126 @@
+"""The app Dockerfiles' builder stages install locked third-party dependencies
+in a layer that precedes the source copy, so an edit to application source
+never invalidates that ~443 MB install. The dependency `uv sync` runs
+`--no-install-workspace` before `COPY . .`; a final `uv sync` without that flag
+runs after, to build the workspace member itself against the already-warm venv.
+The allowlist of instructions permitted before that sync is exact, so nothing
+but manifest copies can land in the dependency layer.
+"""
+
+from __future__ import annotations
+
+import functools
+import tomllib
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+APP_DOCKERFILES = (
+    "apps/api/Dockerfile",
+    "apps/worker/Dockerfile",
+    "apps/dispatcher/Dockerfile",
+    "apps/mail-adapter/Dockerfile",
+)
+
+
+def _logical_instructions(dockerfile_text: str) -> list[str]:
+    instructions: list[str] = []
+    pending: list[str] = []
+    for raw_line in dockerfile_text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        continues = line.endswith("\\")
+        pending.append(line[:-1].rstrip() if continues else line)
+        if not continues:
+            instructions.append(" ".join(pending))
+            pending = []
+    assert not pending, "Dockerfile ends with an unfinished continuation"
+    return instructions
+
+
+@functools.cache
+def _builder_stage_instructions(relative: str) -> list[str]:
+    text = (_REPO_ROOT / relative).read_text(encoding="utf-8")
+    instructions = _logical_instructions(text)
+    from_indexes = [i for i, ins in enumerate(instructions) if ins.startswith("FROM ")]
+    assert len(from_indexes) >= 2, f"{relative} does not have a runtime stage"
+    return instructions[from_indexes[0] : from_indexes[1]]
+
+
+def _index_of(instructions: list[str], predicate: Callable[[str], bool]) -> int:
+    return next(i for i, ins in enumerate(instructions) if predicate(ins))
+
+
+def _is_dep_sync(ins: str) -> bool:
+    return ins.startswith("RUN uv sync") and "--frozen" in ins and "--no-install-workspace" in ins
+
+
+def _is_final_sync(ins: str) -> bool:
+    return (
+        ins.startswith("RUN uv sync") and "--frozen" in ins and "--no-install-workspace" not in ins
+    )
+
+
+@functools.cache
+def _workspace_members() -> list[str]:
+    data = tomllib.loads((_REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    members = data["tool"]["uv"]["workspace"]["members"]
+    assert isinstance(members, list)
+    return [str(m) for m in members]
+
+
+@pytest.mark.parametrize("relative", APP_DOCKERFILES)
+def test_dependency_sync_precedes_source_copy(relative: str) -> None:
+    instructions = _builder_stage_instructions(relative)
+    copy_all_index = _index_of(instructions, lambda ins: ins == "COPY . .")
+    dep_sync_index = _index_of(instructions, _is_dep_sync)
+    final_sync_index = _index_of(instructions, _is_final_sync)
+
+    assert dep_sync_index < copy_all_index, (
+        f"{relative}: the --no-install-workspace dependency sync must precede COPY . ."
+    )
+    assert final_sync_index > copy_all_index, (
+        f"{relative}: the final workspace sync must follow COPY . ."
+    )
+
+
+@pytest.mark.parametrize("relative", APP_DOCKERFILES)
+def test_every_workspace_member_manifest_precedes_dependency_sync(relative: str) -> None:
+    instructions = _builder_stage_instructions(relative)
+    dep_sync_index = _index_of(instructions, _is_dep_sync)
+
+    lockfile_index = _index_of(instructions, lambda ins: ins == "COPY pyproject.toml uv.lock ./")
+    assert lockfile_index < dep_sync_index
+
+    for member in _workspace_members():
+        expected = f"COPY {member}/pyproject.toml {member}/"
+        member_index = next((i for i, ins in enumerate(instructions) if ins == expected), None)
+        assert member_index is not None, (
+            f"{relative}: missing '{expected}' before the dependency sync"
+        )
+        assert member_index < dep_sync_index
+
+
+def _allowed_manifest_copies() -> set[str]:
+    allowed = {"COPY pyproject.toml uv.lock ./"}
+    allowed.update(f"COPY {member}/pyproject.toml {member}/" for member in _workspace_members())
+    return allowed
+
+
+@pytest.mark.parametrize("relative", APP_DOCKERFILES)
+def test_no_source_copied_before_dependency_sync(relative: str) -> None:
+    instructions = _builder_stage_instructions(relative)
+    dep_sync_index = _index_of(instructions, _is_dep_sync)
+    allowed = _allowed_manifest_copies()
+
+    for instruction in instructions[:dep_sync_index]:
+        first_word = instruction.split(maxsplit=1)[0].upper()
+        if first_word not in ("COPY", "ADD"):
+            continue
+        assert instruction in allowed, (
+            f"{relative}: unexpected source transfer before dependency layer: {instruction!r}"
+        )


### PR DESCRIPTION
Restructures the api, worker, dispatcher and mail-adapter Dockerfiles so the locked third-party dependencies install in a layer that precedes the source copy, matching the shape `apps/ui/Dockerfile` already uses for pnpm. Before this, every builder stage did `COPY . .` immediately followed by the single `uv sync`, so a one-line source edit anywhere in the context re-downloaded and re-installed the ~443 MB venv in all four images: the CI image matrix, the ladder builds, release builds and every `curie local up --build`.

Each builder now copies `uv.lock`, the root `pyproject.toml` and every workspace member's `pyproject.toml` (all 14 entries of `[tool.uv.workspace].members`, which uv needs to resolve `--frozen`), runs `uv sync --frozen --no-dev --no-editable --no-install-workspace --package <member>`, and only then copies the sources and runs the unchanged final frozen sync, which builds just the workspace members. `--frozen` stays on both syncs. The runtime stages (non-root uid 1000, copied `.venv`, api's alembic tree, `EXPOSE`/`CMD`) are byte-identical to before.

`runner/tests/test_dockerfile_dependency_layer.py` pins the shape for all four images: the dependency sync must precede `COPY . .`, every member in the root `pyproject.toml` must have its manifest copied before it, and the allowlist of `COPY`/`ADD` instructions before that sync is exact, so a member added to the workspace without a matching `COPY` line, or a source tree slipped into the dependency layer, fails there instead of in a docker build.

Out of scope, deliberately: `runner/Dockerfile` (separate task) and BuildKit cache mounts (nothing in the repo uses them and the CI cache is `type=gha`; a mount would be a second change with its own trade-offs).

## Measurements

All builds from the repo root on the same 16-core box, default `docker` buildx driver, BuildKit. "Old" is `origin/main` at 96b1a537 in a detached worktree; "new" is this branch. The one-line edit appends a comment to `apps/<app>/src/curie_<app>/__init__.py`, and is reverted between runs.

```
docker build --progress=plain -f apps/api/Dockerfile    -t curie-api:dep-layer-<old|new> .
docker build --progress=plain -f apps/worker/Dockerfile -t curie-worker:dep-layer-<old|new> .
echo "# probe" >> apps/api/src/curie_api/__init__.py      # then the same build again
```

Rebuild after the one-line source edit, two rounds back to back, old and new alternating so both see the same load:

| image | old rebuild | new rebuild | dependency sync on rebuild |
|---|---|---|---|
| api | 9.0 s, 10.1 s | 5.1 s, 5.5 s | `#22 [builder 19/21] RUN uv sync ... --no-install-workspace ... CACHED` |
| worker | 8.6 s, 9.1 s | 4.8 s, 5.3 s | `#22 [builder 19/21] RUN uv sync ... --no-install-workspace ... CACHED` |

On the old shape the rebuild's only uv step is `RUN uv sync --frozen --no-dev --no-editable --package curie-api`, which re-downloads and re-installs the whole closure (5.5 s of the 9 s here, on a fast link with no uv cache in the image). On the new shape that step is `CACHED` and the final sync only builds the five workspace members (`Prepared 5 packages in 1.08s`, `Installed 5 packages in 29ms`), 2.9 s for api and 5.2 s for worker under load. The local win is bounded by this box's download speed. In CI the cached layer is the ~443 MB venv that `cache-to: type=gha` no longer re-exports and `cache-from` no longer misses on every source-only push.

The ladder's `curie local up --build` on this branch reports the same `CACHED` line for api, worker and dispatcher.

Builder-stage layer sizes (`docker build --target builder` then `docker history`), api: the cached dependency layer is 428 MB, the source copy 21.3 MB, and the final sync layer 5.94 MB, against a single 434 MB sync layer before. `UV_COMPILE_BYTECODE=1` still applies to the final sync, which walks the venv (`Bytecode compiled 3912 files in 877ms`) but rewrites only what changed, so the per-edit layer stays at 6 MB and the runtime venv keeps every `.pyc` it had before.

## Venv identity

`python -m pip` is not installed in the venv, so the distribution list is the `*.dist-info` directory names under `/app/.venv/lib/python3.13/site-packages`, which carry name and version:

```
docker run --rm --entrypoint /bin/sh curie-<app>:dep-layer-<old|new> -c \
  'ls /app/.venv/lib/python3.13/site-packages | grep -i dist-info | sed "s/.dist-info//" | sort'
```

`diff` of old vs new is empty for all four images: api (76 distributions), worker (61), dispatcher (32), mail-adapter (26). Image sizes: api 477351856 both, dispatcher 178341756 both, mail-adapter 164959330 both, worker 442034149 vs 442034147 (two bytes, a timestamp inside the venv).

## Local tier

Classified as the local tier (compose). Run from this worktree with a CLI built from the branch:

```
CURIE_BIN=<branch-built curie 0.8.6> CURIE_E2E_TIERS=local bash cli/scripts/e2e-ladder.sh
```

The local rung ran `curie local up -f compose.dev.yaml --build` (`built 5 image(s) as :dev`, with the dependency sync `CACHED` for api, worker and dispatcher), `curie local deploy`, `curie local message` (`turn finalized with a reply`, five times across the rung's cases, fake model, plumbing only), the observability and runner-failure cases, and `curie local down`. Result: `LADDER PASS (tiers: local)`, 320 s wall, `no curie containers running` after teardown. The first attempt failed before any rung on a host-port collision (`Bind for :::28123 failed`) with another session's fixture stack; it was rerun once that stack released the ports, with no change to the branch.

## Notes

- The CLI pins `COMPOSE_PROJECT_NAME=curie`, so the local tier ran under that project name after confirming no other stack used it; it was torn down afterwards.
- `apps/ui/Dockerfile` was the reference shape; `runner/Dockerfile` is intentionally untouched here.

## Done-check

- [x] Failing tests committed before implementation: N/A (quick tier; the pin test and the Dockerfile edits landed together, and the pin was demonstrated rejecting four mutated Dockerfiles, including the two loophole shapes the code reviewer named).
- [x] All edits by the delegated executor; the driver ran only validation, docker builds, git and bookkeeping.
- [x] Broadened return types: N/A (no Python production code changed).
- [x] Routed Code Reviewer (codex) completed: one P2 finding, the source-exclusion allowlist was loose; fixed with an exact allowlist derived from the workspace members list.
- [x] Routed Scope Reviewer (grok) completed: approve, every hunk maps to an AC or is the comment text for it, no passengers.
- [x] Sibling-path parity: all four app Dockerfiles carry the identical block; `runner/Dockerfile` is the named out-of-scope sibling (separate task); `adapters/discord/Dockerfile` is not in the release matrix and was not asked for.
- [x] Guard demonstration: the pin test rejected (a) the dependency sync moved after `COPY . .`, (b) a dropped member COPY line, (c) a multi-source COPY carrying sources into the dependency layer, (d) an ADD before the dependency sync.
- [x] Consolidation: `/simplify` applied two cleanups (comment de-duplication, `functools.cache` on the test's file reads); the routed re-check (codex) approved. Skipped as out of this diff's scope: the Dockerfile-instruction parser is now the third copy across `runner/tests` (a shared helper in `packages/test-support` is a follow-up), and a generated member list would break the plain `docker build -f` invariant every build path relies on.
- [x] Security Reviewer: N/A (no security scale-up).
- [x] Observable verification: docker builds with `--progress=plain` before and after a source edit, `CACHED` on the dependency sync, identical distribution lists, local tier through the ladder (below).
- [x] Train check: shared-line change, cut from `origin/main`, PR against `main`.
- [x] Discovery-surface proof: found by a performance review at the build surface; the proof is the build-cache evidence above plus the local tier.
- [x] Re-fix mechanism: N/A.
- [x] Focused tests, ruff check, ruff format and mypy strict clean on the new test; `runner/tests/test_dockerfile_base_pins.py` still passes.
