### PR TITLE
fix(worker): keep the ResourceQuota accounting out of the user's reply

### DIFF
--- a/apps/worker/src/curie_worker/kernel.py
+++ b/apps/worker/src/curie_worker/kernel.py
@@ -2281,16 +2281,16 @@ class Kernel:
             )
             if self._is_approval_resume(qevent.event_id):
                 return TurnOutcome(terminal_ok=False, classification="runner-error")
+            # Quota accounting is operator data and stops at the log line
+            # above (#2434). The quota's name, the resource axis and the three
+            # usage numbers reached a customer Slack channel verbatim on
+            # 2026-09-06; they say nothing to the person who asked a question
+            # and they disclose cluster capacity to anyone who can talk to the
+            # bot. `rejection` is still fully logged for the operator.
             await self._reply_for(
                 qevent,
                 route,
-                (
-                    "This agent is at sandbox capacity. ResourceQuota "
-                    f"{rejection.quota_name} rejected {rejection.resource}: "
-                    f"requested {rejection.requested}, observed usage "
-                    f"{rejection.used}, hard limit {rejection.hard}. Try again "
-                    "after another conversation releases its sandbox."
-                ),
+                "This agent is at capacity right now. Try again in a few minutes.",
             )
             return TurnOutcome(terminal_ok=True)
         except WorkspaceSelectionRefused as exc:

--- a/apps/worker/src/curie_worker/kernel.py
+++ b/apps/worker/src/curie_worker/kernel.py
@@ -2290,7 +2290,10 @@ class Kernel:
             await self._reply_for(
                 qevent,
                 route,
-                "This agent is at capacity right now. Try again in a few minutes.",
+                (
+                    "This agent is at capacity right now. It frees up when "
+                    "another conversation finishes, so please try again shortly."
+                ),
             )
             return TurnOutcome(terminal_ok=True)
         except WorkspaceSelectionRefused as exc:

