### PR TITLE
Dead-letter mail replies whose provider thread was deleted

### DIFF
--- a/apps/mail-adapter/CLAUDE.md
+++ b/apps/mail-adapter/CLAUDE.md
@@ -30,7 +30,9 @@ the enforceable-rule summary.
   provider-visible event witness before deciding whether to send. An unreadable
   witness or a completion with no admitted reply row is 502/no send; an active
   lease owned by this process is 503. Never turn either case into 200 or a
-  permanent 503.
+  permanent 503. A confirmed provider thread 404 for an admitted reply is the
+  exception: persist a deleted receipt and return 410, including on duplicates
+  and restart, so the worker dead-letters it without claiming delivery.
 - **The inbound gate is two checks, in order: the provider's verdict labels, then
   the allow-list.** They are not equivalent and the ordering is not incidental.
   The provider's filtering is the real control; the label check is defense in

--- a/apps/mail-adapter/README.md
+++ b/apps/mail-adapter/README.md
@@ -248,7 +248,9 @@ subprocess.
 A thread lookup returning HTTP 404 after admission is terminal for that reply.
 The adapter durably records deletion, logs one warning with a hashed correlation,
 and returns HTTP 410 on the first and any duplicate completion, including after
-restart. It never records the reply as delivered. The worker dead-letters the
+restart. The response body carries `{"detail":"thread deleted at provider"}`;
+HTTP 410 without that explicit classification remains retryable for other adapters.
+It never records the reply as delivered. The worker dead-letters the
 completion on the first definitive refusal (N = 1) with reason `thread deleted
 at provider`, atomically removing its owed completion from the pending index.
 The existing configured dead-letter stream and size cap apply. Earlier transient

--- a/apps/mail-adapter/README.md
+++ b/apps/mail-adapter/README.md
@@ -242,3 +242,17 @@ AgentMail's API and the platform's channel ingress. Everything inside
 `curie_mail_adapter` runs for real, the egress server included, and the boot
 gates are driven through the real `python -m curie_mail_adapter` entry point in a
 subprocess.
+
+### Deleted provider threads
+
+A thread lookup returning HTTP 404 after admission is terminal for that reply.
+The adapter durably records deletion, logs one warning with a hashed correlation,
+and returns HTTP 410 on the first and any duplicate completion, including after
+restart. It never records the reply as delivered. The worker dead-letters the
+completion on the first definitive refusal (N = 1) with reason `thread deleted
+at provider`, atomically removing its owed completion from the pending index.
+The existing configured dead-letter stream and size cap apply. Earlier transient
+failures do not spend this terminal budget: provider 5xx and transport failures
+still return 502 and remain retryable. A missing local admission record also
+remains retryable. HTTP 410 applies only to completion delivery; other reply
+events and other error statuses keep their existing retry behavior.

--- a/apps/mail-adapter/src/curie_mail_adapter/adapter.py
+++ b/apps/mail-adapter/src/curie_mail_adapter/adapter.py
@@ -37,6 +37,10 @@ CAUSE_MAX_CHARS = 120
 REJECTED_LABELS = frozenset({"unauthenticated", "spam", "blocked"})
 
 
+class ProviderThreadDeletedError(RuntimeError):
+    """The provider definitively rejected the thread lookup with HTTP 404."""
+
+
 class MailAdapter:
     """One AgentMail inbox bridged to one Curie channel binding."""
 
@@ -481,6 +485,8 @@ class MailAdapter:
 
     def thread_carries(self, conversation_id: str, event_id: str) -> bool | None:
         status, thread = self.client.get_thread(conversation_id)
+        if status == 404:
+            raise ProviderThreadDeletedError
         if status != 200 or not isinstance(thread, dict):
             logger.warning("thread listing -> %s; durable witness unreadable", status)
             return None
@@ -502,12 +508,25 @@ class MailAdapter:
             )
             return 200
         claim = self.state.claim_event(event_id, conversation_id, reply_ref, self.owner)
+        if claim == "deleted":
+            return 410
         if claim == "done":
             return 200
         if claim == "busy":
             return 503
         try:
-            carries = self.thread_carries(conversation_id, event_id)
+            try:
+                carries = self.thread_carries(conversation_id, event_id)
+            except ProviderThreadDeletedError:
+                exists, _text = self.state.reply_text(conversation_id, reply_ref)
+                if not exists:
+                    return 502
+                self.state.delete_event(event_id, conversation_id, reply_ref)
+                logger.warning(
+                    "reply terminal: thread deleted at provider; correlation=%s",
+                    _correlation(event_id),
+                )
+                return 410
             if carries is None:
                 return 502
             if carries:

--- a/apps/mail-adapter/src/curie_mail_adapter/egress.py
+++ b/apps/mail-adapter/src/curie_mail_adapter/egress.py
@@ -202,6 +202,8 @@ class EgressHandler(BaseHTTPRequestHandler):
         except Exception:
             logger.error("dispatching event type=%s failed unexpectedly", event.event)
             return self._respond(500, {"detail": "adapter error"})
+        if status == 410:
+            return self._respond(status, {"detail": "thread deleted at provider"})
         self._respond(status, ReplyAck().model_dump())
 
     def dispatch(self, event: ReplyEvent) -> int:

--- a/apps/mail-adapter/src/curie_mail_adapter/state.py
+++ b/apps/mail-adapter/src/curie_mail_adapter/state.py
@@ -18,7 +18,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Literal
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 LEASE_SECONDS = 300.0
 BODY_FAILURE_BACKOFF_SECONDS = 60.0
 TERMINAL_RECEIPT_MAX = 4096
