### PR TITLE
Source probe cadences from values so liveness outlives readiness

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -316,6 +316,21 @@ jobs:
           set -euo pipefail
           bash charts/curie/ci/langfuse-worker-probe-assertions.sh
 
+      # Prove the probe-window invariant across the WHOLE render, not a named
+      # list: for every container carrying both probes, the liveness failure
+      # cutoff -- initialDelaySeconds + (failureThreshold - 1) * periodSeconds,
+      # kubelet defaults applied to omitted keys -- must be strictly LATER than
+      # the readiness one, or the kubelet restarts a container that is still
+      # inside the boot window readiness was sized to tolerate. postgres (WAL
+      # replay), langfuse-web and langfuse-worker (Prisma/ClickHouse boot
+      # migrations) and api all inverted the two probes. Also requires an
+      # explicit livenessProbe timeoutSeconds everywhere, since the kubelet's
+      # invisible 1s default is the silent half of the postgres case.
+      - name: helm render assertions (probe windows)
+        run: |
+          set -euo pipefail
+          bash charts/curie/ci/probe-window-assertions.sh
+
       # Prove the controller NetworkPolicy RBAC split (issue #350): exactly one
       # read-only cluster grant (get/list/watch) so the informer syncs, no
       # cluster-wide mutate anywhere (#66 guarded), namespaced mutate intact, and

--- a/charts/curie/CLAUDE.md
+++ b/charts/curie/CLAUDE.md
@@ -42,34 +42,37 @@ component and rail detail in `charts/curie/README.md`.
     strategy values key**. Pinned by `ci/langfuse-recreate-assertions.sh`.
     Horizontal scale for Langfuse needs an Accepted out-of-band migrator; when
     that lands, this exception is removed rather than extended.
