### PR TITLE
fix: settle interrupted runner turns and repair live ladder controls

### DIFF
--- a/cli/scripts/e2e-ladder.sh
+++ b/cli/scripts/e2e-ladder.sh
@@ -2348,8 +2348,11 @@ alias Curie assigned it, so a pass covers three things at once: the alias
 resolves, the server is serving MCP, and its tool surface is the expected one.
 """
 
+import errno
 import json
 import sys
+import time
+import urllib.error
 import urllib.request
 
 url, expected_csv = sys.argv[1], sys.argv[2]
@@ -2359,7 +2362,7 @@ expected = sorted(name for name in expected_csv.split(",") if name)
 state = {"session": None, "version": "2024-11-05"}
 
 
-def post(body, notification=False):
+def post(body, notification=False, timeout=60):
     headers = {
         "Content-Type": "application/json",
         # Both, because a streamable-HTTP server may answer either shape.
@@ -2371,7 +2374,7 @@ def post(body, notification=False):
     request = urllib.request.Request(
         url, data=json.dumps(body).encode(), headers=headers, method="POST"
     )
-    with urllib.request.urlopen(request, timeout=60) as response:
+    with urllib.request.urlopen(request, timeout=timeout) as response:
         session = response.headers.get("mcp-session-id")
         if session:
             state["session"] = session
@@ -2389,19 +2392,33 @@ def fail(message):
     raise SystemExit(1)
 
 
+# Container running is earlier than MCP serving. Retry only connection-refused
+# startup on initialize; an HTTP/auth/protocol error still fails immediately.
+# The deadline covers every dial and sleep, and tools/list remains exact below.
+ready_deadline = time.monotonic() + 30
 try:
-    handshake = post(
-        {
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "initialize",
-            "params": {
-                "protocolVersion": state["version"],
-                "capabilities": {},
-                "clientInfo": {"name": "curie-e2e-ladder", "version": "0"},
-            },
-        }
-    )
+    while True:
+        remaining = ready_deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError("MCP server did not become reachable within 30s")
+        try:
+            handshake = post(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "initialize",
+                    "params": {
+                        "protocolVersion": state["version"],
+                        "capabilities": {},
+                        "clientInfo": {"name": "curie-e2e-ladder", "version": "0"},
+                    },
+                }, timeout=min(remaining, 10)
+            )
+            break
+        except urllib.error.URLError as exc:
+            if not isinstance(exc.reason, OSError) or exc.reason.errno != errno.ECONNREFUSED:
+                raise
+            time.sleep(min(.25, max(0, ready_deadline - time.monotonic())))
 except Exception as exc:
     fail("the MCP handshake did not complete: %s: %s" % (type(exc).__name__, exc))
 
@@ -3566,6 +3583,13 @@ pin_local_source_images() {
 
 inject_local_runner_failure() {
     LOCAL_OTEL_FAILURE_MODE=1
+    # OpenRouter credentials deliberately select their own provider endpoint
+    # (runner sdk_auth.resolve_sdk_env). A URL override alone therefore still
+    # runs a healthy live turn. Give this failing worker only a placeholder;
+    # retain presence as well as value so cleanup restores the operator input.
+    LOCAL_OTEL_ORIGINAL_CREDENTIALS_SET="${CURIE_CREDENTIALS+x}"
+    LOCAL_OTEL_ORIGINAL_CREDENTIALS="${CURIE_CREDENTIALS-}"
+    export CURIE_CREDENTIALS=not-a-real-token-ladder
     export CURIE_FAKE_MODEL=0
     export CURIE_MODEL_BASE_URL="$LOCAL_OTEL_ENDPOINT"
     export CURIE_MODEL_API_BACKEND=messages
@@ -3575,6 +3599,12 @@ inject_local_runner_failure() {
 }
 
 restore_local_runner_health() {
+    if [[ "${LOCAL_OTEL_ORIGINAL_CREDENTIALS_SET:-}" == x ]]; then
+        export CURIE_CREDENTIALS="$LOCAL_OTEL_ORIGINAL_CREDENTIALS"
+    else
+        unset CURIE_CREDENTIALS
+    fi
+    unset LOCAL_OTEL_ORIGINAL_CREDENTIALS_SET LOCAL_OTEL_ORIGINAL_CREDENTIALS
     if [[ "$LIVE" == "1" ]]; then
         export CURIE_FAKE_MODEL=0
     else

--- a/cli/tests/nightly_graded_ladder.rs
+++ b/cli/tests/nightly_graded_ladder.rs
@@ -3010,3 +3010,112 @@ fn live_cluster_rung_reports_but_does_not_propagate_evaluator_failure() {
          stdout:\n{stdout}\nstderr:\n{stderr}"
     );
 }
+
+#[test]
+fn runner_failure_control_replaces_and_restores_provider_credential() {
+    for credential in [None, Some(""), Some("sk-or-fixture-only")] {
+        let dir = tempfile::tempdir().unwrap();
+        let capture = dir.path().join("worker-env");
+        let script = format!(
+            "set -eu\n{}\n{}\n\
+             docker() {{ printf '%s' \"${{CURIE_CREDENTIALS-unset}}\" > \"$CAPTURE\"; }}\n\
+             sleep() {{ :; }}\n\
+             LOCAL_OTEL_ENDPOINT=http://127.0.0.1:9\nREPO_ROOT=/fixture\nLIVE=1\n\
+             inject_local_runner_failure\n\
+             python3 -c 'import os; c=open(os.environ[\"CAPTURE\"]).read(); assert c and c != \"unset\" and not c.startswith(\"sk-or-\"), \"failure control still selects the live provider\"'\n\
+             restore_local_runner_health\n\
+             python3 -c 'import os; expected=os.environ[\"EXPECTED\"]; actual=os.environ.get(\"CURIE_CREDENTIALS\",\"unset\"); assert actual == expected, \"original credential presence/value was not restored\"'\n",
+            ladder_function("inject_local_runner_failure"),
+            ladder_function("restore_local_runner_health"),
+        );
+        let mut command = Command::new("bash");
+        command
+            .arg("-c")
+            .arg(script)
+            .env("CAPTURE", &capture)
+            .env("EXPECTED", credential.unwrap_or("unset"))
+            .env_remove("CURIE_CREDENTIALS");
+        if let Some(value) = credential {
+            command.env("CURIE_CREDENTIALS", value);
+        }
+        let output = command.output().unwrap();
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}
+
+#[test]
+fn connector_probe_waits_for_serving_and_still_rejects_wrong_tools() {
+    let probe = ladder_python_heredoc("write_connector_probe");
+    for wrong_tools in [false, true] {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("probe.py");
+        fs::write(&path, &probe).unwrap();
+        // A real loopback HTTP MCP fixture starts after the probe first dials.
+        // This is an external MCP mock, never a mocked platform datastore.
+        let fixture = r#"
+import http.server,json,socket,sys,threading,time
+with socket.socket() as reserved:
+    reserved.bind(('127.0.0.1',0)); port=reserved.getsockname()[1]
+class Handler(http.server.BaseHTTPRequestHandler):
+    def log_message(self,*args): pass
+    def do_POST(self):
+        body=json.loads(self.rfile.read(int(self.headers['Content-Length'])))
+        if body['method']=='notifications/initialized':
+            self.send_response(202); self.end_headers(); return
+        result=({'protocolVersion':'2024-11-05','capabilities':{},'serverInfo':{'name':'fixture','version':'1'}}
+                if body['method']=='initialize' else {'tools':[{'name':'wrong' if wrong else 'expected'}]})
+        payload=json.dumps({'jsonrpc':'2.0','id':body['id'],'result':result}).encode()
+        self.send_response(200); self.send_header('Content-Type','application/json')
+        self.send_header('Content-Length',str(len(payload))); self.end_headers(); self.wfile.write(payload)
+def serve():
+    time.sleep(.2)
+    with http.server.HTTPServer(('127.0.0.1',port),Handler) as server: server.serve_forever()
+path=sys.argv[1]; wrong=sys.argv[2]=='1'
+threading.Thread(target=serve,daemon=True).start()
+sys.argv=[path,'http://127.0.0.1:%d/mcp'%port,'expected']
+exec(compile(open(path).read(),path,'exec'))
+"#;
+        let output = Command::new("python3")
+            .arg("-c")
+            .arg(fixture)
+            .arg(path)
+            .arg(if wrong_tools { "1" } else { "0" })
+            .output()
+            .unwrap();
+        if wrong_tools {
+            assert!(!output.status.success());
+            assert!(String::from_utf8_lossy(&output.stderr).contains("tools/list returned"));
+        } else {
+            assert!(
+                output.status.success(),
+                "{}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            assert!(String::from_utf8_lossy(&output.stdout).contains("OK expected"));
+        }
+    }
+}
+
+#[test]
+fn connector_probe_stops_when_server_never_becomes_ready() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("probe.py");
+    fs::write(&path, ladder_python_heredoc("write_connector_probe")).unwrap();
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    let started = std::time::Instant::now();
+    let output = Command::new("python3")
+        .arg(path)
+        .arg(format!("http://127.0.0.1:{port}/mcp"))
+        .arg("expected")
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("within 30s"));
+    assert!(started.elapsed() < std::time::Duration::from_secs(35));
+}

--- a/runner/src/curie_runner/adapter.py
+++ b/runner/src/curie_runner/adapter.py
@@ -21,10 +21,12 @@ from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from typing import Any, Protocol, cast
 
+import anyio
 from claude_agent_sdk import (
     ClaudeAgentOptions,
     ClaudeSDKClient,
     HookMatcher,
+    ResultMessage,
     SdkPluginConfig,
     StreamEvent,
     TaskBudget,
@@ -32,6 +34,7 @@ from claude_agent_sdk import (
 from claude_agent_sdk.types import CanUseTool, McpSdkServerConfig, PermissionMode
 
 _ALLOWED_PARTIAL_BOUNDARY_TYPES = frozenset(("message_start", "content_block_start"))
+_RESPONSE_DRAIN_TIMEOUT_S = 5.0
 
 
 @dataclass(frozen=True, slots=True)
@@ -48,6 +51,10 @@ class StreamedToolUseBoundary:
     call_id: str = field(repr=False)
     tool_name: str
     observed_time_ns: int
+
+
+class SessionQueryBusy(RuntimeError):
+    """A query already owns admission; callers must not queue a stale steer."""
 
 
 class ModelSession(Protocol):
@@ -147,49 +154,88 @@ class ClaudeAgentSession:
     def __init__(self, options: ClaudeAgentOptions) -> None:
         self._options = options
         self._client = ClaudeSDKClient(options)
+        self._response_unfinished = False
+        self._query_lock = anyio.Lock()
 
     async def connect(self) -> None:
         await self._client.connect()
+        self._response_unfinished = False
+        self._query_lock = anyio.Lock()
 
     async def query(self, text: str) -> None:
-        await self._client.query(text)
+        # Never queue a steer behind another query's interrupted-response drain.
+        # That owning turn can fail while we wait, leaving a stale submission
+        # whose response would otherwise be consumed by a later turn.
+        await anyio.lowlevel.checkpoint_if_cancelled()
+        try:
+            self._query_lock.acquire_nowait()
+        except anyio.WouldBlock:
+            raise SessionQueryBusy("SDK query admission is already owned") from None
+        try:
+            if self._response_unfinished:
+                # interrupt() leaves the old ResultMessage in the SDK buffer. Drain
+                # only a reader that was abandoned, never the active reader used by
+                # ordinary steering. Do not submit another query until its terminal
+                # boundary is known; a missing/failed boundary remains retryable.
+                # https://code.claude.com/docs/en/agent-sdk/python#example-using-interrupts
+                try:
+                    with anyio.fail_after(_RESPONSE_DRAIN_TIMEOUT_S):
+                        response = cast("Any", self._client.receive_response())
+                        async with contextlib.aclosing(response):
+                            async for message in response:
+                                if isinstance(message, ResultMessage):
+                                    self._response_unfinished = False
+                                    break
+                except Exception:
+                    raise RuntimeError("interrupted SDK response did not settle") from None
+                if self._response_unfinished:
+                    raise RuntimeError("interrupted SDK response ended without a result")
+            await self._client.query(text)
+        finally:
+            self._query_lock.release()
 
     def receive_turn(self) -> AsyncIterator[Any]:
         async def normalized() -> AsyncIterator[Any]:
             response = cast("Any", self._client.receive_response())
-            async with contextlib.aclosing(response):
-                async for message in response:
-                    if isinstance(message, StreamEvent):
-                        event = message.event
-                        event_type = (
-                            event.get("type") if isinstance(event, dict) else None
-                        )
-                        if event_type == "content_block_start":
-                            content_block = event.get("content_block")
-                            if isinstance(content_block, dict):
-                                call_id = content_block.get("id")
-                                tool_name = content_block.get("name")
-                                if (
-                                    content_block.get("type") == "tool_use"
-                                    and isinstance(call_id, str)
-                                    and call_id
-                                    and isinstance(tool_name, str)
-                                    and tool_name
-                                ):
-                                    yield StreamedToolUseBoundary(
-                                        call_id=call_id,
-                                        tool_name=tool_name,
-                                        observed_time_ns=time.time_ns(),
-                                    )
-                                    continue
-                        if event_type in _ALLOWED_PARTIAL_BOUNDARY_TYPES:
-                            # Do not forward the StreamEvent object: its event body,
-                            # uuid, SDK session id, and parent tool id are all
-                            # provider payload. Only this bounded type survives the
-                            # adapter seam into session telemetry.
-                            yield PartialMessageBoundary(event_type=event_type)
-                        continue
-                    yield message
+            finished = False
+            try:
+                async with contextlib.aclosing(response):
+                    async for message in response:
+                        if isinstance(message, ResultMessage):
+                            finished = True
+                        if isinstance(message, StreamEvent):
+                            event = message.event
+                            event_type = (
+                                event.get("type") if isinstance(event, dict) else None
+                            )
+                            if event_type == "content_block_start":
+                                content_block = event.get("content_block")
+                                if isinstance(content_block, dict):
+                                    call_id = content_block.get("id")
+                                    tool_name = content_block.get("name")
+                                    if (
+                                        content_block.get("type") == "tool_use"
+                                        and isinstance(call_id, str)
+                                        and call_id
+                                        and isinstance(tool_name, str)
+                                        and tool_name
+                                    ):
+                                        yield StreamedToolUseBoundary(
+                                            call_id=call_id,
+                                            tool_name=tool_name,
+                                            observed_time_ns=time.time_ns(),
+                                        )
+                                        continue
+                            if event_type in _ALLOWED_PARTIAL_BOUNDARY_TYPES:
+                                # Do not forward the StreamEvent object: its event body,
+                                # uuid, SDK session id, and parent tool id are all
+                                # provider payload. Only this bounded type survives the
+                                # adapter seam into session telemetry.
+                                yield PartialMessageBoundary(event_type=event_type)
+                            continue
+                        yield message
+            finally:
+                self._response_unfinished = not finished
 
         return normalized()
 

--- a/runner/src/curie_runner/session.py
+++ b/runner/src/curie_runner/session.py
@@ -24,6 +24,7 @@ import hmac
 import logging
 import time
 from collections.abc import AsyncGenerator, AsyncIterator, Callable
+from typing import Any, cast
 
 import anyio
 from aci_protocol import (
@@ -40,7 +41,12 @@ from claude_agent_sdk import AssistantMessage, ResultMessage
 from curie_telemetry import record_metric
 from opentelemetry.context import Context
 
-from .adapter import ModelSession, PartialMessageBoundary, StreamedToolUseBoundary
+from .adapter import (
+    ModelSession,
+    PartialMessageBoundary,
+    SessionQueryBusy,
+    StreamedToolUseBoundary,
+)
 from .approval import ApprovalGate
 from .budget import BUDGET_CLASSIFICATION, BudgetTracker
 from .history import NullTranscriptStore, TranscriptStore, TurnRecord
@@ -398,14 +404,18 @@ class SessionRunner:
     async def steer(self, text: str) -> bool:
         """Inject a follow-up message into the live turn without consuming output.
 
