### PR TITLE
fix(cli): preserve existing Secret sources across cluster upgrades

### DIFF
--- a/charts/curie/README.md
+++ b/charts/curie/README.md
@@ -1538,14 +1538,12 @@ As with `githubAppExistingSecret`, a Secret missing the referenced key fails
 that one pod at `CreateContainerConfigError` rather than the chart silently
 falling back to an empty credential.
 
-**Known gap, tracked in #1801.** None of these 22 new fields are yet covered
-by the CLI's preserved-values mechanism (the same one `COMMS_MANAGED_KEYS` and
-`GITHUB_APP_MANAGED_KEYS` give the Slack tokens and the GitHub App identity in
-`cli/src/ops.rs`). A plain `curie cluster up` runs a full `helm upgrade
---install` with no `--reuse-values`, so it resets any values key it does not
-explicitly re-supply -- set one of these fields today and keep it declared in
-the values file you pass to every `cluster up`/`helm upgrade`, the same way you
-would for any other values key the CLI does not manage yet.
+The CLI preservation mechanism covers all eight pairs outside the mail surface
+tracked by #1801. The three mail pairs were already retained with the mail
+surface and its paired worker credential source. A plain `curie cluster up`
+runs a full `helm upgrade --install` with no `--reuse-values`, so the CLI
+explicitly re-supplies each recorded source that the invocation does not
+replace or clear.
 
 ### Reserved environment variables
 

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -610,15 +610,15 @@ clickhouse:
 sealing:
   privateKey: ""
   # BYO secret (issue #1759, the same idiom every backing store and
-  # api.githubAppExistingSecret use). Wins over privateKey when set. Not yet
-  # preserved by a plain `curie cluster up` (issue #1801) -- until that lands,
-  # re-supply it (or keep it declared in your values file) on every upgrade.
+  # api.githubAppExistingSecret use). Wins over privateKey when set. A plain
+  # `curie cluster up` preserves the reference and key without generating an
+  # unused chart private key (#1801).
   privateKeyExistingSecret: ""
   privateKeyExistingSecretKey: sealingPrivateKey
   # Set only during a rotation, so values sealed to the old key keep opening
   # while repositories are resealed. Remove it once every repository is resealed.
   previousPrivateKey: ""
-  # Same BYO escape and preservation caveat as privateKeyExistingSecret above.
+  # Same BYO escape and upgrade preservation as privateKeyExistingSecret above.
   previousPrivateKeyExistingSecret: ""
   previousPrivateKeyExistingSecretKey: sealingPreviousPrivateKey
 
@@ -1074,10 +1074,9 @@ api:
   # opening-message repository selections.
   githubRepoAllowlist: []
   # BYO secret (issue #1759, the same idiom githubAppExistingSecret below
-  # uses). Wins over githubToken when set. Not yet preserved by a plain
-  # `curie cluster up` (issue #1801) -- until that lands, re-supply it (or keep
-  # it declared in your values file) on every upgrade, same as any other
-  # values key the CLI does not manage.
+  # uses). Wins over githubToken when set. A plain `curie cluster up`
+  # preserves the reference and key; an explicit inline replacement or
+  # --clear-github-token clears the recorded external source (#1801).
   githubTokenExistingSecret: ""
   githubTokenExistingSecretKey: githubToken
   # GitHub App identity (ADR-0092). The scalable alternative to githubToken
@@ -1279,10 +1278,9 @@ dispatcher:
     # uses), one per token. Each wins over its plain value when set. curie.
     # dispatcher.enabled treats a token as present whether it arrives as the
     # plain value or via its existingSecret, so a dispatcher configured
-    # entirely through BYO Secrets still deploys. Not yet preserved by a plain
-    # `curie cluster up` (issue #1801) -- `curie cluster comms` does not know
-    # about these fields yet, so re-supply them (or keep them declared in your
-    # values file) on every upgrade.
+    # entirely through BYO Secrets still deploys. A plain `curie cluster up`
+    # preserves these references and keys; `curie cluster comms` clears the
+    # app and bot token references when replacing or disconnecting them (#1801).
     appTokenExistingSecret: ""
     appTokenExistingSecretKey: slackAppToken
     botToken: ""
@@ -1785,9 +1783,8 @@ worker:
   # BYO secret (issue #1759, the same idiom githubAppExistingSecret uses).
   # Wins over adapterCredentials when set -- the referenced key must hold the
   # already-JSON-encoded slug -> secret map, not a YAML map, since the chart
-  # never re-serializes a BYO Secret's contents. Not yet preserved by a plain
-  # `curie cluster up` (issue #1801) -- re-supply it (or keep it declared in
-  # your values file) on every upgrade.
+  # never re-serializes a BYO Secret's contents. A plain `curie cluster up`
+  # preserves the reference and key alongside the typed worker map (#1801).
   adapterCredentialsExistingSecret: ""
   adapterCredentialsExistingSecretKey: adapterCredentials
   # Extra env for the worker container, list of {name, value}. For SLACK_API_BASE_URL
@@ -2045,10 +2042,9 @@ agentSandbox:
     # BYO secret (issue #1759, the same idiom githubAppExistingSecret uses),
     # for the credential that authorizes the model provider -- the most
     # sensitive value most installs carry. Wins over credentials when set.
-    # Not yet preserved by a plain `curie cluster up` (issue #1801) --
-    # `cluster up --credentials`/CURIE_MODEL_CREDENTIALS re-supply the plain
-    # value across upgrades but do not yet know about this field, so
-    # re-supply it (or keep it declared in your values file) on every upgrade.
+    # A plain `curie cluster up` preserves the reference and key. An explicit
+    # inline credential, fake model, or local model replaces the recorded
+    # external credential source (#1801).
     credentialsExistingSecret: ""
     credentialsExistingSecretKey: agentCredentials
     pluginDir: /unused

