### PR TITLE
docs: let concurrent jobs isolate their local verification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,8 +50,10 @@ Run these from the repo root unless noted. CI (`.github/workflows/ci.yaml`) runs
 the same commands.
 
 **Python (all packages, from root):**
-Run this local Python CI baseline. Do not use `--profile full` for startup
-because it can start stale application images.
+Run this local Python CI baseline. For concurrent jobs, first apply
+[Concurrent local verification](#concurrent-local-verification) below: this
+block is the default port reference, not a requirement to share its resources.
+Do not use `--profile full` for startup because it can start stale application images.
 Set `base=next` when your worktree targets `next`.
 
 ```bash
@@ -98,9 +100,89 @@ git fetch --force --tags origin refs/heads/main:refs/remotes/origin/main
 )
 ```
 
-Fixed host ports already in use are an environment occupancy blocker. Stop the
-existing owner before running this baseline. That does not mean the baseline is
-broken.
+Occupied default ports are a reason to isolate the job, not by themselves a
+failed precondition. Preserve the existing owner and follow the instructions
+below before deciding that local verification is blocked.
+
+### Concurrent local verification
+
+This applies to every local implementation job, including Bonus Drain. Agents
+are authorized to create disposable Compose overrides, endpoint files and test
+launchers inside their own worktree without asking permission. Keep them under
+the gitignored `.projects/` directory. Do not add infrastructure features to the
+product just to run a job. Direct Compose invocation for this disposable setup
+is an exception to the CLI entry point guidance in `CLAUDE.md`.
+
+1. Choose a unique Compose project for this execution, such as
+   `curie-check-<issue>-<run-suffix>`. Inventory running containers, published
+   ports and network ownership first. Use the same project, absolute base
+   Compose path and override files for config, startup, exec, logs and teardown.
+   A project name alone does not change published ports or explicitly named
+   networks.
+2. Generate a private override for every service you will start. Replace each
+   published port list with `ports: !override [...]`, binding to `127.0.0.1`.
+   This requires Compose 2.24.4 or later; see the
+   [Compose merge reference](https://docs.docker.com/reference/compose-file/merge/#replace-value).
+   Plain Compose list merging can retain the original occupied binding. Either
+   choose unused custom ports and retry allocation on a bind collision, or let
+   Docker allocate ports and discover them with `docker compose port` before
+   starting consumers. Do not assume an unused port probe reserves the port.
+   For example, this override replaces only the Postgres and Valkey bindings;
+   extend it to RustFS, Langfuse, ClickHouse, OTel, API, UI and any other enabled
+   service with published ports:
+
+   ```yaml
+   services:
+     postgres:
+       ports: !override ["127.0.0.1:35432:5432"]
+     valkey:
+       ports: !override ["127.0.0.1:36379:6379"]
+   networks:
+     curie_runner:
+       name: "${COMPOSE_PROJECT_NAME}_runner"
+   ```
+
+   These example ports must also be checked for occupancy. Inspect the resolved
+   `docker compose -p "$COMPOSE_PROJECT_NAME" -f compose.dev.yaml -f <override> config`
+   before startup; confirm that no enabled service retains a shared binding and
+   the runner network belongs to this project.
+3. Point every host consumer at the chosen endpoints. Inspect the actual test
+   fixtures and settings: common variables include `DATABASE_URL`,
+   `TEST_DATABASE_URL`, `VALKEY_HOST`, `VALKEY_PORT`, `TEST_VALKEY_PORT`,
+   `S3_ENDPOINT_URL`, `TEST_S3_ENDPOINT_URL`, `LANGFUSE_HOST`, `CURIE_API_URL`,
+   `CURIE_API_TARGET` and `PW_PORT`. Export only settings the consumer reads.
+   Bridge containers keep their internal service addresses. The host network
+   worker needs explicit override entries for its database, Valkey, S3, API
+   and worker OTel endpoints, plus `CURIE_DOCKER_NETWORK` matching the private
+   runner network. Shell exports do not replace literal Compose environment
+   entries. Use private image tags and staging paths when building or running
+   workers; preserve the worker's identical host/container staging mount path.
+4. Run the baseline checks above against these resources, replacing its project,
+   lock path, Compose invocations and health URL consistently. Keep all checks
+   and assertions. Record the resolved endpoints, candidate identity and exact
+   commands in the run evidence, without credential values. Check for hardcoded
+   endpoints before running each test or helper; environment variables do not
+   override literals. In particular, `scripts/check-released-upgrade.py` embeds
+   port 25432, and CLI local lifecycle, connector and ladder paths have shared
+   names or ports. Do not assume `COMPOSE_PROJECT_NAME` makes those paths private.
+5. If a required command cannot target private resources without changing its
+   behavior or assertions, run independent work first and reserve a bounded
+   exclusive verification window for that command. Use the shared baseline
+   lock for default port checks, recheck ownership after acquiring it, and never
+   stop another job's stack. Do not silently replace a required ladder with
+   focused tests, weaken a gate, or count a modified test as the original proof.
+   Only report an occupancy blocker after identifying the exact unredirectable
+   command and why neither isolation nor a bounded exclusive window is possible.
+6. Install cleanup before startup and remove only this execution's containers,
+   networks, volumes and spawned runners. Identify resources by the project
+   label and recorded container IDs, never a global `curie*` name sweep. On a
+   partial startup failure, clean the owned partial stack before reallocating.
+   Verify that owned resources are gone and other jobs remain running.
+
+Existing task contracts still govern scope and required evidence. A running job
+or older worktree does not automatically acquire newer instructions; read this
+section from the updated base when resuming. Do not edit a live claimed Bonus
+Drain task or launch a second copy to apply the guidance.
 
 **Rust CLI:**
 ```bash
@@ -171,8 +253,10 @@ RAM to leave the full stack idling, and this keeps happening: stacks get left
 running across sessions and starve the machine. Before you end a session in
 which you ran `curie local up` / `docker compose ... up`, run `curie local
 down` (or `docker compose -f compose.dev.yaml down`) and confirm with
-`docker ps` that nothing curie-related is still up. Also remove any stray
-`curie-runner*` containers a run may have spawned. The thread that brought the
+`docker ps` that none of this run's containers are still up. Use the same private
+project and overrides used for startup. Also remove stray runner containers this
+run spawned, identified by recorded IDs or ownership labels; preserve other
+jobs' containers. The thread that brought the
 stack up owns tearing it down — a blocked or crashed test agent never cleans up
 after itself, so do not assume someone else will.
 


### PR DESCRIPTION
## Summary

Concurrent jobs currently stop when another task owns the default Compose ports. Update AGENTS.md to authorize disposable worktree overrides, private projects and runner networks, explicit consumer endpoints, and cleanup limited to the owning run. Include a Compose port replacement example and require bounded exclusive verification for helpers that still hardcode ports, preserving all required checks.

## Related issue

No issue closed. Addresses the local environment blockers observed while attempting #1582, #2374 and #2375.

## End-to-end verification

This change does not alter product runtime behavior: only contributor execution instructions change. No CLI, Compose source, tests or scheduler code changes.

Scoped verification:
- `bash scripts/check-docs.sh`: passed with no generated drift.
- `git diff --check`: passed.
- Executed `docker compose --profile full -p curie-check-example-proof -f compose.dev.yaml -f <extracted-example> config --format json` against the documented YAML: Postgres and Valkey each retained only their replacement loopback binding, and the runner network resolved to the private project name.
- Negative control: removing `!override` retained the original conflicting bindings, confirming why plain list merging is insufficient.
- No stack was started. Concurrent runtime execution is not claimed by this documentation check.

## Checklist

- [x] Tests pass for the area touched: documentation gate and Compose example rendering.
- [x] Agent execution guidance and cleanup instructions updated together.
- [x] ADR not applicable: this documents reversible contributor setup using existing Docker capabilities.
