### PR TITLE
Build the macOS release target on main CI, and gate release-target parity

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -446,6 +446,62 @@ jobs:
           path: cli/target/aarch64-unknown-linux-gnu/release/curie
           if-no-files-found: error
 
+  cli-darwin:
+    name: CLI builds for macOS (the fourth release target)
+    runs-on: macos-latest
+    # `aarch64-apple-darwin` ships in the release matrix (release.yaml) and was
+    # compiled for the FIRST TIME when a tag was pushed. Anything that breaks it
+    # -- a dependency that does not build on macOS, a `cfg(unix)` assumption that
+    # is really a Linux assumption, a crate needing a Linux-only system library
+    # -- surfaced inside the release run, with `fail-fast: false` leaving a
+    # partial asset set behind an already-pushed tag (#2458).
+    #
+    # This is the same hole `cli-portability` closes for the two Linux targets,
+    # and it stays a SEPARATE job: that one must remain on `ubuntu-latest`
+    # because its whole point is running the artifact on an old-glibc Linux
+    # image. macOS runner minutes bill at a multiple of Linux, so this job does
+    # the build and nothing else.
+    #
+    # `macos-latest` is arm64, so this is a NATIVE build: no zig, no
+    # cargo-zigbuild, no glibc floor, no cross toolchain. It is the same path a
+    # tag takes for this target (release.yaml's non-`glibc` branch).
+    defaults:
+      run:
+        working-directory: cli
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Cargo cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: cli
+      - name: Add target
+        run: rustup target add aarch64-apple-darwin
+      - name: Build (same path as the release)
+        env:
+          CURIE_BUILD_CHANNEL: release
+        run: cargo build --release --target aarch64-apple-darwin
+      # The release strips this target with the external tool rather than at
+      # link time, because only the cross targets carry `-C strip=symbols`.
+      # `|| true` matches release.yaml: an unstrippable binary is still
+      # shippable, and the release must not fail over symbol size.
+      - name: Strip
+        run: strip target/aarch64-apple-darwin/release/curie || true
+      # Named like the per-commit Linux binaries above and like the release
+      # assets, so an unreleased macOS fix can be installed without a local
+      # Rust toolchain:
+      #
+      #   gh run download <run-id> -R curie-eng/curie \
+      #     -n curie-aarch64-apple-darwin-<sha>
+      #   chmod +x curie && sudo install -m 0755 curie /usr/local/bin/curie
+      - name: Publish the per-commit macOS binary
+        uses: actions/upload-artifact@v7
+        with:
+          name: curie-aarch64-apple-darwin-${{ github.sha }}
+          path: cli/target/aarch64-apple-darwin/release/curie
+          if-no-files-found: error
+
   contracts-ts:
     name: Contracts (generated TypeScript compiles)
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,6 +182,7 @@ testpaths = [
     "tools/e2e-ci-selection/tests",
     "tools/sdk-lock-gate/tests",
     "tools/p0-closes-ci/tests",
+    "tools/ci-release-target-parity/tests",
 ]
 
 [tool.ruff]

--- a/tools/ci-release-target-parity/tests/test_release_target_parity.py
+++ b/tools/ci-release-target-parity/tests/test_release_target_parity.py
@@ -72,18 +72,27 @@ def _commands(run: str) -> Iterator[str]:
 
 
 def _release_cli_targets() -> set[str]:
+    """The Rust targets `release.yaml` publishes, from `cli-binaries` and only there.
+
+    Reading every job's matrix instead would look more thorough and is wrong:
+    `target:` is also buildx vocabulary for a build STAGE, so the day someone
+    writes `- target: runtime` under the image `build` matrix this gate would
+    demand `cargo build --target runtime` and red main until somebody worked out
+    why. A rename is the case worth catching, and the assertion below catches it
+    loudly.
+    """
     jobs = _workflow("release.yaml")["jobs"]
     assert "cli-binaries" in jobs, (
         "release.yaml has no cli-binaries job. Either it was renamed -- update this gate with it "
         "-- or this gate is reading the wrong workflow."
     )
-    targets: set[str] = set()
-    for job in jobs.values():
-        matrix = (job.get("strategy") or {}).get("matrix") or {}
-        for entry in matrix.get("include") or []:
-            if isinstance(entry, dict) and entry.get("target"):
-                targets.add(entry["target"])
-    assert targets, "release.yaml publishes no CLI target; this gate is reading the wrong job"
+    matrix = (jobs["cli-binaries"].get("strategy") or {}).get("matrix") or {}
+    targets = {
+        entry["target"]
+        for entry in matrix.get("include") or []
+        if isinstance(entry, dict) and entry.get("target")
+    }
+    assert targets, "cli-binaries publishes no target; this gate is reading the wrong job"
     return targets
 
 