-  - **Third named exception: `langfuse-worker`'s probe cadences, also in
-    `templates/langfuse.yaml`.** Its `readinessProbe`/`livenessProbe` cadence
-    numbers (#2330) -- `initialDelaySeconds`, `periodSeconds`,
-    `timeoutSeconds`, `failureThreshold` -- are hardcoded to match
-    `langfuse-web`'s, three blocks above in the same file, instead of reading
-    from new `langfuse.worker.readinessProbe.*` / `.livenessProbe.*` values
-    keys. The probe types and endpoints deliberately differ from web's
-    (worker readiness is `httpGet /api/ready`, liveness is `tcpSocket`; web
-    uses `httpGet /api/public/health` for both -- see the liveness rationale
-    below) -- only the cadence numbers follow web. This is a knowing
-    deviation, not a claim that the invariant does not apply: this ticket
-    exists *because* `langfuse-web` and `langfuse-worker` had diverged (web
-    alone had the Postgres readiness gate), and adding values-driven probe
-    keys for the worker while `langfuse-web`'s probes stay hardcoded in the
-    same file would create a new asymmetry in the very file the ticket is
-    about. It is also not a new hole in the chart: every other long-running
-    Deployment already
-    hardcodes its probe numbers -- `api.yaml`, `ui.yaml`, `postgres.yaml`,
-    `clickhouse.yaml`, `valkey.yaml`, `rustfs.yaml`, `otel-collector.yaml`,
-    `mail-adapter.yaml`, `inference.yaml`, and the `curie.heartbeatProbes`
-    helper (used by `worker.yaml` and `dispatcher.yaml`) -- so `langfuse-web`
-    itself was already inside this exception before #2330. The only K8s Probes
-    genuinely driven by values in this chart are
-    `agentSandbox.runner.readinessProbe`, because its cadence couples to the
-    worker's claim-timeout budget, and `dispatcher.startupProbe`; nothing here
-    couples the same way. The correct end state is lifting `langfuse-web` and
-    `langfuse-worker` onto values-driven probes together, tracked as a separate
-    follow-up -- not extended piecemeal from this ticket.
+  - **Probe handlers stay in the template; probe cadences live in values.**
+    The probe *handler* -- `exec` / `httpGet` path / `tcpSocket` port -- is a
+    correctness choice about the image, not an environment knob, so it is
+    hardcoded in `templates/` on purpose (`langfuse-worker`'s `tcpSocket`
+    liveness is load-bearing, #2330; see the liveness invariant below). The
+    *cadence* keys -- `initialDelaySeconds`, `periodSeconds`, `timeoutSeconds`,
+    `failureThreshold` -- are sizing, so they read from values:
+    `postgres.readinessProbe`/`.livenessProbe`,
+    `langfuse.web.readinessProbe`/`.livenessProbe`,
+    `langfuse.worker.readinessProbe`/`.livenessProbe`, and
+    `api.readinessProbe`/`.livenessProbe`, alongside the pre-existing
+    `agentSandbox.runner.readinessProbe` and `dispatcher.startupProbe`. On top of
+    that: **on every container carrying both probes, the liveness failure cutoff
+    must strictly exceed the readiness one**, where
+    `cutoff = initialDelaySeconds + (failureThreshold - 1) * periodSeconds` and
+    omitted keys take the kubelet defaults (`periodSeconds: 10`,
+    `failureThreshold: 3`, `timeoutSeconds: 1`). A liveness probe that gives up
+    before readiness has stopped tolerating a slow boot restarts a container that
+    is still legitimately booting -- postgres replaying WAL, Langfuse running its
+    Prisma/ClickHouse boot migrations, the API warming up -- and the restart
+    re-enters the same boot path. Every `livenessProbe` must also declare
+    `timeoutSeconds` explicitly; the kubelet's 1s default is invisible in the
+    manifest and each timed-out probe counts as a failure. Both rules are pinned
+    for *every* rendered container, with no allowlist, by
+    `ci/probe-window-assertions.sh`. The remaining hardcoded probe blocks
+    (`ui.yaml`, `clickhouse.yaml`, `valkey.yaml`, `rustfs.yaml`,
+    `otel-collector.yaml`, `mail-adapter.yaml`, `inference.yaml`, and the
+    `curie.heartbeatProbes` helper used by `worker.yaml` and `dispatcher.yaml`)
+    all satisfy the ordering invariant today; lifting their numbers onto values
+    is a follow-up, and the assertion pins their ordering wherever the numbers
+    live.
 - **The instrumented set is exactly the workloads whose container `env` block
   includes the `curie.env.otel` helper.** That include *is* the boundary -- it
   is not a count and not a list kept in prose, and this rule exists because a

--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -133,6 +133,49 @@ helm upgrade curie charts/curie -n curie --reuse-values \
 | `dispatcher.startupProbe.periodSeconds` | `10` | Interval between dispatcher startup probes. |
 | `dispatcher.startupProbe.timeoutSeconds` | `5` | Timeout for each dispatcher startup probe. |
 | `dispatcher.startupProbe.failureThreshold` | `27` | Consecutive failures allowed. With the other defaults, the earliest failure cutoff is 260 seconds. |
+`postgres`, `langfuse.web`, `langfuse.worker`, and `api` each declare a paired
+`readinessProbe`/`livenessProbe`. Every failure cutoff below is
+`initialDelaySeconds + (failureThreshold - 1) * periodSeconds`, and on every one
+of these containers the liveness cutoff must strictly exceed the readiness
+cutoff -- otherwise a container still legitimately booting (WAL recovery,
+Prisma/ClickHouse boot migrations, API warm-up) gets killed and restarted back
+into the same boot path instead of being given time to finish it.
+`ci/probe-window-assertions.sh` enforces this ordering render-wide.
+
+| Value | Default | Meaning |
+| --- | --- | --- |
+| `postgres.readinessProbe.initialDelaySeconds` | `5` | Delay before the first probe. |
+| `postgres.readinessProbe.periodSeconds` | `5` | Probe interval. |
+| `postgres.readinessProbe.timeoutSeconds` | `5` | Per-probe timeout (explicit, never the kubelet 1-second default). |
+| `postgres.readinessProbe.failureThreshold` | `12` | Failures before the container is marked unready; earliest cutoff 60 seconds. |
+| `postgres.livenessProbe.initialDelaySeconds` | `20` | Delay before the first probe. |
+| `postgres.livenessProbe.periodSeconds` | `10` | Probe interval. |
+| `postgres.livenessProbe.timeoutSeconds` | `5` | Per-probe timeout (explicit, never the kubelet 1-second default). |
+| `postgres.livenessProbe.failureThreshold` | `30` | Failures before the container is restarted; earliest cutoff 310 seconds. |
+| `langfuse.web.readinessProbe.initialDelaySeconds` | `20` | Delay before the first probe. |
+| `langfuse.web.readinessProbe.periodSeconds` | `10` | Probe interval. |
+| `langfuse.web.readinessProbe.timeoutSeconds` | `5` | Per-probe timeout (explicit, never the kubelet 1-second default). |
+| `langfuse.web.readinessProbe.failureThreshold` | `30` | Failures before the container is marked unready; earliest cutoff 310 seconds. |
+| `langfuse.web.livenessProbe.initialDelaySeconds` | `90` | Delay before the first probe. |
+| `langfuse.web.livenessProbe.periodSeconds` | `20` | Probe interval. |
+| `langfuse.web.livenessProbe.timeoutSeconds` | `5` | Per-probe timeout (explicit, never the kubelet 1-second default). |
+| `langfuse.web.livenessProbe.failureThreshold` | `15` | Failures before the container is restarted; earliest cutoff 370 seconds. |
+| `langfuse.worker.readinessProbe.initialDelaySeconds` | `20` | Delay before the first probe. |
+| `langfuse.worker.readinessProbe.periodSeconds` | `10` | Probe interval. |
+| `langfuse.worker.readinessProbe.timeoutSeconds` | `5` | Per-probe timeout (explicit, never the kubelet 1-second default). |
+| `langfuse.worker.readinessProbe.failureThreshold` | `30` | Failures before the container is marked unready; earliest cutoff 310 seconds. |
+| `langfuse.worker.livenessProbe.initialDelaySeconds` | `90` | Delay before the first probe. |
+| `langfuse.worker.livenessProbe.periodSeconds` | `20` | Probe interval. |
+| `langfuse.worker.livenessProbe.timeoutSeconds` | `5` | Per-probe timeout (explicit, never the kubelet 1-second default). |
+| `langfuse.worker.livenessProbe.failureThreshold` | `15` | Failures before the container is restarted; earliest cutoff 370 seconds. Deliberately equal to `langfuse.web`'s: same boot migrations, same single-replica constraint. |
+| `api.readinessProbe.initialDelaySeconds` | `5` | Delay before the first probe. |
+| `api.readinessProbe.periodSeconds` | `5` | Probe interval. |
+| `api.readinessProbe.timeoutSeconds` | `3` | Per-probe timeout (explicit, never the kubelet 1-second default). |
+| `api.readinessProbe.failureThreshold` | `24` | Failures before the container is marked unready; earliest cutoff 120 seconds. |
+| `api.livenessProbe.initialDelaySeconds` | `30` | Delay before the first probe. |
+| `api.livenessProbe.periodSeconds` | `15` | Probe interval. |
+| `api.livenessProbe.timeoutSeconds` | `5` | Per-probe timeout (explicit, never the kubelet 1-second default). |
+| `api.livenessProbe.failureThreshold` | `12` | Failures before the container is restarted; earliest cutoff 195 seconds. |
 
 The dispatcher starts its heartbeat only after every boot preflight succeeds.
 Until then, the startup probe gates readiness and liveness so Kubernetes does
@@ -583,6 +626,17 @@ the operators who customized the gate. Move any `--set`s or overlay files from
 `langfuse.web.postgresReadiness.*` to `langfuse.postgresReadiness.*`; the
 alias is removed in a future minor. `helm install`/`upgrade` prints a NOTES.txt
 reminder whenever the deprecated key is still set.
+
+Both Langfuse Deployments read their probe cadences from values
+(`langfuse.web.readinessProbe`/`.livenessProbe` and
+`langfuse.worker.readinessProbe`/`.livenessProbe`); only the probe handlers stay
+in the template, because the handler is a correctness choice about the image
+rather than a sizing knob. On each container the liveness failure cutoff
+(`initialDelaySeconds + (failureThreshold - 1) * periodSeconds`) outlasts the
+readiness cutoff by design -- 370 seconds against 310 -- so the kubelet cannot
+restart a container that is still inside the boot window readiness was sized to
+tolerate. `charts/curie/ci/probe-window-assertions.sh` pins that ordering for
+every container in the rendered chart.
 
 `langfuse-worker` also carries its own `readinessProbe` (`httpGet /api/ready`)
 and `livenessProbe` (`tcpSocket` on the same port 3030) once the container is

--- a/charts/curie/ci/langfuse-worker-probe-assertions.sh
+++ b/charts/curie/ci/langfuse-worker-probe-assertions.sh
@@ -32,8 +32,8 @@
 #     couples the worker's LIFE to Postgres and Valkey. The worker is
 #     `replicas: 1` with `strategy: Recreate` and runs Prisma/ClickHouse boot
 #     migrations at container start, and init containers do NOT re-run on a
-#     liveness restart. So a store blip of roughly two minutes
-#     (`failureThreshold: 6` x `periodSeconds: 20`) would kill the only replica
+#     liveness restart. So a store blip of roughly five minutes
+#     (`failureThreshold: 15` x `periodSeconds: 20`) would kill the only replica
 #     and restart it straight into boot migrations against a sick Postgres --
 #     reproducing the exact Prisma `P1001` / `BackOff` class this ticket exists
 #     to stop, with the readiness gate powerless to help. Chart precedent is
@@ -49,9 +49,15 @@
 #   is liveness's only job here, deliberately.
 #
 # `timeoutSeconds` is asserted BY NAME on both probes: the kubelet default is
-# 1s, and `langfuse-web`'s block (the obvious thing to copy) omits the key. A
-# 1s timeout against an endpoint that runs a Prisma query plus a Redis ping is
-# a restart loop waiting to happen.
+# 1s, and a 1s timeout against an endpoint that runs a Prisma query plus a Redis
+# ping is a restart loop waiting to happen.
+#
+# The cadence numbers below are the chart DEFAULTS, which now come from
+# `langfuse.worker.readinessProbe.*` / `.livenessProbe.*` in values.yaml rather
+# than from literals in the template. This script pins those defaults by value.
+# The invariant that survives an operator OVERRIDE -- every container's liveness
+# failure cutoff strictly outlasting its readiness cutoff -- is pinned separately
+# by ci/probe-window-assertions.sh.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -137,7 +143,7 @@ if "httpGet" in liveness:
         f"/api/ready run a Prisma SELECT 1 and a Redis ping, so an HTTP liveness probe couples the "
         f"worker's LIFE to Postgres and Valkey. The worker is replicas:1 + Recreate and runs boot "
         f"migrations at container start, and init containers do NOT re-run on a liveness restart -- "
-        f"so a ~2 minute store blip would restart the single replica straight into boot migrations "
+        f"so a ~5 minute store blip would restart the single replica straight into boot migrations "
         f"against a sick Postgres, which is the exact P1001/BackOff class #2330 exists to stop. Use "
         f"tcpSocket:3030"
     )
@@ -165,7 +171,7 @@ EXPECTED = {
         "initialDelaySeconds": 90,
         "periodSeconds": 20,
         "timeoutSeconds": 5,
-        "failureThreshold": 6,
+        "failureThreshold": 15,
     }),
 }
 for probe_name, (probe, expected) in EXPECTED.items():
