### PR TITLE
feat(api): make readiness depend on PostgreSQL

### DIFF
--- a/apps/api/openapi.json
+++ b/apps/api/openapi.json
@@ -10197,6 +10197,34 @@
         ]
       }
     },
+    "/ready": {
+      "get": {
+        "operationId": "ready_ready_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "title": "Response Ready Ready Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "503": {
+            "description": "Database is unavailable"
+          }
+        },
+        "summary": "Ready",
+        "tags": [
+          "health"
+        ]
+      }
+    },
     "/v1/internal/cluster-message-replies/{reply_ref}": {
       "post": {
         "operationId": "append_cluster_message_reply_v1_internal_cluster_message_replies__reply_ref__post",

--- a/apps/api/src/curie_api/main.py
+++ b/apps/api/src/curie_api/main.py
@@ -22,8 +22,9 @@ from curie_telemetry import (
     operation_span,
     record_metric,
 )
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, HTTPException, Request
 from opentelemetry.trace import SpanKind, StatusCode
+from sqlalchemy import text
 from starlette.routing import Match
 
 from . import __version__
@@ -322,6 +323,23 @@ def create_app() -> FastAPI:
 
     @app.get("/health", tags=["health"])
     async def health() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.get(
+        "/ready",
+        tags=["health"],
+        responses={503: {"description": "Database is unavailable"}},
+    )
+    async def ready(request: Request) -> dict[str, str]:
+        try:
+            async with asyncio.timeout(2):
+                async with request.app.state.sessionmaker() as session:
+                    await session.execute(text("SELECT 1"))
+        except Exception:
+            raise HTTPException(
+                status_code=503,
+                detail="Database is unavailable",
+            ) from None
         return {"status": "ok"}
 
     app.include_router(config.router)

--- a/apps/api/tests/test_auth.py
+++ b/apps/api/tests/test_auth.py
@@ -1,16 +1,96 @@
-"""Auth and health-endpoint behavior."""
+"""Auth, health-endpoint, and readiness-endpoint behavior."""
 
+import time
 import uuid
 from typing import Any
 
 from curie_api.config import get_settings
 from curie_api.sandbox_token import mint
+from sqlalchemy import text
+from sqlalchemy.engine import make_url
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+DATABASE_UNAVAILABLE = {"detail": "Database is unavailable"}
 
 
 def test_health_is_open(client: Any) -> None:
     resp = client.get("/health")
     assert resp.status_code == 200
     assert resp.json() == {"status": "ok"}
+
+
+def test_ready_is_open_and_checks_the_real_database(client: Any) -> None:
+    resp = client.get("/ready")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+
+
+def test_ready_sanitizes_an_unavailable_database_and_health_stays_open(
+    client: Any,
+) -> None:
+    failed_url = make_url(get_settings().database_url).set(
+        host="127.0.0.1",
+        port=1,
+    )
+    engine = create_async_engine(failed_url)
+    failed_sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
+    original_sessionmaker = client.app.state.sessionmaker
+    try:
+        client.app.state.sessionmaker = failed_sessionmaker
+
+        ready = client.get("/ready")
+        assert ready.status_code == 503
+        assert ready.json() == DATABASE_UNAVAILABLE
+        assert "connection" not in ready.text.lower()
+        assert "127.0.0.1" not in ready.text
+        assert failed_url.render_as_string(hide_password=False) not in ready.text
+
+        health = client.get("/health")
+        assert health.status_code == 200
+        assert health.json() == {"status": "ok"}
+    finally:
+        client.app.state.sessionmaker = original_sessionmaker
+        client.portal.call(engine.dispose)
+
+
+def test_ready_times_out_before_the_probe_when_the_real_pool_is_exhausted(
+    client: Any,
+) -> None:
+    engine = create_async_engine(
+        get_settings().database_url,
+        pool_size=1,
+        max_overflow=0,
+        pool_timeout=4,
+    )
+    constrained_sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
+    original_sessionmaker = client.app.state.sessionmaker
+    held_connection: Any | None = None
+    try:
+        held_connection = client.portal.call(engine.connect)
+        client.app.state.sessionmaker = constrained_sessionmaker
+
+        started = time.monotonic()
+        ready = client.get("/ready")
+        elapsed = time.monotonic() - started
+
+        assert ready.status_code == 503
+        assert ready.json() == DATABASE_UNAVAILABLE
+        assert 1.75 <= elapsed < 3.0
+        assert (
+            client.portal.call(held_connection.execute, text("SELECT 1")).scalar_one()
+            == 1
+        )
+
+        client.portal.call(held_connection.close)
+        held_connection = None
+        recovered = client.get("/ready")
+        assert recovered.status_code == 200
+        assert recovered.json() == {"status": "ok"}
+    finally:
+        client.app.state.sessionmaker = original_sessionmaker
+        if held_connection is not None:
+            client.portal.call(held_connection.close)
+        client.portal.call(engine.dispose)
 
 
 def test_agents_require_api_key(client: Any) -> None:

--- a/apps/api/tests/test_channels.py
+++ b/apps/api/tests/test_channels.py
@@ -1102,17 +1102,23 @@ def _other_routes() -> list[tuple[str, str]]:
     anyone remembering to extend a list.
 
     The exclusions are the routes that carry no platform-key dependency at
-    all: `/health` and `/config` are deliberately open (the UI reads config
-    before it has a key), `/github/webhook` authenticates by GitHub's HMAC
-    signature, and `POST /console/session` authenticates on the login code in
-    its body (ADR-0083), never on a header credential. Excluded rather than
+    all: `/health`, `/ready`, and `/config` are deliberately open (the UI reads
+    config before it has a key), `/github/webhook` authenticates by GitHub's
+    HMAC signature, and `POST /console/session` authenticates on the login code
+    in its body (ADR-0083), never on a header credential. Excluded rather than
     asserted, because each would answer for a reason that has nothing to do with
     this token. `POST /console/login-codes` is NOT excluded: it does carry the
     platform-key dependency, so the sweep still asserts it refuses a `chn`
     token.
     """
 
-    open_paths = {"/health", "/config", "/github/webhook", "/console/session"}
+    open_paths = {
+        "/health",
+        "/ready",
+        "/config",
+        "/github/webhook",
+        "/console/session",
+    }
     routes: list[tuple[str, str]] = []
     for route in _walk(create_app().routes):
         if route.path.startswith("/channels") or route.path in open_paths:

--- a/charts/curie/CLAUDE.md
+++ b/charts/curie/CLAUDE.md
@@ -110,7 +110,8 @@ component and rail detail in `charts/curie/README.md`.
   detection of that rides on the **readiness** probe instead, which does
   exercise the event loop and the stores, and flips `Deployment.Available`.
   The chart's other first-party liveness probes are likewise process-local
-  rather than store-probing: `api.yaml`'s `/health` does no store I/O,
+  rather than store-probing: `api.yaml` uses database aware `/ready` for
+  readiness while its liveness `/health` does no store I/O,
   `mail-adapter.yaml` documents `/healthz` as a static liveness signal while
   `/readyz` alone waits on SQLite, `inference.yaml` uses `tcpSocket`, and
   `worker.yaml`/`dispatcher.yaml` use the heartbeat-file check

--- a/charts/curie/ci/probe-window-assertions.sh
+++ b/charts/curie/ci/probe-window-assertions.sh
@@ -16,7 +16,7 @@
 #   * langfuse-web / langfuse-worker running Prisma and ClickHouse boot
 #     migrations at container start (init containers do NOT re-run on a liveness
 #     restart, so the restart lands straight back in the migration),
-#   * api warming up before `/health` answers.
+#   * api waiting for its database-aware `/ready` check to succeed.
 #
 # The failure is invisible in review and invisible at install time: the manifest
 # is valid, `helm install` is green, and the damage shows up minutes later as a
@@ -37,16 +37,17 @@
 #   api             120 s vs 105 s
 #
 # WHAT THIS PINS. Deliberately the CLASS, not those four names. This script
-# walks every object carrying a pod spec in both renders -- Deployment,
+# walks every object carrying a pod spec in all three renders -- Deployment,
 # StatefulSet, DaemonSet, Job, and CronJob's spec.template.spec; a bare Pod's
 # own spec (templates/security-probe.yaml); SandboxTemplate's
 # spec.podTemplate.spec (templates/agent-sandbox.yaml); and, generically, any
 # other kind exposing the conventional spec.template.spec shape -- and checks
 # every container that has both probes, so a fifth violating container added
-# later fails CI with no list here to update -- the lesson
+# later fails CI with no cadence allowlist to update -- the lesson
 # `charts/curie/CLAUDE.md` already records for the `curie.env.otel` membership
-# boundary (#2331). There is no allowlist and no named-container table below
-# on purpose.
+# boundary (#2331). The only named set below requires the four first-party app
+# Deployments to be present in the dispatcher-enabled audit; it does not exempt
+# any container from the generic probe checks.
 #
 # THE FORMULA, matching the chart's own precedent at `templates/dispatcher.yaml`
 # lines 3-9:
@@ -70,10 +71,10 @@
 # NOT CHECKED, deliberately: containers carrying only one probe (the invariant
 # is a relation BETWEEN two probes -- `agentSandbox.runner` has readiness and no
 # liveness by design), and `startupProbe`, which defers readiness and liveness
-# equally and so leaves the comparison unchanged. Containers behind a
-# `deploy: false` toggle (`dispatcher`, `mail-adapter`, `inference`) render in
-# neither of the two renders below and are therefore outside this script's
-# reach; widening to profiled renders is a follow-up.
+# equally and so leaves the comparison unchanged. A synthetic third render
+# enables the dispatcher so the API, worker, dispatcher, and UI app shapes are
+# audited together; opt-in mail-adapter and inference remain outside this
+# script's reach.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -88,6 +89,12 @@ if ! helm template curie "$CHART" >"$TMP/default.yaml"; then
 fi
 if ! helm template curie "$CHART" -f "$CHART/values-dev.yaml" >"$TMP/dev.yaml"; then
   fail "values-dev.yaml render failed"
+fi
+if ! helm template curie "$CHART" \
+  --set-string dispatcher.slack.appToken=xapp-assert \
+  --set-string dispatcher.slack.botToken=xoxb-assert \
+  >"$TMP/dispatcher-enabled.yaml"; then
+  fail "dispatcher-enabled render failed"
 fi
 
 # ------------------------------------------------------------------ the checker
@@ -113,6 +120,7 @@ FORMULA = (
     "applied to omitted keys"
 )
 POD_TEMPLATE_KINDS = ("Deployment", "StatefulSet", "DaemonSet", "Job")
+FIRST_PARTY_DEPLOYMENTS = {"api", "worker", "dispatcher", "ui"}
 
 problems = []
 
@@ -142,6 +150,13 @@ def cadence_str(c):
         f"{c['initialDelaySeconds']}/{c['periodSeconds']}/"
         f"{c['timeoutSeconds']}/{c['failureThreshold']}"
     )
+
+
+def http_target(probe):
+    handler = probe.get("httpGet") if isinstance(probe, dict) else None
+    if not isinstance(handler, dict):
+        return None, None
+    return handler.get("path"), handler.get("port")
 
 
 def pod_templates(doc):
@@ -184,6 +199,7 @@ if __name__ == "__main__":
 
     checked = 0
     liveness_seen = 0
+    first_party_seen = set()
     for doc in docs:
         for kind, name, template in pod_templates(doc):
             spec = template.get("spec") or {}
@@ -197,6 +213,23 @@ if __name__ == "__main__":
                 where = f"{kind}/{name} container={cname}"
                 readiness = container.get("readinessProbe")
                 liveness = container.get("livenessProbe")
+
+                if kind == "Deployment" and cname in FIRST_PARTY_DEPLOYMENTS:
+                    first_party_seen.add(cname)
+
+                if kind == "Deployment" and cname == "api":
+                    ready_path, ready_port = http_target(readiness)
+                    if (ready_path, ready_port) != ("/ready", 8000):
+                        problems.append(
+                            f"[{label}] {where}: api readinessProbe httpGet must target "
+                            f"/ready:8000, got {ready_path}:{ready_port}"
+                        )
+                    live_path, live_port = http_target(liveness)
+                    if (live_path, live_port) != ("/health", 8000):
+                        problems.append(
+                            f"[{label}] {where}: api livenessProbe httpGet must target "
+                            f"/health:8000, got {live_path}:{live_port}"
+                        )
 
                 if isinstance(liveness, dict):
                     liveness_seen += 1
@@ -248,6 +281,19 @@ if __name__ == "__main__":
                     f"legitimately booting, and the restart re-enters the same boot path"
                 )
 
+    if label == "dispatcher-enabled":
+        missing = sorted(FIRST_PARTY_DEPLOYMENTS - first_party_seen)
+        if missing:
+            problems.append(
+                f"[{label}] first-party Deployment audit is incomplete; missing "
+                + ", ".join(missing)
+            )
+        else:
+            print(
+                "  dispatcher-enabled: api, worker, dispatcher, and ui Deployments "
+                "were all present"
+            )
+
     print(
         f"  {label}: {checked} container(s) carry both probes and were checked for "
         f"ordering; {liveness_seen} livenessProbe(s) checked for an explicit timeoutSeconds"
@@ -262,6 +308,7 @@ PY
 
 python3 "$TMP/check.py" "$TMP/default.yaml" "default"
 python3 "$TMP/check.py" "$TMP/dev.yaml" "values-dev"
+python3 "$TMP/check.py" "$TMP/dispatcher-enabled.yaml" "dispatcher-enabled"
 
 # --------------------------------------------------------------- red controls
 # Each control mutates a REAL default render and proves the checker rejects it
@@ -311,6 +358,12 @@ if mutation == "web-liveness-kubelet-defaults":
 elif mutation == "api-drop-liveness-timeout":
     for c in find("api", "livenessProbe"):
         c["livenessProbe"].pop("timeoutSeconds", None)
+elif mutation == "api-readiness-health":
+    for c in find("api", "readinessProbe"):
+        c["readinessProbe"]["httpGet"]["path"] = "/health"
+elif mutation == "api-liveness-ready":
+    for c in find("api", "livenessProbe"):
+        c["livenessProbe"]["httpGet"]["path"] = "/ready"
 elif mutation == "ui-readiness-threshold":
     for c in find("ui", "readinessProbe"):
         c["readinessProbe"]["failureThreshold"] = 1000
@@ -359,6 +412,14 @@ assert_mutation_rejected api-drop-liveness-timeout \
   "dropping the api livenessProbe timeoutSeconds (the kubelet would silently apply 1s)" \
   "container=api" "does not declare timeoutSeconds explicitly"
 
+assert_mutation_rejected api-readiness-health \
+  "routing api readiness back to the shallow health handler" \
+  "container=api" "api readinessProbe httpGet must target /ready:8000" "got /health:8000"
+
+assert_mutation_rejected api-liveness-ready \
+  "routing api liveness to the database-aware readiness handler" \
+  "container=api" "api livenessProbe httpGet must target /health:8000" "got /ready:8000"
+
 assert_mutation_rejected ui-readiness-threshold \
   "widening the ui readiness failureThreshold to 1000 so its readiness tolerance outruns liveness" \
   "container=ui" "liveness cutoff must exceed readiness cutoff"
@@ -398,4 +459,4 @@ assert_rejected "$TMP/values-override.yaml" "red:values-override" \
   "container=postgres" "container=langfuse-web" "container=langfuse-worker" "container=api" \
   "liveness cutoff must exceed readiness cutoff"
 
-echo "PASS: in both the default and values-dev renders, every object carrying a pod spec (Deployment/StatefulSet/DaemonSet/Job/CronJob, a bare Pod, SandboxTemplate, or any kind exposing spec.template.spec) has every container carrying BOTH probes checked, and each such container has a liveness failure cutoff strictly later than its readiness cutoff, every livenessProbe declares timeoutSeconds explicitly, and postgres liveness allows pg_isready at least 5s -- so the kubelet cannot restart a container that is still inside the boot window readiness was sized to tolerate"
+echo "PASS: in the default, values-dev, and dispatcher-enabled renders, every object carrying a pod spec (Deployment/StatefulSet/DaemonSet/Job/CronJob, a bare Pod, SandboxTemplate, or any kind exposing spec.template.spec) has every container carrying BOTH probes checked, and each such container has a liveness failure cutoff strictly later than its readiness cutoff, every livenessProbe declares timeoutSeconds explicitly, postgres liveness allows pg_isready at least 5s, all four first-party app Deployments are audited, and api readiness/liveness target /ready:8000 and /health:8000 respectively -- so the kubelet cannot restart a container that is still inside the boot window readiness was sized to tolerate"

--- a/charts/curie/templates/api.yaml
+++ b/charts/curie/templates/api.yaml
@@ -258,7 +258,7 @@ spec:
               containerPort: 8000
           readinessProbe:
             httpGet:
-              path: /health
+              path: /ready
               port: 8000
             {{- toYaml .Values.api.readinessProbe | nindent 12 }}
           livenessProbe:

--- a/charts/curie/values.yaml
+++ b/charts/curie/values.yaml
@@ -1033,9 +1033,9 @@ api:
   # approval evidence. A sealed install generates and persists this value
   # independently; values-dev.yaml keeps the published deterministic default.
   approvalChatAttesterSecret: curie-dev-approval-chat-attester
-  # Probe cadences. Liveness must outlast readiness so a cold API still warming
-  # up before /health answers is kept out of the Service rather than restarted
-  # back into the same warm-up. Cutoffs: readiness 120s, liveness 195s.
+  # Probe cadences. Database aware /ready keeps the API out of the Service until
+  # Postgres responds, while process local /health keeps the process alive.
+  # Liveness must outlast readiness. Cutoffs: readiness 120s, liveness 195s.
   # Formula/rationale: ci/probe-window-assertions.sh header.
   readinessProbe:
     initialDelaySeconds: 5

--- a/packages/telemetry/schema/metrics.json
+++ b/packages/telemetry/schema/metrics.json
@@ -946,6 +946,7 @@
           "/git-flow/routing-check",
           "/github/webhook",
           "/health",
+          "/ready",
           "/hooks/{agent_id}/{hook}",
           "/langfuse/traces",
           "/langfuse/traces/{trace_id}",
@@ -988,7 +989,7 @@
           "5xx"
         ]
       },
-      "cardinality_bound": 2800
+      "cardinality_bound": 2840
     },
     "curie.http.server.request.duration": {
       "type": "histogram",
@@ -1050,6 +1051,7 @@
           "/git-flow/routing-check",
           "/github/webhook",
           "/health",
+          "/ready",
           "/hooks/{agent_id}/{hook}",
           "/langfuse/traces",
           "/langfuse/traces/{trace_id}",
@@ -1092,7 +1094,7 @@
           "5xx"
         ]
       },
-      "cardinality_bound": 2800
+      "cardinality_bound": 2840
     },
     "curie.http.server.active": {
       "type": "up_down_counter",
@@ -1154,6 +1156,7 @@
           "/git-flow/routing-check",
           "/github/webhook",
           "/health",
+          "/ready",
           "/hooks/{agent_id}/{hook}",
           "/langfuse/traces",
           "/langfuse/traces/{trace_id}",
@@ -1189,7 +1192,7 @@
           "OTHER"
         ]
       },
-      "cardinality_bound": 560
+      "cardinality_bound": 568
     },
     "curie.background.loop": {
       "type": "counter",

--- a/packages/telemetry/src/curie_telemetry/metrics.py
+++ b/packages/telemetry/src/curie_telemetry/metrics.py
@@ -200,6 +200,7 @@ _HTTP_OPERATIONS = [
     "/git-flow/routing-check",
     "/github/webhook",
     "/health",
+    "/ready",
     "/hooks/{agent_id}/{hook}",
     "/langfuse/traces",
     "/langfuse/traces/{trace_id}",


### PR DESCRIPTION
PostgreSQL outages previously left the API Ready and in Service endpoints while real requests failed. Add unauthenticated `/ready` using the existing database session, return a fixed 503 when the check fails, and keep `/health` shallow. The chart now uses `/ready` for readiness and `/health` for liveness. The existing cadence checker audits API, worker, dispatcher, and UI without changing their already-correct timing values.

Closes #1582

Fix pin: apps/api/tests/test_auth.py::test_ready_sanitizes_an_unavailable_database_and_health_stays_open

Candidate: `999afc1844b45f7ff654b356109fc9d8d4dc2f14`. Tree: `5da9f75d71787d5e1eb95a99869fe9f621a54d40`. The final commit has the identical tree reviewed and tested as `dcd24c7d826c75fda01b0c97ea0a5254b7495659`. The task image retained config digest `sha256:1b1695870b639630bc0678d3487779ebccc6f83e35076ae6b4a2f2757d2c0f20`; running handler and metric source hashes matched the final checkout.

The new route is registered in the finite HTTP metric domain and generated manifests. The unknown-value guard remains enforced. The only accompanying documentation edits explain the probe split.

| Tier | Required / n/a | Reason | Mode | Command and observed outcome |
| --- | --- | --- | --- | --- |
| skill | n/a | No runner loop, plugin packaging, ACI, or skill verb changes | — | — |
| local | required | API/session behavior and service wiring | fake model; real services | `PATH="$PWD/.projects/1582-evidence/isolated-bin:$PATH" COMPOSE_PROJECT_NAME=curie CURIE_E2E_TIERS=local CURIE_BIN="$PWD/.projects/1582-evidence/curie" .projects/1582-evidence/curie dev e2e-ladder`: `LADDER PASS (tiers: local)` on the identical pre-squash tree. Direct `/health` and `/ready` returned 200. |
| local-release | n/a | No release images, install path, version pins, or release Compose changes | — | — |
| cluster | required | API probe handler, readiness, and Service endpoint removal | real cluster/database; no model | `python3 .projects/1582-evidence/outage-drill.py candidate`: 210-second outage passed on final commit; readiness and ready endpoints false by 121.394s, health200/restarts0, recovery and retained-data match at 244.17s from drill start. `KUBECONFIG="$PWD/.projects/1582-evidence/chart-kubeconfig" CURIE_CHART_E2E_RUNNER_IMAGE=busybox:1.36.1 .projects/1582-evidence/curie dev chart-runtime-e2e --force`: `PASS: API Service NodePort and runtime security assertions`. |
| live provider | n/a | No model routing, credential resolution, token/cost accounting, or runner MCP/workspace/coding-tool path changes | — | — |
| external integration | n/a | No Slack, webhook, OAuth, or third-party API changes | — | — |

The local ladder used a private launcher that added only task-owned physical volume names to Compose. A full rendered-config comparison confirmed services, images, environment, commands, probes, and networks were unchanged. Original development volumes stayed unmounted. The model portion proves plumbing, not response quality. The chart harness used its supported runner mount-view override; the task-specific readiness drill used the real candidate API.

Acceptance evidence:

- Real database success returns `200 {"status":"ok"}` without a key. Refused connections return exactly `503 {"detail":"Database is unavailable"}`, while `/health` stays 200.
- Holding the only real pool connection produces 503 after approximately two seconds and before the three-second probe timeout. The held connection remains usable, and releasing it restores readiness. This timing proof covers the tested pool/refusal paths; cancellation cleanup is cooperative.
- The chart check covers all four app Deployments and rejects both readiness-to-`/health` and liveness-to-`/ready` mutants. Existing cadence values remain readiness-before-liveness.
- The stable base reproduced the issue for 211.681 seconds: Ready and ready endpoints stayed true while real requests failed. The reviewed candidate drained endpoints during a 210-second outage, kept `/health` 200 and restarts zero, and recovered the same seeded data and pod identity. Final commit `999afc1844b45f7ff654b356109fc9d8d4dc2f14` repeated the same drill: endpoints drained by 121.394s and all routes/routing recovered at 244.17s from drill start with unchanged pod identity, zero restarts, and retained data.
- `.projects/1582-evidence/curie dev verify-fix-pin 999afc18 apps/api/tests/test_auth.py::test_ready_sanitizes_an_unavailable_database_and_health_stays_open` returned `PINNED`: green on the final candidate, failed with 404 when its product change was reversed.

One immediate post-rollout repeat stopped on an ancillary request timeout before the expected 500; readiness itself returned 503 in 2.015 seconds and cleanup restored PostgreSQL. The cluster uses a 30-second DNS TTL. The unchanged drill was rerun after recovery and cache expiry; no assertions or product code were relaxed. Both attempts are retained in private evidence.

Verification checklist:

- [x] Required tiers name commands, candidate identity, mode, and observed outcomes above.
- [x] Every meaningful criterion has positive and falsifiable negative or independent observations; no required tier remains unproved.
- [x] Tests were committed and observed failing before implementation: `35970719` captured three `/ready` 404 failures and the chart handler failure.
- [x] Test writing and implementation used separate contexts; production edits were delegated and reviews were read-only.
- [x] Code review passed with zero confirmed defects and source/AC evidence.
- [x] Scope review passed with zero confirmed defects and every hunk justified.
- [x] No existing return types broadened; HTTP operation catalog and auth route sweep were updated with the new route.
- [x] Sibling paths covered: same local/cluster API route, shared four-Deployment cadence checker, finite metric catalog. Compose retains its single process-health signal.
- [x] New guards were executed against violating inputs; assertions were not weakened.
- [x] Consolidation inspection found no warranted edits; built-in simplification unavailable, no consolidation diff to revalidate.
- [x] Security review n/a: no authorization, secrets handling, PII, payments, or tenant boundary changes.
- [x] Driver and independent deployed observer confirmed readiness drain and same-pod recovery; final runtime repeat is recorded above.
- [x] Worktree and PR target match the issue's v0.8.7 main train.
- [x] Discovery-surface proof is the real disposable-cluster outage/recovery, not rendered manifests alone.
- [x] Re-fix mechanism n/a: this adds the missing endpoint; the prior cadence fix remains unchanged.
- [x] Full affected suite: `uv run pytest -q apps/api/tests packages/telemetry/tests` — 1,801 passed. Mandatory pre-edit baseline: 5,969 passed, 16 skipped. Ruff, mypy (247 files), import lint, docs, Helm lint, and probe assertions passed.
- [x] Prior intent preserved: shallow liveness, existing probe timing, and the finite metric guard from #2278.
- [x] Extra P0/release-blocker spec review n/a: the issue has neither of those labels.
- [x] Probe documentation updated; ADR n/a because no new architecture or data model is introduced.
- [x] Task-owned Compose containers/volumes, both kind clusters, sandbox containers, and task image tags removed. Original five development volumes and pre-existing shared builder/registry preserved.

This PR is source ready for review. Runtime observations are from disposable task-owned environments; no permanent deployment or release was performed.
