### PR TITLE
Reject duplicate chart-owned environment variables before Helm upgrades

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -107,6 +107,9 @@ jobs:
           set -euo pipefail
           bash charts/curie/ci/render-assertions.sh
 
+      - name: Reject chart-owned extraEnv duplicates
+        run: bash charts/curie/ci/reserved-env-assertions.sh
+
       # Prove the API Service keeps a stable NodePort when enabled, allows an
       # override, and omits the field for ClusterIP or explicit auto allocation.
       - name: helm render assertions (api service NodePort)
@@ -591,3 +594,26 @@ jobs:
           helm template "$CHART" -f "$CHART/values-dev.yaml" -f "$CHART/values-e2e-nogvisor.yaml" \
             | python3 -c "import sys, yaml; yaml.safe_dump_all(yaml.safe_load_all(sys.stdin), sys.stdout)" \
             | kubeconform -strict -summary -ignore-missing-schemas -kubernetes-version "$KUBE_VERSION"
+
+  reserved-env-upgrade:
+    name: Reject legacy extraEnv before upgrade mutation
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: azure/setup-helm@v4.3.0
+        with:
+          version: v3.17.3
+      - uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
+        with:
+          cluster_name: curie-reserved-env
+          node_image: kindest/node:v1.31.0@sha256:25a3504b2b340954595fa7a6ed1575ef2edadf5abd83c0776a4308b64bf47c93
+      - name: Install YAML parser
+        run: pip install pyyaml
+      - name: Released retained-values rejection and removed-guard control
+        env:
+          KUBECONFIG: /home/runner/.kube/config
+        run: bash charts/curie/ci/runtime/reserved-env-upgrade-runtime.sh
+      - name: Remove owned cluster
+        if: always()
+        run: kind delete cluster --name curie-reserved-env

--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -613,7 +613,9 @@ jobs:
       - name: Released retained-values rejection and removed-guard control
         env:
           KUBECONFIG: /home/runner/.kube/config
-        run: bash charts/curie/ci/runtime/reserved-env-upgrade-runtime.sh
+        # Keep runtime checks separate from the flat chart-check render inventory.
+        working-directory: charts/curie
+        run: bash ci/runtime/reserved-env-upgrade-runtime.sh
       - name: Remove owned cluster
         if: always()
         run: kind delete cluster --name curie-reserved-env

--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -1546,3 +1546,18 @@ by the CLI's preserved-values mechanism (the same one `COMMS_MANAGED_KEYS` and
 explicitly re-supply -- set one of these fields today and keep it declared in
 the values file you pass to every `cluster up`/`helm upgrade`, the same way you
 would for any other values key the CLI does not manage yet.
+
+### Reserved environment variables
+
+Every workload accepting `extraEnv` uses the reserved names and replacement
+values in `files/reserved-env.yaml`. An entry colliding with a chart-owned name
+fails Helm rendering before upgrade hooks or resources are applied, even when
+its value equals the chart value. For example, remove
+`CURIE_RUNNER_TOTAL_TIMEOUT_S` from `worker.extraEnv` and set
+`worker.runnerTotalTimeoutSeconds` instead. Apply that edit to retained values
+before upgrading a release that previously configured the timeout via `extraEnv`.
+
+The existing OTEL overrides and worker `CURIE_API_URL` / `CURIE_API_KEY`
+overrides remain supported: their helpers omit the chart entry, so each name
+appears once. Repeating any name within `extraEnv` itself is refused. Workloads
+without an `extraEnv` surface cannot append entries to their chart-owned env.

--- a/charts/curie/ci/reserved-env-assertions.sh
+++ b/charts/curie/ci/reserved-env-assertions.sh
@@ -39,6 +39,14 @@ def envs(output, filename, container):
                 yield from walk(child)
     return next(env for doc in docs for env in walk(doc))
 
+def sandbox_runner_envs(output, template_name):
+    docs = yaml.safe_load_all((output / "curie/templates/agent-sandbox.yaml").read_text())
+    templates = [doc for doc in docs if doc and doc.get("kind") == "SandboxTemplate" and doc["metadata"]["name"] == template_name]
+    assert len(templates) == 1, f"expected one SandboxTemplate named {template_name}"
+    runners = [container for container in templates[0]["spec"]["podTemplate"]["spec"]["containers"] if container["name"] == "runner"]
+    assert len(runners) == 1, f"expected one runner in {template_name}"
+    return runners[0]["env"]
+
 with tempfile.TemporaryDirectory() as tmp:
     tmp = pathlib.Path(tmp)
     values = tmp / "values.yaml"
@@ -81,6 +89,26 @@ with tempfile.TemporaryDirectory() as tmp:
     env = envs(output, "worker.yaml", "worker")
     assert [e for e in env if e["name"] == "ACME_EXTENSION"] == [{"name": "ACME_EXTENSION", "value": "preserved"}]
     assert [e for e in env if e["name"] == "CURIE_API_URL"] == [{"name": "CURIE_API_URL", "value": "https://api.example.com"}]
+    # Dynamic connector names belong to the per-agent template, not the generic
+    # runner selected by envs(). Pin both templates by name for these controls.
+    connector_name = "GITHUB_PERSONAL_ACCESS_TOKEN"
+    connector_path = f"agentSandbox.connectorSecrets.acme-a.{connector_name}"
+    _, output = render(chart, "--set", f"agentSandbox.runner.extraEnv[0].name={connector_name}", "--set-string", "agentSandbox.runner.extraEnv[0].value=example-extension")
+    generic_env = sandbox_runner_envs(output, "acme-curie-runner")
+    assert [entry for entry in generic_env if entry["name"] == connector_name] == [{"name": connector_name, "value": "example-extension"}]
+    _, output = render(chart, "--set-string", f"{connector_path}=example-secret", "--set", "agentSandbox.runner.extraEnv[0].name=ACME_CONNECTOR_EXTENSION", "--set-string", "agentSandbox.runner.extraEnv[0].value=preserved")
+    for template_name in ("acme-curie-runner", "acme-curie-agent-acme-a-runner"):
+        runner_env = sandbox_runner_envs(output, template_name)
+        assert [entry for entry in runner_env if entry["name"] == "ACME_CONNECTOR_EXTENSION"] == [{"name": "ACME_CONNECTOR_EXTENSION", "value": "preserved"}]
+        connector_entries = [entry for entry in runner_env if entry["name"] == connector_name]
+        if template_name == "acme-curie-runner":
+            assert connector_entries == [], connector_entries
+        else:
+            assert connector_entries == [{"name": connector_name, "valueFrom": {"secretKeyRef": {"name": "acme-curie-agent-acme-a-connector-secrets", "key": connector_name, "optional": False}}}], connector_entries
+    for value in ("example-secret", "example-conflict"):
+        result, _ = render(chart, "--set-string", f"{connector_path}=example-secret", "--set", f"agentSandbox.runner.extraEnv[0].name={connector_name}", "--set-string", f"agentSandbox.runner.extraEnv[0].value={value}", ok=False)
+        assert result.returncode != 0, f"accepted per-agent connector duplicate with extraEnv value {value}"
+        assert "agentSandbox.runner.extraEnv" in result.stderr and connector_path in result.stderr, result.stderr
     mutant = tmp / "mutant"
     shutil.copytree(chart, mutant)
     helper = mutant / "templates/_reserved-env.tpl"