@@ -174,9 +180,8 @@ for probe_name, (probe, expected) in EXPECTED.items():
             reason = ""
             if field == "timeoutSeconds":
                 reason = (
-                    " -- the kubelet default is 1s, and langfuse-web's block (the obvious thing to "
-                    "copy) omits the key; 1s against an endpoint running a Prisma query plus a Redis "
-                    "ping is a restart loop"
+                    " -- the kubelet default is 1s, an omitted key is invisible in the manifest, and "
+                    "1s against an endpoint running a Prisma query plus a Redis ping is a restart loop"
                 )
             raise SystemExit(
                 f"{probe_name} does not declare {field} explicitly{reason}"
@@ -185,7 +190,7 @@ for probe_name, (probe, expected) in EXPECTED.items():
             raise SystemExit(
                 f"{probe_name}.{field} is {probe[field]!r}, expected {value!r}"
             )
-print("  ok: readiness cadence 20/10/5/30 and liveness cadence 90/20/5/6, both with an explicit timeoutSeconds")
+print("  ok: readiness cadence 20/10/5/30 and liveness cadence 90/20/5/15, both with an explicit timeoutSeconds")
 PY
 
 python3 "$TMP/assert.py" "$TMP/default.yaml"
@@ -219,7 +224,7 @@ elif mutation == "liveness-http-health":
         "initialDelaySeconds": 90,
         "periodSeconds": 20,
         "timeoutSeconds": 5,
-        "failureThreshold": 6,
+        "failureThreshold": 15,
     }
 elif mutation == "readiness-health":
     worker.setdefault("readinessProbe", {}).setdefault("httpGet", {})["path"] = "/api/health"