-        Returns False when no turn is active (the finish-race boundary F1 owns:
-        the caller falls back to opening a fresh turn). The steered output appears
-        on the already-open turn's NDJSON stream.
+        Returns False when no turn is active or its query admission is busy:
+        the caller uses the existing finish-race fallback to open a fresh turn.
+        A steer must not wait behind a drain that can retire its owning turn.
+        Accepted output appears on the already-open turn's NDJSON stream.
         """
 
         if self._session is None or not self._turn_open:
             return False
-        await self._session.query(text)
+        try:
+            await self._session.query(text)
+        except SessionQueryBusy:
+            return False
         return True
 
     async def interrupt(self, _reason: str = "") -> None:
@@ -535,13 +545,16 @@ class SessionRunner:
                     parent=parent,
                 ) as gen:
                     try:
-                        async for line in self._drive_turn(event, state, tracker, gen):
-                            if isinstance(parse_ndjson_line(line), Final):
-                                # The terminal decision is authoritative once the
-                                # Final reaches the consumer, even if it closes
-                                # without requesting the generator's next item.
-                                metric_outcome = self._metric_outcome(tracker)
-                            yield line
+                        async with contextlib.aclosing(
+                            cast("Any", self._drive_turn(event, state, tracker, gen))
+                        ) as turn_lines:
+                            async for line in turn_lines:
+                                if isinstance(parse_ndjson_line(line), Final):
+                                    # The terminal decision is authoritative once the
+                                    # Final reaches the consumer, even if it closes
+                                    # without requesting the generator's next item.
+                                    metric_outcome = self._metric_outcome(tracker)
+                                yield line
                         logger.info(
                             "turn end session=%s status=%s duration_ms=%d",
                             self._session_id,
@@ -719,127 +732,128 @@ class SessionRunner:
         assert self._session is not None
         gen.query_observed()
         await self._session.query(event.text)
-        async for message in self._session.receive_turn():
-            if isinstance(message, StreamedToolUseBoundary):
-                gen.record_first_response_boundary()
-                gen.streamed_tool_use(
-                    message.call_id,
-                    message.tool_name,
-                    observed_time_ns=message.observed_time_ns,
-                )
-                continue
-            if isinstance(message, PartialMessageBoundary):
-                gen.record_first_response_boundary()
-                continue
-            if _is_auth_rejection(message):
-                # A rejected model credential is terminal: stop the live session
-                # so the SDK/CLI does not keep retrying with backoff to the wall,
-                # then surface a distinct, immediate classified failure. Suppress
-                # a failing interrupt (a wedged transport -- the very state a bad
-                # credential can cause) so it cannot propagate to the generic
-                # retryable ``runner-error`` handler and defeat the fast-fail; the
-                # terminal ``model-credential-rejected`` error is emitted regardless.
-                with contextlib.suppress(Exception):
-                    await self._session.interrupt()
-                self._set_failed(gen)
-                for line in self._auth_halt_lines():
-                    yield line
-                return
-            usage = getattr(message, "usage", None)
-            # The terminal result carries the authoritative turn total; streaming
-            # assistant messages carry per-message output. Fold them differently
-            # so the same tokens are not counted twice (see BudgetTracker).
-            if isinstance(message, ResultMessage):
-                tracker.set_total(usage)
-            else:
-                tracker.add_increment(usage)
-            budget_hit = tracker.exceeded
-            events = translate_message(message, state, self._classifier, gen)
-            decided_result_final: Final | None = None
-            if isinstance(message, ResultMessage):
-                terminal_reason = getattr(message, "terminal_reason", None)
-                cancelled = self._interrupt_requested and not self._timeout_requested
-                subtype = message.subtype or ""
-                result_failed = self._timeout_requested or budget_hit or (
-                    not cancelled and (message.is_error or subtype.startswith("error"))
-                )
-                if not budget_hit:
-                    self._merge_gate_block(state)
-                    sdk_final = next(
-                        (outbound for outbound in events if isinstance(outbound, Final)),
-                        None,
+        async with contextlib.aclosing(cast("Any", self._session.receive_turn())) as messages:
+            async for message in messages:
+                if isinstance(message, StreamedToolUseBoundary):
+                    gen.record_first_response_boundary()
+                    gen.streamed_tool_use(
+                        message.call_id,
+                        message.tool_name,
+                        observed_time_ns=message.observed_time_ns,
                     )
-                    if sdk_final is not None:
-                        decided_result_final = _apply_approval_override(
-                            self._reclassify(sdk_final), state
-                        )
-                gen.result_boundary_observed(
-                    failed=result_failed,
-                    terminal_reason=terminal_reason,
-                    approval_paused=decided_result_final is not None
-                    and decided_result_final.status
-                    is SessionStatus.AWAITING_APPROVAL,
-                )
-
-            for outbound in events:
-                if isinstance(outbound, ToolNote):
-                    logger.info("tool call session=%s tool=%s", self._session_id, outbound.tool)
-                if isinstance(outbound, ErrorEvent):
-                    logger.error(
-                        "model error session=%s classification=%s",
-                        self._session_id,
-                        outbound.classification,
-                    )
-                if isinstance(outbound, Final):
-                    if budget_hit:
-                        self._set_failed(gen)
-                        for line in self._budget_halt_lines():
-                            yield line
-                        return
-                    if decided_result_final is None:
-                        self._merge_gate_block(state)
-                        final = _apply_approval_override(
-                            self._reclassify(outbound), state
-                        )
-                    else:
-                        final = decided_result_final
-                    for line in self._approval_not_acted_lines(state, final):
+                    continue
+                if isinstance(message, PartialMessageBoundary):
+                    gen.record_first_response_boundary()
+                    continue
+                if _is_auth_rejection(message):
+                    # A rejected model credential is terminal: stop the live session
+                    # so the SDK/CLI does not keep retrying with backoff to the wall,
+                    # then surface a distinct, immediate classified failure. Suppress
+                    # a failing interrupt (a wedged transport -- the very state a bad
+                    # credential can cause) so it cannot propagate to the generic
+                    # retryable ``runner-error`` handler and defeat the fast-fail; the
+                    # terminal ``model-credential-rejected`` error is emitted regardless.
+                    with contextlib.suppress(Exception):
+                        await self._session.interrupt()
+                    self._set_failed(gen)
+                    for line in self._auth_halt_lines():
                         yield line
-                    for line in self._false_completion_lines(state, final):
-                        yield line
-                    # A timeout can land while one of the warning lines above is
-                    # suspended at its yield. Re-apply its precedence immediately
-                    # before publishing the terminal final.
-                    final = self._reclassify(final)
-                    self._status = final.status
-                    self._turn_open = False
-                    gen.finish_turn(
-                        timeout_requested=self._timeout_requested,
-                        interrupt_requested=self._interrupt_requested,
-                        classified_failure=final.status
-                        is SessionStatus.CLASSIFIED_FAILURE,
-                        approval_paused=final.status
-                        is SessionStatus.AWAITING_APPROVAL,
-                        completed_without_result=final.status
-                        is SessionStatus.AWAITING_APPROVAL,
-                    )
-                    # Only a clean DONE reply belongs in the conversation
-                    # transcript. Classified failures and approval pauses are
-                    # terminal delivery outcomes, not assistant answers (#20).
-                    if final.status is SessionStatus.DONE:
-                        state.final_text = final.text
-                    yield to_ndjson_line(final)
                     return
-                yield to_ndjson_line(outbound)
+                usage = getattr(message, "usage", None)
+                # The terminal result carries the authoritative turn total; streaming
+                # assistant messages carry per-message output. Fold them differently
+                # so the same tokens are not counted twice (see BudgetTracker).
+                if isinstance(message, ResultMessage):
+                    tracker.set_total(usage)
+                else:
+                    tracker.add_increment(usage)
+                budget_hit = tracker.exceeded
+                events = translate_message(message, state, self._classifier, gen)
+                decided_result_final: Final | None = None
+                if isinstance(message, ResultMessage):
+                    terminal_reason = getattr(message, "terminal_reason", None)
+                    cancelled = self._interrupt_requested and not self._timeout_requested
+                    subtype = message.subtype or ""
+                    result_failed = self._timeout_requested or budget_hit or (
+                        not cancelled and (message.is_error or subtype.startswith("error"))
+                    )
+                    if not budget_hit:
+                        self._merge_gate_block(state)
+                        sdk_final = next(
+                            (outbound for outbound in events if isinstance(outbound, Final)),
+                            None,
+                        )
+                        if sdk_final is not None:
+                            decided_result_final = _apply_approval_override(
+                                self._reclassify(sdk_final), state
+                            )
+                    gen.result_boundary_observed(
+                        failed=result_failed,
+                        terminal_reason=terminal_reason,
+                        approval_paused=decided_result_final is not None
+                        and decided_result_final.status
+                        is SessionStatus.AWAITING_APPROVAL,
+                    )
 
-            if budget_hit:
-                # Budget crossed on a non-terminal message: stop the live run,
-                # then emit the same error+final pair.
-                await self._session.interrupt()
-                self._set_failed(gen)
-                for line in self._budget_halt_lines():
-                    yield line
-                return
+                for outbound in events:
+                    if isinstance(outbound, ToolNote):
+                        logger.info("tool call session=%s tool=%s", self._session_id, outbound.tool)
+                    if isinstance(outbound, ErrorEvent):
+                        logger.error(
+                            "model error session=%s classification=%s",
+                            self._session_id,
+                            outbound.classification,
+                        )
+                    if isinstance(outbound, Final):
+                        if budget_hit:
+                            self._set_failed(gen)
+                            for line in self._budget_halt_lines():
+                                yield line
+                            return
+                        if decided_result_final is None:
+                            self._merge_gate_block(state)
+                            final = _apply_approval_override(
+                                self._reclassify(outbound), state
+                            )
+                        else:
+                            final = decided_result_final
+                        for line in self._approval_not_acted_lines(state, final):
+                            yield line
+                        for line in self._false_completion_lines(state, final):
+                            yield line
+                        # A timeout can land while one of the warning lines above is
+                        # suspended at its yield. Re-apply its precedence immediately
+                        # before publishing the terminal final.
+                        final = self._reclassify(final)
+                        self._status = final.status
+                        self._turn_open = False
+                        gen.finish_turn(
+                            timeout_requested=self._timeout_requested,
+                            interrupt_requested=self._interrupt_requested,
+                            classified_failure=final.status
+                            is SessionStatus.CLASSIFIED_FAILURE,
+                            approval_paused=final.status
+                            is SessionStatus.AWAITING_APPROVAL,
+                            completed_without_result=final.status
+                            is SessionStatus.AWAITING_APPROVAL,
+                        )
+                        # Only a clean DONE reply belongs in the conversation
+                        # transcript. Classified failures and approval pauses are
+                        # terminal delivery outcomes, not assistant answers (#20).
+                        if final.status is SessionStatus.DONE:
+                            state.final_text = final.text
+                        yield to_ndjson_line(final)
+                        return
+                    yield to_ndjson_line(outbound)
+
+                if budget_hit:
+                    # Budget crossed on a non-terminal message: stop the live run,
+                    # then emit the same error+final pair.
+                    await self._session.interrupt()
+                    self._set_failed(gen)
+                    for line in self._budget_halt_lines():
+                        yield line
+                    return
 
         # The turn iterator ended without a terminal result (e.g. an interrupt
         # aborted before the model produced one). Emit a final so the stream

--- a/runner/tests/test_session.py
+++ b/runner/tests/test_session.py
@@ -2,14 +2,24 @@
 
 import asyncio
 import logging
+from collections import deque
 
 import anyio
 import pytest
 from aci_protocol import ErrorEvent, Event, Interrupt, SessionStatus, parse_ndjson
-from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock, ToolUseBlock
+from aiohttp.test_utils import TestClient, TestServer
+from claude_agent_sdk import (
+    AssistantMessage,
+    ClaudeAgentOptions,
+    ResultMessage,
+    TextBlock,
+    ToolUseBlock,
+)
 from curie_runner import RunTracer, SideEffectClassifier, build_options
+from curie_runner import adapter as adapter_module
 from curie_runner import session as session_module
 from curie_runner.fake import FakeModelSession, default_turn
+from curie_runner.server import create_app
 from curie_runner.session import SessionRunner
 from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
@@ -1269,6 +1279,333 @@ def test_abandoned_stream_interrupts_the_sdk() -> None:
 
     anyio.run(go)
     assert fake.interrupts >= 1
+
+
+class _BufferedInterruptedSDK:
+    """External SDK buffer, grounded in its documented interrupt contract.
+
+    https://code.claude.com/docs/en/agent-sdk/python#example-using-interrupts
+    Interrupt leaves the interrupted ResultMessage in the shared stream. The
+    next query must not mistake it for its own result. A real worker-loss run
+    observed precisely that old error_during_execution result on the next turn.
+    """
+
+    def __init__(self, interrupt_outcome: str = "result") -> None:
+        self.messages: deque[object] = deque()
+        self.queries: list[str] = []
+        self.closed_readers = 0
+        self.active_readers = 0
+        self.interrupt_outcome = interrupt_outcome
+        self.waiting: anyio.Event | None = None
+
+    def deliver(self, message: object) -> None:
+        self.messages.append(message)
+        if self.waiting is not None:
+            self.waiting.set()
+
+    async def connect(self) -> None: ...
+
+    async def disconnect(self) -> None: ...
+
+    def result(self, text: str, *, interrupted: bool = False) -> ResultMessage:
+        return ResultMessage(
+            subtype="error_during_execution" if interrupted else "success",
+            duration_ms=1,
+            duration_api_ms=1,
+            is_error=interrupted,
+            num_turns=1,
+            session_id="synthetic-buffered-session",
+            result=text,
+        )
+
+    async def query(self, text: str) -> None:
+        self.queries.append(text)
+        if text == "first":
+            self.deliver(AssistantMessage(
+                content=[ToolUseBlock(id="synthetic-read", name="Read", input={})],
+                model="synthetic-model",
+            ))
+        else:
+            self.deliver(self.result("fresh response for " + text))
+
+    async def interrupt(self) -> None:
+        if self.interrupt_outcome == "result":
+            self.deliver(self.result("old interrupted response", interrupted=True))
+        elif self.interrupt_outcome == "error":
+            self.deliver(RuntimeError("synthetic-private-SDK-error"))
+        elif self.interrupt_outcome == "eof":
+            self.deliver(None)
+
+    async def receive_response(self):
+        self.active_readers += 1
+        try:
+            assert self.active_readers == 1, "two consumers entered one SDK stream"
+            while True:
+                if not self.messages:
+                    self.waiting = anyio.Event()
+                    await self.waiting.wait()
+                    self.waiting = None
+                message = self.messages.popleft()
+                if message is None:
+                    return
+                if isinstance(message, Exception):
+                    raise message
+                yield message
+                if isinstance(message, ResultMessage):
+                    return
+        finally:
+            self.active_readers -= 1
+            self.closed_readers += 1
+
+
+def _buffered_sdk_runner(monkeypatch, sdk: _BufferedInterruptedSDK) -> SessionRunner:
+    monkeypatch.setattr(adapter_module, "ClaudeSDKClient", lambda _options: sdk)
+    return SessionRunner(
+        session_factory=lambda: adapter_module.ClaudeAgentSession(ClaudeAgentOptions()),
+        ceiling=0,
+        tracer=RunTracer(None),
+        classifier=SideEffectClassifier(),
+        trace_name="buffered-interrupt",
+    )
+
+
+async def _abandon_buffered_turn(runner: SessionRunner) -> None:
+    first = runner.run_turn(Event(type="message", text="first", user="U", ts="1"))
+    with anyio.fail_after(2):
+        async for line in first:
+            if any(event.type == "tool_note" for event in parse_ndjson(line)):
+                break
+    await first.aclose()
+
+
+@pytest.mark.parametrize("check_closed_first", [False, True])
+def test_abandoned_sdk_response_cannot_become_the_next_turn_result(
+    monkeypatch, check_closed_first: bool
+) -> None:
+    sdk = _BufferedInterruptedSDK()
+    runner = _buffered_sdk_runner(monkeypatch, sdk)
+
+    async def go() -> None:
+        await runner.start()
+        await _abandon_buffered_turn(runner)
+        # Closing the actual session consumer must synchronously retire its SDK
+        # reader. GC on a later task cannot establish response ownership.
+        if check_closed_first:
+            assert sdk.closed_readers == 1
+        with anyio.fail_after(2):
+            lines = [line async for line in runner.run_turn(
+                Event(type="message", text="second", user="U", ts="2")
+            )]
+        events = parse_ndjson("".join(lines))
+        assert events[-1].status == SessionStatus.DONE
+        assert events[-1].text == "fresh response for second"
+        assert sdk.queries == ["first", "second"]
+        assert not any(event.type == "error" for event in events)
+        await runner.close()
+
+    anyio.run(go)
+
+
+@pytest.mark.parametrize("interrupt_outcome", ["missing", "error", "eof"])
+def test_unsettled_sdk_response_refuses_new_query_and_can_recover(
+    monkeypatch, interrupt_outcome: str
+) -> None:
+    sdk = _BufferedInterruptedSDK(interrupt_outcome)
+    runner = _buffered_sdk_runner(monkeypatch, sdk)
+    monkeypatch.setattr(adapter_module, "_RESPONSE_DRAIN_TIMEOUT_S", 0.01)
+
+    async def go() -> None:
+        await runner.start()
+        await _abandon_buffered_turn(runner)
+        with anyio.fail_after(1):
+            lines = [line async for line in runner.run_turn(
+                Event(type="message", text="must not submit", user="U", ts="2")
+            )]
+        events = parse_ndjson("".join(lines))
+        assert events[-1].status == SessionStatus.CLASSIFIED_FAILURE
+        assert sdk.queries == ["first"]
+        assert "synthetic-private-SDK-error" not in "".join(lines)
+        # A later actual boundary repairs this stream; the refused request was
+        # never submitted, so no response for it can be misattributed afterward.
+        sdk.messages.append(sdk.result("old interrupted response", interrupted=True))
+        with anyio.fail_after(1):
+            lines = [line async for line in runner.run_turn(
+                Event(type="message", text="recovered", user="U", ts="3")
+            )]
+        final = parse_ndjson("".join(lines))[-1]
+        assert final.status == SessionStatus.DONE
+        assert final.text == "fresh response for recovered"
+        assert sdk.queries == ["first", "recovered"]
+        await runner.close()
+
+    anyio.run(go)
+
+
+def test_active_sdk_steer_keeps_one_reader_and_normal_terminal_reuse(monkeypatch) -> None:
+    sdk = _BufferedInterruptedSDK()
+    runner = _buffered_sdk_runner(monkeypatch, sdk)
+
+    async def go() -> None:
+        await runner.start()
+        first = runner.run_turn(Event(type="message", text="first", user="U", ts="1"))
+        with anyio.fail_after(2):
+            async for line in first:
+                if any(event.type == "tool_note" for event in parse_ndjson(line)):
+                    break
+            assert await runner.steer("steered")
+            lines = [line async for line in first]
+        assert parse_ndjson("".join(lines))[-1].text == "fresh response for steered"
+        with anyio.fail_after(2):
+            lines = [line async for line in runner.run_turn(
+                Event(type="message", text="next normal", user="U", ts="2")
+            )]
+        final = parse_ndjson("".join(lines))[-1]
+        assert final.status == SessionStatus.DONE
+        assert final.text == "fresh response for next normal"
+        assert sdk.queries == ["first", "steered", "next normal"]
+        await runner.close()
+
+    anyio.run(go)
+
+
+def test_cancelled_sdk_drain_keeps_the_old_response_boundary_required(monkeypatch) -> None:
+    sdk = _BufferedInterruptedSDK("missing")
+    runner = _buffered_sdk_runner(monkeypatch, sdk)
+
+    async def go() -> None:
+        await runner.start()
+        await _abandon_buffered_turn(runner)
+        with anyio.move_on_after(0.01) as cancelled:
+            async for _line in runner.run_turn(
+                Event(type="message", text="cancelled before query", user="U", ts="2")
+            ):
+                pass
+        assert cancelled.cancel_called
+        assert sdk.queries == ["first"]
+        sdk.messages.append(sdk.result("old interrupted response", interrupted=True))
+        with anyio.fail_after(1):
+            lines = [line async for line in runner.run_turn(
+                Event(type="message", text="after cancellation", user="U", ts="3")
+            )]
+        final = parse_ndjson("".join(lines))[-1]
+        assert final.status == SessionStatus.DONE
+        assert final.text == "fresh response for after cancellation"
+        assert sdk.queries == ["first", "after cancellation"]
+        await runner.close()
+
+    anyio.run(go)
+
+
+@pytest.mark.parametrize("cancel_steer", [False, True])
+def test_steer_during_sdk_drain_refuses_without_reader_or_query(
+    monkeypatch, cancel_steer: bool
+) -> None:
+    sdk = _BufferedInterruptedSDK("missing")
+    runner = _buffered_sdk_runner(monkeypatch, sdk)
+
+    async def go() -> None:
+        await runner.start()
+        await _abandon_buffered_turn(runner)
+        lines: list[str] = []
+
+        async def next_turn() -> None:
+            async for line in runner.run_turn(
+                Event(type="message", text="second", user="U", ts="2")
+            ):
+                lines.append(line)
+
+        with anyio.fail_after(2):
+            async with TestClient(TestServer(create_app(runner))) as client:
+                fallback = None
+                async with anyio.create_task_group() as tasks:
+                    tasks.start_soon(next_turn)
+                    while sdk.waiting is None:
+                        await anyio.sleep(0)
+                    if cancel_steer:
+                        with anyio.CancelScope() as scope:
+                            scope.cancel()
+                            await runner.steer("cancelled steer")
+                        assert scope.cancelled_caught
+                    else:
+                        frame = {"kind": "event", "type": "message", "user": "U",
+                                 "ts": "3", "text": "steer during drain"}
+                        response = await client.post("/v1/steer", json=frame)
+                        assert response.status == 409
+                        assert "/v1/event" in (await response.json())["error"]
+                        # Exercise the existing fallback through real HTTP. Its
+                        # headers return while the first turn still owns its lock;
+                        # the SDK submission waits for that turn to finish.
+                        fallback = await client.post("/v1/event", json=frame)
+                        assert fallback.status == 200
+                    assert sdk.queries == ["first"]
+                    assert sdk.active_readers == 1
+                    sdk.deliver(sdk.result("old interrupted response", interrupted=True))
+                final = parse_ndjson("".join(lines))[-1]
+                assert final.status == SessionStatus.DONE
+                assert final.text == "fresh response for second"
+                if fallback is not None:
+                    final = parse_ndjson(await fallback.text())[-1]
+                    assert final.status == SessionStatus.DONE
+                    assert final.text == "fresh response for steer during drain"
+                    assert sdk.queries == ["first", "second", "steer during drain"]
+                else:
+                    assert sdk.queries == ["first", "second"]
+        assert sdk.active_readers == 0
+        await runner.close()
+
+    anyio.run(go)
+
+
+def test_steer_cannot_outlive_a_failed_drain_and_poison_the_next_turn(monkeypatch) -> None:
+    sdk = _BufferedInterruptedSDK("missing")
+    runner = _buffered_sdk_runner(monkeypatch, sdk)
+    monkeypatch.setattr(adapter_module, "_RESPONSE_DRAIN_TIMEOUT_S", 0.05)
+
+    async def go() -> None:
+        await runner.start()
+        await _abandon_buffered_turn(runner)
+        failed_lines: list[str] = []
+        failed_turn_finished = anyio.Event()
+        steer_results: list[bool] = []
+
+        async def refused_turn() -> None:
+            async for line in runner.run_turn(
+                Event(type="message", text="second", user="U", ts="2")
+            ):
+                failed_lines.append(line)
+            failed_turn_finished.set()
+
+        async def late_steer() -> None:
+            steer_results.append(await runner.steer("late steer"))
+
+        with anyio.fail_after(2):
+            async with anyio.create_task_group() as tasks:
+                tasks.start_soon(refused_turn)
+                while sdk.waiting is None:
+                    await anyio.sleep(0)
+                tasks.start_soon(late_steer)
+                await failed_turn_finished.wait()
+                assert parse_ndjson("".join(failed_lines))[-1].status == (
+                    SessionStatus.CLASSIFIED_FAILURE
+                )
+                assert runner.turn_active is False
+                # A terminal arriving after the owning turn failed must not
+                # authorize a previously queued steer to submit on its behalf.
+                sdk.deliver(sdk.result("late old boundary", interrupted=True))
+        assert steer_results == [False]
+        assert sdk.queries == ["first"]
+        with anyio.fail_after(2):
+            lines = [line async for line in runner.run_turn(
+                Event(type="message", text="third", user="U", ts="3")
+            )]
+        final = parse_ndjson("".join(lines))[-1]
+        assert final.status == SessionStatus.DONE
+        assert final.text == "fresh response for third"
+        assert sdk.queries == ["first", "third"]
+        assert sdk.active_readers == 0
+        await runner.close()
+
+    anyio.run(go)
 
 
 def test_cross_task_abandon_does_not_wedge_turn_lock() -> None:


### PR DESCRIPTION
## Summary

An abandoned runner response could leave the SDK's interrupted result queued for the next turn. The runner now closes the response reader, consumes the pending result boundary before admitting another query, and refuses a new query when that boundary cannot be established. Turn cleanup preserves the existing timeout and interruption outcomes.

The live ladder's failure control retained an OpenRouter credential, allowing its deliberately invalid endpoint to produce a successful model reply. The control now installs a placeholder and restores the original credential value and presence afterward. Hosted MCP probing waits up to 30 seconds for connection-refused startup; HTTP/auth/protocol errors and unexpected tools still fail.

## Related issue

No issue is closed by this PR.

## Fix pin verification

Fix pin: cli/tests/nightly_graded_ladder.rs::runner_failure_control_replaces_and_restores_provider_credential

The local fix-pin wrapper remains pending. The new ladder selectors failed against the unchanged script before correction. Exact final-head fix-pin and CI results remain acceptance gates.

## Verification

Candidate: `1b1fc918ea5ecbe4f77c47902fb3f3c671e641b4`, based on stable `0683760917b039085fa61dafa3ae019c064eec73`. The merge preserves all three runner files from `d751bdde4cf161912c03aaf875ed55ce960b3423` and both ladder files from `ec6d07030bdc8c076d46aa3c0fa8368bbbdfa588` byte for byte. Independent source-join review and `git diff --check` passed.

- Runner input: 826 tests passed with one explicit skip; 45 session tests passed. Controls cover interrupted-result draining, missing/error/end-of-stream refusal, cancelled drains, and the next healthy query. These are retained input results; final combined runtime acceptance remains pending.
- Ladder input: 40 tests passed in 30.11 seconds. The actual extracted shell control covers absent, empty and OpenRouter-shaped input with exact restoration. The Python MCP consumer covers delayed loopback startup, wrong tools and permanent refusal at the 30-second bound. Formatting and shell syntax checks passed.
- Published `ec6d0703` CI passed Python, Rust, image/binary builds and the fake parity ladder. Its cargo audit failed on `rsa 0.9.10` / `RUSTSEC-2023-0071`; current stable `06837609` has the identical finding and lockfile. This remains a blocking audit failure, and no ignore or dependency update is included here.
- Exact final-head CI, fix-pin and required live acceptance remain pending. Earlier integration-candidate observations do not establish acceptance of this stable candidate.

## End-to-end verification

| Tier | Required / n/a | Reason | Mode | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | required | SDK response lifecycle and connector initialization. | live | Exact-candidate interrupted-turn/next-query and connector positive/control pending. |
| local | required | Runner interruption and recreated worker failure-control environment. | live | Exact-candidate failure, recovery and hosted connector proof pending. |
| local-release | required | Released runner execution and connector observation under release Compose. | live | Exact-candidate released artifact proof pending. |
| cluster | required | SDK recovery inside a real sandbox and hosted connector observation. | live | Exact-candidate sandbox interruption/recovery and connector proof pending. |
| live provider | required | A real SDK result boundary and deliberately invalid model credential must be observed. | live | Interrupted/fresh query and invalid/restored credential pairs pending. |
| external integration | required | MCP initialize/tools-list must reach actual hosted connectors. | live | Actual connector ready/refusal proof pending. |

- [ ] Every required tier names its exact candidate and observed outcome.
- [x] Changed source paths have positive and negative/independent execution controls on their input commits.
- [ ] All required live tiers are proved. Pending runtime is a completion blocker.

## Checklist

- [x] Input regression results and unchanged source identities are recorded.
- [x] Product protocol and credential-routing policy are unchanged.
- [ ] Exact final-head CI, dependency audit and fix-pin pass.
- [ ] Required live acceptance passes before merge.
