### PR TITLE
Back off the sandbox claim poll interval on a cold boot

### DIFF
--- a/apps/worker/src/curie_worker/sandbox/substrate.py
+++ b/apps/worker/src/curie_worker/sandbox/substrate.py
@@ -26,6 +26,7 @@ import logging
 import secrets
 import time
 import uuid
+from collections.abc import Iterator
 from datetime import UTC, datetime, timedelta
 
 from aci_protocol import BootEnv
@@ -92,6 +93,33 @@ logger = logging.getLogger(__name__)
 # sandbox, and the next claim() takes the existing _evict_stale path, which
 # drops the stale route and rebinds. Slow turn, not corruption.
 REAP_GRACE_MARGIN_SECONDS = 30.0
+
+
+def _poll_sleeps(config: SubstrateConfig) -> Iterator[float]:
+    """Yield the successive sleep lengths for ONE substrate wait loop.
+
+    The first ``poll_fast_polls`` sleeps are the configured interval, so the
+    warm-pool fast path polls exactly as often as the old fixed loop did; after
+    that each sleep grows by ``poll_backoff_factor`` up to the cap. The result
+    is that a cold boot costs tens of ``get_claim``/``get_sandbox`` calls rather
+    than hundreds, without making a warm bind any slower to notice.
+
+    Each wait loop takes its own generator, so the serviceFQDN phase restarts at
+    the fast interval: it begins the moment the claim binds, which is exactly
+    when the sandbox address is about to appear, and inheriting the bind phase's
+    backed-off interval would add half a second to every cold claim.
+
+    The generator is deliberately clock-free. Bounding a sleep by the shared
+    deadline is the caller's job, because only the caller knows the deadline.
+    """
+
+    interval = config.poll_interval_seconds
+    cap = max(config.poll_interval_max_seconds, config.poll_interval_seconds)
+    for _ in range(max(0, config.poll_fast_polls)):
+        yield interval
+    while True:
+        interval = min(interval * config.poll_backoff_factor, cap)
+        yield interval
 
 
 def _sandbox_attributes(operation: str, outcome: str) -> dict[str, str]:
@@ -604,6 +632,7 @@ class SandboxSubstrate:
         last_quota_rejection = None
         last_ready_condition: tuple[str | None, str | None] | None = None
         consecutive_quota = 0
+        sleeps = _poll_sleeps(self._config)
         while time.monotonic() < deadline:
             claim = self._k8s.get_claim(claim_name)
             if claim is not None:
@@ -622,7 +651,10 @@ class SandboxSubstrate:
                     last_ready_condition = (claim.ready_reason, claim.ready_message)
                 if claim.ready and claim.sandbox_name:
                     return claim.sandbox_name
-            time.sleep(self._config.poll_interval_seconds)
+            # Clamped to the time left in the shared budget: an unclamped
+            # backed-off sleep would overshoot the deadline by up to the cap and
+            # steal that much from the serviceFQDN phase downstream.
+            time.sleep(max(0.0, min(next(sleeps), deadline - time.monotonic())))
         if last_quota_rejection is not None:
             raise CapacityExhaustedError(last_quota_rejection)
         condition_detail = "no Ready condition was observed"
@@ -635,11 +667,12 @@ class SandboxSubstrate:
         )
 
     def _await_service_fqdn(self, sandbox_name: str, deadline: float) -> SandboxView:
+        sleeps = _poll_sleeps(self._config)
         while time.monotonic() < deadline:
             sandbox = self._k8s.get_sandbox(sandbox_name)
             if sandbox is not None and sandbox.service_fqdn:
                 return sandbox