--- a/charts/curie/ci/probe-window-assertions.sh
+++ b/charts/curie/ci/probe-window-assertions.sh
@@ -1,0 +1,401 @@
+#!/usr/bin/env bash
+#
+# Render contract: on every rendered container that carries BOTH probes, the
+# livenessProbe's earliest failure cutoff must be strictly LATER than the
+# readinessProbe's.
+#
+# WHY. The two probes have different jobs. Readiness says "this container may
+# legitimately take this long to become useful -- keep it out of the Service
+# until then." Liveness says "past this point the process is wedged -- kill it."
+# When the liveness cutoff lands INSIDE the window readiness was configured to
+# tolerate, the kubelet restarts a container that is still doing exactly what
+# readiness was sized to wait for, and the restart re-enters the same slow boot:
+#
+#   * postgres replaying WAL after an unclean shutdown (`pg_isready` returns
+#     non-zero for the whole of recovery),
+#   * langfuse-web / langfuse-worker running Prisma and ClickHouse boot
+#     migrations at container start (init containers do NOT re-run on a liveness
+#     restart, so the restart lands straight back in the migration),
+#   * api warming up before `/health` answers.
+#
+# The failure is invisible in review and invisible at install time: the manifest
+# is valid, `helm install` is green, and the damage shows up minutes later as a
+# `Killing` event and a BackOff loop under load. So the proof surface is the
+# RENDER, and this script is it.
+#
+# The four containers that were broken on origin/main when this assertion was
+# written, readiness cutoff vs liveness cutoff:
+#
+#   postgres         60 s vs  40 s   (and no explicit liveness timeoutSeconds,
+#                                     so the kubelet's 1 s default applies to a
+#                                     `pg_isready` exec that can exceed 1 s on a
+#                                     contended node during WAL replay -- every
+#                                     such timeout counts as a probe failure, so
+#                                     the effective cutoff is even shorter)
+#   langfuse-web    310 s vs 190 s
+#   langfuse-worker 310 s vs 190 s
+#   api             120 s vs 105 s
+#
+# WHAT THIS PINS. Deliberately the CLASS, not those four names. This script
+# walks every object carrying a pod spec in both renders -- Deployment,
+# StatefulSet, DaemonSet, Job, and CronJob's spec.template.spec; a bare Pod's
+# own spec (templates/security-probe.yaml); SandboxTemplate's
+# spec.podTemplate.spec (templates/agent-sandbox.yaml); and, generically, any
+# other kind exposing the conventional spec.template.spec shape -- and checks
+# every container that has both probes, so a fifth violating container added
+# later fails CI with no list here to update -- the lesson
+# `charts/curie/CLAUDE.md` already records for the `curie.env.otel` membership
+# boundary (#2331). There is no allowlist and no named-container table below
+# on purpose.
+#
+# THE FORMULA, matching the chart's own precedent at `templates/dispatcher.yaml`
+# lines 3-9:
+#
+#     earliest_failure_cutoff = initialDelaySeconds + (failureThreshold - 1) * periodSeconds
+#
+# Omitted keys take the kubelet's defaults -- `initialDelaySeconds: 0`,
+# `periodSeconds: 10`, `failureThreshold: 3`, `timeoutSeconds: 1` -- rather than
+# raising a KeyError. Three of the four broken blocks above omit at least one of
+# these keys, and a crash on a missing key reads as a script bug and gets the
+# assertion weakened instead of the chart fixed.
+#
+# TWO SUPPORTING RULES.
+#
+#   1. Every livenessProbe must declare `timeoutSeconds` explicitly. The
+#      kubelet's 1 s default is invisible in the manifest and is the silent half
+#      of the postgres case above.
+#   2. `postgres` liveness `timeoutSeconds` must be at least 5. `pg_isready`
+#      under WAL replay on a contended node is not a 1 s operation.
+#
+# NOT CHECKED, deliberately: containers carrying only one probe (the invariant
+# is a relation BETWEEN two probes -- `agentSandbox.runner` has readiness and no
+# liveness by design), and `startupProbe`, which defers readiness and liveness
+# equally and so leaves the comparison unchanged. Containers behind a
+# `deploy: false` toggle (`dispatcher`, `mail-adapter`, `inference`) render in
+# neither of the two renders below and are therefore outside this script's
+# reach; widening to profiled renders is a follow-up.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART="$(cd "$SCRIPT_DIR/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+if ! helm template curie "$CHART" >"$TMP/default.yaml"; then
+  fail "default render failed"
+fi
+if ! helm template curie "$CHART" -f "$CHART/values-dev.yaml" >"$TMP/dev.yaml"; then
+  fail "values-dev.yaml render failed"
+fi
+
+# ------------------------------------------------------------------ the checker
+# ONE program, reused by every positive and negative run below: it takes a
+# rendered manifest path plus a label, and it collects ALL problems across the
+# whole render before raising, so a run reports every violating container at
+# once instead of hiding the second one behind the first.
+cat >"$TMP/check.py" <<'PY'
+import sys
+import yaml
+
+# Kubelet defaults for omitted probe keys (k8s core/v1 Probe).
+KUBELET_DEFAULTS = {
+    "initialDelaySeconds": 0,
+    "periodSeconds": 10,
+    "failureThreshold": 3,
+    "timeoutSeconds": 1,
+}
+FORMULA = (
+    "formula: earliest_failure_cutoff = initialDelaySeconds + "
+    "(failureThreshold - 1) * periodSeconds, with kubelet defaults "
+    "initialDelaySeconds=0 periodSeconds=10 failureThreshold=3 timeoutSeconds=1 "
+    "applied to omitted keys"
+)
+POD_TEMPLATE_KINDS = ("Deployment", "StatefulSet", "DaemonSet", "Job")
+
+problems = []
+
+
+def cadence(probe, where):
+    """Probe cadence with kubelet defaults filled in for omitted keys."""
+    resolved = {}
+    for key, default in KUBELET_DEFAULTS.items():
+        value = probe.get(key, default)
+        try:
+            resolved[key] = int(value)
+        except (TypeError, ValueError):
+            problems.append(
+                f"[{label}] {where}: {key} is {value!r}, which is not an integer; "
+                f"cannot compute a cutoff from it"
+            )
+            resolved[key] = default
+    return resolved
+
+
+def cutoff(c):
+    return c["initialDelaySeconds"] + (c["failureThreshold"] - 1) * c["periodSeconds"]
+
+
+def cadence_str(c):
+    return (
+        f"{c['initialDelaySeconds']}/{c['periodSeconds']}/"
+        f"{c['timeoutSeconds']}/{c['failureThreshold']}"
+    )
+
+
+def pod_templates(doc):
+    kind = doc.get("kind")
+    name = doc.get("metadata", {}).get("name", "<unnamed>")
+    if kind in POD_TEMPLATE_KINDS:
+        template = doc.get("spec", {}).get("template")
+    elif kind == "CronJob":
+        template = (
+            doc.get("spec", {}).get("jobTemplate", {}).get("spec", {}).get("template")
+        )
+    elif kind == "Pod":
+        # A bare Pod (templates/security-probe.yaml) has no wrapping
+        # template -- the document's own `spec` IS the pod spec, so hand the
+        # whole document through: callers read `template["spec"]`, which is
+        # exactly this Pod's spec.
+        template = doc
+    elif kind == "SandboxTemplate":
+        # extensions.agents.x-k8s.io SandboxTemplate (templates/agent-sandbox.yaml)
+        # carries its pod spec at spec.podTemplate.spec, not spec.template.spec,
+        # so `podTemplate` itself is the "template" callers expect.
+        template = doc.get("spec", {}).get("podTemplate")
+    else:
+        # Generic fallback: any other object carrying a conventional pod
+        # template at spec.template.spec (the same shape Deployment /
+        # StatefulSet / DaemonSet / Job use) is walked too, so a future
+        # workload kind is covered with no name added here.
+        template = doc.get("spec", {}).get("template")
+    if not isinstance(template, dict):
+        return []
+    return [(kind, name, template)]
+
+
+if __name__ == "__main__":
+    render, label = sys.argv[1], sys.argv[2]
+
+    docs = [doc for doc in yaml.safe_load_all(open(render)) if isinstance(doc, dict)]
+    if not docs:
+        raise SystemExit(f"[{label}] {render} rendered no documents at all")
+
+    checked = 0
+    liveness_seen = 0
+    for doc in docs:
+        for kind, name, template in pod_templates(doc):
+            spec = template.get("spec") or {}
+            containers = list(spec.get("containers") or []) + list(
+                spec.get("initContainers") or []
+            )
+            for container in containers:
+                if not isinstance(container, dict):
+                    continue
+                cname = container.get("name", "<unnamed>")
+                where = f"{kind}/{name} container={cname}"
+                readiness = container.get("readinessProbe")
+                liveness = container.get("livenessProbe")
+
+                if isinstance(liveness, dict):
+                    liveness_seen += 1
+                    # Rule 1: the kubelet's 1s timeoutSeconds default is invisible in
+                    # the manifest, and each timed-out probe counts as a failure.
+                    if "timeoutSeconds" not in liveness:
+                        problems.append(
+                            f"[{label}] {where}: livenessProbe does not declare "
+                            f"timeoutSeconds explicitly -- the kubelet then applies its 1s "
+                            f"default, which is invisible in the manifest, and every timed-out "
+                            f"probe counts as a failure, so the container's real failure "
+                            f"cutoff is shorter than the numbers on the page suggest"
+                        )
+                    # Rule 2: pg_isready during WAL replay on a contended node is not
+                    # a 1s operation.
+                    elif cname == "postgres":
+                        timeout = liveness.get("timeoutSeconds")
+                        if not isinstance(timeout, int) or timeout < 5:
+                            problems.append(
+                                f"[{label}] {where}: postgres liveness timeoutSeconds must be "
+                                f"at least 5, got {timeout!r} -- the liveness handler is an "
+                                f"exec of pg_isready, which under WAL replay on a contended "
+                                f"node routinely exceeds a short timeout, and every timeout "
+                                f"counts as a probe failure"
+                            )
+
+                # The ordering invariant is a relation BETWEEN two probes: a
+                # container with only one, or neither, is skipped silently.
+                if not isinstance(readiness, dict) or not isinstance(liveness, dict):
+                    continue
+
+                rcad = cadence(readiness, f"{where} readinessProbe")
+                lcad = cadence(liveness, f"{where} livenessProbe")
+                rcut = cutoff(rcad)
+                lcut = cutoff(lcad)
+                checked += 1
+
+                if lcut > rcut:
+                    print(f"  ok: {kind}/{name}/{cname} ready={rcut}s live={lcut}s")
+                    continue
+
+                problems.append(
+                    f"[{label}] {where}: liveness cutoff must exceed readiness cutoff, "
+                    f"got liveness {lcut}s vs readiness {rcut}s. "
+                    f"readiness i/p/t/f={cadence_str(rcad)}, "
+                    f"liveness i/p/t/f={cadence_str(lcad)}. {FORMULA}. "
+                    f"A liveness probe that gives up before readiness has stopped "
+                    f"tolerating a slow boot restarts a container that is still "
+                    f"legitimately booting, and the restart re-enters the same boot path"
+                )
+
+    print(
+        f"  {label}: {checked} container(s) carry both probes and were checked for "
+        f"ordering; {liveness_seen} livenessProbe(s) checked for an explicit timeoutSeconds"
+    )
+
+    if problems:
+        raise SystemExit(
+            f"{len(problems)} probe-window problem(s) in the {label} render:\n  - "
+            + "\n  - ".join(problems)
+        )
+PY
+
+python3 "$TMP/check.py" "$TMP/default.yaml" "default"
+python3 "$TMP/check.py" "$TMP/dev.yaml" "values-dev"
+
+# --------------------------------------------------------------- red controls
+# Each control mutates a REAL default render and proves the checker rejects it
+# for the INTENDED reason (needle-matched), not an incidental KeyError. Every
+# mutation asserts its target container was actually found, so a container
+# rename cannot quietly turn a control into a no-op.
+cat >"$TMP/mutate.py" <<'PY'
+import os
+import sys
+import yaml
+
+sys.path.insert(0, os.path.dirname(__file__))
+from check import pod_templates
+
+source, target, mutation = sys.argv[1:]
+docs = [doc for doc in yaml.safe_load_all(open(source)) if isinstance(doc, dict)]
+
+
+def containers():
+    for doc in docs:
+        for _kind, _name, template in pod_templates(doc):
+            spec = template.get("spec") or {}
+            for container in list(spec.get("containers") or []) + list(
+                spec.get("initContainers") or []
+            ):
+                if isinstance(container, dict):
+                    yield container
+
+
+def find(name, probe):
+    hits = [c for c in containers() if c.get("name") == name and probe in c]
+    if not hits:
+        raise SystemExit(
+            f"mutation {mutation!r} found no container named {name!r} carrying a {probe} "
+            f"in the render -- the red control would silently prove nothing, so this is "
+            f"a hard failure, not a skip"
+        )
+    return hits
+
+
+if mutation == "web-liveness-kubelet-defaults":
+    # Cutoff collapses to the kubelet default 0 + (3-1)*10 = 20s, far inside
+    # langfuse-web's readiness tolerance.
+    for c in find("langfuse-web", "livenessProbe"):
+        for key in ("initialDelaySeconds", "periodSeconds", "failureThreshold"):
+            c["livenessProbe"].pop(key, None)
+elif mutation == "api-drop-liveness-timeout":
+    for c in find("api", "livenessProbe"):
+        c["livenessProbe"].pop("timeoutSeconds", None)
+elif mutation == "ui-readiness-threshold":
+    for c in find("ui", "readinessProbe"):
+        c["readinessProbe"]["failureThreshold"] = 1000
+elif mutation == "postgres-liveness-timeout-1":
+    for c in find("postgres", "livenessProbe"):
+        c["livenessProbe"]["timeoutSeconds"] = 1
+else:
+    raise SystemExit(f"unknown mutation {mutation!r}")
+
+with open(target, "w") as output:
+    yaml.safe_dump_all(docs, output)
+PY
+
+# assert_rejected <render> <label> <description> <needle>...
+# Fails loudly if the checker PASSES, and fails loudly if it goes red without
+# every needle -- a non-zero exit on its own proves nothing here, because on an
+# unfixed chart every render is red for several reasons at once.
+assert_rejected() {
+  local render="$1" label="$2" description="$3"
+  shift 3
+  local output rc needle
+  set +e
+  output="$(python3 "$TMP/check.py" "$render" "$label" 2>&1)"
+  rc=$?
+  set -e
+  [[ "$rc" -ne 0 ]] || fail "negative control passed: $description"
+  for needle in "$@"; do
+    [[ "$output" == *"$needle"* ]] \
+      || fail "$description was rejected without the expected reason ($needle): $output"
+  done
+  echo "  ok: $description is rejected"
+}
+
+assert_mutation_rejected() {
+  local mutation="$1" description="$2"
+  shift 2
+  python3 "$TMP/mutate.py" "$TMP/default.yaml" "$TMP/$mutation.yaml" "$mutation"
+  assert_rejected "$TMP/$mutation.yaml" "red:$mutation" "$description" "$@"
+}
+
+assert_mutation_rejected web-liveness-kubelet-defaults \
+  "letting langfuse-web's liveness cadence fall back to the kubelet defaults (cutoff 20s, far inside its readiness tolerance)" \
+  "container=langfuse-web" "liveness cutoff must exceed readiness cutoff"
+
+assert_mutation_rejected api-drop-liveness-timeout \
+  "dropping the api livenessProbe timeoutSeconds (the kubelet would silently apply 1s)" \
+  "container=api" "does not declare timeoutSeconds explicitly"
+
+assert_mutation_rejected ui-readiness-threshold \
+  "widening the ui readiness failureThreshold to 1000 so its readiness tolerance outruns liveness" \
+  "container=ui" "liveness cutoff must exceed readiness cutoff"
+
+assert_mutation_rejected postgres-liveness-timeout-1 \
+  "setting the postgres liveness timeoutSeconds to 1 (pg_isready under WAL replay is not a 1s operation)" \
+  "container=postgres" "postgres liveness timeoutSeconds must be at least 5"
+
+# ------------------------------------------------- values-override red control
+# This one does NOT mutate a render -- it renders with overrides and asserts
+# the OVERRIDES reach the manifest. It is what proves EACH of the four
+# values-driven liveness blocks actually READS its own values key, rather than
+# carrying a hardcoded, ordered set of numbers that happens to satisfy the
+# invariant on its own: a single postgres-only override cannot tell "reads
+# values" apart from "coincidentally ordered hardcoded numbers" on
+# langfuse-web, langfuse-worker, or api, so this renders ONE chart with all
+# four overrides at once and requires the checker to go red naming every one
+# of the four containers by name.
+#
+# NOTE: on the pre-fix templates these values keys do not exist yet, so the
+# overrides are inert and the render is red anyway from the shipped cadence.
+# This control therefore cannot distinguish anything until the template edits
+# land -- which is intended. The whole script is the failing-test contract: it
+# is expected RED against the unmodified chart and green only once the
+# cadences are values-driven and correctly ordered.
+if ! helm template curie "$CHART" \
+  --set postgres.livenessProbe.failureThreshold=3 \
+  --set postgres.livenessProbe.timeoutSeconds=5 \
+  --set langfuse.web.livenessProbe.failureThreshold=1 \
+  --set langfuse.worker.livenessProbe.failureThreshold=1 \
+  --set api.livenessProbe.failureThreshold=1 \
+  >"$TMP/values-override.yaml"; then
+  fail "values-override render failed"
+fi
+assert_rejected "$TMP/values-override.yaml" "red:values-override" \
+  "overriding postgres, langfuse-web, langfuse-worker and api's livenessProbe values keys at once (proves each template reads its own values key)" \
+  "container=postgres" "container=langfuse-web" "container=langfuse-worker" "container=api" \
+  "liveness cutoff must exceed readiness cutoff"
+
+echo "PASS: in both the default and values-dev renders, every object carrying a pod spec (Deployment/StatefulSet/DaemonSet/Job/CronJob, a bare Pod, SandboxTemplate, or any kind exposing spec.template.spec) has every container carrying BOTH probes checked, and each such container has a liveness failure cutoff strictly later than its readiness cutoff, every livenessProbe declares timeoutSeconds explicitly, and postgres liveness allows pg_isready at least 5s -- so the kubelet cannot restart a container that is still inside the boot window readiness was sized to tolerate"