@@ -37,7 +37,7 @@ _ADMISSION_BACKPRESSURE_CODES = frozenset(
 )
 
 DeliveryAdmission = Literal["admitted", "known", "full"]
-EventClaim = Literal["claimed", "busy", "done"]
+EventClaim = Literal["claimed", "busy", "done", "deleted"]
 
 
 class MailState:
@@ -139,6 +139,16 @@ class MailState:
                     updated_at REAL NOT NULL
                 );
                 PRAGMA user_version=1;
+                COMMIT;
+                """
+            )
+
+        if version < 2:
+            self.connection.executescript(
+                """
+                BEGIN IMMEDIATE;
+                ALTER TABLE completion_events ADD COLUMN deleted INTEGER NOT NULL DEFAULT 0;
+                PRAGMA user_version=2;
                 COMMIT;
                 """
             )
@@ -442,10 +452,12 @@ class MailState:
         now = time.time()
         with self.transaction() as connection:
             row = connection.execute(
-                "SELECT delivered, lease_owner, lease_until FROM completion_events "
+                "SELECT delivered, lease_owner, lease_until, deleted FROM completion_events "
                 "WHERE event_id=?",
                 (event_id,),
             ).fetchone()
+            if row and int(row[3]) == 1:
+                return "deleted"
             if row and int(row[0]) == 1:
                 return "done"
             if row and row[1] and float(row[2] or 0) > now:
@@ -469,6 +481,20 @@ class MailState:
                 "UPDATE completion_events SET lease_owner=NULL, lease_until=NULL, updated_at=? "
                 "WHERE event_id=? AND lease_owner=? AND delivered=0",
                 (time.time(), event_id, owner),
+            )
+
+    def delete_event(self, event_id: str, conversation_id: str, reply_ref: str) -> None:
+        """Keep a durable refusal without claiming the provider accepted a send."""
+        with self.transaction() as connection:
+            connection.execute(
+                "UPDATE completion_events SET deleted=1, lease_owner=NULL, lease_until=NULL, "
+                "updated_at=? WHERE event_id=?",
+                (time.time(), event_id),
+            )
+            connection.execute(
+                "UPDATE reply_state SET text=NULL, active=0, updated_at=? "
+                "WHERE conversation_id=? AND reply_ref=?",
+                (time.time(), conversation_id, reply_ref),
             )
 
     def finish_event(self, event_id: str) -> None:

--- a/apps/mail-adapter/tests/_support.py
+++ b/apps/mail-adapter/tests/_support.py
@@ -75,6 +75,7 @@ class MailState:
         self.messages: list[dict[str, Any]] = []  # newest last, as seeded
         self.bodies: dict[str, dict[str, Any]] = {}
         self.threads: dict[str, list[dict[str, Any]]] = {}
+        self.deleted_threads: set[str] = set()
         self.replies: list[tuple[str, str]] = []  # (in_reply_to_message_id, text)
         self.list_calls = 0
         # time.monotonic() per list call, so the retry CADENCE is observable at
@@ -328,6 +329,8 @@ class MailHandler(_JsonHandler):
             failure, state.fail_next_thread = state.fail_next_thread, None
             if self._injected(failure):
                 return
+            if parts[4] in state.deleted_threads:
+                return self._send(404, {"detail": "no such thread"})
             return self._send(200, {"messages": state.threads.get(parts[4], [])})
         self._send(404, {"detail": "not found"})
 

--- a/apps/mail-adapter/tests/test_egress.py
+++ b/apps/mail-adapter/tests/test_egress.py
@@ -699,3 +699,74 @@ def test_an_unexpected_exception_does_not_poison_the_event_id(
 
     assert status == 200
     assert len(mail.replies) == 1
+
+
+def test_deleted_provider_thread_is_terminal_once_across_restart(
+    mail: MailState,
+    adapter: MailAdapter,
+    egress_url: str,
+    serve_egress: Callable[[MailAdapter], str],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # AgentMail Get Thread documents 404 NotFoundError:
+    # https://docs.agentmail.to/api-reference/inboxes/threads/get
+    # Issue #2376 observed this after deleting an admitted thread.
+    seed(mail, adapter)
+    post_event(egress_url, update("answer one"))
+    mail.deleted_threads.add("thr-1")
+    with caplog.at_level(logging.WARNING, logger="curie_mail_adapter.adapter"):
+        assert post_event(egress_url, completed("ev-deleted"))[0] == 410
+        assert post_event(egress_url, completed("ev-deleted"))[0] == 410
+        with restarted_adapter(adapter, serve_egress) as (_, replacement_url):
+            assert post_event(replacement_url, completed("ev-deleted"))[0] == 410
+    assert mail.thread_calls == 1
+    assert mail.replies == []
+    messages = [
+        r.getMessage() for r in caplog.records if "thread deleted at provider" in r.getMessage()
+    ]
+    assert len(messages) == 1
+    assert "thr-1" not in messages[0]
+    assert "ev-deleted" not in messages[0]
+
+
+def test_deleted_unadmitted_thread_does_not_create_a_terminal_receipt(
+    mail: MailState,
+    adapter: MailAdapter,
+    egress_url: str,
+) -> None:
+    seed(mail, adapter)
+    mail.deleted_threads.add("thr-unknown")
+    event = completed("ev-forged", conversation_id="thr-unknown", reply_ref="msg-1")
+    assert post_event(egress_url, event)[0] == 502
+    assert post_event(egress_url, event)[0] == 502
+    assert mail.thread_calls == 2
+    assert mail.replies == []
+
+
+def test_version_one_state_migrates_without_losing_admitted_or_delivered_replies(
+    mail: MailState,
+    adapter: MailAdapter,
+    egress_url: str,
+    serve_egress: Callable[[MailAdapter], str],
+) -> None:
+    import sqlite3
+
+    seed(mail, adapter)
+    assert post_event(egress_url, completed("ev-done"))[0] == 200
+    seed(mail, adapter, "msg-2", thread_id="thr-2")
+    adapter.close()
+    # Reconstruct the released v1 database shape, preserving real admitted rows.
+    with sqlite3.connect(adapter.config.state_path) as connection:
+        connection.execute("ALTER TABLE completion_events DROP COLUMN deleted")
+        connection.execute("PRAGMA user_version=1")
+    replacement = MailAdapter(adapter.config)
+    try:
+        url = serve_egress(replacement) + "/"
+        assert post_event(url, completed("ev-done"))[0] == 200
+        mail.deleted_threads.add("thr-2")
+        event = completed("ev-deleted", conversation_id="thr-2", reply_ref="msg-2")
+        assert post_event(url, event)[0] == 410
+        assert post_event(url, event)[0] == 410
+        assert len(mail.replies) == 1
+    finally:
+        replacement.close()

--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -243,9 +243,12 @@ The API-side graveyard watcher now honors the same `CURIE_DEAD_LETTER_STREAM` /
 agree on the graveyard stream name with no manual sync.
 
 The first `XADD` creates the stream; nothing pre-creates it. It is a sink, **not**
-a second processing lane: it has no consumer group, and nothing reads it
-automatically. Replay, if an operator wants it, is `XRANGE` plus a re-`XADD` onto
-the main stream.
+a second worker processing lane: it has no consumer group, and no worker
+replays its rows. The API graveyard watcher observes it read-only, while the
+resume reconciler acts only on matching resume rows. Stream-consumer rows can
+be inspected with `XRANGE` and, if an operator wants to replay one, re-`XADD`ed
+onto the main stream. Completion-outbox rows are terminal completion records,
+not inbound stream entries, and must not be replayed onto the main stream.
 
 **The graveyard is bounded, and its rows are best-effort.**
 
@@ -263,9 +266,9 @@ the main stream.
   system's poison rate, saturating rather than growing once the bound is
   hit.
 
-Each graveyard row carries the original entry's fields verbatim plus namespaced
-failure metadata, so a human or a replay tool can inspect exactly what died and
-why:
+The graveyard has two row families. Stream-consumer rows carry the original
+entry's fields verbatim plus namespaced failure metadata, so a human or replay
+tool can inspect exactly what inbound entry died and why:
 
 | Field | Meaning |
 |---|---|
@@ -274,22 +277,33 @@ why:
 | `dl_reason` | `max-delivery-exceeded`, or `unparseable` |
 | `dl_dead_lettered_at` | UTC ISO-8601 timestamp |
 
-The `dl_` prefix keeps the metadata namespaced, but the unparseable path stores
+Completion-outbox rows are written by `Markers.dead_letter_completion` only for
+the exact `DeletedReplyTargetError` deleted-thread classification. They carry
+`event_id`, the
+serialized `completion`, `dl_reason="thread deleted at provider"`,
+`dl_delivery_count="1"`, `dl_source="completion-outbox"`, and
+`dl_dead_lettered_at`; they have no `dl_original_id` and are not replayable as
+inbound stream entries. Every other completion delivery failure leaves the
+completion owed in the outbox for re-emission.
+
+The `dl_` prefix keeps the stream-consumer metadata namespaced, but the
+unparseable path stores
 an arbitrary, malformed field map verbatim, so an original field could itself be
 named `dl_something` and collide with one of the four keys above.
 `Consumer._dead_letter` escapes any original key already starting with `dl_`
 by doubling the prefix (`dl_reason` in the original becomes `dl_dl_reason` in
 the row) before writing the metadata last. The escape is injective: an escaped key
 always starts with `dl_dl_`, so it can never collide with the metadata, and
-un-escaping strips exactly one leading `dl_`. Nothing reads the graveyard
-today, so this costs nothing yet, but anything that later does (replay
-tooling, a dashboard, alerting) must strip one leading `dl_` to recover an
-original field whose name collided, or it will silently misread it.
+un-escaping strips exactly one leading `dl_`. The API graveyard watcher and
+resume reconciler read these rows; any reader of stream-consumer rows must strip
+one leading `dl_` to recover an original field whose name collided, or it will
+silently misread it. Completion-outbox rows do not use this escaped original-
+field convention.
 
 An entry that is pending while its message has been trimmed off the source
-stream produces a metadata-only row and is still acked. Every dead-letter
-emits a loud error log naming the entry, its delivery count, the reason, and
-the target stream.
+stream produces a metadata-only stream-consumer row and is still acked. Every
+stream-consumer dead-letter emits a loud error log naming the entry, its
+delivery count, the reason, and the target stream.
 
 Two behaviors worth knowing before changing this path. The delivery count is read
 from Valkey's pending-entries list on every pass rather than tracked in worker

--- a/apps/worker/src/curie_worker/kernel.py
+++ b/apps/worker/src/curie_worker/kernel.py
@@ -98,7 +98,7 @@ from .killswitch import KillSwitch
 from .markers import CompletionRecord, MalformedCompletionError, Markers
 from .publication_validation import validate_snapshot_against_base
 from .receipt import render_receipt
-from .reply_sink import ObservedReplySink, ReplySink, TargetRoute
+from .reply_sink import DeletedReplyTargetError, ObservedReplySink, ReplySink, TargetRoute
 from .runner_client import (
     RunnerClient,
     RunnerError,
@@ -1936,6 +1936,12 @@ class Kernel:
         """
         try:
             await self._sink.emit(record.event, route=record.route)
