### PR TITLE
Require a provider body before a Get Thread 404 becomes terminal

### DIFF
--- a/apps/mail-adapter/README.md
+++ b/apps/mail-adapter/README.md
@@ -273,7 +273,7 @@ A thread lookup returning HTTP 404 after admission is terminal for that reply
 only when the 404 carries the provider's own JSON body. A 404 whose body is not
 JSON came from an edge, gateway or stale route rather than AgentMail, and stays
 retryable as an unreadable witness (502): the receipt below is permanent, and a
-signal that ambiguous must never write one.
+signal this ambiguous must never write one.
 The adapter durably records deletion, logs one warning with a hashed correlation,
 and returns HTTP 410 on the first and any duplicate completion, including after
 restart. The response body carries `{"detail":"thread deleted at provider"}`;

--- a/apps/mail-adapter/README.md
+++ b/apps/mail-adapter/README.md
@@ -269,7 +269,11 @@ subprocess.
 
 ### Deleted provider threads
 
-A thread lookup returning HTTP 404 after admission is terminal for that reply.
+A thread lookup returning HTTP 404 after admission is terminal for that reply
+only when the 404 carries the provider's own JSON body. A 404 whose body is not
+JSON came from an edge, gateway or stale route rather than AgentMail, and stays
+retryable as an unreadable witness (502): the receipt below is permanent, and a
+signal that ambiguous must never write one.
 The adapter durably records deletion, logs one warning with a hashed correlation,
 and returns HTTP 410 on the first and any duplicate completion, including after
 restart. The response body carries `{"detail":"thread deleted at provider"}`;

--- a/apps/mail-adapter/src/curie_mail_adapter/adapter.py
+++ b/apps/mail-adapter/src/curie_mail_adapter/adapter.py
@@ -535,6 +535,20 @@ class MailAdapter:
     def thread_carries(self, conversation_id: str, event_id: str) -> bool | None:
         status, thread = self.client.get_thread(conversation_id)
         if status == 404:
+            # Only the PROVIDER's own answer is deletion. `request` parses a JSON
+            # body and hands back the raw text when it is not JSON, so a 404
+            # carrying anything but an object came from something between us and
+            # AgentMail -- an edge or gateway 404 page, a stale route mid-deploy,
+            # a path that never reached the API. Believing one of those writes a
+            # PERMANENT tombstone (`delete_event`) after which no retry ever
+            # calls the provider again, and the reply is lost with the release
+            # otherwise healthy. Ambiguity retries; only a confirmed answer is
+            # terminal, which is the invariant CLAUDE.md already states.
+            if not isinstance(thread, dict):
+                logger.warning(
+                    "thread listing -> 404 with no provider body; durable witness unreadable"
+                )
+                return None
             raise ProviderThreadDeletedError
         if status != 200 or not isinstance(thread, dict):
             logger.warning("thread listing -> %s; durable witness unreadable", status)

--- a/apps/mail-adapter/tests/_support.py
+++ b/apps/mail-adapter/tests/_support.py
@@ -106,6 +106,12 @@ class MailState:
         # adapter must never render into a log, and putting recognisable content
         # in one is the only way a test can prove it never does.
         self.injected_body: dict[str, Any] | None = None
+        # A NON-JSON failure body, as an edge proxy, gateway or load balancer
+        # serves. Distinct from `injected_body`, which is the provider's own
+        # JSON: the adapter's terminal-vs-retryable split on a 404 turns on
+        # exactly that difference, so a test cannot prove it without being able
+        # to serve a body the provider would never have written.
+        self.injected_raw_body: str | None = None
         # N CONSECUTIVE transport failures on List Messages before answering
         # normally, mirroring `IngressState.drop_next`. `fail_next_list` is
         # one-shot and so cannot express a repeated outage, which is the whole
@@ -270,6 +276,15 @@ class _JsonHandler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(body)
 
+    def _send_raw(self, status: int, text: str) -> None:
+        """Answer with a body that is not JSON, the way an edge 404 page is."""
+        body = text.encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "text/html")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
 
 class MailHandler(_JsonHandler):
     @property
@@ -290,6 +305,10 @@ class MailHandler(_JsonHandler):
             return False
         if failure == 0:
             self.close_connection = True  # a real transport failure
+            return True
+        raw = self.state.injected_raw_body
+        if raw is not None:
+            self._send_raw(failure, raw)
             return True
         body = self.state.injected_body
         self._send(failure, body if body is not None else {"detail": "injected provider failure"})