--- a/charts/curie/templates/api.yaml
+++ b/charts/curie/templates/api.yaml
@@ -262,17 +262,12 @@ spec:
             httpGet:
               path: /health
               port: 8000
-            initialDelaySeconds: 5
-            periodSeconds: 5
-            timeoutSeconds: 3
-            failureThreshold: 24
+            {{- toYaml .Values.api.readinessProbe | nindent 12 }}
           livenessProbe:
             httpGet:
               path: /health
               port: 8000
-            initialDelaySeconds: 30
-            periodSeconds: 15
-            failureThreshold: 6
+            {{- toYaml .Values.api.livenessProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.api.resources | nindent 12 }}
 {{- end }}

--- a/charts/curie/templates/langfuse.yaml
+++ b/charts/curie/templates/langfuse.yaml
@@ -143,17 +143,12 @@ spec:
             httpGet:
               path: /api/public/health
               port: 3000
-            initialDelaySeconds: 20
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 30
+            {{- toYaml .Values.langfuse.web.readinessProbe | nindent 12 }}
           livenessProbe:
             httpGet:
               path: /api/public/health
               port: 3000
-            initialDelaySeconds: 90
-            periodSeconds: 20
-            failureThreshold: 6
+            {{- toYaml .Values.langfuse.web.livenessProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.langfuse.web.resources | nindent 12 }}
 ---