--- a/cli/src/comms.rs
+++ b/cli/src/comms.rs
@@ -62,6 +62,10 @@ pub fn connect_commands(opts: &CommsOpts) -> Vec<OpsCommand> {
             plain(&opts.common.namespace),
             plain("--reuse-values"),
             plain("--set"),
+            plain("dispatcher.slack.appTokenExistingSecret="),
+            plain("--set"),
+            plain("dispatcher.slack.botTokenExistingSecret="),
+            plain("--set"),
             secret_set("dispatcher.slack.appToken", &opts.app_token),
             plain("--set"),
             secret_set("dispatcher.slack.botToken", &opts.bot_token),
@@ -81,6 +85,10 @@ pub fn disconnect_commands(opts: &CommsOpts) -> Vec<OpsCommand> {
             plain("-n"),
             plain(&opts.common.namespace),
             plain("--reuse-values"),
+            plain("--set"),
+            plain("dispatcher.slack.appTokenExistingSecret="),
+            plain("--set"),
+            plain("dispatcher.slack.botTokenExistingSecret="),
             plain("--set"),
             plain("dispatcher.slack.appToken="),
             plain("--set"),
@@ -588,6 +596,8 @@ mod tests {
         assert_eq!(
             cmds[0].display(),
             "helm upgrade curie charts/curie -n curie --reuse-values \
+             --set dispatcher.slack.appTokenExistingSecret= \
+             --set dispatcher.slack.botTokenExistingSecret= \
              --set 'dispatcher.slack.appToken=xapp-123***' \
              --set 'dispatcher.slack.botToken=xoxb-123***' \
              --set worker.slackApiBaseUrl="
@@ -673,11 +683,30 @@ mod tests {
         assert_eq!(
             line,
             "helm upgrade curie charts/curie -n curie --reuse-values \
+             --set dispatcher.slack.appTokenExistingSecret= \
+             --set dispatcher.slack.botTokenExistingSecret= \
              --set dispatcher.slack.appToken= --set dispatcher.slack.botToken="
         );
         assert!(!line.contains("worker.slackApiBaseUrl"), "{line}");
         assert!(!line.contains("xapp-"), "{line}");
         assert!(!line.contains("xoxb-"), "{line}");
+    }
+
+    #[test]
+    fn comms_source_changes_clear_recorded_byo_tokens() {
+        let opts = CommsOpts {
+            common: common(),
+            chart: "charts/curie".into(),
+            app_token: "xapp-EXAMPLE".into(),
+            bot_token: "xoxb-EXAMPLE".into(),
+            disconnect: false,
+        };
+        for command in [connect_commands(&opts), disconnect_commands(&opts)] {
+            let args = command[0].argv();
+            for path in ["appToken", "botToken"] {
+                assert!(args.contains(&format!("dispatcher.slack.{path}ExistingSecret=")));
+            }
+        }
     }
 
     #[test]

--- a/cli/src/installation.rs
+++ b/cli/src/installation.rs
@@ -889,6 +889,14 @@ async fn complete_installation_plan(
             "dispatcher.slack.botToken".to_string(),
             comms.bot_token.clone(),
         );
+        desired.insert(
+            "dispatcher.slack.appTokenExistingSecret".to_string(),
+            String::new(),
+        );
+        desired.insert(
+            "dispatcher.slack.botTokenExistingSecret".to_string(),
+            String::new(),
+        );
         desired.insert("worker.slackApiBaseUrl".to_string(), String::new());
     }
     Ok(EffectiveInstallationPlan {

--- a/cli/src/installation.rs
+++ b/cli/src/installation.rs
@@ -773,7 +773,12 @@ fn plan_installation_inner(
         allow_egress_host: cfg.egress_hosts(),
         resolved_egress_cidrs: vec![],
         allow_web_egress: vec![],
-        fake_model: cfg.credentials.model.is_none(),
+        // Omission is not an explicit fake model request: apply and diff must
+        // preserve a recorded runner credential just like a plain cluster up.
+        fake_model: cfg
+            .set
+            .get(crate::ops::FAKE_MODEL_KEY)
+            .is_some_and(|value| value == "true"),
         credentials: cfg
             .credentials
             .model

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -551,7 +551,8 @@ pub struct UpOpts {
     pub fake_model: bool,
     /// The model credential to install with, resolved from `CURIE_CREDENTIALS`
     /// (or the deprecated `CURIE_MODEL_CREDENTIALS`). `Some(non-empty)` enables the real model;
-    /// `None` installs sealed (fake model). A credential alone opens NO egress --
+    /// `None` leaves the inline source unset; a retained external reference can
+    /// still select the real model. A credential alone opens NO egress --
     /// the model stays unreachable behind the fail-closed sandbox until a
     /// provider (`allow_egress_host`) or a raw range (`allow_web_egress`) is
     /// named (#362).
@@ -1267,7 +1268,7 @@ pub fn model_egress_status_lines(
 /// their own paths (`cluster comms`, `CURIE_MODEL_CREDENTIALS`), not
 /// generated. `langfuse.encryptionKey` must be exactly 64 hex chars, so its 32
 /// bytes are load-bearing.
-/// Values owned by `cluster comms`, not by `cluster up`.
+/// Slack credential values retained across `cluster up`.
 ///
 /// `comms` writes these with `helm upgrade --reuse-values`; `up` does a full
 /// upgrade and therefore drops anything it does not itself pass. That silently
@@ -1346,7 +1347,8 @@ const GITHUB_TOKEN_REFERENCE_KEYS: &[&str] = &[
 ///
 /// Three states, resolved once in [`up`] and consumed by the pure builder:
 /// - `Untouched`: supply nothing. Either the operator pinned the key through
-///   `--set` (theirs to own), or there is no recorded value to keep.
+///   `--set` (theirs to own), an external reference is retained separately, or
+///   there is no recorded value to keep.
 /// - `Set`: write this value through the private 0600 `-f` values file -- an
 ///   explicit `--github-token`, or the value the last run recorded.
 /// - `Clear`: write an empty value, the same shape `comms --disconnect` writes,
@@ -1609,7 +1611,7 @@ fn effective_existing_secret(
     preserved_value(existing, &reference).is_some()
 }
 
-/// Re-supply the [`COMMS_MANAGED_KEYS`] a previous `cluster comms` recorded.
+/// Re-supply the [`COMMS_MANAGED_KEYS`] the release recorded.
 ///
 /// An operator `--set` for a key always wins, and a key helm has no record of
 /// is left alone -- so this only ever preserves, never invents.
@@ -1935,8 +1937,8 @@ const MODEL_CREDENTIAL_REFERENCE_KEYS: &[&str] = &[
     "agentSandbox.runner.credentialsExistingSecretKey",
 ];
 
-/// Emitted alongside [`MODEL_CREDENTIAL_KEY`], and only when a credential is
-/// present -- see `up_commands`, which pushes both inside one `if let`.
+/// Select the real model when an inline credential or an external credential
+/// reference is supplied by the completed upgrade plan.
 pub(crate) const FAKE_MODEL_KEY: &str = "agentSandbox.runner.fakeModel";
 
 const ALLOWED_EGRESS_KEY: &str = "security.networkPolicy.allowedEgress";
@@ -6558,7 +6560,9 @@ async fn run_prepared_up(
             // recorded; on a fresh install (or an existing release that never
             // had one) there is nothing to remove, so the wording must not
             // claim there was.
-            if preserved_value(existing.as_ref(), GITHUB_TOKEN_KEY).is_some() {
+            if preserved_value(existing.as_ref(), GITHUB_TOKEN_KEY).is_some()
+                || effective_existing_secret(existing.as_ref(), &[], GITHUB_TOKEN_KEY)
+            {
                 // This is an incident-response verb, not a revocation: the
                 // running API keeps the old token until it restarts, and the
                 // token stays valid at GitHub until revoked there directly.
@@ -6579,6 +6583,14 @@ async fn run_prepared_up(
             } else {
                 ui.note("preserving the GitHub credential recorded by an earlier cluster up; pass --github-token to change it or --clear-github-token to remove it");
             }
+        }
+        GithubTokenPlan::Untouched
+            if opts
+                .secrets
+                .iter()
+                .any(|(key, value)| key == GITHUB_TOKEN_REFERENCE_KEYS[0] && !value.is_empty()) =>
+        {
+            ui.note("preserving the GitHub credential reference recorded by the release; pass --github-token to replace it or --clear-github-token to remove it");
         }
         GithubTokenPlan::Untouched => {
             // Distinct wording: an empty value with nothing recorded preserves

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -3986,8 +3986,8 @@ fn complete_up_opts_without_runner_egress(
     // this invocation makes that sealing identity change explicit.
     if preserved_value(existing, &sealing_source).is_some()
         && final_operator_value(&opts, &sealing_source).is_some_and(str::is_empty)
-        && !final_operator_value(&opts, crate::sealing::SEALING_PRIVATE_KEY)
-            .is_some_and(|value| !value.is_empty())
+        && final_operator_value(&opts, crate::sealing::SEALING_PRIVATE_KEY)
+            .is_none_or(|value| value.is_empty())
     {
         return Err(crate::exit::CliError::usage(
             "refusing to clear the active sealing private key source without an explicit replacement",

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -1560,8 +1560,10 @@ pub(crate) fn resolve_existing_secret_ref(
     Some((secret_name, data_key))
 }
 
-/// Retain only the active credential source. Explicit source changes must not
-/// revive stale inline values or let a retained reference hide a replacement.
+/// Retain only the effective credential source. A nonempty external source
+/// suppresses any recorded inline copy, while an inline replacement clears the
+/// old reference. An empty external selector does nothing when inline is
+/// already the active source.
 fn resolve_credential_values(
     existing: Option<&serde_json::Value>,
     operator_sets: &[String],
@@ -1577,16 +1579,13 @@ fn resolve_credential_values(
                 .strip_suffix("ExistingSecretKey")
                 .or_else(|| key.strip_suffix("ExistingSecret"))
                 .unwrap_or(key);
-            let reference = format!("{inline}ExistingSecret");
             let inline_replaced = operator_set_entries(operator_sets)
                 .into_iter()
                 .rev()
                 .find(|(name, _)| name.trim() == inline)
                 .is_some_and(|(_, value)| !value.is_empty());
             if (*key != inline && inline_replaced)
-                || (*key == inline
-                    && (overridden.contains(&reference)
-                        || preserved_value(existing, &reference).is_some()))
+                || (*key == inline && effective_existing_secret(existing, operator_sets, inline))
             {
                 return preserved_value(existing, key).map(|_| ((*key).to_string(), String::new()));
             }
@@ -3981,6 +3980,23 @@ fn complete_up_opts_without_runner_egress(
     clear_github_token: bool,
 ) -> Result<UpOpts> {
     let operator_sets = opts.operator_sets();
+    let sealing_source = format!("{}ExistingSecret", crate::sealing::SEALING_PRIVATE_KEY);
+    // Clearing the active external source can otherwise select a leftover
+    // recorded inline key or mint a new one. Only a replacement supplied by
+    // this invocation makes that sealing identity change explicit.
+    if preserved_value(existing, &sealing_source).is_some()
+        && final_operator_value(&opts, &sealing_source).is_some_and(str::is_empty)
+        && !final_operator_value(&opts, crate::sealing::SEALING_PRIVATE_KEY)
+            .is_some_and(|value| !value.is_empty())
+    {
+        return Err(crate::exit::CliError::usage(
+            "refusing to clear the active sealing private key source without an explicit replacement",
+        )
+        .with_fix(
+            "set sealing.privateKey to the replacement private key before clearing its source",
+        )
+        .into());
+    }
     opts.retained_mail_values = resolve_retained_mail_values(existing, &operator_sets)?;
     resolve_preserved_gvisor_mode_value(&mut opts, existing, &operator_sets);
     resolve_preserved_worker_extra_env_values(&mut opts, existing, &operator_sets);

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -1278,7 +1278,17 @@ pub fn model_egress_status_lines(
 /// Preserved the same way generated secrets are: read back from the release and
 /// re-supplied through the values file, never argv, so a bot token cannot leak
 /// into `ps` or shell history.
-const COMMS_MANAGED_KEYS: &[&str] = &["dispatcher.slack.appToken", "dispatcher.slack.botToken"];
+const COMMS_MANAGED_KEYS: &[&str] = &[
+    "dispatcher.slack.appToken",
+    "dispatcher.slack.botToken",
+    "dispatcher.slack.signingSecret",
+    "dispatcher.slack.appTokenExistingSecret",
+    "dispatcher.slack.appTokenExistingSecretKey",
+    "dispatcher.slack.botTokenExistingSecret",
+    "dispatcher.slack.botTokenExistingSecretKey",
+    "dispatcher.slack.signingSecretExistingSecret",
+    "dispatcher.slack.signingSecretExistingSecretKey",
+];
 
 /// The chart values `cluster github-app` records (ADR-0092), preserved across a
 /// plain `cluster up` for exactly the reason [`COMMS_MANAGED_KEYS`] is.
@@ -1327,6 +1337,10 @@ const REQUIRED_SECRETS: &[(&str, usize)] = &[
 /// bearer token, failing auth in a way that reads like a permissions problem
 /// rather than a missing one (#1109). Preserved, never invented.
 pub(crate) const GITHUB_TOKEN_KEY: &str = "api.githubToken";
+const GITHUB_TOKEN_REFERENCE_KEYS: &[&str] = &[
+    "api.githubTokenExistingSecret",
+    "api.githubTokenExistingSecretKey",
+];
 
 /// What `cluster up` does with [`GITHUB_TOKEN_KEY`] on this run.
 ///
@@ -1544,6 +1558,57 @@ pub(crate) fn resolve_existing_secret_ref(
     Some((secret_name, data_key))
 }
 
+/// Retain only the active credential source. Explicit source changes must not
+/// revive stale inline values or let a retained reference hide a replacement.
+fn resolve_credential_values(
+    existing: Option<&serde_json::Value>,
+    operator_sets: &[String],
+    keys: &[&str],
+) -> Vec<(String, String)> {
+    let overridden = operator_set_keys(operator_sets);
+    keys.iter()
+        .filter_map(|key| {
+            if overridden.contains(*key) {
+                return None;
+            }
+            let inline = key
+                .strip_suffix("ExistingSecretKey")
+                .or_else(|| key.strip_suffix("ExistingSecret"))
+                .unwrap_or(key);
+            let reference = format!("{inline}ExistingSecret");
+            let inline_replaced = operator_set_entries(operator_sets)
+                .into_iter()
+                .rev()
+                .find(|(name, _)| name.trim() == inline)
+                .is_some_and(|(_, value)| !value.is_empty());
+            if (*key != inline && inline_replaced)
+                || (*key == inline
+                    && (overridden.contains(&reference)
+                        || preserved_value(existing, &reference).is_some()))
+            {
+                return preserved_value(existing, key).map(|_| ((*key).to_string(), String::new()));
+            }
+            preserved_value(existing, key).map(|value| ((*key).to_string(), value))
+        })
+        .collect()
+}
+
+fn effective_existing_secret(
+    existing: Option<&serde_json::Value>,
+    operator_sets: &[String],
+    inline: &str,
+) -> bool {
+    let reference = format!("{inline}ExistingSecret");
+    if let Some((_, value)) = operator_set_entries(operator_sets)
+        .into_iter()
+        .rev()
+        .find(|(key, _)| key.trim() == reference)
+    {
+        return !value.is_empty();
+    }
+    preserved_value(existing, &reference).is_some()
+}
+
 /// Re-supply the [`COMMS_MANAGED_KEYS`] a previous `cluster comms` recorded.
 ///
 /// An operator `--set` for a key always wins, and a key helm has no record of
@@ -1552,14 +1617,7 @@ fn resolve_comms_values(
     existing: Option<&serde_json::Value>,
     operator_sets: &[String],
 ) -> Vec<(String, String)> {
-    let overridden = operator_set_keys(operator_sets);
-    COMMS_MANAGED_KEYS
-        .iter()
-        .filter(|key| !overridden.contains(**key))
-        .filter_map(|key| {
-            preserved_value(existing, key).map(|current| ((*key).to_string(), current))
-        })
-        .collect()
+    resolve_credential_values(existing, operator_sets, COMMS_MANAGED_KEYS)
 }
 
 /// Re-supply the [`GITHUB_APP_MANAGED_KEYS`] a previous `cluster github-app` recorded.
@@ -1604,6 +1662,7 @@ fn resolve_github_app_values(
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum SealingPrivateKeyDisposition {
     OperatorSet,
+    External,
     Deferred,
     Preserved,
     Generated,
@@ -1617,7 +1676,17 @@ fn sealing_private_key_disposition(
     if operator_set_keys(operator_sets).contains(crate::sealing::SEALING_PRIVATE_KEY) {
         return SealingPrivateKeyDisposition::OperatorSet;
     }
-    if preserved_value(existing, crate::sealing::SEALING_PRIVATE_KEY).is_some() {
+    if effective_existing_secret(existing, operator_sets, crate::sealing::SEALING_PRIVATE_KEY) {
+        return SealingPrivateKeyDisposition::External;
+    }
+    if resolve_credential_values(
+        existing,
+        operator_sets,
+        &[crate::sealing::SEALING_PRIVATE_KEY],
+    )
+    .iter()
+    .any(|(_, value)| !value.is_empty())
+    {
         return SealingPrivateKeyDisposition::Preserved;
     }
     if dry_run {
@@ -1631,25 +1700,11 @@ fn resolve_preserved_sealing_values(
     existing: Option<&serde_json::Value>,
     operator_sets: &[String],
 ) -> Vec<(String, String)> {
-    let overridden = operator_set_keys(operator_sets);
-    let mut resolved = Vec::new();
-
-    if !overridden.contains(crate::sealing::SEALING_PRIVATE_KEY) {
-        if let Some(current) = preserved_value(existing, crate::sealing::SEALING_PRIVATE_KEY) {
-            resolved.push((crate::sealing::SEALING_PRIVATE_KEY.to_string(), current));
-        }
-    }
-    if !overridden.contains(crate::sealing::SEALING_PREVIOUS_PRIVATE_KEY) {
-        if let Some(previous) =
-            preserved_value(existing, crate::sealing::SEALING_PREVIOUS_PRIVATE_KEY)
-        {
-            resolved.push((
-                crate::sealing::SEALING_PREVIOUS_PRIVATE_KEY.to_string(),
-                previous,
-            ));
-        }
-    }
-    resolved
+    resolve_credential_values(
+        existing,
+        operator_sets,
+        crate::sealing::SEALING_MANAGED_KEYS,
+    )
 }
 
 fn resolve_sealing_values(
@@ -1660,6 +1715,7 @@ fn resolve_sealing_values(
     if sealing_private_key_disposition(existing, operator_sets, false)
         == SealingPrivateKeyDisposition::Generated
     {
+        resolved.retain(|(key, _)| key != crate::sealing::SEALING_PRIVATE_KEY);
         resolved.insert(
             0,
             (
@@ -1861,6 +1917,7 @@ fn resolve_managed_values_for_up(
     if sealing_private_key_disposition(existing, operator_sets, dry_run)
         == SealingPrivateKeyDisposition::Generated
     {
+        values.retain(|(key, _)| key != crate::sealing::SEALING_PRIVATE_KEY);
         values.extend(
             resolve_sealing_values(existing, operator_sets)
                 .into_iter()
@@ -1873,6 +1930,10 @@ fn resolve_managed_values_for_up(
 /// The chart value holding the model credential. Named here so the secret
 /// classifier below cannot drift from the key `up_commands` actually masks.
 pub(crate) const MODEL_CREDENTIAL_KEY: &str = "agentSandbox.runner.credentials";
+const MODEL_CREDENTIAL_REFERENCE_KEYS: &[&str] = &[
+    "agentSandbox.runner.credentialsExistingSecret",
+    "agentSandbox.runner.credentialsExistingSecretKey",
+];
 
 /// Emitted alongside [`MODEL_CREDENTIAL_KEY`], and only when a credential is
 /// present -- see `up_commands`, which pushes both inside one `if let`.
@@ -1977,7 +2038,28 @@ fn resolve_preserved_runner_identity_values(
         && opts.credentials.is_none()
         && !overridden.contains(MODEL_CREDENTIAL_KEY)
     {
-        opts.credentials = preserved_value(existing, MODEL_CREDENTIAL_KEY);
+        opts.credentials =
+            resolve_credential_values(existing, operator_sets, &[MODEL_CREDENTIAL_KEY])
+                .into_iter()
+                .next()
+                .map(|(_, value)| value)
+                .filter(|value| !value.is_empty());
+    }
+
+    let mut references =
+        resolve_credential_values(existing, operator_sets, MODEL_CREDENTIAL_REFERENCE_KEYS);
+    if opts.fake_model || opts.local_model.is_some() || opts.credentials.is_some() {
+        for (_, value) in &mut references {
+            value.clear();
+        }
+    }
+    opts.secrets.extend(references);
+    if opts.credentials.is_none() {
+        opts.secrets.extend(
+            resolve_credential_values(existing, operator_sets, &[MODEL_CREDENTIAL_KEY])
+                .into_iter()
+                .filter(|(_, value)| value.is_empty()),
+        );
     }
 
     if !opts.fake_model
@@ -2180,6 +2262,9 @@ pub fn is_preserved_by_up(key: &str) -> bool {
         || key == "worker.adapterCredentialsExistingSecretKey"
         || COMMS_MANAGED_KEYS.contains(&key)
         || GITHUB_APP_MANAGED_KEYS.contains(&key)
+        || GITHUB_TOKEN_REFERENCE_KEYS.contains(&key)
+        || MODEL_CREDENTIAL_REFERENCE_KEYS.contains(&key)
+        || key == GITHUB_TOKEN_KEY
         || REQUIRED_SECRETS.iter().any(|(k, _)| *k == key)
         || crate::sealing::SEALING_MANAGED_KEYS.contains(&key)
         || key == GVISOR_MODE_KEY
@@ -3878,9 +3963,12 @@ fn resolve_github_token(
     if let Some(value) = flag.filter(|v| !v.is_empty()) {
         return GithubTokenPlan::Set(value.to_string());
     }
-    match preserved_value(existing, GITHUB_TOKEN_KEY) {
-        Some(current) => GithubTokenPlan::Set(current),
-        None => GithubTokenPlan::Untouched,
+    match resolve_credential_values(existing, operator_sets, &[GITHUB_TOKEN_KEY])
+        .into_iter()
+        .next()
+    {
+        Some((_, current)) if !current.is_empty() => GithubTokenPlan::Set(current),
+        _ => GithubTokenPlan::Untouched,
     }
 }
 
@@ -3892,7 +3980,6 @@ fn complete_up_opts_without_runner_egress(
 ) -> Result<UpOpts> {
     let operator_sets = opts.operator_sets();
     opts.retained_mail_values = resolve_retained_mail_values(existing, &operator_sets)?;
-    resolve_preserved_runner_identity_values(&mut opts, existing, &operator_sets);
     resolve_preserved_gvisor_mode_value(&mut opts, existing, &operator_sets);
     resolve_preserved_worker_extra_env_values(&mut opts, existing, &operator_sets);
     resolve_preserved_slack_trusted_origins_value(&mut opts, existing, &operator_sets);
@@ -3910,6 +3997,22 @@ fn complete_up_opts_without_runner_egress(
         // to the empty chart default (#1134, #1125). Preserve, never invent.
         opts.secrets
             .extend(resolve_preserved_values(existing, &operator_sets));
+    }
+    resolve_preserved_runner_identity_values(&mut opts, existing, &operator_sets);
+    let mut references =
+        resolve_credential_values(existing, &operator_sets, GITHUB_TOKEN_REFERENCE_KEYS);
+    if clear_github_token || github_token.is_some_and(|value| !value.is_empty()) {
+        for (_, value) in &mut references {
+            value.clear();
+        }
+    }
+    opts.secrets.extend(references);
+    if github_token.is_none_or(|value| value.is_empty()) {
+        opts.secrets.extend(
+            resolve_credential_values(existing, &operator_sets, &[GITHUB_TOKEN_KEY])
+                .into_iter()
+                .filter(|(_, value)| value.is_empty()),
+        );
     }
     opts.github_token =
         resolve_github_token(existing, &operator_sets, github_token, clear_github_token);
@@ -4247,6 +4350,16 @@ impl UpValuePlan {
     }
 }
 
+fn model_credential_source_is_set(opts: &UpOpts) -> bool {
+    opts.credentials.is_some()
+        || final_operator_value(opts, MODEL_CREDENTIAL_REFERENCE_KEYS[0])
+            .is_some_and(|value| !value.is_empty())
+        || opts
+            .secrets
+            .iter()
+            .any(|(key, value)| key == MODEL_CREDENTIAL_REFERENCE_KEYS[0] && !value.is_empty())
+}
+
 /// The ordered chart values supplied by one `cluster up`. Both the Helm command
 /// and installation diff consume this representation, so adding a value cannot
 /// update one path without updating the other.
@@ -4263,8 +4376,10 @@ pub(crate) fn up_value_plan(o: &UpOpts) -> UpValuePlan {
         plan.set("inference.deploy", "true");
         plan.set("inference.model", model);
     }
-    if let Some(credentials) = &o.credentials {
+    if model_credential_source_is_set(o) {
         plan.set(FAKE_MODEL_KEY, "false");
+    }
+    if let Some(credentials) = &o.credentials {
         plan.secret_file(
             vec![(MODEL_CREDENTIAL_KEY.to_string(), credentials.clone())],
             DiffParticipation::Include,
@@ -4301,7 +4416,15 @@ pub(crate) fn up_value_plan(o: &UpOpts) -> UpValuePlan {
             EGRESS_TCP_PORT.to_string(),
         );
     }
-    plan.secret_file(o.secrets.clone(), DiffParticipation::Preserve);
+    let (cleared, preserved) = o
+        .secrets
+        .iter()
+        .cloned()
+        .partition(|(_, value)| value.is_empty());
+    plan.secret_file(preserved, DiffParticipation::Preserve);
+    // Source changes explicitly clear obsolete values. Diff must disclose those
+    // clears instead of labeling the inactive source as preserved.
+    plan.secret_file(cleared, DiffParticipation::Include);
     if let Some(values) = &o.retained_mail_values {
         plan.entries
             .push(PlannedHelmValues::RetainedMail(values.clone()));
@@ -6336,7 +6459,10 @@ async fn run_prepared_up(
             values.keys().len()
         ));
     }
-    let preserved = resolve_preserved_values(existing.as_ref(), &operator_sets);
+    let preserved: Vec<_> = resolve_preserved_values(existing.as_ref(), &operator_sets)
+        .into_iter()
+        .filter(|(_, value)| !value.is_empty())
+        .collect();
     if !preserved.is_empty() {
         let sealing_values = preserved
             .iter()
@@ -6373,8 +6499,9 @@ async fn run_prepared_up(
             SealingPrivateKeyDisposition::Deferred => {
                 ui.note("a live run discovers sealing state and preserves an existing private key or generates one when absent; skipped here to keep --dry-run offline");
             }
-            SealingPrivateKeyDisposition::OperatorSet | SealingPrivateKeyDisposition::Preserved => {
-            }
+            SealingPrivateKeyDisposition::OperatorSet
+            | SealingPrivateKeyDisposition::External
+            | SealingPrivateKeyDisposition::Preserved => {}
         }
         if existing.is_none() && !opts.common.dry_run {
             let generated_required_secrets = opts
@@ -6541,7 +6668,7 @@ async fn run_prepared_up(
                     && !matches!(value.trim(), "" | "[]")
             });
     for (warn, msg) in model_egress_status_lines(
-        opts.credentials.is_some(),
+        model_credential_source_is_set(&opts),
         opts.local_model.is_some(),
         opts.fake_model,
         &opts.allow_egress_host,
@@ -12071,6 +12198,177 @@ mod tests {
             false,
         )
         .unwrap()
+    }
+
+    const BYO_PRESERVATION_PATHS: &[&str] = &[
+        "dispatcher.slack.appToken",
+        "dispatcher.slack.botToken",
+        "dispatcher.slack.signingSecret",
+        "agentSandbox.runner.credentials",
+        "api.githubToken",
+        "sealing.privateKey",
+        "sealing.previousPrivateKey",
+        "worker.adapterCredentials",
+    ];
+
+    fn byo_preservation_fixture() -> serde_json::Value {
+        let mut values = serde_json::json!({});
+        for path in BYO_PRESERVATION_PATHS {
+            let mut current = &mut values;
+            let parts: Vec<_> = path.split('.').collect();
+            for part in &parts[..parts.len() - 1] {
+                current = &mut current[*part];
+            }
+            let leaf = parts.last().unwrap();
+            current[format!("{leaf}ExistingSecret")] = "acme-credentials".into();
+            current[format!("{leaf}ExistingSecretKey")] = format!("{leaf}-custom").into();
+        }
+        values
+    }
+
+    #[test]
+    fn existing_secret_preservation_reaches_plain_up_helm_files_and_diff() {
+        let existing = byo_preservation_fixture();
+        for dev in [false, true] {
+            let mut input = completed_dev_up(None, vec![]);
+            input.dev = dev;
+            let opts = complete_up_opts_without_runner_egress(input, Some(&existing), None, false)
+                .unwrap();
+            let (command, _guards) = up_commands(&opts)[0].materialize_secret_files().unwrap();
+            assert!(!command.argv().contains(&"--reuse-values".to_string()));
+            let bodies = secret_values_file_bodies(&command);
+            let documents: Vec<serde_json::Value> = bodies
+                .iter()
+                .map(|body| serde_norway::from_str(body).unwrap())
+                .collect();
+            for path in BYO_PRESERVATION_PATHS {
+                for suffix in ["ExistingSecret", "ExistingSecretKey"] {
+                    let key = format!("{path}{suffix}");
+                    let expected = lookup_dotted(&existing, &key).unwrap();
+                    assert!(
+                        documents
+                            .iter()
+                            .any(|doc| lookup_dotted(doc, &key).as_deref() == Some(&expected)),
+                        "plain up dropped {key} (dev={dev})"
+                    );
+                    assert!(
+                        is_preserved_by_up(&key),
+                        "diff reports a false reset for {key}"
+                    );
+                }
+            }
+            assert!(
+                secret_for(&opts, "sealing.privateKey").is_none(),
+                "a BYO sealing key must never generate an unused chart key"
+            );
+        }
+    }
+
+    #[test]
+    fn existing_secret_preservation_respects_explicit_reference_clear_and_key_override() {
+        let existing = byo_preservation_fixture();
+        for path in BYO_PRESERVATION_PATHS {
+            let reference = format!("{path}ExistingSecret");
+            let key = format!("{path}ExistingSecretKey");
+            let opts = completed_dev_up(
+                Some(&existing),
+                vec![format!("{reference}="), format!("{key}=replacement")],
+            );
+            let plan = up_value_plan(&opts).effective_values();
+            assert_eq!(plan.get(&reference).map(String::as_str), Some(""));
+            assert_eq!(plan.get(&key).map(String::as_str), Some("replacement"));
+            assert!(secret_for(&opts, &reference).is_none());
+            assert!(secret_for(&opts, &key).is_none());
+        }
+    }
+
+    #[test]
+    fn existing_secret_preservation_explicit_inline_replaces_external_and_stale_inline_stays_absent(
+    ) {
+        let mut existing = byo_preservation_fixture();
+        existing["api"]["githubToken"] = "obsolete-inline".into();
+        existing["agentSandbox"]["runner"]["credentials"] = "obsolete-inline".into();
+        existing["dispatcher"]["slack"]["botToken"] = "obsolete-inline".into();
+        existing["sealing"]["privateKey"] = "obsolete-inline".into();
+        let opts = completed_dev_up(Some(&existing), vec![]);
+        assert!(opts.credentials.is_none());
+        assert_eq!(opts.github_token, GithubTokenPlan::Untouched);
+        assert_eq!(secret_for(&opts, "dispatcher.slack.botToken"), Some(""));
+        assert_eq!(secret_for(&opts, "sealing.privateKey"), Some(""));
+        for path in BYO_PRESERVATION_PATHS
+            .iter()
+            .filter(|path| **path != "worker.adapterCredentials")
+        {
+            let reference = format!("{path}ExistingSecret");
+            let opts = completed_dev_up(Some(&existing), vec![format!("{path}=replacement")]);
+            assert!(
+                secret_for(&opts, &reference) == Some(""),
+                "inline replacement lost to {reference}"
+            );
+        }
+        let input = completed_dev_up(None, vec![]);
+        let opts =
+            complete_up_opts_without_runner_egress(input, Some(&existing), None, true).unwrap();
+        assert_eq!(opts.github_token, GithubTokenPlan::Clear);
+        assert_eq!(secret_for(&opts, "api.githubTokenExistingSecret"), Some(""));
+        let opts = complete_up_opts_without_runner_egress(
+            completed_dev_up(None, vec![]),
+            Some(&existing),
+            Some("replacement"),
+            false,
+        )
+        .unwrap();
+        assert_eq!(secret_for(&opts, "api.githubTokenExistingSecret"), Some(""));
+    }
+
+    #[test]
+    fn existing_secret_preservation_operator_byo_sealing_does_not_generate() {
+        let opts = completed_dev_up(
+            None,
+            vec!["sealing.privateKeyExistingSecret=acme-sealing".into()],
+        );
+        assert!(
+            resolve_managed_values_for_up(None, &opts.operator_sets(), false)
+                .iter()
+                .all(|(key, _)| key != "sealing.privateKey")
+        );
+    }
+
+    #[test]
+    fn existing_secret_preservation_respects_runner_modes_and_last_inline_value() {
+        let existing = byo_preservation_fixture();
+        for mode in ["fake", "local", "inline"] {
+            let mut input = completed_dev_up(None, vec![]);
+            match mode {
+                "fake" => input.fake_model = true,
+                "local" => input.local_model = Some("acme-model".into()),
+                _ => input.credentials = Some("replacement".into()),
+            }
+            let opts = complete_up_opts_without_runner_egress(input, Some(&existing), None, false)
+                .unwrap();
+            assert!(
+                secret_for(&opts, "agentSandbox.runner.credentialsExistingSecret") == Some(""),
+                "{mode} kept obsolete source"
+            );
+        }
+        let opts = completed_dev_up(
+            Some(&existing),
+            vec![
+                "api.githubToken=replacement".into(),
+                "api.githubToken=".into(),
+            ],
+        );
+        assert_eq!(
+            secret_for(&opts, "api.githubTokenExistingSecret"),
+            Some("acme-credentials")
+        );
+        assert_eq!(
+            up_value_plan(&completed_dev_up(Some(&existing), vec![]))
+                .effective_values()
+                .get(FAKE_MODEL_KEY)
+                .map(String::as_str),
+            Some("false")
+        );
     }
 
     /// #1134 / #1125: `cluster up --dev` after `cluster comms` is a FULL

--- a/cli/src/ops.rs
+++ b/cli/src/ops.rs
@@ -12282,13 +12282,23 @@ mod tests {
         for path in BYO_PRESERVATION_PATHS {
             let reference = format!("{path}ExistingSecret");
             let key = format!("{path}ExistingSecretKey");
-            let opts = completed_dev_up(
-                Some(&existing),
-                vec![format!("{reference}="), format!("{key}=replacement")],
-            );
+            let mut set = vec![format!("{reference}="), format!("{key}=replacement")];
+            if *path == "sealing.privateKey" {
+                // A selector override is not sealing replacement material.
+                set.push(format!(
+                    "{path}=AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE="
+                ));
+            }
+            let opts = completed_dev_up(Some(&existing), set);
             let plan = up_value_plan(&opts).effective_values();
             assert_eq!(plan.get(&reference).map(String::as_str), Some(""));
             assert_eq!(plan.get(&key).map(String::as_str), Some("replacement"));
+            if *path == "sealing.privateKey" {
+                assert_eq!(
+                    plan.get(*path).map(String::as_str),
+                    Some("AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE=")
+                );
+            }
             assert!(secret_for(&opts, &reference).is_none());
             assert!(secret_for(&opts, &key).is_none());
         }

--- a/cli/src/sealing.rs
+++ b/cli/src/sealing.rs
@@ -39,7 +39,14 @@ pub const SEALING_PREVIOUS_PRIVATE_KEY: &str = "sealing.previousPrivateKey";
 /// credential in every agent repository becoming permanently unreadable. It is
 /// the same bug with a far worse blast radius, so the keys ride the same
 /// preservation path the other generated secrets do.
-pub const SEALING_MANAGED_KEYS: &[&str] = &[SEALING_PRIVATE_KEY, SEALING_PREVIOUS_PRIVATE_KEY];
+pub const SEALING_MANAGED_KEYS: &[&str] = &[
+    SEALING_PRIVATE_KEY,
+    SEALING_PREVIOUS_PRIVATE_KEY,
+    "sealing.privateKeyExistingSecret",
+    "sealing.privateKeyExistingSecretKey",
+    "sealing.previousPrivateKeyExistingSecret",
+    "sealing.previousPrivateKeyExistingSecretKey",
+];
 
 fn b64() -> base64::engine::general_purpose::GeneralPurpose {
     base64::engine::general_purpose::STANDARD

--- a/cli/tests/installation_plan_parity.rs
+++ b/cli/tests/installation_plan_parity.rs
@@ -444,11 +444,39 @@ case "$verb $object" in
     fi
     ;;
 'get svc')
+    if [ "${{CURIE_TEST_COMMS_ROLLOUTS:-}}" = 1 ]; then
+        case "$all" in
+            '-n parity get svc -l app.kubernetes.io/instance=parity,app.kubernetes.io/component=api -o jsonpath={{range .items[*]}}{{.metadata.name}}{{"\n"}}{{end}}')
+                printf '%s\n' 'parity-curie-api'
+                exit 0
+                ;;
+        esac
+    fi
     # The jsonpath asks for a Service NAME, so answer with one, for whichever
     # store component the caller named and nothing else.
     case "$all" in
         *'=="minio"'*) printf '%s\n' 'parity-minio' ;;
         *'=="rustfs"'*) printf '%s\n' 'parity-rustfs' ;;
+        *) unexpected ;;
+    esac
+    ;;
+'rollout restart')
+    if [ "${{CURIE_TEST_COMMS_ROLLOUTS:-}}" != 1 ]; then
+        unexpected
+    fi
+    case "$all" in
+        '-n parity rollout restart deployment/parity-curie-worker'|\
+        '-n parity rollout restart deployment/parity-curie-dispatcher') : ;;
+        *) unexpected ;;
+    esac
+    ;;
+'rollout status')
+    if [ "${{CURIE_TEST_COMMS_ROLLOUTS:-}}" != 1 ]; then
+        unexpected
+    fi
+    case "$all" in
+        '-n parity rollout status deployment/parity-curie-worker --timeout=120s'|\
+        '-n parity rollout status deployment/parity-curie-dispatcher --timeout=120s') : ;;
         *) unexpected ;;
     esac
     ;;
@@ -622,6 +650,7 @@ exit 0
             .env_remove("CURIE_TEST_KUBECTL_STS_AFTER_UPGRADE")
             .env_remove("CURIE_TEST_KUBECTL_FAIL")
             .env_remove("CURIE_TEST_KUBECTL_FORBIDDEN")
+            .env_remove("CURIE_TEST_COMMS_ROLLOUTS")
             .env_remove("CURIE_TEST_HELM_MIXED_STATEFULSETS")
             .env_remove("CURIE_TEST_RELEASE_SECRET")
             .env_remove("CURIE_TEST_SOURCE_LIST_FAIL")
@@ -2035,6 +2064,7 @@ fn declarative_comms_replaces_byo_sources_in_diff_and_apply_but_omission_preserv
     let env = [
         ("CURIE_TEST_DECLARATIVE_APP_TOKEN", APP_TOKEN),
         ("CURIE_TEST_DECLARATIVE_BOT_TOKEN", BOT_TOKEN),
+        ("CURIE_TEST_COMMS_ROLLOUTS", "1"),
         (
             "CURIE_TEST_CAPTURE_ALL_VALUES",
             captured.to_str().expect("UTF 8 capture path"),
@@ -2090,6 +2120,17 @@ fn declarative_comms_replaces_byo_sources_in_diff_and_apply_but_omission_preserv
             calls.contains(source),
             "the follow-up comms upgrade must consume the declared Slack replacement"
         );
+    }
+    for component in ["worker", "dispatcher"] {
+        for (action, suffix) in [("restart", ""), ("status", " --timeout=120s")] {
+            let expected = format!(
+                "KUBECTL_CALL: -n parity rollout {action} deployment/parity-curie-{component}{suffix}"
+            );
+            assert!(
+                calls.contains(&expected),
+                "the follow-up comms apply must {action} the {component} deployment:\n{calls}"
+            );
+        }
     }
 
     let retained = HelmFixture::new(
@@ -2227,7 +2268,6 @@ fn empty_inline_only_sealing_source_clear_keeps_the_recorded_identity() {
         ("/dispatcher/slack/appToken", INLINE_APP_TOKEN),
         ("/dispatcher/slack/botToken", INLINE_BOT_TOKEN),
         ("/agentSandbox/runner/credentials", INLINE_MODEL_CREDENTIAL),
-        ("/agentSandbox/runner/model", "placeholder/model"),
         ("/api/githubToken", INLINE_GITHUB_TOKEN),
     ] {
         assert!(
@@ -2237,6 +2277,14 @@ fn empty_inline_only_sealing_source_clear_keeps_the_recorded_identity() {
             "the actual Helm values lost retained {pointer}"
         );
     }
+    assert!(
+        fixture.calls().lines().any(|call| {
+            call.split_whitespace()
+                .any(|argument| argument == "agentSandbox.runner.model=placeholder/model")
+        }),
+        "the normal Helm argument must retain the recorded runner model:\n{}",
+        fixture.calls()
+    );
     assert!(
         fixture
             .calls()

--- a/cli/tests/installation_plan_parity.rs
+++ b/cli/tests/installation_plan_parity.rs
@@ -281,6 +281,10 @@ if [ "$1" = upgrade ]; then
     runner_real_mode_preserved='no'
     runner_egress_preserved='no'
     for argument in "$@"; do
+        if [ "$previous" = '-f' ] && [ -n "${CURIE_TEST_CAPTURE_ALL_VALUES:-}" ]; then
+            cat "$argument" >> "$CURIE_TEST_CAPTURE_ALL_VALUES"
+            printf '\n---\n' >> "$CURIE_TEST_CAPTURE_ALL_VALUES"
+        fi
         if [ "$previous" = '-f' ] && [ -n "${CURIE_TEST_CAPTURE_MAIL_VALUES:-}" ] && grep -Fq '"mailAdapter"' "$argument"; then
             cp "$argument" "$CURIE_TEST_CAPTURE_MAIL_VALUES"
         fi
@@ -1929,6 +1933,84 @@ fn apply_and_plain_up_preserve_omitted_mail_but_honor_explicit_source_clear() {
             "diff must disclose stripping the stale inline copy"
         );
         assert!(!fixture.calls().contains("obsolete-inline-token"));
+    }
+}
+
+#[test]
+fn existing_secret_preservation_survives_plain_cli_up_apply_and_diff() {
+    let paths = [
+        "dispatcher.slack.appToken",
+        "dispatcher.slack.botToken",
+        "dispatcher.slack.signingSecret",
+        "agentSandbox.runner.credentials",
+        "api.githubToken",
+        "sealing.privateKey",
+        "sealing.previousPrivateKey",
+        "worker.adapterCredentials",
+    ];
+    let mut existing = json!({});
+    for path in paths {
+        let mut current = &mut existing;
+        let parts: Vec<_> = path.split('.').collect();
+        for part in &parts[..parts.len() - 1] {
+            current = &mut current[*part];
+        }
+        let leaf = parts.last().unwrap();
+        current[format!("{leaf}ExistingSecret")] = json!("acme-credentials");
+        current[format!("{leaf}ExistingSecretKey")] = json!(format!("{leaf}-custom"));
+    }
+    for surface in ["up", "apply"] {
+        let fixture = HelmFixture::new(
+            installation_for_the_stateful_guard(),
+            HelmValuesResponse::Object(existing.clone()),
+        );
+        let captured = fixture.temp.path().join("all-values.yaml");
+        let env = [("CURIE_TEST_CAPTURE_ALL_VALUES", captured.to_str().unwrap())];
+        let output = if surface == "up" {
+            fixture.cluster_up_without_credentials(&env)
+        } else {
+            fixture.apply(&[], &env)
+        };
+        let visible = String::from_utf8_lossy(&output.stderr).to_string();
+        json_output(output, surface);
+        assert!(
+            !visible.contains("installing with the fake model"),
+            "BYO credential reported absent: {visible}"
+        );
+        assert!(
+            !visible.contains("generated a sealing private key"),
+            "unused sealing key generated: {visible}"
+        );
+        let body = fs::read_to_string(captured).expect("Helm consumed private values");
+        let documents: Vec<Value> = body
+            .split("\n---\n")
+            .filter(|part| !part.trim().is_empty())
+            .map(|part| serde_norway::from_str(part).unwrap())
+            .collect();
+        let diff = json_output(fixture.diff(&[]), "diff BYO references");
+        for path in paths {
+            for suffix in ["ExistingSecret", "ExistingSecretKey"] {
+                let key = format!("{path}{suffix}");
+                let pointer = format!("/{}", key.replace('.', "/"));
+                let expected = existing.pointer(&pointer).unwrap();
+                assert!(
+                    documents
+                        .iter()
+                        .any(|doc| doc.pointer(&pointer) == Some(expected)),
+                    "{surface} dropped {key}"
+                );
+                let entry = diff["entries"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .find(|entry| entry["key"] == key)
+                    .unwrap();
+                assert_eq!(
+                    entry["kind"], "preserved",
+                    "diff reports false reset for {key}: {entry}"
+                );
+            }
+        }
     }
 }
 

--- a/cli/tests/installation_plan_parity.rs
+++ b/cli/tests/installation_plan_parity.rs
@@ -2015,6 +2015,33 @@ fn existing_secret_preservation_survives_plain_cli_up_apply_and_diff() {
 }
 
 #[test]
+fn existing_secret_preservation_reports_github_reference_actions() {
+    for clear in [false, true] {
+        let fixture = HelmFixture::new(
+            installation_for_the_stateful_guard(),
+            HelmValuesResponse::Object(json!({
+                "api": {"githubTokenExistingSecret": "acme-credentials", "githubTokenExistingSecretKey": "github-custom"}
+            })),
+        );
+        let args: &[&str] = if clear {
+            &["--clear-github-token"]
+        } else {
+            &["--github-token", ""]
+        };
+        let output = fixture.cluster_up_with(args, &[]);
+        let visible = String::from_utf8_lossy(&output.stderr).to_string();
+        json_output(output, "GitHub reference action");
+        let expected = if clear {
+            "GitHub credential cleared here"
+        } else {
+            "preserving the GitHub credential reference"
+        };
+        assert!(visible.contains(expected), "{visible}");
+        assert!(!visible.contains("no GitHub credential"), "{visible}");
+    }
+}
+
+#[test]
 fn cluster_up_rerun_preserves_existing_runner_model_and_egress_configuration() {
     let fixture = HelmFixture::new(
         installation_for_the_stateful_guard(),

--- a/cli/tests/installation_plan_parity.rs
+++ b/cli/tests/installation_plan_parity.rs
@@ -2015,6 +2015,365 @@ fn existing_secret_preservation_survives_plain_cli_up_apply_and_diff() {
 }
 
 #[test]
+fn declarative_comms_replaces_byo_sources_in_diff_and_apply_but_omission_preserves_them() {
+    const APP_TOKEN: &str = "xapp-PLACEHOLDER-1801";
+    const BOT_TOKEN: &str = "xoxb-PLACEHOLDER-1801";
+    let existing = json!({
+        "dispatcher": {"slack": {
+            "appTokenExistingSecret": "acme-declarative-app-source",
+            "appTokenExistingSecretKey": "custom-app-selector",
+            "botTokenExistingSecret": "acme-declarative-bot-source",
+            "botTokenExistingSecretKey": "custom-bot-selector"
+        }}
+    });
+    let config = format!(
+        "{}comms:\n  slack:\n    app_token: CURIE_TEST_DECLARATIVE_APP_TOKEN\n    bot_token: CURIE_TEST_DECLARATIVE_BOT_TOKEN\n",
+        installation_for_the_stateful_guard()
+    );
+    let fixture = HelmFixture::new(&config, HelmValuesResponse::Object(existing.clone()));
+    let captured = fixture.temp.path().join("declarative-comms-values.yaml");
+    let env = [
+        ("CURIE_TEST_DECLARATIVE_APP_TOKEN", APP_TOKEN),
+        ("CURIE_TEST_DECLARATIVE_BOT_TOKEN", BOT_TOKEN),
+        (
+            "CURIE_TEST_CAPTURE_ALL_VALUES",
+            captured.to_str().expect("UTF 8 capture path"),
+        ),
+    ];
+
+    let diff_output = fixture.diff(&env);
+    let diff_visible = format!(
+        "{}{}",
+        String::from_utf8_lossy(&diff_output.stdout),
+        String::from_utf8_lossy(&diff_output.stderr)
+    );
+    let diff = json_output(diff_output, "diff with declarative Slack replacement");
+    for source in [
+        "dispatcher.slack.appTokenExistingSecret",
+        "dispatcher.slack.botTokenExistingSecret",
+    ] {
+        let source_entry = entry(&diff, source);
+        assert_eq!(source_entry["kind"], "change", "{source_entry}");
+        assert_eq!(source_entry["to"], "<secret>", "{source_entry}");
+    }
+    for token in [APP_TOKEN, BOT_TOKEN] {
+        assert!(
+            !diff_visible.contains(token),
+            "a declarative Slack token leaked from diff: {diff_visible}"
+        );
+    }
+
+    let apply_output = fixture.apply(&[], &env);
+    let apply_visible = format!(
+        "{}{}",
+        String::from_utf8_lossy(&apply_output.stdout),
+        String::from_utf8_lossy(&apply_output.stderr)
+    );
+    let apply = json_output(apply_output, "apply with declarative Slack replacement");
+    assert_eq!(apply["comms"], true, "{apply}");
+    for token in [APP_TOKEN, BOT_TOKEN] {
+        assert!(
+            !apply_visible.contains(token),
+            "a declarative Slack token leaked from apply: {apply_visible}"
+        );
+    }
+    let calls = fixture.calls();
+    let app_assignment = format!("dispatcher.slack.appToken={APP_TOKEN}");
+    let bot_assignment = format!("dispatcher.slack.botToken={BOT_TOKEN}");
+    for source in [
+        "dispatcher.slack.appTokenExistingSecret=",
+        "dispatcher.slack.botTokenExistingSecret=",
+        app_assignment.as_str(),
+        bot_assignment.as_str(),
+    ] {
+        assert!(
+            calls.contains(source),
+            "the follow-up comms upgrade must consume the declared Slack replacement"
+        );
+    }
+
+    let retained = HelmFixture::new(
+        installation_for_the_stateful_guard(),
+        HelmValuesResponse::Object(existing.clone()),
+    );
+    let retained_capture = retained.temp.path().join("retained-byo-comms-values.yaml");
+    let retained_env = [(
+        "CURIE_TEST_CAPTURE_ALL_VALUES",
+        retained_capture.to_str().expect("UTF 8 capture path"),
+    )];
+    let retained_diff = json_output(
+        retained.diff(&retained_env),
+        "diff without comms declaration",
+    );
+    for source in [
+        "dispatcher.slack.appTokenExistingSecret",
+        "dispatcher.slack.botTokenExistingSecret",
+    ] {
+        assert_eq!(entry(&retained_diff, source)["kind"], "preserved");
+    }
+    json_output(
+        retained.apply(&[], &retained_env),
+        "apply without comms declaration",
+    );
+    let documents: Vec<Value> = fs::read_to_string(&retained_capture)
+        .expect("plain apply Helm values")
+        .split("\n---\n")
+        .filter(|document| !document.trim().is_empty())
+        .map(|document| serde_norway::from_str(document).expect("private Helm values JSON"))
+        .collect();
+    for source in [
+        "/dispatcher/slack/appTokenExistingSecret",
+        "/dispatcher/slack/botTokenExistingSecret",
+    ] {
+        let expected = existing.pointer(source).expect("recorded BYO source");
+        assert!(
+            documents
+                .iter()
+                .any(|document| document.pointer(source) == Some(expected)),
+            "plain apply must retain {source}"
+        );
+    }
+    assert!(
+        !retained
+            .calls()
+            .contains("dispatcher.slack.appTokenExistingSecret="),
+        "an omitted comms declaration must not clear the app source:\n{}",
+        retained.calls()
+    );
+    assert!(
+        !retained
+            .calls()
+            .contains("dispatcher.slack.botTokenExistingSecret="),
+        "an omitted comms declaration must not clear the bot source:\n{}",
+        retained.calls()
+    );
+}
+
+#[test]
+fn empty_inline_only_sealing_source_clear_keeps_the_recorded_identity() {
+    const INLINE_APP_TOKEN: &str = "xapp-inline-placeholder-1801";
+    const INLINE_BOT_TOKEN: &str = "xoxb-inline-placeholder-1801";
+    const INLINE_MODEL_CREDENTIAL: &str = "model-credential-placeholder-1801";
+    const INLINE_GITHUB_TOKEN: &str = "github-token-placeholder-1801";
+    let existing = json!({
+        "dispatcher": {"slack": {
+            "appToken": INLINE_APP_TOKEN,
+            "botToken": INLINE_BOT_TOKEN
+        }},
+        "agentSandbox": {"runner": {
+            "credentials": INLINE_MODEL_CREDENTIAL,
+            "model": "placeholder/model"
+        }},
+        "api": {"githubToken": INLINE_GITHUB_TOKEN},
+        "sealing": {"privateKey": PRESERVED_SEALING_KEY}
+    });
+    let fixture = HelmFixture::new(
+        installation_for_the_stateful_guard(),
+        HelmValuesResponse::Object(existing),
+    );
+    let captured = fixture.temp.path().join("inline-sealing-values.yaml");
+    let env = [(
+        "CURIE_TEST_CAPTURE_ALL_VALUES",
+        captured.to_str().expect("UTF 8 capture path"),
+    )];
+    let output = fixture.cluster_up_with(
+        &[
+            "--set",
+            "sealing.privateKeyExistingSecret=",
+            "--set",
+            "dispatcher.slack.appTokenExistingSecret=",
+            "--set",
+            "dispatcher.slack.botTokenExistingSecret=",
+            "--set",
+            "agentSandbox.runner.credentialsExistingSecret=",
+            "--set",
+            "api.githubTokenExistingSecret=",
+        ],
+        &env,
+    );
+    let visible = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    json_output(
+        output,
+        "cluster up with an empty inline-only sealing source clear",
+    );
+    assert!(
+        !visible.contains("generated a sealing private key"),
+        "an empty source selector must not rotate sealing identity: {visible}"
+    );
+    for value in [
+        PRESERVED_SEALING_KEY,
+        INLINE_APP_TOKEN,
+        INLINE_BOT_TOKEN,
+        INLINE_MODEL_CREDENTIAL,
+        INLINE_GITHUB_TOKEN,
+    ] {
+        assert!(
+            !visible.contains(value),
+            "a retained private value leaked into CLI output: {visible}"
+        );
+    }
+    let documents: Vec<Value> = fs::read_to_string(captured)
+        .expect("cluster up Helm values")
+        .split("\n---\n")
+        .filter(|document| !document.trim().is_empty())
+        .map(|document| serde_norway::from_str(document).expect("private Helm values JSON"))
+        .collect();
+    for (pointer, expected) in [
+        ("/sealing/privateKey", PRESERVED_SEALING_KEY),
+        ("/dispatcher/slack/appToken", INLINE_APP_TOKEN),
+        ("/dispatcher/slack/botToken", INLINE_BOT_TOKEN),
+        ("/agentSandbox/runner/credentials", INLINE_MODEL_CREDENTIAL),
+        ("/agentSandbox/runner/model", "placeholder/model"),
+        ("/api/githubToken", INLINE_GITHUB_TOKEN),
+    ] {
+        assert!(
+            documents.iter().any(|document| {
+                document.pointer(pointer).and_then(Value::as_str) == Some(expected)
+            }),
+            "the actual Helm values lost retained {pointer}"
+        );
+    }
+    assert!(
+        fixture
+            .calls()
+            .contains("sealing.privateKeyExistingSecret="),
+        "the explicit empty source clear must reach Helm:\n{}",
+        fixture.calls()
+    );
+}
+
+#[test]
+fn clearing_an_active_sealing_byo_without_an_inline_replacement_refuses_before_mutation() {
+    const LEFTOVER_INLINE_KEY: &str = "LEFTOVER_INLINE_SEALING_KEY";
+    for (copy, inline) in [
+        ("no inline copy", None),
+        ("leftover inline copy", Some(LEFTOVER_INLINE_KEY)),
+    ] {
+        for surface in ["cluster up", "apply"] {
+            let mut sealing = json!({
+                "privateKeyExistingSecret": "acme-active-sealing-source",
+                "privateKeyExistingSecretKey": "active-sealing-selector"
+            });
+            if let Some(inline) = inline {
+                sealing["privateKey"] = json!(inline);
+            }
+            let existing = json!({"sealing": sealing});
+            let config = if surface == "apply" {
+                format!(
+                    "{}set:\n  sealing.privateKeyExistingSecret: \"\"\n",
+                    installation_for_the_stateful_guard()
+                )
+            } else {
+                installation_for_the_stateful_guard().to_string()
+            };
+            let fixture = HelmFixture::new(&config, HelmValuesResponse::Object(existing));
+            let output = if surface == "cluster up" {
+                fixture.cluster_up_with(&["--set", "sealing.privateKeyExistingSecret="], &[])
+            } else {
+                fixture.apply(&[], &[])
+            };
+            let visible = format!(
+                "{}{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            let error = json_error(output, &format!("{surface} with {copy}"));
+            assert!(
+                error.is_object(),
+                "the refusal must be one structured JSON object: {error}"
+            );
+            assert_eq!(
+                error["error"],
+                "refusing to clear the active sealing private key source without an explicit replacement"
+            );
+            assert_eq!(
+                error["fix"],
+                "set sealing.privateKey to the replacement private key before clearing its source"
+            );
+            assert!(
+                !fixture.calls().contains("HELM_CALL: upgrade "),
+                "{surface} with {copy} must stop before Helm mutation:\n{}",
+                fixture.calls()
+            );
+            assert!(
+                !visible.contains("acme-active-sealing-source"),
+                "the external Secret name leaked in the refusal: {visible}"
+            );
+            assert!(
+                !visible.contains(LEFTOVER_INLINE_KEY),
+                "the stale inline key leaked in the refusal: {visible}"
+            );
+        }
+    }
+}
+
+#[test]
+fn explicit_inline_sealing_replacement_allows_an_active_byo_clear_without_generation() {
+    let existing = json!({
+        "sealing": {
+            "privateKeyExistingSecret": "acme-active-sealing-source",
+            "privateKeyExistingSecretKey": "active-sealing-selector"
+        }
+    });
+    for surface in ["cluster up", "apply"] {
+        let config = if surface == "apply" {
+            format!(
+                "{}set:\n  sealing.privateKeyExistingSecret: \"\"\n  \
+                 sealing.privateKey: {PRESERVED_SEALING_KEY:?}\n",
+                installation_for_the_stateful_guard()
+            )
+        } else {
+            installation_for_the_stateful_guard().to_string()
+        };
+        let fixture = HelmFixture::new(&config, HelmValuesResponse::Object(existing.clone()));
+        let replacement = format!("sealing.privateKey={PRESERVED_SEALING_KEY}");
+        let output = if surface == "cluster up" {
+            fixture.cluster_up_with(
+                &[
+                    "--set",
+                    "sealing.privateKeyExistingSecret=",
+                    "--set",
+                    replacement.as_str(),
+                ],
+                &[],
+            )
+        } else {
+            fixture.apply(&[], &[])
+        };
+        let visible = format!(
+            "{}{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        json_output(
+            output,
+            &format!("{surface} with explicit sealing replacement"),
+        );
+        assert!(
+            !visible.contains("generated a sealing private key"),
+            "the supplied replacement must prevent a second generated key: {visible}"
+        );
+        assert!(
+            !visible.contains(PRESERVED_SEALING_KEY),
+            "the replacement private key leaked into CLI output: {visible}"
+        );
+        let calls = fixture.calls();
+        assert!(
+            calls.contains("sealing.privateKeyExistingSecret="),
+            "{surface} must clear the active external source: {calls}"
+        );
+        assert!(
+            calls.contains(&replacement),
+            "{surface} must consume the exact replacement private key: {calls}"
+        );
+    }
+}
+
+#[test]
 fn existing_secret_preservation_reports_github_reference_actions() {
     for clear in [false, true] {
         let fixture = HelmFixture::new(


### PR DESCRIPTION
## Summary

A plain `curie cluster up` now retains all eight credential `existingSecret` and `existingSecretKey` pairs. Explicit source replacements and disconnects clear obsolete references, while removing an active external sealing-key source without an explicit nonempty replacement refuses before Helm mutation. `up`, `apply`, and `diff` now agree about the resulting credential sources.

Closes #1801

Fix pin: cli/tests/installation_plan_parity.rs::existing_secret_preservation_survives_plain_cli_up_apply_and_diff

Candidate: `9cf3d81d8b6a9917e247ee0a4e3d839d3758c565`, independently based on `1a4775d0ae93eceb7e4c950dac7233deb9a43308` (`main`).

## Acceptance evidence

- AC 1-5: an exact-candidate plain `cluster up` on an owned kind cluster retained all 16 source fields and all 11 rendered Secret references. The base control dropped 14 fields; the pre-existing typed worker mail pair survived on both sides.
- AC 6: the exact-head whole-PR fix pin passed (`PINNED`), proving the production reversal breaks the selected `up`/`apply`/`diff` parity regression.
- AC 7 and source transitions: exact-candidate Helm execution retained the fields with an empty `curie.yaml`; GitHub clear and Slack disconnect stayed cleared through another plain `up`. Two active sealing-source removal cases exited 2 before mutation, while explicit replacement and the inline-only no-op each advanced exactly one expected revision.

| Tier | Decision | Exact observation |
| --- | --- | --- |
| skill | N/A | No plugin packaging, runner-loop, ACI-event, skill-eval, or skill-check behavior changed. |
| local | Required, passed | `CURIE_E2E_TIERS=local CURIE_E2E_LIVE=0 curie dev e2e-ladder` passed against an exact-head source archive in a private nested Docker daemon. It covered a positive turn, failure recovery, approval resume, observability negatives, and complete cleanup. |
| local-release | N/A | No released-binary install path, version pin, image identity policy, or release Compose behavior changed. |
| cluster | Required, passed | Exact candidate CLI and Helm on owned kind retained 16/16 fields and 11/11 manifest references; the baseline dropped 14. Guard, replacement, clear, disconnect, and plain-up controls passed. |
| live provider | Required, passed | The exact candidate runner consumed a retained Kubernetes Secret reference and completed one `z-ai/glm-5.3` turn with the exact expected reply. Removing that source produced `CreateContainerConfigError` before start. |
| external integration | Required, passed | The exact candidate dispatcher consumed the retained bot-token Secret reference and posted exactly one reconciled Slack reply. The exact-head disconnect and subsequent plain `up` kept the Slack sources absent. |

An additional bounded `apps.connections.open` diagnostic remains unverified after two private response-capture failures. It is not used as acceptance evidence: #1801 changes source retention, and the required Slack integration tier is established by the real bot-token reply plus the disconnect/plain-up negative.

The exact PR head has 41 passing checks and no pending or failed checks. The byte-identical implementation content passed 2,211 Cargo tests plus formatting, clippy, Helm lint, and docs validation before the rebase; exact-head CI repeated the repository Rust and chart lanes. Post-rebase formatting, Helm lint, docs validation, the hands-on local rung, kind controls, and the whole-PR fix pin also pass.

## Implementation done-check

- [x] N/A — this run adopted an existing Long Horizon candidate, so the prospective “failing tests committed before any implementation” sequencing rule cannot apply retroactively; retained red controls reproduce the dropped references and unsafe key-generation behavior.
- [x] All production-code fixes were performed by delegated native Codex executors; the driver and adversarial reviewers made no production edits.
- [x] The broadened `resolve_credential_values` result was audited at every caller; the Code review enumerates handling for comms, sealing, runner, GitHub, notes, and `SealingPrivateKeyDisposition::External`.
- [x] Agent-router Code review approved the final implementation content with file-and-line prior-intent evidence.
- [x] Agent-router Scope review approved every non-trivial hunk against AC 1-7, required transition controls, or the chart caveat correction.
- [x] Sibling-path parity covers plain `up`, installation `apply`/`diff`, Slack connect/disconnect, GitHub clear/replacement, fake/local model overrides, sealing dispositions, and the typed worker mail path.
- [x] Guard demonstration executed the real CLI consumer: both unsafe active sealing-source removals exited 2 before Helm mutation, with release revision, values, manifest, and release Secret unchanged.
- [x] Consolidation ran and applied no edits, so revalidation and consolidation re-review were N/A.
- [x] Agent-router Security review approved the reconciled credential-source and sealing-key behavior.
- [x] Observable verification covers every user-facing source-preservation, replacement, clear, refusal, and `--json` result change.
- [x] Required deployed E2E passed on exact-head local and kind surfaces, with live provider and Slack observations bound to exact source/image identities.
- [x] Train check passed: the branch targets `main` for milestone v0.8.7.
- [x] N/A — this is a tracked bug fix, not a discovery ticket.
- [x] N/A — no prior merged fix of the #1801 symptom exists.
- [x] Full affected tests, formatting, clippy, Helm lint, docs validation, exact-head CI, and the exact-head whole-PR fix pin pass.
