### PR TITLE
Preserve primary skill-up failure diagnostics in the E2E harness

### DIFF
--- a/cli/scripts/e2e.sh
+++ b/cli/scripts/e2e.sh
@@ -435,8 +435,13 @@ fi
 if [[ -n "${CURIE_E2E_OTEL:-}" ]]; then
     START_ARGS+=(--otel-endpoint "$CURIE_E2E_OTEL")
 fi
-UP_OUTPUT="$("$BIN" skill up "${START_ARGS[@]}" 2>&1)"
-printf '%s\n' "$UP_OUTPUT"
+if UP_OUTPUT="$("$BIN" skill up "${START_ARGS[@]}" 2>&1)"; then
+    printf '%s\n' "$UP_OUTPUT"
+else
+    UP_STATUS=$?
+    printf '%s\n' "$UP_OUTPUT" >&2
+    exit "$UP_STATUS"
+fi
 
 # The boot panel must NAME the model path it resolved. `skill up` picks the
 # credential at boot (commands::select_passthrough_env) but used to say nothing

--- a/cli/tests/nightly_graded_ladder.rs
+++ b/cli/tests/nightly_graded_ladder.rs
@@ -1665,6 +1665,10 @@ json.dump(d, open(p, "w"))' "$(cat "$STUB_STATE/last_plugin_dir")/evals/cases.js
         printf '%s\n' '{"release_found":true}'
         ;;
     "skill up --plugin-dir . --image curie-runner --port 7245 --name curie-e2e-runner --fake-model")
+        if [ -n "${STUB_PRIMARY_SKILL_UP_ERROR:-}" ]; then
+            printf '%s\n' "$STUB_PRIMARY_SKILL_UP_ERROR" >&2
+            exit 7
+        fi
         # The skill rung's identity surface. `skill up` packs an IMMUTABLE
         # snapshot of the source as it stands now and the runner keeps it for its
         # whole lifetime, so the digest is recorded here and replayed by
@@ -1865,6 +1869,9 @@ esac
         &dir.join("docker"),
         r#"#!/bin/sh
 set -u
+if [ -n "${STUB_DOCKER_INVOCATION_LOG:-}" ]; then
+    printf '%s\n' "$*" >> "$STUB_DOCKER_INVOCATION_LOG"
+fi
 case "$*" in
     "inspect curie-runner-local")
         # e2e.sh's ownership precondition: the standard interactive runner is
@@ -2073,6 +2080,8 @@ fn run_ladder_script(script: &Path, harness: &Path, envs: &[(&str, &str)]) -> Ou
         .env_remove("CURIE_FAKE_MODEL")
         .env_remove("CURIE_API_KEY")
         .env_remove("CURIE_API_URL")
+        .env_remove("STUB_PRIMARY_SKILL_UP_ERROR")
+        .env_remove("STUB_DOCKER_INVOCATION_LOG")
         .env_remove("STUB_EXISTING_LOCAL_STACK")
         .env_remove("STUB_RUNS_EXTRA_JSON")
         .env_remove("STUB_UNAVAILABLE_EXIT")
@@ -2634,6 +2643,57 @@ fn parity_passes_when_every_rung_reports_the_same_identity() {
         "the ladder must name the common suite's case ids, so a reader can see \
          WHICH case set every rung shared rather than taking `parity` on \
          trust; transcript:\n{transcript}"
+    );
+}
+
+/// Ref #2423: a refused primary boot must expose its diagnostic through the real
+/// skill ladder, retain its exit status, and still remove the owned runner.
+#[test]
+fn skill_up_failure_surfaces_diagnostic_preserves_exit_and_cleans_up() {
+    let harness = tempfile::tempdir().expect("create harness directory");
+    write_ladder_stubs(harness.path());
+    let invocation_log = harness.path().join("curie-invocations.log");
+    let docker_log = harness.path().join("docker-invocations.log");
+    let diagnostic = "stub primary skill up refused: diagnostic-marker-2423";
+
+    let output = run_ladder(
+        harness.path(),
+        &[
+            ("CURIE_E2E_TIERS", "skill"),
+            ("STUB_PRIMARY_SKILL_UP_ERROR", diagnostic),
+            ("STUB_INVOCATION_LOG", invocation_log.to_str().unwrap()),
+            ("STUB_DOCKER_INVOCATION_LOG", docker_log.to_str().unwrap()),
+        ],
+    );
+
+    let transcript = transcript(&output);
+    assert_eq!(
+        output.status.code(),
+        Some(7),
+        "the primary boot refusal must retain its exit status; transcript:\n{transcript}"
+    );
+    assert!(
+        transcript.contains(diagnostic),
+        "the captured skill up diagnostic must reach the operator; transcript:\n{transcript}"
+    );
+    let invocations = fs::read_to_string(invocation_log).expect("read Curie invocations");
+    let commands: Vec<_> = invocations.lines().collect();
+    let primary_up = commands
+        .iter()
+        .position(|command| {
+            *command == "skill up --plugin-dir . --image curie-runner --port 7245 --name curie-e2e-runner --fake-model"
+        })
+        .expect("the primary skill up must have been attempted");
+    assert!(
+        commands[primary_up + 1..].is_empty(),
+        "no subsequent skill, eval, or local action may follow the refused boot; invocations:\n{invocations}"
+    );
+    let docker_invocations = fs::read_to_string(docker_log).expect("read Docker invocations");
+    assert!(
+        docker_invocations
+            .lines()
+            .any(|command| command == "rm -f curie-e2e-runner"),
+        "the failure must still invoke cleanup for the owned runner; invocations:\n{docker_invocations}"
     );
 }
 