@@ -230,23 +225,22 @@ spec:
           # liveness restart, so a store blip would restart the only replica
           # straight into those boot migrations against a sick Postgres -- the
           # exact P1001/BackOff class the wait-for-postgres gate exists to stop
-          # (#71, #2330). timeoutSeconds is explicit on both: the kubelet
-          # default is 1s, which langfuse-web's block above silently takes.
+          # (#71, #2330). Cadences for both probes come from
+          # `langfuse.worker.readinessProbe` / `.livenessProbe` in values, as
+          # langfuse-web's block above now does from `langfuse.web.*`: both
+          # Deployments declare `timeoutSeconds` explicitly rather than taking
+          # the kubelet's invisible 1s default, and on each container the
+          # liveness failure cutoff must outlive the readiness one, pinned by
+          # ci/probe-window-assertions.sh.
           readinessProbe:
             httpGet:
               path: /api/ready
               port: 3030
-            initialDelaySeconds: 20
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 30
+            {{- toYaml .Values.langfuse.worker.readinessProbe | nindent 12 }}
           livenessProbe:
             tcpSocket:
               port: 3030
-            initialDelaySeconds: 90
-            periodSeconds: 20
-            timeoutSeconds: 5
-            failureThreshold: 6
+            {{- toYaml .Values.langfuse.worker.livenessProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.langfuse.worker.resources | nindent 12 }}
 {{- end }}

--- a/charts/curie/templates/postgres.yaml
+++ b/charts/curie/templates/postgres.yaml
@@ -78,15 +78,16 @@ spec:
           readinessProbe:
             exec:
               command: ["sh", "-c", "pg_isready -U {{ .Values.postgres.auth.username }}"]
-            initialDelaySeconds: 5
-            periodSeconds: 5
-            timeoutSeconds: 5
-            failureThreshold: 12
+            {{- toYaml .Values.postgres.readinessProbe | nindent 12 }}
+          # `pg_isready` returns non-zero for the WHOLE of WAL recovery after an
+          # unclean stop, so the liveness cutoff must outlive the readiness one
+          # -- otherwise the kubelet restarts a Postgres that is still replaying
+          # and the restart re-enters the same recovery. Cadence from values;
+          # ordering pinned by ci/probe-window-assertions.sh.
           livenessProbe:
             exec:
               command: ["sh", "-c", "pg_isready -U {{ .Values.postgres.auth.username }}"]