-            time.sleep(self._config.poll_interval_seconds)
+            time.sleep(max(0.0, min(next(sleeps), deadline - time.monotonic())))
         raise ClaimTimeoutError(
             f"sandbox {sandbox_name} has no serviceFQDN within "
             f"{self._config.claim_timeout_seconds}s (is spec.service true in the template?)"

--- a/apps/worker/src/curie_worker/sandbox/types.py
+++ b/apps/worker/src/curie_worker/sandbox/types.py
@@ -183,7 +183,25 @@ class SubstrateConfig:
     # mid-claim and lets a second worker open a concurrent turn. Overridable via
     # CURIE_CLAIM_TIMEOUT_SECONDS; keep any override under the lock TTL too.
     claim_timeout_seconds: float = 90.0
+    # The INITIAL bind/serviceFQDN poll interval, not the only one. A fixed 50ms
+    # tick is cheap for a warm-pool bind that lands in a few hundred
+    # milliseconds, and expensive for a cold boot that does not: an ~11s cold
+    # create issues roughly 200 apiserver GETs per claim on Kubernetes, and on
+    # the Docker substrate every tick is two docker forks plus a healthz call.
+    # The interval therefore backs off after the fast window below.
     poll_interval_seconds: float = 0.05
+    # Cap on any single sleep, so a claim that binds late is still noticed
+    # promptly and the loop's overshoot past claim_timeout_seconds stays bounded
+    # by one cap rather than growing with the backoff.
+    poll_interval_max_seconds: float = 0.5
+    # How many sleeps stay at poll_interval_seconds before backoff starts. Six
+    # keeps every poll in the first 300ms byte-identical to the old fixed loop,
+    # so a warm-pool claim that binds within 250ms today still binds on the same
+    # poll: the request-volume win is taken entirely out of the cold-boot tail.
+    poll_fast_polls: int = 6
+    # Growth factor once the fast window is spent. Doubling reaches the cap in
+    # four steps, so the tail costs tens of calls instead of hundreds.
+    poll_backoff_factor: float = 2.0
     key_prefix: str = "curie:sandbox"
     claim_prefix: str = "curie-thread"
 

--- a/apps/worker/tests/sandbox/test_substrate.py
+++ b/apps/worker/tests/sandbox/test_substrate.py
@@ -836,3 +836,259 @@ def test_resume_merges_caller_boot_env(
     assert env[HISTORY_ENV] == "h-42"
     # The caller's mapping is not mutated.
     assert SESSION_ENV not in boot_env
+
+
+# --- Bind/serviceFQDN poll backoff -------------------------------------------
+# These run on a SIMULATED clock: the substrate's ``time`` module is swapped for
+# a fake whose ``sleep`` advances a virtual counter instead of waiting, so a 10s
+# cold boot is asserted exactly and instantly. Wall clock would make the cadence
+# assertions jitter-dependent and the suite ten seconds slower per case. The
+# reaper tests above swap ``substrate.datetime`` the same way.
+
+
+class _VirtualClock:
+    """A monotonic clock whose ``sleep`` advances time rather than passing it."""
+
+    def __init__(self) -> None:
+        self.now = 0.0
+        self.sleeps: list[float] = []
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.sleeps.append(seconds)
+        self.now += seconds
+
+
+def _production_poll_config(key_prefix: str) -> SubstrateConfig:
+    """The SHIPPED poll defaults, on a per-test Valkey prefix.
+
+    The ``config`` fixture runs a 5ms interval and a 2s budget to keep the other
+    tests fast; asserting the cadence against that would prove nothing about
+    what operators actually run.
+    """
+
+    return SubstrateConfig(
+        namespace="test-ns",
+        warm_pool="test-pool",
+        key_prefix=key_prefix,
+        claim_timeout_seconds=90.0,
+    )
+
+
+class _VirtualBindClient(FakeSandboxClient):
+    """Binds its claim once the VIRTUAL clock passes ``bind_after_seconds``.
+
+    Every ``get_claim`` records the virtual instant it was made, which is the
+    poll cadence the backoff exists to shape.
+    """
+
+    def __init__(self, clock: _VirtualClock, bind_after_seconds: float) -> None:
+        super().__init__()
+        self.clock = clock
+        self.bind_after_seconds = bind_after_seconds
+        self.poll_times: list[float] = []
+
+    def get_claim(self, name: str) -> ClaimView | None:
+        claim = self.claims.get(name)
+        if claim is None:
+            return None
+        self.poll_times.append(self.clock.now)
+        ready = self.clock.now >= self.bind_after_seconds
+        return ClaimView(
+            name=claim.name,
+            ready=ready,
+            sandbox_name=claim.sandbox_name if ready else None,
+            created_at=claim.created_at,
+            quota_rejection=None,
+            ready_reason=None,
+            ready_message=None,
+        )
+
+
+class _VirtualFqdnClient(FakeSandboxClient):
+    """Binds immediately, but publishes no serviceFQDN until the virtual clock
+    passes ``fqdn_after_seconds`` -- the phase-2 shape of a cold boot."""
+
+    def __init__(self, clock: _VirtualClock, fqdn_after_seconds: float) -> None:
+        super().__init__()
+        self.clock = clock
+        self.fqdn_after_seconds = fqdn_after_seconds
+        self.sandbox_polls: list[float] = []
+
+    def get_sandbox(self, name: str) -> SandboxView | None:
+        view = super().get_sandbox(name)
+        if view is None:
+            return None
+        self.sandbox_polls.append(self.clock.now)
+        if self.clock.now >= self.fqdn_after_seconds:
+            return view
+        return SandboxView(
+            name=view.name,
+            ready=view.ready,
+            service_fqdn="",
+            operating_mode=view.operating_mode,
+            port=view.port,
+        )
+
+
+def test_bind_polling_backs_off_over_a_cold_boot(
+    affinity: AffinityStore, key_prefix: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A cold create (pod scheduling, init containers, runner boot) takes ~10s.
+    # The old fixed 50ms loop asks the apiserver about the claim ~200 times over
+    # that window, per claim; the backoff must bring that down to tens while
+    # still actually polling.
+    clock = _VirtualClock()
+    monkeypatch.setattr("curie_worker.sandbox.substrate.time", clock)
+    fake_k8s = _VirtualBindClient(clock, bind_after_seconds=10.0)
+    substrate = SandboxSubstrate(fake_k8s, affinity, _production_poll_config(key_prefix))
+
+    handle = substrate.claim("T1")
+
+    assert handle.sandbox_name in fake_k8s.sandboxes
+    assert len(fake_k8s.poll_times) <= 40
+    # The lower bound keeps the upper one honest: a loop that stopped polling
+    # altogether would also satisfy "at most 40".
+    assert len(fake_k8s.poll_times) >= 10
+
+
+def test_warm_bind_polls_at_the_unchanged_fast_interval(
+    affinity: AffinityStore, key_prefix: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The warm-pool path is the one the backoff must not tax. A bind at 200ms is
+    # inside the fast window, so the poll instants are exactly the ones the old
+    # fixed loop produced and the claim binds on the very same poll.
+    clock = _VirtualClock()
+    monkeypatch.setattr("curie_worker.sandbox.substrate.time", clock)
+    fake_k8s = _VirtualBindClient(clock, bind_after_seconds=0.2)
+    substrate = SandboxSubstrate(fake_k8s, affinity, _production_poll_config(key_prefix))
+
+    handle = substrate.claim("T1")
+
+    assert fake_k8s.poll_times == pytest.approx([0.0, 0.05, 0.10, 0.15, 0.20])
+    assert handle.sandbox_name in fake_k8s.sandboxes
+
+
+def test_service_fqdn_polling_backs_off_over_a_cold_boot(
+    affinity: AffinityStore, key_prefix: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Phase 2 has its own wait loop and therefore its own call volume: a bound
+    # sandbox whose address takes 10s to publish must not cost ~200 get_sandbox
+    # calls either.
+    clock = _VirtualClock()
+    monkeypatch.setattr("curie_worker.sandbox.substrate.time", clock)
+    fake_k8s = _VirtualFqdnClient(clock, fqdn_after_seconds=10.0)
+    substrate = SandboxSubstrate(fake_k8s, affinity, _production_poll_config(key_prefix))
+
+    handle = substrate.claim("T1")
+
+    assert handle.service_fqdn.endswith(".svc.cluster.local")
+    assert len(fake_k8s.sandbox_polls) <= 40
+    assert len(fake_k8s.sandbox_polls) >= 10
+
+
+def test_backoff_is_capped_and_never_overshoots_the_claim_budget(
+    affinity: AffinityStore, key_prefix: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Two bounds that together stop the backoff from turning into a stall: no
+    # single sleep exceeds the cap, and the last sleep is clamped to whatever is
+    # left of the shared deadline, so a claim that never binds still times out
+    # at claim_timeout_seconds rather than a cap-length overshoot past it.
+    clock = _VirtualClock()
+    monkeypatch.setattr("curie_worker.sandbox.substrate.time", clock)
+    # 90.0s lands the backoff grid (6 x 0.05, then 0.1 + 0.2 + 0.4, then 0.5
+    # steps) exactly on the deadline, so the clamp would never fire and the
+    # test would pass even with the ``min(..., deadline - now)`` clamp
+    # deleted. 90.3 leaves a 0.3s remainder, smaller than
+    # poll_interval_max_seconds, so only the clamp can produce the final sleep.
+    config = replace(_production_poll_config(key_prefix), claim_timeout_seconds=90.3)
+    fake_k8s = _VirtualBindClient(clock, bind_after_seconds=float("inf"))
+    substrate = SandboxSubstrate(fake_k8s, affinity, config)
+
+    with pytest.raises(ClaimTimeoutError):
+        substrate.claim("T1")
+
+    assert max(clock.sleeps) <= config.poll_interval_max_seconds
+    # The clamp is what produced this final sleep: an unclamped backoff would
+    # have kept it at the cap instead of shortening it.
+    assert clock.sleeps[-1] < config.poll_interval_max_seconds
+    assert clock.now == pytest.approx(config.claim_timeout_seconds)
+    # The claim that never bound is still cleaned up.
+    assert fake_k8s.deleted == fake_k8s.created
+
+
+class _VirtualBindThenFqdnClient(FakeSandboxClient):
+    """Binds its claim at ``bind_after_seconds`` and only then starts
+    publishing serviceFQDN, from ``fqdn_after_seconds``.
+
+    Records both poll streams (``poll_times`` for get_claim, ``sandbox_polls``
+    for get_sandbox, matching ``_VirtualBindClient`` and ``_VirtualFqdnClient``
+    above) so a test can check the FQDN loop's own cadence rather than only
+    the combined outcome. A standalone subclass rather than multiple
+    inheritance from those two: both override ``__init__`` with a zero-arg
+    ``super().__init__()``, and combining them would route that call into the
+    sibling's ``__init__``, which needs its own positional args.
+    """
+
+    def __init__(
+        self, clock: _VirtualClock, bind_after_seconds: float, fqdn_after_seconds: float
+    ) -> None:
+        super().__init__()
+        self.clock = clock
+        self.bind_after_seconds = bind_after_seconds
+        self.fqdn_after_seconds = fqdn_after_seconds
+        self.poll_times: list[float] = []
+        self.sandbox_polls: list[float] = []
+
+    def get_claim(self, name: str) -> ClaimView | None:
+        claim = self.claims.get(name)
+        if claim is None:
+            return None
+        self.poll_times.append(self.clock.now)
+        ready = self.clock.now >= self.bind_after_seconds
+        return ClaimView(
+            name=claim.name,
+            ready=ready,
+            sandbox_name=claim.sandbox_name if ready else None,
+            created_at=claim.created_at,
+            quota_rejection=None,
+            ready_reason=None,
+            ready_message=None,
+        )
+
+    def get_sandbox(self, name: str) -> SandboxView | None:
+        view = super().get_sandbox(name)
+        if view is None:
+            return None
+        self.sandbox_polls.append(self.clock.now)
+        if self.clock.now >= self.fqdn_after_seconds:
+            return view
+        return SandboxView(
+            name=view.name,
+            ready=view.ready,
+            service_fqdn="",
+            operating_mode=view.operating_mode,
+            port=view.port,
+        )
+
+
+def test_service_fqdn_polling_restarts_fast_after_a_cold_bind(
+    affinity: AffinityStore, key_prefix: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The bind phase backs off all the way to the 500ms cap over its 10s cold
+    # boot. The FQDN phase must not inherit that backed-off interval: its own
+    # generator starts fresh, so its first sleep is the fast 50ms interval, not
+    # a leftover 500ms from phase 1.
+    clock = _VirtualClock()
+    monkeypatch.setattr("curie_worker.sandbox.substrate.time", clock)
+    fake_k8s = _VirtualBindThenFqdnClient(
+        clock, bind_after_seconds=10.0, fqdn_after_seconds=10.05
+    )
+    substrate = SandboxSubstrate(fake_k8s, affinity, _production_poll_config(key_prefix))
+
+    handle = substrate.claim("T1")
+
+    assert fake_k8s.sandbox_polls == pytest.approx([10.0, 10.05])
+    assert handle.service_fqdn.endswith(".svc.cluster.local")


### PR DESCRIPTION
## Summary

The worker's sandbox claim wait loops (`_await_bound` and `_await_service_fqdn` in `apps/worker/src/curie_worker/sandbox/substrate.py`) slept a fixed `poll_interval_seconds` (50 ms). A cold sandbox boot therefore cost hundreds of `get_claim` calls per claim: about 200 apiserver GETs for the ~11 s cold create measured in #1492 on Kubernetes, and two docker forks plus a healthz call per tick on the Docker substrate. This change replaces the fixed sleep with a bounded exponential backoff, configured through the existing `SubstrateConfig`:

- `poll_interval_seconds` (unchanged, 0.05) is now the initial interval.
- `poll_fast_polls` (6): sleeps that stay at the initial interval, so every poll in the first 300 ms is identical to the old loop and a warm-pool bind is noticed on the same poll as before.
- `poll_backoff_factor` (2.0) and `poll_interval_max_seconds` (0.5): the interval doubles after the fast window and is capped at 500 ms.
- Every sleep is clamped to the time left in the shared claim deadline, so `claim_timeout_seconds` (and the `CURIE_CLAIM_TIMEOUT_SECONDS` override) keep their meaning and the loop no longer overshoots the budget.

Each wait loop takes its own backoff, so the serviceFQDN phase restarts at the fast interval once the claim binds. The sync client seam is kept; no watch API, no wire, schema, or manifest change, and the kernel modules are untouched.

Distinct from #1492 (warm pools) and #760 (throughput design): this is request volume at a fixed poll rate.

## Tests

Five simulated-clock tests in `apps/worker/tests/sandbox/test_substrate.py` (the substrate's `time` module is swapped for a virtual clock; the route store is the real compose Valkey):

- a claim bound after 10 s of simulated time issues at most 40 `get_claim` calls (28 on this branch; 201 on the unmodified code, verified by running the same test against `origin/main`'s substrate and types modules);
- a claim bound at 200 ms polls at exactly 0, 50, 100, 150, 200 ms and binds on the 200 ms poll;
- the serviceFQDN loop backs off the same way (28 `get_sandbox` calls instead of 201);
- the serviceFQDN loop restarts at the fast 50 ms interval after a cold bind at 10 s (polls at exactly 10.0 and 10.05 s), so the phases do not share a backed-off interval;
- no sleep exceeds `poll_interval_max_seconds`, and a claim that never binds times out exactly at `claim_timeout_seconds` (budget deliberately set off the 0.5 s grid so the deadline clamp is observable) with its claim cleaned up.

Validation on this branch against the compose Valkey (`CI_REQUIRE_VALKEY_TESTS=1`):

```
uv run pytest apps/worker/tests/sandbox   # 117 passed, 1 skipped
uv run pytest apps/worker/tests/kernel    # 338 passed, 2 skipped (see note)
uv run ruff check apps/worker && uv run mypy
```

Note: `apps/worker/tests/kernel/test_binding_integration.py::test_kill_interrupts_a_live_turn` failed once in a full kernel run and then passed on re-run. It races `_wait_until(turn_active)` against `_register_run` in the kernel, which happens after the claim path returns, so the poll loop is not in that window. Counting repeated single-test runs: 8 failures in 134 runs on this branch and 0 in 92 on origin/main, but the branch failures clustered in loops that ran alongside docker builds and other load on this box, and a clean interleaved comparison (30 runs each, branch against a fresh origin/main worktree, no concurrent load) passed 60 of 60. The failing run's log shows `claim latency ... 1 ms`, so no backoff sleep ran; the poll loop is not on that race's path. Worth a look as a pre-existing kernel test race, separately from this PR.

## Measured docker fork counts, one cold claim

Measured on the Docker substrate by invoking the worker's own claim path (`SandboxSubstrate.claim` on a `DockerSandboxClient` with the `curie-runner` image, a minimal plugin bundle, the fake model, and the real compose Valkey as the route store), which is the code a `curie local message` cold claim runs inside the worker. The full `curie local` stack was not brought up from this worktree because the compose host ports on this box were already held by a sibling job's stack; the claim path is the same either way. `docker` was counted with a PATH shim that appends each subcommand to a log before exec'ing the real binary:

```
cat > shim/docker <<'SH'
#!/usr/bin/env bash
echo "$(date +%s.%N) $1" >> "$DOCKER_COUNT_LOG"
exec /usr/bin/docker "$@"
SH
DOCKER_COUNT_LOG=count.log PATH=$PWD/shim:$PATH uv run python measure_claim.py <label>
awk '{print $2}' count.log | sort | uniq -c
```

Cold claim (runner boots and passes healthz):

| Code | Claim bound in | `docker inspect` forks | All docker forks |
| --- | --- | --- | --- |
| main, run 1 | 6.22 s | 30 | 61 |
| main, run 2 | 1.69 s | 16 | 33 |
| this branch, run 1 | 2.15 s | 12 | 25 |
| this branch, run 2 | 1.61 s | 11 | 23 |

Boot time varies run to run, so the never-ready case fixes the wait at 10 s (`claim_timeout_seconds=10`, runner exits at boot so the claim never binds):

| Code | `docker inspect` forks in 10 s | All docker forks |
| --- | --- | --- |
| main | 137 | 164 |
| this branch | 26 | 38 |

On this branch the inter-poll gaps for a cold claim were 81, 80, 82, 81, 84, 86, 132, 231, 433, 529 ms: six fast polls, then doubling to the cap.

## Decisions

- No new environment variable: the knobs are `SubstrateConfig` fields only, per the task's "configurable through the existing SubstrateConfig". The conservative default keeps the operator surface unchanged.
- The fast window is six sleeps rather than "several" so the first 300 ms are byte-identical to the old loop; a claim that binds within 250 ms today binds on the same poll.
- The deadline clamp is a tightening of the old behavior (the old loop could overshoot the deadline by one interval); the timeout error and message are unchanged.

## Done check

Quick-tier subset.

- [x] Tests present and green: five simulated-clock tests in `apps/worker/tests/sandbox/test_substrate.py`; sandbox 117 passed, kernel 338 passed on the compose Valkey; the two cold-boot tests fail on the unmodified code with 201 polls.
- [x] Routed adversarial Code review completed through agent-router (second attempt, after a router timeout on the first): ACCEPT with two advisory test-quality findings, both applied (off-grid timeout budget for the clamp test; a bind-then-FQDN test for the phase restart).
- [x] Routed adversarial Scope review completed through agent-router: ACCEPT, every hunk mapped to an acceptance criterion or a mechanical import; no findings.
- [x] Lint and typecheck clean: `ruff check apps/worker`, `mypy` (247 source files).
- [x] Guard demonstration: with the deadline clamp removed from `substrate.py` the clamp test fails (`1 failed`), and it passes on the real code.
- [x] Sibling-path parity: both wait loops (`_await_bound`, `_await_service_fqdn`) get the backoff, each with its own generator; both are pinned by tests. The Docker and Kubernetes clients share these loops, so both substrates are covered by the same change.
- [x] Train check: shared-line change, worktree cut from `origin/main`, PR targets `main`.
- [N/A] Plan doc, failing-tests-first commit, consolidation pass, security and E2E reviewers: quick tier, no scale-up flagged.
- [N/A] Broadened return types: the Implementer reported none.