--- a/charts/curie/ci/reserved-env-assertions.sh
+++ b/charts/curie/ci/reserved-env-assertions.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Exercise the Helm consumer, including a guard-removed duplicate control (#2297).
+set -euo pipefail
+CHART="$(cd "$(dirname "$0")/.." && pwd)"
+python3 - "$CHART" <<'PY'
+import collections
+import pathlib
+import shutil
+import subprocess
+import sys
+import tempfile
+
+import yaml
+
+chart = pathlib.Path(sys.argv[1])
+base = {
+    "dispatcher": {"slack": {"appToken": "xapp-example", "botToken": "xoxb-example"}},
+    "agentSandbox": {"runner": {"credentials": "example", "workspace": {"enabled": True}}},
+}
+workloads = {
+    "worker": ("worker.yaml", "worker"),
+    "api": ("api.yaml", "api"),
+    "dispatcher": ("dispatcher.yaml", "dispatcher"),
+    "agentSandbox.runner": ("agent-sandbox.yaml", "runner"),
+    "otelCollector": ("otel-collector.yaml", "otel-collector"),
+}
+overrides = {"OTEL_EXPORTER_OTLP_ENDPOINT", "OTEL_EXPORTER_OTLP_PROTOCOL", "OTEL_EXPORTER_OTLP_HEADERS"}
+
+def envs(output, filename, container):
+    docs = yaml.safe_load_all((output / "curie/templates" / filename).read_text())
+    def walk(value):
+        if isinstance(value, dict):
+            if value.get("name") == container and "env" in value:
+                yield value["env"]
+            for child in value.values():
+                yield from walk(child)
+        elif isinstance(value, list):
+            for child in value:
+                yield from walk(child)
+    return next(env for doc in docs for env in walk(doc))
+
+with tempfile.TemporaryDirectory() as tmp:
+    tmp = pathlib.Path(tmp)
+    values = tmp / "values.yaml"
+    values.write_text(yaml.safe_dump(base))
+    count = 0
+    def render(source=chart, *args, ok=True):
+        global count
+        count += 1
+        output = tmp / str(count)
+        result = subprocess.run(["helm", "template", "acme", str(source), "-f", str(values), "--output-dir", str(output), *args], text=True, capture_output=True)
+        if ok:
+            assert result.returncode == 0, result.stderr
+        return result, output
+    _, baseline = render()
+    for workload, (filename, container) in workloads.items():
+        for entry in envs(baseline, filename, container):
+            name = entry["name"]
+            if name in overrides or workload == "worker" and name in {"CURIE_API_URL", "CURIE_API_KEY"}:
+                continue  # Existing helpers replace, rather than duplicate, these entries.
+            result, _ = render(chart, "--set", f"{workload}.extraEnv[0].name={name}", "--set-string", f"{workload}.extraEnv[0].value=conflict", ok=False)
+            assert result.returncode != 0, f"accepted reserved {workload}.extraEnv {name}"
+            assert f"{workload}.extraEnv" in result.stderr and name in result.stderr, result.stderr
+    # Optional branches are reserved even before their feature is enabled.
+    for workload, name, replacement in [
+        ("worker", "SLACK_API_BASE_URL", "worker.slackApiBaseUrl"),
+        ("worker", "CURIE_CONNECTOR_RECONCILE", "worker.connectorReconciler.enabled"),
+        ("agentSandbox.runner", "ANTHROPIC_BASE_URL", "inference.service.port"),
+    ]:
+        result, _ = render(chart, "--set", f"{workload}.extraEnv[0].name={name}", "--set-string", f"{workload}.extraEnv[0].value=conflict", ok=False)
+        assert result.returncode != 0 and replacement in result.stderr, result.stderr
+    for workload in workloads:
+        result, _ = render(chart, "--set", f"{workload}.extraEnv[0].name=ACME_EXTENSION", "--set-string", f"{workload}.extraEnv[0].value=same", "--set", f"{workload}.extraEnv[1].name=ACME_EXTENSION", "--set-string", f"{workload}.extraEnv[1].value=same", ok=False)
+        assert result.returncode != 0 and "repeats environment variable ACME_EXTENSION" in result.stderr, result.stderr
+    for value in ("600", "901"):
+        result, _ = render(chart, "--set", "worker.runnerTotalTimeoutSeconds=600", "--set", "worker.extraEnv[0].name=CURIE_RUNNER_TOTAL_TIMEOUT_S", "--set-string", f"worker.extraEnv[0].value={value}", ok=False)
+        assert result.returncode != 0, "accepted exact or conflicting timeout duplicate"
+        assert "worker.runnerTotalTimeoutSeconds" in result.stderr, result.stderr
+    # Ordinary extension envs and the existing single-entry override contract survive.
+    _, output = render(chart, "--set", "worker.extraEnv[0].name=ACME_EXTENSION", "--set-string", "worker.extraEnv[0].value=preserved", "--set", "worker.extraEnv[1].name=CURIE_API_URL", "--set-string", "worker.extraEnv[1].value=https://api.example.com")
+    env = envs(output, "worker.yaml", "worker")
+    assert [e for e in env if e["name"] == "ACME_EXTENSION"] == [{"name": "ACME_EXTENSION", "value": "preserved"}]
+    assert [e for e in env if e["name"] == "CURIE_API_URL"] == [{"name": "CURIE_API_URL", "value": "https://api.example.com"}]
+    mutant = tmp / "mutant"
+    shutil.copytree(chart, mutant)
+    helper = mutant / "templates/_reserved-env.tpl"
+    text = helper.read_text()
+    start = '{{- if hasKey $reserved $name -}}'
+    assert text.count(start) == 1
+    helper.write_text(text.replace(start, '{{- if false -}}'))
+    _, output = render(mutant, "--set", "worker.extraEnv[0].name=CURIE_RUNNER_TOTAL_TIMEOUT_S", "--set-string", "worker.extraEnv[0].value=901")
+    duplicates = [e for e in envs(output, "worker.yaml", "worker") if e["name"] == "CURIE_RUNNER_TOTAL_TIMEOUT_S"]
+    assert len(duplicates) == 2 and duplicates[1]["value"] == "901", duplicates
+    print(f"OK: {count} Helm renders; chart-owned names rejected; exact/conflicting duplicates rejected; removed-guard control reproduced two timeout entries")
+PY

--- a/charts/curie/ci/runtime/reserved-env-upgrade-runtime.sh
+++ b/charts/curie/ci/runtime/reserved-env-upgrade-runtime.sh
@@ -104,7 +104,7 @@ for timeout in 600 599; do
   # mutate both deployments if Helm reached its apply phase.
   if helm upgrade acme "$CHART" --kube-context "$context" -n "$namespace" \
       -f "$TMP/retained.yaml" --set worker.runnerTotalTimeoutSeconds="$timeout" \
-      --set worker.upgradeDrain.enabled=true --set-string api.podAnnotations.upgrade-probe=changed \
+      --set worker.upgradeDrain.enabled=true --set-string placement.platform.annotations.upgrade-probe=changed \
       > "$TMP/refusal.log" 2>&1; then
     echo "accepted legacy duplicate on upgrade" >&2; exit 1
   fi

--- a/charts/curie/ci/runtime/reserved-env-upgrade-runtime.sh
+++ b/charts/curie/ci/runtime/reserved-env-upgrade-runtime.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Released v0.8.4 retained-values upgrade refuses duplicates before hooks/mutation.
+# Run only on an owned disposable kind cluster; no product images are started.
+set -euo pipefail
+: "${KUBECONFIG:?set a private kubeconfig for an owned disposable kind cluster}"
+context="$(kubectl config current-context)"
+[[ "$context" == kind-* ]] || { echo "requires an owned kind context" >&2; exit 2; }
+CHART="$(cd "$(dirname "$0")/../.." && pwd)"
+TMP="$(mktemp -d)"
+namespace="acme-reserved-env-${RANDOM}"
+created=false
+cleanup() {
+  if [[ "$created" == true ]]; then
+    kubectl --context "$context" delete namespace "$namespace" --wait=true --timeout=90s
+  fi
+  rm -rf "$TMP"
+}
+trap cleanup EXIT
+curl -fsSL --retry 2 https://github.com/curie-eng/curie/releases/download/v0.8.4/curie-0.8.4.tgz -o "$TMP/released.tgz"
+echo "fee20ab73c05d7a888165f980fb82d25150fcba509f19218bafc4c187a9044bb  $TMP/released.tgz" | sha256sum -c -
+[[ "$(helm show chart "$TMP/released.tgz" | awk '$1 == "version:" {print $2}')" == 0.8.4 ]]
+# The published v0.8.4 chart already has the typed timeout; its initial install
+# accepts the duplicate. Keep that observed release behavior in this fixture.
+# Zero replicas isolates Helm upgrade semantics from provider credentials or images.
+cat > "$TMP/legacy.yaml" <<'YAML'
+security:
+  allowDevDefaults: true
+  checkDefaultCredentials: false
+  gvisor:
+    enabled: false
+  networkPolicy:
+    enabled: false
+preflights:
+  avxCheck:
+    enabled: false
+  networkPolicyProbe:
+    enabled: false
+  controllerReady:
+    enabled: false
+postgres:
+  deploy: false
+  host: postgres.example.com
+valkey:
+  deploy: false
+  host: valkey.example.com
+clickhouse:
+  deploy: false
+  host: clickhouse.example.com
+rustfs:
+  deploy: false
+  host: object-store.example.com
+  egress:
+    - cidr: 192.0.2.0/24
+      port: 443
+langfuse:
+  deploy: false
+  host: traces.example.com
+otelCollector:
+  deploy: false
+  telemetryDisabled: true
+agentSandbox:
+  deploy: false
+  controller:
+    deploy: false
+api:
+  replicas: 0
+ui:
+  deploy: false
+dispatcher:
+  deploy: false
+worker:
+  replicas: 0
+  publication:
+    enabled: false
+  upgradeDrain:
+    enabled: false
+  extraEnv:
+    - name: CURIE_RUNNER_TOTAL_TIMEOUT_S
+      value: "600"
+YAML
+kubectl --context "$context" create namespace "$namespace"
+created=true
+helm install acme "$TMP/released.tgz" --kube-context "$context" -n "$namespace" -f "$TMP/legacy.yaml" --skip-crds --no-hooks
+helm get values acme --kube-context "$context" -n "$namespace" -o yaml > "$TMP/retained.yaml"
+helm get manifest acme --kube-context "$context" -n "$namespace" > "$TMP/old-manifest.yaml"
+python3 - "$TMP/old-manifest.yaml" <<'PY'
+import sys,yaml
+worker=next(d for d in yaml.safe_load_all(open(sys.argv[1])) if d and d.get('kind')=='Deployment' and d['metadata']['name']=='acme-curie-worker')
+env=worker['spec']['template']['spec']['containers'][0]['env']
+assert [e for e in env if e['name']=='CURIE_RUNNER_TOTAL_TIMEOUT_S']==[{'name':'CURIE_RUNNER_TOTAL_TIMEOUT_S','value':'600'}]*2
+print('OK: released v0.8.4 installed with two timeout entries and retained the legacy extraEnv value')
+PY
+# Let the deployment controllers observe the zero-replica fixture before snapshots.
+kubectl --context "$context" rollout status deployment/acme-curie-worker -n "$namespace" --timeout=60s
+kubectl --context "$context" rollout status deployment/acme-curie-api -n "$namespace" --timeout=60s
+snapshot() {
+  kubectl --context "$context" get deployment,service,secret,configmap,serviceaccount,role,rolebinding,job -n "$namespace" -o json |
+    python3 -c 'import json,sys; d=json.load(sys.stdin); print(json.dumps(sorted(d["items"], key=lambda x:(x["kind"],x["metadata"]["name"])),sort_keys=True))'
+}
+snapshot > "$TMP/before.json"
+helm history acme --kube-context "$context" -n "$namespace" -o json > "$TMP/history-before.json"
+for timeout in 600 599; do
+  # The enabled drain is a real pre-upgrade hook. A changed annotation would
+  # mutate both deployments if Helm reached its apply phase.
+  if helm upgrade acme "$CHART" --kube-context "$context" -n "$namespace" \
+      -f "$TMP/retained.yaml" --set worker.runnerTotalTimeoutSeconds="$timeout" \
+      --set worker.upgradeDrain.enabled=true --set-string api.podAnnotations.upgrade-probe=changed \
+      > "$TMP/refusal.log" 2>&1; then
+    echo "accepted legacy duplicate on upgrade" >&2; exit 1
+  fi
+  cat "$TMP/refusal.log"
+  rg -q 'worker.extraEnv contains chart-owned environment variable CURIE_RUNNER_TOTAL_TIMEOUT_S.*worker.runnerTotalTimeoutSeconds' "$TMP/refusal.log"
+  snapshot > "$TMP/after.json"
+  cmp "$TMP/before.json" "$TMP/after.json"
+  helm history acme --kube-context "$context" -n "$namespace" -o json > "$TMP/history-after.json"
+  cmp "$TMP/history-before.json" "$TMP/history-after.json"
+  [[ "$(kubectl --context "$context" get jobs -n "$namespace" -o jsonpath='{.items}')" == '[]' ]]
+  echo "OK: timeout=$timeout refused; release revision and all observed resources unchanged; no pre-upgrade job"
+done
+# Remove only the guard in an isolated chart copy and replay the retained values.
+cp -a "$CHART" "$TMP/mutant"
+python3 - "$TMP/mutant/templates/_reserved-env.tpl" <<'PY'
+import pathlib,sys
+p=pathlib.Path(sys.argv[1]); s=p.read_text(); old='{{- if hasKey $reserved $name -}}'; assert s.count(old)==1;p.write_text(s.replace(old,'{{- if false -}}'))
+PY
+helm template acme "$TMP/mutant" -f "$TMP/retained.yaml" --is-upgrade --output-dir "$TMP/control" >/dev/null
+python3 - "$TMP/control/curie/templates/worker.yaml" <<'PY'
+import sys,yaml
+worker=next(d for d in yaml.safe_load_all(open(sys.argv[1])) if d and d.get('kind')=='Deployment')
+env=worker['spec']['template']['spec']['containers'][0]['env']
+assert len([e for e in env if e['name']=='CURIE_RUNNER_TOTAL_TIMEOUT_S'])==2
+print('OK: removing only reserved-name guard reproduces two timeout entries from released retained values')
+PY

--- a/charts/curie/ci/runtime/reserved-env-upgrade-runtime.sh
+++ b/charts/curie/ci/runtime/reserved-env-upgrade-runtime.sh
@@ -109,7 +109,7 @@ for timeout in 600 599; do
     echo "accepted legacy duplicate on upgrade" >&2; exit 1
   fi
   cat "$TMP/refusal.log"
-  rg -q 'worker.extraEnv contains chart-owned environment variable CURIE_RUNNER_TOTAL_TIMEOUT_S.*worker.runnerTotalTimeoutSeconds' "$TMP/refusal.log"
+  grep -Eq 'worker.extraEnv contains chart-owned environment variable CURIE_RUNNER_TOTAL_TIMEOUT_S.*worker.runnerTotalTimeoutSeconds' "$TMP/refusal.log"
   snapshot > "$TMP/after.json"
   cmp "$TMP/before.json" "$TMP/after.json"
   helm history acme --kube-context "$context" -n "$namespace" -o json > "$TMP/history-after.json"

--- a/charts/curie/files/reserved-env.yaml
+++ b/charts/curie/files/reserved-env.yaml
@@ -1,0 +1,150 @@
+# Chart-owned names for each workload accepting extraEnv, including optional branches.
+# OTEL variables and worker API URL/key are supported replacements: their helpers
+# suppress the chart entry. The shared validator still refuses repeated extraEnv names.
+worker:
+  BUNDLE_BUCKET: agentSandbox.runner.bundleFetch.bucket
+  CURIE_ADAPTER_CREDENTIALS: worker.adapterCredentialsExistingSecret
+  CURIE_CLAIM_TIMEOUT_SECONDS: worker.claimTimeoutSeconds
+  CURIE_CONNECTOR_APP_NAME: nameOverride
+  CURIE_CONNECTOR_RECONCILE: worker.connectorReconciler.enabled
+  CURIE_CONNECTOR_RECONCILE_INTERVAL_S: worker.connectorReconciler.intervalSeconds
+  CURIE_CREDENTIALS: agentSandbox.runner.credentialsExistingSecret
+  CURIE_DELIVERY_BUDGET_S: worker.deliveryBudgetSeconds
+  CURIE_DELIVERY_LEASE_HEARTBEAT_S: worker.deliveryLeaseHeartbeatSeconds
+  CURIE_DELIVERY_LEASE_TTL_S: worker.deliveryLeaseTtlSeconds
+  CURIE_DELIVERY_SHUTDOWN_RESERVE_S: worker.deliveryShutdownReserveSeconds
+  CURIE_FAKE_MODEL: agentSandbox.runner.fakeModel
+  CURIE_HEARTBEAT_FILE: the chart-managed heartbeat path (remove this override)
+  CURIE_INTERNAL_WORKER_TOKEN: worker.internalWorkerToken
+  CURIE_NAMESPACE: the release namespace (Helm --namespace)
+  CURIE_PUBLICATION_CPU_LIMIT: worker.publication.resources.limits.cpu
+  CURIE_PUBLICATION_CPU_REQUEST: worker.publication.resources.requests.cpu
+  CURIE_PUBLICATION_ENABLED: worker.publication.enabled
+  CURIE_PUBLICATION_EPHEMERAL_LIMIT: worker.publication.resources.limits.ephemeral-storage
+  CURIE_PUBLICATION_EPHEMERAL_REQUEST: worker.publication.resources.requests.ephemeral-storage
+  CURIE_PUBLICATION_GITHUB_API_URL: api.githubApiUrl
+  CURIE_PUBLICATION_GIT_COMMAND_TIMEOUT_SECONDS: worker.publication.gitCommandTimeoutSeconds
+  CURIE_PUBLICATION_GIT_USER_EMAIL: worker.publication.gitUserEmail
+  CURIE_PUBLICATION_GIT_USER_NAME: worker.publication.gitUserName
+  CURIE_PUBLICATION_IMAGE_PULL_POLICY: agentSandbox.runner.imagePullPolicy
+  CURIE_PUBLICATION_IMAGE_PULL_SECRETS: agentSandbox.runner.imagePullSecrets
+  CURIE_PUBLICATION_JOB_ACTIVE_DEADLINE_SECONDS: worker.publication.jobActiveDeadlineSeconds
+  CURIE_PUBLICATION_LEASE_SECONDS: worker.publication.leaseSeconds
+  CURIE_PUBLICATION_MEMORY_LIMIT: worker.publication.resources.limits.memory
+  CURIE_PUBLICATION_MEMORY_REQUEST: worker.publication.resources.requests.memory
+  CURIE_PUBLICATION_NAMESPACE: worker.publication.namespace
+  CURIE_PUBLICATION_OWNER_NAME: worker.publication.ownerName
+  CURIE_PUBLICATION_PATCH_MAX_BYTES: worker.publication.patchMaxBytes
+  CURIE_PUBLICATION_PRIORITY_CLASS_NAME: priorityClasses.platform.name
+  CURIE_PUBLICATION_RECONCILE_INTERVAL_SECONDS: worker.publication.reconcileIntervalSeconds
+  CURIE_PUBLICATION_RECONCILE_MAX_ATTEMPTS: worker.publication.reconcileMaxAttempts
+  CURIE_PUBLICATION_RESULT_MAX_ATTEMPTS: worker.publication.resultMaxAttempts
+  CURIE_PUBLICATION_SERVICE_ACCOUNT_NAME: worker.publication.serviceAccountName
+  CURIE_RELEASE: the Helm release name
+  CURIE_ROUTE_TTL_SECONDS: worker.routeTtlSeconds
+  CURIE_RUNNER_IMAGE: agentSandbox.runner.image
+  CURIE_RUNNER_PORT: agentSandbox.runner.port
+  CURIE_RUNNER_TOTAL_TIMEOUT_S: worker.runnerTotalTimeoutSeconds
+  CURIE_SEALING_PREVIOUS_PRIVATE_KEY: sealing.previousPrivateKeyExistingSecret
+  CURIE_SEALING_PRIVATE_KEY: sealing.privateKeyExistingSecret
+  CURIE_SHIMMER: worker.shimmer
+  CURIE_SLACK_TRUSTED_ORIGINS: worker.slackTrustedOrigins
+  CURIE_STATUS_TEXT: worker.statusText
+  CURIE_SUSPENDED_ROUTE_TTL_SECONDS: worker.suspendedRouteTtlSeconds
+  CURIE_TERMINATION_GRACE_PERIOD_S: worker.terminationGracePeriodSeconds
+  CURIE_WARM_POOL: worker.warmPool
+  CURIE_WORKSPACE_ARCHIVE_TIMEOUT_SECONDS: worker.workspace.archiveTimeoutSeconds
+  CURIE_WORKSPACE_BUCKET: worker.workspace.bucket
+  CURIE_WORKSPACE_CLONE_TIMEOUT_SECONDS: worker.workspace.cloneTimeoutSeconds
+  CURIE_WORKSPACE_ENABLED: agentSandbox.runner.workspace.enabled
+  CURIE_WORKSPACE_MAX_ARCHIVE_BYTES: worker.workspace.maxArchiveBytes
+  CURIE_WORKSPACE_MAX_CHECKOUT_BYTES: worker.workspace.maxCheckoutBytes
+  CURIE_WORKSPACE_MAX_COMPRESSION_RATIO: worker.workspace.maxCompressionRatio
+  CURIE_WORKSPACE_MAX_CONCURRENT_CLONES: worker.workspace.maxConcurrentClones
+  CURIE_WORKSPACE_MAX_MEMBERS: worker.workspace.maxMembers
+  CURIE_WORKSPACE_REFERENCE_TTL_SECONDS: worker.workspace.referenceTtlSeconds
+  CURIE_WORKSPACE_SCRATCH_ROOT: worker.workspace.mountPath
+  CURIE_WORKSPACE_TOTAL_TIMEOUT_SECONDS: worker.workspace.totalTimeoutSeconds
+  CURIE_WORKSPACE_UPLOAD_TIMEOUT_SECONDS: worker.workspace.uploadTimeoutSeconds
+  DATABASE_URL: postgres.host / postgres.port / postgres.auth
+  DB_SCHEMA: the chart-managed database schema (remove this override)
+  LANGFUSE_HOST: langfuse.host / langfuse.web.service.port
+  LANGFUSE_PUBLIC_KEY: langfuse.init.projectPublicKey
+  LANGFUSE_SECRET_KEY: langfuse.existingSecret
+  POSTGRES_PASSWORD: postgres.existingSecret / postgres.auth.password
+  S3_ACCESS_KEY: rustfs.auth.accessKey
+  S3_ENDPOINT_URL: rustfs.host / rustfs.port
+  S3_SECRET_KEY: rustfs.existingSecret
+  SLACK_API_BASE_URL: worker.slackApiBaseUrl
+  SLACK_BOT_TOKEN: dispatcher.slack.botTokenExistingSecret
+  VALKEY_HOST: valkey.host
+  VALKEY_PASSWORD: valkey.existingSecret / valkey.password
+  VALKEY_PORT: valkey.port
+  VALKEY_TLS: valkey.tls
+api:
+  API_KEY: api.apiKey
+  APPROVAL_SWEEP_INTERVAL_S: api.approvalSweepIntervalSeconds
+  BUNDLE_BUCKET: agentSandbox.runner.bundleFetch.bucket
+  COMMIT_POLL_INTERVAL_S: api.commitPollIntervalSeconds
+  CURIE_APPROVAL_CHAT_ATTESTER_SECRET: api.approvalChatAttesterSecret
+  CURIE_INTERNAL_WORKER_TOKEN: worker.internalWorkerToken
+  CURIE_PUBLICATION_PATCH_MAX_BYTES: worker.publication.patchMaxBytes
+  CURIE_PUBLICATION_RETENTION_SECONDS: worker.publication.retentionSeconds
+  DATABASE_URL: postgres.host / postgres.port / postgres.auth
+  DB_SCHEMA: the chart-managed database schema (remove this override)
+  ENVIRONMENT: api.environment
+  GITHUB_API_URL: api.githubApiUrl
+  GITHUB_APP_ID: api.githubAppId
+  GITHUB_APP_PRIVATE_KEY: api.githubAppExistingSecret
+  GITHUB_CLONE_BASE: api.githubCloneBase
+  GITHUB_REPO_ALLOWLIST: api.githubRepoAllowlist
+  GITHUB_TOKEN: api.githubTokenExistingSecret
+  GITHUB_WEBHOOK_SECRET: api.githubWebhookSecret
+  LANGFUSE_HOST: langfuse.host / langfuse.web.service.port
+  LANGFUSE_PUBLIC_KEY: langfuse.init.projectPublicKey
+  LANGFUSE_SECRET_KEY: langfuse.existingSecret
+  LOG_LEVEL: api.logLevel
+  ORG_NAME: api.orgName
+  POSTGRES_PASSWORD: postgres.existingSecret / postgres.auth.password
+  RESUME_RECONCILER_BATCH_LIMIT: api.resumeReconciler.batchLimit
+  RESUME_RECONCILER_ENABLED: api.resumeReconciler.enabled
+  RESUME_RECONCILER_GRACE_SECONDS: api.resumeReconciler.graceSeconds
+  RESUME_RECONCILER_INTERVAL_SECONDS: api.resumeReconciler.intervalSeconds
+  S3_ACCESS_KEY: rustfs.auth.accessKey
+  S3_ENDPOINT_URL: rustfs.host / rustfs.port
+  S3_SECRET_KEY: rustfs.existingSecret
+  SLACK_BOT_TOKEN: dispatcher.slack.botTokenExistingSecret
+  SLACK_USERGROUP_CACHE_TTL_S: api.slackUsergroupCacheTtlSeconds
+  VALKEY_HOST: valkey.host
+  VALKEY_PASSWORD: valkey.existingSecret / valkey.password
+  VALKEY_PORT: valkey.port
+  VALKEY_TLS: valkey.tls
+dispatcher:
+  CURIE_API_KEY: api.apiKey
+  CURIE_API_PREFLIGHT_TIMEOUT_SECONDS: dispatcher.apiPreflightTimeoutSeconds
+  CURIE_API_URL: dispatcher.apiBaseUrl
+  CURIE_APPROVAL_CHAT_ATTESTER_SECRET: api.approvalChatAttesterSecret
+  CURIE_HEARTBEAT_FILE: the chart-managed heartbeat path (remove this override)
+  SLACK_APP_TOKEN: dispatcher.slack.appTokenExistingSecret
+  SLACK_BOT_TOKEN: dispatcher.slack.botTokenExistingSecret
+  SLACK_SIGNING_SECRET: dispatcher.slack.signingSecretExistingSecret
+  VALKEY_HOST: valkey.host
+  VALKEY_PASSWORD: valkey.existingSecret / valkey.password
+  VALKEY_PORT: valkey.port
+  VALKEY_TLS: valkey.tls
+agentSandbox.runner:
+  ANTHROPIC_BASE_URL: inference.service.port
+  CURIE_BUDGET: agentSandbox.runner.budget.maxOutputTokensPerRun
+  CURIE_CREDENTIALS: agentSandbox.runner.credentialsExistingSecret
+  CURIE_FAKE_MODEL: agentSandbox.runner.fakeModel
+  CURIE_MODEL: agentSandbox.runner.model
+  CURIE_PLUGIN_DIR: agentSandbox.runner.pluginDir
+  CURIE_RUNNER_PORT: agentSandbox.runner.port
+  CURIE_SANDBOX_ID: the pod identity (remove this override)
+  CURIE_SESSION_ID: the chart-managed warm session identity (remove this override)
+  GIT_CONFIG_COUNT: agentSandbox.runner.workspace.enabled
+  GIT_CONFIG_KEY_0: agentSandbox.runner.workspace.mountPath
+  GIT_CONFIG_VALUE_0: agentSandbox.runner.workspace.mountPath
+  HOME: agentSandbox.runner.hardening.home
+otelCollector:
+  LANGFUSE_OTLP_AUTH_HEADER: otelCollector.otlpAuthHeader / langfuse.existingSecret

--- a/charts/curie/templates/_reserved-env.tpl
+++ b/charts/curie/templates/_reserved-env.tpl
@@ -1,0 +1,20 @@
+{{/* Render extraEnv only after refusing collisions with chart-owned names.
+     Each workload with this extension surface has an explicit set in files/.
+     Validate names, not values: equal values also break strategic merge patches. */}}
+{{- define "curie.extraEnv" -}}
+{{- $sets := .root.Files.Get "files/reserved-env.yaml" | fromYaml -}}
+{{- $reserved := index $sets .workload -}}
+{{- if not $reserved -}}{{- fail (printf "missing reserved env set for %s" .workload) -}}{{- end -}}
+{{- $seen := dict -}}
+{{- range .env -}}
+{{- $name := .name -}}
+{{- if hasKey $reserved $name -}}
+{{- fail (printf "%s.extraEnv contains chart-owned environment variable %s; remove it from extraEnv and configure %s instead." $.workload $name (index $reserved $name)) -}}
+{{- end -}}
+{{- if hasKey $seen $name -}}
+{{- fail (printf "%s.extraEnv repeats environment variable %s; keep exactly one entry." $.workload $name) -}}
+{{- end -}}
+{{- $_ := set $seen $name true -}}
+{{- end -}}
+{{- with .env }}{{ toYaml . }}{{ end -}}
+{{- end -}}

--- a/charts/curie/templates/_reserved-env.tpl
+++ b/charts/curie/templates/_reserved-env.tpl
@@ -5,11 +5,15 @@
 {{- $sets := .root.Files.Get "files/reserved-env.yaml" | fromYaml -}}
 {{- $reserved := index $sets .workload -}}
 {{- if not $reserved -}}{{- fail (printf "missing reserved env set for %s" .workload) -}}{{- end -}}
+{{- $additionalReserved := .additionalReserved | default dict -}}
 {{- $seen := dict -}}
 {{- range .env -}}
 {{- $name := .name -}}
 {{- if hasKey $reserved $name -}}
 {{- fail (printf "%s.extraEnv contains chart-owned environment variable %s; remove it from extraEnv and configure %s instead." $.workload $name (index $reserved $name)) -}}
+{{- end -}}
+{{- if hasKey $additionalReserved $name -}}
+{{- fail (printf "%s.extraEnv contains chart-owned environment variable %s; remove it from extraEnv and configure %s instead." $.workload $name (index $additionalReserved $name)) -}}
 {{- end -}}
 {{- if hasKey $seen $name -}}
 {{- fail (printf "%s.extraEnv repeats environment variable %s; keep exactly one entry." $.workload $name) -}}

--- a/charts/curie/templates/agent-sandbox.yaml
+++ b/charts/curie/templates/agent-sandbox.yaml
@@ -602,9 +602,7 @@ spec:
               value: {{ $wf.mountPath | quote }}
             {{- end }}
             {{- include "curie.env.otel" (dict "root" . "extraEnv" $runner.extraEnv) | nindent 12 }}
-            {{- with $runner.extraEnv }}
-            {{- toYaml . | nindent 12 }}
-            {{- end }}
+            {{- include "curie.extraEnv" (dict "root" . "workload" "agentSandbox.runner" "env" $runner.extraEnv) | nindent 12 }}
           readinessProbe:
             httpGet:
               path: /healthz

--- a/charts/curie/templates/agent-sandbox.yaml
+++ b/charts/curie/templates/agent-sandbox.yaml
@@ -150,6 +150,12 @@ roleRef:
 {{- define "curie.sandboxTemplate" -}}
 {{- $agent := .agent -}}
 {{- $secrets := .secrets -}}
+{{- $connectorReservedEnv := dict -}}
+{{- if $agent -}}
+{{- range $name := keys $secrets -}}
+{{- $_ := set $connectorReservedEnv $name (printf "agentSandbox.connectorSecrets.%s.%s" $agent $name) -}}
+{{- end -}}
+{{- end -}}
 {{- with .root }}
 {{- $runner := .Values.agentSandbox.runner }}
 {{- $bf := $runner.bundleFetch }}
@@ -602,7 +608,7 @@ spec:
               value: {{ $wf.mountPath | quote }}
             {{- end }}
             {{- include "curie.env.otel" (dict "root" . "extraEnv" $runner.extraEnv) | nindent 12 }}
-            {{- include "curie.extraEnv" (dict "root" . "workload" "agentSandbox.runner" "env" $runner.extraEnv) | nindent 12 }}
+            {{- include "curie.extraEnv" (dict "root" . "workload" "agentSandbox.runner" "env" $runner.extraEnv "additionalReserved" $connectorReservedEnv) | nindent 12 }}
           readinessProbe:
             httpGet:
               path: /healthz

--- a/charts/curie/templates/api.yaml
+++ b/charts/curie/templates/api.yaml
@@ -252,9 +252,7 @@ spec:
             # the setting an operator is trying to make.
             - name: SLACK_USERGROUP_CACHE_TTL_S
               value: {{ .Values.api.slackUsergroupCacheTtlSeconds | quote }}
-            {{- with .Values.api.extraEnv }}
-            {{- toYaml . | nindent 12 }}
-            {{- end }}
+            {{- include "curie.extraEnv" (dict "root" . "workload" "api" "env" .Values.api.extraEnv) | nindent 12 }}
           ports:
             - name: http
               containerPort: 8000

--- a/charts/curie/templates/dispatcher.yaml
+++ b/charts/curie/templates/dispatcher.yaml
@@ -93,9 +93,7 @@ spec:
             # app cannot drift.
             - name: CURIE_HEARTBEAT_FILE
               value: /tmp/curie-dispatcher.heartbeat
-            {{- with .Values.dispatcher.extraEnv }}
-            {{- toYaml . | nindent 12 }}
-            {{- end }}
+            {{- include "curie.extraEnv" (dict "root" . "workload" "dispatcher" "env" .Values.dispatcher.extraEnv) | nindent 12 }}
           # No HTTP port on the dispatcher (Slack Socket Mode is outbound-only),
           # so an exec probe checks a heartbeat file a background daemon thread
           # touches each tick. The dispatcher blocks the main thread in

--- a/charts/curie/templates/otel-collector.yaml
+++ b/charts/curie/templates/otel-collector.yaml
@@ -112,9 +112,7 @@ spec:
                 secretKeyRef:
                   name: {{ include "curie.otlpAuthHeaderSecretName" . }}
                   key: otlpAuthHeader
-            {{- with .Values.otelCollector.extraEnv }}
-            {{- toYaml . | nindent 12 }}
-            {{- end }}
+            {{- include "curie.extraEnv" (dict "root" . "workload" "otelCollector" "env" .Values.otelCollector.extraEnv) | nindent 12 }}
           ports:
             - name: otlp-grpc
               containerPort: 4317

--- a/charts/curie/templates/worker.yaml
+++ b/charts/curie/templates/worker.yaml
@@ -461,9 +461,7 @@ spec:
             - name: BUNDLE_BUCKET
               value: {{ .Values.agentSandbox.runner.bundleFetch.bucket | quote }}
             {{- include "curie.env.otel" (dict "root" . "extraEnv" .Values.worker.extraEnv) | nindent 12 }}
-            {{- with .Values.worker.extraEnv }}
-            {{- toYaml . | nindent 12 }}
-            {{- end }}
+            {{- include "curie.extraEnv" (dict "root" . "workload" "worker" "env" .Values.worker.extraEnv) | nindent 12 }}
           # No HTTP port on the worker, so an exec probe checks a heartbeat file
           # the asyncio event loop touches each tick. A wedged loop stops
           # touching it -> the file goes stale -> the probe fails -> restart.


### PR DESCRIPTION
Reject chart-owned environment names supplied through `extraEnv` during Helm rendering, before upgrade hooks or Kubernetes mutations. Errors name the replacement values path. The guard covers all five extension workloads, including dynamic per-agent connector-secret names, while preserving existing overrides that emit only one entry.

Closes #2297

Fix pin: charts/curie/ci/reserved-env-assertions.sh

Candidate: `a9a260a71290563af2d1f8f1d9cb40a70277bd27`. Independent PR targeting `main`, milestone `v0.8.7`.

153 Helm renders passed, including exact/conflicting static and dynamic duplicates, generic/per-agent isolation controls, and removal of the static guard reproducing two timeout entries. Connector-secret, OTEL durability/override, Helm lint, and commit checks passed. Independent Code and Security review approved this candidate; a separate Scope review approved the final delta against its previously approved full-branch mapping.

| Tier | Required / n/a | Reason | Mode | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | No plugin packaging, ACI or runner execution change | | |
| local | n/a | No compose wiring or CLI surface change | | |
| local-release | n/a | No binary/image pin, install implementation or release compose change | | |
| cluster | required | Helm must refuse collisions before an upgrade mutates the release | live, owned kind | `KUBECONFIG=<owned kubeconfig> bash final-a9a-retained-upgrade-runtime.sh`, an owned copy of `charts/curie/ci/runtime/reserved-env-upgrade-runtime.sh` with additional dynamic-key probes. On this exact candidate, timeout600/599 and equal/conflicting connector-key duplicates were refused with actionable errors; all observed resources and release history remained identical and no pre-upgrade Job appeared. |
| live provider | n/a | Helm admission only; no provider credential execution, MCP or workspace path changes | | |
| external integration | n/a | No third-party API, Slack, webhook or OAuth behavior change | | |

The runtime fixture checksum-pins the published0.8.4 chart, whose actual initial install already contains the typed timeout and accepts two entries when legacy extraEnv is present. The retained-values upgrade refuses that configuration; removing the guard reproduces the duplicate. Dynamic-key probes clear the old worker collision first, so their refusal must come from the per-agent guard. The owned namespace, kind node, containers and kubeconfig were removed after acceptance.

- [x] Every required tier names the candidate, command, mode and observed outcome.
- [x] Each meaningful acceptance criterion has positive proof and a falsifiable negative or independent path.
- [x] No required runtime tier remains unproved.
- [x] Affected tests, lint and documentation checks pass.
- [x] Code, Scope and Security reviews approved the current candidate.
- [x] `curie dev verify-fix-pin 2442 charts/curie/ci/reserved-env-assertions.sh --json` passed on this candidate: 153 renders pass, reversing product changes fails on the reserved worker key, final outcome `PINNED`.
- [ ] Current-candidate required remote checks are green.

Keep draft until current-candidate required remote checks pass.

## Filled /implement done-check

This branch predates Brian's explicit `/implement` adoption. The once-only Fable oracle ruled the unperformed historical sequencing items N/A; it did not waive current review or runtime gates. The subsequent dynamic connector-key fix followed the separate test/source contexts prospectively. No historical stage is represented as having run later.

- [x] Failing tests committed first: prospective dynamic regression was observed red and committed as `d7171975`, then source landed as `a9a260a7`. N/A for separate historical test-commit sequencing before workflow adoption; the original failing render was still observed before its implementation.
- [x] Separate delegated native test writer and source implementer: the prospective regression and two-template fix came from distinct edit-only contexts; driver ran tests and git. N/A for retroactively splitting the original context before adoption.
- [x] Production edits authored by delegated native execution contexts; the external reviewers were read-only.
- [x] Broadened return types / changed callers: source implementer explicitly reported no public return widening. The new optional internal helper argument defaults empty; all five call sites were checked, and only per-agent runner templates supply the dynamic map.
- [x] Code review passed: Fable oracle explicitly approved the exact candidate with source-location evidence; full findings are retained in `.projects/plans/task/v087-wave1-2297.findings.code.md`.
- [x] Scope review passed: independent auto-routed review mapped the earlier complete branch, then approved all three changed files in the final delta; retained in `.projects/plans/task/v087-wave1-2297.findings.scope.md`.
- [x] Sibling paths enumerated: worker, API, dispatcher, runner SandboxTemplate and OTel collector use the shared guard; supported OTEL/worker API overrides remain single-entry. Generic and named-agent connector isolation paths are covered.
- [x] Guard demonstration: 153 real Helm renders rejected equal and conflicting reserved values. The final owned-kind retained upgrade rejected timeout600/599 and both dynamic connector collisions before resource/history changes; removing the static guard reproduced two entries.
- [x] Consolidation disposition: native post-review inspection of the four helper lines and seven per-template wiring lines found no warranted cleanup; no edits applied. `/simplify` is not exposed in this runtime, so no claim that it ran. Revalidation/re-review of an empty consolidation diff is N/A; historical full implementation sequencing is N/A per oracle applicability ruling.
- [x] Security review passed: the same authorized once-only Fable oracle explicitly approved Security; this is one invocation, not a claimed second independent reviewer. Findings are retained in `.projects/plans/task/v087-wave1-2297.findings.security.md`.
- [x] Observable operator surface verified: actual Helm errors identify the supported replacement values path and refuse mutation. Final-candidate runtime evidence was recorded after freezing the source commit; no claim of retroactive pre-commit ordering.
- [x] Deployed E2E observed: the driver exercised the final chart on an owned kind cluster, including real retained-values upgrade rejection, unchanged resources/history, and absent pre-upgrade Jobs.
- [x] Train check: issue milestone `v0.8.7`, branch based on stable `main`, PR targets `main`.
- [x] Discovery-surface proof: the cluster-observed partial-upgrade defect was exercised through a real released-chart install and candidate upgrade on kind.
- N/A Re-fix mechanism: the recorded issue concerns a newly found reserved-name collision; the prospective dynamic-name review finding was reproduced through Helm and corrected in this PR, without claiming a separate earlier shipped fix.
- [x] Full affected tests and lint: 153-render suite, connector-secret suite, OTEL durability and overrides, Helm lint, shell syntax, diff/commit checks and the Rust chart-CI inventory assertion passed. The current-candidate remote Chart lint/template/kubeconform and retained-upgrade job also passed.
- [x] Prior intent preserved: prospective source blame, ADR0009/issue1488 and existing connector/override assertions were inspected; Code review checked the full branch against those behaviors. N/A for claiming that this prospective audit preceded historical implementation.
- [x] All six E2E tiers are classified with concrete reasons in run state and the table above.
- [x] Every required tier has a passing record naming exact command, candidate, mode and observed result.
- [x] Every meaningful AC includes positive proof plus a falsifiable negative or independent path; generic/per-agent and static-guard-removal controls are explicit.
- N/A Additional P0/release-blocker/sre-bot-e2e-demo spec-vs-impl pass: issue2297 currently has only `bug` and `k8s` labels.

Review transport caveat: systemd's default interpolation changed two braced shell snippets in the Fable request. The oracle read the actual candidate files and corrected the apparent discrepancy; its source-grounded verdict is retained. Subsequent review invocations use demonstrated literal argument transport.