-            initialDelaySeconds: 20
-            periodSeconds: 10
+            {{- toYaml .Values.postgres.livenessProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.postgres.resources | nindent 12 }}
           volumeMounts:

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -260,6 +260,20 @@ langfuse:
     # cap (~512Mi) OOM-crashes under a tight container limit; raise it in step
     # with the memory limit. Empty = leave the image default.
     nodeOptions: "--max-old-space-size=1024"
+    # Probe cadences. Liveness must outlast readiness: this replicas:1 +
+    # Recreate Deployment runs Prisma/ClickHouse boot migrations at container
+    # start, and init containers do NOT re-run on a liveness restart. Cutoffs:
+    # readiness 310s, liveness 370s. Formula/rationale: ci/probe-window-assertions.sh header.
+    readinessProbe:
+      initialDelaySeconds: 20
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 30
+    livenessProbe:
+      initialDelaySeconds: 90
+      periodSeconds: 20
+      timeoutSeconds: 5
+      failureThreshold: 15
     # DEPRECATED: langfuse.web.postgresReadiness moved to langfuse.postgresReadiness
     # (#2330), which gates BOTH Langfuse Deployments. Values supplied at the old
     # path are still honoured and are applied to BOTH; the chart no longer sets
@@ -291,6 +305,20 @@ langfuse:
         type: RuntimeDefault
   worker:
     nodeOptions: "--max-old-space-size=640"
+    # Probe cadences, deliberately equal to langfuse.web's above: same boot
+    # migrations, same replicas:1 + Recreate constraint, cadence kept equal to
+    # web's. Cutoffs: readiness 310s, liveness 370s. Formula/rationale:
+    # ci/probe-window-assertions.sh header.
+    readinessProbe:
+      initialDelaySeconds: 20
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 30
+    livenessProbe:
+      initialDelaySeconds: 90
+      periodSeconds: 20
+      timeoutSeconds: 5
+      failureThreshold: 15
     resources:
       requests: { cpu: 150m, memory: 384Mi }
       limits: { cpu: "1", memory: 1Gi }
@@ -336,6 +364,20 @@ postgres:
   # this Alpine image (#2319). Parameterized for BYO images with a different gid.
   podSecurityContext:
     fsGroup: 70
+  # Probe cadences. Liveness MUST outlast readiness here because `pg_isready`
+  # returns non-zero for the whole of WAL recovery after an unclean stop, and a
+  # restart re-enters the same recovery. Cutoffs: readiness 60s, liveness 310s.
+  # Formula/rationale: ci/probe-window-assertions.sh header.
+  readinessProbe:
+    initialDelaySeconds: 5
+    periodSeconds: 5
+    timeoutSeconds: 5
+    failureThreshold: 12
+  livenessProbe:
+    initialDelaySeconds: 20
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 30
   persistence:
     enabled: true
     size: 2Gi
@@ -991,6 +1033,20 @@ api:
   # approval evidence. A sealed install generates and persists this value
   # independently; values-dev.yaml keeps the published deterministic default.
   approvalChatAttesterSecret: curie-dev-approval-chat-attester
+  # Probe cadences. Liveness must outlast readiness so a cold API still warming
+  # up before /health answers is kept out of the Service rather than restarted
+  # back into the same warm-up. Cutoffs: readiness 120s, liveness 195s.
+  # Formula/rationale: ci/probe-window-assertions.sh header.
+  readinessProbe:
+    initialDelaySeconds: 5
+    periodSeconds: 5
+    timeoutSeconds: 3
+    failureThreshold: 24
+  livenessProbe:
+    initialDelaySeconds: 30
+    periodSeconds: 15
+    timeoutSeconds: 5
+    failureThreshold: 12
   # Human-readable org/workspace name the UI reads from the open /config endpoint.
   # Override to white-label the app for a deployment.
   orgName: Curie


### PR DESCRIPTION
Four rendered containers had a liveness probe whose earliest failure cutoff came before their own readiness tolerance, so the kubelet could restart a container that was still inside the boot window readiness was sized for (postgres WAL replay, the Langfuse Prisma/ClickHouse boot migrations on a replicas-1 Recreate Deployment, api warm-up). This moves those probe cadences into values.yaml per the chart rule, raises the liveness defaults so the ordering holds, and adds a render assertion so the class cannot recur.

Cutoff formula (matches `templates/dispatcher.yaml`): `initialDelaySeconds + (failureThreshold - 1) * periodSeconds`, kubelet defaults applied to omitted keys.

| container | readiness cutoff | liveness before | liveness after | liveness timeout before -> after |
| --- | --- | --- | --- | --- |
| postgres | 60 s | 40 s | 310 s | 1 s (kubelet default) -> 5 s |
| langfuse-web | 310 s | 190 s | 370 s | 1 s (kubelet default) -> 5 s |
| langfuse-worker | 310 s | 190 s | 370 s | 5 s -> 5 s |
| api | 120 s | 105 s | 195 s | 1 s (kubelet default) -> 5 s |

Readiness cadences, probe handlers, endpoints, ports, replica counts and strategies are byte-identical to before. A render diff against origin/main (default and values-dev) shows only the probe cadence lines and two comments changing. langfuse-worker is included beyond the three containers the review named because `charts/curie/CLAUDE.md` required web and worker to be lifted onto values together, never piecemeal, and the worker's own liveness (190 s) was also below its readiness (310 s).

New values keys: `postgres.readinessProbe`, `postgres.livenessProbe`, `langfuse.web.readinessProbe`, `langfuse.web.livenessProbe`, `langfuse.worker.readinessProbe`, `langfuse.worker.livenessProbe`, `api.readinessProbe`, `api.livenessProbe` (each `initialDelaySeconds` / `periodSeconds` / `timeoutSeconds` / `failureThreshold`). `values.schema.json` is untouched.

New gate: `charts/curie/ci/probe-window-assertions.sh`, wired into `helm-ci.yaml`. It renders the chart with default and values-dev values, walks every object carrying a pod spec (containers and initContainers), and fails when any container's liveness cutoff is not strictly greater than its readiness cutoff, when a livenessProbe omits `timeoutSeconds`, or when postgres liveness `timeoutSeconds` is below 5. Five red controls mutate a real render and needle-match the rejection; one override control sets all four `livenessProbe` values keys at once and requires each container to go red by name, proving every template reads its key. On the unmodified templates it reports seven problems on exactly these four containers; on this branch it passes.