+        except DeletedReplyTargetError as exc:
+            if await self._markers.dead_letter_completion(
+                record, generation=generation, reason=exc.reason
+            ):
+                logger.warning("turn.completed dead-lettered: %s", exc.reason)
+            return False
         except Exception as exc:  # noqa: BLE001 - the turn is already durably done
             logger.warning(
                 "turn.completed delivery failed for %s (%s); the outbox record stands",

--- a/apps/worker/src/curie_worker/markers.py
+++ b/apps/worker/src/curie_worker/markers.py
@@ -50,6 +50,7 @@ import json
 import uuid
 from collections.abc import Sequence
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from typing import Any
 
 from channel_protocol.reply import TurnCompleted
@@ -137,6 +138,22 @@ if redis.call('HGET', KEYS[1], ARGV[2]) == ARGV[1] then
   return 1
 end
 return 0
+"""
+
+
+# A terminal rejection is retained in the existing bounded graveyard BEFORE the
+# owed record disappears. The generation fence covers both effects: a stale
+# sweep can neither accuse nor clear the replacement record. An XADD failure
+# leaves the outbox intact for the next sweep.
+_DEAD_LETTER_COMPLETION_LUA = """
+if redis.call('HGET', KEYS[1], ARGV[2]) ~= ARGV[1] then return 0 end
+redis.call('XADD', KEYS[3], 'MAXLEN', '~', ARGV[4], '*',
+  'event_id', ARGV[3], 'completion', ARGV[5], 'dl_reason', ARGV[6],
+  'dl_delivery_count', '1', 'dl_source', 'completion-outbox',
+  'dl_dead_lettered_at', ARGV[7])
+redis.call('DEL', KEYS[1])
+redis.call('SREM', KEYS[2], ARGV[3])
+return 1
 """
 
 
@@ -409,6 +426,27 @@ class Markers:
             event_id,
         )
         return bool(cleared)
+
+    async def dead_letter_completion(
+        self, record: CompletionRecord, *, generation: str, reason: str
+    ) -> bool:
+        """Atomically retain a terminal failure and clear only its own generation."""
+        return bool(
+            await self._redis.eval(
+                _DEAD_LETTER_COMPLETION_LUA,
+                3,
+                self._config.completion_key(record.event_id),
+                self._config.completions_pending_key(),
+                self._config.dead_letter_stream_name(),
+                generation,
+                _GENERATION_FIELD,
+                record.event_id,
+                self._config.dead_letter_maxlen,
+                record.event.model_dump_json(),
+                reason,
+                datetime.now(UTC).isoformat(),
+            )
+        )
 
     async def drop_pending_member(self, event_id: str) -> None:
         """Drop ONLY the set membership, leaving whatever key state exists.

--- a/apps/worker/src/curie_worker/reply_sink.py
+++ b/apps/worker/src/curie_worker/reply_sink.py
@@ -33,7 +33,7 @@ from uuid import UUID
 
 import aiohttp
 import curie_telemetry
-from channel_protocol.reply import ReplyAck, ReplyEvent, ReplyPost
+from channel_protocol.reply import ReplyAck, ReplyEvent, ReplyPost, TurnCompleted
 from opentelemetry.trace import SpanKind, StatusCode
 from pydantic import BaseModel, ConfigDict
 
@@ -89,6 +89,12 @@ class RejectedAdapterResponseError(RuntimeError):
     to prevent. The aiohttp exception is never constructed, never chained, and
     never reaches a log.
     """
+
+
+class DeletedReplyTargetError(RejectedAdapterResponseError):
+    """A completion received HTTP 410: its provider thread is permanently gone."""
+
+    reason = "thread deleted at provider"
 
 
 class OversizedAdapterResponseError(RuntimeError):
@@ -339,6 +345,8 @@ class HttpReplyAdapter:
                         f"{response.status} (redirect); refusing to re-send the "
                         "egress credential to the redirect target"
                     )
+                if response.status == 410 and isinstance(event, TurnCompleted):
+                    raise DeletedReplyTargetError(DeletedReplyTargetError.reason)
                 if response.status >= 400:
                     # NOT ``raise_for_status()``: see
                     # ``RejectedAdapterResponseError``. The status is the

--- a/apps/worker/src/curie_worker/reply_sink.py
+++ b/apps/worker/src/curie_worker/reply_sink.py
@@ -92,7 +92,7 @@ class RejectedAdapterResponseError(RuntimeError):
 
 
 class DeletedReplyTargetError(RejectedAdapterResponseError):
-    """A completion received HTTP 410: its provider thread is permanently gone."""
+    """The adapter explicitly reports permanent provider thread deletion."""
 
     reason = "thread deleted at provider"
 
@@ -346,7 +346,18 @@ class HttpReplyAdapter:
                         "egress credential to the redirect target"
                     )
                 if response.status == 410 and isinstance(event, TurnCompleted):
-                    raise DeletedReplyTargetError(DeletedReplyTargetError.reason)
+                    # Only this explicit classification is terminal. An unrelated
+                    # adapter's generic 410 must not be mislabeled as deletion.
+                    payload = await _read_capped(response, endpoint)
+                    try:
+                        rejection = json.loads(payload)
+                    except (ValueError, UnicodeDecodeError):
+                        rejection = None
+                    if (
+                        isinstance(rejection, dict)
+                        and rejection.get("detail") == DeletedReplyTargetError.reason
+                    ):
+                        raise DeletedReplyTargetError(DeletedReplyTargetError.reason)
                 if response.status >= 400:
                     # NOT ``raise_for_status()``: see
                     # ``RejectedAdapterResponseError``. The status is the

--- a/apps/worker/tests/kernel/test_deleted_mail_completion.py
+++ b/apps/worker/tests/kernel/test_deleted_mail_completion.py
@@ -1,0 +1,198 @@
+"""Deleted provider threads settle the actual completion outbox, not only the PEL."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import logging
+import threading
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+from aci_protocol import Final, SessionStatus
+from curie_mail_adapter.adapter import MailAdapter
+from curie_mail_adapter.config import MailAdapterConfig
+from curie_mail_adapter.egress import make_server
+from curie_worker.consumer import Consumer
+from curie_worker.markers import Markers
+from curie_worker.reply_sink import HttpReplyAdapter
+
+from .test_completion_outbox import (
+    _dispatch_and_settle,
+    _qevent,
+    _read_one,
+    _record,
+)
+
+# Reuse the package's documented HTTP provider simulator. Nothing in the
+# adapter, sink, kernel, or Valkey is mocked.
+_SUPPORT_PATH = Path(__file__).resolve().parents[3] / "mail-adapter/tests/_support.py"
+_spec = importlib.util.spec_from_file_location("mail_completion_support", _SUPPORT_PATH)
+assert _spec and _spec.loader
+support = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(support)
+
+
+@contextmanager
+def mail_runtime(tmp_path):
+    mail = support.MailState()
+    ingress = support.IngressState()
+    provider = support.serve(support.MailHandler, mail)
+    api = support.serve(support.IngressHandler, ingress)
+    adapter = MailAdapter(
+        MailAdapterConfig(
+            agentmail_api_key=support.AGENTMAIL_API_KEY,
+            agentmail_inbox=support.INBOX,
+            agentmail_base_url=f"http://127.0.0.1:{provider.server_port}/v0",
+            api_base_url=f"http://127.0.0.1:{api.server_port}",
+            channel_token=support.CHANNEL_TOKEN,
+            egress_secret=support.EGRESS_SECRET,
+            ingress_enabled=True,
+            allowed_senders=(support.ALLOWED_SENDER,),
+            state_path=str(tmp_path / "mail.sqlite3"),
+        )
+    )
+    egress = make_server(adapter, 0)
+    threading.Thread(target=egress.serve_forever, daemon=True).start()
+    try:
+        mail.add_inbound("msg_upstream", "th-1")
+        adapter.poll_once()
+        assert len(ingress.requests) == 1
+        yield mail, f"http://127.0.0.1:{egress.server_port}/"
+    finally:
+        for server in (egress, api, provider):
+            server.shutdown()
+            server.server_close()
+        adapter.close()
+
+
+@pytest.mark.parametrize("deleted", [True, False])
+def test_admitted_mail_completion_dead_letters_deleted_thread_only(
+    make_harness,
+    tmp_path,
+    caplog: pytest.LogCaptureFixture,
+    deleted: bool,
+) -> None:
+    # AgentMail Get Thread 404 semantics, also observed in #2376:
+    # https://docs.agentmail.to/api-reference/inboxes/threads/get
+    async def go() -> None:
+        with mail_runtime(tmp_path) as (mail, endpoint):
+            sink = HttpReplyAdapter({"acme-mail": support.EGRESS_SECRET})
+            try:
+                async with make_harness(
+                    shimmer=False,
+                    completion_sweep_grace_s=0.0,
+                    sink=sink,
+                ) as h:
+                    consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
+                    await consumer.ensure_group()
+                    qe = _qevent(event_id="deleted-completion").model_copy(
+                        update={
+                            "reply_handle": _qevent().reply_handle.model_copy(
+                                update={
+                                    "channel": support.INBOX,
+                                    "endpoint": endpoint,
+                                    "adapter": "acme-mail",
+                                }
+                            ),
+                        }
+                    )
+                    h.runner.default_script = [Final(text="answer", status=SessionStatus.DONE)]
+                    if deleted:
+                        mail.deleted_threads.add("th-1")
+                    else:
+                        mail.fail_next_thread = 500
+                    from curie_dispatcher.queue import to_stream_fields
+
+                    await h.async_redis.xadd(h.config.stream, to_stream_fields(qe))
+                    entry, fields = await _read_one(h, h.config.consumer_name)
+                    await _dispatch_and_settle(consumer, entry, fields)
+                    assert (await h.async_redis.xpending(h.config.stream, h.config.consumer_group))[
+                        "pending"
+                    ] == 0
+                    pending = await h.async_redis.smembers(h.config.completions_pending_key())
+                    rows = await h.async_redis.xrange(h.config.dead_letter_stream_name())
+                    if deleted:
+                        assert pending == set()
+                        assert len(rows) == 1
+                        assert rows[0][1]["dl_reason"] == "thread deleted at provider"
+                        assert rows[0][1]["event_id"] == qe.event_id
+                        assert rows[0][1]["dl_delivery_count"] == "1"
+                    else:
+                        assert pending == {qe.event_id}
+                        assert rows == []
+                    await h.kernel.sweep_pending_completions()
+                    await h.kernel.sweep_pending_completions()
+                    assert await h.async_redis.smembers(h.config.completions_pending_key()) == set()
+                    assert mail.thread_calls == (1 if deleted else 2)
+                    assert len(mail.replies) == (0 if deleted else 1)
+                    assert len(await h.async_redis.xrange(h.config.dead_letter_stream_name())) == (
+                        1 if deleted else 0
+                    )
+            finally:
+                await sink.aclose()
+
+    with caplog.at_level(logging.WARNING):
+        asyncio.run(go())
+    lines = [
+        r.getMessage()
+        for r in caplog.records
+        if r.name == "curie_mail_adapter.adapter" and "thread deleted at provider" in r.getMessage()
+    ]
+    assert len(lines) == (1 if deleted else 0)
+
+
+def test_dead_letter_completion_refuses_stale_generation(make_harness) -> None:
+    async def go() -> None:
+        async with make_harness(shimmer=False) as h:
+            markers = Markers(h.async_redis, h.config)
+            old = _record("stale-deleted", done=True)
+            stale = await markers.mark_completion_pending(old.event_id, old)
+            current = await markers.mark_completion_pending(old.event_id, old)
+            assert not await markers.dead_letter_completion(
+                old, generation=stale, reason="thread deleted at provider"
+            )
+            assert await h.async_redis.xrange(h.config.dead_letter_stream_name()) == []
+            assert await h.async_redis.smembers(h.config.completions_pending_key()) == {
+                old.event_id
+            }
+            assert await markers.dead_letter_completion(
+                old, generation=current, reason="thread deleted at provider"
+            )
+            assert not await markers.dead_letter_completion(
+                old, generation=current, reason="thread deleted at provider"
+            )
+            assert len(await h.async_redis.xrange(h.config.dead_letter_stream_name())) == 1
+            assert await h.async_redis.smembers(h.config.completions_pending_key()) == set()
+
+    asyncio.run(go())
+
+
+def test_graveyard_write_failure_keeps_completion_owed(make_harness) -> None:
+    from redis.exceptions import ResponseError
+
+    async def go() -> None:
+        async with make_harness(shimmer=False) as h:
+            markers = Markers(h.async_redis, h.config)
+            record = _record("failed-graveyard", done=True)
+            generation = await markers.mark_completion_pending(record.event_id, record)
+            await h.async_redis.set(h.config.dead_letter_stream_name(), "wrong-type")
+            with pytest.raises(ResponseError, match="WRONGTYPE"):
+                await markers.dead_letter_completion(
+                    record,
+                    generation=generation,
+                    reason="thread deleted at provider",
+                )
+            assert await h.async_redis.smembers(h.config.completions_pending_key()) == {
+                record.event_id
+            }
+            assert await markers.read_completion(record.event_id) is not None
+            await h.async_redis.delete(h.config.dead_letter_stream_name())
+            assert await markers.dead_letter_completion(
+                record,
+                generation=generation,
+                reason="thread deleted at provider",
+            )
+
+    asyncio.run(go())

--- a/apps/worker/tests/test_reply_sink.py
+++ b/apps/worker/tests/test_reply_sink.py
@@ -1241,17 +1241,25 @@ def test_a_missing_adapter_identity_names_only_the_endpoint_origin() -> None:
 
 @pytest.mark.parametrize("status", [400, 401, 403, 404, 410, 429, 500, 502, 503])
 @pytest.mark.parametrize("completion", [True, False])
-def test_only_gone_completion_is_a_terminal_delivery_failure(status: int, completion: bool) -> None:
+@pytest.mark.parametrize("terminal_response", [True, False])
+@pytest.mark.parametrize("kind", ["email", "discord"])
+def test_only_gone_completion_is_a_terminal_delivery_failure(
+    status: int, completion: bool, terminal_response: bool, kind: str,
+) -> None:
     from curie_worker.reply_sink import DeletedReplyTargetError
 
     async def go() -> None:
         async def handler(request: web.Request) -> web.Response:
-            return web.Response(status=status, text="provider body must not reach error")
+            return web.json_response(
+                {"detail": "thread deleted at provider" if terminal_response
+                 else "provider body must not reach error"},
+                status=status,
+            )
 
         server = await _serve(handler)
         adapter = HttpReplyAdapter({ADAPTER_A: SECRET_A})
         try:
-            event = _update("email")
+            event = _update(kind)
             if completion:
                 event = TurnCompleted(
                     version=REPLY_WIRE_VERSION,
@@ -1269,9 +1277,9 @@ def test_only_gone_completion_is_a_terminal_delivery_failure(status: int, comple
                     ),
                 )
             assert isinstance(caught.value, DeletedReplyTargetError) == (
-                completion and status == 410
+                completion and status == 410 and terminal_response
             )
-            if not (completion and status == 410):
+            if not (completion and status == 410 and terminal_response):
                 assert f"answered {status};" in str(caught.value)
             assert "provider body" not in str(caught.value)
         finally:

--- a/apps/worker/tests/test_reply_sink.py
+++ b/apps/worker/tests/test_reply_sink.py
@@ -1237,3 +1237,45 @@ def test_a_missing_adapter_identity_names_only_the_endpoint_origin() -> None:
         assert _urls_in(message) == ["http://adapter.example"]
 
     asyncio.run(go())
+
+
+@pytest.mark.parametrize("status", [400, 401, 403, 404, 410, 429, 500, 502, 503])
+@pytest.mark.parametrize("completion", [True, False])
+def test_only_gone_completion_is_a_terminal_delivery_failure(status: int, completion: bool) -> None:
+    from curie_worker.reply_sink import DeletedReplyTargetError
+
+    async def go() -> None:
+        async def handler(request: web.Request) -> web.Response:
+            return web.Response(status=status, text="provider body must not reach error")
+
+        server = await _serve(handler)
+        adapter = HttpReplyAdapter({ADAPTER_A: SECRET_A})
+        try:
+            event = _update("email")
+            if completion:
+                event = TurnCompleted(
+                    version=REPLY_WIRE_VERSION,
+                    event="turn.completed",
+                    target=event.target,
+                    event_id="ev-gone",
+                    outcome="delivered",
+                )
+            with pytest.raises(RejectedAdapterResponseError) as caught:
+                await adapter.emit(
+                    event,
+                    route=TargetRoute(
+                        endpoint=f"http://127.0.0.1:{server.port}/ack",
+                        adapter=ADAPTER_A,
+                    ),
+                )
+            assert isinstance(caught.value, DeletedReplyTargetError) == (
+                completion and status == 410
+            )
+            if not (completion and status == 410):
+                assert f"answered {status};" in str(caught.value)
+            assert "provider body" not in str(caught.value)
+        finally:
+            await adapter.aclose()
+            await server.close()
+
+    asyncio.run(go())

--- a/docs/interfaces/queue-stream/INTERFACE.md
+++ b/docs/interfaces/queue-stream/INTERFACE.md
@@ -68,7 +68,17 @@ A second broker must honor the stream key, the payload encoding, and the Stream 
   (`apps/worker/src/curie_worker/stream_consumer.py::StreamConsumer._dead_letter`), then acked off
   the group. The target stream is `WorkerConfig.dead_letter_stream`
   (`apps/worker/src/curie_worker/config.py::WorkerConfig`), defaulting to
-  `"<stream>:dead"`.
+  `"<stream>:dead"`. This writer produces rows with the original stream fields
+  and `dl_original_id`, `dl_delivery_count`, `dl_reason`, and
+  `dl_dead_lettered_at`. The second writer,
+  `Markers.dead_letter_completion`
+  (`apps/worker/src/curie_worker/markers.py::Markers.dead_letter_completion`),
+  writes terminal completion-outbox rows to the same stream with `event_id`,
+  serialized `completion`, `dl_reason`, `dl_delivery_count`, `dl_source`, and
+  `dl_dead_lettered_at`; these rows have no `dl_original_id` and are not
+  replayable as inbound stream entries. Both writers use the bounded,
+  best-effort graveyard; collision escaping applies to the stream-consumer
+  row family.
 - **Consumer liveness and prompt reclaim** (#1532) — `XINFO CONSUMERS` idle is
   only a cheap candidate filter: it rises while a worker drains a turn or waits
   at its local concurrency limit. Before either lane reads, the narrow
@@ -185,13 +195,16 @@ The verbs return a bare `Awaitable`/value matching redis-py's own typing, so
   `apps/api/src/curie_api/resumequeue.py::ResumeQueue.read_dead_letter` (`xrevrange`),
   whose rows the #532 backstop
   (`apps/api/src/curie_api/resumereconciler.py::ResumeReconciler.reopen_dead_lettered_resumes`)
-  consumes. Both readers also depend on the worker's `dl_*` metadata field schema
-  (`dl_original_id`, `dl_delivery_count`, `dl_reason`, `dl_dead_lettered_at`, written by
-  `apps/worker/src/curie_worker/stream_consumer.py::StreamConsumer._dead_letter`), and
-  the API re-derives the graveyard name as `<stream>:dead` rather than reading the
-  worker's config. So a second broker must account for a third producer (the API) and for
-  two API-side graveyard readers, none of which go through a port today, plus an
-  undeclared cross-service field schema on the dead-letter stream.
+  consumes. `GraveyardWatcher` and `ResumeQueue.read_dead_letter` may each see
+  both graveyard row families. The watcher alerts on every row but always
+  projects the stream-consumer metadata fields `dl_original_id`,
+  `dl_delivery_count`, `dl_reason`, and `dl_dead_lettered_at`, using `?` when a
+  field is absent; it does not report completion `event_id` or `dl_source`.
+  The resume reconciler only acts on stream-consumer rows with a `payload` and
+  the expected resume metadata, so it skips completion-outbox rows. The API
+  re-derives the graveyard name as `<stream>:dead` rather than reading the
+  worker's config. A second broker must account for both dead-letter writers and
+  these two API-side readers, none of which go through a port today.
 - **The redis-py exception surface leaks.** The ports type the verbs but not the error
   contract: `redis.exceptions` propagate through the callers unabstracted, so a non-redis
   broker must either raise redis-py-compatible exceptions or the call sites must learn its

--- a/docs/interfaces/queue-stream/INTERFACE.md
+++ b/docs/interfaces/queue-stream/INTERFACE.md
@@ -203,8 +203,9 @@ The verbs return a bare `Awaitable`/value matching redis-py's own typing, so
   The resume reconciler only acts on stream-consumer rows with a `payload` and
   the expected resume metadata, so it skips completion-outbox rows. The API
   re-derives the graveyard name as `<stream>:dead` rather than reading the
-  worker's config. A second broker must account for both dead-letter writers and
-  these two API-side readers, none of which go through a port today.
+  worker's config. The PEL writer already uses `StreamBroker.xadd`; a second
+  broker must additionally account for the off-port completion-outbox writer
+  and these two API-side readers.
 - **The redis-py exception surface leaks.** The ports type the verbs but not the error
   contract: `redis.exceptions` propagate through the callers unabstracted, so a non-redis
   broker must either raise redis-py-compatible exceptions or the call sites must learn its


### PR DESCRIPTION
## Summary

A mail reply to a provider thread that has been deleted now receives a durable terminal refusal instead of retrying forever. The adapter persists deletion, logs it once, and returns HTTP 410 with `thread deleted at provider` on the first and repeated/restarted completions. The worker classifies only that exact completion response, atomically writes one generation-fenced graveyard record, and removes the completion from the owed set. The documented bound is N = 1. Transient failures, unadmitted 404s, and generic 410 responses remain retryable.

Closes #2376

Fix pin: apps/worker/tests/kernel/test_deleted_mail_completion.py::test_admitted_mail_completion_dead_letters_deleted_thread_only[True]

## Candidate and status

Frozen head: `a00058011ca21d15d31bbd432fd5e011d22f7201` (tree `a0349af5ffc9e86394c9df3fc7f60fcbb5fe0857`), targeting `main`. Merge commit `5b39c435aa662528030e61f7236d55b951b0365b` joined the reviewed runtime with stable-main `2aff57267cf43b29be2ed4b5d25fcf208cdbc7d7`; the two later commits are documentation-only corrections. The task does not chase unrelated later main advances.

CI run `34154680391` is green on the exact head: 38 checks pass and one released-chart-upgrade job is intentionally skipped. The PR is mergeable and clean, but remains draft because required live AgentMail acceptance is not yet proven.

## Verification

- Runtime-identical affected tree: 252 mail-adapter/reply-sink tests passed; four task-specific real-Valkey completion tests passed; mypy checked 247 files; scoped Ruff, import contracts, wire tolerance, and docs validation passed.
- Exact-head CI: Python full pytest/ruff/mypy/docs and the declared fix pin passed; Rust, UI, audits, CodeQL, image builds, and fake-model skill/local/local-release/cluster E2E passed.
- Selector proof: the selected `[True]` test passes with the patch and fails when the product patch is reversed, leaving the completion owed; CI reports `PINNED`.
- Hands-on local tier: `CURIE_E2E_TIERS=local CURIE_E2E_LIVE=0 curie dev e2e-ladder` passed from runtime-identical `9be45dd2c12c88b8bc75963799b5f98dfa1d59d6`, including positive completion, injected runner failure/recovery, approval suspend/resume, invalid-observability-auth absence/recovery, metrics, JSON negative cases, and suite parity. All isolated runtime resources were removed.

## Tier decision

| Tier | Decision | Evidence |
| --- | --- | --- |
| skill | n/a | No plugin packaging, runner turn loop, ACI event, skill eval, or skill check change. |
| local | required, passed | Mail adapter and worker delivery behavior changed; task-owned isolated local ladder passed. |
| local-release | n/a | No released identity, install path, version pin, or release-compose change. |
| cluster | n/a | No chart, RBAC, NetworkPolicy, sandbox claim, or init-container change. |
| live provider | n/a | No model routing, model credentials, token/cost accounting, MCP, workspace publication, or coding-tool capability change. |
| external integration | required, blocked | AgentMail accepted the first attempt-2 self-send with HTTP 200 but did not self-deliver it to the exact candidate adapter within 60 seconds, so the deleted-thread/kernel path could not run. |

## External integration boundary

The two authorized live attempts are preserved and exhausted. Attempt 1 stopped on inbox creation HTTP 403 with zero successful provider mutations. The supported attempt-2 path used only the supplied sandbox inbox: the first self-send returned HTTP 200, but no candidate-admitted inbound delivery appeared within the sealed 60-second bound. Per the stop rule, there was no second send, no deleted-thread/kernel/410 assertion, no retry, and no credential switch.

Cleanup succeeded: the sole task-owned thread was deleted with HTTP 202 and verified absent with GET 404; all 1,039 baseline messages and 519 baseline threads remained readable with HTTP 200; the existing inbox remained readable; no inbox, settings, webhook, or listener was changed; task Valkey, temp directory, and ports are absent. This cleanup is not acceptance proof. The live gate stays open pending an explicitly approved disposable second inbox/test sender/profile.

## Review

Routed Code, Scope, and Security review found no unresolved blocker. Code review surfaced stale graveyard documentation; two correction rounds were followed by the required one-shot Fable oracle, which ruled the residual documentation findings in, and they were fixed. Final Scope reconciliation found and corrected one overclaim, then passed with zero passengers. Security review passed. The built-in `/simplify` surface is unavailable in this runtime; a recorded read-only consolidation fallback inspected the complete 14-path patch and found no safe cleanup, so this does not claim `/simplify` ran.

## `/implement` completion checklist

- [x] N/A — `/implement` adopted an existing Long Horizon implementation mid-run; historical failing-test/implementation stages were preserved and not fabricated.
- [x] N/A — production edits predated `/implement` adoption and were authored by the prior native Long Horizon worker; all post-adoption source/documentation fixes were delegated.
- [x] N/A — no public return type was broadened.
- [x] Agent-router Code review completed with source evidence; all confirmed documentation findings were reconciled.
- [x] Agent-router Scope review completed; final reconciliation reports zero unjustified hunks or passenger changes.
- [x] Sibling-path parity is covered across admitted/unadmitted 404, deleted/transient provider outcomes, duplicate/restart, current/stale generations, generic 410, completion/non-completion, and real/fake reply paths.
- [x] Guard behavior was executed: unadmitted 404, transient 500, generic/wrong-detail 410, stale generation, and graveyard-write failure all preserve owed work; the terminal deleted-thread case clears it exactly once.
- [x] Consolidation fallback completed with no edits; `/simplify` was unavailable and is not claimed as run.
- [x] Agent-router Security review completed with no blocking findings.
- [x] Observable local HTTP/Valkey verification passed for the changed adapter/worker behavior and its negative paths.
- [ ] E2E Tester did not observe the required live deleted-thread behavior because accepted AgentMail self-delivery never reached the candidate within 60 seconds.
- [x] Train check: v0.8.7 is a stable patch milestone and the task is based on `main` through `2aff57267cf43b29be2ed4b5d25fcf208cdbc7d7`.
- [ ] Discovery-surface proof remains open: #2376 was found live, and the required AgentMail path has not passed.
- [x] N/A — no previously merged fix claimed to resolve this symptom.
- [x] Full affected tests, typecheck, lint, docs, fix pin, current-head CI, and required local tier pass.