--- a/apps/mail-adapter/tests/test_egress.py
+++ b/apps/mail-adapter/tests/test_egress.py
@@ -729,6 +729,39 @@ def test_deleted_provider_thread_is_terminal_once_across_restart(
     assert "ev-deleted" not in messages[0]
 
 
+def test_a_404_without_a_provider_body_is_not_terminal(
+    mail: MailState,
+    adapter: MailAdapter,
+    egress_url: str,
+) -> None:
+    """An edge 404 is "could not read", not "deleted".
+
+    Get Thread answering 404 with an HTML error page is a gateway, proxy or
+    stale route between the adapter and AgentMail -- not the provider saying the
+    thread is gone. Classifying it as deletion writes a permanent receipt and no
+    later attempt ever consults the provider again, so one transient edge answer
+    silently destroys the reply on an otherwise healthy release.
+
+    The mutation this pins: drop the body check in `thread_carries` and the
+    first completion below answers 410, the receipt is written, `thread_calls`
+    stops at 1, and the recovery never sends.
+    """
+    seed(mail, adapter)
+    post_event(egress_url, update("answer one"))
+    mail.fail_next_thread = 404
+    mail.injected_raw_body = "<html><head><title>404 Not Found</title></head></html>"
+
+    assert post_event(egress_url, completed("ev-1"))[0] == 502
+    assert mail.replies == []
+
+    # No tombstone was written, so the retry asks the provider again and the
+    # completion still settles normally.
+    mail.injected_raw_body = None
+    assert post_event(egress_url, completed("ev-1"))[0] == 200
+    assert mail.thread_calls == 2
+    assert len(mail.replies) == 1
+
+
 def test_deleted_unadmitted_thread_does_not_create_a_terminal_receipt(
     mail: MailState,
     adapter: MailAdapter,


### PR DESCRIPTION
## Summary

`MailAdapter.thread_carries` treated **any** Get Thread 404 as provider deletion, and that decision is permanent: `delete_event` writes `deleted=1`, every later attempt short-circuits at `claim == "deleted"` and answers 410 without calling the provider again, and the worker dead-letters the completion. So a single 404 from an edge, gateway or stale route — not from AgentMail — silently destroyed the reply on an otherwise healthy release.

`request` parses a JSON body and hands back the raw text when the body is not JSON, so the provider's own answer is distinguishable from an intermediary's error page. Only a 404 carrying a JSON object is terminal now. Any other 404 is an unreadable witness and keeps the existing 502/retryable handling. This makes the code implement the invariant `apps/mail-adapter/CLAUDE.md:33` already stated: "a **confirmed** provider thread 404".

Closes #2461

Fix pin: apps/mail-adapter/tests/test_egress.py::test_a_404_without_a_provider_body_is_not_terminal

## Provenance

Found by the pre-merge `agent-router adversarial-review --primary codex` gate on #2441 (the fix for #2376). #2441 was merged before that review returned, so the finding lands here instead of in that PR. The terminal path #2441 added is otherwise unchanged.

## Verification

- `uv run pytest tests` in `apps/mail-adapter`: 143 passed, including the new test.
- Mutation proof: deleting the body check in `thread_carries` makes `test_a_404_without_a_provider_body_is_not_terminal` fail with `assert 410 == 502`, and the captured log shows the terminal receipt being written — the exact regression this pins.
- `uv run ruff check .` and `uv run mypy` from the repository root: clean, 247 source files.

## Tier decision

| Tier | Decision | Evidence |
| --- | --- | --- |
| skill | n/a | No plugin packaging, runner turn loop, ACI event, skill eval, or skill check change. |
| local | required, passed | Adapter HTTP classification changed; the mail-adapter suite drives the real adapter and egress server against the fake AgentMail HTTP server, including the new non-JSON 404 case. |
| local-release | n/a | No released identity, install path, version pin, or release-compose change. |
| cluster | n/a | No chart, RBAC, NetworkPolicy, sandbox claim, or init-container change. |
| live provider | n/a | No model routing, model credentials, token/cost accounting, MCP, workspace publication, or coding-tool capability change. |
| external integration | n/a | This narrows which provider responses are believed; it sends no mail and changes no AgentMail request. The behavior under test is a response shape AgentMail does not produce, so a live run could not exercise it. |

## Known residual, deliberately out of scope

A JSON 404 caused by the *inbox* being wrong or deleted would still read as thread deletion and would tombstone every owed reply. Discriminating that needs a second provider call to confirm the inbox and belongs in its own change with its own evidence. Recorded in #2461.