--- a/apps/worker/tests/kernel/test_kernel.py
+++ b/apps/worker/tests/kernel/test_kernel.py
@@ -1220,7 +1220,10 @@ def test_quota_capacity_is_terminal_without_retry_or_runner_turn(
 
             await h.kernel.process_event(ev)
 
-            expected = "This agent is at capacity right now. Try again in a few minutes."
+            expected = (
+                "This agent is at capacity right now. It frees up when another "
+                "conversation finishes, so please try again shortly."
+            )
             expected_updates = [("C1", "p-1", expected)]
             if not slack_no_edit_streaming:
                 expected_updates.insert(0, ("C1", "p-1", h.config.booting_text))

--- a/apps/worker/tests/kernel/test_kernel.py
+++ b/apps/worker/tests/kernel/test_kernel.py
@@ -1220,11 +1220,7 @@ def test_quota_capacity_is_terminal_without_retry_or_runner_turn(
 
             await h.kernel.process_event(ev)
 
-            expected = (
-                "This agent is at sandbox capacity. ResourceQuota curie-sandbox-quota "
-                "rejected limits.cpu: requested 2, observed usage 7, hard limit 8. "
-                "Try again after another conversation releases its sandbox."
-            )
+            expected = "This agent is at capacity right now. Try again in a few minutes."
             expected_updates = [("C1", "p-1", expected)]
             if not slack_no_edit_streaming:
                 expected_updates.insert(0, ("C1", "p-1", h.config.booting_text))
@@ -1234,6 +1230,64 @@ def test_quota_capacity_is_terminal_without_retry_or_runner_turn(
             assert h.runner.opened == []
             assert h.kernel._order_locks == {}
             assert await h.async_redis.exists(h.config.done_key(ev.event_id))
+
+    asyncio.run(go())
+
+
+def test_quota_refusal_keeps_operator_accounting_out_of_the_reply(
+    make_harness, caplog
+) -> None:
+    """The quota's identity and numbers go to the log, never to the person.
+
+    #2434: the reply body interpolated `quota_name`, `resource`, `requested`,
+    `used` and `hard` verbatim, and on 2026-09-06 that reached a customer Slack
+    channel three times. Those five fields are operator data -- they say nothing
+    to whoever asked the question, and they disclose cluster capacity to anyone
+    who can talk to the bot.
+
+    Asserted as absence of the VALUES rather than equality with the new
+    sentence, so rewording the refusal cannot silently reintroduce them. The
+    second half pins the other side of the boundary: the operator loses nothing,
+    so there is no pressure to put any of it back in the reply.
+    """
+
+    async def go() -> None:
+        async with make_harness(max_attempts=3, claim_timeout_seconds=0.05) as h:
+            h.fake_k8s.quota_rejection = QuotaRejection(
+                quota_name="curie-sandbox-quota",
+                resource="limits.cpu",
+                requested="2",
+                used="7",
+                hard="8",
+            )
+
+            with caplog.at_level(logging.WARNING, logger="curie_worker.kernel"):
+                await h.kernel.process_event(_qevent("go"))
+
+            reply = h.sink.updates[-1][2]
+            for leaked in ("curie-sandbox-quota", "limits.cpu", "ResourceQuota"):
+                assert leaked not in reply, (
+                    f"the capacity refusal must not carry {leaked!r}: it is operator "
+                    f"data and this text is read by a customer. Got: {reply!r}"
+                )
+            assert "quota" not in reply.lower(), (
+                f"the capacity refusal must not name the quota mechanism at all. "
+                f"Got: {reply!r}"
+            )
+
+            logged = "\n".join(record.getMessage() for record in caplog.records)
+            for kept in (
+                "curie-sandbox-quota",
+                "limits.cpu",
+                "requested=2",
+                "used=7",
+                "hard=8",
+            ):
+                assert kept in logged, (
+                    f"the operator log must still carry {kept!r}: taking it out of "
+                    f"the reply must not cost the operator the diagnosis. "
+                    f"Got: {logged!r}"
+                )
 
     asyncio.run(go())
 

--- a/apps/worker/tests/kernel/test_kernel.py
+++ b/apps/worker/tests/kernel/test_kernel.py
@@ -1256,19 +1256,33 @@ def test_quota_refusal_keeps_operator_accounting_out_of_the_reply(
 
     async def go() -> None:
         async with make_harness(max_attempts=3, claim_timeout_seconds=0.05) as h:
-            h.fake_k8s.quota_rejection = QuotaRejection(
+            # Multi-digit and distinctive on purpose. The reply assertions below
+            # are substring checks, so a single-digit "2" would collide with any
+            # unrelated number a future refusal might legitimately carry (a wait
+            # time, say) and fail for the wrong reason.
+            rejection = QuotaRejection(
                 quota_name="curie-sandbox-quota",
                 resource="limits.cpu",
-                requested="2",
-                used="7",
-                hard="8",
+                requested="11",
+                used="47",
+                hard="53",
             )
+            h.fake_k8s.quota_rejection = rejection
 
             with caplog.at_level(logging.WARNING, logger="curie_worker.kernel"):
                 await h.kernel.process_event(_qevent("go"))
 
+            # Read off the rejection rather than retyping literals, so the two
+            # halves of the boundary cannot drift apart.
             reply = h.sink.updates[-1][2]
-            for leaked in ("curie-sandbox-quota", "limits.cpu", "ResourceQuota"):
+            for leaked in (
+                rejection.quota_name,
+                rejection.resource,
+                rejection.requested,
+                rejection.used,
+                rejection.hard,
+                "ResourceQuota",
+            ):
                 assert leaked not in reply, (
                     f"the capacity refusal must not carry {leaked!r}: it is operator "
                     f"data and this text is read by a customer. Got: {reply!r}"
@@ -1280,11 +1294,11 @@ def test_quota_refusal_keeps_operator_accounting_out_of_the_reply(
 
             logged = "\n".join(record.getMessage() for record in caplog.records)
             for kept in (
-                "curie-sandbox-quota",
-                "limits.cpu",
-                "requested=2",
-                "used=7",
-                "hard=8",
+                f"quota={rejection.quota_name}",
+                f"resource={rejection.resource}",
+                f"requested={rejection.requested}",
+                f"used={rejection.used}",
+                f"hard={rejection.hard}",
             ):
                 assert kept in logged, (
                     f"the operator log must still carry {kept!r}: taking it out of "


### PR DESCRIPTION
## Summary

When a sandbox claim is refused by the namespace `ResourceQuota`, the worker replied to the **end user** with the raw Kubernetes quota accounting:

```
This agent is at sandbox capacity. ResourceQuota curie-sandbox-quota rejected
limits.cpu: requested 1, observed usage 8, hard limit 8. Try again after another
conversation releases its sandbox.
```

That reached a customer Slack channel three times on 2026-09-06 (23:25, 23:33, 23:37 UTC). It names an internal object, an internal resource axis, and three numbers that mean nothing to whoever asked the question — and it discloses cluster capacity to anyone who can talk to the bot.

The reply is now one sentence: **"This agent is at capacity right now. Try again in a few minutes."**

Closes #2434.

## Why this is a one-line change

The operator-facing half was already correct and already separate. `kernel.py` logs all five fields in a `logger.warning` immediately above the reply, and that line is untouched — so removing them from the reply costs the operator nothing. Nothing new had to be built; the boundary just had to be respected.

`CapacityExhaustedError`'s own message (`sandbox/types.py`) still carries the detail. That is an internal exception string, not a reply body, and is deliberately left alone.

## Tests

The new test asserts the **absence of the values**, not equality with the new sentence, so a future reword cannot silently reintroduce them — and it pins the other side of the boundary too, so nobody is tempted to put the detail back in the reply to "help" the operator:

- the reply carries no `curie-sandbox-quota`, no `limits.cpu`, no `ResourceQuota`, and does not contain "quota" in any case
- the `logger.warning` still carries all five: `curie-sandbox-quota`, `limits.cpu`, `requested=2`, `used=7`, `hard=8`

**Proven non-vacuous.** Reverted `kernel.py` to `main` and re-ran the new test alone; it fails on exactly the leak it exists to catch:

```
AssertionError: the capacity refusal must not carry 'curie-sandbox-quota'
  'curie-sandbox-quota' is contained here:
    urceQuota curie-sandbox-quota rejected limits.cpu: requested 2, observed usage 7 …
```

`test_quota_capacity_is_terminal_without_retry_or_runner_turn` was updated to the new text; its terminal-outcome, claim-count and no-runner-turn assertions are unchanged. The existing negative assertion at `test_kernel.py:1360` (`"sandbox capacity" not in …`) still holds.

## Not in this PR

The capacity condition itself. A chart default `routeTtlSeconds` of 3600 pins a sandbox for an hour after the last message, against a quota advertising more CPU than the nodes hold — so the cluster serves ~8 conversations an hour and the ninth is refused. That is a deployment-side problem being handled in the overlay, and #2434 is only about the refusal text reaching a user. Widening this PR into quota sizing would mix a user-facing boundary fix with a capacity-planning change.

## Review outcomes

Three read-only reviews ran on this branch.

**Cross-engine adversarial (`agent-router --primary claude` → codex/gpt-6-astra): no introduced defect.** It statically traced the other paths I was worried about and cleared them: normal and hook turns share the sanitized reply, approval resumes return a classification before reaching it, and eval provisioning catches `SandboxError` and logs it. `CapacityExhaustedError`'s own message does not reach a reply body.

It raised one thing worth acting on: **"Try again in a few minutes" was itself inaccurate.** A thread pins its route for `routeTtlSeconds`, which defaults to 3600 and is renewable, so the honest wait can be far longer. `c7c455e3` describes the mechanism instead of promising a duration. That is the reword, not a second concern — the ticket mandates "one sentence a person can act on" but does not fix its words, so choosing them is this ticket's own work.

**Scope-creep review: PASS, zero creep hunks.** All four non-trivial hunks map to AC1/AC2/AC3. The diff touches no chart, no `values.yaml`, no `routeTtlSeconds`, no quota sizing, and leaves `sandbox/types.py` alone, as #2434 requires.

**Spec-vs-impl review: initially FAIL, now addressed.** It caught a real gap I had missed: AC1 names three categories — quota name, resource axis, **usage numbers** — and my absence test covered only the first two. It supplied a counterexample that passed every assertion:

> `"This agent is at capacity: 7 of 8 sandboxes in use, you asked for 2. Try again shortly."`

That is exactly the cluster-capacity disclosure the ticket calls a boundary violation. `3219e898` asserts all five values, read off the `QuotaRejection` rather than retyped so fixture and assertions cannot drift, and pins the log side by `key=value` so it checks the log's shape rather than just finding the strings somewhere. The fixture's numbers are now multi-digit and distinctive, because these are substring checks and a single-digit `"2"` would collide with any unrelated number a future refusal legitimately carried.

Proven non-vacuous against that counterexample specifically: injecting it into the reply fails the test.

Full worker kernel suite after all three commits: **339 passed, 2 skipped**. `ruff check` and `mypy` clean.

## Fix pin

Fix pin: apps/worker/tests/kernel/test_kernel.py::test_quota_refusal_keeps_operator_accounting_out_of_the_reply

Verified locally with the gate's own tool (`curie dev verify-fix-pin`): reversing the product change turns that test red, and the run reports `PINNED`.
