### PR TITLE
Refuse a declared-but-unbound approval route at configuration time

### DIFF
--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -76,6 +76,13 @@ worker, Postgres, RustFS/S3, Langfuse, and GitHub.
   modal, or a git push. Do not
   duplicate validation logic in a new entry point; route through
   `bundles.py`.
+- **The declared/bound approval-route join has exactly one home
+  (`apps/api/src/curie_api/deploy.py`'s `check_approval_route_bindings` family,
+  #2436).** It is called in front of every deployment-creation site, every
+  bundle attachment onto a version an active deployment already references,
+  and the `approval_routes` write. It checks presence of a binding, not its
+  validity -- the worker keeps the validity backstop. Do not duplicate this
+  check per entry point.
 - **Observability endpoints are read-only proxies, not new stores.** The
   `/observability/metrics/*` endpoints compute aggregates from Langfuse's
   public API (`metrics.py` + `langfuse.py`); the runner-pod-log endpoint

--- a/apps/api/src/curie_api/bundles.py
+++ b/apps/api/src/curie_api/bundles.py
@@ -7,6 +7,7 @@ router; this module is pure intake logic.
 """
 
 import io
+import json
 import tarfile
 import tempfile
 import zipfile
@@ -18,10 +19,13 @@ from plugin_format import (
     DEFAULT_MAX_MEMBERS,
     DEFAULT_MAX_UNCOMPRESSED_BYTES,
     MANIFEST_LOCATIONS,
+    ApprovalPolicy,
+    PluginManifest,
     UnsupportedArchive,
     ValidationResult,
     bundle_root,
     connector_render,
+    resolve_manifest,
     safe_extract,
     validate_bundle,
 )
@@ -42,6 +46,7 @@ from plugin_format.yaml_loader import safe_load_unique
 __all__ = [
     "UnsupportedArchive",
     "bundle_root",
+    "declared_approval_routes",
     "detect_format",
     "extract_and_validate",
     "extract_stored_bundle",
@@ -142,6 +147,72 @@ def extract_stored_bundle(
         max_compression_ratio=max_compression_ratio,
         max_members=max_members,
     )
+
+
+def declared_approval_routes(root: Path) -> set[str] | None:
+    """The approval routes a bundle DECLARES, or ``None`` when it declares poison.
+
+    The deploy-time half of the declared/bound approval-route join (#2436). The
+    runtime counterpart is
+    ``runner/src/curie_runner/approval.py::resolve_approval_policy``, and this
+    reader reproduces it step for step. Code cannot be shared across that seam --
+    ``packages/plugin-format`` is a frozen interface and ``curie_api`` must not
+    import ``curie_runner`` -- so the rule is frozen in
+    ``tests/vectors/approval-route-normalization.json`` and EXECUTED from both
+    sides. Drift here is the #453/#544 fail-open shape: a bundle passes the
+    configuration gate and then boots with a different set of gates.
+
+    The declared set is ``set(route_by_tool.values())`` of the loader's LAST-WINS
+    ``{stripped gate: stripped route}`` map, deliberately NOT the union of every
+    gate's route value. Two gates naming one tool are a last-wins duplicate
+    ``validate_bundle`` accepts and the runner boots, and the earlier route can
+    never be raised at runtime -- so unioning would refuse a deploy over a route
+    that does not exist.
+
+    ``None`` is the poison value, returned on exactly the condition the runner
+    raises ``ApprovalPolicyError`` and refuses to boot: a declared gate name that
+    arms no tool, which is what a blank stripped ``gate`` or a blank stripped
+    ``route`` produces. An unreadable manifest or an ``approvalPolicy`` that does
+    not parse is poison too, for the same reason ``resolve_approval_policy``
+    treats it as one -- once a policy is declared, a parse error cannot revoke
+    the intent, and reading it as "declares nothing" would accept, at
+    configuration time, a bundle the runner will not run. The caller turns
+    ``None`` into a refusal (``deploy.check_routes_from_bytes``).
+
+    An empty set is reserved for the honest cases AC4 rests on: no manifest, no
+    ``approvalPolicy``, or an explicitly empty ``gates`` list.
+    """
+
+    manifest_path = resolve_manifest(bundle_root(root))
+    if manifest_path is None:
+        # `validate_bundle` already refuses a manifestless bundle at every
+        # storage entry point, so this is the defensive branch, not a real one.
+        return set()
+    try:
+        raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        # A manifest that will not parse cannot prove it declares no policy.
+        return None
+    if not isinstance(raw, dict) or raw.get("approvalPolicy") is None:
+        return set()
+    try:
+        manifest = PluginManifest.model_validate(raw)
+        policy = ApprovalPolicy.model_validate(manifest.approvalPolicy)
+    except (ValueError, TypeError):
+        return None
+    routes = {
+        gate.gate.strip(): gate.route.strip()
+        for gate in policy.gates
+        if gate.gate and gate.gate.strip() and gate.route and gate.route.strip()
+    }
+    # Compare DISTINCT declared names against armed names, not counts, exactly as
+    # the loader does: two entries for one tool are the last-wins duplicate
+    # above, while a gate whose name survives here but armed nothing is the
+    # partially armed policy the runner refuses to boot.
+    declared_names = {gate.gate.strip() for gate in policy.gates if isinstance(gate.gate, str)}
+    if declared_names - set(routes):
+        return None
+    return set(routes.values())
 
 
 def read_connectors(root: Path) -> ConnectorsFile:

--- a/apps/api/src/curie_api/crud.py
+++ b/apps/api/src/curie_api/crud.py
@@ -208,6 +208,27 @@ async def agent_has_active_deployment(session: AsyncSession, agent_id: uuid.UUID
     return result is not None
 
 
+async def version_has_active_deployment(session: AsyncSession, version_id: uuid.UUID) -> bool:
+    """Whether an active deployment row ALREADY points at this version (#2436).
+
+    The version-scoped sibling of ``agent_has_active_deployment``, and the
+    condition that makes the approval-route gate on a bundle attachment
+    conditional. An ordinary pre-deployment upload stays unrestricted, because
+    the CLI's ``prepare_deploy`` uploads before ``curie <tier> approvals`` binds;
+    an attachment onto a version the worker's resolve query can already boot
+    (``curie_worker.binding`` joins ``deployments.status = 'active'`` to
+    ``agent_versions.bundle_ref``) is the moment the bundle goes live, so it is
+    gated like a deployment.
+    """
+
+    result = await session.scalar(
+        select(Deployment.id)
+        .where(Deployment.version_id == version_id, Deployment.status == "active")
+        .limit(1)
+    )
+    return result is not None
+
+
 async def delete_agent(session: AsyncSession, agent_id: uuid.UUID) -> None:
     # Remove child rows first, then the agent. Bulk deletes bypass the ORM
     # relationship cascade (which would emit an async lazy-load during flush) and
@@ -661,6 +682,40 @@ async def get_active_deployment(
         .limit(1)
     )
     return result
+
+
+async def list_active_deployment_versions(
+    session: AsyncSession, agent_id: uuid.UUID
+) -> list[AgentVersion]:
+    """Every DISTINCT version the agent has an active deployment of, one query.
+
+    Deliberately NOT built on ``get_active_deployment`` (#2436). That helper
+    returns only the NEWEST active row per environment, which is the right answer
+    to "what is current" and the wrong set for "what can this write strand":
+    git-flow appends a new active row per push without superseding older ones,
+    ``end_deployment`` marks exactly one row stopped, and the worker's resolve
+    query orders over ALL active rows
+    (``apps/worker/src/curie_worker/binding.py``). So several active rows
+    routinely coexist in one environment, and a check built on "newest per
+    environment" would let an operator end the newest deployment and immediately
+    unbind a route an older, still-active, still-bootable row declares.
+
+    Rows sharing a version share one bundle object, so the join collapses them
+    here rather than leaving the caller to de-duplicate a row list: each version
+    comes back once, ordered by the earliest active row pointing at it.
+
+    ``get_active_deployment`` is left unchanged: ``create_deployment_row``'s
+    ``workspace_enabled`` inheritance depends on its "newest" semantics.
+    """
+
+    result = await session.scalars(
+        select(AgentVersion)
+        .join(Deployment, Deployment.version_id == AgentVersion.id)
+        .where(Deployment.agent_id == agent_id, Deployment.status == "active")
+        .group_by(AgentVersion.id)
+        .order_by(func.min(Deployment.deployed_at))
+    )
+    return list(result)
 
 
 async def list_deployments(

--- a/apps/api/src/curie_api/deploy.py
+++ b/apps/api/src/curie_api/deploy.py
@@ -8,10 +8,13 @@ per-version key.
 import hashlib
 import tempfile
 import uuid
+from collections.abc import Iterable
 from pathlib import Path
+from typing import Any
 
 import plugin_format
 from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.concurrency import run_in_threadpool
 
 from . import bundles, crud
 from .config import Settings, get_settings
@@ -31,12 +34,137 @@ class BundleInvalid(Exception):
 class BundleTooLarge(Exception):
     """An already-stored bundle fails the CURRENT size/ratio caps.
 
-    Raised by ``revalidate_stored_bundle`` -- the backward-compatibility case
-    ADR-0059 decision 3 commits to: a bundle stored before these caps existed
+    Raised by ``revalidate_stored_bundle``, and by the route checker below when
+    it extracts those same stored bytes (#2436) -- the backward-compatibility
+    case ADR-0059 decision 3 commits to: a bundle stored before these caps existed
     (or under looser ones) must be rejected here, at deploy time, with an
     actionable message, rather than surfacing later as an opaque
     init-container failure or a mid-extract eviction on the node.
+
+    ``code`` is the git-flow half of the same commitment the message below is:
+    it lets ``gitflow._rejected`` build the rejection envelope out of the
+    exception alone, so the code an operator greps for and the sentence they
+    read can never come from two different places.
     """
+
+    code = "bundle.too_large"
+
+    @classmethod
+    def for_stored_bundle(cls, version_id: uuid.UUID, exc: Exception) -> "BundleTooLarge":
+        """The one wording for "these stored bytes no longer fit the caps".
+
+        Several bounds checks can be the first to reach that condition on a
+        given delivery -- ``revalidate_stored_bundle``, git flow's reuse-path
+        ``deploy.yaml`` read, and (since #2436) the route checker's own extract
+        -- and ADR-0059 decision 3's commitment is an operator-facing MESSAGE,
+        not just a code. Building it here keeps the sentence identical whichever
+        one fires, the same way ``ApprovalRoutesUnbound`` builds its two
+        envelopes from one place.
+        """
+
+        return cls(
+            f"stored bundle for version {version_id} fails the current bundle "
+            f"size/ratio limits and must be rebuilt and re-uploaded: {exc}"
+        )
+
+
+class ApprovalRoutesUnbound(Exception):
+    """A version's bundle declares an approval route the agent never bound (#2436).
+
+    The configuration-time half of a join nothing cross-checked before: routes
+    DECLARED in the bundle manifest (``approvalPolicy.gates[].route``, versioned
+    with the agent) against routes BOUND by the operator
+    (``agents.approval_routes``, per agent, mutable). ADR-0050's rationale
+    already asserts the residual widening it leaves open is bounded because "the
+    bundle can only name a route the operator has itself bound to a channel";
+    ADR-0046 refuses an unbound one at REQUEST time, by escalating, which is too
+    late to stop a bad deploy. This exception is where that claim becomes true.
+
+    PRESENCE of a key in ``approval_routes`` is the join. The binding's CONTENTS
+    are deliberately not checked: ``ApprovalRouteBinding`` already requires a
+    resolution target for anything written through the API, so a malformed entry
+    can only arrive by a direct JSONB write, and validity-checking here would put
+    a third copy of the worker's authority envelope in the codebase for the
+    copies to drift. "Bound to junk" stays the worker's request-time fail-closed
+    backstop (``curie_worker.kernel``'s ``_parse_approval_targets``, ADR-0046),
+    which this change must not weaken; this gate closes only "declared but never
+    bound".
+
+    Carries both route lists, and builds both messages, so the two envelopes --
+    an API 422 detail and the git push ``approval_routes.unbound``
+    ``WebhookResult`` error -- render one wording from one place, the same way
+    ``BundleTooLarge`` does for its two. The ``code`` that git-push envelope
+    carries lives here too, so ``gitflow._rejected`` needs nothing but the
+    exception.
+    """
+
+    code = "approval_routes.unbound"
+
+    def __init__(self, message: str, *, unbound: Iterable[str], bound: Iterable[str]) -> None:
+        super().__init__(message)
+        self.unbound = sorted(unbound)
+        self.bound = sorted(bound)
+
+    @classmethod
+    def for_routes(
+        cls, version_id: uuid.UUID, *, unbound: Iterable[str], bound: Iterable[str]
+    ) -> "ApprovalRoutesUnbound":
+        """The ordinary refusal: these declared routes have no binding."""
+
+        return cls(
+            f"the bundle for version {version_id} declares approval route(s)"
+            f" {_quoted(unbound)} with no entry in this agent's approval_routes;"
+            f" {_bound_clause(bound)}. Bind every declared route on this agent"
+            " before deploying this version.",
+            unbound=unbound,
+            bound=bound,
+        )
+
+    @classmethod
+    def for_unreadable_policy(
+        cls, version_id: uuid.UUID, *, bound: Iterable[str]
+    ) -> "ApprovalRoutesUnbound":
+        """The fail-closed refusal: the declared set itself cannot be read.
+
+        Distinct wording because the operator's fix is a different one: the
+        bundle is at fault, not the bindings. Accepting instead would be the
+        fail-open shape ADR-0050 exists to prevent, and it is why the reader
+        returns a poison value rather than an empty set.
+        """
+
+        return cls(
+            f"the bundle for version {version_id} declares an approvalPolicy whose routes"
+            " cannot be read, so they cannot be checked against this agent's"
+            f" approval_routes; {_bound_clause(bound)}. Rebuild the bundle so every"
+            " declared gate names a tool and a route, then deploy it again.",
+            unbound=(),
+            bound=bound,
+        )
+
+
+def _quoted(names: Iterable[str]) -> str:
+    """Route names, sorted and quoted with ``!r``.
+
+    ``repr`` rather than bare text so a padded or oddly cased key is VISIBLE in
+    the error: both runtime consumers of this map (``kernel.py``'s
+    ``(approval_routes or {}).get(route_name)`` and
+    ``crud.get_approval_route_binding``) do an exact dict lookup, so `" ops "`
+    binds nothing and the operator has to be able to see why.
+    """
+
+    return ", ".join(repr(name) for name in sorted(names))
+
+
+def _bound_clause(bound: Iterable[str]) -> str:
+    """Name the BOUND routes alongside the unbound ones.
+
+    The same courtesy the runner's in-turn tool error already gives the model
+    (``resolve_policy_route``: "pass route as one of: ..."), so an operator can
+    see the typo without a second request.
+    """
+
+    names = sorted(bound)
+    return f"bound routes are {_quoted(names)}" if names else "this agent binds no approval routes"
 
 
 def validate_archive(
@@ -92,10 +220,119 @@ async def revalidate_stored_bundle(
             max_members=settings.bundle_max_members,
         )
     except plugin_format.UnsupportedArchive as exc:
-        raise BundleTooLarge(
-            f"stored bundle for version {version.id} fails the current bundle "
-            f"size/ratio limits and must be rebuilt and re-uploaded: {exc}"
-        ) from exc
+        raise BundleTooLarge.for_stored_bundle(version.id, exc) from exc
+
+
+def _declared_routes(data: bytes, settings: Settings) -> set[str] | None:
+    """Blocking half of ``check_routes_from_bytes``; run in a threadpool."""
+
+    with tempfile.TemporaryDirectory() as tmp:
+        dest = Path(tmp)
+        bundles.extract_stored_bundle(
+            data,
+            dest,
+            max_uncompressed_bytes=settings.bundle_max_uncompressed_bytes,
+            max_compression_ratio=settings.bundle_max_compression_ratio,
+            max_members=settings.bundle_max_members,
+        )
+        return bundles.declared_approval_routes(dest)
+
+
+async def check_routes_from_bytes(
+    data: bytes, routes: Any, version_id: uuid.UUID, settings: Settings | None = None
+) -> None:
+    """Refuse an archive's own bytes when they declare a route ``routes`` lacks.
+
+    For the callers that already hold the bytes -- the bundle upload, where the
+    object is not stored yet, and git flow's fresh-clone attach -- so neither
+    pays a store round trip. Extraction is bounded by the operator-configured
+    ``Settings`` caps, never ``plugin_format``'s library defaults (#815), and
+    runs off the event loop, following ``gitflow._read_stored_targets``.
+
+    Reading and deciding are ONE call so the reader's ``None`` poison value
+    never leaves this module. Handed out, it would ask every caller to remember
+    that an empty-looking answer means "refuse", and a caller that forgets is
+    exactly the fail-open shape ADR-0050 exists to prevent.
+
+    Raises ``bundles.UnsupportedArchive`` when a cap refuses the bytes. That is
+    left untranslated here because both byte-holding callers cleared
+    ``validate_archive`` under these same caps a moment earlier, so only the
+    stored-bytes wrapper below -- where the caps CAN have moved under the object
+    -- maps it onto ``BundleTooLarge``.
+    """
+
+    settings = settings or get_settings()
+    declared = await run_in_threadpool(_declared_routes, data, settings)
+    _raise_if_routes_unbound(declared, routes, version_id)
+
+
+def _raise_if_routes_unbound(
+    declared: set[str] | None, routes: Any, version_id: uuid.UUID
+) -> None:
+    """The pure decision: refuse unless every declared route has a binding.
+
+    Comparison is VERBATIM and case-sensitive, because the two lookups this
+    protects are exact dict lookups (see ``_quoted``). A ``declared`` of ``None``
+    is the reader's poison value and refuses. A ``routes`` that is not a dict
+    (a direct JSONB write) counts as no bindings, mirroring
+    ``crud.get_approval_route_binding``'s ``isinstance(..., dict)`` guard rather
+    than raising. A bound route no bundle declares is never an error: the join is
+    one directional, and pre-binding ahead of a bundle bump is supported (AC2).
+    """
+
+    bound: set[str] = set(routes) if isinstance(routes, dict) else set()
+    if declared is None:
+        raise ApprovalRoutesUnbound.for_unreadable_policy(version_id, bound=bound)
+    unbound = declared - bound
+    if unbound:
+        raise ApprovalRoutesUnbound.for_routes(version_id, unbound=unbound, bound=bound)
+
+
+async def check_approval_route_bindings(
+    store: ObjectStore,
+    version: AgentVersion,
+    routes: Any,
+    settings: Settings | None = None,
+) -> None:
+    """Refuse a version whose stored bundle declares a route ``routes`` lacks.
+
+    The store-fetching wrapper, for the callers that hold a version rather than
+    bytes. A no-op when the version carries no bundle yet, exactly like
+    ``revalidate_stored_bundle`` -- and that no-op is precisely why the bundle
+    upload and git flow's attach need their own conditional gate: "deploy
+    bundleless, then attach" would otherwise walk straight past this into the
+    worker's active-deployment join (``curie_worker.binding``).
+
+    ``routes`` is the map to judge: the agent's own ``approval_routes`` for the
+    callers asking about the stored state, or the PROPOSED map the
+    ``PATCH /agents/{id}`` preflight is about to write -- where an explicit
+    ``{}`` is a real proposal and is judged, not skipped. Two exceptions come out
+    of here -- ``ApprovalRoutesUnbound``, and ``BundleTooLarge`` for stored bytes
+    the current caps refuse; a store failure propagates exactly as it already
+    does from ``revalidate_stored_bundle``.
+    """
+
+    if version.bundle_ref is None:
+        return
+    settings = settings or get_settings()
+    data = await store.get(version.bundle_ref)
+    try:
+        await check_routes_from_bytes(data, routes, version.id, settings)
+    except plugin_format.UnsupportedArchive as exc:
+        # Reading what the bundle DECLARES means extracting it, and this
+        # wrapper's bytes are STORED bytes -- so an operator who tightened the
+        # caps under an already-live bundle would otherwise get an uncaught
+        # extraction error out of a gate that has nothing to say about routes
+        # (#2436). Stored bytes that no longer fit have one settled answer
+        # (ADR-0059 decision 3): `bundle.too_large`, naming the version to
+        # rebuild. Translating here rather than at each call site keeps
+        # that answer in one place, and keeps it off the byte-holding callers,
+        # whose archive cleared `validate_archive` under these same caps moments
+        # earlier. Exact, not a catch-all: `safe_extract` also raises this for
+        # unsafe entries, but those were refused before the object could be
+        # stored and the key is immutable, so a cap violation is all that is
+        # left -- the reasoning git flow's reuse path already records.
+        raise BundleTooLarge.for_stored_bundle(version.id, exc) from exc
 
 
 async def store_bundle(

--- a/apps/api/src/curie_api/gitflow.py
+++ b/apps/api/src/curie_api/gitflow.py
@@ -396,6 +396,26 @@ def log_push_outcome(result: WebhookResult, payload: dict[str, object], *, sourc
     )
 
 
+def _rejected(exc: deploy.ApprovalRoutesUnbound | deploy.BundleTooLarge) -> WebhookResult:
+    """The rejection envelope for the two refusals `process_push` shares with the API.
+
+    `approval_routes.unbound` (#2436) can fire at three sites -- the two bundle
+    attachments and the deployment itself -- and `bundle.too_large` (ADR-0059
+    decision 3) at four: the reuse path's `deploy.yaml` read, the revalidation
+    before deployment, and both route gates, which extract a STORED object to
+    learn what it declares and so inherit the caps question. One home for all of
+    them, reading the code and the message off the exception itself, so what an
+    operator greps for cannot come out different depending on which check got
+    there first. The message is the exception's own, identical to the one the
+    API returns as a 422 detail.
+    """
+
+    return WebhookResult(
+        status="rejected",
+        errors=[{"code": exc.code, "message": str(exc)}],
+    )
+
+
 async def process_push(
     session: AsyncSession,
     store: ObjectStore,
@@ -545,11 +565,7 @@ async def process_push(
                 # as `bundle.unsupported` instead would regress an
                 # operator-facing error contract as a side effect of a
                 # performance fix.
-                raise deploy.BundleTooLarge(
-                    f"stored bundle for version {prebuilt.id} fails the current "
-                    f"bundle size/ratio limits and must be rebuilt and "
-                    f"re-uploaded: {exc}"
-                ) from exc
+                raise deploy.BundleTooLarge.for_stored_bundle(prebuilt.id, exc) from exc
         else:
             archive = await run_in_threadpool(
                 clone_and_archive,
@@ -586,9 +602,7 @@ async def process_push(
         # The same code the `revalidate_stored_bundle` block below returns, so a
         # legacy over-cap bundle reports identically whichever of the two
         # bounds checks reaches it first.
-        return WebhookResult(
-            status="rejected", errors=[{"code": "bundle.too_large", "message": str(exc)}]
-        )
+        return _rejected(exc)
     except deploy.BundleInvalid as exc:
         return WebhookResult(status="rejected", errors=exc.errors)
 
@@ -618,7 +632,28 @@ async def process_push(
     # version must not enqueue a second job for the same version.
     bundle_built = version is None or version.bundle_ref is None
     if bundle_built:
+        # Bundle-once, bind-many (ADR-0091). A sibling agent in this repository
+        # may already hold this exact commit -- the dev push that ran minutes
+        # ago. Reuse its stored object rather than uploading the same bytes
+        # again: prod then promotes not merely an identical artifact but the
+        # SAME one, which is what makes "promote what you validated" a property
+        # of the schema rather than of discipline. Resolved before anything is
+        # written, because it decides WHICH object the route check below has to
+        # read, and the lookup needs no version row of this agent's own.
+        sibling = await _bundled_version_for_commit(
+            session, repo_agents, after, exclude_agent_id=agent.id
+        )
         if version is None:
+            # The row, and only the row, precedes the refusal below: it is the
+            # BUNDLE that must not be written yet (#2436). A bundleless row is
+            # inert -- `_bundled_version_for_commit` returns only bundled rows,
+            # the worker's boot join requires a `bundle_ref`
+            # (`curie_worker.binding`), and `bundle_built` above stays true for
+            # it -- so a refused push leaves exactly the residue a store that
+            # failed after its row committed already leaves, and a repaired
+            # redelivery still counts as a build. It is created here rather than
+            # after the check because the refusal has to NAME a version, and
+            # `deploy` builds the one message both envelopes render.
             version = await crud.create_version_row(
                 session,
                 agent.id,
@@ -626,16 +661,51 @@ async def process_push(
                 created_by=GIT_FLOW_CREATED_BY,
                 commit_sha=after,
             )
-        # Bundle-once, bind-many (ADR-0091). A sibling agent in this repository
-        # may already hold this exact commit -- the dev push that ran minutes
-        # ago. Reuse its stored object rather than uploading the same bytes
-        # again: prod then promotes not merely an identical artifact but the
-        # SAME one, which is what makes "promote what you validated" a property
-        # of the schema rather than of discipline.
-        sibling = await _bundled_version_for_commit(
-            session, repo_agents, after, exclude_agent_id=agent.id
-        )
+        # The declared/bound approval-route join on the ATTACHMENT (#2436), run
+        # on every delivery that builds a bundle and BEFORE that bundle is
+        # written -- not, as it first landed, only when an active deployment
+        # already referenced this version.
+        #
+        # WHY IT PRECEDES THE WRITE rather than being left to the deployment
+        # gate below. `bundle_built` is `version.bundle_ref is None`, and it is
+        # also what gates the eval fan-out: a version's eval-as-CI run happens
+        # exactly once, on the delivery that builds its bundle. Both writers
+        # here -- `crud.attach_bundle` and `deploy.store_bundle` -- commit
+        # immediately, so a refusal arriving after either of them spends that
+        # one chance: the operator binds the missing route, redelivers the same
+        # sha, `bundle_built` is now false because the bundle is already stored,
+        # the deployment succeeds, and no eval ever runs for that version.
+        # Refusing first leaves the version bundleless, so the repaired
+        # redelivery is still a build and still fans out its eval, exactly once.
+        #
+        # Running it unconditionally also subsumes the "only when this version
+        # is already live" form this gate first had: refusing whether or not an
+        # active deployment points at the version is strictly the stronger of
+        # the two, and it keeps an unbound bundle out of the object store rather
+        # than merely off a deployment.
+        #
+        # Each branch checks the object it ACTUALLY attaches, and the two can
+        # differ: the sibling branch attaches `sibling.bundle_ref`, which a
+        # bundleless sibling version may have received as an API-uploaded gated
+        # bundle while this delivery cloned the original, ungated commit.
+        # Checking the in-hand archive there would pass on the ungated bytes and
+        # then commit the gated reference. Neither branch re-clones; the stored
+        # sibling object or the bytes already in hand are read (#1211).
         if sibling is not None:
+            try:
+                await deploy.check_approval_route_bindings(
+                    store, sibling, agent.approval_routes, settings
+                )
+            except (deploy.BundleTooLarge, deploy.ApprovalRoutesUnbound) as exc:
+                # `bundle.too_large` is live here, not theoretical: the sibling
+                # object is a DIFFERENT object from the archive
+                # `validate_archive` cleared moments ago, and on this path
+                # nothing revalidates it -- `bundle_built` is true, so the
+                # `revalidate_stored_bundle` block below is skipped. This gate's
+                # extract is the only bounds check the attached object gets, so
+                # an over-cap legacy sibling is refused here and is not attached
+                # (ADR-0059 decision 3).
+                return _rejected(exc)
             version = await crud.attach_bundle(
                 session, version, str(sibling.bundle_ref), str(sibling.bundle_sha256)
             )
@@ -647,6 +717,12 @@ async def process_push(
             # branch above attaches it. So `archive` here is always freshly
             # cloned, and `validate_archive` has always supplied the pair.
             assert extension is not None and content_type is not None
+            try:
+                await deploy.check_routes_from_bytes(
+                    archive, agent.approval_routes, version.id, settings
+                )
+            except deploy.ApprovalRoutesUnbound as exc:
+                return _rejected(exc)
             await deploy.store_bundle(
                 store, session, agent.id, version, archive, extension, content_type
             )
@@ -674,10 +750,38 @@ async def process_push(
         try:
             await deploy.revalidate_stored_bundle(store, version, settings)
         except deploy.BundleTooLarge as exc:
-            return WebhookResult(
-                status="rejected",
-                errors=[{"code": "bundle.too_large", "message": str(exc)}],
+            return _rejected(exc)
+
+    # The declared/bound approval-route join at the moment the version becomes
+    # the thing that boots (#2436), the push-side twin of the 422 that
+    # `POST /deployments` returns. After the revalidation above, so an over-cap
+    # legacy bundle still reports `bundle.too_large` first (ADR-0059 decision 3),
+    # and after `resolve_target_agent`, so the map judged is the RESOLVED
+    # agent's own: one repository builds several agents (ADR-0091), so a prod
+    # promote is re-evaluated against the prod agent's bindings and never
+    # inherits the dev pass. Reads the stored object, never a re-clone (#1211).
+    #
+    # REUSE PATH ONLY. This is where a prod promote, and a redelivery of a
+    # version that already carries its bundle, are refused -- the deliveries
+    # that write no bundle of their own and so never reach the pre-write gate
+    # above. On the build path that gate has already judged the very object this
+    # delivery attached (the sibling object, or the archive `store_bundle`
+    # wrote), against this same resolved agent's map, so repeating the check
+    # here would fetch and extract those bytes a second time to reach the
+    # identical answer.
+    if not bundle_built:
+        try:
+            await deploy.check_approval_route_bindings(
+                store, version, agent.approval_routes, settings
             )
+        except (deploy.BundleTooLarge, deploy.ApprovalRoutesUnbound) as exc:
+            # `bundle.too_large` is unreachable here while
+            # `revalidate_stored_bundle` above guards the same bytes under the
+            # same caps, and is caught anyway so the ordering is a property of
+            # this block rather than of that one: it stays ahead of
+            # `approval_routes.unbound` on the reuse path (ADR-0059 decision 3)
+            # even if the revalidation is ever moved or narrowed.
+            return _rejected(exc)
 
     deployment = await crud.create_deployment_row(
         session,

--- a/apps/api/src/curie_api/routers/agents.py
+++ b/apps/api/src/curie_api/routers/agents.py
@@ -15,7 +15,7 @@ from sqlalchemy.exc import DBAPIError, IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.concurrency import run_in_threadpool
 
-from .. import bundles, crud
+from .. import bundles, crud, deploy
 from ..auth import require_api_key
 from ..config import get_settings
 from ..deps import SessionDep, StoreDep
@@ -150,7 +150,9 @@ async def get_agent(agent_id: uuid.UUID, session: SessionDep) -> AgentOut:
 
 
 @router.patch("/{agent_id}", response_model=AgentOut)
-async def update_agent(agent_id: uuid.UUID, data: AgentUpdate, session: SessionDep) -> AgentOut:
+async def update_agent(
+    agent_id: uuid.UUID, data: AgentUpdate, session: SessionDep, store: StoreDep
+) -> AgentOut:
     # No binding key here since ADR-0118: an agent may hold several bindings, so
     # "move the agent's channel" has no referent and the write surface is the
     # `/agents/{agent_id}/channels` subresource below. A caller still sending the
@@ -158,6 +160,42 @@ async def update_agent(agent_id: uuid.UUID, data: AgentUpdate, session: SessionD
     agent = await crud.get_agent(session, agent_id)
     if agent is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "agent not found")
+    # The declared/bound approval-route join, judged BEFORE the first mutation
+    # (#2436). A write to `approval_routes` is a full replacement (`--route`,
+    # `--routes-from` and `--clear-routes` all replace the whole map), so
+    # dropping a route a live bundle declares strands the human its gate exists
+    # to reach exactly as effectively as a bad deploy does; ADR-0050's bounded
+    # residual has to hold on this side of the join too.
+    #
+    # It is a PREFLIGHT rather than a check beside the write further down
+    # because the field blocks below commit through independently committing
+    # helpers, so a refusal placed at the `approval_routes` block would leave
+    # `model`, `thinking`, `memory` and `approval_required_tools` persisted from
+    # a request this handler answered 422.
+    #
+    # EVERY active row is judged, in both environments: git-flow appends a new
+    # active row per push without superseding older ones and `end_deployment`
+    # stops exactly one row, so several coexist and the worker boots from an
+    # ordering over all of them. Rows sharing a version share one bundle object,
+    # so `list_active_deployment_versions` collapses them to one version each --
+    # which turns the common case of repeated pushes of one version into a
+    # single fetch.
+    if data.approval_routes is not None:
+        proposed = {name: b.model_dump() for name, b in data.approval_routes.items()}
+        for version in await crud.list_active_deployment_versions(session, agent_id):
+            try:
+                await deploy.check_approval_route_bindings(store, version, proposed)
+            except deploy.BundleTooLarge as exc:
+                # Learning what a live bundle declares means extracting it, so
+                # this preflight inherits the caps question even when the write
+                # keeps every declared route bound. Unlike `POST /deployments`,
+                # nothing here calls `revalidate_stored_bundle` first, so this is
+                # where an over-cap stored bundle surfaces -- as the same
+                # actionable 422 that endpoint returns (ADR-0059 decision 3),
+                # never a 500.
+                raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, str(exc)) from exc
+            except deploy.ApprovalRoutesUnbound as exc:
+                raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, str(exc)) from exc
     # Presence, not truthiness (#1310). `is not None` conflates "the client did
     # not mention this field" with "the client explicitly sent null", so setting
     # either override used to be a one-way door: nothing could put it back to the
@@ -181,6 +219,9 @@ async def update_agent(agent_id: uuid.UUID, data: AgentUpdate, session: SessionD
         agent = await crud.update_agent_approval_tools(session, agent, data.approval_required_tools)
     if data.approval_routes is not None:
         # Omitted leaves the bindings unchanged; an explicit {} clears them (#247).
+        # Only the write: the preflight at the top of this handler has already
+        # judged this same map against every active deployment's declared routes
+        # (#2436), because by here four other fields are already committed.
         agent = await crud.update_agent_approval_routes(
             session,
             agent,

--- a/apps/api/src/curie_api/routers/bundles.py
+++ b/apps/api/src/curie_api/routers/bundles.py
@@ -120,6 +120,36 @@ async def upload_bundle(
             {"detail": "bundle failed validation", "errors": exc.errors},
         ) from exc
 
+    # The declared/bound approval-route join, CONDITIONAL on this version already
+    # being live (#2436). `DeploymentCreate` carries no bundle and
+    # `revalidate_stored_bundle` no-ops on a null `bundle_ref`, so a version can
+    # be deployed bundleless and only THEN receive its bundle -- and the worker's
+    # resolve query joins `deployments.status = 'active'` to
+    # `agent_versions.bundle_ref` (`curie_worker.binding`), so that attachment
+    # puts a gated bundle live with no deployment gate ever having run. It is the
+    # same "a bundle becomes the thing that boots" moment, arriving from the
+    # other side.
+    #
+    # Unconditional here would refuse the documented onboarding order instead:
+    # the CLI's `prepare_deploy` uploads the bundle BEFORE `curie <tier>
+    # approvals` binds the route, and a bundle that is never deployed strands
+    # nobody. The incoming bytes are read directly rather than through the store,
+    # because the object is not stored yet at this point. Placed after
+    # `validate_archive` so a malformed bundle still reports its own validation
+    # errors first, and before `store_bundle` so a refusal writes no object and
+    # leaves `bundle_ref` null -- `crud.attach_bundle` commits immediately, so a
+    # check placed after it would already be live.
+    if await crud.version_has_active_deployment(session, version_id):
+        agent = await crud.get_agent(session, agent_id)
+        if agent is None:  # pragma: no cover -- the version lookup above proves it
+            raise HTTPException(status.HTTP_404_NOT_FOUND, "agent not found")
+        try:
+            await deploy.check_routes_from_bytes(
+                data, agent.approval_routes, version_id, get_settings()
+            )
+        except deploy.ApprovalRoutesUnbound as exc:
+            raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, str(exc)) from exc
+
     return await deploy.store_bundle(
         store, session, agent_id, version, data, extension, content_type
     )

--- a/apps/api/src/curie_api/routers/deployments.py
+++ b/apps/api/src/curie_api/routers/deployments.py
@@ -41,6 +41,16 @@ async def create_deployment(
         await deploy.revalidate_stored_bundle(store, version)
     except deploy.BundleTooLarge as exc:
         raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, str(exc)) from exc
+    # The declared/bound approval-route join (#2436): this is the first moment
+    # both halves are known for a specific agent, and the moment the version
+    # becomes the thing that boots. AFTER the bounds check above, so an over-cap
+    # legacy bundle keeps reporting `bundle.too_large` rather than surfacing as
+    # an extraction failure in here (ADR-0059 decision 3's error contract), and
+    # in FRONT of the row creation, so a refusal leaves nothing behind.
+    try:
+        await deploy.check_approval_route_bindings(store, version, agent.approval_routes)
+    except deploy.ApprovalRoutesUnbound as exc:
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, str(exc)) from exc
     deployment = await crud.create_deployment(session, data)
     return DeploymentOut.model_validate(deployment)
 

--- a/apps/api/tests/test_approval_route_config_check.py
+++ b/apps/api/tests/test_approval_route_config_check.py
@@ -1,0 +1,814 @@
+"""The declared/bound approval-route join, refused at CONFIGURATION time (#2436).
+
+Two planes nothing cross-checked before this: the routes a bundle DECLARES in
+its manifest (`approvalPolicy.gates[].route`, versioned with the agent) and the
+routes an operator BINDS (`agents.approval_routes`, per agent, mutable). A
+bundle could declare a route no binding named, deploy green, and only discover
+it at request time -- by escalating instead of routing, which strands the human
+the gate exists to reach. ADR-0050's rationale already claims that residual is
+bounded because "the bundle can only name a route the operator has itself
+bound"; nothing realized the claim until this gate.
+
+Every assertion here goes through the real consumer path -- an HTTP status code
+and JSON body from the running app -- and never an internal struct field
+(AGENTS.md, "Guards are outcome-tested"). The suite runs against the real
+compose Postgres and RustFS the disposable-DB conftest provisions; nothing is
+mocked. The two exceptions are the frozen-vector test and the blank-route poison
+test, which call `bundles.declared_approval_routes` directly: they pin the
+normalization the API side of a cross-process parity seam must implement, and
+its refusal half is deliberately unreachable through HTTP because
+`plugin_format.validate_bundle` already refuses such bytes at every storage
+entry point (asserted, not assumed, in the blank-route test).
+
+The manifest fixture shapes (`_tar_gz`, the valid-files map, the skill
+frontmatter) follow `test_bundles.py`; the route-binding literal follows
+`test_agents.py::_slack`. Helpers are local on purpose: the suite runs under
+`--import-mode=importlib` with no `__init__.py`, so one test module cannot
+import another.
+"""
+
+import io
+import json
+import tarfile
+from pathlib import Path
+from typing import Any
+
+from curie_api import bundles
+
+BUNDLE_NAME = "route-check-plugin"
+VECTOR = Path(__file__).resolve().parents[3] / "tests/vectors/approval-route-normalization.json"
+
+
+def _skill(name: str) -> str:
+    return f"---\nname: {name}\ndescription: does {name} things\n---\n\n# {name}\n"
+
+
+def _manifest(gates: list[dict[str, Any]] | None) -> str:
+    """The plugin manifest, with an `approvalPolicy` only when `gates` is given.
+
+    `gates is None` is the manifest that declares no `approvalPolicy` at all,
+    which is a DIFFERENT case from `gates == []` (a policy declaring nothing).
+    Both must read back as an empty declared set (AC4), and both have a test.
+    """
+
+    manifest: dict[str, Any] = {"name": BUNDLE_NAME, "version": "0.1.0"}
+    if gates is not None:
+        manifest["approvalPolicy"] = {"gates": gates}
+    return json.dumps(manifest)
+
+
+def _gate(route: str, tool: str = "Bash") -> dict[str, Any]:
+    """One gate declaration naming `route`.
+
+    A BUILT-IN tool name by default, so `validate_bundle`'s `mcp__` namespacing
+    rules do not apply and the declared ROUTE is the only variable -- the same
+    isolation `runner/tests/test_approval.py::_write_bundle` uses.
+    """
+
+    return {"gate": tool, "route": route}
+
+
+def _files(gates: list[dict[str, Any]] | None = None) -> dict[str, str]:
+    return {
+        ".claude-plugin/plugin.json": _manifest(gates),
+        "skills/alpha/SKILL.md": _skill("alpha"),
+    }
+
+
+def _tar_gz(files: dict[str, str], top: str = BUNDLE_NAME) -> bytes:
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        for rel, content in files.items():
+            data = content.encode("utf-8")
+            info = tarfile.TarInfo(f"{top}/{rel}")
+            info.size = len(data)
+            tf.addfile(info, io.BytesIO(data))
+    return buf.getvalue()
+
+
+def _archive(gates: list[dict[str, Any]] | None = None) -> bytes:
+    return _tar_gz(_files(gates))
+
+
+def _slack(address: str) -> dict[str, str]:
+    """The Slack-kind binding literal, so a shape change lands in one place."""
+
+    return {"kind": "slack", "address": address}
+
+
+def _binding(address: str = "C0EXAMPLE1") -> dict[str, Any]:
+    return {"resolution": _slack(address)}
+
+
+def _routes(*names: str, address: str = "C0EXAMPLE1") -> dict[str, Any]:
+    return {name: _binding(address) for name in names}
+
+
+def _create_agent(
+    client: Any,
+    headers: dict[str, str],
+    *,
+    name: str = "route-agent",
+    channel: str = "C000000A01",
+    routes: dict[str, Any] | None = None,
+) -> str:
+    payload: dict[str, Any] = {"name": name, "channel": _slack(channel)}
+    if routes is not None:
+        payload["approval_routes"] = routes
+    resp = client.post("/agents", json=payload, headers=headers)
+    assert resp.status_code == 201, resp.text
+    return str(resp.json()["id"])
+
+
+def _create_version(client: Any, headers: dict[str, str], agent_id: str, label: str = "v1") -> str:
+    resp = client.post(
+        f"/agents/{agent_id}/versions",
+        json={"version_label": label, "created_by": "bconn"},
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    return str(resp.json()["id"])
+
+
+def _upload(
+    client: Any, headers: dict[str, str], agent_id: str, version_id: str, archive: bytes
+) -> Any:
+    return client.put(
+        f"/agents/{agent_id}/versions/{version_id}/bundle",
+        files={"file": ("bundle.tar.gz", archive)},
+        headers=headers,
+    )
+
+
+def _bundled_version(
+    client: Any,
+    headers: dict[str, str],
+    agent_id: str,
+    gates: list[dict[str, Any]] | None = None,
+    label: str = "v1",
+) -> str:
+    """A version carrying a stored bundle that declares `gates`."""
+
+    version_id = _create_version(client, headers, agent_id, label)
+    upload = _upload(client, headers, agent_id, version_id, _archive(gates))
+    assert upload.status_code == 201, upload.text
+    return version_id
+
+
+def _deploy(
+    client: Any,
+    headers: dict[str, str],
+    agent_id: str,
+    version_id: str,
+    environment: str = "dev",
+) -> Any:
+    return client.post(
+        "/deployments",
+        json={"agent_id": agent_id, "version_id": version_id, "environment": environment},
+        headers=headers,
+    )
+
+
+def _deployments(client: Any, headers: dict[str, str], agent_id: str) -> list[dict[str, Any]]:
+    resp = client.get("/deployments", params={"agent_id": agent_id}, headers=headers)
+    assert resp.status_code == 200, resp.text
+    return list(resp.json())
+
+
+def _versions(client: Any, headers: dict[str, str], agent_id: str) -> list[dict[str, Any]]:
+    resp = client.get(f"/agents/{agent_id}/versions", headers=headers)
+    assert resp.status_code == 200, resp.text
+    return list(resp.json())
+
+
+def _agent(client: Any, headers: dict[str, str], agent_id: str) -> dict[str, Any]:
+    resp = client.get(f"/agents/{agent_id}", headers=headers)
+    assert resp.status_code == 200, resp.text
+    return dict(resp.json())
+
+
+def _detail(response: Any) -> str:
+    return str(response.json()["detail"])
+
+
+def _write_bundle_root(root: Path, gates: list[dict[str, Any]] | None) -> Path:
+    """A bundle directory on disk carrying `gates`, for the reader-level tests."""
+
+    (root / ".claude-plugin").mkdir(parents=True)
+    (root / ".claude-plugin" / "plugin.json").write_text(_manifest(gates), encoding="utf-8")
+    return root
+
+
+# --- AC1: a declared route with no binding is refused at configuration ---------
+
+
+def test_deploy_is_refused_when_the_bundle_declares_an_unbound_route(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    """AC1, the fix pin: `POST /deployments` refuses a bundle declaring `ops`
+    when the agent's `approval_routes` binds only `finance` (plan test table,
+    API row 1)."""
+
+    agent_id = _create_agent(client, auth_headers, routes=_routes("finance"))
+    version_id = _bundled_version(client, auth_headers, agent_id, [_gate("ops")])
+
+    resp = _deploy(client, auth_headers, agent_id, version_id)
+
+    assert resp.status_code == 422, resp.text
+    assert "'ops'" in _detail(resp), resp.text
+    assert _deployments(client, auth_headers, agent_id) == [], "a refusal must leave no row"
+
+
+def test_the_refusal_names_the_bound_routes_alongside_the_unbound_one(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    """AC1: the 422 detail names the BOUND routes as well as the unbound one, so
+    the operator can see the typo without a second request (plan test table, API
+    row 2)."""
+
+    agent_id = _create_agent(client, auth_headers, routes=_routes("finance", "legal"))
+    version_id = _bundled_version(client, auth_headers, agent_id, [_gate("ops")])
+
+    resp = _deploy(client, auth_headers, agent_id, version_id)
+
+    assert resp.status_code == 422, resp.text
+    detail = _detail(resp)
+    assert "'ops'" in detail, detail
+    assert "'finance'" in detail and "'legal'" in detail, detail
+
+
+def test_a_route_declared_and_bound_deploys(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    """AC1's falsifiable pair: the same bundle with `ops` bound deploys (plan
+    test table, API row 3). Without it a gate that refused every gated bundle
+    would satisfy every negative above."""
+
+    agent_id = _create_agent(client, auth_headers, routes=_routes("ops"))
+    version_id = _bundled_version(client, auth_headers, agent_id, [_gate("ops")])
+
+    resp = _deploy(client, auth_headers, agent_id, version_id)
+
+    assert resp.status_code == 201, resp.text
+    deployments = _deployments(client, auth_headers, agent_id)
+    assert [(d["version_id"], d["status"]) for d in deployments] == [(version_id, "active")]
+
+
+# --- F1: the late-attachment hole, and the pre-deployment upload it must spare -
+
+
+def test_uploading_a_gated_bundle_onto_an_already_deployed_version_is_refused(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    """AC1 / F1: attaching a gated bundle to an already-active version is refused.
+
+    Plan test table (API), the late-attachment row. `DeploymentCreate` carries no
+    bundle and `revalidate_stored_bundle` no-ops on a null `bundle_ref`, so
+    `POST /deployments` succeeds for a bundleless version -- and the worker's
+    resolve query joins `deployments.status = 'active'` to
+    `agent_versions.bundle_ref`, so a later upload puts the bundle live with no
+    deployment gate ever running. The same join therefore has to fire on the
+    upload, arriving from the other side. The null `bundle_ref` afterwards is the
+    load-bearing half: `crud.attach_bundle` commits immediately, so a refusal
+    that ran after it would already be live.
+    """
+
+    agent_id = _create_agent(client, auth_headers)
+    version_id = _create_version(client, auth_headers, agent_id)
+    assert _deploy(client, auth_headers, agent_id, version_id).status_code == 201
+
+    resp = _upload(client, auth_headers, agent_id, version_id, _archive([_gate("ops")]))
+
+    assert resp.status_code == 422, resp.text
+    assert "'ops'" in _detail(resp), resp.text
+    assert [v["bundle_ref"] for v in _versions(client, auth_headers, agent_id)] == [None]
+
+
+def test_uploading_a_gated_bundle_before_any_deployment_is_unrestricted(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    """AC2 / F1's falsifiable pair: the ordinary pre-deployment upload is untouched.
+
+    Plan test table (API), the unrestricted-upload row. The CLI's `prepare_deploy`
+    uploads the bundle BEFORE `curie <tier> approvals` binds the route, so an
+    unconditional upload gate would refuse the documented onboarding order for
+    every gated agent -- and would refuse a bundle that may never be deployed.
+    The gate is conditional on the version already being live, and this is what
+    holds it conditional.
+    """
+
+    agent_id = _create_agent(client, auth_headers)
+    version_id = _create_version(client, auth_headers, agent_id)
+
+    resp = _upload(client, auth_headers, agent_id, version_id, _archive([_gate("ops")]))
+
+    assert resp.status_code == 201, resp.text
+    assert [v["bundle_ref"] for v in _versions(client, auth_headers, agent_id)] == [
+        resp.json()["bundle_ref"]
+    ]
+
+
+# --- AC2: a bound route no bundle declares is never an error ------------------
+
+
+def test_a_bound_route_no_bundle_declares_is_accepted(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    """AC2: binding ahead of a bundle bump is a supported workflow, not a warning.
+
+    Plan test table (API), the bound-but-undeclared row. The join is one
+    directional: every DECLARED route must be bound, and a bound route no bundle
+    names is simply pre-binding.
+    """
+
+    agent_id = _create_agent(client, auth_headers, routes=_routes("finance", "ops"))
+    version_id = _bundled_version(client, auth_headers, agent_id, [_gate("ops")])
+
+    resp = _deploy(client, auth_headers, agent_id, version_id)
+
+    assert resp.status_code == 201, resp.text
+
+
+def test_agent_create_with_a_route_no_bundle_declares_succeeds(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    """AC2: `POST /agents` with `approval_routes` and no version is legal.
+
+    Plan test table (API), the create row, and behavior site 6's explicit no-op:
+    no version and no bundle exists yet, so a create naming a route nothing
+    declares is exactly the legal pre-binding AC2 protects.
+    """
+
+    resp = client.post(
+        "/agents",
+        json={
+            "name": "prebound-agent",
+            "channel": _slack("C000000A02"),
+            "approval_routes": _routes("ops"),
+        },
+        headers=auth_headers,
+    )
+
+    assert resp.status_code == 201, resp.text
+    assert set(resp.json()["approval_routes"]) == {"ops"}
+
+
+# --- AC4: the check does not fire for a bundle that declares no gates ----------
+
+
+def test_a_bundle_with_no_approval_policy_deploys_with_no_routes_bound(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    """AC4: no `approvalPolicy` in the manifest means an empty declared set.
+
+    Plan test table (API), the no-policy row. The agent's `approval_routes` is
+    null, so any reader that turned "cannot find a policy" into a refusal would
+    break every ungated agent on the platform at once.
+    """
+
+    agent_id = _create_agent(client, auth_headers)
+    assert _agent(client, auth_headers, agent_id)["approval_routes"] is None
+    version_id = _bundled_version(client, auth_headers, agent_id, None)
+
+    resp = _deploy(client, auth_headers, agent_id, version_id)
+
+    assert resp.status_code == 201, resp.text
+
+
+def test_a_bundle_with_an_empty_gates_list_deploys_with_no_routes_bound(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    """AC4: `"approvalPolicy": {"gates": []}` also declares nothing.
+
+    Plan test table (API), the empty-gates row: the boundary between "no policy"
+    and "a policy declaring nothing". They reach the reader by different
+    branches, so one passing does not imply the other.
+    """
+
+    agent_id = _create_agent(client, auth_headers)
+    assert _agent(client, auth_headers, agent_id)["approval_routes"] is None
+    version_id = _bundled_version(client, auth_headers, agent_id, [])
+
+    resp = _deploy(client, auth_headers, agent_id, version_id)
+
+    assert resp.status_code == 201, resp.text
+
+
+# --- F4: the normalization the deploy reader shares with the runtime loader ----
+
+
+def test_a_gate_with_a_blank_route_is_refused_like_the_runner_refuses_it(
+    client: Any, auth_headers: dict[str, str], clean_db: None, tmp_path: Path
+) -> None:
+    """AC1 / F4: a gate whose stripped route is blank is poison, not a silent drop.
+
+    Plan test table (API), the blank-route row. The first half asserts rather
+    than assumes the premise: `plugin_format.validate_bundle` already refuses
+    these bytes at the storage entry point (`approval_policy.incomplete`), so the
+    reader can only meet such a manifest on bytes that predate the rule or
+    arrived out of band. That is exactly when it must fail CLOSED. The reader
+    returns the `None` poison value the caller turns into a refusal, on the SAME
+    condition `curie_runner.approval.resolve_approval_policy` raises
+    `ApprovalPolicyError` and refuses to boot: a declared gate name that arms no
+    tool. Returning an empty set instead would accept, at configuration time, a
+    bundle the runner will not run -- the fail-open shape ADR-0050 exists to
+    prevent.
+    """
+
+    agent_id = _create_agent(client, auth_headers)
+    version_id = _create_version(client, auth_headers, agent_id)
+    upload = _upload(client, auth_headers, agent_id, version_id, _archive([_gate("   ")]))
+    assert upload.status_code == 422, upload.text
+    assert "approval_policy.incomplete" in {
+        e["code"] for e in upload.json()["detail"]["errors"]
+    }, upload.text
+
+    root = _write_bundle_root(tmp_path / "blank-route", [_gate("   ")])
+    assert bundles.declared_approval_routes(root) is None, (
+        "a gate arming no tool must poison the declared set, not read as 'declares "
+        "nothing' -- the runner raises ApprovalPolicyError on this exact condition"
+    )
+
+
+def test_two_gates_on_one_tool_declare_only_the_last_route(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    """F4: the declared set is the LAST-WINS tool-to-route map, not a route union.
+
+    Plan test table (API), the repeated-tool row. `resolve_approval_policy`
+    builds `{tool: route}` and keeps only the last gate for a repeated tool, so
+    `alpha` below can never be raised at runtime. A reader that unioned every
+    gate's route value would refuse this deploy over a route that does not exist,
+    which is an over-refusal of a bundle `validate_bundle` accepts and the runner
+    boots.
+    """
+
+    agent_id = _create_agent(client, auth_headers, routes=_routes("omega"))
+    version_id = _bundled_version(
+        client, auth_headers, agent_id, [_gate("alpha"), _gate("omega")]
+    )
+
+    resp = _deploy(client, auth_headers, agent_id, version_id)
+
+    assert resp.status_code == 201, resp.text
+
+
+def test_declared_route_normalization_matches_the_frozen_vector(tmp_path: Path) -> None:
+    """Parity seam / F4: the API reader executes the frozen normalization vector.
+
+    Plan test table (API), the vector row. The deploy-time reader and the runtime
+    loader must normalize identically, including the refusal case, or a bundle
+    passes this configuration gate and then boots with a different set of gates.
+    Code cannot be shared across the seam -- `packages/plugin-format` is frozen
+    and `curie_api` must not import `curie_runner` -- so
+    `tests/vectors/approval-route-normalization.json` is the rule and both sides
+    EXECUTE it. The runner half is
+    `runner/tests/test_approval.py::test_route_normalization_vector_matches_the_runtime_loader`,
+    which asserts a RAISE where this asserts `None`, so the vector cannot be
+    satisfied by weakening either side's fail-closed posture.
+    """
+
+    cases = json.loads(VECTOR.read_text(encoding="utf-8"))["cases"]
+    assert cases, "the frozen vector must carry cases, or this test proves nothing"
+
+    for case in cases:
+        root = _write_bundle_root(tmp_path / str(case["id"]), case["gates"])
+        declared = bundles.declared_approval_routes(root)
+        if case["expected"] == "rejected":
+            assert declared is None, (
+                f"case {case['id']!r}: the reader returned {declared!r}, but the frozen "
+                "vector says this bundle is refused; an empty set here accepts a bundle "
+                "the runner refuses to boot"
+            )
+            continue
+        assert declared == set(case["expected"]), (
+            f"case {case['id']!r}: the reader declared {declared!r} but the frozen vector "
+            f"says {case['expected']!r} -- normalization drift between the deploy-time "
+            "reader and the runtime loader is the #453/#544 fail-open shape"
+        )
+
+
+# --- The operator-side write: `PATCH /agents/{id}` with `approval_routes` ------
+
+
+def test_patch_dropping_a_route_declared_by_an_active_deployment_is_refused(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    """AC1: an unbind strands a live agent exactly as a bad deploy would.
+
+    Plan test table (API), the patch-drop row. A write to `approval_routes` is a
+    full replacement (`--route`, `--routes-from` and `--clear-routes` all replace
+    the whole map), so dropping `ops` while a deployment whose bundle declares it
+    is active is the same defect arriving from the operator's side.
+    """
+
+    agent_id = _create_agent(client, auth_headers, routes=_routes("ops", "finance"))
+    version_id = _bundled_version(client, auth_headers, agent_id, [_gate("ops")])
+    assert _deploy(client, auth_headers, agent_id, version_id).status_code == 201
+
+    resp = client.patch(
+        f"/agents/{agent_id}", json={"approval_routes": _routes("finance")}, headers=auth_headers
+    )
+
+    assert resp.status_code == 422, resp.text
+    assert "'ops'" in _detail(resp), resp.text
+    assert set(_agent(client, auth_headers, agent_id)["approval_routes"]) == {"ops", "finance"}
+
+
+def test_patch_clearing_all_routes_is_refused_while_a_gated_deployment_is_active(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    """AC1: the explicit `{}` clear is a real request here, and it is refused.
+
+    Plan test table (API), the clear row. `{}` is not "omitted" for this field --
+    it is the documented way to clear the map (#247) -- so it has to be judged,
+    not skipped, or `--clear-routes` walks straight past the gate.
+    """
+
+    agent_id = _create_agent(client, auth_headers, routes=_routes("ops"))
+    version_id = _bundled_version(client, auth_headers, agent_id, [_gate("ops")])
+    assert _deploy(client, auth_headers, agent_id, version_id).status_code == 201
+
+    resp = client.patch(f"/agents/{agent_id}", json={"approval_routes": {}}, headers=auth_headers)
+
+    assert resp.status_code == 422, resp.text
+    assert "'ops'" in _detail(resp), resp.text
+    assert set(_agent(client, auth_headers, agent_id)["approval_routes"]) == {"ops"}
+
+
+def test_patch_that_keeps_every_declared_route_is_accepted(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    """AC1's falsifiable pair on the write side: a rewrite that keeps `ops` is 200.
+
+    Plan test table (API), the patch-accepted row. The gate is about the ROUTE
+    NAME's presence, not about the binding's contents, so moving the resolution
+    channel must stay an ordinary operator action.
+    """
+
+    agent_id = _create_agent(client, auth_headers, routes=_routes("ops"))
+    version_id = _bundled_version(client, auth_headers, agent_id, [_gate("ops")])
+    assert _deploy(client, auth_headers, agent_id, version_id).status_code == 201
+
+    resp = client.patch(
+        f"/agents/{agent_id}",
+        json={"approval_routes": {"ops": _binding("C0EXAMPLE2")}},
+        headers=auth_headers,
+    )
+
+    assert resp.status_code == 200, resp.text
+    routes = _agent(client, auth_headers, agent_id)["approval_routes"]
+    assert routes["ops"]["resolution"]["address"] == "C0EXAMPLE2"
+
+
+def test_ending_the_newest_deployment_still_refuses_while_an_older_active_row_declares_the_route(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    """F2: the check unions EVERY active row, not the newest one per environment.
+
+    Plan test table (API), the F2 row. `crud.get_active_deployment` deliberately
+    returns only the newest active row per environment, git-flow appends a new
+    active row per push without superseding older ones, and `end_deployment`
+    stops exactly one row -- so several active rows routinely coexist in one
+    environment, and the worker's resolve query orders over ALL of them. A check
+    built on "newest per environment" would let the FIRST patch below through:
+    the newest row is the ungated one, while the older gated row is still active
+    and still bootable. The three steps are the discriminator, in order.
+    """
+
+    agent_id = _create_agent(client, auth_headers, routes=_routes("ops"))
+    gated = _bundled_version(client, auth_headers, agent_id, [_gate("ops")], label="gated")
+    ungated = _bundled_version(client, auth_headers, agent_id, None, label="ungated")
+
+    older = _deploy(client, auth_headers, agent_id, gated)
+    assert older.status_code == 201, older.text
+    newer = _deploy(client, auth_headers, agent_id, ungated)
+    assert newer.status_code == 201, newer.text
+
+    clear: dict[str, Any] = {"approval_routes": {}}
+    first = client.patch(f"/agents/{agent_id}", json=clear, headers=auth_headers)
+    assert first.status_code == 422, (
+        "the newest active row declares nothing, but the older one is still active "
+        f"and still declares 'ops': {first.text}"
+    )
+    assert "'ops'" in _detail(first), first.text
+
+    assert (
+        client.delete(f"/deployments/{newer.json()['id']}", headers=auth_headers).status_code == 204
+    )
+    second = client.patch(f"/agents/{agent_id}", json=clear, headers=auth_headers)
+    assert second.status_code == 422, second.text
+
+    assert (
+        client.delete(f"/deployments/{older.json()['id']}", headers=auth_headers).status_code == 204
+    )
+    third = client.patch(f"/agents/{agent_id}", json=clear, headers=auth_headers)
+    assert third.status_code == 200, third.text
+    assert _agent(client, auth_headers, agent_id)["approval_routes"] is None
+
+
+def test_clearing_routes_succeeds_only_after_every_declaring_deployment_is_ended(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    """AC1 recovery: the refusal is not a one-way door, and it is not one DELETE.
+
+    Plan test table (API), the recovery row, and question (b) in the plan's own
+    words: to clear the map an operator must end EVERY active deployment whose
+    bundle declares one of those routes. Two active rows in two environments both
+    declare `ops` here, so ending one is deliberately not enough.
+    """
+
+    agent_id = _create_agent(client, auth_headers, routes=_routes("ops"))
+    version_id = _bundled_version(client, auth_headers, agent_id, [_gate("ops")])
+    dev = _deploy(client, auth_headers, agent_id, version_id, "dev")
+    assert dev.status_code == 201, dev.text
+    prod = _deploy(client, auth_headers, agent_id, version_id, "prod")
+    assert prod.status_code == 201, prod.text
+
+    clear: dict[str, Any] = {"approval_routes": {}}
+    assert client.patch(f"/agents/{agent_id}", json=clear, headers=auth_headers).status_code == 422
+
+    assert (
+        client.delete(f"/deployments/{dev.json()['id']}", headers=auth_headers).status_code == 204
+    )
+    halfway = client.patch(f"/agents/{agent_id}", json=clear, headers=auth_headers)
+    assert halfway.status_code == 422, (
+        f"the prod row still declares 'ops' and is still active: {halfway.text}"
+    )
+
+    assert (
+        client.delete(f"/deployments/{prod.json()['id']}", headers=auth_headers).status_code == 204
+    )
+    cleared = client.patch(f"/agents/{agent_id}", json=clear, headers=auth_headers)
+    assert cleared.status_code == 200, cleared.text
+    assert _agent(client, auth_headers, agent_id)["approval_routes"] is None
+
+
+def test_a_prod_declared_route_blocks_a_dev_shaped_route_write(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    """AC1, question (c): the write is judged against BOTH environments at once.
+
+    Plan test table (API), the two-environment row. The proposed map below
+    satisfies everything the dev deployment declares, so a check scoped to one
+    environment (or to the newest row of the environment it happened to look at)
+    would accept it while the prod deployment's `compliance` route is silently
+    unbound.
+    """
+
+    agent_id = _create_agent(client, auth_headers, routes=_routes("ops", "compliance"))
+    dev_version = _bundled_version(client, auth_headers, agent_id, [_gate("ops")], label="dev")
+    prod_version = _bundled_version(
+        client, auth_headers, agent_id, [_gate("compliance")], label="prod"
+    )
+    assert _deploy(client, auth_headers, agent_id, dev_version, "dev").status_code == 201
+    assert _deploy(client, auth_headers, agent_id, prod_version, "prod").status_code == 201
+
+    resp = client.patch(
+        f"/agents/{agent_id}", json={"approval_routes": _routes("ops")}, headers=auth_headers
+    )
+
+    assert resp.status_code == 422, resp.text
+    assert "'compliance'" in _detail(resp), resp.text
+    assert set(_agent(client, auth_headers, agent_id)["approval_routes"]) == {"ops", "compliance"}
+
+
+def test_a_refused_mixed_field_patch_persists_no_field(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    """F3: a refused PATCH persists nothing, including the fields it also carried.
+
+    Plan test table (API), the mixed-field row. `update_agent` commits `model`,
+    `thinking`, `memory` and `approval_required_tools` through independently
+    committing helpers BEFORE it reaches the `approval_routes` block, so a
+    refusal placed at that block would leave four fields persisted from a request
+    the API answered 422. The preflight therefore runs at the top of the handler,
+    and this is the test that says so through the read path.
+    """
+
+    agent_id = _create_agent(client, auth_headers, routes=_routes("ops"))
+    version_id = _bundled_version(client, auth_headers, agent_id, [_gate("ops")])
+    assert _deploy(client, auth_headers, agent_id, version_id).status_code == 201
+    before = _agent(client, auth_headers, agent_id)
+
+    resp = client.patch(
+        f"/agents/{agent_id}",
+        json={
+            "model": "claude-sonnet-5",
+            "thinking": "enabled:2000",
+            "memory": True,
+            "approval_required_tools": ["Bash"],
+            "approval_routes": {},
+        },
+        headers=auth_headers,
+    )
+
+    assert resp.status_code == 422, resp.text
+    after = _agent(client, auth_headers, agent_id)
+    for field in ("model", "thinking", "memory", "approval_required_tools", "approval_routes"):
+        assert after[field] == before[field], (
+            f"{field} was committed by a request the API refused: "
+            f"{before[field]!r} -> {after[field]!r}"
+        )
+
+
+# --- Verbatim, case-sensitive matching ----------------------------------------
+
+
+def test_a_whitespace_padded_binding_key_does_not_satisfy_a_declared_route(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    """AC1 edge: the binding key is matched VERBATIM against the stripped route.
+
+    Plan test table (API), the whitespace row. The worker's lookup
+    (`kernel.py`, `(approval_routes or {}).get(route_name)`) and the API's
+    resolve-time lookup (`crud.get_approval_route_binding`) are both exact dict
+    lookups, so `" ops "` binds nothing at runtime and the config check must say
+    so rather than trimming the operator's key into agreement. The message quotes
+    with `!r` precisely so the invisible difference is visible in the 422.
+    """
+
+    agent_id = _create_agent(client, auth_headers, routes={" ops ": _binding()})
+    version_id = _bundled_version(client, auth_headers, agent_id, [_gate("ops")])
+
+    resp = _deploy(client, auth_headers, agent_id, version_id)
+
+    assert resp.status_code == 422, resp.text
+    detail = _detail(resp)
+    assert "'ops'" in detail, detail
+    assert "' ops '" in detail, (
+        "the bound key must be quoted so the operator can SEE the padding that "
+        f"makes it a different route: {detail}"
+    )
+
+
+def test_route_matching_is_case_sensitive(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    """AC1 edge: `Ops` does not bind `ops` (ADR-0046 Decision B).
+
+    Plan test table (API), the case row. Both runtime consumers of this map do a
+    case-sensitive exact lookup, so folding case here would report a binding that
+    does not exist -- a silent failure at request time is exactly what this
+    ticket exists to move forward to configuration time.
+    """
+
+    agent_id = _create_agent(client, auth_headers, routes=_routes("Ops"))
+    version_id = _bundled_version(client, auth_headers, agent_id, [_gate("ops")])
+
+    resp = _deploy(client, auth_headers, agent_id, version_id)
+
+    assert resp.status_code == 422, resp.text
+    assert "'ops'" in _detail(resp), resp.text
+
+
+# --- Stage 5 regression pin: the preflight's own read is bounded too ----------
+
+
+def test_patch_keeping_every_route_under_a_tightened_archive_cap_is_refused_as_too_large_not_500(
+    client: Any, auth_headers: dict[str, str], clean_db: None
+) -> None:
+    """Code review P2 (`deploy.py:204-210`): AC1's preflight must translate a cap failure.
+
+    The preflight extracts the stored bundle to learn what it DECLARES, so an
+    operator who tightens the archive caps under an already-deployed bundle
+    makes every `approval_routes` write raise an uncaught extraction error --
+    including this one, which keeps every declared route and would otherwise be
+    the accepted case. ADR-0059 decision 3 already fixes the operator-facing
+    answer for stored bytes that no longer fit the current caps: the
+    `BundleTooLarge` 422 `revalidate_stored_bundle` produces at
+    `POST /deployments`, named in `test_bundle_ingestion_bounds.py`. A 500 is
+    not that answer, and it tells the operator nothing about size.
+
+    The caps are moved the same way the ingestion-bounds suite moves them, by
+    patching `deploy.get_settings`, because the preflight calls
+    `check_approval_route_bindings` without a `settings` argument and that call
+    resolves the name in `deploy`'s own namespace.
+    """
+
+    from unittest.mock import patch
+
+    from curie_api import deploy
+    from curie_api.config import Settings
+
+    agent_id = _create_agent(client, auth_headers, routes=_routes("ops"))
+    version_id = _bundled_version(client, auth_headers, agent_id, [_gate("ops")])
+    assert _deploy(client, auth_headers, agent_id, version_id).status_code == 201
+
+    with patch.object(deploy, "get_settings", lambda: Settings(bundle_max_uncompressed_bytes=1)):
+        resp = client.patch(
+            f"/agents/{agent_id}",
+            json={"approval_routes": {"ops": _binding("C0EXAMPLE2")}},
+            headers=auth_headers,
+        )
+
+    assert resp.status_code == 422, resp.text
+    detail = _detail(resp)
+    assert "size/ratio" in detail, detail
+    assert "rebuilt and re-uploaded" in detail, detail
+    assert version_id in detail, detail  # actionable: names the affected version
+
+    # Refused BEFORE the write, like every other preflight refusal here.
+    routes = _agent(client, auth_headers, agent_id)["approval_routes"]
+    assert set(routes) == {"ops"}, routes
+    assert routes["ops"]["resolution"]["address"] == "C0EXAMPLE1", routes

--- a/apps/api/tests/test_gitflow_integration.py
+++ b/apps/api/tests/test_gitflow_integration.py
@@ -1768,3 +1768,477 @@ def test_a_git_push_of_a_stale_build_bundle_creates_no_version(
     assert body["status"] == "rejected"
     assert "connectors.lock_stale" in {e["code"] for e in body["errors"]}
     assert client.get(f"/agents/{agent_id}/versions", headers=auth_headers).json() == []
+
+
+# --------------------------------------------------------------------------- #
+# The declared/bound approval-route join, driven by a real signed push (#2436)
+#
+# A push is the other way a version becomes the thing that boots, so the same
+# configuration-time refusal `POST /deployments` returns as a 422 arrives here
+# as `WebhookResult(status="rejected")` with code `approval_routes.unbound`.
+# Every assertion below reads the webhook response body and `GET /deployments`,
+# never an internal struct field.
+# --------------------------------------------------------------------------- #
+
+
+def _gated_manifest(route: str, gate: str = "Bash") -> str:
+    """`VALID_FILES`' manifest plus one approvalPolicy gate naming `route`.
+
+    A BUILT-IN tool name, so `validate_bundle`'s `mcp__` namespacing rules do
+    not apply and the declared ROUTE is the only variable -- the same isolation
+    `runner/tests/test_approval.py::_write_bundle` uses.
+    """
+
+    return json.dumps(
+        {
+            "name": "demo-plugin",
+            "version": "0.1.0",
+            "approvalPolicy": {"gates": [{"gate": gate, "route": route}]},
+        }
+    )
+
+
+def _gated_files(base: dict[str, str], route: str) -> dict[str, str]:
+    return {**base, ".claude-plugin/plugin.json": _gated_manifest(route)}
+
+
+def _gated_archive(route: str) -> bytes:
+    """The gated bundle as an uploadable tar.gz, for the API-upload half."""
+
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as archive:
+        for rel, content in _gated_files(VALID_FILES, route).items():
+            data = content.encode()
+            info = tarfile.TarInfo(f"demo-plugin/{rel}")
+            info.size = len(data)
+            archive.addfile(info, io.BytesIO(data))
+    return buf.getvalue()
+
+
+def _push_commit(
+    base_dir: Path,
+    files: dict[str, str],
+    branch: str = "dev",
+    repo_full_name: str = REPO,
+) -> str:
+    """Add a commit on top of `_build_bare_repo`'s tree and move `branch` to it.
+
+    A second delivery needs a second sha: git-flow keys version reuse on
+    `commit_sha`, so re-pushing the first one would take the redelivery path
+    instead of building the new bundle. The branch really moves in the bare
+    repo, so #1139's ancestry check sees the sha on the branch it claims.
+    """
+
+    work = base_dir / "_work" / repo_full_name
+    for rel, content in files.items():
+        path = work / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+    _git("add", "-A", cwd=work)
+    _git("commit", "-q", "-m", "declare an approval gate", cwd=work)
+    sha = _git("rev-parse", "HEAD", cwd=work)
+    bare = base_dir / f"{repo_full_name}.git"
+    _git("push", "--quiet", "--force", str(bare), f"HEAD:refs/heads/{branch}", cwd=work)
+    return sha
+
+
+def _bind_route(
+    client: Any,
+    headers: dict[str, str],
+    agent_id: str,
+    route: str,
+    address: str = "C000000R01",
+) -> None:
+    resp = client.patch(
+        f"/agents/{agent_id}",
+        json={"approval_routes": {route: {"resolution": {"kind": "slack", "address": address}}}},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+
+def _unbound_codes(body: dict[str, Any]) -> set[str]:
+    return {e["code"] for e in body.get("errors") or []}
+
+
+def test_a_push_declaring_an_unbound_route_is_rejected_and_leaves_the_prior_deployment_active(
+    client: Any,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    trusted_clone_base: Path,
+) -> None:
+    """AC1 on the git push path: a declared route with no binding is refused.
+
+    Plan test table (gitflow), row 1. The first push is the control -- the same
+    repository, the same agent, an ungated bundle -- so the rejection below can
+    only be the new join and not a broken delivery. The still-active first
+    deployment is the "nothing is torn down" half of question (a): a refused
+    push must leave every previously active row serving.
+    """
+
+    agent_id = _register_agent(client, auth_headers)
+    clone_url, first_sha = _build_bare_repo(trusted_clone_base, REPO, VALID_FILES)
+
+    first = _post(client, "push", _push_payload("refs/heads/dev", first_sha, clone_url)).json()
+    assert first["status"] == "deployed", first
+
+    gated_sha = _push_commit(trusted_clone_base, _gated_files(VALID_FILES, "ops"))
+    body = _post(client, "push", _push_payload("refs/heads/dev", gated_sha, clone_url)).json()
+
+    assert body["status"] == "rejected", body
+    assert "approval_routes.unbound" in _unbound_codes(body), body
+    assert "'ops'" in " ".join(e["message"] for e in body["errors"]), body
+
+    deployments = client.get(
+        "/deployments", params={"agent_id": agent_id}, headers=auth_headers
+    ).json()
+    assert len(deployments) == 1, deployments
+    assert deployments[0]["status"] == "active"
+    assert deployments[0]["version_id"] == first["version_id"]
+
+
+def test_a_push_declaring_a_bound_route_deploys(
+    client: Any,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    trusted_clone_base: Path,
+) -> None:
+    """AC1's falsifiable pair for the push path: bind the route and it deploys.
+
+    Plan test table (gitflow), row 3. Byte-identical to the rejection above
+    except for the binding, so a gate that rejected every gated push would turn
+    this red.
+    """
+
+    agent_id = _register_agent(client, auth_headers)
+    clone_url, first_sha = _build_bare_repo(trusted_clone_base, REPO, VALID_FILES)
+    _post(client, "push", _push_payload("refs/heads/dev", first_sha, clone_url))
+    _bind_route(client, auth_headers, agent_id, "ops")
+
+    gated_sha = _push_commit(trusted_clone_base, _gated_files(VALID_FILES, "ops"))
+    body = _post(client, "push", _push_payload("refs/heads/dev", gated_sha, clone_url)).json()
+
+    assert body["status"] == "deployed", body
+    deployments = client.get(
+        "/deployments", params={"agent_id": agent_id}, headers=auth_headers
+    ).json()
+    assert len(deployments) == 2, deployments
+    assert body["version_id"] in {d["version_id"] for d in deployments}, deployments
+
+
+def test_a_prod_promote_is_refused_when_the_promoting_agent_lacks_the_binding(
+    client: Any,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    trusted_clone_base: Path,
+) -> None:
+    """AC1, question (c): the promote is judged against the PROD agent's map.
+
+    Plan test table (gitflow), row 2. ADR-0091 lets one repository build several
+    agents, so the prod agent holds a different `approval_routes` map from the
+    dev agent that already deployed this exact artifact. The join is therefore
+    re-evaluated against the resolved target agent and never inherited from the
+    dev pass -- which is what the dev half deploying green proves.
+    """
+
+    dev_id = _register(client, auth_headers, "two-agent-dev", "C000000D01")
+    prod_id = _register(client, auth_headers, "two-agent-prod", "C000000E01")
+    clone_url, sha = _build_bare_repo(
+        trusted_clone_base, REPO, _gated_files(TWO_TARGET_FILES, "ops")
+    )
+    _bind_route(client, auth_headers, dev_id, "ops")
+
+    dev = _post(client, "push", _push_payload("refs/heads/dev", sha, clone_url)).json()
+    assert dev["status"] == "deployed", dev
+
+    prod = _post(client, "push", _push_payload("refs/heads/main", sha, clone_url)).json()
+    assert prod["status"] == "rejected", prod
+    assert "approval_routes.unbound" in _unbound_codes(prod), prod
+    assert "'ops'" in " ".join(e["message"] for e in prod["errors"]), prod
+
+    assert (
+        client.get("/deployments", params={"agent_id": prod_id}, headers=auth_headers).json() == []
+    )
+    assert [
+        d["environment"]
+        for d in client.get(
+            "/deployments", params={"agent_id": dev_id}, headers=auth_headers
+        ).json()
+    ] == ["dev"]
+
+
+def test_a_sibling_attach_is_refused_when_the_sibling_object_declares_an_unbound_route(
+    client: Any,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    trusted_clone_base: Path,
+) -> None:
+    """AC1 / F1 residual: the attach path checks the object it actually attaches.
+
+    Plan test table (gitflow), row 4 -- the differing-artifact case, and the test
+    that separates the two designs. The delivery clones the ORIGINAL, UNGATED
+    commit, but ADR-0091's bundle-once/bind-many reuse attaches the SIBLING's
+    stored object, which an API upload has since made a gated one. A check that
+    read the in-hand archive would pass on the ungated bytes and then commit the
+    gated reference, and `crud.attach_bundle` commits before the deployment gate
+    runs -- so the unbound bundle would already be live on the target version,
+    which an active deployment row already points at, by the time the push is
+    rejected. The null `bundle_ref` afterwards is the assertion that carries it.
+    """
+
+    dev_id = _register(client, auth_headers, "two-agent-dev", "C000000D01")
+    prod_id = _register(client, auth_headers, "two-agent-prod", "C000000E01")
+    clone_url, sha = _build_bare_repo(trusted_clone_base, REPO, TWO_TARGET_FILES)
+
+    # The target: a git-flow version row this commit left bundleless (a store
+    # that failed after the row committed), deployed out of band through
+    # `POST /deployments`, which does not require a bundle.
+    _insert_partial_version(dev_id, sha)
+    target = client.get(f"/agents/{dev_id}/versions", headers=auth_headers).json()[0]
+    assert target["bundle_ref"] is None, target
+    activated = client.post(
+        "/deployments",
+        json={"agent_id": dev_id, "version_id": target["id"], "environment": "dev"},
+        headers=auth_headers,
+    )
+    assert activated.status_code == 201, activated.text
+
+    # The sibling: the same commit on the other agent of this repository,
+    # carrying an API-uploaded GATED bundle. A different object from the archive
+    # the redelivered push below clones.
+    _insert_partial_version(prod_id, sha)
+    sibling = client.get(f"/agents/{prod_id}/versions", headers=auth_headers).json()[0]
+    upload = client.put(
+        f"/agents/{prod_id}/versions/{sibling['id']}/bundle",
+        files={"file": ("gated.tar.gz", _gated_archive("ops"))},
+        headers=auth_headers,
+    )
+    assert upload.status_code == 201, upload.text
+
+    body = _post(client, "push", _push_payload("refs/heads/dev", sha, clone_url)).json()
+
+    assert body["status"] == "rejected", body
+    assert "approval_routes.unbound" in _unbound_codes(body), body
+    assert "'ops'" in " ".join(e["message"] for e in body["errors"]), body
+
+    after = client.get(f"/agents/{dev_id}/versions", headers=auth_headers).json()[0]
+    assert after["bundle_ref"] is None, (
+        "the gated sibling object was attached to an already-active version: the "
+        "attach commits before the deployment gate runs, so this is live"
+    )
+
+
+def test_a_push_attaching_a_gated_bundle_to_an_already_deployed_version_is_rejected(
+    client: Any,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    trusted_clone_base: Path,
+) -> None:
+    """AC1 / F1: the git-flow repair route hits the same conditional attach gate.
+
+    Plan test table (API file), the git-flow repair row -- kept HERE rather than
+    in `test_approval_route_config_check.py` because it needs this module's bare
+    repositories and HMAC-signed delivery, and duplicating that plumbing into a
+    second module would give the seam two implementations to drift between.
+
+    The route: a git-flow version row committed and then left bundleless by a
+    failed store, deployed out of band through `POST /deployments` (which does
+    not require a bundle), then repaired by a redelivered push. `bundle_built` is
+    true for a null `bundle_ref`, so the delivery clones and calls
+    `deploy.store_bundle` -- attaching a gated bundle to a version an active
+    deployment ALREADY points at, which is the worker's boot join, with no
+    deployment gate ever having run. The null `bundle_ref` afterwards is the
+    load-bearing half: `crud.attach_bundle` commits immediately, so a refusal
+    that ran after it would already be live.
+    """
+
+    agent_id = _register_agent(client, auth_headers)
+    clone_url, sha = _build_bare_repo(
+        trusted_clone_base, REPO, _gated_files(VALID_FILES, "ops")
+    )
+
+    _insert_partial_version(agent_id, sha)
+    target = client.get(f"/agents/{agent_id}/versions", headers=auth_headers).json()[0]
+    assert target["bundle_ref"] is None, target
+    activated = client.post(
+        "/deployments",
+        json={"agent_id": agent_id, "version_id": target["id"], "environment": "dev"},
+        headers=auth_headers,
+    )
+    assert activated.status_code == 201, activated.text
+
+    body = _post(client, "push", _push_payload("refs/heads/dev", sha, clone_url)).json()
+
+    assert body["status"] == "rejected", body
+    assert "approval_routes.unbound" in _unbound_codes(body), body
+    assert "'ops'" in " ".join(e["message"] for e in body["errors"]), body
+
+    after = client.get(f"/agents/{agent_id}/versions", headers=auth_headers).json()[0]
+    assert after["bundle_ref"] is None, (
+        "the gated bundle was stored onto an already-active version: the attach "
+        "commits before the deployment gate runs, so this is live"
+    )
+    assert [d["id"] for d in client.get(
+        "/deployments", params={"agent_id": agent_id}, headers=auth_headers
+    ).json()] == [activated.json()["id"]]
+
+
+# --------------------------------------------------------------------------- #
+# Stage 5 regression pins for the Code Reviewer's two P2 findings on #2436.
+# Both are consequences of WHERE the new gate sits rather than of what it
+# decides, so both are driven end to end through a signed delivery and read
+# only the webhook body, `GET /deployments`, `GET /agents/{id}/versions` and the
+# recorded eval queue.
+# --------------------------------------------------------------------------- #
+
+
+def test_a_rejected_push_that_is_bound_and_redelivered_deploys_and_fans_out_exactly_one_eval(
+    client: Any,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    trusted_clone_base: Path,
+) -> None:
+    """Code review P2 (`gitflow.py:735-738`): AC1's refusal must not eat the eval fan-out.
+
+    The refused push has ALREADY committed its version row and stored its bundle
+    by the time the deployment gate rejects it, so once the operator binds the
+    missing route the redelivery finds `bundle_built` false, takes the reuse
+    path, and deploys a version eval-as-CI never ran against: the fan-out is
+    skipped permanently because the only delivery that would have enqueued it
+    was the one that was refused.
+
+    The queue is recorded across BOTH deliveries on purpose, the same way
+    `test_a_redelivered_dev_push_reuses_the_version_without_rebuilding` does:
+    zero after the rejection and exactly one after the repair is what separates
+    "the recovery path fans out" from "the fan-out stopped working entirely",
+    and from "the refusal leaked an eval for a version that never deployed".
+    """
+
+    agent_id = _register_agent(client, auth_headers)
+    clone_url, sha = _build_bare_repo(trusted_clone_base, REPO, _gated_files(VALID_FILES, "ops"))
+    # The SAME payload both times: a redelivery from the GitHub deliveries UI is
+    # byte-identical, and version reuse keys on `after`, so a second sha would
+    # test the ordinary first-delivery path instead of the recovery one.
+    payload = _push_payload("refs/heads/dev", sha, clone_url)
+
+    eval_queue = _RecordingEvalQueue()
+    client.app.dependency_overrides[get_eval_queue] = lambda: eval_queue
+    try:
+        refused = _post(client, "push", payload).json()
+        assert refused["status"] == "rejected", refused
+        assert "approval_routes.unbound" in _unbound_codes(refused), refused
+        assert eval_queue.jobs == [], "a refused push must not fan out an eval"
+        assert (
+            client.get("/deployments", params={"agent_id": agent_id}, headers=auth_headers).json()
+            == []
+        )
+
+        # The operator does exactly what the refusal told them to do.
+        _bind_route(client, auth_headers, agent_id, "ops")
+
+        redelivered = _post(client, "push", payload).json()
+    finally:
+        client.app.dependency_overrides.pop(get_eval_queue, None)
+
+    assert redelivered["status"] == "deployed", redelivered
+
+    deployments = client.get(
+        "/deployments", params={"agent_id": agent_id}, headers=auth_headers
+    ).json()
+    assert len(deployments) == 1, deployments
+    assert deployments[0]["status"] == "active", deployments
+    assert deployments[0]["version_id"] == redelivered["version_id"], deployments
+
+    assert len(eval_queue.jobs) == 1, (
+        "the repaired push went live on a version eval-as-CI never ran against: the "
+        "refused delivery stored the bundle, so the redelivery took the reuse path"
+    )
+    assert str(eval_queue.jobs[0].version_id) == redelivered["version_id"], eval_queue.jobs
+    assert eval_queue.jobs[0].sha == sha, eval_queue.jobs
+
+
+def test_a_live_sibling_attach_whose_stored_object_exceeds_the_current_cap_reports_bundle_too_large(
+    client: Any,
+    auth_headers: dict[str, str],
+    clean_db: None,
+    trusted_clone_base: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Code review P2 (`deploy.py:204-210`): AC1's sibling gate must keep the size contract.
+
+    The conditional attach gate reads the SIBLING's stored object, which is a
+    different object from the freshly cloned archive `deploy.validate_archive`
+    passed moments earlier, so an operator who tightens the caps under a legacy
+    sibling makes `check_routes_from_bytes` raise an uncaught extraction
+    error straight out of the webhook handler. ADR-0059 decision 3 commits to a
+    specific operator-facing outcome for stored bytes that no longer fit the
+    current caps, and the gate runs BEFORE `revalidate_stored_bundle` on this
+    path, so the translation has to happen where the extraction does.
+
+    The cloned archive is deliberately far under the tightened cap and the
+    stored sibling far over it, so the cap is the only variable: a delivery that
+    reported `bundle.unsupported` for the clone instead would be a different
+    test.
+    """
+
+    dev_id = _register(client, auth_headers, "two-agent-dev", "C000000D01")
+    prod_id = _register(client, auth_headers, "two-agent-prod", "C000000E01")
+    clone_url, sha = _build_bare_repo(trusted_clone_base, REPO, TWO_TARGET_FILES)
+
+    # The target: a git-flow version row left bundleless by a store that failed
+    # after the row committed, deployed out of band through `POST /deployments`.
+    # That is what makes `attach_is_live` true and puts the sibling gate on the
+    # path at all.
+    _insert_partial_version(dev_id, sha)
+    target = client.get(f"/agents/{dev_id}/versions", headers=auth_headers).json()[0]
+    assert target["bundle_ref"] is None, target
+    activated = client.post(
+        "/deployments",
+        json={"agent_id": dev_id, "version_id": target["id"], "environment": "dev"},
+        headers=auth_headers,
+    )
+    assert activated.status_code == 201, activated.text
+
+    # The sibling: the same commit on the other agent of this repository
+    # (ADR-0091), carrying an object stored under the DEFAULT caps that is far
+    # larger than the archive this delivery clones. The filler is incompressible
+    # so the upload clears the compression-ratio cap and the uncompressed-size
+    # cap tightened below is the only thing that can refuse it. It declares no
+    # approvalPolicy, so `approval_routes.unbound` is not an available answer
+    # and `bundle.too_large` is the only correct one.
+    _insert_partial_version(prod_id, sha)
+    sibling = client.get(f"/agents/{prod_id}/versions", headers=auth_headers).json()[0]
+    members: dict[str, bytes] = {rel: text.encode() for rel, text in VALID_FILES.items()}
+    members["filler.bin"] = os.urandom(500_000)
+    legacy = io.BytesIO()
+    with tarfile.open(fileobj=legacy, mode="w:gz") as archive:
+        for rel, data in members.items():
+            info = tarfile.TarInfo(f"demo-plugin/{rel}")
+            info.size = len(data)
+            archive.addfile(info, io.BytesIO(data))
+    upload = client.put(
+        f"/agents/{prod_id}/versions/{sibling['id']}/bundle",
+        files={"file": ("legacy.tar.gz", legacy.getvalue())},
+        headers=auth_headers,
+    )
+    assert upload.status_code == 201, upload.text
+
+    # Now the caps move under it: well above the cloned archive, well below the
+    # stored sibling object.
+    _tighten_uncompressed_cap(monkeypatch, "100000")
+
+    body = _post(client, "push", _push_payload("refs/heads/dev", sha, clone_url)).json()
+
+    assert body["status"] == "rejected", body
+    assert {e["code"] for e in body["errors"]} == {"bundle.too_large"}, body
+
+    after = client.get(f"/agents/{dev_id}/versions", headers=auth_headers).json()[0]
+    assert after["bundle_ref"] is None, (
+        "the over-cap sibling object was attached to an already-active version"
+    )
+    assert [
+        d["id"]
+        for d in client.get(
+            "/deployments", params={"agent_id": dev_id}, headers=auth_headers
+        ).json()
+    ] == [activated.json()["id"]]

--- a/docs/approvals.md
+++ b/docs/approvals.md
@@ -156,6 +156,19 @@ posted to the requesting channel. Silently widening a request to whoever happens
 in the requesting channel is exactly the failure the gate exists to prevent, so the
 platform refuses rather than guesses.
 
+Since #2436, that same gap is also closed a step earlier, at configuration time. A route
+the bundle declares with no entry in the agent's `approval_routes` now refuses the write
+that would make it live: `POST /deployments` returns 422, a git push deploy or promote is
+rejected with code `approval_routes.unbound`, and a bundle uploaded onto a version an
+active deployment already references is refused too. The refusal names the unbound
+route(s) alongside the ones that are bound. A bound route no bundle declares is still
+accepted, so pre-binding ahead of a bundle bump remains supported. The check tests only
+whether a binding is present, not whether it is valid; the worker's request-time
+escalation above stays the backstop for a binding removed or corrupted after this check
+ran. An `approval_routes` write, including `--clear-routes` or an empty routes file, that
+would drop a route declared by any active deployment of the agent, in either environment,
+is refused on the same terms.
+
 Bind one from the CLI rather than by hand. A write REPLACES the whole map, so name
 every route it should keep:
 
@@ -169,10 +182,16 @@ The strict `--routes-from` JSON uses the complete binding shape shown above and 
 way to declare a notification, including the `endpoint` and `adapter` required for a
 non-Slack target. `--route-resolution` and `--route-approvers` can override resolution and
 authority from that file; the latter takes `users:U0123ABCD,W0456DEFG` or `group:S0123ABCD`.
-`--clear-routes` removes every binding. A `--routes-from` file containing `{}` clears every
-binding too, the same as `--clear-routes`. The retired `--route` flag and `channel` JSON key
-are not accepted. Nothing is written unless every entry parses, so a typo cannot leave a
-half-written map behind.
+`--clear-routes` removes every binding, but only when no active deployment for the agent
+declares one of the routes being removed; otherwise the write is refused, naming those
+routes. A `--routes-from` file containing `{}` clears every binding too, the same as
+`--clear-routes`, and is refused on the same terms. To clear a gated agent's routes, first
+end every still-active deployment whose bundle declares one of them (`DELETE
+/deployments/{id}`), then clear. Deploying a version that declares no gates is not enough:
+deployments append rather than stop earlier ones, so an older active deployment still
+declares the route and the preflight still refuses. The retired `--route` flag and
+`channel` JSON key are not accepted. Nothing is written unless every entry parses, so a
+typo cannot leave a half-written map behind.
 
 ## Who may resolve
 
@@ -349,7 +368,8 @@ case, the requesting channel is the card location.
 | `403 could not verify approver group membership` | Slack group membership could not be verified. This fails closed and does not name its cause. Check the API `SLACK_BOT_TOKEN`, its `usergroups:read` scope and reinstallation, and Slack availability. It never falls back to channel membership. |
 | `409 already resolved by ...` | Someone else won the claim. The decision stands. |
 | `410 expired` | The record passed its deadline. The session was already woken down its timeout branch. |
-| Agent says a request is pending, no card anywhere | The named route is not bound for this agent, so the turn escalated instead of posting. Add the binding. |
+| Agent says a request is pending, no card anywhere | The named route is not bound for this agent, so the turn escalated instead of posting. Since #2436 this case is now caught before deploy for a newly declared route; the escalation remains the backstop for a binding removed after deployment. Add the binding. |
+| `422`, or a rejected push with code `approval_routes.unbound` | The bundle declares an approval route with no entry in this agent's `approval_routes`. Bind every route the bundle declares, then redeploy. |
 | Notification arrived, but it has no buttons | Expected: notification is visibility-only. Use its approval ID and go to the configured approval channel to find the verified Slack resolution card; the ping deliberately does not disclose that channel's identifier. |
 | Card resolved, but the agent never continued | The skill has no instruction for the `[approval resolved]` prefix. |
 

--- a/docs/interfaces/approval/INTERFACE.md
+++ b/docs/interfaces/approval/INTERFACE.md
@@ -262,6 +262,16 @@ in code now:
   decision, and the authorizer snapshot -- who resolved, how the platform authenticated
   them, and why they counted (or were refused). Rows written before ADR-0106 retain
   `principal_kind=NULL` and `authenticated=false` rather than being retroactively trusted.
+- **The declared/bound join is also checked at configuration time (landed, #2436).**
+  `check_approval_route_bindings` and its sibling helpers
+  (`apps/api/src/curie_api/deploy.py`) refuse, before a version becomes live, whenever the
+  bundle declares a route with no entry in `approval_routes`: at `POST /deployments`, at
+  both git push paths (dev deploy and prod promote), at a bundle attached to a version an
+  active deployment already references, and at an `approval_routes` write that would drop
+  a route an active deployment still declares. It deliberately checks only presence, not
+  validity, of a binding -- a binding that fails schema validation is still treated as
+  bound -- and ADR-0046's request-time escalation above is retained unchanged as the
+  backstop for that residual.
 
 ### Arming a gate: bare MCP shorthand is normalized; unresolvable names fail closed
 

--- a/runner/tests/test_approval.py
+++ b/runner/tests/test_approval.py
@@ -2753,3 +2753,68 @@ def test_ambiguous_connector_and_server_gate_refuses_to_boot(tmp_path) -> None:
             mcp_servers=resolution.mcp_servers,
             connector_servers=resolution.connector_servers,
         )
+
+
+def test_route_normalization_vector_matches_the_runtime_loader(tmp_path) -> None:
+    """F4 parity seam: the frozen route vector IS the runtime loader's behavior.
+
+    The runner half of the two-sided probe (`#2436`). The deploy-time reader
+    `curie_api.bundles.declared_approval_routes` must derive the same declared
+    route set this loader arms, or a bundle passes the new configuration-time
+    join and then boots with a different set of gates. Code cannot be shared
+    across that seam -- `packages/plugin-format` is frozen and the API must not
+    import `curie_runner` -- so `tests/vectors/approval-route-normalization.json`
+    is the rule and BOTH sides execute it, exactly as
+    `test_route_normalization_agrees_between_validator_and_runner` above
+    executes the validator/loader pair rather than reasoning about it.
+
+    Two properties the vector pins, both of which have already shipped as
+    fail-opens on adjacent code:
+
+    - the declared set is `set(route_by_tool.values())`, a LAST-WINS map per
+      tool, not the union of every gate's route. A repeated tool's earlier route
+      is discarded here and can never be raised at runtime, so a deploy-time
+      reader that unioned the values would refuse a deploy-valid bundle over a
+      route that does not exist.
+    - a `"rejected"` row asserts a RAISE, not an empty map. That is what keeps
+      the vector from being satisfiable by weakening this loader's #520
+      fail-closed posture: a loader that quietly returned `{}` for a gate it
+      cannot arm would satisfy an equality-only vector while booting ungated.
+    """
+
+    from pathlib import Path
+
+    vector_path = (
+        Path(__file__).resolve().parents[2]
+        / "tests"
+        / "vectors"
+        / "approval-route-normalization.json"
+    )
+    cases = json.loads(vector_path.read_text(encoding="utf-8"))["cases"]
+    assert cases, "the frozen vector must carry cases, or this test proves nothing"
+
+    for case in cases:
+        root = tmp_path / str(case["id"])
+        (root / ".claude-plugin").mkdir(parents=True)
+        # Built-in tool names ("Bash", "Write") throughout: they carry no mcp__
+        # prefix, so the namespacing rules are out of the picture and the ROUTE
+        # normalization is the only variable, the same isolation `_write_bundle`
+        # above uses.
+        manifest: dict[str, object] = {"name": "route-vector", "version": "0.1.0"}
+        if case["gates"] is not None:
+            manifest["approvalPolicy"] = {"gates": case["gates"]}
+        (root / ".claude-plugin" / "plugin.json").write_text(
+            json.dumps(manifest), encoding="utf-8"
+        )
+
+        if case["expected"] == "rejected":
+            with pytest.raises(ApprovalPolicyError):
+                resolve_approval_policy(str(root))
+            continue
+
+        resolved = sorted(set(resolve_approval_policy(str(root)).route_by_tool.values()))
+        assert resolved == case["expected"], (
+            f"case {case['id']!r}: the runtime loader declares {resolved!r} but the "
+            f"frozen vector says {case['expected']!r} -- normalization drift between "
+            "the deploy-time reader and the loader is the #453/#544 fail-open shape"
+        )

--- a/tests/vectors/approval-route-normalization.json
+++ b/tests/vectors/approval-route-normalization.json
@@ -1,0 +1,98 @@
+{
+  "description": "The frozen declared-approval-route normalization, executed from BOTH sides of the deploy-time/runtime seam (#2436). `gates` is the manifest `approvalPolicy.gates` list, or null for a manifest that declares no `approvalPolicy` at all. `expected` is either the SORTED list of route names the bundle declares, or the string \"rejected\" for the fail-closed case where a declared gate arms no tool. The API reader (`curie_api.bundles.declared_approval_routes`) must return the set for a route list and the None poison value for \"rejected\"; the runtime loader (`curie_runner.approval.resolve_approval_policy`) must return a `route_by_tool` map whose values are that same set, and must RAISE `ApprovalPolicyError` for \"rejected\". Code cannot be shared -- packages/plugin-format is frozen and the API must not import curie_runner -- so this file is the shared rule, following the pattern of runner/tests/test_approval.py::test_route_normalization_agrees_between_validator_and_runner. Note the declared set is `set(route_by_tool.values())` and NOT the union of every gate's route: the loader's map is last-wins per tool, so an earlier route for a repeated tool can never be raised at runtime.",
+  "cases": [
+    {
+      "id": "plain-route",
+      "gates": [{"gate": "Bash", "route": "ops"}],
+      "expected": ["ops"]
+    },
+    {
+      "id": "padded-route",
+      "gates": [{"gate": "Bash", "route": "  ops  "}],
+      "expected": ["ops"]
+    },
+    {
+      "id": "padded-gate",
+      "gates": [{"gate": "  Bash  ", "route": "ops"}],
+      "expected": ["ops"]
+    },
+    {
+      "id": "blank-gate",
+      "gates": [{"gate": "   ", "route": "ops"}],
+      "expected": "rejected"
+    },
+    {
+      "id": "empty-gate",
+      "gates": [{"gate": "", "route": "ops"}],
+      "expected": "rejected"
+    },
+    {
+      "id": "blank-route",
+      "gates": [{"gate": "Bash", "route": "   "}],
+      "expected": "rejected"
+    },
+    {
+      "id": "empty-route",
+      "gates": [{"gate": "Bash", "route": ""}],
+      "expected": "rejected"
+    },
+    {
+      "id": "one-unarmed-gate-among-valid-ones",
+      "gates": [
+        {"gate": "Bash", "route": "ops"},
+        {"gate": "Write", "route": "   "}
+      ],
+      "expected": "rejected"
+    },
+    {
+      "id": "same-tool-twice-last-route-wins",
+      "gates": [
+        {"gate": "Bash", "route": "alpha"},
+        {"gate": "Bash", "route": "omega"}
+      ],
+      "expected": ["omega"]
+    },
+    {
+      "id": "same-tool-twice-padded-duplicate-of-one-route",
+      "gates": [
+        {"gate": "Bash", "route": "ops"},
+        {"gate": "Bash", "route": " ops "}
+      ],
+      "expected": ["ops"]
+    },
+    {
+      "id": "duplicate-identical-route-across-two-gates",
+      "gates": [
+        {"gate": "Bash", "route": "ops"},
+        {"gate": "Write", "route": "ops"}
+      ],
+      "expected": ["ops"]
+    },
+    {
+      "id": "two-tools-two-routes",
+      "gates": [
+        {"gate": "Bash", "route": "ops"},
+        {"gate": "Write", "route": "finance"}
+      ],
+      "expected": ["finance", "ops"]
+    },
+    {
+      "id": "routes-differing-only-by-case-are-two-routes",
+      "gates": [
+        {"gate": "Bash", "route": "ops"},
+        {"gate": "Write", "route": "Ops"}
+      ],
+      "expected": ["Ops", "ops"]
+    },
+    {
+      "id": "no-approval-policy",
+      "gates": null,
+      "expected": []
+    },
+    {
+      "id": "empty-gates-list",
+      "gates": [],
+      "expected": []
+    }
+  ]
+}


### PR DESCRIPTION
Closes #2436

Fix pin: apps/api/tests/test_approval_route_config_check.py::test_deploy_is_refused_when_the_bundle_declares_an_unbound_route

## What changed

A route a bundle declares under `approvalPolicy.gates[].route` and an operator binding in the agent's `approval_routes` map lived in two layers nothing cross-checked, so a declared-but-unbound route was only discovered at request time, in front of a user, by the worker's escalation. The API now joins the two sets at configuration time, through one helper family in `deploy.py`, and refuses the write that would make an unbound route live:

- `POST /deployments` returns 422 naming the unbound route(s) and the bound ones.
- A git push deploy or promote is rejected with code `approval_routes.unbound`. On the build path the check runs before the bundle is attached or stored, so a refused push leaves the version bundleless and a redelivery after binding rebuilds and fans out its eval once. The sibling-attach path checks the sibling's stored object, not the in-hand archive.
- A bundle uploaded onto a version an active deployment already references is refused; an ordinary pre-deployment upload stays unrestricted, so the CLI's create-version, upload, deploy order is unchanged.
- An `approval_routes` write, including an explicit `{}`, that drops a route declared by any active deployment row in either environment is refused before any other field of the PATCH commits.
- A bound route no bundle declares is accepted. A bundle with no `approvalPolicy`, or with an empty `gates` list, never triggers the check.
- The check tests binding presence, not validity. The worker's request-time escalation is untouched (zero diff under `apps/worker`) and remains the backstop for a binding removed or corrupted after validation.
- An archive cap tightened after an object was stored surfaces as the established `bundle.too_large` refusal, not a 500.

The declared-route reader mirrors the runner loader's normalization (last-wins tool-to-route, blank gates refused) and both sides are pinned to `tests/vectors/approval-route-normalization.json`.

Docs: `docs/approvals.md` (binding section, route clearing recovery, common failures), `docs/interfaces/approval/INTERFACE.md`, `apps/api/CLAUDE.md`.

## When the check fires

| Moment | Result |
|---|---|
| `POST /agents` with routes, `PUT .../bundle` before any deployment | nothing to join yet, accepted |
| `POST /deployments`, git push deploy, git push promote | refused when a declared route is unbound |
| `PUT .../bundle` onto an already-deployed version, git push attach onto one | refused likewise |
| `PATCH /agents/{id}` with `approval_routes` | refused when the new map drops a route any active deployment declares |
| bound route no bundle declares | accepted |

To clear a gated agent's routes, end every still-active deployment whose bundle declares them first. Deploying an ungated version is not enough because deployments append rather than stop earlier rows.

## Follow-ups

- #2446 live-tier pin for the refusal (discovery waiver: this run had no cluster access).
- #2447 decide whether `POST /evals/trigger` should honor the check.
- #2448 CLI pre-check before deploy and `--clear-routes`.
- #2449 console rendering of the refusal.

Open required tier: external integration. The git push path is exercised by the in-repo signed-webhook integration tests against local bare repos; a real GitHub webhook delivery against a running API was not performed from this run.

## Done-check

- [x] Failing tests committed before implementation: the pipeline history had the test commits ahead of each implementation commit (squashed here into one commit; the run record has the sequence).
- [x] All production edits performed by delegated sub-agents (implementer, three fixers, consolidation pass); the driver made no direct edits.
- [x] Broadened return types: none reported; `update_agent` gained a dependency parameter and `check_approval_route_bindings` changed signature, and every caller of every changed symbol is inside the seven changed API modules.
- [x] Cross-engine Code Reviewer: round 1 requested two changes (eval fan-out on retry, uncaught cap error), both fixed and pinned; round 2 closed both and found one doc sentence, fixed; consolidation re-check approved with no findings.
- [x] Cross-engine Scope Reviewer: every hunk mapped to an AC or the decision table; one docs finding, fixed.
- [x] Sibling-path parity: 20 behavior sites enumerated in the plan; deferred siblings filed as #2447, #2448, #2449; no new site surfaced at this gate.
- [x] Guard demonstration: executed over HTTP against a locally running API on the final tree (deploy refused naming `ops` with no row; bind then 201; clear refused while active; clear accepted after the deployment ended).
- [x] Consolidation pass: four cleanups applied, full validation green afterwards, cross-engine re-check approved.
- [x] Cross-engine Security Reviewer: completed; its three findings coincided with the code and scope findings and are fixed.
- [x] Observable verification for the user-facing operator flow: the HTTP pass above, recorded before commit.
- [ ] N/A E2E Tester: deployed-surface not flagged (pure API validation, no boot boundary or chart change).
- [x] Train check: milestone v0.8.7 is a patch milestone and this is a bug fix, so `main`.
- [x] Discovery-surface proof: `found:live` ticket; discovery waiver recorded in the plan; higher-tier pin filed as #2446.
- [ ] N/A Re-fix mechanism: no prior fix of this symptom exists.
- [x] Full affected suite: 3232 passed, 7 skipped; mypy, ruff, lint-imports, docs lint, contract drift, and OpenAPI drift all clean; `apps/worker` and `packages` carry zero diff.
