### PR TITLE
fix(cli): drop rsa from the tree via the aws_lc_rs jwt backend

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -284,6 +284,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
+dependencies = [
+ "aws-lc-sys",
+ "untrusted 0.7.1",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -332,12 +356,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "base16ct"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -348,12 +366,6 @@ name = "base64"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
-
-[[package]]
-name = "base64ct"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bit-set"
@@ -486,6 +498,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -564,6 +578,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -617,12 +640,6 @@ dependencies = [
  "unicode-width",
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const-oid"
@@ -713,18 +730,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
-]
-
-[[package]]
-name = "crypto-bigint"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
-dependencies = [
- "generic-array",
- "rand_core 0.6.4",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -838,7 +843,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -897,17 +901,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
-name = "der"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
-dependencies = [
- "const-oid 0.9.6",
- "pem-rfc7468",
- "zeroize",
-]
-
-[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -942,7 +935,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid 0.9.6",
  "crypto-common 0.1.7",
  "subtle",
 ]
@@ -954,7 +946,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.1",
- "const-oid 0.10.2",
+ "const-oid",
  "crypto-common 0.2.2",
 ]
 
@@ -985,69 +977,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
-name = "ecdsa"
-version = "0.16.9"
+name = "dunce"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
-dependencies = [
- "der",
- "digest 0.10.7",
- "elliptic-curve",
- "rfc6979",
- "signature",
- "spki",
-]
-
-[[package]]
-name = "ed25519"
-version = "2.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
-dependencies = [
- "pkcs8",
- "signature",
-]
-
-[[package]]
-name = "ed25519-dalek"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
-dependencies = [
- "curve25519-dalek",
- "ed25519",
- "serde",
- "sha2 0.10.9",
- "subtle",
- "zeroize",
-]
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
-
-[[package]]
-name = "elliptic-curve"
-version = "0.13.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
-dependencies = [
- "base16ct",
- "crypto-bigint",
- "digest 0.10.7",
- "ff",
- "generic-array",
- "group",
- "hkdf",
- "pem-rfc7468",
- "pkcs8",
- "rand_core 0.6.4",
- "sec1",
- "subtle",
- "zeroize",
-]
 
 [[package]]
 name = "email_address"
@@ -1152,16 +1091,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
-name = "ff"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
-dependencies = [
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
 name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1228,6 +1157,12 @@ dependencies = [
  "num",
  "num-bigint",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures-channel"
@@ -1352,17 +1287,6 @@ dependencies = [
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "group"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
-dependencies = [
- "ff",
- "rand_core 0.6.4",
- "subtle",
 ]
 
 [[package]]
@@ -1729,6 +1653,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.3",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1797,19 +1731,13 @@ version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "881733cbc631fc9e472e24447ce32a64bedf2da498d6d8570b08edc87de71f65"
 dependencies = [
+ "aws-lc-rs",
  "base64 0.22.1",
- "ed25519-dalek",
  "getrandom 0.2.17",
- "hmac",
  "js-sys",
- "p256",
- "p384",
  "pem",
- "rand 0.8.8",
- "rsa",
  "serde",
  "serde_json",
- "sha2 0.10.9",
  "signature",
  "simple_asn1",
  "zeroize",
@@ -1845,15 +1773,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb1e621458ca9c51aa110bd0339d4751a056b9576bf1253aee1aa560dda0fc9d"
 dependencies = [
  "log",
-]
-
-[[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin",
 ]
 
 [[package]]
@@ -2015,22 +1934,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint-dig"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
-dependencies = [
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand 0.8.8",
- "smallvec",
- "zeroize",
-]
-
-[[package]]
 name = "num-cmp"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2088,7 +1991,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -2133,30 +2035,6 @@ name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
-
-[[package]]
-name = "p256"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2 0.10.9",
-]
-
-[[package]]
-name = "p384"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2 0.10.9",
-]
 
 [[package]]
 name = "palette"
@@ -2222,15 +2100,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2254,25 +2123,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "pkcs1"
-version = "0.7.5"
+name = "pkg-config"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
-dependencies = [
- "der",
- "pkcs8",
- "spki",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der",
- "spki",
-]
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "polling"
@@ -2321,24 +2175,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
-name = "primeorder"
-version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
-dependencies = [
- "elliptic-curve",
-]
-
-[[package]]
 name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2385,7 +2221,7 @@ dependencies = [
  "bytes",
  "getrandom 0.4.3",
  "lru-slab",
- "rand 0.10.2",
+ "rand",
  "rand_pcg",
  "ring",
  "rustc-hash",
@@ -2435,17 +2271,6 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
@@ -2453,16 +2278,6 @@ dependencies = [
  "chacha20",
  "getrandom 0.4.3",
  "rand_core 0.10.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2696,16 +2511,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rfc6979"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
-dependencies = [
- "hmac",
- "subtle",
-]
-
-[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2715,7 +2520,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -2728,26 +2533,6 @@ dependencies = [
  "libc",
  "rtoolbox",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rsa"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
-dependencies = [
- "const-oid 0.9.6",
- "digest 0.10.7",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
- "pkcs1",
- "pkcs8",
- "rand_core 0.6.4",
- "signature",
- "spki",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -2820,7 +2605,7 @@ checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -2849,20 +2634,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sec1"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
-dependencies = [
- "base16ct",
- "der",
- "generic-array",
- "pkcs8",
- "subtle",
- "zeroize",
-]
 
 [[package]]
 name = "secret-service"
@@ -3077,7 +2848,6 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -3119,22 +2889,6 @@ checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "spin"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
-
-[[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der",
 ]
 
 [[package]]
@@ -3566,6 +3320,12 @@ name = "unsafe-libyaml-norway"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39abd59bf32521c7f2301b52d05a6a2c975b6003521cbd0c6dc1582f0a22104"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -79,7 +79,22 @@ jsonschema = { version = "0.51", default-features = false }
 serde_norway = "0.9.42"
 crypto_box = { version = "0.9.1", features = ["seal", "std"] }
 base64 = "0.23.1"
-jsonwebtoken = { version = "11.0.0", default-features = false, features = ["use_pem", "rust_crypto"] }
+# GitHub App auth signs a JWT with RS256 (`github_app::sign_app_jwt`), which
+# GitHub requires, so RSA is not optional here. The backend is: `rust_crypto`
+# pulls the pure-Rust `rsa` crate, which carries RUSTSEC-2023-0071 (Marvin
+# timing sidechannel) with `patched = []` upstream since 2023 -- there is no
+# version to bump to, so the advisory is permanent for as long as we use it.
+# `aws_lc_rs` removes `rsa` from the tree outright (#2381) rather than
+# suppressing the finding, and takes the rest of the RustCrypto stack with it
+# (ed25519-dalek, p256, p384, sha2, hmac, rand): a net dependency reduction.
+#
+# The cost is a C/asm crypto library, which is the classic way a portable-CLI
+# story breaks, so that is the property that was actually tested rather than
+# assumed. Both release targets cross-compile under `cargo zigbuild` to the
+# GLIBC_2.28 floor, both assert that floor, and the x86_64 artifact runs on
+# Amazon Linux 2023 -- i.e. the `CLI runs on old glibc` job, not `cargo audit`,
+# is the check that governs this line. Revisit only if that job regresses.
+jsonwebtoken = { version = "11.0.0", default-features = false, features = ["use_pem", "aws_lc_rs"] }
 
 [dev-dependencies]
 # The frozen ACI types are a normal dependency of the lib, but integration test

--- a/cli/tests/github_app_identity.rs
+++ b/cli/tests/github_app_identity.rs
@@ -80,6 +80,76 @@ fn generate_rsa_pem(path: &Path) {
     std::fs::write(path, output.stdout).expect("write generated PEM");
 }
 
+/// Derive the public half of a generated key, so a signature can be checked
+/// against something other than the library that produced it.
+fn rsa_public_pem(private_key: &Path, out: &Path) {
+    let output = Command::new("openssl")
+        .args(["rsa", "-pubout", "-in"])
+        .arg(private_key)
+        .arg("-out")
+        .arg(out)
+        .output()
+        .unwrap_or_else(|e| panic!("openssl rsa -pubout: {e}"));
+    assert!(
+        output.status.success(),
+        "openssl rsa -pubout failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// Verify the JWT's RS256 signature with openssl rather than with
+/// `jsonwebtoken`.
+///
+/// Decoding the claims (`jwt_payload`) proves only that the CLI emitted three
+/// dot-separated segments with the right `iss`; a backend that produced a
+/// malformed, truncated, or wrongly-padded signature would satisfy every
+/// claim assertion in this file and be rejected only by GitHub, in
+/// production. That mattered when #2381 moved the RS256 implementation from
+/// the pure-Rust `rsa` crate to `aws-lc-rs`: the swap is exactly the kind
+/// that a claims-only test cannot see. openssl is used deliberately because
+/// verifying an `aws-lc-rs` signature with `aws-lc-rs` would be circular.
+fn assert_rs256_signature_verifies(authorization: &str, private_key: &Path, dir: &Path) {
+    let token = authorization
+        .strip_prefix("Bearer ")
+        .unwrap_or_else(|| panic!("Authorization is not a Bearer token: {authorization}"));
+    let parts: Vec<&str> = token.split('.').collect();
+    assert_eq!(
+        parts.len(),
+        3,
+        "a JWS compact serialization has exactly three segments: {token}"
+    );
+    let signature =
+        base64::Engine::decode(&base64::engine::general_purpose::URL_SAFE_NO_PAD, parts[2])
+            .unwrap_or_else(|e| panic!("JWT signature is not base64url: {e}"));
+    assert!(
+        !signature.is_empty(),
+        "JWT carries an empty signature: {token}"
+    );
+
+    let public_key = dir.join("app.pub.pem");
+    rsa_public_pem(private_key, &public_key);
+    let signing_input = dir.join("jwt.signing-input");
+    std::fs::write(&signing_input, format!("{}.{}", parts[0], parts[1]))
+        .expect("write JWT signing input");
+    let signature_path = dir.join("jwt.sig");
+    std::fs::write(&signature_path, &signature).expect("write JWT signature");
+
+    let output = Command::new("openssl")
+        .args(["dgst", "-sha256", "-verify"])
+        .arg(&public_key)
+        .arg("-signature")
+        .arg(&signature_path)
+        .arg(&signing_input)
+        .output()
+        .unwrap_or_else(|e| panic!("openssl dgst -verify: {e}"));
+    assert!(
+        output.status.success(),
+        "the App JWT's RS256 signature does not verify against its own key: {} {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
 fn b64(bytes: &[u8]) -> String {
     base64::Engine::encode(&base64::engine::general_purpose::STANDARD, bytes)
 }
@@ -271,6 +341,7 @@ fn assert_probed_matching_app(probe: &Probe) {
         Some(MATCHING_APP_ID),
         "JWT iss must be the requested App id: {claims}"
     );
+    assert_rs256_signature_verifies(auth, &PathBuf::from(probe.private_key()), probe.dir.path());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

`cargo audit` has been red on `main` (and therefore on every open PR) because `cli/Cargo.lock` carries `rsa 0.9.10` and RUSTSEC-2023-0071 (Marvin timing sidechannel). This switches `jsonwebtoken`'s backend from `rust_crypto` to `aws_lc_rs`, which **removes `rsa` from the dependency tree entirely**.

Closes #2381.

## Why this option

#2381 laid out two options and recommended B (ignore the advisory with a written justification). I took **A** instead, because the reason the issue gave for rejecting A turned out to be an assumption rather than a measurement, and it does not hold.

Ordered by preference:

1. **A fixed release** — does not exist. The advisory carries `patched = []` and has since 2023; there is no version to bump to, so the finding is permanent for as long as we depend on `rsa`.
2. **A replacement crate** — this PR. `aws_lc_rs` is a supported `jsonwebtoken 11` backend and eliminates the vulnerable crate rather than suppressing the report.
3. **A justified ignore with an expiry** — not needed, so not taken. An ignore would have left the vulnerable code in the shipped binary and put a dated waiver on a permanent advisory.

The issue's concern about A was that a C/asm crypto library is "the classic way" the portable-CLI story breaks, and that `CLI runs on old glibc` — not `cargo audit` — is the real test. That framing is right, so I ran that job's exact commands rather than reasoning about them.

## Verification

Baseline, unmodified `main`:

```
error: 1 vulnerability found!    # RUSTSEC-2023-0071, rsa 0.9.10
cargo audit exit 1
```

With this change:

| check | command | result |
|---|---|---|
| advisory cleared | `cargo audit` | **exit 0** (3 allowed warnings, all pre-existing and unrelated) |
| `rsa` actually gone | `cargo tree -p rsa` | `package ID specification 'rsa' did not match any packages` |
| x86_64 release path | `cargo zigbuild --release --target x86_64-unknown-linux-gnu.2.28` | pass |
| aarch64 release path | `cargo zigbuild --release --target aarch64-unknown-linux-gnu.2.28` | pass |
| glibc floor, x86_64 | `check-glibc-floor.sh … 2.28` | `OK: requires at most GLIBC_2.28` |
| glibc floor, aarch64 | `check-glibc-floor.sh … 2.28` | `OK: requires at most GLIBC_2.28` |
| runs on the target distro | `docker run amazonlinux:2023 /curie --version` | `curie 0.8.6` |
| signing path unchanged | `cargo test --release github_app` | 59 passed |
| JWT identity contract | `cargo test --release --test github_app_identity` | 6 passed |
| lint | `cargo fmt --check`, `cargo clippy --all-targets -D warnings` | clean |

The aarch64 cross-compile was the one I expected to fail, since it is `aws-lc-sys` assembly built through `zig cc` for a non-host architecture. It builds.

## Effect on `cargo install`

#2381 asked for this to be stated explicitly. Building from source now requires a C compiler, because `aws-lc-sys` compiles C and assembly. On this machine it built in 17 s with `cc` alone — `cmake` is **not** installed here and was not needed.

This does not affect how the CLI is actually distributed: `cli-portability` publishes prebuilt per-commit binaries for both Linux targets at the 2.28 floor, and those are unchanged and still verified above. Nothing in `README.md` or `docs/` documents `cargo install curie` as an install path, and the `curie` name on crates.io is at `0.1.4` and is not this crate.

## Dependency delta

Net **reduction**: `-309/+69` lines of `Cargo.lock`. Removing `rust_crypto` drops the whole RustCrypto stack (`rsa`, `ed25519-dalek`, `p256`, `p384`, `sha2`, `hmac`, `rand`); `aws-lc-rs` and `aws-lc-sys` replace it.

## Risk

The RS256 signing path (`github_app::sign_app_jwt`, `EncodingKey::from_rsa_pem`) is unchanged at the call site — only the crate implementing it moves. It is covered by the 6 identity tests above, including `a_matching_key_configures_the_app_after_github_confirms_identity`, which decodes the produced JWT.

The rationale and the condition for revisiting it are committed next to the dependency in `cli/Cargo.toml`, not left in this description.

## Adversarial review (read-only, cross-engine)

`agent-router adversarial-review --primary claude` → reviewed by codex/gpt-6-astra. Verdict: **no concrete regression found** — PEM extraction and the CLI error mapping are unchanged, the removed RustCrypto crates have no other consumer in this crate, and the added dependencies are permissively licensed and checksum-locked. It raised three evidence gaps rather than defects. Two are now closed, one is stated below.

**Closed — the tests never verified a signature.** `jwt_payload` base64-decodes the claims; nothing checked the RS256 signature, so a backend emitting a malformed or truncated signature would have passed every assertion in that file and failed only against GitHub, in production. `2bb6fb0f` verifies it with `openssl dgst` against the public half of the same generated key — openssl deliberately, because verifying an `aws-lc-rs` signature with `aws-lc-rs` is circular. Proven non-vacuous: flipping one bit of the signature fails it with `Verification failure`.

**Closed — "AWS-LC can reject keys RustCrypto accepted."** True in general (AWS-LC enforces stricter RSA key validation). Not reachable here: the key is a GitHub-issued App private key, GitHub issues 2048-bit PKCS#1 RSA, and the bad-key path is still asserted by `a_private_key_that_is_not_a_usable_pem_is_a_usage_error_naming_the_flag` and the three mismatch tests. No key GitHub issues is affected.

**Open, and worth a decision — `aarch64-apple-darwin` is a release target this PR never exercised.** `release.yaml` builds four targets; `cli-portability` covers only the two Linux ones. macOS arm64 builds `aws-lc-sys` natively on `macos-latest`, which is a first-class aws-lc-rs target, so the risk is low — but it is untested until a tag, which is the same "undiscoverable until someone tries the artifact" shape that `cli-portability` was created for after #1341. Flagged rather than fixed: widening that job to a `macos-latest` runner is a cost decision, not mine to make inside this PR.

Also noted by the reviewer and true: cross-compiling plus `curie --version` does not prove aarch64 *signing* works, since `--version` touches no crypto. CI has never executed the aarch64 artifact (the job's own comment says arm64 execution would need qemu), so this is a pre-existing coverage gap rather than one this PR introduces — but it carries more weight for a C/asm crypto library with per-architecture assembly than it did for pure Rust.

## Note on a local test failure

`chart_check_passes_on_the_unmodified_chart` fails on my machine. It fails identically on unmodified `origin/main` (verified in a clean worktree), does not reproduce in CI — `Rust (fmt + clippy + test)` is green on this PR — and reads the chart, which this PR does not touch. Local helm/kubectl artifact, recorded so the next person who sees it does not re-derive it.
