### PR TITLE
Record a publication approval the SDK gate layers missed

### DIFF
--- a/docs/approvals.md
+++ b/docs/approvals.md
@@ -47,10 +47,15 @@ write-capable and is classified conservatively. Publication's dedicated approval
 and the state tools remain independent.
 
 **Permission gate.** Configuration marks a tool approval-required, and the runner denies
-the call through the SDK's `can_use_tool` callback before it runs. The denied call never
-executes. Two sources name gated tools and they are unioned, never subtracted: the
-bundle manifest's `approvalPolicy`, and the `CURIE_APPROVAL_REQUIRED_TOOLS` operator
-override.
+the call through its unscoped `PreToolUse` hook, with the SDK's `can_use_tool` callback as
+the second line, before it runs. The denied call never executes. Two sources name gated
+tools and they are unioned, never subtracted: the bundle manifest's `approvalPolicy`, and
+the `CURIE_APPROVAL_REQUIRED_TOOLS` operator override. For the platform's own
+`publish_changes` tool the runner additionally records every call it sees on the model
+stream (#2294): if neither SDK layer recorded the call, the in-sandbox tool body runs and
+returns its defensive error (it carries no publication authority), the stream record still
+parks the turn awaiting approval, and a publication call that left no record ends the turn
+as a `publication-unrecorded` classified failure rather than a clean `done`.
 
 ## Declaring routes in the bundle
 

--- a/docs/interfaces/approval/INTERFACE.md
+++ b/docs/interfaces/approval/INTERFACE.md
@@ -136,8 +136,9 @@ in code now:
   (`binding.approval_grant_tool`) decides grant eligibility from the **durable
   `gate_kind`/`granted_tool` columns** rather than sniffing the summary (ADR-0046 supersedes
   ADR-0035's summary-prefix discriminator): for a `gate_kind='permission'` row it injects
-  `CURIE_APPROVAL_GRANT_TOOL=<granted_tool>` (`GRANT_TOOL_ENV`, the exact tool name
-  `can_use_tool` denied, a trusted runner-authored value); for a `gate_kind='policy'` row it
+  `CURIE_APPROVAL_GRANT_TOOL=<granted_tool>` (`GRANT_TOOL_ENV`, the exact tool name a
+  runner gate layer denied or, for `publish_changes` only, the runner's own stream observer
+  recorded (#2294); a trusted runner-authored value either way); for a `gate_kind='policy'` row it
   injects the same `CURIE_APPROVAL_GRANT_TOOL` from the `granted_tool` column **when that
   column is non-null** — the runner sets it only for a manifest gate the operator opted into
   grantability via `grantableViaPolicy` (#558, ADR-0056), with the granted tool sourced from

--- a/runner/src/curie_runner/approval.py
+++ b/runner/src/curie_runner/approval.py
@@ -626,23 +626,77 @@ class ApprovalGate:
         # blocked call in the same turn must still assert that the runner asked
         # for a stop. Do not tidy this back inside the guard below.
         self.pending_halt = True
-        if self.pending_summary is None:
-            if tool_name == PUBLISH_TOOL_NAME:
-                title = tool_input.get("title")
-                body = tool_input.get("body", "")
-                if not isinstance(title, str) or not title.strip() or len(title) > 240:
-                    raise ValueError("publication title must be 1-240 characters")
-                if not isinstance(body, str) or len(body) > 65_536:
-                    raise ValueError("publication body must be at most 65536 characters")
-                self.publication_title = title.strip()
-                self.publication_body = body
-            self.pending_summary = summarize_tool_call(tool_name, tool_input)
-            self.pending_route = self.route_by_tool.get(tool_name)
-            # Provenance for the permission gate (#544, Decision C): the tool
-            # name here is the value ``can_use_tool`` itself denied -- the
-            # trusted grant target, never derived from the summary string.
-            self.pending_gate_kind = "permission"
-            self.pending_granted_tool = tool_name
+        self._record_pending(tool_name, tool_input)
+
+    def _record_pending(self, tool_name: str, tool_input: dict[str, Any]) -> bool:
+        """Write the first pending record of the turn; report whether it wrote.
+
+        Extracted from ``block`` so the stream-side observer
+        (``observe_publication``, #2294) writes the IDENTICAL record a denying
+        gate layer writes -- the worker recognizes a publication by exactly this
+        runner-stamped provenance pair (``pending_gate_kind='permission'`` plus
+        ``pending_granted_tool``), so two spellings of it would be two
+        behaviors. It does NOT touch ``pending_halt``: asking the CLI to stop is
+        the caller's decision, not the record's.
+
+        Returns False when a record already stands (first-block-wins), True when
+        this call created it. Raises ``ValueError`` on a malformed publication
+        proposal, before anything is recorded.
+        """
+
+        if self.pending_summary is not None:
+            return False
+        if tool_name == PUBLISH_TOOL_NAME:
+            title = tool_input.get("title")
+            body = tool_input.get("body", "")
+            if not isinstance(title, str) or not title.strip() or len(title) > 240:
+                raise ValueError("publication title must be 1-240 characters")
+            if not isinstance(body, str) or len(body) > 65_536:
+                raise ValueError("publication body must be at most 65536 characters")
+            self.publication_title = title.strip()
+            self.publication_body = body
+        self.pending_summary = summarize_tool_call(tool_name, tool_input)
+        self.pending_route = self.route_by_tool.get(tool_name)
+        # Provenance for the permission gate (#544, Decision C): the tool
+        # name here is the value ``can_use_tool`` itself denied -- the
+        # trusted grant target, never derived from the summary string.
+        self.pending_gate_kind = "permission"
+        self.pending_granted_tool = tool_name
+        return True
+
+    def observe_publication(self, tool_input: dict[str, Any]) -> bool:
+        """Record a publication request the runner saw on the STREAM (#2294).
+
+        The runner's own observer of a publication call, alongside the
+        PreToolUse hook (#1852) and ``can_use_tool`` (#245) rather than behind
+        them. Against the real SDK the stream reaches the session loop BEFORE
+        the CLI dispatches PreToolUse (observed live, #2294), so this is
+        normally the FIRST writer of the record and the hook's ``block`` then
+        finds it standing and only adds the halt marker; the fake tier inverts
+        that order, and there this call is the duplicate. It replaces neither
+        layer -- both still DECIDE the call, which this never does.
+
+        What it closes is the case where NEITHER layer recorded the call (a
+        hook that raised is reported and the call proceeds; a concurrently
+        dispatched bundle hook; an input shape a layer abstains on): the stream
+        still carries the ``ToolUseBlock``, and without this the turn finalizes
+        DONE with nothing for a human to approve.
+
+        It can only ever RECORD or raise -- it never returns an allow decision
+        and never mints a grant, so it cannot widen authority: ``safe_grant_tool``
+        already refuses a sandbox grant for the publish tool, and a second call
+        blocks again. It deliberately leaves ``pending_halt`` False: the runner
+        did not ask the CLI to stop this turn, and claiming otherwise would
+        relabel an unrelated failure as awaiting-approval.
+
+        Returns True when it created the pending record, False when one already
+        stands (an earlier call this turn, or a gate layer that got there first
+        on the fake tier -- exactly one record per turn either way). Raises
+        ``ValueError`` on a malformed title/body, identically to ``block``; the
+        session turns that into a fail-closed classified failure.
+        """
+
+        return self._record_pending(PUBLISH_TOOL_NAME, tool_input)
 
 
 class _GateDecision(NamedTuple):

--- a/runner/src/curie_runner/session.py
+++ b/runner/src/curie_runner/session.py
@@ -41,7 +41,7 @@ from curie_telemetry import record_metric
 from opentelemetry.context import Context
 
 from .adapter import ModelSession, PartialMessageBoundary, StreamedToolUseBoundary
-from .approval import ApprovalGate
+from .approval import PUBLISH_TOOL_NAME, ApprovalGate
 from .budget import BUDGET_CLASSIFICATION, BudgetTracker
 from .history import NullTranscriptStore, TranscriptStore, TurnRecord
 from .memory import (
@@ -89,6 +89,13 @@ APPROVAL_NOT_ACTED_CLASSIFICATION = "approval-not-acted"
 # substantive answer but no tool-call evidence. Rides the free-form
 # ErrorEvent.classification field like the markers above, so it is contract-safe.
 FALSE_COMPLETION_CLASSIFICATION = "false-completion"
+# The fail-closed classification for a publication call the runner observed on
+# the stream but could NOT record as a pending approval (#2294): a malformed
+# proposal, or a gate that does not carry the publication tool at all. Unlike
+# the two observe-only markers above this one is terminal -- it rides an
+# error+final pair, because a publication request that produced no approval
+# record must never finalize looking like a clean turn.
+PUBLICATION_UNRECORDED_CLASSIFICATION = "publication-unrecorded"
 
 
 def _is_auth_rejection(message: object) -> bool:
@@ -755,6 +762,11 @@ class SessionRunner:
                 tracker.add_increment(usage)
             budget_hit = tracker.exceeded
             events = translate_message(message, state, self._classifier, gen)
+            # Synchronous, on the very iteration that delivered the block and
+            # strictly before any ResultMessage iteration classifies the turn
+            # (#2294). Never a task, and nothing is awaited between observing a
+            # publication call and classifying the turn that made it.
+            self._observe_publication_calls(state)
             decided_result_final: Final | None = None
             if isinstance(message, ResultMessage):
                 terminal_reason = getattr(message, "terminal_reason", None)
@@ -803,6 +815,14 @@ class SessionRunner:
                         )
                     else:
                         final = decided_result_final
+                    unrecorded = self._publication_unrecorded_lines(state, final)
+                    if unrecorded:
+                        self._set_failed(gen)
+                        for line in unrecorded:
+                            yield line
+                        return
+                    self._log_publication_fallback_alone(state)
+                    self._log_publication_not_carried(state, final)
                     for line in self._approval_not_acted_lines(state, final):
                         yield line
                     for line in self._false_completion_lines(state, final):
@@ -852,6 +872,14 @@ class SessionRunner:
             status = SessionStatus.DONE
         self._merge_gate_block(state)
         final = _apply_approval_override(Final(text="", status=status), state)
+        unrecorded = self._publication_unrecorded_lines(state, final)
+        if unrecorded:
+            self._set_failed(gen)
+            for line in unrecorded:
+                yield line
+            return
+        self._log_publication_fallback_alone(state)
+        self._log_publication_not_carried(state, final)
         for line in self._approval_not_acted_lines(state, final):
             yield line
         for line in self._false_completion_lines(state, final):
@@ -867,6 +895,238 @@ class SessionRunner:
             completed_without_result=final.status is SessionStatus.AWAITING_APPROVAL,
         )
         yield to_ndjson_line(final)
+
+    def _observe_publication_calls(self, state: TurnState) -> None:
+        """Record every publication call the runner sees on the stream (#2294).
+
+        The runner's own observer, alongside the PreToolUse hook (#1852) and
+        ``can_use_tool`` (#245). Against the real SDK it is normally the FIRST
+        writer, not a rare backstop: the ``AssistantMessage`` carrying the
+        ``ToolUseBlock`` reaches this loop before the CLI dispatches PreToolUse
+        (observed live, #2294), so the hook's own ``block`` then finds the
+        record already standing and only adds its halt marker. The fake tier is
+        the inverted case -- its gate seam runs before the block is delivered,
+        so there the observation is the duplicate.
+
+        Either ordering yields exactly one record with identical fields, which
+        is the point. What this closes is the case the live run hit: neither SDK
+        layer recorded the call at all, the in-process tool body ran and
+        returned its defensive ``is_error``, and the turn was about to finalize
+        DONE with nothing for a human to approve.
+
+        It can only record or fail closed -- it never allows a call and never
+        mints a grant. Called on every message of the turn, it acts only on
+        calls it has not seen yet, and it is deliberately synchronous: the
+        record must stand before the ResultMessage iteration classifies the
+        turn (see the call site in ``_drive_turn``).
+
+        A call it cannot record stores the FIRST such reason in
+        ``state.publication_unrecorded``, for the fail-closed error message
+        ONLY. It is deliberately NOT sticky: observation continues over every
+        later call in the turn, because the gate's own deny text tells the model
+        to "Correct it and retry", so a malformed first attempt must not poison
+        the corrected record that follows it. Whether the turn actually fails
+        closed is decided from the OUTCOME at classification time -- see
+        ``_publication_unrecorded_lines``.
+        """
+
+        gate = self._approval_gate
+        while state.publication_calls_observed < len(state.publication_calls):
+            payload = state.publication_calls[state.publication_calls_observed]
+            state.publication_calls_observed += 1
+            if gate is None or PUBLISH_TOOL_NAME not in gate.required:
+                # The model named the publication tool where the platform has no
+                # gated checkout to publish from. Recording it anyway would ask a
+                # human to authorize an action that cannot exist, so fail closed.
+                state.publication_unrecorded = state.publication_unrecorded or (
+                    "the session carries no publication approval gate, so the"
+                    " request could not be recorded"
+                )
+                continue
+            try:
+                recorded = gate.observe_publication(payload)
+            except ValueError as exc:
+                # First reason wins for the message; the loop carries on so a
+                # corrected retry later in the same turn can still record.
+                state.publication_unrecorded = state.publication_unrecorded or str(exc)
+                continue
+            if recorded:
+                # Neutral wording, and NOT a warning: against the real SDK this
+                # observer is normally the FIRST writer, because the
+                # AssistantMessage carrying the ToolUseBlock reaches this loop
+                # before the CLI dispatches PreToolUse (observed live, #2294,
+                # session=live-publish-gated). Writing first proves nothing about
+                # whether a gate layer decided, so claiming "no layer recorded
+                # this" here fired on the fully gated path too. The real
+                # layer-missed signal is at turn end, in
+                # ``_log_publication_fallback_alone``.
+                logger.debug(
+                    "publication call observed on the stream and recorded session=%s",
+                    self._session_id,
+                )
+            else:
+                # A record already stands. On the fake tier that is the gate
+                # layer's (it runs before the block is delivered); on the real
+                # path it is this observer's own earlier call in the same turn.
+                logger.debug(
+                    "publication already recorded this turn session=%s",
+                    self._session_id,
+                )
+
+    def _log_publication_fallback_alone(self, state: TurnState) -> None:
+        """Warn when the stream observer was the ONLY layer that decided (#2294).
+
+        The honest "a gate layer missed this call" signal, and it can only be
+        computed at turn end. Per-call it is unknowable: against the real SDK the
+        stream delivers the ``ToolUseBlock`` to ``_drive_turn`` BEFORE the CLI
+        dispatches PreToolUse, so the observer writes first on every real
+        publication call, gated or not (observed live, #2294). Only the fake tier
+        runs its gate seam ahead of the block, so "the hook got there first"
+        describes that tier alone.
+
+        ``pending_halt`` is the discriminator: it is set by ``ApprovalGate.block``
+        and by nothing else, so ONLY the PreToolUse hook (#1852) or
+        ``can_use_tool`` (#245) can set it. The observer deliberately never does.
+        A turn that observed a publication call, ends holding its record, and
+        still has ``pending_halt`` False is therefore a turn in which neither SDK
+        layer denied the call -- the exact #2294 condition, and the one an
+        operator needs to see, because a gate that reports itself armed while
+        deciding nothing is the one they trust.
+
+        Called from the two Final emission sites, which are mutually exclusive
+        (each returns after yielding), so this logs at most once per turn.
+        Skipped on the interrupt/timeout paths: neither ran the gate to a
+        decision, so neither says anything about the layers.
+        """
+
+        gate = self._approval_gate
+        if (
+            not state.publication_calls
+            or gate is None
+            or gate.pending_summary is None
+            or gate.pending_granted_tool != PUBLISH_TOOL_NAME
+            or gate.pending_halt
+            or self._interrupt_requested
+            or self._timeout_requested
+        ):
+            return
+        logger.warning(
+            "publication stream fallback stood alone session=%s: neither the"
+            " PreToolUse hook nor can_use_tool denied this publication call;"
+            " the pending approval was recorded from the stream",
+            self._session_id,
+        )
+
+    def _log_publication_not_carried(self, state: TurnState, final: Final) -> None:
+        """Warn when a parked turn carries a DIFFERENT approval than the publish.
+
+        A turn has one pending approval slot, so a publication call can lose it
+        to a gated tool denied earlier in the turn or to a policy
+        ``request_approval`` (``_merge_gate_block`` never overwrites a standing
+        policy summary with a permission block). That is legitimate -- the turn
+        parks on a real decision and nothing is lost -- but the publish intent
+        does NOT ride the final, so after the human resolves the card the model
+        must ask to publish again. Silently dropping that is how a publication
+        request disappears without any operator-visible trace, so it is a
+        warning rather than a failure: failing the turn would discard the very
+        approval a human still has to act on.
+
+        Called from the two mutually exclusive Final emission sites, so it logs
+        at most once per turn.
+        """
+
+        if (
+            not state.publication_calls
+            or final.status is not SessionStatus.AWAITING_APPROVAL
+            or final.approval_granted_tool == PUBLISH_TOOL_NAME
+        ):
+            return
+        if state.publication_unrecorded is not None:
+            # Not slot contention: this request was never recordable in the
+            # first place (a malformed proposal, or a gate without the publish
+            # tool). Naming only the other approval here would misreport it and
+            # send an operator looking for a race that did not happen.
+            logger.warning(
+                "publication request not carried session=%s: the publication"
+                " request itself could not be recorded: %s; the turn is awaiting"
+                " a different approval (%s)",
+                self._session_id,
+                state.publication_unrecorded,
+                final.approval_granted_tool or final.approval_gate_kind or "unknown",
+            )
+            return
+        logger.warning(
+            "publication request not carried session=%s: the turn is awaiting a"
+            " different approval (%s); the model must request publication again"
+            " after it resolves",
+            self._session_id,
+            final.approval_granted_tool or final.approval_gate_kind or "unknown",
+        )
+
+    def _publication_unrecorded_lines(self, state: TurnState, final: Final) -> list[str]:
+        """The fail-closed error+final pair for an unrecordable publication (#2294).
+
+        Modeled on ``_auth_halt_lines``: a terminal pair, not an observe-only
+        warning frame. The runner saw a publication request and the turn is
+        ending with no pending approval to show for it, so the only safe report
+        is a classified failure carrying NO approval fields -- an approval card
+        with no usable proposal is worse than none, and a DONE final would be
+        the very silent hole #2294 closed.
+
+        **The decision is keyed on the FINAL about to be emitted, never on gate
+        state.** A turn holds exactly ONE pending approval slot
+        (``ApprovalGate._record_pending``'s first-block-wins rule, and
+        ``_merge_gate_block``'s preference for a standing policy summary), so
+        another approval can legitimately own it: a gated ``Bash`` call denied
+        before the publish call arrived, or a ``request_approval`` the model
+        raised in the same turn. Reading gate state would then rewrite a turn
+        that is correctly parked on a real human decision into a classified
+        failure, DESTROYING a card a human could have acted on -- a strictly
+        worse outcome than the silent DONE #2294 set out to fix. So an
+        AWAITING_APPROVAL final is never overridden; the unclaimed publish
+        intent is reported by ``_log_publication_not_carried`` instead.
+
+        A sticky "any attempt failed -> fail the turn" rule is wrong for the
+        same reason: the gate's deny text tells the model to "Correct it and
+        retry", so a malformed attempt followed by a corrected one must end
+        awaiting-approval on the record that stands.
+
+        Precedence is unchanged and deliberately narrow: a final that already
+        reports a classified failure keeps its own cause, and an operator
+        interrupt (or a timeout) outranks this entirely -- a human pressing stop
+        gets idle-awaiting-input, not a failure about a request their stop
+        already prevented. What is left is the real hole: publish calls were
+        observed and the turn is about to report a clean, unparked outcome.
+        """
+
+        if (
+            not state.publication_calls
+            or final.status is SessionStatus.AWAITING_APPROVAL
+            or final.status is SessionStatus.CLASSIFIED_FAILURE
+            or self._interrupt_requested
+            or self._timeout_requested
+        ):
+            return []
+        reason = state.publication_unrecorded or (
+            "the publication call was not recorded by any approval gate layer"
+        )
+        logger.error("publication request not recorded session=%s: %s", self._session_id, reason)
+        self._turn_open = False
+        self._status = SessionStatus.CLASSIFIED_FAILURE
+        return [
+            to_ndjson_line(
+                ErrorEvent(
+                    message=f"publication request was not recorded: {reason}",
+                    classification=PUBLICATION_UNRECORDED_CLASSIFICATION,
+                )
+            ),
+            to_ndjson_line(
+                Final(
+                    text="run failed: publication request could not be recorded",
+                    status=SessionStatus.CLASSIFIED_FAILURE,
+                )
+            ),
+        ]
 
     def _approval_not_acted_lines(self, state: TurnState, final: Final) -> list[str]:
         """The OBSERVE-ONLY reconciliation warning (#544, Decision A2).

--- a/runner/src/curie_runner/translate.py
+++ b/runner/src/curie_runner/translate.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import json
 from collections.abc import Mapping
 from dataclasses import dataclass, field
+from typing import Any
 
 from aci_protocol import (
     ErrorEvent,
@@ -38,7 +39,7 @@ from claude_agent_sdk import (
     UserMessage,
 )
 
-from .approval import APPROVAL_TOOL_NAME, guard_reserved_summary
+from .approval import APPROVAL_TOOL_NAME, PUBLISH_TOOL_NAME, guard_reserved_summary
 from .otel import _GenerationSpan
 from .side_effects import SideEffectClassifier
 
@@ -106,6 +107,26 @@ class TurnState:
     # reported as errored *because we interrupted it*, instead of reporting a
     # failure with nothing to approve.
     approval_halt_requested: bool = False
+    # The raw ``ToolUseBlock.input`` of every publication call seen on the
+    # stream this turn (#2294), in call order. Captured here, decided in
+    # ``SessionRunner._observe_publication_calls``: this module stays pure and
+    # never touches the ApprovalGate, so the same seam serves the live turn and
+    # the offline fake. Not a rare path: against the real SDK the stream reaches
+    # the session before the CLI dispatches PreToolUse, so this list is what
+    # normally writes the record first and the hook's own block then finds it
+    # standing. It is load-bearing for the case where neither SDK layer recorded
+    # the call at all and the turn would otherwise finalize DONE with nothing to
+    # approve.
+    publication_calls: list[dict[str, Any]] = field(default_factory=list)
+    # How many of ``publication_calls`` the session has already acted on, so the
+    # observation runs exactly once per call even though it is invoked on every
+    # message of the turn.
+    publication_calls_observed: int = 0
+    # Why a publication call could NOT be recorded (a malformed proposal, or a
+    # gate that does not carry the publish tool). Runner-internal, never a wire
+    # field: the session turns it into a fail-closed classified failure, because
+    # a publication the runner cannot record must not look like a clean turn.
+    publication_unrecorded: str | None = None
 
 
 def translate_message(
@@ -172,6 +193,13 @@ def _translate_assistant(
                 # The SDK block says only that a tool interval should be
                 # inferred. It is not proof this runner executed the tool.
                 gen.tool_use(block.id, block.name)
+            if block.name == PUBLISH_TOOL_NAME:
+                # Wire-level capture only (#2294). The session decides what to
+                # do with it; recording it here would put gate state in a
+                # deliberately pure module.
+                state.publication_calls.append(
+                    block.input if isinstance(block.input, dict) else {}
+                )
             if block.name == APPROVAL_TOOL_NAME:
                 # A policy gate fired (ADR-0010). Capture the summary (and the
                 # optional route, #247) at the wire level so the real path

--- a/runner/tests/test_approval.py
+++ b/runner/tests/test_approval.py
@@ -929,6 +929,121 @@ def test_publish_tool_never_consumes_a_resume_grant_or_executes() -> None:
     anyio.run(go)
 
 
+def _managed_publish_gate() -> ApprovalGate:
+    """The exact gate a managed-workspace boot assembles (publish only)."""
+
+    gate = build_approval_gate(operator_tools=None, policy_routes={}, managed_workspace=True)
+    assert gate is not None
+    assert PUBLISH_TOOL_NAME in gate.required
+    return gate
+
+
+def test_observe_publication_records_the_pending_approval_without_a_halt() -> None:
+    # revert: drop observe_publication (or make it a no-op) -> this fails, and a
+    # publish call that neither gate layer saw leaves the turn with nothing to
+    # approve -- the #2294 defect. The record must be field-for-field what a hook
+    # block writes, because the worker keys the trusted publication path on that
+    # exact runner-stamped provenance.
+    gate = _managed_publish_gate()
+
+    recorded = gate.observe_publication({"title": "  Ship changes  ", "body": "Full body"})
+
+    assert recorded is True
+    assert gate.pending_summary is not None
+    assert gate.pending_summary.startswith(APPROVAL_SUMMARY_PREFIX)
+    assert PUBLISH_TOOL_NAME in gate.pending_summary
+    assert gate.pending_gate_kind == "permission"
+    assert gate.pending_granted_tool == PUBLISH_TOOL_NAME
+    # Platform-owned gate: the request thread owns the card, so no bundle route.
+    assert gate.pending_route is None
+    assert gate.publication_title == "Ship changes"
+    assert gate.publication_body == "Full body"
+    # The stream observer never ASKED the CLI to stop, so it must not claim it
+    # did: pending_halt is what rescues an error-shaped terminal result, and
+    # setting it here would relabel an unrelated failure as awaiting-approval.
+    assert gate.pending_halt is False
+
+
+def test_observe_publication_is_idempotent_for_a_duplicate_call() -> None:
+    # revert: let a second observation overwrite the record -> a model that calls
+    # publish_changes twice in one turn creates two approvals for one action, and
+    # the human resolves against the second while the first stays pending.
+    gate = _managed_publish_gate()
+    assert gate.observe_publication({"title": "First proposal", "body": "one"}) is True
+    first_summary = gate.pending_summary
+
+    second = gate.observe_publication({"title": "Second proposal", "body": "two"})
+
+    assert second is False
+    assert gate.pending_summary == first_summary
+    assert gate.publication_title == "First proposal"
+    assert gate.publication_body == "one"
+    assert gate.pending_halt is False
+
+
+def test_observe_publication_rejects_a_malformed_title_and_records_nothing() -> None:
+    # revert: swallow the validation (or record the raw input) -> a blank-titled
+    # proposal becomes an approval card a human cannot act on, and the worker
+    # captures a patch with no title. The session turns this raise into a
+    # fail-closed classified failure; it must never be a silent pass.
+    gate = _managed_publish_gate()
+
+    with pytest.raises(ValueError):
+        gate.observe_publication({"title": "   ", "body": "ignored"})
+
+    assert gate.pending_summary is None
+    assert gate.pending_granted_tool is None
+    assert gate.publication_title is None
+    assert gate.publication_body is None
+    assert gate.pending_halt is False
+
+
+def test_observe_publication_never_overwrites_a_hook_recorded_block() -> None:
+    # revert: record unconditionally -> when the PreToolUse hook DID fire (the
+    # normal path) the stream observer would overwrite the hook's record and drop
+    # its halt-backed provenance, turning the working path into a second one.
+    gate = _managed_publish_gate()
+    gate.block(PUBLISH_TOOL_NAME, {"title": "Hook recorded", "body": "hook body"})
+    hook_summary = gate.pending_summary
+
+    assert gate.observe_publication({"title": "Stream observed", "body": "stream body"}) is False
+
+    assert gate.pending_summary == hook_summary
+    assert gate.publication_title == "Hook recorded"
+    assert gate.publication_body == "hook body"
+    assert gate.pending_gate_kind == "permission"
+    assert gate.pending_granted_tool == PUBLISH_TOOL_NAME
+    # The hook's own halt marker survives untouched: the observer only ever adds
+    # a record, it never edits what another layer already decided.
+    assert gate.pending_halt is True
+
+
+def test_observe_publication_never_mints_a_grant() -> None:
+    # revert: have observe_publication set (or restore) grant_tool, or let the
+    # publish tool consume a grant -> this fails. The observer is the one gate
+    # layer that can never ALLOW: publication happens outside the sandbox after
+    # approval, so an injected or stale grant must never let a second call walk
+    # through, and recording a request must never mint the allowance for it.
+    gate = build_approval_gate(
+        operator_tools=None,
+        policy_routes={},
+        grant_tool=PUBLISH_TOOL_NAME,
+        managed_workspace=True,
+    )
+    assert gate is not None
+    # build_approval_gate already refuses to carry a publish grant (safe_grant_tool).
+    assert gate.grant_tool is None
+
+    assert gate.observe_publication({"title": "Ship changes", "body": "body"}) is True
+
+    assert gate.grant_tool is None
+    assert gate.consume_grant(PUBLISH_TOOL_NAME) is False
+    # And the record it wrote is still the one-per-turn record: a second call
+    # blocks again rather than being waved through.
+    assert gate.observe_publication({"title": "Ship changes", "body": "body"}) is False
+    assert gate.pending_granted_tool == PUBLISH_TOOL_NAME
+
+
 def test_build_approval_gate_carries_the_grant_tool() -> None:
     """The ADR-0035/0046 one-shot grant still reaches the gate unchanged."""
 

--- a/runner/tests/test_approval_gate_enforcement.py
+++ b/runner/tests/test_approval_gate_enforcement.py
@@ -74,8 +74,11 @@ from curie_runner.approval import (
     _DENY_MESSAGE,
     APPROVAL_SERVER_NAME,
     APPROVAL_SUMMARY_PREFIX,
+    APPROVAL_TOOL_NAME,
+    PUBLISH_TOOL_NAME,
     ApprovalGate,
     ApprovalPolicyError,
+    build_approval_gate,
     build_approval_hook,
     build_can_use_tool,
 )
@@ -1132,3 +1135,601 @@ def test_permission_result_deny_still_carries_an_interrupt_field() -> None:
     fields = {f.name for f in dataclasses.fields(PermissionResultDeny)}
     assert {"message", "interrupt"} <= fields
     assert PermissionResultDeny().interrupt is False  # the default we must override
+
+
+# --- L. the runner-owned stream fallback for publication (#2294) -----------------
+#
+# Both SDK-level gate layers can miss a call: ``can_use_tool`` is skipped whenever
+# another permission rule already allowed it, and the PreToolUse hook was observed
+# live NOT to gate an in-process ``mcp__curie__*`` call. When both miss, the
+# stream still carries the ``ToolUseBlock`` -- so the runner itself observes it and
+# either records the pending approval or fails the turn closed. It can never allow.
+
+
+def _publish_block(
+    title: str = "Ship changes",
+    body: str = "The proposed change.",
+    *,
+    call_id: str = "p1",
+) -> AssistantMessage:
+    return AssistantMessage(
+        content=[
+            ToolUseBlock(
+                id=call_id,
+                name=PUBLISH_TOOL_NAME,
+                input={"title": title, "body": body},
+            )
+        ],
+        model="m",
+    )
+
+
+def _publish_then_clean_done(
+    title: str = "Ship changes", body: str = "The proposed change."
+) -> list[Any]:
+    """The observed live shape: the publish call runs, then the turn ends clean.
+
+    Neither gate layer denied, so the in-process tool body executed and returned
+    its defensive ``is_error`` result; the model then finished its turn normally
+    and the CLI reported a SUCCESS terminal result. Before #2294 that finalized
+    DONE with no approval record at all.
+    """
+
+    return [
+        _publish_block(title, body),
+        AssistantMessage(content=[TextBlock(text="I requested publication.")], model="m"),
+        ResultMessage(
+            subtype="success",
+            duration_ms=1,
+            duration_api_ms=1,
+            is_error=False,
+            num_turns=1,
+            session_id="s",
+            result="I requested publication.",
+        ),
+    ]
+
+
+def _managed_publish_gate() -> ApprovalGate:
+    """The gate a managed-workspace boot assembles: publish is the only member."""
+
+    gate = build_approval_gate(operator_tools=None, policy_routes={}, managed_workspace=True)
+    assert gate is not None
+    assert PUBLISH_TOOL_NAME in gate.required
+    return gate
+
+
+def _run_lines(runner: SessionRunner) -> list[str]:
+    lines: list[str] = []
+
+    async def go() -> None:
+        await runner.start()
+        async for line in runner.run_turn(Event(type="message", text="go", user="U", ts="1")):
+            lines.append(line)
+
+    anyio.run(go)
+    return lines
+
+
+def test_publish_call_neither_gate_layer_saw_still_pauses_awaiting_approval(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # revert: drop _observe_publication_calls from _drive_turn -> this fails with
+    # status == done and no approval_summary, which is the verbatim #2294 live
+    # observation: the tool body ran, returned its defensive is_error, and the
+    # turn finalized DONE with nothing for a human to approve.
+    #
+    # NO can_use_tool is wired here on purpose: that models BOTH SDK layers
+    # skipping the call (the hook did not gate the in-process MCP tool, and the
+    # callback was never consulted). The stream is then the only observer left.
+    gate = _managed_publish_gate()
+    runner, _session = _runner_over(_publish_then_clean_done(), gate=gate)
+
+    with caplog.at_level(logging.WARNING, logger="curie_runner.session"):
+        lines = _run_lines(runner)
+
+    events = parse_ndjson("".join(lines))
+    final = events[-1]
+    assert final.type == "final"
+    assert final.status == SessionStatus.AWAITING_APPROVAL
+    assert final.status != SessionStatus.DONE
+    assert final.approval_summary
+    assert final.approval_summary.startswith(APPROVAL_SUMMARY_PREFIX)
+    assert PUBLISH_TOOL_NAME in final.approval_summary
+    # The trusted provenance pair the worker branches on before it captures a
+    # patch. A fallback record that stamped anything else would be inert.
+    assert final.approval_gate_kind == "permission"
+    assert final.approval_granted_tool == PUBLISH_TOOL_NAME
+    assert final.approval_route is None
+    assert gate.publication_title == "Ship changes"
+    assert gate.publication_body == "The proposed change."
+    assert runner.status == SessionStatus.AWAITING_APPROVAL
+    # No gate layer denied this call, so no layer asked the CLI to stop the turn.
+    # That absence is the ONLY honest signal that a layer missed the call: the
+    # real SDK streams the ToolUseBlock BEFORE it dispatches the PreToolUse hook,
+    # so "the observer wrote the record first" is true on the normal path too and
+    # cannot be what the warning below keys on.
+    assert gate.pending_halt is False
+
+    # Operator-visible, because this path means a gate layer that was supposed to
+    # decide did not: silently papering over that is how the next regression goes
+    # unnoticed for a whole release.
+    assert any(
+        "publication" in record.getMessage().lower()
+        and "fallback" in record.getMessage().lower()
+        for record in caplog.records
+    ), caplog.text
+
+
+def test_hook_recorded_publish_is_not_recorded_twice_by_the_stream(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # revert: record unconditionally in _observe_publication_calls -> the normal
+    # (working) path grows a second record, and the WARNING fires on every publish
+    # so it stops meaning "a gate layer missed this call".
+    gate = _managed_publish_gate()
+    runner, _session = _runner_over(
+        _publish_then_clean_done("Hook recorded", "hook body"),
+        gate=gate,
+        # The fake tier does not run PreToolUse hooks, so the callback seam is how
+        # a session-level test drives a hook-shaped block (see _recording_deny).
+        can_use_tool=_recording_deny(gate, interrupt=False),
+        truncate_on_interrupt=False,
+    )
+
+    with caplog.at_level(logging.WARNING, logger="curie_runner.session"):
+        lines = _run_lines(runner)
+
+    events = parse_ndjson("".join(lines))
+    final = events[-1]
+    assert final.status == SessionStatus.AWAITING_APPROVAL
+    assert final.approval_gate_kind == "permission"
+    assert final.approval_granted_tool == PUBLISH_TOOL_NAME
+    # Exactly one record, and it is the gate layer's own -- the observer added
+    # nothing on top of it.
+    assert gate.publication_title == "Hook recorded"
+    assert gate.publication_body == "hook body"
+    assert final.approval_summary == gate.pending_summary
+    assert gate.observe_publication({"title": "another", "body": "x"}) is False
+    assert gate.publication_title == "Hook recorded"
+    # A gate layer DID deny this call and asked the CLI to stop, which is exactly
+    # what distinguishes this path from the fallback one -- and why no warning
+    # about a missed layer may fire here.
+    assert gate.pending_halt is True
+    assert not any(
+        "fallback" in record.getMessage().lower() for record in caplog.records
+    ), caplog.text
+
+
+def test_malformed_publish_proposal_fails_the_turn_closed() -> None:
+    # revert: swallow the ValueError and let the turn finalize as it was -> a
+    # blank-titled publish call ends DONE with no approval record, which is the
+    # same silent hole #2294 closed, reached through the validation path instead.
+    # Failing closed is the only safe direction: the runner cannot record the
+    # approval, so it must not let the turn look like it succeeded.
+    from curie_runner.session import PUBLICATION_UNRECORDED_CLASSIFICATION
+
+    gate = _managed_publish_gate()
+    runner, _session = _runner_over(_publish_then_clean_done(title="   "), gate=gate)
+
+    events = parse_ndjson("".join(_run_lines(runner)))
+
+    classifications = [e.classification for e in events if e.type == "error"]
+    assert PUBLICATION_UNRECORDED_CLASSIFICATION in classifications
+    unrecorded = next(
+        e
+        for e in events
+        if e.type == "error" and e.classification == PUBLICATION_UNRECORDED_CLASSIFICATION
+    )
+    assert "title" in (unrecorded.message or "").lower()
+    final = events[-1]
+    assert final.type == "final"
+    assert final.status == SessionStatus.CLASSIFIED_FAILURE
+    assert final.status != SessionStatus.AWAITING_APPROVAL
+    # A fail-closed turn carries NO approval fields: there is nothing a human
+    # could resolve, and a card with an empty title is worse than none.
+    assert final.approval_summary is None
+    assert final.approval_gate_kind is None
+    assert final.approval_granted_tool is None
+    assert gate.pending_summary is None
+    assert runner.status == SessionStatus.CLASSIFIED_FAILURE
+
+
+def test_two_publish_calls_in_one_turn_record_exactly_one_approval() -> None:
+    # revert: record every observed call -> one action produces two approval
+    # cards, and a human resolving the second leaves the first pending forever.
+    # The FIRST proposal wins, matching ApprovalGate.block's first-block-wins rule.
+    gate = _managed_publish_gate()
+    script = [
+        _publish_block("First proposal", "one", call_id="p1"),
+        _publish_block("Second proposal", "two", call_id="p2"),
+        AssistantMessage(content=[TextBlock(text="Requested twice.")], model="m"),
+        ResultMessage(
+            subtype="success",
+            duration_ms=1,
+            duration_api_ms=1,
+            is_error=False,
+            num_turns=1,
+            session_id="s",
+            result="Requested twice.",
+        ),
+    ]
+    runner, _session = _runner_over(script, gate=gate)
+
+    events = parse_ndjson("".join(_run_lines(runner)))
+
+    final = events[-1]
+    assert final.status == SessionStatus.AWAITING_APPROVAL
+    assert gate.publication_title == "First proposal"
+    assert gate.publication_body == "one"
+    assert "First proposal" in (final.approval_summary or "")
+    assert "Second proposal" not in (final.approval_summary or "")
+
+
+def test_publish_call_on_a_gate_that_does_not_carry_publish_fails_closed() -> None:
+    # revert: record the publication anyway when the tool is not gated -> a model
+    # that names publish_changes where it is not mounted (no managed workspace)
+    # mints an approval for an action the platform has no checkout to perform,
+    # and an approver would be asked to authorize a publication that cannot exist.
+    # Never AWAITING_APPROVAL, never DONE: fail closed.
+    from curie_runner.session import PUBLICATION_UNRECORDED_CLASSIFICATION
+
+    gate = build_approval_gate(operator_tools=["Bash"], policy_routes={})
+    assert gate is not None
+    assert PUBLISH_TOOL_NAME not in gate.required
+    runner, _session = _runner_over(_publish_then_clean_done(), gate=gate)
+
+    events = parse_ndjson("".join(_run_lines(runner)))
+
+    assert any(
+        e.type == "error" and e.classification == PUBLICATION_UNRECORDED_CLASSIFICATION
+        for e in events
+    ), [e.type for e in events]
+    final = events[-1]
+    assert final.status == SessionStatus.CLASSIFIED_FAILURE
+    assert final.status != SessionStatus.AWAITING_APPROVAL
+    assert final.approval_summary is None
+    assert gate.pending_summary is None
+    assert gate.publication_title is None
+
+
+def test_operator_interrupt_outranks_a_stream_recorded_publication() -> None:
+    # negative control for L: the observer records, it never decides the turn's
+    # status. A human pressing stop is an intentional stop -- reporting it as
+    # awaiting-approval would suspend the thread behind a decision nobody asked
+    # for. revert: set pending_halt in observe_publication, or apply the approval
+    # override ahead of _reclassify -> this fails with awaiting-approval.
+    gate = _managed_publish_gate()
+    runner, session = _runner_over(_publish_then_clean_done(), gate=gate)
+
+    lines: list[str] = []
+
+    async def go() -> None:
+        await runner.start()
+        gen = runner.run_turn(Event(type="message", text="go", user="U", ts="1"))
+        lines.append(await gen.__anext__())  # first frame; the turn is live
+        await runner.interrupt("user stop")  # the operator's own stop
+        async for line in gen:
+            lines.append(line)
+
+    anyio.run(go)
+    events = parse_ndjson("".join(lines))
+
+    # Not vacuous: the fallback really did record this publication, so the ONLY
+    # thing keeping the turn out of awaiting-approval is the operator's stop.
+    assert gate.pending_summary is not None
+    assert gate.publication_title == "Ship changes"
+    assert gate.pending_halt is False
+    assert session.interrupts >= 1
+    assert events[-1].type == "final"
+    assert events[-1].status == SessionStatus.IDLE_AWAITING_INPUT
+
+
+def test_malformed_publish_followed_by_a_valid_one_pauses_on_the_valid_record() -> None:
+    # revert (the mutation this kills): make state.publication_unrecorded sticky,
+    # i.e. skip every later publish call once one failed to record -> this fails
+    # with classified-failure, and a model that did exactly what the deny message
+    # told it to ("Correct it and retry") loses the corrected request. The
+    # fail-closed rule keys on the OUTCOME at classification time -- did the gate
+    # end the turn holding a publication record? -- not on whether some earlier
+    # attempt was malformed.
+    from curie_runner.session import PUBLICATION_UNRECORDED_CLASSIFICATION
+
+    gate = _managed_publish_gate()
+    script = [
+        _publish_block("   ", "first attempt", call_id="p1"),
+        _publish_block("Ship changes", "the corrected proposal", call_id="p2"),
+        AssistantMessage(content=[TextBlock(text="Requested publication.")], model="m"),
+        ResultMessage(
+            subtype="success",
+            duration_ms=1,
+            duration_api_ms=1,
+            is_error=False,
+            num_turns=1,
+            session_id="s",
+            result="Requested publication.",
+        ),
+    ]
+    runner, _session = _runner_over(script, gate=gate)
+
+    events = parse_ndjson("".join(_run_lines(runner)))
+
+    assert not any(
+        e.type == "error" and e.classification == PUBLICATION_UNRECORDED_CLASSIFICATION
+        for e in events
+    ), "a recorded publication must not also report itself unrecorded"
+    final = events[-1]
+    assert final.type == "final"
+    assert final.status == SessionStatus.AWAITING_APPROVAL
+    assert final.status != SessionStatus.CLASSIFIED_FAILURE
+    assert final.approval_gate_kind == "permission"
+    assert final.approval_granted_tool == PUBLISH_TOOL_NAME
+    # Exactly one record, and it is the VALID proposal -- not the malformed one,
+    # which never wrote anything.
+    assert gate.publication_title == "Ship changes"
+    assert gate.publication_body == "the corrected proposal"
+    assert final.approval_summary == gate.pending_summary
+    assert "Ship changes" in (final.approval_summary or "")
+    assert runner.status == SessionStatus.AWAITING_APPROVAL
+
+
+def test_hook_recorded_publish_survives_a_later_malformed_stream_observation() -> None:
+    # revert: validate the publication proposal BEFORE the first-record-wins guard
+    # in _record_pending -> this fails, because the malformed second call would
+    # raise on a turn that already holds a good record and fail the turn closed,
+    # discarding an approval a human could have acted on. A record that already
+    # stands is never re-derived from a later attempt.
+    from curie_runner.session import PUBLICATION_UNRECORDED_CLASSIFICATION
+
+    gate = _managed_publish_gate()
+    script = [
+        _publish_block("Ship changes", "the proposal", call_id="p1"),
+        _publish_block("", "second attempt", call_id="p2"),
+        AssistantMessage(content=[TextBlock(text="Requested publication.")], model="m"),
+        ResultMessage(
+            subtype="success",
+            duration_ms=1,
+            duration_api_ms=1,
+            is_error=False,
+            num_turns=1,
+            session_id="s",
+            result="Requested publication.",
+        ),
+    ]
+    runner, _session = _runner_over(
+        script,
+        gate=gate,
+        # The gate layer records the FIRST call, exactly as the PreToolUse hook
+        # does in production (the fake tier does not run hooks; see _recording_deny).
+        can_use_tool=_recording_deny(gate, interrupt=False),
+        truncate_on_interrupt=False,
+    )
+
+    events = parse_ndjson("".join(_run_lines(runner)))
+
+    assert not any(
+        e.type == "error" and e.classification == PUBLICATION_UNRECORDED_CLASSIFICATION
+        for e in events
+    ), "a later malformed attempt must not poison the record the hook already wrote"
+    final = events[-1]
+    assert final.type == "final"
+    assert final.status == SessionStatus.AWAITING_APPROVAL
+    assert final.status != SessionStatus.CLASSIFIED_FAILURE
+    assert final.approval_gate_kind == "permission"
+    assert final.approval_granted_tool == PUBLISH_TOOL_NAME
+    # The hook's own record, untouched by the second observation.
+    assert gate.publication_title == "Ship changes"
+    assert gate.publication_body == "the proposal"
+    assert final.approval_summary == gate.pending_summary
+    assert "Ship changes" in (final.approval_summary or "")
+
+
+def test_another_gated_tools_approval_is_kept_when_a_publish_call_cannot_take_the_slot(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # revert: fail the turn closed whenever the gate does not end holding a
+    # PUBLICATION record -> this fails with classified-failure, and the Bash
+    # approval a human could have acted on is destroyed by a publish call that
+    # merely arrived second. Exactly one record per turn is the gate's own
+    # first-block-wins rule (ApprovalGate._record_pending); a publish call losing
+    # that race is not evidence that anything went wrong, so the turn parks on
+    # the approval that DOES stand and the unclaimed publish intent is reported
+    # as a log line, not by discarding the card.
+    from curie_runner.session import PUBLICATION_UNRECORDED_CLASSIFICATION
+
+    gate = build_approval_gate(
+        operator_tools=["Bash"], policy_routes={}, managed_workspace=True
+    )
+    assert gate is not None
+    assert gate.required == frozenset({"Bash", PUBLISH_TOOL_NAME})
+    script = [
+        AssistantMessage(
+            content=[ToolUseBlock(id="b1", name="Bash", input={"command": "git status"})],
+            model="m",
+        ),
+        _publish_block("Ship changes", "the proposal", call_id="p1"),
+        ResultMessage(
+            subtype="success",
+            duration_ms=1,
+            duration_api_ms=1,
+            is_error=False,
+            num_turns=1,
+            session_id="s",
+            result="asked for both",
+        ),
+    ]
+    runner, _session = _runner_over(
+        script,
+        gate=gate,
+        can_use_tool=_recording_deny(gate, interrupt=False),
+        truncate_on_interrupt=False,
+    )
+
+    with caplog.at_level(logging.WARNING, logger="curie_runner.session"):
+        events = parse_ndjson("".join(_run_lines(runner)))
+
+    assert not any(
+        e.type == "error" and e.classification == PUBLICATION_UNRECORDED_CLASSIFICATION
+        for e in events
+    ), "a turn that ends holding an approval has not lost the human's decision"
+    final = events[-1]
+    assert final.type == "final"
+    assert final.status == SessionStatus.AWAITING_APPROVAL
+    assert final.status != SessionStatus.CLASSIFIED_FAILURE
+    assert final.approval_gate_kind == "permission"
+    assert final.approval_granted_tool == "Bash"
+    assert "git status" in (final.approval_summary or "")
+    # A gate layer denied the Bash call and asked the CLI to stop.
+    assert gate.pending_halt is True
+    # The publish intent did not make it onto the card, so it must be visible to
+    # an operator rather than silently dropped.
+    assert any(
+        "publication" in record.getMessage().lower()
+        and "not carried" in record.getMessage().lower()
+        for record in caplog.records
+    ), caplog.text
+
+
+def test_policy_approval_and_publish_in_one_turn_park_on_the_policy_request(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # revert: fail closed because the FINAL carries a policy approval rather than
+    # the publication record -> this fails with classified-failure, and a model
+    # that legitimately paged a human (request_approval) loses that card because
+    # it also asked to publish. _merge_gate_block's precedence (a policy summary
+    # already standing is never overwritten by a permission block) is pre-existing
+    # and unchanged here; what must not happen is the turn being failed for it.
+    from curie_runner.session import PUBLICATION_UNRECORDED_CLASSIFICATION
+
+    gate = _managed_publish_gate()
+    script = [
+        AssistantMessage(
+            content=[
+                ToolUseBlock(
+                    id="a1",
+                    name=APPROVAL_TOOL_NAME,
+                    input={"summary": "Approve the discount before I continue"},
+                )
+            ],
+            model="m",
+        ),
+        _publish_block("Ship changes", "the proposal", call_id="p1"),
+        ResultMessage(
+            subtype="success",
+            duration_ms=1,
+            duration_api_ms=1,
+            is_error=False,
+            num_turns=1,
+            session_id="s",
+            result="asked for both",
+        ),
+    ]
+    # approval_gate wires the fake to the SAME route-resolution decision table the
+    # real in-process request_approval tool runs (#561), so the policy flags
+    # _merge_gate_block reconciles are set exactly as they are in production.
+    runner, _session = _runner_over(script, gate=gate, approval_gate=gate)
+
+    with caplog.at_level(logging.WARNING, logger="curie_runner.session"):
+        events = parse_ndjson("".join(_run_lines(runner)))
+
+    assert not any(
+        e.type == "error" and e.classification == PUBLICATION_UNRECORDED_CLASSIFICATION
+        for e in events
+    ), "the turn ends on a real approval; nothing was lost to fail closed for"
+    final = events[-1]
+    assert final.type == "final"
+    assert final.status == SessionStatus.AWAITING_APPROVAL
+    assert final.status != SessionStatus.CLASSIFIED_FAILURE
+    # A policy gate authorizes a business decision, never a tool (#544, A/C), so
+    # it must not acquire a grant target from the publish call riding along.
+    assert final.approval_gate_kind == "policy"
+    assert final.approval_granted_tool is None
+    assert "discount" in (final.approval_summary or "")
+    assert any(
+        "publication" in record.getMessage().lower()
+        and "not carried" in record.getMessage().lower()
+        for record in caplog.records
+    ), caplog.text
+
+
+def test_publish_call_with_no_terminal_result_still_fails_closed() -> None:
+    # revert: drop the _publication_unrecorded_lines call from the ITERATOR-END
+    # Final site in _drive_turn (keeping only the ResultMessage one) -> this fails
+    # with status done. A turn whose generator simply ends without a terminal
+    # result still emits a final, and an unrecordable publication must fail it
+    # closed there too -- otherwise the silent hole #2294 closed reopens for every
+    # turn the CLI ends without a ResultMessage.
+    from curie_runner.session import PUBLICATION_UNRECORDED_CLASSIFICATION
+
+    gate = _managed_publish_gate()
+    # No ResultMessage at all: receive_turn is exhausted after this message, which
+    # is the second Final emission site in _drive_turn.
+    runner, _session = _runner_over([_publish_block("   ", "no title")], gate=gate)
+
+    events = parse_ndjson("".join(_run_lines(runner)))
+
+    unrecorded = [
+        e
+        for e in events
+        if e.type == "error" and e.classification == PUBLICATION_UNRECORDED_CLASSIFICATION
+    ]
+    assert len(unrecorded) == 1
+    assert "title" in (unrecorded[0].message or "").lower()
+    final = events[-1]
+    assert final.type == "final"
+    assert final.status == SessionStatus.CLASSIFIED_FAILURE
+    assert final.status != SessionStatus.DONE
+    assert final.approval_summary is None
+    assert final.approval_granted_tool is None
+    assert runner.status == SessionStatus.CLASSIFIED_FAILURE
+
+
+def test_operator_interrupt_outranks_an_unrecordable_publication() -> None:
+    # revert: drop the interrupt/timeout guard from _publication_unrecorded_lines
+    # -> this fails with classified-failure. A human pressing stop gets
+    # idle-awaiting-input, not a failure about a request their own stop
+    # prevented from ever being recorded; reporting it as a run failure would
+    # trip F1's escalation path on an intentional stop.
+    from curie_runner.session import PUBLICATION_UNRECORDED_CLASSIFICATION
+
+    gate = _managed_publish_gate()
+    runner, session = _runner_over(
+        [
+            _publish_block("   ", "no title"),
+            AssistantMessage(content=[TextBlock(text="never delivered")], model="m"),
+            ResultMessage(
+                subtype="success",
+                duration_ms=1,
+                duration_api_ms=1,
+                is_error=False,
+                num_turns=1,
+                session_id="s",
+                result="never delivered",
+            ),
+        ],
+        gate=gate,
+    )
+
+    lines: list[str] = []
+
+    async def go() -> None:
+        await runner.start()
+        gen = runner.run_turn(Event(type="message", text="go", user="U", ts="1"))
+        lines.append(await gen.__anext__())  # first frame; the turn is live
+        await runner.interrupt("user stop")  # the operator's own stop
+        async for line in gen:
+            lines.append(line)
+
+    anyio.run(go)
+    events = parse_ndjson("".join(lines))
+
+    # Not vacuous: the unrecordable call really was observed, so the ONLY thing
+    # keeping this out of classified-failure is the operator's stop.
+    assert session.interrupts >= 1
+    assert gate.pending_summary is None
+    assert not any(
+        e.type == "error" and e.classification == PUBLICATION_UNRECORDED_CLASSIFICATION
+        for e in events
+    )
+    assert events[-1].type == "final"
+    assert events[-1].status == SessionStatus.IDLE_AWAITING_INPUT

--- a/runner/tests/test_live.py
+++ b/runner/tests/test_live.py
@@ -9,6 +9,7 @@ course, and turn 2 shows a warm prompt cache
 A third live test covers the OpenRouter path, gated on ``OPENROUTER_API_KEY``.
 """
 
+import logging
 import os
 
 import anyio
@@ -16,6 +17,15 @@ import pytest
 from aci_protocol import Event, SessionStatus, parse_ndjson
 from curie_runner import RunTracer, SideEffectClassifier, build_options
 from curie_runner.adapter import ClaudeAgentSession
+from curie_runner.approval import (
+    APPROVAL_SERVER_NAME,
+    PUBLISH_TOOL_NAME,
+    ApprovalGate,
+    build_approval_gate,
+    build_approval_hook,
+    build_approval_server,
+    build_can_use_tool,
+)
 from curie_runner.session import SessionRunner
 
 _HAS_CRED = bool(os.environ.get("CLAUDE_CODE_OAUTH_TOKEN") or os.environ.get("ANTHROPIC_API_KEY"))
@@ -179,8 +189,6 @@ def test_live_permission_gate_pauses_awaiting_approval() -> None:
     approval-required is intercepted by can_use_tool (never executed) and the
     turn ends awaiting-approval with the blocked call in the summary."""
 
-    from curie_runner.approval import ApprovalGate, build_can_use_tool
-
     gate = ApprovalGate(required=frozenset({"Bash"}))
     options = build_options(
         plugins=[],
@@ -230,3 +238,170 @@ def test_live_permission_gate_pauses_awaiting_approval() -> None:
     # The blocked command never executed and never produced output text
     # claiming it ran; the summary records what WOULD have run.
     assert "echo curie-gate-live" in final.approval_summary
+
+
+# --- the managed-workspace publication gate on a real model (#2294) --------------
+#
+# Both tests mount the in-process ``curie`` MCP server carrying
+# ``publish_changes`` and ask the model to call it. They differ ONLY in whether
+# the two SDK-level gate layers are wired, which is exactly the difference
+# between the production shape and the live run that lost its approval record.
+
+
+def _live_model_and_env() -> tuple[str | None, dict[str, str] | None]:
+    """The model/env pair for a live run, preferring the OpenRouter path.
+
+    Mirrors ``test_live_openrouter_cache_reuse``: the OpenRouter key is fed
+    through ``resolve_model_credential`` into the SDK ``env`` exactly as the
+    runner does in production. With only an Anthropic credential present, the
+    ambient credential and default model are used instead.
+    """
+
+    from curie_runner.sdk_auth import CREDENTIALS_ENV, resolve_model_credential
+
+    if _OPENROUTER_KEY:
+        env: dict[str, str] = {CREDENTIALS_ENV: _OPENROUTER_KEY}
+        resolve_model_credential(env)
+        return os.environ.get("OPENROUTER_MODEL", "anthropic/claude-sonnet-4.5"), env
+    return None, None
+
+
+_PUBLISH_PROMPT = (
+    "You are working in a git checkout and the change is finished. Call the"
+    " mcp__curie__publish_changes tool exactly once with title 'Live gate check'"
+    " and a one-sentence body, then end your turn and say the request is pending."
+)
+
+_PUBLISH_SYSTEM_PROMPT = (
+    "You are a terse test agent. When asked to publish changes, use the"
+    " mcp__curie__publish_changes tool. Do not use any other tool."
+)
+
+
+def _publish_runner(trace_name: str, *, gated: bool) -> tuple[SessionRunner, ApprovalGate]:
+    gate = build_approval_gate(operator_tools=None, policy_routes={}, managed_workspace=True)
+    assert gate is not None
+    model, env = _live_model_and_env()
+    options = build_options(
+        plugins=[],
+        model=model,
+        system_prompt=_PUBLISH_SYSTEM_PROMPT,
+        max_turns=6,
+        max_budget_usd=1.0,
+        resume=None,
+        env=env,
+        mcp_servers={
+            APPROVAL_SERVER_NAME: build_approval_server(gate, managed_workspace=True)
+        },
+        # The production shape wires both SDK gate layers; the second test omits
+        # them so the tool body actually executes (permission_mode falls back to
+        # bypassPermissions), which is the live shape that lost its record.
+        hooks=build_approval_hook(gate) if gated else None,
+        can_use_tool=build_can_use_tool(gate) if gated else None,
+    )
+    runner = SessionRunner(
+        session_factory=lambda: ClaudeAgentSession(options),
+        ceiling=0,
+        tracer=RunTracer(None),
+        classifier=SideEffectClassifier(),
+        trace_name=trace_name,
+        session_id=trace_name,
+        approval_gate=gate,
+    )
+    return runner, gate
+
+
+def _live_publish_lines(runner: SessionRunner) -> list[str]:
+    async def go() -> list[str]:
+        await runner.start()
+        try:
+            return [
+                line
+                async for line in runner.run_turn(
+                    Event(type="message", text=_PUBLISH_PROMPT, user="U-live", ts="1.0")
+                )
+            ]
+        finally:
+            await runner.close()
+
+    return anyio.run(go)
+
+
+@pytest.mark.skipif(
+    not (_HAS_CRED or _OPENROUTER_KEY),
+    reason="no live credential (CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_API_KEY / OPENROUTER_API_KEY)",
+)
+def test_live_publish_with_both_gate_layers_pauses_awaiting_approval(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """L1, the production shape: hook + can_use_tool wired.
+
+    The publish call is denied before execution, recorded once, and the turn ends
+    awaiting-approval carrying the trusted permission-gate provenance the worker
+    keys the publication path on.
+    """
+
+    runner, gate = _publish_runner("live-publish-gated", gated=True)
+
+    with caplog.at_level(logging.WARNING, logger="curie_runner.session"):
+        events = parse_ndjson("".join(_live_publish_lines(runner)))
+
+    final = events[-1]
+    assert final.type == "final"
+    assert final.status is SessionStatus.AWAITING_APPROVAL
+    assert final.approval_summary is not None
+    assert PUBLISH_TOOL_NAME in final.approval_summary
+    assert final.approval_gate_kind == "permission"
+    assert final.approval_granted_tool == PUBLISH_TOOL_NAME
+    assert gate.publication_title
+    # A gate layer denied the call and asked the CLI to stop the turn.
+    assert gate.pending_halt is True
+    # And therefore no layer missed it. The real SDK streams the ToolUseBlock
+    # BEFORE dispatching the PreToolUse hook, so the stream observer writes the
+    # record first even here -- "who wrote it first" must NOT be what the warning
+    # keys on, or it fires on the fully-gated production path (observed live).
+    assert not any(
+        "fallback" in record.getMessage().lower() for record in caplog.records
+    ), caplog.text
+
+
+@pytest.mark.skipif(
+    not (_HAS_CRED or _OPENROUTER_KEY),
+    reason="no live credential (CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_API_KEY / OPENROUTER_API_KEY)",
+)
+def test_live_publish_without_gate_layers_still_pauses_via_the_stream(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """L2, the observed failing shape (#2294): neither gate layer is wired.
+
+    With no hook and no permission callback the session runs bypassPermissions,
+    so the in-process tool body executes and returns its defensive ``is_error``
+    and the turn ends clean. The runner-owned stream observer is then the only
+    thing that can record the pending approval -- before #2294 this finalized
+    DONE with nothing to approve.
+    """
+
+    runner, gate = _publish_runner("live-publish-ungated", gated=False)
+
+    with caplog.at_level(logging.WARNING, logger="curie_runner.session"):
+        events = parse_ndjson("".join(_live_publish_lines(runner)))
+
+    final = events[-1]
+    assert final.type == "final"
+    assert final.status is SessionStatus.AWAITING_APPROVAL
+    assert final.status is not SessionStatus.DONE
+    assert final.approval_summary is not None
+    assert PUBLISH_TOOL_NAME in final.approval_summary
+    assert final.approval_gate_kind == "permission"
+    assert final.approval_granted_tool == PUBLISH_TOOL_NAME
+    assert gate.publication_title
+    # Nothing in this path may claim a halt the runner never requested -- and
+    # that absence is precisely what proves neither gate layer ever denied it.
+    assert gate.pending_halt is False
+    # So the operator-visible warning MUST fire here: a layer that was supposed
+    # to decide did not.
+    assert any(
+        "publication" in record.getMessage().lower()
+        and "fallback" in record.getMessage().lower()
+        for record in caplog.records
+    ), caplog.text


### PR DESCRIPTION
## Summary

A managed-workspace run called `mcp__curie__publish_changes`, neither the PreToolUse hook nor `can_use_tool` recorded the block, the in-process tool returned its defensive error, and the turn finalized `done` with no approval record. The runner now records every publication call it sees on the model stream through the same gate record the hook writes, synchronously on the iteration that delivers the `ToolUseBlock` and before the terminal result is classified. The observer can only record or fail closed: it never returns allow, never sets the halt marker, never mints a grant, and a duplicate observation is a no-op, so one turn yields exactly one record with the identical provenance pair the worker keys publication on. A turn whose publication calls left no approval of any kind ends as a `publication-unrecorded` classified failure instead of `done`; a malformed first attempt does not poison a corrected retry, and a turn already parking on another approval keeps that approval and logs that the publication request was not carried. A throwaway spike against claude-agent-sdk 0.2.147 and 0.2.152 (50/50 dispatches) showed the SDK does dispatch the unscoped hook for in-process `mcp__curie__*` tools, so this is a runner-owned backstop, not an SDK workaround; the same live runs showed the stream reaches the runner before hook dispatch, so the "no gate layer decided this call" warning is keyed on `pending_halt` at turn end.

## Related issue

Closes #2294

## Fix pin verification

Fix pin: runner/tests/test_approval_gate_enforcement.py::test_publish_call_neither_gate_layer_saw_still_pauses_awaiting_approval

`curie dev verify-fix-pin HEAD <selector>` on 5099207a: the test fails with `SessionStatus.DONE` on the pre-fix tree, then `PINNED`.

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | required | the change alters the runner turn loop and adds an ACI error classification | fake | `curie build && CURIE_BIN=~/.cargo/bin/curie CURIE_E2E_TIERS=skill curie dev e2e-ladder` on 5099207a (image `curie-runner` sha256:ae0faa84): `LADDER PASS (tiers: skill)`, plumbing-only |
| local | n/a | no compose service, dispatcher, worker, API wiring, boot env, console UI, or `curie` verb output changes; the worker consumes the unchanged provenance pair | | |
| local-release | n/a | no released binary or image identity, install path, version pin, or release compose change | | |
| cluster | n/a | no chart template, RBAC, securityContext, NetworkPolicy, sandbox claim, or init container change | | |
| live provider | required | the change reaches unscoped PreToolUse and in-process platform MCP tools; AC 6 demands real-SDK regressions | live | `OPENROUTER_API_KEY=... uv run pytest -v -rA runner/tests/test_live.py -k publish -o log_cli=true --log-cli-level=WARNING` on 5099207a, claude-agent-sdk 0.2.147, `anthropic/claude-sonnet-4.5` via OpenRouter: `2 passed in 20.49s`. Positive: `test_live_publish_with_both_gate_layers_pauses_awaiting_approval` PASSED (AWAITING_APPROVAL, granted tool is the publish tool, `pending_halt is True`, no fallback WARNING). Negative, the exact #2294 shape: `test_live_publish_without_gate_layers_still_pauses_via_the_stream` PASSED with hooks and `can_use_tool` omitted, the tool body executed, the turn still parked, `pending_halt is False`, and the log read `publication stream fallback stood alone session=live-publish-ungated: neither the PreToolUse hook nor can_use_tool denied this publication call` |
| external integration | required, **blocked** | the change reaches workspace publication, so the template requires Slack evidence | live | not run: no safe Slack workspace plus managed-workspace install is available to an unattended session; the issue's AC 7 names unsafe live Slack evidence as an explicit blocker. Left open for the maintainer |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [ ] No required tier is left unproved; any blocked tier names its blocker in the table. (external integration is blocked, see the table)

## Offline regressions (845 passed on 5099207a)

- Gate unit: `observe_publication` records once, duplicate is a no-op, malformed title raises and records nothing, a hook-recorded block is never overwritten, the observer never mints a grant.
- Session: neither gate layer sees the call and the turn still parks; hook-recorded call is not recorded twice; malformed proposal fails closed; two calls record one approval; a gate without the publish tool fails closed; operator interrupt outranks both a recorded and an unrecordable publication; malformed then valid parks on the valid record; hook-recorded then malformed keeps the hook's record; another gated tool holding the slot keeps its approval; policy request plus publish parks on the policy request; a turn with no terminal result still fails closed.

## Out of scope, noted for follow-up

- A policy `request_approval` and a publish call in one turn end awaiting the policy approval only (pre-existing single pending slot); the runner now logs `publication request not carried` and the model must request publication again after the resolution.
- `publish_changes` is not in `PLATFORM_IDEMPOTENT_TOOLS`, so an executed defensive call emits a SideEffectFlag (pre-existing).
- An error-shaped ResultMessage after a stream-only record still ends classified-failure with no card (fail-closed, not silent).
- The timeout guard in the fail-closed pair has no dedicated test (the interrupt guard does).

## Checklist

- [x] Tests pass for the area I touched (see CONTRIBUTING.md for the commands): `uv run pytest -q runner/tests` 845 passed, `uv run ruff check runner`, `uv run mypy runner/src` on 5099207a.
- [x] Docs updated if behavior changed: `docs/approvals.md` and `docs/interfaces/approval/INTERFACE.md`; `curie dev docs-lint` green.
- [x] An ADR is added under `docs/adr/` if this is an architectural decision: not applicable, the gate record, provenance pair, and approval flow are unchanged; this adds a runner-internal observer of an existing record.