@@ -103,7 +112,7 @@ def _unbuilt(ci: dict[str, Any]) -> list[str]:
 def test_every_released_cli_target_is_built_by_main_ci() -> None:
     missing = _unbuilt(_workflow("ci.yaml"))
     assert not missing, (
-        f"{missing} ship in release.yaml's build matrices but no ci.yaml step builds them. "
+        f"{missing} ship in release.yaml's cli-binaries matrix but no ci.yaml step builds them. "
         "A target compiled for the first time at tag time has no pre-release signal, and a break "
         "in it fails the release run with the tag already pushed (#2458, #1341). Add a ci.yaml "
         "job that builds it the same way a tag does."

--- a/tools/ci-release-target-parity/tests/test_release_target_parity.py
+++ b/tools/ci-release-target-parity/tests/test_release_target_parity.py
@@ -1,0 +1,88 @@
+"""Release-target parity gate over the real GitHub Actions workflows (issue #2458).
+
+The rule this file encodes: every Rust target `release.yaml` publishes must also
+be BUILT by `ci.yaml` on ordinary pushes and pull requests. A target compiled for
+the first time when a tag is pushed has no signal before the release, and
+`fail-fast: false` then leaves a partial asset set behind a tag that is already
+pushed and cannot be taken back.
+
+Issue #2458 is the instance: `aarch64-apple-darwin` shipped in the release matrix
+from the start while `ci.yaml` added only the two Linux targets, so a macOS build
+break was undiscoverable until a release run hit it. Issue #1341 is the same shape
+one layer down -- the cross-compile PATH was never exercised before a tag -- and
+`cli-portability` was added to close it for Linux; this gate is what stops the
+next target from being added to the release matrix alone.
+
+The gate parses `.github/workflows/*.yaml` directly. There are no fixtures and no
+mocks: the whole value of it is that it reads what CI actually runs.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+WORKFLOWS = Path(__file__).resolve().parents[3] / ".github" / "workflows"
+
+# `cargo zigbuild` takes the glibc floor as a SUFFIX on the triple
+# (`x86_64-unknown-linux-gnu.2.28`), and cargo-zigbuild strips it again for the
+# output directory. Match the triple and let any floor follow it, so pinning a
+# different floor is not mistaken for dropping the target.
+_TARGET_FLAG = re.compile(
+    r"""--target[= ]+['"]?([A-Za-z0-9_]+-[A-Za-z0-9_.-]+?)(?:\.\d+\.\d+)?['"]?(?:\s|$)"""
+)
+
+
+def _workflow(name: str) -> dict[str, Any]:
+    return yaml.safe_load((WORKFLOWS / name).read_text())
+
+
+def _run_steps(workflow: dict[str, Any]) -> list[str]:
+    commands: list[str] = []
+    for job in workflow.get("jobs", {}).values():
+        for step in job.get("steps") or []:
+            run = step.get("run")
+            if isinstance(run, str):
+                commands.append(run)
+    return commands
+
+
+def _release_cli_targets() -> set[str]:
+    jobs = _workflow("release.yaml")["jobs"]
+    include = jobs["cli-binaries"]["strategy"]["matrix"]["include"]
+    targets = {entry["target"] for entry in include}
+    assert targets, "release.yaml publishes no CLI target; this gate is reading the wrong job"
+    return targets
+
+
+def _ci_built_targets() -> set[str]:
+    built: set[str] = set()
+    for command in _run_steps(_workflow("ci.yaml")):
+        built.update(_TARGET_FLAG.findall(command))
+    return built
+
+
+def test_every_released_cli_target_is_built_by_main_ci() -> None:
+    missing = sorted(_release_cli_targets() - _ci_built_targets())
+    assert not missing, (
+        f"{missing} ship in release.yaml's cli-binaries matrix but no ci.yaml step builds them. "
+        "A target compiled for the first time at tag time has no pre-release signal, and a break "
+        "in it fails the release run with the tag already pushed (#2458, #1341). Add a ci.yaml "
+        "job that builds it the same way a tag does."
+    )
+
+
+def test_the_parity_gate_can_fail() -> None:
+    """A gate that cannot fail is not a gate: prove the matcher discriminates."""
+    assert _TARGET_FLAG.findall("cargo build --release --target aarch64-apple-darwin") == [
+        "aarch64-apple-darwin"
+    ]
+    # The glibc floor is a suffix, not a different target.
+    assert _TARGET_FLAG.findall(
+        "cargo zigbuild --release --target x86_64-unknown-linux-gnu.2.28"
+    ) == ["x86_64-unknown-linux-gnu"]
+    assert _TARGET_FLAG.findall("cargo build --release") == []
+    assert "aarch64-apple-darwin" not in _ci_built_targets() - {"aarch64-apple-darwin"}

--- a/tools/ci-release-target-parity/tests/test_release_target_parity.py
+++ b/tools/ci-release-target-parity/tests/test_release_target_parity.py
@@ -14,12 +14,15 @@ one layer down -- the cross-compile PATH was never exercised before a tag -- and
 next target from being added to the release matrix alone.
 
 The gate parses `.github/workflows/*.yaml` directly. There are no fixtures and no
-mocks: the whole value of it is that it reads what CI actually runs.
+mocks: the whole value of it is that it reads what CI actually runs. Its negative
+control doctors a copy of the real `ci.yaml` and drives the same assertion the
+real check uses, rather than testing the matcher in isolation.
 """
 
 from __future__ import annotations
 
 import re
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
@@ -27,11 +30,17 @@ import yaml
 
 WORKFLOWS = Path(__file__).resolve().parents[3] / ".github" / "workflows"
 
+# A target only counts when a cargo BUILD command names it. Mentioning a triple
+# is not building it: `rustup target add` installs the std rlibs, `echo` and a
+# commented-out line say nothing at all, and a gate that counted those would go
+# green on a job whose build step had been commented out.
+_BUILD = re.compile(r"\bcargo\s+(?:\+\S+\s+)?(?:build|zigbuild)\b")
+
 # `cargo zigbuild` takes the glibc floor as a SUFFIX on the triple
 # (`x86_64-unknown-linux-gnu.2.28`), and cargo-zigbuild strips it again for the
 # output directory. Match the triple and let any floor follow it, so pinning a
 # different floor is not mistaken for dropping the target.
-_TARGET_FLAG = re.compile(
+_TARGET = re.compile(
     r"""--target[= ]+['"]?([A-Za-z0-9_]+-[A-Za-z0-9_.-]+?)(?:\.\d+\.\d+)?['"]?(?:\s|$)"""
 )
 
@@ -40,49 +49,98 @@ def _workflow(name: str) -> dict[str, Any]:
     return yaml.safe_load((WORKFLOWS / name).read_text())
 
 
-def _run_steps(workflow: dict[str, Any]) -> list[str]:
-    commands: list[str] = []
+def _run_steps(workflow: dict[str, Any]) -> Iterator[str]:
     for job in workflow.get("jobs", {}).values():
         for step in job.get("steps") or []:
             run = step.get("run")
             if isinstance(run, str):
-                commands.append(run)
-    return commands
+                yield run
+
+
+def _commands(run: str) -> Iterator[str]:
+    """The executable lines of one `run:` block.
+
+    Backslash continuations are joined first, so a build split across lines is
+    still one command. Whole-line comments are then dropped: a build step that
+    has been commented out must read as absent, which is the case that made the
+    first version of this gate pass on a workflow that built nothing.
+    """
+    for line in re.sub(r"\\\n", " ", run).splitlines():
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#"):
+            yield stripped
 
 
 def _release_cli_targets() -> set[str]:
     jobs = _workflow("release.yaml")["jobs"]
-    include = jobs["cli-binaries"]["strategy"]["matrix"]["include"]
-    targets = {entry["target"] for entry in include}
+    assert "cli-binaries" in jobs, (
+        "release.yaml has no cli-binaries job. Either it was renamed -- update this gate with it "
+        "-- or this gate is reading the wrong workflow."
+    )
+    targets: set[str] = set()
+    for job in jobs.values():
+        matrix = (job.get("strategy") or {}).get("matrix") or {}
+        for entry in matrix.get("include") or []:
+            if isinstance(entry, dict) and entry.get("target"):
+                targets.add(entry["target"])
     assert targets, "release.yaml publishes no CLI target; this gate is reading the wrong job"
     return targets
 
 
-def _ci_built_targets() -> set[str]:
+def _built_targets(workflow: dict[str, Any]) -> set[str]:
     built: set[str] = set()
-    for command in _run_steps(_workflow("ci.yaml")):
-        built.update(_TARGET_FLAG.findall(command))
+    for run in _run_steps(workflow):
+        for command in _commands(run):
+            if _BUILD.search(command):
+                built.update(_TARGET.findall(command))
     return built
 
 
+def _unbuilt(ci: dict[str, Any]) -> list[str]:
+    return sorted(_release_cli_targets() - _built_targets(ci))
+
+
 def test_every_released_cli_target_is_built_by_main_ci() -> None:
-    missing = sorted(_release_cli_targets() - _ci_built_targets())
+    missing = _unbuilt(_workflow("ci.yaml"))
     assert not missing, (
-        f"{missing} ship in release.yaml's cli-binaries matrix but no ci.yaml step builds them. "
+        f"{missing} ship in release.yaml's build matrices but no ci.yaml step builds them. "
         "A target compiled for the first time at tag time has no pre-release signal, and a break "
         "in it fails the release run with the tag already pushed (#2458, #1341). Add a ci.yaml "
         "job that builds it the same way a tag does."
     )
 
 
-def test_the_parity_gate_can_fail() -> None:
-    """A gate that cannot fail is not a gate: prove the matcher discriminates."""
-    assert _TARGET_FLAG.findall("cargo build --release --target aarch64-apple-darwin") == [
+def test_the_gate_rejects_a_build_that_was_commented_out() -> None:
+    """The negative control, driven through the real assertion.
+
+    A gate that cannot fail is not a gate, and the failure that matters is the
+    realistic one: the job is still there, its build line is not.
+    """
+    raw = (WORKFLOWS / "ci.yaml").read_text()
+    build = "run: cargo build --release --target aarch64-apple-darwin"
+    assert raw.count(build) == 1, "the darwin build step moved; update this control"
+    doctored = yaml.safe_load(raw.replace(build, f'run: "# {build.removeprefix("run: ")}"'))
+
+    assert _unbuilt(doctored) == ["aarch64-apple-darwin"]
+
+
+def test_naming_a_target_is_not_building_it() -> None:
+    def ci(command: str) -> dict[str, Any]:
+        return {"jobs": {"a-job": {"steps": [{"run": command}]}}}
+
+    # Installing the std rlibs for a target is a prerequisite of building it, not
+    # the build. `cli-portability` really does add both Linux targets this way.
+    assert _built_targets(
+        ci("rustup target add x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu")
+    ) == set()
+    assert _built_targets(ci("echo --target aarch64-apple-darwin")) == set()
+    assert _built_targets(ci("cargo build --release --target aarch64-apple-darwin")) == {
         "aarch64-apple-darwin"
-    ]
+    }
     # The glibc floor is a suffix, not a different target.
-    assert _TARGET_FLAG.findall(
-        "cargo zigbuild --release --target x86_64-unknown-linux-gnu.2.28"
-    ) == ["x86_64-unknown-linux-gnu"]
-    assert _TARGET_FLAG.findall("cargo build --release") == []
-    assert "aarch64-apple-darwin" not in _ci_built_targets() - {"aarch64-apple-darwin"}
+    floored = ci("cargo zigbuild --release --target x86_64-unknown-linux-gnu.2.28")
+    assert _built_targets(floored) == {"x86_64-unknown-linux-gnu"}
+    # A build split across lines is still one build.
+    assert _built_targets(ci("cargo build --release \\\n  --target aarch64-apple-darwin")) == {
+        "aarch64-apple-darwin"
+    }


### PR DESCRIPTION
## Summary

`aarch64-apple-darwin` ships in `release.yaml`'s `cli-binaries` matrix and was compiled for the **first time when a tag was pushed**. Anything that breaks it — a dependency that does not build on macOS, a `cfg(unix)` assumption that is really a Linux assumption, a crate needing a Linux-only system library — surfaced inside the release run, with `fail-fast: false` leaving a partial asset set behind a tag that is already pushed. macOS is also the platform most people install the CLI on.

`cli-darwin` builds it the same way a tag does and publishes the per-commit binary, named like the Linux ones so the same `gh run download` recipe works.

Closes #2458

Fix pin: n/a - the defect is the absence of a build job in GitHub Actions, which no test under the gate's supported roots (apps/, packages/, runner/, cli/tests/, charts/curie/ci/) can execute. The change IS pinned, by tools/ci-release-target-parity/tests/test_release_target_parity.py::test_every_released_cli_target_is_built_by_main_ci -- see the mutation table below -- but tools/ is outside the selector grammar.

## Why a separate job, and what it costs

`cli-portability` must stay on `ubuntu-latest` — its whole point is running the built artifact on an old-glibc Linux image — so this cannot fold into it. `macos-latest` is arm64, which makes `aarch64-apple-darwin` a **native** build there: no zig, no `cargo-zigbuild`, no glibc floor, no cross toolchain. macOS runner minutes bill at a multiple of Linux, so the job does the build, the strip and the upload, and nothing else. It is not added to the branch ruleset's required checks; like `rust-build`, it is a signal, and promoting it is a separate decision.

This is the same hole `cli-portability` was created to close for Linux (#1341: "the release cross-compile path was never exercised before a tag, so a regression in it was undiscoverable until someone tried the artifact on a real host").

## The gate

A CI job alone fixes today's instance; the parity test is what stops the next target being added to the release matrix alone. It parses the real workflow files — like the retry-eligibility and workspace-path gates beside it in `tools/` — and asserts every target in `release.yaml`'s `cli-binaries` matrix is built by some `ci.yaml` step. The glibc floor is matched as a suffix on the triple, so re-pinning a floor is not mistaken for dropping a target. It carries its own negative control, because a gate that cannot fail is not a gate.

## Verification

- `uv run pytest tools/ci-release-target-parity/tests`: 3 passed.
- `uv run pytest tools/ci-workflow-paths/tests tools/ci-retry-gate/tests tools/e2e-ci-selection/tests`: 175 passed.
- Mutation table — `_unbuilt()` against doctored copies of the real `ci.yaml`:

  | Mutation | Result |
  | --- | --- |
  | `cli-darwin` job deleted | `['aarch64-apple-darwin']` — fails |
  | build step removed, job kept | `['aarch64-apple-darwin']` — fails |
  | build line `#`-commented inside the `run:` block | `['aarch64-apple-darwin']` — fails |

  The third row is why the second commit exists: the first version of the gate matched `--target <triple>` anywhere in a `run:` block, so a commented-out build — and `rustup target add aarch64-apple-darwin` on its own — kept it green. A gate that passes on the exact edit it exists to catch is worse than none.
- `uv run ruff check .` and `uv run mypy` from the repository root: clean.
- The `cli-darwin` job itself runs for the first time on this PR; its result is the direct evidence that the target still builds.

## Rulings recorded from the scope review

The scope-creep reviewer raised three items. One is fixed; two are **intentionally bundled**, recorded here so the next reader does not re-raise them.

**Fixed: `_release_cli_targets` read every release job's matrix.** It now reads `cli-binaries` and only that. The wide read was meant to stop a second CLI matrix being added and silently ignored; it bought a hypothetical and cost a real failure, because `target:` is also buildx vocabulary for a build *stage* — the day someone writes `- target: runtime` under the image `build` matrix, the wide gate would demand `cargo build --target runtime` and red main. The rename case is still caught loudly by the `cli-binaries` assertion.

**Intentionally bundled: the parity gate itself.** No AC asks for it, and it could be its own ticket. It stays here because splitting means the `cli-darwin` job merges guarded by nothing, and this issue *is* the second occurrence of exactly that pattern — #1341 was a build path that existed and quietly stopped being exercised, and the fix then was a job with no gate behind it. A follow-up ticket for the guard is the shape most likely never to land. Note the `Fix pin: n/a` above is a statement about the gate's selector grammar not accepting `tools/`, not about whether a regression guard is warranted here.

**Intentionally bundled: `test_naming_a_target_is_not_building_it`.** It is the matcher's negative control, required by the adversarial review that found the commented-out-build hole. Its Linux and zigbuild assertions are there to prove the matcher does not produce *false* failures against the existing `ci.yaml`, not to extend coverage to those targets.

**Not changed: `Swatinem/rust-cache` in the new job.** The reviewer flagged it as the one step making the job not literally the tag path, since `release.yaml` has no cache. The repo's own precedent settles it: `cli-portability` — the job that exists precisely to run the tag's cross-compile path before a tag — also caches (`ci.yaml:378-381`), as does every other Rust job here. Dropping it would cost macOS runner minutes on every PR, which is the constraint the issue itself raises.

## Known gate limitations, recorded

The gate models workflow *steps*, not job execution. Two edits leave it green while the hole reopens: adding `if: false` (or a `needs:` on a change-detection job) to `cli-darwin`, and deleting the Strip or upload steps while keeping the build. Closing those means modelling job reachability, which is a larger gate than this issue warrants; recorded here so the next reader does not assume coverage it does not have.

## Tier decision

| Tier | Decision | Evidence |
| --- | --- | --- |
| skill | n/a | No plugin packaging, runner turn loop, ACI event, skill eval, or skill check change. |
| local | n/a | No product source changed; the only executable addition is a gate over the workflow files, run by pytest above. |
| local-release | n/a | `release.yaml` is unchanged and no released identity, install path or version pin moves. |
| cluster | n/a | No chart, RBAC, NetworkPolicy, sandbox claim, or init-container change. |
| live provider | n/a | No model routing, credentials, token/cost accounting, MCP, workspace publication, or coding-tool capability change. |
| external integration | n/a | No provider request changes. |


