### PR TITLE
Tell the person when a turn fails and reclaim it on lease expiry, not the 900 s backstop

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -320,6 +320,9 @@ Each has an integration test under `apps/worker/tests/`:
    preventing replacement replicas from racing through the delivery budget;
    unknown older consumers retain `XAUTOCLAIM` as the compatibility backstop
    ([`apps/worker/src/curie_worker/stream_consumer.py::StreamConsumer._reclaim_once`](apps/worker/src/curie_worker/stream_consumer.py)).
+   The same `_reclaim_once` also transfers a delivery whose lease has expired even
+   when its PEL consumer is still alive, so a live handler that raised and released
+   its lease is not stuck waiting for a peer to be proven dead.
    A restarted generation first recovers rows under its own stable consumer name.
    The runs consumer group is created at `$`, so a cold worker never replays ancient
    backlog ([`apps/worker/src/curie_worker/consumer.py::Consumer.ensure_group`](apps/worker/src/curie_worker/consumer.py)).

--- a/apps/worker/CLAUDE.md
+++ b/apps/worker/CLAUDE.md
@@ -65,6 +65,27 @@ simplification.
   sustained-absence proof. That path still reads pre-claim `XPENDING` metadata
   and applies the local `_inflight_ids` skip before either a direct
   dead-letter or an `XCLAIM`; it never charges a live peer another delivery.