Decisions taken as the conservative default: raised `failureThreshold` with an explicit `timeoutSeconds` rather than a startupProbe (one probe shape, matches every other container in the chart); the assertion covers the default and values-dev renders only, so `dispatcher`, `mail-adapter` and `inference` (deploy off in both) are outside its reach although correctly ordered today; the remaining correctly ordered hardcoded probe blocks (ui, clickhouse, valkey, rustfs, otel-collector, mail-adapter, inference, `curie.heartbeatProbes`) are left for a follow-up. Consolidation review noted two deeper changes deliberately left for a follow-up: a shared `_helpers.tpl` cadence helper that also `fail()`s at render time when liveness does not exceed readiness (the way `dispatcher.yaml` guards its startupProbe), which would extend the guard to operator overrides, and a shared pod-spec walker between this script and `render-assertions.sh`, whose kind lists have already drifted. Advisory reviewer notes not acted on here: a `livenessProbe: null` or single-key partial override in an overlay can re-invert a container at render time (the assertion catches it in CI, the templates do not `fail()`), and the assertion skips containers carrying only one probe, so the both-probes rule from #71 stays pinned only for langfuse-worker.

## Cluster proof (k8scratch, disposable namespaces, torn down)

Baseline = the origin/main chart, after = this branch, both installed with `values-dev.yaml` + `values-e2e-nogvisor.yaml`, sandbox/worker/dispatcher/ui/otel off, `--no-hooks`. Same script for both.

```
helm install <rel> charts/curie -n <ns> --create-namespace -f charts/curie/values-dev.yaml -f charts/curie/values-e2e-nogvisor.yaml \
  --set worker.deploy=false --set dispatcher.deploy=false --set ui.deploy=false --set otelCollector.deploy=false \
  --set priorityClasses.platform.create=false --set priorityClasses.sandbox.create=false --no-hooks --wait
kubectl -n <ns> exec <rel>-postgres-0 -- pgbench -i -q -s 30 -U postgres postgres
kubectl -n <ns> exec <rel>-postgres-0 -- pgbench -c 8 -j 2 -T 90 -U postgres postgres &   # write load
sleep 60; kubectl -n <ns> exec <rel>-postgres-0 -- kill -QUIT 1                            # immediate shutdown, no checkpoint
sleep 40; kubectl -n <ns> delete pod <rel>-postgres-0 --force --grace-period=0              # second variant, mid-write
helm upgrade <rel> charts/curie -n <ns> --reuse-values --set langfuse.web.nodeOptions=... --no-hooks --wait   # cold Recreate
kubectl -n <ns> get pod <pod> -o jsonpath='{.status.containerStatuses[0].restartCount}'
kubectl -n <ns> get events --field-selector reason=Killing
```

Postgres, SIGQUIT mid-write (WAL replay on restart, "database system was not properly shut down; automatic recovery in progress"):

| | redo elapsed | Ready after | restartCount | liveness kills |
| --- | --- | --- | --- | --- |
| baseline | 7.49 s | 13 s | 1 | 0 |
| after | 6.53 s | 14 s | 1 | 0 |

Postgres, `delete pod --force --grace-period=0` mid-write: new pod Ready in 8 s (baseline) and 9 s (after), restartCount 0, no liveness kill either way. On this node recovery is far shorter than the old 40 s cutoff, so the baseline could not be made to crash-loop on recovery alone; the 1 s exec timeout did fire on the baseline under a 50m CPU cap (`Liveness probe failed: command timed out: "sh -c pg_isready -U postgres" timed out after 1s`), and did not on the branch (timeout 5 s).

langfuse-web cold `helm upgrade` (Recreate, boot migrations), node-default CPU: Ready in 59 s both before and after, restartCount 0, zero `Killing ... failed liveness probe` events for langfuse-web in either namespace.

langfuse-web cold boot with CPU request=limit=50m (`--set langfuse.web.resources.limits.cpu=50m --set langfuse.web.resources.requests.cpu=50m`), the case the old cutoff actually reaches:

| | outcome |
| --- | --- |
| baseline (liveness 90/20/1/6) | `Killing x3: Container langfuse-web failed liveness probe, will be restarted`; restartCount 3 at 636 s; never Ready in 772 s |
| after (liveness 90/20/5/15) | 6 slow liveness probes absorbed, Ready at 304 s, restartCount 0, no Killing |

Static checks on this branch: `helm lint charts/curie` and `helm lint charts/curie -f charts/curie/values-dev.yaml` clean; all 48 `charts/curie/ci/*.sh` scripts pass; `charts/curie/ci/probe-window-assertions.sh` red on the origin/main templates (7 problems) and green here.

## Tier classification

| tier | decision | reason |
| --- | --- | --- |
| skill | n/a | no plugin, skill, runner turn loop, ACI or eval surface is touched |
| local | n/a | compose services, dispatcher, worker, API wiring and the CLI are untouched; the change is chart-only |
| local-release | n/a | no binary, image identity, install path, version pin or release compose change |
| cluster | required | chart templates changed; proved above on k8scratch with the origin/main chart as baseline |
| live provider | n/a | no model routing, credential resolution or provider auth surface |
| external integration | n/a | no Slack, webhook, connector or third-party API shape |

## Done-check

- [x] Failing tests committed before implementation: `probe-window-assertions.sh` landed first, red on the templates (7 problems), then the template/values commit turned it green.
- [x] All production edits by delegated native executors (Test Writer, Implementer, two Fixers); the driver ran only validation, git and bookkeeping.
- [x] Broadened return types: N/A, no code returns changed (chart templates, values, bash/python CI script).
- [x] Agent-router Code Reviewer: completed (grok), verdict ACCEPT, five advisory findings; three fixed (four-container override control, walker covers Pod/SandboxTemplate, stale error string), two recorded above as follow-ups.
- [x] Agent-router Scope Reviewer: completed (grok), verdict ACCEPT; every hunk mapped to an AC or a mechanical consequence; the langfuse-worker lift ruled justified by the chart's own documented rule.
- [x] Sibling-path parity: the assertion walks every pod spec in both renders rather than a named list; the three deploy-off workloads are named as the stated gap.
- [x] Guard demonstration: the assertion was executed red on the base templates and its five negative controls plus the override control each rejected a violating render (output in the run transcript).
- [x] Consolidation pass ran (`/simplify`) and applied edits (compacted README rows and values comments, shared pod walker in the assertion); revalidated green with a byte-identical values-dev render, and the agent-router re-review of that diff (codex) returned ACCEPT.
- [x] Security Reviewer: N/A, no security scale-up flagged.
- [x] Observable verification / E2E: cluster tier proved above.
- [x] Train check: shared-line chart fix cut from origin/main, PR against main.
- [x] Discovery-surface proof: cluster; the k8scratch runs above.
- [x] Re-fix mechanism: N/A, no prior fix of this symptom exists.
- [x] Full affected validation: helm lint (both value sets) and all 48 chart CI scripts green.