### PR DESCRIPTION
## Summary

When the primary `curie skill up` command failed during the skill E2E harness, Bash exited before printing its captured output. Print that failure output to stderr and retain the original exit status, so CI exposes the diagnostic while preserving cleanup and the successful path.

Ref #2423. This change addresses captured failure diagnostics only; it does not close the issue's directory-ownership or complete live-ladder requirements.

## Fix pin verification

Fix pin: cli/tests/nightly_graded_ladder.rs::skill_up_failure_surfaces_diagnostic_preserves_exit_and_cleans_up

`curie dev verify-fix-pin 3219ba20f43b10ae7c195a99cf59c154a34e44f5 cli/tests/nightly_graded_ladder.rs::skill_up_failure_surfaces_diagnostic_preserves_exit_and_cleans_up` → `PINNED`.

## Verification

The regression invokes the real `e2e-ladder.sh` and `e2e.sh` scripts using their existing subprocess stubs. Injecting a primary boot refusal proves its diagnostic reaches the transcript, exit 7 is retained, owned cleanup is invoked, and no later Curie operation follows the refusal. Before the implementation, this test failed specifically because the captured diagnostic was absent. The unchanged positive parity control also passes.

- `cargo test --manifest-path cli/Cargo.toml --test nightly_graded_ladder -- --test-threads=1` — 38 passed, 0 failed.
- `cargo clippy --manifest-path cli/Cargo.toml --test nightly_graded_ladder -- -D warnings` — passed.
- `cargo fmt --manifest-path cli/Cargo.toml --check` and `bash -n cli/scripts/e2e.sh` — passed.

Hands-on verification also ran the candidate shell with a single owned-container-name substitution, a real source-equivalent CLI binary, and a pinned local runner image. The valid weather bundle completed with `E2E PASS`; an empty bundle exited 1 and surfaced `no plugin manifest`, with owned resources removed. This proves the harness diagnostic behavior, not live provider acceptance.

Routed Code and Scope review passed on `3219ba20` with zero blocking findings. Nonblocking observations remain: the test merges stdout/stderr, and the second re-up capture is outside this primary-boot slice. All review processes and temporary sessions were verified absent.

- [x] Tests present and green: 38 nightly harness controls pass; diagnostic control observed red before implementation.
- [x] Quick path: separate test/source contexts and failing-test-first commits N/A; delegated native executor made edits, driver ran git/tests.
- [x] Code review passed: second routed Grok/default result on 3219ba20; zero blocking findings, two advisory observations retained.
- [x] Scope review passed: second routed Grok/default result on 3219ba20; zero passengers and each hunk mapped to an AC.
- [x] Changed return types/contracts: N/A; shell invocation and exit contract retained.
- [x] Sibling path scope: primary boot only; second re-up capture explicitly deferred in Ref #2423 scope.
- [x] Guard/failure outcome: primary refused boot retains exit7 in consumer test and exit1 in real Docker harness run, with cleanup and no later Curie operation.
- [x] Security review: N/A; no new credential, authorization, API or tenant surface.
- [x] Real affected surface exercised: actual candidate shell with one literal owned-container-name substitution; real source-equivalent CLI and pinned runner image. Valid bundle passes; invalid bundle exposes missing-manifest diagnostic.
- [x] All six tiers classified: local required and passed; skill/local-release/cluster/live-provider/external-integration N/A with concrete reasons in run state.
- [x] Each AC has positive/control proof tied to candidate3219ba20 and retained logs.
- [x] Prior intent preserved: successful boot output checks, original exit, and existing EXIT trap unchanged; reviewed.
- [x] Final affected suite, formatting, clippy, and bash syntax pass; exact fix pin reports PINNED.
- [x] Spec-vs-impl extra pass: N/A; Ref #2423 only, no closing keyword.
- [x] Runtime cleanup: owned containers/network names absent; review sessions/dirs absent; review units MainPID0 inactive/dead.
Merge remains gated on this pull request's required GitHub checks passing.