+- **Lease-expiry exception (#2433).** A pending row whose delivery state exists
+  but whose delivery lease has expired is cap-evaluated and graveyard-eligible
+  at `lease_expired_idle_ms` (`CURIE_LEASE_EXPIRED_IDLE_MS`, default one lease
+  TTL, 45 s) rather than at `reclaim_min_idle_ms` (900 s), regardless of whether
+  its PEL consumer is still alive. It still reads the delivery count from the
+  pre-claim `XPENDING` row, caps at `>=`, and keeps the `_inflight_ids` skip
+  ahead of the cap check. Implementation:
+  `apps/worker/src/curie_worker/stream_consumer.py::StreamConsumer._select_lease_expired_entries`.
+  An entry with no delivery state carries no evidence a lease was ever granted
+  and stays on the unchanged 900-second backstop.
+- **Compare-and-claim: every transfer `XCLAIM` passes the idle the caller
+  observed for that row, and `0` is never passed.** The lease-expiry pass passes
+  its scan `IDLE`; the proven-dead pass passes each row's own
+  `time_since_delivered` from the pre-claim `XPENDING` read. `XCLAIM` with a
+  positive min-idle is an atomic compare-and-claim on the row's idle clock, and
+  any competing transfer (a claim, a heartbeat, `XAUTOCLAIM`) resets that clock,
+  so two transfer paths cannot both move one row. Accepted residual: a row this
+  process claimed whose dispatch then waits past one lease TTL can be re-claimed
+  by a peer, and the late handler's `acquire` is refused `not-owner` and returns
+  without acking. The cost is one charged delivery, logged at WARNING, never a
+  double run and never a stranded turn.
 - **`XADD` before `XACK`, never the reverse.** A crash between them costs a
   duplicate graveyard row; the reverse costs the entry.
 - **`max_delivery` is not `max_attempts`.** The latter is the kernel's
@@ -130,6 +151,15 @@ string-key verbs.
   consumer is not guessed dead by the prompt path; its PEL entries stay on the
   existing 900-second `XAUTOCLAIM` backstop. The prompt path is additional
   recovery for a proven-dead capable peer, not a shorter global idle timeout.
+- **A live consumer's own stranded row is not a prompt-path case (#2433).** A
+  handler that raised released its delivery lease and left the entry pending,
+  and no prompt path looks at a peer that is not dead. `_reclaim_once`'s
+  lease-expiry pass recovers such a row once its lease has expired, whoever owns
+  it. A pre-lease or pre-marker entry with no delivery state still waits out the
+  unchanged 900-second backstop. While the row waits,
+  `apps/worker/src/curie_worker/kernel.py::Kernel.notify_turn_not_started` edits
+  the placeholder to `turn_not_started_text` (`CURIE_TURN_NOT_STARTED_TEXT`),
+  best effort, so the thread is not silent.
 - **Runs/eval parity is mandatory.** Both
   `apps/worker/src/curie_worker/consumer.py::Consumer` and
   `apps/worker/src/curie_worker/eval/stream.py::EvalStreamConsumer` use the shared

--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -121,7 +121,10 @@ Runtime rules (each has a provoking integration test in `tests/eval/test_stream.
 - **XACK only after the report POST attempt completes** (success, or terminally failed
   after bounded retries and logged). A worker crash before that leaves the entry
   pending. The shared runs/eval liveness path promptly transfers a capable dead
-  consumer's PEL after two lease-absence observations; unknown older consumers
+  consumer's PEL after two lease-absence observations. A live consumer's own
+  stranded row (delivery state present, delivery lease expired) is separately
+  recovered by the lease-expiry pass after about one lease TTL. Unknown older
+  consumers, or an entry with no delivery state at all,
   retain the 15-minute `XAUTOCLAIM` fallback. A restarted generation first
   recovers rows under its own stable consumer name. The entry is re-run, so
   delivery is **at-least-once** with a best-effort
@@ -152,9 +155,11 @@ the Slack thread by editing the placeholder in place, and gets every failure
 mode right.
 
 ```
-XREADGROUP curie:runs        Consumer (consumer group; XAUTOCLAIM reclaims a
-   -> QueuedTurn                  dead consumer's pending entries after an idle
-   -> Kernel.process_event        timeout, then reprocesses them idempotently)
+XREADGROUP curie:runs        Consumer (consumer group; a pending entry is
+   -> QueuedTurn                  reclaimed by proof of death, by lease expiry,
+   -> Kernel.process_event        or as a compatibility backstop by XAUTOCLAIM
+                                  after an idle timeout, then reprocessed
+                                  idempotently)
         -> SlackSink     chat.update placeholder to booting text (best effort)
         -> substrate.lookup/claim/resume   (sandbox substrate)
         -> RunnerClient  POST /v1/event | /v1/steer | /v1/interrupt   (runner)
@@ -202,7 +207,11 @@ Rules (detailed-architecture 2b), each with an integration test that provokes it
   A renewable worker lease distinguishes process death from ordinary consumer
   idle. After two absent observations, one replacement wins a Valkey arbitration
   lease and transfers the dead consumer's pending entries without racing other
-  replicas through the delivery budget. Unknown older consumers retain the
+  replicas through the delivery budget. A delivery whose handler raised released
+  its lease and left its entry pending under a consumer that is still alive; the
+  lease-expiry pass recovers that row after about one lease TTL
+  (`CURIE_LEASE_EXPIRED_IDLE_MS`) rather than leaving it to the backstop.
+  Unknown older consumers, and any entry with no delivery state, retain the
   15-minute `XAUTOCLAIM` fallback; a restarted generation also recovers pending
   rows left under its own stable consumer name. The markers make reprocessing safe.
 - **Bounded delivery + a dead-letter graveyard** (ADR-0039, an Architecture
@@ -314,7 +323,9 @@ Config surface (`WorkerConfig`): `VALKEY_*`, `SLACK_BOT_TOKEN`,
 `CURIE_STREAM` / `CURIE_CONSUMER_GROUP` / `CURIE_CONSUMER_NAME`,
 `CURIE_MAX_ATTEMPTS`, `CURIE_MAX_DELIVERY` / `CURIE_DEAD_LETTER_STREAM` /
 `CURIE_DEAD_LETTER_MAXLEN` (approximate graveyard cap, default `10000`, minimum
-`1`), plus `CURIE_NAMESPACE` / `CURIE_WARM_POOL` / `CURIE_RUNNER_PORT` for
+`1`), `CURIE_LEASE_EXPIRED_IDLE_MS` (the lease-expiry reclaim threshold, default
+one delivery lease TTL) and `CURIE_TURN_NOT_STARTED_TEXT` (the placeholder edit
+when a delivery's handler raises), plus `CURIE_NAMESPACE` / `CURIE_WARM_POOL` / `CURIE_RUNNER_PORT` for
 the substrate. Run with `python -m curie_worker`.
 
 Tests: `uv run pytest apps/worker/tests/kernel -q` runs against the real Valkey

--- a/apps/worker/src/curie_worker/config.py
+++ b/apps/worker/src/curie_worker/config.py
@@ -315,6 +315,26 @@ class WorkerConfig(BaseSettings):
         validation_alias="CURIE_BOOTING_TEXT",
     )
 
+    # Edited onto the placeholder when a delivery's handler RAISED and the entry
+    # was left pending for the bounded retry, so the thread is never silent while
+    # the redelivery is waited out (#2433).
+    #
+    # The wording is load-bearing, because this branch is reachable in three
+    # shapes, not one: the turn that never started; the turn that streamed partial
+    # text and then raised; and the turn that persisted a side-effect marker,
+    # where the next delivery escalates to a person rather than re-running (kernel
+    # rule 4). "I could not finish" and "picked up again" are true in all three;
+    # "I could not start" and "I will retry" are each a product lie on two of
+    # them. Kept free of internal vocabulary and of any id (#717): there is
+    # nothing here a person can look up, so naming one only leaks architecture.
+    turn_not_started_text: str = Field(
+        default=(
+            "I ran into a problem and could not finish this request, so if no "
+            "answer appears here shortly, please send it again."
+        ),
+        validation_alias="CURIE_TURN_NOT_STARTED_TEXT",
+    )
+
     # Stream / consumer group (must match the dispatcher's CURIE_STREAM). The
     # defaults are the shared declarations (#492) so a rename cannot drift this
     # lane out of sync with the dispatcher/API/CLI; the validation_alias keeps
@@ -463,6 +483,47 @@ class WorkerConfig(BaseSettings):
         return self
 
     @model_validator(mode="after")
+    def _lease_expiry_idle_sits_between_the_lease_and_the_backstop(self) -> WorkerConfig:
+        """Bound an EXPLICIT lease-expiry threshold on both sides (#2433).
+
+        Each end is a distinct silent failure. Below one lease TTL the scan can
+        select an entry between a healthy owner's heartbeats, before its lease
+        has actually expired, which reintroduces the cross-replica dup-dispatch
+        the lease exists to close. At or above the backstop the pass selects
+        nothing ``XAUTOCLAIM`` was not already claiming, so it is dead
+        configuration and ADR-0131's "recoverable after at most one short lease"
+        bound is silently off.
+
+        Only an EXPLICIT value is checked, deliberately. The derived default
+        cannot violate the lower bound because it IS the lease TTL, and
+        ``reclaim_min_idle_ms`` carries no ``validation_alias`` so no operator
+        can move the upper bound either; the only configurations that put the
+        derived default at or above the backstop are the test harnesses that
+        shorten the backstop into milliseconds, which would otherwise be
+        rejected by their own product code.
+        """
+        if self.lease_expired_idle_ms is None:
+            return self
+        idle_ms = self.lease_expired_idle_ms_value()
+        lease_ms = int(self.delivery_lease_ttl_s * 1000)
+        if idle_ms < lease_ms:
+            raise ValueError(
+                f"CURIE_LEASE_EXPIRED_IDLE_MS ({idle_ms!r}) must be at least one "
+                "delivery lease TTL, CURIE_DELIVERY_LEASE_TTL_S "
+                f"({self.delivery_lease_ttl_s!r}, {lease_ms!r}ms): a shorter "
+                "threshold can select an entry between a healthy owner's "
+                "heartbeats, before its lease has expired"
+            )
+        if idle_ms >= self.reclaim_min_idle_ms:
+            raise ValueError(
+                f"CURIE_LEASE_EXPIRED_IDLE_MS ({idle_ms!r}) must be below "
+                f"reclaim_min_idle_ms ({self.reclaim_min_idle_ms!r}): at or above "
+                "the backstop the lease-expiry pass selects nothing XAUTOCLAIM "
+                "was not already claiming, so the knob is dead configuration"
+            )
+        return self
+
+    @model_validator(mode="after")
     def _termination_grace_covers_the_budget(self) -> WorkerConfig:
         """Fail at construction if platform grace cannot cover budget + reserve.
 
@@ -593,6 +654,26 @@ class WorkerConfig(BaseSettings):
     # entirely, but is not needed now that the lease is the primary guard, and
     # would slow crash recovery for entries the lease mechanism cannot cover.
     reclaim_min_idle_ms: int = 900000
+    # The lease-expiry reclaim threshold (#2433, ADR-0131). An ADDITION to the
+    # backstop above and never a replacement: an entry with no delivery state
+    # carries no evidence a lease was ever granted, so "the lease is gone" cannot
+    # be told apart from "there never was one", and such an entry stays on the
+    # unchanged 900 second window.
+    #
+    # It is safe at exactly the lease TTL because a healthy owner's heartbeat
+    # resets PEL idle with ``XCLAIM ... JUSTID`` every
+    # ``delivery_lease_heartbeat_s``, so a live delivery's idle never approaches
+    # it; TTL plus one heartbeat would exceed ADR-0131's "recoverable after at
+    # most one short lease" bound.
+    #
+    # ``None`` means derive ``delivery_lease_ttl_s * 1000`` at the use site, the
+    # same shape ``dead_letter_stream`` uses, because a static ``Field`` default
+    # cannot reference another field. Both consumer lanes read the resolver, not
+    # this field, so the runs/eval parity seam is structural.
+    lease_expired_idle_ms: int | None = Field(
+        default=None,
+        validation_alias="CURIE_LEASE_EXPIRED_IDLE_MS",
+    )
     # Unchanged at 30.0; now bound by ``_reclaim_scan_shorter_than_lease``,
     # which enforces the ADR's actual requirement (scan strictly shorter than
     # the lease TTL) rather than a specific number. See the delivery-lease
@@ -1102,6 +1183,22 @@ class WorkerConfig(BaseSettings):
         this writer can never drift on the name.
         """
         return derive_dead_letter_stream_name(self.stream, self.dead_letter_stream)
+
+    def lease_expired_idle_ms_value(self) -> int:
+        """The lease-expiry reclaim threshold: the override, else one lease TTL.
+
+        ``lease_expired_idle_ms``'s Field default cannot reference
+        ``self.delivery_lease_ttl_s``, so the derivation lives here rather than at
+        the two use sites, next to ``dead_letter_stream_name()``, which resolves a
+        default the same way, and next to the validator that bounds the result.
+        Both consumer lanes read THIS method, which is what keeps ADR-0131's
+        runs/eval parity true by construction rather than by review.
+        """
+        return (
+            self.lease_expired_idle_ms
+            if self.lease_expired_idle_ms is not None
+            else int(self.delivery_lease_ttl_s * 1000)
+        )
 
     def eval_dead_letter_stream_name(self) -> str:
         """The eval lane's graveyard: ``<eval_stream>:dead`` (#535).

--- a/apps/worker/src/curie_worker/consumer.py
+++ b/apps/worker/src/curie_worker/consumer.py
@@ -205,6 +205,7 @@ class Consumer(StreamConsumer):
             logger=logger,
             dead_letter_log="dead-lettered entry %s after %d deliveries (reason=%s) -> %s",
             dead_letter_fail_log="dead-lettering entry %s failed; left pending, not dispatched",
+            lease_expired_idle_ms=config.lease_expired_idle_ms_value(),
         )
 
     async def ensure_group(self) -> None:
@@ -276,6 +277,14 @@ class Consumer(StreamConsumer):
             ),
             self._dispatch,
         )
+
+    def _transfer_capacity(self) -> int | None:
+        # Mirrors the semaphore rather than reading it: ``_dispatch`` adds to
+        # ``_inflight_ids`` immediately after ``self._sem.acquire()`` and
+        # ``_handle``'s finally discards it beside ``self._sem.release()``, so the
+        # two move together and this is the free-slot count without touching
+        # asyncio.Semaphore internals.
+        return max(0, self._max_concurrency - len(self._inflight_ids))
 
     async def _dispatch(self, entry_id: str, fields: dict[str, str]) -> None:
         if entry_id in self._inflight_ids:
@@ -398,7 +407,10 @@ class Consumer(StreamConsumer):
                         else:
                             await self._kernel.process_event(qevent, lease=lease)
                     except Exception as exc:
-                        # Leave the entry pending: XAUTOCLAIM will reclaim and retry.
+                        # Leave the entry pending: the lease-expiry reclaim pass
+                        # picks it up one lease TTL after this handler released
+                        # its lease, with XAUTOCLAIM still the 15 minute backstop
+                        # behind that (#2433).
                         if hasattr(span, "set_status"):
                             span.set_status(StatusCode.ERROR)
                         span.add_event(
@@ -414,6 +426,36 @@ class Consumer(StreamConsumer):
                             attributes={**metric_attributes, "outcome": "pending"},
                         )
                         logger.exception("processing failed for entry %s; left pending", entry_id)
+                        # Best-effort, and belt and braces: the kernel method
+                        # already swallows its own failures, but an exception
+                        # escaping THIS branch is the #673 shape exactly, and a
+                        # notice may never change the settlement outcome of a
+                        # delivery. The return below stays unconditional.
+                        try:
+                            # This branch can run AFTER lease loss and sits ahead
+                            # of the pre-ACK guard below, so terminality alone is
+                            # not permission to edit. A replacement that holds the
+                            # fence now owns this thread and will speak for it;
+                            # talking over it is worse than saying nothing. On the
+                            # leaseless sentinel this never raises, so a base-only
+                            # consumer still notifies.
+                            lease.raise_if_lost()
+                            await self._kernel.notify_turn_not_started(
+                                qevent, lease=lease
+                            )
+                        except LeaseLostError:
+                            logger.warning(
+                                "skipping the not-started notice for entry %s: this "
+                                "owner lost the delivery lease, and the current owner "
+                                "speaks for the thread",
+                                entry_id,
+                            )
+                        except Exception:
+                            logger.warning(
+                                "not-started notice failed for entry %s",
+                                entry_id,
+                                exc_info=True,
+                            )
                         return
                     try:
                         # A stale owner may not ACK. Checked immediately before

--- a/apps/worker/src/curie_worker/delivery_lease.py
+++ b/apps/worker/src/curie_worker/delivery_lease.py
@@ -466,6 +466,25 @@ class DeliveryLeaseStore:
         lease_key, _state_key = self._keys(stream, group, entry_id)
         return bool(await self._redis.exists(lease_key))
 
+    async def has_state(self, stream: str, group: str, entry_id: str) -> bool:
+        """Was a lease ever granted for this delivery?
+
+        A bare ``EXISTS`` on the state key, the cheap counterpart of
+        :meth:`is_live`'s ``EXISTS`` on the lease key. It exists rather than a
+        truthiness test on :meth:`peek` because that would drag the whole hash
+        back for a question that is one bit.
+
+        What it is FOR: positive evidence. It separates "a lease-aware owner died
+        or failed here", which is reclaimable once its lease is gone, from "a
+        pre-lease or pre-marker consumer's entry", which has no evidence at all
+        and stays on the unchanged XAUTOCLAIM backstop (the mixed-version rule in
+        ``apps/worker/CLAUDE.md``). Absence is authoritative for the second case
+        because only :meth:`settle` removes the state: a ``release`` leaves it, so
+        a failed handler's entry still carries it long after its lease is gone.
+        """
+        _lease_key, state_key = self._keys(stream, group, entry_id)
+        return bool(await self._redis.exists(state_key))
+
     async def peek(self, stream: str, group: str, entry_id: str) -> dict[str, str]:
         """The delivery state hash for diagnostics, ``{}`` when absent."""
         _lease_key, state_key = self._keys(stream, group, entry_id)

--- a/apps/worker/src/curie_worker/eval/stream.py
+++ b/apps/worker/src/curie_worker/eval/stream.py
@@ -328,6 +328,12 @@ class EvalStreamConsumer(StreamConsumer):
             logger=logger,
             dead_letter_log="dead-lettered eval entry %s after %d deliveries (reason=%s) -> %s",
             dead_letter_fail_log="dead-lettering eval entry %s failed; left pending, not re-run",
+            # The same resolver the runs lane reads, because ADR-0131 requires both
+            # consumer lanes to share the lease implementation by construction ("a
+            # fix on only one consumer lane is incomplete"). Not a copy-paste: an
+            # eval delivery whose owner was force-killed would otherwise wait out
+            # the 900s backstop while a runs delivery recovered in one lease.
+            lease_expired_idle_ms=config.lease_expired_idle_ms_value(),
         )
 
     async def ensure_group(self) -> None:
@@ -403,6 +409,15 @@ class EvalStreamConsumer(StreamConsumer):
             except Exception:
                 logger.exception("eval reclaim tick failed")
             await self._sleep_or_stop(self._config.reclaim_interval_s)
+
+    def _transfer_capacity(self) -> int | None:
+        # The eval lane runs one suite at a time: ``_dispatch`` below awaits the
+        # handler (``asyncio.shield``), so ``_dispatch_reclaimed`` runs suites
+        # strictly one at a time. Subtract a suite already running inline so the
+        # expiry pass claims nothing while one is in flight -- claiming a second
+        # row would leave it XCLAIMed and unleased for the length of a whole eval
+        # run.
+        return max(0, 1 - len(self._inflight_ids))
 
     async def _dispatch(self, entry_id: str, fields: dict[str, str]) -> None:
         """Track the inline eval handler so graceful stop can drain it alive."""

--- a/apps/worker/src/curie_worker/kernel.py
+++ b/apps/worker/src/curie_worker/kernel.py
@@ -93,7 +93,7 @@ from .behaviorpacks import (
 )
 from .binding import DECISION_ENV, GRANT_TOOL_ENV, RESUMED_KIND_ENV, BindingResolver
 from .config import WorkerConfig
-from .delivery_lease import DeliveryLease
+from .delivery_lease import DeliveryLease, LeaseLostError
 from .killswitch import KillSwitch
 from .markers import CompletionRecord, MalformedCompletionError, Markers
 from .publication_validation import validate_snapshot_against_base
@@ -660,6 +660,7 @@ class _ThrottledReply:
         no_edit: bool = False,
         best_effort: bool = False,
         on_ref: Callable[[str], None] | None = None,
+        on_final: Callable[[], None] | None = None,
     ) -> None:
         self._sink = ObservedReplySink(sink)
         self._target = target
@@ -667,6 +668,11 @@ class _ThrottledReply:
         # delivery paths edit the same message this streamer created. Only fires
         # on a placeholder-less turn, where the first emit posts rather than edits.
         self._on_ref = on_ref
+        # Told when the FINAL flush is attempted (#2433), mirroring ``on_ref``.
+        # ``stream`` and ``context`` deliberately never call it: a streamed
+        # fragment is a preview, not the answer, and one of #2433's three named
+        # shapes is the turn that streamed partial text and then raised.
+        self._on_final = on_final
         self._min_interval_s = min_interval_s
         self._no_edit = no_edit
         self._last = 0.0
@@ -731,6 +737,11 @@ class _ThrottledReply:
             logger.warning("context reply update failed: %s", type(exc).__name__)
 
     async def finalize(self, text: str) -> None:
+        # First statement, BEFORE the early return: an identical final means the
+        # last streamed edit already IS the answer, so it is delivered and must
+        # mark. Before the emit for the same reason ``_reply_for`` marks first.
+        if self._on_final is not None:
+            self._on_final()
         if text == self._last_text:
             return
         self._last_text = text
@@ -846,6 +857,17 @@ class Kernel:
         # deliberately NOT a cache across turns -- a later turn on the same
         # thread gets its own message, exactly as a Slack mention does.
         self._minted_refs: dict[str, str] = {}
+        # Event ids whose TERMINAL person-facing send was attempted during THIS
+        # delivery (#2433). An attempt counts even if it raised: an ambiguous
+        # delivery failure may still have landed remotely, and the fail-safe
+        # direction is to treat the person as already answered rather than
+        # overwrite the answer with a notice telling them to send it again.
+        # Booting edits and streaming previews deliberately never mark: the first
+        # is the placeholder saying work started, and a streamed fragment is not
+        # an answer. Bounded exactly as ``_minted_refs`` is -- every successful or
+        # cancelled turn clears its own entry in ``process_event``'s finally, and
+        # a FAILED one is cleared by the notice that reads it.
+        self._terminal_reply_attempted: set[str] = set()
 
     def _target_for(self, qevent: QueuedTurn) -> ReplyTarget:
         """This turn's reply target, including any ref minted during the turn.
@@ -884,6 +906,7 @@ class Kernel:
         text: str,
         *,
         best_effort_unreachable: bool = False,
+        terminal: bool = True,
     ) -> ReplyAck:
         """Deliver platform-authored text for this turn, adopting any minted ref.
 
@@ -895,10 +918,18 @@ class Kernel:
             route: This turn's egress route.
             text: The platform-authored text.
             best_effort_unreachable: Swallow an unreachable transport rather than raising.
+            terminal: Whether this text is the turn's RESULT for the person
+                (#2433). True for every caller that answers, drops, escalates or
+                notifies; False for the two booting edits and for the
+                not-started notice itself, none of which is a result.
 
         Returns:
             The adapter's acknowledgement.
         """
+        if terminal:
+            # Marked BEFORE the send, never after, so an exception from ``_reply``
+            # cannot skip the mark for text that may already be on the screen.
+            self._terminal_reply_attempted.add(qevent.event_id)
         ack = await self._reply(
             self._target_for(qevent),
             route,
@@ -907,6 +938,127 @@ class Kernel:
         )
         self._adopt_ref(qevent, ack)
         return ack
+
+    async def notify_turn_not_started(
+        self, qevent: QueuedTurn, *, lease: DeliveryLease | None = None
+    ) -> None:
+        """Tell the person their turn failed and is waiting for its retry (#2433).
+
+        Called from the consumer's ``except`` branch, where a delivery whose
+        handler raised is left pending. The log there is the operator's surface
+        and it always worked; the person on the other end of the thread had none,
+        and sat on the dispatcher's placeholder until the delivery was
+        redelivered.
+
+        It fires REGARDLESS of ``slack_no_edit_streaming``. That flag's promise is
+        "the placeholder gets exactly one chat.update: the final". A turn that
+        never finished emits no final, so obeying it here would leave the
+        placeholder frozen, the reported bug reproduced inside its fix.
+
+        It is best-effort by construction: a Slack outage may not turn a pending
+        delivery into a failed one, so nothing here raises. ``CancelledError``
+        still propagates, because cooperative shutdown is not a notice failure.
+
+        A placeholder-less turn (CLI, job, hook) is skipped entirely: with nothing
+        to edit, ``_reply_for`` POSTS a new message and adopts the minted ref,
+        which would hand every such failure a spurious message it never had.
+
+        Args:
+            qevent: The queued turn whose delivery failed.
+            lease: This delivery's ownership fence, when the caller holds one.
+        """
+        event_id = qevent.event_id
+
+        # Popped FIRST so the entry cannot leak if a later guard returns early.
+        # This is the in-process half of the delivered-answer guard: some
+        # person-facing RESULT was already sent during this delivery, and the
+        # notice must not overwrite it with an invitation to resend.
+        attempted = event_id in self._terminal_reply_attempted
+        self._terminal_reply_attempted.discard(event_id)
+
+        if qevent.reply_handle.placeholder is None:
+            logger.debug(
+                "event %s has no placeholder to edit; no not-started notice",
+                event_id,
+            )
+            return
+
+        if attempted:
+            logger.warning(
+                "skipping the not-started notice for event %s: this delivery had "
+                "already sent the person a result, and an ambiguous send may still "
+                "have landed",
+                event_id,
+            )
+            return
+
+        try:
+            # The durable half. ``is_terminal``, not a bare done marker: a DONE
+            # outbox record proves the turn finished just as well and outlives the
+            # marker. ``_complete`` emits the reply BEFORE it settles, so a settle
+            # that applies in Valkey and then loses its response unwinds into the
+            # consumer's except branch with the answer already on the person's
+            # screen and the done marker already written.
+            already_terminal = await self._markers.is_terminal(event_id)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            # FAIL CLOSED. The two errors are not symmetric: a notice skipped for
+            # a turn that did fail costs the person the seconds until the
+            # lease-expiry reclaim redelivers, which is the behaviour before this
+            # change; a notice sent for a turn that succeeded costs them the
+            # answer permanently.
+            logger.warning(
+                "terminality unreadable for event %s; skipping the not-started "
+                "notice rather than risk overwriting a delivered answer",
+                event_id,
+                exc_info=True,
+            )
+            return
+
+        if already_terminal:
+            logger.warning(
+                "event %s failed after settling terminally; leaving its delivered "
+                "reply in place rather than promising a retry that cannot happen",
+                event_id,
+            )
+            return
+
+        if lease is not None:
+            try:
+                # Re-checked at the emission boundary, AFTER the terminality read:
+                # a heartbeat can mark the lease lost while that read is pending,
+                # so a check taken only at the call site is already stale by the
+                # time the edit happens. An in-process event read, no Valkey call:
+                # ADR-0131 fences four verbs (ACK, dead-letter, clear record,
+                # terminal result) and this non-terminal edit is none of them, and
+                # a stale notice is self-correcting because the replacement's own
+                # booting edit overwrites it within milliseconds of its acquire.
+                lease.raise_if_lost()
+            except LeaseLostError:
+                logger.warning(
+                    "skipping the not-started notice for event %s: this owner lost "
+                    "the delivery lease, and the current owner speaks for the "
+                    "thread",
+                    event_id,
+                )
+                return
+
+        try:
+            await self._reply_for(
+                qevent,
+                _route_from_handle(qevent),
+                self._config.turn_not_started_text,
+                terminal=False,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.warning(
+                "the not-started notice for event %s could not be delivered",
+                event_id,
+                exc_info=True,
+            )
 
     async def process_event(
         self, qevent: QueuedTurn, *, lease: DeliveryLease | None = None
@@ -921,6 +1073,9 @@ class Kernel:
         """
 
         error: BaseException | None = None
+        # A redelivery must never inherit an earlier delivery's terminal-send mark
+        # from this process (#2433).
+        self._terminal_reply_attempted.discard(qevent.event_id)
         with operation_span(
             "curie.turn.process",
             kind=SpanKind.INTERNAL,
@@ -951,6 +1106,13 @@ class Kernel:
                     {"outcome": "classified_failure", "error.class": type(exc).__name__},
                 )
             finally:
+                if not isinstance(error, Exception):
+                    # Success and cooperative cancellation clear the mark; a
+                    # FAILED delivery deliberately leaves it, because the
+                    # consumer's except branch has not read it yet.
+                    # ``CancelledError`` is a ``BaseException``, so it clears here
+                    # too: a cancelled turn is a shutdown, not a lost answer.
+                    self._terminal_reply_attempted.discard(qevent.event_id)
                 outcome = _LIFECYCLE_OUTCOME.get()
                 if outcome is None:
                     # A normal early return is the already-terminal skip. An
@@ -2229,7 +2391,9 @@ class Kernel:
         defer_job_booting = qevent.reply_handle.placeholder is None and qevent.source.is_job
         if not self._config.slack_no_edit_streaming and not defer_job_booting:
             try:
-                await self._reply_for(qevent, route, self._config.booting_text)
+                await self._reply_for(
+                    qevent, route, self._config.booting_text, terminal=False
+                )
             except Exception:
                 logger.warning("booting-state update failed for %s", qevent.event_id)
 
@@ -2371,7 +2535,9 @@ class Kernel:
             try:
                 # Routing succeeded, so this delivery owns a real turn. Adopt the
                 # minted ref before streaming so every later update edits it.
-                await self._reply_for(qevent, route, self._config.booting_text)
+                await self._reply_for(
+                    qevent, route, self._config.booting_text, terminal=False
+                )
             except asyncio.CancelledError:
                 close_routed_turn()
                 raise
@@ -3360,6 +3526,7 @@ class Kernel:
             # plan-ratified, not an oversight.
             best_effort=self._is_approval_resume(qevent.event_id),
             on_ref=lambda ref: self._adopt_ref(qevent, ReplyAck(ref=ref)),
+            on_final=lambda: self._terminal_reply_attempted.add(qevent.event_id),
         )
         try:
             # ``async with`` releases the aiohttp response on every exit path

--- a/apps/worker/src/curie_worker/stream_consumer.py
+++ b/apps/worker/src/curie_worker/stream_consumer.py
@@ -102,6 +102,12 @@ class DeliverySpec:
     logger: logging.Logger
     dead_letter_log: str
     dead_letter_fail_log: str
+    # The idle threshold for the lease-expiry reclaim pass (ADR-0131, #2433).
+    # ``None`` means the lane opted out and the pass is inert, which is also what
+    # a base-only consumer with no lease store gets for free. Last in the
+    # dataclass because it is the first defaulted field; both lanes construct
+    # ``DeliverySpec`` with keyword arguments only, so appending is safe.
+    lease_expired_idle_ms: int | None = None
 
 
 class ConsumerLivenessExpired(RuntimeError):
@@ -339,6 +345,27 @@ class StreamConsumer:
         """Tasks whose handlers own PEL entries in this generation."""
 
         return set()
+
+    def _transfer_capacity(self) -> int | None:
+        """How many rows the lease-expiry pass may claim this tick, or None.
+
+        ``None``, the base default, means unbounded, which is what a base-only
+        consumer with no local dispatch accounting can honestly report.
+
+        Why a bound exists at all (#2433): every row this pass claims sits
+        XCLAIMed but UNLEASED until its dispatched handler acquires the delivery
+        lease. A lane whose dispatch can BLOCK (the runs semaphore, the eval
+        inline await) therefore parks claimed-but-unowned rows for the whole
+        wait, where every other replica reads them as expired-lease candidates.
+        Claiming only what can be dispatched now also routes the surplus to a
+        replica that has capacity, which is the behavior a saturated node should
+        have.
+
+        Consulted ONLY by ``_select_lease_expired_entries``. The proven-dead
+        transfer path is deliberately unbounded and unchanged.
+        """
+
+        return None
 
     def _reset_generation_resources(self) -> None:
         """Subclass hook for semaphore/accounting reset after forced teardown."""
@@ -641,6 +668,37 @@ class StreamConsumer:
                 exc_info=True,
             )
             return True
+
+    async def _has_delivery_state(self, entry_id: str) -> bool:
+        """Was a delivery lease ever granted for this entry?
+
+        The mirror image of :meth:`_lease_is_live`'s posture. That one fails
+        closed as OWNED; this one fails closed as ABSENT, meaning "no evidence".
+        Both answers refuse the claim, which is the point: failing open here
+        would let one Valkey blip manufacture a duplicate dispatch of a turn
+        somebody may still be running.
+
+        Absence is what keeps the mixed-version rule true (#2433). A pre-lease or
+        pre-marker consumer's pending entry carries no evidence a lease was ever
+        granted, so "the lease is gone" cannot be told apart from "there never
+        was one", and such an entry stays on the unchanged XAUTOCLAIM backstop.
+        With no lease store configured there is no evidence to read either.
+        """
+        if self._leases is None:
+            return False
+        try:
+            return await self._leases.has_state(
+                self._spec.stream, self._spec.group, entry_id
+            )
+        except Exception:
+            self._spec.logger.warning(
+                "delivery state unreadable for entry %s on stream %s; treating it "
+                "as ABSENT and leaving it on the backstop",
+                entry_id,
+                self._spec.stream,
+                exc_info=True,
+            )
+            return False
 
     @asynccontextmanager
     async def _delivery_lease(
@@ -1263,50 +1321,169 @@ class StreamConsumer:
             )
             if not rows:
                 break
-            claim_ids: list[str] = []
-            for row in rows:
-                entry_id = str(row["message_id"])
-                if entry_id in self._inflight_ids or entry_id in over_cap:
-                    continue
-                if await self._lease_is_live(entry_id):
-                    continue
-                delivered = int(row["times_delivered"])
-                if delivered >= self._spec.max_delivery:
-                    over_cap.add(entry_id)
-                    try:
-                        await self._dead_letter(
-                            entry_id,
-                            await self._entry_fields(entry_id),
-                            reason=self._spec.over_cap_reason,
-                            delivery_count=delivered,
-                        )
-                    except Exception:
-                        self._spec.logger.exception(
-                            self._spec.dead_letter_fail_log,
-                            entry_id,
-                        )
-                    continue
-                claim_ids.append(entry_id)
-
-            if claim_ids:
-                claimed = await self._redis.xclaim(
-                    self._spec.stream,
-                    self._spec.group,
-                    self._spec.consumer,
-                    0,
-                    claim_ids,
-                )
-                for entry_id, fields in cast("list[StreamEntry]", claimed or []):
-                    if entry_id in self._inflight_ids or entry_id in over_cap:
-                        continue
-                    # Re-checked after the XCLAIM: the window between the filter
-                    # above and the claim is exactly long enough for a
-                    # replacement to acquire the lease.
-                    if await self._lease_is_live(entry_id):
-                        continue
-                    selected.append((entry_id, dict(fields)))
+            # ``min_idle_ms=None`` means compare-and-claim against each row's own
+            # observed idle. Never 0: a stalled claim here must lose to a pass
+            # that already took the row. See ``_claim_pending_page``.
+            selected.extend(
+                await self._claim_pending_page(rows, over_cap, min_idle_ms=None)
+            )
             if len(rows) < page_size:
                 break
+            cursor = f"({rows[-1]['message_id']}"
+        return selected
+
+    async def _claim_pending_page(
+        self,
+        rows: list[Any],
+        over_cap: set[str],
+        *,
+        min_idle_ms: int | None,
+        require_delivery_state: bool = False,
+        budget: int | None = None,
+    ) -> list[StreamEntry]:
+        """Transfer one page of pending rows, enforcing cap before XCLAIM.
+
+        The ONE transfer primitive, shared by the proven-dead path and the
+        lease-expiry pass, so ADR-0039's rules (the pre-claim delivery count, the
+        cap at ``>=``, the ``_inflight_ids`` skip ahead of the cap, the lease
+        re-read after the claim) live in one place instead of drifting in two.
+
+        The claim's min-idle is ALWAYS the idle the caller observed for the row,
+        never 0 (#2433). ``min_idle_ms=None`` means each row's own
+        ``time_since_delivered`` from the pre-claim XPENDING read, which is what
+        the proven-dead path and local recovery pass; an int means that value for
+        every row on the page, which is what the lease-expiry pass passes, equal
+        to its own scan filter. That makes XCLAIM an atomic compare-and-claim on
+        the row's idle clock: any competing transfer resets that clock to about
+        zero the instant it wins, so a stalled caller's claim simply returns
+        nothing rather than stealing a row another pass already took. An empty
+        return is the intended outcome of losing that race, not an error.
+
+        Caller holds ``_reclaim_lock``. At/over-cap entries are dead-lettered
+        directly without XCLAIM's delivery-count increment. ``budget``, when set,
+        stops the page once that many rows have been selected; the rest are left
+        pending with no XCLAIM at all, so a replica with capacity picks them up.
+        """
+
+        selected: list[StreamEntry] = []
+        for row in rows:
+            entry_id = str(row["message_id"])
+            if entry_id in self._inflight_ids or entry_id in over_cap:
+                continue
+            if budget is not None and len(selected) >= budget:
+                break
+            if await self._lease_is_live(entry_id):
+                continue
+            if require_delivery_state and not await self._has_delivery_state(entry_id):
+                continue
+            delivered = int(row["times_delivered"])
+            if delivered >= self._spec.max_delivery:
+                over_cap.add(entry_id)
+                try:
+                    await self._dead_letter(
+                        entry_id,
+                        await self._entry_fields(entry_id),
+                        reason=self._spec.over_cap_reason,
+                        delivery_count=delivered,
+                    )
+                except Exception:
+                    self._spec.logger.exception(
+                        self._spec.dead_letter_fail_log,
+                        entry_id,
+                    )
+                continue
+            idle_for_row = (
+                min_idle_ms
+                if min_idle_ms is not None
+                # Floored to 1: a just-delivered row's own
+                # ``time_since_delivered`` can read 0, and XCLAIM with min-idle
+                # 0 always matches regardless of ownership, which would break
+                # the compare-and-claim guarantee above.
+                else max(1, int(row["time_since_delivered"]))
+            )
+            claimed = await self._redis.xclaim(
+                self._spec.stream,
+                self._spec.group,
+                self._spec.consumer,
+                idle_for_row,
+                [entry_id],
+            )
+            for claimed_id, fields in cast("list[StreamEntry]", claimed or []):
+                if claimed_id in self._inflight_ids or claimed_id in over_cap:
+                    continue
+                # Re-checked after the XCLAIM: the window between the filter
+                # above and the claim is exactly long enough for a
+                # replacement to acquire the lease.
+                if await self._lease_is_live(claimed_id):
+                    continue
+                selected.append((claimed_id, dict(fields)))
+        return selected
+
+    async def _select_lease_expired_entries(
+        self, over_cap: set[str], *, already_selected: int = 0
+    ) -> list[StreamEntry]:
+        """Transfer rows whose delivery lease has expired, including a live peer's.
+
+        Caller holds ``_reclaim_lock``. The rule is ADR-0131's: "a replacement may
+        transfer a delivery only after the lease has expired." The failure it
+        closes (#2433) is a LIVE consumer's own PEL row: a handler that raised
+        released its lease and left the entry pending, and no prompt path looks at
+        a peer that is not dead, so before this pass such an entry waited out the
+        900 second XAUTOCLAIM backstop.
+
+        Inert without a lease store or without a configured threshold, so a
+        base-only consumer keeps its pre-ADR-0131 behavior exactly.
+        """
+
+        idle_ms = self._spec.lease_expired_idle_ms
+        if self._leases is None or idle_ms is None:
+            return []
+        # Claim only what this process can dispatch NOW. Everything claimed here
+        # sits XCLAIMed but UNLEASED until its handler acquires the delivery
+        # lease, and the runs lane's ``_dispatch`` waits on a semaphore before it
+        # even gets that far, so an unbounded pass on a saturated node parks rows
+        # a peer will legitimately compare-and-claim one lease TTL later.
+        # ``already_selected`` is what the proven-dead pass already took this same
+        # tick: nothing is dispatched until every pass has finished selecting, so
+        # without it a concurrency-one consumer would still see a free slot here.
+        # ``None`` capacity means unbounded (the base default).
+        capacity = self._transfer_capacity()
+        budget = None if capacity is None else max(0, capacity - already_selected)
+        if budget is not None and budget <= 0:
+            return []
+
+        selected: list[StreamEntry] = []
+        page_size = self._spec.cap_scan_page
+        cursor = "-"
+        while not self._should_stop():
+            rows = await self._redis.xpending_range(
+                self._spec.stream,
+                self._spec.group,
+                min=cursor,
+                max="+",
+                count=page_size,
+                idle=idle_ms,
+            )
+            if not rows:
+                break
+            # Compare-and-claim: the min-idle handed to XCLAIM is exactly the IDLE
+            # this scan filtered on, so a row any competing transfer path already
+            # took (which reset its idle to about zero) no longer matches and this
+            # pass simply does not win it. Never 0.
+            claimed = await self._claim_pending_page(
+                rows,
+                over_cap,
+                min_idle_ms=idle_ms,
+                require_delivery_state=True,
+                budget=None if budget is None else budget - len(selected),
+            )
+            selected.extend(claimed)
+            if budget is not None and len(selected) >= budget:
+                break
+            if len(rows) < page_size:
+                break
+            # Exclusive lower bound: a single page would leave the tail unscanned
+            # at backlog scale.
             cursor = f"({rows[-1]['message_id']}"
         return selected
 
@@ -1366,11 +1543,26 @@ class StreamConsumer:
 
         The prompt capable-peer path shares this selection lock, while unknown
         peers retain this 15-minute compatibility backstop unchanged.
+
+        Between the proven-dead pass and that backstop runs the lease-expiry pass
+        (#2433), which recovers a row whose delivery lease has expired, including
+        a LIVE consumer's own, long before the backstop. It is hosted here rather
+        than on the faster prompt cadence so it inherits the upgrade-drain gate
+        and can reuse the ``over_cap`` set this tick already produced.
         """
         selected: list[StreamEntry] = []
         async with self._reclaim_lock:
             over_cap = await self._dead_letter_over_cap()
             selected.extend(await self._select_dead_consumer_entries(over_cap))
+            # ``already_selected`` is load-bearing rather than tidiness: nothing is
+            # dispatched until every pass has finished selecting, so omitting it
+            # lets a concurrency-one consumer claim a second row that then waits
+            # behind the first.
+            selected.extend(
+                await self._select_lease_expired_entries(
+                    over_cap, already_selected=len(selected)
+                )
+            )
             cursor: str = "0-0"
             while not self._should_stop():
                 raw = await self._redis.xautoclaim(

--- a/apps/worker/tests/binding/test_boot_env_single_declaration.py
+++ b/apps/worker/tests/binding/test_boot_env_single_declaration.py
@@ -95,9 +95,20 @@ _NON_BOOT_ALLOWLIST: frozenset[str] = frozenset(
         "CURIE_CONSUMER_HEARTBEAT_TTL_MS",
         "CURIE_CONSUMER_NAME",
         "CURIE_DEAD_LETTER_MAXLEN",
+        # Reclaim scan policy for the WORKER's own maintenance tick (#2433):
+        # how idle a pending row whose delivery lease has expired must be before
+        # the lease-expiry pass may transfer it. Read from the worker's env by
+        # WorkerConfig and consumed by both consumer lanes' DeliverySpec. Nothing
+        # about it is ever injected into a sandbox claim.
+        "CURIE_LEASE_EXPIRED_IDLE_MS",
         "CURIE_MAX_ATTEMPTS",
         "CURIE_MAX_DELIVERY",
         "CURIE_SLACK_NO_EDIT_STREAMING",
+        # The person-facing line the KERNEL delivers to a channel when a
+        # delivery's handler raised and the entry was left pending (#2433),
+        # exactly like CURIE_BOOTING_TEXT above. Read from the worker's env by
+        # WorkerConfig; never a sandbox boot key.
+        "CURIE_TURN_NOT_STARTED_TEXT",
         # The per-adapter EGRESS credentials (ADR-0096 D4.2), read from the
         # WORKER's env by ``build_reply_sink`` and presented to a channel
         # adapter as ``X-Curie-Adapter-Secret``. Never a sandbox boot key, and

--- a/apps/worker/tests/eval/test_stream.py
+++ b/apps/worker/tests/eval/test_stream.py
@@ -3444,3 +3444,72 @@ def test_an_unfenced_eval_lane_has_no_deadline_at_all_while_a_fenced_one_does() 
         await _eval_cleanup(client, cfg)
 
     asyncio.run(go())
+
+
+# --- The lease-expiry reclaim knob, and the eval lane's dispatch bound (#2433) --
+
+
+def test_the_eval_lane_carries_the_configured_lease_expiry_threshold() -> None:
+    """AC5, the eval half of the parity seam.
+
+    ADR-0131 requires both consumer lanes to share the lease implementation by
+    construction: "a fix on only one consumer lane is incomplete." An eval
+    delivery whose owner was force-killed would otherwise wait out the 900 second
+    backstop while a runs delivery on the same fleet recovered in one lease.
+
+    Two assertions, and the second is the one that matters: the first alone
+    cannot tell "wired to the config resolver" from "hard-coded to today's
+    default", so an explicit non-default value is passed as well.
+
+    Red on omitting ``lease_expired_idle_ms`` from the eval ``DeliverySpec``.
+    Twin: ``tests/kernel/test_delivery_ownership.py``'s
+    ``test_the_runs_lane_carries_the_configured_lease_expiry_threshold``.
+    """
+    default_cfg = WorkerConfig()
+    default_consumer = EvalStreamConsumer(
+        redis=None,  # type: ignore[arg-type]
+        config=default_cfg,
+        bundle_store=None,  # type: ignore[arg-type]
+        substrate=None,  # type: ignore[arg-type]
+        reporter=None,  # type: ignore[arg-type]
+        recorder=None,  # type: ignore[arg-type]
+        repo_lookup=None,
+    )
+    assert (
+        default_consumer._delivery.lease_expired_idle_ms
+        == default_cfg.lease_expired_idle_ms_value()
+    )
+
+    explicit_cfg = WorkerConfig(lease_expired_idle_ms=60000)
+    explicit_consumer = EvalStreamConsumer(
+        redis=None,  # type: ignore[arg-type]
+        config=explicit_cfg,
+        bundle_store=None,  # type: ignore[arg-type]
+        substrate=None,  # type: ignore[arg-type]
+        reporter=None,  # type: ignore[arg-type]
+        recorder=None,  # type: ignore[arg-type]
+        repo_lookup=None,
+    )
+    assert explicit_consumer._delivery.lease_expired_idle_ms == 60000
+
+
+def test_the_eval_lane_claims_one_expired_row_at_a_time() -> None:
+    """The eval lane's transfer capacity is 1, because its handler runs inline.
+
+    ``EvalStreamConsumer._dispatch`` awaits ``asyncio.shield(task)``, so
+    ``_dispatch_reclaimed`` runs suites strictly one at a time. A second claimed
+    row would sit XCLAIMed and UNLEASED for the length of a whole eval run, where
+    every other replica reads it as an expired-lease candidate.
+
+    Red on inheriting the base's unbounded ``None``.
+    """
+    consumer = EvalStreamConsumer(
+        redis=None,  # type: ignore[arg-type]
+        config=WorkerConfig(),
+        bundle_store=None,  # type: ignore[arg-type]
+        substrate=None,  # type: ignore[arg-type]
+        reporter=None,  # type: ignore[arg-type]
+        recorder=None,  # type: ignore[arg-type]
+        repo_lookup=None,
+    )
+    assert consumer._transfer_capacity() == 1

--- a/apps/worker/tests/kernel/conftest.py
+++ b/apps/worker/tests/kernel/conftest.py
@@ -573,6 +573,49 @@ class _ProcessEventSpy:
         return sum(1 for eid, _ in self.calls if eid == event_id)
 
 
+def _failing_process_event(h: Any) -> list[str]:
+    """Replace ``process_event`` with a raiser; returns the attempt log.
+
+    The incident's shape exactly: the handler raised, the consumer logged and
+    left the entry pending. Each appended id is one delivery that reached the
+    kernel, which is what "the retry actually happened" means here.
+
+    Shared by ``test_turn_not_started.py`` and ``test_delivery_ownership.py``,
+    which both drive this same arrangement against the real ``Consumer``.
+    """
+    attempts: list[str] = []
+
+    async def failing(qevent: QueuedTurn, *, lease: Any = None) -> None:
+        attempts.append(qevent.event_id)
+        raise RuntimeError("simulated handler failure")
+
+    h.kernel.process_event = failing  # type: ignore[method-assign,assignment]
+    return attempts
+
+
+def _updates_for(h: Any, thread: str) -> list[str]:
+    """Every reply.update text delivered to ONE thread, in order.
+
+    ``sink.last_text`` and ``sink.updates`` are fleet-wide: two threads in one
+    channel share both the address and the placeholder ref, and since #2433 a
+    failed delivery edits its own placeholder with the not-started notice, so
+    the last edit the sink saw belongs to whichever thread failed most
+    recently rather than to the healthy one. A per-thread read therefore goes
+    through the neutral event log, where the target carries the conversation
+    id.
+
+    Shared by ``test_turn_not_started.py`` and ``test_consumer_dead_letter.py``,
+    which both assert on one thread's replies amid a fleet-wide sink.
+    """
+    return [
+        event.text or ""
+        for event, _route, _best in h.sink.events
+        if isinstance(event, ReplyUpdate)
+        and event.message is None
+        and event.target.conversation_id == thread
+    ]
+
+
 async def _pending_rows(h: Any) -> dict[str, int]:
     """Every pending entry id -> its current ``times_delivered``."""
     rows = await h.async_redis.xpending_range(

--- a/apps/worker/tests/kernel/test_consumer_dead_letter.py
+++ b/apps/worker/tests/kernel/test_consumer_dead_letter.py
@@ -49,7 +49,7 @@ from curie_worker.consumer import Consumer
 from curie_worker.dead_letter_alert import install_dead_letter_alerting
 from pydantic import ValidationError
 
-from .conftest import _pending_rows
+from .conftest import _pending_rows, _updates_for
 
 DONE = SessionStatus.DONE
 
@@ -193,8 +193,26 @@ def test_permanently_failing_entry_is_dead_lettered_at_the_cap_and_group_progres
                 # completion, and the group's PEL is now empty -- forward progress,
                 # no stall.
                 assert h.runner.opened == ["healthy turn"]
-                assert h.sink.last_text == "answer"
+                assert _updates_for(h, "tdl-healthy")[-1] == "answer"
                 assert calls["healthy"] == 1
+
+                # AC1 (#2433): the person on the POISON thread was told on every
+                # failed delivery, and the placeholder still carries that line
+                # after the dead-letter rather than sitting on the dispatcher's
+                # original text forever. The notice is an EDIT of the same
+                # placeholder, so no additional channel notification is produced
+                # however many times the entry is retried -- which is what makes
+                # a faster retry cadence safe for the person.
+                #
+                # F1 (a distinct terminal notice once the cap is spent) is the
+                # named limit of this copy, not a reason to skip the assertion:
+                # "if no answer appears here shortly, please send it again" is
+                # true both before the cap and at it.
+                poison_updates = _updates_for(h, "tdl-poison")
+                assert poison_updates == [h.config.turn_not_started_text] * 3, (
+                    "the poison thread was left silent, or told a different "
+                    f"number of times than it was delivered: {poison_updates}"
+                )
                 summary = await h.async_redis.xpending(h.config.stream, h.config.consumer_group)
                 assert summary["pending"] == 0
             finally:

--- a/apps/worker/tests/kernel/test_delivery_ownership.py
+++ b/apps/worker/tests/kernel/test_delivery_ownership.py
@@ -31,18 +31,21 @@ hide exactly the difference that matters.
 from __future__ import annotations
 
 import asyncio
+import logging
 import time
 import uuid
 from collections.abc import Callable
+from dataclasses import replace
 from typing import Any
 
 from aci_protocol import Final, QueuedTurn, ReplyHandle, SessionStatus, TextDelta
 from curie_dispatcher.queue import to_stream_fields
 from curie_worker import kernel as kernel_module
 from curie_worker.consumer import Consumer
+from curie_worker.consumer_liveness import ConsumerLivenessStore, consumer_heartbeat_key
 from curie_worker.delivery_lease import DeliveryLeaseStore
 
-from .conftest import _pending_rows, _ProcessEventSpy
+from .conftest import _failing_process_event, _pending_rows, _ProcessEventSpy
 
 DONE = SessionStatus.DONE
 
@@ -785,3 +788,983 @@ def test_an_already_expired_delivery_escalates_once_records_deadline_halted_and_
 
     asyncio.run(go())
 
+
+
+# --- AC2: the lease-expiry reclaim pass ---------------------------------------
+#
+# The gap #1532 and #1971 deliberately left open: a LIVE consumer's own pending
+# row. A handler that RAISED released its delivery lease and left the entry
+# pending, but no prompt path looks at a peer that is not dead, so the row waited
+# out the 900 second XAUTOCLAIM backstop.
+#
+# Every test below pins ``reclaim_min_idle_ms`` at its PRODUCTION 900000,
+# deliberately not shortened the way the harness default is. With the backstop
+# out of reach, any redelivery observed can only have come from the new pass.
+# That is the whole measurement.
+#
+# PEL idle is driven by ``XCLAIM ... IDLE ... JUSTID`` rather than by sleeping.
+# Two properties make that the right lever, both observed against the live
+# Valkey (see ``.projects/plans/task-2433-lease-expiry-reclaim.valkey-probe.md``
+# and the XCLAIM documentation): ``JUSTID`` returns ids only and does NOT
+# increment ``times_delivered``, so arming a boundary does not spend the
+# ADR-0039 budget these tests measure; and passing the row's CURRENT owner as
+# the consumer name leaves ownership untouched, so only idle moves.
+
+# The threshold under test: one lease TTL, which is both the derived default and
+# the floor the config validator allows.
+_EXPIRY_IDLE_MS = int(_TTL_S * 1000)
+
+_EXPIRY_KNOBS: dict[str, object] = {
+    **_LEASE_KNOBS,
+    "lease_expired_idle_ms": _EXPIRY_IDLE_MS,
+    # NOT shortened. See the banner above: this is the measurement.
+    "reclaim_min_idle_ms": 900000,
+}
+
+# The proven-dead peer recipe needs a sustained-absence window short enough to
+# sleep through. ``consumer_capability_ttl_ms`` keeps its 1800000 default, which
+# the ``_capability_outlives_reclaim_backstop`` validator requires to exceed the
+# 900000 backstop above.
+_DEAD_PEER_KNOBS: dict[str, object] = {
+    **_EXPIRY_KNOBS,
+    "dead_consumer_idle_ms": 0,
+    "consumer_heartbeat_ttl_ms": 200,
+}
+
+
+async def _arm_pel_idle(h: Any, entry_id: str, *, owner: str, idle_ms: int) -> None:
+    """Set one PEL row's idle explicitly, spending no delivery and moving no owner.
+
+    ``justid=True`` is load-bearing: a plain XCLAIM bumps ``times_delivered``
+    (probe: 1 -> 2), which is the very number these tests measure. Passing the
+    row's current ``owner`` keeps the PEL consumer unchanged, so this moves the
+    idle clock and nothing else.
+    """
+    claimed = await h.async_redis.xclaim(
+        h.config.stream,
+        h.config.consumer_group,
+        owner,
+        0,
+        [entry_id],
+        idle=idle_ms,
+        justid=True,
+    )
+    assert claimed, f"arming idle for {entry_id} claimed nothing"
+
+
+async def _pel_owners(h: Any) -> dict[str, str]:
+    """Every pending entry id -> the consumer that currently owns its PEL row."""
+    rows = await h.async_redis.xpending_range(
+        h.config.stream, h.config.consumer_group, min="-", max="+", count=50
+    )
+    return {str(row["message_id"]): str(row["consumer"]) for row in rows}
+
+
+async def _fenced_failing_consumer(h: Any) -> tuple[Consumer, DeliveryLeaseStore, list[str]]:
+    """A fenced ``Consumer`` (leases=store) plus the incident's failing handler.
+
+    Five tests below open with exactly this: a ``DeliveryLeaseStore``, a
+    single ``Consumer`` bound to it via ``leases=store``, its group ensured, and
+    ``process_event`` replaced with the raiser. Kept here rather than repeated so
+    the shape of a fenced consumer cannot quietly drift between call sites; a
+    test whose consumer varies (a second replica, ``max_concurrency``, no lease
+    store at all) builds its own ``Consumer`` instead of calling this.
+    """
+    store = DeliveryLeaseStore(h.async_redis, h.config)
+    consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config, leases=store)
+    await consumer.ensure_group()
+    attempts = _failing_process_event(h)
+    return consumer, store, attempts
+
+
+async def _lease_expired_row(
+    h: Any, store: DeliveryLeaseStore, *, event_id: str, owner: str
+) -> tuple[str, dict[str, str]]:
+    """A pending row with delivery state present and its lease gone.
+
+    Taken through the store rather than by cancelling a real handler, because
+    that asymmetry IS the signal the new pass keys on: ``release`` drops only the
+    lease key and deliberately leaves the state hash, so a handler that raised
+    looks exactly like this. Only ``settle`` removes the state.
+    """
+    await h.async_redis.xadd(
+        h.config.stream,
+        to_stream_fields(_qevent(event_id, thread=event_id, event_id=event_id)),
+    )
+    entry_id, fields = await _read_one(h, owner)
+    lease = await store.acquire(
+        h.config.stream, h.config.consumer_group, entry_id, consumer=owner
+    )
+    await store.release(
+        h.config.stream, h.config.consumer_group, entry_id, owner=lease.owner
+    )
+    return entry_id, fields
+
+
+async def _prove_peer_dead(h: Any, consumer: Consumer, peer: str) -> None:
+    """Make ``peer`` proven-dead to ``consumer``'s prompt path (#1961).
+
+    The proof is deliberately expensive: the peer must have advertised the
+    liveness protocol, and its alive lease must be absent on TWO observations at
+    least one heartbeat TTL apart. Call this BEFORE arming any idle: the priming
+    observation is a full ``_reclaim_once`` and would otherwise let the expiry
+    pass claim the very row the test is about to set up.
+    """
+    liveness = ConsumerLivenessStore(h.async_redis)
+    await liveness.publish(
+        stream=h.config.stream,
+        group=h.config.consumer_group,
+        consumer=peer,
+        heartbeat_ttl_ms=1,
+        capability_ttl_ms=h.config.consumer_capability_ttl_ms,
+    )
+    alive_key = consumer_heartbeat_key(h.config.stream, h.config.consumer_group, peer)
+    deadline = time.monotonic() + 5.0
+    while await h.async_redis.exists(alive_key):
+        if time.monotonic() > deadline:
+            raise AssertionError(f"the alive lease for {peer} never expired")
+        await asyncio.sleep(0.005)
+    assert await consumer._reclaim_once() == 0, (
+        "the first absent observation transferred work: the sustained-absence "
+        "proof is not being required"
+    )
+    await asyncio.sleep(h.config.consumer_heartbeat_ttl_ms / 1000 + 0.02)
+
+
+def _synchronize_first_eligibility_read(
+    consumer: Consumer, barrier: asyncio.Barrier
+) -> None:
+    """Barrier the FIRST ``_lease_is_live`` per consumer; the re-read runs free.
+
+    A plain ``asyncio.gather`` does not force the interleaving the AC4 tests are
+    about: one replica can finish its whole pass before the other starts, and the
+    test then passes just as happily against a ``min_idle_time=0`` claim.
+    Barriering EVERY call instead deadlocks a CORRECT implementation, because the
+    mandatory post-claim re-read would wait for a second participant that has
+    already left. One-shot is the shape that forces the read and leaves the
+    revalidation alone.
+    """
+    inner = consumer._lease_is_live
+    state = {"armed": True}
+
+    async def wrapped(entry_id: str) -> bool:
+        result = await inner(entry_id)
+        if state["armed"]:
+            state["armed"] = False
+            await barrier.wait()
+        return result
+
+    consumer._lease_is_live = wrapped  # type: ignore[method-assign,assignment]
+
+
+class _ClaimGate:
+    """Delegates to the real client, ordering ONE replica's ``XCLAIM`` against another.
+
+    A rendezvous alone leaves the claim order free, and if the dead pass claims
+    first its competitor's positive min-idle correctly rejects it and the test
+    passes for the wrong reason. This makes the order an input.
+    """
+
+    def __init__(
+        self,
+        inner: Any,
+        *,
+        before: asyncio.Event | None = None,
+        after: asyncio.Event | None = None,
+    ) -> None:
+        self._inner = inner
+        self._before = before
+        self._after = after
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._inner, name)
+
+    async def xclaim(self, *args: Any, **kwargs: Any) -> Any:
+        if self._before is not None:
+            await asyncio.wait_for(self._before.wait(), timeout=20.0)
+        result = await self._inner.xclaim(*args, **kwargs)
+        if self._after is not None:
+            self._after.set()
+        return result
+
+
+def test_a_failed_turn_is_reclaimed_after_one_lease_not_after_the_backstop(
+    make_harness,
+) -> None:
+    """AC2, the boundary measurement, on a LIVE consumer's own pending row.
+
+    A real turn is driven into ``Consumer._handle``'s ``except`` branch, so the
+    row's shape is the incident's: this consumer still owns the PEL entry, its
+    delivery state survives, and its lease is gone.
+
+    Red on reverting EB-9/EB-10: nothing is redelivered at all, which is the
+    reported symptom. The negative control is the pass BELOW the threshold, which
+    keeps the positive from passing against an implementation that reclaims
+    everything on sight. ``reclaim_min_idle_ms`` is pinned at 900000 throughout,
+    so the redelivery cannot have come from the backstop.
+
+    The exact ``+1`` on ``times_delivered`` is the ADR-0039 half: one logical
+    retry charges exactly one delivery of the budget, never two.
+
+    Twin: ``test_the_running_consumer_redelivers_a_failed_turn_without_a_manual_reclaim``
+    observes the same behavior through the real ``Consumer.run()`` maintenance
+    tick with no reclaim helper called at all.
+    """
+
+    async def go() -> None:
+        async with make_harness(**_EXPIRY_KNOBS) as h:
+            consumer, store, attempts = await _fenced_failing_consumer(h)
+
+            await h.async_redis.xadd(
+                h.config.stream,
+                to_stream_fields(_qevent("expired", thread="exp-1", event_id="exp-1")),
+            )
+            entry_id, fields = await _read_one(h, h.config.consumer_name)
+            before = (await _pending_rows(h))[entry_id]
+            await consumer._dispatch(entry_id, fields)
+            await _settle(consumer)
+            assert attempts == ["exp-1"], "the first delivery never reached the kernel"
+
+            # NEGATIVE CONTROL: under the threshold the pass selects nothing.
+            assert await consumer._reclaim_once() == 0
+            assert attempts == ["exp-1"]
+            assert (await _pending_rows(h))[entry_id] == before
+
+            await _arm_pel_idle(
+                h,
+                entry_id,
+                owner=h.config.consumer_name,
+                idle_ms=_EXPIRY_IDLE_MS + 200,
+            )
+            assert await consumer._reclaim_once() == 1
+            await _settle(consumer)
+
+            assert attempts == ["exp-1", "exp-1"], "the retry never reached the kernel"
+            assert (await _pending_rows(h))[entry_id] == before + 1, (
+                "one logical retry charged more than one delivery of the budget"
+            )
+
+    asyncio.run(go())
+
+
+def test_a_live_lease_is_never_reclaimed_by_the_expiry_pass(make_harness) -> None:
+    """AC2's primary fence: a live delivery is never transferred, however idle.
+
+    The peer's lease is kept alive with a bare ``PEXPIRE``, never
+    ``store.heartbeat``: a real heartbeat also resets PEL idle with
+    ``XCLAIM ... JUSTID`` (probe: JUSTID resets idle and does not bump the
+    delivery count), which would take the row out of the scan's IDLE filter
+    entirely and let this test pass without ever exercising the lease check.
+
+    Red on dropping the ``_lease_is_live`` guard from the pass. The positive
+    control -- the same row, the same pass, with the lease key deleted -- is what
+    keeps the refusal from being a dead code path.
+    """
+
+    async def go() -> None:
+        async with make_harness(**_EXPIRY_KNOBS) as h:
+            consumer, store, attempts = await _fenced_failing_consumer(h)
+
+            await h.async_redis.xadd(
+                h.config.stream,
+                to_stream_fields(_qevent("live", thread="live-1", event_id="live-1")),
+            )
+            entry_id, _fields = await _read_one(h, "live-peer")
+            await store.acquire(
+                h.config.stream, h.config.consumer_group, entry_id, consumer="live-peer"
+            )
+            lease_key = h.config.delivery_lease_key(
+                h.config.stream, h.config.consumer_group, entry_id
+            )
+            await h.async_redis.pexpire(lease_key, 60000)
+            before = (await _pending_rows(h))[entry_id]
+            await _arm_pel_idle(
+                h, entry_id, owner="live-peer", idle_ms=_EXPIRY_IDLE_MS + 200
+            )
+
+            assert await consumer._reclaim_once() == 0
+            assert attempts == []
+            assert (await _pending_rows(h))[entry_id] == before, (
+                "the row was XCLAIMed, so a delivery was burnt off a live turn"
+            )
+
+            # POSITIVE CONTROL: the fence, not a dead pass.
+            await h.async_redis.delete(lease_key)
+            assert await consumer._reclaim_once() == 1
+            await _settle(consumer)
+            assert attempts == ["live-1"]
+            assert (await _pending_rows(h))[entry_id] == before + 1
+
+    asyncio.run(go())
+
+
+def test_the_expiry_pass_is_inert_without_a_lease_store(make_harness) -> None:
+    """A base-only consumer keeps its pre-ADR-0131 behavior exactly.
+
+    Red on dereferencing ``self._leases`` unconditionally in the new pass, and
+    red on keying the pass on the CONFIGURED threshold alone: the config carries
+    a threshold here, and the leaseless consumer must still do nothing with it,
+    because with no lease store there is no evidence to key on.
+
+    The fenced consumer on the same row is the positive control.
+    """
+
+    async def go() -> None:
+        async with make_harness(**_EXPIRY_KNOBS) as h:
+            store = DeliveryLeaseStore(h.async_redis, h.config)
+            leaseless = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
+            await leaseless.ensure_group()
+            attempts = _failing_process_event(h)
+
+            entry_id, _fields = await _lease_expired_row(
+                h, store, event_id="inert-1", owner="peer-one"
+            )
+            before = (await _pending_rows(h))[entry_id]
+            await _arm_pel_idle(
+                h, entry_id, owner="peer-one", idle_ms=_EXPIRY_IDLE_MS + 200
+            )
+
+            assert await leaseless._reclaim_once() == 0
+            assert attempts == []
+            assert (await _pending_rows(h))[entry_id] == before
+
+            # POSITIVE CONTROL: the same row, a fenced consumer.
+            fenced = Consumer(
+                redis=h.async_redis, kernel=h.kernel, config=h.config, leases=store
+            )
+            assert await fenced._reclaim_once() == 1
+            await _settle(fenced)
+            assert attempts == ["inert-1"]
+
+    asyncio.run(go())
+
+
+def test_the_runs_lane_carries_the_configured_lease_expiry_threshold(
+    make_harness,
+) -> None:
+    """AC5, the runs half of the parity seam.
+
+    Both lanes must read the SAME resolver, which is what makes ADR-0131's
+    runs/eval parity structural rather than a review promise. Red on hard-coding
+    the threshold anywhere in the reclaim machinery instead of carrying it on the
+    ``DeliverySpec``.
+
+    Twin: ``tests/eval/test_stream.py``'s
+    ``test_the_eval_lane_carries_the_configured_lease_expiry_threshold``.
+    """
+
+    async def go() -> None:
+        async with make_harness(**_EXPIRY_KNOBS) as h:
+            store = DeliveryLeaseStore(h.async_redis, h.config)
+            consumer = Consumer(
+                redis=h.async_redis, kernel=h.kernel, config=h.config, leases=store
+            )
+
+            assert h.config.lease_expired_idle_ms_value() == _EXPIRY_IDLE_MS
+            assert consumer._delivery.lease_expired_idle_ms == _EXPIRY_IDLE_MS
+
+    asyncio.run(go())
+
+
+# --- AC3: no delivery state means the unchanged backstop still applies --------
+
+
+def test_an_entry_with_no_delivery_state_stays_on_the_backstop(make_harness) -> None:
+    """AC3, the mixed-version rule, as one control pair in a single pass.
+
+    A pre-lease or pre-marker consumer's pending entry carries no evidence a
+    lease was ever granted, so "the lease is gone" cannot be told apart from
+    "there never was one". Such a row stays on the unchanged 900 second backstop.
+    Its lease-aware sibling, armed identically in the same pass, is redelivered.
+
+    The legacy row is asserted to really BE the legacy shape (``peek`` returns
+    ``{}``) before anything else, so a change that silently started writing state
+    on read would fail here rather than making the pair vacuous.
+
+    Red on dropping the ``has_state`` guard: every legacy consumer's pending
+    entry becomes reclaimable by a replica that never had any evidence about it.
+    """
+
+    async def go() -> None:
+        async with make_harness(**_EXPIRY_KNOBS) as h:
+            consumer, store, attempts = await _fenced_failing_consumer(h)
+
+            await h.async_redis.xadd(
+                h.config.stream,
+                to_stream_fields(
+                    _qevent("legacy", thread="legacy-1", event_id="legacy-1")
+                ),
+            )
+            legacy_id, _legacy_fields = await _read_one(h, "legacy-peer")
+            assert (
+                await store.peek(h.config.stream, h.config.consumer_group, legacy_id)
+                == {}
+            ), "the legacy row carries delivery state, so it is not the legacy shape"
+
+            new_id, _new_fields = await _lease_expired_row(
+                h, store, event_id="new-1", owner="lease-aware-peer"
+            )
+            before = await _pending_rows(h)
+            await _arm_pel_idle(
+                h, legacy_id, owner="legacy-peer", idle_ms=_EXPIRY_IDLE_MS + 200
+            )
+            await _arm_pel_idle(
+                h, new_id, owner="lease-aware-peer", idle_ms=_EXPIRY_IDLE_MS + 200
+            )
+
+            assert await consumer._reclaim_once() == 1
+            await _settle(consumer)
+
+            assert attempts == ["new-1"]
+            after = await _pending_rows(h)
+            assert after[legacy_id] == before[legacy_id], (
+                "a row with no delivery state was XCLAIMed off the backstop"
+            )
+            assert after[new_id] == before[new_id] + 1
+
+    asyncio.run(go())
+
+
+def test_an_unreadable_delivery_state_read_leaves_the_entry_on_the_backstop(
+    make_harness, caplog
+) -> None:
+    """AC3's fail-closed posture, which is the MIRROR of ``_lease_is_live``'s.
+
+    ``_lease_is_live`` fails closed as OWNED and ``_has_delivery_state`` fails
+    closed as ABSENT. Both answers refuse the claim: failing open here would let
+    one Valkey blip manufacture a duplicate dispatch of a turn somebody may still
+    be running.
+
+    Red on ``return True`` in the ``except``, and red on swallowing the failure
+    with no WARNING. The positive control restores the read and reclaims the very
+    same row in the very same pass shape.
+    """
+
+    async def go() -> None:
+        async with make_harness(**_EXPIRY_KNOBS) as h:
+            consumer, store, attempts = await _fenced_failing_consumer(h)
+
+            entry_id, _fields = await _lease_expired_row(
+                h, store, event_id="unreadable-1", owner="peer-one"
+            )
+            before = (await _pending_rows(h))[entry_id]
+            await _arm_pel_idle(
+                h, entry_id, owner="peer-one", idle_ms=_EXPIRY_IDLE_MS + 200
+            )
+
+            readable = store.has_state
+
+            async def unreadable(stream: str, group: str, entry: str) -> bool:
+                raise ConnectionError("injected delivery-state read failure")
+
+            store.has_state = unreadable  # type: ignore[method-assign,assignment]
+            with caplog.at_level(logging.WARNING, logger="curie_worker.consumer"):
+                assert await consumer._reclaim_once() == 0
+            assert attempts == []
+            assert (await _pending_rows(h))[entry_id] == before
+            assert any(entry_id in message for message in caplog.messages), (
+                "an unreadable delivery state was swallowed silently"
+            )
+
+            # POSITIVE CONTROL: the read, not a dead pass.
+            store.has_state = readable  # type: ignore[method-assign]
+            assert await consumer._reclaim_once() == 1
+            await _settle(consumer)
+            assert attempts == ["unreadable-1"]
+            assert (await _pending_rows(h))[entry_id] == before + 1
+
+    asyncio.run(go())
+
+
+# --- AC4: two transfer paths cannot both move one row -------------------------
+
+
+def test_two_replicas_reclaiming_the_same_expired_row_dispatch_it_once(
+    make_harness,
+) -> None:
+    """AC4, same-path: two expiry passes, one row, one dispatch.
+
+    ``_reclaim_lock`` is per-process and proves nothing across replicas, and this
+    pass takes no ``try_acquire_reclaim`` arbitration lease (that one is keyed per
+    DEAD consumer, which does not apply when the owner is alive). The only
+    serializer is the claim itself: ``XCLAIM`` with a positive min-idle is an
+    atomic compare-and-claim on the row's idle clock, and the winner resets that
+    clock to about zero (probe: replica B's ``XCLAIM min-idle=1000`` on a row A
+    just claimed returns ``[]``).
+
+    The interleaving is FORCED, because a plain gather lets one replica finish
+    before the other starts and would pass against a broken implementation.
+
+    Mutation map: this test goes red, and only red, on ``min_idle_ms=0`` in the
+    EXPIRY pass. It says nothing about the proven-dead pass, which is the
+    cross-path test's job. The two assertions isolate different failures:
+    ``sum(dispatched) == 1`` catches "both claims succeed", and the exact ``+1``
+    on ``times_delivered`` catches the silent form where the loser steals the row,
+    the winner is fenced out on its next heartbeat, and nobody runs the turn while
+    a delivery was still charged.
+    """
+
+    async def go() -> None:
+        async with make_harness(**_EXPIRY_KNOBS) as h:
+            store = DeliveryLeaseStore(h.async_redis, h.config)
+            cfg_a = h.config.model_copy(update={"consumer_name": "worker-a"})
+            cfg_b = h.config.model_copy(update={"consumer_name": "worker-b"})
+            consumer_a = Consumer(
+                redis=h.async_redis, kernel=h.kernel, config=cfg_a, leases=store
+            )
+            consumer_b = Consumer(
+                redis=h.async_redis, kernel=h.kernel, config=cfg_b, leases=store
+            )
+            await consumer_a.ensure_group()
+            attempts = _failing_process_event(h)
+
+            entry_id, _fields = await _lease_expired_row(
+                h, store, event_id="race-1", owner="departed-peer"
+            )
+            before = (await _pending_rows(h))[entry_id]
+            await _arm_pel_idle(
+                h, entry_id, owner="departed-peer", idle_ms=_EXPIRY_IDLE_MS + 200
+            )
+
+            barrier = asyncio.Barrier(2)
+            _synchronize_first_eligibility_read(consumer_a, barrier)
+            _synchronize_first_eligibility_read(consumer_b, barrier)
+
+            async with asyncio.timeout(30):
+                dispatched = await asyncio.gather(
+                    consumer_a._reclaim_once(), consumer_b._reclaim_once()
+                )
+            await _settle(consumer_a)
+            await _settle(consumer_b)
+
+            assert sum(dispatched) == 1, f"both replicas dispatched: {dispatched}"
+            assert attempts == ["race-1"]
+            assert (await _pending_rows(h))[entry_id] == before + 1, (
+                "two transfer paths both moved one row: a delivery was charged "
+                "for a turn nobody ran"
+            )
+
+    asyncio.run(go())
+
+
+def test_a_dead_consumer_pass_does_not_steal_a_row_the_expiry_pass_just_claimed(
+    make_harness,
+) -> None:
+    """AC4, cross-path: the pre-existing zero-idle competitor is the real hazard.
+
+    One row is eligible for BOTH passes: its owner is proven dead to replica A,
+    and its lease has expired with its state intact, which is replica B's expiry
+    candidate. The interleaving under test is the one that costs two deliveries
+    and runs the turn zero times: B claims and acquires the lease, A's stale
+    ``XCLAIM`` steals the PEL row anyway, B's next heartbeat fails its PEL-owner
+    guard and B is fenced out mid-turn, and A skips dispatch on B's now-live
+    lease.
+
+    Both halves of the ordering are inputs, not luck: the one-shot barrier makes
+    A's eligibility read provably precede B's claim (which is what makes A's
+    observed idle stale), and the claim gate makes B claim first.
+
+    Mutation map: this test goes red, and only red, on the proven-dead pass
+    reverting to a batched ``min_idle_time=0``. The last assertion catches the
+    silent form: with the counts alone a reviewer cannot tell a clean handoff
+    from a fenced-out winner, so the winner is required to settle.
+    """
+
+    async def go() -> None:
+        async with make_harness(**_DEAD_PEER_KNOBS) as h:
+            store = DeliveryLeaseStore(h.async_redis, h.config)
+            cfg_a = h.config.model_copy(update={"consumer_name": "worker-a"})
+            cfg_b = h.config.model_copy(update={"consumer_name": "worker-b"})
+            consumer_a = Consumer(
+                redis=h.async_redis, kernel=h.kernel, config=cfg_a, leases=store
+            )
+            consumer_b = Consumer(
+                redis=h.async_redis, kernel=h.kernel, config=cfg_b, leases=store
+            )
+            await consumer_a.ensure_group()
+            spy = _ProcessEventSpy(h.kernel)
+
+            hold = asyncio.Event()
+            h.runner.hold = hold
+            h.runner.default_script = [TextDelta(text="working")]
+            h.runner.tail = [Final(text="one run", status=DONE)]
+
+            entry_id, _fields = await _lease_expired_row(
+                h, store, event_id="steal-1", owner="dying-peer"
+            )
+            before = (await _pending_rows(h))[entry_id]
+
+            await _prove_peer_dead(h, consumer_a, "dying-peer")
+            await _arm_pel_idle(
+                h, entry_id, owner="dying-peer", idle_ms=_EXPIRY_IDLE_MS + 200
+            )
+
+            b_claimed = asyncio.Event()
+            consumer_a._redis = _ClaimGate(  # type: ignore[assignment]
+                h.async_redis, before=b_claimed
+            )
+            consumer_b._redis = _ClaimGate(  # type: ignore[assignment]
+                h.async_redis, after=b_claimed
+            )
+            barrier = asyncio.Barrier(2)
+            _synchronize_first_eligibility_read(consumer_a, barrier)
+            _synchronize_first_eligibility_read(consumer_b, barrier)
+
+            async with asyncio.timeout(60):
+                dispatched = await asyncio.gather(
+                    consumer_a._reclaim_once(), consumer_b._reclaim_once()
+                )
+
+            assert sum(dispatched) == 1, f"both passes moved the row: {dispatched}"
+            await _wait_until(lambda: h.runner.turn_active)
+            assert (await _pending_rows(h))[entry_id] == before + 1, (
+                "the dead pass stole a row the expiry pass had already claimed: "
+                "two deliveries charged for one logical retry"
+            )
+
+            hold.set()
+            await _settle(consumer_a)
+            await _settle(consumer_b)
+
+            assert spy.entries_for("steal-1") == 1
+            winner = spy.leases_for("steal-1")[0]
+            assert winner is not None, "the kernel was handed no lease"
+            assert not winner.lost.is_set(), (
+                "the winner was fenced out mid-turn by a competing claim"
+            )
+            assert entry_id not in await _pending_rows(h), (
+                "nobody settled the row: the turn was charged and never finished"
+            )
+
+    asyncio.run(go())
+
+
+def test_a_delayed_handoff_loses_the_row_to_a_peer_without_a_double_run(
+    make_harness, caplog
+) -> None:
+    """The ACCEPTED residual, pinned as a bounded number rather than left as prose.
+
+    Selection completes before any dispatch, and the runs lane's ``_dispatch``
+    then waits on a semaphore. If that wait exceeds one lease TTL, the row this
+    process claimed has been idle long enough to become a legitimate expiry-pass
+    candidate for a peer. The peer compare-and-claims it, and this process's late
+    ``acquire`` is refused ``not-owner`` and returns WITHOUT acking.
+
+    The cost is exactly one extra charged delivery. Never a double run, never a
+    stranded turn. The ``+2`` is deliberately exact: it documents the residual as
+    a known number, so a future change that made the cost three goes red here
+    rather than being absorbed silently.
+
+    Red on a residual that grows, and red on a late handler that runs anyway
+    (which would be the double run this whole design exists to prevent).
+    """
+
+    async def go() -> None:
+        async with make_harness(**_EXPIRY_KNOBS) as h:
+            store = DeliveryLeaseStore(h.async_redis, h.config)
+            cfg_a = h.config.model_copy(update={"consumer_name": "worker-a"})
+            cfg_b = h.config.model_copy(update={"consumer_name": "worker-b"})
+            consumer_a = Consumer(
+                redis=h.async_redis, kernel=h.kernel, config=cfg_a, leases=store
+            )
+            consumer_b = Consumer(
+                redis=h.async_redis, kernel=h.kernel, config=cfg_b, leases=store
+            )
+            await consumer_a.ensure_group()
+            attempts = _failing_process_event(h)
+
+            entry_id, _fields = await _lease_expired_row(
+                h, store, event_id="delayed-1", owner="departed-peer"
+            )
+            before = (await _pending_rows(h))[entry_id]
+            await _arm_pel_idle(
+                h, entry_id, owner="departed-peer", idle_ms=_EXPIRY_IDLE_MS + 200
+            )
+
+            released = asyncio.Event()
+            dispatch_a = consumer_a._delivery.handler
+
+            async def held(held_id: str, fields: dict[str, str]) -> None:
+                await released.wait()
+                await dispatch_a(held_id, fields)
+
+            consumer_a._delivery = replace(consumer_a._delivery, handler=held)
+
+            with caplog.at_level(logging.WARNING, logger="curie_worker.consumer"):
+                task_a = asyncio.create_task(consumer_a._reclaim_once())
+                deadline = time.monotonic() + 10.0
+                while (await _pel_owners(h)).get(entry_id) != "worker-a":
+                    if time.monotonic() > deadline:
+                        raise AssertionError("replica A never claimed the row")
+                    await asyncio.sleep(0.01)
+
+                # A's dispatch is still parked, so its claimed row is unleased and
+                # ages back past the threshold, exactly as a saturated node's does.
+                await _arm_pel_idle(
+                    h, entry_id, owner="worker-a", idle_ms=_EXPIRY_IDLE_MS + 200
+                )
+                assert await consumer_b._reclaim_once() == 1
+                await _settle(consumer_b)
+
+                released.set()
+                await asyncio.wait_for(task_a, timeout=20.0)
+                await _settle(consumer_a)
+
+            assert attempts == ["delayed-1"], (
+                f"the delayed handoff ran the turn more than once: {attempts}"
+            )
+            assert any(
+                "refused the delivery lease for entry" in message
+                for message in caplog.messages
+            ), "the late handler was not refused; it may have run beside the peer"
+            assert entry_id in await _pending_rows(h), (
+                "the late owner acked a delivery it no longer held"
+            )
+            assert (await _pending_rows(h))[entry_id] == before + 2, (
+                "the accepted residual is exactly one EXTRA charged delivery"
+            )
+
+    asyncio.run(go())
+
+
+# --- The capacity bound: claim only what this process can dispatch now --------
+
+
+def test_a_saturated_consumer_claims_no_more_expired_rows_than_it_can_dispatch(
+    make_harness,
+) -> None:
+    """The capacity budget, and why an unbounded pass is worse than a slow one.
+
+    Every row this pass claims sits XCLAIMed but UNLEASED until its dispatched
+    handler acquires the delivery lease, and ``_dispatch`` waits on the semaphore
+    before it gets that far. On a saturated node an unbounded pass therefore parks
+    claimed-but-unowned rows for the whole wait, where every other replica reads
+    them as expired-lease candidates.
+
+    Neither row being XCLAIMed AT ALL is the assertion that matters: it proves the
+    pass stopped before claiming rather than claiming and discarding. The passes
+    after the slot frees prove the bound is a DEFERRAL, not a refusal, and that
+    the surplus is routed rather than dropped.
+
+    Red on an unbounded expiry pass.
+    """
+
+    async def go() -> None:
+        async with make_harness(**_EXPIRY_KNOBS) as h:
+            store = DeliveryLeaseStore(h.async_redis, h.config)
+            consumer = Consumer(
+                redis=h.async_redis,
+                kernel=h.kernel,
+                config=h.config,
+                max_concurrency=1,
+                leases=store,
+            )
+            await consumer.ensure_group()
+
+            real_process = h.kernel.process_event
+            attempts: list[str] = []
+
+            async def routed(qevent: QueuedTurn, *, lease: Any = None) -> None:
+                attempts.append(qevent.event_id)
+                if qevent.event_id != "held-1":
+                    raise RuntimeError("simulated handler failure")
+                if lease is None:
+                    await real_process(qevent)
+                else:
+                    await real_process(qevent, lease=lease)
+
+            h.kernel.process_event = routed  # type: ignore[method-assign,assignment]
+
+            hold = asyncio.Event()
+            h.runner.hold = hold
+            h.runner.default_script = [TextDelta(text="working")]
+            h.runner.tail = [Final(text="done", status=DONE)]
+
+            await h.async_redis.xadd(
+                h.config.stream,
+                to_stream_fields(_qevent("held", thread="sat-held", event_id="held-1")),
+            )
+            held_id, held_fields = await _read_one(h, h.config.consumer_name)
+            await consumer._dispatch(held_id, held_fields)
+            await _wait_until(lambda: h.runner.turn_active)
+            assert len(consumer._inflight_ids) == 1, "the only slot is not occupied"
+
+            first_id, _first = await _lease_expired_row(
+                h, store, event_id="sat-1", owner="peer-one"
+            )
+            second_id, _second = await _lease_expired_row(
+                h, store, event_id="sat-2", owner="peer-two"
+            )
+            before = await _pending_rows(h)
+            await _arm_pel_idle(
+                h, first_id, owner="peer-one", idle_ms=_EXPIRY_IDLE_MS + 200
+            )
+            await _arm_pel_idle(
+                h, second_id, owner="peer-two", idle_ms=_EXPIRY_IDLE_MS + 200
+            )
+
+            assert await consumer._reclaim_once() == 0
+            after = await _pending_rows(h)
+            assert after[first_id] == before[first_id]
+            assert after[second_id] == before[second_id]
+            owners = await _pel_owners(h)
+            assert owners[first_id] == "peer-one", "a row was claimed then discarded"
+            assert owners[second_id] == "peer-two", "a row was claimed then discarded"
+
+            hold.set()
+            await _settle(consumer)
+            assert not consumer._inflight_ids
+
+            # One free slot means exactly one claim, and the deferred row follows
+            # on the next tick rather than being dropped.
+            assert await consumer._reclaim_once() == 1
+            await _settle(consumer)
+
+            # Exactly one row was deferred, and it is re-armed explicitly so the
+            # next tick cannot pick the row this one already took: the claim
+            # above reset that row's idle, and which of the two was claimed is
+            # not this test's business.
+            owners_now = await _pel_owners(h)
+            deferred = [
+                row
+                for row in (first_id, second_id)
+                if owners_now[row] != h.config.consumer_name
+            ]
+            assert len(deferred) == 1, f"the bound claimed {2 - len(deferred)} rows"
+            await _arm_pel_idle(
+                h,
+                deferred[0],
+                owner=owners_now[deferred[0]],
+                idle_ms=_EXPIRY_IDLE_MS + 200,
+            )
+            assert await consumer._reclaim_once() == 1
+            await _settle(consumer)
+
+            final = await _pending_rows(h)
+            assert final[first_id] == before[first_id] + 1
+            assert final[second_id] == before[second_id] + 1
+            assert sorted(attempts) == ["held-1", "sat-1", "sat-2"]
+
+    asyncio.run(go())
+
+
+def test_the_expiry_pass_leaves_no_room_for_a_row_the_dead_pass_already_took(
+    make_harness,
+) -> None:
+    """``already_selected``: the two passes share one tick's capacity, not two.
+
+    Nothing is dispatched until every pass has finished selecting, so a
+    concurrency-one consumer whose proven-dead pass just took a row still sees a
+    free slot when the expiry pass runs. Without subtracting what the dead pass
+    already selected, it claims a second row that then waits behind the first,
+    which is the very parking the budget exists to prevent.
+
+    The dead-pass row carries NO delivery state on purpose, so only the dead pass
+    can select it and the two passes cannot be confused for one another.
+
+    Red on dropping ``already_selected=len(selected)`` from the ``_reclaim_once``
+    call: both rows are claimed and both are charged.
+    """
+
+    async def go() -> None:
+        async with make_harness(**_DEAD_PEER_KNOBS) as h:
+            store = DeliveryLeaseStore(h.async_redis, h.config)
+            consumer = Consumer(
+                redis=h.async_redis,
+                kernel=h.kernel,
+                config=h.config,
+                max_concurrency=1,
+                leases=store,
+            )
+            await consumer.ensure_group()
+            attempts = _failing_process_event(h)
+
+            await h.async_redis.xadd(
+                h.config.stream,
+                to_stream_fields(
+                    _qevent("dead row", thread="budget-dead", event_id="dead-1")
+                ),
+            )
+            dead_id, _dead_fields = await _read_one(h, "dying-peer")
+            expiry_id, _expiry_fields = await _lease_expired_row(
+                h, store, event_id="budget-1", owner="other-peer"
+            )
+            before = await _pending_rows(h)
+
+            await _prove_peer_dead(h, consumer, "dying-peer")
+            await _arm_pel_idle(
+                h, expiry_id, owner="other-peer", idle_ms=_EXPIRY_IDLE_MS + 200
+            )
+
+            assert await consumer._reclaim_once() == 1
+            await _settle(consumer)
+
+            assert attempts == ["dead-1"]
+            after = await _pending_rows(h)
+            assert after[dead_id] == before[dead_id] + 1
+            assert after[expiry_id] == before[expiry_id], (
+                "the expiry pass claimed a row the tick had no capacity to dispatch"
+            )
+
+    asyncio.run(go())
+
+
+# --- The Fix pin: the same behavior through the real maintenance tick ---------
+
+
+def test_the_running_consumer_redelivers_a_failed_turn_without_a_manual_reclaim(
+    make_harness,
+) -> None:
+    """The Fix pin (#2433). No reclaim helper is called by this test at all.
+
+    Every other AC2 test invokes ``_reclaim_once()`` by hand, which proves the
+    algorithm and nothing about the deployed worker ever scheduling it. This one
+    drives the real ``Consumer.run()``, whose maintenance loop calls the pass on
+    ``reclaim_interval_s``, and observes AC1's placeholder edit and AC2's
+    redelivery together through one running consumer, which is the shape the
+    incident had.
+
+    ``reclaim_min_idle_ms`` stays pinned at 900000, so the redelivery still
+    cannot have come from the backstop.
+
+    Red on wiring the pass anywhere the maintenance tick does not reach, red on a
+    pass that only works when a test calls it directly, and red on a retry that
+    charges more than one delivery of the ADR-0039 budget.
+    """
+
+    async def go() -> None:
+        async with make_harness(**_EXPIRY_KNOBS) as h:
+            consumer, store, attempts = await _fenced_failing_consumer(h)
+
+            entry_id = await h.async_redis.xadd(
+                h.config.stream,
+                to_stream_fields(
+                    _qevent("lifecycle", thread="life-1", event_id="life-1")
+                ),
+            )
+
+            task = asyncio.create_task(consumer.run())
+            try:
+                await _wait_until(lambda: len(attempts) >= 2, timeout=30.0)
+            finally:
+                consumer.request_stop()
+                await asyncio.wait_for(task, timeout=20.0)
+                await _settle(consumer)
+
+            delivered = list(attempts)
+            rows = await _pending_rows(h)
+
+            assert delivered == ["life-1"] * len(delivered)
+            assert len(delivered) >= 2, "the running consumer never redelivered"
+            assert entry_id in rows, "the redelivered turn was acked or dead-lettered"
+            assert rows[entry_id] == len(delivered), (
+                "each redelivery must charge exactly one delivery of the budget"
+            )
+            assert h.sink.updates == [
+                ("C1", "p-1", h.config.turn_not_started_text)
+            ] * len(delivered), (
+                "AC1 and AC2 must be observable together: the person is told on "
+                "every failed delivery while the redelivery is waited out"
+            )
+
+    asyncio.run(go())

--- a/apps/worker/tests/kernel/test_turn_not_started.py
+++ b/apps/worker/tests/kernel/test_turn_not_started.py
@@ -1,0 +1,781 @@
+"""AC1 (#2433): a delivery whose handler RAISED tells the person, once.
+
+The operator surface for that branch always worked: ``Consumer._handle`` logs
+"processing failed for entry %s; left pending" and returns. The person on the
+other end of the thread had no surface at all. They sat on the dispatcher's
+placeholder, unchanged, until the delivery was redelivered, which before this
+ticket meant the 900 second backstop.
+
+Every test here drives the **real** ``Consumer._handle`` against **real
+Valkey** and the real ``Kernel``. ``Kernel.notify_turn_not_started`` is the
+production method throughout; only the thing that fails is arranged. Two shapes
+of arrangement are used, and the difference is deliberate:
+
+* the guard tests replace ``Kernel.process_event`` with a coroutine that
+  raises, which is exactly what the incident's handler did;
+* the F3 delivered-answer tests keep the REAL ``process_event`` and induce the
+  failure DOWNSTREAM of the terminal send, because those guards depend on
+  ``process_event``'s own lifecycle (its ``finally`` clears the in-process mark
+  only for a non-``Exception`` exit) and a substituted ``process_event`` would
+  pass against a broken implementation.
+
+Two invariants every test asserts, because both are ways a plausible fix looks
+clean while breaking something load-bearing: the entry is **still pending**
+afterwards (acking to tidy the thread throws the turn away, #505 and ADR-0039),
+and the notice is **best effort** (a Slack outage may not turn a pending
+delivery into a failed one).
+
+``_settle`` here gathers WITHOUT ``return_exceptions``, unlike
+``test_delivery_ownership.py``'s: an exception escaping ``_handle`` is the #673
+shape and must fail loudly rather than be collected and dropped.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+import time
+from typing import Any
+
+import pytest
+from aci_protocol import Final, QueuedTurn, ReplyHandle, SessionStatus, TextDelta
+from channel_protocol.reply import (
+    REPLY_WIRE_VERSION,
+    ReplyAck,
+    ReplyEvent,
+    ReplyTarget,
+    ReplyUpdate,
+    TurnCompleted,
+)
+from curie_dispatcher.queue import to_stream_fields
+from curie_worker.config import WorkerConfig
+from curie_worker.consumer import Consumer
+from curie_worker.delivery_lease import DeliveryLeaseStore
+from curie_worker.kernel import _route_from_handle
+from curie_worker.markers import CompletionRecord
+from curie_worker.reply_sink import TargetRoute
+
+from .conftest import _failing_process_event, _pending_rows, _updates_for
+
+DONE = SessionStatus.DONE
+
+# The same compressed lease clocks ``test_delivery_ownership.py`` uses, kept
+# here rather than imported so a cross-file import cannot make one suite's
+# timing depend on the other's. Every ratio the config validators enforce is
+# preserved: TTL (1.0) >= 3 * heartbeat (0.3); the harness reclaim interval
+# (0.05) < TTL; the runner ceiling (30) <= the budget (60, its floor).
+_TTL_S = 1.0
+
+_LEASE_KNOBS: dict[str, object] = {
+    "delivery_budget_s": 60.0,
+    "delivery_lease_ttl_s": _TTL_S,
+    "delivery_lease_heartbeat_s": 0.3,
+    "runner_total_timeout_s": 30.0,
+}
+
+
+def _qevent(
+    text: str,
+    *,
+    thread: str = "th-1",
+    event_id: str = "notice-1",
+    placeholder: str | None = "p-1",
+) -> QueuedTurn:
+    return QueuedTurn(
+        event_id=event_id,
+        conversation_id=thread,
+        author="U1",
+        text=text,
+        reply_handle=ReplyHandle(kind="slack", channel="C1", placeholder=placeholder),
+        received_at="2026-07-05T00:00:00+00:00",
+    )
+
+
+async def _settle(consumer: Consumer) -> None:
+    """Drain the in-flight handlers, letting any escaped exception fail loudly."""
+    await asyncio.gather(*list(consumer._inflight))
+
+
+async def _read_one(h: Any, consumer_name: str) -> tuple[str, dict[str, str]]:
+    """Take the next new entry into ``consumer_name``'s PEL, as the read loop does."""
+    rows = await h.async_redis.xreadgroup(
+        h.config.consumer_group, consumer_name, {h.config.stream: ">"}, count=1
+    )
+    assert rows, "expected an entry to read"
+    entry_id, fields = rows[0][1][0]
+    return entry_id, dict(fields)
+
+
+async def _deliver_one(
+    h: Any, consumer: Consumer, qevent: QueuedTurn
+) -> str:
+    """XADD, read into this consumer's PEL, dispatch, and drain. Returns the entry id."""
+    await h.async_redis.xadd(h.config.stream, to_stream_fields(qevent))
+    entry_id, fields = await _read_one(h, h.config.consumer_name)
+    await consumer._dispatch(entry_id, fields)
+    await _settle(consumer)
+    return entry_id
+
+
+# --- AC1: the notice itself ---------------------------------------------------
+
+
+def test_a_failed_turn_edits_the_placeholder_to_the_not_started_text(make_harness) -> None:
+    """AC1, the reported defect directly: the thread stops being silent.
+
+    Red on reverting EB-12/EB-14: no reply of any kind is delivered and the
+    placeholder still reads the dispatcher's own text while the delivery waits
+    out its redelivery.
+
+    Exactly ONE edit, of the dispatcher's own placeholder, and no post: a post
+    would notify the thread a second time for a turn that has not even started,
+    which is a worse experience than the silence it replaces. The twin that
+    proves the opposite half is
+    ``test_a_placeholderless_turn_gets_no_message_at_all``.
+    """
+
+    async def go() -> None:
+        async with make_harness() as h:
+            consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
+            await consumer.ensure_group()
+            attempts = _failing_process_event(h)
+
+            entry_id = await _deliver_one(
+                h, consumer, _qevent("hello", thread="nts-1", event_id="nts-1")
+            )
+
+            assert attempts == ["nts-1"]
+            assert h.sink.updates == [("C1", "p-1", h.config.turn_not_started_text)]
+            assert h.sink.text_posts == [], (
+                "the notice POSTED a new message instead of editing the placeholder"
+            )
+            assert entry_id in await _pending_rows(h), (
+                "the notice acked the entry: the turn was thrown away, not retried"
+            )
+
+    asyncio.run(go())
+
+
+def test_a_placeholderless_turn_gets_no_message_at_all(make_harness) -> None:
+    """AC1's negative, and the reason the placeholder guard is first in the method.
+
+    The CLI, job and hook shape (ADR-0079) carries no placeholder. On that path
+    ``_reply_for`` POSTS a new message and adopts the minted ref, so firing the
+    notice here would hand every non-Slack failure a message it never had.
+
+    Red on dropping the ``reply_handle.placeholder is None`` early return.
+    Zero reply traffic of ANY shape is asserted, not just zero updates: a fix
+    that skipped only the edit would still post. Twin:
+    ``test_a_failed_turn_edits_the_placeholder_to_the_not_started_text``.
+    """
+
+    async def go() -> None:
+        async with make_harness() as h:
+            consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
+            await consumer.ensure_group()
+            attempts = _failing_process_event(h)
+
+            entry_id = await _deliver_one(
+                h,
+                consumer,
+                _qevent("hello", thread="nts-2", event_id="nts-2", placeholder=None),
+            )
+
+            assert attempts == ["nts-2"]
+            assert h.sink.events == []
+            assert h.sink.updates == []
+            assert h.sink.posts == []
+            assert h.sink.text_posts == []
+            assert entry_id in await _pending_rows(h)
+
+    asyncio.run(go())
+
+
+def test_the_notice_fires_even_under_no_edit_streaming(make_harness) -> None:
+    """AC1 under ``slack_no_edit_streaming``.
+
+    That flag's promise is "the placeholder gets exactly one chat.update: the
+    final". A turn that never finished emits no final, so honoring the flag here
+    would leave the placeholder frozen: the reported bug reproduced inside its
+    own fix, and only in the deployments that enabled the flag.
+
+    Red on copying the ``if not self._config.slack_no_edit_streaming`` guard
+    from the booting edit into the notice.
+    """
+
+    async def go() -> None:
+        async with make_harness(slack_no_edit_streaming=True) as h:
+            consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
+            await consumer.ensure_group()
+            _failing_process_event(h)
+
+            entry_id = await _deliver_one(
+                h, consumer, _qevent("hello", thread="nts-3", event_id="nts-3")
+            )
+
+            assert h.sink.updates == [("C1", "p-1", h.config.turn_not_started_text)]
+            assert entry_id in await _pending_rows(h)
+
+    asyncio.run(go())
+
+
+def test_a_failing_slack_sink_does_not_change_the_pending_outcome(
+    make_harness, caplog: pytest.LogCaptureFixture
+) -> None:
+    """AC1's best-effort half: a Slack outage may not change a settlement.
+
+    Red twice over. Red on making the notice non-best-effort: the exception
+    escapes ``_handle`` past ``_consume``'s per-entry isolation guard, which is
+    the #673 shape, and ``_settle`` here re-raises it rather than collecting it.
+    Red also on swallowing the failure silently, because the WARNING is the only
+    trace an operator has that the person was never told.
+    """
+
+    async def go() -> None:
+        async with make_harness() as h:
+            consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
+            await consumer.ensure_group()
+            _failing_process_event(h)
+            h.sink.fail_events.add("reply.update")
+
+            with caplog.at_level(logging.WARNING, logger="curie_worker.kernel"):
+                entry_id = await _deliver_one(
+                    h, consumer, _qevent("hello", thread="nts-4", event_id="nts-4")
+                )
+
+            assert h.sink.updates == []
+            assert entry_id in await _pending_rows(h), (
+                "a failed notice changed the delivery's settlement outcome"
+            )
+            assert any("nts-4" in message for message in caplog.messages), (
+                "the notice failed silently: nothing names the event id"
+            )
+
+    asyncio.run(go())
+
+
+def test_a_turn_that_already_settled_keeps_its_answer(make_harness) -> None:
+    """AC1's terminality guard, the DURABLE half.
+
+    ``_complete`` emits the reply BEFORE it settles, so a settle that applies in
+    Valkey and then loses its response unwinds into the same ``except`` branch
+    with the answer already on the person's screen and the done marker already
+    written. Editing then destroys a delivered answer AND promises a retry that
+    provably cannot happen: the redelivery reads this same predicate and takes
+    the "already done; skipping" path without re-running the turn.
+
+    The answer here is delivered with ``terminal=False`` on purpose, so the
+    in-process ``_terminal_reply_attempted`` mark is NOT taken and this test
+    isolates the ``Markers.is_terminal`` read. Its twin
+    ``test_an_answer_delivered_before_a_failed_settle_is_not_overwritten``
+    isolates the other half, where ``is_terminal`` is False and only the mark
+    can save the answer.
+
+    Red on dropping the ``is_terminal`` guard, and red on reading a bare done
+    marker instead (a DONE outbox record proves the turn finished just as well
+    and outlives the marker).
+    """
+
+    async def go() -> None:
+        async with make_harness() as h:
+            consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
+            await consumer.ensure_group()
+
+            async def settled_then_raised(qevent: QueuedTurn, *, lease: Any = None) -> None:
+                await h.kernel._reply_for(
+                    qevent, _route_from_handle(qevent), "the answer", terminal=False
+                )
+                await h.kernel._markers.mark_done(qevent.event_id)
+                raise ConnectionError("the settle applied and lost its response")
+
+            h.kernel.process_event = settled_then_raised  # type: ignore[method-assign,assignment]
+
+            entry_id = await _deliver_one(
+                h, consumer, _qevent("hello", thread="nts-5", event_id="nts-5")
+            )
+
+            assert h.sink.updates == [("C1", "p-1", "the answer")], (
+                "the notice overwrote a delivered answer for a turn that is "
+                "durably terminal and will never rerun"
+            )
+            assert entry_id in await _pending_rows(h)
+
+    asyncio.run(go())
+
+
+def test_a_done_outbox_record_without_a_done_marker_keeps_its_answer(
+    make_harness, caplog: pytest.LogCaptureFixture
+) -> None:
+    """AC1's terminality guard, the half that OUTLIVES the done marker.
+
+    ``is_terminal`` is deliberately wider than the done marker: the marker is one
+    key with ``idempotency_ttl_s`` (one day) behind it, while a DONE outbox record
+    proves the turn finished and is retained for ``completion_max_retention_s``
+    (seven days). A turn recovered after a long outage therefore reaches the
+    consumer's except branch with a DONE record and no marker at all, and it is
+    still just as terminal: editing the placeholder there destroys a delivered
+    answer and promises a retry the record itself refuses.
+
+    Its twin ``test_a_turn_that_already_settled_keeps_its_answer`` arms the marker
+    and would stay green if the guard were narrowed to a bare done-marker read.
+    This one is the test that goes RED on exactly that narrowing, so the pair
+    pins both terms of the predicate rather than one.
+
+    The record is written with ``mark_completion_pending`` and ``done=True``,
+    which is the state ``settle_fenced`` and ``mark_completion_pending`` plus
+    ``mark_done`` both leave behind, minus the marker those two also set.
+    """
+
+    async def go() -> None:
+        async with make_harness() as h:
+            consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
+            await consumer.ensure_group()
+            _failing_process_event(h)
+
+            await h.kernel._markers.mark_completion_pending(
+                "nts-12",
+                CompletionRecord(
+                    event_id="nts-12",
+                    event=TurnCompleted(
+                        version=REPLY_WIRE_VERSION,
+                        event="turn.completed",
+                        target=ReplyTarget(
+                            kind="slack",
+                            address="C1",
+                            conversation_id="nts-12",
+                            reply_ref="p-1",
+                        ),
+                        event_id="nts-12",
+                        outcome="delivered",
+                    ),
+                    route=TargetRoute(),
+                    created_at=time.time(),
+                    done=True,
+                ),
+            )
+            assert await h.async_redis.exists(h.config.done_key("nts-12")) == 0, (
+                "a done marker was armed, so this test no longer isolates the "
+                "outbox half of the predicate"
+            )
+
+            with caplog.at_level(logging.WARNING, logger="curie_worker.kernel"):
+                entry_id = await _deliver_one(
+                    h, consumer, _qevent("hello", thread="nts-12", event_id="nts-12")
+                )
+
+            assert any("nts-12" in message for message in caplog.messages), (
+                "nothing reached the terminality guard at all, so a green result "
+                "here would prove nothing about it"
+            )
+            assert h.sink.updates == [], (
+                "the notice overwrote the answer of a turn whose DONE outbox "
+                "record proves it finished, because terminality was read from "
+                "the done marker alone"
+            )
+            assert entry_id in await _pending_rows(h)
+
+    asyncio.run(go())
+
+
+def test_an_unreadable_terminality_check_leaves_the_placeholder_alone(
+    make_harness, caplog: pytest.LogCaptureFixture
+) -> None:
+    """AC1's terminality guard FAILS CLOSED.
+
+    The two errors are not symmetric. A notice skipped for a turn that did fail
+    costs the person the seconds until the lease-expiry reclaim redelivers,
+    which is the behavior before this change; a notice sent for a turn that
+    succeeded costs them the answer permanently.
+
+    Red on ``except Exception: pass`` around the terminality read (which would
+    fall through and edit), and red on swallowing the failure with no WARNING.
+    """
+
+    async def go() -> None:
+        async with make_harness() as h:
+            consumer = Consumer(redis=h.async_redis, kernel=h.kernel, config=h.config)
+            await consumer.ensure_group()
+            _failing_process_event(h)
+
+            async def unreadable(event_id: str) -> bool:
+                raise ConnectionError("injected marker read failure")
+
+            h.kernel._markers.is_terminal = unreadable  # type: ignore[method-assign,assignment]
+
+            with caplog.at_level(logging.WARNING, logger="curie_worker.kernel"):
+                entry_id = await _deliver_one(
+                    h, consumer, _qevent("hello", thread="nts-6", event_id="nts-6")
+                )
+
+            assert h.sink.updates == []
+            assert entry_id in await _pending_rows(h)
+            assert any("nts-6" in message for message in caplog.messages)
+
+    asyncio.run(go())
+
+
+def test_the_not_started_text_names_no_tool_and_no_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#717's prose rule as an assertion, plus AC1's "one sentence" contract.
+
+    An end user talking to an agent must never see curie's own architecture
+    vocabulary in a status line, and there is nothing in an internal id a person
+    can look up, so naming one only leaks architecture. The one-sentence check
+    is AC1's own wording made enforceable rather than described: two sentences
+    is what the round-1 copy did.
+
+    Red on any default that reintroduces internal vocabulary, a digit, or a
+    second sentence. No Valkey; this is the copy, not the delivery.
+    """
+    monkeypatch.delenv("CURIE_TURN_NOT_STARTED_TEXT", raising=False)
+
+    text = WorkerConfig().turn_not_started_text
+
+    for word in ("runner", "sandbox", "valkey", "stream", "entry", "id"):
+        assert re.search(rf"\b{word}\b", text, re.IGNORECASE) is None, (
+            f"the person-facing notice names {word!r}"
+        )
+    assert re.search(r"\d", text) is None, "the notice carries an identifier"
+    assert len(re.findall(r"[.!?]", text)) == 1, "AC1 asks for ONE sentence"
+    assert text.rstrip().endswith((".", "!", "?"))
+
+
+# --- F3: the notice never overwrites a delivered answer -----------------------
+
+
+def test_an_answer_delivered_before_a_failed_settle_is_not_overwritten(
+    make_harness,
+) -> None:
+    """F3, the ``finalize`` half. The REAL ``process_event`` unwind, deliberately.
+
+    ``is_terminal`` protects a settlement that succeeded and lost its response.
+    It does NOT protect one that failed BEFORE writing: the answer reaches the
+    person at ``reply.finalize``, and only afterwards does ``_complete`` make its
+    first fenced write. With ``settle_fenced`` raising, the exception unwinds
+    with the answer on screen and ``is_terminal`` reading False.
+
+    A substituted ``process_event`` would pass against a broken implementation,
+    because ``_process_event``'s ``finally`` runs BEFORE the exception reaches
+    the consumer and ``process_event``'s ``finally`` is what decides whether the
+    mark survives. So the real one runs here, the runner is scripted with a
+    Final, and only the fenced write fails.
+
+    Red without EB-12b: the notice overwrites a delivered answer. Twin:
+    ``test_a_turn_that_already_settled_keeps_its_answer`` (the durable half).
+    """
+
+    async def go() -> None:
+        async with make_harness(**_LEASE_KNOBS) as h:
+            store = DeliveryLeaseStore(h.async_redis, h.config)
+            consumer = Consumer(
+                redis=h.async_redis, kernel=h.kernel, config=h.config, leases=store
+            )
+            await consumer.ensure_group()
+            h.runner.default_script = [Final(text="the answer", status=DONE)]
+
+            async def refuse(*args: Any, **kwargs: Any) -> str | None:
+                raise ConnectionError("the fenced write never landed")
+
+            h.kernel._markers.settle_fenced = refuse  # type: ignore[method-assign,assignment]
+
+            entry_id = await _deliver_one(
+                h, consumer, _qevent("hello", thread="nts-7", event_id="nts-7")
+            )
+
+            assert _updates_for(h, "nts-7")[-1] == "the answer", (
+                "the notice overwrote an answer the person had already read"
+            )
+            assert h.config.turn_not_started_text not in _updates_for(h, "nts-7")
+            assert await h.kernel._markers.is_terminal("nts-7") is False, (
+                "the settle wrote a marker, so this test no longer exercises the "
+                "in-process mark it exists to pin"
+            )
+            assert entry_id in await _pending_rows(h)
+
+    asyncio.run(go())
+
+
+def test_a_terminal_send_that_lands_then_raises_is_treated_as_delivered(
+    make_harness, caplog: pytest.LogCaptureFixture
+) -> None:
+    """AC1's AMBIGUOUS terminal send: the edit landed, the await did not.
+
+    An HTTP edit that applies on the platform and then loses its response is
+    indistinguishable, locally, from one that never applied. The answer is on the
+    person's screen and the local call raised, so the delivery still unwinds into
+    the consumer's except branch. ``is_terminal`` cannot save it (the settle is
+    downstream of the send and never ran) and neither can a mark taken on
+    SUCCESS, because there was no success to take it on. Only marking BEFORE the
+    send covers this shape, and the fail-safe direction is to treat the person as
+    already answered: a duplicate notice costs them an answer they can read,
+    while a skipped one costs them the seconds until the redelivery.
+
+    The REAL ``process_event`` runs, for the reason the module docstring gives:
+    the mark's survival is decided by ``process_event``'s own ``finally``, which a
+    substituted one would not have. The sink's ``fail_events`` cannot arm this
+    shape because it raises BEFORE recording, which is the unambiguous
+    never-landed case, so ``emit`` is wrapped HERE to record first and raise
+    after.
+
+    Red if the terminal mark moves from before the send to after a successful
+    send, and red if it moves to the top of ``_complete``: both leave this
+    delivery unmarked, and the notice replaces a delivered answer with an
+    invitation to resend it.
+    """
+
+    async def go() -> None:
+        async with make_harness(**_LEASE_KNOBS) as h:
+            store = DeliveryLeaseStore(h.async_redis, h.config)
+            consumer = Consumer(
+                redis=h.async_redis, kernel=h.kernel, config=h.config, leases=store
+            )
+            await consumer.ensure_group()
+            h.runner.default_script = [Final(text="the answer", status=DONE)]
+
+            landed = h.sink.emit
+
+            async def lands_then_raises(
+                event: ReplyEvent,
+                *,
+                route: TargetRoute,
+                best_effort_unreachable: bool = False,
+            ) -> ReplyAck:
+                ack = await landed(
+                    event, route=route, best_effort_unreachable=best_effort_unreachable
+                )
+                if isinstance(event, ReplyUpdate) and event.text == "the answer":
+                    raise ConnectionError("the edit applied and lost its response")
+                return ack
+
+            h.sink.emit = lands_then_raises  # type: ignore[method-assign]
+
+            with caplog.at_level(logging.WARNING, logger="curie_worker.kernel"):
+                entry_id = await _deliver_one(
+                    h, consumer, _qevent("hello", thread="nts-13", event_id="nts-13")
+                )
+
+            assert any("nts-13" in message for message in caplog.messages), (
+                "the delivery never reached the notice branch, so a green result "
+                "here would prove nothing about the mark"
+            )
+            texts = _updates_for(h, "nts-13")
+            assert texts[-1] == "the answer", (
+                "the notice overwrote an answer that had already reached the "
+                "person, because the send raised after it landed"
+            )
+            assert h.config.turn_not_started_text not in texts
+            assert await h.kernel._markers.is_terminal("nts-13") is False, (
+                "the turn settled, so this test no longer exercises the "
+                "before-the-send mark it exists to pin"
+            )
+            assert entry_id in await _pending_rows(h)
+
+    asyncio.run(go())
+
+
+def test_a_polite_drop_is_not_overwritten_by_the_notice(make_harness) -> None:
+    """F3, the ``_drop_with_message`` half: the second delivery path before ``_complete``.
+
+    An unmapped channel is answered politely and then completed. If that
+    completion's fenced write fails, the drop text is already on the person's
+    screen and ``is_terminal`` still reads False, exactly as in the twin above.
+    One test per marking site is why both ``terminal=True`` paths are covered:
+    this one goes through ``_reply_for``, the twin through
+    ``_ThrottledReply.finalize``.
+
+    Red on marking only at ``finalize``: the drop message is replaced by the
+    notice, and the person is told to resend a message the platform already
+    answered.
+    """
+
+    class _UnmappedBinding:
+        """Resolves nothing, which is the polite-drop route."""
+
+        async def resolve(self, kind: str, address: str) -> None:
+            return None
+
+    async def go() -> None:
+        async with make_harness(binding=_UnmappedBinding(), **_LEASE_KNOBS) as h:
+            store = DeliveryLeaseStore(h.async_redis, h.config)
+            consumer = Consumer(
+                redis=h.async_redis, kernel=h.kernel, config=h.config, leases=store
+            )
+            await consumer.ensure_group()
+
+            async def refuse(*args: Any, **kwargs: Any) -> str | None:
+                raise ConnectionError("the fenced write never landed")
+
+            h.kernel._markers.settle_fenced = refuse  # type: ignore[method-assign,assignment]
+
+            entry_id = await _deliver_one(
+                h, consumer, _qevent("hello", thread="nts-8", event_id="nts-8")
+            )
+
+            drop_texts = _updates_for(h, "nts-8")
+            assert drop_texts, "the polite drop never reached the person at all"
+            assert "no agent is configured" in drop_texts[-1].lower(), (
+                "the notice overwrote the polite drop"
+            )
+            assert h.config.turn_not_started_text not in drop_texts
+            assert entry_id in await _pending_rows(h)
+
+    asyncio.run(go())
+
+
+def test_a_partially_streamed_turn_still_gets_the_notice(make_harness) -> None:
+    """F3's mandatory NEGATIVE, and one of #2433's three named shapes.
+
+    "The turn that streamed partial text and then raised" must still be told
+    about. Streaming previews are not a terminal result: the person has a
+    fragment, not an answer, and suppressing the notice here would silently
+    delete a third of AC1's coverage while the two tests above stayed green.
+
+    The failure is induced at ``_finish``, which is downstream of every streamed
+    edit and upstream of ``reply.finalize``, so ``stream`` provably fired and
+    ``finalize`` provably did not. ``process_event`` itself is untouched, so the
+    whole real lifecycle still runs.
+
+    Red on calling the mark from ``_ThrottledReply.stream`` or
+    ``stream_context``. Twin:
+    ``test_an_answer_delivered_before_a_failed_settle_is_not_overwritten``.
+    """
+
+    async def go() -> None:
+        async with make_harness(**_LEASE_KNOBS) as h:
+            store = DeliveryLeaseStore(h.async_redis, h.config)
+            consumer = Consumer(
+                redis=h.async_redis, kernel=h.kernel, config=h.config, leases=store
+            )
+            await consumer.ensure_group()
+            h.runner.default_script = [
+                TextDelta(text="partial "),
+                TextDelta(text="thought"),
+            ]
+
+            async def never_finishes(*args: Any, **kwargs: Any) -> Any:
+                raise RuntimeError("the turn raised before it could finalize")
+
+            h.kernel._finish = never_finishes  # type: ignore[method-assign,assignment]
+
+            entry_id = await _deliver_one(
+                h, consumer, _qevent("hello", thread="nts-9", event_id="nts-9")
+            )
+
+            texts = _updates_for(h, "nts-9")
+            assert any(text.startswith("partial") for text in texts), (
+                "nothing streamed, so this test does not exercise the negative"
+            )
+            assert texts[-1] == h.config.turn_not_started_text, (
+                "a partially streamed turn was treated as delivered and the "
+                "person was never told it failed"
+            )
+            assert entry_id in await _pending_rows(h)
+
+    asyncio.run(go())
+
+
+# --- The notice may not talk over the current fence holder --------------------
+
+
+def test_a_notice_is_skipped_when_this_owner_lost_the_fence(
+    make_harness, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The call-site guard (EB-14): terminality is not permission to edit.
+
+    ``Consumer._handle``'s generic ``except`` can run AFTER lease loss and sits
+    ahead of the pre-ACK ``raise_if_lost``. A replacement that holds the fence
+    now owns this thread and will speak for it, starting with its own booting
+    edit; talking over it is worse than saying nothing.
+
+    Red on removing ``lease.raise_if_lost()`` from the call site: this owner
+    edits a placeholder it no longer has authority over. Twin:
+    ``test_a_notice_is_skipped_when_the_lease_is_lost_during_the_terminality_read``,
+    which covers the instant AFTER this check, where only the kernel's own
+    re-check can see the loss.
+    """
+
+    async def go() -> None:
+        async with make_harness(**_LEASE_KNOBS) as h:
+            store = DeliveryLeaseStore(h.async_redis, h.config)
+            consumer = Consumer(
+                redis=h.async_redis, kernel=h.kernel, config=h.config, leases=store
+            )
+            await consumer.ensure_group()
+
+            async def fenced_out(qevent: QueuedTurn, *, lease: Any = None) -> None:
+                assert lease is not None, "the kernel was handed no lease"
+                lease.lost.set()
+                raise RuntimeError("simulated handler failure after lease loss")
+
+            h.kernel.process_event = fenced_out  # type: ignore[method-assign,assignment]
+
+            with caplog.at_level(logging.WARNING, logger="curie_worker.consumer"):
+                entry_id = await _deliver_one(
+                    h, consumer, _qevent("hello", thread="nts-10", event_id="nts-10")
+                )
+
+            assert h.sink.updates == [], (
+                "a fenced-out owner talked over the replacement that holds the fence"
+            )
+            assert entry_id in await _pending_rows(h)
+            assert any(
+                "not-started notice" in message or "lost the delivery lease" in message
+                for message in caplog.messages
+            )
+
+    asyncio.run(go())
+
+
+def test_a_notice_is_skipped_when_the_lease_is_lost_during_the_terminality_read(
+    make_harness, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The kernel's own re-check at the emission boundary (EB-12 step 4).
+
+    A heartbeat can mark the lease lost WHILE the ``is_terminal`` read is
+    pending, so a check taken only at the call site is already stale by the time
+    the edit happens. Here the call-site check provably passes (the lease is
+    still held when the branch is entered) and only the kernel's
+    post-``is_terminal`` ``raise_if_lost`` can catch the loss.
+
+    Red on placing that check BEFORE the ``is_terminal`` await instead of after
+    it, which is the whole point of the placement. Twin:
+    ``test_a_notice_is_skipped_when_this_owner_lost_the_fence``.
+    """
+
+    async def go() -> None:
+        async with make_harness(**_LEASE_KNOBS) as h:
+            store = DeliveryLeaseStore(h.async_redis, h.config)
+            consumer = Consumer(
+                redis=h.async_redis, kernel=h.kernel, config=h.config, leases=store
+            )
+            await consumer.ensure_group()
+
+            held: list[Any] = []
+
+            async def failing(qevent: QueuedTurn, *, lease: Any = None) -> None:
+                assert lease is not None, "the kernel was handed no lease"
+                held.append(lease)
+                raise RuntimeError("simulated handler failure")
+
+            h.kernel.process_event = failing  # type: ignore[method-assign,assignment]
+
+            async def loses_the_fence_mid_read(event_id: str) -> bool:
+                held[0].lost.set()
+                return False
+
+            h.kernel._markers.is_terminal = (  # type: ignore[method-assign,assignment]
+                loses_the_fence_mid_read
+            )
+
+            with caplog.at_level(logging.WARNING, logger="curie_worker.kernel"):
+                entry_id = await _deliver_one(
+                    h, consumer, _qevent("hello", thread="nts-11", event_id="nts-11")
+                )
+
+            assert h.sink.updates == []
+            assert entry_id in await _pending_rows(h)
+            assert any("nts-11" in message for message in caplog.messages)
+
+    asyncio.run(go())

--- a/apps/worker/tests/test_config.py
+++ b/apps/worker/tests/test_config.py
@@ -1099,3 +1099,114 @@ def test_delivery_key_helpers_are_keyed_by_the_delivery_triple(
     assert lease_key == "curie:worker:lease:curie:runs:curie-workers:1-0"
     assert state_key == "curie:worker:delivery:curie:runs:curie-workers:1-0"
     assert lease_key != state_key
+
+
+# --- The lease-expiry reclaim threshold and the not-started copy (#2433) ------
+#
+# The threshold is an ADDITION to ``reclaim_min_idle_ms``, never a replacement:
+# an entry with no delivery state carries no evidence a lease was ever granted
+# and stays on the unchanged 900 second window. It is bounded on BOTH sides
+# because each end is a distinct silent failure. Below one lease TTL the scan
+# can select an entry between a healthy owner's heartbeats, before its lease has
+# actually expired, which reintroduces the cross-replica dup-dispatch the lease
+# exists to close. At or above the backstop the pass selects nothing XAUTOCLAIM
+# was not already claiming, so it is dead code and ADR-0131's "recoverable after
+# at most one short lease" bound is silently off.
+
+
+def test_lease_expiry_idle_defaults_to_exactly_one_lease_ttl(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The default DERIVES from the lease TTL rather than restating it.
+
+    A static ``Field`` default cannot reference another field, so the derivation
+    lives in a resolver both consumer lanes read, which is what keeps runs/eval
+    parity structural. Asserting only the 45000 number would pass against a
+    hard-coded literal, so the second half lowers the TTL and requires the
+    threshold to follow: an operator who shortens the lease must not be left with
+    an incoherent pair.
+    """
+    _clear_all_config_env(monkeypatch)
+
+    config = WorkerConfig()
+    assert config.lease_expired_idle_ms is None
+    assert config.lease_expired_idle_ms_value() == int(
+        config.delivery_lease_ttl_s * 1000
+    )
+    assert config.lease_expired_idle_ms_value() == 45000
+
+    shorter = _lease_config(
+        delivery_lease_ttl_s=30.0,
+        delivery_lease_heartbeat_s=10.0,
+        reclaim_interval_s=20.0,
+    )
+    assert shorter.lease_expired_idle_ms is None
+    assert shorter.lease_expired_idle_ms_value() == 30000
+
+
+def test_an_explicit_threshold_below_one_lease_ttl_is_rejected_at_boot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Below one lease TTL the pass can transfer a delivery somebody still owns.
+
+    The operator must learn at boot, not at 2am, so the rejection NAMES both env
+    vars and both values.
+    """
+    _clear_all_config_env(monkeypatch)
+
+    with pytest.raises(ValidationError) as exc_info:
+        _lease_config(delivery_lease_ttl_s=45.0, lease_expired_idle_ms=44999)
+
+    message = str(exc_info.value)
+    assert "CURIE_LEASE_EXPIRED_IDLE_MS" in message
+    assert "CURIE_DELIVERY_LEASE_TTL_S" in message
+
+
+def test_an_explicit_threshold_at_or_above_the_backstop_is_rejected_at_boot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """At or above the backstop the whole pass is dead configuration.
+
+    Rejected at the boundary rather than one past it, because 900000 exactly is
+    the value an operator reaches for when they mean "same as the backstop", and
+    it selects nothing XAUTOCLAIM was not already claiming.
+    """
+    _clear_all_config_env(monkeypatch)
+
+    with pytest.raises(ValidationError) as exc_info:
+        _lease_config(lease_expired_idle_ms=900000)
+
+    message = str(exc_info.value)
+    assert "CURIE_LEASE_EXPIRED_IDLE_MS" in message
+    assert "reclaim_min_idle_ms" in message
+
+
+def test_a_threshold_inside_the_band_is_accepted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The control that stops the two rejections above passing vacuously.
+
+    Without it a validator that rejected every explicit value would keep them
+    both green while deleting the operator's ability to tune the knob at all.
+    """
+    _clear_all_config_env(monkeypatch)
+
+    config = _lease_config(lease_expired_idle_ms=60000)
+    assert config.lease_expired_idle_ms == 60000
+    assert config.lease_expired_idle_ms_value() == 60000
+
+
+def test_the_turn_not_started_text_is_operator_overridable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every person-facing string this pipeline emits is operator-tunable (#717).
+
+    ``booting_text`` and ``status_text`` already carry a ``CURIE_`` alias so an
+    operator can retune the voice for their own users; a hard-coded literal here
+    would be the only exception, on the one line #717 is about.
+    """
+    _clear_all_config_env(monkeypatch)
+    assert WorkerConfig().turn_not_started_text
+
+    monkeypatch.setenv("CURIE_TURN_NOT_STARTED_TEXT", "Sorry, please resend that.")
+    assert WorkerConfig().turn_not_started_text == "Sorry, please resend that."

--- a/docs/interfaces/queue-stream/INTERFACE.md
+++ b/docs/interfaces/queue-stream/INTERFACE.md
@@ -87,6 +87,15 @@ A second broker must honor the stream key, the payload encoding, and the Stream 
   replicas from racing through the delivery budget. A restarted generation
   also recovers rows under its own stable consumer name through the same
   pre-claim cap check before it reads new entries.
+- **Lease expiry** (#2433): a pending row whose delivery state exists and whose
+  delivery lease has expired is transferred regardless of whether its PEL consumer
+  is alive, because a handler that raised released its lease and no prompt path
+  looks at a peer that is not dead. The scan is `xpending_range` with an `IDLE`
+  filter at `CURIE_LEASE_EXPIRED_IDLE_MS` (default one delivery lease TTL) and the
+  claim is `xclaim` at that same min-idle, which makes the claim an atomic
+  compare-and-claim on the row's idle clock. An entry with no delivery state
+  carries no evidence a lease was ever granted and remains on the 900-second
+  `XAUTOCLAIM` fallback.
 - **Compatibility and the prompt cap rule** — an unknown/pre-marker peer keeps
   the unchanged 900-second `XAUTOCLAIM` backstop. For a proven-dead capable
   peer, the prompt path first reads `XPENDING` metadata and skips local
@@ -129,7 +138,9 @@ is not touched:
 - **Consumer transport** — `StreamBroker` (`apps/worker/src/curie_worker/broker.py::StreamBroker`):
   `xgroup_create`/`xreadgroup`/`xack`/`xautoclaim`, plus — since the bounded-delivery
   dead-letter path (#505, ADR-0039) — `xpending_range`/`xrange`/`xadd`, plus — since
-  dead-consumer prompt reclaim (#1532) — `xinfo_consumers`/`xclaim`. The non-sacred `StreamConsumer`
+  dead-consumer prompt reclaim (#1532): `xinfo_consumers`/`xclaim`, which the
+  lease-expiry pass (#2433) reuses as an `IDLE`-filtered `xpending_range` plus an
+  `xclaim` at the same min-idle. The non-sacred `StreamConsumer`
   base (`apps/worker/src/curie_worker/stream_consumer.py`) holds a `StreamBroker`; the sacred `consumer.py` subclass
   inherits it unchanged (its `XAUTOCLAIM` reclaim now targets the port by inheritance).
 - **Consumer liveness store** — `ConsumerLivenessStore`


### PR DESCRIPTION
## Summary

A handler that raises inside the worker releases its delivery lease, so the entry sits in a live consumer's own pending list where the prompt reclaim path never looks, and the person is left on the dispatcher's placeholder until the 900 s `XAUTOCLAIM` backstop. This change does two things. The consumer's "left pending" branch now asks the kernel to edit the placeholder in place to one person-facing sentence (`CURIE_TURN_NOT_STARTED_TEXT`), best effort, skipped for turns with no placeholder, and never over an answer that already reached the thread or after this owner lost the fence. `_reclaim_once` gains a lease-expiry pass: a pending entry whose delivery state exists but whose lease is gone is claimed to self at one lease TTL (`CURIE_LEASE_EXPIRED_IDLE_MS`, default the 45 s lease TTL, validated to sit between the TTL and the backstop); an entry with no delivery state stays on the unchanged 900 s backstop. Every transfer `XCLAIM` now compares against the idle its caller observed (the expiry pass its `XPENDING IDLE` filter, the proven-dead pass each row's `time_since_delivered`, floored at 1 ms), so two replicas cannot double-claim, and the expiry pass claims only what this process can run now. Both consumer lanes wire the knob through one resolver. `max_delivery`, its `ge=2` floor, the pre-claim `XPENDING` count and `reclaim_min_idle_ms` are unchanged.

## Related issue

Closes #2433

## Fix pin verification

Fix pin: apps/worker/tests/kernel/test_delivery_ownership.py::test_the_running_consumer_redelivers_a_failed_turn_without_a_manual_reclaim

## End-to-end verification

| Tier | Required / n/a | Reason | Mode (fake / live) | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | no change to plugin packaging, the runner turn loop, ACI events, or skill eval | | |
| local | required | worker reclaim and placeholder-edit wiring inside the worker service, both stream lanes | live | `uv run pytest apps/worker/tests` against the compose Valkey at `915166d4`: 1358 passed, 9 skipped, including `test_the_running_consumer_redelivers_a_failed_turn_without_a_manual_reclaim` (the real `Consumer.run()` lifecycle redelivers with `reclaim_min_idle_ms` pinned at 900000). Host-process harness (`python -m curie_worker` from this checkout on an isolated stream, `DATABASE_URL` at a closed port so `BindingResolver.resolve` raises out of `process_event`): `XPENDING` showed `times_delivered` 1 at idle 68 s, 2 at t+75 s, 3 at t+133 s, a 58 s cadence (45 s TTL plus up to one 30 s tick), never the 900 s backstop. The ladder rung `CURIE_E2E_TIERS=local curie dev e2e-ladder` was blocked: it refuses to run over a compose stack another session owns, and one was up for the whole run. |
| local-release | n/a | no change to the released binary or image identity, the install path, version pins, or the release compose | | |
| cluster | n/a | no chart template, RBAC, securityContext, NetworkPolicy, sandbox claim, or init container change | | |
| live provider | n/a | no model routing, credential resolution, provider auth, or token accounting change; the MCP, workspace and coding-tool path set is untouched | | |
| external integration | required | the notice is a new person-facing edit that reaches Slack | live | Same harness with the Socket Mode dispatcher from this checkout connected to the dev Slack app and a Slack-shaped turn whose placeholder is a real message in the test channel: within 6 s `conversations.replies` showed the placeholder text replaced by `I ran into a problem and could not finish this request, so if no answer appears here shortly, please send it again.` and it stayed that single edited message across three redeliveries. Negative: a turn with `reply_handle.placeholder` unset (the CLI and hook shape) was redelivered twice and `conversations.history` gained no message (5 before, 5 after). The inbound mention was originated through the dispatcher's own producer (`curie_dispatcher.enqueue_once`) because no human identity for the dev workspace exists on the build host; the Socket Mode ingest path is unchanged by this PR. |

- [x] Every required tier above names its exact command, the commit it ran against, the mode it ran in, and the literal outcome observed.
- [x] Each meaningful acceptance criterion has positive proof plus a falsifiable negative or a second independent path.
- [x] No required tier is left unproved; any blocked tier names its blocker in the table.

Discovery waiver: the defect was observed on a live cluster with a dying worker node under concurrent sandbox load. That surface was not reachable from this run; the cluster-tier pin is filed as #2453.

## Follow-ups named, not fixed here

- #2453: the cluster-tier replay (concurrent handler failures on a two-replica worker, placeholder edits and redelivery near the threshold, a SIGKILL transfer).
- Once `max_delivery` is spent the entry dead-letters and the notice is not updated; the sentence stays true at the cap but does not say the retries are over.
- The worker `booting_text` still drifts from the dispatcher's placeholder copy; a shared constant needs both service packages.
- Accepted residual, documented in `apps/worker/CLAUDE.md`: a claimed row whose dispatch waits past one lease TTL can be re-claimed by a peer; the late acquire is refused `not-owner`, so the cost is one charged delivery, never a double run or a stranded turn.

## Review record

Adversarial plan review ran two rounds without converging on transfer safety; a one-shot oracle ruling chose compare-and-claim over a reservation key and terminal-send marking at the emission boundary, and the plan was rewritten to it. Independent code review: approve, five advisories, all applied (min-idle floor, mark popped before the placeholderless return, eval capacity subtracts in-flight work, two added AC1 pins). Independent scope review: approve, no flagged hunks. The extra P0 spec-vs-impl pass: all five acceptance criteria visible in the product diff, the three unchanged-by-requirement items byte-identical to `main`. Consolidation (test helper dedup) re-reviewed: approve, one cosmetic advisory (two unused unpacked variables) left as noted.

## Done-check

- [x] Failing tests committed before any implementation code (`7c0575f9` precedes `2eeea9e8`).
- [x] All production edits by delegated sub-agents; the driver ran only validation, git, and bookkeeping.
- [x] Broadened return types: none reported. Signature changes are additive keyword-only (`_reply_for(terminal=)`, `_ThrottledReply(on_final=)`); all 11 `_reply_for` call sites and the single `_ThrottledReply` construction still type-check under mypy strict.
- [x] Code Reviewer completed with file:line evidence (approve, advisories applied).
- [x] Scope Reviewer completed; every non-trivial hunk mapped to an AC or a mechanical exception.
- [x] Sibling-path parity: runs and eval lanes both wire `lease_expired_idle_ms` through `WorkerConfig.lease_expired_idle_ms_value()` with a test each; the eval lane's per-entry handler has no placeholder and is deferred by design; the unparseable and lease-lost branches are named out of scope in the plan.
- [x] Guard demonstration by execution: `WorkerConfig(lease_expired_idle_ms=1000)` and `(=900000)` both raise naming the bound, `60000` is accepted, the default derives 45000; the mixed-version guard proved against real Valkey by `test_an_entry_with_no_delivery_state_stays_on_the_backstop` and its unreadable-read sibling.
- [x] Consolidation pass ran (test helper dedup applied, 1358 tests re-passed, re-reviewed).
- [ ] Security Reviewer: N/A (not flagged).
- [x] Observable verification for the user-facing change recorded above on the real Slack surface.
- [ ] E2E Tester: N/A (deployed-surface not flagged).
- [x] Train check: bug on the v0.8.7 patch milestone, cut from `main`.
- [x] Discovery-surface: live; waiver recorded and the cluster-tier follow-up filed and named above.
- [ ] Re-fix mechanism: N/A (no prior fix of this symptom).
- [x] Full affected test suite passes; ruff, mypy, and docs lint clean.
